### PR TITLE
test: consolidate settings and connection coverage

### DIFF
--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -1,23 +1,10 @@
-/**
- * Tests for SessionStatus + SessionBlockedReason presentation helpers
- * (PR109b).
- *
- * Lock down the two contracts @kenji called out:
- *  - blocked-reason copy must never expose the enum identifier
- *  - status tone matrix follows the design-system tokens
- */
-
 import { strict as assert } from 'node:assert';
-import { readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import {
   SANDBOX_BOUNDARY_RESTART_CLOSURE_CLASS,
   SESSION_BLOCKED_REASONS,
   SESSION_STATUSES,
 } from '@maka/core';
-import { readRendererShellCombinedSource } from './renderer-shell-source-helpers.js';
-import { renderSessionListPanel } from './session-list-render-helpers.js';
 import {
   deriveFailedTurnRecovery,
   describeBlockedReason,
@@ -26,481 +13,122 @@ import {
   sessionStatusAriaLabel,
 } from '../../renderer/session-status-presentation.js';
 
-const REPO_ROOT = resolve(process.cwd(), '..', '..');
-
-describe('presentSessionStatus', () => {
-  it('covers every SessionStatus enum value', () => {
+describe('session status presentation', () => {
+  it('covers the status vocabulary with localized semantic presentations', () => {
+    const tones = new Set([
+      'accent',
+      'warning',
+      'destructive',
+      'info',
+      'success',
+      'muted',
+      'neutral',
+    ]);
     for (const status of SESSION_STATUSES) {
       const presentation = presentSessionStatus(status);
-      assert.ok(presentation.label, `${status} should have a label`);
-      assert.ok(presentation.tone, `${status} should have a tone`);
+      assert.match(presentation.label, /[一-鿿]/, status);
+      assert.equal(tones.has(presentation.tone), true, status);
     }
-  });
 
-  it('labels are Chinese (no English fallback)', () => {
-    for (const status of SESSION_STATUSES) {
-      const presentation = presentSessionStatus(status);
-      assert.match(presentation.label, /[一-鿿]/, `${status} label should contain Chinese chars`);
-      assert.doesNotMatch(presentation.label, /[a-zA-Z]/, `${status} label should have no Latin letters`);
-    }
-  });
-
-  it('terminal states (archived, aborted) are not interactive', () => {
     assert.equal(presentSessionStatus('archived').interactive, false);
     assert.equal(presentSessionStatus('aborted').interactive, false);
-  });
-
-  it('working states (active, running, etc.) are interactive', () => {
-    for (const status of ['active', 'running', 'waiting_for_user', 'blocked', 'review', 'done'] as const) {
-      assert.equal(presentSessionStatus(status).interactive, true, `${status} should be interactive`);
-    }
-  });
-
-  it('tones map to a small closed vocabulary', () => {
-    const allowedTones = new Set(['accent', 'warning', 'destructive', 'info', 'success', 'muted', 'neutral']);
-    for (const status of SESSION_STATUSES) {
-      const tone = presentSessionStatus(status).tone;
-      assert.ok(allowedTones.has(tone), `${status} tone ${tone} not in allowed set`);
-    }
-  });
-
-  it('blocked is warning (recoverable, not a hard failure)', () => {
+    assert.equal(presentSessionStatus('running').interactive, true);
     assert.equal(presentSessionStatus('blocked').tone, 'warning');
-  });
-
-  it('done is success', () => {
     assert.equal(presentSessionStatus('done').tone, 'success');
   });
-});
 
-describe('describeBlockedReason (@kenji generalized copy contract)', () => {
-  it('covers every SessionBlockedReason enum value', () => {
+  it('localizes blocked reasons and composes safe accessible labels', () => {
     for (const reason of SESSION_BLOCKED_REASONS) {
-      const text = describeBlockedReason(reason);
-      assert.ok(text, `${reason} should have copy`);
+      const copy = describeBlockedReason(reason);
+      assert.match(copy, /[一-鿿]/, reason);
+      assert.equal(copy.includes(reason), false, reason);
     }
-  });
 
-  it('NEVER returns the raw enum identifier as the label', () => {
-    for (const reason of SESSION_BLOCKED_REASONS) {
-      const text = describeBlockedReason(reason);
-      // Each enum identifier must not appear literally in the copy
-      assert.doesNotMatch(text, new RegExp(reason), `copy "${text}" leaks enum identifier ${reason}`);
-    }
-  });
-
-  it('all blocked copy is Chinese', () => {
-    for (const reason of SESSION_BLOCKED_REASONS) {
-      const text = describeBlockedReason(reason);
-      assert.match(text, /[一-鿿]/, `"${text}" should contain Chinese chars`);
-      assert.doesNotMatch(text, /[a-zA-Z]/, `"${text}" should have no Latin letters`);
-    }
-  });
-
-  it('falls back to "unknown" copy when reason is undefined', () => {
-    const fallback = describeBlockedReason(undefined);
-    assert.equal(fallback, describeBlockedReason('unknown'));
-  });
-
-  it('NO_REAL_CONNECTION maps to user-facing model-connection phrasing', () => {
-    const text = describeBlockedReason('NO_REAL_CONNECTION');
-    assert.equal(text, '等待配置可用模型连接');
-    assert.doesNotMatch(text, /缺少可用模型连接/);
-  });
-
-  it('keeps the shared UI blocked-reason tooltip in sync with actionable waiting copy', async () => {
-    const markup = renderSessionListPanel({
-      session: {
-        status: 'blocked',
-        blockedReason: 'NO_REAL_CONNECTION',
-      },
-    });
-
-    assert.match(markup, /等待配置可用模型连接/);
-    assert.doesNotMatch(markup, /缺少可用模型连接/);
-  });
-
-  it('auth maps to re-login phrasing', () => {
+    assert.equal(describeBlockedReason(undefined), describeBlockedReason('unknown'));
+    assert.equal(describeBlockedReason('NO_REAL_CONNECTION'), '等待配置可用模型连接');
     assert.match(describeBlockedReason('auth'), /登录|登陆/);
+    assert.equal(sessionStatusAriaLabel('running'), presentSessionStatus('running').label);
+    assert.match(sessionStatusAriaLabel('blocked', 'auth'), /需要处理 · .*登录|需要处理 · .*登陆/);
+    assert.match(sessionStatusAriaLabel('blocked'), /运行中断，可重试/);
   });
 });
 
-describe('sessionStatusAriaLabel', () => {
-  it('non-blocked status returns just the status label', () => {
-    assert.equal(sessionStatusAriaLabel('running'), '进行中');
-    assert.equal(sessionStatusAriaLabel('active'), '可继续');
-  });
+describe('failed turn presentation', () => {
+  it('classifies representative runtime errors without exposing raw identifiers', () => {
+    const cases: Array<[string | undefined, RegExp]> = [
+      ['timeout', /超时/],
+      ['AUTH_FAILED', /鉴权/],
+      ['rate_limit', /速率/],
+      ['fetch_failed', /网络/],
+      ['503', /模型服务返回错误/],
+      ['context_overflow', /上下文/],
+      ['provider_billing', /计费/],
+      ['tool_failed', /工具/],
+      ['tool_step_cap_reached', /工具步骤上限/],
+      ['app_restarted', /应用重启/],
+      [SANDBOX_BOUNDARY_RESTART_CLOSURE_CLASS, /等待确认.*请求已按拒绝关闭/],
+      [undefined, /未知错误/],
+      ['something_new', /未知错误/],
+    ];
 
-  it('blocked status combines status label + blocked reason', () => {
-    const text = sessionStatusAriaLabel('blocked', 'auth');
-    assert.match(text, /需要处理/);
-    assert.match(text, /登录|登陆/);
-    // Separator stays consistent
-    assert.match(text, / · /);
-  });
-
-  it('blocked without reason falls back to actionable recovery copy', () => {
-    const text = sessionStatusAriaLabel('blocked');
-    assert.match(text, /需要处理/);
-    assert.match(text, /运行中断，可重试/);
-    assert.doesNotMatch(text, /未知阻塞/);
-  });
-});
-
-describe('permission mode transition guard copy', () => {
-  // PR-MOVE-PERMISSION-MODE (2026-06-23): the permission-mode picker no
-  // longer lives in the chat header — it moved into the composer's
-  // left-controls dropdown. Disabled-reason copy is now computed at the
-  // <Composer/> call site in main.tsx and passed down via the
-  // `permissionModeDisabledReason` prop, so the gating contract pins
-  // main.tsx, not components.tsx.
-  it('passes a disabled-reason for running, waiting, streaming, and pending sessions', async () => {
-    const renderer = await readRendererShellCombinedSource();
-    const composerReasonBlock = renderer.match(/permissionModeDisabledReason=\{[\s\S]*?\}\s*onPermissionModeChange/)?.[0] ?? '';
-
-    assert.ok(composerReasonBlock, 'main.tsx must pass permissionModeDisabledReason to the <Composer/>');
-    assert.match(composerReasonBlock, /pendingPermissionModeBySession\[activeId\] === true/);
-    assert.match(composerReasonBlock, /shellCopy\.permissionModeChanging/);
-    assert.match(composerReasonBlock, /activeStreamingLive/);
-    assert.doesNotMatch(composerReasonBlock, /activeStreaming\.length > 0/);
-    assert.match(composerReasonBlock, /shellCopy\.permissionModeStreaming/);
-    assert.match(composerReasonBlock, /activeSessionForView\?\.status === 'running'/);
-    assert.match(composerReasonBlock, /shellCopy\.permissionModeRunning/);
-    assert.match(composerReasonBlock, /activeSessionForView\?\.status === 'waiting_for_user'/);
-    assert.match(composerReasonBlock, /shellCopy\.permissionModeWaiting/);
-  });
-
-  it('composer permission picker disables itself when the composer is disabled, pending, or a disabledReason is present', async () => {
-    // The picker must respect the composer's own `disabled` state (the
-    // interaction-wait freeze, driven by `Boolean(activeInteraction)` in
-    // app-shell.tsx), not only the separately-computed `permissionModeDisabledReason`
-    // (which keys off `status === 'waiting_for_user'`). The two are NOT fully
-    // coupled: a pending permission can set `props.disabled` before the session
-    // status flips to `waiting_for_user`, leaving a window where the composer is
-    // frozen (permission-hint pulsing, attach button + textarea disabled) but
-    // the mode picker stays clickable. CDP-verified on the `permission-destructive`
-    // fixture: before this guard the Select trigger read `disabled=false`,
-    // `pointer-events:auto`; after, `disabled=true`, `pointer-events:none`.
-    const ui = await readFile(join(REPO_ROOT, 'packages/ui/src/composer.tsx'), 'utf8');
-    const dropdownBlock = ui.match(/props\.onPermissionModeChange \? \([\s\S]*?\) : null/)?.[0] ?? '';
-
-    assert.ok(dropdownBlock, 'composer.tsx must render a PermissionModeSelect picker');
-    assert.match(dropdownBlock, /<PermissionModeSelect/);
-    assert.match(dropdownBlock, /disabled=\{props\.disabled \|\| props\.permissionModePending === true \|\| Boolean\(props\.permissionModeDisabledReason\)\}/);
-    assert.match(dropdownBlock, /disabledReason=\{props\.permissionModeDisabledReason\}/);
-  });
-
-  it('composer permission picker uses the shared Base UI Select', async () => {
-    const ui = await readFile(join(REPO_ROOT, 'packages/ui/src/composer.tsx'), 'utf8');
-    const menuModule = await readFile(join(REPO_ROOT, 'packages/ui/src/permission-mode-menu.tsx'), 'utf8');
-
-    // Three-mode picker: explore is retired from the picker entirely
-    // (read-only mode has no useful runtime toggle for normal chat —
-    // Deep-Research sessions set it internally). The list is DERIVED from
-    // @maka/core's canonical CHAT_DEFAULT_PERMISSION_MODES (itself derived
-    // from PERMISSION_MODES minus 'explore') — not a hand-copied literal
-    // that can drift when a new mode is added.
-    assert.match(
-      menuModule,
-      /export const PERMISSION_MODE_ORDER: readonly ChatDefaultPermissionMode\[\] = CHAT_DEFAULT_PERMISSION_MODES;/,
-    );
-
-    // Permission picker is Base UI Select (the correct primitive for a
-    // single-value choice), not a hand-styled Menu + chip. The composer
-    // renders the shared PermissionModeSelect so option markup can't drift
-    // from the Settings picker; keyboard arrow/Home/End is delegated to
-    // the Select primitive.
-    const dropdownBlock = ui.match(/props\.onPermissionModeChange \? \([\s\S]*?\) : null/)?.[0] ?? '';
-    assert.match(dropdownBlock, /<PermissionModeSelect/);
-    assert.match(dropdownBlock, /activeMode=\{props\.permissionMode/);
-    assert.match(dropdownBlock, /void props\.onPermissionModeChange\?\.\(mode\);/);
-    assert.match(menuModule, /export function PermissionModeSelect/);
-    assert.match(menuModule, /PERMISSION_MODE_ORDER\.map\(\(mode\) =>/);
-  });
-
-  it('updates the active session boundary or the new-session default and scrubs failures before toast', async () => {
-    const renderer = await readRendererShellCombinedSource();
-    const setPermissionModeBlock = renderer.match(/async function setPermissionMode[\s\S]*?async function setSessionModel/)?.[0] ?? '';
-
-    assert.match(renderer, /const permissionModeChangeRegistry = useKeyedPendingRegistry\(\);/);
-    assert.match(
-      renderer,
-      /pendingPermissionModeChangesRef: permissionModeChangeRegistry\.keysRef/,
-      'the permission-mode-change dedup Set the setPermissionMode action guards on must be backed by the shared keyed-pending registry',
-    );
-    assert.match(renderer, /const sessionUi = useAppShellSessionUiState\(\);[\s\S]*setPendingPermissionModeBySession: sessionUi\.setPendingPermissionModeBySession/);
-    assert.match(renderer, /const \{[\s\S]*pendingPermissionModeBySession,[\s\S]*\} = sessionUiState;/);
-    assert.match(
-      setPermissionModeBlock,
-      /if \(mode !== 'ask' && mode !== 'bypass'\) return;[\s\S]*const sessionId = activeIdRef\.current;[\s\S]*const pendingKey = sessionId \?\? '__global_permission_mode__';[\s\S]*pendingPermissionModeChangesRef\.current\.has\(pendingKey\)/,
-      'Boundary changes must accept only Auto or Bypass, capture the active session id, and gate duplicate active/global saves',
-    );
-    assert.match(
-      setPermissionModeBlock,
-      /mode === 'bypass'[\s\S]*toastApi\.confirm\(\{[\s\S]*destructive: true/,
-      'Bypass must require a destructive confirmation before changing the session boundary',
-    );
-    assert.match(setPermissionModeBlock, /pendingPermissionModeChangesRef\.current\.add\(pendingKey\);[\s\S]*if \(sessionId\)\s*setPendingPermissionModeBySession\(\(current\) => \(\{\s*\.\.\.current,\s*\[sessionId\]: true,?\s*\}\)\);/);
-    assert.match(
-      setPermissionModeBlock,
-      /if \(sessionId\) \{[\s\S]*window\.maka\.sessions\.setPermissionMode\(sessionId, mode\)[\s\S]*\} else \{[\s\S]*window\.maka\.settings\.update\(\{\s*chatDefaults: \{ permissionMode: mode \},?\s*\}\)/,
-      'Boundary changes must update the active session without changing the default, or update the default when no session is active',
-    );
-    assert.match(setPermissionModeBlock, /nextMode = next\.permissionMode === 'bypass' \? 'bypass' : 'ask';/);
-    assert.match(setPermissionModeBlock, /nextMode = result\.settings\.chatDefaults\.permissionMode;/);
-    assert.match(setPermissionModeBlock, /setDefaultPermissionMode\(nextMode\);/);
-    assert.match(
-      setPermissionModeBlock,
-      /setSessions\(\(prev\) =>\s*prev\.map\(\(session\) => \(session\.id === sessionId \? next : session\)\),?\s*\);/,
-    );
-    assert.match(
-      setPermissionModeBlock,
-      /toastApi\.success\(\s*copy\.permissionSwitched\(copy\.permissionLabels\[nextMode\]\),\s*copy\.permissionDescriptions\[nextMode\],?\s*\);/,
-    );
-    assert.match(setPermissionModeBlock, /await refreshSessions\(\)/, 'Permission mode changes must still refresh the sidebar/session list');
-    assert.match(
-      setPermissionModeBlock,
-      /catch \(error\) \{[\s\S]*toastApi\.error\(copy\.permissionFailedTitle, localizedShellErrorMessage\(error, copy\.permissionFallback, uiLocale\)\)/,
-      'Permission mode failures must use shared Chinese error classification/redaction before reaching toast',
-    );
-    assert.match(setPermissionModeBlock, /finally \{[\s\S]*pendingPermissionModeChangesRef\.current\.delete\(pendingKey\);[\s\S]*\}/);
-    assert.match(setPermissionModeBlock, /if \(sessionId\) setPendingPermissionModeBySession\(\(current\) => omitSessionKey\(current, sessionId\)\);/);
-    assert.match(renderer, /permissionModePending=\{activeId \? pendingPermissionModeBySession\[activeId\] === true : false\}/);
-    assert.match(
-      renderer,
-      /onPermissionModeChange=\{\s*activeBoundarySurface\.localInteractionAvailable\s*\? \(mode\) => setPermissionMode\(mode\)\s*: undefined\s*\}/,
-    );
-    assert.match(
-      renderer,
-      /onboardingComposerHidden=\{\s*onboardingComposerHidden \|\| !activeBoundarySurface\.localInteractionAvailable\s*\}/,
-    );
-    assert.doesNotMatch(renderer, /onPermissionModeChange=\{\(mode\) => void setPermissionMode\(mode\)\}/);
-    assert.doesNotMatch(
-      setPermissionModeBlock,
-      /error instanceof Error \? error\.message : String\(error\)/,
-      'Permission mode failures must not render raw thrown Error.message',
-    );
-    assert.doesNotMatch(setPermissionModeBlock, /setPendingNewChatPermissionMode\(mode\)/);
-    assert.doesNotMatch(setPermissionModeBlock, /window\.maka\.sessions\.setPermissionMode\(activeId, mode\)/);
-  });
-
-  it('uses the configured default permission mode without one-shot new-chat state', async () => {
-    const renderer = await readRendererShellCombinedSource();
-    const sendBlock = renderer.match(/async function send\([\s\S]*?\n  async function respondToSandboxBoundary/)?.[0] ?? '';
-
-    assert.doesNotMatch(
-      renderer,
-      /const \[pendingNewChatPermissionMode, setPendingNewChatPermissionMode\] = useState<PermissionMode \| null>\(null\)/,
-      'The shell must not keep renderer-only permission mode state while no session is active',
-    );
-    assert.doesNotMatch(
-      sendBlock,
-      /\.\.\.\(pendingNewChatPermissionMode \? \{ permissionMode: pendingNewChatPermissionMode \} : \{\}\)/,
-      'New session creation must omit permissionMode so main.ts resolves the configured Settings -> General default as the single authority',
-    );
-    assert.doesNotMatch(
-      sendBlock,
-      /setPendingNewChatPermissionMode\(null\)/,
-      'Successful first send must not clear a removed renderer-only permission mode pick',
-    );
-    assert.match(
-      renderer,
-      /permissionMode=\{activePermissionMode\}/,
-      'The Composer mode chip must show the active session boundary and use the configured default only before a session exists',
-    );
-    assert.match(renderer, /setDefaultPermissionMode\(next\.chatDefaults\?\.permissionMode \?\? 'ask'\)/);
-    assert.match(
-      renderer,
-      /permissionModeDisabledReason=\{[\s\S]*activeId && activeSessionForView\?\.status === 'running'/,
-      'No-session default permission changes must stay enabled while running/waiting guards apply only to existing sessions',
-    );
-  });
-});
-
-describe('describeTurnErrorClass (PR109e-d @kenji gate #3)', () => {
-  it('returns Chinese label for known timeout class', () => {
-    assert.match(describeTurnErrorClass('timeout'), /超时/);
-  });
-
-  it('returns Chinese label for known auth / 401 / 403 classes', () => {
-    for (const cls of ['auth', '401', '403']) {
-      assert.match(describeTurnErrorClass(cls), /鉴权/, `${cls} should map to 鉴权失败`);
+    for (const [errorClass, pattern] of cases) {
+      const copy = describeTurnErrorClass(errorClass);
+      assert.match(copy, pattern, String(errorClass));
+      if (errorClass) assert.equal(copy.includes(errorClass), false, errorClass);
     }
   });
 
-  it('returns Chinese label for rate_limit / rate_exceeded', () => {
-    for (const cls of ['rate_limit', 'rate_exceeded']) {
-      assert.match(describeTurnErrorClass(cls), /速率/, `${cls} should map to rate-limit phrasing`);
-    }
-  });
+  it('chooses recovery from side-effect and resumability evidence', () => {
+    const cases = [
+      {
+        input: ['app_restarted', false, 0, 0] as const,
+        action: 'continue',
+      },
+      {
+        input: [SANDBOX_BOUNDARY_RESTART_CLOSURE_CLASS, false, 0, 0] as const,
+        action: 'retry',
+      },
+      {
+        input: ['tool_failed', false, 1, 1] as const,
+        action: 'inspect_tool',
+      },
+      {
+        input: ['tool_step_cap_reached', true, 1, 0] as const,
+        action: 'continue',
+      },
+      {
+        input: ['auth', false, 0, 0] as const,
+        action: 'check_connection',
+      },
+      {
+        input: ['provider_billing', false, 0, 0] as const,
+        action: 'check_connection',
+      },
+      {
+        input: ['timeout', true, 0, 0] as const,
+        action: 'continue',
+      },
+      {
+        input: ['timeout', false, 1, 0] as const,
+        action: 'inspect_tool',
+      },
+      {
+        input: ['timeout', false, 0, 0] as const,
+        action: 'retry',
+      },
+    ];
 
-  it('returns Chinese label for network / fetch / econn classes', () => {
-    for (const cls of ['network', 'fetch_failed', 'econnrefused']) {
-      assert.match(describeTurnErrorClass(cls), /网络/, `${cls} should map to network error`);
-    }
-  });
-
-  it('returns Chinese label for provider_unavailable / 5xx codes', () => {
-    for (const cls of ['provider_unavailable', '500', '503']) {
-      const text = describeTurnErrorClass(cls);
-      assert.equal(text, '模型服务返回错误', `${cls} should map to provider error copy`);
-      assert.doesNotMatch(text, /暂不可用/);
-    }
-  });
-
-  it('returns specific labels for context overflow and provider billing', () => {
-    assert.equal(describeTurnErrorClass('context_overflow'), '上下文窗口已超出限制');
-    assert.equal(describeTurnErrorClass('provider_billing'), '模型服务计费受限');
-  });
-
-  it('returns Chinese label for tool_failed', () => {
-    assert.match(describeTurnErrorClass('tool_failed'), /工具/);
-  });
-
-  it('distinguishes a tool step cap from a failed tool call', () => {
-    assert.equal(describeTurnErrorClass('tool_step_cap_reached'), '达到工具步骤上限');
-    assert.deepEqual(deriveFailedTurnRecovery({
-      errorClass: 'tool_step_cap_reached',
-      partialOutputRetained: true,
-      toolActivityCount: 1,
-      erroredToolCount: 0,
-    }), {
-      action: 'continue',
-      label: '任务可能尚未完成，可以继续',
-    });
-  });
-
-  it('returns a specific Chinese label for app restart recovery', () => {
-    assert.equal(describeTurnErrorClass('app_restarted'), '本地应用重启，上一轮没有完成');
-  });
-
-  it('explains a sandbox boundary request the host restart closed (#1612)', () => {
-    // The prompt the user never answered must read as a named closure, not as
-    // a bare restart and not as the generic "等待权限确认" catch-all.
-    const text = describeTurnErrorClass(SANDBOX_BOUNDARY_RESTART_CLOSURE_CLASS);
-    assert.equal(text, '本地应用重启，等待确认的「允许访问工作区以外的内容」请求已按拒绝关闭');
-    assert.notEqual(text, describeTurnErrorClass('app_restarted'));
-    assert.notEqual(text, describeTurnErrorClass('permission_required'));
-    assert.doesNotMatch(text, new RegExp(SANDBOX_BOUNDARY_RESTART_CLOSURE_CLASS));
-    assert.equal(
-      describeTurnErrorClass(SANDBOX_BOUNDARY_RESTART_CLOSURE_CLASS.toUpperCase()),
-      text,
-    );
-  });
-
-  it('falls back to "未知错误" for unrecognized classes', () => {
-    for (const cls of [undefined, 'xyz', 'something_new', '']) {
-      assert.match(describeTurnErrorClass(cls), /未知/, `${JSON.stringify(cls)} should fall back to 未知错误`);
-    }
-  });
-
-  it('NEVER returns the raw enum identifier verbatim (Chinese-only)', () => {
-    // Per @kenji review: UI must not display the raw `errorClass`.
-    for (const cls of ['timeout', 'auth', 'rate_limit', 'network', 'tool_failed', 'provider_unavailable']) {
-      const text = describeTurnErrorClass(cls);
-      assert.match(text, /[一-鿿]/, `${cls} should produce Chinese text`);
-      assert.doesNotMatch(text, new RegExp(`\\b${cls}\\b`), `${cls} copy "${text}" leaks enum identifier`);
-    }
-  });
-
-  it('is case-insensitive', () => {
-    assert.equal(describeTurnErrorClass('TIMEOUT'), describeTurnErrorClass('timeout'));
-    assert.equal(describeTurnErrorClass('Network'), describeTurnErrorClass('network'));
-  });
-});
-
-describe('deriveFailedTurnRecovery (PawWork run-incident lite)', () => {
-  it('routes app restart failures to safe resume instead of blind retry', () => {
-    const result = deriveFailedTurnRecovery({
-      errorClass: 'app_restarted',
-      partialOutputRetained: false,
-      toolActivityCount: 0,
-      erroredToolCount: 0,
-    });
-
-    assert.equal(result.action, 'continue');
-    assert.match(result.label, /安全恢复/);
-  });
-
-  it('offers retry, not resume, for a boundary request closed by the restart (#1612)', () => {
-    const result = deriveFailedTurnRecovery({
-      errorClass: SANDBOX_BOUNDARY_RESTART_CLOSURE_CLASS,
-      partialOutputRetained: false,
-      toolActivityCount: 0,
-      erroredToolCount: 0,
-    });
-
-    assert.equal(result.action, 'retry');
-    assert.match(result.label, /重试本轮/);
-  });
-
-  it('asks the user to inspect tool output when a tool failed', () => {
-    const result = deriveFailedTurnRecovery({
-      errorClass: 'tool_failed',
-      partialOutputRetained: false,
-      toolActivityCount: 1,
-      erroredToolCount: 1,
-    });
-    assert.equal(result.action, 'inspect_tool');
-    assert.match(result.label, /工具|结果/);
-  });
-
-  it('routes auth failures to connection/login checks before retrying', () => {
-    for (const cls of ['auth', '401', '403']) {
-      const result = deriveFailedTurnRecovery({
-        errorClass: cls,
-        partialOutputRetained: false,
-        toolActivityCount: 0,
-        erroredToolCount: 0,
-      });
-      assert.equal(result.action, 'check_connection');
-      assert.match(result.label, /模型|连接|登录/);
-    }
-  });
-
-  it('routes provider billing failures to connection/account checks before retrying', () => {
-    const result = deriveFailedTurnRecovery({
-      errorClass: 'provider_billing',
-      partialOutputRetained: false,
-      toolActivityCount: 0,
-      erroredToolCount: 0,
-    });
-    assert.equal(result.action, 'check_connection');
-    assert.match(result.label, /模型|连接|登录/);
-  });
-
-  it('offers continue when partial output was retained and no tool failed', () => {
-    const result = deriveFailedTurnRecovery({
-      errorClass: 'timeout',
-      partialOutputRetained: true,
-      toolActivityCount: 0,
-      erroredToolCount: 0,
-    });
-    assert.equal(result.action, 'continue');
-    assert.match(result.label, /保留|继续/);
-  });
-
-  it('offers direct retry only when no side-effect or partial-output evidence exists', () => {
-    const result = deriveFailedTurnRecovery({
-      errorClass: 'timeout',
-      partialOutputRetained: false,
-      toolActivityCount: 0,
-      erroredToolCount: 0,
-    });
-    assert.equal(result.action, 'retry');
-    assert.match(result.label, /重试/);
-  });
-
-  it('keeps all recovery labels Chinese and does not echo raw error classes', () => {
-    for (const errorClass of ['timeout', 'auth', 'tool_failed', 'provider_unavailable']) {
-      const text = deriveFailedTurnRecovery({
+    for (const { input, action } of cases) {
+      const [errorClass, partialOutputRetained, toolActivityCount, erroredToolCount] = input;
+      const recovery = deriveFailedTurnRecovery({
         errorClass,
-        partialOutputRetained: errorClass === 'provider_unavailable',
-        toolActivityCount: errorClass === 'tool_failed' ? 1 : 0,
-        erroredToolCount: errorClass === 'tool_failed' ? 1 : 0,
-      }).label;
-      assert.match(text, /[一-鿿]/);
-      assert.ok(!text.includes(errorClass), `${errorClass} leaked into "${text}"`);
+        partialOutputRetained,
+        toolActivityCount,
+        erroredToolCount,
+      });
+      assert.equal(recovery.action, action, errorClass);
+      assert.match(recovery.label, /[一-鿿]/, errorClass);
+      assert.equal(recovery.label.includes(errorClass), false, errorClass);
     }
   });
 });

--- a/packages/cli/src/__tests__/connection-target.test.ts
+++ b/packages/cli/src/__tests__/connection-target.test.ts
@@ -8,874 +8,105 @@ import {
 } from '../connection-target.js';
 
 describe('default session target resolver', () => {
-  test('resolves OpenCode Go credentials without rewriting its exact model id', async () => {
-    const connection = makeConnection({
-      slug: 'opencode-go',
-      name: 'OpenCode Go',
-      providerType: 'opencode-go',
-      defaultModel: 'minimax-m3',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'opencode-go',
-        get: async (slug) => (slug === 'opencode-go' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'opencode-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'opencode-go');
-    assert.equal(target.apiKey, 'opencode-test-key');
-    assert.equal(target.model, 'minimax-m3');
-  });
-
-  test('resolves Volcengine Coding Plan credentials without rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'volcengine-coding-plan',
-      name: 'Volcengine Ark Coding Plan (China)',
-      providerType: 'volcengine-coding-plan',
-      defaultModel: 'kimi-k2.7-code',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'volcengine-coding-plan',
-        get: async (slug) => (slug === 'volcengine-coding-plan' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) =>
-          kind === 'api_key' ? 'volcengine-coding-plan-test-key' : null,
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'volcengine-coding-plan');
-    assert.equal(target.apiKey, 'volcengine-coding-plan-test-key');
-    assert.equal(target.model, 'kimi-k2.7-code');
-  });
-
-  test('resolves Volcengine Ark credentials without rewriting the snapshot model id', async () => {
-    const modelId = 'doubao-seed-2-0-pro-260215';
-    const connection = makeConnection({
-      slug: 'volcengine-ark',
-      name: 'Volcengine Ark (China)',
-      providerType: 'volcengine-ark',
-      defaultModel: modelId,
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'volcengine-ark',
-        get: async (slug) => (slug === 'volcengine-ark' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'ark-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'volcengine-ark');
-    assert.equal(target.apiKey, 'ark-test-key');
-    assert.equal(target.model, modelId);
-  });
-
-  test('resolves Fireworks credentials without rewriting the exact model path', async () => {
-    const connection = makeConnection({
-      slug: 'fireworks-ai',
-      name: 'Fireworks AI',
-      providerType: 'fireworks-ai',
-      defaultModel: 'accounts/fireworks/models/kimi-k2p6',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'fireworks-ai',
-        get: async (slug) => (slug === 'fireworks-ai' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'fireworks-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'fireworks-ai');
-    assert.equal(target.apiKey, 'fireworks-test-key');
-    assert.equal(target.model, 'accounts/fireworks/models/kimi-k2p6');
-  });
-
-  test('resolves StepFun China credentials without rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'stepfun',
-      name: 'StepFun (China)',
-      providerType: 'stepfun',
-      defaultModel: 'step-3.7-flash',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'stepfun',
-        get: async (slug) => (slug === 'stepfun' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'stepfun-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'stepfun');
-    assert.equal(target.apiKey, 'stepfun-test-key');
-    assert.equal(target.model, 'step-3.7-flash');
-  });
-
-  test('resolves StepFun Step Plan credentials without rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'stepfun-step-plan',
-      name: 'StepFun Step Plan (China)',
-      providerType: 'stepfun-step-plan',
-      defaultModel: 'step-router-v1',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'stepfun-step-plan',
-        get: async (slug) => (slug === 'stepfun-step-plan' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) =>
-          kind === 'api_key' ? 'stepfun-step-plan-test-key' : null,
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'stepfun-step-plan');
-    assert.equal(target.apiKey, 'stepfun-step-plan-test-key');
-    assert.equal(target.model, 'step-router-v1');
-  });
-
-  test('resolves StepFun Step Plan Global credentials without rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'stepfun-ai-step-plan',
-      name: 'StepFun Step Plan (Global)',
-      providerType: 'stepfun-ai-step-plan',
-      defaultModel: 'step-3.5-flash-2603',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'stepfun-ai-step-plan',
-        get: async (slug) => (slug === 'stepfun-ai-step-plan' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) =>
-          kind === 'api_key' ? 'stepfun-global-step-plan-test-key' : null,
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'stepfun-ai-step-plan');
-    assert.equal(target.apiKey, 'stepfun-global-step-plan-test-key');
-    assert.equal(target.model, 'step-3.5-flash-2603');
-  });
-
-  test('resolves StepFun Global credentials without rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'stepfun-ai',
-      name: 'StepFun (Global)',
-      providerType: 'stepfun-ai',
-      defaultModel: 'step-3.7-flash',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'stepfun-ai',
-        get: async (slug) => (slug === 'stepfun-ai' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'stepfun-global-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'stepfun-ai');
-    assert.equal(target.apiKey, 'stepfun-global-test-key');
-    assert.equal(target.model, 'step-3.7-flash');
-  });
-
-  test('resolves Tencent TokenHub credentials without rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'tencent-tokenhub',
-      name: 'Tencent TokenHub',
-      providerType: 'tencent-tokenhub',
-      defaultModel: 'hy3-preview',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'tencent-tokenhub',
-        get: async (slug) => (slug === 'tencent-tokenhub' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'tencent-tokenhub-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'tencent-tokenhub');
-    assert.equal(target.apiKey, 'tencent-tokenhub-test-key');
-    assert.equal(target.model, 'hy3-preview');
-  });
-
-  test('resolves Tencent Coding Plan credentials without rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'tencent-coding-plan',
-      name: 'Tencent Coding Plan (China)',
-      providerType: 'tencent-coding-plan',
-      defaultModel: 'glm-5',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'tencent-coding-plan',
-        get: async (slug) => (slug === 'tencent-coding-plan' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) =>
-          kind === 'api_key' ? 'tencent-coding-plan-test-key' : null,
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'tencent-coding-plan');
-    assert.equal(target.apiKey, 'tencent-coding-plan-test-key');
-    assert.equal(target.model, 'glm-5');
-  });
-
-  test('resolves Tencent Token Plan credentials without rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'tencent-token-plan',
-      name: 'Tencent Token Plan',
-      providerType: 'tencent-token-plan',
-      defaultModel: 'deepseek-v4-pro-202606',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'tencent-token-plan',
-        get: async (slug) => (slug === 'tencent-token-plan' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) =>
-          kind === 'api_key' ? 'tencent-token-plan-test-key' : null,
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'tencent-token-plan');
-    assert.equal(target.apiKey, 'tencent-token-plan-test-key');
-    assert.equal(target.model, 'deepseek-v4-pro-202606');
-  });
-
-  test('resolves both Alibaba Coding Plan regions without rewriting the selected model id', async () => {
-    for (const [providerType, defaultModel] of [
-      ['alibaba-coding-plan-cn', 'qwen3.7-plus'],
-      ['alibaba-coding-plan', 'qwen3-coder-plus'],
-    ] as const) {
-      const connection = makeConnection({
-        slug: providerType,
-        name: providerType,
-        providerType,
-        defaultModel,
-      });
-
-      const target = await resolveDefaultSessionTarget({
-        connectionStore: {
-          getDefault: async () => providerType,
-          get: async (slug) => (slug === providerType ? connection : null),
-        },
-        credentialStore: {
-          getSecret: async (_slug, kind) =>
-            kind === 'api_key' ? `${providerType}-test-key` : null,
-        },
-      });
-
-      assert.equal(target.connection.providerType, providerType);
-      assert.equal(target.apiKey, `${providerType}-test-key`);
-      assert.equal(target.model, defaultModel);
-    }
-  });
-
-  test('resolves Alibaba Token Plan credentials without rewriting the selected model id', async () => {
-    for (const [providerType, model] of [
-      ['alibaba-token-plan-cn', 'qwen3.7-max'],
-      ['alibaba-token-plan', 'deepseek-v4-pro'],
-    ] as const) {
-      const connection = makeConnection({
-        slug: providerType,
-        name: 'Alibaba Token Plan',
-        providerType,
-        defaultModel: model,
-      });
-
-      const target = await resolveDefaultSessionTarget({
-        connectionStore: {
-          getDefault: async () => providerType,
-          get: async (slug) => (slug === providerType ? connection : null),
-        },
-        credentialStore: {
-          getSecret: async (_slug, kind) =>
-            kind === 'api_key' ? `${providerType}-test-key` : null,
-        },
-      });
-
-      assert.equal(target.connection.providerType, providerType);
-      assert.equal(target.apiKey, `${providerType}-test-key`);
-      assert.equal(target.model, model);
-    }
-  });
-
-  for (const providerType of [
-    'xiaomi-token-plan-cn',
-    'xiaomi-token-plan-sgp',
-    'xiaomi-token-plan-ams',
-  ] as const) {
-    test(`resolves ${providerType} credentials without rewriting the selected model id`, async () => {
-      const connection = makeConnection({
-        slug: providerType,
-        name: providerType,
-        providerType,
-        defaultModel: 'mimo-v2.5-pro',
-      });
-
-      const target = await resolveDefaultSessionTarget({
-        connectionStore: {
-          getDefault: async () => providerType,
-          get: async (slug) => (slug === providerType ? connection : null),
-        },
-        credentialStore: {
-          getSecret: async (_slug, kind) =>
-            kind === 'api_key' ? `${providerType}-test-key` : null,
-        },
-      });
-
-      assert.equal(target.connection.providerType, providerType);
-      assert.equal(target.apiKey, `${providerType}-test-key`);
-      assert.equal(target.model, 'mimo-v2.5-pro');
-    });
-  }
-
-  test('resolves LM Studio without reading a credential or rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'lm-studio',
-      name: 'LM Studio',
-      providerType: 'lm-studio',
-      defaultModel: 'lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-GGUF',
-    });
-    let credentialReads = 0;
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'lm-studio',
-        get: async (slug) => (slug === 'lm-studio' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async () => {
-          credentialReads += 1;
-          return null;
-        },
-      },
-    });
-
-    assert.equal(credentialReads, 0);
-    assert.equal(target.connection.providerType, 'lm-studio');
-    assert.equal(target.apiKey, '');
-    assert.equal(target.model, 'lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-GGUF');
-  });
-
-  test('resolves LocalAI without requiring its optional credential or rewriting the exact alias', async () => {
-    const model = 'localai/Qwen3-8B-Instruct-GGUF:Q4_K_M';
-    const connection = makeConnection({
-      slug: 'localai',
-      name: 'LocalAI',
-      providerType: 'localai',
-      defaultModel: model,
-    });
-    const credentialReads: string[] = [];
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'localai',
-        get: async (slug) => (slug === 'localai' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => {
-          credentialReads.push(kind);
-          return null;
-        },
-      },
-    });
-
-    assert.deepEqual(credentialReads, ['api_key']);
-    assert.equal(target.connection.providerType, 'localai');
-    assert.equal(target.apiKey, '');
-    assert.equal(target.model, model);
-  });
-
-  test('resolves Cerebras credentials without rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'cerebras',
-      name: 'Cerebras',
-      providerType: 'cerebras',
-      defaultModel: 'gpt-oss-120b',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'cerebras',
-        get: async (slug) => (slug === 'cerebras' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'cerebras-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'cerebras');
-    assert.equal(target.apiKey, 'cerebras-test-key');
-    assert.equal(target.model, 'gpt-oss-120b');
-  });
-
-  test('resolves a Together AI API-key connection without rewriting its exact model id', async () => {
-    const connection = makeConnection({
-      slug: 'together',
-      name: 'Together AI',
-      providerType: 'togetherai',
-      defaultModel: 'MiniMaxAI/MiniMax-M3',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'together',
-        get: async (slug) => (slug === 'together' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'together-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'togetherai');
-    assert.equal(target.apiKey, 'together-test-key');
-    assert.equal(target.model, 'MiniMaxAI/MiniMax-M3');
-  });
-
-  test('resolves DeepInfra credentials without rewriting the exact model id', async () => {
-    const modelId = 'moonshotai/Kimi-K2.7-Code';
-    const connection = makeConnection({
-      slug: 'deepinfra',
-      name: 'Deep Infra',
-      providerType: 'deepinfra',
-      defaultModel: modelId,
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'deepinfra',
-        get: async (slug) => (slug === 'deepinfra' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'deepinfra-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'deepinfra');
-    assert.equal(target.apiKey, 'deepinfra-test-key');
-    assert.equal(target.model, modelId);
-  });
-
-  test('resolves Groq credentials without rewriting the exact model id', async () => {
-    const modelId = 'llama-3.3-70b-versatile';
-    const connection = makeConnection({
-      slug: 'groq',
-      name: 'Groq',
-      providerType: 'groq',
-      defaultModel: modelId,
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'groq',
-        get: async (slug) => (slug === 'groq' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'groq-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'groq');
-    assert.equal(target.apiKey, 'groq-test-key');
-    assert.equal(target.model, modelId);
-  });
-
-  test('resolves OpenRouter credentials without rewriting the exact model id', async () => {
-    const modelId = 'anthropic/claude-sonnet-5';
-    const connection = makeConnection({
-      slug: 'openrouter',
-      name: 'OpenRouter',
-      providerType: 'openrouter',
-      defaultModel: modelId,
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'openrouter',
-        get: async (slug) => (slug === 'openrouter' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'openrouter-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'openrouter');
-    assert.equal(target.apiKey, 'openrouter-test-key');
-    assert.equal(target.model, modelId);
-  });
-
-  test('resolves Ollama Cloud credentials without crossing into local Ollama state', async () => {
-    const modelId = 'qwen3.5:397b';
-    const connection = makeConnection({
-      slug: 'ollama-cloud',
-      name: 'Ollama Cloud',
-      providerType: 'ollama-cloud',
-      defaultModel: modelId,
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'ollama-cloud',
-        get: async (slug) => (slug === 'ollama-cloud' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (slug, kind) =>
-          slug === 'ollama-cloud' && kind === 'api_key' ? 'ollama-cloud-test-key' : null,
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'ollama-cloud');
-    assert.equal(target.apiKey, 'ollama-cloud-test-key');
-    assert.equal(target.model, modelId);
-  });
-
-  test('resolves Cloudflare Workers AI credentials without rewriting account scope or model id', async () => {
-    const modelId = '@cf/moonshotai/kimi-k2.6';
-    const baseUrl = 'https://api.cloudflare.com/client/v4/accounts/account-123/ai/v1';
-    const connection = makeConnection({
-      slug: 'cloudflare-workers-ai',
-      name: 'Cloudflare Workers AI',
-      providerType: 'cloudflare-workers-ai',
-      baseUrl,
-      defaultModel: modelId,
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'cloudflare-workers-ai',
-        get: async (slug) => (slug === 'cloudflare-workers-ai' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) =>
-          kind === 'api_key' ? 'cloudflare-workers-ai-test-token' : null,
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'cloudflare-workers-ai');
-    assert.equal(target.connection.baseUrl, baseUrl);
-    assert.equal(target.apiKey, 'cloudflare-workers-ai-test-token');
-    assert.equal(target.model, modelId);
-  });
-
-  test('resolves NVIDIA credentials without rewriting the selected model id', async () => {
-    const modelId = 'nvidia/nemotron-3-super-120b-a12b';
-    const connection = makeConnection({
-      slug: 'nvidia',
-      name: 'NVIDIA',
-      providerType: 'nvidia',
-      defaultModel: modelId,
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'nvidia',
-        get: async (slug) => (slug === 'nvidia' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'nvidia-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'nvidia');
-    assert.equal(target.apiKey, 'nvidia-test-key');
-    assert.equal(target.model, modelId);
-  });
-
-  test('resolves MiniMax Coding Plan credentials without rewriting the selected model id', async () => {
-    const connection = makeConnection({
-      slug: 'minimax-plan',
-      name: 'MiniMax Coding Plan',
-      providerType: 'minimax-coding-plan',
-      defaultModel: 'MiniMax-M2.7-highspeed',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'minimax-plan',
-        get: async (slug) => (slug === 'minimax-plan' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'minimax-plan-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'minimax-coding-plan');
-    assert.equal(target.apiKey, 'minimax-plan-test-key');
-    assert.equal(target.model, 'MiniMax-M2.7-highspeed');
-  });
-
-  test('resolves an xAI API-key connection without rewriting its exact model id', async () => {
-    const connection = makeConnection({
-      slug: 'xai',
-      name: 'xAI',
-      providerType: 'xai',
-      defaultModel: 'grok-4.5',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'xai',
-        get: async (slug) => (slug === 'xai' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'xai-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'xai');
-    assert.equal(target.apiKey, 'xai-test-key');
-    assert.equal(target.model, 'grok-4.5');
-  });
-
-  test('resolves a Mistral API-key connection without rewriting its exact model id', async () => {
-    const connection = makeConnection({
-      slug: 'mistral',
-      name: 'Mistral',
-      providerType: 'mistral',
-      defaultModel: 'mistral-small-2603',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'mistral',
-        get: async (slug) => (slug === 'mistral' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'mistral-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'mistral');
-    assert.equal(target.apiKey, 'mistral-test-key');
-    assert.equal(target.model, 'mistral-small-2603');
-  });
-
-  test('resolves a Cohere API-key connection without rewriting its exact model id', async () => {
-    const connection = makeConnection({
-      slug: 'cohere',
-      name: 'Cohere',
-      providerType: 'cohere',
-      defaultModel: 'command-a-plus-05-2026',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'cohere',
-        get: async (slug) => (slug === 'cohere' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'cohere-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'cohere');
-    assert.equal(target.apiKey, 'cohere-test-key');
-    assert.equal(target.model, 'command-a-plus-05-2026');
-  });
-
-  test('resolves a Hugging Face token without rewriting its exact routing suffix', async () => {
-    const modelId = 'openai/gpt-oss-120b:preferred';
-    const connection = makeConnection({
-      slug: 'huggingface',
-      name: 'Hugging Face',
-      providerType: 'huggingface',
-      defaultModel: modelId,
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'huggingface',
-        get: async (slug) => (slug === 'huggingface' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'hf-test-token' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'huggingface');
-    assert.equal(target.apiKey, 'hf-test-token');
-    assert.equal(target.model, modelId);
-  });
-
-  for (const provider of [
-    { type: 'xiaomi', label: 'Xiaomi', modelId: 'mimo-v2.5' },
-    { type: 'zai', label: 'Z.AI', modelId: 'glm-5.2' },
-  ] as const) {
-    test(`resolves ${provider.label} credentials without rewriting its exact model id`, async () => {
-      const connection = makeConnection({
-        slug: provider.type,
-        name: provider.label,
-        providerType: provider.type,
-        defaultModel: provider.modelId,
-      });
-
-      const target = await resolveDefaultSessionTarget({
-        connectionStore: {
-          getDefault: async () => provider.type,
-          get: async (slug) => (slug === provider.type ? connection : null),
-        },
-        credentialStore: {
-          getSecret: async (_slug, kind) =>
-            kind === 'api_key' ? `${provider.type}-test-key` : null,
-        },
-      });
-
-      assert.equal(target.connection.providerType, provider.type);
-      assert.equal(target.apiKey, `${provider.type}-test-key`);
-      assert.equal(target.model, provider.modelId);
-    });
-  }
-
-  test('resolves a SiliconFlow registry connection without rewriting its model id', async () => {
-    const connection = makeConnection({
-      slug: 'siliconflow',
-      name: 'SiliconFlow',
-      providerType: 'siliconflow',
-      defaultModel: 'moonshotai/Kimi-K2.6',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'siliconflow',
-        get: async (slug) => (slug === 'siliconflow' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'sf-test-key' : null),
-      },
-    });
-
-    assert.equal(target.connection.providerType, 'siliconflow');
-    assert.equal(target.apiKey, 'sf-test-key');
-    assert.equal(target.model, 'moonshotai/Kimi-K2.6');
-  });
-
-  test('resolves a Vercel Gateway connection without rewriting its creator/model id', async () => {
+  test('uses the selected API-key connection without rewriting its endpoint or model', async () => {
     const connection = makeConnection({
       slug: 'vercel',
       name: 'Vercel AI Gateway',
       providerType: 'vercel',
+      baseUrl: 'https://gateway.example.test/v1',
       defaultModel: 'xai/grok-4.3',
+      enabledModelIds: ['xai/grok-4.3', 'anthropic/claude-sonnet-4.5'],
     });
 
     const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'vercel',
-        get: async (slug) => (slug === 'vercel' ? connection : null),
-      },
+      connectionStore: storeFor(connection),
       credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'vercel-test-key' : null),
+        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'gateway-key' : null),
       },
+      requestedModel: 'anthropic/claude-sonnet-4.5',
     });
 
-    assert.equal(target.connection.providerType, 'vercel');
-    assert.equal(target.apiKey, 'vercel-test-key');
-    assert.equal(target.model, 'xai/grok-4.3');
+    assert.equal(target.connection, connection);
+    assert.equal(target.apiKey, 'gateway-key');
+    assert.equal(target.model, 'anthropic/claude-sonnet-4.5');
   });
 
-  test('resolves ZenMux credentials without rewriting the exact creator/model id', async () => {
-    const connection = makeConnection({
-      slug: 'zenmux',
-      name: 'ZenMux',
-      providerType: 'zenmux',
-      defaultModel: 'moonshotai/kimi-k2.5',
-    });
-
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'zenmux',
-        get: async (slug) => (slug === 'zenmux' ? connection : null),
+  test('honors required, optional, and absent credential policies', async () => {
+    const cases = [
+      {
+        connection: makeConnection({
+          slug: 'lm-studio',
+          providerType: 'lm-studio',
+          defaultModel: 'lmstudio-community/Qwen3-Coder',
+        }),
+        expectedReads: 0,
       },
-      credentialStore: {
-        getSecret: async (_slug, kind) => (kind === 'api_key' ? 'zenmux-test-key' : null),
+      {
+        connection: makeConnection({
+          slug: 'localai',
+          providerType: 'localai',
+          defaultModel: 'localai/Qwen3-8B:Q4_K_M',
+        }),
+        expectedReads: 1,
       },
-    });
+    ];
 
-    assert.equal(target.connection.providerType, 'zenmux');
-    assert.equal(target.apiKey, 'zenmux-test-key');
-    assert.equal(target.model, 'moonshotai/kimi-k2.5');
-  });
+    for (const { connection, expectedReads } of cases) {
+      let reads = 0;
+      const target = await resolveDefaultSessionTarget({
+        connectionStore: storeFor(connection),
+        credentialStore: {
+          getSecret: async () => {
+            reads += 1;
+            return null;
+          },
+        },
+      });
 
-  test('uses the default ready connection and requested model', async () => {
-    const connection = makeConnection({
-      slug: 'local',
-      providerType: 'ollama',
-      defaultModel: 'qwen2.5-coder',
-      // Requested model must be user-enabled; discovered catalog alone is not enough.
-      enabledModelIds: ['qwen2.5-coder', 'llama3.2'],
-      models: [{ id: 'qwen2.5-coder' }, { id: 'llama3.2' }],
-    });
+      assert.equal(reads, expectedReads, connection.providerType);
+      assert.equal(target.apiKey, '');
+      assert.equal(target.model, connection.defaultModel);
+    }
 
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'local',
-        get: async (slug) => (slug === 'local' ? connection : null),
-      },
-      credentialStore: {
-        getSecret: async () => null,
-      },
-      requestedModel: 'llama3.2',
-    });
-
-    assert.equal(target.connection.slug, 'local');
-    assert.equal(target.apiKey, '');
-    assert.equal(target.model, 'llama3.2');
-  });
-
-  test('uses a stored subscription access token for OAuth default connections', async () => {
-    const connection = makeConnection({
-      slug: 'openai-codex',
-      providerType: 'openai-codex',
+    const required = makeConnection({
+      slug: 'openai',
+      providerType: 'openai',
       defaultModel: 'gpt-5.5',
     });
+    await assert.rejects(
+      resolveDefaultSessionTarget({
+        connectionStore: storeFor(required),
+        credentialStore: { getSecret: async () => null },
+      }),
+      /NO_REAL_CONNECTION:missing_api_key/,
+    );
+  });
 
+  test('uses the account endpoint from a valid OAuth credential record', async () => {
+    const connection = makeConnection({
+      slug: 'github-copilot',
+      providerType: 'github-copilot',
+      baseUrl: 'https://api.githubcopilot.com',
+      defaultModel: 'gpt-5.4',
+    });
     const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'openai-codex',
-        get: async (slug) => (slug === 'openai-codex' ? connection : null),
-      },
+      connectionStore: storeFor(connection),
       credentialStore: {
         getSecret: async () =>
           JSON.stringify({
-            access_token: 'oauth-access-token',
-            refresh_token: 'oauth-refresh-token',
+            access_token: 'github-account-token',
+            refresh_token: 'github-account-token',
             expires_at: Date.now() + 10 * 60_000,
-            account_id: 'acct_123',
+            base_url: 'https://api.business.githubcopilot.com',
           }),
       },
     });
 
-    assert.equal(target.connection.slug, 'openai-codex');
-    assert.equal(target.apiKey, 'oauth-access-token');
-    assert.equal(target.model, 'gpt-5.5');
+    assert.equal(target.apiKey, 'github-account-token');
+    assert.equal(target.connection.baseUrl, 'https://api.business.githubcopilot.com');
   });
 
-  test('refreshes an expired OAuth subscription token before selecting the default target', async () => {
+  test('refreshes and persists an expired OAuth credential before returning it', async () => {
     const connection = makeConnection({
       slug: 'openai-codex',
       providerType: 'openai-codex',
@@ -890,10 +121,7 @@ describe('default session target resolver', () => {
     let refreshBody = '';
 
     const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'openai-codex',
-        get: async (slug) => (slug === 'openai-codex' ? connection : null),
-      },
+      connectionStore: storeFor(connection),
       credentialStore: {
         getSecret: async () => stored,
         setSecret: async (_slug, _kind, value) => {
@@ -917,34 +145,7 @@ describe('default session target resolver', () => {
     assert.equal(JSON.parse(stored).access_token, 'fresh-access-token');
   });
 
-  test('uses the GitHub Copilot account endpoint from the shared OAuth credential record', async () => {
-    const connection = makeConnection({
-      slug: 'github-copilot',
-      providerType: 'github-copilot',
-      baseUrl: 'https://api.githubcopilot.com',
-      defaultModel: 'gpt-5.4',
-    });
-    const target = await resolveDefaultSessionTarget({
-      connectionStore: {
-        getDefault: async () => 'github-copilot',
-        get: async () => connection,
-      },
-      credentialStore: {
-        getSecret: async () =>
-          JSON.stringify({
-            access_token: 'github-account-token',
-            refresh_token: 'github-account-token',
-            expires_at: Date.now() + 10 * 60_000,
-            base_url: 'https://api.business.githubcopilot.com',
-          }),
-      },
-    });
-
-    assert.equal(target.apiKey, 'github-account-token');
-    assert.equal(target.connection.baseUrl, 'https://api.business.githubcopilot.com');
-  });
-
-  test('rejects unusable OAuth subscription credentials instead of using the raw secret as an API key', async () => {
+  test('rejects malformed or unrefreshable OAuth credentials instead of using raw secrets', async () => {
     const connection = makeConnection({
       slug: 'openai-codex',
       providerType: 'openai-codex',
@@ -960,16 +161,8 @@ describe('default session target resolver', () => {
     for (const secret of ['not-json', expiredToken]) {
       await assert.rejects(
         resolveDefaultSessionTarget({
-          connectionStore: {
-            getDefault: async () => 'openai-codex',
-            get: async (slug) => (slug === 'openai-codex' ? connection : null),
-          },
-          credentialStore: {
-            getSecret: async () => secret,
-            setSecret: async () => {
-              throw new Error('refresh should fail before storing');
-            },
-          },
+          connectionStore: storeFor(connection),
+          credentialStore: { getSecret: async () => secret },
           now: () => 10_000,
           fetchFn: async () => new Response('refresh failed', { status: 500 }),
         }),
@@ -978,190 +171,99 @@ describe('default session target resolver', () => {
     }
   });
 
-  test('fails before session creation when no default connection exists', async () => {
+  test('fails closed when no default connection exists', async () => {
     await assert.rejects(
       resolveDefaultSessionTarget({
         connectionStore: {
           getDefault: async () => null,
           get: async () => null,
         },
-        credentialStore: {
-          getSecret: async () => null,
-        },
+        credentialStore: { getSecret: async () => null },
       }),
       /NO_REAL_CONNECTION:missing_default_connection/,
     );
   });
 });
 
-describe('selectableModelIdsForTarget', () => {
-  test('filters the picker to the connection enabledModelIds, keeping the current model selectable', () => {
-    const connection = makeConnection({
-      providerType: 'ollama',
-      defaultModel: 'glm-5.2',
-      enabledModelIds: ['glm-5.2'],
-      models: [{ id: 'glm-5.2' }, { id: 'glm-5-air' }, { id: 'glm-4.6' }],
-    });
-
-    // The session is currently on glm-5-air: it stays selectable even though
-    // the user curated it out; the rest of the catalog (glm-4.6) stays hidden.
-    assert.deepEqual(selectableModelIdsForTarget({ connection, model: 'glm-5-air' }), [
-      'glm-5-air',
-      'glm-5.2',
-    ]);
+test('selectable models are limited to the curated set plus the current model', () => {
+  const connection = makeConnection({
+    providerType: 'ollama',
+    defaultModel: 'glm-5.2',
+    enabledModelIds: ['glm-5.2'],
+    models: [{ id: 'glm-5.2' }, { id: 'glm-5-air' }, { id: 'glm-4.6' }],
   });
 
-  test('legacy connections without enabledModelIds collapse to the default model, never the full catalog', () => {
-    const connection = makeConnection({
-      providerType: 'ollama',
-      defaultModel: 'glm-5.2',
-      models: [{ id: 'glm-5.2' }, { id: 'glm-5-air' }],
-    });
-
-    assert.deepEqual(selectableModelIdsForTarget({ connection, model: 'glm-5.2' }), ['glm-5.2']);
-  });
+  assert.deepEqual(selectableModelIdsForTarget({ connection, model: 'glm-5-air' }), [
+    'glm-5-air',
+    'glm-5.2',
+  ]);
 });
 
-describe('listReadyModelChoices', () => {
-  test('lists only enabledModelIds for connections with a curated model set', async () => {
-    const zai = makeConnection({
-      slug: 'zai',
-      name: 'Z.ai',
-      providerType: 'ollama', // authKind none → ready without a stored secret
-      defaultModel: 'glm-5.2',
-      enabledModelIds: ['glm-5.2'],
-      models: [{ id: 'glm-5.2' }, { id: 'glm-5-air' }],
-    });
-
-    const choices = await listReadyModelChoices({
-      connectionStore: {
-        list: async () => [zai],
-        getDefault: async () => 'zai',
-      },
-      credentialStore: {
-        getSecret: async () => null,
-      },
-    });
-
-    // glm-5-air is discovered but curated out on desktop, so the TUI picker
-    // must not offer it either.
-    assert.deepEqual(
-      choices.map((choice) => choice.model),
-      ['glm-5.2'],
-    );
+test('ready model choices apply curation and isolate unavailable credentials', async () => {
+  const local = makeConnection({
+    slug: 'local',
+    name: 'Local',
+    providerType: 'ollama',
+    defaultModel: 'qwen',
+    enabledModelIds: ['qwen'],
+    models: [{ id: 'qwen' }, { id: 'hidden' }],
+  });
+  const openai = makeConnection({
+    slug: 'openai',
+    name: 'OpenAI',
+    providerType: 'openai',
+    defaultModel: 'gpt-5.5',
+    enabledModelIds: ['gpt-5.5'],
+    models: [{ id: 'gpt-5.5' }],
+  });
+  const keyless = makeConnection({
+    slug: 'keyless',
+    providerType: 'openai',
+    defaultModel: 'gpt-5.5',
+    enabledModelIds: ['gpt-5.5'],
+    models: [{ id: 'gpt-5.5' }],
+  });
+  const corrupt = makeConnection({
+    slug: 'corrupt',
+    providerType: 'openai',
+    defaultModel: 'gpt-5.5',
+    enabledModelIds: ['gpt-5.5'],
+    models: [{ id: 'gpt-5.5' }],
   });
 
-  test('lists models across every ready connection and skips fake / not-ready', async () => {
-    const zai = makeConnection({
-      slug: 'zai',
-      name: 'Z.ai',
-      providerType: 'ollama', // authKind none → ready without a stored secret
-      defaultModel: 'glm-5.2',
-      enabledModelIds: ['glm-5.2', 'glm-5-air'],
-      models: [{ id: 'glm-5.2' }, { id: 'glm-5-air' }],
-    });
-    const openai = makeConnection({
-      slug: 'openai',
-      name: 'OpenAI',
-      providerType: 'openai', // needs an api key
-      defaultModel: 'gpt-5.5',
-      models: [{ id: 'gpt-5.5' }],
-    });
-    const openaiNoKey = makeConnection({
-      slug: 'openai-2',
-      name: 'OpenAI 2',
-      providerType: 'openai',
-      defaultModel: 'gpt-5.5',
-    });
-    const fake = makeConnection({
-      slug: 'fake',
-      name: 'Fake',
-      providerType: 'ollama',
-      defaultModel: 'x',
-    });
-
-    const choices = await listReadyModelChoices({
-      connectionStore: {
-        list: async () => [zai, openai, openaiNoKey, fake],
-        getDefault: async () => 'zai',
+  const choices = await listReadyModelChoices({
+    connectionStore: {
+      list: async () => [local, openai, keyless, corrupt],
+      getDefault: async () => 'local',
+    },
+    credentialStore: {
+      getSecret: async (slug) => {
+        if (slug === 'openai') return 'sk-real';
+        if (slug === 'corrupt') throw new Error('credentials.json is unreadable');
+        return null;
       },
-      credentialStore: {
-        getSecret: async (slug) => (slug === 'openai' ? 'sk-real' : null),
-      },
-    });
-
-    // Two ready connections contribute; the keyless OpenAI and the fake are skipped.
-    assert.deepEqual(
-      choices.filter((choice) => choice.connectionSlug === 'zai').map((choice) => choice.model),
-      ['glm-5.2', 'glm-5-air'],
-    );
-    assert.deepEqual(
-      choices.filter((choice) => choice.connectionSlug === 'openai').map((choice) => choice.model),
-      ['gpt-5.5'],
-    );
-    assert.equal(
-      choices.some((choice) => choice.connectionSlug === 'openai-2'),
-      false,
-    );
-    assert.equal(
-      choices.some((choice) => choice.connectionSlug === 'fake'),
-      false,
-    );
-    // The default connection is flagged so the picker can mark it.
-    assert.equal(
-      choices.find((choice) => choice.connectionSlug === 'zai')?.isDefaultConnection,
-      true,
-    );
-    assert.equal(
-      choices.find((choice) => choice.connectionSlug === 'openai')?.isDefaultConnection,
-      false,
-    );
-    assert.equal(choices.find((choice) => choice.connectionSlug === 'zai')?.connectionName, 'Z.ai');
+    },
   });
 
-  test('skips a connection whose credential read throws instead of failing the whole list', async () => {
-    // A local keyless connection plus an API connection whose stored credentials
-    // are corrupt/legacy, so reading its secret throws.
-    const local = makeConnection({
-      slug: 'local',
-      name: 'Local',
-      providerType: 'ollama', // authKind none → no secret read
-      defaultModel: 'qwen',
-      models: [{ id: 'qwen' }],
-    });
-    const broken = makeConnection({
-      slug: 'openai',
-      name: 'OpenAI',
-      providerType: 'openai', // needs a secret → getSecret is called and throws
-      defaultModel: 'gpt-5.5',
-      models: [{ id: 'gpt-5.5' }],
-    });
-
-    const choices = await listReadyModelChoices({
-      connectionStore: {
-        list: async () => [local, broken],
-        getDefault: async () => 'local',
-      },
-      credentialStore: {
-        getSecret: async (slug) => {
-          if (slug === 'openai') throw new Error('credentials.json is unreadable');
-          return null;
-        },
-      },
-    });
-
-    // The broken connection is skipped; the keyless local model still lists, so
-    // startup (which awaits this) survives an unrelated corrupt credential file.
-    assert.deepEqual(
-      choices.map((choice) => choice.connectionSlug),
-      ['local'],
-    );
-    assert.deepEqual(
-      choices.map((choice) => choice.model),
-      ['qwen'],
-    );
-  });
+  assert.deepEqual(
+    choices.map(({ connectionSlug, model, isDefaultConnection }) => ({
+      connectionSlug,
+      model,
+      isDefaultConnection,
+    })),
+    [
+      { connectionSlug: 'local', model: 'qwen', isDefaultConnection: true },
+      { connectionSlug: 'openai', model: 'gpt-5.5', isDefaultConnection: false },
+    ],
+  );
 });
+
+function storeFor(connection: LlmConnection) {
+  return {
+    getDefault: async () => connection.slug,
+    get: async (slug: string) => (slug === connection.slug ? connection : null),
+  };
+}
 
 function makeConnection(input: Partial<LlmConnection>): LlmConnection {
   return {

--- a/packages/core/src/__tests__/settings.test.ts
+++ b/packages/core/src/__tests__/settings.test.ts
@@ -2,697 +2,131 @@ import { describe, test } from 'node:test';
 import { expect } from '../test-helpers.js';
 import {
   THEME_PALETTES,
-  createDefaultBotChannel,
   createDefaultSettings,
   isThemePalette,
   mergeSettings,
   normalizeSettings,
 } from '../settings.js';
 
-describe('bot readiness settings contract', () => {
-  test('default bot channels are scaffolded, not operational', () => {
-    const channel = createDefaultBotChannel('telegram');
-
-    expect(channel.connected).toBe(false);
-    expect(channel.readiness).toBe('scaffolded');
+test('delegates bot patches and persisted normalization to the bot settings owner', () => {
+  const current = createDefaultSettings();
+  Object.assign(current.botChat.channels.telegram, {
+    enabled: true,
+    token: 'live-token',
+    readiness: 'operational',
   });
 
-  test('normalizes legacy connected boolean to credentials_valid, not operational', () => {
-    const legacy = createDefaultSettings();
-    const telegram = legacy.botChat.channels.telegram as Partial<
-      typeof legacy.botChat.channels.telegram
-    >;
-    delete telegram.readiness;
-    legacy.botChat.channels.telegram.connected = true;
-    legacy.botChat.channels.telegram.enabled = true;
-    legacy.botChat.channels.telegram.token = 'telegram-token';
-
-    const normalized = normalizeSettings(legacy);
-
-    expect(normalized.botChat.channels.telegram.connected).toBe(true);
-    expect(normalized.botChat.channels.telegram.readiness).toBe('credentials_valid');
-  });
-
-  test('does not treat non-boolean legacy connected values as credentials_valid', () => {
-    const legacy = createDefaultSettings() as unknown as {
+  const normalized = normalizeSettings(
+    mergeSettings(current, {
       botChat: {
         channels: {
-          telegram: { connected: unknown; readiness?: unknown; enabled: boolean; token: string };
-        };
-      };
-    };
-    delete legacy.botChat.channels.telegram.readiness;
-    legacy.botChat.channels.telegram.connected = 'true';
-    legacy.botChat.channels.telegram.enabled = true;
-    legacy.botChat.channels.telegram.token = 'telegram-token';
-
-    const normalized = normalizeSettings(legacy);
-
-    expect(normalized.botChat.channels.telegram.connected).toBe(false);
-    expect(normalized.botChat.channels.telegram.readiness).toBe('configured');
-  });
-
-  test('normalizes enabled configured channels to configured, not operational', () => {
-    const legacy = createDefaultSettings();
-    const discord = legacy.botChat.channels.discord as Partial<
-      typeof legacy.botChat.channels.discord
-    >;
-    delete discord.readiness;
-    legacy.botChat.channels.discord.enabled = true;
-    legacy.botChat.channels.discord.token = 'discord-token';
-
-    const normalized = normalizeSettings(legacy);
-
-    expect(normalized.botChat.channels.discord.readiness).toBe('configured');
-  });
-
-  /*
-   * PR-HEALTH-1 (xuan msg `e4887ffd`, I1) — write-path single-authority
-   * gate: persisted `readiness` must be coerced to be consistent with
-   * current credential state. Locks F1 / F3 from the audit catalog
-   * (the original health audit).
-   *
-   * Without this gate, a `mergeSettings({channels:{telegram:{token:''}}})`
-   * over `{readiness:'credentials_valid', token:'X'}` would persist
-   * stale `'credentials_valid'` even though credentials no longer
-   * exist. Capability snapshot → Health Center then surfaces a
-   * "configured / verified" UI for a channel with zero credentials.
-   */
-  describe('I1 — write-path coerces stale credential-claiming readiness (F1 / F3)', () => {
-    test('F1: persisted credentials_valid + token cleared → downgrades to scaffolded', () => {
-      const legacy = createDefaultSettings();
-      legacy.botChat.channels.telegram.enabled = true;
-      legacy.botChat.channels.telegram.token = '';
-      legacy.botChat.channels.telegram.appId = undefined;
-      legacy.botChat.channels.telegram.appSecret = undefined;
-      // Simulate stale persisted state from a previous credential-valid run.
-      legacy.botChat.channels.telegram.readiness = 'credentials_valid';
-
-      const normalized = normalizeSettings(legacy);
-
-      expect(normalized.botChat.channels.telegram.readiness).toBe('scaffolded');
-    });
-
-    test('F1b: persisted operational + token cleared → downgrades to scaffolded', () => {
-      const legacy = createDefaultSettings();
-      legacy.botChat.channels.feishu.enabled = true;
-      legacy.botChat.channels.feishu.token = '';
-      legacy.botChat.channels.feishu.appId = undefined;
-      legacy.botChat.channels.feishu.appSecret = undefined;
-      legacy.botChat.channels.feishu.readiness = 'operational';
-
-      const normalized = normalizeSettings(legacy);
-
-      expect(normalized.botChat.channels.feishu.readiness).toBe('scaffolded');
-    });
-
-    test('F1c: persisted degraded + token cleared → downgrades to scaffolded', () => {
-      const legacy = createDefaultSettings();
-      legacy.botChat.channels.discord.enabled = true;
-      legacy.botChat.channels.discord.token = '';
-      legacy.botChat.channels.discord.appId = undefined;
-      legacy.botChat.channels.discord.appSecret = undefined;
-      legacy.botChat.channels.discord.readiness = 'degraded';
-
-      const normalized = normalizeSettings(legacy);
-
-      expect(normalized.botChat.channels.discord.readiness).toBe('scaffolded');
-    });
-
-    test('F1d: persisted configured + token cleared → downgrades to scaffolded', () => {
-      const legacy = createDefaultSettings();
-      legacy.botChat.channels.wecom.enabled = true;
-      legacy.botChat.channels.wecom.token = '';
-      legacy.botChat.channels.wecom.appId = undefined;
-      legacy.botChat.channels.wecom.appSecret = undefined;
-      legacy.botChat.channels.wecom.readiness = 'configured';
-
-      const normalized = normalizeSettings(legacy);
-
-      expect(normalized.botChat.channels.wecom.readiness).toBe('scaffolded');
-    });
-
-    test('F1e: appId-only credentials keep credential-claiming readiness', () => {
-      // The credential trio is `token` OR `appId` OR `appSecret`. Any one
-      // present is enough to keep a credential-claiming readiness.
-      const legacy = createDefaultSettings();
-      legacy.botChat.channels.feishu.enabled = true;
-      legacy.botChat.channels.feishu.token = '';
-      legacy.botChat.channels.feishu.appId = 'fei-app-id';
-      legacy.botChat.channels.feishu.appSecret = undefined;
-      legacy.botChat.channels.feishu.readiness = 'credentials_valid';
-
-      const normalized = normalizeSettings(legacy);
-
-      expect(normalized.botChat.channels.feishu.readiness).toBe('credentials_valid');
-    });
-
-    test('F1f: appSecret-only credentials keep credential-claiming readiness', () => {
-      const legacy = createDefaultSettings();
-      legacy.botChat.channels.feishu.enabled = true;
-      legacy.botChat.channels.feishu.token = '';
-      legacy.botChat.channels.feishu.appId = undefined;
-      legacy.botChat.channels.feishu.appSecret = 'fei-app-secret';
-      legacy.botChat.channels.feishu.readiness = 'credentials_valid';
-
-      const normalized = normalizeSettings(legacy);
-
-      expect(normalized.botChat.channels.feishu.readiness).toBe('credentials_valid');
-    });
-
-    test('F3: mergeSettings clearing token over operational state then normalize → scaffolded', () => {
-      // End-to-end flow: existing settings have a credential-valid channel;
-      // user issues a settings update that clears the token. The merge +
-      // normalize pipeline must produce a state without the stale
-      // credential claim.
-      const current = createDefaultSettings();
-      current.botChat.channels.telegram.enabled = true;
-      current.botChat.channels.telegram.token = 'live-token';
-      current.botChat.channels.telegram.readiness = 'operational';
-
-      const merged = mergeSettings(current, {
-        botChat: {
-          channels: {
-            telegram: { token: '' },
-          },
+          telegram: { token: '', allowedUserIds: [' 123 ', '456', '123', ''] },
         },
-      });
-      const normalized = normalizeSettings(merged);
-
-      expect(normalized.botChat.channels.telegram.token).toBe('');
-      expect(normalized.botChat.channels.telegram.readiness).toBe('scaffolded');
-    });
-
-    test('F3b: coerce never UPGRADES scaffolded → configured (write-path stays down-only)', () => {
-      // Even when credentials are present, the coerce path does NOT
-      // promote a persisted 'scaffolded' to 'configured' — that is the
-      // live bridge / explicit-readiness write path's responsibility.
-      const legacy = createDefaultSettings();
-      legacy.botChat.channels.discord.enabled = true;
-      legacy.botChat.channels.discord.token = 'discord-token';
-      // Explicit persisted scaffolded should survive coerce (no upgrade).
-      legacy.botChat.channels.discord.readiness = 'scaffolded';
-
-      const normalized = normalizeSettings(legacy);
-
-      expect(normalized.botChat.channels.discord.readiness).toBe('scaffolded');
-    });
-
-    test('non-credential-claiming readiness (unscaffolded / scaffolded) passes through unchanged', () => {
-      const legacy = createDefaultSettings();
-      legacy.botChat.channels.qq.enabled = false;
-      legacy.botChat.channels.qq.token = '';
-      legacy.botChat.channels.qq.readiness = 'unscaffolded';
-
-      const normalized = normalizeSettings(legacy);
-
-      expect(normalized.botChat.channels.qq.readiness).toBe('unscaffolded');
-    });
-  });
+      },
+    }),
+  );
+  expect(normalized.botChat.channels.telegram.token).toBe('');
+  expect(normalized.botChat.channels.telegram.readiness).toBe('scaffolded');
+  expect(normalized.botChat.channels.telegram.allowedUserIds).toEqual(['123', '456']);
 });
 
-describe('theme palette settings contract (PR-UI-D1, @kenji msg 68bf2b13)', () => {
-  test('THEME_PALETTES allowlist exposes 11 palettes including default + product accents', () => {
-    // Pin the palette set: 5 editor-style + 6 product accent palettes
-    // (coral, azure, forest, dusk, sand, mono). Update this pin when
-    // the palette set legitimately changes.
-    expect(THEME_PALETTES.length).toBe(11);
-    expect(THEME_PALETTES.includes('default')).toBe(true);
-    expect(THEME_PALETTES.includes('onedark')).toBe(true);
-    expect(THEME_PALETTES.includes('catppuccin-mocha')).toBe(true);
-    expect(THEME_PALETTES.includes('tokyo-night')).toBe(true);
-    expect(THEME_PALETTES.includes('nord')).toBe(true);
-    expect(THEME_PALETTES.includes('coral')).toBe(true);
-    expect(THEME_PALETTES.includes('azure')).toBe(true);
-    expect(THEME_PALETTES.includes('forest')).toBe(true);
-    expect(THEME_PALETTES.includes('dusk')).toBe(true);
-    expect(THEME_PALETTES.includes('sand')).toBe(true);
-    expect(THEME_PALETTES.includes('mono')).toBe(true);
-  });
-
-  test('isThemePalette accepts allowlist values, rejects everything else', () => {
+describe('appearance settings boundaries', () => {
+  test('validates, normalizes, and merges the palette as one closed vocabulary', () => {
     for (const palette of THEME_PALETTES) {
       expect(isThemePalette(palette)).toBe(true);
+      expect(normalizeSettings({ appearance: { theme: 'auto', palette } }).appearance.palette).toBe(
+        palette,
+      );
     }
-    expect(isThemePalette('evil-unknown')).toBe(false);
-    expect(isThemePalette('')).toBe(false);
-    expect(isThemePalette(undefined)).toBe(false);
-    expect(isThemePalette(null)).toBe(false);
-    expect(isThemePalette(42)).toBe(false);
-    expect(isThemePalette({ palette: 'onedark' })).toBe(false);
-    expect(isThemePalette([])).toBe(false);
-    // Case-sensitive: TypeScript union is exact-case, runtime guard must agree.
-    expect(isThemePalette('Default')).toBe(false);
-    expect(isThemePalette('ONEDARK')).toBe(false);
-  });
-
-  test('createDefaultSettings seeds palette as `default`', () => {
-    const defaults = createDefaultSettings();
-    expect(defaults.appearance.palette).toBe('default');
-  });
-
-  test('migration: settings.json without `palette` field loads with palette=default', () => {
-    // Older settings.json that pre-dates PR-UI-D1 will not have
-    // `appearance.palette`. normalizeSettings must seed `default`
-    // without touching theme.
-    const legacy = {
-      appearance: {
-        theme: 'dark' as const,
-        // no palette field
-      },
-    };
-    const normalized = normalizeSettings(legacy);
-    expect(normalized.appearance.palette).toBe('default');
-    expect(normalized.appearance.theme).toBe('dark');
-    expect('density' in normalized.appearance).toBe(false);
-  });
-
-  test('fail-closed: unknown palette string falls back to default', () => {
-    const malformed = {
-      appearance: {
-        theme: 'auto' as const,
-        palette: 'evil-unknown',
-      },
-    };
-    const normalized = normalizeSettings(malformed);
-    expect(normalized.appearance.palette).toBe('default');
-  });
-
-  test('fail-closed: non-string palette falls back to default', () => {
-    for (const bad of [42, true, null, {}, []]) {
-      const malformed = {
-        appearance: {
-          theme: 'auto' as const,
-          palette: bad,
-        },
-      };
-      const normalized = normalizeSettings(malformed);
-      expect(normalized.appearance.palette).toBe('default');
+    for (const invalid of ['evil-unknown', '', 'Default', undefined, null, 42, {}, []]) {
+      expect(isThemePalette(invalid)).toBe(false);
     }
+
+    expect(normalizeSettings({}).appearance.palette).toBe('default');
+    expect(
+      normalizeSettings({ appearance: { theme: 'dark', palette: 'evil-unknown' } }).appearance,
+    ).toMatchObject({ theme: 'dark', palette: 'default' });
+    expect(
+      mergeSettings(createDefaultSettings(), { appearance: { palette: 'onedark' } }).appearance,
+    ).toMatchObject({ theme: 'auto', palette: 'onedark' });
   });
 
-  test('valid palette survives normalize untouched', () => {
-    for (const palette of THEME_PALETTES) {
-      const input = {
-        appearance: {
-          theme: 'auto' as const,
-          palette,
-        },
-      };
-      const normalized = normalizeSettings(input);
-      expect(normalized.appearance.palette).toBe(palette);
-    }
-  });
-
-  test('palette validation does NOT silently reset unrelated settings fields', () => {
-    // @kenji gate: "no silent reset of unrelated settings". Even with
-    // a malformed palette, all other current fields (theme,
-    // personalization, network, bot channels) must keep their values.
-    const input = {
-      appearance: {
-        theme: 'dark' as const,
-        palette: 'evil-unknown',
-      },
-      personalization: {
-        displayName: 'Yuejing',
-        assistantTone: 'concise',
-      },
-      network: {
-        proxy: {
-          enabled: true,
-          protocol: 'http' as const,
-          host: '127.0.0.1',
-          port: 7890,
-          authEnabled: false,
-          username: '',
-          password: '',
-          bypassList: ['localhost'],
-          autoBypassDomains: [],
-        },
-      },
-    };
-    const normalized = normalizeSettings(input);
-    expect(normalized.appearance.palette).toBe('default');
-    expect(normalized.appearance.theme).toBe('dark');
-    expect('density' in normalized.appearance).toBe(false);
-    expect(normalized.personalization.displayName).toBe('Yuejing');
-    expect(normalized.personalization.assistantTone).toBe('concise');
-    expect(normalized.network.proxy.enabled).toBe(true);
-    expect(normalized.network.proxy.host).toBe('127.0.0.1');
-    expect(normalized.network.proxy.port).toBe(7890);
-  });
-
-  test('mergeSettings carries palette through patch surface', () => {
-    const current = createDefaultSettings();
-    const patched = mergeSettings(current, { appearance: { palette: 'onedark' } });
-    expect(patched.appearance.palette).toBe('onedark');
-    expect(patched.appearance.theme).toBe('auto'); // unchanged
-  });
-
-  test('mergeSettings + normalizeSettings: patching with unknown palette ends up at default', () => {
-    // Real-world: a UI might submit a misconfigured palette via the
-    // patch surface. The normalize pass after mergeSettings catches it.
-    const current = createDefaultSettings();
-    const patched = mergeSettings(current, {
-      appearance: { palette: 'evil-unknown' as 'default' /* coerced for test */ },
-    });
-    const normalized = normalizeSettings(patched);
-    expect(normalized.appearance.palette).toBe('default');
-  });
-});
-
-describe('run-completion notification settings contract', () => {
-  test('createDefaultSettings enables run-complete notifications by default', () => {
-    const defaults = createDefaultSettings();
-    expect(defaults.notifications.runComplete).toBe(true);
-  });
-
-  test('migration: settings.json without a notifications section defaults to enabled', () => {
-    const legacy = { appearance: { theme: 'dark' as const } };
-    const normalized = normalizeSettings(legacy);
-    expect(normalized.notifications.runComplete).toBe(true);
-  });
-
-  test('mergeSettings carries the toggle through the patch surface', () => {
-    const current = createDefaultSettings();
-    const patched = mergeSettings(current, { notifications: { runComplete: false } });
-    expect(patched.notifications.runComplete).toBe(false);
-  });
-
-  test('fail-closed: a non-boolean runComplete normalizes back to enabled', () => {
-    for (const bad of [1, 0, 'yes', null, {}, []]) {
-      const malformed = { notifications: { runComplete: bad } };
-      const normalized = normalizeSettings(malformed);
-      expect(normalized.notifications.runComplete).toBe(true);
-    }
-  });
-
-  test('a valid disabled toggle survives normalize untouched', () => {
-    const normalized = normalizeSettings({ notifications: { runComplete: false } });
-    expect(normalized.notifications.runComplete).toBe(false);
-  });
-});
-
-describe('keep-system-awake settings contract', () => {
-  test('createDefaultSettings leaves keep-system-awake off by default', () => {
-    const defaults = createDefaultSettings();
-    expect(defaults.system.keepSystemAwake).toBe(false);
-  });
-
-  test('migration: settings.json without a system section defaults to off', () => {
-    const legacy = { appearance: { theme: 'dark' as const } };
-    const normalized = normalizeSettings(legacy);
-    expect(normalized.system.keepSystemAwake).toBe(false);
-  });
-
-  test('mergeSettings carries the toggle through the patch surface', () => {
-    const current = createDefaultSettings();
-    const patched = mergeSettings(current, { system: { keepSystemAwake: true } });
-    expect(patched.system.keepSystemAwake).toBe(true);
-  });
-
-  test('fail-closed: a non-boolean keepSystemAwake normalizes back to off', () => {
-    for (const bad of [1, 0, 'yes', null, {}, []]) {
-      const malformed = { system: { keepSystemAwake: bad } };
-      const normalized = normalizeSettings(malformed);
-      expect(normalized.system.keepSystemAwake).toBe(false);
-    }
-  });
-
-  test('a valid enabled toggle survives normalize untouched', () => {
-    const normalized = normalizeSettings({ system: { keepSystemAwake: true } });
-    expect(normalized.system.keepSystemAwake).toBe(true);
-  });
-});
-
-describe('fixed toast position settings contract', () => {
-  test('createDefaultSettings does not persist a toastPosition setting', () => {
-    const defaults = createDefaultSettings();
-    expect('toastPosition' in defaults.appearance).toBe(false);
-  });
-
-  test('migration: legacy settings.json with toastPosition drops that field', () => {
-    const legacy = {
-      appearance: {
-        theme: 'dark' as const,
-        palette: 'onedark' as const,
-        toastPosition: 'top-left',
-      },
-    };
-    const normalized = normalizeSettings(legacy);
-    expect('toastPosition' in normalized.appearance).toBe(false);
-    expect(normalized.appearance.theme).toBe('dark');
-    expect(normalized.appearance.palette).toBe('onedark');
-  });
-
-  test('dropping legacy toastPosition does NOT silently reset unrelated settings fields', () => {
-    const input = {
-      appearance: {
-        theme: 'dark' as const,
-        palette: 'tokyo-night' as const,
-        toastPosition: 'evil-corner',
-      },
-      personalization: {
-        displayName: 'Yuejing',
-        assistantTone: 'concise',
-      },
-    };
-    const normalized = normalizeSettings(input);
-    expect('toastPosition' in normalized.appearance).toBe(false);
-    expect(normalized.appearance.theme).toBe('dark');
-    expect(normalized.appearance.palette).toBe('tokyo-night');
-    expect(normalized.personalization.displayName).toBe('Yuejing');
-    expect(normalized.personalization.assistantTone).toBe('concise');
-  });
-
-  test('mergeSettings + normalizeSettings strips toastPosition patch input', () => {
-    const current = createDefaultSettings();
-    const patched = mergeSettings(current, {
-      appearance: { toastPosition: 'top-center' } as never,
-    });
-    const normalized = normalizeSettings(patched);
-    expect('toastPosition' in patched.appearance).toBe(true);
-    expect('toastPosition' in normalized.appearance).toBe(false);
-    expect(normalized.appearance.theme).toBe('auto');
-    expect(normalized.appearance.palette).toBe('default');
-  });
-
-  test('malformed palette still falls back while legacy toastPosition is stripped', () => {
-    const input = {
-      appearance: {
-        theme: 'auto' as const,
-        palette: 'evil-unknown',
-        toastPosition: 'evil-corner',
-      },
-    };
-    const normalized = normalizeSettings(input);
-    expect(normalized.appearance.palette).toBe('default');
-    expect('toastPosition' in normalized.appearance).toBe(false);
-  });
-});
-
-describe('removed UI density settings contract', () => {
-  test('createDefaultSettings does not persist a density setting', () => {
-    const defaults = createDefaultSettings();
-    expect('density' in defaults.appearance).toBe(false);
-  });
-
-  test('migration: legacy settings.json with density drops that field', () => {
+  test('drops retired appearance fields without resetting current settings', () => {
     const normalized = normalizeSettings({
       appearance: {
-        theme: 'dark' as const,
+        theme: 'dark',
+        palette: 'tokyo-night',
+        toastPosition: 'top-left',
         density: 'compact',
-        palette: 'onedark' as const,
       },
+      personalization: { displayName: 'Yuejing', assistantTone: 'concise' },
     });
 
+    expect('toastPosition' in normalized.appearance).toBe(false);
     expect('density' in normalized.appearance).toBe(false);
-    expect(normalized.appearance.theme).toBe('dark');
-    expect(normalized.appearance.palette).toBe('onedark');
-  });
-
-  test('mergeSettings + normalizeSettings strips density patch input', () => {
-    const current = createDefaultSettings();
-    const patched = mergeSettings(current, { appearance: { density: 'spacious' } as never });
-    const normalized = normalizeSettings(patched);
-
-    expect('density' in patched.appearance).toBe(true);
-    expect('density' in normalized.appearance).toBe(false);
-    expect(normalized.appearance.theme).toBe('auto');
-    expect(normalized.appearance.palette).toBe('default');
+    expect(normalized.appearance).toMatchObject({ theme: 'dark', palette: 'tokyo-night' });
+    expect(normalized.personalization).toMatchObject({
+      displayName: 'Yuejing',
+      assistantTone: 'concise',
+    });
   });
 });
 
-describe('settings normalization boundaries', () => {
-  test('delegates web search patches and persisted normalization to the web-search owner', () => {
-    const patched = mergeSettings(createDefaultSettings(), {
+test('boolean settings default, normalize, and merge through their shared boundary', () => {
+  const defaults = createDefaultSettings();
+  expect(defaults.notifications.runComplete).toBe(true);
+  expect(defaults.system.keepSystemAwake).toBe(false);
+  expect(defaults.workspaceInstructions.enabled).toBe(true);
+  expect(defaults.privacy.incognitoActive).toBe(false);
+
+  const normalized = normalizeSettings({
+    notifications: { runComplete: false },
+    system: { keepSystemAwake: true },
+    workspaceInstructions: { enabled: false },
+    privacy: { incognitoActive: true },
+  });
+  expect(normalized.notifications.runComplete).toBe(false);
+  expect(normalized.system.keepSystemAwake).toBe(true);
+  expect(normalized.workspaceInstructions.enabled).toBe(false);
+  expect(normalized.privacy.incognitoActive).toBe(true);
+
+  const malformed = normalizeSettings({
+    notifications: { runComplete: 'yes' },
+    system: { keepSystemAwake: 1 },
+    workspaceInstructions: { enabled: 'yes' },
+    privacy: { incognitoActive: 'yes' },
+  });
+  expect(malformed.notifications.runComplete).toBe(true);
+  expect(malformed.system.keepSystemAwake).toBe(false);
+  expect(malformed.workspaceInstructions.enabled).toBe(true);
+  expect(malformed.privacy.incognitoActive).toBe(false);
+
+  const merged = mergeSettings(defaults, {
+    notifications: { runComplete: false },
+    system: { keepSystemAwake: true },
+    workspaceInstructions: { enabled: false },
+    privacy: { incognitoActive: true },
+  });
+  expect(merged.notifications.runComplete).toBe(false);
+  expect(merged.system.keepSystemAwake).toBe(true);
+  expect(merged.workspaceInstructions.enabled).toBe(false);
+  expect(merged.privacy.incognitoActive).toBe(true);
+});
+
+test('web-search settings stay owned by their normalization boundary', () => {
+  const normalized = normalizeSettings(
+    mergeSettings(createDefaultSettings(), {
       webSearch: {
         enabled: true,
         providers: { tavily: { apiKey: 'stored-key' } },
       },
-    });
-    const normalized = normalizeSettings(patched);
+    }),
+  );
 
-    expect(normalized.webSearch.enabled).toBe(true);
-    expect(normalized.webSearch.providers.tavily.apiKey).toBe('stored-key');
-    expect(normalized.webSearch.providers.tavily.credentialSource).toBe('saved');
-    expect(normalized.webSearch.providers.tavily.credentialVersion).toBe(1);
-  });
-
-  test('workspace instructions are visible settings and default to enabled', () => {
-    const defaults = createDefaultSettings();
-
-    expect(defaults.workspaceInstructions.enabled).toBe(true);
-    expect(
-      normalizeSettings({ workspaceInstructions: { enabled: false } }).workspaceInstructions
-        .enabled,
-    ).toBe(false);
-    expect(
-      normalizeSettings({ workspaceInstructions: { enabled: 'yes' } }).workspaceInstructions
-        .enabled,
-    ).toBe(true);
-  });
-
-  test('mergeSettings carries workspace instruction toggle through update surface', () => {
-    const patched = mergeSettings(createDefaultSettings(), {
-      workspaceInstructions: {
-        enabled: false,
-      },
-    });
-
-    expect(patched.workspaceInstructions.enabled).toBe(false);
-  });
-
-  test('workspace privacy defaults to non-incognito and normalizes strictly', () => {
-    const defaults = createDefaultSettings();
-
-    expect(defaults.privacy.incognitoActive).toBe(false);
-    expect(normalizeSettings({ privacy: { incognitoActive: true } }).privacy.incognitoActive).toBe(
-      true,
-    );
-    expect(normalizeSettings({ privacy: { incognitoActive: 'yes' } }).privacy.incognitoActive).toBe(
-      false,
-    );
-    expect(normalizeSettings({}).privacy.incognitoActive).toBe(false);
-  });
-
-  test('mergeSettings carries privacy toggle through update surface', () => {
-    const patched = mergeSettings(createDefaultSettings(), {
-      privacy: {
-        incognitoActive: true,
-      },
-    });
-
-    expect(patched.privacy.incognitoActive).toBe(true);
-  });
-
-  // PR-BOT-USER-ALLOWLIST-0 — settings shape normalization. The runtime gate
-  // (isAllowedUser in @maka/runtime/bots/simple-bridge) is covered separately.
-  // These tests exercise `normalizeSettings`, which is the boundary that
-  // sees on-disk / cross-IPC payloads. `mergeSettings` itself trusts the
-  // in-memory shape because the entry from disk went through normalize.
-  test('default channel has no allowlist (V0.1 unrestricted)', () => {
-    const channel = createDefaultBotChannel('telegram');
-    expect(channel.allowedUserIds).toBeUndefined();
-  });
-
-  test('normalizes a valid allowlist and trims/dedups entries', () => {
-    const legacy = createDefaultSettings() as unknown as {
-      botChat: { channels: { telegram: { allowedUserIds?: unknown } } };
-    };
-    legacy.botChat.channels.telegram.allowedUserIds = ['  123  ', '456', '123', '', '  '];
-
-    const normalized = normalizeSettings(legacy);
-
-    expect(normalized.botChat.channels.telegram.allowedUserIds).toEqual(['123', '456']);
-  });
-
-  test('drops non-string entries from a persisted allowlist', () => {
-    const legacy = createDefaultSettings() as unknown as {
-      botChat: { channels: { telegram: { allowedUserIds?: unknown } } };
-    };
-    legacy.botChat.channels.telegram.allowedUserIds = ['123', 456, null, '789'];
-
-    const normalized = normalizeSettings(legacy);
-
-    expect(normalized.botChat.channels.telegram.allowedUserIds).toEqual(['123', '789']);
-  });
-
-  test('caps the persisted allowlist at 50 entries', () => {
-    const overflow = Array.from({ length: 80 }, (_, i) => `user-${i}`);
-    const legacy = createDefaultSettings() as unknown as {
-      botChat: { channels: { telegram: { allowedUserIds?: unknown } } };
-    };
-    legacy.botChat.channels.telegram.allowedUserIds = overflow;
-
-    const normalized = normalizeSettings(legacy);
-
-    const list = normalized.botChat.channels.telegram.allowedUserIds!;
-    expect(list.length).toBe(50);
-    expect(list[0]).toBe('user-0');
-    expect(list[49]).toBe('user-49');
-  });
-
-  test('an empty / all-blank allowlist normalizes to undefined (no restriction)', () => {
-    const legacy = createDefaultSettings() as unknown as {
-      botChat: { channels: { telegram: { allowedUserIds?: unknown } } };
-    };
-    legacy.botChat.channels.telegram.allowedUserIds = ['', '  ', '\t'];
-
-    const normalized = normalizeSettings(legacy);
-
-    expect(normalized.botChat.channels.telegram.allowedUserIds).toBeUndefined();
-  });
-
-  test('non-array persisted allowlist normalizes to undefined fail-closed', () => {
-    const legacy = createDefaultSettings() as unknown as {
-      botChat: { channels: { telegram: { allowedUserIds?: unknown } } };
-    };
-    legacy.botChat.channels.telegram.allowedUserIds = 'not-an-array';
-
-    const normalized = normalizeSettings(legacy);
-
-    expect(normalized.botChat.channels.telegram.allowedUserIds).toBeUndefined();
-  });
-
-  // PR-BOT-USER-ALLOWLIST-UI-0 — mergeSettings normalize gate. The
-  // renderer textarea-bound field hands us a dirty array on every save;
-  // the IPC merge layer must trim/dedup/cap so the persisted shape
-  // matches what `normalizeSettings` would have produced on cold load.
-  test('mergeSettings trims and dedups when the patch explicitly sets allowedUserIds', () => {
-    const updated = mergeSettings(createDefaultSettings(), {
-      botChat: {
-        channels: {
-          telegram: { allowedUserIds: ['  123  ', '456', '123', ''] as unknown as string[] },
-        },
-      },
-    });
-
-    expect(updated.botChat.channels.telegram.allowedUserIds).toEqual(['123', '456']);
-  });
-
-  test('mergeSettings downgrades an all-blank patch to undefined (no restriction)', () => {
-    const seeded = mergeSettings(createDefaultSettings(), {
-      botChat: { channels: { telegram: { allowedUserIds: ['123'] } } },
-    });
-    expect(seeded.botChat.channels.telegram.allowedUserIds).toEqual(['123']);
-
-    const cleared = mergeSettings(seeded, {
-      botChat: { channels: { telegram: { allowedUserIds: ['', '  '] as string[] } } },
-    });
-
-    expect(cleared.botChat.channels.telegram.allowedUserIds).toBeUndefined();
-  });
-
-  test('mergeSettings leaves the allowlist untouched when an unrelated field is patched', () => {
-    const seeded = mergeSettings(createDefaultSettings(), {
-      botChat: { channels: { telegram: { allowedUserIds: ['123', '456'] } } },
-    });
-
-    const tokenPatched = mergeSettings(seeded, {
-      botChat: { channels: { telegram: { token: 'tg-token', enabled: true } } },
-    });
-
-    expect(tokenPatched.botChat.channels.telegram.allowedUserIds).toEqual(['123', '456']);
+  expect(normalized.webSearch.enabled).toBe(true);
+  expect(normalized.webSearch.providers.tavily).toMatchObject({
+    apiKey: 'stored-key',
+    credentialSource: 'saved',
+    credentialVersion: 1,
   });
 });


### PR DESCRIPTION
## Summary
- replace provider-by-provider CLI target happy paths with credential-policy, OAuth, fail-closed, and model-curation boundaries
- remove Desktop source-regex assertions and consolidate status/error/recovery copy into behavioral matrices
- collapse field-by-field settings tests around owner delegation, normalization, merge, and malformed-input boundaries

## Impact
- source declarations: 142 -> 17
- actual tests: 145 -> 17
- 3 files changed, 328 additions, 2,164 deletions (net -1,836 lines)

## Preserved boundaries
- required, optional, and absent provider credentials
- OAuth account endpoint, refresh persistence, and malformed credential rejection
- curated model selection and unavailable credential isolation
- localized status/error output and side-effect-aware recovery decisions
- settings owner delegation, strict normalization, retired-field stripping, and unrelated-field preservation

## Validation
- npm run build:test
- npm --workspace @maka/core run test:dist (978 passed)
- npm --workspace maka-agent run test:dist (650 passed)
- npm --workspace @maka/desktop run test:dist (1,775 passed)
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check