### PR TITLE
test: collapse TUI presentation fixtures

### DIFF
--- a/packages/cli/src/__tests__/session-recap.test.ts
+++ b/packages/cli/src/__tests__/session-recap.test.ts
@@ -1,44 +1,29 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
-  AUTO_RECAP_DISPLAY_LIMIT_BYTES,
   AUTO_RECAP_IDLE_MS,
   AUTO_RECAP_MIN_TURNS,
   cleanRecapText,
   shouldAutoRecap,
 } from '../session-recap.js';
 
-// AUTO_RECAP_DISPLAY_LIMIT_BYTES itself is a plain constant (contract value
-// consumed by the runner's idle-recap display suppression, exercised in
-// pi-tui-runner.test.ts's "/recap command" suite). Pin its value here so a
-// drift is caught next to the rest of the recap contract constants.
-test('AUTO_RECAP_DISPLAY_LIMIT_BYTES is 500 bytes', () => {
-  assert.equal(AUTO_RECAP_DISPLAY_LIMIT_BYTES, 500);
-});
-
 describe('cleanRecapText', () => {
-  test('collapses whitespace and trims', () => {
-    assert.equal(cleanRecapText('  We   fixed\n\nthe   bug.  '), 'We fixed the bug.');
-  });
+  test('normalizes whitespace, labels, and wrapping quotes', () => {
+    const cases = [
+      ['  We   fixed\n\nthe   bug.  ', 'We fixed the bug.'],
+      ['Recap: We fixed the bug.', 'We fixed the bug.'],
+      ['RECAP:We fixed the bug.', 'We fixed the bug.'],
+      ['Summary:  We fixed the bug.', 'We fixed the bug.'],
+      ['summary：We fixed the bug.', 'We fixed the bug.'],
+      ['回顾：我们修复了问题。', '我们修复了问题。'],
+      ['"We fixed the bug."', 'We fixed the bug.'],
+      ["'We fixed the bug.'", 'We fixed the bug.'],
+      ['“We fixed the bug.”', 'We fixed the bug.'],
+    ];
 
-  test('strips a leading Recap: label (case-insensitive)', () => {
-    assert.equal(cleanRecapText('Recap: We fixed the bug.'), 'We fixed the bug.');
-    assert.equal(cleanRecapText('RECAP:We fixed the bug.'), 'We fixed the bug.');
-  });
-
-  test('strips a leading Summary: label (case-insensitive)', () => {
-    assert.equal(cleanRecapText('Summary:  We fixed the bug.'), 'We fixed the bug.');
-    assert.equal(cleanRecapText('summary：We fixed the bug.'), 'We fixed the bug.');
-  });
-
-  test('strips a leading 回顾： label', () => {
-    assert.equal(cleanRecapText('回顾：我们修复了问题。'), '我们修复了问题。');
-  });
-
-  test('strips one layer of wrapping quotes', () => {
-    assert.equal(cleanRecapText('"We fixed the bug."'), 'We fixed the bug.');
-    assert.equal(cleanRecapText("'We fixed the bug.'"), 'We fixed the bug.');
-    assert.equal(cleanRecapText('“We fixed the bug.”'), 'We fixed the bug.');
+    for (const [input, expected] of cases) {
+      assert.equal(cleanRecapText(input), expected, input);
+    }
   });
 
   test('truncates to 1200 characters with an ellipsis', () => {
@@ -51,48 +36,32 @@ describe('cleanRecapText', () => {
 });
 
 describe('shouldAutoRecap', () => {
-  test('idle-time boundary: 179999ms does not trigger, 180000ms does', () => {
-    assert.equal(
-      shouldAutoRecap({
-        idleMs: AUTO_RECAP_IDLE_MS - 1,
-        mainTurnCount: 3,
-        lastRecapMainTurnCount: 0,
-      }),
-      false,
-    );
-    assert.equal(
-      shouldAutoRecap({ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: 3, lastRecapMainTurnCount: 0 }),
-      true,
-    );
-  });
+  test('enforces idle, turn-count, and watermark boundaries', () => {
+    const cases = [
+      [{ idleMs: AUTO_RECAP_IDLE_MS - 1, mainTurnCount: 3, lastRecapMainTurnCount: 0 }, false],
+      [{ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: 3, lastRecapMainTurnCount: 0 }, true],
+      [
+        {
+          idleMs: AUTO_RECAP_IDLE_MS,
+          mainTurnCount: AUTO_RECAP_MIN_TURNS - 1,
+          lastRecapMainTurnCount: 0,
+        },
+        false,
+      ],
+      [
+        {
+          idleMs: AUTO_RECAP_IDLE_MS,
+          mainTurnCount: AUTO_RECAP_MIN_TURNS,
+          lastRecapMainTurnCount: 0,
+        },
+        true,
+      ],
+      [{ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: 3, lastRecapMainTurnCount: 3 }, false],
+      [{ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: 4, lastRecapMainTurnCount: 3 }, true],
+    ] as const;
 
-  test('main-turn boundary: 2 turns does not trigger, 3 turns does', () => {
-    assert.equal(
-      shouldAutoRecap({
-        idleMs: AUTO_RECAP_IDLE_MS,
-        mainTurnCount: AUTO_RECAP_MIN_TURNS - 1,
-        lastRecapMainTurnCount: 0,
-      }),
-      false,
-    );
-    assert.equal(
-      shouldAutoRecap({
-        idleMs: AUTO_RECAP_IDLE_MS,
-        mainTurnCount: AUTO_RECAP_MIN_TURNS,
-        lastRecapMainTurnCount: 0,
-      }),
-      true,
-    );
-  });
-
-  test('watermark: equal main-turn count does not re-trigger', () => {
-    assert.equal(
-      shouldAutoRecap({ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: 3, lastRecapMainTurnCount: 3 }),
-      false,
-    );
-    assert.equal(
-      shouldAutoRecap({ idleMs: AUTO_RECAP_IDLE_MS, mainTurnCount: 4, lastRecapMainTurnCount: 3 }),
-      true,
-    );
+    for (const [input, expected] of cases) {
+      assert.equal(shouldAutoRecap(input), expected, JSON.stringify(input));
+    }
   });
 });

--- a/packages/cli/src/__tests__/tui-ansi.test.ts
+++ b/packages/cli/src/__tests__/tui-ansi.test.ts
@@ -13,138 +13,54 @@ import {
 afterEach(() => _setColorLevelForTesting(3));
 
 describe('tui-ansi semantic slots (#1053)', () => {
-  test('muted is a truecolor cool-grey slot', () => {
-    _setColorLevelForTesting(3);
-    assert.equal(ansi.muted('x'), '\x1b[38;2;128;132;140mx\x1b[39m');
-  });
-});
-
-describe('disc (#1053)', () => {
   test('renders a single ● glyph regardless of tone', () => {
     _setColorLevelForTesting(3);
     for (const tone of ['ok', 'muted', 'accent', 'danger'] as const) {
       assert.equal(stripAnsi(disc(tone)), '●', `tone ${tone} should yield one ●`);
     }
   });
-
-  test('done (ok) disc uses standard green', () => {
-    _setColorLevelForTesting(3);
-    assert.equal(disc('ok'), '\x1b[32m●\x1b[39m');
-  });
-
-  test('detached/unavailable (muted) disc uses the muted cool-grey', () => {
-    _setColorLevelForTesting(3);
-    assert.equal(disc('muted'), '\x1b[38;2;128;132;140m●\x1b[39m');
-  });
-
-  test('running (accent) disc uses the logo blue', () => {
-    _setColorLevelForTesting(3);
-    assert.equal(disc('accent'), '\x1b[38;2;87;163;239m●\x1b[39m');
-  });
-
-  test('error (danger) disc uses standard red', () => {
-    _setColorLevelForTesting(3);
-    assert.equal(disc('danger'), '\x1b[31m●\x1b[39m');
-  });
 });
 
 describe('color capability fallback (#1064)', () => {
-  test('level 3 (truecolor) emits 24-bit RGB escapes', () => {
-    _setColorLevelForTesting(3);
-    assert.equal(ansi.accent('x'), '\x1b[38;2;87;163;239mx\x1b[39m');
-    assert.equal(ansi.muted('x'), '\x1b[38;2;128;132;140mx\x1b[39m');
-  });
+  test('adapts semantic and basic styles to each terminal color level', () => {
+    const cases = [
+      [3, '\x1b[38;2;87;163;239mx\x1b[39m', '\x1b[38;2;128;132;140mx\x1b[39m', '\x1b[1mx\x1b[22m'],
+      [2, '\x1b[38;5;75mx\x1b[39m', '\x1b[38;5;102mx\x1b[39m', '\x1b[1mx\x1b[22m'],
+      [1, '\x1b[37mx\x1b[39m', '\x1b[90mx\x1b[39m', '\x1b[1mx\x1b[22m'],
+      [0, 'x', 'x', 'x'],
+    ] as const;
 
-  test('level 2 (256-color) downgrades to nearest 256-color palette entry', () => {
-    _setColorLevelForTesting(2);
-    // Logo blue [87, 163, 239] → cube: r=1(95), g=3(175), b=5(255)
-    // → 16 + 1*36 + 3*6 + 5 = 16 + 36 + 18 + 5 = 75
-    assert.equal(ansi.accent('x'), '\x1b[38;5;75mx\x1b[39m');
-    // Muted grey [128, 132, 140] → cube: r=2(135), g=2(135), b=2(135)
-    // → 16 + 2*36 + 2*6 + 2 = 16 + 72 + 12 + 2 = 102
-    assert.equal(ansi.muted('x'), '\x1b[38;5;102mx\x1b[39m');
-  });
-
-  test('level 1 (16-color) downgrades to nearest ANSI 16-color entry', () => {
-    _setColorLevelForTesting(1);
-    // Logo blue [87, 163, 239] → nearest is white (7) → code 37
-    assert.equal(ansi.accent('x'), '\x1b[37mx\x1b[39m');
-    // Muted grey [128, 132, 140] → nearest is bright black/grey (8) → code 90
-    assert.equal(ansi.muted('x'), '\x1b[90mx\x1b[39m');
-  });
-
-  test('level 0 (no color) strips all color escapes', () => {
-    _setColorLevelForTesting(0);
-    assert.equal(ansi.accent('x'), 'x');
-    assert.equal(ansi.muted('x'), 'x');
-    assert.equal(ansi.bold('x'), 'x');
-    assert.equal(ansi.red('x'), 'x');
-    assert.equal(disc('ok'), '●');
-    assert.equal(disc('muted'), '●');
-    assert.equal(disc('accent'), '●');
-    assert.equal(disc('danger'), '●');
-  });
-
-  test('basic style codes (bold, dim, red) still work at level 1', () => {
-    _setColorLevelForTesting(1);
-    assert.equal(ansi.bold('x'), '\x1b[1mx\x1b[22m');
-    assert.equal(ansi.dim('x'), '\x1b[2mx\x1b[22m');
-    assert.equal(ansi.red('x'), '\x1b[31mx\x1b[39m');
-  });
-
-  test('basic style codes are stripped at level 0', () => {
-    _setColorLevelForTesting(0);
-    assert.equal(ansi.bold('x'), 'x');
-    assert.equal(ansi.dim('x'), 'x');
-    assert.equal(ansi.yellow('x'), 'x');
+    for (const [level, accent, muted, bold] of cases) {
+      _setColorLevelForTesting(level);
+      assert.equal(ansi.accent('x'), accent, `accent level ${level}`);
+      assert.equal(ansi.muted('x'), muted, `muted level ${level}`);
+      assert.equal(ansi.bold('x'), bold, `bold level ${level}`);
+    }
   });
 });
 
 describe('detectColorLevel env detection (#1064)', () => {
-  test('NO_COLOR with non-empty value → level 0', () => {
-    assert.equal(detect({ NO_COLOR: '1', TERM: 'xterm-256color', COLORTERM: 'truecolor' }), 0);
-    assert.equal(detect({ NO_COLOR: '0', TERM: 'xterm-256color' }), 0);
-  });
+  test('maps environment capabilities and overrides to color levels', () => {
+    const cases: Array<[Record<string, string>, number]> = [
+      [{ NO_COLOR: '1', TERM: 'xterm-256color', COLORTERM: 'truecolor' }, 0],
+      [{ NO_COLOR: '0', TERM: 'xterm-256color' }, 0],
+      [{ NO_COLOR: '', TERM: 'xterm-256color', COLORTERM: 'truecolor' }, 3],
+      [{}, 0],
+      [{ TERM: '' }, 0],
+      [{ TERM: 'dumb' }, 0],
+      [{ TERM: 'xterm-256color', COLORTERM: 'truecolor' }, 3],
+      [{ TERM: 'xterm', COLORTERM: '24bit' }, 3],
+      [{ TERM: 'xterm-truecolor' }, 3],
+      [{ TERM: 'tmux-24bit' }, 3],
+      [{ TERM: 'xterm-256color' }, 2],
+      [{ TERM: 'screen-256color' }, 2],
+      [{ TERM: 'xterm' }, 1],
+      [{ TERM: 'screen' }, 1],
+      [{ TERM: 'rxvt-unicode' }, 1],
+    ];
 
-  test('NO_COLOR with empty string → color still enabled (per spec)', () => {
-    assert.equal(detect({ NO_COLOR: '', TERM: 'xterm-256color', COLORTERM: 'truecolor' }), 3);
-  });
-
-  test('NO_COLOR unset → color enabled', () => {
-    assert.equal(detect({ TERM: 'xterm-256color', COLORTERM: 'truecolor' }), 3);
-  });
-
-  test('TERM=dumb → level 0', () => {
-    assert.equal(detect({ TERM: 'dumb' }), 0);
-  });
-
-  test('TERM unset/empty → level 0', () => {
-    assert.equal(detect({}), 0);
-    assert.equal(detect({ TERM: '' }), 0);
-  });
-
-  test('COLORTERM=truecolor → level 3', () => {
-    assert.equal(detect({ TERM: 'xterm-256color', COLORTERM: 'truecolor' }), 3);
-    assert.equal(detect({ TERM: 'xterm', COLORTERM: '24bit' }), 3);
-  });
-
-  test('TERM ending with -truecolor → level 3', () => {
-    assert.equal(detect({ TERM: 'xterm-truecolor' }), 3);
-    assert.equal(detect({ TERM: 'tmux-24bit' }), 3);
-  });
-
-  test('TERM with 256color (no COLORTERM) → level 2', () => {
-    assert.equal(detect({ TERM: 'xterm-256color' }), 2);
-    assert.equal(detect({ TERM: 'screen-256color' }), 2);
-  });
-
-  test('TERM with 256color + COLORTERM=truecolor → level 3 (COLORTERM wins)', () => {
-    assert.equal(detect({ TERM: 'xterm-256color', COLORTERM: 'truecolor' }), 3);
-  });
-
-  test('Generic TERM (xterm, screen, rxvt) → level 1', () => {
-    assert.equal(detect({ TERM: 'xterm' }), 1);
-    assert.equal(detect({ TERM: 'screen' }), 1);
-    assert.equal(detect({ TERM: 'rxvt-unicode' }), 1);
+    for (const [env, expected] of cases) {
+      assert.equal(detect(env), expected, JSON.stringify(env));
+    }
   });
 });

--- a/packages/cli/src/__tests__/tui-attention.test.ts
+++ b/packages/cli/src/__tests__/tui-attention.test.ts
@@ -32,8 +32,7 @@ function makeController(longTurnThresholdMs = 8000) {
     baseTitle: 'Maka',
     now: () => clock,
     longTurnThresholdMs,
-    // Capture the spinner callback instead of scheduling a real interval, so the
-    // test drives frame advances deterministically and no timer leaks.
+    // Capture the spinner callback instead of scheduling a real interval so no timer leaks.
     scheduleSpinnerInterval: (callback) => {
       spinnerTick = callback;
       return () => {
@@ -45,17 +44,11 @@ function makeController(longTurnThresholdMs = 8000) {
     terminal,
     controller,
     advance: (ms: number) => (clock += ms),
-    tickSpinner: () => spinnerTick?.(),
     spinnerRunning: () => spinnerTick !== null,
   };
 }
 
 describe('AttentionController title', () => {
-  test('starts on the plain base title', () => {
-    const { terminal } = makeController();
-    assert.equal(terminal.title, 'Maka');
-  });
-
   test('updates the base title while preserving the current state marker', () => {
     const { terminal, controller } = makeController();
     controller.promptTurnStarted();
@@ -67,16 +60,6 @@ describe('AttentionController title', () => {
     assert.equal(terminal.title, 'Generated title');
   });
 
-  test('marks busy while a turn runs and returns to plain when it ends quickly', () => {
-    const { terminal, controller, advance } = makeController(8000);
-    controller.promptTurnStarted();
-    assert.equal(terminal.title, BUSY);
-    advance(500);
-    controller.promptTurnEnded();
-    assert.equal(terminal.title, 'Maka');
-    assert.equal(terminal.bells, 0);
-  });
-
   test('control actions mark busy without ever ringing', () => {
     const { terminal, controller } = makeController();
     controller.focusChanged(false);
@@ -85,13 +68,6 @@ describe('AttentionController title', () => {
     controller.controlEnded();
     assert.equal(terminal.title, 'Maka');
     assert.equal(terminal.bells, 0);
-  });
-
-  test('writes the title only on a real change', () => {
-    const { terminal, controller } = makeController();
-    const before = terminal.titles.length;
-    controller.focusChanged(true); // still focused, still idle → no new title
-    assert.equal(terminal.titles.length, before);
   });
 
   test('reset clears the busy marker and goes inert', () => {
@@ -110,26 +86,6 @@ describe('AttentionController title', () => {
     assert.equal(terminal.bells, 0);
   });
 
-  test('animates the busy marker through spinner frames while a turn runs', () => {
-    const { terminal, controller, tickSpinner, spinnerRunning } = makeController(8000);
-    controller.promptTurnStarted();
-    assert.equal(terminal.title, `${BUSY_SPINNER_FRAMES[0]} Maka`);
-    assert.equal(spinnerRunning(), true);
-
-    tickSpinner();
-    assert.equal(terminal.title, `${BUSY_SPINNER_FRAMES[1]} Maka`);
-    tickSpinner();
-    assert.equal(terminal.title, `${BUSY_SPINNER_FRAMES[2]} Maka`);
-
-    controller.promptTurnEnded();
-    assert.equal(terminal.title, 'Maka');
-    // The interval is released and the frame resets, so the next turn opens on
-    // the first frame rather than mid-cycle.
-    assert.equal(spinnerRunning(), false);
-    controller.promptTurnStarted();
-    assert.equal(terminal.title, `${BUSY_SPINNER_FRAMES[0]} Maka`);
-  });
-
   test('stops the spinner while an attention marker overrides the busy marker', () => {
     const { controller, spinnerRunning } = makeController(8000);
     controller.focusChanged(false);
@@ -144,82 +100,47 @@ describe('AttentionController title', () => {
 });
 
 describe('AttentionController long-turn ring', () => {
-  test('rings and marks attention when a long turn ends while unfocused', () => {
-    const { terminal, controller, advance } = makeController(8000);
-    controller.focusChanged(false);
-    controller.promptTurnStarted();
-    advance(9000);
-    controller.promptTurnEnded();
-    assert.equal(terminal.bells, 1);
-    assert.equal(terminal.title, '★ Maka');
+  test('rings only when a long turn ends while unfocused', () => {
+    const cases = [
+      { focused: false, elapsedMs: 9000, bells: 1, title: '★ Maka' },
+      { focused: true, elapsedMs: 9000, bells: 0, title: 'Maka' },
+      { focused: false, elapsedMs: 200, bells: 0, title: 'Maka' },
+    ];
+
+    for (const { focused, elapsedMs, bells, title } of cases) {
+      const harness = makeController(8000);
+      harness.controller.focusChanged(focused);
+      harness.controller.promptTurnStarted();
+      harness.advance(elapsedMs);
+      harness.controller.promptTurnEnded();
+      assert.equal(harness.terminal.bells, bells, `${focused}/${elapsedMs}`);
+      assert.equal(harness.terminal.title, title, `${focused}/${elapsedMs}`);
+    }
   });
 
-  test('stays silent when a long turn ends while focused', () => {
-    const { terminal, controller, advance } = makeController(8000);
-    controller.promptTurnStarted();
-    advance(9000);
-    controller.promptTurnEnded();
-    assert.equal(terminal.bells, 0);
-    assert.equal(terminal.title, 'Maka');
-  });
-
-  test('does not ring for a short turn even while unfocused', () => {
-    const { terminal, controller, advance } = makeController(8000);
-    controller.focusChanged(false);
-    controller.promptTurnStarted();
-    advance(200);
-    controller.promptTurnEnded();
-    assert.equal(terminal.bells, 0);
-    assert.equal(terminal.title, 'Maka');
-  });
-
-  test('regaining focus clears the attention marker', () => {
-    const { terminal, controller, advance } = makeController(8000);
-    controller.focusChanged(false);
-    controller.promptTurnStarted();
-    advance(9000);
-    controller.promptTurnEnded();
-    assert.equal(terminal.title, '★ Maka');
-    controller.focusChanged(true);
-    assert.equal(terminal.title, 'Maka');
-  });
-
-  test('a new turn clears a stale attention marker', () => {
-    const { terminal, controller, advance } = makeController(8000);
-    controller.focusChanged(false);
-    controller.promptTurnStarted();
-    advance(9000);
-    controller.promptTurnEnded();
-    assert.equal(terminal.title, '★ Maka');
-    controller.promptTurnStarted();
-    assert.equal(terminal.title, BUSY);
+  test('focus and a new turn both clear a stale attention marker', () => {
+    for (const action of ['focus', 'turn'] as const) {
+      const { terminal, controller, advance } = makeController(8000);
+      controller.focusChanged(false);
+      controller.promptTurnStarted();
+      advance(9000);
+      controller.promptTurnEnded();
+      assert.equal(terminal.title, '★ Maka');
+      if (action === 'focus') controller.focusChanged(true);
+      else controller.promptTurnStarted();
+      assert.equal(terminal.title, action === 'focus' ? 'Maka' : BUSY, action);
+    }
   });
 });
 
 describe('AttentionController attention events', () => {
-  test('rings for a permission prompt or error while unfocused', () => {
-    const { terminal, controller } = makeController();
-    controller.focusChanged(false);
-    controller.attentionNeeded();
-    assert.equal(terminal.bells, 1);
-    assert.equal(terminal.title, '★ Maka');
-  });
-
-  test('stays silent for a permission prompt or error while focused', () => {
-    const { terminal, controller } = makeController();
-    controller.attentionNeeded();
-    assert.equal(terminal.bells, 0);
-    assert.equal(terminal.title, 'Maka');
-  });
-
-  test('never rings on a terminal that never reports a blur (no 1004 support)', () => {
-    // Without focus reports the controller assumes focus and suppresses every
-    // ring — the conservative degradation. Title busy/idle still tracks.
-    const { terminal, controller, advance } = makeController(8000);
-    controller.promptTurnStarted();
-    advance(60_000);
-    controller.promptTurnEnded();
-    controller.attentionNeeded();
-    assert.equal(terminal.bells, 0);
+  test('rings for explicit attention only while unfocused', () => {
+    for (const focused of [false, true]) {
+      const { terminal, controller } = makeController();
+      controller.focusChanged(focused);
+      controller.attentionNeeded();
+      assert.equal(terminal.bells, focused ? 0 : 1, String(focused));
+      assert.equal(terminal.title, focused ? 'Maka' : '★ Maka', String(focused));
+    }
   });
 });

--- a/packages/cli/src/__tests__/workspace-root.test.ts
+++ b/packages/cli/src/__tests__/workspace-root.test.ts
@@ -3,28 +3,28 @@ import { describe, test } from 'node:test';
 import { resolveMakaWorkspaceRoot } from '../workspace-root.js';
 
 describe('Maka workspace root resolver', () => {
-  test('resolves the desktop default workspace under Electron userData on macOS', () => {
-    assert.equal(
-      resolveMakaWorkspaceRoot({ platform: 'darwin', homeDir: '/Users/ada', env: {} }),
-      '/Users/ada/Library/Application Support/Maka/workspaces/default',
-    );
-  });
+  test('resolves each platform under its canonical application-data root', () => {
+    const cases = [
+      [
+        { platform: 'darwin', homeDir: '/Users/ada', env: {} },
+        '/Users/ada/Library/Application Support/Maka/workspaces/default',
+      ],
+      [
+        { platform: 'linux', homeDir: '/home/ada', env: {} },
+        '/home/ada/.config/Maka/workspaces/default',
+      ],
+      [
+        {
+          platform: 'win32',
+          homeDir: 'C:\\Users\\Ada',
+          env: { APPDATA: 'C:\\Users\\Ada\\AppData\\Roaming' },
+        },
+        'C:\\Users\\Ada\\AppData\\Roaming\\Maka\\workspaces\\default',
+      ],
+    ] as const;
 
-  test('resolves the desktop default workspace under Electron userData on Linux', () => {
-    assert.equal(
-      resolveMakaWorkspaceRoot({ platform: 'linux', homeDir: '/home/ada', env: {} }),
-      '/home/ada/.config/Maka/workspaces/default',
-    );
-  });
-
-  test('resolves the desktop default workspace under Electron userData on Windows', () => {
-    assert.equal(
-      resolveMakaWorkspaceRoot({
-        platform: 'win32',
-        homeDir: 'C:\\Users\\Ada',
-        env: { APPDATA: 'C:\\Users\\Ada\\AppData\\Roaming' },
-      }),
-      'C:\\Users\\Ada\\AppData\\Roaming\\Maka\\workspaces\\default',
-    );
+    for (const [options, expected] of cases) {
+      assert.equal(resolveMakaWorkspaceRoot(options), expected, options.platform);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- collapse terminal color-level and environment matrices into behavioral contracts
- remove exact disc-color and spinner-frame presentation mirrors
- consolidate attention focus/threshold transitions without dropping state boundaries
- collapse recap normalization, trigger thresholds, and platform workspace paths into tables

## Impact
- CLI: 575 -> 538 tests
- 37 fewer tests
- 194 net lines removed

## Validation
- npm run clean
- npm run build:test
- touched tests: 14/14
- npm --workspace maka-agent run test:dist (538 tests, 0 fail)
- npm run test:scripts:full (48 tests, 0 fail)
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check