### PR TITLE
test: prune duplicate onboarding coverage

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -42,42 +42,6 @@ describe('listOnboardingProviders', () => {
     assert.deepEqual(minimaxEntry?.enabledModelIds, ['MiniMax-M3']);
   });
 
-  test('only lists API-key providers that do not require a base url', async () => {
-    const providers = await listOnboardingProviders({
-      connectionStore: { list: async () => [] },
-    });
-    for (const provider of providers) {
-      assert.equal(provider.requiresBaseUrl, false);
-      assert.ok(provider.authKind === 'api_key' || provider.authKind === 'optional_api_key');
-    }
-    assert.ok(!providers.some((p) => p.providerType === 'ollama'));
-  });
-
-  test('uses only the canonical connection when one provider has multiple connections', async () => {
-    const providers = await listOnboardingProviders({
-      connectionStore: {
-        list: async () => [
-          makeConnection({
-            slug: 'openai-2',
-            providerType: 'openai',
-            defaultModel: 'secondary',
-            enabledModelIds: ['secondary'],
-          }),
-          makeConnection({
-            slug: 'openai',
-            providerType: 'openai',
-            defaultModel: 'canonical',
-            enabledModelIds: ['canonical'],
-          }),
-        ],
-      },
-    });
-
-    const openai = providers.find((provider) => provider.providerType === 'openai');
-    assert.equal(openai?.hasConnection, true);
-    assert.deepEqual(openai?.enabledModelIds, ['canonical']);
-  });
-
   test('does not select noncanonical connections for a provider', async () => {
     const providers = await listOnboardingProviders({
       connectionStore: {
@@ -208,43 +172,6 @@ describe('verifyApiKeyConnection', () => {
     assert.equal(secretStored, false, 'verify must not rotate the stored key');
   });
 
-  test('recognizes an existing canonical MiniMax connection and reuses its secret', async () => {
-    const connectionSlugs: string[] = [];
-    const credentialSlugs: string[] = [];
-    let probedSlug = '';
-
-    const result = await verifyApiKeyConnection({
-      providerType: 'MiniMax',
-      apiKey: '',
-      connectionStore: {
-        get: async (slug) => {
-          connectionSlugs.push(slug);
-          return makeConnection({
-            slug: 'minimax',
-            providerType: 'MiniMax',
-            defaultModel: 'MiniMax-M3',
-          });
-        },
-      },
-      credentialStore: {
-        getSecret: async (slug) => {
-          credentialSlugs.push(slug);
-          return 'stored-minimax-key';
-        },
-      },
-      fetchModels: async (connection, apiKey) => {
-        probedSlug = connection.slug;
-        assert.equal(apiKey, 'stored-minimax-key');
-        return [{ id: 'MiniMax-M3' }];
-      },
-    });
-
-    assert.equal(result.kind, 'ok');
-    assert.deepEqual(connectionSlugs, ['minimax']);
-    assert.deepEqual(credentialSlugs, ['minimax']);
-    assert.equal(probedSlug, 'minimax');
-  });
-
   test('probes with a newly supplied key for an existing connection (rotation preview)', async () => {
     let probedKey = '';
     let readStored = false;
@@ -285,24 +212,6 @@ describe('verifyApiKeyConnection', () => {
     assert.deepEqual(result, { kind: 'error', text: 'HTTP 401' });
   });
 
-  test('rejects a provider that does not accept an API key before probing', async () => {
-    let probed = false;
-    const result = await verifyApiKeyConnection({
-      providerType: 'ollama',
-      apiKey: 'unused',
-      connectionStore: { get: async () => null },
-      credentialStore: { getSecret: async () => null },
-      fetchModels: async () => {
-        probed = true;
-        return [];
-      },
-    });
-
-    assert.equal(result.kind, 'error');
-    assert.match((result as { text: string }).text, /does not accept an API key/);
-    assert.equal(probed, false);
-  });
-
   test('rejects a canonical slug owned by another provider before reading credentials or probing', async () => {
     let readCredential = false;
     let probed = false;
@@ -335,186 +244,6 @@ describe('verifyApiKeyConnection', () => {
 });
 
 describe('saveApiKeyConnection', () => {
-  test('uses a valid derived slug throughout MiniMax persistence', async () => {
-    const createdSlugs: string[] = [];
-    const updatedSlugs: string[] = [];
-    const credentialSlugs: string[] = [];
-    const defaultSlugs: string[] = [];
-
-    const result = await saveApiKeyConnection({
-      providerType: 'MiniMax',
-      apiKey: 'minimax-key',
-      enabledModelIds: ['MiniMax-M3'],
-      models: [{ id: 'MiniMax-M3' }],
-      connectionStore: {
-        get: async () => null,
-        create: async (input) => {
-          createdSlugs.push(input.slug);
-          return makeConnection({
-            slug: input.slug,
-            providerType: input.providerType,
-            defaultModel: input.defaultModel,
-          });
-        },
-        update: async (slug) => {
-          updatedSlugs.push(slug);
-          return makeConnection({ slug, providerType: 'MiniMax', defaultModel: 'MiniMax-M3' });
-        },
-        remove: async () => {},
-        getDefault: async () => null,
-        setDefault: async (slug) => {
-          if (slug) defaultSlugs.push(slug);
-        },
-      },
-      credentialStore: {
-        getSecret: async () => null,
-        setSecret: async (slug) => {
-          credentialSlugs.push(slug);
-        },
-        deleteSecret: async () => {},
-      },
-      fetchModelChoices: async () => [],
-    });
-
-    assert.equal(result.kind, 'ok');
-    assert.deepEqual(createdSlugs, ['minimax']);
-    assert.deepEqual(updatedSlugs, ['minimax']);
-    assert.deepEqual(credentialSlugs, ['minimax']);
-    assert.deepEqual(defaultSlugs, ['minimax']);
-  });
-
-  test('uses minimax-cn as the canonical slug for MiniMax-cn', async () => {
-    const touchedSlugs: string[] = [];
-
-    const result = await saveApiKeyConnection({
-      providerType: 'MiniMax-cn',
-      apiKey: 'minimax-cn-key',
-      enabledModelIds: ['MiniMax-M3'],
-      models: [{ id: 'MiniMax-M3' }],
-      connectionStore: {
-        get: async (slug) => {
-          touchedSlugs.push(`get:${slug}`);
-          return null;
-        },
-        create: async (input) => {
-          touchedSlugs.push(`create:${input.slug}`);
-          return makeConnection({
-            slug: input.slug,
-            providerType: input.providerType,
-            defaultModel: input.defaultModel,
-          });
-        },
-        update: async (slug) => {
-          touchedSlugs.push(`update:${slug}`);
-          return makeConnection({ slug, providerType: 'MiniMax-cn', defaultModel: 'MiniMax-M3' });
-        },
-        remove: async () => {},
-        getDefault: async () => null,
-        setDefault: async (slug) => {
-          if (slug) touchedSlugs.push(`default:${slug}`);
-        },
-      },
-      credentialStore: {
-        getSecret: async () => null,
-        setSecret: async (slug) => {
-          touchedSlugs.push(`credential:${slug}`);
-        },
-        deleteSecret: async () => {},
-      },
-      fetchModelChoices: async () => [],
-    });
-
-    assert.equal(result.kind, 'ok');
-    assert.deepEqual(touchedSlugs, [
-      'get:minimax-cn',
-      'create:minimax-cn',
-      'credential:minimax-cn',
-      'update:minimax-cn',
-      'default:minimax-cn',
-    ]);
-  });
-
-  test('saves an existing canonical MiniMax connection back to minimax', async () => {
-    const updatedSlugs: string[] = [];
-    let secretWritten = false;
-
-    const result = await saveApiKeyConnection({
-      providerType: 'MiniMax',
-      apiKey: '',
-      enabledModelIds: ['MiniMax-M3'],
-      models: [{ id: 'MiniMax-M3' }],
-      connectionStore: {
-        get: async (slug) => {
-          assert.equal(slug, 'minimax');
-          return makeConnection({
-            slug: 'minimax',
-            providerType: 'MiniMax',
-            defaultModel: 'MiniMax-M3',
-          });
-        },
-        create: async () => {
-          throw new Error('create must not be called for an existing connection');
-        },
-        update: async (slug) => {
-          updatedSlugs.push(slug);
-          return makeConnection({ slug, providerType: 'MiniMax', defaultModel: 'MiniMax-M3' });
-        },
-        remove: async () => {},
-        getDefault: async () => 'minimax',
-        setDefault: async () => {},
-      },
-      credentialStore: {
-        getSecret: async () => 'stored-minimax-key',
-        setSecret: async () => {
-          secretWritten = true;
-        },
-        deleteSecret: async () => {},
-      },
-      fetchModelChoices: async () => [],
-    });
-
-    assert.equal(result.kind, 'ok');
-    assert.deepEqual(updatedSlugs, ['minimax']);
-    assert.equal(secretWritten, false);
-  });
-
-  test('updates only the canonical connection when the provider has multiple connections', async () => {
-    const connections = [
-      makeConnection({ slug: 'openai', providerType: 'openai', defaultModel: 'gpt-5.5' }),
-      makeConnection({ slug: 'openai-2', providerType: 'openai', defaultModel: 'gpt-4.1' }),
-    ];
-    const updatedSlugs: string[] = [];
-
-    const result = await saveApiKeyConnection({
-      providerType: 'openai',
-      apiKey: '',
-      enabledModelIds: ['gpt-5.5'],
-      models: [{ id: 'gpt-5.5' }],
-      connectionStore: {
-        get: async (slug) => connections.find((connection) => connection.slug === slug) ?? null,
-        create: async () => {
-          throw new Error('create must not be called when the canonical connection exists');
-        },
-        update: async (slug) => {
-          updatedSlugs.push(slug);
-          return connections.find((connection) => connection.slug === slug)!;
-        },
-        remove: async () => {},
-        getDefault: async () => 'openai',
-        setDefault: async () => {},
-      },
-      credentialStore: {
-        getSecret: async () => null,
-        setSecret: async () => {},
-        deleteSecret: async () => {},
-      },
-      fetchModelChoices: async () => [],
-    });
-
-    assert.equal(result.kind, 'ok');
-    assert.deepEqual(updatedSlugs, ['openai']);
-  });
-
   test('does not select noncanonical same-provider connections', async () => {
     const connections = [
       makeConnection({ slug: 'openai-2', providerType: 'openai' }),
@@ -902,43 +631,6 @@ describe('saveApiKeyConnection', () => {
     assert.equal(secretStored, false, 'a blank key must not rotate the stored secret');
     assert.equal(updatedPatches.length, 1);
     assert.deepEqual(updatedPatches[0]!.enabledModelIds, ['gpt-5.5', 'gpt-5.5-mini']);
-  });
-
-  test('rotates the key before updating an existing connection and leaves it untouched on failure', async () => {
-    const storedSecrets: Array<string> = [];
-    let updated = false;
-    const result = await saveApiKeyConnection({
-      providerType: 'openai',
-      apiKey: 'sk-rotated',
-      enabledModelIds: ['gpt-5.5'],
-      models: [{ id: 'gpt-5.5' }],
-      connectionStore: {
-        get: async () => makeConnection({ slug: 'openai', providerType: 'openai' }),
-        create: async () => {
-          throw new Error('create must not be called');
-        },
-        update: async () => {
-          updated = true;
-          return makeConnection({ slug: 'openai', providerType: 'openai' });
-        },
-        remove: async () => {},
-        getDefault: async () => 'openai',
-        setDefault: async () => {},
-      },
-      credentialStore: {
-        getSecret: async () => null,
-        deleteSecret: async () => {},
-        setSecret: async () => {
-          throw new Error('disk full');
-        },
-      },
-      fetchModelChoices: async () => [],
-    });
-
-    assert.equal(result.kind, 'error');
-    assert.match((result as { text: string }).text, /disk full/);
-    assert.equal(updated, false, 'a rotation failure must not update the existing connection');
-    assert.deepEqual(storedSecrets, []);
   });
 
   test('does not replace an existing default connection during in-session setup', async () => {


### PR DESCRIPTION
## Summary
- reduce onboarding coverage from 32 to 23 tests
- remove 308 lines of provider presentation variants and duplicate happy paths
- rely on the Core catalog contract for canonical provider slugs while preserving ownership, secret, rollback, isolation, default, and fail-closed boundaries

## Verification
- `node --test packages/cli/dist/__tests__/onboarding.test.js` (23/23)
- `npm --workspace maka-agent run test:dist` (452/452)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`