### PR TITLE
test: collapse presentation helper coverage

### DIFF
--- a/packages/core/src/__tests__/relative-time.test.ts
+++ b/packages/core/src/__tests__/relative-time.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { describe, it, beforeEach } from 'node:test';
+import { beforeEach, describe, it } from 'node:test';
 
 import {
   formatRelativeTimestamp,
@@ -7,87 +7,48 @@ import {
   resetRelativeTimeFormatters,
 } from '../relative-time.js';
 
-beforeEach(() => {
-  // Some test environments still have `navigator` from prior runs;
-  // reset the cache so each case independently resolves the locale.
-  resetRelativeTimeFormatters();
-});
+const NOW = Date.parse('2026-05-29T12:00:00Z');
 
-describe('formatRelativeTimestamp', () => {
-  const NOW = Date.parse('2026-05-29T12:00:00Z');
+beforeEach(resetRelativeTimeFormatters);
 
-  it('defaults to Chinese instead of the host navigator locale', () => {
-    const out = formatRelativeTimestamp(NOW - 8_000, NOW);
-    assert.match(out, /秒/);
-    assert.doesNotMatch(out, /seconds?\s+ago/i);
+describe('relative time', () => {
+  it('formats locale, bucket, horizon, and clock-skew boundaries', () => {
+    const cases: Array<{
+      timestamp: number;
+      locale?: 'zh' | 'en';
+      matches: RegExp;
+      excludes?: RegExp;
+    }> = [
+      { timestamp: NOW - 8_000, matches: /秒/, excludes: /seconds?\s+ago/i },
+      { timestamp: NOW - 100, matches: /1.*second|秒|now|刚刚/i },
+      { timestamp: NOW - 30_000, matches: /30.*second|秒/i },
+      { timestamp: NOW - 5 * 60_000, matches: /5.*minute|分钟/i },
+      { timestamp: NOW - 5 * 60_000, locale: 'en', matches: /5 minutes ago/i, excludes: /分钟/ },
+      { timestamp: NOW - 5 * 60_000, locale: 'zh', matches: /5.*分钟/, excludes: /minutes ago/i },
+      { timestamp: NOW - 3 * 60 * 60_000, matches: /3.*hour|小时/i },
+      { timestamp: NOW - 2 * 24 * 60 * 60_000, matches: /2.*day|天/i },
+      { timestamp: NOW - 30 * 24 * 60 * 60_000, matches: /2026|4月|Apr|April/ },
+      {
+        timestamp: NOW + 5 * 60_000,
+        matches: /second|秒|now|刚刚/i,
+        excludes: /in 5 minutes|5 分钟后/,
+      },
+    ];
+    for (const { timestamp, locale, matches, excludes } of cases) {
+      const output = formatRelativeTimestamp(timestamp, NOW, locale);
+      assert.match(output, matches);
+      if (excludes) assert.doesNotMatch(output, excludes);
+    }
   });
 
-  it('clamps sub-second ages to >=1s so we never see "0 seconds ago"', () => {
-    const out = formatRelativeTimestamp(NOW - 100, NOW);
-    assert.match(out, /1.*second|秒|now|刚刚/i);
-  });
-
-  it('formats a 30-second age in seconds', () => {
-    const out = formatRelativeTimestamp(NOW - 30_000, NOW);
-    assert.match(out, /30.*second|秒/i);
-  });
-
-  it('formats a 5-minute age in minutes', () => {
-    const out = formatRelativeTimestamp(NOW - 5 * 60_000, NOW);
-    assert.match(out, /5.*minute|分钟/i);
-  });
-
-  it('formats against the explicitly resolved English locale', () => {
-    const out = formatRelativeTimestamp(NOW - 5 * 60_000, NOW, 'en');
-    assert.match(out, /5 minutes ago/i);
-    assert.doesNotMatch(out, /分钟/);
-  });
-
-  it('formats against the explicitly resolved Chinese locale', () => {
-    const out = formatRelativeTimestamp(NOW - 5 * 60_000, NOW, 'zh');
-    assert.match(out, /5.*分钟/);
-    assert.doesNotMatch(out, /minutes ago/i);
-  });
-
-  it('formats a 3-hour age in hours', () => {
-    const out = formatRelativeTimestamp(NOW - 3 * 60 * 60_000, NOW);
-    assert.match(out, /3.*hour|小时/i);
-  });
-
-  it('formats a 2-day age in days', () => {
-    const out = formatRelativeTimestamp(NOW - 2 * 24 * 60 * 60_000, NOW);
-    assert.match(out, /2.*day|天/i);
-  });
-
-  it('falls back to absolute date past the 7-day horizon', () => {
-    const out = formatRelativeTimestamp(NOW - 30 * 24 * 60 * 60_000, NOW);
-    // Absolute format includes the year (medium dateStyle).
-    assert.match(out, /2026|4月|Apr|April/);
-  });
-
-  it('clamps future timestamps to "刚刚" instead of emitting "in N minutes"', () => {
-    const out = formatRelativeTimestamp(NOW + 5 * 60_000, NOW);
-    assert.doesNotMatch(out, /in 5 minutes|5 分钟后/);
-    assert.match(out, /second|秒|now|刚刚/i);
-  });
-});
-
-describe('nextRelativeRefreshDelay', () => {
-  const NOW = Date.parse('2026-05-29T12:00:00Z');
-
-  it('returns 1s when within the first minute', () => {
-    assert.equal(nextRelativeRefreshDelay(NOW - 5_000, NOW), 1_000);
-  });
-
-  it('returns 60s when within the first hour', () => {
-    assert.equal(nextRelativeRefreshDelay(NOW - 10 * 60_000, NOW), 60_000);
-  });
-
-  it('returns 10m when within the day window', () => {
-    assert.equal(nextRelativeRefreshDelay(NOW - 5 * 60 * 60_000, NOW), 10 * 60_000);
-  });
-
-  it('returns null past the horizon (no further ticks needed)', () => {
-    assert.equal(nextRelativeRefreshDelay(NOW - 30 * 24 * 60 * 60_000, NOW), null);
+  it('selects refresh cadence by age', () => {
+    for (const [timestamp, expected] of [
+      [NOW - 5_000, 1_000],
+      [NOW - 10 * 60_000, 60_000],
+      [NOW - 5 * 60 * 60_000, 10 * 60_000],
+      [NOW - 30 * 24 * 60 * 60_000, null],
+    ] as const) {
+      assert.equal(nextRelativeRefreshDelay(timestamp, NOW), expected);
+    }
   });
 });

--- a/packages/core/src/__tests__/tool-quiet-preview.test.ts
+++ b/packages/core/src/__tests__/tool-quiet-preview.test.ts
@@ -5,120 +5,80 @@ import {
   formatAsKeyValueLines,
   formatQuietJsonValue,
   formatToolInvocationLine,
-  type UiLocale,
 } from '../tool-quiet-preview.js';
 
-describe('tool-quiet-preview', () => {
-  describe('extractToolCommand', () => {
-    it('extracts command from args', () => {
-      assert.equal(extractToolCommand({ command: 'ls -la' }), 'ls -la');
-      assert.equal(extractToolCommand({ cmd: 'echo hi' }), 'echo hi');
-      assert.equal(extractToolCommand({ script: 'run.sh' }), 'run.sh');
-    });
-    it('returns undefined for non-command shapes', () => {
-      assert.equal(extractToolCommand({ path: '/foo' }), undefined);
-      assert.equal(extractToolCommand(undefined), undefined);
-      assert.equal(extractToolCommand('string'), undefined);
-    });
+describe('tool quiet preview', () => {
+  it('extracts command aliases and rejects non-command shapes', () => {
+    assert.equal(extractToolCommand({ command: 'ls -la' }), 'ls -la');
+    assert.equal(extractToolCommand({ cmd: 'echo hi' }), 'echo hi');
+    assert.equal(extractToolCommand({ script: 'run.sh' }), 'run.sh');
+    assert.equal(extractToolCommand({ path: '/foo' }), undefined);
+    assert.equal(extractToolCommand(undefined), undefined);
+    assert.equal(extractToolCommand('string'), undefined);
   });
 
-  describe('formatToolInvocationLine', () => {
-    it('extracts command for Bash', () => {
-      const line = formatToolInvocationLine(
-        { toolName: 'Bash', args: { command: 'npm test' } },
-        'en',
-      );
-      assert.equal(line, 'npm test');
-    });
-    it('extracts path for Read', () => {
-      const line = formatToolInvocationLine(
-        { toolName: 'Read', args: { path: '/foo/bar.ts' } },
-        'en',
-      );
-      assert.equal(line, '/foo/bar.ts');
-    });
-    it('extracts name for Skill (Bug 1 fix)', () => {
-      const line = formatToolInvocationLine(
-        { toolName: 'Skill', args: { name: 'my-skill' } },
-        'en',
-      );
-      assert.equal(line, 'my-skill');
-    });
-    it('uses zh strings for WriteStdin', () => {
-      const line = formatToolInvocationLine(
-        {
-          toolName: 'WriteStdin',
-          args: { inputPreview: { text: 'echo hi', bytes: 7, truncated: false } },
-        },
-        'zh',
-      );
-      assert.match(line!, /后台终端交互/);
-    });
-    it('uses en strings for WriteStdin', () => {
-      const line = formatToolInvocationLine(
-        {
-          toolName: 'WriteStdin',
-          args: { inputPreview: { text: 'echo hi', bytes: 7, truncated: false } },
-        },
-        'en',
-      );
-      assert.match(line!, /Background terminal interaction/);
-    });
-    it('falls back to key:value lines, not JSON', () => {
-      const line = formatToolInvocationLine(
-        { toolName: 'Custom', args: { alpha: 1, beta: 'two' } },
-        'en',
-      );
-      assert.match(line!, /alpha: 1/);
-      assert.match(line!, /beta: two/);
-      assert.doesNotMatch(line!, /\{/);
-    });
+  it('projects known invocations and uses key-value fallback', () => {
+    assert.equal(
+      formatToolInvocationLine({ toolName: 'Bash', args: { command: 'npm test' } }, 'en'),
+      'npm test',
+    );
+    assert.equal(
+      formatToolInvocationLine({ toolName: 'Read', args: { path: '/foo/bar.ts' } }, 'en'),
+      '/foo/bar.ts',
+    );
+    assert.equal(
+      formatToolInvocationLine({ toolName: 'Skill', args: { name: 'my-skill' } }, 'en'),
+      'my-skill',
+    );
+    const stdin = { inputPreview: { text: 'echo hi', bytes: 7, truncated: false } };
+    assert.match(
+      formatToolInvocationLine({ toolName: 'WriteStdin', args: stdin }, 'zh')!,
+      /后台终端交互/,
+    );
+    assert.match(
+      formatToolInvocationLine({ toolName: 'WriteStdin', args: stdin }, 'en')!,
+      /Background terminal interaction/,
+    );
+    const fallback = formatToolInvocationLine(
+      { toolName: 'Custom', args: { alpha: 1, beta: 'two' } },
+      'en',
+    )!;
+    assert.match(fallback, /alpha: 1/);
+    assert.match(fallback, /beta: two/);
+    assert.doesNotMatch(fallback, /\{/);
   });
 
-  describe('formatQuietJsonValue', () => {
-    it('renders empty for null/undefined', () => {
-      assert.equal(formatQuietJsonValue(null, 'zh').body, '（空）');
-      assert.equal(formatQuietJsonValue(null, 'en').body, '(empty)');
-    });
-    it('renders Write/Edit result with locale strings', () => {
-      const zh = formatQuietJsonValue({ ok: true, path: '/foo.ts', bytes: 42 }, 'zh');
-      assert.equal(zh.headline, '/foo.ts');
-      assert.match(zh.body, /已完成/);
-      assert.match(zh.body, /42 B/);
-
-      const en = formatQuietJsonValue({ ok: true, path: '/foo.ts', bytes: 42 }, 'en');
-      assert.equal(en.headline, '/foo.ts');
-      assert.match(en.body, /done/);
-      assert.match(en.body, /42 B/);
-    });
-    it('renders replacements with locale strings', () => {
-      const zh = formatQuietJsonValue({ ok: true, path: '/foo.ts', replacements: 3 }, 'zh');
-      assert.match(zh.body, /3 处/);
-      const en = formatQuietJsonValue({ ok: true, path: '/foo.ts', replacements: 3 }, 'en');
-      assert.match(en.body, /3 replacements/);
-    });
-    it('renders list payloads', () => {
-      const { body } = formatQuietJsonValue({ matches: ['a.ts:1:foo', 'b.ts:2:bar'] }, 'en');
-      assert.match(body, /a\.ts:1:foo/);
-      assert.match(body, /b\.ts:2:bar/);
-    });
-    it('keeps error diagnostics when a list is present', () => {
-      const { body } = formatQuietJsonValue({ results: [], error: 'denied', ok: false }, 'en');
-      assert.match(body, /error: denied/);
-      assert.match(body, /ok: false/);
-    });
-    it('redacts sensitive keys', () => {
-      const { body } = formatQuietJsonValue({ password: 'correct-horse', ok: true }, 'en');
-      assert.doesNotMatch(body, /correct-horse/);
-      assert.match(body, /redacted/i);
-    });
+  it('formats localized results, lists, replacements, and diagnostics', () => {
+    assert.equal(formatQuietJsonValue(null, 'zh').body, '（空）');
+    assert.equal(formatQuietJsonValue(null, 'en').body, '(empty)');
+    for (const locale of ['zh', 'en'] as const) {
+      const output = formatQuietJsonValue({ ok: true, path: '/foo.ts', bytes: 42 }, locale);
+      assert.equal(output.headline, '/foo.ts');
+      assert.match(output.body, locale === 'zh' ? /已完成/ : /done/);
+      assert.match(output.body, /42 B/);
+    }
+    assert.match(
+      formatQuietJsonValue({ ok: true, path: '/foo.ts', replacements: 3 }, 'zh').body,
+      /3 处/,
+    );
+    assert.match(
+      formatQuietJsonValue({ ok: true, path: '/foo.ts', replacements: 3 }, 'en').body,
+      /3 replacements/,
+    );
+    const list = formatQuietJsonValue({ matches: ['a.ts:1:foo', 'b.ts:2:bar'] }, 'en').body;
+    assert.match(list, /a\.ts:1:foo/);
+    assert.match(list, /b\.ts:2:bar/);
+    const diagnostic = formatQuietJsonValue({ results: [], error: 'denied', ok: false }, 'en').body;
+    assert.match(diagnostic, /error: denied/);
+    assert.match(diagnostic, /ok: false/);
   });
 
-  describe('formatAsKeyValueLines', () => {
-    it('redacts secrets embedded in keys', () => {
-      const out = formatAsKeyValueLines({ 'password=secret': true }, 0, 'en');
-      assert.doesNotMatch(out, /secret/);
-      assert.match(out, /redacted/i);
-    });
+  it('redacts secrets in values and embedded keys', () => {
+    const value = formatQuietJsonValue({ password: 'correct-horse', ok: true }, 'en').body;
+    assert.doesNotMatch(value, /correct-horse/);
+    assert.match(value, /redacted/i);
+    const key = formatAsKeyValueLines({ 'password=secret': true }, 0, 'en');
+    assert.doesNotMatch(key, /secret/);
+    assert.match(key, /redacted/i);
   });
 });

--- a/packages/core/src/__tests__/ui-locale.test.ts
+++ b/packages/core/src/__tests__/ui-locale.test.ts
@@ -1,77 +1,48 @@
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'node:test';
+import { it } from 'node:test';
 
 import {
   UI_LOCALES,
   UI_LOCALE_PREFERENCES,
   isUiLocale,
   isUiLocalePreference,
-  resolveUiLocale,
   resolveSystemUiLocale,
+  resolveUiLocale,
   uiLocaleToIntlLocale,
-  type UiCatalog,
 } from '../index.js';
 
-// @ts-expect-error Every catalog must include English; no implicit fallback.
-const missingEnglishCatalog: UiCatalog<string> = { zh: '中文' };
-void missingEnglishCatalog;
-
-describe('UI locale contract', () => {
-  it('exposes the complete supported locale and preference sets', () => {
-    assert.deepEqual([...UI_LOCALES], ['zh', 'en']);
-    assert.deepEqual([...UI_LOCALE_PREFERENCES], ['auto', 'zh', 'en']);
-  });
-
-  it('accepts only supported resolved locales', () => {
-    assert.equal(isUiLocale('zh'), true);
-    assert.equal(isUiLocale('en'), true);
-    assert.equal(isUiLocale('auto'), false);
-    assert.equal(isUiLocale('ja'), false);
-    assert.equal(isUiLocale(null), false);
-  });
-
-  it('accepts only supported persisted preferences', () => {
-    assert.equal(isUiLocalePreference('auto'), true);
-    assert.equal(isUiLocalePreference('zh'), true);
-    assert.equal(isUiLocalePreference('en'), true);
-    assert.equal(isUiLocalePreference('ja'), false);
-    assert.equal(isUiLocalePreference(undefined), false);
-  });
-
-  it('resolves the first supported system language and falls back to English', () => {
-    assert.equal(resolveSystemUiLocale(['zh-CN', 'en-US']), 'zh');
-    assert.equal(resolveSystemUiLocale(['ja-JP', 'en-GB']), 'en');
-    assert.equal(resolveSystemUiLocale(['fr-FR', 'de-DE']), 'en');
-    assert.equal(resolveSystemUiLocale([]), 'en');
-  });
-
-  it('resolves auto from the supported system locale', () => {
-    assert.equal(resolveUiLocale('auto', 'zh'), 'zh');
-    assert.equal(resolveUiLocale('auto', 'en'), 'en');
-  });
-
-  it('preserves an explicit supported preference', () => {
-    assert.equal(resolveUiLocale('zh', 'en'), 'zh');
-    assert.equal(resolveUiLocale('en', 'zh'), 'en');
-  });
-
-  it('gives a test override precedence over every persisted preference', () => {
-    assert.equal(resolveUiLocale('auto', 'zh', 'en'), 'en');
-    assert.equal(resolveUiLocale('en', 'en', 'zh'), 'zh');
-    assert.equal(resolveUiLocale('zh', 'en', null), 'zh');
-  });
-
-  it('maps the resolved locale to the Intl locale used by formatters', () => {
-    assert.equal(uiLocaleToIntlLocale('zh'), 'zh-CN');
-    assert.equal(uiLocaleToIntlLocale('en'), 'en');
-  });
-
-  it('provides a compile-time complete catalog shape', () => {
-    const catalog = {
-      zh: { label: '中文' },
-      en: { label: 'English' },
-    } satisfies UiCatalog<{ label: string }>;
-
-    assert.deepEqual(Object.keys(catalog), ['zh', 'en']);
-  });
+it('validates and resolves the complete UI locale contract', () => {
+  assert.deepEqual([...UI_LOCALES], ['zh', 'en']);
+  assert.deepEqual([...UI_LOCALE_PREFERENCES], ['auto', 'zh', 'en']);
+  for (const [value, expected] of [
+    ['zh', true],
+    ['en', true],
+    ['auto', false],
+    ['ja', false],
+    [null, false],
+  ] as const) {
+    assert.equal(isUiLocale(value), expected);
+  }
+  for (const [value, expected] of [
+    ['auto', true],
+    ['zh', true],
+    ['en', true],
+    ['ja', false],
+    [undefined, false],
+  ] as const) {
+    assert.equal(isUiLocalePreference(value), expected);
+  }
+  assert.equal(resolveSystemUiLocale(['zh-CN', 'en-US']), 'zh');
+  assert.equal(resolveSystemUiLocale(['ja-JP', 'en-GB']), 'en');
+  assert.equal(resolveSystemUiLocale(['fr-FR', 'de-DE']), 'en');
+  assert.equal(resolveSystemUiLocale([]), 'en');
+  assert.equal(resolveUiLocale('auto', 'zh'), 'zh');
+  assert.equal(resolveUiLocale('auto', 'en'), 'en');
+  assert.equal(resolveUiLocale('zh', 'en'), 'zh');
+  assert.equal(resolveUiLocale('en', 'zh'), 'en');
+  assert.equal(resolveUiLocale('auto', 'zh', 'en'), 'en');
+  assert.equal(resolveUiLocale('en', 'en', 'zh'), 'zh');
+  assert.equal(resolveUiLocale('zh', 'en', null), 'zh');
+  assert.equal(uiLocaleToIntlLocale('zh'), 'zh-CN');
+  assert.equal(uiLocaleToIntlLocale('en'), 'en');
 });


### PR DESCRIPTION
## Summary
- collapse relative-time boundary coverage into two behavior matrices
- collapse UI locale validation and resolution into one contract test
- collapse quiet tool preview coverage around projections, localization, diagnostics, and redaction
- remove the compile-time catalog shape mirror already enforced by TypeScript

## Impact
- 38 tests -> 7 tests (31 fewer)
- 3 files, net -108 lines
- production code unchanged

## Verification
- targeted tests: 7/7
- @maka/core test:dist: 663/663
- test:scripts:full: 33/33
- typecheck
- lint
- format:check
- git diff --check