### PR TITLE
test: collapse low-signal decision cases

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-readiness.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-readiness.test.ts
@@ -56,6 +56,20 @@ describe('chat readiness guard', () => {
         includes: '等待填写 API key',
         reason: 'missing_api_key',
       },
+      {
+        name: 'OAuth provider requires login token',
+        slug: 'claude-subscription',
+        deps: deps({
+          connection: connection({
+            slug: 'claude-subscription',
+            name: 'Claude OAuth',
+            providerType: 'claude-subscription',
+          }),
+          apiKey: null,
+        }),
+        includes: '等待完成 OAuth 登录',
+        reason: 'missing_api_key',
+      },
     ];
 
     for (const entry of table) {
@@ -132,42 +146,6 @@ describe('chat readiness guard', () => {
     assert.equal(real.model, 'claude-3-5-sonnet-20241022');
   });
 
-  test('allows Claude OAuth once its subscription send path is wired', async () => {
-    const ready = await requireReadyConnection(
-      'claude-subscription',
-      deps({
-        connection: connection({
-          slug: 'claude-subscription',
-          name: 'Claude OAuth',
-          providerType: 'claude-subscription',
-          defaultModel: 'claude-sonnet-4-5-20250929',
-        }),
-        apiKey: 'oauth-access-token',
-      }),
-    );
-    assert.equal(ready.connection.slug, 'claude-subscription');
-    assert.equal(ready.apiKey, 'oauth-access-token');
-    assert.equal(ready.model, 'claude-sonnet-4-5-20250929');
-  });
-
-  test('allows Codex OAuth once its subscription send path is wired', async () => {
-    const ready = await requireReadyConnection(
-      'openai-codex',
-      deps({
-        connection: connection({
-          slug: 'openai-codex',
-          name: 'Codex Subscription',
-          providerType: 'openai-codex',
-          defaultModel: 'gpt-5.5',
-        }),
-        apiKey: 'codex-oauth-secret',
-      }),
-    );
-    assert.equal(ready.connection.slug, 'openai-codex');
-    assert.equal(ready.apiKey, 'codex-oauth-secret');
-    assert.equal(ready.model, 'gpt-5.5');
-  });
-
   test('normalizes stale Codex OAuth session model away from unsupported ChatGPT-account model', async () => {
     const ready = await requireReadyConnection(
       'openai-codex',
@@ -236,55 +214,6 @@ describe('chat readiness guard', () => {
         assert.match(message, /gpt-4o-NOT-IN-LIST/, 'requested model must appear in error copy');
         assert.doesNotMatch(message, /claude-3-5-sonnet-20241022/, 'defaultModel must NOT leak into requested-model error');
         assert.equal(errorReason(error), 'model_not_enabled');
-        return true;
-      },
-    );
-  });
-
-  test('PR110a regression: missing_model error fires when both requested and default are empty', async () => {
-    await assertRejectsReadiness(
-      'no requested, no default',
-      () => requireReadyConnection('custom', deps({
-        connection: connection({ slug: 'custom', defaultModel: '' }),
-        apiKey: 'sk-test',
-      })),
-      '没有可用模型',
-      'missing_model',
-    );
-  });
-
-  test('missing_api_key copy is an actionable waiting state, not a raw missing-field error', async () => {
-    await assert.rejects(
-      () => requireReadyConnection('anthropic', deps({ connection: connection(), apiKey: null })),
-      (error) => {
-        const message = (error as Error).message;
-        assert.match(message, /等待填写 API key/);
-        assert.doesNotMatch(message, /缺少 API key/);
-        assert.equal(errorReason(error), 'missing_api_key');
-        return true;
-      },
-    );
-  });
-
-  test('Claude OAuth missing token copy asks the user to login, not paste an API key', async () => {
-    await assert.rejects(
-      () => requireReadyConnection(
-        'claude-subscription',
-        deps({
-          connection: connection({
-            slug: 'claude-subscription',
-            name: 'Claude OAuth',
-            providerType: 'claude-subscription',
-            defaultModel: 'claude-sonnet-4-5-20250929',
-          }),
-          apiKey: null,
-        }),
-      ),
-      (error) => {
-        const message = (error as Error).message;
-        assert.match(message, /等待完成 OAuth 登录/);
-        assert.doesNotMatch(message, /等待填写 API key/);
-        assert.equal(errorReason(error), 'missing_api_key');
         return true;
       },
     );
@@ -537,19 +466,6 @@ describe('chat readiness guard', () => {
     );
   });
 
-  test('fake backend send failures do not expose dev/demo terminology', async () => {
-    await assert.rejects(
-      () => assertSessionCanSend(header({ backend: 'fake', llmConnectionSlug: 'fake', model: 'fake-model' }), deps()),
-      (error) => {
-        const message = (error as Error).message;
-        const visibleMessage = message.replace(/^NO_REAL_CONNECTION:[a-z_]+:\s*/, '');
-        assert.match(visibleMessage, /旧的本地模拟连接/);
-        assert.doesNotMatch(visibleMessage, /FakeBackend|fake|开发演示|演示版/i);
-        assert.equal(errorReason(error), 'fake_backend');
-        return true;
-      },
-    );
-  });
 });
 
 async function assertRejectsReadiness(name: string, fn: () => Promise<unknown>, includes: string, reason: string): Promise<void> {

--- a/apps/desktop/src/main/__tests__/explore-agent-tool.test.ts
+++ b/apps/desktop/src/main/__tests__/explore-agent-tool.test.ts
@@ -1,11 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { buildExploreAgentTool, runReadOnlyExplore } from '../explore-agent-tool.js';
-
-const repoRoot = join(process.cwd(), '..', '..');
 
 describe('ExploreAgent read-only worker', () => {
   it('exposes a categorized read-only subagent tool', () => {
@@ -473,110 +471,6 @@ describe('ExploreAgent read-only worker', () => {
     });
   });
 
-  it('has a structured chat preview instead of raw JSON fallback', async () => {
-    const [toolResultPreview, agentPreview, events] = await Promise.all([
-      readFile(join(process.cwd(), '../../packages/ui/src/tool-activity/tool-result-preview.tsx'), 'utf8'),
-      readFile(join(process.cwd(), '../../packages/ui/src/tool-activity/agent-preview.tsx'), 'utf8'),
-      readFile(join(process.cwd(), '../../packages/core/src/events.ts'), 'utf8'),
-    ]);
-
-    assert.match(events, /kind: 'explore_agent'/);
-    assert.match(events, /partial\?: boolean/);
-    assert.match(events, /terminalStatus\?: 'completed'/);
-    assert.match(events, /filesDiscovered\?: number/);
-    assert.match(events, /ignoredPaths\?: string/);
-    assert.match(events, /stoppingCondition\?: string/);
-    assert.match(events, /limitReasons\?: ReadonlyArray/);
-    assert.match(events, /summary\?: string/);
-    assert.match(events, /recentEvents\?: ReadonlyArray/);
-    assert.match(toolResultPreview, /content\.kind === 'explore_agent'/);
-    assert.match(agentPreview, /export function ExploreAgentPreview/);
-    const previewBlock = agentPreview.match(/export function ExploreAgentPreview[\s\S]*$/)?.[0] ?? '';
-    assert.match(previewBlock, /result\.progress/);
-    assert.match(previewBlock, /result\.recentEvents/);
-    assert.match(previewBlock, /formatExploreAgentEvent/);
-    assert.match(previewBlock, /formatExploreAgentEvent\(event, result\.startedAt, locale\)/);
-    assert.match(previewBlock, /formatExploreAgentEventOffset/);
-    assert.match(previewBlock, /result\.evidence/);
-    assert.match(previewBlock, /result\.summary/);
-    assert.match(previewBlock, /result\.report/);
-    assert.match(previewBlock, /result\.durationMs/);
-    assert.match(previewBlock, /copy\.section\.process/);
-    assert.match(previewBlock, /copy\.section\.evidence/);
-    assert.match(previewBlock, /copy\.section\.report/);
-    assert.match(previewBlock, /copy\.duration/);
-    assert.match(previewBlock, /resultSummary/);
-    assert.match(previewBlock, /terminalStatus/);
-    assert.match(previewBlock, /copy\.field\.terminal/);
-    assert.match(previewBlock, /copy\.terminalStatus\.completed_empty/);
-    assert.match(previewBlock, /filesDiscovered/);
-    assert.match(previewBlock, /copy\.field\.foundRead/);
-    assert.match(previewBlock, /copy\.foundRead/);
-    assert.match(previewBlock, /copyPayloads\.summary/);
-    assert.match(previewBlock, /copy\.detail\.scope/);
-    assert.match(previewBlock, /copy\.detail\.queries/);
-    assert.match(previewBlock, /copy\.detail\.boundary/);
-    assert.match(previewBlock, /copy\.copyButtons\.summary/);
-    assert.match(previewBlock, /processLines/);
-    assert.match(previewBlock, /result\.recentEvents\.slice\(0, 20\)/);
-    assert.match(previewBlock, /copyPayloads\.process/);
-    assert.match(previewBlock, /copy\.field\.events/);
-    assert.match(previewBlock, /copy\.copyButtons\.process/);
-    assert.match(previewBlock, /copyPayloads\.evidence/);
-    assert.match(previewBlock, /copy\.field\.evidence/);
-    assert.match(previewBlock, /copy\.copyButtons\.evidence/);
-    assert.match(previewBlock, /copyPayloads\.candidate/);
-    assert.match(previewBlock, /copy\.field\.candidates/);
-    assert.match(previewBlock, /copy\.copyButtons\.candidate/);
-    assert.match(previewBlock, /copyPayloads\.matches/);
-    assert.match(previewBlock, /copy\.field\.matches/);
-    assert.match(previewBlock, /copy\.copyButtons\.matches/);
-    assert.match(previewBlock, /continuationText/);
-    assert.match(previewBlock, /needsContinuation/);
-    assert.match(previewBlock, /continuationReason/);
-    assert.match(previewBlock, /presentExploreAgentContinuationReason/);
-    assert.match(previewBlock, /copy\.continuationIntro/);
-    assert.match(previewBlock, /copy\.field\.continuationReason/);
-    assert.match(previewBlock, /copy\.continuationSuggested/);
-    assert.match(previewBlock, /getToolActivityCopy\(locale\)\.agent\.continuationReason/);
-    assert.match(previewBlock, /return copy\.empty/);
-    assert.match(previewBlock, /copy\.field\.previousDuration/);
-    assert.match(previewBlock, /copy\.field\.previousBoundary/);
-    assert.match(previewBlock, /copy\.continuationCandidates/);
-    assert.match(previewBlock, /copy\.copyButtons\.continuation/);
-    assert.match(previewBlock, /copy\.copyButtons\.report/);
-    assert.match(previewBlock, /useClipboardCopyFeedback\(\)/);
-    assert.match(previewBlock, /data-pending=\{summaryCopy\.phase === 'pending'/);
-    assert.match(previewBlock, /data-copy-error=\{summaryCopy\.phase === 'failed'/);
-    // #1565 PR 3: Astryx Button spells the disabled prop `isDisabled`.
-    assert.match(previewBlock, /isDisabled=\{summaryCopy\.disabled\}/);
-    assert.match(previewBlock, /<UiButton[\s\S]*?variant="ghost"[\s\S]*?size="sm"[\s\S]*?className=\{previewVariants\(\{ part: 'agent-copy' \}\)\}/);
-    assert.equal(
-      previewBlock.match(/previewVariants\(\{ part: 'agent-copy' \}\)/g)?.length,
-      7,
-      'ExploreAgent copy actions should keep the governed previewVariants agent-copy part on shared UiButton controls',
-    );
-    assert.doesNotMatch(previewBlock, /\bmaka-explore-agent-copy\b/);
-    const chatPrimitive = await readFile(join(repoRoot, 'packages/ui/src/primitives/chat.tsx'), 'utf8');
-    const agentCopyVariant = chatPrimitive.match(/"agent-copy":\s*[\s\S]*?data-\[copy-error=true\][^,]+/)?.[0] ?? '';
-    assert.doesNotMatch(agentCopyVariant, /\b(?:gap-|min-h-|px-|py-|text-xs)\b/);
-    assert.doesNotMatch(previewBlock, /data-size="sm"/);
-    assert.match(previewBlock, /copy\.copyState\.pending/);
-    assert.match(previewBlock, /copy\.copyState\.failed/);
-    assert.match(previewBlock, /sensitiveFilesSkipped/);
-    assert.match(previewBlock, /ignoredPaths/);
-    assert.match(previewBlock, /copy\.detail\.ignored/);
-    assert.match(previewBlock, /stoppingCondition/);
-    assert.match(previewBlock, /copy\.detail\.stopping/);
-    assert.match(previewBlock, /limitReasons/);
-    assert.match(previewBlock, /copy\.budgetLimited/);
-    assert.match(previewBlock, /copy\.detail\.boundary/);
-    assert.match(previewBlock, /copy\.cancelledPartial/);
-    assert.match(previewBlock, /copy\.terminalStatus\.canceled/);
-    assert.match(previewBlock, /copy\.candidateReason/);
-    assert.match(previewBlock, /redactSecrets/);
-    assert.doesNotMatch(previewBlock, /<a\s/i, 'ExploreAgent preview should not create links from tool result paths');
-  });
 });
 
 async function withWorkspace(fn: (workspaceRoot: string) => Promise<void>): Promise<void> {

--- a/apps/desktop/src/main/__tests__/maka-uri.test.ts
+++ b/apps/desktop/src/main/__tests__/maka-uri.test.ts
@@ -1,25 +1,3 @@
-/**
- * Tests for the PR-UI-RENDER-2 internal-URI parser.
- *
- * The renderer's `<a>` override calls `parseMakaUri(href)` exactly
- * once and branches on a discriminated union or `null`. We lock the
- * parser's narrow contract here so a future "let's also allow
- * `maka://tool/...`" change can't sneak past silently.
- *
- * @kenji review gates (msg 1e9a9d96 + msg 4d41ba39) addressed:
- *   - scheme is exact `maka:` (no `Maka:` / `MAKA:` etc.)
- *   - settings section must be a real `SettingsSection` member
- *   - host-based dispatch (not pathname-segment-0 dispatch)
- *   - compose.text length-capped, empty-text rejected, raw href
- *     length-capped before URL constructor
- *   - unsupported namespace → null (renderer renders broken-link
- *     inline error, NOT external-link fallback)
- *   - no userinfo / port / fragment leakage
- *
- * Imported via `@maka/ui/maka-uri` subpath so node:test doesn't load
- * the React barrel.
- */
-
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { SETTINGS_SECTIONS } from '@maka/core';
@@ -30,288 +8,140 @@ import {
   parseMakaUri,
 } from '@maka/ui/maka-uri';
 
-describe('parseMakaUri — scheme gate', () => {
-  it('rejects non-maka schemes', () => {
-    assert.equal(parseMakaUri('https://example.com/'), null);
-    assert.equal(parseMakaUri('http://settings/account'), null);
-    assert.equal(parseMakaUri('file:///etc/passwd'), null);
-    assert.equal(parseMakaUri('javascript:alert(1)'), null);
-    assert.equal(parseMakaUri('data:text/html,<script>'), null);
-  });
+describe('Maka URI safety boundary', () => {
+  it('parses only supported settings and compose destinations', () => {
+    for (const section of SETTINGS_SECTIONS) {
+      assert.deepEqual(parseMakaUri(`maka://settings/${section}`), {
+        kind: 'settings',
+        section,
+      });
+    }
 
-  it('rejects mixed-case scheme writes (Maka:, MAKA:)', () => {
-    // The parser is intentionally strict here so a prompt-injected
-    // assistant can't slip past with `Maka://settings/account`.
-    assert.equal(parseMakaUri('Maka://settings/account'), null);
-    assert.equal(parseMakaUri('MAKA://settings/account'), null);
-    assert.equal(parseMakaUri('MaKa://settings/account'), null);
-  });
-
-  it('rejects empty / non-string inputs', () => {
-    assert.equal(parseMakaUri(''), null);
-    // @ts-expect-error — intentional bad input
-    assert.equal(parseMakaUri(null), null);
-    // @ts-expect-error — intentional bad input
-    assert.equal(parseMakaUri(undefined), null);
-    // @ts-expect-error — intentional bad input
-    assert.equal(parseMakaUri(42), null);
-  });
-
-  it('rejects oversized raw hrefs before reaching URL()', () => {
-    const giant = 'maka://compose?text=' + 'x'.repeat(8192);
-    assert.equal(parseMakaUri(giant), null);
-  });
-
-  it('rejects malformed maka: hrefs', () => {
-    assert.equal(parseMakaUri('maka://'), null);
-    assert.equal(parseMakaUri('maka:settings/account'), null); // no `//`
-  });
-});
-
-describe('parseMakaUri — settings', () => {
-  it('accepts every known SettingsSection', () => {
-    for (const s of SETTINGS_SECTIONS) {
-      const dest = parseMakaUri(`maka://settings/${s}`);
-      assert.deepEqual(dest, { kind: 'settings', section: s }, `section=${s}`);
+    const composeCases = [
+      ['maka://compose?text=hello', 'hello'],
+      ['maka://compose?text=%E4%BD%A0%E5%A5%BD', '你好'],
+      ['maka://compose/?text=Hello%20world%21', 'Hello world!'],
+    ] as const;
+    for (const [href, text] of composeCases) {
+      assert.deepEqual(parseMakaUri(href), { kind: 'compose', text });
     }
   });
 
-  it('rejects unknown sections', () => {
-    assert.equal(parseMakaUri('maka://settings/zzz'), null);
-    assert.equal(parseMakaUri('maka://settings/account-list'), null);
-    assert.equal(parseMakaUri('maka://settings/admin'), null);
-  });
-
-  it('rejects empty / missing section', () => {
-    assert.equal(parseMakaUri('maka://settings/'), null);
-    assert.equal(parseMakaUri('maka://settings'), null);
-  });
-
-  it('rejects sub-paths under settings', () => {
-    assert.equal(parseMakaUri('maka://settings/account/edit'), null);
-    assert.equal(parseMakaUri('maka://settings/account/../tools'), null);
-  });
-
-  it('rejects query / fragment on settings', () => {
-    assert.equal(parseMakaUri('maka://settings/account?force=1'), null);
-    assert.equal(parseMakaUri('maka://settings/account#section'), null);
-  });
-
-  it('dispatches by host, not by pathname-segment-0', () => {
-    // `URL('maka://settings/models')` exposes:
-    //   host = 'settings', pathname = '/models'
-    // If the parser ever regresses to "split path and take [0]" it
-    // would treat the section "settings" as the namespace and the
-    // (now-missing) section as undefined. Lock the host invariant.
-    const dest = parseMakaUri('maka://settings/models');
-    assert.deepEqual(dest, { kind: 'settings', section: 'models' });
-  });
-
-  it('rejects uppercase host variants (maka: is a non-special scheme so URL keeps host as-is)', () => {
-    // For "special" URL schemes (http, https, ftp, ws, wss, ftp,
-    // file) the WHATWG URL parser lowercases the hostname. For
-    // every other scheme — including `maka:` — the hostname is
-    // preserved verbatim. So `new URL('maka://SETTINGS/account')`
-    // exposes `hostname === 'SETTINGS'`, which does NOT match our
-    // case-sensitive switch on `'settings'`. The parser returns
-    // null. This is strictly more conservative than lowercasing
-    // would be — locking it in.
-    assert.equal(parseMakaUri('maka://SETTINGS/account'), null);
-    assert.equal(parseMakaUri('maka://Settings/account'), null);
-    assert.equal(parseMakaUri('maka://COMPOSE?text=hi'), null);
-  });
-});
-
-describe('parseMakaUri — compose', () => {
-  it('accepts a plain text param', () => {
-    const dest = parseMakaUri('maka://compose?text=hello');
-    assert.deepEqual(dest, { kind: 'compose', text: 'hello' });
-  });
-
-  it('URL-decodes the text param (UTF-8)', () => {
-    const dest = parseMakaUri('maka://compose?text=%E4%BD%A0%E5%A5%BD');
-    assert.deepEqual(dest, { kind: 'compose', text: '你好' });
-  });
-
-  it('accepts text with spaces and punctuation', () => {
-    const dest = parseMakaUri('maka://compose?text=Hello%20world%21');
-    assert.deepEqual(dest, { kind: 'compose', text: 'Hello world!' });
-  });
-
-  it('rejects empty text', () => {
-    assert.equal(parseMakaUri('maka://compose?text='), null);
-  });
-
-  it('rejects missing text param', () => {
-    assert.equal(parseMakaUri('maka://compose'), null);
-    assert.equal(parseMakaUri('maka://compose?other=value'), null);
-  });
-
-  it('rejects text exceeding decoded length cap', () => {
-    // 5000 chars of text → past the 4096 cap.
-    const long = 'a'.repeat(5000);
-    assert.equal(parseMakaUri(`maka://compose?text=${long}`), null);
-  });
-
-  it('rejects compose sub-paths', () => {
-    assert.equal(parseMakaUri('maka://compose/run?text=hi'), null);
-    assert.equal(parseMakaUri('maka://compose/admin?text=hi'), null);
-  });
-
-  it('treats trailing slash as no path (accept)', () => {
-    const dest = parseMakaUri('maka://compose/?text=hi');
-    assert.deepEqual(dest, { kind: 'compose', text: 'hi' });
-  });
-});
-
-describe('parseMakaUri — unsupported namespaces (action runners)', () => {
-  it('rejects maka://tool/... (no action execution)', () => {
-    assert.equal(parseMakaUri('maka://tool/run'), null);
-    assert.equal(parseMakaUri('maka://tool/Bash?cmd=ls'), null);
-  });
-
-  it('rejects maka://auth/... (no auth flow trigger)', () => {
-    assert.equal(parseMakaUri('maka://auth/login'), null);
-    assert.equal(parseMakaUri('maka://auth/oauth?provider=claude'), null);
-  });
-
-  it('rejects maka://exec/... and other action namespaces', () => {
-    assert.equal(parseMakaUri('maka://exec/shell'), null);
-    assert.equal(parseMakaUri('maka://run/skill'), null);
-    assert.equal(parseMakaUri('maka://mcp/connect'), null);
-  });
-
-  it('rejects maka://session/... (defer to session navigation API)', () => {
-    // PR-RENDER-2 review explicitly defers this. Lock the null
-    // behavior so when a real session API arrives, this test will
-    // need to be updated alongside.
-    assert.equal(parseMakaUri('maka://session/abc-123'), null);
-  });
-
-  it('rejects maka://runtime/... (tool resource refs, not UI navigation)', () => {
-    assert.equal(parseMakaUri('maka://runtime/background-tasks/shell-run-1'), null);
-  });
-
-  it('rejects empty host', () => {
-    assert.equal(parseMakaUri('maka:///account'), null);
-  });
-
-  it('rejects host with userinfo / port', () => {
-    assert.equal(parseMakaUri('maka://user@settings/account'), null);
-    assert.equal(parseMakaUri('maka://settings:9999/account'), null);
-  });
-});
-
-describe('isMakaUri', () => {
-  it('returns true for any string starting with maka:', () => {
-    assert.equal(isMakaUri('maka://settings/account'), true);
-    assert.equal(isMakaUri('maka://tool/run'), true); // valid scheme, just unsupported namespace
-    assert.equal(isMakaUri('maka:'), true);
-  });
-
-  it('returns false for other schemes', () => {
-    assert.equal(isMakaUri('https://example.com/'), false);
-    assert.equal(isMakaUri('Maka://settings/account'), false); // case-sensitive
-    assert.equal(isMakaUri('   maka://settings/account'), false); // no whitespace trim
-  });
-
-  it('returns false for non-strings', () => {
-    // @ts-expect-error — intentional bad input
-    assert.equal(isMakaUri(null), false);
-    // @ts-expect-error — intentional bad input
-    assert.equal(isMakaUri(undefined), false);
-  });
-});
-
-describe('isMakaUriCandidate — case-insensitive renderer probe (@kenji msg 7fb8d15c)', () => {
-  // The renderer needs to catch ANY case-variant of `maka:` so that
-  // `Maka://settings/account` etc. route to the broken-link inline
-  // error rather than falling through to external `<a target=_blank>`.
-  // `parseMakaUri` still strictly accepts only lowercase `maka:`,
-  // so case-variants here cause `parseMakaUri === null` AND
-  // `isMakaUriCandidate === true` → broken-link render.
-
-  it('returns true for lowercase maka:', () => {
-    assert.equal(isMakaUriCandidate('maka://settings/account'), true);
-  });
-
-  it('returns true for uppercase / mixed-case scheme', () => {
-    assert.equal(isMakaUriCandidate('Maka://settings/account'), true);
-    assert.equal(isMakaUriCandidate('MAKA://settings/account'), true);
-    assert.equal(isMakaUriCandidate('MaKa://compose?text=hi'), true);
-  });
-
-  it('returns false for other schemes', () => {
-    assert.equal(isMakaUriCandidate('https://example.com/'), false);
-    assert.equal(isMakaUriCandidate('javascript:alert(1)'), false);
-    assert.equal(isMakaUriCandidate('makafake://oops'), false);
-  });
-
-  it('returns false for non-strings', () => {
-    // @ts-expect-error — defensive
-    assert.equal(isMakaUriCandidate(null), false);
-    // @ts-expect-error — defensive
-    assert.equal(isMakaUriCandidate(undefined), false);
-    // @ts-expect-error — defensive
-    assert.equal(isMakaUriCandidate(42), false);
-  });
-
-  it('case-variants are candidate=true but parseMakaUri=null → renderer renders broken-link', () => {
-    // The two halves of the gate combined: this is the contract the
-    // renderer relies on for "Maka://... must NOT navigate".
-    for (const href of ['Maka://settings/account', 'MAKA://compose?text=hi', 'MaKa://settings/health']) {
-      assert.equal(isMakaUriCandidate(href), true, `candidate true for ${href}`);
-      assert.equal(parseMakaUri(href), null, `parseMakaUri null for ${href}`);
+  it('rejects malformed, case-variant, and oversized internal URIs', () => {
+    const invalidInputs: unknown[] = [
+      '',
+      null,
+      undefined,
+      42,
+      'https://example.com/',
+      'file:///etc/passwd',
+      'javascript:alert(1)',
+      'data:text/html,<script>',
+      'Maka://settings/account',
+      'MAKA://settings/account',
+      'maka://',
+      'maka:settings/account',
+      `maka://compose?text=${'x'.repeat(8192)}`,
+    ];
+    for (const input of invalidInputs) {
+      assert.equal(parseMakaUri(input as string), null, String(input));
     }
   });
-});
 
-describe('isSafeExternalScheme — explicit external allowlist (@kenji msg 7fb8d15c + 73e92ef0)', () => {
-  it('accepts http: / https: / mailto: only', () => {
-    assert.equal(isSafeExternalScheme('http://example.com'), true);
-    assert.equal(isSafeExternalScheme('https://example.com/path?q=1'), true);
-    assert.equal(isSafeExternalScheme('mailto:user@example.com'), true);
+  it('rejects widened settings, compose, and action namespaces', () => {
+    const invalidHrefs = [
+      'maka://settings/zzz',
+      'maka://settings/',
+      'maka://settings',
+      'maka://settings/account/edit',
+      'maka://settings/account?force=1',
+      'maka://settings/account#section',
+      'maka://SETTINGS/account',
+      'maka://compose?text=',
+      'maka://compose?other=value',
+      `maka://compose?text=${'a'.repeat(5000)}`,
+      'maka://compose/run?text=hi',
+      'maka://tool/Bash?cmd=ls',
+      'maka://auth/oauth?provider=claude',
+      'maka://exec/shell',
+      'maka://run/skill',
+      'maka://mcp/connect',
+      'maka://session/abc-123',
+      'maka://runtime/background-tasks/shell-run-1',
+      'maka:///account',
+      'maka://user@settings/account',
+      'maka://settings:9999/account',
+    ];
+    for (const href of invalidHrefs) assert.equal(parseMakaUri(href), null, href);
   });
 
-  it('rejects dangerous schemes', () => {
-    assert.equal(isSafeExternalScheme('javascript:alert(1)'), false);
-    assert.equal(isSafeExternalScheme('data:text/html,<script>alert(1)</script>'), false);
-    assert.equal(isSafeExternalScheme('file:///etc/passwd'), false);
-    assert.equal(isSafeExternalScheme('vbscript:msgbox("x")'), false);
+  it('recognizes only the exact internal scheme', () => {
+    for (const href of ['maka://settings/account', 'maka://tool/run', 'maka:']) {
+      assert.equal(isMakaUri(href), true, href);
+    }
+    for (const input of [
+      'https://example.com/',
+      'Maka://settings/account',
+      '   maka://settings/account',
+      null,
+      undefined,
+    ]) {
+      assert.equal(isMakaUri(input as string), false, String(input));
+    }
   });
 
-  it('rejects maka: scheme (handled by the internal path, not external)', () => {
-    assert.equal(isSafeExternalScheme('maka://settings/account'), false);
-    assert.equal(isSafeExternalScheme('Maka://settings/account'), false);
+  it('flags case-variant internal candidates without allowing navigation', () => {
+    for (const href of [
+      'maka://settings/account',
+      'Maka://settings/account',
+      'MAKA://compose?text=hi',
+      'MaKa://settings/health',
+    ]) {
+      assert.equal(isMakaUriCandidate(href), true, href);
+      if (!href.startsWith('maka:')) assert.equal(parseMakaUri(href), null, href);
+    }
+    for (const input of [
+      'https://example.com/',
+      'javascript:alert(1)',
+      'makafake://oops',
+      null,
+      undefined,
+      42,
+    ]) {
+      assert.equal(isMakaUriCandidate(input as string), false, String(input));
+    }
   });
 
-  it('rejects custom / unknown schemes', () => {
-    assert.equal(isSafeExternalScheme('ms-excel://something'), false);
-    assert.equal(isSafeExternalScheme('telnet://host'), false);
-    assert.equal(isSafeExternalScheme('ftp://host'), false);
-  });
+  it('allows only explicit external schemes', () => {
+    for (const href of [
+      'http://example.com',
+      'https://example.com/path?q=1',
+      'mailto:user@example.com',
+    ]) {
+      assert.equal(isSafeExternalScheme(href), true, href);
+    }
 
-  it('rejects garbage / unparseable hrefs', () => {
-    assert.equal(isSafeExternalScheme(''), false);
-    assert.equal(isSafeExternalScheme('not a url'), false);
-    assert.equal(isSafeExternalScheme('://no-scheme'), false);
-  });
-
-  it('rejects bare emails without mailto: prefix (parser must see real mailto URL)', () => {
-    // @kenji msg 73e92ef0: bare `user@example.com` is not a URL and
-    // must not auto-link. The C2 PR doesn't introduce email
-    // autolinking; this test locks that we don't accidentally
-    // accept it via a prefix-match shortcut.
-    assert.equal(isSafeExternalScheme('user@example.com'), false);
-    assert.equal(isSafeExternalScheme('mailto-info:contact'), false);
-  });
-
-  it('rejects non-strings', () => {
-    // @ts-expect-error — defensive
-    assert.equal(isSafeExternalScheme(null), false);
-    // @ts-expect-error — defensive
-    assert.equal(isSafeExternalScheme(undefined), false);
-    // @ts-expect-error — defensive
-    assert.equal(isSafeExternalScheme(42), false);
+    const rejected: unknown[] = [
+      '',
+      null,
+      undefined,
+      42,
+      'not a url',
+      '://no-scheme',
+      'user@example.com',
+      'mailto-info:contact',
+      'javascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'file:///etc/passwd',
+      'vbscript:msgbox("x")',
+      'maka://settings/account',
+      'Maka://settings/account',
+      'ms-excel://something',
+      'telnet://host',
+      'ftp://host',
+    ];
+    for (const href of rejected) {
+      assert.equal(isSafeExternalScheme(href as string), false, String(href));
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/materialize-turns.test.ts
+++ b/apps/desktop/src/main/__tests__/materialize-turns.test.ts
@@ -629,119 +629,42 @@ describe('materializeTurns timeline', () => {
 });
 
 describe('deriveTurnLineageMap', () => {
-  it('derives reverse links without mutating old turns', () => {
-    const map = deriveTurnLineageMap([
-      { turnId: 'old' },
-      { turnId: 'retry', retriedFromTurnId: 'old' },
-      { turnId: 'regen', regeneratedFromTurnId: 'old' },
-    ]);
-
-    assert.deepEqual(map.get('old'), {
-      retriedToTurnId: 'retry',
-      regeneratedToTurnId: 'regen',
-    });
-  });
-
-  it('returns empty map when no descendants', () => {
-    const map = deriveTurnLineageMap([
-      { turnId: 'solo-a' },
-      { turnId: 'solo-b' },
-    ]);
-    assert.equal(map.size, 0);
-  });
-
-  it('retriedTo only when no regenerate descendant exists', () => {
-    const map = deriveTurnLineageMap([
-      { turnId: 'origin' },
-      { turnId: 'retry-1', retriedFromTurnId: 'origin' },
-    ]);
-    assert.deepEqual(map.get('origin'), { retriedToTurnId: 'retry-1' });
-    assert.equal(map.get('origin')?.regeneratedToTurnId, undefined);
-  });
-
-  it('regeneratedTo only when no retry descendant exists', () => {
-    const map = deriveTurnLineageMap([
-      { turnId: 'origin' },
-      { turnId: 'regen-1', regeneratedFromTurnId: 'origin' },
-    ]);
-    assert.deepEqual(map.get('origin'), { regeneratedToTurnId: 'regen-1' });
-    assert.equal(map.get('origin')?.retriedToTurnId, undefined);
-  });
-
-  it('multi-retry uses last-wins semantics (most recent retry surfaced)', () => {
-    // Two retries off the same origin: the most recent one in the
-    // input array wins. UI consumers can show "已重新生成 → turn ${id}"
-    // pointing at the latest attempt; older retries are still findable
-    // by scanning the turn list for `retriedFromTurnId === origin`.
-    const map = deriveTurnLineageMap([
-      { turnId: 'origin' },
-      { turnId: 'retry-1', retriedFromTurnId: 'origin' },
-      { turnId: 'retry-2', retriedFromTurnId: 'origin' },
-      { turnId: 'retry-3', retriedFromTurnId: 'origin' },
-    ]);
-    assert.equal(map.get('origin')?.retriedToTurnId, 'retry-3');
-  });
-
-  it('mixed retry + regenerate descendants populate both fields independently', () => {
-    const map = deriveTurnLineageMap([
-      { turnId: 'origin' },
-      { turnId: 'retry-1', retriedFromTurnId: 'origin' },
-      { turnId: 'regen-1', regeneratedFromTurnId: 'origin' },
-      { turnId: 'regen-2', regeneratedFromTurnId: 'origin' },
-    ]);
-    const entry = map.get('origin');
-    assert.equal(entry?.retriedToTurnId, 'retry-1');
-    assert.equal(entry?.regeneratedToTurnId, 'regen-2'); // last regen wins
-  });
-
-  it('multiple origins each get their own entry', () => {
-    const map = deriveTurnLineageMap([
+  it('derives independent reverse links with last-wins semantics', () => {
+    const input = [
       { turnId: 'origin-a' },
       { turnId: 'origin-b' },
-      { turnId: 'retry-a', retriedFromTurnId: 'origin-a' },
+      { turnId: 'retry-a-1', retriedFromTurnId: 'origin-a' },
+      { turnId: 'regen-a-1', regeneratedFromTurnId: 'origin-a' },
+      { turnId: 'retry-a-2', retriedFromTurnId: 'origin-a' },
       { turnId: 'retry-b', retriedFromTurnId: 'origin-b' },
-    ]);
-    assert.equal(map.size, 2);
-    assert.equal(map.get('origin-a')?.retriedToTurnId, 'retry-a');
-    assert.equal(map.get('origin-b')?.retriedToTurnId, 'retry-b');
-  });
-
-  it('descendant turns without a lineage parent do not appear as origins', () => {
-    // A bare turn list (no parents pointing to anything) produces an
-    // empty map even if the turns themselves carry no lineage fields.
-    const map = deriveTurnLineageMap([
-      { turnId: 'a' },
-      { turnId: 'b' },
-      { turnId: 'c' },
-    ]);
-    assert.equal(map.size, 0);
-  });
-
-  it('helper is pure (no mutation of input)', () => {
-    const input = [
-      { turnId: 'origin' },
-      { turnId: 'retry', retriedFromTurnId: 'origin' },
     ] as const;
     const before = JSON.stringify(input);
-    deriveTurnLineageMap(input);
+    const map = deriveTurnLineageMap(input);
+
+    assert.deepEqual([...map], [
+      [
+        'origin-a',
+        { retriedToTurnId: 'retry-a-2', regeneratedToTurnId: 'regen-a-1' },
+      ],
+      ['origin-b', { retriedToTurnId: 'retry-b' }],
+    ]);
     assert.equal(JSON.stringify(input), before);
+  });
+
+  it('returns no reverse links when turns have no lineage parent', () => {
+    assert.equal(deriveTurnLineageMap([{ turnId: 'a' }, { turnId: 'b' }]).size, 0);
   });
 });
 
 describe('automation turn attribution (F6)', () => {
-  it('projects an automation origin onto the turn user entry', () => {
+  it('projects only explicit automation origins', () => {
     const turns = materializeTurns([
       { type: 'user', id: 'u1', turnId: 't1', ts: 1, text: '早报', origin: { kind: 'automation', automationId: 'auto-1' } },
       { type: 'assistant', id: 'a1', turnId: 't1', ts: 2, text: '好的' },
+      { type: 'user', id: 'u2', turnId: 't2', ts: 3, text: '你好' },
     ] as StoredMessage[]);
     assert.equal(turns[0]?.user?.automationOrigin?.automationId, 'auto-1');
-  });
-
-  it('hand-typed turns carry no automation origin', () => {
-    const turns = materializeTurns([
-      { type: 'user', id: 'u1', turnId: 't1', ts: 1, text: '你好' },
-    ] as StoredMessage[]);
-    assert.equal(turns[0]?.user?.automationOrigin, undefined);
+    assert.equal(turns[1]?.user?.automationOrigin, undefined);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/smooth-stream.test.ts
+++ b/apps/desktop/src/main/__tests__/smooth-stream.test.ts
@@ -1,28 +1,3 @@
-/**
- * Tests for the PR-UI-RENDER-1 smooth-streaming pure helpers.
- *
- * The React hook `useSmoothStreamContent` lives in `packages/ui` and
- * is exercised via screenshots + manual smoke. The helpers under test
- * here are the load-bearing pure functions the hook is a thin shell
- * over:
- *   - grapheme segmentation must not split emoji ZWJ sequences,
- *     skin-tone modifiers, flag indicators (review blocker #2)
- *   - frame advance respects EMA × dt with min/max CPS clamp, never
- *     overshoots the backlog, and always emits ≥1 char when work
- *     remains
- *   - live backlog raises the speed continuously instead of snapping
- *   - EMA ignores degenerate observations so a stalled arrival can't
- *     poison the typewriter speed
- *   - initial displayed count handles the three modes: snap=true,
- *     history hydration (streaming=false), live stream (streaming=true)
- *
- * Imported via the dedicated `@maka/ui/smooth-stream` subpath export so
- * the node:test environment loads ONLY the pure-helper module — not the
- * React-heavy `components.tsx` barrel. (@kenji review concern #1.) A
- * future export break in either `packages/ui/package.json` exports map
- * or `packages/ui/src/smooth-stream.ts` shows up here as a load error.
- */
-
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import {
@@ -35,256 +10,60 @@ import {
   updateEma,
 } from '@maka/ui/smooth-stream';
 
-describe('segmentGraphemes', () => {
-  it('returns [] for the empty string', () => {
+describe('smooth stream helpers', () => {
+  it('segments text without corrupting grapheme content', () => {
     assert.deepEqual(segmentGraphemes(''), []);
-  });
-
-  it('keeps ASCII as individual segments', () => {
     assert.deepEqual(segmentGraphemes('hi'), ['h', 'i']);
-  });
 
-  it('does not split a surrogate-pair emoji', () => {
-    // U+1F642 'slightly smiling face' is a non-BMP codepoint encoded
-    // as a UTF-16 surrogate pair. A naive `text.slice(0, 1)` would
-    // return half a surrogate, producing a lone surrogate that
-    // renders as the replacement char. We require the segmenter to
-    // treat it as a single grapheme.
-    const text = '🙂';
-    const graphemes = segmentGraphemes(text);
-    assert.equal(graphemes.length, 1);
-    assert.equal(graphemes[0], text);
-  });
-
-  it('keeps a ZWJ family emoji as one grapheme', () => {
-    // 👨‍👩‍👧‍👦 = man + ZWJ + woman + ZWJ + girl + ZWJ + boy.
-    // Codepoints: 7 (4 emoji + 3 ZWJ). Graphemes: 1 (the family).
-    // If we fall back to Array.from this assertion would see 7;
-    // Intl.Segmenter (which Node 22 ships with) collapses to 1.
-    const family = '👨‍👩‍👧‍👦';
-    const graphemes = segmentGraphemes(family);
-    // Either segmenter behavior is acceptable AS LONG AS we never
-    // mid-cut a surrogate. With Intl.Segmenter we expect 1; with
-    // Array.from we expect 7 codepoint atoms but NEVER a half
-    // surrogate. Assert the contract that matters: the join is
-    // lossless and no segment is a lone surrogate.
-    assert.equal(graphemes.join(''), family);
-    for (const g of graphemes) {
-      assert.ok(g.length >= 1, 'segment must be non-empty');
-      // No lone surrogate: each segment, when re-encoded, must
-      // round-trip through the codepoint iterator.
-      assert.deepEqual([...g], [...g]);
+    for (const text of ['🙂', '👨‍👩‍👧‍👦', '👍🏽', '🇨🇳', '\r\n', 'Hello 🙂 你好 👨‍👩‍👧 测试 🇨🇳!']) {
+      assert.equal(segmentGraphemes(text).join(''), text);
+    }
+    if (typeof Intl.Segmenter === 'function') {
+      for (const text of ['🙂', '👨‍👩‍👧‍👦', '👍🏽', '🇨🇳', '\r\n']) {
+        assert.equal(segmentGraphemes(text).length, 1, text);
+      }
     }
   });
 
-  it('keeps a skin-tone modified emoji as one grapheme', () => {
-    // 👍🏽 = thumbs up + medium skin tone (Fitzpatrick 4).
-    const thumb = '👍🏽';
-    const graphemes = segmentGraphemes(thumb);
-    assert.equal(graphemes.join(''), thumb);
-    // We require the segmenter behavior; Node 22's Intl.Segmenter
-    // collapses skin-tone modifiers into one grapheme.
-    if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
-      assert.equal(graphemes.length, 1);
-    }
-  });
-
-  it('keeps a regional-indicator flag as one grapheme', () => {
-    // 🇨🇳 = U+1F1E8 U+1F1F3 (two regional indicators that combine
-    // into the China flag).
-    const flag = '🇨🇳';
-    const graphemes = segmentGraphemes(flag);
-    assert.equal(graphemes.join(''), flag);
-    if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
-      assert.equal(graphemes.length, 1);
-    }
-  });
-
-  it('CRLF stays as one grapheme', () => {
-    const crlf = '\r\n';
-    const graphemes = segmentGraphemes(crlf);
-    assert.equal(graphemes.join(''), crlf);
-    if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
-      assert.equal(graphemes.length, 1);
-    }
-  });
-
-  it('round-trips arbitrary mixed content losslessly', () => {
-    const text = 'Hello 🙂 你好 👨‍👩‍👧 测试 🇨🇳!';
-    const graphemes = segmentGraphemes(text);
-    assert.equal(graphemes.join(''), text);
-  });
-});
-
-describe('computeFrameAdvance', () => {
-  it('returns 0 when displayed already caught up', () => {
-    assert.equal(
-      computeFrameAdvance({
-        rawGraphemeCount: 10,
-        displayedGraphemeCount: 10,
-        emaCps: 60,
-        dtMs: 16,
-        minCps: 30,
-        maxCps: 400,
-      }),
-      0,
-    );
-  });
-
-  // Regression lock (streaming UI rework, blank-bubble freeze): rAF timestamps
-  // are vsync-aligned and lag the wall clock under IPC delta bursts, so dtMs
-  // clamps to 0 for every tick in the recovery window. Returning 0 left
-  // displayedCount unchanged → the RAF effect never re-armed → the typewriter
-  // died with a full backlog and the answer snapped in at stream end. With
-  // backlog present, a non-positive dt must still advance 1 to keep the
-  // single-owner RAF chain alive.
-  it('advances 1 (not 0) when dt is non-positive but backlog remains — keeps the RAF chain alive', () => {
-    assert.equal(
-      computeFrameAdvance({
-        rawGraphemeCount: 100,
-        displayedGraphemeCount: 0,
-        emaCps: 60,
-        dtMs: 0,
-        minCps: 30,
-        maxCps: 400,
-      }),
-      1,
-    );
-    assert.equal(
-      computeFrameAdvance({
-        rawGraphemeCount: 100,
-        displayedGraphemeCount: 0,
-        emaCps: 60,
-        dtMs: -10,
-        minCps: 30,
-        maxCps: 400,
-      }),
-      1,
-    );
-    // …but never invents work: zero backlog still returns 0.
-    assert.equal(
-      computeFrameAdvance({
-        rawGraphemeCount: 10,
-        displayedGraphemeCount: 10,
-        emaCps: 60,
-        dtMs: 0,
-        minCps: 30,
-        maxCps: 400,
-      }),
-      0,
-    );
-  });
-
-  it('emits at least 1 grapheme when there is backlog and dt > 0', () => {
-    // EMA × dt / 1000 = 0.5 → floor = 0 → bumped to 1.
-    assert.equal(
-      computeFrameAdvance({
-        rawGraphemeCount: 100,
-        displayedGraphemeCount: 0,
-        emaCps: 30,
-        dtMs: 16,
-        minCps: 30,
-        maxCps: 400,
-      }),
-      1,
-    );
-  });
-
-  it('computes floor(cps * dt / 1000) for normal frames', () => {
-    // 120 cps × 50ms = 6 graphemes per frame.
-    assert.equal(
-      computeFrameAdvance({
-        rawGraphemeCount: 100,
-        displayedGraphemeCount: 0,
-        emaCps: 120,
-        dtMs: 50,
-        minCps: 30,
-        maxCps: 400,
-      }),
-      6,
-    );
-  });
-
-  it('clamps the EMA into [minCps, maxCps]', () => {
-    // Below minCps: 5 cps observed but min is 30. 30 × 50ms = 1.5 → 1.
-    assert.equal(
-      computeFrameAdvance({
-        rawGraphemeCount: 100,
-        displayedGraphemeCount: 0,
-        emaCps: 5,
-        dtMs: 50,
-        minCps: 30,
-        maxCps: 400,
-      }),
-      1,
-    );
-    // Above maxCps: 9999 cps but max is 400. 400 × 50ms = 20.
-    assert.equal(
-      computeFrameAdvance({
-        rawGraphemeCount: 100,
-        displayedGraphemeCount: 0,
-        emaCps: 9999,
-        dtMs: 50,
-        minCps: 30,
-        maxCps: 400,
-      }),
-      20,
-    );
-  });
-
-  it('never overshoots the available backlog', () => {
-    // 400 cps × 50ms = 20 chars wanted, but only 3 remain.
-    assert.equal(
-      computeFrameAdvance({
-        rawGraphemeCount: 3,
-        displayedGraphemeCount: 0,
-        emaCps: 400,
-        dtMs: 50,
-        minCps: 30,
-        maxCps: 400,
-      }),
-      3,
-    );
-  });
-});
-
-describe('resolveLiveBacklogCps', () => {
-  it('uses the required catch-up speed when the backlog fits the budget', () => {
-    assert.equal(resolveLiveBacklogCps({ backlog: 800, elapsedMs: 0, budgetMs: 2_000, emaCps: 80, minCps: 30, maxCps: 400 }), 400);
-  });
-
-  it('raises speed continuously above the budget instead of snapping position', () => {
-    assert.equal(resolveLiveBacklogCps({ backlog: 801, elapsedMs: 0, budgetMs: 2_000, emaCps: 80, minCps: 30, maxCps: 400 }), 401);
-    assert.equal(resolveLiveBacklogCps({ backlog: 5_000, elapsedMs: 0, budgetMs: 2_000, emaCps: 80, minCps: 30, maxCps: 400 }), 2_500);
-  });
-
-  it('still advances only one frame at a time for a large burst', () => {
-    const frameCps = resolveLiveBacklogCps({ backlog: 5_000, elapsedMs: 0, budgetMs: 2_000, emaCps: 80, minCps: 30, maxCps: 400 });
-    assert.equal(computeFrameAdvance({
-      rawGraphemeCount: 5_000,
+  it('advances frames within backlog and speed bounds', () => {
+    const base = {
+      rawGraphemeCount: 100,
       displayedGraphemeCount: 0,
-      emaCps: frameCps,
+      emaCps: 60,
       dtMs: 16,
       minCps: 30,
-      maxCps: frameCps,
-    }), 40);
+      maxCps: 400,
+    };
+    const cases = [
+      [{ ...base, rawGraphemeCount: 10, displayedGraphemeCount: 10 }, 0],
+      [{ ...base, dtMs: 0 }, 1],
+      [{ ...base, dtMs: -10 }, 1],
+      [{ ...base, emaCps: 30 }, 1],
+      [{ ...base, emaCps: 120, dtMs: 50 }, 6],
+      [{ ...base, emaCps: 5, dtMs: 50 }, 1],
+      [{ ...base, emaCps: 9999, dtMs: 50 }, 20],
+      [{ ...base, rawGraphemeCount: 3, emaCps: 400, dtMs: 50 }, 3],
+    ] as const;
+    for (const [input, expected] of cases) {
+      assert.equal(computeFrameAdvance(input), expected);
+    }
   });
 
-  it('drains one live burst inside a single catch-up budget', () => {
+  it('raises live speed continuously and drains a burst within budget', () => {
+    const base = { elapsedMs: 0, budgetMs: 2_000, emaCps: 80, minCps: 30, maxCps: 400 };
+    assert.equal(resolveLiveBacklogCps({ ...base, backlog: 800 }), 400);
+    assert.equal(resolveLiveBacklogCps({ ...base, backlog: 801 }), 401);
+    assert.equal(resolveLiveBacklogCps({ ...base, backlog: 5_000 }), 2_500);
+
     const rawGraphemeCount = 5_000;
-    const budgetMs = 2_000;
     const frameMs = 16;
     let displayedGraphemeCount = 0;
     let elapsedMs = 0;
-
     while (displayedGraphemeCount < rawGraphemeCount && elapsedMs < 20_000) {
       const frameCps = resolveLiveBacklogCps({
+        ...base,
         backlog: rawGraphemeCount - displayedGraphemeCount,
         elapsedMs,
-        budgetMs,
-        emaCps: 80,
-        minCps: 30,
-        maxCps: 400,
       });
       displayedGraphemeCount += computeFrameAdvance({
         rawGraphemeCount,
@@ -296,175 +75,74 @@ describe('resolveLiveBacklogCps', () => {
       });
       elapsedMs += frameMs;
     }
-
     assert.equal(displayedGraphemeCount, rawGraphemeCount);
-    assert.ok(elapsedMs <= budgetMs + frameMs * 2, `catch-up took ${elapsedMs}ms`);
+    assert.ok(elapsedMs <= base.budgetMs + frameMs * 2, `catch-up took ${elapsedMs}ms`);
   });
-});
 
-describe('updateEma', () => {
-  it('blends prev and observed by alpha', () => {
-    // 0.3 * 100 + 0.7 * 50 = 65
+  it('updates EMA only from positive finite observations', () => {
     assert.equal(updateEma({ prevEma: 50, alpha: 0.3, observedCps: 100 }), 65);
+    for (const observedCps of [0, -100, Infinity, Number.NaN]) {
+      assert.equal(updateEma({ prevEma: 50, alpha: 0.3, observedCps }), 50);
+    }
   });
 
-  it('ignores observed = 0', () => {
-    assert.equal(updateEma({ prevEma: 50, alpha: 0.3, observedCps: 0 }), 50);
-  });
-
-  it('ignores negative observed', () => {
-    assert.equal(updateEma({ prevEma: 50, alpha: 0.3, observedCps: -100 }), 50);
-  });
-
-  it('ignores non-finite observed (stalled arrival → dt 0 → cps Infinity)', () => {
-    assert.equal(updateEma({ prevEma: 50, alpha: 0.3, observedCps: Infinity }), 50);
-    assert.equal(updateEma({ prevEma: 50, alpha: 0.3, observedCps: NaN }), 50);
-  });
-});
-
-describe('resolveCompletionCps', () => {
-  it('raises the actual completion speed so a large final tail drains inside the budget', () => {
-    const frameCps = resolveCompletionCps({
+  it('chooses completion speed from the remaining tail and budget', () => {
+    const base = { elapsedMs: 0, budgetMs: 500, emaCps: 80, minCps: 30, maxCps: 400 };
+    const largeTailCps = resolveCompletionCps({
+      ...base,
       rawGraphemeCount: 5_200,
       displayedGraphemeCount: 200,
-      elapsedMs: 0,
-      budgetMs: 500,
-      emaCps: 80,
-      minCps: 30,
-      maxCps: 400,
     });
-    assert.equal(frameCps, 10_000);
-    assert.equal(computeFrameAdvance({
-      rawGraphemeCount: 5_200,
-      displayedGraphemeCount: 200,
-      emaCps: frameCps,
-      dtMs: 16,
-      minCps: 30,
-      maxCps: frameCps,
-    }), 160);
-  });
-
-  it('uses only the required catch-up speed when the final tail fits the budget', () => {
+    assert.equal(largeTailCps, 10_000);
+    assert.equal(
+      computeFrameAdvance({
+        rawGraphemeCount: 5_200,
+        displayedGraphemeCount: 200,
+        emaCps: largeTailCps,
+        dtMs: 16,
+        minCps: 30,
+        maxCps: largeTailCps,
+      }),
+      160,
+    );
     assert.equal(
       resolveCompletionCps({
+        ...base,
         rawGraphemeCount: 260,
         displayedGraphemeCount: 200,
-        elapsedMs: 0,
-        budgetMs: 500,
-        emaCps: 80,
-        minCps: 30,
-        maxCps: 400,
       }),
       120,
     );
   });
-});
 
-describe('resolveInitialDisplayedCount', () => {
-  it('snap=true → full immediately regardless of streaming', () => {
-    assert.equal(
-      resolveInitialDisplayedCount({ rawGraphemeCount: 500, streaming: true, snap: true }),
-      500,
-    );
-    assert.equal(
-      resolveInitialDisplayedCount({ rawGraphemeCount: 500, streaming: false, snap: true }),
-      500,
-    );
-  });
-
-  it('streaming=false with non-empty raw → history hydration snap', () => {
-    // The stream already finished; the caller is replaying a stored
-    // message. A "type it back out" animation would be misleading.
-    assert.equal(
-      resolveInitialDisplayedCount({ rawGraphemeCount: 2000, streaming: false, snap: false }),
-      2000,
-    );
-  });
-
-  it('streaming=true + snap=false → start from 0 (typewriter live)', () => {
-    assert.equal(
-      resolveInitialDisplayedCount({ rawGraphemeCount: 5, streaming: true, snap: false }),
-      0,
-    );
-  });
-
-  it('empty raw → 0 (nothing to display either way)', () => {
-    assert.equal(
-      resolveInitialDisplayedCount({ rawGraphemeCount: 0, streaming: true, snap: false }),
-      0,
-    );
-  });
-});
-
-describe('prepareSmoothStreamText — secret-prefix safety gate (@kenji msg fbb8f119)', () => {
-  /**
-   * The smoother typewriters PREFIXES of its input. So the trust
-   * contract we want from `prepareSmoothStreamText` is:
-   *   for any raw input containing a known secret pattern,
-   *   no prefix of `prepareSmoothStreamText(raw)` reveals the raw
-   *   secret token.
-   *
-   * Easiest check: ensure `prepared` itself never contains the
-   * raw secret. Since every prefix of `prepared` is a substring of
-   * `prepared`, that's sufficient.
-   */
-  it('masks Authorization: Bearer in raw text', () => {
-    const raw = 'response: Authorization: Bearer sk-test1234567890ABCDEF\nmore text';
-    const prepared = prepareSmoothStreamText(raw);
-    assert.equal(
-      prepared.includes('sk-test1234567890ABCDEF'),
-      false,
-      'raw bearer token must not survive into prepared text',
-    );
-  });
-
-  it('masks bare API-key prefixes', () => {
-    const raw = 'planning to use sk-ant-1234567890abcdefghijklmnopqrstuvwxyz';
-    const prepared = prepareSmoothStreamText(raw);
-    assert.equal(prepared.includes('sk-ant-1234567890abcdefghijklmnopqrstuvwxyz'), false);
-  });
-
-  it('every prefix of prepared output is secret-free', () => {
-    // The contract that matters for the smoother: every typewriter
-    // frame renders some prefix of the prepared text. We can't
-    // enumerate every prefix at runtime, but we can verify the
-    // load-bearing invariant: the SECRET TOKEN does not appear in
-    // the prepared text, so every prefix is by definition free of
-    // the secret token (a string contains a substring iff one of
-    // its prefixes ends with that substring).
-    const raw = 'Authorization: Bearer sk-secret123ABCDEFG more text';
-    const prepared = prepareSmoothStreamText(raw);
-    // Sample 5 prefixes across the prepared length; none should
-    // contain the secret.
-    for (const len of [10, 25, 50, prepared.length - 1, prepared.length]) {
-      const prefix = prepared.slice(0, Math.max(0, len));
-      assert.equal(
-        prefix.includes('sk-secret123ABCDEFG'),
-        false,
-        `prefix length=${len} unexpectedly contains the secret`,
-      );
+  it('initializes from snap and streaming state', () => {
+    const cases = [
+      [{ rawGraphemeCount: 500, streaming: true, snap: true }, 500],
+      [{ rawGraphemeCount: 500, streaming: false, snap: true }, 500],
+      [{ rawGraphemeCount: 2_000, streaming: false, snap: false }, 2_000],
+      [{ rawGraphemeCount: 5, streaming: true, snap: false }, 0],
+      [{ rawGraphemeCount: 0, streaming: true, snap: false }, 0],
+    ] as const;
+    for (const [input, expected] of cases) {
+      assert.equal(resolveInitialDisplayedCount(input), expected);
     }
   });
 
-  it('is idempotent on already-redacted text (safe to apply twice)', () => {
-    // Defense-in-depth use case (ReasoningPanel): C0's
-    // `applyThinkingDelta` already redacted the text, then
-    // `prepareSmoothStreamText` runs again in the renderer. Must be
-    // a no-op on already-clean text.
+  it('redacts secrets before any streamed prefix can render', () => {
+    const secrets = [
+      'sk-test1234567890ABCDEF',
+      'sk-ant-1234567890abcdefghijklmnopqrstuvwxyz',
+    ];
+    const prepared = prepareSmoothStreamText(
+      `Authorization: Bearer ${secrets[0]} planning to use ${secrets[1]}`,
+    );
+    for (const secret of secrets) assert.equal(prepared.includes(secret), false);
+
     const clean = 'normal reasoning step about the math';
     assert.equal(prepareSmoothStreamText(clean), clean);
-    // And applying twice on a raw-secret input must be stable.
-    const onceMasked = prepareSmoothStreamText('Bearer sk-test1234567890ABCDEF rest');
-    const twiceMasked = prepareSmoothStreamText(onceMasked);
-    assert.equal(twiceMasked, onceMasked);
-  });
-
-  it('returns empty string for non-string input (defensive)', () => {
-    // @ts-expect-error — defensive
-    assert.equal(prepareSmoothStreamText(null), '');
-    // @ts-expect-error — defensive
-    assert.equal(prepareSmoothStreamText(undefined), '');
-    // @ts-expect-error — defensive
-    assert.equal(prepareSmoothStreamText(42), '');
+    assert.equal(prepareSmoothStreamText(prepared), prepared);
+    for (const input of [null, undefined, 42]) {
+      assert.equal(prepareSmoothStreamText(input as unknown as string), '');
+    }
   });
 });

--- a/packages/headless/src/__tests__/provider-env.test.ts
+++ b/packages/headless/src/__tests__/provider-env.test.ts
@@ -1,328 +1,126 @@
 import assert from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 import {
   providerBaseUrlFromEnv,
   providerCredentialEnv,
   requireProviderCredentialEnv,
 } from '../provider-env.js';
 
-test('OpenAI Codex OAuth keeps account tokens separate from Platform API keys', () => {
-  assert.deepEqual(providerCredentialEnv('openai-codex'), {
-    apiKeys: ['OPENAI_CODEX_OAUTH_TOKEN'],
-    apiKeyFile: 'OPENAI_CODEX_OAUTH_TOKEN_FILE',
-    baseUrls: [],
+describe('provider credential environment', () => {
+  test('keeps account tokens separate from platform API keys', () => {
+    assert.deepEqual(providerCredentialEnv('openai-codex'), {
+      apiKeys: ['OPENAI_CODEX_OAUTH_TOKEN'],
+      apiKeyFile: 'OPENAI_CODEX_OAUTH_TOKEN_FILE',
+      baseUrls: [],
+    });
+    assert.deepEqual(providerCredentialEnv('github-copilot'), {
+      apiKeys: ['COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN'],
+      apiKeyFile: 'COPILOT_GITHUB_TOKEN_FILE',
+      baseUrls: [],
+    });
   });
-});
 
-test('GitHub Copilot headless credentials are GitHub account tokens, not GitHub Models PATs', () => {
-  assert.deepEqual(providerCredentialEnv('github-copilot'), {
-    apiKeys: ['COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN'],
-    apiKeyFile: 'COPILOT_GITHUB_TOKEN_FILE',
-    baseUrls: [],
+  test('separates direct and plan credential namespaces', () => {
+    const cases = [
+      [
+        'MiniMax',
+        {
+          apiKeys: ['MINIMAX_API_KEY'],
+          apiKeyFile: 'MINIMAX_API_KEY_FILE',
+          baseUrls: ['MINIMAX_BASE_URL'],
+        },
+      ],
+      [
+        'minimax-coding-plan',
+        {
+          apiKeys: ['MINIMAX_CODING_PLAN_API_KEY'],
+          apiKeyFile: 'MINIMAX_CODING_PLAN_API_KEY_FILE',
+          baseUrls: ['MINIMAX_CODING_PLAN_BASE_URL'],
+        },
+      ],
+      [
+        'stepfun',
+        {
+          apiKeys: ['STEPFUN_API_KEY'],
+          apiKeyFile: 'STEPFUN_API_KEY_FILE',
+          baseUrls: ['STEPFUN_BASE_URL'],
+        },
+      ],
+      [
+        'stepfun-step-plan',
+        {
+          apiKeys: ['STEPFUN_STEP_PLAN_API_KEY'],
+          apiKeyFile: 'STEPFUN_STEP_PLAN_API_KEY_FILE',
+          baseUrls: ['STEPFUN_STEP_PLAN_BASE_URL'],
+        },
+      ],
+    ] as const;
+    for (const [provider, expected] of cases) {
+      assert.deepEqual(providerCredentialEnv(provider), expected, provider);
+    }
   });
-});
 
-test('MiniMax Coding Plan uses a credential namespace separate from MiniMax direct API', () => {
-  assert.deepEqual(providerCredentialEnv('minimax-coding-plan'), {
-    apiKeys: ['MINIMAX_CODING_PLAN_API_KEY'],
-    apiKeyFile: 'MINIMAX_CODING_PLAN_API_KEY_FILE',
-    baseUrls: ['MINIMAX_CODING_PLAN_BASE_URL'],
+  test('preserves exceptional official credential names', () => {
+    assert.deepEqual(providerCredentialEnv('huggingface'), {
+      apiKeys: ['HF_TOKEN'],
+      apiKeyFile: 'HF_TOKEN_FILE',
+      baseUrls: ['HUGGINGFACE_BASE_URL'],
+    });
+    assert.deepEqual(providerCredentialEnv('vercel'), {
+      apiKeys: ['AI_GATEWAY_API_KEY'],
+      apiKeyFile: 'AI_GATEWAY_API_KEY_FILE',
+      baseUrls: ['AI_GATEWAY_BASE_URL'],
+    });
+    assert.deepEqual(providerCredentialEnv('opencode-go'), {
+      apiKeys: ['OPENCODE_API_KEY'],
+      apiKeyFile: 'OPENCODE_API_KEY_FILE',
+      baseUrls: ['OPENCODE_GO_BASE_URL'],
+    });
   });
-  assert.deepEqual(providerCredentialEnv('MiniMax'), {
-    apiKeys: ['MINIMAX_API_KEY'],
-    apiKeyFile: 'MINIMAX_API_KEY_FILE',
-    baseUrls: ['MINIMAX_BASE_URL'],
+
+  test('rejects interactive plan identities in headless credential loading', () => {
+    const unsupported = [
+      'tencent-coding-plan',
+      'volcengine-coding-plan',
+      'volcengine-agent-plan',
+      'tencent-token-plan',
+      'alibaba-coding-plan-cn',
+      'alibaba-coding-plan',
+      'alibaba-token-plan-cn',
+      'alibaba-token-plan',
+      'xiaomi-token-plan-cn',
+      'xiaomi-token-plan-sgp',
+      'xiaomi-token-plan-ams',
+    ];
+    for (const provider of unsupported) {
+      assert.equal(providerCredentialEnv(provider), undefined, provider);
+      assert.throws(
+        () => requireProviderCredentialEnv(provider),
+        new RegExp(`provider does not support API key files: ${provider}`),
+      );
+    }
   });
-});
 
-test('xAI keeps provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('xai'), {
-    apiKeys: ['XAI_API_KEY'],
-    apiKeyFile: 'XAI_API_KEY_FILE',
-    baseUrls: ['XAI_BASE_URL'],
-  });
-});
-
-test('Xiaomi direct API keeps provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('xiaomi'), {
-    apiKeys: ['XIAOMI_API_KEY'],
-    apiKeyFile: 'XIAOMI_API_KEY_FILE',
-    baseUrls: ['XIAOMI_BASE_URL'],
-  });
-});
-
-test('Z.AI direct API uses its own credential namespace', () => {
-  assert.deepEqual(providerCredentialEnv('zai'), {
-    apiKeys: ['ZAI_API_KEY'],
-    apiKeyFile: 'ZAI_API_KEY_FILE',
-    baseUrls: ['ZAI_BASE_URL'],
-  });
-});
-
-test('Cerebras credentials stay provider-scoped and support key files', () => {
-  assert.deepEqual(providerCredentialEnv('cerebras'), {
-    apiKeys: ['CEREBRAS_API_KEY'],
-    apiKeyFile: 'CEREBRAS_API_KEY_FILE',
-    baseUrls: ['CEREBRAS_BASE_URL'],
-  });
-});
-
-test('Mistral keeps provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('mistral'), {
-    apiKeys: ['MISTRAL_API_KEY'],
-    apiKeyFile: 'MISTRAL_API_KEY_FILE',
-    baseUrls: ['MISTRAL_BASE_URL'],
-  });
-});
-
-test('Cohere keeps its official provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('cohere'), {
-    apiKeys: ['COHERE_API_KEY'],
-    apiKeyFile: 'COHERE_API_KEY_FILE',
-    baseUrls: ['COHERE_BASE_URL'],
-  });
-});
-
-test('Hugging Face uses its official HF_TOKEN without accepting another provider key', () => {
-  assert.deepEqual(providerCredentialEnv('huggingface'), {
-    apiKeys: ['HF_TOKEN'],
-    apiKeyFile: 'HF_TOKEN_FILE',
-    baseUrls: ['HUGGINGFACE_BASE_URL'],
-  });
-});
-
-test('Together AI keeps its official provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('togetherai'), {
-    apiKeys: ['TOGETHER_API_KEY'],
-    apiKeyFile: 'TOGETHER_API_KEY_FILE',
-    baseUrls: ['TOGETHER_BASE_URL'],
-  });
-});
-
-test('DeepInfra keeps its official provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('deepinfra'), {
-    apiKeys: ['DEEPINFRA_API_KEY'],
-    apiKeyFile: 'DEEPINFRA_API_KEY_FILE',
-    baseUrls: ['DEEPINFRA_BASE_URL'],
-  });
-});
-
-test('Groq keeps its official provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('groq'), {
-    apiKeys: ['GROQ_API_KEY'],
-    apiKeyFile: 'GROQ_API_KEY_FILE',
-    baseUrls: ['GROQ_BASE_URL'],
-  });
-});
-
-test('OpenRouter keeps its official provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('openrouter'), {
-    apiKeys: ['OPENROUTER_API_KEY'],
-    apiKeyFile: 'OPENROUTER_API_KEY_FILE',
-    baseUrls: ['OPENROUTER_BASE_URL'],
-  });
-});
-
-test('Ollama Cloud keeps its official provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('ollama-cloud'), {
-    apiKeys: ['OLLAMA_API_KEY'],
-    apiKeyFile: 'OLLAMA_API_KEY_FILE',
-    baseUrls: [],
-  });
-});
-
-test('Cloudflare Workers AI separates account scope from API token credentials', () => {
-  assert.deepEqual(providerCredentialEnv('cloudflare-workers-ai'), {
-    apiKeys: ['CLOUDFLARE_API_KEY'],
-    apiKeyFile: 'CLOUDFLARE_API_KEY_FILE',
-    baseUrls: ['CLOUDFLARE_WORKERS_AI_BASE_URL'],
-    accountId: 'CLOUDFLARE_ACCOUNT_ID',
-  });
-  assert.equal(
-    providerBaseUrlFromEnv('cloudflare-workers-ai', {
-      CLOUDFLARE_ACCOUNT_ID: 'account-123',
-    }),
-    'https://api.cloudflare.com/client/v4/accounts/account-123/ai/v1',
-  );
-  assert.equal(
-    providerBaseUrlFromEnv('cloudflare-workers-ai', {
-      CLOUDFLARE_ACCOUNT_ID: 'account-123',
-      CLOUDFLARE_WORKERS_AI_BASE_URL: 'https://workers-ai.example.test/v1',
-    }),
-    'https://workers-ai.example.test/v1',
-  );
-  assert.equal(providerBaseUrlFromEnv('cloudflare-workers-ai', {}), undefined);
-});
-
-test('Fireworks AI keeps provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('fireworks-ai'), {
-    apiKeys: ['FIREWORKS_API_KEY'],
-    apiKeyFile: 'FIREWORKS_API_KEY_FILE',
-    baseUrls: ['FIREWORKS_BASE_URL'],
-  });
-});
-
-test('NVIDIA credentials stay provider-scoped and support key files', () => {
-  assert.deepEqual(providerCredentialEnv('nvidia'), {
-    apiKeys: ['NVIDIA_API_KEY'],
-    apiKeyFile: 'NVIDIA_API_KEY_FILE',
-    baseUrls: ['NVIDIA_BASE_URL'],
-  });
-});
-
-test('Tencent TokenHub keeps direct API credentials separate from Tencent plans', () => {
-  assert.deepEqual(providerCredentialEnv('tencent-tokenhub'), {
-    apiKeys: ['TENCENT_TOKENHUB_API_KEY'],
-    apiKeyFile: 'TENCENT_TOKENHUB_API_KEY_FILE',
-    baseUrls: ['TENCENT_TOKENHUB_BASE_URL'],
-  });
-});
-
-test('Tencent Coding Plan is unavailable to non-interactive headless credential loading', () => {
-  assert.equal(providerCredentialEnv('tencent-coding-plan'), undefined);
-  assert.throws(
-    () => requireProviderCredentialEnv('tencent-coding-plan'),
-    /provider does not support API key files: tencent-coding-plan/,
-  );
-});
-
-test('Volcengine Coding Plan is unavailable to non-interactive headless credential loading', () => {
-  assert.equal(providerCredentialEnv('volcengine-coding-plan'), undefined);
-  assert.throws(
-    () => requireProviderCredentialEnv('volcengine-coding-plan'),
-    /provider does not support API key files: volcengine-coding-plan/,
-  );
-});
-
-test('Volcengine Agent Plan is unavailable to non-interactive headless credential loading', () => {
-  assert.equal(providerCredentialEnv('volcengine-agent-plan'), undefined);
-  assert.throws(
-    () => requireProviderCredentialEnv('volcengine-agent-plan'),
-    /provider does not support API key files: volcengine-agent-plan/,
-  );
-});
-
-test('Tencent Token Plan is unavailable to non-interactive headless credential loading', () => {
-  assert.equal(providerCredentialEnv('tencent-token-plan'), undefined);
-  assert.throws(
-    () => requireProviderCredentialEnv('tencent-token-plan'),
-    /provider does not support API key files: tencent-token-plan/,
-  );
-});
-
-test('Alibaba Coding Plan (China) is unavailable to non-interactive headless credential loading', () => {
-  assert.equal(providerCredentialEnv('alibaba-coding-plan-cn'), undefined);
-  assert.throws(
-    () => requireProviderCredentialEnv('alibaba-coding-plan-cn'),
-    /provider does not support API key files: alibaba-coding-plan-cn/,
-  );
-});
-
-test('Alibaba Coding Plan (global) is unavailable to non-interactive headless credential loading', () => {
-  assert.equal(providerCredentialEnv('alibaba-coding-plan'), undefined);
-  assert.throws(
-    () => requireProviderCredentialEnv('alibaba-coding-plan'),
-    /provider does not support API key files: alibaba-coding-plan/,
-  );
-});
-
-test('Alibaba Token Plan variants are unavailable to non-interactive headless credential loading', () => {
-  for (const providerType of ['alibaba-token-plan-cn', 'alibaba-token-plan'] as const) {
-    assert.equal(providerCredentialEnv(providerType), undefined);
-    assert.throws(
-      () => requireProviderCredentialEnv(providerType),
-      new RegExp(`provider does not support API key files: ${providerType}`),
+  test('derives Cloudflare base URLs only from explicit authority', () => {
+    assert.deepEqual(providerCredentialEnv('cloudflare-workers-ai'), {
+      apiKeys: ['CLOUDFLARE_API_KEY'],
+      apiKeyFile: 'CLOUDFLARE_API_KEY_FILE',
+      baseUrls: ['CLOUDFLARE_WORKERS_AI_BASE_URL'],
+      accountId: 'CLOUDFLARE_ACCOUNT_ID',
+    });
+    assert.equal(
+      providerBaseUrlFromEnv('cloudflare-workers-ai', {
+        CLOUDFLARE_ACCOUNT_ID: 'account-123',
+      }),
+      'https://api.cloudflare.com/client/v4/accounts/account-123/ai/v1',
     );
-  }
-});
-
-for (const providerType of [
-  'xiaomi-token-plan-cn',
-  'xiaomi-token-plan-sgp',
-  'xiaomi-token-plan-ams',
-] as const) {
-  test(`${providerType} is unavailable to non-interactive headless credential loading`, () => {
-    assert.equal(providerCredentialEnv(providerType), undefined);
-    assert.throws(
-      () => requireProviderCredentialEnv(providerType),
-      new RegExp(`provider does not support API key files: ${providerType}`),
+    assert.equal(
+      providerBaseUrlFromEnv('cloudflare-workers-ai', {
+        CLOUDFLARE_ACCOUNT_ID: 'account-123',
+        CLOUDFLARE_WORKERS_AI_BASE_URL: 'https://workers-ai.example.test/v1',
+      }),
+      'https://workers-ai.example.test/v1',
     );
-  });
-}
-
-test('StepFun China keeps direct API credentials separate from global and plan identities', () => {
-  assert.deepEqual(providerCredentialEnv('stepfun'), {
-    apiKeys: ['STEPFUN_API_KEY'],
-    apiKeyFile: 'STEPFUN_API_KEY_FILE',
-    baseUrls: ['STEPFUN_BASE_URL'],
-  });
-});
-
-test('StepFun Step Plan China uses an independent credential namespace', () => {
-  assert.deepEqual(providerCredentialEnv('stepfun-step-plan'), {
-    apiKeys: ['STEPFUN_STEP_PLAN_API_KEY'],
-    apiKeyFile: 'STEPFUN_STEP_PLAN_API_KEY_FILE',
-    baseUrls: ['STEPFUN_STEP_PLAN_BASE_URL'],
-  });
-});
-
-test('StepFun Step Plan Global uses an independent credential namespace', () => {
-  assert.deepEqual(providerCredentialEnv('stepfun-ai-step-plan'), {
-    apiKeys: ['STEPFUN_AI_STEP_PLAN_API_KEY'],
-    apiKeyFile: 'STEPFUN_AI_STEP_PLAN_API_KEY_FILE',
-    baseUrls: ['STEPFUN_AI_STEP_PLAN_BASE_URL'],
-  });
-});
-
-test('StepFun Global keeps direct API credentials separate from China and plan identities', () => {
-  assert.deepEqual(providerCredentialEnv('stepfun-ai'), {
-    apiKeys: ['STEPFUN_AI_API_KEY'],
-    apiKeyFile: 'STEPFUN_AI_API_KEY_FILE',
-    baseUrls: ['STEPFUN_AI_BASE_URL'],
-  });
-});
-
-test('Volcengine Ark direct API uses its official credential namespace', () => {
-  assert.deepEqual(providerCredentialEnv('volcengine-ark'), {
-    apiKeys: ['ARK_API_KEY'],
-    apiKeyFile: 'ARK_API_KEY_FILE',
-    baseUrls: ['ARK_BASE_URL'],
-  });
-});
-
-test('LocalAI exposes only its optional provider-scoped key and base URL env', () => {
-  assert.deepEqual(providerCredentialEnv('localai'), {
-    apiKeys: ['LOCALAI_API_KEY'],
-    apiKeyFile: 'LOCALAI_API_KEY_FILE',
-    baseUrls: ['LOCALAI_BASE_URL'],
-  });
-});
-
-test('Vercel Gateway uses its official AI Gateway credential namespace', () => {
-  assert.deepEqual(providerCredentialEnv('vercel'), {
-    apiKeys: ['AI_GATEWAY_API_KEY'],
-    apiKeyFile: 'AI_GATEWAY_API_KEY_FILE',
-    baseUrls: ['AI_GATEWAY_BASE_URL'],
-  });
-});
-
-test('ZenMux keeps its official provider-scoped credential environment names', () => {
-  assert.deepEqual(providerCredentialEnv('zenmux'), {
-    apiKeys: ['ZENMUX_API_KEY'],
-    apiKeyFile: 'ZENMUX_API_KEY_FILE',
-    baseUrls: ['ZENMUX_BASE_URL'],
-  });
-});
-
-test('OpenCode Zen and Go share the official API key identity with independent endpoints', () => {
-  assert.deepEqual(providerCredentialEnv('opencode'), {
-    apiKeys: ['OPENCODE_API_KEY'],
-    apiKeyFile: 'OPENCODE_API_KEY_FILE',
-    baseUrls: ['OPENCODE_BASE_URL'],
-  });
-  assert.deepEqual(providerCredentialEnv('opencode-go'), {
-    apiKeys: ['OPENCODE_API_KEY'],
-    apiKeyFile: 'OPENCODE_API_KEY_FILE',
-    baseUrls: ['OPENCODE_GO_BASE_URL'],
+    assert.equal(providerBaseUrlFromEnv('cloudflare-workers-ai', {}), undefined);
   });
 });


### PR DESCRIPTION
## Summary

- collapse URI and smooth-stream micro-tests into behavioral decision tables
- remove the ExploreAgent source-regex UI contract and duplicate chat-readiness happy/copy cases
- consolidate lineage and attribution permutations without dropping last-wins or purity coverage
- replace per-provider environment constant mirrors with tests for exceptional namespaces and unsupported interactive plans

## Impact

- 6 files changed
- 352 additions, 1,313 deletions; net -961 lines
- touched suites: 191 -> 83 test declarations
- Desktop: 1,571 -> 1,494 tests
- Headless: 31 fewer provider-env tests

## Verification

- npm run clean
- npm run build:test
- Core: 847/847
- UI: 259/259
- Desktop: 1,494/1,494
- Headless: 1,420 passed, 4 skipped, 0 failed
- default scripts: 34/34
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check