### PR TITLE
fix(desktop): restore dev startup

### DIFF
--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -11,7 +11,9 @@
  *         └→ ui
  *
  *   libs (tsc --build tsconfig.lib.json) ─── covers core+storage+runtime+ui
- *   preload (esbuild)                     ─── parallel, no tsc dependency
+ *     ├─→ preload (esbuild)
+ *     └─→ filesystem worker (esbuild)
+ *   cursor overlay (esbuild)              ─── independent
  *   main (esbuild)                        ─── fast app bundle for Electron
  *   Vite dev server + Electron            ─── fork
  */
@@ -65,15 +67,19 @@ function resolveElectronBin() {
 const TIMER_START = Date.now();
 
 // Phase 1: all library packages via `tsc --build` (single process, shared
-// .tsbuildinfo, sub-project incremental detection).  Also runs preload
-// (esbuild is fast) in parallel since it has no tsc dependency.
-log('build', 'libraries — starting (tsc --build + preload)');
+// .tsbuildinfo, sub-project incremental detection). The preload bundle imports
+// workspace package dist files, so it starts only after that build is ready.
+log('build', 'libraries — starting (tsc --build)');
+const librariesBuild = runNodeTool(REPO_ROOT, TSC_CLI, ['--build', 'tsconfig.lib.json']).then(
+  () => log('build', 'libraries (all) — done'),
+  (e) => {
+    log('build', `libraries — FAILED: ${e.message}`);
+    throw e;
+  },
+);
 await Promise.all([
-  runNodeTool(REPO_ROOT, TSC_CLI, ['--build', 'tsconfig.lib.json']).then(
-    () => log('build', 'libraries (all) — done'),
-    (e) => { log('build', `libraries — FAILED: ${e.message}`); throw e; },
-  ),
-  runNodeTool(REPO_ROOT, RUNTIME_WORKER_BUILD, []).then(
+  librariesBuild,
+  librariesBuild.then(() => runNodeTool(REPO_ROOT, RUNTIME_WORKER_BUILD, [])).then(
     () => log('build', 'filesystem worker bundle — done'),
     (e) => { log('build', `filesystem worker bundle — FAILED: ${e.message}`); throw e; },
   ),
@@ -81,7 +87,7 @@ await Promise.all([
   // esbuild's postinstall swaps that file for a platform-native binary,
   // and executing a Mach-O file with node throws SyntaxError (broke
   // `npm run dev` on any machine where postinstall ran).
-  esbuildBuild({
+  librariesBuild.then(() => esbuildBuild({
     absWorkingDir: DESKTOP_DIR,
     entryPoints: ['src/preload/preload.ts'],
     bundle: true,
@@ -90,7 +96,7 @@ await Promise.all([
     outfile: 'dist/preload/preload.cjs',
     external: ['electron'],
     logLevel: 'warning',
-  }).then(
+  })).then(
     () => log('build', 'preload — done'),
     (e) => { log('build', `preload — FAILED: ${e.message}`); throw e; },
   ),

--- a/packages/core/src/runtime-boundary.ts
+++ b/packages/core/src/runtime-boundary.ts
@@ -1,4 +1,5 @@
-import { createHash, type Hash } from 'node:crypto';
+import * as nodeCrypto from 'node:crypto';
+import type { Hash } from 'node:crypto';
 import { decodeAgentRunHeader, type AgentRunHeader } from './agent-run.js';
 import { encodeCanonicalRuntimeEvent } from './canonical-runtime-event.js';
 import { isRecord } from './record-schema.js';
@@ -156,7 +157,7 @@ export function digestRuntimeBoundaryManifest(
     protocol: 'runtime_boundary_cursor_v1',
     segments: canonicalSegments,
   });
-  const hash = createHash('sha256');
+  const hash = nodeCrypto.createHash('sha256');
   updateLengthPrefixed(hash, Buffer.from('maka.runtime-boundary-manifest.v1', 'utf8'));
   updateLengthPrefixed(hash, Buffer.from(json, 'utf8'));
   return `sha256:${hash.digest('hex')}`;
@@ -333,7 +334,7 @@ function digestCanonicalRuntimePrefix(
   identity: RuntimePrefixIdentityV1,
   rows: readonly RuntimePrefixRowV1[],
 ): RuntimeBoundaryDigest {
-  const hash = createHash('sha256');
+  const hash = nodeCrypto.createHash('sha256');
   updateLengthPrefixed(hash, Buffer.from('maka.runtime-prefix.v1', 'utf8'));
   updateLengthPrefixed(hash, Buffer.from(stableJsonStringify(identity), 'utf8'));
   for (const row of rows) {


### PR DESCRIPTION
## Summary

- defer the preload and filesystem worker bundles until workspace library dist files exist
- avoid eagerly reading the Node-only `createHash` export when the core barrel loads in the renderer
- keep the cursor overlay build independent so startup remains fast

## Root cause

A renderer import of `@maka/core` evaluated a named `node:crypto` export before React mounted, leaving the static startup skeleton on screen. Fresh checkouts also had a build race where preload or the filesystem worker could resolve workspace packages before their dist entrypoints existed.

## Verification

- clean-room `npm run clean` followed by `npm run dev` with a fresh Electron profile
- DevTools protocol: document ready, React root mounted, `.maka-preload` removed, no renderer exception
- `npm run build:test`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/core run test:dist`
- `npm --workspace @maka/desktop run test:dist`
- `npm --workspace @maka/desktop run build:renderer`