### PR TITLE
test: remove duplicate CLI process coverage

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,42 +1,17 @@
 import assert from 'node:assert/strict';
-import { execFile, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { once } from 'node:events';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { promisify } from 'node:util';
 import { describe, test } from 'node:test';
-import { createConnectionStore, createSessionStore } from '@maka/storage';
+import { createSessionStore } from '@maka/storage';
 import {
   parseMakaCliArgs,
   formatStartupConnectionError,
   resolveMakaCliExitCode,
   resolveTuiResumeTarget,
 } from '../cli.js';
-import { createMakaCliRuntimeContext } from '../runtime-bootstrap.js';
-
-const execFileAsync = promisify(execFile);
-const cliPath = new URL('../cli.js', import.meta.url).pathname;
-
-function runCliProcess(
-  entrypoint: string,
-  args: string[],
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<{ code: number | null; stdout: string; stderr: string }> {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, [entrypoint, ...args], { env });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString('utf8');
-    });
-    child.stderr.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString('utf8');
-    });
-    child.on('close', (code) => resolve({ code, stdout, stderr }));
-    child.stdin.end();
-  });
-}
 
 describe('Maka CLI args', () => {
   test('parses canonical commands and rejects malformed input', () => {
@@ -91,134 +66,6 @@ describe('Maka CLI args', () => {
 
     assert.equal(signal, null);
     assert.equal(code, 1);
-  });
-
-  test('coordinates repeated exit requests through the shell cleanup grace period', async () => {
-    const cliUrl = new URL('../cli.js', import.meta.url).href;
-    const childSource = `
-      import { beginMakaCliExit } from ${JSON.stringify(cliUrl)};
-      setInterval(() => {}, 1_000);
-      beginMakaCliExit(0);
-      setTimeout(() => beginMakaCliExit(1), 100);
-    `;
-    const startedAt = Date.now();
-    const child = spawn(process.execPath, ['--input-type=module', '-e', childSource], {
-      stdio: 'ignore',
-    });
-    const watchdog = setTimeout(() => child.kill('SIGKILL'), 10_000);
-    const [code, signal] = (await once(child, 'exit')) as [number | null, NodeJS.Signals | null];
-    clearTimeout(watchdog);
-
-    assert.equal(signal, null);
-    assert.equal(code, 1);
-    assert.ok(Date.now() - startedAt >= 2_500);
-  });
-
-  test('inspects a Session through the executable entrypoint', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'maka-cli-inspect-'));
-    try {
-      const connections = createConnectionStore(root);
-      await connections.create({
-        slug: 'local',
-        name: 'Local',
-        providerType: 'ollama',
-        defaultModel: 'local-model',
-      });
-      const context = await createMakaCliRuntimeContext({
-        surface: 'run',
-        workspaceRoot: root,
-        cwd: '/tmp/workspace',
-      });
-      let sessionId: string;
-      try {
-        sessionId = (
-          await context.runtime.createSession({
-            cwd: context.cwd,
-            name: 'CLI inspect',
-            backend: 'ai-sdk',
-            llmConnectionSlug: context.target.connection.slug,
-            model: context.target.model,
-            permissionMode: 'ask',
-          })
-        ).id;
-      } finally {
-        await context.close();
-      }
-      const result = await runCliProcess(cliPath, [
-        'inspect',
-        sessionId,
-        '--store',
-        root,
-        '--kind',
-        'session',
-        '--json',
-      ]);
-
-      assert.equal(result.code, 0);
-      assert.equal(result.stderr, '');
-      const document = JSON.parse(result.stdout) as { schemaVersion: string; kind: string };
-      assert.equal(document.schemaVersion, 'maka.session_inspect.v1');
-      assert.equal(document.kind, 'session');
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  test('runs a fake evaluation through the unified executable', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'maka-unified-eval-'));
-    try {
-      await mkdir(join(dir, 'fixture'), { recursive: true });
-      await writeFile(join(dir, 'fixture', 'marker.txt'), 'ok', 'utf8');
-      const specPath = join(dir, 'spec.json');
-      const outDir = join(dir, 'out');
-      await writeFile(
-        specPath,
-        JSON.stringify({
-          configs: [
-            { id: 'fake-cfg', backend: 'fake', llmConnectionSlug: 'fake', model: 'fake-model' },
-          ],
-          tasks: [
-            {
-              id: 't-pass',
-              instruction: 'go',
-              workspaceDir: 'fixture',
-              verification: { command: 'test -f marker.txt', protectedPaths: [] },
-            },
-          ],
-        }),
-        'utf8',
-      );
-
-      const result = await runCliProcess(cliPath, ['eval', 'run', specPath, '--out', outDir]);
-
-      assert.equal(result.code, 0, result.stderr);
-      assert.doesNotMatch(result.stderr, /deprecated/);
-      assert.match(result.stdout, /t-pass/);
-      assert.match(await readFile(join(outDir, 'comparison.md'), 'utf8'), /t-pass/);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  test('returns exit 2 for missing non-interactive input before configuration startup', async () => {
-    const result = await runCliProcess(cliPath, ['run']);
-
-    assert.equal(result.code, 2);
-    assert.match(result.stderr, /missing prompt input/);
-    assert.equal(result.stdout, '');
-  });
-
-  test('runs when launched through a bin symlink', async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), 'maka-cli-bin-'));
-    try {
-      const linkPath = join(tempDir, 'maka');
-      await symlink(cliPath, linkPath);
-      const { stdout } = await execFileAsync(linkPath, ['--version']);
-
-      assert.equal(stdout.trim(), '0.1.0');
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
   });
 });
 


### PR DESCRIPTION
## Summary
- remove five slow executable happy paths already covered by command/headless suites
- delete the three-second exit-grace timer assertion that only waits on an implementation constant
- remove the now-unused process and temporary-file harness

## Impact
- cli.test.ts: 11 to 6 tests
- targeted runtime: about 8.3s to 1.24s
- 156 lines removed

## Retained boundaries
- CLI parser and malformed input matrix
- established exit-code precedence
- fatal writer ordering in a real child process
- resume target storage behavior
- classified startup connection errors

## Test plan
- npm run build:test
- node --test packages/cli/dist/__tests__/cli.test.js (6/6)
- npm --workspace maka-agent run test:dist (495/495)
- npm run typecheck
- npm run lint
- npm run format:check