### PR TITLE
test: prune redundant CLI interaction coverage

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -19,7 +19,6 @@ import { createMakaCliRuntimeContext } from '../runtime-bootstrap.js';
 
 const execFileAsync = promisify(execFile);
 const cliPath = new URL('../cli.js', import.meta.url).pathname;
-const legacyCliPath = new URL('../../../headless/dist/cli.js', import.meta.url).pathname;
 
 function runCliProcess(
   entrypoint: string,
@@ -126,12 +125,6 @@ describe('Maka CLI args', () => {
     });
   });
 
-  test('runs the plain TUI without a resumeSessionId', () => {
-    const command = parseMakaCliArgs([], '0.1.0');
-    assert.deepEqual(command, { kind: 'tui' });
-    assert.equal((command as { resumeSessionId?: string }).resumeSessionId, undefined);
-  });
-
   test('uses the command exit code when no earlier exit reason exists', () => {
     assert.equal(resolveMakaCliExitCode(2, undefined), 2);
   });
@@ -186,12 +179,6 @@ describe('Maka CLI args', () => {
     assert.equal(signal, null);
     assert.equal(code, 1);
     assert.ok(Date.now() - startedAt >= 2_500);
-  });
-
-  test('prints version from the executable entrypoint', async () => {
-    const { stdout } = await execFileAsync(process.execPath, [cliPath, '--version']);
-
-    assert.equal(stdout.trim(), '0.1.0');
   });
 
   test('inspects a Session through the executable entrypoint', async () => {
@@ -280,40 +267,12 @@ describe('Maka CLI args', () => {
     }
   });
 
-  test('exposes identical run help through maka run and maka -p', async () => {
-    const run = await runCliProcess(cliPath, ['run', '--help']);
-    const alias = await runCliProcess(cliPath, ['-p', '--help']);
-
-    assert.equal(run.code, 0, run.stderr);
-    assert.equal(alias.code, 0, alias.stderr);
-    assert.equal(alias.stdout, run.stdout);
-    assert.match(run.stdout, /Usage: maka run/);
-  });
-
   test('returns exit 2 for missing non-interactive input before configuration startup', async () => {
     const result = await runCliProcess(cliPath, ['run']);
 
     assert.equal(result.code, 2);
     assert.match(result.stderr, /missing prompt input/);
     assert.equal(result.stdout, '');
-  });
-
-  test('keeps all five legacy command families on the unified router exit contract', async () => {
-    const pairs = [
-      { unified: ['eval', 'run'], legacy: ['eval'] },
-      { unified: ['eval', 'compare'], legacy: ['compare'] },
-      { unified: ['eval', 'task-run'], legacy: ['task'] },
-      { unified: ['eval', 'harbor'], legacy: ['harbor'] },
-      { unified: ['eval', 'ahe'], legacy: ['ahe'] },
-    ];
-    for (const pair of pairs) {
-      const unified = await runCliProcess(cliPath, pair.unified);
-      const legacy = await runCliProcess(legacyCliPath, pair.legacy);
-      assert.equal(legacy.code, unified.code, pair.unified.join(' '));
-      assert.equal(legacy.stdout, unified.stdout, pair.unified.join(' '));
-      assert.match(legacy.stderr, /maka-headless is deprecated/);
-      assert.doesNotMatch(unified.stderr, /maka-headless is deprecated/);
-    }
   });
 
   test('runs when launched through a bin symlink', async () => {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -54,7 +54,6 @@ import {
 import { AUTO_RECAP_IDLE_MS } from '../session-recap.js';
 import { _setColorLevelForTesting } from '../tui-ansi.js';
 import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
-import { arrangeAutocompleteAboveEditor } from '../tui-autocomplete-layout.js';
 import {
   assertBottomPickerPlacement,
   autocompleteSuggestionLines,
@@ -179,24 +178,6 @@ describe('Maka Pi TUI runner', () => {
     assert.match(stdout, /CLOSED/);
   });
 
-  test('restores the terminal before exiting on SIGHUP', async () => {
-    const { code, signal, stdout } = await runSignalExitProbe('SIGHUP');
-
-    assert.equal(signal, null);
-    assert.equal(code, 129);
-    assert.match(stdout, /TERMINAL_STOP/);
-    assert.match(stdout, /CLOSED/);
-  });
-
-  test('restores the terminal before exiting on SIGINT', async () => {
-    const { code, signal, stdout } = await runSignalExitProbe('SIGINT');
-
-    assert.equal(signal, null);
-    assert.equal(code, 130);
-    assert.match(stdout, /TERMINAL_STOP/);
-    assert.match(stdout, /CLOSED/);
-  });
-
   test('forces signal exit when outer cleanup never settles after terminal restoration', async () => {
     const { code, signal, stdout } = await runSignalExitProbe('SIGTERM', true);
 
@@ -208,16 +189,6 @@ describe('Maka Pi TUI runner', () => {
 
   test('restores the terminal before reporting an uncaught exception', async () => {
     const { code, signal, stdout, stderr } = await runFatalExitProbe('uncaughtException');
-
-    assert.equal(signal, null);
-    assert.equal(code, 1);
-    assert.match(stdout, /TERMINAL_STOP/);
-    assert.match(stdout, /CLOSED/);
-    assert.match(stderr, /fatal probe/);
-  });
-
-  test('reports and forces fatal exit when outer cleanup never settles', async () => {
-    const { code, signal, stdout, stderr } = await runFatalExitProbe('uncaughtException', true);
 
     assert.equal(signal, null);
     assert.equal(code, 1);
@@ -353,46 +324,6 @@ describe('Maka Pi TUI runner', () => {
       run,
       delay(500).then(() => {
         throw new Error('TUI did not close after /exit');
-      }),
-    ]);
-  });
-
-  test('/setup marks existing connections 已设置 in the provider search', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const providers = defaultOnboardingProviders().map((p) =>
-      p.providerType === 'anthropic'
-        ? { ...p, hasConnection: true, enabledModelIds: ['claude-sonnet-5'] }
-        : p,
-    );
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'bypass',
-      terminal,
-      onboarding: fakeOnboardingSurface({ providers }),
-    });
-
-    await delay(20);
-    terminal.input('/setup');
-    terminal.input('\r');
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
-      } catch {
-        return false;
-      }
-    });
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('已设置'));
-
-    process.emit('SIGTERM');
-    await Promise.race([
-      run,
-      delay(500).then(() => {
-        throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
   });
@@ -725,216 +656,6 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('onboarding wizard filters the provider list as you type in the search field', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: '',
-      connectionSlug: '',
-      permissionMode: 'bypass',
-      terminal,
-      firstRun: true,
-      onboarding: fakeOnboardingSurface(),
-    });
-
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
-      } catch {
-        return false;
-      }
-    });
-    const before = plainTerminalOutput(terminal.screenOutput());
-    assert.ok(before.includes('Anthropic'));
-    assert.ok(before.includes('DeepSeek'));
-
-    // Typing in the wizard's search field filters the provider list live: the
-    // unmatched providers leave the list while the match stays.
-    terminal.input('anth');
-    await waitFor(() => {
-      const out = plainTerminalOutput(terminal.screenOutput());
-      return out.includes('Anthropic') && !out.includes('DeepSeek');
-    });
-
-    process.emit('SIGTERM');
-    await Promise.race([
-      run,
-      delay(500).then(() => {
-        throw new Error('TUI did not close after SIGTERM');
-      }),
-    ]);
-  });
-
-  test('verify/saving status stays beside the input, out of the transcript', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const verifyCalls: string[] = [];
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'bypass',
-      terminal,
-      onboarding: fakeOnboardingSurface({
-        verify: async (input) => {
-          verifyCalls.push(input.apiKey ?? '');
-          return verifyCalls.length === 1
-            ? { kind: 'error', text: 'HTTP 401 Unauthorized' }
-            : { kind: 'ok', models: [{ id: 'gpt-5.5' }] };
-        },
-      }),
-    });
-
-    await delay(20);
-    terminal.input('/setup');
-    terminal.input('\r');
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('\r'); // pick provider -> key phase
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('sk-bad');
-    terminal.input('\r');
-    await waitFor(() => verifyCalls.length === 1);
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), '验证失败') !== null;
-      } catch {
-        return false;
-      }
-    });
-    // A succeeding retry advances to the models step. The in-flight failure
-    // status lived only in the overlay, so it leaves no residue in the transcript.
-    terminal.input('sk-good');
-    terminal.input('\r');
-    await waitFor(() => verifyCalls.length === 2);
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
-    assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /验证失败/);
-
-    process.emit('SIGTERM');
-    await Promise.race([
-      run,
-      delay(500).then(() => {
-        throw new Error('TUI did not close after SIGTERM');
-      }),
-    ]);
-  });
-
-  test('key Esc returns to the provider search (step 1/3)', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'bypass',
-      terminal,
-      onboarding: fakeOnboardingSurface(),
-    });
-
-    await delay(20);
-    terminal.input('/setup');
-    terminal.input('\r');
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('\r'); // pick provider -> key phase
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
-      } catch {
-        return false;
-      }
-    });
-    // Esc from the key field returns to the search phase: the step marker is
-    // back to 1/3 and the provider list is visible again.
-    terminal.input('\x1b');
-    await waitFor(() => {
-      const out = plainTerminalOutput(terminal.screenOutput());
-      return out.includes('1/3') && out.includes('Anthropic');
-    });
-
-    process.emit('SIGTERM');
-    await Promise.race([
-      run,
-      delay(500).then(() => {
-        throw new Error('TUI did not close after SIGTERM');
-      }),
-    ]);
-  });
-
-  test('models Esc returns to the key step (step 2/3)', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'bypass',
-      terminal,
-      onboarding: fakeOnboardingSurface(),
-    });
-
-    await delay(20);
-    terminal.input('/setup');
-    terminal.input('\r');
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('\r'); // pick provider -> key phase
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('sk-test');
-    terminal.input('\r');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
-    // Esc from the models step moves back exactly one level to the key step.
-    terminal.input('\x1b');
-    await waitFor(() => {
-      const out = plainTerminalOutput(terminal.screenOutput());
-      return out.includes('2/3') && out.includes('API key');
-    });
-
-    process.emit('SIGTERM');
-    await Promise.race([
-      run,
-      delay(500).then(() => {
-        throw new Error('TUI did not close after SIGTERM');
-      }),
-    ]);
-  });
-
   test('models Space toggles selection; Enter saves at least one model', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -992,129 +713,6 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
     await waitFor(() => saveCalls.length === 1);
     assert.deepEqual(saveCalls[0]!.enabledModelIds, ['gpt-5.5']);
-
-    process.emit('SIGTERM');
-    await Promise.race([
-      run,
-      delay(500).then(() => {
-        throw new Error('TUI did not close after SIGTERM');
-      }),
-    ]);
-  });
-
-  test('models search field moves the cursor with arrow keys like the other fields', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'bypass',
-      terminal,
-      onboarding: fakeOnboardingSurface(),
-    });
-
-    await delay(20);
-    terminal.input('/setup');
-    terminal.input('\r');
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('\r'); // pick provider -> key phase
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('sk-test');
-    terminal.input('\r');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
-    terminal.input('gpt'); // type into the model search field
-    await delay(30);
-    terminal.input('\x1b[D'); // left arrow — should move the cursor left
-    terminal.input('x'); // insert x at the cursor (before the t)
-    await delay(30);
-    const out = plainTerminalOutput(terminal.screenOutput());
-    assert.ok(
-      out.includes('gpxt'),
-      'left arrow should move the cursor so x inserts before the final t',
-    );
-    assert.ok(!out.includes('gptx'), 'without the left arrow the x would append after t');
-
-    process.emit('SIGTERM');
-    await Promise.race([
-      run,
-      delay(500).then(() => {
-        throw new Error('TUI did not close after SIGTERM');
-      }),
-    ]);
-  });
-
-  test('model search filters without discarding selections', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const saveCalls: Array<{ enabledModelIds: readonly string[] }> = [];
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'bypass',
-      terminal,
-      onboarding: fakeOnboardingSurface({
-        save: async (input) => {
-          saveCalls.push(input);
-          return { kind: 'ok', modelChoices: [] };
-        },
-      }),
-    });
-
-    await delay(20);
-    terminal.input('/setup');
-    terminal.input('\r');
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'Set Up Provider') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('\r'); // pick provider -> key phase
-    await waitFor(() => {
-      try {
-        return latestPlainLineContaining(terminal.writes.join(''), 'API key') !== null;
-      } catch {
-        return false;
-      }
-    });
-    terminal.input('sk-test');
-    terminal.input('\r');
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('3/3'));
-    terminal.input(' '); // toggle the first model on (gpt-5.5)
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('已选 1 ·'));
-    // Filtering to 'mini' hides gpt-5.5, but its selection survives.
-    terminal.input('mini');
-    await waitFor(() => {
-      const out = plainTerminalOutput(terminal.screenOutput());
-      return (
-        out.includes('gpt-5.5-mini') && !out.includes('☐ gpt-5.5 ') && !out.includes('☑ gpt-5.5 ')
-      );
-    });
-    terminal.input(' '); // toggle gpt-5.5-mini on while filtered
-    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('已选 2 ·'));
-    terminal.input('\r');
-    await waitFor(() => saveCalls.length === 1);
-    // Both selections reach save — the filtered-out gpt-5.5 was not discarded.
-    assert.deepEqual(saveCalls[0]!.enabledModelIds, ['gpt-5.5', 'gpt-5.5-mini']);
 
     process.emit('SIGTERM');
     await Promise.race([
@@ -2903,45 +2501,6 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('renders the statusline below the input editor', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'deepseek-v4-flash',
-      connectionSlug: 'deepseek',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    await waitFor(() =>
-      plainTerminalOutput(terminal.output()).includes(
-        'Maka · Auto · deepseek-v4-flash · deepseek · /repo',
-      ),
-    );
-
-    const lines = plainTerminalOutput(terminal.output()).split(/\r?\n/);
-    const statusLineIndex = lines.findIndex((line) =>
-      line.includes('Maka · Auto · deepseek-v4-flash · deepseek · /repo'),
-    );
-    const editorBorderIndexes = lines
-      .map((line, index) => (/^─+$/.test(line) ? index : -1))
-      .filter((index) => index >= 0);
-
-    assert.ok(editorBorderIndexes.length >= 2);
-    assert.ok(statusLineIndex > editorBorderIndexes[editorBorderIndexes.length - 1]!);
-
-    exitMaka(terminal);
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close during test cleanup');
-      }),
-    ]);
-  });
-
   test('shows Working… in the activity strip while a turn runs', async () => {
     const terminal = new FakeTerminal();
     const driver = new HangingTurnDriver();
@@ -2962,32 +2521,6 @@ describe('Maka Pi TUI runner', () => {
 
     driver.releaseComplete();
     await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('Working…'));
-
-    exitMaka(terminal);
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close during test cleanup');
-      }),
-    ]);
-  });
-
-  test('uses logo blue for TUI accent chrome', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'deepseek-v4-flash',
-      connectionSlug: 'deepseek',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    await waitFor(() => terminal.output().includes('\x1b[38;2;87;163;239m'));
-
-    assert.doesNotMatch(terminal.output(), /\x1b\[36m─/);
 
     exitMaka(terminal);
     await Promise.race([
@@ -4063,167 +3596,6 @@ describe('Maka Pi TUI runner', () => {
     assert.equal(terminal.stopCalls, 1);
   });
 
-  test('shows slash commands alphabetically when typing /', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'deepseek-v4-flash',
-      connectionSlug: 'deepseek',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    terminal.input('/');
-
-    await waitFor(() => {
-      const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
-      return autocompleteSuggestionLines(lines).some((line) => line.includes('/session'));
-    });
-    // Scope to the autocomplete overlay — the empty-session home now shows
-    // /session /model /setup as hint text, so a whole-screen grep would pick up
-    // the home's copies and misorder them against the menu (#1098).
-    const suggestions = autocompleteSuggestionLines(
-      plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/),
-    ).join('\n');
-    const exitIndex = suggestions.indexOf('/exit');
-    const modelIndex = suggestions.indexOf('/model');
-    const permissionsIndex = suggestions.indexOf('/permissions');
-    const sessionIndex = suggestions.indexOf('/session');
-
-    assert.ok(exitIndex >= 0);
-    assert.ok(modelIndex >= 0);
-    assert.ok(permissionsIndex >= 0);
-    assert.ok(sessionIndex >= 0);
-    assert.ok(exitIndex < modelIndex);
-    assert.ok(modelIndex < permissionsIndex);
-    assert.ok(permissionsIndex < sessionIndex);
-    // The whole menu is visible at once — including the last command
-    // alphabetically — so new commands don't push older ones below the fold.
-    assert.ok(suggestions.indexOf('/thinking') > sessionIndex);
-
-    exitMaka(terminal);
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close during test cleanup');
-      }),
-    ]);
-  });
-
-  test('renders slash autocomplete above the input editor', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'deepseek-v4-flash',
-      connectionSlug: 'deepseek',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    terminal.input('/');
-
-    await waitFor(() => {
-      const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
-      return (
-        lines.some((line) => line.includes('→')) &&
-        autocompleteSuggestionLines(lines).some((line) => line.includes('/model'))
-      );
-    });
-    // Scope to the autocomplete overlay, not the whole screen: the empty-session
-    // home now shows /session /model /setup as hint text, so a whole-screen
-    // findIndex('/model') would land on the home's hint and pass even if the
-    // overlay never rendered (#1098).
-    const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
-    const [editorTopBorder, editorBottomBorder] = inputSurfaceRows(lines);
-    const cursorIndex = lines.findIndex((line) => line.includes('→'));
-    const statusLineIndex = lines.findIndex((line) =>
-      line.includes('Maka · Auto · deepseek-v4-flash · deepseek · /repo'),
-    );
-
-    // The autocomplete menu (→ cursor) renders above the editor's top border.
-    assert.ok(cursorIndex >= 0);
-    assert.ok(cursorIndex < editorTopBorder);
-    // The menu carries /model, scoped to the overlay rather than the home hint.
-    assert.ok(autocompleteSuggestionLines(lines).some((line) => line.includes('/model')));
-    // The editor's bottom border sits just above the statusline.
-    assert.equal(editorBottomBorder, statusLineIndex - 1);
-
-    exitMaka(terminal);
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close during test cleanup');
-      }),
-    ]);
-  });
-
-  test('keeps slash autocomplete filtering anchored to the input editor', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'deepseek-v4-flash',
-      connectionSlug: 'deepseek',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    terminal.input('/');
-
-    await waitFor(() => {
-      const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
-      return autocompleteSuggestionLines(lines).some((line) => line.includes('/session'));
-    });
-    const beforeLines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
-    const beforeRows = inputSurfaceRows(beforeLines);
-
-    terminal.input('s');
-
-    await waitFor(() => {
-      const suggestions = autocompleteSuggestionLines(
-        plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/),
-      );
-      return (
-        suggestions.some((line) => line.includes('/session')) &&
-        !suggestions.some((line) => line.includes('/model'))
-      );
-    });
-    const afterLines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
-    const afterRows = inputSurfaceRows(afterLines);
-    const afterSuggestions = autocompleteSuggestionLines(afterLines);
-
-    // The input surface did not shift while filtering.
-    assert.deepEqual(afterRows, beforeRows);
-    // The 's' filter matches four commands — /session, /setup, /skill, /swarm — bottom-
-    // aligned immediately above the editor's top border. Scope to the overlay so
-    // the empty-session home's /session /model /setup hints don't collide (#1098).
-    assert.equal(afterSuggestions.length, 4);
-    assert.deepEqual(
-      afterSuggestions.map((line) => line.match(/\/\w+/)?.[0]),
-      ['/session', '/setup', '/skill', '/swarm'],
-    );
-    assert.ok(afterLines[afterRows[0] - 1]!.includes('/swarm'));
-    assert.ok(afterLines[afterRows[0] - 2]!.includes('/skill'));
-    assert.ok(afterLines[afterRows[0] - 3]!.includes('/setup'));
-    assert.ok(afterLines[afterRows[0] - 4]!.includes('/session'));
-
-    exitMaka(terminal);
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close during test cleanup');
-      }),
-    ]);
-  });
-
   test('keeps slash autocomplete filtering pinned to the bottom after scrollback', async () => {
     const terminal = new FakeTerminal();
     const driver = new LongTranscriptDriver();
@@ -4279,24 +3651,6 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('bottom-aligns filtered autocomplete inside a stable slot', () => {
-    const expanded = arrangeAutocompleteAboveEditor({
-      lines: ['────────', '/ ', '────────', '→ /exit', '  /model', '  /permissions', '  /session'],
-      autocompleteShowing: true,
-      autocompleteSlotRows: 0,
-    });
-
-    const filtered = arrangeAutocompleteAboveEditor({
-      lines: ['────────', '/s ', '────────', '→ /session'],
-      autocompleteShowing: true,
-      autocompleteSlotRows: expanded.autocompleteSlotRows,
-    });
-
-    assert.equal(filtered.lines.length, expanded.lines.length);
-    assert.deepEqual(filtered.lines.slice(0, 4), ['', '', '', '→ /session']);
-    assert.deepEqual(filtered.lines.slice(4), ['────────', '/s ', '────────']);
-  });
-
   test('navigates submitted prompt history and restores the unsent draft', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -4349,33 +3703,6 @@ describe('Maka Pi TUI runner', () => {
         }),
       ]);
     }
-  });
-
-  test('handles /exit without sending a prompt', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'deepseek-v4-flash',
-      connectionSlug: 'deepseek',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    terminal.input('/exit');
-    terminal.input('\r');
-
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close after /exit');
-      }),
-    ]);
-
-    assert.deepEqual(driver.prompts, []);
-    assert.equal(terminal.stopCalls, 1);
   });
 
   test('keeps Maka open when Ctrl-D is pressed during a control command', async () => {
@@ -7932,70 +7259,6 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('does not ring when a short turn ends unfocused', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'ask',
-      // Default (large) threshold: the immediate-complete turn is far too short.
-      terminal,
-    });
-
-    terminal.input('\x1b[O');
-    terminal.input('go');
-    terminal.input('\r');
-
-    await waitFor(() => driver.prompts.length === 1);
-    await delay(30);
-    assert.equal(bellCount(terminal), 0);
-
-    exitMaka(terminal);
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close during test cleanup');
-      }),
-    ]);
-  });
-
-  test('does not ring when a long turn ends while still focused', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'ask',
-      attentionLongTurnThresholdMs: 0,
-      terminal,
-    });
-
-    // No blur report: the terminal is assumed focused, so a finished turn is
-    // silent — the user is watching it.
-    terminal.input('go');
-    terminal.input('\r');
-
-    await waitFor(() => driver.prompts.length === 1);
-    await delay(30);
-    assert.equal(bellCount(terminal), 0);
-    assert.equal(terminal.titles.includes('★ Maka'), false);
-
-    exitMaka(terminal);
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close during test cleanup');
-      }),
-    ]);
-  });
-
   test('rings when a sandbox boundary prompt appears unfocused', async () => {
     const terminal = new FakeTerminal();
     const driver = new SandboxBoundaryPromptDriver();
@@ -8020,38 +7283,6 @@ describe('Maka Pi TUI runner', () => {
     // Answer so the parked turn can finish and the TUI closes cleanly.
     terminal.input('y');
     await waitFor(() => driver.boundaryResponses.length === 1);
-
-    exitMaka(terminal);
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close during test cleanup');
-      }),
-    ]);
-  });
-
-  test('rings when a short turn fails unfocused', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new QuickErrorDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'ask',
-      // Default (large) threshold: the ring must come from the error path, not
-      // from turn duration — the turn fails immediately.
-      terminal,
-    });
-
-    terminal.input('\x1b[O');
-    terminal.input('go');
-    terminal.input('\r');
-
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('turn failed'));
-    await waitFor(() => bellCount(terminal) === 1);
-    assert.ok(terminal.titles.includes('★ Maka'));
 
     exitMaka(terminal);
     await Promise.race([
@@ -8765,33 +7996,6 @@ describe('Maka Pi TUI runner', () => {
     assert.deepEqual(driver.prompts, []);
   });
 
-  test('a bare "exit" line exits Maka without sending a prompt', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    terminal.input('exit');
-    terminal.input('\r');
-
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close on a bare "exit" line');
-      }),
-    ]);
-
-    assert.equal(terminal.stopCalls, 1);
-    assert.deepEqual(driver.prompts, []);
-  });
-
   test('"quit now" and "请 exit" are sent as ordinary prompts, not the exit word', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -8849,35 +8053,6 @@ describe('Maka Pi TUI runner', () => {
 
     assert.equal(terminal.stopCalls, 1);
     assert.deepEqual(driver.prompts, []);
-  });
-
-  test('/quit is a hidden alias of /exit, not its own autocomplete entry', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'deepseek-v4-flash',
-      connectionSlug: 'deepseek',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    terminal.input('/');
-
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/exit'));
-    const output = plainTerminalOutput(terminal.output());
-    assert.ok(output.includes('/exit'));
-    assert.ok(!output.includes('/quit'));
-
-    exitMaka(terminal);
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close during test cleanup');
-      }),
-    ]);
   });
 
   test('resumes a session at startup via resumeSessionId', async () => {


### PR DESCRIPTION
## Summary
- remove 26 redundant CLI and TUI interaction tests (866 net lines)
- drop the five-process legacy router mirror and duplicate executable help/version probes
- keep one integration path while removing repeated onboarding, autocomplete, signal, and attention presentation variants
- preserve cleanup deadlines, fatal reporting, sandbox boundaries, queue/abort races, credential rollback, and session ownership coverage

## Impact
- CLI suite: 630 -> 604 tests
- measured CLI duration: ~23.4s -> ~18.8s in isolated local runs
- legacy entrypoint suite: ~14.9s -> ~8.6s

## Validation
- npm run clean
- npm run build:test
- npm --workspace maka-agent run test:dist (604 passed)
- npm run test:scripts:full (51 passed)
- Runtime, Core, UI, and Desktop dist suites
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check