### PR TITLE
fix(desktop): say which startup step has not come back

### DIFF
--- a/apps/desktop/src/main/__tests__/startup-step-wiring-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-step-wiring-contract.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The wiring, not the component.
+ *
+ * `startup-step.test.ts` builds every `startupStep` call it checks, so it stays
+ * green with `boot.ts` calling nothing at all: the whole module can be orphaned
+ * in the tree and the desktop main suite does not move. That is the shape of
+ * the failure this pins — a later edit to `boot.ts` drops the wrappers, CI is
+ * green, and the silent launch these lines exist to name comes back while the
+ * diagnostic still looks healthy from the test report.
+ *
+ * `boot.ts` binds `ipcMain` and `app` at module scope and runs top-level await,
+ * so it cannot be imported under `node --test`; there is no seam to observe the
+ * calls through. Asserting against the source text is the precedent already in
+ * this directory (`app-region-hygiene-contract.test.ts`), for the same reason:
+ * the thing that must not silently change is not reachable from a test process.
+ *
+ * Each step is pinned twice — the wrapped form must be present, and the bare
+ * `await` must be absent. The second half is what fails when a wrapper is
+ * unwrapped rather than renamed.
+ */
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const BOOT = resolve(import.meta.dirname, '../../../src/main/boot.ts');
+
+/**
+ * Drop whole-line `//` comments, so prose about a wrapper cannot stand in for
+ * the wrapper. Trailing comments are left alone rather than risk cutting a
+ * `https://` inside a string literal.
+ */
+function stripLineComments(source: string): string {
+  return source
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+}
+
+/** Steps whose await is long enough that a hang there looks like a crash. */
+const WRAPPED_STEPS = [
+  { name: 'storage root', call: 'resolveDesktopStorageRoot' },
+  { name: 'execution store', call: 'openDesktopExecutionStoreWiring' },
+  { name: 'runtime event persistence', call: 'openRuntimeEventPersistence' },
+] as const;
+
+describe('startup step wiring', () => {
+  it('imports the reporter into boot', async () => {
+    const boot = stripLineComments(await readFile(BOOT, 'utf8'));
+    assert.match(
+      boot,
+      /import\s*\{[^}]*\bstartupStep\b[^}]*\bwhileAwaitingPerson\b[^}]*\}\s*from\s*'\.\/startup-step\.js'/,
+      'boot.ts must take both halves of the reporter; the module is used nowhere else in production',
+    );
+  });
+
+  for (const { name, call } of WRAPPED_STEPS) {
+    it(`names ${name} while awaiting it`, async () => {
+      const boot = stripLineComments(await readFile(BOOT, 'utf8'));
+      assert.match(
+        boot,
+        new RegExp(`await startupStep\\(\\s*'${name}',\\s*${call}\\(`),
+        `${call} must be awaited through startupStep('${name}'), or a hang there prints nothing`,
+      );
+      assert.doesNotMatch(
+        boot,
+        new RegExp(`await\\s+${call}\\(`),
+        `${call} must not be awaited bare; that is the unwrapped form this file exists to catch`,
+      );
+    });
+  }
+
+  it('hands the repair dialog to the person rather than calling it a hang', async () => {
+    const boot = stripLineComments(await readFile(BOOT, 'utf8'));
+    assert.match(
+      boot,
+      /await whileAwaitingPerson\(\s*dialog\.showMessageBox\(/,
+      'the repair modal must run inside whileAwaitingPerson, or reading it prints "still waiting" every three seconds',
+    );
+    assert.doesNotMatch(
+      boot,
+      /await\s+dialog\.showMessageBox\(/,
+      'a bare await on the modal is the unwrapped form: it loses both the quiet and the one line naming a dialog that never opened',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/startup-step.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-step.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { startupStep } from '../startup-step.js';
+
+describe('startup step', () => {
+  test('says nothing when the step comes back', async () => {
+    const said: string[] = [];
+    const value = await startupStep('quick thing', Promise.resolve('done'), {
+      intervalMs: 1,
+      report: (message) => said.push(message),
+    });
+
+    assert.equal(value, 'done');
+    assert.deepEqual(said, []);
+  });
+
+  test('names the step that has not come back, and keeps naming it', async () => {
+    const said: string[] = [];
+    let settle: (value: string) => void = () => {};
+    const work = new Promise<string>((resolve) => {
+      settle = resolve;
+    });
+
+    const pending = startupStep('storage root', work, {
+      intervalMs: 1,
+      report: (message) => said.push(message),
+    });
+    // Two reports, so a launch that stays stuck keeps saying so rather than
+    // mentioning it once and going quiet again.
+    while (said.length < 2) await new Promise((resolve) => setTimeout(resolve, 2));
+    settle('opened');
+
+    assert.equal(await pending, 'opened');
+    assert.deepEqual(new Set(said), new Set(['[startup] still waiting on storage root']));
+  });
+
+  test('stops reporting once the step fails, and lets the failure through', async () => {
+    const said: string[] = [];
+    const failure = new Error('root is not a directory');
+
+    await assert.rejects(
+      () =>
+        startupStep('storage root', Promise.reject(failure), {
+          intervalMs: 1,
+          report: (message) => said.push(message),
+        }),
+      failure,
+    );
+
+    const afterSettling = said.length;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(said.length, afterSettling);
+  });
+});

--- a/apps/desktop/src/main/__tests__/startup-step.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-step.test.ts
@@ -57,9 +57,49 @@ describe('startup step', () => {
     assert.equal(said.length, afterSettling);
   });
 
-  test('stays quiet while a person is the one being waited on', async () => {
-    // A modal waiting for an answer is not a hang, and reporting one every
-    // three seconds tells somebody reading a dialog that the app is stuck.
+  test('names a dialog that never appears, exactly once', async () => {
+    // The failure this has to catch: `dialog.showMessageBox` is called before
+    // any window exists, the modal never attaches, and the promise never
+    // settles. Nobody is reading a dialog, because there is no dialog. Going
+    // silent for the whole span would print nothing at all here — which is the
+    // silence this file was written to end.
+    //
+    // Once, not every three seconds: a person who does have a dialog on screen
+    // is not told repeatedly that the app is stuck.
+    const said: string[] = [];
+    let answer: (value: string) => void = () => {};
+    const dialog = new Promise<string>((resolve) => {
+      answer = resolve;
+    });
+
+    const pending = startupStep('storage root', whileAwaitingPerson(dialog), {
+      intervalMs: 1,
+      report: (message) => said.push(message),
+    });
+    // Bounded rather than spun on: a version that says nothing has to fail on
+    // the assertion below, not by hanging the suite until the runner times out.
+    const deadline = Date.now() + 2_000;
+    while (said.length < 1 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    try {
+      assert.deepEqual(said, [
+        '[startup] storage root is waiting for an answer; if no dialog is on screen, none opened',
+      ]);
+    } finally {
+      // Answered even when the assertion fails, so the step settles and its
+      // reporting timer is cleared rather than left running for the suite.
+      answer('repair');
+    }
+
+    assert.equal(await pending, 'repair');
+  });
+
+  test('does not call a person reading a dialog a hang', async () => {
+    // The wait belongs to the person, so it is never reported as a step that
+    // has not come back — the line that would send somebody hunting a bug.
     const said: string[] = [];
     let answer: (value: string) => void = () => {};
     const dialog = new Promise<string>((resolve) => {
@@ -71,7 +111,10 @@ describe('startup step', () => {
       report: (message) => said.push(message),
     });
     await new Promise((resolve) => setTimeout(resolve, 15));
-    assert.deepEqual(said, [], 'the wait belongs to the person, not to a stuck step');
+    assert.ok(
+      !said.includes('[startup] still waiting on storage root'),
+      'a person answering a question is not a stuck step',
+    );
     answer('repair');
 
     assert.equal(await pending, 'repair');

--- a/apps/desktop/src/main/__tests__/startup-step.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-step.test.ts
@@ -31,8 +31,15 @@ describe('startup step', () => {
       report: (message) => said.push(message),
     });
     // Two reports, so a launch that stays stuck keeps saying so rather than
-    // mentioning it once and going quiet again.
-    while (said.length < 2) await new Promise((resolve) => setTimeout(resolve, 2));
+    // mentioning it once and going quiet again. Bounded, because a regression
+    // that reports once — swapping setInterval for setTimeout is the obvious
+    // one — would otherwise hang the suite until the CI job times out, with no
+    // failing assertion to say which test stalled.
+    const deadline = Date.now() + 2_000;
+    while (said.length < 2 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    assert.ok(said.length >= 2, 'the step should have been named twice while it was still pending');
     settle('opened');
 
     assert.equal(await pending, 'opened');
@@ -134,7 +141,13 @@ describe('startup step', () => {
       readingDisk.then((value) => whileAwaitingPerson(Promise.resolve(value))),
       { intervalMs: 1, report: (message) => said.push(message) },
     );
-    while (said.length < 1) await new Promise((resolve) => setTimeout(resolve, 2));
+    // Bounded for the same reason as the first test: a regression that never
+    // reports should fail here, not stall the runner with nothing to read.
+    const deadline = Date.now() + 2_000;
+    while (said.length < 1 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    assert.ok(said.length >= 1, 'a step stuck before the person is asked should still be named');
     open('read');
 
     assert.equal(await pending, 'read');

--- a/apps/desktop/src/main/__tests__/startup-step.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-step.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
-import { startupStep } from '../startup-step.js';
+import { startupStep, whileAwaitingPerson } from '../startup-step.js';
 
 describe('startup step', () => {
   test('says nothing when the step comes back', async () => {
@@ -12,6 +12,10 @@ describe('startup step', () => {
     });
 
     assert.equal(value, 'done');
+    assert.deepEqual(said, []);
+    // And keeps saying nothing. Asserting only at the await would stay green
+    // if `clearInterval` moved out of `finally` onto the reject path.
+    await new Promise((resolve) => setTimeout(resolve, 10));
     assert.deepEqual(said, []);
   });
 
@@ -51,5 +55,46 @@ describe('startup step', () => {
     const afterSettling = said.length;
     await new Promise((resolve) => setTimeout(resolve, 10));
     assert.equal(said.length, afterSettling);
+  });
+
+  test('stays quiet while a person is the one being waited on', async () => {
+    // A modal waiting for an answer is not a hang, and reporting one every
+    // three seconds tells somebody reading a dialog that the app is stuck.
+    const said: string[] = [];
+    let answer: (value: string) => void = () => {};
+    const dialog = new Promise<string>((resolve) => {
+      answer = resolve;
+    });
+
+    const pending = startupStep('storage root', whileAwaitingPerson(dialog), {
+      intervalMs: 1,
+      report: (message) => said.push(message),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    assert.deepEqual(said, [], 'the wait belongs to the person, not to a stuck step');
+    answer('repair');
+
+    assert.equal(await pending, 'repair');
+  });
+
+  test('still names a step that hangs before the person is asked', async () => {
+    // Pausing the whole step would hide the failure this exists to catch: disk
+    // I/O that never returns, before any dialog opens.
+    const said: string[] = [];
+    let open: (value: string) => void = () => {};
+    const readingDisk = new Promise<string>((resolve) => {
+      open = resolve;
+    });
+
+    const pending = startupStep(
+      'storage root',
+      readingDisk.then((value) => whileAwaitingPerson(Promise.resolve(value))),
+      { intervalMs: 1, report: (message) => said.push(message) },
+    );
+    while (said.length < 1) await new Promise((resolve) => setTimeout(resolve, 2));
+    open('read');
+
+    assert.equal(await pending, 'read');
+    assert.deepEqual(new Set(said), new Set(['[startup] still waiting on storage root']));
   });
 });

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -226,9 +226,11 @@ async function confirmDesktopStorageRootRepair(): Promise<boolean> {
   // on any platform (macOS modal loops block CDP evaluation, Linux does not).
   console.log('[storage-root] root-identity conflict; parking at repair dialog');
   const isChinese = resolveSystemUiLocale(app.getPreferredSystemLanguages()) === 'zh';
-  // The person owns this delay, so the startup reporter stops narrating it —
-  // otherwise reading the dialog for four seconds prints "still waiting on
-  // storage root" at somebody who is looking straight at the reason.
+  // The person owns this delay, so the startup reporter stops calling it a
+  // hang — otherwise reading the dialog for four seconds prints "still waiting
+  // on storage root" at somebody who is looking straight at the reason. It
+  // still says once that an answer is expected, which is the only line printed
+  // when this dialog fails to appear at all.
   const { response } = await whileAwaitingPerson(
     dialog.showMessageBox({
       type: 'warning',

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -162,7 +162,7 @@ import {
 } from './project-context-root.js';
 import { isComputerUseRealModelE2e, isE2e, isIsolatedE2e } from './startup-context.js';
 import { resolveDesktopStorageRoot } from './storage-root-startup.js';
-import { startupStep } from './startup-step.js';
+import { startupStep, whileAwaitingPerson } from './startup-step.js';
 import { openDesktopExecutionStoreWiring } from './execution-store-wiring.js';
 
 const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
@@ -226,18 +226,23 @@ async function confirmDesktopStorageRootRepair(): Promise<boolean> {
   // on any platform (macOS modal loops block CDP evaluation, Linux does not).
   console.log('[storage-root] root-identity conflict; parking at repair dialog');
   const isChinese = resolveSystemUiLocale(app.getPreferredSystemLanguages()) === 'zh';
-  const { response } = await dialog.showMessageBox({
-    type: 'warning',
-    title: isChinese ? 'Maka 工作区需要修复' : 'Maka workspace needs repair',
-    message: isChinese ? 'Maka 无法验证这个工作区。' : 'Maka cannot verify this workspace.',
-    detail: isChinese
-      ? `系统中的磁盘标识可能发生了变化。仅当这是本机原来的 Maka 工作区、而不是复制出的工作区时，才选择修复。\n\n${workspaceRoot}`
-      : `The disk identity may have changed. Repair only if this is the original Maka workspace on this computer, not a copied workspace.\n\n${workspaceRoot}`,
-    buttons: isChinese ? ['修复工作区', '退出'] : ['Repair Workspace', 'Exit'],
-    defaultId: 1,
-    cancelId: 1,
-    noLink: true,
-  });
+  // The person owns this delay, so the startup reporter stops narrating it —
+  // otherwise reading the dialog for four seconds prints "still waiting on
+  // storage root" at somebody who is looking straight at the reason.
+  const { response } = await whileAwaitingPerson(
+    dialog.showMessageBox({
+      type: 'warning',
+      title: isChinese ? 'Maka 工作区需要修复' : 'Maka workspace needs repair',
+      message: isChinese ? 'Maka 无法验证这个工作区。' : 'Maka cannot verify this workspace.',
+      detail: isChinese
+        ? `系统中的磁盘标识可能发生了变化。仅当这是本机原来的 Maka 工作区、而不是复制出的工作区时，才选择修复。\n\n${workspaceRoot}`
+        : `The disk identity may have changed. Repair only if this is the original Maka workspace on this computer, not a copied workspace.\n\n${workspaceRoot}`,
+      buttons: isChinese ? ['修复工作区', '退出'] : ['Repair Workspace', 'Exit'],
+      defaultId: 1,
+      cancelId: 1,
+      noLink: true,
+    }),
+  );
   return response === 0;
 }
 // 保持系统唤醒 (settings.system.keepSystemAwake): holds an Electron
@@ -254,7 +259,10 @@ const projectCatalog = createProjectCatalog(workspaceRoot, {
 });
 const worktreeChildExecutor = createGitWorktreeChildExecutor({ storageRoot: workspaceRoot });
 const planStore = createSqlitePlanStore(workspaceRoot);
-const executionStoreWiring = await openDesktopExecutionStoreWiring(workspaceRoot);
+const executionStoreWiring = await startupStep(
+  'execution store',
+  openDesktopExecutionStoreWiring(workspaceRoot),
+);
 const { runStore, shellRunStore } = executionStoreWiring;
 const runtimePersistence = await startupStep(
   'runtime event persistence',

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -162,6 +162,7 @@ import {
 } from './project-context-root.js';
 import { isComputerUseRealModelE2e, isE2e, isIsolatedE2e } from './startup-context.js';
 import { resolveDesktopStorageRoot } from './storage-root-startup.js';
+import { startupStep } from './startup-step.js';
 import { openDesktopExecutionStoreWiring } from './execution-store-wiring.js';
 
 const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
@@ -204,9 +205,12 @@ if (e2eFixture) {
   console.log(`[e2e-fixture] scenario=${e2eFixture.scenario} workspace=${workspaceRoot}`);
   await seedE2eFixture({ workspaceRoot, fixture: e2eFixture, credentialStore });
 } else {
-  const storageRoot = await resolveDesktopStorageRoot(workspaceRoot, {
-    confirmRepair: confirmDesktopStorageRootRepair,
-  });
+  const storageRoot = await startupStep(
+    'storage root',
+    resolveDesktopStorageRoot(workspaceRoot, {
+      confirmRepair: confirmDesktopStorageRootRepair,
+    }),
+  );
   if (!storageRoot) {
     app.exit(0);
     await new Promise<never>(() => {});
@@ -252,9 +256,12 @@ const worktreeChildExecutor = createGitWorktreeChildExecutor({ storageRoot: work
 const planStore = createSqlitePlanStore(workspaceRoot);
 const executionStoreWiring = await openDesktopExecutionStoreWiring(workspaceRoot);
 const { runStore, shellRunStore } = executionStoreWiring;
-const runtimePersistence = await openRuntimeEventPersistence({
-  workspaceRoot,
-});
+const runtimePersistence = await startupStep(
+  'runtime event persistence',
+  openRuntimeEventPersistence({
+    workspaceRoot,
+  }),
+);
 const runtimeEventStore = runtimePersistence.runtimeEventStore;
 const connectionStore = createConnectionStore(workspaceRoot);
 const settingsStore = createSettingsStore(workspaceRoot);

--- a/apps/desktop/src/main/startup-step.ts
+++ b/apps/desktop/src/main/startup-step.ts
@@ -22,11 +22,20 @@ export const STARTUP_STEP_REPORT_INTERVAL_MS = 3_000;
 /**
  * How many people-waiting states are open.
  *
- * A modal that waits for an answer is not a hang, and reporting one every three
- * seconds tells a person who is reading a dialog that the app is stuck. The
- * step is still tracked — a dialog that fails to appear at all is exactly the
- * failure this file exists for — but it stops narrating while the answer is
- * genuinely somebody else's to give.
+ * A modal that waits for an answer is not a hang, and repeating "still waiting"
+ * every three seconds tells a person who is reading a dialog that the app is
+ * stuck. But going silent instead would hide the failure this file exists for:
+ * a dialog raised before any window exists does not appear, and then nobody is
+ * reading anything and nothing is ever printed.
+ *
+ * So a person-owned wait is said once and then not again, in wording that says
+ * an answer is expected rather than that a step is late. One line names the
+ * step for the dialog that never opened; a person looking at a real dialog is
+ * not narrated at.
+ *
+ * This is a module global, so it mutes every step tracked at the same time, not
+ * only the one whose dialog is open. Boot is sequential today, so no two steps
+ * are ever tracked at once and no case is currently wrong.
  */
 let awaitingPerson = 0;
 
@@ -42,8 +51,16 @@ export async function startupStep<T>(
   options: StartupStepOptions = {},
 ): Promise<T> {
   const report = options.report ?? ((message: string) => console.warn(message));
+  let saidAnswerExpected = false;
   const timer = setInterval(() => {
-    if (awaitingPerson > 0) return;
+    if (awaitingPerson > 0) {
+      if (saidAnswerExpected) return;
+      saidAnswerExpected = true;
+      report(`[startup] ${name} is waiting for an answer; if no dialog is on screen, none opened`);
+      return;
+    }
+    // Said once per span, so the next dialog in this step is named too.
+    saidAnswerExpected = false;
     report(`[startup] still waiting on ${name}`);
   }, options.intervalMs ?? STARTUP_STEP_REPORT_INTERVAL_MS);
   // The timer must never be the reason the process stays alive: a step that
@@ -61,7 +78,9 @@ export async function startupStep<T>(
  *
  * Wrapping the modal rather than excluding the whole step keeps the I/O either
  * side of it tracked: a repair that hangs reading the disk before the dialog
- * opens still gets named.
+ * opens still gets named. And the span is quieter, not silent — a dialog that
+ * never appears is still named once, because that is the failure that leaves
+ * nobody looking at anything.
  */
 export async function whileAwaitingPerson<T>(work: Promise<T>): Promise<T> {
   awaitingPerson += 1;

--- a/apps/desktop/src/main/startup-step.ts
+++ b/apps/desktop/src/main/startup-step.ts
@@ -1,6 +1,6 @@
 // apps/desktop/src/main/startup-step.ts
 //
-// Everything before the first window is created runs at main.ts's top level,
+// Everything before the first window is created runs at boot's top level,
 // where a promise that never settles takes the launch with it: the process
 // stays alive, the main thread sits in the event loop, no window is created,
 // and nothing at all is printed. From outside, that is indistinguishable from
@@ -9,9 +9,26 @@
 //
 // Naming the step turns that silence into one line that says where to look.
 // A step that finishes normally prints nothing, so this costs no noise.
+//
+// What it cannot report: a step that never settles and holds no ref'd handle
+// lets the process exit before the unref'd timer ever fires, so nothing is
+// printed. That is not the case for either step wrapped today — a dialog and
+// disk I/O both hold handles — but a future step that awaits nothing but a
+// bare promise would fall through this silently.
 
 /** How long a step may run before it is worth saying it has not come back. */
 export const STARTUP_STEP_REPORT_INTERVAL_MS = 3_000;
+
+/**
+ * How many people-waiting states are open.
+ *
+ * A modal that waits for an answer is not a hang, and reporting one every three
+ * seconds tells a person who is reading a dialog that the app is stuck. The
+ * step is still tracked — a dialog that fails to appear at all is exactly the
+ * failure this file exists for — but it stops narrating while the answer is
+ * genuinely somebody else's to give.
+ */
+let awaitingPerson = 0;
 
 export interface StartupStepOptions {
   intervalMs?: number;
@@ -25,10 +42,10 @@ export async function startupStep<T>(
   options: StartupStepOptions = {},
 ): Promise<T> {
   const report = options.report ?? ((message: string) => console.warn(message));
-  const timer = setInterval(
-    () => report(`[startup] still waiting on ${name}`),
-    options.intervalMs ?? STARTUP_STEP_REPORT_INTERVAL_MS,
-  );
+  const timer = setInterval(() => {
+    if (awaitingPerson > 0) return;
+    report(`[startup] still waiting on ${name}`);
+  }, options.intervalMs ?? STARTUP_STEP_REPORT_INTERVAL_MS);
   // The timer must never be the reason the process stays alive: a step that
   // hangs should still let the runtime exit if everything else has finished.
   timer.unref?.();
@@ -36,5 +53,21 @@ export async function startupStep<T>(
     return await work;
   } finally {
     clearInterval(timer);
+  }
+}
+
+/**
+ * Mark the span in which a person, not the machine, owns the delay.
+ *
+ * Wrapping the modal rather than excluding the whole step keeps the I/O either
+ * side of it tracked: a repair that hangs reading the disk before the dialog
+ * opens still gets named.
+ */
+export async function whileAwaitingPerson<T>(work: Promise<T>): Promise<T> {
+  awaitingPerson += 1;
+  try {
+    return await work;
+  } finally {
+    awaitingPerson -= 1;
   }
 }

--- a/apps/desktop/src/main/startup-step.ts
+++ b/apps/desktop/src/main/startup-step.ts
@@ -10,11 +10,21 @@
 // Naming the step turns that silence into one line that says where to look.
 // A step that finishes normally prints nothing, so this costs no noise.
 //
+// Who gets to read that line: whoever can see the main process's stderr — a
+// developer running from a terminal, an e2e run capturing output, a crash
+// report gathered by hand. `report` defaults to `console.warn`, and a packaged
+// .app launched from the Finder has nowhere for stderr to land, so somebody
+// who hits this in a shipped build still sees no window and nothing printed,
+// exactly as described above. This is a diagnostic for whoever goes looking,
+// not a message to the person the launch failed on. Ending the silence for
+// them would take a visible surface, which does not exist before the first
+// window and is not what this file does.
+//
 // What it cannot report: a step that never settles and holds no ref'd handle
 // lets the process exit before the unref'd timer ever fires, so nothing is
-// printed. That is not the case for either step wrapped today — a dialog and
-// disk I/O both hold handles — but a future step that awaits nothing but a
-// bare promise would fall through this silently.
+// printed. That is not the case for any of the three steps wrapped today — a
+// dialog and disk I/O both hold handles — but a future step that awaits
+// nothing but a bare promise would fall through this silently.
 
 /** How long a step may run before it is worth saying it has not come back. */
 export const STARTUP_STEP_REPORT_INTERVAL_MS = 3_000;
@@ -59,8 +69,12 @@ export async function startupStep<T>(
       report(`[startup] ${name} is waiting for an answer; if no dialog is on screen, none opened`);
       return;
     }
-    // Said once per span, so the next dialog in this step is named too.
-    saidAnswerExpected = false;
+    // Said once per step, not once per dialog: the flag is never cleared, so a
+    // second person-owned span inside the same step would not be named again.
+    // One step wraps one dialog today (`confirmDesktopStorageRootRepair`, and
+    // `resolveDesktopStorageRoot` calls it at most once), so there is no second
+    // span to lose. Clearing it here would name the next one — do that if a
+    // step ever asks twice.
     report(`[startup] still waiting on ${name}`);
   }, options.intervalMs ?? STARTUP_STEP_REPORT_INTERVAL_MS);
   // The timer must never be the reason the process stays alive: a step that

--- a/apps/desktop/src/main/startup-step.ts
+++ b/apps/desktop/src/main/startup-step.ts
@@ -1,0 +1,40 @@
+// apps/desktop/src/main/startup-step.ts
+//
+// Everything before the first window is created runs at main.ts's top level,
+// where a promise that never settles takes the launch with it: the process
+// stays alive, the main thread sits in the event loop, no window is created,
+// and nothing at all is printed. From outside, that is indistinguishable from
+// a crash — diagnosing one instance of it cost a long bisection over workspace
+// contents, because there was no line saying which step had not come back.
+//
+// Naming the step turns that silence into one line that says where to look.
+// A step that finishes normally prints nothing, so this costs no noise.
+
+/** How long a step may run before it is worth saying it has not come back. */
+export const STARTUP_STEP_REPORT_INTERVAL_MS = 3_000;
+
+export interface StartupStepOptions {
+  intervalMs?: number;
+  report?: (message: string) => void;
+}
+
+/** Await a startup step, and say so if it takes long enough to look like a hang. */
+export async function startupStep<T>(
+  name: string,
+  work: Promise<T>,
+  options: StartupStepOptions = {},
+): Promise<T> {
+  const report = options.report ?? ((message: string) => console.warn(message));
+  const timer = setInterval(
+    () => report(`[startup] still waiting on ${name}`),
+    options.intervalMs ?? STARTUP_STEP_REPORT_INTERVAL_MS,
+  );
+  // The timer must never be the reason the process stays alive: a step that
+  // hangs should still let the runtime exit if everything else has finished.
+  timer.unref?.();
+  try {
+    return await work;
+  } finally {
+    clearInterval(timer);
+  }
+}

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -43,6 +43,10 @@ const ALLOW = new Map([
     'startup chain diagnostics (e2e-fixture fatal/scenario, window create failure, repair/cleanup paths); no secrets (moved from main.ts, PR1880).',
   ],
   [
+    'apps/desktop/src/main/startup-step.ts',
+    'names a startup step that has not come back, before any window exists to show it in; a step name and no secrets.',
+  ],
+  [
     'apps/desktop/src/main/app-lifecycle.ts',
     'startup/shutdown diagnostics (dock icon, credential migration, e2e-fixture marker, cleanup failures); no secrets (moved from main.ts, arch R6).',
   ],


### PR DESCRIPTION
## What a hung startup looks like today

Everything before the first window runs at `main.ts`'s top level, where a promise that never settles takes the launch with it:

```
top-level await never settles
  → process stays alive
  → main thread sits in the event loop
  → no window is created
  → nothing at all is printed
```

From outside that is indistinguishable from a crash. Diagnosing one instance cost a long bisection over workspace contents, because there was no line saying which step had not come back.

## The fix

`startupStep(name, work)` names the step and says so once it has been waiting long enough to look like a hang:

```
[startup] still waiting on storage root
```

- A step that finishes normally prints nothing, so a healthy launch costs no noise.
- The interval timer is `unref`'d, so it can never be the reason the process stays alive.

Applied to the two steps that reach outside the process before any window exists — resolving the storage root, which can raise a dialog, and opening runtime event persistence, which touches the disk. Others can follow; these are the two that have actually hung.