### PR TITLE
fix(storage): ignore inherited bundle provenance

### DIFF
--- a/packages/storage/src/__tests__/session-bundle-manifest.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-manifest.test.ts
@@ -61,6 +61,21 @@ test('omits optional Activation provenance instead of inventing authority', () =
   assert.doesNotMatch(text, /lastCommittedActivationId/);
 });
 
+test('does not serialize inherited Activation provenance', () => {
+  const envelope = Object.assign(
+    Object.create({ lastCommittedActivationId: 'inherited-activation' }) as object,
+    { sessionId: manifest.envelope.sessionId },
+  ) as SessionBundleManifestV1['envelope'];
+
+  const encoded = encodeSessionBundleManifestV1({ ...manifest, envelope });
+  const text = new TextDecoder().decode(encoded);
+  assert.match(text, /"envelope":\{"sessionId":"cloud-session-α"\}/);
+  assert.doesNotMatch(text, /inherited-activation|lastCommittedActivationId/);
+  assert.deepEqual(decodeSessionBundleManifestV1(encoded).envelope, {
+    sessionId: manifest.envelope.sessionId,
+  });
+});
+
 test('rejects parseable but non-canonical manifest bytes', () => {
   const nonCanonical = new TextEncoder().encode(JSON.stringify(manifest));
   assertBundleError(() => decodeSessionBundleManifestV1(nonCanonical), 'invalid_manifest');

--- a/packages/storage/src/session-bundle-manifest.ts
+++ b/packages/storage/src/session-bundle-manifest.ts
@@ -137,17 +137,14 @@ function decodeEnvelope(value: unknown): SessionBundleManifestV1['envelope'] {
   ) {
     throw invalidManifest();
   }
-  if (
-    Object.hasOwn(value, 'lastCommittedActivationId') &&
-    !isNonEmptyUnicodeString(value.lastCommittedActivationId)
-  ) {
-    throw invalidManifest();
+  let lastCommittedActivationId: string | undefined;
+  if (Object.hasOwn(value, 'lastCommittedActivationId')) {
+    if (!isNonEmptyUnicodeString(value.lastCommittedActivationId)) throw invalidManifest();
+    lastCommittedActivationId = value.lastCommittedActivationId;
   }
   return {
     sessionId: value.sessionId,
-    ...(typeof value.lastCommittedActivationId === 'string'
-      ? { lastCommittedActivationId: value.lastCommittedActivationId }
-      : {}),
+    ...(lastCommittedActivationId === undefined ? {} : { lastCommittedActivationId }),
   };
 }
 


### PR DESCRIPTION
## Summary

Follow up on the non-blocking review comment from #1697.

- admit lastCommittedActivationId only when it is an own envelope property
- prevent inherited or prototype-polluted provenance from being serialized into a canonical Session Bundle manifest
- add a regression test using an inherited activation identifier without mutating the global object prototype

## Tests

- npm --workspace @maka/storage test
- npm run lint
- npm run format:check
- npm run build
- npm run typecheck

All checks pass on the latest main.

Part of #1528.