### PR TITLE
fix(desktop): restore SideNav resize-handle pointer hit area

### DIFF
--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -5,6 +5,21 @@
   height: 100%;
 }
 
+/*
+ * Astryx 0.2.0 ResizeHandle: when pillPlacement is not "center", hitAreaOffsetX
+ * applies translateY(-50%) without a matching top: 50%. The grab zone then only
+ * covers the top half of the handle, so a pointer drag at the vertical center
+ * (where the pill sits) hits the handle root — which has no pointerdown — and
+ * no-ops. SideNav uses pillPlacement="end" (sub-pixel X bias) and mounts the
+ * handle as a sibling of <nav.maka-session-panel>, not a descendant — target the
+ * handle test id. Remove once Astryx fixes hitAreaOffsetX.
+ */
+[data-testid="astryx-sidenav-resize-handle"] > div:not(.astryx-resize-handle-pill) {
+  /* !important: Astryx StyleX injects the bad transform unlayered, which
+     otherwise beats every rule in @layer maka.legacy. */
+  transform: none !important;
+}
+
 .maka-session-list {
   /* PR-SIDEBAR-IA-0 Phase 1 (xuan msg `dc790a54`, kenji msg `0f7bb872`):
    * scroll fix. The previous block layout let the inner `.maka-list-stack`


### PR DESCRIPTION
## Summary

Main's e2e job has been red since the Astryx shell migration: after #1752 fixed the stale conversation selectors, one test still failed — `titlebar restores the official SideNav width after pointer collapse`.

Root cause is an Astryx 0.2.0 `ResizeHandle` hit-area layout bug, not a stale selector. With `pillPlacement="end"` (what SideNav uses), `hitAreaOffsetX` applies `translateY(-50%)` without a matching `top: 50%`. The grab zone only covers the **top half** of the handle; a pointer drag at the vertical center (where the pill sits, and where the e2e aims) hits the handle root, which has no `pointerdown` handler, so collapse never fires and `data-sidebar-state` stays `expanded`.

This also breaks the real product path: users grabbing the handle near the pill cannot drag-resize or drag-collapse.

Fix: neutralize the bad transform on the official SideNav handle (`[data-testid="astryx-sidenav-resize-handle"]`). The handle is a sibling of `<nav.maka-session-panel>`, not a descendant, so the selector must target the handle itself. `!important` is required because StyleX injects the transform unlayered, which beats `@layer maka.legacy`. Remove once Astryx fixes `hitAreaOffsetX`.

## Verification

- `npx playwright test --config e2e/playwright.config.ts e2e/sidebar-geometry.spec.ts` (apps/desktop): **3 passed**, including the previously failing pointer-collapse case.
- Confirmed via live probe before/after: hit-area `getBoundingClientRect` no longer shifted by half height; center `elementFromPoint` resolves to the hit-area child; center drag collapses the shell.
- Full suite / CI e2e job not re-run locally (only the failing file); CI will cover the rest.