### PR TITLE
test: collapse skill completion coverage

### DIFF
--- a/packages/cli/src/__tests__/skill-invocation.test.ts
+++ b/packages/cli/src/__tests__/skill-invocation.test.ts
@@ -16,7 +16,7 @@ import { FakeTerminal } from './tui-terminal-mock.js';
 before(() => _setColorLevelForTesting(3));
 
 describe('skill invocation tokens', () => {
-  test('parses tokens anywhere in text, deduped case-insensitively, in order', () => {
+  test('parses canonical tokens and rejects lookalikes', () => {
     const tokens = parseSkillInvocationTokens(
       '帮我 /skill:weekly-report 整理\n然后 /skill:Alpha 和 /skill:WEEKLY-REPORT 各来一遍',
     );
@@ -26,50 +26,41 @@ describe('skill invocation tokens', () => {
     );
     assert.equal(tokens[0].start, 3);
     assert.equal(tokens[0].end, 3 + '/skill:weekly-report'.length);
-  });
-
-  test('rejects path-like and colon-less occurrences', () => {
-    assert.deepEqual(parseSkillInvocationTokens('cat docs/skill:alpha'), []);
-    assert.deepEqual(parseSkillInvocationTokens('/skill alpha'), []);
-    assert.deepEqual(parseSkillInvocationTokens('/skill:'), []);
-    assert.deepEqual(parseSkillInvocationTokens('看 https://example.com/skill:x'), []);
-  });
-
-  test('token name stops at the id charset boundary', () => {
-    const tokens = parseSkillInvocationTokens('/skill:alpha，整理一下');
+    for (const input of [
+      'cat docs/skill:alpha',
+      '/skill alpha',
+      '/skill:',
+      '看 https://example.com/skill:x',
+    ]) {
+      assert.deepEqual(parseSkillInvocationTokens(input), [], input);
+    }
     assert.deepEqual(
-      tokens.map((token) => token.name),
+      parseSkillInvocationTokens('/skill:alpha，整理一下').map((token) => token.name),
       ['alpha'],
     );
   });
 
-  test('strips named tokens and tidies only the touched lines', () => {
-    const text = [
-      '帮我 /skill:alpha 整理一下',
-      '```',
-      'code  with  double  spaces',
-      '```',
-      '/skill:beta',
-      '收尾 /skill:ALPHA',
-    ].join('\n');
-    const stripped = stripSkillInvocationTokens(text, new Set(['alpha', 'beta']));
-    assert.equal(
-      stripped,
-      ['帮我 整理一下', '```', 'code  with  double  spaces', '```', '收尾'].join('\n'),
-    );
-  });
+  test('strips resolved tokens without disturbing unrelated text', () => {
+    const cases: Array<[string, string[], string]> = [
+      [
+        [
+          '帮我 /skill:alpha 整理一下',
+          '```',
+          'code  with  double  spaces',
+          '```',
+          '/skill:beta',
+          '收尾 /skill:ALPHA',
+        ].join('\n'),
+        ['alpha', 'beta'],
+        ['帮我 整理一下', '```', 'code  with  double  spaces', '```', '收尾'].join('\n'),
+      ],
+      ['用 /skill:nope 和 /skill:alpha 处理', ['alpha'], '用 /skill:nope 和 处理'],
+      ['/skill:alpha\n    make target\n', ['alpha'], '    make target\n'],
+    ];
 
-  test('keeps unresolved tokens literal', () => {
-    const text = '用 /skill:nope 和 /skill:alpha 处理';
-    assert.equal(stripSkillInvocationTokens(text, new Set(['alpha'])), '用 /skill:nope 和 处理');
-  });
-
-  test('preserves indented code after a token-only line (no global trim)', () => {
-    const stripped = stripSkillInvocationTokens(
-      '/skill:alpha\n    make target\n',
-      new Set(['alpha']),
-    );
-    assert.equal(stripped, '    make target\n');
+    for (const [text, resolved, expected] of cases) {
+      assert.equal(stripSkillInvocationTokens(text, new Set(resolved)), expected, text);
+    }
   });
 
   test('detects the autocomplete prefix at the cursor', () => {
@@ -106,8 +97,12 @@ describe('skill autocomplete', () => {
   ];
   const listSkills = async () => skills;
 
-  test('suggests by id prefix or name substring, suppressing file completion', async () => {
-    const provider = new MakaAutocompleteProvider('/repo', [], listSkills);
+  test('suggests and applies skills ahead of command and file completion', async () => {
+    const provider = new MakaAutocompleteProvider(
+      '/repo',
+      [{ name: 'skill', description: 'Invoke a skill' }],
+      listSkills,
+    );
     const byId = await provider.getSuggestions(['/skill:we'], 0, 9, {
       signal: new AbortController().signal,
     });
@@ -131,15 +126,7 @@ describe('skill autocomplete', () => {
     const noMatch = await provider.getSuggestions(['/skill:zzz'], 0, 10, {
       signal: new AbortController().signal,
     });
-    assert.equal(noMatch, null, 'no skill match closes the popup instead of offering paths');
-  });
-
-  test('wins over slash-command completion at line start', async () => {
-    const provider = new MakaAutocompleteProvider(
-      '/repo',
-      [{ name: 'skill', description: 'Invoke a skill' }],
-      listSkills,
-    );
+    assert.equal(noMatch, null);
     const suggestions = await provider.getSuggestions(['/skill:dat'], 0, 10, {
       signal: new AbortController().signal,
     });
@@ -147,10 +134,6 @@ describe('skill autocomplete', () => {
       suggestions?.items.map((item) => item.value),
       ['data-crunch'],
     );
-  });
-
-  test('applies completion as a token with trailing space, mid-line', () => {
-    const provider = new MakaAutocompleteProvider('/repo', [], listSkills);
     const applied = provider.applyCompletion(
       ['帮我 /skill:we 一下'],
       0,
@@ -160,10 +143,6 @@ describe('skill autocomplete', () => {
     );
     assert.deepEqual(applied.lines, ['帮我 /skill:weekly-report  一下']);
     assert.equal(applied.lines[0].slice(0, applied.cursorCol), '帮我 /skill:weekly-report ');
-  });
-
-  test('never triggers file completion inside a token', () => {
-    const provider = new MakaAutocompleteProvider('/repo', [], listSkills);
     assert.equal(provider.shouldTriggerFileCompletion(['/skill:we'], 0, 9), false);
   });
 });

--- a/packages/cli/src/__tests__/slash-command-completion.test.ts
+++ b/packages/cli/src/__tests__/slash-command-completion.test.ts
@@ -49,23 +49,14 @@ describe('MakaAutocompleteProvider mid-message skill completion', () => {
     baseDir = mkdtempSync(join(tmpdir(), 'maka-skill-'));
   });
 
-  test('completes a `/skill:` token mid-message with a slash-less prefix', async () => {
+  test('completes and applies a mid-message `/skill:` token without a submit prefix', async () => {
     const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
     const result = await provider.getSuggestions(['see /skill:w'], 0, 12, { signal });
-    assert.equal(
-      result?.prefix,
-      'w',
-      'mid-message prefix must drop /skill: so select does not submit',
-    );
+    assert.equal(result?.prefix, 'w');
     assert.deepEqual(
       (result?.items ?? []).map((i) => i.value),
       ['weekly-report', 'web-search'],
     );
-  });
-
-  test('applies a mid-message skill completion as `/skill:name ` (no submit)', async () => {
-    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
-    await provider.getSuggestions(['see /skill:w'], 0, 12, { signal });
     const applied = provider.applyCompletion(
       ['see /skill:w'],
       0,
@@ -77,73 +68,36 @@ describe('MakaAutocompleteProvider mid-message skill completion', () => {
     assert.equal(applied.cursorCol, 'see /skill:weekly-report '.length);
   });
 
-  test('does NOT complete plain commands mid-message (only line start)', async () => {
+  test('keeps plain commands and non-first-line skills out of mid-message completion', async () => {
     const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
-    const result = await provider.getSuggestions(['see /co'], 0, 7, { signal });
+    const plain = await provider.getSuggestions(['see /co'], 0, 7, { signal });
     assert.equal(
-      (result?.items ?? []).some((i) => commands.some((c) => c.name === i.value)),
+      (plain?.items ?? []).some((item) => commands.some((command) => command.name === item.value)),
       false,
-      'plain commands must not complete mid-message',
     );
-  });
-
-  test('line-start skill completion is unchanged (prefix keeps `/skill:`)', async () => {
-    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
-    const result = await provider.getSuggestions(['/skill:w'], 0, 8, { signal });
-    assert.equal(result?.prefix, '/skill:w');
-    assert.deepEqual(
-      (result?.items ?? []).map((i) => i.value),
-      ['weekly-report', 'web-search'],
-    );
-  });
-
-  test('line-start plain command completion is unchanged', async () => {
-    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
-    const result = await provider.getSuggestions(['/co'], 0, 3, { signal });
-    assert.equal(result?.prefix, '/co');
-    assert.deepEqual(
-      (result?.items ?? []).map((i) => i.value),
-      ['compact', 'config'],
-    );
-  });
-
-  test('mid-message skill completion is first-line only', async () => {
-    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
-    const result = await provider.getSuggestions(['first', 'see /skill:w'], 1, 12, { signal });
+    const secondLine = await provider.getSuggestions(['first', 'see /skill:w'], 1, 12, {
+      signal,
+    });
     assert.equal(
-      (result?.items ?? []).some((i) => skills.some((s) => s.id === i.value)),
+      (secondLine?.items ?? []).some((item) => skills.some((skill) => skill.id === item.value)),
       false,
-      'a `/skill:` on a non-first line must not surface skill completion',
     );
   });
 
-  test('completes `/skill:xxx` from a bare mid-message `/` token', async () => {
+  test('filters and applies skill completion from a bare mid-message slash', async () => {
     const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
-    const result = await provider.getSuggestions(['see /'], 0, 5, { signal });
-    assert.equal(
-      result?.prefix,
-      '',
-      'bare / prefix is empty (slash-less) so select does not submit',
-    );
-    assert.deepEqual(
-      (result?.items ?? []).map((i) => i.value),
-      ['skill:weekly-report', 'skill:web-search'],
-    );
-  });
-
-  test('filters bare mid-message `/` completions by the text after `/`', async () => {
-    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
-    const result = await provider.getSuggestions(['see /w'], 0, 6, { signal });
-    assert.equal(result?.prefix, 'w');
-    assert.deepEqual(
-      (result?.items ?? []).map((i) => i.value),
-      ['skill:weekly-report', 'skill:web-search'],
-    );
-  });
-
-  test('applies a bare mid-message `/` skill completion as `/skill:name `', async () => {
-    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
-    await provider.getSuggestions(['see /'], 0, 5, { signal });
+    for (const [line, column, prefix] of [
+      ['see /', 5, ''],
+      ['see /w', 6, 'w'],
+    ] as const) {
+      const result = await provider.getSuggestions([line], 0, column, { signal });
+      assert.equal(result?.prefix, prefix, line);
+      assert.deepEqual(
+        (result?.items ?? []).map((item) => item.value),
+        ['skill:weekly-report', 'skill:web-search'],
+        line,
+      );
+    }
     const applied = provider.applyCompletion(
       ['see /'],
       0,
@@ -155,43 +109,19 @@ describe('MakaAutocompleteProvider mid-message skill completion', () => {
     assert.equal(applied.cursorCol, 'see /skill:weekly-report '.length);
   });
 
-  test('a bare mid-message `/` with no skill match does not surface skills', async () => {
-    const provider = new MakaAutocompleteProvider(baseDir, commands, listSkills);
-    const result = await provider.getSuggestions(['see /zzz'], 0, 8, { signal });
-    assert.equal(
-      (result?.items ?? []).some((i) =>
-        skills.some((s) => s.id === i.value || `skill:${s.id}` === i.value),
-      ),
-      false,
-    );
-  });
-
-  test('a bare mid-message `/` with no skill match does NOT fall through to file completion', async () => {
-    // Regression: falling through to the file provider returns a `/`-prefixed
-    // prefix, and pi-tui auto-submits on select when prefix starts with `/` -
-    // so selecting the file item would send the unfinished message. Mid-message
-    // `/`-path completion was not available before this PR either (pi-tui
-    // excludes `/` from triggerCharacters), so returning null restores prior
-    // behavior instead of introducing an auto-submit footgun.
+  test('a bare mid-message slash with no skill match never falls through to files', async () => {
     const provider = new MakaAutocompleteProvider('/', commands, listSkills);
-    const result = await provider.getSuggestions(['see /U'], 0, 6, { signal });
-    assert.equal(
-      result,
-      null,
-      'must not fall through to file provider (would auto-submit on select)',
-    );
+    assert.equal(await provider.getSuggestions(['see /zzz'], 0, 8, { signal }), null);
+    assert.equal(await provider.getSuggestions(['see /U'], 0, 6, { signal }), null);
   });
 
-  test('a bare mid-message `/` keeps the original (non-lowercased) prefix for apply', async () => {
-    // Regression: toLowerCase can change UTF-16 length (e.g. "İ" -> "i̇", len 1->2).
-    // Using the lowercased query as the replacement prefix makes applyCompletion
-    // slice by the wrong length, over-deleting the original text.
+  test('keeps the original Unicode prefix length when applying a completion', async () => {
     const provider = new MakaAutocompleteProvider(baseDir, commands, async () => [
       { ref: 'workspace:legacy:info', id: 'info', name: 'İnfo', description: '' },
     ]);
     const result = await provider.getSuggestions(['see /İ'], 0, 6, { signal });
-    assert.equal(result?.prefix, 'İ', 'prefix must be the original text, not its lowercased form');
-    assert.ok(result && result.items.length > 0, 'expected a skill match');
+    assert.equal(result?.prefix, 'İ');
+    assert.ok(result && result.items.length > 0);
     const applied = provider.applyCompletion(['see /İ'], 0, 6, result.items[0], result.prefix);
     assert.deepEqual(applied.lines, ['see /skill:info ']);
   });
@@ -254,24 +184,7 @@ describe('MakaSkillHighlightEditor mid-message skill trigger', () => {
   ];
   const listSkills = async (): Promise<readonly InvocableSkillEntry[]> => skills;
 
-  test('typing `/skill:` mid-message triggers skill autocomplete', async () => {
-    const tui = new TUI(new FakeTerminal());
-    const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
-    editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
-    for (const ch of 'see /skill:w') editor.handleInput(ch);
-    await waitFor(() => editor.isShowingAutocomplete());
-    const rendered = editor.render(80).join('\n');
-    assert.ok(
-      rendered.includes('/skill:weekly-report'),
-      `expected /skill:weekly-report in:\n${rendered}`,
-    );
-    assert.ok(
-      rendered.includes('/skill:web-search'),
-      `expected /skill:web-search in:\n${rendered}`,
-    );
-  });
-
-  test('selecting a mid-message skill inserts `/skill:name ` and does not submit', async () => {
+  test('selecting a mid-message skill completes without submitting', async () => {
     const tui = new TUI(new FakeTerminal());
     const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
     editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
@@ -281,23 +194,12 @@ describe('MakaSkillHighlightEditor mid-message skill trigger', () => {
     };
     for (const ch of 'see /skill:w') editor.handleInput(ch);
     await waitFor(() => editor.isShowingAutocomplete());
-    editor.handleInput('\r');
-    assert.equal(submitted, undefined, 'mid-message skill select must not submit');
-    assert.deepEqual(editor.getLines(), ['see /skill:weekly-report ']);
-  });
-
-  test('typing a plain command mid-message does NOT surface plain commands', async () => {
-    const tui = new TUI(new FakeTerminal());
-    const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
-    editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
-    for (const ch of 'see /co') editor.handleInput(ch);
-    await new Promise((resolve) => setTimeout(resolve, 80));
     const rendered = editor.render(80).join('\n');
-    // `/co` may trigger file completion (e.g. /cores), but plain slash commands
-    // must never appear mid-message - they only execute at line start.
-    assert.ok(!rendered.includes('/compact'), 'plain commands must not complete mid-message');
-    assert.ok(!rendered.includes('/config'));
-    assert.ok(!rendered.includes('/model'));
+    assert.match(rendered, /\/skill:weekly-report/);
+    assert.match(rendered, /\/skill:web-search/);
+    editor.handleInput('\r');
+    assert.equal(submitted, undefined);
+    assert.deepEqual(editor.getLines(), ['see /skill:weekly-report ']);
   });
 
   test('typing a bare `/` mid-message triggers skill autocomplete', async () => {
@@ -317,41 +219,37 @@ describe('MakaSkillHighlightEditor mid-message skill trigger', () => {
     );
   });
 
-  test('mid-message trigger works under Kitty CSI-u keyboard protocol', async () => {
-    // Regression: a Kitty keyboard terminal encodes printable chars as CSI-u
-    // (starting with ESC). A naive `data.startsWith('\x1b')` guard skipped
-    // them, so the text was inserted but the completion menu never appeared.
-    setKittyProtocolActive(true);
-    try {
-      const tui = new TUI(new FakeTerminal());
-      const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
-      editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
-      for (const ch of 'see /skill:w') editor.handleInput(`\x1b[${ch.codePointAt(0)}u`);
-      await waitFor(() => editor.isShowingAutocomplete());
-      const rendered = editor.render(80).join('\n');
-      assert.ok(
-        rendered.includes('/skill:weekly-report'),
-        `expected skill completion under Kitty CSI-u:\n${rendered}`,
-      );
-    } finally {
-      setKittyProtocolActive(false);
-    }
-  });
+  test('mid-message trigger supports Kitty and xterm encoded printable input', async () => {
+    const protocols = [
+      {
+        kitty: true,
+        text: 'see /skill:w',
+        encode: (codePoint: number) => `\x1b[${codePoint}u`,
+      },
+      {
+        kitty: false,
+        text: 'see /',
+        encode: (codePoint: number) => `\x1b[27;1;${codePoint}~`,
+      },
+    ];
 
-  test('mid-message trigger works under xterm modifyOtherKeys encoding', async () => {
-    // Regression: pi-tui's Editor decodes modifyOtherKeys printables
-    // (ESC[27;1;<cp>~), but the trigger guard only recognized Kitty CSI-u, so
-    // the menu never appeared even though the text was inserted.
-    const tui = new TUI(new FakeTerminal());
-    const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
-    editor.setAutocompleteProvider(new MakaAutocompleteProvider(tmpdir(), commands, listSkills));
-    for (const ch of 'see /') editor.handleInput(`\x1b[27;1;${ch.codePointAt(0)}~`);
-    await waitFor(() => editor.isShowingAutocomplete());
-    const rendered = editor.render(80).join('\n');
-    assert.ok(
-      rendered.includes('/skill:weekly-report'),
-      `expected skill completion under modifyOtherKeys:\n${rendered}`,
-    );
+    for (const protocol of protocols) {
+      setKittyProtocolActive(protocol.kitty);
+      try {
+        const tui = new TUI(new FakeTerminal());
+        const editor = new MakaSkillHighlightEditor(tui, editorTheme(), { paddingX: 1 });
+        editor.setAutocompleteProvider(
+          new MakaAutocompleteProvider(tmpdir(), commands, listSkills),
+        );
+        for (const character of protocol.text) {
+          editor.handleInput(protocol.encode(character.codePointAt(0) ?? 0));
+        }
+        await waitFor(() => editor.isShowingAutocomplete());
+        assert.match(editor.render(80).join('\n'), /\/skill:weekly-report/);
+      } finally {
+        setKittyProtocolActive(false);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- collapse duplicate skill-token, provider, and editor happy paths
- retain Unicode prefix, no-file-fallback, no-auto-submit, Kitty, and xterm protocol boundaries
- reduce CLI coverage from 538 to 521 tests (17 fewer tests, 123 net lines removed)

## Verification
- npm run clean
- npm run build:test
- npm --workspace maka-agent run test:dist (521/521)
- npm run test:scripts:full
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check HEAD^ HEAD