### PR TITLE
fix(runtime): add gateway to InvocationSource

### DIFF
--- a/packages/runtime/src/invocation-context.ts
+++ b/packages/runtime/src/invocation-context.ts
@@ -25,11 +25,11 @@ import type { EphemeralVoiceAudio } from '@maka/core/voice';
 // ============================================================================
 
 /**
- * Where the invocation entered the runtime. Desktop, bot, and gateway should
- * eventually share the same runner; `test` covers in-process fake-service
- * invocations like the ones in this node's test suite.
+ * Where the invocation entered the runtime. Desktop, bot, and gateway share
+ * the same runner; `test` covers in-process fake-service invocations like the
+ * ones in this package's test suite.
  */
-export const INVOCATION_SOURCES = ['desktop', 'bot', 'test'] as const;
+export const INVOCATION_SOURCES = ['desktop', 'bot', 'gateway', 'test'] as const;
 export type InvocationSource = (typeof INVOCATION_SOURCES)[number];
 
 export function isInvocationSource(value: unknown): value is InvocationSource {


### PR DESCRIPTION
## Summary

#1587 sets `runtimeSource: 'gateway'` for one-shot Cloud Session activation, but `INVOCATION_SOURCES` only allowed `desktop | bot | test`. After the merge, `packages/cli` failed typecheck/build on main (`TS2322`).

Add `gateway` to the union so activation can label invocations correctly. Refs #1587.

## Verification

- `npm --workspace @maka/runtime run build` — pass
- dependency chain through `npm --workspace maka-agent run build` (the packages that failed on main CI) — pass
- `npm run format:check` — pass
- `npm run lint` — pass
- Did not re-run full workspace unit/e2e suite; failure was compile-time only