### PR TITLE
fix(headless): upstream published-run failure semantics from experiment branch

### DIFF
--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -7,7 +7,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { ensureAbRunManifest, readAbRunManifest } from '#ab-manifest';
+import { buildRunManifestFingerprint, ensureAbRunManifest, readAbRunManifest } from '#ab-manifest';
 import {
   discoverCachedHarborTasks,
   fingerprintFixedPromptTaskTree,
@@ -794,6 +794,57 @@ export function buildHarnessAbManifest({
   });
 }
 
+export async function resolveHarnessAbManifestForRun({
+  manifestPath,
+  proposedManifest,
+  retryRoundIds,
+  expectedExistingFingerprint,
+}) {
+  if (!expectedExistingFingerprint) {
+    return ensureAbRunManifest(manifestPath, proposedManifest);
+  }
+  if (retryRoundIds.length === 0) {
+    throw new Error(
+      'MAKA_HARNESS_AB_EXPECTED_EXISTING_MANIFEST_FINGERPRINT requires an explicit adjudicated infra retry',
+    );
+  }
+  const existing = await readAbRunManifest(manifestPath);
+  if (!existing) {
+    throw new Error('explicit adjudicated infra retry requires an existing run manifest');
+  }
+  if (existing.fingerprint !== expectedExistingFingerprint) {
+    throw new Error(
+      `existing run manifest fingerprint does not match MAKA_HARNESS_AB_EXPECTED_EXISTING_MANIFEST_FINGERPRINT: expected ${expectedExistingFingerprint}, found ${existing.fingerprint}`,
+    );
+  }
+  const frozenMakaArm = existing.arms.find((arm) => arm.id === 'maka');
+  if (!frozenMakaArm) throw new Error('existing run manifest is missing the Maka arm');
+  const { fingerprint: _proposedFingerprint, ...proposedBody } = proposedManifest;
+  const normalizedBody = {
+    ...proposedBody,
+    subjectFingerprint: existing.subjectFingerprint,
+    toolchainFingerprint: existing.toolchainFingerprint,
+    arms: proposedBody.arms.map((arm) =>
+      arm.id === 'maka'
+        ? {
+            ...arm,
+            fingerprint: frozenMakaArm.fingerprint,
+            metadata: {
+              ...arm.metadata,
+              version: frozenMakaArm.metadata.version,
+            },
+          }
+        : arm,
+    ),
+  };
+  if (buildRunManifestFingerprint(normalizedBody) !== existing.fingerprint) {
+    throw new Error(
+      'adjudicated infra retry manifest differs beyond the frozen subject and toolchain identity',
+    );
+  }
+  return existing;
+}
+
 export async function main() {
   const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
   const makaRepoPath = process.env.MAKA_HARNESS_AB_MAKA_REPO
@@ -934,7 +985,7 @@ async function runLocked({
     makaNodeToolchainFingerprint:
       benchmarkProfile.executor === 'pier' ? MAKA_NODE_TOOLCHAIN_FINGERPRINT : null,
   });
-  const manifest = buildHarnessAbManifest({
+  const proposedManifest = buildHarnessAbManifest({
     subjectFingerprint,
     taskSourceFingerprint,
     toolchainFingerprint,
@@ -946,7 +997,12 @@ async function runLocked({
     credentialIdentity: credentials.credentialIdentity,
     pierVersion,
   });
-  await ensureAbRunManifest(manifestPath, manifest);
+  const manifest = await resolveHarnessAbManifestForRun({
+    manifestPath,
+    proposedManifest,
+    retryRoundIds: retryAdjudicatedInfraRoundIdsOnce,
+    expectedExistingFingerprint: process.env.MAKA_HARNESS_AB_EXPECTED_EXISTING_MANIFEST_FINGERPRINT,
+  });
   const evaluationTasks = manifest.evaluationTaskIds
     .slice(0, selection.limit)
     .map((taskId) => tasksById.get(taskId));

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -655,6 +655,23 @@ export function resolveHarnessAbTaskSelection(
   return { taskIds: [taskId], limit: 1 };
 }
 
+export function resolveHarnessAdjudicatedInfraRetryRoundIds(raw) {
+  if (raw === undefined) return [];
+  const roundIds = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (roundIds.length === 0) {
+    throw new Error('MAKA_HARNESS_AB_RETRY_ADJUDICATED_INFRA_ROUND_IDS_ONCE must not be empty');
+  }
+  if (new Set(roundIds).size !== roundIds.length) {
+    throw new Error(
+      'MAKA_HARNESS_AB_RETRY_ADJUDICATED_INFRA_ROUND_IDS_ONCE must not contain duplicates',
+    );
+  }
+  return roundIds;
+}
+
 export function harnessMakaContextBudgetEnv() {
   return {
     MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'on',
@@ -808,6 +825,9 @@ export async function main() {
     process.env.MAKA_HARNESS_AB_ARM_EXECUTION,
     selection.taskIds.length,
   );
+  const retryAdjudicatedInfraRoundIdsOnce = resolveHarnessAdjudicatedInfraRetryRoundIds(
+    process.env.MAKA_HARNESS_AB_RETRY_ADJUDICATED_INFRA_ROUND_IDS_ONCE,
+  );
   const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_HARNESS_AB_RUN_ID');
   await withHarnessAbRunLock(runRoot, async () => {
     const journal = backgroundJournal(runRoot);
@@ -823,6 +843,7 @@ export async function main() {
         executionPolicy,
         runRoot,
         composition,
+        retryAdjudicatedInfraRoundIdsOnce,
       });
     } catch (error) {
       exitCode = 1;
@@ -849,6 +870,7 @@ async function runLocked({
   executionPolicy,
   runRoot,
   composition,
+  retryAdjudicatedInfraRoundIdsOnce,
 }) {
   const { benchmarkProfile, runtimeProfile, competitorProfile } = composition;
   const { tasks: allTasks, taskSourceFingerprint } = await resolveFrozenBenchmarkTasks(
@@ -1027,6 +1049,7 @@ async function runLocked({
         ],
         pairConcurrency: manifest.maxConcurrency,
         armExecution: manifest.metadata.execution.armExecution,
+        retryAdjudicatedInfraRoundIdsOnce,
       });
       return buildHarnessAbReport(
         summary,

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -85,6 +85,61 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.taskLevel.losses, 1);
   });
 
+  test('classifies a scored completed benchmark deadline as budget exhausted', () => {
+    const deadlineFailure = {
+      ...completed('long-task', false),
+      status: 'failed' as const,
+      errorClass: 'budget_exhausted',
+      deadlineSettlement: { source: 'benchmark.deadline' as const, mode: 'immediate' as const },
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka-baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['long-task'],
+      baselineRuns: [[deadlineFailure]],
+      candidateRuns: [[completed('long-task', true)]],
+    });
+
+    assert.equal(result.baseline.valid, 1);
+    assert.equal(result.baseline.budgetExhausted, 1);
+    assert.equal(result.baseline.passRate, 0);
+  });
+
+  test('uses one shared paired denominator for non-budget conditional outcomes', () => {
+    const baselineBudget = {
+      ...completed('baseline-budget', false),
+      status: 'failed' as const,
+      errorClass: 'budget_exhausted',
+    };
+    const candidateBudget = {
+      ...completed('candidate-budget', false),
+      status: 'failed' as const,
+      errorClass: 'budget_exhausted',
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['quality', 'baseline-budget', 'candidate-budget'],
+      baselineRuns: [
+        [completed('quality', true), baselineBudget, completed('candidate-budget', false)],
+      ],
+      candidateRuns: [
+        [completed('quality', false), completed('baseline-budget', true), candidateBudget],
+      ],
+    });
+    const paired = result.pairedAttempts;
+
+    assert.equal(paired.evaluatedPairs, 3);
+    assert.equal(paired.nonBudgetEvaluatedPairs, 1);
+    assert.equal(paired.baselineNonBudgetPassed, 1);
+    assert.equal(paired.candidateNonBudgetPassed, 0);
+    assert.deepEqual(paired.budgetExcludedPairIds, ['baseline-budget#r0', 'candidate-budget#r0']);
+  });
+
   test('counts an unattested timeout as an observed budget failure with an attestation warning', () => {
     const unverifiedTimeout = {
       ...budgetExhausted('long-task'),

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -845,6 +845,68 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('permits one explicitly adjudicated infra retry without allowing a third attempt', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await appendFixedPromptWalEvent(`${resultsJsonlPath}.attempts.jsonl`, {
+        schemaVersion: 1,
+        type: 'task_attempt_started',
+        id: 'attempt-1',
+        ts: 1,
+        runId: 'run-1',
+        roundId: 'round-1',
+        taskId: 'task-a',
+        promptHash: hashSystemPrompt('fixed prompt\n'),
+      });
+      await appendFixedPromptWalEvent(resultsJsonlPath, {
+        schemaVersion: 1,
+        type: 'task_infra_failed',
+        id: 'infra-1',
+        ts: 2,
+        runId: 'run-1',
+        roundId: 'round-1',
+        taskId: 'task-a',
+        status: 'infra_failed',
+        passed: false,
+        scored: false,
+        eligible: false,
+        errorClass: 'infra_error',
+        error: 'adjudicated pre-execution failure',
+      });
+      let harborCalls = 0;
+      const input = {
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        infraFailurePolicy: 'terminal' as const,
+        protectPassAtOne: true,
+        retryAdjudicatedInfraTaskIdsOnce: ['task-a'],
+        taskRunner: async () => {
+          harborCalls += 1;
+          throw new Error('provider failed before the agent started again');
+        },
+        now: () => 100,
+        newId: idFactory(),
+      };
+
+      const retried = await runFixedPromptController(input);
+      assert.equal(harborCalls, 1);
+      assert.equal(retried.events.at(-1)?.type, 'task_infra_failed');
+
+      await runFixedPromptController(input);
+      assert.equal(harborCalls, 1);
+      assert.equal(
+        (await readFile(`${resultsJsonlPath}.attempts.jsonl`, 'utf8')).trim().split('\n').length,
+        2,
+      );
+    });
+  });
+
   test('retries a thrown infra error once and records the successful retry', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -2781,6 +2781,42 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('accepts a prompt hash attested by execution identity without the legacy field', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const promptHash = hashSystemPrompt('fixed prompt\n');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        taskRunner: async () =>
+          harborOutput({
+            taskId: 'task-a',
+            omitPromptHash: true,
+            executionIdentity: {
+              llmConnectionSlug: 'fake',
+              model: 'fake-model',
+              systemPromptHash: promptHash,
+              pricingProfile: 'test-profile',
+            },
+          }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.promptHash, promptHash);
+    });
+  });
+
   test('resumes a legacy terminal whose prompt hash is attested by execution identity', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -623,6 +623,59 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
+  test('rejects an OpenCode cell whose terminal provider stream is incomplete', async () => {
+    await withRun(async ({ jobsDir, repo, keyFile }) => {
+      const upstream = createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'text/event-stream' });
+        response.end('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n');
+      });
+      await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+      const address = upstream.address();
+      assert.ok(address && typeof address !== 'string');
+      try {
+        const runner = createHarborTaskRunner({
+          makaRepoPath: repo,
+          jobsDir,
+          agent: 'opencode',
+          opencodeToolchainPath: '/toolchain',
+          agentVersion: '1.17.18',
+          model: 'deepseek/deepseek-v4-flash',
+          provider: 'deepseek',
+          reasoningEffort: 'max',
+          apiKeyFile: keyFile,
+          agentEnv: { DEEPSEEK_BASE_URL: `http://127.0.0.1:${address.port}` },
+          runHarbor: async (request) => {
+            const proxyUrl = request.env?.MAKA_PROVIDER_PROXY_URL?.replace(
+              'host.docker.internal',
+              '127.0.0.1',
+            );
+            const proxyToken = request.env?.MAKA_PROVIDER_PROXY_TOKEN;
+            assert.ok(proxyUrl && proxyToken);
+            const response = await fetch(`${proxyUrl}/chat/completions`, {
+              method: 'POST',
+              headers: { authorization: `Bearer ${proxyToken}` },
+              body: '{}',
+            });
+            assert.equal(response.status, 200);
+            await response.text();
+            return fakeRunner({ reward: '0\n' })(request);
+          },
+        });
+
+        await assert.rejects(runner(runInput()), (error: unknown) => {
+          assert.ok(error instanceof HarborInfraError);
+          assert.match(error.message, /terminal provider request did not complete/);
+          assert.ok(error.artifactRefs?.providerTelemetryPath);
+          return true;
+        });
+      } finally {
+        await new Promise<void>((resolve, reject) =>
+          upstream.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+    });
+  });
+
   test('gives Codex an ephemeral OpenAI proxy without exposing the provider key file', async () => {
     await withRun(async ({ jobsDir, repo, keyFile }) => {
       const captured: { config?: Record<string, unknown> } = {};
@@ -785,6 +838,9 @@ describe('createHarborTaskRunner', () => {
             '',
             'event: message_delta',
             'data: {"type":"message_delta","usage":{"output_tokens":25}}',
+            '',
+            'event: message_stop',
+            'data: {"type":"message_stop"}',
             '',
           ].join('\n'),
         );

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -127,6 +127,79 @@ test('harness A/B parses an explicit one-shot adjudicated infra retry', async ()
   );
 });
 
+test('harness A/B resumes an explicit infra retry from the frozen manifest identity', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-frozen-resume-'));
+  try {
+    const { buildHarnessAbManifest, resolveHarnessAbManifestForRun, resolveHarnessComposition } =
+      await import(new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href);
+    const manifestPath = join(dir, 'harness-ab-manifest.json');
+    const composition = resolveHarnessComposition({
+      runtime: 'deepseek-v4-flash-max',
+      competitor: 'opencode',
+    });
+    const taskIds = ['winning-avg-corewars'];
+    const frozen = buildHarnessAbManifest({
+      subjectFingerprint: `sha256:${'1'.repeat(64)}`,
+      taskSourceFingerprint: `sha256:${'2'.repeat(64)}`,
+      toolchainFingerprint: `sha256:${'3'.repeat(64)}`,
+      composition,
+      taskIds,
+      pairConcurrency: 1,
+      armExecution: 'parallel',
+    });
+    await writeFile(manifestPath, `${JSON.stringify(frozen)}\n`, 'utf8');
+    const current = buildHarnessAbManifest({
+      subjectFingerprint: `sha256:${'4'.repeat(64)}`,
+      taskSourceFingerprint: frozen.taskSourceFingerprint,
+      toolchainFingerprint: `sha256:${'5'.repeat(64)}`,
+      composition,
+      taskIds,
+      pairConcurrency: 1,
+      armExecution: 'parallel',
+    });
+
+    assert.deepEqual(
+      await resolveHarnessAbManifestForRun({
+        manifestPath,
+        proposedManifest: current,
+        retryRoundIds: ['ab-maka-r0-winning-avg-corewars'],
+        expectedExistingFingerprint: frozen.fingerprint,
+      }),
+      frozen,
+    );
+    await assert.rejects(
+      resolveHarnessAbManifestForRun({
+        manifestPath,
+        proposedManifest: current,
+        retryRoundIds: [],
+        expectedExistingFingerprint: frozen.fingerprint,
+      }),
+      /requires an explicit adjudicated infra retry/,
+    );
+
+    const changedSchedule = buildHarnessAbManifest({
+      subjectFingerprint: current.subjectFingerprint,
+      taskSourceFingerprint: current.taskSourceFingerprint,
+      toolchainFingerprint: current.toolchainFingerprint,
+      composition,
+      taskIds,
+      pairConcurrency: 1,
+      armExecution: 'sequential',
+    });
+    await assert.rejects(
+      resolveHarnessAbManifestForRun({
+        manifestPath,
+        proposedManifest: changedSchedule,
+        retryRoundIds: ['ab-maka-r0-winning-avg-corewars'],
+        expectedExistingFingerprint: frozen.fingerprint,
+      }),
+      /differs beyond the frozen subject and toolchain identity/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('harness A/B selects one named task only with an explicit run identity', async () => {
   const {
     buildHarnessAbManifest,

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -110,6 +110,23 @@ test('harness A/B uses one safe execution default and accepts per-run overrides'
   );
 });
 
+test('harness A/B parses an explicit one-shot adjudicated infra retry', async () => {
+  const { resolveHarnessAdjudicatedInfraRetryRoundIds } = await import(
+    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
+  );
+
+  assert.deepEqual(resolveHarnessAdjudicatedInfraRetryRoundIds(undefined), []);
+  assert.deepEqual(
+    resolveHarnessAdjudicatedInfraRetryRoundIds(' ab-maka-r0-winning-avg-corewars '),
+    ['ab-maka-r0-winning-avg-corewars'],
+  );
+  assert.throws(() => resolveHarnessAdjudicatedInfraRetryRoundIds(' , '), /must not be empty/);
+  assert.throws(
+    () => resolveHarnessAdjudicatedInfraRetryRoundIds('ab-maka-r0-a,ab-maka-r0-a'),
+    /must not contain duplicates/,
+  );
+});
+
 test('harness A/B selects one named task only with an explicit run identity', async () => {
   const {
     buildHarnessAbManifest,

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -77,16 +77,29 @@ describe('harness A/B report', () => {
 
     const report = buildHarnessAbReport(summary);
 
-    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v3');
+    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v4');
     assert.deepEqual(report.effectiveness, {
-      metric: 'pass@1',
+      metric: 'end-to-end-pass@1',
       pairedEvaluated: 2,
       baseline: { armId: 'maka', passed: 2, evaluated: 2, passRate: 1 },
       candidate: { armId: 'opencode', passed: 1, evaluated: 2, passRate: 0.5 },
       candidateMinusBaseline: -0.5,
+      pairedCandidateMinusBaseline: -0.5,
       candidateWins: 0,
       baselineWins: 1,
       ties: 1,
+      nonBudgetConditional: {
+        pairedEvaluated: 2,
+        excludedBudgetPairs: 0,
+        baseline: { armId: 'maka', passed: 2, evaluated: 2, passRate: 1 },
+        candidate: { armId: 'opencode', passed: 1, evaluated: 2, passRate: 0.5 },
+        candidateMinusBaseline: -0.5,
+      },
+      budgetExhaustion: {
+        baseline: { armId: 'maka', exhausted: 0, evaluated: 2, rate: 0 },
+        candidate: { armId: 'opencode', exhausted: 0, evaluated: 2, rate: 0 },
+        candidateMinusBaseline: 0,
+      },
     });
     assert.equal(report.economy.baseline.totalTokens, 240);
     assert.equal(report.economy.candidate.totalTokens, 360);
@@ -99,15 +112,15 @@ describe('harness A/B report', () => {
     const csv = renderHarnessAbReportCsv(report);
     assert.match(
       csv,
-      /^run_status,stop_reason,billing_mode,economy_basis,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline\n/,
+      /^run_status,stop_reason,billing_mode,economy_basis,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_non_budget_evaluated,budget_excluded_pairs,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline\n/,
     );
     assert.match(
       csv,
-      /completed,,metered,cache-aware-api-equivalent-usd,4,4,4,0,0,0,2,2,0,effectiveness,pass_rate,maka,1,opencode,0.5,-0.5/,
+      /completed,,metered,cache-aware-api-equivalent-usd,4,4,4,0,0,0,2,2,0,2,0,effectiveness,end_to_end_pass_at_1,maka,1,opencode,0.5,-0.5/,
     );
     assert.match(
       csv,
-      /completed,,metered,cache-aware-api-equivalent-usd,4,4,4,0,0,0,2,2,0,economy,total_tokens,maka,240,opencode,360,120/,
+      /completed,,metered,cache-aware-api-equivalent-usd,4,4,4,0,0,0,2,2,0,2,0,economy,total_tokens,maka,240,opencode,360,120/,
     );
 
     const markdown = renderHarnessAbReportMarkdown(report);
@@ -119,6 +132,65 @@ describe('harness A/B report', () => {
       /Cell coverage: 4\/4 attempted; 4 model-scored; 0 unscored \(including 0 infra-failed\); 0 missing final usage\./,
     );
     assert.match(markdown, /No composite score/);
+  });
+
+  test('reports end-to-end, paired non-budget conditional, and budget exhaustion rates', () => {
+    const baselineBudget = {
+      ...completed('baseline-budget', false),
+      status: 'failed' as const,
+      errorClass: 'budget_exhausted',
+    };
+    const candidateBudget = {
+      ...completed('candidate-budget', false),
+      status: 'failed' as const,
+      errorClass: 'budget_exhausted',
+    };
+    const summary = summarizeAbComparison({
+      runId: 'deepseek-full-v7',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka',
+      candidateArmId: 'opencode',
+      evaluationTaskIds: ['quality', 'baseline-budget', 'candidate-budget'],
+      baselineRuns: [
+        [completed('quality', true), baselineBudget, completed('candidate-budget', false)],
+      ],
+      candidateRuns: [
+        [completed('quality', false), completed('baseline-budget', true), candidateBudget],
+      ],
+    });
+
+    const report = buildHarnessAbReport(summary);
+
+    assert.deepEqual(report.effectiveness.baseline, {
+      armId: 'maka',
+      passed: 1,
+      evaluated: 3,
+      passRate: 1 / 3,
+    });
+    assert.deepEqual(report.effectiveness.candidate, {
+      armId: 'opencode',
+      passed: 1,
+      evaluated: 3,
+      passRate: 1 / 3,
+    });
+    assert.deepEqual(report.effectiveness.nonBudgetConditional, {
+      pairedEvaluated: 1,
+      excludedBudgetPairs: 2,
+      baseline: { armId: 'maka', passed: 1, evaluated: 1, passRate: 1 },
+      candidate: { armId: 'opencode', passed: 0, evaluated: 1, passRate: 0 },
+      candidateMinusBaseline: -1,
+    });
+    assert.deepEqual(report.effectiveness.budgetExhaustion, {
+      baseline: { armId: 'maka', exhausted: 1, evaluated: 3, rate: 1 / 3 },
+      candidate: { armId: 'opencode', exhausted: 1, evaluated: 3, rate: 1 / 3 },
+      candidateMinusBaseline: 0,
+    });
+
+    const markdown = renderHarnessAbReportMarkdown(report);
+    assert.match(markdown, /End-to-end Pass@1/);
+    assert.match(markdown, /Non-budget Conditional Pass Rate/);
+    assert.match(markdown, /Budget Exhaustion Rate/);
+    assert.match(markdown, /excludes the entire pair when either arm is budget-exhausted/);
   });
 
   test('labels account-plan cost without presenting it as public API pricing', () => {
@@ -155,7 +227,7 @@ describe('harness A/B report', () => {
 
     const report = buildHarnessAbReport(summary);
 
-    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v3');
+    assert.equal(report.schemaVersion, 'maka.harness_ab.report.v4');
     assert.equal(report.runStatus, 'completed_with_gaps');
     assert.deepEqual(report.coverage, {
       scheduledCells: 4,
@@ -168,13 +240,13 @@ describe('harness A/B report', () => {
     assert.throws(() => assertHarnessAbReportCompleted(report), /completed with gaps/);
     assert.match(
       renderHarnessAbReportCsv(report),
-      /completed_with_gaps,,metered,cache-aware-api-equivalent-usd,4,4,3,1,1,0,1,1,0,effectiveness,pass_rate/,
+      /completed_with_gaps,,metered,cache-aware-api-equivalent-usd,4,4,3,1,1,0,1,1,0,1,0,effectiveness,end_to_end_pass_at_1/,
     );
     assert.match(renderHarnessAbReportMarkdown(report), /Status: completed_with_gaps\./);
     assert.deepEqual(report.effectiveness.baseline, {
       armId: 'maka',
-      passed: 1,
-      evaluated: 1,
+      passed: 2,
+      evaluated: 2,
       passRate: 1,
     });
     assert.deepEqual(report.effectiveness.candidate, {
@@ -186,7 +258,7 @@ describe('harness A/B report', () => {
     assert.equal(report.effectiveness.candidateMinusBaseline, -1);
   });
 
-  test('reports a budget-exhausted cell with final usage as unscored', () => {
+  test('reports a budget-exhausted cell with final usage as scored', () => {
     const meteredTimeout = {
       ...budgetExhausted('a'),
       tokenSummary: usage('a', false, 100, 40, 20, 0.00018).tokenSummary,
@@ -204,15 +276,17 @@ describe('harness A/B report', () => {
 
     const report = buildHarnessAbReport(summary);
 
-    assert.equal(report.runStatus, 'completed_with_gaps');
+    assert.equal(report.runStatus, 'completed');
     assert.deepEqual(report.coverage, {
       scheduledCells: 2,
       attemptedCells: 2,
-      modelScoredCells: 1,
+      modelScoredCells: 2,
       infraFailedCells: 0,
-      unscoredCells: 1,
+      unscoredCells: 0,
       missingFinalUsageCells: 0,
     });
+    assert.equal(report.effectiveness.budgetExhaustion.baseline.rate, 1);
+    assert.equal(report.effectiveness.nonBudgetConditional.pairedEvaluated, 0);
   });
 
   test('stays incomplete when scheduled cells were never attempted', () => {
@@ -333,11 +407,11 @@ describe('harness A/B report', () => {
     assert.equal(report.stopReason, 'systemic_provider_failure');
     assert.match(
       renderHarnessAbReportCsv(report),
-      /^run_status,stop_reason,billing_mode,economy_basis,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,/,
+      /^run_status,stop_reason,billing_mode,economy_basis,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_non_budget_evaluated,budget_excluded_pairs,paired_metered,missing_usage_pairs,axis,metric,/,
     );
     assert.match(
       renderHarnessAbReportCsv(report),
-      /stopped,systemic_provider_failure,metered,cache-aware-api-equivalent-usd,2,2,1,1,1,0,0,0,0,effectiveness,pass_rate/,
+      /stopped,systemic_provider_failure,metered,cache-aware-api-equivalent-usd,2,2,1,1,1,0,0,0,0,0,0,effectiveness,end_to_end_pass_at_1/,
     );
     assert.match(
       renderHarnessAbReportMarkdown(report),

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -205,6 +205,16 @@ describe('runHarnessAbComparison', () => {
 
       await runHarnessAbComparison(input);
       assert.equal(failingAttempts, 1);
+
+      const adjudicatedRetry = {
+        ...input,
+        retryAdjudicatedInfraRoundIdsOnce: ['ab-maka-r0-a'],
+      };
+      await runHarnessAbComparison(adjudicatedRetry);
+      assert.equal(failingAttempts, 2);
+
+      await runHarnessAbComparison(adjudicatedRetry);
+      assert.equal(failingAttempts, 2);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -579,6 +579,10 @@ function summarizeAttemptPairs(
   let evaluatedPairs = 0;
   let baselinePassed = 0;
   let candidatePassed = 0;
+  let nonBudgetEvaluatedPairs = 0;
+  let baselineNonBudgetPassed = 0;
+  let candidateNonBudgetPassed = 0;
+  const budgetExcludedPairIds: string[] = [];
   let fullyMeteredPairs = 0;
   let baselineMeteredPassed = 0;
   let candidateMeteredPassed = 0;
@@ -612,6 +616,13 @@ function summarizeAttemptPairs(
       evaluatedPairs += 1;
       if (baseline.passed) baselinePassed += 1;
       if (candidate.passed) candidatePassed += 1;
+      if (isBudgetExhaustedOutcome(baseline) || isBudgetExhaustedOutcome(candidate)) {
+        budgetExcludedPairIds.push(pairId);
+      } else {
+        nonBudgetEvaluatedPairs += 1;
+        if (baseline.passed) baselineNonBudgetPassed += 1;
+        if (candidate.passed) candidateNonBudgetPassed += 1;
+      }
       if (hasCompleteTokenSummary(baseline) && hasCompleteTokenSummary(candidate)) {
         fullyMeteredPairs += 1;
         baselineEvaluatedEvents.push(baseline);
@@ -636,6 +647,10 @@ function summarizeAttemptPairs(
     evaluatedPairs,
     baselinePassed,
     candidatePassed,
+    nonBudgetEvaluatedPairs,
+    baselineNonBudgetPassed,
+    candidateNonBudgetPassed,
+    budgetExcludedPairIds,
     fullyMeteredPairs,
     baselineMeteredPassed,
     candidateMeteredPassed,
@@ -767,7 +782,8 @@ function abOutcomeCategory(event: FixedPromptTaskWalEvent): AbOutcomeCategory {
   if (event.type === 'task_plumbing_failed') return 'plumbing';
   if (event.type === 'task_completed') {
     if (isHardPlumbingErrorClass(event.errorClass)) return 'plumbing';
-    if (event.errorClass === 'tool_step_cap_reached') return 'budget';
+    if (event.errorClass === 'budget_exhausted' || event.errorClass === 'tool_step_cap_reached')
+      return 'budget';
     return event.scored ? 'completed' : 'infra';
   }
   if (

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -197,6 +197,10 @@ export interface AbAttemptPairSummary {
   evaluatedPairs: number;
   baselinePassed: number;
   candidatePassed: number;
+  nonBudgetEvaluatedPairs: number;
+  baselineNonBudgetPassed: number;
+  candidateNonBudgetPassed: number;
+  budgetExcludedPairIds: string[];
   fullyMeteredPairs: number;
   baselineMeteredPassed: number;
   candidateMeteredPassed: number;

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -152,6 +152,9 @@ export interface RunFixedPromptControllerInput {
   /** Refuse resume when a model attempt was durably admitted but no terminal
    * event exists, preserving single-sample benchmark semantics. */
   protectPassAtOne?: boolean;
+  /** Permit exactly one additional attempt for explicitly adjudicated terminal
+   * infra failures. The durable attempt WAL prevents a third attempt. */
+  retryAdjudicatedInfraTaskIdsOnce?: readonly string[];
   taskRunner: TaskRunner;
   now?: () => number;
   newId?: () => string;
@@ -203,6 +206,16 @@ export async function runFixedPromptController(
     input.resumeFingerprint,
     terminalInfraFailures,
   );
+  permitAdjudicatedInfraRetries({
+    taskIds: input.retryAdjudicatedInfraTaskIdsOnce ?? [],
+    tasks: input.tasks,
+    completed,
+    attemptEvents,
+    runId: input.runId,
+    roundId: input.roundId,
+    expectedPromptHash,
+    resumeFingerprint: input.resumeFingerprint,
+  });
   const orphanedAttempts = orphanedTaskAttempts(
     [...attemptEvents, ...events],
     input.runId,
@@ -324,6 +337,39 @@ export async function runFixedPromptController(
     ...(input.resultsTsvPath !== undefined ? { resultsTsvPath: input.resultsTsvPath } : {}),
     ...(stopReason ? { stopReason } : {}),
   };
+}
+
+function permitAdjudicatedInfraRetries(input: {
+  taskIds: readonly string[];
+  tasks: readonly FixedPromptTask[];
+  completed: Map<string, FixedPromptTaskWalEvent>;
+  attemptEvents: readonly FixedPromptWalEvent[];
+  runId: string;
+  roundId: string;
+  expectedPromptHash: string;
+  resumeFingerprint?: string;
+}): void {
+  assertUniqueTaskIds(input.taskIds);
+  const configuredTaskIds = new Set(input.tasks.map((task) => task.id));
+  for (const taskId of input.taskIds) {
+    if (!configuredTaskIds.has(taskId)) {
+      throw new Error(`adjudicated infra retry names unknown task ${taskId}`);
+    }
+    const terminal = input.completed.get(taskId);
+    if (terminal?.type !== 'task_infra_failed') {
+      throw new Error(`adjudicated infra retry requires a terminal infra failure for ${taskId}`);
+    }
+    const admittedAttempts = input.attemptEvents.filter(
+      (event) =>
+        event.type === 'task_attempt_started' &&
+        event.runId === input.runId &&
+        event.roundId === input.roundId &&
+        event.taskId === taskId &&
+        event.promptHash === input.expectedPromptHash &&
+        event.resumeFingerprint === input.resumeFingerprint,
+    ).length;
+    if (admittedAttempts === 1) input.completed.delete(taskId);
+  }
 }
 
 function assertUniqueTaskIds(taskIds: readonly string[]): void {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -653,7 +653,7 @@ function taskCompletedEvent(input: {
   ts: number;
 }): FixedPromptTaskCompletedEvent {
   const { output } = input;
-  const promptHash = output.cell.promptHash ?? output.cell.executionIdentity?.systemPromptHash;
+  const promptHash = attestedPromptHash(output.cell);
   const deadlineSettled = output.cell.deadlineSettlement?.source === 'benchmark.deadline';
   const verifierGrade = structuredVerifierGrade(output.harbor);
   const verifierGraded =
@@ -814,16 +814,17 @@ function classifyPlumbingFailure(
     expectedPricingProfile,
   );
   if (identityFailure) return identityFailure;
-  if (output.cell.status === 'completed' && output.cell.promptHash === undefined) {
+  const promptHash = attestedPromptHash(output.cell);
+  if (output.cell.status === 'completed' && promptHash === undefined) {
     return {
       errorClass: 'missing_prompt_hash',
       error: `Harbor cell did not report prompt hash ${expectedPromptHash}`,
     };
   }
-  if (output.cell.promptHash !== undefined && output.cell.promptHash !== expectedPromptHash) {
+  if (promptHash !== undefined && promptHash !== expectedPromptHash) {
     return {
       errorClass: 'prompt_hash_mismatch',
-      error: `Harbor cell prompt hash ${output.cell.promptHash} did not match ${expectedPromptHash}`,
+      error: `Harbor cell prompt hash ${promptHash} did not match ${expectedPromptHash}`,
     };
   }
   if (requireFinalUsage && output.cell.tokenSummary === undefined) {
@@ -844,6 +845,10 @@ function classifyPlumbingFailure(
     };
   }
   return undefined;
+}
+
+function attestedPromptHash(cell: TaskRunOutput['cell']): string | undefined {
+  return cell.promptHash ?? cell.executionIdentity?.systemPromptHash;
 }
 
 function classifyExecutionIdentityFailure(

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -374,6 +374,29 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
           tail(result.stderr || result.stdout),
         );
       }
+      const terminalProviderRequest = providerTelemetry.at(-1);
+      if (
+        !completeTimedOutTrial &&
+        terminalProviderRequest &&
+        terminalProviderRequest.outcome !== 'completed'
+      ) {
+        throw new HarborInfraError(
+          `terminal provider request did not complete for task ${input.task.id}`,
+          [
+            `outcome=${terminalProviderRequest.outcome}`,
+            terminalProviderRequest.status !== undefined
+              ? `status=${terminalProviderRequest.status}`
+              : undefined,
+            terminalProviderRequest.errorClass
+              ? `errorClass=${terminalProviderRequest.errorClass}`
+              : undefined,
+          ]
+            .filter(Boolean)
+            .join(', '),
+          'infra_failed',
+          { providerTelemetryPath },
+        );
+      }
       const reward = await readReward(rewardPath, resultPath, input.task.id);
       const rawCell = await readCellOutput(cellOutputPath, input.task.id);
       const usageCheckpoint = await readOptionalTokenSummary(

--- a/packages/headless/src/harness-ab-report.ts
+++ b/packages/headless/src/harness-ab-report.ts
@@ -12,6 +12,13 @@ export interface HarnessAbArmEffectiveness {
   passRate: number | null;
 }
 
+export interface HarnessAbArmBudgetExhaustion {
+  armId: string;
+  exhausted: number;
+  evaluated: number;
+  rate: number | null;
+}
+
 export interface HarnessAbArmEconomy {
   armId: string;
   inputTokens: number;
@@ -26,7 +33,7 @@ export interface HarnessAbArmEconomy {
 }
 
 export interface HarnessAbReport {
-  schemaVersion: 'maka.harness_ab.report.v3';
+  schemaVersion: 'maka.harness_ab.report.v4';
   runId: string;
   billingMode: 'metered' | 'account-plan';
   runStatus: 'completed' | 'completed_with_gaps' | 'incomplete' | 'stopped';
@@ -41,14 +48,27 @@ export interface HarnessAbReport {
     missingFinalUsageCells: number;
   };
   effectiveness: {
-    metric: 'pass@1';
+    metric: 'end-to-end-pass@1';
     pairedEvaluated: number;
     baseline: HarnessAbArmEffectiveness;
     candidate: HarnessAbArmEffectiveness;
     candidateMinusBaseline: number | null;
+    pairedCandidateMinusBaseline: number | null;
     candidateWins: number;
     baselineWins: number;
     ties: number;
+    nonBudgetConditional: {
+      pairedEvaluated: number;
+      excludedBudgetPairs: number;
+      baseline: HarnessAbArmEffectiveness;
+      candidate: HarnessAbArmEffectiveness;
+      candidateMinusBaseline: number | null;
+    };
+    budgetExhaustion: {
+      baseline: HarnessAbArmBudgetExhaustion;
+      candidate: HarnessAbArmBudgetExhaustion;
+      candidateMinusBaseline: number | null;
+    };
   };
   economy: {
     basis: 'cache-aware-api-equivalent-usd' | 'account-plan-recorded-usd';
@@ -83,13 +103,13 @@ export function buildHarnessAbReport(
   const coverage = {
     scheduledCells: summary.baseline.attempts + summary.candidate.attempts,
     attemptedCells: summary.baseline.observed + summary.candidate.observed,
-    modelScoredCells: summary.baseline.completed + summary.candidate.completed,
+    modelScoredCells: summary.baseline.valid + summary.candidate.valid,
     infraFailedCells: summary.baseline.infraFailed + summary.candidate.infraFailed,
     unscoredCells:
       summary.baseline.observed +
       summary.candidate.observed -
-      summary.baseline.completed -
-      summary.candidate.completed,
+      summary.baseline.valid -
+      summary.candidate.valid,
     missingFinalUsageCells:
       summary.baseline.missingFinalUsage + summary.candidate.missingFinalUsage,
   };
@@ -102,7 +122,7 @@ export function buildHarnessAbReport(
         : 'completed';
   const execution = manifestExecution(manifest);
   return {
-    schemaVersion: 'maka.harness_ab.report.v3',
+    schemaVersion: 'maka.harness_ab.report.v4',
     runId: summary.runId,
     billingMode,
     runStatus,
@@ -110,22 +130,58 @@ export function buildHarnessAbReport(
     taskCount: summary.taskCount,
     coverage,
     effectiveness: {
-      metric: 'pass@1',
+      metric: 'end-to-end-pass@1',
       pairedEvaluated: summary.pairedAttempts.evaluatedPairs,
       baseline: pairedArmEffectiveness(
         summary.baselineArmId,
-        summary.pairedAttempts.baselinePassed,
-        summary.pairedAttempts.evaluatedPairs,
+        summary.baseline.passed,
+        summary.baseline.valid,
       ),
       candidate: pairedArmEffectiveness(
         summary.candidateArmId,
-        summary.pairedAttempts.candidatePassed,
-        summary.pairedAttempts.evaluatedPairs,
+        summary.candidate.passed,
+        summary.candidate.valid,
       ),
-      candidateMinusBaseline: summary.passRateDelta,
+      candidateMinusBaseline: nullableDelta(summary.candidate.passRate, summary.baseline.passRate),
+      pairedCandidateMinusBaseline: summary.passRateDelta,
       candidateWins: summary.pairedAttempts.wins,
       baselineWins: summary.pairedAttempts.losses,
       ties: summary.pairedAttempts.ties,
+      nonBudgetConditional: {
+        pairedEvaluated: summary.pairedAttempts.nonBudgetEvaluatedPairs,
+        excludedBudgetPairs: summary.pairedAttempts.budgetExcludedPairIds.length,
+        baseline: pairedArmEffectiveness(
+          summary.baselineArmId,
+          summary.pairedAttempts.baselineNonBudgetPassed,
+          summary.pairedAttempts.nonBudgetEvaluatedPairs,
+        ),
+        candidate: pairedArmEffectiveness(
+          summary.candidateArmId,
+          summary.pairedAttempts.candidateNonBudgetPassed,
+          summary.pairedAttempts.nonBudgetEvaluatedPairs,
+        ),
+        candidateMinusBaseline: divide(
+          summary.pairedAttempts.candidateNonBudgetPassed -
+            summary.pairedAttempts.baselineNonBudgetPassed,
+          summary.pairedAttempts.nonBudgetEvaluatedPairs,
+        ),
+      },
+      budgetExhaustion: {
+        baseline: armBudgetExhaustion(
+          summary.baselineArmId,
+          summary.baseline.budgetExhausted,
+          summary.baseline.valid,
+        ),
+        candidate: armBudgetExhaustion(
+          summary.candidateArmId,
+          summary.candidate.budgetExhausted,
+          summary.candidate.valid,
+        ),
+        candidateMinusBaseline: nullableDelta(
+          divide(summary.candidate.budgetExhausted, summary.candidate.valid),
+          divide(summary.baseline.budgetExhausted, summary.baseline.valid),
+        ),
+      },
     },
     economy: {
       basis:
@@ -172,12 +228,30 @@ export function renderHarnessAbReportCsv(report: HarnessAbReport): string {
     [
       [
         'effectiveness',
-        'pass_rate',
+        'end_to_end_pass_at_1',
         baselineEffectiveness.armId,
         baselineEffectiveness.passRate,
         candidateEffectiveness.armId,
         candidateEffectiveness.passRate,
         report.effectiveness.candidateMinusBaseline,
+      ],
+      [
+        'diagnostic',
+        'non_budget_conditional_pass_rate',
+        report.effectiveness.nonBudgetConditional.baseline.armId,
+        report.effectiveness.nonBudgetConditional.baseline.passRate,
+        report.effectiveness.nonBudgetConditional.candidate.armId,
+        report.effectiveness.nonBudgetConditional.candidate.passRate,
+        report.effectiveness.nonBudgetConditional.candidateMinusBaseline,
+      ],
+      [
+        'diagnostic',
+        'budget_exhaustion_rate',
+        report.effectiveness.budgetExhaustion.baseline.armId,
+        report.effectiveness.budgetExhaustion.baseline.rate,
+        report.effectiveness.budgetExhaustion.candidate.armId,
+        report.effectiveness.budgetExhaustion.candidate.rate,
+        report.effectiveness.budgetExhaustion.candidateMinusBaseline,
       ],
       [
         'effectiveness',
@@ -272,7 +346,7 @@ export function renderHarnessAbReportCsv(report: HarnessAbReport): string {
     ];
   return (
     [
-      'run_status,stop_reason,billing_mode,economy_basis,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline',
+      'run_status,stop_reason,billing_mode,economy_basis,scheduled_cells,attempted_cells,model_scored_cells,infra_failed_cells,unscored_cells,missing_final_usage_cells,paired_evaluated,paired_non_budget_evaluated,budget_excluded_pairs,paired_metered,missing_usage_pairs,axis,metric,baseline_arm,baseline_value,candidate_arm,candidate_value,candidate_minus_baseline',
       ...rows.map((row) =>
         [
           report.runStatus,
@@ -286,6 +360,8 @@ export function renderHarnessAbReportCsv(report: HarnessAbReport): string {
           report.coverage.unscoredCells,
           report.coverage.missingFinalUsageCells,
           report.effectiveness.pairedEvaluated,
+          report.effectiveness.nonBudgetConditional.pairedEvaluated,
+          report.effectiveness.nonBudgetConditional.excludedBudgetPairs,
           report.economy.pairedMetered,
           report.economy.missingUsagePairs,
           ...row,
@@ -320,8 +396,12 @@ export function renderHarnessAbReportMarkdown(report: HarnessAbReport): string {
       candidateEffectiveness.armId +
       ' | Candidate − baseline |',
     '| --- | ---: | ---: | ---: |',
-    `| Pass@1 | ${rate(baselineEffectiveness.passRate)} (${baselineEffectiveness.passed}/${baselineEffectiveness.evaluated}) | ${rate(candidateEffectiveness.passRate)} (${candidateEffectiveness.passed}/${candidateEffectiveness.evaluated}) | ${rate(report.effectiveness.candidateMinusBaseline)} |`,
+    `| End-to-end Pass@1 | ${rate(baselineEffectiveness.passRate)} (${baselineEffectiveness.passed}/${baselineEffectiveness.evaluated}) | ${rate(candidateEffectiveness.passRate)} (${candidateEffectiveness.passed}/${candidateEffectiveness.evaluated}) | ${rate(report.effectiveness.candidateMinusBaseline)} |`,
+    `| Non-budget Conditional Pass Rate | ${rate(report.effectiveness.nonBudgetConditional.baseline.passRate)} (${report.effectiveness.nonBudgetConditional.baseline.passed}/${report.effectiveness.nonBudgetConditional.pairedEvaluated}) | ${rate(report.effectiveness.nonBudgetConditional.candidate.passRate)} (${report.effectiveness.nonBudgetConditional.candidate.passed}/${report.effectiveness.nonBudgetConditional.pairedEvaluated}) | ${rate(report.effectiveness.nonBudgetConditional.candidateMinusBaseline)} |`,
+    `| Budget Exhaustion Rate | ${rate(report.effectiveness.budgetExhaustion.baseline.rate)} (${report.effectiveness.budgetExhaustion.baseline.exhausted}/${report.effectiveness.budgetExhaustion.baseline.evaluated}) | ${rate(report.effectiveness.budgetExhaustion.candidate.rate)} (${report.effectiveness.budgetExhaustion.candidate.exhausted}/${report.effectiveness.budgetExhaustion.candidate.evaluated}) | ${rate(report.effectiveness.budgetExhaustion.candidateMinusBaseline)} |`,
     `| Paired outcomes | — | wins ${report.effectiveness.candidateWins}, losses ${report.effectiveness.baselineWins}, ties ${report.effectiveness.ties} | — |`,
+    '',
+    `The formal paired End-to-end Pass@1 delta is ${rate(report.effectiveness.pairedCandidateMinusBaseline)} across ${report.effectiveness.pairedEvaluated} evaluated pairs; it remains the A/B conclusion input. Non-budget Conditional Pass Rate is diagnostic only and excludes the entire pair when either arm is budget-exhausted (${report.effectiveness.nonBudgetConditional.excludedBudgetPairs} pairs excluded), preserving one shared paired denominator. It helps distinguish solution-quality differences from inference-service speed and Agent turnover efficiency.`,
     '',
     '## Economy',
     '',
@@ -429,6 +509,14 @@ function pairedArmEffectiveness(
   evaluated: number,
 ): HarnessAbArmEffectiveness {
   return { armId, passed, evaluated, passRate: divide(passed, evaluated) };
+}
+
+function armBudgetExhaustion(
+  armId: string,
+  exhausted: number,
+  evaluated: number,
+): HarnessAbArmBudgetExhaustion {
+  return { armId, exhausted, evaluated, rate: divide(exhausted, evaluated) };
 }
 
 function armEconomy(

--- a/packages/headless/src/harness-ab-run.ts
+++ b/packages/headless/src/harness-ab-run.ts
@@ -30,6 +30,7 @@ export interface RunHarnessAbComparisonInput {
   arms: readonly [HarnessAbRuntimeArm, HarnessAbRuntimeArm];
   pairConcurrency?: number;
   armExecution?: 'parallel' | 'sequential';
+  retryAdjudicatedInfraRoundIdsOnce?: readonly string[];
   now?: () => number;
   newId?: () => string;
 }
@@ -50,6 +51,18 @@ export async function runHarnessAbComparisonUnlocked(
   const pairConcurrency = input.pairConcurrency ?? HARNESS_AB_PAIR_CONCURRENCY;
   if (!Number.isSafeInteger(pairConcurrency) || pairConcurrency < 1) {
     throw new Error('pairConcurrency must be a positive integer');
+  }
+  const retryRoundIds = new Set(input.retryAdjudicatedInfraRoundIdsOnce ?? []);
+  if (retryRoundIds.size !== (input.retryAdjudicatedInfraRoundIdsOnce?.length ?? 0)) {
+    throw new Error('adjudicated infra retry round ids must be unique');
+  }
+  const validRoundIds = new Set(
+    input.evaluationTasks.flatMap((task) => input.arms.map((arm) => `ab-${arm.id}-r0-${task.id}`)),
+  );
+  for (const roundId of retryRoundIds) {
+    if (!validRoundIds.has(roundId)) {
+      throw new Error(`adjudicated infra retry names unknown round ${roundId}`);
+    }
   }
   const preexistingEventIds = new Set(
     (await readFixedPromptWal(input.resultsJsonlPath))
@@ -92,6 +105,7 @@ export async function runHarnessAbComparisonUnlocked(
         tasks: [task],
         infraFailurePolicy: 'terminal',
         protectPassAtOne: true,
+        ...(retryRoundIds.has(roundId) ? { retryAdjudicatedInfraTaskIdsOnce: [task.id] } : {}),
         requireExecutionIdentity: true,
         requireFinalUsage: true,
         expectedPricingProfile: runtimeArm.expectedPricingProfile,


### PR DESCRIPTION
## Summary

Upstreams the remaining failure-handling semantics that produced the published DeepSeek Flash TB2.1 report (#1719) from the experiment branch. Audit of all 11 branch commits against main:

| branch commit | status on main |
| --- | --- |
| `acd979a64` runtime profile | already merged (#1730) |
| `23b6bef7c` DeepSeek OpenCode proxy routing | already merged (#1753) |
| `17746a319` command-output isolation | already merged (#1210) |
| `699a81554` agent-deadline propagation | already merged (#1717) |
| `84e0c6ffb` pre-execution failure exclusion | superseded by #1717's richer version |
| `b31d6e469` execution-opportunity classification | already merged (#1717) |
| `99f1ee37e` identity-attested prompt hashes | **this PR** |
| `d783aa3a4` incomplete terminal provider streams | **this PR** |
| `b2d78c28b` one adjudicated infra retry | **this PR** |
| `5c2bbc6db` budget-aware pass rates | **this PR** |
| `e88bcc2f0` resume infra retries from frozen manifest | **this PR** |

The five cherry-picks (clean, only one auto-merge in a test file) complete the semantics the published numbers were computed under:

- **identity-attested prompt hashes** — execution-identity check accepts the hash attested by the cell's identity record
- **incomplete terminal provider streams** — a trial whose last provider request did not complete classifies as infra, not a graded failure
- **one adjudicated infra retry** — explicit per-task one-shot retry of terminal infra failures, gated by the durable attempt WAL
- **budget-aware pass rates** — report separates budget-exhausted arms from scored pass rates instead of diluting them
- **resume retries from frozen manifest** — adjudicated retries resume against the frozen manifest fingerprint, never a re-resolved one

Without these, rerunning the published composition on main would score the same raw cells differently from the published report.

## Verification

- `packages/headless` suite: 1456 pass / 0 fail (each commit carries its own tests from the original TDD)
- `npm run format` / `npm run lint` clean
- Every other branch commit verified already on main or superseded (table above, checked by symbol against current source)

## Review focus

Cherry-pick fidelity: the five commits are byte-identical to the branch versions except the auto-merged context in `harness-ab-cli.test.ts`. The superseded six were deliberately not picked — #1717's versions are strictly richer.
