### PR TITLE
test: collapse window reveal state coverage

### DIFF
--- a/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
@@ -1,50 +1,13 @@
-/**
- * PR-SHOW-AFTER-FIRST-COMMIT contract.
- *
- * The BrowserWindow is now created `show: false` on every run so the OS never
- * flashes the index.html `.maka-preload` skeleton before React paints. The
- * renderer signals `window:notifyRendererReady` after its first React commit,
- * and a fallback timer reveals the window if that signal never arrives. Under
- * e2e-fixture capture the window must stay hidden for its whole life.
- *
- * The reveal decision lives in showWindowOnceReady (window-reveal.ts) precisely
- * so it can be exercised behaviorally here — main-window.ts can't be imported
- * under plain `node --test` because it pulls in `electron`, whose API is only
- * present inside the Electron binary.
- */
-
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
+
 import {
   createWindowRevealGate,
   showWindowOnceReady,
   type FocusableRevealableWindow,
-  type RevealableWindow,
 } from '../window-reveal.js';
 
-/** Fake window that flips visible on show() and records every show() call. */
-function makeFakeWindow(): RevealableWindow & { showCount: number; destroy(): void } {
-  let visible = false;
-  let destroyed = false;
-  let showCount = 0;
-  return {
-    isVisible: () => visible,
-    isDestroyed: () => destroyed,
-    show() {
-      showCount += 1;
-      visible = true;
-    },
-    destroy() {
-      destroyed = true;
-    },
-    get showCount() {
-      return showCount;
-    },
-  };
-}
-
-/** Fake window with the focus surface the reveal gate's deferred focus touches. */
-function makeFakeFocusableWindow(): FocusableRevealableWindow & {
+function makeWindow(): FocusableRevealableWindow & {
   showCount: number;
   focusCount: number;
   maximizeCount: number;
@@ -68,8 +31,6 @@ function makeFakeFocusableWindow(): FocusableRevealableWindow & {
       focusCount += 1;
     },
     maximize() {
-      // Mirror the real Electron behavior this gate exists to contain:
-      // maximize() on a hidden window reveals it (verified on macOS).
       maximizeCount += 1;
       visible = true;
     },
@@ -88,134 +49,76 @@ function makeFakeFocusableWindow(): FocusableRevealableWindow & {
   };
 }
 
-// ChatGPT Pro review P2: second-instance / 'activate' land in controller
-// focus() while the window may still be pre-first-commit. The gate must defer
-// (not show) those requests, then flush them when the renderer signals ready.
-describe('window reveal gate defers early focus (ChatGPT Pro review P2)', () => {
-  it('focus before renderer-ready does not show; markReady flushes show+focus', () => {
+describe('window reveal gate', () => {
+  it('defers focus and maximize until ready, then applies later requests immediately', () => {
     const gate = createWindowRevealGate(false);
-    const win = makeFakeFocusableWindow();
-    // User re-launches / clicks the dock icon while the window is hidden.
-    gate.requestFocus(win);
-    assert.equal(win.showCount, 0, 'pre-ready focus must not reveal the skeleton');
-    assert.equal(win.isVisible(), false);
-    // First commit arrives: reveal once and honor the deferred foreground intent.
-    gate.markReady(win);
-    assert.equal(win.isVisible(), true);
-    assert.equal(win.focusCount, 1);
+    const window = makeWindow();
+
+    gate.requestFocus(window);
+    gate.requestMaximize(window);
+    assert.deepEqual(
+      [window.isVisible(), window.showCount, window.focusCount, window.maximizeCount],
+      [false, 0, 0, 0],
+    );
+
+    gate.markReady(window);
+    assert.deepEqual(
+      [window.isVisible(), window.showCount, window.focusCount, window.maximizeCount],
+      [true, 1, 1, 1],
+    );
+
+    gate.requestFocus(window);
+    gate.requestMaximize(window);
+    assert.deepEqual([window.showCount, window.focusCount, window.maximizeCount], [2, 2, 2]);
   });
 
-  it('focus after renderer-ready shows and focuses immediately (old behavior)', () => {
-    const gate = createWindowRevealGate(false);
-    const win = makeFakeFocusableWindow();
-    gate.markReady(win);
-    gate.requestFocus(win);
-    assert.equal(win.isVisible(), true);
-    assert.equal(win.focusCount, 1);
-  });
-
-  it('keepHidden (e2e-fixture / E2E) never shows or focuses from any path', () => {
+  it('keepHidden blocks reveal, focus, and maximize through every gate path', () => {
     const gate = createWindowRevealGate(true);
-    const win = makeFakeFocusableWindow();
-    gate.requestFocus(win);
-    gate.markReady(win);
-    gate.requestFocus(win);
-    assert.equal(win.showCount, 0);
-    assert.equal(win.focusCount, 0);
+    const window = makeWindow();
+
+    gate.requestFocus(window);
+    gate.requestMaximize(window);
+    gate.markReady(window);
+    gate.requestFocus(window);
+    gate.requestMaximize(window);
+
+    assert.deepEqual(
+      [window.isVisible(), window.showCount, window.focusCount, window.maximizeCount],
+      [false, 0, 0, 0],
+    );
   });
 
-  // ChatGPT Pro review P2 (round 2): Electron's maximize() reveals a hidden
-  // window, so restoring a saved maximized state in createWindow() bypassed
-  // the gate — a user who closed the app maximized saw the skeleton again on
-  // every launch. The gate must defer the maximize alongside focus.
-  it('saved-maximized restore before renderer-ready stays hidden; markReady applies it', () => {
+  it('reset re-arms readiness for a recreated window', () => {
     const gate = createWindowRevealGate(false);
-    const win = makeFakeFocusableWindow();
-    // createWindow() restores the persisted maximized state on a hidden window.
-    gate.requestMaximize(win);
-    assert.equal(win.maximizeCount, 0, 'pre-ready maximize must not reveal the skeleton');
-    assert.equal(win.isVisible(), false);
-    // First commit: maximize lands first, so the first visible frame is
-    // already maximized and the reveal itself becomes a no-op.
-    gate.markReady(win);
-    assert.equal(win.maximizeCount, 1);
-    assert.equal(win.isVisible(), true);
-    assert.equal(win.showCount, 0, 'maximize() already revealed; show() must not fire again');
-  });
-
-  it('maximize after renderer-ready applies immediately; keepHidden never maximizes', () => {
-    const readyGate = createWindowRevealGate(false);
-    const readyWin = makeFakeFocusableWindow();
-    readyGate.markReady(readyWin);
-    readyGate.requestMaximize(readyWin);
-    assert.equal(readyWin.maximizeCount, 1);
-
-    const fixtureGate = createWindowRevealGate(true);
-    const fixtureWin = makeFakeFocusableWindow();
-    fixtureGate.requestMaximize(fixtureWin);
-    fixtureGate.markReady(fixtureWin);
-    fixtureGate.requestMaximize(fixtureWin);
-    assert.equal(fixtureWin.maximizeCount, 0);
-    assert.equal(fixtureWin.isVisible(), false);
-  });
-
-  it('reset() re-arms the gate for a recreated window (macOS close-all)', () => {
-    const gate = createWindowRevealGate(false);
-    const first = makeFakeFocusableWindow();
-    gate.markReady(first);
+    gate.markReady(makeWindow());
     gate.reset();
-    const second = makeFakeFocusableWindow();
-    // Stale readiness from the first window must not leak: focus and maximize
-    // requests on the fresh hidden window defer again until its own first commit.
-    gate.requestFocus(second);
-    gate.requestMaximize(second);
-    assert.equal(second.showCount, 0);
-    assert.equal(second.maximizeCount, 0);
-    gate.markReady(second);
-    assert.equal(second.isVisible(), true);
-    assert.equal(second.focusCount, 1);
-    assert.equal(second.maximizeCount, 1);
-  });
-});
 
-describe('window reveal gate (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
-  it('renderer-ready reveals the hidden window exactly once (idempotent)', () => {
-    const win = makeFakeWindow();
-    // First commit signal reveals the hidden window.
-    showWindowOnceReady(win, false);
-    assert.equal(win.showCount, 1);
-    assert.equal(win.isVisible(), true);
-    // HMR reload re-fires the signal, and the fallback timer may race it — the
-    // isVisible() guard makes every later call a no-op so focus is never stolen.
-    showWindowOnceReady(win, false);
-    showWindowOnceReady(win, false);
-    assert.equal(win.showCount, 1);
+    const recreated = makeWindow();
+    gate.requestFocus(recreated);
+    gate.requestMaximize(recreated);
+    assert.equal(recreated.isVisible(), false);
+
+    gate.markReady(recreated);
+    assert.deepEqual(
+      [recreated.isVisible(), recreated.focusCount, recreated.maximizeCount],
+      [true, 1, 1],
+    );
   });
 
-  it('fallback timer path reveals a window that never signaled', () => {
-    // The timer routes through the same gate with keepHidden=false: a wedged
-    // renderer still gets a visible window.
-    const win = makeFakeWindow();
-    showWindowOnceReady(win, false);
-    assert.equal(win.showCount, 1);
-    assert.equal(win.isVisible(), true);
-  });
+  it('reveals once and ignores hidden-fixture, null, and destroyed targets', () => {
+    const visible = makeWindow();
+    showWindowOnceReady(visible, false);
+    showWindowOnceReady(visible, false);
+    assert.deepEqual([visible.isVisible(), visible.showCount], [true, 1]);
 
-  it('e2e-fixture (keepHidden) never reveals, from either the signal or the timer', () => {
-    const win = makeFakeWindow();
-    // Renderer-ready path.
-    showWindowOnceReady(win, true);
-    // Fallback-timer path.
-    showWindowOnceReady(win, true);
-    assert.equal(win.showCount, 0);
-    assert.equal(win.isVisible(), false);
-  });
+    const fixture = makeWindow();
+    showWindowOnceReady(fixture, true);
+    assert.deepEqual([fixture.isVisible(), fixture.showCount], [false, 0]);
 
-  it('never reveals a null or destroyed window (teardown raced the timer/IPC)', () => {
     assert.doesNotThrow(() => showWindowOnceReady(null, false));
-    const win = makeFakeWindow();
-    win.destroy();
-    showWindowOnceReady(win, false);
-    assert.equal(win.showCount, 0);
+    const destroyed = makeWindow();
+    destroyed.destroy();
+    showWindowOnceReady(destroyed, false);
+    assert.equal(destroyed.showCount, 0);
   });
 });


### PR DESCRIPTION
## Summary
- replace ten scenario-fragment tests with four state-transition contracts
- combine deferred focus and maximize behavior into one readiness transition
- retain keepHidden, reset/recreate, idempotent reveal, null, and destroyed-window races
- remove the duplicate fallback test that called the same reveal function as renderer-ready

## Impact
- 10 tests -> 4 tests
- net -97 lines
- production code unchanged

## Verification
- targeted: 4/4
- desktop test:dist: 1402/1402
- build:test
- typecheck
- lint
- format:check
- desktop console/a11y/copy checks
- git diff --check