### PR TITLE
test: prune low-value script helper checks

### DIFF
--- a/scripts/check-visual-contract.test.mjs
+++ b/scripts/check-visual-contract.test.mjs
@@ -1,11 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
-import {
-  checkSalvagedAnchors,
-  checkScopeCoverage,
-  diffRecords,
-  partitionChanges,
-} from './check-visual-contract.mjs';
+import { checkScopeCoverage, diffRecords, partitionChanges } from './check-visual-contract.mjs';
 
 const record = (path, extra = {}) => ({ path, rect: [0, 0, 10, 10], ...extra });
 
@@ -69,11 +64,4 @@ test('repeatable scopes stay bounded per root and in total', () => {
     ),
     [{ scope: 'item', claimed: 60, total: 100 }],
   );
-});
-
-test('salvaged anchors require an exact current capture hook', () => {
-  const anchors = [{ commit: 'abc', regression: 'r', route: 'chat', anchor: 'list-row' }];
-  const captures = new Map([['chat.light.darwin', [record('a', { contract: 'list-row-meta' })]]]);
-  assert.equal(checkSalvagedAnchors(captures, anchors).length, 1);
-  assert.deepEqual(checkSalvagedAnchors(new Map(), anchors), []);
 });

--- a/scripts/cu-e2e-scenarios.test.mjs
+++ b/scripts/cu-e2e-scenarios.test.mjs
@@ -1,25 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import {
-  evaluateCuE2eScenarioState,
-  getCuE2eScenario,
-  validateCuE2eScenario,
-} from './cu-e2e-scenarios.mjs';
-
-test('state evaluation separates expected-state and forbidden-effect failures', () => {
-  const scenario = getCuE2eScenario('l1-single-click');
-  const result = evaluateCuE2eScenarioState(scenario, {
-    target: { primaryClicks: 2, primaryOverClicks: 1, dangerClicks: 1 },
-  });
-
-  assert.equal(result.pass, false);
-  assert.equal(result.expected.find(({ path }) => path === 'primaryClicks').pass, false);
-  assert.equal(
-    result.forbidden.every(({ pass }) => !pass),
-    true,
-  );
-});
+import { getCuE2eScenario, validateCuE2eScenario } from './cu-e2e-scenarios.mjs';
 
 test('validation rejects unsafe action, matcher, budget, and expected-failure declarations', () => {
   const base = structuredClone(getCuE2eScenario('l1-single-click'));

--- a/scripts/cu-provider-matrix.test.mjs
+++ b/scripts/cu-provider-matrix.test.mjs
@@ -149,16 +149,6 @@ test('matrix generation never executes provider command templates', async () => 
   }
 });
 
-test('invalid readiness fails closed', async () => {
-  await assert.rejects(
-    buildProviderMatrix({
-      scenarios: [{ id: 'click' }],
-      providers: [{ id: 'claude', readiness: 'maybe' }],
-    }),
-    /invalid readiness/,
-  );
-});
-
 test('a real report from another scenario is invalid instead of a fixture failure', async () => {
   const matrix = await buildProviderMatrix({
     scenarios: [scenario({ id: 'l0-observe-only' })],


### PR DESCRIPTION
## Summary
- remove a synthetic CU state-evaluation helper test already exercised by provider matrix contracts
- remove a trivial readiness literal check while retaining provenance and fail-closed report validation
- remove a presentation-only salvaged-anchor helper check while retaining scope boundary coverage
- keep privacy, release, teardown, artifact trust, lineage, and false-green gates intact

## Validation
- npm run clean
- npm run build:test
- npm run test:scripts:full (48 tests, 0 fail)
- npm --workspace @maka/runtime-host run test:dist (446 tests, 0 fail)
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check

## Note
An attempted all-workspace parallel run reproduced the existing macOS Storage root-lock-holder stall. The script suite and Runtime Host passed independently; this PR does not change production or Storage code.