### PR TITLE
test: prune redundant search and UI coverage

### DIFF
--- a/apps/desktop/src/main/__tests__/antigravity-subscription-service.test.ts
+++ b/apps/desktop/src/main/__tests__/antigravity-subscription-service.test.ts
@@ -1,84 +1,19 @@
-/**
- * Static-analysis + unit tests for the Antigravity (Google /
- * Gemini) subscription OAuth service.
- *
- * We pin:
- *   - the loopback port (51121)
- *   - the `STATUS = 'preview'` marker
- *   - the fail-closed envelope when GOOGLE_CLIENT_ID is empty
- *     (the entire point of this preview service is that real
- *     calls must surface a clear, copy-paste-ready error so a
- *     future review catches an accidental enable).
- *
- * The service receives its Electron-only URL opener as a dependency,
- * so the preview's public behavior can run under plain `node --test`.
- */
-
 import { strict as assert } from 'node:assert';
-import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
-import { resolve } from 'node:path';
 import {
   ANTIGRAVITY_MISSING_CLIENT_ID_ENVELOPE,
   ANTIGRAVITY_OAUTH_CONFIG,
   GOOGLE_CLIENT_ID,
-  STATUS,
   buildAntigravityAuthorizationUrl,
 } from '../oauth/antigravity-subscription-helpers.js';
 import { AntigravitySubscriptionService } from '../oauth/antigravity-subscription-service.js';
 
-const REPO_ROOT = resolve(process.cwd(), '..', '..');
-const SERVICE_SOURCE = resolve(
-  REPO_ROOT,
-  'apps',
-  'desktop',
-  'src',
-  'main',
-  'oauth',
-  'antigravity-subscription-service.ts',
-);
-describe('Antigravity subscription preview config', () => {
-  it('stays in preview status', () => {
-    assert.equal(STATUS, 'preview');
-    assert.equal(ANTIGRAVITY_OAUTH_CONFIG.status, 'preview');
-  });
-
-  it('uses port 51121 for the loopback callback', () => {
-    assert.equal(ANTIGRAVITY_OAUTH_CONFIG.callbackPort, 51121);
-    assert.equal(
-      ANTIGRAVITY_OAUTH_CONFIG.redirectUri,
-      'http://localhost:51121/callback',
-    );
-  });
-
-  it('targets Google OAuth endpoints', () => {
-    assert.equal(
-      ANTIGRAVITY_OAUTH_CONFIG.authUrl,
-      'https://accounts.google.com/o/oauth2/v2/auth',
-    );
-    assert.equal(ANTIGRAVITY_OAUTH_CONFIG.tokenUrl, 'https://oauth2.googleapis.com/token');
-  });
-
-  it('marks itself as not configured because no Google client_id is bundled', () => {
+describe('Antigravity subscription preview', () => {
+  it('keeps the unconfigured preview on the standard Google PKCE flow', () => {
     assert.equal(GOOGLE_CLIENT_ID, '');
-    assert.equal(
-      ANTIGRAVITY_OAUTH_CONFIG.hasClientId,
-      false,
-      'a future PR must explicitly flip GOOGLE_CLIENT_ID; CI should catch any silent fill-in',
-    );
-  });
+    assert.equal(ANTIGRAVITY_OAUTH_CONFIG.status, 'preview');
+    assert.equal(ANTIGRAVITY_OAUTH_CONFIG.hasClientId, false);
 
-  it('exposes a clear "needs Google client_id" envelope as a pure constant', () => {
-    assert.equal(ANTIGRAVITY_MISSING_CLIENT_ID_ENVELOPE.ok, false);
-    assert.equal(ANTIGRAVITY_MISSING_CLIENT_ID_ENVELOPE.reason, 'unknown');
-    assert.match(
-      ANTIGRAVITY_MISSING_CLIENT_ID_ENVELOPE.message,
-      /Google client_id/,
-      'error copy must call out the missing client_id so the user knows why',
-    );
-  });
-
-  it('built authorize URL carries access_type=offline + prompt=consent (standard Google PKCE)', () => {
     const url = new URL(
       buildAntigravityAuthorizationUrl({
         clientId: 'fixture-client',
@@ -89,16 +24,15 @@ describe('Antigravity subscription preview config', () => {
         challenge: 'pinned-challenge',
       }),
     );
+    assert.equal(url.origin, 'https://accounts.google.com');
     assert.equal(url.searchParams.get('response_type'), 'code');
     assert.equal(url.searchParams.get('access_type'), 'offline');
     assert.equal(url.searchParams.get('prompt'), 'consent');
     assert.equal(url.searchParams.get('code_challenge_method'), 'S256');
     assert.equal(url.searchParams.get('state'), 'pinned-state');
   });
-});
 
-describe('Antigravity service contract', () => {
-  it('fails closed through the public authorization API when no Google client_id is bundled', async () => {
+  it('fails closed through the public API while no client id is bundled', async () => {
     const service = new AntigravitySubscriptionService({
       userDataDir: '/unused',
       openExternal: async () => undefined,
@@ -109,14 +43,9 @@ describe('Antigravity service contract', () => {
       },
     });
 
-    assert.deepEqual(
-      await service.getAuthorizationUrl(),
-      ANTIGRAVITY_MISSING_CLIENT_ID_ENVELOPE,
-    );
-  });
-
-  it('uses globalThis.fetch by default so Electron session proxy applies', async () => {
-    const src = await readFile(SERVICE_SOURCE, 'utf8');
-    assert.match(src, /globalThis\.fetch/);
+    const result = await service.getAuthorizationUrl();
+    assert.deepEqual(result, ANTIGRAVITY_MISSING_CLIENT_ID_ENVELOPE);
+    assert.equal(result.ok, false);
+    assert.match(result.message, /Google client_id/);
   });
 });

--- a/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
@@ -8,10 +8,6 @@ const repoRoot = process.cwd().endsWith('apps/desktop')
   ? join(process.cwd(), '..', '..')
   : process.cwd();
 
-async function readRepo(path: string): Promise<string> {
-  return readFile(join(repoRoot, path), 'utf8');
-}
-
 function extractChannels(source: string, pattern: RegExp): string[] {
   return [...source.matchAll(pattern)].map((match) => match[1]).sort();
 }
@@ -20,99 +16,23 @@ describe('IPC surface contract', () => {
   it('keeps main handlers paired with preload invocations', async () => {
     const [main, preload] = await Promise.all([
       readMainProcessCombinedSource(),
-      readRepo('apps/desktop/src/preload/preload.ts'),
+      readFile(join(repoRoot, 'apps/desktop/src/preload/preload.ts'), 'utf8'),
     ]);
-    const mainChannels = extractChannels(main, /ipcMain\.handle\(\s*['"]([^'"]+)['"]/g);
-    const preloadChannels = extractChannels(preload, /ipcRenderer\.invoke\(\s*['"]([^'"]+)['"]/g);
-    const mainSet = new Set(mainChannels);
-    const preloadSet = new Set(preloadChannels);
-    const missingMainHandlers = preloadChannels.filter((channel) => !mainSet.has(channel));
-    const staleMainHandlers = mainChannels.filter((channel) => !preloadSet.has(channel));
-
-    assert.deepEqual(missingMainHandlers, [], 'every preload invoke channel must have a main handler');
-    assert.deepEqual(staleMainHandlers, [], 'main process must not expose stale invoke handlers outside the preload bridge');
-  });
-
-  it('exposes the bounded graph read model without renderer execution authority', async () => {
-    const [main, preload, bridge] = await Promise.all([
-      readMainProcessCombinedSource(),
-      readRepo('apps/desktop/src/preload/preload.ts'),
-      readRepo('apps/desktop/src/preload/bridge-contract.d.ts'),
-    ]);
-    for (const channel of [
-      'graphs:getSnapshot',
-      'graphs:inspectOperator',
-      'graphs:stop',
-    ]) {
-      assert.match(main, new RegExp(`ipcMain\\.handle\\(\\s*['"]${channel}['"]`));
-      assert.match(preload, new RegExp(`ipcRenderer\\.invoke\\(\\s*['"]${channel}['"]`));
-    }
-    assert.match(main, /coordinator\.subscribeAll/);
-    assert.match(preload, /payload\.rootSessionId === rootSessionId/);
-    assert.match(bridge, /AgentGraphClientSnapshot/);
-    assert.match(bridge, /AgentGraphOperatorInspection/);
-    assert.doesNotMatch(bridge, /AgentGraphScheduleControlStore|RuntimeEventStore/);
-  });
-
-  it('exposes memory lifecycle IPC without renderer-forged metadata', async () => {
-    const [main, preload] = await Promise.all([
-      readMainProcessCombinedSource(),
-      readRepo('apps/desktop/src/preload/preload.ts'),
-    ]);
-    for (const channel of [
-      'memory:listProposals',
-      'memory:propose',
-      'memory:remember',
-      'memory:approveProposal',
-      'memory:rejectProposal',
-      'memory:archiveEntry',
-      'memory:restoreEntry',
-    ]) {
-      assert.match(main, new RegExp(`ipcMain\\.handle\\('${channel}'`));
-      assert.match(preload, new RegExp(`ipcRenderer\\.invoke\\('${channel}'`));
-    }
-
-    const normalizeBlock = main.match(/function normalizeMemoryTextInput[\s\S]*?\n}\n\nfunction localMemoryOpenFailureCopy/)?.[0] ?? '';
-    assert.match(normalizeBlock, /title/);
-    assert.match(normalizeBlock, /content/);
-    assert.match(normalizeBlock, /scope/);
-    assert.doesNotMatch(normalizeBlock, /confirmedAt|status|sourceTurnId|source:/);
-  });
-
-  it('wires memory to main-owned privacy state and current-turn update tail', async () => {
-    const [main, combinedMainProcess] = await Promise.all([
-      readRepo('apps/desktop/src/main/main.ts'),
-      readMainProcessCombinedSource(),
-    ]);
-
-    assert.match(main, /async function getWorkspacePrivacyContext\(\)/);
-    assert.match(main, /settings\.privacy\.incognitoActive === true/);
-    assert.match(main, /new LocalMemoryService\([\s\S]*getPrivacyContext: getWorkspacePrivacyContext/);
-    assert.doesNotMatch(main, /defaultWorkspacePrivacyContext/);
-
-    // The ai-sdk backend wiring lives in session-stream.ts and its shared tool
-    // surface resolver; these pins target the combined main-process source.
-    assert.match(
-      combinedMainProcess,
-      /systemPrompt: async \(\{ cwd, emitSkillCatalogTrace \}\) => \{/,
+    const mainChannels = new Set(
+      extractChannels(main, /ipcMain\.handle\(\s*['"]([^'"]+)['"]/g),
     );
-    assert.match(combinedMainProcess, /const base = await systemPromptService\.buildBackendSystemPrompt\([\s\S]*ctx\.header,[\s\S]*cwd,[\s\S]*childInstruction: ctx\.systemPrompt/);
-    assert.match(combinedMainProcess, /async function buildBackendSystemPrompt/);
-    assert.match(combinedMainProcess, /childInstruction[\s\S]*memoryFragment: null, includePersonalization: false/);
-    assert.match(combinedMainProcess, /子代理必须继承当前会话的权限、隐私、工作区和技能约束/);
-    assert.match(combinedMainProcess, /子代理不会隐式继承父会话的本地记忆或个性化上下文/);
-    assert.match(combinedMainProcess, /<memory-update>/);
-    assert.match(
-      combinedMainProcess,
-      /const unscopedCandidateTools = input\.tools\s+\? \[\.\.\.input\.tools\]\s+: deps\.isComputerUseRealModelE2e/,
+    const preloadChannels = new Set(
+      extractChannels(preload, /ipcRenderer\.invoke\(\s*['"]([^'"]+)['"]/g),
     );
-    assert.match(
-      combinedMainProcess,
-      /const candidateTools =\s+!input\.tools && isDeepResearchSession\(input\.header\.labels\)\s+\? unscopedCandidateTools\.filter\(isDeepResearchToolAllowed\)\s+: unscopedCandidateTools/,
+    assert.deepEqual(
+      [...preloadChannels].filter((channel) => !mainChannels.has(channel)),
+      [],
+      'every preload invoke channel must have a main handler',
     );
-    assert.match(
-      combinedMainProcess,
-      /const planControlTools = input\.tools\s+\? \[\]\s+: collaborationMode === 'plan'/,
+    assert.deepEqual(
+      [...mainChannels].filter((channel) => !preloadChannels.has(channel)),
+      [],
+      'main process must not expose stale invoke handlers outside the preload bridge',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/redact.test.ts
+++ b/apps/desktop/src/main/__tests__/redact.test.ts
@@ -1,117 +1,40 @@
-/**
- * Tests for @maka/ui defensive secret redactor. Lives in the desktop
- * workspace because that's where node:test is already wired up; the
- * subject under test is the renderer-facing helper at
- * `packages/ui/src/redact.ts`, imported through the @maka/ui public API.
- *
- * These tests pin the invariants @kenji asked for in the personalization /
- * tool-error security review:
- *   - Authorization header / Bearer / Basic / Token mask the value
- *   - URL query params with secret-like keys mask the value, preserve
- *     host / path / other params
- *   - Provider key prefixes (sk-, sk-ant-, AIza, ghp_/gho_/ghu_/ghs_/ghr_,
- *     xox[abprs]-) are masked
- *   - X-API-Key / api-key HTTP header forms mask the value
- *   - Long high-entropy hex/base64 strings (40+) are masked as catch-all
- *   - Plain prose passes through unchanged
- */
-
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { redactSecrets } from '@maka/ui';
 
 describe('redactSecrets', () => {
-  it('masks Authorization: Bearer token', () => {
-    const out = redactSecrets('Authorization: Bearer sk-ant-api03-abc123def456ghi789jkl0mn1opq');
-    assert.match(out, /Authorization: Bearer <redacted>/);
-    assert.doesNotMatch(out, /sk-ant-api03/);
-  });
-
-  it('masks Authorization: Basic credentials', () => {
-    const out = redactSecrets('Authorization: Basic dXNlcjpwYXNzd29yZA==');
-    assert.match(out, /Basic <redacted>/);
-    assert.doesNotMatch(out, /dXNlcjpwYXNz/);
-  });
-
-  it('masks X-API-Key HTTP header but preserves header name + surrounding URL', () => {
-    const input = 'curl -H "X-API-Key: 1234567890abcdef1234567890abcdef" https://x.com/path';
-    const out = redactSecrets(input);
-    assert.match(out, /X-API-Key: <redacted>/);
-    assert.doesNotMatch(out, /1234567890abcdef1234567890abcdef/);
-    assert.match(out, /https:\/\/x\.com\/path/);
-  });
-
-  it('masks ?api_key= URL query value only, preserves host / path / other params', () => {
-    const input = 'https://api.example.com/v1/chat?model=gpt-4o&api_key=secret123abc&user=alice&max_tokens=2048';
-    const out = redactSecrets(input);
-    // Secret value is masked
-    assert.doesNotMatch(out, /secret123abc/);
-    // Host + path preserved
-    assert.match(out, /https:\/\/api\.example\.com\/v1\/chat/);
-    // Other params preserved
-    assert.match(out, /model=gpt-4o/);
-    assert.match(out, /user=alice/);
-    assert.match(out, /max_tokens=2048/);
-    // Secret param uses the URL-query replacement form. In this input
-    // `api_key` follows `&`, not `?`, so we assert against either delimiter.
-    assert.match(out, /[?&]api_key=<redacted>/);
-  });
-
-  it('masks various URL query secret-key spellings', () => {
-    const cases = [
-      ['?access_token=abc', /access_token=<redacted>/],
-      ['&token=abc', /&token=<redacted>/],
-      ['?secret=abc', /\?secret=<redacted>/],
-      ['?signature=abc', /\?signature=<redacted>/],
-      ['?apikey=abc', /\?apikey=<redacted>/],
-      ['?api-key=abc', /\?api-key=<redacted>/],
-    ] as const;
-    for (const [input, expect] of cases) {
-      assert.match(redactSecrets(`https://x.com/p${input}&keep=ok`), expect, `failed for ${input}`);
-    }
-  });
-
-  it('masks OpenAI / Anthropic / Google / GitHub / Slack provider key prefixes', () => {
-    const inputs = [
-      'use sk-proj-abcdefghijklmnopqrstuvwxyz1234567890abcdef as your key',
-      'Anthropic: sk-ant-api03-aabbccddeeffgghhiijjkk1122334455',
-      'Google AIzaSyDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-      'gh ghp_abcdefghijklmnopqrstuvwxyz1234567890abcd',
-      'slack xoxb-1234567890-abcdefghijklmnopqrstuvwx',
+  it('masks credential headers, query parameters, provider keys, and high-entropy tokens', () => {
+    const cases: Array<[string, RegExp]> = [
+      ['Authorization: Bearer sk-ant-api03-abc123def456ghi789jkl0mn1opq', /Bearer <redacted>/],
+      ['Authorization: Basic dXNlcjpwYXNzd29yZA==', /Basic <redacted>/],
+      ['X-API-Key: 1234567890abcdef1234567890abcdef', /X-API-Key: <redacted>/],
+      ['https://x.com/p?access_token=abc&keep=ok', /access_token=<redacted>/],
+      ['https://x.com/p?api-key=abc&keep=ok', /api-key=<redacted>/],
+      ['use sk-proj-abcdefghijklmnopqrstuvwxyz1234567890abcdef', /<redacted>/],
+      ['Anthropic sk-ant-api03-aabbccddeeffgghhiijjkk1122334455', /<redacted>/],
+      ['Google AIzaSyDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', /<redacted>/],
+      ['GitHub ghp_abcdefghijklmnopqrstuvwxyz1234567890abcd', /<redacted>/],
+      ['Slack xoxb-1234567890-abcdefghijklmnopqrstuvwx', /<redacted>/],
+      [`hash=${'deadbeef'.repeat(6)}`, /hash=<redacted>/],
     ];
-    for (const input of inputs) {
-      const out = redactSecrets(input);
-      assert.match(out, /<redacted>/, `expected mask in: ${out}`);
-      // Sanity: the original raw token should not survive verbatim
-      assert.doesNotMatch(out, /sk-proj-abcdefghijklmn/);
-      assert.doesNotMatch(out, /sk-ant-api03-aabbccdd/);
-      assert.doesNotMatch(out, /AIzaSyDxxxxxxxxx/);
-      assert.doesNotMatch(out, /ghp_abcdefghij/);
-      assert.doesNotMatch(out, /xoxb-1234567890-abcdef/);
+    for (const [input, expected] of cases) {
+      const output = redactSecrets(input);
+      assert.match(output, expected, input);
+      assert.notEqual(output, input, input);
     }
   });
 
-  it('masks long high-entropy hex/base64 strings (40+ chars) as catch-all', () => {
-    const hash = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
-    const out = redactSecrets(`hash=${hash}`);
-    assert.match(out, /hash=<redacted>/);
-    assert.doesNotMatch(out, /deadbeefdeadbeefdeadbeef/);
-  });
+  it('preserves non-secret URL context and ordinary text', () => {
+    const url = redactSecrets(
+      'https://api.example.com/v1/chat?model=gpt-4o&api_key=secret123abc&user=alice',
+    );
+    assert.equal(url.includes('secret123abc'), false);
+    assert.match(url, /https:\/\/api\.example\.com\/v1\/chat/);
+    assert.match(url, /model=gpt-4o/);
+    assert.match(url, /user=alice/);
 
-  it('leaves plain text untouched', () => {
-    const inputs = [
-      'Connection refused',
-      'Request timed out',
-      'Provider returned an error',
-      'Authentication failed',
-      'Permission denied for /tmp/file.txt',
-    ];
-    for (const input of inputs) {
-      assert.equal(redactSecrets(input), input);
+    for (const text of ['', 'Connection refused', 'Permission denied for /tmp/file.txt']) {
+      assert.equal(redactSecrets(text), text);
     }
-  });
-
-  it('is safe on empty / undefined-like input', () => {
-    assert.equal(redactSecrets(''), '');
   });
 });

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -1,6 +1,4 @@
 import { strict as assert } from 'node:assert';
-import { readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { filterLinkedSessionTree, projectLinkedSessionTree } from '@maka/core';
 import { sessionMatchesNavSelection } from '../../renderer/session-nav-filter.js';
@@ -9,12 +7,6 @@ import {
   deriveWorktreeSessionIds,
 } from '../../renderer/session-project-grouping.js';
 import { makeSessionSummary, renderSessionListPanel } from './session-list-render-helpers.js';
-
-const REPO_ROOT = resolve(process.cwd(), '..', '..');
-
-async function readRepo(path: string): Promise<string> {
-  return readFile(join(REPO_ROOT, path), 'utf8');
-}
 
 describe('sidebar project view mode', () => {
   it('groups by stable project identity, retains empty projects, and marks only worktree sessions', () => {
@@ -83,7 +75,7 @@ describe('sidebar project view mode', () => {
     assert.deepEqual([...deriveWorktreeSessionIds([session], [surviving])], ['late-session']);
   });
 
-  it('renders compact project rows, lifecycle menus, archived disclosure, and one worktree icon', async () => {
+  it('renders compact project rows, lifecycle menus, archived disclosure, and one worktree icon', () => {
     const active = project('project-active', 'Active project', [
       { path: '/work/active', isWorktree: false },
     ]);
@@ -138,27 +130,6 @@ describe('sidebar project view mode', () => {
     assert.match(markup, />已归档项目</);
     assert.doesNotMatch(markup, />Archived project</);
     assert.equal((markup.match(/lucide-folder-git-2/g) ?? []).length, 1);
-
-    const list = await readRepo('packages/ui/src/session-history-list.tsx');
-    assert.match(list, /project\.available \?[\s\S]*copy\.projectNewTask[\s\S]*copy\.projectRelink/);
-    assert.match(list, /copy\.projectRename/);
-    assert.match(list, /copy\.projectArchive/);
-    assert.match(list, /copy\.projectRestore/);
-  });
-
-  it('keeps empty project rows on Astryx compact TreeList geometry', async () => {
-    const projects = [
-      project('project-a', 'Project A', [{ path: '/work/a', isWorktree: false }]),
-      project('project-b', 'Project B', [{ path: '/work/b', isWorktree: false }]),
-    ];
-    const markup = renderSessionListPanel({
-      sessions: [],
-      groups: deriveProjectGroups([], projects, 'zh'),
-      viewMode: 'project',
-    });
-    assert.match(markup, /class="astryx-tree-list compact/);
-    assert.equal((markup.match(/data-variant="project"/g) ?? []).length, 2);
-    assert.equal((markup.match(/role="treeitem"/g) ?? []).length, 2);
   });
 
   it('renders project groups, the unassigned bucket, and keeps the conversation fallback path', () => {
@@ -199,9 +170,8 @@ describe('sidebar project view mode', () => {
     assert.doesNotMatch(fallbackMarkup, /maka-list-group-label/);
   });
 
-  it('moves the conversation/project controls into the session-list heading menu', async () => {
+  it('moves the conversation/project controls into the session-list heading menu', () => {
     const markup = renderSessionListPanel({ viewMode: 'conversation' });
-    const panel = await readRepo('packages/ui/src/session-list-panel.tsx');
 
     assert.match(markup, /class="maka-session-list-heading"[^>]*>会话/);
     assert.match(markup, /aria-label="会话分组方式"/);
@@ -209,9 +179,6 @@ describe('sidebar project view mode', () => {
     assert.ok(trigger, 'the grouping trigger must render');
     assert.doesNotMatch(trigger, />按时间|>按项目/);
     assert.match(markup, /role="menuitemradio"/);
-    assert.match(panel, /<DropdownMenuRadioGroup[\s\S]*?value=\{viewMode\}/);
-    assert.match(panel, /<DropdownMenuRadioItem value="conversation" label=\{copy\.groupByTime\} \/>/);
-    assert.match(panel, /<DropdownMenuRadioItem value="project" label=\{copy\.groupByProject\} \/>/);
   });
 
   it('renders lifecycle state only on non-active conversation rows', () => {
@@ -244,55 +211,6 @@ describe('sidebar project view mode', () => {
     assert.match(markup, /data-status="blocked"/);
     assert.doesNotMatch(markup, /data-status="active"/);
     assert.doesNotMatch(markup, />进行中|>需要处理|>可继续|>已完成/);
-  });
-
-  it('uses the sidebar UI type tier for the session-list heading', async () => {
-    const css = await readRepo('apps/desktop/src/renderer/styles/sidebar.css');
-
-    assert.match(
-      css,
-      /\.maka-session-list-heading\s*\{[^}]*font-size:\s*var\(--font-size-ui\)/s,
-    );
-  });
-
-  it('keeps module-selected conversation controls out of the flexible list track', async () => {
-    const css = await readRepo('apps/desktop/src/renderer/styles/sidebar.css');
-
-    assert.doesNotMatch(
-      css,
-      /\.maka-session-panel\[data-content="module"\]\s*\{[^}]*grid-template-rows:/s,
-      'module selection must not replace the shared five-row sidebar grid',
-    );
-  });
-
-  it('renders project groups as expanded Astryx trees without a parallel preview state', () => {
-    const sessions = Array.from({ length: 5 }, (_, index) => makeSessionSummary({
-      id: `project-session-${index + 1}`,
-      name: `Project chat ${index + 1}`,
-      projectId: 'project-testzcode',
-      cwd: 'D:\\work\\testzcode',
-      lastMessageAt: 10 - index,
-    }));
-
-    const markup = renderSessionListPanel({
-      sessions,
-      groups: deriveProjectGroups(sessions, [
-        project('project-testzcode', 'testzcode', [
-          { path: 'D:\\work\\testzcode', isWorktree: false },
-        ]),
-      ]),
-      viewMode: 'project',
-    });
-
-    assert.match(markup, /class="astryx-tree-list compact/);
-    assert.match(markup, /role="treeitem" aria-expanded="true"/);
-    assert.match(markup, /data-tree-id="project:[^"]+"/);
-    assert.match(markup, /lucide-folder-open/);
-    assert.match(markup, />testzcode</);
-    assert.match(markup, /Project chat 1/);
-    assert.match(markup, /Project chat 4/);
-    assert.match(markup, /Project chat 5/);
-    assert.doesNotMatch(markup, /显示更多/);
   });
 
   it('renders linked child sessions directly beneath their parent as normal selectable rows', () => {
@@ -406,32 +324,6 @@ describe('sidebar project view mode', () => {
     );
   });
 
-  it('AppShell derives only project groups and lets conversation mode use the flat list', async () => {
-    const appShell = await readRepo('apps/desktop/src/renderer/app-shell.tsx');
-    const panel = await readRepo('packages/ui/src/session-list-panel.tsx');
-
-    assert.match(
-      appShell,
-      /const sidebarSessionTree = useMemo\([\s\S]*projectRevisionLinkedSessionTree\(sessions, activeId\)[\s\S]*\[sessions, activeId\]/,
-    );
-    assert.match(
-      appShell,
-      /const visibleSessionTree = useMemo\([\s\S]*filterLinkedSessionTree\(sidebarSessionTree,[\s\S]*sessionMatchesNavSelection\(session, navSelection\)[\s\S]*\[sidebarSessionTree, navSelection[^\]]*\]/,
-    );
-    assert.doesNotMatch(appShell, /deriveSessionStatusGroups|sessionStatusGroups/);
-    assert.match(appShell, /deriveProjectGroups\(visibleSessions, projects, uiLocale\)/);
-    assert.match(appShell, /deriveWorktreeSessionIds\(visibleSessions, projects\)/);
-    assert.match(appShell, /groups=\{viewMode === 'project' \? sessionProjectGroups : undefined\}/);
-    assert.match(
-      appShell,
-      /childSessionsByParentId=\{visibleSessionTree\.childrenByParentId\}/,
-    );
-    assert.doesNotMatch(appShell, /projectGroups=\{/);
-
-    assert.doesNotMatch(panel, /projectGroups\?:/);
-    assert.doesNotMatch(panel, /id: 'all'/);
-  });
-
   it('project group ids stay DOM-safe and distinct when the cwd has spaces or shared basenames', () => {
     const sessions = [
       makeSessionSummary({
@@ -499,13 +391,6 @@ function project(
     available: true,
     preferredPath: locations[0]?.path,
   };
-}
-
-function ruleBody(css: string, selector: string): string {
-  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const body = new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`).exec(css)?.[1];
-  assert.ok(body, `${selector} rule must exist`);
-  return body;
 }
 
 function childRelation(parentSessionId: string) {

--- a/apps/desktop/src/main/__tests__/settings-navigation-copy.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-navigation-copy.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 import { SETTINGS_SECTIONS } from '@maka/core';
 import { getSettingsNavigationCopy } from '../../renderer/locales/settings-navigation-copy.js';
@@ -7,53 +6,22 @@ import { getSettingsSharedCopy } from '../../renderer/locales/settings-shared-co
 import { SETTINGS_NAV, groupedNav, navLabel } from '../../renderer/settings/settings-nav.js';
 
 describe('Settings navigation copy', () => {
-  it('covers every SettingsSection in both locales', () => {
+  it('keeps every routable section unique and localized', () => {
+    const navIds = SETTINGS_NAV.map((item) => item.id);
+    assert.deepEqual([...navIds].sort(), [...SETTINGS_SECTIONS].sort());
+    assert.equal(new Set(navIds).size, navIds.length);
+
     for (const locale of ['zh', 'en'] as const) {
-      const copy = getSettingsNavigationCopy(locale);
-      assert.deepEqual(Object.keys(copy.sections).sort(), [...SETTINGS_SECTIONS].sort());
+      const sections = getSettingsNavigationCopy(locale).sections;
+      assert.deepEqual(Object.keys(sections).sort(), [...SETTINGS_SECTIONS].sort());
       for (const section of SETTINGS_SECTIONS) {
-        assert.ok(copy.sections[section].label.length > 0);
-        assert.ok(copy.sections[section].description.length > 0);
+        assert.ok(sections[section].label);
+        assert.ok(sections[section].description);
       }
     }
   });
 
-  // U1 regression guard: the `account` section was routable (a SettingsSection
-  // with a live case in settings-surface) yet absent from SETTINGS_NAV — so it
-  // had no sidebar entry to highlight and its header fell through to the
-  // `nav[0]` (通用) copy. Pin that every routable section is a nav item: an
-  // orphaned section must fail here instead of silently borrowing another
-  // page's title.
-  it('routes every SettingsSection through a nav item (no orphaned sections)', () => {
-    const navIds = SETTINGS_NAV.map((item) => item.id).sort();
-    assert.deepEqual(navIds, [...SETTINGS_SECTIONS].sort());
-    // Nav ids are unique — a duplicate would double-render the sidebar row.
-    assert.equal(new Set(navIds).size, navIds.length);
-  });
-
-  // The page header must derive its title/description from the section→copy
-  // map keyed by the active section, never from a `nav[0]`/`localizedNav[0]`
-  // fallback. Source-level pin so a regression to the old fallback (which
-  // rendered the wrong title over an unrouted section's body) is caught.
-  it('derives the settings header from the section→copy map, not a nav fallback', async () => {
-    const surface = await readFile(
-      new URL('../../../src/renderer/settings/settings-surface.tsx', import.meta.url),
-      'utf8',
-    );
-    assert.match(
-      surface,
-      /getSettingsNavigationCopy\(locale\)\.sections\[section\]/,
-      'header copy must be keyed by the active section',
-    );
-    assert.match(surface, /\{headerCopy\.label\}/);
-    assert.doesNotMatch(
-      surface,
-      /localizedNav\[0\]\?\.items\[0\]/,
-      'header must not fall back to the first nav item',
-    );
-  });
-
-  it('renders stable metadata with locale-specific labels', () => {
+  it('builds localized groups and shared frame copy without fallbacks', () => {
     assert.equal(navLabel('general', 'zh'), '通用');
     assert.equal(navLabel('general', 'en'), 'General');
     assert.deepEqual(
@@ -65,14 +33,7 @@ describe('Settings navigation copy', () => {
         ['System', ['data', 'permissions', 'health', 'about']],
       ],
     );
-    assert.equal(groupedNav('en').flatMap((group) => group.items).find((item) => item.id === 'search')?.badge, 'Beta');
-  });
-
-  it('provides complete shared frame and failure copy without fallback', () => {
     assert.equal(getSettingsSharedCopy('zh').modalLabel, '设置');
     assert.equal(getSettingsSharedCopy('en').modalLabel, 'Settings');
-    assert.equal(getSettingsSharedCopy('en').backToApp, 'Back to app');
-    assert.equal(getSettingsSharedCopy('en').loading, 'Loading settings');
-    assert.equal(getSettingsSharedCopy('en').unknownError, 'Something went wrong. Try again.');
   });
 });

--- a/apps/desktop/src/main/__tests__/theme-source.test.ts
+++ b/apps/desktop/src/main/__tests__/theme-source.test.ts
@@ -1,140 +1,20 @@
-/**
- * Astro-Han review (#493) P2: a small regression test for the
- * ThemePreference -> nativeTheme.themeSource bridge. The main-process side
- * (setThemeSource IPC handler, createWindow startup sync) is Electron-coupled
- * and covered by the main-window-safe-send-contract-style source checks;
- * this test covers the pure mapping/validation logic directly.
- */
-
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import { isThemePreference, toNativeThemeSource } from '../theme-source.js';
-import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
-
-// Anchored at the repo root, not relative to this test file's own location --
-// `npm test` runs the compiled dist/main/__tests__/*.test.js, so a plain
-// relative path would resolve into dist/ (no .ts sources there) instead of
-// the real src/ file. Same approach as main-process-contract-source-helpers.ts.
-const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
-const MAIN_TS = resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts');
-const MAIN_WINDOW_TS = resolve(REPO_ROOT, 'apps/desktop/src/main/main-window.ts');
-const RENDERER_THEME_TS = resolve(REPO_ROOT, 'apps/desktop/src/renderer/theme.ts');
 
 describe('theme-source', () => {
-  describe('toNativeThemeSource', () => {
-    it('maps auto to system', () => {
-      assert.equal(toNativeThemeSource('auto'), 'system');
-    });
-
-    it('passes light and dark through unchanged', () => {
-      assert.equal(toNativeThemeSource('light'), 'light');
-      assert.equal(toNativeThemeSource('dark'), 'dark');
-    });
-  });
-
-  describe('isThemePreference', () => {
-    it('accepts the three valid preferences', () => {
-      assert.equal(isThemePreference('auto'), true);
-      assert.equal(isThemePreference('light'), true);
-      assert.equal(isThemePreference('dark'), true);
-    });
-
-    it('rejects the already-mapped nativeTheme.themeSource value ("system")', () => {
-      // Regression guard: the IPC contract now carries the app's own
-      // ThemePreference, not the Electron-native themeSource. A caller
-      // that still sends the old pre-mapped 'system' value must be
-      // rejected, not silently accepted as if it were a no-op 'auto'.
-      assert.equal(isThemePreference('system'), false);
-    });
-
-    it('rejects garbage / wrong-type values', () => {
-      assert.equal(isThemePreference('evil-unknown'), false);
-      assert.equal(isThemePreference(undefined), false);
-      assert.equal(isThemePreference(null), false);
-      assert.equal(isThemePreference(42), false);
-      assert.equal(isThemePreference({}), false);
-    });
-  });
-
-  describe('main-window.ts wiring', () => {
-    it('setThemeSource validates the sender is the main window and rejects invalid preferences', async () => {
-      const src = await readFile(MAIN_WINDOW_TS, 'utf8');
-      const methodMatch = src.match(/setThemeSource\(sender, themePref\) \{([\s\S]*?)\n {4}\},/);
-      assert.ok(methodMatch, 'setThemeSource method must exist on the controller');
-      const body = methodMatch![1];
-      assert.match(body, /target !== mainWindow/, 'must reject senders that are not the tracked main window');
-      assert.match(body, /isThemePreference\(themePref\)/, 'must reject values that are not a valid ThemePreference');
-      assert.match(body, /nativeTheme\.themeSource = toNativeThemeSource\(themePref\)/, 'must assign via the shared mapping helper');
-    });
-
-    it('createWindow syncs nativeTheme.themeSource before creating the BrowserWindow, not only via the later IPC call', async () => {
-      const src = await readFile(MAIN_WINDOW_TS, 'utf8');
-      // Astro-Han review (#493) P2: on a cold start where the OS appearance
-      // disagrees with the persisted preference, the vibrancy material must
-      // already be on the right theme before the window is even created --
-      // syncing it only after the renderer's later setThemeSource() IPC call
-      // would let the first frame or two flash the *system* theme's tint.
-      const syncIndex = src.indexOf('nativeTheme.themeSource = toNativeThemeSource(themePref)');
-      const newWindowIndex = src.indexOf('new BrowserWindow({');
-      assert.notEqual(syncIndex, -1, 'createWindow must sync nativeTheme.themeSource from the resolved themePref');
-      assert.notEqual(newWindowIndex, -1, 'new BrowserWindow(...) call must exist');
-      assert.ok(syncIndex < newWindowIndex, 'the nativeTheme sync must happen before the BrowserWindow is constructed');
-    });
-
-    it('keeps Windows titleBarOverlay height stable at window creation and runtime theme sync', async () => {
-      const src = await readFile(MAIN_WINDOW_TS, 'utf8');
-
-      assert.match(
-        src,
-        /const titleBarOverlayOptions = \([\s\S]*?isDark: boolean,[\s\S]*?color = isDark \? '#1c1d21' : '#ffffff',[\s\S]*?\): \{ color: string; symbolColor: string; height: number \} => \(\{[\s\S]*height: TITLEBAR_OVERLAY_HEIGHT,[\s\S]*\}\);/,
-        'one helper should include color, symbolColor, and height',
-      );
-      assert.match(
-        src,
-        /titleBarOverlay:\s*titleBarOverlayOptions\(isDark\)/,
-        'window creation should use the shared titleBarOverlay options helper',
-      );
-
-      const methodMatch = src.match(/setTitleBarOverlayTheme\(sender, theme\) \{([\s\S]*?)\n {4}\},/);
-      assert.ok(methodMatch, 'setTitleBarOverlayTheme method must exist on the controller');
-      const body = methodMatch![1];
-      assert.match(body, /target !== mainWindow/, 'must reject senders that are not the tracked main window');
-      assert.match(body, /isTitleBarOverlayTheme\(theme\)/, 'must validate the renderer-provided theme payload');
-      assert.match(
-        body,
-        /mainWindow\.setTitleBarOverlay\(titleBarOverlayOptions\(theme\.isDark, theme\.backgroundColor\)\)/,
-        'runtime theme sync should preserve the height and use the renderer surface color',
-      );
-    });
-
-    it('samples the resolved renderer background again after light/dark and palette changes', async () => {
-      const src = await readFile(RENDERER_THEME_TS, 'utf8');
-      assert.match(
-        src,
-        /getComputedStyle\(root\)\.getPropertyValue\('--background'\)/,
-        'the native controls should use the actual rendered content-surface color',
-      );
-      assert.match(
-        src,
-        /function setDarkClass[\s\S]*?syncTitleBarOverlay\(root\);/,
-        'light/dark changes should update the native controls',
-      );
-      assert.match(
-        src,
-        /function applyThemePalette[\s\S]*?syncTitleBarOverlay\(root\);/,
-        'palette changes should update the native controls',
-      );
-    });
-
-    it('window:setTitleBarOverlayTheme forwards the sender to the guarded main-window controller', async () => {
-      const src = await readMainProcessCombinedSource();
-      assert.match(
-        src,
-        /ipcMain\.handle\('window:setTitleBarOverlayTheme', \(event, theme: unknown\): void => \{\s*mainWindowController\.setTitleBarOverlayTheme\(event\.sender, theme\);\s*\}\);/,
-        'the IPC handler should let main-window.ts validate both sender and payload',
-      );
-    });
+  it('maps and validates the closed app preference enum', () => {
+    const valid = [
+      ['auto', 'system'],
+      ['light', 'light'],
+      ['dark', 'dark'],
+    ] as const;
+    for (const [preference, nativeSource] of valid) {
+      assert.equal(isThemePreference(preference), true);
+      assert.equal(toNativeThemeSource(preference), nativeSource);
+    }
+    for (const value of ['system', 'unknown', undefined, null, 42, {}]) {
+      assert.equal(isThemePreference(value), false);
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/thread-search.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-search.test.ts
@@ -1,27 +1,7 @@
-/**
- * Tests for `runThreadSearch` — the PR-SEARCH-2 pure helper.
- *
- * Locks the thread-search gate catalog:
- *   G1: snippet redaction (every snippet runs through redactSecrets).
- *   G2: backend='fake' sessions excluded.
- *   G3: incognito — cross-lane deferred, no test here.
- *   G4: result + total byte caps.
- *   G5: query case-fold + NFC + CJK match.
- *   G6: no provider/network call (source-grep gate; not a runtime test).
- *   G7: no telemetry leakage of query body (source-grep gate).
- *   G8: cross-workspace not exercised — single workspace tested.
- *   G9: tool_result.content size guard.
- *  G10: SystemNote / TokenUsage / TurnState / PermissionDecision excluded.
- *
- * Plus contract tests: SearchResult.target = thread variant, url omitted,
- * SEARCH_MAX_LIMIT reused, empty / invalid query rejected.
- */
-
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import type { SessionSummary, StoredMessage } from '@maka/core';
 import {
-  MAX_SESSIONS_SCANNED,
   SNIPPET_MAX_CODE_POINTS,
   TOOL_RESULT_SCAN_CAP_BYTES,
   capCodePoints,
@@ -32,9 +12,8 @@ import {
   runThreadSearch,
 } from '../search/thread-search.js';
 
-// ---------------------------------------------------------------------------
-// Fixtures
-// ---------------------------------------------------------------------------
+type Entry = { session: SessionSummary; messages: StoredMessage[] };
+type SearchOutcome = Awaited<ReturnType<typeof runThreadSearch>>;
 
 function session(overrides: Partial<SessionSummary> & { id: string }): SessionSummary {
   return {
@@ -54,38 +33,44 @@ function session(overrides: Partial<SessionSummary> & { id: string }): SessionSu
   };
 }
 
-function userMessage(text: string, turnId: string = 't1', id: string = 'u1'): StoredMessage {
+function userMessage(text: string, turnId = 't1', id = 'u1'): StoredMessage {
   return { type: 'user', id, turnId, ts: 1_700_000_000_000, text };
 }
 
-function assistantMessage(text: string, turnId: string = 't1', id: string = 'a1'): Extract<StoredMessage, { type: 'assistant' }> {
+function assistantMessage(
+  text: string,
+  thinking?: string,
+  turnId = 't1',
+): Extract<StoredMessage, { type: 'assistant' }> {
   return {
     type: 'assistant',
-    id,
+    id: 'a1',
     turnId,
     ts: 1_700_000_000_000,
     text,
     modelId: 'glm-4.7',
+    ...(thinking ? { thinking: { text: thinking } } : {}),
   };
 }
 
-function assistantMessageWithThinking(
-  text: string,
-  thinkingText: string,
-  turnId: string = 't1',
-  id: string = 'a1',
-): Extract<StoredMessage, { type: 'assistant' }> {
+function toolCall(intent?: string): Extract<StoredMessage, { type: 'tool_call' }> {
   return {
-    ...assistantMessage(text, turnId, id),
-    thinking: { text: thinkingText },
+    type: 'tool_call',
+    id: 'tc1',
+    turnId: 't1',
+    ts: 1_700_000_000_000,
+    toolName: 'Bash',
+    displayName: 'Shell command',
+    intent,
+    args: {},
   };
 }
 
-function toolResultMessage(content: unknown, turnId: string = 't1', isError: boolean = false): StoredMessage {
+function toolResult(content: unknown, isError = false): Extract<StoredMessage, { type: 'tool_result' }> {
   return {
     type: 'tool_result',
     id: 'tr1',
-    turnId,
+    turnId: 't1',
     ts: 1_700_000_000_000,
     toolUseId: 'call1',
     isError,
@@ -93,929 +78,304 @@ function toolResultMessage(content: unknown, turnId: string = 't1', isError: boo
   };
 }
 
-function systemNoteMessage(text: string): StoredMessage {
-  return {
-    type: 'system_note',
-    id: 'sn1',
-    ts: 1_700_000_000_000,
-    kind: 'session_start',
-    data: { note: text },
-  };
-}
-
-/**
- * Default `getPrivacyContext` returns a not-incognito context. Tests
- * that want to exercise the incognito gate override this via
- * `makeDepsWithPrivacy`.
- */
-function makeDeps(map: Record<string, { session: SessionSummary; messages: StoredMessage[] }>) {
+function makeDeps(entries: Record<string, Entry>, privacyPayload: unknown = { incognitoActive: false }) {
   return {
     async listSessions() {
-      return Object.values(map).map((entry) => entry.session);
+      return Object.values(entries).map((entry) => entry.session);
     },
     async readMessages(sessionId: string) {
-      return map[sessionId]?.messages ?? [];
+      return entries[sessionId]?.messages ?? [];
     },
-    async getPrivacyContext(): Promise<unknown> {
-      return { incognitoActive: false };
-    },
-  };
-}
-
-/**
- * Spy-deps for the privacy gate tests. Tracks how many times
- * `listSessions` / `readMessages` were invoked so the test can assert
- * "early return before scan".
- */
-function makeSpyDeps(
-  map: Record<string, { session: SessionSummary; messages: StoredMessage[] }>,
-  privacyPayload: unknown,
-) {
-  let listCalls = 0;
-  let readCalls = 0;
-  const deps = {
-    async listSessions() {
-      listCalls++;
-      return Object.values(map).map((entry) => entry.session);
-    },
-    async readMessages(sessionId: string) {
-      readCalls++;
-      return map[sessionId]?.messages ?? [];
-    },
-    async getPrivacyContext(): Promise<unknown> {
+    async getPrivacyContext() {
       return privacyPayload;
     },
   };
-  return {
-    deps,
-    counts: () => ({ list: listCalls, read: readCalls }),
-  };
 }
 
-// ---------------------------------------------------------------------------
-// Query / limit normalization (reuse PR-SEARCH-0 normalizers)
-// ---------------------------------------------------------------------------
+function expectResults(outcome: SearchOutcome) {
+  if (!Array.isArray(outcome)) assert.fail(`expected results, got ${outcome.reason}`);
+  return outcome;
+}
 
-describe('runThreadSearch — input validation reuses @maka/core normalizers', () => {
-  // PR-SEARCH-2 review fixup (@xuan `2f1aba55`): IPC payload is
-  // untrusted. The helper accepts `unknown` and MUST return an
-  // error envelope, never throw, for any malformed renderer input.
-  describe('runtime shape guard (renderer fail-closed)', () => {
-    it('rejects null payload as invalid_query', async () => {
-      const result = await runThreadSearch(null, makeDeps({}));
-      if (Array.isArray(result)) assert.fail('expected error');
-      assert.equal(result.reason, 'invalid_query');
-    });
-
-    it('rejects undefined payload as invalid_query', async () => {
-      const result = await runThreadSearch(undefined, makeDeps({}));
-      if (Array.isArray(result)) assert.fail('expected error');
-      assert.equal(result.reason, 'invalid_query');
-    });
-
-    it('rejects string payload as invalid_query', async () => {
-      const result = await runThreadSearch('hello', makeDeps({}));
-      if (Array.isArray(result)) assert.fail('expected error');
-      assert.equal(result.reason, 'invalid_query');
-    });
-
-    it('rejects array payload as invalid_query', async () => {
-      const result = await runThreadSearch([], makeDeps({}));
-      if (Array.isArray(result)) assert.fail('expected error');
-      assert.equal(result.reason, 'invalid_query');
-    });
-
-    it('rejects payload missing source as disabled (source guard fires after shape guard)', async () => {
-      const result = await runThreadSearch({ query: 'hello', limit: 5 }, makeDeps({}));
-      if (Array.isArray(result)) assert.fail('expected error');
-      assert.equal(result.reason, 'disabled');
-    });
-
-    it('rejects payload missing query as invalid_query (after source guard)', async () => {
-      const result = await runThreadSearch({ source: 'thread', limit: 5 }, makeDeps({}));
-      if (Array.isArray(result)) assert.fail('expected error');
-      assert.equal(result.reason, 'invalid_query');
-    });
-
-    it('rejects payload with non-string query as invalid_query', async () => {
-      const result = await runThreadSearch({ source: 'thread', query: 42, limit: 5 }, makeDeps({}));
-      if (Array.isArray(result)) assert.fail('expected error');
-      assert.equal(result.reason, 'invalid_query');
-    });
-
-    it('does NOT throw on malformed payloads (returns error envelope)', async () => {
-      // Build a payload mix designed to probe every guard layer.
-      for (const bad of [null, undefined, '', 'string', 42, true, [], { source: 'web' }, { source: 'thread' }, { source: 'thread', query: null }]) {
-        const result = await runThreadSearch(bad, makeDeps({}));
-        assert.ok(
-          Array.isArray(result) || result.ok === false,
-          'must return result OR error envelope for ' + JSON.stringify(bad),
-        );
-      }
-    });
-  });
-
-  it('rejects empty query as invalid_query', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: '   ', limit: 5 },
-      makeDeps({}),
-    );
-    if (Array.isArray(result)) {
-      assert.fail('expected error result for empty query');
-    } else {
-      assert.equal(result.reason, 'invalid_query');
+describe('runThreadSearch', () => {
+  it('fails closed for malformed requests and unsupported sources', async () => {
+    const cases: Array<[unknown, 'invalid_query' | 'disabled']> = [
+      [null, 'invalid_query'],
+      [undefined, 'invalid_query'],
+      ['hello', 'invalid_query'],
+      [[], 'invalid_query'],
+      [{ query: 'hello', limit: 5 }, 'disabled'],
+      [{ source: 'web', query: 'hello', limit: 5 }, 'disabled'],
+      [{ source: 'thread', limit: 5 }, 'invalid_query'],
+      [{ source: 'thread', query: 42, limit: 5 }, 'invalid_query'],
+      [{ source: 'thread', query: '   ', limit: 5 }, 'invalid_query'],
+    ];
+    for (const [request, reason] of cases) {
+      const outcome = await runThreadSearch(request, makeDeps({}));
+      assert.equal(Array.isArray(outcome), false);
+      if (!Array.isArray(outcome)) assert.equal(outcome.reason, reason);
     }
   });
 
-  it('rejects non-thread source as disabled', async () => {
-    const result = await runThreadSearch(
-      // Forced cast to exercise the source guard at runtime.
-      { source: 'web', query: 'hello', limit: 5 },
-      makeDeps({}),
-    );
-    if (Array.isArray(result)) {
-      assert.fail('expected error result for non-thread source');
-    } else {
-      assert.equal(result.reason, 'disabled');
-    }
-  });
-
-  it('clamps limit to SEARCH_MAX_LIMIT=10 (does not allow desktop helper to exceed)', async () => {
-    // Build 15 sessions each with a matching message.
-    const map: Record<string, { session: SessionSummary; messages: StoredMessage[] }> = {};
-    for (let i = 0; i < 15; i++) {
-      const id = `s${String(i).padStart(2, '0')}`;
-      map[id] = {
-        session: session({ id, name: id, lastMessageAt: 1_700_000_000_000 - i }),
+  it('clamps results to the shared maximum and marks truncation', async () => {
+    const entries: Record<string, Entry> = {};
+    for (let index = 0; index < 15; index++) {
+      const id = `s${String(index).padStart(2, '0')}`;
+      entries[id] = {
+        session: session({ id, lastMessageAt: 1_700_000_000_000 - index }),
         messages: [userMessage('hello world')],
       };
     }
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 50 },
-      makeDeps(map),
+    const hits = expectResults(
+      await runThreadSearch({ source: 'thread', query: 'hello', limit: 50 }, makeDeps(entries)),
     );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.ok(result.length <= 10, 'must not exceed SEARCH_MAX_LIMIT (10); got ' + result.length);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// G1 — snippet redaction
-// ---------------------------------------------------------------------------
-
-describe('G1 — snippet redaction', () => {
-  it('redacts sk-ant-* keys in user message snippet', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1' }),
-          messages: [userMessage('hello sk-ant-test-secret-token-12345 world')],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
-    assert.ok(result[0]?.snippet, 'expected snippet');
-    assert.ok(!result[0]!.snippet!.includes('sk-ant-test-secret-token-12345'), 'snippet must redact key');
-    assert.match(result[0]!.snippet!, /\[redacted\]/);
+    assert.equal(hits.length, 10);
+    assert.equal(hits.at(-1)?.truncated, true);
   });
 
-  it('redacts Authorization Bearer in assistant message', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'authorization', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1' }),
-          messages: [assistantMessage('the header was Authorization: Bearer secret-token-here')],
-        },
-      }),
+  it('redacts snippets and excludes fake-backend sessions', async () => {
+    const hits = expectResults(
+      await runThreadSearch(
+        { source: 'thread', query: 'hello', limit: 5 },
+        makeDeps({
+          fake: {
+            session: session({ id: 'fake', backend: 'fake' }),
+            messages: [userMessage('hello from fixture')],
+          },
+          real: {
+            session: session({ id: 'real' }),
+            messages: [userMessage('hello sk-ant-test-secret-token-12345 world')],
+          },
+        }),
+      ),
     );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.ok(result[0]?.snippet, 'expected snippet');
-    assert.ok(!result[0]!.snippet!.includes('secret-token-here'), 'must redact bearer token');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// G2 — backend='fake' exclusion
-// ---------------------------------------------------------------------------
-
-describe('G2 — fake-backend sessions excluded', () => {
-  it('does NOT return matches from a fake-backend session', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      makeDeps({
-        fakeSession: {
-          session: session({ id: 'fakeSession', name: 'hello fake title', backend: 'fake' }),
-          messages: [userMessage('hello from fixture')],
-        },
-        realSession: {
-          session: session({ id: 'realSession', backend: 'ai-sdk' }),
-          messages: [userMessage('hello from real chat')],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
-    assert.equal(result[0]?.target?.kind, 'thread');
-    if (result[0]?.target?.kind === 'thread') {
-      assert.equal(result[0].target.sessionId, 'realSession');
-    }
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0]?.target?.kind === 'thread' && hits[0].target.sessionId, 'real');
+    assert.match(hits[0]?.snippet ?? '', /\[redacted\]/);
+    assert.equal(hits[0]?.snippet?.includes('sk-ant-test-secret-token-12345'), false);
   });
 
-  it('returns empty when only fake sessions match', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'unique-fixture-string', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1', backend: 'fake' }),
-          messages: [userMessage('this contains unique-fixture-string only')],
-        },
-      }),
+  it('searches only the current committed conversation revision', async () => {
+    const hits = expectResults(
+      await runThreadSearch(
+        { source: 'thread', query: 'shared-match', limit: 10 },
+        makeDeps({
+          root: {
+            session: session({ id: 'root', lastMessageAt: 10 }),
+            messages: [userMessage('shared-match old version')],
+          },
+          revision: {
+            session: session({
+              id: 'revision',
+              revisionRootSessionId: 'root',
+              revisionParentSessionId: 'root',
+              revisionIndex: 2,
+              revisionState: 'committed',
+              lastMessageAt: 20,
+            }),
+            messages: [userMessage('shared-match current version')],
+          },
+          preparing: {
+            session: session({
+              id: 'preparing',
+              revisionRootSessionId: 'root',
+              revisionParentSessionId: 'revision',
+              revisionIndex: 3,
+              revisionState: 'preparing',
+              lastMessageAt: 30,
+            }),
+            messages: [userMessage('shared-match uncommitted version')],
+          },
+        }),
+      ),
     );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Logical revision projection
-// ---------------------------------------------------------------------------
-
-describe('logical revision projection', () => {
-  it('searches only the current committed version of one conversation', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'shared-match', limit: 10 },
-      makeDeps({
-        root: {
-          session: session({ id: 'root', lastMessageAt: 10 }),
-          messages: [userMessage('shared-match old version')],
-        },
-        revision: {
-          session: session({
-            id: 'revision',
-            revisionRootSessionId: 'root',
-            revisionParentSessionId: 'root',
-            revisionIndex: 2,
-            revisionState: 'committed',
-            lastMessageAt: 20,
-          }),
-          messages: [userMessage('shared-match current version')],
-        },
-        preparing: {
-          session: session({
-            id: 'preparing',
-            revisionRootSessionId: 'root',
-            revisionParentSessionId: 'revision',
-            revisionIndex: 3,
-            revisionState: 'preparing',
-            lastMessageAt: 30,
-          }),
-          messages: [userMessage('shared-match uncommitted version')],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
     assert.deepEqual(
-      result.map((entry) => entry.target?.kind === 'thread' ? entry.target.sessionId : undefined),
+      hits.map((hit) => (hit.target?.kind === 'thread' ? hit.target.sessionId : undefined)),
       ['revision'],
     );
   });
-});
 
-// ---------------------------------------------------------------------------
-// Session title hits
-// ---------------------------------------------------------------------------
-
-describe('session title hits', () => {
-  it('returns a thread result when the query matches the session title', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'roadmap', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1', name: 'Maka roadmap planning' }),
-          messages: [userMessage('no matching body here')],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
-    const hit = result[0]!;
-    assert.equal(hit.summary, '会话标题');
-    assert.equal(hit.title, 'Maka roadmap planning');
-    assert.match(hit.snippet ?? '', /roadmap/i);
-    assert.equal(hit.url, undefined, 'thread title result must not construct a maka://session URL');
-    assert.equal(hit.target?.kind, 'thread');
-    if (hit.target?.kind === 'thread') {
-      assert.equal(hit.target.sessionId, 's1');
-      assert.equal(hit.target.turnId, undefined, 'title hit has no turn anchor');
-    }
-  });
-
-  it('redacts secrets from title snippets', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'sk-ant', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1', name: 'Rotate sk-ant-test-secret-token-12345 now' }),
-          messages: [userMessage('no body match')],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
-    assert.ok(!result[0]!.snippet!.includes('sk-ant-test-secret-token-12345'));
-    assert.match(result[0]!.snippet!, /\[redacted\]/);
-  });
-
-  it('marks truncation when title hit alone reaches the requested limit', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'planning', limit: 1 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1', name: 'planning title' }),
-          messages: [userMessage('planning body')],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
-    assert.equal(result[0]?.summary, '会话标题');
-    assert.equal(result[0]?.truncated, true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// G3 — incognito gate (PR-SEARCH-2.5)
-// ---------------------------------------------------------------------------
-
-describe('G3 — incognito gate (PR-SEARCH-2.5 @xuan 2c55b975)', () => {
-  /*
-   * Pinned via xuan msg `2c55b975`:
-   *   - active incognito → return error envelope with reason='incognito_active'
-   *   - malformed privacy context → fail-closed with the SAME reason
-   *     (UI sees one blocked state, not two)
-   *   - both paths MUST NOT call listSessions / readMessages
-   *   - `incognitoActive=false` does not bypass other gates
-   */
-
-  it('G3a: incognitoActive=true returns incognito_active envelope (no scan)', async () => {
-    const { deps, counts } = makeSpyDeps(
-      {
-        s1: { session: session({ id: 's1' }), messages: [userMessage('hello world')] },
+  it('returns navigable title and transcript results without synthetic URLs', async () => {
+    const entries = {
+      s1: {
+        session: session({
+          id: 's1',
+          name: 'Maka roadmap sk-ant-test-secret-token-12345 planning',
+        }),
+        messages: [userMessage('diagnostic from user', 'turn-user')],
       },
-      { incognitoActive: true },
-    );
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      deps,
-    );
-    if (Array.isArray(result)) assert.fail('expected error envelope');
-    assert.equal(result.reason, 'incognito_active');
-    assert.match(result.message, /incognito/);
-    const c = counts();
-    assert.equal(c.list, 0, 'listSessions must NOT be called when incognito');
-    assert.equal(c.read, 0, 'readMessages must NOT be called when incognito');
-  });
-
-  it('G3b: malformed privacy context (null) fails closed with incognito_active (no scan)', async () => {
-    const { deps, counts } = makeSpyDeps(
-      {
-        s1: { session: session({ id: 's1' }), messages: [userMessage('hello world')] },
-      },
-      null,
-    );
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      deps,
-    );
-    if (Array.isArray(result)) assert.fail('expected error envelope');
-    assert.equal(result.reason, 'incognito_active');
-    assert.match(result.message, /privacy state could not be verified/);
-    const c = counts();
-    assert.equal(c.list, 0);
-    assert.equal(c.read, 0);
-  });
-
-  it('G3b: malformed privacy context (missing field) fails closed', async () => {
-    const { deps, counts } = makeSpyDeps(
-      { s1: { session: session({ id: 's1' }), messages: [userMessage('hello')] } },
-      {}, // missing incognitoActive
-    );
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      deps,
-    );
-    if (Array.isArray(result)) assert.fail('expected error envelope');
-    assert.equal(result.reason, 'incognito_active');
-    assert.match(result.message, /privacy state could not be verified/);
-    const c = counts();
-    assert.equal(c.list, 0);
-    assert.equal(c.read, 0);
-  });
-
-  it('G3b: malformed privacy context (non-boolean field) fails closed', async () => {
-    const { deps, counts } = makeSpyDeps(
-      { s1: { session: session({ id: 's1' }), messages: [userMessage('hello')] } },
-      { incognitoActive: 'true' }, // string, not boolean
-    );
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      deps,
-    );
-    if (Array.isArray(result)) assert.fail('expected error envelope');
-    assert.equal(result.reason, 'incognito_active');
-    assert.match(result.message, /privacy state could not be verified/);
-    const c = counts();
-    assert.equal(c.list, 0);
-    assert.equal(c.read, 0);
-  });
-
-  it('G3b: malformed privacy context (non-object) fails closed', async () => {
-    const { deps, counts } = makeSpyDeps(
-      { s1: { session: session({ id: 's1' }), messages: [userMessage('hello')] } },
-      'not-an-object',
-    );
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      deps,
-    );
-    if (Array.isArray(result)) assert.fail('expected error envelope');
-    assert.equal(result.reason, 'incognito_active');
-    const c = counts();
-    assert.equal(c.list, 0);
-    assert.equal(c.read, 0);
-  });
-
-  it('G3b: malformed privacy context (array) fails closed', async () => {
-    const { deps } = makeSpyDeps(
-      { s1: { session: session({ id: 's1' }), messages: [userMessage('hello')] } },
-      [],
-    );
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      deps,
-    );
-    if (Array.isArray(result)) assert.fail('expected error envelope');
-    assert.equal(result.reason, 'incognito_active');
-  });
-
-  it('G3c: incognitoActive=false does NOT bypass other gates (empty query still invalid_query)', async () => {
-    const { deps } = makeSpyDeps(
-      { s1: { session: session({ id: 's1' }), messages: [userMessage('hello')] } },
-      { incognitoActive: false },
-    );
-    const result = await runThreadSearch(
-      { source: 'thread', query: '   ', limit: 5 },
-      deps,
-    );
-    if (Array.isArray(result)) assert.fail('expected error envelope');
-    // The empty-query gate fires BEFORE the privacy gate. This proves
-    // the order: query normalize → privacy. (If privacy fired first, we
-    // would not even get to invalid_query.)
-    assert.equal(result.reason, 'invalid_query');
-  });
-
-  it('G3 message distinguishes active vs malformed paths (consumers can read message for diagnostics)', async () => {
-    const active = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      makeSpyDeps({}, { incognitoActive: true }).deps,
-    );
-    if (Array.isArray(active)) assert.fail('expected error envelope');
-    assert.match(active.message, /incognito is active/);
-    assert.doesNotMatch(active.message, /could not be verified/);
-
-    const malformed = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      makeSpyDeps({}, null).deps,
-    );
-    if (Array.isArray(malformed)) assert.fail('expected error envelope');
-    assert.match(malformed.message, /could not be verified/);
-    assert.doesNotMatch(malformed.message, /incognito is active/);
-
-    // External reason is the same.
-    assert.equal(active.reason, 'incognito_active');
-    assert.equal(malformed.reason, 'incognito_active');
-  });
-
-  it('G3 happy path: incognitoActive=false + valid query returns results', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      makeSpyDeps(
-        { s1: { session: session({ id: 's1' }), messages: [userMessage('hello world')] } },
-        { incognitoActive: false },
-      ).deps,
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// G4 — caps
-// ---------------------------------------------------------------------------
-
-describe('G4 — result + payload caps', () => {
-  it('snippet caps at SNIPPET_MAX_CODE_POINTS code points', () => {
-    const long = 'a'.repeat(500);
-    const capped = capCodePoints(long, SNIPPET_MAX_CODE_POINTS);
-    assert.ok(Array.from(capped).length <= SNIPPET_MAX_CODE_POINTS);
-  });
-
-  it('marks last result truncated when limit reached during scan', async () => {
-    const map: Record<string, { session: SessionSummary; messages: StoredMessage[] }> = {};
-    for (let i = 0; i < 8; i++) {
-      const id = `s${i}`;
-      map[id] = {
-        session: session({ id, lastMessageAt: 1_700_000_000_000 - i }),
-        messages: [userMessage('hello world')],
-      };
-    }
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 3 },
-      makeDeps(map),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 3);
-    // Last result carries `truncated: true` to indicate caller should
-    // suggest narrowing the query.
-    assert.equal(result[result.length - 1]?.truncated, true);
-  });
-
-  it('MAX_SESSIONS_SCANNED is sane upper bound (>= 100, <= 1000)', () => {
-    assert.ok(MAX_SESSIONS_SCANNED >= 100 && MAX_SESSIONS_SCANNED <= 1000);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// G5 — case-fold + NFC + CJK
-// ---------------------------------------------------------------------------
-
-describe('G5 — case-fold + NFC + CJK match', () => {
-  it('case-insensitive ASCII match', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'HELLO', limit: 5 },
-      makeDeps({
-        s1: { session: session({ id: 's1' }), messages: [userMessage('hello world')] },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
-  });
-
-  it('CJK substring match', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: '项目', limit: 5 },
-      makeDeps({
-        s1: { session: session({ id: 's1' }), messages: [userMessage('我的项目计划已经完成')] },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
-  });
-
-  it('foldForMatch is NFC + lowercase', () => {
-    assert.equal(foldForMatch('HELLO'), 'hello');
-    assert.equal(foldForMatch('Héllo'), 'héllo'); // composed
-    // NFC composes decomposed forms (e + combining acute → é).
-    const decomposed = 'Héllo';
-    const composed = 'Héllo';
-    assert.equal(foldForMatch(decomposed), foldForMatch(composed));
-  });
-
-  it('findMatch returns index of folded match in original text', () => {
-    const idx = findMatch('hello world', foldForMatch('WORLD'));
-    assert.equal(idx, 6);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// G9 — tool_result content scan cap
-// ---------------------------------------------------------------------------
-
-describe('G9 — tool_result content scan cap', () => {
-  it('large tool_result content is bounded at TOOL_RESULT_SCAN_CAP_BYTES', () => {
-    // 100 KB content
-    const large = 'X'.repeat(100_000);
-    const message = toolResultMessage({ data: large });
-    const extracted = collectSearchableText(message);
-    assert.ok(extracted !== undefined);
-    assert.ok(
-      Buffer.byteLength(extracted!, 'utf8') <= TOOL_RESULT_SCAN_CAP_BYTES,
-      'extracted text must be within the scan cap',
-    );
-  });
-
-  it('small tool_result content passes through unchanged', () => {
-    const message = toolResultMessage({ result: 'short result' });
-    const extracted = collectSearchableText(message);
-    assert.equal(typeof extracted, 'string');
-    assert.ok(extracted!.includes('short result'));
-  });
-});
-
-// ---------------------------------------------------------------------------
-// G10 — excluded message types
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// ToolCallMessage: index `intent` ONLY (xuan `2f1aba55` fixup)
-// ---------------------------------------------------------------------------
-
-describe('ToolCallMessage indexes intent only (not toolName / displayName)', () => {
-  function toolCall(overrides: { toolName: string; displayName?: string; intent?: string }): StoredMessage {
-    return {
-      type: 'tool_call',
-      id: 'tc1',
-      turnId: 't1',
-      ts: 1_700_000_000_000,
-      toolName: overrides.toolName,
-      displayName: overrides.displayName,
-      intent: overrides.intent,
-      args: {},
     };
-  }
+    const titleHit = expectResults(
+      await runThreadSearch({ source: 'thread', query: 'roadmap', limit: 5 }, makeDeps(entries)),
+    )[0]!;
+    assert.deepEqual(titleHit.target, { kind: 'thread', sessionId: 's1' });
+    assert.equal(titleHit.summary, '会话标题');
+    assert.equal(titleHit.url, undefined);
+    assert.match(titleHit.snippet ?? '', /\[redacted\]/);
+    assert.equal(titleHit.snippet?.includes('sk-ant-test-secret-token-12345'), false);
 
-  it('collectSearchableText returns intent when present', () => {
-    const text = collectSearchableText(toolCall({ toolName: 'Bash', intent: 'list files in current dir' }));
-    assert.equal(text, 'list files in current dir');
+    const messageHit = expectResults(
+      await runThreadSearch({ source: 'thread', query: 'diagnostic', limit: 5 }, makeDeps(entries)),
+    )[0]!;
+    assert.deepEqual(messageHit.target, {
+      kind: 'thread',
+      sessionId: 's1',
+      turnId: 'turn-user',
+    });
+    assert.equal(messageHit.summary, '用户消息');
+    assert.equal(messageHit.url, undefined);
   });
 
-  it('collectSearchableText returns undefined when intent is missing', () => {
-    const text = collectSearchableText(toolCall({ toolName: 'Bash' }));
-    assert.equal(text, undefined);
-  });
-
-  it('collectSearchableText returns undefined when intent is empty string', () => {
-    const text = collectSearchableText(toolCall({ toolName: 'Bash', intent: '' }));
-    assert.equal(text, undefined);
-  });
-
-  it('does NOT index toolName — searching for "Bash" with no intent match returns 0', async () => {
-    // Plan-locked behavior: tool names are internal labels, not
-    // user-visible content. A bash invocation with no intent
-    // description must NOT appear when the user searches for `Bash`.
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'Bash', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1' }),
-          messages: [toolCall({ toolName: 'Bash', displayName: 'Bash', intent: 'check disk usage' })],
+  it('blocks active or unverifiable privacy state before scanning', async () => {
+    for (const privacyPayload of [
+      { incognitoActive: true },
+      null,
+      {},
+      { incognitoActive: 'true' },
+      'invalid',
+      [],
+    ]) {
+      let listCalls = 0;
+      let readCalls = 0;
+      const base = makeDeps({}, privacyPayload);
+      const outcome = await runThreadSearch(
+        { source: 'thread', query: 'hello', limit: 5 },
+        {
+          ...base,
+          async listSessions() {
+            listCalls++;
+            return [];
+          },
+          async readMessages() {
+            readCalls++;
+            return [];
+          },
         },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    // Intent says "check disk usage" — `Bash` shouldn't match it.
-    assert.equal(result.length, 0);
-  });
-
-  it('does NOT index displayName — searching for displayName-only does not hit', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'CustomDisplayName', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1' }),
-          messages: [toolCall({ toolName: 'Bash', displayName: 'CustomDisplayName', intent: 'tail logs' })],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 0);
-  });
-
-  it('DOES index intent — searching for intent-only string matches', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'disk usage', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1' }),
-          messages: [toolCall({ toolName: 'Bash', intent: 'check disk usage on /var' })],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
+      );
+      assert.equal(Array.isArray(outcome), false);
+      if (!Array.isArray(outcome)) {
+        assert.equal(outcome.reason, 'incognito_active');
+        assert.match(
+          outcome.message,
+          privacyPayload && !Array.isArray(privacyPayload) &&
+            typeof privacyPayload === 'object' &&
+            (privacyPayload as { incognitoActive?: unknown }).incognitoActive === true
+            ? /incognito is active/
+            : /could not be verified/,
+        );
+      }
+      assert.deepEqual({ listCalls, readCalls }, { listCalls: 0, readCalls: 0 });
+    }
   });
 });
 
-describe('AssistantMessage indexes answer text only (not thinking)', () => {
-  it('collectSearchableText omits assistant thinking from local search snippets', () => {
-    const text = collectSearchableText(
-      assistantMessageWithThinking(
-        'visible assistant answer',
-        'private reasoning path: The user is greeting me in Chinese',
+describe('thread search text projection', () => {
+  it('normalizes case and NFC and caps snippets by code point', () => {
+    assert.equal(foldForMatch('HELLO'), 'hello');
+    assert.equal(foldForMatch('Héllo'), foldForMatch('Héllo'));
+    assert.equal(findMatch('hello world', foldForMatch('WORLD')), 6);
+
+    const capped = capCodePoints(`${'a'.repeat(500)}🦊`, SNIPPET_MAX_CODE_POINTS);
+    assert.equal(Array.from(capped).length, SNIPPET_MAX_CODE_POINTS);
+    assert.ok(capped.endsWith('…'));
+  });
+
+  it('bounds serialized tool results', () => {
+    assert.equal(collectSearchableText(toolResult({ result: 'short' })), '{"result":"short"}');
+    const extracted = collectSearchableText(toolResult({ data: 'X'.repeat(100_000) }));
+    assert.ok(extracted);
+    assert.ok(Buffer.byteLength(extracted, 'utf8') <= TOOL_RESULT_SCAN_CAP_BYTES);
+  });
+
+  it('indexes tool intent but not tool names or display names', async () => {
+    assert.equal(collectSearchableText(toolCall('check disk usage')), 'check disk usage');
+    assert.equal(collectSearchableText(toolCall()), undefined);
+
+    const entries = {
+      s1: { session: session({ id: 's1' }), messages: [toolCall('check disk usage on /var')] },
+    };
+    for (const query of ['Bash', 'Shell command']) {
+      assert.deepEqual(
+        expectResults(
+          await runThreadSearch({ source: 'thread', query, limit: 5 }, makeDeps(entries)),
+        ),
+        [],
+      );
+    }
+    assert.equal(
+      expectResults(
+        await runThreadSearch(
+          { source: 'thread', query: 'disk usage', limit: 5 },
+          makeDeps(entries),
+        ),
+      ).length,
+      1,
+    );
+  });
+
+  it('indexes assistant answers without exposing thinking', async () => {
+    const message = assistantMessage(
+      'this is the visible answer',
+      'private reasoning path: greeting me in Chinese',
+    );
+    assert.equal(collectSearchableText(message), 'this is the visible answer');
+
+    const entries = { s1: { session: session({ id: 's1' }), messages: [message] } };
+    assert.equal(
+      expectResults(
+        await runThreadSearch(
+          { source: 'thread', query: 'private reasoning', limit: 5 },
+          makeDeps(entries),
+        ),
+      ).length,
+      0,
+    );
+    const visible = expectResults(
+      await runThreadSearch(
+        { source: 'thread', query: 'visible answer', limit: 5 },
+        makeDeps(entries),
       ),
     );
-
-    assert.equal(text, 'visible assistant answer');
-    assert.ok(!text?.includes('private reasoning'), 'assistant thinking must not enter searchable text');
+    assert.equal(visible.length, 1);
+    assert.equal(visible[0]?.snippet?.includes('private reasoning'), false);
   });
 
-  it('does NOT match assistant thinking-only text', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'greeting me in Chinese', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1' }),
-          messages: [
-            assistantMessageWithThinking(
-              '你好！很高兴见到你。',
-              'The user is greeting me in Chinese. I will respond in Chinese.',
-            ),
-          ],
-        },
-      }),
-    );
-
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 0);
+  it('excludes system, token, turn-state, and permission records', () => {
+    const excluded: StoredMessage[] = [
+      {
+        type: 'system_note',
+        id: 'sn1',
+        ts: 1,
+        kind: 'session_start',
+        data: { note: 'private' },
+      },
+      { type: 'token_usage', id: 'tk1', turnId: 't1', ts: 1, input: 1, output: 2 },
+      {
+        type: 'turn_state',
+        id: 'ts1',
+        turnId: 't1',
+        ts: 1,
+        status: 'completed',
+        partialOutputRetained: false,
+      },
+      {
+        type: 'permission_decision',
+        id: 'pd1',
+        turnId: 't1',
+        ts: 1,
+        toolUseId: 'call1',
+        toolName: 'Bash',
+        decision: 'allow',
+      },
+    ];
+    for (const message of excluded) assert.equal(collectSearchableText(message), undefined);
   });
 
-  it('matches visible assistant answer text without appending thinking to the snippet', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'visible answer', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1' }),
-          messages: [
-            assistantMessageWithThinking(
-              'this is the visible answer',
-              'private reasoning path: do not expose in search',
-            ),
-          ],
-        },
-      }),
-    );
-
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
-    assert.match(result[0]!.snippet ?? '', /visible answer/);
-    assert.ok(!result[0]!.snippet!.includes('private reasoning'), 'snippet must stay answer-only');
-  });
-});
-
-describe('G10 — system / token / turn-state / permission-decision excluded', () => {
-  it('returns undefined for SystemNoteMessage', () => {
-    const result = collectSearchableText(systemNoteMessage('session resumed'));
-    assert.equal(result, undefined);
-  });
-
-  it('returns undefined for TokenUsageMessage', () => {
-    const message: StoredMessage = {
-      type: 'token_usage',
-      id: 'tk1',
-      turnId: 't1',
-      ts: 1_700_000_000_000,
-      input: 100,
-      output: 200,
-    };
-    assert.equal(collectSearchableText(message), undefined);
-  });
-
-  it('returns undefined for TurnStateMessage', () => {
-    const message: StoredMessage = {
-      type: 'turn_state',
-      id: 'ts1',
-      turnId: 't1',
-      ts: 1_700_000_000_000,
-      status: 'completed',
-      partialOutputRetained: false,
-    };
-    assert.equal(collectSearchableText(message), undefined);
-  });
-
-  it('returns undefined for PermissionDecisionMessage', () => {
-    const message: StoredMessage = {
-      type: 'permission_decision',
-      id: 'pd1',
-      turnId: 't1',
-      ts: 1_700_000_000_000,
-      toolUseId: 'call1',
-      toolName: 'Bash',
-      decision: 'allow',
-    };
-    assert.equal(collectSearchableText(message), undefined);
-  });
-
-  it('a session containing ONLY excluded messages produces 0 hits', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'anything', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1' }),
-          messages: [
-            systemNoteMessage('session resumed with anything'),
-            {
-              type: 'token_usage',
-              id: 'tk1',
-              turnId: 't1',
-              ts: 1_700_000_000_000,
-              input: 100,
-              output: 200,
-            },
-          ],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// SearchResult shape (PR-SEARCH-1.5 target)
-// ---------------------------------------------------------------------------
-
-describe('SearchResult.target carries thread navigation (PR-SEARCH-1.5)', () => {
-  it('populates target with sessionId + turnId, omits url', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'hello', limit: 5 },
-      makeDeps({
-        sX: {
-          session: session({ id: 'sX', name: 'My Chat' }),
-          messages: [userMessage('hello world', 'turnA', 'u1')],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.equal(result.length, 1);
-    const hit = result[0]!;
-    assert.equal(hit.source, 'thread');
-    assert.equal(hit.url, undefined, 'thread results must NOT set url (maka://session deferred)');
-    assert.equal(hit.target?.kind, 'thread');
-    if (hit.target?.kind === 'thread') {
-      assert.equal(hit.target.sessionId, 'sX');
-      assert.equal(hit.target.turnId, 'turnA');
-    }
-    assert.equal(hit.title, 'My Chat');
-  });
-
-  it('populates user-facing summary so UI shows where the hit came from', async () => {
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'diagnostic', limit: 5 },
-      makeDeps({
-        s1: {
-          session: session({ id: 's1', name: 'Ops Run' }),
-          messages: [
-            userMessage('diagnostic from user', 'turnUser', 'u1'),
-            assistantMessage('diagnostic from assistant', 'turnAssistant', 'a1'),
-          ],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    assert.deepEqual(result.map((hit) => hit.summary), ['用户消息', '助手回复']);
-  });
-
-  it('omits turnId in target when message has no turnId (e.g. session-level hit)', async () => {
-    // SystemNoteMessage has no turnId, but it is excluded by G10.
-    // In current schema all searchable transcript messages have
-    // turnId; this test pins the optional field semantics by
-    // simulating an edge case.
-    const result = await runThreadSearch(
-      { source: 'thread', query: 'special', limit: 5 },
-      makeDeps({
-        sY: {
-          session: session({ id: 'sY' }),
-          messages: [{ ...userMessage('a special thing', '', 'u1'), turnId: '' as unknown as string }],
-        },
-      }),
-    );
-    if (!Array.isArray(result)) assert.fail('expected results');
-    if (result.length === 1) {
-      const target = result[0]!.target;
-      assert.equal(target?.kind, 'thread');
-      if (target?.kind === 'thread') {
-        // Either turnId is omitted, or it's an empty string — both are acceptable
-        // documentation values for "no turn anchor".
-        if (target.turnId !== undefined) {
-          assert.equal(typeof target.turnId, 'string');
-        }
-      }
-    }
-  });
-});
-
-describe('formatSearchResultSummary', () => {
-  function toolCall(overrides: { toolName: string; displayName?: string; intent?: string }): StoredMessage {
-    return {
-      type: 'tool_call',
-      id: 'tc-summary',
-      turnId: 't1',
-      ts: 1_700_000_000_000,
-      toolName: overrides.toolName,
-      displayName: overrides.displayName,
-      intent: overrides.intent,
-      args: {},
-    };
-  }
-
-  it('labels user / assistant / tool hits without leaking raw enum names', () => {
+  it('labels searchable message types without leaking raw enum names', () => {
     assert.equal(formatSearchResultSummary(userMessage('hello')), '用户消息');
     assert.equal(formatSearchResultSummary(assistantMessage('hello')), '助手回复');
-    assert.equal(formatSearchResultSummary(toolCall({ toolName: 'Bash', displayName: 'Shell' })), '工具调用：Shell');
-    assert.equal(formatSearchResultSummary(toolResultMessage({ ok: true })), '工具结果：成功');
-    assert.equal(formatSearchResultSummary(toolResultMessage({ ok: false }, 't1', true)), '工具结果：失败');
+    assert.equal(formatSearchResultSummary(toolCall('list files')), '工具调用：Shell command');
+    assert.equal(formatSearchResultSummary(toolResult({ ok: true })), '工具结果：成功');
+    assert.equal(formatSearchResultSummary(toolResult({ ok: false }, true)), '工具结果：失败');
   });
 });

--- a/packages/core/src/__tests__/explore-agent.test.ts
+++ b/packages/core/src/__tests__/explore-agent.test.ts
@@ -1,29 +1,24 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import {
-  DEEP_RESEARCH_EVIDENCE_CHECKLIST,
   DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_CHARS,
-  DEEP_RESEARCH_PROGRESS_CHECKPOINTS,
-  DEEP_RESEARCH_REPORT_SECTIONS,
-  DEEP_RESEARCH_SCOPE_OPTIONS,
   DEEP_RESEARCH_SESSION_LABEL,
-  DEEP_RESEARCH_STARTER_PROMPTS,
-  DEEP_RESEARCH_WORKFLOW_STEPS,
-  buildDeepResearchSystemPromptFragment,
   buildDeepResearchImplementationPrompt,
+  buildDeepResearchSystemPromptFragment,
   isDeepResearchSession,
 } from '../explore-agent.js';
 import type { DeepResearchRun } from '../deep-research-run.js';
 import { createGenesisExecutionBoundary } from '../sandbox-boundary.js';
 
 describe('deep research session profile', () => {
-  it('detects the stable session label', () => {
+  it('detects only the stable session label', () => {
     assert.equal(isDeepResearchSession([DEEP_RESEARCH_SESSION_LABEL]), true);
-    assert.equal(isDeepResearchSession(['research']), false);
-    assert.equal(isDeepResearchSession(undefined), false);
+    for (const labels of [['research'], [], undefined]) {
+      assert.equal(isDeepResearchSession(labels), false);
+    }
   });
 
-  it('builds a bounded, explicit read-only-to-implementation handoff prompt', () => {
+  it('builds a bounded handoff only from a completed run', () => {
     const run = {
       schemaVersion: 1,
       sessionId: 'session-research',
@@ -67,141 +62,30 @@ describe('deep research session profile', () => {
     );
   });
 
-  it('explore sessions receive a managed read-only boundary', () => {
+  it('gives explore sessions a managed read-only filesystem and restricted network', () => {
     const boundary = createGenesisExecutionBoundary('explore');
     assert.equal(boundary.kind, 'managed');
     if (boundary.kind !== 'managed') return;
     assert.equal(boundary.profile.name, 'read-only');
-    assert.equal(boundary.profile.fileSystem.kind, 'restricted');
-    assert.deepEqual(boundary.profile.fileSystem.entries, [
-      { kind: 'special', access: 'read', special: ':workspace_roots' },
-    ]);
+    assert.deepEqual(boundary.profile.fileSystem, {
+      kind: 'restricted',
+      entries: [{ kind: 'special', access: 'read', special: ':workspace_roots' }],
+    });
     assert.equal(boundary.profile.network.kind, 'restricted');
   });
 
-  it('system prompt names source-grounded research and no-write boundaries', () => {
+  it('keeps the system prompt source-grounded, read-only, and explicit about its write exception', () => {
     const prompt = buildDeepResearchSystemPromptFragment();
-    assert.match(prompt, /Read, Glob, Grep/);
-    assert.match(prompt, /ExploreAgent/);
-    assert.match(prompt, /Do not use ExploreAgent just because it is available/);
-    assert.match(
-      prompt,
-      /known file, a specific symbol, package scripts, test setup, config, or 1-3 obvious files/,
-    );
-    assert.match(prompt, /goal, relevant paths or keywords, what to ignore, a stopping condition/);
-    assert.match(prompt, /Do not write/);
-    assert.match(prompt, /deep_research_\* tools are the one write exception/);
-    assert.match(prompt, /deep_research_start once/);
-    assert.match(prompt, /deep_research_status, then deep_research_read_artifact/);
-    assert.match(prompt, /archive each important raw source first/);
-    assert.match(prompt, /deep_research_record_step/);
-    assert.match(prompt, /deep_research_update_checklist/);
-    assert.match(prompt, /deep_research_checkpoint/);
-    assert.match(prompt, /all five report sections are completed/);
-    assert.match(prompt, /role=handoff artifact/);
-    assert.match(prompt, /borrow \/ diverge \/ risk \/ gate/);
-    for (const step of DEEP_RESEARCH_WORKFLOW_STEPS) {
-      assert.match(prompt, new RegExp(step.title));
-      assert.match(prompt, new RegExp(step.body.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-    }
-    for (const section of DEEP_RESEARCH_REPORT_SECTIONS) {
-      assert.match(prompt, new RegExp(section.title));
-      assert.match(prompt, new RegExp(section.body.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-    }
-    for (const option of DEEP_RESEARCH_SCOPE_OPTIONS) {
-      assert.match(prompt, new RegExp(option.label));
-      assert.match(prompt, new RegExp(option.body.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-    }
-    for (const item of DEEP_RESEARCH_EVIDENCE_CHECKLIST) {
-      assert.match(prompt, new RegExp(item.title));
-      assert.match(prompt, new RegExp(item.body.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-    }
-    for (const item of DEEP_RESEARCH_PROGRESS_CHECKPOINTS) {
-      assert.match(prompt, new RegExp(item.title));
-      assert.match(prompt, new RegExp(item.body.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-    }
-    assert.match(prompt, /If the user does not specify a scope, use 标准/);
-    assert.match(prompt, /Use 深挖 only when the user explicitly asks/);
-    assert.match(prompt, /call that out explicitly instead of guessing/);
-    assert.match(prompt, /Progress checkpoints/);
-    assert.match(prompt, /control loop/);
-    assert.match(prompt, /not as a hidden task system/);
-  });
-
-  it('keeps the visible workflow compact and implementation-oriented', () => {
-    assert.equal(DEEP_RESEARCH_WORKFLOW_STEPS.length, 4);
-    assert.deepEqual(
-      DEEP_RESEARCH_WORKFLOW_STEPS.map((step) => step.title),
-      ['先定位入口', '再追数据流', '然后对照参考', '最后给可合入方案'],
-    );
-    assert.match(DEEP_RESEARCH_WORKFLOW_STEPS.at(-1)?.body ?? '', /不在只读模式里动手改/);
-  });
-
-  it('keeps the final report contract evidence-backed and PR-oriented', () => {
-    assert.equal(DEEP_RESEARCH_REPORT_SECTIONS.length, 4);
-    assert.deepEqual(
-      DEEP_RESEARCH_REPORT_SECTIONS.map((section) => section.title),
-      ['结论先行', '源码证据', '借鉴拆解', '落地改进'],
-    );
-    assert.match(DEEP_RESEARCH_REPORT_SECTIONS[1]?.body ?? '', /文件、函数、配置、测试/);
-    assert.match(DEEP_RESEARCH_REPORT_SECTIONS[2]?.body ?? '', /borrow \/ diverge \/ risk \/ gate/);
-    assert.match(DEEP_RESEARCH_REPORT_SECTIONS[3]?.body ?? '', /验证命令/);
-  });
-
-  it('keeps the research scope budget explicit', () => {
-    assert.deepEqual(
-      DEEP_RESEARCH_SCOPE_OPTIONS.map((option) => option.label),
-      ['快速', '标准', '深挖'],
-    );
-    assert.match(DEEP_RESEARCH_SCOPE_OPTIONS[0]?.body ?? '', /小问题/);
-    assert.match(DEEP_RESEARCH_SCOPE_OPTIONS[1]?.body ?? '', /默认深度/);
-    assert.match(DEEP_RESEARCH_SCOPE_OPTIONS[2]?.body ?? '', /明确要求/);
-  });
-
-  it('keeps the deep research evidence checklist source-grounded', () => {
-    assert.equal(DEEP_RESEARCH_EVIDENCE_CHECKLIST.length, 4);
-    assert.deepEqual(
-      DEEP_RESEARCH_EVIDENCE_CHECKLIST.map((item) => item.title),
-      ['项目入口', '核心链路', '边界条件', '验证证据'],
-    );
-    assert.match(DEEP_RESEARCH_EVIDENCE_CHECKLIST[0]?.body ?? '', /README、package\/config/);
-    assert.match(DEEP_RESEARCH_EVIDENCE_CHECKLIST[1]?.body ?? '', /IPC\/服务、存储、运行时/);
-    assert.match(DEEP_RESEARCH_EVIDENCE_CHECKLIST[2]?.body ?? '', /权限、隐身模式/);
-    assert.match(DEEP_RESEARCH_EVIDENCE_CHECKLIST[3]?.body ?? '', /测试、fixture、smoke/);
-  });
-
-  it('keeps the progress checkpoints visible and non-autonomous', () => {
-    assert.equal(DEEP_RESEARCH_PROGRESS_CHECKPOINTS.length, 4);
-    assert.deepEqual(
-      DEEP_RESEARCH_PROGRESS_CHECKPOINTS.map((item) => item.title),
-      ['先建清单', '标当前项', '记阻塞点', '收敛方案'],
-    );
-    assert.match(DEEP_RESEARCH_PROGRESS_CHECKPOINTS[0]?.body ?? '', /相互关联/);
-    assert.match(DEEP_RESEARCH_PROGRESS_CHECKPOINTS[1]?.body ?? '', /当前正在验证/);
-    assert.match(DEEP_RESEARCH_PROGRESS_CHECKPOINTS[2]?.body ?? '', /blocked/);
-    assert.match(
-      DEEP_RESEARCH_PROGRESS_CHECKPOINTS[3]?.body ?? '',
+    for (const contract of [
+      /Read, Glob, Grep/,
+      /Do not write/,
+      /deep_research_\* tools are the one write exception/,
+      /archive each important raw source first/,
+      /all five report sections are completed/,
+      /role=handoff artifact/,
       /borrow \/ diverge \/ risk \/ gate/,
-    );
-  });
-
-  it('keeps starter prompts read-only and implementation-oriented', () => {
-    assert.deepEqual(
-      DEEP_RESEARCH_STARTER_PROMPTS.map((prompt) => prompt.label),
-      ['研究一个参考项目', '完整读一遍参考项目', '对比一个功能实现', '做一次安全边界审计'],
-    );
-    for (const starter of DEEP_RESEARCH_STARTER_PROMPTS) {
-      assert.match(starter.prompt, /只读/);
-      assert.doesNotMatch(starter.prompt, /PR/);
+    ]) {
+      assert.match(prompt, contract);
     }
-    assert.match(DEEP_RESEARCH_STARTER_PROMPTS[1]?.prompt ?? '', /深挖范围/);
-    assert.match(
-      DEEP_RESEARCH_STARTER_PROMPTS[1]?.prompt ?? '',
-      /核心功能、运行时、存储、权限、UI、测试和文档/,
-    );
-    assert.match(
-      DEEP_RESEARCH_STARTER_PROMPTS[1]?.prompt ?? '',
-      /borrow \/ diverge \/ risk \/ gate/,
-    );
   });
 });

--- a/packages/core/src/__tests__/session-name.test.ts
+++ b/packages/core/src/__tests__/session-name.test.ts
@@ -1,293 +1,70 @@
-/**
- * Tests for the PR-UI-IPC-2 session-name normalization contract
- * (`@maka/core/session-name`).
- *
- * Locks the gate kenji + xuan signed off on (msgs 0474c3fe + 88d96a87):
- * runtime-type guard, NFC, C0/C1 + bidi + zero-width handling,
- * whitespace collapse, trim, empty-after-sanitize reject, 80
- * code-point cap (NOT byte/UTF-16 unit cap).
- */
-
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { SESSION_NAME_MAX_CODE_POINTS, normalizeUserSessionName } from '../session-name.js';
 
-describe('normalizeUserSessionName (PR-UI-IPC-2)', () => {
-  describe('runtime-type guard', () => {
-    it('non-string inputs reject with typed error (never throw)', () => {
-      for (const bad of [
-        undefined,
-        null,
-        42,
-        0,
-        NaN,
-        true,
-        false,
-        {},
-        [],
-        Symbol('x'),
-        () => '',
-        BigInt(1),
-      ]) {
-        const result = normalizeUserSessionName(bad);
-        assert.equal(result.ok, false, `bad input ${String(bad)} must reject`);
-        if (!result.ok) {
-          assert.ok(result.error.includes('must be a string'));
-        }
-      }
-    });
-
-    it('never throws on bad runtime type — sanity gate against `.normalize()` on non-string', () => {
-      for (const bad of [undefined, null, 42, true, {}, [], Symbol('x'), () => '', BigInt(1)]) {
-        assert.doesNotThrow(
-          () => normalizeUserSessionName(bad),
-          `bad input ${String(bad)} must not throw`,
-        );
-      }
-    });
+describe('normalizeUserSessionName', () => {
+  it('rejects invalid runtime values and empty sanitized names without throwing', () => {
+    for (const value of [
+      undefined,
+      null,
+      42,
+      true,
+      {},
+      [],
+      Symbol('x'),
+      () => '',
+      BigInt(1),
+      '',
+      ' \t\n ',
+      '\x00\x01\x02',
+    ]) {
+      assert.doesNotThrow(() => normalizeUserSessionName(value));
+      assert.equal(normalizeUserSessionName(value).ok, false, String(value));
+    }
   });
 
-  describe('happy path', () => {
-    it('plain ASCII text passes through unchanged', () => {
-      assert.deepEqual(normalizeUserSessionName('My chat session'), {
-        ok: true,
-        value: 'My chat session',
-      });
-    });
-
-    it('Chinese text passes through unchanged', () => {
-      assert.deepEqual(normalizeUserSessionName('帮我写代码'), { ok: true, value: '帮我写代码' });
-    });
-
-    it('emoji passes through unchanged (single code point even if surrogate pair)', () => {
-      assert.deepEqual(normalizeUserSessionName('🦊 fox chat'), { ok: true, value: '🦊 fox chat' });
-    });
-
-    it('mixed CJK + emoji + ASCII passes through', () => {
-      assert.deepEqual(normalizeUserSessionName('帮我写 Python 🐍 代码'), {
-        ok: true,
-        value: '帮我写 Python 🐍 代码',
-      });
-    });
-
-    it('trim leading and trailing whitespace', () => {
-      assert.deepEqual(normalizeUserSessionName('  hello  '), { ok: true, value: 'hello' });
-      assert.deepEqual(normalizeUserSessionName('\t\nhello\n\t'), { ok: true, value: 'hello' });
-    });
-
-    it('collapse internal whitespace runs to single space', () => {
-      assert.deepEqual(normalizeUserSessionName('foo    bar'), { ok: true, value: 'foo bar' });
-      assert.deepEqual(normalizeUserSessionName('foo\t\tbar'), { ok: true, value: 'foo bar' });
-    });
+  it('preserves representative Unicode while trimming and collapsing whitespace', () => {
+    const cases = [
+      ['My chat session', 'My chat session'],
+      ['帮我写 Python 🐍 代码', '帮我写 Python 🐍 代码'],
+      ['  hello  ', 'hello'],
+      ['foo\t\tbar\n baz', 'foo bar baz'],
+    ] as const;
+    for (const [input, value] of cases) {
+      assert.deepEqual(normalizeUserSessionName(input), { ok: true, value });
+    }
   });
 
-  describe('empty / whitespace-only reject', () => {
-    it('empty string rejects', () => {
-      assert.equal(normalizeUserSessionName('').ok, false);
-    });
-
-    it('whitespace-only rejects', () => {
-      for (const raw of ['   ', '\t', '\n', '\r\n', ' \t \n ']) {
-        const result = normalizeUserSessionName(raw);
-        assert.equal(result.ok, false, `raw=${JSON.stringify(raw)}`);
-        if (!result.ok) {
-          assert.ok(result.error.includes('empty'));
-        }
-      }
-    });
-
-    it('after sanitize empty rejects (control chars only)', () => {
-      // String of only C0 controls → after replace becomes whitespace
-      // → after collapse + trim becomes empty → reject.
-      const onlyControls = '\x00\x01\x02\x03';
-      assert.equal(normalizeUserSessionName(onlyControls).ok, false);
-    });
+  it('neutralizes control and bidi characters while removing zero-width characters', () => {
+    const cases = [
+      ['safe\x00name', 'safe name'],
+      ['a\x7fb\x80c\x9fd', 'a b c d'],
+      ['file‮txt.exe', 'file txt.exe'],
+      ['pre⁦post', 'pre post'],
+      ['clean​name', 'cleanname'],
+      ['ad‍min', 'admin'],
+    ] as const;
+    for (const [input, value] of cases) {
+      assert.deepEqual(normalizeUserSessionName(input), { ok: true, value });
+    }
   });
 
-  describe('C0/C1 control character handling', () => {
-    it('newline / tab replaced with space (not removed)', () => {
-      assert.deepEqual(normalizeUserSessionName('line1\nline2'), {
-        ok: true,
-        value: 'line1 line2',
-      });
-      assert.deepEqual(normalizeUserSessionName('col1\tcol2'), { ok: true, value: 'col1 col2' });
-    });
-
-    it('ANSI escape sequences (C0 ESC) replaced with space', () => {
-      // Raw ESC byte (U+001B) — common in tool output paste.
-      assert.deepEqual(normalizeUserSessionName('green\x1b[32mtext\x1b[0m'), {
-        ok: true,
-        value: 'green [32mtext [0m',
-      });
-    });
-
-    it('NUL byte (U+0000) replaced with space', () => {
-      assert.deepEqual(normalizeUserSessionName('safe\x00name'), { ok: true, value: 'safe name' });
-    });
-
-    it('DEL (U+007F) and C1 controls (U+0080..U+009F) replaced', () => {
-      assert.deepEqual(normalizeUserSessionName('a\x7fb\x80c\x9fd'), {
-        ok: true,
-        value: 'a b c d',
-      });
-    });
+  it('normalizes canonically equivalent text to NFC', () => {
+    assert.deepEqual(normalizeUserSessionName('café'), { ok: true, value: 'café' });
   });
 
-  describe('bidi format character handling', () => {
-    it('RLO (U+202E) replaced with space — defeats RTL display spoof', () => {
-      // Classic RLO spoof: a string "file‮txt.exe" displays as
-      // "fileexe.txt" in some renderers. Replacing with space
-      // prevents the spoof and shows what the bytes actually are.
-      assert.deepEqual(normalizeUserSessionName('file‮txt.exe'), {
-        ok: true,
-        value: 'file txt.exe',
-      });
-    });
+  it('caps by code points after sanitization without splitting surrogate pairs', () => {
+    const exact = `${'a'.repeat(SESSION_NAME_MAX_CODE_POINTS - 1)}🦊`;
+    assert.deepEqual(normalizeUserSessionName(exact), { ok: true, value: exact });
 
-    it('LRE / RLE / PDF / LRO removed too', () => {
-      for (const ch of ['‪', '‫', '‬', '‭']) {
-        const input = `before${ch}after`;
-        const result = normalizeUserSessionName(input);
-        assert.ok(result.ok);
-        if (result.ok) {
-          assert.ok(
-            !result.value.includes(ch),
-            `${ch.codePointAt(0)?.toString(16)} must be removed`,
-          );
-        }
-      }
-    });
+    const result = normalizeUserSessionName(`${exact}overflow`);
+    assert.ok(result.ok);
+    assert.equal(Array.from(result.value).length, SESSION_NAME_MAX_CODE_POINTS);
+    assert.ok(result.value.endsWith('🦊'));
 
-    it('isolate format chars (U+2066..U+2069) replaced', () => {
-      for (const ch of ['⁦', '⁧', '⁨', '⁩']) {
-        const input = `pre${ch}post`;
-        const result = normalizeUserSessionName(input);
-        assert.ok(result.ok);
-        if (result.ok) {
-          assert.ok(!result.value.includes(ch));
-        }
-      }
-    });
-  });
-
-  describe('zero-width format character handling', () => {
-    it('ZWSP / ZWNJ / ZWJ / BOM removed (NOT replaced with space)', () => {
-      // Zero-width chars are meant to be invisible. Removing them
-      // entirely keeps the visible text intact; replacing with
-      // space would inject visible whitespace into Chinese/emoji
-      // strings that may legitimately use ZWJ for compound emoji.
-      for (const ch of ['​', '‌', '‍', '﻿']) {
-        const input = `clean${ch}name`;
-        const result = normalizeUserSessionName(input);
-        assert.ok(result.ok);
-        if (result.ok) {
-          assert.equal(
-            result.value,
-            'cleanname',
-            `${ch.codePointAt(0)?.toString(16)} must be removed, not space-replaced`,
-          );
-        }
-      }
-    });
-
-    it('zero-width prefix-attack (e.g. "ad\\u200Bmin") collapses to its visible form', () => {
-      // Common spoof: prefix ZWSP between letters to evade exact-
-      // string filters. After normalize, the string is what the
-      // user sees: "admin".
-      assert.deepEqual(normalizeUserSessionName('ad​min'), { ok: true, value: 'admin' });
-    });
-  });
-
-  describe('NFC canonicalization', () => {
-    it('NFD form normalizes to NFC', () => {
-      // "café" in NFC: "café" (5 code units)
-      // in NFD: "café" (5 code units, decomposed)
-      const nfd = 'café';
-      const nfc = 'café';
-      const result = normalizeUserSessionName(nfd);
-      assert.ok(result.ok);
-      if (result.ok) {
-        assert.equal(result.value, nfc);
-      }
-    });
-
-    it('NFC alone does NOT defeat zero-width injection (must run with strip step)', () => {
-      // Documentation gate: NFC is canonicalization, not a security
-      // boundary. Zero-width chars survive NFC; the dedicated strip
-      // step (L5) is what removes them.
-      const withZwsp = 'a​b';
-      assert.equal(
-        withZwsp.normalize('NFC'),
-        withZwsp,
-        'NFC keeps ZWSP — security requires explicit strip',
-      );
-      // Our normalize DOES strip it:
-      const result = normalizeUserSessionName(withZwsp);
-      assert.ok(result.ok);
-      if (result.ok) {
-        assert.equal(result.value, 'ab');
-      }
-    });
-  });
-
-  describe('code-point length cap (80)', () => {
-    it('exactly 80 code points unchanged', () => {
-      const exact = 'a'.repeat(80);
-      const result = normalizeUserSessionName(exact);
-      assert.deepEqual(result, { ok: true, value: exact });
-    });
-
-    it('81+ code points truncated to 80', () => {
-      const long = 'a'.repeat(120);
-      const result = normalizeUserSessionName(long);
-      assert.ok(result.ok);
-      if (result.ok) {
-        assert.equal(Array.from(result.value).length, 80);
-      }
-    });
-
-    it('surrogate pair (emoji) counts as 1 code point, never cut in half', () => {
-      // 79 ASCII + 1 emoji = 80 code points. UTF-16 length is 79 + 2 = 81 code units.
-      // A naive `.slice(0, 80)` would cut the emoji's high-surrogate
-      // and leave a lone low-surrogate (invalid string). Our
-      // `Array.from` iteration prevents that.
-      const input = `${'a'.repeat(79)}🦊`;
-      assert.equal(Array.from(input).length, 80);
-      assert.equal(input.length, 81); // UTF-16 code units
-      const result = normalizeUserSessionName(input);
-      assert.ok(result.ok);
-      if (result.ok) {
-        assert.equal(Array.from(result.value).length, 80);
-        // The emoji must be intact, not split.
-        assert.ok(result.value.endsWith('🦊'));
-      }
-    });
-
-    it('CJK characters count as 1 code point each (visual width is layout concern)', () => {
-      // 80 CJK chars fits exactly at the cap (regardless that each
-      // CJK char takes 2-3 visual columns in monospace). This is
-      // intentional — the cap is on contract size, not visual
-      // width.
-      const cjk = '帮我写代码'.repeat(16); // 5 × 16 = 80
-      assert.equal(Array.from(cjk).length, 80);
-      const result = normalizeUserSessionName(cjk);
-      assert.deepEqual(result, { ok: true, value: cjk });
-    });
-
-    it('exposes the cap constant', () => {
-      assert.equal(SESSION_NAME_MAX_CODE_POINTS, 80);
-    });
-
-    it('truncation happens AFTER NFC/strip/trim (not on raw input)', () => {
-      // Pad with controls that get stripped — final length matters,
-      // not pre-strip raw length.
-      const input = '\x00\x00\x00valid name';
-      const result = normalizeUserSessionName(input);
-      assert.ok(result.ok);
-      if (result.ok) {
-        // After strip + trim → "valid name" (10 chars). Cap doesn't fire.
-        assert.equal(result.value, 'valid name');
-      }
+    assert.deepEqual(normalizeUserSessionName(`\x00\x00valid name`), {
+      ok: true,
+      value: 'valid name',
     });
   });
 });

--- a/packages/core/src/__tests__/web-search.test.ts
+++ b/packages/core/src/__tests__/web-search.test.ts
@@ -1,16 +1,15 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-
 import {
   MASKED_TOKEN_SENTINEL,
-  WEB_SEARCH_DEFAULT_LIMIT,
   WEB_SEARCH_CREDENTIAL_SOURCES,
+  WEB_SEARCH_DEFAULT_LIMIT,
   WEB_SEARCH_MAX_LIMIT,
-  WEB_SEARCH_QUERY_MAX_CHARS,
   WEB_SEARCH_PROVIDERS,
+  WEB_SEARCH_QUERY_MAX_CHARS,
   defaultWebSearchSettings,
-  isWebSearchCredentialStatus,
   isWebSearchCredentialSource,
+  isWebSearchCredentialStatus,
   isWebSearchProvider,
   maskedTokenForDisplay,
   mergeWebSearchSettings,
@@ -18,103 +17,64 @@ import {
   normalizeWebSearchQuery,
   normalizeWebSearchSettings,
   reconcileMaskedToken,
-  webSearchCredentialStatusFromResponse,
   webSearchCredentialSourceFromStoredKey,
+  webSearchCredentialStatusFromResponse,
 } from '../web-search.js';
 
-describe('normalizeWebSearchQuery', () => {
-  it('trims and accepts a typical query', () => {
+describe('web search settings', () => {
+  it('normalizes bounded queries and result limits', () => {
     assert.equal(normalizeWebSearchQuery('  hello world  '), 'hello world');
+    for (const value of ['', '   ', undefined, 123, {}]) {
+      assert.equal(normalizeWebSearchQuery(value), null);
+    }
+    assert.equal(
+      normalizeWebSearchQuery('a'.repeat(WEB_SEARCH_QUERY_MAX_CHARS + 1))?.length,
+      WEB_SEARCH_QUERY_MAX_CHARS,
+    );
+
+    const limits: Array<[unknown, number]> = [
+      [undefined, WEB_SEARCH_DEFAULT_LIMIT],
+      [NaN, WEB_SEARCH_DEFAULT_LIMIT],
+      ['5', WEB_SEARCH_DEFAULT_LIMIT],
+      [-3, 1],
+      [0, 1],
+      [3.7, 3],
+      [WEB_SEARCH_MAX_LIMIT + 1, WEB_SEARCH_MAX_LIMIT],
+    ];
+    for (const [value, expected] of limits) assert.equal(normalizeWebSearchLimit(value), expected);
   });
 
-  it('rejects empty / whitespace-only / non-string', () => {
-    assert.equal(normalizeWebSearchQuery(''), null);
-    assert.equal(normalizeWebSearchQuery('   '), null);
-    assert.equal(normalizeWebSearchQuery(undefined), null);
-    assert.equal(normalizeWebSearchQuery(123), null);
-    assert.equal(normalizeWebSearchQuery({}), null);
-  });
+  it('accepts only closed provider and credential enums', () => {
+    for (const provider of WEB_SEARCH_PROVIDERS) assert.equal(isWebSearchProvider(provider), true);
+    for (const value of ['google', '', undefined]) assert.equal(isWebSearchProvider(value), false);
 
-  it('truncates to the hard cap', () => {
-    const long = 'a'.repeat(WEB_SEARCH_QUERY_MAX_CHARS + 100);
-    const out = normalizeWebSearchQuery(long);
-    assert.ok(out);
-    assert.equal(out!.length, WEB_SEARCH_QUERY_MAX_CHARS);
-  });
-});
+    for (const source of WEB_SEARCH_CREDENTIAL_SOURCES) {
+      assert.equal(isWebSearchCredentialSource(source), true);
+    }
+    for (const value of ['anonymous', '']) assert.equal(isWebSearchCredentialSource(value), false);
 
-describe('normalizeWebSearchLimit', () => {
-  it('returns default for non-finite / non-number input', () => {
-    assert.equal(normalizeWebSearchLimit(undefined), WEB_SEARCH_DEFAULT_LIMIT);
-    assert.equal(normalizeWebSearchLimit(NaN), WEB_SEARCH_DEFAULT_LIMIT);
-    assert.equal(normalizeWebSearchLimit('5' as unknown), WEB_SEARCH_DEFAULT_LIMIT);
-  });
-
-  it('clamps below 1 to 1 and above max to max', () => {
-    assert.equal(normalizeWebSearchLimit(-3), 1);
-    assert.equal(normalizeWebSearchLimit(0), 1);
-    assert.equal(normalizeWebSearchLimit(WEB_SEARCH_MAX_LIMIT + 99), WEB_SEARCH_MAX_LIMIT);
-  });
-
-  it('truncates fractional values', () => {
-    assert.equal(normalizeWebSearchLimit(3.7), 3);
-  });
-});
-
-describe('isWebSearchProvider', () => {
-  it('accepts every member of WEB_SEARCH_PROVIDERS', () => {
-    for (const p of WEB_SEARCH_PROVIDERS) {
-      assert.equal(isWebSearchProvider(p), true);
+    for (const value of ['valid', 'invalid_credentials']) {
+      assert.equal(isWebSearchCredentialStatus(value), true);
+    }
+    for (const value of ['unsupported_provider', '']) {
+      assert.equal(isWebSearchCredentialStatus(value), false);
     }
   });
 
-  it('rejects unknown providers', () => {
-    assert.equal(isWebSearchProvider('google'), false);
-    assert.equal(isWebSearchProvider(''), false);
-    assert.equal(isWebSearchProvider(undefined), false);
-  });
-});
-
-describe('reconcileMaskedToken', () => {
-  it('preserves persisted when candidate is the mask sentinel', () => {
-    assert.equal(reconcileMaskedToken('secret-key', MASKED_TOKEN_SENTINEL), 'secret-key');
-  });
-
-  it('overwrites persisted when candidate is a real new value', () => {
-    assert.equal(reconcileMaskedToken('old', 'new-token'), 'new-token');
-  });
-
-  it('clears persisted when candidate is the empty string', () => {
-    // Empty string is an explicit clear, not "keep current".
-    assert.equal(reconcileMaskedToken('old', ''), '');
-  });
-});
-
-describe('maskedTokenForDisplay', () => {
-  it('returns empty for unset key', () => {
+  it('masks persisted tokens while preserving explicit replace and clear operations', () => {
+    const reconciled = [
+      ['secret-key', MASKED_TOKEN_SENTINEL, 'secret-key'],
+      ['old', 'new-token', 'new-token'],
+      ['old', '', ''],
+    ] as const;
+    for (const [persisted, candidate, expected] of reconciled) {
+      assert.equal(reconcileMaskedToken(persisted, candidate), expected);
+    }
     assert.equal(maskedTokenForDisplay(''), '');
+    assert.equal(maskedTokenForDisplay('secret'), MASKED_TOKEN_SENTINEL);
   });
 
-  it('returns the sentinel for any non-empty persisted value', () => {
-    assert.equal(maskedTokenForDisplay('any'), MASKED_TOKEN_SENTINEL);
-    assert.equal(maskedTokenForDisplay('a'.repeat(64)), MASKED_TOKEN_SENTINEL);
-  });
-});
-
-describe('defaultWebSearchSettings', () => {
-  it('starts disabled with tavily as default provider and empty key', () => {
-    const s = defaultWebSearchSettings();
-    assert.equal(s.enabled, false);
-    assert.equal(s.defaultProvider, 'tavily');
-    assert.equal(s.providers.tavily.apiKey, '');
-    assert.equal(s.providers.tavily.credentialSource, 'none');
-    assert.equal(s.providers.tavily.credentialVersion, 0);
-    assert.equal(s.providers.tavily.credentialStatus, 'untested');
-  });
-});
-
-describe('web search settings reconciliation', () => {
-  it('preserves credential status and version across a masked key round-trip', () => {
+  it('preserves validation metadata for a masked round-trip and resets it for a new key', () => {
     const current = mergeWebSearchSettings(defaultWebSearchSettings(), {
       providers: {
         tavily: {
@@ -124,76 +84,56 @@ describe('web search settings reconciliation', () => {
         },
       },
     });
-
-    const patched = mergeWebSearchSettings(current, {
+    const masked = mergeWebSearchSettings(current, {
       providers: { tavily: { apiKey: MASKED_TOKEN_SENTINEL } },
     });
+    assert.deepEqual(masked.providers.tavily, current.providers.tavily);
 
-    assert.equal(patched.providers.tavily.apiKey, 'stored-key');
-    assert.equal(patched.providers.tavily.credentialSource, 'saved');
-    assert.equal(patched.providers.tavily.credentialVersion, 1);
-    assert.equal(patched.providers.tavily.credentialStatus, 'valid');
-    assert.equal(patched.providers.tavily.credentialCheckedAt, '2026-05-29T00:00:00.000Z');
-  });
-
-  it('increments the credential version and clears stale status when the saved key changes', () => {
-    const current = mergeWebSearchSettings(defaultWebSearchSettings(), {
-      providers: {
-        tavily: {
-          apiKey: 'old-key',
-          credentialStatus: 'valid',
-          credentialCheckedAt: '2026-05-29T00:00:00.000Z',
-        },
-      },
-    });
-
-    const patched = mergeWebSearchSettings(current, {
+    const changed = mergeWebSearchSettings(current, {
       providers: { tavily: { apiKey: 'new-key' } },
     });
-
-    assert.equal(patched.providers.tavily.apiKey, 'new-key');
-    assert.equal(patched.providers.tavily.credentialSource, 'saved');
-    assert.equal(patched.providers.tavily.credentialVersion, 2);
-    assert.equal(patched.providers.tavily.credentialStatus, 'untested');
-    assert.equal(patched.providers.tavily.credentialCheckedAt, undefined);
+    assert.equal(changed.providers.tavily.apiKey, 'new-key');
+    assert.equal(changed.providers.tavily.credentialSource, 'saved');
+    assert.equal(changed.providers.tavily.credentialVersion, 2);
+    assert.equal(changed.providers.tavily.credentialStatus, 'untested');
+    assert.equal(changed.providers.tavily.credentialCheckedAt, undefined);
   });
 
-  it('ignores a credential result for an older key version', () => {
-    const current = mergeWebSearchSettings(defaultWebSearchSettings(), {
-      providers: { tavily: { apiKey: 'current-key' } },
+  it('ignores stale credential results after the key version changes', () => {
+    const original = mergeWebSearchSettings(defaultWebSearchSettings(), {
+      providers: { tavily: { apiKey: 'old-key' } },
     });
-    const updatedKey = mergeWebSearchSettings(current, {
-      providers: { tavily: { apiKey: 'newer-key' } },
+    const current = mergeWebSearchSettings(original, {
+      providers: { tavily: { apiKey: 'new-key' } },
     });
-
-    const staleResult = mergeWebSearchSettings(updatedKey, {
-      providers: {
-        tavily: {
-          credentialVersion: current.providers.tavily.credentialVersion,
-          credentialStatus: 'invalid_credentials',
-          credentialCheckedAt: '2026-05-29T00:00:00.000Z',
+    const applyResult = (
+      credentialVersion: number,
+      credentialStatus: 'valid' | 'invalid_credentials',
+    ) =>
+      mergeWebSearchSettings(current, {
+        providers: {
+          tavily: {
+            credentialVersion,
+            credentialStatus,
+            credentialCheckedAt: '2026-05-29T00:01:00.000Z',
+          },
         },
-      },
-    });
-    const freshResult = mergeWebSearchSettings(updatedKey, {
-      providers: {
-        tavily: {
-          credentialVersion: updatedKey.providers.tavily.credentialVersion,
-          credentialStatus: 'valid',
-          credentialCheckedAt: '2026-05-29T00:01:00.000Z',
-        },
-      },
-    });
+      });
 
-    assert.equal(updatedKey.providers.tavily.credentialVersion, 2);
-    assert.equal(staleResult.providers.tavily.credentialStatus, 'untested');
-    assert.equal(staleResult.providers.tavily.credentialCheckedAt, undefined);
-    assert.equal(freshResult.providers.tavily.credentialStatus, 'valid');
-    assert.equal(freshResult.providers.tavily.credentialCheckedAt, '2026-05-29T00:01:00.000Z');
+    assert.equal(
+      applyResult(original.providers.tavily.credentialVersion, 'invalid_credentials').providers
+        .tavily.credentialStatus,
+      'untested',
+    );
+    assert.equal(
+      applyResult(current.providers.tavily.credentialVersion, 'valid').providers.tavily
+        .credentialStatus,
+      'valid',
+    );
   });
 
   it('normalizes malformed persisted credential metadata fail-closed', () => {
-    const malformed = {
+    const normalized = normalizeWebSearchSettings({
       enabled: 'yes',
       defaultProvider: 'unknown',
       providers: {
@@ -205,42 +145,14 @@ describe('web search settings reconciliation', () => {
           credentialCheckedAt: 'x'.repeat(65),
         },
       },
-    } as unknown as Parameters<typeof normalizeWebSearchSettings>[0];
+    } as never);
 
-    const normalized = normalizeWebSearchSettings(malformed);
-
-    assert.equal(normalized.enabled, false);
-    assert.equal(normalized.defaultProvider, 'tavily');
-    assert.equal(normalized.providers.tavily.apiKey, '');
-    assert.equal(normalized.providers.tavily.credentialSource, 'none');
-    assert.equal(normalized.providers.tavily.credentialVersion, 0);
-    assert.equal(normalized.providers.tavily.credentialStatus, 'untested');
-    assert.equal(normalized.providers.tavily.credentialCheckedAt, undefined);
-  });
-});
-
-describe('web search credential status helpers', () => {
-  it('accepts only the closed credential status enum', () => {
-    assert.equal(isWebSearchCredentialStatus('valid'), true);
-    assert.equal(isWebSearchCredentialStatus('invalid_credentials'), true);
-    assert.equal(isWebSearchCredentialStatus('unsupported_provider'), false);
-    assert.equal(isWebSearchCredentialStatus(''), false);
+    assert.deepEqual(normalized, defaultWebSearchSettings());
   });
 
-  it('accepts only the closed credential source enum', () => {
-    for (const source of WEB_SEARCH_CREDENTIAL_SOURCES) {
-      assert.equal(isWebSearchCredentialSource(source), true);
-    }
-    assert.equal(isWebSearchCredentialSource('anonymous'), false);
-    assert.equal(isWebSearchCredentialSource(''), false);
-  });
-
-  it('derives renderer-safe credential source from stored key presence', () => {
+  it('derives renderer-safe credential metadata from storage and test responses', () => {
     assert.equal(webSearchCredentialSourceFromStoredKey(''), 'none');
     assert.equal(webSearchCredentialSourceFromStoredKey('tvly-secret'), 'saved');
-  });
-
-  it('maps test responses to persisted credential status without leaking unsupported provider', () => {
     assert.equal(webSearchCredentialStatusFromResponse({ ok: true, results: [] }), 'valid');
     assert.equal(
       webSearchCredentialStatusFromResponse({


### PR DESCRIPTION
## Summary
- collapse thread-search privacy, redaction, revision, and text-projection cases into compact decision tables
- consolidate session-name sanitization and web-search credential coverage around real boundaries
- remove prompt/copy snapshots and renderer source/CSS shape assertions from Desktop suites
- preserve runtime grouping, child lineage, secret redaction, incognito early-return, stale credential, Unicode, and size-cap coverage

## Impact
- 10 test files changed
- test declarations: 166 -> 46
- 505 additions / 2,074 deletions (net -1,569 lines)
- production code unchanged

## Verification
- clean install after rebasing latest `origin/main`
- `npm run clean && npm run build:test`
- `npm --workspace @maka/core run test:dist` (866 passed)
- Desktop dist suite from workspace cwd (1,637 passed)
- `npm run test:scripts` (37 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
