### PR TITLE
test: collapse script contract fixtures

### DIFF
--- a/scripts/cu-provider-matrix.test.mjs
+++ b/scripts/cu-provider-matrix.test.mjs
@@ -149,77 +149,58 @@ test('matrix generation never executes provider command templates', async () => 
   }
 });
 
-test('a real report from another scenario is invalid instead of a fixture failure', async () => {
-  const matrix = await buildProviderMatrix({
-    scenarios: [scenario({ id: 'l0-observe-only' })],
-    providers: [
-      {
-        id: 'openai',
-        readiness: 'real',
-        producer: 'cu-real-model-launcher',
-        model: 'gpt-5.4',
-        report: 'report.json',
-      },
+test('real reports reject invalid identity, provenance, and lineage', () => {
+  for (const [label, patch, reportScenario, patterns] of [
+    [
+      'scenario mismatch',
+      { scenarioId: 'l1-single-click' },
+      scenario({ id: 'l0-observe-only' }),
+      [/scenarioId mismatch/],
     ],
-    loadReport: async () => realReport({ scenarioId: 'l1-single-click' }),
-  });
-  assert.equal(matrix.rows[0].status, 'invalid-report');
-  assert.match(matrix.rows[0].reportError, /scenarioId mismatch/);
-});
-
-test('a hermetic or unlabeled report cannot satisfy real-provider readiness', async () => {
-  for (const evidenceClass of [undefined, 'hermetic-protocol']) {
-    const matrix = await buildProviderMatrix({
-      scenarios: [scenario()],
-      providers: [
-        {
-          id: 'openai',
-          readiness: 'real',
-          producer: 'cu-real-model-launcher',
-          model: 'gpt-5.4',
-          report: 'report.json',
-        },
-      ],
-      loadReport: async () => realReport({ evidenceClass }),
-    });
-    assert.equal(matrix.rows[0].status, 'invalid-report');
-    assert.match(matrix.rows[0].reportError, /real-runtime/);
-  }
-});
-
-test('real reports reject invalid readiness, identity, provenance, and lineage', async () => {
-  for (const [label, patch, pattern] of [
-    ['inconclusive status', { status: 'inconclusive' }, /status must be pass/],
-    ['wrong provider', { provider: 'claude' }, /provider mismatch/],
-    ['wrong model', { model: 'other' }, /model mismatch/],
+    ['missing evidence class', { evidenceClass: undefined }, scenario(), [/real-runtime/]],
+    ['hermetic evidence', { evidenceClass: 'hermetic-protocol' }, scenario(), [/real-runtime/]],
+    ['inconclusive status', { status: 'inconclusive' }, scenario(), [/status must be pass/]],
+    ['wrong provider', { provider: 'claude' }, scenario(), [/provider mismatch/]],
+    ['wrong model', { model: 'other' }, scenario(), [/model mismatch/]],
     [
       'bad terminal',
       { terminal: { type: 'complete', stopReason: 'max_tokens' } },
-      /complete\/end_turn/,
+      scenario(),
+      [/complete\/end_turn/],
     ],
-    ['unknown producer', { producer: 'legacy-runner' }, /producer missing or unknown/],
-    ['missing policy provenance', { policyMode: undefined }, /policyMode missing or unknown/],
-    ['unknown transport provenance', { transportClass: 'unknown' }, /live-network/],
-    ['ineligible qualification', { qualificationEligible: false }, /qualificationEligible/],
-    ['deprecated report', { deprecated: true }, /deprecated reports cannot qualify/],
+    [
+      'unknown producer',
+      { producer: 'legacy-runner' },
+      scenario(),
+      [/producer missing or unknown/],
+    ],
+    [
+      'missing policy provenance',
+      { policyMode: undefined },
+      scenario(),
+      [/policyMode missing or unknown/],
+    ],
+    ['unknown transport provenance', { transportClass: 'unknown' }, scenario(), [/live-network/]],
+    [
+      'ineligible qualification',
+      { qualificationEligible: false },
+      scenario(),
+      [/qualificationEligible/],
+    ],
+    ['deprecated report', { deprecated: true }, scenario(), [/deprecated reports cannot qualify/]],
+    [
+      'broken content lineage',
+      { gitRevision: 'bad', contentLineage: undefined },
+      scenario(),
+      [/gitRevision/, /contentLineage/],
+    ],
   ]) {
-    const report = realReport(patch);
-    Object.assign(report, withLedgerCounts(report));
-    const matrix = await buildProviderMatrix({
-      scenarios: [scenario()],
-      providers: [
-        {
-          id: 'openai',
-          readiness: 'real',
-          producer: 'cu-real-model-launcher',
-          model: 'gpt-5.4',
-          report: 'report.json',
-        },
-      ],
-      loadReport: async () => report,
-    });
-    assert.equal(matrix.rows[0].status, 'invalid-report', label);
-    assert.match(matrix.rows[0].reportError, pattern, label);
+    const errors = validateRealReport(
+      realReport(patch),
+      { id: 'openai', producer: 'cu-real-model-launcher', model: 'gpt-5.4' },
+      reportScenario,
+    ).join('; ');
+    for (const pattern of patterns) assert.match(errors, pattern, label);
   }
 });
 
@@ -595,22 +576,4 @@ test('restart recovery requires target_missing then fresh observation and AX set
     validateRealReport(complete, provider, restartScenario).join('; '),
     /restart recovery requires/,
   );
-});
-
-test('real reports require matching run and content lineage', () => {
-  const errors = validateRealReport(
-    realReport({
-      gitRevision: 'bad',
-      contentLineage: undefined,
-    }),
-    {
-      id: 'openai',
-      producer: 'cu-real-model-launcher',
-      model: 'gpt-5.4',
-    },
-    scenario(),
-  );
-
-  assert.match(errors.join('; '), /gitRevision/);
-  assert.match(errors.join('; '), /contentLineage/);
 });

--- a/scripts/cu-report-sanitize.test.mjs
+++ b/scripts/cu-report-sanitize.test.mjs
@@ -53,54 +53,7 @@ test('CU reports keep metrics while dropping typed text, coordinates, URL secret
   assert.doesNotMatch(serialized, /"x":12|"y":34/);
 });
 
-test('report sanitizer preserves validated attribution and drops arbitrary fields', () => {
-  const report = sanitizeCuReport({
-    schemaVersion: 1,
-    evidenceClass: 'real-runtime',
-    scenarioId: 'l0-observe-only',
-    producer: 'cu-real-model-launcher',
-    transportClass: 'live-network',
-    policyMode: 'bypassed',
-    qualificationEligible: true,
-    provider: 'openai',
-    model: 'gpt-5.4',
-    status: 'inconclusive',
-    run: { status: 'waiting_for_user' },
-    failure: 'private provider body',
-    loopStatus: { private: true },
-    turns: [{ text: 'private' }],
-    state: { private: true },
-    display: { private: true },
-    traces: [
-      {
-        type: 'dispatch',
-        actionType: 'click_element',
-        path: 'private-path',
-        effect: 'private-effect',
-        address: 'ax',
-        tool: 'click',
-      },
-    ],
-  });
-  assert.equal(report.producer, 'cu-real-model-launcher');
-  assert.equal(report.provider, 'openai');
-  assert.equal(report.model, 'gpt-5.4');
-  assert.equal(report.qualificationEligible, true);
-  assert.equal(report.run.status, 'waiting_for_user');
-  assert.deepEqual(report.traces, [
-    {
-      type: 'dispatch',
-      actionType: 'click_element',
-      address: 'ax',
-      tool: 'click',
-    },
-  ]);
-  const serialized = JSON.stringify(report);
-  assert.doesNotMatch(serialized, /private/);
-  assert.doesNotMatch(serialized, /loopStatus|turns|display/);
-});
-
-test('canonical evidence keeps privacy-safe ownership and observation lineage', () => {
+test('canonical evidence keeps attribution and lineage without private fields', () => {
   const generatedAt = '2026-07-12T00:00:00.000Z';
   const gitRevision = '0123456789abcdef0123456789abcdef01234567';
   const report = sanitizeCuReport({
@@ -119,6 +72,15 @@ test('canonical evidence keeps privacy-safe ownership and observation lineage', 
     transportClass: 'live-network',
     policyMode: 'enforced',
     qualificationEligible: false,
+    provider: 'openai',
+    model: 'gpt-5.4',
+    status: 'inconclusive',
+    run: { status: 'waiting_for_user' },
+    failure: 'private provider body',
+    loopStatus: { private: true },
+    turns: [{ text: 'private' }],
+    state: { private: true },
+    display: { private: true },
     fixtureIdentity: {
       instances: [
         { pid: 42, windowIds: [7, 7, -1] },
@@ -148,6 +110,8 @@ test('canonical evidence keeps privacy-safe ownership and observation lineage', 
         windowId: 7,
         address: 'ax',
         tool: 'set_value',
+        path: 'private-path',
+        effect: 'private-effect',
       },
     ],
   });
@@ -167,6 +131,9 @@ test('canonical evidence keeps privacy-safe ownership and observation lineage', 
     generatedAt,
   });
   assert.equal(report.actionAttempts, 1);
+  assert.equal(report.provider, 'openai');
+  assert.equal(report.model, 'gpt-5.4');
+  assert.equal(report.run.status, 'waiting_for_user');
   assert.deepEqual(report.faultInjection, {
     layer: 'runtime',
     kind: 'user_intervened',
@@ -190,4 +157,7 @@ test('canonical evidence keeps privacy-safe ownership and observation lineage', 
     address: 'ax',
     tool: 'set_value',
   });
+  const serialized = JSON.stringify(report);
+  assert.doesNotMatch(serialized, /private/);
+  assert.doesNotMatch(serialized, /loopStatus|turns|display/);
 });

--- a/scripts/macos-arm64-release.test.mjs
+++ b/scripts/macos-arm64-release.test.mjs
@@ -9,8 +9,11 @@ const signingEnvironment = {
   APPLE_API_ISSUER: '00000000-0000-0000-0000-000000000000',
 };
 
-test('release packaging refuses an unsupported host or incomplete signing identity', async () => {
+test('release tooling fails closed on unsupported hosts, signing, and architecture', async () => {
   const { packageMacosArm64 } = await import(new URL('package-macos-arm64.mjs', import.meta.url));
+  const { verifyPackagedMacApp } = await import(
+    new URL('verify-macos-arm64-dmg.mjs', import.meta.url)
+  );
 
   await assert.rejects(
     packageMacosArm64({ platform: 'darwin', arch: 'x64', env: signingEnvironment }),
@@ -20,53 +23,15 @@ test('release packaging refuses an unsupported host or incomplete signing identi
     packageMacosArm64({ platform: 'darwin', arch: 'arm64', env: {} }),
     /CSC_LINK/,
   );
-});
-
-test('packaged app verification covers trust, runtime resources, and renderer launch', async () => {
-  const { verifyPackagedMacApp } = await import(
-    new URL('verify-macos-arm64-dmg.mjs', import.meta.url)
-  );
-  const commands = [];
-  const requiredPaths = [];
-  const forbiddenPaths = [];
-  const rendererLaunches = [];
-  const workerLaunches = [];
-  const run = async (command, args, options) => {
-    commands.push([command, args, options]);
-    if (command === 'plutil') {
-      if (args[1] === 'CFBundleIdentifier') return { stdout: 'com.maka.desktop\n', stderr: '' };
-      if (args[1] === 'CFBundleShortVersionString') return { stdout: '0.1.2\n', stderr: '' };
-      return { stdout: 'Maka\n', stderr: '' };
-    }
-    if (command === 'lipo') return { stdout: 'arm64\n', stderr: '' };
-    return { stdout: '', stderr: '' };
-  };
-
-  await verifyPackagedMacApp('/tmp/Maka.app', {
-    run,
-    requirePath: async (path) => requiredPaths.push(path),
-    forbidPath: async (path) => forbiddenPaths.push(path),
-    smokeRenderer: async (...args) => rendererLaunches.push(args),
-    smokeFilesystemWorker: async (...args) => workerLaunches.push(args),
-  });
-
-  for (const command of ['codesign', 'spctl', 'xcrun']) {
-    assert.ok(
-      commands.some(([actual]) => actual === command),
-      `${command} must run`,
-    );
-  }
-  assert.ok(requiredPaths.some((path) => path.endsWith('/Resources/app.asar')));
-  assert.ok(requiredPaths.some((path) => path.endsWith('/Resources/workers/filesystem-worker.js')));
-  assert.ok(requiredPaths.some((path) => path.endsWith('/Resources/licenses/maka/LICENSE')));
-  assert.ok(forbiddenPaths.some((path) => path.endsWith('/Resources/bin/cua-driver')));
-  assert.equal(rendererLaunches.length, 1);
-  assert.equal(workerLaunches.length, 1);
 
   await assert.rejects(
     verifyPackagedMacApp('/tmp/Maka.app', {
       run: async (command, args) => {
-        if (command === 'plutil') return run(command, args);
+        if (command === 'plutil') {
+          if (args[1] === 'CFBundleIdentifier') return { stdout: 'com.maka.desktop\n' };
+          if (args[1] === 'CFBundleShortVersionString') return { stdout: '0.1.2\n' };
+          return { stdout: 'Maka\n' };
+        }
         if (command === 'lipo') return { stdout: 'x86_64\n', stderr: '' };
         return { stdout: '', stderr: '' };
       },
@@ -91,15 +56,5 @@ test('renderer readiness rejects the static preload skeleton', async () => {
       hasAppShell: false,
     }),
     false,
-  );
-  assert.equal(
-    isPackagedRendererUsable({
-      readyState: 'complete',
-      hasBridge: true,
-      hasRoot: true,
-      hasPreloadSkeleton: false,
-      hasAppShell: true,
-    }),
-    true,
   );
 });


### PR DESCRIPTION
## Summary
- collapse repeated provider-report invalid fixtures into one boundary table
- combine canonical CU attribution/lineage and private-field redaction coverage
- remove macOS verifier checklist mirrors while retaining host, signing, architecture, and renderer fail-closed gates
- reduce script coverage from 48 to 43 tests (5 fewer tests, 112 net lines removed)

## Verification
- npm run clean
- npm run build:test
- npm run test:scripts:full (43/43)
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check HEAD^ HEAD