### PR TITLE
test(runtime-host): make lifecycle races deterministic

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -30,6 +30,7 @@ import {
   classifyTerminalRuntimeLedger,
   commitTerminalRunWithRuntimeFact,
   FAKE_ASK_USER_QUESTION_PROMPT,
+  FAKE_WAIT_FOR_STEERING_PROMPT,
   type MakaTool,
   type MakaToolContext,
 } from '@maka/runtime';
@@ -1489,7 +1490,7 @@ test('steering becomes durable and ordered followups automatically start the nex
     await first.startTurn({
       sessionId: fixture.sessionId,
       turnId: firstTurnId,
-      content: { text: `long-running root ${'x'.repeat(540)}` },
+      content: { text: FAKE_WAIT_FOR_STEERING_PROMPT },
     });
     const steeringId = randomUUID();
     const steeringContent = {
@@ -1521,18 +1522,6 @@ test('steering becomes durable and ordered followups automatically start the nex
       },
     ];
 
-    assert.equal(
-      (
-        await second.request('turn.message.submit', {
-          originHostEpoch: host.hostEpoch,
-          sessionId: fixture.sessionId,
-          messageId: steeringId,
-          content: steeringContent,
-          placement: 'current_turn',
-        })
-      ).disposition,
-      'steering',
-    );
     for (const source of followupSources) {
       assert.equal(
         (
@@ -1546,6 +1535,18 @@ test('steering becomes durable and ordered followups automatically start the nex
         'followup',
       );
     }
+    assert.equal(
+      (
+        await second.request('turn.message.submit', {
+          originHostEpoch: host.hostEpoch,
+          sessionId: fixture.sessionId,
+          messageId: steeringId,
+          content: steeringContent,
+          placement: 'current_turn',
+        })
+      ).disposition,
+      'steering',
+    );
 
     assert.equal(
       (await waitForTerminalTurn(first, fixture.sessionId, firstTurnId)).status,

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { fork, type ChildProcess } from 'node:child_process';
+import { execFile, fork, type ChildProcess } from 'node:child_process';
 import {
   chmod,
   lstat,
@@ -18,6 +18,7 @@ import { connect, Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { describe, test } from 'node:test';
+import { promisify } from 'node:util';
 import { connectOrSpawnRuntimeHost, connectRuntimeHost } from '../client/index.js';
 import { connectOrSpawnRuntimeHostWithDependencies } from '../client/connect-or-spawn.js';
 import {
@@ -61,6 +62,7 @@ const CURRENT_PROTOCOL = {
 } as const;
 const LEGACY_PROTOCOL = { min: 1, max: 1 } as const;
 const require = createRequire(import.meta.url);
+const execFileAsync = promisify(execFile);
 
 describe('non-serving Runtime Host kernel', () => {
   test('elects one owner, serves status, and releases ownership after true-idle shutdown', async () => {
@@ -656,7 +658,7 @@ describe('non-serving Runtime Host kernel', () => {
 
         process.kill(attempt.pid, 'SIGSTOP');
         stopped = true;
-        await sleep(20);
+        await waitForProcessStopped(attempt.pid);
         await assert.rejects(
           () => connected.connection.status(50),
           (error: unknown) =>
@@ -685,7 +687,7 @@ describe('non-serving Runtime Host kernel', () => {
 
         process.kill(attempt.pid, 'SIGSTOP');
         stopped = true;
-        await sleep(20);
+        await waitForProcessStopped(attempt.pid);
         await withTimeout(
           reconnected.connection.close(),
           500,
@@ -795,7 +797,7 @@ describe('non-serving Runtime Host kernel', () => {
 
         process.kill(attempt.pid, 'SIGSTOP');
         stopped = true;
-        await sleep(20);
+        await waitForProcessStopped(attempt.pid);
         let launchCount = 0;
         const result = await withTimeout(
           connectOrSpawnRuntimeHostWithDependencies(
@@ -1783,6 +1785,17 @@ async function waitForProcessExit(pid: number, timeoutMs = 5_000): Promise<void>
   const deadline = Date.now() + timeoutMs;
   while (isProcessAlive(pid) && Date.now() < deadline) await sleep(20);
   if (isProcessAlive(pid)) throw new Error(`process ${pid} did not exit`);
+}
+
+async function waitForProcessStopped(pid: number, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { stdout } = await execFileAsync('ps', ['-o', 'state=', '-p', String(pid)]);
+    if (/^[Tt]/.test(stdout.trim())) return;
+    if (!isProcessAlive(pid)) throw new Error(`Process ${pid} exited before it stopped`);
+    await sleep(5);
+  }
+  throw new Error(`Process ${pid} did not enter a stopped state`);
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -833,182 +833,104 @@ test('successor admission failure retains the terminal transition and its confir
   }
 });
 
-test('shutdown re-scans a successor created by an in-flight terminal handoff', {
+test('shutdown contains a successor backend start rejected by Interaction drain', {
   timeout: 20_000,
 }, async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-root-turn-close-'));
-  const capability = await resolveStorageRoot({
-    path: join(base, 'root'),
-    kind: 'interactive',
-  });
-  const owner = await tryAcquireInteractiveRootOwner(capability);
-  assert.ok(owner);
-  if (!owner) throw new Error('Unable to acquire test root');
-
-  try {
-    const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
-    const session = await stores.sessionStore.create({
-      cwd: capability.canonicalPath,
-      backend: 'fake',
-      llmConnectionSlug: 'fake',
-      model: 'fake-model',
-      permissionMode: 'ask',
-    });
-    const followupAdmissionStarted = deferred<void>();
-    const releaseFollowupAdmission = deferred<void>();
-    const admissionStore: RootTurnAdmissionStore = {
+  const followupAdmissionStarted = deferred<void>();
+  const releaseFollowupAdmission = deferred<void>();
+  let backend: LinkedChildAuthorityBackend | undefined;
+  const fixture = await createFailureFixture({
+    withInteractions: true,
+    wrapAdmissionStore: (store) => ({
       admitRootTurn: async (input) => {
         if (input.previousRootTurnId !== null) {
           followupAdmissionStarted.resolve();
           await releaseFollowupAdmission.promise;
         }
-        return stores.agentRunStore.admitRootTurn(input);
+        return store.admitRootTurn(input);
       },
-      readRootTurnAdmission: (sessionId, turnId) =>
-        stores.agentRunStore.readRootTurnAdmission(sessionId, turnId),
+      readRootTurnAdmission: (sessionId, turnId) => store.readRootTurnAdmission(sessionId, turnId),
       readRootTurnSourceMessageReceipt: (sessionId, messageId) =>
-        stores.agentRunStore.readRootTurnSourceMessageReceipt(sessionId, messageId),
+        store.readRootTurnSourceMessageReceipt(sessionId, messageId),
       listRootTurnAdmissionsForRecovery: (sessionId) =>
-        stores.agentRunStore.listRootTurnAdmissionsForRecovery(sessionId),
-    };
-    const rootAdmissionOwner = new RootAdmissionOwner(admissionStore);
-    await rootAdmissionOwner.recoverSession(session.id);
+        store.listRootTurnAdmissionsForRecovery(sessionId),
+    }),
+    registerBackend: (backends) => {
+      backends.register('fake', (context) => {
+        backend = new LinkedChildAuthorityBackend(context.sessionId);
+        return backend;
+      });
+    },
+  });
+  let closed = false;
 
-    let liveResidencies = 0;
-    const acquireResidency = (): RuntimeHostResidency => {
-      liveResidencies += 1;
-      let released = false;
-      return {
-        release: () => {
-          assert.equal(released, false);
-          released = true;
-          liveResidencies -= 1;
-        },
-      };
-    };
-    const sessionAdmission = new SessionAdmissionGate();
-    let coordinator: RootTurnCoordinator | undefined;
-    let continuity: SessionContinuityCoordinator | undefined;
-    let canonicalProjection: CanonicalSessionProjectionReader | undefined;
-    const rootPort: HostMessageRootPort = {
-      readSessionHeader: (sessionId) =>
-        requireCoordinator(coordinator).readSessionHeader(sessionId),
-      readRootState: (sessionId) => requireCoordinator(coordinator).readRootState(sessionId),
-      claimStopFence: (input, commitQueueFence, admission) =>
-        requireCoordinator(coordinator).claimStopFence(input, commitQueueFence, admission),
-      startFromMessage: (input, admission) =>
-        requireCoordinator(coordinator).startFromMessage(input, admission),
-      claimStop: (input, commitQueueFence, admission) =>
-        requireCoordinator(coordinator).claimStop(input, commitQueueFence, admission),
-    };
-    const hostEpoch = 'epoch-close-handoff';
-    await stores.messageReceiptStore.beginHostEpoch(hostEpoch);
-    const messages = new HostMessageCoordinator({
-      hostEpoch,
-      root: rootPort,
-      durableProof: {
-        readRootTurnSourceMessageReceipt: (sessionId, messageId) =>
-          stores.agentRunStore.readRootTurnSourceMessageReceipt(sessionId, messageId),
-        readImmutableSteeringMessageProof: (sessionId, messageId) =>
-          stores.runtimeEventStore.readImmutableSteeringMessageProof(sessionId, messageId),
-      },
-      receipts: stores.messageReceiptStore,
-      sessionAdmission,
-      acquireResidency,
-      preflightSessionSnapshot: (sessionId, candidate) =>
-        requireCanonicalProjection(canonicalProjection).fitsCandidate(sessionId, candidate),
-      onProjectionChanged: (sessionId) =>
-        requireContinuity(continuity).enqueueCanonicalRefresh(sessionId),
-    });
-    const canonicalProjectionReader = new CanonicalSessionProjectionReader({
-      stores,
-      rootAdmissions: rootAdmissionOwner,
-      messages,
-    });
-    canonicalProjection = canonicalProjectionReader;
-    continuity = new SessionContinuityCoordinator(
-      hostEpoch,
-      (sessionId) => canonicalProjectionReader.read(sessionId),
-      sessionAdmission,
-    );
-    const backends = new BackendRegistry();
-    backends.register('fake', (context) => new FakeBackend(context));
-    const manager = new SessionManager({
-      store: stores.sessionStore,
-      runStore: stores.agentRunStore,
-      runtimeEventStore: stores.runtimeEventStore,
-      backends,
-      newId: randomUUID,
-      now: Date.now,
-      messageAuthority: messages,
-    });
-    let drainRequested = false;
-    coordinator = new RootTurnCoordinator(
-      manager,
-      stores,
-      sessionAdmission,
-      rootAdmissionOwner,
-      {
-        assertTerminalFence: async () => undefined,
-        claimRunClosure: async () => undefined,
-      },
-      messages,
-      continuity,
-      acquireResidency,
-      () => {
-        drainRequested = true;
-      },
-    );
-
+  try {
     const firstTurnId = 'turn-close-first';
-    const started = await coordinator.handlers['turn.start'](
+    const started = await fixture.coordinator.handlers['turn.start'](
       {
-        sessionId: session.id,
+        sessionId: fixture.sessionId,
         turnId: firstTurnId,
-        content: { text: `long-running root ${'x'.repeat(540)}` },
+        content: { text: HOLD_EXTERNAL_PROMPT },
       },
-      operationContext(hostEpoch, acquireResidency),
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
     );
     assert.equal(started.ok, true);
-    const followup = await messages.handlers['turn.message.submit'](
+    assert.ok(backend);
+    assert.ok(fixture.interactions);
+    await completesWithin(backend.externalHoldStarted.promise, 2_000, 'held root start');
+
+    const followup = await fixture.messages.handlers['turn.message.submit'](
       {
-        originHostEpoch: hostEpoch,
-        sessionId: session.id,
+        originHostEpoch: fixture.hostEpoch,
+        sessionId: fixture.sessionId,
         messageId: 'message-close-followup',
-        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+        content: { text: 'start successor while shutdown drains Interaction authority' },
         placement: 'next_turn',
       },
-      operationContext(hostEpoch, acquireResidency),
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
     );
     assert.equal(followup.ok && followup.result.disposition, 'followup');
 
-    await followupAdmissionStarted.promise;
-    messages.beginDrain();
-    const closing = coordinator.close();
-    assert.equal(await settlesWithin(closing, 25), false);
+    backend.release();
+    await completesWithin(followupAdmissionStarted.promise, 2_000, 'successor root admission');
+    fixture.messages.beginDrain();
+    fixture.interactions.beginDrain();
+    const closing = fixture.coordinator.close();
     releaseFollowupAdmission.resolve();
-    await closing;
-    await messages.close();
-    continuity.close();
+    await completesWithin(closing, 2_000, 'root close after successor admission');
+    await fixture.messages.close();
+    await fixture.interactions.close();
+    closed = true;
 
-    assert.deepEqual(coordinator.readRootState(session.id), { kind: 'idle' });
-    assert.equal(liveResidencies, 0);
-    assert.equal(drainRequested, false);
-    const admissions = await stores.agentRunStore.listRootTurnAdmissionsForRecovery(session.id);
+    assert.deepEqual(fixture.coordinator.readRootState(fixture.sessionId), { kind: 'idle' });
+    assert.equal(fixture.liveResidencies(), 0);
+    assert.equal(fixture.drainRequested(), false);
+    assert.equal(fixture.interactions.isPoisoned(), false);
+    const admissions = await fixture.stores.agentRunStore.listRootTurnAdmissionsForRecovery(
+      fixture.sessionId,
+    );
     assert.equal(admissions.length, 2);
     const successor = admissions[1];
     assert.ok(successor);
-    const run = await stores.agentRunStore.readRun(session.id, successor.runId);
-    const runtimeEvents = await stores.runtimeEventStore.readImmutableRuntimeEvents(
-      session.id,
+    const run = await fixture.stores.agentRunStore.readRun(fixture.sessionId, successor.runId);
+    const runtimeEvents = await fixture.stores.runtimeEventStore.readImmutableRuntimeEvents(
+      fixture.sessionId,
       successor.runId,
     );
     const terminal = classifyTerminalRuntimeLedger(run, runtimeEvents);
     assert.equal(terminal.kind, 'fact');
     if (terminal.kind === 'fact') assert.equal(terminal.fact.runStatus, 'cancelled');
   } finally {
-    await owner.close();
-    await rm(base, { recursive: true, force: true });
+    releaseFollowupAdmission.resolve();
+    backend?.release();
+    if (!closed) {
+      await Promise.allSettled([
+        fixture.coordinator.close(),
+        fixture.messages.close(),
+        fixture.interactions?.close(),
+      ]);
+    }
+    await fixture.dispose();
   }
 });
 
@@ -1803,7 +1725,7 @@ test('Runtime stop lets a running admission publish before its exact-Run closure
     const stopping = fixture.manager.stopSession(fixture.sessionId, {
       source: 'stop_button',
     });
-    assert.equal(await settlesWithin(stopping, 25), false);
+    await completesWithin(backend.stopRequested.promise, 2_000, 'Runtime stop request');
     releasePreflight.resolve();
 
     await completesWithin(backend.admitted.promise, 2_000, 'running admission completion');
@@ -2597,16 +2519,6 @@ class ObservableSessionAdmissionGate extends SessionAdmissionGate {
   }
 }
 
-async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
-  return Promise.race([
-    promise.then(
-      () => true,
-      () => true,
-    ),
-    new Promise<false>((resolve) => setTimeout(resolve, timeoutMs, false)),
-  ]);
-}
-
 async function waitUntil(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
@@ -2617,6 +2529,7 @@ async function waitUntil(predicate: () => boolean, timeoutMs = 2_000): Promise<v
 
 class LinkedChildAuthorityBackend implements AgentBackend {
   readonly kind = 'fake' as const;
+  readonly externalHoldStarted = deferred<void>();
   sendCount = 0;
   stopCount = 0;
   private stopped = false;
@@ -2630,6 +2543,7 @@ class LinkedChildAuthorityBackend implements AgentBackend {
     if (input.text === HOLD_EXTERNAL_PROMPT) {
       await new Promise<void>((resolve) => {
         this.releaseWait = resolve;
+        this.externalHoldStarted.resolve();
       });
     }
     if (input.text === FAKE_ASK_USER_QUESTION_PROMPT) {
@@ -2846,6 +2760,7 @@ class StopReleasedAdmissionBackend implements AgentBackend {
 class RunningAdmissionBackend implements AgentBackend {
   readonly kind = 'fake' as const;
   readonly admitted = deferred<void>();
+  readonly stopRequested = deferred<void>();
   readonly closureReasons: string[] = [];
   private readonly settled = deferred<void>();
 
@@ -2904,7 +2819,9 @@ class RunningAdmissionBackend implements AgentBackend {
     };
   }
 
-  async stop(): Promise<void> {}
+  async stop(): Promise<void> {
+    this.stopRequested.resolve();
+  }
 
   async respondToSandboxBoundary(): Promise<void> {}
 

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { inspect } from 'node:util';
 import { createServer, type Server, type Socket } from 'node:net';
 import {
   assertInteractiveRootOwner,
@@ -594,16 +593,10 @@ export class RuntimeHostKernel {
     await this.#options.owner.close().catch((error: unknown) => errors.push(error));
     this.#assertShutdownCanContinue();
     if (errors.length > 0) {
-      const aggregate = new AggregateError(
+      throw new AggregateError(
         errors,
         'Runtime Host shutdown did not cleanly close every resource',
       );
-      // The default uncaught-error printer truncates nested AggregateErrors to
-      // `[errors]: [Array]`, which leaves the actual resource failure
-      // undiagnosable. Print the full structure so the failing close step is
-      // visible in Host stderr.
-      console.error('Runtime Host shutdown failure:', inspect(aggregate, { depth: null }));
-      throw aggregate;
     }
   }
 

--- a/packages/runtime/src/fake-backend.ts
+++ b/packages/runtime/src/fake-backend.ts
@@ -16,6 +16,7 @@ import type { SessionStore } from './session-manager.js';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 export const FAKE_ASK_USER_QUESTION_PROMPT = '__e2e_ask_user_question__';
+export const FAKE_WAIT_FOR_STEERING_PROMPT = '__e2e_wait_for_steering__';
 
 type PendingQuestion = {
   turnId: string;
@@ -97,6 +98,18 @@ export class FakeBackend implements AgentBackend {
     };
 
     try {
+      if (input.text === FAKE_WAIT_FOR_STEERING_PROMPT) {
+        let pending = drainSteering();
+        while (pending.length === 0 && !this.stopped) {
+          await sleep(5);
+          pending = drainSteering();
+        }
+        for (const { leaseId, event } of pending) {
+          yield event;
+          settleOutstanding(leaseId);
+        }
+      }
+
       for (const chunk of chunks) {
         if (this.stopped) {
           yield { type: 'abort', id: randomUUID(), turnId, ts: Date.now(), reason: 'user_stop' };
@@ -109,7 +122,7 @@ export class FakeBackend implements AgentBackend {
           };
           return;
         }
-        await sleep(45);
+        if (input.text !== FAKE_WAIT_FOR_STEERING_PROMPT) await sleep(45);
         for (const { leaseId, event } of drainSteering()) {
           yield event;
           settleOutstanding(leaseId);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1055,7 +1055,11 @@ export { materializeSession, applyAppendedMessage, setToolStatus } from './mater
 export type { ToolActivityItem, ChatItem, SessionViewModel } from './materializer.js';
 
 export { AsyncEventQueue } from './async-queue.js';
-export { FAKE_ASK_USER_QUESTION_PROMPT, FakeBackend } from './fake-backend.js';
+export {
+  FAKE_ASK_USER_QUESTION_PROMPT,
+  FAKE_WAIT_FOR_STEERING_PROMPT,
+  FakeBackend,
+} from './fake-backend.js';
 
 export {
   BUILTIN_PRICING,


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Replace response-length-based Turn liveness with an explicit steering-gated Fake backend scenario.
- Deterministically cover Host drain while a committed follow-up enters backend and Interaction startup.
- Replace a short negative-time assertion and fixed sleeps after `SIGSTOP` with observable lifecycle checkpoints.
- Remove the temporary unbounded shutdown error dump.

## Why

#1760 fixed a real shutdown race, but the surrounding regression coverage still depended on scheduler timing. The same execution-host test could also finish before its messages were admitted and fail with `session_busy`.

These tests now coordinate through steering leases, admission barriers, backend stop observation, and the operating system's process state. Timeouts remain only as final failure bounds.

## Validation

- Shutdown/startup race: 20 consecutive passes.
- Steering/follow-up race: 20 consecutive passes.
- `@maka/runtime-host`: 445/445 tests passed.
- Fake backend tests: 6/6 passed.
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`

Closes #1771.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 用显式的 steering gate Fake backend 场景替代依赖响应长度维持 Turn 活跃的做法。
- 确定性覆盖已提交 follow-up 进入 backend 与 Interaction startup 时发生 Host drain 的场景。
- 用可观察的 lifecycle checkpoint 替代短时间负向断言以及 `SIGSTOP` 后的固定 sleep。
- 删除临时加入的无限深度 shutdown error dump。

## 原因

#1760 修复了真实的 shutdown 竞态，但周边回归测试仍依赖调度时序。同一个 execution-host 测试也可能在消息完成 admission 之前结束，并以 `session_busy` 失败。

现在测试通过 steering lease、admission barrier、backend stop 观察和操作系统进程状态进行同步；timeout 只保留为最终失控保护。

## 验证

- Shutdown/startup 竞态：连续通过 20 次。
- Steering/follow-up 竞态：连续通过 20 次。
- `@maka/runtime-host`：445/445 通过。
- Fake backend 测试：6/6 通过。
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`

关闭 #1771。

</details>
