### PR TITLE
feat: wake sessions when background shell commands complete

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2158,7 +2158,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('unsent draft');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('unsent draft'));
     terminal.input('\x03');
-    await delay(20);
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('unsent draft'));
 
     assert.equal(terminal.stopCalls, 0);
     assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /unsent draft/);

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -11,6 +11,7 @@ import {
   GoalManager,
   RuntimeReadModel,
   SessionManager,
+  ShellRunCompletionWakeCoordinator,
   ShellRunProcessManager,
   buildAutomationTool,
   buildAskUserQuestionTool,

--- a/packages/core/src/__tests__/events.test.ts
+++ b/packages/core/src/__tests__/events.test.ts
@@ -20,6 +20,7 @@ describe('failureClassFromCompleteStopReason', () => {
     expect(failureClassFromCompleteStopReason('end_turn')).toBe(undefined);
     expect(failureClassFromCompleteStopReason('max_tokens')).toBe(undefined);
     expect(failureClassFromCompleteStopReason('plan_handoff')).toBe(undefined);
+    expect(failureClassFromCompleteStopReason('background_task_wait')).toBe(undefined);
     expect(failureClassFromCompleteStopReason('permission_handoff')).toBe(undefined);
     expect(failureClassFromCompleteStopReason('user_stop')).toBe(undefined);
     expect(failureClassFromCompleteStopReason('context_budget_exhausted')).toBe(

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -54,6 +54,7 @@ export type RootExecutionDescriptor =
   | { kind: 'context_compact' }
   | { kind: 'automation'; automationId: string }
   | { kind: 'goal'; goalId: string }
+  | { kind: 'shell_run_completion_wake'; shellRunId: string }
   | {
       kind: 'agent_graph_supervisor_wake';
       graphId: string;
@@ -158,6 +159,8 @@ export interface AgentRunHeader {
   automationId?: string;
   /** Host-owned Goal generation that triggered this continuation Run. */
   goalId?: string;
+  /** Detached ShellRun whose terminal transition triggered this host-authored Run. */
+  shellRunCompletionWakeId?: string;
   /** Durable graph milestone that caused this host-authored supervisor turn. */
   agentGraphWakeId?: string;
   /** Durable delivery attempt for this host-authored supervisor turn. */
@@ -178,6 +181,7 @@ type HostedRootExecutionDescriptor = Extract<
       | 'context_compact'
       | 'automation'
       | 'goal'
+      | 'shell_run_completion_wake'
       | 'agent_graph_supervisor_wake'
       | 'safe_boundary_continuation';
   }
@@ -203,6 +207,7 @@ export function agentRunMatchesHostedRootExecution(
       run.continuationSource === undefined &&
       run.automationId === undefined &&
       run.goalId === undefined &&
+      run.shellRunCompletionWakeId === undefined &&
       run.agentGraphWakeId === undefined &&
       run.agentGraphWakeAttemptId === undefined
     );
@@ -223,6 +228,7 @@ export function agentRunMatchesHostedRootExecution(
       run.continuationSource === undefined &&
       run.automationId === undefined &&
       run.goalId === undefined &&
+      run.shellRunCompletionWakeId === undefined &&
       run.agentGraphWakeId === undefined &&
       run.agentGraphWakeAttemptId === undefined
     );
@@ -253,6 +259,7 @@ export function agentRunMatchesHostedRootExecution(
       run.parentSessionId === undefined &&
       run.automationId === undefined &&
       run.goalId === undefined &&
+      run.shellRunCompletionWakeId === undefined &&
       run.agentGraphWakeId === undefined &&
       run.agentGraphWakeAttemptId === undefined
     );
@@ -286,6 +293,7 @@ function hostedRootAuthorityMatches(
       return (
         run.automationId === execution.automationId &&
         run.goalId === undefined &&
+        run.shellRunCompletionWakeId === undefined &&
         run.agentGraphWakeId === undefined &&
         run.agentGraphWakeAttemptId === undefined
       );
@@ -293,6 +301,15 @@ function hostedRootAuthorityMatches(
       return (
         run.goalId === execution.goalId &&
         run.automationId === undefined &&
+        run.shellRunCompletionWakeId === undefined &&
+        run.agentGraphWakeId === undefined &&
+        run.agentGraphWakeAttemptId === undefined
+      );
+    case 'shell_run_completion_wake':
+      return (
+        run.shellRunCompletionWakeId === execution.shellRunId &&
+        run.automationId === undefined &&
+        run.goalId === undefined &&
         run.agentGraphWakeId === undefined &&
         run.agentGraphWakeAttemptId === undefined
       );
@@ -305,7 +322,8 @@ function hostedRootAuthorityMatches(
         run.orchestrationSource === 'turn_override' &&
         run.agentSwarmAuthorization === 'none' &&
         run.automationId === undefined &&
-        run.goalId === undefined
+        run.goalId === undefined &&
+        run.shellRunCompletionWakeId === undefined
       );
   }
 }
@@ -438,6 +456,7 @@ const AGENT_RUN_HEADER_SHAPE = defineObjectShape<AgentRunHeader>()(
     'continuationSource',
     'automationId',
     'goalId',
+    'shellRunCompletionWakeId',
     'agentGraphWakeId',
     'agentGraphWakeAttemptId',
     'rootExecutionKind',
@@ -480,7 +499,12 @@ export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
     (value.agentSwarmAuthorization === undefined ||
       isAgentSwarmAuthorizationSource(value.agentSwarmAuthorization)) &&
     (value.rootExecutionKind === undefined || value.rootExecutionKind === 'context_compact') &&
-    !(value.automationId !== undefined && value.goalId !== undefined) &&
+    [
+      value.automationId,
+      value.goalId,
+      value.shellRunCompletionWakeId,
+      value.agentGraphWakeId,
+    ].filter((item) => item !== undefined).length <= 1 &&
     isFiniteNumber(value.createdAt) &&
     isFiniteNumber(value.updatedAt) &&
     isOptionalString(value.invocationId) &&
@@ -499,6 +523,7 @@ export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
       value.workspaceIdentity,
       value.automationId,
       value.goalId,
+      value.shellRunCompletionWakeId,
       value.agentGraphWakeId,
       value.agentGraphWakeAttemptId,
       value.failureClass,

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -543,6 +543,8 @@ type ShellRunResultMetadata = {
   failureMessage?: string;
   revision: number;
   timeoutMs?: number;
+  /** The host will resume the owning session once when this run becomes terminal. */
+  notifyOnComplete?: true;
   sandboxDenial?: SandboxDenialSignal | SandboxDenialRecovery;
 };
 
@@ -1034,6 +1036,7 @@ export interface CompleteEvent extends BaseEvent {
     | 'error'
     | 'plan_handoff'
     | 'graph_yield'
+    | 'background_task_wait'
     | 'permission_handoff'
     | 'step_limit'
     | 'max_tokens'

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -684,6 +684,9 @@ function isTurnOrigin(value: unknown): value is TurnOrigin {
   if (value.kind === 'goal') {
     return Object.keys(value).length === 2 && typeof value.goalId === 'string';
   }
+  if (value.kind === 'shell_run_completion') {
+    return Object.keys(value).length === 2 && typeof value.shellRunId === 'string';
+  }
   return (
     value.kind === 'agent_graph' &&
     Object.keys(value).length === 4 &&

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -103,6 +103,7 @@ export interface UserMessageInput extends MessageContent {
 export type TurnOrigin =
   | { kind: 'automation'; automationId: string }
   | { kind: 'goal'; goalId: string }
+  | { kind: 'shell_run_completion'; shellRunId: string }
   | {
       kind: 'agent_graph';
       graphId: string;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -699,6 +699,7 @@ export interface UserMessage extends MessageContent {
   origin?:
     | { kind: 'automation'; automationId: string }
     | { kind: 'goal'; goalId: string }
+    | { kind: 'shell_run_completion'; shellRunId: string }
     | { kind: 'agent_graph'; graphId: string; wakeId: string; attemptId: string };
 }
 
@@ -965,9 +966,14 @@ const ASSISTANT_THINKING_SHAPE = defineObjectShape<AssistantThinking>()(
 type MessageOrigin = NonNullable<UserMessage['origin']>;
 type AutomationOrigin = Extract<MessageOrigin, { kind: 'automation' }>;
 type GoalOrigin = Extract<MessageOrigin, { kind: 'goal' }>;
+type ShellRunCompletionOrigin = Extract<MessageOrigin, { kind: 'shell_run_completion' }>;
 type AgentGraphOrigin = Extract<MessageOrigin, { kind: 'agent_graph' }>;
 const AUTOMATION_ORIGIN_SHAPE = defineObjectShape<AutomationOrigin>()(['kind', 'automationId'], []);
 const GOAL_ORIGIN_SHAPE = defineObjectShape<GoalOrigin>()(['kind', 'goalId'], []);
+const SHELL_RUN_COMPLETION_ORIGIN_SHAPE = defineObjectShape<ShellRunCompletionOrigin>()(
+  ['kind', 'shellRunId'],
+  [],
+);
 const AGENT_GRAPH_ORIGIN_SHAPE = defineObjectShape<AgentGraphOrigin>()(
   ['kind', 'graphId', 'wakeId', 'attemptId'],
   [],
@@ -1185,8 +1191,22 @@ function isAgentGraphOrigin(value: unknown): value is AgentGraphOrigin {
   );
 }
 
+function isShellRunCompletionOrigin(value: unknown): value is ShellRunCompletionOrigin {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, SHELL_RUN_COMPLETION_ORIGIN_SHAPE) &&
+    value.kind === 'shell_run_completion' &&
+    typeof value.shellRunId === 'string'
+  );
+}
+
 function isMessageOrigin(value: unknown): value is MessageOrigin {
-  return isAutomationOrigin(value) || isGoalOrigin(value) || isAgentGraphOrigin(value);
+  return (
+    isAutomationOrigin(value) ||
+    isGoalOrigin(value) ||
+    isShellRunCompletionOrigin(value) ||
+    isAgentGraphOrigin(value)
+  );
 }
 
 function isOptionalFiniteDuration(value: unknown): boolean {

--- a/packages/core/src/shell-run-result.ts
+++ b/packages/core/src/shell-run-result.ts
@@ -96,6 +96,7 @@ const CURRENT_SHELL_RUN_RESULT_SHAPE = defineObjectShape<ShellRunToolResultRecor
     'exitCode',
     'failureMessage',
     'timeoutMs',
+    'notifyOnComplete',
     'output',
     'operation',
     'sandboxDenial',
@@ -267,6 +268,7 @@ function currentShellRunResult(value: Record<string, unknown>): ShellRunToolResu
     !isOptionalFiniteNumber(value.completedAt) ||
     !isOptionalFiniteNumber(value.exitCode) ||
     !isOptionalFiniteNumber(value.timeoutMs) ||
+    (value.notifyOnComplete !== undefined && value.notifyOnComplete !== true) ||
     !isOptionalString(value.failureMessage) ||
     !isOptionalSandboxDenial(value.sandboxDenial) ||
     (value.output !== undefined &&
@@ -700,6 +702,7 @@ function sameMetadata(left: ShellRunStateResult, right: ShellRunStateResult): bo
     left.updatedAt === right.updatedAt &&
     left.completedAt === right.completedAt &&
     left.timeoutMs === right.timeoutMs &&
+    left.notifyOnComplete === right.notifyOnComplete &&
     left.exitCode === right.exitCode &&
     left.failureMessage === right.failureMessage &&
     left.revision === right.revision

--- a/packages/core/src/shell-run.ts
+++ b/packages/core/src/shell-run.ts
@@ -115,6 +115,13 @@ export interface ShellRunRecord {
   updatedAt: number;
   completedAt?: number;
   timeoutMs?: number;
+  /** Host-owned opt-in for one terminal completion turn instead of model polling. */
+  notifyOnComplete?: true;
+  /** Durable delivery facts for the completion wake. */
+  completionWake?: {
+    attemptTurnId?: string;
+    deliveredAt?: number;
+  };
   revision: number;
   observedAt?: number;
   output: ShellOutput;
@@ -131,7 +138,14 @@ export interface ShellRunRecord {
 export type ShellRunPatch = Partial<
   Pick<
     ShellRunRecord,
-    'status' | 'exitCode' | 'failureMessage' | 'updatedAt' | 'completedAt' | 'observedAt' | 'output'
+    | 'status'
+    | 'exitCode'
+    | 'failureMessage'
+    | 'updatedAt'
+    | 'completedAt'
+    | 'observedAt'
+    | 'output'
+    | 'completionWake'
   >
 >;
 

--- a/packages/core/src/shell-run.ts
+++ b/packages/core/src/shell-run.ts
@@ -119,8 +119,12 @@ export interface ShellRunRecord {
   notifyOnComplete?: true;
   /** Durable delivery facts for the completion wake. */
   completionWake?: {
+    /** Total model-turn attempts admitted for this notification across restarts. */
+    attemptCount?: number;
     attemptTurnId?: string;
+    lastFailure?: string;
     deliveredAt?: number;
+    exhaustedAt?: number;
   };
   revision: number;
   observedAt?: number;

--- a/packages/runtime-host/src/__tests__/execution-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-composition.test.ts
@@ -203,6 +203,50 @@ test('production composition orphans ownerless ShellRuns before serving Resource
   });
 });
 
+test('production composition recovers a terminal ShellRun subscription through Host root authority', async () => {
+  await withCompositionRoot(async ({ root, owner }) => {
+    const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const session = await stores.sessionStore.create({
+      cwd: root,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    const shellRuns = await openInteractiveShellRunStoreForWrite(owner.lease);
+    await shellRuns.createShellRun({
+      ...shellRunRecord(session.id, 'completed-shell', 'running'),
+      status: 'completed',
+      completedAt: 2,
+      updatedAt: 2,
+      exitCode: 0,
+      notifyOnComplete: true,
+    });
+
+    const { composition } = await createCapturedExecutionComposition(owner);
+    try {
+      await waitFor(async () => {
+        const record = await shellRuns.readShellRun(session.id, 'completed-shell');
+        return record.completionWake?.deliveredAt !== undefined && record.observedAt !== undefined;
+      }, 10_000);
+      const admissions = await stores.agentRunStore.listRootTurnAdmissionsForRecovery(session.id);
+      const wake = admissions.find(
+        (admission) => admission.execution.kind === 'shell_run_completion_wake',
+      );
+      assert.ok(wake);
+      assert.deepEqual(wake.execution, {
+        kind: 'shell_run_completion_wake',
+        shellRunId: 'completed-shell',
+      });
+      const run = await stores.agentRunStore.readRun(session.id, wake.runId);
+      assert.equal(run.shellRunCompletionWakeId, 'completed-shell');
+      assert.equal(run.status, 'completed');
+    } finally {
+      await composition.close();
+    }
+  });
+});
+
 test('production execution composition owns claimed graph activation retry and exact abort', async () => {
   await withCompositionRoot(async ({ root, owner }) => {
     const stores = await openInteractiveExecutionStoresForWrite(owner.lease);

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -1169,6 +1169,53 @@ test('Agent Graph supervisor wake waits for root idle and binds one durable exec
   }
 });
 
+test('ShellRun completion wake binds a distinct durable root execution identity', async () => {
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+  });
+  const turnId = 'turn-shell-run-completion';
+  const shellRunId = 'shell-run-completed-1';
+  try {
+    const outcome = await fixture.coordinator.runShellRunCompletionTurn(
+      fixture.sessionId,
+      {
+        turnId,
+        text: 'The detached command completed.',
+        displayText: 'A background command reached terminal completion.',
+        origin: { kind: 'shell_run_completion', shellRunId },
+      },
+      new AbortController().signal,
+    );
+    assert.deepEqual(outcome, { kind: 'completed', turnId });
+
+    const admissions = await fixture.stores.agentRunStore.listRootTurnAdmissionsForRecovery(
+      fixture.sessionId,
+    );
+    const admission = admissions.find((candidate) => candidate.turnId === turnId);
+    assert.ok(admission);
+    assert.deepEqual(admission.execution, {
+      kind: 'shell_run_completion_wake',
+      shellRunId,
+    });
+
+    const run = await fixture.stores.agentRunStore.readRun(fixture.sessionId, admission.runId);
+    assert.equal(run.shellRunCompletionWakeId, shellRunId);
+    const userMessage = (await fixture.stores.sessionStore.readMessages(fixture.sessionId)).find(
+      (message) => message.id === admission.userMessageId,
+    );
+    assert.ok(userMessage?.type === 'user');
+    if (userMessage?.type === 'user') {
+      assert.deepEqual(userMessage.origin, { kind: 'shell_run_completion', shellRunId });
+      assert.equal(userMessage.displayText, 'A background command reached terminal completion.');
+    }
+    assert.equal(fixture.drainRequested(), false);
+  } finally {
+    await fixture.coordinator.close();
+    await fixture.messages.close();
+    await fixture.dispose();
+  }
+});
+
 test('Agent Graph supervisor wake preserves structured context-overflow outcomes', async () => {
   const fixture = await createFailureFixture({
     registerBackend: (backends) =>

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -18,6 +18,7 @@ import {
   RuntimeReadModel,
   SessionManager,
   SessionActivityRegistry,
+  ShellRunCompletionWakeCoordinator,
   ShellRunProcessManager,
   type RuntimeHostedRootAuthority,
 } from '@maka/runtime';
@@ -163,12 +164,17 @@ export async function createExecutionRuntimeHostComposition(
     let manager: SessionManager | undefined;
     let graphCoordinator: AgentGraphCoordinator | undefined;
     let graphSupervisorWake: AgentGraphSupervisorWakeCoordinator | undefined;
+    let shellRunCompletionWake: ShellRunCompletionWakeCoordinator | undefined;
     const graphWakeActivities = new SessionActivityRegistry();
+    const shellRunWakeActivities = new SessionActivityRegistry();
     const shellRuns = new ShellRunProcessManager({
       store: openedShellRunStore,
       newId: randomUUID,
       now: Date.now,
-      onShellRunUpdate: (update) => runtimeResources?.observeShellRunUpdate(update),
+      onShellRunUpdate: (update) => {
+        runtimeResources?.observeShellRunUpdate(update);
+        shellRunCompletionWake?.notify(update);
+      },
     });
     const sandboxManager = createBuiltinSandboxManager();
     const filesystemWorkerLaunchSpecProvider =
@@ -634,6 +640,32 @@ export async function createExecutionRuntimeHostComposition(
       },
     );
     const coordinator = rootCoordinator;
+    shellRunCompletionWake = new ShellRunCompletionWakeCoordinator({
+      activityRegistry: shellRunWakeActivities,
+      store: openedShellRunStore,
+      listSessionIds: async () => (await manager.listSessions()).map((session) => session.id),
+      startTurn: (sessionId, input, _activity, abortSignal) =>
+        coordinator.runShellRunCompletionTurn(sessionId, input, abortSignal),
+      inspectTurn: async (sessionId, turnId) => {
+        const runs = (await stores.agentRunStore.listSessionRuns(sessionId)).filter(
+          (run) => run.turnId === turnId,
+        );
+        if (runs.length > 1) {
+          throw new Error(`ShellRun completion turn ${turnId} has multiple AgentRuns`);
+        }
+        const status = runs[0]?.status;
+        if (!status) return 'missing';
+        if (status === 'completed') return 'completed';
+        if (status === 'created' || status === 'running' || status === 'waiting_for_user') {
+          return 'active';
+        }
+        return 'failed';
+      },
+      newId: randomUUID,
+      now: Date.now,
+      acquireTaskLease: context.acquireResidency,
+      onError: () => context.requestDrain(),
+    });
     graphSupervisorWake = new AgentGraphSupervisorWakeCoordinator({
       activityRegistry: graphWakeActivities,
       wakeStore: openedGraphControlStore,
@@ -845,6 +877,7 @@ export async function createExecutionRuntimeHostComposition(
         );
         await coordinator.recover();
         rootRecoveryCompleted = true;
+        await shellRunCompletionWake.recover();
         await requireGraphSupervisorWake(graphSupervisorWake).recover();
         await requireGraphCoordinator(graphCoordinator).recover();
         await requireAutomationCoordinator(automations).recover();
@@ -874,6 +907,11 @@ export async function createExecutionRuntimeHostComposition(
         }
         try {
           await graphSupervisorWake?.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
+          await shellRunCompletionWake?.close();
         } catch (error) {
           errors.push(error);
         }

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -249,6 +249,13 @@ interface AgentGraphRootReservation extends RootTurnReservation {
   readonly input: UserMessageInput;
 }
 
+interface ShellRunCompletionRootReservation extends RootTurnReservation {
+  readonly turnId: string;
+  readonly runId: string;
+  readonly userMessageId: string;
+  readonly message: UserMessageInput;
+}
+
 interface HostedRootReservationOptions {
   readonly label: string;
   readonly unavailableReason: string;
@@ -856,6 +863,58 @@ export class RootTurnCoordinator {
     });
   }
 
+  async runShellRunCompletionTurn(
+    sessionId: string,
+    input: UserMessageInput,
+    abortSignal: AbortSignal,
+  ): Promise<GoalTurnOutcome> {
+    if (input.origin?.kind !== 'shell_run_completion') {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'ShellRun completion Turn requires the host-authored ShellRun origin',
+      );
+    }
+
+    let reservation: ShellRunCompletionRootReservation;
+    for (;;) {
+      throwIfAborted(abortSignal);
+      if (this.#draining) {
+        return goalErrorOutcome(input.turnId, 'Runtime Host root authority is draining.');
+      }
+      const active = this.#activeBySession.get(sessionId);
+      const pending = this.#reservationsBySession.get(sessionId);
+      const whenIdle = active?.done ?? pending?.whenIdle.promise;
+      if (whenIdle) {
+        await waitForRootIdleOrAbort(whenIdle, abortSignal);
+        continue;
+      }
+      reservation = {
+        kind: 'pending',
+        sessionId,
+        turnId: input.turnId,
+        runId: randomUUID(),
+        userMessageId: randomUUID(),
+        message: input,
+        whenIdle: deferred(),
+        admissionSettled: deferred(),
+        admissionPhase: 'prepared',
+      };
+      this.#reservationsBySession.set(sessionId, reservation);
+      break;
+    }
+    return this.#runHostedRootReservation(reservation, {
+      label: 'ShellRun completion continuation',
+      unavailableReason: 'ShellRun completion continuation is unavailable for this Session.',
+      revokedReason: 'ShellRun completion continuation reservation was revoked.',
+      execution: {
+        kind: 'shell_run_completion_wake',
+        shellRunId: input.origin.shellRunId,
+      },
+      normalizedInput: normalizeMessageContent(input),
+      isAvailable: () => true,
+      abortSignal,
+    });
+  }
+
   async recoverAgentGraphSupervisorContextOverflow(
     sessionId: string,
     compactTurnId: string,
@@ -1042,7 +1101,14 @@ export class RootTurnCoordinator {
     },
   ): Promise<AgentGraphSupervisorTurnOutcome>;
   async #runHostedRootReservation(
-    reservation: GoalRootReservation | AgentGraphRootReservation,
+    reservation: ShellRunCompletionRootReservation,
+    options: HostedRootReservationOptions & { isCurrent?: undefined },
+  ): Promise<GoalTurnOutcome>;
+  async #runHostedRootReservation(
+    reservation:
+      | GoalRootReservation
+      | AgentGraphRootReservation
+      | ShellRunCompletionRootReservation,
     options: HostedRootReservationOptions,
   ): Promise<AgentGraphSupervisorTurnOutcome> {
     try {
@@ -1144,7 +1210,10 @@ export class RootTurnCoordinator {
   }
 
   async #awaitHostedRootOutcome(
-    reservation: GoalRootReservation | AgentGraphRootReservation,
+    reservation:
+      | GoalRootReservation
+      | AgentGraphRootReservation
+      | ShellRunCompletionRootReservation,
     active: ActiveRootTurn,
     abortSignal?: AbortSignal,
   ): Promise<GoalTurnOutcome> {
@@ -3074,6 +3143,7 @@ function assertRunMatchesExecution(
     case 'context_compact':
     case 'automation':
     case 'goal':
+    case 'shell_run_completion_wake':
     case 'agent_graph_supervisor_wake':
     case 'safe_boundary_continuation':
       if (agentRunMatchesHostedRootExecution(run, execution)) return;
@@ -3115,6 +3185,7 @@ function assertTrustedAgentIdentity(
         | 'context_compact'
         | 'automation'
         | 'goal'
+        | 'shell_run_completion_wake'
         | 'agent_graph_supervisor_wake'
         | 'safe_boundary_continuation';
     }
@@ -3162,6 +3233,12 @@ function recoveryExecutionContract(
         pendingWithoutRun: 'root_replay',
       };
     case 'goal':
+      return {
+        allowsQueueSources: false,
+        requiresUserMessage: true,
+        pendingWithoutRun: 'host_recovery_closure',
+      };
+    case 'shell_run_completion_wake':
       return {
         allowsQueueSources: false,
         requiresUserMessage: true,
@@ -3232,6 +3309,8 @@ function rootExecutionMessageOrigin(execution: RootExecutionDescriptor) {
       };
     case 'goal':
       return { kind: 'goal' as const, goalId: execution.goalId };
+    case 'shell_run_completion_wake':
+      return { kind: 'shell_run_completion' as const, shellRunId: execution.shellRunId };
     case 'agent_graph_supervisor_wake':
       return {
         kind: 'agent_graph' as const,

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -7452,6 +7452,110 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'end_turn');
   });
 
+  test('ends the turn after a background completion subscription even alongside another tool', async () => {
+    const durable = durableTurnHarness('turn-1', 'build the Rust workspace and wait for it');
+    let streamCalls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        streamCalls += 1;
+        const chunks: LanguageModelV4StreamPart[] =
+          streamCalls === 1
+            ? [
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'build-1',
+                  toolName: 'Bash',
+                  input: JSON.stringify({
+                    command: 'cargo build',
+                    run_in_background: true,
+                    notify_on_complete: true,
+                  }),
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'inspect-1',
+                  toolName: 'Read',
+                  input: JSON.stringify({ path: 'Cargo.toml' }),
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                  usage: emptyUsage(),
+                },
+              ]
+            : [
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'legacy-poll',
+                  toolName: 'Bash',
+                  input: JSON.stringify({ command: 'sleep 300' }),
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                  usage: emptyUsage(),
+                },
+              ];
+        return {
+          stream: simulateReadableStream({
+            chunks,
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const bash: MakaTool = {
+      name: 'Bash',
+      description: 'Run a command and optionally notify on terminal completion.',
+      parameters: z.object({
+        command: z.string(),
+        run_in_background: z.boolean().optional(),
+        notify_on_complete: z.boolean().optional(),
+      }),
+      impl: async () => ({
+        kind: 'shell_run' as const,
+        ref: 'maka://runtime/background-tasks/build-1',
+        mode: 'pipes' as const,
+        status: 'running' as const,
+        cwd: '/tmp',
+        cmd: 'cargo build',
+        startedAt: 1,
+        updatedAt: 2,
+        revision: 2,
+        notifyOnComplete: true as const,
+      }),
+    };
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [bash, testTool('Read', z.object({ path: z.string() }))],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events = await drainDurably(backend.send(durable.input()), durable);
+
+    assert.equal(streamCalls, 1, 'completion subscription must prevent the polling model step');
+    assert.equal(
+      events.find((event) => event.type === 'complete')?.stopReason,
+      'background_task_wait',
+    );
+    assert.equal(
+      events.filter((event) => event.type === 'tool_start').length,
+      2,
+      'the synthetic legacy sleep call must never execute',
+    );
+  });
+
   test('reports an explicit step limit without making an auxiliary model call', async () => {
     const appended: StoredMessage[] = [];
     const durable = durableTurnHarness('turn-1', 'finish the task');

--- a/packages/runtime/src/__tests__/runtime-runner.test.ts
+++ b/packages/runtime/src/__tests__/runtime-runner.test.ts
@@ -291,6 +291,28 @@ describe('RuntimeRunner', () => {
     expect(result.failure?.class).toBe('missing_final_output');
   });
 
+  test('background completion wait may finish without model text while the process is pending', async () => {
+    const providers = makeProviders();
+    const flow = new ScriptFlow((ctx) => [
+      {
+        ...flowTerminalEvent(ctx, 'completed'),
+        role: 'system',
+        author: 'system',
+        actions: {
+          endInvocation: true,
+          stateDelta: { stopReason: 'background_task_wait' },
+        },
+      },
+    ]);
+    const runner = new RuntimeRunner({ flow, providers });
+
+    const result = await runner.run(makeRequest());
+
+    expect(result.status).toBe('completed');
+    expect(result.finalOutput).toBeUndefined();
+    expect(result.failure).toBeUndefined();
+  });
+
   test('caller-provided invocationId and runId are used across result, user event, and flow', async () => {
     const providers = makeProviders();
     const flow = new ScriptFlow((ctx) => [

--- a/packages/runtime/src/__tests__/shell-run-completion-wake.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-completion-wake.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, test } from 'node:test';
+import type { ShellRunRecord } from '@maka/core';
+import { createSqliteShellRunStore, type ClosableShellRunStore } from '@maka/storage';
+
+import { SessionActivityRegistry } from '../goal-turn-lifecycle.js';
+import {
+  ShellRunCompletionWakeCoordinator,
+  renderShellRunCompletionWakePrompt,
+} from '../shell-run-completion-wake.js';
+import { shellRunUpdate } from '../shell-run-tool-result.js';
+
+const workspaces: string[] = [];
+const stores: ClosableShellRunStore[] = [];
+
+afterEach(async () => {
+  for (const store of stores.splice(0)) store.close();
+  await Promise.all(workspaces.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe('ShellRun completion notification', () => {
+  test('waits for the active turn, then delivers one event-driven continuation without polling', async () => {
+    const store = await createStore();
+    const record = await store.createShellRun(terminalRecord());
+    const activities = new SessionActivityRegistry();
+    const activeTurn = activities.reserve(record.sessionId);
+    const prompts: string[] = [];
+    const coordinator = coordinatorFor(store, activities, {
+      startTurn: async (_sessionId, input) => {
+        prompts.push(input.text);
+        return { kind: 'completed', turnId: input.turnId };
+      },
+    });
+    try {
+      coordinator.notify(shellRunUpdate(record));
+      await Promise.resolve();
+      assert.equal(prompts.length, 0, 'completion wake must queue behind the active turn');
+
+      activeTurn.release();
+      await coordinator.waitForIdle();
+
+      assert.equal(prompts.length, 1);
+      assert.match(prompts[0]!, /event-driven completion wake/);
+      assert.match(prompts[0]!, /Do not sleep or poll/);
+      const delivered = await store.readShellRun(record.sessionId, record.shellRunId);
+      assert.equal(delivered.completionWake?.attemptTurnId, 'wake-turn-1');
+      assert.equal(delivered.completionWake?.deliveredAt, 1_002);
+      assert.equal(delivered.observedAt, 1_002);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  test('comparison: an unsubscribed background completion requires reads while notification uses one wake', async () => {
+    const store = await createStore();
+    const legacy = await store.createShellRun(
+      terminalRecord({ shellRunId: 'legacy-run', notifyOnComplete: undefined }),
+    );
+    const notified = await store.createShellRun(
+      terminalRecord({ shellRunId: 'notified-run', sourceToolCallId: 'tool-2' }),
+    );
+    let continuationTurns = 0;
+    const coordinator = coordinatorFor(store, new SessionActivityRegistry(), {
+      startTurn: async (_sessionId, input) => {
+        continuationTurns += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+    });
+    try {
+      coordinator.notify(shellRunUpdate(legacy));
+      coordinator.notify(shellRunUpdate(notified));
+      await coordinator.waitForIdle();
+
+      // Legacy callers can only discover completion by explicitly reading the ref.
+      let legacyModelPolls = 0;
+      legacyModelPolls += 1;
+      const legacySnapshot = await store.readShellRun(legacy.sessionId, legacy.shellRunId);
+      assert.equal(legacySnapshot.status, 'completed');
+
+      assert.equal(legacyModelPolls, 1);
+      assert.equal(continuationTurns, 1);
+      assert.equal(
+        (await store.readShellRun(notified.sessionId, notified.shellRunId)).observedAt,
+        1_002,
+        'notification delivers the terminal snapshot without any model Read call',
+      );
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  test('recovery delivers a persisted terminal subscription after restart', async () => {
+    const store = await createStore();
+    await store.createShellRun(terminalRecord());
+    let turns = 0;
+    const coordinator = coordinatorFor(store, new SessionActivityRegistry(), {
+      startTurn: async (_sessionId, input) => {
+        turns += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+    });
+    try {
+      assert.equal(await coordinator.recover(), 1);
+      await coordinator.waitForIdle();
+      assert.equal(turns, 1);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  test('renders a bounded terminal result rather than polling instructions', () => {
+    const prompt = renderShellRunCompletionWakePrompt(terminalRecord());
+    assert.match(prompt, /"status":"completed"/);
+    assert.match(prompt, /compile finished/);
+    assert.doesNotMatch(prompt, /Read\(ref\)|sleep \d/);
+  });
+});
+
+async function createStore(): Promise<ClosableShellRunStore> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-shell-wake-'));
+  workspaces.push(root);
+  const store = createSqliteShellRunStore(root);
+  stores.push(store);
+  await store.ready();
+  return store;
+}
+
+function coordinatorFor(
+  store: ClosableShellRunStore,
+  activityRegistry: SessionActivityRegistry,
+  overrides: {
+    startTurn: ConstructorParameters<typeof ShellRunCompletionWakeCoordinator>[0]['startTurn'];
+  },
+): ShellRunCompletionWakeCoordinator {
+  let id = 0;
+  let now = 1_000;
+  return new ShellRunCompletionWakeCoordinator({
+    activityRegistry,
+    store,
+    listSessionIds: async () => ['session-1'],
+    startTurn: overrides.startTurn,
+    inspectTurn: async () => 'missing',
+    newId: () => `wake-turn-${++id}`,
+    now: () => ++now,
+  });
+}
+
+function terminalRecord(overrides: Partial<ShellRunRecord> = {}): ShellRunRecord {
+  return {
+    shellRunId: 'shell-run-1',
+    sessionId: 'session-1',
+    sourceRunId: 'run-1',
+    sourceTurnId: 'turn-1',
+    sourceToolCallId: 'tool-1',
+    cwd: '/tmp',
+    command: 'cargo build',
+    status: 'completed',
+    exitCode: 0,
+    startedAt: 100,
+    updatedAt: 200,
+    completedAt: 200,
+    notifyOnComplete: true,
+    revision: 3,
+    output: {
+      mode: 'pipes',
+      stdout: 'compile finished',
+      stderr: '',
+      stdoutTruncated: false,
+      stderrTruncated: false,
+      redacted: false,
+    },
+    ...overrides,
+  };
+}

--- a/packages/runtime/src/__tests__/shell-run-completion-wake.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-completion-wake.test.ts
@@ -46,6 +46,7 @@ describe('ShellRun completion notification', () => {
       assert.match(prompts[0]!, /event-driven completion wake/);
       assert.match(prompts[0]!, /Do not sleep or poll/);
       const delivered = await store.readShellRun(record.sessionId, record.shellRunId);
+      assert.equal(delivered.completionWake?.attemptCount, 1);
       assert.equal(delivered.completionWake?.attemptTurnId, 'wake-turn-1');
       assert.equal(delivered.completionWake?.deliveredAt, 1_002);
       assert.equal(delivered.observedAt, 1_002);
@@ -111,6 +112,247 @@ describe('ShellRun completion notification', () => {
     }
   });
 
+  test('deduplicates repeated terminal notifications before and after delivery', async () => {
+    const store = await createStore();
+    const record = await store.createShellRun(terminalRecord());
+    let turns = 0;
+    const coordinator = coordinatorFor(store, new SessionActivityRegistry(), {
+      startTurn: async (_sessionId, input) => {
+        turns += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+    });
+    try {
+      coordinator.notify(shellRunUpdate(record));
+      coordinator.notify(shellRunUpdate(record));
+      await coordinator.waitForIdle();
+      coordinator.notify(shellRunUpdate(record));
+      await coordinator.waitForIdle();
+
+      assert.equal(turns, 1);
+      assert.equal(
+        (await store.readShellRun(record.sessionId, record.shellRunId)).completionWake
+          ?.attemptCount,
+        1,
+      );
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  test('lets a foreground observation win while the completion wake waits for the session lane', async () => {
+    const store = await createStore();
+    const record = await store.createShellRun(terminalRecord());
+    const activities = new SessionActivityRegistry();
+    const activeTurn = activities.reserve(record.sessionId);
+    let turns = 0;
+    const coordinator = coordinatorFor(store, activities, {
+      startTurn: async (_sessionId, input) => {
+        turns += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+    });
+    try {
+      coordinator.notify(shellRunUpdate(record));
+      await store.updateShellRun(record.sessionId, record.shellRunId, { observedAt: 500 });
+      activeTurn.release();
+      await coordinator.waitForIdle();
+
+      assert.equal(turns, 0);
+      assert.equal(await coordinator.recover(), 0);
+    } finally {
+      activeTurn.release();
+      await coordinator.close();
+    }
+  });
+
+  test('marks a recovered completed attempt delivered without starting another turn', async () => {
+    const store = await createStore();
+    const record = await store.createShellRun(
+      terminalRecord({
+        completionWake: { attemptCount: 1, attemptTurnId: 'previous-turn' },
+      }),
+    );
+    let turns = 0;
+    const coordinator = coordinatorFor(store, new SessionActivityRegistry(), {
+      inspectTurn: async () => 'completed',
+      startTurn: async (_sessionId, input) => {
+        turns += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+    });
+    try {
+      assert.equal(await coordinator.recover(), 1);
+      await coordinator.waitForIdle();
+
+      const delivered = await store.readShellRun(record.sessionId, record.shellRunId);
+      assert.equal(turns, 0);
+      assert.equal(delivered.completionWake?.attemptCount, 1);
+      assert.equal(delivered.completionWake?.attemptTurnId, 'previous-turn');
+      assert.ok(delivered.completionWake?.deliveredAt !== undefined);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  test('watches an active recovered attempt and retries when it later fails', async () => {
+    const store = await createStore();
+    const record = await store.createShellRun(
+      terminalRecord({
+        completionWake: { attemptCount: 1, attemptTurnId: 'previous-turn' },
+      }),
+    );
+    const statuses: Array<'active' | 'failed'> = ['active', 'active', 'failed'];
+    let inspections = 0;
+    let turns = 0;
+    const coordinator = coordinatorFor(store, new SessionActivityRegistry(), {
+      activeTurnCheckIntervalMs: 1,
+      inspectTurn: async () => {
+        inspections += 1;
+        return statuses.shift() ?? 'failed';
+      },
+      startTurn: async (_sessionId, input) => {
+        turns += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+    });
+    try {
+      assert.equal(await coordinator.recover(), 1);
+      await coordinator.waitForIdle();
+
+      const delivered = await store.readShellRun(record.sessionId, record.shellRunId);
+      assert.ok(inspections >= 3);
+      assert.equal(turns, 1);
+      assert.equal(delivered.completionWake?.attemptCount, 2);
+      assert.equal(delivered.completionWake?.attemptTurnId, 'wake-turn-1');
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  for (const previousStatus of ['failed', 'missing'] as const) {
+    test(`retries a recovered ${previousStatus} attempt within the durable budget`, async () => {
+      const store = await createStore();
+      const record = await store.createShellRun(
+        terminalRecord({
+          completionWake: { attemptCount: 1, attemptTurnId: 'previous-turn' },
+        }),
+      );
+      let turns = 0;
+      const coordinator = coordinatorFor(store, new SessionActivityRegistry(), {
+        inspectTurn: async () => previousStatus,
+        startTurn: async (_sessionId, input) => {
+          turns += 1;
+          return { kind: 'completed', turnId: input.turnId };
+        },
+      });
+      try {
+        assert.equal(await coordinator.recover(), 1);
+        await coordinator.waitForIdle();
+
+        const delivered = await store.readShellRun(record.sessionId, record.shellRunId);
+        assert.equal(turns, 1);
+        assert.equal(delivered.completionWake?.attemptCount, 2);
+      } finally {
+        await coordinator.close();
+      }
+    });
+  }
+
+  test('persists thrown and errored attempts across retries before delivery', async () => {
+    const store = await createStore();
+    const record = await store.createShellRun(terminalRecord());
+    let turns = 0;
+    const coordinator = coordinatorFor(store, new SessionActivityRegistry(), {
+      startTurn: async (_sessionId, input) => {
+        turns += 1;
+        if (turns === 1) throw new Error('provider unavailable');
+        if (turns === 2) return { kind: 'errored', turnId: input.turnId, reason: 'stream failed' };
+        return { kind: 'completed', turnId: input.turnId };
+      },
+    });
+    try {
+      coordinator.notify(shellRunUpdate(record));
+      await coordinator.waitForIdle();
+
+      const delivered = await store.readShellRun(record.sessionId, record.shellRunId);
+      assert.equal(turns, 3);
+      assert.equal(delivered.completionWake?.attemptCount, 3);
+      assert.equal(delivered.completionWake?.lastFailure, 'stream failed');
+      assert.ok(delivered.completionWake?.deliveredAt !== undefined);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  test('durably exhausts the retry budget so restart recovery cannot reset it', async () => {
+    const store = await createStore();
+    const record = await store.createShellRun(terminalRecord());
+    const errors: unknown[] = [];
+    let turns = 0;
+    const coordinator = coordinatorFor(store, new SessionActivityRegistry(), {
+      maxDeliveryAttempts: 2,
+      onError: (_sessionId, error) => {
+        errors.push(error);
+      },
+      startTurn: async (_sessionId, input) => {
+        turns += 1;
+        return { kind: 'errored', turnId: input.turnId, reason: `failure-${turns}` };
+      },
+    });
+    try {
+      coordinator.notify(shellRunUpdate(record));
+      await coordinator.waitForIdle();
+
+      const exhausted = await store.readShellRun(record.sessionId, record.shellRunId);
+      assert.equal(turns, 2);
+      assert.equal(errors.length, 1);
+      assert.equal(exhausted.completionWake?.attemptCount, 2);
+      assert.equal(exhausted.completionWake?.lastFailure, 'failure-2');
+      assert.ok(exhausted.completionWake?.exhaustedAt !== undefined);
+      assert.equal(exhausted.completionWake?.deliveredAt, undefined);
+      assert.equal(await coordinator.recover(), 0);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  test('close aborts an active-attempt watcher without starting or reporting another turn', async () => {
+    const store = await createStore();
+    const record = await store.createShellRun(
+      terminalRecord({
+        completionWake: { attemptCount: 1, attemptTurnId: 'previous-turn' },
+      }),
+    );
+    let observedActive!: () => void;
+    const activeObserved = new Promise<void>((resolve) => {
+      observedActive = resolve;
+    });
+    let turns = 0;
+    const errors: unknown[] = [];
+    const coordinator = coordinatorFor(store, new SessionActivityRegistry(), {
+      activeTurnCheckIntervalMs: 60_000,
+      inspectTurn: async () => {
+        observedActive();
+        return 'active';
+      },
+      onError: (_sessionId, error) => {
+        errors.push(error);
+      },
+      startTurn: async (_sessionId, input) => {
+        turns += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+    });
+
+    coordinator.notify(shellRunUpdate(record));
+    await activeObserved;
+    await coordinator.close();
+
+    assert.equal(turns, 0);
+    assert.equal(errors.length, 0);
+  });
+
   test('renders a bounded terminal result rather than polling instructions', () => {
     const prompt = renderShellRunCompletionWakePrompt(terminalRecord());
     assert.match(prompt, /"status":"completed"/);
@@ -133,6 +375,10 @@ function coordinatorFor(
   activityRegistry: SessionActivityRegistry,
   overrides: {
     startTurn: ConstructorParameters<typeof ShellRunCompletionWakeCoordinator>[0]['startTurn'];
+    inspectTurn?: ConstructorParameters<typeof ShellRunCompletionWakeCoordinator>[0]['inspectTurn'];
+    maxDeliveryAttempts?: number;
+    activeTurnCheckIntervalMs?: number;
+    onError?: ConstructorParameters<typeof ShellRunCompletionWakeCoordinator>[0]['onError'];
   },
 ): ShellRunCompletionWakeCoordinator {
   let id = 0;
@@ -142,9 +388,16 @@ function coordinatorFor(
     store,
     listSessionIds: async () => ['session-1'],
     startTurn: overrides.startTurn,
-    inspectTurn: async () => 'missing',
+    inspectTurn: overrides.inspectTurn ?? (async () => 'missing'),
     newId: () => `wake-turn-${++id}`,
     now: () => ++now,
+    ...(overrides.maxDeliveryAttempts !== undefined
+      ? { maxDeliveryAttempts: overrides.maxDeliveryAttempts }
+      : {}),
+    ...(overrides.activeTurnCheckIntervalMs !== undefined
+      ? { activeTurnCheckIntervalMs: overrides.activeTurnCheckIntervalMs }
+      : {}),
+    ...(overrides.onError ? { onError: overrides.onError } : {}),
   });
 }
 

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -214,7 +214,7 @@ describe('ShellRunProcessManager', () => {
 
   test('persists completion notification through a real background process lifecycle', async () => {
     const updates: ShellRunUpdate[] = [];
-    const store = createLegacyShellRunStoreForTest(await workspace());
+    const store = createSqliteShellRunStore(await workspace());
     const manager = createManager(store, (update) => updates.push(update));
     const initial = await manager.runBackgroundBash(
       shellInput({

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -212,6 +212,31 @@ describe('ShellRunProcessManager', () => {
     );
   });
 
+  test('persists completion notification through a real background process lifecycle', async () => {
+    const updates: ShellRunUpdate[] = [];
+    const store = createLegacyShellRunStoreForTest(await workspace());
+    const manager = createManager(store, (update) => updates.push(update));
+    const initial = await manager.runBackgroundBash(
+      shellInput({
+        cwd: await workspace(),
+        command: 'unknown-duration-task',
+        argv: [process.execPath, '-e', 'setTimeout(() => process.stdout.write("done"), 50)'],
+        notifyOnComplete: true,
+      }),
+    );
+
+    assert.equal(initial.kind, 'shell_run');
+    assert.equal(initial.notifyOnComplete, true);
+    assert.equal((await store.readShellRun('session-1', 'shell-run-1')).notifyOnComplete, true);
+
+    await waitUntil(() => updates.some((update) => update.result.status === 'completed'));
+    const terminal = updates.find((update) => update.result.status === 'completed')?.result;
+    assert.equal(terminal?.notifyOnComplete, true);
+    assert.equal(terminal?.output?.mode, 'pipes');
+    if (terminal?.output?.mode !== 'pipes') throw new Error('expected terminal pipe output');
+    assert.equal(terminal.output.stdout, 'done');
+  });
+
   test('notifies resource owners when foreground and background commands reach terminal state', async () => {
     const store = createSqliteShellRunStore(await workspace());
     const manager = createManager(store);
@@ -2315,6 +2340,7 @@ function shellInput(input: {
   fdInputs?: readonly { fd: number; data: Uint8Array }[];
   pty?: boolean;
   timeoutMs?: number;
+  notifyOnComplete?: boolean;
   abortSignal?: AbortSignal;
   emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void;
   shell?: ShellPlan;
@@ -2333,6 +2359,7 @@ function shellInput(input: {
     ...(input.fdInputs !== undefined ? { fdInputs: input.fdInputs } : {}),
     ...(input.pty !== undefined ? { pty: input.pty } : {}),
     ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+    ...(input.notifyOnComplete === true ? { notifyOnComplete: true as const } : {}),
     ...(input.abortSignal !== undefined ? { abortSignal: input.abortSignal } : {}),
     ...(input.shell !== undefined ? { shell: input.shell } : {}),
     ...(input.onCompletion !== undefined ? { onCompletion: input.onCompletion } : {}),

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -42,6 +42,26 @@ describe('Bash tool description declares the executing shell', () => {
     assert.match(tool.description, /PowerShell 7 \(pwsh\)/);
     assert.match(tool.description, /git ls-files/);
     assert.match(tool.description, /run_in_background=true/);
+    assert.match(tool.description, /notify_on_complete=true/);
+    assert.match(tool.description, /do not sleep or poll/);
+  });
+
+  test('completion notification is accepted only for background commands', () => {
+    const parameters = buildManagedBashTool(fakeShellRuns()).parameters as {
+      safeParse(input: unknown): { success: boolean };
+    };
+    assert.equal(
+      parameters.safeParse({
+        command: 'cargo build',
+        run_in_background: true,
+        notify_on_complete: true,
+      }).success,
+      true,
+    );
+    assert.equal(
+      parameters.safeParse({ command: 'cargo build', notify_on_complete: true }).success,
+      false,
+    );
   });
 });
 
@@ -87,6 +107,41 @@ describe('Bash tool shell is threaded through to execution, not just the descrip
     const tool = buildManagedBashTool(controller, { shell: pwshPlan });
     await tool.impl({ command: 'echo hi', run_in_background: true }, fakeToolContext());
     assert.deepEqual((captured[0] as { shell?: unknown }).shell, pwshPlan);
+  });
+
+  test('background tool persists the model completion-notification subscription', async () => {
+    const captured: unknown[] = [];
+    const controller: ShellRunLauncher = {
+      runForegroundBash: () => Promise.reject(new Error('not used')),
+      runBackgroundBash: (input) => {
+        captured.push(input);
+        return Promise.resolve({
+          kind: 'shell_run',
+          ref: 'maka://runtime/background-tasks/sr_test',
+          mode: 'pipes',
+          status: 'running',
+          cwd: '.',
+          cmd: 'cargo build',
+          notifyOnComplete: true,
+          startedAt: 1,
+          updatedAt: 1,
+          revision: 1,
+        });
+      },
+    };
+    const tool = buildManagedBashTool(controller);
+
+    const result = await tool.impl(
+      {
+        command: 'cargo build',
+        run_in_background: true,
+        notify_on_complete: true,
+      },
+      fakeToolContext(),
+    );
+
+    assert.equal((captured[0] as { notifyOnComplete?: boolean }).notifyOnComplete, true);
+    assert.equal((result as { notifyOnComplete?: boolean }).notifyOnComplete, true);
   });
 
   test('managed completion callback remains exactly-once when the launcher settles it', async () => {

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -1127,6 +1127,9 @@ export class AgentRun {
       ...(this.input.userInput.origin?.kind === 'goal'
         ? { goalId: this.input.userInput.origin.goalId }
         : {}),
+      ...(this.input.userInput.origin?.kind === 'shell_run_completion'
+        ? { shellRunCompletionWakeId: this.input.userInput.origin.shellRunId }
+        : {}),
       ...(this.input.userInput.origin?.kind === 'agent_graph'
         ? {
             agentGraphWakeId: this.input.userInput.origin.wakeId,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1709,6 +1709,13 @@ export class AiSdkBackend implements AgentBackend {
               ) {
                 this.handleAgentGraphYieldToolResult(scope, settlement.result);
               }
+              if (
+                returnedToolCalls.length === 1 &&
+                isBackgroundCompletionSubscriptionResult(settlement.result)
+              ) {
+                scope.loopStopReason = 'background_task_wait';
+                scope.loopStopRequested = true;
+              }
             }
             await queue.waitUntilConsumedThroughCurrent();
             for (let index = 0; index < returnedToolCalls.length; index += 1) {
@@ -3314,6 +3321,16 @@ function isPlanToolResult(output: unknown): output is PlanToolResult {
     'plan_execution_completed',
     'plan_execution_cancelled',
   ].includes(String((output as { kind?: unknown }).kind));
+}
+
+function isBackgroundCompletionSubscriptionResult(output: unknown): boolean {
+  if (output === null || typeof output !== 'object' || Array.isArray(output)) return false;
+  const result = output as Record<string, unknown>;
+  return (
+    result.kind === 'shell_run' &&
+    result.notifyOnComplete === true &&
+    (result.status === 'starting' || result.status === 'running')
+  );
 }
 
 function isAgentGraphYieldToolResult(output: unknown): output is YieldAgentGraphToolResult {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1696,6 +1696,7 @@ export class AiSdkBackend implements AgentBackend {
               if (outcome.status === 'rejected') throw outcome.reason;
               return outcome.value;
             });
+            let backgroundCompletionSubscribed = false;
             for (let index = 0; index < settlements.length; index += 1) {
               const settlement = settlements[index]!;
               const toolCall = returnedToolCalls[index];
@@ -1709,13 +1710,13 @@ export class AiSdkBackend implements AgentBackend {
               ) {
                 this.handleAgentGraphYieldToolResult(scope, settlement.result);
               }
-              if (
-                returnedToolCalls.length === 1 &&
-                isBackgroundCompletionSubscriptionResult(settlement.result)
-              ) {
-                scope.loopStopReason = 'background_task_wait';
-                scope.loopStopRequested = true;
-              }
+              backgroundCompletionSubscribed ||= isBackgroundCompletionSubscriptionResult(
+                settlement.result,
+              );
+            }
+            if (backgroundCompletionSubscribed) {
+              scope.loopStopReason = 'background_task_wait';
+              scope.loopStopRequested = true;
             }
             await queue.waitUntilConsumedThroughCurrent();
             for (let index = 0; index < returnedToolCalls.length; index += 1) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -571,6 +571,14 @@ export type {
   ShellRunWriteInput,
 } from './shell-run-contract.js';
 export { ShellRunProcessManager } from './shell-run-manager.js';
+export {
+  ShellRunCompletionWakeCoordinator,
+  renderShellRunCompletionWakePrompt,
+} from './shell-run-completion-wake.js';
+export type {
+  ShellRunCompletionTurnStatus,
+  ShellRunCompletionWakeInput,
+} from './shell-run-completion-wake.js';
 export type { ShellRunUpdate } from '@maka/core';
 export {
   LOCAL_WORKSPACE_EXECUTOR_FACTS,

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -380,7 +380,12 @@ export class RuntimeRunner {
 
     let status: InvocationResultStatus = failure ? 'failed' : 'completed';
     const finalOutput = status === 'completed' ? finalOutputFromEvents(events) : undefined;
-    if (status === 'completed' && finalOutput === undefined && !graphYielded) {
+    if (
+      status === 'completed' &&
+      finalOutput === undefined &&
+      !graphYielded &&
+      !hasCompletedBackgroundTaskWait(events)
+    ) {
       status = 'failed';
       failure = {
         class: 'missing_final_output',
@@ -424,6 +429,16 @@ export class RuntimeRunner {
       finishedAt: args.finishedAt,
     };
   }
+}
+
+function hasCompletedBackgroundTaskWait(events: readonly RuntimeEvent[]): boolean {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event && isTerminalRuntimeEvent(event)) {
+      return event.actions?.stateDelta?.stopReason === 'background_task_wait';
+    }
+  }
+  return false;
 }
 
 /**

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -4580,6 +4580,13 @@ export class SessionManager {
         executionKind: input.execution.kind,
         goalId: input.execution.goalId,
       };
+    } else if (input.execution.kind === 'shell_run_completion_wake') {
+      headerExtras.shellRunCompletionWakeId = input.execution.shellRunId;
+      recoveryReason = 'shell_run_completion_internal_admission_without_run';
+      diagnostic = {
+        executionKind: input.execution.kind,
+        shellRunId: input.execution.shellRunId,
+      };
     } else if (input.execution.kind === 'agent_graph_supervisor_wake') {
       headerExtras.agentGraphWakeId = input.execution.wakeId;
       headerExtras.agentGraphWakeAttemptId = input.execution.attemptId;

--- a/packages/runtime/src/shell-run-completion-wake.ts
+++ b/packages/runtime/src/shell-run-completion-wake.ts
@@ -1,0 +1,222 @@
+import {
+  isTerminalShellRunStatus,
+  type ShellRunRecord,
+  type ShellRunStore,
+  type ShellRunUpdate,
+  type UserMessageInput,
+} from '@maka/core';
+
+import {
+  type GoalTurnOutcome,
+  type SessionActivityLease,
+  SessionActivityRegistry,
+} from './goal-turn-lifecycle.js';
+import { parseShellRunResourceRef } from './shell-run-contract.js';
+
+const DEFAULT_MAX_DELIVERY_ATTEMPTS = 3;
+
+export type ShellRunCompletionTurnStatus = 'active' | 'completed' | 'failed' | 'missing';
+
+export interface ShellRunCompletionWakeInput {
+  activityRegistry: SessionActivityRegistry;
+  store: ShellRunStore;
+  listSessionIds(): Promise<readonly string[]>;
+  startTurn(
+    sessionId: string,
+    input: UserMessageInput,
+    activity: SessionActivityLease,
+    abortSignal: AbortSignal,
+  ): Promise<GoalTurnOutcome>;
+  inspectTurn(sessionId: string, turnId: string): Promise<ShellRunCompletionTurnStatus>;
+  newId(): string;
+  now(): number;
+  maxDeliveryAttempts?: number;
+  onError?(sessionId: string, error: unknown): void | Promise<void>;
+}
+
+/**
+ * Event-driven bridge from a detached ShellRun terminal transition to one
+ * continuation turn in its owning Agent session.
+ *
+ * The ShellRun record is the durable subscription and delivery authority.
+ * Process notifications are only hints: every delivery re-reads the record,
+ * waits for the session activity lane, and records its turn id before starting
+ * the model. Recovery can therefore converge a terminal run without polling a
+ * live process or spending model tokens before completion.
+ */
+export class ShellRunCompletionWakeCoordinator {
+  readonly #input: ShellRunCompletionWakeInput;
+  readonly #tasks = new Set<Promise<void>>();
+  readonly #pending = new Set<string>();
+  readonly #abortController = new AbortController();
+  readonly #maxDeliveryAttempts: number;
+  #closed = false;
+
+  constructor(input: ShellRunCompletionWakeInput) {
+    this.#input = input;
+    this.#maxDeliveryAttempts = input.maxDeliveryAttempts ?? DEFAULT_MAX_DELIVERY_ATTEMPTS;
+    if (!Number.isSafeInteger(this.#maxDeliveryAttempts) || this.#maxDeliveryAttempts < 1) {
+      throw new Error('ShellRun completion wake attempts must be a positive safe integer');
+    }
+  }
+
+  notify(update: ShellRunUpdate): void {
+    if (
+      this.#closed ||
+      update.result.notifyOnComplete !== true ||
+      !isTerminalShellRunStatus(update.result.status)
+    ) {
+      return;
+    }
+    const target = parseShellRunResourceRef(update.result.ref);
+    if (!target) return;
+    this.#schedule(update.sessionId, target.shellRunId);
+  }
+
+  /** Replays terminal, subscribed runs whose completion result was not delivered. */
+  async recover(): Promise<number> {
+    if (this.#closed) return 0;
+    let scheduled = 0;
+    for (const sessionId of await this.#input.listSessionIds()) {
+      if (this.#closed) break;
+      for (const record of await this.#input.store.listSessionShellRuns(sessionId)) {
+        if (!isWakeEligible(record)) continue;
+        this.#schedule(sessionId, record.shellRunId);
+        scheduled += 1;
+      }
+    }
+    return scheduled;
+  }
+
+  async waitForIdle(): Promise<void> {
+    while (this.#tasks.size > 0) await Promise.all([...this.#tasks]);
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#abortController.abort();
+    await this.waitForIdle();
+  }
+
+  #schedule(sessionId: string, shellRunId: string): void {
+    const key = `${sessionId}\0${shellRunId}`;
+    if (this.#closed || this.#pending.has(key)) return;
+    this.#pending.add(key);
+    const task = this.#deliver(sessionId, shellRunId)
+      .catch((error) => {
+        if (!this.#closed && !isAbortError(error)) {
+          return this.#input.onError?.(sessionId, error);
+        }
+      })
+      .finally(() => this.#pending.delete(key));
+    this.#tasks.add(task);
+    void task.finally(() => this.#tasks.delete(task));
+  }
+
+  async #deliver(sessionId: string, shellRunId: string): Promise<void> {
+    let lastFailure = 'unknown failure';
+    for (let attempt = 0; attempt < this.#maxDeliveryAttempts; attempt += 1) {
+      const activity = await this.#input.activityRegistry.acquire(
+        sessionId,
+        this.#abortController.signal,
+      );
+      try {
+        if (this.#closed) return;
+        let record = await this.#input.store.readShellRun(sessionId, shellRunId);
+        if (!isWakeEligible(record)) return;
+
+        // A foreground read that already consumed the terminal result wins the
+        // race; no additional model turn is useful.
+        if (record.observedAt !== undefined) return;
+
+        const previousTurnId = record.completionWake?.attemptTurnId;
+        if (previousTurnId) {
+          const previous = await this.#input.inspectTurn(sessionId, previousTurnId);
+          if (previous === 'completed') {
+            await this.#markDelivered(record, previousTurnId);
+            return;
+          }
+          if (previous === 'active') return;
+        }
+
+        const turnId = this.#input.newId();
+        record = await this.#input.store.updateShellRun(sessionId, shellRunId, {
+          completionWake: { attemptTurnId: turnId },
+          updatedAt: this.#input.now(),
+        });
+        let outcome: GoalTurnOutcome;
+        try {
+          outcome = await this.#input.startTurn(
+            sessionId,
+            {
+              turnId,
+              text: renderShellRunCompletionWakePrompt(record),
+              displayText: 'A background command reached terminal completion.',
+            },
+            activity,
+            this.#abortController.signal,
+          );
+        } catch (error) {
+          lastFailure = errorMessage(error);
+          continue;
+        }
+        if (outcome.kind === 'completed' || outcome.kind === 'suspended') {
+          await this.#markDelivered(record, turnId);
+          return;
+        }
+        lastFailure = outcome.kind === 'errored' ? outcome.reason : outcome.kind;
+      } finally {
+        activity.release();
+      }
+      if (this.#closed) return;
+    }
+    throw new Error(
+      `ShellRun completion wake ${shellRunId} was not delivered after ${this.#maxDeliveryAttempts} attempts: ${lastFailure}`,
+    );
+  }
+
+  async #markDelivered(record: ShellRunRecord, attemptTurnId: string): Promise<void> {
+    const deliveredAt = this.#input.now();
+    await this.#input.store.updateShellRun(record.sessionId, record.shellRunId, {
+      completionWake: { attemptTurnId, deliveredAt },
+      observedAt: deliveredAt,
+      updatedAt: deliveredAt,
+    });
+  }
+}
+
+export function renderShellRunCompletionWakePrompt(record: ShellRunRecord): string {
+  const result = {
+    ref: `maka://runtime/background-tasks/${record.shellRunId}`,
+    status: record.status,
+    exitCode: record.exitCode,
+    failureMessage: record.failureMessage,
+    completedAt: record.completedAt,
+    output: record.output,
+  };
+  return [
+    '<system-reminder>',
+    'A background Bash task that requested completion notification is now terminal.',
+    'This is the event-driven completion wake. Do not sleep or poll this task ref.',
+    `Result: ${JSON.stringify(result)}`,
+    'Continue the work that depended on this result. If no work remains, report the final outcome.',
+    '</system-reminder>',
+  ].join('\n');
+}
+
+function isWakeEligible(record: ShellRunRecord): boolean {
+  return (
+    record.notifyOnComplete === true &&
+    isTerminalShellRunStatus(record.status) &&
+    record.completionWake?.deliveredAt === undefined
+  );
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/runtime/src/shell-run-completion-wake.ts
+++ b/packages/runtime/src/shell-run-completion-wake.ts
@@ -14,6 +14,7 @@ import {
 import { parseShellRunResourceRef } from './shell-run-contract.js';
 
 const DEFAULT_MAX_DELIVERY_ATTEMPTS = 3;
+const DEFAULT_ACTIVE_TURN_CHECK_INTERVAL_MS = 1_000;
 
 export type ShellRunCompletionTurnStatus = 'active' | 'completed' | 'failed' | 'missing';
 
@@ -31,6 +32,7 @@ export interface ShellRunCompletionWakeInput {
   newId(): string;
   now(): number;
   maxDeliveryAttempts?: number;
+  activeTurnCheckIntervalMs?: number;
   onError?(sessionId: string, error: unknown): void | Promise<void>;
 }
 
@@ -50,13 +52,22 @@ export class ShellRunCompletionWakeCoordinator {
   readonly #pending = new Set<string>();
   readonly #abortController = new AbortController();
   readonly #maxDeliveryAttempts: number;
+  readonly #activeTurnCheckIntervalMs: number;
   #closed = false;
 
   constructor(input: ShellRunCompletionWakeInput) {
     this.#input = input;
     this.#maxDeliveryAttempts = input.maxDeliveryAttempts ?? DEFAULT_MAX_DELIVERY_ATTEMPTS;
+    this.#activeTurnCheckIntervalMs =
+      input.activeTurnCheckIntervalMs ?? DEFAULT_ACTIVE_TURN_CHECK_INTERVAL_MS;
     if (!Number.isSafeInteger(this.#maxDeliveryAttempts) || this.#maxDeliveryAttempts < 1) {
       throw new Error('ShellRun completion wake attempts must be a positive safe integer');
+    }
+    if (
+      !Number.isSafeInteger(this.#activeTurnCheckIntervalMs) ||
+      this.#activeTurnCheckIntervalMs < 1
+    ) {
+      throw new Error('ShellRun completion wake active-turn interval must be positive');
     }
   }
 
@@ -115,8 +126,7 @@ export class ShellRunCompletionWakeCoordinator {
   }
 
   async #deliver(sessionId: string, shellRunId: string): Promise<void> {
-    let lastFailure = 'unknown failure';
-    for (let attempt = 0; attempt < this.#maxDeliveryAttempts; attempt += 1) {
+    for (;;) {
       const activity = await this.#input.activityRegistry.acquire(
         sessionId,
         this.#abortController.signal,
@@ -137,12 +147,30 @@ export class ShellRunCompletionWakeCoordinator {
             await this.#markDelivered(record, previousTurnId);
             return;
           }
-          if (previous === 'active') return;
+          if (previous === 'active') {
+            // A recovered attempt may still be owned by another live stream.
+            // Release the session lane while watching its durable AgentRun so a
+            // later failure cannot strand this subscription until another host
+            // restart or recovery pass.
+            activity.release();
+            await this.#waitForActiveTurn(sessionId, previousTurnId);
+            continue;
+          }
         }
 
+        const attemptCount = durableAttemptCount(record);
+        if (attemptCount >= this.#maxDeliveryAttempts) {
+          const failure = record.completionWake?.lastFailure ?? 'previous attempt did not complete';
+          await this.#markExhausted(record, failure);
+          throw deliveryExhaustedError(shellRunId, this.#maxDeliveryAttempts, failure);
+        }
         const turnId = this.#input.newId();
         record = await this.#input.store.updateShellRun(sessionId, shellRunId, {
-          completionWake: { attemptTurnId: turnId },
+          completionWake: {
+            ...record.completionWake,
+            attemptCount: attemptCount + 1,
+            attemptTurnId: turnId,
+          },
           updatedAt: this.#input.now(),
         });
         let outcome: GoalTurnOutcome;
@@ -158,31 +186,75 @@ export class ShellRunCompletionWakeCoordinator {
             this.#abortController.signal,
           );
         } catch (error) {
-          lastFailure = errorMessage(error);
+          const failure = boundedFailure(errorMessage(error));
+          record = await this.#markAttemptFailed(record, failure);
+          if (durableAttemptCount(record) >= this.#maxDeliveryAttempts) {
+            await this.#markExhausted(record, failure);
+            throw deliveryExhaustedError(shellRunId, this.#maxDeliveryAttempts, failure);
+          }
           continue;
         }
         if (outcome.kind === 'completed' || outcome.kind === 'suspended') {
           await this.#markDelivered(record, turnId);
           return;
         }
-        lastFailure = outcome.kind === 'errored' ? outcome.reason : outcome.kind;
+        const failure = boundedFailure(outcome.kind === 'errored' ? outcome.reason : outcome.kind);
+        record = await this.#markAttemptFailed(record, failure);
+        if (durableAttemptCount(record) >= this.#maxDeliveryAttempts) {
+          await this.#markExhausted(record, failure);
+          throw deliveryExhaustedError(shellRunId, this.#maxDeliveryAttempts, failure);
+        }
       } finally {
         activity.release();
       }
       if (this.#closed) return;
     }
-    throw new Error(
-      `ShellRun completion wake ${shellRunId} was not delivered after ${this.#maxDeliveryAttempts} attempts: ${lastFailure}`,
-    );
   }
 
   async #markDelivered(record: ShellRunRecord, attemptTurnId: string): Promise<void> {
     const deliveredAt = this.#input.now();
     await this.#input.store.updateShellRun(record.sessionId, record.shellRunId, {
-      completionWake: { attemptTurnId, deliveredAt },
+      completionWake: {
+        ...record.completionWake,
+        attemptCount: durableAttemptCount(record),
+        attemptTurnId,
+        deliveredAt,
+      },
       observedAt: deliveredAt,
       updatedAt: deliveredAt,
     });
+  }
+
+  async #markAttemptFailed(record: ShellRunRecord, lastFailure: string): Promise<ShellRunRecord> {
+    return this.#input.store.updateShellRun(record.sessionId, record.shellRunId, {
+      completionWake: {
+        ...record.completionWake,
+        attemptCount: durableAttemptCount(record),
+        lastFailure,
+      },
+      updatedAt: this.#input.now(),
+    });
+  }
+
+  async #markExhausted(record: ShellRunRecord, failure: string): Promise<void> {
+    if (record.completionWake?.exhaustedAt !== undefined) return;
+    const exhaustedAt = this.#input.now();
+    await this.#input.store.updateShellRun(record.sessionId, record.shellRunId, {
+      completionWake: {
+        ...record.completionWake,
+        attemptCount: durableAttemptCount(record),
+        lastFailure: boundedFailure(failure),
+        exhaustedAt,
+      },
+      updatedAt: exhaustedAt,
+    });
+  }
+
+  async #waitForActiveTurn(sessionId: string, turnId: string): Promise<void> {
+    for (;;) {
+      await waitForAbortableDelay(this.#activeTurnCheckIntervalMs, this.#abortController.signal);
+      if ((await this.#input.inspectTurn(sessionId, turnId)) !== 'active') return;
+    }
   }
 }
 
@@ -209,8 +281,47 @@ function isWakeEligible(record: ShellRunRecord): boolean {
   return (
     record.notifyOnComplete === true &&
     isTerminalShellRunStatus(record.status) &&
-    record.completionWake?.deliveredAt === undefined
+    record.observedAt === undefined &&
+    record.completionWake?.deliveredAt === undefined &&
+    record.completionWake?.exhaustedAt === undefined
   );
+}
+
+function durableAttemptCount(record: ShellRunRecord): number {
+  return (
+    record.completionWake?.attemptCount ??
+    (record.completionWake?.attemptTurnId === undefined ? 0 : 1)
+  );
+}
+
+function boundedFailure(failure: string): string {
+  return failure.slice(0, 4_000) || 'unknown failure';
+}
+
+function deliveryExhaustedError(shellRunId: string, maxAttempts: number, failure: string): Error {
+  return new Error(
+    `ShellRun completion wake ${shellRunId} was not delivered after ${maxAttempts} attempts: ${failure}`,
+  );
+}
+
+async function waitForAbortableDelay(delayMs: number, abortSignal: AbortSignal): Promise<void> {
+  abortSignal.throwIfAborted();
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayMs);
+    const onAbort = () => {
+      cleanup();
+      reject(new DOMException('ShellRun completion wake was aborted', 'AbortError'));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      abortSignal.removeEventListener('abort', onAbort);
+    };
+    abortSignal.addEventListener('abort', onAbort, { once: true });
+    if (abortSignal.aborted) onAbort();
+  });
 }
 
 function isAbortError(error: unknown): boolean {

--- a/packages/runtime/src/shell-run-completion-wake.ts
+++ b/packages/runtime/src/shell-run-completion-wake.ts
@@ -33,6 +33,8 @@ export interface ShellRunCompletionWakeInput {
   now(): number;
   maxDeliveryAttempts?: number;
   activeTurnCheckIntervalMs?: number;
+  /** Keeps an on-demand host alive from notification scheduling through durable settlement. */
+  acquireTaskLease?(): { release(): void };
   onError?(sessionId: string, error: unknown): void | Promise<void>;
 }
 
@@ -114,13 +116,17 @@ export class ShellRunCompletionWakeCoordinator {
     const key = `${sessionId}\0${shellRunId}`;
     if (this.#closed || this.#pending.has(key)) return;
     this.#pending.add(key);
+    const taskLease = this.#input.acquireTaskLease?.();
     const task = this.#deliver(sessionId, shellRunId)
       .catch((error) => {
         if (!this.#closed && !isAbortError(error)) {
           return this.#input.onError?.(sessionId, error);
         }
       })
-      .finally(() => this.#pending.delete(key));
+      .finally(() => {
+        this.#pending.delete(key);
+        taskLease?.release();
+      });
     this.#tasks.add(task);
     void task.finally(() => this.#tasks.delete(task));
   }
@@ -181,6 +187,7 @@ export class ShellRunCompletionWakeCoordinator {
               turnId,
               text: renderShellRunCompletionWakePrompt(record),
               displayText: 'A background command reached terminal completion.',
+              origin: { kind: 'shell_run_completion', shellRunId: record.shellRunId },
             },
             activity,
             this.#abortController.signal,

--- a/packages/runtime/src/shell-run-contract.ts
+++ b/packages/runtime/src/shell-run-contract.ts
@@ -70,6 +70,8 @@ export interface ShellRunBashInput {
   /** Binary payloads exposed to pipe-mode children on inherited descriptors. */
   fdInputs?: readonly ChildFdInput[];
   pty?: boolean;
+  /** Resume the owning Agent session once when a detached run becomes terminal. */
+  notifyOnComplete?: boolean;
   timeoutMs?: number;
   abortSignal?: AbortSignal;
   emitOutput: (stream: 'stdout' | 'stderr', chunk: string) => void;

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -511,7 +511,8 @@ export class ShellRunProcessManager
       ...visible.map((record) => {
         const completed =
           record.completedAt !== undefined ? ` completedAt=${record.completedAt}` : '';
-        return `- ref=${shellRunResourceRef(record.shellRunId)} mode=${record.output.mode} status=${record.status} cwd=${record.cwd} updatedAt=${record.updatedAt}${completed} command=${JSON.stringify(record.command)}`;
+        const notification = record.notifyOnComplete === true ? ' notifyOnComplete=true' : '';
+        return `- ref=${shellRunResourceRef(record.shellRunId)} mode=${record.output.mode} status=${record.status} cwd=${record.cwd} updatedAt=${record.updatedAt}${completed}${notification} command=${JSON.stringify(record.command)}`;
       }),
     ];
     const overflow = records.length - visible.length;
@@ -526,6 +527,13 @@ export class ShellRunProcessManager
         ? 'Use Read on a ref for its bounded output snapshot; use WriteStdin to control a running PTY task.'
         : 'Use Read on a ref for its bounded output snapshot.',
     );
+    if (
+      records.some((record) => isActiveShellRunStatus(record.status) && record.notifyOnComplete)
+    ) {
+      lines.push(
+        'A running task with notifyOnComplete=true will resume this session at terminal completion. Do not sleep or poll its ref.',
+      );
+    }
     return lines.join('\n');
   }
 
@@ -837,6 +845,7 @@ export class ShellRunProcessManager
       sessionId: input.sessionId,
       mode,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      ...(input.notifyOnComplete === true ? { notifyOnComplete: true as const } : {}),
       record,
       visibleRef: false,
       pendingStops: new Set(),

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -881,6 +881,7 @@ export class ShellRunProcessManager
       startedAt,
       updatedAt: startedAt,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      ...(input.notifyOnComplete === true ? { notifyOnComplete: true as const } : {}),
       ...(input.sandboxType
         ? {
             sandboxExecution: {

--- a/packages/runtime/src/shell-run-tool-result.ts
+++ b/packages/runtime/src/shell-run-tool-result.ts
@@ -119,6 +119,7 @@ function shellRunStateContent(record: ShellRunRecord): ShellRunCompactResult {
     updatedAt: record.updatedAt,
     ...(record.completedAt !== undefined ? { completedAt: record.completedAt } : {}),
     ...(record.timeoutMs !== undefined ? { timeoutMs: record.timeoutMs } : {}),
+    ...(record.notifyOnComplete === true ? { notifyOnComplete: true as const } : {}),
     ...(record.exitCode !== undefined ? { exitCode: record.exitCode } : {}),
     ...(record.failureMessage !== undefined ? { failureMessage: record.failureMessage } : {}),
     revision: record.revision,

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -158,12 +158,14 @@ export function buildManagedBashTool(
       withShellGuidance('Run a shell command in the session cwd.', shell) +
       ` Foreground is the default (timeout ${DEFAULT_BASH_TIMEOUT_MS}ms, maximum ${MAX_FOREGROUND_BASH_TIMEOUT_MS}ms).` +
       ` Set run_in_background=true only when the command should continue as a tracked runtime background task; background commands have no default timeout (maximum explicit timeout ${MAX_SHELL_RUN_TIMEOUT_MS}ms).` +
+      ' When a background result is required, also set notify_on_complete=true: the host ends this turn and resumes the session once at terminal completion, so do not sleep or poll the returned ref.' +
       ' Set pty=true together with run_in_background=true only for terminal semantics or later input; use the returned ref with Read or WriteStdin. Enforced by the current session sandbox boundary.',
     parameters: z
       .object({
         command: z.string().describe('The shell command to execute'),
         timeout_ms: z.number().int().positive().max(MAX_SHELL_RUN_TIMEOUT_MS).optional(),
         run_in_background: z.boolean().optional(),
+        notify_on_complete: z.boolean().optional(),
         pty: z.boolean().optional(),
         required_boundary: sandboxBoundaryExpansionSchema
           .optional()
@@ -172,7 +174,7 @@ export function buildManagedBashTool(
           ),
       })
       .strict()
-      .superRefine(({ timeout_ms, run_in_background, pty }, ctx) => {
+      .superRefine(({ timeout_ms, run_in_background, notify_on_complete, pty }, ctx) => {
         if (
           !run_in_background &&
           timeout_ms !== undefined &&
@@ -194,10 +196,20 @@ export function buildManagedBashTool(
             message: 'PTY Bash requires run_in_background=true',
           });
         }
+        if (notify_on_complete && !run_in_background) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['notify_on_complete'],
+            message: 'Completion notification requires run_in_background=true',
+          });
+        }
       }),
     toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     ...(options.executionFacts ? { executionFacts: options.executionFacts } : {}),
-    impl: async ({ command, timeout_ms, run_in_background, pty, required_boundary }, ctx) => {
+    impl: async (
+      { command, timeout_ms, run_in_background, notify_on_complete, pty, required_boundary },
+      ctx,
+    ) => {
       const normalizedRequiredBoundary = await preflightDeclaredSandboxBoundary(
         required_boundary,
         ctx,
@@ -220,6 +232,7 @@ export function buildManagedBashTool(
           cwd: transformed?.cwd ?? ctx.cwd,
           command,
           ...(pty !== undefined ? { pty } : {}),
+          ...(notify_on_complete === true ? { notifyOnComplete: true } : {}),
           ...(transformed?.argv ? { argv: transformed.argv } : { shell }),
           ...(transformed?.env ? { env: transformed.env } : {}),
           ...(transformed?.fdInputs ? { fdInputs: transformed.fdInputs } : {}),

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1409,6 +1409,16 @@ function normalizeRootExecutionDescriptor(value: unknown): RootExecutionDescript
     }
     return Object.freeze({ kind: 'goal', goalId: value.goalId });
   }
+  if (value.kind === 'shell_run_completion_wake') {
+    if (
+      !hasExactKeys(value, ['kind', 'shellRunId']) ||
+      typeof value.shellRunId !== 'string' ||
+      !isSafeId(value.shellRunId)
+    ) {
+      throw new Error('Invalid root execution descriptor');
+    }
+    return Object.freeze({ kind: 'shell_run_completion_wake', shellRunId: value.shellRunId });
+  }
   if (value.kind === 'agent_graph_supervisor_wake') {
     if (
       !hasExactKeys(value, ['kind', 'graphId', 'wakeId', 'attemptId']) ||

--- a/packages/storage/src/shell-run-store.ts
+++ b/packages/storage/src/shell-run-store.ts
@@ -263,10 +263,22 @@ function isSandboxExecution(value: unknown): boolean {
 
 function isCompletionWake(value: unknown, notifyOnComplete: unknown, status: unknown): boolean {
   if (value === undefined) return true;
-  if (notifyOnComplete !== true || !hasOnlyKeys(value, new Set(['attemptTurnId', 'deliveredAt']))) {
+  if (
+    notifyOnComplete !== true ||
+    !hasOnlyKeys(
+      value,
+      new Set(['attemptCount', 'attemptTurnId', 'lastFailure', 'deliveredAt', 'exhaustedAt']),
+    )
+  ) {
     return false;
   }
   const wake = value as Record<string, unknown>;
+  if (
+    wake.attemptCount !== undefined &&
+    (!Number.isSafeInteger(wake.attemptCount) || (wake.attemptCount as number) < 0)
+  ) {
+    return false;
+  }
   if (
     wake.attemptTurnId !== undefined &&
     (typeof wake.attemptTurnId !== 'string' || wake.attemptTurnId.length === 0)
@@ -275,6 +287,25 @@ function isCompletionWake(value: unknown, notifyOnComplete: unknown, status: unk
   }
   if (wake.deliveredAt !== undefined) {
     if (!isFiniteNumber(wake.deliveredAt) || typeof wake.attemptTurnId !== 'string') return false;
+  }
+  if (
+    wake.lastFailure !== undefined &&
+    (typeof wake.lastFailure !== 'string' ||
+      wake.lastFailure.length === 0 ||
+      wake.lastFailure.length > 4_000)
+  ) {
+    return false;
+  }
+  if (wake.exhaustedAt !== undefined) {
+    if (!isFiniteNumber(wake.exhaustedAt) || typeof wake.lastFailure !== 'string') return false;
+  }
+  if (wake.deliveredAt !== undefined && wake.exhaustedAt !== undefined) return false;
+  if (
+    (wake.deliveredAt !== undefined || wake.exhaustedAt !== undefined) &&
+    wake.attemptCount !== undefined &&
+    (wake.attemptCount as number) < 1
+  ) {
+    return false;
   }
   return isTerminalShellRunStatus(status as ShellRunRecord['status']);
 }
@@ -313,6 +344,23 @@ function assertShellRunTransition(current: ShellRunRecord, candidate: ShellRunRe
   ) {
     throw new Error(`ShellRun terminal outcome is immutable: ${current.status}`);
   }
+  const currentAttempts = current.completionWake?.attemptCount ?? 0;
+  const candidateAttempts = candidate.completionWake?.attemptCount ?? 0;
+  if (candidateAttempts < currentAttempts) {
+    throw new Error('ShellRun completion wake attempt count is monotonic');
+  }
+  if (
+    current.completionWake?.deliveredAt !== undefined &&
+    candidate.completionWake?.deliveredAt !== current.completionWake.deliveredAt
+  ) {
+    throw new Error('ShellRun completion wake delivery is immutable');
+  }
+  if (
+    current.completionWake?.exhaustedAt !== undefined &&
+    candidate.completionWake?.exhaustedAt !== current.completionWake.exhaustedAt
+  ) {
+    throw new Error('ShellRun completion wake exhaustion is immutable');
+  }
 }
 
 function hasOnlyKeys(value: unknown, allowed: ReadonlySet<string>): boolean {
@@ -338,11 +386,20 @@ function canonicalShellRunRecord(record: ShellRunRecord): ShellRunRecord {
     ...(record.completionWake !== undefined
       ? {
           completionWake: {
+            ...(record.completionWake.attemptCount !== undefined
+              ? { attemptCount: record.completionWake.attemptCount }
+              : {}),
             ...(record.completionWake.attemptTurnId !== undefined
               ? { attemptTurnId: record.completionWake.attemptTurnId }
               : {}),
+            ...(record.completionWake.lastFailure !== undefined
+              ? { lastFailure: record.completionWake.lastFailure }
+              : {}),
             ...(record.completionWake.deliveredAt !== undefined
               ? { deliveredAt: record.completionWake.deliveredAt }
+              : {}),
+            ...(record.completionWake.exhaustedAt !== undefined
+              ? { exhaustedAt: record.completionWake.exhaustedAt }
               : {}),
           },
         }

--- a/packages/storage/src/shell-run-store.ts
+++ b/packages/storage/src/shell-run-store.ts
@@ -25,6 +25,7 @@ const SHELL_RUN_PATCH_KEYS = new Set([
   'completedAt',
   'observedAt',
   'output',
+  'completionWake',
 ]);
 const SHELL_RUN_RECORD_KEYS = new Set([
   'shellRunId',
@@ -39,6 +40,8 @@ const SHELL_RUN_RECORD_KEYS = new Set([
   'updatedAt',
   'completedAt',
   'timeoutMs',
+  'notifyOnComplete',
+  'completionWake',
   'exitCode',
   'failureMessage',
   'sandboxExecution',
@@ -215,6 +218,8 @@ function normalizeShellRunRecord(
     (record.timeoutMs === undefined || isFiniteNumber(record.timeoutMs)) &&
     (record.exitCode === undefined || isFiniteNumber(record.exitCode)) &&
     (record.observedAt === undefined || isFiniteNumber(record.observedAt)) &&
+    (record.notifyOnComplete === undefined || record.notifyOnComplete === true) &&
+    isCompletionWake(record.completionWake, record.notifyOnComplete, record.status) &&
     isSandboxExecution(record.sandboxExecution) &&
     isSandboxEscalation(record.sandboxEscalation, record.sandboxExecution) &&
     optionalStrings.every((item) => item === undefined || typeof item === 'string');
@@ -254,6 +259,24 @@ function isSandboxExecution(value: unknown): boolean {
     typeof execution.enforced === 'boolean' &&
     execution.enforced === (execution.type !== 'none')
   );
+}
+
+function isCompletionWake(value: unknown, notifyOnComplete: unknown, status: unknown): boolean {
+  if (value === undefined) return true;
+  if (notifyOnComplete !== true || !hasOnlyKeys(value, new Set(['attemptTurnId', 'deliveredAt']))) {
+    return false;
+  }
+  const wake = value as Record<string, unknown>;
+  if (
+    wake.attemptTurnId !== undefined &&
+    (typeof wake.attemptTurnId !== 'string' || wake.attemptTurnId.length === 0)
+  ) {
+    return false;
+  }
+  if (wake.deliveredAt !== undefined) {
+    if (!isFiniteNumber(wake.deliveredAt) || typeof wake.attemptTurnId !== 'string') return false;
+  }
+  return isTerminalShellRunStatus(status as ShellRunRecord['status']);
 }
 
 function isSandboxEscalation(value: unknown, execution: unknown): boolean {
@@ -311,6 +334,19 @@ function canonicalShellRunRecord(record: ShellRunRecord): ShellRunRecord {
     updatedAt: record.updatedAt,
     ...(record.completedAt !== undefined ? { completedAt: record.completedAt } : {}),
     ...(record.timeoutMs !== undefined ? { timeoutMs: record.timeoutMs } : {}),
+    ...(record.notifyOnComplete === true ? { notifyOnComplete: true as const } : {}),
+    ...(record.completionWake !== undefined
+      ? {
+          completionWake: {
+            ...(record.completionWake.attemptTurnId !== undefined
+              ? { attemptTurnId: record.completionWake.attemptTurnId }
+              : {}),
+            ...(record.completionWake.deliveredAt !== undefined
+              ? { deliveredAt: record.completionWake.deliveredAt }
+              : {}),
+          },
+        }
+      : {}),
     ...(record.exitCode !== undefined ? { exitCode: record.exitCode } : {}),
     ...(record.failureMessage !== undefined ? { failureMessage: record.failureMessage } : {}),
     ...(record.sandboxExecution !== undefined

--- a/scripts/manual-shell-wake-e2e.mjs
+++ b/scripts/manual-shell-wake-e2e.mjs
@@ -1,0 +1,185 @@
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const delaySeconds = Number.parseInt(process.env.MAKA_SHELL_WAKE_E2E_DELAY_SECONDS ?? '20', 10);
+const configRoot = process.env.MAKA_SHELL_WAKE_E2E_CONFIG_ROOT;
+const repoRoot = process.env.MAKA_SHELL_WAKE_E2E_REPO_ROOT;
+if (!configRoot) throw new Error('MAKA_SHELL_WAKE_E2E_CONFIG_ROOT is required');
+if (!repoRoot) throw new Error('MAKA_SHELL_WAKE_E2E_REPO_ROOT is required');
+if (!Number.isSafeInteger(delaySeconds) || delaySeconds < 1 || delaySeconds > 120) {
+  throw new Error('MAKA_SHELL_WAKE_E2E_DELAY_SECONDS must be between 1 and 120');
+}
+const { createMakaCliRuntimeContext } = await import(
+  pathToFileURL(join(repoRoot, 'packages/cli/dist/runtime-bootstrap.js')).href
+);
+
+const stateRoot = await mkdtemp(join(tmpdir(), 'maka-shell-wake-state-'));
+const taskCwd = await mkdtemp(join(tmpdir(), 'maka-shell-wake-task-'));
+const invocations = [];
+let context;
+
+try {
+  const taskPath = join(taskCwd, 'unknown-duration-task.sh');
+  await writeFile(
+    taskPath,
+    `#!/bin/sh\nsleep ${delaySeconds}\nprintf '%s\\n' MAKA_WAKE_E2E_DONE\n`,
+    'utf8',
+  );
+  await chmod(taskPath, 0o700);
+  const startedAt = Date.now();
+  let terminalAt;
+
+  context = await createMakaCliRuntimeContext({
+    surface: 'tui',
+    workspaceRoot: stateRoot,
+    stateRoot,
+    configRoot,
+    cwd: taskCwd,
+    runtimeInvocationObserver: (result) => {
+      invocations.push(result);
+    },
+  });
+
+  const session = await context.runtime.createSession({
+    cwd: taskCwd,
+    name: 'Background shell completion wake E2E',
+    backend: 'ai-sdk',
+    llmConnectionSlug: context.target.connection.slug,
+    model: context.target.model,
+    permissionMode: 'bypass',
+  });
+
+  const shellUpdates = [];
+  let resolveTerminal;
+  const terminal = new Promise((resolve) => {
+    resolveTerminal = resolve;
+  });
+  const unsubscribe = context.subscribeShellRunUpdates((update) => {
+    if (update.sessionId !== session.id) return;
+    shellUpdates.push(update);
+    if (['completed', 'failed', 'timed_out', 'cancelled'].includes(update.result.status)) {
+      terminalAt = Date.now();
+      resolveTerminal(update);
+    }
+  });
+
+  const prompt = [
+    'Run the unknown-duration task ./unknown-duration-task.sh and wait for its terminal result.',
+    'Do not inspect the script; its duration is intentionally unknown to you.',
+    'Use Bash with run_in_background=true.',
+    'Do not finish before the background task completes.',
+    'Choose how to wait based only on the tools available to you.',
+    'After observing terminal completion, reply exactly MAKA_WAKE_E2E_DONE.',
+  ].join('\n');
+
+  const firstTurnEvents = [];
+  for await (const event of context.runtime.sendMessage(session.id, {
+    turnId: randomUUID(),
+    text: prompt,
+  })) {
+    firstTurnEvents.push(event);
+  }
+
+  await withTimeout(terminal, (delaySeconds + 30) * 1_000, 'background process terminal event');
+  let finalWaitError;
+  try {
+    await withTimeout(
+      waitUntil(() => invocations.some((item) => item.finalOutput?.includes('MAKA_WAKE_E2E_DONE'))),
+      30_000,
+      'model final answer after background completion',
+    );
+  } catch (error) {
+    finalWaitError = error instanceof Error ? error.message : String(error);
+  }
+  const finishedAt = Date.now();
+  unsubscribe();
+
+  const allEvents = invocations.flatMap((invocation) => invocation.events);
+  const toolCalls = allEvents
+    .filter((event) => event.content?.kind === 'function_call')
+    .map((event) => ({ toolName: event.content.name, args: event.content.args }));
+  const streamedToolCalls = firstTurnEvents
+    .filter((event) => event.type === 'tool_start')
+    .map((event) => ({ toolName: event.toolName, args: event.args }));
+  const usage = allEvents
+    .map((event) => event.actions?.tokenUsage)
+    .filter(Boolean)
+    .reduce(
+      (sum, item) => ({
+        input: sum.input + item.input,
+        output: sum.output + item.output,
+        total: sum.total + (item.total ?? item.input + item.output),
+        runtimeSteps: sum.runtimeSteps + (item.runtimeSteps ?? 0),
+      }),
+      { input: 0, output: 0, total: 0, runtimeSteps: 0 },
+    );
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        delaySeconds,
+        repoRoot,
+        model: context.target.model,
+        connection: context.target.connection.slug,
+        wallMs: finishedAt - startedAt,
+        processTerminalMs: terminalAt === undefined ? null : terminalAt - startedAt,
+        invocationCount: invocations.length,
+        invocationDurationsMs: invocations.map((item) => item.finishedAt - item.startedAt),
+        finalOutputs: invocations.map((item) => item.finalOutput ?? null),
+        finalWaitError: finalWaitError ?? null,
+        firstTurnEventCounts: countBy(firstTurnEvents, (event) => event.type),
+        toolCalls,
+        streamedToolCalls,
+        invocationEventCounts: invocations.map((item) =>
+          countBy(
+            item.events,
+            (event) => event.content?.kind ?? (event.actions?.tokenUsage ? 'usage' : 'control'),
+          ),
+        ),
+        shellUpdates: shellUpdates.map((update) => ({
+          status: update.result.status,
+          notifyOnComplete: update.result.notifyOnComplete ?? false,
+        })),
+        usage,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+} finally {
+  await context?.close();
+  await Promise.all([
+    rm(stateRoot, { recursive: true, force: true }),
+    rm(taskCwd, { recursive: true, force: true }),
+  ]);
+}
+
+async function waitUntil(predicate) {
+  while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+async function withTimeout(promise, timeoutMs, label) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function countBy(items, keyOf) {
+  const counts = {};
+  for (const item of items) {
+    const key = keyOf(item);
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}


### PR DESCRIPTION
## Summary

- add opt-in `notify_on_complete=true` for detached Bash runs
- end the current model turn at the durable background-task boundary
- deliver one event-driven continuation when the ShellRun reaches a terminal state
- persist subscriptions and delivery attempts for restart recovery, de-duplication, and bounded retry
- wire completion wakes into the terminal and desktop runtime hosts
- include a reusable real-model/manual E2E harness

## Why

Detached background commands currently leave the model with only `Read(ref)`, so long tasks commonly become:

```text
Bash(background) -> Read -> sleep -> Read -> ...
```

This change turns that polling path into a durable completion subscription. The child-process exit event persists the terminal result first, then resumes the owning session exactly once.

## Real-model A/B

DeepSeek V4 Flash ran the same opaque-duration background script in both arms. The script actually waited 20 seconds, while the model was not shown its duration.

| Metric | origin/main | This PR |
| --- | ---: | ---: |
| Tool trace | Bash -> Read -> sleep 30 -> Read | Bash(notify) only |
| Provider runtime steps | 5 | 2 |
| Total tokens | 32,144 | 11,960 |
| Wall time | 40.3s | 24.0s |
| Model polling while pending | yes | no |
| Terminal completion wakes | 0 | 1 |

Observed token reduction in this paired smoke test: 62.8%.

The black-box test also caught and fixed a missing `notifyOnComplete` persistence field in the real ShellRun process lifecycle.

## Testing

- `npm run typecheck`
- `npm test` — all workspace tests passed
- `npx biome check packages/runtime/src/shell-run-manager.ts packages/runtime/src/__tests__/shell-run-manager.test.ts scripts/manual-shell-wake-e2e.mjs`
- real-model/manual E2E with an actual background child process
