### PR TITLE
test: collapse model wait state coverage

### DIFF
--- a/apps/desktop/src/main/__tests__/model-wait-state.test.ts
+++ b/apps/desktop/src/main/__tests__/model-wait-state.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+
 import {
   MODEL_PROCESSING_DELAY_MS,
   createDelayedFlag,
@@ -16,12 +17,12 @@ const HEAD = {
 
 function fakeScheduler() {
   let now = 0;
-  let seq = 0;
-  const timers = new Map<number, { at: number; fn: () => void }>();
+  let sequence = 0;
+  const timers = new Map<number, { at: number; run: () => void }>();
   const scheduler: DelayedFlagScheduler = {
-    setTimeout(fn, ms) {
-      const id = ++seq;
-      timers.set(id, { at: now + ms, fn });
+    setTimeout(run, delay) {
+      const id = ++sequence;
+      timers.set(id, { at: now + delay, run });
       return id;
     },
     clearTimeout(handle) {
@@ -30,123 +31,73 @@ function fakeScheduler() {
   };
   return {
     scheduler,
-    advance(ms: number) {
-      now += ms;
-      for (const [id, timer] of [...timers.entries()]) {
-        if (timer.at <= now) {
-          timers.delete(id);
-          timer.fn();
-        }
+    advance(duration: number) {
+      now += duration;
+      for (const [id, timer] of [...timers]) {
+        if (timer.at > now) continue;
+        timers.delete(id);
+        timer.run();
       }
     },
     pending: () => timers.size,
   };
 }
 
-describe('deriveModelWait', () => {
-  it("is 'processing' at the turn head — armed, waiting for the first token", () => {
-    assert.equal(deriveModelWait(HEAD), 'processing');
+describe('model wait state', () => {
+  it('derives head, active-content, tool, and mid-turn wait states', () => {
+    for (const [input, expected] of [
+      [HEAD, 'processing'],
+      [{ ...HEAD, turnPhase: undefined }, 'none'],
+      [{ ...HEAD, streamingText: 'answer' }, 'none'],
+      [{ ...HEAD, thinkingText: 'reasoning' }, 'none'],
+      [{ ...HEAD, hasInFlightTools: true }, 'none'],
+      [{ ...HEAD, turnPhase: 'streamed', hasInFlightTools: true }, 'none'],
+      [{ ...HEAD, turnPhase: 'streamed' }, 'continuing'],
+    ] as const) {
+      assert.equal(deriveModelWait(input), expected);
+    }
   });
 
-  it("is 'none' when no turn is in flight", () => {
-    assert.equal(deriveModelWait({ ...HEAD, turnPhase: undefined }), 'none');
-  });
-
-  it("is 'none' once answer text is streaming", () => {
-    assert.equal(deriveModelWait({ ...HEAD, streamingText: 'hi' }), 'none');
-  });
-
-  it("is 'none' once reasoning is streaming", () => {
-    assert.equal(deriveModelWait({ ...HEAD, thinkingText: 'because' }), 'none');
-  });
-
-  it("is 'none' while a tool is in flight", () => {
-    assert.equal(deriveModelWait({ ...HEAD, hasInFlightTools: true }), 'none');
-  });
-
-  it("a mid-turn lull after content is 'continuing', NOT 'processing' (#646)", () => {
-    // Once the turn has streamed (phase 'streamed'), a tool settling back to an
-    // idle state is the calm "继续中…" hint — the prominent "正在处理…" must not
-    // re-fire in every step-to-step gap (the regression this split fixes).
-    const running = deriveModelWait({ ...HEAD, turnPhase: 'streamed', hasInFlightTools: true });
-    const settled = deriveModelWait({ ...HEAD, turnPhase: 'streamed', hasInFlightTools: false });
-    assert.equal(running, 'none');
-    assert.equal(settled, 'continuing');
-  });
-
-  it("the head wait stays 'processing' only until the first content event flips the phase", () => {
-    assert.equal(deriveModelWait({ ...HEAD, turnPhase: 'waiting' }), 'processing');
-    assert.equal(deriveModelWait({ ...HEAD, turnPhase: 'streamed' }), 'continuing');
-  });
-});
-
-describe('createDelayedFlag', () => {
-  it('reveals only after the delay elapses with the condition held true', () => {
-    const clock = fakeScheduler();
-    const flag = createDelayedFlag({ delayMs: MODEL_PROCESSING_DELAY_MS, scheduler: clock.scheduler });
-    flag.setCondition(true);
-    clock.advance(MODEL_PROCESSING_DELAY_MS - 1);
-    assert.equal(flag.get(), false, 'still hidden just before the delay');
-    clock.advance(1);
-    assert.equal(flag.get(), true, 'revealed at the delay boundary');
-  });
-
-  it('never reveals when the condition drops before the delay (fast response, no flash)', () => {
-    const clock = fakeScheduler();
-    const flag = createDelayedFlag({ delayMs: MODEL_PROCESSING_DELAY_MS, scheduler: clock.scheduler });
-    flag.setCondition(true);
-    clock.advance(100);
-    flag.setCondition(false);
-    clock.advance(MODEL_PROCESSING_DELAY_MS);
-    assert.equal(flag.get(), false);
-    assert.equal(clock.pending(), 0, 'the pending reveal timer was cancelled');
-  });
-
-  it('hides immediately when the condition drops after being visible', () => {
-    const clock = fakeScheduler();
-    const flag = createDelayedFlag({ delayMs: MODEL_PROCESSING_DELAY_MS, scheduler: clock.scheduler });
-    flag.setCondition(true);
-    clock.advance(MODEL_PROCESSING_DELAY_MS);
-    assert.equal(flag.get(), true);
-    flag.setCondition(false);
-    assert.equal(flag.get(), false);
-  });
-
-  it('re-arms on a fresh rising edge', () => {
-    const clock = fakeScheduler();
-    const flag = createDelayedFlag({ delayMs: MODEL_PROCESSING_DELAY_MS, scheduler: clock.scheduler });
-    flag.setCondition(true);
-    clock.advance(MODEL_PROCESSING_DELAY_MS);
-    flag.setCondition(false);
-    flag.setCondition(true);
-    clock.advance(MODEL_PROCESSING_DELAY_MS - 1);
-    assert.equal(flag.get(), false, 'the second window is delayed too');
-    clock.advance(1);
-    assert.equal(flag.get(), true);
-  });
-
-  it('emits onChange only on real transitions', () => {
+  it('delays rising edges, hides immediately, re-arms, and emits only transitions', () => {
     const clock = fakeScheduler();
     const changes: boolean[] = [];
     const flag = createDelayedFlag({
       delayMs: MODEL_PROCESSING_DELAY_MS,
       scheduler: clock.scheduler,
-      onChange: (v) => changes.push(v),
+      onChange: (visible) => changes.push(visible),
     });
+
     flag.setCondition(true);
-    flag.setCondition(true); // redundant, no timer churn
-    clock.advance(MODEL_PROCESSING_DELAY_MS);
+    flag.setCondition(true);
+    clock.advance(MODEL_PROCESSING_DELAY_MS - 1);
+    assert.equal(flag.get(), false);
+    clock.advance(1);
+    assert.equal(flag.get(), true);
+
     flag.setCondition(false);
-    assert.deepEqual(changes, [true, false]);
+    assert.equal(flag.get(), false);
+    flag.setCondition(true);
+    clock.advance(MODEL_PROCESSING_DELAY_MS - 1);
+    assert.equal(flag.get(), false);
+    clock.advance(1);
+    assert.equal(flag.get(), true);
+    assert.deepEqual(changes, [true, false, true]);
   });
 
-  it('dispose cancels a pending reveal', () => {
-    const clock = fakeScheduler();
-    const flag = createDelayedFlag({ delayMs: MODEL_PROCESSING_DELAY_MS, scheduler: clock.scheduler });
-    flag.setCondition(true);
-    flag.dispose();
-    clock.advance(MODEL_PROCESSING_DELAY_MS);
-    assert.equal(flag.get(), false);
-    assert.equal(clock.pending(), 0);
+  it('cancels a pending reveal when the condition drops or the owner disposes', () => {
+    for (const cancel of ['condition', 'dispose'] as const) {
+      const clock = fakeScheduler();
+      const flag = createDelayedFlag({
+        delayMs: MODEL_PROCESSING_DELAY_MS,
+        scheduler: clock.scheduler,
+      });
+      flag.setCondition(true);
+      clock.advance(100);
+      if (cancel === 'condition') flag.setCondition(false);
+      else flag.dispose();
+      clock.advance(MODEL_PROCESSING_DELAY_MS);
+      assert.equal(flag.get(), false, cancel);
+      assert.equal(clock.pending(), 0, cancel);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- collapse seven model-wait micro-tests into one input/output matrix
- exercise delay, hide, re-arm, and transition callbacks as one lifecycle
- combine condition-drop and dispose cancellation into one fail-closed contract
- retain every previous state and timer boundary assertion

## Impact
- 13 tests -> 3 tests
- 152 lines -> 103 lines
- net -49 lines
- production code unchanged

## Verification
- targeted: 3/3
- desktop test:dist: 1380/1380
- build:test
- typecheck
- lint
- format:check
- desktop console/a11y/copy checks
- git diff --check