### PR TITLE
refactor(ui): drop the user-bubble overrides that fork Astryx defaults

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -28,10 +28,12 @@
   line-height: 1.6154em;
 }
 
+/* Geometry (radius, padding, max-width) belongs to ChatMessageBubble: under
+   `density="compact"` it resolves --radius-container plus the compact padding
+   step, so re-declaring them here only forked the primitive. What stays is the
+   product tint and the verbatim-text rule — Maka renders user input as typed,
+   which the primitive has no opinion about. */
 .maka-chat-message-bubble-user {
-  max-width: min(100%, 640px);
-  padding: var(--space-2-5) var(--space-3);
-  border-radius: var(--radius-surface);
   background: var(--chat-user-bg);
   color: var(--chat-user-foreground, var(--foreground));
   white-space: pre-wrap;
@@ -127,7 +129,8 @@
 }
 
 /* --- Assistant bubble shell ----------------------------------------------- */
-/* User message: a tinted, width-capped Astryx bubble anchored to the right. */
+/* User message: a tinted Astryx bubble anchored to the right, sized by the
+   primitive's own compact-density geometry. */
 /* Assistant: no bubble — just text on background, like an editor. The
    Markdown typography and block rhythm belong to Astryx, so the shell keeps
    only container geometry.


### PR DESCRIPTION
## Summary

The user bubble redeclared `border-radius`, `padding` and `max-width` on top of `ChatMessageBubble`, so the primitive's compact-density geometry never applied and the bubble read squarer and tighter than the surface it sits on. Geometry belongs to the primitive; this drops the three overrides.

`--chat-user-bg` and the text colour stay — the brand tint is deliberate and must not fall back to Astryx's `--color-neutral`. `white-space: pre-wrap` stays too: Maka renders user input verbatim, which the primitive has no opinion about.

Refs #1861 (slice 1 of 4).

## Verification

Computed styles on the first user bubble, read from the running app (Playwright + the E2E fake backend, 1280px):

| | before | after |
|---|---|---|
| `border-radius` | 8px | 9.75px |
| `padding` | 10px / 12px | 12px / 16px |
| `max-width` | `min(100%, 640px)` | `max(80%, 280px)` |
| rendered width | 640px | 526px |

Bubble width stays flat from 1280px up (544px on the `NativeConversation` story at 1280 / 1680 / 1920 / 2560), because the reading column caps at 680px well before the percentage does — dropping the 640px cap does not let the bubble grow without bound on a wide window.

- `npm run lint`, `npm run format:check` — clean
- `apps/desktop` E2E `send-message`, `scroll-geometry`, `attachment` — 8 passed, two consecutive runs. One earlier run had `scroll-geometry.spec.ts:104` fail; it passes in isolation and in both repeat runs, and it asserts composer docking rather than bubble geometry, so it is pre-existing flake, not a regression from this change.
- Not run: full E2E suite, typecheck (no TS touched).

## Review focus

`--radius-container` is `0.75rem` against a 13px root, so the radius lands at 9.75px rather than the 12px an `1rem = 16px` reading would predict. The visible change is therefore mostly padding and width, not corner shape. If we want the template's rounder corner, that is a token decision (`--radius-container`, or opting the bubble into `--radius-chat`), not a per-component override — happy to follow up separately.
