### PR TITLE
fix(runtime): eliminate lifecycle test races

### DIFF
--- a/packages/runtime/src/__tests__/agent-run-steering-recovery.test.ts
+++ b/packages/runtime/src/__tests__/agent-run-steering-recovery.test.ts
@@ -188,14 +188,23 @@ test('awaits canonical Run status persistence before accepting an interaction re
     });
     const updateStarted = deferred<void>();
     const allowUpdate = deferred<void>();
+    const auditStarted = deferred<void>();
+    const allowAudit = deferred<void>();
     const delayedRunStore = {
       updateRun: async (...args: Parameters<typeof runStore.updateRun>) => {
         updateStarted.resolve();
         await allowUpdate.promise;
         return await runStore.updateRun(...args);
       },
-      appendEvent: runStore.appendEvent.bind(runStore),
+      appendEvent: async (...args: Parameters<typeof runStore.appendEvent>) => {
+        if (args[2].type === 'run_status_changed') {
+          auditStarted.resolve();
+          await allowAudit.promise;
+        }
+        return await runStore.appendEvent(...args);
+      },
     } as typeof runStore;
+    let sessionUpdateStarted = false;
     const run = new AgentRun({
       sessionId: session.id,
       header: session,
@@ -215,6 +224,7 @@ test('awaits canonical Run status persistence before accepting an interaction re
         unregisterRun: () => {},
         updateHeader: (sessionId, patch) => store.updateHeader(sessionId, patch),
         updateStatus: async (sessionId, status, blockedReason, ts = 0) => {
+          sessionUpdateStarted = true;
           await store.updateHeader(sessionId, buildStatusPatch(status, ts, blockedReason));
         },
         appendTurnState: async () => {},
@@ -234,13 +244,26 @@ test('awaits canonical Run status persistence before accepting an interaction re
         accepted = true;
       });
 
-    await updateStarted.promise;
-    assert.equal(accepted, false);
-    assert.equal((await store.readHeader(session.id)).status, 'waiting_for_user');
-    allowUpdate.resolve();
-    await accepting;
-    assert.equal((await runStore.readRun(session.id, runId))?.status, 'running');
-    assert.equal((await store.readHeader(session.id)).status, 'running');
+    try {
+      await updateStarted.promise;
+      assert.equal(accepted, false);
+      assert.equal((await store.readHeader(session.id)).status, 'waiting_for_user');
+      allowUpdate.resolve();
+      await auditStarted.promise;
+      await Promise.resolve();
+      assert.equal(accepted, false);
+      assert.equal(sessionUpdateStarted, false);
+      assert.equal((await store.readHeader(session.id)).status, 'waiting_for_user');
+      allowAudit.resolve();
+      await accepting;
+      assert.equal(sessionUpdateStarted, true);
+      assert.equal((await runStore.readRun(session.id, runId))?.status, 'running');
+      assert.equal((await store.readHeader(session.id)).status, 'running');
+    } finally {
+      allowUpdate.resolve();
+      allowAudit.resolve();
+      await accepting.catch(() => undefined);
+    }
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -476,23 +476,41 @@ describe('ShellRunProcessManager', () => {
     );
   });
 
-  test('latches timeout while POSIX process discovery is pending', {
+  test('latches timeout when the root exits during POSIX process discovery', {
     skip: process.platform === 'win32' ? 'POSIX process discovery only' : false,
   }, async (context) => {
     const processDiscovery = delayPosixProcessDiscovery(context);
-
+    const cwd = await workspace();
+    const rootPidPath = join(cwd, 'root.pid');
+    const rootScript = `
+      const { writeFileSync } = require('node:fs');
+      writeFileSync(${JSON.stringify(rootPidPath)}, String(process.pid));
+      process.once('SIGUSR1', () => process.exit(0));
+      setInterval(() => {}, 1000);
+    `;
     const manager = await createTestManager();
     try {
       const initial = await manager.runBackgroundBash(
         shellInput({
-          cwd: await workspace(),
-          command: nodeCommand('setTimeout(() => process.exit(0), 80);'),
+          cwd,
+          command: 'exit when the test releases the root process',
+          argv: [process.execPath, '-e', rootScript],
           timeoutMs: 50,
         }),
       );
       assert.equal(initial.kind, 'shell_run');
+      await waitUntil(async () => {
+        try {
+          return Number.isSafeInteger(Number.parseInt(await readFile(rootPidPath, 'utf8'), 10));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+          throw error;
+        }
+      });
       await processDiscovery.started;
-      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+      const rootPid = Number.parseInt(await readFile(rootPidPath, 'utf8'), 10);
+      assert.ok(Number.isSafeInteger(rootPid) && rootPid > 0);
+      process.kill(rootPid, 'SIGUSR1');
       processDiscovery.release();
 
       const result = await waitForTerminalShellRun(manager, initial.ref);

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -1181,7 +1181,9 @@ export class AgentRun {
           { durable: true },
         );
       });
-      this.enqueueRunStore('append run status audit', appendAudit);
+      // The audit remains best-effort, but its physical write belongs to this
+      // required transition and must settle before the resume acknowledgement.
+      await this.enqueueRunStore('append run status audit', appendAudit);
     } else {
       this.enqueueRunStore('record run status', async () => {
         await runStore.updateRun(this.sessionId, this.runId, { status, updatedAt: ts });


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Wait for the best-effort Run status audit write to settle before acknowledging a durability-required interaction resume.
- Replace the ShellRun timeout test's wall-clock race with explicit process lifecycle checkpoints.
- Add deterministic regression coverage for both lifecycle boundaries.

## Root cause

A required Run status transition waited for the durable Run header update but left its queued audit append running in the background. Test teardown could then race that physical write and remove the session root while it was being recreated.

Separately, the ShellRun regression expected a 50 ms timeout to beat an 80 ms child exit. Under workspace-level parallel load, the child could exit first, so the test waited forever for process discovery that never started.

## Impact

Required interaction resume acknowledgement now covers the complete physical persistence lifecycle while audit failures remain best-effort. The ShellRun test preserves the original timeout-latching scenario without depending on scheduler timing.

## Validation

- Both targeted regressions passed 50 consecutive runs each.
- The Runtime suite passed 3 consecutive runs: 2645 passed, 9 skipped, 0 failed per run.
- The complete workspace test suite passed with 0 failures and no residual worker.
- `npm run build:test`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

</details>

<details>
<summary>中文</summary>

## 摘要

- 在确认 durability-required 的交互恢复前，等待 best-effort Run 状态审计写入完成。
- 使用显式进程生命周期检查点替代 ShellRun timeout 测试中的墙钟竞态。
- 为两个生命周期边界补充确定性的回归覆盖。

## 根因

required Run 状态转换会等待 durable Run header 更新，但其后排队的 audit append 仍在后台运行。测试开始 teardown 后，这个物理写入可能在 session 根目录被删除时重新创建目录，从而触发清理竞态。

另外，ShellRun 回归测试假设 50 ms timeout 一定早于子进程的 80 ms 自动退出。在 workspace 并行负载下，子进程可能先退出，导致测试永久等待一个根本不会开始的 process discovery。

## 影响

required 交互恢复的确认现在覆盖完整的物理持久化生命周期，同时 audit 失败仍保持 best-effort 语义。ShellRun 测试继续覆盖原有的 timeout 锁存场景，但不再依赖调度时序。

## 验证

- 两条定向回归分别连续运行 50 次并全部通过。
- Runtime 全套连续运行 3 次，每次 2645 passed、9 skipped、0 failed。
- workspace 完整测试全部通过，0 failures 且无残留 worker。
- `npm run build:test`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

</details>
