### PR TITLE
refactor(ui): name every renderer line-height after its Astryx role

### DIFF
--- a/apps/desktop/e2e/type-scale.spec.ts
+++ b/apps/desktop/e2e/type-scale.spec.ts
@@ -155,19 +155,27 @@ test('resolves one type scale from the root down to the transcript', async ({
     // 12px size at once, and `.maka-onboarding-setup header h1` taking a 16px
     // rule's leading at 18px.
     //
-    // The grid rule is Astryx's own (expandTypeScale.ts): target 1.5 under
-    // 20px, 1.4 through 31px, 1.25 above, snapped to 4px, floor size + 4.
-    // Recomputed here rather than table-copied so an Astryx scale change moves
-    // the expectation with it.
+    // The grid rule is Astryx's own (expandTypeScale.ts `computeLeading`):
+    // target 1.5 under 20px, 1.4 through 31px, 1.25 above, snapped to 4px,
+    // floored at the next 4px step at or above size + 4. Recomputed here
+    // rather than table-copied so an Astryx scale change moves the
+    // expectation with it — which only works if it is the same arithmetic:
+    // an earlier revision floored at `size + 4` instead of rounding that
+    // floor up to the grid, and at a 9px tier would have accepted 13px and
+    // rejected Astryx's own 16px.
     //
     // Scope stated with the measured number rather than hidden: this window
     // renders 129 elements with their own text, and of the 323 classes whose
     // rules declare a leading, 3 land on one. Sweeping every scenario would
-    // import other surfaces' vendor gaps — measured, Astryx's own TextArea
-    // counter row (TextArea.tsx declares --text-supporting-size with no
-    // matching leading) is off-grid in the plan-reminders window, and an
-    // allowlist keyed to generated atom class names would rot on the next
-    // Astryx build.
+    // import other surfaces' vendor gaps, and an allowlist keyed to generated
+    // atom class names would rot on the next Astryx build. TextArea has two:
+    // its counter row declares --text-supporting-size with no matching leading
+    // (off-grid in the plan-reminders window, measured), and its input raises
+    // the size to `max(1rem, --text-body-size)` under `(pointer: coarse)`
+    // without raising the leading with it — 16px against the 14px tier's
+    // 1.4286, so 22.86px where the grid wants 24. Both are upstream: this
+    // sweep is first-party CSS's guard, and vendor component styles are not
+    // in any scan in this repo.
     //
     // So this is not the repo-wide guard and must not be described as one:
     // what it covers is the one thing text cannot, an inherited ratio meeting
@@ -179,7 +187,7 @@ test('resolves one type scale from the root down to the transcript', async ({
     const offGrid = await page.evaluate(() => {
       const grid = (px: number) => {
         const target = px < 20 ? 1.5 : px < 32 ? 1.4 : 1.25;
-        return Math.max(Math.round((px * target) / 4) * 4, px + 4);
+        return Math.max(Math.round((px * target) / 4) * 4, Math.ceil((px + 4) / 4) * 4);
       };
       const out: string[] = [];
       for (const el of document.querySelectorAll('*')) {

--- a/apps/desktop/e2e/type-scale.spec.ts
+++ b/apps/desktop/e2e/type-scale.spec.ts
@@ -160,12 +160,22 @@ test('resolves one type scale from the root down to the transcript', async ({
     // Recomputed here rather than table-copied so an Astryx scale change moves
     // the expectation with it.
     //
-    // Scope stated rather than hidden: this window only. Sweeping every
-    // scenario would import other surfaces' vendor gaps — measured, Astryx's
-    // own TextArea counter row (TextArea.tsx declares --text-supporting-size
-    // with no matching leading) is off-grid in the plan-reminders window, and
-    // an allowlist keyed to generated atom class names would rot on the next
-    // Astryx build. Repo-wide coverage is the pairing contract's job.
+    // Scope stated with the measured number rather than hidden: this window
+    // renders 129 elements with their own text, and of the 323 classes whose
+    // rules declare a leading, 3 land on one. Sweeping every scenario would
+    // import other surfaces' vendor gaps — measured, Astryx's own TextArea
+    // counter row (TextArea.tsx declares --text-supporting-size with no
+    // matching leading) is off-grid in the plan-reminders window, and an
+    // allowlist keyed to generated atom class names would rot on the next
+    // Astryx build.
+    //
+    // So this is not the repo-wide guard and must not be described as one:
+    // what it covers is the one thing text cannot, an inherited ratio meeting
+    // an overridden size in a resolved document. Repo-wide coverage is the
+    // pairing contract's, which now checks both directions — an earlier
+    // revision of that contract deferred leading-without-size here, and
+    // measured, none of the three such blocks in the tree rendered in this
+    // window, so the class had no coverage in either place.
     const offGrid = await page.evaluate(() => {
       const grid = (px: number) => {
         const target = px < 20 ? 1.5 : px < 32 ? 1.4 : 1.25;

--- a/apps/desktop/e2e/type-scale.spec.ts
+++ b/apps/desktop/e2e/type-scale.spec.ts
@@ -133,6 +133,64 @@ test('resolves one type scale from the root down to the transcript', async ({
     expect(await label.evaluate((el) => getComputedStyle(el).fontSize)).toBe('14px');
   });
 
+  await test.step('the document default leading pairs with the body tier', async () => {
+    // The single highest-leverage line in the leading convergence, and one no
+    // stylesheet in this repo used to own: Astryx's reset declares
+    // `line-height: 1.5` on `:where(html)`, so every element that did not
+    // declare a leading inherited that ratio — measured 21px at the 14px body
+    // tier, on hundreds of nodes. `body` in maka-tokens.css now declares the
+    // body role's leading next to the body size it already declared.
+    expect(
+      Number.parseFloat(
+        await page.evaluate(() => getComputedStyle(document.body).lineHeight),
+      ),
+    ).toBeCloseTo(20, 1);
+  });
+
+  await test.step('every rendered line box sits on the 4px grid', async () => {
+    // The measurement the pairing contract cannot make. That contract reads
+    // co-located declarations; this asks the resolved document, which is where
+    // an inherited ratio meets an overridden size — the failure that had
+    // `.maka-attachment-file-content` holding one 1.25 for a 14px name and a
+    // 12px size at once, and `.maka-onboarding-setup header h1` taking a 16px
+    // rule's leading at 18px.
+    //
+    // The grid rule is Astryx's own (expandTypeScale.ts): target 1.5 under
+    // 20px, 1.4 through 31px, 1.25 above, snapped to 4px, floor size + 4.
+    // Recomputed here rather than table-copied so an Astryx scale change moves
+    // the expectation with it.
+    //
+    // Scope stated rather than hidden: this window only. Sweeping every
+    // scenario would import other surfaces' vendor gaps — measured, Astryx's
+    // own TextArea counter row (TextArea.tsx declares --text-supporting-size
+    // with no matching leading) is off-grid in the plan-reminders window, and
+    // an allowlist keyed to generated atom class names would rot on the next
+    // Astryx build. Repo-wide coverage is the pairing contract's job.
+    const offGrid = await page.evaluate(() => {
+      const grid = (px: number) => {
+        const target = px < 20 ? 1.5 : px < 32 ? 1.4 : 1.25;
+        return Math.max(Math.round((px * target) / 4) * 4, px + 4);
+      };
+      const out: string[] = [];
+      for (const el of document.querySelectorAll('*')) {
+        const hasOwnText = [...el.childNodes].some(
+          (n) => n.nodeType === Node.TEXT_NODE && (n.textContent ?? '').trim().length > 0,
+        );
+        if (!hasOwnText) continue;
+        const style = getComputedStyle(el);
+        const size = Number.parseFloat(style.fontSize);
+        const leading = Number.parseFloat(style.lineHeight);
+        if (!Number.isFinite(leading)) continue; // `normal` — no declared leading to check
+        const want = grid(size);
+        if (Math.abs(leading - want) < 0.51) continue;
+        const name = typeof el.className === 'string' ? el.className.split(' ')[0] : '';
+        out.push(`${el.tagName.toLowerCase()}.${name}: ${size}px leading ${leading}px, grid wants ${want}px`);
+      }
+      return [...new Set(out)];
+    });
+    expect(offGrid).toEqual([]);
+  });
+
   await test.step('code elements resolve the theme mono stack, not the reset one', async () => {
     expect(
       await page.evaluate(() => {

--- a/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
@@ -15,6 +15,12 @@
  *    shared backstop for the font-weight and line-height converge contracts,
  *    which scan longhand declarations only and would otherwise miss bare
  *    weight or line-height smuggled in via `font:` shorthand.
+ *
+ * 3. `parseCssBlocks` reports every rule's OWN declarations at any nesting
+ *    depth, and reads the last declaration of a repeated property. Both are
+ *    silent-failure shapes: the innermost-block-only form it replaced dropped
+ *    a nested rule's parent entirely, and a first-match read reports the value
+ *    the browser discards. Untested, the pairing contract inherits both.
  */
 
 import { strict as assert } from 'node:assert';
@@ -25,6 +31,7 @@ import { describe, it, after } from 'node:test';
 import {
   expandCssImports,
   findFontShorthandOffenders,
+  parseCssBlocks,
   assertCustomPropPinnedOnce,
   cssRuleBody,
   cssMediaBody,
@@ -78,6 +85,43 @@ describe('css-test-helpers', () => {
 
     it('ignores font: inside comments', () => {
       assert.deepEqual(findFontShorthandOffenders('/* font: 600 12px sans-serif */', 'test'), []);
+    });
+  });
+
+  describe('parseCssBlocks (own declarations, at any depth)', () => {
+    const bodyOf = (css: string, selector: string) =>
+      parseCssBlocks(css).find((b) => b.selector === selector)?.body;
+
+    it('keeps a parent rule’s declarations when a nested rule follows them', () => {
+      // The regression that motivated replacing the innermost-block-only
+      // parser: under it `.a` disappeared entirely, taking its font-size out
+      // of the pairing scan and silently exempting the rule.
+      const css = '.a { font-size: 18px; & span { color: red; } }';
+      assert.match(bodyOf(css, '.a') ?? '', /font-size:\s*18px/);
+      assert.match(bodyOf(css, '& span') ?? '', /color:\s*red/);
+    });
+
+    it('keeps a parent rule’s declarations that follow the nested rule', () => {
+      const css = '.a { & span { color: red; } line-height: 1.9; }';
+      assert.match(bodyOf(css, '.a') ?? '', /line-height:\s*1\.9/);
+    });
+
+    it('emits rules inside at-rules but not the at-rule body itself', () => {
+      const blocks = parseCssBlocks('@media (min-width: 40rem) { .a { font-size: 18px; } }');
+      assert.deepEqual(
+        blocks.map((b) => b.selector),
+        ['.a'],
+      );
+    });
+
+    it('does not leak a sibling rule’s declarations into a block', () => {
+      const css = '.a { font-size: 18px; }\n.b { color: red; }';
+      assert.doesNotMatch(bodyOf(css, '.a') ?? '', /color/);
+      assert.doesNotMatch(bodyOf(css, '.b') ?? '', /font-size/);
+    });
+
+    it('strips comments before parsing', () => {
+      assert.doesNotMatch(bodyOf('.a { /* font-size: 18px; */ color: red; }', '.a') ?? '', /18px/);
     });
   });
 

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -174,15 +174,62 @@ export function findFontShorthandOffenders(css: string, label: string): string[]
 
 // --- size ↔ leading pairing ------------------------------------------------
 
-/** Innermost declaration blocks. Nested at-rules (`@media`, `@layer`) are
- * skipped rather than mis-parsed: their body contains braces, so only the
- * rules inside them match — which is exactly the level declarations live at. */
+/** Every style rule's own declarations, at any nesting depth.
+ *
+ * Depth-aware rather than `/([^{}]+)\{([^{}]*)\}/g`, which only ever matches
+ * the INNERMOST block. That form reads correctly against this repo's CSS today
+ * and is wrong the moment anyone writes native nesting: given
+ * `.a { font-size: X; & span { … } }` it yields only `& span`, and the
+ * declarations on `.a` vanish from every scan built on it — silently
+ * disarming the pairing contract for that rule. Nesting is supported by the
+ * build (Vite/Lightning CSS) and unused today, which is exactly when a parser
+ * bug is cheapest to fix and most likely to go unnoticed.
+ *
+ * At-rule bodies (`@media`, `@layer`, `@keyframes`) are not themselves rules,
+ * so they are not emitted; the style rules nested inside them are.
+ */
 export function parseCssBlocks(css: string): { selector: string; body: string }[] {
+  const src = stripCssComments(css);
   const out: { selector: string; body: string }[] = [];
-  for (const m of stripCssComments(css).matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-    out.push({ selector: m[1].trim().split('\n').pop()!.trim(), body: m[2] });
+  const stack: { selector: string; body: string }[] = [];
+  let buf = '';
+
+  for (const ch of src) {
+    if (ch === '{') {
+      // Declarations the enclosing rule made before this nested block opened
+      // are everything up to the last `;`; the remainder is the selector.
+      const cut = buf.lastIndexOf(';');
+      if (stack.length > 0 && cut >= 0) stack[stack.length - 1].body += buf.slice(0, cut + 1);
+      stack.push({ selector: (cut >= 0 ? buf.slice(cut + 1) : buf).trim(), body: '' });
+      buf = '';
+    } else if (ch === '}') {
+      const rule = stack.pop();
+      if (!rule) continue;
+      rule.body += buf;
+      buf = '';
+      if (!rule.selector.startsWith('@')) {
+        out.push({ selector: rule.selector.split('\n').pop()!.trim(), body: rule.body });
+      }
+    } else {
+      buf += ch;
+    }
   }
   return out;
+}
+
+/** Last-declared value of `prop` in a block body, or undefined.
+ *
+ * Last, not first: within one block CSS takes the later declaration, so a
+ * scanner that reads `body.match(...)` reports the value the browser discards.
+ * `assertCustomPropPinnedOnce` below documents that same false-green at length
+ * for custom properties; this is the longhand case of it.
+ *
+ * `\s*` around the colon because nothing normalizes it — biome.jsonc excludes
+ * both `apps/desktop/**` and `packages/ui/**` from the formatter, so
+ * `font-size : 18px` would otherwise slip every check in this file. */
+function lastDecl(body: string, prop: string): string | undefined {
+  const matches = [...body.matchAll(new RegExp(`(?:^|[;{])\\s*${prop}\\s*:\\s*([^;}]+)`, 'g'))];
+  return matches.at(-1)?.[1].trim();
 }
 
 /**
@@ -197,9 +244,18 @@ export function parseCssBlocks(css: string): { selector: string; body: string }[
  * table, so an Astryx scale change moves this contract with it instead of
  * failing it.
  *
- * One-directional on purpose. A block may declare a leading with no size (it
- * inherits one), and no amount of text says what it inherits; `type-scale`
- * e2e measures that in the resolved document instead.
+ * Bidirectional. An earlier revision checked only size→leading and deferred
+ * leading-without-size to the e2e sweep — but that sweep measures one window,
+ * and measured, none of the three leading-only blocks in the tree rendered in
+ * it, so the class had no coverage anywhere. It is also the exact shape
+ * maka-tokens.css bans in prose ("leading belongs on the element that sets the
+ * size, never on a container above it"), and one of the three
+ * (`.maka-stat-tile-value`) was dead code overridden by both of its own
+ * variants. A rule that declares only a leading is either redundant with what
+ * it inherits or a ratio waiting to meet a size it was not chosen for.
+ *
+ * `inherit`/`unset`/`revert` are a legal pair when BOTH sides use them: the
+ * block is deferring the whole pairing upward, not splitting it.
  */
 export function findLeadingPairingOffenders(
   css: string,
@@ -227,19 +283,39 @@ export function findLeadingPairingOffenders(
     return sized ? sizeOf(sized) : undefined;
   };
 
+  const DEFER = /^(?:inherit|unset|revert)$/;
   const offenders: string[] = [];
   for (const { selector, body } of parseCssBlocks(css)) {
-    const size = body.match(/font-size:\s*var\((--[\w-]+)/)?.[1];
-    if (!size) continue;
-    const leading = body.match(/line-height:\s*var\((--[\w-]+)/)?.[1];
+    const size = lastDecl(body, 'font-size');
+    const leading = lastDecl(body, 'line-height');
+    if (!size && !leading) continue;
+    if (size && leading && DEFER.test(size) && DEFER.test(leading)) continue;
     if (!leading) {
       offenders.push(`${selector}: declares font-size ${size} and no line-height`);
       continue;
     }
-    const want = sizeOf(size);
-    const got = leadingTierOf(leading);
+    if (!size) {
+      offenders.push(`${selector}: declares line-height ${leading} and no font-size`);
+      continue;
+    }
+    // Naming a token is the whole mechanism: a literal is a copy of what the
+    // tier happened to compute before the last scale change. `18px` typed out
+    // is how `.maka-onboarding-setup header h1` drifted in the first place,
+    // and the em/rem ban alone never saw it.
+    const sizeToken = /^var\((--[\w-]+)/.exec(size)?.[1];
+    const leadingToken = /^var\((--[\w-]+)/.exec(leading)?.[1];
+    if (!sizeToken || !leadingToken) {
+      offenders.push(
+        `${selector}: font-size ${size} / line-height ${leading} — both must name a scale token`,
+      );
+      continue;
+    }
+    const want = sizeOf(sizeToken);
+    const got = leadingTierOf(leadingToken);
     if (want && got && want === got) continue;
-    offenders.push(`${selector}: font-size ${size} (${want}) paired with ${leading} (${got})`);
+    offenders.push(
+      `${selector}: font-size ${sizeToken} (${want}) paired with ${leadingToken} (${got})`,
+    );
   }
   return offenders;
 }

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -172,6 +172,78 @@ export function findFontShorthandOffenders(css: string, label: string): string[]
   return offenders;
 }
 
+// --- size ↔ leading pairing ------------------------------------------------
+
+/** Innermost declaration blocks. Nested at-rules (`@media`, `@layer`) are
+ * skipped rather than mis-parsed: their body contains braces, so only the
+ * rules inside them match — which is exactly the level declarations live at. */
+export function parseCssBlocks(css: string): { selector: string; body: string }[] {
+  const out: { selector: string; body: string }[] = [];
+  for (const m of stripCssComments(css).matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    out.push({ selector: m[1].trim().split('\n').pop()!.trim(), body: m[2] });
+  }
+  return out;
+}
+
+/**
+ * Report blocks whose `font-size` and `line-height` name different tiers.
+ *
+ * The rule is not "leading must be token X": Astryx's leading is a pure
+ * function of size (`expandTypeScale.ts` snaps each tier to the 4px grid), so
+ * several role names share one value at one size and the choice between them
+ * is a readability one. What must hold is that the role whose leading a block
+ * names is the role sized like the size the block declares — checked by
+ * resolving both through the generated theme rather than against a hand-copied
+ * table, so an Astryx scale change moves this contract with it instead of
+ * failing it.
+ *
+ * One-directional on purpose. A block may declare a leading with no size (it
+ * inherits one), and no amount of text says what it inherits; `type-scale`
+ * e2e measures that in the resolved document instead.
+ */
+export function findLeadingPairingOffenders(
+  css: string,
+  themeCss: string,
+  tokensCss: string,
+): string[] {
+  const theme = parseCssCustomProps(themeCss);
+  const tokens = parseCssCustomProps(tokensCss);
+  const first = (map: Map<string, string[]>, name: string) => map.get(name)?.[0];
+
+  // Raw size token → length. Product aliases resolve through one hop.
+  const sizeOf = (token: string): string | undefined => {
+    const direct = first(theme, token);
+    if (direct && !direct.startsWith('var(')) return direct;
+    const alias = first(tokens, token) ?? direct;
+    const inner = alias?.match(/var\((--[\w-]+)\)/)?.[1];
+    return inner ? first(theme, inner) : undefined;
+  };
+  // Role leading token → the length of the tier that role is sized at.
+  const leadingTierOf = (token: string): string | undefined => {
+    if (token === '--maka-line-body') return sizeOf('--text-body-size');
+    const role = token.match(/^--text-(.+)-leading$/)?.[1];
+    if (!role) return undefined;
+    const sized = first(theme, `--text-${role}-size`)?.match(/var\((--[\w-]+)\)/)?.[1];
+    return sized ? sizeOf(sized) : undefined;
+  };
+
+  const offenders: string[] = [];
+  for (const { selector, body } of parseCssBlocks(css)) {
+    const size = body.match(/font-size:\s*var\((--[\w-]+)/)?.[1];
+    if (!size) continue;
+    const leading = body.match(/line-height:\s*var\((--[\w-]+)/)?.[1];
+    if (!leading) {
+      offenders.push(`${selector}: declares font-size ${size} and no line-height`);
+      continue;
+    }
+    const want = sizeOf(size);
+    const got = leadingTierOf(leading);
+    if (want && got && want === got) continue;
+    offenders.push(`${selector}: font-size ${size} (${want}) paired with ${leading} (${got})`);
+  }
+  return offenders;
+}
+
 // --- token pin (exact-once) -----------------------------------------------
 
 /** Parse all custom property declarations (`--token: value;`) from CSS.

--- a/apps/desktop/src/main/__tests__/type-scale-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/type-scale-contract.test.ts
@@ -26,6 +26,7 @@ import {
   cssRuleBody,
   assertCssRuleDecls,
   assertCustomPropPinnedOnce,
+  findFontShorthandOffenders,
   findLeadingPairingOffenders,
   parseCssCustomProps,
   readAllRendererCss,
@@ -200,18 +201,48 @@ describe('type scale contracts', () => {
     // not the body role: it is a copy of what the role happened to compute
     // before the last scale change.
     assert.deepEqual(
-      [...css.matchAll(/line-height:\s*[\d.]+/g)].map((m) => m[0]),
+      [...css.matchAll(/line-height\s*:\s*[\d.]+/g)].map((m) => m[0]),
       [],
       'line-height must name an Astryx role token, not a literal ratio',
     );
+    // The bypass the two checks above cannot see, and the one this branch is
+    // most exposed to: rebinding a role token itself. The transcript uses that
+    // mechanism deliberately (`--text-supporting-leading: var(--maka-line-body)`
+    // in chat-message.css), so a rebind is legal — but only to another token.
+    // Rebound to a literal, one line re-establishes a second leading authority
+    // for a whole subtree and reaches every `line-height: var(--text-*-leading)`
+    // site under it, with every other check in this file still green.
+    assert.deepEqual(
+      [...css.matchAll(/--text-[\w-]+-leading\s*:\s*[\d.]+/g)].map((m) => m[0]),
+      [],
+      'an Astryx leading role may be rebound to another token, never to a literal',
+    );
+    // Product CSS is already in the last cascade layer, so the keyword buys
+    // nothing here and costs the ability to retune a tier from the theme. The
+    // font-size ban below has always said this; leading was left out.
+    assert.deepEqual(
+      [...css.matchAll(/line-height:[^;]*!important/g)].map((m) => m[0]),
+      [],
+      'no renderer stylesheet may force a line-height',
+    );
+    // `font:` shorthand carries a leading in its `/` slot (`12px/1.9 sans`),
+    // which every longhand scan above is blind to. The backstop for exactly
+    // this existed in css-test-helpers.ts with no caller anywhere in the repo
+    // outside its own unit test — a guard that was written but never posted.
+    assert.deepEqual(findFontShorthandOffenders(css, 'renderer'), []);
   });
 
-  it('declares every font-size with the leading of its own tier', async () => {
+  it('pairs every font-size and every line-height with its own tier', async () => {
     // The pairing this branch exists to make unbreakable. Size and leading
     // were separately chosen per site, so a site could move one and leave the
     // other — measured, `.maka-onboarding-setup header h1` had done exactly
     // that, overriding the size to 18px while the leading came from a 16px
     // rule one selector up, and rendering 22.5px.
+    //
+    // Both directions, because both are ways for the pair to come apart: a
+    // size with no leading takes whatever ratio it inherits, and a leading
+    // with no size pins a ratio to a size it was never chosen against. The
+    // second half found three blocks in this tree that no check anywhere saw.
     //
     // Resolved through the generated theme rather than a copied table, so
     // this tracks an Astryx scale change instead of failing on one.

--- a/apps/desktop/src/main/__tests__/type-scale-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/type-scale-contract.test.ts
@@ -26,6 +26,7 @@ import {
   cssRuleBody,
   assertCssRuleDecls,
   assertCustomPropPinnedOnce,
+  findLeadingPairingOffenders,
   parseCssCustomProps,
   readAllRendererCss,
 } from './css-test-helpers.js';
@@ -180,6 +181,46 @@ describe('type scale contracts', () => {
       /font-size:[^;]*!important/,
       'no renderer stylesheet may force a font-size — product CSS is already in the last layer',
     );
+  });
+
+  it('leaves no product leading vocabulary to compete with the roles', async () => {
+    // Both halves matter. A surviving `--leading-*` DEFINITION is a second
+    // authority waiting to be used; a surviving REFERENCE with the definition
+    // gone resolves to nothing and lands as `line-height: <invalid>`, which
+    // renders as the inherited leading rather than as a visible break. The
+    // scan covers packages/ui too — its bare `@import "@maka/ui/styles.css"`
+    // is expanded by readAllRendererCss, and it held eight of the literals.
+    const css = stripCssComments(await readAllRendererCss());
+    assert.deepEqual(
+      [...css.matchAll(/--leading-[\w-]+/g)].map((m) => m[0]),
+      [],
+      'no renderer stylesheet may define or read a product --leading-* tier',
+    );
+    // Literals are the same divergence written inline. `1.4286` typed out is
+    // not the body role: it is a copy of what the role happened to compute
+    // before the last scale change.
+    assert.deepEqual(
+      [...css.matchAll(/line-height:\s*[\d.]+/g)].map((m) => m[0]),
+      [],
+      'line-height must name an Astryx role token, not a literal ratio',
+    );
+  });
+
+  it('declares every font-size with the leading of its own tier', async () => {
+    // The pairing this branch exists to make unbreakable. Size and leading
+    // were separately chosen per site, so a site could move one and leave the
+    // other — measured, `.maka-onboarding-setup header h1` had done exactly
+    // that, overriding the size to 18px while the leading came from a 16px
+    // rule one selector up, and rendering 22.5px.
+    //
+    // Resolved through the generated theme rather than a copied table, so
+    // this tracks an Astryx scale change instead of failing on one.
+    const offenders = findLeadingPairingOffenders(
+      await readAllRendererCss(),
+      await read('astryx-theme/maka.css'),
+      await read('maka-tokens.css'),
+    );
+    assert.deepEqual(offenders, [], `size/leading pairs must name one tier:\n${offenders.join('\n')}`);
   });
 
   it('keeps font-size off em multipliers and rem', async () => {

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -375,8 +375,9 @@
      different method, and the method is what could not survive. A unitless
      ratio is one value applied across every tier it is used at; Astryx snaps
      each tier's line box to the 4px grid on its own (`expandTypeScale.ts`:
-     target 1.5 under 20px, 1.4 through 31px, 1.25 above, snapped, floor
-     size + 4) and reports the quotient. So 1.4286 is not a chosen ratio, it is
+     target 1.5 under 20px, 1.4 through 31px, 1.25 above, snapped, floored at
+     the next 4px step at or above size + 4) and reports the quotient. So
+     1.4286 is not a chosen ratio, it is
      20/14. No single ratio can sit on the grid at 12, 14, 16 and 22px at once,
      which is why the two vocabularies could disagree by 1px on body copy while
      both looked deliberate — and why picking a third number would not have
@@ -385,8 +386,16 @@
      The grid is not decoration: Astryx sizes component boxes off the same 4px
      scale, so a line box that lands on it stops fighting the box around it.
      Its own Badge and Kbd carry `--text-supporting-leading` (20px) inside a
-     `--spacing-5` (20px) box; that identity is why Astryx ships no
-     `line-height: 1` escape hatch and why this file no longer needs one.
+     `--spacing-5` (20px) box; that identity is why no rule in this file needs
+     a `line-height: 1` escape hatch. Astryx does keep exactly one, and it is
+     worth naming rather than claiming there is none: the sortable table's rank
+     glyph (`useTableSortable.tsx`) sets `lineHeight: '1'` at 10px behind a
+     lint exception reading "no token for lineHeight:1 (tight badge)". It is a
+     glyph, not text — below the smallest governed size, in a box the scale
+     never sized. Nothing in this file is in that position; the compact pills
+     here sit at the caption tier, centre their 20px line box inside a shorter
+     flex control without clipping it, and are tracked for a box-height fit in
+     their own follow-up rather than by opting back out of the scale.
 
      A consequence worth stating, because it limits what this convergence
      bought: a unitless leading still inherits as a ratio. An element that

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -367,29 +367,34 @@
   --maka-line-body: calc(var(--text-body-size) * var(--text-body-leading));
 
   /* === line-height ===
-     PR-LEADING-CONVERGE-0 (issue #520 PR1):
-     four-tier scale for single-line, heading, dense UI, and body copy.
-     relaxed/loose had zero sites and were dropped.
+     There is no product leading vocabulary. The four semantic tiers that used
+     to live here (none 1 / tight 1.25 / snug 1.375 / normal 1.5) are gone, and
+     every line-height in the renderer now names an Astryx role token.
 
-     NOT yet single-source, and deliberately left that way by the type-scale
-     convergence. Leading now has three vocabularies: these semantic tiers,
-     Astryx's role tiers (--text-body-leading 1.4286, --text-supporting-leading
-     1.6667, …), and --maka-line-body above. Two of them disagree about body
-     copy: --leading-normal is 1.5, which at the 14px body tier is 21px and off
-     the 4px grid, while Astryx computes 20px. The transcript is internally
-     consistent because it reads Astryx's; the rest of the product chrome sits
-     1px looser. Converging them moves 66 --leading-normal sites at once, which
-     is a relayout, not a token change — it wants its own PR with its own
-     before/after, and it gets easier now that the size ladder has one source.
+     They were not merely different numbers from Astryx's — they were a
+     different method, and the method is what could not survive. A unitless
+     ratio is one value applied across every tier it is used at; Astryx snaps
+     each tier's line box to the 4px grid on its own (`expandTypeScale.ts`:
+     target 1.5 under 20px, 1.4 through 31px, 1.25 above, snapped, floor
+     size + 4) and reports the quotient. So 1.4286 is not a chosen ratio, it is
+     20/14. No single ratio can sit on the grid at 12, 14, 16 and 22px at once,
+     which is why the two vocabularies could disagree by 1px on body copy while
+     both looked deliberate — and why picking a third number would not have
+     helped.
 
-     Snug is the one tier that can't be cut: 40 sites at 1.3-1.4 (small-
-     title / UI text in small-text dense zones) collapse to tight
-     (1.25, too tight) or normal (1.5, too loose) at ±0.1-0.2 on small
-     text. relaxed/loose had zero sites, dropped. */
-  --leading-none: 1;        /* single-line: kbd / tag / button label / count / timestamp */
-  --leading-tight: 1.25;   /* headings: h1-h4 / card titles */
-  --leading-snug: 1.375;   /* small titles / UI text: dense zones */
-  --leading-normal: 1.5;   /* body / long-form / markdown */
+     The grid is not decoration: Astryx sizes component boxes off the same 4px
+     scale, so a line box that lands on it stops fighting the box around it.
+     Its own Badge and Kbd carry `--text-supporting-leading` (20px) inside a
+     `--spacing-5` (20px) box; that identity is why Astryx ships no
+     `line-height: 1` escape hatch and why this file no longer needs one.
+
+     A consequence worth stating, because it limits what this convergence
+     bought: a unitless leading still inherits as a ratio. An element that
+     inherits a role's leading and then overrides its own font-size lands off
+     the grid again — measured, that is what `.maka-attachment-file-content`
+     did, holding 1.25 for a 14px name and a 12px size at once. The rule that
+     follows from it is that leading belongs on the element that sets the size,
+     never on a container above it. */
 
   /* === font-weight ===
      PR-FONT-WEIGHT-CONVERGE-0 (issue #520 PR1):
@@ -1012,6 +1017,14 @@ html[data-os="darwin"].dark {
 
   body {
     font-size: var(--font-size-base);
+    /* The document's default leading, and the one site where declaring it
+       matters most: Astryx's reset puts `line-height: 1.5` on `:where(html)`,
+       so before this line every element that did not declare a leading of its
+       own inherited that ratio — measured 21px at the 14px body tier, off the
+       grid, on hundreds of nodes no stylesheet in this repo names. Declared
+       here rather than on `html` because the size it pairs with is declared
+       here; the root stays free of typography, per the contract above. */
+    line-height: var(--text-body-leading);
     font-family: var(--font-default);
     background: var(--background);
     color: var(--foreground);
@@ -1087,6 +1100,7 @@ html[data-os="darwin"].dark {
     background: var(--background);
     color: var(--foreground);
     font-size: var(--font-size-base);
+    line-height: var(--text-body-leading);
   }
 
   .maka-shell-rail-right {
@@ -1111,6 +1125,7 @@ html[data-os="darwin"].dark {
     border-bottom: var(--border-width-hairline) solid var(--border);
     font-weight: var(--font-weight-semibold);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     letter-spacing: var(--tracking-wide);
     text-transform: uppercase;
     color: var(--foreground-secondary);
@@ -1126,7 +1141,7 @@ html[data-os="darwin"].dark {
     border-radius: var(--radius-control);
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-snug);
+    line-height: var(--text-body-leading);
     user-select: none;
     transition: background var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong);
   }
@@ -1152,6 +1167,7 @@ html[data-os="darwin"].dark {
     border-radius: var(--radius-control);
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
   .maka-sidebar-button:hover { background: var(--state-hover-bg); color: var(--foreground); }
 
@@ -1176,6 +1192,7 @@ html[data-os="darwin"].dark {
     gap: var(--space-3);
     padding: 0 var(--space-4);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     color: var(--foreground-secondary);
   }
   .maka-titlebar strong { color: var(--foreground); font-weight: var(--font-weight-medium); }
@@ -1287,6 +1304,7 @@ html[data-os="darwin"].dark {
     gap: var(--space-2);
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
 
   /* ---- Code blocks (used in args preview inside permission prompt) --- */
@@ -1298,6 +1316,7 @@ html[data-os="darwin"].dark {
        command surfaces read literally, so ligatures stay off. */
     font-variant-ligatures: none;
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     background: var(--foreground-3);
     border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);

--- a/apps/desktop/src/renderer/styles/agent-graph.css
+++ b/apps/desktop/src/renderer/styles/agent-graph.css
@@ -25,6 +25,7 @@
 
 .maka-agent-graph-heading strong {
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -36,7 +37,7 @@
 .maka-agent-graph-results {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-agent-graph-error {
@@ -106,13 +107,14 @@
 
 .maka-agent-graph-operator-copy strong {
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-medium);
 }
 
 .maka-agent-graph-operator-copy span,
 .maka-agent-graph-operator-status {
   font-size: var(--font-size-caption);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-agent-graph-wait {

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -22,6 +22,7 @@
     padding: var(--space-4);
     color: var(--muted-foreground);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     font-weight: var(--font-weight-semibold);
     text-align: center;
   }

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -60,6 +60,7 @@
   background: var(--control);
   color: var(--foreground-dimmed);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-variant-numeric: tabular-nums;
 }
 
@@ -169,6 +170,7 @@
   color: var(--foreground);
   text-align: left;
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   transition:
     background var(--duration-base) var(--ease-out-strong),
     border-color var(--duration-base) var(--ease-out-strong);
@@ -211,6 +213,7 @@
   margin-left: auto;
   gap: 1px;
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   color: oklch(from var(--foreground) l c h / 0.62);
   font-variant-numeric: tabular-nums;
 }
@@ -237,10 +240,12 @@
   justify-content: center;
   color: oklch(from var(--foreground) l c h / 0.5);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-artifact-preview-empty {
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-artifact-preview-file {
@@ -248,12 +253,13 @@
   white-space: pre-wrap;
   word-break: break-word;
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-artifact-preview-diff {
   margin: 0;
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-artifact-preview-html {
@@ -275,6 +281,7 @@
 
 .maka-artifact-preview-external-links-bar {
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   padding: var(--space-1) var(--space-1-5);
   border-radius: var(--radius-control);
   background: oklch(from var(--info) l c h / 0.10);
@@ -323,6 +330,7 @@
 
 .maka-artifact-preview-unsupported-title {
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
   color: var(--foreground);
 }
@@ -330,7 +338,7 @@
 .maka-artifact-preview-unsupported-body {
   margin: 0;
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
   color: var(--foreground-secondary);
 }
 
@@ -341,6 +349,7 @@
   margin: 0;
   padding: 0;
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   color: var(--foreground-secondary);
 }
 .maka-artifact-preview-unsupported-meta > div {
@@ -376,6 +385,7 @@
 .maka-artifact-preview-pdf-fallback {
   margin: 0;
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   color: oklch(from var(--foreground) l c h / 0.6);
 }
 
@@ -384,6 +394,7 @@
   align-items: center;
   gap: var(--space-2);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   color: oklch(from var(--foreground) l c h / 0.65);
 }
 
@@ -398,6 +409,7 @@
   border-radius: var(--radius-surface);
   border: var(--border-width-hairline) solid var(--border);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
 }
 
 .maka-artifact-preview-fail[data-tone="destructive"] {
@@ -419,7 +431,7 @@
 .maka-artifact-preview-fail-body {
   margin: 0;
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-artifact-toolbar {

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -192,7 +192,7 @@
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-normal);
-  line-height: var(--leading-none);
+  line-height: var(--text-supporting-leading);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -232,9 +232,15 @@
    h1–h6 with stylex props (Markdown.js `const Tag = \`h${level}\``). The
    .astryx-heading.level-N classes come from the standalone Heading
    component, which Markdown never mounts. */
+/* The one heading in a turn that is not at the body size, and so the one that
+   cannot take the body baseline with it: at 16px, --maka-line-body's 20px is
+   on the 4px grid but is the 14px tier's line box, one step tighter than the
+   tier this heading actually sits at. It takes its own tier's leading (24px);
+   the turn still reads as one rhythm because 24 is the next step of the same
+   grid, not a different one. */
 .maka-turn [data-maka-contract="markdown"] h1 {
   font-size: var(--font-size-lg);
-  line-height: var(--maka-line-body);
+  line-height: var(--text-large-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -259,4 +265,5 @@
   color: var(--info-text);
   padding: var(--space-0-5) var(--space-1-5);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }

--- a/apps/desktop/src/renderer/styles/composer-mention.css
+++ b/apps/desktop/src/renderer/styles/composer-mention.css
@@ -54,6 +54,7 @@
 .maka-composer-mention-name {
   min-width: 0;
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   color: var(--foreground);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -63,6 +64,7 @@
 .maka-composer-mention-secondary {
   min-width: 0;
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   color: var(--muted-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -76,6 +78,7 @@
 .maka-composer-mention-status {
   padding: var(--space-2) var(--space-2);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   color: var(--muted-foreground);
   text-align: center;
 }
@@ -117,7 +120,7 @@
      contract), so the pill is sized to fit it rather than the reverse. */
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-none);
+  line-height: var(--text-supporting-leading);
   pointer-events: none;
 }
 
@@ -145,6 +148,7 @@
   flex: 1 1 auto;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -166,6 +170,7 @@
   background: transparent;
   color: var(--link);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
   transition: background var(--duration-base) var(--ease-out-strong);
@@ -210,6 +215,7 @@
   color: var(--foreground);
   font-family: var(--font-default);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
 }
 
 .maka-composer-skill-panel-search-input::placeholder {
@@ -284,6 +290,7 @@
 .maka-composer-skill-panel-name {
   min-width: 0;
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -293,6 +300,7 @@
   min-width: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -306,5 +314,6 @@
   padding: var(--space-3) var(--space-2);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   text-align: center;
 }

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -145,6 +145,7 @@
   background: transparent;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
   max-width: min(180px, 28vw);
@@ -211,9 +212,10 @@
 /* The textarea owns no chrome (the card does). It auto-resizes from
    --h-composer-min up to 240px (capped in @maka/ui), then scrolls. Type
    matches Astryx ChatComposer / ChatComposerInput: body scale tokens, not
-   a local 14/22 magic pair. --text-body-* comes from the Astryx theme;
-   --font-size-base / product leading cover Storybook or mounts where the
-   theme wrapper is absent.
+   a local 14/22 magic pair. The size keeps its --font-size-base fallback for
+   Storybook or mounts where the theme wrapper is absent; the leading dropped
+   its fallback chain with the product leading tiers it named, and there is no
+   second vocabulary left to fall back to.
 
    Kill the global `*:focus-visible` ring (maka-tokens) — Astryx ChatComposer
    elevates the outer shell on focus-within; a second rectangle on the field
@@ -232,7 +234,7 @@
   font-family: var(--font-default);
   font-size: var(--text-body-size, var(--font-size-base));
   font-weight: var(--text-body-weight, var(--font-weight-normal, 400));
-  line-height: var(--text-body-leading, var(--leading-normal, 1.4286));
+  line-height: var(--text-body-leading);
   min-height: var(--h-composer-min);
   max-height: 240px;
 }
@@ -313,6 +315,7 @@
   padding: var(--space-2) var(--space-2);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   text-align: center;
 }
 
@@ -351,6 +354,7 @@
   margin-left: auto;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-composer-project-check {
@@ -376,12 +380,14 @@
   border-radius: var(--radius-control);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-composer-no-model-hint-action {
   flex-shrink: 0;
   color: var(--link);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-medium);
   text-decoration: none;
   border-radius: var(--radius-control);
@@ -413,7 +419,7 @@
   background: var(--background-elevated);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-none);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-composer-revision-notice > svg {
@@ -447,6 +453,7 @@
   background: transparent;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
   transition: background-color var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong);

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -84,6 +84,7 @@
   text-align: center;
   font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-variant-numeric: tabular-nums;
   letter-spacing: var(--tracking-normal);
   color: var(--foreground);
@@ -162,6 +163,7 @@
 .maka-daily-review-session-time {
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     white-space: nowrap;
     font-variant-numeric: tabular-nums;
   }
@@ -169,6 +171,7 @@
 .maka-daily-review-session-preview {
     min-width: 0;
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     color: var(--muted-foreground);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -182,6 +185,7 @@
 
 .maka-daily-review-top-meta {
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     color: var(--muted-foreground);
     font-variant-numeric: tabular-nums;
   }
@@ -221,6 +225,7 @@
 
 .maka-daily-review-archive-count {
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     color: var(--muted-foreground);
     font-variant-numeric: tabular-nums;
   }
@@ -244,6 +249,7 @@
     min-width: 0;
     color: var(--foreground);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     font-weight: var(--font-weight-semibold);
     letter-spacing: var(--tracking-normal);
     overflow: hidden;
@@ -256,7 +262,7 @@
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     font-variant-numeric: tabular-nums;
-    line-height: var(--leading-normal);
+    line-height: var(--text-supporting-leading);
     overflow-wrap: anywhere;
   }
 
@@ -277,14 +283,14 @@
 .maka-daily-review-archive-empty {
     color: var(--muted-foreground);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
   }
 
 .maka-daily-review-archive-error {
     margin: 0;
     color: var(--destructive, var(--foreground));
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
   }
 
 .maka-daily-review-archive-sections {
@@ -310,7 +316,7 @@
 .maka-daily-review-archive-section-body {
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
     overflow-wrap: anywhere;
   }
 
@@ -336,5 +342,5 @@
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }

--- a/apps/desktop/src/renderer/styles/deep-research.css
+++ b/apps/desktop/src/renderer/styles/deep-research.css
@@ -21,6 +21,7 @@
   margin: 0 0 var(--space-1);
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-bold);
 }
 
@@ -28,7 +29,7 @@
   display: block;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .maka-deep-research-report,
@@ -48,7 +49,7 @@
   margin: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-snug);
+  line-height: var(--text-body-leading);
 }
 
 .maka-deep-research-report ul,
@@ -79,6 +80,7 @@
 .maka-deep-research-progress-title {
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-bold);
   white-space: nowrap;
 }
@@ -90,7 +92,7 @@
   min-width: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .maka-deep-research-run-panel {
@@ -121,14 +123,14 @@
 
 .maka-deep-research-run-summary strong {
   font-size: var(--font-size-ui);
-  line-height: var(--leading-snug);
+  line-height: var(--text-body-leading);
 }
 
 .maka-deep-research-run-summary span,
 .maka-deep-research-run-panel p {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-deep-research-run-actions {
@@ -156,6 +158,7 @@
   background: var(--background);
   color: var(--foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
   transition:
     background-color var(--duration-quick) var(--ease-out-strong),
@@ -186,7 +189,7 @@
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-deep-research-run-grid ul {
@@ -203,7 +206,7 @@
   min-width: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-deep-research-run-grid li[data-status="completed"] > span {

--- a/apps/desktop/src/renderer/styles/error.css
+++ b/apps/desktop/src/renderer/styles/error.css
@@ -48,6 +48,7 @@
     margin: 0;
     color: var(--foreground);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     font-weight: var(--font-weight-semibold);
   }
 
@@ -55,7 +56,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
     max-width: 56ch;
   }
 
@@ -70,7 +71,7 @@
     overflow: auto;
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
-    line-height: var(--leading-normal);
+    line-height: var(--text-supporting-leading);
     white-space: pre-wrap;
     word-break: break-word;
   }

--- a/apps/desktop/src/renderer/styles/help.css
+++ b/apps/desktop/src/renderer/styles/help.css
@@ -16,6 +16,7 @@
   margin: 0 0 var(--space-1);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-normal);
   text-transform: none;
@@ -35,7 +36,7 @@
 .maka-help-section dt {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-help-section dd {
@@ -55,4 +56,5 @@
 .maka-help-plus {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }

--- a/apps/desktop/src/renderer/styles/hero.css
+++ b/apps/desktop/src/renderer/styles/hero.css
@@ -59,6 +59,7 @@
     gap: var(--space-1-5);
     color: var(--brand-deep);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     font-weight: var(--font-weight-bold);
     letter-spacing: var(--tracking-widest);
     text-transform: uppercase;
@@ -69,8 +70,8 @@
     /* Hero typography uses
        `.welcome-title` with `Instrument Sans` variable font at wght:500
        for hero. Maka uses the system stack; the heading takes the top rung
-       of the type scale with semibold weight + tight leading
-       (PR-FONT-WEIGHT-CONVERGE-0 / PR-LEADING-CONVERGE-0, #520 PR1).
+       of the type scale with semibold weight, and its leading from the role
+       that shares that rung (display-1, measured 40px at 28px).
        This was `2.1333em` until the type-scale convergence: an em multiplier
        hand-derived from a 15px body, which then silently rendered 27.7px
        once the body became 13px — the comment still claimed 32px. That is
@@ -84,7 +85,7 @@
     font-size: var(--font-size-5xl);
     font-weight: var(--font-weight-semibold);
     letter-spacing: var(--tracking-normal);
-    line-height: var(--leading-tight);
+    line-height: var(--text-display-1-leading);
     text-wrap: balance;
   }
 .maka-hero p {
@@ -92,7 +93,7 @@
     max-width: 54ch;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
     text-wrap: pretty;
   }
 /* #1433: the daily empty chat is a returning user's landing surface, not a
@@ -101,4 +102,5 @@
    they are seen once, and there the headline is the whole message. */
 .maka-hero-empty-chat:not(.maka-hero-deep-research) h1 {
     font-size: var(--font-size-2xl);
+    line-height: var(--text-heading-1-leading);
   }

--- a/apps/desktop/src/renderer/styles/interaction-prompts.css
+++ b/apps/desktop/src/renderer/styles/interaction-prompts.css
@@ -18,6 +18,7 @@
 .maka-sandbox-boundary-copy h2 {
   color: var(--text-primary);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -25,7 +26,7 @@
   margin-top: var(--space-1);
   color: var(--text-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-sandbox-boundary-scopes {
@@ -46,6 +47,7 @@
   gap: var(--space-3);
   color: var(--text-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-sandbox-boundary-scopes code {
@@ -90,6 +92,7 @@
   color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -131,7 +134,7 @@
   color: var(--foreground);
   font-size: var(--font-size-heading);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-tight);
+  line-height: var(--text-large-leading);
 }
 
 .maka-interaction-actions {

--- a/apps/desktop/src/renderer/styles/model-switcher.css
+++ b/apps/desktop/src/renderer/styles/model-switcher.css
@@ -60,6 +60,7 @@
   box-shadow: none;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-medium);
   transition:
     background-color var(--duration-base) var(--ease-out-strong),

--- a/apps/desktop/src/renderer/styles/module-pages/mcp.css
+++ b/apps/desktop/src/renderer/styles/module-pages/mcp.css
@@ -37,13 +37,13 @@
   color: var(--foreground);
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-tight);
+  line-height: var(--text-large-leading);
 }
 
 .maka-mcp-hero span {
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .maka-mcp-hero-signal {
@@ -78,7 +78,7 @@
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
-  line-height: var(--leading-tight);
+  line-height: var(--text-supporting-leading);
 }
 
 /* Tab row rhythm mirrors the skills page (.maka-skill-tabs-bar): an
@@ -142,6 +142,7 @@
 
 .maka-mcp-market-icon span {
   font-size: var(--font-size-heading);
+  line-height: var(--text-large-leading);
   font-weight: var(--font-weight-bold);
   letter-spacing: var(--tracking-normal);
 }
@@ -184,12 +185,14 @@
 .maka-mcp-market-copy strong {
   color: var(--foreground);
   font-size: var(--font-size-heading);
+  line-height: var(--text-large-leading);
   font-weight: var(--font-weight-semibold);
 }
 
 .maka-mcp-market-copy small {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-mcp-market-copy p {
@@ -198,7 +201,7 @@
   overflow: hidden;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }
@@ -328,12 +331,14 @@
   margin: 0 var(--space-3) var(--space-3);
   color: var(--destructive-text);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
 }
 
 .maka-mcp-server-details {
   margin: 0 var(--space-3) var(--space-3);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-mcp-tool-list {
@@ -419,7 +424,7 @@
   padding-inline: var(--space-4);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-mcp-editor-footer {

--- a/apps/desktop/src/renderer/styles/module-pages/module-shell.css
+++ b/apps/desktop/src/renderer/styles/module-pages/module-shell.css
@@ -42,14 +42,14 @@
   font-size: var(--font-size-4xl);
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-normal);
-  line-height: var(--leading-tight);
+  line-height: var(--text-display-2-leading);
 }
 
 .maka-module-main-header p {
   margin: var(--space-1) 0 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .maka-module-hub-heading {

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -45,6 +45,7 @@
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-normal);
 }
@@ -55,14 +56,14 @@
   font-size: var(--font-size-4xl);
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-normal);
-  line-height: var(--leading-tight);
+  line-height: var(--text-display-2-leading);
 }
 
 .maka-plan-heading p:last-child {
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .maka-plan-top-actions {
@@ -197,7 +198,7 @@
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-tight);
+  line-height: var(--text-body-leading);
 }
 
 .maka-plan-presets {
@@ -218,7 +219,7 @@
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-plan-search,
@@ -227,6 +228,7 @@
   gap: var(--space-1);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -252,6 +254,7 @@
   gap: var(--space-1-5);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -274,7 +277,7 @@
   color: var(--foreground);
   font-size: var(--font-size-heading);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-snug);
+  line-height: var(--text-large-leading);
   overflow-wrap: anywhere;
 }
 
@@ -285,7 +288,7 @@
   align-items: flex-start;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-plan-card-run > :first-child {
@@ -306,7 +309,7 @@
   row-gap: var(--space-0-5);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-plan-card-schedule > span {
@@ -333,13 +336,14 @@
   color: var(--foreground-secondary);
   font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   letter-spacing: var(--tracking-normal);
 }
 
 .maka-plan-card-note {
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
   margin: 0;
   padding: 0;
   overflow-wrap: anywhere;
@@ -367,6 +371,7 @@
   min-width: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -376,7 +381,7 @@
 .maka-plan-run-row time {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-plan-run-row time {

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -53,7 +53,7 @@
   color: var(--foreground);
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-tight);
+  line-height: var(--text-large-leading);
 }
 
 .maka-skill-featured-banner p {
@@ -61,7 +61,7 @@
   margin: var(--space-2-5) 0 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .maka-skill-featured-art {
@@ -104,14 +104,14 @@
 color: oklch(from var(--brand-deep) 0.34 min(c, 0.02) h);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-tight);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-skill-featured-art small {
 color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-tight);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-skill-featured-art span:first-child {
@@ -196,6 +196,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   background: var(--background-elevated);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   padding: var(--space-2) var(--space-3);
 }
 
@@ -213,6 +214,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   font-variant-numeric: tabular-nums;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -269,7 +271,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   color: var(--foreground);
   font-size: var(--font-size-heading);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-tight);
+  line-height: var(--text-large-leading);
 }
 
 /* Slug caption: soft monospace, matching the library row's id treatment. */
@@ -286,6 +288,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
 .maka-skill-market-card-foot span {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -298,7 +301,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -338,6 +341,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
 .maka-skill-section-label {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-widest);
   text-transform: uppercase;
@@ -449,6 +453,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -459,7 +464,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   white-space: nowrap;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-skill-library-meta {
@@ -469,6 +474,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   gap: var(--space-1-5);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   white-space: nowrap;
   min-width: 0;
   overflow: hidden;
@@ -534,6 +540,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   background: oklch(from var(--foreground) l c h / 0.05);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
   padding: var(--space-0-5) var(--space-2);
 }
@@ -545,7 +552,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   background: oklch(from var(--warning) l c h / 0.08);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
   padding: var(--space-2);
 }
 
@@ -565,6 +572,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
 .maka-skill-diff-grid span {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -579,7 +587,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   color: var(--foreground);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   padding: var(--space-2);
@@ -629,5 +637,6 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-normal);
 }

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -370,10 +370,13 @@
   font-size: var(--font-size-xl);
   line-height: var(--text-heading-2-leading);
 }
+/* No leading here on purpose: this paragraph declares no size either, so it
+   takes the body tier whole from `body` in maka-tokens.css. Naming the leading
+   without the size is the split this branch exists to end — it pins a ratio
+   that stops matching the moment anything above changes the size. */
 .maka-onboarding-setup header p {
   margin-top: var(--space-2);
   color: var(--foreground-secondary);
-  line-height: var(--text-body-leading);
 }
 .maka-onboarding-setup[data-tone="warning"] header h1 {
   color: var(--warning, var(--info-text));

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -31,7 +31,7 @@
   color: var(--foreground);
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-tight);
+  line-height: var(--text-large-leading);
   letter-spacing: var(--tracking-normal);
 }
 
@@ -80,7 +80,7 @@
   max-width: none;
   font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);
-  line-height: var(--leading-tight);
+  line-height: var(--text-display-3-leading);
   letter-spacing: var(--tracking-normal);
   color: var(--foreground);
 }
@@ -88,7 +88,7 @@
 .maka-firstrun-sub {
   margin: var(--space-2) 0 0;
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
   color: var(--muted-foreground);
 }
 
@@ -118,6 +118,7 @@
   height: 21px;
   border-radius: var(--radius-pill);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
   border: var(--border-width-hairline) solid var(--border-strong);
   color: var(--muted-foreground);
@@ -125,6 +126,7 @@
 
 .maka-firstrun-step-label {
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   color: var(--muted-foreground);
   white-space: nowrap;
 }
@@ -171,11 +173,13 @@
 }
 .maka-firstrun-pick-label {
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
   color: var(--foreground);
 }
 .maka-firstrun-pick-hint {
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   color: var(--muted-foreground);
 }
 
@@ -290,6 +294,7 @@
   background: var(--background-elevated);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -313,13 +318,13 @@
   color: var(--foreground);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-tight);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-onboarding-setup-step-copy small {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-onboarding-setup-step-state {
@@ -329,6 +334,7 @@
   background: var(--background-elevated);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
   white-space: nowrap;
 }
@@ -362,11 +368,12 @@
      for `blocked` so a stranded user immediately sees gravity. */
 .maka-onboarding-setup header h1 {
   font-size: var(--font-size-xl);
+  line-height: var(--text-heading-2-leading);
 }
 .maka-onboarding-setup header p {
   margin-top: var(--space-2);
   color: var(--foreground-secondary);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 .maka-onboarding-setup[data-tone="warning"] header h1 {
   color: var(--warning, var(--info-text));
@@ -388,6 +395,7 @@
 .maka-onboarding-slug {
   font-family: var(--font-mono);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   padding: var(--space-0-5) var(--space-1-5);
   /* PR-UI-LAYOUT-25: slug radius 6 → 8 to join the form input
    * family (same chrome as inline code badges). */

--- a/apps/desktop/src/renderer/styles/palette.css
+++ b/apps/desktop/src/renderer/styles/palette.css
@@ -28,6 +28,7 @@
   color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-variant-numeric: tabular-nums;
 }
 

--- a/apps/desktop/src/renderer/styles/plan-mode.css
+++ b/apps/desktop/src/renderer/styles/plan-mode.css
@@ -41,14 +41,14 @@
   overflow-wrap: anywhere;
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-snug);
+  line-height: var(--text-body-leading);
 }
 
 .plan-proposal-kicker,
 .plan-proposal-revision {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .plan-proposal-kicker {
@@ -68,7 +68,7 @@
   border-radius: var(--radius-pill);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .plan-proposal-status[data-status="pending_approval"] {
@@ -90,7 +90,7 @@
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .plan-proposal-section {
@@ -103,7 +103,7 @@
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .plan-proposal-steps,
@@ -126,7 +126,7 @@
   background: var(--foreground-2);
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .plan-proposal-step-number {
@@ -142,7 +142,7 @@
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
   font-variant-numeric: tabular-nums;
-  line-height: var(--leading-none);
+  line-height: var(--text-supporting-leading);
 }
 
 .plan-proposal-step-content {
@@ -154,7 +154,7 @@
 .plan-proposal-step-content strong {
   overflow-wrap: anywhere;
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-snug);
+  line-height: var(--text-body-leading);
 }
 
 .plan-proposal-step-content p {
@@ -166,7 +166,7 @@
 .plan-proposal-risks ul {
   color: var(--warning-text);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .plan-proposal-risks li {
@@ -233,7 +233,7 @@
 .plan-execution-toggle span {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .plan-execution-toggle strong {
@@ -242,7 +242,7 @@
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-medium);
-  line-height: var(--leading-snug);
+  line-height: var(--text-body-leading);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -295,7 +295,7 @@
   padding: var(--space-1-5) var(--space-2);
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-snug);
+  line-height: var(--text-body-leading);
 }
 
 .plan-execution-steps li + li {
@@ -323,7 +323,7 @@
   color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-none);
+  line-height: var(--text-supporting-leading);
 }
 
 .plan-execution-step-marker[data-status="in_progress"] {
@@ -352,4 +352,5 @@
   margin: var(--space-1-5) 0 0;
   color: var(--destructive-text);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }

--- a/apps/desktop/src/renderer/styles/plan-mode.css
+++ b/apps/desktop/src/renderer/styles/plan-mode.css
@@ -154,7 +154,6 @@
 .plan-proposal-step-content strong {
   overflow-wrap: anywhere;
   font-weight: var(--font-weight-semibold);
-  line-height: var(--text-body-leading);
 }
 
 .plan-proposal-step-content p {

--- a/apps/desktop/src/renderer/styles/prompt-rail.css
+++ b/apps/desktop/src/renderer/styles/prompt-rail.css
@@ -76,6 +76,7 @@
   background: var(--card-bg);
   box-shadow: var(--card-shadow);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   text-align: left;
   opacity: 0;
   pointer-events: none;

--- a/apps/desktop/src/renderer/styles/quote-chip.css
+++ b/apps/desktop/src/renderer/styles/quote-chip.css
@@ -19,6 +19,7 @@
   color: var(--foreground-secondary);
   box-shadow: var(--shadow-medium);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
   transition:

--- a/apps/desktop/src/renderer/styles/quote-side-panel.css
+++ b/apps/desktop/src/renderer/styles/quote-side-panel.css
@@ -72,6 +72,7 @@
   background: var(--card-bg);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   white-space: pre-wrap;
 }
 
@@ -79,6 +80,7 @@
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-quote-companion-error {
@@ -86,6 +88,7 @@
   padding: var(--space-1) var(--space-3);
   color: var(--destructive-text);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-quote-companion-actions {

--- a/apps/desktop/src/renderer/styles/search-modal.css
+++ b/apps/desktop/src/renderer/styles/search-modal.css
@@ -13,6 +13,7 @@
   overflow: hidden;
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -23,6 +24,7 @@
   overflow: hidden;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -32,7 +34,7 @@
   overflow: hidden;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
 }

--- a/apps/desktop/src/renderer/styles/settings/about.css
+++ b/apps/desktop/src/renderer/styles/settings/about.css
@@ -42,6 +42,7 @@
   margin: 0;
   color: var(--foreground);
   font-size: var(--font-size-xl);
+  line-height: var(--text-heading-2-leading);
   font-weight: var(--font-weight-bold);
   letter-spacing: var(--tracking-normal);
 }
@@ -49,6 +50,7 @@
 .settingsAboutVersion {
   font-family: var(--font-mono);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   color: var(--foreground-secondary);
   padding: var(--space-0-5) var(--space-2);
   border-radius: var(--radius-pill);
@@ -57,6 +59,7 @@
 
 .settingsAboutChannel {
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   color: var(--brand-deep);
   padding: var(--space-0-5) var(--space-2);
   border-radius: var(--radius-pill);
@@ -68,7 +71,7 @@
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 /* Detail audit / polish wave: the retired `.settingsAboutPrivacy` dialect

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -45,6 +45,7 @@
   margin: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -52,6 +53,7 @@
 .settingsBotConfigurationHeader span {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .settingsRemoteAccessActiveList {
@@ -148,13 +150,14 @@
   margin: 0 0 var(--space-1);
   color: var(--foreground);
   font-size: var(--font-size-heading);
+  line-height: var(--text-large-leading);
 }
 
 .settingsBotDetailHeader p {
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .settingsBotEnableHint {
@@ -162,6 +165,7 @@
   margin-top: var(--space-1);
   color: var(--warning-text, var(--foreground-secondary));
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .settingsBotConfigDocLink {
@@ -196,6 +200,7 @@
   margin: 0 0 var(--space-1);
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -203,6 +208,7 @@
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .settingsBotStatusGrid {
@@ -218,12 +224,14 @@
   margin-bottom: var(--space-1);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 .settingsBotStatusGrid dd {
   min-width: 0;
   margin: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   overflow-wrap: anywhere;
 }
 
@@ -371,7 +379,7 @@
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-medium);
-  line-height: var(--leading-none);
+  line-height: var(--text-body-leading);
   white-space: nowrap;
 }
 
@@ -382,7 +390,7 @@
   align-items: center;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-none);
+  line-height: var(--text-supporting-leading);
   white-space: nowrap;
 }
 
@@ -460,6 +468,7 @@
   margin-bottom: var(--space-1);
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
 }
 
 .settingsBotQuickSetup p {
@@ -467,7 +476,7 @@
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .settingsBotQuickSetup .settingsBotBrandChoice {
@@ -538,6 +547,7 @@
 .settingsBotOnboardingStatus {
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-medium);
 }
 
@@ -549,6 +559,7 @@
 .settingsBotOnboardingPrivacy {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .settingsBotOnboardingActions {

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -53,6 +53,7 @@
     display: flex;
     justify-content: space-between;
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     font-variant-numeric: tabular-nums;
   }
 .settingsOauthPastePanel {
@@ -92,18 +93,20 @@
 .settingsConnectionRowText strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     font-weight: var(--font-weight-semibold);
   }
 .settingsConnectionRowText small {
     color: var(--muted-foreground);
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
   }
 .settingsConnectionDetail {
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: var(--leading-normal);
+    line-height: var(--text-supporting-leading);
   }
 .settingsConnectionMeta {
     margin: 0;
@@ -111,6 +114,7 @@
     gap: var(--space-3);
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     font-family: var(--font-mono);
   }
 .settingsInlineFileState {

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -72,6 +72,7 @@
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-bold);
   letter-spacing: var(--tracking-wider);
   text-transform: uppercase;

--- a/apps/desktop/src/renderer/styles/settings/health.css
+++ b/apps/desktop/src/renderer/styles/settings/health.css
@@ -54,6 +54,7 @@
 .settingsHealthLayer > header h4 {
     margin: 0 0 var(--space-0-5);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     font-weight: var(--font-weight-semibold);
     color: var(--foreground);
   }
@@ -61,6 +62,7 @@
 .settingsHealthLayer > header small {
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
   }
 
 /* Polish wave Item 2: the per-signal bordered blocks (.settingsHealthSignalRow*
@@ -101,6 +103,7 @@
 .settingsHealthSignalMeta {
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
   }
 
 .settingsHealthSignalMeta {
@@ -160,8 +163,8 @@
     background: var(--foreground-3);
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: var(--leading-normal);
+    line-height: var(--text-supporting-leading);
   }
-.settingsHealthMetaLabel { color: var(--foreground-secondary); font-size: var(--font-size-caption); white-space: nowrap; }
-.settingsHealthSignalLabel { color: var(--foreground); font-size: var(--font-size-ui); font-weight: 600; }
-.settingsHealthSignalScope { color: var(--muted-foreground); font-size: var(--font-size-caption); letter-spacing: var(--tracking-wider); text-transform: uppercase; }
+.settingsHealthMetaLabel { color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); white-space: nowrap; }
+.settingsHealthSignalLabel { color: var(--foreground); font-size: var(--font-size-ui); line-height: var(--text-body-leading); font-weight: 600; }
+.settingsHealthSignalScope { color: var(--muted-foreground); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); letter-spacing: var(--tracking-wider); text-transform: uppercase; }

--- a/apps/desktop/src/renderer/styles/settings/memory.css
+++ b/apps/desktop/src/renderer/styles/settings/memory.css
@@ -19,17 +19,19 @@
   }
 .settingsMemoryPreview strong {
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     color: var(--foreground);
   }
 .settingsMemoryPreview small {
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     color: var(--muted-foreground);
   }
 .settingsMemoryPreview p {
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
     white-space: pre-wrap;
     word-break: break-word;
   }
@@ -58,6 +60,7 @@
 .settingsMemoryPromptPreviewHeader strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
 .settingsMemoryPromptPreviewHeader div {
     display: inline-flex;
@@ -68,6 +71,7 @@
     flex-shrink: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
   }
 .settingsMemoryPromptPreview[data-active="true"] .settingsMemoryPromptPreviewHeader span {
     color: var(--foreground);
@@ -75,7 +79,7 @@
 .settingsMemoryPromptPreview small {
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
-    line-height: var(--leading-snug);
+    line-height: var(--text-supporting-leading);
   }
 .settingsMemoryPromptPreviewBudget {
     font-family: var(--font-mono);
@@ -92,7 +96,7 @@
     color: var(--foreground-secondary);
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
-    line-height: var(--leading-normal);
+    line-height: var(--text-supporting-leading);
     white-space: pre-wrap;
     word-break: break-word;
   }
@@ -100,7 +104,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
   }
 .settingsMemoryEntryPreviewNotice {
     display: grid;
@@ -113,11 +117,12 @@
 .settingsMemoryEntryPreviewNotice strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
 .settingsMemoryEntryPreviewNotice small {
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: var(--leading-snug);
+    line-height: var(--text-supporting-leading);
   }
 .settingsMemorySaveSummary {
     display: grid;
@@ -130,14 +135,17 @@
 .settingsMemorySaveSummary strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
 .settingsMemorySaveSummary small {
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
 .settingsMemorySaveSummaryTime {
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
   }
 .settingsMemoryBackupState {
     color: var(--foreground-secondary);
@@ -158,6 +166,7 @@
 .settingsMemoryBackupList strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
 /* PR-MEMORY-BACKUP-LIST-A11Y-0 (round 16/30): selector
      targeted the old `<div role="list">`. Container is now a
@@ -179,7 +188,7 @@
 .settingsMemoryBackupList small {
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
-    line-height: var(--leading-snug);
+    line-height: var(--text-supporting-leading);
   }
 .settingsMemoryBackupCandidate {
     display: inline-flex;
@@ -195,6 +204,7 @@
     background: var(--background);
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
   }
 
 .settingsMemoryEntryGroups {
@@ -218,12 +228,14 @@
     justify-content: space-between;
     gap: var(--space-3);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     color: var(--foreground-secondary);
   }
 
 .settingsMemoryEntryGroupHeader strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
 
 .settingsMemoryEntryDraftNotice {
@@ -234,7 +246,7 @@
     background: oklch(from var(--warning) l c h / 0.08);
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
   }
 
 .settingsMemoryEntryList {
@@ -286,11 +298,13 @@
 
 .settingsMemoryEntryCard strong {
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     color: var(--foreground);
   }
 
 .settingsMemoryEntryCard small {
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     color: var(--muted-foreground);
   }
 
@@ -313,7 +327,7 @@
     background: var(--foreground-5);
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: var(--leading-snug);
+    line-height: var(--text-supporting-leading);
   }
 
 .settingsMemoryPromptScope[data-active="true"] {
@@ -332,7 +346,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
     white-space: pre-wrap;
     word-break: break-word;
   }
@@ -355,6 +369,7 @@
 .settingsMemoryFilter small {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   white-space: nowrap;
 }
 
@@ -372,13 +387,14 @@
   .settingsMemoryListEmpty strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
 
 .settingsMemoryFilterEmpty small,
   .settingsMemoryListEmpty small {
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
   }
 
 .settingsMemoryManualAdd {
@@ -398,11 +414,13 @@
 .settingsMemoryManualAddHeader strong {
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
 }
 
 .settingsMemoryManualAddHeader small {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .settingsMemoryDraftWarning {
@@ -417,12 +435,13 @@
 .settingsMemoryDraftWarning strong {
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
 }
 
 .settingsMemoryDraftWarning small {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 /* Memory page meta row — relocated from connection.css — issue #546 PR1. */

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -38,6 +38,7 @@
 
 .catalogPillTabs strong {
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-bold);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -45,6 +45,7 @@
   margin: 0 0 var(--space-0-5);
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -53,7 +54,7 @@
   max-width: 56ch;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .settingsFeatureStatusList {
@@ -63,7 +64,7 @@
   gap: var(--space-1);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .settingsFeatureStatusList li::marker {
@@ -194,7 +195,7 @@
   font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-normal);
-  line-height: var(--leading-tight);
+  line-height: var(--text-display-3-leading);
   text-wrap: balance;
 }
 
@@ -206,7 +207,7 @@
   max-width: 56ch;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
   text-wrap: pretty;
 }
 

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -30,11 +30,13 @@
 
 .settingsPermissionError strong {
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
 
 .settingsPermissionError small {
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
   }
 
 .settingsPermissionError button {
@@ -50,6 +52,7 @@
 .settingsPermissionSection > header h4 {
     margin: 0 0 var(--space-0-5);
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     font-weight: var(--font-weight-semibold);
     color: var(--foreground);
   }
@@ -57,6 +60,7 @@
 .settingsPermissionSection > header small {
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
   }
 
 /* Polish wave Item 3: the per-capability bordered blocks (border + radius +
@@ -106,12 +110,14 @@
 
 .settingsCapabilityHeading strong {
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     font-weight: var(--font-weight-semibold);
   }
 
 .settingsCapabilityId {
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     color: var(--muted-foreground);
     overflow-wrap: anywhere;
   }
@@ -120,7 +126,7 @@
     margin: 0;
     font-size: var(--font-size-ui);
     color: var(--foreground-secondary);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
   }
 
 /* Polish wave Item 3: the five-layer breakdown was a nested gray boxed grid
@@ -148,6 +154,7 @@
 
 .settingsCapabilityLayers dt {
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     letter-spacing: var(--tracking-wider);
     text-transform: uppercase;
     color: var(--muted-foreground);
@@ -157,6 +164,7 @@
 .settingsCapabilityLayers dd {
     margin: 0;
     font-size: var(--font-size-ui);
+    line-height: var(--text-body-leading);
     color: var(--foreground);
     display: flex;
     flex-direction: column;
@@ -165,6 +173,7 @@
 
 .settingsCapabilityLayers dd small {
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     color: var(--muted-foreground);
   }
 
@@ -187,6 +196,7 @@
 
 .settingsCapabilityOsPermissions > span {
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     letter-spacing: var(--tracking-wider);
     text-transform: uppercase;
     color: var(--muted-foreground);
@@ -209,6 +219,7 @@
     border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-pill);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     background: var(--background);
     color: var(--foreground-secondary);
   }
@@ -216,6 +227,7 @@
 .settingsCapabilityOsPermissions li em {
     font-style: normal;
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     padding: 1px var(--space-1-5);
     border-radius: var(--radius-pill);
     background: var(--foreground-5);
@@ -257,6 +269,7 @@
 
 .settingsCapabilityGuidance > span {
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     font-weight: var(--font-weight-semibold);
     color: var(--foreground-secondary);
   }
@@ -266,7 +279,7 @@
     padding-left: var(--space-4);
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: var(--leading-normal);
+    line-height: var(--text-supporting-leading);
   }
 
 .settingsCapabilityAuditSlot {
@@ -277,6 +290,7 @@
 .settingsCapabilityAuditSlot small {
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
   }
 
 .settingsCapabilityAuditSlot ul {
@@ -284,6 +298,7 @@
     margin: 0;
     padding-left: var(--space-4);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     color: var(--foreground-secondary);
   }
 
@@ -406,6 +421,7 @@
 
 .settingsOsPermissionHeading strong {
     font-size: var(--font-size-heading);
+    line-height: var(--text-large-leading);
     font-weight: var(--font-weight-semibold);
     color: var(--foreground);
     min-width: 0;
@@ -415,7 +431,7 @@
 .settingsOsPermissionPurpose {
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
   }
 
 /* #1361: `flex-wrap` so the "影响功能" pill and the impact sentence can break
@@ -428,7 +444,7 @@
     gap: var(--space-1-5);
     font-size: var(--font-size-ui);
     color: var(--foreground-secondary);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
   }
 
 .settingsOsPermissionImpactLabel {
@@ -439,6 +455,7 @@
     background: oklch(from var(--foreground) l c h / 0.05);
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     font-weight: var(--font-weight-semibold);
     letter-spacing: var(--tracking-wider);
   }
@@ -446,6 +463,7 @@
 .settingsOsPermissionReason {
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     font-style: italic;
   }
 
@@ -568,11 +586,12 @@
     background: var(--foreground-3);
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: var(--leading-normal);
+    line-height: var(--text-supporting-leading);
   }
 .settingsCapabilityAuditEmpty {
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
-.settingsPermissionMetaLabel { color: var(--foreground-secondary); font-size: var(--font-size-caption); white-space: nowrap; }
+.settingsPermissionMetaLabel { color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); white-space: nowrap; }

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -2,6 +2,7 @@
   margin: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
 }
 
@@ -9,18 +10,19 @@
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-snug);
+  line-height: var(--text-body-leading);
 }
 
 .catalogTabs strong {
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-semibold);
 }
 
 .catalogTabs small {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-tight);
+  line-height: var(--text-supporting-leading);
 }
 
 /* Provider catalog + OAuth login render as governed Item rows (media ·
@@ -64,6 +66,7 @@
   margin-left: var(--space-2);
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
 }
 
 .providerCatalogChevron {
@@ -82,7 +85,7 @@
   font-size: var(--font-size-caption);
   font-style: normal;
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .providerEditor {
@@ -127,7 +130,7 @@
 
 .providerConnectionIssue span {
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }
 
 .providerAdvancedSettings {
@@ -174,6 +177,7 @@
   gap: var(--space-1-5);
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-medium);
 }
 
@@ -220,6 +224,7 @@
   width: fit-content;
   color: var(--link);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-medium);
   text-decoration: none;
   /* PR-UI-LAYOUT-33: explicit padding + radius so the focus halo
@@ -327,6 +332,7 @@
 .providerCatalogEmpty {
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   padding: var(--space-8) var(--space-2);
   text-align: center;
 }
@@ -337,7 +343,7 @@
   background: color-mix(in srgb, var(--warning) 10%, var(--background));
   color: var(--warning-text);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
   padding: var(--space-2) var(--space-3);
 }
 .providerOAuthGrid {
@@ -348,6 +354,7 @@
 
 .providerOAuthCardBadge {
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-medium);
   letter-spacing: var(--tracking-wide);
 }
@@ -392,11 +399,11 @@
 .enabledEmptyChip strong {
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-bold);
-  line-height: var(--leading-snug);
+  line-height: var(--text-body-leading);
 }
 
 .enabledEmptyChip small {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
 }

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -11,6 +11,7 @@
   max-width: min(320px, 45cqi);
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-variant-numeric: tabular-nums;
   overflow-wrap: anywhere;
   text-align: end;
@@ -28,7 +29,7 @@
 .settingsReadOnlyValue[data-mono="true"] {
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
   text-align: start;
   word-break: break-all;
 }

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -150,6 +150,7 @@
 .settingsPaletteGroupHeading {
   margin: 0;
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-weight: var(--font-weight-medium);
   color: var(--muted-foreground);
   letter-spacing: var(--tracking-normal);

--- a/apps/desktop/src/renderer/styles/settings/web-search.css
+++ b/apps/desktop/src/renderer/styles/settings/web-search.css
@@ -27,6 +27,7 @@
 .settingsWebSearchStatusCluster small {
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-family: var(--font-mono);
   white-space: nowrap;
 }
@@ -51,7 +52,7 @@
 .settingsWebSearchDisabledReason {
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
   text-align: right;
   /* #1364: the hint names an env var (TAVILY_API_KEY) — an unbreakable token
      wider than the whole content column at the 480px window floor. */
@@ -87,6 +88,7 @@
 .settingsWebSearchResult small {
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
+    line-height: var(--text-supporting-leading);
     text-transform: uppercase;
     letter-spacing: var(--tracking-wider);
     /* #1364: the source is a hostname — one unbreakable token, and long ones
@@ -97,7 +99,7 @@
     margin: 0;
     font-size: var(--font-size-ui);
     color: var(--foreground-secondary);
-    line-height: var(--leading-normal);
+    line-height: var(--text-body-leading);
     white-space: pre-wrap;
     word-break: break-word;
   }

--- a/apps/desktop/src/renderer/styles/settings/wechat.css
+++ b/apps/desktop/src/renderer/styles/settings/wechat.css
@@ -4,7 +4,7 @@
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .settingsWechatQrBody {
@@ -45,7 +45,7 @@
   color: var(--foreground-secondary);
   padding: var(--space-4);
   font-size: var(--font-size-ui);
-  line-height: var(--leading-normal);
+  line-height: var(--text-body-leading);
 }
 
 .settingsWechatQrState strong {

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -20,6 +20,7 @@
   background: var(--surface-canvas);
   color: var(--foreground);
   font-size: var(--font-size-base);
+  line-height: var(--text-body-leading);
   box-sizing: border-box;
 }
 

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -77,7 +77,7 @@
   color: var(--control-foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-none);
+  line-height: var(--text-body-leading);
   box-shadow: none;
   overflow: hidden;
   -webkit-app-region: no-drag;
@@ -206,6 +206,7 @@
   color: var(--foreground);
   font: inherit;
   font-size: var(--font-size-ui);
+  line-height: var(--text-body-leading);
   font-weight: var(--font-weight-semibold);
   outline: 0;
   padding: 1px 0;
@@ -223,7 +224,7 @@
   color: var(--warning-text, var(--info-text));
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 /* ⌘N hint on the 新任务 row — quiet text, no chip chrome. */
@@ -239,6 +240,6 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-normal);
   letter-spacing: var(--tracking-wide);
-  line-height: var(--leading-normal);
+  line-height: var(--text-supporting-leading);
   white-space: nowrap;
 }

--- a/apps/desktop/src/renderer/styles/task-ledger.css
+++ b/apps/desktop/src/renderer/styles/task-ledger.css
@@ -20,6 +20,7 @@
   border-radius: var(--radius-control);
   color: var(--foreground-dimmed);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-task-ledger-group {
@@ -38,6 +39,7 @@
   color: var(--foreground-dimmed);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   white-space: nowrap;
 }
 
@@ -49,10 +51,10 @@
   white-space: nowrap;
 }
 
-.maka-task-ledger-subject { color: var(--foreground); font-size: var(--font-size-base); }
+.maka-task-ledger-subject { color: var(--foreground); font-size: var(--font-size-base); line-height: var(--text-body-leading); }
 .maka-task-ledger-meta { display: inline-flex; justify-content: flex-end; gap: var(--space-1-5); white-space: nowrap; }
 .maka-task-ledger-meta > span + span::before { content: "·"; margin-right: var(--space-1-5); }
-.maka-task-ledger-detail { grid-column: 3 / -1; color: var(--foreground-dimmed); font-size: var(--font-size-caption); }
+.maka-task-ledger-detail { grid-column: 3 / -1; color: var(--foreground-dimmed); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); }
 
 .maka-task-ledger-terminal {
   margin-top: var(--space-1);
@@ -69,6 +71,7 @@
   padding: var(--space-1) var(--space-2);
   color: var(--foreground-dimmed);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-task-ledger-terminal-trigger > span { display: inline-flex; align-items: center; gap: var(--space-1-5); }
@@ -81,6 +84,7 @@
   padding: var(--space-1) var(--space-2);
   color: var(--foreground-dimmed);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-task-ledger-retry {

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -4,11 +4,11 @@
 .maka-attachment-file-card { display: flex; width: 200px; max-width: 100%; align-items: center; gap: 10px; padding: 8px; border-radius: var(--radius-surface); background: var(--foreground-alpha-6); box-shadow: inset 0 0 0 1px var(--foreground-alpha-12); }
 .maka-attachment-file-icon { display: grid; width: 36px; height: 36px; flex: 0 0 auto; place-items: center; border-radius: var(--radius-control); color: var(--foreground-secondary); background: var(--foreground-alpha-10); }
 .maka-attachment-file-icon > svg { width: 20px; height: 20px; }
-.maka-attachment-file-content { min-width: 0; flex: 1; line-height: 1.25; }
+.maka-attachment-file-content { min-width: 0; flex: 1; }
 .maka-attachment-file-name,
 .maka-attachment-file-size { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.maka-attachment-file-name { color: var(--foreground); font-size: var(--font-size-base); font-weight: 500; }
-.maka-attachment-file-size { margin-top: 2px; color: var(--muted-foreground); font-family: var(--font-mono); font-size: var(--font-size-caption); font-variant-numeric: tabular-nums; }
+.maka-attachment-file-name { color: var(--foreground); font-size: var(--font-size-base); font-weight: 500; line-height: var(--text-body-leading); }
+.maka-attachment-file-size { margin-top: 2px; color: var(--muted-foreground); font-family: var(--font-mono); font-size: var(--font-size-caption); font-variant-numeric: tabular-nums; line-height: var(--text-supporting-leading); }
 .maka-attachment-file-remove,
 .maka-quote-chip-remove { display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; border: 0; color: var(--muted-foreground); background: transparent; transition: color var(--duration-quick), background var(--duration-quick); }
 .maka-attachment-file-remove { width: 24px; height: 24px; margin-left: 4px; border-radius: var(--radius-control); }
@@ -24,10 +24,10 @@
 
 .maka-section-header { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: 12px; }
 .maka-section-header-content { min-width: 0; }
-.maka-section-header-title { display: inline-flex; align-items: center; gap: 8px; margin: 0; color: var(--foreground); font-size: var(--font-size-ui); font-weight: 600; }
+.maka-section-header-title { display: inline-flex; align-items: center; gap: 8px; margin: 0; color: var(--foreground); font-size: var(--font-size-ui); line-height: var(--text-body-leading); font-weight: 600; }
 .maka-section-header-title-accent::before { display: inline-block; width: 3px; height: 12px; border-radius: var(--radius-pill); background: oklch(from var(--status-running) l c h / 0.85); content: ""; }
-.maka-section-header-count { color: var(--muted-foreground); font-size: var(--font-size-caption); font-weight: 400; font-variant-numeric: tabular-nums; }
-.maka-section-header-subtitle { display: block; margin-top: 2px; color: var(--foreground-secondary); font-size: var(--font-size-caption); font-weight: 400; }
+.maka-section-header-count { color: var(--muted-foreground); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); font-weight: 400; font-variant-numeric: tabular-nums; }
+.maka-section-header-subtitle { display: block; margin-top: 2px; color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); font-weight: 400; }
 .maka-section-header-action { display: flex; flex: 0 0 auto; align-items: center; gap: 8px; }
 
 .maka-stat-tile { display: flex; min-width: 0; flex-direction: column; align-items: flex-start; gap: 4px; padding: 12px; }
@@ -38,15 +38,15 @@
 .maka-stat-tile-border-warning { border-color: oklch(from var(--warning) l c h / 0.28); }
 .maka-stat-tile-border-destructive { border-color: oklch(from var(--destructive) l c h / 0.3); }
 .maka-stat-tile-empty { opacity: var(--opacity-disabled); }
-.maka-stat-tile-value { display: block; min-width: 0; max-width: 100%; overflow-wrap: anywhere; color: var(--foreground); font-weight: 600; font-variant-numeric: tabular-nums; line-height: 1.25; white-space: normal; }
-.maka-stat-tile-value-outline { font-size: var(--font-size-stat); }
-.maka-stat-tile-value-filled { font-size: var(--font-size-ui); }
+.maka-stat-tile-value { display: block; min-width: 0; max-width: 100%; overflow-wrap: anywhere; color: var(--foreground); font-weight: 600; font-variant-numeric: tabular-nums; line-height: var(--text-heading-1-leading); white-space: normal; }
+.maka-stat-tile-value-outline { font-size: var(--font-size-stat); line-height: var(--text-heading-1-leading); }
+.maka-stat-tile-value-filled { font-size: var(--font-size-ui); line-height: var(--text-body-leading); }
 .maka-stat-tile-value-info { color: var(--info-text); }
 .maka-stat-tile-value-success { color: var(--success-text); }
 .maka-stat-tile-value-warning { color: var(--warning-text); }
 .maka-stat-tile-value-destructive { color: var(--destructive-text); }
-.maka-stat-tile-label { color: var(--foreground-secondary); font-size: var(--font-size-caption); letter-spacing: 0.025em; }
-.maka-stat-tile-detail { color: var(--muted-foreground); font-size: var(--font-size-caption); }
+.maka-stat-tile-label { color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); letter-spacing: 0.025em; }
+.maka-stat-tile-detail { color: var(--muted-foreground); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); }
 
 .maka-quote-chip { display: inline-flex; gap: 4px; padding-left: 8px; background: var(--foreground-alpha-6); box-shadow: inset 0 0 0 1px var(--foreground-alpha-12); }
 .maka-quote-chip-expanded { width: 100%; max-width: 100%; align-items: flex-start; padding-block: 4px; border-radius: var(--radius-surface); }
@@ -55,14 +55,14 @@
 .maka-quote-chip-readonly { padding-right: 8px; }
 .maka-quote-chip-icon { width: 12px; height: 12px; flex: 0 0 auto; color: var(--muted-foreground); }
 .maka-quote-chip-icon-expanded { margin-top: 2px; }
-.maka-quote-chip-text { min-width: 0; flex: 1; border: 0; padding: 0; color: var(--foreground-secondary); background: transparent; font-size: var(--font-size-caption); text-align: left; }
+.maka-quote-chip-text { min-width: 0; flex: 1; border: 0; padding: 0; color: var(--foreground-secondary); background: transparent; font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); text-align: left; }
 .maka-quote-chip-text-expanded { max-height: 128px; overflow-y: auto; overflow-wrap: break-word; white-space: pre-wrap; }
 .maka-quote-chip-text-clipped { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .maka-quote-chip-label { color: var(--muted-foreground); }
 .maka-quote-chip-remove { width: 16px; height: 16px; border-radius: 50%; }
 .maka-quote-chip-remove > svg { width: 12px; height: 12px; }
 
-.maka-task-ledger-empty { margin: 0; color: var(--muted-foreground); font-size: var(--font-size-ui); line-height: 1.5; }
+.maka-task-ledger-empty { margin: 0; color: var(--muted-foreground); font-size: var(--font-size-ui); line-height: var(--text-body-leading); }
 
 .maka-user-attachment-thumb-pending { display: grid; width: 128px; height: 128px; place-items: center; border: 1px solid var(--border); border-radius: var(--radius-surface); color: var(--muted-foreground); background: var(--foreground-alpha-6); }
 .maka-user-attachment-thumb-pending > svg { width: 20px; height: 20px; animation: maka-spin 1s linear infinite; }
@@ -80,22 +80,22 @@
 .maka-live-turn-footer-placeholder { height: 32px; margin-top: 2px; }
 .maka-turn-processing,
 .maka-turn-status,
-.maka-turn-continuing { display: flex; align-items: center; padding-block: 2px; color: var(--muted-foreground); font-size: var(--font-size-base); }
+.maka-turn-continuing { display: flex; align-items: center; padding-block: 2px; color: var(--muted-foreground); font-size: var(--font-size-base); line-height: var(--text-body-leading); }
 .maka-turn-processing,
 .maka-turn-status { gap: 8px; }
 .maka-turn-processing-spinner { flex: 0 0 auto; animation: maka-spin 1s linear infinite; }
 .maka-turn-indicator-text { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .maka-turn-continuing { opacity: 0.7; animation: maka-stream-fade-in var(--duration-emphasized) var(--ease-out-strong) both; }
-.maka-turn-truncation-badge { display: inline-block; margin-top: 6px; border: 1px solid oklch(from var(--warning) l c h / 0.24); border-radius: var(--radius-control); padding-inline: 4px; color: var(--warning-text, var(--info-text)); background: oklch(from var(--warning) l c h / 0.05); font-size: var(--font-size-caption); cursor: help; }
+.maka-turn-truncation-badge { display: inline-block; margin-top: 6px; border: 1px solid oklch(from var(--warning) l c h / 0.24); border-radius: var(--radius-control); padding-inline: 4px; color: var(--warning-text, var(--info-text)); background: oklch(from var(--warning) l c h / 0.05); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); cursor: help; }
 .maka-deep-thinking { min-width: 0; }
 
 @keyframes maka-spin { to { transform: rotate(360deg); } }
 .maka-spin { animation: maka-spin 1s linear infinite; }
 
 .maka-tool-output-panel { display: grid; gap: 8px; margin-top: 4px; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius-surface); background: var(--foreground-3); }
-.maka-tool-output-command { display: block; min-width: 0; color: var(--foreground); font-family: var(--font-mono); font-size: var(--font-size-base); font-variant-ligatures: none; line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
-.maka-tool-output-body { max-height: 256px; margin: 0; overflow-y: auto; color: var(--muted-foreground); font-family: var(--font-mono); font-size: var(--font-size-base); font-variant-ligatures: none; line-height: 1.5; scroll-behavior: auto; white-space: pre-wrap; word-break: break-word; }
-.maka-tool-output-note { margin: 0; color: var(--muted-foreground); font-size: var(--font-size-base); line-height: 1.5; }
+.maka-tool-output-command { display: block; min-width: 0; color: var(--foreground); font-family: var(--font-mono); font-size: var(--font-size-base); font-variant-ligatures: none; line-height: var(--text-body-leading); white-space: pre-wrap; word-break: break-word; }
+.maka-tool-output-body { max-height: 256px; margin: 0; overflow-y: auto; color: var(--muted-foreground); font-family: var(--font-mono); font-size: var(--font-size-base); font-variant-ligatures: none; line-height: var(--text-body-leading); scroll-behavior: auto; white-space: pre-wrap; word-break: break-word; }
+.maka-tool-output-note { margin: 0; color: var(--muted-foreground); font-size: var(--font-size-base); line-height: var(--text-body-leading); }
 .maka-tool-output-wrap { min-width: 0; overflow-wrap: anywhere; }
 .maka-tool-output-destructive { color: var(--destructive); }
 .maka-tool-output-warning { color: var(--warning-text, var(--info-text)); }
@@ -104,23 +104,23 @@
 .maka-tool-output-stack { display: flex; min-width: 0; flex-direction: column; gap: 6px; margin-top: 4px; }
 .maka-pty-shell { gap: 0; overflow: hidden; padding: 0; }
 .maka-pty-shell-header { display: flex; min-width: 0; align-items: center; padding: 10px 12px 4px; }
-.maka-pty-shell-title { color: var(--foreground-secondary); font-size: var(--font-size-base); font-weight: 500; }
+.maka-pty-shell-title { color: var(--foreground-secondary); font-size: var(--font-size-base); line-height: var(--text-body-leading); font-weight: 500; }
 .maka-pty-shell-body { display: grid; min-width: 0; gap: 8px; padding: 6px 12px; }
-.maka-pty-shell-footer { display: flex; min-height: 32px; align-items: center; justify-content: flex-end; gap: 6px; padding: 4px 12px 10px; color: var(--muted-foreground); font-size: var(--font-size-base); }
+.maka-pty-shell-footer { display: flex; min-height: 32px; align-items: center; justify-content: flex-end; gap: 6px; padding: 4px 12px 10px; color: var(--muted-foreground); font-size: var(--font-size-base); line-height: var(--text-body-leading); }
 .maka-pty-terminal-body { overflow: auto; white-space: pre; word-break: normal; }
 
 .maka-web-result { display: grid; gap: 8px; font-family: var(--font-sans); }
 .maka-web-result-header { display: grid; gap: 2px; }
-.maka-web-result-header strong { color: var(--foreground); font-size: var(--font-size-base); }
+.maka-web-result-header strong { color: var(--foreground); font-size: var(--font-size-base); line-height: var(--text-body-leading); }
 .maka-web-result-header small,
-.maka-web-result-list small { color: var(--muted-foreground); font-size: var(--font-size-base); }
+.maka-web-result-list small { color: var(--muted-foreground); font-size: var(--font-size-base); line-height: var(--text-body-leading); }
 .maka-web-result-list { display: grid; gap: 8px; margin: 0; padding: 0; list-style: none; }
 .maka-web-result-list li { display: grid; gap: 2px; }
-.maka-web-result-list a { color: var(--link); font-size: var(--font-size-base); font-weight: 500; }
-.maka-web-result-list p { margin: 0; color: var(--foreground-secondary); font-size: var(--font-size-base); line-height: 1.375; }
+.maka-web-result-list a { color: var(--link); font-size: var(--font-size-base); line-height: var(--text-body-leading); font-weight: 500; }
+.maka-web-result-list p { margin: 0; color: var(--foreground-secondary); font-size: var(--font-size-base); line-height: var(--text-body-leading); }
 .maka-web-result-error { gap: 6px; }
 .maka-web-result-error-message,
-.maka-web-result-repair { margin: 0; font-size: var(--font-size-base); }
+.maka-web-result-repair { margin: 0; font-size: var(--font-size-base); line-height: var(--text-body-leading); }
 .maka-web-result-error-message { color: var(--destructive); }
 .maka-web-result-repair { color: var(--muted-foreground); }
 .maka-tool-header-full { width: 100%; }
@@ -132,15 +132,15 @@
 .maka-tool-trow { display: flex; flex-direction: column; }
 .maka-tool-trow-trigger { display: flex; min-width: 0; align-items: center; gap: var(--spacing-1-5, 6px); padding-block: 2px; }
 .maka-tool-trow-icon { flex: 0 0 auto; }
-.maka-tool-trow-summary { min-width: 0; overflow: hidden; font-size: var(--text-supporting-size); font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.maka-tool-trow-summary { min-width: 0; overflow: hidden; font-size: var(--text-supporting-size); line-height: var(--text-supporting-leading); font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
 .maka-tool-trow-children { display: flex; flex-direction: column; gap: 2px; margin-top: 2px; margin-left: 8px; padding-left: 10px; border-left: 1px solid var(--border); }
-.maka-tool-trow-duration { flex: 0 0 auto; color: var(--muted-foreground); font-size: var(--text-supporting-size); font-variant-numeric: tabular-nums; }
+.maka-tool-trow-duration { flex: 0 0 auto; color: var(--muted-foreground); font-size: var(--text-supporting-size); line-height: var(--text-supporting-leading); font-variant-numeric: tabular-nums; }
 .maka-tool-output-chunk { display: contents; }
 .maka-tool-output-chunk-stderr { color: var(--destructive); }
 .maka-tool-output-chunk-redacted { opacity: 0.65; }
 .maka-tool-output-redacted { display: inline; margin-left: 2px; color: var(--warning-text, var(--info-text)); }
 .maka-sandbox-blocked-banner { margin-bottom: 10px; }
-.maka-sandbox-blocked-description { display: flex; flex-direction: column; gap: 4px; font-size: var(--font-size-caption); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+.maka-sandbox-blocked-description { display: flex; flex-direction: column; gap: 4px; font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); white-space: pre-wrap; word-break: break-word; }
 .maka-sandbox-blocked-error { font-family: var(--font-mono); }
 .maka-sandbox-blocked-copy { align-self: start; }
 .maka-sandbox-blocked-copy[data-pending="true"] { cursor: progress; }
@@ -165,7 +165,7 @@
   margin-inline: 0;
   border-radius: var(--radius-control);
   font-size: var(--font-size-caption);
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
 }
 
 .maka-turn-aborted-marker {
@@ -302,6 +302,7 @@
   margin-bottom: var(--space-0-5);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 .maka-tool-count {
   display: inline-flex;
@@ -314,6 +315,7 @@
   background: var(--foreground-5);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-variant-numeric: tabular-nums;
 }
 .maka-tool-item {
@@ -327,6 +329,7 @@
   color: var(--foreground-secondary);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 .maka-tool-item[data-status="waiting_permission"] { border-color: oklch(from var(--info) l c h / 0.4); }
 .maka-tool-item[data-status="running"] { border-color: oklch(from var(--status-running) l c h / 0.4); }
@@ -379,11 +382,11 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.maka-tool-meta { display: inline-flex; align-items: center; gap: var(--space-2); color: var(--muted-foreground); font-size: var(--font-size-caption); }
+.maka-tool-meta { display: inline-flex; align-items: center; gap: var(--space-2); color: var(--muted-foreground); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); }
 .maka-tool-duration { font-variant-numeric: tabular-nums; }
 .maka-tool-status-label { color: var(--foreground-secondary); }
 .maka-tool-body { padding: var(--space-2-5) var(--space-3) var(--space-3); }
-.maka-tool-intent { margin: 0 0 var(--space-2); color: var(--foreground-secondary); font-family: var(--font-default); font-size: var(--font-size-caption); line-height: var(--leading-snug); }
+.maka-tool-intent { margin: 0 0 var(--space-2); color: var(--foreground-secondary); font-family: var(--font-default); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); }
 .maka-tool-args { max-height: 110px; margin: 0; overflow: auto; }
 
 .maka-overlay-preview {
@@ -392,6 +395,7 @@
   overflow: auto;
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
   font-variant-ligatures: none;
   white-space: pre-wrap;
   word-break: break-word;
@@ -417,6 +421,7 @@
   background: var(--foreground-2);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
+  line-height: var(--text-supporting-leading);
 }
 .maka-tool-terminal-head { align-items: center; font-variant-ligatures: none; }
 .maka-tool-diff-paths code { color: var(--foreground-secondary); background: transparent; }
@@ -428,7 +433,7 @@
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
   font-variant-ligatures: none;
-  line-height: var(--leading-snug);
+  line-height: var(--text-supporting-leading);
   white-space: pre;
   word-break: normal;
 }
@@ -440,14 +445,14 @@
 .maka-tool-diff-line[data-line="ctx"] { color: var(--foreground-secondary); }
 .maka-tool-terminal-cwd { color: var(--muted-foreground); background: transparent; }
 .maka-tool-terminal-cmd { min-width: 0; flex: 1 1 auto; overflow: hidden; background: transparent; color: var(--foreground); font-weight: var(--font-weight-semibold); text-overflow: ellipsis; white-space: nowrap; }
-.maka-tool-terminal-exit { padding: 1px var(--space-1-5); border-radius: var(--radius-pill); background: var(--foreground-5); color: var(--foreground-secondary); font-size: var(--font-size-caption); font-weight: var(--font-weight-bold); letter-spacing: 0.04em; }
+.maka-tool-terminal-exit { padding: 1px var(--space-1-5); border-radius: var(--radius-pill); background: var(--foreground-5); color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); font-weight: var(--font-weight-bold); letter-spacing: 0.04em; }
 .maka-tool-terminal-exit[data-ok="true"] { background: oklch(from var(--success) l c h / 0.14); color: var(--success); }
 .maka-tool-terminal-exit[data-ok="false"] { background: oklch(from var(--destructive) l c h / 0.14); color: var(--destructive); }
-.maka-tool-terminal-empty { margin: 0; padding: var(--space-2); color: var(--muted-foreground); font-family: var(--font-mono); font-size: var(--font-size-caption); font-style: italic; }
-.maka-tool-terminal-stream { max-height: 180px; margin: 0; padding: var(--space-1-5) var(--space-2); overflow: auto; font-family: var(--font-mono); font-size: var(--font-size-caption); font-variant-ligatures: none; white-space: pre-wrap; word-break: break-word; }
+.maka-tool-terminal-empty { margin: 0; padding: var(--space-2); color: var(--muted-foreground); font-family: var(--font-mono); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); font-style: italic; }
+.maka-tool-terminal-stream { max-height: 180px; margin: 0; padding: var(--space-1-5) var(--space-2); overflow: auto; font-family: var(--font-mono); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); font-variant-ligatures: none; white-space: pre-wrap; word-break: break-word; }
 .maka-tool-terminal-stream[data-stream="stdout"] { color: var(--foreground); }
 .maka-tool-terminal-stream[data-stream="stderr"] { border-top: 1px solid var(--border); background: oklch(from var(--destructive) l c h / 0.04); color: var(--destructive); }
-.maka-tool-terminal-truncated-note { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); padding: var(--space-1-5) var(--space-2); border-top: 1px solid var(--border); background: oklch(from var(--warning) l c h / 0.06); color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--leading-normal); }
+.maka-tool-terminal-truncated-note { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); padding: var(--space-1-5) var(--space-2); border-top: 1px solid var(--border); background: oklch(from var(--warning) l c h / 0.06); color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); }
 .maka-tool-terminal-truncated-note > span { min-width: 0; }
 .maka-tool-terminal-copy,
 .maka-agent-preview-copy { flex: 0 0 auto; }
@@ -461,50 +466,50 @@
 .maka-agent-preview[data-status="failed"],
 .maka-agent-preview[data-status="cancelled"] { border-color: oklch(from var(--destructive) l c h / 0.22); }
 .maka-agent-preview-head { display: grid; gap: var(--space-0-5); padding-bottom: var(--space-1-5); border-bottom: 1px solid var(--foreground-10); }
-.maka-agent-preview-head strong { min-width: 0; overflow: hidden; color: var(--foreground); font-size: var(--font-size-ui); text-overflow: ellipsis; white-space: nowrap; }
+.maka-agent-preview-head strong { min-width: 0; overflow: hidden; color: var(--foreground); font-size: var(--font-size-ui); line-height: var(--text-body-leading); text-overflow: ellipsis; white-space: nowrap; }
 .maka-agent-preview-head small,
 .maka-agent-preview-section small,
-.maka-agent-preview-meta dt { color: var(--muted-foreground); font-size: var(--font-size-caption); letter-spacing: 0.04em; text-transform: uppercase; }
+.maka-agent-preview-meta dt { color: var(--muted-foreground); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); letter-spacing: 0.04em; text-transform: uppercase; }
 .maka-agent-preview-summary-line,
 .maka-agent-preview-section-head { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: var(--space-2); }
 .maka-agent-preview-summary-line small { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .maka-agent-preview-actions { display: flex; align-items: center; justify-content: flex-end; gap: var(--space-1-5); margin-top: var(--space-1); }
-.maka-agent-preview-message { padding: var(--space-2) var(--space-2-5); border-radius: var(--radius-control); background: oklch(from var(--destructive) l c h / 0.07); color: var(--destructive); font-size: var(--font-size-caption); }
+.maka-agent-preview-message { padding: var(--space-2) var(--space-2-5); border-radius: var(--radius-control); background: oklch(from var(--destructive) l c h / 0.07); color: var(--destructive); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); }
 .maka-agent-preview-meta { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2); margin: 0; }
 .maka-agent-preview-meta > div { display: grid; min-width: 0; gap: var(--space-0-5); }
-.maka-agent-preview-meta dd { min-width: 0; margin: 0; overflow: hidden; color: var(--foreground-secondary); font-size: var(--font-size-caption); text-overflow: ellipsis; white-space: nowrap; }
+.maka-agent-preview-meta dd { min-width: 0; margin: 0; overflow: hidden; color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); text-overflow: ellipsis; white-space: nowrap; }
 .maka-agent-preview-section { display: grid; gap: var(--space-1-5); }
 .maka-agent-preview-section > strong,
-.maka-agent-preview-section-head > strong { min-width: 0; color: var(--foreground); font-size: var(--font-size-caption); }
+.maka-agent-preview-section-head > strong { min-width: 0; color: var(--foreground); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); }
 .maka-agent-preview-section ul { display: grid; gap: var(--space-1-5); margin: 0; padding: 0; list-style: none; }
 .maka-agent-preview-section li { display: grid; min-width: 0; gap: var(--space-0-5); padding-block: var(--space-1-5); border-top: 1px solid var(--foreground-5); }
 .maka-agent-preview-section li:first-child { padding-top: 0; border-top: 0; }
-.maka-agent-preview-section code { min-width: 0; overflow: hidden; background: transparent; color: var(--foreground); font-family: var(--font-mono); font-size: var(--font-size-caption); text-overflow: ellipsis; white-space: nowrap; }
+.maka-agent-preview-section code { min-width: 0; overflow: hidden; background: transparent; color: var(--foreground); font-family: var(--font-mono); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); text-overflow: ellipsis; white-space: nowrap; }
 .maka-agent-preview-section p,
-.maka-agent-preview-section span { margin: 0; color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--leading-snug); white-space: pre-wrap; word-break: break-word; }
+.maka-agent-preview-section span { margin: 0; color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); white-space: pre-wrap; word-break: break-word; }
 .maka-agent-preview-copy[data-copied="true"] { border-color: oklch(from var(--link) l c h / 0.35); color: var(--link); }
 
 .maka-web-search-preview { display: grid; gap: var(--space-2); padding: var(--space-2-5) var(--space-3); border: 1px solid var(--foreground-10); border-radius: var(--radius-surface); background: var(--foreground-3); }
 .maka-web-search-preview > header { display: flex; flex-direction: column; gap: var(--space-0-5); padding-bottom: var(--space-1-5); border-bottom: 1px solid var(--foreground-10); }
-.maka-web-search-preview > header strong { color: var(--foreground); font-size: var(--font-size-ui); font-weight: var(--font-weight-semibold); }
+.maka-web-search-preview > header strong { color: var(--foreground); font-size: var(--font-size-ui); line-height: var(--text-body-leading); font-weight: var(--font-weight-semibold); }
 .maka-web-search-preview > header small,
-.maka-web-search-preview li small { color: var(--muted-foreground); font-size: var(--font-size-caption); letter-spacing: 0.04em; text-transform: uppercase; }
+.maka-web-search-preview li small { color: var(--muted-foreground); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); letter-spacing: 0.04em; text-transform: uppercase; }
 .maka-web-search-preview ul { display: grid; gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
 .maka-web-search-preview li { display: grid; gap: var(--space-0-5); padding-block: var(--space-2); border-top: 1px solid var(--foreground-5); }
 .maka-web-search-preview li:first-child { padding-top: 0; border-top: 0; }
 .maka-web-search-preview a { color: var(--foreground); font-weight: var(--font-weight-semibold); text-decoration: none; }
 .maka-web-search-preview a:hover { text-decoration: underline; }
-.maka-web-search-preview li p { margin: 0; color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--leading-snug); white-space: pre-wrap; word-break: break-word; }
+.maka-web-search-preview li p { margin: 0; color: var(--foreground-secondary); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); white-space: pre-wrap; word-break: break-word; }
 .maka-web-search-error { border-color: color-mix(in oklab, var(--destructive-text) 32%, var(--foreground-10)); background: color-mix(in oklab, var(--destructive-text) 8%, var(--foreground-3)); }
 .maka-web-search-error-message,
-.maka-web-search-error-repair { margin: 0; font-size: var(--font-size-caption); line-height: var(--leading-snug); white-space: pre-wrap; word-break: break-word; }
+.maka-web-search-error-repair { margin: 0; font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); white-space: pre-wrap; word-break: break-word; }
 .maka-web-search-error-message { color: var(--destructive-text); }
 .maka-web-search-error-repair { color: var(--foreground-secondary); }
 
-.maka-load-tool-preview { display: grid; gap: var(--space-0-5); margin: var(--space-1) 0 0; padding: var(--space-1) var(--space-2); border-radius: var(--radius-control); background: var(--background); box-shadow: var(--shadow-minimal-flat); font-size: var(--font-size-caption); }
+.maka-load-tool-preview { display: grid; gap: var(--space-0-5); margin: var(--space-1) 0 0; padding: var(--space-1) var(--space-2); border-radius: var(--radius-control); background: var(--background); box-shadow: var(--shadow-minimal-flat); font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); }
 .maka-load-tool-preview p { margin: 0; }
 .maka-load-tool-title { font-weight: var(--font-weight-semibold); }
 .maka-load-tool-count,
 .maka-load-tool-footer { color: var(--muted-foreground); }
 .maka-load-tool-tools { font-family: var(--font-mono); word-break: break-word; }
-.maka-load-tool-footer { font-size: var(--font-size-caption); }
+.maka-load-tool-footer { font-size: var(--font-size-caption); line-height: var(--text-supporting-leading); }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -38,7 +38,7 @@
 .maka-stat-tile-border-warning { border-color: oklch(from var(--warning) l c h / 0.28); }
 .maka-stat-tile-border-destructive { border-color: oklch(from var(--destructive) l c h / 0.3); }
 .maka-stat-tile-empty { opacity: var(--opacity-disabled); }
-.maka-stat-tile-value { display: block; min-width: 0; max-width: 100%; overflow-wrap: anywhere; color: var(--foreground); font-weight: 600; font-variant-numeric: tabular-nums; line-height: var(--text-heading-1-leading); white-space: normal; }
+.maka-stat-tile-value { display: block; min-width: 0; max-width: 100%; overflow-wrap: anywhere; color: var(--foreground); font-weight: 600; font-variant-numeric: tabular-nums; white-space: normal; }
 .maka-stat-tile-value-outline { font-size: var(--font-size-stat); line-height: var(--text-heading-1-leading); }
 .maka-stat-tile-value-filled { font-size: var(--font-size-ui); line-height: var(--text-body-leading); }
 .maka-stat-tile-value-info { color: var(--info-text); }


### PR DESCRIPTION
## Summary

Leading had three vocabularies: four product semantic ratios in `maka-tokens.css`, Astryx's per-role tiers, and `--maka-line-body`. Two of them disagreed about body copy — 21px against 20px at the 14px tier — and both looked deliberate. #1857 converged size and left this deliberately for its own PR.

They were not different numbers but different *methods*, which is why retuning could not work. A unitless ratio is one value spread across every tier it is used at; Astryx snaps each tier's line box to the 4px grid and reports the quotient (`expandTypeScale.ts`: target 1.5 under 20px, 1.4 through 31px, 1.25 above, snapped, floor size + 4), so 1.4286 is 20/14 rather than a chosen ratio. No single ratio sits on the grid at 12, 14, 16 and 22px at once. Astryx removed the same named tiers in its own v0.0.8 codemod, its docs say "you should never need to set line-height manually", and its Badge, Kbd, Button and Item carry role leadings inside boxes sized off the same 4px scale — which is why it ships no `line-height: 1` escape hatch and this file no longer needs one.

So the four tiers are deleted and all 130 declaring sites — including the eight bare literals in `packages/ui/src/styles.css` — name the role sized like the size they declare. The leading is a pure function of size, so the role name is chosen for readability and carries no visual consequence.

Two further changes came out of measurement rather than the stylesheets:

- Astryx's reset puts `line-height: 1.5` on `:where(html)`, so every element that declared no leading inherited it — measured 21px at the body tier across hundreds of nodes, owned by no stylesheet in this repo. `body` now declares the body role next to the body size it already had.
- A unitless leading still inherits as a ratio, so an element that inherits one and overrides its own size lands off the grid again. Measured, `.maka-attachment-file-content` held one 1.25 for a 14px name and a 12px size at once, and `.maka-onboarding-setup header h1` took a 16px rule's leading at 18px. Leading therefore belongs on the element that sets the size, and the 212 blocks that declared a size without one now declare both.

One deliberate move worth flagging: the transcript's Markdown `h1` was pinned to `--maka-line-body` so a turn read as one rhythm. At 16px that 20px box is the 14px tier's, one step tight for the tier the heading sits at, so it takes `--text-large-leading` (24px) — the next step of the same grid, not a different one.

Refs #1875 — the follow-up that makes the call site name a role instead of restating values, which cannot ride along here because the CSS-native form resets weight and family.

## Verification

`npm run lint`, `npm run format:check`, `npm run typecheck`, `npm --workspace @maka/desktop run test` (1321 pass), `npm --workspace @maka/ui run test` (239 pass), `npm --workspace @maka/desktop run e2e` (71 pass), `node scripts/check-dead-css.mjs --check`, `npm run astryx:theme -- --check` — all green.

One earlier full e2e run failed 4 specs (`providers` ×3, `quote-companion`) inside the window fixture; both subsequent full runs passed 71/71, and each of those specs passes in isolation. Flagging it rather than hiding it — nothing in the diff touches those paths.

**Measured, not inferred.** A temporary harness booted the existing fixtures and swept every rendered element with its own text against Astryx's grid rule, in six scenarios:

| | off-grid text elements | distinct shapes |
|---|---|---|
| before | 544 | 50 |
| after the 130 declaring sites | 260 | 20 |
| after `body` + the 212 size-only blocks | **1** | 1 |

The remaining one is upstream: Astryx's own `TextArea` counter row declares `--text-supporting-size` with no matching leading (`TextArea.tsx`, against `TabMenu.tsx` which declares both).

Live perturbation — applying the proposed leading in the running document and remeasuring the box — is what separated the chips that grow from the ones whose height is pinned: `.maka-plan-card-run` did not move, `.maka-message-time-inline` grew 8px inside a parent that did not, `.settingsPageHeader h2` moved +4.5px with its parent. No padding was touched; where a box grows, it grows.

Screenshot diffs (ImageMagick `compare -metric AE`, six scenarios captured before and after from the live app): permission-settings 2.7% of pixels, plan-reminders 1.7%, bot-settings 0.9%, sandbox-boundary 0.4%, skills 0.01%, transcript **0 px** — the transcript already read Astryx's leading, which is exactly what the token comment claimed before this PR and is now confirmed rather than assumed.

Every guard added here was mutation-verified and restored: redefining a `--leading-*` tier, referencing one, a literal ratio, a leading from the wrong tier, a size declared with no leading, and `body` losing its leading each fail the contract; moving the document default off the body tier and giving a rendered element an off-grid leading through a block with no `font-size` each fail e2e *while the contract stays green* — which is what shows the two guards are not covering for each other.

<img width="4964" height="1642" alt="image" src="https://github.com/user-attachments/assets/f1ea9aa1-83cd-4776-8bbd-3fe9242f0169" />
<img width="4964" height="1642" alt="image" src="https://github.com/user-attachments/assets/8d387ca7-024a-4af9-9682-9b2c2bb00261" />
<img width="4964" height="1642" alt="image" src="https://github.com/user-attachments/assets/35b87f4a-fbff-42eb-8938-71f2377903f6" />
<img width="4964" height="1642" alt="image" src="https://github.com/user-attachments/assets/03bbcc81-502b-4beb-89b7-6fef6d7e64e1" />

## After review

Three independent reviews ran against the first two commits. None found a rendering defect; all three converged on the same hole in the guards, and one found a factual overreach in a comment. Both are fixed here, each mutation-verified.

**The pairing contract was one-directional.** It checked size → leading and deferred leading-without-size to the e2e grid sweep. Measured, that sweep renders 129 elements with their own text out of the 323 classes whose rules declare a leading, and none of the three leading-only blocks in the tree appear in it — so the class had no coverage in either place, while `maka-tokens.css` bans it in prose. The check is now bidirectional and the three blocks are gone: `.maka-stat-tile-value` was dead (`stat-tile.tsx` always appends `-outline` or `-filled`, and both declare their own pair), the other two were redundant with what they inherit. Rendering is unchanged — e2e stays 71/71 with the sweep still empty.

Five further bypasses were demonstrated and closed, each with a mutation that fails now and passed before: an Astryx leading role rebound to a literal (the likeliest regression shape, since token rebinding is this branch's own mechanism); `font: 12px/1.9 sans` smuggling both halves past every longhand scan, through a backstop helper that had no caller anywhere outside its own unit test; `font-size: 18px` skipping the pairing check entirely — the exact drift the test's own comment cites; the scanner reading the first declaration where CSS takes the last; and `parseCssBlocks` matching only innermost blocks, so one nested rule erased its parent's declarations from every scan built on it. `line-height : 1.9` was also unseen, because biome excludes both directories and nothing normalizes the whitespace.

**The e2e sweep recomputed Astryx's floor wrong** — `max(snapped, size + 4)` against `computeLeading`'s `max(snapped, ceil((size + 4) / 4) * 4)`. Recomputing rather than copying a table only tracks an Astryx change if it is the same arithmetic; at a 9px tier the two disagree, and the sweep would have accepted 13px and rejected Astryx's own 16px. Verified identical across 8–40px after the fix.

**One comment claimed more than the source supports.** `maka-tokens.css` said Astryx ships no `line-height: 1` escape hatch. It ships exactly one — the sortable table's 10px rank glyph, behind a lint exception reading "no token for lineHeight:1 (tight badge)". The comment now names it and says why nothing here is in that position, instead of resting on a false absolute. The e2e vendor-gap note also listed one `TextArea` gap where there are two: under `(pointer: coarse)` it raises the input to `max(1rem, --text-body-size)` without raising the leading, rendering 22.86px at 16px where the grid wants 24. Both are upstream, and no scan in this repo covers vendor component styles.

**Considered and rejected:** declaring an absolute `20px` leading on `body` and deleting the ~326 declarations at the 12px and 14px tiers, which today share one 20px line box. The identity is a coincidence of the current scale — 12 × 1.5 and 14 × 1.5 both snap to 20 — not an invariant, so an Astryx retune would silently mis-render every site that had no declaration of its own to move. Naming the role at each site is what makes a scale change propagate. It also makes a leaf's correctness independent of what any ancestor declares, which inherited length cannot.

## Review focus

This moves 342 declaration blocks. The direction is uniform: at the 14px body tier text tightens 1px, and everywhere else it loosens — 12px body copy +2px, 12px dense zones +3.5px, 16px titles +4px, the large headings +4.5 to +5px, and the former `line-height: 1` chips +6 to +8px inside boxes that mostly do not move. If any of those reads as too airy, the argument to have is about Astryx's density opinion, not about this PR's mechanism.

