### PR TITLE
fix(runtime): preserve swarm ledger and child summaries

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -7034,6 +7034,92 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(loop.callCount(), 3);
   });
 
+  test('reserves the final child-agent step for a tool-free evidence summary', async () => {
+    const durable = durableTurnHarness('turn-1', 'audit the repository');
+    let streamCalls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        streamCalls += 1;
+        const chunks: LanguageModelV4StreamPart[] =
+          streamCalls === 1
+            ? [
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'tool-1',
+                  toolName: 'Read',
+                  input: JSON.stringify({ path: 'notes.md' }),
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                  usage: {
+                    inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+                    outputTokens: { total: 1, text: 1, reasoning: 0 },
+                  },
+                },
+              ]
+            : [
+                { type: 'stream-start', warnings: [] },
+                { type: 'text-start', id: 'text-final' },
+                {
+                  type: 'text-delta',
+                  id: 'text-final',
+                  delta: 'Verified evidence summary with explicit gaps.',
+                },
+                { type: 'text-end', id: 'text-final' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: {
+                    inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+                    outputTokens: { total: 1, text: 1, reasoning: 0 },
+                  },
+                },
+              ];
+        return {
+          stream: simulateReadableStream({
+            chunks,
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: { ...header(), collaborationMode: 'agent' },
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [testTool('Read', z.object({ path: z.string() }))],
+      maxSteps: 2,
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events = await drainDurably(backend.send(durable.input()), durable);
+
+    assert.equal(streamCalls, 2);
+    assert.equal(model.doStreamCalls[1]?.tools?.length ?? 0, 0);
+    assert.match(JSON.stringify(model.doStreamCalls[1]?.prompt), /final budgeted step/i);
+    assert.ok(
+      events.some(
+        (event) =>
+          event.type === 'text_delta' &&
+          event.text === 'Verified evidence summary with explicit gaps.',
+      ),
+    );
+    assert.equal(events.at(-1)?.type, 'complete');
+    assert.equal(
+      (events.at(-1) as Extract<SessionEvent, { type: 'complete' }>).stopReason,
+      'end_turn',
+    );
+  });
+
   test('reports an explicit step limit without making an auxiliary model call', async () => {
     const appended: StoredMessage[] = [];
     const durable = durableTurnHarness('turn-1', 'finish the task');

--- a/packages/runtime/src/__tests__/tool-runtime-sqlite-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sqlite-boundary.test.ts
@@ -11,6 +11,90 @@ import type { InvocationContext } from '../invocation-context.js';
 import { ToolRuntime, type MakaTool } from '../tool-runtime.js';
 
 describe('ToolRuntime with real SQLite boundary', () => {
+  it('persists a preflight-rejected sibling beside an exclusive tool without an orphan response', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-tool-sqlite-exclusive-reject-'));
+    const store = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));
+    try {
+      const runtime = createTestToolRuntime({
+        sessionId: 'session-1',
+        header: header(),
+        connection: connection(),
+        modelId: 'model-1',
+        appendMessage: async () => {},
+        newId: nextId(),
+        now: nextNow(),
+        getPermissionPauseTarget: () => null,
+        getCurrentRunId: () => 'run-1',
+        getCurrentInvocationId: () => 'invocation-1',
+        runtimeCommitSink: store,
+      });
+      runtime.beginTurn('turn-1');
+      const published: SessionEvent[] = [];
+      const eventSink = {
+        push: (event: SessionEvent) => published.push(event),
+        pushAndWaitUntilConsumed: async (event: SessionEvent) => {
+          published.push(event);
+        },
+      };
+      const exclusive: MakaTool = {
+        name: 'agent_swarm',
+        description: 'exclusive',
+        parameters: {},
+        executionSemantics: 'exclusive_step',
+        impl: async () => ({ ok: true }),
+      };
+      const sibling: MakaTool = {
+        name: 'agent_output',
+        description: 'sibling',
+        parameters: {},
+        impl: async () => ({ ok: true }),
+      };
+
+      await runtime.settleToolCall({
+        tool: exclusive,
+        turnId: 'turn-1',
+        stepId: 'step-1',
+        toolCallId: 'provider-call-exclusive',
+        input: {},
+        abortSignal: new AbortController().signal,
+        eventSink,
+      });
+      const rejected = await runtime.settleToolCall({
+        tool: sibling,
+        turnId: 'turn-1',
+        stepId: 'step-1',
+        toolCallId: 'provider-call-rejected',
+        input: {},
+        abortSignal: new AbortController().signal,
+        eventSink,
+      });
+      assert.match(JSON.stringify(rejected.result), /exclusive tool agent_swarm/i);
+
+      const memory = createSessionEventMapMemory();
+      for (const event of published) {
+        if (event.type !== 'tool_start' && event.type !== 'tool_result') continue;
+        const runtimeEvent = mapSessionEventToRuntimeEvent(event, invocationContext(), memory);
+        if (runtimeEvent.refs?.operationId !== undefined) continue;
+        await store.appendRuntimeEvent('session-1', 'run-1', runtimeEvent);
+      }
+
+      const rejectedEvents = (await store.readRuntimeEvents('session-1', 'run-1')).filter(
+        (event) =>
+          event.content?.kind === 'function_call'
+            ? event.content.id === 'provider-call-rejected'
+            : event.content?.kind === 'function_response' &&
+              event.content.id === 'provider-call-rejected',
+      );
+      assert.deepEqual(
+        rejectedEvents.map((event) => event.content?.kind),
+        ['function_call', 'function_response'],
+      );
+    } finally {
+      store.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('persists one atomic prepared/outcome pair around the real implementation', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-tool-sqlite-'));
     const store = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -208,6 +208,14 @@ export { normalizeAiSdkUsage } from './model-adapter.js';
 export type { ModelFactory, ModelFactoryInput, RepairableAiSdkToolCall } from './model-adapter.js';
 export type { RunTraceEvent, RunTraceRecorder } from './run-trace.js';
 
+const CHILD_STEP_BUDGET_FINALIZATION_PROMPT = [
+  '<step_budget_finalization>',
+  'This is the final budgeted step for this child-agent turn.',
+  'Do not call tools. Return the best concise final answer now using evidence already gathered.',
+  'Clearly separate verified findings from inference and explicitly name any remaining gaps.',
+  '</step_budget_finalization>',
+].join('\n');
+
 // ============================================================================
 // AgentBackend interface — port contract now lives in @maka/core/backend-types;
 // re-exported here for backward compatibility with existing import sites.
@@ -1231,7 +1239,18 @@ export class AiSdkBackend implements AgentBackend {
               })
             : undefined;
           const projectedMessages = shaped?.messages ?? requestMessages;
-          const activeToolsForRequest = shaped?.activeTools ?? currentRepairToolNames();
+          const finalChildSummaryStep =
+            this.input.header.collaborationMode === 'agent' &&
+            this.maxSteps !== undefined &&
+            this.maxSteps > 1 &&
+            runtimeSteps === this.maxSteps - 1 &&
+            completedProviderSteps.length > 0;
+          const activeToolsForRequest = finalChildSummaryStep
+            ? []
+            : (shaped?.activeTools ?? currentRepairToolNames());
+          const requestSystemPrompt = finalChildSummaryStep
+            ? joinPromptFragments([systemPrompt, CHILD_STEP_BUDGET_FINALIZATION_PROMPT])
+            : systemPrompt;
           providerRequestTracker?.setStep(runtimeSteps);
           let attemptMessages = projectedMessages;
           let providerAttempt = 1;
@@ -1262,7 +1281,7 @@ export class AiSdkBackend implements AgentBackend {
                   error,
                 });
               },
-              system: systemPrompt,
+              system: requestSystemPrompt,
               abortSignal: turnAbortController.signal,
               ...(providerRequestTracker ? { providerRequestTracker } : {}),
             });

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -788,8 +788,13 @@ export class ToolRuntime {
         new Error('Durable tool execution requires a run id'),
       );
     }
+    // Exclusive-step rejection is preflight: it must remain on the generic
+    // call/response lane instead of claiming the T1 dispatch protocol. If the
+    // call carried an operationId here, AgentRun would (correctly) skip its
+    // generic projection assuming commitToolPrepared already persisted it;
+    // the synthetic response would then become an orphan.
     const operationId =
-      this.input.runtimeCommitSink && invocationId
+      this.input.runtimeCommitSink && invocationId && !admissionFailure
         ? buildToolOperationId({ invocationId, providerToolCallId: toolUseId })
         : undefined;
     const startEv: ToolStartEvent = {


### PR DESCRIPTION
## Summary

- keep exclusive-step preflight rejections on the generic call/response persistence lane
- reserve the final budgeted child-agent step for a tool-free evidence summary
- cover both paths with SQLite-boundary and provider-loop regressions

## Root cause

A model can emit `agent_swarm` and a sibling tool in the same provider step. The exclusive-step guard rejects the sibling before T1 dispatch, but the rejected call previously still received an `operationId`. AgentRun then skipped generic call projection under the assumption that T1 had persisted it, leaving the synthetic response orphaned in SQLite.

Separately, a child could spend its last allowed provider step on another tool call and terminate with `step_limit` before returning its evidence. The final child step is now tool-free once at least one provider step has completed.

## Verification

- built `@maka/core`, `@maka/storage`, `@maka/mcp`, and `@maka/runtime` from current `origin/main`
- `npm --workspace @maka/runtime run typecheck`
- 173 focused runtime tests passed, including SQLite boundary, backend loop, and swarm orchestration coverage
- real Maka Graph Mode smoke completed 8/8 DeepSeek Flash children plus parent with exit code 0 and no `orphan_response`

Discovered while reviewing the SQLite migration and swarm behavior around #1649.