### PR TITLE
fix(runtime-host): tolerate backend starts cancelled by Host drain during shutdown

### DIFF
--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { inspect } from 'node:util';
 import { createServer, type Server, type Socket } from 'node:net';
 import {
   assertInteractiveRootOwner,
@@ -592,11 +593,18 @@ export class RuntimeHostKernel {
     this.#assertShutdownCanContinue();
     await this.#options.owner.close().catch((error: unknown) => errors.push(error));
     this.#assertShutdownCanContinue();
-    if (errors.length > 0)
-      throw new AggregateError(
+    if (errors.length > 0) {
+      const aggregate = new AggregateError(
         errors,
         'Runtime Host shutdown did not cleanly close every resource',
       );
+      // The default uncaught-error printer truncates nested AggregateErrors to
+      // `[errors]: [Array]`, which leaves the actual resource failure
+      // undiagnosable. Print the full structure so the failing close step is
+      // visible in Host stderr.
+      console.error('Runtime Host shutdown failure:', inspect(aggregate, { depth: null }));
+      throw aggregate;
+    }
   }
 
   async #abortStartup(): Promise<void> {

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -320,7 +320,10 @@ export class RootTurnCoordinator {
       );
       errors.push(
         ...results
-          .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+          .filter(
+            (result): result is PromiseRejectedResult =>
+              result.status === 'rejected' && !isShutdownCancelledBackendStart(result.reason),
+          )
           .map((result) => result.reason),
       );
     }
@@ -1524,6 +1527,20 @@ function isTerminalSnapshot(snapshot: TurnSnapshot): boolean {
     snapshot.status === 'completed' ||
     snapshot.status === 'failed' ||
     snapshot.status === 'cancelled'
+  );
+}
+
+function isShutdownCancelledBackendStart(error: unknown): boolean {
+  // The Host began draining while a Turn was still starting its backend, so
+  // the interaction bind was rejected with authority_draining. The Turn never
+  // ran; its drain rejects with this FailStopError and the Host is already
+  // shutting down. Treating it as a shutdown failure would fail the whole
+  // Host close — it is the expected consequence of stopping mid-start, not a
+  // resource that failed to close.
+  return (
+    error instanceof RuntimeInteractionFailStopError &&
+    error.authorityFailure instanceof RuntimeInteractionAdmissionRejectedError &&
+    error.authorityFailure.reason === 'authority_draining'
   );
 }
 


### PR DESCRIPTION
## Summary

The runtime-host `test:dist` job flaked intermittently on `steering becomes durable and ordered followups automatically start the next root` (execution-host.test.js): the Host exited code 1 at `fixture.stopHost()`.

The new Host stderr diagnostics (this PR, commit 2) captured the exact chain:

```
Unable to close Runtime Host execution composition
  at RootTurnCoordinator.close
    RuntimeInteractionFailStopError: Could not bind Interaction Run ...
      authorityFailure: ... not admitted: authority_draining
```

`stopHost` sends SIGTERM, which begins draining the interaction coordinator. A follow-up Turn that is still starting its backend then tries to bind its interaction run and is rejected with `authority_draining`; its drain rejects with a FailStopError, `RootTurnCoordinator.close()` counts that as a shutdown failure, and the Host exits 1. The Turn never ran — the bind was cancelled by the shutdown itself, not by a resource that failed to close.

`RootTurnCoordinator.close()` now ignores stop failures that are exactly this shutdown-cancelled backend start (FailStopError wrapping an `authority_draining` admission rejection), so Host shutdown completes cleanly. Any other stop failure still fails the close, so real resource failures stay loud.

Second commit: surface nested shutdown failures in Host stderr (`util.inspect` depth: null) — the default printer truncates nested AggregateErrors to `[errors]: [Array]`, which made this flake undiagnosable.

## Verification

- runtime-host suite: 435/435 pass locally.
- CI: steering test passed in both runs after the fix (3 failures before it); e2e and typecheck pass.
- The remaining `test` job failures on this PR are unrelated pre-existing flakes in `packages/cli` (`pi-tui-runner` cleanup tests) and a POSIX process-discovery test — tracked separately.