### PR TITLE
test: collapse notification policy coverage

### DIFF
--- a/apps/desktop/src/main/__tests__/notifications-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/notifications-policy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   isRunNotificationKind,
@@ -7,97 +7,58 @@ import {
   shouldRaiseRunNotification,
 } from '../notifications-policy.js';
 
-describe('shouldRaiseRunNotification gate', () => {
+it('gates native notifications through every required condition', () => {
   const base = { enabled: true, supported: true, windowFocused: false, incognito: false, e2e: false };
+  const cases = [
+    [base, true],
+    [{ ...base, enabled: false }, false],
+    [{ ...base, supported: false }, false],
+    [{ ...base, windowFocused: true }, false],
+    [{ ...base, incognito: true }, false],
+    [{ ...base, e2e: true }, false],
+  ] as const;
 
-  it('raises a notification only when enabled, supported, unfocused, and not incognito', () => {
-    assert.equal(shouldRaiseRunNotification(base), true);
-  });
-
-  it('suppresses when the product toggle is off', () => {
-    assert.equal(shouldRaiseRunNotification({ ...base, enabled: false }), false);
-  });
-
-  it('suppresses when the platform does not support notifications', () => {
-    assert.equal(shouldRaiseRunNotification({ ...base, supported: false }), false);
-  });
-
-  it('suppresses while the window is focused (user is already looking)', () => {
-    assert.equal(shouldRaiseRunNotification({ ...base, windowFocused: true }), false);
-  });
-
-  it('suppresses in incognito mode (no session name/preview outside the app)', () => {
-    assert.equal(shouldRaiseRunNotification({ ...base, incognito: true }), false);
-  });
-
-  it('suppresses native notifications during E2E runs', () => {
-    assert.equal(shouldRaiseRunNotification({ ...base, e2e: true }), false);
-  });
+  for (const [input, expected] of cases) {
+    assert.equal(shouldRaiseRunNotification(input), expected);
+  }
 });
 
-describe('isRunNotificationKind guard', () => {
-  it('accepts the two terminal kinds', () => {
-    assert.equal(isRunNotificationKind('completed'), true);
-    assert.equal(isRunNotificationKind('errored'), true);
-  });
+it('recognizes terminal kinds and keeps distinct fallback copy', () => {
+  for (const value of ['completed', 'errored']) assert.equal(isRunNotificationKind(value), true);
+  for (const value of ['complete', 'error', 'aborted', '', undefined, null, 1, {}]) {
+    assert.equal(isRunNotificationKind(value), false);
+  }
 
-  it('rejects anything else, including near-misses and non-strings', () => {
-    for (const bad of ['complete', 'error', 'aborted', '', undefined, null, 1, {}]) {
-      assert.equal(isRunNotificationKind(bad), false);
-    }
-  });
+  const completed = runNotificationCopy('completed');
+  const errored = runNotificationCopy('errored');
+  assert.ok(completed.title && completed.body);
+  assert.ok(errored.title && errored.body);
+  assert.notEqual(completed.title, errored.title);
 });
 
-describe('runNotificationCopy', () => {
-  it('gives distinct, non-empty copy per kind', () => {
-    const completed = runNotificationCopy('completed');
-    const errored = runNotificationCopy('errored');
-    assert.ok(completed.title.length > 0 && completed.body.length > 0);
-    assert.ok(errored.title.length > 0 && errored.body.length > 0);
-    assert.notEqual(completed.title, errored.title);
+it('sanitizes renderer content, caps it, and falls back per field', () => {
+  const clean = resolveNotificationContent({
+    kind: 'completed',
+    title: '  会话  A  ',
+    body: 'line one\n\nline two\tindented',
   });
-});
+  assert.deepEqual(clean, { title: '会话 A', body: 'line one line two indented' });
 
-describe('resolveNotificationContent', () => {
-  it('prefers the renderer session name + reply preview', () => {
-    const copy = resolveNotificationContent({
-      kind: 'completed',
-      title: '重构登录流程',
-      body: '好的，我先梳理当前的认证链路，再分三步改造：',
-    });
-    assert.equal(copy.title, '重构登录流程');
-    assert.equal(copy.body, '好的，我先梳理当前的认证链路，再分三步改造：');
-  });
+  const completedFallback = runNotificationCopy('completed');
+  for (const value of ['', '   ', undefined, null, 42, {}]) {
+    assert.deepEqual(
+      resolveNotificationContent({ kind: 'completed', title: value, body: value }),
+      completedFallback,
+    );
+  }
 
-  it('collapses whitespace/newlines into a single line', () => {
-    const copy = resolveNotificationContent({
-      kind: 'completed',
-      title: '  会话  A  ',
-      body: 'line one\n\nline two\tindented',
-    });
-    assert.equal(copy.title, '会话 A');
-    assert.equal(copy.body, 'line one line two indented');
-  });
+  const capped = resolveNotificationContent({ kind: 'completed', title: 'S', body: 'x'.repeat(500) });
+  assert.equal(capped.body.length, 160);
+  assert.ok(capped.body.endsWith('…'));
 
-  it('falls back per-field to generic copy when blank or non-string', () => {
-    const fallback = runNotificationCopy('completed');
-    for (const bad of ['', '   ', undefined, null, 42, {}]) {
-      const copy = resolveNotificationContent({ kind: 'completed', title: bad, body: bad });
-      assert.equal(copy.title, fallback.title);
-      assert.equal(copy.body, fallback.body);
-    }
-  });
-
-  it('caps an overlong body with an ellipsis', () => {
-    const copy = resolveNotificationContent({ kind: 'completed', title: 'S', body: 'x'.repeat(500) });
-    assert.ok(copy.body.length <= 160);
-    assert.ok(copy.body.endsWith('…'));
-  });
-
-  it('uses the errored fallback body when the error message is blank', () => {
-    const fallback = runNotificationCopy('errored');
-    const copy = resolveNotificationContent({ kind: 'errored', title: '出错的会话', body: '' });
-    assert.equal(copy.title, '出错的会话');
-    assert.equal(copy.body, fallback.body);
+  const erroredFallback = runNotificationCopy('errored');
+  assert.deepEqual(resolveNotificationContent({ kind: 'errored', title: '出错的会话', body: '' }), {
+    title: '出错的会话',
+    body: erroredFallback.body,
   });
 });


### PR DESCRIPTION
## Summary
- collapse notification gating cases into one behavior matrix
- combine terminal-kind and fallback-copy coverage
- keep sanitization, invalid-field fallback, length cap, and error-copy boundaries

## Test plan
- npm run build:test
- node --test apps/desktop/dist/main/__tests__/notifications-policy.test.js
- npm --workspace @maka/desktop run test:dist (1369/1369)
- npm run typecheck
- npm run lint
- npm run format:check