### PR TITLE
test: collapse connection and cell-output fixtures

### DIFF
--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -10,114 +10,79 @@ import {
 } from '../cell-output.js';
 
 describe('Harbor cell output contract', () => {
-  test('rejects non-catalog names in a new product-tool surface identity', () => {
-    assert.throws(
-      () =>
-        validateHarborCellExecutionIdentity({
-          llmConnectionSlug: 'deepseek',
-          model: 'deepseek-v4-flash',
-          systemPromptHash: 'sha256:prompt-a',
-          pricingProfile: 'public',
-          agentTools: false,
-          productToolSurface: {
-            policy: { economy: true, disabledSurfaceIds: ['agent'] },
-            productToolNames: ['Read', 'not_a_catalog_tool'],
-          },
+  test('rejects malformed or internally inconsistent product-tool identities', () => {
+    const identity = (
+      productToolSurface: {
+        policy: { economy: boolean; disabledSurfaceIds: string[] };
+        productToolNames: string[];
+      },
+      agentTools = false,
+    ) => ({
+      llmConnectionSlug: 'deepseek',
+      model: 'deepseek-v4-flash',
+      systemPromptHash: 'sha256:prompt-a',
+      pricingProfile: 'public',
+      agentTools,
+      productToolSurface,
+    });
+    const cases: Array<[string, unknown, RegExp]> = [
+      [
+        'unknown tool',
+        identity({
+          policy: { economy: true, disabledSurfaceIds: ['agent'] },
+          productToolNames: ['Read', 'not_a_catalog_tool'],
         }),
-      /productToolNames.*not_a_catalog_tool.*catalog/,
-    );
-  });
-
-  test('rejects a non-canonical disabled-surface policy in a new identity', () => {
-    assert.throws(
-      () =>
-        validateHarborCellExecutionIdentity({
-          llmConnectionSlug: 'deepseek',
-          model: 'deepseek-v4-flash',
-          systemPromptHash: 'sha256:prompt-a',
-          pricingProfile: 'public',
-          agentTools: false,
-          productToolSurface: {
-            policy: { economy: true, disabledSurfaceIds: ['office', 'agent'] },
-            productToolNames: ['Read'],
-          },
+        /productToolNames.*not_a_catalog_tool.*catalog/,
+      ],
+      [
+        'non-canonical disabled surfaces',
+        identity({
+          policy: { economy: true, disabledSurfaceIds: ['office', 'agent'] },
+          productToolNames: ['Read'],
         }),
-      /disabledSurfaceIds must be sorted and unique/,
-    );
-  });
-
-  test('rejects unknown disabled surfaces in a new identity', () => {
-    assert.throws(
-      () =>
-        validateHarborCellExecutionIdentity({
-          llmConnectionSlug: 'deepseek',
-          model: 'deepseek-v4-flash',
-          systemPromptHash: 'sha256:prompt-a',
-          pricingProfile: 'public',
-          agentTools: true,
-          productToolSurface: {
-            policy: { economy: true, disabledSurfaceIds: ['agnet'] },
-            productToolNames: ['Read'],
-          },
+        /disabledSurfaceIds must be sorted and unique/,
+      ],
+      [
+        'unknown disabled surface',
+        identity({
+          policy: { economy: true, disabledSurfaceIds: ['agnet'] },
+          productToolNames: ['Read'],
         }),
-      /disabledSurfaceIds.*agnet.*catalog/,
-    );
-  });
-
-  test('rejects non-canonical effective product-tool names in a new identity', () => {
-    assert.throws(
-      () =>
-        validateHarborCellExecutionIdentity({
-          llmConnectionSlug: 'deepseek',
-          model: 'deepseek-v4-flash',
-          systemPromptHash: 'sha256:prompt-a',
-          pricingProfile: 'public',
-          agentTools: false,
-          productToolSurface: {
-            policy: { economy: true, disabledSurfaceIds: ['agent'] },
-            productToolNames: ['Read', 'Read'],
-          },
+        /disabledSurfaceIds.*agnet.*catalog/,
+      ],
+      [
+        'duplicate effective tool',
+        identity({
+          policy: { economy: true, disabledSurfaceIds: ['agent'] },
+          productToolNames: ['Read', 'Read'],
         }),
-      /productToolNames must be sorted and unique/,
-    );
-  });
-
-  test('rejects product tools that belong to a disabled surface', () => {
-    assert.throws(
-      () =>
-        validateHarborCellExecutionIdentity({
-          llmConnectionSlug: 'deepseek',
-          model: 'deepseek-v4-flash',
-          systemPromptHash: 'sha256:prompt-a',
-          pricingProfile: 'public',
-          agentTools: false,
-          productToolSurface: {
-            policy: { economy: true, disabledSurfaceIds: ['agent'] },
-            productToolNames: ['Read', 'agent_spawn'],
-          },
+        /productToolNames must be sorted and unique/,
+      ],
+      [
+        'tool from disabled surface',
+        identity({
+          policy: { economy: true, disabledSurfaceIds: ['agent'] },
+          productToolNames: ['Read', 'agent_spawn'],
         }),
-      /agent_spawn.*disabled surface "agent"/,
-    );
-  });
-
-  test('requires legacy agentTools to match the effective product-tool names', () => {
-    assert.throws(
-      () =>
-        validateHarborCellExecutionIdentity({
-          llmConnectionSlug: 'deepseek',
-          model: 'deepseek-v4-flash',
-          systemPromptHash: 'sha256:prompt-a',
-          pricingProfile: 'public',
-          agentTools: true,
-          productToolSurface: {
+        /agent_spawn.*disabled surface "agent"/,
+      ],
+      [
+        'legacy agentTools mismatch',
+        identity(
+          {
             policy: { economy: true, disabledSurfaceIds: [] },
             productToolNames: ['Read'],
           },
-        }),
-      /agentTools must match.*effective product-tool surface/,
-    );
-  });
+          true,
+        ),
+        /agentTools must match.*effective product-tool surface/,
+      ],
+    ];
 
+    for (const [label, value, pattern] of cases) {
+      assert.throws(() => validateHarborCellExecutionIdentity(value), pattern, label);
+    }
+  });
   test('summarizes runtime outcome, prompt hash, token cost, and event path', () => {
     const events: RuntimeEvent[] = [
       runtimeEvent({ id: 'user-event' }),

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -36,133 +36,97 @@ afterEach(() => {
 });
 
 describe('applyConnectionDefaults', () => {
-  test('happy path: injects env vars from default connection', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-anthropic',
-      connections: [
-        {
-          slug: 'harbor-anthropic',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4-20250514',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: true,
-        },
-      ],
-    });
+  const defaultDocument = (connection: Record<string, unknown> = {}) => ({
+    defaultSlug: 'harbor-anthropic',
+    connections: [
+      {
+        slug: 'harbor-anthropic',
+        providerType: 'anthropic',
+        defaultModel: 'claude-sonnet-4-20250514',
+        baseUrl: 'http://127.0.0.1:8537',
+        enabled: true,
+        ...connection,
+      },
+    ],
+  });
 
+  test('injects the complete default connection and colocated credentials path', () => {
+    const connectionsPath = makeTempConnections(defaultDocument());
     const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+
     applyConnectionDefaults(env);
 
     assert.equal(env.MAKA_MODEL, 'anthropic/claude-sonnet-4-20250514');
     assert.equal(env.MAKA_LLM_CONNECTION_SLUG, 'harbor-anthropic');
     assert.equal(env.MAKA_BASE_URL, 'http://127.0.0.1:8537');
-  });
-
-  test('sets MAKA_CREDENTIALS_PATH to credentials.json next to the connections file (cross-platform no-env)', () => {
-    // credentials.json lives next to llm-connections.json in the workspace.
-    // Without this, readStoredMakaApiKey falls back to the macOS-only path and
-    // Windows/Linux users can read the default connection but not its API key.
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-anthropic',
-      connections: [
-        {
-          slug: 'harbor-anthropic',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4-20250514',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: true,
-        },
-      ],
-    });
-    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
-    applyConnectionDefaults(env);
     assert.equal(env.MAKA_CREDENTIALS_PATH, join(dirname(connectionsPath), 'credentials.json'));
   });
 
-  test('MAKA_MODEL already set → no override', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-anthropic',
-      connections: [
-        {
-          slug: 'harbor-anthropic',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4-20250514',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: true,
-        },
-      ],
-    });
+  test('does not override explicit model, provider, or connection authority', () => {
+    const connectionsPath = makeTempConnections(defaultDocument());
 
-    const env: Record<string, string | undefined> = {
-      MAKA_CONNECTIONS_PATH: connectionsPath,
-      MAKA_MODEL: 'deepseek/deepseek-v4-flash',
-    };
-    applyConnectionDefaults(env);
+    for (const [name, value] of [
+      ['MAKA_MODEL', 'deepseek/deepseek-v4-flash'],
+      ['HARBOR_MODEL', 'some-model'],
+      ['MAKA_PROVIDER', 'deepseek'],
+      ['MAKA_LLM_CONNECTION_SLUG', 'my-custom-slug'],
+    ] as const) {
+      const env: Record<string, string | undefined> = {
+        MAKA_CONNECTIONS_PATH: connectionsPath,
+        [name]: value,
+      };
+      const before = { ...env };
 
-    assert.equal(env.MAKA_MODEL, 'deepseek/deepseek-v4-flash');
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-    assert.equal(env.MAKA_BASE_URL, undefined);
+      applyConnectionDefaults(env);
+
+      assert.deepEqual(env, before, name);
+    }
   });
 
-  test('HARBOR_MODEL already set → no override', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-anthropic',
-      connections: [
-        {
-          slug: 'harbor-anthropic',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4-20250514',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: true,
-        },
-      ],
-    });
+  test('ignores missing, malformed, disabled, incomplete, or unsupported connection sources', () => {
+    const malformedDir = mkdtempSync(join(tmpdir(), 'maka-conn-test-'));
+    cleanupDirs.push(malformedDir);
+    const malformedPath = join(malformedDir, 'llm-connections.json');
+    writeFileSync(malformedPath, '{ not valid json!!!', 'utf8');
 
-    const env: Record<string, string | undefined> = {
-      MAKA_CONNECTIONS_PATH: connectionsPath,
-      HARBOR_MODEL: 'some-model',
-    };
-    applyConnectionDefaults(env);
+    const sources = [
+      '/tmp/nonexistent-path-abc123/llm-connections.json',
+      malformedPath,
+      makeTempConnections(defaultDocument({ enabled: false })),
+      makeTempConnections({
+        connections: [
+          {
+            slug: 'some-conn',
+            providerType: 'anthropic',
+            defaultModel: 'claude-sonnet-4',
+            enabled: true,
+          },
+        ],
+      }),
+      makeTempConnections({
+        defaultSlug: 'missing-slug',
+        connections: [
+          {
+            slug: 'other-conn',
+            providerType: 'anthropic',
+            defaultModel: 'claude-sonnet-4',
+            enabled: true,
+          },
+        ],
+      }),
+      makeTempConnections(defaultDocument({ providerType: 'totally-unknown-provider' })),
+    ];
 
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-    assert.equal(env.MAKA_BASE_URL, undefined);
+    for (const connectionsPath of sources) {
+      const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+
+      applyConnectionDefaults(env);
+
+      assert.deepEqual(env, { MAKA_CONNECTIONS_PATH: connectionsPath }, connectionsPath);
+    }
   });
 
-  test('file missing → no error, no env vars set', () => {
-    const env: Record<string, string | undefined> = {
-      MAKA_CONNECTIONS_PATH: '/tmp/nonexistent-path-abc123/llm-connections.json',
-    };
-    applyConnectionDefaults(env);
-
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-    assert.equal(env.MAKA_BASE_URL, undefined);
-  });
-
-  test('defaultSlug connection has enabled:false → skipped', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-anthropic',
-      connections: [
-        {
-          slug: 'harbor-anthropic',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4-20250514',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: false,
-        },
-      ],
-    });
-
-    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
-    applyConnectionDefaults(env);
-
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-    assert.equal(env.MAKA_BASE_URL, undefined);
-  });
-
-  test('connection has no baseUrl → MAKA_BASE_URL not set', () => {
+  test('leaves MAKA_BASE_URL unset when the connection has no base URL', () => {
     const connectionsPath = makeTempConnections({
       defaultSlug: 'deepseek-default',
       connections: [
@@ -174,8 +138,8 @@ describe('applyConnectionDefaults', () => {
         },
       ],
     });
-
     const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+
     applyConnectionDefaults(env);
 
     assert.equal(env.MAKA_MODEL, 'deepseek/deepseek-v4-flash');
@@ -183,235 +147,37 @@ describe('applyConnectionDefaults', () => {
     assert.equal(env.MAKA_BASE_URL, undefined);
   });
 
-  test('MAKA_CONNECTIONS_PATH override works', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'custom-conn',
-      connections: [
-        {
-          slug: 'custom-conn',
-          providerType: 'moonshot',
-          defaultModel: 'moonshot-v1-8k',
-          baseUrl: 'https://api.moonshot.cn/v1',
-          enabled: true,
-        },
-      ],
-    });
-
-    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
-    applyConnectionDefaults(env);
-
-    assert.equal(env.MAKA_MODEL, 'moonshot/moonshot-v1-8k');
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, 'custom-conn');
-    assert.equal(env.MAKA_BASE_URL, 'https://api.moonshot.cn/v1');
-  });
-
-  test('malformed JSON → no error, no env vars set', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'maka-conn-test-'));
-    cleanupDirs.push(dir);
-    const filePath = join(dir, 'llm-connections.json');
-    writeFileSync(filePath, '{ not valid json!!!', 'utf8');
-
-    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: filePath };
-    applyConnectionDefaults(env);
-
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-    assert.equal(env.MAKA_BASE_URL, undefined);
-  });
-
-  test('no defaultSlug in file → no env vars set', () => {
-    const connectionsPath = makeTempConnections({
-      connections: [
-        {
-          slug: 'some-conn',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4',
-          enabled: true,
-        },
-      ],
-    });
-
-    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
-    applyConnectionDefaults(env);
-
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-  });
-
-  test('defaultSlug points to non-existent connection → no env vars set', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'missing-slug',
-      connections: [
-        {
-          slug: 'other-conn',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4',
-          enabled: true,
-        },
-      ],
-    });
-
-    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
-    applyConnectionDefaults(env);
-
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-  });
-
-  test('MAKA_PROVIDER set without MAKA_MODEL → no override (respects explicit provider)', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-anthropic',
-      connections: [
-        {
-          slug: 'harbor-anthropic',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4-20250514',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: true,
-        },
-      ],
-    });
-
-    const env: Record<string, string | undefined> = {
-      MAKA_CONNECTIONS_PATH: connectionsPath,
-      MAKA_PROVIDER: 'deepseek',
-    };
-    applyConnectionDefaults(env);
-
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-    assert.equal(env.MAKA_BASE_URL, undefined);
-  });
-
-  test('MAKA_BASE_URL set without MAKA_MODEL → base-url not overwritten', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-anthropic',
-      connections: [
-        {
-          slug: 'harbor-anthropic',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4-20250514',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: true,
-        },
-      ],
-    });
-
+  test('preserves an explicit base URL while filling the remaining defaults', () => {
+    const connectionsPath = makeTempConnections(defaultDocument());
     const env: Record<string, string | undefined> = {
       MAKA_CONNECTIONS_PATH: connectionsPath,
       MAKA_BASE_URL: 'http://custom-url:9999',
     };
+
     applyConnectionDefaults(env);
 
-    // Model gets set since no MAKA_MODEL/HARBOR_MODEL/MAKA_PROVIDER/MAKA_LLM_CONNECTION_SLUG guard triggered
     assert.equal(env.MAKA_MODEL, 'anthropic/claude-sonnet-4-20250514');
-    // But MAKA_BASE_URL is NOT overwritten (per-field respect)
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, 'harbor-anthropic');
     assert.equal(env.MAKA_BASE_URL, 'http://custom-url:9999');
   });
 
-  test('MAKA_LLM_CONNECTION_SLUG set without MAKA_MODEL → no override (respects explicit slug)', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-anthropic',
-      connections: [
-        {
-          slug: 'harbor-anthropic',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4-20250514',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: true,
-        },
-      ],
-    });
+  test('skips defaults for fake and pi-agent backends', () => {
+    const connectionsPath = makeTempConnections(defaultDocument());
 
-    const env: Record<string, string | undefined> = {
-      MAKA_CONNECTIONS_PATH: connectionsPath,
-      MAKA_LLM_CONNECTION_SLUG: 'my-custom-slug',
-    };
-    applyConnectionDefaults(env);
+    for (const backend of ['fake', 'pi-agent']) {
+      const env: Record<string, string | undefined> = {
+        MAKA_CONNECTIONS_PATH: connectionsPath,
+        MAKA_BACKEND: backend,
+      };
+      const before = { ...env };
 
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, 'my-custom-slug');
-    assert.equal(env.MAKA_BASE_URL, undefined);
+      applyConnectionDefaults(env);
+
+      assert.deepEqual(env, before, backend);
+    }
   });
 
-  test('MAKA_BACKEND=fake → no defaults applied', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-anthropic',
-      connections: [
-        {
-          slug: 'harbor-anthropic',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4-20250514',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: true,
-        },
-      ],
-    });
-
-    const env: Record<string, string | undefined> = {
-      MAKA_CONNECTIONS_PATH: connectionsPath,
-      MAKA_BACKEND: 'fake',
-    };
-    applyConnectionDefaults(env);
-
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-    assert.equal(env.MAKA_BASE_URL, undefined);
-  });
-
-  test('MAKA_BACKEND=pi-agent → no defaults applied', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-anthropic',
-      connections: [
-        {
-          slug: 'harbor-anthropic',
-          providerType: 'anthropic',
-          defaultModel: 'claude-sonnet-4-20250514',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: true,
-        },
-      ],
-    });
-
-    const env: Record<string, string | undefined> = {
-      MAKA_CONNECTIONS_PATH: connectionsPath,
-      MAKA_BACKEND: 'pi-agent',
-    };
-    applyConnectionDefaults(env);
-
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-    assert.equal(env.MAKA_BASE_URL, undefined);
-  });
-
-  test('invalid providerType in connections file → no-op', () => {
-    const connectionsPath = makeTempConnections({
-      defaultSlug: 'harbor-invalid',
-      connections: [
-        {
-          slug: 'harbor-invalid',
-          providerType: 'totally-unknown-provider',
-          defaultModel: 'some-model',
-          baseUrl: 'http://127.0.0.1:8537',
-          enabled: true,
-        },
-      ],
-    });
-
-    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
-    applyConnectionDefaults(env);
-
-    assert.equal(env.MAKA_MODEL, undefined);
-    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
-    assert.equal(env.MAKA_BASE_URL, undefined);
-  });
-
-  test('legacy codex-subscription providerType normalized to openai-codex', () => {
-    // Connections persisted before the codex-subscription -> openai-codex
-    // rename keep the old providerType on disk. applyConnectionDefaults reads
-    // llm-connections.json directly (bypassing ConnectionStore's on-read
-    // normalization), so it must normalize the alias itself or the headless
-    // path silently drops a still-valid connection.
+  test('normalizes the legacy codex-subscription provider type', () => {
     const connectionsPath = makeTempConnections({
       defaultSlug: 'codex-subscription',
       connections: [
@@ -424,8 +190,8 @@ describe('applyConnectionDefaults', () => {
         },
       ],
     });
-
     const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+
     applyConnectionDefaults(env);
 
     assert.equal(env.MAKA_MODEL, 'openai-codex/gpt-5.6-sol');
@@ -433,7 +199,6 @@ describe('applyConnectionDefaults', () => {
     assert.equal(env.MAKA_BASE_URL, 'https://chatgpt.com/backend-api/codex');
   });
 });
-
 describe('resolveHarborRunOptions backend guard', () => {
   test('uses one boolean vocabulary for the Agent tool switch', async () => {
     const defaultOptions = await resolveHarborRunOptions(


### PR DESCRIPTION
## Summary
- collapse repeated connection-default fixtures into behavior tables
- collapse product-tool identity rejection fixtures into one contract table
- preserve every existing branch and assertion while removing 16 redundant test registrations

## Validation
- npm run clean
- npm run build:test
- npm --workspace @maka/headless run test:dist (1303 tests, 0 fail)
- npm run test:scripts:full
- Core, Runtime (serial), CLI, UI, and Desktop full suites
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check