### PR TITLE
test: consolidate onboarding and preview coverage

### DIFF
--- a/apps/desktop/src/main/__tests__/artifact-preview-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-preview-registry.test.ts
@@ -1,16 +1,3 @@
-/**
- * Tests for the PR-UI-RENDER-3a artifact preview registry.
- *
- * Locks the pure-classifier contract @kenji signed off on
- * (#my-ai:2f91befb msg 2aa3cfc3 + msg adc10d66 + msg 9cf1ca7a). Each
- * test pins one row of the resolution truth table so a future PR
- * adding (say) SVG or HEIC can't silently re-classify existing
- * inputs.
- *
- * Imported via `@maka/ui/artifact-preview-registry` subpath so
- * node:test doesn't load the React barrel.
- */
-
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import type { ArtifactBinaryReadResult } from '@maka/core';
@@ -26,467 +13,152 @@ import {
   resolvePreviewKind,
 } from '@maka/ui/artifact-preview-registry';
 
-describe('resolvePreviewKind — kind gate', () => {
-  it('file kind → unsupported(kind_disallowed)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'log.txt', kind: 'file' }),
-      { kind: 'unsupported', reason: 'kind_disallowed' },
-    );
-  });
-  it('diff kind → unsupported(kind_disallowed)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'patch.diff', kind: 'diff' }),
-      { kind: 'unsupported', reason: 'kind_disallowed' },
-    );
-  });
-  it('html kind → unsupported(kind_disallowed)', () => {
-    // PR-RENDER-3a explicitly excludes html. Future PR-RENDER-3c
-    // will add it; until then the registry rejects it cleanly.
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'page.html', kind: 'html', mimeType: 'text/html' }),
-      { kind: 'unsupported', reason: 'kind_disallowed' },
-    );
-  });
-  it('pdf kind → unsupported(kind_disallowed)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'doc.pdf', kind: 'pdf', mimeType: 'application/pdf' }),
-      { kind: 'unsupported', reason: 'kind_disallowed' },
-    );
-  });
-});
+describe('artifact preview registry', () => {
+  it('resolves kinds, MIME metadata, and extension fallback from one decision table', () => {
+    const cases: Array<{
+      input: Parameters<typeof resolvePreviewKind>[0];
+      expected: ReturnType<typeof resolvePreviewKind>;
+    }> = [
+      ...(['file', 'diff', 'html', 'pdf'] as const).map((kind) => ({
+        input: { name: `artifact.${kind}`, kind },
+        expected: { kind: 'unsupported' as const, reason: 'kind_disallowed' as const },
+      })),
+      ...[...ALLOWED_IMAGE_MIMES].map((mimeType) => ({
+        input: { name: 'untitled', kind: 'image' as const, mimeType },
+        expected: { kind: 'image' as const, reason: 'mime_match' as const },
+      })),
+      { input: { name: 'shot.png', kind: 'image', mimeType: ' IMAGE/PNG ' }, expected: { kind: 'image', reason: 'mime_match' } },
+      ...['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif'].map((extension) => ({
+        input: { name: `image.${extension}`, kind: 'image' as const },
+        expected: { kind: 'image' as const, reason: 'ext_fallback' as const },
+      })),
+      { input: { name: 'image.JpEg', kind: 'image' }, expected: { kind: 'image', reason: 'ext_fallback' } },
+      ...['untitled', 'photo.heic', '', 'shot.', '.hidden'].map((name) => ({
+        input: { name, kind: 'image' as const },
+        expected: { kind: 'unsupported' as const, reason: 'no_mime_no_ext' as const },
+      })),
+    ];
 
-describe('resolvePreviewKind — image MIME match', () => {
-  const mimes = [
-    'image/png',
-    'image/jpeg',
-    'image/gif',
-    'image/webp',
-    'image/avif',
-  ] as const;
-  for (const mime of mimes) {
-    it(`accepts ${mime}`, () => {
+    for (const { input, expected } of cases) {
+      assert.deepEqual(resolvePreviewKind(input), expected, JSON.stringify(input));
+    }
+  });
+
+  it('treats present MIME metadata as authoritative and rejects unsafe formats', () => {
+    for (const mimeType of ['image/svg+xml', 'image/heic', 'image/bmp']) {
       assert.deepEqual(
-        resolvePreviewKind({ name: 'untitled', kind: 'image', mimeType: mime }),
-        { kind: 'image', reason: 'mime_match' },
+        resolvePreviewKind({ name: 'tricky.png', kind: 'image', mimeType }),
+        { kind: 'unsupported', reason: 'mime_disallowed' },
       );
+    }
+  });
+
+  it('enforces the inclusive metadata size boundary before loading', () => {
+    const base = { name: 'image.png', kind: 'image' as const, mimeType: 'image/png' };
+    assert.deepEqual(resolvePreviewKind({ ...base, sizeBytes: IMAGE_PAYLOAD_MAX_BYTES }), {
+      kind: 'image',
+      reason: 'mime_match',
     });
-  }
-  it('is case-insensitive on MIME', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'shot.png', kind: 'image', mimeType: 'IMAGE/PNG' }),
-      { kind: 'image', reason: 'mime_match' },
-    );
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'shot.png', kind: 'image', mimeType: 'Image/Png' }),
-      { kind: 'image', reason: 'mime_match' },
-    );
-  });
-  it('trims whitespace on MIME', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'shot.png', kind: 'image', mimeType: '  image/png  ' }),
-      { kind: 'image', reason: 'mime_match' },
-    );
-  });
-});
-
-describe('resolvePreviewKind — image ext fallback', () => {
-  const exts = [
-    ['.png', 'shot.png'],
-    ['.jpg', 'photo.jpg'],
-    ['.jpeg', 'photo.jpeg'],
-    ['.gif', 'sticker.gif'],
-    ['.webp', 'modern.webp'],
-    ['.avif', 'newest.avif'],
-  ];
-  for (const [ext, name] of exts) {
-    it(`accepts ${ext} via filename when no MIME`, () => {
-      assert.deepEqual(
-        resolvePreviewKind({ name, kind: 'image' }),
-        { kind: 'image', reason: 'ext_fallback' },
-      );
+    assert.deepEqual(resolvePreviewKind({ ...base, sizeBytes: IMAGE_PAYLOAD_MAX_BYTES + 1 }), {
+      kind: 'unsupported',
+      reason: 'oversize',
     });
-  }
-  it('is case-insensitive on ext', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'shot.PNG', kind: 'image' }),
-      { kind: 'image', reason: 'ext_fallback' },
-    );
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'shot.JpEg', kind: 'image' }),
-      { kind: 'image', reason: 'ext_fallback' },
-    );
   });
-  it('does NOT fall back to ext when MIME matched', () => {
-    // MIME is authoritative: even if ext is `.png`, mime `image/png`
-    // is what resolved it.
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'shot.png', kind: 'image', mimeType: 'image/png' }),
-      { kind: 'image', reason: 'mime_match' },
-    );
-  });
-});
 
-describe('resolvePreviewKind — disallowed image MIMEs', () => {
-  it('image/svg+xml → unsupported(mime_disallowed) [deferred to PR-RENDER-3b]', () => {
-    // The SVG defer is the load-bearing PR-RENDER-3a boundary.
-    // If this test starts failing it means someone allowed SVG
-    // without going through the sanitizer / sandbox PR. Stop them.
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'icon.svg', kind: 'image', mimeType: 'image/svg+xml' }),
-      { kind: 'unsupported', reason: 'mime_disallowed' },
-    );
+  it('fails closed at the post-load payload cap', () => {
+    assert.equal(exceedsImagePayloadCap('A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH)), false);
+    assert.equal(exceedsImagePayloadCap('A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH + 1)), true);
+    for (const value of [null, undefined, 42]) {
+      assert.equal(exceedsImagePayloadCap(value as never), true);
+    }
   });
-  it('image/heic → unsupported(mime_disallowed)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'photo.heic', kind: 'image', mimeType: 'image/heic' }),
-      { kind: 'unsupported', reason: 'mime_disallowed' },
-    );
-  });
-  it('image/bmp → unsupported(mime_disallowed)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'old.bmp', kind: 'image', mimeType: 'image/bmp' }),
-      { kind: 'unsupported', reason: 'mime_disallowed' },
-    );
-  });
-  it('disallowed MIME does NOT fall back to ext (MIME is authoritative when present)', () => {
-    // Filename says .png but MIME says svg+xml → trust MIME, reject.
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'tricky.png', kind: 'image', mimeType: 'image/svg+xml' }),
-      { kind: 'unsupported', reason: 'mime_disallowed' },
-    );
-  });
-});
 
-describe('resolvePreviewKind — no MIME, no usable ext', () => {
-  it('image kind with no MIME and no ext → unsupported(no_mime_no_ext)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'untitled', kind: 'image' }),
-      { kind: 'unsupported', reason: 'no_mime_no_ext' },
-    );
+  it('formats representative sizes and invalid metadata', () => {
+    const cases: Array<[number | undefined, string]> = [
+      [0, '0 B'],
+      [1023, '1023 B'],
+      [1024, '1.0 KB'],
+      [IMAGE_PAYLOAD_MAX_BYTES, '2.0 MB'],
+      [undefined, '未知大小'],
+      [-1, '未知大小'],
+      [NaN, '未知大小'],
+      [Infinity, '未知大小'],
+    ];
+    for (const [size, expected] of cases) assert.equal(formatPreviewSize(size), expected);
   });
-  it('image kind with non-image ext → unsupported(no_mime_no_ext)', () => {
-    // `.heic` is real but disallowed here. Without MIME, we treat
-    // it as "no usable ext" rather than mime_disallowed.
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'photo.heic', kind: 'image' }),
-      { kind: 'unsupported', reason: 'no_mime_no_ext' },
-    );
-  });
-  it('empty name → unsupported(no_mime_no_ext)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: '', kind: 'image' }),
-      { kind: 'unsupported', reason: 'no_mime_no_ext' },
-    );
-  });
-  it('name with trailing dot only → unsupported(no_mime_no_ext)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'shot.', kind: 'image' }),
-      { kind: 'unsupported', reason: 'no_mime_no_ext' },
-    );
-  });
-  it('name with leading dot only (no ext, dotfile) → unsupported(no_mime_no_ext)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: '.hidden', kind: 'image' }),
-      { kind: 'unsupported', reason: 'no_mime_no_ext' },
-    );
-  });
-});
 
-describe('resolvePreviewKind — oversize gate', () => {
-  it('sizeBytes > cap → unsupported(oversize) BEFORE attempting load', () => {
+  it('normalizes only allowlisted image MIME values', () => {
+    for (const mimeType of ALLOWED_IMAGE_MIMES) {
+      assert.equal(normalizeAllowedImageMime(` ${mimeType.toUpperCase()} `), mimeType);
+    }
+    for (const mimeType of ['image/svg+xml', 'image/heic', 'application/octet-stream', '', '   ']) {
+      assert.equal(normalizeAllowedImageMime(mimeType), null);
+    }
+    for (const value of [undefined, null, 42]) {
+      assert.equal(normalizeAllowedImageMime(value as never), null);
+    }
+  });
+
+  it('uses sniffed MIME and checks size before MIME after loading', () => {
+    const base64 = 'AAAA';
+    assert.deepEqual(decideImagePostLoad({ base64, mimeType: ' IMAGE/PNG ' }), {
+      kind: 'image',
+      safeMime: 'image/png',
+      base64,
+    });
+    for (const mimeType of ['image/svg+xml', 'application/octet-stream']) {
+      assert.deepEqual(decideImagePostLoad({ base64, mimeType }), {
+        kind: 'unsupported',
+        reason: 'mime_disallowed',
+      });
+    }
     assert.deepEqual(
-      resolvePreviewKind({
-        name: 'huge.png',
-        kind: 'image',
-        mimeType: 'image/png',
-        sizeBytes: IMAGE_PAYLOAD_MAX_BYTES + 1,
+      decideImagePostLoad({
+        base64: 'A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH + 1),
+        mimeType: 'image/svg+xml',
       }),
       { kind: 'unsupported', reason: 'oversize' },
     );
   });
-  it('sizeBytes exactly at cap → image (boundary inclusive)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({
-        name: 'edge.png',
-        kind: 'image',
-        mimeType: 'image/png',
-        sizeBytes: IMAGE_PAYLOAD_MAX_BYTES,
-      }),
-      { kind: 'image', reason: 'mime_match' },
-    );
-  });
-  it('undefined sizeBytes → no oversize reject (L2 cap kicks in later)', () => {
-    assert.deepEqual(
-      resolvePreviewKind({ name: 'unknown.png', kind: 'image', mimeType: 'image/png' }),
-      { kind: 'image', reason: 'mime_match' },
-    );
-  });
-});
 
-describe('exceedsImagePayloadCap — L2 post-load gate', () => {
-  it('returns true on oversize base64', () => {
-    // String length comparison is O(1); we never need to actually
-    // create a 2MB+ base64 here — just go past the threshold.
-    const oversize = 'A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH + 1);
-    assert.equal(exceedsImagePayloadCap(oversize), true);
-  });
-  it('returns false at the threshold', () => {
-    const atCap = 'A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH);
-    assert.equal(exceedsImagePayloadCap(atCap), false);
-  });
-  it('returns false on small payloads', () => {
-    assert.equal(exceedsImagePayloadCap(''), false);
-    assert.equal(exceedsImagePayloadCap('abcd'), false);
-  });
-  it('returns true for non-string inputs (fail closed)', () => {
-    // @ts-expect-error — intentional bad input
-    assert.equal(exceedsImagePayloadCap(null), true);
-    // @ts-expect-error — intentional bad input
-    assert.equal(exceedsImagePayloadCap(undefined), true);
-    // @ts-expect-error — intentional bad input
-    assert.equal(exceedsImagePayloadCap(42), true);
-  });
-});
-
-describe('formatPreviewSize', () => {
-  it('handles bytes', () => {
-    assert.equal(formatPreviewSize(0), '0 B');
-    assert.equal(formatPreviewSize(512), '512 B');
-    assert.equal(formatPreviewSize(1023), '1023 B');
-  });
-  it('handles kilobytes', () => {
-    assert.equal(formatPreviewSize(1024), '1.0 KB');
-    assert.equal(formatPreviewSize(2048), '2.0 KB');
-    assert.equal(formatPreviewSize(1024 * 100), '100.0 KB');
-  });
-  it('handles megabytes', () => {
-    assert.equal(formatPreviewSize(1024 * 1024), '1.0 MB');
-    assert.equal(formatPreviewSize(IMAGE_PAYLOAD_MAX_BYTES), '2.0 MB');
-  });
-  it('returns 未知大小 for undefined / negative / NaN', () => {
-    assert.equal(formatPreviewSize(undefined), '未知大小');
-    assert.equal(formatPreviewSize(-1), '未知大小');
-    assert.equal(formatPreviewSize(NaN), '未知大小');
-    assert.equal(formatPreviewSize(Infinity), '未知大小');
-  });
-});
-
-describe('normalizeAllowedImageMime — L2 MIME re-validation', () => {
-  it('returns the lower-cased MIME for every allowed entry', () => {
-    for (const mime of ALLOWED_IMAGE_MIMES) {
-      assert.equal(normalizeAllowedImageMime(mime), mime);
+  it('routes IPC failures and malformed successful payloads without retaining base64', () => {
+    for (const reason of ['not_found', 'too_large', 'read_failed', 'not_allowed', 'deleted', 'unsupported_mime'] as const) {
+      assert.deepEqual(decideImageReadOutcome({ ok: false, reason }), {
+        kind: 'unsupported',
+        reason: 'read_failed',
+      });
     }
-  });
-  it('lower-cases and trims before checking', () => {
-    assert.equal(normalizeAllowedImageMime('IMAGE/PNG'), 'image/png');
-    assert.equal(normalizeAllowedImageMime('  image/JPEG  '), 'image/jpeg');
-  });
-  it('rejects disallowed MIMEs', () => {
-    assert.equal(normalizeAllowedImageMime('image/svg+xml'), null);
-    assert.equal(normalizeAllowedImageMime('image/heic'), null);
-    assert.equal(normalizeAllowedImageMime('application/octet-stream'), null);
-    assert.equal(normalizeAllowedImageMime('text/html'), null);
-  });
-  it('rejects empty / non-string', () => {
-    assert.equal(normalizeAllowedImageMime(''), null);
-    assert.equal(normalizeAllowedImageMime('   '), null);
-    assert.equal(normalizeAllowedImageMime(undefined), null);
-    // @ts-expect-error — intentional bad input
-    assert.equal(normalizeAllowedImageMime(null), null);
-    // @ts-expect-error — intentional bad input
-    assert.equal(normalizeAllowedImageMime(42), null);
-  });
-});
 
-describe('decideImagePostLoad — cross-layer resolver+sniff scenarios (@kenji msg f1ef0cc5)', () => {
-  const smallBase64 = 'A'.repeat(100); // well under cap
-  const oversizeBase64 = 'A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH + 1);
-
-  it('metadata image/png + sniffed image/svg+xml → unsupported(mime_disallowed), NO image render', () => {
-    // Even though the L1 resolver accepted the artifact (because
-    // metadata claimed `image/png`), the post-load sniff revealed
-    // SVG. Rendering this as `<img src="data:image/svg+xml;...">`
-    // would execute it as an active document. Hard reject.
-    const outcome = decideImagePostLoad({
-      base64: smallBase64,
-      mimeType: 'image/svg+xml',
-    });
-    assert.deepEqual(outcome, { kind: 'unsupported', reason: 'mime_disallowed' });
-  });
-
-  it('metadata no MIME + ext .png + sniffed image/png → image render with sniffed MIME', () => {
-    // The resolver took the ext fallback path; main's sniff
-    // confirmed PNG. Render normally, using the SNIFFED MIME (not
-    // the absent metadata MIME).
-    const outcome = decideImagePostLoad({
-      base64: smallBase64,
-      mimeType: 'image/png',
-    });
-    assert.deepEqual(outcome, { kind: 'image', safeMime: 'image/png', base64: smallBase64 });
-  });
-
-  it('metadata no MIME + ext .png + sniffed application/octet-stream → unsupported(mime_disallowed)', () => {
-    // The ext fallback let the artifact through L1, but main's
-    // sniff couldn't classify it (or sniffed a non-image type).
-    // No image render.
-    const outcome = decideImagePostLoad({
-      base64: smallBase64,
-      mimeType: 'application/octet-stream',
-    });
-    assert.deepEqual(outcome, { kind: 'unsupported', reason: 'mime_disallowed' });
-  });
-
-  it('oversize takes precedence over MIME — even a valid PNG over cap is rejected', () => {
-    const outcome = decideImagePostLoad({
-      base64: oversizeBase64,
-      mimeType: 'image/png',
-    });
-    assert.deepEqual(outcome, { kind: 'unsupported', reason: 'oversize' });
-  });
-
-  it('oversize + disallowed MIME → oversize reason (cap is the earlier gate)', () => {
-    // Documents the precedence: cap is cheaper to check and
-    // shouldn't be masked by a separately-disallowed MIME.
-    const outcome = decideImagePostLoad({
-      base64: oversizeBase64,
-      mimeType: 'image/svg+xml',
-    });
-    assert.equal(outcome.kind, 'unsupported');
-    if (outcome.kind === 'unsupported') {
-      assert.equal(outcome.reason, 'oversize');
-    }
-  });
-
-  it('safeMime returned is lowercased even if sniffed MIME was uppercase', () => {
-    // Defensive against main returning unnormalized MIME. The
-    // safeMime placed in the DOM is always a member of the
-    // allowlist, in canonical lower-case form.
-    const outcome = decideImagePostLoad({
-      base64: smallBase64,
-      mimeType: 'IMAGE/PNG',
-    });
-    assert.deepEqual(outcome, { kind: 'image', safeMime: 'image/png', base64: smallBase64 });
-  });
-});
-
-describe('decideImageReadOutcome — IPC failure routing (@kenji msg 5fa6f6a5)', () => {
-  // PR-UI-RENDER-3a fixup: the post-readBinary chokepoint MUST run
-  // before React setState so a 10MB base64 oversize payload never
-  // enters renderer state. These tests lock the contract.
-  const smallBase64 = 'A'.repeat(100);
-  const oversizeBase64 = 'A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH + 1);
-
-  it('ok: false → unsupported(read_failed) (all failure reasons collapse here)', () => {
-    // Every `ArtifactBinaryReadFailureReason` routes to `read_failed`.
-    // The user copy is "load failed", not "format unsupported".
-    const reasons = [
-      'not_found',
-      'too_large',
-      'read_failed',
-      'not_allowed',
-      'deleted',
-      'unsupported_mime',
-    ] as const;
-    for (const reason of reasons) {
-      const result: ArtifactBinaryReadResult = { ok: false, reason };
-      assert.deepEqual(
-        decideImageReadOutcome(result),
-        { kind: 'unsupported', reason: 'read_failed' },
-        `failure reason ${reason} should map to read_failed`,
-      );
-    }
-  });
-
-  it('ok: true with valid PNG payload → image branch with safeMime + base64', () => {
-    const result: ArtifactBinaryReadResult = {
-      ok: true,
-      base64: smallBase64,
-      mimeType: 'image/png',
-    };
-    assert.deepEqual(decideImageReadOutcome(result), {
+    const valid: ArtifactBinaryReadResult = { ok: true, base64: 'AAAA', mimeType: 'image/png' };
+    assert.deepEqual(decideImageReadOutcome(valid), {
       kind: 'image',
       safeMime: 'image/png',
-      base64: smallBase64,
+      base64: 'AAAA',
     });
-  });
 
-  it('ok: true with oversize payload → unsupported(oversize), NO base64 in outcome', () => {
-    // This is the critical case @kenji flagged: the caller would
-    // setState with the outcome, and the outcome MUST NOT carry the
-    // 10MB base64 forward.
-    const result: ArtifactBinaryReadResult = {
-      ok: true,
-      base64: oversizeBase64,
-      mimeType: 'image/png',
-    };
-    const outcome = decideImageReadOutcome(result);
-    assert.equal(outcome.kind, 'unsupported');
-    if (outcome.kind === 'unsupported') {
-      assert.equal(outcome.reason, 'oversize');
-      // Explicit: the unsupported outcome does NOT have a base64
-      // property. The TS type already enforces this; the runtime
-      // check below is the kenji-gate to catch any future shape drift.
-      assert.equal((outcome as Record<string, unknown>).base64, undefined);
+    const malformed = [
+      { ok: true, mimeType: 'image/png' },
+      { ok: true, base64: 'AAAA' },
+    ] as unknown as ArtifactBinaryReadResult[];
+    for (const result of malformed) {
+      assert.deepEqual(decideImageReadOutcome(result), { kind: 'unsupported', reason: 'read_failed' });
     }
-  });
 
-  it('ok: true with disallowed MIME → unsupported(mime_disallowed), NO base64 in outcome', () => {
-    const result: ArtifactBinaryReadResult = {
-      ok: true,
-      base64: smallBase64,
-      mimeType: 'image/svg+xml',
-    };
-    const outcome = decideImageReadOutcome(result);
-    assert.equal(outcome.kind, 'unsupported');
-    if (outcome.kind === 'unsupported') {
-      assert.equal(outcome.reason, 'mime_disallowed');
-      assert.equal((outcome as Record<string, unknown>).base64, undefined);
+    const rejected: Array<[ArtifactBinaryReadResult, 'oversize' | 'mime_disallowed']> = [
+      [
+        {
+          ok: true,
+          base64: 'A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH + 1),
+          mimeType: 'image/png',
+        },
+        'oversize',
+      ],
+      [{ ok: true, base64: 'AAAA', mimeType: 'image/svg+xml' }, 'mime_disallowed'],
+    ];
+    for (const [result, reason] of rejected) {
+      const outcome = decideImageReadOutcome(result);
+      assert.deepEqual(outcome, { kind: 'unsupported', reason });
+      assert.equal('base64' in outcome, false);
     }
-  });
-
-  it('ok: true with missing base64 (contract break) → unsupported(read_failed) defensively', () => {
-    // Defensive: a future main-process bug or contract drift that
-    // leaves `base64` undefined on an `ok: true` branch must route
-    // to read_failed, NOT crash and NOT shove undefined into the
-    // <img src="data:..."> attribute.
-    const malformed = { ok: true, mimeType: 'image/png' } as unknown as ArtifactBinaryReadResult;
-    assert.deepEqual(decideImageReadOutcome(malformed), { kind: 'unsupported', reason: 'read_failed' });
-  });
-
-  it('ok: true with missing mimeType (contract break) → unsupported(read_failed) defensively', () => {
-    const malformed = { ok: true, base64: 'AAAA' } as unknown as ArtifactBinaryReadResult;
-    assert.deepEqual(decideImageReadOutcome(malformed), { kind: 'unsupported', reason: 'read_failed' });
-  });
-
-  it('precedence: ok: false short-circuits before MIME / size checks', () => {
-    // Even if a malformed `ok: false` carried a base64 attribute
-    // alongside, the function should return `read_failed` based on
-    // the ok flag and never inspect the payload.
-    const malformed = {
-      ok: false,
-      reason: 'not_found',
-      base64: oversizeBase64,
-      mimeType: 'image/png',
-    } as unknown as ArtifactBinaryReadResult;
-    assert.deepEqual(decideImageReadOutcome(malformed), { kind: 'unsupported', reason: 'read_failed' });
-  });
-});
-
-describe('PR-RENDER-3a boundary lock — explicitly NOT in the registry yet', () => {
-  // These tests are documentation as much as assertion. If anyone
-  // adds SVG / HTML / Mermaid support to the resolver without an
-  // accompanying PR-RENDER-3b/c/d, these tests fail and surface
-  // the scope creep.
-  it('image/svg+xml is rejected (PR-RENDER-3b boundary)', () => {
-    assert.equal(
-      resolvePreviewKind({ name: 'icon.svg', kind: 'image', mimeType: 'image/svg+xml' }).kind,
-      'unsupported',
-    );
-  });
-  it('html kind is rejected (PR-RENDER-3c boundary)', () => {
-    assert.equal(resolvePreviewKind({ name: 'page.html', kind: 'html' }).kind, 'unsupported');
-  });
-  it('pdf kind is rejected (PR-RENDER-3 future boundary)', () => {
-    assert.equal(resolvePreviewKind({ name: 'doc.pdf', kind: 'pdf' }).kind, 'unsupported');
   });
 });

--- a/apps/desktop/src/main/__tests__/onboarding-hero-copy.test.ts
+++ b/apps/desktop/src/main/__tests__/onboarding-hero-copy.test.ts
@@ -1,139 +1,18 @@
-/**
- * Tests for `getOnboardingHeroCopy` (PR110c).
- *
- * Locks the per-`OnboardingState.kind` copy + CTA mapping:
- *  - every variant returns a structure (or null for `ready_with_history`)
- *  - no raw `state.kind` enum identifier leaks into eyebrow / title /
- *    body / cta.label
- *  - Chinese-only copy
- *  - slug-only promise for per-connection variants (no connectionName /
- *    model list leaked)
- *  - `blocked: all_connections_unhealthy` is labeled (not a generic
- *    default), and its CTA points to `models` (the single connection home)
- */
-
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { readFile } from 'node:fs/promises';
 import type { OnboardingState } from '@maka/core';
 import {
-  getOnboardingHeroCopy as getLocalizedOnboardingHeroCopy,
-  getOnboardingSetupSteps as getLocalizedOnboardingSetupSteps,
+  getOnboardingHeroCopy,
+  getOnboardingSetupSteps,
 } from '../../renderer/onboarding-hero-copy.js';
 
-const getOnboardingHeroCopy = (state: OnboardingState) => getLocalizedOnboardingHeroCopy(state, 'zh');
-const getOnboardingSetupSteps = (state: OnboardingState) => getLocalizedOnboardingSetupSteps(state, 'zh');
-import { readRendererContractCss } from './contract-css-helpers.js';
+const configuredStates: OnboardingState[] = [
+  { kind: 'ready_empty', defaultConnectionSlug: 'a', defaultModel: 'm' },
+  { kind: 'ready_with_history', defaultConnectionSlug: 'a', defaultModel: 'm' },
+];
 
-// Every OnboardingState.kind string. Any rendered field MUST NOT
-// contain one of these as a substring — Chinese-only copy.
-const RAW_KINDS = [
-  'needs_connection',
-  'needs_default_connection',
-  'needs_connection_credentials',
-  'needs_default_model',
-  'ready_empty',
-  'ready_with_history',
-  'blocked',
-  'all_connections_unhealthy',
-] as const;
-
-function renderedFields(copy: ReturnType<typeof getOnboardingHeroCopy>): string[] {
-  if (!copy) return [];
-  return [copy.eyebrow, copy.title, copy.body, copy.cta.label];
-}
-
-describe('getOnboardingHeroCopy — per-variant mapping', () => {
-  it('needs_connection produces a welcome eyebrow + models CTA', () => {
-    const copy = getOnboardingHeroCopy({ kind: 'needs_connection' } as OnboardingState);
-    assert.ok(copy);
-    assert.equal(copy.kind, 'needs_connection');
-    assert.equal(copy.cta.settingsSection, 'models');
-    assert.match(copy.title, /[一-鿿]/);
-  });
-
-  it('needs_default_connection routes to settings · models', () => {
-    const copy = getOnboardingHeroCopy({ kind: 'needs_default_connection' } as OnboardingState);
-    assert.ok(copy);
-    assert.equal(copy.cta.settingsSection, 'models');
-    assert.match(copy.body, /默认/);
-  });
-
-  it('needs_connection_credentials carries the connectionSlug but no connectionName promise', () => {
-    const copy = getOnboardingHeroCopy({
-      kind: 'needs_connection_credentials',
-      connectionSlug: 'anthropic-live',
-    } as OnboardingState);
-    assert.ok(copy);
-    assert.equal(copy.connectionSlug, 'anthropic-live');
-    assert.equal(copy.cta.settingsSection, 'models');
-    // PR110c slug-only promise: body must NOT include something that
-    // looks like a fabricated connectionName / human label. The body
-    // string from the helper itself doesn't reference the slug — the
-    // hero component renders the slug via the `connectionSlug` field
-    // as a `<code>`. The body MUST NOT include the literal slug to
-    // avoid promising a sanitized name.
-    assert.equal(
-      copy.body.includes('anthropic-live'),
-      false,
-      'body should not embed the raw slug; component renders it as a separate <code>',
-    );
-    assert.match(copy.body, /等待填写 API key/);
-    assert.doesNotMatch(copy.body, /缺少可用的 API key/);
-  });
-
-  it('needs_default_model carries the connectionSlug and points to models', () => {
-    const copy = getOnboardingHeroCopy({
-      kind: 'needs_default_model',
-      connectionSlug: 'openai-live',
-    } as OnboardingState);
-    assert.ok(copy);
-    assert.equal(copy.connectionSlug, 'openai-live');
-    assert.equal(copy.cta.settingsSection, 'models');
-    assert.match(copy.body, /模型/);
-  });
-
-  it('ready_empty returns null (hero must NOT mount)', () => {
-    // #1433: a configured user with no sessions is not an onboarding
-    // case — they land on the normal empty chat with the one Composer.
-    const copy = getOnboardingHeroCopy({
-      kind: 'ready_empty',
-      defaultConnectionSlug: 'a',
-      defaultModel: 'm',
-    } as OnboardingState);
-    assert.equal(copy, null);
-  });
-
-  it('blocked: all_connections_unhealthy is labeled, routes to settings · models, destructive tone', () => {
-    // @kenji PR110c review gate: blocked must NOT fall through a
-    // generic default. The branch is labeled and routes to 模型 —
-    // the single home for connection status, re-test, and re-login
-    // now that the redundant account section is retired (U1).
-    const copy = getOnboardingHeroCopy({
-      kind: 'blocked',
-      reason: 'all_connections_unhealthy',
-    } as OnboardingState);
-    assert.ok(copy);
-    assert.equal(copy.kind, 'blocked');
-    assert.equal(copy.tone, 'destructive');
-    assert.equal(copy.cta.settingsSection, 'models');
-    assert.match(copy.eyebrow, /等待恢复模型连接/);
-    assert.match(copy.title, /没有通过验证/);
-    assert.doesNotMatch(renderedFields(copy).join('\n'), /连接暂不可用|所有模型连接都不可用/);
-  });
-
-  it('ready_with_history returns null (hero must NOT mount)', () => {
-    const copy = getOnboardingHeroCopy({
-      kind: 'ready_with_history',
-      defaultConnectionSlug: 'a',
-      defaultModel: 'm',
-    } as OnboardingState);
-    assert.equal(copy, null);
-  });
-});
-
-describe('getOnboardingHeroCopy — bilingual catalog', () => {
-  const variants: OnboardingState[] = [
+describe('onboarding hero copy', () => {
+  const onboardingStates: OnboardingState[] = [
     { kind: 'needs_connection' },
     { kind: 'needs_default_connection' },
     { kind: 'needs_connection_credentials', connectionSlug: 'anthropic-live' },
@@ -141,296 +20,73 @@ describe('getOnboardingHeroCopy — bilingual catalog', () => {
     { kind: 'blocked', reason: 'all_connections_unhealthy' },
   ];
 
-  it('renders every onboarding state and setup step in English without CJK', () => {
-    for (const state of variants) {
-      const hero = getLocalizedOnboardingHeroCopy(state, 'en');
-      assert.ok(hero);
-      assert.doesNotMatch(renderedFields(hero).join('\n'), /[\u3400-\u9fff]/, state.kind);
-      const steps = getLocalizedOnboardingSetupSteps(state, 'en');
-      if (steps) assert.doesNotMatch(JSON.stringify(steps), /[\u3400-\u9fff]/, state.kind);
+  it('maps incomplete states to the models recovery flow', () => {
+    for (const state of onboardingStates) {
+      const copy = getOnboardingHeroCopy(state, 'zh');
+      assert.ok(copy, state.kind);
+      assert.equal(copy.kind, state.kind);
+      assert.equal(copy.cta.settingsSection, 'models');
+      assert.match(`${copy.title}${copy.body}${copy.cta.label}`, /[一-鿿]/);
+      assert.equal(copy.tone, state.kind === 'blocked' ? 'destructive' : undefined);
     }
   });
 
-  it('keeps slugs byte-identical and never renders ready_with_history', () => {
-    const state = { kind: 'needs_connection_credentials', connectionSlug: 'anthropic-live' } as OnboardingState;
-    assert.equal(getLocalizedOnboardingHeroCopy(state, 'en')?.connectionSlug, 'anthropic-live');
-    assert.equal(
-      getLocalizedOnboardingHeroCopy(
-        { kind: 'ready_with_history', defaultConnectionSlug: 'a', defaultModel: 'm' } as OnboardingState,
-        'en',
-      ),
-      null,
-    );
-  });
-
-  it('uses the labeled English recovery CTA', () => {
-    assert.equal(
-      getLocalizedOnboardingHeroCopy({ kind: 'needs_connection' } as OnboardingState, 'en')?.cta.label,
-      'Open Settings · Models',
-    );
-  });
-});
-
-describe('getOnboardingHeroCopy — invariants', () => {
-  // Every state variant we currently render.
-  const ALL_VARIANTS: OnboardingState[] = [
-    { kind: 'needs_connection' },
-    { kind: 'needs_default_connection' },
-    { kind: 'needs_connection_credentials', connectionSlug: 'anthropic-live' },
-    { kind: 'needs_default_model', connectionSlug: 'openai-live' },
-    { kind: 'blocked', reason: 'all_connections_unhealthy' },
-  ];
-
-  it('no raw state.kind / blocked.reason identifier leaks into rendered copy', () => {
-    for (const variant of ALL_VARIANTS) {
-      const copy = getOnboardingHeroCopy(variant);
-      assert.ok(copy, `${variant.kind} should produce copy`);
-      for (const field of renderedFields(copy)) {
-        for (const token of RAW_KINDS) {
-          assert.equal(
-            field.includes(token),
-            false,
-            `${variant.kind} rendered field "${field}" leaks raw token "${token}"`,
-          );
-        }
+  it('keeps connection slugs as metadata instead of interpolating them into copy', () => {
+    for (const state of onboardingStates) {
+      if (state.kind !== 'needs_connection_credentials' && state.kind !== 'needs_default_model') continue;
+      for (const locale of ['zh', 'en'] as const) {
+        const copy = getOnboardingHeroCopy(state, locale);
+        assert.ok(copy);
+        assert.equal(copy.connectionSlug, state.connectionSlug);
+        assert.equal(copy.body.includes(state.connectionSlug), false);
       }
     }
   });
 
-  it('every rendered field is Chinese (no English / ASCII-only labels)', () => {
-    for (const variant of ALL_VARIANTS) {
-      const copy = getOnboardingHeroCopy(variant);
-      assert.ok(copy);
-      // Eyebrow is allowed to include uppercase Latin tags (e.g.
-      // "READY · 开始对话") because the design uses it as a small
-      // banner; title / body / cta.label must contain Chinese.
-      for (const [name, value] of [
-        ['title', copy.title],
-        ['body', copy.body],
-        ['cta.label', copy.cta.label],
-      ] as const) {
-        assert.match(value, /[一-鿿]/, `${variant.kind} ${name} should contain Chinese: "${value}"`);
-      }
+  it('does not render onboarding copy or steps for configured users', () => {
+    for (const state of configuredStates) {
+      assert.equal(getOnboardingHeroCopy(state, 'zh'), null);
+      assert.equal(getOnboardingSetupSteps(state, 'zh'), null);
     }
   });
 
-  it('CTA settingsSection is always a known SettingsSection', () => {
-    // Soft sanity — the type system already enforces this, but
-    // anchor the gate so a future loosening to `string` is caught.
-    const knownSections = new Set([
-      'general',
-      'personalization',
-      'theme',
-      'daily-review',
-      'models',
-      'usage',
-      'voice-models',
-      'bot-chat',
-      'search',
-      'network',
-      'data',
-      'about',
-    ]);
-    for (const variant of ALL_VARIANTS) {
-      const copy = getOnboardingHeroCopy(variant);
-      assert.ok(copy);
-      assert.ok(knownSections.has(copy.cta.settingsSection), `${variant.kind} bad CTA section`);
-    }
-  });
-
-  it('only blocked carries destructive tone', () => {
-    for (const variant of ALL_VARIANTS) {
-      const copy = getOnboardingHeroCopy(variant);
-      assert.ok(copy);
-      if (variant.kind === 'blocked') {
-        assert.equal(copy.tone, 'destructive');
-      } else {
-        assert.equal(copy.tone, undefined, `${variant.kind} must not have destructive tone`);
-      }
-    }
-  });
-});
-
-describe('getOnboardingSetupSteps — first-run AI setup guide', () => {
-  it('guides completely new users through AI setup before first chat', () => {
-    const steps = getOnboardingSetupSteps({ kind: 'needs_connection' } as OnboardingState);
-    assert.ok(steps);
-    assert.deepEqual(
-      steps.map((step) => step.state),
-      ['active', 'pending', 'pending'],
-    );
-    assert.match(steps.map((step) => step.label).join('\n'), /选择 AI 接入/);
-    assert.match(steps.map((step) => step.detail).join('\n'), /API key|OAuth/);
-    assert.match(steps.map((step) => step.detail).join('\n'), /测试并设默认|开始第一条对话/);
-  });
-
-  it('moves the active setup step to the exact missing AI configuration', () => {
-    const cases: Array<[OnboardingState, string]> = [
-      [{ kind: 'needs_default_connection' } as OnboardingState, '设为默认'],
-      [
-        {
-          kind: 'needs_connection_credentials',
-          connectionSlug: 'anthropic-live',
-        } as OnboardingState,
-        '补齐认证',
-      ],
-      [
-        {
-          kind: 'needs_default_model',
-          connectionSlug: 'openai-live',
-        } as OnboardingState,
-        '选择聊天模型',
-      ],
-      [
-        {
-          kind: 'blocked',
-          reason: 'all_connections_unhealthy',
-        } as OnboardingState,
-        '修复认证或网络',
-      ],
+  it('provides localized copy without leaking internal state identifiers', () => {
+    const internalTokens = [
+      'needs_connection',
+      'needs_default_connection',
+      'needs_connection_credentials',
+      'needs_default_model',
+      'all_connections_unhealthy',
     ];
+    for (const state of onboardingStates) {
+      for (const locale of ['zh', 'en'] as const) {
+        const copy = getOnboardingHeroCopy(state, locale);
+        const steps = getOnboardingSetupSteps(state, locale);
+        assert.ok(copy);
+        assert.ok(steps);
+        const rendered = JSON.stringify({
+          copy: [copy.eyebrow, copy.title, copy.body, copy.cta.label],
+          steps,
+        });
+        for (const token of internalTokens) assert.equal(rendered.includes(token), false, token);
+        if (locale === 'en') assert.doesNotMatch(rendered, /[\u3400-\u9fff]/);
+      }
+    }
+  });
 
-    for (const [state, expectedActiveLabel] of cases) {
-      const steps = getOnboardingSetupSteps(state);
-      assert.ok(steps, `${state.kind} should expose setup steps`);
+  it('moves exactly one active setup step to the missing requirement', () => {
+    const cases: Array<[OnboardingState, string]> = [
+      [{ kind: 'needs_connection' }, '选择 AI 接入'],
+      [{ kind: 'needs_default_connection' }, '设为默认'],
+      [{ kind: 'needs_connection_credentials', connectionSlug: 'anthropic-live' }, '补齐认证'],
+      [{ kind: 'needs_default_model', connectionSlug: 'openai-live' }, '选择聊天模型'],
+      [{ kind: 'blocked', reason: 'all_connections_unhealthy' }, '修复认证或网络'],
+    ];
+    for (const [state, label] of cases) {
+      const steps = getOnboardingSetupSteps(state, 'zh');
+      assert.ok(steps);
       assert.equal(steps.length, 3);
-      const activeSteps = steps.filter((step) => step.state === 'active');
-      assert.equal(activeSteps.length, 1, `${state.kind} should have exactly one active setup step`);
-      assert.equal(activeSteps[0]?.label, expectedActiveLabel);
+      assert.deepEqual(steps.filter((step) => step.state === 'active').map((step) => step.label), [label]);
     }
-  });
-
-  it('does not render setup steps once setup is complete', () => {
-    assert.equal(
-      getOnboardingSetupSteps({
-        kind: 'ready_empty',
-        defaultConnectionSlug: 'a',
-        defaultModel: 'm',
-      } as OnboardingState),
-      null,
-    );
-    assert.equal(
-      getOnboardingSetupSteps({
-        kind: 'ready_with_history',
-        defaultConnectionSlug: 'a',
-        defaultModel: 'm',
-      } as OnboardingState),
-      null,
-    );
-  });
-
-  it('renderer uses the setup helper rather than a disconnected static checklist', async () => {
-    const hero = await readFile(new URL('../../../src/renderer/OnboardingHero.tsx', import.meta.url), 'utf8');
-    const styles = await readRendererContractCss();
-
-    assert.match(hero, /import \{ getOnboardingHeroCopy, getOnboardingSetupSteps, type OnboardingSetupStep \} from '\.\/onboarding-hero-copy'/);
-    assert.match(hero, /function SetupProgress\(props: \{ steps: readonly OnboardingSetupStep\[\] \}\)/);
-    assert.match(hero, /aria-label=\{copy\.setupProgressLabel\}/);
-    assert.match(hero, /copy\.setupStatus\[step\.state\]/);
-    assert.match(hero, /getOnboardingSetupSteps\(\{ kind: 'needs_connection' \}, locale\)/);
-    assert.match(hero, /setupSteps=\{getOnboardingSetupSteps\(\{ kind: 'needs_default_connection' \}, locale\)\}/);
-    assert.equal((hero.match(/setupSteps=\{getOnboardingSetupSteps\(state, locale\)\}/g) ?? []).length, 3);
-    assert.match(styles, /\.maka-onboarding-setup-steps\s*\{/);
-    assert.match(styles, /\.maka-onboarding-setup-steps > li\[data-state="active"\]/);
-    assert.match(styles, /@media \(max-width: 620px\)[\s\S]*\.maka-onboarding-setup-step-state/);
-  });
-
-  it('keeps default-connection setup recoverable after external Settings changes', async () => {
-    const hero = await readFile(new URL('../../../src/renderer/OnboardingHero.tsx', import.meta.url), 'utf8');
-    const switchBlock = hero.match(/switch \(state\.kind\) \{[\s\S]*?case 'needs_connection_credentials':/)?.[0] ?? '';
-    const defaultConnectionBlock = hero.match(/function NeedsDefaultConnectionHero[\s\S]*?function NeedsConnectionCredentialsHero/)?.[0] ?? '';
-
-    assert.match(switchBlock, /case 'needs_default_connection':[\s\S]*onRefreshConnections=\{props\.onRefreshConnections \? runRefreshConnections : undefined\}/);
-    assert.match(switchBlock, /case 'needs_default_connection':[\s\S]*refreshConnectionsPending=\{refreshConnectionsPending\}/);
-    assert.match(defaultConnectionBlock, /onRefreshConnections\?: \(\) => void/);
-    assert.match(defaultConnectionBlock, /label: props\.refreshConnectionsPending === true \? copy\.refresh\.pending : copy\.refresh\.connection/);
-    assert.match(defaultConnectionBlock, /disabled: props\.refreshConnectionsPending === true/);
-    assert.match(defaultConnectionBlock, /busy: props\.refreshConnectionsPending === true/);
-  });
-
-  it('keeps the blocked hero action driven by the copy layer, not a hardcoded CTA', async () => {
-    const hero = await readFile(new URL('../../../src/renderer/OnboardingHero.tsx', import.meta.url), 'utf8');
-    const blockedBlock = hero.match(/function BlockedHero[\s\S]*?function SkipButton/)?.[0] ?? '';
-
-    assert.match(blockedBlock, /const hero = getOnboardingHeroCopy\(state, locale\)!/);
-    assert.match(blockedBlock, /title=\{hero\.title\}/);
-    assert.match(blockedBlock, /primaryCta=\{\{ label: hero\.cta\.label, onClick: \(\) => props\.onOpenSettings\(hero\.cta\.settingsSection\) \}\}/);
-    assert.match(blockedBlock, /tone="destructive"/);
-    assert.doesNotMatch(
-      blockedBlock,
-      /primaryCta=\{\{ label: '打开设置 · 模型', onClick: \(\) => props\.onOpenSettings\('models'\) \}\}/,
-      'Blocked first-run recovery must route through hero.cta.settingsSection, not a hardcoded models CTA that bypasses the copy layer',
-    );
-    assert.doesNotMatch(
-      blockedBlock,
-      /tone="warning"/,
-      'All-connections-unhealthy should keep destructive gravity in the rendered hero',
-    );
-  });
-
-  it('keeps the Item row hover neutral, reserving accent for active rows', async () => {
-    // The onboarding provider tiles now render through the shared `Item`
-    // primitive, so the "neutral hover" contract lives in item.tsx rather
-    // than a bespoke `.maka-onboarding-card` rule. A clickable Item should
-    // wash with a faint foreground tint, never the brand `accent` (which in
-    // this theme maps to the brand color reserved for active/selected rows).
-    const item = await readFile(
-      new URL('../../../../../packages/ui/src/primitives/item.tsx', import.meta.url),
-      'utf8',
-    );
-
-    assert.match(item, /\[a&,button&\]:hover:bg-foreground\/4/);
-    assert.doesNotMatch(
-      item,
-      /hover:bg-accent/,
-      'Item rows should keep neutral hover chrome; semantic accent belongs to active rows',
-    );
-  });
-});
-
-describe('OnboardingHero structure', () => {
-  it('renders first-run provider recommendations from the shared registry', async () => {
-    const hero = await readFile(new URL('../../../src/renderer/OnboardingHero.tsx', import.meta.url), 'utf8');
-
-    assert.match(hero, /RECOMMENDED_PROVIDER_TYPES/);
-    assert.match(hero, /RECOMMENDED_PROVIDER_TYPES\.map\(\(type\) =>/);
-    assert.doesNotMatch(hero, /const FEATURED\s*=/, 'onboarding must not own a parallel provider list');
-  });
-
-  it('keeps first-run form controls on shared UI primitives', async () => {
-    const hero = await readFile(new URL('../../../src/renderer/OnboardingHero.tsx', import.meta.url), 'utf8');
-
-    const heroImport = hero.match(/import \{[\s\S]*?\} from '@maka\/ui';/)?.[0] ?? '';
-    for (const name of ['Button', 'Item', 'ItemContent', 'ItemMedia']) {
-      assert.match(heroImport, new RegExp(`\\b${name}\\b`), `OnboardingHero must import ${name} from @maka/ui`);
-    }
-    // A bare `<button className=...>` is a hand-rolled control; forbid it. The
-    // only raw `<button>` allowed is the polymorphic render target handed to an
-    // `Item` (it carries no className — the primitive owns the styling).
-    assert.doesNotMatch(hero, /<button[^>]*className=/, 'OnboardingHero actions must use the shared Button/Item primitives, not hand-styled buttons');
-    assert.doesNotMatch(hero, /className="maka-button/, 'OnboardingHero must not keep legacy maka-button styling on migrated actions');
-  });
-
-  // #1433: the hero must never grow a second composer again. Everything
-  // below — text input, Skill chips, mention popup, file import — belongs
-  // to packages/ui/src/composer.tsx, which already owns the IME guard the
-  // deleted clone had to be patched with (PR-FE-BUG-HUNT-0).
-  it('carries no chat input of its own', async () => {
-    const hero = await readFile(new URL('../../../src/renderer/OnboardingHero.tsx', import.meta.url), 'utf8');
-
-    assert.doesNotMatch(hero, /<textarea\b/i, 'the setup hero must not render a text input');
-    assert.doesNotMatch(hero, /\bTextarea\b/, 'the setup hero must not import the Textarea primitive');
-    assert.doesNotMatch(hero, /useMentionPopup|ComposerMentionPopup/, 'Skill mention popups belong to the Composer');
-    assert.doesNotMatch(hero, /useComposerSkillDraft|maka-composer-skill-chip/, 'Skill drafts belong to the Composer');
-    // Was `/onQuickChatSubmit|quickChatPending/`, which stopped being able to
-    // fail once #1433 deleted both identifiers repo-wide. The send path it was
-    // guarding still exists — it is just spelled `sessions.create` now, and
-    // the Composer and the command palette own it.
-    assert.doesNotMatch(
-      hero,
-      /sessions\.create/,
-      'the setup hero must not own a send path — creating a session belongs to the Composer and the command palette',
-    );
-    assert.doesNotMatch(hero, /onDrop=|onPaste=|onImportDroppedTextFiles/, 'file import belongs to the Composer');
   });
 });

--- a/packages/core/src/__tests__/bot-events.test.ts
+++ b/packages/core/src/__tests__/bot-events.test.ts
@@ -28,271 +28,94 @@ describe('bot event contract', () => {
     receivedAt: 1_700_000_000_000,
   };
 
-  test('uses stable platform labels for session names and prompts', () => {
-    assert.equal(botDisplayLabel('telegram'), 'Telegram');
-    assert.equal(botDisplayLabel('feishu'), '飞书');
-    assert.equal(botDisplayLabel('dingtalk'), '钉钉');
-  });
-
-  test('builds stable conversation keys from platform and chat id', () => {
-    assert.equal(botConversationKey(message), 'telegram:chat-1');
-  });
-
-  test('builds stable source event keys from platform chat and source message id', () => {
-    assert.equal(botSourceEventKey(message), 'telegram:chat-1:m1');
-    assert.equal(
-      botSourceEventKey({
-        ...message,
-        platform: 'discord',
-        chatId: 'chan-1',
-        sourceMessageId: 'msg-99',
-      }),
-      'discord:chan-1:msg-99',
+  test('derives user-visible labels, session text, and stable keys', () => {
+    assert.deepEqual(
+      ['telegram', 'feishu', 'dingtalk'].map((platform) => botDisplayLabel(platform as never)),
+      ['Telegram', '飞书', '钉钉'],
     );
-  });
-
-  test('does not fabricate source event keys when platform id is missing', () => {
-    assert.equal(botSourceEventKey({ ...message, sourceMessageId: '' }), undefined);
+    assert.equal(botConversationKey(message), 'telegram:chat-1');
+    assert.equal(botSourceEventKey(message), 'telegram:chat-1:m1');
     assert.equal(botSourceEventKey({ ...message, sourceMessageId: '   ' }), undefined);
-  });
-
-  test('formats incoming bot text before appending to a Maka session', () => {
     assert.equal(formatBotMessageForSession(message), '[Telegram:Alice] hello');
   });
-});
 
-// PR-BOT-PLAINTEXT-RESET-COMMAND-0
-describe('isPlaintextResetCommand', () => {
-  const dm = { isGroup: false };
-  const group = { isGroup: true };
-
-  test('matches the bare English reset commands in DMs', () => {
-    assert.equal(isPlaintextResetCommand({ ...dm, text: 'restart' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: 'reset' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '/restart' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '/reset' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '/new' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: 'new chat' }), true);
-  });
-
-  test('matches the bare Chinese reset commands in DMs', () => {
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '重启' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '重置' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '重新开始' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '新对话' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '新会话' }), true);
-  });
-
-  test('is case-insensitive and tolerates surrounding whitespace', () => {
-    assert.equal(isPlaintextResetCommand({ ...dm, text: 'RESET' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '  Restart  ' }), true);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '\n/reset\n' }), true);
-  });
-
-  test('does NOT substring-match a sentence containing the word "restart"', () => {
-    // Critical: "please restart the conversation" must NOT trigger.
-    assert.equal(isPlaintextResetCommand({ ...dm, text: 'please restart' }), false);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: 'restart the conversation' }), false);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '我想重启电脑' }), false);
-  });
-
-  test('is silently ignored in group chats — conversation key is not user-scoped', () => {
-    // Until userId-scoped conversation keys land, a group member typing
-    // "restart" would otherwise drop the conversation for everyone in
-    // the chat. Stay defensive and require the explicit DM context.
-    assert.equal(isPlaintextResetCommand({ ...group, text: 'restart' }), false);
-    assert.equal(isPlaintextResetCommand({ ...group, text: '重置' }), false);
-  });
-
-  test('treats empty / whitespace-only text as no command', () => {
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '' }), false);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '   ' }), false);
-    assert.equal(isPlaintextResetCommand({ ...dm, text: '\n\t' }), false);
-  });
-
-  test('exports the canonical command list for downstream UI hints', () => {
-    // Downstream UI (e.g. bot help footer) should be able to enumerate
-    // the supported phrases without duplicating the list.
-    assert.equal(BOT_PLAINTEXT_RESET_COMMANDS.length > 0, true);
-    assert.equal(BOT_PLAINTEXT_RESET_COMMANDS.includes('restart'), true);
-    assert.equal(BOT_PLAINTEXT_RESET_COMMANDS.includes('重置'), true);
-  });
-});
-
-// PR-BOT-PLAINTEXT-HELP-COMMAND-0
-describe('isPlaintextHelpCommand', () => {
-  const dm = { isGroup: false };
-  const group = { isGroup: true };
-
-  test('matches the canonical help phrases in DMs', () => {
+  test('recognizes only exact plaintext commands in direct messages', () => {
+    const commandCases = [
+      [isPlaintextResetCommand, BOT_PLAINTEXT_RESET_COMMANDS],
+      [isPlaintextHelpCommand, BOT_PLAINTEXT_HELP_COMMANDS],
+    ] as const;
+    for (const [matches, commands] of commandCases) {
+      for (const text of commands) assert.equal(matches({ isGroup: false, text }), true, text);
+      assert.equal(matches({ isGroup: false, text: `  ${commands[0]!.toUpperCase()}  ` }), true);
+      assert.equal(matches({ isGroup: true, text: commands[0]! }), false);
+      assert.equal(matches({ isGroup: false, text: `please ${commands[0]}` }), false);
+      assert.equal(matches({ isGroup: false, text: '   ' }), false);
+    }
     for (const phrase of BOT_PLAINTEXT_HELP_COMMANDS) {
-      assert.equal(
-        isPlaintextHelpCommand({ ...dm, text: phrase }),
-        true,
-        `should match: ${phrase}`,
-      );
+      assert.equal(BOT_PLAINTEXT_RESET_COMMANDS.includes(phrase), false);
     }
   });
 
-  test('is case-insensitive and tolerates surrounding whitespace', () => {
-    assert.equal(isPlaintextHelpCommand({ ...dm, text: 'HELP' }), true);
-    assert.equal(isPlaintextHelpCommand({ ...dm, text: '  Help  ' }), true);
-  });
-
-  test('does NOT substring-match', () => {
-    assert.equal(isPlaintextHelpCommand({ ...dm, text: 'I need help with this' }), false);
-    assert.equal(isPlaintextHelpCommand({ ...dm, text: '请帮助我' }), false);
-  });
-
-  test('is silently ignored in group chats', () => {
-    assert.equal(isPlaintextHelpCommand({ ...group, text: 'help' }), false);
-    assert.equal(isPlaintextHelpCommand({ ...group, text: '帮助' }), false);
-  });
-
-  test('plaintextHelpReply lists the supported actions without marketing copy', () => {
+  test('help copy exposes actionable commands without roadmap language', () => {
     const reply = plaintextHelpReply();
-    // Must surface the user-visible commands so a help-asker can act.
     assert.match(reply, /Maka 机器人帮助/);
     assert.match(reply, /restart/);
     assert.match(reply, /重置/);
-    // Must NOT contain demo-stage / roadmap language.
     assert.equal(/即将|尚未|TODO|coming soon/i.test(reply), false);
   });
 
-  test('does not collide with the reset phrases — they remain distinct', () => {
-    for (const phrase of BOT_PLAINTEXT_HELP_COMMANDS) {
-      assert.equal(
-        BOT_PLAINTEXT_RESET_COMMANDS.includes(phrase),
-        false,
-        `help phrase ${phrase} must not also be a reset trigger`,
-      );
+  test('humanizes known runtime reasons and preserves useful diagnostics', () => {
+    const cases: Array<[string, RegExp]> = [
+      ['rate-limited', /节流/],
+      ['polling-timeout', /轮询超时/],
+      ['send-failed', /发送失败/],
+      ['get-me-failed', /凭据探测失败/],
+      ['gateway-bot-401', /Gateway.*401/],
+      ['gateway-closed-4004', /Gateway 连接关闭.*4004.*重连/],
+      ['connections-open-503', /Stream 订阅打开失败.*503/],
+      ['stream-closed-1006', /Stream 连接关闭.*1006.*重连/],
+      ['send-failed-403', /发送失败.*403/],
+      ['getAppAccessToken-401', /access_token.*401/],
+    ];
+    for (const [reason, expected] of cases)
+      assert.match(humanizeBotStatusReason(reason)!, expected);
+    assert.equal(humanizeBotStatusReason('  Unauthorized  '), 'Unauthorized');
+    assert.equal(humanizeBotStatusReason('something-weird-42'), 'something-weird-42');
+    assert.equal(humanizeBotStatusReason('A'.repeat(300)), 'A'.repeat(200));
+  });
+
+  test('does not manufacture errors for empty or non-error status reasons', () => {
+    for (const reason of [
+      undefined,
+      '',
+      '   ',
+      'disabled',
+      'stopped',
+      'no-token',
+      'scaffold-only',
+      'unimplemented',
+      'feishu-domain-required',
+    ]) {
+      assert.equal(humanizeBotStatusReason(reason), undefined);
     }
   });
-});
 
-// PR-BOT-LASTERROR-FROM-SEND-0
-describe('humanizeBotStatusReason', () => {
-  test('returns undefined for non-error states so we do not overwrite a real lastError', () => {
-    assert.equal(humanizeBotStatusReason('disabled'), undefined);
-    assert.equal(humanizeBotStatusReason('stopped'), undefined);
-    assert.equal(humanizeBotStatusReason('no-token'), undefined);
-    assert.equal(humanizeBotStatusReason('scaffold-only'), undefined);
-    assert.equal(humanizeBotStatusReason('unimplemented'), undefined);
-    assert.equal(humanizeBotStatusReason('feishu-domain-required'), undefined);
-  });
-
-  test('translates known send-path failure reasons to user-readable copy', () => {
-    assert.match(humanizeBotStatusReason('rate-limited')!, /节流/);
-    assert.match(humanizeBotStatusReason('polling-timeout')!, /轮询超时/);
-    assert.match(humanizeBotStatusReason('send-failed')!, /发送失败/);
-    assert.match(humanizeBotStatusReason('get-me-failed')!, /凭据探测失败/);
-  });
-
-  test('passes through Telegram-supplied descriptions verbatim (trimmed)', () => {
-    assert.equal(
-      humanizeBotStatusReason('  Bad Request: chat not found  '),
-      'Bad Request: chat not found',
-    );
-    assert.equal(humanizeBotStatusReason('Unauthorized'), 'Unauthorized');
-  });
-
-  test('length-caps unknown reasons to 200 chars defensively', () => {
-    const long = 'A'.repeat(300);
-    const out = humanizeBotStatusReason(long)!;
-    assert.equal(out.length, 200);
-    assert.equal(out, 'A'.repeat(200));
-  });
-
-  // PR-BOT-RUNTIME-REASON-HUMANIZE-0: pattern-based translation for the
-  // parameterized reason strings emitted by Discord / DingTalk / QQ
-  // bridges. Without these the user would see raw `gateway-closed-4004`
-  // in `lastError`.
-  test('translates gateway-bot-NNN to a readable description preserving the diagnostic code', () => {
-    assert.match(humanizeBotStatusReason('gateway-bot-401')!, /Gateway/);
-    assert.match(humanizeBotStatusReason('gateway-bot-401')!, /401/);
-    assert.match(humanizeBotStatusReason('gateway-bot-500')!, /500/);
-  });
-
-  test('translates gateway-closed-NNN to "正在重连" so users see active recovery', () => {
-    const out = humanizeBotStatusReason('gateway-closed-4004')!;
-    assert.match(out, /Gateway 连接关闭/);
-    assert.match(out, /4004/);
-    assert.match(out, /重连/);
-  });
-
-  test('translates connections-open-NNN (DingTalk Stream open failed)', () => {
-    const out = humanizeBotStatusReason('connections-open-503')!;
-    assert.match(out, /Stream 订阅打开失败/);
-    assert.match(out, /503/);
-  });
-
-  test('translates stream-closed-NNN (DingTalk Stream gateway closed)', () => {
-    const out = humanizeBotStatusReason('stream-closed-1006')!;
-    assert.match(out, /Stream 连接关闭/);
-    assert.match(out, /1006/);
-    assert.match(out, /重连/);
-  });
-
-  test('translates send-failed-NNN (Discord REST send returned non-2xx)', () => {
-    const out = humanizeBotStatusReason('send-failed-403')!;
-    assert.match(out, /发送失败/);
-    assert.match(out, /403/);
-  });
-
-  test('translates getAppAccessToken-NNN (QQ token refresh failed)', () => {
-    const out = humanizeBotStatusReason('getAppAccessToken-401')!;
-    assert.match(out, /access_token/);
-    assert.match(out, /401/);
-  });
-
-  test('falls through to verbatim pass-through for unrecognized parameterized reasons', () => {
-    // A future bridge might emit a code we haven't taught the
-    // humanizer about yet — the user still sees something rather
-    // than `undefined` or an empty `lastError`.
-    assert.equal(humanizeBotStatusReason('something-weird-42'), 'something-weird-42');
-  });
-
-  test('returns undefined for empty / whitespace / non-string', () => {
-    assert.equal(humanizeBotStatusReason(undefined), undefined);
-    assert.equal(humanizeBotStatusReason(''), undefined);
-    assert.equal(humanizeBotStatusReason('   '), undefined);
-    assert.equal(humanizeBotStatusReason('\t\n'), undefined);
-  });
-});
-
-// PR-BOT-NON-TEXT-MESSAGE-ACK-0
-describe('nonTextMessageAck', () => {
-  test('returns kind-appropriate copy for each attachment kind', () => {
-    assert.match(nonTextMessageAck('photo'), /caption/);
-    assert.match(nonTextMessageAck('voice'), /语音/);
-    assert.match(nonTextMessageAck('audio'), /语音/);
-    assert.match(nonTextMessageAck('sticker'), /贴纸/);
-    assert.match(nonTextMessageAck('video'), /视频/);
-    assert.match(nonTextMessageAck('animation'), /视频/);
-    assert.match(nonTextMessageAck('document'), /附件文件/);
-    assert.match(nonTextMessageAck('unknown'), /文字/);
-  });
-
-  test('all messages explain that Maka only handles text (consistent contract)', () => {
-    const kinds: BotAttachmentKind[] = [
-      'photo',
-      'voice',
-      'audio',
-      'sticker',
-      'video',
-      'animation',
-      'document',
-      'unknown',
+  test('attachment acknowledgements describe current text-only behavior', () => {
+    const expected: Array<[BotAttachmentKind, RegExp]> = [
+      ['photo', /caption/],
+      ['voice', /语音/],
+      ['audio', /语音/],
+      ['sticker', /贴纸/],
+      ['video', /视频/],
+      ['animation', /视频/],
+      ['document', /附件文件/],
+      ['unknown', /文字/],
     ];
-    for (const kind of kinds) {
-      assert.match(nonTextMessageAck(kind), /Maka/, `${kind} ack should mention Maka by name`);
-      // Must not contain demo-stage or roadmap language — these are
-      // user-facing acks that should describe current product behavior.
-      assert.equal(
-        /即将|尚未|TODO|coming soon|后续版本/i.test(nonTextMessageAck(kind)),
-        false,
-        `${kind} ack must not use roadmap language`,
-      );
+    for (const [kind, pattern] of expected) {
+      const reply = nonTextMessageAck(kind);
+      assert.match(reply, pattern);
+      assert.match(reply, /Maka/);
+      assert.equal(/即将|尚未|TODO|coming soon|后续版本/i.test(reply), false);
     }
   });
 });

--- a/packages/core/src/__tests__/onboarding.test.ts
+++ b/packages/core/src/__tests__/onboarding.test.ts
@@ -1,12 +1,5 @@
-/**
- * Tests for the onboarding state machine + milestone schema (PR110a).
- *
- * Locks the 15-case matrix @kenji + @xuan signed off on plus the
- * milestone validator gates.
- */
-
-import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import {
   deriveOnboardingState,
   hasSettledInitialOnboarding,
@@ -17,66 +10,55 @@ import {
   type OnboardingMilestone,
   type OnboardingState,
 } from '../onboarding.js';
-import { isConnectionReady, isRealConnection } from '../connection-readiness.js';
 import type { LlmConnection } from '../llm-connections.js';
 import type { SessionSummary } from '../session.js';
 
-// ---------------------------------------------------------------------------
-// Test factories — keep them minimal so each test row reads as data.
-// ---------------------------------------------------------------------------
-
 function realConnection(overrides: Partial<LlmConnection> = {}): LlmConnection {
   return {
-    slug: overrides.slug ?? 'anthropic-live',
-    name: overrides.name ?? 'Anthropic Live',
-    providerType: overrides.providerType ?? 'anthropic',
-    defaultModel: overrides.defaultModel ?? 'claude-sonnet-4-5-20250929',
-    enabled: overrides.enabled ?? true,
-    models: overrides.models ?? [
+    slug: 'anthropic-live',
+    name: 'Anthropic Live',
+    providerType: 'anthropic',
+    defaultModel: 'claude-sonnet-4-5-20250929',
+    enabled: true,
+    models: [
       {
         id: 'claude-sonnet-4-5-20250929',
         capabilities: { vision: true, reasoning: true, functionCalling: true },
         contextWindow: 200_000,
       },
     ],
-    modelSource: overrides.modelSource ?? 'fetched',
-    createdAt: overrides.createdAt ?? 1,
-    updatedAt: overrides.updatedAt ?? 1,
-    ...overrides,
-  } as LlmConnection;
-}
-
-function fakeConnection(overrides: Partial<LlmConnection> = {}): LlmConnection {
-  return {
-    slug: overrides.slug ?? 'fake-demo',
-    name: overrides.name ?? 'Fake Demo',
-    providerType: 'fake' as LlmConnection['providerType'],
-    defaultModel: 'fake-model',
-    enabled: overrides.enabled ?? true,
-    models: [{ id: 'fake-model', capabilities: {}, contextWindow: 1_000 }],
-    modelSource: 'fallback',
+    modelSource: 'fetched',
     createdAt: 1,
     updatedAt: 1,
-    lastTestStatus: overrides.lastTestStatus ?? 'verified',
     ...overrides,
   } as LlmConnection;
 }
 
-function session(id: string, overrides: Partial<SessionSummary> = {}): SessionSummary {
+function fakeConnection(): LlmConnection {
   return {
-    id,
-    name: overrides.name ?? id,
+    ...realConnection(),
+    slug: 'fake-demo',
+    providerType: 'fake' as LlmConnection['providerType'],
+    defaultModel: 'fake-model',
+    models: [{ id: 'fake-model' }],
+    lastTestStatus: 'verified',
+  };
+}
+
+function session(status: SessionSummary['status'] = 'active'): SessionSummary {
+  return {
+    id: `session-${status}`,
+    name: 'Session',
     isFlagged: false,
-    isArchived: overrides.isArchived ?? false,
+    isArchived: status === 'archived',
     labels: [],
     hasUnread: false,
-    status: overrides.status ?? 'active',
+    status,
     backend: 'ai-sdk',
     llmConnectionSlug: 'anthropic-live',
     connectionLocked: false,
     model: 'claude-sonnet-4-5-20250929',
     permissionMode: 'ask',
-    ...overrides,
   };
 }
 
@@ -89,629 +71,233 @@ function derive(input: Partial<DeriveOnboardingStateInput> = {}): OnboardingStat
   });
 }
 
-// ---------------------------------------------------------------------------
-// 15-case derive matrix
-// ---------------------------------------------------------------------------
-
-describe('deriveOnboardingState — 15-case matrix (@kenji + @xuan PR110a)', () => {
-  it('case 1: 0 connections → needs_connection', () => {
-    assert.deepEqual(derive(), { kind: 'needs_connection' });
+describe('deriveOnboardingState', () => {
+  it('covers the top-level state decision table', () => {
+    const ready = realConnection();
+    const disabled = realConnection({ enabled: false });
+    const cases: Array<[string, Partial<DeriveOnboardingStateInput>, OnboardingState]> = [
+      ['no connections', {}, { kind: 'needs_connection' }],
+      [
+        'fake is not a real connection regardless of test status',
+        {
+          connections: [fakeConnection()],
+          defaultSlug: 'fake-demo',
+          secrets: { 'fake-demo': true },
+        },
+        { kind: 'needs_connection' },
+      ],
+      [
+        'ready default without history',
+        { connections: [ready], defaultSlug: ready.slug, secrets: { [ready.slug]: true } },
+        {
+          kind: 'ready_empty',
+          defaultConnectionSlug: ready.slug,
+          defaultModel: ready.defaultModel!,
+        },
+      ],
+      [
+        'ready default with history',
+        {
+          connections: [ready],
+          defaultSlug: ready.slug,
+          secrets: { [ready.slug]: true },
+          sessions: [session()],
+        },
+        {
+          kind: 'ready_with_history',
+          defaultConnectionSlug: ready.slug,
+          defaultModel: ready.defaultModel!,
+        },
+      ],
+      [
+        'unset default',
+        { connections: [ready], secrets: { [ready.slug]: true } },
+        { kind: 'needs_default_connection' },
+      ],
+      [
+        'missing default with a ready alternative',
+        { connections: [ready], defaultSlug: 'deleted', secrets: { [ready.slug]: true } },
+        { kind: 'needs_default_connection' },
+      ],
+      [
+        'disabled default with no ready alternative',
+        { connections: [disabled], defaultSlug: disabled.slug, secrets: { [disabled.slug]: true } },
+        { kind: 'blocked', reason: 'all_connections_unhealthy' },
+      ],
+    ];
+    for (const [name, input, expected] of cases) assert.deepEqual(derive(input), expected, name);
   });
 
-  it('case 2: only fake (verified, defaultSlug→fake) → needs_connection (isRealConnection ignores telemetry)', () => {
-    const fake = fakeConnection({ slug: 'fake-x', lastTestStatus: 'verified' });
-    assert.deepEqual(
-      derive({ connections: [fake], defaultSlug: 'fake-x', secrets: { 'fake-x': true } }),
-      { kind: 'needs_connection' },
-    );
-    // Regression: isRealConnection MUST NOT look at lastTestStatus.
-    assert.equal(isRealConnection(fake), false);
+  it('counts active, archived, and aborted sessions as history', () => {
+    const connection = realConnection();
+    for (const status of ['active', 'archived', 'aborted'] as const) {
+      assert.equal(
+        derive({
+          connections: [connection],
+          defaultSlug: connection.slug,
+          secrets: { [connection.slug]: true },
+          sessions: [session(status)],
+        }).kind,
+        'ready_with_history',
+      );
+    }
   });
 
-  it('case 3: 1 real ready, defaultSlug=real, 0 sessions → ready_empty', () => {
-    const conn = realConnection({ slug: 'anthropic-live' });
+  it('routes the current default to the exact actionable fix', () => {
+    const cases: Array<[LlmConnection, Record<string, boolean>, OnboardingState]> = [
+      [
+        realConnection({ slug: 'missing-secret' }),
+        {},
+        { kind: 'needs_connection_credentials', connectionSlug: 'missing-secret' },
+      ],
+      [
+        realConnection({ slug: 'missing-model', defaultModel: '', models: undefined }),
+        { 'missing-model': true },
+        { kind: 'needs_default_model', connectionSlug: 'missing-model' },
+      ],
+      [
+        realConnection({ slug: 'empty-models', defaultModel: 'stale', models: [] }),
+        { 'empty-models': true },
+        { kind: 'needs_default_model', connectionSlug: 'empty-models' },
+      ],
+      [
+        realConnection({ slug: 'stale-model', defaultModel: 'stale', models: [{ id: 'fresh' }] }),
+        { 'stale-model': true },
+        { kind: 'needs_default_model', connectionSlug: 'stale-model' },
+      ],
+      [
+        realConnection({
+          slug: 'image-only',
+          defaultModel: 'image-only',
+          models: [{ id: 'image-only', capabilities: { chat: false, imageGeneration: true } }],
+        }),
+        { 'image-only': true },
+        { kind: 'needs_default_model', connectionSlug: 'image-only' },
+      ],
+    ];
+    for (const [connection, secrets, expected] of cases) {
+      assert.deepEqual(
+        derive({ connections: [connection], defaultSlug: connection.slug, secrets }),
+        expected,
+      );
+    }
+  });
+
+  it('preserves readiness priority across broken and ready alternatives', () => {
+    const missingSecret = realConnection({ slug: 'current' });
+    const brokenAlternative = realConnection({ slug: 'broken-alt', models: [] });
     assert.deepEqual(
       derive({
-        connections: [conn],
-        defaultSlug: 'anthropic-live',
-        secrets: { 'anthropic-live': true },
+        connections: [missingSecret, brokenAlternative],
+        defaultSlug: 'current',
+        secrets: { 'broken-alt': true },
       }),
-      {
-        kind: 'ready_empty',
-        defaultConnectionSlug: 'anthropic-live',
-        defaultModel: 'claude-sonnet-4-5-20250929',
-      },
+      { kind: 'needs_connection_credentials', connectionSlug: 'current' },
     );
-  });
 
-  it('case 4: 1 real ready, defaultSlug=real, ≥1 active session → ready_with_history', () => {
-    const conn = realConnection({ slug: 'anthropic-live' });
-    const result = derive({
-      connections: [conn],
-      defaultSlug: 'anthropic-live',
-      secrets: { 'anthropic-live': true },
-      sessions: [session('s1')],
-    });
-    assert.deepEqual(result, {
-      kind: 'ready_with_history',
-      defaultConnectionSlug: 'anthropic-live',
-      defaultModel: 'claude-sonnet-4-5-20250929',
-    });
-  });
-
-  it('case 5: ≥1 archived session counts as history (must not regress to ready_empty)', () => {
-    const conn = realConnection({ slug: 'anthropic-live' });
-    const result = derive({
-      connections: [conn],
-      defaultSlug: 'anthropic-live',
-      secrets: { 'anthropic-live': true },
-      sessions: [session('s1', { isArchived: true, status: 'archived' })],
-    });
-    assert.equal(result.kind, 'ready_with_history');
-  });
-
-  it('case 6: 1 aborted session counts as history', () => {
-    const conn = realConnection({ slug: 'anthropic-live' });
-    const result = derive({
-      connections: [conn],
-      defaultSlug: 'anthropic-live',
-      secrets: { 'anthropic-live': true },
-      sessions: [session('s1', { status: 'aborted' })],
-    });
-    assert.equal(result.kind, 'ready_with_history');
-  });
-
-  it('case 7: 1 real, defaultSlug unset → needs_default_connection', () => {
-    const conn = realConnection({ slug: 'anthropic-live' });
-    assert.deepEqual(derive({ connections: [conn], secrets: { 'anthropic-live': true } }), {
-      kind: 'needs_default_connection',
-    });
-  });
-
-  it('case 8: 1 real ready, defaultSlug points to deleted conn → needs_default_connection', () => {
-    const conn = realConnection({ slug: 'anthropic-live' });
+    const readyAlternative = realConnection({ slug: 'ready-alt' });
     assert.deepEqual(
       derive({
-        connections: [conn],
-        defaultSlug: 'deleted-slug',
-        secrets: { 'anthropic-live': true },
+        connections: [missingSecret, readyAlternative],
+        defaultSlug: 'current',
+        secrets: { 'ready-alt': true },
       }),
       { kind: 'needs_default_connection' },
     );
   });
 
-  it('case 9: 1 real ready + 1 fake, defaultSlug=fake → needs_default_connection', () => {
-    const conn = realConnection({ slug: 'anthropic-live' });
-    const fake = fakeConnection({ slug: 'fake-x' });
-    assert.deepEqual(
-      derive({
-        connections: [conn, fake],
-        defaultSlug: 'fake-x',
-        secrets: { 'anthropic-live': true },
+  it('accepts wired OAuth providers and ignores validation telemetry', () => {
+    const connections = [
+      realConnection({ slug: 'claude-subscription', providerType: 'claude-subscription' }),
+      realConnection({
+        slug: 'openai-codex',
+        providerType: 'openai-codex',
+        defaultModel: 'gpt-5.5',
+        models: [{ id: 'gpt-5.5' }],
       }),
-      { kind: 'needs_default_connection' },
-    );
-  });
-
-  it('case 10: 1 real, defaultSlug=real, missing API key → needs_connection_credentials', () => {
-    const conn = realConnection({ slug: 'anthropic-live' });
-    assert.deepEqual(derive({ connections: [conn], defaultSlug: 'anthropic-live', secrets: {} }), {
-      kind: 'needs_connection_credentials',
-      connectionSlug: 'anthropic-live',
-    });
-  });
-
-  it('case 11: 1 real, has key, no defaultModel → needs_default_model', () => {
-    const conn = realConnection({
-      slug: 'anthropic-live',
-      defaultModel: '',
-      models: undefined, // no enumerated list — falls through to missing_model
-    });
-    assert.deepEqual(
-      derive({
-        connections: [conn],
-        defaultSlug: 'anthropic-live',
-        secrets: { 'anthropic-live': true },
-      }),
-      { kind: 'needs_default_model', connectionSlug: 'anthropic-live' },
-    );
-  });
-
-  it('case 12: 1 real, has key, defaultModel not_enabled → needs_default_model', () => {
-    const conn = realConnection({
-      slug: 'anthropic-live',
-      defaultModel: 'stale-model-id',
-      models: [{ id: 'claude-sonnet-4-5-20250929', capabilities: {}, contextWindow: 200_000 }],
-    });
-    assert.deepEqual(
-      derive({
-        connections: [conn],
-        defaultSlug: 'anthropic-live',
-        secrets: { 'anthropic-live': true },
-      }),
-      { kind: 'needs_default_model', connectionSlug: 'anthropic-live' },
-    );
-  });
-
-  it('case 13: 1 real, has key, empty_model_list → needs_default_model', () => {
-    const conn = realConnection({ slug: 'anthropic-live', defaultModel: 'something', models: [] });
-    assert.deepEqual(
-      derive({
-        connections: [conn],
-        defaultSlug: 'anthropic-live',
-        secrets: { 'anthropic-live': true },
-      }),
-      { kind: 'needs_default_model', connectionSlug: 'anthropic-live' },
-    );
-  });
-
-  it('case 13b: 1 real, has key, defaultModel unsupported_for_chat → needs_default_model', () => {
-    const conn = realConnection({
-      slug: 'anthropic-live',
-      defaultModel: 'image-only',
-      models: [{ id: 'image-only', capabilities: { chat: false, imageGeneration: true } }],
-    });
-    assert.deepEqual(
-      derive({
-        connections: [conn],
-        defaultSlug: 'anthropic-live',
-        secrets: { 'anthropic-live': true },
-      }),
-      { kind: 'needs_default_model', connectionSlug: 'anthropic-live' },
-    );
-  });
-
-  it('case 14: 1 real disabled, no ready alt → blocked: all_connections_unhealthy', () => {
-    const conn = realConnection({ slug: 'anthropic-live', enabled: false });
-    assert.deepEqual(
-      derive({
-        connections: [conn],
-        defaultSlug: 'anthropic-live',
-        secrets: { 'anthropic-live': true },
-      }),
-      { kind: 'blocked', reason: 'all_connections_unhealthy' },
-    );
-  });
-
-  it('case 15: 2 real both disabled → blocked: all_connections_unhealthy', () => {
-    const a = realConnection({ slug: 'conn-a', enabled: false });
-    const b = realConnection({ slug: 'conn-b', enabled: false });
-    assert.deepEqual(
-      derive({
-        connections: [a, b],
-        defaultSlug: 'conn-a',
-        secrets: { 'conn-a': true, 'conn-b': true },
-      }),
-      { kind: 'blocked', reason: 'all_connections_unhealthy' },
-    );
-  });
-
-  // @kenji PR110a review gate: `needs_default_connection` requires
-  // an ACTUALLY ready alt — not just a real connection that happens
-  // to be the same kind of broken as the default.
-  it('case 16: default missing_api_key + alt also missing_api_key → needs_connection_credentials, NOT needs_default_connection', () => {
-    const a = realConnection({ slug: 'conn-a' });
-    const b = realConnection({ slug: 'conn-b' });
-    // Neither has a secret; defaultSlug=conn-a. The default's reason
-    // is `missing_api_key` which has a per-connection fix path, so we
-    // route to that. Falling through to `needs_default_connection`
-    // would be a bug because switching to `conn-b` would NOT make the
-    // workspace usable.
-    assert.deepEqual(
-      derive({
-        connections: [a, b],
-        defaultSlug: 'conn-a',
-        secrets: {}, // both lack secret
-      }),
-      { kind: 'needs_connection_credentials', connectionSlug: 'conn-a' },
-    );
-  });
-
-  it('case 17: default disabled + alt also disabled → blocked: all_connections_unhealthy (no per-connection fix wins)', () => {
-    const a = realConnection({ slug: 'conn-a', enabled: false });
-    const b = realConnection({ slug: 'conn-b', enabled: false });
-    assert.deepEqual(
-      derive({
-        connections: [a, b],
-        defaultSlug: 'conn-a',
-        secrets: { 'conn-a': true, 'conn-b': true },
-      }),
-      { kind: 'blocked', reason: 'all_connections_unhealthy' },
-    );
-  });
-
-  // @kenji PR110a review gate: the slug carried by needs_connection_credentials
-  // (and needs_default_model) MUST be the current default's slug. The UI
-  // uses it to focus a setup panel; pointing it at an alt would route the
-  // user to a provider they did not choose.
-  it('case 18: default missing_api_key + alt empty_model_list → needs_connection_credentials { CURRENT default slug, not alt }', () => {
-    const a = realConnection({ slug: 'conn-default' });
-    const b = realConnection({ slug: 'conn-alt', models: [] }); // empty_model_list
-    const result = derive({
-      connections: [a, b],
-      defaultSlug: 'conn-default',
-      secrets: { 'conn-alt': true }, // alt has key; default doesn't
-    });
-    assert.deepEqual(result, {
-      kind: 'needs_connection_credentials',
-      connectionSlug: 'conn-default',
-    });
-    // The alt is also broken (empty_model_list); we MUST NOT route the
-    // user to fix that one. The default's missing_api_key wins.
-    if (result.kind === 'needs_connection_credentials') {
-      assert.notEqual(result.connectionSlug, 'conn-alt');
+    ];
+    for (const connection of connections) {
+      for (const lastTestStatus of [undefined, 'verified', 'needs_reauth', 'error'] as const) {
+        assert.equal(
+          derive({
+            connections: [{ ...connection, lastTestStatus }],
+            defaultSlug: connection.slug,
+            secrets: { [connection.slug]: true },
+          }).kind,
+          'ready_empty',
+        );
+      }
     }
   });
 
-  it('case 19: needs_default_model slug is the CURRENT default, not an alt with the same issue', () => {
-    const a = realConnection({
-      slug: 'conn-default',
-      defaultModel: 'stale',
-      models: [{ id: 'fresh' }],
-    });
-    const b = realConnection({
-      slug: 'conn-alt',
-      defaultModel: 'also-stale',
-      models: [{ id: 'something' }],
-    });
-    const result = derive({
-      connections: [a, b],
-      defaultSlug: 'conn-default',
-      secrets: { 'conn-default': true, 'conn-alt': true },
-    });
-    assert.deepEqual(result, { kind: 'needs_default_model', connectionSlug: 'conn-default' });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Cross-cutting invariants
-// ---------------------------------------------------------------------------
-
-describe('deriveOnboardingState invariants', () => {
-  it('does NOT actively produce blocked: no_real_connection (only-fake rolls back to needs_connection)', () => {
-    // @kenji + @xuan PR110a gate: `no_real_connection` is reserved for
-    // send-path/readiness reason codes; onboarding derive never emits
-    // it because the actionable fix path is `needs_connection`.
-    const fake = fakeConnection({ slug: 'fake-only' });
-    const result = derive({
-      connections: [fake],
-      defaultSlug: 'fake-only',
-      secrets: { 'fake-only': true },
-    });
-    assert.notDeepEqual(result, { kind: 'blocked', reason: 'no_real_connection' });
-    assert.deepEqual(result, { kind: 'needs_connection' });
-  });
-
-  it('isConnectionReady is the single source of truth (helper reuse, @kenji review #1)', () => {
-    // Locks the integration: deriveOnboardingState must reach a ready
-    // state if and only if isConnectionReady() returns ready for the
-    // default connection with the same secret presence.
-    const conn = realConnection({ slug: 'shared-slug' });
-    const ready = isConnectionReady({ connection: conn, hasSecret: true });
-    assert.equal(ready.ready, true);
-    const result = derive({
-      connections: [conn],
-      defaultSlug: 'shared-slug',
-      secrets: { 'shared-slug': true },
-    });
-    assert.equal(result.kind, 'ready_empty');
-
-    // Flipping hasSecret to false flips both helpers consistently.
-    const notReady = isConnectionReady({ connection: conn, hasSecret: false });
-    assert.equal(notReady.ready, false);
-    if (!notReady.ready) {
-      assert.equal(notReady.reason, 'missing_api_key');
-    }
-    const result2 = derive({ connections: [conn], defaultSlug: 'shared-slug', secrets: {} });
-    assert.equal(result2.kind, 'needs_connection_credentials');
-  });
-
-  it('Claude OAuth subscription connections become onboarding-ready after login', () => {
-    const conn = realConnection({
-      slug: 'claude-subscription',
-      providerType: 'claude-subscription',
-      defaultModel: 'claude-sonnet-4-5-20250929',
-    });
-    const ready = isConnectionReady({ connection: conn, hasSecret: true });
-    assert.equal(ready.ready, true);
-    const result = derive({
-      connections: [conn],
-      defaultSlug: 'claude-subscription',
-      secrets: { 'claude-subscription': true },
-    });
-    assert.equal(result.kind, 'ready_empty');
-  });
-
-  it('Codex OAuth subscription connections are onboarding-ready once their send path lands', () => {
-    const conn = realConnection({
-      slug: 'openai-codex',
-      providerType: 'openai-codex',
-      defaultModel: 'gpt-5.5',
-      models: [{ id: 'gpt-5.5' }],
-    });
-    const ready = isConnectionReady({ connection: conn, hasSecret: true });
-    assert.equal(ready.ready, true);
-    const result = derive({
-      connections: [conn],
-      defaultSlug: 'openai-codex',
-      secrets: { 'openai-codex': true },
-    });
-    assert.equal(result.kind, 'ready_empty');
-  });
-
-  it('is pure: same input always produces same output (deep-equal)', () => {
-    const conn = realConnection({ slug: 'a' });
+  it('does not mutate its inputs', () => {
     const input: DeriveOnboardingStateInput = {
-      connections: [conn],
+      connections: [realConnection({ slug: 'a' })],
       defaultSlug: 'a',
-      sessions: [session('s1')],
+      sessions: [session()],
       secrets: { a: true },
     };
-    assert.deepEqual(deriveOnboardingState(input), deriveOnboardingState(input));
-  });
-
-  it('does not mutate inputs', () => {
-    const conn = realConnection({ slug: 'a' });
-    const connections = [conn];
-    const sessions = [session('s1')];
-    const secrets = { a: true };
-    const before = JSON.stringify({ connections, sessions, secrets });
-    deriveOnboardingState({ connections, defaultSlug: 'a', sessions, secrets });
-    assert.equal(JSON.stringify({ connections, sessions, secrets }), before);
-  });
-
-  // PR-HEALTH-1 — E2 lock (three-layer separation):
-  // OnboardingState must NOT consider `lastTestStatus`. Credential test
-  // outcome is a validation-layer concern; onboarding answers
-  // "fact: do you have a usable real connection set as default?" which
-  // is a configuration-layer concern. Flipping lastTestStatus across all
-  // states must produce the SAME OnboardingState — the two layers are
-  // independent.
-  it('E2: flipping lastTestStatus does not change OnboardingState (validation ≠ onboarding)', () => {
-    const baseSession = [session('s1')];
-    for (const lastTestStatus of [undefined, 'verified', 'needs_reauth', 'error'] as const) {
-      const conn = realConnection({ slug: 'a', lastTestStatus });
-      const result = derive({
-        connections: [conn],
-        defaultSlug: 'a',
-        sessions: baseSession,
-        secrets: { a: true },
-      });
-      assert.equal(
-        result.kind,
-        'ready_with_history',
-        `lastTestStatus=${lastTestStatus} must produce ready_with_history (credential test is validation-layer, not onboarding-layer)`,
-      );
-    }
+    const before = structuredClone(input);
+    deriveOnboardingState(input);
+    assert.deepEqual(input, before);
   });
 });
 
-// ---------------------------------------------------------------------------
-// Milestone validator + sanitizer
-// ---------------------------------------------------------------------------
+describe('onboarding milestone persistence', () => {
+  it('accepts the closed schema and rejects malformed or privacy-leaking values', () => {
+    for (const id of ONBOARDING_MILESTONE_IDS) assert.equal(isOnboardingMilestone({ id }), true);
+    assert.equal(isOnboardingMilestone({ id: 'first_chat_sent', completedAt: 0 }), true);
+    assert.equal(isOnboardingMilestone({ id: 'first_chat_sent', skippedAt: 1 }), true);
 
-describe('isOnboardingMilestone', () => {
-  it('accepts a bare placeholder {id} (not yet completed / skipped)', () => {
-    for (const id of ONBOARDING_MILESTONE_IDS) {
-      assert.equal(isOnboardingMilestone({ id }), true);
-    }
-  });
-
-  it('accepts {id, completedAt}', () => {
-    assert.equal(
-      isOnboardingMilestone({ id: 'first_chat_sent', completedAt: 1_700_000_000_000 }),
-      true,
-    );
-  });
-
-  it('accepts {id, skippedAt}', () => {
-    assert.equal(
-      isOnboardingMilestone({ id: 'first_chat_sent', skippedAt: 1_700_000_000_000 }),
-      true,
-    );
-  });
-
-  it('rejects entries with BOTH completedAt and skippedAt (at-most-one terminal)', () => {
-    assert.equal(
-      isOnboardingMilestone({
-        id: 'first_chat_sent',
-        completedAt: 1_700_000_000_000,
-        skippedAt: 1_700_000_001_000,
-      }),
-      false,
-    );
-  });
-
-  it('rejects unknown milestone ids', () => {
-    assert.equal(isOnboardingMilestone({ id: 'first_made_up_milestone' }), false);
-    assert.equal(isOnboardingMilestone({ id: '' }), false);
-    assert.equal(isOnboardingMilestone({ id: 42 }), false);
-  });
-
-  it('rejects extra fields (no prompt/provider error/user content leakage)', () => {
-    assert.equal(
-      isOnboardingMilestone({ id: 'first_chat_sent', prompt: 'hello world' } as unknown),
-      false,
-    );
-    assert.equal(
-      isOnboardingMilestone({
-        id: 'first_chat_sent',
-        completedAt: 1_700_000_000_000,
-        providerError: 'rate limited',
-      } as unknown),
-      false,
-    );
-  });
-
-  it('rejects non-finite timestamps (NaN, Infinity, -Infinity)', () => {
-    for (const ts of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
-      assert.equal(isOnboardingMilestone({ id: 'first_chat_sent', completedAt: ts }), false);
-      assert.equal(isOnboardingMilestone({ id: 'first_chat_sent', skippedAt: ts }), false);
-    }
-  });
-
-  it('rejects negative timestamps', () => {
-    assert.equal(isOnboardingMilestone({ id: 'first_chat_sent', completedAt: -1 }), false);
-    assert.equal(isOnboardingMilestone({ id: 'first_chat_sent', skippedAt: -1 }), false);
-  });
-
-  it('rejects string / boolean timestamps', () => {
-    for (const ts of ['1700000000000', '0', '', true, false]) {
-      assert.equal(
-        isOnboardingMilestone({ id: 'first_chat_sent', completedAt: ts } as unknown),
-        false,
-      );
-    }
-  });
-
-  it('rejects null / undefined / primitives / arrays / Date / Map / Set', () => {
-    for (const value of [
+    const invalid = [
       null,
-      undefined,
-      1,
-      'string',
-      true,
-      false,
       [],
-      [{ id: 'first_chat_sent' }],
       new Date(),
-      new Map(),
-      new Set(),
-    ]) {
-      assert.equal(isOnboardingMilestone(value), false, `should reject ${String(value)}`);
-    }
+      { id: 'unknown' },
+      { id: 'first_chat_sent', completedAt: 1, skippedAt: 2 },
+      { id: 'first_chat_sent', completedAt: -1 },
+      { id: 'first_chat_sent', completedAt: Infinity },
+      { id: 'first_chat_sent', completedAt: '1' },
+      { id: 'first_chat_sent', prompt: 'private user content' },
+    ];
+    for (const value of invalid) assert.equal(isOnboardingMilestone(value), false);
   });
 
-  it('accepts an entry from an Object.create(null) "plain" dict', () => {
-    const dict = Object.create(null) as Record<string, unknown>;
-    dict.id = 'first_chat_sent';
-    dict.completedAt = 1_700_000_000_000;
-    assert.equal(isOnboardingMilestone(dict), true);
+  it('accepts null-prototype records', () => {
+    const milestone = Object.create(null) as Record<string, unknown>;
+    milestone.id = 'first_chat_sent';
+    milestone.completedAt = 1;
+    assert.equal(isOnboardingMilestone(milestone), true);
   });
-});
 
-describe('sanitizeOnboardingMilestones', () => {
-  it('returns [] for non-array input (no value-digging)', () => {
-    for (const value of [
-      null,
-      undefined,
-      {},
-      { foo: { id: 'first_chat_sent' } },
-      'string',
-      42,
-      true,
-      false,
-    ]) {
+  it('sanitizes invalid entries with last-valid-value and first-seen-order semantics', () => {
+    const raw = [
+      { id: 'first_personalization', completedAt: 10 },
+      { id: 'first_chat_sent', completedAt: 1 },
+      { id: 'first_chat_sent', completedAt: 'invalid' },
+      { id: 'unknown', completedAt: 2 },
+      { id: 'first_chat_sent', skippedAt: 3 },
+      { id: 'first_personalization', completedAt: 11 },
+    ];
+    assert.deepEqual<OnboardingMilestone[]>(sanitizeOnboardingMilestones(raw), [
+      { id: 'first_personalization', completedAt: 11 },
+      { id: 'first_chat_sent', skippedAt: 3 },
+    ]);
+    for (const value of [null, {}, 'string', 42]) {
       assert.deepEqual(sanitizeOnboardingMilestones(value), []);
     }
   });
 
-  it('keeps valid entries, drops invalid ones (no fail-empty)', () => {
-    const result = sanitizeOnboardingMilestones([
-      { id: 'first_chat_sent', completedAt: 1_700_000_000_000 },
-      { id: 'first_personalization', completedAt: 'oops' }, // bad timestamp
-      { id: 'first_model_swap', skippedAt: 1_700_000_001_000 },
-      { id: 'first_artifact_open', completedAt: 1, skippedAt: 2 }, // both set
-      { id: 'unknown_id', completedAt: 1_700_000_000_000 }, // unknown id
-      { id: 'first_chat_sent', extra: 'leak' }, // extra field
-    ] as unknown[]);
-
-    assert.deepEqual<OnboardingMilestone[]>(result, [
-      { id: 'first_chat_sent', completedAt: 1_700_000_000_000 },
-      { id: 'first_model_swap', skippedAt: 1_700_000_001_000 },
-    ]);
-  });
-
-  it('de-duplicates by id, last valid entry wins (@kenji PR110a review)', () => {
-    // Milestone is a user-progress snapshot, not an audit log. Later
-    // valid entries reflect newer user intent. First-wins would let a
-    // bare `{ id }` placeholder erase a subsequent terminal transition.
-    const result = sanitizeOnboardingMilestones([
-      { id: 'first_chat_sent', completedAt: 1 },
-      { id: 'first_chat_sent', completedAt: 2 },
-      { id: 'first_chat_sent', skippedAt: 3 },
-    ]);
-    assert.deepEqual<OnboardingMilestone[]>(result, [{ id: 'first_chat_sent', skippedAt: 3 }]);
-  });
-
-  it('last-wins: placeholder followed by terminal entry → terminal entry survives', () => {
-    // {id} alone is the "unseen yet" placeholder; the user later
-    // completes it. Sanitize must NOT drop the completedAt.
-    const result = sanitizeOnboardingMilestones([
-      { id: 'first_chat_sent' },
-      { id: 'first_chat_sent', completedAt: 1_700_000_000_000 },
-    ]);
-    assert.deepEqual<OnboardingMilestone[]>(result, [
-      { id: 'first_chat_sent', completedAt: 1_700_000_000_000 },
-    ]);
-  });
-
-  it('last-wins: completed → skipped transition survives', () => {
-    const result = sanitizeOnboardingMilestones([
-      { id: 'first_chat_sent', completedAt: 1 },
-      { id: 'first_chat_sent', skippedAt: 2 },
-    ]);
-    assert.deepEqual<OnboardingMilestone[]>(result, [{ id: 'first_chat_sent', skippedAt: 2 }]);
-  });
-
-  it("output array position is the milestone's first-seen index", () => {
-    // Stable ordering across rewrites: ids appear in the order they
-    // first showed up, regardless of where the last-wins value came
-    // from.
-    const result = sanitizeOnboardingMilestones([
-      { id: 'first_personalization', completedAt: 10 },
-      { id: 'first_chat_sent', completedAt: 1 },
-      { id: 'first_chat_sent', completedAt: 2 }, // updates first_chat_sent
-      { id: 'first_personalization', completedAt: 11 }, // updates first_personalization
-    ]);
-    assert.deepEqual<OnboardingMilestone[]>(result, [
-      { id: 'first_personalization', completedAt: 11 },
-      { id: 'first_chat_sent', completedAt: 2 },
-    ]);
-  });
-
-  it('invalid duplicate is dropped, then last-wins applies to remaining valid entries', () => {
-    const result = sanitizeOnboardingMilestones([
-      { id: 'first_chat_sent', completedAt: 1 },
-      { id: 'first_chat_sent', completedAt: 'oops' }, // invalid — dropped
-      { id: 'first_chat_sent', completedAt: 3 }, // last valid
-    ] as unknown[]);
-    assert.deepEqual<OnboardingMilestone[]>(result, [{ id: 'first_chat_sent', completedAt: 3 }]);
-  });
-
-  it('returns [] when input is an empty array', () => {
-    assert.deepEqual(sanitizeOnboardingMilestones([]), []);
-  });
-});
-
-describe('hasSettledInitialOnboarding', () => {
-  it('returns false for empty milestones', () => {
-    assert.equal(hasSettledInitialOnboarding([]), false);
-  });
-
-  it('returns false when initial_onboarding is absent', () => {
-    assert.equal(hasSettledInitialOnboarding([{ id: 'first_chat_sent', completedAt: 1 }]), false);
-  });
-
-  it('returns false for a bare placeholder {id} without terminal timestamp', () => {
-    assert.equal(hasSettledInitialOnboarding([{ id: 'initial_onboarding' }]), false);
-  });
-
-  it('returns true when initial_onboarding has completedAt', () => {
-    assert.equal(hasSettledInitialOnboarding([{ id: 'initial_onboarding', completedAt: 1 }]), true);
-  });
-
-  it('returns true when initial_onboarding has skippedAt', () => {
-    assert.equal(hasSettledInitialOnboarding([{ id: 'initial_onboarding', skippedAt: 1 }]), true);
-  });
-
-  it('returns true alongside other milestones', () => {
-    assert.equal(
-      hasSettledInitialOnboarding([
-        { id: 'first_chat_sent', completedAt: 1 },
-        { id: 'initial_onboarding', completedAt: 2 },
-      ]),
-      true,
-    );
+  it('settles initial onboarding only on its completed or skipped terminal state', () => {
+    const cases: Array<[OnboardingMilestone[], boolean]> = [
+      [[], false],
+      [[{ id: 'first_chat_sent', completedAt: 1 }], false],
+      [[{ id: 'initial_onboarding' }], false],
+      [[{ id: 'initial_onboarding', completedAt: 1 }], true],
+      [[{ id: 'initial_onboarding', skippedAt: 1 }], true],
+    ];
+    for (const [milestones, expected] of cases) {
+      assert.equal(hasSettledInitialOnboarding(milestones), expected);
+    }
   });
 });

--- a/scripts/cu-provider-matrix.test.mjs
+++ b/scripts/cu-provider-matrix.test.mjs
@@ -112,17 +112,6 @@ function withLedgerCounts(report) {
   };
 }
 
-test('a valid real report passes the shared verdict', () => {
-  assert.deepEqual(
-    validateRealReport(
-      realReport(),
-      { id: 'openai', producer: 'cu-real-model-launcher', model: 'gpt-5.4' },
-      scenario(),
-    ),
-    [],
-  );
-});
-
 test('matrix generation never executes provider command templates', async () => {
   const directory = await mkdtemp(join(tmpdir(), 'cu-matrix-'));
   const marker = join(directory, 'executed');


### PR DESCRIPTION
## Summary
- consolidate artifact preview security and size-cap coverage into decision tables
- remove onboarding renderer source-shape/regex assertions and merge state-machine happy paths
- consolidate bot copy/command matrices and drop a duplicate CU provider happy-path test

## Impact
- 5 test files changed
- test declarations: 175 -> 45
- 450 additions / 1,724 deletions (net -1,274 lines)
- production code unchanged

## Verification
- `npm run build:test`
- `npm --workspace @maka/core run test:dist` (910 passed)
- direct Desktop dist suite (1,705 passed)
- `npm run test:scripts:full` (37 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

`npm --workspace @maka/desktop run test:dist` reaches an existing baseline `check-console` failure in `packages/runtime-host/src/server/host-kernel.ts:605`; the direct Desktop dist suite passes and this PR does not touch that file.
