### PR TITLE
fix(ci): resolve three intermittent test flakes across runtime-host, runtime, and cli

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -10953,16 +10953,23 @@ async function runSignalExitProbe(
   });
   let stdout = '';
   let signalSent = false;
+  let killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', (chunk: string) => {
     stdout += chunk;
     if (!signalSent && stdout.includes('READY')) {
       signalSent = true;
       child.kill(signalToSend);
+      // Time the kill against the signal handling window, not the child's
+      // startup: on a slow CI runner importing the TUI and reaching READY can
+      // itself take seconds, which would otherwise leave the 3s exit grace
+      // (beginMakaCliExit) past the 5s kill timer and the probe would be
+      // SIGKILLed before the graceful exit it is asserting.
+      clearTimeout(killTimer);
+      killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
     }
   });
 
-  const killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
   const [code, signal] = (await once(child, 'exit')) as [number | null, NodeJS.Signals | null];
   clearTimeout(killTimer);
   return { code, signal, stdout };
@@ -11052,11 +11059,20 @@ async function runFatalExitProbe(
   });
   let stdout = '';
   let stderr = '';
-  const killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
+  let childReady = false;
+  let killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
   child.stdout.setEncoding('utf8');
   child.stderr.setEncoding('utf8');
   child.stdout.on('data', (chunk: string) => {
     stdout += chunk;
+    // Same reasoning as runSignalExitProbe: the fatal trigger fires right
+    // after READY, and the process needs the 3s exit grace after that; on a
+    // slow CI runner the pre-READY startup must not eat into that budget.
+    if (!childReady && stdout.includes('READY')) {
+      childReady = true;
+      clearTimeout(killTimer);
+      killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
+    }
   });
   child.stderr.on('data', (chunk: string) => {
     stderr += chunk;

--- a/packages/runtime-host/src/__tests__/message-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/message-coordinator.test.ts
@@ -52,6 +52,52 @@ test('idle submit starts exactly one root Turn and retry identity is connection-
   assert.equal(fixture.liveResidencies(), 0);
 });
 
+test('submit re-runs admission when the queue revision moves during preflight', async () => {
+  let preflightCalls = 0;
+  const fixture = createFixture(undefined, async () => {
+    preflightCalls += 1;
+    if (preflightCalls === 2) {
+      // The steering submit already passed its preflight (call 1). This is
+      // the follow-up submit's preflight: a running Turn consumes the queued
+      // steering outside the admission lock while it awaits, so the queue
+      // revision moves and the stale candidate must be re-admitted instead
+      // of surfacing a spurious session_busy to the client.
+      const [lease] = owner.pull();
+      assert.ok(lease);
+      owner.ack([lease.id]);
+    }
+    return true;
+  });
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  const input = (messageId: string, text: string, placement: 'current_turn' | 'next_turn') =>
+    ({
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      messageId,
+      content: { text },
+      placement,
+    }) as const;
+
+  const steering = await fixture.coordinator.handlers['turn.message.submit'](
+    input('steering-1', 'steer', 'current_turn'),
+    operationContext(),
+  );
+  assert.equal(steering.ok, true);
+
+  const followup = await fixture.coordinator.handlers['turn.message.submit'](
+    input('followup-1', 'queued task', 'next_turn'),
+    operationContext(),
+  );
+  assert.equal(followup.ok, true);
+  assert.equal(followup.ok && followup.result.disposition, 'followup');
+  assert.ok(
+    preflightCalls >= 2,
+    `expected admission retry, preflight ran ${preflightCalls} time(s)`,
+  );
+  owner.release();
+});
+
 test('invalidates the canonical projection after each observable queue mutation', async () => {
   const changedSessions: string[] = [];
   const fixture = createFixture((sessionId) => changedSessions.push(sessionId));

--- a/packages/runtime-host/src/server/message-coordinator.ts
+++ b/packages/runtime-host/src/server/message-coordinator.ts
@@ -223,6 +223,15 @@ export interface QueueFenceResult {
   readonly retracted: readonly RetractedMessageSnapshot[];
 }
 
+/**
+ * How many times a submit re-runs admission after its preflight snapshot went
+ * stale. Steering consumption (pull/ack/nack) happens outside the admission
+ * lock, so the queue can change while a submit awaits its preflight; the
+ * change is transient and a fresh pass succeeds. The cap bounds how long a
+ * contended submit waits before reporting session_busy.
+ */
+const SUBMIT_ADMISSION_RETRY_LIMIT = 4;
+
 /** The sole in-memory message authority for one Runtime Host Epoch. */
 export class HostMessageCoordinator implements RuntimeMessageAuthority {
   readonly handlers: MessageOperationHandlerMap = {
@@ -496,144 +505,159 @@ export class HostMessageCoordinator implements RuntimeMessageAuthority {
       if (this.#draining) {
         return failure('host_draining', 'Runtime Host is draining');
       }
-      const header = await this.#root.readSessionHeader(input.sessionId);
-      if (this.#failStopped) {
-        return failure('host_draining', 'Runtime Host message authority has failed');
-      }
-      if (!header) return failure('not_found', 'Session does not exist');
-      if (header.isArchived) return failure('session_archived', 'Session is archived');
-      const rootState = await this.#root.readRootState(input.sessionId);
-      if (this.#failStopped) {
-        return failure('host_draining', 'Runtime Host message authority has failed');
-      }
-      if (rootState.kind === 'idle') {
-        if (header.unavailableReason) {
-          return failure('operation_unavailable', header.unavailableReason);
+      // A Turn consumes steering out of the queue outside the admission lock
+      // (#pull/#ack/#nack), so a submit's preflight snapshot can go stale while
+      // it awaits. That is transient: re-read the queue and re-run admission
+      // instead of surfacing a spurious session_busy to the client.
+      for (let attempt = 0; ; attempt++) {
+        const header = await this.#root.readSessionHeader(input.sessionId);
+        if (this.#failStopped) {
+          return failure('host_draining', 'Runtime Host message authority has failed');
         }
-        const existingState = this.#sessions.get(input.sessionId);
-        if (existingState && hasLiveMessageState(existingState)) {
+        if (!header) return failure('not_found', 'Session does not exist');
+        if (header.isArchived) return failure('session_archived', 'Session is archived');
+        const rootState = await this.#root.readRootState(input.sessionId);
+        if (this.#failStopped) {
+          return failure('host_draining', 'Runtime Host message authority has failed');
+        }
+        if (rootState.kind === 'idle') {
+          if (header.unavailableReason) {
+            return failure('operation_unavailable', header.unavailableReason);
+          }
+          const existingState = this.#sessions.get(input.sessionId);
+          if (existingState && hasLiveMessageState(existingState)) {
+            throw new RuntimeMessageAuthorityInvariantError(
+              'Root reported idle while the message authority retained live state',
+            );
+          }
+          const sourceMessage: RootTurnSourceMessage = {
+            messageId: input.messageId,
+            content: payload.content,
+            placement: input.placement,
+            disposition: 'turn_started',
+          };
+          const started = await this.#root.startFromMessage(
+            {
+              sessionId: input.sessionId,
+              content: payload.content,
+              sourceMessage,
+              initiatingConnectionId,
+            },
+            admission,
+          );
+          if ('error' in started) {
+            return failure('operation_conflict', started.error);
+          }
+          if (!isEntityId(started.turnId)) {
+            throw new RuntimeMessageAuthorityInvariantError(
+              'Started Turn identity is not encodable',
+            );
+          }
+          const result = { disposition: 'turn_started', turnId: started.turnId } as const;
+          return success(result);
+        }
+        const state = this.#requireState(input.sessionId);
+        if (state.phase !== 'open') {
+          return failure('session_busy', 'Message admission is closed for the active generation');
+        }
+        if (!state.reservedRoot || !sameRun(state.reservedRoot, rootState)) {
           throw new RuntimeMessageAuthorityInvariantError(
-            'Root reported idle while the message authority retained live state',
+            'Root state does not match message reservation',
           );
         }
-        const sourceMessage: RootTurnSourceMessage = {
+        if (allLiveEntries(state).length >= MESSAGE_QUEUE_MAX_ENTRIES) {
+          return failure('session_busy', 'Message queue capacity is full');
+        }
+        const disposition = input.placement === 'current_turn' ? 'steering' : 'followup';
+        const candidateRevision = state.revision;
+        const candidateGeneration = state.generation;
+        const entryId = this.#createId();
+        if (!isEntityId(entryId)) {
+          throw new RuntimeMessageAuthorityInvariantError(
+            'Message entry identity is not encodable',
+          );
+        }
+        const candidateEntry: QueuedMessageSnapshot = {
+          entryId,
           messageId: input.messageId,
           content: payload.content,
           placement: input.placement,
-          disposition: 'turn_started',
+          state: 'queued',
         };
-        const started = await this.#root.startFromMessage(
+        const current = this.#project(state);
+        const candidate: SessionMessageQueueProjection = {
+          ...current,
+          queueRevision: state.revision + 1,
+          steering:
+            disposition === 'steering'
+              ? [
+                  ...[...state.inFlight.values()].map(inFlightSnapshot),
+                  ...state.steering.map(queuedSteeringSnapshot),
+                  { ...candidateEntry, placement: 'current_turn' },
+                ]
+              : current.steering,
+          followup:
+            disposition === 'followup' ? [...current.followup, candidateEntry] : current.followup,
+        };
+        if (!projectionFitsEveryEntryState(candidate)) {
+          return failure('session_busy', 'Message queue projection capacity is full');
+        }
+        if (!(await this.#preflightSessionSnapshot(input.sessionId, { queue: candidate }))) {
+          return failure('session_busy', 'Session projection capacity is full');
+        }
+        if (!interruptResultFits(candidate, rootState)) {
+          return failure('session_busy', 'Message queue interrupt result capacity is full');
+        }
+        const prospectiveSources = [
+          ...[...state.inFlight.values(), ...state.steering, ...state.followup].map(
+            sourceFromEntry,
+          ),
           {
-            sessionId: input.sessionId,
+            messageId: input.messageId,
             content: payload.content,
-            sourceMessage,
-            initiatingConnectionId,
+            placement: input.placement,
+            disposition,
           },
-          admission,
-        );
-        if ('error' in started) {
-          return failure('operation_conflict', started.error);
+        ] satisfies RootTurnSourceMessage[];
+        if (!rootAdmissionPayloadFits(prospectiveSources)) {
+          return failure('session_busy', 'Message queue cannot form a durable follow-up Turn');
         }
-        if (!isEntityId(started.turnId)) {
-          throw new RuntimeMessageAuthorityInvariantError('Started Turn identity is not encodable');
+        if (
+          state.phase !== 'open' ||
+          state.revision !== candidateRevision ||
+          state.generation !== candidateGeneration ||
+          !state.reservedRoot ||
+          !sameRun(state.reservedRoot, rootState)
+        ) {
+          if (attempt >= SUBMIT_ADMISSION_RETRY_LIMIT) {
+            return failure('session_busy', 'Message queue changed during admission');
+          }
+          continue;
         }
-        const result = { disposition: 'turn_started', turnId: started.turnId } as const;
-        return success(result);
-      }
-      const state = this.#requireState(input.sessionId);
-      if (state.phase !== 'open') {
-        return failure('session_busy', 'Message admission is closed for the active generation');
-      }
-      if (!state.reservedRoot || !sameRun(state.reservedRoot, rootState)) {
-        throw new RuntimeMessageAuthorityInvariantError(
-          'Root state does not match message reservation',
-        );
-      }
-      if (allLiveEntries(state).length >= MESSAGE_QUEUE_MAX_ENTRIES) {
-        return failure('session_busy', 'Message queue capacity is full');
-      }
-      const disposition = input.placement === 'current_turn' ? 'steering' : 'followup';
-      const candidateRevision = state.revision;
-      const candidateGeneration = state.generation;
-      const entryId = this.#createId();
-      if (!isEntityId(entryId)) {
-        throw new RuntimeMessageAuthorityInvariantError('Message entry identity is not encodable');
-      }
-      const candidateEntry: QueuedMessageSnapshot = {
-        entryId,
-        messageId: input.messageId,
-        content: payload.content,
-        placement: input.placement,
-        state: 'queued',
-      };
-      const current = this.#project(state);
-      const candidate: SessionMessageQueueProjection = {
-        ...current,
-        queueRevision: state.revision + 1,
-        steering:
-          disposition === 'steering'
-            ? [
-                ...[...state.inFlight.values()].map(inFlightSnapshot),
-                ...state.steering.map(queuedSteeringSnapshot),
-                { ...candidateEntry, placement: 'current_turn' },
-              ]
-            : current.steering,
-        followup:
-          disposition === 'followup' ? [...current.followup, candidateEntry] : current.followup,
-      };
-      if (!projectionFitsEveryEntryState(candidate)) {
-        return failure('session_busy', 'Message queue projection capacity is full');
-      }
-      if (!(await this.#preflightSessionSnapshot(input.sessionId, { queue: candidate }))) {
-        return failure('session_busy', 'Session projection capacity is full');
-      }
-      if (!interruptResultFits(candidate, rootState)) {
-        return failure('session_busy', 'Message queue interrupt result capacity is full');
-      }
-      const prospectiveSources = [
-        ...[...state.inFlight.values(), ...state.steering, ...state.followup].map(sourceFromEntry),
-        {
+        const result = { disposition, queueRevision: candidateRevision + 1 } as const;
+        const residency = this.#acquireResidency();
+        const entry: LiveEntry = {
+          entryId,
           messageId: input.messageId,
           content: payload.content,
+          initiatingConnectionId,
           placement: input.placement,
           disposition,
-        },
-      ] satisfies RootTurnSourceMessage[];
-      if (!rootAdmissionPayloadFits(prospectiveSources)) {
-        return failure('session_busy', 'Message queue cannot form a durable follow-up Turn');
+          generation: state.generation,
+          residency,
+          state: 'queued',
+        };
+        if (disposition === 'steering') state.steering.push(entry);
+        else state.followup.push(entry);
+        this.#mutated(state);
+        try {
+          await this.#commitReceipt('submit', input.sessionId, input.messageId, payload, result);
+        } catch (error) {
+          this.#failStop();
+          throw error;
+        }
+        return success(result);
       }
-      if (
-        state.phase !== 'open' ||
-        state.revision !== candidateRevision ||
-        state.generation !== candidateGeneration ||
-        !state.reservedRoot ||
-        !sameRun(state.reservedRoot, rootState)
-      ) {
-        return failure('session_busy', 'Message queue changed during admission');
-      }
-      const result = { disposition, queueRevision: candidateRevision + 1 } as const;
-      const residency = this.#acquireResidency();
-      const entry: LiveEntry = {
-        entryId,
-        messageId: input.messageId,
-        content: payload.content,
-        initiatingConnectionId,
-        placement: input.placement,
-        disposition,
-        generation: state.generation,
-        residency,
-        state: 'queued',
-      };
-      if (disposition === 'steering') state.steering.push(entry);
-      else state.followup.push(entry);
-      this.#mutated(state);
-      try {
-        await this.#commitReceipt('submit', input.sessionId, input.messageId, payload, result);
-      } catch (error) {
-        this.#failStop();
-        throw error;
-      }
-      return success(result);
     });
   }
 

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -1175,7 +1175,17 @@ export class ShellRunProcessManager
     cause?: LifecycleCause,
   ): TerminationLifecycle | undefined {
     if (live.rootExited || live.finalizeOnce) return live.termination;
-    if (live.termination) return live.termination;
+    if (live.termination) {
+      // A timeout fired while termination was still waiting for the process
+      // (POSIX process discovery, child startup); a cancellation that arrives
+      // before the kill is applied should win, so callers observe 'cancelled'
+      // instead of a stale 'timed_out'. Once the process is gone (rootExited /
+      // finalizeOnce) we never reach this branch.
+      if (cause === 'cancel' && live.lifecycleCause === 'timeout') {
+        live.lifecycleCause = 'cancel';
+      }
+      return live.termination;
+    }
     const lifecycle = createTerminationLifecycle();
     live.termination = lifecycle;
     this.startTermination(live, lifecycle, cause, () => {

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -116,6 +116,10 @@ const ALLOW = new Map([
     'packages/core/src/shell-run-result.ts',
     'ShellRun reconciliation invariant diagnostics contain only runtime refs and revisions, never command or output data.',
   ],
+  [
+    'packages/runtime-host/src/server/host-kernel.ts',
+    'Host shutdown failure diagnostics print the full nested AggregateError chain (Node truncates it to [errors]: [Array] by default); error metadata only, no secrets (PR1760).',
+  ],
 ]);
 
 async function walk(root) {

--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -159,7 +159,12 @@ export function planTests(changedFiles, options = {}) {
     e2e: directWorkspaces.has('apps/desktop') || directWorkspaces.has('packages/ui'),
     full: false,
     headless: workspaces.includes('packages/headless'),
-    runtimeSandbox: directWorkspaces.has('packages/runtime'),
+    runtimeSandbox:
+      directWorkspaces.has('packages/runtime') ||
+      // runtime-bootstrap.test.ts (packages/cli) executes real sandboxed shell
+      // tools, so it needs the bubblewrap + user-namespace setup even though
+      // the change is scoped to the cli workspace.
+      files.some((path) => path === 'packages/cli/src/__tests__/runtime-bootstrap.test.ts'),
     scriptMode,
     storageStress,
     workspaces,


### PR DESCRIPTION
## Summary

The CI `test` job flaked intermittently on three unrelated suites. Each root cause was captured from the failed job logs:

1. **runtime-host steering** (`execution-host.test.js`) — submit fails with `Message queue changed during admission` (`session_busy`). A running Turn consumes steering out of the queue **outside** the admission lock (`#pull`/`#ack`/`#nack`), so a submit's preflight snapshot can go stale while it awaits and the final admission check fails. Submit now **re-runs admission** (up to 4 times) when the queue changed, instead of surfacing a spurious `session_busy`. Regression test simulates the race by pulling/acking the queued steering from inside a delayed preflight.

2. **runtime shell-run-manager** — `preserves cancellation when timeout fires during POSIX process discovery` expected `cancelled` but got `timed_out`. `armTimeout` pins `lifecycleCause` to `timeout` immediately; a later cancellation was ignored because `requestTermination` returned the existing termination. A cancel that arrives **before the kill is applied** now upgrades the cause to `cancel`.

3. **cli pi-tui-runner** — `forces signal exit` / `reports and forces fatal exit when outer cleanup never settles` expected graceful exit (143/1) but got `SIGKILL`. The probe's 5s kill timer started at spawn, while the process exit grace (`PROCESS_EXIT_GRACE_MS=3000`) starts after `READY`; slow CI startup ate the budget. The kill timer now **resets when the probe reports READY**.

4. **ci-test-plan** — `runtime-bootstrap.test.ts` (packages/cli) executes real sandboxed shell tools, but the bubblewrap + user-namespace install only ran when `packages/runtime` changed; editing the cli workspace ran it without a sandbox → `sandbox required but unavailable`. The plan now also flags the sandbox when that test file changes.

## Verification

- `message-coordinator` 26/26 incl. new regression test — **confirmed it fails when retry is disabled**, passes with the fix.
- `shell-run-manager` 51/51, `pi-tui-runner` 205/205, `ci-test-plan` 4/4.
- `packages/runtime` suite 2839 pass / 0 fail; `runtime-host` 445/446 (one pre-existing concurrent UDS timeout, passes alone).
- `npm run format:check` and `npm run lint` clean.

The original flakes are CI-scheduling dependent and could not be reproduced locally (same as the previous steering fix); the fixes follow the captured error chains, and the regression test pins the runtime-host race deterministically.