### PR TITLE
test: prune redundant script coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           MAKA_REQUIRE_LINUX_SANDBOX_SMOKE: '1'
         run: npm exec -w @maka/runtime -- node --test dist/__tests__/linux-sandbox-smoke.test.js
       - name: Run fast script tests
-        if: needs.changes.outputs.script_mode != 'none'
+        if: needs.changes.outputs.script_mode == 'fast' || needs.changes.outputs.script_mode == 'full'
         run: npm run test:scripts
       - name: Run extended script tests
         if: needs.changes.outputs.script_mode == 'extended' || needs.changes.outputs.script_mode == 'full'

--- a/scripts/build-astryx-theme.test.mjs
+++ b/scripts/build-astryx-theme.test.mjs
@@ -1,26 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import {
-  buildAstryxTheme,
-  normalizeGeneratedHeader,
-  stripResetLayer,
-} from './build-astryx-theme.mjs';
-
-test('normalizes volatile Astryx generator metadata', () => {
-  const generated = `/**
- * Command: astryx theme build source.ts --out /tmp/build/maka.css
- * Generated: 2026-07-31T12:34:56.789Z
- */
-`;
-
-  assert.equal(
-    normalizeGeneratedHeader(generated),
-    `/**
- * Command: astryx theme build src/renderer/astryx-theme/makaTheme.ts --out src/renderer/astryx-theme/maka.css
- */
-`,
-  );
-});
+import { stripResetLayer } from './build-astryx-theme.mjs';
 
 test('strips exactly the generated reset layer and preserves nested rules', () => {
   const generated = `/**
@@ -40,14 +20,9 @@ test('strips exactly the generated reset layer and preserves nested rules', () =
 
   const stripped = stripResetLayer(generated);
   assert.doesNotMatch(stripped, /@layer reset\s*\{/);
-  assert.match(stripped, /Post-processed by scripts\/build-astryx-theme\.mjs/);
   assert.match(stripped, /@layer astryx-theme/);
   assert.throws(
     () => stripResetLayer('@layer astryx-theme {}'),
     /expected a leading "@layer reset/,
   );
-});
-
-test('checked-in Astryx theme artifacts match a fresh build', () => {
-  assert.doesNotThrow(() => buildAstryxTheme({ check: true, stdio: 'pipe' }));
 });

--- a/scripts/check-hit-test.test.mjs
+++ b/scripts/check-hit-test.test.mjs
@@ -1,56 +1,12 @@
-// CLI contract for the hit-test harness, driven as a real subprocess so the
-// exit codes under test are the ones a shell actually sees. Every case here
-// fails (or prints help) during argument parsing, before any window launches.
-//
-// The case that earns this file: `--route chat --route chatt` used to drop
-// the typo, probe one route, and exit 0 as "1 route(s) clean" — a coverage
-// tool silently shrinking the requested coverage.
 import { strict as assert } from 'node:assert';
-import { spawn } from 'node:child_process';
-import { dirname, join } from 'node:path';
-import { describe, it } from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
 import { HitTestArgumentError, parseHitTestArgs } from './check-hit-test.mjs';
 
-const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'check-hit-test.mjs');
-
-function runCli(args) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [SCRIPT, ...args], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', (chunk) => {
-      stdout += chunk;
-    });
-    child.stderr.on('data', (chunk) => {
-      stderr += chunk;
-    });
-    child.on('error', reject);
-    child.on('close', (code) => resolve({ code, stdout, stderr }));
-  });
-}
-
-describe('check-hit-test CLI', () => {
-  it('parses repeated routes without silently dropping a typo', () => {
-    assert.deepEqual(parseHitTestArgs(['--route', 'chat', '--route', 'settings-general']), {
-      routes: ['chat', 'settings-general'],
-    });
-    assert.throws(
-      () => parseHitTestArgs(['--route', 'chat', '--route', 'chatt']),
-      (error) =>
-        error instanceof HitTestArgumentError && /must be one of: .*chat/.test(error.message),
-    );
-  });
-
-  it('rejects unknown flags without starting the renderer harness', () => {
-    assert.throws(() => parseHitTestArgs(['--not-a-flag']), /unknown arg/);
-  });
-
-  it('preserves the real process help and exit-code contract', async () => {
-    const { code, stdout } = await runCli(['--help']);
-    assert.equal(code, 0);
-    assert.match(stdout, /Routes: chat, settings-general, settings-providers, mcp-hub, onboarding/);
-  });
+test('hit-test arguments reject typos and unknown flags', () => {
+  assert.throws(
+    () => parseHitTestArgs(['--route', 'chat', '--route', 'chatt']),
+    (error) =>
+      error instanceof HitTestArgumentError && /must be one of: .*chat/.test(error.message),
+  );
+  assert.throws(() => parseHitTestArgs(['--not-a-flag']), /unknown arg/);
 });

--- a/scripts/check-visual-contract.test.mjs
+++ b/scripts/check-visual-contract.test.mjs
@@ -1,12 +1,5 @@
-// Unit tests for the pure parts of the migration contract harness.
-//
-// These exist because the harness shipped two bugs a table test would have
-// caught at design time: three `INITIAL_VALUES` entries that never matched
-// what Chromium serialises (so the properties they were meant to suppress
-// appeared on every record), and a diff whose behaviour under a wrapper
-// insertion nobody had measured.
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'node:test';
+import { test } from 'node:test';
 import {
   checkSalvagedAnchors,
   checkScopeCoverage,
@@ -21,81 +14,31 @@ import {
 
 const record = (path, extra = {}) => ({ path, rect: [0, 0, 10, 10], ...extra });
 
-describe('diffRecords', () => {
-  it('names the changed properties with both values', () => {
-    const before = [record('body>div', { color: 'red' })];
-    const after = [record('body>div', { color: 'blue' })];
-    const changes = diffRecords(before, after);
-    assert.equal(changes.length, 1);
-    assert.equal(changes[0].kind, 'changed');
-    assert.deepEqual(changes[0].properties, [{ property: 'color', before: 'red', after: 'blue' }]);
-  });
+test('visual diffs preserve property values, scope, and structural priority', () => {
+  const changes = diffRecords(
+    [record('body>div', { color: 'red', scope: 'legacy' }), record('body>p')],
+    [record('body>div', { color: 'blue', scope: 'current' }), record('body>section')],
+  );
 
-  it('reports a property that appeared as a diff from absent', () => {
-    // The omission scheme reads "absent means the initial or inherited value",
-    // so a migration that starts setting one has to show up.
-    const changes = diffRecords([record('body>div')], [record('body>div', { boxShadow: '0 1px' })]);
-    assert.deepEqual(changes[0].properties, [
-      { property: 'boxShadow', before: undefined, after: '0 1px' },
-    ]);
-  });
-
-  it('sorts real property changes ahead of the structural churn', () => {
-    // A wrapper insertion renames paths, which reads as removed+added. Those
-    // must not push a genuine `changed` past the print limit.
-    const before = [record('body>div', { color: 'red' }), record('body>p')];
-    const after = [record('body>div', { color: 'blue' }), record('body>section')];
-    const kinds = diffRecords(before, after).map((change) => change.kind);
-    assert.equal(kinds[0], 'changed');
-    assert.deepEqual(kinds.slice(1).sort(), ['added', 'removed']);
-  });
-
-  it('re-keys the whole subtree when a wrapper is inserted', () => {
-    // Documents the known limit rather than asserting it is fine: identity is
-    // the path, so this is a `removed` plus an `added` per descendant. PR 1
-    // does not touch the DOM, which is the slice this harness was built for.
-    const before = [record('body>div'), record('body>div>span'), record('body>div>span>b')];
-    const after = [
-      record('body>div'),
-      record('body>div>i'),
-      record('body>div>i>span'),
-      record('body>div>i>span>b'),
-    ];
-    const changes = diffRecords(before, after);
-    assert.equal(changes.filter((c) => c.kind === 'removed').length, 2);
-    assert.equal(changes.filter((c) => c.kind === 'added').length, 3);
-  });
+  assert.equal(changes[0].kind, 'changed');
+  assert.equal(changes[0].scope, 'current');
+  assert.deepEqual(changes[0].properties, [{ property: 'color', before: 'red', after: 'blue' }]);
+  assert.deepEqual(
+    diffRecords([record('a')], [record('a', { boxShadow: '0 1px' })])[0].properties,
+    [{ property: 'boxShadow', before: undefined, after: '0 1px' }],
+  );
+  assert.deepEqual(
+    changes
+      .slice(1)
+      .map(({ kind }) => kind)
+      .sort(),
+    ['added', 'removed'],
+  );
+  assert.equal(summarise(Array(60).fill({ kind: 'removed' }), 100).structural, true);
 });
 
-describe('summarise', () => {
-  it('flags a diff whose shape means the tree moved, not the styles', () => {
-    const changes = Array.from({ length: 60 }, (_, i) => ({
-      kind: 'removed',
-      path: `body>div>p:${i}`,
-    }));
-    const { structural, text } = summarise(changes, 100);
-    assert.equal(structural, true);
-    assert.match(text, /60 removed/);
-  });
-
-  it('does not flag a handful of removals in a large baseline', () => {
-    const changes = [
-      { kind: 'removed', path: 'body>div' },
-      { kind: 'changed', path: 'body>p' },
-    ];
-    assert.equal(summarise(changes, 100).structural, false);
-  });
-});
-
-describe('property tables', () => {
-  // Which properties CSS itself inherits, among those worth capturing. This
-  // is a spec fact, restated here so the tables cannot drift from it: the
-  // harness shipped `textAlign` in PROPERTIES but not INHERITED_PROPERTIES,
-  // and 79–85% of all records re-recorded an ancestor's value — one container
-  // change printed as N descendant lines and ate the 40-line print limit.
-  // `findDeadOmissionRules` cannot see this class (it only checks
-  // INITIAL_VALUES keys), so it is pinned statically instead.
-  const CSS_INHERITED = new Set([
+test('omission tables encode CSS inheritance without ambiguous or dead rules', () => {
+  const cssInherited = new Set([
     'color',
     'cursor',
     'fontFamily',
@@ -112,160 +55,42 @@ describe('property tables', () => {
     'wordBreak',
   ]);
 
-  it('routes every CSS-inherited property through the inherited omission', () => {
-    for (const property of PROPERTIES) {
-      if (!CSS_INHERITED.has(property)) continue;
-      assert.ok(
-        INHERITED_PROPERTIES.includes(property),
-        `${property} is CSS-inherited but absent from INHERITED_PROPERTIES: every descendant will re-record its ancestor's value`,
-      );
-    }
-  });
-
-  it('never routes a non-inherited property through the inherited omission', () => {
-    // The reverse direction: a non-inherited property in INHERITED_PROPERTIES
-    // would be omitted whenever it happens to equal an ancestor's value —
-    // an omission the reader would wrongly "recover" as inheritance.
-    for (const property of INHERITED_PROPERTIES) {
-      assert.ok(
-        CSS_INHERITED.has(property),
-        `${property} is in INHERITED_PROPERTIES but CSS does not inherit it`,
-      );
-    }
-  });
-
-  it('never gives an inherited property an initial-value rule too', () => {
-    // "Absent" must mean exactly one thing. If an inherited property also had
-    // an INITIAL_VALUES entry, a record could omit it for either reason, and
-    // a reader recovering the value from the nearest recorded ancestor would
-    // recover the wrong one.
-    for (const property of INHERITED_PROPERTIES) {
-      assert.ok(
-        !(property in INITIAL_VALUES),
-        `${property} is in both INHERITED_PROPERTIES and INITIAL_VALUES`,
-      );
-    }
-  });
+  assert.deepEqual(
+    PROPERTIES.filter((property) => cssInherited.has(property)).sort(),
+    [...INHERITED_PROPERTIES].sort(),
+  );
+  assert.equal(
+    INHERITED_PROPERTIES.some((property) => property in INITIAL_VALUES),
+    false,
+  );
+  assert.deepEqual(findDeadOmissionRules({ sampled: 10, hits: { gap: 0 } }, { gap: 'normal' }), [
+    { property: 'gap', sampled: 10 },
+  ]);
 });
 
-describe('findDeadOmissionRules', () => {
-  it('flags a rule that never matched a single raw sample', () => {
-    // The real bug: `gap: 'normal normal'` in the table, `normal` from
-    // Chromium, so the rule matched zero samples and every record kept a
-    // constant nobody could read as signal.
-    const dead = findDeadOmissionRules(
-      { sampled: 120, hits: { gap: 0 } },
-      { gap: 'normal normal' },
-    );
-    assert.deepEqual(dead, [{ property: 'gap', sampled: 120 }]);
-  });
-});
+test('declared scopes fail closed and cannot claim most of a capture', () => {
+  const baseOnlyClaim = diffRecords(
+    [record('body>div', { color: 'red', scope: 'legacy' })],
+    [record('body>div', { color: 'blue' })],
+  );
+  assert.equal(partitionChanges(baseOnlyClaim, ['legacy']).outOfScope.length, 1);
 
-describe('checkSalvagedAnchors', () => {
-  const anchors = [{ commit: 'abc', regression: 'r', route: 'chat', anchor: 'list-row' }];
-  const captureKey = 'chat.light.darwin';
-
-  it('rejects a different hook that merely contains the anchor', () => {
-    // `list-row-meta` is a different element; a substring match would report
-    // the anchor as watched by something that is not the element the
-    // regression happened on.
-    const captures = new Map([[captureKey, [record('a', { contract: 'list-row-meta' })]]]);
-    assert.equal(checkSalvagedAnchors(captures, anchors).length, 1);
-  });
-
-  it('does not accept a product class in place of the hook', () => {
-    // Anchors moved off product classes on purpose: the class dies with the
-    // slice that migrates the component, the hook survives it.
-    const captures = new Map([[captureKey, [record('a', { classes: 'maka-list-row' })]]]);
-    assert.equal(checkSalvagedAnchors(captures, anchors).length, 1);
-  });
-
-  it('skips routes that were not captured this run', () => {
-    assert.deepEqual(checkSalvagedAnchors(new Map(), anchors), []);
-  });
-});
-
-describe('declared scopes', () => {
-  it('never reports harness bookkeeping as a visual diff', () => {
-    // PR 2 adds the hooks while `main` has none: if `contract` or `scope`
-    // were compared, the hook rollout itself would break the zero-diff gate.
-    const before = [record('body>div'), record('body>div>span')];
-    const after = [
-      record('body>div', { contract: 'session-workbar', scope: 'workbar' }),
-      record('body>div>span', { scope: 'workbar' }),
-    ];
-    assert.deepEqual(diffRecords(before, after), []);
-  });
-
-  it('attributes a changed element to the scope that landed it', () => {
-    const before = [record('body>div', { color: 'red', scope: 'legacy-button' })];
-    const after = [record('body>div', { color: 'blue', scope: 'button' })];
-    const changes = diffRecords(before, after);
-    assert.equal(changes[0].scope, 'button');
-  });
-
-  it('fails closed when only the base side claimed a changed element', () => {
-    // A mistyped migrated selector leaves the current side unclaimed. The
-    // base side's legacy claim must NOT carry over, or every change inside
-    // the old subtree would be silently waived (external review finding).
-    const before = [record('body>div', { color: 'red', scope: 'legacy-button' })];
-    const after = [record('body>div', { color: 'blue' })];
-    const { outOfScope } = partitionChanges(diffRecords(before, after), ['legacy-button']);
-    assert.equal(outOfScope.length, 1);
-  });
-
-  it('keeps the base attribution for a removed element', () => {
-    // The migrated side no longer has the element, so only the base capture
-    // knows which scope claimed it — the legacy selector the slice declared.
-    const changes = diffRecords([record('body>div', { scope: 'button' })], []);
-    assert.equal(changes[0].kind, 'removed');
-    assert.equal(changes[0].scope, 'button');
-  });
-
-  it('splits declared changes from undeclared ones', () => {
-    const changes = [
-      { kind: 'changed', path: 'a', scope: 'button' },
-      { kind: 'added', path: 'b', scope: 'badge' },
-      { kind: 'changed', path: 'c' },
-    ];
-    const { inScope, outOfScope } = partitionChanges(changes, ['button']);
-    assert.deepEqual(
-      inScope.map((change) => change.path),
-      ['a'],
-    );
-    assert.deepEqual(
-      outOfScope.map((change) => change.path),
-      ['b', 'c'],
-    );
-  });
-
-  it('treats an empty declaration as the zero-diff gate', () => {
-    const changes = [{ kind: 'changed', path: 'a', scope: 'button' }];
-    const { inScope, outOfScope } = partitionChanges(changes, []);
-    assert.equal(inScope.length, 0);
-    assert.equal(outOfScope.length, 1);
-  });
-});
-
-describe('checkScopeCoverage', () => {
-  const claimed = (n, scope) => Array.from({ length: n }, (_, i) => record(`p${i}`, { scope }));
-
-  it('fails a scope that claims most of a capture', () => {
-    // `#root *` avoids the in-browser root floor (it matches no root element)
-    // but still declares essentially the whole UI (external review finding).
-    const records = [...claimed(6, 'frame'), ...claimed(4, undefined)];
-    assert.deepEqual(checkScopeCoverage(records), [{ scope: 'frame', claimed: 6, total: 10 }]);
-  });
-
-  it('fails several individually small scopes whose union claims most of a capture', () => {
-    const records = [
+  const claimed = (count, scope) =>
+    Array.from({ length: count }, (_, index) => record(`p${index}-${scope}`, { scope }));
+  assert.deepEqual(
+    checkScopeCoverage([
       ...claimed(2, 'field'),
       ...claimed(2, 'switch'),
       ...claimed(2, 'selector'),
       ...claimed(4, undefined),
-    ];
-    assert.deepEqual(checkScopeCoverage(records), [
-      { scope: '<declared union>', claimed: 6, total: 10 },
-    ]);
-  });
+    ]),
+    [{ scope: '<declared union>', claimed: 6, total: 10 }],
+  );
+});
+
+test('salvaged anchors require an exact current capture hook', () => {
+  const anchors = [{ commit: 'abc', regression: 'r', route: 'chat', anchor: 'list-row' }];
+  const captures = new Map([['chat.light.darwin', [record('a', { contract: 'list-row-meta' })]]]);
+  assert.equal(checkSalvagedAnchors(captures, anchors).length, 1);
+  assert.deepEqual(checkSalvagedAnchors(new Map(), anchors), []);
 });

--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -147,7 +147,6 @@ export function planTests(changedFiles, options = {}) {
   }
 
   const workspaces = reverseDependencyClosure(directWorkspaces, graph);
-  if (code && scriptMode === 'none') scriptMode = 'fast';
   const storageStress = files.some(
     (path) =>
       path === 'packages/storage/src/agent-run-store.ts' ||

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -11,6 +11,7 @@ test('impact planning distinguishes docs, UI, and backend changes', () => {
 
   const ui = planTests(['packages/ui/src/button.tsx'], { graph });
   assert.equal(ui.e2e, true);
+  assert.equal(ui.scriptMode, 'none');
   assert.deepEqual(ui.workspaces, ['packages/ui', 'apps/desktop']);
 
   const backend = planTests(['packages/storage/src/session-store.ts'], { graph });
@@ -41,8 +42,18 @@ test('global and unknown production changes fail safe to the complete suite', ()
 });
 
 test('GitHub outputs stay scalar and shell-safe', () => {
-  const output = formatGitHubOutputs(planTests(['packages/ui/src/button.tsx'], { graph }));
-  assert.match(output, /^code=true$/m);
-  assert.match(output, /^unit=true$/m);
-  assert.match(output, /^workspaces=packages\/ui,apps\/desktop$/m);
+  assert.equal(
+    formatGitHubOutputs(planTests(['README.md'], { graph })),
+    [
+      'code=false',
+      'e2e=false',
+      'full=false',
+      'headless=false',
+      'runtime_sandbox=false',
+      'script_mode=none',
+      'storage_stress=false',
+      'unit=false',
+      'workspaces=',
+    ].join('\n'),
+  );
 });

--- a/scripts/cu-e2e-scenarios.test.mjs
+++ b/scripts/cu-e2e-scenarios.test.mjs
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
-  CU_E2E_ACTIONS,
   CU_E2E_SCENARIOS,
   evaluateCuE2eScenarioState,
   getCuE2eScenario,
@@ -10,9 +9,9 @@ import {
   validateCuE2eScenarioLibrary,
 } from './cu-e2e-scenarios.mjs';
 
-test('scenario library validates and covers every layer', () => {
+test('the scenario library is internally valid and covers every layer', () => {
   assert.equal(validateCuE2eScenarioLibrary(), CU_E2E_SCENARIOS);
-  assert.deepEqual([...new Set(CU_E2E_SCENARIOS.map((scenario) => scenario.level))].sort(), [
+  assert.deepEqual([...new Set(CU_E2E_SCENARIOS.map(({ level }) => level))].sort(), [
     'L0',
     'L1',
     'L2',
@@ -20,210 +19,52 @@ test('scenario library validates and covers every layer', () => {
     'L4',
     'L5',
   ]);
-  assert.equal(
-    new Set(CU_E2E_SCENARIOS.map((scenario) => scenario.id)).size,
-    CU_E2E_SCENARIOS.length,
-  );
 });
 
-test('L4 and L5 use dedicated non-mutating runners', () => {
-  const l4 = getCuE2eScenario('l4-user-concurrency');
-  const l5 = getCuE2eScenario('l5-provider-matrix');
-  assert.equal(l4.runner, 'safety-sentinel');
-  assert.equal(l5.runner, 'provider-matrix');
-  assert.deepEqual(l4.allowedActions, ['observe', 'screenshot', 'wait']);
-  assert.deepEqual(l5.allowedActions, ['observe']);
-});
-
-test('the first enabled real-model scenario is observe-only', () => {
-  const first = CU_E2E_SCENARIOS.find((scenario) => scenario.realRunEnabled);
-  assert.equal(first?.id, 'l0-observe-only');
-  assert.deepEqual(first?.allowedActions, ['observe']);
-  assert.deepEqual(first?.requiresExecutionCapabilities, []);
-});
-
-test('every scenario carries prompt, fixture, expected state, forbidden effects, and bounded actions', () => {
-  const knownActions = new Set(CU_E2E_ACTIONS);
-  for (const scenario of CU_E2E_SCENARIOS) {
-    assert.ok(scenario.prompt.length >= 20, scenario.id);
-    assert.ok(scenario.fixtureSetup.windows.length > 0, scenario.id);
-    assert.ok(scenario.expectedState.length > 0, scenario.id);
-    assert.ok(scenario.forbiddenEffects.length > 0, scenario.id);
-    assert.ok(
-      scenario.allowedActions.includes('screenshot') || scenario.allowedActions.includes('observe'),
-      scenario.id,
-    );
-    assert.ok(
-      scenario.allowedActions.every((action) => knownActions.has(action)),
-      scenario.id,
-    );
-    assert.equal(typeof scenario.realRunEnabled, 'boolean', scenario.id);
-    assert.ok(Array.isArray(scenario.requiresExecutionCapabilities), scenario.id);
-    assert.ok(Array.isArray(scenario.contractChecks), scenario.id);
-    if (['L0', 'L1', 'L2', 'L3', 'L4'].includes(scenario.level)) {
-      assert.ok((scenario.minimumActionCounts?.observe ?? 0) >= 1, scenario.id);
-      assert.ok(Number.isInteger(scenario.maxTotalActions), scenario.id);
-      assert.ok(scenario.maxTotalActions > 0, scenario.id);
-    }
-  }
-});
-
-test('layer action budgets increase deliberately', () => {
-  assert.deepEqual(getCuE2eScenario('l0-observe-only').allowedActions, ['observe']);
-  assert.ok(getCuE2eScenario('l1-single-click').allowedActions.includes('click_element'));
-  assert.ok(!getCuE2eScenario('l1-single-click').allowedActions.includes('left_click'));
-  assert.equal(getCuE2eScenario('l1-single-click').minimumActionCounts.observe, 2);
-  assert.deepEqual(getCuE2eScenario('l1-single-click').expectedActionSequence, [
-    'observe',
-    'observe',
-    'click_element',
-  ]);
-
-  const multi = getCuE2eScenario('l2-multi-control');
-  assert.ok(multi.allowedActions.includes('scroll'));
-  assert.ok(multi.allowedActions.includes('left_click_drag'));
-  assert.ok(multi.allowedActions.includes('type'));
-
-  const occlusion = getCuE2eScenario('l3-occlusion');
-  assert.ok(!occlusion.allowedActions.includes('left_click'));
-  assert.equal(occlusion.realRunEnabled, true);
-  assert.equal(getCuE2eScenario('l3-two-window').realRunEnabled, false);
-});
-
-test('L3 isolates two-window, stale, and occlusion hazards', () => {
-  const l3 = CU_E2E_SCENARIOS.filter((scenario) => scenario.level === 'L3');
-  assert.deepEqual(
-    l3.map((scenario) => scenario.id),
-    ['l3-two-window', 'l3-stale-window', 'l3-occlusion'],
-  );
-  assert.equal(getCuE2eScenario('l3-two-window').fixtureSetup.windows.length, 2);
-  assert.equal(
-    getCuE2eScenario('l3-stale-window').fixtureSetup.transitions[0].type,
-    'replace-window',
-  );
-  assert.equal(getCuE2eScenario('l3-occlusion').fixtureSetup.layout, 'overlap');
-});
-
-test('L1-L4 declare exact Window/frame, stale, zoom, display, and ownership gates', () => {
-  const checks = new Set(
-    CU_E2E_SCENARIOS.filter(({ level }) => ['L1', 'L2', 'L3', 'L4'].includes(level)).flatMap(
-      ({ contractChecks }) => contractChecks,
-    ),
-  );
-  assert.deepEqual([...checks].sort(), [
-    'ax-diff-secondary-oracle',
-    'duplicate-action-rejection',
-    'explicit-occurrence-selection',
-    'focus-cursor-safety',
-    'fresh-post-action-observation',
-    'identity-preserving-stale-resolution',
-    'immediately-preceding-local-screenshot',
-    'keyboard-ownership',
-    'mixed-scale-mapping',
-    'negative-origin-mapping',
-    'observation-window-frame-binding',
-    'occlusion-rejection',
-    'semantic-action-coverage',
-    'two-window-isolation',
-    'unrelated-dynamic-content-tolerated',
-    'zoom-crop-coordinate-space',
-  ]);
-});
-
-test('state evaluation reports expected and forbidden-effect failures separately', () => {
+test('state evaluation separates expected-state and forbidden-effect failures', () => {
   const scenario = getCuE2eScenario('l1-single-click');
-  const passing = evaluateCuE2eScenarioState(scenario, {
-    target: { primaryClicks: 1, primaryOverClicks: 0, dangerClicks: 0 },
-  });
-  assert.equal(passing.pass, true);
-
-  const failing = evaluateCuE2eScenarioState(scenario, {
+  const result = evaluateCuE2eScenarioState(scenario, {
     target: { primaryClicks: 2, primaryOverClicks: 1, dangerClicks: 1 },
   });
-  assert.equal(failing.pass, false);
-  assert.equal(failing.expected.find((result) => result.path === 'primaryClicks').pass, false);
+
+  assert.equal(result.pass, false);
+  assert.equal(result.expected.find(({ path }) => path === 'primaryClicks').pass, false);
   assert.equal(
-    failing.forbidden.every((result) => !result.pass),
+    result.forbidden.every(({ pass }) => !pass),
     true,
   );
 });
 
-test('validation rejects ambiguous or unsafe scenario declarations', () => {
+test('validation rejects unsafe action, matcher, budget, and expected-failure declarations', () => {
   const base = structuredClone(getCuE2eScenario('l1-single-click'));
-
-  assert.throws(
-    () => validateCuE2eScenario({ ...base, allowedActions: ['screenshot', 'shell'] }),
-    /unknown action "shell"/,
-  );
-  assert.throws(
-    () => validateCuE2eScenario({ ...base, forbiddenEffects: [] }),
-    /forbiddenEffects must be non-empty/,
-  );
-
-  const unknownWindow = structuredClone(base);
-  unknownWindow.expectedState[0].windowId = 'other';
-  assert.throws(() => validateCuE2eScenario(unknownWindow), /references unknown window "other"/);
-
-  const ambiguousMatcher = structuredClone(base);
-  ambiguousMatcher.expectedState[0].greaterThan = 0;
-  assert.throws(() => validateCuE2eScenario(ambiguousMatcher), /exactly one matcher/);
-
-  assert.throws(
-    () => validateCuE2eScenario({ ...base, contractChecks: ['not-a-contract'] }),
-    /unknown check/,
-  );
-  assert.throws(
-    () =>
-      validateCuE2eScenario({
+  const invalid = [
+    [{ ...base, allowedActions: ['screenshot', 'shell'] }, /unknown action/],
+    [{ ...base, forbiddenEffects: [] }, /forbiddenEffects must be non-empty/],
+    [
+      {
         ...base,
-        minimumActionCounts: { left_click: 1 },
-      }),
-    /disallowed action/,
-  );
-  assert.throws(
-    () =>
-      validateCuE2eScenario({
+        expectedState: [{ ...base.expectedState[0], greaterThan: 0 }],
+      },
+      /exactly one matcher/,
+    ],
+    [
+      {
         ...base,
         minimumActionCounts: { observe: 3 },
         maxActionCounts: { observe: 2 },
-      }),
-    /minimum exceeds maximum/,
-  );
-  assert.throws(
-    () =>
-      validateCuE2eScenario({
-        ...base,
-        minimumActionCounts: { observe: 2, click_element: 2 },
-        maxActionCounts: { observe: 2, click_element: 2 },
-        maxTotalActions: 3,
-      }),
-    /exceed maxTotalActions/,
-  );
-  assert.throws(
-    () =>
-      validateCuE2eScenario({
+      },
+      /minimum exceeds maximum/,
+    ],
+    [
+      {
         ...base,
         expectedFailures: [{ action: 'left_click', error: 'stale_frame' }],
-      }),
-    /allowed action and error pairs/,
-  );
-  assert.throws(
-    () =>
-      validateCuE2eScenario({
-        ...base,
-        expectedFailures: [{ action: 'click_element', error: 'Stale frame' }],
-      }),
-    /allowed action and error pairs/,
-  );
-  assert.throws(
-    () =>
-      validateCuE2eScenario({
-        ...base,
-        expectedFailures: [
-          { action: 'click_element', error: 'stale_frame' },
-          { action: 'click_element', error: 'stale_frame' },
-        ],
-      }),
-    /contains duplicates/,
-  );
+      },
+      /allowed action and error pairs/,
+    ],
+  ];
+
+  for (const [scenario, pattern] of invalid) {
+    assert.throws(() => validateCuE2eScenario(scenario), pattern);
+  }
 });

--- a/scripts/cu-provider-matrix.test.mjs
+++ b/scripts/cu-provider-matrix.test.mjs
@@ -1,16 +1,9 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { spawnSync } from 'node:child_process';
 import test from 'node:test';
-import {
-  buildProviderMatrix,
-  normalizeReport,
-  renderMarkdown,
-  summarizeLatency,
-  validateRealReport,
-} from './cu-provider-matrix.mjs';
+import { buildProviderMatrix, runCli, validateRealReport } from './cu-provider-matrix.mjs';
 
 function scenario(overrides = {}) {
   return {
@@ -119,213 +112,52 @@ function withLedgerCounts(report) {
   };
 }
 
-test('summarizeLatency reports stable aggregate latency metrics', () => {
-  assert.deepEqual(summarizeLatency([40, 10, 30, 20]), {
-    samples: 4,
-    averageMs: 25,
-    p50Ms: 20,
-    p95Ms: 40,
-    maxMs: 40,
-  });
-  assert.equal(summarizeLatency([null, undefined, Number.NaN]), null);
-});
-
-test('normalizeReport unifies real-model and direct-provider report fields', () => {
-  const metrics = normalizeReport(
-    {
-      actions: [
-        { modelLatencyMs: 120, toolLatencyMs: 40, displayLagMs: 8 },
-        { modelLatencyMs: 80, durationMs: 20, displayLagMs: 4, retry: true },
-      ],
-      forbiddenEffects: [],
-      fixtureState: { target: { blue: 1, red: 0 } },
-    },
-    scenario(),
-  );
-
-  assert.equal(metrics.modelLatency.averageMs, 100);
-  assert.equal(metrics.toolLatency.averageMs, 30);
-  assert.equal(metrics.displayLag.p50Ms, 4);
-  assert.equal(metrics.actionCount, 2);
-  assert.equal(metrics.retries, 1);
-  assert.equal(metrics.fixture.status, 'pass');
-  assert.equal(metrics.forbiddenEffects.status, 'pass');
-});
-
-test('buildProviderMatrix covers Claude, OpenAI, Kimi, and MiniMax readiness', async () => {
-  const reports = new Map([
-    [
-      '/reports/claude-click.json',
-      realReport({
-        provider: 'claude',
-        model: 'claude-sonnet',
-        actions: [
-          {
-            type: 'observe',
-            toolCallId: 'observe-1',
-            resultObservationId: 'observation-1',
-            targetPid: 42,
-            targetWindowId: 7,
-            success: true,
-            targetOwned: true,
-            modelLatencyMs: 100,
-            toolLatencyMs: 25,
-            displayLagMs: 5,
-          },
-          {
-            type: 'click_element',
-            toolCallId: 'click-1',
-            sourceObservationId: 'observation-1',
-            resultObservationId: 'observation-2',
-            targetPid: 42,
-            targetWindowId: 7,
-            success: true,
-            targetOwned: true,
-            durationMs: 30,
-          },
-        ],
-      }),
-    ],
-    [
-      '/reports/openai-click.json',
-      realReport({
-        status: 'fail',
-        fixtureState: { target: { blue: 1, red: 1 } },
-        forbiddenEffects: {
-          status: 'fail',
-          violations: [{ windowId: 'target', path: 'red', actual: 1, pass: false }],
-        },
-      }),
-    ],
-  ]);
-  const scenarios = [scenario()];
-  const providers = [
-    {
-      id: 'claude',
-      label: 'Claude',
-      readiness: 'real',
-      producer: 'cu-real-model-launcher',
-      model: 'claude-sonnet',
-      commandTemplate: ['npm', 'run', 'e2e:computer-use:model', '--', '{scenarioId}'],
-      reportTemplate: '/reports/{providerId}-{scenarioId}.json',
-    },
-    {
-      id: 'openai',
-      label: 'OpenAI',
-      readiness: 'real',
-      producer: 'cu-real-model-launcher',
-      model: 'gpt-5.4',
-      commandTemplate: 'npm run e2e:computer-use:openai -- {scenarioId}',
-      reportTemplate: '/reports/{providerId}-{scenarioId}.json',
-    },
-    {
-      id: 'kimi',
-      label: 'Kimi',
-      readiness: 'contract',
-      commandTemplate: 'node kimi.mjs {scenarioId}',
-    },
-    { id: 'minimax', label: 'MiniMax', readiness: 'unsupported' },
-  ];
-  const matrix = await buildProviderMatrix({
-    scenarios,
-    providers,
-    generatedAt: '2026-07-12T00:00:00.000Z',
-    loadReport: async (path) => {
-      if (!reports.has(path)) {
-        const error = new Error('missing');
-        error.code = 'ENOENT';
-        throw error;
-      }
-      return reports.get(path);
-    },
-  });
-
-  assert.deepEqual(matrix.summary.readiness, { real: 2, contract: 1, unsupported: 1 });
-  assert.deepEqual(matrix.summary.status, {
-    pass: 1,
-    'invalid-report': 1,
-    'contract-only': 1,
-    unsupported: 1,
-  });
-  assert.equal(matrix.rows[0].command, 'npm run e2e:computer-use:model -- click');
-  assert.equal(matrix.rows[0].modelLatency.p50Ms, 100);
-  assert.equal(matrix.rows[1].status, 'invalid-report');
-  assert.match(matrix.rows[1].reportError, /status must be pass/);
-  assert.equal(matrix.rows[2].actionCount, null);
-  assert.equal(matrix.rows[3].status, 'unsupported');
-
-  const markdown = renderMarkdown(matrix);
-  assert.match(
-    markdown,
-    /Claude \| Owned fixture click \| real \| real-runtime \| enforced \| pass/,
-  );
-  assert.match(markdown, /OpenAI \| Owned fixture click \| real \| - \| - \| invalid-report/);
-  assert.match(markdown, /Kimi \| Owned fixture click \| contract \| - \| - \| contract-only/);
-  assert.match(markdown, /MiniMax \| Owned fixture click \| unsupported \| - \| - \| unsupported/);
-});
-
-test('CLI writes JSON and Markdown without executing provider command templates', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'cu-provider-matrix-'));
-  const marker = join(dir, 'provider-command-ran');
-  const scenariosPath = join(dir, 'scenarios.json');
-  const providersPath = join(dir, 'providers.json');
-  const reportPath = join(dir, 'claude-click.json');
-  const jsonPath = join(dir, 'output', 'matrix.json');
-  const markdownPath = join(dir, 'output', 'matrix.md');
-  await Promise.all([
-    writeFile(scenariosPath, JSON.stringify({ scenarios: [scenario()] })),
-    writeFile(
-      providersPath,
-      JSON.stringify({
-        providers: [
-          {
-            id: 'claude',
-            readiness: 'real',
-            producer: 'cu-real-model-launcher',
-            model: 'gpt-5.4',
-            commandTemplate: `${process.execPath} -e "require('node:fs').writeFileSync('${marker}','bad')"`,
-            reportTemplate: '{providerId}-{scenarioId}.json',
-          },
-          { id: 'openai', readiness: 'contract', commandTemplate: 'openai {scenarioId}' },
-          { id: 'kimi', readiness: 'contract', commandTemplate: 'kimi {scenarioId}' },
-          { id: 'minimax', readiness: 'unsupported' },
-        ],
-      }),
+test('a valid real report passes the shared verdict', () => {
+  assert.deepEqual(
+    validateRealReport(
+      realReport(),
+      { id: 'openai', producer: 'cu-real-model-launcher', model: 'gpt-5.4' },
+      scenario(),
     ),
-    writeFile(
-      reportPath,
-      JSON.stringify(
-        realReport({
-          provider: 'claude',
-          model: 'gpt-5.4',
+    [],
+  );
+});
+
+test('matrix generation never executes provider command templates', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'cu-matrix-'));
+  const marker = join(directory, 'executed');
+  const scenariosPath = join(directory, 'scenarios.json');
+  const providersPath = join(directory, 'providers.json');
+  try {
+    await Promise.all([
+      writeFile(scenariosPath, JSON.stringify({ scenarios: [scenario()] })),
+      writeFile(
+        providersPath,
+        JSON.stringify({
+          providers: [
+            {
+              id: 'openai',
+              readiness: 'contract',
+              commandTemplate: `${process.execPath} -e "require('node:fs').writeFileSync('${marker}','bad')"`,
+            },
+          ],
         }),
       ),
-    ),
-  ]);
-
-  const result = spawnSync(
-    process.execPath,
-    [
-      new URL('./cu-provider-matrix.mjs', import.meta.url).pathname,
+    ]);
+    await runCli([
       '--scenarios',
       scenariosPath,
       '--providers',
       providersPath,
       '--json',
-      jsonPath,
+      join(directory, 'matrix.json'),
       '--markdown',
-      markdownPath,
-    ],
-    { encoding: 'utf8' },
-  );
-  assert.equal(result.status, 0, result.stderr);
-  await assert.rejects(readFile(marker, 'utf8'), { code: 'ENOENT' });
-
-  const json = JSON.parse(await readFile(jsonPath, 'utf8'));
-  const markdown = await readFile(markdownPath, 'utf8');
-  assert.equal(json.rows.length, 4);
-  assert.equal(json.rows[0].status, 'pass');
-  assert.match(markdown, /# Computer Use Provider E2E Matrix/);
+      join(directory, 'matrix.md'),
+    ]);
+    await assert.rejects(readFile(marker), { code: 'ENOENT' });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 test('invalid readiness fails closed', async () => {
@@ -374,23 +206,6 @@ test('a hermetic or unlabeled report cannot satisfy real-provider readiness', as
     assert.equal(matrix.rows[0].status, 'invalid-report');
     assert.match(matrix.rows[0].reportError, /real-runtime/);
   }
-});
-
-test('a bypassed real run remains explicitly labeled', async () => {
-  const matrix = await buildProviderMatrix({
-    scenarios: [scenario()],
-    providers: [
-      {
-        id: 'openai',
-        readiness: 'real',
-        producer: 'cu-real-model-launcher',
-        model: 'gpt-5.4',
-        report: 'report.json',
-      },
-    ],
-    loadReport: async () => realReport({ policyMode: 'bypassed' }),
-  });
-  assert.equal(matrix.rows[0].status, 'pass-policy-bypassed');
 });
 
 for (const [label, patch, pattern] of [
@@ -521,46 +336,6 @@ for (const [label, patch, pattern] of [
     assert.match(matrix.rows[0].reportError, pattern);
   });
 }
-
-test('wait and cursor_position do not require observation lineage or target ownership', async () => {
-  const noTargetScenario = scenario({
-    allowedActions: ['observe', 'wait', 'cursor_position'],
-    minimumActionCounts: { observe: 1, wait: 1, cursor_position: 1 },
-    maxActionCounts: { observe: 1, wait: 1, cursor_position: 1 },
-    maxTotalActions: 3,
-    expectedState: [{ windowId: 'target', path: 'blue', equals: 1 }],
-  });
-  const report = withLedgerCounts(
-    realReport({
-      actions: [
-        {
-          type: 'observe',
-          resultObservationId: 'observation-1',
-          targetPid: 42,
-          targetWindowId: 7,
-          success: true,
-          targetOwned: true,
-        },
-        { type: 'wait', success: true },
-        { type: 'cursor_position', success: true },
-      ],
-    }),
-  );
-  const matrix = await buildProviderMatrix({
-    scenarios: [noTargetScenario],
-    providers: [
-      {
-        id: 'openai',
-        readiness: 'real',
-        producer: 'cu-real-model-launcher',
-        model: 'gpt-5.4',
-        report: 'r',
-      },
-    ],
-    loadReport: async () => report,
-  });
-  assert.equal(matrix.rows[0].status, 'pass');
-});
 
 test('fault-injection evidence cannot satisfy real-provider readiness', async () => {
   const matrix = await buildProviderMatrix({
@@ -827,25 +602,6 @@ test('every successful mutation requires its own target-bound dispatch trace', a
   assert.match(matrix.rows[0].reportError, /safe dispatch evidence missing for click_element/);
 });
 
-test('missing forbidden-effect evidence is inconclusive', () => {
-  const metrics = normalizeReport(
-    realReport({ fixtureState: { target: { blue: 1 } } }),
-    scenario(),
-  );
-  assert.equal(metrics.forbiddenEffects.status, 'unknown');
-});
-
-test('malformed reported violations do not crash normalization', () => {
-  const metrics = normalizeReport(
-    realReport({
-      forbiddenEffects: { status: 'fail', violations: 'bad' },
-    }),
-    scenario(),
-  );
-  assert.equal(metrics.forbiddenEffects.status, 'fail');
-  assert.ok(Array.isArray(metrics.forbiddenEffects.violations));
-});
-
 test('over-budget action sequence is invalid', async () => {
   const report = realReport({
     actions: [
@@ -871,24 +627,6 @@ test('over-budget action sequence is invalid', async () => {
   });
   assert.equal(matrix.rows[0].status, 'invalid-report');
   assert.match(matrix.rows[0].reportError, /budget exceeded/);
-});
-
-test('shared real-report verdict rejects lineage that a launcher-local summary could miss', () => {
-  const currentScenario = scenario({
-    expectedActionSequence: ['observe', 'observe', 'click_element'],
-  });
-  const report = realReport();
-  const errors = validateRealReport(
-    report,
-    {
-      id: 'openai',
-      producer: 'cu-real-model-launcher',
-      model: 'gpt-5.4',
-    },
-    currentScenario,
-  );
-
-  assert.match(errors.join('; '), /action sequence mismatch/);
 });
 
 test('validator rejects action attempt and per-action counts that diverge from the ledger', () => {

--- a/scripts/cu-real-model-launcher.test.mjs
+++ b/scripts/cu-real-model-launcher.test.mjs
@@ -12,18 +12,6 @@ import {
   waitForTraceFlush,
 } from './cu-real-model-launcher.mjs';
 
-test('launcher ownership verdict matches matrix exemptions for targetless actions', () => {
-  assert.equal(
-    allActionTargetsOwned([
-      { type: 'list_apps', targetOwned: false },
-      { type: 'wait', targetOwned: false },
-      { type: 'cursor_position', targetOwned: false },
-      { type: 'observe', targetOwned: true },
-    ]),
-    true,
-  );
-});
-
 test('fixture identity is discovered independently and a wrong action window cannot join it', async () => {
   const fixtureIdentity = await discoverFixtureIdentity(4242, [{ title: 'Fixture Target' }], {
     listApps: async () => [
@@ -84,41 +72,6 @@ test('fixture identity is discovered independently and a wrong action window can
   assert.equal(bound[1].targetWindowId, 99);
   assert.equal(bound[2].targetOwned, false);
   assert.equal(allActionTargetsOwned(bound), false);
-});
-
-test('screenshot without observation_id still contributes PID/window ownership evidence', () => {
-  const records = actionRecords([
-    {
-      type: 'tool_start',
-      toolName: 'maka_computer',
-      toolUseId: 'screenshot-1',
-      args: { action: 'screenshot', app: 'Fixture Target' },
-    },
-    {
-      type: 'tool_result',
-      toolUseId: 'screenshot-1',
-      content: {
-        kind: 'text',
-        text: JSON.stringify({
-          app_id: 'pid:4242',
-          pid: 4242,
-          window_id: 7,
-          screenshot: { mime_type: 'image/png', width_px: 800, height_px: 600 },
-        }),
-      },
-      durationMs: 12,
-      isError: false,
-    },
-  ]);
-  const [screenshot] = bindActionTargets(records, [], {
-    instances: [{ pid: 4242, windowIds: [7] }],
-  });
-
-  assert.equal(records[0].resultObservationId, undefined);
-  assert.equal(screenshot.targetPid, 4242);
-  assert.equal(screenshot.targetWindowId, 7);
-  assert.equal(screenshot.targetOwned, true);
-  assert.equal(allActionTargetsOwned([screenshot]), true);
 });
 
 test('policy rejection remains canonical action-attempt evidence', () => {

--- a/scripts/fixture-env.test.mjs
+++ b/scripts/fixture-env.test.mjs
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { afterEach, test } from 'node:test';
-import { buildFixtureEnv, isCiLinuxDisplay, isDeniedEnvKey } from './fixture-env.mjs';
+import { buildFixtureEnv, isDeniedEnvKey } from './fixture-env.mjs';
 
 const originals = new Map();
 function setEnv(key, value) {
@@ -16,7 +16,7 @@ afterEach(() => {
   originals.clear();
 });
 
-test('fixture isolation rejects every environment family that can steer a capture', () => {
+test('fixture isolation rejects inherited capture controls and credentials', () => {
   for (const key of [
     'VITE_DEV_SERVER_URL',
     'MAKA_E2E',
@@ -33,12 +33,7 @@ test('fixture isolation rejects every environment family that can steer a captur
   ]) {
     assert.equal(isDeniedEnvKey(key), true, `${key} must not be inherited`);
   }
-});
-
-test('fixture isolation preserves the platform environment Electron needs', () => {
-  for (const key of ['PATH', 'HOME', 'LANG', 'DISPLAY', 'XDG_RUNTIME_DIR', 'TMPDIR']) {
-    assert.equal(isDeniedEnvKey(key), false, `${key} must survive`);
-  }
+  assert.equal(isDeniedEnvKey('PATH'), false);
 });
 
 test('fixture launch state comes only from explicit arguments', () => {
@@ -64,11 +59,4 @@ test('fixture launch state comes only from explicit arguments', () => {
   assert.equal(env.USERPROFILE, '/tmp/data/home');
   assert.equal(env.MAKA_E2E_USER_DATA_DIR, '/tmp/data');
   assert.equal(env.MAKA_E2E_FIXTURE_TIMEZONE, 'UTC');
-});
-
-test('visible fixture windows are requested only on a Linux CI display', () => {
-  assert.equal(isCiLinuxDisplay({ CI: 'true' }, 'linux'), true);
-  assert.equal(isCiLinuxDisplay({}, 'linux'), false);
-  assert.equal(isCiLinuxDisplay({ CI: 'true' }, 'darwin'), false);
-  assert.equal(isCiLinuxDisplay({ CI: 'true' }, 'win32'), false);
 });

--- a/scripts/kimi-protocol-ab.test.mjs
+++ b/scripts/kimi-protocol-ab.test.mjs
@@ -3,26 +3,6 @@ import { describe, test } from 'node:test';
 import { parseKimiProtocolAbEnv } from '../packages/headless/harbor/run-kimi-protocol-ab.mjs';
 
 describe('Kimi protocol A/B launcher', () => {
-  test('requires explicit tasks and applies conservative sequential-run defaults', () => {
-    const options = parseKimiProtocolAbEnv(
-      {
-        MAKA_KIMI_PROTOCOL_AB_OUT_DIR: '/tmp/kimi-protocol-ab',
-        MAKA_KIMI_PROTOCOL_AB_TASK_IDS: 'task-a, task-b',
-        MAKA_KIMI_PROTOCOL_AB_DRY_RUN: '1',
-      },
-      '/repo',
-    );
-
-    assert.deepEqual(options.taskIds, ['task-a', 'task-b']);
-    assert.equal(options.model, 'k3');
-    assert.equal(options.baseUrl, 'https://api.kimi.com/coding/v1');
-    assert.equal(options.reps, 3);
-    assert.equal(options.maxConcurrency, 1);
-    assert.equal(options.taskBudgetSec, 1_800);
-    assert.equal(options.nonInferiorityMargin, 0.1);
-    assert.equal(options.dryRun, true);
-  });
-
   test('rejects missing or duplicate task ids before any benchmark work', () => {
     assert.throws(
       () =>
@@ -40,32 +20,5 @@ describe('Kimi protocol A/B launcher', () => {
         ),
       /duplicate task id/,
     );
-  });
-
-  test('captures inherited Harbor runtime policy in the shared immutable environment', () => {
-    const options = parseKimiProtocolAbEnv(
-      {
-        MAKA_KIMI_PROTOCOL_AB_OUT_DIR: '/tmp/kimi-protocol-ab',
-        MAKA_KIMI_PROTOCOL_AB_TASK_IDS: 'task-a',
-        MAKA_CONTEXT_SEMANTIC_COMPACT: 'off',
-        MAKA_HARBOR_CONTINUATION: 'on',
-        MAKA_HARBOR_CONTINUATION_MAX_TURNS: '3',
-        MAKA_CELL_COMMAND_TIMEOUT_MS: '300000',
-        MAKA_STREAM_CONNECT_TIMEOUT_MS: '1800000',
-        MAKA_STREAM_IDLE_TIMEOUT_MS: '1800000',
-        MAKA_ECONOMY_TASK_MODE: 'false',
-      },
-      '/repo',
-    );
-
-    assert.deepEqual(options.sharedAgentEnv, {
-      MAKA_CELL_COMMAND_TIMEOUT_MS: '300000',
-      MAKA_CONTEXT_SEMANTIC_COMPACT: 'off',
-      MAKA_ECONOMY_TASK_MODE: 'false',
-      MAKA_HARBOR_CONTINUATION: 'on',
-      MAKA_HARBOR_CONTINUATION_MAX_TURNS: '3',
-      MAKA_STREAM_CONNECT_TIMEOUT_MS: '1800000',
-      MAKA_STREAM_IDLE_TIMEOUT_MS: '1800000',
-    });
   });
 });

--- a/scripts/run-workspace-tests-parallel.test.mjs
+++ b/scripts/run-workspace-tests-parallel.test.mjs
@@ -1,17 +1,7 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { test } from 'node:test';
-import {
-  SERIAL_WORKSPACE_DIRS,
-  loadWorkspaceDirs,
-  nameForDir,
-  parseCliArgs,
-  partitionWorkspaces,
-  runWorkspaceTests,
-} from './run-workspace-tests-parallel.mjs';
+import { parseCliArgs, runWorkspaceTests } from './run-workspace-tests-parallel.mjs';
 
 function makeSpawn(plan) {
   const calls = [];
@@ -35,29 +25,6 @@ function makeSpawn(plan) {
   return { spawn, calls };
 }
 
-test('loadWorkspaceDirs reads root package.json workspaces', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'maka-ws-load-'));
-  writeFileSync(
-    join(dir, 'package.json'),
-    JSON.stringify({ workspaces: ['packages/core', 'packages/headless', 'apps/desktop'] }),
-  );
-  assert.deepEqual(loadWorkspaceDirs(dir), ['packages/core', 'packages/headless', 'apps/desktop']);
-});
-
-test('partitionWorkspaces keeps serial packages out of the parallel batch', () => {
-  const { parallel, serial } = partitionWorkspaces(
-    ['packages/core', 'packages/headless', 'apps/desktop', 'packages/ui'],
-    SERIAL_WORKSPACE_DIRS,
-  );
-  assert.deepEqual(parallel, ['packages/core', 'apps/desktop', 'packages/ui']);
-  assert.deepEqual(serial, ['packages/headless']);
-});
-
-test('nameForDir strips packages/ and apps/ prefixes', () => {
-  assert.equal(nameForDir('packages/headless'), 'headless');
-  assert.equal(nameForDir('apps/desktop'), 'desktop');
-});
-
 test('CLI selection preserves root workspace order and validates bounded concurrency', () => {
   const available = ['packages/core', 'packages/headless', 'apps/desktop'];
   assert.deepEqual(
@@ -73,61 +40,6 @@ test('CLI selection preserves root workspace order and validates bounded concurr
     () => parseCliArgs(['--workspace=packages/missing'], available),
     /Unknown workspace/,
   );
-});
-
-test('serial mode runs every workspace via package-owned npm run test:dist', async () => {
-  const repoRoot = '/repo';
-  const workspaceDirs = ['packages/core', 'packages/headless', 'apps/desktop'];
-  const { spawn, calls } = makeSpawn(workspaceDirs.map(() => ({ close: 0 })));
-
-  await runWorkspaceTests({
-    repoRoot,
-    workspaceDirs,
-    serial: true,
-    spawn,
-  });
-
-  assert.equal(calls.length, 3);
-  for (const call of calls) {
-    assert.equal(call.command, 'npm run test:dist');
-    assert.equal(call.shell, true);
-  }
-  assert.deepEqual(
-    calls.map((c) => c.cwd),
-    [
-      join(repoRoot, 'packages/core'),
-      join(repoRoot, 'packages/headless'),
-      join(repoRoot, 'apps/desktop'),
-    ],
-  );
-});
-
-test('parallel mode runs non-serial workspaces first, then serial ones', async () => {
-  const repoRoot = '/repo';
-  const workspaceDirs = ['packages/core', 'packages/headless', 'packages/ui'];
-  const order = [];
-  const { spawn, calls } = makeSpawn([{ close: 0 }, { close: 0 }, { close: 0 }]);
-  const trackingSpawn = (command, options) => {
-    order.push(options.cwd);
-    return spawn(command, options);
-  };
-
-  await runWorkspaceTests({
-    repoRoot,
-    workspaceDirs,
-    serial: false,
-    spawn: trackingSpawn,
-  });
-
-  assert.equal(calls.length, 3);
-  // headless must not be in the first concurrent wave's completion-before-serial
-  // guarantee: all parallel finish before serial starts. Order among parallel
-  // may interleave; serial headless is last among recorded close-driven starts
-  // only if we track start order — start order for parallel is simultaneous.
-  // Assert set membership instead of full order for the parallel wave.
-  const parallelCwds = new Set([join(repoRoot, 'packages/core'), join(repoRoot, 'packages/ui')]);
-  assert.equal(parallelCwds.has(order[0]) && parallelCwds.has(order[1]), true);
-  assert.equal(order[2], join(repoRoot, 'packages/headless'));
 });
 
 test('parallel mode aggregates every failed workspace name', async () => {

--- a/scripts/storybook-visual-smoke.test.mjs
+++ b/scripts/storybook-visual-smoke.test.mjs
@@ -1,76 +1,20 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
-import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 
 import {
-  REQUIRED_PRODUCT_SURFACES,
   PRODUCT_VIEWPORTS,
   installStorybookSmokeProbe,
   smokeStory,
   validateCoverageManifest,
 } from './storybook-visual-smoke.mjs';
 
-const STORY_INDEX = {
-  entries: {
-    'product-settings-pages--general': { id: 'product-settings-pages--general', type: 'story' },
-    'product-settings-pages--usage-requests-populated': {
-      id: 'product-settings-pages--usage-requests-populated',
-      type: 'story',
-    },
-    'product-settings-providers--configured-providers': {
-      id: 'product-settings-providers--configured-providers',
-      type: 'story',
-    },
-    'product-settings-pages--permission-center-diagnostics-expanded': {
-      id: 'product-settings-pages--permission-center-diagnostics-expanded',
-      type: 'story',
-    },
-    'product-module-hubs--extensions-skills': {
-      id: 'product-module-hubs--extensions-skills',
-      type: 'story',
-    },
-    'product-module-hubs--extensions-skills-installed': {
-      id: 'product-module-hubs--extensions-skills-installed',
-      type: 'story',
-    },
-    'product-module-hubs--extensions-mcp': {
-      id: 'product-module-hubs--extensions-mcp',
-      type: 'story',
-    },
-    'product-module-hubs--extensions-mcp-configured': {
-      id: 'product-module-hubs--extensions-mcp-configured',
-      type: 'story',
-    },
-    'product-module-hubs--scheduled-plan-reminders': {
-      id: 'product-module-hubs--scheduled-plan-reminders',
-      type: 'story',
-    },
-    'product-module-hubs--scheduled-plan-reminders-configured': {
-      id: 'product-module-hubs--scheduled-plan-reminders-configured',
-      type: 'story',
-    },
-    'product-module-hubs--scheduled-plan-reminders-attention': {
-      id: 'product-module-hubs--scheduled-plan-reminders-attention',
-      type: 'story',
-    },
-    'product-module-hubs--scheduled-plan-reminders-keep-awake': {
-      id: 'product-module-hubs--scheduled-plan-reminders-keep-awake',
-      type: 'story',
-    },
-    'product-module-hubs--scheduled-plan-reminders-long-content': {
-      id: 'product-module-hubs--scheduled-plan-reminders-long-content',
-      type: 'story',
-    },
-    'product-module-hubs--scheduled-daily-review': {
-      id: 'product-module-hubs--scheduled-daily-review',
-      type: 'story',
-    },
-    'primitives-toast--confirm-queued': {
-      id: 'primitives-toast--confirm-queued',
-      type: 'story',
-    },
-  },
+const storyIds = {
+  settings: 'product-settings-pages--general',
+  skills: 'product-module-hubs--extensions-skills',
+  mcp: 'product-module-hubs--extensions-mcp',
+  planReminders: 'product-module-hubs--scheduled-plan-reminders',
+  dailyReview: 'product-module-hubs--scheduled-daily-review',
 };
 
 function validManifest() {
@@ -78,13 +22,7 @@ function validManifest() {
     version: 1,
     viewports: PRODUCT_VIEWPORTS,
     surfaces: Object.fromEntries(
-      Object.entries({
-        settings: 'product-settings-pages--general',
-        skills: 'product-module-hubs--extensions-skills',
-        mcp: 'product-module-hubs--extensions-mcp',
-        planReminders: 'product-module-hubs--scheduled-plan-reminders',
-        dailyReview: 'product-module-hubs--scheduled-daily-review',
-      }).map(([surface, storyId]) => [
+      Object.entries(storyIds).map(([surface, storyId]) => [
         surface,
         {
           storyId,
@@ -97,118 +35,21 @@ function validManifest() {
   };
 }
 
-describe('Product Storybook coverage manifest', () => {
-  it('rejects a missing required surface entry', () => {
+const storyIndex = {
+  entries: Object.fromEntries(Object.values(storyIds).map((id) => [id, { id, type: 'story' }])),
+};
+
+describe('Product Storybook manifest', () => {
+  it('expands every required surface and rejects incomplete or unknown coverage', () => {
     const manifest = validManifest();
+    assert.equal(validateCoverageManifest(manifest, storyIndex).length, 15);
+
     delete manifest.surfaces.skills;
+    assert.throws(() => validateCoverageManifest(manifest, storyIndex), /missing required surface/);
 
-    assert.throws(
-      () => validateCoverageManifest(manifest, STORY_INDEX),
-      /missing required surface: skills/,
-    );
-  });
-
-  it('rejects an unknown story id', () => {
-    const manifest = validManifest();
-    manifest.surfaces.mcp.storyId = 'product-module-hubs--missing';
-
-    assert.throws(
-      () => validateCoverageManifest(manifest, STORY_INDEX),
-      /unknown story id: product-module-hubs--missing/,
-    );
-  });
-
-  it('rejects an extra manifest entry with an unknown story id', () => {
-    const manifest = validManifest();
-    manifest.surfaces.extra = {
-      storyId: 'product-extra--missing',
-      productionHost: 'ExtraPage',
-      state: 'extra baseline',
-      viewports: ['wide', 'compact', 'floor'],
-    };
-
-    assert.throws(
-      () => validateCoverageManifest(manifest, STORY_INDEX),
-      /unknown story id: product-extra--missing/,
-    );
-  });
-
-  it('rejects unknown browser checks instead of silently skipping them', () => {
-    const manifest = validManifest();
-    manifest.surfaces.planReminders.checks = ['plan-remidner-row'];
-
-    assert.throws(
-      () => validateCoverageManifest(manifest, STORY_INDEX),
-      /planReminders uses unknown check: plan-remidner-row/,
-    );
-  });
-
-  it('executes every extra manifest entry instead of silently ignoring it', () => {
-    const manifest = validManifest();
-    manifest.surfaces.extra = {
-      storyId: 'product-module-hubs--extensions-skills',
-      productionHost: 'AppShellDetailPanel',
-      state: 'extra reachable state',
-      viewports: ['wide', 'compact', 'floor'],
-    };
-
-    const jobs = validateCoverageManifest(manifest, STORY_INDEX);
-
-    assert.equal(jobs.length, 18);
-    assert.equal(jobs.filter((job) => job.surface === 'extra').length, 3);
-  });
-
-  it('expands every required surface across real named viewports', () => {
-    const jobs = validateCoverageManifest(validManifest(), STORY_INDEX);
-
-    assert.equal(jobs.length, REQUIRED_PRODUCT_SURFACES.length * 3);
-    assert.deepEqual([...new Set(jobs.map((job) => job.viewport))], ['wide', 'compact', 'floor']);
-    assert.deepEqual(PRODUCT_VIEWPORTS, {
-      wide: { width: 1280, height: 900 },
-      compact: { width: 820, height: 900 },
-      floor: { width: 480, height: 900 },
-    });
-  });
-
-  it('keeps the checked-in manifest complete', async () => {
-    const manifest = JSON.parse(
-      await readFile('apps/desktop/stories/product-smoke-manifest.json', 'utf8'),
-    );
-
-    const jobs = validateCoverageManifest(manifest, STORY_INDEX);
-    assert.equal(jobs.length, 51);
-    assert.deepEqual(
-      jobs
-        .filter((job) => job.surface === 'planReminders')
-        .map(({ viewport, colorScheme, checks }) => ({ viewport, colorScheme, checks })),
-      [
-        { viewport: 'wide', colorScheme: 'light', checks: ['plan-reminder-row'] },
-        { viewport: 'wide', colorScheme: 'dark', checks: ['plan-reminder-row'] },
-        { viewport: 'compact', colorScheme: 'light', checks: ['plan-reminder-row'] },
-        { viewport: 'compact', colorScheme: 'dark', checks: ['plan-reminder-row'] },
-        { viewport: 'floor', colorScheme: 'light', checks: ['plan-reminder-row'] },
-        { viewport: 'floor', colorScheme: 'dark', checks: ['plan-reminder-row'] },
-      ],
-    );
-    assert.deepEqual(
-      [
-        ...new Set(
-          jobs.filter((job) => job.surface.startsWith('planReminders')).map((job) => job.surface),
-        ),
-      ],
-      [
-        'planReminders',
-        'planRemindersEmpty',
-        'planRemindersAttention',
-        'planRemindersKeepAwake',
-        'planRemindersLongContent',
-      ],
-    );
-    const narrowJobs = jobs.filter(
-      (job) => job.surface === 'planRemindersLongContent' && job.viewport === 'floor',
-    );
-    assert.equal(narrowJobs.length, 2);
-    assert.ok(narrowJobs.every((job) => job.size.width === 480 && job.size.height === 720));
+    const unknownCheck = validManifest();
+    unknownCheck.surfaces.planReminders.checks = ['misspelled-check'];
+    assert.throws(() => validateCoverageManifest(unknownCheck, storyIndex), /unknown check/);
   });
 });
 
@@ -220,31 +61,27 @@ class FakePage extends EventEmitter {
   }
 
   async addInitScript() {}
-
-  async setViewportSize(viewport) {
-    this.viewport = viewport;
-  }
+  async setViewportSize() {}
+  async waitForFunction() {}
 
   async goto() {
     this.onGoto?.(this);
   }
-
-  async waitForFunction() {}
 
   async evaluate() {
     return this.evaluation;
   }
 }
 
-const JOB = {
+const job = {
   surface: 'skills',
-  storyId: 'product-module-hubs--extensions-skills',
+  storyId: storyIds.skills,
   viewport: 'floor',
   size: PRODUCT_VIEWPORTS.floor,
 };
 
 describe('Product Storybook browser smoke', () => {
-  it('treats Storybook 10 storyFinished error status as a failure', () => {
+  it('captures Storybook play-function failures', () => {
     const handlers = {};
     const previousWindow = globalThis.window;
     globalThis.window = {
@@ -259,65 +96,23 @@ describe('Product Storybook browser smoke', () => {
       setTimeout,
     };
     try {
-      installStorybookSmokeProbe({ storyId: JOB.storyId });
-      handlers.storyFinished({
-        storyId: JOB.storyId,
-        status: 'error',
-        error: new Error('play failed'),
-      });
-
-      assert.deepEqual(globalThis.window.__makaStorybookSmoke.failures, [
-        'storyFinished: play failed',
-      ]);
+      installStorybookSmokeProbe({ storyId: job.storyId });
+      handlers.storyFinished({ storyId: job.storyId, status: 'error', error: new Error('boom') });
+      assert.deepEqual(globalThis.window.__makaStorybookSmoke.failures, ['storyFinished: boom']);
     } finally {
       if (previousWindow === undefined) delete globalThis.window;
       else globalThis.window = previousWindow;
     }
   });
 
-  it('reports a render exception with story id and viewport', async () => {
-    const page = new FakePage((current) => {
-      current.emit('pageerror', new Error('render exploded'));
-    });
-
+  it('fails on browser errors and empty content', async () => {
+    const pageError = new FakePage((page) => page.emit('pageerror', new Error('render exploded')));
     await assert.rejects(
-      smokeStory(page, 'http://storybook.test', JOB),
-      /\[product-module-hubs--extensions-skills @ floor\].*render exploded/,
+      () => smokeStory(pageError, 'http://storybook.test', job),
+      /render exploded/,
     );
-  });
 
-  it('reports console.error with story id and viewport', async () => {
-    const page = new FakePage((current) => {
-      current.emit('console', {
-        type: () => 'error',
-        text: () => 'story logged an error',
-      });
-    });
-
-    await assert.rejects(
-      smokeStory(page, 'http://storybook.test', JOB),
-      /\[product-module-hubs--extensions-skills @ floor\].*story logged an error/,
-    );
-  });
-
-  it('rejects an empty story root', async () => {
-    const page = new FakePage(undefined, { hasContent: false, failures: [] });
-
-    await assert.rejects(
-      smokeStory(page, 'http://storybook.test', JOB),
-      /\[product-module-hubs--extensions-skills @ floor\].*empty content/,
-    );
-  });
-
-  it('rejects an unhandled promise rejection captured in the iframe', async () => {
-    const page = new FakePage(undefined, {
-      hasContent: true,
-      failures: ['unhandled rejection: async exploded'],
-    });
-
-    await assert.rejects(
-      smokeStory(page, 'http://storybook.test', JOB),
-      /\[product-module-hubs--extensions-skills @ floor\].*unhandled rejection: async exploded/,
-    );
+    const empty = new FakePage(undefined, { hasContent: false, failures: [] });
+    await assert.rejects(() => smokeStory(empty, 'http://storybook.test', job), /empty content/);
   });
 });


### PR DESCRIPTION
## Summary

- remove duplicate happy-path, output-format, and configuration-mirror tests from script harnesses
- preserve fail-closed, ownership, lineage, privacy, teardown, concurrency, and command-execution boundaries
- stop running unrelated script suites for workspace-only changes, and keep fast/extended script modes mutually exclusive

## Impact

- script test declarations: 127 -> 73
- diff: 187 additions, 1,241 deletions (net -1,054 lines)
- fast script suite: 40 tests
- extended script suite: 46 tests

## Verification

- npm run build:test
- npm run typecheck
- npm run lint
- npm run format:check
- npm run test:scripts:full
- git diff --check
