### PR TITLE
test: keep script test changes off the full suite

### DIFF
--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -13,9 +13,7 @@ const FULL_SUITE_FILES = new Set([
   'package-lock.json',
   'package.json',
   'scripts/ci-test-plan.mjs',
-  'scripts/ci-test-plan.test.mjs',
   'scripts/run-workspace-tests-parallel.mjs',
-  'scripts/run-workspace-tests-parallel.test.mjs',
 ]);
 
 const TYPECHECK_ONLY_FILES = new Set([

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -26,7 +26,15 @@ test('stress and specialized script checks run only for their owning surfaces', 
     planTests(['packages/storage/src/agent-run-store.ts'], { graph }).storageStress,
     true,
   );
-  assert.equal(planTests(['scripts/fixture-env.mjs'], { graph }).scriptMode, 'fast');
+  for (const path of [
+    'scripts/fixture-env.mjs',
+    'scripts/ci-test-plan.test.mjs',
+    'scripts/run-workspace-tests-parallel.test.mjs',
+  ]) {
+    const plan = planTests([path], { graph });
+    assert.equal(plan.full, false, path);
+    assert.equal(plan.scriptMode, 'fast', path);
+  }
   const measurement = planTests(['scripts/measure-session-bundle.mjs'], { graph });
   assert.equal(measurement.scriptMode, 'extended');
   assert.deepEqual(measurement.workspaces, []);


### PR DESCRIPTION
## Summary
- stop treating two script test files as full-suite triggers
- route their changes to the fast script checks only
- keep source changes to the CI planner and workspace runner fail-safe

## Why
The complete script suite is already only 28 high-value security, isolation, teardown, provenance, and recovery tests. The waste was running every workspace, E2E, and storage stress test for test-only harness edits.

## Test plan
- node --test scripts/ci-test-plan.test.mjs
- npm run build:test
- npm run test:scripts:full (28/28)
- npm run typecheck
- npm run lint
- npm run format:check