### PR TITLE
fix(runtime): evict oldest queued PTY data instead of pausing the source

### DIFF
--- a/packages/runtime/src/__tests__/pty-screen-collector.test.ts
+++ b/packages/runtime/src/__tests__/pty-screen-collector.test.ts
@@ -39,6 +39,25 @@ describe('PtyScreenCollector', () => {
     }
   });
 
+  test('resets the parser at an input gap so eviction cannot swallow the newest frame behind an unterminated escape sequence', async () => {
+    const { collector, failures } = await createCollector();
+    try {
+      // OSC starts and parses into the terminal (parser waits for BEL/ST).
+      collector.accept('\u001b]0;unterminated');
+      await collector.snapshotAtCut();
+      // The chunk carrying the OSC terminator exceeds the queue budget and is
+      // evicted as the oldest queued data, creating an input gap.
+      collector.accept('\u0007' + 'x'.repeat(PTY_PARSER_HIGH_WATER_BYTES));
+      collector.accept('FINAL-DRAIN\n');
+      const output = (await collector.snapshotAtCut()).output;
+      assert.match(output.screen, /FINAL-DRAIN/);
+      assert.equal(output.truncated, true);
+      assert.deepEqual(failures, []);
+    } finally {
+      collector.dispose();
+    }
+  });
+
   test('distinguishes an intentional screen clear from scrollback eviction', async () => {
     const { collector, failures } = await createCollector();
     try {

--- a/packages/runtime/src/__tests__/pty-screen-collector.test.ts
+++ b/packages/runtime/src/__tests__/pty-screen-collector.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
-import { PTY_SCROLLBACK_ROWS, PtyScreenCollector } from '../pty-screen-collector.js';
+import {
+  PTY_PARSER_HIGH_WATER_BYTES,
+  PTY_SCROLLBACK_ROWS,
+  PtyScreenCollector,
+} from '../pty-screen-collector.js';
 import { loadPtyStack } from '../pty-stack.js';
 
 describe('PtyScreenCollector', () => {
@@ -13,6 +17,22 @@ describe('PtyScreenCollector', () => {
 
       collector.accept('\u001b[!p');
       assert.equal((await collector.snapshotAtCut()).output.cursor.visible, true);
+      assert.deepEqual(failures, []);
+    } finally {
+      collector.dispose();
+    }
+  });
+
+  test('keeps the newest frame and evicts the oldest queued data when the parse queue exceeds its budget', async () => {
+    const { collector, failures } = await createCollector();
+    try {
+      const flood = 'x'.repeat(PTY_PARSER_HIGH_WATER_BYTES + 128 * 1024);
+      collector.accept(flood);
+      collector.accept('FINAL-DRAIN\n');
+      const output = (await collector.snapshotAtCut()).output;
+      assert.match([output.scrollback, output.screen].filter(Boolean).join('\n'), /FINAL-DRAIN/);
+      assert.equal(output.truncated, true);
+      assert.doesNotMatch(output.scrollback, /x{80}/);
       assert.deepEqual(failures, []);
     } finally {
       collector.dispose();
@@ -56,8 +76,6 @@ async function createCollector(): Promise<{
     onProtocolReply: () => {},
     onDirty: () => {},
     onFailure: (error) => failures.push(error),
-    pauseSource: () => {},
-    resumeSource: () => {},
   });
   return { collector, failures };
 }

--- a/packages/runtime/src/pty-process-driver.ts
+++ b/packages/runtime/src/pty-process-driver.ts
@@ -88,14 +88,6 @@ export class PtyProcessDriver {
     this.pty.resize(cols, rows);
   }
 
-  pause(): void {
-    this.pty.pause();
-  }
-
-  resume(): void {
-    this.pty.resume();
-  }
-
   kill(signal: 'SIGTERM' | 'SIGKILL'): void {
     killPty(this.pty, signal);
   }

--- a/packages/runtime/src/pty-screen-collector.ts
+++ b/packages/runtime/src/pty-screen-collector.ts
@@ -8,7 +8,6 @@ export const PTY_INITIAL_COLS = 80;
 export const PTY_INITIAL_ROWS = 24;
 export const PTY_SCROLLBACK_ROWS = 500;
 export const PTY_PARSER_HIGH_WATER_BYTES = 1024 * 1024;
-export const PTY_PARSER_LOW_WATER_BYTES = 256 * 1024;
 export const PTY_PROTOCOL_REPLY_MAX_BYTES = 1024 * 1024;
 
 const REDACTED_MARKER = '[redacted]';
@@ -20,6 +19,12 @@ interface RawRow {
   isWrapped: boolean;
   region: 'scrollback' | 'screen';
   screenIndex?: number;
+}
+
+interface PendingEntry {
+  data: string;
+  bytes: number;
+  dropped: boolean;
 }
 
 interface SanitizedBuffer {
@@ -41,8 +46,6 @@ export interface PtyScreenCollectorOptions {
   onProtocolReply: (data: string) => void;
   onDirty: (generation: number) => void;
   onFailure: (error: Error) => void;
-  pauseSource: () => void;
-  resumeSource: () => void;
 }
 
 export class PtyScreenCollector {
@@ -52,7 +55,7 @@ export class PtyScreenCollector {
   private admittedGeneration = 0;
   private parsedGeneration = 0;
   private pendingBytes = 0;
-  private sourcePaused = false;
+  private pending: PendingEntry[] = [];
   private dataOpen = true;
   private disposed = false;
   private cursorVisible = true;
@@ -92,23 +95,42 @@ export class PtyScreenCollector {
     }
     const generation = ++this.admittedGeneration;
     const bytes = Buffer.byteLength(data, 'utf8');
+    const entry: PendingEntry = { data, bytes, dropped: false };
     this.pendingBytes += bytes;
-    this.applyBackpressure();
+    this.pending.push(entry);
+    this.evictOldestIfOverBudget();
     this.options.onDirty(generation);
 
-    const parse = this.sequence.then(() => this.write(data));
+    const parse = this.sequence.then(() => (entry.dropped ? undefined : this.write(data)));
     this.sequence = parse.then(
       () => {
+        if (entry.dropped) return;
         this.parsedGeneration = generation;
         this.pendingBytes -= bytes;
-        this.applyBackpressure();
+        const index = this.pending.indexOf(entry);
+        if (index >= 0) this.pending.splice(index, 1);
       },
       (error: unknown) => {
-        this.pendingBytes -= bytes;
-        this.applyBackpressure();
+        if (!entry.dropped) this.pendingBytes -= bytes;
         this.fail(asError(error, 'PTY parser failed'));
       },
     );
+  }
+
+  private evictOldestIfOverBudget(): void {
+    // The parse queue is a newest-first bounded buffer: when it exceeds its
+    // budget, evict the oldest queued data instead of pausing the source.
+    // The source is never paused, so process exit can never strand unread
+    // bytes behind node-pty's socket-destroy fence; only the newest frame is
+    // ever guaranteed to reach the terminal. Eviction marks the output
+    // truncated, matching scrollback eviction semantics.
+    while (this.pendingBytes > PTY_PARSER_HIGH_WATER_BYTES && this.pending.length > 1) {
+      const oldest = this.pending.shift();
+      if (!oldest) break;
+      oldest.dropped = true;
+      this.pendingBytes -= oldest.bytes;
+      this.historyTruncated = true;
+    }
   }
 
   mutateAtCut<T>(mutation: () => T | Promise<T>): Promise<T> {
@@ -313,20 +335,6 @@ export class PtyScreenCollector {
     this.normalBufferAtScrollbackLimit = atLimit;
   }
 
-  private applyBackpressure(): void {
-    try {
-      if (!this.sourcePaused && this.pendingBytes >= PTY_PARSER_HIGH_WATER_BYTES) {
-        this.options.pauseSource();
-        this.sourcePaused = true;
-      } else if (this.sourcePaused && this.pendingBytes <= PTY_PARSER_LOW_WATER_BYTES) {
-        this.options.resumeSource();
-        this.sourcePaused = false;
-      }
-    } catch (error) {
-      this.fail(asError(error, 'PTY parser backpressure failed'));
-    }
-  }
-
   private throwIfUnavailable(): void {
     if (this.failure) throw this.failure;
     if (this.disposed) throw new Error('PTY collector is disposed');
@@ -336,14 +344,6 @@ export class PtyScreenCollector {
     if (this.failure || this.disposed) return;
     this.failure = error;
     this.dataOpen = false;
-    if (this.sourcePaused) {
-      try {
-        this.options.resumeSource();
-      } catch {
-        // Termination owns recovery once the collector has failed.
-      }
-      this.sourcePaused = false;
-    }
     this.options.onFailure(error);
   }
 }

--- a/packages/runtime/src/pty-screen-collector.ts
+++ b/packages/runtime/src/pty-screen-collector.ts
@@ -102,7 +102,7 @@ export class PtyScreenCollector {
     this.evictOldestIfOverBudget();
     this.options.onDirty(generation);
 
-    const parse = this.sequence.then(() => (entry.dropped ? undefined : this.write(data)));
+    const parse = this.sequence.then(() => (entry.dropped ? undefined : this.write(entry.data)));
     this.sequence = parse.then(
       () => {
         if (entry.dropped) return;
@@ -129,6 +129,11 @@ export class PtyScreenCollector {
       const oldest = this.pending.shift();
       if (!oldest) break;
       oldest.dropped = true;
+      // Release the payload: the queued closure still references the entry
+      // until the parse chain reaches it, so a paused write would otherwise
+      // keep every evicted string alive — the byte counter would be bounded
+      // while actual memory grows without bound.
+      oldest.data = '';
       this.pendingBytes -= oldest.bytes;
       this.historyTruncated = true;
       // Eviction creates an input gap: the dropped chunk may have carried the

--- a/packages/runtime/src/pty-screen-collector.ts
+++ b/packages/runtime/src/pty-screen-collector.ts
@@ -56,6 +56,7 @@ export class PtyScreenCollector {
   private parsedGeneration = 0;
   private pendingBytes = 0;
   private pending: PendingEntry[] = [];
+  private resetBeforeNextWrite = false;
   private dataOpen = true;
   private disposed = false;
   private cursorVisible = true;
@@ -130,6 +131,10 @@ export class PtyScreenCollector {
       oldest.dropped = true;
       this.pendingBytes -= oldest.bytes;
       this.historyTruncated = true;
+      // Eviction creates an input gap: the dropped chunk may have carried the
+      // terminator of an escape sequence the parser is still waiting on, so
+      // the retained suffix must be parsed from a known ground state.
+      this.resetBeforeNextWrite = true;
     }
   }
 
@@ -277,6 +282,10 @@ export class PtyScreenCollector {
     return new Promise<void>((resolve, reject) => {
       this.protocolReplyBatch = '';
       try {
+        if (this.resetBeforeNextWrite) {
+          this.resetBeforeNextWrite = false;
+          this.resetTerminalAtInputGap();
+        }
         this.terminal.write(data, () => {
           this.suppressNextNormalScrollRetention = false;
           const protocolReply = this.protocolReplyBatch;
@@ -296,6 +305,22 @@ export class PtyScreenCollector {
         reject(error);
       }
     });
+  }
+
+  private resetTerminalAtInputGap(): void {
+    // The retained suffix must be parsed from a known ground state: eviction
+    // may have dropped the terminator of an escape sequence the parser is
+    // still waiting on. `terminal.reset()` alone clears the buffer but leaves
+    // the parser state machine untouched (an unterminated OSC still swallows
+    // the suffix), so feed RIS (ESC c): its full reset puts the parser back
+    // to ground and empties the buffer. The old screen was built from
+    // incomplete input and is cleared with it. historyTruncated is kept:
+    // eviction itself is truncation.
+    this.terminal.write('\u001bc');
+    this.cursorVisible = true;
+    this.lastAlternateRows = undefined;
+    this.normalBufferAtScrollbackLimit = false;
+    this.suppressNextNormalScrollRetention = false;
   }
 
   private createSnapshot(): PtyShellOutput {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -716,8 +716,6 @@ export class ShellRunProcessManager
         },
         onDirty: () => dispatch((target) => this.scheduleAutomaticFlush(target)),
         onFailure: (error) => dispatch((target) => this.handleIntegrityFailure(target, error)),
-        pauseSource: () => driver?.pause(),
-        resumeSource: () => driver?.resume(),
       });
       const plan = buildPtyShellSpawnPlan(input.shell ?? defaultShellPlan(), input.command);
       startingRecord = await this.createStartingRecord(


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure in `shell-run-manager.test.js` "drains the final frame after parser backpressure and drops an evicted wrapped prefix" (`AssertionError: /FINAL-DRAIN/` with empty output). The `test` job failed on `main` twice today (runs 30730791871, 30729759095); both failures were this test.

Root cause: `PtyScreenCollector` paused the node-pty read stream when the parse queue exceeded its high-water mark (1 MiB). If the child process exited while the stream was still paused, node-pty destroyed the socket after 200 ms (`DESTROY_SOCKET_TIMEOUT_MS`) and the unread tail of the output — including the final frame — was lost before the exit event fired. The final snapshot then saw only the partially-parsed output stream, whose rows are all soft-wrapped continuations; `sanitizeBuffer` evicts the entire wrapped prefix, producing empty output with `truncated: true`. Status stayed `completed` because the lost bytes were never delivered, which is why only the text assertion failed.

Fix: backpressure now evicts the oldest queued data from a newest-first bounded queue instead of pausing the source. The source is never paused, so a fast-exiting child can never strand unread bytes behind node-pty's socket-destroy fence, and the final frame always reaches the terminal. This also matches the terminal's own newest-first semantics: scrollback eviction, wrapped-prefix eviction, and queue eviction are the same idea. Eviction marks the output `truncated`.

Design reasoning (first principles): pausing couples flow control (bounded memory) with delivery (complete data), and pause semantics conflict with process exit (exit means no more data will come, but a paused stream cannot deliver the final bytes within node-pty's destroy fence). Decoupling them — never pause the source, bound the parse queue, evict oldest — removes the race entirely.

## Verification

- New regression test `PtyScreenCollector` "keeps the newest frame and evicts the oldest queued data when the parse queue exceeds its budget": red on the old code (empty output), green on the new.
- Existing integration test "drains the final frame after parser backpressure and drops an evicted wrapped prefix": passes locally (macOS). This is the test that fails on CI (Linux) — the race is timing-sensitive, so CI is the authoritative check.
- `node --test "dist/**/*.test.js"` in `packages/runtime`: 2693 tests, 0 fail.
- `npm run lint`, `npm run format:check`, `npm run typecheck`: clean.

Note: the CI failure could not be reproduced locally on macOS (timing differences), so the red-to-green signal for the integration test comes from CI; the new collector unit test locks the eviction semantics locally.
