### PR TITLE
fix: align settings and modules with Astryx authority

### DIFF
--- a/apps/desktop/e2e/floating-layers.spec.ts
+++ b/apps/desktop/e2e/floating-layers.spec.ts
@@ -39,8 +39,9 @@ test('daily review uses the canonical time field and persists its value', async 
 }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();
+  const settingsNavigation = page.getByRole('navigation', { name: '设置分组' });
   const settings = page.getByRole('main', { name: '设置内容' });
-  await settings.getByRole('button', { name: '每日回顾', exact: true }).click();
+  await settingsNavigation.getByRole('button', { name: '每日回顾', exact: true }).click();
 
   const time = settings.getByRole('textbox', { name: '每日回顾执行时间' });
   await expect(time).toHaveValue('08:00');
@@ -48,8 +49,8 @@ test('daily review uses the canonical time field and persists its value', async 
   await time.blur();
   await expect(time).toHaveValue('08:05');
 
-  await settings.getByRole('button', { name: '通用', exact: true }).click();
-  await settings.getByRole('button', { name: '每日回顾', exact: true }).click();
+  await settingsNavigation.getByRole('button', { name: '通用', exact: true }).click();
+  await settingsNavigation.getByRole('button', { name: '每日回顾', exact: true }).click();
   const persistedTime = settings.getByRole('textbox', {
     name: '每日回顾执行时间',
   });
@@ -62,8 +63,8 @@ test('daily review uses the canonical time field and persists its value', async 
     settings.getByText('请输入 24 小时制时间，例如 08:00。'),
   ).toBeVisible();
 
-  await settings.getByRole('button', { name: '通用', exact: true }).click();
-  await settings.getByRole('button', { name: '每日回顾', exact: true }).click();
+  await settingsNavigation.getByRole('button', { name: '通用', exact: true }).click();
+  await settingsNavigation.getByRole('button', { name: '每日回顾', exact: true }).click();
   await expect(
     settings.getByRole('textbox', { name: '每日回顾执行时间' }),
   ).toHaveValue('08:05');

--- a/apps/desktop/e2e/locale-renderer.spec.ts
+++ b/apps/desktop/e2e/locale-renderer.spec.ts
@@ -17,8 +17,11 @@ test('English e2e-fixture renderer uses the resolved locale', async ({ enLocaleW
 test('locale switching, persistence, and Follow system need no reload', async ({ localeSwitchWindow: page }) => {
   await page.getByRole('button', { name: /展开侧边栏|Expand sidebar/ }).click();
   await page.getByRole('button', { name: /设置|Settings/ }).click();
+  const settingsNavigation = page.getByRole('navigation', {
+    name: /设置分组|Settings sections/,
+  });
   const settings = page.getByRole('main', { name: /设置内容|Settings content/ });
-  await settings.getByRole('button', { name: /通用|General/, exact: true }).click();
+  await settingsNavigation.getByRole('button', { name: /通用|General/, exact: true }).click();
 
   await page.evaluate(() => { (window as unknown as { __localeE2eMarker: string }).__localeE2eMarker = 'alive'; });
   let language = settings.getByRole('radiogroup', { name: /界面语言|Interface language/ });

--- a/apps/desktop/e2e/mcp.spec.ts
+++ b/apps/desktop/e2e/mcp.spec.ts
@@ -20,7 +20,7 @@ test('MCP module completes stdio add, discovery, disable, JSON import, and delet
 
   const extensionSelector = page.locator('.maka-module-hub-selector');
   await expect(extensionSelector).toHaveAccessibleName('扩展内容：技能');
-  await extensionSelector.getByRole('radio', { name: 'MCP' }).click();
+  await extensionSelector.getByRole('button', { name: 'MCP' }).click();
   const mcp = page.getByRole('main', { name: '扩展' });
   await expect(mcp.getByRole('heading', { name: '扩展' })).toBeVisible();
   await expect(extensionSelector).toHaveAccessibleName('扩展内容：MCP');
@@ -35,14 +35,15 @@ test('MCP module completes stdio add, discovery, disable, JSON import, and delet
     await page.screenshot({ path: variantPath(screenshotPath, 'market') });
     await page.getByRole('button', { name: '设置', exact: true }).click();
     const settings = page.getByRole('main', { name: '设置内容' });
-    await settings.getByRole('button', { name: '外观', exact: true }).click();
+    const settingsNav = page.getByRole('navigation', { name: '设置分组' });
+    await settingsNav.getByRole('button', { name: '外观', exact: true }).click();
     await settings.getByRole('radio', { name: '深色' }).click();
-    await settings.getByRole('button', { name: '返回应用' }).click();
+    await settingsNav.getByRole('button', { name: '返回应用' }).click();
     await page.screenshot({ path: variantPath(screenshotPath, 'dark-market') });
     await page.getByRole('button', { name: '设置', exact: true }).click();
-    await settings.getByRole('button', { name: '外观', exact: true }).click();
+    await settingsNav.getByRole('button', { name: '外观', exact: true }).click();
     await settings.getByRole('radio', { name: '浅色' }).click();
-    await settings.getByRole('button', { name: '返回应用' }).click();
+    await settingsNav.getByRole('button', { name: '返回应用' }).click();
     const viewport = await page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
     await page.setViewportSize({ width: 760, height: 700 });
     await page.screenshot({ path: variantPath(screenshotPath, 'narrow-market') });

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -1,9 +1,14 @@
+import type { Page } from '@playwright/test';
 import { test, expect } from './fixtures';
+
+function settingsNavigation(page: Page) {
+  return page.getByRole('navigation', { name: /^(设置分组|Settings sections)$/ });
+}
 
 test('settings switches keep the compact shared control geometry', async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();
-  await page.getByRole('main', { name: '设置内容' }).getByRole('button', { name: '通用', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '通用', exact: true }).click();
 
   const privacySwitch = page.getByRole('switch', { name: '启用隐身模式' });
   await expect(privacySwitch).toBeVisible();
@@ -22,7 +27,7 @@ test('general default-model options keep provider marks inside the Selector slot
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();
   const settings = page.getByRole('main', { name: '设置内容' });
-  await settings.getByRole('button', { name: '通用', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '通用', exact: true }).click();
 
   await settings.getByRole('button', { name: '默认模型' }).click();
   const mark = page.getByRole('listbox').locator('.modelPickerProviderMark').first();
@@ -69,7 +74,7 @@ test('changing the theme in settings applies to the UI', async ({ window: page }
   await page.getByRole('button', { name: '设置' }).click();
   await expect(page.getByLabel('设置内容')).toBeVisible();
 
-  await page.locator('[aria-label="设置分组"]').getByText('外观').click();
+  await settingsNavigation(page).getByRole('button', { name: '外观', exact: true }).click();
   const themeGroup = page.getByRole('radiogroup', { name: '主题' });
   const lightTheme = themeGroup.getByRole('radio', { name: '浅色' });
   const darkTheme = themeGroup.getByRole('radio', { name: '深色' });
@@ -85,7 +90,7 @@ test('changing the theme in settings applies to the UI', async ({ window: page }
 test('settings textareas use Astryx native resizing and persist edits across section re-entry', async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();
-  await page.getByRole('main', { name: '设置内容' }).getByRole('button', { name: '通用', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '通用', exact: true }).click();
 
   const textarea = page.getByRole('textbox', { name: '助手语气偏好' });
   await expect(textarea).toBeVisible();
@@ -94,7 +99,7 @@ test('settings textareas use Astryx native resizing and persist edits across sec
   await textarea.fill(edited);
   await expect(textarea).toHaveValue(edited);
 
-  await page.getByRole('main', { name: '设置内容' }).getByRole('button', { name: '记忆', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '记忆', exact: true }).click();
   await expect(page.locator('label').filter({ hasText: '记忆标题' })).toBeVisible();
   await expect(page.locator('label').filter({ hasText: '记忆标签' })).toBeVisible();
   await expect(page.locator('label').filter({ hasText: '记忆内容' })).toBeVisible();
@@ -102,10 +107,10 @@ test('settings textareas use Astryx native resizing and persist edits across sec
   await expect(page.getByRole('textbox', { name: '记忆内容' })).toHaveCSS('resize', 'vertical');
   await expect(page.getByRole('textbox', { name: 'MEMORY.md 内容' })).toHaveCSS('resize', 'vertical');
 
-  await page.getByRole('main', { name: '设置内容' }).getByRole('button', { name: '数据', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '数据', exact: true }).click();
   await expect(page.locator('label').filter({ hasText: '导入时同名连接的处理方式' })).toBeVisible();
 
-  await page.getByRole('main', { name: '设置内容' }).getByRole('button', { name: '通用', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '通用', exact: true }).click();
   await expect(page.getByRole('textbox', { name: '助手语气偏好' })).toHaveValue(edited);
 });
 
@@ -113,7 +118,7 @@ test('voice settings expose Astryx-owned fields and persist a draft on blur', as
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();
   const settings = page.getByRole('main', { name: '设置内容' });
-  await settings.getByRole('button', { name: '语音', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '语音', exact: true }).click();
 
   await expect(settings.getByRole('combobox', { name: '模型连接' })).toHaveCount(2);
   await expect(settings.getByRole('textbox', { name: '模型 ID' })).toHaveCount(2);
@@ -123,8 +128,8 @@ test('voice settings expose Astryx-owned fields and persist a draft on blur', as
 
   await language.fill('en');
   await language.press('Tab');
-  await settings.getByRole('button', { name: '通用', exact: true }).click();
-  await settings.getByRole('button', { name: '语音', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '通用', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '语音', exact: true }).click();
   await expect(settings.getByRole('textbox', { name: '语言（可选）' })).toHaveValue('en');
 });
 
@@ -217,7 +222,7 @@ test('permission rows keep their text at the window floor', async ({ permissionS
 test('health summary tiles stay readable at the window floor', async ({ window: page }) => {
   await page.setViewportSize({ width: 480, height: 900 });
   const settings = await openSettings(page);
-  await settings.getByRole('button', { name: '健康', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '健康', exact: true }).click();
 
   const healthSummary = settings.locator('.settingsHealthSummary');
   await expect(healthSummary).toBeVisible();
@@ -240,7 +245,7 @@ test('permission and health summaries keep one track per metric when wide', asyn
   const settings = await openSettings(page);
 
   // `auto-fit` must not cost the full-width layout: one track per metric.
-  await settings.getByRole('button', { name: '权限与能力', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '权限与能力', exact: true }).click();
   await expect(settings.locator('.settingsPermissionSummary')).toBeVisible();
   await expect.poll(async () => {
     const { trackCount, tileCount } = await summaryGeometry(
@@ -249,7 +254,7 @@ test('permission and health summaries keep one track per metric when wide', asyn
     return { trackCount, tileCount };
   }).toEqual({ trackCount: 4, tileCount: 4 });
 
-  await settings.getByRole('button', { name: '健康', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '健康', exact: true }).click();
   await expect(settings.locator('.settingsHealthSummary')).toBeVisible();
   await expect.poll(async () => {
     const { trackCount, tileCount } = await summaryGeometry(
@@ -302,7 +307,7 @@ test('usage and web search stay contained at the window floor', async ({ window:
   await page.setViewportSize({ width: 480, height: 900 });
   const settings = await openSettings(page);
 
-  await settings.getByRole('button', { name: '使用统计', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '使用统计', exact: true }).click();
   const tabsBar = settings.locator('.settingsUsageTabsBar');
   await expect(tabsBar).toBeVisible();
   await expect(tabsBar).toHaveCSS('overflow-x', 'auto');
@@ -317,7 +322,7 @@ test('usage and web search stay contained at the window floor', async ({ window:
   ).toBe(true);
 
   // Not `exact`: the nav entry's accessible name carries its Beta badge.
-  await settings.getByRole('button', { name: '联网搜索' }).click();
+  await settingsNavigation(page).getByRole('button', { name: '联网搜索' }).click();
   const disabledReason = settings.locator('.settingsWebSearchDisabledReason');
   await expect(disabledReason).toBeVisible();
   await expect(disabledReason).toHaveCSS('overflow-wrap', 'anywhere');
@@ -325,7 +330,7 @@ test('usage and web search stay contained at the window floor', async ({ window:
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
   ).toBe(true);
 
-  await settings.getByRole('button', { name: '记忆', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '记忆', exact: true }).click();
   const previewHeader = settings.locator('.settingsMemoryPromptPreviewHeader');
   await expect(previewHeader).toBeVisible();
   await expect(previewHeader).toHaveCSS('flex-wrap', 'wrap');
@@ -392,7 +397,7 @@ test('web search results wrap inside their cards at the window floor', async ({
 test('usage keeps one summary track per metric when wide', async ({ window: page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   const settings = await openSettings(page);
-  await settings.getByRole('button', { name: '使用统计', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '使用统计', exact: true }).click();
 
   // `auto-fit` must not cost the full-width layout: four metrics, four tracks.
   await expect(settings.locator('.settingsUsageSummary')).toBeVisible();
@@ -409,7 +414,7 @@ test('remote access opens a channel detail from the overview and returns', async
   await page.getByRole('button', { name: '设置' }).click();
 
   const settings = page.getByRole('main', { name: '设置内容' });
-  await settings.getByRole('button', { name: '远程接入' }).click();
+  await settingsNavigation(page).getByRole('button', { name: '远程接入' }).click();
 
   await expect(settings.getByRole('heading', { name: '远程接入' })).toBeVisible();
   await expect(settings.getByRole('heading', { name: '接入更多渠道' })).toBeVisible();
@@ -485,7 +490,7 @@ test('remote access prioritizes a configured channel that needs attention', asyn
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();
   const settings = page.getByRole('main', { name: '设置内容' });
-  await settings.getByRole('button', { name: '远程接入' }).click();
+  await settingsNavigation(page).getByRole('button', { name: '远程接入' }).click();
 
   const activeChannels = page.getByRole('region', { name: '正在使用' }).getByRole('button');
   await expect(activeChannels).toHaveCount(2);
@@ -592,7 +597,7 @@ test('remote access prioritizes a configured channel that needs attention', asyn
 test('general forms and Astryx Item controls stay contained across widths', async ({ window: page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   const settings = await openSettings(page);
-  await settings.getByRole('button', { name: '通用', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '通用', exact: true }).click();
 
   const formLayout = settings.locator('.settingsFormLayout').first();
   const incognitoRow = settings.locator('.astryx-item').filter({ hasText: '隐身模式' });
@@ -634,7 +639,7 @@ test('appearance palette names stay fully visible at the window floor', async ({
 }) => {
   await page.setViewportSize({ width: 480, height: 900 });
   const settings = await openSettings(page);
-  await settings.getByRole('button', { name: '外观', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '外观', exact: true }).click();
 
   const label = settings.getByText('Catppuccin Mocha', { exact: true });
   await expect(label).toBeVisible();
@@ -662,7 +667,7 @@ test('data, about, and daily review stay contained at the window floor', async (
   await page.setViewportSize({ width: 480, height: 900 });
   const settings = await openSettings(page);
 
-  await settings.getByRole('button', { name: '数据', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '数据', exact: true }).click();
   const strategy = settings.getByRole('combobox', { name: '导入时同名连接的处理方式' });
   await expect(strategy).toBeVisible();
   const strategyBox = await strategy.boundingBox();
@@ -682,13 +687,13 @@ test('data, about, and daily review stay contained at the window floor', async (
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
   ).toBe(true);
 
-  await settings.getByRole('button', { name: '关于', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '关于', exact: true }).click();
   await expect(settings.locator('.settingsAboutPage')).toBeVisible();
   await expect.poll(
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
   ).toBe(true);
 
-  await settings.getByRole('button', { name: '每日回顾', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '每日回顾', exact: true }).click();
   await expect(settings.locator('.settingsFeatureStatusPage')).toBeVisible();
   await expect.poll(
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
@@ -707,7 +712,7 @@ test('data config strategy stays contained at the window floor in English', asyn
   await page.getByRole('button', { name: 'Expand sidebar' }).click();
   await page.getByRole('button', { name: 'Settings' }).click();
   const settings = page.getByRole('main', { name: 'Settings content' });
-  await settings.getByRole('button', { name: 'Data', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: 'Data', exact: true }).click();
 
   const strategy = settings.getByRole('combobox', {
     name: 'How to handle connections with the same name during import',
@@ -731,7 +736,7 @@ test('data config strategy stays contained at the window floor in English', asyn
 test('memory status Item stays contained at the window floor', async ({ window: page }) => {
   await page.setViewportSize({ width: 480, height: 900 });
   const settings = await openSettings(page);
-  await settings.getByRole('button', { name: '记忆', exact: true }).click();
+  await settingsNavigation(page).getByRole('button', { name: '记忆', exact: true }).click();
 
   const statusRow = settings.locator('.astryx-item').filter({ hasText: '本地 MEMORY.md' });
   await expect(statusRow).toBeVisible();

--- a/apps/desktop/e2e/sidebar-navigation.spec.ts
+++ b/apps/desktop/e2e/sidebar-navigation.spec.ts
@@ -113,7 +113,7 @@ test('scheduled-task hub restores the last selected child module', async ({ wind
 
   const selector = page.locator('.maka-module-hub-selector');
   await expect(selector).toHaveAccessibleName('定时任务内容：计划提醒');
-  await selector.getByRole('radio', { name: '每日回顾' }).click();
+  await selector.getByRole('button', { name: '每日回顾' }).click();
   await expect(selector).toHaveAccessibleName('定时任务内容：每日回顾');
 
   await sidebar.getByRole('button', { name: '扩展', exact: true }).click();

--- a/apps/desktop/src/main/__tests__/provider-disclosure-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/provider-disclosure-authority.test.ts
@@ -27,3 +27,11 @@ test('MCP diagnostics and advanced fields delegate disclosure behavior to Astryx
   const css = read('apps/desktop/src/renderer/styles/module-pages/mcp.css');
   assert.doesNotMatch(css, /\.maka-mcp-(?:server-details|advanced)\s+summary\b/);
 });
+
+test('Daily Review archive history delegates single-open disclosure to Astryx CollapsibleGroup', () => {
+  const source = read('packages/ui/src/daily-review-panel.tsx');
+  assert.match(source, /import[^;]*\bCollapsible\b[^;]*\bCollapsibleGroup\b[^;]*from '@astryxdesign\/core'/s);
+  assert.match(source, /<CollapsibleGroup\b[^>]*type="single"[^>]*value=\{selectedArchiveId \?\? ''\}/s);
+  assert.match(source, /<Collapsible\b[^>]*value=\{archive\.id\}/s);
+  assert.doesNotMatch(source, /<button\b[^>]*aria-expanded=\{selected\}/s);
+});

--- a/apps/desktop/src/main/__tests__/segmented-control-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/segmented-control-authority.test.ts
@@ -8,7 +8,6 @@ const read = (rel: string) => readFileSync(join(REPO_ROOT, rel), 'utf8');
 
 test('Settings and Module navigation inputs use Astryx SegmentedControl directly', () => {
   for (const rel of [
-    'packages/ui/src/module-hub-selector.tsx',
     'packages/ui/src/daily-review-panel.tsx',
     'apps/desktop/src/renderer/settings/appearance-settings-page.tsx',
     'apps/desktop/src/renderer/settings/bot-chat-detail.tsx',
@@ -19,8 +18,5 @@ test('Settings and Module navigation inputs use Astryx SegmentedControl directly
     assert.match(source, /\bSegmentedControl\b/);
     assert.match(source, /\bSegmentedControlItem\b/);
     assert.doesNotMatch(source, /<Segmented\b|\bSegmented,/);
-    if (rel.endsWith('module-hub-selector.tsx')) {
-      assert.doesNotMatch(source, /DropdownMenu/);
-    }
   }
 });

--- a/apps/desktop/src/main/__tests__/settings-density-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-density-authority.test.ts
@@ -6,12 +6,19 @@ import { REPO_ROOT } from './css-test-helpers.js';
 
 const read = (rel: string) => readFileSync(join(REPO_ROOT, rel), 'utf8');
 
-test('settings use a 640px form column without the retired 72px row density', () => {
+test('settings delegate shell geometry and scrolling to Astryx Layout', () => {
+  const surfaceSource = read('apps/desktop/src/renderer/settings/settings-surface.tsx');
+  const formCss = read('apps/desktop/src/renderer/styles/settings/form.css');
   const navCss = read('apps/desktop/src/renderer/styles/settings/nav-sidebar.css');
   const rowsCss = read('apps/desktop/src/renderer/styles/settings/rows.css');
 
-  assert.match(navCss, /\.settingsPageContentInner\s*\{[^}]*max-width:\s*640px/s);
-  assert.match(navCss, /calc\(\(100% - 640px\)/);
-  assert.doesNotMatch(navCss, /768px/);
+  assert.match(surfaceSource, /Layout,\s*LayoutContent,\s*LayoutHeader,\s*LayoutPanel/);
+  assert.match(surfaceSource, /const isNarrowSettings = useMediaQuery\(NARROW_SETTINGS_QUERY\)/);
+  assert.match(surfaceSource, /contentWidth=\{640\}/);
+  assert.match(surfaceSource, /<LayoutPanel[\s\S]*?width=\{isNarrowSettings \? 48 : 260\}/);
+  assert.match(surfaceSource, /<LayoutContent padding=\{6\}/);
+  assert.doesNotMatch(surfaceSource, /OverlayScrollArea|useSyncExternalStore|subscribeToNarrowSettings/);
+  assert.doesNotMatch(formCss, /grid-template-columns:\s*260px|@media\s*\(max-width:\s*760px\)/);
+  assert.doesNotMatch(navCss, /settingsPageContent(?:Viewport|Inner)|calc\(\(100% - 640px\)/);
   assert.doesNotMatch(rowsCss, /min-height:\s*72px/);
 });

--- a/apps/desktop/src/main/__tests__/settings-feedback-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-feedback-authority.test.ts
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { REPO_ROOT } from './css-test-helpers.js';
+
+const read = (rel: string) => readFileSync(join(REPO_ROOT, rel), 'utf8');
+
+test('provider loading failure uses the Astryx error feedback seam', () => {
+  const source = read('apps/desktop/src/renderer/settings/ProvidersPanel.tsx');
+  assert.match(source, /import[^;]*\bBanner\b[^;]*from '@astryxdesign\/core'/s);
+  assert.match(source, /<Banner\b[^>]*status="error"[^>]*title=\{copy\.loadFailed\}/s);
+  assert.match(source, /endContent=\{<Button\b[^>]*onClick=\{\(\) => void reload\(\)\}/s);
+  assert.doesNotMatch(source, /enabledEmptyAction|Button as BaseButton/);
+});

--- a/apps/desktop/src/main/__tests__/settings-side-nav-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-side-nav-authority.test.ts
@@ -23,7 +23,9 @@ test('settings navigation collapses through the Astryx API at the narrow window 
   const source = read('apps/desktop/src/renderer/settings/settings-surface.tsx');
   const css = read('apps/desktop/src/renderer/styles/settings/form.css');
 
-  assert.match(source, /useSyncExternalStore/);
+  assert.match(source, /useMediaQuery\(NARROW_SETTINGS_QUERY\)/);
   assert.match(source, /collapsible=\{\{[\s\S]*?isCollapsed: isNarrowSettings/);
-  assert.match(css, /@media \(max-width: 760px\)[\s\S]*?grid-template-columns: 48px minmax\(0, 1fr\)/);
+  assert.match(source, /<LayoutPanel[\s\S]*?width=\{isNarrowSettings \? 48 : 260\}/);
+  assert.doesNotMatch(source, /useSyncExternalStore|subscribeToNarrowSettings/);
+  assert.doesNotMatch(css, /@media \(max-width: 760px\)|grid-template-columns/);
 });

--- a/apps/desktop/src/main/__tests__/skeleton-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/skeleton-authority.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { REPO_ROOT } from './css-test-helpers.js';
+
+const read = (rel: string) => readFileSync(join(REPO_ROOT, rel), 'utf8');
+
+test('Settings and Module loading placeholders delegate geometry and motion to Astryx Skeleton', () => {
+  for (const rel of [
+    'apps/desktop/src/renderer/settings/settings-skeleton.tsx',
+    'apps/desktop/src/renderer/settings/ProvidersPanel.tsx',
+    'packages/ui/src/daily-review-panel.tsx',
+  ]) {
+    const source = read(rel);
+    assert.match(source, /import[^;]*\bSkeleton\b[^;]*from '@astryxdesign\/core'/s);
+    assert.match(source, /<Skeleton\b/);
+    assert.doesNotMatch(source, /maka-skeleton/);
+  }
+
+  assert.doesNotMatch(read('apps/desktop/src/renderer/maka-tokens.css'), /\.maka-skeleton/);
+});

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -1581,12 +1581,14 @@ description: Exercise workspace-contained open paths.
     assert.match(skillPanel, /copy\.row\.hover\(skill\.id, runtimeLabel, statusLabel\)/);
     // Detail round 6, exception-only: the runtime badge renders ONLY for
     // state_error — enabled/disabled is already expressed by the Switch.
-    // Round 1 convergence (#520 follow-up): the two status labels now render
-    // the Astryx Badge primitive (was a hand-rolled span). data-status is
-    // preserved for tone derivation; the render condition is unchanged.
+    // Only exceptional runtime/context/source states use Astryx Badge.
+    // Routine scope, advertised/disabled context, and source are supporting text.
     assert.match(skillPanel, /\{skill\.runtimeStatus === 'state_error' && \([\s\S]*?<Badge[\s\S]*?className="maka-skill-library-runtime-label"[\s\S]*?label=\{runtimeLabel\}/);
-    assert.match(skillPanel, /<Badge[\s\S]*?className="maka-skill-library-status-label"[\s\S]*?label=\{statusLabel\}/);
-    assert.match(skillPanel, /function skillStatusBadgeVariant\(skill: SkillEntry\)/, 'status-label variant derives from data-status via skillStatusBadgeVariant');
+    assert.match(skillPanel, /className="maka-skill-library-supporting"[\s\S]*?\{supportingMeta\.join\(' · '\)\}/);
+    assert.doesNotMatch(skillPanel, /maka-skill-library-scope-label/);
+    assert.match(skillPanel, /\{contextNeedsAttention && \([\s\S]*?<Badge[\s\S]*?className="maka-skill-library-context-exception"/);
+    assert.match(skillPanel, /\{sourceStatusNeedsAttention && \([\s\S]*?<Badge[\s\S]*?className="maka-skill-library-status-label"/);
+    assert.match(skillPanel, /function skillSourceStatusNeedsAttention\(skill: SkillEntry\)/);
     assert.match(ui, /function formatSkillStatusLabel\(skill: SkillEntry, copy: SkillsCopy\): string/);
     assert.match(ui, /function formatSkillRuntimeLabel\(skill: SkillEntry, copy: SkillsCopy\): string/);
     assert.match(ui, /runtimeStatus === 'state_error'\) return copy\.status\.stateError/);
@@ -1669,7 +1671,7 @@ description: Exercise workspace-contained open paths.
     assert.doesNotMatch(skillPanel, /恢复|修复|合并/, 'Phase 3 still must not imply automatic merge or repair flows');
     assert.doesNotMatch(skillPanel, /const SKILL_GOVERNANCE_FILTERS/);
     assert.doesNotMatch(skillPanel, /aria-label="技能状态筛选"/);
-    assert.match(skillPanel, /className="maka-skill-library-status-label"/);
+    assert.match(skillPanel, /sourceStatusNeedsAttention/);
     assert.match(skillPanel, /function previewText\(content: string\): string/);
     assert.doesNotMatch(skillPanel, /maka-skill-library-action/, 'Open must be an explicit file icon button, not a status-like text pill');
     assert.match(skillPanel, /label=\{props\.createPending \? copy\.installed\.createPending : copy\.installed\.createExample\}/);

--- a/apps/desktop/src/main/__tests__/tab-list-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/tab-list-authority.test.ts
@@ -9,6 +9,7 @@ const read = (rel: string) => readFileSync(join(REPO_ROOT, rel), 'utf8');
 test('settings and module view navigation uses Astryx TabList directly', () => {
   for (const rel of [
     'packages/ui/src/skills-panel.tsx',
+    'packages/ui/src/module-hub-selector.tsx',
     'packages/ui/src/plan-reminder-panel.tsx',
     'apps/desktop/src/renderer/mcp-page.tsx',
     'apps/desktop/src/renderer/settings/usage-settings-page.tsx',
@@ -24,6 +25,7 @@ test('settings and module view navigation uses Astryx TabList directly', () => {
       `${rel} must not consume the old tabs API`,
     );
   }
+  assert.doesNotMatch(read('packages/ui/src/module-hub-selector.tsx'), /SegmentedControl|DropdownMenu/);
   for (const rel of [
     'apps/desktop/src/renderer/styles/module-pages/skills.css',
     'apps/desktop/src/renderer/styles/module-pages/mcp.css',

--- a/apps/desktop/src/main/__tests__/tab-list-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/tab-list-authority.test.ts
@@ -29,11 +29,12 @@ test('settings and module view navigation uses Astryx TabList directly', () => {
   for (const rel of [
     'apps/desktop/src/renderer/styles/module-pages/skills.css',
     'apps/desktop/src/renderer/styles/module-pages/mcp.css',
+    'apps/desktop/src/renderer/styles/module-pages/plan-reminders.css',
     'apps/desktop/src/renderer/styles/settings/bot.css',
   ]) {
     assert.doesNotMatch(
       read(rel),
-      /\.(?:maka-skill-tab|maka-mcp-tab|settingsUsageTab)(?:s)?(?:\s|,|\{)/,
+      /\.(?:maka-skill-tabs?|maka-mcp-tabs?|maka-plan-tab|maka-plan-tabs-list|settingsUsageTabs?)(?:\s|,|\{)/,
       `${rel} must leave Astryx Tab geometry intact`,
     );
   }

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1388,44 +1388,6 @@ html[data-os="darwin"].dark {
   animation: maka-shimmer 1.5s var(--ease-in-out-strong) infinite;
 }
 
-/* Skeleton placeholder primitives — used while data is still in flight.
-   The base block carries the shimmer animation and a token-based tint so
-   they read the same in light + dark modes. Compose `.maka-skeleton-line`
-   widths via `style={{ width: '40%' }}` from the consuming component. */
-.maka-skeleton {
-  position: relative;
-  overflow: hidden;
-  background: var(--foreground-3);
-  border-radius: var(--radius-control);
-}
-.maka-skeleton::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image: linear-gradient(
-    90deg,
-    transparent 0%,
-    oklch(from var(--foreground) l c h / 0.06) 50%,
-    transparent 100%
-  );
-  background-size: 200% 100%;
-  animation: maka-shimmer 1.6s var(--ease-in-out-strong) infinite;
-}
-.maka-skeleton-line {
-  height: 12px;
-  border-radius: var(--radius-pill);
-}
-.maka-skeleton-line[data-size="lg"] { height: 16px; }
-.maka-skeleton-line[data-size="sm"] { height: 9px; }
-.maka-skeleton-card {
-  height: 92px;
-  border-radius: var(--radius-surface);
-}
-.maka-skeleton-stack {
-  display: grid;
-  gap: var(--space-2-5);
-}
-
 /* =============================================================================
    Icon stroke governance: call sites had
    accumulated EIGHT different strokeWidth values (1.5 → 2) across 143

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Banner, Button, Item, Tab, TabList } from '@astryxdesign/core';
+import { Banner, Button, Item, Skeleton, Tab, TabList } from '@astryxdesign/core';
 import { ChevronRight, Search } from '@maka/ui/icons';
 import {
   CATALOG_PROVIDER_TYPES,
@@ -207,11 +207,11 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
     return (
       <div className="providersPanel providersLoading" data-maka-contract="providers-panel" aria-busy="true" aria-label={copy.loadingAria}>
         <div className="providersLoadingStrip">
-          <div className="maka-skeleton maka-skeleton-line" data-size="lg" style={{ width: '34%' }} />
-          <div className="maka-skeleton maka-skeleton-line" data-size="sm" style={{ width: '52%' }} />
+          <Skeleton width="34%" height={16} radius="rounded" index={0} />
+          <Skeleton width="52%" height={9} radius="rounded" index={1} />
         </div>
         <div className="providersLoadingGrid">
-          {[0, 1, 2, 3, 4, 5].map((index) => <div key={index} className="maka-skeleton maka-skeleton-card" />)}
+          {[0, 1, 2, 3, 4, 5].map((index) => <Skeleton key={index} height={92} radius={3} index={index + 2} />)}
         </div>
       </div>
     );

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Button as BaseButton } from '@base-ui/react/button';
-import { Item, Tab, TabList } from '@astryxdesign/core';
+import { Banner, Button, Item, Tab, TabList } from '@astryxdesign/core';
 import { ChevronRight, Search } from '@maka/ui/icons';
 import {
   CATALOG_PROVIDER_TYPES,
@@ -231,10 +230,12 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
             count={connections.length > 0 ? copy.count(connections.length) : undefined}
           />
           {loadError ? (
-            <BaseButton className="enabledEmptyChip enabledEmptyAction" type="button" onClick={() => void reload()}>
-              <strong>{copy.loadFailed}</strong>
-              <small>{loadError} · {copy.retry}</small>
-            </BaseButton>
+            <Banner
+              status="error"
+              title={copy.loadFailed}
+              description={loadError}
+              endContent={<Button variant="ghost" label={copy.retry} onClick={() => void reload()} />}
+            />
           ) : connections.length === 0 ? (
             <div className="enabledEmptyChip" role="note">
               <strong>{copy.empty}</strong>

--- a/apps/desktop/src/renderer/settings/settings-skeleton.tsx
+++ b/apps/desktop/src/renderer/settings/settings-skeleton.tsx
@@ -1,3 +1,7 @@
+import { Skeleton } from '@astryxdesign/core';
+import { useUiLocale } from '@maka/ui';
+import { getSettingsSharedCopy } from '../locales/settings-shared-copy.js';
+
 type SkeletonLine = { width: string; size?: 'lg' | 'sm' };
 
 // 权限/健康快照页共用的骨架行预设：首行大号标题条，其余模拟段落行宽。
@@ -17,13 +21,14 @@ export function SettingsSkeletonStack({
   lines?: ReadonlyArray<SkeletonLine>;
 }) {
   return (
-    <div className="maka-skeleton-stack" aria-busy="true" aria-label={label}>
+    <div className="settingsSkeletonStack" aria-busy="true" aria-label={label}>
       {lines.map((line, index) => (
-        <div
+        <Skeleton
           key={index}
-          className="maka-skeleton maka-skeleton-line"
-          data-size={line.size}
-          style={{ width: line.width }}
+          width={line.width}
+          height={line.size === 'lg' ? 16 : line.size === 'sm' ? 9 : 12}
+          radius="rounded"
+          index={index}
         />
       ))}
     </div>
@@ -34,16 +39,14 @@ export function SettingsSkeleton() {
   const copy = getSettingsSharedCopy(useUiLocale());
   return (
     <div className="settingsLoadingSkeleton" aria-busy="true" aria-label={copy.loading}>
-      <div className="maka-skeleton-stack">
-        <div className="maka-skeleton maka-skeleton-line" data-size="lg" style={{ width: '38%' }} />
-        <div className="maka-skeleton maka-skeleton-card" />
-        <div className="maka-skeleton maka-skeleton-line" data-size="sm" style={{ width: '60%' }} />
-        <div className="maka-skeleton maka-skeleton-line" style={{ width: '85%' }} />
-        <div className="maka-skeleton maka-skeleton-line" style={{ width: '72%' }} />
-        <div className="maka-skeleton maka-skeleton-line" style={{ width: '48%' }} />
+      <div className="settingsSkeletonStack">
+        <Skeleton width="38%" height={16} radius="rounded" index={0} />
+        <Skeleton height={92} radius={3} index={1} />
+        <Skeleton width="60%" height={9} radius="rounded" index={2} />
+        <Skeleton width="85%" height={12} radius="rounded" index={3} />
+        <Skeleton width="72%" height={12} radius="rounded" index={4} />
+        <Skeleton width="48%" height={12} radius="rounded" index={5} />
       </div>
     </div>
   );
 }
-import { useUiLocale } from '@maka/ui';
-import { getSettingsSharedCopy } from '../locales/settings-shared-copy.js';

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -1,5 +1,18 @@
-import { useEffect, useRef, useState, useSyncExternalStore, type RefObject } from 'react';
-import { Badge, Button, Card, IconButton, SideNav, SideNavItem, SideNavSection } from '@astryxdesign/core';
+import { useEffect, useRef, useState, type RefObject } from 'react';
+import {
+  Badge,
+  Button,
+  Card,
+  IconButton,
+  Layout,
+  LayoutContent,
+  LayoutHeader,
+  LayoutPanel,
+  SideNav,
+  SideNavItem,
+  SideNavSection,
+  useMediaQuery,
+} from '@astryxdesign/core';
 import { ArrowLeft } from '@maka/ui/icons';
 import type {
   AppSettings,
@@ -14,7 +27,7 @@ import type {
   UsageStats,
 } from '@maka/core';
 import { createDefaultSettings } from '@maka/core/settings';
-import { OverlayScrollArea, useMountedRef, useToast, useUiLocale } from '@maka/ui';
+import { useMountedRef, useToast, useUiLocale } from '@maka/ui';
 import { ProvidersPanel } from './ProvidersPanel';
 import { safeLocalStorageSet } from '../browser-storage';
 import { AboutSettingsPage } from './about-settings-page';
@@ -39,19 +52,6 @@ import { getSettingsSharedCopy } from '../locales/settings-shared-copy.js';
 
 const NARROW_SETTINGS_QUERY = '(max-width: 760px)';
 
-function subscribeToNarrowSettings(onChange: () => void) {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {};
-  const query = window.matchMedia(NARROW_SETTINGS_QUERY);
-  query.addEventListener('change', onChange);
-  return () => query.removeEventListener('change', onChange);
-}
-
-function getNarrowSettingsSnapshot() {
-  return typeof window !== 'undefined' &&
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia(NARROW_SETTINGS_QUERY).matches;
-}
-
 export function SettingsSurface(props: {
   connections: LlmConnection[];
   defaultSlug: string | null;
@@ -75,11 +75,7 @@ export function SettingsSurface(props: {
   const locale = useUiLocale();
   const copy = getSettingsSharedCopy(locale);
   const localizedNav = groupedNav(locale);
-  const isNarrowSettings = useSyncExternalStore(
-    subscribeToNarrowSettings,
-    getNarrowSettingsSnapshot,
-    () => false,
-  );
+  const isNarrowSettings = useMediaQuery(NARROW_SETTINGS_QUERY);
   const [section, setSection] = useState<SettingsSection>(() => props.requestedSection ?? readLastSettingsSection());
   const [providerCatalogRequested, setProviderCatalogRequested] = useState(props.openProviderCatalog === true);
   // One-shot landing intent, mirroring providerCatalogRequested above: the
@@ -247,99 +243,123 @@ export function SettingsSurface(props: {
   const headerCopy = getSettingsNavigationCopy(locale).sections[section];
 
   return (
-    <main className="settingsSurface agents-layout-body" data-modal="true" aria-label={copy.contentLabel}>
-      <SideNav
-        className="settingsSidebar agents-sidebar"
-        collapsible={{ isCollapsed: isNarrowSettings, hasButton: false }}
-        data-maka-contract="settings-sidebar"
-        data-settings-nav-column
-        aria-label={copy.navigationLabel}
-        topContent={(
-          isNarrowSettings
-            ? <IconButton
-                variant="ghost"
-                label={copy.backToApp}
-                tooltip={copy.backToApp}
-                icon={<ArrowLeft size={16} aria-hidden="true" />}
-                onClick={props.onClose}
-              />
-            : <Button
-                className="settingsBackButton"
-                variant="ghost"
-                width="100%"
-                label={copy.backToApp}
-                icon={<ArrowLeft size={16} aria-hidden="true" />}
-                onClick={props.onClose}
-              />
+    <div className="settingsSurface" data-modal="true">
+      <Layout
+        height="fill"
+        padding={0}
+        start={(
+          <LayoutPanel
+            width={isNarrowSettings ? 48 : 260}
+            padding={0}
+            isScrollable={false}
+          >
+            <SideNav
+              className="settingsSidebar"
+              collapsible={{ isCollapsed: isNarrowSettings, hasButton: false }}
+              data-maka-contract="settings-sidebar"
+              data-settings-nav-column
+              aria-label={copy.navigationLabel}
+              topContent={(
+                isNarrowSettings
+                  ? <IconButton
+                      variant="ghost"
+                      label={copy.backToApp}
+                      tooltip={copy.backToApp}
+                      icon={<ArrowLeft size={16} aria-hidden="true" />}
+                      onClick={props.onClose}
+                    />
+                  : <Button
+                      className="settingsBackButton"
+                      variant="ghost"
+                      width="100%"
+                      label={copy.backToApp}
+                      icon={<ArrowLeft size={16} aria-hidden="true" />}
+                      onClick={props.onClose}
+                    />
+              )}
+            >
+              {localizedNav.map(({ group, label, items }) => (
+                <SideNavSection key={group} title={label}>
+                  {items.map((item) => (
+                    <SideNavItem
+                      key={item.id}
+                      label={item.label}
+                      icon={<item.Icon size={16} aria-hidden="true" />}
+                      isSelected={section === item.id}
+                      isDisabled={!item.enabled}
+                      ref={section === item.id
+                        ? (element) => {
+                            props.initialFocusRef.current = element instanceof HTMLButtonElement
+                              ? element
+                              : null;
+                          }
+                        : undefined}
+                      endContent={item.badge ? <Badge variant="neutral" label={item.badge} /> : undefined}
+                      onClick={() => setSection(item.id)}
+                    />
+                  ))}
+                </SideNavSection>
+              ))}
+            </SideNav>
+          </LayoutPanel>
         )}
-      >
-        {localizedNav.map(({ group, label, items }) => (
-          <SideNavSection key={group} title={label}>
-            {items.map((item) => (
-              <SideNavItem
-                key={item.id}
-                label={item.label}
-                icon={<item.Icon size={16} aria-hidden="true" />}
-                isSelected={section === item.id}
-                isDisabled={!item.enabled}
-                ref={section === item.id
-                  ? (element) => {
-                      props.initialFocusRef.current = element instanceof HTMLButtonElement
-                        ? element
-                        : null;
-                    }
-                  : undefined}
-                endContent={item.badge ? <Badge variant="neutral" label={item.badge} /> : undefined}
-                onClick={() => setSection(item.id)}
-              />
-            ))}
-          </SideNavSection>
-        ))}
-      </SideNav>
-
-      <section className="settingsMainPane agents-content-area" data-agents-view="settings">
-        <header className="settingsPageHeader">
-          <div className="settingsPageHeaderTitleStack">
-            <h2>{headerCopy.label}</h2>
-            {headerCopy.description && (
-              <p className="settingsPageHeaderDescription">{headerCopy.description}</p>
-            )}
-          </div>
-        </header>
-
-        <OverlayScrollArea
-          className="settingsPageContent"
-          viewportClassName="settingsPageContentViewport"
-          contentClassName="settingsPageContentInner"
-        >
-          {loading ? (
-            <SettingsSkeleton />
-          ) : (
-            <SettingsPage
-              section={section}
-              settings={settings}
-              usageStats={usageStats}
-              connections={props.connections}
-              defaultSlug={props.defaultSlug}
-              themePref={props.themePref}
-              themePalette={props.themePalette}
-              onRefreshConnections={props.onRefresh}
-              onUpdateSettings={updateSettings}
-              onReloadSettings={reloadSettings}
-              onReloadUsage={reloadUsage}
-              onThemeChange={props.onThemeChange}
-              onThemePaletteChange={props.onThemePaletteChange}
-              onOpenDailyReview={props.onOpenDailyReview}
-              onOpenSession={props.onOpenSession}
-              openProviderCatalog={providerCatalogRequested}
-              initialConnectionSlug={props.initialConnectionSlug}
-              initialCreateProviderType={createProviderRequest}
-              onInitialCreateProviderConsumed={() => setCreateProviderRequest(undefined)}
+        content={(
+          <section
+            className="settingsMainPane"
+            data-agents-view="settings"
+            role="main"
+            aria-label={copy.contentLabel}
+          >
+            <Layout
+              height="fill"
+              padding={0}
+              contentWidth={640}
+              header={(
+                <LayoutHeader padding={6}>
+                  <div className="settingsPageHeader">
+                    <div className="settingsPageHeaderTitleStack">
+                      <h2>{headerCopy.label}</h2>
+                      {headerCopy.description && (
+                        <p className="settingsPageHeaderDescription">{headerCopy.description}</p>
+                      )}
+                    </div>
+                  </div>
+                </LayoutHeader>
+              )}
+              content={(
+                <LayoutContent padding={6}>
+                  {loading ? (
+                    <SettingsSkeleton />
+                  ) : (
+                    <SettingsPage
+                      section={section}
+                      settings={settings}
+                      usageStats={usageStats}
+                      connections={props.connections}
+                      defaultSlug={props.defaultSlug}
+                      themePref={props.themePref}
+                      themePalette={props.themePalette}
+                      onRefreshConnections={props.onRefresh}
+                      onUpdateSettings={updateSettings}
+                      onReloadSettings={reloadSettings}
+                      onReloadUsage={reloadUsage}
+                      onThemeChange={props.onThemeChange}
+                      onThemePaletteChange={props.onThemePaletteChange}
+                      onOpenDailyReview={props.onOpenDailyReview}
+                      onOpenSession={props.onOpenSession}
+                      openProviderCatalog={providerCatalogRequested}
+                      initialConnectionSlug={props.initialConnectionSlug}
+                      initialCreateProviderType={createProviderRequest}
+                      onInitialCreateProviderConsumed={() => setCreateProviderRequest(undefined)}
+                    />
+                  )}
+                </LayoutContent>
+              )}
             />
-          )}
-        </OverlayScrollArea>
-      </section>
-    </main>
+          </section>
+        )}
+      />
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -41,8 +41,7 @@
    utilities/components blocks that must keep merging into the top-level
    Tailwind layers. Wrapping the import would nest them under maka.legacy
    and raise them above the utilities layer. Residual asymmetry: its few
-   unlayered non-token rules (.maka-shimmer, the .maka-skeleton family,
-   svg.lucide) now beat all maka.legacy rules unconditionally, no longer
+   unlayered non-token rules (.maka-shimmer and svg.lucide) now beat all maka.legacy rules unconditionally, no longer
    by source order — do not add competing declarations for them under
    styles/. */
 @import "./maka-tokens.css";

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -258,68 +258,13 @@
     font-variant-numeric: tabular-nums;
   }
 
-.maka-daily-review-report-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: var(--space-2);
-    min-width: 0;
-  }
-
-.maka-daily-review-report-list > li {
-    margin: 0;
-    padding: 0;
-    min-width: 0;
-  }
-
-/* Each report is one full-width surface. The meta head is always visible; the
-   selected report expands its body below. One frame only (no box-in-box): the
-   body sections divide with hairlines, not nested cards. */
-.maka-daily-review-report {
-    display: grid;
-    min-width: 0;
-    border: var(--border-width-hairline) solid var(--card-border-color);
-    border-radius: var(--radius-surface);
-    background: oklch(from var(--foreground) l c h / 0.025);
-    box-shadow: var(--card-highlight);
-    overflow: hidden;
-  }
-
-.maka-daily-review-report[data-selected] {
-    border-color: var(--border-strong);
-  }
-
-/* The whole meta head is the select/expand target. Reset native button chrome;
-   layout is title-column + optional exception chip. */
-.maka-daily-review-report-head {
-    appearance: none;
-    background: none;
-    border: 0;
-    font: inherit;
-    text-align: left;
-    width: 100%;
+.maka-daily-review-report-trigger {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
     gap: var(--space-2-5);
-    padding: var(--space-2-5) var(--space-3);
-    color: var(--foreground);
-    transition: background var(--duration-base) var(--ease-out-strong);
-  }
-
-.maka-daily-review-report-head:hover {
-    background: var(--state-hover-bg);
-  }
-
-.maka-daily-review-report[data-selected] .maka-daily-review-report-head {
-    background: var(--state-selected-bg);
-  }
-
-@media (prefers-reduced-motion: reduce) {
-    .maka-daily-review-report-head {
-      transition: background 0ms;
-    }
+    min-width: 0;
+    width: 100%;
   }
 
 .maka-daily-review-report-heading {
@@ -360,8 +305,6 @@
     display: grid;
     gap: var(--space-2);
     min-width: 0;
-    padding: var(--space-1) var(--space-3) var(--space-3);
-    border-top: var(--border-width-hairline) solid var(--foreground-10);
   }
 
 .maka-daily-review-archive-empty {

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -92,26 +92,6 @@
   row-gap: var(--space-2-5);
 }
 
-.maka-plan-tabs-list {
-  gap: var(--space-4);
-  border-radius: 0;
-  background: transparent;
-  padding: 0;
-}
-
-.maka-plan-tab {
-  position: relative;
-  gap: var(--space-1-5);
-  min-width: 0;
-  height: 28px;
-  padding: 0;
-  border-radius: 0;
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-}
-
 .maka-plan-toolbar {
   display: flex;
   flex-wrap: wrap;

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -474,21 +474,12 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   overflow: hidden;
 }
 
-/* PR-UI-PIXEL-3: the skill id reads as a soft monospace metadata pill
-   (reference treats ids/counts/sources as filled fill-tertiary pills, §4 rule 8)
-   instead of loose gray text. */
-.maka-skill-library-meta > span:first-child {
+.maka-skill-library-supporting {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
-  padding: var(--space-0-5) var(--space-2);
-  border-radius: var(--radius-pill);
-  background: oklch(from var(--foreground) l c h / 0.05);
   color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: var(--font-size-caption);
-  letter-spacing: var(--tracking-normal);
 }
 
 /* .maka-skill-library-runtime-label / .maka-skill-library-status-label are now

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -3,8 +3,6 @@
 .settingsSurface {
   min-height: 0;
   height: 100%;
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
   overflow: hidden;
   background: var(--background);
 }
@@ -54,15 +52,6 @@
 .settingsSurface[data-modal="true"] {
   position: relative;
   background: transparent;
-  grid-template-columns: 260px minmax(0, 1fr);
-  grid-template-rows: minmax(0, 1fr);
-  gap: 0;
-}
-
-@media (max-width: 760px) {
-  .settingsSurface[data-modal="true"] {
-    grid-template-columns: 48px minmax(0, 1fr);
-  }
 }
 
 .settingsActionRow {

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -111,6 +111,11 @@
   max-width: 540px;
 }
 
+.settingsSkeletonStack {
+  display: grid;
+  gap: var(--space-2-5);
+}
+
 .providersLoading {
   display: grid;
   align-content: start;

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -153,27 +153,22 @@
   position: relative;
   min-width: 0;
   min-height: 0;
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  box-sizing: border-box;
+  width: calc(100% - var(--agents-content-area-gap));
+  height: calc(100% - 2 * var(--agents-content-area-gap));
   margin: var(--agents-content-area-gap) var(--agents-content-area-gap) var(--agents-content-area-gap) 0;
   border: 0;
   border-radius: var(--radius-modal);
   background: var(--agents-content-area-bg);
   box-shadow: none;
   overflow: hidden;
-  /* Traffic-light-aligned top padding so the page title sits at the
-     same Y baseline as the sidebar brand. */
-  padding: var(--space-12) 0 0;
 }
 
-/* PR-SETTINGS-REVIEW-0 fix-2: max-width centering on a grid child
-   didn't actually align the H2 with the centered column underneath.
-   Use the same edge math the content column uses
-   (`calc((100% - 640px) / 2 + 24px)`) so the header content lines up
-   with row cards regardless of viewport width. */
 .settingsPageHeader {
   min-height: 36px;
-  padding: 0 max(var(--space-6), calc((100% - 640px) / 2 + var(--space-6)));
+  /* Astryx owns the header's inline geometry. This extra block inset is the
+     Electron traffic-light clearance shared with the settings navigation. */
+  padding-top: var(--space-6);
   display: flex;
   align-items: center;
   /* X close button moved to the sidebar `返回应用` — header hosts the
@@ -213,36 +208,6 @@
   font-size: var(--font-size-ui);
   line-height: var(--leading-normal);
   text-wrap: pretty;
-}
-
-.settingsPageContent {
-  min-height: 0;
-  overflow: hidden;
-}
-
-.settingsPageContentViewport {
-  height: 100%;
-  overscroll-behavior: contain;
-}
-
-/* PR-SETTINGS-SHELL-OWNS-LAYOUT-0 (2026-06-23, WAWQAQ msg `70c224f4`):
-   the page chrome (max-width column + side padding + top/bottom gutter)
-   used to live on each sub-page's own wrapper (settingsStructuredPage,
-   settingsAboutPage, settingsPermissionPage, settingsHealthPage…),
-   forcing per-page CSS edits whenever the chrome shifts. The shell
-   now owns it via `.settingsPageContentInner` — the single
-   OverlayScrollArea inner div every page renders through. Sub-pages
-   only manage their own row stack.
-
-   WAWQAQ msg `eafc18a1` correction: reference rows DO have 1px borders
-   + small radius, not flat. Earlier flat-row recipe (PR-PAGE-BODY-0)
-   was wrong; this PR reinstates per-row borders with the reference
-   recipe — 1px subtle border, 8px radius, white-ish bg, 8px gap. */
-.settingsPageContentInner {
-  box-sizing: border-box;
-  max-width: 640px;
-  margin: 0 auto;
-  padding: var(--space-10) var(--space-6) var(--space-16);
 }
 
 /* PR-SETTINGS-CSS-ROOT-CLEANUP-0 (WAWQAQ msg `57de86ae`): the renamed

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -371,7 +371,7 @@
   gap: var(--space-2-5);
 }
 
-/* Empty / load-error CTA shown when there are no connections yet.
+/* Empty state shown when there are no connections yet.
    Despite the name this is a full-width two-line card (16px padding,
    <strong> heading + <small> body), not a chip — surface tier, matching
    its structural twin .settingsWechatQrState. The control tier here came
@@ -387,11 +387,6 @@
   color: var(--foreground);
   padding: var(--space-4) var(--space-4);
   text-align: left;
-}
-
-.enabledEmptyAction:hover {
-  border-color: var(--border-strong);
-  background: var(--background-elevated);
 }
 
 .enabledEmptyChip strong {

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -110,7 +110,6 @@ html[data-os="darwin"] .maka-session-panel-footer {
   .maka-module-main-header,
   .maka-plan-heading,
   .maka-skill-tab,
-  .maka-plan-tab,
   .maka-titlebar-action {
     -webkit-user-select: none;
     user-select: none;

--- a/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
+++ b/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
@@ -61,7 +61,7 @@ describe('sidebar subtraction', () => {
     assert.doesNotMatch(markup, /aria-label="Automations,/);
   });
 
-  it('renders each pair of peer modules as a localized segmented control', () => {
+  it('renders each pair of peer modules as localized view navigation', () => {
     const extensions = renderToStaticMarkup(
       <LocaleProvider locale="zh">
         <ModuleHubSelector hub="extensions" value="skills" onChange={() => {}} />
@@ -73,13 +73,14 @@ describe('sidebar subtraction', () => {
       </LocaleProvider>,
     );
 
-    assert.match(extensions, /astryx-segmented-control/);
+    assert.match(extensions, /astryx-tab-list/);
     assert.match(extensions, /aria-label="扩展内容：技能"/);
-    assert.match(extensions, /role="radiogroup"/);
+    assert.doesNotMatch(extensions, /role="radiogroup"/);
+    assert.match(extensions, /aria-current="page"/);
     assert.match(extensions, />技能</);
     assert.match(extensions, />MCP</);
     assert.doesNotMatch(extensions, /aria-haspopup="menu"/);
-    assert.match(automations, /astryx-segmented-control/);
+    assert.match(automations, /astryx-tab-list/);
     assert.match(automations, /aria-label="定时任务内容：计划提醒"/);
     assert.match(automations, />计划提醒</);
     assert.match(automations, />每日回顾</);

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -31,6 +31,7 @@ import {
   SegmentedControlItem,
   Selector,
   type SelectorOptionData,
+  Skeleton,
 } from '@astryxdesign/core';
 import { Alert, AlertAction, AlertDescription } from './primitives/alert.js';
 import { StatTile } from './primitives/stat-tile.js';
@@ -462,9 +463,9 @@ export function DailyReviewPanel(props: {
           />
         ) : !visibleSummary ? (
           <div className="maka-daily-review-loading" aria-busy="true">
-            <div className="maka-skeleton maka-skeleton-line" style={{ width: '60%' }} />
-            <div className="maka-skeleton maka-skeleton-line" style={{ width: '90%' }} />
-            <div className="maka-skeleton maka-skeleton-line" style={{ width: '75%' }} />
+            <Skeleton width="60%" height={12} radius="rounded" index={0} />
+            <Skeleton width="90%" height={12} radius="rounded" index={1} />
+            <Skeleton width="75%" height={12} radius="rounded" index={2} />
           </div>
         ) : (
           <>
@@ -636,9 +637,9 @@ function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loa
   if (props.loading) {
     return (
       <div className="maka-daily-review-report-body" aria-busy="true">
-        <div className="maka-skeleton maka-skeleton-line" style={{ width: '58%' }} />
-        <div className="maka-skeleton maka-skeleton-line" style={{ width: '92%' }} />
-        <div className="maka-skeleton maka-skeleton-line" style={{ width: '74%' }} />
+        <Skeleton width="58%" height={12} radius="rounded" index={0} />
+        <Skeleton width="92%" height={12} radius="rounded" index={1} />
+        <Skeleton width="74%" height={12} radius="rounded" index={2} />
       </div>
     );
   }

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -23,6 +23,8 @@ import {
   Badge,
   type BadgeProps,
   Button as UiButton,
+  Collapsible,
+  CollapsibleGroup,
   EmptyState,
   IconButton,
   SegmentedControl,
@@ -108,7 +110,7 @@ export function DailyReviewPanel(props: {
     };
   }, []);
 
-  function chooseDailyReviewArchive(archiveId: string) {
+  function chooseDailyReviewArchive(archiveId: string | null) {
     archiveLoadRequestRef.current += 1;
     setSelectedArchiveId(archiveId);
     setSelectedArchive(null);
@@ -573,9 +575,16 @@ export function DailyReviewPanel(props: {
               className="maka-daily-review-summary-empty"
             />
           ) : (
-            <ul className="maka-daily-review-report-list" aria-label={copy.reports.historyAriaLabel}>
+            <CollapsibleGroup
+              type="single"
+              value={selectedArchiveId ?? ''}
+              onChange={(value) => chooseDailyReviewArchive(typeof value === 'string' && value ? value : null)}
+              hasDividers
+              density="balanced"
+              role="list"
+              aria-label={copy.reports.historyAriaLabel}
+            >
               {archives.map((archive) => {
-                const selected = selectedArchiveId === archive.id;
                 // Status color is exception-only (#651): 已生成 / 无数据 / 已跳过
                 // are EXPECTED outcomes and stay as muted prose meta. Only a
                 // failed / no_model run raises a colored Badge that needs eyes.
@@ -586,14 +595,12 @@ export function DailyReviewPanel(props: {
                   archive.modelKey ? formatDailyReviewModelLabel(archive.modelKey) : copy.archive.defaultModel,
                 ].join(' · ');
                 return (
-                  <li key={archive.id}>
-                    <article className="maka-daily-review-report" data-selected={selected ? '' : undefined}>
-                      <button
-                        type="button"
-                        className="maka-daily-review-report-head"
-                        onClick={() => chooseDailyReviewArchive(archive.id)}
-                        aria-expanded={selected}
-                      >
+                  <Collapsible
+                    key={archive.id}
+                    value={archive.id}
+                    role="listitem"
+                    trigger={(
+                      <span className="maka-daily-review-report-trigger">
                         <span className="maka-daily-review-report-heading">
                           <span className="maka-daily-review-report-title">
                             {formatDailyReviewArchiveTitle(archive, locale)}
@@ -608,15 +615,14 @@ export function DailyReviewPanel(props: {
                             label={copy.archive.status[archive.status]}
                           />
                         )}
-                      </button>
-                      {selected && (
-                        <DailyReviewArchiveBody archive={selectedArchive} loading={archiveLoading} />
-                      )}
-                    </article>
-                  </li>
+                      </span>
+                    )}
+                  >
+                    <DailyReviewArchiveBody archive={selectedArchive} loading={archiveLoading} />
+                  </Collapsible>
                 );
               })}
-            </ul>
+            </CollapsibleGroup>
           )}
         </section>
       )}

--- a/packages/ui/src/module-hub-selector.tsx
+++ b/packages/ui/src/module-hub-selector.tsx
@@ -1,8 +1,5 @@
 import type { ReactNode } from 'react';
-import {
-  SegmentedControl,
-  SegmentedControlItem,
-} from '@astryxdesign/core';
+import { Tab, TabList } from '@astryxdesign/core';
 import type { AutomationModule, ExtensionModule } from './nav-selection.js';
 import { useUiLocale } from './locale-context.js';
 import { Blocks, CalendarCheck, Plug, Sun } from './icons.js';
@@ -35,16 +32,16 @@ function Selector(props: {
   onChange(value: string): void;
 }) {
   return (
-    <SegmentedControl
+    <TabList
       className="maka-module-hub-selector"
       value={props.value}
-      label={props.ariaLabel}
+      aria-label={props.ariaLabel}
       onChange={props.onChange}
     >
       {props.options.map(([value, label, icon]) => (
-        <SegmentedControlItem key={value} value={value} label={label} icon={icon} />
+        <Tab key={value} value={value} label={label} icon={icon} />
       ))}
-    </SegmentedControl>
+    </TabList>
   );
 }
 

--- a/packages/ui/src/plan-reminder-form-dialog.tsx
+++ b/packages/ui/src/plan-reminder-form-dialog.tsx
@@ -5,8 +5,8 @@
  * `plan-reminder-panel.tsx`: the nine field states, editingId, the
  * submitPending single-flight owner, validation, and the close guard. The
  * panel keeps only list/runs/query state and opens this dialog with a
- * `PlanReminderFormSeed`. It remounts the closed form session before opening,
- * so Astryx always observes a false-to-true transition.
+ * `PlanReminderFormSeed`. It remounts each form session so Astryx receives a
+ * fresh native dialog with the selected seed.
  *
  * Async-owner invariants (pinned by plan-reminder-panel-contract):
  *   - submit rejects re-entry synchronously via submitPendingRef before

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
 import { useToast } from './toast.js';
 import {
@@ -105,20 +105,11 @@ export function PlanReminderPanel(props: {
   const refreshPendingRef = useRef(false);
   const pendingActionKeysRef = useRef<Set<string>>(new Set());
   const pendingReminderMenuIntentRef = useRef<((trigger?: HTMLButtonElement) => void) | null>(null);
-  // A reminder row's menu trigger button, keyed by reminder id. When a
-  // deferred menu intent (edit/duplicate/clear-runs/delete) opens a dialog
-  // after the menu closes, Astryx Dialog restores focus on Esc to whatever
-  // was `document.activeElement` when it opened. The menu's own close-focus-
-  // return and the deferred dialog open sit across animation frames, so on a
-  // loaded runner the captured element can land on <body> instead of the
-  // trigger and Esc strands focus away from the row. The trigger is passed to
-  // the deferred dialog intent and focused in the same frame that opens the
-  // dialog, making Astryx Dialog's own capture deterministic. See the
-  // plan-reminders E2E.
   const reminderMenuTriggerRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+  const formDialogTriggerRef = useRef<HTMLButtonElement | null>(null);
   // Issue #1044: all create/edit form fields + submit moved into
   // PlanReminderFormDialog. The panel owns its open state and seed;
-  // `formNonce` remounts a closed form session before Astryx opens it.
+  // `formNonce` gives Astryx a fresh native dialog for each form session.
   const [formDialogOpen, setFormDialogOpen] = useState(false);
   const [openReminderMenuId, setOpenReminderMenuId] = useState<string | null>(null);
   const [formSeed, setFormSeed] = useState<PlanReminderFormSeed>(() => createPlanReminderFormSeed());
@@ -176,6 +167,15 @@ export function PlanReminderPanel(props: {
     };
   }, []);
 
+  // Put the product action that opened the form back in focus before Astryx
+  // Dialog's passive effect captures its opener. Astryx still owns opening,
+  // Escape handling, trapping, and focus restoration on close.
+  useLayoutEffect(() => {
+    if (!formDialogOpen) return;
+    formDialogTriggerRef.current?.focus();
+    formDialogTriggerRef.current = null;
+  }, [formDialogOpen, formNonce]);
+
   // Re-sync the switch to the persisted snapshot when it changes (external
   // edit, relaunch), unless a local write is mid-flight — the optimistic
   // value wins until the write settles.
@@ -210,14 +210,10 @@ export function PlanReminderPanel(props: {
   }
 
   function openReminderDialog(seed: PlanReminderFormSeed, trigger?: HTMLButtonElement) {
-    setFormDialogOpen(false);
+    formDialogTriggerRef.current = trigger ?? null;
     setFormSeed(seed);
     setFormNonce((nonce) => nonce + 1);
-    window.requestAnimationFrame(() => {
-      if (!planReminderMountedRef.current) return;
-      trigger?.focus();
-      setFormDialogOpen(true);
-    });
+    setFormDialogOpen(true);
   }
 
   function openCreateReminderDialog() {

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -340,11 +340,10 @@ export function PlanReminderPanel(props: {
                 if (value === 'tasks' || value === 'runs') setPlanView(value);
               }}
               hasDivider
-              className="maka-plan-tabs-list"
               aria-label={copy.page.viewsAriaLabel}
             >
-              <Tab className="maka-plan-tab" value="tasks" label={copy.page.tasks} />
-              <Tab className="maka-plan-tab" value="runs" label={copy.page.runs} />
+              <Tab value="tasks" label={copy.page.tasks} />
+              <Tab value="runs" label={copy.page.runs} />
             </TabList>
             {planView === 'tasks' ? (
               showListControls ? (

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -16,7 +16,6 @@ import type { CapabilityAuditReport } from '@maka/core';
 import { deriveCapabilityAuditReport } from '@maka/core';
 import {
   Badge,
-  type BadgeProps,
   Button as UiButton,
   EmptyState,
   IconButton,
@@ -470,6 +469,16 @@ function SkillLibraryPanel(props: {
                   : formatSkillLibraryDescription(skill, copy);
               const statusLabel = formatSkillStatusLabel(skill, copy);
               const runtimeLabel = formatSkillRuntimeLabel(skill, copy);
+              const contextLabel = `${isDiscoveryDiagnostic && skill.discoveryDiagnosticReason
+                ? copy.context.discoveryDiagnostic[skill.discoveryDiagnosticReason]
+                : copy.context.decision[contextStatus]}${!isDiscoveryDiagnostic && skill.contextRank ? ` #${skill.contextRank}` : ''}`;
+              const contextNeedsAttention = isDiscoveryDiagnostic || (contextStatus !== 'advertised' && contextStatus !== 'disabled');
+              const sourceStatusNeedsAttention = !isDiscoveryDiagnostic && skillSourceStatusNeedsAttention(skill);
+              const supportingMeta = [
+                skill.scope ? copy.context.scope[skill.scope] : null,
+                contextNeedsAttention ? null : contextLabel,
+                !isDiscoveryDiagnostic && !sourceStatusNeedsAttention ? statusLabel : null,
+              ].filter((value): value is string => Boolean(value));
               const opening = props.openingSkillId === skillRef;
               const updating = props.updatingSkillId === skill.id;
               const toggling = props.togglingSkillId === skillRef;
@@ -519,8 +528,8 @@ function SkillLibraryPanel(props: {
                       {skill.runtimeStatus === 'state_error' && (
                         <Badge variant="warning" className="maka-skill-library-runtime-label" data-status={skill.runtimeStatus} label={runtimeLabel} />
                       )}
-                      {skill.scope && (
-                        <Badge variant="neutral" className="maka-skill-library-scope-label" data-scope={skill.scope} label={copy.context.scope[skill.scope]} />
+                      {supportingMeta.length > 0 && (
+                        <span className="maka-skill-library-supporting">{supportingMeta.join(' · ')}</span>
                       )}
                       {skill.needsReview && (
                         <Badge
@@ -529,16 +538,16 @@ function SkillLibraryPanel(props: {
                           label={copy.context.needsReview}
                         />
                       )}
-                      <Badge
-                        variant={contextStatus === 'advertised' ? 'neutral' : 'warning'}
-                        className="maka-skill-library-context-label"
-                        data-status={contextStatus}
-                        label={`${isDiscoveryDiagnostic && skill.discoveryDiagnosticReason
-                          ? copy.context.discoveryDiagnostic[skill.discoveryDiagnosticReason]
-                          : copy.context.decision[contextStatus]}${!isDiscoveryDiagnostic && skill.contextRank ? ` #${skill.contextRank}` : ''}`}
-                      />
-                      {!isDiscoveryDiagnostic && (
-                        <Badge variant={skillStatusBadgeVariant(skill)} className="maka-skill-library-status-label" data-status={skill.managedUpdateStatus ?? skill.validationStatus ?? skill.sourceType ?? 'workspace'} label={statusLabel} />
+                      {contextNeedsAttention && (
+                        <Badge
+                          variant="warning"
+                          className="maka-skill-library-context-exception"
+                          data-status={contextStatus}
+                          label={contextLabel}
+                        />
+                      )}
+                      {sourceStatusNeedsAttention && (
+                        <Badge variant="warning" className="maka-skill-library-status-label" data-status={skill.managedUpdateStatus ?? skill.validationStatus ?? skill.sourceType ?? 'workspace'} label={statusLabel} />
                       )}
                       {opening && <span>{copy.row.opening}</span>}
                       {updating && <span>{copy.row.updating}</span>}
@@ -740,19 +749,13 @@ function formatSkillRuntimeLabel(skill: SkillEntry, copy: SkillsCopy): string {
   return skill.enabled ? copy.status.enabled : copy.status.disabled;
 }
 
-// Derive the source-status Badge tone from the same data-status the retired
-// .maka-skill-library-status-label CSS keyed off. Exception-only: 内置 / 本地
-// (expected states) stay neutral; only genuine attention states carry a tone.
-//   metadata_error / local_modified → warning (needs the user's attention)
-//   受管理 (managed base) → info (managed but nothing wrong)
-//   bundled / workspace default → neutral
-function skillStatusBadgeVariant(skill: SkillEntry): BadgeProps['variant'] {
-  if (skill.validationStatus === 'metadata_error') return 'warning';
-  if (skill.sourceType === 'managed') {
-    if (skill.managedUpdateStatus === 'local_modified' || skill.managedUpdateStatus === 'metadata_error') return 'warning';
-    return 'info';
-  }
-  return 'neutral';
+function skillSourceStatusNeedsAttention(skill: SkillEntry): boolean {
+  if (skill.validationStatus && skill.validationStatus !== 'ok') return true;
+  if (skill.userModified) return true;
+  if (skill.sourceType !== 'managed') return false;
+  return skill.managedUpdateStatus !== undefined
+    && skill.managedUpdateStatus !== 'not_managed'
+    && skill.managedUpdateStatus !== 'up_to_date';
 }
 
 function previewText(content: string): string {


### PR DESCRIPTION
## Summary

Follow-up to #1733. Removes the remaining Maka-owned presentation paths that duplicate Astryx 0.1.9 behavior.

- use Astryx Layout, LayoutPanel, LayoutHeader, LayoutContent, and useMediaQuery for the settings shell
- use TabList for module navigation and Collapsible for Daily Review archives
- use Banner and Skeleton for provider failures and loading states
- remove plan-tab geometry overrides and reserve skill badges for exceptional state only
- let Astryx DropdownMenu and Dialog own Plan Reminder close/Escape/focus behavior without Maka frame-timing restoration
- update authority contracts and Electron journeys to the resulting Astryx navigation semantics

## Verification

- npm run format:check
- npm run lint
- npm run build
- npm run typecheck
- npm --workspace @maka/desktop test — 1855 passed
- npm --workspace @maka/ui run test:dist — 294 passed
- npm --workspace @maka/desktop run build-storybook
- npm --workspace @maka/desktop run smoke:storybook — 51 render/play checks passed
- targeted Settings/Modules Electron suite — 30 passed
- Plan Reminder menu-to-dialog focus stress — 20/20 passed with four workers
- GitHub CI typecheck and test — passed
- GitHub CI e2e — 85 passed; the remaining 8 failures match the current base conversation regressions listed below

## Review focus

The implementation was compared against the official Astryx 0.1.9 Storybook and package source. Astryx now owns component geometry, responsive layout, disclosure, loading, feedback, tabs, menu dismissal, dialog trapping, and focus restoration; Maka retains product data, runtime, IPC, persistence, routing, validation, security state, and the identity of the product action opening a dialog.

At the current base commit 82f7dfcab, the full E2E job still fails on eight out-of-scope conversation journeys: disclosure output, two permission-mode cases, four scroll-geometry cases, and session-health notice. This PR does not modify those authorities. Its Settings navigation regressions and Plan Reminder focus race are covered by the passing targeted suite above.