### PR TITLE
feat(runtime-host): establish Automation authority

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "./orchestration": "./dist/orchestration.js",
     "./plan": "./dist/plan.js",
     "./agent-run": "./dist/agent-run.js",
+    "./automation": "./dist/automation.js",
     "./model-call-attempt": "./dist/model-call-attempt.js",
     "./shell-run": "./dist/shell-run.js",
     "./shell-run-result": "./dist/shell-run-result.js",

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -50,6 +50,7 @@ export type AgentRunContinuationSource =
 
 export type RootExecutionDescriptor =
   | { kind: 'external_message' }
+  | { kind: 'automation'; automationId: string }
   | {
       kind: 'linked_child_initial';
       agentId: string;

--- a/packages/core/src/automation.ts
+++ b/packages/core/src/automation.ts
@@ -1,0 +1,144 @@
+import type { BackendKind } from './session.js';
+import type { CollaborationMode } from './collaboration.js';
+import type { OrchestrationMode } from './orchestration.js';
+import type { ThinkingLevel } from './model-thinking.js';
+
+const UTF8 = new TextEncoder();
+
+// Preserve the embedded model schema's code-unit limits while giving every
+// boundary an explicit UTF-8 ceiling. TextEncoder needs at most three bytes per
+// JavaScript code unit, including replacement encoding for lone surrogates.
+export const AUTOMATION_NAME_MAX_CODE_UNITS = 100;
+export const AUTOMATION_NAME_MAX_BYTES = 300;
+export const AUTOMATION_PROMPT_MAX_CODE_UNITS = 2_000;
+export const AUTOMATION_PROMPT_MAX_BYTES = 6_000;
+export const AUTOMATION_CRON_EXPRESSION_MAX_CODE_UNITS = 100;
+export const AUTOMATION_CRON_EXPRESSION_MAX_BYTES = 300;
+export const AUTOMATION_LAST_ERROR_MAX_CODE_UNITS = 2_000;
+export const AUTOMATION_LAST_ERROR_MAX_BYTES = 6_000;
+
+export interface AutomationTextLimit {
+  readonly maxCodeUnits: number;
+  readonly maxBytes: number;
+}
+
+export const AUTOMATION_NAME_LIMIT: AutomationTextLimit = Object.freeze({
+  maxCodeUnits: AUTOMATION_NAME_MAX_CODE_UNITS,
+  maxBytes: AUTOMATION_NAME_MAX_BYTES,
+});
+export const AUTOMATION_PROMPT_LIMIT: AutomationTextLimit = Object.freeze({
+  maxCodeUnits: AUTOMATION_PROMPT_MAX_CODE_UNITS,
+  maxBytes: AUTOMATION_PROMPT_MAX_BYTES,
+});
+export const AUTOMATION_CRON_EXPRESSION_LIMIT: AutomationTextLimit = Object.freeze({
+  maxCodeUnits: AUTOMATION_CRON_EXPRESSION_MAX_CODE_UNITS,
+  maxBytes: AUTOMATION_CRON_EXPRESSION_MAX_BYTES,
+});
+export const AUTOMATION_LAST_ERROR_LIMIT: AutomationTextLimit = Object.freeze({
+  maxCodeUnits: AUTOMATION_LAST_ERROR_MAX_CODE_UNITS,
+  maxBytes: AUTOMATION_LAST_ERROR_MAX_BYTES,
+});
+
+export function isAutomationTextWithinLimit(
+  value: unknown,
+  limit: AutomationTextLimit,
+  options: { readonly nonblank?: boolean } = {},
+): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= limit.maxCodeUnits &&
+    UTF8.encode(value).byteLength <= limit.maxBytes &&
+    (options.nonblank !== true || value.trim().length > 0)
+  );
+}
+
+export function truncateAutomationText(value: string, limit: AutomationTextLimit): string {
+  if (value.length <= limit.maxCodeUnits && UTF8.encode(value).byteLength <= limit.maxBytes) {
+    return value;
+  }
+  let result = '';
+  let bytes = 0;
+  for (const character of value) {
+    const nextBytes = UTF8.encode(character).byteLength;
+    if (
+      result.length + character.length > limit.maxCodeUnits ||
+      bytes + nextBytes > limit.maxBytes
+    ) {
+      break;
+    }
+    result += character;
+    bytes += nextBytes;
+  }
+  return result;
+}
+
+export type AutomationKind = 'heartbeat' | 'cron';
+export type AutomationStatus = 'active' | 'paused' | 'completed' | 'expired';
+
+export type AutomationSchedule =
+  | { type: 'cron'; expression: string }
+  | { type: 'interval'; seconds: number }
+  | { type: 'once'; delaySeconds: number };
+
+/** Frozen execution settings used by durable cron fires after their creator changes. */
+export interface AutomationExecutionTemplate {
+  readonly cwd: string;
+  readonly projectId?: string | null;
+  readonly backend: BackendKind;
+  readonly llmConnectionSlug: string;
+  readonly model: string;
+  readonly thinkingLevel?: ThinkingLevel;
+  readonly collaborationMode: CollaborationMode;
+  readonly orchestrationMode: OrchestrationMode;
+}
+
+export interface AutomationDefinition {
+  id: string;
+  kind: AutomationKind;
+  name: string;
+  status: AutomationStatus;
+  prompt: string;
+  sessionId: string;
+  schedule: AutomationSchedule;
+  createdAt: number;
+  updatedAt: number;
+  nextFireAt: number | null;
+  lastFireAt: number | null;
+  lastRunId: string | null;
+  fireCount: number;
+  maxFires: number | null;
+  expiresAt: number | null;
+  lastError: string | null;
+  consecutiveFailures: number;
+  /** Cron definitions are globally visible and survive the creating Client. */
+  durable?: boolean;
+  deferredFireCount?: number;
+  /** Present for Host-created cron definitions; legacy definitions acquire it before firing. */
+  execution?: AutomationExecutionTemplate;
+}
+
+/** Durable execution intent removed atomically when its canonical Run settles. */
+export interface AutomationPendingFire {
+  readonly id: string;
+  readonly automationId: string;
+  readonly automationKind: AutomationKind;
+  readonly automationName: string;
+  readonly prompt: string;
+  readonly scheduledFor: number;
+  readonly targetSessionId: string;
+  readonly turnId: string;
+  readonly runId: string;
+  readonly userMessageId: string;
+  readonly status: 'admitted' | 'running';
+  readonly admittedAt: number;
+  readonly updatedAt: number;
+  readonly startedAt?: number;
+  readonly execution?: AutomationExecutionTemplate;
+}
+
+export interface AutomationAuthoritySnapshot {
+  readonly revision: number;
+  readonly automations: readonly AutomationDefinition[];
+  readonly pendingFires: readonly AutomationPendingFire[];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1741,3 +1741,13 @@ export {
   PROVIDER_IMAGE_BUDGET_EXCEEDED_MESSAGE,
 } from './attachments.js';
 export type { AttachmentByteReader } from './attachments.js';
+
+export type {
+  AutomationAuthoritySnapshot,
+  AutomationDefinition,
+  AutomationExecutionTemplate,
+  AutomationKind,
+  AutomationPendingFire,
+  AutomationSchedule,
+  AutomationStatus,
+} from './automation.js';

--- a/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { performance } from 'node:perf_hooks';
 import { describe, test } from 'node:test';
 import type { AgentRunHeader, SessionHeader } from '@maka/core';
 import type { AutomationDefinition, AutomationPendingFire } from '@maka/core/automation';
@@ -35,6 +36,9 @@ const CONNECTION_CONTEXT: ConnectionContext = {
   acquireResidency: () => ({ release() {} }),
 };
 
+const ASYNC_STATE_TIMEOUT_MS = 5_000;
+const ASYNC_STATE_POLL_MS = 5;
+
 describe('Host Automation coordinator', () => {
   test('atomically admits one heartbeat fire and settles the same durable Run identity', async () => {
     await withHarness(async (harness) => {
@@ -54,7 +58,10 @@ describe('Host Automation coordinator', () => {
       harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
 
       harness.fireTimer();
-      await waitFor(async () => (await harness.store.read()).pendingFires[0]?.status === 'running');
+      await waitFor(
+        'heartbeat fire to enter running state',
+        async () => (await harness.store.read()).pendingFires[0]?.status === 'running',
+      );
       const admitted = await harness.store.read();
       assert.equal(admitted.pendingFires.length, 1);
       assert.equal(admitted.automations[0]?.fireCount, 1);
@@ -66,7 +73,10 @@ describe('Host Automation coordinator', () => {
       assert.equal(harness.rootInputs[0]?.userMessageId, fire.userMessageId);
 
       harness.finishRun();
-      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+      await waitFor(
+        'heartbeat fire to settle',
+        async () => (await harness.store.read()).pendingFires.length === 0,
+      );
       const settled = await harness.store.read();
       assert.equal(settled.automations[0]?.status, 'completed');
       assert.equal(settled.automations[0]?.lastRunId, fire.runId);
@@ -87,7 +97,10 @@ describe('Host Automation coordinator', () => {
 
       await harness.coordinator.prepareRecovery();
       await harness.coordinator.recover();
-      await waitFor(() => harness.rootInputs.length === 1);
+      await waitFor(
+        'recovered fire to enter the root coordinator',
+        () => harness.rootInputs.length === 1,
+      );
       const input = harness.rootInputs[0];
       assert.ok(input);
       assert.deepEqual(
@@ -108,7 +121,10 @@ describe('Host Automation coordinator', () => {
       );
 
       harness.finishRun();
-      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+      await waitFor(
+        'recovered fire to settle',
+        async () => (await harness.store.read()).pendingFires.length === 0,
+      );
       assert.equal((await harness.store.read()).automations[0]?.lastRunId, fire.runId);
     });
   });
@@ -202,7 +218,10 @@ describe('Host Automation coordinator', () => {
       assert.equal(harness.rootInputs[0]?.userMessageId, fire.userMessageId);
 
       harness.finishRun();
-      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+      await waitFor(
+        'recovered running fire to settle',
+        async () => (await harness.store.read()).pendingFires.length === 0,
+      );
       assert.equal((await harness.store.read()).automations[0]?.lastRunId, fire.runId);
     });
   });
@@ -235,7 +254,10 @@ describe('Host Automation coordinator', () => {
 
         harness.coordinator.start();
         harness.fireTimer();
-        await waitFor(() => harness.rootInputs.length === 2);
+        await waitFor(
+          'busy fire retry to enter the root coordinator',
+          () => harness.rootInputs.length === 2,
+        );
         assert.equal(harness.rootInputs[1]?.runId, fire.runId);
         assert.equal((await harness.store.read()).pendingFires[0]?.id, fire.id);
       },
@@ -261,7 +283,10 @@ describe('Host Automation coordinator', () => {
 
         harness.coordinator.start();
         harness.fireTimer();
-        await waitFor(() => harness.rootInputs.length === 2);
+        await waitFor(
+          'unavailable fire retry to enter the root coordinator',
+          () => harness.rootInputs.length === 2,
+        );
         assert.equal(harness.rootInputs[1]?.runId, fire.runId);
         assert.equal((await harness.store.read()).pendingFires[0]?.id, fire.id);
       },
@@ -286,7 +311,7 @@ describe('Host Automation coordinator', () => {
       harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
 
       harness.fireTimer();
-      await waitFor(() => harness.stableCreates.length === 1);
+      await waitFor('cron Session creation', () => harness.stableCreates.length === 1);
       const request = harness.stableCreates[0];
       assert.ok(request);
       assert.match(request.sessionId, /^automation_session_[0-9a-f]{48}$/);
@@ -297,7 +322,10 @@ describe('Host Automation coordinator', () => {
       assert.equal(request.input.permissionMode, 'explore');
 
       harness.finishRun();
-      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+      await waitFor(
+        'cron fire to settle',
+        async () => (await harness.store.read()).pendingFires.length === 0,
+      );
     });
   });
 
@@ -351,7 +379,7 @@ describe('Host Automation coordinator', () => {
         harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
 
         harness.fireTimer();
-        await waitFor(() => harness.timerCount() === 1);
+        await waitFor('deferred heartbeat retry timer', () => harness.timerCount() === 1);
         const snapshot = await harness.store.read();
         assert.equal(snapshot.automations[0]?.deferredFireCount, 1);
         assert.equal(snapshot.automations[0]?.fireCount, 0);
@@ -527,7 +555,10 @@ describe('Host Automation coordinator', () => {
       if ('error' in created) return;
       harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
       harness.fireTimer();
-      await waitFor(async () => (await harness.store.read()).pendingFires[0]?.status === 'running');
+      await waitFor(
+        'accepted fire to enter running state',
+        async () => (await harness.store.read()).pendingFires[0]?.status === 'running',
+      );
 
       let closed = false;
       const closing = harness.coordinator.close().then(() => {
@@ -559,14 +590,20 @@ describe('Host Automation coordinator', () => {
       if ('error' in created) return;
       harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
       harness.fireTimer();
-      await waitFor(async () => (await harness.store.read()).pendingFires[0]?.status === 'running');
+      await waitFor(
+        'draining fire to enter running state',
+        async () => (await harness.store.read()).pendingFires[0]?.status === 'running',
+      );
       const pendingRunId = (await harness.store.read()).pendingFires[0]?.runId;
       assert.ok(pendingRunId);
 
       const paused = await harness.coordinator.pause(created.id, 'creator-session');
       assert.equal(paused?.status, 'paused');
       harness.finishRun();
-      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+      await waitFor(
+        'draining fire to settle',
+        async () => (await harness.store.read()).pendingFires.length === 0,
+      );
       const settled = (await harness.store.read()).automations[0];
       assert.equal(settled?.status, 'paused');
       assert.equal(settled?.lastRunId, pendingRunId);
@@ -591,7 +628,10 @@ describe('Host Automation coordinator', () => {
       if ('error' in created) return;
       harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
       harness.fireTimer();
-      await waitFor(async () => (await harness.store.read()).pendingFires[0]?.status === 'running');
+      await waitFor(
+        'closing fire to enter running state',
+        async () => (await harness.store.read()).pendingFires[0]?.status === 'running',
+      );
 
       assert.deepEqual(
         await harness.coordinator.handlers['automation.mutate'](
@@ -609,7 +649,10 @@ describe('Host Automation coordinator', () => {
       assert.equal(pending.pendingFires[0]?.automationId, created.id);
 
       harness.finishRun();
-      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+      await waitFor(
+        'closing fire to settle',
+        async () => (await harness.store.read()).pendingFires.length === 0,
+      );
     });
   });
 
@@ -642,7 +685,7 @@ describe('Host Automation coordinator', () => {
         } finally {
           releasePolicy.resolve();
         }
-        await waitFor(() => harness.timerCount() === 1);
+        await waitFor('policy-unblocked scheduler timer', () => harness.timerCount() === 1);
 
         const snapshot = await harness.store.read();
         assert.equal(snapshot.revision, 3);
@@ -992,10 +1035,15 @@ function deferred(): { promise: Promise<void>; resolve(): void } {
   return { promise, resolve: resolvePromise };
 }
 
-async function waitFor(predicate: () => boolean | Promise<boolean>): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+async function waitFor(
+  description: string,
+  predicate: () => boolean | Promise<boolean>,
+): Promise<void> {
+  const deadline = performance.now() + ASYNC_STATE_TIMEOUT_MS;
+  while (true) {
     if (await predicate()) return;
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    if (performance.now() >= deadline) break;
+    await new Promise<void>((resolve) => setTimeout(resolve, ASYNC_STATE_POLL_MS));
   }
-  assert.fail('Timed out waiting for Automation coordinator state');
+  assert.fail(`Timed out waiting for ${description}`);
 }

--- a/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
@@ -1,0 +1,956 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { AgentRunHeader, SessionHeader } from '@maka/core';
+import type { AutomationDefinition, AutomationPendingFire } from '@maka/core/automation';
+import {
+  RuntimeHostedRootConflictError,
+  RuntimeHostedRootUnavailableError,
+  type RuntimeHostedRootExecutionInput,
+  type SessionManager,
+} from '@maka/runtime';
+import {
+  openInteractiveAutomationAuthorityForWrite,
+  type InteractiveAutomationAuthorityWriter,
+} from '@maka/storage/automation-authority';
+import type {
+  ExecutionAgentRunWriter,
+  ExecutionSessionWriter,
+  RootTurnAdmission,
+} from '@maka/storage/execution-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import type { RuntimePolicyStoresWriter } from '@maka/storage/runtime-policy-stores';
+import { HostAutomationCoordinator } from '../server/automation-coordinator.js';
+import { HostAutomationFireCoordinator } from '../server/automation-fire-coordinator.js';
+import type { ConnectionContext } from '../server/operation-dispatcher.js';
+
+const CONNECTION_CONTEXT: ConnectionContext = {
+  hostEpoch: 'automation-test',
+  connectionId: 'automation-test-connection',
+  surface: 'tui',
+  principal: 'local_os_user',
+  acquireResidency: () => ({ release() {} }),
+};
+
+describe('Host Automation coordinator', () => {
+  test('atomically admits one heartbeat fire and settles the same durable Run identity', async () => {
+    await withHarness(async (harness) => {
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      harness.coordinator.start();
+
+      const created = await harness.coordinator.create({
+        kind: 'heartbeat',
+        name: 'check build',
+        prompt: 'Check the build.',
+        sessionId: 'creator-session',
+        schedule: { type: 'once', delaySeconds: 5 },
+      });
+      assert.ok(!('error' in created));
+      if ('error' in created) return;
+      harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
+
+      harness.fireTimer();
+      await waitFor(async () => (await harness.store.read()).pendingFires[0]?.status === 'running');
+      const admitted = await harness.store.read();
+      assert.equal(admitted.pendingFires.length, 1);
+      assert.equal(admitted.automations[0]?.fireCount, 1);
+      assert.equal(admitted.automations[0]?.nextFireAt, null);
+      assert.equal(harness.rootInputs.length, 1);
+      const fire = admitted.pendingFires[0];
+      assert.ok(fire);
+      assert.equal(harness.rootInputs[0]?.runId, fire.runId);
+      assert.equal(harness.rootInputs[0]?.userMessageId, fire.userMessageId);
+
+      harness.finishRun();
+      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+      const settled = await harness.store.read();
+      assert.equal(settled.automations[0]?.status, 'completed');
+      assert.equal(settled.automations[0]?.lastRunId, fire.runId);
+      assert.equal(settled.automations[0]?.lastError, null);
+      assert.equal(harness.residencyCount, 0);
+    });
+  });
+
+  test('recovers a pre-Run pending fire without allocating any new identity', async () => {
+    await withHarness(async (harness) => {
+      const automation = startedDefinition();
+      const fire = pendingFire();
+      await harness.store.commit({
+        expectedRevision: 0,
+        automations: [automation],
+        pendingFires: [fire],
+      });
+
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      await waitFor(() => harness.rootInputs.length === 1);
+      const input = harness.rootInputs[0];
+      assert.ok(input);
+      assert.deepEqual(
+        {
+          sessionId: input.sessionId,
+          turnId: input.turnId,
+          runId: input.runId,
+          userMessageId: input.userMessageId,
+          execution: input.execution,
+        },
+        {
+          sessionId: fire.targetSessionId,
+          turnId: fire.turnId,
+          runId: fire.runId,
+          userMessageId: fire.userMessageId,
+          execution: { kind: 'automation', automationId: fire.automationId },
+        },
+      );
+
+      harness.finishRun();
+      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+      assert.equal((await harness.store.read()).automations[0]?.lastRunId, fire.runId);
+    });
+  });
+
+  test('settles a terminal Run during recovery without executing it again', async () => {
+    await withHarness(async (harness) => {
+      const automation = startedDefinition();
+      const fire = pendingFire();
+      harness.runs.set(fire.runId, runHeader(fire, 'failed'));
+      await harness.store.commit({
+        expectedRevision: 0,
+        automations: [automation],
+        pendingFires: [fire],
+      });
+
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      assert.equal(harness.rootInputs.length, 0);
+      const recovered = await harness.store.read();
+      assert.deepEqual(recovered.pendingFires, []);
+      assert.equal(recovered.automations[0]?.status, 'paused');
+      assert.equal(recovered.automations[0]?.lastRunId, fire.runId);
+      assert.equal(recovered.automations[0]?.consecutiveFailures, 1);
+    });
+  });
+
+  test('settles a terminal Run whose backend recorded an empty failure diagnostic', async () => {
+    await withHarness(async (harness) => {
+      const automation = startedDefinition();
+      const fire = pendingFire();
+      harness.runs.set(fire.runId, { ...runHeader(fire, 'failed'), failureMessage: '' });
+      await harness.store.commit({
+        expectedRevision: 0,
+        automations: [automation],
+        pendingFires: [fire],
+      });
+
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      const recovered = await harness.store.read();
+      assert.deepEqual(recovered.pendingFires, []);
+      assert.equal(recovered.automations[0]?.lastError, 'Automation run failed');
+    });
+  });
+
+  test('bounds a multibyte terminal failure while preserving its diagnostic prefix', async () => {
+    await withHarness(async (harness) => {
+      const automation = startedDefinition();
+      const fire = pendingFire();
+      const failureMessage = '故'.repeat(4_000);
+      harness.runs.set(fire.runId, {
+        ...runHeader(fire, 'failed'),
+        failureMessage,
+      });
+      await harness.store.commit({
+        expectedRevision: 0,
+        automations: [automation],
+        pendingFires: [fire],
+      });
+
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      const settled = (await harness.store.read()).automations[0];
+      assert.equal(settled?.lastError, '故'.repeat(2_000));
+      assert.equal(Buffer.byteLength(settled?.lastError ?? '', 'utf8'), 6_000);
+      assert.deepEqual((await harness.store.read()).pendingFires, []);
+    });
+  });
+
+  test('recovers a running fire through the same root and Run identity', async () => {
+    await withHarness(async (harness) => {
+      const automation = startedDefinition();
+      const fire: AutomationPendingFire = {
+        ...pendingFire(),
+        status: 'running',
+        startedAt: 6_001,
+        updatedAt: 6_001,
+      };
+      harness.runs.set(fire.runId, runHeader(fire, 'running'));
+      await harness.store.commit({
+        expectedRevision: 0,
+        automations: [automation],
+        pendingFires: [fire],
+      });
+
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      assert.equal(harness.rootInputs.length, 1);
+      assert.equal(harness.rootInputs[0]?.turnId, fire.turnId);
+      assert.equal(harness.rootInputs[0]?.runId, fire.runId);
+      assert.equal(harness.rootInputs[0]?.userMessageId, fire.userMessageId);
+
+      harness.finishRun();
+      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+      assert.equal((await harness.store.read()).automations[0]?.lastRunId, fire.runId);
+    });
+  });
+
+  test('keeps one busy pending fire retryable and validates its recovery admission', async () => {
+    await withHarness(
+      async (harness) => {
+        const automation = startedDefinition();
+        const fire = pendingFire();
+        await harness.store.commit({
+          expectedRevision: 0,
+          automations: [automation],
+          pendingFires: [fire],
+        });
+        harness.rootMode = 'busy';
+
+        await harness.coordinator.prepareRecovery();
+        harness.coordinator.assertRecoveryAdmission(rootAdmission(fire));
+        assert.throws(
+          () =>
+            harness.coordinator.assertRecoveryAdmission({
+              ...rootAdmission(fire),
+              runId: 'different-run',
+            }),
+          /no matching pending fire/,
+        );
+        await harness.coordinator.recover();
+        assert.equal(harness.rootInputs.length, 1);
+        assert.deepEqual((await harness.store.read()).pendingFires, [fire]);
+
+        harness.coordinator.start();
+        harness.fireTimer();
+        await waitFor(() => harness.rootInputs.length === 2);
+        assert.equal(harness.rootInputs[1]?.runId, fire.runId);
+        assert.equal((await harness.store.read()).pendingFires[0]?.id, fire.id);
+      },
+      { rootMode: 'busy' },
+    );
+  });
+
+  test('keeps an unavailable target retryable without changing its durable fire identity', async () => {
+    await withHarness(
+      async (harness) => {
+        const automation = startedDefinition();
+        const fire = pendingFire();
+        await harness.store.commit({
+          expectedRevision: 0,
+          automations: [automation],
+          pendingFires: [fire],
+        });
+
+        await harness.coordinator.prepareRecovery();
+        await harness.coordinator.recover();
+        assert.equal(harness.rootInputs.length, 1);
+        assert.deepEqual((await harness.store.read()).pendingFires, [fire]);
+
+        harness.coordinator.start();
+        harness.fireTimer();
+        await waitFor(() => harness.rootInputs.length === 2);
+        assert.equal(harness.rootInputs[1]?.runId, fire.runId);
+        assert.equal((await harness.store.read()).pendingFires[0]?.id, fire.id);
+      },
+      { rootMode: 'unavailable' },
+    );
+  });
+
+  test('creates one stable cron Session from the frozen execution template', async () => {
+    await withHarness(async (harness) => {
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      harness.coordinator.start();
+      const created = await harness.coordinator.create({
+        kind: 'cron',
+        name: 'daily summary',
+        prompt: 'Summarize the workspace.',
+        sessionId: 'creator-session',
+        schedule: { type: 'once', delaySeconds: 5 },
+      });
+      assert.ok(!('error' in created));
+      if ('error' in created) return;
+      harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
+
+      harness.fireTimer();
+      await waitFor(() => harness.stableCreates.length === 1);
+      const request = harness.stableCreates[0];
+      assert.ok(request);
+      assert.match(request.sessionId, /^automation_session_[0-9a-f]{48}$/);
+      assert.match(request.requestFingerprint, /^sha256:[0-9a-f]{64}$/);
+      assert.equal(request.input.cwd, '/workspace');
+      assert.equal(request.input.llmConnectionSlug, 'openrouter');
+      assert.equal(request.input.model, 'openrouter/free');
+      assert.equal(request.input.permissionMode, 'explore');
+
+      harness.finishRun();
+      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+    });
+  });
+
+  test('rejects new Automations whose creator Session cannot execute hosted roots', async () => {
+    await withHarness(
+      async (harness) => {
+        await harness.coordinator.prepareRecovery();
+        const result = await harness.coordinator.handlers['automation.mutate'](
+          {
+            kind: 'create',
+            sessionId: 'creator-session',
+            automationKind: 'heartbeat',
+            name: 'unsupported heartbeat',
+            prompt: 'This cannot execute here.',
+            schedule: { type: 'interval', seconds: 60 },
+          },
+          CONNECTION_CONTEXT,
+        );
+        assert.deepEqual(result, {
+          ok: false,
+          error: {
+            code: 'operation_unavailable',
+            message: 'Plan sessions are not yet supported by Runtime Host.',
+          },
+        });
+        assert.deepEqual(await harness.store.read(), {
+          revision: 0,
+          automations: [],
+          pendingFires: [],
+        });
+      },
+      { creatorHeader: { collaborationMode: 'plan' } },
+    );
+  });
+
+  test('defers a due fire while incognito without admitting execution', async () => {
+    await withHarness(
+      async (harness) => {
+        await harness.coordinator.prepareRecovery();
+        await harness.coordinator.recover();
+        harness.coordinator.start();
+        const created = await harness.coordinator.create({
+          kind: 'cron',
+          name: 'daily summary',
+          prompt: 'Summarize the workspace.',
+          sessionId: 'creator-session',
+          schedule: { type: 'once', delaySeconds: 5 },
+        });
+        assert.ok(!('error' in created));
+        if ('error' in created) return;
+        harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
+
+        harness.fireTimer();
+        await waitFor(() => harness.timerCount() === 1);
+        const snapshot = await harness.store.read();
+        assert.equal(snapshot.automations[0]?.deferredFireCount, 1);
+        assert.equal(snapshot.automations[0]?.fireCount, 0);
+        assert.equal(snapshot.automations[0]?.nextFireAt, created.nextFireAt);
+        assert.deepEqual(snapshot.pendingFires, []);
+        assert.equal(harness.rootInputs.length, 0);
+      },
+      { readIncognito: async () => true },
+    );
+  });
+
+  test('drain cancels the timer residency and rejects new mutations', async () => {
+    await withHarness(async (harness) => {
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      harness.coordinator.start();
+      const created = await harness.coordinator.create({
+        kind: 'heartbeat',
+        name: 'check build',
+        prompt: 'Check the build.',
+        sessionId: 'creator-session',
+        schedule: { type: 'interval', seconds: 60 },
+      });
+      assert.ok(!('error' in created));
+      assert.equal(harness.timerCount(), 1);
+      assert.equal(harness.residencyCount, 1);
+
+      harness.coordinator.beginDrain();
+      assert.equal(harness.timerCount(), 0);
+      assert.equal(harness.residencyCount, 0);
+      assert.deepEqual(
+        await harness.coordinator.create({
+          kind: 'heartbeat',
+          name: 'second check',
+          prompt: 'Check again.',
+          sessionId: 'creator-session',
+          schedule: { type: 'interval', seconds: 60 },
+        }),
+        { error: 'Automation authority is unavailable.' },
+      );
+    });
+  });
+
+  test('drain waits for a scheduler admission already crossing the durable commit boundary', async () => {
+    const admitEntered = deferred();
+    const releaseAdmission = deferred();
+    const timers: Array<() => void> = [];
+    const fire = pendingFire();
+    const due: AutomationDefinition = {
+      ...startedDefinition(),
+      schedule: { type: 'interval', seconds: 60 },
+      updatedAt: 1,
+      nextFireAt: 6_000,
+      lastFireAt: null,
+      fireCount: 0,
+    };
+    let rootCalls = 0;
+    const coordinator = new HostAutomationFireCoordinator({
+      state: {
+        listPendingFires: async () => [],
+        listDueAutomations: async () => [due],
+        recordDeferredFire: async () => false,
+        admitFire: async () => {
+          admitEntered.resolve();
+          await releaseAdmission.promise;
+          return fire;
+        },
+        assertPendingFire: async () => undefined,
+        markFireRunning: async () => undefined,
+        settleFire: async () => undefined,
+        residencyState: () => ({ pending: false, scheduled: false }),
+      },
+      sessions: {
+        readHeaderSnapshot: async () => sessionHeader('creator-session'),
+        createStableSession: async () => assert.fail('Heartbeat must not create a Session'),
+      },
+      runs: {
+        readRun: async () => {
+          throw missingRecord('Run not found');
+        },
+      },
+      runtime: {
+        sendMessage: async function* () {
+          assert.fail('Draining fire must not enter Runtime');
+        },
+      },
+      root: {
+        executeRoot: async (input) => {
+          rootCalls += 1;
+          await input.admitExecution?.();
+        },
+      },
+      runtimePolicy: runtimePolicyStores(),
+      isSessionActive: () => false,
+      acquireResidency: () => ({ release() {} }),
+      requestDrain: () => undefined,
+      now: () => 6_000,
+      setTimeout: (callback) => {
+        timers.push(callback);
+        return callback;
+      },
+      clearTimeout: () => undefined,
+    });
+
+    await coordinator.recover();
+    coordinator.start();
+    timers.shift()?.();
+    await admitEntered.promise;
+    let closed = false;
+    const closing = coordinator.close().then(() => {
+      closed = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(closed, false);
+    releaseAdmission.resolve();
+    await closing;
+    assert.equal(rootCalls, 1);
+  });
+
+  test('close waits for an accepted fire to settle', async () => {
+    await withHarness(async (harness) => {
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      harness.coordinator.start();
+      const created = await harness.coordinator.create({
+        kind: 'heartbeat',
+        name: 'check build',
+        prompt: 'Check the build.',
+        sessionId: 'creator-session',
+        schedule: { type: 'once', delaySeconds: 5 },
+      });
+      assert.ok(!('error' in created));
+      if ('error' in created) return;
+      harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
+      harness.fireTimer();
+      await waitFor(async () => (await harness.store.read()).pendingFires[0]?.status === 'running');
+
+      let closed = false;
+      const closing = harness.coordinator.close().then(() => {
+        closed = true;
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(closed, false);
+      harness.finishRun();
+      await closing;
+      assert.equal(closed, true);
+      assert.deepEqual((await harness.store.read()).pendingFires, []);
+      assert.equal(harness.residencyCount, 0);
+    });
+  });
+
+  test('records an accepted fire outcome after the definition is paused', async () => {
+    await withHarness(async (harness) => {
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      harness.coordinator.start();
+      const created = await harness.coordinator.create({
+        kind: 'heartbeat',
+        name: 'check build',
+        prompt: 'Check the build.',
+        sessionId: 'creator-session',
+        schedule: { type: 'once', delaySeconds: 5 },
+      });
+      assert.ok(!('error' in created));
+      if ('error' in created) return;
+      harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
+      harness.fireTimer();
+      await waitFor(async () => (await harness.store.read()).pendingFires[0]?.status === 'running');
+      const pendingRunId = (await harness.store.read()).pendingFires[0]?.runId;
+      assert.ok(pendingRunId);
+
+      const paused = await harness.coordinator.pause(created.id, 'creator-session');
+      assert.equal(paused?.status, 'paused');
+      harness.finishRun();
+      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+      const settled = (await harness.store.read()).automations[0];
+      assert.equal(settled?.status, 'paused');
+      assert.equal(settled?.lastRunId, pendingRunId);
+      assert.equal(settled?.lastError, null);
+      assert.equal(settled?.consecutiveFailures, 0);
+    });
+  });
+
+  test('rejects deletion while an accepted fire still owns its definition', async () => {
+    await withHarness(async (harness) => {
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      harness.coordinator.start();
+      const created = await harness.coordinator.create({
+        kind: 'heartbeat',
+        name: 'check build',
+        prompt: 'Check the build.',
+        sessionId: 'creator-session',
+        schedule: { type: 'once', delaySeconds: 5 },
+      });
+      assert.ok(!('error' in created));
+      if ('error' in created) return;
+      harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
+      harness.fireTimer();
+      await waitFor(async () => (await harness.store.read()).pendingFires[0]?.status === 'running');
+
+      assert.deepEqual(
+        await harness.coordinator.handlers['automation.mutate'](
+          {
+            kind: 'delete',
+            sessionId: 'creator-session',
+            automationId: created.id,
+          },
+          CONNECTION_CONTEXT,
+        ),
+        { ok: true, result: { kind: 'rejected', reason: 'fire_pending' } },
+      );
+      const pending = await harness.store.read();
+      assert.equal(pending.automations[0]?.id, created.id);
+      assert.equal(pending.pendingFires[0]?.automationId, created.id);
+
+      harness.finishRun();
+      await waitFor(async () => (await harness.store.read()).pendingFires.length === 0);
+    });
+  });
+
+  test('ignores a stale deferred decision after the schedule is re-armed', async () => {
+    const policyEntered = deferred();
+    const releasePolicy = deferred();
+    await withHarness(
+      async (harness) => {
+        await harness.coordinator.prepareRecovery();
+        await harness.coordinator.recover();
+        harness.coordinator.start();
+        const created = await harness.coordinator.create({
+          kind: 'cron',
+          name: 'daily summary',
+          prompt: 'Summarize the workspace.',
+          sessionId: 'creator-session',
+          schedule: { type: 'once', delaySeconds: 5 },
+        });
+        assert.ok(!('error' in created));
+        if ('error' in created) return;
+        harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
+
+        harness.fireTimer();
+        await policyEntered.promise;
+        let resumed: AutomationDefinition | undefined;
+        try {
+          assert.ok(await harness.coordinator.pause(created.id, 'creator-session'));
+          resumed = await harness.coordinator.resume(created.id, 'creator-session');
+          assert.ok(resumed);
+        } finally {
+          releasePolicy.resolve();
+        }
+        await waitFor(() => harness.timerCount() === 1);
+
+        const snapshot = await harness.store.read();
+        assert.equal(snapshot.revision, 3);
+        assert.equal(snapshot.automations[0]?.nextFireAt, resumed?.nextFireAt);
+        assert.equal(snapshot.automations[0]?.deferredFireCount, undefined);
+        assert.deepEqual(snapshot.pendingFires, []);
+      },
+      {
+        readIncognito: async () => {
+          policyEntered.resolve();
+          await releasePolicy.promise;
+          return true;
+        },
+      },
+    );
+  });
+});
+
+interface Harness {
+  coordinator: HostAutomationCoordinator;
+  readonly store: InteractiveAutomationAuthorityWriter;
+  readonly runs: Map<string, AgentRunHeader>;
+  readonly rootInputs: RuntimeHostedRootExecutionInput[];
+  readonly stableCreates: Parameters<ExecutionSessionWriter['createStableSession']>[0][];
+  now: number;
+  rootMode: 'run' | 'busy' | 'unavailable';
+  residencyCount: number;
+  fireTimer(): void;
+  finishRun(): void;
+  timerCount(): number;
+}
+
+async function withHarness(
+  run: (harness: Harness) => Promise<void>,
+  options: {
+    rootMode?: Harness['rootMode'];
+    readIncognito?: () => Promise<boolean>;
+    creatorHeader?: Partial<SessionHeader>;
+  } = {},
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-automation-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'interactive'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  const store = await openInteractiveAutomationAuthorityForWrite(owner.lease);
+  const runs = new Map<string, AgentRunHeader>();
+  const rootInputs: RuntimeHostedRootExecutionInput[] = [];
+  const stableCreates: Parameters<ExecutionSessionWriter['createStableSession']>[0][] = [];
+  const sessionHeaders = new Map<string, SessionHeader>([
+    ['creator-session', sessionHeader('creator-session', options.creatorHeader)],
+  ]);
+  const timers: Array<() => void> = [];
+  let finishRun = deferred();
+  const harness: Harness = {
+    coordinator: undefined as unknown as HostAutomationCoordinator,
+    store,
+    runs,
+    rootInputs,
+    stableCreates,
+    now: 1_000,
+    rootMode: options.rootMode ?? 'run',
+    residencyCount: 0,
+    fireTimer: () => {
+      const timer = timers.shift();
+      assert.ok(timer, 'Expected an Automation scheduler timer');
+      timer();
+    },
+    finishRun: () => finishRun.resolve(),
+    timerCount: () => timers.length,
+  };
+  const sessions = {
+    readHeaderSnapshot: async (sessionId: string) => {
+      const header = sessionHeaders.get(sessionId);
+      if (!header) throw missingRecord(`Session not found: ${sessionId}`);
+      return structuredClone(header);
+    },
+    createStableSession: async (
+      request: Parameters<ExecutionSessionWriter['createStableSession']>[0],
+    ) => {
+      stableCreates.push(structuredClone(request));
+      const existing = sessionHeaders.get(request.sessionId);
+      if (existing) {
+        return {
+          kind: 'existing' as const,
+          record: { header: structuredClone(existing), revision: 1, committedAt: harness.now },
+        };
+      }
+      const header = sessionHeader(request.sessionId, request.input);
+      sessionHeaders.set(request.sessionId, header);
+      return {
+        kind: 'created' as const,
+        record: { header: structuredClone(header), revision: 1, committedAt: harness.now },
+      };
+    },
+  } as Pick<ExecutionSessionWriter, 'createStableSession' | 'readHeaderSnapshot'>;
+  const runtime = {
+    sendMessage: async function* (
+      sessionId: string,
+      input: { turnId: string; origin?: { automationId: string } },
+      turnOptions: {
+        runId?: string;
+        onRunStarted?: (runId: string, header: SessionHeader) => Promise<void> | void;
+      },
+    ) {
+      const fire = [...(await store.read()).pendingFires].find(
+        (candidate) => candidate.runId === turnOptions.runId,
+      );
+      assert.ok(fire);
+      assert.equal(input.turnId, fire.turnId);
+      assert.equal(input.origin?.automationId, fire.automationId);
+      runs.set(fire.runId, runHeader(fire, 'running'));
+      await turnOptions.onRunStarted?.(fire.runId, sessionHeaders.get(sessionId)!);
+      await finishRun.promise;
+      runs.set(fire.runId, runHeader(fire, 'completed'));
+    },
+  } as unknown as Pick<SessionManager, 'sendMessage'>;
+  const root = {
+    executeRoot: async (input: RuntimeHostedRootExecutionInput) => {
+      rootInputs.push(input);
+      if (harness.rootMode === 'busy') {
+        throw new RuntimeHostedRootConflictError(input.sessionId, 'Session is busy');
+      }
+      if (harness.rootMode === 'unavailable') {
+        throw new RuntimeHostedRootUnavailableError(input.sessionId, 'Session is unavailable');
+      }
+      assert.equal(await input.admitExecution?.(), 'executing');
+      const stream = input.start({
+        runId: input.runId,
+        userMessageId: input.userMessageId,
+        onRunStarted: async () => input.onReady?.(),
+      });
+      for await (const _event of stream) {
+        assert.fail('Automation test runtime emitted an unexpected event');
+      }
+    },
+  };
+  harness.coordinator = new HostAutomationCoordinator({
+    store,
+    sessions,
+    runs: {
+      readRun: async (_sessionId, runId) => {
+        const header = runs.get(runId);
+        if (!header) throw missingRecord(`Run not found: ${runId}`);
+        return structuredClone(header);
+      },
+    } as Pick<ExecutionAgentRunWriter, 'readRun'>,
+    runtime,
+    root,
+    runtimePolicy: runtimePolicyStores(options.readIncognito),
+    isSessionActive: () => false,
+    acquireResidency: () => {
+      harness.residencyCount += 1;
+      let released = false;
+      return {
+        release: () => {
+          if (released) return;
+          released = true;
+          harness.residencyCount -= 1;
+        },
+      };
+    },
+    requestDrain: () => undefined,
+    newId: sequentialIds(),
+    now: () => harness.now,
+    random: () => 0,
+    setTimeout: (callback) => {
+      timers.push(callback);
+      return callback;
+    },
+    clearTimeout: (timer) => {
+      const index = timers.indexOf(timer as () => void);
+      if (index >= 0) timers.splice(index, 1);
+    },
+  });
+
+  try {
+    await run(harness);
+  } finally {
+    harness.rootMode = 'busy';
+    finishRun.resolve();
+    await harness.coordinator.close();
+    store.close();
+    if (!owner.closed) await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+function sessionHeader(id: string, input: Partial<SessionHeader> = {}): SessionHeader {
+  return {
+    id,
+    workspaceRoot: '/workspace',
+    cwd: '/workspace',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Session',
+    titleIsManual: false,
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'openrouter',
+    connectionLocked: false,
+    model: 'openrouter/free',
+    permissionMode: 'explore',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+    schemaVersion: 1,
+    ...input,
+  };
+}
+
+function startedDefinition(): AutomationDefinition {
+  return {
+    id: 'automation-1',
+    kind: 'heartbeat',
+    name: 'check build',
+    status: 'active',
+    prompt: 'Check the build.',
+    sessionId: 'creator-session',
+    schedule: { type: 'once', delaySeconds: 5 },
+    createdAt: 1,
+    updatedAt: 6_000,
+    nextFireAt: null,
+    lastFireAt: 6_000,
+    lastRunId: null,
+    fireCount: 1,
+    maxFires: null,
+    expiresAt: 604_800_001,
+    lastError: null,
+    consecutiveFailures: 0,
+  };
+}
+
+function pendingFire(): AutomationPendingFire {
+  return {
+    id: 'fire-1',
+    automationId: 'automation-1',
+    automationKind: 'heartbeat',
+    automationName: 'check build',
+    prompt: 'Check the build.',
+    scheduledFor: 6_000,
+    targetSessionId: 'creator-session',
+    turnId: 'turn-1',
+    runId: 'run-1',
+    userMessageId: 'message-1',
+    status: 'admitted',
+    admittedAt: 6_000,
+    updatedAt: 6_000,
+  };
+}
+
+function runHeader(fire: AutomationPendingFire, status: AgentRunHeader['status']): AgentRunHeader {
+  return {
+    runId: fire.runId,
+    sessionId: fire.targetSessionId,
+    turnId: fire.turnId,
+    status,
+    backendKind: 'ai-sdk',
+    llmConnectionSlug: 'openrouter',
+    modelId: 'openrouter/free',
+    cwd: '/workspace',
+    permissionMode: 'explore',
+    createdAt: 6_000,
+    updatedAt: 6_001,
+    automationId: fire.automationId,
+    ...(status === 'failed'
+      ? { completedAt: 6_001, failureClass: 'provider_error', failureMessage: 'Provider failed' }
+      : status === 'completed'
+        ? { completedAt: 6_001 }
+        : {}),
+  };
+}
+
+function rootAdmission(fire: AutomationPendingFire): RootTurnAdmission {
+  return {
+    schemaVersion: 1,
+    sessionId: fire.targetSessionId,
+    turnId: fire.turnId,
+    runId: fire.runId,
+    userMessageId: fire.userMessageId,
+    execution: { kind: 'automation', automationId: fire.automationId },
+    previousRootTurnId: null,
+    normalizedInput: {
+      text: `[Automation: ${fire.automationName}]\n\n${fire.prompt}`,
+    },
+    sourceMessages: [],
+    admittedAt: fire.admittedAt,
+  };
+}
+
+function runtimePolicyStores(
+  readIncognito: () => Promise<boolean> = async () => false,
+): RuntimePolicyStoresWriter {
+  return {
+    runtimePolicy: {
+      getSnapshot: async () => ({
+        revision: 0,
+        policy: {
+          networkProxy: {
+            enabled: false,
+            protocol: 'http',
+            host: '',
+            port: 0,
+            authEnabled: false,
+            username: '',
+            bypassList: [],
+            autoBypassDomains: [],
+          },
+          personalization: { displayName: '', assistantTone: '' },
+          memory: { enabled: false, agentReadEnabled: false },
+          workspaceInstructions: { enabled: true },
+          privacy: { incognitoActive: await readIncognito() },
+          chatDefaults: { permissionMode: 'explore' },
+          webSearch: { enabled: false, defaultProvider: 'tavily' },
+        },
+      }),
+    },
+  } as unknown as RuntimePolicyStoresWriter;
+}
+
+function sequentialIds(): () => string {
+  let next = 0;
+  return () => `generated-${++next}`;
+}
+
+function missingRecord(message: string): NodeJS.ErrnoException {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = 'ENOENT';
+  return error;
+}
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolvePromise!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (await predicate()) return;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  assert.fail('Timed out waiting for Automation coordinator state');
+}

--- a/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
@@ -8,6 +8,7 @@ import type { AutomationDefinition, AutomationPendingFire } from '@maka/core/aut
 import {
   RuntimeHostedRootConflictError,
   RuntimeHostedRootUnavailableError,
+  type MakaToolContext,
   type RuntimeHostedRootExecutionInput,
   type SessionManager,
 } from '@maka/runtime';
@@ -394,6 +395,46 @@ describe('Host Automation coordinator', () => {
     });
   });
 
+  test('model mutation persistence failure drains and rolls back canonical state', async () => {
+    await withHarness(async (harness) => {
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      const concurrentCommit = await harness.store.commit({
+        expectedRevision: 0,
+        automations: [],
+        pendingFires: [],
+      });
+      assert.equal(concurrentCommit.kind, 'committed');
+
+      const output = await harness.coordinator.modelTool.impl(
+        {
+          mode: 'create',
+          kind: 'heartbeat',
+          name: 'check build',
+          prompt: 'Check the build.',
+          schedule: { type: 'interval', seconds: 60 },
+        },
+        {
+          sessionId: 'creator-session',
+          turnId: 'turn-model',
+          cwd: '/workspace',
+          toolCallId: 'tool-model',
+          abortSignal: new AbortController().signal,
+          emitOutput: () => {},
+        } satisfies MakaToolContext,
+      );
+
+      assert.equal(output, 'Error: Automation authority is unavailable.');
+      assert.equal(harness.drainCount, 1);
+      assert.deepEqual(await harness.store.read(), {
+        revision: 1,
+        automations: [],
+        pendingFires: [],
+      });
+      assert.deepEqual(await harness.coordinator.listVisibleForSession('creator-session'), []);
+    });
+  });
+
   test('drain waits for a scheduler admission already crossing the durable commit boundary', async () => {
     const admitEntered = deferred();
     const releaseAdmission = deferred();
@@ -629,6 +670,7 @@ interface Harness {
   now: number;
   rootMode: 'run' | 'busy' | 'unavailable';
   residencyCount: number;
+  drainCount: number;
   fireTimer(): void;
   finishRun(): void;
   timerCount(): number;
@@ -668,6 +710,7 @@ async function withHarness(
     now: 1_000,
     rootMode: options.rootMode ?? 'run',
     residencyCount: 0,
+    drainCount: 0,
     fireTimer: () => {
       const timer = timers.shift();
       assert.ok(timer, 'Expected an Automation scheduler timer');
@@ -767,7 +810,9 @@ async function withHarness(
         },
       };
     },
-    requestDrain: () => undefined,
+    requestDrain: () => {
+      harness.drainCount += 1;
+    },
     newId: sequentialIds(),
     now: () => harness.now,
     random: () => 0,

--- a/packages/runtime-host/src/__tests__/automation-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-protocol.test.ts
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  AUTOMATION_MAX_FIRES,
+  AUTOMATION_OPERATION_SPECS,
+  AUTOMATION_PAGE_MAX_ITEMS,
+  decodeAutomationMutateInput,
+  decodeAutomationMutateResult,
+  decodeAutomationQueryInput,
+  decodeAutomationQueryResult,
+  type AutomationProjection,
+} from '../protocol/automation.js';
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
+
+describe('Automation protocol', () => {
+  test('declares one ready query and one ready command', () => {
+    assert.deepEqual(Object.keys(AUTOMATION_OPERATION_SPECS), [
+      'automation.query',
+      'automation.mutate',
+    ]);
+    assert.equal(AUTOMATION_OPERATION_SPECS['automation.query'].mode, 'query');
+    assert.equal(AUTOMATION_OPERATION_SPECS['automation.mutate'].mode, 'command');
+    assert.equal(AUTOMATION_OPERATION_SPECS['automation.query'].availability, 'ready');
+    assert.equal(AUTOMATION_OPERATION_SPECS['automation.mutate'].availability, 'ready');
+  });
+
+  test('round-trips every query and mutation branch', () => {
+    for (const input of [
+      { kind: 'list_start', sessionId: 'session-1' },
+      { kind: 'list_continue', sessionId: 'session-1', revision: 2, cursor: '64' },
+      { kind: 'get', sessionId: 'session-1', automationId: 'automation-1' },
+    ] as const) {
+      assert.deepEqual(decodeAutomationQueryInput(input), input);
+    }
+    const automation = projection();
+    for (const result of [
+      {
+        kind: 'page',
+        sessionId: 'session-1',
+        revision: 2,
+        automations: [automation],
+        nextCursor: '1',
+      },
+      { kind: 'revision_changed', expected: 1, actual: 2 },
+      {
+        kind: 'automation',
+        sessionId: 'session-1',
+        revision: 2,
+        automation,
+      },
+      {
+        kind: 'automation',
+        sessionId: 'session-1',
+        revision: 2,
+        automation: null,
+      },
+    ] as const) {
+      assert.deepEqual(decodeAutomationQueryResult(result), result);
+    }
+
+    const create = {
+      kind: 'create' as const,
+      sessionId: 'session-1',
+      automationKind: 'cron' as const,
+      name: 'daily summary',
+      prompt: 'Summarize the workspace.',
+      schedule: { type: 'once' as const, delaySeconds: 30 },
+      maxFires: 1,
+      durable: true,
+    };
+    assert.deepEqual(decodeAutomationMutateInput(create), create);
+    for (const kind of ['delete', 'pause', 'resume'] as const) {
+      const input = { kind, sessionId: 'session-1', automationId: 'automation-1' };
+      assert.deepEqual(decodeAutomationMutateInput(input), input);
+    }
+    assert.deepEqual(decodeAutomationMutateResult({ kind: 'committed', revision: 3, automation }), {
+      kind: 'committed',
+      revision: 3,
+      automation,
+    });
+    assert.deepEqual(decodeAutomationMutateResult({ kind: 'rejected', reason: 'fire_pending' }), {
+      kind: 'rejected',
+      reason: 'fire_pending',
+    });
+  });
+
+  test('rejects unknown fields, blank content, and out-of-range schedules', () => {
+    assertInvalid(() =>
+      decodeAutomationQueryInput({
+        kind: 'get',
+        sessionId: 'session-1',
+        automationId: 'automation-1',
+        execution: { cwd: '/private' },
+      }),
+    );
+    for (const input of [
+      createInput({ name: '   ' }),
+      createInput({ prompt: '\n\t' }),
+      createInput({ maxFires: AUTOMATION_MAX_FIRES + 1 }),
+      createInput({ schedule: { type: 'interval', seconds: 9 } }),
+      createInput({ schedule: { type: 'once', delaySeconds: 86_401 } }),
+      createInput({ schedule: { type: 'cron', expression: '*'.repeat(101) } }),
+    ]) {
+      assertInvalid(() => decodeAutomationMutateInput(input));
+    }
+    assertInvalid(() =>
+      decodeAutomationMutateResult({ kind: 'rejected', reason: 'permission_denied' }),
+    );
+  });
+
+  test('uses one Unicode text contract for mutations and projections', () => {
+    const accepted = createInput({
+      name: '名'.repeat(100),
+      prompt: '提'.repeat(2_000),
+    });
+    assert.deepEqual(decodeAutomationMutateInput(accepted), accepted);
+    assertInvalid(() => decodeAutomationMutateInput(createInput({ name: '名'.repeat(101) })));
+    assertInvalid(() => decodeAutomationMutateInput(createInput({ prompt: '提'.repeat(2_001) })));
+
+    const acceptedProjection = { ...projection(), lastError: '故'.repeat(2_000) };
+    assert.deepEqual(
+      decodeAutomationQueryResult({
+        kind: 'automation',
+        sessionId: 'session-1',
+        revision: 1,
+        automation: acceptedProjection,
+      }),
+      {
+        kind: 'automation',
+        sessionId: 'session-1',
+        revision: 1,
+        automation: acceptedProjection,
+      },
+    );
+    assertInvalid(() =>
+      decodeAutomationQueryResult({
+        kind: 'automation',
+        sessionId: 'session-1',
+        revision: 1,
+        automation: { ...projection(), lastError: '故'.repeat(2_001) },
+      }),
+    );
+  });
+
+  test('enforces bounded query pages and excludes internal execution settings', () => {
+    const item = projection();
+    assertInvalid(() =>
+      decodeAutomationQueryResult({
+        kind: 'page',
+        sessionId: 'session-1',
+        revision: 1,
+        automations: Array.from({ length: AUTOMATION_PAGE_MAX_ITEMS + 1 }, () => item),
+        nextCursor: null,
+      }),
+    );
+    assertInvalid(() =>
+      decodeAutomationQueryResult({
+        kind: 'automation',
+        sessionId: 'session-1',
+        revision: 1,
+        automation: { ...item, execution: { cwd: '/private' } },
+      }),
+    );
+  });
+});
+
+function createInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    kind: 'create',
+    sessionId: 'session-1',
+    automationKind: 'heartbeat',
+    name: 'check build',
+    prompt: 'Check the build.',
+    schedule: { type: 'interval', seconds: 60 },
+    ...overrides,
+  };
+}
+
+function projection(): AutomationProjection {
+  return {
+    id: 'automation-1',
+    kind: 'cron',
+    name: 'daily summary',
+    status: 'active',
+    prompt: 'Summarize the workspace.',
+    sessionId: 'session-1',
+    schedule: { type: 'cron', expression: '0 9 * * 1-5' },
+    createdAt: 1,
+    updatedAt: 2,
+    nextFireAt: 3,
+    lastFireAt: null,
+    lastRunId: null,
+    fireCount: 0,
+    maxFires: null,
+    expiresAt: 4,
+    lastError: null,
+    consecutiveFailures: 0,
+    durable: true,
+    deferredFireCount: 0,
+    firePending: false,
+  };
+}
+
+function assertInvalid(run: () => unknown): void {
+  assert.throws(run, (error) => error instanceof RuntimeHostProtocolError);
+}

--- a/packages/runtime-host/src/__tests__/automation-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-two-client-uds.test.ts
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { SessionHeader } from '@maka/core';
+import type { SessionManager } from '@maka/runtime';
+import { openInteractiveAutomationAuthorityForWrite } from '@maka/storage/automation-authority';
+import type {
+  ExecutionAgentRunWriter,
+  ExecutionSessionWriter,
+} from '@maka/storage/execution-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import type { RuntimePolicyStoresWriter } from '@maka/storage/runtime-policy-stores';
+import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.js';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '../protocol/index.js';
+import { HostAutomationCoordinator } from '../server/automation-coordinator.js';
+import { RuntimeHostKernel } from '../server/host-kernel.js';
+import { createUnavailableDomainOperationHandlers } from '../server/operation-dispatcher.js';
+
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+
+test('two UDS Clients share one revision-pinned Automation authority', {
+  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-automation-uds-'));
+  const root = join(base, 'interactive');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  const headers = new Map<string, SessionHeader>([
+    ['desktop-session', sessionHeader('desktop-session')],
+    ['tui-session', sessionHeader('tui-session')],
+  ]);
+  const host = await RuntimeHostKernel.start({
+    owner,
+    idleGraceMs: 10_000,
+    compositionFactory: async (context) => {
+      const writer = await openInteractiveAutomationAuthorityForWrite(context.owner.lease);
+      const coordinator = new HostAutomationCoordinator({
+        store: writer,
+        sessions: {
+          readHeaderSnapshot: async (sessionId) => {
+            const header = headers.get(sessionId);
+            if (!header) throw missingRecord();
+            return structuredClone(header);
+          },
+          createStableSession: async () => assert.fail('No cron fire is expected in this test'),
+        } as Pick<ExecutionSessionWriter, 'createStableSession' | 'readHeaderSnapshot'>,
+        runs: {
+          readRun: async () => {
+            throw missingRecord();
+          },
+        } as Pick<ExecutionAgentRunWriter, 'readRun'>,
+        runtime: {
+          sendMessage: async function* () {
+            assert.fail('No Automation fire is expected in this test');
+          },
+        } as unknown as Pick<SessionManager, 'sendMessage'>,
+        root: {
+          executeRoot: async () => assert.fail('No Automation fire is expected in this test'),
+        },
+        runtimePolicy: runtimePolicyStores(),
+        isSessionActive: () => false,
+        acquireResidency: context.acquireResidency,
+        requestDrain: context.requestDrain,
+        now: () => 1_000,
+        random: () => 0,
+      });
+      return {
+        handlers: {
+          ...createUnavailableDomainOperationHandlers(),
+          ...coordinator.handlers,
+        },
+        beginDrain: () => coordinator.beginDrain(),
+        recover: async () => {
+          await coordinator.prepareRecovery();
+          await coordinator.recover();
+          coordinator.start();
+        },
+        close: async () => {
+          await coordinator.close();
+          writer.close();
+        },
+      };
+    },
+  });
+  let desktop: RuntimeHostConnection | undefined;
+  let tui: RuntimeHostConnection | undefined;
+  try {
+    desktop = await connect(root, 'desktop');
+    tui = await connect(root, 'tui');
+    const created = await desktop.request('automation.mutate', {
+      kind: 'create',
+      sessionId: 'desktop-session',
+      automationKind: 'heartbeat',
+      name: 'check build',
+      prompt: 'Check the build.',
+      schedule: { type: 'interval', seconds: 60 },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed' || !created.automation) return;
+    assert.equal(created.automation.firePending, false);
+
+    const firstPage = await tui.request('automation.query', {
+      kind: 'list_start',
+      sessionId: 'desktop-session',
+    });
+    assert.equal(firstPage.kind, 'page');
+    if (firstPage.kind !== 'page') return;
+    assert.deepEqual(firstPage.automations, [created.automation]);
+    assert.equal(firstPage.revision, created.revision);
+
+    const paused = await tui.request('automation.mutate', {
+      kind: 'pause',
+      sessionId: 'desktop-session',
+      automationId: created.automation.id,
+    });
+    assert.equal(paused.kind, 'committed');
+    if (paused.kind !== 'committed' || !paused.automation) return;
+    assert.equal(paused.automation.status, 'paused');
+    assert.equal(paused.revision, firstPage.revision + 1);
+
+    const stale = await desktop.request('automation.query', {
+      kind: 'list_continue',
+      sessionId: 'desktop-session',
+      revision: firstPage.revision,
+      cursor: '0',
+    });
+    assert.deepEqual(stale, {
+      kind: 'revision_changed',
+      expected: firstPage.revision,
+      actual: paused.revision,
+    });
+
+    const cron = await desktop.request('automation.mutate', {
+      kind: 'create',
+      sessionId: 'desktop-session',
+      automationKind: 'cron',
+      name: 'daily summary',
+      prompt: 'Summarize the workspace.',
+      schedule: { type: 'once', delaySeconds: 30 },
+    });
+    assert.equal(cron.kind, 'committed');
+    if (cron.kind !== 'committed' || !cron.automation) return;
+    const globallyVisible = await tui.request('automation.query', {
+      kind: 'get',
+      sessionId: 'tui-session',
+      automationId: cron.automation.id,
+    });
+    assert.equal(globallyVisible.kind, 'automation');
+    if (globallyVisible.kind === 'automation') {
+      assert.equal(globallyVisible.automation?.id, cron.automation.id);
+      assert.equal(globallyVisible.automation?.durable, true);
+    }
+    assert.equal(JSON.stringify(globallyVisible).includes('execution'), false);
+  } finally {
+    await Promise.allSettled([desktop?.close(), tui?.close()]);
+    await host.close().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+async function connect(
+  rootPath: string,
+  surface: 'desktop' | 'tui',
+): Promise<RuntimeHostConnection> {
+  const result = await connectRuntimeHost({ rootPath, surface, protocol: PROTOCOL });
+  assert.equal(result.kind, 'connected');
+  if (result.kind !== 'connected') throw new Error('Unable to connect to Runtime Host');
+  return result.connection;
+}
+
+function sessionHeader(id: string): SessionHeader {
+  return {
+    id,
+    workspaceRoot: '/workspace',
+    cwd: '/workspace',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Session',
+    titleIsManual: false,
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'openrouter',
+    connectionLocked: false,
+    model: 'openrouter/free',
+    permissionMode: 'explore',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+    schemaVersion: 1,
+  };
+}
+
+function runtimePolicyStores(): RuntimePolicyStoresWriter {
+  return {
+    runtimePolicy: {
+      getSnapshot: async () => ({
+        revision: 0,
+        policy: {
+          networkProxy: {
+            enabled: false,
+            protocol: 'http',
+            host: '',
+            port: 0,
+            authEnabled: false,
+            username: '',
+            bypassList: [],
+            autoBypassDomains: [],
+          },
+          personalization: { displayName: '', assistantTone: '' },
+          memory: { enabled: false, agentReadEnabled: false },
+          workspaceInstructions: { enabled: true },
+          privacy: { incognitoActive: false },
+          chatDefaults: { permissionMode: 'explore' },
+          webSearch: { enabled: false, defaultProvider: 'tavily' },
+        },
+      }),
+    },
+  } as unknown as RuntimePolicyStoresWriter;
+}
+
+function missingRecord(): NodeJS.ErrnoException {
+  const error = new Error('Record not found') as NodeJS.ErrnoException;
+  error.code = 'ENOENT';
+  return error;
+}

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -26,6 +26,7 @@ const allowedServerExternalImports = new Set([
   ...allowedHostExternalImports,
   '@maka/core/agent-run',
   '@maka/core/artifacts',
+  '@maka/core/automation',
   '@maka/core/backend-types',
   '@maka/core/events',
   '@maka/core/interaction',
@@ -46,6 +47,7 @@ const allowedServerExternalImports = new Set([
   '@maka/runtime',
   '@maka/storage/agent-graph-control-store',
   '@maka/storage/artifact-stores',
+  '@maka/storage/automation-authority',
   '@maka/storage/execution-stores',
   '@maka/storage/interaction-store',
   '@maka/storage/memory-bundle-store',
@@ -60,6 +62,7 @@ const allowedExternalImports = {
   protocol: new Set([
     '@maka/core/attachments',
     '@maka/core/artifacts',
+    '@maka/core/automation',
     '@maka/core/collaboration',
     '@maka/core/events',
     '@maka/core/interaction',

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -652,6 +652,7 @@ test('production Host executes a canonical ai-sdk Session against a real provide
     assert.match(requestText, /HOSTED_MEMORY_SENTINEL/);
     assert.deepEqual(toolNames(request?.body), [
       'AskUserQuestion',
+      'Automation',
       'Bash',
       'Edit',
       'FormatJson',
@@ -947,6 +948,12 @@ test('a bound tool ceiling excludes dynamic Client Capability tools', () => {
     categoryHint: 'client_capability',
     impl: async () => 'capability',
   };
+  const automationTool: MakaTool = {
+    name: 'Automation',
+    description: 'A root-only Host authority outside the exact child ceiling.',
+    parameters: {},
+    impl: async () => 'automation',
+  };
   const composition = createHostExecutionModelComposition({
     policy: {
       getSnapshot: async () => ({
@@ -960,6 +967,7 @@ test('a bound tool ceiling excludes dynamic Client Capability tools', () => {
     memory: {} as HostMemoryCoordinator,
     taskLedger: {} as TaskLedgerStore,
     boundTools: [boundTool],
+    automationTool,
     builtinTools: {},
     clientCapabilities: {
       tools: [capabilityTool],

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -47,6 +47,8 @@ describe('Runtime Host bootstrap protocol', () => {
     assert.deepEqual(Object.keys(HOST_OPERATION_SPECS).sort(), [
       'artifact.delete',
       'artifact.query',
+      'automation.mutate',
+      'automation.query',
       'client.capability.replace',
       'client.capability.unregister',
       'connection.catalog.create',

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -11,6 +11,7 @@ import {
   FAKE_ASK_USER_QUESTION_PROMPT,
   LOCAL_READ_AGENT_PROFILE,
   RuntimeHostedRootConflictError,
+  RuntimeHostedRootUnavailableError,
   RuntimeInteractionAdmissionRejectedError,
   RuntimeMessageAuthorityInvariantError,
   SessionManager,
@@ -24,6 +25,7 @@ import type { SessionEvent } from '@maka/core/events';
 import type { MakaTool } from '@maka/runtime';
 import {
   openInteractiveExecutionStoresForWrite,
+  type RootTurnAdmission,
   type RootTurnAdmissionStore,
 } from '@maka/storage/execution-stores';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
@@ -45,6 +47,101 @@ import type { SessionContinuityFrameSink } from '../server/session-continuity-se
 import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
 
 const HOLD_EXTERNAL_PROMPT = 'hold external root before follow-up';
+
+test('hosted Automation roots preserve one admission, UserMessage, and AgentRun identity', async () => {
+  let recoveryValidationCount = 0;
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+  });
+  const automationId = 'automation-root-fixture';
+  const turnId = 'turn-automation-root';
+  const runId = 'run-automation-root';
+  const userMessageId = 'message-automation-root';
+  const prompt = '[Automation: check build]\n\nCheck the build.';
+  try {
+    await fixture.coordinator.executeRoot({
+      sessionId: fixture.sessionId,
+      turnId,
+      runId,
+      userMessageId,
+      execution: { kind: 'automation', automationId },
+      content: { text: prompt },
+      start: ({ runId: admittedRunId, userMessageId: admittedMessageId, onRunStarted }) =>
+        fixture.manager.sendMessage(
+          fixture.sessionId,
+          {
+            turnId,
+            text: prompt,
+            origin: { kind: 'automation', automationId },
+          },
+          {
+            runId: admittedRunId,
+            userMessageId: admittedMessageId ?? undefined,
+            durability: 'required',
+            onRunStarted,
+          },
+        ),
+    });
+
+    const admission = await fixture.stores.agentRunStore.readRootTurnAdmission(
+      fixture.sessionId,
+      turnId,
+    );
+    assert.ok(admission);
+    assert.deepEqual(admission?.execution, { kind: 'automation', automationId });
+    assert.equal(admission?.runId, runId);
+    assert.equal(admission?.userMessageId, userMessageId);
+    const run = await fixture.stores.agentRunStore.readRun(fixture.sessionId, runId);
+    assert.equal(run.status, 'completed');
+    assert.equal(run.automationId, automationId);
+    const messages = await fixture.stores.sessionStore.readMessagesSnapshot(fixture.sessionId);
+    const user = messages.find((message) => message.id === userMessageId);
+    assert.ok(user?.type === 'user');
+    if (user?.type === 'user') {
+      assert.deepEqual(user.origin, { kind: 'automation', automationId });
+      assert.equal(user.text, prompt);
+    }
+    assert.equal(fixture.drainRequested(), false);
+
+    await fixture.coordinator.close();
+    const recoveryCoordinator = fixture.createRecoveryCoordinator(() => {
+      recoveryValidationCount += 1;
+    });
+    await recoveryCoordinator.prepareRecovery();
+    assert.equal(recoveryValidationCount, 0);
+
+    await recoveryCoordinator.close();
+    await fixture.messages.close();
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('hosted root target unavailability is retryable without poisoning the Host', async () => {
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+  });
+  try {
+    await assert.rejects(
+      () =>
+        fixture.coordinator.executeRoot({
+          sessionId: 'missing-session',
+          turnId: 'turn-missing-root',
+          runId: 'run-missing-root',
+          userMessageId: 'message-missing-root',
+          execution: { kind: 'automation', automationId: 'automation-missing-root' },
+          content: { text: 'Retry later.' },
+          start: async function* () {},
+        }),
+      RuntimeHostedRootUnavailableError,
+    );
+    assert.equal(fixture.drainRequested(), false);
+  } finally {
+    await fixture.coordinator.close();
+    await fixture.messages.close();
+    await fixture.dispose();
+  }
+});
 
 test('hosted linked child roots share admission, message, terminal, and stop authority', {
   timeout: 20_000,
@@ -2417,21 +2514,27 @@ async function createFailureFixture(options: {
         }),
       })
     : new SessionManager(managerDeps);
-  coordinator = new RootTurnCoordinator(
-    manager,
-    stores,
-    sessionAdmission,
-    rootAdmissionOwner,
-    interactions ?? {
-      assertTerminalFence: async () => undefined,
-      claimRunClosure: async () => undefined,
-    },
-    messages,
-    continuity,
-    acquireResidency,
-    requestDrain,
-    options.clientCapabilities,
-  );
+  const createCoordinator = (
+    admissionOwner: RootAdmissionOwner,
+    assertAutomationRecoveryAdmission?: (admission: RootTurnAdmission) => void,
+  ) =>
+    new RootTurnCoordinator(
+      manager,
+      stores,
+      sessionAdmission,
+      admissionOwner,
+      interactions ?? {
+        assertTerminalFence: async () => undefined,
+        claimRunClosure: async () => undefined,
+      },
+      messages,
+      continuity,
+      acquireResidency,
+      requestDrain,
+      options.clientCapabilities,
+      assertAutomationRecoveryAdmission,
+    );
+  coordinator = createCoordinator(rootAdmissionOwner);
 
   return {
     stores,
@@ -2444,6 +2547,15 @@ async function createFailureFixture(options: {
     interactions,
     sessionAdmission,
     acquireResidency,
+    createRecoveryCoordinator: (
+      assertAutomationRecoveryAdmission?: (admission: RootTurnAdmission) => void,
+    ) => {
+      coordinator = createCoordinator(
+        new RootAdmissionOwner(stores.agentRunStore),
+        assertAutomationRecoveryAdmission,
+      );
+      return coordinator;
+    },
     liveResidencies: () => liveResidencies,
     drainRequested: () => drainRequested,
     dispose: async () => {

--- a/packages/runtime-host/src/protocol/automation.ts
+++ b/packages/runtime-host/src/protocol/automation.ts
@@ -1,0 +1,466 @@
+import {
+  AUTOMATION_CRON_EXPRESSION_LIMIT,
+  AUTOMATION_CRON_EXPRESSION_MAX_BYTES as CORE_AUTOMATION_CRON_EXPRESSION_MAX_BYTES,
+  AUTOMATION_LAST_ERROR_LIMIT,
+  AUTOMATION_NAME_LIMIT,
+  AUTOMATION_NAME_MAX_BYTES as CORE_AUTOMATION_NAME_MAX_BYTES,
+  AUTOMATION_PROMPT_LIMIT,
+  AUTOMATION_PROMPT_MAX_BYTES as CORE_AUTOMATION_PROMPT_MAX_BYTES,
+  isAutomationTextWithinLimit,
+  type AutomationKind,
+  type AutomationSchedule,
+  type AutomationStatus,
+} from '@maka/core/automation';
+import {
+  requireCount,
+  requireEncodedByteLimit,
+  requireEntityId,
+  requireExactRecord,
+  requireRecord,
+  requireShapedRecord,
+  requireUtf8String,
+} from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const AUTOMATION_PAGE_MAX_ITEMS = 64;
+export const AUTOMATION_RESULT_MAX_BYTES = 48 * 1024;
+export const AUTOMATION_NAME_MAX_BYTES = CORE_AUTOMATION_NAME_MAX_BYTES;
+export const AUTOMATION_PROMPT_MAX_BYTES = CORE_AUTOMATION_PROMPT_MAX_BYTES;
+export const AUTOMATION_CRON_EXPRESSION_MAX_BYTES = CORE_AUTOMATION_CRON_EXPRESSION_MAX_BYTES;
+export const AUTOMATION_MAX_FIRES = 10_000;
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'invalid_request',
+  'internal_failure',
+] as const;
+const MUTATION_ERRORS = [
+  ...QUERY_ERRORS,
+  'not_found',
+  'session_archived',
+  'operation_conflict',
+  'persistence_failed',
+] as const;
+
+export interface AutomationProjection {
+  readonly id: string;
+  readonly kind: AutomationKind;
+  readonly name: string;
+  readonly status: AutomationStatus;
+  readonly prompt: string;
+  readonly sessionId: string;
+  readonly schedule: AutomationSchedule;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly nextFireAt: number | null;
+  readonly lastFireAt: number | null;
+  readonly lastRunId: string | null;
+  readonly fireCount: number;
+  readonly maxFires: number | null;
+  readonly expiresAt: number | null;
+  readonly lastError: string | null;
+  readonly consecutiveFailures: number;
+  readonly durable: boolean;
+  readonly deferredFireCount: number;
+  readonly firePending: boolean;
+}
+
+export type AutomationQueryInput =
+  | { readonly kind: 'list_start'; readonly sessionId: string }
+  | {
+      readonly kind: 'list_continue';
+      readonly sessionId: string;
+      readonly revision: number;
+      readonly cursor: string;
+    }
+  | { readonly kind: 'get'; readonly sessionId: string; readonly automationId: string };
+
+export type AutomationQueryResult =
+  | {
+      readonly kind: 'page';
+      readonly sessionId: string;
+      readonly revision: number;
+      readonly automations: readonly AutomationProjection[];
+      readonly nextCursor: string | null;
+    }
+  | {
+      readonly kind: 'revision_changed';
+      readonly expected: number;
+      readonly actual: number;
+    }
+  | {
+      readonly kind: 'automation';
+      readonly sessionId: string;
+      readonly revision: number;
+      readonly automation: AutomationProjection | null;
+    };
+
+export type AutomationMutateInput =
+  | {
+      readonly kind: 'create';
+      readonly sessionId: string;
+      readonly automationKind: AutomationKind;
+      readonly name: string;
+      readonly prompt: string;
+      readonly schedule: AutomationSchedule;
+      readonly maxFires?: number;
+      readonly durable?: boolean;
+    }
+  | {
+      readonly kind: 'delete' | 'pause' | 'resume';
+      readonly sessionId: string;
+      readonly automationId: string;
+    };
+
+export type AutomationMutationRejection =
+  | 'not_owned'
+  | 'not_active'
+  | 'not_paused'
+  | 'fire_pending'
+  | 'fire_budget_exhausted'
+  | 'limit_reached'
+  | 'invalid_schedule';
+
+export type AutomationMutateResult =
+  | {
+      readonly kind: 'committed';
+      readonly revision: number;
+      readonly automation: AutomationProjection | null;
+    }
+  | { readonly kind: 'rejected'; readonly reason: AutomationMutationRejection };
+
+export const AUTOMATION_OPERATION_SPECS = {
+  'automation.query': defineOperation<
+    AutomationQueryInput,
+    AutomationQueryResult,
+    (typeof QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeAutomationQueryInput,
+    decodeOutput: decodeAutomationQueryResult,
+  }),
+  'automation.mutate': defineOperation<
+    AutomationMutateInput,
+    AutomationMutateResult,
+    (typeof MUTATION_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodeAutomationMutateInput,
+    decodeOutput: decodeAutomationMutateResult,
+  }),
+} as const;
+
+export function decodeAutomationQueryInput(value: unknown): AutomationQueryInput {
+  const record = requireRecord(value, 'Automation query input');
+  if (record.kind === 'list_start') {
+    const input = requireExactRecord(record, 'Automation list start input', ['kind', 'sessionId']);
+    return { kind: 'list_start', sessionId: requireEntityId(input.sessionId, 'sessionId') };
+  }
+  if (record.kind === 'list_continue') {
+    const input = requireExactRecord(record, 'Automation list continuation input', [
+      'kind',
+      'sessionId',
+      'revision',
+      'cursor',
+    ]);
+    return {
+      kind: 'list_continue',
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      revision: requireCount(input.revision, 'Automation revision'),
+      cursor: requireEntityId(input.cursor, 'Automation cursor'),
+    };
+  }
+  if (record.kind === 'get') {
+    const input = requireExactRecord(record, 'Automation get input', [
+      'kind',
+      'sessionId',
+      'automationId',
+    ]);
+    return {
+      kind: 'get',
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      automationId: requireEntityId(input.automationId, 'automationId'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid Automation query kind');
+}
+
+export function decodeAutomationQueryResult(value: unknown): AutomationQueryResult {
+  const record = requireRecord(value, 'Automation query result');
+  if (record.kind === 'revision_changed') {
+    const result = requireExactRecord(record, 'Automation revision changed result', [
+      'kind',
+      'expected',
+      'actual',
+    ]);
+    return {
+      kind: 'revision_changed',
+      expected: requireCount(result.expected, 'expected Automation revision'),
+      actual: requireCount(result.actual, 'actual Automation revision'),
+    };
+  }
+  if (record.kind === 'automation') {
+    const result = requireExactRecord(record, 'Automation get result', [
+      'kind',
+      'sessionId',
+      'revision',
+      'automation',
+    ]);
+    const decoded: AutomationQueryResult = {
+      kind: 'automation',
+      sessionId: requireEntityId(result.sessionId, 'sessionId'),
+      revision: requireCount(result.revision, 'Automation revision'),
+      automation: result.automation === null ? null : decodeAutomationProjection(result.automation),
+    };
+    requireEncodedByteLimit(decoded, 'Automation get result', AUTOMATION_RESULT_MAX_BYTES);
+    return decoded;
+  }
+  if (record.kind !== 'page') throw invalidProtocolFrame('Invalid Automation query result kind');
+  const result = requireExactRecord(record, 'Automation page result', [
+    'kind',
+    'sessionId',
+    'revision',
+    'automations',
+    'nextCursor',
+  ]);
+  if (!Array.isArray(result.automations) || result.automations.length > AUTOMATION_PAGE_MAX_ITEMS) {
+    throw invalidProtocolFrame('Automation page exceeds item limit');
+  }
+  const decoded: AutomationQueryResult = {
+    kind: 'page',
+    sessionId: requireEntityId(result.sessionId, 'sessionId'),
+    revision: requireCount(result.revision, 'Automation revision'),
+    automations: result.automations.map(decodeAutomationProjection),
+    nextCursor:
+      result.nextCursor === null
+        ? null
+        : requireEntityId(result.nextCursor, 'Automation next cursor'),
+  };
+  requireEncodedByteLimit(decoded, 'Automation page result', AUTOMATION_RESULT_MAX_BYTES);
+  return decoded;
+}
+
+export function decodeAutomationMutateInput(value: unknown): AutomationMutateInput {
+  const record = requireRecord(value, 'Automation mutation input');
+  if (record.kind === 'create') {
+    const input = requireShapedRecord(
+      record,
+      'Automation create input',
+      ['kind', 'sessionId', 'automationKind', 'name', 'prompt', 'schedule'],
+      ['maxFires', 'durable'],
+    );
+    if (input.automationKind !== 'heartbeat' && input.automationKind !== 'cron') {
+      throw invalidProtocolFrame('Invalid Automation kind');
+    }
+    const maxFires =
+      input.maxFires === undefined ? undefined : positiveCount(input.maxFires, 'maxFires');
+    if (maxFires !== undefined && maxFires > AUTOMATION_MAX_FIRES) {
+      throw invalidProtocolFrame('Automation maxFires is out of range');
+    }
+    if (!(input.durable === undefined || typeof input.durable === 'boolean')) {
+      throw invalidProtocolFrame('Invalid durable flag');
+    }
+    return {
+      kind: 'create',
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      automationKind: input.automationKind,
+      name: requireAutomationText(input.name, 'Automation name', AUTOMATION_NAME_LIMIT, true),
+      prompt: requireAutomationText(
+        input.prompt,
+        'Automation prompt',
+        AUTOMATION_PROMPT_LIMIT,
+        true,
+      ),
+      schedule: decodeAutomationSchedule(input.schedule),
+      ...(maxFires === undefined ? {} : { maxFires }),
+      ...(input.durable === undefined ? {} : { durable: input.durable }),
+    };
+  }
+  if (record.kind === 'delete' || record.kind === 'pause' || record.kind === 'resume') {
+    const input = requireExactRecord(record, 'Automation mutation input', [
+      'kind',
+      'sessionId',
+      'automationId',
+    ]);
+    return {
+      kind: record.kind,
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      automationId: requireEntityId(input.automationId, 'automationId'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid Automation mutation kind');
+}
+
+export function decodeAutomationMutateResult(value: unknown): AutomationMutateResult {
+  const record = requireRecord(value, 'Automation mutation result');
+  if (record.kind === 'rejected') {
+    const result = requireExactRecord(record, 'Automation rejected result', ['kind', 'reason']);
+    if (!isMutationRejection(result.reason)) {
+      throw invalidProtocolFrame('Invalid Automation rejection reason');
+    }
+    return { kind: 'rejected', reason: result.reason };
+  }
+  if (record.kind !== 'committed') {
+    throw invalidProtocolFrame('Invalid Automation mutation result kind');
+  }
+  const result = requireExactRecord(record, 'Automation committed result', [
+    'kind',
+    'revision',
+    'automation',
+  ]);
+  const decoded: AutomationMutateResult = {
+    kind: 'committed',
+    revision: requireCount(result.revision, 'Automation revision'),
+    automation: result.automation === null ? null : decodeAutomationProjection(result.automation),
+  };
+  requireEncodedByteLimit(decoded, 'Automation mutation result', AUTOMATION_RESULT_MAX_BYTES);
+  return decoded;
+}
+
+export function decodeAutomationProjection(value: unknown): AutomationProjection {
+  const record = requireExactRecord(value, 'Automation projection', [
+    'id',
+    'kind',
+    'name',
+    'status',
+    'prompt',
+    'sessionId',
+    'schedule',
+    'createdAt',
+    'updatedAt',
+    'nextFireAt',
+    'lastFireAt',
+    'lastRunId',
+    'fireCount',
+    'maxFires',
+    'expiresAt',
+    'lastError',
+    'consecutiveFailures',
+    'durable',
+    'deferredFireCount',
+    'firePending',
+  ]);
+  if (record.kind !== 'heartbeat' && record.kind !== 'cron') {
+    throw invalidProtocolFrame('Invalid Automation projection kind');
+  }
+  if (
+    record.status !== 'active' &&
+    record.status !== 'paused' &&
+    record.status !== 'completed' &&
+    record.status !== 'expired'
+  ) {
+    throw invalidProtocolFrame('Invalid Automation projection status');
+  }
+  if (typeof record.durable !== 'boolean' || typeof record.firePending !== 'boolean') {
+    throw invalidProtocolFrame('Invalid Automation projection flags');
+  }
+  return {
+    id: requireEntityId(record.id, 'Automation id'),
+    kind: record.kind,
+    name: requireAutomationText(record.name, 'Automation name', AUTOMATION_NAME_LIMIT),
+    status: record.status,
+    prompt: requireAutomationText(record.prompt, 'Automation prompt', AUTOMATION_PROMPT_LIMIT),
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    schedule: decodeAutomationSchedule(record.schedule),
+    createdAt: requireCount(record.createdAt, 'createdAt'),
+    updatedAt: requireCount(record.updatedAt, 'updatedAt'),
+    nextFireAt: nullableCount(record.nextFireAt, 'nextFireAt'),
+    lastFireAt: nullableCount(record.lastFireAt, 'lastFireAt'),
+    lastRunId: record.lastRunId === null ? null : requireEntityId(record.lastRunId, 'lastRunId'),
+    fireCount: requireCount(record.fireCount, 'fireCount'),
+    maxFires: nullablePositiveCount(record.maxFires, 'maxFires'),
+    expiresAt: nullableCount(record.expiresAt, 'expiresAt'),
+    lastError:
+      record.lastError === null
+        ? null
+        : requireAutomationText(record.lastError, 'lastError', AUTOMATION_LAST_ERROR_LIMIT),
+    consecutiveFailures: requireCount(record.consecutiveFailures, 'consecutiveFailures'),
+    durable: record.durable,
+    deferredFireCount: requireCount(record.deferredFireCount, 'deferredFireCount'),
+    firePending: record.firePending,
+  };
+}
+
+function decodeAutomationSchedule(value: unknown): AutomationSchedule {
+  const record = requireRecord(value, 'Automation schedule');
+  if (record.type === 'cron') {
+    const schedule = requireExactRecord(record, 'cron Automation schedule', ['type', 'expression']);
+    return {
+      type: 'cron',
+      expression: requireAutomationText(
+        schedule.expression,
+        'cron expression',
+        AUTOMATION_CRON_EXPRESSION_LIMIT,
+      ),
+    };
+  }
+  if (record.type === 'interval') {
+    const schedule = requireExactRecord(record, 'interval Automation schedule', [
+      'type',
+      'seconds',
+    ]);
+    const seconds = positiveCount(schedule.seconds, 'interval seconds');
+    if (seconds < 10 || seconds > 86_400) {
+      throw invalidProtocolFrame('Automation interval is out of range');
+    }
+    return { type: 'interval', seconds };
+  }
+  if (record.type === 'once') {
+    const schedule = requireExactRecord(record, 'one-shot Automation schedule', [
+      'type',
+      'delaySeconds',
+    ]);
+    const delaySeconds = positiveCount(schedule.delaySeconds, 'one-shot delay');
+    if (delaySeconds < 5 || delaySeconds > 86_400) {
+      throw invalidProtocolFrame('Automation one-shot delay is out of range');
+    }
+    return { type: 'once', delaySeconds };
+  }
+  throw invalidProtocolFrame('Invalid Automation schedule kind');
+}
+
+function positiveCount(value: unknown, label: string): number {
+  const count = requireCount(value, label);
+  if (count === 0) throw invalidProtocolFrame(`Invalid ${label}`);
+  return count;
+}
+
+function requireAutomationText(
+  value: unknown,
+  label: string,
+  limit: Parameters<typeof isAutomationTextWithinLimit>[1],
+  nonblank = false,
+): string {
+  const decoded = requireUtf8String(value, label, limit.maxBytes);
+  if (!isAutomationTextWithinLimit(decoded, limit, { nonblank })) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return decoded;
+}
+
+function nullableCount(value: unknown, label: string): number | null {
+  return value === null ? null : requireCount(value, label);
+}
+
+function nullablePositiveCount(value: unknown, label: string): number | null {
+  return value === null ? null : positiveCount(value, label);
+}
+
+function isMutationRejection(value: unknown): value is AutomationMutationRejection {
+  return (
+    value === 'not_owned' ||
+    value === 'not_active' ||
+    value === 'not_paused' ||
+    value === 'fire_pending' ||
+    value === 'fire_budget_exhausted' ||
+    value === 'limit_reached' ||
+    value === 'invalid_schedule'
+  );
+}

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -25,6 +25,7 @@ import {
 
 export { RuntimeHostProtocolError } from './errors.js';
 export * from './interaction.js';
+export * from './automation.js';
 export * from './client-capability.js';
 export * from './message.js';
 export * from './operations.js';

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -1,4 +1,5 @@
 import { ARTIFACT_OPERATION_SPECS } from './artifact.js';
+import { AUTOMATION_OPERATION_SPECS } from './automation.js';
 import { requireExactRecord, requireId, requireRecord, requireString } from './codec.js';
 import { CONNECTION_EFFECT_OPERATION_SPECS } from './connection-effects.js';
 import { CLIENT_CAPABILITY_OPERATION_SPECS } from './client-capability.js';
@@ -99,6 +100,7 @@ export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   CONNECTION_EFFECT_OPERATION_SPECS,
   RUNTIME_POLICY_OPERATION_SPECS,
   RUNTIME_RESOURCE_OPERATION_SPECS,
+  AUTOMATION_OPERATION_SPECS,
   MESSAGE_OPERATION_SPECS,
   TASK_LEDGER_OPERATION_SPECS,
   INTERACTION_OPERATION_SPECS,

--- a/packages/runtime-host/src/server/automation-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-coordinator.ts
@@ -32,7 +32,6 @@ import {
   AUTOMATION_RESULT_MAX_BYTES,
   type AutomationMutateInput,
   type AutomationMutateResult,
-  type AutomationMutationRejection,
   type AutomationProjection,
   type AutomationQueryInput,
   type AutomationQueryResult,
@@ -100,7 +99,9 @@ class AutomationMutationFailure extends Error {
       | 'limit_reached'
       | 'invalid_schedule'
       | 'session_archived'
-      | 'session_unavailable',
+      | 'session_unavailable'
+      | 'host_not_ready'
+      | 'host_draining',
     message: string,
   ) {
     super(message);
@@ -240,7 +241,7 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
     try {
       return (await this.#create(input)).automation;
     } catch (error) {
-      return { error: modelMutationError(error) };
+      return { error: modelMutationError(this.#classifyMutationError(error)) };
     }
   }
 
@@ -249,7 +250,8 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
       await this.#delete(id, sessionId);
       return true;
     } catch (error) {
-      if (error instanceof AutomationMutationFailure) return false;
+      const failure = this.#classifyMutationError(error);
+      if (failure && isModelMutationRejection(failure)) return false;
       throw error;
     }
   }
@@ -258,7 +260,8 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
     try {
       return (await this.#pause(id, sessionId)).automation;
     } catch (error) {
-      if (error instanceof AutomationMutationFailure) return undefined;
+      const failure = this.#classifyMutationError(error);
+      if (failure && isModelMutationRejection(failure)) return undefined;
       throw error;
     }
   }
@@ -267,7 +270,8 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
     try {
       return (await this.#resume(id, sessionId)).automation;
     } catch (error) {
-      if (error instanceof AutomationMutationFailure) return undefined;
+      const failure = this.#classifyMutationError(error);
+      if (failure && isModelMutationRejection(failure)) return undefined;
       throw error;
     }
   }
@@ -371,17 +375,23 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
         automation,
       });
     } catch (error) {
-      if (error instanceof AutomationMutationFailure) {
-        if (error.kind === 'not_found') return mutationFailure('not_found', error.message);
-        if (error.kind === 'session_archived') {
-          return mutationFailure('session_archived', error.message);
+      const failure = this.#classifyMutationError(error);
+      if (failure) {
+        if (failure.kind === 'host_not_ready') {
+          return mutationFailure('host_not_ready', failure.message);
         }
-        if (error.kind === 'session_unavailable') {
-          return mutationFailure('operation_unavailable', error.message);
+        if (failure.kind === 'host_draining') {
+          return mutationFailure('host_draining', failure.message);
         }
-        return mutationSuccess({ kind: 'rejected', reason: error.kind });
+        if (failure.kind === 'not_found') return mutationFailure('not_found', failure.message);
+        if (failure.kind === 'session_archived') {
+          return mutationFailure('session_archived', failure.message);
+        }
+        if (failure.kind === 'session_unavailable') {
+          return mutationFailure('operation_unavailable', failure.message);
+        }
+        return mutationSuccess({ kind: 'rejected', reason: failure.kind });
       }
-      this.#requestDrain();
       return mutationFailure('persistence_failed', 'Automation mutation could not be committed');
     }
   }
@@ -516,10 +526,18 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
   }
 
   #assertWritable(): void {
-    if (!this.#prepared) throw new Error('Automation authority is not ready');
-    if (this.#fireCoordinator.isDraining || this.#closed) {
-      throw new Error('Automation authority is draining');
+    if (!this.#prepared) {
+      throw new AutomationMutationFailure('host_not_ready', 'Automation authority is not ready');
     }
+    if (this.#fireCoordinator.isDraining || this.#closed) {
+      throw new AutomationMutationFailure('host_draining', 'Automation authority is draining');
+    }
+  }
+
+  #classifyMutationError(error: unknown): AutomationMutationFailure | undefined {
+    if (error instanceof AutomationMutationFailure) return error;
+    this.#requestDrain();
+    return undefined;
   }
 
   #listDueAutomations(now: number): Promise<readonly AutomationDefinition[]> {
@@ -892,8 +910,12 @@ function mutationFailure(
   return { ok: false, error: { code, message } };
 }
 
-function modelMutationError(error: unknown): string {
-  if (error instanceof AutomationMutationFailure) return error.message;
+function isModelMutationRejection(error: AutomationMutationFailure): boolean {
+  return error.kind !== 'host_not_ready' && error.kind !== 'host_draining';
+}
+
+function modelMutationError(error: AutomationMutationFailure | undefined): string {
+  if (error && isModelMutationRejection(error)) return error.message;
   return 'Automation authority is unavailable.';
 }
 

--- a/packages/runtime-host/src/server/automation-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-coordinator.ts
@@ -1,0 +1,907 @@
+import { randomUUID } from 'node:crypto';
+import type { AgentRunHeader } from '@maka/core/agent-run';
+import { messageContentsEqual } from '@maka/core/events';
+import type { SessionHeader } from '@maka/core/session';
+import type {
+  AutomationDefinition,
+  AutomationExecutionTemplate,
+  AutomationPendingFire,
+} from '@maka/core/automation';
+import {
+  AutomationManager,
+  buildAutomationAuthorityTool,
+  settleAutomationAttempt,
+  type AutomationToolAuthority,
+  type MakaTool,
+  type RuntimeHostedRootAuthority,
+  type SessionManager,
+} from '@maka/runtime';
+import {
+  authenticateInteractiveAutomationAuthorityWriter,
+  type InteractiveAutomationAuthorityWriter,
+} from '@maka/storage/automation-authority';
+import {
+  isSessionNotFoundError,
+  type ExecutionAgentRunWriter,
+  type ExecutionSessionWriter,
+  type RootTurnAdmission,
+} from '@maka/storage/execution-stores';
+import type { RuntimePolicyStoresWriter } from '@maka/storage/runtime-policy-stores';
+import {
+  AUTOMATION_PAGE_MAX_ITEMS,
+  AUTOMATION_RESULT_MAX_BYTES,
+  type AutomationMutateInput,
+  type AutomationMutateResult,
+  type AutomationMutationRejection,
+  type AutomationProjection,
+  type AutomationQueryInput,
+  type AutomationQueryResult,
+  type OperationOutcome,
+} from '../protocol/index.js';
+import type { RuntimeHostResidency } from './host-kernel.js';
+import type { AutomationOperationHandlerMap } from './operation-dispatcher.js';
+import { AutomationAuthorityInvariantError } from './automation-errors.js';
+import {
+  assertFireRunIdentity,
+  automationSessionId,
+  fireContent,
+  HostAutomationFireCoordinator,
+} from './automation-fire-coordinator.js';
+import { runtimeHostSessionUnavailableReason } from './host-session-availability.js';
+
+type AutomationSessions = Pick<
+  ExecutionSessionWriter,
+  'createStableSession' | 'readHeaderSnapshot'
+>;
+type AutomationRuns = Pick<ExecutionAgentRunWriter, 'readRun'>;
+type AutomationRuntime = Pick<SessionManager, 'sendMessage'>;
+type AutomationRoot = Pick<RuntimeHostedRootAuthority, 'executeRoot'>;
+
+export interface HostAutomationCoordinatorInput {
+  readonly store: InteractiveAutomationAuthorityWriter;
+  readonly sessions: AutomationSessions;
+  readonly runs: AutomationRuns;
+  readonly runtime: AutomationRuntime;
+  readonly root: AutomationRoot;
+  readonly runtimePolicy: RuntimePolicyStoresWriter;
+  readonly isSessionActive: (sessionId: string) => boolean;
+  readonly acquireResidency: () => RuntimeHostResidency;
+  readonly requestDrain: () => void;
+  readonly newId?: () => string;
+  readonly now?: () => number;
+  readonly random?: () => number;
+  readonly setTimeout?: (callback: () => void, delayMs: number) => unknown;
+  readonly clearTimeout?: (timer: unknown) => void;
+}
+
+interface CommittedAutomation {
+  readonly automation: AutomationDefinition;
+  readonly revision: number;
+  readonly firePending: boolean;
+}
+
+interface AutomationStateSnapshot {
+  readonly revision: number;
+  readonly automations: readonly AutomationDefinition[];
+  readonly pendingFires: readonly AutomationPendingFire[];
+}
+
+class AutomationMutationFailure extends Error {
+  readonly name = 'AutomationMutationFailure';
+
+  constructor(
+    readonly kind:
+      | 'not_found'
+      | 'not_owned'
+      | 'not_active'
+      | 'not_paused'
+      | 'fire_pending'
+      | 'fire_budget_exhausted'
+      | 'limit_reached'
+      | 'invalid_schedule'
+      | 'session_archived'
+      | 'session_unavailable',
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+/** Host-owned Automation Store, scheduler, fire admission, and tool authority. */
+export class HostAutomationCoordinator implements AutomationToolAuthority {
+  readonly handlers: AutomationOperationHandlerMap = {
+    'automation.query': (input) => this.#query(input),
+    'automation.mutate': (input) => this.#mutate(input),
+  };
+
+  readonly modelTool: MakaTool;
+
+  readonly #store: InteractiveAutomationAuthorityWriter;
+  readonly #sessions: AutomationSessions;
+  readonly #requestDrain: () => void;
+  readonly #newId: () => string;
+  readonly #now: () => number;
+  readonly #manager: AutomationManager;
+  readonly #fireCoordinator: HostAutomationFireCoordinator;
+  readonly #pendingFires = new Map<string, AutomationPendingFire>();
+
+  #revision = 0;
+  #lane: Promise<void> = Promise.resolve();
+  #prepared = false;
+  #closed = false;
+
+  constructor(input: HostAutomationCoordinatorInput) {
+    this.#store = authenticateInteractiveAutomationAuthorityWriter(input.store);
+    this.#sessions = input.sessions;
+    this.#requestDrain = input.requestDrain;
+    this.#newId = input.newId ?? randomUUID;
+    this.#now = input.now ?? Date.now;
+    this.#manager = new AutomationManager({
+      generateId: this.#newId,
+      now: this.#now,
+      ...(input.random ? { random: input.random } : {}),
+    });
+    this.#fireCoordinator = new HostAutomationFireCoordinator({
+      state: {
+        listPendingFires: () =>
+          this.#exclusive(() => [...this.#pendingFires.values()].map(cloneFire)),
+        listDueAutomations: (now) => this.#listDueAutomations(now),
+        recordDeferredFire: (automationId, expectedSchedule, skip) =>
+          this.#recordDeferredFire(automationId, expectedSchedule, skip),
+        admitFire: (automationId, expectedSchedule) =>
+          this.#admitFire(automationId, expectedSchedule),
+        assertPendingFire: (fire) => this.#assertPendingFire(fire),
+        markFireRunning: (fire) => this.#markFireRunning(fire),
+        settleFire: (fire, run) => this.#settleFire(fire, run),
+        residencyState: () => ({
+          pending: this.#pendingFires.size > 0,
+          scheduled: this.#manager
+            .listActive()
+            .some((automation) => automation.nextFireAt !== null),
+        }),
+      },
+      sessions: input.sessions,
+      runs: input.runs,
+      runtime: input.runtime,
+      root: input.root,
+      runtimePolicy: input.runtimePolicy,
+      isSessionActive: input.isSessionActive,
+      acquireResidency: input.acquireResidency,
+      requestDrain: input.requestDrain,
+      now: this.#now,
+      setTimeout: input.setTimeout ?? ((callback, delayMs) => setTimeout(callback, delayMs)),
+      clearTimeout: input.clearTimeout ?? ((timer) => clearTimeout(timer as NodeJS.Timeout)),
+    });
+    this.modelTool = buildAutomationAuthorityTool({ authority: this, cronEnabled: true });
+  }
+
+  async prepareRecovery(): Promise<void> {
+    await this.#exclusive(async () => {
+      if (this.#prepared) return;
+      const snapshot = await this.#store.read();
+      this.#restore(snapshot);
+      this.#prepared = true;
+      this.#fireCoordinator.refreshResidency();
+    });
+  }
+
+  assertRecoveryAdmission(admission: RootTurnAdmission): void {
+    if (!this.#prepared) {
+      throw new AutomationAuthorityInvariantError(
+        'Automation recovery admission was inspected before Store recovery',
+      );
+    }
+    if (admission.execution.kind !== 'automation') return;
+    const fire = this.#pendingFires.get(admission.execution.automationId);
+    if (
+      !fire ||
+      fire.targetSessionId !== admission.sessionId ||
+      fire.turnId !== admission.turnId ||
+      fire.runId !== admission.runId ||
+      fire.userMessageId !== admission.userMessageId ||
+      !messageContentsEqual(fireContent(fire), admission.normalizedInput)
+    ) {
+      throw new AutomationAuthorityInvariantError(
+        `Automation admission ${admission.turnId} has no matching pending fire`,
+      );
+    }
+  }
+
+  async recover(): Promise<void> {
+    if (!this.#prepared) throw new Error('Automation recovery was not prepared');
+    await this.#fireCoordinator.recover();
+  }
+
+  start(): void {
+    this.#fireCoordinator.start();
+  }
+
+  beginDrain(): void {
+    this.#fireCoordinator.beginDrain();
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    await this.#fireCoordinator.close();
+    await this.#lane;
+    this.#closed = true;
+    this.#manager.dispose();
+  }
+
+  async create(input: {
+    kind: AutomationDefinition['kind'];
+    name: string;
+    prompt: string;
+    sessionId: string;
+    schedule: AutomationDefinition['schedule'];
+    maxFires?: number;
+    durable?: boolean;
+  }): Promise<AutomationDefinition | { error: string }> {
+    try {
+      return (await this.#create(input)).automation;
+    } catch (error) {
+      return { error: modelMutationError(error) };
+    }
+  }
+
+  async delete(id: string, sessionId: string): Promise<boolean> {
+    try {
+      await this.#delete(id, sessionId);
+      return true;
+    } catch (error) {
+      if (error instanceof AutomationMutationFailure) return false;
+      throw error;
+    }
+  }
+
+  async pause(id: string, sessionId: string): Promise<AutomationDefinition | undefined> {
+    try {
+      return (await this.#pause(id, sessionId)).automation;
+    } catch (error) {
+      if (error instanceof AutomationMutationFailure) return undefined;
+      throw error;
+    }
+  }
+
+  async resume(id: string, sessionId: string): Promise<AutomationDefinition | undefined> {
+    try {
+      return (await this.#resume(id, sessionId)).automation;
+    } catch (error) {
+      if (error instanceof AutomationMutationFailure) return undefined;
+      throw error;
+    }
+  }
+
+  get(id: string, sessionId: string): Promise<AutomationDefinition | undefined> {
+    return this.#exclusive(() => {
+      const automation = this.#manager.get(id);
+      return automation && visibleTo(automation, sessionId)
+        ? cloneDefinition(automation)
+        : undefined;
+    });
+  }
+
+  listVisibleForSession(sessionId: string): Promise<readonly AutomationDefinition[]> {
+    return this.#exclusive(() =>
+      this.#manager.listVisibleForSession(sessionId).sort(compareAutomations).map(cloneDefinition),
+    );
+  }
+
+  #query(input: AutomationQueryInput): Promise<OperationOutcome<'automation.query'>> {
+    return this.#exclusive(() => {
+      if (!this.#prepared)
+        return queryFailure('host_not_ready', 'Automation authority is not ready');
+      const visible = this.#manager
+        .listVisibleForSession(input.sessionId)
+        .sort(compareAutomations)
+        .map((automation) => projectAutomation(automation, this.#pendingFires.has(automation.id)));
+      if (input.kind === 'get') {
+        return querySuccess({
+          kind: 'automation',
+          sessionId: input.sessionId,
+          revision: this.#revision,
+          automation: visible.find((automation) => automation.id === input.automationId) ?? null,
+        });
+      }
+      if (input.kind === 'list_continue' && input.revision !== this.#revision) {
+        return querySuccess({
+          kind: 'revision_changed',
+          expected: input.revision,
+          actual: this.#revision,
+        });
+      }
+      const offset = input.kind === 'list_start' ? 0 : decodeCursor(input.cursor);
+      if (
+        offset === undefined ||
+        offset > visible.length ||
+        (input.kind === 'list_continue' && offset === visible.length)
+      ) {
+        return queryFailure('invalid_request', 'Automation cursor is invalid');
+      }
+      return querySuccess(createAutomationPage(input.sessionId, this.#revision, visible, offset));
+    });
+  }
+
+  async #mutate(input: AutomationMutateInput): Promise<OperationOutcome<'automation.mutate'>> {
+    if (!this.#prepared) {
+      return mutationFailure('host_not_ready', 'Automation authority is not ready');
+    }
+    if (this.#fireCoordinator.isDraining) {
+      return mutationFailure('host_draining', 'Automation authority is draining');
+    }
+    try {
+      let revision: number;
+      let automation: AutomationProjection | null;
+      switch (input.kind) {
+        case 'create': {
+          const committed = await this.#create({
+            kind: input.automationKind,
+            name: input.name,
+            prompt: input.prompt,
+            sessionId: input.sessionId,
+            schedule: input.schedule,
+            ...(input.maxFires === undefined ? {} : { maxFires: input.maxFires }),
+            ...(input.durable === undefined ? {} : { durable: input.durable }),
+          });
+          revision = committed.revision;
+          automation = projectAutomation(committed.automation, committed.firePending);
+          break;
+        }
+        case 'delete': {
+          revision = await this.#delete(input.automationId, input.sessionId);
+          automation = null;
+          break;
+        }
+        case 'pause': {
+          const committed = await this.#pause(input.automationId, input.sessionId);
+          revision = committed.revision;
+          automation = projectAutomation(committed.automation, committed.firePending);
+          break;
+        }
+        case 'resume': {
+          const committed = await this.#resume(input.automationId, input.sessionId);
+          revision = committed.revision;
+          automation = projectAutomation(committed.automation, committed.firePending);
+          break;
+        }
+      }
+      return mutationSuccess({
+        kind: 'committed',
+        revision,
+        automation,
+      });
+    } catch (error) {
+      if (error instanceof AutomationMutationFailure) {
+        if (error.kind === 'not_found') return mutationFailure('not_found', error.message);
+        if (error.kind === 'session_archived') {
+          return mutationFailure('session_archived', error.message);
+        }
+        if (error.kind === 'session_unavailable') {
+          return mutationFailure('operation_unavailable', error.message);
+        }
+        return mutationSuccess({ kind: 'rejected', reason: error.kind });
+      }
+      this.#requestDrain();
+      return mutationFailure('persistence_failed', 'Automation mutation could not be committed');
+    }
+  }
+
+  async #create(input: {
+    kind: AutomationDefinition['kind'];
+    name: string;
+    prompt: string;
+    sessionId: string;
+    schedule: AutomationDefinition['schedule'];
+    maxFires?: number;
+    durable?: boolean;
+  }): Promise<CommittedAutomation> {
+    return this.#exclusive(async () => {
+      this.#assertWritable();
+      const header = await this.#readMutableSession(input.sessionId);
+      const unavailableReason = runtimeHostSessionUnavailableReason(header);
+      if (unavailableReason) {
+        throw new AutomationMutationFailure('session_unavailable', unavailableReason);
+      }
+      const execution = input.kind === 'cron' ? executionTemplateFromHeader(header) : undefined;
+      const before = this.#snapshot();
+      const result = this.#manager.create({ ...input, ...(execution ? { execution } : {}) });
+      if ('error' in result) {
+        const kind = result.error.includes('Invalid cron') ? 'invalid_schedule' : 'limit_reached';
+        throw new AutomationMutationFailure(kind, result.error);
+      }
+      await this.#commitOrRestore(before);
+      return this.#committedAutomation(result.id);
+    });
+  }
+
+  async #delete(id: string, sessionId: string): Promise<number> {
+    return this.#exclusive(async () => {
+      this.#assertWritable();
+      await this.#readMutableSession(sessionId);
+      const automation = this.#requireManagedAutomation(id, sessionId);
+      if (this.#pendingFires.has(automation.id)) {
+        throw new AutomationMutationFailure(
+          'fire_pending',
+          'Automation cannot be deleted while a fire is pending',
+        );
+      }
+      const before = this.#snapshot();
+      if (!this.#manager.delete(automation.id, sessionId)) {
+        throw new AutomationAuthorityInvariantError('Automation delete lost its admitted state');
+      }
+      await this.#commitOrRestore(before);
+      return this.#revision;
+    });
+  }
+
+  async #pause(id: string, sessionId: string): Promise<CommittedAutomation> {
+    return this.#exclusive(async () => {
+      this.#assertWritable();
+      await this.#readMutableSession(sessionId);
+      const automation = this.#requireManagedAutomation(id, sessionId);
+      if (automation.status !== 'active') {
+        throw new AutomationMutationFailure('not_active', 'Automation is not active');
+      }
+      const before = this.#snapshot();
+      const result = this.#manager.pause(id, sessionId);
+      if (!result) throw new AutomationAuthorityInvariantError('Automation pause lost its state');
+      await this.#commitOrRestore(before);
+      return this.#committedAutomation(id);
+    });
+  }
+
+  async #resume(id: string, sessionId: string): Promise<CommittedAutomation> {
+    return this.#exclusive(async () => {
+      this.#assertWritable();
+      await this.#readMutableSession(sessionId);
+      const automation = this.#requireManagedAutomation(id, sessionId);
+      if (automation.status !== 'paused') {
+        throw new AutomationMutationFailure('not_paused', 'Automation is not paused');
+      }
+      if (
+        (automation.maxFires !== null && automation.fireCount >= automation.maxFires) ||
+        (automation.schedule.type === 'once' && automation.fireCount > 0)
+      ) {
+        throw new AutomationMutationFailure(
+          'fire_budget_exhausted',
+          'Automation fire budget is exhausted',
+        );
+      }
+      const before = this.#snapshot();
+      const result = this.#manager.resume(id, sessionId);
+      if (!result) throw new AutomationAuthorityInvariantError('Automation resume lost its state');
+      await this.#commitOrRestore(before);
+      return this.#committedAutomation(id);
+    });
+  }
+
+  #committedAutomation(id: string): CommittedAutomation {
+    const automation = this.#manager.get(id);
+    if (!automation) {
+      throw new AutomationAuthorityInvariantError('Committed Automation is unavailable');
+    }
+    return {
+      automation: cloneDefinition(automation),
+      revision: this.#revision,
+      firePending: this.#pendingFires.has(id),
+    };
+  }
+
+  #requireManagedAutomation(id: string, sessionId: string): AutomationDefinition {
+    const automation = this.#manager.get(id);
+    if (!automation) throw new AutomationMutationFailure('not_found', 'Automation was not found');
+    if (!visibleTo(automation, sessionId)) {
+      throw new AutomationMutationFailure('not_owned', 'Automation is not owned by this Session');
+    }
+    return automation;
+  }
+
+  async #readMutableSession(sessionId: string): Promise<SessionHeader> {
+    let header: SessionHeader;
+    try {
+      header = await this.#sessions.readHeaderSnapshot(sessionId);
+    } catch (error) {
+      if (isSessionNotFoundError(error) || isMissingRecord(error)) {
+        throw new AutomationMutationFailure('not_found', 'Session was not found');
+      }
+      throw error;
+    }
+    if (header.isArchived || header.status === 'archived') {
+      throw new AutomationMutationFailure(
+        'session_archived',
+        'Archived Sessions cannot mutate Automations',
+      );
+    }
+    return header;
+  }
+
+  #assertWritable(): void {
+    if (!this.#prepared) throw new Error('Automation authority is not ready');
+    if (this.#fireCoordinator.isDraining || this.#closed) {
+      throw new Error('Automation authority is draining');
+    }
+  }
+
+  #listDueAutomations(now: number): Promise<readonly AutomationDefinition[]> {
+    return this.#exclusive(async () => {
+      const before = this.#snapshot();
+      let changed = false;
+      for (const automation of this.#manager.listActive()) {
+        if (this.#pendingFires.has(automation.id)) continue;
+        if (automation.expiresAt !== null && now >= automation.expiresAt) {
+          changed = this.#manager.sweepExpired(automation.id) || changed;
+        }
+      }
+      if (changed) {
+        await this.#commitOrRestore(before);
+      }
+      return this.#manager
+        .listActive()
+        .filter(
+          (automation) =>
+            !this.#pendingFires.has(automation.id) &&
+            automation.nextFireAt !== null &&
+            automation.nextFireAt <= now,
+        )
+        .map(cloneDefinition);
+    });
+  }
+
+  #recordDeferredFire(
+    automationId: string,
+    expectedSchedule: number | null,
+    skip: boolean,
+  ): Promise<boolean> {
+    return this.#exclusive(async () => {
+      const automation = this.#manager.get(automationId);
+      if (
+        !automation ||
+        automation.status !== 'active' ||
+        automation.nextFireAt !== expectedSchedule ||
+        this.#pendingFires.has(automationId)
+      ) {
+        return false;
+      }
+      const before = this.#snapshot();
+      this.#manager.recordDeferredFire(automationId);
+      if (skip) this.#manager.skipFire(automationId);
+      await this.#commitOrRestore(before);
+      return true;
+    });
+  }
+
+  async #admitFire(
+    automationId: string,
+    expectedSchedule: number | null,
+  ): Promise<AutomationPendingFire | undefined> {
+    return this.#exclusive(async () => {
+      if (this.#fireCoordinator.isDraining || this.#closed || expectedSchedule === null) {
+        return undefined;
+      }
+      const automation = this.#manager.get(automationId);
+      if (
+        !automation ||
+        automation.status !== 'active' ||
+        automation.nextFireAt !== expectedSchedule ||
+        automation.nextFireAt > this.#now() ||
+        this.#pendingFires.has(automationId)
+      ) {
+        return undefined;
+      }
+      const before = this.#snapshot();
+      if (automation.kind === 'cron' && !automation.execution) {
+        try {
+          const creator = await this.#sessions.readHeaderSnapshot(automation.sessionId);
+          const unavailableReason = runtimeHostSessionUnavailableReason(creator);
+          if (unavailableReason) {
+            automation.status = 'paused';
+            automation.nextFireAt = null;
+            automation.updatedAt = this.#now();
+            automation.lastError = unavailableReason;
+            await this.#commitOrRestore(before);
+            return undefined;
+          }
+          automation.execution = executionTemplateFromHeader(creator);
+        } catch (error) {
+          if (!isSessionNotFoundError(error) && !isMissingRecord(error)) throw error;
+          automation.status = 'paused';
+          automation.nextFireAt = null;
+          automation.updatedAt = this.#now();
+          automation.lastError = 'Creator Session is unavailable; execution settings are unknown.';
+          await this.#commitOrRestore(before);
+          return undefined;
+        }
+      }
+      const started = this.#manager.attemptStarted(automationId);
+      if (!started) {
+        await this.#commitOrRestore(before);
+        return undefined;
+      }
+      const fireId = this.#newId();
+      const admittedAt = this.#now();
+      const fire: AutomationPendingFire = {
+        id: fireId,
+        automationId,
+        automationKind: started.kind,
+        automationName: started.name,
+        prompt: started.prompt,
+        scheduledFor: expectedSchedule,
+        targetSessionId:
+          started.kind === 'heartbeat' ? started.sessionId : automationSessionId(fireId),
+        turnId: this.#newId(),
+        runId: this.#newId(),
+        userMessageId: this.#newId(),
+        status: 'admitted',
+        admittedAt,
+        updatedAt: admittedAt,
+        ...(started.execution ? { execution: structuredClone(started.execution) } : {}),
+      };
+      this.#pendingFires.set(automationId, fire);
+      await this.#commitOrRestore(before);
+      return cloneFire(this.#pendingFires.get(automationId) ?? fire);
+    });
+  }
+
+  #assertPendingFire(fire: AutomationPendingFire): Promise<void> {
+    return this.#exclusive(() => {
+      const current = this.#pendingFires.get(fire.automationId);
+      if (!current || current.id !== fire.id) {
+        throw new AutomationAuthorityInvariantError('Pending Automation fire disappeared');
+      }
+    });
+  }
+
+  async #markFireRunning(fire: AutomationPendingFire): Promise<void> {
+    await this.#exclusive(async () => {
+      const current = this.#pendingFires.get(fire.automationId);
+      if (!current || current.id !== fire.id) {
+        throw new AutomationAuthorityInvariantError('Pending Automation fire changed before start');
+      }
+      if (current.status === 'running') return;
+      const before = this.#snapshot();
+      const now = this.#now();
+      this.#pendingFires.set(fire.automationId, {
+        ...current,
+        status: 'running',
+        startedAt: now,
+        updatedAt: now,
+      });
+      await this.#commitOrRestore(before);
+    });
+  }
+
+  async #settleFire(fire: AutomationPendingFire, run: AgentRunHeader): Promise<void> {
+    await this.#exclusive(async () => {
+      const current = this.#pendingFires.get(fire.automationId);
+      if (!current) return;
+      if (current.id !== fire.id) {
+        throw new AutomationAuthorityInvariantError('Automation settlement changed fire identity');
+      }
+      assertFireRunIdentity(current, run);
+      const before = this.#snapshot();
+      const automation = this.#manager.get(fire.automationId);
+      if (!automation) {
+        throw new AutomationAuthorityInvariantError(
+          'Pending Automation fire has no canonical definition',
+        );
+      }
+      if (run.status === 'completed') {
+        settleAutomationAttempt(automation, { status: 'completed', runId: run.runId }, this.#now());
+      } else if (run.status === 'failed' || run.status === 'cancelled') {
+        settleAutomationAttempt(
+          automation,
+          { status: run.status, runId: run.runId, error: runFailureMessage(run) },
+          this.#now(),
+        );
+      } else {
+        throw new AutomationAuthorityInvariantError('Automation settled from a non-terminal Run');
+      }
+      this.#pendingFires.delete(fire.automationId);
+      await this.#commitOrRestore(before);
+    });
+  }
+
+  async #commitCurrent(): Promise<void> {
+    const result = await this.#store.commit({
+      expectedRevision: this.#revision,
+      automations: this.#manager.listAll(),
+      pendingFires: [...this.#pendingFires.values()],
+    });
+    if (result.kind === 'revision_conflict') {
+      throw new AutomationAuthorityInvariantError(
+        `Automation revision changed from ${this.#revision} to ${result.actualRevision}`,
+      );
+    }
+    this.#restore(result.snapshot);
+    this.#fireCoordinator.refreshResidency();
+  }
+
+  async #commitOrRestore(before: AutomationStateSnapshot): Promise<void> {
+    try {
+      await this.#commitCurrent();
+    } catch (error) {
+      this.#restore(before);
+      throw error;
+    }
+  }
+
+  #snapshot(): AutomationStateSnapshot {
+    return {
+      revision: this.#revision,
+      automations: this.#manager.listAll().map(cloneDefinition),
+      pendingFires: [...this.#pendingFires.values()].map(cloneFire),
+    };
+  }
+
+  #restore(snapshot: AutomationStateSnapshot): void {
+    this.#revision = snapshot.revision;
+    this.#manager.hydrate(snapshot.automations);
+    this.#pendingFires.clear();
+    for (const fire of snapshot.pendingFires)
+      this.#pendingFires.set(fire.automationId, cloneFire(fire));
+  }
+
+  #exclusive<T>(operation: () => T | Promise<T>): Promise<T> {
+    const result = this.#lane.then(operation);
+    this.#lane = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}
+
+function executionTemplateFromHeader(header: SessionHeader): AutomationExecutionTemplate {
+  return {
+    cwd: header.cwd,
+    ...(header.projectId === undefined ? {} : { projectId: header.projectId }),
+    backend: header.backend,
+    llmConnectionSlug: header.llmConnectionSlug,
+    model: header.model,
+    ...(header.thinkingLevel === undefined ? {} : { thinkingLevel: header.thinkingLevel }),
+    collaborationMode: header.collaborationMode ?? 'agent',
+    orchestrationMode: header.orchestrationMode ?? 'default',
+  };
+}
+
+function runFailureMessage(run: AgentRunHeader): string {
+  if (run.status === 'cancelled') {
+    return run.abortSource
+      ? `Automation run cancelled: ${run.abortSource}`
+      : 'Automation run cancelled';
+  }
+  return run.failureMessage ?? run.failureClass ?? 'Automation run failed';
+}
+
+function visibleTo(automation: AutomationDefinition, sessionId: string): boolean {
+  return automation.sessionId === sessionId || automation.durable === true;
+}
+
+function compareAutomations(left: AutomationDefinition, right: AutomationDefinition): number {
+  return left.createdAt - right.createdAt || left.id.localeCompare(right.id);
+}
+
+function projectAutomation(
+  automation: AutomationDefinition,
+  firePending: boolean,
+): AutomationProjection {
+  return {
+    id: automation.id,
+    kind: automation.kind,
+    name: automation.name,
+    status: automation.status,
+    prompt: automation.prompt,
+    sessionId: automation.sessionId,
+    schedule: structuredClone(automation.schedule),
+    createdAt: automation.createdAt,
+    updatedAt: automation.updatedAt,
+    nextFireAt: automation.nextFireAt,
+    lastFireAt: automation.lastFireAt,
+    lastRunId: automation.lastRunId,
+    fireCount: automation.fireCount,
+    maxFires: automation.maxFires,
+    expiresAt: automation.expiresAt,
+    lastError: automation.lastError,
+    consecutiveFailures: automation.consecutiveFailures,
+    durable: automation.durable === true,
+    deferredFireCount: automation.deferredFireCount ?? 0,
+    firePending,
+  };
+}
+
+function cloneDefinition(automation: AutomationDefinition): AutomationDefinition {
+  return structuredClone(automation);
+}
+
+function cloneFire(fire: AutomationPendingFire): AutomationPendingFire {
+  return structuredClone(fire);
+}
+
+function createAutomationPage(
+  sessionId: string,
+  revision: number,
+  automations: readonly AutomationProjection[],
+  offset: number,
+): AutomationQueryResult {
+  const page: AutomationProjection[] = [];
+  for (let index = offset; index < automations.length; index += 1) {
+    if (page.length >= AUTOMATION_PAGE_MAX_ITEMS) break;
+    const automation = automations[index];
+    if (!automation)
+      throw new AutomationAuthorityInvariantError('Automation page index is invalid');
+    const candidate = [...page, automation];
+    const nextOffset = offset + candidate.length;
+    const result = {
+      kind: 'page' as const,
+      sessionId,
+      revision,
+      automations: candidate,
+      nextCursor: nextOffset < automations.length ? encodeCursor(nextOffset) : null,
+    };
+    if (Buffer.byteLength(JSON.stringify(result), 'utf8') > AUTOMATION_RESULT_MAX_BYTES) break;
+    page.push(automation);
+  }
+  if (page.length === 0 && offset < automations.length) {
+    throw new AutomationAuthorityInvariantError('Automation exceeds the query byte limit');
+  }
+  const nextOffset = offset + page.length;
+  return {
+    kind: 'page',
+    sessionId,
+    revision,
+    automations: page,
+    nextCursor: nextOffset < automations.length ? encodeCursor(nextOffset) : null,
+  };
+}
+
+function encodeCursor(offset: number): string {
+  return String(offset);
+}
+
+function decodeCursor(cursor: string): number | undefined {
+  if (!/^(?:0|[1-9]\d*)$/.test(cursor)) return undefined;
+  const offset = Number(cursor);
+  return Number.isSafeInteger(offset) ? offset : undefined;
+}
+
+function querySuccess(result: AutomationQueryResult): OperationOutcome<'automation.query'> {
+  return { ok: true, result };
+}
+
+function queryFailure(
+  code: 'host_not_ready' | 'host_draining' | 'invalid_request' | 'internal_failure',
+  message: string,
+): OperationOutcome<'automation.query'> {
+  return { ok: false, error: { code, message } };
+}
+
+function mutationSuccess(result: AutomationMutateResult): OperationOutcome<'automation.mutate'> {
+  return { ok: true, result };
+}
+
+function mutationFailure(
+  code:
+    | 'host_not_ready'
+    | 'host_draining'
+    | 'operation_unavailable'
+    | 'not_found'
+    | 'session_archived'
+    | 'persistence_failed',
+  message: string,
+): OperationOutcome<'automation.mutate'> {
+  return { ok: false, error: { code, message } };
+}
+
+function modelMutationError(error: unknown): string {
+  if (error instanceof AutomationMutationFailure) return error.message;
+  return 'Automation authority is unavailable.';
+}
+
+function isMissingRecord(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}

--- a/packages/runtime-host/src/server/automation-errors.ts
+++ b/packages/runtime-host/src/server/automation-errors.ts
@@ -1,0 +1,3 @@
+export class AutomationAuthorityInvariantError extends Error {
+  readonly name = 'AutomationAuthorityInvariantError';
+}

--- a/packages/runtime-host/src/server/automation-fire-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-fire-coordinator.ts
@@ -1,0 +1,543 @@
+import { createHash } from 'node:crypto';
+import type { AgentRunHeader } from '@maka/core/agent-run';
+import type { AutomationDefinition, AutomationPendingFire } from '@maka/core/automation';
+import type { MessageContent } from '@maka/core/events';
+import type { SessionHeader } from '@maka/core/session';
+import {
+  DEFER_WINDOW_MS,
+  evaluateAutomationCanFire,
+  FIRE_CHECK_INTERVAL_MS,
+  HEARTBEAT_IDLE_STATUSES,
+  RuntimeHostedRootConflictError,
+  RuntimeHostedRootUnavailableError,
+  type RuntimeHostedRootAuthority,
+  type SessionManager,
+} from '@maka/runtime';
+import {
+  isSessionNotFoundError,
+  type ExecutionAgentRunWriter,
+  type ExecutionSessionWriter,
+} from '@maka/storage/execution-stores';
+import type { RuntimePolicyStoresWriter } from '@maka/storage/runtime-policy-stores';
+import { AutomationAuthorityInvariantError } from './automation-errors.js';
+import type { RuntimeHostResidency } from './host-kernel.js';
+import { runtimeHostSessionUnavailableReason } from './host-session-availability.js';
+
+type AutomationSessions = Pick<
+  ExecutionSessionWriter,
+  'createStableSession' | 'readHeaderSnapshot'
+>;
+type AutomationRuns = Pick<ExecutionAgentRunWriter, 'readRun'>;
+type AutomationRuntime = Pick<SessionManager, 'sendMessage'>;
+type AutomationRoot = Pick<RuntimeHostedRootAuthority, 'executeRoot'>;
+
+export interface AutomationFireStateAuthority {
+  listPendingFires(): Promise<readonly AutomationPendingFire[]>;
+  listDueAutomations(now: number): Promise<readonly AutomationDefinition[]>;
+  recordDeferredFire(
+    automationId: string,
+    expectedSchedule: number | null,
+    skip: boolean,
+  ): Promise<boolean>;
+  admitFire(
+    automationId: string,
+    expectedSchedule: number | null,
+  ): Promise<AutomationPendingFire | undefined>;
+  assertPendingFire(fire: AutomationPendingFire): Promise<void>;
+  markFireRunning(fire: AutomationPendingFire): Promise<void>;
+  settleFire(fire: AutomationPendingFire, run: AgentRunHeader): Promise<void>;
+  residencyState(): { readonly pending: boolean; readonly scheduled: boolean };
+}
+
+export interface HostAutomationFireCoordinatorInput {
+  readonly state: AutomationFireStateAuthority;
+  readonly sessions: AutomationSessions;
+  readonly runs: AutomationRuns;
+  readonly runtime: AutomationRuntime;
+  readonly root: AutomationRoot;
+  readonly runtimePolicy: RuntimePolicyStoresWriter;
+  readonly isSessionActive: (sessionId: string) => boolean;
+  readonly acquireResidency: () => RuntimeHostResidency;
+  readonly requestDrain: () => void;
+  readonly now: () => number;
+  readonly setTimeout: (callback: () => void, delayMs: number) => unknown;
+  readonly clearTimeout: (timer: unknown) => void;
+}
+
+interface DeferredFireState {
+  readonly firstDeferredAt: number;
+  count: number;
+}
+
+interface FireTask {
+  readonly established: Promise<void>;
+  readonly done: Promise<void>;
+}
+
+interface Deferred {
+  readonly promise: Promise<void>;
+  resolve(): void;
+  reject(error: unknown): void;
+}
+
+class AutomationFireDeferredError extends Error {
+  readonly name = 'AutomationFireDeferredError';
+}
+
+/** Owns timers and execution side effects; canonical state stays behind its narrow port. */
+export class HostAutomationFireCoordinator {
+  readonly #state: AutomationFireStateAuthority;
+  readonly #sessions: AutomationSessions;
+  readonly #runs: AutomationRuns;
+  readonly #runtime: AutomationRuntime;
+  readonly #root: AutomationRoot;
+  readonly #runtimePolicy: RuntimePolicyStoresWriter;
+  readonly #isSessionActive: (sessionId: string) => boolean;
+  readonly #acquireResidency: () => RuntimeHostResidency;
+  readonly #requestDrain: () => void;
+  readonly #now: () => number;
+  readonly #setTimeout: (callback: () => void, delayMs: number) => unknown;
+  readonly #clearTimeout: (timer: unknown) => void;
+  readonly #deferredFires = new Map<string, DeferredFireState>();
+  readonly #fireTasks = new Map<string, FireTask>();
+
+  #timer: unknown;
+  #tickTask: Promise<void> | undefined;
+  #residency: RuntimeHostResidency | undefined;
+  #recovered = false;
+  #started = false;
+  #draining = false;
+  #closed = false;
+
+  constructor(input: HostAutomationFireCoordinatorInput) {
+    this.#state = input.state;
+    this.#sessions = input.sessions;
+    this.#runs = input.runs;
+    this.#runtime = input.runtime;
+    this.#root = input.root;
+    this.#runtimePolicy = input.runtimePolicy;
+    this.#isSessionActive = input.isSessionActive;
+    this.#acquireResidency = input.acquireResidency;
+    this.#requestDrain = input.requestDrain;
+    this.#now = input.now;
+    this.#setTimeout = input.setTimeout;
+    this.#clearTimeout = input.clearTimeout;
+  }
+
+  get isDraining(): boolean {
+    return this.#draining || this.#closed;
+  }
+
+  async recover(): Promise<void> {
+    if (this.#recovered) return;
+    const fires = await this.#state.listPendingFires();
+    if (this.isDraining) return;
+    await Promise.all(fires.map((fire) => this.#launchFire(fire).established));
+    this.#recovered = true;
+  }
+
+  start(): void {
+    if (this.isDraining) return;
+    if (!this.#recovered) throw new Error('Automation scheduler started before recovery');
+    if (this.#started) return;
+    this.#started = true;
+    this.refreshResidency();
+    this.#scheduleTick();
+  }
+
+  beginDrain(): void {
+    if (this.#draining) return;
+    this.#draining = true;
+    this.#stopTimer();
+    this.refreshResidency();
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.beginDrain();
+    while (this.#tickTask || this.#fireTasks.size > 0) {
+      await Promise.allSettled([
+        ...(this.#tickTask ? [this.#tickTask] : []),
+        ...[...this.#fireTasks.values()].map((task) => task.done),
+      ]);
+    }
+    this.#closed = true;
+    this.#deferredFires.clear();
+    this.#residency?.release();
+    this.#residency = undefined;
+  }
+
+  refreshResidency(): void {
+    const state = this.#state.residencyState();
+    const shouldHold = state.pending || (!this.#draining && this.#started && state.scheduled);
+    if (shouldHold && !this.#residency) this.#residency = this.#acquireResidency();
+    if (!shouldHold && this.#residency) {
+      this.#residency.release();
+      this.#residency = undefined;
+    }
+  }
+
+  #scheduleTick(): void {
+    if (!this.#started || this.isDraining || this.#timer !== undefined) return;
+    this.#timer = this.#setTimeout(() => {
+      this.#timer = undefined;
+      const task = this.#checkAndFire();
+      this.#tickTask = task;
+      void task
+        .catch(() => this.#requestDrain())
+        .finally(() => {
+          if (this.#tickTask === task) this.#tickTask = undefined;
+          this.#scheduleTick();
+        });
+    }, FIRE_CHECK_INTERVAL_MS);
+  }
+
+  #stopTimer(): void {
+    if (this.#timer === undefined) return;
+    this.#clearTimeout(this.#timer);
+    this.#timer = undefined;
+  }
+
+  async #checkAndFire(): Promise<void> {
+    if (this.isDraining) return;
+    for (const fire of await this.#state.listPendingFires()) {
+      if (this.isDraining) return;
+      this.#launchFire(fire);
+    }
+    for (const automation of await this.#state.listDueAutomations(this.#now())) {
+      if (this.isDraining) return;
+      let allowed: boolean;
+      try {
+        allowed = await this.#canFire(automation);
+      } catch (error) {
+        this.#requestDrain();
+        throw error;
+      }
+      if (!allowed) {
+        await this.#recordDeferred(automation);
+        continue;
+      }
+      const fire = await this.#state.admitFire(automation.id, automation.nextFireAt);
+      if (fire) {
+        this.#deferredFires.delete(automation.id);
+        this.#launchFire(fire);
+      }
+    }
+  }
+
+  async #canFire(automation: Pick<AutomationDefinition, 'kind' | 'sessionId'>): Promise<boolean> {
+    if (this.isDraining) return false;
+    if (automation.kind === 'heartbeat' && this.#isSessionActive(automation.sessionId))
+      return false;
+    return evaluateAutomationCanFire(automation, {
+      isIncognitoActive: async () =>
+        (await this.#runtimePolicy.runtimePolicy.getSnapshot()).policy.privacy.incognitoActive,
+      readSessionHeader: async (sessionId) => {
+        try {
+          const header = await this.#sessions.readHeaderSnapshot(sessionId);
+          return header.isArchived ||
+            header.status === 'archived' ||
+            runtimeHostSessionUnavailableReason(header)
+            ? null
+            : header;
+        } catch (error) {
+          if (isSessionNotFoundError(error) || isMissingRecord(error)) return null;
+          throw error;
+        }
+      },
+    });
+  }
+
+  async #recordDeferred(
+    automation: Pick<AutomationDefinition, 'id' | 'nextFireAt'>,
+  ): Promise<void> {
+    const now = this.#now();
+    const deferred = this.#deferredFires.get(automation.id);
+    const skip = deferred !== undefined && now - deferred.firstDeferredAt >= DEFER_WINDOW_MS;
+    const recorded = await this.#state.recordDeferredFire(
+      automation.id,
+      automation.nextFireAt,
+      skip,
+    );
+    if (!recorded) return;
+    if (skip) {
+      this.#deferredFires.delete(automation.id);
+    } else if (!deferred) {
+      this.#deferredFires.set(automation.id, { firstDeferredAt: now, count: 1 });
+    } else {
+      deferred.count += 1;
+    }
+  }
+
+  #launchFire(fire: AutomationPendingFire): FireTask {
+    const current = this.#fireTasks.get(fire.id);
+    if (current) return current;
+    const established = deferred();
+    let task: FireTask;
+    const done = this.#runFire(fire, established)
+      .catch((error) => {
+        this.#requestDrain();
+        throw error;
+      })
+      .finally(() => {
+        if (this.#fireTasks.get(fire.id) === task) this.#fireTasks.delete(fire.id);
+      });
+    task = { established: established.promise, done };
+    this.#fireTasks.set(fire.id, task);
+    void done.catch(() => undefined);
+    return task;
+  }
+
+  async #runFire(fire: AutomationPendingFire, established: Deferred): Promise<void> {
+    try {
+      await this.#ensureFireTarget(fire);
+      const existingRun = await this.#readRun(fire);
+      if (existingRun) {
+        assertFireRunIdentity(fire, existingRun);
+        if (isTerminalRun(existingRun)) {
+          await this.#state.settleFire(fire, existingRun);
+          established.resolve();
+          return;
+        }
+        established.resolve();
+      }
+      await this.#root.executeRoot({
+        sessionId: fire.targetSessionId,
+        turnId: fire.turnId,
+        runId: fire.runId,
+        userMessageId: fire.userMessageId,
+        execution: { kind: 'automation', automationId: fire.automationId },
+        content: fireContent(fire),
+        admitExecution: async () => {
+          await this.#assertFireCanEnterRuntime(fire);
+          return 'executing';
+        },
+        start: ({ runId, userMessageId, onRunStarted }) => {
+          if (runId !== fire.runId || userMessageId !== fire.userMessageId) {
+            throw new AutomationAuthorityInvariantError(
+              'Runtime Host changed the pending Automation fire identity',
+            );
+          }
+          return this.#runtime.sendMessage(
+            fire.targetSessionId,
+            {
+              turnId: fire.turnId,
+              ...fireContent(fire),
+              origin: { kind: 'automation', automationId: fire.automationId },
+            },
+            {
+              runId: fire.runId,
+              userMessageId: fire.userMessageId,
+              durability: 'required',
+              onRunStarted: async (startedRunId) => {
+                if (startedRunId !== fire.runId) {
+                  throw new AutomationAuthorityInvariantError(
+                    'Runtime started a different Automation Run identity',
+                  );
+                }
+                await this.#state.markFireRunning(fire);
+                await onRunStarted();
+              },
+            },
+          );
+        },
+        onReady: () => established.resolve(),
+      });
+      established.resolve();
+      const run = await this.#readRun(fire);
+      if (!run || !isTerminalRun(run)) {
+        throw new AutomationAuthorityInvariantError(
+          `Automation fire ${fire.id} completed without a terminal Run`,
+        );
+      }
+      assertFireRunIdentity(fire, run);
+      await this.#state.settleFire(fire, run);
+    } catch (error) {
+      let run: AgentRunHeader | undefined;
+      try {
+        run = await this.#readRun(fire);
+      } catch (readError) {
+        established.reject(readError);
+        throw readError;
+      }
+      if (run && isTerminalRun(run)) {
+        assertFireRunIdentity(fire, run);
+        try {
+          await this.#state.settleFire(fire, run);
+        } catch (settleError) {
+          established.reject(settleError);
+          throw settleError;
+        }
+        established.resolve();
+        return;
+      }
+      if (
+        error instanceof AutomationFireDeferredError ||
+        error instanceof RuntimeHostedRootConflictError ||
+        error instanceof RuntimeHostedRootUnavailableError
+      ) {
+        established.resolve();
+        return;
+      }
+      established.reject(error);
+      throw error;
+    }
+  }
+
+  async #ensureFireTarget(fire: AutomationPendingFire): Promise<void> {
+    if (fire.automationKind === 'heartbeat') return;
+    if (!fire.execution) {
+      throw new AutomationAuthorityInvariantError('Pending cron fire has no execution template');
+    }
+    const result = await this.#sessions.createStableSession({
+      sessionId: fire.targetSessionId,
+      requestFingerprint: automationSessionFingerprint(fire),
+      input: {
+        cwd: fire.execution.cwd,
+        ...(fire.execution.projectId === undefined ? {} : { projectId: fire.execution.projectId }),
+        name: fire.automationName,
+        labels: ['automation', 'cron'],
+        backend: fire.execution.backend,
+        llmConnectionSlug: fire.execution.llmConnectionSlug,
+        model: fire.execution.model,
+        ...(fire.execution.thinkingLevel === undefined
+          ? {}
+          : { thinkingLevel: fire.execution.thinkingLevel }),
+        permissionMode: 'explore',
+        collaborationMode: fire.execution.collaborationMode,
+        orchestrationMode: fire.execution.orchestrationMode,
+      },
+    });
+    if (result.kind === 'conflict') {
+      throw new AutomationAuthorityInvariantError(
+        `Cron Session identity conflicts for fire ${fire.id}`,
+      );
+    }
+  }
+
+  async #assertFireCanEnterRuntime(fire: AutomationPendingFire): Promise<void> {
+    if (this.isDraining) {
+      throw new AutomationFireDeferredError('Automation authority is draining');
+    }
+    await this.#state.assertPendingFire(fire);
+    if (this.#isSessionActive(fire.targetSessionId)) {
+      throw new AutomationFireDeferredError('Automation target Session is busy');
+    }
+    const incognito = (await this.#runtimePolicy.runtimePolicy.getSnapshot()).policy.privacy
+      .incognitoActive;
+    if (incognito) throw new AutomationFireDeferredError('Incognito mode is active');
+    let header: SessionHeader;
+    try {
+      header = await this.#sessions.readHeaderSnapshot(fire.targetSessionId);
+    } catch (error) {
+      if (isSessionNotFoundError(error) || isMissingRecord(error)) {
+        throw new AutomationFireDeferredError('Automation target Session is unavailable');
+      }
+      throw error;
+    }
+    if (header.isArchived || header.status === 'archived') {
+      throw new AutomationFireDeferredError('Automation target Session is archived');
+    }
+    if (runtimeHostSessionUnavailableReason(header)) {
+      throw new AutomationFireDeferredError('Automation target Session is unavailable');
+    }
+    if (fire.automationKind === 'heartbeat' && !HEARTBEAT_IDLE_STATUSES.has(header.status)) {
+      throw new AutomationFireDeferredError('Automation target Session is not idle');
+    }
+  }
+
+  async #readRun(fire: AutomationPendingFire): Promise<AgentRunHeader | undefined> {
+    try {
+      return await this.#runs.readRun(fire.targetSessionId, fire.runId);
+    } catch (error) {
+      if (isMissingRecord(error)) return undefined;
+      throw error;
+    }
+  }
+}
+
+export function fireContent(fire: AutomationPendingFire): MessageContent {
+  return {
+    text:
+      fire.automationKind === 'heartbeat'
+        ? `[Automation: ${fire.automationName}]\n\n${fire.prompt}`
+        : fire.prompt,
+  };
+}
+
+export function automationSessionId(fireId: string): string {
+  const digest = createHash('sha256').update(`automation-session-v0\0${fireId}`).digest('hex');
+  return `automation_session_${digest.slice(0, 48)}`;
+}
+
+function automationSessionFingerprint(fire: AutomationPendingFire): string {
+  return `sha256:${createHash('sha256')
+    .update(
+      JSON.stringify({
+        protocol: 'automation-session-v0',
+        fireId: fire.id,
+        automationId: fire.automationId,
+        targetSessionId: fire.targetSessionId,
+        execution: fire.execution,
+      }),
+    )
+    .digest('hex')}`;
+}
+
+export function assertFireRunIdentity(fire: AutomationPendingFire, run: AgentRunHeader): void {
+  if (
+    run.sessionId !== fire.targetSessionId ||
+    run.turnId !== fire.turnId ||
+    run.runId !== fire.runId ||
+    run.automationId !== fire.automationId ||
+    run.parentRunId !== undefined ||
+    run.resumedFromRunId !== undefined ||
+    run.retriedFromRunId !== undefined ||
+    run.parentSessionId !== undefined ||
+    run.agentId !== undefined ||
+    run.agentName !== undefined ||
+    run.continuationSource !== undefined ||
+    run.agentGraphWakeId !== undefined ||
+    run.agentGraphWakeAttemptId !== undefined
+  ) {
+    throw new AutomationAuthorityInvariantError(
+      `Run ${run.runId} does not match pending Automation fire ${fire.id}`,
+    );
+  }
+}
+
+export function isTerminalRun(run: AgentRunHeader): boolean {
+  return run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled';
+}
+
+function isMissingRecord(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+function deferred(): Deferred {
+  let settled = false;
+  let resolvePromise!: () => void;
+  let rejectPromise!: (error: unknown) => void;
+  const promise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return {
+    promise,
+    resolve: () => {
+      if (settled) return;
+      settled = true;
+      resolvePromise();
+    },
+    reject: (error) => {
+      if (settled) return;
+      settled = true;
+      rejectPromise(error);
+    },
+  };
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -16,6 +16,7 @@ import {
   createReadImageSnapshotter,
   openInteractiveArtifactStoreForWrite,
 } from '@maka/storage/artifact-stores';
+import { openInteractiveAutomationAuthorityForWrite } from '@maka/storage/automation-authority';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
 import { openInteractiveMemoryBundleStoreForWrite } from '@maka/storage/memory-bundle-store';
 import { runWithStorageRootLease } from '@maka/storage/root-authority';
@@ -26,6 +27,7 @@ import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
 import { CanonicalSessionProjectionReader } from './canonical-session-projection.js';
 import { HostCanonicalPermissionOutcomeReader } from './canonical-permission-outcome-reader.js';
 import { HostArtifactCoordinator } from './artifact-coordinator.js';
+import { HostAutomationCoordinator } from './automation-coordinator.js';
 import { recoverClientCapabilityOutcomes } from './client-capability-recovery.js';
 import { HostConnectionEffectCoordinator } from './connection-effect-coordinator.js';
 import { HostClientCapabilityCoordinator } from './client-capability-coordinator.js';
@@ -61,11 +63,18 @@ export async function createExecutionRuntimeHostComposition(
   let usageStores: Awaited<ReturnType<typeof openInteractiveUsageStoresForWrite>> | undefined;
   let artifactStore: Awaited<ReturnType<typeof openInteractiveArtifactStoreForWrite>> | undefined;
   let shellRunStore: Awaited<ReturnType<typeof openInteractiveShellRunStoreForWrite>> | undefined;
+  let automationStore:
+    | Awaited<ReturnType<typeof openInteractiveAutomationAuthorityForWrite>>
+    | undefined;
   try {
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,
     );
     const oauthCredentials = new HostOAuthExecutionAuthority(runtimePolicyStores);
+    const openedAutomationStore = await openInteractiveAutomationAuthorityForWrite(
+      context.owner.lease,
+    );
+    automationStore = openedAutomationStore;
     const memoryStore = await openInteractiveMemoryBundleStoreForWrite(context.owner.lease);
     taskLedgerStore = await openInteractiveTaskLedgerStoreForWrite(context.owner.lease);
     const openedArtifactStore = await openInteractiveArtifactStoreForWrite(context.owner.lease);
@@ -118,6 +127,7 @@ export async function createExecutionRuntimeHostComposition(
     let canonicalProjection: CanonicalSessionProjectionReader | undefined;
     let memory: HostMemoryCoordinator | undefined;
     let clientCapabilities: HostClientCapabilityCoordinator | undefined;
+    let automations: HostAutomationCoordinator | undefined;
     const rootPort: HostMessageRootPort = {
       readSessionHeader: (sessionId) =>
         requireRootCoordinator(rootCoordinator).readSessionHeader(sessionId),
@@ -166,12 +176,14 @@ export async function createExecutionRuntimeHostComposition(
     let draining = false;
     let recoveryTask: Promise<void> | undefined;
     let rootCloseTask: Promise<void> | undefined;
+    let rootRecoveryCompleted = false;
     let closeTask: Promise<void> | undefined;
     let backendInvalidationPoisoned = false;
     const beginDrain = () => {
       if (draining) return;
       draining = true;
       runtimeResources?.beginDrain();
+      automations?.beginDrain();
       messages.beginDrain();
       interactions.beginDrain();
       connectionEffects.beginDrain();
@@ -217,6 +229,7 @@ export async function createExecutionRuntimeHostComposition(
         artifacts: openedArtifactStore,
         usage: openedUsageStores,
         clientCapabilities: requireClientCapabilities(clientCapabilities),
+        automationTool: requireAutomationCoordinator(automations).modelTool,
         builtinTools: {
           shellRuns: requireRuntimeResources(runtimeResources),
           runtimeResources: requireRuntimeResources(runtimeResources),
@@ -309,8 +322,20 @@ export async function createExecutionRuntimeHostComposition(
       context.acquireResidency,
       context.requestDrain,
       clientCapabilities,
+      (admission) => requireAutomationCoordinator(automations).assertRecoveryAdmission(admission),
     );
     const coordinator = rootCoordinator;
+    automations = new HostAutomationCoordinator({
+      store: openedAutomationStore,
+      sessions: stores.sessionStore,
+      runs: stores.agentRunStore,
+      runtime: manager,
+      root: { executeRoot: (input) => coordinator.executeRoot(input) },
+      runtimePolicy: runtimePolicyStores,
+      isSessionActive: (sessionId) => coordinator.readRootState(sessionId).kind === 'active',
+      acquireResidency: context.acquireResidency,
+      requestDrain: context.requestDrain,
+    });
     const runtimePolicy = new HostRuntimePolicyCoordinator(
       runtimePolicyStores,
       runtimePolicyActivation,
@@ -368,6 +393,7 @@ export async function createExecutionRuntimeHostComposition(
       ...requireMemory(memory).handlers,
       ...clientCapabilities.handlers,
       ...runtimeResources.handlers,
+      ...automations.handlers,
     } satisfies DomainOperationHandlerMap;
     const recover = () => {
       recoveryTask ??= (async () => {
@@ -385,11 +411,15 @@ export async function createExecutionRuntimeHostComposition(
           stores.runtimeEventStore,
           sessions.map((session) => session.id),
         );
+        await requireAutomationCoordinator(automations).prepareRecovery();
         await coordinator.prepareRecovery();
         await interactions.recoverPendingAfterHostRestart();
         await manager.recoverInterruptedSessionsStrict(stores);
         await graphCoordinator.recover();
         await coordinator.recover();
+        rootRecoveryCompleted = true;
+        await requireAutomationCoordinator(automations).recover();
+        requireAutomationCoordinator(automations).start();
       })();
       return recoveryTask;
     };
@@ -397,10 +427,8 @@ export async function createExecutionRuntimeHostComposition(
       closeTask ??= (async () => {
         beginDrain();
         const errors: unknown[] = [];
-        let recovered = false;
         try {
           await recover();
-          recovered = true;
         } catch (error) {
           errors.push(error);
         }
@@ -414,13 +442,18 @@ export async function createExecutionRuntimeHostComposition(
         } catch (error) {
           errors.push(error);
         }
-        if (recovered && !poisonFailure) {
+        if (rootRecoveryCompleted && !poisonFailure) {
           try {
             rootCloseTask ??= coordinator.close();
             await rootCloseTask;
           } catch (error) {
             errors.push(error);
           }
+        }
+        try {
+          await automations?.close();
+        } catch (error) {
+          errors.push(error);
         }
         try {
           await runtimeResources?.close();
@@ -490,6 +523,11 @@ export async function createExecutionRuntimeHostComposition(
           errors.push(error);
         }
         try {
+          openedAutomationStore.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
           await stores.sessionStore.close?.();
         } catch (error) {
           errors.push(error);
@@ -542,6 +580,11 @@ export async function createExecutionRuntimeHostComposition(
       errors.push(closeError);
     }
     try {
+      automationStore?.close();
+    } catch (closeError) {
+      errors.push(closeError);
+    }
+    try {
       await stores.sessionStore.close?.();
     } catch (closeError) {
       errors.push(closeError);
@@ -579,6 +622,13 @@ function requireClientCapabilities(
   coordinator: HostClientCapabilityCoordinator | undefined,
 ): HostClientCapabilityCoordinator {
   if (!coordinator) throw new Error('Runtime Host Client Capability coordinator is not composed');
+  return coordinator;
+}
+
+function requireAutomationCoordinator(
+  coordinator: HostAutomationCoordinator | undefined,
+): HostAutomationCoordinator {
+  if (!coordinator) throw new Error('Runtime Host Automation coordinator is not composed');
   return coordinator;
 }
 

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -101,6 +101,7 @@ export interface HostExecutionModelCompositionInput {
   readonly now?: () => Date;
   readonly clientCapabilities?: Pick<ClientCapabilitySnapshot, 'tools' | 'groups'>;
   readonly builtinTools?: BuildBuiltinToolsOptions;
+  readonly automationTool?: MakaTool;
 }
 
 /** Composes one Host-owned prompt and pure tool surface from canonical authorities. */
@@ -110,7 +111,12 @@ export function createHostExecutionModelComposition(
   const inventoryFor = createTurnSkillInventoryResolver(input.skills);
   const defaultTools = input.boundTools
     ? input.boundTools
-    : buildDefaultHostTools(input.taskLedger, inventoryFor, input.builtinTools);
+    : buildDefaultHostTools(
+        input.taskLedger,
+        inventoryFor,
+        input.builtinTools,
+        input.automationTool,
+      );
   const productSurface = projectEffectiveProductToolSurface({
     host: 'runtime-host',
     tools: defaultTools,
@@ -201,6 +207,7 @@ export interface HostAiSdkBackendInput {
   readonly clientCapabilities: HostClientCapabilityCoordinator;
   readonly runtimeCommitSink?: RuntimeCommitSink;
   readonly builtinTools?: BuildBuiltinToolsOptions;
+  readonly automationTool?: MakaTool;
   readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
 }
 
@@ -266,6 +273,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
       ...(input.context.tools ? { boundTools: input.context.tools } : {}),
       ...(clientCapabilities ? { clientCapabilities } : {}),
       ...(input.builtinTools ? { builtinTools: input.builtinTools } : {}),
+      ...(input.automationTool ? { automationTool: input.automationTool } : {}),
       skillBudget: {
         contextWindow: resolveSelectedModelContextWindow(target.connection, target.model),
       },
@@ -597,6 +605,7 @@ function buildDefaultHostTools(
   taskLedger: TaskLedgerStore,
   inventoryFor: SkillInventoryResolver,
   builtinOptions?: BuildBuiltinToolsOptions,
+  automationTool?: MakaTool,
 ): MakaTool[] {
   const builtins = builtinOptions ? buildBuiltinTools(builtinOptions) : [];
   const question = buildAskUserQuestionTool();
@@ -607,6 +616,7 @@ function buildDefaultHostTools(
     'Skill',
     'SkillSearch',
     ...taskTools.map((tool) => tool.name),
+    ...(automationTool ? [automationTool.name] : []),
   ];
   const skillHost = buildHostCapabilitiesFromBinding(toolNames);
   const shadowTracker = new SkillShadowSelectionTracker();
@@ -620,6 +630,7 @@ function buildDefaultHostTools(
       shadowTracker,
     }),
     ...taskTools,
+    ...(automationTool ? [automationTool] : []),
   ];
 }
 

--- a/packages/runtime-host/src/server/host-session-availability.ts
+++ b/packages/runtime-host/src/server/host-session-availability.ts
@@ -1,0 +1,13 @@
+import { isDeepResearchSession, type SessionHeader } from '@maka/core/session';
+
+export function runtimeHostSessionUnavailableReason(
+  header: Pick<SessionHeader, 'collaborationMode' | 'labels'>,
+): string | undefined {
+  if (header.collaborationMode === 'plan') {
+    return 'Plan sessions are not yet supported by Runtime Host.';
+  }
+  if (isDeepResearchSession(header.labels)) {
+    return 'Deep Research sessions are not yet supported by Runtime Host.';
+  }
+  return undefined;
+}

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -67,6 +67,7 @@ export type UsagePricingOperationKey = Extract<OperationKey, 'usage.query' | `pr
 export type MemoryOperationKey = Extract<OperationKey, `memory.${string}`>;
 export type RuntimeResourceOperationKey = Extract<OperationKey, `runtime.resource.${string}`>;
 export type ClientCapabilityOperationKey = Extract<OperationKey, `client.capability.${string}`>;
+export type AutomationOperationKey = Extract<OperationKey, `automation.${string}`>;
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
 export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
 export type RuntimePolicyOperationHandlerMap = Pick<OperationHandlerMap, RuntimePolicyOperationKey>;
@@ -101,6 +102,7 @@ export type ClientCapabilityOperationHandlerMap = Pick<
   OperationHandlerMap,
   ClientCapabilityOperationKey
 >;
+export type AutomationOperationHandlerMap = Pick<OperationHandlerMap, AutomationOperationKey>;
 
 export function composeOperationHandlers(
   ...handlerMaps: readonly Partial<OperationHandlerMap>[]

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -8,10 +8,11 @@ import {
   type MessageContent,
   type SessionEvent,
 } from '@maka/core/events';
-import { isDeepResearchSession, type SessionHeader, type StoredMessage } from '@maka/core/session';
+import type { SessionHeader, StoredMessage } from '@maka/core/session';
 import {
   classifyTerminalRuntimeLedger,
   RuntimeHostedRootConflictError,
+  RuntimeHostedRootUnavailableError,
   RuntimeInteractionAdmissionRejectedError,
   RuntimeInteractionFailStopError,
   RuntimeInteractionInvariantError,
@@ -54,6 +55,7 @@ import {
   SessionContinuityCoordinator,
 } from './session-continuity-coordinator.js';
 import type { HostClientCapabilityCoordinator } from './client-capability-coordinator.js';
+import { runtimeHostSessionUnavailableReason } from './host-session-availability.js';
 
 type RootTerminalInteractionFence = Pick<
   HostInteractionCoordinator,
@@ -65,6 +67,7 @@ interface ActiveRootTurn {
   runId: string;
   userMessageId: string | null;
   execution?: RuntimeHostedRootExecutionInput;
+  admissionExecution: RootTurnAdmission['execution'];
   startSettled: Deferred;
   done: Promise<void>;
   residency: RuntimeHostResidency;
@@ -126,6 +129,7 @@ export class RootTurnCoordinator {
     private readonly acquireRecoveryResidency: () => RuntimeHostResidency,
     private readonly requestHostDrain: () => void,
     private readonly clientCapabilities?: HostClientCapabilityCoordinator,
+    private readonly assertAutomationRecoveryAdmission?: (admission: RootTurnAdmission) => void,
   ) {
     this.stores = authenticateExecutionStoresWriter(stores, 'interactive');
   }
@@ -153,6 +157,18 @@ export class RootTurnCoordinator {
           ? (messageIndex.messagesById.get(admission.userMessageId) ?? [])
           : [];
         const executionContract = recoveryExecutionContract(admission.execution);
+        if (
+          admission.execution.kind === 'automation' &&
+          (!run ||
+            (run.status !== 'completed' && run.status !== 'failed' && run.status !== 'cancelled'))
+        ) {
+          if (!this.assertAutomationRecoveryAdmission) {
+            throw new RuntimeMessageAuthorityInvariantError(
+              'Automation recovery admission has no canonical authority validator',
+            );
+          }
+          this.assertAutomationRecoveryAdmission(admission);
+        }
         if (!executionContract.allowsQueueSources && admission.sourceMessages.length !== 0) {
           throw new Error(
             `Admitted Turn ${admission.turnId} has queue-independent execution with Message queue sources`,
@@ -256,8 +272,11 @@ export class RootTurnCoordinator {
         await this.stores.sessionStore.appendMessage(plan.sessionId, message);
       }
       for (const admission of plan.pendingChildAdmissions) {
-        if (admission.execution.kind === 'external_message') {
-          throw new Error('External Message admission cannot use child recovery closure');
+        if (
+          admission.execution.kind === 'external_message' ||
+          admission.execution.kind === 'automation'
+        ) {
+          throw new Error('Root-replay admission cannot use child recovery closure');
         }
         await this.manager.closePendingHostedLinkedChildAdmission({
           sessionId: admission.sessionId,
@@ -340,7 +359,7 @@ export class RootTurnCoordinator {
       if (header.conversationCopy?.state === 'preparing') return null;
       return {
         isArchived: header.isArchived || header.status === 'archived',
-        unavailableReason: unsupportedSessionModeReason(header),
+        unavailableReason: runtimeHostSessionUnavailableReason(header),
       };
     } catch (error) {
       if (isSessionNotFoundError(error)) return null;
@@ -394,12 +413,29 @@ export class RootTurnCoordinator {
           );
         }
 
-        const header = await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
-        if (header.status === 'archived' || header.isArchived) {
-          throw new Error('Cannot start a hosted root execution in an archived Session');
+        let header: SessionHeader;
+        try {
+          header = await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
+        } catch (error) {
+          if (isSessionNotFoundError(error)) {
+            throw new RuntimeHostedRootUnavailableError(
+              input.sessionId,
+              'Hosted root execution target Session is unavailable',
+              { cause: error },
+            );
+          }
+          throw error;
         }
-        const unavailableReason = unsupportedSessionModeReason(header);
-        if (unavailableReason) throw new Error(unavailableReason);
+        if (header.status === 'archived' || header.isArchived) {
+          throw new RuntimeHostedRootUnavailableError(
+            input.sessionId,
+            'Cannot start a hosted root execution in an archived Session',
+          );
+        }
+        const unavailableReason = runtimeHostSessionUnavailableReason(header);
+        if (unavailableReason) {
+          throw new RuntimeHostedRootUnavailableError(input.sessionId, unavailableReason);
+        }
         if (this.#activeBySession.has(input.sessionId)) {
           throw new RuntimeHostedRootConflictError(
             input.sessionId,
@@ -707,7 +743,7 @@ export class RootTurnCoordinator {
         if (header.status === 'archived' || header.isArchived) {
           return completedStart(sessionArchived('Cannot start a new Turn in an archived Session'));
         }
-        const unavailableReason = unsupportedSessionModeReason(header);
+        const unavailableReason = runtimeHostSessionUnavailableReason(header);
         if (unavailableReason) {
           return completedStart(operationUnavailable(unavailableReason));
         }
@@ -944,6 +980,7 @@ export class RootTurnCoordinator {
       runId,
       userMessageId: admission.userMessageId,
       ...(execution ? { execution } : {}),
+      admissionExecution: admission.execution,
       startSettled,
       done: Promise.resolve(),
       residency,
@@ -1007,7 +1044,18 @@ export class RootTurnCoordinator {
           })
         : this.manager.sendMessage(
             input.sessionId,
-            { turnId: input.turnId, ...normalizeMessageContent(input.content) },
+            {
+              turnId: input.turnId,
+              ...normalizeMessageContent(input.content),
+              ...(active.admissionExecution.kind === 'automation'
+                ? {
+                    origin: {
+                      kind: 'automation' as const,
+                      automationId: active.admissionExecution.automationId,
+                    },
+                  }
+                : {}),
+            },
             {
               runId: active.runId,
               userMessageId: active.userMessageId ?? undefined,
@@ -1321,6 +1369,7 @@ export class RootTurnCoordinator {
     } catch (error) {
       if (
         !(error instanceof RuntimeHostedRootConflictError) &&
+        !(error instanceof RuntimeHostedRootUnavailableError) &&
         !(error instanceof HostedRootAdmissionGateError)
       ) {
         this.requestHostDrain();
@@ -1357,6 +1406,14 @@ function recoveryUserMessage(admission: RootTurnAdmission): RecoveryUserMessage 
     turnId: admission.turnId,
     ts: admission.admittedAt,
     ...normalizeMessageContent(admission.normalizedInput),
+    ...(admission.execution.kind === 'automation'
+      ? {
+          origin: {
+            kind: 'automation' as const,
+            automationId: admission.execution.automationId,
+          },
+        }
+      : {}),
   };
 }
 
@@ -1377,6 +1434,22 @@ function assertRunMatchesExecution(
   switch (execution.kind) {
     case 'external_message':
       return;
+    case 'automation':
+      if (
+        run.automationId === execution.automationId &&
+        run.parentRunId === undefined &&
+        run.resumedFromRunId === undefined &&
+        run.retriedFromRunId === undefined &&
+        run.parentSessionId === undefined &&
+        run.agentId === undefined &&
+        run.agentName === undefined &&
+        run.continuationSource === undefined &&
+        run.agentGraphWakeId === undefined &&
+        run.agentGraphWakeAttemptId === undefined
+      ) {
+        return;
+      }
+      break;
     case 'linked_child_initial':
     case 'claimed_agent_graph_intent':
       assertTrustedAgentIdentity(run, turnId, execution);
@@ -1405,7 +1478,10 @@ function assertRunMatchesExecution(
 function assertTrustedAgentIdentity(
   run: AgentRunHeader,
   turnId: string,
-  execution: Exclude<RootTurnAdmission['execution'], { kind: 'external_message' }>,
+  execution: Exclude<
+    RootTurnAdmission['execution'],
+    { kind: 'external_message' } | { kind: 'automation' }
+  >,
 ): void {
   if (run.agentId !== execution.agentId || run.agentName !== execution.agentName) {
     throw new RuntimeMessageAuthorityInvariantError(
@@ -1427,6 +1503,12 @@ function recoveryExecutionContract(
     case 'external_message':
       return {
         allowsQueueSources: true,
+        requiresUserMessage: true,
+        pendingWithoutRun: 'root_replay',
+      };
+    case 'automation':
+      return {
+        allowsQueueSources: false,
         requiresUserMessage: true,
         pendingWithoutRun: 'root_replay',
       };
@@ -1508,18 +1590,6 @@ function deferred(): Deferred {
 
 function isMissingFile(error: unknown): boolean {
   return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT';
-}
-
-function unsupportedSessionModeReason(
-  header: Pick<SessionHeader, 'collaborationMode' | 'labels'>,
-): string | undefined {
-  if (header.collaborationMode === 'plan') {
-    return 'Plan sessions are not yet supported by Runtime Host.';
-  }
-  if (isDeepResearchSession(header.labels)) {
-    return 'Deep Research sessions are not yet supported by Runtime Host.';
-  }
-  return undefined;
 }
 
 function isTerminalSnapshot(snapshot: TurnSnapshot): boolean {

--- a/packages/runtime/src/__tests__/automation-integration.test.ts
+++ b/packages/runtime/src/__tests__/automation-integration.test.ts
@@ -263,6 +263,37 @@ describe('Automation integration: turn-tail shows active automations', () => {
     assert.ok(listResult.includes('monitor ci'));
     assert.ok(listResult.includes('ACTIVE'));
   });
+
+  test('list mode bounds app-global durable Automation output', async () => {
+    const t = createIntegrationSetup();
+    t.manager.hydrate(
+      Array.from({ length: 101 }, (_, index) => ({
+        id: `durable-${index}`,
+        kind: 'cron' as const,
+        name: `durable automation ${index}`,
+        status: 'paused' as const,
+        prompt: 'check',
+        sessionId: `other-session-${index}`,
+        schedule: { type: 'interval' as const, seconds: 60 },
+        createdAt: index,
+        updatedAt: index,
+        nextFireAt: null,
+        lastFireAt: null,
+        lastRunId: null,
+        fireCount: 0,
+        maxFires: null,
+        expiresAt: null,
+        lastError: null,
+        consecutiveFailures: 0,
+        durable: true,
+      })),
+    );
+
+    const result = (await t.tool.impl({ mode: 'list' }, t.ctx())) as string;
+    assert.match(result, /durable automation 99/);
+    assert.doesNotMatch(result, /durable automation 100/);
+    assert.match(result, /1 additional automations omitted\./);
+  });
 });
 
 describe('Automation integration: expired automations do not fire', () => {
@@ -469,5 +500,21 @@ describe('Automation integration: cron gating by host capability', () => {
       schedule: { type: 'interval', seconds: 30 },
     });
     assert.equal(parsed.success, true);
+  });
+
+  test('model schema accepts the legacy Unicode boundary and rejects larger text', () => {
+    const mgr = new AutomationManager({ generateId: () => 'g', now: () => 1 });
+    const tool = buildAutomationTool({ automationManager: mgr, cronEnabled: true });
+    const schema = tool.parameters as { safeParse: (value: unknown) => { success: boolean } };
+    const input = {
+      mode: 'create',
+      kind: 'heartbeat',
+      name: '名'.repeat(100),
+      prompt: '提'.repeat(2_000),
+      schedule: { type: 'interval', seconds: 30 },
+    };
+    assert.equal(schema.safeParse(input).success, true);
+    assert.equal(schema.safeParse({ ...input, name: '名'.repeat(101) }).success, false);
+    assert.equal(schema.safeParse({ ...input, prompt: '提'.repeat(2_001) }).success, false);
   });
 });

--- a/packages/runtime/src/__tests__/automation.test.ts
+++ b/packages/runtime/src/__tests__/automation.test.ts
@@ -217,6 +217,24 @@ describe('AutomationManager', () => {
       assert.equal(mgr.get(auto.id)?.status, 'completed'); // 2/2
     });
 
+    test('an accepted attempt still records its outcome when paused in flight', () => {
+      const mgr = createManager();
+      const auto = mgr.create({
+        kind: 'heartbeat',
+        name: 'in flight',
+        prompt: 'p',
+        sessionId: 'sess-1',
+        schedule: { type: 'once', delaySeconds: 30 },
+      });
+      assert.ok(!('error' in auto));
+      mgr.attemptStarted(auto.id);
+      mgr.pause(auto.id, 'sess-1');
+      mgr.attemptSucceeded(auto.id, 'run-in-flight');
+      assert.equal(mgr.get(auto.id)?.status, 'paused');
+      assert.equal(mgr.get(auto.id)?.lastRunId, 'run-in-flight');
+      assert.equal(mgr.get(auto.id)?.lastError, null);
+    });
+
     test('a failed fire does NOT complete (even at maxFires)', () => {
       const mgr = createManager();
       const auto = mgr.create({
@@ -277,6 +295,21 @@ describe('AutomationManager', () => {
       mgr.attemptStarted(auto.id); // nextFireAt → null
       mgr.attemptFailed(auto.id, 'boom');
       assert.equal(mgr.get(auto.id)?.status, 'paused');
+    });
+
+    test('an empty accepted failure gets a stable diagnostic', () => {
+      const mgr = createManager();
+      const auto = mgr.create({
+        kind: 'heartbeat',
+        name: 'empty failure',
+        prompt: 'p',
+        sessionId: 'sess-1',
+        schedule: { type: 'once', delaySeconds: 10 },
+      });
+      assert.ok(!('error' in auto));
+      mgr.attemptStarted(auto.id);
+      mgr.attemptFailed(auto.id, '');
+      assert.equal(mgr.get(auto.id)?.lastError, 'Automation run failed');
     });
 
     test('attemptSucceeded resets failure count', () => {

--- a/packages/runtime/src/automation-state.ts
+++ b/packages/runtime/src/automation-state.ts
@@ -6,41 +6,21 @@
  * - "cron": standalone scheduled runs (create fresh session each time)
  */
 
-export type AutomationKind = 'heartbeat' | 'cron';
-export type AutomationStatus = 'active' | 'paused' | 'completed' | 'expired';
+import type {
+  AutomationDefinition,
+  AutomationExecutionTemplate,
+  AutomationKind,
+  AutomationSchedule,
+} from '@maka/core/automation';
+import { AUTOMATION_LAST_ERROR_LIMIT, truncateAutomationText } from '@maka/core/automation';
 
-export interface AutomationDefinition {
-  id: string;
-  kind: AutomationKind;
-  name: string;
-  status: AutomationStatus;
-  prompt: string;
-  sessionId: string;
-  schedule: AutomationSchedule;
-  createdAt: number;
-  updatedAt: number;
-  nextFireAt: number | null;
-  lastFireAt: number | null;
-  lastRunId: string | null;
-  fireCount: number;
-  maxFires: number | null;
-  expiresAt: number | null;
-  lastError: string | null;
-  consecutiveFailures: number;
-  /** When true, this automation persists across app restarts. */
-  durable?: boolean;
-  /**
-   * Total fire attempts deferred because the target was busy (idle-gate).
-   * Cumulative, in-memory observability — surfaced in the model-facing list
-   * (mirrors the old CronList's fire_attempts / deferred_fires).
-   */
-  deferredFireCount?: number;
-}
-
-export type AutomationSchedule =
-  | { type: 'cron'; expression: string }
-  | { type: 'interval'; seconds: number }
-  | { type: 'once'; delaySeconds: number };
+export type {
+  AutomationDefinition,
+  AutomationExecutionTemplate,
+  AutomationKind,
+  AutomationSchedule,
+  AutomationStatus,
+} from '@maka/core/automation';
 
 export interface AutomationManagerDeps {
   generateId: () => string;
@@ -52,6 +32,7 @@ export interface AutomationManagerDeps {
 const MAX_AUTOMATIONS_PER_SESSION = 20;
 const MAX_CONSECUTIVE_FAILURES = 5;
 const DEFAULT_EXPIRY_DAYS = 7;
+const DEFAULT_AUTOMATION_FAILURE_MESSAGE = 'Automation run failed';
 
 /** Maximum jitter cap for recurring re-schedules: 15 minutes. */
 const MAX_JITTER_MS = 15 * 60 * 1000;
@@ -98,6 +79,7 @@ export class AutomationManager {
     maxFires?: number;
     expiresAt?: number;
     durable?: boolean;
+    execution?: AutomationExecutionTemplate;
   }): AutomationDefinition | { error: string } {
     // Only count active/paused automations toward the limit (not completed/expired).
     const activeCount = this.listForSession(input.sessionId).filter(
@@ -157,6 +139,7 @@ export class AutomationManager {
       lastError: null,
       consecutiveFailures: 0,
       ...(durable ? { durable: true } : {}),
+      ...(input.kind === 'cron' && input.execution ? { execution: input.execution } : {}),
     };
 
     this.automations.set(id, automation);
@@ -333,19 +316,7 @@ export class AutomationManager {
   attemptSucceeded(id: string, runId?: string): void {
     const automation = this.automations.get(id);
     if (!automation) return;
-    if (automation.status !== 'active') return;
-    automation.consecutiveFailures = 0;
-    automation.lastError = null;
-    if (runId) automation.lastRunId = runId;
-    automation.updatedAt = this.deps.now();
-
-    if (automation.schedule.type === 'once') {
-      automation.status = 'completed';
-      automation.nextFireAt = null;
-    } else if (automation.maxFires && automation.fireCount >= automation.maxFires) {
-      automation.status = 'completed';
-      automation.nextFireAt = null;
-    }
+    settleAutomationAttempt(automation, { status: 'completed', runId }, this.deps.now());
   }
 
   /**
@@ -356,18 +327,7 @@ export class AutomationManager {
   attemptFailed(id: string, error: string): void {
     const automation = this.automations.get(id);
     if (!automation) return;
-    if (automation.status !== 'active') return;
-    automation.consecutiveFailures++;
-    automation.lastError = error;
-    automation.updatedAt = this.deps.now();
-
-    if (automation.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-      automation.status = 'paused';
-    } else if (automation.nextFireAt === null) {
-      // Nothing will fire this again (one-shot failure) — pause so it is a
-      // visible terminal-ish state, not a silent zombie.
-      automation.status = 'paused';
-    }
+    settleAutomationAttempt(automation, { status: 'failed', error }, this.deps.now());
   }
 
   removeAllForSession(sessionId: string): number {
@@ -412,6 +372,14 @@ export class AutomationManager {
         }
       }
       this.automations.set(automation.id, automation);
+    }
+  }
+
+  /** Replace the projection without applying legacy restart reconciliation. */
+  hydrate(automations: readonly AutomationDefinition[]): void {
+    this.automations.clear();
+    for (const automation of automations) {
+      this.automations.set(automation.id, structuredClone(automation));
     }
   }
 
@@ -461,6 +429,47 @@ export class AutomationManager {
         return base + computeJitter(base - fromTime, true, random);
       }
     }
+  }
+}
+
+export type AutomationAttemptOutcome =
+  | { readonly status: 'completed'; readonly runId?: string }
+  | {
+      readonly status: 'failed' | 'cancelled';
+      readonly error: string;
+      readonly runId?: string;
+    };
+
+/** Settle an attempt that was accepted while the definition was active. */
+export function settleAutomationAttempt(
+  automation: AutomationDefinition,
+  outcome: AutomationAttemptOutcome,
+  now: number,
+): void {
+  if (automation.status === 'completed' || automation.status === 'expired') return;
+  if (outcome.runId) automation.lastRunId = outcome.runId;
+  automation.updatedAt = now;
+  if (outcome.status === 'completed') {
+    automation.consecutiveFailures = 0;
+    automation.lastError = null;
+    if (
+      automation.status === 'active' &&
+      (automation.schedule.type === 'once' ||
+        (automation.maxFires !== null && automation.fireCount >= automation.maxFires))
+    ) {
+      automation.status = 'completed';
+      automation.nextFireAt = null;
+    }
+    return;
+  }
+  automation.consecutiveFailures += 1;
+  const diagnostic = truncateAutomationText(outcome.error, AUTOMATION_LAST_ERROR_LIMIT);
+  automation.lastError = diagnostic.length > 0 ? diagnostic : DEFAULT_AUTOMATION_FAILURE_MESSAGE;
+  if (
+    automation.status === 'active' &&
+    (automation.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES || automation.nextFireAt === null)
+  ) {
+    automation.status = 'paused';
   }
 }
 

--- a/packages/runtime/src/automation-tools.ts
+++ b/packages/runtime/src/automation-tools.ts
@@ -8,10 +8,20 @@
  */
 
 import { z } from 'zod';
+import {
+  AUTOMATION_CRON_EXPRESSION_LIMIT,
+  AUTOMATION_CRON_EXPRESSION_MAX_CODE_UNITS,
+  AUTOMATION_NAME_LIMIT,
+  AUTOMATION_NAME_MAX_CODE_UNITS,
+  AUTOMATION_PROMPT_LIMIT,
+  AUTOMATION_PROMPT_MAX_CODE_UNITS,
+  isAutomationTextWithinLimit,
+} from '@maka/core/automation';
 import type { MakaTool } from './tool-runtime.js';
 import type { AutomationManager, AutomationDefinition } from './automation-state.js';
 
 export const AUTOMATION_TOOL_NAME = 'Automation';
+export const AUTOMATION_MODEL_LIST_MAX_ITEMS = 100;
 
 export interface AutomationToolDeps {
   automationManager: AutomationManager;
@@ -21,13 +31,38 @@ export interface AutomationToolDeps {
   cronEnabled?: boolean;
 }
 
+export interface AutomationToolAuthority {
+  create(input: {
+    kind: AutomationDefinition['kind'];
+    name: string;
+    prompt: string;
+    sessionId: string;
+    schedule: AutomationDefinition['schedule'];
+    maxFires?: number;
+    durable?: boolean;
+  }): Promise<AutomationDefinition | { error: string }>;
+  delete(id: string, sessionId: string): Promise<boolean>;
+  pause(id: string, sessionId: string): Promise<AutomationDefinition | undefined>;
+  resume(id: string, sessionId: string): Promise<AutomationDefinition | undefined>;
+  get(id: string, sessionId: string): Promise<AutomationDefinition | undefined>;
+  listVisibleForSession(sessionId: string): Promise<readonly AutomationDefinition[]>;
+}
+
+export interface AutomationAuthorityToolDeps {
+  readonly authority: AutomationToolAuthority;
+  readonly cronEnabled?: boolean;
+}
+
 const scheduleSchema = z.union([
   z.object({
     type: z.literal('cron'),
     expression: z
       .string()
       .min(9)
-      .max(100)
+      .max(AUTOMATION_CRON_EXPRESSION_MAX_CODE_UNITS)
+      .refine((value) => isAutomationTextWithinLimit(value, AUTOMATION_CRON_EXPRESSION_LIMIT), {
+        message: 'Cron expression exceeds the Automation text limit.',
+      })
       .describe(
         '5-field cron expression: "minute hour day-of-month month day-of-week". Example: "*/5 * * * *" = every 5 min, "0 9 * * 1-5" = weekdays at 9am.',
       ),
@@ -68,14 +103,22 @@ function makeAutomationSchema(kindSchema: z.ZodType) {
       .string()
       .trim()
       .min(1)
-      .max(100)
+      .max(AUTOMATION_NAME_MAX_CODE_UNITS)
+      .refine(
+        (value) => isAutomationTextWithinLimit(value, AUTOMATION_NAME_LIMIT, { nonblank: true }),
+        { message: 'Automation name exceeds the text limit.' },
+      )
       .optional()
       .describe('[create] Short human-readable name.'),
     prompt: z
       .string()
       .trim()
       .min(1)
-      .max(2000)
+      .max(AUTOMATION_PROMPT_MAX_CODE_UNITS)
+      .refine(
+        (value) => isAutomationTextWithinLimit(value, AUTOMATION_PROMPT_LIMIT, { nonblank: true }),
+        { message: 'Automation prompt exceeds the text limit.' },
+      )
       .optional()
       .describe('[create] The prompt to execute on each fire.'),
     schedule: scheduleSchema
@@ -121,6 +164,32 @@ const AUTOMATION_SCHEMA_HEARTBEAT_ONLY = makeAutomationSchema(
 type AutomationInput = z.infer<typeof AUTOMATION_SCHEMA_WITH_CRON>;
 
 export function buildAutomationTool(deps: AutomationToolDeps): MakaTool<AutomationInput, string> {
+  const changed = <T>(value: T): T => {
+    deps.onAutomationChange?.();
+    return value;
+  };
+  return buildAutomationAuthorityTool({
+    cronEnabled: deps.cronEnabled,
+    authority: {
+      create: async (input) => changed(deps.automationManager.create(input)),
+      delete: async (id, sessionId) => changed(deps.automationManager.delete(id, sessionId)),
+      pause: async (id, sessionId) => changed(deps.automationManager.pause(id, sessionId)),
+      resume: async (id, sessionId) => changed(deps.automationManager.resume(id, sessionId)),
+      get: async (id, sessionId) => {
+        const automation = deps.automationManager.get(id);
+        return automation && (automation.sessionId === sessionId || automation.durable === true)
+          ? automation
+          : undefined;
+      },
+      listVisibleForSession: async (sessionId) =>
+        deps.automationManager.listVisibleForSession(sessionId),
+    },
+  });
+}
+
+export function buildAutomationAuthorityTool(
+  deps: AutomationAuthorityToolDeps,
+): MakaTool<AutomationInput, string> {
   const cronEnabled = deps.cronEnabled === true;
   return {
     name: AUTOMATION_TOOL_NAME,
@@ -133,24 +202,24 @@ export function buildAutomationTool(deps: AutomationToolDeps): MakaTool<Automati
         : '') +
       'Automations auto-expire after 7 days unless deleted earlier.',
     parameters: cronEnabled ? AUTOMATION_SCHEMA_WITH_CRON : AUTOMATION_SCHEMA_HEARTBEAT_ONLY,
-    impl: (input, ctx) => {
+    impl: async (input, ctx) => {
       let result: string;
       switch (input.mode) {
         case 'create':
-          result = handleCreate(deps, input, ctx.sessionId, cronEnabled);
+          result = await handleCreate(deps.authority, input, ctx.sessionId, cronEnabled);
           break;
         case 'delete':
-          result = handleById(input, (id) =>
-            deps.automationManager.delete(id, ctx.sessionId)
+          result = await handleById(input, async (id) =>
+            (await deps.authority.delete(id, ctx.sessionId))
               ? `Automation "${id}" deleted.`
               : `Automation "${id}" not found or not owned by this session.`,
           );
           break;
         case 'list':
-          return handleList(deps, ctx.sessionId);
+          return handleList(deps.authority, ctx.sessionId);
         case 'pause': {
-          result = handleById(input, (id) => {
-            const r = deps.automationManager.pause(id, ctx.sessionId);
+          result = await handleById(input, async (id) => {
+            const r = await deps.authority.pause(id, ctx.sessionId);
             return r
               ? `Automation "${r.name}" paused. Use mode "resume" to reactivate.`
               : `Cannot pause "${id}": not found, not owned, or not active.`;
@@ -158,14 +227,14 @@ export function buildAutomationTool(deps: AutomationToolDeps): MakaTool<Automati
           break;
         }
         case 'resume': {
-          result = handleById(input, (id) => {
-            const r = deps.automationManager.resume(id, ctx.sessionId);
+          result = await handleById(input, async (id) => {
+            const r = await deps.authority.resume(id, ctx.sessionId);
             if (r) {
               return `Automation "${r.name}" resumed. Next fire: ${r.nextFireAt ? new Date(r.nextFireAt).toLocaleString() : 'N/A'}`;
             }
             // Distinguish a spent fire budget from other resume failures so the
             // agent doesn't keep retrying a cap that can never be revived.
-            const existing = deps.automationManager.get(id);
+            const existing = await deps.authority.get(id, ctx.sessionId);
             if (existing && existing.status === 'paused') {
               const spent =
                 (existing.maxFires != null && existing.fireCount >= existing.maxFires) ||
@@ -179,23 +248,25 @@ export function buildAutomationTool(deps: AutomationToolDeps): MakaTool<Automati
           break;
         }
       }
-      deps.onAutomationChange?.();
       return result;
     },
   };
 }
 
-function handleById(input: AutomationInput, run: (id: string) => string): string {
+async function handleById(
+  input: AutomationInput,
+  run: (id: string) => Promise<string>,
+): Promise<string> {
   if (!input.id) return 'Error: "id" is required for delete/pause/resume.';
-  return run(input.id);
+  return await run(input.id);
 }
 
-function handleCreate(
-  deps: AutomationToolDeps,
+async function handleCreate(
+  authority: AutomationToolAuthority,
   input: AutomationInput,
   sessionId: string,
   cronEnabled: boolean,
-): string {
+): Promise<string> {
   if (!input.kind) return 'Error: "kind" is required for create.';
   if (!input.name) return 'Error: "name" is required for create.';
   if (!input.prompt) return 'Error: "prompt" is required for create.';
@@ -208,7 +279,7 @@ function handleCreate(
       ? { type: 'once' as const, delaySeconds: input.schedule.delay_seconds }
       : input.schedule;
 
-  const result = deps.automationManager.create({
+  const result = await authority.create({
     kind: input.kind as 'heartbeat' | 'cron',
     name: input.name,
     prompt: input.prompt,
@@ -234,14 +305,18 @@ function handleCreate(
   ].join('\n');
 }
 
-function handleList(deps: AutomationToolDeps, sessionId: string): string {
+async function handleList(authority: AutomationToolAuthority, sessionId: string): Promise<string> {
   // Includes this session's automations plus every durable (app-global) one,
   // so persisted cron jobs stay queryable and manageable after a restart even
   // from a fresh session.
-  const automations = deps.automationManager.listVisibleForSession(sessionId);
+  const automations = await authority.listVisibleForSession(sessionId);
   if (automations.length === 0) return 'No automations for this session.';
-
-  return automations.map((a) => formatAutomation(a)).join('\n---\n');
+  const visible = automations.slice(0, AUTOMATION_MODEL_LIST_MAX_ITEMS);
+  const formatted = visible.map((a) => formatAutomation(a));
+  if (automations.length > visible.length) {
+    formatted.push(`${automations.length - visible.length} additional automations omitted.`);
+  }
+  return formatted.join('\n---\n');
 }
 
 function formatAutomation(a: AutomationDefinition): string {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -249,6 +249,7 @@ export { renderSwarmModePrompt } from './swarm-mode.js';
 export { renderGraphModePrompt } from './graph-mode.js';
 export {
   RuntimeHostedRootConflictError,
+  RuntimeHostedRootUnavailableError,
   RuntimeMessageAuthorityInvariantError,
 } from './message-authority.js';
 export type {
@@ -1385,9 +1386,12 @@ export {
   computeNextCronFire,
   computeJitter,
   matchesCronField,
+  settleAutomationAttempt,
 } from './automation-state.js';
 export type {
+  AutomationAttemptOutcome,
   AutomationDefinition,
+  AutomationExecutionTemplate,
   AutomationKind,
   AutomationSchedule,
   AutomationStatus,
@@ -1399,8 +1403,17 @@ export {
   DEFER_WINDOW_MS,
 } from './automation-scheduler.js';
 export type { AutomationSchedulerDeps, AutomationFireResult } from './automation-scheduler.js';
-export { buildAutomationTool, AUTOMATION_TOOL_NAME } from './automation-tools.js';
-export type { AutomationToolDeps } from './automation-tools.js';
+export {
+  buildAutomationAuthorityTool,
+  buildAutomationTool,
+  AUTOMATION_TOOL_NAME,
+  AUTOMATION_MODEL_LIST_MAX_ITEMS,
+} from './automation-tools.js';
+export type {
+  AutomationAuthorityToolDeps,
+  AutomationToolAuthority,
+  AutomationToolDeps,
+} from './automation-tools.js';
 export { evaluateAutomationCanFire, HEARTBEAT_IDLE_STATUSES } from './automation-can-fire.js';
 export type { CanFireSessionHeader, EvaluateAutomationCanFireDeps } from './automation-can-fire.js';
 

--- a/packages/runtime/src/message-authority.ts
+++ b/packages/runtime/src/message-authority.ts
@@ -87,3 +87,14 @@ export class RuntimeHostedRootConflictError extends Error {
     this.scope = { kind: 'session', sessionId };
   }
 }
+
+export class RuntimeHostedRootUnavailableError extends Error {
+  readonly name = 'RuntimeHostedRootUnavailableError';
+  readonly code = 'session_unavailable';
+  readonly scope: { readonly kind: 'session'; readonly sessionId: string };
+
+  constructor(sessionId: string, message: string, options: ErrorOptions = {}) {
+    super(message, options);
+    this.scope = { kind: 'session', sessionId };
+  }
+}

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -4221,7 +4221,10 @@ export class SessionManager {
     turnId: string;
     runId: string;
     admittedAt: number;
-    execution: Exclude<RootExecutionDescriptor, { kind: 'external_message' }>;
+    execution: Exclude<
+      RootExecutionDescriptor,
+      { kind: 'external_message' } | { kind: 'automation' }
+    >;
   }): Promise<void> {
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {
       throw new Error('Linked child admission recovery requires execution stores');
@@ -5474,7 +5477,10 @@ function assertClaimOwnsHostedLinkedChildAdmission(
     sessionId: string;
     turnId: string;
     runId: string;
-    execution: Exclude<RootExecutionDescriptor, { kind: 'external_message' }>;
+    execution: Exclude<
+      RootExecutionDescriptor,
+      { kind: 'external_message' } | { kind: 'automation' }
+    >;
   },
   claim: ContinuationClaimV1,
 ): void {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./artifact-stores": "./dist/artifact-stores.js",
+    "./automation-authority": "./dist/automation-authority.js",
     "./execution-stores": "./dist/execution-stores.js",
     "./agent-graph-control-store": "./dist/agent-graph-control-store.js",
     "./interaction-store": "./dist/interaction-store-public.js",

--- a/packages/storage/src/__tests__/automation-authority.test.ts
+++ b/packages/storage/src/__tests__/automation-authority.test.ts
@@ -1,0 +1,360 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { describe, test } from 'node:test';
+import type { AutomationDefinition, AutomationPendingFire } from '@maka/core/automation';
+import {
+  authenticateInteractiveAutomationAuthorityWriter,
+  openInteractiveAutomationAuthorityForWrite,
+  type InteractiveAutomationAuthorityWriter,
+} from '../automation-authority.js';
+import {
+  resolveStorageRoot,
+  StorageRootAuthorityError,
+  tryAcquireInteractiveRootOwner,
+} from '../root-authority.js';
+
+describe('interactive Automation authority', () => {
+  test('single-flights one authentic writer and atomically commits definitions with pending fires', async () => {
+    await withInteractiveRoot(async ({ capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      try {
+        const [first, second] = await Promise.all([
+          openInteractiveAutomationAuthorityForWrite(owner.lease),
+          openInteractiveAutomationAuthorityForWrite(owner.lease),
+        ]);
+        assert.equal(first, second);
+        assert.equal(authenticateInteractiveAutomationAuthorityWriter(first), first);
+
+        const automation = definitionWithPendingFire();
+        const fire = pendingFire();
+        const committed = await first.commit({
+          expectedRevision: 0,
+          automations: [automation],
+          pendingFires: [fire],
+        });
+        assert.equal(committed.kind, 'committed');
+        if (committed.kind !== 'committed') return;
+        assert.equal(committed.snapshot.revision, 1);
+
+        automation.name = 'mutated after commit';
+        assert.equal((await second.read()).automations[0]?.name, 'daily summary');
+
+        assert.deepEqual(
+          await second.commit({ expectedRevision: 0, automations: [], pendingFires: [] }),
+          { kind: 'revision_conflict', actualRevision: 1 },
+        );
+        const settled = await second.commit({
+          expectedRevision: 1,
+          automations: [{ ...definition(), status: 'completed', nextFireAt: null }],
+          pendingFires: [],
+        });
+        assert.equal(settled.kind, 'committed');
+
+        first.close();
+        assert.throws(
+          () => authenticateInteractiveAutomationAuthorityWriter(first),
+          isInvalidLease,
+        );
+        const reopened = await openInteractiveAutomationAuthorityForWrite(owner.lease);
+        assert.notEqual(reopened, first);
+        const snapshot = await reopened.read();
+        assert.equal(snapshot.revision, 2);
+        assert.equal(snapshot.automations[0]?.status, 'completed');
+        assert.deepEqual(snapshot.pendingFires, []);
+        reopened.close();
+      } finally {
+        if (!owner.closed) await owner.close();
+      }
+    });
+  });
+
+  test('imports the legacy file once and fails closed if that source changes after cutover', async () => {
+    await withInteractiveRoot(async ({ root, capability }) => {
+      await writeLegacy(root, [definition()]);
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      try {
+        const writer = await openInteractiveAutomationAuthorityForWrite(owner.lease);
+        const imported = await writer.read();
+        assert.equal(imported.revision, 1);
+        assert.deepEqual(
+          imported.automations.map((automation) => automation.id),
+          ['automation-1'],
+        );
+        writer.close();
+
+        await writeLegacy(root, [{ ...definition(), name: 'changed legacy source' }]);
+        await assert.rejects(
+          () => openInteractiveAutomationAuthorityForWrite(owner.lease),
+          /cutover|fingerprint|source/i,
+        );
+      } finally {
+        if (!owner.closed) await owner.close();
+      }
+    });
+  });
+
+  test('imports the full legacy text contract and bounds historical failure diagnostics', async () => {
+    await withInteractiveRoot(async ({ root, capability }) => {
+      await writeLegacy(root, [
+        {
+          ...definition(),
+          name: '名'.repeat(100),
+          prompt: '提'.repeat(2_000),
+          lastError: '故'.repeat(4_000),
+        },
+        {
+          ...definition(),
+          id: 'automation-2',
+          createdAt: 2,
+          lastError: '',
+        },
+      ]);
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      try {
+        const writer = await openInteractiveAutomationAuthorityForWrite(owner.lease);
+        const automations = (await writer.read()).automations;
+        const imported = automations[0];
+        assert.equal(imported?.name, '名'.repeat(100));
+        assert.equal(imported?.prompt, '提'.repeat(2_000));
+        assert.equal(imported?.lastError, '故'.repeat(2_000));
+        assert.equal(Buffer.byteLength(imported?.lastError ?? '', 'utf8'), 6_000);
+        assert.equal(automations[1]?.lastError, null);
+        writer.close();
+      } finally {
+        if (!owner.closed) await owner.close();
+      }
+    });
+  });
+
+  test('updates only changed definition rows while advancing a full-snapshot revision', async () => {
+    await withInteractiveRoot(async ({ root, capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      const writer = await openInteractiveAutomationAuthorityForWrite(owner.lease);
+      const second = { ...definition(), id: 'automation-2', name: 'second summary' };
+      const database = new DatabaseSync(join(root, 'runtime.sqlite'));
+      try {
+        const first = await writer.commit({
+          expectedRevision: 0,
+          automations: [definition(), second],
+          pendingFires: [],
+        });
+        assert.equal(first.kind, 'committed');
+        database.exec(`
+          CREATE TABLE automation_write_audit(operation TEXT NOT NULL, automation_id TEXT NOT NULL);
+          CREATE TRIGGER automation_definition_insert_audit
+          AFTER INSERT ON automation_definitions BEGIN
+            INSERT INTO automation_write_audit VALUES ('insert', NEW.automation_id);
+          END;
+          CREATE TRIGGER automation_definition_update_audit
+          AFTER UPDATE ON automation_definitions BEGIN
+            INSERT INTO automation_write_audit VALUES ('update', NEW.automation_id);
+          END;
+          CREATE TRIGGER automation_definition_delete_audit
+          AFTER DELETE ON automation_definitions BEGIN
+            INSERT INTO automation_write_audit VALUES ('delete', OLD.automation_id);
+          END;
+        `);
+
+        const changed = { ...definition(), name: 'updated summary', updatedAt: 2 };
+        const committed = await writer.commit({
+          expectedRevision: 1,
+          automations: [changed, second],
+          pendingFires: [],
+        });
+        assert.equal(committed.kind, 'committed');
+        assert.deepEqual(
+          database
+            .prepare('SELECT operation, automation_id FROM automation_write_audit ORDER BY rowid')
+            .all()
+            .map((row) => ({ ...row })),
+          [{ operation: 'update', automation_id: 'automation-1' }],
+        );
+      } finally {
+        database.close();
+        writer.close();
+        if (!owner.closed) await owner.close();
+      }
+    });
+  });
+
+  test('rejects multiple pending fires for one Automation without changing canonical state', async () => {
+    await withWriter(async ({ writer }) => {
+      assert.throws(
+        () =>
+          void writer.commit({
+            expectedRevision: 0,
+            automations: [definitionWithPendingFire()],
+            pendingFires: [pendingFire(), { ...pendingFire(), id: 'fire-2', runId: 'run-2' }],
+          }),
+        /Duplicate pending Automation id/,
+      );
+      assert.deepEqual(await writer.read(), { revision: 0, automations: [], pendingFires: [] });
+    });
+  });
+
+  test('rejects canonical reads and commits after the owner lease closes', async () => {
+    await withInteractiveRoot(async ({ capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      const writer = await openInteractiveAutomationAuthorityForWrite(owner.lease);
+      await owner.close();
+      await assert.rejects(() => writer.read(), isInvalidLease);
+      await assert.rejects(
+        () => writer.commit({ expectedRevision: 0, automations: [], pendingFires: [] }),
+        isInvalidLease,
+      );
+      writer.close();
+    });
+  });
+
+  test('rejects orphaned and contradictory pending fires before mutation', async () => {
+    await withWriter(async ({ writer }) => {
+      assert.throws(
+        () =>
+          void writer.commit({
+            expectedRevision: 0,
+            automations: [],
+            pendingFires: [pendingFire()],
+          }),
+        /has no definition/,
+      );
+      assert.throws(
+        () =>
+          void writer.commit({
+            expectedRevision: 0,
+            automations: [definitionWithPendingFire()],
+            pendingFires: [{ ...pendingFire(), prompt: 'Different prompt.' }],
+          }),
+        /contradicts its definition/,
+      );
+      assert.deepEqual(await writer.read(), { revision: 0, automations: [], pendingFires: [] });
+    });
+  });
+});
+
+function definition(): AutomationDefinition {
+  return {
+    id: 'automation-1',
+    kind: 'cron',
+    name: 'daily summary',
+    status: 'active',
+    prompt: 'Summarize the workspace.',
+    sessionId: 'creator-session',
+    schedule: { type: 'interval', seconds: 60 },
+    createdAt: 1,
+    updatedAt: 1,
+    nextFireAt: 60_001,
+    lastFireAt: null,
+    lastRunId: null,
+    fireCount: 0,
+    maxFires: null,
+    expiresAt: 604_800_001,
+    lastError: null,
+    consecutiveFailures: 0,
+    durable: true,
+    execution: {
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openrouter',
+      model: 'openrouter/free',
+      collaborationMode: 'agent',
+      orchestrationMode: 'default',
+    },
+  };
+}
+
+function definitionWithPendingFire(): AutomationDefinition {
+  return {
+    ...definition(),
+    updatedAt: 60_002,
+    nextFireAt: 120_002,
+    lastFireAt: 60_002,
+    fireCount: 1,
+  };
+}
+
+function pendingFire(): AutomationPendingFire {
+  return {
+    id: 'fire-1',
+    automationId: 'automation-1',
+    automationKind: 'cron',
+    automationName: 'daily summary',
+    prompt: 'Summarize the workspace.',
+    scheduledFor: 60_001,
+    targetSessionId: 'automation-session-1',
+    turnId: 'turn-1',
+    runId: 'run-1',
+    userMessageId: 'message-1',
+    status: 'admitted',
+    admittedAt: 60_002,
+    updatedAt: 60_002,
+    execution: {
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openrouter',
+      model: 'openrouter/free',
+      collaborationMode: 'agent',
+      orchestrationMode: 'default',
+    },
+  };
+}
+
+async function writeLegacy(
+  root: string,
+  automations: readonly AutomationDefinition[],
+): Promise<void> {
+  await writeFile(
+    join(root, 'automations.json'),
+    `${JSON.stringify({ version: 1, automations }, null, 2)}\n`,
+    'utf8',
+  );
+}
+
+async function withWriter(
+  run: (input: { writer: InteractiveAutomationAuthorityWriter }) => Promise<void>,
+): Promise<void> {
+  await withInteractiveRoot(async ({ capability }) => {
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    if (!owner) return;
+    const writer = await openInteractiveAutomationAuthorityForWrite(owner.lease);
+    try {
+      await run({ writer });
+    } finally {
+      writer.close();
+      if (!owner.closed) await owner.close();
+    }
+  });
+}
+
+async function withInteractiveRoot(
+  run: (input: {
+    root: string;
+    capability: Awaited<ReturnType<typeof resolveStorageRoot<'interactive'>>>;
+  }) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-automation-authority-'));
+  try {
+    const root = join(base, 'interactive');
+    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    await run({ root, capability });
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+function isInvalidLease(error: unknown): boolean {
+  return error instanceof StorageRootAuthorityError && error.code === 'invalid_lease';
+}

--- a/packages/storage/src/__tests__/claimed-agent-graph-root-admission.test.ts
+++ b/packages/storage/src/__tests__/claimed-agent-graph-root-admission.test.ts
@@ -143,7 +143,7 @@ describe('claimed agent graph root admission', () => {
               ],
             }),
           ),
-        /linked child execution cannot have source messages/,
+        /host-authored execution cannot have source messages/,
       );
       await assert.rejects(
         () =>

--- a/packages/storage/src/__tests__/operational-state-backup.test.ts
+++ b/packages/storage/src/__tests__/operational-state-backup.test.ts
@@ -65,6 +65,7 @@ test('backs up live WAL state and restores a writable relational closure', async
         content: 'second payload\n',
         now: 11,
       });
+      seedAutomationState(stateRoot, first.id);
       await writeFile(join(stateRoot, 'credentials.json'), 'secret-canary\n');
       await writeFile(join(stateRoot, 'settings.json'), 'settings-canary\n');
 
@@ -114,6 +115,12 @@ test('backs up live WAL state and restores a writable relational closure', async
       const restoredSessions = createSessionStore(restoreRoot);
       const restoredArtifacts = createSqliteArtifactStore(restoreRoot);
       try {
+        assert.deepEqual(readAutomationState(restoreRoot), {
+          revision: 1,
+          automationId: 'backup-automation',
+          name: 'Backup automation',
+          pendingFireId: 'backup-fire',
+        });
         assert.deepEqual(
           (await restoredSessions.list()).map((session) => session.id).sort(),
           [first.id, second.id].sort(),
@@ -155,6 +162,101 @@ test('backs up live WAL state and restores a writable relational closure', async
     }
   });
 });
+
+function seedAutomationState(root: string, sessionId: string): void {
+  const database = new DatabaseSync(join(root, 'runtime.sqlite'));
+  try {
+    const automation = {
+      id: 'backup-automation',
+      kind: 'heartbeat',
+      name: 'Backup automation',
+      status: 'active',
+      prompt: 'Preserve this Automation.',
+      sessionId,
+      schedule: { type: 'interval', seconds: 60 },
+      createdAt: 1,
+      updatedAt: 1,
+      nextFireAt: null,
+      lastFireAt: 60_001,
+      lastRunId: null,
+      fireCount: 1,
+      maxFires: null,
+      expiresAt: 604_800_001,
+      lastError: null,
+      consecutiveFailures: 0,
+    };
+    database
+      .prepare(`
+        INSERT INTO automation_definitions(
+          automation_id, session_id, created_at, status, durable, record_json
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        automation.id,
+        automation.sessionId,
+        automation.createdAt,
+        automation.status,
+        0,
+        JSON.stringify(automation),
+      );
+    const fire = {
+      id: 'backup-fire',
+      automationId: automation.id,
+      automationKind: automation.kind,
+      automationName: automation.name,
+      prompt: automation.prompt,
+      scheduledFor: 60_001,
+      targetSessionId: sessionId,
+      turnId: 'backup-turn',
+      runId: 'backup-run',
+      userMessageId: 'backup-message',
+      status: 'admitted',
+      admittedAt: 60_001,
+      updatedAt: 60_001,
+    };
+    database
+      .prepare(`
+        INSERT INTO automation_pending_fires(
+          fire_id, automation_id, target_session_id, admitted_at, record_json
+        ) VALUES (?, ?, ?, ?, ?)
+      `)
+      .run(fire.id, fire.automationId, fire.targetSessionId, fire.admittedAt, JSON.stringify(fire));
+    database
+      .prepare('UPDATE automation_authority_state SET revision = 1 WHERE singleton = 1')
+      .run();
+  } finally {
+    database.close();
+  }
+}
+
+function readAutomationState(root: string): {
+  revision: number;
+  automationId: string;
+  name: string;
+  pendingFireId: string;
+} {
+  const database = new DatabaseSync(join(root, 'runtime.sqlite'), { readOnly: true });
+  try {
+    const state = database
+      .prepare('SELECT revision FROM automation_authority_state WHERE singleton = 1')
+      .get() as { revision: number };
+    const row = database
+      .prepare('SELECT automation_id, record_json FROM automation_definitions')
+      .get() as { automation_id: string; record_json: string };
+    const fire = database.prepare('SELECT fire_id FROM automation_pending_fires').get() as {
+      fire_id: string;
+    };
+    const record = JSON.parse(row.record_json) as { name: string };
+    return {
+      revision: state.revision,
+      automationId: row.automation_id,
+      name: record.name,
+      pendingFireId: fire.fire_id,
+    };
+  } finally {
+    database.close();
+  }
+}
 
 test('linearizes an Artifact mutation after the backup snapshot', async () => {
   await withBackupRoots(async ({ stateRoot, backupRoot, restoreRoot }) => {

--- a/packages/storage/src/__tests__/operational-state-backup.test.ts
+++ b/packages/storage/src/__tests__/operational-state-backup.test.ts
@@ -19,11 +19,17 @@ import { DatabaseSync } from 'node:sqlite';
 import {
   createOperationalStateBackup,
   OPERATIONAL_BACKUP_MANIFEST_FILE,
+  OPERATIONAL_BACKUP_SCHEMA_VERSION,
   type OperationalBackupError,
   restoreOperationalStateBackup,
   validateOperationalStateBackup,
 } from '../operational-state-backup.js';
+import {
+  LEGACY_AUTOMATION_FILE,
+  openInteractiveAutomationAuthorityForWrite,
+} from '../automation-authority.js';
 import { createSqliteArtifactStore } from '../artifact-store.js';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '../root-authority.js';
 import { createSessionStore } from '../session-store.js';
 
 test('backs up live WAL state and restores a writable relational closure', async () => {
@@ -163,28 +169,147 @@ test('backs up live WAL state and restores a writable relational closure', async
   });
 });
 
+test('restores a writable Automation authority after a real legacy cutover', async () => {
+  await withBackupRoots(async ({ stateRoot, backupRoot, restoreRoot }) => {
+    const sessionId = await createSession(stateRoot);
+    const legacyAutomation = backupAutomationDefinition(sessionId);
+    await writeFile(
+      join(stateRoot, LEGACY_AUTOMATION_FILE),
+      `${JSON.stringify({ version: 1, automations: [legacyAutomation] }, null, 2)}\n`,
+    );
+
+    const sourceCapability = await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
+    const sourceOwner = await tryAcquireInteractiveRootOwner(sourceCapability);
+    assert.ok(sourceOwner);
+    if (!sourceOwner) return;
+    try {
+      const writer = await openInteractiveAutomationAuthorityForWrite(sourceOwner.lease);
+      assert.deepEqual(
+        (await writer.read()).automations.map((automation) => automation.id),
+        [legacyAutomation.id],
+      );
+      writer.close();
+    } finally {
+      if (!sourceOwner.closed) await sourceOwner.close();
+    }
+
+    const manifest = await createOperationalStateBackup({
+      stateRoot,
+      destinationRoot: backupRoot,
+    });
+    assert.equal(manifest.schemaVersion, OPERATIONAL_BACKUP_SCHEMA_VERSION);
+    assert.equal(
+      manifest.schemaVersion === OPERATIONAL_BACKUP_SCHEMA_VERSION
+        ? manifest.legacyAutomation?.path
+        : undefined,
+      LEGACY_AUTOMATION_FILE,
+    );
+    await restoreOperationalStateBackup({ backupRoot, destinationRoot: restoreRoot });
+
+    const restoredCapability = await resolveStorageRoot({
+      path: restoreRoot,
+      kind: 'interactive',
+    });
+    const restoredOwner = await tryAcquireInteractiveRootOwner(restoredCapability);
+    assert.ok(restoredOwner);
+    if (!restoredOwner) return;
+    try {
+      const writer = await openInteractiveAutomationAuthorityForWrite(restoredOwner.lease);
+      const restored = await writer.read();
+      assert.deepEqual(restored.pendingFires, []);
+      assert.equal(restored.automations[0]?.id, legacyAutomation.id);
+      const committed = await writer.commit({
+        expectedRevision: restored.revision,
+        automations: [{ ...restored.automations[0]!, name: 'Restored automation' }],
+        pendingFires: [],
+      });
+      assert.equal(committed.kind, 'committed');
+      assert.equal((await writer.read()).automations[0]?.name, 'Restored automation');
+      writer.close();
+    } finally {
+      if (!restoredOwner.closed) await restoredOwner.close();
+    }
+  });
+});
+
+test('restores a pre-Automation v1 backup into a writable current authority', async () => {
+  await withBackupRoots(async ({ stateRoot, backupRoot, restoreRoot }) => {
+    const sessionId = await createSession(stateRoot);
+    await createOperationalStateBackup({ stateRoot, destinationRoot: backupRoot });
+
+    const databasePath = join(backupRoot, 'runtime.sqlite');
+    const database = new DatabaseSync(databasePath);
+    try {
+      database.exec(`
+        DROP TABLE automation_pending_fires;
+        DROP TABLE automation_definitions;
+        DROP TABLE automation_authority_state;
+        DELETE FROM operational_schema_migrations WHERE scope = 'automation';
+      `);
+    } finally {
+      database.close();
+    }
+    const manifestPath = join(backupRoot, OPERATIONAL_BACKUP_MANIFEST_FILE);
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as Record<string, unknown> & {
+      database: { sizeBytes: number; sha256: string };
+    };
+    manifest.schemaVersion = 1;
+    delete manifest.legacyAutomation;
+    manifest.database.sizeBytes = (await stat(databasePath)).size;
+    manifest.database.sha256 = await hashFile(databasePath);
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    assert.equal((await validateOperationalStateBackup(backupRoot)).schemaVersion, 1);
+    await restoreOperationalStateBackup({ backupRoot, destinationRoot: restoreRoot });
+
+    const capability = await resolveStorageRoot({ path: restoreRoot, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    if (!owner) return;
+    try {
+      const writer = await openInteractiveAutomationAuthorityForWrite(owner.lease);
+      const restored = await writer.read();
+      assert.deepEqual(restored, { revision: 0, automations: [], pendingFires: [] });
+      const committed = await writer.commit({
+        expectedRevision: 0,
+        automations: [backupAutomationDefinition(sessionId)],
+        pendingFires: [],
+      });
+      assert.equal(committed.kind, 'committed');
+      assert.equal((await writer.read()).automations[0]?.id, 'backup-automation');
+      writer.close();
+    } finally {
+      if (!owner.closed) await owner.close();
+    }
+  });
+});
+
+function backupAutomationDefinition(sessionId: string) {
+  return {
+    id: 'backup-automation',
+    kind: 'heartbeat' as const,
+    name: 'Backup automation',
+    status: 'active' as const,
+    prompt: 'Preserve this Automation.',
+    sessionId,
+    schedule: { type: 'interval' as const, seconds: 60 },
+    createdAt: 1,
+    updatedAt: 1,
+    nextFireAt: null,
+    lastFireAt: 60_001,
+    lastRunId: null,
+    fireCount: 1,
+    maxFires: null,
+    expiresAt: 604_800_001,
+    lastError: null,
+    consecutiveFailures: 0,
+  };
+}
+
 function seedAutomationState(root: string, sessionId: string): void {
   const database = new DatabaseSync(join(root, 'runtime.sqlite'));
   try {
-    const automation = {
-      id: 'backup-automation',
-      kind: 'heartbeat',
-      name: 'Backup automation',
-      status: 'active',
-      prompt: 'Preserve this Automation.',
-      sessionId,
-      schedule: { type: 'interval', seconds: 60 },
-      createdAt: 1,
-      updatedAt: 1,
-      nextFireAt: null,
-      lastFireAt: 60_001,
-      lastRunId: null,
-      fireCount: 1,
-      maxFires: null,
-      expiresAt: 604_800_001,
-      lastError: null,
-      consecutiveFailures: 0,
-    };
+    const automation = backupAutomationDefinition(sessionId);
     database
       .prepare(`
         INSERT INTO automation_definitions(
@@ -358,6 +483,31 @@ test('fails the whole backup when a transcript changes across the SQLite snapsho
   });
 });
 
+test('fails the whole backup when a legacy Automation source appears after its snapshot', async () => {
+  await withBackupRoots(async ({ stateRoot, backupRoot }) => {
+    const sessionId = await createSession(stateRoot);
+
+    await assertBackupError(
+      createOperationalStateBackup({
+        stateRoot,
+        destinationRoot: backupRoot,
+        failpoint: async (point) => {
+          if (point !== 'after_database_snapshot') return;
+          await writeFile(
+            join(stateRoot, LEGACY_AUTOMATION_FILE),
+            `${JSON.stringify({
+              version: 1,
+              automations: [backupAutomationDefinition(sessionId)],
+            })}\n`,
+          );
+        },
+      }),
+      'source_changed',
+    );
+    await assert.rejects(lstat(backupRoot), { code: 'ENOENT' });
+  });
+});
+
 test('rejects a corrupt source transcript instead of preserving unreadable state', async () => {
   await withBackupRoots(async ({ stateRoot, backupRoot }) => {
     const sessionId = await createSession(stateRoot);
@@ -371,6 +521,51 @@ test('rejects a corrupt source transcript instead of preserving unreadable state
       'corrupt_backup',
     );
     await assert.rejects(lstat(backupRoot), { code: 'ENOENT' });
+  });
+});
+
+test('rejects an invalid legacy Automation source instead of preserving unreadable state', async () => {
+  await withBackupRoots(async ({ stateRoot, backupRoot }) => {
+    await createSession(stateRoot);
+    await writeFile(join(stateRoot, LEGACY_AUTOMATION_FILE), '{"version":2,"automations":[]}\n');
+
+    await assertBackupError(
+      createOperationalStateBackup({ stateRoot, destinationRoot: backupRoot }),
+      'corrupt_backup',
+    );
+    await assert.rejects(lstat(backupRoot), { code: 'ENOENT' });
+  });
+});
+
+test('rejects a digest-matching invalid legacy Automation backup before restore', async () => {
+  await withBackupRoots(async ({ stateRoot, backupRoot, restoreRoot }) => {
+    const sessionId = await createSession(stateRoot);
+    const legacyPath = join(stateRoot, LEGACY_AUTOMATION_FILE);
+    await writeFile(
+      legacyPath,
+      `${JSON.stringify({
+        version: 1,
+        automations: [backupAutomationDefinition(sessionId)],
+      })}\n`,
+    );
+    await createOperationalStateBackup({ stateRoot, destinationRoot: backupRoot });
+
+    const backupLegacyPath = join(backupRoot, LEGACY_AUTOMATION_FILE);
+    await writeFile(backupLegacyPath, '{"version":2,"automations":[]}\n');
+    const manifestPath = join(backupRoot, OPERATIONAL_BACKUP_MANIFEST_FILE);
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as {
+      legacyAutomation: { sizeBytes: number; sha256: string };
+    };
+    manifest.legacyAutomation.sizeBytes = (await stat(backupLegacyPath)).size;
+    manifest.legacyAutomation.sha256 = await hashFile(backupLegacyPath);
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    await assertBackupError(validateOperationalStateBackup(backupRoot), 'corrupt_backup');
+    await assertBackupError(
+      restoreOperationalStateBackup({ backupRoot, destinationRoot: restoreRoot }),
+      'corrupt_backup',
+    );
+    await assert.rejects(lstat(restoreRoot), { code: 'ENOENT' });
   });
 });
 

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -75,6 +75,7 @@ describe('operational state database cutover', () => {
           .map((row) => ({ ...row })),
         [
           { scope: 'artifact', version: 1 },
+          { scope: 'automation', version: 1 },
           { scope: 'core_execution', version: 1 },
           { scope: 'operational', version: 1 },
           { scope: 'runtime', version: SQLITE_RUNTIME_SCHEMA_VERSION },

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -2874,7 +2874,7 @@ function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
   }
   if (execution.kind !== 'external_message' && admission.sourceMessages.length !== 0) {
     throw new Error(
-      'Invalid root turn admission contract: linked child execution cannot have source messages',
+      'Invalid root turn admission contract: host-authored execution cannot have source messages',
     );
   }
   if (execution.kind === 'claimed_agent_graph_intent') {
@@ -2936,6 +2936,16 @@ function normalizeRootExecutionDescriptor(value: unknown): RootExecutionDescript
   if (value.kind === 'external_message') {
     if (!hasExactKeys(value, ['kind'])) throw new Error('Invalid root execution descriptor');
     return Object.freeze({ kind: 'external_message' });
+  }
+  if (value.kind === 'automation') {
+    if (
+      !hasExactKeys(value, ['kind', 'automationId']) ||
+      typeof value.automationId !== 'string' ||
+      !isSafeId(value.automationId)
+    ) {
+      throw new Error('Invalid root execution descriptor');
+    }
+    return Object.freeze({ kind: 'automation', automationId: value.automationId });
   }
   if (value.kind === 'claimed_agent_graph_intent') {
     if (

--- a/packages/storage/src/automation-authority.ts
+++ b/packages/storage/src/automation-authority.ts
@@ -1,0 +1,752 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { isCollaborationMode } from '@maka/core/collaboration';
+import { isOrchestrationMode } from '@maka/core/orchestration';
+import { isThinkingLevel } from '@maka/core/model-thinking';
+import {
+  AUTOMATION_CRON_EXPRESSION_LIMIT,
+  AUTOMATION_LAST_ERROR_LIMIT,
+  AUTOMATION_NAME_LIMIT,
+  AUTOMATION_PROMPT_LIMIT,
+  isAutomationTextWithinLimit,
+  truncateAutomationText,
+  type AutomationAuthoritySnapshot,
+  type AutomationDefinition,
+  type AutomationExecutionTemplate,
+  type AutomationPendingFire,
+  type AutomationSchedule,
+} from '@maka/core/automation';
+import {
+  completeOperationalStoreCutover,
+  acquireOperationalStateDatabase,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
+import {
+  assertStorageRootLease,
+  runWithStorageRootLease,
+  StorageRootAuthorityError,
+  type StorageRootLease,
+} from './root-authority.js';
+
+const LEGACY_AUTOMATION_FILE = 'automations.json';
+const MAX_AUTOMATIONS = 10_000;
+const MAX_PENDING_FIRES = 10_000;
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const DEFINITION_KEYS = new Set([
+  'id',
+  'kind',
+  'name',
+  'status',
+  'prompt',
+  'sessionId',
+  'schedule',
+  'createdAt',
+  'updatedAt',
+  'nextFireAt',
+  'lastFireAt',
+  'lastRunId',
+  'fireCount',
+  'maxFires',
+  'expiresAt',
+  'lastError',
+  'consecutiveFailures',
+  'durable',
+  'deferredFireCount',
+  'execution',
+]);
+const PENDING_FIRE_KEYS = new Set([
+  'id',
+  'automationId',
+  'automationKind',
+  'automationName',
+  'prompt',
+  'scheduledFor',
+  'targetSessionId',
+  'turnId',
+  'runId',
+  'userMessageId',
+  'status',
+  'admittedAt',
+  'updatedAt',
+  'startedAt',
+  'execution',
+]);
+
+const writerBrand: unique symbol = Symbol('InteractiveAutomationAuthorityWriter');
+const writers = new WeakSet<object>();
+const writerByLease = new WeakMap<object, InteractiveAutomationAuthorityWriter>();
+const writerOpeningByLease = new WeakMap<object, Promise<InteractiveAutomationAuthorityWriter>>();
+
+export interface CommitAutomationAuthorityInput {
+  readonly expectedRevision: number;
+  readonly automations: readonly AutomationDefinition[];
+  readonly pendingFires: readonly AutomationPendingFire[];
+}
+
+export type CommitAutomationAuthorityResult =
+  | { readonly kind: 'committed'; readonly snapshot: AutomationAuthoritySnapshot }
+  | { readonly kind: 'revision_conflict'; readonly actualRevision: number };
+
+export interface InteractiveAutomationAuthorityWriter {
+  readonly kind: 'interactive';
+  readonly access: 'write';
+  readonly [writerBrand]: true;
+  read(): Promise<AutomationAuthoritySnapshot>;
+  commit(input: CommitAutomationAuthorityInput): Promise<CommitAutomationAuthorityResult>;
+  close(): void;
+}
+
+export interface OpenAutomationAuthorityOptions {
+  readonly failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export function authenticateInteractiveAutomationAuthorityWriter(
+  writer: InteractiveAutomationAuthorityWriter,
+): InteractiveAutomationAuthorityWriter {
+  if (!writers.has(writer)) {
+    throw new StorageRootAuthorityError(
+      'invalid_lease',
+      'Expected an authentic interactive Automation authority writer',
+    );
+  }
+  return writer;
+}
+
+export async function openInteractiveAutomationAuthorityForWrite(
+  lease: StorageRootLease<'interactive', 'write'>,
+  options: OpenAutomationAuthorityOptions = {},
+): Promise<InteractiveAutomationAuthorityWriter> {
+  await assertStorageRootLease(lease, 'interactive', 'write');
+  const existing = writerByLease.get(lease);
+  if (existing) return existing;
+  const opening = writerOpeningByLease.get(lease);
+  if (opening) return opening;
+
+  const pending = Promise.resolve().then(async () => {
+    let store: SqliteAutomationAuthority | undefined;
+    try {
+      store = await runWithStorageRootLease(lease, 'interactive', 'write', async (root) => {
+        const opened = new SqliteAutomationAuthority(root, options);
+        await opened.ready();
+        return opened;
+      });
+      await assertStorageRootLease(lease, 'interactive', 'write');
+      const recoveredExisting = writerByLease.get(lease);
+      if (recoveredExisting) {
+        store.close();
+        return recoveredExisting;
+      }
+      const writer = createWriterFacade(lease, store);
+      writers.add(writer);
+      writerByLease.set(lease, writer);
+      return writer;
+    } catch (error) {
+      store?.close();
+      throw error;
+    }
+  });
+  writerOpeningByLease.set(lease, pending);
+  try {
+    return await pending;
+  } finally {
+    if (writerOpeningByLease.get(lease) === pending) writerOpeningByLease.delete(lease);
+  }
+}
+
+function createWriterFacade(
+  lease: StorageRootLease<'interactive', 'write'>,
+  store: SqliteAutomationAuthority,
+): InteractiveAutomationAuthorityWriter {
+  let closed = false;
+  const run = <T>(operation: () => T | Promise<T>): Promise<T> => {
+    if (closed) {
+      return Promise.reject(
+        new StorageRootAuthorityError('invalid_lease', 'Automation authority writer is closed'),
+      );
+    }
+    return runWithStorageRootLease(lease, 'interactive', 'write', async () => operation());
+  };
+  const writer: InteractiveAutomationAuthorityWriter = {
+    kind: 'interactive',
+    access: 'write',
+    [writerBrand]: true,
+    read: () => run(() => store.read()),
+    commit: (input) => {
+      const accepted = normalizeCommitInput(input);
+      return run(() => store.commit(accepted));
+    },
+    close: () => {
+      if (closed) return;
+      closed = true;
+      if (writerByLease.get(lease) === writer) writerByLease.delete(lease);
+      writers.delete(writer);
+      store.close();
+    },
+  };
+  return Object.freeze(writer);
+}
+
+class SqliteAutomationAuthority {
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #ready: Promise<void>;
+
+  constructor(root: string, options: OpenAutomationAuthorityOptions) {
+    this.#lease = acquireOperationalStateDatabase(root);
+    this.#ready = importLegacyAutomations(root, this.#lease, options);
+  }
+
+  ready(): Promise<void> {
+    return this.#ready;
+  }
+
+  read(): AutomationAuthoritySnapshot {
+    const revision = readRevision(this.#lease);
+    const automations = this.#lease.database
+      .prepare(`
+        SELECT automation_id, session_id, created_at, status, durable, record_json
+        FROM automation_definitions
+        ORDER BY created_at, automation_id
+      `)
+      .all()
+      .map((row) => readDefinitionRow(row));
+    const pendingFires = this.#lease.database
+      .prepare(`
+        SELECT fire_id, automation_id, target_session_id, admitted_at, record_json
+        FROM automation_pending_fires
+        ORDER BY admitted_at, fire_id
+      `)
+      .all()
+      .map((row) => readPendingFireRow(row));
+    assertSnapshotRelationships(automations, pendingFires);
+    return cloneSnapshot({ revision, automations, pendingFires });
+  }
+
+  commit(input: CommitAutomationAuthorityInput): CommitAutomationAuthorityResult {
+    return this.#lease.transaction('write', () => {
+      const actualRevision = readRevision(this.#lease);
+      if (actualRevision !== input.expectedRevision) {
+        return { kind: 'revision_conflict', actualRevision };
+      }
+      const existingDefinitions = new Map(
+        this.#lease.database
+          .prepare('SELECT automation_id, record_json FROM automation_definitions')
+          .all()
+          .map((row) => readRecordJsonIndexRow(row, 'automation_id')),
+      );
+      const existingFires = new Map(
+        this.#lease.database
+          .prepare('SELECT fire_id, record_json FROM automation_pending_fires')
+          .all()
+          .map((row) => readRecordJsonIndexRow(row, 'fire_id')),
+      );
+      const desiredDefinitionIds = new Set(input.automations.map((automation) => automation.id));
+      const desiredFireIds = new Set(input.pendingFires.map((fire) => fire.id));
+      const deleteFire = this.#lease.database.prepare(
+        'DELETE FROM automation_pending_fires WHERE fire_id = ?',
+      );
+      for (const fireId of existingFires.keys()) {
+        if (!desiredFireIds.has(fireId)) deleteFire.run(fireId);
+      }
+      const deleteDefinition = this.#lease.database.prepare(
+        'DELETE FROM automation_definitions WHERE automation_id = ?',
+      );
+      for (const automationId of existingDefinitions.keys()) {
+        if (!desiredDefinitionIds.has(automationId)) deleteDefinition.run(automationId);
+      }
+      const upsertDefinition = this.#lease.database.prepare(`
+        INSERT INTO automation_definitions(
+          automation_id, session_id, created_at, status, durable, record_json
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(automation_id) DO UPDATE SET
+          session_id = excluded.session_id,
+          created_at = excluded.created_at,
+          status = excluded.status,
+          durable = excluded.durable,
+          record_json = excluded.record_json
+      `);
+      for (const automation of input.automations) {
+        const encoded = JSON.stringify(automation);
+        if (existingDefinitions.get(automation.id) === encoded) continue;
+        upsertDefinition.run(
+          automation.id,
+          automation.sessionId,
+          automation.createdAt,
+          automation.status,
+          automation.durable === true ? 1 : 0,
+          encoded,
+        );
+      }
+      const changedFires = input.pendingFires
+        .map((fire) => ({ fire, encoded: JSON.stringify(fire) }))
+        .filter(({ fire, encoded }) => existingFires.get(fire.id) !== encoded);
+      for (const { fire } of changedFires) {
+        if (existingFires.has(fire.id)) deleteFire.run(fire.id);
+      }
+      const insertFire = this.#lease.database.prepare(`
+        INSERT INTO automation_pending_fires(
+          fire_id, automation_id, target_session_id, admitted_at, record_json
+        ) VALUES (?, ?, ?, ?, ?)
+      `);
+      for (const { fire, encoded } of changedFires) {
+        insertFire.run(fire.id, fire.automationId, fire.targetSessionId, fire.admittedAt, encoded);
+      }
+      const revision = actualRevision + 1;
+      const updated = this.#lease.database
+        .prepare('UPDATE automation_authority_state SET revision = ? WHERE singleton = 1')
+        .run(revision);
+      if (updated.changes !== 1) throw new Error('Unable to advance Automation revision');
+      return {
+        kind: 'committed',
+        snapshot: cloneSnapshot({
+          revision,
+          automations: input.automations,
+          pendingFires: input.pendingFires,
+        }),
+      };
+    });
+  }
+
+  close(): void {
+    this.#lease.close();
+  }
+}
+
+async function importLegacyAutomations(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  options: OpenAutomationAuthorityOptions,
+): Promise<void> {
+  const sourcePath = join(root, LEGACY_AUTOMATION_FILE);
+  const source = await readLegacyAutomationFile(sourcePath);
+  completeOperationalStoreCutover(lease, {
+    storeName: 'automations',
+    sourcePath,
+    sourceFingerprint: source.fingerprint,
+    ...(options.failpoint ? { failpoint: options.failpoint } : {}),
+    importAndValidate: (database) => {
+      const insert = database.prepare(`
+        INSERT OR IGNORE INTO automation_definitions(
+          automation_id, session_id, created_at, status, durable, record_json
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `);
+      for (const automation of source.automations) {
+        const encoded = JSON.stringify(automation);
+        const result = insert.run(
+          automation.id,
+          automation.sessionId,
+          automation.createdAt,
+          automation.status,
+          automation.durable === true ? 1 : 0,
+          encoded,
+        );
+        if (result.changes === 0) {
+          const row = database
+            .prepare('SELECT record_json FROM automation_definitions WHERE automation_id = ?')
+            .get(automation.id) as { record_json?: unknown } | undefined;
+          if (!row || row.record_json !== encoded) {
+            throw new Error(`Automation cutover conflict: ${automation.id}`);
+          }
+        }
+      }
+      if (source.automations.length > 0) {
+        database
+          .prepare(`
+            UPDATE automation_authority_state
+            SET revision = CASE WHEN revision = 0 THEN 1 ELSE revision END
+            WHERE singleton = 1
+          `)
+          .run();
+      }
+      return { automations: source.automations.length };
+    },
+  });
+}
+
+async function readLegacyAutomationFile(
+  path: string,
+): Promise<{ fingerprint: string; automations: readonly AutomationDefinition[] }> {
+  let contents: string;
+  try {
+    contents = await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {
+        fingerprint: `sha256:${createHash('sha256').update('absent').digest('hex')}`,
+        automations: [],
+      };
+    }
+    throw error;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (error) {
+    throw new Error('Legacy Automation store is not valid JSON', { cause: error });
+  }
+  if (!isRecord(parsed) || parsed.version !== 1 || !Array.isArray(parsed.automations)) {
+    throw new Error('Legacy Automation store has an unsupported shape or version');
+  }
+  if (parsed.automations.length > MAX_AUTOMATIONS) {
+    throw new Error('Legacy Automation store exceeds the definition limit');
+  }
+  const automations = parsed.automations.map((automation) =>
+    normalizeAutomationDefinition(automation, { legacy: true }),
+  );
+  assertUnique(
+    automations.map((automation) => automation.id),
+    'Automation id',
+  );
+  return {
+    fingerprint: `sha256:${createHash('sha256').update(contents).digest('hex')}`,
+    automations,
+  };
+}
+
+function normalizeCommitInput(
+  input: CommitAutomationAuthorityInput,
+): CommitAutomationAuthorityInput {
+  if (!isNonnegativeInteger(input.expectedRevision)) {
+    throw new Error('Expected Automation revision must be a non-negative integer');
+  }
+  if (!Array.isArray(input.automations) || input.automations.length > MAX_AUTOMATIONS) {
+    throw new Error('Automation definitions exceed the authority limit');
+  }
+  if (!Array.isArray(input.pendingFires) || input.pendingFires.length > MAX_PENDING_FIRES) {
+    throw new Error('Pending Automation fires exceed the authority limit');
+  }
+  const automations = input.automations.map((automation) =>
+    normalizeAutomationDefinition(automation),
+  );
+  const pendingFires = input.pendingFires.map(normalizePendingFire);
+  assertUnique(
+    automations.map((automation) => automation.id),
+    'Automation id',
+  );
+  assertUnique(
+    pendingFires.map((fire) => fire.id),
+    'Automation fire id',
+  );
+  assertUnique(
+    pendingFires.map((fire) => fire.automationId),
+    'pending Automation id',
+  );
+  assertSnapshotRelationships(automations, pendingFires);
+  return { expectedRevision: input.expectedRevision, automations, pendingFires };
+}
+
+function assertSnapshotRelationships(
+  automations: readonly AutomationDefinition[],
+  pendingFires: readonly AutomationPendingFire[],
+): void {
+  const definitions = new Map(automations.map((automation) => [automation.id, automation]));
+  for (const fire of pendingFires) {
+    const automation = definitions.get(fire.automationId);
+    if (!automation) {
+      throw new Error(`Pending Automation fire has no definition: ${fire.id}`);
+    }
+    if (
+      automation.kind !== fire.automationKind ||
+      automation.name !== fire.automationName ||
+      automation.prompt !== fire.prompt ||
+      automation.fireCount === 0 ||
+      automation.lastFireAt === null ||
+      automation.lastFireAt > fire.admittedAt ||
+      (automation.kind === 'heartbeat' && automation.sessionId !== fire.targetSessionId) ||
+      (automation.kind === 'cron' &&
+        JSON.stringify(automation.execution) !== JSON.stringify(fire.execution))
+    ) {
+      throw new Error(`Pending Automation fire contradicts its definition: ${fire.id}`);
+    }
+  }
+}
+
+function normalizeAutomationDefinition(
+  value: unknown,
+  options: { readonly legacy?: boolean } = {},
+): AutomationDefinition {
+  if (!isRecord(value) || !hasOnlyKeys(value, DEFINITION_KEYS)) {
+    throw new Error('Invalid Automation definition');
+  }
+  const schedule = normalizeSchedule(value.schedule);
+  const execution =
+    value.execution === undefined ? undefined : normalizeExecutionTemplate(value.execution);
+  if (!isId(value.id) || !isId(value.sessionId)) throw new Error('Invalid Automation identity');
+  if (value.kind !== 'heartbeat' && value.kind !== 'cron') {
+    throw new Error('Invalid Automation kind');
+  }
+  if (
+    (value.status !== 'active' &&
+      value.status !== 'paused' &&
+      value.status !== 'completed' &&
+      value.status !== 'expired') ||
+    !isAutomationTextWithinLimit(value.name, AUTOMATION_NAME_LIMIT, { nonblank: true }) ||
+    !isAutomationTextWithinLimit(value.prompt, AUTOMATION_PROMPT_LIMIT, { nonblank: true })
+  ) {
+    throw new Error('Invalid Automation state');
+  }
+  const lastError = normalizeLastError(value.lastError, options.legacy === true);
+  if (
+    !isNonnegativeInteger(value.createdAt) ||
+    !isNonnegativeInteger(value.updatedAt) ||
+    !isNullableNonnegativeInteger(value.nextFireAt) ||
+    !isNullableNonnegativeInteger(value.lastFireAt) ||
+    !(value.lastRunId === null || isId(value.lastRunId)) ||
+    !isNonnegativeInteger(value.fireCount) ||
+    !(value.maxFires === null || (isNonnegativeInteger(value.maxFires) && value.maxFires > 0)) ||
+    !isNullableNonnegativeInteger(value.expiresAt) ||
+    lastError === undefined ||
+    !isNonnegativeInteger(value.consecutiveFailures) ||
+    !(value.durable === undefined || typeof value.durable === 'boolean') ||
+    !(value.deferredFireCount === undefined || isNonnegativeInteger(value.deferredFireCount))
+  ) {
+    throw new Error('Invalid Automation counters or timestamps');
+  }
+  if (execution && value.kind !== 'cron') {
+    throw new Error('Only cron Automations may carry an execution template');
+  }
+  return structuredClone({
+    id: value.id,
+    kind: value.kind,
+    name: value.name,
+    status: value.status,
+    prompt: value.prompt,
+    sessionId: value.sessionId,
+    schedule,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+    nextFireAt: value.nextFireAt,
+    lastFireAt: value.lastFireAt,
+    lastRunId: value.lastRunId,
+    fireCount: value.fireCount,
+    maxFires: value.maxFires,
+    expiresAt: value.expiresAt,
+    lastError,
+    consecutiveFailures: value.consecutiveFailures,
+    ...(value.durable === undefined ? {} : { durable: value.durable }),
+    ...(value.deferredFireCount === undefined
+      ? {}
+      : { deferredFireCount: value.deferredFireCount }),
+    ...(execution ? { execution } : {}),
+  } satisfies AutomationDefinition);
+}
+
+function normalizePendingFire(value: unknown): AutomationPendingFire {
+  if (!isRecord(value) || !hasOnlyKeys(value, PENDING_FIRE_KEYS)) {
+    throw new Error('Invalid pending Automation fire');
+  }
+  if (
+    !isId(value.id) ||
+    !isId(value.automationId) ||
+    !isId(value.targetSessionId) ||
+    !isId(value.turnId) ||
+    !isId(value.runId) ||
+    !isId(value.userMessageId) ||
+    (value.automationKind !== 'heartbeat' && value.automationKind !== 'cron') ||
+    !isAutomationTextWithinLimit(value.automationName, AUTOMATION_NAME_LIMIT, {
+      nonblank: true,
+    }) ||
+    !isAutomationTextWithinLimit(value.prompt, AUTOMATION_PROMPT_LIMIT, { nonblank: true }) ||
+    !isNonnegativeInteger(value.scheduledFor) ||
+    !isNonnegativeInteger(value.admittedAt) ||
+    !isNonnegativeInteger(value.updatedAt) ||
+    (value.status !== 'admitted' && value.status !== 'running')
+  ) {
+    throw new Error('Invalid pending Automation fire state');
+  }
+  const startedAt =
+    value.startedAt === undefined ? undefined : requireNonnegativeInteger(value.startedAt);
+  if ((value.status === 'running') !== (startedAt !== undefined)) {
+    throw new Error('Pending Automation fire start state is inconsistent');
+  }
+  const execution =
+    value.execution === undefined ? undefined : normalizeExecutionTemplate(value.execution);
+  if ((value.automationKind === 'cron') !== (execution !== undefined)) {
+    throw new Error('Pending cron fire must freeze its execution template');
+  }
+  return structuredClone({
+    id: value.id,
+    automationId: value.automationId,
+    automationKind: value.automationKind,
+    automationName: value.automationName,
+    prompt: value.prompt,
+    scheduledFor: value.scheduledFor,
+    targetSessionId: value.targetSessionId,
+    turnId: value.turnId,
+    runId: value.runId,
+    userMessageId: value.userMessageId,
+    status: value.status,
+    admittedAt: value.admittedAt,
+    updatedAt: value.updatedAt,
+    ...(startedAt === undefined ? {} : { startedAt }),
+    ...(execution ? { execution } : {}),
+  } satisfies AutomationPendingFire);
+}
+
+function normalizeSchedule(value: unknown): AutomationSchedule {
+  if (!isRecord(value)) throw new Error('Invalid Automation schedule');
+  if (
+    value.type === 'cron' &&
+    hasOnlyKeys(value, new Set(['type', 'expression'])) &&
+    isAutomationTextWithinLimit(value.expression, AUTOMATION_CRON_EXPRESSION_LIMIT)
+  ) {
+    return { type: 'cron', expression: value.expression };
+  }
+  if (
+    value.type === 'interval' &&
+    hasOnlyKeys(value, new Set(['type', 'seconds'])) &&
+    isNonnegativeInteger(value.seconds) &&
+    value.seconds >= 10 &&
+    value.seconds <= 86_400
+  ) {
+    return { type: 'interval', seconds: value.seconds };
+  }
+  if (
+    value.type === 'once' &&
+    hasOnlyKeys(value, new Set(['type', 'delaySeconds'])) &&
+    isNonnegativeInteger(value.delaySeconds) &&
+    value.delaySeconds >= 5 &&
+    value.delaySeconds <= 86_400
+  ) {
+    return { type: 'once', delaySeconds: value.delaySeconds };
+  }
+  throw new Error('Invalid Automation schedule');
+}
+
+function normalizeExecutionTemplate(value: unknown): AutomationExecutionTemplate {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(
+      value,
+      new Set([
+        'cwd',
+        'projectId',
+        'backend',
+        'llmConnectionSlug',
+        'model',
+        'thinkingLevel',
+        'collaborationMode',
+        'orchestrationMode',
+      ]),
+    ) ||
+    !isBoundedString(value.cwd, 4_096) ||
+    !(value.projectId === undefined || value.projectId === null || isId(value.projectId)) ||
+    (value.backend !== 'ai-sdk' && value.backend !== 'fake' && value.backend !== 'pi-agent') ||
+    !isId(value.llmConnectionSlug) ||
+    !isBoundedString(value.model, 256) ||
+    !(value.thinkingLevel === undefined || isThinkingLevel(value.thinkingLevel)) ||
+    !isCollaborationMode(value.collaborationMode) ||
+    !isOrchestrationMode(value.orchestrationMode)
+  ) {
+    throw new Error('Invalid Automation execution template');
+  }
+  return {
+    cwd: value.cwd,
+    ...(value.projectId === undefined ? {} : { projectId: value.projectId }),
+    backend: value.backend,
+    llmConnectionSlug: value.llmConnectionSlug,
+    model: value.model,
+    ...(value.thinkingLevel === undefined ? {} : { thinkingLevel: value.thinkingLevel }),
+    collaborationMode: value.collaborationMode,
+    orchestrationMode: value.orchestrationMode,
+  };
+}
+
+function readDefinitionRow(value: unknown): AutomationDefinition {
+  if (!isRecord(value) || typeof value.record_json !== 'string') {
+    throw new Error('Invalid SQLite Automation definition row');
+  }
+  const definition = normalizeAutomationDefinition(JSON.parse(value.record_json));
+  if (
+    value.automation_id !== definition.id ||
+    value.session_id !== definition.sessionId ||
+    value.created_at !== definition.createdAt ||
+    value.status !== definition.status ||
+    value.durable !== (definition.durable === true ? 1 : 0)
+  ) {
+    throw new Error(`SQLite Automation definition index mismatch: ${definition.id}`);
+  }
+  return definition;
+}
+
+function readPendingFireRow(value: unknown): AutomationPendingFire {
+  if (!isRecord(value) || typeof value.record_json !== 'string') {
+    throw new Error('Invalid SQLite pending Automation fire row');
+  }
+  const fire = normalizePendingFire(JSON.parse(value.record_json));
+  if (
+    value.fire_id !== fire.id ||
+    value.automation_id !== fire.automationId ||
+    value.target_session_id !== fire.targetSessionId ||
+    value.admitted_at !== fire.admittedAt
+  ) {
+    throw new Error(`SQLite pending Automation fire index mismatch: ${fire.id}`);
+  }
+  return fire;
+}
+
+function readRevision(lease: OperationalStateDatabaseLease): number {
+  const row = lease.database
+    .prepare('SELECT revision FROM automation_authority_state WHERE singleton = 1')
+    .get() as { revision?: unknown } | undefined;
+  if (!row || !isNonnegativeInteger(row.revision)) {
+    throw new Error('Invalid Automation authority revision');
+  }
+  return row.revision;
+}
+
+function cloneSnapshot(snapshot: AutomationAuthoritySnapshot): AutomationAuthoritySnapshot {
+  return structuredClone(snapshot);
+}
+
+function readRecordJsonIndexRow(
+  value: unknown,
+  key: 'automation_id' | 'fire_id',
+): readonly [string, string] {
+  if (!isRecord(value) || typeof value[key] !== 'string' || typeof value.record_json !== 'string') {
+    throw new Error('Invalid SQLite Automation index row');
+  }
+  return [value[key], value.record_json];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: ReadonlySet<string>): boolean {
+  return Object.keys(value).every((key) => keys.has(key));
+}
+
+function isId(value: unknown): value is string {
+  return typeof value === 'string' && ID_PATTERN.test(value);
+}
+
+function isBoundedString(value: unknown, max: number): value is string {
+  return typeof value === 'string' && value.length > 0 && Buffer.byteLength(value, 'utf8') <= max;
+}
+
+function normalizeLastError(value: unknown, legacy: boolean): string | null | undefined {
+  if (value === null) return null;
+  if (legacy && value === '') return null;
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  if (legacy) return truncateAutomationText(value, AUTOMATION_LAST_ERROR_LIMIT);
+  return isAutomationTextWithinLimit(value, AUTOMATION_LAST_ERROR_LIMIT) ? value : undefined;
+}
+
+function isNonnegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function isNullableNonnegativeInteger(value: unknown): value is number | null {
+  return value === null || isNonnegativeInteger(value);
+}
+
+function requireNonnegativeInteger(value: unknown): number {
+  if (!isNonnegativeInteger(value)) throw new Error('Expected a non-negative integer');
+  return value;
+}
+
+function assertUnique(values: readonly string[], label: string): void {
+  if (new Set(values).size !== values.length) throw new Error(`Duplicate ${label}`);
+}

--- a/packages/storage/src/automation-authority.ts
+++ b/packages/storage/src/automation-authority.ts
@@ -30,7 +30,7 @@ import {
   type StorageRootLease,
 } from './root-authority.js';
 
-const LEGACY_AUTOMATION_FILE = 'automations.json';
+export const LEGACY_AUTOMATION_FILE = 'automations.json';
 const MAX_AUTOMATIONS = 10_000;
 const MAX_PENDING_FIRES = 10_000;
 const ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
@@ -379,6 +379,13 @@ async function readLegacyAutomationFile(
     }
     throw error;
   }
+  return {
+    fingerprint: `sha256:${createHash('sha256').update(contents).digest('hex')}`,
+    automations: decodeLegacyAutomationFile(contents),
+  };
+}
+
+export function decodeLegacyAutomationFile(contents: string): readonly AutomationDefinition[] {
   let parsed: unknown;
   try {
     parsed = JSON.parse(contents);
@@ -398,10 +405,7 @@ async function readLegacyAutomationFile(
     automations.map((automation) => automation.id),
     'Automation id',
   );
-  return {
-    fingerprint: `sha256:${createHash('sha256').update(contents).digest('hex')}`,
-    automations,
-  };
+  return automations;
 }
 
 function normalizeCommitInput(

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -132,6 +132,7 @@ export type {
 } from './deep-research-store.js';
 export * from './config-transfer.js';
 export * from './automation-store.js';
+export * from './automation-authority.js';
 export * from './sqlite-runtime-store.js';
 export * from './runtime-event-transfer.js';
 export * from './operational-state-store.js';

--- a/packages/storage/src/operational-state-backup.ts
+++ b/packages/storage/src/operational-state-backup.ts
@@ -17,6 +17,7 @@ import { createRequire } from 'node:module';
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import type { ArtifactRecord } from '@maka/core/artifacts';
+import { decodeLegacyAutomationFile, LEGACY_AUTOMATION_FILE } from './automation-authority.js';
 import { decodeArtifactMetadata } from './artifact-metadata-codec.js';
 import {
   ARTIFACT_PUBLICATION_STAGING_PATTERN,
@@ -43,10 +44,11 @@ import { SQLITE_WORKFLOW_SCHEMA_VERSION } from './sqlite-workflow-schema.js';
 import { syncDirectory, syncDirectoryChain, syncFile } from './stable-storage.js';
 
 export const OPERATIONAL_BACKUP_FORMAT = 'maka-operational-backup';
-export const OPERATIONAL_BACKUP_SCHEMA_VERSION = 1 as const;
+export const OPERATIONAL_BACKUP_SCHEMA_VERSION = 2 as const;
 export const OPERATIONAL_BACKUP_MANIFEST_FILE = 'operational-backup.json';
 
 const MAX_MANIFEST_BYTES = 64 * 1024 * 1024;
+const LEGACY_OPERATIONAL_BACKUP_SCHEMA_VERSION = 1 as const;
 const require = createRequire(import.meta.url);
 const supportedSchemaVersions = new Map<string, number>([
   ['runtime', SQLITE_RUNTIME_SCHEMA_VERSION],
@@ -99,14 +101,26 @@ export interface OperationalBackupArtifact extends OperationalBackupFile {
   readonly record: ArtifactRecord;
 }
 
-export interface OperationalBackupManifest {
+interface OperationalBackupManifestBase {
   readonly format: typeof OPERATIONAL_BACKUP_FORMAT;
-  readonly schemaVersion: typeof OPERATIONAL_BACKUP_SCHEMA_VERSION;
   readonly createdAt: number;
   readonly database: OperationalBackupFile;
   readonly transcripts: readonly OperationalBackupTranscript[];
   readonly artifacts: readonly OperationalBackupArtifact[];
 }
+
+export interface LegacyOperationalBackupManifest extends OperationalBackupManifestBase {
+  readonly schemaVersion: typeof LEGACY_OPERATIONAL_BACKUP_SCHEMA_VERSION;
+}
+
+export interface CurrentOperationalBackupManifest extends OperationalBackupManifestBase {
+  readonly schemaVersion: typeof OPERATIONAL_BACKUP_SCHEMA_VERSION;
+  readonly legacyAutomation: OperationalBackupFile | null;
+}
+
+export type OperationalBackupManifest =
+  | LegacyOperationalBackupManifest
+  | CurrentOperationalBackupManifest;
 
 export interface CreateOperationalBackupInput {
   readonly stateRoot: string;
@@ -132,6 +146,10 @@ interface SourceFileSnapshot extends OperationalBackupFile {
 interface SourceTranscriptSnapshot extends SourceFileSnapshot {
   readonly sessionId: string;
 }
+
+type OptionalSourceFileSnapshot =
+  | { readonly kind: 'present'; readonly snapshot: SourceFileSnapshot }
+  | { readonly kind: 'absent'; readonly sourcePath: string; readonly path: string };
 
 interface ValidatedDatabaseSnapshot {
   readonly artifacts: ArtifactRecord[];
@@ -159,6 +177,13 @@ export async function createOperationalStateBackup(
       const artifactRecords = metadata.readAll();
       const transcriptSnapshots = await snapshotSessionTranscripts(stateRoot);
       const artifactSnapshots = await snapshotArtifactPayloads(stateRoot, artifactRecords);
+      const legacyAutomationSnapshot = await snapshotOptionalSourceFile(
+        stateRoot,
+        LEGACY_AUTOMATION_FILE,
+      );
+      if (legacyAutomationSnapshot.kind === 'present') {
+        await validateLegacyAutomationSourceSnapshot(legacyAutomationSnapshot.snapshot);
+      }
 
       await mkdir(stagingRoot, { recursive: true, mode: 0o700 });
       const databasePath = resolve(stagingRoot, OPERATIONAL_STATE_DATABASE_NAME);
@@ -168,7 +193,10 @@ export async function createOperationalStateBackup(
       await syncFile(databasePath);
       await input.failpoint?.('after_database_snapshot');
 
-      const validated = await validateDatabaseSnapshot(databasePath);
+      const validated = await validateDatabaseSnapshot(
+        databasePath,
+        OPERATIONAL_BACKUP_SCHEMA_VERSION,
+      );
       assertSameArtifactRecords(
         validated.artifacts,
         artifactRecords,
@@ -188,6 +216,10 @@ export async function createOperationalStateBackup(
         artifactSnapshots,
         artifactRecords,
       );
+      const legacyAutomation = await copyOptionalSourceSnapshot(
+        stagingRoot,
+        legacyAutomationSnapshot,
+      );
       assertSameArtifactRecords(
         metadata.readAll(),
         artifactRecords,
@@ -200,13 +232,14 @@ export async function createOperationalStateBackup(
       if (!Number.isSafeInteger(createdAt) || createdAt < 0) {
         throw new OperationalBackupError('invalid_manifest', 'Operational backup time is invalid');
       }
-      const manifest: OperationalBackupManifest = {
+      const manifest: CurrentOperationalBackupManifest = {
         format: OPERATIONAL_BACKUP_FORMAT,
         schemaVersion: OPERATIONAL_BACKUP_SCHEMA_VERSION,
         createdAt,
         database: await describeBackupFile(databasePath, OPERATIONAL_STATE_DATABASE_NAME),
         transcripts,
         artifacts,
+        legacyAutomation,
       };
       const manifestPath = resolve(stagingRoot, OPERATIONAL_BACKUP_MANIFEST_FILE);
       await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, {
@@ -240,7 +273,10 @@ export async function validateOperationalStateBackup(
   const manifest = await readOperationalBackupManifest(manifestPath);
   await assertBackupTreeExactlyMatchesManifest(backupRoot, manifest);
   await validateManifestFiles(backupRoot, manifest);
-  const validated = await validateDatabaseSnapshot(resolve(backupRoot, manifest.database.path));
+  const validated = await validateDatabaseSnapshot(
+    resolve(backupRoot, manifest.database.path),
+    manifest.schemaVersion,
+  );
   assertSameArtifactRecords(
     validated.artifacts,
     manifest.artifacts.map((artifact) => artifact.record),
@@ -279,7 +315,10 @@ export async function restoreOperationalStateBackup(
     }
     await input.failpoint?.('after_restore_copy');
     await validateManifestFiles(stagingRoot, manifest);
-    const validated = await validateDatabaseSnapshot(resolve(stagingRoot, manifest.database.path));
+    const validated = await validateDatabaseSnapshot(
+      resolve(stagingRoot, manifest.database.path),
+      manifest.schemaVersion,
+    );
     assertSameArtifactRecords(
       validated.artifacts,
       manifest.artifacts.map((artifact) => artifact.record),
@@ -332,6 +371,25 @@ async function snapshotSessionTranscripts(stateRoot: string): Promise<SourceTran
     snapshots.push(snapshot);
   }
   return snapshots;
+}
+
+async function snapshotOptionalSourceFile(
+  stateRoot: string,
+  relativePath: string,
+): Promise<OptionalSourceFileSnapshot> {
+  const sourcePath = resolve(stateRoot, relativePath);
+  try {
+    await lstat(sourcePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { kind: 'absent', sourcePath, path: relativePath };
+    }
+    throw error;
+  }
+  return {
+    kind: 'present',
+    snapshot: await snapshotSourceFile(sourcePath, stateRoot, relativePath),
+  };
 }
 
 async function snapshotArtifactPayloads(
@@ -458,6 +516,42 @@ async function copyArtifactSnapshots(
   return copied;
 }
 
+async function copyOptionalSourceSnapshot(
+  stagingRoot: string,
+  optional: OptionalSourceFileSnapshot,
+): Promise<OperationalBackupFile | null> {
+  if (optional.kind === 'absent') {
+    await assertOptionalSourceStillAbsent(optional);
+    return null;
+  }
+  const { snapshot } = optional;
+  await copySourceSnapshot(stagingRoot, snapshot);
+  return {
+    path: snapshot.path,
+    sizeBytes: snapshot.sizeBytes,
+    sha256: snapshot.sha256,
+  };
+}
+
+async function assertOptionalSourceStillAbsent(
+  snapshot: Extract<OptionalSourceFileSnapshot, { readonly kind: 'absent' }>,
+): Promise<void> {
+  try {
+    await lstat(snapshot.sourcePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw new OperationalBackupError(
+      'source_changed',
+      `Operational backup source changed during copy: ${snapshot.path}`,
+      { cause: error },
+    );
+  }
+  throw new OperationalBackupError(
+    'source_changed',
+    `Operational backup source changed during copy: ${snapshot.path}`,
+  );
+}
+
 async function copySourceSnapshot(
   stagingRoot: string,
   snapshot: SourceFileSnapshot,
@@ -534,7 +628,10 @@ async function hashFile(path: string): Promise<`sha256:${string}`> {
   return `sha256:${hash.digest('hex')}`;
 }
 
-async function validateDatabaseSnapshot(path: string): Promise<ValidatedDatabaseSnapshot> {
+async function validateDatabaseSnapshot(
+  path: string,
+  backupSchemaVersion: OperationalBackupManifest['schemaVersion'],
+): Promise<ValidatedDatabaseSnapshot> {
   const metadata = await lstat(path).catch((error: unknown) => {
     throw new OperationalBackupError('corrupt_backup', 'Backup runtime.sqlite is missing', {
       cause: error,
@@ -564,7 +661,7 @@ async function validateDatabaseSnapshot(path: string): Promise<ValidatedDatabase
     if (foreignKeys.length > 0) {
       throw new OperationalBackupError('corrupt_backup', 'Backup SQLite foreign keys are invalid');
     }
-    validateOperationalSchemaVersions(database);
+    validateOperationalSchemaVersions(database, backupSchemaVersion);
     if (!sqliteTableExists(database, 'artifact_records')) {
       throw new OperationalBackupError('corrupt_backup', 'Backup is missing artifact_records');
     }
@@ -655,7 +752,10 @@ function normalizeStandaloneSqliteSnapshot(path: string): void {
   }
 }
 
-function validateOperationalSchemaVersions(database: DatabaseSync): void {
+function validateOperationalSchemaVersions(
+  database: DatabaseSync,
+  backupSchemaVersion: OperationalBackupManifest['schemaVersion'],
+): void {
   if (!sqliteTableExists(database, 'operational_schema_migrations')) {
     throw new OperationalBackupError('corrupt_backup', 'Backup is missing schema migrations');
   }
@@ -677,6 +777,12 @@ function validateOperationalSchemaVersions(database: DatabaseSync): void {
   for (const [scope, supported] of supportedSchemaVersions) {
     const version = actual.get(scope);
     if (version === undefined) {
+      if (
+        scope === 'automation' &&
+        backupSchemaVersion === LEGACY_OPERATIONAL_BACKUP_SCHEMA_VERSION
+      ) {
+        continue;
+      }
       throw new OperationalBackupError('corrupt_backup', `Backup schema is missing ${scope}`);
     }
     if (version > supported) {
@@ -723,22 +829,23 @@ async function readOperationalBackupManifest(path: string): Promise<OperationalB
 }
 
 function decodeOperationalBackupManifest(value: unknown): OperationalBackupManifest {
-  if (
-    !isRecord(value) ||
-    !hasExactKeys(value, [
-      'format',
-      'schemaVersion',
-      'createdAt',
-      'database',
-      'transcripts',
-      'artifacts',
-    ])
-  ) {
+  if (!isRecord(value)) throw invalidManifest();
+  const legacy = value.schemaVersion === LEGACY_OPERATIONAL_BACKUP_SCHEMA_VERSION;
+  const current = value.schemaVersion === OPERATIONAL_BACKUP_SCHEMA_VERSION;
+  const commonKeys = [
+    'format',
+    'schemaVersion',
+    'createdAt',
+    'database',
+    'transcripts',
+    'artifacts',
+  ];
+  if (!legacy && !current) throw invalidManifest();
+  if (!hasExactKeys(value, current ? [...commonKeys, 'legacyAutomation'] : commonKeys)) {
     throw invalidManifest();
   }
   if (
     value.format !== OPERATIONAL_BACKUP_FORMAT ||
-    value.schemaVersion !== OPERATIONAL_BACKUP_SCHEMA_VERSION ||
     typeof value.createdAt !== 'number' ||
     !Number.isSafeInteger(value.createdAt) ||
     value.createdAt < 0 ||
@@ -751,7 +858,20 @@ function decodeOperationalBackupManifest(value: unknown): OperationalBackupManif
   if (database.path !== OPERATIONAL_STATE_DATABASE_NAME) throw invalidManifest();
   const transcripts = value.transcripts.map((entry) => decodeTranscript(entry));
   const artifacts = value.artifacts.map((entry) => decodeArtifact(entry));
-  assertUniqueManifestPaths([database, ...transcripts, ...artifacts]);
+  const legacyAutomation = current
+    ? value.legacyAutomation === null
+      ? null
+      : decodeBackupFile(value.legacyAutomation)
+    : undefined;
+  if (legacyAutomation && legacyAutomation.path !== LEGACY_AUTOMATION_FILE) {
+    throw invalidManifest();
+  }
+  assertUniqueManifestPaths([
+    database,
+    ...transcripts,
+    ...artifacts,
+    ...(legacyAutomation ? [legacyAutomation] : []),
+  ]);
   assertUniqueValues(
     transcripts.map((entry) => entry.sessionId),
     'session id',
@@ -760,14 +880,23 @@ function decodeOperationalBackupManifest(value: unknown): OperationalBackupManif
     artifacts.map((entry) => entry.record.id),
     'Artifact id',
   );
-  return {
+  const common: OperationalBackupManifestBase = {
     format: OPERATIONAL_BACKUP_FORMAT,
-    schemaVersion: OPERATIONAL_BACKUP_SCHEMA_VERSION,
     createdAt: value.createdAt,
     database,
     transcripts,
     artifacts,
   };
+  return current
+    ? {
+        ...common,
+        schemaVersion: OPERATIONAL_BACKUP_SCHEMA_VERSION,
+        legacyAutomation: legacyAutomation ?? null,
+      }
+    : {
+        ...common,
+        schemaVersion: LEGACY_OPERATIONAL_BACKUP_SCHEMA_VERSION,
+      };
 }
 
 function decodeBackupFile(value: unknown): OperationalBackupFile {
@@ -882,6 +1011,43 @@ async function validateManifestFiles(
   for (const transcript of manifest.transcripts) {
     await validateTranscriptFile(resolveBackupPath(root, transcript.path), transcript.sessionId);
   }
+  if (manifest.schemaVersion === OPERATIONAL_BACKUP_SCHEMA_VERSION && manifest.legacyAutomation) {
+    await validateLegacyAutomationBackupFile(
+      resolveBackupPath(root, manifest.legacyAutomation.path),
+    );
+  }
+}
+
+async function validateLegacyAutomationSourceSnapshot(snapshot: SourceFileSnapshot): Promise<void> {
+  const contents = await readFile(snapshot.sourcePath);
+  const sha256 = `sha256:${createHash('sha256').update(contents).digest('hex')}`;
+  if (contents.byteLength !== snapshot.sizeBytes || sha256 !== snapshot.sha256) {
+    throw new OperationalBackupError(
+      'source_changed',
+      `Operational backup source changed during validation: ${snapshot.path}`,
+    );
+  }
+  try {
+    decodeLegacyAutomationFile(contents.toString('utf8'));
+  } catch (error) {
+    throw new OperationalBackupError(
+      'corrupt_backup',
+      'Legacy Automation source cannot be backed up',
+      { cause: error },
+    );
+  }
+}
+
+async function validateLegacyAutomationBackupFile(path: string): Promise<void> {
+  try {
+    decodeLegacyAutomationFile(await readFile(path, 'utf8'));
+  } catch (error) {
+    throw new OperationalBackupError(
+      'corrupt_backup',
+      'Legacy Automation backup payload cannot be restored',
+      { cause: error },
+    );
+  }
 }
 
 async function validateTranscriptFile(path: string, sessionId: string): Promise<void> {
@@ -910,7 +1076,14 @@ async function validateTranscriptFile(path: string, sessionId: string): Promise<
 }
 
 function manifestFiles(manifest: OperationalBackupManifest): OperationalBackupFile[] {
-  return [manifest.database, ...manifest.transcripts, ...manifest.artifacts];
+  return [
+    manifest.database,
+    ...manifest.transcripts,
+    ...manifest.artifacts,
+    ...(manifest.schemaVersion === OPERATIONAL_BACKUP_SCHEMA_VERSION && manifest.legacyAutomation
+      ? [manifest.legacyAutomation]
+      : []),
+  ];
 }
 
 async function listBackupTree(

--- a/packages/storage/src/operational-state-backup.ts
+++ b/packages/storage/src/operational-state-backup.ts
@@ -31,6 +31,7 @@ import {
   OPERATIONAL_STATE_SCHEMA_VERSION,
 } from './operational-state-store.js';
 import { SQLITE_ARTIFACT_SCHEMA_VERSION } from './sqlite-artifact-schema.js';
+import { SQLITE_AUTOMATION_SCHEMA_VERSION } from './sqlite-automation-schema.js';
 import { createSqliteArtifactMetadataRepository } from './sqlite-artifact-metadata.js';
 import { SQLITE_CORE_EXECUTION_SCHEMA_VERSION } from './sqlite-core-execution-schema.js';
 import { SQLITE_RUNTIME_SCHEMA_VERSION } from './sqlite-runtime-schema.js';
@@ -54,6 +55,7 @@ const supportedSchemaVersions = new Map<string, number>([
   ['workflow', SQLITE_WORKFLOW_SCHEMA_VERSION],
   ['usage', SQLITE_USAGE_SCHEMA_VERSION],
   ['artifact', SQLITE_ARTIFACT_SCHEMA_VERSION],
+  ['automation', SQLITE_AUTOMATION_SCHEMA_VERSION],
   ['operational', OPERATIONAL_STATE_SCHEMA_VERSION],
 ]);
 

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -25,6 +25,10 @@ import {
   migrateSqliteArtifactDatabase,
   SQLITE_ARTIFACT_SCHEMA_VERSION,
 } from './sqlite-artifact-schema.js';
+import {
+  migrateSqliteAutomationDatabase,
+  SQLITE_AUTOMATION_SCHEMA_VERSION,
+} from './sqlite-automation-schema.js';
 
 export const OPERATIONAL_STATE_DATABASE_NAME = 'runtime.sqlite';
 export const LEGACY_SESSION_METADATA_DATABASE_NAME = 'sessions.sqlite';
@@ -134,6 +138,7 @@ class OperationalStateDatabaseOwner {
       migrateSqliteWorkflowDatabase(this.database);
       migrateSqliteUsageDatabase(this.database);
       migrateSqliteArtifactDatabase(this.database);
+      migrateSqliteAutomationDatabase(this.database);
       migrateOperationalStateDatabase(this.database, options.now ?? Date.now);
       cutoverLegacySessionMetadata({
         destination: this.database,
@@ -240,6 +245,7 @@ function migrateOperationalStateDatabase(db: DatabaseSync, now: () => number): v
     registerSchema(db, 'workflow', SQLITE_WORKFLOW_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'usage', SQLITE_USAGE_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'artifact', SQLITE_ARTIFACT_SCHEMA_VERSION, appliedAt);
+    registerSchema(db, 'automation', SQLITE_AUTOMATION_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'operational', OPERATIONAL_STATE_SCHEMA_VERSION, appliedAt);
     db.exec('COMMIT');
   } catch (error) {

--- a/packages/storage/src/sqlite-automation-schema.ts
+++ b/packages/storage/src/sqlite-automation-schema.ts
@@ -1,0 +1,41 @@
+import type { DatabaseSync } from 'node:sqlite';
+
+export const SQLITE_AUTOMATION_SCHEMA_VERSION = 1;
+
+export function migrateSqliteAutomationDatabase(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS automation_authority_state (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      revision INTEGER NOT NULL CHECK (revision >= 0)
+    );
+
+    INSERT OR IGNORE INTO automation_authority_state(singleton, revision)
+    VALUES (1, 0);
+
+    CREATE TABLE IF NOT EXISTS automation_definitions (
+      automation_id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL CHECK (created_at >= 0),
+      status TEXT NOT NULL,
+      durable INTEGER NOT NULL CHECK (durable IN (0, 1)),
+      record_json TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS automation_definitions_session_order
+      ON automation_definitions(session_id, created_at, automation_id);
+
+    CREATE INDEX IF NOT EXISTS automation_definitions_active_schedule
+      ON automation_definitions(status, created_at, automation_id);
+
+    CREATE TABLE IF NOT EXISTS automation_pending_fires (
+      fire_id TEXT PRIMARY KEY,
+      automation_id TEXT NOT NULL UNIQUE,
+      target_session_id TEXT NOT NULL,
+      admitted_at INTEGER NOT NULL CHECK (admitted_at >= 0),
+      record_json TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS automation_pending_fires_order
+      ON automation_pending_fires(admitted_at, fire_id);
+  `);
+}


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

This PR moves Automation from process-local JSON state into Runtime Host-owned canonical authority.

- Add a lease-bound SQLite Automation Store with full-snapshot CAS, one-time legacy `automations.json` cutover, and durable pending-fire identity.
- Add bounded `v0` Host query and mutation operations plus a model-facing Automation tool backed by the same authority.
- Add Host-owned scheduling, startup recovery, execution residency, and drain behavior. Heartbeats keep their creator Session; cron fires create a fresh Session from the frozen execution template.
- Settle each accepted fire through its exact durable AgentRun identity. Busy or temporarily unavailable targets retain the same pending fire for retry; terminal outcomes are recorded consistently.
- Integrate Automation roots with hosted admission and recovery without enabling a new Desktop, CLI, or TUI surface. The existing embedded path remains available.

This is part of #1167.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:scripts` — 25 passed
- `npm --workspace @maka/storage run test:dist`
- `npm --workspace @maka/runtime-host run test:dist`
- `npm --workspace @maka/runtime run test:dist` — 2,766 passed, 9 skipped

</details>

<details>
<summary>中文</summary>

## 摘要

此 PR 将 Automation 从进程内 JSON 状态迁移为 Runtime Host 持有的规范 authority。

- 新增绑定 lease 的 SQLite Automation Store，支持全量快照 CAS、一次性 `automations.json` 旧数据切换，以及持久化的 pending fire 标识。
- 新增有界的 `v0` Host 查询与变更操作，并让模型侧 Automation 工具使用同一份 authority。
- 由 Host 统一负责调度、启动恢复、执行驻留与 drain。Heartbeat 沿用创建它的 Session；cron 每次触发时根据冻结的执行模板创建新 Session。
- 每个已接受的 fire 都通过其精确、持久化的 AgentRun 标识结算。目标忙碌或暂时不可用时保留同一个 pending fire 重试；终态结果采用一致的记录语义。
- 将 Automation root 接入 Host 的 admission 与 recovery，但不启用新的 Desktop、CLI 或 TUI 界面；现有 embedded 路径继续保留。

这是 #1167 的一部分。

## 验证

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:scripts` — 25 项通过
- `npm --workspace @maka/storage run test:dist`
- `npm --workspace @maka/runtime-host run test:dist`
- `npm --workspace @maka/runtime run test:dist` — 2,766 项通过，9 项跳过

</details>
