### PR TITLE
fix(e2e): align Astryx-migrated selectors in four specs

### DIFF
--- a/apps/desktop/e2e/disclosure-output.spec.ts
+++ b/apps/desktop/e2e/disclosure-output.spec.ts
@@ -3,21 +3,19 @@ import { expect, test } from './fixtures.js';
 test('a collapsed live tool mounts output on demand and follows its tail', async ({
   disclosureOutputWindow: page,
 }) => {
-  const processing = page.locator('[data-processing="block"]');
-  const processingTrigger = processing.locator(':scope > button');
+  // #1728: live tools render through Astryx ChatToolCalls. A single running
+  // tool is one CallRow (role="button") with its detail collapsed — the
+  // same on-demand output contract the old processing-block wrapper enforced.
+  const calls = page.locator('.astryx-chat-tool-calls');
+  const collapsedRow = calls.locator('[role="button"][aria-expanded="false"]');
 
-  await expect(processingTrigger).toHaveAttribute('aria-expanded', 'false');
-  await expect(processing.locator('[data-trow="row"]')).toHaveCount(0);
+  await expect(collapsedRow).toHaveCount(1);
+  await expect(calls.locator('[data-slot="tool-output"]')).toHaveCount(0);
 
-  await processingTrigger.click();
-  const row = processing.locator('[data-trow="row"]');
-  const rowTrigger = row.locator(':scope > button');
-  await expect(rowTrigger).toHaveAttribute('aria-expanded', 'false');
-  await expect(row.locator('[data-slot="tool-output"]')).toHaveCount(0);
-
-  await rowTrigger.click();
-  await expect(rowTrigger).toHaveAttribute('aria-expanded', 'true');
-  const output = row.locator('pre[data-live="true"]');
+  await collapsedRow.click();
+  const expandedRow = calls.locator('[role="button"][aria-expanded="true"]');
+  await expect(expandedRow).toHaveCount(1);
+  const output = calls.locator('pre[data-live="true"]');
   await expect(output).toContainText('diagnostic line 160');
   await expect
     .poll(() => output.evaluate((element) => (
@@ -25,7 +23,7 @@ test('a collapsed live tool mounts output on demand and follows its tail', async
     )))
     .toBeLessThanOrEqual(1);
 
-  await rowTrigger.press(' ');
-  await expect(rowTrigger).toHaveAttribute('aria-expanded', 'false');
-  await expect(row.locator('[data-slot="tool-output"]')).toHaveCount(0);
+  await expandedRow.press(' ');
+  await expect(calls.locator('[role="button"][aria-expanded="false"]')).toHaveCount(1);
+  await expect(calls.locator('[data-slot="tool-output"]')).toHaveCount(0);
 });

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -309,7 +309,7 @@ export const test = base.extend<{
     await withE2eWindow(
       {
         seed: false,
-        readinessSelector: '[data-processing="block"] > button[aria-expanded="false"]',
+        readinessSelector: '.astryx-chat-tool-calls [role="button"][aria-expanded="false"]',
         e2eFixtureScenario: 'disclosure-output',
         locale: 'zh',
       },

--- a/apps/desktop/e2e/permission-mode-surface.spec.ts
+++ b/apps/desktop/e2e/permission-mode-surface.spec.ts
@@ -11,7 +11,7 @@ const READ_ONLY_HINT = '只读取和搜索，不写入文件、不访问网络�
 test('a read-only session names its boundary and can still be raised to full access', async ({
   readOnlyBoundaryWindow: page,
 }) => {
-  const trigger = page.locator('.maka-composer-left-controls').getByRole('combobox');
+  const trigger = page.locator('.maka-composer-header-context').getByRole('combobox');
   await expect(trigger).toHaveText('只读');
   await expect(trigger).toHaveAccessibleName('权限模式：只读');
   await expect(trigger).toHaveAccessibleDescription(READ_ONLY_HINT);
@@ -65,7 +65,7 @@ test('approving an expansion updates the permission label at once and after a re
   sandboxBoundaryWindow: page,
 }) => {
   const prompt = page.locator('.maka-sandbox-boundary-prompt');
-  const trigger = page.locator('.maka-composer-left-controls').getByRole('combobox');
+  const trigger = page.locator('.maka-composer-header-context').getByRole('combobox');
 
   // The session runs read-only and is asking to write outside the workspace.
   await expect(prompt).toHaveCount(1);

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -48,7 +48,7 @@ async function probeColumnGeometry(page: import('@playwright/test').Page): Promi
     const host = document.querySelector<HTMLElement>('.maka-chat.messages');
     const viewport = document.querySelector<HTMLElement>('.maka-chatViewport');
     const turn = document.querySelector<HTMLElement>('.maka-turn');
-    const composer = document.querySelector<HTMLElement>('.composer .maka-composer-inner');
+    const composer = document.querySelector<HTMLElement>('.composer .maka-composer-astryx');
     if (!host || !viewport || !turn || !composer) {
       throw new Error('Expected the active chat host, viewport, turn, and composer to be mounted');
     }
@@ -95,9 +95,12 @@ async function settleGeometry(page: import('@playwright/test').Page, options: { 
   const settled = await page.evaluate(probeScroller) as { scrollHeight: number };
   expect(settled.scrollHeight, JSON.stringify(settled)).toBeGreaterThan(WARMED_HEIGHT_FLOOR);
   // The last chunk's inflation reaches the pinned follower through a
-  // ResizeObserver, one layout after the walk hands back.
+  // ResizeObserver, one layout after the walk hands back. A fully pinned
+  // scroller can read distance 1 rather than 0: Chromium keeps sub-pixel
+  // scrollTop values (observed 30106.5), so the rounded distance lands on 1
+  // even though the content is flush. The contract is "flush", so accept both.
   if (options.pinned) {
-    await expect.poll(async () => (await page.evaluate(probeScroller)).distanceFromBottom).toBe(0);
+    await expect.poll(async () => (await page.evaluate(probeScroller)).distanceFromBottom).toBeLessThanOrEqual(1);
   }
 }
 
@@ -140,7 +143,7 @@ test('empty chat keeps its grid content flush with the viewport', async ({ windo
   }
 });
 
-test('chat turns keep twelve pixels of vertical separation', async ({ longTranscriptWindow: page }) => {
+test('chat turns keep sixteen pixels of vertical separation', async ({ longTranscriptWindow: page }) => {
   await expect(page.locator('.maka-turn')).toHaveCount(24);
 
   const gap = await page.evaluate(() => {
@@ -150,7 +153,9 @@ test('chat turns keep twelve pixels of vertical separation', async ({ longTransc
     if (!first || !second) throw new Error('Expected two chat turns');
     return second.top - first.bottom;
   });
-  expect(gap).toBe(12);
+  // #1728 moved the transcript onto Astryx ChatMessageList (`density="compact"`
+  // `gap={4}`), which spaces turns at 16px instead of the pre-Astryx 12px.
+  expect(gap).toBe(16);
 });
 
 test('long session opens pinned to bottom and stays pinned while geometry settles', async ({ longTranscriptWindow: page }) => {
@@ -159,10 +164,11 @@ test('long session opens pinned to bottom and stays pinned while geometry settle
   // Pinned from the start: the session-open pin must hold. During the idle
   // warm-up the document grows by thousands of pixels with no mutation and
   // no scroll event — the follower must ride every growth step, so the
-  // distance stays 0 while scrollHeight rises to its final value.
-  await expect.poll(async () => (await page.evaluate(probeScroller)).distanceFromBottom).toBe(0);
+  // distance stays within 1px (sub-pixel scrollTop; see settleGeometry)
+  // while scrollHeight rises to its final value.
+  await expect.poll(async () => (await page.evaluate(probeScroller)).distanceFromBottom).toBeLessThanOrEqual(1);
 
-  // And the pin is still 0 once the walk reports itself done, which is what
+  // And the pin still holds once the walk reports itself done, which is what
   // makes the poll above a contract rather than a lucky early read.
   await settleGeometry(page, { pinned: true });
 });

--- a/apps/desktop/e2e/session-health-notice.spec.ts
+++ b/apps/desktop/e2e/session-health-notice.spec.ts
@@ -26,7 +26,7 @@ import { test, expect } from './fixtures';
 async function probeNoticeAlignment(page: import('@playwright/test').Page) {
   return await page.evaluate(() => {
     const notice = document.querySelector<HTMLElement>('.maka-session-health-notice');
-    const composer = document.querySelector<HTMLElement>('.composer .maka-composer-inner');
+    const composer = document.querySelector<HTMLElement>('.composer .maka-composer-astryx');
     if (!notice || !composer) {
       throw new Error('Expected both the health notice and the composer card to be mounted');
     }


### PR DESCRIPTION
## Summary

`#1728` moved the conversation surface onto Astryx primitives but left four E2E specs pointing at removed DOM, failing the CI e2e job with the same 8 tests across runs (scroll-geometry ×4, permission-mode-surface ×2, disclosure-output, session-health-notice). The product contracts those tests lock are all still live; only the selectors went stale.

- **permission-mode-surface**: the permission picker moved from the footer's `.maka-composer-left-controls` to the Astryx header context (`.maka-composer-header-context`); the Selector trigger is still a combobox, so only the container selector changed.
- **scroll-geometry / session-health-notice**: the composer card anchor `.maka-composer-inner` is gone; `.maka-composer-astryx` now carries the centered measure (`width: min(var(--maka-chat-measure), 100%)`).
- **disclosure-output**: live tools now render through Astryx ChatToolCalls; a single running tool is one collapsed CallRow (`role=button`) whose detail mounts on demand, replacing the `[data-processing=block]` wrapper and its fixture readiness selector.

Two assertions tracked deliberate Astryx changes instead of product regressions: the turn gap is now 16px (`ChatMessageList density=compact gap={4}`), and a fully pinned scroller can read a 1px distance because Chromium keeps sub-pixel `scrollTop` values (observed 30106.5), so the pin contract accepts `<= 1px`.

## Verification

- `npx playwright test` (apps/desktop): **93 passed** — full suite green, including the 8 previously failing tests.
- `npm run format:check` and `npm run lint`: clean (specs live under the formatter-excluded `apps/desktop/**`).
