### PR TITLE
test: collapse UI helper coverage

### DIFF
--- a/apps/desktop/src/main/__tests__/turn-footer-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/turn-footer-actions.test.ts
@@ -1,18 +1,5 @@
-/**
- * Tests for the Turn footer action helper.
- *
- * @kenji review gate #1: footer action enabled set must come
- * exclusively from `TurnStatus` + lineage map — never from the turn's
- * text content or optimistic UI guesses. This matrix locks that down.
- *
- * #546: retry was merged into regenerate. The footer now has one
- * "重新生成" action that re-runs the turn regardless of how the
- * previous attempt ended (failed / aborted / completed).
- */
-
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { SESSION_STATUSES } from '@maka/core';
 import {
   deriveTurnFooterActions,
   enabledTurnFooterActions,
@@ -20,221 +7,50 @@ import {
   type TurnFooterContext,
 } from '../../renderer/turn-footer-actions.js';
 
-function ctx(partial: Partial<TurnFooterContext>): TurnFooterContext {
-  return {
-    status: 'completed',
-    hasContent: true,
-    ...partial,
-  };
+function ctx(partial: Partial<TurnFooterContext> = {}): TurnFooterContext {
+  return { status: 'completed', hasContent: true, ...partial };
 }
 
 function enabledIds(input: TurnFooterContext): TurnFooterActionId[] {
-  return enabledTurnFooterActions(input).map((a) => a.id);
+  return enabledTurnFooterActions(input).map((action) => action.id);
 }
 
 describe('deriveTurnFooterActions', () => {
-  it('always returns the same 3 actions in fixed order', () => {
-    const ids = deriveTurnFooterActions(ctx({})).map((a) => a.id);
-    assert.deepEqual(ids, ['regenerate', 'branch', 'copy']);
+  it('keeps the operation order stable', () => {
+    assert.deepEqual(
+      deriveTurnFooterActions(ctx()).map((action) => action.id),
+      ['regenerate', 'branch', 'copy'],
+    );
   });
 
-  it('labels are Chinese', () => {
-    for (const action of deriveTurnFooterActions(ctx({}))) {
-      assert.match(action.label, /[一-鿿]/, `${action.id} label should be Chinese`);
-      assert.doesNotMatch(action.label, /[a-zA-Z]/, `${action.id} should have no English`);
+  it('derives enabled operations from status and content', () => {
+    assert.deepEqual(enabledIds(ctx({ status: 'running' })), ['copy']);
+    for (const status of ['completed', 'failed', 'aborted'] as const) {
+      assert.deepEqual(enabledIds(ctx({ status })), ['regenerate', 'branch', 'copy']);
+      assert.deepEqual(enabledIds(ctx({ status, hasContent: false })), [
+        'regenerate',
+        'branch',
+      ]);
     }
   });
 
-  describe('per-status enabled matrix (@kenji gate #1)', () => {
-    it('running: only copy enabled', () => {
-      assert.deepEqual(enabledIds(ctx({ status: 'running' })), ['copy']);
-    });
-
-    it('completed: regenerate + branch + copy enabled', () => {
-      assert.deepEqual(enabledIds(ctx({ status: 'completed' })), ['regenerate', 'branch', 'copy']);
-    });
-
-    it('failed: regenerate + branch + copy enabled (retry merged into regenerate)', () => {
-      assert.deepEqual(enabledIds(ctx({ status: 'failed' })), ['regenerate', 'branch', 'copy']);
-    });
-
-    it('aborted: regenerate + branch + copy enabled (retry merged into regenerate)', () => {
-      assert.deepEqual(enabledIds(ctx({ status: 'aborted' })), ['regenerate', 'branch', 'copy']);
-    });
+  it('masks only pending remote operations and leaves local copy available', () => {
+    const actions = deriveTurnFooterActions(
+      ctx({ pendingActions: new Set(['regenerate', 'copy']) }),
+    );
+    const regenerate = actions.find((action) => action.id === 'regenerate');
+    assert.equal(regenerate?.enabled, false);
+    assert.equal(regenerate?.tooltip, '正在处理…');
+    assert.equal(actions.find((action) => action.id === 'branch')?.enabled, true);
+    assert.equal(actions.find((action) => action.id === 'copy')?.enabled, true);
   });
 
-  describe('copy depends on hasContent only', () => {
-    it('hasContent=false drops copy regardless of status', () => {
-      for (const status of ['running', 'completed', 'aborted', 'failed'] as const) {
-        const ids = enabledIds(ctx({ status, hasContent: false }));
-        assert.equal(ids.includes('copy'), false, `${status} with empty content should not enable copy`);
-      }
-    });
-  });
-
-  describe('tooltip hints (no enum leak)', () => {
-    it('tooltips are Chinese only', () => {
-      for (const action of deriveTurnFooterActions(ctx({}))) {
-        assert.match(action.tooltip ?? '', /[一-鿿]/, `${action.id} tooltip should be Chinese`);
-        const TURN_STATUSES = new Set(['running', 'completed', 'aborted', 'failed']);
-        for (const status of TURN_STATUSES) {
-          assert.doesNotMatch(
-            action.tooltip ?? '',
-            new RegExp(`\\b${status}\\b`),
-            `${action.id} tooltip should not expose enum identifier ${status}`,
-          );
-        }
-      }
-    });
-
-    it('tooltip distinguishes aborted branch from running branch (per @kenji "从中断前分支")', () => {
-      const abortedBranch = deriveTurnFooterActions(ctx({ status: 'aborted' })).find((a) => a.id === 'branch');
-      assert.match(abortedBranch?.tooltip ?? '', /中断/);
-    });
-
-    it('alreadyRegenerated changes the regenerate tooltip hint without disabling the button', () => {
-      const first = deriveTurnFooterActions(ctx({ status: 'completed' })).find((a) => a.id === 'regenerate');
-      const second = deriveTurnFooterActions(ctx({ status: 'completed', alreadyRegenerated: true })).find(
-        (a) => a.id === 'regenerate',
-      );
-      assert.equal(first?.enabled, true);
-      assert.equal(second?.enabled, true);
-      assert.notEqual(first?.tooltip, second?.tooltip);
-      assert.match(second?.tooltip ?? '', /已重新生成/);
-    });
-  });
-
-  describe('matrix invariants (regression-proof)', () => {
-    it('action enabled-state does NOT depend on hasContent (except for copy)', () => {
-      const withContent = deriveTurnFooterActions(ctx({ status: 'completed', hasContent: true }));
-      const noContent = deriveTurnFooterActions(ctx({ status: 'completed', hasContent: false }));
-      for (const action of withContent) {
-        const counterpart = noContent.find((a) => a.id === action.id);
-        if (action.id === 'copy') {
-          assert.notEqual(action.enabled, counterpart?.enabled);
-        } else {
-          assert.equal(action.enabled, counterpart?.enabled);
-        }
-      }
-    });
-
-    it('every TurnStatus produces a non-empty enabled set (copy is always available with content)', () => {
-      for (const status of ['running', 'completed', 'aborted', 'failed'] as const) {
-        const ids = enabledIds(ctx({ status }));
-        assert.ok(ids.length >= 1, `${status} should have at least 1 enabled action`);
-      }
-    });
-  });
-
-  describe('pending mask (@kenji review: double-click guard)', () => {
-    it('pending regenerate returns enabled=false + "正在处理…" tooltip', () => {
-      const actions = deriveTurnFooterActions(
-        ctx({ status: 'completed', pendingActions: new Set(['regenerate']) }),
-      );
-      const regen = actions.find((a) => a.id === 'regenerate');
-      assert.equal(regen?.enabled, false);
-      assert.equal(regen?.tooltip, '正在处理…');
-    });
-
-    it('pending branch returns enabled=false + busy tooltip', () => {
-      const actions = deriveTurnFooterActions(
-        ctx({ status: 'completed', pendingActions: new Set(['branch']) }),
-      );
-      const branch = actions.find((a) => a.id === 'branch');
-      assert.equal(branch?.enabled, false);
-      assert.equal(branch?.tooltip, '正在处理…');
-    });
-
-    it('pending on one action does NOT disable other actions', () => {
-      const actions = deriveTurnFooterActions(
-        ctx({ status: 'completed', pendingActions: new Set(['regenerate']) }),
-      );
-      const branch = actions.find((a) => a.id === 'branch');
-      assert.equal(branch?.enabled, true);
-      assert.notEqual(branch?.tooltip, '正在处理…');
-    });
-
-    it('pending labels preserved (screen readers still hear which action)', () => {
-      const actions = deriveTurnFooterActions(
-        ctx({ status: 'completed', pendingActions: new Set(['regenerate']) }),
-      );
-      const regen = actions.find((a) => a.id === 'regenerate');
-      assert.equal(regen?.label, '重新生成');
-    });
-
-    it('empty pending set behaves identically to undefined', () => {
-      const baseline = deriveTurnFooterActions(ctx({ status: 'completed' }));
-      const withEmpty = deriveTurnFooterActions(
-        ctx({ status: 'completed', pendingActions: new Set() }),
-      );
-      assert.deepEqual(baseline, withEmpty);
-    });
-
-    it('pending mask overrides the "alreadyRegenerated" hint (busy tooltip wins)', () => {
-      const actions = deriveTurnFooterActions(
-        ctx({
-          status: 'completed',
-          alreadyRegenerated: true,
-          pendingActions: new Set(['regenerate']),
-        }),
-      );
-      const regen = actions.find((a) => a.id === 'regenerate');
-      assert.equal(regen?.tooltip, '正在处理…');
-    });
-
-    it('copy is NOT affected by pending mask (it is in-component clipboard)', () => {
-      const actions = deriveTurnFooterActions(
-        ctx({ status: 'completed', pendingActions: new Set(['copy']) }),
-      );
-      const copy = actions.find((a) => a.id === 'copy');
-      assert.equal(copy?.enabled, true);
-    });
-  });
-
-  describe('info action carries the meta summary (#546)', () => {
-    it('appends an info action whose tooltip is the meta summary, when provided', () => {
-      const actions = deriveTurnFooterActions(
-        ctx({ status: 'completed', metaSummary: 'gpt-5.5 · 4.9s · $0.0123' }),
-      );
-      const info = actions.find((a) => a.id === 'info');
-      assert.ok(info, 'info action should be present when metaSummary is set');
-      assert.equal(info?.tooltip, 'gpt-5.5 · 4.9s · $0.0123');
-    });
-
-    it('omits the info action when no meta summary is provided', () => {
-      const actions = deriveTurnFooterActions(ctx({ status: 'completed' }));
-      assert.equal(actions.find((a) => a.id === 'info'), undefined);
-    });
-
-    it('info action is always enabled (it is informational, not an operation)', () => {
-      const actions = deriveTurnFooterActions(
-        ctx({ status: 'running', metaSummary: 'gpt-5.5 · 进行中' }),
-      );
-      const info = actions.find((a) => a.id === 'info');
-      assert.equal(info?.enabled, true);
-    });
-  });
-
-  describe('copy action tooltip reflects enabled state (#546)', () => {
-    it('shows the copy affordance when there is content', () => {
-      const copy = deriveTurnFooterActions(ctx({ status: 'completed', hasContent: true })).find(
-        (a) => a.id === 'copy',
-      );
-      assert.equal(copy?.enabled, true);
-      assert.equal(copy?.tooltip, '复制回答到剪贴板');
-    });
-
-    it('shows the disabled reason when there is no content', () => {
-      const copy = deriveTurnFooterActions(ctx({ status: 'completed', hasContent: false })).find(
-        (a) => a.id === 'copy',
-      );
-      assert.equal(copy?.enabled, false);
-      assert.equal(copy?.tooltip, '此回答尚无可复制的内容');
-    });
-  });
-
-  it('SessionStatus and TurnStatus are kept distinct', () => {
-    assert.ok(SESSION_STATUSES.includes('active'));
-    assert.ok(SESSION_STATUSES.includes('blocked'));
+  it('adds an enabled informational action only when meta is present', () => {
+    assert.equal(deriveTurnFooterActions(ctx()).some((action) => action.id === 'info'), false);
+    const info = deriveTurnFooterActions(
+      ctx({ status: 'running', metaSummary: 'gpt-5.5 · 4.9s' }),
+    ).find((action) => action.id === 'info');
+    assert.equal(info?.enabled, true);
+    assert.equal(info?.tooltip, 'gpt-5.5 · 4.9s');
   });
 });

--- a/packages/ui/src/__tests__/chat-input-behavior.test.ts
+++ b/packages/ui/src/__tests__/chat-input-behavior.test.ts
@@ -9,41 +9,37 @@ import {
   mentionQueryMatches,
   skillMentionQuery,
 } from '../chat-input-behavior.js';
-import {
-  addUniqueComposerSkillSelection,
-} from '../use-composer-skill-draft.js';
+import { addUniqueComposerSkillSelection } from '../use-composer-skill-draft.js';
 
 describe('shared chat input behavior', () => {
-  it('recognizes IME composition from either the native flag or Process key', () => {
+  it('recognizes composition and file transfers across browser event shapes', () => {
     assert.equal(isChatInputComposing({ key: 'Enter', nativeEvent: { isComposing: true } }), true);
     assert.equal(isChatInputComposing({ key: 'Process', nativeEvent: {} }), true);
     assert.equal(isChatInputComposing({ nativeEvent: {} }, true), true);
     assert.equal(isChatInputComposing({ key: 'Enter', nativeEvent: {} }), false);
-  });
-
-  it('recognizes file drag and paste payloads without depending on one event type', () => {
     assert.equal(fileTransferContainsFiles(['text/plain', 'Files'], 0), true);
     assert.equal(fileTransferContainsFiles(['text/plain'], 1), true);
     assert.equal(fileTransferContainsFiles(['text/plain'], 0), false);
   });
 
-  it('focuses a text input and moves its selection to the visible value end', () => {
+  it('focuses a text input at the visible value end', () => {
     const calls: Array<string | [number, number]> = [];
-    const input = {
+    focusTextInputAtEnd({
       value: 'hello',
       focus: () => calls.push('focus'),
-      setSelectionRange: (start: number, end: number) => calls.push([start, end]),
-    };
-    focusTextInputAtEnd(input);
+      setSelectionRange: (start, end) => calls.push([start, end]),
+    });
     assert.deepEqual(calls, ['focus', [5, 5]]);
   });
 
-  it('owns async input actions synchronously and releases only the active action', async () => {
+  it('serializes async actions and releases only their owned pending state', async () => {
     const states: Array<string | null> = [];
     const owner = createChatInputActionOwner<string>((action) => states.push(action));
     let release!: () => void;
-    const first = owner.run('drop', () => new Promise<string>((resolve) => { release = () => resolve('done'); }));
-    assert.equal(owner.pending, 'drop');
+    const first = owner.run(
+      'drop',
+      () => new Promise<string>((resolve) => (release = () => resolve('done'))),
+    );
     assert.equal(await owner.run('paste', async () => 'ignored'), undefined);
     release();
     assert.equal(await first, 'done');
@@ -51,11 +47,11 @@ describe('shared chat input behavior', () => {
     assert.deepEqual(states, ['drop', null]);
   });
 
-  it('reset invalidates late completion cleanup', async () => {
+  it('does not let late completion clear state after reset', async () => {
     const states: Array<string | null> = [];
     const owner = createChatInputActionOwner<string>((action) => states.push(action));
     let release!: () => void;
-    const action = owner.run('drop', () => new Promise<void>((resolve) => { release = resolve; }));
+    const action = owner.run('drop', () => new Promise<void>((resolve) => (release = resolve)));
     owner.reset();
     release();
     await action;
@@ -64,85 +60,62 @@ describe('shared chat input behavior', () => {
 });
 
 describe('detectMentionTrigger', () => {
-  it('fires an @ trigger at start-of-input', () => {
-    assert.deepEqual(detectMentionTrigger('@', 1), { trigger: '@', query: '', start: 0 });
+  it('finds @ queries at boundaries, inside paths, and relative to the caret', () => {
     assert.deepEqual(detectMentionTrigger('@src', 4), { trigger: '@', query: 'src', start: 0 });
+    assert.deepEqual(detectMentionTrigger('open @src/app', 13), {
+      trigger: '@',
+      query: 'src/app',
+      start: 5,
+    });
+    assert.deepEqual(detectMentionTrigger('@src/app', 3), {
+      trigger: '@',
+      query: 'sr',
+      start: 0,
+    });
+    assert.deepEqual(detectMentionTrigger('@my file', 8), {
+      trigger: '@',
+      query: 'my file',
+      start: 0,
+    });
   });
 
-  it('fires an @ trigger after whitespace (word boundary)', () => {
-    assert.deepEqual(detectMentionTrigger('open @src/app', 13), { trigger: '@', query: 'src/app', start: 5 });
-    assert.deepEqual(detectMentionTrigger('a\n@x', 4), { trigger: '@', query: 'x', start: 2 });
+  it('rejects non-boundary and terminated @ queries', () => {
+    for (const [value, caret] of [
+      ['foo@bar', 7],
+      ['user@host.com', 13],
+      ['hello world', 11],
+      ['@later', 0],
+      ['@my  file', 9],
+      ['@line\nmore', 10],
+    ] as const) {
+      assert.equal(detectMentionTrigger(value, caret), null, value);
+    }
   });
 
-  it('does NOT fire mid-word (no boundary before the trigger)', () => {
-    assert.equal(detectMentionTrigger('foo@bar', 7), null);
-    assert.equal(detectMentionTrigger('a/b', 3), null);
-    assert.equal(detectMentionTrigger('user@host.com', 13), null);
-  });
-
-  it('returns null when there is no trigger before the caret', () => {
-    assert.equal(detectMentionTrigger('hello world', 11), null);
-    assert.equal(detectMentionTrigger('@later', 0), null); // caret before the @
-  });
-
-  it('allows single spaces in an @ query (filenames with spaces)', () => {
-    assert.deepEqual(detectMentionTrigger('@my file', 8), { trigger: '@', query: 'my file', start: 0 });
-  });
-
-  it('kills an @ query on a double space', () => {
-    assert.equal(detectMentionTrigger('@my  file', 9), null);
-  });
-
-  it('kills an @ query on a newline', () => {
-    assert.equal(detectMentionTrigger('@line\nmore', 10), null);
-  });
-
-  it('fires a / trigger as a single token', () => {
-    assert.deepEqual(detectMentionTrigger('/', 1), { trigger: '/', query: '', start: 0 });
-    assert.deepEqual(detectMentionTrigger('/deep', 5), { trigger: '/', query: 'deep', start: 0 });
-    assert.deepEqual(detectMentionTrigger('run /skill', 10), { trigger: '/', query: 'skill', start: 4 });
-  });
-
-  it('kills a / query on ANY space or newline', () => {
+  it('keeps / queries single-token and chooses the nearest boundary trigger', () => {
+    assert.deepEqual(detectMentionTrigger('run /skill', 10), {
+      trigger: '/',
+      query: 'skill',
+      start: 4,
+    });
+    assert.deepEqual(detectMentionTrigger('@a /b', 5), {
+      trigger: '/',
+      query: 'b',
+      start: 3,
+    });
     assert.equal(detectMentionTrigger('/deep research', 14), null);
     assert.equal(detectMentionTrigger('/a\nb', 4), null);
   });
-
-  it('a path-internal slash does not hijack the @ trigger (only boundary triggers count)', () => {
-    // The `/` in `@foo/bar` is not at a word boundary, so it is part of the `@`
-    // query, not a competing `/` trigger. The `@` stays active with the full path.
-    assert.deepEqual(detectMentionTrigger('@foo/bar', 8), { trigger: '@', query: 'foo/bar', start: 0 });
-    assert.deepEqual(detectMentionTrigger('@src/app', 8), { trigger: '@', query: 'src/app', start: 0 });
-  });
-
-  it('the nearest boundary-anchored trigger wins', () => {
-    // A `/` typed at a boundary after an `@…` wins as the active trigger.
-    assert.deepEqual(detectMentionTrigger('@a /b', 5), { trigger: '/', query: 'b', start: 3 });
-  });
-
-  it('detects the trigger relative to the caret, not the value end', () => {
-    // Caret sits right after `@sr`; the trailing `c/app` is ignored.
-    assert.deepEqual(detectMentionTrigger('@src/app', 3), { trigger: '@', query: 'sr', start: 0 });
-  });
 });
 
-describe('mentionQueryMatches', () => {
-  it('matches case-insensitively', () => {
-    assert.equal(mentionQueryMatches('APP', 'src/app.tsx'), true);
-  });
-
-  it('requires every whitespace-separated token (AND-of-substring)', () => {
-    assert.equal(mentionQueryMatches('src app', 'src/app.tsx'), true);
+describe('mention filtering', () => {
+  it('matches case-insensitive AND tokens and treats an empty query as universal', () => {
+    assert.equal(mentionQueryMatches('SRC APP', 'src/app.tsx'), true);
     assert.equal(mentionQueryMatches('src app', 'src/main.tsx'), false);
-  });
-
-  it('matches everything on an empty query', () => {
     assert.equal(mentionQueryMatches('', 'anything'), true);
   });
-});
 
-describe('Skill mention filtering', () => {
-  it('supports direct /skill: filtering and bare names', () => {
+  it('normalizes /skill prefixes while preserving bare queries', () => {
     assert.equal(skillMentionQuery('skill:wri'), 'wri');
     assert.equal(skillMentionQuery('SKILL:wri'), 'wri');
     assert.equal(skillMentionQuery('writer'), 'writer');
@@ -150,30 +123,14 @@ describe('Skill mention filtering', () => {
 });
 
 describe('structured Skill selections', () => {
-  it('deduplicates ids case-insensitively and preserves first-selection order', () => {
-    const first = addUniqueComposerSkillSelection([], { id: 'alpha', name: 'Alpha' });
-    const second = addUniqueComposerSkillSelection(first, { id: 'beta', name: 'Beta' });
-    const duplicate = addUniqueComposerSkillSelection(second, {
-      id: 'ALPHA',
-      name: 'Renamed Alpha',
-    });
-    assert.deepEqual(duplicate, [
-      { id: 'alpha', name: 'Alpha' },
-      { id: 'beta', name: 'Beta' },
-    ]);
-  });
-
-  it('keeps same-id selections from different stable refs distinct', () => {
-    const project = {
-      ref: 'project:maka:writer',
-      id: 'writer',
-      name: 'Project Writer',
-    };
-    const user = {
-      ref: 'user:agents:writer',
-      id: 'writer',
-      name: 'User Writer',
-    };
+  it('deduplicates stable identities while keeping same-id selections from distinct refs', () => {
+    const alpha = { id: 'alpha', name: 'Alpha' };
+    assert.deepEqual(
+      addUniqueComposerSkillSelection([alpha], { id: 'ALPHA', name: 'Renamed Alpha' }),
+      [alpha],
+    );
+    const project = { ref: 'project:maka:writer', id: 'writer', name: 'Project Writer' };
+    const user = { ref: 'user:agents:writer', id: 'writer', name: 'User Writer' };
     assert.deepEqual(addUniqueComposerSkillSelection([project], user), [project, user]);
   });
 });

--- a/packages/ui/src/__tests__/composer-helpers.test.ts
+++ b/packages/ui/src/__tests__/composer-helpers.test.ts
@@ -1,204 +1,115 @@
-import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import {
   isReferenceSizedPaste,
   navigateComposerHistory,
+  PASTE_AS_QUOTE_MIN_CHARS,
+  PASTE_AS_QUOTE_MIN_LINES,
   readComposerDraft,
   reconcileHistorySync,
   rememberComposerDraft,
   rememberComposerHistoryEntry,
-  PASTE_AS_QUOTE_MIN_CHARS,
-  PASTE_AS_QUOTE_MIN_LINES,
   type ComposerHistoryState,
 } from '../composer-helpers.js';
 
-// reconcileHistorySync reconciles the Composer's in-memory history state
-// with what localStorage reports, right before a history-navigation keystroke
-// is dispatched to navigateComposerHistory. It is the seam that keeps a
-// storage clear or a transient storage failure from clobbering the user's
-// in-memory history or the draft they were typing.
-
 describe('reconcileHistorySync', () => {
-  // P2-2: localStorage read failed — keep the in-memory history intact so a
-  // transient storage failure (private browsing, quota, SSR) does not wipe
-  // history the user already has in memory.
-  it('keeps the current state when synced is null (storage read failed)', () => {
-    const current: ComposerHistoryState = { entries: ['内存里的历史'], index: 0, savedDraft: '草稿' };
+  it('preserves in-memory state when storage cannot be read', () => {
+    const current: ComposerHistoryState = {
+      entries: ['内存里的历史'],
+      index: 0,
+      savedDraft: '草稿',
+    };
     const result = reconcileHistorySync(current, null);
-    assert.deepEqual(result.state, current);
+    assert.equal(result.state, current);
     assert.equal(result.restoreDraft, false);
   });
 
-  // P2-1: history was cleared (e.g. from Settings) while the Composer was
-  // mid-navigation — the saved draft must be restored so the user does not
-  // lose what they were typing.
-  it('resets to empty and signals draft restore when cleared mid-navigation', () => {
-    const current: ComposerHistoryState = { entries: ['旧'], index: 0, savedDraft: '用户正在编辑的草稿' };
-    const result = reconcileHistorySync(current, []);
-    assert.deepEqual(result.state, { entries: [], index: -1, savedDraft: '' });
-    assert.equal(result.restoreDraft, true);
-  });
-
-  it('resets to empty without draft restore when cleared but not navigating', () => {
-    const current: ComposerHistoryState = { entries: ['旧'], index: -1, savedDraft: '' };
-    const result = reconcileHistorySync(current, []);
-    assert.deepEqual(result.state, { entries: [], index: -1, savedDraft: '' });
-    assert.equal(result.restoreDraft, false);
-  });
-
-  it('does not signal draft restore when mid-navigation but savedDraft is empty', () => {
-    const current: ComposerHistoryState = { entries: ['旧'], index: 0, savedDraft: '' };
-    const result = reconcileHistorySync(current, []);
-    assert.equal(result.restoreDraft, false);
-  });
-
-  it('adopts synced entries and clamps the index into range', () => {
-    const current: ComposerHistoryState = { entries: [], index: 5, savedDraft: '草稿' };
-    const result = reconcileHistorySync(current, ['a', 'b']);
-    assert.deepEqual(result.state, { entries: ['a', 'b'], index: 1, savedDraft: '草稿' });
-    assert.equal(result.restoreDraft, false);
-  });
-
-  it('preserves savedDraft when adopting synced entries', () => {
-    const current: ComposerHistoryState = { entries: [], index: -1, savedDraft: '保留的草稿' };
-    const result = reconcileHistorySync(current, ['a']);
-    assert.equal(result.state.savedDraft, '保留的草稿');
+  it('restores a navigated draft on clear and otherwise adopts bounded synced state', () => {
+    const current: ComposerHistoryState = {
+      entries: ['旧'],
+      index: 5,
+      savedDraft: '用户正在编辑的草稿',
+    };
+    assert.deepEqual(reconcileHistorySync(current, []), {
+      state: { entries: [], index: -1, savedDraft: '' },
+      restoreDraft: true,
+    });
+    assert.equal(
+      reconcileHistorySync({ ...current, savedDraft: '' }, []).restoreDraft,
+      false,
+    );
+    assert.deepEqual(reconcileHistorySync(current, ['a', 'b']), {
+      state: { entries: ['a', 'b'], index: 1, savedDraft: current.savedDraft },
+      restoreDraft: false,
+    });
   });
 });
 
-// The draft store backs useComposerDraft (issue #1044): the hook's
-// save/clear/swap paths all delegate here, so pin the store semantics the
-// hook relies on — no-op without a key, blank-means-delete, overwrite keeps
-// one entry, and both caps (120k chars, 32 keys) bound the Map.
-describe('rememberComposerDraft / readComposerDraft', () => {
-  it('is a no-op when the draft key is undefined', () => {
+describe('composer draft storage', () => {
+  it('stores, overwrites, and deletes keyed drafts while ignoring missing keys', () => {
     const store = new Map<string, string>();
-    rememberComposerDraft(store, undefined, 'hello');
-    assert.equal(store.size, 0);
-    assert.equal(readComposerDraft(store, undefined), '');
-  });
-
-  it('stores and reads back the draft under its key', () => {
-    const store = new Map<string, string>();
-    rememberComposerDraft(store, 'session-a', '草稿内容');
-    assert.equal(readComposerDraft(store, 'session-a'), '草稿内容');
+    rememberComposerDraft(store, undefined, 'ignored');
+    rememberComposerDraft(store, 'session-a', 'first');
+    rememberComposerDraft(store, 'session-a', 'second');
+    assert.deepEqual([...store], [['session-a', 'second']]);
     assert.equal(readComposerDraft(store, 'session-b'), '');
-  });
-
-  it('deletes the entry when the remembered value is blank', () => {
-    const store = new Map<string, string>();
-    rememberComposerDraft(store, 'session-a', '草稿内容');
     rememberComposerDraft(store, 'session-a', '   ');
-    assert.equal(store.has('session-a'), false);
     assert.equal(readComposerDraft(store, 'session-a'), '');
   });
 
-  it('overwrites an existing key without growing the store', () => {
+  it('keeps only the trailing 120k characters of an oversized draft', () => {
     const store = new Map<string, string>();
-    rememberComposerDraft(store, 'session-a', 'first');
-    rememberComposerDraft(store, 'session-a', 'second');
-    assert.equal(store.size, 1);
-    assert.equal(readComposerDraft(store, 'session-a'), 'second');
-  });
-
-  it('keeps only the trailing 120k characters of an over-long draft', () => {
-    const store = new Map<string, string>();
-    const head = 'H'.repeat(100);
     const tail = 'T'.repeat(120_000);
-    rememberComposerDraft(store, 'session-a', head + tail);
-    const stored = readComposerDraft(store, 'session-a');
-    assert.equal(stored.length, 120_000);
-    assert.equal(stored, tail);
+    rememberComposerDraft(store, 'session-a', `${'H'.repeat(100)}${tail}`);
+    assert.equal(readComposerDraft(store, 'session-a'), tail);
   });
 
-  it('evicts the oldest key past 32 entries, and re-remembering refreshes recency', () => {
+  it('caps the LRU store at 32 entries and refreshes remembered keys', () => {
     const store = new Map<string, string>();
-    for (let i = 0; i < 32; i++) rememberComposerDraft(store, `key-${i}`, `draft-${i}`);
+    for (let index = 0; index < 32; index++) {
+      rememberComposerDraft(store, `key-${index}`, `draft-${index}`);
+    }
+    rememberComposerDraft(store, 'key-0', 'fresh');
+    rememberComposerDraft(store, 'key-32', 'new');
     assert.equal(store.size, 32);
-    // Refresh key-0 so key-1 becomes the oldest.
-    rememberComposerDraft(store, 'key-0', 'draft-0-fresh');
-    rememberComposerDraft(store, 'key-32', 'draft-32');
-    assert.equal(store.size, 32);
-    assert.equal(store.has('key-0'), true, 'refreshed key survives eviction');
-    assert.equal(store.has('key-1'), false, 'oldest untouched key is evicted first');
-    assert.equal(readComposerDraft(store, 'key-32'), 'draft-32');
+    assert.equal(store.has('key-0'), true);
+    assert.equal(store.has('key-1'), false);
   });
 });
 
-// rememberComposerHistoryEntry backs useComposerHistory.rememberSentEntry —
-// the in-memory list mirrors the persisted global history (dedup + cap).
 describe('rememberComposerHistoryEntry', () => {
-  it('appends a trimmed new entry', () => {
-    assert.deepEqual(rememberComposerHistoryEntry(['a'], '  b  '), ['a', 'b']);
-  });
-
-  it('leaves the list unchanged for blank input', () => {
-    assert.deepEqual(rememberComposerHistoryEntry(['a'], '   '), ['a']);
-  });
-
-  it('dedups an existing entry by moving it to the newest position', () => {
-    assert.deepEqual(rememberComposerHistoryEntry(['a', 'b', 'c'], 'a'), ['b', 'c', 'a']);
-  });
-
-  it('evicts the oldest entry past 50 entries', () => {
-    const entries = Array.from({ length: 50 }, (_, i) => `entry-${i}`);
-    const next = rememberComposerHistoryEntry(entries, 'entry-50');
-    assert.equal(next.length, 50);
-    assert.equal(next[0], 'entry-1');
-    assert.equal(next[49], 'entry-50');
+  it('ignores blanks, trims and refreshes duplicates, and caps history at 50', () => {
+    const entries = Array.from({ length: 50 }, (_, index) => `entry-${index}`);
+    assert.equal(rememberComposerHistoryEntry(entries, '   '), entries);
+    const refreshed = rememberComposerHistoryEntry(entries, '  entry-0  ');
+    assert.equal(refreshed.at(-1), 'entry-0');
+    assert.equal(refreshed.length, 50);
+    const appended = rememberComposerHistoryEntry(refreshed, 'entry-50');
+    assert.deepEqual(appended.slice(-2), ['entry-0', 'entry-50']);
+    assert.equal(appended.length, 50);
   });
 });
 
-// navigateComposerHistory backs useComposerHistory.handleArrowKey — the
-// up/down recall transitions, including the saved-draft round trip the
-// textarea applies verbatim.
 describe('navigateComposerHistory', () => {
-  it('does nothing when history is empty', () => {
-    const state: ComposerHistoryState = { entries: [], index: -1, savedDraft: '' };
-    assert.deepEqual(navigateComposerHistory(state, 'previous', 'draft'), { state, value: 'draft', changed: false });
+  it('leaves empty history and next-from-idle unchanged', () => {
+    const empty: ComposerHistoryState = { entries: [], index: -1, savedDraft: '' };
+    assert.deepEqual(navigateComposerHistory(empty, 'previous', 'draft'), {
+      state: empty,
+      value: 'draft',
+      changed: false,
+    });
+    const idle: ComposerHistoryState = { entries: ['a'], index: -1, savedDraft: '' };
+    assert.deepEqual(navigateComposerHistory(idle, 'next', 'draft'), {
+      state: idle,
+      value: 'draft',
+      changed: false,
+    });
   });
 
-  it('previous from idle recalls the newest entry and saves the current draft', () => {
-    const state: ComposerHistoryState = { entries: ['old', 'new'], index: -1, savedDraft: '' };
-    const result = navigateComposerHistory(state, 'previous', '正在输入');
-    assert.equal(result.changed, true);
-    assert.equal(result.value, 'new');
-    assert.deepEqual(result.state, { entries: ['old', 'new'], index: 1, savedDraft: '正在输入' });
-  });
-
-  it('previous walks older and clamps at the oldest entry', () => {
-    let state: ComposerHistoryState = { entries: ['old', 'new'], index: 1, savedDraft: 'draft' };
-    const first = navigateComposerHistory(state, 'previous', 'new');
-    assert.equal(first.value, 'old');
-    assert.equal(first.state.index, 0);
-    const clamped = navigateComposerHistory(first.state, 'previous', 'old');
-    assert.equal(clamped.value, 'old', 'stays on the oldest entry instead of wrapping');
-    assert.equal(clamped.state.index, 0);
-    assert.equal(clamped.changed, true);
-    state = clamped.state;
-    assert.equal(state.savedDraft, 'draft', 'the saved draft survives repeated previous');
-  });
-
-  it('next from idle is a no-op', () => {
-    const state: ComposerHistoryState = { entries: ['a'], index: -1, savedDraft: '' };
-    assert.deepEqual(navigateComposerHistory(state, 'next', 'draft'), { state, value: 'draft', changed: false });
-  });
-
-  it('next walks newer and restores the saved draft past the newest entry', () => {
-    const navigating: ComposerHistoryState = { entries: ['old', 'new'], index: 0, savedDraft: '我的草稿' };
-    const newer = navigateComposerHistory(navigating, 'next', 'old');
-    assert.equal(newer.value, 'new');
-    assert.equal(newer.state.index, 1);
-    const restored = navigateComposerHistory(newer.state, 'next', 'new');
-    assert.equal(restored.changed, true);
-    assert.equal(restored.value, '我的草稿');
-    assert.deepEqual(restored.state, { entries: ['old', 'new'], index: -1, savedDraft: '' });
-  });
-
-  it('round-trips a full up-up-down-down cycle back to the original draft', () => {
+  it('walks, clamps, and round-trips history without losing the draft', () => {
     let state: ComposerHistoryState = { entries: ['one', 'two'], index: -1, savedDraft: '' };
     let value = '原始输入';
-    for (const direction of ['previous', 'previous', 'next', 'next'] as const) {
+    for (const direction of ['previous', 'previous', 'previous', 'next', 'next'] as const) {
       const result = navigateComposerHistory(state, direction, value);
       assert.equal(result.changed, true);
       state = result.state;
@@ -209,27 +120,13 @@ describe('navigateComposerHistory', () => {
   });
 });
 
-// A reference-sized paste becomes a quote chip instead of flooding the
-// textarea. The threshold has to catch both shapes of reference material —
-// long prose (few lines, many characters) and logs/diffs (many short lines) —
-// without stealing an ordinary multi-line prompt the user is still writing.
 describe('isReferenceSizedPaste', () => {
-  it('leaves an ordinary prompt alone', () => {
-    assert.equal(isReferenceSizedPaste(''), false);
-    assert.equal(isReferenceSizedPaste('fix the failing test'), false);
-    assert.equal(isReferenceSizedPaste('line one\nline two\nline three'), false);
-  });
-
-  it('catches a wall of prose on the character bound', () => {
+  it('uses either the character or line boundary without capturing ordinary prompts', () => {
+    const lines = (count: number) => Array.from({ length: count }, () => 'ok').join('\n');
+    assert.equal(isReferenceSizedPaste('line one\nline two'), false);
     assert.equal(isReferenceSizedPaste('x'.repeat(PASTE_AS_QUOTE_MIN_CHARS - 1)), false);
     assert.equal(isReferenceSizedPaste('x'.repeat(PASTE_AS_QUOTE_MIN_CHARS)), true);
-  });
-
-  it('catches a log or diff on the line bound while each line stays short', () => {
-    const lines = (count: number) => Array.from({ length: count }, () => 'ok').join('\n');
     assert.equal(isReferenceSizedPaste(lines(PASTE_AS_QUOTE_MIN_LINES)), false);
-    const pasted = lines(PASTE_AS_QUOTE_MIN_LINES + 1);
-    assert.ok(pasted.length < PASTE_AS_QUOTE_MIN_CHARS, 'must trip the line bound, not the char bound');
-    assert.equal(isReferenceSizedPaste(pasted), true);
+    assert.equal(isReferenceSizedPaste(lines(PASTE_AS_QUOTE_MIN_LINES + 1)), true);
   });
 });


### PR DESCRIPTION
## Summary\n- collapse composer draft/history cases into behavior and boundary matrices\n- consolidate chat input mention, IME, file-transfer, and action-owner coverage\n- remove footer presentation/config mirrors while retaining status and pending isolation behavior\n\n## Test reduction\n- composer helpers: 25 -> 9\n- chat input behavior: 23 -> 10\n- turn footer actions: 25 -> 4\n- total: 73 -> 23 tests\n- net: 330 lines removed\n\n## Validation\n- npm run clean\n- npm run build:test\n- targeted tests (23 pass)\n- npm --workspace @maka/ui run test:dist (229 pass)\n- npm --workspace @maka/desktop run test:dist (1460 pass)\n- npm run test:scripts:full (37 pass)\n- npm run typecheck\n- npm run lint\n- npm run format:check