### PR TITLE
fix(headless): classify incomplete terminal provider streams under Pier

### DIFF
--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -18,6 +18,7 @@ import { CODEX_TOOLCHAIN_FINGERPRINT, CODEX_TOOLCHAIN_SPEC } from '../codex-tool
 import { OPENCODE_TOOLCHAIN_FINGERPRINT, OPENCODE_TOOLCHAIN_SPEC } from '../opencode-toolchain.js';
 import { findTrialDir } from '../harbor-task-runner.js';
 import { MAKA_NODE_TOOLCHAIN_FINGERPRINT } from '../maka-node-toolchain.js';
+import type { ProviderRequestTelemetry } from '../provider-auth-proxy.js';
 import {
   buildPierRunArgs,
   createPierProviderProxyHub,
@@ -1470,6 +1471,63 @@ test('createPierTaskRunner requires the OpenCode toolchain mount for the OpenCod
       }),
     );
     await assert.rejects(runner(runInput()), /opencodeToolchainPath is required/);
+  });
+});
+
+test('createPierTaskRunner rejects a Pier cell whose terminal provider stream is incomplete', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const makeRunner = (outcome: ProviderRequestTelemetry['outcome']) =>
+      createPierTaskRunner(
+        baseOptions({
+          jobsDir,
+          makaRepoPath: repo,
+          agent: 'opencode',
+          agentVersion: OPENCODE_TOOLCHAIN_SPEC.opencode.version,
+          backend: 'ai-sdk',
+          provider: 'deepseek',
+          model: 'deepseek-v4-flash',
+          reasoningEffort: 'max',
+          opencodeToolchainPath: repo,
+          apiKeyFile: '/secrets/deepseek.key',
+          providerProxyHub: {
+            baseUrl: 'http://host.docker.internal:443',
+            issue: () => ({
+              baseUrl: 'http://host.docker.internal:443',
+              token: 'ephemeral-token',
+              usage: () => null,
+              telemetry: () => [
+                {
+                  requestId: 1,
+                  method: 'POST',
+                  path: '/chat/completions',
+                  status: 200,
+                  outcome,
+                  durationMs: 5,
+                  bodyChunks: 1,
+                  responseBytes: 64,
+                  terminalEvent: outcome === 'completed',
+                },
+              ],
+              close: async () => {},
+            }),
+            close: async () => {},
+          },
+          runPier: fakePier({ reward: 0 }),
+        }),
+      );
+
+    // A 200 stream without its protocol terminal event means the provider
+    // response is incomplete: same infra classification as the Harbor runner,
+    // never a graded model failure.
+    await assert.rejects(makeRunner('interrupted')(runInput()), (error: unknown) => {
+      assert.ok(error instanceof PierInfraError);
+      assert.match(error.message, /terminal provider request did not complete/);
+      assert.ok(error.artifactRefs?.providerTelemetryPath);
+      return true;
+    });
+    // A completed terminal request takes the normal reward path.
+    const output = await makeRunner('completed')(runInput());
+    assert.equal(output.harbor.reward, 0);
   });
 });
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -82,6 +82,20 @@ const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
 /** A Harbor-side failure (build/docker/timeout/missing artifact) — NOT a benchmark
  * result. The controller turns a thrown error into an infra_failed event so it is
  * excluded from scoring instead of polluting the KEEP/DISCARD decision as reward 0. */
+/** Shared across runners: the last proxied provider request must have
+ * completed. A 200 stream without its protocol terminal event means the
+ * provider response is incomplete — the trial is an infra failure, never a
+ * graded model failure. Complete timed-out trials settle by deadline, so
+ * their truncated tail request is expected and exempt. */
+export function incompleteTerminalProviderRequest(
+  providerTelemetry: readonly ProviderRequestTelemetry[],
+  completeTimedOutTrial: boolean,
+): ProviderRequestTelemetry | undefined {
+  if (completeTimedOutTrial) return undefined;
+  const terminal = providerTelemetry.at(-1);
+  return terminal && terminal.outcome !== 'completed' ? terminal : undefined;
+}
+
 export class HarborInfraError extends Error {
   constructor(
     message: string,
@@ -374,12 +388,11 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
           tail(result.stderr || result.stdout),
         );
       }
-      const terminalProviderRequest = providerTelemetry.at(-1);
-      if (
-        !completeTimedOutTrial &&
-        terminalProviderRequest &&
-        terminalProviderRequest.outcome !== 'completed'
-      ) {
+      const terminalProviderRequest = incompleteTerminalProviderRequest(
+        providerTelemetry,
+        completeTimedOutTrial,
+      );
+      if (terminalProviderRequest) {
         throw new HarborInfraError(
           `terminal provider request did not complete for task ${input.task.id}`,
           [

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -32,6 +32,7 @@ import {
   readTrialException,
   resolveNativeTrialTimeoutMs,
   withProviderTelemetryArtifact,
+  incompleteTerminalProviderRequest,
   modelForOpenCode,
   type HarborTaskPricing,
 } from './harbor-task-runner.js';
@@ -537,6 +538,27 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
         throw new PierInfraError(
           `pier run exited ${result.exitCode} for task ${input.task.id}`,
           tail(result.stderr || result.stdout),
+        );
+      }
+      // Same terminal-stream contract as the Harbor runner: a non-completing
+      // last provider request is infra, never a graded model failure.
+      const terminalProviderRequest = incompleteTerminalProviderRequest(
+        providerTelemetry,
+        completeTimedOutTrial,
+      );
+      if (terminalProviderRequest) {
+        throw new PierInfraError(
+          `terminal provider request did not complete for task ${input.task.id}`,
+          [
+            `outcome=${terminalProviderRequest.outcome}`,
+            terminalProviderRequest.status !== undefined
+              ? `status=${terminalProviderRequest.status}`
+              : undefined,
+          ]
+            .filter(Boolean)
+            .join(', '),
+          'infra_failed',
+          { providerTelemetryPath },
         );
       }
 


### PR DESCRIPTION
## Summary

Post-merge external review of #1758 found that `d783aa3a4`'s terminal-provider-stream classification only exists in the Harbor runner: a Pier trial whose last proxied provider request ends `interrupted`/`failed`/`aborted` (a 200 stream without its protocol terminal event = incomplete provider response) still reads the verifier reward and can record a graded model failure where Harbor throws infra. This ports the semantic to the Pier runner.

- Extracts the predicate as `incompleteTerminalProviderRequest` in `harbor-task-runner.ts` (the module both runners already import shared helpers from); Harbor's behavior is byte-identical
- `pier-task-runner.ts` throws `PierInfraError` ('infra_failed', telemetry artifact attached) at the same point in its flow — after the exit-code check, before reading the reward
- Both DeepSWE arms run under Pier, so paired comparability was never broken; this fixes the classification itself for every Pier benchmark

## Verification

- RED first: new pier-runner test fails with "Missing expected rejection" before the fix
- The test drives the runner's real seam — a hub lease whose recorded telemetry ends `interrupted` must throw, `completed` must take the reward path (the proxy's recording of truncated streams is already covered by the Harbor live-SSE test on the shared proxy machinery)
- `packages/headless` suite: 1456 pass / 0 fail; `format`/`lint` clean

## Review focus

The timed-out-trial exemption is shared with Harbor: complete timed-out trials settle by deadline, so their truncated tail request is expected.
