### PR TITLE
test: collapse bot helper coverage

### DIFF
--- a/packages/runtime/src/bots/__tests__/bot-user-allowlist.test.ts
+++ b/packages/runtime/src/bots/__tests__/bot-user-allowlist.test.ts
@@ -5,37 +5,21 @@ import { __TEST__ } from '../simple-bridge.js';
 
 const { isAllowedUser } = __TEST__;
 
-describe('isAllowedUser (PR-BOT-USER-ALLOWLIST-0)', () => {
-  it('returns true when no allowlist is configured (V0.1 default)', () => {
-    assert.equal(isAllowedUser(undefined, '12345'), true);
-  });
-
-  it('returns true when the allowlist is empty (treated as unconfigured)', () => {
-    assert.equal(isAllowedUser([], '12345'), true);
-  });
-
-  it('admits a user whose id matches an entry exactly', () => {
-    assert.equal(isAllowedUser(['12345', '67890'], '12345'), true);
-    assert.equal(isAllowedUser(['12345', '67890'], '67890'), true);
-  });
-
-  it('rejects a user whose id is not in the list', () => {
-    assert.equal(isAllowedUser(['12345', '67890'], '99999'), false);
-  });
-
-  it('does not substring-match — a prefix is NOT a match', () => {
-    // Telegram user IDs are 64-bit so partial matches must never be
-    // accepted: '123' should not unlock '1234567890'.
-    assert.equal(isAllowedUser(['1234567890'], '123'), false);
-    assert.equal(isAllowedUser(['1234567890'], '67890'), false);
-  });
-
-  it('rejects empty / falsy candidate user IDs even when present in list', () => {
-    // Defense-in-depth: even if normalization let an empty string through
-    // (it does not — see settings test), the runtime gate should still
-    // not match an empty incoming id to anything.
-    assert.equal(isAllowedUser([''], ''), true); // exact match per Set semantics
-    // ...but a real allowlist of real IDs should not admit '':
-    assert.equal(isAllowedUser(['12345'], ''), false);
+describe('isAllowedUser', () => {
+  it('defaults open and otherwise requires an exact user-id match', () => {
+    const cases: Array<[string[] | undefined, string, boolean]> = [
+      [undefined, '12345', true],
+      [[], '12345', true],
+      [['12345', '67890'], '12345', true],
+      [['12345', '67890'], '67890', true],
+      [['12345', '67890'], '99999', false],
+      [['1234567890'], '123', false],
+      [['1234567890'], '67890', false],
+      [[''], '', true],
+      [['12345'], '', false],
+    ];
+    for (const [allowlist, userId, expected] of cases) {
+      assert.equal(isAllowedUser(allowlist, userId), expected, `${allowlist}:${userId}`);
+    }
   });
 });

--- a/packages/runtime/src/bots/__tests__/telegram-attachment-kind.test.ts
+++ b/packages/runtime/src/bots/__tests__/telegram-attachment-kind.test.ts
@@ -5,66 +5,38 @@ import { __TEST__ } from '../simple-bridge.js';
 
 const { telegramAttachmentKind } = __TEST__;
 
-describe('telegramAttachmentKind (PR-BOT-NON-TEXT-MESSAGE-ACK-0)', () => {
-  it('returns undefined for a plain text message', () => {
-    assert.equal(telegramAttachmentKind({ text: 'hello' }), undefined);
-    assert.equal(telegramAttachmentKind({ caption: 'hi' }), undefined);
+describe('telegramAttachmentKind', () => {
+  it('maps supported attachment fields and rejects non-attachments', () => {
+    const cases: Array<[unknown, string | undefined]> = [
+      [{ text: 'hello' }, undefined],
+      [{ caption: 'hi' }, undefined],
+      [{ photo: [] }, undefined],
+      [undefined, undefined],
+      [null, undefined],
+      ['text', undefined],
+      [{ photo: [{ file_id: 'a' }], caption: 'look' }, 'photo'],
+      [{ voice: { file_id: 'v' } }, 'voice'],
+      [{ audio: { file_id: 'a' } }, 'audio'],
+      [{ sticker: { file_id: 's' } }, 'sticker'],
+      [{ animation: { file_id: 'g' } }, 'animation'],
+      [{ video: { file_id: 'v' } }, 'video'],
+      [{ video_note: { file_id: 'vn' } }, 'video'],
+      [{ document: { file_id: 'd' } }, 'document'],
+    ];
+    for (const [message, expected] of cases) {
+      assert.equal(telegramAttachmentKind(message), expected, JSON.stringify(message));
+    }
   });
 
-  it('identifies photo messages (Telegram sends an array of sizes)', () => {
-    assert.equal(
-      telegramAttachmentKind({ photo: [{ file_id: 'a', width: 90, height: 90 }] }),
-      'photo',
-    );
-  });
-
-  it('treats an empty photo array as no photo', () => {
-    // Telegram never sends an empty photo array, but be defensive.
-    assert.equal(telegramAttachmentKind({ photo: [] }), undefined);
-  });
-
-  it('identifies voice / audio separately so the ack copy can differ', () => {
-    assert.equal(telegramAttachmentKind({ voice: { file_id: 'v' } }), 'voice');
-    assert.equal(telegramAttachmentKind({ audio: { file_id: 'a' } }), 'audio');
-  });
-
-  it('identifies stickers without confusing them with images', () => {
-    assert.equal(telegramAttachmentKind({ sticker: { file_id: 's' } }), 'sticker');
-  });
-
-  it('identifies animation (GIFs) separately from video', () => {
-    assert.equal(telegramAttachmentKind({ animation: { file_id: 'g' } }), 'animation');
-    assert.equal(telegramAttachmentKind({ video: { file_id: 'v' } }), 'video');
-    assert.equal(telegramAttachmentKind({ video_note: { file_id: 'vn' } }), 'video');
-  });
-
-  it('identifies generic documents', () => {
-    assert.equal(telegramAttachmentKind({ document: { file_id: 'd' } }), 'document');
-  });
-
-  it('returns "unknown" for less common subtypes so they still get an ack', () => {
-    assert.equal(telegramAttachmentKind({ location: { latitude: 0, longitude: 0 } }), 'unknown');
-    assert.equal(telegramAttachmentKind({ contact: { phone_number: '+1' } }), 'unknown');
-    assert.equal(telegramAttachmentKind({ poll: { question: 'q' } }), 'unknown');
-    assert.equal(telegramAttachmentKind({ dice: { emoji: '🎲', value: 4 } }), 'unknown');
-    assert.equal(telegramAttachmentKind({ venue: { title: 'v' } }), 'unknown');
-  });
-
-  it('defends against missing / non-object input', () => {
-    assert.equal(telegramAttachmentKind(undefined), undefined);
-    assert.equal(telegramAttachmentKind(null), undefined);
-    assert.equal(telegramAttachmentKind('text'), undefined);
-  });
-
-  it('photo takes precedence over caption text presence', () => {
-    // A photo with caption — kind should still be detectable so the
-    // handler can route on attachment + text together.
-    assert.equal(
-      telegramAttachmentKind({
-        photo: [{ file_id: 'a', width: 90, height: 90 }],
-        caption: 'look at this',
-      }),
-      'photo',
-    );
+  it('classifies less common Telegram payloads as unknown so they still receive an ack', () => {
+    for (const message of [
+      { location: { latitude: 0, longitude: 0 } },
+      { contact: { phone_number: '+1' } },
+      { poll: { question: 'q' } },
+      { dice: { emoji: '🎲', value: 4 } },
+      { venue: { title: 'v' } },
+    ]) {
+      assert.equal(telegramAttachmentKind(message), 'unknown');
+    }
   });
 });

--- a/packages/runtime/src/bots/__tests__/telegram-ephemeral.test.ts
+++ b/packages/runtime/src/bots/__tests__/telegram-ephemeral.test.ts
@@ -5,52 +5,24 @@ import { __TEST__ } from '../simple-bridge.js';
 
 const { ephemeralDelayFromOptions, EPHEMERAL_REPLY_MIN_MS, EPHEMERAL_REPLY_MAX_MS } = __TEST__;
 
-describe('ephemeralDelayFromOptions (PR-BOT-EPHEMERAL-REPLY-0)', () => {
-  it('returns undefined when no options are provided', () => {
-    assert.equal(ephemeralDelayFromOptions(undefined), undefined);
-  });
-
-  it('returns undefined when ephemeralTtlMs is missing', () => {
-    assert.equal(ephemeralDelayFromOptions({}), undefined);
-    assert.equal(ephemeralDelayFromOptions({ replyToMessageId: 'm-1' }), undefined);
-  });
-
-  it('returns undefined when ephemeralTtlMs is zero or negative (opt-out)', () => {
-    assert.equal(ephemeralDelayFromOptions({ ephemeralTtlMs: 0 }), undefined);
-    assert.equal(ephemeralDelayFromOptions({ ephemeralTtlMs: -1 }), undefined);
-    assert.equal(ephemeralDelayFromOptions({ ephemeralTtlMs: -60_000 }), undefined);
-  });
-
-  it('returns undefined for non-finite ephemeralTtlMs (defends against NaN / Infinity)', () => {
-    assert.equal(ephemeralDelayFromOptions({ ephemeralTtlMs: Number.NaN }), undefined);
-    assert.equal(
-      ephemeralDelayFromOptions({ ephemeralTtlMs: Number.POSITIVE_INFINITY }),
-      undefined,
-    );
-  });
-
-  it('floors a too-small TTL at the minimum so an immediate self-delete cannot race the send', () => {
-    // 100ms requested — clamp up to MIN so we never schedule a delete
-    // that could fire before the Telegram receiver finishes rendering.
-    assert.equal(ephemeralDelayFromOptions({ ephemeralTtlMs: 100 }), EPHEMERAL_REPLY_MIN_MS);
-    assert.equal(ephemeralDelayFromOptions({ ephemeralTtlMs: 1 }), EPHEMERAL_REPLY_MIN_MS);
-  });
-
-  it('passes through TTLs within the valid window', () => {
-    assert.equal(ephemeralDelayFromOptions({ ephemeralTtlMs: 5 * 60 * 1_000 }), 5 * 60 * 1_000);
-    assert.equal(ephemeralDelayFromOptions({ ephemeralTtlMs: 60 * 60 * 1_000 }), 60 * 60 * 1_000);
-  });
-
-  it('caps a too-large TTL at the 48-hour bot self-delete window', () => {
-    // Telegram silently refuses bot self-delete past 48 hours in DMs,
-    // so scheduling a longer timer would be a no-op surprise.
-    assert.equal(
-      ephemeralDelayFromOptions({ ephemeralTtlMs: 72 * 60 * 60 * 1_000 }),
-      EPHEMERAL_REPLY_MAX_MS,
-    );
-    assert.equal(
-      ephemeralDelayFromOptions({ ephemeralTtlMs: 7 * 24 * 60 * 60 * 1_000 }),
-      EPHEMERAL_REPLY_MAX_MS,
-    );
+describe('ephemeralDelayFromOptions', () => {
+  it('rejects invalid TTLs and clamps valid TTLs to Telegram limits', () => {
+    const cases: Array<[Parameters<typeof ephemeralDelayFromOptions>[0], number | undefined]> = [
+      [undefined, undefined],
+      [{}, undefined],
+      [{ replyToMessageId: 'm-1' }, undefined],
+      [{ ephemeralTtlMs: 0 }, undefined],
+      [{ ephemeralTtlMs: -1 }, undefined],
+      [{ ephemeralTtlMs: Number.NaN }, undefined],
+      [{ ephemeralTtlMs: Number.POSITIVE_INFINITY }, undefined],
+      [{ ephemeralTtlMs: 1 }, EPHEMERAL_REPLY_MIN_MS],
+      [{ ephemeralTtlMs: 5 * 60_000 }, 5 * 60_000],
+      [{ ephemeralTtlMs: 60 * 60_000 }, 60 * 60_000],
+      [{ ephemeralTtlMs: 72 * 60 * 60_000 }, EPHEMERAL_REPLY_MAX_MS],
+      [{ ephemeralTtlMs: 7 * 24 * 60 * 60_000 }, EPHEMERAL_REPLY_MAX_MS],
+    ];
+    for (const [options, expected] of cases) {
+      assert.equal(ephemeralDelayFromOptions(options), expected, JSON.stringify(options));
+    }
   });
 });

--- a/packages/runtime/src/bots/__tests__/telegram-ratelimit-retry.test.ts
+++ b/packages/runtime/src/bots/__tests__/telegram-ratelimit-retry.test.ts
@@ -5,93 +5,44 @@ import { __TEST__ } from '../simple-bridge.js';
 
 const { classifyTelegramSendResponse, TELEGRAM_RETRY_MIN_MS, TELEGRAM_RETRY_MAX_MS } = __TEST__;
 
-describe('classifyTelegramSendResponse (PR-BOT-RATELIMIT-RETRY-0)', () => {
-  it('returns ok with the message id on a successful response', () => {
-    const result = classifyTelegramSendResponse({
-      ok: true,
-      result: { message_id: 12345 },
+describe('classifyTelegramSendResponse', () => {
+  it('returns the optional message id on successful responses', () => {
+    assert.deepEqual(classifyTelegramSendResponse({ ok: true, result: { message_id: 12345 } }), {
+      kind: 'ok',
+      messageId: '12345',
     });
-    assert.deepEqual(result, { kind: 'ok', messageId: '12345' });
+    assert.deepEqual(classifyTelegramSendResponse({ ok: true, result: {} }), {
+      kind: 'ok',
+      messageId: null,
+    });
   });
 
-  it('returns ok with null id when the success response has no message_id', () => {
-    const result = classifyTelegramSendResponse({ ok: true, result: {} });
-    assert.deepEqual(result, { kind: 'ok', messageId: null });
-  });
-
-  it('returns retry with the Telegram-provided backoff on 429', () => {
-    const result = classifyTelegramSendResponse({
-      ok: false,
-      error_code: 429,
-      description: 'Too Many Requests: retry after 5',
-      parameters: { retry_after: 5 },
-    });
-    assert.equal(result.kind, 'retry');
-    if (result.kind === 'retry') {
-      assert.equal(result.delayMs, 5_000);
+  it('clamps Telegram retry hints to the bounded retry window', () => {
+    for (const [retryAfter, expected] of [
+      [5, 5_000],
+      [0, TELEGRAM_RETRY_MIN_MS],
+      [3600, TELEGRAM_RETRY_MAX_MS],
+      ['wat', TELEGRAM_RETRY_MIN_MS],
+    ] as const) {
+      const result = classifyTelegramSendResponse({
+        ok: false,
+        error_code: 429,
+        parameters: { retry_after: retryAfter },
+      });
+      assert.equal(result.kind, 'retry');
+      if (result.kind === 'retry') assert.equal(result.delayMs, expected, String(retryAfter));
     }
   });
 
-  it('floors the retry delay at the minimum even when Telegram reports 0', () => {
-    const result = classifyTelegramSendResponse({
-      ok: false,
-      error_code: 429,
-      parameters: { retry_after: 0 },
-    });
-    assert.equal(result.kind, 'retry');
-    if (result.kind === 'retry') {
-      assert.equal(result.delayMs, TELEGRAM_RETRY_MIN_MS);
-    }
-  });
-
-  it('caps the retry delay at the maximum so an inflated retry_after cannot stall the bridge', () => {
-    const result = classifyTelegramSendResponse({
-      ok: false,
-      error_code: 429,
-      parameters: { retry_after: 3600 }, // 1 hour
-    });
-    assert.equal(result.kind, 'retry');
-    if (result.kind === 'retry') {
-      assert.equal(result.delayMs, TELEGRAM_RETRY_MAX_MS);
-    }
-  });
-
-  it('returns fatal for permanent 4xx errors', () => {
-    const result = classifyTelegramSendResponse({
-      ok: false,
-      error_code: 400,
-      description: 'Bad Request: chat not found',
-    });
-    assert.deepEqual(result, { kind: 'fatal', description: 'Bad Request: chat not found' });
-  });
-
-  it('returns fatal for 5xx so the bridge does not loop on a Telegram outage', () => {
-    const result = classifyTelegramSendResponse({
-      ok: false,
-      error_code: 502,
-      description: 'Bad Gateway',
-    });
-    assert.deepEqual(result, { kind: 'fatal', description: 'Bad Gateway' });
-  });
-
-  it('returns fatal with a stable description when the response shape is unexpected', () => {
-    const result = classifyTelegramSendResponse(null);
-    assert.deepEqual(result, { kind: 'fatal', description: 'send-failed' });
-
-    const noBody = classifyTelegramSendResponse({});
-    assert.deepEqual(noBody, { kind: 'fatal', description: 'send-failed' });
-  });
-
-  it('treats a non-numeric retry_after as the floor delay', () => {
-    // Defense-in-depth: malformed parameters payload should not crash.
-    const result = classifyTelegramSendResponse({
-      ok: false,
-      error_code: 429,
-      parameters: { retry_after: 'wat' },
-    });
-    assert.equal(result.kind, 'retry');
-    if (result.kind === 'retry') {
-      assert.equal(result.delayMs, TELEGRAM_RETRY_MIN_MS);
+  it('classifies permanent and malformed failures with stable descriptions', () => {
+    const cases: Array<[unknown, string]> = [
+      [{ ok: false, error_code: 400, description: 'Bad Request' }, 'Bad Request'],
+      [{ ok: false, error_code: 502, description: 'Bad Gateway' }, 'Bad Gateway'],
+      [null, 'send-failed'],
+      [{}, 'send-failed'],
+    ];
+    for (const [payload, description] of cases) {
+      assert.deepEqual(classifyTelegramSendResponse(payload), { kind: 'fatal', description });
     }
   });
 });

--- a/packages/runtime/src/bots/__tests__/telegram-reply-to.test.ts
+++ b/packages/runtime/src/bots/__tests__/telegram-reply-to.test.ts
@@ -5,77 +5,39 @@ import { __TEST__ } from '../simple-bridge.js';
 
 const { buildTelegramSendBody, normalizeTelegramReplyToMessageId } = __TEST__;
 
-describe('buildTelegramSendBody (PR-BOT-REPLY-TO-MESSAGE-0)', () => {
-  it('emits only chat_id + text when no reply target is provided', () => {
-    const body = buildTelegramSendBody('chat-1', 'hello', undefined, 0);
-    assert.deepEqual(body, { chat_id: 'chat-1', text: 'hello' });
-  });
-
-  it('threads the first chunk under the originating user message', () => {
-    const body = buildTelegramSendBody('chat-1', 'hello', { replyToMessageId: '42' }, 0);
-    assert.equal(body.chat_id, 'chat-1');
-    assert.equal(body.text, 'hello');
-    assert.equal(body.reply_to_message_id, 42);
-    // Telegram returns 400 if the parent has been deleted; allow_sending_without_reply
-    // lets the bot reply still go through as an ordinary message.
-    assert.equal(body.allow_sending_without_reply, true);
-  });
-
-  it('does NOT thread continuation chunks (chunkIndex > 0)', () => {
-    const body = buildTelegramSendBody('chat-1', '[2/3]\ntail', { replyToMessageId: '42' }, 1);
-    assert.equal(body.chat_id, 'chat-1');
-    assert.equal(body.text, '[2/3]\ntail');
-    assert.equal('reply_to_message_id' in body, false);
-    assert.equal('allow_sending_without_reply' in body, false);
-  });
-
-  it('treats empty / missing replyToMessageId as no thread', () => {
-    const withoutField = buildTelegramSendBody('chat-1', 'hello', {}, 0);
-    assert.equal('reply_to_message_id' in withoutField, false);
-    assert.equal('allow_sending_without_reply' in withoutField, false);
-  });
-
-  it('coerces a decimal message id string to Number — Telegram requires an integer', () => {
-    // BotMessageEvent.sourceMessageId is typed as `string` so the call site
-    // forwards the platform handler capture; safe decimal coercion happens
-    // here so the API call uses the integer the wire protocol expects.
-    const body = buildTelegramSendBody('chat-1', 'hello', { replyToMessageId: '1234567890' }, 0);
-    assert.equal(body.reply_to_message_id, 1234567890);
-    assert.equal(typeof body.reply_to_message_id, 'number');
-  });
-
-  it('omits invalid reply ids rather than sending NaN or zero to Telegram', () => {
-    for (const replyToMessageId of ['abc', '  ', '0', '-1', '1.5']) {
-      const body = buildTelegramSendBody('chat-1', 'hello', { replyToMessageId }, 0);
-      assert.equal('reply_to_message_id' in body, false, replyToMessageId);
-      assert.equal('allow_sending_without_reply' in body, false, replyToMessageId);
-    }
-  });
-
-  it('rejects reply ids outside JavaScript safe integer range', () => {
-    const body = buildTelegramSendBody(
-      'chat-1',
-      'hello',
-      { replyToMessageId: '9007199254740992' },
-      0,
+describe('buildTelegramSendBody', () => {
+  it('threads only the first chunk under a valid originating message', () => {
+    assert.deepEqual(buildTelegramSendBody('chat-1', 'hello', undefined, 0), {
+      chat_id: 'chat-1',
+      text: 'hello',
+    });
+    assert.deepEqual(buildTelegramSendBody('chat-1', 'hello', { replyToMessageId: '42' }, 0), {
+      chat_id: 'chat-1',
+      text: 'hello',
+      reply_to_message_id: 42,
+      allow_sending_without_reply: true,
+    });
+    assert.deepEqual(
+      buildTelegramSendBody('chat-1', '[2/3]\ntail', { replyToMessageId: '42' }, 1),
+      { chat_id: 'chat-1', text: '[2/3]\ntail' },
     );
+  });
 
-    assert.equal('reply_to_message_id' in body, false);
-    assert.equal('allow_sending_without_reply' in body, false);
+  it('omits malformed reply ids instead of sending an invalid Telegram payload', () => {
+    for (const replyToMessageId of ['', 'abc', '0', '-1', '1.5', '9007199254740992']) {
+      assert.deepEqual(buildTelegramSendBody('chat-1', 'hello', { replyToMessageId }, 0), {
+        chat_id: 'chat-1',
+        text: 'hello',
+      });
+    }
   });
 });
 
 describe('normalizeTelegramReplyToMessageId', () => {
-  it('trims and accepts positive safe integer strings', () => {
+  it('accepts positive safe integers and rejects malformed or unsafe values', () => {
     assert.equal(normalizeTelegramReplyToMessageId(' 42 '), 42);
-  });
-
-  it('rejects missing, non-decimal, zero, and unsafe values', () => {
-    assert.equal(normalizeTelegramReplyToMessageId(undefined), undefined);
-    assert.equal(normalizeTelegramReplyToMessageId(''), undefined);
-    assert.equal(normalizeTelegramReplyToMessageId('abc'), undefined);
-    assert.equal(normalizeTelegramReplyToMessageId('0'), undefined);
-    assert.equal(normalizeTelegramReplyToMessageId('1.5'), undefined);
-    assert.equal(normalizeTelegramReplyToMessageId('9007199254740992'), undefined);
+    for (const value of [undefined, '', 'abc', '0', '-1', '1.5', '9007199254740992']) {
+      assert.equal(normalizeTelegramReplyToMessageId(value), undefined, String(value));
+    }
   });
 });

--- a/packages/runtime/src/bots/__tests__/telegram-utf16.test.ts
+++ b/packages/runtime/src/bots/__tests__/telegram-utf16.test.ts
@@ -5,98 +5,51 @@ import { __TEST__ } from '../simple-bridge.js';
 
 const { utf16Len, prefixWithinUtf16, splitForTelegram } = __TEST__;
 
-describe('utf16Len (PR-TELEGRAM-UTF16-LIMIT-0)', () => {
-  it('counts BMP characters as 1 unit each', () => {
-    assert.equal(utf16Len('hello'), 5);
-    assert.equal(utf16Len('你好世界'), 4);
-  });
-
-  it('counts astral-plane characters as 2 units each (surrogate pair)', () => {
-    // U+1F600 GRINNING FACE = surrogate pair, 2 code units
-    assert.equal(utf16Len('😀'), 2);
-    assert.equal(utf16Len('a😀b'), 4);
-    // CJK Extension B (U+20000) — also a surrogate pair
-    assert.equal(utf16Len('\u{20000}'), 2);
-  });
-
-  it('handles empty string', () => {
-    assert.equal(utf16Len(''), 0);
-  });
-});
-
-describe('prefixWithinUtf16 (PR-TELEGRAM-UTF16-LIMIT-0)', () => {
-  it('returns the input untouched when it already fits', () => {
-    assert.equal(prefixWithinUtf16('hello', 100), 'hello');
-  });
-
-  it('truncates at cap when input exceeds it', () => {
-    const out = prefixWithinUtf16('abcdef', 3);
-    assert.equal(out, 'abc');
-  });
-
-  it('does NOT slice a surrogate pair in half', () => {
-    // 'a😀' = 1 + 2 = 3 code units. Cap of 2 should drop the emoji
-    // entirely, NOT yield 'a\uD83D' (the high-surrogate alone).
-    const out = prefixWithinUtf16('a😀', 2);
-    assert.equal(out, 'a');
-    assert.equal(utf16Len(out), 1);
-  });
-
-  it('handles a string composed entirely of surrogate pairs', () => {
-    const out = prefixWithinUtf16('😀😀😀😀', 5);
-    // Two emojis = 4 code units fit; three = 6 don't. Three are out;
-    // two are in.
-    assert.equal(out, '😀😀');
-  });
-});
-
-describe('splitForTelegram (PR-TELEGRAM-UTF16-LIMIT-0)', () => {
-  it('returns the original text in a single-element array when it fits', () => {
-    const out = splitForTelegram('hello world');
-    assert.deepEqual(out, ['hello world']);
-  });
-
-  it('splits an oversized text and stamps continuation headers', () => {
-    const big = 'a'.repeat(8500); // > 4000 cap, will produce 3 chunks
-    const out = splitForTelegram(big);
-    assert.ok(out.length >= 2);
-    assert.match(out[0]!, /^\[1\/\d+\]\n/);
-    assert.match(out[out.length - 1]!, /^\[\d+\/\d+\]\n/);
-    // Every chunk MUST fit under the cap.
-    for (const piece of out) {
-      assert.ok(utf16Len(piece) <= 4000, `chunk over cap: ${utf16Len(piece)}`);
+describe('Telegram UTF-16 limits', () => {
+  it('counts BMP and astral-plane characters in UTF-16 code units', () => {
+    for (const [text, expected] of [
+      ['', 0],
+      ['hello', 5],
+      ['你好世界', 4],
+      ['😀', 2],
+      ['a😀b', 4],
+      ['\u{20000}', 2],
+    ] as const) {
+      assert.equal(utf16Len(text), expected, text);
     }
   });
 
-  it('does not split mid-surrogate', () => {
-    // 4000 emojis = 8000 code units, requires at least 2 splits.
-    const emoji = '😀'.repeat(4000);
-    const out = splitForTelegram(emoji);
-    assert.ok(out.length >= 2);
-    for (const piece of out) {
-      // Strip the [i/N]\n header before checking content for orphan
-      // surrogates.
-      const body = piece.replace(/^\[\d+\/\d+\]\n/, '');
-      // If we split mid-surrogate, the first/last char of body would
-      // be an unpaired surrogate. Round-trip through UTF-16 to verify
-      // every codepoint survives.
-      for (let i = 0; i < body.length; ) {
-        const code = body.codePointAt(i)!;
-        assert.ok(code >= 0x20 || code === 0x0a, `bad codepoint at ${i}`);
-        i += code > 0xffff ? 2 : 1;
+  it('truncates prefixes without splitting surrogate pairs', () => {
+    for (const [text, limit, expected] of [
+      ['hello', 100, 'hello'],
+      ['abcdef', 3, 'abc'],
+      ['a😀', 2, 'a'],
+      ['😀😀😀😀', 5, '😀😀'],
+    ] as const) {
+      assert.equal(prefixWithinUtf16(text, limit), expected, text);
+    }
+  });
+
+  it('splits oversized text within limits, on code points, and preferably at newlines', () => {
+    assert.deepEqual(splitForTelegram('hello world'), ['hello world']);
+
+    const chunks = splitForTelegram('a'.repeat(8500));
+    assert.ok(chunks.length >= 2);
+    assert.match(chunks[0]!, /^\[1\/\d+\]\n/);
+    assert.match(chunks.at(-1)!, /^\[\d+\/\d+\]\n/);
+    for (const chunk of chunks) assert.ok(utf16Len(chunk) <= 4000);
+
+    for (const chunk of splitForTelegram('😀'.repeat(4000))) {
+      const body = chunk.replace(/^\[\d+\/\d+\]\n/, '');
+      for (let index = 0; index < body.length; ) {
+        const codePoint = body.codePointAt(index)!;
+        assert.ok(codePoint >= 0x20 || codePoint === 0x0a);
+        index += codePoint > 0xffff ? 2 : 1;
       }
     }
-  });
 
-  it('prefers newline split points when available', () => {
-    const line = 'line\n'.repeat(900); // 5 * 900 = 4500 code units, splits
-    const out = splitForTelegram(line);
-    assert.ok(out.length >= 2);
-    // The first chunk SHOULD end on a line boundary (not mid-word).
-    const body0 = out[0]!.replace(/^\[\d+\/\d+\]\n/, '');
-    assert.ok(
-      body0.endsWith('line') || body0.endsWith('line\n'),
-      `unexpected tail: ${JSON.stringify(body0.slice(-20))}`,
-    );
+    const lineChunks = splitForTelegram('line\n'.repeat(900));
+    const firstBody = lineChunks[0]!.replace(/^\[\d+\/\d+\]\n/, '');
+    assert.ok(firstBody.endsWith('line') || firstBody.endsWith('line\n'));
   });
 });


### PR DESCRIPTION
## Summary
- replace one-input-per-test Telegram helper cases with compact contract tables
- collapse allowlist exact-match cases into one truth table
- retain attachment precedence, TTL bounds, retry clamps, unsafe reply IDs, UTF-16 boundaries, and malformed-input handling
- reduce the touched bot helper coverage from 52 to 13 tests (39 fewer tests, 206 net lines removed)

## Verification
- npm run clean
- npm run build:test
- npm --workspace @maka/runtime run test:dist (2690 pass, 9 skip)
- npm run test:scripts:full
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check HEAD^ HEAD