### PR TITLE
fix: stop one undefined field killing every turn that calls a tool

### DIFF
--- a/packages/core/src/__tests__/tool-args-identity.test.ts
+++ b/packages/core/src/__tests__/tool-args-identity.test.ts
@@ -1,0 +1,33 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { stableJsonStringify, stripUndefinedDeep } from '../tool-args-identity.js';
+
+describe('stripUndefinedDeep', () => {
+  it('removes a property the provider left undefined, so the value round-trips', () => {
+    // Anthropic's `caller` arrives as `{ type: 'direct', toolId: undefined }`
+    // when the response carries no tool id. JSON drops that property, so the
+    // value no longer reads back as it was written and the canonical encoder
+    // refuses the event — which took every tool-calling turn with it.
+    const providerOptions = { anthropic: { caller: { type: 'direct', toolId: undefined } } };
+
+    const cleaned = stripUndefinedDeep(providerOptions);
+
+    assert.deepEqual(cleaned, { anthropic: { caller: { type: 'direct' } } });
+    assert.deepEqual(JSON.parse(stableJsonStringify(cleaned)), cleaned);
+  });
+
+  it('leaves everything else exactly as it was', () => {
+    const value = { a: 0, b: '', c: false, d: null, e: [1, undefined, 3], f: { g: undefined } };
+
+    assert.deepEqual(stripUndefinedDeep(value), {
+      a: 0,
+      b: '',
+      c: false,
+      d: null,
+      // An array hole is a position, not a property: dropping it would shift
+      // the rest, so the entry survives as-is.
+      e: [1, undefined, 3],
+      f: {},
+    });
+  });
+});

--- a/packages/core/src/__tests__/tool-args-identity.test.ts
+++ b/packages/core/src/__tests__/tool-args-identity.test.ts
@@ -31,8 +31,8 @@ describe('stripUndefinedDeep', () => {
     assert.ok(roundTrips(cleaned));
   });
 
-  it('writes an array hole as the null JSON would have written', () => {
-    // A hole is a position, not a property, so it cannot be dropped without
+  it('writes an undefined array entry as the null JSON would have written', () => {
+    // An entry is a position, not a property, so it cannot be dropped without
     // shifting everything after it. Leaving `undefined` there does not help:
     // JSON writes it as `null` either way, so the value still fails to read
     // back as written and the encoder still refuses it.
@@ -47,6 +47,45 @@ describe('stripUndefinedDeep', () => {
     assert.deepEqual(cleaned, { items: [1, null, 3] });
     assert.ok(roundTrips(cleaned), 'the whole point is that the result round-trips');
     assert.ok(!roundTrips(value), 'and that the input did not');
+  });
+
+  it('writes an array hole as null too, and not only an explicit undefined', () => {
+    // A hole reads as `undefined` but is not one: `map` and `some` both skip
+    // it, so a version of this written with `map` returns the sparse array
+    // untouched and the encoder refuses it exactly as before. The two cases
+    // look identical from the outside and have to be handled separately.
+    const items: unknown[] = [1, 2, 3];
+    Reflect.deleteProperty(items, 1);
+    const value = { items };
+
+    const cleaned = stripUndefinedDeep(value);
+
+    assert.ok(!Object.hasOwn(items, 1), 'the input is a hole, not an explicit undefined');
+    assert.deepEqual(cleaned, { items: [1, null, 3] });
+    assert.ok(Object.hasOwn(cleaned.items, 1), 'the hole was filled, not carried through');
+    assert.ok(roundTrips(cleaned), 'the whole point is that the result round-trips');
+    assert.ok(!roundTrips(value), 'and that the input did not');
+  });
+
+  it('descends into a null-prototype object, which the encoder accepts', () => {
+    // Prototype-pollution-safe JSON parsing hands back objects made with
+    // `Object.create(null)`. `canonicalizeStrictJson` accepts that prototype
+    // and then throws on the nested `undefined`, so skipping these objects
+    // leaves the original failure in place for exactly the callers that were
+    // careful about how they parsed.
+    const caller = Object.assign(Object.create(null), { type: 'direct', toolId: undefined });
+    const value = Object.assign(Object.create(null), { anthropic: { caller } });
+
+    const cleaned = stripUndefinedDeep(value);
+
+    assert.ok(!roundTrips(value), 'the input is the shape the encoder refuses');
+    assert.ok(roundTrips(cleaned));
+    assert.deepEqual({ ...cleaned.anthropic.caller }, { type: 'direct' });
+    assert.equal(
+      Object.getPrototypeOf(cleaned.anthropic.caller),
+      null,
+      'a null prototype is what keeps a __proto__ key as data, so it is put back',
+    );
   });
 
   it('reaches an undefined nested inside an array', () => {

--- a/packages/core/src/__tests__/tool-args-identity.test.ts
+++ b/packages/core/src/__tests__/tool-args-identity.test.ts
@@ -2,6 +2,21 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { stableJsonStringify, stripUndefinedDeep } from '../tool-args-identity.js';
 
+/**
+ * What the canonical encoder demands: the value reads back as it was written.
+ *
+ * Refusing outright counts as not round-tripping — that is the encoder's own
+ * behaviour, and it is the failure this function exists to prevent.
+ */
+function roundTrips(value: unknown): boolean {
+  try {
+    const written = stableJsonStringify(value);
+    return stableJsonStringify(JSON.parse(written)) === written;
+  } catch {
+    return false;
+  }
+}
+
 describe('stripUndefinedDeep', () => {
   it('removes a property the provider left undefined, so the value round-trips', () => {
     // Anthropic's `caller` arrives as `{ type: 'direct', toolId: undefined }`
@@ -13,21 +28,73 @@ describe('stripUndefinedDeep', () => {
     const cleaned = stripUndefinedDeep(providerOptions);
 
     assert.deepEqual(cleaned, { anthropic: { caller: { type: 'direct' } } });
-    assert.deepEqual(JSON.parse(stableJsonStringify(cleaned)), cleaned);
+    assert.ok(roundTrips(cleaned));
+  });
+
+  it('writes an array hole as the null JSON would have written', () => {
+    // A hole is a position, not a property, so it cannot be dropped without
+    // shifting everything after it. Leaving `undefined` there does not help:
+    // JSON writes it as `null` either way, so the value still fails to read
+    // back as written and the encoder still refuses it.
+    //
+    // This case was pinned the wrong way round when the function was written —
+    // the test asserted `[1, undefined, 3]` came back unchanged, which is a
+    // value that cannot round-trip. The assertion was protecting the bug.
+    const value = { items: [1, undefined, 3] };
+
+    const cleaned = stripUndefinedDeep(value);
+
+    assert.deepEqual(cleaned, { items: [1, null, 3] });
+    assert.ok(roundTrips(cleaned), 'the whole point is that the result round-trips');
+    assert.ok(!roundTrips(value), 'and that the input did not');
+  });
+
+  it('reaches an undefined nested inside an array', () => {
+    const value = { calls: [{ id: 'a', toolId: undefined }] };
+
+    assert.deepEqual(stripUndefinedDeep(value), { calls: [{ id: 'a' }] });
   });
 
   it('leaves everything else exactly as it was', () => {
-    const value = { a: 0, b: '', c: false, d: null, e: [1, undefined, 3], f: { g: undefined } };
+    const value = { a: 0, b: '', c: false, d: null, e: [1, 2], f: { g: 1 } };
 
-    assert.deepEqual(stripUndefinedDeep(value), {
-      a: 0,
-      b: '',
-      c: false,
-      d: null,
-      // An array hole is a position, not a property: dropping it would shift
-      // the rest, so the entry survives as-is.
-      e: [1, undefined, 3],
-      f: {},
-    });
+    assert.deepEqual(stripUndefinedDeep(value), value);
+  });
+
+  it('returns the value itself when nothing needed removing', () => {
+    // Rebuilding a value that needed nothing would drop symbol keys and re-run
+    // getters for no gain, and by far the common case is that nothing needs
+    // removing. Identity is the observable form of "did not rebuild".
+    const nested = { b: 1 };
+    const value = { a: nested, list: [1, 2] };
+
+    const cleaned = stripUndefinedDeep(value);
+
+    assert.equal(cleaned, value);
+    assert.equal(cleaned.a, nested);
+  });
+
+  it('keeps a symbol key on a value it did have to rebuild', () => {
+    // JSON never sees a symbol key, so dropping one changes nothing about what
+    // is persisted — but it changes the object a caller still holds.
+    const tag = Symbol('tag');
+    const value = { keep: 1, drop: undefined, [tag]: 'kept' } as Record<string | symbol, unknown>;
+
+    const cleaned = stripUndefinedDeep(value);
+
+    assert.deepEqual({ ...cleaned }, { keep: 1, [tag]: 'kept' });
+    assert.equal(cleaned[tag], 'kept');
+    assert.ok(!('drop' in cleaned));
+  });
+
+  it('does not descend into a class instance', () => {
+    // Only plain objects are rebuilt. Anything with its own prototype is
+    // returned untouched rather than flattened into a plain object.
+    class Holder {
+      constructor(readonly value: number) {}
+    }
+    const holder = new Holder(1);
+
+    assert.equal(stripUndefinedDeep({ holder }).holder, holder);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -293,7 +293,11 @@ export {
   interpretScannedToolRecovery,
   validateToolRecoveryEventBundle,
 } from './tool-recovery-bundle.js';
-export { canonicalToolArgsHash, stableJsonStringify } from './tool-args-identity.js';
+export {
+  canonicalToolArgsHash,
+  stableJsonStringify,
+  stripUndefinedDeep,
+} from './tool-args-identity.js';
 export {
   encodeCanonicalRuntimeEvent,
   type CanonicalRuntimeEventEncoding,

--- a/packages/core/src/tool-args-identity.ts
+++ b/packages/core/src/tool-args-identity.ts
@@ -155,24 +155,43 @@ function canonicalizeMainlineV1(value: unknown, parentKey?: string): unknown {
  * What it does not do: it never rebuilds a value that needed no change, so
  * symbol keys, getters and object identity survive untouched on that path; a
  * value it does rebuild is a plain-object spread, which keeps symbol keys and
- * loses nothing JSON could have seen. Anything with its own prototype is
- * returned as-is rather than flattened.
+ * loses nothing JSON could have seen. It descends into exactly the two shapes
+ * the encoder accepts — a plain object and a null-prototype one, the shape
+ * prototype-safe JSON parsing produces — and a null prototype is put back on
+ * the rebuilt value, because that prototype is what keeps a `__proto__`
+ * property as data. Anything with any other prototype is returned as-is
+ * rather than flattened.
  */
 export function stripUndefinedDeep<T>(value: T): T {
   if (Array.isArray(value)) {
     // An array hole is not a property that can be dropped: JSON writes it as
-    // `null`, so leaving `undefined` in place produces a value that does not
+    // `null`, so leaving the position empty produces a value that does not
     // round-trip and the encoder refuses it just the same. Writing `null` is
     // not inventing a value — it is writing down what would be persisted.
-    const mapped = value.map((entry) => (entry === undefined ? null : stripUndefinedDeep(entry)));
-    return (mapped.some((entry, index) => entry !== value[index]) ? mapped : value) as unknown as T;
+    // `map` would not do: it skips holes and leaves them exactly as they were.
+    let changedEntry = false;
+    const mapped = Array.from({ length: value.length }, (_unused, index) => {
+      if (!Object.hasOwn(value, index) || value[index] === undefined) {
+        changedEntry = true;
+        return null;
+      }
+      const entry = value[index];
+      const next = stripUndefinedDeep(entry);
+      if (next !== entry) changedEntry = true;
+      return next;
+    });
+    return (changedEntry ? mapped : value) as unknown as T;
   }
   if (value === null || typeof value !== 'object') return value;
-  if (Object.getPrototypeOf(value) !== Object.prototype) return value;
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return value;
   const record = value as Record<string, unknown>;
   const keys = Object.keys(record);
   let changed = false;
+  // Spread rather than assignment, and the prototype restored afterwards: both
+  // keep a `__proto__` property as the data the encoder will read back.
   const out: Record<string, unknown> = { ...record };
+  if (prototype === null) Object.setPrototypeOf(out, null);
   for (const key of keys) {
     const entry = record[key];
     if (entry === undefined) {

--- a/packages/core/src/tool-args-identity.ts
+++ b/packages/core/src/tool-args-identity.ts
@@ -130,3 +130,34 @@ function canonicalizeMainlineV1(value: unknown, parentKey?: string): unknown {
   }
   return result;
 }
+
+/**
+ * The same value with every `undefined`-valued property removed.
+ *
+ * Provider metadata is handed to Maka as the SDK parsed it, and a field the
+ * response did not carry arrives as an explicit `undefined` — Anthropic's
+ * `caller` object comes through as `{ type: 'direct', toolId: undefined }` when
+ * there is no tool id. JSON drops such a property, so the value no longer
+ * round-trips, and `encodeCanonicalRuntimeEvent` refuses it. That refusal is
+ * correct: an immutable event must mean the same thing after it is read back.
+ *
+ * The cost of not doing this was total. The refused write marked the runtime
+ * event store unavailable, the turn's terminal write then threw, and every turn
+ * that called any tool died a tenth of a second after the tool returned —
+ * `load_tools` succeeded, reported the group loaded, and the turn ended there.
+ *
+ * Dropping the key is lossless in the only sense that matters: JSON cannot tell
+ * an absent property from one set to `undefined`, so this writes down what
+ * would have been persisted anyway.
+ */
+export function stripUndefinedDeep<T>(value: T): T {
+  if (Array.isArray(value)) return value.map((entry) => stripUndefinedDeep(entry)) as unknown as T;
+  if (value === null || typeof value !== 'object') return value;
+  if (Object.getPrototypeOf(value) !== Object.prototype) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (entry === undefined) continue;
+    out[key] = stripUndefinedDeep(entry);
+  }
+  return out as unknown as T;
+}

--- a/packages/core/src/tool-args-identity.ts
+++ b/packages/core/src/tool-args-identity.ts
@@ -153,14 +153,22 @@ function canonicalizeMainlineV1(value: unknown, parentKey?: string): unknown {
  * the entry would shift everything after it.
  *
  * What it does not do: it never rebuilds a value that needed no change, so
- * symbol keys, getters and object identity survive untouched on that path; a
- * value it does rebuild is a plain-object spread, which keeps symbol keys and
- * loses nothing JSON could have seen. It descends into exactly the two shapes
- * the encoder accepts — a plain object and a null-prototype one, the shape
- * prototype-safe JSON parsing produces — and a null prototype is put back on
- * the rebuilt value, because that prototype is what keeps a `__proto__`
- * property as data. Anything with any other prototype is returned as-is
- * rather than flattened.
+ * symbol keys and object identity survive untouched on that path; a value it
+ * does rebuild is a plain-object spread, which keeps symbol keys and loses
+ * nothing JSON could have seen. An accessor survives that path too, and that
+ * is not a benefit to lean on: `canonicalizeStrictJson` throws on any getter it
+ * reaches, so at the call site a surviving getter kills the same write a
+ * surviving `undefined` would have. Nothing produces one today — provider
+ * metadata arrives as parsed plain objects — and widening this function to
+ * rebuild accessors would change what it means for callers that hand it
+ * anything else. Read this line as "getters are out of scope, and out of
+ * scope is fatal downstream", not as a shape this makes safe to pass.
+ *
+ * It descends into exactly the two shapes the encoder accepts — a plain object
+ * and a null-prototype one, the shape prototype-safe JSON parsing produces —
+ * and a null prototype is put back on the rebuilt value, because that prototype
+ * is what keeps a `__proto__` property as data. Anything with any other
+ * prototype is returned as-is rather than flattened.
  */
 export function stripUndefinedDeep<T>(value: T): T {
   if (Array.isArray(value)) {
@@ -205,8 +213,9 @@ export function stripUndefinedDeep<T>(value: T): T {
       changed = true;
     }
   }
-  // Unchanged values are returned as they came. Rebuilding one that needed
-  // nothing would drop symbol keys and re-run getters for no gain, and the
-  // common case by far is that nothing needs removing.
+  // Unchanged values are returned as they came, so the common case — nothing
+  // needed removing — keeps object identity. The spread above has already read
+  // any accessor once; returning the original leaves the accessor itself live,
+  // which the encoder refuses exactly as it refuses a surviving `undefined`.
   return (changed ? out : value) as unknown as T;
 }

--- a/packages/core/src/tool-args-identity.ts
+++ b/packages/core/src/tool-args-identity.ts
@@ -148,16 +148,46 @@ function canonicalizeMainlineV1(value: unknown, parentKey?: string): unknown {
  *
  * Dropping the key is lossless in the only sense that matters: JSON cannot tell
  * an absent property from one set to `undefined`, so this writes down what
- * would have been persisted anyway.
+ * would have been persisted anyway. The same reasoning gives an array hole a
+ * `null` rather than a removal — JSON writes one there regardless, and removing
+ * the entry would shift everything after it.
+ *
+ * What it does not do: it never rebuilds a value that needed no change, so
+ * symbol keys, getters and object identity survive untouched on that path; a
+ * value it does rebuild is a plain-object spread, which keeps symbol keys and
+ * loses nothing JSON could have seen. Anything with its own prototype is
+ * returned as-is rather than flattened.
  */
 export function stripUndefinedDeep<T>(value: T): T {
-  if (Array.isArray(value)) return value.map((entry) => stripUndefinedDeep(entry)) as unknown as T;
+  if (Array.isArray(value)) {
+    // An array hole is not a property that can be dropped: JSON writes it as
+    // `null`, so leaving `undefined` in place produces a value that does not
+    // round-trip and the encoder refuses it just the same. Writing `null` is
+    // not inventing a value — it is writing down what would be persisted.
+    const mapped = value.map((entry) => (entry === undefined ? null : stripUndefinedDeep(entry)));
+    return (mapped.some((entry, index) => entry !== value[index]) ? mapped : value) as unknown as T;
+  }
   if (value === null || typeof value !== 'object') return value;
   if (Object.getPrototypeOf(value) !== Object.prototype) return value;
-  const out: Record<string, unknown> = {};
-  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-    if (entry === undefined) continue;
-    out[key] = stripUndefinedDeep(entry);
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  let changed = false;
+  const out: Record<string, unknown> = { ...record };
+  for (const key of keys) {
+    const entry = record[key];
+    if (entry === undefined) {
+      delete out[key];
+      changed = true;
+      continue;
+    }
+    const next = stripUndefinedDeep(entry);
+    if (next !== entry) {
+      out[key] = next;
+      changed = true;
+    }
   }
-  return out as unknown as T;
+  // Unchanged values are returned as they came. Rebuilding one that needed
+  // nothing would drop symbol keys and re-run getters for no gain, and the
+  // common case by far is that nothing needs removing.
+  return (changed ? out : value) as unknown as T;
 }

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -13,6 +13,7 @@ import type {
   SessionHeader,
   StorageRef,
 } from '@maka/core';
+import { encodeCanonicalRuntimeEvent } from '@maka/core';
 import type { SessionEvent } from '@maka/core/events';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import { createSessionEventMapMemory, mapSessionEventToRuntimeEvent } from '../ai-sdk-flow.js';
@@ -12758,6 +12759,126 @@ describe('AiSdkBackend steering durability and identity', () => {
       { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
       { role: 'user', content: [{ type: 'text', text: 'continue' }] },
     ]);
+  });
+
+  test('persists provider metadata a canonical event can read back', async () => {
+    // The failure this pins is not in the sanitiser, it is at this seam.
+    //
+    // A field the response did not carry arrives as an explicit `undefined` —
+    // Anthropic sends `{ type: 'direct', toolId: undefined }` when there is no
+    // tool id. JSON drops such a property, so the persisted event no longer
+    // reads back as it was written and `encodeCanonicalRuntimeEvent` refuses
+    // it. That refusal marked the runtime event store unavailable and the
+    // turn's terminal write then threw, so every turn that called any tool
+    // died about a tenth of a second after the tool returned.
+    //
+    // Asserting on the sanitiser alone cannot catch a regression here: the
+    // sanitiser is a pure function and could not have produced the bug. This
+    // streams the shape a real provider sends and encodes what was persisted.
+    const anchor = runtimeTextEvent({
+      id: 'runtime-user',
+      turnId: 'turn-1',
+      role: 'user',
+      author: 'user',
+      text: 'call the tool',
+    });
+    const ledger: RuntimeEvent[] = [anchor];
+    const mappingMemory = createSessionEventMapMemory();
+    const mappingContext: InvocationContext = {
+      sessionId: 'session-1',
+      invocationId: 'invocation-1',
+      runId: 'run-1',
+      turnId: 'turn-1',
+      source: 'desktop',
+      startedAt: 1,
+      request: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        text: 'call the tool',
+        source: 'desktop',
+        initialRuntimeEvent: anchor,
+      },
+      newId: idGenerator(),
+      now: monotonicClock(),
+    };
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        calls += 1;
+        const chunks: LanguageModelV4StreamPart[] =
+          calls === 1
+            ? [
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'Read',
+                  input: JSON.stringify({ path: 'ok.md' }),
+                  providerMetadata: {
+                    anthropic: { caller: { type: 'direct', toolId: undefined } },
+                  },
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                  usage: emptyUsage(),
+                },
+              ]
+            : [
+                { type: 'stream-start', warnings: [] },
+                { type: 'text-start', id: 'text-1' },
+                { type: 'text-delta', id: 'text-1', delta: 'Done.' },
+                { type: 'text-end', id: 'text-1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'end_turn' },
+                  usage: emptyUsage(),
+                },
+              ];
+        return {
+          stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [
+        {
+          name: 'Read',
+          description: 'read',
+          parameters: z.object({ path: z.string() }),
+          impl: async () => ({ body: 'ok' }),
+        },
+      ],
+      loadTurnRuntimeEvents: async () => ledger,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    for await (const event of backend.send({
+      turnId: 'turn-1',
+      text: 'call the tool',
+      context: [],
+      headAnchorRuntimeEvent: anchor,
+    })) {
+      const mapped = mapSessionEventToRuntimeEvent(event, mappingContext, mappingMemory);
+      if (mapped.partial !== true && mapped.content?.kind !== 'error') ledger.push(mapped);
+    }
+
+    // Every persisted event has to survive the encoder, because one that does
+    // not takes the store — and the turn — with it.
+    for (const event of ledger) {
+      assert.doesNotThrow(
+        () => encodeCanonicalRuntimeEvent(event),
+        `a persisted ${event.content?.kind} event must read back as it was written`,
+      );
+    }
   });
 });
 

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -12880,6 +12880,111 @@ describe('AiSdkBackend steering durability and identity', () => {
       );
     }
   });
+
+  test('rebuilds reasoning metadata rather than persisting what the provider sent', async () => {
+    // The tool-call seam above carries `providerOptions` from the stream into
+    // the persisted event, so an omitted provider field arrives as an explicit
+    // `undefined` and the canonical encoder refuses the write. Reasoning looks
+    // like the same seam and is not: `translateChunk` rebuilds the reasoning
+    // metadata from two named string fields, so nothing the provider sends
+    // reaches the event verbatim and no `undefined` can ride along.
+    //
+    // This pins that, because it is the only reason the reasoning path needs
+    // no sanitiser. If reasoning metadata is ever passed through instead, this
+    // test fails and says so.
+    const anchor = runtimeTextEvent({
+      id: 'runtime-user',
+      turnId: 'turn-1',
+      role: 'user',
+      author: 'user',
+      text: 'think about it',
+    });
+    const ledger: RuntimeEvent[] = [anchor];
+    const mappingMemory = createSessionEventMapMemory();
+    const mappingContext: InvocationContext = {
+      sessionId: 'session-1',
+      invocationId: 'invocation-1',
+      runId: 'run-1',
+      turnId: 'turn-1',
+      source: 'desktop',
+      startedAt: 1,
+      request: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        text: 'think about it',
+        source: 'desktop',
+        initialRuntimeEvent: anchor,
+      },
+      newId: idGenerator(),
+      now: monotonicClock(),
+    };
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            { type: 'reasoning-start', id: 'reasoning-1' },
+            {
+              type: 'reasoning-delta',
+              id: 'reasoning-1',
+              delta: 'weighing it up',
+              providerMetadata: {
+                openai: { itemId: 'item-1', reasoningEncryptedContent: undefined },
+              },
+            },
+            { type: 'reasoning-end', id: 'reasoning-1' },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Done.' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'end_turn' },
+              usage: emptyUsage(),
+            },
+          ] satisfies LanguageModelV4StreamPart[],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      }),
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      loadTurnRuntimeEvents: async () => ledger,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    for await (const event of backend.send({
+      turnId: 'turn-1',
+      text: 'think about it',
+      context: [],
+      headAnchorRuntimeEvent: anchor,
+    })) {
+      const mapped = mapSessionEventToRuntimeEvent(event, mappingContext, mappingMemory);
+      if (mapped.partial !== true && mapped.content?.kind !== 'error') ledger.push(mapped);
+    }
+
+    const thinking = ledger.find((event) => event.content?.kind === 'thinking');
+    assert.ok(thinking, 'the reasoning part has to reach the ledger for this to pin anything');
+    assert.deepEqual(
+      thinking.content?.kind === 'thinking' ? thinking.content.providerOptions : undefined,
+      { openai: { itemId: 'item-1' } },
+      'the omitted field was not carried, because the metadata was rebuilt',
+    );
+    for (const event of ledger) {
+      assert.doesNotThrow(
+        () => encodeCanonicalRuntimeEvent(event),
+        `a persisted ${event.content?.kind} event must read back as it was written`,
+      );
+    }
+  });
 });
 
 function textCompletionModel(text: string): MockLanguageModelV4 {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -71,6 +71,7 @@ import type { AttachmentByteReader } from '@maka/core/attachments';
 import {
   MAX_PROVIDER_IMAGE_REQUEST_BYTES,
   PROVIDER_IMAGE_BUDGET_EXCEEDED_MESSAGE,
+  stripUndefinedDeep,
 } from '@maka/core';
 import type {
   LlmCallRecord,
@@ -1561,8 +1562,14 @@ export class AiSdkBackend implements AgentBackend {
                   turnId,
                   stepId: providerStepId,
                   toolCallId: toolCall.toolCallId,
+                  // Provider metadata is persisted verbatim into an immutable
+                  // RuntimeEvent, and a field the response did not carry
+                  // arrives as an explicit `undefined` — which JSON drops, so
+                  // the event no longer reads back as it was written and the
+                  // store refuses it. One refusal took every tool-calling turn
+                  // with it.
                   ...(toolCall.providerOptions !== undefined
-                    ? { providerOptions: toolCall.providerOptions }
+                    ? { providerOptions: stripUndefinedDeep(toolCall.providerOptions) }
                     : {}),
                   input:
                     requestedTool !== undefined

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -720,6 +720,12 @@ export class AiSdkBackend implements AgentBackend {
             messageId: stepId,
             text: part.text,
             ...(part.signature !== undefined ? { signature: part.signature } : {}),
+            // No sanitiser here, unlike the tool call below: these options are
+            // not the provider's object. `translateChunk` rebuilds reasoning
+            // metadata from two named string fields, so an omitted provider
+            // field cannot arrive as an explicit `undefined` and break the
+            // canonical encoding. Passing the provider's object through
+            // instead would need the same `stripUndefinedDeep` a tool call has.
             ...(part.providerOptions !== undefined
               ? { providerOptions: part.providerOptions }
               : {}),


### PR DESCRIPTION
## What happens without this

Provider metadata reaches Maka as the SDK parsed it, and a field the response did not carry arrives as an explicit `undefined` — Anthropic's `caller` comes through as `{ type: 'direct', toolId: undefined }` when there is no tool id.

JSON drops such a property, so the value no longer round-trips and `encodeCanonicalRuntimeEvent` refuses it. That refusal is correct: an immutable event must mean the same thing after it is read back.

The cost was total, and it did not look like this from the outside:

```
load_tools returns ok
  → settleToolCall persists providerOptions verbatim
  → encodeCanonicalRuntimeEvent refuses (undefined does not round-trip)
  → runtime event store marked unavailable
  → the turn's terminal write throws
  → every turn that calls any tool dies ~100ms after the tool returns
```

The visible symptom was "the group loaded and then nothing happened".

## The fix

`stripUndefinedDeep` removes the keys before they are persisted. Lossless in the only sense that matters: JSON cannot tell an absent property from one set to `undefined`, so this writes down what would have been persisted anyway.

Applied at the one place provider metadata enters an event, rather than by loosening what the encoder accepts — the encoder is the check that caught this, and it should keep catching things.

## Verification

`packages/core` builds and its `tool-args-identity` tests pass on this branch against current main; `@maka/runtime` typechecks.