### PR TITLE
fix: restore Astryx shell navigation authority

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -290,7 +290,7 @@ export const test = base.extend<{
   // The `[data-sidebar-state="expanded"]` part is load-bearing. The shell
   // boots collapsed (the localStorage default), and `sidebarCollapsed: false`
   // only lands later, from `applyE2eFixture` — a rAF plus two IPC round trips
-  // after mount. A bare `.maka-list-row` does not gate on it: a collapsed
+  // after mount. A bare session label does not gate on it: a collapsed
   // sidebar keeps the whole list mounted at full width behind `opacity: 0` in
   // a 0px grid column, which Playwright still reports as visible. Tests then
   // started against a sidebar that was about to expand under them.
@@ -298,7 +298,7 @@ export const test = base.extend<{
     await withE2eWindow(
       {
         seed: false,
-        readinessSelector: '[data-sidebar-state="expanded"] .maka-list-row',
+        readinessSelector: '[data-sidebar-state="expanded"] [data-session-id]',
         e2eFixtureScenario: 'sidebar-long-sessions',
         locale: 'zh',
       },

--- a/apps/desktop/e2e/sidebar-geometry.spec.ts
+++ b/apps/desktop/e2e/sidebar-geometry.spec.ts
@@ -161,7 +161,7 @@ test('sidebar list scrolls independently and keeps the footer in view with 60 se
   // handful of baseline chat sessions; their exact count is not this
   // contract's concern — the 60-row pin alone proves the overflow
   // precondition the geometry assertions depend on.
-  await expect(page.locator('.maka-list-row-main[title^="会话 "]')).toHaveCount(60);
+  await expect(page.locator('[data-session-id][title^="会话 "]')).toHaveCount(60);
 
   // The list scroller and the chat scroller are distinct elements.
   await expect(page.locator(LIST_CONTENT)).toHaveCount(1);
@@ -225,4 +225,28 @@ test('official SideNav resize handle updates the sidebar width from the keyboard
   await expect.poll(async () => Number(await handle.getAttribute('aria-valuenow'))).toBe(beforeWidth + 10);
   await expect.poll(() => panel.evaluate((element) => element.getBoundingClientRect().width))
     .toBe(beforeWidth + 10);
+});
+
+test('titlebar restores the official SideNav width after pointer collapse', async ({
+  sidebarLongSessionsWindow: page,
+}) => {
+  const shell = page.locator('.appFrame');
+  const panel = page.locator('.maka-session-panel');
+  const handle = page.getByTestId('astryx-sidenav-resize-handle');
+  const handleBox = await handle.boundingBox();
+  const panelBox = await panel.boundingBox();
+  expect(handleBox).not.toBeNull();
+  expect(panelBox).not.toBeNull();
+  if (!handleBox || !panelBox) return;
+
+  await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(panelBox.x + 100, handleBox.y + handleBox.height / 2, { steps: 4 });
+  await page.mouse.up();
+
+  await expect(shell).toHaveAttribute('data-sidebar-state', 'collapsed');
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  await expect(shell).toHaveAttribute('data-sidebar-state', 'expanded');
+  await expect.poll(() => panel.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeGreaterThanOrEqual(180);
 });

--- a/apps/desktop/e2e/sidebar-navigation.spec.ts
+++ b/apps/desktop/e2e/sidebar-navigation.spec.ts
@@ -31,7 +31,7 @@ test('session grouping menu switches between flat conversations and project disc
   const popup = page.getByRole('menu', { name: '会话分组方式' });
 
   await expect(sidebar.locator('.maka-list-group-label')).toHaveCount(0);
-  await expect(sidebar.locator('.maka-list-row').first()).toBeVisible();
+  await expect(sidebar.locator('.astryx-list-item').first()).toBeVisible();
   await grouping.click();
   const byTime = page.getByRole('menuitemradio', { name: '按时间' });
   const byProject = page.getByRole('menuitemradio', { name: '按项目' });
@@ -53,6 +53,76 @@ test('session grouping menu switches between flat conversations and project disc
   await expect(page.getByRole('menuitemradio', { name: '按时间' })).toHaveAttribute('aria-checked', 'false');
 });
 
+test('project history keeps Astryx TreeList as the only arrow-key focus authority', async ({
+  sidebarLongSessionsWindow: page,
+}) => {
+  const sidebar = await expandedSidebar(page);
+  await sidebar.getByRole('button', { name: '会话分组方式' }).click();
+  await page.getByRole('menuitemradio', { name: '按项目' }).click();
+
+  const treeItems = sidebar.getByRole('treeitem');
+  const current = sidebar.getByRole('treeitem', { name: /^会话 00\b/ });
+  await expect(current).toHaveCount(1);
+  const currentIndex = await current.evaluate((element) =>
+    Array.from(element.closest('[role="tree"]')?.querySelectorAll('[role="treeitem"]') ?? []).indexOf(element),
+  );
+  expect(currentIndex).toBeGreaterThanOrEqual(0);
+  const next = treeItems.nth(currentIndex + 1);
+  await expect(current.getByRole('button', { name: /^会话 00\b/ })).toHaveAttribute('tabindex', '-1');
+
+  await current.focus();
+  await expect(current).toBeFocused();
+  await current.press('ArrowDown');
+  await expect(next).toBeFocused();
+});
+
+test('project rename owns Enter without toggling the Astryx TreeList disclosure', async ({
+  sidebarLongSessionsWindow: page,
+}) => {
+  const sidebar = await expandedSidebar(page);
+  await sidebar.getByRole('button', { name: '会话分组方式' }).click();
+  await page.getByRole('menuitemradio', { name: '按项目' }).click();
+
+  const project = sidebar.getByRole('treeitem').first();
+  await expect(project).toHaveAttribute('aria-expanded', 'true');
+  await project.getByRole('button', { name: /项目操作$/ }).click();
+  await page.getByRole('menuitem', { name: '重命名', exact: true }).click();
+
+  const rename = project.getByRole('textbox', { name: '重命名' });
+  await expect(rename).toBeFocused();
+  const disclosureState = await project.getAttribute('aria-expanded');
+  const originalName = await rename.inputValue();
+  const tree = sidebar.getByRole('tree');
+  await rename.press('A');
+  await expect(rename).toBeFocused();
+  await rename.press('Space');
+  await expect(rename).toHaveValue('A ');
+  await expect(rename).toBeFocused();
+  await rename.evaluate((element) => {
+    element.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      isComposing: true,
+    }));
+  });
+  await expect(rename).toBeFocused();
+  await rename.fill(originalName);
+  await rename.press('Enter');
+  await expect(tree).toBeVisible();
+  await expect(project).toHaveAttribute('aria-expanded', disclosureState ?? 'false');
+});
+
+test('double-clicking the flat ListItem menu does not enter rename', async ({
+  sidebarLongSessionsWindow: page,
+}) => {
+  const sidebar = await expandedSidebar(page);
+  const row = sidebar.locator('.astryx-list-item').filter({ hasText: '会话 00' }).first();
+
+  await row.getByRole('button', { name: '对话操作' }).dispatchEvent('dblclick');
+
+  await expect(sidebar.getByRole('textbox', { name: '重命名对话' })).toHaveCount(0);
+});
+
 test('session grouping menu fits its Chinese labels instead of inheriting the generic minimum width', async ({
   sidebarLongSessionsWindow: page,
 }) => {
@@ -69,8 +139,9 @@ test('session delete intent opens only after its menu closes and restores the tr
   sidebarLongSessionsWindow: page,
 }) => {
   const sidebar = await expandedSidebar(page);
-  const row = sidebar.locator('.maka-list-row').filter({ hasText: '会话 00' }).first();
-  const rowButton = row.locator('[data-session-id]').first();
+  const row = sidebar.locator('.astryx-list-item').filter({ hasText: '会话 00' }).first();
+  const rowButton = row.locator(':scope > button');
+  await expect(rowButton).toHaveCount(1);
   await rowButton.focus();
 
   const trigger = row.getByRole('button', { name: '对话操作' });

--- a/apps/desktop/src/main/__tests__/astryx-shell-authority-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/astryx-shell-authority-contract.test.ts
@@ -23,6 +23,8 @@ test('the desktop shell composes the official Astryx AppShell directly', async (
 test('the session sidebar delegates geometry and collapse to official SideNav', async () => {
   const panel = await source('packages/ui/src/session-list-panel.tsx');
   const navigation = await source('packages/ui/src/session-sidebar-nav.tsx');
+  const chrome = await source('apps/desktop/src/renderer/app-shell-chrome-actions.tsx');
+  const shellCss = await source('apps/desktop/src/renderer/styles/shell-layout.css');
 
   assert.match(panel, /@astryxdesign\/core\/SideNav/);
   assert.match(panel, /<SideNav/);
@@ -34,6 +36,10 @@ test('the session sidebar delegates geometry and collapse to official SideNav', 
   assert.match(navigation, /size="md"/);
   assert.doesNotMatch(navigation, /BaseButton/);
   assert.doesNotMatch(navigation, /\bcva\b/);
+  assert.doesNotMatch(navigation, /className="maka-nav-row/);
+  assert.doesNotMatch(chrome, /<SideNavCollapseButton[^>]*\bsize=/);
+  assert.equal(chrome.match(/size(?::|=)\s*(?:"md"|'md')/g)?.length, 4);
+  assert.doesNotMatch(shellCss, /maka-shell-2col|maka-resize-handle|isResizingColumns/);
 });
 
 test('history and workbar use Astryx navigation taxonomy without shared wrappers', async () => {
@@ -42,10 +48,20 @@ test('history and workbar use Astryx navigation taxonomy without shared wrappers
 
   assert.match(history, /@astryxdesign\/core\/List/);
   assert.match(history, /@astryxdesign\/core\/TreeList/);
-  const renameNavigationGuards = history.match(
-    /\['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'\]\.includes\(event\.key\)\)\s*\{\s*event\.stopPropagation\(\);/g,
+  assert.doesNotMatch(history, /@base-ui\/react\/button/);
+  assert.doesNotMatch(history, /querySelectorAll<HTMLButtonElement>\('\.maka-list-row-main'\)/);
+  assert.match(history, /<ListItem[\s\S]*?onClick=\{isEditing \? undefined/);
+  assert.match(history, /startContent=\{/);
+  assert.match(history, /endContent=\{/);
+  assert.match(history, /function sessionItem\(session: SessionSummary\): TreeListItemData/);
+  assert.match(history, /onClick: isEditing[\s\S]*?props\.onSelectSession\(session\.id\)/);
+  assert.doesNotMatch(history, /function ProjectSessionGroup/);
+  assert.match(history, /const projectItem[\s\S]*?startContent:[\s\S]*?endContent:/);
+  const renameExclusiveKeyHandlers = history.match(
+    /onKeyDown=\{\(event\) => \{\s*event\.stopPropagation\(\);/g,
   );
-  assert.equal(renameNavigationGuards?.length, 2);
+  assert.equal(renameExclusiveKeyHandlers?.length, 2);
+  assert.doesNotMatch(history, /onDoubleClick=/);
   assert.match(workbar, /@astryxdesign\/core\/Toolbar/);
   assert.match(workbar, /@astryxdesign\/core\/TabList/);
   assert.match(workbar, /<Toolbar/);

--- a/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
@@ -810,7 +810,7 @@ describe('e2e-fixture mode', () => {
     // `E2eFixtureState.focusActiveRow=true`, which the renderer
     // reads to focus the active row's button after mount. That
     // triggers `:focus-within` and reveals the
-    // `.maka-list-row-menu-trigger` — the fixture then proves
+    // official session item action — the fixture then proves
     // the time meta / unread dot are correctly hidden underneath.
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-e2e-fixture-row-actions-'));
     try {

--- a/apps/desktop/src/main/__tests__/stale-sessions.test.ts
+++ b/apps/desktop/src/main/__tests__/stale-sessions.test.ts
@@ -122,14 +122,14 @@ describe('stale session CSS contract (@kenji review gate)', () => {
     // Inactive stale dimming rule must exist.
     assert.match(
       css,
-      /\.maka-list-row\[data-stale="true"\]\s*\{[\s\S]*?opacity:\s*var\(--opacity-muted\)/,
-      'expected `.maka-list-row[data-stale="true"]` opacity dim rule (var(--opacity-muted) per PR2)',
+      /\.maka-session-item-label\[data-stale="true"\]\s*\{[\s\S]*?opacity:\s*var\(--opacity-muted\)/,
+      'expected stale product content to use the muted opacity token',
     );
     // Active stale restoration rule must exist.
     assert.match(
       css,
-      /\.maka-list-row\[data-stale="true"\]\[data-active="true"\]\s*\{[\s\S]*?opacity:\s*1/,
-      'expected active-stale opacity restore rule',
+      /\[role="treeitem"\]\[aria-selected="true"\][\s\S]*?\.maka-session-item-label\[data-stale="true"\][\s\S]*?opacity:\s*1/,
+      'expected Astryx-selected stale content to restore full opacity',
     );
   });
 

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -186,7 +186,7 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2eFixtureScenario>([
   // kenji `b3d156e9`): same 60-session seed; differs in
   // `focusActiveRow: true`, which programmatically focuses the
   // active row's button after mount so `:focus-within` triggers
-  // and the `.maka-list-row-menu-trigger` becomes visible.
+  // and the official session item receives focus.
   // Captures the overflow-trigger state so reviewers can verify
   // the time meta + unread dot are hidden underneath (no overlap).
   'sidebar-row-actions-visible',

--- a/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
+++ b/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
@@ -20,14 +20,17 @@ import {
   DropdownMenuItem,
 } from '@astryxdesign/core/DropdownMenu';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
-import { useRef, useState } from 'react';
+import {
+  SideNavCollapseButton,
+  type SideNavImperativeCollapseHandle,
+} from '@astryxdesign/core/SideNav';
+import { useRef, useState, type RefObject } from 'react';
 import { getShellCopy } from './locales/shell-copy';
 
 export function AppShellTopbarActions(props: {
   sidebarCollapsed: boolean;
+  sidebarHandleRef: RefObject<SideNavImperativeCollapseHandle | null>;
   onOpenSearchModal(): void;
-  onCollapseSidebar(): void;
-  onExpandSidebar(): void;
   onCreateSession(): void;
 }) {
   const locale = useUiLocale();
@@ -39,22 +42,21 @@ export function AppShellTopbarActions(props: {
           label={copy.searchConversations}
           icon={<Search aria-hidden="true" />}
           variant="ghost"
-          size="sm"
+          size="md"
           className="maka-titlebar-action"
           data-maka-search-trigger="true"
           onClick={props.onOpenSearchModal}
         />
       </Tooltip>
       <Tooltip content={props.sidebarCollapsed ? copy.expandSidebar : copy.collapseSidebar}>
-        <IconButton
+        <SideNavCollapseButton
+          handleRef={props.sidebarHandleRef}
           label={props.sidebarCollapsed ? copy.expandSidebar : copy.collapseSidebar}
-          icon={props.sidebarCollapsed ? <PanelLeftOpen aria-hidden="true" /> : <PanelLeftClose aria-hidden="true" />}
-          variant="ghost"
-          size="sm"
           className="maka-titlebar-action"
-          onClick={props.sidebarCollapsed ? props.onExpandSidebar : props.onCollapseSidebar}
           aria-expanded={!props.sidebarCollapsed}
-        />
+        >
+          {props.sidebarCollapsed ? <PanelLeftOpen aria-hidden="true" /> : <PanelLeftClose aria-hidden="true" />}
+        </SideNavCollapseButton>
       </Tooltip>
       {props.sidebarCollapsed && (
         <Tooltip content={copy.newTask}>
@@ -62,7 +64,7 @@ export function AppShellTopbarActions(props: {
             label={copy.newTask}
             icon={<SquarePen aria-hidden="true" />}
             variant="ghost"
-            size="sm"
+            size="md"
             className="maka-titlebar-action"
             onClick={props.onCreateSession}
           />
@@ -107,7 +109,7 @@ export function AppShellWorkspaceTopActions(props: {
           icon: <MoreHorizontal aria-hidden="true" />,
           isIconOnly: true,
           variant: 'ghost',
-          size: 'sm',
+          size: 'md',
           className: 'maka-titlebar-action',
         }}
       >
@@ -122,7 +124,7 @@ export function AppShellWorkspaceTopActions(props: {
             label={workbarLabel}
             icon={props.workbarCollapsed ? <PanelRightOpen aria-hidden="true" /> : <PanelRightClose aria-hidden="true" />}
             variant="ghost"
-            size="sm"
+            size="md"
             className="maka-titlebar-action"
             onClick={props.onToggleWorkbar}
             aria-expanded={!props.workbarCollapsed}

--- a/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
+++ b/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
@@ -178,18 +178,14 @@ export function createAppShellE2eFixtureActions(options: {
     }
     // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 (WAWQAQ msg `5dd1c348`,
     // kenji `b3d156e9`): when the fixture sets `focusActiveRow`,
-    // focus the active row's button after the next paint so the
-    // row's `:focus-within` triggers and the `.maka-list-row-menu-trigger`
-    // becomes visible. The fixture then shows the overflow
-    // trigger against the slim row, proving the time meta
-    // + unread dot are hidden underneath (no overlap with the
-    // action icons — the bug WAWQAQ flagged). Two RAFs let React
+    // focus the Astryx-owned active ListItem action after the next paint.
+    // Two RAFs let React
     // commit the active selection before we query the DOM.
     if (state.focusActiveRow) {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           const activeRowButton = document.querySelector<HTMLButtonElement>(
-            '.maka-list-row[data-active="true"] .maka-list-row-main',
+            '.astryx-list-item[aria-current="true"] > button',
           );
           activeRowButton?.focus({ preventScroll: true });
         });

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -149,6 +149,7 @@ import {
   showSessionWorkspaceUnavailableToast,
 } from './session-workspace-errors';
 import { AppShell as AstryxAppShell } from '@astryxdesign/core/AppShell';
+import type { SideNavImperativeCollapseHandle } from '@astryxdesign/core/SideNav';
 
 type ComposerImportOwner = {
   sessionId: string | undefined;
@@ -1177,6 +1178,7 @@ function AppShellContent({
     workbarTab,
     setWorkbarTab,
   } = useShellLayout();
+  const sessionSideNavHandleRef = useRef<SideNavImperativeCollapseHandle>(null);
   const { startWorkbarResize, onWorkbarResizeHandleKeyDown } = useStableActions(createAppShellLayoutActions, {
     workbarCollapsed,
     workbarWidth,
@@ -2047,9 +2049,8 @@ function AppShellContent({
           <header className="maka-window-titlebar">
             <AppShellTopbarActions
               sidebarCollapsed={sessionListCollapsed}
+              sidebarHandleRef={sessionSideNavHandleRef}
               onOpenSearchModal={() => setSearchModalOpen(true)}
-              onCollapseSidebar={() => setSessionListCollapsed(true)}
-              onExpandSidebar={() => setSessionListCollapsed(false)}
               onCreateSession={createSession}
             />
             {!VIEWS_WITHOUT_WORKSPACE_ACTIONS.has(agentsView) && (
@@ -2067,10 +2068,13 @@ function AppShellContent({
         }
         sideNav={
           <SessionListPanel
+            collapseHandleRef={sessionSideNavHandleRef}
             collapsed={sessionListCollapsed}
             onCollapsedChange={setSessionListCollapsed}
             width={sessionListWidth}
-            onWidthChange={setSessionListWidth}
+            onWidthChange={(width) => {
+              if (width >= SESSION_LIST_EXPANDED_MIN_WIDTH) setSessionListWidth(width);
+            }}
             minWidth={SESSION_LIST_EXPANDED_MIN_WIDTH}
             maxWidth={SESSION_LIST_EXPANDED_MAX_WIDTH}
             selection={navSelection}

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -35,17 +35,6 @@
   border-top: 0;
 }
 
-/* Sidebar footer — Settings affordance only. The earlier "Free Plan" account
-   widget was removed (WAWQAQ msg cad3dec4: "现在左下角怎么还有 账户部分,
-   我们没有账户"). About / version still reachable via Settings → 关于. */
-.maka-sidebar-settings-button {
-  display: inline-grid;
-  /* Same glyph column as .maka-nav-row so the gear shares the nav rows'
-     icon axis and 16px chrome size (icon-system contract). */
-  grid-template-columns: var(--icon-size) minmax(0, 1fr);
-  align-items: center;
-}
-
 .maka-sidebar-update-button {
   position: relative;
   min-width: 0;
@@ -113,33 +102,6 @@
   -webkit-app-region: no-drag;
 }
 
-.maka-nav-row {
-  -webkit-app-region: no-drag;
-}
-
-.maka-nav-row span:nth-child(2) {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.maka-nav-row small {
-  font-variant-numeric: tabular-nums;
-}
-
-.maka-nav-count {
-  min-width: 16px;
-  height: 16px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-pill);
-  padding: 0 var(--space-1);
-  font-size: var(--font-size-caption);
-  font-variant-numeric: tabular-nums;
-}
-
 .maka-list-stack {
   min-height: 0;
   overflow: hidden;
@@ -166,16 +128,6 @@
   border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.05);
 }
 
-.maka-list-group[data-variant="project"] + .maka-list-group[data-variant="project"] {
-  margin-top: 0;
-  padding-top: 0;
-  border-top: 0;
-}
-
-.maka-list-group[data-variant="project"][data-expanded="true"] + .maka-list-group[data-variant="project"] {
-  margin-top: var(--space-3);
-}
-
 /* Group label — a quiet, non-interactive divider for flat conversations.
    Project disclosures use their own heading control below. */
 .maka-list-group-label {
@@ -190,32 +142,13 @@
 }
 
 .maka-list-project-heading {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
   gap: var(--space-1-5);
-  width: 100%;
-  min-height: var(--h-control-lg);
-  padding: 0 var(--space-1-5);
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-medium);
-  text-align: left;
-}
-
-.maka-list-project-header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) var(--h-control-lg);
-  align-items: center;
   min-width: 0;
-}
-
-.maka-list-project-heading:disabled {
-  cursor: default;
-  opacity: 1;
 }
 
 .maka-list-project-name {
@@ -232,19 +165,15 @@
   font-variant-numeric: tabular-nums;
 }
 
-.maka-list-project-menu-trigger {
-  justify-self: end;
-}
-
-.maka-list-group[data-unavailable="true"] .maka-list-project-heading {
+.maka-list-project-heading[data-unavailable="true"] {
   color: var(--muted-foreground);
 }
 
-.maka-list-group[data-unavailable="true"] .maka-list-project-heading [aria-label] {
+.maka-list-project-heading[data-unavailable="true"] [aria-label] {
   color: var(--warning-foreground, var(--muted-foreground));
 }
 
-.maka-list-project-rename input {
+.maka-list-project-rename {
   min-width: 0;
   width: 100%;
   height: var(--h-control-sm);
@@ -257,7 +186,7 @@
   padding: 0 var(--space-1);
 }
 
-.maka-list-project-rename input:focus-visible {
+.maka-list-project-rename:focus-visible {
   border-color: var(--focus-ring);
   box-shadow: 0 0 0 var(--focus-ring-width) color-mix(in srgb, var(--focus-ring) 24%, transparent);
 }
@@ -267,56 +196,48 @@
   color: var(--muted-foreground);
 }
 
-/* The semantic project heading owns its composite row states. Only the
-   folder-glyph tint + flex-shrink guard remain heading-specific here. */
-.maka-list-project-heading svg {
-  color: var(--muted-foreground);
-  flex: 0 0 auto;
+/* Astryx ListItem and TreeListItem own row geometry, selection, hover, and focus.
+   Maka contributes only product content inside their public slots. */
+.maka-session-item-start,
+.maka-session-item-end,
+.maka-session-item-label,
+.maka-project-item-end {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
 }
 
+.maka-session-item-start,
+.maka-session-item-end,
+.maka-project-item-end {
+  gap: var(--space-1);
+}
 
-
-/* PR-SIDEBAR-IA-0 Phase 3 (WAWQAQ msgs `14ed98b5`, `761141c5` —
- * "list 很丑、很肥很臃肿"; xuan `6b28984e` sign-off + "32-40px 薄行";
- * kenji `2b20c73c`): slim row.
- *
- * Before Phase 3: each row was a 56-72px card (border + radius +
- * shadow) showing title + snippet + meta stacked over three lines.
- * That made 9-10 rows visible in a 990px viewport — far too few for
- * a sidebar of 60 sessions.
- *
- * After Phase 3:
- *   - 32px min-height, single line: status indicator + name + time.
- *   - Flat list (no border, no radius, no shadow); the surrounding
- *     `.maka-list-stackContent` provides the row stack, so rows just need
- *     to read as a list, not a stack of cards.
- *   - Snippet drops out of the default DOM (lives only in a native
- *     `title=` tooltip on hover) — see SessionRow render path.
- *   - A single overflow trigger replaces the time/unread slot on hover or focus.
- *   - Active row uses a neutral flat fill instead of the old accent rail.
- */
-.maka-list-row {
-  position: relative;
-  width: 100%;
-  min-height: var(--h-control-lg);
-  display: flex;
-  align-items: stretch;
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--foreground);
+.maka-session-item-label {
+  gap: var(--space-1-5);
   overflow: hidden;
-  transition: background-color var(--duration-base) var(--ease-out-strong);
+  font-size: var(--font-size-ui);
+  font-weight: var(--font-weight-medium);
 }
 
-.maka-list-session-children {
-  margin-inline-start: var(--space-2);
-  padding-inline-start: var(--space-1);
-  border-inline-start: var(--border-width-hairline) solid var(--border);
+.maka-session-item-label > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.maka-list-row[data-subagent="true"] {
-  background: var(--selection);
+.maka-session-item-label[data-stale="true"] {
+  opacity: var(--opacity-muted);
+}
+
+:is(.astryx-list-item[aria-current="true"], [role="treeitem"][aria-selected="true"])
+  .maka-session-item-label[data-stale="true"] {
+  opacity: 1;
+}
+
+.maka-session-list-item[data-subagent="true"] .maka-session-item-label {
+  color: var(--foreground-secondary);
 }
 
 .maka-list-row-subagent-icon {
@@ -324,100 +245,11 @@
   color: var(--muted-foreground);
 }
 
-.maka-list-row:hover {
-  background: var(--state-hover-bg);
-}
-
-.maka-list-row:active {
-  background: var(--state-selected-bg);
-}
-
-/* Active session row: slightly stronger than hover so the current
-   session is distinguishable from hover, but lighter than nav-row
-   active (0.09) so the main navigation reads as the primary surface. */
-.maka-list-row[data-active="true"] {
-  background: var(--state-selected-bg);
-}
-
-.maka-list-row[data-active="true"] .maka-list-row-name {
-  color: var(--foreground);
-  font-weight: var(--font-weight-semibold);
-}
-
-.maka-list-row-main {
-  flex: 1;
-  min-width: 0;
-  display: grid;
-  /* Phase 3: single-row layout — name takes the flex column, time
-   * sits in the auto column at the inline-end. Snippet drops out of
-   * the default DOM entirely (replaced by native title= tooltip on
-   * the button). */
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--space-1-5);
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: inherit;
-  padding: var(--space-0-5) var(--space-2) var(--space-0-5) var(--space-2-5);
-  text-align: left;
-}
-
-.maka-list-row-menu-trigger {
-  position: absolute;
-  top: 0;
-  right: var(--space-1);
-  width: var(--h-control-lg);
-  height: var(--h-control-lg);
-  display: grid;
-  place-items: center;
-  padding: 0;
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--foreground-secondary);
-  opacity: 0;
-  transform: translateX(var(--space-1));
-  transition:
-    opacity var(--duration-base) var(--ease-out-strong),
-    transform var(--duration-base) var(--ease-out-strong),
-    background-color var(--duration-base) var(--ease-out-strong),
-    color var(--duration-base) var(--ease-out-strong);
-  pointer-events: none;
-}
-
-.maka-list-row-menu-trigger:hover,
-.maka-list-row-menu-trigger:focus-visible,
-.maka-list-row-menu-trigger[aria-expanded="true"] {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-}
-
-.maka-list-row-menu-trigger:focus-visible {
-  outline: var(--focus-ring-width) solid var(--focus-ring);
-  outline-offset: var(--focus-ring-offset);
-}
-
-.maka-list-row:hover .maka-list-row-menu-trigger,
-.maka-list-row:focus-within .maka-list-row-menu-trigger,
-.maka-list-row-menu-trigger[data-visible="true"] {
-  opacity: 1;
-  transform: translateX(0);
-  pointer-events: auto;
-}
-
-.maka-list-row:hover .maka-list-row-meta,
-.maka-list-row:hover .maka-list-row-unread,
-.maka-list-row:focus-within .maka-list-row-meta,
-.maka-list-row:focus-within .maka-list-row-unread,
-.maka-list-row[data-menu-open="true"] .maka-list-row-meta,
-.maka-list-row[data-menu-open="true"] .maka-list-row-unread {
-  visibility: hidden;
-}
-
 .maka-list-row-rename-input {
   width: 100%;
+  min-width: 0;
   border: 0;
+  border-bottom: var(--border-width-hairline) solid oklch(from var(--focus-ring) l c h / 0.4);
   background: transparent;
   color: var(--foreground);
   font: inherit;
@@ -425,29 +257,10 @@
   font-weight: var(--font-weight-semibold);
   outline: 0;
   padding: 1px 0;
-  border-bottom: var(--border-width-hairline) solid oklch(from var(--focus-ring) l c h / 0.4);
 }
 
 .maka-list-row-rename-input:focus {
   border-bottom-color: var(--focus-ring);
-}
-
-.maka-list-row[data-editing="true"] {
-  border-color: oklch(from var(--focus-ring) l c h / 0.45);
-  background: var(--background);
-}
-
-.maka-list-row[data-editing="true"] .maka-list-row-main {
-  cursor: text;
-}
-
-.maka-list-row-main:focus-visible {
-  outline: 0;
-}
-
-.maka-list-row:has(.maka-list-row-main:focus-visible) {
-  border-color: oklch(from var(--focus-ring) l c h / 0.4);
-  box-shadow: 0 0 0 var(--focus-ring-width) oklch(from var(--focus-ring) l c h / 0.18);
 }
 
 
@@ -467,24 +280,6 @@
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-semibold);
-}
-
-/* List-row status family — merged back from onboarding.css — issue #546 PR3. */
-.maka-list-row-name {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1-5);
-  overflow: hidden;
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-medium);
-  min-width: 0;
-}
-
-.maka-list-row-name > span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
 }
 
 /* Small pulsing accent dot rendered when a session has live streaming
@@ -518,10 +313,6 @@
   }
 }
 
-.maka-list-row[data-streaming="true"] .maka-list-row-name > span {
-  color: var(--foreground);
-}
-
 /* PR-SIDEBAR-IA-0 Phase 3: meta (relative time) now sits inline at
  * the row's inline-end instead of stacked below the name. Color +
  * size kept muted so it reads as secondary info, not a competing
@@ -535,16 +326,6 @@
   font-weight: var(--font-weight-medium);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
-}
-
-/* PR-SIDEBAR-IA-0 Phase 3: `.maka-list-row-text` collapses to a single
- * row (name on the inline-start). The previous stack-of-three
- * layout (name / preview / meta) is gone — preview drops out of the
- * default DOM, meta moves inline to the row's right column. */
-.maka-list-row-text {
-  min-width: 0;
-  display: flex;
-  align-items: center;
 }
 
 /* PR-SIDEBAR-IA-0 Phase 3: `.maka-list-row-preview` is no longer
@@ -568,25 +349,6 @@
   border-radius: var(--radius-pill);
   background: var(--status-running);
   box-shadow: 0 0 0 3px oklch(from var(--status-running) l c h / 0.15);
-}
-
-/* Stale session — `backend='fake'` or `llmConnectionSlug` no longer
- * resolves. Pairs with the chat-header banner (PR108e) so users can spot
- * dead sessions in the sidebar list before clicking in. Visual treatment:
- *
- * - Row body dimmed via opacity reduction (preserves all underlying tones
- *   but reads as "secondary"); active state remains fully opaque so the
- *   currently-selected row never disappears just because it's stale.
- * - A small amber pill labelled "已过期" sits next to the session name —
- *   muted-warning tone, not destructive, because @xuan's send-path silent
- *   rebind makes these sessions still functional.
- */
-.maka-list-row[data-stale="true"] {
-  opacity: var(--opacity-muted);
-}
-
-.maka-list-row[data-stale="true"][data-active="true"] {
-  opacity: 1;
 }
 
 /* PR109b: SessionStatusIcon — small inline icon next to session name
@@ -651,32 +413,6 @@
   animation: none;
 }
 
-.maka-list-project-heading {
-  transition:
-    background-color var(--duration-base) var(--ease-out-strong),
-    color var(--duration-base) var(--ease-out-strong),
-    opacity var(--duration-base) var(--ease-out-strong);
-}
-.maka-list-project-heading:hover {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-}
-.maka-list-project-heading:active {
-  background: var(--state-selected-bg);
-}
-.maka-list-project-heading:focus-visible {
-  outline: var(--focus-ring-width) solid var(--focus-ring);
-  outline-offset: var(--focus-ring-offset);
-  border-radius: var(--radius-control);
-}
-.maka-list-project-heading:disabled {
-  cursor: not-allowed;
-  opacity: var(--opacity-disabled);
-}
-.maka-list-project-heading:disabled:hover {
-  background: transparent;
-  color: var(--muted-foreground);
-}
 .maka-list-row-stale-pill {
   flex-shrink: 0;
   /* PR-UI-3: drop margin-left, let parent's gap (6px) handle spacing
@@ -692,10 +428,6 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
   line-height: var(--leading-snug);
-}
-
-.maka-list-row:hover .maka-list-row-name {
-  color: var(--foreground);
 }
 
 /* ⌘N hint on the 新任务 row — quiet kbd chip pushed to the right rail,

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -64,20 +64,9 @@ html[data-os="darwin"] .maka-list-group-label {
   color: var(--color-text-quaternary);
 }
 
-/* Force opaque-foreground text on every direct sidebar text surface so
-   the glass material doesn't pull legibility down through inheritance
-   (audit finding §6). The wash + 50% base provide enough contrast for
-   foreground @ full alpha; nav rows / list rows / settings button all
-   inherit. */
-html[data-os="darwin"] .maka-session-list,
-  html[data-os="darwin"] .maka-list-row {
-    color: var(--foreground);
-  }
-
-/* `.maka-nav-row` is a semantic navigation control, so this darwin glass
-   override must outrank the sidebar default color — same maka.legacy layer,
-   higher specificity. */
-html[data-os="darwin"] .maka-nav-row {
+/* Product content inherits one foreground while Astryx owns the navigation
+   item chrome and its state colors. */
+html[data-os="darwin"] .maka-session-list {
   color: var(--foreground);
 }
 
@@ -105,8 +94,6 @@ html[data-os="darwin"] .maka-session-panel-footer {
 
 .maka-session-panel,
   .maka-session-panel-footer,
-  .maka-nav-row,
-  .maka-list-row,
   .maka-module-main-header,
   .maka-plan-heading,
   .maka-skill-tab,

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -1,11 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState, type ReactNode } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
 import type { ComponentProps } from 'react';
 import type { ProjectRecord, SessionSummary, StoredMessage } from '@maka/core';
 import { ChatView, Composer, SessionListPanel } from '@maka/ui';
 import type { ChatModelChoice, SessionViewMode } from '@maka/ui';
 import { AppShellTopbarActions, AppShellWorkspaceTopActions } from '../src/renderer/app-shell-chrome-actions';
 import { AppShell as AstryxAppShell } from '@astryxdesign/core/AppShell';
+import type { SideNavImperativeCollapseHandle } from '@astryxdesign/core/SideNav';
 
 const NOW = Date.UTC(2026, 6, 1, 9, 30, 0);
 
@@ -253,6 +254,7 @@ function ComposedShell(props: {
   motionEnabled?: boolean;
 }) {
   const [collapsed, setCollapsed] = useState(props.sidebarCollapsed ?? false);
+  const sidebarHandleRef = useRef<SideNavImperativeCollapseHandle>(null);
   const [viewMode, setViewMode] = useState<SessionViewMode>(props.initialViewMode ?? 'conversation');
   const sidebarWidth = 260;
   const sessions = sidebarSessions.map((s) =>
@@ -284,9 +286,8 @@ function ComposedShell(props: {
           <header className="maka-window-titlebar">
             <AppShellTopbarActions
               sidebarCollapsed={collapsed}
+              sidebarHandleRef={sidebarHandleRef}
               onOpenSearchModal={noop}
-              onCollapseSidebar={() => setCollapsed(true)}
-              onExpandSidebar={() => setCollapsed(false)}
               onCreateSession={noop}
             />
             <AppShellWorkspaceTopActions
@@ -302,6 +303,7 @@ function ComposedShell(props: {
         }
         sideNav={
           <SessionListPanel
+            collapseHandleRef={sidebarHandleRef}
             collapsed={collapsed}
             onCollapsedChange={setCollapsed}
             width={sidebarWidth}

--- a/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
+++ b/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
@@ -32,7 +32,7 @@ describe('sidebar subtraction', () => {
     assert.doesNotMatch(markup, /aria-expanded=/);
   });
 
-  it('keeps the visible scheduled-task label in its pending-reminder accessible name', () => {
+  it('keeps pending-reminder state in the collapsed SideNavItem accessible name', () => {
     const reminder: PlanReminder = {
       id: 'reminder-1',
       title: 'Review open work',
@@ -48,17 +48,21 @@ describe('sidebar subtraction', () => {
     };
     const markup = renderToStaticMarkup(
       <LocaleProvider locale="en">
-        <SessionSidebarNav
+        <SessionListPanel
+          collapsed
           selection={{ section: 'automations', module: 'plan-reminders' }}
           planReminders={[reminder]}
+          sessions={[]}
+          onSelectSession={() => {}}
           onSelect={() => {}}
+          onOpenSettings={() => {}}
           onNew={() => {}}
         />
       </LocaleProvider>,
     );
 
-    assert.match(markup, />Scheduled tasks<\/span>.*>1<\/small>/);
-    assert.doesNotMatch(markup, /aria-label="Automations,/);
+    assert.match(markup, /aria-label="Scheduled tasks, 1 unfinished reminder"/);
+    assert.doesNotMatch(markup, /maka-nav-count/);
   });
 
   it('renders each pair of peer modules as a localized segmented control', () => {

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -1,4 +1,12 @@
-import { memo, useEffect, useRef, useState, type FocusEvent, type KeyboardEvent } from 'react';
+import {
+  memo,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type KeyboardEvent,
+  type SetStateAction,
+} from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
 import type { ProjectRecord, SessionSummary, UiLocale } from '@maka/core';
 import { formatCompactTimestamp } from '@maka/core';
@@ -29,7 +37,6 @@ import {
   DropdownMenuItem,
 } from '@astryxdesign/core/DropdownMenu';
 import { Divider } from '@astryxdesign/core/Divider';
-import { Button as BaseButton } from '@base-ui/react/button';
 import { List, ListItem } from '@astryxdesign/core/List';
 import { TreeList, type TreeListItemData } from '@astryxdesign/core/TreeList';
 import { describeBlockedReason, presentSessionStatus } from './session-status-presentation.js';
@@ -111,54 +118,15 @@ export function SessionHistoryList(props: {
   // by status / time / filter.
 
   function handleListKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    // PR-SIDEBAR-IA-0 Phase 2 fixup (xuan `71687cc7`): the
-    // ArrowLeft/ArrowRight filter cycle was REMOVED. Hidden state
-    // without visible UI is harder for users to discover and harder
-    // for review to verify. If we re-introduce Pinned/Archived
-    // access in the future it will be a deliberate, visible,
-    // lightweight control (per kenji `9f683ea8`).
-    if (event.key === 'Delete' || event.key === 'Backspace') {
-      // Delete on a focused row opens the App-level confirmation (which
-      // toast.confirm()s); we do not delete silently per the lifecycle
-      // contract.
-      const active = document.activeElement as HTMLElement | null;
-      const row = active?.closest('.maka-list-row');
-      const sessionId = row?.querySelector<HTMLButtonElement>('.maka-list-row-main')?.dataset.sessionId;
-      if (sessionId && props.rowActions) {
-        event.preventDefault();
-        void props.rowActions.onDelete(sessionId);
-      }
-      return;
-    }
-    if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown' && event.key !== 'Home' && event.key !== 'End') {
-      return;
-    }
-    const list = event.currentTarget;
-    const focusables = Array.from(
-      list.querySelectorAll<HTMLButtonElement>('.maka-list-row-main'),
-    );
-    if (focusables.length === 0) return;
+    if (event.key !== 'Delete' && event.key !== 'Backspace') return;
     const active = document.activeElement as HTMLElement | null;
-    const currentIndex = active ? focusables.indexOf(active as HTMLButtonElement) : -1;
-    let nextIndex = currentIndex;
-    switch (event.key) {
-      case 'ArrowDown':
-        nextIndex = currentIndex < 0 ? 0 : Math.min(focusables.length - 1, currentIndex + 1);
-        break;
-      case 'ArrowUp':
-        nextIndex = currentIndex <= 0 ? 0 : currentIndex - 1;
-        break;
-      case 'Home':
-        nextIndex = 0;
-        break;
-      case 'End':
-        nextIndex = focusables.length - 1;
-        break;
+    if (!active || active.matches('input, textarea, [contenteditable="true"]')) return;
+    const row = active.closest<HTMLElement>('[role="treeitem"], .astryx-list-item, [data-session-id]');
+    const sessionId = row?.dataset.sessionId ?? row?.querySelector<HTMLElement>('[data-session-id]')?.dataset.sessionId;
+    if (sessionId && props.rowActions) {
+      event.preventDefault();
+      void props.rowActions.onDelete(sessionId);
     }
-    if (nextIndex === currentIndex) return;
-    event.preventDefault();
-    focusables[nextIndex]?.focus({ preventScroll: false });
-    focusables[nextIndex]?.scrollIntoView({ block: 'nearest' });
   }
 
   return (
@@ -228,41 +196,105 @@ function SessionListGroups(props: {
   projectActions?: ProjectRowActions;
 }) {
   const copy = getConversationCopy(useUiLocale()).sessions;
+  const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
+  const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
+
+  function commitSessionRename(session: SessionSummary, name: string) {
+    setEditingSessionId(null);
+    if (!props.rowActions || !name || name === session.name) return;
+    void Promise.resolve(props.rowActions.onRename(session.id, name)).catch(() => {
+      // AppShell owns visible session-action failure feedback.
+    });
+  }
+
+  function commitProjectRename(project: ProjectRecord, name: string) {
+    setEditingProjectId(null);
+    if (!props.projectActions || !name || name === project.name) return;
+    void Promise.resolve(props.projectActions.onRename(project.id, name)).catch(() => {
+      // AppShell owns visible project-action failure feedback.
+    });
+  }
+
   if (props.groupVariant === 'project') {
     const activeGroups = props.groups.filter((group) => group.project?.archivedAt === undefined);
     const archivedGroups = props.groups.filter((group) => group.project?.archivedAt !== undefined);
     function sessionItem(session: SessionSummary): TreeListItemData {
+      const isEditing = editingSessionId === session.id;
+      const nested = true;
       return {
         id: session.id,
         label: (
-          <SessionRow
+          <SessionItemLabel
+            session={session}
+            stale={props.staleSessionIds?.has(session.id) ?? false}
+            editing={isEditing}
+            onCommit={(name) => commitSessionRename(session, name)}
+            onCancel={() => setEditingSessionId(null)}
+          />
+        ),
+        startContent: (
+          <SessionItemStartContent
+            session={session}
+            nested={nested}
+            streaming={props.streamingSessionIds?.has(session.id) ?? false}
+            worktree={props.worktreeSessionIds?.has(session.id) ?? false}
+          />
+        ),
+        endContent: (
+          <SessionItemEndContent
             session={session}
             active={session.id === props.activeId}
             streaming={props.streamingSessionIds?.has(session.id) ?? false}
-            stale={props.staleSessionIds?.has(session.id) ?? false}
-            worktree={props.worktreeSessionIds?.has(session.id) ?? false}
-            nested
-            onSelect={props.onSelectSession}
+            editing={isEditing}
             actions={props.rowActions}
+            setEditingSessionId={setEditingSessionId}
           />
         ),
+        onClick: isEditing
+          ? undefined
+          : (event) => {
+              if (event.detail > 1 && props.rowActions) {
+                setEditingSessionId(session.id);
+                return;
+              }
+              props.onSelectSession(session.id);
+            },
         isSelected: session.id === props.activeId,
         children: (props.childSessionsByParentId?.get(session.id) ?? []).map(sessionItem),
       };
     }
-    const projectItem = (group: (typeof props.groups)[number]): TreeListItemData => ({
-      id: group.key,
-      label: (
-        <ProjectSessionGroup
-          {...props}
-          label={group.label}
-          sessions={group.sessions}
-          project={group.project}
-        />
-      ),
-      isExpanded: group.sessions.length > 0,
-      children: group.sessions.map(sessionItem),
-    });
+    const projectItem = (group: (typeof props.groups)[number]): TreeListItemData => {
+      const project = group.project;
+      const isEditing = Boolean(project && editingProjectId === project.id);
+      return {
+        id: group.key,
+        label: (
+          <ProjectItemLabel
+            label={group.label}
+            project={project}
+            editing={isEditing}
+            onCommit={(name) => {
+              if (project) commitProjectRename(project, name);
+            }}
+            onCancel={() => setEditingProjectId(null)}
+          />
+        ),
+        startContent: <FolderOpen size={14} aria-hidden="true" />,
+        endContent: (
+          <ProjectItemEndContent
+            project={project}
+            sessionCount={group.sessions.length}
+            editing={isEditing}
+            actions={props.projectActions}
+            onStartRename={() => {
+              if (project) setEditingProjectId(project.id);
+            }}
+          />
+        ),
+        isExpanded: group.sessions.length > 0,
+        children: group.sessions.map(sessionItem),
+      };
+    };
     const items = activeGroups.map(projectItem);
     if (archivedGroups.length > 0) {
       items.push({
@@ -279,31 +311,65 @@ function SessionListGroups(props: {
   return (
     <>
       {props.groups.map((group) => {
+        const sessions = group.sessions.flatMap((session) =>
+          flattenSessionBranch(session, props.childSessionsByParentId),
+        );
         return (
           <List
             key={group.key}
             className="maka-list-group"
             density="compact"
-            header={group.label ? <div className="maka-list-group-label"><span>{group.label}</span></div> : undefined}
+            header={group.label ? (
+              <div className="maka-list-group-label">
+                <span>{group.label}</span>
+              </div>
+            ) : undefined}
           >
-              {group.sessions.map((session) => (
+            {sessions.map(({ session, nested }) => {
+              const isEditing = editingSessionId === session.id;
+              return (
                 <ListItem
                   key={session.id}
+                  className="maka-session-list-item"
+                  data-subagent={nested ? 'true' : undefined}
                   isSelected={session.id === props.activeId}
-                  label={
-                    <SessionTreeRow
+                  onClick={isEditing ? undefined : (event) => {
+                    if (event.detail > 1 && props.rowActions) {
+                      setEditingSessionId(session.id);
+                      return;
+                    }
+                    props.onSelectSession(session.id);
+                  }}
+                  startContent={
+                    <SessionItemStartContent
                       session={session}
-                      activeId={props.activeId}
-                      streamingSessionIds={props.streamingSessionIds}
-                      staleSessionIds={props.staleSessionIds}
-                      childSessionsByParentId={props.childSessionsByParentId}
-                      worktreeSessionIds={props.worktreeSessionIds}
-                      onSelectSession={props.onSelectSession}
-                      rowActions={props.rowActions}
+                      nested={nested}
+                      streaming={props.streamingSessionIds?.has(session.id) ?? false}
+                      worktree={props.worktreeSessionIds?.has(session.id) ?? false}
+                    />
+                  }
+                  label={
+                    <SessionItemLabel
+                      session={session}
+                      stale={props.staleSessionIds?.has(session.id) ?? false}
+                      editing={isEditing}
+                      onCommit={(name) => commitSessionRename(session, name)}
+                      onCancel={() => setEditingSessionId(null)}
+                    />
+                  }
+                  endContent={
+                    <SessionItemEndContent
+                      session={session}
+                      active={session.id === props.activeId}
+                      streaming={props.streamingSessionIds?.has(session.id) ?? false}
+                      editing={isEditing}
+                      actions={props.rowActions}
+                      setEditingSessionId={setEditingSessionId}
                     />
                   }
                 />
-              ))}
+              );
+            })}
           </List>
         );
       })}
@@ -311,41 +377,88 @@ function SessionListGroups(props: {
   );
 }
 
-interface ProjectGroupSharedProps {
-  activeId?: string;
-  streamingSessionIds?: Set<string>;
-  staleSessionIds?: Set<string>;
-  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
-  worktreeSessionIds?: ReadonlySet<string>;
-  onSelectSession(sessionId: string): void;
-  rowActions?: SessionRowActions;
-  projectActions?: ProjectRowActions;
-}
-
-function ProjectSessionGroup(props: ProjectGroupSharedProps & {
+function ProjectItemLabel(props: {
   label: string;
-  sessions: SessionSummary[];
   project?: ProjectRecord;
+  editing: boolean;
+  onCommit(name: string): void;
+  onCancel(): void;
 }) {
   const copy = getConversationCopy(useUiLocale()).sessions;
-  const [editing, setEditing] = useState(false);
-  const [pendingAction, setPendingAction] = useState<string | null>(null);
-  const mountedRef = useMountedRef();
-  const pendingActionRef = useRef<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const escapeCancelledRef = useRef(false);
-  const project = props.project;
 
   useEffect(() => {
-    if (!editing) return;
+    if (!props.editing) return;
     inputRef.current?.focus();
     inputRef.current?.select();
-  }, [editing]);
+  }, [props.editing]);
 
-  useEffect(() => {
-    return () => {
-      pendingActionRef.current = null;
-    };
+  if (props.editing) {
+    return (
+      <input
+        ref={inputRef}
+        className="maka-list-project-rename"
+        defaultValue={props.label}
+        maxLength={80}
+        aria-label={copy.projectRename}
+        onBlur={(event) => {
+          if (escapeCancelledRef.current) {
+            escapeCancelledRef.current = false;
+            return;
+          }
+          props.onCommit(event.currentTarget.value.trim());
+        }}
+        onKeyDown={(event) => {
+          event.stopPropagation();
+          if (event.nativeEvent.isComposing || event.key === 'Process') return;
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            props.onCommit(event.currentTarget.value.trim());
+          } else if (event.key === 'Escape') {
+            event.preventDefault();
+            escapeCancelledRef.current = true;
+            props.onCancel();
+          }
+        }}
+        autoComplete="off"
+        spellCheck={false}
+      />
+    );
+  }
+
+  return (
+    <span
+      className="maka-list-project-heading"
+      data-variant="project"
+      data-unavailable={props.project && !props.project.available ? 'true' : undefined}
+    >
+      <span className="maka-list-project-name">{props.label}</span>
+      {props.project && !props.project.available && (
+        <AlertTriangle size={12} aria-label={copy.projectUnavailable} />
+      )}
+    </span>
+  );
+}
+
+function ProjectItemEndContent(props: {
+  project?: ProjectRecord;
+  sessionCount: number;
+  editing: boolean;
+  actions?: ProjectRowActions;
+  onStartRename(): void;
+}) {
+  const copy = getConversationCopy(useUiLocale()).sessions;
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const mountedRef = useMountedRef();
+  const pendingActionRef = useRef<string | null>(null);
+  const pendingMenuIntentRef = useRef<(() => void) | null>(null);
+  const project = props.project;
+  const actions = props.actions;
+
+  useEffect(() => () => {
+    pendingActionRef.current = null;
   }, []);
 
   function runProjectAction(actionId: string, action: () => void | Promise<void>) {
@@ -364,175 +477,83 @@ function ProjectSessionGroup(props: ProjectGroupSharedProps & {
     })();
   }
 
-  function commitRename(value: string) {
-    const name = value.trim();
-    setEditing(false);
-    if (!project || !props.projectActions || !name || name === project.name) return;
-    runProjectAction('rename', () => props.projectActions!.onRename(project.id, name));
-  }
-
   return (
-    <div
-      className="maka-list-group"
-      data-variant="project"
-      data-unavailable={project && !project.available ? 'true' : undefined}
-    >
-      <div className="maka-list-project-header">
-        {editing ? (
-          <form
-            className="maka-list-project-heading maka-list-project-rename"
-            onSubmit={(event) => {
-              event.preventDefault();
-              commitRename(inputRef.current?.value ?? '');
-            }}
-          >
-            <FolderOpen size={14} aria-hidden="true" />
-            <input
-              ref={inputRef}
-              defaultValue={props.label}
-              maxLength={80}
-              aria-label={copy.projectRename}
-              onBlur={(event) => {
-                if (escapeCancelledRef.current) {
-                  escapeCancelledRef.current = false;
-                  return;
-                }
-                commitRename(event.currentTarget.value);
-              }}
-              onKeyDown={(event) => {
-                if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
-                  event.stopPropagation();
-                }
-                if (event.nativeEvent.isComposing || event.key === 'Process') return;
-                if (event.key === 'Escape') {
-                  event.preventDefault();
-                  escapeCancelledRef.current = true;
-                  setEditing(false);
-                }
-              }}
+    <span className="maka-project-item-end">
+      <span className="maka-list-project-count">{props.sessionCount}</span>
+      {project && actions && !props.editing && (
+        <DropdownMenu
+          isMenuOpen={menuOpen}
+          onOpenChange={(open) => {
+            setMenuOpen(open);
+            if (open) return;
+            const intent = pendingMenuIntentRef.current;
+            pendingMenuIntentRef.current = null;
+            if (intent) window.requestAnimationFrame(intent);
+          }}
+          button={{
+            label: copy.projectActionsAriaLabel(project.name),
+            icon: pendingAction
+              ? <Loader2 size={14} aria-hidden="true" />
+              : <MoreHorizontal size={14} aria-hidden="true" />,
+            isIconOnly: true,
+            variant: 'ghost',
+            size: 'sm',
+            isDisabled: pendingAction !== null,
+          }}
+        >
+          {project.archivedAt !== undefined ? (
+            <DropdownMenuItem
+              onClick={() => runProjectAction('restore', () => actions.onRestore(project.id))}
+              icon={<ArchiveRestore size={15} aria-hidden="true" />}
+              label={copy.projectRestore}
             />
-          </form>
-        ) : (
-          <div className="maka-list-project-heading">
-            <FolderOpen size={14} aria-hidden="true" />
-            <span className="maka-list-project-name">{props.label}</span>
-            {project && !project.available && (
-              <AlertTriangle size={12} aria-label={copy.projectUnavailable} />
-            )}
-            <span className="maka-list-project-count">{props.sessions.length}</span>
-          </div>
-        )}
-        {project && props.projectActions && !editing && (
-          <DropdownMenu
-            button={{
-              label: copy.projectActionsAriaLabel(project.name),
-              icon: pendingAction ? (
-                <Loader2 size={14} aria-hidden="true" />
-              ) : (
-                <MoreHorizontal size={14} aria-hidden="true" />
-              ),
-              isIconOnly: true,
-              variant: 'ghost',
-              size: 'sm',
-              className: 'maka-list-project-menu-trigger',
-              isDisabled: pendingAction !== null,
-            }}
-          >
-              {project.archivedAt !== undefined ? (
+          ) : (
+            <>
+              {project.available ? (
                 <DropdownMenuItem
-                  onClick={() =>
-                    runProjectAction('restore', () => props.projectActions!.onRestore(project.id))
-                  }
-                  icon={<ArchiveRestore size={15} aria-hidden="true" />}
-                  label={copy.projectRestore}
+                  onClick={() => runProjectAction('new', () => actions.onNew(project.id))}
+                  icon={<Plus size={15} aria-hidden="true" />}
+                  label={copy.projectNewTask}
                 />
               ) : (
-                <>
-                  {project.available ? (
-                    <DropdownMenuItem
-                      onClick={() =>
-                        runProjectAction('new', () => props.projectActions!.onNew(project.id))
-                      }
-                      icon={<Plus size={15} aria-hidden="true" />}
-                      label={copy.projectNewTask}
-                    />
-                  ) : (
-                    <DropdownMenuItem
-                      onClick={() =>
-                        runProjectAction('relink', () =>
-                          props.projectActions!.onRelink(project.id))
-                      }
-                      icon={<FolderOpen size={15} aria-hidden="true" />}
-                      label={copy.projectRelink}
-                    />
-                  )}
-                  <Divider orientation="horizontal" />
-                  <DropdownMenuItem
-                    onClick={() => {
-                      if (!pendingActionRef.current) setEditing(true);
-                    }}
-                    icon={<Pencil size={15} aria-hidden="true" />}
-                    label={copy.projectRename}
-                  />
-                  <DropdownMenuItem
-                    onClick={() =>
-                      runProjectAction('archive', () =>
-                        props.projectActions!.onArchive(project.id))
-                    }
-                    icon={<Archive size={15} aria-hidden="true" />}
-                    label={copy.projectArchive}
-                  />
-                </>
+                <DropdownMenuItem
+                  onClick={() => runProjectAction('relink', () => actions.onRelink(project.id))}
+                  icon={<FolderOpen size={15} aria-hidden="true" />}
+                  label={copy.projectRelink}
+                />
               )}
-          </DropdownMenu>
-        )}
-      </div>
-    </div>
+              <Divider orientation="horizontal" />
+              <DropdownMenuItem
+                onClick={() => {
+                  pendingMenuIntentRef.current = props.onStartRename;
+                }}
+                icon={<Pencil size={15} aria-hidden="true" />}
+                label={copy.projectRename}
+              />
+              <DropdownMenuItem
+                onClick={() => runProjectAction('archive', () => actions.onArchive(project.id))}
+                icon={<Archive size={15} aria-hidden="true" />}
+                label={copy.projectArchive}
+              />
+            </>
+          )}
+        </DropdownMenu>
+      )}
+    </span>
   );
 }
 
-function SessionTreeRow(props: {
-  session: SessionSummary;
-  activeId?: string;
-  streamingSessionIds?: Set<string>;
-  staleSessionIds?: Set<string>;
-  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
-  worktreeSessionIds?: ReadonlySet<string>;
-  onSelectSession(sessionId: string): void;
-  rowActions?: SessionRowActions;
-  depth?: number;
-}) {
-  const depth = props.depth ?? 0;
-  const children = props.childSessionsByParentId?.get(props.session.id) ?? [];
-  return (
-    <div
-      className="maka-list-session-tree"
-      data-depth={depth > 0 ? String(depth) : undefined}
-    >
-      <SessionRow
-        session={props.session}
-        active={props.session.id === props.activeId}
-        streaming={props.streamingSessionIds?.has(props.session.id) ?? false}
-        stale={props.staleSessionIds?.has(props.session.id) ?? false}
-        worktree={props.worktreeSessionIds?.has(props.session.id) ?? false}
-        nested={depth > 0}
-        onSelect={props.onSelectSession}
-        actions={props.rowActions}
-      />
-      {children.length > 0 && (
-        <div className="maka-list-session-children">
-          {children.map((child) => (
-            <SessionTreeRow
-              key={child.id}
-              {...props}
-              session={child}
-              depth={depth + 1}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  );
+function flattenSessionBranch(
+  session: SessionSummary,
+  childrenByParentId?: ReadonlyMap<string, readonly SessionSummary[]>,
+  nested = false,
+): Array<{ session: SessionSummary; nested: boolean }> {
+  return [
+    { session, nested },
+    ...(childrenByParentId?.get(session.id) ?? []).flatMap((child) =>
+      flattenSessionBranch(child, childrenByParentId, true),
+    ),
+  ];
 }
 
 /**
@@ -608,64 +629,127 @@ const STATUS_ICON_BY_STATUS = {
   aborted: Ban,
 } as const;
 
-const SessionRow = memo(function SessionRow(props: {
+function SessionItemLabel(props: {
+  session: SessionSummary;
+  stale: boolean;
+  editing: boolean;
+  onCommit(name: string): void;
+  onCancel(): void;
+}) {
+  const copy = getConversationCopy(useUiLocale()).sessions;
+  const inputRef = useRef<HTMLInputElement>(null);
+  const escapeCancelledRef = useRef(false);
+
+  useEffect(() => {
+    if (!props.editing) return;
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [props.editing]);
+
+  if (props.editing) {
+    return (
+      <input
+        ref={inputRef}
+        className="maka-list-row-rename-input"
+        defaultValue={props.session.name}
+        maxLength={80}
+        aria-label={copy.renameAriaLabel}
+        onBlur={(event) => {
+          if (escapeCancelledRef.current) {
+            escapeCancelledRef.current = false;
+            return;
+          }
+          props.onCommit(event.currentTarget.value.trim());
+        }}
+        onKeyDown={(event) => {
+          event.stopPropagation();
+          if (event.nativeEvent.isComposing || event.key === 'Process') return;
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            props.onCommit(event.currentTarget.value.trim());
+          } else if (event.key === 'Escape') {
+            event.preventDefault();
+            escapeCancelledRef.current = true;
+            props.onCancel();
+          }
+        }}
+        autoComplete="off"
+        spellCheck={false}
+      />
+    );
+  }
+
+  return (
+    <span
+      className="maka-session-item-label"
+      data-session-id={props.session.id}
+      data-stale={props.stale ? 'true' : undefined}
+      title={props.session.name}
+    >
+      <span>{props.session.name}</span>
+      {props.stale && (
+        <span
+          className="maka-list-row-stale-pill"
+          title={copy.staleTitle}
+          aria-label={copy.staleAriaLabel}
+        >
+          {copy.stale}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function SessionItemStartContent(props: {
+  session: SessionSummary;
+  nested: boolean;
+  streaming: boolean;
+  worktree: boolean;
+}) {
+  const copy = getConversationCopy(useUiLocale()).sessions;
+  return (
+    <span className="maka-session-item-start">
+      {props.nested && <Bot size={12} aria-hidden="true" className="maka-list-row-subagent-icon" />}
+      {props.worktree && (
+        <FolderGit2
+          size={12}
+          aria-label={copy.worktreeAriaLabel}
+          className="maka-list-row-worktree-icon"
+        />
+      )}
+      {props.streaming && (
+        <span
+          className="maka-list-row-streaming-dot"
+          aria-label={copy.respondingAriaLabel}
+          title={copy.respondingTitle}
+        />
+      )}
+      <SessionStatusIcon session={props.session} />
+    </span>
+  );
+}
+
+const SessionItemEndContent = memo(function SessionItemEndContent(props: {
   session: SessionSummary;
   active: boolean;
-  /** This session has a live streaming delta in flight. */
-  streaming?: boolean;
-  /**
-   * This session's backend / connection is stale (FakeBackend or a removed
-   * connection slug). Dims the row + renders a small "已过期" pill so the
-   * user can spot broken sessions in the list before clicking in.
-   */
-  stale?: boolean;
-  /** This session runs from a linked Git worktree. */
-  worktree?: boolean;
-  /** Render this linked child as an indented nested Session row. */
-  nested?: boolean;
-  onSelect(sessionId: string): void;
+  streaming: boolean;
+  editing: boolean;
   actions?: SessionRowActions;
+  setEditingSessionId: Dispatch<SetStateAction<string | null>>;
 }) {
-  const { session, active, streaming, stale, worktree, nested, actions, onSelect } = props;
   const locale = useUiLocale();
   const copy = getConversationCopy(locale).sessions;
-  const [editing, setEditing] = useState(false);
-  const [actionsVisible, setActionsVisible] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<SessionRowActionId | null>(null);
-  const rowMountedRef = useMountedRef();
+  const mountedRef = useMountedRef();
   const pendingActionRef = useRef<SessionRowActionId | null>(null);
   const pendingMenuIntentRef = useRef<(() => void) | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  // PR-FE-BUG-HUNT-11: Escape on the rename input has to suppress the
-  // blur-fires-on-unmount commit. Without this ref, the sequence
-  //   type → Escape → setEditing(false) → input unmounts → blur fires
-  //   with the typed value → commitRename(typed) → rename happens
-  // would silently commit the user's typed value despite the cancel.
-  const escapeCancelledRef = useRef(false);
-  const actionBusy = pendingAction !== null;
-  const actionTriggerVisible = actionsVisible || menuOpen;
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
+  const actions = props.actions;
 
-  useEffect(() => {
-    return () => {
-      pendingActionRef.current = null;
-    };
+  useEffect(() => () => {
+    pendingActionRef.current = null;
   }, []);
-
-  // Auto-focus + select-all when the row enters edit mode so the user can
-  // overwrite the current name without an extra Cmd+A.
-  useEffect(() => {
-    if (!editing) return;
-    const input = inputRef.current;
-    if (!input) return;
-    input.focus();
-    input.select();
-  }, [editing]);
-
-  function startRename() {
-    if (!actions || pendingActionRef.current) return;
-    setEditing(true);
-  }
 
   function runRowAction(actionId: SessionRowActionId, action: () => void | Promise<void>) {
     if (pendingActionRef.current) return;
@@ -675,266 +759,89 @@ const SessionRow = memo(function SessionRow(props: {
       try {
         await action();
       } catch {
-        // The AppShell row-action owner reports the visible failure toast.
+        // AppShell owns visible session-action failure feedback.
       } finally {
         pendingActionRef.current = null;
-        if (rowMountedRef.current) setPendingAction(null);
+        if (mountedRef.current) setPendingAction(null);
       }
     })();
   }
 
-  function commitRename(rawValue: string) {
-    const trimmed = rawValue.trim();
-    setEditing(false);
-    if (!trimmed || trimmed === session.name) return;
-    if (!actions) return;
-    runRowAction('rename', () => actions.onRename(session.id, trimmed));
-  }
-
-  function handleDelete() {
-    if (!actions) return;
-    // Delegation: the App-level handler owns the confirmation flow via the
-    // toast system (PR24), so SessionRow stays presentation-only.
-    runRowAction('delete', () => actions.onDelete(session.id));
-  }
-
-  function handleMenuOpenChange(open: boolean) {
-    setMenuOpen(open);
-    if (open) return;
-    const intent = pendingMenuIntentRef.current;
-    pendingMenuIntentRef.current = null;
-    if (intent) {
-      window.requestAnimationFrame(() => {
-        if (rowMountedRef.current) intent();
-      });
-    }
-  }
-
-  function handleRowBlur(event: FocusEvent<HTMLDivElement>) {
-    if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
-    setActionsVisible(false);
-  }
-
   return (
-    <div
-      className="maka-list-row"
-      data-maka-contract="list-row"
-      data-active={active}
-      data-editing={editing}
-      data-menu-open={menuOpen ? 'true' : undefined}
-      data-streaming={streaming ? 'true' : undefined}
-      data-stale={stale ? 'true' : undefined}
-      data-subagent={nested ? 'true' : undefined}
-      onMouseEnter={() => setActionsVisible(true)}
-      onMouseLeave={(event) => {
-        if (event.currentTarget.contains(document.activeElement)) return;
-        setActionsVisible(false);
-      }}
-      onFocus={() => setActionsVisible(true)}
-      onBlur={handleRowBlur}
-    >
-      {editing ? (
-        <form
-          className="maka-list-row-main"
-          onSubmit={(event) => {
-            event.preventDefault();
-            commitRename(inputRef.current?.value ?? '');
-          }}
-        >
-          <div>
-            <input
-              ref={inputRef}
-              className="maka-list-row-rename-input"
-              defaultValue={session.name}
-              maxLength={80}
-              aria-label={copy.renameAriaLabel}
-              onBlur={(event) => {
-                // PR-FE-BUG-HUNT-11: skip the commit when the blur was
-                // caused by Escape cancelling edit mode (input unmounts
-                // → blur fires with the typed value otherwise).
-                if (escapeCancelledRef.current) {
-                  escapeCancelledRef.current = false;
-                  return;
-                }
-                commitRename(event.currentTarget.value);
-              }}
-              onKeyDown={(event) => {
-                if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
-                  event.stopPropagation();
-                }
-                // IME guard so committing CJK characters with Enter doesn't
-                // submit the rename before the user is done.
-                if (event.nativeEvent.isComposing || event.key === 'Process') return;
-                if (event.key === 'Escape') {
-                  event.preventDefault();
-                  escapeCancelledRef.current = true;
-                  setEditing(false);
-                }
-              }}
-              autoComplete="off"
-              spellCheck={false}
-            />
-            <div className="maka-list-row-meta" data-maka-contract="list-row-meta">{formatSessionMeta(session, locale)}</div>
-          </div>
-        </form>
+    <span className="maka-session-item-end">
+      {shouldShowSessionUnreadDot(props.session, props.streaming, props.active) ? (
+        <span className="maka-list-row-unread" aria-label={copy.unreadAriaLabel} />
       ) : (
-        // PR-SIDEBAR-IA-0 Phase 3 (WAWQAQ `14ed98b5` "list 很丑、很肥很
-        // 臃肿"; xuan `6b28984e` Phase 2 sign-off + Phase 3 32-40px
-        // target; xuan `2d4526b5` tightening: NO native title= snippet,
-        // title is ONLY for name truncation): slim row.
-        //
-        // The button is the row's hit target. The native `title=`
-        // attribute carries ONLY the session name so it serves as a
-        // truncation tooltip when the name overflows the row. The
-        // `lastMessagePreview` snippet is intentionally NOT exposed
-        // here — per xuan `2d4526b5`, snippet visibility is a
-        // separate, deliberate design (future PR), not a Phase 3
-        // afterthought via native tooltip.
-        //
-        // `data-active` on the row controls the active-state accent
-        // rail + bg tint via CSS; the row's `name` cluster also
-        // recolors to accent on selected so the row reads as
-        // "current" without a heavy full-bg pill.
-        /* PR-SESSION-ROW-MAIN-PRIMITIVE-0 (round 14/30): the
-           single most-clicked button in the app — every session
-           row's main click target. This composite navigation row keeps its
-           grid layout and multi-line density in the semantic row seam rather
-           than masquerading as a shared Button size. */
-        <BaseButton
-          className="maka-list-row-main"
-          type="button"
-          data-session-id={session.id}
-          aria-current={active ? 'true' : undefined}
-          title={session.name}
-          onClick={() => onSelect(session.id)}
-          onDoubleClick={(event) => {
-            event.stopPropagation();
-            if (actions && !pendingActionRef.current) setEditing(true);
-          }}
-        >
-          {/*
-            PR-SIDEBAR-IA-0 Phase 3 layout (xuan `2d4526b5`):
-              [.maka-list-row-text  (col 1: minmax(0,1fr))] [meta/unread  (col 2: auto)]
-            The text container holds the name cluster (status icons +
-            name + stale pill) and truncates via min-width: 0. The
-            meta column sits at the inline-end with a clear gap so
-            "会话 02" doesn't run into "0m ago".
-          */}
-          <div className="maka-list-row-text">
-            <div className="maka-list-row-name">
-              {nested && (
-                <Bot
-                  size={12}
-                  aria-hidden="true"
-                  className="maka-list-row-subagent-icon"
-                />
-              )}
-              {worktree && (
-                <FolderGit2
-                  size={12}
-                  aria-label={copy.worktreeAriaLabel}
-                  className="maka-list-row-worktree-icon"
-                />
-              )}
-              {streaming && (
-                <span
-                  className="maka-list-row-streaming-dot"
-                  aria-label={copy.respondingAriaLabel}
-                  title={copy.respondingTitle}
-                />
-              )}
-              <SessionStatusIcon session={session} />
-              <span>{session.name}</span>
-              {stale && (
-                <span
-                  className="maka-list-row-stale-pill"
-                  // The pill semantics match the chat-header banner: the
-                  // session uses a backend / connection that no longer exists,
-                  // but @xuan's send-path silent rebind will swap to the
-                  // default on send. Tooltip explains why.
-                  title={copy.staleTitle}
-                  aria-label={copy.staleAriaLabel}
-                >
-                  {copy.stale}
-                </span>
-              )}
-            </div>
-          </div>
-          {/*
-            PR-SIDEBAR-IA-0 Phase 3 (xuan `2d4526b5`): snippet preview
-            (`.maka-list-row-preview`) is no longer rendered in the
-            default DOM AND is no longer exposed via native `title=`
-            tooltip. Snippet visibility is deliberately deferred to a
-            future PR with its own hover/focus detail design.
-            `formatSessionMeta` shows the relative time inline in the
-            row's `auto` grid column (sibling of `.maka-list-row-text`,
-            not nested inside it — required for proper gap + alignment).
-            The unread dot replaces the time only when no higher-priority
-            row state is active. Borrowed from PawWork's sidebar priority:
-            asking/busy/error outrank unread; unread outranks plain time.
-          */}
-          {shouldShowSessionUnreadDot(session, Boolean(streaming), active) ? (
-            <span className="maka-list-row-unread" aria-label={copy.unreadAriaLabel} />
-          ) : (
-            <span className="maka-list-row-meta" data-maka-contract="list-row-meta">{formatSessionMeta(session, locale)}</span>
-          )}
-        </BaseButton>
+        <span className="maka-list-row-meta" data-maka-contract="list-row-meta">
+          {formatSessionMeta(props.session, locale)}
+        </span>
       )}
-      {actions && !editing && (
+      {actions && !props.editing && (
         <DropdownMenu
           isMenuOpen={menuOpen}
-          onOpenChange={handleMenuOpenChange}
+          onOpenChange={(open) => {
+            setMenuOpen(open);
+            if (open) return;
+            const intent = pendingMenuIntentRef.current;
+            pendingMenuIntentRef.current = null;
+            if (intent) {
+              window.requestAnimationFrame(() => {
+                menuTriggerRef.current?.focus();
+                intent();
+              });
+            }
+          }}
           button={{
             label: copy.actionsAriaLabel,
+            ref: menuTriggerRef,
             icon: <MoreHorizontal size={16} aria-hidden="true" />,
             isIconOnly: true,
             variant: 'ghost',
             size: 'sm',
             className: 'maka-list-row-menu-trigger',
-            'aria-hidden': actionTriggerVisible ? undefined : 'true',
-            'data-visible': actionTriggerVisible ? 'true' : undefined,
-            tabIndex: actionTriggerVisible ? 0 : -1,
           }}
         >
-            <DropdownMenuItem
-              isDisabled={actionBusy}
-              onClick={() => runRowAction('flag', () => actions.onToggleFlag(session.id, !session.isFlagged))}
-              icon={session.isFlagged
-                ? <PinOff size={16} aria-hidden="true" />
-                : <Pin size={16} aria-hidden="true" />}
-              label={session.isFlagged ? copy.unpin : copy.pin}
-            />
-            <DropdownMenuItem
-              isDisabled={actionBusy}
-              onClick={startRename}
-              icon={<Pencil size={16} aria-hidden="true" />}
-              label={copy.rename}
-            />
-            <DropdownMenuItem
-              isDisabled={actionBusy}
-              onClick={() => runRowAction('archive', () => (
-                session.isArchived
-                  ? actions.onUnarchive(session.id)
-                  : actions.onArchive(session.id)
-              ))}
-              icon={session.isArchived
-                ? <ArchiveRestore size={16} aria-hidden="true" />
-                : <Archive size={16} aria-hidden="true" />}
-              label={session.isArchived ? copy.unarchive : copy.archive}
-            />
-            <Divider orientation="horizontal" />
-            <DropdownMenuItem
-              isDisabled={actionBusy}
-              onClick={() => {
-                pendingMenuIntentRef.current = handleDelete;
-              }}
-              icon={<Trash2 size={16} aria-hidden="true" />}
-              label={copy.delete}
-              style={{ color: 'var(--destructive-text)' }}
-            />
+          <DropdownMenuItem
+            isDisabled={pendingAction !== null}
+            onClick={() => runRowAction('flag', () => actions.onToggleFlag(props.session.id, !props.session.isFlagged))}
+            icon={props.session.isFlagged
+              ? <PinOff size={16} aria-hidden="true" />
+              : <Pin size={16} aria-hidden="true" />}
+            label={props.session.isFlagged ? copy.unpin : copy.pin}
+          />
+          <DropdownMenuItem
+            isDisabled={pendingAction !== null}
+            onClick={() => {
+              pendingMenuIntentRef.current = () => props.setEditingSessionId(props.session.id);
+            }}
+            icon={<Pencil size={16} aria-hidden="true" />}
+            label={copy.rename}
+          />
+          <DropdownMenuItem
+            isDisabled={pendingAction !== null}
+            onClick={() => runRowAction('archive', () => (
+              props.session.isArchived
+                ? actions.onUnarchive(props.session.id)
+                : actions.onArchive(props.session.id)
+            ))}
+            icon={props.session.isArchived
+              ? <ArchiveRestore size={16} aria-hidden="true" />
+              : <Archive size={16} aria-hidden="true" />}
+            label={props.session.isArchived ? copy.unarchive : copy.archive}
+          />
+          <Divider orientation="horizontal" />
+          <DropdownMenuItem
+            isDisabled={pendingAction !== null}
+            onClick={() => {
+              pendingMenuIntentRef.current = () => runRowAction('delete', () => actions.onDelete(props.session.id));
+            }}
+            icon={<Trash2 size={16} aria-hidden="true" />}
+            label={copy.delete}
+            style={{ color: 'var(--destructive-text)' }}
+          />
         </DropdownMenu>
       )}
-    </div>
+    </span>
   );
 });
 

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -15,13 +15,18 @@ import { SessionSidebarFooter, SessionSidebarNav, type SidebarUpdateReminder } f
 import { ListTodo } from './icons.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
-import { SideNav } from '@astryxdesign/core/SideNav';
+import {
+  SideNav,
+  type SideNavImperativeCollapseHandle,
+} from '@astryxdesign/core/SideNav';
+import type { Ref } from 'react';
 
 export type SessionViewMode = 'conversation' | 'project';
 
 export function SessionListPanel(props: {
   collapsed?: boolean;
   onCollapsedChange?(collapsed: boolean): void;
+  collapseHandleRef?: Ref<SideNavImperativeCollapseHandle>;
   width?: number;
   onWidthChange?(width: number): void;
   minWidth?: number;
@@ -62,6 +67,7 @@ export function SessionListPanel(props: {
 
   return (
     <SideNav
+      handleRef={props.collapseHandleRef}
       className="maka-session-panel agents-sidebar"
       aria-label={copy.listAriaLabel}
       collapsible={{

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -26,7 +26,6 @@ export function SessionSidebarNav(props: {
   return (
     <nav className="maka-sidebar-modules" aria-label={copy.mainLabel}>
       <SideNavItem
-        className="maka-nav-row maka-nav-new-task"
         label={copy.newTask}
         icon={SquarePen}
         size="md"
@@ -34,7 +33,6 @@ export function SessionSidebarNav(props: {
         endContent={<kbd className="maka-nav-kbd" aria-hidden="true">⌘ N</kbd>}
       />
       <SideNavItem
-        className="maka-nav-row"
         label={copy.extensions}
         icon={Blocks}
         size="md"
@@ -42,13 +40,13 @@ export function SessionSidebarNav(props: {
         onClick={() => props.onSelect({ section: 'extensions', module: moduleMemory.extensions })}
       />
       <SideNavItem
-        className="maka-nav-row"
-        label={copy.automations}
+        label={activePlanReminderCount > 0
+          ? copy.pendingReminders(activePlanReminderCount)
+          : copy.automations}
         icon={Timer}
         size="md"
         isSelected={automationsActive}
         onClick={() => props.onSelect({ section: 'automations', module: moduleMemory.automations })}
-        endContent={activePlanReminderCount > 0 ? <small className="maka-nav-count">{activePlanReminderCount}</small> : undefined}
       />
     </nav>
   );
@@ -83,7 +81,6 @@ export function SessionSidebarFooter(props: {
   return (
     <footer className="maka-session-panel-footer">
       <SideNavItem
-        className="maka-sidebar-settings-button"
         label={copy.settings}
         icon={Settings}
         size="md"

--- a/packages/ui/stories/interaction-states.stories.tsx
+++ b/packages/ui/stories/interaction-states.stories.tsx
@@ -106,9 +106,9 @@ export const ListRowStates: Story = {
     </StoryFrame>
   ),
   play: async ({ canvasElement }) => {
-    const hoverTarget = canvasElement.querySelector<HTMLButtonElement>('.maka-nav-row:not([data-active="true"])');
+    const hoverTarget = canvasElement.querySelector<HTMLButtonElement>('.astryx-side-nav-item');
     hoverTarget?.setAttribute('data-state-target', 'hover');
-    const focusTarget = canvasElement.querySelector<HTMLButtonElement>('.maka-list-row[data-active="true"] .maka-list-row-main');
+    const focusTarget = canvasElement.querySelector<HTMLButtonElement>('.astryx-list-item[aria-current="true"] > button');
     focusTarget?.setAttribute('data-state-target', 'focus');
     const tabStops = Array.from(canvasElement.querySelectorAll<HTMLButtonElement>('button:not([disabled])'));
     const focusIndex = focusTarget ? tabStops.indexOf(focusTarget) : -1;

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -98,8 +98,8 @@ function StoryFrame(props: {
     if (!focusActiveRow && !openActiveRowMenu) return;
     let menuTimeout: number | undefined;
     const focusTimeout = window.setTimeout(() => {
-      const activeRow = ref.current?.querySelector<HTMLElement>('.maka-list-row[data-active="true"]');
-      activeRow?.querySelector<HTMLButtonElement>('.maka-list-row-main')?.focus({ preventScroll: true });
+      const activeRow = ref.current?.querySelector<HTMLElement>('.astryx-list-item[aria-current="true"]');
+      activeRow?.querySelector<HTMLButtonElement>(':scope > button')?.focus({ preventScroll: true });
       if (openActiveRowMenu) {
         menuTimeout = window.setTimeout(() => {
           activeRow?.querySelector<HTMLButtonElement>('[aria-label="对话操作"]')?.click();


### PR DESCRIPTION
## Summary

- restore a zero-width SideNav through the official `SideNavCollapseButton` imperative handle instead of persisting collapsed geometry
- delegate session and project row geometry, selection, activation, and tree keyboard focus to Astryx `ListItem` and `TreeList` public slots
- keep rename, menu intent, session metadata, and product actions in Maka while removing the superseded custom row/hover/focus CSS
- align titlebar actions to the official collapse control geometry and preserve collapsed reminder context in the Astryx item label

## Verification

- `npm --workspace @maka/ui test` (296 passed)
- `npm --workspace @maka/desktop test` (1852 passed)
- `npx tsc -p apps/desktop/tsconfig.renderer.json --noEmit`
- `npx tsc -p apps/desktop/tsconfig.storybook.json --noEmit`
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run build:renderer`
- `npx playwright test --config e2e/playwright.config.ts e2e/session-management.spec.ts e2e/sidebar-geometry.spec.ts e2e/sidebar-navigation.spec.ts` (12 passed)

## Review focus

The change intentionally does not touch shared Tabs, Item, Empty, Spinner, or package index authority. An independent read-only review against Astryx 0.1.9 source and stories reported no remaining findings.