### PR TITLE
feat(runtime-host): establish Goal authority

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-incoming-goal-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-goal-lifecycle.test.ts
@@ -91,7 +91,7 @@ describe('bot incoming Goal lifecycle', () => {
           turnId: input.turnId,
           goalBoundary: 'external',
           activities,
-          beginExternalTurn: (sessionId, turnId) => coordinator.beginExternalTurn(sessionId, turnId),
+          beginObservedTurn: (sessionId, turnId) => coordinator.beginObservedTurn(sessionId, turnId),
           onEvent: input.onEvent,
           onStreamError: (error) => { assert.fail(String(error)); },
           onDrained: () => {},

--- a/apps/desktop/src/main/__tests__/goal-wiring.test.ts
+++ b/apps/desktop/src/main/__tests__/goal-wiring.test.ts
@@ -37,7 +37,7 @@ describe('Desktop Goal session lifecycle transaction', () => {
       const persisted = deferred<void>();
       const pending = wiring.archiveSession(SESSION, () => persisted.promise);
 
-      assert.equal(wiring.coordinator.beginExternalTurn(SESSION, 'turn-pending').kind, 'unavailable');
+      assert.equal(wiring.coordinator.beginObservedTurn(SESSION, 'turn-pending').kind, 'unavailable');
       persisted.reject(new Error('archive failed'));
       await assert.rejects(pending, /archive failed/);
 
@@ -47,7 +47,7 @@ describe('Desktop Goal session lifecycle transaction', () => {
         wiring.manager.get(SESSION)?.lastReason,
         'Goal continuation paused because session archive did not complete.',
       );
-      assert.equal(wiring.coordinator.beginExternalTurn(SESSION, 'turn-after-rollback').kind, 'registered');
+      assert.equal(wiring.coordinator.beginObservedTurn(SESSION, 'turn-after-rollback').kind, 'registered');
       wiring.coordinator.dispose();
       wiring.manager.dispose();
     });
@@ -58,7 +58,7 @@ describe('Desktop Goal session lifecycle transaction', () => {
       const persisted = deferred<void>();
       const pending = wiring.removeSession(SESSION, () => persisted.promise);
 
-      assert.equal(wiring.coordinator.beginExternalTurn(SESSION, 'turn-pending').kind, 'unavailable');
+      assert.equal(wiring.coordinator.beginObservedTurn(SESSION, 'turn-pending').kind, 'unavailable');
       persisted.reject(new Error('remove failed'));
       await assert.rejects(pending, /remove failed/);
 
@@ -68,7 +68,7 @@ describe('Desktop Goal session lifecycle transaction', () => {
         wiring.manager.get(SESSION)?.lastReason,
         'Goal continuation paused because session removal did not complete.',
       );
-      assert.equal(wiring.coordinator.beginExternalTurn(SESSION, 'turn-after-rollback').kind, 'registered');
+      assert.equal(wiring.coordinator.beginObservedTurn(SESSION, 'turn-after-rollback').kind, 'registered');
       wiring.coordinator.dispose();
       wiring.manager.dispose();
     });
@@ -88,9 +88,9 @@ describe('Desktop Goal session lifecycle transaction', () => {
     await assert.rejects(remove, /remove failed/);
 
     assert.equal(wiring.manager.get(SESSION), undefined);
-    assert.equal(wiring.coordinator.beginExternalTurn(SESSION, 'turn-archived').kind, 'unavailable');
+    assert.equal(wiring.coordinator.beginObservedTurn(SESSION, 'turn-archived').kind, 'unavailable');
     await wiring.unarchiveSession(SESSION, async () => {});
-    assert.equal(wiring.coordinator.beginExternalTurn(SESSION, 'turn-restored').kind, 'registered');
+    assert.equal(wiring.coordinator.beginObservedTurn(SESSION, 'turn-restored').kind, 'registered');
     wiring.coordinator.dispose();
     wiring.manager.dispose();
   });
@@ -107,7 +107,7 @@ describe('Desktop Goal session lifecycle transaction', () => {
     await wiring.unarchiveSession(SESSION, async () => {});
 
     assert.equal(wiring.manager.get(SESSION), undefined);
-    assert.equal(wiring.coordinator.beginExternalTurn(SESSION, 'turn-deleted').kind, 'unavailable');
+    assert.equal(wiring.coordinator.beginObservedTurn(SESSION, 'turn-deleted').kind, 'unavailable');
     wiring.coordinator.dispose();
     wiring.manager.dispose();
   });

--- a/apps/desktop/src/main/__tests__/materialize-turns.test.ts
+++ b/apps/desktop/src/main/__tests__/materialize-turns.test.ts
@@ -663,8 +663,11 @@ describe('automation turn attribution (F6)', () => {
       { type: 'assistant', id: 'a1', turnId: 't1', ts: 2, text: '好的' },
       { type: 'user', id: 'u2', turnId: 't2', ts: 3, text: '你好' },
     ] as StoredMessage[]);
-    assert.equal(turns[0]?.user?.automationOrigin?.automationId, 'auto-1');
-    assert.equal(turns[1]?.user?.automationOrigin, undefined);
+    assert.deepEqual(turns[0]?.user?.hostOrigin, {
+      kind: 'automation',
+      automationId: 'auto-1',
+    });
+    assert.equal(turns[1]?.user?.hostOrigin, undefined);
   });
 });
 
@@ -686,7 +689,8 @@ describe('Agent Graph supervisor turn attribution', () => {
         },
       },
     ] as StoredMessage[]);
-    assert.deepEqual(turns[0]?.user?.agentGraphOrigin, {
+    assert.deepEqual(turns[0]?.user?.hostOrigin, {
+      kind: 'agent_graph',
       graphId: 'graph-1',
       wakeId: 'graph-1:snapshot-1',
       attemptId: 'attempt-1',

--- a/apps/desktop/src/main/__tests__/session-turn-stream.test.ts
+++ b/apps/desktop/src/main/__tests__/session-turn-stream.test.ts
@@ -38,7 +38,7 @@ describe('Desktop session turn Goal boundary', () => {
       turnId: 'turn-1',
       goalBoundary: 'external',
       activities: registry,
-      beginExternalTurn: () => ({
+      beginObservedTurn: () => ({
         kind: 'registered',
         settle: async (outcome) => {
           assert.equal(registry.whenIdle('session-1'), undefined);
@@ -75,7 +75,7 @@ describe('Desktop session turn Goal boundary', () => {
           turnId: 'turn-1',
           goalBoundary,
           activities: registry,
-          beginExternalTurn: () => {
+          beginObservedTurn: () => {
             settlements++;
             return { kind: 'unavailable', reason: 'unused' };
           },
@@ -114,7 +114,7 @@ describe('Desktop session turn Goal boundary', () => {
       turnId: 'turn-closed',
       goalBoundary: 'external',
       activities: registry,
-      beginExternalTurn: (sessionId, turnId) => coordinator.beginExternalTurn(sessionId, turnId),
+      beginObservedTurn: (sessionId, turnId) => coordinator.beginObservedTurn(sessionId, turnId),
       onEvent: () => {},
       onStreamError: () => {},
       onDrained: () => {},

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -481,8 +481,8 @@ export function createSessionStreamer(deps: SessionStreamerDeps): StreamEvents {
       goalBoundary: options.goalBoundary,
       activities: sessionActivities,
       ...(options.activity ? { activity: options.activity } : {}),
-      beginExternalTurn: (externalSessionId, externalTurnId) =>
-        goalWiring.coordinator.beginExternalTurn(externalSessionId, externalTurnId),
+      beginObservedTurn: (externalSessionId, externalTurnId) =>
+        goalWiring.coordinator.beginObservedTurn(externalSessionId, externalTurnId),
       onEvent: (event) => {
         if (!userAppendBroadcasted) {
           emitSessionsChanged('message-appended', sessionId);

--- a/apps/desktop/src/main/session-turn-stream.ts
+++ b/apps/desktop/src/main/session-turn-stream.ts
@@ -1,7 +1,7 @@
 import type { SessionEvent } from '@maka/core';
 import {
   drainGoalTurn,
-  type GoalExternalTurnStart,
+  type GoalObservedTurnStart,
   type GoalTurnOutcome,
   type SessionActivityLease,
   type SessionActivityRegistry,
@@ -16,7 +16,7 @@ export interface StartDesktopSessionTurnInput {
   goalBoundary: SessionGoalBoundary;
   activities: SessionActivityRegistry;
   activity?: SessionActivityLease;
-  beginExternalTurn: (sessionId: string, turnId: string) => GoalExternalTurnStart;
+  beginObservedTurn: (sessionId: string, turnId: string) => GoalObservedTurnStart;
   onEvent: (event: SessionEvent) => void | Promise<void>;
   onStreamError: (error: unknown) => void | Promise<void>;
   onDrained: (outcome: GoalTurnOutcome) => void | Promise<void>;
@@ -34,7 +34,7 @@ export function startDesktopSessionTurn(
   input: StartDesktopSessionTurnInput,
 ): DesktopSessionTurnStart {
   const registration = input.goalBoundary === 'external'
-    ? input.beginExternalTurn(input.sessionId, input.turnId)
+    ? input.beginObservedTurn(input.sessionId, input.turnId)
     : undefined;
   if (registration && registration.kind !== 'registered') {
     return {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -106,7 +106,7 @@ function createTestGoalLifecycle(
 ): MakaPiTuiGoalLifecycle {
   return {
     activities,
-    beginExternalTurn: (sessionId, turnId) => ({
+    beginObservedTurn: (sessionId, turnId) => ({
       kind: 'registered',
       settle: async (outcome) => {
         onSettled?.(sessionId, turnId, outcome);
@@ -1955,7 +1955,7 @@ describe('Maka Pi TUI runner', () => {
     assert.equal(lifecycle.activities.whenIdle('session-1'), undefined);
 
     assert.equal(manager.create('session-1', 'old session goal').kind, 'created');
-    const switched = lifecycle.beginExternalTurn('session-1', 'turn-after-switch');
+    const switched = lifecycle.beginObservedTurn('session-1', 'turn-after-switch');
     assert.equal(switched.kind, 'registered');
     if (switched.kind !== 'registered') throw new Error('expected registered switch-boundary turn');
     await driver.switchSession('session-2');
@@ -2020,7 +2020,7 @@ describe('Maka Pi TUI runner', () => {
       goalLifecycle: {
         activities,
         bindHost: () => () => {},
-        beginExternalTurn: (sessionId, turnId) => {
+        beginObservedTurn: (sessionId, turnId) => {
           assert.equal(sessionId, 'session-first');
           assert.equal(turnId, 'turn-first');
           assert.ok(activities.whenIdle(sessionId));
@@ -8245,7 +8245,7 @@ async function runSignalExitProbe(
     const terminal = new ReportingTerminal();
     const goalLifecycle = {
       activities: {},
-      beginExternalTurn() { throw new Error('unused'); },
+      beginObservedTurn() { throw new Error('unused'); },
       bindHost() { return () => {}; },
     };
     const driver = {
@@ -8340,7 +8340,7 @@ async function runFatalExitProbe(
     const terminal = new ReportingTerminal();
     const goalLifecycle = {
       activities: {},
-      beginExternalTurn() { throw new Error('unused'); },
+      beginObservedTurn() { throw new Error('unused'); },
       bindHost() { return () => {}; },
     };
     const driver = {

--- a/packages/cli/src/__tests__/pi-tui-turn.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-turn.test.ts
@@ -31,7 +31,7 @@ describe('Maka Pi TUI turn', () => {
       },
       lifecycle: {
         activities,
-        beginExternalTurn: (sessionId, turnId) => {
+        beginObservedTurn: (sessionId, turnId) => {
           sequence.push('register');
           assert.equal(sessionId, 'session-1');
           assert.equal(turnId, 'turn-1');
@@ -88,7 +88,7 @@ describe('Maka Pi TUI turn', () => {
       },
       lifecycle: {
         activities,
-        beginExternalTurn: () => ({
+        beginObservedTurn: () => ({
           kind: 'registered',
           settle: async () => {},
         }),
@@ -123,7 +123,7 @@ describe('Maka Pi TUI turn', () => {
       },
       lifecycle: {
         activities,
-        beginExternalTurn: () => {
+        beginObservedTurn: () => {
           registrations++;
           return {
             kind: 'registered',

--- a/packages/cli/src/cli-goal-continuation.ts
+++ b/packages/cli/src/cli-goal-continuation.ts
@@ -5,8 +5,8 @@ import {
   drainGoalTurn,
   type GoalContinuationDeps,
   type GoalState,
-  type GoalExternalTurnStart,
-  type GoalExternalTurnSettler,
+  type GoalObservedTurnStart,
+  type GoalObservedTurnSettler,
   type GoalTurnAdmission,
   type GoalTurnOutcome,
 } from '@maka/runtime';
@@ -47,8 +47,8 @@ export class CliGoalContinuation {
     };
   }
 
-  beginExternalTurn(sessionId: string, turnId: string): GoalExternalTurnStart {
-    return this.coordinator.beginExternalTurn(sessionId, turnId);
+  beginObservedTurn(sessionId: string, turnId: string): GoalObservedTurnStart {
+    return this.coordinator.beginObservedTurn(sessionId, turnId);
   }
 
   activateGoal(
@@ -77,12 +77,12 @@ export class CliGoalContinuation {
         reason: 'CLI Goal continuation is disposed.',
       };
     }
-    const registration = this.beginExternalTurn(input.sessionId, input.turnId);
+    const registration = this.beginObservedTurn(input.sessionId, input.turnId);
     if (registration.kind !== 'registered') {
       activity.release();
       return { kind: 'errored', turnId: input.turnId, reason: registration.reason };
     }
-    const settleExternalTurn: GoalExternalTurnSettler = registration.settle;
+    const settleExternalTurn: GoalObservedTurnSettler = registration.settle;
     let events: AsyncIterable<SessionEvent>;
     try {
       events = input.start();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -319,7 +319,7 @@ async function runFirstRunOnboarding(workspaceRoot: string): Promise<boolean> {
     firstRun: true,
     goalLifecycle: {
       activities: new SessionActivityRegistry(),
-      beginExternalTurn: () => ({ kind: 'registered', settle: async () => {} }),
+      beginObservedTurn: () => ({ kind: 'registered', settle: async () => {} }),
       bindHost: () => () => {},
     } satisfies MakaPiTuiGoalLifecycle,
     onboarding: createApiKeyOnboardingSurface({

--- a/packages/cli/src/pi-tui-turn.ts
+++ b/packages/cli/src/pi-tui-turn.ts
@@ -2,8 +2,8 @@ import type { SessionEvent } from '@maka/core';
 import type { TurnOrchestration } from '@maka/core/runtime-inputs';
 import {
   drainGoalTurn,
-  type GoalExternalTurnStart,
-  type GoalExternalTurnSettler,
+  type GoalObservedTurnStart,
+  type GoalObservedTurnSettler,
   type GoalTurnOutcome,
   type SessionActivityLease,
   type SessionActivityRegistry,
@@ -12,7 +12,7 @@ import type { MakaSessionDriver } from './session-driver.js';
 
 export interface MakaPiTuiTurnLifecycle {
   activities: SessionActivityRegistry;
-  beginExternalTurn: (sessionId: string, turnId: string) => GoalExternalTurnStart;
+  beginObservedTurn: (sessionId: string, turnId: string) => GoalObservedTurnStart;
 }
 
 export type MakaPiTuiTurnRequest =
@@ -52,7 +52,7 @@ export async function runMakaPiTuiTurn(input: RunMakaPiTuiTurnInput): Promise<Go
   const { request } = input;
   let activity = request.kind === 'coordinator' ? request.activity : undefined;
   let preparedTurnId = request.kind === 'coordinator' ? request.turnId : undefined;
-  let settleExternalTurn: GoalExternalTurnSettler | undefined;
+  let settleExternalTurn: GoalObservedTurnSettler | undefined;
 
   const notifySettlement = (outcome: GoalTurnOutcome): void => {
     if (!settleExternalTurn) return;
@@ -96,7 +96,7 @@ export async function runMakaPiTuiTurn(input: RunMakaPiTuiTurnInput): Promise<Go
     }
 
     if (request.kind === 'external') {
-      const registration = input.lifecycle.beginExternalTurn(turn.sessionId, turn.turnId);
+      const registration = input.lifecycle.beginObservedTurn(turn.sessionId, turn.turnId);
       if (registration.kind !== 'registered') {
         throw new Error(registration.reason);
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "./tool-recovery-fact": "./dist/tool-recovery-fact.js",
     "./tool-recovery-bundle": "./dist/tool-recovery-bundle.js",
     "./runtime-policy": "./dist/runtime-policy.js",
+    "./goal": "./dist/goal.js",
     "./execution-evidence": "./dist/execution-evidence.js",
     "./events": "./dist/events.js",
     "./interaction": "./dist/interaction.js",

--- a/packages/core/src/__tests__/agent-run-authority.test.ts
+++ b/packages/core/src/__tests__/agent-run-authority.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { decodeAgentRunHeader, type AgentRunHeader } from '../agent-run.js';
+
+test('rejects a Run header with multiple hosted root authorities', () => {
+  assert.throws(
+    () =>
+      decodeAgentRunHeader({
+        ...runHeader(),
+        automationId: 'automation-1',
+        goalId: 'goal-1',
+      }),
+    /Invalid AgentRun header schema/,
+  );
+});
+
+function runHeader(): AgentRunHeader {
+  return {
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    status: 'created',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/workspace',
+    permissionMode: 'ask',
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/packages/core/src/__tests__/model-call-attempt.test.ts
+++ b/packages/core/src/__tests__/model-call-attempt.test.ts
@@ -49,6 +49,13 @@ describe('ModelCallAttempt codec', () => {
     assert.equal(decoded.costUsd, 0.004);
   });
 
+  test('accepts Goal evaluator attribution', () => {
+    assert.equal(
+      decodeModelCallAttempt(attempt({ callKind: 'goal_evaluation' })).callKind,
+      'goal_evaluation',
+    );
+  });
+
   test('accepts an unpriced attempt that carries usage but no cost', () => {
     const decoded = decodeModelCallAttempt(attempt({ costBasis: 'unpriced', costUsd: undefined }));
     assert.equal(decoded.costBasis, 'unpriced');

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -148,6 +148,37 @@ export interface AgentRunHeader {
   traceWriteError?: string;
 }
 
+type HostedRootExecutionDescriptor = Extract<
+  RootExecutionDescriptor,
+  { kind: 'automation' | 'goal' }
+>;
+
+export function agentRunMatchesHostedRootExecution(
+  run: AgentRunHeader,
+  execution: HostedRootExecutionDescriptor,
+): boolean {
+  const authorityMatches =
+    execution.kind === 'automation'
+      ? run.automationId === execution.automationId && run.goalId === undefined
+      : run.goalId === execution.goalId && run.automationId === undefined;
+  return (
+    authorityMatches &&
+    run.parentRunId === undefined &&
+    run.resumedFromRunId === undefined &&
+    run.retriedFromRunId === undefined &&
+    run.agentId === undefined &&
+    run.agentName === undefined &&
+    run.parentTurnId === undefined &&
+    run.retriedFromTurnId === undefined &&
+    run.regeneratedFromTurnId === undefined &&
+    run.branchOfTurnId === undefined &&
+    run.parentSessionId === undefined &&
+    run.continuationSource === undefined &&
+    run.agentGraphWakeId === undefined &&
+    run.agentGraphWakeAttemptId === undefined
+  );
+}
+
 export interface AgentRunInputSummary {
   textLength: number;
   attachmentCount: number;
@@ -293,6 +324,7 @@ export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
       isEffectiveOrchestrationSource(value.orchestrationSource)) &&
     (value.agentSwarmAuthorization === undefined ||
       isAgentSwarmAuthorizationSource(value.agentSwarmAuthorization)) &&
+    !(value.automationId !== undefined && value.goalId !== undefined) &&
     isFiniteNumber(value.createdAt) &&
     isFiniteNumber(value.updatedAt) &&
     isOptionalString(value.invocationId) &&

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -51,6 +51,7 @@ export type AgentRunContinuationSource =
 export type RootExecutionDescriptor =
   | { kind: 'external_message' }
   | { kind: 'automation'; automationId: string }
+  | { kind: 'goal'; goalId: string }
   | {
       kind: 'linked_child_initial';
       agentId: string;
@@ -135,6 +136,8 @@ export interface AgentRunHeader {
   continuationSource?: AgentRunContinuationSource;
   /** Non-user trigger for this run (e.g. a scheduled automation fire). */
   automationId?: string;
+  /** Host-owned Goal generation that triggered this continuation Run. */
+  goalId?: string;
   /** Durable graph milestone that caused this host-authored supervisor turn. */
   agentGraphWakeId?: string;
   /** Durable delivery attempt for this host-authored supervisor turn. */
@@ -249,6 +252,7 @@ const AGENT_RUN_HEADER_SHAPE = defineObjectShape<AgentRunHeader>()(
     'workspaceIdentity',
     'continuationSource',
     'automationId',
+    'goalId',
     'agentGraphWakeId',
     'agentGraphWakeAttemptId',
     'failureClass',
@@ -306,6 +310,7 @@ export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
       value.parentSessionId,
       value.workspaceIdentity,
       value.automationId,
+      value.goalId,
       value.agentGraphWakeId,
       value.agentGraphWakeAttemptId,
       value.failureClass,

--- a/packages/core/src/goal.ts
+++ b/packages/core/src/goal.ts
@@ -1,0 +1,34 @@
+export const GOAL_STATUSES = [
+  'active',
+  'waiting',
+  'achieved',
+  'impossible',
+  'cleared',
+  'paused',
+  'stalled',
+  'budget_limited',
+  'max_iterations',
+] as const;
+
+export type GoalStatus = (typeof GOAL_STATUSES)[number];
+
+export function isGoalStatus(value: unknown): value is GoalStatus {
+  return typeof value === 'string' && (GOAL_STATUSES as readonly string[]).includes(value);
+}
+
+export interface GoalTextLimit {
+  readonly codeUnits: number;
+  readonly utf8Bytes: number;
+}
+
+/** Shared boundary for a Goal condition in model tools and Host projections. */
+export const GOAL_CONDITION_TEXT_LIMIT: GoalTextLimit = Object.freeze({
+  codeUnits: 500,
+  utf8Bytes: 1_500,
+});
+
+/** Shared boundary for evaluator and lifecycle diagnostics. */
+export const GOAL_REASON_TEXT_LIMIT: GoalTextLimit = Object.freeze({
+  codeUnits: 500,
+  utf8Bytes: 1_500,
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export * from './agent-graph-client-projection.js';
 export * from './agent-graph-supervisor-wake.js';
 export * from './agent-graph-timeline.js';
 export * from './runtime-policy.js';
+export * from './goal.js';
 export * from './interaction.js';
 export * from './project.js';
 export * from './subagent-workspace.js';

--- a/packages/core/src/model-call-attempt.ts
+++ b/packages/core/src/model-call-attempt.ts
@@ -6,7 +6,9 @@ import {
   isOptionalString,
   isRecord,
 } from './record-schema.js';
-import type { PricingConfig } from './usage-stats/types.js';
+import { MODEL_CALL_KINDS, type ModelCallKind, type PricingConfig } from './usage-stats/types.js';
+
+export { MODEL_CALL_KINDS, type ModelCallKind } from './usage-stats/types.js';
 
 /**
  * Canonical accounting record for one physical provider request attempt.
@@ -29,9 +31,6 @@ export const MODEL_CALL_ATTEMPT_SCHEMA_VERSION = 1 as const;
 
 /** AgentRun event type carrying a {@link ModelCallAttempt} in `data`. */
 export const MODEL_CALL_ATTEMPT_EVENT_TYPE = 'model_call_attempt_recorded' as const;
-
-export const MODEL_CALL_KINDS = ['main', 'semantic_compact', 'history_compact'] as const;
-export type ModelCallKind = (typeof MODEL_CALL_KINDS)[number];
 
 export const MODEL_CALL_ATTEMPT_STATUSES = [
   'completed',

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -669,6 +669,9 @@ function isTurnOrigin(value: unknown): value is TurnOrigin {
   if (value.kind === 'automation') {
     return Object.keys(value).length === 2 && typeof value.automationId === 'string';
   }
+  if (value.kind === 'goal') {
+    return Object.keys(value).length === 2 && typeof value.goalId === 'string';
+  }
   return (
     value.kind === 'agent_graph' &&
     Object.keys(value).length === 4 &&

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -102,6 +102,7 @@ export interface UserMessageInput extends MessageContent {
 /** Non-user trigger source for a turn. */
 export type TurnOrigin =
   | { kind: 'automation'; automationId: string }
+  | { kind: 'goal'; goalId: string }
   | {
       kind: 'agent_graph';
       graphId: string;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -629,6 +629,7 @@ export interface UserMessage extends MessageContent {
    * hand-type. Mirrors TurnOrigin in runtime-inputs. */
   origin?:
     | { kind: 'automation'; automationId: string }
+    | { kind: 'goal'; goalId: string }
     | { kind: 'agent_graph'; graphId: string; wakeId: string; attemptId: string };
 }
 
@@ -885,8 +886,10 @@ const ASSISTANT_THINKING_SHAPE = defineObjectShape<AssistantThinking>()(
 );
 type MessageOrigin = NonNullable<UserMessage['origin']>;
 type AutomationOrigin = Extract<MessageOrigin, { kind: 'automation' }>;
+type GoalOrigin = Extract<MessageOrigin, { kind: 'goal' }>;
 type AgentGraphOrigin = Extract<MessageOrigin, { kind: 'agent_graph' }>;
 const AUTOMATION_ORIGIN_SHAPE = defineObjectShape<AutomationOrigin>()(['kind', 'automationId'], []);
+const GOAL_ORIGIN_SHAPE = defineObjectShape<GoalOrigin>()(['kind', 'goalId'], []);
 const AGENT_GRAPH_ORIGIN_SHAPE = defineObjectShape<AgentGraphOrigin>()(
   ['kind', 'graphId', 'wakeId', 'attemptId'],
   [],
@@ -1078,6 +1081,15 @@ function isAutomationOrigin(value: unknown): value is AutomationOrigin {
   );
 }
 
+function isGoalOrigin(value: unknown): value is GoalOrigin {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, GOAL_ORIGIN_SHAPE) &&
+    value.kind === 'goal' &&
+    typeof value.goalId === 'string'
+  );
+}
+
 function isAgentGraphOrigin(value: unknown): value is AgentGraphOrigin {
   return (
     isRecord(value) &&
@@ -1090,7 +1102,7 @@ function isAgentGraphOrigin(value: unknown): value is AgentGraphOrigin {
 }
 
 function isMessageOrigin(value: unknown): value is MessageOrigin {
-  return isAutomationOrigin(value) || isAgentGraphOrigin(value);
+  return isAutomationOrigin(value) || isGoalOrigin(value) || isAgentGraphOrigin(value);
 }
 
 function isOptionalFiniteDuration(value: unknown): boolean {

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -1,3 +1,11 @@
+export const MODEL_CALL_KINDS = [
+  'main',
+  'semantic_compact',
+  'history_compact',
+  'goal_evaluation',
+] as const;
+export type ModelCallKind = (typeof MODEL_CALL_KINDS)[number];
+
 export type TimeRange = '24h' | '7d' | '30d' | 'all' | { from: number; to: number };
 
 export type UsageGroupBy = 'provider' | 'model' | 'tool' | 'day' | 'hour';
@@ -49,7 +57,7 @@ export interface UsageBucket {
 export interface UsageLogRow {
   id: string;
   ts: number;
-  callKind?: 'main' | 'semantic_compact' | 'history_compact';
+  callKind?: ModelCallKind;
   callId?: string;
   connectionSlug?: string;
   providerId: string;
@@ -94,7 +102,7 @@ export interface LlmCallRecord {
    * Distinguishes the main agent stream from auxiliary model calls such as
    * semantic or history compaction. Omitted means the historical main stream call.
    */
-  callKind?: 'main' | 'semantic_compact' | 'history_compact';
+  callKind?: ModelCallKind;
   /** Stable id for auxiliary calls so multiple records in one turn do not collide. */
   callId?: string;
   connectionSlug?: string;

--- a/packages/runtime-host/src/__tests__/canonical-session-projection.test.ts
+++ b/packages/runtime-host/src/__tests__/canonical-session-projection.test.ts
@@ -18,6 +18,7 @@ import {
   createSessionContinuitySnapshot,
 } from '../server/canonical-session-projection.js';
 import { type HostMessageRootPort, HostMessageCoordinator } from '../server/message-coordinator.js';
+import { worstCaseGoalProjection } from '../server/goal-projection.js';
 import { RootAdmissionOwner } from '../server/root-admission-owner.js';
 import { SessionAdmissionGate } from '../server/session-admission-gate.js';
 
@@ -43,6 +44,7 @@ test('projects the canonical root lifecycle and the attachment queue from real S
         isArchived: false,
       },
       rootTurn: null,
+      goal: null,
       queue: { hostEpoch: 'epoch-1', queueRevision: 0, steering: [], followup: [] },
       interactions: { pending: [] },
     });
@@ -210,22 +212,29 @@ test('preflights queued steering at the exact in-flight snapshot boundary', asyn
     });
     const canonical = await reader.read(session.id);
     assert.ok(canonical);
+    const capacityCanonical = {
+      ...canonical,
+      goal: worstCaseGoalProjection(session.id),
+    };
 
-    const inFlightBoundary = largestFittingInFlightSteeringText(canonical);
+    const inFlightBoundary = largestFittingInFlightSteeringText(capacityCanonical);
     const rejectedQueued = {
       ...steeringQueue(inFlightBoundary + 1, 'queued'),
       queueRevision: 1,
     };
     assert.deepEqual(
       createSessionContinuitySnapshot(
-        { ...canonical, queue: rejectedQueued },
+        { ...capacityCanonical, queue: rejectedQueued },
         Number.MAX_SAFE_INTEGER,
       ).queue,
       rejectedQueued,
     );
     assert.throws(() =>
       createSessionContinuitySnapshot(
-        { ...canonical, queue: steeringQueue(inFlightBoundary + 1, 'in_flight') },
+        {
+          ...capacityCanonical,
+          queue: steeringQueue(inFlightBoundary + 1, 'in_flight'),
+        },
         Number.MAX_SAFE_INTEGER,
       ),
     );
@@ -247,7 +256,7 @@ test('preflights queued steering at the exact in-flight snapshot boundary', asyn
     const allowedInFlight = steeringQueue(inFlightBoundary, 'in_flight');
     assert.deepEqual(
       createSessionContinuitySnapshot(
-        { ...canonical, queue: allowedInFlight },
+        { ...capacityCanonical, queue: allowedInFlight },
         Number.MAX_SAFE_INTEGER,
       ).queue,
       allowedInFlight,

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -960,6 +960,7 @@ function canonicalProjection(sessionId: string): CanonicalSessionProjection {
       runId: `run-${sessionId}`,
       status: 'running',
     },
+    goal: null,
     queue: {
       hostEpoch: 'host-epoch',
       queueRevision: 0,

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -66,6 +66,7 @@ const allowedExternalImports = {
     '@maka/core/automation',
     '@maka/core/collaboration',
     '@maka/core/events',
+    '@maka/core/goal',
     '@maka/core/interaction',
     '@maka/core/local-memory',
     '@maka/core/model-thinking',

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -9,6 +9,7 @@ import {
   createBypassExecutionBoundary,
   createManagedExecutionBoundary,
   createWorkspaceWritePermissionProfile,
+  type ModelCallKind,
   type RuntimeEvent,
 } from '@maka/core';
 import { createDefaultRuntimePolicy } from '@maka/core/runtime-policy';
@@ -34,12 +35,14 @@ import {
 } from '@maka/storage/runtime-policy-stores';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-authority';
+import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
 import type { TurnSnapshot, UsageQueryResult } from '../protocol/index.js';
 import type { ClientCapabilityHostFrame } from '../protocol/index.js';
 import { createExecutionRuntimeHostComposition } from '../server/execution-composition.js';
 import {
   createHostAiSdkBackend,
   createHostExecutionModelComposition,
+  createHostGoalEvaluator,
   type HostAiSdkBackendInput,
 } from '../server/execution-model-composition.js';
 import { HostClientCapabilityCoordinator } from '../server/client-capability-coordinator.js';
@@ -657,6 +660,11 @@ test('production Host executes a canonical ai-sdk Session against a real provide
       'Edit',
       'FormatJson',
       'Glob',
+      'GoalClear',
+      'GoalPause',
+      'GoalResume',
+      'GoalSet',
+      'GoalStatus',
       'Grep',
       'Read',
       'Skill',
@@ -749,6 +757,123 @@ test('production Host executes a canonical ai-sdk Session against a real provide
         await rm(base, { recursive: true, force: true });
       }
     }
+  }
+});
+
+test('Host Goal evaluator meters provider usage and aborts its physical request', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-goal-evaluator-'));
+  const provider = await startProvider();
+  const capability = await resolveStorageRoot({
+    path: join(base, 'interactive'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+
+  const policy = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+  const usage = await openInteractiveUsageStoresForWrite(owner.lease);
+  const execution = await openInteractiveExecutionStoresForWrite(owner.lease);
+  try {
+    const created = await policy.connectionCatalog.create({
+      expectedCatalogRevision: 0,
+      connection: {
+        slug: 'goal-evaluator-provider',
+        name: 'Goal evaluator provider',
+        providerType: 'moonshot',
+        baseUrl: provider.baseUrl,
+        enabled: true,
+        enabledModelIds: [MODEL_ID],
+      },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed') return;
+    const connection = created.snapshot.connections[0];
+    assert.ok(connection);
+    if (!connection) return;
+    const credential = await policy.credentialVault.set({
+      locator: {
+        scope: 'connection',
+        connectionId: connection.connectionId,
+        kind: 'api_key',
+      },
+      expected: null,
+      secret: API_KEY,
+    });
+    assert.equal(credential.kind, 'committed');
+    await publishConnectionModel(policy, connection.connectionId, MODEL_ID);
+    const session = await execution.sessionStore.create({
+      cwd: capability.canonicalPath,
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'goal-evaluator-provider',
+      model: MODEL_ID,
+      permissionMode: 'ask',
+    });
+    const evaluatorInput = {
+      runtimePolicy: policy,
+      oauthCredentials: new HostOAuthExecutionAuthority(policy),
+      claudeDeviceId: capability.rootId,
+      usage,
+      requestDrain: () => assert.fail('Goal evaluator telemetry must not drain the Host'),
+      readSessionHeader: (sessionId: string) =>
+        execution.sessionStore.readHeaderSnapshot(sessionId),
+      newId: () => 'call-1',
+    };
+    const evaluator = createHostGoalEvaluator(evaluatorInput);
+    const result = await evaluator.evaluate(
+      'Judge the completed Goal.',
+      session.id,
+      new AbortController().signal,
+    );
+    assert.equal(result, SUMMARY_TEXT);
+    const logs = await usage.telemetry.logs({ range: 'all' });
+    const recorded = logs.rows.find((row) => row.callKind === 'goal_evaluation');
+    assert.ok(recorded);
+    assert.equal(recorded.callId, `goal_evaluation_${session.id}_call-1`);
+    assert.equal(recorded.inputTokens, 7);
+    assert.equal(recorded.outputTokens, 3);
+    assert.equal(recorded.status, 'success');
+
+    let providerSignal: AbortSignal | undefined;
+    let transportCloses = 0;
+    const stalled = createHostGoalEvaluator({
+      ...evaluatorInput,
+      newId: () => 'call-2',
+      createFetchTransport: () => ({
+        fetch: async (_request, init) => {
+          providerSignal = init?.signal ?? undefined;
+          return await new Promise<Response>((_resolve, reject) => {
+            providerSignal?.addEventListener(
+              'abort',
+              () => reject(providerSignal?.reason ?? new DOMException('Aborted', 'AbortError')),
+              { once: true },
+            );
+          });
+        },
+        close: async () => {
+          transportCloses += 1;
+        },
+      }),
+    });
+    const abort = new AbortController();
+    const pending = stalled.evaluate('Wait forever.', session.id, abort.signal);
+    await waitForCondition(() => providerSignal !== undefined, 'Goal evaluator did not dispatch');
+    abort.abort(new DOMException('Goal lane invalidated', 'AbortError'));
+    await assert.rejects(settleWithin(pending));
+    assert.equal(providerSignal?.aborted, true);
+    assert.equal(transportCloses, 1);
+    const abortedLogs = await usage.telemetry.logs({ range: 'all' });
+    assert.ok(
+      abortedLogs.rows.some(
+        (row) => row.callId === `goal_evaluation_${session.id}_call-2` && row.status === 'aborted',
+      ),
+    );
+  } finally {
+    await usage.close();
+    await execution.sessionStore.close?.();
+    await owner.close();
+    await provider.close();
+    await rm(base, { recursive: true, force: true });
   }
 });
 
@@ -1053,7 +1178,7 @@ async function waitForUsage(
   composition: Awaited<ReturnType<typeof createExecutionRuntimeHostComposition>>,
   context: ConnectionContext,
   connectionSlug: string,
-  callKind: 'main' | 'semantic_compact' | 'history_compact',
+  callKind: ModelCallKind,
 ): Promise<Extract<UsageQueryResult, { kind: 'logs'; source: 'llm' }>['rows'][number]> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const queried = await composition.handlers['usage.query'](
@@ -1244,6 +1369,14 @@ async function settleWithin<T>(pending: Promise<T>): Promise<T> {
   } finally {
     if (timeout) clearTimeout(timeout);
   }
+}
+
+async function waitForCondition(predicate: () => boolean, message: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error(message);
 }
 
 function controlledOAuthTransports(): {

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -760,7 +760,9 @@ test('production Host executes a canonical ai-sdk Session against a real provide
   }
 });
 
-test('Host Goal evaluator meters provider usage and aborts its physical request', async () => {
+test('Host Goal evaluator meters provider usage and aborts its physical request', {
+  timeout: 10_000,
+}, async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-goal-evaluator-'));
   const provider = await startProvider();
   const capability = await resolveStorageRoot({
@@ -833,22 +835,21 @@ test('Host Goal evaluator meters provider usage and aborts its physical request'
     assert.equal(recorded.inputTokens, 7);
     assert.equal(recorded.outputTokens, 3);
     assert.equal(recorded.status, 'success');
+    await evaluator.close();
 
     let providerSignal: AbortSignal | undefined;
     let transportCloses = 0;
+    const providerDispatched = deferred<void>();
+    const providerRelease = deferred<void>();
     const stalled = createHostGoalEvaluator({
       ...evaluatorInput,
       newId: () => 'call-2',
       createFetchTransport: () => ({
         fetch: async (_request, init) => {
           providerSignal = init?.signal ?? undefined;
-          return await new Promise<Response>((_resolve, reject) => {
-            providerSignal?.addEventListener(
-              'abort',
-              () => reject(providerSignal?.reason ?? new DOMException('Aborted', 'AbortError')),
-              { once: true },
-            );
-          });
+          providerDispatched.resolve();
+          await providerRelease.promise;
+          throw providerSignal?.reason ?? new DOMException('Aborted', 'AbortError');
         },
         close: async () => {
           transportCloses += 1;
@@ -857,17 +858,37 @@ test('Host Goal evaluator meters provider usage and aborts its physical request'
     });
     const abort = new AbortController();
     const pending = stalled.evaluate('Wait forever.', session.id, abort.signal);
-    await waitForCondition(() => providerSignal !== undefined, 'Goal evaluator did not dispatch');
-    abort.abort(new DOMException('Goal lane invalidated', 'AbortError'));
-    await assert.rejects(settleWithin(pending));
-    assert.equal(providerSignal?.aborted, true);
-    assert.equal(transportCloses, 1);
-    const abortedLogs = await usage.telemetry.logs({ range: 'all' });
-    assert.ok(
-      abortedLogs.rows.some(
-        (row) => row.callId === `goal_evaluation_${session.id}_call-2` && row.status === 'aborted',
-      ),
-    );
+    try {
+      await settleWithin(providerDispatched.promise);
+      abort.abort(new DOMException('Goal lane invalidated', 'AbortError'));
+      assert.equal(providerSignal?.aborted, true);
+      let closeSettled = false;
+      const closing = stalled.close().then(() => {
+        closeSettled = true;
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(closeSettled, false);
+
+      providerRelease.resolve();
+      await assert.rejects(settleWithin(pending), (error: unknown) => {
+        assert.notEqual(error instanceof Error ? error.message : undefined, SETTLE_TIMEOUT_MESSAGE);
+        return true;
+      });
+      await closing;
+      assert.equal(transportCloses, 1);
+      const abortedLogs = await usage.telemetry.logs({ range: 'all' });
+      assert.ok(
+        abortedLogs.rows.some(
+          (row) =>
+            row.callId === `goal_evaluation_${session.id}_call-2` && row.status === 'aborted',
+        ),
+      );
+    } finally {
+      abort.abort(new DOMException('Goal evaluator test cleanup', 'AbortError'));
+      providerRelease.resolve();
+      await stalled.close();
+      await pending.catch(() => undefined);
+    }
   } finally {
     await usage.close();
     await execution.sessionStore.close?.();
@@ -1359,10 +1380,7 @@ function readyExecutionConnection(baseUrl?: string) {
 async function settleWithin<T>(pending: Promise<T>): Promise<T> {
   let timeout: NodeJS.Timeout | undefined;
   const deadline = new Promise<never>((_resolve, reject) => {
-    timeout = setTimeout(
-      () => reject(new Error('Backend creation did not settle after abort')),
-      250,
-    );
+    timeout = setTimeout(() => reject(new Error(SETTLE_TIMEOUT_MESSAGE)), 5_000);
   });
   try {
     return await Promise.race([pending, deadline]);
@@ -1371,12 +1389,16 @@ async function settleWithin<T>(pending: Promise<T>): Promise<T> {
   }
 }
 
-async function waitForCondition(predicate: () => boolean, message: string): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    if (predicate()) return;
-    await new Promise<void>((resolve) => setImmediate(resolve));
-  }
-  throw new Error(message);
+const SETTLE_TIMEOUT_MESSAGE = 'Operation did not settle within five seconds';
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((next, fail) => {
+    resolve = next;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
 }
 
 function controlledOAuthTransports(): {

--- a/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import type { GoalTurnOutcome } from '@maka/runtime';
+import { HostGoalCoordinator } from '../server/goal-coordinator.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+
+test('one Host Goal is shared across clients with CAS control and crash-clear residency', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-goal-'));
+  const capability = await resolveStorageRoot({ path: join(base, 'root'), kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+
+  try {
+    const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const session = await stores.sessionStore.create({
+      cwd: capability.canonicalPath,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    let acquired = 0;
+    let released = 0;
+    let admittedText: string | undefined;
+    let settleGoalTurn!: (outcome: GoalTurnOutcome) => void;
+    const goalTurn = new Promise<GoalTurnOutcome>((resolve) => {
+      settleGoalTurn = resolve;
+    });
+    const coordinator = new HostGoalCoordinator({
+      stores,
+      sessionAdmission: new SessionAdmissionGate(),
+      evaluator: {
+        evaluate: async () =>
+          '{"met":false,"impossible":false,"progress":true,"waiting":false,"reason":"continue"}',
+      },
+      admitTurn: (_sessionId, text) => {
+        admittedText = text;
+        return { kind: 'prepared', turnId: 'goal-turn-1', start: () => goalTurn };
+      },
+      listActionableTaskKeys: async () => [],
+      acquireResidency: () => {
+        acquired++;
+        return { release: () => released++ };
+      },
+      onProjectionChanged: () => {},
+      newId: () => 'goal-1',
+      now: () => 10,
+    });
+
+    const external = coordinator.beginExternalTurn(session.id, 'turn-1');
+    assert.equal(external.kind, 'registered');
+    if (external.kind !== 'registered') return;
+    const created = coordinator.continuation.activateGoal(
+      session.id,
+      'turn-1',
+      () => coordinator.manager.create(session.id, 'Finish the whole slice').goal,
+    );
+    assert.equal(created?.status, 'active');
+    assert.equal(acquired, 1);
+
+    const firstClient = await coordinator.handlers['goal.query'](
+      { sessionId: session.id },
+      operationContext('connection-1'),
+    );
+    const secondClient = await coordinator.handlers['goal.query'](
+      { sessionId: session.id },
+      operationContext('connection-2'),
+    );
+    assert.deepEqual(firstClient, secondClient);
+    assert.equal(firstClient.ok && firstClient.result.goal?.goalId, 'goal-1');
+
+    const paused = await coordinator.handlers['goal.control'](
+      {
+        sessionId: session.id,
+        goalId: 'goal-1',
+        expectedRevision: 0,
+        action: 'pause',
+      },
+      operationContext('connection-1'),
+    );
+    assert.equal(paused.ok && paused.result.goal.status, 'paused');
+    assert.equal(released, 0, 'paused Goal must retain Host residency');
+
+    const staleResume = await coordinator.handlers['goal.control'](
+      {
+        sessionId: session.id,
+        goalId: 'goal-1',
+        expectedRevision: 0,
+        action: 'resume',
+      },
+      operationContext('connection-2'),
+    );
+    assert.equal(staleResume.ok, false);
+    if (!staleResume.ok) assert.equal(staleResume.error.code, 'operation_conflict');
+
+    const resumed = await coordinator.handlers['goal.control'](
+      {
+        sessionId: session.id,
+        goalId: 'goal-1',
+        expectedRevision: 1,
+        action: 'resume',
+      },
+      operationContext('connection-2'),
+    );
+    assert.equal(resumed.ok && resumed.result.goal.status, 'active');
+    await waitFor(() => admittedText !== undefined);
+    assert.match(admittedText ?? '', /Goal resumed by a connected client/);
+
+    const cleared = await coordinator.handlers['goal.control'](
+      {
+        sessionId: session.id,
+        goalId: 'goal-1',
+        expectedRevision: 2,
+        action: 'clear',
+      },
+      operationContext('connection-1'),
+    );
+    assert.equal(cleared.ok && cleared.result.goal.status, 'cleared');
+    assert.equal(released, 1);
+    settleGoalTurn({ kind: 'completed', turnId: 'goal-turn-1' });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(coordinator.manager.get(session.id)?.status, 'cleared');
+
+    coordinator.manager.create(session.id, 'A second Host-epoch Goal');
+    assert.equal(acquired, 2);
+    coordinator.beginDrain();
+    assert.equal(released, 2);
+    assert.equal(coordinator.readProjection(session.id), null);
+    coordinator.close();
+    assert.equal(released, 2, 'close must not release Goal residency twice');
+  } finally {
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+function operationContext(connectionId: string) {
+  return {
+    hostEpoch: 'epoch-1',
+    connectionId,
+    surface: 'tui' as const,
+    principal: 'local_os_user' as const,
+    acquireResidency: () => ({ release() {} }),
+  };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for Goal continuation');
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}

--- a/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
@@ -54,7 +54,7 @@ test('one Host Goal is shared across clients with CAS control and crash-clear re
       now: () => 10,
     });
 
-    const external = coordinator.beginExternalTurn(session.id, 'turn-1');
+    const external = coordinator.beginObservedTurn(session.id, 'turn-1');
     assert.equal(external.kind, 'registered');
     if (external.kind !== 'registered') return;
     const created = coordinator.continuation.activateGoal(

--- a/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
@@ -38,6 +38,7 @@ test('one Host Goal is shared across clients with CAS control and crash-clear re
       evaluator: {
         evaluate: async () =>
           '{"met":false,"impossible":false,"progress":true,"waiting":false,"reason":"continue"}',
+        close: async () => {},
       },
       admitTurn: (_sessionId, text) => {
         admittedText = text;
@@ -132,7 +133,7 @@ test('one Host Goal is shared across clients with CAS control and crash-clear re
     coordinator.beginDrain();
     assert.equal(released, 2);
     assert.equal(coordinator.readProjection(session.id), null);
-    coordinator.close();
+    await coordinator.close();
     assert.equal(released, 2, 'close must not release Goal residency twice');
   } finally {
     await owner.close();

--- a/packages/runtime-host/src/__tests__/goal-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-protocol.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  decodeGoalProjection,
+  decodeRequestFrame,
+  decodeResponseFrame,
+  decodeSessionContinuitySnapshot,
+  HOST_OPERATION_SPECS,
+  SESSION_CONTINUITY_SCHEMA_VERSION,
+} from '../protocol/index.js';
+
+const goal = {
+  goalId: 'goal-1',
+  revision: 3,
+  sessionId: 'session-1',
+  condition: 'Ship the complete slice',
+  status: 'paused' as const,
+  setAt: 1,
+  iterations: 2,
+  maxIterations: 50,
+  consecutiveNoProgress: 0,
+  blockCap: 8,
+  tokenBudget: 10_000,
+  tokensSpent: 500,
+  lastReason: 'Waiting for an exact resume',
+  achievedAt: null,
+  pausedAt: 2,
+};
+
+test('Goal query and exact-revision control frames round-trip', () => {
+  assert.deepEqual(
+    decodeRequestFrame({
+      requestId: 'request-query',
+      operation: 'goal.query',
+      input: { sessionId: 'session-1' },
+    }),
+    {
+      requestId: 'request-query',
+      operation: 'goal.query',
+      input: { sessionId: 'session-1' },
+    },
+  );
+  assert.deepEqual(
+    decodeRequestFrame({
+      requestId: 'request-control',
+      operation: 'goal.control',
+      input: {
+        sessionId: 'session-1',
+        goalId: 'goal-1',
+        expectedRevision: 3,
+        action: 'resume',
+      },
+    }),
+    {
+      requestId: 'request-control',
+      operation: 'goal.control',
+      input: {
+        sessionId: 'session-1',
+        goalId: 'goal-1',
+        expectedRevision: 3,
+        action: 'resume',
+      },
+    },
+  );
+  assert.deepEqual(
+    decodeResponseFrame({
+      requestId: 'request-control',
+      operation: 'goal.control',
+      ok: true,
+      result: { sessionId: 'session-1', goal },
+    }),
+    {
+      requestId: 'request-control',
+      operation: 'goal.control',
+      ok: true,
+      result: { sessionId: 'session-1', goal },
+    },
+  );
+  assert.throws(() =>
+    HOST_OPERATION_SPECS['goal.control'].assertOutputForInput?.(
+      {
+        sessionId: 'session-1',
+        goalId: 'another-goal',
+        expectedRevision: 3,
+        action: 'resume',
+      },
+      { sessionId: 'session-1', goal },
+    ),
+  );
+});
+
+test('Goal projection is part of the exact Session continuity schema', () => {
+  const snapshot = decodeSessionContinuitySnapshot({
+    schemaVersion: SESSION_CONTINUITY_SCHEMA_VERSION,
+    session: {
+      sessionId: 'session-1',
+      metadataRevision: 1,
+      status: 'running',
+      createdAt: 1,
+      lastUsedAt: 2,
+      isArchived: false,
+    },
+    projectionRevision: 1,
+    rootTurn: null,
+    goal,
+    queue: { hostEpoch: 'epoch-1', queueRevision: 0, steering: [], followup: [] },
+    interactions: { pending: [] },
+  });
+  assert.deepEqual(snapshot.goal, goal);
+  assert.throws(() =>
+    decodeSessionContinuitySnapshot({
+      ...snapshot,
+      goal: { ...goal, sessionId: 'session-2' },
+    }),
+  );
+});
+
+test('Goal projection rejects unknown fields and text beyond the shared UTF-8 boundary', () => {
+  assert.throws(() => decodeGoalProjection({ ...goal, extra: true }));
+  assert.throws(() => decodeGoalProjection({ ...goal, condition: '界'.repeat(501) }));
+  assert.throws(() => decodeGoalProjection({ ...goal, lastReason: '界'.repeat(501) }));
+});

--- a/packages/runtime-host/src/__tests__/goal-root-authority.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-root-authority.test.ts
@@ -4,9 +4,11 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import type { AgentRunHeader } from '@maka/core';
 import {
   BackendRegistry,
   FakeBackend,
+  GOAL_SET_TOOL_NAME,
   goalCheckpoint,
   SessionManager,
   type RuntimeHostedRootAuthority,
@@ -155,6 +157,201 @@ test('queued Goal control revokes a prepared root before durable admission', asy
   }
 });
 
+test('Goal continuation cannot overtake a pending Automation admission', async () => {
+  const fixture = await createFixture();
+  const admissionEntered = deferred();
+  const releaseAdmission = deferred();
+  try {
+    const automationTurnId = randomUUID();
+    const automationRunId = randomUUID();
+    const automationId = 'automation-reservation';
+    const automation = fixture.coordinator.executeRoot({
+      sessionId: fixture.sessionId,
+      turnId: automationTurnId,
+      runId: automationRunId,
+      userMessageId: randomUUID(),
+      execution: { kind: 'automation', automationId },
+      content: { text: 'Hold the shared root reservation.' },
+      admitExecution: async () => {
+        admissionEntered.resolve();
+        await releaseAdmission.promise;
+        return 'executing';
+      },
+      start: ({ runId, userMessageId, onRunStarted }) =>
+        fixture.manager.sendMessage(
+          fixture.sessionId,
+          {
+            turnId: automationTurnId,
+            text: 'Hold the shared root reservation.',
+            origin: { kind: 'automation', automationId },
+          },
+          {
+            runId,
+            userMessageId: userMessageId ?? undefined,
+            durability: 'required',
+            onRunStarted,
+          },
+        ),
+    });
+    await admissionEntered.promise;
+
+    const overtakingGoal = fixture.coordinator.admitGoalTurn(
+      fixture.sessionId,
+      { goalId: 'goal-pending', revision: 1 },
+      { goalId: 'goal-pending' },
+      'Do not overtake the Automation admission.',
+    );
+    assert.equal(overtakingGoal.kind, 'busy');
+    assert.deepEqual(fixture.coordinator.readRootState(fixture.sessionId), { kind: 'reserved' });
+
+    releaseAdmission.resolve();
+    await automation;
+    if (overtakingGoal.kind === 'busy') await overtakingGoal.whenIdle;
+
+    const goal = fixture.goal.manager.create(fixture.sessionId, 'Run after Automation').goal;
+    const controlLease = fixture.goal.manager.getControlLease(fixture.sessionId);
+    assert.ok(controlLease);
+    if (!controlLease) return;
+    const goalAdmission = fixture.coordinator.admitGoalTurn(
+      fixture.sessionId,
+      goalCheckpoint(goal),
+      controlLease,
+      'Continue after Automation.',
+    );
+    assert.equal(goalAdmission.kind, 'prepared');
+    if (goalAdmission.kind !== 'prepared') return;
+    assert.deepEqual(await goalAdmission.start(), {
+      kind: 'completed',
+      turnId: goalAdmission.turnId,
+    });
+
+    const durableGoal = await fixture.stores.agentRunStore.readRootTurnAdmission(
+      fixture.sessionId,
+      goalAdmission.turnId,
+    );
+    assert.equal(durableGoal?.previousRootTurnId, automationTurnId);
+    assert.equal(fixture.drainRequested(), false);
+  } finally {
+    releaseAdmission.resolve();
+    await fixture.close();
+  }
+});
+
+test('drain revokes pending Automation before durable root admission', async () => {
+  const fixture = await createFixture();
+  const admissionEntered = deferred();
+  const releaseAdmission = deferred();
+  const turnId = randomUUID();
+  const runId = randomUUID();
+  try {
+    const automation = fixture.coordinator.executeRoot({
+      sessionId: fixture.sessionId,
+      turnId,
+      runId,
+      userMessageId: randomUUID(),
+      execution: { kind: 'automation', automationId: 'draining-automation' },
+      content: { text: 'Do not admit after drain.' },
+      admitExecution: async () => {
+        admissionEntered.resolve();
+        await releaseAdmission.promise;
+        return 'executing';
+      },
+      start: ({ runId: admittedRunId, userMessageId, onRunStarted }) =>
+        fixture.manager.sendMessage(
+          fixture.sessionId,
+          {
+            turnId,
+            text: 'Do not admit after drain.',
+            origin: { kind: 'automation', automationId: 'draining-automation' },
+          },
+          {
+            runId: admittedRunId,
+            userMessageId: userMessageId ?? undefined,
+            durability: 'required',
+            onRunStarted,
+          },
+        ),
+    });
+    await admissionEntered.promise;
+
+    fixture.coordinator.beginDrain();
+    releaseAdmission.resolve();
+
+    await assert.rejects(automation, /lost its pending reservation/);
+    assert.equal(
+      await fixture.stores.agentRunStore.readRootTurnAdmission(fixture.sessionId, turnId),
+      undefined,
+    );
+    assert.equal(
+      (await fixture.stores.agentRunStore.listSessionRuns(fixture.sessionId)).some(
+        (run) => run.runId === runId,
+      ),
+      false,
+    );
+  } finally {
+    releaseAdmission.resolve();
+    await fixture.close();
+  }
+});
+
+test('Automation turns can use Goal tools and contribute evaluation evidence', async () => {
+  const fixture = await createFixture();
+  try {
+    const automationId = 'automation-goal-tool';
+    const turnId = randomUUID();
+    const runId = randomUUID();
+    const goalSet = fixture.goal.tools.find((tool) => tool.name === GOAL_SET_TOOL_NAME);
+    assert.ok(goalSet);
+    if (!goalSet) return;
+
+    await fixture.coordinator.executeRoot({
+      sessionId: fixture.sessionId,
+      turnId,
+      runId,
+      userMessageId: randomUUID(),
+      execution: { kind: 'automation', automationId },
+      content: { text: 'Set and verify a Goal.' },
+      start: ({ runId: admittedRunId, userMessageId, onRunStarted }) => {
+        const result = goalSet.impl(
+          { condition: 'Automation Goal completes' },
+          {
+            sessionId: fixture.sessionId,
+            runId: admittedRunId,
+            turnId,
+            cwd: fixture.base,
+            toolCallId: 'goal-set-from-automation',
+            abortSignal: new AbortController().signal,
+            emitOutput: () => {},
+          },
+        );
+        assert.equal(typeof result, 'string');
+        assert.match(result as string, /Goal set/);
+        return fixture.manager.sendMessage(
+          fixture.sessionId,
+          {
+            turnId,
+            text: 'Set and verify a Goal.',
+            origin: { kind: 'automation', automationId },
+          },
+          {
+            runId: admittedRunId,
+            userMessageId: userMessageId ?? undefined,
+            durability: 'required',
+            onRunStarted,
+          },
+        );
+      },
+    });
+
+    const goal = await waitForGoalStatus(fixture, 'achieved');
+    assert.equal(goal.condition, 'Automation Goal completes');
+    assert.equal(goal.lastReason, 'verified');
+    assert.equal(fixture.drainRequested(), false);
+  } finally {
+    await fixture.close();
+  }
+});
+
 test('Host Goal continuation bridges its exact generation into root authority', async () => {
   const fixture = await createFixture();
   try {
@@ -253,6 +450,42 @@ test('restart rejects an admitted Goal whose existing UserMessage lost its origi
   }
 });
 
+test('restart rejects a Goal Run carrying delegated execution lineage', async () => {
+  const fixture = await createFixture({ recoverAdmissions: false });
+  try {
+    const turnId = randomUUID();
+    const runId = randomUUID();
+    const goalId = 'goal-cross-lineage';
+    await fixture.stores.agentRunStore.admitRootTurn({
+      sessionId: fixture.sessionId,
+      turnId,
+      proposedRunId: runId,
+      proposedUserMessageId: randomUUID(),
+      execution: { kind: 'goal', goalId },
+      previousRootTurnId: null,
+      normalizedInput: { text: 'Reject ambiguous root ownership.' },
+      sourceMessages: [],
+      admittedAt: 1,
+    });
+    await fixture.stores.agentRunStore.createRun(
+      runHeader({
+        sessionId: fixture.sessionId,
+        turnId,
+        runId,
+        goalId,
+        parentRunId: 'foreign-parent-run',
+      }),
+    );
+
+    await assert.rejects(
+      () => fixture.coordinator.prepareRecovery(),
+      /changed its root execution identity/,
+    );
+  } finally {
+    await fixture.close();
+  }
+});
+
 interface Fixture {
   readonly owner: InteractiveRootOwner;
   readonly base: string;
@@ -261,6 +494,7 @@ interface Fixture {
   readonly rootAdmissions: RootAdmissionOwner;
   readonly coordinator: RootTurnCoordinator;
   readonly goal: HostGoalCoordinator;
+  readonly manager: SessionManager;
   readonly messages: HostMessageCoordinator;
   readonly sessionAdmission: SessionAdmissionGate;
   readonly drainRequested: () => boolean;
@@ -411,6 +645,7 @@ async function createFixture(options: { recoverAdmissions?: boolean } = {}): Pro
     rootAdmissions,
     coordinator: rootCoordinator,
     goal: goalCoordinator,
+    manager,
     messages,
     sessionAdmission: admission,
     drainRequested: () => requestedDrain,
@@ -449,6 +684,36 @@ async function waitForGoalRun(
     await new Promise<void>((resolve) => setImmediate(resolve));
   }
   throw new Error('Goal continuation did not reach the root authority');
+}
+
+async function waitForGoalStatus(
+  fixture: Fixture,
+  status: NonNullable<ReturnType<Fixture['goal']['manager']['get']>>['status'],
+) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const goal = fixture.goal.manager.get(fixture.sessionId);
+    if (goal?.status === status) return goal;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error(`Goal did not reach ${status}`);
+}
+
+function runHeader(overrides: Partial<AgentRunHeader>): AgentRunHeader {
+  return {
+    runId: 'run-1',
+    invocationId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    status: 'created',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/workspace',
+    permissionMode: 'ask',
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
 }
 
 function operationContext() {

--- a/packages/runtime-host/src/__tests__/goal-root-authority.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-root-authority.test.ts
@@ -1,0 +1,484 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  BackendRegistry,
+  FakeBackend,
+  goalCheckpoint,
+  SessionManager,
+  type RuntimeHostedRootAuthority,
+} from '@maka/runtime';
+import {
+  openInteractiveExecutionStoresForWrite,
+  type InteractiveExecutionStoresWriter,
+} from '@maka/storage/execution-stores';
+import {
+  resolveStorageRoot,
+  tryAcquireInteractiveRootOwner,
+  type InteractiveRootOwner,
+} from '@maka/storage/root-authority';
+import { HostCanonicalPermissionOutcomeReader } from '../server/canonical-permission-outcome-reader.js';
+import { CanonicalSessionProjectionReader } from '../server/canonical-session-projection.js';
+import type { RuntimeHostResidency } from '../server/host-kernel.js';
+import { HostInteractionCoordinator } from '../server/interaction-coordinator.js';
+import { HostGoalCoordinator } from '../server/goal-coordinator.js';
+import { type HostMessageRootPort, HostMessageCoordinator } from '../server/message-coordinator.js';
+import { RootAdmissionOwner } from '../server/root-admission-owner.js';
+import { RootTurnCoordinator } from '../server/root-turn-coordinator.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+import { SessionContinuityCoordinator } from '../server/session-continuity-coordinator.js';
+
+test('Goal continuation uses the canonical root admission and durable origin', {
+  timeout: 10_000,
+}, async () => {
+  const fixture = await createFixture();
+  try {
+    const created = fixture.goal.manager.create(fixture.sessionId, 'Finish the whole slice').goal;
+    const controlLease = fixture.goal.manager.getControlLease(fixture.sessionId);
+    assert.ok(controlLease);
+    if (!controlLease) return;
+    const admission = fixture.coordinator.admitGoalTurn(
+      fixture.sessionId,
+      goalCheckpoint(created),
+      controlLease,
+      'Continue the Goal',
+    );
+    assert.equal(admission.kind, 'prepared');
+    if (admission.kind !== 'prepared') return;
+    assert.deepEqual(fixture.coordinator.readRootState(fixture.sessionId), { kind: 'reserved' });
+    const competingMessage = await fixture.messages.handlers['turn.message.submit'](
+      {
+        originHostEpoch: 'goal-root-epoch',
+        sessionId: fixture.sessionId,
+        messageId: 'competing-message',
+        content: { text: 'Do not overtake the Goal reservation' },
+        placement: 'current_turn',
+      },
+      operationContext(),
+    );
+    assert.equal(competingMessage.ok, false);
+    if (!competingMessage.ok) assert.equal(competingMessage.error.code, 'session_busy');
+
+    const outcome = await admission.start();
+    assert.deepEqual(outcome, { kind: 'completed', turnId: admission.turnId });
+    assert.deepEqual(fixture.coordinator.readRootState(fixture.sessionId), { kind: 'idle' });
+
+    const durableAdmission = await fixture.stores.agentRunStore.readRootTurnAdmission(
+      fixture.sessionId,
+      admission.turnId,
+    );
+    assert.deepEqual(durableAdmission?.execution, { kind: 'goal', goalId: created.id });
+    assert.ok(durableAdmission);
+    if (!durableAdmission) return;
+    const run = await fixture.stores.agentRunStore.readRun(
+      fixture.sessionId,
+      durableAdmission.runId,
+    );
+    assert.equal(run.goalId, created.id);
+    const user = (await fixture.stores.sessionStore.readMessages(fixture.sessionId)).find(
+      (message) => message.type === 'user' && message.turnId === admission.turnId,
+    );
+    assert.deepEqual(user?.type === 'user' ? user.origin : undefined, {
+      kind: 'goal',
+      goalId: created.id,
+    });
+    assert.equal(fixture.drainRequested(), false);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test('queued Goal control revokes a prepared root before durable admission', async () => {
+  const fixture = await createFixture();
+  try {
+    const created = fixture.goal.manager.create(fixture.sessionId, 'Do not run after clear').goal;
+    const controlLease = fixture.goal.manager.getControlLease(fixture.sessionId);
+    assert.ok(controlLease);
+    if (!controlLease) return;
+    const admission = fixture.coordinator.admitGoalTurn(
+      fixture.sessionId,
+      goalCheckpoint(created),
+      controlLease,
+      'This stale continuation must never run',
+    );
+    assert.equal(admission.kind, 'prepared');
+    if (admission.kind !== 'prepared') return;
+
+    const entered = deferred();
+    const release = deferred();
+    const held = fixture.sessionAdmission.run(fixture.sessionId, async () => {
+      entered.resolve();
+      await release.promise;
+    });
+    await entered.promise;
+    const clearing = fixture.goal.handlers['goal.control'](
+      {
+        sessionId: fixture.sessionId,
+        goalId: created.id,
+        expectedRevision: created.revision,
+        action: 'clear',
+      },
+      operationContext(),
+    );
+    const outcome = admission.start();
+    release.resolve();
+    await held;
+
+    const cleared = await clearing;
+    assert.equal(cleared.ok && cleared.result.goal.status, 'cleared');
+    assert.deepEqual(await outcome, {
+      kind: 'errored',
+      turnId: admission.turnId,
+      reason: 'Goal continuation is unavailable for this Session.',
+    });
+    assert.equal(
+      await fixture.stores.agentRunStore.readRootTurnAdmission(fixture.sessionId, admission.turnId),
+      undefined,
+    );
+    assert.equal(
+      (await fixture.stores.agentRunStore.listSessionRuns(fixture.sessionId)).some(
+        (run) => run.goalId === created.id,
+      ),
+      false,
+    );
+    assert.equal(
+      (await fixture.stores.sessionStore.readMessages(fixture.sessionId)).some(
+        (message) => message.type === 'user' && message.turnId === admission.turnId,
+      ),
+      false,
+    );
+  } finally {
+    await fixture.close();
+  }
+});
+
+test('Host Goal continuation bridges its exact generation into root authority', async () => {
+  const fixture = await createFixture();
+  try {
+    const created = fixture.goal.manager.create(fixture.sessionId, 'Bridge through the Host').goal;
+    const paused = fixture.goal.manager.pause(fixture.sessionId, {
+      checkpoint: goalCheckpoint(created),
+    });
+    assert.ok(paused);
+    if (!paused) return;
+    const resumed = fixture.goal.continuation.resumeFromControl(
+      fixture.sessionId,
+      goalCheckpoint(paused),
+    );
+    assert.ok(resumed);
+    if (!resumed) return;
+
+    const run = await waitForGoalRun(fixture, resumed.id);
+    assert.equal(run.goalId, resumed.id);
+    const admission = await fixture.stores.agentRunStore.readRootTurnAdmission(
+      fixture.sessionId,
+      run.turnId,
+    );
+    assert.deepEqual(admission?.execution, { kind: 'goal', goalId: resumed.id });
+    assert.deepEqual(admission?.sourceMessages, []);
+    assert.equal(fixture.drainRequested(), false);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test('restart closes an admitted Goal without a Run instead of replaying it', async () => {
+  const fixture = await createFixture({ recoverAdmissions: false });
+  try {
+    const turnId = randomUUID();
+    const runId = randomUUID();
+    await fixture.stores.agentRunStore.admitRootTurn({
+      sessionId: fixture.sessionId,
+      turnId,
+      proposedRunId: runId,
+      proposedUserMessageId: randomUUID(),
+      execution: { kind: 'goal', goalId: 'goal-restart' },
+      previousRootTurnId: null,
+      normalizedInput: { text: 'Do not replay after restart' },
+      sourceMessages: [],
+      admittedAt: 1,
+    });
+
+    await fixture.coordinator.prepareRecovery();
+    const run = await fixture.stores.agentRunStore.readRun(fixture.sessionId, runId);
+    assert.equal(run.goalId, 'goal-restart');
+    assert.equal(run.status, 'failed');
+    assert.equal(run.failureClass, 'app_restarted');
+    const user = (await fixture.stores.sessionStore.readMessages(fixture.sessionId)).find(
+      (message) => message.type === 'user' && message.turnId === turnId,
+    );
+    assert.deepEqual(user?.type === 'user' ? user.origin : undefined, {
+      kind: 'goal',
+      goalId: 'goal-restart',
+    });
+    assert.deepEqual(fixture.coordinator.readRootState(fixture.sessionId), { kind: 'idle' });
+  } finally {
+    await fixture.close();
+  }
+});
+
+test('restart rejects an admitted Goal whose existing UserMessage lost its origin', async () => {
+  const fixture = await createFixture({ recoverAdmissions: false });
+  try {
+    const turnId = randomUUID();
+    const userMessageId = randomUUID();
+    await fixture.stores.agentRunStore.admitRootTurn({
+      sessionId: fixture.sessionId,
+      turnId,
+      proposedRunId: randomUUID(),
+      proposedUserMessageId: userMessageId,
+      execution: { kind: 'goal', goalId: 'goal-corrupt-origin' },
+      previousRootTurnId: null,
+      normalizedInput: { text: 'Preserve durable Goal provenance' },
+      sourceMessages: [],
+      admittedAt: 1,
+    });
+    await fixture.stores.sessionStore.appendMessage(fixture.sessionId, {
+      type: 'user',
+      id: userMessageId,
+      turnId,
+      ts: 1,
+      text: 'Preserve durable Goal provenance',
+    });
+
+    await assert.rejects(
+      () => fixture.coordinator.prepareRecovery(),
+      /does not match its UserMessage/,
+    );
+  } finally {
+    await fixture.close();
+  }
+});
+
+interface Fixture {
+  readonly owner: InteractiveRootOwner;
+  readonly base: string;
+  readonly stores: InteractiveExecutionStoresWriter;
+  readonly sessionId: string;
+  readonly rootAdmissions: RootAdmissionOwner;
+  readonly coordinator: RootTurnCoordinator;
+  readonly goal: HostGoalCoordinator;
+  readonly messages: HostMessageCoordinator;
+  readonly sessionAdmission: SessionAdmissionGate;
+  readonly drainRequested: () => boolean;
+  close(): Promise<void>;
+}
+
+async function createFixture(options: { recoverAdmissions?: boolean } = {}): Promise<Fixture> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-goal-root-'));
+  const capability = await resolveStorageRoot({ path: join(base, 'root'), kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) throw new Error('Unable to acquire test root');
+  const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+  const session = await stores.sessionStore.create({
+    cwd: capability.canonicalPath,
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    model: 'fake-model',
+    permissionMode: 'ask',
+  });
+  const admission = new SessionAdmissionGate();
+  const rootAdmissions = new RootAdmissionOwner(stores.agentRunStore);
+  if (options.recoverAdmissions !== false) await rootAdmissions.recoverSession(session.id);
+  const acquireResidency = (): RuntimeHostResidency => ({ release() {} });
+  let coordinator: RootTurnCoordinator | undefined;
+  let continuity: SessionContinuityCoordinator | undefined;
+  let projection: CanonicalSessionProjectionReader | undefined;
+  let goal: HostGoalCoordinator | undefined;
+  let requestedDrain = false;
+  const rootPort: HostMessageRootPort = {
+    readSessionHeader: (sessionId) => requireCoordinator(coordinator).readSessionHeader(sessionId),
+    readRootState: (sessionId) => requireCoordinator(coordinator).readRootState(sessionId),
+    claimStopFence: (input, commitQueueFence, lease) =>
+      requireCoordinator(coordinator).claimStopFence(input, commitQueueFence, lease),
+    startFromMessage: (input, lease) =>
+      requireCoordinator(coordinator).startFromMessage(input, lease),
+    claimStop: (input, commitQueueFence, lease) =>
+      requireCoordinator(coordinator).claimStop(input, commitQueueFence, lease),
+  };
+  const hostEpoch = 'goal-root-epoch';
+  await stores.messageReceiptStore.beginHostEpoch(hostEpoch);
+  const messages = new HostMessageCoordinator({
+    hostEpoch,
+    root: rootPort,
+    durableProof: {
+      readRootTurnSourceMessageReceipt: (sessionId, messageId) =>
+        stores.agentRunStore.readRootTurnSourceMessageReceipt(sessionId, messageId),
+      readImmutableSteeringMessageProof: (sessionId, messageId) =>
+        stores.runtimeEventStore.readImmutableSteeringMessageProof(sessionId, messageId),
+    },
+    receipts: stores.messageReceiptStore,
+    sessionAdmission: admission,
+    acquireResidency,
+    requestDrain: () => {
+      requestedDrain = true;
+    },
+    preflightSessionSnapshot: (sessionId, candidate) =>
+      requireProjection(projection).fitsCandidate(sessionId, candidate),
+    onProjectionChanged: (sessionId) =>
+      requireContinuity(continuity).enqueueCanonicalRefresh(sessionId),
+  });
+  const canonical = new CanonicalSessionProjectionReader({
+    stores,
+    rootAdmissions,
+    messages,
+    readGoal: (sessionId) => requireGoal(goal).readProjection(sessionId),
+  });
+  projection = canonical;
+  continuity = new SessionContinuityCoordinator(
+    hostEpoch,
+    (sessionId) => canonical.read(sessionId),
+    admission,
+    () => {
+      requestedDrain = true;
+    },
+  );
+  const interactions = new HostInteractionCoordinator({
+    store: stores.interactionStore,
+    sessionAdmission: admission,
+    preflightSessionSnapshot: (sessionId, interactions) =>
+      canonical.fitsCandidate(sessionId, { interactions }),
+    refreshCanonicalContinuity: (sessionId, lease) =>
+      requireContinuity(continuity).refreshCanonical(sessionId, lease),
+    onPoison: () => {
+      requestedDrain = true;
+    },
+  });
+  const backends = new BackendRegistry();
+  backends.register('fake', (context) => new FakeBackend(context));
+  const authority: RuntimeHostedRootAuthority = {
+    bindRun: (identity) => messages.bindRun(identity),
+    executeRoot: (input) => requireCoordinator(coordinator).executeRoot(input),
+    stopRoot: (identity, input) => requireCoordinator(coordinator).stopRoot(identity, input),
+    stopSession: (sessionId, input) =>
+      requireCoordinator(coordinator).stopSession(sessionId, input),
+  };
+  const manager = new SessionManager({
+    store: stores.sessionStore,
+    runStore: stores.agentRunStore,
+    runtimeEventStore: stores.runtimeEventStore,
+    backends,
+    newId: randomUUID,
+    now: Date.now,
+    messageAuthority: authority,
+    interactionAuthority: interactions,
+    canonicalPermissionOutcomes: new HostCanonicalPermissionOutcomeReader({
+      store: stores.interactionStore,
+    }),
+  });
+  coordinator = new RootTurnCoordinator(
+    manager,
+    stores,
+    admission,
+    rootAdmissions,
+    interactions,
+    messages,
+    continuity,
+    acquireResidency,
+    () => {
+      requestedDrain = true;
+    },
+    undefined,
+    () => requireGoal(goal),
+  );
+  const rootCoordinator = coordinator;
+  goal = new HostGoalCoordinator({
+    stores,
+    sessionAdmission: admission,
+    evaluator: {
+      evaluate: async () =>
+        '{"met":true,"impossible":false,"progress":true,"waiting":false,"reason":"verified"}',
+    },
+    admitTurn: (sessionId, text, checkpoint, controlLease) =>
+      rootCoordinator.admitGoalTurn(sessionId, checkpoint, controlLease, text),
+    listActionableTaskKeys: async () => [],
+    acquireResidency,
+    onProjectionChanged: (sessionId) =>
+      requireContinuity(continuity).enqueueCanonicalRefresh(sessionId),
+  });
+  const goalCoordinator = goal;
+
+  return {
+    owner,
+    base,
+    stores,
+    sessionId: session.id,
+    rootAdmissions,
+    coordinator: rootCoordinator,
+    goal: goalCoordinator,
+    messages,
+    sessionAdmission: admission,
+    drainRequested: () => requestedDrain,
+    async close() {
+      goalCoordinator.beginDrain();
+      rootCoordinator.beginDrain();
+      await rootCoordinator.close();
+      await messages.close();
+      await interactions.close();
+      continuity?.close();
+      await stores.sessionStore.close?.();
+      await owner.close();
+      await rm(base, { recursive: true, force: true });
+    },
+  };
+}
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+async function waitForGoalRun(
+  fixture: Fixture,
+  goalId: string,
+): Promise<Awaited<ReturnType<Fixture['stores']['agentRunStore']['readRun']>>> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const run = (await fixture.stores.agentRunStore.listSessionRuns(fixture.sessionId)).find(
+      (candidate) => candidate.goalId === goalId,
+    );
+    if (run) return run;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error('Goal continuation did not reach the root authority');
+}
+
+function operationContext() {
+  return {
+    hostEpoch: 'goal-root-epoch',
+    connectionId: 'connection-1',
+    surface: 'tui' as const,
+    principal: 'local_os_user' as const,
+    acquireResidency: () => ({ release() {} }),
+  };
+}
+
+function requireCoordinator(value: RootTurnCoordinator | undefined): RootTurnCoordinator {
+  if (!value) throw new Error('Root coordinator is not composed');
+  return value;
+}
+
+function requireContinuity(
+  value: SessionContinuityCoordinator | undefined,
+): SessionContinuityCoordinator {
+  if (!value) throw new Error('Continuity coordinator is not composed');
+  return value;
+}
+
+function requireProjection(
+  value: CanonicalSessionProjectionReader | undefined,
+): CanonicalSessionProjectionReader {
+  if (!value) throw new Error('Canonical projection is not composed');
+  return value;
+}
+
+function requireGoal(value: HostGoalCoordinator | undefined): HostGoalCoordinator {
+  if (!value) throw new Error('Goal coordinator is not composed');
+  return value;
+}

--- a/packages/runtime-host/src/__tests__/goal-root-authority.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-root-authority.test.ts
@@ -392,6 +392,7 @@ async function createFixture(options: { recoverAdmissions?: boolean } = {}): Pro
     evaluator: {
       evaluate: async () =>
         '{"met":true,"impossible":false,"progress":true,"waiting":false,"reason":"verified"}',
+      close: async () => {},
     },
     admitTurn: (sessionId, text, checkpoint, controlLease) =>
       rootCoordinator.admitGoalTurn(sessionId, checkpoint, controlLease, text),
@@ -416,6 +417,7 @@ async function createFixture(options: { recoverAdmissions?: boolean } = {}): Pro
     async close() {
       goalCoordinator.beginDrain();
       rootCoordinator.beginDrain();
+      await goalCoordinator.close();
       await rootCoordinator.close();
       await messages.close();
       await interactions.close();

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -61,6 +61,8 @@ describe('Runtime Host bootstrap protocol', () => {
       'credential.vault.delete',
       'credential.vault.query',
       'credential.vault.set',
+      'goal.control',
+      'goal.query',
       'host.status',
       'interaction.answer',
       'interaction.query',
@@ -127,7 +129,7 @@ describe('Runtime Host bootstrap protocol', () => {
   });
 
   test('keeps subscription operations closed, ready-only, and queue Epoch correlated', () => {
-    assert.equal(SESSION_CONTINUITY_SCHEMA_VERSION, 2);
+    assert.equal(SESSION_CONTINUITY_SCHEMA_VERSION, 3);
     assert.deepEqual(
       Object.fromEntries(
         (['subscription.open', 'subscription.close'] as const).map((operation) => [
@@ -1072,6 +1074,7 @@ function continuitySnapshot(hostEpoch: string) {
       runId: 'run-1',
       status: 'running' as const,
     },
+    goal: null,
     queue: {
       hostEpoch,
       queueRevision: 1,

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -51,7 +51,7 @@ import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation
 
 const HOLD_EXTERNAL_PROMPT = 'hold external root before follow-up';
 const NO_GOAL_ROOT_AUTHORITY: HostGoalRootAuthority = {
-  beginExternalTurn: () => ({ kind: 'unavailable', reason: 'Goal authority is not composed.' }),
+  beginObservedTurn: () => ({ kind: 'unavailable', reason: 'Goal authority is not composed.' }),
   matchesActive: () => false,
 };
 

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -37,7 +37,10 @@ import type { RuntimeHostResidency } from '../server/host-kernel.js';
 import { HostInteractionCoordinator } from '../server/interaction-coordinator.js';
 import { type HostMessageRootPort, HostMessageCoordinator } from '../server/message-coordinator.js';
 import { RootAdmissionOwner } from '../server/root-admission-owner.js';
-import { RootTurnCoordinator } from '../server/root-turn-coordinator.js';
+import {
+  type HostGoalRootAuthority,
+  RootTurnCoordinator,
+} from '../server/root-turn-coordinator.js';
 import {
   SessionAdmissionGate,
   type SessionAdmissionLease,
@@ -47,6 +50,10 @@ import type { SessionContinuityFrameSink } from '../server/session-continuity-se
 import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
 
 const HOLD_EXTERNAL_PROMPT = 'hold external root before follow-up';
+const NO_GOAL_ROOT_AUTHORITY: HostGoalRootAuthority = {
+  beginExternalTurn: () => ({ kind: 'unavailable', reason: 'Goal authority is not composed.' }),
+  matchesActive: () => false,
+};
 
 test('hosted Automation roots preserve one admission, UserMessage, and AgentRun identity', async () => {
   let recoveryValidationCount = 0;
@@ -288,6 +295,8 @@ test('hosted linked child roots share admission, message, terminal, and stop aut
       () => {
         drainRequested = true;
       },
+      undefined,
+      () => NO_GOAL_ROOT_AUTHORITY,
     );
 
     const parentSink = new RecordingContinuitySink();
@@ -2532,6 +2541,7 @@ async function createFailureFixture(options: {
       acquireResidency,
       requestDrain,
       options.clientCapabilities,
+      () => NO_GOAL_ROOT_AUTHORITY,
       assertAutomationRecoveryAdmission,
     );
   coordinator = createCoordinator(rootAdmissionOwner);

--- a/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
@@ -376,6 +376,7 @@ function canonical(
       overrides.rootTurn === undefined
         ? { sessionId: SESSION_ID, turnId: 'turn-1', runId: 'run-1', status: 'running' }
         : overrides.rootTurn,
+    goal: null,
     queue: {
       hostEpoch: HOST_EPOCH,
       queueRevision: 0,

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -323,6 +323,7 @@ function openResult(hostEpoch: string, subscriptionId: string) {
         runId: 'run-1',
         status: 'running' as const,
       },
+      goal: null,
       queue: { hostEpoch, queueRevision: 1, steering: [], followup: [] },
       interactions: { pending: [] },
     },

--- a/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
@@ -190,7 +190,7 @@ describe('Usage/Pricing protocol', () => {
       usageResponse({
         kind: 'logs',
         source: 'llm',
-        rows: [validLog(), { ...validLog(1), callKind: 'history_compact' }],
+        rows: [validLog(), { ...validLog(1), callKind: 'goal_evaluation' }],
         offset: 0,
         total: 2,
         nextOffset: null,

--- a/packages/runtime-host/src/protocol/goal.ts
+++ b/packages/runtime-host/src/protocol/goal.ts
@@ -1,0 +1,221 @@
+import {
+  GOAL_CONDITION_TEXT_LIMIT,
+  GOAL_REASON_TEXT_LIMIT,
+  isGoalStatus,
+  type GoalStatus,
+} from '@maka/core/goal';
+import {
+  requireCount,
+  requireEncodedByteLimit,
+  requireEntityId,
+  requireExactRecord,
+  requireUtf8String,
+} from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const GOAL_RESULT_MAX_BYTES = 8 * 1024;
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'not_found',
+  'internal_failure',
+] as const;
+const CONTROL_ERRORS = [...QUERY_ERRORS, 'session_archived', 'operation_conflict'] as const;
+
+export type GoalControlAction = 'pause' | 'resume' | 'clear';
+
+export interface GoalProjection {
+  readonly goalId: string;
+  readonly revision: number;
+  readonly sessionId: string;
+  readonly condition: string;
+  readonly status: GoalStatus;
+  readonly setAt: number;
+  readonly iterations: number;
+  readonly maxIterations: number;
+  readonly consecutiveNoProgress: number;
+  readonly blockCap: number;
+  readonly tokenBudget: number | null;
+  readonly tokensSpent: number;
+  readonly lastReason: string | null;
+  readonly achievedAt: number | null;
+  readonly pausedAt: number | null;
+}
+
+export interface GoalQueryInput {
+  readonly sessionId: string;
+}
+
+export interface GoalQueryResult {
+  readonly sessionId: string;
+  readonly goal: GoalProjection | null;
+}
+
+export interface GoalControlInput {
+  readonly sessionId: string;
+  readonly goalId: string;
+  readonly expectedRevision: number;
+  readonly action: GoalControlAction;
+}
+
+export interface GoalControlResult {
+  readonly sessionId: string;
+  readonly goal: GoalProjection;
+}
+
+export const GOAL_OPERATION_SPECS = {
+  'goal.query': defineOperation({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeGoalQueryInput,
+    decodeOutput: decodeGoalQueryResult,
+    assertOutputForInput(input, output) {
+      if (input.sessionId !== output.sessionId) {
+        throw invalidProtocolFrame('Goal query result belongs to a different Session');
+      }
+    },
+  }),
+  'goal.control': defineOperation({
+    mode: 'control',
+    availability: 'ready',
+    errors: CONTROL_ERRORS,
+    decodeInput: decodeGoalControlInput,
+    decodeOutput: decodeGoalControlResult,
+    assertOutputForInput(input, output) {
+      if (input.sessionId !== output.sessionId || input.goalId !== output.goal.goalId) {
+        throw invalidProtocolFrame('Goal control result belongs to a different Goal');
+      }
+    },
+  }),
+} as const;
+
+export function decodeGoalProjection(value: unknown): GoalProjection {
+  const record = requireExactRecord(value, 'Goal projection', [
+    'goalId',
+    'revision',
+    'sessionId',
+    'condition',
+    'status',
+    'setAt',
+    'iterations',
+    'maxIterations',
+    'consecutiveNoProgress',
+    'blockCap',
+    'tokenBudget',
+    'tokensSpent',
+    'lastReason',
+    'achievedAt',
+    'pausedAt',
+  ]);
+  const condition = requireUtf8String(
+    record.condition,
+    'Goal condition',
+    GOAL_CONDITION_TEXT_LIMIT.utf8Bytes,
+  );
+  if (condition.length > GOAL_CONDITION_TEXT_LIMIT.codeUnits) {
+    throw invalidProtocolFrame('Invalid Goal condition');
+  }
+  const lastReason = requireNullableGoalReason(record.lastReason);
+  return {
+    goalId: requireEntityId(record.goalId, 'goalId'),
+    revision: requireCount(record.revision, 'Goal revision'),
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    condition,
+    status: requireGoalStatus(record.status),
+    setAt: requireCount(record.setAt, 'Goal setAt'),
+    iterations: requireCount(record.iterations, 'Goal iterations'),
+    maxIterations: requirePositiveCount(record.maxIterations, 'Goal maxIterations'),
+    consecutiveNoProgress: requireCount(record.consecutiveNoProgress, 'Goal consecutiveNoProgress'),
+    blockCap: requirePositiveCount(record.blockCap, 'Goal blockCap'),
+    tokenBudget: requireNullablePositiveCount(record.tokenBudget, 'Goal tokenBudget'),
+    tokensSpent: requireCount(record.tokensSpent, 'Goal tokensSpent'),
+    lastReason,
+    achievedAt: requireNullableCount(record.achievedAt, 'Goal achievedAt'),
+    pausedAt: requireNullableCount(record.pausedAt, 'Goal pausedAt'),
+  };
+}
+
+function decodeGoalQueryInput(value: unknown): GoalQueryInput {
+  const record = requireExactRecord(value, 'goal.query input', ['sessionId']);
+  return { sessionId: requireEntityId(record.sessionId, 'sessionId') };
+}
+
+function decodeGoalQueryResult(value: unknown): GoalQueryResult {
+  requireEncodedByteLimit(value, 'Goal query result', GOAL_RESULT_MAX_BYTES);
+  const record = requireExactRecord(value, 'goal.query result', ['sessionId', 'goal']);
+  const sessionId = requireEntityId(record.sessionId, 'sessionId');
+  const goal = record.goal === null ? null : decodeGoalProjection(record.goal);
+  if (goal && goal.sessionId !== sessionId) {
+    throw invalidProtocolFrame('Goal query result contains a Goal from another Session');
+  }
+  return { sessionId, goal };
+}
+
+function decodeGoalControlInput(value: unknown): GoalControlInput {
+  const record = requireExactRecord(value, 'goal.control input', [
+    'sessionId',
+    'goalId',
+    'expectedRevision',
+    'action',
+  ]);
+  return {
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    goalId: requireEntityId(record.goalId, 'goalId'),
+    expectedRevision: requireCount(record.expectedRevision, 'expectedRevision'),
+    action: requireGoalControlAction(record.action),
+  };
+}
+
+function decodeGoalControlResult(value: unknown): GoalControlResult {
+  requireEncodedByteLimit(value, 'Goal control result', GOAL_RESULT_MAX_BYTES);
+  const record = requireExactRecord(value, 'goal.control result', ['sessionId', 'goal']);
+  const sessionId = requireEntityId(record.sessionId, 'sessionId');
+  const goal = decodeGoalProjection(record.goal);
+  if (goal.sessionId !== sessionId) {
+    throw invalidProtocolFrame('Goal control result contains a Goal from another Session');
+  }
+  return { sessionId, goal };
+}
+
+function requireGoalStatus(value: unknown): GoalStatus {
+  if (!isGoalStatus(value)) {
+    throw invalidProtocolFrame('Invalid Goal status');
+  }
+  return value;
+}
+
+function requireGoalControlAction(value: unknown): GoalControlAction {
+  if (value !== 'pause' && value !== 'resume' && value !== 'clear') {
+    throw invalidProtocolFrame('Invalid Goal control action');
+  }
+  return value;
+}
+
+function requireNullableGoalReason(value: unknown): string | null {
+  if (value === null) return null;
+  const reason = requireUtf8String(value, 'Goal lastReason', GOAL_REASON_TEXT_LIMIT.utf8Bytes);
+  if (reason.length > GOAL_REASON_TEXT_LIMIT.codeUnits) {
+    throw invalidProtocolFrame('Invalid Goal lastReason');
+  }
+  return reason;
+}
+
+function requirePositiveCount(value: unknown, label: string): number {
+  const count = requireCount(value, label);
+  if (count === 0) throw invalidProtocolFrame(`Invalid ${label}`);
+  return count;
+}
+
+function requireNullablePositiveCount(value: unknown, label: string): number | null {
+  if (value === null) return null;
+  return requirePositiveCount(value, label);
+}
+
+function requireNullableCount(value: unknown, label: string): number | null {
+  if (value === null) return null;
+  return requireCount(value, label);
+}

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -27,6 +27,7 @@ export { RuntimeHostProtocolError } from './errors.js';
 export * from './interaction.js';
 export * from './automation.js';
 export * from './client-capability.js';
+export * from './goal.js';
 export * from './message.js';
 export * from './operations.js';
 export * from './runtime-resource.js';

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -5,6 +5,7 @@ import { CONNECTION_EFFECT_OPERATION_SPECS } from './connection-effects.js';
 import { CLIENT_CAPABILITY_OPERATION_SPECS } from './client-capability.js';
 import { invalidProtocolFrame } from './errors.js';
 import { HOST_STATUS_OPERATION_SPECS } from './host-status.js';
+import { GOAL_OPERATION_SPECS } from './goal.js';
 import { INTERACTION_OPERATION_SPECS } from './interaction.js';
 import { MESSAGE_OPERATION_SPECS } from './message.js';
 import { MEMORY_OPERATION_SPECS } from './memory.js';
@@ -86,6 +87,7 @@ export type {
 } from './turn.js';
 export * from './connection-effects.js';
 export * from './client-capability.js';
+export * from './goal.js';
 export * from './memory.js';
 export * from './runtime-policy.js';
 export * from './runtime-resource.js';
@@ -96,6 +98,7 @@ export * from './usage-pricing.js';
 
 export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   HOST_STATUS_OPERATION_SPECS,
+  GOAL_OPERATION_SPECS,
   TURN_OPERATION_SPECS,
   CONNECTION_EFFECT_OPERATION_SPECS,
   RUNTIME_POLICY_OPERATION_SPECS,

--- a/packages/runtime-host/src/protocol/session-continuity.ts
+++ b/packages/runtime-host/src/protocol/session-continuity.ts
@@ -18,8 +18,9 @@ import {
 } from './message.js';
 import { defineOperation } from './operation-spec.js';
 import { decodeTurnSnapshot, type TurnSnapshot } from './turn.js';
+import { decodeGoalProjection, type GoalProjection } from './goal.js';
 
-export const SESSION_CONTINUITY_SCHEMA_VERSION = 2 as const;
+export const SESSION_CONTINUITY_SCHEMA_VERSION = 3 as const;
 export const SESSION_CONTINUITY_SNAPSHOT_MAX_BYTES = 56 * 1024;
 export const SESSION_LIVE_DELTA_MAX_BYTES = 16 * 1024;
 // Core emits at most 8,192 UTF-16 code units per tool output event. A code unit
@@ -53,6 +54,7 @@ export interface SessionContinuitySnapshot {
   session: SessionContinuityIdentity;
   projectionRevision: number;
   rootTurn: TurnSnapshot | null;
+  goal: GoalProjection | null;
   queue: SessionMessageQueueProjection;
   interactions: SessionInteractionProjection;
 }
@@ -283,6 +285,7 @@ export function decodeSessionContinuitySnapshot(value: unknown): SessionContinui
     'session',
     'projectionRevision',
     'rootTurn',
+    'goal',
     'queue',
     'interactions',
   ]);
@@ -295,11 +298,16 @@ export function decodeSessionContinuitySnapshot(value: unknown): SessionContinui
     throw invalidProtocolFrame('Session continuity root Turn belongs to a different Session');
   }
   const interactions = decodeSessionInteractionProjection(record.interactions, session.sessionId);
+  const goal = record.goal === null ? null : decodeGoalProjection(record.goal);
+  if (goal !== null && goal.sessionId !== session.sessionId) {
+    throw invalidProtocolFrame('Session continuity Goal belongs to a different Session');
+  }
   return {
     schemaVersion: SESSION_CONTINUITY_SCHEMA_VERSION,
     session,
     projectionRevision: requirePositiveCount(record.projectionRevision, 'projectionRevision'),
     rootTurn,
+    goal,
     queue: decodeSessionMessageQueueProjection(record.queue),
     interactions,
   };

--- a/packages/runtime-host/src/protocol/usage-pricing.ts
+++ b/packages/runtime-host/src/protocol/usage-pricing.ts
@@ -5,6 +5,7 @@ import {
 } from '@maka/core/usage-stats/pricing';
 import type {
   CacheMissInputSource,
+  ModelCallKind,
   PricingConfig,
   ToolInvocationResultSummary,
   UsageBucket,
@@ -12,6 +13,7 @@ import type {
   UsageQuery,
   UsageSummaryV2,
 } from '@maka/core/usage-stats/types';
+import { MODEL_CALL_KINDS } from '@maka/core/usage-stats/types';
 import { requireCount, requireExactRecord, requireRecord } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
 import { defineOperation } from './operation-spec.js';
@@ -122,7 +124,7 @@ export interface LlmUsageLogProjection {
   readonly source: 'llm';
   readonly id: string;
   readonly ts: number;
-  readonly callKind?: 'main' | 'semantic_compact' | 'history_compact';
+  readonly callKind?: ModelCallKind;
   readonly callId?: string;
   readonly connectionSlug?: string;
   readonly providerId: string;
@@ -814,7 +816,7 @@ function decodeLlmUsageLog(value: unknown): LlmUsageLogProjection {
     source: 'llm',
     id: projectionText(row.id, 'usage log id'),
     ts: nonnegativeFinite(row.ts, 'usage log timestamp'),
-    ...optionalEnum(row, 'callKind', ['main', 'semantic_compact', 'history_compact'] as const),
+    ...optionalEnum(row, 'callKind', MODEL_CALL_KINDS),
     ...optionalProjectionText(row, 'callId'),
     ...optionalProjectionText(row, 'connectionSlug'),
     providerId: projectionText(row.providerId, 'usage log provider'),

--- a/packages/runtime-host/src/server/automation-fire-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-fire-coordinator.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import type { AgentRunHeader } from '@maka/core/agent-run';
+import { agentRunMatchesHostedRootExecution, type AgentRunHeader } from '@maka/core/agent-run';
 import type { AutomationDefinition, AutomationPendingFire } from '@maka/core/automation';
 import type { MessageContent } from '@maka/core/events';
 import type { SessionHeader } from '@maka/core/session';
@@ -489,16 +489,10 @@ export function assertFireRunIdentity(fire: AutomationPendingFire, run: AgentRun
     run.sessionId !== fire.targetSessionId ||
     run.turnId !== fire.turnId ||
     run.runId !== fire.runId ||
-    run.automationId !== fire.automationId ||
-    run.parentRunId !== undefined ||
-    run.resumedFromRunId !== undefined ||
-    run.retriedFromRunId !== undefined ||
-    run.parentSessionId !== undefined ||
-    run.agentId !== undefined ||
-    run.agentName !== undefined ||
-    run.continuationSource !== undefined ||
-    run.agentGraphWakeId !== undefined ||
-    run.agentGraphWakeAttemptId !== undefined
+    !agentRunMatchesHostedRootExecution(run, {
+      kind: 'automation',
+      automationId: fire.automationId,
+    })
   ) {
     throw new AutomationAuthorityInvariantError(
       `Run ${run.runId} does not match pending Automation fire ${fire.id}`,

--- a/packages/runtime-host/src/server/canonical-session-projection.ts
+++ b/packages/runtime-host/src/server/canonical-session-projection.ts
@@ -5,6 +5,7 @@ import type {
   SessionContinuityIdentity,
   SessionInteractionProjection,
   SessionMessageQueueProjection,
+  GoalProjection,
   TurnSnapshot,
 } from '../protocol/index.js';
 import {
@@ -17,6 +18,7 @@ import type { HostMessageCoordinator } from './message-coordinator.js';
 import { worstCaseMessageQueueProjection } from './message-queue-capacity.js';
 import { projectSessionInteractions } from './interaction-projection.js';
 import type { RootAdmissionOwner } from './root-admission-owner.js';
+import { worstCaseGoalProjection } from './goal-projection.js';
 
 type CanonicalSessionProjectionStores = Pick<
   ExecutionStoresWriter<'interactive'>,
@@ -26,6 +28,7 @@ type CanonicalSessionProjectionStores = Pick<
 export interface CanonicalSessionProjection {
   readonly session: SessionContinuityIdentity;
   readonly rootTurn: TurnSnapshot | null;
+  readonly goal: GoalProjection | null;
   readonly queue: SessionMessageQueueProjection;
   readonly interactions: SessionInteractionProjection;
 }
@@ -39,17 +42,20 @@ export interface CanonicalSessionProjectionReaderOptions {
   readonly stores: CanonicalSessionProjectionStores;
   readonly rootAdmissions: RootAdmissionOwner;
   readonly messages: Pick<HostMessageCoordinator, 'projection'>;
+  readonly readGoal?: (sessionId: string) => GoalProjection | null;
 }
 
 export class CanonicalSessionProjectionReader {
   readonly #stores: CanonicalSessionProjectionStores;
   readonly #rootAdmissions: RootAdmissionOwner;
   readonly #messages: Pick<HostMessageCoordinator, 'projection'>;
+  readonly #readGoal: (sessionId: string) => GoalProjection | null;
 
   constructor(options: CanonicalSessionProjectionReaderOptions) {
     this.#stores = options.stores;
     this.#rootAdmissions = options.rootAdmissions;
     this.#messages = options.messages;
+    this.#readGoal = options.readGoal ?? (() => null);
   }
 
   async read(sessionId: string): Promise<CanonicalSessionProjection | null> {
@@ -86,6 +92,7 @@ export class CanonicalSessionProjectionReader {
     );
     // The Session lane barrier must remain held through this final synchronous read.
     const queue = this.#messages.projection(sessionId);
+    const goal = this.#readGoal(sessionId);
     const session: SessionContinuityIdentity = {
       sessionId: header.id,
       metadataRevision,
@@ -95,7 +102,7 @@ export class CanonicalSessionProjectionReader {
       isArchived: header.isArchived,
       ...(header.archivedAt !== undefined ? { archivedAt: header.archivedAt } : {}),
     };
-    return { session, rootTurn, queue, interactions };
+    return { session, rootTurn, goal, queue, interactions };
   }
 
   async fitsCandidate(
@@ -107,6 +114,7 @@ export class CanonicalSessionProjectionReader {
     const candidateProjection = {
       ...canonical,
       ...candidate,
+      goal: worstCaseGoalProjection(sessionId),
       queue: worstCaseMessageQueueProjection(candidate.queue ?? canonical.queue),
     };
     const snapshotInput = sessionContinuitySnapshotInput(
@@ -152,6 +160,7 @@ function sessionContinuitySnapshotInput(
     session: canonical.session,
     projectionRevision,
     rootTurn: canonical.rootTurn,
+    goal: canonical.goal,
     queue: canonical.queue,
     interactions: canonical.interactions,
   };

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { filterModelVisibleTaskLedgerTasks } from '@maka/core/task-ledger';
 import {
   AgentGraphCoordinator,
   BackendRegistry,
@@ -35,7 +36,8 @@ import { HostAutomationCoordinator } from './automation-coordinator.js';
 import { recoverClientCapabilityOutcomes } from './client-capability-recovery.js';
 import { HostConnectionEffectCoordinator } from './connection-effect-coordinator.js';
 import { HostClientCapabilityCoordinator } from './client-capability-coordinator.js';
-import { createHostAiSdkBackend } from './execution-model-composition.js';
+import { createHostAiSdkBackend, createHostGoalEvaluator } from './execution-model-composition.js';
+import { HostGoalCoordinator } from './goal-coordinator.js';
 import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './host-kernel.js';
 import { HostInteractionCoordinator } from './interaction-coordinator.js';
 import { HostMemoryCoordinator } from './memory-coordinator.js';
@@ -134,6 +136,7 @@ export async function createExecutionRuntimeHostComposition(
     let memory: HostMemoryCoordinator | undefined;
     let clientCapabilities: HostClientCapabilityCoordinator | undefined;
     let automations: HostAutomationCoordinator | undefined;
+    let goal: HostGoalCoordinator | undefined;
     const rootPort: HostMessageRootPort = {
       readSessionHeader: (sessionId) =>
         requireRootCoordinator(rootCoordinator).readSessionHeader(sessionId),
@@ -169,6 +172,7 @@ export async function createExecutionRuntimeHostComposition(
       stores,
       rootAdmissions: rootAdmissionOwner,
       messages,
+      readGoal: (sessionId) => requireGoal(goal).readProjection(sessionId),
     });
     canonicalProjection = canonicalProjectionReader;
     continuity = new SessionContinuityCoordinator(
@@ -188,6 +192,8 @@ export async function createExecutionRuntimeHostComposition(
     const beginDrain = () => {
       if (draining) return;
       draining = true;
+      goal?.beginDrain();
+      rootCoordinator?.beginDrain();
       runtimeResources?.beginDrain();
       automations?.beginDrain();
       messages.beginDrain();
@@ -236,6 +242,7 @@ export async function createExecutionRuntimeHostComposition(
         usage: openedUsageStores,
         clientCapabilities: requireClientCapabilities(clientCapabilities),
         automationTool: requireAutomationCoordinator(automations).modelTool,
+        goalTools: requireGoal(goal).tools,
         builtinTools: {
           shellRuns: requireRuntimeResources(runtimeResources),
           runtimeResources: requireRuntimeResources(runtimeResources),
@@ -328,6 +335,7 @@ export async function createExecutionRuntimeHostComposition(
       context.acquireResidency,
       context.requestDrain,
       clientCapabilities,
+      () => requireGoal(goal),
       (admission) => requireAutomationCoordinator(automations).assertRecoveryAdmission(admission),
     );
     const coordinator = rootCoordinator;
@@ -338,9 +346,35 @@ export async function createExecutionRuntimeHostComposition(
       runtime: manager,
       root: { executeRoot: (input) => coordinator.executeRoot(input) },
       runtimePolicy: runtimePolicyStores,
-      isSessionActive: (sessionId) => coordinator.readRootState(sessionId).kind === 'active',
+      isSessionActive: (sessionId) => coordinator.readRootState(sessionId).kind !== 'idle',
       acquireResidency: context.acquireResidency,
       requestDrain: context.requestDrain,
+    });
+    goal = new HostGoalCoordinator({
+      stores,
+      sessionAdmission,
+      evaluator: createHostGoalEvaluator({
+        runtimePolicy: runtimePolicyStores,
+        oauthCredentials,
+        claudeDeviceId: context.owner.capability.rootId,
+        usage: openedUsageStores,
+        requestDrain: context.requestDrain,
+        readSessionHeader: (sessionId) => stores.sessionStore.readHeaderSnapshot(sessionId),
+      }),
+      admitTurn: (sessionId, text, checkpoint, controlLease) =>
+        coordinator.admitGoalTurn(sessionId, checkpoint, controlLease, text),
+      listActionableTaskKeys: async (sessionId) => {
+        const tasks = await taskLedger.list(sessionId, {
+          includeTerminal: false,
+          includeArchived: false,
+          classifyResumeTrust: true,
+        });
+        return filterModelVisibleTaskLedgerTasks(tasks)
+          .filter((task) => task.status === 'pending' || task.status === 'in_progress')
+          .map((task) => task.key);
+      },
+      acquireResidency: context.acquireResidency,
+      onProjectionChanged: (sessionId) => continuityCoordinator.enqueueCanonicalRefresh(sessionId),
     });
     const runtimePolicy = new HostRuntimePolicyCoordinator(
       runtimePolicyStores,
@@ -375,7 +409,7 @@ export async function createExecutionRuntimeHostComposition(
       manager,
       admission: sessionAdmission,
       continuity: continuityCoordinator,
-      isSessionActive: (sessionId) => coordinator.readRootState(sessionId).kind === 'active',
+      isSessionActive: (sessionId) => coordinator.readRootState(sessionId).kind !== 'idle',
       requestDrain: context.requestDrain,
     });
     const artifacts = new HostArtifactCoordinator(
@@ -385,6 +419,7 @@ export async function createExecutionRuntimeHostComposition(
     );
     const handlers = {
       ...coordinator.handlers,
+      ...requireGoal(goal).handlers,
       ...sessionCatalog.handlers,
       ...sessionRevisions.handlers,
       ...messages.handlers,
@@ -435,6 +470,11 @@ export async function createExecutionRuntimeHostComposition(
         const errors: unknown[] = [];
         try {
           await recover();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
+          goal?.close();
         } catch (error) {
           errors.push(error);
         }
@@ -652,5 +692,10 @@ function requireRuntimeResources(
   coordinator: HostRuntimeResourceCoordinator | undefined,
 ): HostRuntimeResourceCoordinator {
   if (!coordinator) throw new Error('Runtime Host Runtime Resource coordinator is not composed');
+  return coordinator;
+}
+
+function requireGoal(coordinator: HostGoalCoordinator | undefined): HostGoalCoordinator {
+  if (!coordinator) throw new Error('Runtime Host Goal coordinator is not composed');
   return coordinator;
 }

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -474,7 +474,7 @@ export async function createExecutionRuntimeHostComposition(
           errors.push(error);
         }
         try {
-          goal?.close();
+          await goal?.close();
         } catch (error) {
           errors.push(error);
         }

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -3,6 +3,7 @@ import { PROVIDER_DEFAULTS, type RuntimeExecutionConnection } from '@maka/core/l
 import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
 import { resolveModelVisionSupport } from '@maka/core/model-metadata';
 import type { RuntimePolicy } from '@maka/core/runtime-policy';
+import type { SessionHeader } from '@maka/core/session';
 import {
   filterModelVisibleTaskLedgerTasks,
   renderTaskLedgerPromptText,
@@ -27,6 +28,8 @@ import {
   createProviderRequestCaptureRecorder,
   createProxiedFetchTransport,
   getAIModel,
+  generateGoalEvaluationModelCall,
+  llmCallUsageFields,
   projectEffectiveProductToolSurface,
   recordLlmCall,
   recordToolInvocation,
@@ -35,6 +38,7 @@ import {
   SkillShadowSelectionTracker,
   type BackendFactoryContext,
   type BuildBuiltinToolsOptions,
+  type GoalEvaluatorDeps,
   type MakaTool,
   type ProxiedFetchProxy,
   type ProxiedFetchTransport,
@@ -102,6 +106,7 @@ export interface HostExecutionModelCompositionInput {
   readonly clientCapabilities?: Pick<ClientCapabilitySnapshot, 'tools' | 'groups'>;
   readonly builtinTools?: BuildBuiltinToolsOptions;
   readonly automationTool?: MakaTool;
+  readonly goalTools?: readonly MakaTool[];
 }
 
 /** Composes one Host-owned prompt and pure tool surface from canonical authorities. */
@@ -116,6 +121,7 @@ export function createHostExecutionModelComposition(
         inventoryFor,
         input.builtinTools,
         input.automationTool,
+        input.goalTools,
       );
   const productSurface = projectEffectiveProductToolSurface({
     host: 'runtime-host',
@@ -208,7 +214,150 @@ export interface HostAiSdkBackendInput {
   readonly runtimeCommitSink?: RuntimeCommitSink;
   readonly builtinTools?: BuildBuiltinToolsOptions;
   readonly automationTool?: MakaTool;
+  readonly goalTools?: readonly MakaTool[];
   readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
+}
+
+export interface HostGoalEvaluatorInput {
+  readonly runtimePolicy: RuntimePolicyStoresWriter;
+  readonly oauthCredentials: HostOAuthExecutionAuthority;
+  readonly claudeDeviceId: string;
+  readonly usage: InteractiveUsageStoresWriter;
+  readonly requestDrain: () => void;
+  readonly readSessionHeader: (sessionId: string) => Promise<SessionHeader>;
+  readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
+  readonly now?: () => number;
+  readonly newId?: () => string;
+}
+
+/** Creates a tool-free Goal judge on the Session's canonical connection and model. */
+export function createHostGoalEvaluator(input: HostGoalEvaluatorInput): GoalEvaluatorDeps {
+  const createFetchTransport = input.createFetchTransport ?? createProxiedFetchTransport;
+  const now = input.now ?? Date.now;
+  const newId = input.newId ?? randomUUID;
+  let telemetryDrainRequested = false;
+  const telemetry = {
+    insertLlmCall: async (
+      record: Parameters<typeof input.usage.telemetry.recordLlmCall>[0],
+    ): Promise<void> => {
+      try {
+        await input.usage.telemetry.recordLlmCall(record);
+      } catch (error) {
+        if (!telemetryDrainRequested) {
+          telemetryDrainRequested = true;
+          input.requestDrain();
+        }
+        throw error;
+      }
+    },
+  };
+  return {
+    evaluate: async (prompt, sessionId, signal) => {
+      const header = await readDuringBackendCreation(
+        () => input.readSessionHeader(sessionId),
+        signal,
+      );
+      const [target, pricingSnapshot] = await Promise.all([
+        readDuringBackendCreation(
+          () =>
+            resolveExecutionTarget(
+              header,
+              input.runtimePolicy,
+              input.oauthCredentials,
+              createFetchTransport,
+            ),
+          signal,
+        ),
+        readDuringBackendCreation(() => input.usage.pricing.snapshot(), signal),
+      ]);
+      const pricing = buildPricingLookup(pricingSnapshot.overrides);
+      const transport = createFetchTransport(
+        toProxySettings(target.networkProxy, target.proxySecret),
+      );
+      let apiKey = target.apiKey;
+      let modelFetch: typeof fetch = transport.fetch;
+      try {
+        if (target.oauthBinding) {
+          const initialOAuthTokens = await readDuringBackendCreation(
+            () => target.oauthBinding!.resolve(),
+            signal,
+          );
+          apiKey = initialOAuthTokens.access_token;
+          modelFetch = createHostOAuthModelFetch({
+            binding: target.oauthBinding,
+            initialTokens: initialOAuthTokens,
+            connection: target.connection,
+            sessionId,
+            modelId: target.model,
+            claudeDeviceId: input.claudeDeviceId,
+            fetchFn: transport.fetch,
+          });
+        }
+        const startedAt = now();
+        const callId = `goal_evaluation_${sessionId}_${newId()}`;
+        const baseRecord = {
+          sessionId,
+          callKind: 'goal_evaluation' as const,
+          callId,
+          connectionSlug: target.connection.slug,
+          providerId: target.connection.providerType,
+          modelId: target.model,
+          startedAt,
+        };
+        try {
+          const result = await generateGoalEvaluationModelCall({
+            model: getAIModel({
+              connection: target.connection,
+              apiKey,
+              modelId: target.model,
+              fetch: modelFetch,
+            }),
+            prompt,
+            abortSignal: signal,
+            providerOptions: buildProviderOptions(
+              target.connection,
+              target.model,
+              header.thinkingLevel,
+            ),
+          });
+          await recordLlmCall(
+            { repo: telemetry, lookupPricing: pricing },
+            {
+              ...baseRecord,
+              ...(result.usage
+                ? llmCallUsageFields(result.usage)
+                : { inputTokens: 0, outputTokens: 0 }),
+              ...(result.finishReason && !result.usage
+                ? { rawFinishReason: result.finishReason }
+                : {}),
+              latencyMs: Math.max(0, now() - startedAt),
+              status: 'success',
+            },
+          );
+          return result.text;
+        } catch (error) {
+          await recordLlmCall(
+            { repo: telemetry, lookupPricing: pricing },
+            {
+              ...baseRecord,
+              inputTokens: 0,
+              outputTokens: 0,
+              latencyMs: Math.max(0, now() - startedAt),
+              status: signal.aborted ? 'aborted' : 'error',
+              errorClass: evaluatorErrorClass(error),
+            },
+          );
+          throw error;
+        }
+      } finally {
+        await transport.close();
+      }
+    },
+  };
+}
+
+function evaluatorErrorClass(error: unknown): string {
+  return error instanceof Error ? error.name : 'UnknownError';
 }
 
 /** Builds one real provider backend from canonical Host state. */
@@ -274,6 +423,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
       ...(clientCapabilities ? { clientCapabilities } : {}),
       ...(input.builtinTools ? { builtinTools: input.builtinTools } : {}),
       ...(input.automationTool ? { automationTool: input.automationTool } : {}),
+      ...(input.goalTools ? { goalTools: input.goalTools } : {}),
       skillBudget: {
         contextWindow: resolveSelectedModelContextWindow(target.connection, target.model),
       },
@@ -606,6 +756,7 @@ function buildDefaultHostTools(
   inventoryFor: SkillInventoryResolver,
   builtinOptions?: BuildBuiltinToolsOptions,
   automationTool?: MakaTool,
+  goalTools: readonly MakaTool[] = [],
 ): MakaTool[] {
   const builtins = builtinOptions ? buildBuiltinTools(builtinOptions) : [];
   const question = buildAskUserQuestionTool();
@@ -617,6 +768,7 @@ function buildDefaultHostTools(
     'SkillSearch',
     ...taskTools.map((tool) => tool.name),
     ...(automationTool ? [automationTool.name] : []),
+    ...goalTools.map((tool) => tool.name),
   ];
   const skillHost = buildHostCapabilitiesFromBinding(toolNames);
   const shadowTracker = new SkillShadowSelectionTracker();
@@ -631,6 +783,7 @@ function buildDefaultHostTools(
     }),
     ...taskTools,
     ...(automationTool ? [automationTool] : []),
+    ...goalTools,
   ];
 }
 

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -38,7 +38,7 @@ import {
   SkillShadowSelectionTracker,
   type BackendFactoryContext,
   type BuildBuiltinToolsOptions,
-  type GoalEvaluatorDeps,
+  type GoalEvaluatorResource,
   type MakaTool,
   type ProxiedFetchProxy,
   type ProxiedFetchTransport,
@@ -231,7 +231,7 @@ export interface HostGoalEvaluatorInput {
 }
 
 /** Creates a tool-free Goal judge on the Session's canonical connection and model. */
-export function createHostGoalEvaluator(input: HostGoalEvaluatorInput): GoalEvaluatorDeps {
+export function createHostGoalEvaluator(input: HostGoalEvaluatorInput): GoalEvaluatorResource {
   const createFetchTransport = input.createFetchTransport ?? createProxiedFetchTransport;
   const now = input.now ?? Date.now;
   const newId = input.newId ?? randomUUID;
@@ -251,7 +251,7 @@ export function createHostGoalEvaluator(input: HostGoalEvaluatorInput): GoalEval
       }
     },
   };
-  return {
+  return createOwnedGoalEvaluator({
     evaluate: async (prompt, sessionId, signal) => {
       const header = await readDuringBackendCreation(
         () => input.readSessionHeader(sessionId),
@@ -352,6 +352,32 @@ export function createHostGoalEvaluator(input: HostGoalEvaluatorInput): GoalEval
       } finally {
         await transport.close();
       }
+    },
+  });
+}
+
+function createOwnedGoalEvaluator(
+  evaluator: Pick<GoalEvaluatorResource, 'evaluate'>,
+): GoalEvaluatorResource {
+  const active = new Set<Promise<void>>();
+  let closing = false;
+  let closeTask: Promise<void> | undefined;
+  return {
+    evaluate: (prompt, sessionId, signal) => {
+      if (closing) return Promise.reject(new Error('Goal evaluator is closing'));
+      const task = evaluator.evaluate(prompt, sessionId, signal);
+      const settled = task.then(
+        () => undefined,
+        () => undefined,
+      );
+      active.add(settled);
+      void settled.finally(() => active.delete(settled));
+      return task;
+    },
+    close: () => {
+      closing = true;
+      closeTask ??= Promise.all([...active]).then(() => undefined);
+      return closeTask;
     },
   };
 }

--- a/packages/runtime-host/src/server/goal-coordinator.ts
+++ b/packages/runtime-host/src/server/goal-coordinator.ts
@@ -7,7 +7,7 @@ import {
   TERMINAL_GOAL_STATUSES,
   buildGoalTools,
   truncateGoalText,
-  type GoalEvaluatorDeps,
+  type GoalEvaluatorResource,
   type GoalCheckpoint,
   type GoalControlLease,
   type GoalExternalTurnStart,
@@ -28,7 +28,7 @@ type GoalStores = Pick<ExecutionStoresWriter<'interactive'>, 'sessionStore' | 'a
 export interface HostGoalCoordinatorOptions {
   readonly stores: GoalStores;
   readonly sessionAdmission: SessionAdmissionGate;
-  readonly evaluator: GoalEvaluatorDeps;
+  readonly evaluator: GoalEvaluatorResource;
   readonly admitTurn: (
     sessionId: string,
     text: string,
@@ -129,8 +129,9 @@ export class HostGoalCoordinator {
     this.#residencies.clear();
   }
 
-  close(): void {
+  close(): Promise<void> {
     this.beginDrain();
+    return this.continuation.close();
   }
 
   #query(sessionId: string): Promise<OperationOutcome<'goal.query'>> {

--- a/packages/runtime-host/src/server/goal-coordinator.ts
+++ b/packages/runtime-host/src/server/goal-coordinator.ts
@@ -10,7 +10,7 @@ import {
   type GoalEvaluatorResource,
   type GoalCheckpoint,
   type GoalControlLease,
-  type GoalExternalTurnStart,
+  type GoalObservedTurnStart,
   type GoalState,
   type GoalTaskGateTrace,
   type GoalTurnAdmission,
@@ -105,8 +105,8 @@ export class HostGoalCoordinator {
     return goal ? projectGoalState(goal) : null;
   }
 
-  beginExternalTurn(sessionId: string, turnId: string): GoalExternalTurnStart {
-    return this.continuation.beginExternalTurn(sessionId, turnId);
+  beginObservedTurn(sessionId: string, turnId: string): GoalObservedTurnStart {
+    return this.continuation.beginObservedTurn(sessionId, turnId);
   }
 
   matchesActive(

--- a/packages/runtime-host/src/server/goal-coordinator.ts
+++ b/packages/runtime-host/src/server/goal-coordinator.ts
@@ -1,0 +1,253 @@
+import { randomUUID } from 'node:crypto';
+import { userFacingText, type StoredMessage } from '@maka/core/session';
+import {
+  GoalContinuationCoordinator,
+  GoalManager,
+  GOAL_REASON_TEXT_LIMIT,
+  TERMINAL_GOAL_STATUSES,
+  buildGoalTools,
+  truncateGoalText,
+  type GoalEvaluatorDeps,
+  type GoalCheckpoint,
+  type GoalControlLease,
+  type GoalExternalTurnStart,
+  type GoalState,
+  type GoalTaskGateTrace,
+  type GoalTurnAdmission,
+  type MakaTool,
+} from '@maka/runtime';
+import { isSessionNotFoundError, type ExecutionStoresWriter } from '@maka/storage/execution-stores';
+import type { GoalControlInput, GoalProjection, OperationOutcome } from '../protocol/index.js';
+import type { RuntimeHostResidency } from './host-kernel.js';
+import type { GoalOperationHandlerMap } from './operation-dispatcher.js';
+import { projectGoalState } from './goal-projection.js';
+import { SessionAdmissionGate } from './session-admission-gate.js';
+
+type GoalStores = Pick<ExecutionStoresWriter<'interactive'>, 'sessionStore' | 'agentRunStore'>;
+
+export interface HostGoalCoordinatorOptions {
+  readonly stores: GoalStores;
+  readonly sessionAdmission: SessionAdmissionGate;
+  readonly evaluator: GoalEvaluatorDeps;
+  readonly admitTurn: (
+    sessionId: string,
+    text: string,
+    checkpoint: GoalCheckpoint,
+    controlLease: GoalControlLease,
+  ) => GoalTurnAdmission;
+  readonly listActionableTaskKeys: (sessionId: string) => Promise<string[]>;
+  readonly acquireResidency: () => RuntimeHostResidency;
+  readonly onProjectionChanged: (sessionId: string) => void;
+  readonly now?: () => number;
+  readonly newId?: () => string;
+}
+
+/** In-memory Runtime Host authority for one Goal generation per Session. */
+export class HostGoalCoordinator {
+  readonly handlers: GoalOperationHandlerMap = {
+    'goal.query': (input) => this.#query(input.sessionId),
+    'goal.control': (input) => this.#control(input),
+  };
+
+  readonly manager: GoalManager;
+  readonly continuation: GoalContinuationCoordinator;
+  readonly tools: readonly MakaTool[];
+  readonly #stores: GoalStores;
+  readonly #sessionAdmission: SessionAdmissionGate;
+  readonly #residencies = new Map<string, RuntimeHostResidency>();
+  readonly #onProjectionChanged: (sessionId: string) => void;
+  readonly #newId: () => string;
+  #draining = false;
+
+  constructor(options: HostGoalCoordinatorOptions) {
+    this.#stores = options.stores;
+    this.#sessionAdmission = options.sessionAdmission;
+    this.#onProjectionChanged = options.onProjectionChanged;
+    const now = options.now ?? Date.now;
+    this.#newId = options.newId ?? randomUUID;
+    this.manager = new GoalManager({
+      generateId: this.#newId,
+      now,
+      onChange: (goal) => {
+        this.#syncResidency(goal, options.acquireResidency);
+        this.#onProjectionChanged(goal.sessionId);
+      },
+    });
+    const tokenCache = new Map<string, number>();
+    this.continuation = new GoalContinuationCoordinator({
+      goalManager: this.manager,
+      evaluator: options.evaluator,
+      getRecentContext: async (sessionId) => {
+        const messages = await this.#stores.sessionStore.readMessagesSnapshot(sessionId);
+        tokenCache.set(sessionId, tokenCount(messages));
+        return recentContext(messages);
+      },
+      getTokenCount: (sessionId) => tokenCache.get(sessionId) ?? 0,
+      admitTurn: options.admitTurn,
+      taskGate: {
+        listActionableTaskKeys: options.listActionableTaskKeys,
+        recordDecision: (trace) => this.#recordTaskGateDecision(trace, now),
+      },
+    });
+    this.tools = Object.freeze(
+      buildGoalTools({
+        goalManager: this.manager,
+        goalContinuation: this.continuation,
+        getTokenCount: (sessionId) => tokenCache.get(sessionId) ?? 0,
+        isAvailable: () => !this.#draining,
+        now,
+      }),
+    );
+  }
+
+  readProjection(sessionId: string): GoalProjection | null {
+    const goal = this.manager.get(sessionId);
+    return goal ? projectGoalState(goal) : null;
+  }
+
+  beginExternalTurn(sessionId: string, turnId: string): GoalExternalTurnStart {
+    return this.continuation.beginExternalTurn(sessionId, turnId);
+  }
+
+  matchesActive(
+    sessionId: string,
+    checkpoint: GoalCheckpoint,
+    controlLease: GoalControlLease,
+  ): boolean {
+    return (
+      this.manager.matchesActive(sessionId, checkpoint) &&
+      this.manager.matchesControlLease(sessionId, controlLease)
+    );
+  }
+
+  beginDrain(): void {
+    if (this.#draining) return;
+    this.#draining = true;
+    this.continuation.dispose();
+    this.manager.dispose();
+    for (const residency of this.#residencies.values()) residency.release();
+    this.#residencies.clear();
+  }
+
+  close(): void {
+    this.beginDrain();
+  }
+
+  #query(sessionId: string): Promise<OperationOutcome<'goal.query'>> {
+    return this.#sessionAdmission.run(sessionId, async () => {
+      try {
+        await this.#stores.sessionStore.readHeaderSnapshot(sessionId);
+      } catch (error) {
+        if (isSessionNotFoundError(error)) return notFound('Session does not exist');
+        throw error;
+      }
+      return { ok: true, result: { sessionId, goal: this.readProjection(sessionId) } };
+    });
+  }
+
+  #control(input: GoalControlInput): Promise<OperationOutcome<'goal.control'>> {
+    return this.#sessionAdmission.run(input.sessionId, async () => {
+      let header;
+      try {
+        header = await this.#stores.sessionStore.readHeaderSnapshot(input.sessionId);
+      } catch (error) {
+        if (isSessionNotFoundError(error)) return notFound('Session does not exist');
+        throw error;
+      }
+      if (header.isArchived || header.status === 'archived') {
+        return sessionArchived('Archived Session Goal state cannot be controlled');
+      }
+      const current = this.manager.get(input.sessionId);
+      if (!current) return notFound('Session has no Goal in this Host Epoch');
+      if (current.id !== input.goalId || current.revision !== input.expectedRevision) {
+        return operationConflict('Goal generation or revision no longer matches');
+      }
+
+      let changed: GoalState | undefined;
+      if (input.action === 'pause') {
+        changed = this.manager.pause(input.sessionId);
+        if (changed) this.continuation.invalidateSession(input.sessionId);
+      } else if (input.action === 'resume') {
+        changed = this.continuation.resumeFromControl(input.sessionId, {
+          goalId: current.id,
+          revision: current.revision,
+        });
+      } else {
+        changed = this.manager.clear(input.sessionId);
+        if (changed) this.continuation.invalidateSession(input.sessionId);
+      }
+      if (!changed) {
+        return operationConflict(`Goal cannot ${input.action} from status ${current.status}`);
+      }
+      return {
+        ok: true,
+        result: { sessionId: input.sessionId, goal: projectGoalState(changed) },
+      };
+    });
+  }
+
+  #syncResidency(goal: GoalState, acquire: () => RuntimeHostResidency): void {
+    const retained = this.#residencies.get(goal.sessionId);
+    if (!TERMINAL_GOAL_STATUSES.has(goal.status)) {
+      if (!retained && !this.#draining) this.#residencies.set(goal.sessionId, acquire());
+      return;
+    }
+    retained?.release();
+    this.#residencies.delete(goal.sessionId);
+  }
+
+  async #recordTaskGateDecision(trace: GoalTaskGateTrace, now: () => number): Promise<void> {
+    const admission = await this.#stores.agentRunStore.readRootTurnAdmission(
+      trace.sessionId,
+      trace.turnId,
+    );
+    if (!admission) return;
+    await this.#stores.agentRunStore.appendEvent(trace.sessionId, admission.runId, {
+      type: 'task_gate_decided',
+      id: this.#newId(),
+      runId: admission.runId,
+      sessionId: trace.sessionId,
+      turnId: trace.turnId,
+      ts: now(),
+      message: `Task gate: ${trace.decision}`,
+      data: {
+        goalId: trace.goalId,
+        decision: trace.decision,
+        taskKeys: trace.taskKeys,
+      },
+    });
+  }
+}
+
+function recentContext(messages: readonly StoredMessage[]): string {
+  return messages
+    .filter(
+      (message): message is Extract<StoredMessage, { type: 'user' | 'assistant' }> =>
+        message.type === 'user' || message.type === 'assistant',
+    )
+    .slice(-6)
+    .map((message) => {
+      const text = message.type === 'user' ? userFacingText(message) : message.text;
+      return `[${message.type}]: ${truncateGoalText(text, GOAL_REASON_TEXT_LIMIT)}`;
+    })
+    .join('\n');
+}
+
+function tokenCount(messages: readonly StoredMessage[]): number {
+  return messages.reduce((total, message) => {
+    if (message.type !== 'token_usage') return total;
+    return total + (message.total ?? message.input + message.output);
+  }, 0);
+}
+
+function notFound(message: string) {
+  return { ok: false as const, error: { code: 'not_found' as const, message } };
+}
+
+function sessionArchived(message: string) {
+  return { ok: false as const, error: { code: 'session_archived' as const, message } };
+}
+
+function operationConflict(message: string) {
+  return { ok: false as const, error: { code: 'operation_conflict' as const, message } };
+}

--- a/packages/runtime-host/src/server/goal-projection.ts
+++ b/packages/runtime-host/src/server/goal-projection.ts
@@ -1,0 +1,43 @@
+import { GOAL_CONDITION_TEXT_LIMIT, GOAL_REASON_TEXT_LIMIT, type GoalState } from '@maka/runtime';
+import { decodeGoalProjection, type GoalProjection } from '../protocol/index.js';
+
+export function projectGoalState(goal: GoalState): GoalProjection {
+  return decodeGoalProjection({
+    goalId: goal.id,
+    revision: goal.revision,
+    sessionId: goal.sessionId,
+    condition: goal.condition,
+    status: goal.status,
+    setAt: goal.setAt,
+    iterations: goal.iterations,
+    maxIterations: goal.maxIterations,
+    consecutiveNoProgress: goal.consecutiveNoProgress,
+    blockCap: goal.blockCap,
+    tokenBudget: goal.tokenBudget ?? null,
+    tokensSpent: Math.max(0, goal.tokensNow - goal.tokensAtStart),
+    lastReason: goal.lastReason ?? null,
+    achievedAt: goal.achievedAt ?? null,
+    pausedAt: goal.pausedAt ?? null,
+  });
+}
+
+/** Reserves Session snapshot capacity for a Goal before one is created. */
+export function worstCaseGoalProjection(sessionId: string): GoalProjection {
+  return {
+    goalId: 'g'.repeat(128),
+    revision: Number.MAX_SAFE_INTEGER,
+    sessionId,
+    condition: '界'.repeat(GOAL_CONDITION_TEXT_LIMIT.codeUnits),
+    status: 'paused',
+    setAt: Number.MAX_SAFE_INTEGER,
+    iterations: Number.MAX_SAFE_INTEGER,
+    maxIterations: Number.MAX_SAFE_INTEGER,
+    consecutiveNoProgress: Number.MAX_SAFE_INTEGER,
+    blockCap: Number.MAX_SAFE_INTEGER,
+    tokenBudget: Number.MAX_SAFE_INTEGER,
+    tokensSpent: Number.MAX_SAFE_INTEGER,
+    lastReason: '界'.repeat(GOAL_REASON_TEXT_LIMIT.codeUnits),
+    achievedAt: Number.MAX_SAFE_INTEGER,
+    pausedAt: Number.MAX_SAFE_INTEGER,
+  };
+}

--- a/packages/runtime-host/src/server/message-coordinator.ts
+++ b/packages/runtime-host/src/server/message-coordinator.ts
@@ -67,6 +67,7 @@ export interface HostMessageSessionHeader {
 
 export type HostMessageRootState =
   | { readonly kind: 'idle' }
+  | { readonly kind: 'reserved' }
   | ({ readonly kind: 'active' } & RuntimeMessageRunIdentity);
 
 export interface HostMessageStartInput {
@@ -555,6 +556,9 @@ export class HostMessageCoordinator implements RuntimeMessageAuthority {
           }
           const result = { disposition: 'turn_started', turnId: started.turnId } as const;
           return success(result);
+        }
+        if (rootState.kind === 'reserved') {
+          return failure('session_busy', 'A Goal continuation is reserving the next root Turn');
         }
         const state = this.#requireState(input.sessionId);
         if (state.phase !== 'open') {

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -48,6 +48,7 @@ export type MessageOperationKey = Extract<
   'turn.message.submit' | 'queue.retract' | 'turn.interrupt'
 >;
 export type InteractionOperationKey = Extract<OperationKey, `interaction.${string}`>;
+export type GoalOperationKey = Extract<OperationKey, `goal.${string}`>;
 export type SessionContinuityOperationKey = Extract<
   OperationKey,
   'subscription.open' | 'subscription.close'
@@ -77,6 +78,7 @@ export type ConnectionEffectOperationHandlerMap = Pick<
 >;
 export type MessageOperationHandlerMap = Pick<OperationHandlerMap, MessageOperationKey>;
 export type InteractionOperationHandlerMap = Pick<OperationHandlerMap, InteractionOperationKey>;
+export type GoalOperationHandlerMap = Pick<OperationHandlerMap, GoalOperationKey>;
 export type SessionContinuityOperationHandlerMap = Pick<
   OperationHandlerMap,
   SessionContinuityOperationKey

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { isDeepStrictEqual } from 'node:util';
 import type { BackendStopMode } from '@maka/core/backend-types';
-import type { AgentRunHeader } from '@maka/core/agent-run';
+import type { AgentRunHeader, RootExecutionDescriptor } from '@maka/core/agent-run';
 import {
   messageContentsEqual,
   normalizeMessageContent,
@@ -21,6 +21,12 @@ import {
   type RuntimeHostedRootExecutionInput,
   type RuntimeMessageRunIdentity,
   type SessionManager,
+  type GoalExternalTurnSettler,
+  type GoalExternalTurnStart,
+  type GoalCheckpoint,
+  type GoalControlLease,
+  type GoalTurnAdmission,
+  type GoalTurnOutcome,
 } from '@maka/runtime';
 import {
   authenticateExecutionStoresWriter,
@@ -67,7 +73,10 @@ interface ActiveRootTurn {
   runId: string;
   userMessageId: string | null;
   execution?: RuntimeHostedRootExecutionInput;
-  admissionExecution: RootTurnAdmission['execution'];
+  descriptor: RootExecutionDescriptor;
+  externalGoalSettler?: GoalExternalTurnSettler;
+  goalOutcome: ValueDeferred<GoalTurnOutcome>;
+  observedGoalOutcome?: GoalTurnOutcome;
   startSettled: Deferred;
   done: Promise<void>;
   residency: RuntimeHostResidency;
@@ -100,11 +109,37 @@ interface Deferred {
   reject(error: unknown): void;
 }
 
+interface ValueDeferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+interface GoalRootReservation {
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly runId: string;
+  readonly userMessageId: string;
+  readonly checkpoint: GoalCheckpoint;
+  readonly controlLease: GoalControlLease;
+  readonly text: string;
+  readonly whenIdle: Deferred;
+  completion?: Promise<GoalTurnOutcome>;
+}
+
+export interface HostGoalRootAuthority {
+  beginExternalTurn(sessionId: string, turnId: string): GoalExternalTurnStart;
+  matchesActive(
+    sessionId: string,
+    checkpoint: GoalCheckpoint,
+    controlLease: GoalControlLease,
+  ): boolean;
+}
+
 interface RecoverySessionPlan {
   sessionId: string;
   admissions: readonly RootTurnAdmission[];
   missingMessages: readonly RecoveryUserMessage[];
-  pendingChildAdmissions: readonly RootTurnAdmission[];
+  pendingRecoveryClosures: readonly RootTurnAdmission[];
 }
 
 export class RootTurnCoordinator {
@@ -115,8 +150,10 @@ export class RootTurnCoordinator {
   };
 
   readonly #activeBySession = new Map<string, ActiveRootTurn>();
+  readonly #goalReservationsBySession = new Map<string, GoalRootReservation>();
   readonly #recoveryAdmissionsBySession = new Map<string, readonly RootTurnAdmission[]>();
   private readonly stores: ExecutionStoresWriter<'interactive'>;
+  #draining = false;
 
   constructor(
     private readonly manager: SessionManager,
@@ -128,7 +165,8 @@ export class RootTurnCoordinator {
     private readonly continuity: SessionContinuityCoordinator,
     private readonly acquireRecoveryResidency: () => RuntimeHostResidency,
     private readonly requestHostDrain: () => void,
-    private readonly clientCapabilities?: HostClientCapabilityCoordinator,
+    private readonly clientCapabilities: HostClientCapabilityCoordinator | undefined,
+    private readonly resolveGoal: () => HostGoalRootAuthority,
     private readonly assertAutomationRecoveryAdmission?: (admission: RootTurnAdmission) => void,
   ) {
     this.stores = authenticateExecutionStoresWriter(stores, 'interactive');
@@ -149,7 +187,7 @@ export class RootTurnCoordinator {
       const messageIndex = indexRecoveryMessages(messages);
       const pending: RootTurnAdmission[] = [];
       const missingMessages: RecoveryUserMessage[] = [];
-      const pendingChildAdmissions: RootTurnAdmission[] = [];
+      const pendingRecoveryClosures: RootTurnAdmission[] = [];
       for (const admission of admissions) {
         const run = runsById.get(admission.runId);
         const userMessages = messageIndex.userMessagesByTurnId.get(admission.turnId) ?? [];
@@ -184,7 +222,7 @@ export class RootTurnCoordinator {
             throw new Error(`Admitted Turn ${admission.turnId} must not record a UserMessage`);
           }
           if (!run) {
-            pendingChildAdmissions.push(admission);
+            pendingRecoveryClosures.push(admission);
             continue;
           }
           assertRunMatchesAdmission(run, admission);
@@ -196,7 +234,7 @@ export class RootTurnCoordinator {
           );
         }
         const messageIdOwner = messageIdOwners[0];
-        if (!run && executionContract.pendingWithoutRun === 'child_recovery_closure') {
+        if (!run && executionContract.pendingWithoutRun === 'host_recovery_closure') {
           if (userMessages.length > 1) {
             throw new Error(`Admitted Turn ${admission.turnId} has multiple UserMessages`);
           }
@@ -205,6 +243,7 @@ export class RootTurnCoordinator {
             if (
               messageIdOwner !== userMessage ||
               userMessage.id !== admission.userMessageId ||
+              !recoveryUserMessageOriginMatches(userMessage, admission.execution) ||
               !messageContentsEqual(
                 storedUserMessageContent(userMessage),
                 admission.normalizedInput,
@@ -220,7 +259,7 @@ export class RootTurnCoordinator {
             missingMessages.push(recoveredMessage);
             indexRecoveryMessage(messageIndex, recoveredMessage);
           }
-          pendingChildAdmissions.push(admission);
+          pendingRecoveryClosures.push(admission);
           continue;
         }
         if (!run) {
@@ -239,6 +278,7 @@ export class RootTurnCoordinator {
           if (
             messageIdOwner !== userMessage ||
             userMessage.id !== admission.userMessageId ||
+            !recoveryUserMessageOriginMatches(userMessage, admission.execution) ||
             !messageContentsEqual(storedUserMessageContent(userMessage), admission.normalizedInput)
           ) {
             throw new Error(`Admitted Turn ${admission.turnId} does not match its UserMessage`);
@@ -263,7 +303,7 @@ export class RootTurnCoordinator {
         sessionId: session.id,
         admissions,
         missingMessages,
-        pendingChildAdmissions,
+        pendingRecoveryClosures,
       });
     }
 
@@ -271,14 +311,14 @@ export class RootTurnCoordinator {
       for (const message of plan.missingMessages) {
         await this.stores.sessionStore.appendMessage(plan.sessionId, message);
       }
-      for (const admission of plan.pendingChildAdmissions) {
+      for (const admission of plan.pendingRecoveryClosures) {
         if (
           admission.execution.kind === 'external_message' ||
           admission.execution.kind === 'automation'
         ) {
-          throw new Error('Root-replay admission cannot use child recovery closure');
+          throw new Error('Root-replay admission cannot use Host recovery closure');
         }
-        await this.manager.closePendingHostedLinkedChildAdmission({
+        await this.manager.closePendingHostedAdmission({
           sessionId: admission.sessionId,
           turnId: admission.turnId,
           runId: admission.runId,
@@ -330,6 +370,7 @@ export class RootTurnCoordinator {
   }
 
   async close(): Promise<void> {
+    this.beginDrain();
     const errors: unknown[] = [];
     while (errors.length === 0) {
       const active = [...this.#activeBySession.entries()];
@@ -369,14 +410,150 @@ export class RootTurnCoordinator {
 
   readRootState(sessionId: string): HostMessageRootState {
     const active = this.#activeBySession.get(sessionId);
-    return active
-      ? {
-          kind: 'active',
-          sessionId,
-          turnId: active.turnId,
-          runId: active.runId,
+    if (active) {
+      return {
+        kind: 'active',
+        sessionId,
+        turnId: active.turnId,
+        runId: active.runId,
+      };
+    }
+    return this.#goalReservationsBySession.has(sessionId) ? { kind: 'reserved' } : { kind: 'idle' };
+  }
+
+  beginDrain(): void {
+    if (this.#draining) return;
+    this.#draining = true;
+    for (const reservation of this.#goalReservationsBySession.values()) {
+      reservation.whenIdle.resolve();
+    }
+    this.#goalReservationsBySession.clear();
+  }
+
+  admitGoalTurn(
+    sessionId: string,
+    checkpoint: GoalCheckpoint,
+    controlLease: GoalControlLease,
+    text: string,
+  ): GoalTurnAdmission {
+    if (this.#draining) {
+      return { kind: 'unavailable', reason: 'Runtime Host root authority is draining.' };
+    }
+    const active = this.#activeBySession.get(sessionId);
+    if (active) return { kind: 'busy', whenIdle: active.done };
+    const existing = this.#goalReservationsBySession.get(sessionId);
+    if (existing) return { kind: 'busy', whenIdle: existing.whenIdle.promise };
+
+    const reservation: GoalRootReservation = {
+      sessionId,
+      turnId: randomUUID(),
+      runId: randomUUID(),
+      userMessageId: randomUUID(),
+      checkpoint,
+      controlLease,
+      text,
+      whenIdle: deferred(),
+    };
+    this.#goalReservationsBySession.set(sessionId, reservation);
+    return {
+      kind: 'prepared',
+      turnId: reservation.turnId,
+      start: () => {
+        reservation.completion ??= this.#startGoalReservation(reservation);
+        return reservation.completion;
+      },
+    };
+  }
+
+  async #startGoalReservation(reservation: GoalRootReservation): Promise<GoalTurnOutcome> {
+    try {
+      if (this.#goalReservationsBySession.get(reservation.sessionId) !== reservation) {
+        return goalErrorOutcome(reservation.turnId, 'Goal continuation reservation was revoked.');
+      }
+      const disposition = await this.sessionAdmission.run(reservation.sessionId, async (lease) => {
+        if (
+          this.#draining ||
+          this.#goalReservationsBySession.get(reservation.sessionId) !== reservation
+        ) {
+          return undefined;
         }
-      : { kind: 'idle' };
+        if (this.#activeBySession.has(reservation.sessionId)) {
+          throw new RuntimeMessageAuthorityInvariantError(
+            'Goal root reservation overlapped an active root Turn',
+          );
+        }
+        let header: SessionHeader;
+        try {
+          header = await this.stores.sessionStore.readHeaderSnapshot(reservation.sessionId);
+        } catch (error) {
+          if (isSessionNotFoundError(error)) return undefined;
+          throw error;
+        }
+        if (header.status === 'archived' || header.isArchived) return undefined;
+        if (runtimeHostSessionUnavailableReason(header)) return undefined;
+        if (
+          !this.resolveGoal().matchesActive(
+            reservation.sessionId,
+            reservation.checkpoint,
+            reservation.controlLease,
+          )
+        ) {
+          return undefined;
+        }
+
+        const admitted = await this.rootAdmissionOwner.admitRootTurn({
+          sessionId: reservation.sessionId,
+          turnId: reservation.turnId,
+          proposedRunId: reservation.runId,
+          proposedUserMessageId: reservation.userMessageId,
+          execution: { kind: 'goal', goalId: reservation.checkpoint.goalId },
+          normalizedInput: { text: reservation.text },
+          sourceMessages: [],
+          admittedAt: Date.now(),
+        });
+        if (admitted.kind !== 'admitted') {
+          throw new RuntimeMessageAuthorityInvariantError(
+            'Fresh Goal root Turn identity already existed',
+          );
+        }
+        return this.prepareAdmittedTurn(
+          {
+            sessionId: reservation.sessionId,
+            turnId: reservation.turnId,
+            content: admitted.admission.normalizedInput,
+          },
+          admitted.admission,
+          this.acquireRecoveryResidency,
+          lease,
+          undefined,
+          undefined,
+          reservation,
+        );
+      });
+      if (!disposition) {
+        return goalErrorOutcome(
+          reservation.turnId,
+          'Goal continuation is unavailable for this Session.',
+        );
+      }
+      if (disposition.kind !== 'await_start') {
+        return goalErrorOutcome(
+          reservation.turnId,
+          disposition.outcome.ok
+            ? 'Goal continuation did not reserve execution.'
+            : disposition.outcome.error.message,
+        );
+      }
+      return await disposition.active.goalOutcome.promise;
+    } catch (error) {
+      this.requestHostDrain();
+      return goalErrorOutcome(reservation.turnId, errorMessage(error));
+    } finally {
+      if (this.#goalReservationsBySession.get(reservation.sessionId) === reservation) {
+        this.#goalReservationsBySession.delete(reservation.sessionId);
+      }
+      reservation.whenIdle.resolve();
+    }
   }
 
   executeRoot(input: RuntimeHostedRootExecutionInput): Promise<void> {
@@ -436,7 +613,10 @@ export class RootTurnCoordinator {
         if (unavailableReason) {
           throw new RuntimeHostedRootUnavailableError(input.sessionId, unavailableReason);
         }
-        if (this.#activeBySession.has(input.sessionId)) {
+        if (
+          this.#activeBySession.has(input.sessionId) ||
+          this.#goalReservationsBySession.has(input.sessionId)
+        ) {
           throw new RuntimeHostedRootConflictError(
             input.sessionId,
             'Session already has an active root Turn',
@@ -607,6 +787,9 @@ export class RootTurnCoordinator {
           'Message authority attempted an idle start while a root Turn was active',
         );
       }
+      if (this.#goalReservationsBySession.has(input.sessionId)) {
+        return { error: 'A Goal continuation is reserving the next root Turn' };
+      }
       const binding = await this.clientCapabilities?.bindSession(
         input.sessionId,
         input.initiatingConnectionId,
@@ -748,7 +931,10 @@ export class RootTurnCoordinator {
           return completedStart(operationUnavailable(unavailableReason));
         }
 
-        if (this.#activeBySession.has(input.sessionId)) {
+        if (
+          this.#activeBySession.has(input.sessionId) ||
+          this.#goalReservationsBySession.has(input.sessionId)
+        ) {
           return completedStart(sessionBusy('Session already has an active root Turn'));
         }
 
@@ -913,6 +1099,7 @@ export class RootTurnCoordinator {
     admissionLease: SessionAdmissionLease,
     replacing?: ActiveRootTurn,
     execution?: RuntimeHostedRootExecutionInput,
+    goalReservation?: GoalRootReservation,
   ): Promise<TurnStartDisposition> {
     if (admission.sessionId !== input.sessionId || admission.turnId !== input.turnId) {
       throw new Error('Root Turn admission identity does not match its input');
@@ -941,6 +1128,13 @@ export class RootTurnCoordinator {
     }
 
     const active = this.#activeBySession.get(input.sessionId);
+    const reservedGoal = this.#goalReservationsBySession.get(input.sessionId);
+    if (reservedGoal && reservedGoal !== goalReservation) {
+      return completedStart(sessionBusy('A Goal continuation is reserving the next root Turn'));
+    }
+    if (goalReservation && reservedGoal !== goalReservation) {
+      return completedStart(sessionBusy('Goal continuation reservation is no longer current'));
+    }
     if (replacing && active !== replacing) {
       throw new RuntimeMessageAuthorityInvariantError(
         'Follow-up root replacement lost the previous active Turn',
@@ -975,12 +1169,21 @@ export class RootTurnCoordinator {
       throw error;
     }
     const startSettled = deferred();
+    const goalOutcome = valueDeferred<GoalTurnOutcome>();
+    const goalRegistration =
+      admission.execution.kind === 'external_message'
+        ? this.resolveGoal().beginExternalTurn(input.sessionId, input.turnId)
+        : undefined;
     const entry: ActiveRootTurn = {
       turnId: input.turnId,
       runId,
       userMessageId: admission.userMessageId,
       ...(execution ? { execution } : {}),
-      admissionExecution: admission.execution,
+      descriptor: admission.execution,
+      ...(goalRegistration?.kind === 'registered'
+        ? { externalGoalSettler: goalRegistration.settle }
+        : {}),
+      goalOutcome,
       startSettled,
       done: Promise.resolve(),
       residency,
@@ -1031,6 +1234,7 @@ export class RootTurnCoordinator {
   ): Promise<void> {
     let terminalTransitionStarted = false;
     try {
+      const messageOrigin = rootExecutionMessageOrigin(active.descriptor);
       const stream = active.execution
         ? active.execution.start({
             runId: active.runId,
@@ -1047,14 +1251,7 @@ export class RootTurnCoordinator {
             {
               turnId: input.turnId,
               ...normalizeMessageContent(input.content),
-              ...(active.admissionExecution.kind === 'automation'
-                ? {
-                    origin: {
-                      kind: 'automation' as const,
-                      automationId: active.admissionExecution.automationId,
-                    },
-                  }
-                : {}),
+              ...(messageOrigin ? { origin: messageOrigin } : {}),
             },
             {
               runId: active.runId,
@@ -1098,6 +1295,7 @@ export class RootTurnCoordinator {
       if (snapshot.status === 'cancelled' && active.stopRequested) {
         startSettled.resolve();
       }
+      this.observeGoalOutcome(active, goalOutcomeFromSnapshot(snapshot));
       terminalTransitionStarted = true;
       await this.completeTerminalTransition(input.sessionId, active);
     } catch (error) {
@@ -1116,6 +1314,7 @@ export class RootTurnCoordinator {
             } catch (auditFailure) {
               executionAuditFailure = auditFailure;
             }
+            this.observeGoalOutcome(active, goalOutcomeFromSnapshot(snapshot));
             terminalTransitionStarted = true;
             await this.completeTerminalTransition(input.sessionId, active);
             containedRunFailure =
@@ -1134,6 +1333,10 @@ export class RootTurnCoordinator {
       }
       if (containedRunFailure) return;
       const commandFailure = executionAuditFailure ?? error;
+      this.observeGoalOutcome(
+        active,
+        goalErrorOutcome(active.turnId, errorMessage(commandFailure)),
+      );
       startSettled.reject(commandFailure);
       this.requestHostDrain();
       throw commandFailure;
@@ -1157,7 +1360,18 @@ export class RootTurnCoordinator {
         }
         active.residency.release();
       }
+      this.observeGoalOutcome(
+        active,
+        goalErrorOutcome(active.turnId, 'Runtime root Turn ended without a Goal outcome.'),
+      );
+      active.goalOutcome.resolve(active.observedGoalOutcome!);
     }
+  }
+
+  private observeGoalOutcome(active: ActiveRootTurn, outcome: GoalTurnOutcome): void {
+    if (active.observedGoalOutcome) return;
+    active.observedGoalOutcome = outcome;
+    if (active.externalGoalSettler) void active.externalGoalSettler(outcome);
   }
 
   private completeTerminalTransition(sessionId: string, active: ActiveRootTurn): Promise<void> {
@@ -1353,14 +1567,13 @@ export class RootTurnCoordinator {
     input: TurnStartInput,
     active: ActiveRootTurn,
   ): Promise<void> {
-    if (!active.execution) return;
     const completedRun = await this.readRunIfPresent(input.sessionId, active.runId);
     if (!completedRun) {
       throw new RuntimeMessageAuthorityInvariantError(
         'Hosted root execution completed without its admitted Run',
       );
     }
-    assertRunMatchesExecution(completedRun, input.turnId, active.execution.execution);
+    assertRunMatchesExecution(completedRun, input.turnId, active.descriptor);
   }
 
   private async runCommand<T>(operation: () => Promise<T>): Promise<T> {
@@ -1400,20 +1613,14 @@ function recoveryUserMessage(admission: RootTurnAdmission): RecoveryUserMessage 
   if (!admission.userMessageId) {
     throw new Error(`Admitted Turn ${admission.turnId} does not own a UserMessage`);
   }
+  const origin = rootExecutionMessageOrigin(admission.execution);
   return {
     type: 'user',
     id: admission.userMessageId,
     turnId: admission.turnId,
     ts: admission.admittedAt,
     ...normalizeMessageContent(admission.normalizedInput),
-    ...(admission.execution.kind === 'automation'
-      ? {
-          origin: {
-            kind: 'automation' as const,
-            automationId: admission.execution.automationId,
-          },
-        }
-      : {}),
+    ...(origin ? { origin } : {}),
   };
 }
 
@@ -1450,6 +1657,9 @@ function assertRunMatchesExecution(
         return;
       }
       break;
+    case 'goal':
+      if (run.goalId === execution.goalId) return;
+      break;
     case 'linked_child_initial':
     case 'claimed_agent_graph_intent':
       assertTrustedAgentIdentity(run, turnId, execution);
@@ -1471,7 +1681,7 @@ function assertRunMatchesExecution(
       assertNever(execution);
   }
   throw new RuntimeMessageAuthorityInvariantError(
-    `Admitted Turn ${turnId} changed its child execution lineage`,
+    `Admitted Turn ${turnId} changed its root execution identity`,
   );
 }
 
@@ -1480,7 +1690,7 @@ function assertTrustedAgentIdentity(
   turnId: string,
   execution: Exclude<
     RootTurnAdmission['execution'],
-    { kind: 'external_message' } | { kind: 'automation' }
+    { kind: 'external_message' | 'automation' | 'goal' }
   >,
 ): void {
   if (run.agentId !== execution.agentId || run.agentName !== execution.agentName) {
@@ -1493,7 +1703,7 @@ function assertTrustedAgentIdentity(
 interface RecoveryExecutionContract {
   allowsQueueSources: boolean;
   requiresUserMessage: boolean;
-  pendingWithoutRun: 'root_replay' | 'child_recovery_closure';
+  pendingWithoutRun: 'root_replay' | 'host_recovery_closure';
 }
 
 function recoveryExecutionContract(
@@ -1512,19 +1722,25 @@ function recoveryExecutionContract(
         requiresUserMessage: true,
         pendingWithoutRun: 'root_replay',
       };
+    case 'goal':
+      return {
+        allowsQueueSources: false,
+        requiresUserMessage: true,
+        pendingWithoutRun: 'host_recovery_closure',
+      };
     case 'linked_child_initial':
     case 'linked_child_resume':
     case 'claimed_agent_graph_intent':
       return {
         allowsQueueSources: false,
         requiresUserMessage: true,
-        pendingWithoutRun: 'child_recovery_closure',
+        pendingWithoutRun: 'host_recovery_closure',
       };
     case 'linked_child_provider_retry':
       return {
         allowsQueueSources: false,
         requiresUserMessage: false,
-        pendingWithoutRun: 'child_recovery_closure',
+        pendingWithoutRun: 'host_recovery_closure',
       };
     default:
       return assertNever(execution);
@@ -1546,6 +1762,25 @@ function indexRecoveryMessages(messages: readonly StoredMessage[]): RecoveryMess
 
 function storedUserMessageContent(message: RecoveryUserMessage): MessageContent {
   return normalizeMessageContent(message);
+}
+
+function recoveryUserMessageOriginMatches(
+  message: RecoveryUserMessage,
+  execution: RootTurnAdmission['execution'],
+): boolean {
+  const expected = rootExecutionMessageOrigin(execution);
+  return expected === undefined || isDeepStrictEqual(message.origin, expected);
+}
+
+function rootExecutionMessageOrigin(execution: RootExecutionDescriptor) {
+  switch (execution.kind) {
+    case 'automation':
+      return { kind: 'automation' as const, automationId: execution.automationId };
+    case 'goal':
+      return { kind: 'goal' as const, goalId: execution.goalId };
+    default:
+      return undefined;
+  }
 }
 
 function indexRecoveryMessage(index: RecoveryMessageIndex, message: StoredMessage): void {
@@ -1586,6 +1821,47 @@ function deferred(): Deferred {
       rejectPromise(error);
     },
   };
+}
+
+function valueDeferred<T>(): ValueDeferred<T> {
+  let settled = false;
+  let resolvePromise!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value) {
+      if (settled) return;
+      settled = true;
+      resolvePromise(value);
+    },
+  };
+}
+
+function goalOutcomeFromSnapshot(snapshot: TurnSnapshot): GoalTurnOutcome {
+  if (snapshot.status === 'completed') {
+    return { kind: 'completed', turnId: snapshot.turnId };
+  }
+  if (snapshot.status === 'cancelled') {
+    return { kind: 'aborted', turnId: snapshot.turnId };
+  }
+  if (snapshot.status === 'failed') {
+    return {
+      kind: 'errored',
+      turnId: snapshot.turnId,
+      reason: `Turn ended with ${snapshot.failureClass}`,
+    };
+  }
+  return goalErrorOutcome(snapshot.turnId, `Turn ended in non-terminal status ${snapshot.status}`);
+}
+
+function goalErrorOutcome(turnId: string, reason: string): GoalTurnOutcome {
+  return { kind: 'errored', turnId, reason };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isMissingFile(error: unknown): boolean {

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import { isDeepStrictEqual } from 'node:util';
 import type { BackendStopMode } from '@maka/core/backend-types';
-import type { AgentRunHeader, RootExecutionDescriptor } from '@maka/core/agent-run';
+import {
+  agentRunMatchesHostedRootExecution,
+  type AgentRunHeader,
+  type RootExecutionDescriptor,
+} from '@maka/core/agent-run';
 import {
   messageContentsEqual,
   normalizeMessageContent,
@@ -21,8 +25,8 @@ import {
   type RuntimeHostedRootExecutionInput,
   type RuntimeMessageRunIdentity,
   type SessionManager,
-  type GoalExternalTurnSettler,
-  type GoalExternalTurnStart,
+  type GoalObservedTurnSettler,
+  type GoalObservedTurnStart,
   type GoalCheckpoint,
   type GoalControlLease,
   type GoalTurnAdmission,
@@ -74,7 +78,7 @@ interface ActiveRootTurn {
   userMessageId: string | null;
   execution?: RuntimeHostedRootExecutionInput;
   descriptor: RootExecutionDescriptor;
-  externalGoalSettler?: GoalExternalTurnSettler;
+  observedGoalSettler?: GoalObservedTurnSettler;
   goalOutcome: ValueDeferred<GoalTurnOutcome>;
   observedGoalOutcome?: GoalTurnOutcome;
   startSettled: Deferred;
@@ -114,20 +118,25 @@ interface ValueDeferred<T> {
   resolve(value: T): void;
 }
 
-interface GoalRootReservation {
+interface RootTurnReservation {
   readonly sessionId: string;
+  readonly whenIdle: Deferred;
+  readonly admissionSettled: Deferred;
+  admissionPhase: 'prepared' | 'committing';
+}
+
+interface GoalRootReservation extends RootTurnReservation {
   readonly turnId: string;
   readonly runId: string;
   readonly userMessageId: string;
   readonly checkpoint: GoalCheckpoint;
   readonly controlLease: GoalControlLease;
   readonly text: string;
-  readonly whenIdle: Deferred;
   completion?: Promise<GoalTurnOutcome>;
 }
 
 export interface HostGoalRootAuthority {
-  beginExternalTurn(sessionId: string, turnId: string): GoalExternalTurnStart;
+  beginObservedTurn(sessionId: string, turnId: string): GoalObservedTurnStart;
   matchesActive(
     sessionId: string,
     checkpoint: GoalCheckpoint,
@@ -150,7 +159,7 @@ export class RootTurnCoordinator {
   };
 
   readonly #activeBySession = new Map<string, ActiveRootTurn>();
-  readonly #goalReservationsBySession = new Map<string, GoalRootReservation>();
+  readonly #reservationsBySession = new Map<string, RootTurnReservation>();
   readonly #recoveryAdmissionsBySession = new Map<string, readonly RootTurnAdmission[]>();
   private readonly stores: ExecutionStoresWriter<'interactive'>;
   #draining = false;
@@ -371,6 +380,11 @@ export class RootTurnCoordinator {
 
   async close(): Promise<void> {
     this.beginDrain();
+    await Promise.all(
+      [...this.#reservationsBySession.values()].map(
+        (reservation) => reservation.admissionSettled.promise,
+      ),
+    );
     const errors: unknown[] = [];
     while (errors.length === 0) {
       const active = [...this.#activeBySession.entries()];
@@ -418,16 +432,51 @@ export class RootTurnCoordinator {
         runId: active.runId,
       };
     }
-    return this.#goalReservationsBySession.has(sessionId) ? { kind: 'reserved' } : { kind: 'idle' };
+    return this.#reservationsBySession.has(sessionId) ? { kind: 'reserved' } : { kind: 'idle' };
+  }
+
+  private reserveRootTurn(sessionId: string): RootTurnReservation | undefined {
+    if (
+      this.#draining ||
+      this.#activeBySession.has(sessionId) ||
+      this.#reservationsBySession.has(sessionId)
+    ) {
+      return undefined;
+    }
+    const reservation: RootTurnReservation = {
+      sessionId,
+      whenIdle: deferred(),
+      admissionSettled: deferred(),
+      admissionPhase: 'prepared',
+    };
+    this.#reservationsBySession.set(sessionId, reservation);
+    return reservation;
+  }
+
+  private beginRootAdmission(reservation: RootTurnReservation): boolean {
+    if (this.#reservationsBySession.get(reservation.sessionId) !== reservation) return false;
+    if (reservation.admissionPhase === 'committing') return true;
+    if (this.#draining) return false;
+    reservation.admissionPhase = 'committing';
+    return true;
+  }
+
+  private releaseRootReservation(reservation: RootTurnReservation): void {
+    if (this.#reservationsBySession.get(reservation.sessionId) !== reservation) return;
+    this.#reservationsBySession.delete(reservation.sessionId);
+    reservation.admissionSettled.resolve();
+    reservation.whenIdle.resolve();
   }
 
   beginDrain(): void {
     if (this.#draining) return;
     this.#draining = true;
-    for (const reservation of this.#goalReservationsBySession.values()) {
+    for (const reservation of this.#reservationsBySession.values()) {
+      if (reservation.admissionPhase === 'committing') continue;
+      this.#reservationsBySession.delete(reservation.sessionId);
+      reservation.admissionSettled.resolve();
       reservation.whenIdle.resolve();
     }
-    this.#goalReservationsBySession.clear();
   }
 
   admitGoalTurn(
@@ -441,7 +490,7 @@ export class RootTurnCoordinator {
     }
     const active = this.#activeBySession.get(sessionId);
     if (active) return { kind: 'busy', whenIdle: active.done };
-    const existing = this.#goalReservationsBySession.get(sessionId);
+    const existing = this.#reservationsBySession.get(sessionId);
     if (existing) return { kind: 'busy', whenIdle: existing.whenIdle.promise };
 
     const reservation: GoalRootReservation = {
@@ -453,8 +502,10 @@ export class RootTurnCoordinator {
       controlLease,
       text,
       whenIdle: deferred(),
+      admissionSettled: deferred(),
+      admissionPhase: 'prepared',
     };
-    this.#goalReservationsBySession.set(sessionId, reservation);
+    this.#reservationsBySession.set(sessionId, reservation);
     return {
       kind: 'prepared',
       turnId: reservation.turnId,
@@ -467,13 +518,13 @@ export class RootTurnCoordinator {
 
   async #startGoalReservation(reservation: GoalRootReservation): Promise<GoalTurnOutcome> {
     try {
-      if (this.#goalReservationsBySession.get(reservation.sessionId) !== reservation) {
+      if (this.#reservationsBySession.get(reservation.sessionId) !== reservation) {
         return goalErrorOutcome(reservation.turnId, 'Goal continuation reservation was revoked.');
       }
       const disposition = await this.sessionAdmission.run(reservation.sessionId, async (lease) => {
         if (
           this.#draining ||
-          this.#goalReservationsBySession.get(reservation.sessionId) !== reservation
+          this.#reservationsBySession.get(reservation.sessionId) !== reservation
         ) {
           return undefined;
         }
@@ -500,6 +551,8 @@ export class RootTurnCoordinator {
         ) {
           return undefined;
         }
+
+        if (!this.beginRootAdmission(reservation)) return undefined;
 
         const admitted = await this.rootAdmissionOwner.admitRootTurn({
           sessionId: reservation.sessionId,
@@ -549,20 +602,25 @@ export class RootTurnCoordinator {
       this.requestHostDrain();
       return goalErrorOutcome(reservation.turnId, errorMessage(error));
     } finally {
-      if (this.#goalReservationsBySession.get(reservation.sessionId) === reservation) {
-        this.#goalReservationsBySession.delete(reservation.sessionId);
-      }
-      reservation.whenIdle.resolve();
+      this.releaseRootReservation(reservation);
     }
   }
 
   executeRoot(input: RuntimeHostedRootExecutionInput): Promise<void> {
     return this.runCommand(async () => {
+      const activeAtEntry = this.#activeBySession.has(input.sessionId);
+      let reservation = activeAtEntry ? undefined : this.reserveRootTurn(input.sessionId);
+      if (!activeAtEntry && !reservation) {
+        throw new RuntimeHostedRootConflictError(
+          input.sessionId,
+          'Session already has a pending root Turn',
+        );
+      }
       const canonicalInput = {
         ...input,
         content: normalizeMessageContent(input.content),
       };
-      const disposition = await this.sessionAdmission.run(input.sessionId, async (lease) => {
+      const admissionTask = this.sessionAdmission.run(input.sessionId, async (lease) => {
         const existing = await this.stores.agentRunStore.readRootTurnAdmission(
           input.sessionId,
           input.turnId,
@@ -587,6 +645,15 @@ export class RootTurnCoordinator {
             lease,
             undefined,
             canonicalInput,
+            reservation,
+          );
+        }
+
+        reservation ??= this.reserveRootTurn(input.sessionId);
+        if (!reservation) {
+          throw new RuntimeHostedRootConflictError(
+            input.sessionId,
+            'Session already has an active or pending root Turn',
           );
         }
 
@@ -613,13 +680,16 @@ export class RootTurnCoordinator {
         if (unavailableReason) {
           throw new RuntimeHostedRootUnavailableError(input.sessionId, unavailableReason);
         }
-        if (
-          this.#activeBySession.has(input.sessionId) ||
-          this.#goalReservationsBySession.has(input.sessionId)
-        ) {
+        if (this.#activeBySession.has(input.sessionId)) {
           throw new RuntimeHostedRootConflictError(
             input.sessionId,
             'Session already has an active root Turn',
+          );
+        }
+        if (reservation && this.#reservationsBySession.get(input.sessionId) !== reservation) {
+          throw new RuntimeHostedRootConflictError(
+            input.sessionId,
+            'Hosted root execution lost its pending reservation',
           );
         }
         if (canonicalInput.admitExecution) {
@@ -634,6 +704,12 @@ export class RootTurnCoordinator {
               new Error('Turn start was cancelled before runtime admission'),
             );
           }
+        }
+        if (!reservation || !this.beginRootAdmission(reservation)) {
+          throw new RuntimeHostedRootConflictError(
+            input.sessionId,
+            'Hosted root execution lost its pending reservation',
+          );
         }
         const admitted = await this.rootAdmissionOwner.admitRootTurn({
           sessionId: input.sessionId,
@@ -663,7 +739,11 @@ export class RootTurnCoordinator {
           lease,
           undefined,
           canonicalInput,
+          reservation,
         );
+      });
+      const disposition = await admissionTask.finally(() => {
+        if (reservation) this.releaseRootReservation(reservation);
       });
       if (disposition.kind === 'complete') {
         if (!disposition.outcome.ok) {
@@ -787,43 +867,52 @@ export class RootTurnCoordinator {
           'Message authority attempted an idle start while a root Turn was active',
         );
       }
-      if (this.#goalReservationsBySession.has(input.sessionId)) {
-        return { error: 'A Goal continuation is reserving the next root Turn' };
-      }
-      const binding = await this.clientCapabilities?.bindSession(
-        input.sessionId,
-        input.initiatingConnectionId,
-      );
-      if (binding && !binding.ok) return { error: binding.message };
+      const reservation = this.reserveRootTurn(input.sessionId);
+      if (!reservation) return { error: 'Another root Turn is being admitted' };
+      try {
+        const binding = await this.clientCapabilities?.bindSession(
+          input.sessionId,
+          input.initiatingConnectionId,
+        );
+        if (binding && !binding.ok) return { error: binding.message };
+        if (!this.beginRootAdmission(reservation)) {
+          return { error: 'Root Turn reservation is no longer current' };
+        }
 
-      const turnId = randomUUID();
-      const admitted = await this.rootAdmissionOwner.admitRootTurn({
-        sessionId: input.sessionId,
-        turnId,
-        proposedRunId: randomUUID(),
-        proposedUserMessageId: input.sourceMessage.messageId,
-        execution: { kind: 'external_message' },
-        normalizedInput: content,
-        sourceMessages: [input.sourceMessage],
-        admittedAt: Date.now(),
-      });
-      if (admitted.kind !== 'admitted') {
-        throw new RuntimeMessageAuthorityInvariantError(
-          'Fresh Message root Turn identity already existed',
+        const turnId = randomUUID();
+        const admitted = await this.rootAdmissionOwner.admitRootTurn({
+          sessionId: input.sessionId,
+          turnId,
+          proposedRunId: randomUUID(),
+          proposedUserMessageId: input.sourceMessage.messageId,
+          execution: { kind: 'external_message' },
+          normalizedInput: content,
+          sourceMessages: [input.sourceMessage],
+          admittedAt: Date.now(),
+        });
+        if (admitted.kind !== 'admitted') {
+          throw new RuntimeMessageAuthorityInvariantError(
+            'Fresh Message root Turn identity already existed',
+          );
+        }
+        const disposition = await this.prepareAdmittedTurn(
+          { sessionId: input.sessionId, turnId, content },
+          admitted.admission,
+          this.acquireRecoveryResidency,
+          admissionLease,
+          undefined,
+          undefined,
+          reservation,
         );
+        if (disposition.kind !== 'await_start') {
+          throw new RuntimeMessageAuthorityInvariantError(
+            'Fresh Message root Turn did not reserve execution',
+          );
+        }
+        return { turnId };
+      } finally {
+        this.releaseRootReservation(reservation);
       }
-      const disposition = await this.prepareAdmittedTurn(
-        { sessionId: input.sessionId, turnId, content },
-        admitted.admission,
-        this.acquireRecoveryResidency,
-        admissionLease,
-      );
-      if (disposition.kind !== 'await_start') {
-        throw new RuntimeMessageAuthorityInvariantError(
-          'Fresh Message root Turn did not reserve execution',
-        );
-      }
-      return { turnId };
     });
   }
 
@@ -874,7 +963,12 @@ export class RootTurnCoordinator {
         ...input,
         content: normalizeMessageContent(input.content),
       };
-      const disposition = await this.sessionAdmission.run(input.sessionId, async (lease) => {
+      const activeAtEntry = this.#activeBySession.has(input.sessionId);
+      let reservation = activeAtEntry ? undefined : this.reserveRootTurn(input.sessionId);
+      if (!activeAtEntry && !reservation) {
+        return sessionBusy('Session already has a pending root Turn');
+      }
+      const admissionTask = this.sessionAdmission.run(input.sessionId, async (lease) => {
         const existing = await this.stores.agentRunStore.readRootTurnAdmission(
           input.sessionId,
           input.turnId,
@@ -911,7 +1005,15 @@ export class RootTurnCoordinator {
             existing,
             context.acquireResidency,
             lease,
+            undefined,
+            undefined,
+            reservation,
           );
+        }
+
+        reservation ??= this.reserveRootTurn(input.sessionId);
+        if (!reservation) {
+          return completedStart(sessionBusy('Session already has an active or pending root Turn'));
         }
 
         let header: SessionHeader;
@@ -931,11 +1033,11 @@ export class RootTurnCoordinator {
           return completedStart(operationUnavailable(unavailableReason));
         }
 
-        if (
-          this.#activeBySession.has(input.sessionId) ||
-          this.#goalReservationsBySession.has(input.sessionId)
-        ) {
+        if (this.#activeBySession.has(input.sessionId)) {
           return completedStart(sessionBusy('Session already has an active root Turn'));
+        }
+        if (reservation && this.#reservationsBySession.get(input.sessionId) !== reservation) {
+          return completedStart(sessionBusy('Root Turn reservation is no longer current'));
         }
 
         const binding = await this.clientCapabilities?.bindSession(
@@ -944,6 +1046,9 @@ export class RootTurnCoordinator {
         );
         if (binding && !binding.ok) {
           return completedStart(operationConflict(binding.message));
+        }
+        if (!reservation || !this.beginRootAdmission(reservation)) {
+          return completedStart(sessionBusy('Root Turn reservation is no longer current'));
         }
         const admission = await this.rootAdmissionOwner.admitRootTurn({
           sessionId: input.sessionId,
@@ -973,7 +1078,13 @@ export class RootTurnCoordinator {
           admission.admission,
           context.acquireResidency,
           lease,
+          undefined,
+          undefined,
+          reservation,
         );
+      });
+      const disposition = await admissionTask.finally(() => {
+        if (reservation) this.releaseRootReservation(reservation);
       });
       return this.resolveStartDisposition(canonicalInput, disposition);
     });
@@ -1099,7 +1210,7 @@ export class RootTurnCoordinator {
     admissionLease: SessionAdmissionLease,
     replacing?: ActiveRootTurn,
     execution?: RuntimeHostedRootExecutionInput,
-    goalReservation?: GoalRootReservation,
+    rootReservation?: RootTurnReservation,
   ): Promise<TurnStartDisposition> {
     if (admission.sessionId !== input.sessionId || admission.turnId !== input.turnId) {
       throw new Error('Root Turn admission identity does not match its input');
@@ -1128,12 +1239,12 @@ export class RootTurnCoordinator {
     }
 
     const active = this.#activeBySession.get(input.sessionId);
-    const reservedGoal = this.#goalReservationsBySession.get(input.sessionId);
-    if (reservedGoal && reservedGoal !== goalReservation) {
-      return completedStart(sessionBusy('A Goal continuation is reserving the next root Turn'));
+    const currentReservation = this.#reservationsBySession.get(input.sessionId);
+    if (currentReservation && currentReservation !== rootReservation) {
+      return completedStart(sessionBusy('Another root Turn is being admitted'));
     }
-    if (goalReservation && reservedGoal !== goalReservation) {
-      return completedStart(sessionBusy('Goal continuation reservation is no longer current'));
+    if (rootReservation && currentReservation !== rootReservation) {
+      return completedStart(sessionBusy('Root Turn reservation is no longer current'));
     }
     if (replacing && active !== replacing) {
       throw new RuntimeMessageAuthorityInvariantError(
@@ -1145,6 +1256,9 @@ export class RootTurnCoordinator {
         return completedStart(sessionBusy('Session already has an active root Turn'));
       }
       return { kind: 'await_start', active };
+    }
+    if (rootReservation && !this.beginRootAdmission(rootReservation)) {
+      return completedStart(sessionBusy('Root Turn reservation is no longer current'));
     }
 
     const residency = acquireResidency();
@@ -1171,8 +1285,8 @@ export class RootTurnCoordinator {
     const startSettled = deferred();
     const goalOutcome = valueDeferred<GoalTurnOutcome>();
     const goalRegistration =
-      admission.execution.kind === 'external_message'
-        ? this.resolveGoal().beginExternalTurn(input.sessionId, input.turnId)
+      admission.execution.kind !== 'goal'
+        ? this.resolveGoal().beginObservedTurn(input.sessionId, input.turnId)
         : undefined;
     const entry: ActiveRootTurn = {
       turnId: input.turnId,
@@ -1181,7 +1295,7 @@ export class RootTurnCoordinator {
       ...(execution ? { execution } : {}),
       descriptor: admission.execution,
       ...(goalRegistration?.kind === 'registered'
-        ? { externalGoalSettler: goalRegistration.settle }
+        ? { observedGoalSettler: goalRegistration.settle }
         : {}),
       goalOutcome,
       startSettled,
@@ -1196,9 +1310,24 @@ export class RootTurnCoordinator {
         'Follow-up root replacement changed during execution reservation',
       );
     }
+    if (rootReservation) {
+      if (this.#reservationsBySession.get(input.sessionId) !== rootReservation) {
+        throw new RuntimeMessageAuthorityInvariantError(
+          'Root Turn activation lost its committing reservation',
+        );
+      }
+    }
     this.#activeBySession.set(input.sessionId, entry);
     entry.done = this.drainTurn(input, entry, startSettled);
     void entry.done.catch(() => undefined);
+    if (rootReservation) {
+      this.#reservationsBySession.delete(input.sessionId);
+      rootReservation.admissionSettled.resolve();
+      void entry.done.then(
+        () => rootReservation.whenIdle.resolve(),
+        () => rootReservation.whenIdle.resolve(),
+      );
+    }
     return { kind: 'await_start', active: entry };
   }
 
@@ -1371,7 +1500,7 @@ export class RootTurnCoordinator {
   private observeGoalOutcome(active: ActiveRootTurn, outcome: GoalTurnOutcome): void {
     if (active.observedGoalOutcome) return;
     active.observedGoalOutcome = outcome;
-    if (active.externalGoalSettler) void active.externalGoalSettler(outcome);
+    if (active.observedGoalSettler) void active.observedGoalSettler(outcome);
   }
 
   private completeTerminalTransition(sessionId: string, active: ActiveRootTurn): Promise<void> {
@@ -1642,23 +1771,8 @@ function assertRunMatchesExecution(
     case 'external_message':
       return;
     case 'automation':
-      if (
-        run.automationId === execution.automationId &&
-        run.parentRunId === undefined &&
-        run.resumedFromRunId === undefined &&
-        run.retriedFromRunId === undefined &&
-        run.parentSessionId === undefined &&
-        run.agentId === undefined &&
-        run.agentName === undefined &&
-        run.continuationSource === undefined &&
-        run.agentGraphWakeId === undefined &&
-        run.agentGraphWakeAttemptId === undefined
-      ) {
-        return;
-      }
-      break;
     case 'goal':
-      if (run.goalId === execution.goalId) return;
+      if (agentRunMatchesHostedRootExecution(run, execution)) return;
       break;
     case 'linked_child_initial':
     case 'claimed_agent_graph_intent':

--- a/packages/runtime/src/__tests__/cost.test.ts
+++ b/packages/runtime/src/__tests__/cost.test.ts
@@ -85,7 +85,6 @@ describe('recordLlmCall', () => {
           insertLlmCall: async (record) => {
             inserted.push(record);
           },
-          insertToolInvocation: async () => {},
         },
         lookupPricing: () => {
           throw new Error('lookup should not run when costUsd is already present');
@@ -122,7 +121,6 @@ describe('recordLlmCall', () => {
             inserted.push(record);
             return publication;
           },
-          insertToolInvocation: async () => {},
         },
         lookupPricing: () => null,
       },
@@ -220,7 +218,6 @@ describe('recordLlmCall', () => {
               insertLlmCall: async () => {
                 throw new Error('publication failed');
               },
-              insertToolInvocation: async () => {},
             },
             lookupPricing: () => null,
           },
@@ -256,7 +253,6 @@ describe('recordToolInvocation', () => {
     const recording = recordToolInvocation(
       {
         repo: {
-          insertLlmCall: async () => {},
           insertToolInvocation: (record) => {
             inserted.push(record);
             return publication;
@@ -304,7 +300,6 @@ describe('recordToolInvocation', () => {
         recordToolInvocation(
           {
             repo: {
-              insertLlmCall: async () => {},
               insertToolInvocation: async () => {
                 throw new Error('publication failed');
               },

--- a/packages/runtime/src/__tests__/goal-continuation.test.ts
+++ b/packages/runtime/src/__tests__/goal-continuation.test.ts
@@ -42,6 +42,10 @@ function controlledCall<T>() {
       return result.promise;
     },
     started,
+    settled: result.promise.then(
+      () => undefined,
+      () => undefined,
+    ),
     resolve: result.resolve,
     reject: result.reject,
   };
@@ -142,6 +146,7 @@ function setup(opts?: {
         const next = { ...defaultEvaluation, ...evaluationQueue.shift() };
         return JSON.stringify(next);
       },
+      close: async () => {},
     },
     getRecentContext: async () => 'recent context',
     getTokenCount: opts?.tokenCount !== undefined ? () => opts.tokenCount! : undefined,
@@ -833,6 +838,34 @@ describe('GoalContinuationCoordinator settlement', () => {
       '{"met":false,"impossible":false,"progress":true,"waiting":false,"reason":"late"}',
     );
 
+    await pending;
+    assert.equal(manager.get(SESSION)?.iterations, 0);
+    assert.equal(admitted.length, 0);
+  });
+
+  test('close waits for accepted evaluator resource cleanup', async () => {
+    const { manager, coordinator, deps, admitted } = setup();
+    const evaluation = controlledCall<string>();
+    deps.evaluator.evaluate = evaluation.invoke;
+    deps.evaluator.close = () => evaluation.settled;
+    manager.create(SESSION, 'ship');
+
+    const pending = settleExternal(coordinator, SESSION, {
+      kind: 'completed',
+      turnId: 'turn-1',
+    });
+    await evaluation.started;
+    let closeSettled = false;
+    const closing = coordinator.close().then(() => {
+      closeSettled = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(closeSettled, false);
+
+    evaluation.resolve(
+      '{"met":false,"impossible":false,"progress":true,"waiting":false,"reason":"late"}',
+    );
+    await closing;
     await pending;
     assert.equal(manager.get(SESSION)?.iterations, 0);
     assert.equal(admitted.length, 0);

--- a/packages/runtime/src/__tests__/goal-continuation.test.ts
+++ b/packages/runtime/src/__tests__/goal-continuation.test.ts
@@ -186,17 +186,17 @@ function settleExternal(
   outcome: GoalTurnOutcome,
 ): Promise<void> {
   assert.ok(outcome.turnId, 'an external turn must have a stable identity before it starts');
-  const registration = coordinator.beginExternalTurn(sessionId, outcome.turnId);
+  const registration = coordinator.beginObservedTurn(sessionId, outcome.turnId);
   assert.equal(registration.kind, 'registered');
   return registration.settle(outcome);
 }
 
-function registerExternalTurn(
+function registerObservedTurn(
   coordinator: GoalContinuationCoordinator,
   sessionId: string,
   turnId: string,
 ) {
-  const registration = coordinator.beginExternalTurn(sessionId, turnId);
+  const registration = coordinator.beginObservedTurn(sessionId, turnId);
   assert.equal(registration.kind, 'registered');
   return registration.settle;
 }
@@ -224,7 +224,7 @@ describe('GoalContinuationCoordinator settlement', () => {
     const { manager, coordinator } = setup({
       evaluations: [{ met: true, reason: 'same-turn Goal verified' }],
     });
-    const settle = registerExternalTurn(coordinator, SESSION, 'turn-owner');
+    const settle = registerObservedTurn(coordinator, SESSION, 'turn-owner');
     const tools = goalToolsFor(manager, coordinator);
     const set = tools.find((tool) => tool.name === GOAL_SET_TOOL_NAME);
     assert.ok(set);
@@ -245,8 +245,8 @@ describe('GoalContinuationCoordinator settlement', () => {
       evaluations++;
       return evaluate(...args);
     };
-    const settleOther = registerExternalTurn(coordinator, SESSION, 'turn-other');
-    const settleOwner = registerExternalTurn(coordinator, SESSION, 'turn-owner');
+    const settleOther = registerObservedTurn(coordinator, SESSION, 'turn-other');
+    const settleOwner = registerObservedTurn(coordinator, SESSION, 'turn-owner');
     const set = goalToolsFor(manager, coordinator).find((tool) => tool.name === GOAL_SET_TOOL_NAME);
     assert.ok(set);
     await set.impl({ condition: 'ship' }, goalToolContext('turn-owner'));
@@ -266,8 +266,8 @@ describe('GoalContinuationCoordinator settlement', () => {
 
   test('an older unbound turn cannot activate a Goal after another turn activated and cleared one', async () => {
     const { manager, coordinator } = setup();
-    registerExternalTurn(coordinator, SESSION, 'turn-old');
-    registerExternalTurn(coordinator, SESSION, 'turn-owner');
+    registerObservedTurn(coordinator, SESSION, 'turn-old');
+    registerObservedTurn(coordinator, SESSION, 'turn-owner');
     const tools = goalToolsFor(manager, coordinator);
     const set = tools.find((tool) => tool.name === GOAL_SET_TOOL_NAME);
     const clear = tools.find((tool) => tool.name === GOAL_CLEAR_TOOL_NAME);
@@ -289,8 +289,8 @@ describe('GoalContinuationCoordinator settlement', () => {
     const { manager, coordinator } = setup();
     manager.create(SESSION, 'paused goal');
     manager.pause(SESSION);
-    registerExternalTurn(coordinator, SESSION, 'turn-old');
-    registerExternalTurn(coordinator, SESSION, 'turn-clear');
+    registerObservedTurn(coordinator, SESSION, 'turn-old');
+    registerObservedTurn(coordinator, SESSION, 'turn-clear');
     const tools = goalToolsFor(manager, coordinator);
     const clear = tools.find((tool) => tool.name === GOAL_CLEAR_TOOL_NAME);
     const set = tools.find((tool) => tool.name === GOAL_SET_TOOL_NAME);
@@ -310,8 +310,8 @@ describe('GoalContinuationCoordinator settlement', () => {
   test('an old Goal turn cannot pause or clear a replacement Goal', async () => {
     const { manager, coordinator } = setup();
     manager.create(SESSION, 'first');
-    registerExternalTurn(coordinator, SESSION, 'turn-old');
-    registerExternalTurn(coordinator, SESSION, 'turn-clear');
+    registerObservedTurn(coordinator, SESSION, 'turn-old');
+    registerObservedTurn(coordinator, SESSION, 'turn-clear');
     const tools = goalToolsFor(manager, coordinator);
     const clear = tools.find((tool) => tool.name === GOAL_CLEAR_TOOL_NAME);
     const pause = tools.find((tool) => tool.name === GOAL_PAUSE_TOOL_NAME);
@@ -321,7 +321,7 @@ describe('GoalContinuationCoordinator settlement', () => {
     assert.ok(set);
 
     await clear.impl({}, goalToolContext('turn-clear'));
-    registerExternalTurn(coordinator, SESSION, 'turn-replacement');
+    registerObservedTurn(coordinator, SESSION, 'turn-replacement');
     await set.impl({ condition: 'replacement' }, goalToolContext('turn-replacement'));
 
     assert.match(
@@ -339,7 +339,7 @@ describe('GoalContinuationCoordinator settlement', () => {
   test('a removed external turn cannot create or resume a Goal through the real tools', async (t) => {
     await t.test('GoalSet after permanent removal', async () => {
       const { manager, coordinator } = setup();
-      registerExternalTurn(coordinator, SESSION, 'turn-deleted');
+      registerObservedTurn(coordinator, SESSION, 'turn-deleted');
       const set = goalToolsFor(manager, coordinator).find(
         (tool) => tool.name === GOAL_SET_TOOL_NAME,
       );
@@ -360,7 +360,7 @@ describe('GoalContinuationCoordinator settlement', () => {
       const { manager, coordinator } = setup();
       manager.create(SESSION, 'old');
       manager.pause(SESSION);
-      registerExternalTurn(coordinator, SESSION, 'turn-archived');
+      registerObservedTurn(coordinator, SESSION, 'turn-archived');
       const resume = goalToolsFor(manager, coordinator).find(
         (tool) => tool.name === GOAL_RESUME_TOOL_NAME,
       );
@@ -384,13 +384,13 @@ describe('GoalContinuationCoordinator settlement', () => {
     const { coordinator } = setup();
     coordinator.beginSessionClose(SESSION, 'archive').commit();
 
-    assert.deepEqual(coordinator.beginExternalTurn(SESSION, 'turn-closed'), {
+    assert.deepEqual(coordinator.beginObservedTurn(SESSION, 'turn-closed'), {
       kind: 'unavailable',
       reason: 'Goal continuation session is closed.',
     });
 
     coordinator.unarchiveSession(SESSION);
-    assert.equal(coordinator.beginExternalTurn(SESSION, 'turn-reopened').kind, 'registered');
+    assert.equal(coordinator.beginObservedTurn(SESSION, 'turn-reopened').kind, 'registered');
   });
 
   test('a rolled-back session close leaves revoked continuation visibly paused', async (t) => {
@@ -421,7 +421,7 @@ describe('GoalContinuationCoordinator settlement', () => {
       );
       assert.equal(attemptedPrompts.length, 1);
 
-      registerExternalTurn(coordinator, SESSION, 'turn-resume');
+      registerObservedTurn(coordinator, SESSION, 'turn-resume');
       const resume = goalToolsFor(manager, coordinator).find(
         (tool) => tool.name === GOAL_RESUME_TOOL_NAME,
       );
@@ -461,7 +461,7 @@ describe('GoalContinuationCoordinator settlement', () => {
       const { manager, coordinator } = setup({
         evaluations: [{ met: true, reason: 'resumed Goal verified' }],
       });
-      const settle = registerExternalTurn(coordinator, SESSION, 'turn-control');
+      const settle = registerObservedTurn(coordinator, SESSION, 'turn-control');
       const tools = goalToolsFor(manager, coordinator);
       const context = goalToolContext('turn-control');
       const set = tools.find((tool) => tool.name === GOAL_SET_TOOL_NAME);
@@ -484,7 +484,7 @@ describe('GoalContinuationCoordinator settlement', () => {
         evaluations: [{ met: true, reason: 'replacement Goal verified' }],
       });
       manager.create(SESSION, 'old Goal');
-      const settle = registerExternalTurn(coordinator, SESSION, 'turn-control');
+      const settle = registerObservedTurn(coordinator, SESSION, 'turn-control');
       const tools = goalToolsFor(manager, coordinator);
       const context = goalToolContext('turn-control');
       const clear = tools.find((tool) => tool.name === GOAL_CLEAR_TOOL_NAME);
@@ -694,7 +694,7 @@ describe('GoalContinuationCoordinator settlement', () => {
       return '{"met":true,"reason":"must not evaluate"}';
     };
     manager.create(SESSION, 'ship');
-    const settleLate = registerExternalTurn(coordinator, SESSION, 'turn-late');
+    const settleLate = registerObservedTurn(coordinator, SESSION, 'turn-late');
 
     await settleExternal(coordinator, SESSION, {
       kind: 'errored',
@@ -771,7 +771,7 @@ describe('GoalContinuationCoordinator settlement', () => {
         });
         await evaluation.started;
 
-        const settleControl = registerExternalTurn(coordinator, SESSION, 'turn-control');
+        const settleControl = registerObservedTurn(coordinator, SESSION, 'turn-control');
         const tools = goalToolsFor(manager, coordinator);
         const context = goalToolContext('turn-control');
         const toolName = action === 'pause' ? GOAL_PAUSE_TOOL_NAME : GOAL_CLEAR_TOOL_NAME;
@@ -808,7 +808,7 @@ describe('GoalContinuationCoordinator settlement', () => {
       return '{"met":true,"reason":"old turn must not evaluate"}';
     };
     manager.create(SESSION, 'old');
-    const settleOld = registerExternalTurn(coordinator, SESSION, 'turn-still-draining');
+    const settleOld = registerObservedTurn(coordinator, SESSION, 'turn-still-draining');
 
     const archive = coordinator.beginSessionClose(SESSION, 'archive');
     assert.equal(manager.remove(SESSION), true);

--- a/packages/runtime/src/__tests__/goal-continuation.test.ts
+++ b/packages/runtime/src/__tests__/goal-continuation.test.ts
@@ -708,7 +708,11 @@ describe('GoalContinuationCoordinator settlement', () => {
   test('archive invalidates queued and in-flight outcomes before Goal replacement', async () => {
     const { manager, coordinator, deps, admitted } = setup();
     const evaluation = controlledCall<string>();
-    deps.evaluator.evaluate = evaluation.invoke;
+    let evaluationSignal: AbortSignal | undefined;
+    deps.evaluator.evaluate = (_prompt, _sessionId, signal) => {
+      evaluationSignal = signal;
+      return evaluation.invoke();
+    };
     manager.create(SESSION, 'old');
 
     const inFlight = settleExternal(coordinator, SESSION, {
@@ -722,6 +726,7 @@ describe('GoalContinuationCoordinator settlement', () => {
     });
 
     const archive = coordinator.beginSessionClose(SESSION, 'archive');
+    assert.equal(evaluationSignal?.aborted, true);
     assert.equal(manager.remove(SESSION), true);
     archive.commit();
     coordinator.unarchiveSession(SESSION);
@@ -742,6 +747,52 @@ describe('GoalContinuationCoordinator settlement', () => {
     assert.equal(manager.get(SESSION)?.condition, 'replacement');
     assert.equal(manager.get(SESSION)?.status, 'active');
     assert.equal(admitted.length, 0);
+  });
+
+  test('model pause and clear abort an older evaluator without revoking their own turn', async (t) => {
+    for (const action of ['pause', 'clear'] as const) {
+      await t.test(action, async () => {
+        const { manager, coordinator, deps, admitted } = setup();
+        const evaluation = controlledCall<string>();
+        let evaluationSignal: AbortSignal | undefined;
+        deps.evaluator.evaluate = (_prompt, _sessionId, signal) => {
+          evaluationSignal = signal;
+          return evaluation.invoke();
+        };
+        manager.create(SESSION, 'ship');
+        const priorSettlement = settleExternal(coordinator, SESSION, {
+          kind: 'completed',
+          turnId: 'turn-evaluating',
+        });
+        await evaluation.started;
+
+        const settleControl = registerExternalTurn(coordinator, SESSION, 'turn-control');
+        const tools = goalToolsFor(manager, coordinator);
+        const context = goalToolContext('turn-control');
+        const toolName = action === 'pause' ? GOAL_PAUSE_TOOL_NAME : GOAL_CLEAR_TOOL_NAME;
+        const tool = tools.find((candidate) => candidate.name === toolName);
+        assert.ok(tool);
+        assert.match(String(await tool.impl({}, context)), /Goal/);
+        assert.equal(evaluationSignal?.aborted, true);
+        await priorSettlement;
+
+        if (action === 'pause') {
+          const resume = tools.find((candidate) => candidate.name === GOAL_RESUME_TOOL_NAME);
+          assert.ok(resume);
+          assert.match(String(await resume.impl({}, context)), /Goal resumed/);
+          assert.match(String(await tool.impl({}, context)), /Goal paused/);
+        } else {
+          const set = tools.find((candidate) => candidate.name === GOAL_SET_TOOL_NAME);
+          assert.ok(set);
+          assert.match(String(await set.impl({ condition: 'replacement' }, context)), /Goal set/);
+          assert.match(String(await tool.impl({}, context)), /Goal cleared/);
+        }
+
+        await settleControl({ kind: 'completed', turnId: 'turn-control' });
+        assert.equal(manager.get(SESSION)?.status, action === 'pause' ? 'paused' : 'cleared');
+        assert.equal(admitted.length, 0);
+      });
+    }
   });
 
   test('archive consumes an external turn that has not reached the FIFO', async () => {

--- a/packages/runtime/src/__tests__/goal-evaluator.test.ts
+++ b/packages/runtime/src/__tests__/goal-evaluator.test.ts
@@ -127,10 +127,14 @@ describe('evaluateGoal', () => {
   });
 
   test('fails open on timeout (evaluatorFailed=true, continue)', async () => {
+    let signal: AbortSignal | undefined;
     const r = await evaluateGoal(
       {
         // Never resolves — force the timeout branch.
-        evaluate: () => new Promise<string>(() => {}),
+        evaluate: (_prompt, _sessionId, receivedSignal) => {
+          signal = receivedSignal;
+          return new Promise<string>(() => {});
+        },
         timeoutMs: 10,
         // Injected timer fires immediately so the race resolves to timeout.
         setTimeout: (fn) => {
@@ -147,6 +151,30 @@ describe('evaluateGoal', () => {
     assert.equal(r.progress, false);
     assert.equal(r.evaluatorFailed, true);
     assert.ok(r.reason.includes('timed out'));
+    assert.equal(signal?.aborted, true);
+  });
+
+  test('aborts the physical evaluator call when its owner is invalidated', async () => {
+    const owner = new AbortController();
+    let signal: AbortSignal | undefined;
+    const pending = evaluateGoal(
+      {
+        evaluate: (_prompt, _sessionId, receivedSignal) => {
+          signal = receivedSignal;
+          return new Promise<string>(() => {});
+        },
+      },
+      'finish',
+      'ctx',
+      'sess-1',
+      owner.signal,
+    );
+
+    owner.abort(new Error('lane invalidated'));
+    const result = await pending;
+    assert.equal(result.evaluatorFailed, true);
+    assert.ok(result.reason.includes('cancelled'));
+    assert.equal(signal?.aborted, true);
   });
 
   test('successful parse sets evaluatorFailed=false', async () => {

--- a/packages/runtime/src/__tests__/goal-tools.test.ts
+++ b/packages/runtime/src/__tests__/goal-tools.test.ts
@@ -39,7 +39,7 @@ function makeTools(getTokenCount?: (s: string) => number) {
     getRecentContext: async () => '',
     admitTurn: () => ({ kind: 'unavailable', reason: 'tool test' }),
   });
-  assert.equal(goalContinuation.beginExternalTurn(SESSION, 't').kind, 'registered');
+  assert.equal(goalContinuation.beginObservedTurn(SESSION, 't').kind, 'registered');
   const tools = buildGoalTools({
     goalManager: mgr,
     goalContinuation,
@@ -113,7 +113,7 @@ describe('goal tools', () => {
     assert.ok(pauseOut.includes('paused'));
     assert.equal(mgr.get(SESSION)?.status, 'paused');
 
-    assert.equal(goalContinuation.beginExternalTurn(SESSION, 'resume-turn').kind, 'registered');
+    assert.equal(goalContinuation.beginObservedTurn(SESSION, 'resume-turn').kind, 'registered');
     const resumeOut = (await findTool(tools, GOAL_RESUME_TOOL_NAME).impl(
       {},
       ctx('resume-turn'),

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -1159,7 +1159,7 @@ describe('SessionManager claimed graph intent execution', () => {
       targetRunId: 'recovered-graph-run',
     });
 
-    await manager.closePendingHostedLinkedChildAdmission({
+    await manager.closePendingHostedAdmission({
       sessionId: child.id,
       turnId: claim.targetTurnId,
       runId: claim.targetRunId,
@@ -2273,7 +2273,7 @@ describe('SessionManager child-session runtime primitive', () => {
     if (!claimedHeader.agentId || !claimedHeader.agentName) {
       throw new Error('linked child continuation claim lost its trusted agent identity');
     }
-    await manager.closePendingHostedLinkedChildAdmission({
+    await manager.closePendingHostedAdmission({
       sessionId: child.childSessionId,
       turnId: claimState.claim.target.turnId,
       runId: claimState.claim.target.runId,

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -1029,6 +1029,9 @@ export class AgentRun {
       ...(this.input.userInput.origin?.kind === 'automation'
         ? { automationId: this.input.userInput.origin.automationId }
         : {}),
+      ...(this.input.userInput.origin?.kind === 'goal'
+        ? { goalId: this.input.userInput.origin.goalId }
+        : {}),
       ...(this.input.userInput.origin?.kind === 'agent_graph'
         ? {
             agentGraphWakeId: this.input.userInput.origin.wakeId,

--- a/packages/runtime/src/goal-continuation.ts
+++ b/packages/runtime/src/goal-continuation.ts
@@ -56,7 +56,12 @@ export interface GoalContinuationDeps {
   /** Current cumulative token count for the session (for budget tracking). */
   getTokenCount?: (sessionId: string) => number;
   /** Synchronously prepare, defer, or reject a Goal-owned turn. */
-  admitTurn: (sessionId: string, text: string) => GoalTurnAdmission;
+  admitTurn: (
+    sessionId: string,
+    text: string,
+    checkpoint: GoalCheckpoint,
+    controlLease: GoalControlLease,
+  ) => GoalTurnAdmission;
   taskGate?: GoalTaskGateDeps;
   scheduler?: GoalContinuationScheduler;
 }
@@ -79,7 +84,7 @@ interface QueuedTurn {
 interface ContinuationIntent {
   checkpoint: GoalCheckpoint;
   controlLease: GoalControlLease;
-  triggeringTurnId: string;
+  triggeringTurnId?: string;
   evaluation: GoalEvaluation;
 }
 
@@ -104,6 +109,7 @@ interface SessionLane {
   intent?: ContinuationIntent;
   busyWake?: Promise<void>;
   waitingTimer?: WaitingTimer;
+  evaluationAbort?: AbortController;
   consecutiveWaits: number;
 }
 
@@ -207,6 +213,7 @@ export class GoalContinuationCoordinator {
     }
 
     const goal = mutate();
+    this.abortEvaluation(lane, 'Goal lifecycle changed during evaluation');
     this.discardIntentOwnedBy(lane, controlLease);
     registration.observedControlLease = this.deps.goalManager.getControlLease(sessionId);
     registration.controlLease = undefined;
@@ -267,6 +274,33 @@ export class GoalContinuationCoordinator {
   /** Clear only a committed archive fence; removal and pending holders remain. */
   unarchiveSession(sessionId: string): void {
     this.sessionCloseFence.unarchive(sessionId);
+  }
+
+  /** Resume an exact paused Goal generation from Host control without a model-owned Turn. */
+  resumeFromControl(sessionId: string, checkpoint: GoalCheckpoint): GoalState | undefined {
+    if (this.disposed || this.sessionCloseFence.isClosed(sessionId)) return undefined;
+    const resumed = this.deps.goalManager.resume(sessionId, checkpoint);
+    if (!resumed) return undefined;
+    const controlLease = this.deps.goalManager.getControlLease(sessionId);
+    if (!controlLease) return undefined;
+    const lane = this.laneFor(sessionId);
+    lane.intent = {
+      checkpoint: goalCheckpoint(resumed),
+      controlLease,
+      evaluation: {
+        met: false,
+        impossible: false,
+        progress: false,
+        waiting: false,
+        evaluatorFailed: false,
+        reason: 'Goal resumed by a connected client.',
+      },
+    };
+    lane.busyWake = undefined;
+    this.clearWaitingTimer(lane);
+    this.resetWaitingBackoff(lane);
+    this.scheduleDrain(lane);
+    return resumed;
   }
 
   dispose(): void {
@@ -453,12 +487,20 @@ export class GoalContinuationCoordinator {
       return;
     }
 
-    const evaluation = await evaluateGoal(
-      this.deps.evaluator,
-      goal.condition,
-      context,
-      lane.sessionId,
-    );
+    const evaluationAbort = new AbortController();
+    lane.evaluationAbort = evaluationAbort;
+    let evaluation: GoalEvaluation;
+    try {
+      evaluation = await evaluateGoal(
+        this.deps.evaluator,
+        goal.condition,
+        context,
+        lane.sessionId,
+        evaluationAbort.signal,
+      );
+    } finally {
+      if (lane.evaluationAbort === evaluationAbort) lane.evaluationAbort = undefined;
+    }
     if (!this.isCurrent(lane) || !this.deps.goalManager.matchesActive(lane.sessionId, checkpoint)) {
       return;
     }
@@ -553,7 +595,12 @@ export class GoalContinuationCoordinator {
     }
 
     const prompt = buildContinuationPrompt(goal, intent.evaluation, taskPlan.reminder);
-    const admission = this.deps.admitTurn(lane.sessionId, prompt);
+    const admission = this.deps.admitTurn(
+      lane.sessionId,
+      prompt,
+      intent.checkpoint,
+      intent.controlLease,
+    );
 
     if (admission.kind === 'busy') {
       this.watchBusyLane(lane, admission.whenIdle);
@@ -599,13 +646,15 @@ export class GoalContinuationCoordinator {
 
     lane.intent = undefined;
     this.taskGatePolicy.markStarted(intent.checkpoint.goalId, taskPlan);
-    this.taskGatePolicy.record({
-      sessionId: lane.sessionId,
-      turnId: intent.triggeringTurnId,
-      goalId: intent.checkpoint.goalId,
-      decision: taskPlan.decision,
-      taskKeys: taskPlan.taskKeys,
-    });
+    if (intent.triggeringTurnId) {
+      this.taskGatePolicy.record({
+        sessionId: lane.sessionId,
+        turnId: intent.triggeringTurnId,
+        goalId: intent.checkpoint.goalId,
+        decision: taskPlan.decision,
+        taskKeys: taskPlan.taskKeys,
+      });
+    }
   }
 
   private watchBusyLane(lane: SessionLane, whenIdle: Promise<void>): void {
@@ -682,6 +731,7 @@ export class GoalContinuationCoordinator {
   }
 
   private invalidateLane(lane: SessionLane): void {
+    this.abortEvaluation(lane, 'Goal continuation lane was invalidated');
     lane.intent = undefined;
     lane.busyWake = undefined;
     this.clearWaitingTimer(lane);
@@ -692,6 +742,11 @@ export class GoalContinuationCoordinator {
     for (const item of lane.queue.splice(0)) {
       item.resolve();
     }
+  }
+
+  private abortEvaluation(lane: SessionLane, reason: string): void {
+    lane.evaluationAbort?.abort(new Error(reason));
+    lane.evaluationAbort = undefined;
   }
 }
 

--- a/packages/runtime/src/goal-continuation.ts
+++ b/packages/runtime/src/goal-continuation.ts
@@ -45,8 +45,8 @@ export type GoalTurnAdmission =
   | { kind: 'busy'; whenIdle: Promise<void> }
   | { kind: 'unavailable'; reason: string };
 
-/** Exactly-once settlement capability captured when an external Agent turn starts. */
-export type GoalExternalTurnSettler = (outcome: GoalTurnOutcome) => Promise<void>;
+/** Exactly-once settlement capability captured when a non-Goal Agent turn starts. */
+export type GoalObservedTurnSettler = (outcome: GoalTurnOutcome) => Promise<void>;
 
 export interface GoalContinuationScheduler {
   setTimeout: (callback: () => void, delayMs: number) => unknown;
@@ -118,8 +118,8 @@ interface SessionLane {
   consecutiveWaits: number;
 }
 
-export type GoalExternalTurnStart =
-  | { kind: 'registered'; settle: GoalExternalTurnSettler }
+export type GoalObservedTurnStart =
+  | { kind: 'registered'; settle: GoalObservedTurnSettler }
   | { kind: 'unavailable'; reason: string };
 
 export class GoalContinuationCoordinator {
@@ -148,11 +148,11 @@ export class GoalContinuationCoordinator {
   }
 
   /**
-   * Register an external Agent turn before its iterator starts. The returned
+   * Register a non-Goal Agent turn before its iterator starts. The returned
    * closure is the only legal settlement path, so terminal handling never has
    * to rediscover Goal ownership from mutable current state.
    */
-  beginExternalTurn(sessionId: string, turnId: string): GoalExternalTurnStart {
+  beginObservedTurn(sessionId: string, turnId: string): GoalObservedTurnStart {
     if (this.disposed) {
       return { kind: 'unavailable', reason: 'Goal continuation is disposed.' };
     }

--- a/packages/runtime/src/goal-continuation.ts
+++ b/packages/runtime/src/goal-continuation.ts
@@ -6,7 +6,12 @@
  * an in-memory backoff instead of immediately spending another turn.
  */
 
-import { evaluateGoal, type GoalEvaluation, type GoalEvaluatorDeps } from './goal-evaluator.js';
+import {
+  evaluateGoal,
+  type GoalEvaluation,
+  type GoalEvaluatorDeps,
+  type GoalEvaluatorResource,
+} from './goal-evaluator.js';
 import {
   goalCheckpoint,
   type GoalControlLease,
@@ -50,7 +55,7 @@ export interface GoalContinuationScheduler {
 
 export interface GoalContinuationDeps {
   goalManager: GoalManager;
-  evaluator: GoalEvaluatorDeps;
+  evaluator: GoalEvaluatorDeps & Partial<Pick<GoalEvaluatorResource, 'close'>>;
   /** Summarized recent conversation (last ~5 messages) for the evaluator. */
   getRecentContext: (sessionId: string) => Promise<string>;
   /** Current cumulative token count for the session (for budget tracking). */
@@ -119,10 +124,12 @@ export type GoalExternalTurnStart =
 
 export class GoalContinuationCoordinator {
   private readonly lanes = new Map<string, SessionLane>();
+  private readonly activeDrains = new Set<Promise<void>>();
   private readonly sessionCloseFence: GoalSessionCloseFence;
   private readonly taskGatePolicy: GoalTaskGatePolicy;
   private readonly scheduler: GoalContinuationScheduler;
   private disposed = false;
+  private closeTask?: Promise<void>;
 
   constructor(private readonly deps: GoalContinuationDeps) {
     this.scheduler = deps.scheduler ?? defaultScheduler;
@@ -311,6 +318,15 @@ export class GoalContinuationCoordinator {
     this.sessionCloseFence.dispose();
   }
 
+  close(): Promise<void> {
+    this.dispose();
+    this.closeTask ??= Promise.all([
+      ...this.activeDrains,
+      Promise.resolve().then(() => this.deps.evaluator.close?.()),
+    ]).then(() => undefined);
+    return this.closeTask;
+  }
+
   private enqueueTurn(
     outcome: GoalTurnOutcome,
     controlLease: GoalControlLease,
@@ -388,10 +404,12 @@ export class GoalContinuationCoordinator {
 
   private scheduleDrain(lane: SessionLane): void {
     if (!this.isCurrent(lane) || lane.draining) return;
-    void this.drainLane(lane).catch((error) => {
+    const task = this.drainLane(lane).catch((error) => {
       if (!this.isCurrent(lane)) return;
       this.pauseCurrentGoal(lane, `Goal continuation coordinator failed: ${errorMessage(error)}`);
     });
+    this.activeDrains.add(task);
+    void task.finally(() => this.activeDrains.delete(task));
   }
 
   private async drainLane(lane: SessionLane): Promise<void> {

--- a/packages/runtime/src/goal-evaluator.ts
+++ b/packages/runtime/src/goal-evaluator.ts
@@ -49,6 +49,11 @@ export interface GoalEvaluatorDeps {
   clearTimeout?: (handle: unknown) => void;
 }
 
+export interface GoalEvaluatorResource extends GoalEvaluatorDeps {
+  /** Wait until every accepted physical evaluation and its cleanup have settled. */
+  close(): Promise<void>;
+}
+
 export interface GoalEvaluationModelInput {
   readonly model: unknown;
   readonly prompt: string;

--- a/packages/runtime/src/goal-evaluator.ts
+++ b/packages/runtime/src/goal-evaluator.ts
@@ -11,6 +11,10 @@
  * "done", which is Codex's documented failure mode.
  */
 
+import { truncateGoalText, type GoalTextLimit } from './goal-state.js';
+import { normalizeAiSdkUsage, type AiSdkUsageLike } from './model-adapter.js';
+import { rawFinishReasonString, type NormalizedUsage } from './model-protocol.js';
+
 export interface GoalEvaluation {
   /** Condition is satisfied — stop, success. */
   met: boolean;
@@ -37,7 +41,7 @@ export interface GoalEvaluatorDeps {
    * (the wiring resolves the session's connection from `sessionId`). The
    * evaluator must not run tools or read files — it judges from text only.
    */
-  evaluate: (prompt: string, sessionId: string) => Promise<string>;
+  evaluate: (prompt: string, sessionId: string, signal: AbortSignal) => Promise<string>;
   /** Hard timeout for the evaluator call (ms). Defaults to 30_000 (CC's limit). */
   timeoutMs?: number;
   /** Injectable timer for tests. Defaults to global setTimeout/clearTimeout. */
@@ -45,7 +49,51 @@ export interface GoalEvaluatorDeps {
   clearTimeout?: (handle: unknown) => void;
 }
 
+export interface GoalEvaluationModelInput {
+  readonly model: unknown;
+  readonly prompt: string;
+  readonly providerOptions?: unknown;
+  readonly abortSignal?: AbortSignal;
+}
+
+export interface GoalEvaluationModelResult {
+  readonly text: string;
+  readonly usage?: NormalizedUsage;
+  readonly finishReason?: string;
+}
+
+/** Runs the bounded, tool-free model call and returns its accounting facts. */
+export async function generateGoalEvaluationModelCall(
+  input: GoalEvaluationModelInput,
+): Promise<GoalEvaluationModelResult> {
+  const ai = (await import('ai')) as unknown as {
+    generateText(options: Record<string, unknown>): Promise<{
+      text: string;
+      usage?: AiSdkUsageLike;
+      finishReason?: unknown;
+    }>;
+  };
+  const result = await ai.generateText({
+    model: input.model,
+    prompt: input.prompt,
+    ...(input.abortSignal === undefined ? {} : { abortSignal: input.abortSignal }),
+    ...(input.providerOptions === undefined ? {} : { providerOptions: input.providerOptions }),
+    maxOutputTokens: 1_024,
+  });
+  const usage = normalizeAiSdkUsage(result.usage, { rawFinishReason: result.finishReason });
+  const finishReason = rawFinishReasonString(result.finishReason);
+  return {
+    text: result.text,
+    ...(usage ? { usage } : {}),
+    ...(finishReason ? { finishReason } : {}),
+  };
+}
+
 const DEFAULT_EVALUATOR_TIMEOUT_MS = 30_000;
+const EVALUATOR_REASON_TEXT_LIMIT: GoalTextLimit = Object.freeze({
+  codeUnits: 200,
+  utf8Bytes: 600,
+});
 
 const EVALUATOR_SYSTEM = `You are a goal evaluation judge for an autonomous coding agent. Given a GOAL CONDITION and recent CONVERSATION CONTEXT, judge the agent's progress.
 
@@ -100,7 +148,7 @@ export function parseGoalEvaluation(raw: string): GoalEvaluation {
       evaluatorFailed: false,
       reason:
         typeof parsed.reason === 'string' && parsed.reason.trim()
-          ? parsed.reason.slice(0, 200)
+          ? truncateGoalText(parsed.reason, EVALUATOR_REASON_TEXT_LIMIT)
           : 'No reason provided',
     };
   } catch {
@@ -118,20 +166,39 @@ export async function evaluateGoal(
   condition: string,
   context: string,
   sessionId: string,
+  abortSignal?: AbortSignal,
 ): Promise<GoalEvaluation> {
   const prompt = buildGoalEvaluationPrompt(condition, context);
   const timeoutMs = deps.timeoutMs ?? DEFAULT_EVALUATOR_TIMEOUT_MS;
   const setT = deps.setTimeout ?? ((fn, ms) => setTimeout(fn, ms));
   const clearT = deps.clearTimeout ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
 
+  const controller = new AbortController();
+  const timedOut = Symbol('timed_out');
+  const cancelled = Symbol('cancelled');
   let timer: unknown;
-  const timeout = new Promise<'__timeout__'>((resolve) => {
-    timer = setT(() => resolve('__timeout__'), timeoutMs);
+  let resolveCancellation!: (result: typeof timedOut | typeof cancelled) => void;
+  const cancellation = new Promise<typeof timedOut | typeof cancelled>((resolve) => {
+    resolveCancellation = resolve;
   });
+  const cancel = () => {
+    resolveCancellation(cancelled);
+    controller.abort(abortSignal?.reason);
+  };
+  if (abortSignal?.aborted) cancel();
+  else abortSignal?.addEventListener('abort', cancel, { once: true });
+  timer = setT(() => {
+    resolveCancellation(timedOut);
+    controller.abort(new Error('Goal evaluator timed out'));
+  }, timeoutMs);
 
   try {
-    const result = await Promise.race([deps.evaluate(prompt, sessionId), timeout]);
-    if (result === '__timeout__') {
+    if (abortSignal?.aborted) return cancelledEvaluation();
+    const result = await Promise.race([
+      deps.evaluate(prompt, sessionId, controller.signal),
+      cancellation,
+    ]);
+    if (result === timedOut) {
       return {
         met: false,
         impossible: false,
@@ -141,6 +208,7 @@ export async function evaluateGoal(
         reason: 'Evaluator timed out (continuing)',
       };
     }
+    if (result === cancelled) return cancelledEvaluation();
     return parseGoalEvaluation(result);
   } catch {
     return {
@@ -152,8 +220,20 @@ export async function evaluateGoal(
       reason: 'Evaluator call failed (continuing)',
     };
   } finally {
+    abortSignal?.removeEventListener('abort', cancel);
     clearT(timer);
   }
+}
+
+function cancelledEvaluation(): GoalEvaluation {
+  return {
+    met: false,
+    impossible: false,
+    progress: false,
+    waiting: false,
+    evaluatorFailed: true,
+    reason: 'Evaluator cancelled (continuing)',
+  };
 }
 
 export { DEFAULT_EVALUATOR_TIMEOUT_MS };

--- a/packages/runtime/src/goal-state.ts
+++ b/packages/runtime/src/goal-state.ts
@@ -17,16 +17,19 @@
  *          → max_iterations (total turn ceiling)
  */
 
-export type GoalStatus =
-  | 'active'
-  | 'waiting'
-  | 'achieved'
-  | 'impossible'
-  | 'cleared'
-  | 'paused'
-  | 'stalled'
-  | 'budget_limited'
-  | 'max_iterations';
+import {
+  GOAL_CONDITION_TEXT_LIMIT,
+  GOAL_REASON_TEXT_LIMIT,
+  type GoalStatus,
+  type GoalTextLimit,
+} from '@maka/core/goal';
+
+export {
+  GOAL_CONDITION_TEXT_LIMIT,
+  GOAL_REASON_TEXT_LIMIT,
+  type GoalStatus,
+  type GoalTextLimit,
+} from '@maka/core/goal';
 
 /** Terminal statuses — a goal in one of these states will not continue. */
 export const TERMINAL_GOAL_STATUSES: ReadonlySet<GoalStatus> = new Set<GoalStatus>([
@@ -51,7 +54,10 @@ export interface GoalState {
   readonly consecutiveNoProgress: number;
   /** Force-stop after this many consecutive no-progress turns (CC's 8). */
   readonly blockCap: number;
-  /** Optional token budget; goal → budget_limited when exceeded. */
+  /**
+   * Optional working-turn token budget; goal → budget_limited when exceeded.
+   * Evaluator calls are usage-metered separately and do not spend this budget.
+   */
   readonly tokenBudget?: number;
   /** Token count observed when the goal was set (baseline for spend). */
   readonly tokensAtStart: number;
@@ -136,6 +142,31 @@ export interface GoalManagerDeps {
 export const DEFAULT_MAX_ITERATIONS = 50;
 export const DEFAULT_BLOCK_CAP = 8;
 
+export function isGoalTextWithinLimit(value: string, limit: GoalTextLimit): boolean {
+  return value.length <= limit.codeUnits && Buffer.byteLength(value, 'utf8') <= limit.utf8Bytes;
+}
+
+export function truncateGoalText(value: string, limit: GoalTextLimit): string {
+  if (isGoalTextWithinLimit(value, limit)) return value;
+  let result = '';
+  let codeUnits = 0;
+  let utf8Bytes = 0;
+  for (const character of value) {
+    const nextCodeUnits = character.length;
+    const nextUtf8Bytes = Buffer.byteLength(character, 'utf8');
+    if (
+      codeUnits + nextCodeUnits > limit.codeUnits ||
+      utf8Bytes + nextUtf8Bytes > limit.utf8Bytes
+    ) {
+      break;
+    }
+    result += character;
+    codeUnits += nextCodeUnits;
+    utf8Bytes += nextUtf8Bytes;
+  }
+  return result;
+}
+
 interface GoalRecord {
   state: GoalState;
   controlLease: GoalControlLease;
@@ -170,9 +201,13 @@ export class GoalManager {
     options?: { renewControlLease?: boolean },
   ): GoalState {
     const previous = record.state.status;
+    const boundedPatch =
+      patch.lastReason === undefined
+        ? patch
+        : { ...patch, lastReason: truncateGoalText(patch.lastReason, GOAL_REASON_TEXT_LIMIT) };
     const committed = Object.freeze({
       ...record.state,
-      ...patch,
+      ...boundedPatch,
       revision: record.state.revision + 1,
     });
     record.state = committed;
@@ -193,6 +228,9 @@ export class GoalManager {
       tokensAtStart?: number;
     },
   ): GoalCreateResult {
+    if (!condition.trim() || !isGoalTextWithinLimit(condition, GOAL_CONDITION_TEXT_LIMIT)) {
+      throw new RangeError('Goal condition exceeds its shared text limit');
+    }
     const existing = this.goals.get(sessionId)?.state;
     if (existing && !TERMINAL_GOAL_STATUSES.has(existing.status)) {
       return { kind: 'unfinished', goal: existing };
@@ -359,9 +397,10 @@ export class GoalManager {
     );
   }
 
-  resume(sessionId: string): GoalState | undefined {
+  resume(sessionId: string, checkpoint?: GoalCheckpoint): GoalState | undefined {
     const record = this.goals.get(sessionId);
     if (!record || record.state.status !== 'paused') return undefined;
+    if (checkpoint && !this.matches(sessionId, checkpoint)) return undefined;
     return this.commit(
       record,
       { status: 'active', pausedAt: undefined },

--- a/packages/runtime/src/goal-tools.ts
+++ b/packages/runtime/src/goal-tools.ts
@@ -8,7 +8,13 @@
 
 import { z } from 'zod';
 import type { MakaTool } from './tool-runtime.js';
-import { TERMINAL_GOAL_STATUSES, type GoalManager, type GoalState } from './goal-state.js';
+import {
+  GOAL_CONDITION_TEXT_LIMIT,
+  isGoalTextWithinLimit,
+  TERMINAL_GOAL_STATUSES,
+  type GoalManager,
+  type GoalState,
+} from './goal-state.js';
 import type { GoalContinuationCoordinator } from './goal-continuation.js';
 
 export const GOAL_SET_TOOL_NAME = 'GoalSet';
@@ -23,6 +29,8 @@ export interface GoalToolsDeps {
   goalContinuation: Pick<GoalContinuationCoordinator, 'activateGoal' | 'mutateGoal'>;
   /** Current cumulative token count for a session (baseline for budget). */
   getTokenCount?: (sessionId: string) => number;
+  /** Reject new model-owned mutations while the enclosing authority drains. */
+  isAvailable?: () => boolean;
   now?: () => number;
 }
 
@@ -58,7 +66,10 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<
         .string()
         .trim()
         .min(1)
-        .max(500)
+        .max(GOAL_CONDITION_TEXT_LIMIT.codeUnits)
+        .refine((value) => isGoalTextWithinLimit(value, GOAL_CONDITION_TEXT_LIMIT), {
+          message: 'Goal condition exceeds its UTF-8 byte limit',
+        })
         .describe(
           'The objective to achieve. Should be observable and verifiable (e.g. "all tests in packages/runtime pass", "PR #522 review comments addressed").',
         ),
@@ -88,6 +99,7 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<
         ),
     }),
     impl: (input, ctx) => {
+      if (deps.isAvailable?.() === false) return 'Goal authority is unavailable.';
       const existing = deps.goalManager.get(ctx.sessionId);
       if (existing && !TERMINAL_GOAL_STATUSES.has(existing.status)) {
         return (
@@ -129,6 +141,7 @@ function buildGoalClearTool(deps: GoalToolsDeps): MakaTool<Record<string, never>
     description: 'Clear the active goal, stopping autonomous execution after the current turn.',
     parameters: z.object({}),
     impl: (_input, ctx) => {
+      if (deps.isAvailable?.() === false) return 'Goal authority is unavailable.';
       const current = deps.goalManager.get(ctx.sessionId);
       if (!current || TERMINAL_GOAL_STATUSES.has(current.status)) {
         return 'No active goal to clear.';
@@ -152,6 +165,7 @@ function buildGoalPauseTool(deps: GoalToolsDeps): MakaTool<Record<string, never>
       'Pause the active goal. Autonomous continuation stops until GoalResume is called; state is preserved.',
     parameters: z.object({}),
     impl: (_input, ctx) => {
+      if (deps.isAvailable?.() === false) return 'Goal authority is unavailable.';
       const current = deps.goalManager.get(ctx.sessionId);
       if (!current || (current.status !== 'active' && current.status !== 'waiting')) {
         return 'No active goal to pause.';
@@ -174,6 +188,7 @@ function buildGoalResumeTool(deps: GoalToolsDeps): MakaTool<Record<string, never
     description: 'Resume a paused goal, re-enabling autonomous continuation.',
     parameters: z.object({}),
     impl: (_input, ctx) => {
+      if (deps.isAvailable?.() === false) return 'Goal authority is unavailable.';
       if (deps.goalManager.get(ctx.sessionId)?.status !== 'paused') {
         return 'No paused goal to resume.';
       }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1067,6 +1067,7 @@ export {
   buildPricingLookup,
   computeCost,
   getBuiltinPricing,
+  llmCallUsageFields,
   recordLlmCall,
   recordToolInvocation,
 } from './telemetry/index.js';
@@ -1425,21 +1426,34 @@ export {
   TERMINAL_GOAL_STATUSES,
   DEFAULT_MAX_ITERATIONS,
   DEFAULT_BLOCK_CAP,
+  GOAL_CONDITION_TEXT_LIMIT,
+  GOAL_REASON_TEXT_LIMIT,
+  goalCheckpoint,
+  isGoalTextWithinLimit,
+  truncateGoalText,
 } from './goal-state.js';
 export type {
   GoalCheckpoint,
+  GoalControlLease,
   GoalManagerDeps,
   GoalPauseOptions,
   GoalState,
   GoalStatus,
+  GoalTextLimit,
 } from './goal-state.js';
 export {
   evaluateGoal,
   buildGoalEvaluationPrompt,
   parseGoalEvaluation,
+  generateGoalEvaluationModelCall,
   DEFAULT_EVALUATOR_TIMEOUT_MS,
 } from './goal-evaluator.js';
-export type { GoalEvaluation, GoalEvaluatorDeps } from './goal-evaluator.js';
+export type {
+  GoalEvaluation,
+  GoalEvaluationModelInput,
+  GoalEvaluationModelResult,
+  GoalEvaluatorDeps,
+} from './goal-evaluator.js';
 export {
   buildGoalTools,
   GOAL_SET_TOOL_NAME,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1472,8 +1472,8 @@ export {
 export type {
   GoalContinuationDeps,
   GoalContinuationScheduler,
-  GoalExternalTurnStart,
-  GoalExternalTurnSettler,
+  GoalObservedTurnStart,
+  GoalObservedTurnSettler,
   GoalSessionCloseOperation,
   GoalTaskGateDecision,
   GoalTaskGateDeps,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1453,6 +1453,7 @@ export type {
   GoalEvaluationModelInput,
   GoalEvaluationModelResult,
   GoalEvaluatorDeps,
+  GoalEvaluatorResource,
 } from './goal-evaluator.js';
 export {
   buildGoalTools,

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -4216,7 +4216,7 @@ export class SessionManager {
     if (childStopError !== undefined) throw childStopError;
   }
 
-  async closePendingHostedLinkedChildAdmission(input: {
+  async closePendingHostedAdmission(input: {
     sessionId: string;
     turnId: string;
     runId: string;
@@ -4227,53 +4227,82 @@ export class SessionManager {
     >;
   }): Promise<void> {
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {
-      throw new Error('Linked child admission recovery requires execution stores');
+      throw new Error('Hosted admission recovery requires execution stores');
     }
     const session = await this.deps.store.readHeader(input.sessionId);
-    if (
-      session.subagentParent?.kind !== 'subagent' ||
-      session.subagentRuntime?.agentId !== input.execution.agentId ||
-      session.subagentRuntime.agentName !== input.execution.agentName
-    ) {
-      throw new Error(
-        `Admitted Turn ${input.turnId} does not match its linked child Session identity`,
-      );
-    }
-
-    const continuationAuthority = runtimeContinuationAuthority(this.deps.runtimeEventStore);
-    if (continuationAuthority) {
-      const claimState = (
-        await continuationAuthority.listContinuationClaimsForRecovery(input.sessionId)
-      ).find(
-        (candidate) =>
-          candidate.claim.target.runId === input.runId ||
-          candidate.claim.target.turnId === input.turnId,
-      );
-      if (claimState) {
-        assertClaimOwnsHostedLinkedChildAdmission(input, claimState.claim);
-        // The continuation claim is the durable owner of this target identity.
-        // SessionManager's claim-repair saga must materialize its exact header;
-        // the generic hosted-admission repair must not steal the same Run ID.
-        return;
-      }
-    }
-
+    const headerExtras: Partial<AgentRunHeader> = {};
+    let recoveryReason: string;
+    let diagnostic: Record<string, unknown>;
     let workspaceIdentity: string | undefined;
-    if (
-      input.execution.kind === 'linked_child_resume' ||
-      input.execution.kind === 'linked_child_provider_retry'
-    ) {
-      const sourceRun = await this.deps.runStore.readRun(
-        input.sessionId,
-        input.execution.sourceRunId,
-      );
+    if (input.execution.kind === 'goal') {
+      headerExtras.goalId = input.execution.goalId;
+      recoveryReason = 'goal_internal_admission_without_run';
+      diagnostic = {
+        executionKind: input.execution.kind,
+        goalId: input.execution.goalId,
+      };
+    } else {
       if (
-        sourceRun.agentId !== input.execution.agentId ||
-        sourceRun.agentName !== input.execution.agentName
+        session.subagentParent?.kind !== 'subagent' ||
+        session.subagentRuntime?.agentId !== input.execution.agentId ||
+        session.subagentRuntime.agentName !== input.execution.agentName
       ) {
-        throw new Error(`Admitted Turn ${input.turnId} source changed its trusted agent identity`);
+        throw new Error(
+          `Admitted Turn ${input.turnId} does not match its linked child Session identity`,
+        );
       }
-      workspaceIdentity = sourceRun.workspaceIdentity;
+
+      const continuationAuthority = runtimeContinuationAuthority(this.deps.runtimeEventStore);
+      if (continuationAuthority) {
+        const claimState = (
+          await continuationAuthority.listContinuationClaimsForRecovery(input.sessionId)
+        ).find(
+          (candidate) =>
+            candidate.claim.target.runId === input.runId ||
+            candidate.claim.target.turnId === input.turnId,
+        );
+        if (claimState) {
+          assertClaimOwnsHostedLinkedChildAdmission(input, claimState.claim);
+          // The continuation claim is the durable owner of this target identity.
+          // SessionManager's claim-repair saga must materialize its exact header;
+          // the generic hosted-admission repair must not steal the same Run ID.
+          return;
+        }
+      }
+
+      if (
+        input.execution.kind === 'linked_child_resume' ||
+        input.execution.kind === 'linked_child_provider_retry'
+      ) {
+        const sourceRun = await this.deps.runStore.readRun(
+          input.sessionId,
+          input.execution.sourceRunId,
+        );
+        if (
+          sourceRun.agentId !== input.execution.agentId ||
+          sourceRun.agentName !== input.execution.agentName
+        ) {
+          throw new Error(
+            `Admitted Turn ${input.turnId} source changed its trusted agent identity`,
+          );
+        }
+        workspaceIdentity = sourceRun.workspaceIdentity;
+        if (input.execution.kind === 'linked_child_resume') {
+          headerExtras.resumedFromRunId = input.execution.sourceRunId;
+        } else {
+          headerExtras.retriedFromRunId = input.execution.sourceRunId;
+        }
+      }
+      headerExtras.agentId = input.execution.agentId;
+      headerExtras.agentName = input.execution.agentName;
+      recoveryReason = 'child_internal_admission_without_run';
+      diagnostic = {
+        executionKind: input.execution.kind,
+        ...(input.execution.kind === 'linked_child_resume' ||
+        input.execution.kind === 'linked_child_provider_retry'
+          ? { sourceRunId: input.execution.sourceRunId }
+          : {}),
+      };
     }
 
     const run: AgentRunHeader = {
@@ -4291,19 +4320,11 @@ export class SessionManager {
       collaborationMode: session.collaborationMode ?? 'agent',
       createdAt: input.admittedAt,
       updatedAt: input.admittedAt,
-      ...(input.execution.kind === 'linked_child_resume'
-        ? { resumedFromRunId: input.execution.sourceRunId }
-        : {}),
-      ...(input.execution.kind === 'linked_child_provider_retry'
-        ? { retriedFromRunId: input.execution.sourceRunId }
-        : {}),
-      agentId: input.execution.agentId,
-      agentName: input.execution.agentName,
+      ...headerExtras,
     };
     await this.deps.runStore.createRun(run, { durable: true });
 
     const ts = this.deps.now();
-    const recoveryReason = 'child_internal_admission_without_run';
     const terminalEvent = buildRecoveredTerminalRuntimeEvent({
       id: this.deps.newId(),
       run,
@@ -4311,13 +4332,7 @@ export class SessionManager {
       ts,
       failureClass: 'app_restarted',
       recoveryReason,
-      diagnostic: {
-        executionKind: input.execution.kind,
-        ...(input.execution.kind === 'linked_child_resume' ||
-        input.execution.kind === 'linked_child_provider_retry'
-          ? { sourceRunId: input.execution.sourceRunId }
-          : {}),
-      },
+      diagnostic,
       message: 'app_restarted',
     });
     await commitTerminalRunWithRuntimeFact({
@@ -4334,7 +4349,7 @@ export class SessionManager {
       runEventData: {
         recovered: true,
         recoveryReason,
-        executionKind: input.execution.kind,
+        ...diagnostic,
       },
       existingEvents: [],
     });

--- a/packages/runtime/src/telemetry/index.ts
+++ b/packages/runtime/src/telemetry/index.ts
@@ -2,6 +2,7 @@ export { BUILTIN_PRICING, getBuiltinPricing } from './builtin-pricing.js';
 export { computeCost } from './cost.js';
 export { buildPricingLookup } from './pricing.js';
 export { recordLlmCall } from './record-llm-call.js';
+export { llmCallUsageFields } from './llm-call-usage.js';
 export { recordToolInvocation } from './record-tool-invocation.js';
 export type { LlmRecorderDeps } from './record-llm-call.js';
 export type { ToolRecorderDeps } from './record-tool-invocation.js';

--- a/packages/runtime/src/telemetry/record-llm-call.ts
+++ b/packages/runtime/src/telemetry/record-llm-call.ts
@@ -5,7 +5,7 @@ import { computeCost } from './cost.js';
 import type { TelemetryRepoLite } from './types.js';
 
 export interface LlmRecorderDeps {
-  repo: TelemetryRepoLite;
+  repo: Pick<TelemetryRepoLite, 'insertLlmCall'>;
   lookupPricing: (modelKey: string) => PricingConfig | null;
 }
 

--- a/packages/runtime/src/telemetry/record-tool-invocation.ts
+++ b/packages/runtime/src/telemetry/record-tool-invocation.ts
@@ -6,7 +6,7 @@ import type { TelemetryRepoLite } from './types.js';
 const ARGS_SUMMARY_MAX = 512;
 
 export interface ToolRecorderDeps {
-  repo: TelemetryRepoLite;
+  repo: Pick<TelemetryRepoLite, 'insertToolInvocation'>;
 }
 
 export async function recordToolInvocation(

--- a/packages/storage/src/__tests__/telemetry-repo.test.ts
+++ b/packages/storage/src/__tests__/telemetry-repo.test.ts
@@ -350,6 +350,14 @@ describe('FileTelemetryRepo', () => {
         ),
         repo.insertLlmCall(
           llmRecord({
+            id: 'usage_goal_evaluation_session_1_3',
+            callKind: 'goal_evaluation',
+            callId: 'goal_evaluation_session_1_3',
+            ts: 3,
+          }),
+        ),
+        repo.insertLlmCall(
+          llmRecord({
             id: 'usage_semantic_compact_turn_1_2_3',
             callKind: 'semantic_compact',
             callId: 'semantic_compact_turn_1_2_3',
@@ -362,6 +370,7 @@ describe('FileTelemetryRepo', () => {
       assert.deepEqual(
         rows.map((row) => [row.callKind, row.callId]),
         [
+          ['goal_evaluation', 'goal_evaluation_session_1_3'],
           ['semantic_compact', 'semantic_compact_turn_1_2_3'],
           ['history_compact', 'history_compact_turn_1_1_2'],
         ],

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -2947,6 +2947,16 @@ function normalizeRootExecutionDescriptor(value: unknown): RootExecutionDescript
     }
     return Object.freeze({ kind: 'automation', automationId: value.automationId });
   }
+  if (value.kind === 'goal') {
+    if (
+      !hasExactKeys(value, ['kind', 'goalId']) ||
+      typeof value.goalId !== 'string' ||
+      !isSafeId(value.goalId)
+    ) {
+      throw new Error('Invalid root execution descriptor');
+    }
+    return Object.freeze({ kind: 'goal', goalId: value.goalId });
+  }
   if (value.kind === 'claimed_agent_graph_intent') {
     if (
       !hasExactKeys(value, ['kind', 'claim', 'agentId', 'agentName']) ||

--- a/packages/storage/src/telemetry-file-schema.ts
+++ b/packages/storage/src/telemetry-file-schema.ts
@@ -1,4 +1,8 @@
-import type { LlmCallRecord, ToolInvocationRecord } from '@maka/core/usage-stats/types';
+import {
+  MODEL_CALL_KINDS,
+  type LlmCallRecord,
+  type ToolInvocationRecord,
+} from '@maka/core/usage-stats/types';
 import { isContextBudgetDiagnostic, isPromptSegmentEstimate } from '@maka/core/usage-record-schema';
 
 export type PersistedLlmCallRecord = LlmCallRecord & {
@@ -262,7 +266,7 @@ export function decodePersistedLlmCallRecord(input: unknown): PersistedLlmCallRe
   ) {
     throw invalid('invalid optional LLM string');
   }
-  if (!optionalEnum(input.callKind, new Set(['main', 'semantic_compact', 'history_compact']))) {
+  if (!optionalEnum(input.callKind, new Set(MODEL_CALL_KINDS))) {
     throw invalid('invalid callKind');
   }
   if (!optionalEnum(input.prefixChangeReason, PREFIX_CHANGE_REASONS)) {

--- a/packages/ui/src/__tests__/goal-origin-presentation.test.tsx
+++ b/packages/ui/src/__tests__/goal-origin-presentation.test.tsx
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TurnView } from '../chat-turn.js';
+import { LocaleProvider } from '../locale-context.js';
+import type { TurnViewModel } from '../materialize.js';
+
+test('marks a Goal continuation as Host-authored and does not offer user-message editing', () => {
+  const markup = renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <TurnView turn={goalTurn()} onEditUserMessage={() => {}} />
+    </LocaleProvider>,
+  );
+
+  assert.match(markup, /Continued by Goal/);
+  assert.match(markup, /Continued by Goal · goal-1/);
+  assert.doesNotMatch(markup, /Edit &amp; resend/);
+});
+
+function goalTurn(): TurnViewModel {
+  return {
+    turnId: 'turn-1',
+    status: 'completed',
+    partialOutputRetained: false,
+    user: {
+      id: 'message-1',
+      role: 'user',
+      text: '[Goal continuation] Keep working.',
+      hostOrigin: { kind: 'goal', goalId: 'goal-1' },
+    },
+    tools: [],
+    timeline: [],
+    notes: [],
+    startedAt: 1,
+  };
+}

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -43,6 +43,28 @@ describe('materializeChat attachments', () => {
     assert.equal(items[0].attachments, undefined);
   });
 
+  test('preserves Host provenance on a Goal continuation', () => {
+    const messages: StoredMessage[] = [
+      {
+        type: 'user',
+        id: 'm1',
+        turnId: 't1',
+        ts: 1,
+        text: '[Goal continuation] Keep working.',
+        origin: { kind: 'goal', goalId: 'goal-1' },
+      },
+    ];
+
+    assert.deepEqual(materializeChat(messages)[0]?.hostOrigin, {
+      kind: 'goal',
+      goalId: 'goal-1',
+    });
+    assert.deepEqual(materializeTurns(messages)[0]?.user?.hostOrigin, {
+      kind: 'goal',
+      goalId: 'goal-1',
+    });
+  });
+
   test('surfaces automatic context compaction system notes inline', () => {
     const messages: StoredMessage[] = [
       { type: 'system_note', id: 'note-1', turnId: 't1', ts: 1, kind: 'context_compacted' },

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -388,24 +388,33 @@ export const TurnView = memo(function TurnView(props: {
           ))}
         </Marker>
       )}
-      {/* Automation provenance: a turn injected by a scheduled automation is
-          NOT something the user typed — say so above the bubble instead of
-          impersonating the user. Id stays in the tooltip (no raw ids inline). */}
-      {turn.user?.automationOrigin && (
+      {/* Host provenance keeps non-user prompts from impersonating the user.
+          Durable ids stay in tooltips instead of the transcript body. */}
+      {turn.user?.hostOrigin?.kind === 'automation' && (
         <Marker
           variant="automation-origin"
           role="note"
-          title={copy.automationTitle(turn.user.automationOrigin.automationId)}
+          title={copy.automationTitle(turn.user.hostOrigin.automationId)}
         >
           <Timer size={12} aria-hidden="true" />
           <span>{copy.automationTriggered}</span>
         </Marker>
       )}
-      {turn.user?.agentGraphOrigin && (
+      {turn.user?.hostOrigin?.kind === 'goal' && (
         <Marker
           variant="automation-origin"
           role="note"
-          title={copy.agentGraphTitle(turn.user.agentGraphOrigin.graphId)}
+          title={copy.goalTitle(turn.user.hostOrigin.goalId)}
+        >
+          <RefreshCcw size={12} aria-hidden="true" />
+          <span>{copy.goalContinued}</span>
+        </Marker>
+      )}
+      {turn.user?.hostOrigin?.kind === 'agent_graph' && (
+        <Marker
+          variant="automation-origin"
+          role="note"
+          title={copy.agentGraphTitle(turn.user.hostOrigin.graphId)}
         >
           <GitBranch size={12} aria-hidden="true" />
           <span>{copy.agentGraphTriggered}</span>
@@ -425,9 +434,7 @@ export const TurnView = memo(function TurnView(props: {
             quotes={turn.user.quotes}
             onReadAttachmentBytes={props.onReadAttachmentBytes}
             onEditUserMessage={
-              props.onEditUserMessage &&
-              !turn.user.automationOrigin &&
-              !turn.user.agentGraphOrigin
+              props.onEditUserMessage && !turn.user.hostOrigin
                 ? () => props.onEditUserMessage?.(turn.turnId)
                 : undefined
             }

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -212,6 +212,8 @@ export interface ConversationCopy {
     derivativesAriaLabel: string;
     automationTriggered: string;
     automationTitle: (id: string) => string;
+    goalContinued: string;
+    goalTitle: (id: string) => string;
     agentGraphTriggered: string;
     agentGraphTitle: (graphId: string) => string;
     thinkingTruncatedTitle: string;
@@ -393,7 +395,7 @@ const CONVERSATION_COPY = {
     },
     messages: {
       you: '你', assistant: 'Maka', processing: '正在处理…', continuing: '继续中…', providerRetryScheduled: (seconds, attempt, maxAttempts) => `${seconds} 秒后重试（${attempt}/${maxAttempts}）`, providerRetryStarted: (attempt, maxAttempts) => `正在重试（${attempt}/${maxAttempts}）`, safeResumePending: '正在验证…', safeResume: '安全恢复', thinking: '深度思考', truncated: '已截断', copied: '已复制', copying: '复制中', copyFailed: '复制失败', copy: '复制', editMessage: '编辑并重发', editMessageDisabledRunning: '当前回答仍在进行中，结束后再编辑', editMessageDisabledAttachments: '包含附件的历史消息暂不支持编辑并重发', editMessageDisabledQuotes: '包含引用的历史消息暂不支持编辑并重发', editMessageDisabledTransformedText: '通过显式技能发送的历史消息暂不支持编辑并重发',
-      imageAriaLabel: (name) => `查看图片 ${name}`, userAriaLabel: '你发送的消息', systemAriaLabel: '系统消息', assistantAriaLabel: 'Maka 的回答', answerActionsAriaLabel: '本轮回答操作', sourceAriaLabel: '本轮回答的来源', derivativesAriaLabel: '本轮回答的衍生', automationTriggered: '定时任务触发', automationTitle: (id) => `由定时任务触发 · ${id}`, agentGraphTriggered: 'Agent Graph 自动继续', agentGraphTitle: (graphId) => `由 Agent Graph 调度器触发 · ${graphId}`,
+      imageAriaLabel: (name) => `查看图片 ${name}`, userAriaLabel: '你发送的消息', systemAriaLabel: '系统消息', assistantAriaLabel: 'Maka 的回答', answerActionsAriaLabel: '本轮回答操作', sourceAriaLabel: '本轮回答的来源', derivativesAriaLabel: '本轮回答的衍生', automationTriggered: '定时任务触发', automationTitle: (id) => `由定时任务触发 · ${id}`, goalContinued: 'Goal 自动继续', goalTitle: (id) => `由 Goal 继续执行 · ${id}`, agentGraphTriggered: 'Agent Graph 自动继续', agentGraphTitle: (graphId) => `由 Agent Graph 调度器触发 · ${graphId}`,
       thinkingTruncatedTitle: '部分 reasoning 已截断；显示的是最近的内容', outputTruncatedTitle: '助手输出已超过单次回合上限，超出部分未渲染。如需完整内容请重新生成或查看持久化的会话日志。', removeAttachmentAriaLabel: (name) => `移除 ${name}`, quoteLabel: '引用', quoteExpandAriaLabel: '展开引用全文', quoteCollapseAriaLabel: '收起引用', removeQuoteAriaLabel: '移除引用', aborted: '(已中断)', abortedByStop: '(已中断 · 由停止按钮触发)',
     },
     chat: {
@@ -540,7 +542,7 @@ const CONVERSATION_COPY = {
     },
     messages: {
       you: 'You', assistant: 'Maka', processing: 'Working…', continuing: 'Continuing…', providerRetryScheduled: (seconds, attempt, maxAttempts) => `Retrying in ${seconds}s (${attempt}/${maxAttempts})`, providerRetryStarted: (attempt, maxAttempts) => `Retrying (${attempt}/${maxAttempts})`, safeResumePending: 'Checking…', safeResume: 'Safe recovery', thinking: 'Thinking', truncated: 'Truncated', copied: 'Copied', copying: 'Copying', copyFailed: 'Copy failed', copy: 'Copy', editMessage: 'Edit & resend', editMessageDisabledRunning: 'Wait for this answer to finish before editing', editMessageDisabledAttachments: 'Edit & resend does not yet support messages with attachments', editMessageDisabledQuotes: 'Edit & resend does not yet support messages with quotes', editMessageDisabledTransformedText: 'Edit & resend does not yet support messages sent with an explicit skill',
-      imageAriaLabel: (name) => `View image ${name}`, userAriaLabel: 'Your message', systemAriaLabel: 'System message', assistantAriaLabel: "Maka's response", answerActionsAriaLabel: 'Response actions', sourceAriaLabel: 'Source of this response', derivativesAriaLabel: 'Responses derived from this one', automationTriggered: 'Triggered by automation', automationTitle: (id) => `Triggered by automation · ${id}`, agentGraphTriggered: 'Continued by Agent Graph', agentGraphTitle: (graphId) => `Triggered by the Agent Graph scheduler · ${graphId}`,
+      imageAriaLabel: (name) => `View image ${name}`, userAriaLabel: 'Your message', systemAriaLabel: 'System message', assistantAriaLabel: "Maka's response", answerActionsAriaLabel: 'Response actions', sourceAriaLabel: 'Source of this response', derivativesAriaLabel: 'Responses derived from this one', automationTriggered: 'Triggered by automation', automationTitle: (id) => `Triggered by automation · ${id}`, goalContinued: 'Continued by Goal', goalTitle: (id) => `Continued by Goal · ${id}`, agentGraphTriggered: 'Continued by Agent Graph', agentGraphTitle: (graphId) => `Triggered by the Agent Graph scheduler · ${graphId}`,
       thinkingTruncatedTitle: 'Some reasoning was truncated; showing the most recent content', outputTruncatedTitle: 'The assistant output exceeded the per-turn limit. Regenerate it or inspect the persisted session log for the complete content.', removeAttachmentAriaLabel: (name) => `Remove ${name}`, quoteLabel: 'Quote', quoteExpandAriaLabel: 'Show the full quoted excerpt', quoteCollapseAriaLabel: 'Collapse the quoted excerpt', removeQuoteAriaLabel: 'Remove quote', aborted: '(Interrupted)', abortedByStop: '(Interrupted · Stop button)',
     },
     chat: {

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -6,7 +6,7 @@ import {
   STEP_LIMIT_NOTICE_TEXT,
   toolResultActivityStatus,
 } from '@maka/core';
-import type { AttachmentRef, QuoteRef, ShellRunUpdate, StoredMessage, ToolActivityKind, ToolResultContent, TurnRecord, TurnStatus } from '@maka/core';
+import type { AttachmentRef, QuoteRef, ShellRunUpdate, StoredMessage, ToolActivityKind, ToolResultContent, TurnRecord, TurnStatus, UserMessage } from '@maka/core';
 import type { LiveTurnProjection } from './live-turn-projection.js';
 
 export { isCancelledToolResultContent, toolResultActivityStatus } from '@maka/core';
@@ -21,10 +21,8 @@ export interface ChatItem {
   attachments?: AttachmentRef[];
   /** Inline quoted excerpts projected from StoredMessage; user rows only. */
   quotes?: QuoteRef[];
-  /** Present when the turn was fired by an automation, not hand-typed. */
-  automationOrigin?: { automationId: string };
-  /** Present when the host resumed the root Agent at a durable graph milestone. */
-  agentGraphOrigin?: { graphId: string; wakeId: string; attemptId: string };
+  /** Present when the Host authored this message instead of the user. */
+  hostOrigin?: NonNullable<UserMessage['origin']>;
 }
 
 /**
@@ -117,6 +115,7 @@ export function materializeChat(messages: StoredMessage[]): ChatItem[] {
         ts: message.ts,
         ...(message.attachments && message.attachments.length > 0 ? { attachments: message.attachments } : {}),
         ...(message.quotes && message.quotes.length > 0 ? { quotes: message.quotes } : {}),
+        ...(message.origin ? { hostOrigin: message.origin } : {}),
       });
     }
     if (message.type === 'assistant') items.push({ id: message.id, role: 'assistant', text: message.text, ts: message.ts });
@@ -480,16 +479,7 @@ export function materializeTurns(messages: StoredMessage[]): TurnViewModel[] {
         ts: message.ts,
         ...(message.attachments && message.attachments.length > 0 ? { attachments: message.attachments } : {}),
         ...(message.quotes && message.quotes.length > 0 ? { quotes: message.quotes } : {}),
-        ...(message.origin?.kind === 'automation' ? { automationOrigin: { automationId: message.origin.automationId } } : {}),
-        ...(message.origin?.kind === 'agent_graph'
-          ? {
-              agentGraphOrigin: {
-                graphId: message.origin.graphId,
-                wakeId: message.origin.wakeId,
-                attemptId: message.origin.attemptId,
-              },
-            }
-          : {}),
+        ...(message.origin ? { hostOrigin: message.origin } : {}),
       };
     } else if (message.type === 'assistant') {
       // A turn now holds one AssistantMessage per model step. Concatenate their


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Move Goal lifecycle authority into Runtime Host so every client attached to a Session observes and controls the same Goal.
- Add closed query and revision-CAS control operations for setting, pausing, resuming, and clearing Goals.
- Route Goal continuations through canonical root-turn admission with durable Goal provenance and crash-window recovery.
- Run Goal evaluation against the Session's canonical model connection, with physical cancellation and normal usage/pricing telemetry.

## Runtime contract

- Goal state is intentionally Host-resident and is cleared when the Host process restarts.
- Continuation admission is bound to the exact Goal checkpoint and control lease, so stale work cannot cross a concurrent Goal mutation.
- A crash after durable Goal admission but before Run creation is closed as failed during recovery; it is not replayed blindly.
- Evaluator usage is recorded as `goal_evaluation`, while evaluator tokens remain outside the Goal's working-turn token budget.
- The wire protocol remains v0; the exact Session continuity projection advances to schema v3 to include Goal state.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- Runtime: 2,754 passed, 9 skipped
- Runtime Host: 456 passed

Related to #1167.

</details>

<details>
<summary>中文</summary>

## 概要

- 将 Goal 生命周期权威迁移到 Runtime Host，使连接到同一 Session 的所有客户端观察并控制同一个 Goal。
- 新增封闭的查询接口，以及基于 revision CAS 的设置、暂停、恢复和清除操作。
- 让 Goal continuation 统一经过规范的 root-turn admission，并持久记录 Goal 来源及处理崩溃窗口恢复。
- 使用 Session 的规范模型连接执行 Goal 评估，同时支持真实请求取消，并纳入正常的 usage/pricing 计量。

## 运行时契约

- Goal 状态有意仅驻留在 Host 内存中；Host 进程重启时会清除。
- Continuation admission 绑定精确的 Goal checkpoint 与 control lease，因此过期工作无法越过并发 Goal 变更。
- 若在 Goal admission 已持久化、但 Run 尚未创建时崩溃，恢复阶段会将其关闭为失败，而不会盲目重放。
- Evaluator 用量以 `goal_evaluation` 记录，但 evaluator token 不计入 Goal 的工作轮次 token budget。
- Wire protocol 继续保持 v0；为包含 Goal 状态，精确 Session continuity projection 升级到 schema v3。

## 验证

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- Runtime：2,754 passed，9 skipped
- Runtime Host：456 passed

关联 #1167。

</details>
