### PR TITLE
feat(runtime-host): execute with OAuth credentials

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -13,18 +13,23 @@ import {
 } from '@maka/core';
 import { createDefaultRuntimePolicy } from '@maka/core/runtime-policy';
 import type { TaskLedgerStore } from '@maka/core/task-ledger';
-import type {
-  BackendFactoryContext,
-  FilesystemWorkerExecuteInput,
-  MakaTool,
-  MakaToolContext,
-  RunTraceEvent,
-  ScannedSkill,
+import {
+  serializeOAuthSubscriptionTokens,
+  type OAuthSubscriptionTokens,
+  type BackendFactoryContext,
+  type FilesystemWorkerExecuteInput,
+  type MakaTool,
+  type MakaToolContext,
+  type RunTraceEvent,
+  type ScannedSkill,
 } from '@maka/runtime';
 import { createSqliteRuntimeStore } from '@maka/storage';
 import { openInteractiveArtifactStoreForWrite } from '@maka/storage/artifact-stores';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
-import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
+import {
+  openInteractiveRuntimePolicyStoresForWrite,
+  type RuntimePolicyStoresWriter,
+} from '@maka/storage/runtime-policy-stores';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-authority';
 import type { TurnSnapshot, UsageQueryResult } from '../protocol/index.js';
@@ -39,6 +44,7 @@ import { HostClientCapabilityCoordinator } from '../server/client-capability-coo
 import type { HostMemoryCoordinator } from '../server/memory-coordinator.js';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
 import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
+import { HostOAuthExecutionAuthority } from '../server/oauth-execution-authority.js';
 import type { HostSkillCatalogCoordinator } from '../server/skill-catalog-coordinator.js';
 
 const MODEL_ID = 'hosted-real-model';
@@ -89,6 +95,91 @@ test('backend creation aborts a stalled pricing snapshot read', async () => {
     name: 'AbortError',
     message: 'Pricing resolution was interrupted',
   });
+});
+
+test('backend creation accepts a current canonical OAuth execution credential', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-oauth-backend-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'interactive'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  let backend: Awaited<ReturnType<typeof createHostAiSdkBackend>> | undefined;
+  try {
+    const policy = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    const created = await policy.connectionCatalog.create({
+      expectedCatalogRevision: 0,
+      connection: {
+        slug: 'backend-creation-connection',
+        name: 'OAuth backend creation',
+        providerType: 'github-copilot',
+        enabled: true,
+        enabledModelIds: [MODEL_ID],
+      },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed') return;
+    const connection = created.snapshot.connections[0];
+    assert.ok(connection);
+    if (!connection) return;
+    const tokens: OAuthSubscriptionTokens = {
+      access_token: 'canonical-oauth-access',
+      refresh_token: 'canonical-oauth-refresh',
+      expires_at: Number.MAX_SAFE_INTEGER,
+    };
+    const configured = await policy.credentialVault.set({
+      locator: {
+        scope: 'connection',
+        connectionId: connection.connectionId,
+        kind: 'oauth_token',
+      },
+      expected: null,
+      secret: serializeOAuthSubscriptionTokens(tokens),
+    });
+    assert.equal(configured.kind, 'committed');
+    await publishConnectionModel(policy, connection.connectionId, MODEL_ID);
+    const beforeActivation = await policy.operations.resolveExecutionConnection(
+      'backend-creation-connection',
+    );
+    assert.equal(beforeActivation.kind, 'ready');
+    if (beforeActivation.kind !== 'ready') return;
+
+    backend = await createHostAiSdkBackend(
+      backendCreationFixture({
+        abortSignal: new AbortController().signal,
+        resolveExecutionConnection: () =>
+          policy.operations.resolveExecutionConnection('backend-creation-connection'),
+        runtimePolicy: policy,
+        oauthCredentials: new HostOAuthExecutionAuthority(policy),
+        claudeDeviceId: capability.rootId,
+        readPricing: async () => ({ revision: 0, overrides: [] }),
+      }),
+    );
+
+    const resolved = await policy.operations.resolveExecutionConnection(
+      'backend-creation-connection',
+    );
+    assert.equal(resolved.kind, 'ready');
+    if (resolved.kind === 'ready') {
+      assert.equal(
+        resolved.secretMaterial.connection?.secret,
+        serializeOAuthSubscriptionTokens(tokens),
+      );
+      assert.equal(
+        resolved.secretMaterial.connection?.revision,
+        beforeActivation.secretMaterial.connection?.revision,
+      );
+    }
+  } finally {
+    try {
+      await backend?.dispose();
+    } finally {
+      await owner.close();
+      await rm(base, { recursive: true, force: true });
+    }
+  }
 });
 
 test('backend creation does not acquire Client Capabilities beyond a bound tool ceiling', async () => {
@@ -410,22 +501,7 @@ test('production Host executes a canonical ai-sdk Session against a real provide
       secret: API_KEY,
     });
     assert.equal(configured.kind, 'committed');
-    const fetchPreparation = await policy.operations.beginModelFetch(connection.connectionId);
-    assert.equal(fetchPreparation.kind, 'ready');
-    if (fetchPreparation.kind !== 'ready') return;
-    const fetched = await policy.operations.completeModelFetch(fetchPreparation.ticket, {
-      models: [
-        {
-          id: MODEL_ID,
-          capabilities: { chat: true, functionCalling: true },
-          contextWindow: 3_072,
-          maxOutputTokens: 64,
-        },
-      ],
-      source: 'fetched',
-      fetchedAt: Date.now(),
-    });
-    assert.equal(fetched.kind, 'committed');
+    await publishConnectionModel(policy, connection.connectionId, MODEL_ID);
     let policySnapshot = await policy.runtimePolicy.getSnapshot();
     const personalized = await policy.runtimePolicy.mutate({
       expectedRevision: policySnapshot.revision,
@@ -973,10 +1049,36 @@ function isTerminal(snapshot: TurnSnapshot): boolean {
   );
 }
 
+async function publishConnectionModel(
+  policy: RuntimePolicyStoresWriter,
+  connectionId: string,
+  modelId: string,
+): Promise<void> {
+  const prepared = await policy.operations.beginModelFetch(connectionId);
+  assert.equal(prepared.kind, 'ready');
+  if (prepared.kind !== 'ready') throw new Error('Model discovery was not ready');
+  const committed = await policy.operations.completeModelFetch(prepared.ticket, {
+    models: [
+      {
+        id: modelId,
+        capabilities: { chat: true, functionCalling: true },
+        contextWindow: 3_072,
+        maxOutputTokens: 64,
+      },
+    ],
+    source: 'fetched',
+    fetchedAt: Date.now(),
+  });
+  assert.equal(committed.kind, 'committed');
+}
+
 function backendCreationFixture(input: {
   abortSignal: AbortSignal;
   resolveExecutionConnection: () => Promise<unknown>;
   readPricing: () => Promise<unknown>;
+  runtimePolicy?: RuntimePolicyStoresWriter;
+  oauthCredentials?: HostOAuthExecutionAuthority;
+  claudeDeviceId?: string;
   tools?: readonly MakaTool[];
   snapshotClientCapabilities?: () => unknown;
   executionBoundary?: unknown;
@@ -1005,7 +1107,7 @@ function backendCreationFixture(input: {
         readExecutionBoundary: async () => input.executionBoundary,
       },
     } as unknown as BackendFactoryContext,
-    runtimePolicy: {
+    runtimePolicy: input.runtimePolicy ?? {
       operations: {
         resolveExecutionConnection: input.resolveExecutionConnection,
       },
@@ -1016,6 +1118,8 @@ function backendCreationFixture(input: {
         }),
       },
     },
+    ...(input.oauthCredentials ? { oauthCredentials: input.oauthCredentials } : {}),
+    ...(input.claudeDeviceId ? { claudeDeviceId: input.claudeDeviceId } : {}),
     skills: {
       readCanonicalModelInventory: async () => ({ inventory: [] }),
     },

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -20,6 +20,8 @@ import {
   type FilesystemWorkerExecuteInput,
   type MakaTool,
   type MakaToolContext,
+  type ProxiedFetchProxy,
+  type ProxiedFetchTransport,
   type RunTraceEvent,
   type ScannedSkill,
 } from '@maka/runtime';
@@ -97,7 +99,7 @@ test('backend creation aborts a stalled pricing snapshot read', async () => {
   });
 });
 
-test('backend creation accepts a current canonical OAuth execution credential', async () => {
+test('backend abort cannot cancel the authority-owned OAuth refresh used by its successor', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-oauth-backend-'));
   const capability = await resolveStorageRoot({
     path: join(base, 'interactive'),
@@ -106,7 +108,8 @@ test('backend creation accepts a current canonical OAuth execution credential', 
   const owner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(owner);
   if (!owner) return;
-  let backend: Awaited<ReturnType<typeof createHostAiSdkBackend>> | undefined;
+  let secondBackend: Awaited<ReturnType<typeof createHostAiSdkBackend>> | undefined;
+  let transports: ReturnType<typeof controlledOAuthTransports> | undefined;
   try {
     const policy = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
     const created = await policy.connectionCatalog.create({
@@ -114,7 +117,7 @@ test('backend creation accepts a current canonical OAuth execution credential', 
       connection: {
         slug: 'backend-creation-connection',
         name: 'OAuth backend creation',
-        providerType: 'github-copilot',
+        providerType: 'claude-subscription',
         enabled: true,
         enabledModelIds: [MODEL_ID],
       },
@@ -125,56 +128,98 @@ test('backend creation accepts a current canonical OAuth execution credential', 
     assert.ok(connection);
     if (!connection) return;
     const tokens: OAuthSubscriptionTokens = {
-      access_token: 'canonical-oauth-access',
-      refresh_token: 'canonical-oauth-refresh',
-      expires_at: Number.MAX_SAFE_INTEGER,
+      access_token: 'expired-oauth-access',
+      refresh_token: 'rotating-oauth-refresh',
+      expires_at: 0,
+      account_uuid: 'oauth-account-v1',
     };
-    const configured = await policy.credentialVault.set({
-      locator: {
-        scope: 'connection',
-        connectionId: connection.connectionId,
-        kind: 'oauth_token',
-      },
-      expected: null,
-      secret: serializeOAuthSubscriptionTokens(tokens),
-    });
-    assert.equal(configured.kind, 'committed');
-    await publishConnectionModel(policy, connection.connectionId, MODEL_ID);
-    const beforeActivation = await policy.operations.resolveExecutionConnection(
-      'backend-creation-connection',
+    await writeFile(
+      join(capability.canonicalPath, 'credential-vault.json'),
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          revision: 1,
+          entries: [
+            {
+              locator: {
+                scope: 'connection',
+                connectionId: connection.connectionId,
+                kind: 'oauth_token',
+              },
+              credentialId: randomUUID(),
+              revision: 1,
+              secret: serializeOAuthSubscriptionTokens(tokens),
+              updatedAt: Date.now(),
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      { encoding: 'utf8', mode: 0o600 },
     );
-    assert.equal(beforeActivation.kind, 'ready');
-    if (beforeActivation.kind !== 'ready') return;
+    await publishConnectionModel(policy, connection.connectionId, MODEL_ID);
+    transports = controlledOAuthTransports();
+    const authority = new HostOAuthExecutionAuthority(policy);
+    const firstAbort = new AbortController();
+    const firstCreation = createHostAiSdkBackend(
+      backendCreationFixture({
+        abortSignal: firstAbort.signal,
+        resolveExecutionConnection: () =>
+          policy.operations.resolveExecutionConnection('backend-creation-connection'),
+        runtimePolicy: policy,
+        oauthCredentials: authority,
+        claudeDeviceId: capability.rootId,
+        readPricing: async () => ({ revision: 0, overrides: [] }),
+        createFetchTransport: transports.create,
+      }),
+    );
+    await transports.refreshStarted;
 
-    backend = await createHostAiSdkBackend(
+    const abortReason = new DOMException('First backend stopped', 'AbortError');
+    firstAbort.abort(abortReason);
+    await assert.rejects(settleWithin(firstCreation), (error) => error === abortReason);
+    assert.equal(transports.modelTransportsClosed, 1);
+    assert.equal(transports.refreshTransportClosed, false);
+
+    transports.completeRefresh();
+    await transports.refreshTransportSettled;
+    assert.equal(transports.refreshTransportClosed, true);
+
+    secondBackend = await createHostAiSdkBackend(
       backendCreationFixture({
         abortSignal: new AbortController().signal,
         resolveExecutionConnection: () =>
           policy.operations.resolveExecutionConnection('backend-creation-connection'),
         runtimePolicy: policy,
-        oauthCredentials: new HostOAuthExecutionAuthority(policy),
+        oauthCredentials: authority,
         claudeDeviceId: capability.rootId,
         readPricing: async () => ({ revision: 0, overrides: [] }),
+        createFetchTransport: transports.create,
       }),
     );
+    assert.equal(transports.refreshCalls, 1);
 
     const resolved = await policy.operations.resolveExecutionConnection(
       'backend-creation-connection',
     );
     assert.equal(resolved.kind, 'ready');
     if (resolved.kind === 'ready') {
-      assert.equal(
-        resolved.secretMaterial.connection?.secret,
-        serializeOAuthSubscriptionTokens(tokens),
-      );
-      assert.equal(
-        resolved.secretMaterial.connection?.revision,
-        beforeActivation.secretMaterial.connection?.revision,
-      );
+      const persisted = JSON.parse(
+        resolved.secretMaterial.connection?.secret ?? '',
+      ) as OAuthSubscriptionTokens;
+      assert.equal(persisted.access_token, 'refreshed-oauth-access');
+      assert.equal(persisted.refresh_token, 'rotated-oauth-refresh');
+      assert.equal(persisted.account_uuid, 'oauth-account-v2');
+      assert.ok((persisted.expires_at ?? 0) > Date.now());
     }
   } finally {
     try {
-      await backend?.dispose();
+      if (transports && transports.refreshCalls > 0) {
+        transports.completeRefresh();
+        await transports.refreshTransportSettled;
+      }
+      await secondBackend?.dispose();
     } finally {
       await owner.close();
       await rm(base, { recursive: true, force: true });
@@ -1085,6 +1130,7 @@ function backendCreationFixture(input: {
   loadTurnRuntimeEvents?: () => Promise<RuntimeEvent[]>;
   recordRunTrace?: (event: RunTraceEvent) => unknown;
   runtimeCommitSink?: HostAiSdkBackendInput['runtimeCommitSink'];
+  createFetchTransport?: HostAiSdkBackendInput['createFetchTransport'];
 }): HostAiSdkBackendInput {
   return {
     context: {
@@ -1149,6 +1195,7 @@ function backendCreationFixture(input: {
       snapshotForSession: input.snapshotClientCapabilities ?? (() => undefined),
     },
     ...(input.runtimeCommitSink ? { runtimeCommitSink: input.runtimeCommitSink } : {}),
+    ...(input.createFetchTransport ? { createFetchTransport: input.createFetchTransport } : {}),
   } as unknown as HostAiSdkBackendInput;
 }
 
@@ -1189,6 +1236,86 @@ async function settleWithin<T>(pending: Promise<T>): Promise<T> {
   } finally {
     if (timeout) clearTimeout(timeout);
   }
+}
+
+function controlledOAuthTransports(): {
+  readonly create: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
+  readonly refreshStarted: Promise<void>;
+  readonly refreshTransportSettled: Promise<void>;
+  readonly refreshCalls: number;
+  readonly refreshTransportClosed: boolean;
+  readonly modelTransportsClosed: number;
+  completeRefresh(): void;
+} {
+  let markRefreshStarted!: () => void;
+  const refreshStarted = new Promise<void>((resolve) => {
+    markRefreshStarted = resolve;
+  });
+  let markRefreshTransportSettled!: () => void;
+  const refreshTransportSettled = new Promise<void>((resolve) => {
+    markRefreshTransportSettled = resolve;
+  });
+  let refreshCalls = 0;
+  let refreshTransportClosed = false;
+  let modelTransportsClosed = 0;
+  let resolveRefresh: ((response: Response) => void) | undefined;
+  let rejectRefresh: ((error: Error) => void) | undefined;
+  let refreshCompleted = false;
+
+  const create = (_proxy: ProxiedFetchProxy | null): ProxiedFetchTransport => {
+    let usedForRefresh = false;
+    let closed = false;
+    return {
+      fetch: async (url) => {
+        assert.equal(String(url), 'https://platform.claude.com/v1/oauth/token');
+        usedForRefresh = true;
+        refreshCalls += 1;
+        markRefreshStarted();
+        return new Promise<Response>((resolve, reject) => {
+          resolveRefresh = resolve;
+          rejectRefresh = reject;
+        });
+      },
+      close: async () => {
+        if (closed) return;
+        closed = true;
+        if (usedForRefresh) {
+          refreshTransportClosed = true;
+          rejectRefresh?.(new Error('Controlled OAuth transport closed'));
+          markRefreshTransportSettled();
+        } else {
+          modelTransportsClosed += 1;
+        }
+      },
+    };
+  };
+
+  return {
+    create,
+    refreshStarted,
+    refreshTransportSettled,
+    get refreshCalls() {
+      return refreshCalls;
+    },
+    get refreshTransportClosed() {
+      return refreshTransportClosed;
+    },
+    get modelTransportsClosed() {
+      return modelTransportsClosed;
+    },
+    completeRefresh: () => {
+      if (refreshCompleted || !resolveRefresh) return;
+      refreshCompleted = true;
+      resolveRefresh(
+        Response.json({
+          access_token: 'refreshed-oauth-access',
+          refresh_token: 'rotated-oauth-refresh',
+          expires_in: 3_600,
+          account: { uuid: 'oauth-account-v2' },
+        }),
+      );
+    },
+  };
 }
 
 function toolNames(body: Record<string, unknown> | undefined): string[] {

--- a/packages/runtime-host/src/__tests__/oauth-execution-authority.test.ts
+++ b/packages/runtime-host/src/__tests__/oauth-execution-authority.test.ts
@@ -5,7 +5,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mock, test } from 'node:test';
 import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
-import { serializeOAuthSubscriptionTokens, type OAuthSubscriptionTokens } from '@maka/runtime';
+import {
+  serializeOAuthSubscriptionTokens,
+  type OAuthSubscriptionTokens,
+  type ProxiedFetchTransport,
+} from '@maka/runtime';
 import {
   openInteractiveRuntimePolicyStoresForWrite,
   type RuntimePolicyCredentialMaterial,
@@ -31,12 +35,10 @@ test('one OAuth generation singleflights refresh and persists its lease with can
       providerType: 'github-copilot',
       connectionSlug: CONNECTION_SLUG,
       material: before,
+      createRefreshTransport: () => testRefreshTransport(unexpectedFetch),
     });
 
-    const [first, second] = await Promise.all([
-      binding.resolve(unexpectedFetch),
-      binding.resolve(unexpectedFetch),
-    ]);
+    const [first, second] = await Promise.all([binding.resolve(), binding.resolve()]);
 
     assert.deepEqual(first, expiredTokens('access-v1'));
     assert.deepEqual(second, first);
@@ -47,12 +49,13 @@ test('one OAuth generation singleflights refresh and persists its lease with can
   });
 });
 
-test('an active OAuth binding cannot adopt a credential generation replaced by the user', async () => {
-  await withCopilotCredential(expiredTokens('old-access'), async (fixture) => {
+test('an active OAuth binding cannot use a credential generation replaced by the user', async () => {
+  await withCopilotCredential(currentTokens('old-access'), async (fixture) => {
     const oldBinding = fixture.authority.bind({
       providerType: 'github-copilot',
       connectionSlug: CONNECTION_SLUG,
       material: fixture.material,
+      createRefreshTransport: () => testRefreshTransport(unexpectedFetch),
     });
     const replacement = currentTokens('replacement-access');
     const replaced = await fixture.stores.credentialVault.set({
@@ -69,11 +72,12 @@ test('an active OAuth binding cannot adopt a credential generation replaced by t
       providerType: 'github-copilot',
       connectionSlug: CONNECTION_SLUG,
       material: replacementMaterial,
+      createRefreshTransport: () => testRefreshTransport(unexpectedFetch),
     });
 
-    assert.deepEqual(await newBinding.resolve(unexpectedFetch), replacement);
+    assert.deepEqual(await newBinding.resolve(), replacement);
     await assert.rejects(
-      () => oldBinding.resolve(unexpectedFetch),
+      () => oldBinding.resolve(),
       (error) =>
         error instanceof OAuthExecutionCredentialError && error.code === 'credential_superseded',
     );
@@ -88,11 +92,6 @@ test('a rotated Claude token crosses canonical CAS into request auth and identit
     'claude-subscription',
     expiredTokens('access-v1', 'account-v1'),
     async (fixture) => {
-      const binding = fixture.authority.bind({
-        providerType: 'claude-subscription',
-        connectionSlug: CONNECTION_SLUG,
-        material: fixture.material,
-      });
       const observed: Array<{ headers: Headers; body: Record<string, unknown> }> = [];
       let refreshCalls = 0;
       const providerFetch: typeof fetch = async (url, init) => {
@@ -106,8 +105,14 @@ test('a rotated Claude token crosses canonical CAS into request auth and identit
         });
         return Response.json({ ok: true });
       };
+      const binding = fixture.authority.bind({
+        providerType: 'claude-subscription',
+        connectionSlug: CONNECTION_SLUG,
+        material: fixture.material,
+        createRefreshTransport: () => testRefreshTransport(providerFetch),
+      });
 
-      const initialTokens = await binding.resolve(providerFetch);
+      const initialTokens = await binding.resolve();
       const modelFetch = createHostOAuthModelFetch({
         binding,
         initialTokens,
@@ -134,7 +139,7 @@ test('a rotated Claude token crosses canonical CAS into request auth and identit
         account_uuid: 'account-v2',
       });
       assert.equal(canonical.revision, fixture.material.revision + 2);
-      assert.equal((await binding.resolve(providerFetch)).access_token, initialTokens.access_token);
+      assert.equal((await binding.resolve()).access_token, initialTokens.access_token);
       assert.equal(refreshCalls, 1);
     },
   );
@@ -201,35 +206,31 @@ test('reconciles a published OAuth lease claim before the next demand', async ()
     'claude-subscription',
     expiredTokens('claim-v1', 'account-v1'),
     async (fixture) => {
+      let refreshCalls = 0;
+      const providerFetch = successfulClaudeRefresh(() => {
+        refreshCalls += 1;
+      });
       const binding = fixture.authority.bind({
         providerType: 'claude-subscription',
         connectionSlug: CONNECTION_SLUG,
         material: fixture.material,
-      });
-      let refreshCalls = 0;
-      const providerFetch = successfulClaudeRefresh(() => {
-        refreshCalls += 1;
+        createRefreshTransport: () => testRefreshTransport(providerFetch),
       });
       let leaseNow = FIXED_NOW;
       const nowMock = mock.method(Date, 'now', () => leaseNow);
       try {
         await withPublishedSyncFailure(fixture.root, 2, async () => {
-          await assert.rejects(
-            () => binding.resolve(providerFetch),
-            isOAuthError('persistence_failed'),
-          );
+          await assert.rejects(() => binding.resolve(), isOAuthError('persistence_failed'));
         });
         assert.equal(refreshCalls, 0);
         const secondBinding = fixture.authority.bind({
           providerType: 'claude-subscription',
           connectionSlug: CONNECTION_SLUG,
           material: await readMaterial(fixture.stores),
+          createRefreshTransport: () => testRefreshTransport(providerFetch),
         });
         leaseNow += 30_001;
-        const [first, second] = await Promise.all([
-          binding.resolve(providerFetch),
-          secondBinding.resolve(providerFetch),
-        ]);
+        const [first, second] = await Promise.all([binding.resolve(), secondBinding.resolve()]);
         assert.equal(first.access_token, 'access-v2');
         assert.equal(second.access_token, 'access-v2');
         assert.equal(refreshCalls, 1);
@@ -245,23 +246,21 @@ test('reconciles a published OAuth refresh finalization before the next demand',
     'claude-subscription',
     expiredTokens('finalize-v1', 'account-v1'),
     async (fixture) => {
-      const binding = fixture.authority.bind({
-        providerType: 'claude-subscription',
-        connectionSlug: CONNECTION_SLUG,
-        material: fixture.material,
-      });
       let refreshCalls = 0;
       const providerFetch = successfulClaudeRefresh(() => {
         refreshCalls += 1;
       });
+      const binding = fixture.authority.bind({
+        providerType: 'claude-subscription',
+        connectionSlug: CONNECTION_SLUG,
+        material: fixture.material,
+        createRefreshTransport: () => testRefreshTransport(providerFetch),
+      });
 
       await withPublishedSyncFailure(fixture.root, 4, async () => {
-        await assert.rejects(
-          () => binding.resolve(providerFetch),
-          isOAuthError('persistence_failed'),
-        );
+        await assert.rejects(() => binding.resolve(), isOAuthError('persistence_failed'));
       });
-      assert.equal((await binding.resolve(providerFetch)).access_token, 'access-v2');
+      assert.equal((await binding.resolve()).access_token, 'access-v2');
       assert.equal(refreshCalls, 1);
     },
   );
@@ -272,11 +271,6 @@ test('reconciles a published OAuth lease release before retrying refresh', async
     'claude-subscription',
     expiredTokens('release-v1', 'account-v1'),
     async (fixture) => {
-      const binding = fixture.authority.bind({
-        providerType: 'claude-subscription',
-        connectionSlug: CONNECTION_SLUG,
-        material: fixture.material,
-      });
       let refreshCalls = 0;
       const providerFetch: typeof fetch = async (url) => {
         assert.equal(String(url), CLAUDE_TOKEN_ENDPOINT);
@@ -285,14 +279,17 @@ test('reconciles a published OAuth lease release before retrying refresh', async
           ? Response.json({ error: 'temporary failure' }, { status: 503 })
           : claudeRefreshResponse('access-v2', 'refresh-v2', 'account-v2');
       };
+      const binding = fixture.authority.bind({
+        providerType: 'claude-subscription',
+        connectionSlug: CONNECTION_SLUG,
+        material: fixture.material,
+        createRefreshTransport: () => testRefreshTransport(providerFetch),
+      });
 
       await withPublishedSyncFailure(fixture.root, 4, async () => {
-        await assert.rejects(
-          () => binding.resolve(providerFetch),
-          isOAuthError('persistence_failed'),
-        );
+        await assert.rejects(() => binding.resolve(), isOAuthError('persistence_failed'));
       });
-      assert.equal((await binding.resolve(providerFetch)).access_token, 'access-v2');
+      assert.equal((await binding.resolve()).access_token, 'access-v2');
       assert.equal(refreshCalls, 2);
     },
   );
@@ -653,3 +650,7 @@ function codexAccessToken(accountId: string): string {
 const unexpectedFetch: typeof fetch = async () => {
   throw new Error('GitHub Copilot credential refresh must not perform provider I/O');
 };
+
+function testRefreshTransport(fetchFn: typeof fetch): ProxiedFetchTransport {
+  return { fetch: fetchFn, close: async () => undefined };
+}

--- a/packages/runtime-host/src/__tests__/oauth-execution-authority.test.ts
+++ b/packages/runtime-host/src/__tests__/oauth-execution-authority.test.ts
@@ -1,0 +1,655 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { open, writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mock, test } from 'node:test';
+import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
+import { serializeOAuthSubscriptionTokens, type OAuthSubscriptionTokens } from '@maka/runtime';
+import {
+  openInteractiveRuntimePolicyStoresForWrite,
+  type RuntimePolicyCredentialMaterial,
+  type RuntimePolicyStoresWriter,
+} from '@maka/storage/runtime-policy-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import {
+  createHostOAuthModelFetch,
+  HostOAuthExecutionAuthority,
+  OAuthExecutionCredentialError,
+  type HostOAuthExecutionBinding,
+} from '../server/oauth-execution-authority.js';
+
+const CONNECTION_SLUG = 'host-oauth-execution';
+const MODEL_ID = 'gpt-5';
+const CLAUDE_TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
+const FIXED_NOW = 1_785_600_000_000;
+
+test('one OAuth generation singleflights refresh and persists its lease with canonical CAS', async () => {
+  await withCopilotCredential(expiredTokens('access-v1'), async (fixture) => {
+    const before = fixture.material;
+    const binding = fixture.authority.bind({
+      providerType: 'github-copilot',
+      connectionSlug: CONNECTION_SLUG,
+      material: before,
+    });
+
+    const [first, second] = await Promise.all([
+      binding.resolve(unexpectedFetch),
+      binding.resolve(unexpectedFetch),
+    ]);
+
+    assert.deepEqual(first, expiredTokens('access-v1'));
+    assert.deepEqual(second, first);
+    const after = await readMaterial(fixture.stores);
+    assert.equal(after.credentialId, before.credentialId);
+    assert.equal(after.revision, before.revision + 2);
+    assert.equal(after.secret, before.secret);
+  });
+});
+
+test('an active OAuth binding cannot adopt a credential generation replaced by the user', async () => {
+  await withCopilotCredential(expiredTokens('old-access'), async (fixture) => {
+    const oldBinding = fixture.authority.bind({
+      providerType: 'github-copilot',
+      connectionSlug: CONNECTION_SLUG,
+      material: fixture.material,
+    });
+    const replacement = currentTokens('replacement-access');
+    const replaced = await fixture.stores.credentialVault.set({
+      locator: fixture.material.locator,
+      expected: {
+        credentialId: fixture.material.credentialId,
+        revision: fixture.material.revision,
+      },
+      secret: serializeOAuthSubscriptionTokens(replacement),
+    });
+    assert.equal(replaced.kind, 'committed');
+    const replacementMaterial = await readMaterial(fixture.stores);
+    const newBinding = fixture.authority.bind({
+      providerType: 'github-copilot',
+      connectionSlug: CONNECTION_SLUG,
+      material: replacementMaterial,
+    });
+
+    assert.deepEqual(await newBinding.resolve(unexpectedFetch), replacement);
+    await assert.rejects(
+      () => oldBinding.resolve(unexpectedFetch),
+      (error) =>
+        error instanceof OAuthExecutionCredentialError && error.code === 'credential_superseded',
+    );
+    const canonical = await readMaterial(fixture.stores);
+    assert.equal(canonical.secret, replacementMaterial.secret);
+    assert.equal(canonical.revision, replacementMaterial.revision);
+  });
+});
+
+test('a rotated Claude token crosses canonical CAS into request auth and identity', async () => {
+  await withSeededOAuthCredential(
+    'claude-subscription',
+    expiredTokens('access-v1', 'account-v1'),
+    async (fixture) => {
+      const binding = fixture.authority.bind({
+        providerType: 'claude-subscription',
+        connectionSlug: CONNECTION_SLUG,
+        material: fixture.material,
+      });
+      const observed: Array<{ headers: Headers; body: Record<string, unknown> }> = [];
+      let refreshCalls = 0;
+      const providerFetch: typeof fetch = async (url, init) => {
+        if (String(url) === CLAUDE_TOKEN_ENDPOINT) {
+          refreshCalls += 1;
+          return claudeRefreshResponse('access-v2', 'refresh-v2', 'account-v2');
+        }
+        observed.push({
+          headers: new Headers(init?.headers),
+          body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+        });
+        return Response.json({ ok: true });
+      };
+
+      const initialTokens = await binding.resolve(providerFetch);
+      const modelFetch = createHostOAuthModelFetch({
+        binding,
+        initialTokens,
+        connection: claudeConnection(),
+        sessionId: 'rotation-session',
+        modelId: 'claude-sonnet-4-5',
+        claudeDeviceId: 'b'.repeat(64),
+        fetchFn: providerFetch,
+      });
+      await modelFetch('https://api.anthropic.com/v1/messages', claudeRequest());
+
+      assert.equal(refreshCalls, 1);
+      assert.equal(observed[0]?.headers.get('authorization'), 'Bearer access-v2');
+      assert.deepEqual(claudeIdentity(observed[0]?.body), {
+        device_id: 'b'.repeat(64),
+        account_uuid: 'account-v2',
+        session_id: 'rotation-session',
+      });
+      const canonical = await readMaterial(fixture.stores);
+      assert.deepEqual(JSON.parse(canonical.secret), {
+        access_token: 'access-v2',
+        refresh_token: 'refresh-v2',
+        expires_at: FIXED_NOW + 3_600_000,
+        account_uuid: 'account-v2',
+      });
+      assert.equal(canonical.revision, fixture.material.revision + 2);
+      assert.equal((await binding.resolve(providerFetch)).access_token, initialTokens.access_token);
+      assert.equal(refreshCalls, 1);
+    },
+  );
+});
+
+test('request abort stops waiting for shared OAuth resolution without dispatching the model call', async () => {
+  const pending = deferred<OAuthSubscriptionTokens>();
+  const tokens = currentTokens(codexAccessToken('account-v1'));
+  let modelCalls = 0;
+  let resolveCalls = 0;
+  const modelFetch = createHostOAuthModelFetch({
+    binding: {
+      providerType: 'openai-codex',
+      connectionSlug: CONNECTION_SLUG,
+      resolve: async () => {
+        resolveCalls += 1;
+        return pending.promise;
+      },
+    },
+    initialTokens: tokens,
+    connection: {
+      slug: CONNECTION_SLUG,
+      providerType: 'openai-codex',
+      defaultModel: 'gpt-5.6-sol',
+    },
+    sessionId: 'abort-session',
+    modelId: 'gpt-5.6-sol',
+    claudeDeviceId: 'unused',
+    fetchFn: async () => {
+      modelCalls += 1;
+      return Response.json({ ok: true });
+    },
+  });
+  const controller = new AbortController();
+  const reason = new Error('run stopped');
+  const request = modelFetch('https://chatgpt.com/backend-api/codex/responses', {
+    method: 'POST',
+    signal: controller.signal,
+    body: JSON.stringify({ input: [] }),
+  });
+
+  controller.abort(reason);
+  await assert.rejects(request, (error) => error === reason);
+  assert.equal(modelCalls, 0);
+  pending.resolve(tokens);
+  await pending.promise;
+
+  const alreadyAborted = new AbortController();
+  const earlierReason = new Error('run was already stopped');
+  alreadyAborted.abort(earlierReason);
+  await assert.rejects(
+    () =>
+      modelFetch('https://chatgpt.com/backend-api/codex/responses', {
+        signal: alreadyAborted.signal,
+      }),
+    (error) => error === earlierReason,
+  );
+  assert.equal(resolveCalls, 1);
+  assert.equal(modelCalls, 0);
+});
+
+test('reconciles a published OAuth lease claim before the next demand', async () => {
+  await withSeededOAuthCredential(
+    'claude-subscription',
+    expiredTokens('claim-v1', 'account-v1'),
+    async (fixture) => {
+      const binding = fixture.authority.bind({
+        providerType: 'claude-subscription',
+        connectionSlug: CONNECTION_SLUG,
+        material: fixture.material,
+      });
+      let refreshCalls = 0;
+      const providerFetch = successfulClaudeRefresh(() => {
+        refreshCalls += 1;
+      });
+      let leaseNow = FIXED_NOW;
+      const nowMock = mock.method(Date, 'now', () => leaseNow);
+      try {
+        await withPublishedSyncFailure(fixture.root, 2, async () => {
+          await assert.rejects(
+            () => binding.resolve(providerFetch),
+            isOAuthError('persistence_failed'),
+          );
+        });
+        assert.equal(refreshCalls, 0);
+        const secondBinding = fixture.authority.bind({
+          providerType: 'claude-subscription',
+          connectionSlug: CONNECTION_SLUG,
+          material: await readMaterial(fixture.stores),
+        });
+        leaseNow += 30_001;
+        const [first, second] = await Promise.all([
+          binding.resolve(providerFetch),
+          secondBinding.resolve(providerFetch),
+        ]);
+        assert.equal(first.access_token, 'access-v2');
+        assert.equal(second.access_token, 'access-v2');
+        assert.equal(refreshCalls, 1);
+      } finally {
+        nowMock.mock.restore();
+      }
+    },
+  );
+});
+
+test('reconciles a published OAuth refresh finalization before the next demand', async () => {
+  await withSeededOAuthCredential(
+    'claude-subscription',
+    expiredTokens('finalize-v1', 'account-v1'),
+    async (fixture) => {
+      const binding = fixture.authority.bind({
+        providerType: 'claude-subscription',
+        connectionSlug: CONNECTION_SLUG,
+        material: fixture.material,
+      });
+      let refreshCalls = 0;
+      const providerFetch = successfulClaudeRefresh(() => {
+        refreshCalls += 1;
+      });
+
+      await withPublishedSyncFailure(fixture.root, 4, async () => {
+        await assert.rejects(
+          () => binding.resolve(providerFetch),
+          isOAuthError('persistence_failed'),
+        );
+      });
+      assert.equal((await binding.resolve(providerFetch)).access_token, 'access-v2');
+      assert.equal(refreshCalls, 1);
+    },
+  );
+});
+
+test('reconciles a published OAuth lease release before retrying refresh', async () => {
+  await withSeededOAuthCredential(
+    'claude-subscription',
+    expiredTokens('release-v1', 'account-v1'),
+    async (fixture) => {
+      const binding = fixture.authority.bind({
+        providerType: 'claude-subscription',
+        connectionSlug: CONNECTION_SLUG,
+        material: fixture.material,
+      });
+      let refreshCalls = 0;
+      const providerFetch: typeof fetch = async (url) => {
+        assert.equal(String(url), CLAUDE_TOKEN_ENDPOINT);
+        refreshCalls += 1;
+        return refreshCalls === 1
+          ? Response.json({ error: 'temporary failure' }, { status: 503 })
+          : claudeRefreshResponse('access-v2', 'refresh-v2', 'account-v2');
+      };
+
+      await withPublishedSyncFailure(fixture.root, 4, async () => {
+        await assert.rejects(
+          () => binding.resolve(providerFetch),
+          isOAuthError('persistence_failed'),
+        );
+      });
+      assert.equal((await binding.resolve(providerFetch)).access_token, 'access-v2');
+      assert.equal(refreshCalls, 2);
+    },
+  );
+});
+
+test('each Claude request uses one current token snapshot for auth and cloak identity', async () => {
+  const observed: Array<{ headers: Headers; body: Record<string, unknown> }> = [];
+  let tokens = currentTokens('access-v1', 'account-v1');
+  const binding: HostOAuthExecutionBinding = {
+    providerType: 'claude-subscription',
+    connectionSlug: CONNECTION_SLUG,
+    resolve: async () => tokens,
+  };
+  const modelFetch = createHostOAuthModelFetch({
+    binding,
+    initialTokens: tokens,
+    connection: claudeConnection(),
+    sessionId: 'session-v1',
+    modelId: 'claude-sonnet-4-5',
+    claudeDeviceId: 'a'.repeat(64),
+    fetchFn: async (_url, init) => {
+      observed.push({
+        headers: new Headers(init?.headers),
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+      });
+      return Response.json({ ok: true });
+    },
+  });
+  const request = {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer stale-sdk-token',
+      'x-api-key': 'stale-sdk-token',
+    },
+    body: JSON.stringify({
+      stream: false,
+      system: 'Use the Host prompt.',
+      messages: [{ role: 'user', content: 'hello' }],
+    }),
+  } satisfies RequestInit;
+
+  await modelFetch('https://api.anthropic.com/v1/messages', request);
+  tokens = currentTokens('access-v2', 'account-v2');
+  await modelFetch('https://api.anthropic.com/v1/messages', request);
+
+  assert.equal(observed.length, 2);
+  assert.equal(observed[0]?.headers.get('authorization'), 'Bearer access-v1');
+  assert.equal(observed[1]?.headers.get('authorization'), 'Bearer access-v2');
+  for (const item of observed) assert.equal(item.headers.get('x-api-key'), null);
+  assert.deepEqual(claudeIdentity(observed[0]?.body), {
+    device_id: 'a'.repeat(64),
+    account_uuid: 'account-v1',
+    session_id: 'session-v1',
+  });
+  assert.deepEqual(claudeIdentity(observed[1]?.body), {
+    device_id: 'a'.repeat(64),
+    account_uuid: 'account-v2',
+    session_id: 'session-v1',
+  });
+});
+
+test('Codex request auth and account identity advance from the same token snapshot', async () => {
+  const observed: Headers[] = [];
+  let tokens = currentTokens(codexAccessToken('account-v1'));
+  const binding: HostOAuthExecutionBinding = {
+    providerType: 'openai-codex',
+    connectionSlug: CONNECTION_SLUG,
+    resolve: async () => tokens,
+  };
+  const modelFetch = createHostOAuthModelFetch({
+    binding,
+    initialTokens: tokens,
+    connection: {
+      slug: CONNECTION_SLUG,
+      providerType: 'openai-codex',
+      defaultModel: 'gpt-5.6-sol',
+    },
+    sessionId: 'codex-session',
+    modelId: 'gpt-5.6-sol',
+    claudeDeviceId: 'unused',
+    fetchFn: async (_url, init) => {
+      observed.push(new Headers(init?.headers));
+      return Response.json({ ok: true });
+    },
+  });
+  const request = {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer stale-sdk-token',
+      'ChatGPT-Account-Id': 'stale-account',
+    },
+    body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
+  } satisfies RequestInit;
+
+  await modelFetch('https://chatgpt.com/backend-api/codex/responses', request);
+  tokens = currentTokens(codexAccessToken('account-v2'));
+  await modelFetch('https://chatgpt.com/backend-api/codex/responses', request);
+
+  assert.equal(observed[0]?.get('authorization'), `Bearer ${codexAccessToken('account-v1')}`);
+  assert.equal(observed[0]?.get('ChatGPT-Account-Id'), 'account-v1');
+  assert.equal(observed[1]?.get('authorization'), `Bearer ${codexAccessToken('account-v2')}`);
+  assert.equal(observed[1]?.get('ChatGPT-Account-Id'), 'account-v2');
+  assert.equal(observed[1]?.get('session_id'), 'codex-session');
+});
+
+interface CopilotCredentialFixture {
+  readonly root: string;
+  readonly stores: RuntimePolicyStoresWriter;
+  readonly authority: HostOAuthExecutionAuthority;
+  readonly material: RuntimePolicyCredentialMaterial;
+}
+
+async function withCopilotCredential(
+  tokens: OAuthSubscriptionTokens,
+  run: (fixture: CopilotCredentialFixture) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-oauth-execution-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'interactive'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  try {
+    const stores = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    const created = await stores.connectionCatalog.create({
+      expectedCatalogRevision: 0,
+      connection: {
+        slug: CONNECTION_SLUG,
+        name: 'Host OAuth execution',
+        providerType: 'github-copilot',
+        enabled: true,
+        enabledModelIds: [MODEL_ID],
+      },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed') return;
+    const connection = created.snapshot.connections[0];
+    assert.ok(connection);
+    if (!connection) return;
+    const configured = await stores.credentialVault.set({
+      locator: {
+        scope: 'connection',
+        connectionId: connection.connectionId,
+        kind: 'oauth_token',
+      },
+      expected: null,
+      secret: serializeOAuthSubscriptionTokens(tokens),
+    });
+    assert.equal(configured.kind, 'committed');
+    await run({
+      root: capability.canonicalPath,
+      stores,
+      authority: new HostOAuthExecutionAuthority(stores),
+      material: await readMaterial(stores),
+    });
+  } finally {
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+async function withSeededOAuthCredential(
+  providerType: 'claude-subscription' | 'openai-codex',
+  tokens: OAuthSubscriptionTokens,
+  run: (fixture: CopilotCredentialFixture) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-oauth-seeded-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'interactive'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  try {
+    const stores = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    const created = await stores.connectionCatalog.create({
+      expectedCatalogRevision: 0,
+      connection: {
+        slug: CONNECTION_SLUG,
+        name: 'Host OAuth execution',
+        providerType,
+        enabled: true,
+        enabledModelIds: [MODEL_ID],
+      },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed') return;
+    const connection = created.snapshot.connections[0];
+    assert.ok(connection);
+    if (!connection) return;
+    await writeFile(
+      join(capability.canonicalPath, 'credential-vault.json'),
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          revision: 1,
+          entries: [
+            {
+              locator: {
+                scope: 'connection',
+                connectionId: connection.connectionId,
+                kind: 'oauth_token',
+              },
+              credentialId: randomUUID(),
+              revision: 1,
+              secret: serializeOAuthSubscriptionTokens(tokens),
+              updatedAt: FIXED_NOW,
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      { encoding: 'utf8', mode: 0o600 },
+    );
+    await run({
+      root: capability.canonicalPath,
+      stores,
+      authority: new HostOAuthExecutionAuthority(stores, () => FIXED_NOW),
+      material: await readMaterial(stores),
+    });
+  } finally {
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+async function readMaterial(
+  stores: RuntimePolicyStoresWriter,
+): Promise<RuntimePolicyCredentialMaterial> {
+  const resolved = await stores.operations.resolveExecutionConnection(CONNECTION_SLUG);
+  assert.equal(resolved.kind, 'ready');
+  if (resolved.kind !== 'ready' || !resolved.secretMaterial.connection) {
+    throw new Error('OAuth execution material was not ready');
+  }
+  return resolved.secretMaterial.connection;
+}
+
+function expiredTokens(accessToken: string, accountUuid?: string): OAuthSubscriptionTokens {
+  return {
+    access_token: accessToken,
+    refresh_token: `${accessToken}-refresh`,
+    expires_at: 0,
+    ...(accountUuid ? { account_uuid: accountUuid } : {}),
+  };
+}
+
+function currentTokens(accessToken: string, accountUuid?: string): OAuthSubscriptionTokens {
+  return {
+    access_token: accessToken,
+    refresh_token: `${accessToken}-refresh`,
+    expires_at: Number.MAX_SAFE_INTEGER,
+    ...(accountUuid ? { account_uuid: accountUuid } : {}),
+  };
+}
+
+function claudeConnection(): RuntimeExecutionConnection {
+  return {
+    slug: CONNECTION_SLUG,
+    providerType: 'claude-subscription',
+    defaultModel: 'claude-sonnet-4-5',
+  };
+}
+
+function claudeRequest(): RequestInit {
+  return {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer stale-sdk-token',
+      'x-api-key': 'stale-sdk-token',
+    },
+    body: JSON.stringify({
+      stream: false,
+      system: 'Use the Host prompt.',
+      messages: [{ role: 'user', content: 'hello' }],
+    }),
+  };
+}
+
+function claudeRefreshResponse(
+  accessToken: string,
+  refreshToken: string,
+  accountUuid: string,
+): Response {
+  return Response.json({
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    expires_in: 3_600,
+    account: { uuid: accountUuid },
+  });
+}
+
+function successfulClaudeRefresh(onRefresh: () => void): typeof fetch {
+  return async (url) => {
+    assert.equal(String(url), CLAUDE_TOKEN_ENDPOINT);
+    onRefresh();
+    return claudeRefreshResponse('access-v2', 'refresh-v2', 'account-v2');
+  };
+}
+
+async function withPublishedSyncFailure(
+  root: string,
+  failingCall: number,
+  run: () => Promise<void>,
+): Promise<void> {
+  const probe = await open(root, 'r');
+  const prototype = Object.getPrototypeOf(probe) as { sync: typeof probe.sync };
+  const originalSync = prototype.sync;
+  await probe.close();
+  let syncCalls = 0;
+  const syncMock = mock.method(prototype, 'sync', async function (this: typeof probe) {
+    syncCalls += 1;
+    if (syncCalls === failingCall) throw new Error('injected published OAuth commit failure');
+    return originalSync.call(this);
+  });
+  try {
+    await run();
+    assert.equal(syncCalls, failingCall);
+  } finally {
+    syncMock.mock.restore();
+  }
+}
+
+function isOAuthError(code: OAuthExecutionCredentialError['code']): (error: unknown) => boolean {
+  return (error) => error instanceof OAuthExecutionCredentialError && error.code === code;
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+function claudeIdentity(body: Record<string, unknown> | undefined): Record<string, unknown> {
+  assert.ok(body);
+  const metadata = body.metadata as { user_id?: unknown } | undefined;
+  if (!metadata || typeof metadata.user_id !== 'string') {
+    throw new Error('Claude cloak metadata did not contain a user identity');
+  }
+  return JSON.parse(metadata.user_id) as Record<string, unknown>;
+}
+
+function codexAccessToken(accountId: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ 'https://api.openai.com/auth': { chatgpt_account_id: accountId } }),
+  ).toString('base64url');
+  return `header.${payload}.signature`;
+}
+
+const unexpectedFetch: typeof fetch = async () => {
+  throw new Error('GitHub Copilot credential refresh must not perform provider I/O');
+};

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -34,6 +34,7 @@ import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './ho
 import { HostInteractionCoordinator } from './interaction-coordinator.js';
 import { HostMemoryCoordinator } from './memory-coordinator.js';
 import { type HostMessageRootPort, HostMessageCoordinator } from './message-coordinator.js';
+import { HostOAuthExecutionAuthority } from './oauth-execution-authority.js';
 import type { DomainOperationHandlerMap } from './operation-dispatcher.js';
 import { RootAdmissionOwner } from './root-admission-owner.js';
 import { RootTurnCoordinator } from './root-turn-coordinator.js';
@@ -64,6 +65,7 @@ export async function createExecutionRuntimeHostComposition(
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,
     );
+    const oauthCredentials = new HostOAuthExecutionAuthority(runtimePolicyStores);
     const memoryStore = await openInteractiveMemoryBundleStoreForWrite(context.owner.lease);
     taskLedgerStore = await openInteractiveTaskLedgerStoreForWrite(context.owner.lease);
     const openedArtifactStore = await openInteractiveArtifactStoreForWrite(context.owner.lease);
@@ -207,6 +209,8 @@ export async function createExecutionRuntimeHostComposition(
       createHostAiSdkBackend({
         context: backendContext,
         runtimePolicy: runtimePolicyStores,
+        oauthCredentials,
+        claudeDeviceId: context.owner.capability.rootId,
         skills,
         memory: requireMemory(memory),
         taskLedger,

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -37,6 +37,7 @@ import {
   type BuildBuiltinToolsOptions,
   type MakaTool,
   type ProxiedFetchProxy,
+  type ProxiedFetchTransport,
   type RuntimeCommitSink,
   type ScannedSkill,
   type SkillCatalogBudgetOptions,
@@ -200,12 +201,20 @@ export interface HostAiSdkBackendInput {
   readonly clientCapabilities: HostClientCapabilityCoordinator;
   readonly runtimeCommitSink?: RuntimeCommitSink;
   readonly builtinTools?: BuildBuiltinToolsOptions;
+  readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
 }
 
 /** Builds one real provider backend from canonical Host state. */
 export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Promise<AiSdkBackend> {
+  const createFetchTransport = input.createFetchTransport ?? createProxiedFetchTransport;
   const target = await readDuringBackendCreation(
-    () => resolveExecutionTarget(input.context.header, input.runtimePolicy, input.oauthCredentials),
+    () =>
+      resolveExecutionTarget(
+        input.context.header,
+        input.runtimePolicy,
+        input.oauthCredentials,
+        createFetchTransport,
+      ),
     input.context.abortSignal,
   );
   const pricingSnapshot = await readDuringBackendCreation(
@@ -213,16 +222,14 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
     input.context.abortSignal,
   );
   const pricing = buildPricingLookup(pricingSnapshot.overrides);
-  const transport = createProxiedFetchTransport(
-    toProxySettings(target.networkProxy, target.proxySecret),
-  );
+  const transport = createFetchTransport(toProxySettings(target.networkProxy, target.proxySecret));
   let apiKey = target.apiKey;
   let modelFetch: typeof fetch = transport.fetch;
   const oauthBinding = target.oauthBinding;
   if (oauthBinding) {
     try {
       const initialOAuthTokens = await readDuringBackendCreation(
-        () => oauthBinding.resolve(transport.fetch),
+        () => oauthBinding.resolve(),
         input.context.abortSignal,
       );
       apiKey = initialOAuthTokens.access_token;
@@ -523,6 +530,7 @@ async function resolveExecutionTarget(
   header: BackendFactoryContext['header'],
   runtimePolicy: RuntimePolicyStoresWriter,
   oauthCredentials: HostOAuthExecutionAuthority,
+  createFetchTransport: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport,
 ): Promise<ResolvedExecutionTarget> {
   const resolved = await runtimePolicy.operations.resolveExecutionConnection(
     header.llmConnectionSlug,
@@ -553,6 +561,10 @@ async function resolveExecutionTarget(
   if (provider.authKind === 'oauth_token') {
     const material = resolved.secretMaterial.connection;
     if (!material) throw new Error('Runtime Host OAuth credential is not configured');
+    const refreshProxy = toProxySettings(
+      resolved.networkProxy,
+      resolved.secretMaterial.networkProxy?.secret,
+    );
     return {
       connection,
       model,
@@ -561,6 +573,7 @@ async function resolveExecutionTarget(
         providerType: resolved.connection.providerType,
         connectionSlug: resolved.connection.slug,
         material,
+        createRefreshTransport: () => createFetchTransport(refreshProxy),
       }),
       networkProxy: resolved.networkProxy,
       ...(resolved.secretMaterial.networkProxy

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -60,6 +60,11 @@ import type {
   ClientCapabilitySnapshot,
   HostClientCapabilityCoordinator,
 } from './client-capability-coordinator.js';
+import {
+  createHostOAuthModelFetch,
+  type HostOAuthExecutionAuthority,
+  type HostOAuthExecutionBinding,
+} from './oauth-execution-authority.js';
 
 const CHILD_INSTRUCTION_BOUNDARY = [
   'A child agent inherits the current session permission, privacy, workspace, and skill constraints.',
@@ -184,6 +189,8 @@ export function createHostExecutionModelComposition(
 export interface HostAiSdkBackendInput {
   readonly context: BackendFactoryContext;
   readonly runtimePolicy: RuntimePolicyStoresWriter;
+  readonly oauthCredentials: HostOAuthExecutionAuthority;
+  readonly claudeDeviceId: string;
   readonly skills: HostSkillCatalogCoordinator;
   readonly memory: HostMemoryCoordinator;
   readonly taskLedger: TaskLedgerStore;
@@ -198,7 +205,7 @@ export interface HostAiSdkBackendInput {
 /** Builds one real provider backend from canonical Host state. */
 export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Promise<AiSdkBackend> {
   const target = await readDuringBackendCreation(
-    () => resolveExecutionTarget(input.context.header, input.runtimePolicy),
+    () => resolveExecutionTarget(input.context.header, input.runtimePolicy, input.oauthCredentials),
     input.context.abortSignal,
   );
   const pricingSnapshot = await readDuringBackendCreation(
@@ -209,6 +216,30 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
   const transport = createProxiedFetchTransport(
     toProxySettings(target.networkProxy, target.proxySecret),
   );
+  let apiKey = target.apiKey;
+  let modelFetch: typeof fetch = transport.fetch;
+  const oauthBinding = target.oauthBinding;
+  if (oauthBinding) {
+    try {
+      const initialOAuthTokens = await readDuringBackendCreation(
+        () => oauthBinding.resolve(transport.fetch),
+        input.context.abortSignal,
+      );
+      apiKey = initialOAuthTokens.access_token;
+      modelFetch = createHostOAuthModelFetch({
+        binding: oauthBinding,
+        initialTokens: initialOAuthTokens,
+        connection: target.connection,
+        sessionId: input.context.sessionId,
+        modelId: target.model,
+        claudeDeviceId: input.claudeDeviceId,
+        fetchFn: transport.fetch,
+      });
+    } catch (error) {
+      await transport.close();
+      throw error;
+    }
+  }
   const providerOptions = buildProviderOptions(
     target.connection,
     target.model,
@@ -242,7 +273,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
   }
   const modelFactory = (
     modelInput: Parameters<typeof getAIModel>[0],
-  ): ReturnType<typeof getAIModel> => getAIModel({ ...modelInput, fetch: transport.fetch });
+  ): ReturnType<typeof getAIModel> => getAIModel({ ...modelInput, fetch: modelFetch });
   let telemetryDrainRequested = false;
   const persistTelemetry = async (operation: () => Promise<void>): Promise<void> => {
     try {
@@ -315,7 +346,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
             }
           : {}),
         connection: target.connection,
-        apiKey: target.apiKey,
+        apiKey,
         modelId: target.model,
         modelFactory,
         tools: [...modelComposition.tools],
@@ -339,7 +370,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
           resolveModel: () =>
             modelFactory({
               connection: target.connection,
-              apiKey: target.apiKey,
+              apiKey,
               modelId: target.model,
             }),
           providerOptions,
@@ -483,6 +514,7 @@ interface ResolvedExecutionTarget {
   readonly connection: RuntimeExecutionConnection;
   readonly model: string;
   readonly apiKey: string;
+  readonly oauthBinding?: HostOAuthExecutionBinding;
   readonly networkProxy: RuntimePolicy['networkProxy'];
   readonly proxySecret?: string;
 }
@@ -490,6 +522,7 @@ interface ResolvedExecutionTarget {
 async function resolveExecutionTarget(
   header: BackendFactoryContext['header'],
   runtimePolicy: RuntimePolicyStoresWriter,
+  oauthCredentials: HostOAuthExecutionAuthority,
 ): Promise<ResolvedExecutionTarget> {
   const resolved = await runtimePolicy.operations.resolveExecutionConnection(
     header.llmConnectionSlug,
@@ -501,10 +534,6 @@ async function resolveExecutionTarget(
   if (!provider || provider.runtimeAdapter.kind === 'unavailable') {
     throw new Error('Runtime Host model provider is not executable');
   }
-  if (provider.authKind === 'oauth_token') {
-    throw new Error('Runtime Host OAuth execution authority is not available');
-  }
-
   const model = header.model.trim();
   const modelInfo = resolved.connection.models.find((candidate) => candidate.id === model);
   if (!model || !resolved.connection.enabledModelIds.includes(model) || !modelInfo) {
@@ -514,14 +543,34 @@ async function resolveExecutionTarget(
     throw new Error('Runtime Host Session model is not chat-capable');
   }
 
+  const connection: RuntimeExecutionConnection = {
+    slug: resolved.connection.slug,
+    providerType: resolved.connection.providerType,
+    ...(resolved.connection.baseUrl ? { baseUrl: resolved.connection.baseUrl } : {}),
+    defaultModel: model,
+    models: [...resolved.connection.models],
+  };
+  if (provider.authKind === 'oauth_token') {
+    const material = resolved.secretMaterial.connection;
+    if (!material) throw new Error('Runtime Host OAuth credential is not configured');
+    return {
+      connection,
+      model,
+      apiKey: '',
+      oauthBinding: oauthCredentials.bind({
+        providerType: resolved.connection.providerType,
+        connectionSlug: resolved.connection.slug,
+        material,
+      }),
+      networkProxy: resolved.networkProxy,
+      ...(resolved.secretMaterial.networkProxy
+        ? { proxySecret: resolved.secretMaterial.networkProxy.secret }
+        : {}),
+    };
+  }
+
   return {
-    connection: {
-      slug: resolved.connection.slug,
-      providerType: resolved.connection.providerType,
-      ...(resolved.connection.baseUrl ? { baseUrl: resolved.connection.baseUrl } : {}),
-      defaultModel: model,
-      models: [...resolved.connection.models],
-    },
+    connection,
     model,
     apiKey: resolved.secretMaterial.connection?.secret ?? '',
     networkProxy: resolved.networkProxy,

--- a/packages/runtime-host/src/server/oauth-execution-authority.ts
+++ b/packages/runtime-host/src/server/oauth-execution-authority.ts
@@ -8,6 +8,7 @@ import {
   type OAuthSubscriptionCredentialStore,
   type OAuthSubscriptionProvider,
   type OAuthSubscriptionTokens,
+  type ProxiedFetchTransport,
 } from '@maka/runtime';
 import {
   authenticateRuntimePolicyStoresWriter,
@@ -44,7 +45,6 @@ interface CredentialState {
   readonly credentialId: string;
   revision: number;
   raw: string;
-  superseded: boolean;
   uncertainCommit?: CredentialCommitCandidate;
   resolving?: Promise<OAuthSubscriptionTokens>;
 }
@@ -58,7 +58,7 @@ interface CredentialCommitCandidate {
 export interface HostOAuthExecutionBinding {
   readonly providerType: OAuthSubscriptionProvider;
   readonly connectionSlug: string;
-  resolve(fetchFn?: typeof fetch): Promise<OAuthSubscriptionTokens>;
+  resolve(): Promise<OAuthSubscriptionTokens>;
 }
 
 /** Host-local generation binding over the canonical Runtime Policy OAuth credential. */
@@ -76,6 +76,7 @@ export class HostOAuthExecutionAuthority {
     providerType: RuntimeExecutionConnection['providerType'];
     connectionSlug: string;
     material: RuntimePolicyCredentialMaterial;
+    createRefreshTransport: () => ProxiedFetchTransport;
   }): HostOAuthExecutionBinding {
     if (!isOAuthSubscriptionProvider(input.providerType)) {
       throw new OAuthExecutionCredentialError(
@@ -123,7 +124,6 @@ export class HostOAuthExecutionAuthority {
         credentialId: input.material.credentialId,
         revision: input.material.revision,
         raw: input.material.secret,
-        superseded: false,
       };
       this.#states.set(state.locator.connectionId, state);
     }
@@ -132,13 +132,17 @@ export class HostOAuthExecutionAuthority {
     return Object.freeze({
       providerType: bound.providerType,
       connectionSlug: bound.connectionSlug,
-      resolve: (fetchFn?: typeof fetch) => this.#resolve(bound, fetchFn),
+      resolve: () => this.#resolve(bound, input.createRefreshTransport),
     });
   }
 
-  async #resolve(state: CredentialState, fetchFn?: typeof fetch): Promise<OAuthSubscriptionTokens> {
+  async #resolve(
+    state: CredentialState,
+    createRefreshTransport: () => ProxiedFetchTransport,
+  ): Promise<OAuthSubscriptionTokens> {
+    this.#assertCurrent(state);
     if (state.resolving) return state.resolving;
-    const resolving = this.#resolveUnshared(state, fetchFn);
+    const resolving = this.#resolveUnshared(state, createRefreshTransport);
     state.resolving = resolving;
     try {
       return await resolving;
@@ -149,31 +153,39 @@ export class HostOAuthExecutionAuthority {
 
   async #resolveUnshared(
     state: CredentialState,
-    fetchFn?: typeof fetch,
+    createRefreshTransport: () => ProxiedFetchTransport,
   ): Promise<OAuthSubscriptionTokens> {
-    if (state.superseded) throw supersededError();
     await this.#reconcileUncertainCommit(state);
     const credentialStore = this.#credentialStore(state);
-    const result = await resolveAndPersistOAuthSubscriptionTokens({
-      providerType: state.providerType,
-      slug: state.connectionSlug,
-      credentialStore,
-      now: this.#now,
-      ...(fetchFn ? { fetchFn } : {}),
-    });
+    let refreshTransport: ProxiedFetchTransport | undefined;
+    let result;
+    try {
+      result = await resolveAndPersistOAuthSubscriptionTokens({
+        providerType: state.providerType,
+        slug: state.connectionSlug,
+        credentialStore,
+        now: this.#now,
+        fetchFn: async (url, init) => {
+          if (!this.#isCurrent(state)) throw new OAuthCredentialSupersededError();
+          refreshTransport ??= createRefreshTransport();
+          return refreshTransport.fetch(url, init);
+        },
+      });
+    } finally {
+      await refreshTransport?.close();
+    }
+    this.#assertCurrent(state);
     switch (result.outcome) {
       case 'current':
       case 'refreshed':
         return result.tokens;
       case 'superseded':
-        state.superseded = true;
+        this.#invalidate(state);
         throw supersededError();
       case 'logged-out':
         throw new OAuthExecutionCredentialError(
-          state.superseded ? 'credential_superseded' : 'credential_unavailable',
-          state.superseded
-            ? 'OAuth credential changed during backend execution'
-            : 'OAuth credential is no longer configured',
+          'credential_unavailable',
+          'OAuth credential is no longer configured',
         );
       case 'refresh-failed':
         throw new OAuthExecutionCredentialError(
@@ -207,6 +219,7 @@ export class HostOAuthExecutionAuthority {
         { cause: error },
       );
     }
+    this.#assertCurrent(state);
     const material = resolved.kind === 'ready' ? resolved.secretMaterial.connection : undefined;
     if (
       material &&
@@ -222,7 +235,7 @@ export class HostOAuthExecutionAuthority {
     }
 
     state.uncertainCommit = undefined;
-    state.superseded = true;
+    this.#invalidate(state);
     throw supersededError();
   }
 
@@ -230,12 +243,12 @@ export class HostOAuthExecutionAuthority {
     return {
       getSecret: async (slug, kind) => {
         assertBoundRequest(state, slug, kind);
-        if (state.superseded) throw new OAuthCredentialSupersededError();
+        if (!this.#isCurrent(state)) throw new OAuthCredentialSupersededError();
         return state.raw;
       },
       compareAndSetSecret: async (slug, kind, expected, value) => {
         assertBoundRequest(state, slug, kind);
-        if (state.superseded) throw new OAuthCredentialSupersededError();
+        if (!this.#isCurrent(state)) throw new OAuthCredentialSupersededError();
         if (expected !== state.raw) return { committed: false, current: state.raw };
         let committed;
         try {
@@ -248,6 +261,7 @@ export class HostOAuthExecutionAuthority {
             secret: value,
           });
         } catch (error) {
+          if (!this.#isCurrent(state)) throw new OAuthCredentialSupersededError();
           if (error instanceof RuntimePolicyStoreError && error.code === 'commit_outcome_unknown') {
             state.uncertainCommit = {
               credentialId: state.credentialId,
@@ -258,14 +272,27 @@ export class HostOAuthExecutionAuthority {
           throw error;
         }
         if (committed.kind !== 'committed') {
-          state.superseded = true;
+          this.#invalidate(state);
           throw new OAuthCredentialSupersededError();
         }
+        if (!this.#isCurrent(state)) throw new OAuthCredentialSupersededError();
         state.revision = committed.revision;
         state.raw = value;
         return { committed: true };
       },
     };
+  }
+
+  #isCurrent(state: CredentialState): boolean {
+    return this.#states.get(state.locator.connectionId) === state;
+  }
+
+  #assertCurrent(state: CredentialState): void {
+    if (!this.#isCurrent(state)) throw supersededError();
+  }
+
+  #invalidate(state: CredentialState): void {
+    if (this.#isCurrent(state)) this.#states.delete(state.locator.connectionId);
   }
 }
 
@@ -290,7 +317,7 @@ export function createHostOAuthModelFetch(input: {
   return async (url, init) => {
     const signal = effectiveRequestSignal(url, init);
     signal?.throwIfAborted();
-    const tokens = await waitForCaller(input.binding.resolve(input.fetchFn), signal);
+    const tokens = await waitForCaller(input.binding.resolve(), signal);
     signal?.throwIfAborted();
     const authenticatedFetch = authenticatedOAuthFetch(input, tokens);
     const subscriptionFetch = buildSubscriptionModelFetch({

--- a/packages/runtime-host/src/server/oauth-execution-authority.ts
+++ b/packages/runtime-host/src/server/oauth-execution-authority.ts
@@ -1,0 +1,409 @@
+import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
+import type { CredentialLocator } from '@maka/core/runtime-policy';
+import {
+  buildSubscriptionModelFetch,
+  isOAuthSubscriptionProvider,
+  openAiCodexHeaders,
+  resolveAndPersistOAuthSubscriptionTokens,
+  type OAuthSubscriptionCredentialStore,
+  type OAuthSubscriptionProvider,
+  type OAuthSubscriptionTokens,
+} from '@maka/runtime';
+import {
+  authenticateRuntimePolicyStoresWriter,
+  RuntimePolicyStoreError,
+  type RuntimePolicyCredentialMaterial,
+  type RuntimePolicyStoresWriter,
+} from '@maka/storage/runtime-policy-stores';
+
+export type OAuthExecutionCredentialErrorCode =
+  | 'credential_unavailable'
+  | 'credential_superseded'
+  | 'refresh_failed'
+  | 'persistence_failed';
+
+type OAuthCredentialLocator = Extract<CredentialLocator, { scope: 'connection' }> & {
+  readonly kind: 'oauth_token';
+};
+
+export class OAuthExecutionCredentialError extends Error {
+  constructor(
+    readonly code: OAuthExecutionCredentialErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'OAuthExecutionCredentialError';
+  }
+}
+
+interface CredentialState {
+  readonly providerType: OAuthSubscriptionProvider;
+  readonly connectionSlug: string;
+  readonly locator: OAuthCredentialLocator;
+  readonly credentialId: string;
+  revision: number;
+  raw: string;
+  superseded: boolean;
+  uncertainCommit?: CredentialCommitCandidate;
+  resolving?: Promise<OAuthSubscriptionTokens>;
+}
+
+interface CredentialCommitCandidate {
+  readonly credentialId: string;
+  readonly revision: number;
+  readonly raw: string;
+}
+
+export interface HostOAuthExecutionBinding {
+  readonly providerType: OAuthSubscriptionProvider;
+  readonly connectionSlug: string;
+  resolve(fetchFn?: typeof fetch): Promise<OAuthSubscriptionTokens>;
+}
+
+/** Host-local generation binding over the canonical Runtime Policy OAuth credential. */
+export class HostOAuthExecutionAuthority {
+  readonly #stores: RuntimePolicyStoresWriter;
+  readonly #states = new Map<string, CredentialState>();
+  readonly #now: () => number;
+
+  constructor(stores: RuntimePolicyStoresWriter, now: () => number = Date.now) {
+    this.#stores = authenticateRuntimePolicyStoresWriter(stores);
+    this.#now = now;
+  }
+
+  bind(input: {
+    providerType: RuntimeExecutionConnection['providerType'];
+    connectionSlug: string;
+    material: RuntimePolicyCredentialMaterial;
+  }): HostOAuthExecutionBinding {
+    if (!isOAuthSubscriptionProvider(input.providerType)) {
+      throw new OAuthExecutionCredentialError(
+        'credential_unavailable',
+        `OAuth execution is not available for provider ${input.providerType}`,
+      );
+    }
+    const locator = requireOAuthLocator(input.material.locator);
+    let state = this.#states.get(locator.connectionId);
+    if (state) {
+      if (
+        state.providerType !== input.providerType ||
+        state.connectionSlug !== input.connectionSlug ||
+        !sameLocator(state.locator, locator)
+      ) {
+        throw new OAuthExecutionCredentialError(
+          'persistence_failed',
+          'Canonical OAuth credential identity was reused for a different connection',
+        );
+      }
+      const candidate = state.uncertainCommit;
+      if (
+        candidate &&
+        candidate.credentialId === input.material.credentialId &&
+        candidate.revision === input.material.revision &&
+        candidate.raw === input.material.secret
+      ) {
+        state.revision = candidate.revision;
+        state.raw = candidate.raw;
+        state.uncertainCommit = undefined;
+      }
+      if (
+        state.credentialId !== input.material.credentialId ||
+        state.revision !== input.material.revision ||
+        state.raw !== input.material.secret
+      ) {
+        state = undefined;
+      }
+    }
+    if (!state) {
+      state = {
+        providerType: input.providerType,
+        connectionSlug: input.connectionSlug,
+        locator,
+        credentialId: input.material.credentialId,
+        revision: input.material.revision,
+        raw: input.material.secret,
+        superseded: false,
+      };
+      this.#states.set(state.locator.connectionId, state);
+    }
+
+    const bound = state;
+    return Object.freeze({
+      providerType: bound.providerType,
+      connectionSlug: bound.connectionSlug,
+      resolve: (fetchFn?: typeof fetch) => this.#resolve(bound, fetchFn),
+    });
+  }
+
+  async #resolve(state: CredentialState, fetchFn?: typeof fetch): Promise<OAuthSubscriptionTokens> {
+    if (state.resolving) return state.resolving;
+    const resolving = this.#resolveUnshared(state, fetchFn);
+    state.resolving = resolving;
+    try {
+      return await resolving;
+    } finally {
+      if (state.resolving === resolving) state.resolving = undefined;
+    }
+  }
+
+  async #resolveUnshared(
+    state: CredentialState,
+    fetchFn?: typeof fetch,
+  ): Promise<OAuthSubscriptionTokens> {
+    if (state.superseded) throw supersededError();
+    await this.#reconcileUncertainCommit(state);
+    const credentialStore = this.#credentialStore(state);
+    const result = await resolveAndPersistOAuthSubscriptionTokens({
+      providerType: state.providerType,
+      slug: state.connectionSlug,
+      credentialStore,
+      now: this.#now,
+      ...(fetchFn ? { fetchFn } : {}),
+    });
+    switch (result.outcome) {
+      case 'current':
+      case 'refreshed':
+        return result.tokens;
+      case 'superseded':
+        state.superseded = true;
+        throw supersededError();
+      case 'logged-out':
+        throw new OAuthExecutionCredentialError(
+          state.superseded ? 'credential_superseded' : 'credential_unavailable',
+          state.superseded
+            ? 'OAuth credential changed during backend execution'
+            : 'OAuth credential is no longer configured',
+        );
+      case 'refresh-failed':
+        throw new OAuthExecutionCredentialError(
+          'refresh_failed',
+          'OAuth credential refresh failed',
+          { cause: result.error },
+        );
+      case 'storage-failed':
+        if (result.error instanceof OAuthCredentialSupersededError) {
+          throw supersededError(result.error);
+        }
+        throw new OAuthExecutionCredentialError(
+          'persistence_failed',
+          'OAuth credential persistence failed',
+          { cause: result.error },
+        );
+    }
+  }
+
+  async #reconcileUncertainCommit(state: CredentialState): Promise<void> {
+    const candidate = state.uncertainCommit;
+    if (!candidate) return;
+
+    let resolved;
+    try {
+      resolved = await this.#stores.operations.resolveExecutionConnection(state.connectionSlug);
+    } catch (error) {
+      throw new OAuthExecutionCredentialError(
+        'persistence_failed',
+        'Canonical OAuth credential could not be reconciled',
+        { cause: error },
+      );
+    }
+    const material = resolved.kind === 'ready' ? resolved.secretMaterial.connection : undefined;
+    if (
+      material &&
+      material.credentialId === candidate.credentialId &&
+      material.revision === candidate.revision &&
+      material.secret === candidate.raw &&
+      sameLocator(material.locator, state.locator)
+    ) {
+      state.revision = candidate.revision;
+      state.raw = candidate.raw;
+      state.uncertainCommit = undefined;
+      return;
+    }
+
+    state.uncertainCommit = undefined;
+    state.superseded = true;
+    throw supersededError();
+  }
+
+  #credentialStore(state: CredentialState): OAuthSubscriptionCredentialStore {
+    return {
+      getSecret: async (slug, kind) => {
+        assertBoundRequest(state, slug, kind);
+        if (state.superseded) throw new OAuthCredentialSupersededError();
+        return state.raw;
+      },
+      compareAndSetSecret: async (slug, kind, expected, value) => {
+        assertBoundRequest(state, slug, kind);
+        if (state.superseded) throw new OAuthCredentialSupersededError();
+        if (expected !== state.raw) return { committed: false, current: state.raw };
+        let committed;
+        try {
+          committed = await this.#stores.operations.compareAndSetOAuthCredential({
+            locator: state.locator,
+            expected: {
+              credentialId: state.credentialId,
+              revision: state.revision,
+            },
+            secret: value,
+          });
+        } catch (error) {
+          if (error instanceof RuntimePolicyStoreError && error.code === 'commit_outcome_unknown') {
+            state.uncertainCommit = {
+              credentialId: state.credentialId,
+              revision: state.revision + 1,
+              raw: value,
+            };
+          }
+          throw error;
+        }
+        if (committed.kind !== 'committed') {
+          state.superseded = true;
+          throw new OAuthCredentialSupersededError();
+        }
+        state.revision = committed.revision;
+        state.raw = value;
+        return { committed: true };
+      },
+    };
+  }
+}
+
+export function createHostOAuthModelFetch(input: {
+  binding: HostOAuthExecutionBinding;
+  initialTokens: OAuthSubscriptionTokens;
+  connection: RuntimeExecutionConnection;
+  sessionId: string;
+  modelId: string;
+  claudeDeviceId: string;
+  fetchFn: typeof fetch;
+}): typeof fetch {
+  if (
+    input.binding.providerType === 'claude-subscription' &&
+    !input.initialTokens.account_uuid?.trim()
+  ) {
+    throw new OAuthExecutionCredentialError(
+      'credential_unavailable',
+      'Claude OAuth credential is missing its canonical account identity',
+    );
+  }
+  return async (url, init) => {
+    const signal = effectiveRequestSignal(url, init);
+    signal?.throwIfAborted();
+    const tokens = await waitForCaller(input.binding.resolve(input.fetchFn), signal);
+    signal?.throwIfAborted();
+    const authenticatedFetch = authenticatedOAuthFetch(input, tokens);
+    const subscriptionFetch = buildSubscriptionModelFetch({
+      connection: input.connection,
+      sessionId: input.sessionId,
+      modelId: input.modelId,
+      fetchFn: authenticatedFetch,
+      ...(input.binding.providerType === 'claude-subscription'
+        ? {
+            claude: {
+              deviceId: input.claudeDeviceId,
+              accountUuid: tokens.account_uuid ?? '',
+            },
+          }
+        : {}),
+    });
+    return (subscriptionFetch ?? authenticatedFetch)(url, init);
+  };
+}
+
+function effectiveRequestSignal(
+  url: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1],
+): AbortSignal | null | undefined {
+  return init?.signal !== undefined ? init.signal : url instanceof Request ? url.signal : undefined;
+}
+
+async function waitForCaller<T>(pending: Promise<T>, signal?: AbortSignal | null): Promise<T> {
+  if (!signal) return pending;
+  signal.throwIfAborted();
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(signal.reason ?? new DOMException('Request aborted', 'AbortError'));
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+  try {
+    return await Promise.race([pending, aborted]);
+  } finally {
+    if (onAbort) signal.removeEventListener('abort', onAbort);
+  }
+}
+
+function authenticatedOAuthFetch(
+  input: Pick<Parameters<typeof createHostOAuthModelFetch>[0], 'binding' | 'fetchFn'>,
+  tokens: OAuthSubscriptionTokens,
+): typeof fetch {
+  return async (url, init) => {
+    const headers = mergedHeaders(url, init?.headers);
+    headers.delete('api-key');
+    headers.delete('x-api-key');
+    headers.set('Authorization', `Bearer ${tokens.access_token}`);
+    if (input.binding.providerType === 'openai-codex') {
+      headers.delete('ChatGPT-Account-Id');
+      for (const [name, value] of Object.entries(openAiCodexHeaders(tokens.access_token))) {
+        headers.set(name, value);
+      }
+    }
+    return input.fetchFn(url, { ...init, headers });
+  };
+}
+
+class OAuthCredentialSupersededError extends Error {
+  constructor() {
+    super('OAuth credential generation is no longer canonical');
+    this.name = 'OAuthCredentialSupersededError';
+  }
+}
+
+function requireOAuthLocator(locator: CredentialLocator): OAuthCredentialLocator {
+  if (locator.scope !== 'connection' || locator.kind !== 'oauth_token') {
+    throw new OAuthExecutionCredentialError(
+      'persistence_failed',
+      'Canonical OAuth credential material has an invalid locator',
+    );
+  }
+  return {
+    scope: 'connection',
+    connectionId: locator.connectionId,
+    kind: 'oauth_token',
+  };
+}
+
+function assertBoundRequest(state: CredentialState, slug: string, kind: 'oauth_token'): void {
+  if (slug !== state.connectionSlug || kind !== 'oauth_token') {
+    throw new OAuthExecutionCredentialError(
+      'persistence_failed',
+      'OAuth credential resolver escaped its bound connection',
+    );
+  }
+}
+
+function sameLocator(left: CredentialLocator, right: CredentialLocator): boolean {
+  return (
+    left.scope === 'connection' &&
+    right.scope === 'connection' &&
+    left.connectionId === right.connectionId &&
+    left.kind === right.kind
+  );
+}
+
+function mergedHeaders(
+  url: Parameters<typeof fetch>[0],
+  override: HeadersInit | undefined,
+): Headers {
+  const headers = new Headers(url instanceof Request ? url.headers : undefined);
+  new Headers(override).forEach((value, name) => headers.set(name, value));
+  return headers;
+}
+
+function supersededError(cause?: unknown): OAuthExecutionCredentialError {
+  return new OAuthExecutionCredentialError(
+    'credential_superseded',
+    'OAuth credential changed during backend execution',
+    cause === undefined ? undefined : { cause },
+  );
+}

--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -439,6 +439,83 @@ describe('runtime policy stores', () => {
     });
   });
 
+  test('refreshes only the matching OAuth credential generation without invalidating verification', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('oauth-refresh', 'github-copilot', 'OAuth refresh'),
+      );
+      const locator = connectionCredential(connection, 'oauth_token');
+      const originalSecret = JSON.stringify({
+        access_token: 'github-access-v1',
+        refresh_token: 'github-refresh-v1',
+        expires_at: 1,
+      });
+      const configured = await stores.credentialVault.set({
+        locator,
+        expected: null,
+        secret: originalSecret,
+      });
+      assert.equal(configured.kind, 'committed');
+      if (configured.kind !== 'committed') return;
+      await verifyConnection(stores, connection.connectionId, '2026-08-01T00:00:00.000Z');
+      const status = await getCredentialStatus(stores.credentialVault, locator);
+      const initialRevision = credentialBasis(status).revision;
+      const replacementSecret = JSON.stringify({
+        access_token: 'github-access-v2',
+        refresh_token: 'github-refresh-v2',
+        expires_at: Number.MAX_SAFE_INTEGER,
+      });
+
+      const refreshed = await stores.operations.compareAndSetOAuthCredential({
+        locator: { ...locator, kind: 'oauth_token' },
+        expected: credentialExpectation(status),
+        secret: replacementSecret,
+      });
+
+      assert.equal(refreshed.kind, 'committed');
+      if (refreshed.kind !== 'committed') return;
+      assert.equal(refreshed.credentialId, credentialBasis(status).credentialId);
+      assert.equal(refreshed.revision, initialRevision + 1);
+      const refreshedStatus = await getCredentialStatus(stores.credentialVault, locator);
+      assert.equal(credentialBasis(refreshedStatus).revision, initialRevision + 1);
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest?.status,
+        'verified',
+      );
+      const resolved = await stores.operations.resolveExecutionConnection(connection.slug);
+      assert.equal(resolved.kind, 'ready');
+      if (resolved.kind === 'ready') {
+        assert.equal(resolved.secretMaterial.connection?.secret, replacementSecret);
+      }
+
+      const stale = await stores.operations.compareAndSetOAuthCredential({
+        locator: { ...locator, kind: 'oauth_token' },
+        expected: credentialExpectation(status),
+        secret: 'stale-refresh-must-not-commit',
+      });
+      assert.equal(stale.kind, 'superseded');
+      const stillResolved = await stores.operations.resolveExecutionConnection(connection.slug);
+      assert.equal(stillResolved.kind, 'ready');
+      if (stillResolved.kind === 'ready') {
+        assert.equal(stillResolved.secretMaterial.connection?.secret, replacementSecret);
+      }
+
+      const deleted = await stores.credentialVault.delete({
+        expected: credentialBasis(refreshedStatus),
+      });
+      assert.equal(deleted.kind, 'committed');
+      const resurrection = await stores.operations.compareAndSetOAuthCredential({
+        locator: { ...locator, kind: 'oauth_token' },
+        expected: credentialExpectation(refreshedStatus),
+        secret: 'refresh-must-not-recreate-a-deleted-credential',
+      });
+      assert.equal(resurrection.kind, 'superseded');
+      assert.equal((await getCredentialStatus(stores.credentialVault, locator)).configured, false);
+    });
+  });
+
   test('conditionally commits discovery and test facts from the latest admitted state with one-shot tickets', async () => {
     await withInteractiveOwner(async ({ stores }) => {
       const connection = await createConnection(

--- a/packages/storage/src/runtime-policy-stores.ts
+++ b/packages/storage/src/runtime-policy-stores.ts
@@ -33,6 +33,8 @@ export {
 export type {
   BeginConnectionTestResult,
   BeginModelFetchResult,
+  CompareAndSetOAuthCredentialInput,
+  CompareAndSetOAuthCredentialResult,
   ConnectionEffectChangedDomain,
   ConnectionEffectCompletionResult,
   ConnectionEffectPreparationFailure,
@@ -196,6 +198,7 @@ function createWriterFacade(coordinator: RuntimePolicyCoordinator): RuntimePolic
     operations: {
       resolveExecutionConnection: (connectionSlug) =>
         coordinator.resolveExecutionConnection(connectionSlug),
+      compareAndSetOAuthCredential: (input) => coordinator.compareAndSetOAuthCredential(input),
       beginModelFetch: (connectionId) => coordinator.beginModelFetch(connectionId),
       completeModelFetch: (ticket, result) => coordinator.completeModelFetch(ticket, result),
       beginConnectionTest: (connectionId, modelId) =>

--- a/packages/storage/src/runtime-policy/coordinator.ts
+++ b/packages/storage/src/runtime-policy/coordinator.ts
@@ -52,6 +52,7 @@ import {
   type CredentialStatusQueryResult,
   type BeginConnectionTestResult,
   type BeginModelFetchResult,
+  type CompareAndSetOAuthCredentialInput,
   type ConnectionEffectChangedDomain,
   type ConnectionEffectCompletionResult,
   type ConnectionTestTicket,
@@ -271,7 +272,11 @@ export class RuntimePolicyCoordinator {
       if (prepared.kind !== 'ready') return prepared;
       const cleared = await this.clearCredentialDependentLastTests(root, locator, catalog);
       try {
-        return await this.vault.commitSet(root, prepared);
+        await this.vault.commitSet(root, prepared);
+        return deepFreeze({
+          kind: 'committed' as const,
+          snapshot: vaultSnapshot(prepared.document),
+        });
       } catch (error) {
         if (cleared) {
           throw commitOutcomeUnknown(
@@ -281,6 +286,39 @@ export class RuntimePolicyCoordinator {
         }
         throw error;
       }
+    });
+  }
+
+  compareAndSetOAuthCredential(rawInput: CompareAndSetOAuthCredentialInput) {
+    return this.inLane(async (root) => {
+      const input = decodeCredentialInput(() => normalizeSetCredentialInput(rawInput));
+      if (
+        input.locator.scope !== 'connection' ||
+        input.locator.kind !== 'oauth_token' ||
+        input.expected === null
+      ) {
+        throw codecError(
+          'invalid_credential_input',
+          'OAuth refresh requires an existing connection OAuth credential generation',
+        );
+      }
+      const catalog = await this.catalog.read(root);
+      const connection = findConnection(catalog, input.locator);
+      if (!connection) return deepFreeze({ kind: 'superseded' as const });
+      if (PROVIDER_DEFAULTS[connection.providerType].authKind !== 'oauth_token') {
+        throw codecError(
+          'invalid_credential_input',
+          'OAuth refresh credential does not match the provider auth contract',
+        );
+      }
+      const prepared = this.vault.prepareSet(await this.vault.read(root), input);
+      if (prepared.kind !== 'ready') return deepFreeze({ kind: 'superseded' as const });
+      await this.vault.commitSet(root, prepared);
+      return deepFreeze({
+        kind: 'committed' as const,
+        credentialId: prepared.entry.credentialId,
+        revision: prepared.entry.revision,
+      });
     });
   }
 

--- a/packages/storage/src/runtime-policy/credential-vault-document.ts
+++ b/packages/storage/src/runtime-policy/credential-vault-document.ts
@@ -46,6 +46,7 @@ export interface CredentialVaultDocument {
 interface PreparedCredentialSet {
   readonly kind: 'ready';
   readonly document: CredentialVaultDocument;
+  readonly entry: CredentialVaultEntry;
 }
 
 interface PreparedCredentialDelete {
@@ -85,7 +86,8 @@ export class CredentialVaultDocumentOwner {
   async set(root: string, rawInput: SetCredentialInput): Promise<CredentialMutationResult> {
     const prepared = this.prepareSet(await this.read(root), rawInput);
     if (prepared.kind !== 'ready') return prepared;
-    return this.commitSet(root, prepared);
+    await this.commitSet(root, prepared);
+    return committed(prepared.document);
   }
 
   prepareSet(
@@ -128,15 +130,11 @@ export class CredentialVaultDocumentOwner {
       entries,
     };
     this.assertDocumentSize(next);
-    return { kind: 'ready', document: next };
+    return { kind: 'ready', document: next, entry };
   }
 
-  async commitSet(
-    root: string,
-    prepared: PreparedCredentialSet,
-  ): Promise<CredentialMutationResult> {
+  async commitSet(root: string, prepared: PreparedCredentialSet): Promise<void> {
     await this.write(root, prepared.document);
-    return committed(prepared.document);
   }
 
   async delete(root: string, rawInput: DeleteCredentialInput): Promise<CredentialMutationResult> {

--- a/packages/storage/src/runtime-policy/operations.ts
+++ b/packages/storage/src/runtime-policy/operations.ts
@@ -29,6 +29,27 @@ export interface RuntimePolicyOperationSecretMaterial {
   readonly networkProxy?: RuntimePolicyCredentialMaterial;
 }
 
+export type OAuthCredentialLocator = Omit<
+  Extract<CredentialLocator, { scope: 'connection' }>,
+  'kind'
+> & {
+  readonly kind: 'oauth_token';
+};
+
+export interface CompareAndSetOAuthCredentialInput {
+  readonly locator: OAuthCredentialLocator;
+  readonly expected: Pick<CredentialVersionBasis, 'credentialId' | 'revision'>;
+  readonly secret: string;
+}
+
+export type CompareAndSetOAuthCredentialResult =
+  | {
+      readonly kind: 'committed';
+      readonly credentialId: string;
+      readonly revision: number;
+    }
+  | { readonly kind: 'superseded' };
+
 export type CredentialStatusQueryResult =
   | { readonly kind: 'status'; readonly status: CredentialStatus }
   | { readonly kind: 'connection_not_found' };
@@ -91,6 +112,9 @@ export type ResolveExecutionConnectionResult =
 
 export interface RuntimePolicyOperationCoordinator {
   resolveExecutionConnection(connectionSlug: string): Promise<ResolveExecutionConnectionResult>;
+  compareAndSetOAuthCredential(
+    input: CompareAndSetOAuthCredentialInput,
+  ): Promise<CompareAndSetOAuthCredentialResult>;
   beginModelFetch(connectionId: string): Promise<BeginModelFetchResult>;
   completeModelFetch(
     ticket: ModelFetchTicket,


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- let Runtime Host activate real model backends from canonical OAuth credentials
- keep token resolution, refresh, and persistence under Host and Runtime Policy authority
- apply the current token snapshot consistently to request authentication and provider account metadata

## Behavior

- current credentials activate without rewriting the Vault
- expired credentials reuse the existing durable refresh lease and persist through an exact-generation CAS
- concurrent backends for one connection share the current credential state and refresh singleflight
- replaced or deleted credentials fail old bindings closed without adopting the new secret
- published-but-unacknowledged claim, finalize, and release transitions reconcile against the exact canonical candidate on the next demand
- request cancellation stops waiting immediately without cancelling a refresh shared by other callers or dispatching a model request
- routine refresh does not clear connection verification or rebuild the backend

## Scope

This slice consumes and refreshes credentials that already exist in the canonical Vault. It does not add OAuth login/enrollment, Client Service support, production client cutover, provider endpoint overrides, or a new Runtime Policy wire operation. Public client-supplied OAuth writes remain limited to GitHub Copilot.

## Validation

- Storage full suite: 924 passed, 1 skipped
- Runtime Host full suite: 445 passed
- Runtime full suite: 2,839 passed, 9 skipped
- root format, lint, build, typecheck, and diff checks

Part of #1167.

</details>

<details>
<summary>中文</summary>

## 概要

- 让 Runtime Host 能从 canonical OAuth credential 激活真实模型 backend
- token 解析、刷新与持久化继续由 Host 和 Runtime Policy authority 负责
- 每次请求的认证信息与 provider account metadata 使用同一份当前 token 快照

## 行为

- 未过期的 credential 可直接激活，不重写 Vault
- 过期 credential 复用现有 durable refresh lease，并通过精确 generation CAS 持久化
- 同一 connection 的并发 backend 共享当前 credential state 与 refresh singleflight
- credential 被替换或删除后，旧 binding 会失败关闭，不采用新 secret
- claim、finalize 或 release 已发布但未确认时，下一次 demand 会与精确 canonical candidate 对账
- 请求取消会立即停止当前 caller 的等待，不取消其他 caller 共享的 refresh，也不会继续发送模型请求
- routine refresh 不清除 connection verification，也不重建 backend

## 范围

本 slice 只消费和刷新 canonical Vault 中已经存在的 credential，不新增 OAuth 登录或 enrollment、Client Service、production client 切换、provider endpoint override，也不新增 Runtime Policy wire operation。公共客户端提交 OAuth credential 的能力仍只开放给 GitHub Copilot。

## 验证

- Storage 完整测试：924 通过，1 跳过
- Runtime Host 完整测试：445 通过
- Runtime 完整测试：2,839 通过，9 跳过
- 根级 format、lint、build、typecheck 与 diff 检查

属于 #1167 的一部分。

</details>
