### PR TITLE
fix(ci): provision sandbox whenever the cli workspace runs

### DIFF
--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -101,7 +101,7 @@ export function planTests(changedFiles, options = {}) {
       e2e: true,
       full: true,
       headless: graph.dirs.includes('packages/headless'),
-      runtimeSandbox: graph.dirs.includes('packages/runtime'),
+      runtimeSandbox: graph.dirs.includes('packages/cli'),
       scriptMode: 'full',
       storageStress: graph.dirs.includes('packages/storage'),
       workspaces: [...graph.dirs],
@@ -159,12 +159,11 @@ export function planTests(changedFiles, options = {}) {
     e2e: directWorkspaces.has('apps/desktop') || directWorkspaces.has('packages/ui'),
     full: false,
     headless: workspaces.includes('packages/headless'),
-    runtimeSandbox:
-      directWorkspaces.has('packages/runtime') ||
-      // runtime-bootstrap.test.ts (packages/cli) executes real sandboxed shell
-      // tools, so it needs the bubblewrap + user-namespace setup even though
-      // the change is scoped to the cli workspace.
-      files.some((path) => path === 'packages/cli/src/__tests__/runtime-bootstrap.test.ts'),
+    // packages/cli/src/__tests__/runtime-bootstrap.test.ts executes real sandboxed
+    // shell tools, so the bubblewrap + user-namespace setup is required whenever
+    // the cli workspace runs in the dependency closure, not only for direct
+    // cli/runtime edits (e.g. a storage-only change still selects cli via runtime).
+    runtimeSandbox: workspaces.includes('packages/cli'),
     scriptMode,
     storageStress,
     workspaces,

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -32,6 +32,20 @@ test('stress and specialized script checks run only for their owning surfaces', 
   assert.deepEqual(measurement.workspaces, []);
 });
 
+test('sandbox is flagged whenever the cli workspace runs in the closure', () => {
+  // packages/cli/src/__tests__/runtime-bootstrap.test.ts executes real sandboxed
+  // shell tools, so any change whose dependency closure selects packages/cli must
+  // provision the sandbox — not only direct cli/runtime edits.
+  for (const path of [
+    'packages/cli/src/__tests__/runtime-bootstrap.test.ts',
+    'packages/runtime/src/shell-tools.ts',
+    'packages/storage/src/session-store.ts',
+    'packages/headless/src/cell-output.ts',
+  ]) {
+    assert.equal(planTests([path], { graph }).runtimeSandbox, true, path);
+  }
+});
+
 test('global and unknown production changes fail safe to the complete suite', () => {
   for (const path of ['package-lock.json', 'scripts/ci-test-plan.mjs', 'new-root/file.ts']) {
     const plan = planTests([path], { graph });


### PR DESCRIPTION
## Summary

`packages/cli/src/__tests__/runtime-bootstrap.test.ts` executes real sandboxed shell tools, but the CI test plan only provisioned the bubblewrap + user-namespace sandbox for direct `packages/runtime` / `packages/cli` edits. Changes that reach the cli workspace through the dependency closure (e.g. a storage-only change `storage → runtime → headless → cli`, or a headless change `headless → cli`) selected the cli tests without the sandbox, failing with `Command sandbox is required but unavailable`.

`runtimeSandbox` now keys off `workspaces.includes('packages/cli')` — the closure result — instead of `directWorkspaces`. This unblocks the current PR queue (e.g. #1775, #1770, #1742, #1781) which merged latest `main` and still hit this.

## Verification

- `node --test scripts/ci-test-plan.test.mjs scripts/run-workspace-tests-parallel.test.mjs` → 8/8 pass
- New regression test asserts `runtimeSandbox` for direct cli, direct runtime, and closure-only storage/headless changes (failed before this change)
- `biome check` / `biome format` clean on both files
