### PR TITLE
test: prune story annotation script cases

### DIFF
--- a/scripts/check-story-annotations.test.mjs
+++ b/scripts/check-story-annotations.test.mjs
@@ -18,66 +18,13 @@ export const Annotated: Story = { render: () => null };
   assert.match(problems[0], /Annotated has no `\/\/ Real path:` comment/);
 });
 
-test('an annotation anywhere in the contiguous comment block above counts', () => {
-  assert.deepEqual(
-    problemsFor(`${PRODUCT_META}
-// Real path: sidebar → 扩展 → 技能, with skills installed.
-// The frame is imported rather than retyped.
-export const Annotated: Story = { render: () => null };
-`),
-    [],
-  );
-});
-
-test('a blank line between the comment and the export breaks the block', () => {
+test('an unsupported export shape fails instead of being skipped', () => {
   const problems = problemsFor(`${PRODUCT_META}
 // Real path: sidebar → 扩展 → 技能.
-
-export const Detached: Story = { render: () => null };
+export const Sneaky = { render: () => null };
 `);
   assert.equal(problems.length, 1);
-});
-
-// The three shapes that reach a browser as a real story but do not match
-// STORY_EXPORT. Each used to be waved through, which is the exact failure the
-// "fail on what you cannot parse" rule exists to prevent.
-for (const [shape, source] of [
-  ['a plain const', 'export const Sneaky = { render: () => null };'],
-  ['a re-export', 'const Sneaky: Story = {};\nexport { Sneaky };'],
-  ['an async function', 'export async function Sneaky() {}'],
-]) {
-  test(`${shape} export fails instead of being skipped`, () => {
-    const problems = problemsFor(`${PRODUCT_META}
-// Real path: sidebar → 扩展 → 技能.
-${source}
-`);
-    assert.equal(problems.length, 1);
-    assert.match(problems[0], /Sneaky is not `export const <Name>: Story = …`/);
-  });
-}
-
-// `export const X: Story =` wrapping onto the next line is the same story, and
-// a guard that reddens on formatting teaches people to ignore it.
-test('a story whose initializer wraps to the next line passes', () => {
-  assert.deepEqual(
-    problemsFor(`${PRODUCT_META}
-// Real path: sidebar → 扩展 → 技能.
-export const Wrapped: Story =
-  { render: () => null };
-`),
-    [],
-  );
-});
-
-// A fixture with its own `title` sits above meta as often as below it, and
-// `Design System/…` in one would exempt the whole file.
-test('a fixture title above meta does not decide the file namespace', () => {
-  const problems = problemsFor(`const fixture = { title: 'Design System/Fake' };
-${PRODUCT_META}
-export const Sneaky: Story = { render: () => null };
-`);
-  assert.equal(problems.length, 1);
-  assert.match(problems[0], /Sneaky has no `\/\/ Real path:` comment/);
+  assert.match(problems[0], /Sneaky is not `export const <Name>: Story = …`/);
 });
 
 test('an empty `// Real path:` is not an annotation', () => {
@@ -86,17 +33,6 @@ test('an empty `// Real path:` is not an annotation', () => {
 export const Bare: Story = { render: () => null };
 `);
   assert.equal(problems.length, 1);
-});
-
-test('Primitives/* and Design System/* are exempt', () => {
-  for (const title of ['Primitives/Toast', 'Design System/Icons']) {
-    assert.deepEqual(
-      problemsFor(`const meta = { title: '${title}' } satisfies Meta;
-export const Unannotated: Story = { render: () => null };
-`),
-      [],
-    );
-  }
 });
 
 test('a title in no known namespace is reported rather than silently skipped', () => {
@@ -120,10 +56,6 @@ function rootProblems(config) {
   checkStorybookRoots(config, problems);
   return problems;
 }
-
-test('the config this repo actually ships is accepted', () => {
-  assert.deepEqual(rootProblems(BOTH_ROOTS), []);
-});
 
 // Both story roots end in `stories`, so matching only the last path segment
 // stays satisfied by whichever root is left and passes in silence.


### PR DESCRIPTION
## Summary
- reduce the Storybook annotation script test from 15 to 7 cases
- remove formatting variants and current-config happy paths
- retain malformed annotation, unsupported export, invalid namespace, missing metadata, and bidirectional Storybook root boundaries

## Verification
- `npm run build:test`
- `npm run test:scripts` (20/20)
- `node scripts/check-story-annotations.mjs`
- `npm run lint`
- `npm run format:check`
- `git diff --check`