### PR TITLE
test: prune duplicate computer use script coverage

### DIFF
--- a/scripts/cu-provider-matrix.test.mjs
+++ b/scripts/cu-provider-matrix.test.mjs
@@ -169,22 +169,14 @@ test('real reports reject invalid identity, provenance, sequence, budget, and le
       scenario({ id: 'l0-observe-only' }),
       [/scenarioId mismatch/],
     ],
-    ['missing evidence class', { evidenceClass: undefined }, scenario(), [/real-runtime/]],
     ['hermetic evidence', { evidenceClass: 'hermetic-protocol' }, scenario(), [/real-runtime/]],
     ['inconclusive status', { status: 'inconclusive' }, scenario(), [/status must be pass/]],
     ['wrong provider', { provider: 'claude' }, scenario(), [/provider mismatch/]],
-    ['wrong model', { model: 'other' }, scenario(), [/model mismatch/]],
     [
       'bad terminal',
       { terminal: { type: 'complete', stopReason: 'max_tokens' } },
       scenario(),
       [/complete\/end_turn/],
-    ],
-    [
-      'unknown producer',
-      { producer: 'legacy-runner' },
-      scenario(),
-      [/producer missing or unknown/],
     ],
     [
       'missing policy provenance',
@@ -199,7 +191,6 @@ test('real reports reject invalid identity, provenance, sequence, budget, and le
       scenario(),
       [/qualificationEligible/],
     ],
-    ['deprecated report', { deprecated: true }, scenario(), [/deprecated reports cannot qualify/]],
     [
       'broken content lineage',
       { gitRevision: 'bad', contentLineage: undefined },
@@ -225,14 +216,7 @@ test('real reports reject invalid identity, provenance, sequence, budget, and le
   }
 });
 
-test('real readiness accepts one canonical report and rejects an unowned producer', async () => {
-  const matrix = await buildProviderMatrix({
-    scenarios: [scenario()],
-    providers: [provider],
-    loadReport: async () => realReport(),
-  });
-  assert.equal(matrix.rows[0].status, 'pass');
-
+test('real readiness rejects an unowned producer', async () => {
   await assert.rejects(
     buildProviderMatrix({
       scenarios: [scenario()],

--- a/scripts/cu-real-model-launcher.test.mjs
+++ b/scripts/cu-real-model-launcher.test.mjs
@@ -92,22 +92,6 @@ test('policy rejection remains canonical action-attempt evidence', () => {
       durationMs: 1,
       isError: true,
     },
-    {
-      type: 'tool_start',
-      toolName: 'maka_computer',
-      toolUseId: 'budget-1',
-      args: { action: 'observe', app: 'Fixture Target' },
-    },
-    {
-      type: 'tool_result',
-      toolUseId: 'budget-1',
-      content: {
-        kind: 'text',
-        text: 'maka_computer failed: total_action_budget_exceeded',
-      },
-      durationMs: 1,
-      isError: true,
-    },
   ]);
 
   assert.deepEqual(
@@ -118,17 +102,11 @@ test('policy rejection remains canonical action-attempt evidence', () => {
         success: false,
         resultCode: 'unsupported_action_policy',
       },
-      {
-        type: 'observe',
-        success: false,
-        resultCode: 'total_action_budget_exceeded',
-      },
     ],
   );
 });
 
 test('fixture READY identity and window discovery fail closed', async () => {
-  assert.equal(parseFixtureReady('CU_FIXTURE_READY 4242\n', 4242), 4242);
   assert.throws(
     () => parseFixtureReady('CU_FIXTURE_READY 99\n', 4242),
     /does not match launcher child pid/,

--- a/scripts/cu-report-sanitize.test.mjs
+++ b/scripts/cu-report-sanitize.test.mjs
@@ -66,16 +66,6 @@ test('canonical evidence keeps attribution and lineage without private fields', 
       gitRevision,
       generatedAt,
     },
-    evidenceClass: 'fault-injection',
-    scenarioId: 'appkit-ax-intervention-recovery',
-    producer: 'cu-real-ax-model-e2e',
-    transportClass: 'live-network',
-    policyMode: 'enforced',
-    qualificationEligible: false,
-    provider: 'openai',
-    model: 'gpt-5.4',
-    status: 'inconclusive',
-    run: { status: 'waiting_for_user' },
     failure: 'private provider body',
     loopStatus: { private: true },
     turns: [{ text: 'private' }],
@@ -87,7 +77,6 @@ test('canonical evidence keeps attribution and lineage without private fields', 
         { pid: 84, windowIds: [9] },
       ],
     },
-    faultInjection: { layer: 'runtime', kind: 'user_intervened' },
     actions: [
       {
         action: { type: 'set_value', value: 'private' },
@@ -100,7 +89,6 @@ test('canonical evidence keeps attribution and lineage without private fields', 
         success: true,
       },
     ],
-    actionAttempts: 1,
     traces: [
       {
         type: 'dispatch',
@@ -123,20 +111,10 @@ test('canonical evidence keeps attribution and lineage without private fields', 
     ],
   });
   assert.equal(report.runId, 'run-1');
-  assert.equal(report.gitRevision, gitRevision);
-  assert.equal(report.generatedAt, generatedAt);
   assert.deepEqual(report.contentLineage, {
     generator: 'scripts/cu-real-ax-model-e2e.mjs',
     gitRevision,
     generatedAt,
-  });
-  assert.equal(report.actionAttempts, 1);
-  assert.equal(report.provider, 'openai');
-  assert.equal(report.model, 'gpt-5.4');
-  assert.equal(report.run.status, 'waiting_for_user');
-  assert.deepEqual(report.faultInjection, {
-    layer: 'runtime',
-    kind: 'user_intervened',
   });
   assert.deepEqual(report.actions[0], {
     type: 'set_value',


### PR DESCRIPTION
## Summary
- remove duplicate invalid-field permutations from provider report validation
- drop canonical happy-path and repeated policy-error cases
- stop asserting ordinary sanitizer metadata while retaining privacy, ownership, lineage, dispatch, and recovery boundaries

## Verification
- `npm run build:test`
- `npm run test:scripts` (20/20)
- `npm run test:scripts:extended` (15/15)
- `npm run lint`
- `npm run format:check`
- `git diff --check`