### PR TITLE
fix(ui): move the single-line chip family onto Astryx Badge

### DIFF
--- a/apps/desktop/e2e/type-scale.spec.ts
+++ b/apps/desktop/e2e/type-scale.spec.ts
@@ -220,6 +220,57 @@ test('resolves one type scale from the root down to the transcript', async ({
     expect(offGrid).toEqual([]);
   });
 
+  await test.step('a chip box does not move when its own leading does', async () => {
+    // #1879. The whole file above proves the leading is one scale; this asks
+    // the question that outlives any particular leading — can a leading change
+    // still be a layout change? A pinned box says no by construction, and the
+    // only way to show it is to move the leading and remeasure, which is what
+    // no text contract can do: `height: var(--h-control-xs)` next to
+    // `line-height: var(--text-supporting-leading)` reads as pinned whether or
+    // not the two resolve to compatible lengths in a live document.
+    //
+    // Bumped to 40px rather than nudged, so the assertion is "did not move at
+    // all" instead of "moved within tolerance".
+    // Measured on the PARENT as well as the box. A non-replaced `display:
+    // inline` chip's own border-box height is its font content area and does
+    // not track leading at all, so a probe that reads only the chip reports
+    // "did not move" for a chip whose line box is pushing its row open. The
+    // parent delta is the one measure that covers inline, block and flex.
+    const time = await page
+      .locator('.maka-message-time-inline')
+      .first()
+      .evaluate((el: HTMLElement) => {
+        const parent = el.parentElement!;
+        const before = el.getBoundingClientRect().height;
+        const parentBefore = parent.getBoundingClientRect().height;
+        // The floor, measured rather than computed: what this box would be if
+        // it were not pinned — its line box plus its own padding and border.
+        // A tier below that number does not clip visibly (the line box centres
+        // and the ink still fits) but it silently voids the padding the rule
+        // declares, which is how eleven chips shipped 2-4px shorter than they
+        // read.
+        el.style.setProperty('height', 'auto', 'important');
+        const natural = el.getBoundingClientRect().height;
+        el.style.removeProperty('height');
+        el.style.setProperty('line-height', '40px', 'important');
+        const after = el.getBoundingClientRect().height;
+        const parentAfter = parent.getBoundingClientRect().height;
+        el.style.removeProperty('line-height');
+        return { before, after, natural, parentBefore, parentAfter };
+      });
+    expect(time.before).toBe(20); // --h-control-xs
+    expect(time.after).toBe(time.before); // was 20 -> 40 before the pin
+    expect(time.parentAfter).toBe(time.parentBefore); // and took the meta row with it
+
+    // "Did not move" and "holds its content" are different claims, and a pin
+    // converts the first failure mode into the second. An earlier revision
+    // asserted `scrollHeight <= clientHeight` and was inert twice over: it read
+    // both values AFTER restoring the leading, and on an `overflow: visible`
+    // box the two are equal even while the line box overflows. The tier vs its
+    // own floor is the measure that can actually fail.
+    expect(time.natural).toBeLessThanOrEqual(time.before);
+  });
+
   await test.step('code elements resolve the theme mono stack, not the reset one', async () => {
     expect(
       await page.evaluate(() => {
@@ -289,5 +340,143 @@ test('resolves one type scale from the root down to the transcript', async ({
         return family;
       }),
     ).not.toContain('Geist Mono');
+  });
+});
+
+/**
+ * #1879, the half of the chip invariant the transcript window cannot show.
+ *
+ * Two claims that pull in opposite directions, which is why they belong in one
+ * test: a single-line chip must NOT move when its leading moves, and a box that
+ * wraps MUST still grow with its content. Pinning everything satisfies the
+ * first and breaks the second.
+ *
+ * Both halves assert RELATIVELY. An earlier revision wrote the measured
+ * outcome of a viewport squeeze into the assertion — `{height: 42, rows: 2}` at
+ * 480px — and CI Linux produced `{height: 20, rows: 1}`: the wrap slack was
+ * -4.75px against 244.75px of content, i.e. 1.9%, and the CJK font stack
+ * resolves to different families per platform. A wrap threshold is a font
+ * metric, not an invariant. So the content is made to wrap by construction and
+ * the assertion is "grew", not "grew to N".
+ *
+ * Reuses the existing fixture rather than adding one, per AGENTS.md. Measured,
+ * no booted window renders a chip above `--h-control-xs`:
+ * `.maka-composer-model-chip`, `.plan-proposal-step-number`,
+ * `.maka-skill-governance-summary span`, `.maka-quote-action`,
+ * `.maka-composer-revision-notice` and `.settingsUsage{DetailToggle,RecordCount}`
+ * all resolve to zero nodes in both fixtures. So the floor assertion below
+ * proves the MECHANISM (a tier must hold its own content) on three chips whose
+ * slack is zero by construction, and not the TIER CHOICE for sm/md/lg — that
+ * stays arithmetic in `type-scale-contract.test.ts`, where each rule states its
+ * own floor. Booting those surfaces is a fixture change, not a test change, and
+ * it does not belong to this one.
+ */
+test('pins single-line chips without pinning the boxes that wrap', async ({
+  planRemindersWindow: page,
+}) => {
+  await test.step('every rung of the control ruler resolves to a number', async () => {
+    // `--h-control-md/lg/xl` are `var(--size-element-sm/md/lg)`, and those are
+    // declared by Astryx's own generated sheet, outside every static scan in
+    // this repo (bare imports are skipped by design). If an upgrade renames or
+    // drops them, `height: var(--h-control-md)` becomes invalid at
+    // computed-value time and falls back to `auto` — #1879 on every md/lg/xl
+    // control at once, with nothing in the text contracts able to see it.
+    // Nothing else in the suite resolves these to numbers.
+    const rungs = await page.evaluate(() => {
+      const out: Record<string, number> = {};
+      for (const rung of ['xs', 'sm', 'md', 'lg', 'xl', '2xl']) {
+        // A FRESH element per rung, and the `var()` written into the
+        // declaration rather than resolved in JS first. Reassigning
+        // `style.height` on one reused probe reported the first rung's height
+        // for every rung — the inline value updated and the computed value did
+        // not — so the reuse form measured 20px six times and would have
+        // passed a ruler that had collapsed to a single rung.
+        const probe = document.createElement('div');
+        probe.style.cssText = `position:fixed;top:0;left:0;width:1px;visibility:hidden;height:var(--h-control-${rung});`;
+        document.documentElement.append(probe);
+        out[rung] = probe.getBoundingClientRect().height;
+        probe.remove();
+      }
+      return out;
+    });
+    expect(rungs).toEqual({ xs: 20, sm: 24, md: 28, lg: 32, xl: 36, '2xl': 40 });
+  });
+
+  await test.step('the pinned chips hold their box against a 40px leading', async () => {
+    // Both measured at 20px holding a 20px line box, and both doubled under
+    // this bump before the pin. `.maka-plan-card-countdown` is in none of
+    // #1879's lists — it was found by measuring, and it is one of the "12px
+    // badges" that issue's scope names: real pill chrome, no height of its own.
+    for (const selector of ['.maka-nav-kbd', '.maka-plan-card-countdown']) {
+      const box = await page.locator(selector).first().evaluate((el: HTMLElement) => {
+        const parent = el.parentElement!;
+        const before = el.getBoundingClientRect().height;
+        const parentBefore = parent.getBoundingClientRect().height;
+        // The floor, measured rather than computed: what this box would be if
+        // it were not pinned — its line box plus its own padding and border.
+        // A tier below that number does not clip visibly (the line box centres
+        // and the ink still fits) but it silently voids the padding the rule
+        // declares, which is how eleven chips shipped 2-4px shorter than they
+        // read.
+        el.style.setProperty('height', 'auto', 'important');
+        const natural = el.getBoundingClientRect().height;
+        el.style.removeProperty('height');
+        el.style.setProperty('line-height', '40px', 'important');
+        const after = el.getBoundingClientRect().height;
+        const parentAfter = parent.getBoundingClientRect().height;
+        el.style.removeProperty('line-height');
+        return { before, after, natural, parentBefore, parentAfter };
+      });
+      expect(box.before, `${selector} sits on --h-control-xs`).toBe(20);
+      expect(box.after, `${selector} must not move with its leading`).toBe(box.before);
+      expect(box.parentAfter, `${selector} must not push its row open`).toBe(box.parentBefore);
+      expect(box.natural, `${selector} must sit on a tier that holds its own floor`).toBeLessThanOrEqual(box.before);
+    }
+  });
+
+  await test.step('the boxes that wrap still grow with their content', async () => {
+    // The guard against over-applying the fix, and the one #1879 would have
+    // got wrong: it read `.maka-plan-card-run` as already pinned and offered it
+    // as the shape for the rest.
+    //
+    // The message is the row's LAST child. An earlier revision took
+    // `> span` .first(), which is the Astryx Badge — itself a `span` with its
+    // own `white-space: nowrap`. Writing a long string into it blew the nowrap
+    // flex row out sideways and squeezed the untouched real message to one
+    // character per line, which is where that revision's "220px" came from: an
+    // artifact that stayed 220px for `.repeat(2)` through `.repeat(12)`.
+    const grow = (selector: string, child: string) =>
+      page.locator(selector).first().evaluate(
+        (el: HTMLElement, sel: string) => {
+          const target = el.querySelector(sel) as HTMLElement | null;
+          if (!target) return { before: -1, after: -1 };
+          const previous = target.textContent;
+          const before = el.getBoundingClientRect().height;
+          target.textContent = '这是一条很长的运行结果消息用来验证它是否会真的换行'.repeat(4);
+          const after = el.getBoundingClientRect().height;
+          target.textContent = previous;
+          return { before, after };
+        },
+        child,
+      );
+
+    const run = await grow('.maka-plan-card-run', ':scope > span:last-child');
+    expect(run.before, 'the run row starts as one line').toBe(20);
+    expect(run.after, 'a long run message must not be clipped to one line').toBeGreaterThan(run.before);
+
+    // Same question for the schedule row, constrained at the element rather
+    // than by resizing the window: a max-width derived from its own scrollWidth
+    // forces a wrap at any font metric, on any platform.
+    const schedule = await page.locator('.maka-plan-card-schedule').first().evaluate((el: HTMLElement) => {
+      const rowCount = () => new Set([...el.children].map((c) => Math.round(c.getBoundingClientRect().top))).size;
+      const before = { height: el.getBoundingClientRect().height, rows: rowCount() };
+      el.style.maxWidth = `${Math.ceil(el.scrollWidth / 2)}px`;
+      const after = { height: el.getBoundingClientRect().height, rows: rowCount() };
+      el.style.removeProperty('max-width');
+      return { before, after };
+    });
+    expect(schedule.before.rows, 'the schedule row starts as one line').toBe(1);
+    expect(schedule.after.rows, 'the schedule row must wrap rather than clip').toBeGreaterThan(schedule.before.rows);
+    expect(schedule.after.height).toBeGreaterThan(schedule.before.height);
   });
 });

--- a/apps/desktop/e2e/type-scale.spec.ts
+++ b/apps/desktop/e2e/type-scale.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from './fixtures.js';
 
 // The one thing the type-scale CSS contracts cannot prove.
@@ -27,6 +28,53 @@ import { expect, test } from './fixtures.js';
 // `<code>` gets is decided by `reset` preceding `base` — an ordering no
 // contract in this repo asserts. Asserting the rule's text only proves it was
 // written, not that it wins.
+/**
+ * A chip's box, its parent's box, and its own natural floor, measured before
+ * and after its leading is forced to 40px.
+ *
+ * One helper rather than the same twenty lines pasted at each call site: the
+ * probe is subtle (it must restore what it mutates, read the floor with the
+ * pin lifted, and measure the PARENT as well as the box) and two copies of a
+ * subtle probe drift into two different measurements of the same thing.
+ *
+ * Bumped to 40px rather than nudged, so the assertion is "did not move at all"
+ * instead of "moved within tolerance". Measured on the parent as well, because
+ * a non-replaced `display: inline` chip's own border-box height is its font
+ * content area and does not track leading at all — a probe that reads only the
+ * chip reports "did not move" for a chip whose line box is pushing its row
+ * open. The parent delta is the one measure that covers inline, block and flex.
+ *
+ * `natural` is the floor, measured rather than computed: what this box would be
+ * if it were not pinned — its line box plus its own padding and border. A tier
+ * below that number does not clip visibly (the line box centres and the ink
+ * still fits) but it silently voids the padding the rule declares, which is how
+ * eleven chips shipped 2-4px shorter than they read.
+ */
+async function measureUnderLeadingBump(page: Page, selector: string) {
+  return page.locator(selector).first().evaluate((el: HTMLElement) => {
+    const parent = el.parentElement!;
+    const before = el.getBoundingClientRect().height;
+    const parentBefore = parent.getBoundingClientRect().height;
+    el.style.setProperty('height', 'auto', 'important');
+    const natural = el.getBoundingClientRect().height;
+    el.style.removeProperty('height');
+    el.style.setProperty('line-height', '40px', 'important');
+    const after = el.getBoundingClientRect().height;
+    const parentAfter = parent.getBoundingClientRect().height;
+    el.style.removeProperty('line-height');
+    return { before, after, natural, parentBefore, parentAfter };
+  });
+}
+
+/** The four assertions every pinned chip owes, in one place so a new chip is a
+ * one-line addition rather than another copy of the probe. */
+function expectHoldsItsBox(box: Awaited<ReturnType<typeof measureUnderLeadingBump>>, selector: string, tier: number) {
+  expect(box.before, `${selector} sits on its declared tier`).toBe(tier);
+  expect(box.after, `${selector} must not move with its leading`).toBe(box.before);
+  expect(box.parentAfter, `${selector} must not push its row open`).toBe(box.parentBefore);
+  expect(box.natural, `${selector} must sit on a tier that holds its own floor`).toBeLessThanOrEqual(box.before);
+}
+
 test('resolves one type scale from the root down to the transcript', async ({
   disclosureOutputWindow: page,
 }) => {
@@ -225,50 +273,21 @@ test('resolves one type scale from the root down to the transcript', async ({
     // the question that outlives any particular leading — can a leading change
     // still be a layout change? A pinned box says no by construction, and the
     // only way to show it is to move the leading and remeasure, which is what
-    // no text contract can do: `height: var(--h-control-xs)` next to
-    // `line-height: var(--text-supporting-leading)` reads as pinned whether or
-    // not the two resolve to compatible lengths in a live document.
+    // no text contract can do: `height: var(--h-control-xs)` next to a
+    // supporting role reads as pinned whether or not the two resolve to
+    // compatible lengths in a live document.
     //
-    // Bumped to 40px rather than nudged, so the assertion is "did not move at
-    // all" instead of "moved within tolerance".
-    // Measured on the PARENT as well as the box. A non-replaced `display:
-    // inline` chip's own border-box height is its font content area and does
-    // not track leading at all, so a probe that reads only the chip reports
-    // "did not move" for a chip whose line box is pushing its row open. The
-    // parent delta is the one measure that covers inline, block and flex.
-    const time = await page
-      .locator('.maka-message-time-inline')
-      .first()
-      .evaluate((el: HTMLElement) => {
-        const parent = el.parentElement!;
-        const before = el.getBoundingClientRect().height;
-        const parentBefore = parent.getBoundingClientRect().height;
-        // The floor, measured rather than computed: what this box would be if
-        // it were not pinned — its line box plus its own padding and border.
-        // A tier below that number does not clip visibly (the line box centres
-        // and the ink still fits) but it silently voids the padding the rule
-        // declares, which is how eleven chips shipped 2-4px shorter than they
-        // read.
-        el.style.setProperty('height', 'auto', 'important');
-        const natural = el.getBoundingClientRect().height;
-        el.style.removeProperty('height');
-        el.style.setProperty('line-height', '40px', 'important');
-        const after = el.getBoundingClientRect().height;
-        const parentAfter = parent.getBoundingClientRect().height;
-        el.style.removeProperty('line-height');
-        return { before, after, natural, parentBefore, parentAfter };
-      });
-    expect(time.before).toBe(20); // --h-control-xs
-    expect(time.after).toBe(time.before); // was 20 -> 40 before the pin
-    expect(time.parentAfter).toBe(time.parentBefore); // and took the meta row with it
-
     // "Did not move" and "holds its content" are different claims, and a pin
     // converts the first failure mode into the second. An earlier revision
     // asserted `scrollHeight <= clientHeight` and was inert twice over: it read
     // both values AFTER restoring the leading, and on an `overflow: visible`
     // box the two are equal even while the line box overflows. The tier vs its
-    // own floor is the measure that can actually fail.
-    expect(time.natural).toBeLessThanOrEqual(time.before);
+    // own floor is the measure that can actually fail — see the helper.
+    expectHoldsItsBox(
+      await measureUnderLeadingBump(page, '.maka-message-time-inline'),
+      '.maka-message-time-inline',
+      20, // --h-control-xs; was 20 -> 40 before the pin, and took the meta row with it
+    );
   });
 
   await test.step('code elements resolve the theme mono stack, not the reset one', async () => {
@@ -403,34 +422,15 @@ test('pins single-line chips without pinning the boxes that wrap', async ({
   });
 
   await test.step('the pinned chips hold their box against a 40px leading', async () => {
-    // Both measured at 20px holding a 20px line box, and both doubled under
-    // this bump before the pin. `.maka-plan-card-countdown` is in none of
-    // #1879's lists — it was found by measuring, and it is one of the "12px
-    // badges" that issue's scope names: real pill chrome, no height of its own.
-    for (const selector of ['.maka-nav-kbd', '.maka-plan-card-countdown']) {
-      const box = await page.locator(selector).first().evaluate((el: HTMLElement) => {
-        const parent = el.parentElement!;
-        const before = el.getBoundingClientRect().height;
-        const parentBefore = parent.getBoundingClientRect().height;
-        // The floor, measured rather than computed: what this box would be if
-        // it were not pinned — its line box plus its own padding and border.
-        // A tier below that number does not clip visibly (the line box centres
-        // and the ink still fits) but it silently voids the padding the rule
-        // declares, which is how eleven chips shipped 2-4px shorter than they
-        // read.
-        el.style.setProperty('height', 'auto', 'important');
-        const natural = el.getBoundingClientRect().height;
-        el.style.removeProperty('height');
-        el.style.setProperty('line-height', '40px', 'important');
-        const after = el.getBoundingClientRect().height;
-        const parentAfter = parent.getBoundingClientRect().height;
-        el.style.removeProperty('line-height');
-        return { before, after, natural, parentBefore, parentAfter };
-      });
-      expect(box.before, `${selector} sits on --h-control-xs`).toBe(20);
-      expect(box.after, `${selector} must not move with its leading`).toBe(box.before);
-      expect(box.parentAfter, `${selector} must not push its row open`).toBe(box.parentBefore);
-      expect(box.natural, `${selector} must sit on a tier that holds its own floor`).toBeLessThanOrEqual(box.before);
+    // Each doubled under this bump before its pin. `.maka-plan-card-countdown`
+    // is in none of #1879's lists — it was found by measuring, and it is one of
+    // the "12px badges" that issue's scope names: real pill chrome, no height
+    // of its own.
+    for (const [selector, tier] of [
+      ['.maka-nav-kbd', 20],
+      ['.maka-plan-card-countdown', 20],
+    ] as const) {
+      expectHoldsItsBox(await measureUnderLeadingBump(page, selector), selector, tier);
     }
   });
 

--- a/apps/desktop/e2e/type-scale.spec.ts
+++ b/apps/desktop/e2e/type-scale.spec.ts
@@ -383,12 +383,21 @@ test('resolves one type scale from the root down to the transcript', async ({
  * `.maka-composer-model-chip`, `.plan-proposal-step-number`,
  * `.maka-skill-governance-summary span`, `.maka-quote-action`,
  * `.maka-composer-revision-notice` and `.settingsUsage{DetailToggle,RecordCount}`
- * all resolve to zero nodes in both fixtures. So the floor assertion below
- * proves the MECHANISM (a tier must hold its own content) on three chips whose
- * slack is zero by construction, and not the TIER CHOICE for sm/md/lg — that
- * stays arithmetic in `type-scale-contract.test.ts`, where each rule states its
- * own floor. Booting those surfaces is a fixture change, not a test change, and
- * it does not belong to this one.
+ * all resolve to zero nodes in both fixtures, and so do the four chips pinned
+ * last — `.maka-quote-chip-collapsed`, `.maka-deep-research-run-count`,
+ * `.maka-firstrun-step` and `.maka-mcp-install-button` (measured with a
+ * throwaway probe against both booted windows, with `.maka-turn` and
+ * `.maka-nav-kbd` as controls).
+ *
+ * So the floor assertion below proves the MECHANISM (a tier must hold its own
+ * content) on three chips whose slack is zero by construction, and not the
+ * TIER CHOICE for sm/md/lg. That choice is UNASSERTED, deliberately and
+ * stated plainly rather than credited to a check elsewhere: a floor is a live
+ * metric — a font's line box, or a 21px child dot — so no text contract can
+ * compute it, and each rule records the number it was measured at in its own
+ * comment. A padding change that lifts a floor past its tier is caught by
+ * reading, not by this suite. Booting those surfaces is a fixture change, not
+ * a test change, and it does not belong to this one.
  */
 test('pins single-line chips without pinning the boxes that wrap', async ({
   planRemindersWindow: page,

--- a/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
@@ -36,6 +36,7 @@ import { describe, it, after } from 'node:test';
 import {
   expandCssImports,
   findTextRoleOffenders,
+  mergeBySelector,
   parseCssBlocks,
   stripCssComments,
   assertCustomPropPinnedOnce,
@@ -234,7 +235,19 @@ describe('css-test-helpers', () => {
     it('keeps a parent rule’s declarations when a nested rule follows them', () => {
       const css = '.a { font-size: 18px; & span { color: red; } }';
       assert.deepEqual(props(css, '.a'), ['font-size']);
-      assert.deepEqual(props(css, '& span'), ['color']);
+      // Resolved against the parent, not emitted as the literal `& span`. The
+      // raw form is a key every nested rule in the tree collides on, and one
+      // that no scan keyed on real selectors can ever reach.
+      assert.deepEqual(props(css, '.a span'), ['color']);
+    });
+
+    it('resolves a bare nested selector as a descendant', () => {
+      assert.deepEqual(props('.a { span { color: red; } }', '.a span'), ['color']);
+    });
+
+    it('resolves `&` in every position it can take', () => {
+      assert.deepEqual(props('.a { &:hover { color: red; } }', '.a:hover'), ['color']);
+      assert.deepEqual(props('.a { .b & { color: red; } }', '.b .a'), ['color']);
     });
 
     it('keeps a parent rule’s declarations that follow the nested rule', () => {
@@ -439,6 +452,51 @@ describe('css-test-helpers', () => {
 
     it('strips comments before parsing (inline comment after value)', () => {
       assert.doesNotThrow(() => assertCustomPropPinnedOnce('--leading-none: 1;        /* single-line: kbd */', '--leading-none', '1'));
+    });
+  });
+
+  describe('mergeBySelector (one box per selector, unconditional only)', () => {
+    it('merges rules that name the same selector, in source order', () => {
+      const merged = mergeBySelector('.a { border-radius: 9999px; }\n.a { height: 20px; }');
+      assert.match(merged.get('.a') ?? '', /border-radius/);
+      assert.match(merged.get('.a') ?? '', /height:\s*20px/);
+    });
+
+    it('merges a selector reached through a group with one reached on its own', () => {
+      const merged = mergeBySelector('.a, .b { border-radius: 9999px; }\n.a { height: 20px; }');
+      assert.match(merged.get('.a') ?? '', /border-radius/);
+      assert.match(merged.get('.a') ?? '', /height:\s*20px/);
+      assert.match(merged.get('.b') ?? '', /border-radius/);
+    });
+
+    it('skips rules gated by a conditional at-rule', () => {
+      // Folding these in read a chip pinned only inside a breakpoint as pinned
+      // everywhere, and made a deliberate responsive unpin illegal. The
+      // unconditional box is what the box contracts are about.
+      const merged = mergeBySelector('.a { height: 20px; }\n@media (min-width: 900px) { .a { height: auto; } }');
+      assert.doesNotMatch(merged.get('.a') ?? '', /auto/);
+    });
+
+    it('keeps rules inside a non-conditional at-rule', () => {
+      const merged = mergeBySelector('@layer components { .a { height: 20px; } }');
+      assert.match(merged.get('.a') ?? '', /height:\s*20px/);
+    });
+
+    it('does not let a nested rule collide on a global `&` key', () => {
+      const merged = mergeBySelector('.a { & { color: red; } }\n.b { & { color: blue; } }');
+      assert.equal(merged.get('&'), undefined);
+      assert.match(merged.get('.a') ?? '', /red/);
+      assert.match(merged.get('.b') ?? '', /blue/);
+    });
+
+    it('keeps a qualified override as its own key', () => {
+      // Documented limitation, asserted so it cannot change silently: this
+      // models one rule per selector, not the cascade. `.wrap .a` is a
+      // different box here, and what covers it is the Badge call-site contract
+      // and the live e2e measurement.
+      const merged = mergeBySelector('.a { height: 20px; }\n.wrap .a { height: auto; }');
+      assert.doesNotMatch(merged.get('.a') ?? '', /auto/);
+      assert.match(merged.get('.wrap .a') ?? '', /auto/);
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
@@ -35,6 +35,8 @@ import { join } from 'node:path';
 import { describe, it, after } from 'node:test';
 import {
   expandCssImports,
+  findBadgeClassNames,
+  findDynamicBadgeClassNames,
   findTextRoleOffenders,
   mergeBySelector,
   parseCssBlocks,
@@ -497,6 +499,50 @@ describe('css-test-helpers', () => {
       const merged = mergeBySelector('.a { height: 20px; }\n.wrap .a { height: auto; }');
       assert.doesNotMatch(merged.get('.a') ?? '', /auto/);
       assert.match(merged.get('.wrap .a') ?? '', /auto/);
+    });
+  });
+
+  describe('findBadgeClassNames (a scanner that cannot quietly stop seeing a call site)', () => {
+    // A fresh dir per case: one shared root would let each case see every
+    // other case's fixture, and `deepEqual` on the whole result would then be
+    // asserting the suite's execution order rather than the scanner.
+    const dirs: string[] = [];
+    const write = async (name: string, src: string) => {
+      const dir = await mkdtemp(join(tmpdir(), 'badge-scan-'));
+      dirs.push(dir);
+      await writeFile(join(dir, name), src, 'utf8');
+      return dir;
+    };
+    after(async () => {
+      await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    });
+
+    it('reads a className past a `>` inside a prop expression', async () => {
+      // `/<Badge\b[^>]*?>/` ended the tag at the `>` in the ternary, and the
+      // truncated text held neither `className="` nor `className={` — so the
+      // call site left BOTH Badge contracts while they reported green.
+      const root = await write('gt.tsx', `<Badge label={a > b ? 'x' : 'y'} className="evil" />`);
+      assert.deepEqual((await findBadgeClassNames([root])).map((f) => f.className), ['evil']);
+    });
+
+    it('reads a className past an apostrophe inside a prop comment', async () => {
+      // Measured on the real tree: `/* the Tooltip's popover */` inside a
+      // `<Badge>` put a quote-aware walk into string mode at the apostrophe and
+      // carried the tag end past its own `/>`. Three live call sites silently
+      // left the scan, which still reported green on the other 16.
+      const root = await write('apos.tsx', `<Badge\n  label="x"\n  /* the Tooltip's popover is display:none */\n  className="quiet"\n/>`);
+      assert.deepEqual((await findBadgeClassNames([root])).map((f) => f.className), ['quiet']);
+    });
+
+    it('reads both quote styles and whitespace around `=`', async () => {
+      const root = await write('quotes.tsx', `<Badge className = 'spaced' label="x" />`);
+      assert.deepEqual((await findBadgeClassNames([root])).map((f) => f.className), ['spaced']);
+    });
+
+    it('still routes a computed className to the dynamic scanner', async () => {
+      const root = await write('dyn.tsx', `<Badge label={a > b} className={cls} />`);
+      assert.deepEqual(await findBadgeClassNames([root]), []);
+      assert.equal((await findDynamicBadgeClassNames([root])).length, 1);
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
@@ -36,7 +36,9 @@ import { describe, it, after } from 'node:test';
 import {
   expandCssImports,
   findBadgeClassNames,
-  findDynamicBadgeClassNames,
+  findUnreadableBadgeCallSites,
+  mergeByContext,
+  UNCONDITIONAL,
   findTextRoleOffenders,
   mergeBySelector,
   parseCssBlocks,
@@ -539,10 +541,60 @@ describe('css-test-helpers', () => {
       assert.deepEqual((await findBadgeClassNames([root])).map((f) => f.className), ['spaced']);
     });
 
-    it('still routes a computed className to the dynamic scanner', async () => {
+    it('reads a className past a `>` inside a line comment', async () => {
+      // The other spelling of the comment above, and the same failure: a `//`
+      // holding a `>` ends the tag there.
+      const root = await write('line.tsx', `<Badge\n  // show this when a > b\n  className="commented"\n/>`);
+      assert.deepEqual((await findBadgeClassNames([root])).map((f) => f.className), ['commented']);
+    });
+
+    it('reports a computed className as unreadable', async () => {
       const root = await write('dyn.tsx', `<Badge label={a > b} className={cls} />`);
       assert.deepEqual(await findBadgeClassNames([root]), []);
-      assert.equal((await findDynamicBadgeClassNames([root])).length, 1);
+      assert.equal((await findUnreadableBadgeCallSites([root])).length, 1);
+    });
+
+    it('reports a spread call site as unreadable rather than as class-less', async () => {
+      // Legal JSX that neither scanner could read: the static one finds no
+      // `className="…"` and the computed one finds no `className={`, so the
+      // geometry contract concluded there was nothing to govern. Measured on a
+      // real call site, with a `height` added to the class it hides — green.
+      const root = await write('spread.tsx', `<Badge {...{ className: 'hidden' }} label="x" />`);
+      assert.deepEqual(await findBadgeClassNames([root]), []);
+      assert.equal((await findUnreadableBadgeCallSites([root])).length, 1);
+    });
+
+    it('does not read a spread inside a prop expression as a prop spread', async () => {
+      const root = await write('inner.tsx', `<Badge label={[...parts]} className="readable" />`);
+      assert.deepEqual((await findBadgeClassNames([root])).map((f) => f.className), ['readable']);
+      assert.deepEqual(await findUnreadableBadgeCallSites([root]), []);
+    });
+  });
+
+  describe('mergeByContext (one box per selector PER cascade context)', () => {
+    it('keeps mutually exclusive conditions apart', () => {
+      // Flattened, `height: auto` here and `white-space: normal` there satisfy
+      // two independent matches while applying at no viewport at all.
+      const contexts = mergeByContext(
+        '@media (max-width: 620px) { .a { height: auto; } }\n@media (min-width: 621px) { .a { white-space: normal; } }',
+      );
+      const bodies = [...(contexts.get('.a') ?? new Map<string, string>()).values()];
+      assert.equal(bodies.length, 2);
+      assert.equal(bodies.filter((b) => /height/.test(b) && /white-space/.test(b)).length, 0);
+    });
+
+    it('keys unconditional declarations under UNCONDITIONAL', () => {
+      const contexts = mergeByContext('.a { height: 20px; }\n@media print { .a { height: auto; } }');
+      const byContext = contexts.get('.a') ?? new Map<string, string>();
+      assert.match(byContext.get(UNCONDITIONAL) ?? '', /20px/);
+      assert.match(byContext.get('@media print') ?? '', /auto/);
+    });
+
+    it('does not split one context on a cascade-only at-rule', () => {
+      // `@layer` changes how a rule cascades, not whether it applies.
+      const contexts = mergeByContext('.a { height: 20px; }\n@layer components { .a { color: red; } }');
+      const byContext = contexts.get('.a') ?? new Map<string, string>();
+      assert.deepEqual([...byContext.keys()], [UNCONDITIONAL]);
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -97,6 +97,59 @@ export function stripCssComments(src: string): string {
   return out;
 }
 
+/** Every first-party `.tsx` that can mount a renderer component. */
+export async function readTsxTree(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === 'node_modules' || entry.name === 'dist' ? [] : readTsxTree(path);
+    }
+    return entry.name.endsWith('.tsx') ? [path] : [];
+  }));
+  return files.flat().sort();
+}
+
+/**
+ * The `className`s handed to an Astryx `<Badge>`, with the file that does it.
+ *
+ * Deliberately a source scan and not a render: the invariant is about what
+ * product CSS is allowed to say to a Badge, and that is decidable from text.
+ * `className={cond ? 'a' : 'b'}` and other computed forms are not matched —
+ * they are reported by `findDynamicBadgeClassNames` instead, so a call site
+ * cannot leave this contract just by moving its class into an expression.
+ */
+export async function findBadgeClassNames(roots: string[]): Promise<{ file: string; className: string }[]> {
+  const out: { file: string; className: string }[] = [];
+  for (const root of roots) {
+    for (const file of await readTsxTree(root)) {
+      const src = await readFile(file, 'utf8');
+      for (const tag of src.matchAll(/<Badge\b[^>]*?\/?>/gs)) {
+        for (const attr of tag[0].matchAll(/\bclassName="([^"]*)"/g)) {
+          for (const one of attr[1].split(/\s+/).filter(Boolean)) {
+            out.push({ file, className: one });
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** `<Badge className={…}>` call sites, which the static contract cannot read. */
+export async function findDynamicBadgeClassNames(roots: string[]): Promise<string[]> {
+  const out: string[] = [];
+  for (const root of roots) {
+    for (const file of await readTsxTree(root)) {
+      const src = await readFile(file, 'utf8');
+      for (const tag of src.matchAll(/<Badge\b[^>]*?\/?>/gs)) {
+        if (/\bclassName=\{/.test(tag[0])) out.push(file);
+      }
+    }
+  }
+  return [...new Set(out)];
+}
+
 /** Escape a CSS selector for a RegExp, allowing flexible whitespace. */
 function escapeCssSelector(selector: string): string {
   return selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
@@ -359,7 +412,7 @@ export function parseCssBlocks(css: string): CssBlock[] {
     const rule = nearestRuleSelector(node);
     const conditions = enclosingConditions(node);
     if (node.type === 'rule') {
-      const selector = normalizeSelector(node.selector);
+      const selector = resolveNesting(normalizeSelector(node.selector), rule);
       out.push({ selector, rule: selector, conditions, decls });
     } else if (rule !== null) {
       out.push({ selector: `${rule} @${node.name} ${node.params}`.trim(), rule, conditions, decls });
@@ -370,6 +423,66 @@ export function parseCssBlocks(css: string): CssBlock[] {
 
 function normalizeSelector(selector: string): string {
   return selector.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * A nested rule's selector rewritten against its nearest style-rule ancestor.
+ *
+ * Without this, `.a { & { height: auto } }` is emitted under the literal key
+ * `&` — so it neither reaches `.a` (a false green) nor stays distinct from
+ * every OTHER nested rule in the tree, which all collide on that one key.
+ * Nothing in this tree nests today; that is exactly when it is cheapest to
+ * close, because the first nested rule someone writes would otherwise walk
+ * through every scan built on these blocks.
+ */
+function resolveNesting(selector: string, parent: string | null): string {
+  if (parent === null) return selector;
+  return splitSelectorList(selector)
+    .map((one) => (one.includes('&') ? one.replaceAll('&', parent) : `${parent} ${one}`))
+    .join(', ');
+}
+
+/** `@media`, `@supports` and `@container` gate WHETHER a rule applies;
+ * `@layer` and `@scope` only gate how it cascades. */
+const CONDITIONAL_AT = /^@(?:media|supports|container)\b/;
+
+/**
+ * Every selector's UNCONDITIONAL declarations, merged across every rule that
+ * names it, in source order.
+ *
+ * A chip whose type lives in one rule and whose pill chrome lives in another
+ * is one box to a browser and was two blocks to a per-block scan — which is
+ * how `.plan-proposal-revision` sat five lines from a selector the scan did
+ * catch and was invisible to it. Merging in source order also makes "the last
+ * declaration wins" true across files, not just within a block.
+ *
+ * What this is NOT, stated because the difference is load-bearing and easy to
+ * assume away: it is not the browser's computed value. It merges on the
+ * literal selector text, so it models one rule for one selector and nothing
+ * about the cascade around it.
+ *
+ *   - `.wrap .chip { height: auto }` is a DIFFERENT key from `.chip`, so it
+ *     neither relaxes nor triggers a check on `.chip`. Qualified overrides are
+ *     invisible here by construction. What covers them is the Badge call-site
+ *     contract and the live e2e measurements, not this.
+ *   - Conditional rules are skipped entirely rather than folded in. Folding
+ *     them made a chip pinned only inside a breakpoint read as pinned
+ *     everywhere (false green) AND made a deliberate responsive unpin illegal
+ *     (false red); dropping them keeps the unconditional box honest, which is
+ *     the box every contract here is about.
+ *   - `!important` is not modelled. Nothing in this tree uses it on the
+ *     properties these contracts read.
+ */
+export function mergeBySelector(css: string): Map<string, string> {
+  const merged = new Map<string, string>();
+  for (const { rule, conditions, decls } of parseCssBlocks(css)) {
+    if (conditions.some((c) => CONDITIONAL_AT.test(c))) continue;
+    const body = decls.map((d) => `${d.prop}: ${d.value};`).join(' ');
+    for (const one of splitSelectorList(rule)) {
+      merged.set(one, `${merged.get(one) ?? ''}${body} `);
+    }
+  }
+  return merged;
 }
 
 /** Every enclosing at-rule's `@name params`, outermost first. `@layer` counts:

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -111,6 +111,66 @@ export async function readTsxTree(dir: string): Promise<string[]> {
 }
 
 /**
+ * The opening tags of one JSX element, as raw text.
+ *
+ * A brace/quote-aware walk to the tag's real `>`, NOT `/<Tag\b[^>]*?>/`. That
+ * form ends at the first `>` ANYWHERE, including one inside a prop expression,
+ * so `<Badge label={a > b ? 'x' : 'y'} className="evil" />` matched as
+ * `<Badge label={a >` — and the truncated text contains neither
+ * `className="` nor `className={`, which took the call site out of BOTH Badge
+ * contracts while they reported green. A scan whose entire job is to stop a
+ * call site slipping out quietly cannot have a quiet exit of its own.
+ */
+function jsxOpeningTags(src: string, tagName: string): string[] {
+  const out: string[] = [];
+  const opener = new RegExp(`<${tagName}\\b`, 'g');
+  for (const match of src.matchAll(opener)) {
+    let depth = 0;
+    let quote: string | undefined;
+    let closed = false;
+    for (let i = match.index; i < src.length; i += 1) {
+      const ch = src[i];
+      if (quote) {
+        if (ch === '\\') i += 1;
+        else if (ch === quote) quote = undefined;
+        continue;
+      }
+      // Comments BEFORE quotes. A JSX prop comment is ordinary prose and
+      // ordinary prose has apostrophes: measured, `/* the Tooltip's popover */`
+      // inside two real `<Badge>` tags put this walk into string mode at the
+      // apostrophe and carried the tag end past its own `/>`, dropping both
+      // call sites from a scan that then reported green on 16 of 18. A
+      // hand-rolled scanner that mis-parses is worse than the regex it
+      // replaced, because it fails silently in the same direction.
+      if (ch === '/' && src[i + 1] === '*') {
+        const end = src.indexOf('*/', i + 2);
+        if (end === -1) break;
+        i = end + 1;
+        continue;
+      }
+      if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+      else if (ch === '{') depth += 1;
+      else if (ch === '}') depth -= 1;
+      else if (ch === '>' && depth === 0) {
+        out.push(src.slice(match.index, i + 1));
+        closed = true;
+        break;
+      }
+    }
+    // Fail loudly. A tag this walk cannot finish is a tag the Badge contracts
+    // silently stop governing, which is the failure mode they exist to prevent.
+    assert.ok(closed, `unterminated <${tagName}> tag at offset ${match.index}`);
+  }
+  return out;
+}
+
+/** `className="a b"` on a JSX tag. Whitespace around `=` is legal JSX and both
+ * quote styles are, so all three are read; keying on one spelling would make
+ * the contract a formatter preference rather than an invariant. */
+const STATIC_CLASS_NAME = /\bclassName\s*=\s*(["'])([^"']*)\1/g;
+const DYNAMIC_CLASS_NAME = /\bclassName\s*=\s*\{/;
+
+/**
  * The `className`s handed to an Astryx `<Badge>`, with the file that does it.
  *
  * Deliberately a source scan and not a render: the invariant is about what
@@ -124,9 +184,9 @@ export async function findBadgeClassNames(roots: string[]): Promise<{ file: stri
   for (const root of roots) {
     for (const file of await readTsxTree(root)) {
       const src = await readFile(file, 'utf8');
-      for (const tag of src.matchAll(/<Badge\b[^>]*?\/?>/gs)) {
-        for (const attr of tag[0].matchAll(/\bclassName="([^"]*)"/g)) {
-          for (const one of attr[1].split(/\s+/).filter(Boolean)) {
+      for (const tag of jsxOpeningTags(src, 'Badge')) {
+        for (const attr of tag.matchAll(STATIC_CLASS_NAME)) {
+          for (const one of attr[2].split(/\s+/).filter(Boolean)) {
             out.push({ file, className: one });
           }
         }
@@ -142,8 +202,8 @@ export async function findDynamicBadgeClassNames(roots: string[]): Promise<strin
   for (const root of roots) {
     for (const file of await readTsxTree(root)) {
       const src = await readFile(file, 'utf8');
-      for (const tag of src.matchAll(/<Badge\b[^>]*?\/?>/gs)) {
-        if (/\bclassName=\{/.test(tag[0])) out.push(file);
+      for (const tag of jsxOpeningTags(src, 'Badge')) {
+        if (DYNAMIC_CLASS_NAME.test(tag)) out.push(file);
       }
     }
   }
@@ -465,18 +525,26 @@ const CONDITIONAL_AT = /^@(?:media|supports|container)\b/;
  *     neither relaxes nor triggers a check on `.chip`. Qualified overrides are
  *     invisible here by construction. What covers them is the Badge call-site
  *     contract and the live e2e measurements, not this.
- *   - Conditional rules are skipped entirely rather than folded in. Folding
- *     them made a chip pinned only inside a breakpoint read as pinned
- *     everywhere (false green) AND made a deliberate responsive unpin illegal
- *     (false red); dropping them keeps the unconditional box honest, which is
- *     the box every contract here is about.
+ *   - Conditional rules are skipped by DEFAULT, not by nature. Folding them in
+ *     makes a chip pinned only inside a breakpoint read as pinned everywhere
+ *     (false green) and makes a deliberate responsive unpin illegal (false
+ *     red), so the box contracts — which are about the unconditional box —
+ *     take the default view. But a caller asking "does ANY rule, under any
+ *     condition, restate what this component computes?" has no such
+ *     distinction, and on the default view its answer is silently empty for a
+ *     rule that lives only inside a breakpoint. `includeConditional` is that
+ *     second question, and it is a parameter rather than a second helper
+ *     because the merge is otherwise identical.
  *   - `!important` is not modelled. Nothing in this tree uses it on the
  *     properties these contracts read.
  */
-export function mergeBySelector(css: string): Map<string, string> {
+export function mergeBySelector(
+  css: string,
+  options: { includeConditional?: boolean } = {},
+): Map<string, string> {
   const merged = new Map<string, string>();
   for (const { rule, conditions, decls } of parseCssBlocks(css)) {
-    if (conditions.some((c) => CONDITIONAL_AT.test(c))) continue;
+    if (!options.includeConditional && conditions.some((c) => CONDITIONAL_AT.test(c))) continue;
     const body = decls.map((d) => `${d.prop}: ${d.value};`).join(' ');
     for (const one of splitSelectorList(rule)) {
       merged.set(one, `${merged.get(one) ?? ''}${body} `);

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -110,24 +110,42 @@ export async function readTsxTree(dir: string): Promise<string[]> {
   return files.flat().sort();
 }
 
+/** One JSX opening tag: its raw text, and whether it spreads props. */
+type JsxOpeningTag = { text: string; spreads: boolean };
+
 /**
- * The opening tags of one JSX element, as raw text.
+ * The opening tags of one JSX element.
  *
  * A brace/quote-aware walk to the tag's real `>`, NOT `/<Tag\b[^>]*?>/`. That
  * form ends at the first `>` ANYWHERE, including one inside a prop expression,
  * so `<Badge label={a > b ? 'x' : 'y'} className="evil" />` matched as
  * `<Badge label={a >` — and the truncated text contains neither
  * `className="` nor `className={`, which took the call site out of BOTH Badge
- * contracts while they reported green. A scan whose entire job is to stop a
- * call site slipping out quietly cannot have a quiet exit of its own.
+ * contracts while they reported green.
+ *
+ * This is a lexer, not a parser, and it stays one deliberately. The property
+ * the Badge contracts actually need is not a faithful AST — it is that a call
+ * site this cannot READ fails loudly instead of reading as a call site with no
+ * `className`. (TypeScript 7 is the Go port and ships no JS compiler API, so
+ * `ts.createSourceFile` is not available to reach for; the parsers in the tree
+ * are transitive dependencies of Storybook and knip.) So every shape below
+ * either parses or throws:
+ *
+ *   - a tag whose `>` this cannot find throws;
+ *   - a tag that spreads props is reported as spreading, and the readability
+ *     contract rejects it. `<Badge {...{ className: 'x' }} />` is legal JSX
+ *     that the static scan cannot read and the `className={` scan does not
+ *     match, so before this it left BOTH contracts while they reported green
+ *     — the same silent exit as the truncated tag above, one level in.
  */
-function jsxOpeningTags(src: string, tagName: string): string[] {
-  const out: string[] = [];
+function jsxOpeningTags(src: string, tagName: string): JsxOpeningTag[] {
+  const out: JsxOpeningTag[] = [];
   const opener = new RegExp(`<${tagName}\\b`, 'g');
   for (const match of src.matchAll(opener)) {
     let depth = 0;
     let quote: string | undefined;
     let closed = false;
+    let spreads = false;
     for (let i = match.index; i < src.length; i += 1) {
       const ch = src[i];
       if (quote) {
@@ -142,17 +160,30 @@ function jsxOpeningTags(src: string, tagName: string): string[] {
       // call sites from a scan that then reported green on 16 of 18. A
       // hand-rolled scanner that mis-parses is worse than the regex it
       // replaced, because it fails silently in the same direction.
+      // Both spellings: `//` is the same habit written the other way, and a
+      // line comment holding a `>` ends the tag early in exactly the way the
+      // brace-aware walk exists to prevent.
       if (ch === '/' && src[i + 1] === '*') {
         const end = src.indexOf('*/', i + 2);
         if (end === -1) break;
         i = end + 1;
         continue;
       }
+      if (ch === '/' && src[i + 1] === '/') {
+        const end = src.indexOf('\n', i + 2);
+        if (end === -1) break;
+        i = end;
+        continue;
+      }
       if (ch === '"' || ch === "'" || ch === '`') quote = ch;
-      else if (ch === '{') depth += 1;
-      else if (ch === '}') depth -= 1;
+      else if (ch === '{') {
+        // Attribute level only. `{...` one brace in is a spread inside a prop
+        // expression (`label={[...parts]}`), which the scan reads fine.
+        if (depth === 0 && /^\s*\.\.\./.test(src.slice(i + 1, i + 8))) spreads = true;
+        depth += 1;
+      } else if (ch === '}') depth -= 1;
       else if (ch === '>' && depth === 0) {
-        out.push(src.slice(match.index, i + 1));
+        out.push({ text: src.slice(match.index, i + 1), spreads });
         closed = true;
         break;
       }
@@ -176,7 +207,7 @@ const DYNAMIC_CLASS_NAME = /\bclassName\s*=\s*\{/;
  * Deliberately a source scan and not a render: the invariant is about what
  * product CSS is allowed to say to a Badge, and that is decidable from text.
  * `className={cond ? 'a' : 'b'}` and other computed forms are not matched —
- * they are reported by `findDynamicBadgeClassNames` instead, so a call site
+ * they are reported by `findUnreadableBadgeCallSites` instead, so a call site
  * cannot leave this contract just by moving its class into an expression.
  */
 export async function findBadgeClassNames(roots: string[]): Promise<{ file: string; className: string }[]> {
@@ -184,8 +215,8 @@ export async function findBadgeClassNames(roots: string[]): Promise<{ file: stri
   for (const root of roots) {
     for (const file of await readTsxTree(root)) {
       const src = await readFile(file, 'utf8');
-      for (const tag of jsxOpeningTags(src, 'Badge')) {
-        for (const attr of tag.matchAll(STATIC_CLASS_NAME)) {
+      for (const { text } of jsxOpeningTags(src, 'Badge')) {
+        for (const attr of text.matchAll(STATIC_CLASS_NAME)) {
           for (const one of attr[2].split(/\s+/).filter(Boolean)) {
             out.push({ file, className: one });
           }
@@ -196,14 +227,23 @@ export async function findBadgeClassNames(roots: string[]): Promise<{ file: stri
   return out;
 }
 
-/** `<Badge className={…}>` call sites, which the static contract cannot read. */
-export async function findDynamicBadgeClassNames(roots: string[]): Promise<string[]> {
+/**
+ * `<Badge>` call sites whose className the static scan cannot read: a computed
+ * `className={…}`, or a prop spread that may carry one.
+ *
+ * The spread arm is the same invariant as the computed arm, not a second one.
+ * Both are "this call site has a className the contract cannot see", and both
+ * have to be reported rather than read as "this call site has no className" —
+ * which is what a scan looking only for `className=` concludes about
+ * `<Badge {...props} />`, silently and while green.
+ */
+export async function findUnreadableBadgeCallSites(roots: string[]): Promise<string[]> {
   const out: string[] = [];
   for (const root of roots) {
     for (const file of await readTsxTree(root)) {
       const src = await readFile(file, 'utf8');
-      for (const tag of jsxOpeningTags(src, 'Badge')) {
-        if (DYNAMIC_CLASS_NAME.test(tag)) out.push(file);
+      for (const { text, spreads } of jsxOpeningTags(src, 'Badge')) {
+        if (spreads || DYNAMIC_CLASS_NAME.test(text)) out.push(file);
       }
     }
   }
@@ -395,7 +435,7 @@ export function findTextRoleOffenders(css: string, tokensCss: string, label: str
 
 /** Split a selector list on top-level commas, ignoring those inside `:is()`,
  * `:where()`, `:not()` and attribute strings. */
-function splitSelectorList(selector: string): string[] {
+export function splitSelectorList(selector: string): string[] {
   const out: string[] = [];
   let depth = 0;
   let quote: string | null = null;
@@ -543,14 +583,46 @@ export function mergeBySelector(
   options: { includeConditional?: boolean } = {},
 ): Map<string, string> {
   const merged = new Map<string, string>();
-  for (const { rule, conditions, decls } of parseCssBlocks(css)) {
-    if (!options.includeConditional && conditions.some((c) => CONDITIONAL_AT.test(c))) continue;
-    const body = decls.map((d) => `${d.prop}: ${d.value};`).join(' ');
-    for (const one of splitSelectorList(rule)) {
-      merged.set(one, `${merged.get(one) ?? ''}${body} `);
-    }
+  for (const [selector, byContext] of mergeByContext(css)) {
+    const bodies = options.includeConditional
+      ? [...byContext.values()]
+      : [byContext.get(UNCONDITIONAL) ?? ''].filter((body) => body !== '');
+    if (bodies.length > 0) merged.set(selector, bodies.join(''));
   }
   return merged;
+}
+
+/** The key `mergeByContext` gives declarations that apply at every viewport. */
+export const UNCONDITIONAL = '';
+
+/**
+ * Every selector's declarations, merged per CASCADE CONTEXT rather than
+ * flattened across them: selector → (condition key → body).
+ *
+ * `mergeBySelector`'s inclusive view answers "does any rule anywhere say X",
+ * which is the right question for a must-NOT contract and the wrong one for a
+ * must-hold PAIR. Measured: a Badge released `height: auto` inside
+ * `@media (max-width: 620px)` and `white-space: normal` inside the mutually
+ * exclusive `@media (min-width: 621px)`, so at no viewport was it actually
+ * released — and two independent matches against one flattened body both
+ * passed. Contexts have to stay distinguishable for that to be visible.
+ *
+ * Only `@media`/`@supports`/`@container` form the key: `@layer` changes how a
+ * rule cascades, not whether it applies, so folding it into the key would
+ * split one context in two.
+ */
+export function mergeByContext(css: string): Map<string, Map<string, string>> {
+  const out = new Map<string, Map<string, string>>();
+  for (const { rule, conditions, decls } of parseCssBlocks(css)) {
+    const key = conditions.filter((c) => CONDITIONAL_AT.test(c)).join(' ');
+    const body = decls.map((d) => `${d.prop}: ${d.value};`).join(' ');
+    for (const one of splitSelectorList(rule)) {
+      const byContext = out.get(one) ?? new Map<string, string>();
+      byContext.set(key, `${byContext.get(key) ?? ''}${body} `);
+      out.set(one, byContext);
+    }
+  }
+  return out;
 }
 
 /** Every enclosing at-rule's `@name params`, outermost first. `@layer` counts:

--- a/apps/desktop/src/main/__tests__/type-scale-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/type-scale-contract.test.ts
@@ -27,10 +27,82 @@ import {
   cssRuleBody,
   assertCssRuleDecls,
   assertCustomPropPinnedOnce,
+  findBadgeClassNames,
+  findDynamicBadgeClassNames,
   findTextRoleOffenders,
+  mergeBySelector,
   parseCssCustomProps,
   readAllRendererCss,
 } from './css-test-helpers.js';
+
+/**
+ * A `height` declaration, excluding `min-height`, `max-height`, `line-height`
+ * and custom properties. `block-size` is the logical alias and is the same
+ * declaration to a browser, so a check that reads one and not the other is a
+ * check with a documented bypass. The `\s*` before the colon is not cosmetic:
+ * `height : 20px` is valid CSS.
+ */
+const HEIGHT_DECL = /(?<![-\w])(?:height|block-size)\s*:/;
+const HEIGHT_DECL_G = /(?<![-\w])(?:height|block-size)\s*:([^;}]*)/g;
+const RULER_VALUE = /^\s*var\(--h-control-[a-z0-9]+\)\s*$/;
+
+/**
+ * Does this box's EFFECTIVE height come from the control ruler?
+ *
+ * Effective, not "mentioned anywhere": CSS takes the last declaration, so a
+ * body reading `height: var(--h-control-xs); … height: auto` is an unpinned
+ * box that a test matching anywhere in the text reports as pinned. That is a
+ * legal, one-line bypass of the whole contract, and this file already
+ * documents the same false-green for custom properties.
+ */
+function pinnedToRuler(body: string): boolean {
+  const values = [...body.matchAll(HEIGHT_DECL_G)].map((m) => m[1]);
+  const last = values.at(-1);
+  return last !== undefined && RULER_VALUE.test(last);
+}
+
+/**
+ * The chips that carry pill chrome but must not take a `--h-control-*` height,
+ * each for a reason that was measured rather than asserted. Anything not named
+ * here has to pin, so growing this set is a deliberate act visible in review —
+ * the property the enumerated inventory this replaced did not have.
+ */
+const EXEMPT = new Set([
+  // A system-note block, not a chip: it wraps, and pinning clips every line but
+  // the first. Keyed by its FULL prelude — the old key was the last line of a
+  // multi-line selector, which also exempted any future rule ending that way.
+  '.maka-chat-message[data-sender="system"] pre:not([data-maka-contract="markdown"] pre)',
+  // `flex-wrap: wrap` is load-bearing — its buttons flow to a second line
+  // inside the pill on the floor column (see that rule's own comment).
+  '.settingsMemoryBackupCandidate',
+  // Wraps too, and measured: its English copy is 317px on one line in a 260px
+  // column. A pin here is only safe with `white-space: nowrap`, which trades a
+  // clipped second line for a 57px overflow past the card. See that rule.
+  '.settingsCapabilityOsPermissions li',
+  // Sized by its Astryx component, which is the stronger form of the same
+  // invariant: the height comes from `--size-element-*` rather than from a
+  // product rule racing it. Declaring a height here would reintroduce the
+  // override #1879 removed. The three composer `.astryx-selector` rules used
+  // to sit in this list while still declaring a height — a reason that was
+  // false about the CSS it excused. They declare no height at all now, so the
+  // reason is finally true of every entry under it.
+  //
+  // `.maka-composer-model-chip` sat here too, on the same false reason: its
+  // class is on `ModelChipStatic`'s inert `<span>`, never on the `Button` it
+  // renders when it is clickable, so no component was sizing it and the
+  // exemption hid a 22px box next to a 28px Selector. It pins like any other
+  // chip now. `.maka-sidebar-update-button` is gone from the list for the
+  // opposite reason — it declares neither a height nor pill chrome any more,
+  // so neither filter selects it and the entry was inert.
+  '.maka-model-switcher-trigger.astryx-selector',
+  '.maka-new-chat-model-selector.astryx-selector',
+  '.maka-thinking-level-selector.astryx-selector',
+  // Deliberate literal. A `pointer-events: none` overlay on a button's corner:
+  // it aligns with no control, so no neighbour names a tier, and the ruler's
+  // smallest rung would grow a decorative badge by 25%. It is already pinned,
+  // which is the invariant; only the vocabulary differs. Reasoning at the rule.
+  '.maka-composer-skill-trigger-count',
+]);
 
 const RENDERER = resolve(REPO_ROOT, 'apps/desktop/src/renderer');
 
@@ -265,5 +337,211 @@ describe('type scale contracts', () => {
       [],
       'no renderer stylesheet may define or read a product --leading-* tier',
     );
+  });
+
+  it('pins every pill chip to the control ruler', async () => {
+    // #1879. #1878 and #1893 made every line box name a role; they did not stop
+    // a line box from DECIDING a box. Where a chip declares no height, leading
+    // and box height are one decision, so the next role retune is a layout
+    // change — measured, these boxes doubled when their own leading was bumped
+    // to 40px, and the inline ones took their parent's line box with them.
+    //
+    // Derived, not enumerated. The first revision of this contract listed
+    // eight selectors, which could only fail for a chip someone remembered to
+    // add: measured against that list, nine identically-defective chips were
+    // shipping in the same files, one of them sixteen lines from a selector
+    // the list did contain. A rule that reads the stylesheet cannot have that
+    // failure mode, and it is less code than the table it replaces.
+    //
+    // The predicate is deliberately the visual definition of a chip rather
+    // than a naming convention: pill radius plus its own padding plus its own
+    // type. That is a box a reader perceives as a discrete object, which is
+    // exactly the population whose height should come from the control ruler.
+    // Merged per selector, not per rule block. A chip whose type lives in one
+    // rule and whose pill chrome lives in another is one box to a browser and
+    // was two invisible halves to the first revision of this scan — which is
+    // exactly how `.plan-proposal-revision` sat five lines from a selector
+    // this scan did catch and went unseen. Splitting a rule in two is not a
+    // way to be exempt from it.
+    const merged = mergeBySelector(stripCssComments(await readAllRendererCss()));
+
+    // Pill radius only, and that boundary was measured rather than assumed:
+    // widening the arm to `--radius-control` reported 27 offenders, among them
+    // `pre` blocks, failure banners, sidebar rows and buttons — every one a box
+    // a pin would clip. `--radius-control` is the repo's general control shape,
+    // not a chip signal. The squared chips that motivated trying it are Astryx
+    // `Badge`s now, so that population is empty rather than unguarded.
+    //
+    // Both type vocabularies count. #1893 folded the size/leading pair into a
+    // `font:` role shorthand, and a scan that only knew the pair would have
+    // gone green on an empty population the day that landed — the loudest
+    // possible failure mode for a derived check is one that finds nothing.
+    const OWNS_ITS_TYPE = /font:\s*var\(--maka-text-[\w-]+\)|line-height:\s*var\(--text-[\w-]+-leading\)/;
+    const isChip = (body: string) =>
+      /border-radius:\s*var\(--radius-pill\)/.test(body) &&
+      /padding/.test(body) &&
+      OWNS_ITS_TYPE.test(body);
+
+    // Guard the guard: a predicate over declarations goes quiet, not red, when
+    // the vocabulary it reads moves out from under it. #1893 moved it once
+    // already.
+    const chips = [...merged].filter(([, body]) => isChip(body));
+    assert.ok(
+      chips.length >= 8,
+      `the chip predicate selected ${chips.length} rules — it has stopped seeing the population it governs`,
+    );
+
+    // Named exemptions, each with a measured reason. Anything not listed here
+    // must pin, so adding a chip to this list is a deliberate act that shows
+    // up in review — the property the eight-row table did not have.
+    const offenders = chips
+      .filter(([selector]) => !EXEMPT.has(selector))
+      .filter(([, body]) => !pinnedToRuler(body))
+      .map(([selector]) => selector);
+    assert.deepEqual(
+      offenders,
+      [],
+      `every chip must take its height from --h-control-*, or be named in EXEMPT with a measured reason:\n${offenders.join('\n')}`,
+    );
+  });
+
+  it('pins the chrome-less chips the scan cannot see', async () => {
+    // The scan above finds chips by their chrome. These two are chips by
+    // behaviour and not by appearance — a timestamp and a ⌘N hint, both
+    // deliberately styled with no pill, no background and no border — so no
+    // predicate over declarations can distinguish them from ordinary inline
+    // text. They are the two #1879 measured first, so they are listed rather
+    // than derived, and the list is short because it can only ever hold boxes
+    // that carry no chrome at all.
+    for (const [file, selector] of [
+      ['styles/chat-message.css', '.maka-message-time-inline'],
+      ['styles/sidebar.css', '.maka-nav-kbd'],
+    ] as const) {
+      const body = cssRuleBody(stripCssComments(await read(file)), selector);
+      assert.ok(body, `${file} must still declare ${selector}`);
+      assert.ok(pinnedToRuler(body), `${selector} must take its height from --h-control-*`);
+    }
+  });
+
+  it('centres the line box inside every box it pins', async () => {
+    // A height with nothing centring the line box inside it clips off-centre
+    // once the two disagree, which is the failure the pin exists to prevent
+    // rather than to cause. Asserted as a PAIR: `align-items` is inert text on
+    // a `display: block` box, so a mutation that keeps the property and drops
+    // the flex display passed a version of this check that read only the
+    // alignment. `grid` is accepted alongside `flex` because it honours
+    // `align-items` identically; measured, every selector this currently
+    // selects uses flex, so the grid arm guards a shape nothing has taken yet
+    // rather than one that was observed.
+    const offenders = [...mergeBySelector(stripCssComments(await readAllRendererCss()))]
+      .filter(([selector, body]) => pinnedToRuler(body) && !EXEMPT.has(selector))
+      .filter(
+        ([, body]) =>
+          !(
+            /display:\s*(?:inline-)?(?:flex|grid)/.test(body) &&
+            /(?:align-items|place-items):\s*(?:safe\s+|unsafe\s+)?center/.test(body)
+          ),
+      )
+      .map(([selector]) => selector);
+    assert.deepEqual(
+      offenders,
+      [],
+      `a box pinned to --h-control-* must centre its line box with a flex/grid display AND align-items: center:\n${offenders.join('\n')}`,
+    );
+  });
+
+  it('lets no product rule redraw the box an Astryx Badge already owns', async () => {
+    // The other half of #1879, and the half the derived scan above cannot see.
+    // Twelve chips stopped hand-drawing a pill and became `<Badge>`s, which is
+    // the stronger form of the invariant — the box comes from the component
+    // instead of from a rule a scan has to police. But it moved them OUT of
+    // that scan's population: a Badge has no product rule, so `isChip` is
+    // false and nothing above would notice `.maka-turn-truncation-badge
+    // { height: auto }` reappearing. Product CSS is in the last cascade layer,
+    // so such a rule would win — the guard and the fix had moved in opposite
+    // directions.
+    //
+    // This is the same invariant read from the other end: whatever a Badge is
+    // handed as a `className` may add layout and may add what the component
+    // has no opinion on (tracking, mono figures, flex-shrink), but may not
+    // restate or override the geometry and type Badge computes for itself.
+    // `font` is in the banned set as well as `font-size`: naming a role on a
+    // component that composes its own type is the type-axis form of pinning
+    // its box, and it is the shape the rules deleted here left behind.
+    const css = stripCssComments(await readAllRendererCss());
+    const merged = mergeBySelector(css);
+    const OWNED = /(?<![-\w])(?:height|block-size|line-height|font|font-size|padding(?:-[a-z]+)?|border-radius)\s*:/;
+    // The wrap/no-wrap duality again, read from the Badge side. A Badge is a
+    // single-line pill by construction (`white-space: nowrap` and a fixed
+    // `--spacing-5` height); a call site whose content genuinely wraps has to
+    // release BOTH or the second line is clipped. That is a real need, not a
+    // rule racing the component — but it is the only one, so it is named here
+    // rather than pattern-matched.
+    const RELEASES_THE_SINGLE_LINE_BOX = new Set([
+      // Health blockers are sentences, not labels. Predates #1879.
+      '.settingsHealthBlockerBadge',
+    ]);
+    const roots = [
+      resolve(REPO_ROOT, 'apps/desktop/src/renderer'),
+      resolve(REPO_ROOT, 'packages/ui/src'),
+    ];
+    const offenders = (await findBadgeClassNames(roots))
+      .filter(({ className }) => !RELEASES_THE_SINGLE_LINE_BOX.has(`.${className}`))
+      .filter(({ className }) => OWNED.test(merged.get(`.${className}`) ?? ''))
+      .map(({ file, className }) => `.${className} (${file.replace(`${REPO_ROOT}/`, '')})`);
+    assert.deepEqual(
+      offenders,
+      [],
+      `a class on an Astryx <Badge> must not declare its height, padding, radius or type:\n${offenders.join('\n')}`,
+    );
+  });
+
+  it('keeps every Badge className readable to the contract above', async () => {
+    // `className={x}` would take a call site out of the scan without deleting
+    // anything, which is how the enumerated inventories this file replaced
+    // used to rot. There is no legitimate need for a computed class on a Badge
+    // today; if one arrives, it needs a seam that stays checkable rather than
+    // a quiet exit.
+    const dynamic = (await findDynamicBadgeClassNames([
+      resolve(REPO_ROOT, 'apps/desktop/src/renderer'),
+      resolve(REPO_ROOT, 'packages/ui/src'),
+    ])).map((file) => file.replace(`${REPO_ROOT}/`, ''));
+    assert.deepEqual(
+      dynamic,
+      [],
+      `<Badge className={…}> cannot be read statically, so it escapes the Badge-geometry contract:\n${dynamic.join('\n')}`,
+    );
+  });
+
+  it('leaves the boxes that wrap unpinned', async () => {
+    // The other half of #1879, and the half that is easy to "fix" wrongly: a
+    // pinned height is only sound for content that cannot wrap. #1879 read
+    // `.maka-plan-card-run` as already pinned and proposed it as the shape for
+    // the rest. It declares no height — the 20px it measures at comes from the
+    // Badge beside the message — and it must not gain one: measured, replacing
+    // the message with a long string grows the row to many lines, so a 20px
+    // pin would clip all but the first. The exact figure is deliberately not
+    // recorded: a wrap threshold is a font metric, so it differs per platform
+    // and would be a number that rots rather than an invariant.
+    //
+    // Repo-wide rather than file-local. The earlier revision read one
+    // stylesheet, so appending `.maka-plan-card-run { height: 20px }` from any
+    // other file satisfied it — the same bypass the heading and font-size
+    // checks in this file already went repo-wide to close.
+    const merged = mergeBySelector(stripCssComments(await readAllRendererCss()));
+    for (const selector of [
+      '.maka-plan-card-run',
+      '.maka-plan-card-schedule',
+      '.settingsMemoryBackupCandidate',
+      '.settingsCapabilityOsPermissions li',
+    ]) {
+      const body = merged.get(selector) ?? '';
+      const offenders = HEIGHT_DECL.test(body) ? [body.trim()] : [];
+      assert.deepEqual(
+        offenders,
+        [],
+        `${selector} wraps by design; a pinned height clips it rather than stabilising it`,
+      );
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/type-scale-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/type-scale-contract.test.ts
@@ -36,15 +36,33 @@ import {
 } from './css-test-helpers.js';
 
 /**
- * A `height` declaration, excluding `min-height`, `max-height`, `line-height`
- * and custom properties. `block-size` is the logical alias and is the same
- * declaration to a browser, so a check that reads one and not the other is a
- * check with a documented bypass. The `\s*` before the colon is not cosmetic:
- * `height : 20px` is valid CSS.
+ * TWO height vocabularies, deliberately different, because two different
+ * questions are being asked and the same regex answers one of them wrongly.
+ *
+ * `CONSTRAINS_BLOCK_SIZE` — "does anything here fix this box's block size?"
+ * That is the wrap contract's question and the Badge contract's question, and
+ * `min-height` and `max-height` answer it just as `height` does: measured,
+ * `min-height: 40px` on a Badge className beats the component's own
+ * `height: var(--spacing-5)`, and `min-height: 20px; max-height: 20px` on a
+ * wrapping row clips its second line exactly as `height: 20px` would. Both
+ * used to pass this file green.
+ *
+ * `HEIGHT_DECL_G` — "is this box's height taken FROM the ruler?" There
+ * `min-height` is emphatically not an answer, and this PR is where that was
+ * learned: `.settingsUsageDetailToggle` declared `min-height: 34px` and still
+ * grew to 40px when its leading moved, which is why settings/bot.css now
+ * declares a real `height`. Widening this one too would have re-accepted the
+ * exact declaration the fix replaced.
+ *
+ * `line-height` and custom properties are excluded from both by the negative
+ * lookbehind. `block-size` is the logical alias and is the same declaration to
+ * a browser, so a check that reads one and not the other is a check with a
+ * documented bypass. The `\s*` before the colon is not cosmetic: `height :
+ * 20px` is valid CSS.
  */
-const HEIGHT_DECL = /(?<![-\w])(?:height|block-size)\s*:/;
+const CONSTRAINS_BLOCK_SIZE = /(?<![-\w])(?:min-|max-)?(?:height|block-size)\s*:/;
 const HEIGHT_DECL_G = /(?<![-\w])(?:height|block-size)\s*:([^;}]*)/g;
-const RULER_VALUE = /^\s*var\(--h-control-[a-z0-9]+\)\s*$/;
+const RULER_VALUE = /^\s*var\((--h-control-[a-z0-9-]+)\)\s*$/;
 
 /**
  * Does this box's EFFECTIVE height come from the control ruler?
@@ -54,54 +72,119 @@ const RULER_VALUE = /^\s*var\(--h-control-[a-z0-9]+\)\s*$/;
  * box that a test matching anywhere in the text reports as pinned. That is a
  * legal, one-line bypass of the whole contract, and this file already
  * documents the same false-green for custom properties.
+ *
+ * `rungs` is the set of tiers the ruler actually defines. Naming a tier that
+ * does not exist makes the declaration invalid at computed-value time, so the
+ * box falls back to `auto` — #1879 restored by a typo, with every text check
+ * green. A name-is-defined arm is the same guard #1893 already runs over role
+ * tokens; the tiers are read from maka-tokens.css rather than listed here so
+ * there is one authority for what the ruler contains.
  */
-function pinnedToRuler(body: string): boolean {
+function pinnedToRuler(body: string, rungs: Set<string>): boolean {
   const values = [...body.matchAll(HEIGHT_DECL_G)].map((m) => m[1]);
   const last = values.at(-1);
-  return last !== undefined && RULER_VALUE.test(last);
+  if (last === undefined) return false;
+  const tier = RULER_VALUE.exec(last)?.[1];
+  return tier !== undefined && rungs.has(tier);
+}
+
+/** The tiers `--h-control-*` actually defines, read from the token file. */
+async function rulerRungs(): Promise<Set<string>> {
+  const names = [...parseCssCustomProps(await read('maka-tokens.css')).keys()].filter((name) =>
+    name.startsWith('--h-control-'),
+  );
+  assert.ok(names.length >= 6, `the control ruler must define its tiers; found ${names.length}`);
+  return new Set(names);
 }
 
 /**
- * The chips that carry pill chrome but must not take a `--h-control-*` height,
- * each for a reason that was measured rather than asserted. Anything not named
- * here has to pin, so growing this set is a deliberate act visible in review —
- * the property the enumerated inventory this replaced did not have.
+ * The pill-shaped boxes that do NOT take a `--h-control-*` height, grouped by
+ * WHY — because the three reasons are three different invariants, and a set
+ * that merges them can only be honoured by skipping.
+ *
+ * Skipping was the earlier shape and it was wrong twice over. It let a review
+ * mutation add `height: 1px` to a rule excused as "the component sizes this"
+ * and stay green, and it made an entry whose check could never have fired read
+ * exactly like an entry whose check would have. An exemption that suppresses
+ * nothing is the defect class this file exists to retire: a stated reason that
+ * is false about the code it governs.
+ *
+ * So each group below is ASSERTED, not skipped. Every entry has to keep
+ * earning its place, and an entry that stops being true fails the contract
+ * that names it rather than silently widening it.
  */
-const EXEMPT = new Set([
-  // A system-note block, not a chip: it wraps, and pinning clips every line but
-  // the first. Keyed by its FULL prelude — the old key was the last line of a
-  // multi-line selector, which also exempted any future rule ending that way.
+
+/** Wraps by design: content is a sentence, so nothing may fix its block size.
+ * Asserted by 'leaves the boxes that wrap unpinned', which is where these live
+ * — they are not a second list. */
+const WRAPS = [
+  // A system-note block, not a chip: pinning clips every line but the first.
+  // Keyed by its FULL prelude — the old key was the last line of a multi-line
+  // selector, which also exempted any future rule ending that way.
   '.maka-chat-message[data-sender="system"] pre:not([data-maka-contract="markdown"] pre)',
   // `flex-wrap: wrap` is load-bearing — its buttons flow to a second line
   // inside the pill on the floor column (see that rule's own comment).
   '.settingsMemoryBackupCandidate',
-  // Wraps too, and measured: its English copy is 317px on one line in a 260px
-  // column. A pin here is only safe with `white-space: nowrap`, which trades a
-  // clipped second line for a 57px overflow past the card. See that rule.
+  // Measured: its English copy is 317px on one line in a 260px column. A pin
+  // here is only safe with `white-space: nowrap`, which trades a clipped
+  // second line for a 57px overflow past the card. See that rule.
   '.settingsCapabilityOsPermissions li',
-  // Sized by its Astryx component, which is the stronger form of the same
-  // invariant: the height comes from `--size-element-*` rather than from a
-  // product rule racing it. Declaring a height here would reintroduce the
-  // override #1879 removed. The three composer `.astryx-selector` rules used
-  // to sit in this list while still declaring a height — a reason that was
-  // false about the CSS it excused. They declare no height at all now, so the
-  // reason is finally true of every entry under it.
-  //
-  // `.maka-composer-model-chip` sat here too, on the same false reason: its
-  // class is on `ModelChipStatic`'s inert `<span>`, never on the `Button` it
-  // renders when it is clickable, so no component was sizing it and the
-  // exemption hid a 22px box next to a 28px Selector. It pins like any other
-  // chip now. `.maka-sidebar-update-button` is gone from the list for the
-  // opposite reason — it declares neither a height nor pill chrome any more,
-  // so neither filter selects it and the entry was inert.
+  // Both of these hold a Badge plus a message that grows without bound; the
+  // 20px they measure at comes from the Badge, and must keep coming from it.
+  '.maka-plan-card-run',
+  '.maka-plan-card-schedule',
+] as const;
+
+/** Sized by the Astryx component that renders them, which is the stronger form
+ * of the same invariant: the box comes from `--size-element-*` instead of from
+ * a product rule racing it. Asserted as "declares no block size AT ALL" —
+ * the positive form of the reason, so re-adding the override #1879 removed
+ * fails here instead of being waved through.
+ *
+ * `.maka-composer-model-chip` sat in the old merged list on a reason that was
+ * false: its class is on `ModelChipStatic`'s inert `<span>`, never on the
+ * `Button` it renders when clickable, so no component was sizing it and the
+ * exemption hid a 22px box next to a 28px Selector. It pins like any other
+ * chip now. */
+const COMPONENT_OWNED = [
   '.maka-model-switcher-trigger.astryx-selector',
   '.maka-new-chat-model-selector.astryx-selector',
   '.maka-thinking-level-selector.astryx-selector',
-  // Deliberate literal. A `pointer-events: none` overlay on a button's corner:
-  // it aligns with no control, so no neighbour names a tier, and the ruler's
-  // smallest rung would grow a decorative badge by 25%. It is already pinned,
-  // which is the invariant; only the vocabulary differs. Reasoning at the rule.
+] as const;
+
+/** Pinned, but to a literal rather than to the ruler. The invariant #1879 is
+ * about — the box does not come from the line box — already holds; only the
+ * vocabulary differs, and each has a reason the ruler cannot express.
+ * Asserted as "is pinned", so losing the literal fails rather than passing as
+ * a box with no height at all. */
+const PINNED_OFF_RULER = [
+  // A `pointer-events: none` overlay on a button's corner: it aligns with no
+  // control, so no neighbour names a tier, and the ruler's smallest rung would
+  // grow a decorative badge by 25%. Reasoning at the rule.
   '.maka-composer-skill-trigger-count',
+] as const;
+
+/** Pinned boxes whose flex display comes from a BASE rule, not from the
+ * modifier that pins them. `mergeBySelector` keys on literal selector text, so
+ * `.maka-quote-chip-collapsed` cannot see the `display: inline-flex` its
+ * `.maka-quote-chip` base declares. Restating the display on the modifier
+ * would be a product rule duplicating a product rule — the thing this PR
+ * removes everywhere else — so the pair is named here and the base is asserted
+ * to still carry it. Modifier → base. */
+const CENTRED_BY_A_BASE_RULE: ReadonlyArray<readonly [string, string]> = [
+  ['.maka-quote-chip-collapsed', '.maka-quote-chip'],
+];
+
+/** Not a chip at all — a scrollbar thumb, whose block size is the scroll
+ * geometry's business and never a line box's. It reaches the pill scan only
+ * because it is round and padded. */
+const NOT_A_BOX_A_READER_SEES = ['.maka-composer-project-scroll::-webkit-scrollbar-thumb'] as const;
+
+const NOT_ON_THE_RULER = new Set<string>([
+  ...WRAPS,
+  ...COMPONENT_OWNED,
+  ...PINNED_OFF_RULER,
+  ...NOT_A_BOX_A_READER_SEES,
 ]);
 
 const RENDERER = resolve(REPO_ROOT, 'apps/desktop/src/renderer');
@@ -354,9 +437,29 @@ describe('type scale contracts', () => {
     // failure mode, and it is less code than the table it replaces.
     //
     // The predicate is deliberately the visual definition of a chip rather
-    // than a naming convention: pill radius plus its own padding plus its own
-    // type. That is a box a reader perceives as a discrete object, which is
-    // exactly the population whose height should come from the control ruler.
+    // than a naming convention: pill radius plus its own padding. That is a box
+    // a reader perceives as a discrete object, which is exactly the population
+    // whose height should come from the control ruler.
+    //
+    // TWO arms, not three. An earlier revision also required the rule to
+    // declare its own type — a `font:` role or a `--text-*-leading` pair — on
+    // the theory that a discrete object names its own text. It does not: a
+    // COMPOUND chip delegates its type to a child, and a simple one may just
+    // inherit. Measured, that third arm was hiding exactly three shipping
+    // chips with the #1879 defect — `.maka-quote-chip-collapsed` (type on its
+    // `.maka-quote-chip-text` child), `.maka-deep-research-run-count` (no type
+    // declaration anywhere, it inherits) and `.maka-firstrun-step` — while the
+    // scan reported the other 15 green. The arm did not narrow the population
+    // to real chips; it narrowed it to chips that happen to write text rules.
+    //
+    // Dropping it also removes the reason the scan needed a guard of its own.
+    // The third arm read the type vocabulary, and #1893 moved that vocabulary
+    // out from under it once already — which is why a `chips.length >= 8`
+    // floor sat here, an unanchored number whose only job was to notice the
+    // predicate going quiet. Two arms read radius and padding, which no type
+    // convergence can move. The floor is deleted rather than retuned: a guard
+    // that exists to watch a fragile arm should not outlive the arm.
+    //
     // Merged per selector, not per rule block. A chip whose type lives in one
     // rule and whose pill chrome lives in another is one box to a browser and
     // was two invisible halves to the first revision of this scan — which is
@@ -364,6 +467,7 @@ describe('type scale contracts', () => {
     // this scan did catch and went unseen. Splitting a rule in two is not a
     // way to be exempt from it.
     const merged = mergeBySelector(stripCssComments(await readAllRendererCss()));
+    const rungs = await rulerRungs();
 
     // Pill radius only, and that boundary was measured rather than assumed:
     // widening the arm to `--radius-control` reported 27 offenders, among them
@@ -371,38 +475,55 @@ describe('type scale contracts', () => {
     // a pin would clip. `--radius-control` is the repo's general control shape,
     // not a chip signal. The squared chips that motivated trying it are Astryx
     // `Badge`s now, so that population is empty rather than unguarded.
-    //
-    // Both type vocabularies count. #1893 folded the size/leading pair into a
-    // `font:` role shorthand, and a scan that only knew the pair would have
-    // gone green on an empty population the day that landed — the loudest
-    // possible failure mode for a derived check is one that finds nothing.
-    const OWNS_ITS_TYPE = /font:\s*var\(--maka-text-[\w-]+\)|line-height:\s*var\(--text-[\w-]+-leading\)/;
     const isChip = (body: string) =>
-      /border-radius:\s*var\(--radius-pill\)/.test(body) &&
-      /padding/.test(body) &&
-      OWNS_ITS_TYPE.test(body);
+      /border-radius:\s*var\(--radius-pill\)/.test(body) && /padding/.test(body);
 
-    // Guard the guard: a predicate over declarations goes quiet, not red, when
-    // the vocabulary it reads moves out from under it. #1893 moved it once
-    // already.
-    const chips = [...merged].filter(([, body]) => isChip(body));
-    assert.ok(
-      chips.length >= 8,
-      `the chip predicate selected ${chips.length} rules — it has stopped seeing the population it governs`,
-    );
-
-    // Named exemptions, each with a measured reason. Anything not listed here
-    // must pin, so adding a chip to this list is a deliberate act that shows
-    // up in review — the property the eight-row table did not have.
-    const offenders = chips
-      .filter(([selector]) => !EXEMPT.has(selector))
-      .filter(([, body]) => !pinnedToRuler(body))
+    // Anything not named in one of the three reason-groups must pin, and each
+    // group is asserted by its own contract below rather than merely skipped
+    // here — so a name in this filter is a name that has to keep being true.
+    const offenders = [...merged]
+      .filter(([, body]) => isChip(body))
+      .filter(([selector]) => !NOT_ON_THE_RULER.has(selector))
+      .filter(([, body]) => !pinnedToRuler(body, rungs))
       .map(([selector]) => selector);
     assert.deepEqual(
       offenders,
       [],
-      `every chip must take its height from --h-control-*, or be named in EXEMPT with a measured reason:\n${offenders.join('\n')}`,
+      `every chip must take its height from --h-control-*, or be named in one of WRAPS / COMPONENT_OWNED / PINNED_OFF_RULER with a measured reason:\n${offenders.join('\n')}`,
     );
+  });
+
+  it('holds every off-ruler exemption to the reason it claims', async () => {
+    // The half of an exemption set that a skip cannot express. Each group
+    // states WHY a pill is off the ruler; without this, "why" is a comment and
+    // the code is an unconditional pass — measured, a review mutation added
+    // `height: 1px` to a rule excused as "the Astryx component sizes this" and
+    // the whole suite stayed green.
+    const merged = mergeBySelector(stripCssComments(await readAllRendererCss()));
+    const rungs = await rulerRungs();
+
+    for (const selector of COMPONENT_OWNED) {
+      const body = merged.get(selector) ?? '';
+      assert.ok(body !== '', `${selector} must still exist for its exemption to mean anything`);
+      assert.doesNotMatch(
+        body,
+        CONSTRAINS_BLOCK_SIZE,
+        `${selector} is excused because its Astryx component sizes it; declaring any block size here is the override #1879 removed`,
+      );
+    }
+
+    for (const selector of PINNED_OFF_RULER) {
+      const body = merged.get(selector) ?? '';
+      assert.match(
+        body,
+        CONSTRAINS_BLOCK_SIZE,
+        `${selector} is excused because it is already pinned to a literal; losing that pin hands the box back to the line box`,
+      );
+      assert.ok(
+        !pinnedToRuler(body, rungs),
+        `${selector} now takes a ruler tier — drop it from PINNED_OFF_RULER rather than carrying a stale reason`,
+      );
+    }
   });
 
   it('pins the chrome-less chips the scan cannot see', async () => {
@@ -413,13 +534,14 @@ describe('type scale contracts', () => {
     // text. They are the two #1879 measured first, so they are listed rather
     // than derived, and the list is short because it can only ever hold boxes
     // that carry no chrome at all.
+    const rungs = await rulerRungs();
     for (const [file, selector] of [
       ['styles/chat-message.css', '.maka-message-time-inline'],
       ['styles/sidebar.css', '.maka-nav-kbd'],
     ] as const) {
       const body = cssRuleBody(stripCssComments(await read(file)), selector);
       assert.ok(body, `${file} must still declare ${selector}`);
-      assert.ok(pinnedToRuler(body), `${selector} must take its height from --h-control-*`);
+      assert.ok(pinnedToRuler(body, rungs), `${selector} must take its height from --h-control-*`);
     }
   });
 
@@ -433,8 +555,30 @@ describe('type scale contracts', () => {
     // `align-items` identically; measured, every selector this currently
     // selects uses flex, so the grid arm guards a shape nothing has taken yet
     // rather than one that was observed.
-    const offenders = [...mergeBySelector(stripCssComments(await readAllRendererCss()))]
-      .filter(([selector, body]) => pinnedToRuler(body) && !EXEMPT.has(selector))
+    //
+    // No exemption list. This question is "is this pin safe", and the reasons
+    // a pill may sit off the ruler have nothing to say about it — a box that
+    // IS pinned has to centre its line box whatever the reason for its tier.
+    // The earlier revision filtered `EXEMPT` here, inherited from a different
+    // question; measured, it excluded nothing, so it was a silent widening
+    // waiting for its first entry.
+    const rungs = await rulerRungs();
+    const merged = mergeBySelector(stripCssComments(await readAllRendererCss()));
+    // The base half of the pair, asserted rather than assumed: a modifier is
+    // only excused because its base centres for it, and that has to stay true.
+    const CENTRES = (body: string) =>
+      /display:\s*(?:inline-)?(?:flex|grid)/.test(body) &&
+      /(?:align-items|place-items):\s*(?:safe\s+|unsafe\s+)?center/.test(body);
+    for (const [modifier, base] of CENTRED_BY_A_BASE_RULE) {
+      const pair = `${merged.get(base) ?? ''} ${merged.get(modifier) ?? ''}`;
+      assert.ok(
+        CENTRES(pair),
+        `${modifier} is pinned and is excused from centring because ${base} does it; together they no longer do`,
+      );
+    }
+    const excused = new Set(CENTRED_BY_A_BASE_RULE.map(([modifier]) => modifier));
+    const offenders = [...merged]
+      .filter(([selector, body]) => pinnedToRuler(body, rungs) && !excused.has(selector))
       .filter(
         ([, body]) =>
           !(
@@ -468,9 +612,22 @@ describe('type scale contracts', () => {
     // `font` is in the banned set as well as `font-size`: naming a role on a
     // component that composes its own type is the type-axis form of pinning
     // its box, and it is the shape the rules deleted here left behind.
+    //
+    // Read on the CONDITIONAL-INCLUSIVE view, unlike the chip and wrap scans
+    // above. Those two ask about the unconditional box, where folding a
+    // breakpoint in produces both false greens and false reds. This one asks
+    // whether ANY product rule, under any condition, restates what the
+    // component computes — a question with no unconditional/conditional
+    // distinction. The difference was not academic: `.settingsHealthBlockerBadge`
+    // lives entirely inside `@media (max-width: 620px)` (settings/health.css),
+    // so on the unconditional view its merged body was empty, it could never
+    // have been flagged, and the exemption naming it suppressed nothing. That
+    // is the same defect this file exists to retire — a stated reason that is
+    // false about the code it governs — so the view was widened rather than
+    // the entry deleted.
     const css = stripCssComments(await readAllRendererCss());
-    const merged = mergeBySelector(css);
-    const OWNED = /(?<![-\w])(?:height|block-size|line-height|font|font-size|padding(?:-[a-z]+)?|border-radius)\s*:/;
+    const merged = mergeBySelector(css, { includeConditional: true });
+    const OWNED = /(?<![-\w])(?:min-|max-)?(?:height|block-size|line-height|font|font-size|padding(?:-(?:inline|block))?(?:-(?:start|end))?|border-radius)\s*:/;
     // The wrap/no-wrap duality again, read from the Badge side. A Badge is a
     // single-line pill by construction (`white-space: nowrap` and a fixed
     // `--spacing-5` height); a call site whose content genuinely wraps has to
@@ -478,14 +635,42 @@ describe('type scale contracts', () => {
     // rule racing the component — but it is the only one, so it is named here
     // rather than pattern-matched.
     const RELEASES_THE_SINGLE_LINE_BOX = new Set([
-      // Health blockers are sentences, not labels. Predates #1879.
+      // Health blockers are sentences, not labels: at the 620px floor a full
+      // sentence in a pill is wider than the content column, so this one
+      // releases `height` and `white-space` together. Predates #1879.
       '.settingsHealthBlockerBadge',
     ]);
     const roots = [
       resolve(REPO_ROOT, 'apps/desktop/src/renderer'),
       resolve(REPO_ROOT, 'packages/ui/src'),
     ];
-    const offenders = (await findBadgeClassNames(roots))
+    const badges = await findBadgeClassNames(roots);
+    // Guard the exemption, not just the rule, and guard it POSITIVELY. An
+    // entry that suppresses nothing is indistinguishable in review from one
+    // that suppresses a real finding — but "declares something OWNED" is too
+    // weak a test of that, because re-pinning this badge to a fixed 20px also
+    // declares something OWNED while doing the exact opposite of what the
+    // exemption is for. The reason is "it releases the single-line box", so
+    // that is what gets asserted: height genuinely released, and `white-space`
+    // with it, since releasing one without the other still clips.
+    for (const selector of RELEASES_THE_SINGLE_LINE_BOX) {
+      const body = merged.get(selector) ?? '';
+      assert.match(
+        body,
+        /(?<![-\w])height\s*:\s*auto\b/,
+        `${selector} is exempted because it releases Badge's fixed height; it must actually release it`,
+      );
+      assert.match(
+        body,
+        /white-space\s*:\s*(?:normal|pre-wrap|pre-line)\b/,
+        `${selector} releases Badge's height but not its nowrap, so the second line is clipped anyway`,
+      );
+      assert.ok(
+        badges.some(({ className }) => `.${className}` === selector),
+        `${selector} is exempted from the Badge-geometry contract but is not on any <Badge>`,
+      );
+    }
+    const offenders = badges
       .filter(({ className }) => !RELEASES_THE_SINGLE_LINE_BOX.has(`.${className}`))
       .filter(({ className }) => OWNED.test(merged.get(`.${className}`) ?? ''))
       .map(({ file, className }) => `.${className} (${file.replace(`${REPO_ROOT}/`, '')})`);
@@ -524,23 +709,28 @@ describe('type scale contracts', () => {
     // recorded: a wrap threshold is a font metric, so it differs per platform
     // and would be a number that rots rather than an invariant.
     //
+    // The selectors are `WRAPS` itself, not a second list beside it. Naming
+    // them twice — once to excuse them from the pin scan, once to require
+    // wrapping — let the two copies drift, and a selector dropped from one
+    // while kept in the other reads as governed by both while governed by
+    // neither.
+    //
+    // `CONSTRAINS_BLOCK_SIZE`, not `height` alone. `min-height: 20px;
+    // max-height: 20px` clips a wrapping row exactly as `height: 20px` does,
+    // and used to pass this check green.
+    //
     // Repo-wide rather than file-local. The earlier revision read one
     // stylesheet, so appending `.maka-plan-card-run { height: 20px }` from any
     // other file satisfied it — the same bypass the heading and font-size
     // checks in this file already went repo-wide to close.
     const merged = mergeBySelector(stripCssComments(await readAllRendererCss()));
-    for (const selector of [
-      '.maka-plan-card-run',
-      '.maka-plan-card-schedule',
-      '.settingsMemoryBackupCandidate',
-      '.settingsCapabilityOsPermissions li',
-    ]) {
+    for (const selector of WRAPS) {
       const body = merged.get(selector) ?? '';
-      const offenders = HEIGHT_DECL.test(body) ? [body.trim()] : [];
-      assert.deepEqual(
-        offenders,
-        [],
-        `${selector} wraps by design; a pinned height clips it rather than stabilising it`,
+      assert.ok(body !== '', `${selector} must still exist for its exemption to mean anything`);
+      assert.doesNotMatch(
+        body,
+        CONSTRAINS_BLOCK_SIZE,
+        `${selector} wraps by design; a fixed block size clips it rather than stabilising it`,
       );
     }
   });

--- a/apps/desktop/src/main/__tests__/type-scale-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/type-scale-contract.test.ts
@@ -28,11 +28,15 @@ import {
   assertCssRuleDecls,
   assertCustomPropPinnedOnce,
   findBadgeClassNames,
-  findDynamicBadgeClassNames,
   findTextRoleOffenders,
+  findUnreadableBadgeCallSites,
+  mergeByContext,
   mergeBySelector,
+  parseCssBlocks,
   parseCssCustomProps,
   readAllRendererCss,
+  splitSelectorList,
+  UNCONDITIONAL,
 } from './css-test-helpers.js';
 
 /**
@@ -63,15 +67,47 @@ import {
 const CONSTRAINS_BLOCK_SIZE = /(?<![-\w])(?:min-|max-)?(?:height|block-size)\s*:/;
 const HEIGHT_DECL_G = /(?<![-\w])(?:height|block-size)\s*:([^;}]*)/g;
 const RULER_VALUE = /^\s*var\((--h-control-[a-z0-9-]+)\)\s*$/;
+/** A height that hands the box back to its content. */
+const CONTENT_DRIVEN = /^\s*(?:auto|inherit|initial|unset|revert|(?:fit|min|max)-content)\b/;
 
 /**
- * Does this box's EFFECTIVE height come from the control ruler?
+ * The padding vocabulary, ONE authority, shared by the two contracts that read
+ * it — a chip is a box with its own padding, and a Badge className may not
+ * restate the padding the component computes.
+ *
+ * Written out because both shorthand families are real CSS and a guard that
+ * knows one of them is a guard with a documented bypass. Measured, both
+ * directions of that mistake have shipped in this file: `padding(?:-[a-z]+)?`
+ * missed `padding-inline-start`, and the rewrite that added the logical family
+ * dropped `padding-top/right/bottom/left` — a Badge className given
+ * `padding-left: 9px` redrew the component's box while the contract stayed
+ * green.
+ *
+ * A DECLARATION, not a substring. `/padding/` also matches
+ * `background-clip: padding-box`, which is not padding and not a chip: it is
+ * how a scrollbar thumb — a box no reader perceives as an object, whose block
+ * size is the scroll geometry's business — entered the chip population and
+ * earned an exemption group of its own. The group is deleted with the
+ * substring that created it.
+ */
+const PADDING = 'padding(?:-(?:inline|block|top|right|bottom|left))?(?:-(?:start|end))?';
+const DECLARES_PADDING = new RegExp(`(?<![-\\w])${PADDING}\\s*:`);
+
+/**
+ * This box's EFFECTIVE height declaration, or undefined.
  *
  * Effective, not "mentioned anywhere": CSS takes the last declaration, so a
  * body reading `height: var(--h-control-xs); … height: auto` is an unpinned
  * box that a test matching anywhere in the text reports as pinned. That is a
  * legal, one-line bypass of the whole contract, and this file already
  * documents the same false-green for custom properties.
+ */
+function effectiveHeight(body: string): string | undefined {
+  return [...body.matchAll(HEIGHT_DECL_G)].map((m) => m[1]).at(-1);
+}
+
+/**
+ * Does this box's effective height come from the control ruler?
  *
  * `rungs` is the set of tiers the ruler actually defines. Naming a tier that
  * does not exist makes the declaration invalid at computed-value time, so the
@@ -81,20 +117,35 @@ const RULER_VALUE = /^\s*var\((--h-control-[a-z0-9-]+)\)\s*$/;
  * there is one authority for what the ruler contains.
  */
 function pinnedToRuler(body: string, rungs: Set<string>): boolean {
-  const values = [...body.matchAll(HEIGHT_DECL_G)].map((m) => m[1]);
-  const last = values.at(-1);
+  const last = effectiveHeight(body);
   if (last === undefined) return false;
   const tier = RULER_VALUE.exec(last)?.[1];
   return tier !== undefined && rungs.has(tier);
 }
 
-/** The tiers `--h-control-*` actually defines, read from the token file. */
+/** The tiers `--h-control-*` defines, read from the ruler's OWN scope.
+ *
+ * The scope is the guard, not decoration. `parseCssCustomProps` reads the
+ * whole file, so a `--h-control-xss` declared under `.dark` — or in any other
+ * qualified rule — counted as a rung the ruler does not have: a chip naming it
+ * falls back to `auto` in every other theme, which is #1879 again, and the
+ * membership arm that exists to catch a typo waved it through. A rung is a
+ * rung only where every chip can inherit it. */
 async function rulerRungs(): Promise<Set<string>> {
-  const names = [...parseCssCustomProps(await read('maka-tokens.css')).keys()].filter((name) =>
-    name.startsWith('--h-control-'),
-  );
-  assert.ok(names.length >= 6, `the control ruler must define its tiers; found ${names.length}`);
-  return new Set(names);
+  const names = rootCustomProps(await read('maka-tokens.css'), '--h-control-');
+  assert.ok(names.size >= 6, `the control ruler must define its tiers; found ${names.size}`);
+  return names;
+}
+
+/** Custom properties with the given prefix declared unconditionally on `:root`. */
+function rootCustomProps(css: string, prefix: string): Set<string> {
+  const out = new Set<string>();
+  for (const { rule, conditions, decls } of parseCssBlocks(stripCssComments(css))) {
+    if (conditions.length > 0) continue;
+    if (!splitSelectorList(rule).includes(':root')) continue;
+    for (const { prop } of decls) if (prop.startsWith(prefix)) out.add(prop);
+  }
+  return out;
 }
 
 /**
@@ -150,6 +201,14 @@ const COMPONENT_OWNED = [
   '.maka-model-switcher-trigger.astryx-selector',
   '.maka-new-chat-model-selector.astryx-selector',
   '.maka-thinking-level-selector.astryx-selector',
+  // Takes its pill shape from Astryx `Button` via `--_button-radius` rather
+  // than a `border-radius` of its own, so the chip scan cannot see it and only
+  // this group governs it. An earlier revision dropped it as inert on the
+  // reasoning that neither filter selects it — true while the groups were
+  // skips, false the moment they became assertions: a skip nothing reaches is
+  // dead weight, but an assertion nothing reaches is the only thing standing
+  // between this rule and the `height` override #1879 removed.
+  '.maka-sidebar-update-button',
 ] as const;
 
 /** Pinned, but to a literal rather than to the ruler. The invariant #1879 is
@@ -175,17 +234,7 @@ const CENTRED_BY_A_BASE_RULE: ReadonlyArray<readonly [string, string]> = [
   ['.maka-quote-chip-collapsed', '.maka-quote-chip'],
 ];
 
-/** Not a chip at all — a scrollbar thumb, whose block size is the scroll
- * geometry's business and never a line box's. It reaches the pill scan only
- * because it is round and padded. */
-const NOT_A_BOX_A_READER_SEES = ['.maka-composer-project-scroll::-webkit-scrollbar-thumb'] as const;
-
-const NOT_ON_THE_RULER = new Set<string>([
-  ...WRAPS,
-  ...COMPONENT_OWNED,
-  ...PINNED_OFF_RULER,
-  ...NOT_A_BOX_A_READER_SEES,
-]);
+const NOT_ON_THE_RULER = new Set<string>([...WRAPS, ...COMPONENT_OWNED, ...PINNED_OFF_RULER]);
 
 const RENDERER = resolve(REPO_ROOT, 'apps/desktop/src/renderer');
 
@@ -452,13 +501,16 @@ describe('type scale contracts', () => {
     // scan reported the other 15 green. The arm did not narrow the population
     // to real chips; it narrowed it to chips that happen to write text rules.
     //
-    // Dropping it also removes the reason the scan needed a guard of its own.
-    // The third arm read the type vocabulary, and #1893 moved that vocabulary
-    // out from under it once already — which is why a `chips.length >= 8`
-    // floor sat here, an unanchored number whose only job was to notice the
-    // predicate going quiet. Two arms read radius and padding, which no type
-    // convergence can move. The floor is deleted rather than retuned: a guard
-    // that exists to watch a fragile arm should not outlive the arm.
+    // Dropping it also changed what guards this scan against going quiet. The
+    // third arm read the type vocabulary, which #1893 had moved out from under
+    // it once already, so a `chips.length >= 8` floor sat here — an unanchored
+    // number, deleted with the arm it watched. But the two surviving arms read
+    // token NAMES, and a name that is not defined resolves to nothing: measured,
+    // renaming `--radius-pill` across the tree reported CHIP POPULATION 0 and
+    // this contract passed. So the floor is replaced by the thing it was
+    // approximating and the same arm `rulerRungs` already runs — the tokens the
+    // predicate reads must exist — which fails on the rename rather than
+    // reporting an empty population as compliance.
     //
     // Merged per selector, not per rule block. A chip whose type lives in one
     // rule and whose pill chrome lives in another is one box to a browser and
@@ -475,8 +527,12 @@ describe('type scale contracts', () => {
     // a pin would clip. `--radius-control` is the repo's general control shape,
     // not a chip signal. The squared chips that motivated trying it are Astryx
     // `Badge`s now, so that population is empty rather than unguarded.
+    assert.ok(
+      rootCustomProps(await read('maka-tokens.css'), '--radius-pill').size === 1,
+      'the pill radius this scan derives its population from must exist on :root',
+    );
     const isChip = (body: string) =>
-      /border-radius:\s*var\(--radius-pill\)/.test(body) && /padding/.test(body);
+      /border-radius:\s*var\(--radius-pill\)/.test(body) && DECLARES_PADDING.test(body);
 
     // Anything not named in one of the three reason-groups must pin, and each
     // group is asserted by its own contract below rather than merely skipped
@@ -499,11 +555,22 @@ describe('type scale contracts', () => {
     // the code is an unconditional pass — measured, a review mutation added
     // `height: 1px` to a rule excused as "the Astryx component sizes this" and
     // the whole suite stayed green.
-    const merged = mergeBySelector(stripCssComments(await readAllRendererCss()));
+    //
+    // WHICH VIEW follows from which question, and the two groups below ask
+    // opposite ones. "Does any rule, under any condition, declare a block size
+    // here" is a must-NOT question with no conditional distinction — measured,
+    // `@media (max-width: 620px) { .maka-model-switcher-trigger.astryx-selector
+    // { height: 40px } }` is verbatim the override #1879 removed and passed the
+    // unconditional view green. "Is this box still pinned" is a must-HOLD
+    // question about the unconditional box, and folding breakpoints into it
+    // would read a responsive value as the pin.
+    const css = stripCssComments(await readAllRendererCss());
+    const anyCondition = mergeBySelector(css, { includeConditional: true });
+    const merged = mergeBySelector(css);
     const rungs = await rulerRungs();
 
     for (const selector of COMPONENT_OWNED) {
-      const body = merged.get(selector) ?? '';
+      const body = anyCondition.get(selector) ?? '';
       assert.ok(body !== '', `${selector} must still exist for its exemption to mean anything`);
       assert.doesNotMatch(
         body,
@@ -513,14 +580,20 @@ describe('type scale contracts', () => {
     }
 
     for (const selector of PINNED_OFF_RULER) {
-      const body = merged.get(selector) ?? '';
-      assert.match(
-        body,
-        CONSTRAINS_BLOCK_SIZE,
-        `${selector} is excused because it is already pinned to a literal; losing that pin hands the box back to the line box`,
+      // The EFFECTIVE height, not "constrains its block size somehow".
+      // `CONSTRAINS_BLOCK_SIZE` answers the must-not question above and is the
+      // wrong instrument here: measured, rewriting this group's `height: 16px`
+      // as `min-height: 16px` left the line box free to grow the chip again —
+      // the exact defect #1879 is about — and the exemption stayed green,
+      // because a min-height does constrain a block size. The two vocabularies
+      // are documented apart at the top of this file for this reason.
+      const height = effectiveHeight(anyCondition.get(selector) ?? '')?.trim();
+      assert.ok(
+        height !== undefined && height !== '' && !CONTENT_DRIVEN.test(height),
+        `${selector} is excused because it is already pinned to a literal; its effective height is ${height ?? 'unset'}, which hands the box back to the line box`,
       );
       assert.ok(
-        !pinnedToRuler(body, rungs),
+        !pinnedToRuler(merged.get(selector) ?? '', rungs),
         `${selector} now takes a ruler tier — drop it from PINNED_OFF_RULER rather than carrying a stale reason`,
       );
     }
@@ -562,13 +635,22 @@ describe('type scale contracts', () => {
     // The earlier revision filtered `EXEMPT` here, inherited from a different
     // question; measured, it excluded nothing, so it was a silent widening
     // waiting for its first entry.
+    // LAST declaration, not "matches somewhere". Both halves are overridable
+    // in place: measured, appending `display: block` after an `inline-flex`
+    // left the earlier text in the merged body and passed this check, which is
+    // precisely the inert-`align-items` failure the pair form was adopted to
+    // catch, one property over. `lastValue` is what a browser reads.
+    const lastValue = (body: string, prop: string) =>
+      [...body.matchAll(new RegExp(`(?<![-\\w])${prop}\\s*:([^;}]*)`, 'g'))].map((m) => m[1]).at(-1) ?? '';
+    const CENTRES = (body: string) =>
+      /^\s*(?:inline-)?(?:flex|grid)\b/.test(lastValue(body, 'display')) &&
+      /^\s*(?:safe\s+|unsafe\s+)?center\b/.test(
+        lastValue(body, 'place-items') || lastValue(body, 'align-items'),
+      );
     const rungs = await rulerRungs();
     const merged = mergeBySelector(stripCssComments(await readAllRendererCss()));
     // The base half of the pair, asserted rather than assumed: a modifier is
     // only excused because its base centres for it, and that has to stay true.
-    const CENTRES = (body: string) =>
-      /display:\s*(?:inline-)?(?:flex|grid)/.test(body) &&
-      /(?:align-items|place-items):\s*(?:safe\s+|unsafe\s+)?center/.test(body);
     for (const [modifier, base] of CENTRED_BY_A_BASE_RULE) {
       const pair = `${merged.get(base) ?? ''} ${merged.get(modifier) ?? ''}`;
       assert.ok(
@@ -579,13 +661,7 @@ describe('type scale contracts', () => {
     const excused = new Set(CENTRED_BY_A_BASE_RULE.map(([modifier]) => modifier));
     const offenders = [...merged]
       .filter(([selector, body]) => pinnedToRuler(body, rungs) && !excused.has(selector))
-      .filter(
-        ([, body]) =>
-          !(
-            /display:\s*(?:inline-)?(?:flex|grid)/.test(body) &&
-            /(?:align-items|place-items):\s*(?:safe\s+|unsafe\s+)?center/.test(body)
-          ),
-      )
+      .filter(([, body]) => !CENTRES(body))
       .map(([selector]) => selector);
     assert.deepEqual(
       offenders,
@@ -627,7 +703,9 @@ describe('type scale contracts', () => {
     // the entry deleted.
     const css = stripCssComments(await readAllRendererCss());
     const merged = mergeBySelector(css, { includeConditional: true });
-    const OWNED = /(?<![-\w])(?:min-|max-)?(?:height|block-size|line-height|font|font-size|padding(?:-(?:inline|block))?(?:-(?:start|end))?|border-radius)\s*:/;
+    const OWNED = new RegExp(
+      `(?<![-\\w])(?:(?:min-|max-)?(?:height|block-size)|line-height|font|font-size|${PADDING}|border-radius)\\s*:`,
+    );
     // The wrap/no-wrap duality again, read from the Badge side. A Badge is a
     // single-line pill by construction (`white-space: nowrap` and a fixed
     // `--spacing-5` height); a call site whose content genuinely wraps has to
@@ -653,17 +731,27 @@ describe('type scale contracts', () => {
     // exemption is for. The reason is "it releases the single-line box", so
     // that is what gets asserted: height genuinely released, and `white-space`
     // with it, since releasing one without the other still clips.
+    //
+    // BOTH IN ONE CASCADE CONTEXT. The flattened inclusive view is the right
+    // instrument for the must-not scan below and the wrong one here: it answers
+    // "does any rule anywhere say X" twice, which two rules under mutually
+    // exclusive conditions satisfy without ever applying together. Measured,
+    // leaving `height: auto` in `@media (max-width: 620px)` and moving
+    // `white-space: normal` into `@media (min-width: 621px)` releases the box
+    // at no viewport at all and passed both matches. So the pair is checked
+    // per context, each read as the unconditional rules plus that context's.
+    const contexts = mergeByContext(css);
     for (const selector of RELEASES_THE_SINGLE_LINE_BOX) {
-      const body = merged.get(selector) ?? '';
-      assert.match(
-        body,
-        /(?<![-\w])height\s*:\s*auto\b/,
-        `${selector} is exempted because it releases Badge's fixed height; it must actually release it`,
-      );
-      assert.match(
-        body,
-        /white-space\s*:\s*(?:normal|pre-wrap|pre-line)\b/,
-        `${selector} releases Badge's height but not its nowrap, so the second line is clipped anyway`,
+      const byContext = contexts.get(selector) ?? new Map<string, string>();
+      const base = byContext.get(UNCONDITIONAL) ?? '';
+      const applied = [...byContext].map(([key, body]) => (key === UNCONDITIONAL ? body : base + body));
+      assert.ok(
+        applied.some(
+          (body) =>
+            /(?<![-\w])height\s*:\s*auto\b/.test(body) &&
+            /white-space\s*:\s*(?:normal|pre-wrap|pre-line)\b/.test(body),
+        ),
+        `${selector} is exempted because it releases Badge's fixed height AND its nowrap; no single cascade context does both, so at every viewport the box is still clipped`,
       );
       assert.ok(
         badges.some(({ className }) => `.${className}` === selector),
@@ -687,14 +775,22 @@ describe('type scale contracts', () => {
     // used to rot. There is no legitimate need for a computed class on a Badge
     // today; if one arrives, it needs a seam that stays checkable rather than
     // a quiet exit.
-    const dynamic = (await findDynamicBadgeClassNames([
+    //
+    // A prop SPREAD is the same exit and was open until measured: rewriting a
+    // real call site as `<Badge {...{ className: 'settingsOsPermissionImpactLabel' }} />`
+    // is legal JSX that the static scan cannot read and that a `className={`
+    // check does not match, so the contract above read it as a Badge with no
+    // class at all and a `height` added to that class passed everything green.
+    // Anything this scan cannot read has to say so rather than resolve to
+    // "nothing to govern here".
+    const unreadable = (await findUnreadableBadgeCallSites([
       resolve(REPO_ROOT, 'apps/desktop/src/renderer'),
       resolve(REPO_ROOT, 'packages/ui/src'),
     ])).map((file) => file.replace(`${REPO_ROOT}/`, ''));
     assert.deepEqual(
-      dynamic,
+      unreadable,
       [],
-      `<Badge className={…}> cannot be read statically, so it escapes the Badge-geometry contract:\n${dynamic.join('\n')}`,
+      `a <Badge> whose className is computed or spread cannot be read statically, so it escapes the Badge-geometry contract:\n${unreadable.join('\n')}`,
     );
   });
 
@@ -723,7 +819,15 @@ describe('type scale contracts', () => {
     // stylesheet, so appending `.maka-plan-card-run { height: 20px }` from any
     // other file satisfied it — the same bypass the heading and font-size
     // checks in this file already went repo-wide to close.
-    const merged = mergeBySelector(stripCssComments(await readAllRendererCss()));
+    //
+    // And condition-inclusive, for the same reason as the component-owned
+    // group: this is a must-NOT question. Measured, pinning `.maka-plan-card-run`
+    // to 20px inside `@media (max-width: 620px)` clips its sentence at exactly
+    // the width where the column is narrowest and wrapping likeliest, and the
+    // unconditional view reported it green.
+    const merged = mergeBySelector(stripCssComments(await readAllRendererCss()), {
+      includeConditional: true,
+    });
     for (const selector of WRAPS) {
       const body = merged.get(selector) ?? '';
       assert.ok(body !== '', `${selector} must still exist for its exemption to mean anything`);

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -28,13 +28,15 @@ import { ChevronRight, KeyRound, Settings as SettingsIcon, Cpu, AlertCircle } fr
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { RECOMMENDED_PROVIDER_TYPES, type LlmConnection, type OnboardingState, type ProviderType, type SettingsSection } from '@maka/core';
 import {
+  Badge,
+  type BadgeVariant,
   Button,
   useMountedRef,
   useUiLocale,
 } from '@maka/ui';
 import { Item } from '@astryxdesign/core/Item';
 import { ProviderLogo, providerDisplay } from './settings/provider-display';
-import { getOnboardingHeroCopy, getOnboardingSetupSteps, type OnboardingSetupStep } from './onboarding-hero-copy';
+import { getOnboardingHeroCopy, getOnboardingSetupSteps, type OnboardingSetupStep, type OnboardingSetupStepState } from './onboarding-hero-copy';
 import { getOnboardingCopy } from './locales/onboarding-copy';
 
 export interface OnboardingHeroProps {
@@ -538,6 +540,20 @@ function SetupHero(props: SetupHeroProps) {
   );
 }
 
+/* #1879: the per-step state pill is an Astryx `Badge`. `active` and `warning`
+   were the only two states product CSS ever tinted; the other two were the
+   untinted default, which is what `neutral` is.
+   Colour names rather than the semantic `info`/`error`: Astryx paints the
+   semantic archive as solid saturated fills and the colour archive as tints,
+   and these two states were a 12% wash. A solid red step in a setup checklist
+   reads as a failure; the state means "needs your attention". */
+const SETUP_STEP_VARIANT: Record<OnboardingSetupStepState, BadgeVariant> = {
+  done: 'neutral',
+  active: 'blue',
+  pending: 'neutral',
+  warning: 'red',
+};
+
 function SetupProgress(props: { steps: readonly OnboardingSetupStep[] }) {
   const copy = getOnboardingCopy(useUiLocale());
   return (
@@ -551,9 +567,11 @@ function SetupProgress(props: { steps: readonly OnboardingSetupStep[] }) {
             <strong>{step.label}</strong>
             <small>{step.detail}</small>
           </span>
-          <span className="maka-onboarding-setup-step-state">
-            {copy.setupStatus[step.state]}
-          </span>
+          <Badge
+            className="maka-onboarding-setup-step-state"
+            variant={SETUP_STEP_VARIANT[step.state]}
+            label={copy.setupStatus[step.state]}
+          />
         </li>
       ))}
     </ol>

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -406,10 +406,66 @@
      glyph (`useTableSortable.tsx`) sets `lineHeight: '1'` at 10px behind a
      lint exception reading "no token for lineHeight:1 (tight badge)". It is a
      glyph, not text — below the smallest governed size, in a box the scale
-     never sized. Nothing in this file is in that position; the compact pills
-     here sit at the caption tier, centre their 20px line box inside a shorter
-     flex control without clipping it, and are tracked for a box-height fit in
-     their own follow-up rather than by opting back out of the scale.
+     never sized. That exception is Astryx's own, in `@astryxdesign/core`, and
+     the boundary is worth being precise about: the contracts in this repo scan
+     first-party CSS, so a vendor component's inline React style was never in
+     their reach and needs no exemption here to stay legal. First-party PRODUCT
+     code holds no `lineHeight` inline style; the stories under
+     `packages/ui/stories/` do, which is why the boundary is scoped to what
+     the contracts actually scan rather than stated as an absolute.
+
+     The box-height follow-up this paragraph used to defer is #1879, and it has
+     landed, so the compact pills are no longer "tracked" — they are pinned.
+     Each single-line chip takes its height from the `--h-control-*` scale
+     below and centres its line box, which is the Badge/Kbd identity above
+     expressed with maka's own control ruler. The per-chip measurements are in
+     that PR rather than here: a log of before/after numbers in this file is
+     what the sentence it replaces already proved would rot.
+
+     Two relationships belong here, because nothing else records them.
+
+     First, most of these chips are not product CSS any more. Astryx ships a
+     `Badge` whose box IS this recipe — 20px off `--spacing-5`, pill radius,
+     supporting tier, `nowrap` — so the status pills, counts and category
+     badges are `<Badge variant=...>` at the call site, and their height, chrome
+     and per-state colour left this stylesheet with them. What stayed in CSS is
+     what Badge does not do: a chip with no chrome at all (a timestamp, a ⌘N
+     hint), one that truncates, one that wraps, or one whose colour is a
+     product concept Badge has no variant for.
+
+     Two things the swap changed that no rule records. Badge's weight is
+     `--font-weight-medium` and its inline padding is `--spacing-2`, so the six
+     chips that were semibold at 4–6px now read one step lighter and one step
+     wider. And Astryx keeps TWO badge archives: the semantic names
+     (`warning`, `error`, `info`, `success`) paint SOLID saturated fills — maka
+     retunes them to flat hex, and `warning` has no `light-dark()` at all —
+     while the colour names (`yellow`, `red`, `blue`, `green`) paint tints.
+     Chips whose hand-written chrome was a 5–18% wash take the colour archive,
+     so the swap does not turn a quiet marker into an alert. The exception is
+     Settings' status rows, which route through `statusBadgeVariant` and were
+     already on the semantic archive before this; one tone table per page beats
+     a per-chip opinion. Neither archive follows `data-maka-theme` — that is a
+     property of the Astryx palette, and buying it back would mean product CSS
+     repainting a component's own surface.
+
+     Second, `--h-control-md/lg/xl` now DERIVE from `--size-element-sm/md/lg`
+     rather than restating 28/32/36. That is Astryx's own control ruler — what
+     its Button, TextInput, Selector and SideNavItem read — and maka's md/lg/xl
+     are those three at shifted names. While the two were independent
+     arithmetic, a chip at `--h-control-lg` and an Astryx control beside it at
+     `--size-element-md` lined up by coincidence; retuning Astryx would have
+     reintroduced, at the box, the drift #1878 removed at the line. They agree
+     at `:root`, which is where both are declared and therefore where the
+     substitution happens — a retune inside a nested `<Theme>` would land on
+     that wrapper and leave `--h-control-*` frozen at the root value, so this
+     is "they agree" and not "they cannot disagree". The e2e resolves all six
+     rungs to numbers, which is what catches an upstream token being renamed
+     away. Where a box IS an Astryx component the fix is still its `size` prop
+     and not a height here — `.maka-sidebar-update-button` and the three
+     composer selectors were moved that way rather than pinned.
+     `.maka-composer-model-chip` is NOT one of those: that class sits on
+     `ModelChipStatic`'s inert `<span>`, never on the Button it renders when
+     clickable, so it pins like any other chip.
 
      A consequence worth stating, because it limits what this convergence
      bought: a unitless leading still inherits as a ratio. An element that
@@ -649,18 +705,24 @@
      the same token for width and height (their footprint = control size).
      App-chrome bars (--h-titlebar/--h-composer-min) stay as their own
      semantic tokens — they are structure, not controls.
-     md (28) and xl (36) use calc(var(--spacing) * 7/9) directly because maka's
-     discrete spacing scale skips 7 and 9 — control-only tiers must not expand
-     the general --space-* scale (that would invite p-7 / gap-7 drift). */
+     xs/sm/2xl (20/24/40) stay on the --space-* ruler: Astryx has no element
+     token at those sizes, and 20px is what its own Badge and Kbd take from
+     --spacing-5, so that tier already agrees by construction. */
   --h-control-xs:  var(--space-5);  /* 20px — kbd, dot, tiny chip / close  */
   --h-control-sm:  var(--space-6);  /* 24px — small button, chip, sidebar
                                       topbar button, model switcher       */
-  --h-control-md:  calc(var(--spacing) * 7);  /* 28px — compact menu item, sm tab,
+  /* #1879: md/lg/xl DERIVE from Astryx rather than restating its numbers.
+     Astryx sizes Button, TextInput, Selector and SideNavItem off
+     `--size-element-sm/md/lg` (28/32/36); maka's md/lg/xl ARE those three at
+     shifted names. They used to be independent arithmetic on `--spacing`, so a
+     chip at `--h-control-lg` and an Astryx control beside it at
+     `--size-element-md` lined up by coincidence. Now they cannot disagree. */
+  --h-control-md:  var(--size-element-sm);  /* 28px — compact menu item, sm tab,
                                       round FAB (jump-to-bottom)          */
-  --h-control-lg:  var(--space-8);  /* 32px — default button, input, tab,
+  --h-control-lg:  var(--size-element-md);  /* 32px — default button, input, tab,
                                       sidebar nav row, session row,
                                       settings nav row, select            */
-  --h-control-xl:  calc(var(--spacing) * 9);  /* 36px — prominent button,
+  --h-control-xl:  var(--size-element-lg);  /* 36px — prominent button,
                                       first-run checklist row             */
   --h-control-2xl: var(--space-10); /* 40px — toolbar, large touch target  */
 

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -721,9 +721,15 @@
                                       round FAB (jump-to-bottom)          */
   --h-control-lg:  var(--size-element-md);  /* 32px — default button, input, tab,
                                       sidebar nav row, session row,
-                                      settings nav row, select            */
-  --h-control-xl:  var(--size-element-lg);  /* 36px — prominent button,
-                                      first-run checklist row             */
+                                      settings nav row, select, first-run
+                                      stepper item                        */
+  /* #1879: this tier used to name "first-run checklist row" as a consumer.
+     Nothing in the renderer reads it — that row is the stepper item above, and
+     measured, its floor is 29px, so it takes `lg`. A tier documenting a
+     consumer it does not have is the same defect as an exemption documenting a
+     rule it does not govern; the tier stays (Astryx defines it and a prominent
+     button is a real future need) but it is honest about having no reader. */
+  --h-control-xl:  var(--size-element-lg);  /* 36px — no consumer today     */
   --h-control-2xl: var(--space-10); /* 40px — toolbar, large touch target  */
 
   /* === content measure (#520 PR4 item 16) ================================

--- a/apps/desktop/src/renderer/plan-mode-panel.tsx
+++ b/apps/desktop/src/renderer/plan-mode-panel.tsx
@@ -6,7 +6,7 @@ import type {
   SessionEvent,
   SessionSummary,
 } from '@maka/core';
-import { Button as UiButton, useToast } from '@maka/ui';
+import { Badge, type BadgeVariant, Button as UiButton, useToast } from '@maka/ui';
 import { ChevronDown } from '@maka/ui/icons';
 
 export interface PlanModeState {
@@ -122,10 +122,18 @@ export function PlanProposalCard(props: {
             <strong>{proposal.title}</strong>
           </div>
           <div className="plan-proposal-meta">
-            <span className="plan-proposal-revision">Revision {proposal.revision}</span>
-            <span className="plan-proposal-status" data-status={proposal.status}>
-              {proposalStatusLabel(proposal.status)}
-            </span>
+            <Badge
+              className="plan-proposal-revision"
+              label={
+                <>
+                  Revision <code>{proposal.revision}</code>
+                </>
+              }
+            />
+            <Badge
+              variant={proposalStatusVariant(proposal.status)}
+              label={proposalStatusLabel(proposal.status)}
+            />
           </div>
         </div>
         {proposal.overview && <p className="plan-proposal-overview">{proposal.overview}</p>}
@@ -279,6 +287,16 @@ function proposalStatusLabel(status: PlanProposal['status']): string {
   if (status === 'approved') return '已批准';
   if (status === 'stale') return '已过期';
   return '等待确认';
+}
+
+/* #1879: the status pill is an Astryx `Badge`. Only `approved` is a semantic
+   outcome; waiting and stale are steady states, so they stay neutral rather
+   than borrowing a colour the state does not mean. `green` rather than
+   `success` because Astryx paints its semantic archive as solid saturated
+   fills and its colour archive as tints — the chrome this replaced was a
+   tint. */
+function proposalStatusVariant(status: PlanProposal['status']): BadgeVariant {
+  return status === 'approved' ? 'green' : 'neutral';
 }
 
 function executionStepStatusLabel(status: PlanExecutionStep['status']): string {

--- a/apps/desktop/src/renderer/settings/about-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/about-settings-page.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useState } from 'react';
 import { Card } from '@astryxdesign/core';
 import { Sparkles } from '@maka/ui/icons';
 import {
+  Badge,
   Button,
   PageHeader,
   SectionHeader,
@@ -134,14 +135,17 @@ export function AboutSettingsPage() {
         title="Maka"
         badge={
           <>
-            <code className="settingsAboutVersion">v{info.appVersion}</code>
-            <span className="settingsAboutChannel">
-              {info.buildMode === 'dev'
-                ? info.buildCommit
-                  ? `${copy.devBuild} · ${info.buildCommit}`
-                  : copy.devBuild
-                : copy.packagedBuild}
-            </span>
+            <Badge label={<code>v{info.appVersion}</code>} />
+            <Badge
+              variant="blue"
+              label={
+                info.buildMode === 'dev'
+                  ? info.buildCommit
+                    ? `${copy.devBuild} · ${info.buildCommit}`
+                    : copy.devBuild
+                  : copy.packagedBuild
+              }
+            />
           </>
         }
         subtitle={copy.subtitle}

--- a/apps/desktop/src/renderer/settings/memory-entry-list.tsx
+++ b/apps/desktop/src/renderer/settings/memory-entry-list.tsx
@@ -1,5 +1,5 @@
 import type { LocalMemoryState } from '@maka/core';
-import { Button, RelativeTime } from '@maka/ui';
+import { Badge, Button, RelativeTime } from '@maka/ui';
 import { memoryOriginLabel } from './memory-settings-labels';
 import type { MemorySettingsCopy } from '../locales/settings-memory-copy';
 
@@ -71,9 +71,14 @@ export function MemoryEntryList(props: {
                     </span>
                   )}
                 </small>
-                <span className="settingsMemoryPromptScope" data-active={props.archived ? 'false' : 'true'}>
-                  {props.archived ? props.copy.text.archivedNoPrompt : props.copy.text.activePrompt}
-                </span>
+                <Badge
+                  className="settingsMemoryPromptScope"
+                  /* `blue`, not `info`: Astryx's semantic archive is solid
+                     fills and its colour archive is tints, and the wash this
+                     replaced was `--state-selected-bg`. */
+                  variant={props.archived ? 'neutral' : 'blue'}
+                  label={props.archived ? props.copy.text.archivedNoPrompt : props.copy.text.activePrompt}
+                />
                 <p>{entry.content}</p>
                 {(props.onCopyReference || props.onFocusDraft || props.onStatusChange) && (
                   <div className="settingsMemoryEntryActions" role="group" aria-label={props.copy.entryActionsAria(entry.title)}>

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -379,9 +379,20 @@ function CapabilityRow(props: { capability: CapabilitySnapshot; copy: Permission
             {capability.osPermissions.map((req) => (
               <li key={req.id}>
                 <span>{copy.osPermissions[req.id]?.label ?? req.id}</span>
-                <em data-tone={copy.osStates[req.status].tone}>
-                  {copy.osStates[req.status].label}
-                </em>
+                {/* #1879: was an `<em data-tone>` with a base rule and three
+                    hand-tinted overrides. Routed through the same
+                    `statusBadgeVariant` seam the readiness badge above already
+                    used — one tone table for the page beats a per-chip
+                    opinion. That keeps it on Astryx's semantic (solid) archive
+                    rather than the tinted one the chat and sidebar chips use,
+                    which is deliberate: every other status badge in Settings
+                    reads from this seam, and dissenting here would recreate
+                    the local exception this replaced. No tone actually
+                    changed — `granted` is `neutral` in the copy table. */}
+                <Badge
+                  variant={statusBadgeVariant(copy.osStates[req.status].tone)}
+                  label={copy.osStates[req.status].label}
+                />
               </li>
             ))}
           </ul>
@@ -462,7 +473,7 @@ function OsPermissionRow(props: {
         <small className="settingsOsPermissionPurpose">{purpose}</small>
         {impact ? (
           <small className="settingsOsPermissionImpact">
-            <span className="settingsOsPermissionImpactLabel">{props.copy.impact}</span>
+            <Badge className="settingsOsPermissionImpactLabel" label={props.copy.impact} />
             <span>{impact}</span>
           </small>
         ) : null}

--- a/apps/desktop/src/renderer/settings/provider-catalog.tsx
+++ b/apps/desktop/src/renderer/settings/provider-catalog.tsx
@@ -25,9 +25,12 @@ export function ProviderCatalogCard(props: { type: ProviderType; count: number; 
         label={<span className="providerCatalogTitle">{display.name}</span>}
         description={<span className="providerCatalogDesc">{display.description}</span>}
         endContent={(
+          /* Tinted archive, not the semantic one — this is a catalogue
+             decoration, not a status seam, and the rule it replaced was a
+             tint. `statusBadgeVariant`'s solid archive is reserved for the
+             rows that actually report state. */
           <Badge
-            variant={disabledStatus === 'experimental' ? 'warning' : 'info'}
-            className="providerCatalogStateBadge"
+            variant={disabledStatus === 'experimental' ? 'yellow' : 'blue'}
             aria-hidden="true"
             label={disabledStatus === 'experimental' ? copy.experiment : copy.unavailable}
           />
@@ -50,7 +53,7 @@ export function ProviderCatalogCard(props: { type: ProviderType; count: number; 
         </span>
       )}
       endContent={<span className="providerCatalogActions">
-        {display.badge && <span className="providerCatalogBadge">{display.badge}</span>}
+        {display.badge && <Badge label={display.badge} />}
         <ChevronRight className="providerCatalogChevron" size={15} aria-hidden="true" />
       </span>}
       onClick={props.onSelect}

--- a/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
+++ b/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
@@ -5,6 +5,7 @@ import {
   type ProviderType,
 } from '@maka/core';
 import {
+  Badge,
   Button,
   useMountedRef,
   useToast,
@@ -196,7 +197,7 @@ export function ModelOAuthSection(props: { query?: string; onConnectionsChanged(
               label={<span className="providerCatalogTitle" aria-label={copy.cardAria(card.name, liveBadge, liveDescription)}>{card.name}</span>}
               description={<span className="providerCatalogDesc providerOAuthCardDescription">{liveDescription}</span>}
               endContent={<span className="providerCatalogActions">
-                <span className="providerCatalogBadge providerOAuthCardBadge">{liveBadge}</span>
+                <Badge className="providerOAuthCardBadge" label={liveBadge} />
                 <ChevronRight className="providerCatalogChevron" size={15} aria-hidden="true" />
               </span>}
               onClick={() => openOAuthModal(card.id)}

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -55,6 +55,11 @@
 
 .maka-session-workbar-count {
   font: var(--maka-text-supporting);
+  height: var(--h-control-xs);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
   min-width: var(--space-4);
   padding-inline: var(--space-1);
   border-radius: var(--radius-pill);

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -191,9 +191,18 @@
    touch + from assistive tech). It stays quiet — caption tier at
    normal weight, muted — and rides in the user turn's meta row beneath
    the block. Aligned to the same tier the footer-action cva uses (text-xs). */
+/* #1879: height off the control ruler, not off the line box. `inline-block`
+   let the leading decide the box — measured, bumping this element's own
+   leading to 40px took the box from 20px to 40px and carried the meta row
+   with it. `--h-control-xs` is 20px, the value the supporting leading
+   already resolves to, so the pin is pixel-neutral today and load-bearing
+   the next time a leading moves. Safe to pin because `white-space: nowrap`
+   below makes single-line a property of this box rather than an assumption. */
 .maka-message-time-inline {
   font: var(--maka-text-supporting);
-  display: inline-block;
+  height: var(--h-control-xs);
+  display: inline-flex;
+  align-items: center;
   color: var(--muted-foreground);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;

--- a/apps/desktop/src/renderer/styles/composer-mention.css
+++ b/apps/desktop/src/renderer/styles/composer-mention.css
@@ -105,6 +105,13 @@
   position: absolute;
   top: -2px;
   right: -2px;
+  /* #1879 left this one at a literal 16px, the only chip in that sweep it did
+     not move onto `--h-control-*`, so the reason is on the record rather than
+     looking like an oversight. This badge is `pointer-events: none` and is
+     positioned OUT of the layout, on the trigger's corner. It
+     aligns with no control, so there is no neighbour to name a tier, and the
+     nearest rung would grow a decorative overlay by 25%. It is already pinned
+     — measured, the leading cannot move it — which is all #1879 asked for. */
   min-width: 16px;
   height: 16px;
   padding: 0 var(--space-0-5);

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -135,7 +135,16 @@
 /* Model chip (static fallback) still owns its own quiet geometry. */
 .maka-composer-model-chip {
   font: var(--maka-text-label);
-  height: 26px;
+  /* #1879: was a bare 26px. It is NOT an Astryx component — `ModelChipStatic`
+     puts this class only on its inert `<span>` branch; the `onOpenSettings`
+     branch renders a `Button size="sm"` that carries no class at all
+     (chat-model-switcher.tsx). So nothing sizes this box but this rule, and
+     unpinning it measured 22px (the label role's 20px line box plus two
+     hairlines) against the 28px Selector beside it. `--h-control-md` resolves
+     to `--size-element-sm`, which is the token that Selector's own `size="sm"`
+     reads — so the two agree by deriving from one token rather than by two
+     product rules agreeing on a literal. */
+  height: var(--h-control-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -400,7 +409,11 @@
   margin: 0 auto var(--space-1);
   padding: 0 var(--space-1-5);
   box-sizing: border-box;
-  height: 26px;
+  /* #1879: was `height: 26px`, an off-ruler literal. The floor is arithmetic
+     under `border-box`: a 20px supporting line box plus two hairline borders
+     needs 22px, so `--h-control-sm` (24px) is the smallest tier that holds it
+     without clipping. Loses 2px. */
+  height: var(--h-control-sm);
   border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-pill);
   background: var(--background-elevated);
@@ -428,11 +441,19 @@
   text-overflow: ellipsis;
 }
 
+/* #1879: the one site in this family where the old height was not merely
+   off-ruler but smaller than the line box it renders — measured, an 18px box
+   around a 20px line box, and `display: block` so the text was not centred
+   either. Nothing clipped (the 2px excess is half-leading, and there is no
+   `overflow: hidden` here), but a box shorter than its own line box has no
+   defensible height. `--h-control-xs` (20px) is that line box. Gains 2px. */
 .maka-composer-revision-notice-cancel {
   font: var(--maka-text-supporting);
   appearance: none;
   flex: 0 0 auto;
-  height: 18px;
+  height: var(--h-control-xs);
+  display: inline-flex;
+  align-items: center;
   padding: 0 var(--space-1-5);
   border: none;
   border-radius: var(--radius-pill);

--- a/apps/desktop/src/renderer/styles/deep-research.css
+++ b/apps/desktop/src/renderer/styles/deep-research.css
@@ -130,7 +130,15 @@
   gap: var(--space-2);
 }
 
+/* #1879: a count pill beside an Astryx Button, and the same shape as
+   `.maka-session-workbar-count` and `.maka-tool-count`. It declared no type of
+   its own — it inherits — which is precisely how it stayed invisible to a chip
+   scan that required a rule to name its own role. Measured 24px natural (20px
+   line box plus 2 x 2px padding); `--h-control-sm` is 24, so nothing moves. */
 .maka-deep-research-run-count {
+  height: var(--h-control-sm);
+  display: inline-flex;
+  align-items: center;
   padding: var(--space-0-5) var(--space-2);
   border-radius: var(--radius-pill);
   background: oklch(from var(--focus-ring) l c h / 0.10);

--- a/apps/desktop/src/renderer/styles/model-switcher.css
+++ b/apps/desktop/src/renderer/styles/model-switcher.css
@@ -50,9 +50,14 @@
 .maka-new-chat-model-selector.astryx-selector,
 .maka-thinking-level-selector.astryx-selector {
   font: var(--maka-text-label);
-  height: 26px;
-  min-height: 26px;
-  box-sizing: border-box;
+  /* #1879: this rule used to force a height — 26px originally, then 24px on the
+     ruler. Both were wrong for the same reason the sidebar update button was:
+     these ARE Astryx Selectors (`size="sm"`), and Selector sizes off
+     `--size-element-sm` (28px). Forcing 24px pushed a component below its own
+     smallest tier and desynced it from `ModelChipStatic`, the inert state of
+     the same chip, which is a `Button size="sm"` at 28px — the pill changed
+     height when it became clickable. Declaring no height is what makes the two
+     states agree by derivation. */
   padding-block: 0;
   padding-inline: var(--space-2);
   border-color: transparent;

--- a/apps/desktop/src/renderer/styles/module-pages/mcp.css
+++ b/apps/desktop/src/renderer/styles/module-pages/mcp.css
@@ -195,10 +195,19 @@
   -webkit-line-clamp: 2;
 }
 
+/* #1879: was a bare 34px square — one of the off-ruler literals
+   (22/26/30/34/38) the control ruler exists to end, named as such in
+   maka-tokens.css. It is the install branch of a slot whose other branch
+   renders `<Button size="sm">` (mcp-page.tsx), i.e. an Astryx control at
+   `--size-element-sm` = 28px, so the row changed height depending on whether
+   a server was installed. `--h-control-md` resolves to that same
+   `--size-element-sm`: the two branches now agree by deriving from one token
+   rather than by two rules happening to match. Square icon control, so width
+   and height take the same tier. */
 .maka-mcp-install-button {
   position: relative;
-  width: 34px;
-  height: 34px;
+  width: var(--h-control-md);
+  height: var(--h-control-md);
   display: grid;
   flex: 0 0 auto;
   place-items: center;

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -266,6 +266,16 @@
   overflow-wrap: anywhere;
 }
 
+/* #1879 measured this row and deliberately leaves its height unpinned, which
+   is the opposite of what that issue assumed (it read the row as already
+   pinned and offered it as the shape the other chips should take; it declares
+   no height at all — the 20px it measures at comes from the Badge beside the
+   message). It must stay unpinned: the message wraps by design
+   (`overflow-wrap: anywhere` below), and measured, replacing it with a long
+   string grows this row well past its one-line 20px. A pinned height would
+   clip all of that to one line. Multi-line capability is what disqualifies a
+   row from the single-line chip family — same call as
+   `.maka-plan-card-schedule` and `.settingsMemoryBackupCandidate`. */
 .maka-plan-card-run {
   font: var(--maka-text-supporting);
   display: flex;
@@ -284,6 +294,14 @@
   overflow-wrap: anywhere;
 }
 
+/* #1879: unpinned on purpose. `flex-wrap: wrap` is not decorative here —
+   measured, this row wraps to a second row at the 480px window floor. (The
+   pixel height is not recorded: a wrap threshold is a font metric, and CI
+   Linux reported a different one than macOS did, which is exactly why the e2e
+   for this asserts the relation and not a figure.) It is a wrapping meta row,
+   not a single-line chip; its height tracking its content is correct
+   behaviour, so there is nothing here for a box-height pin to fix. The chip
+   inside it (`.maka-plan-card-countdown`) is an Astryx Badge instead. */
 .maka-plan-card-schedule {
   font: var(--maka-text-supporting);
   display: flex;
@@ -310,15 +328,13 @@
    steady state, so the pill is neutral (foreground wash) rather than
    accent-tinted — colour is reserved for genuinely exceptional states
    (e.g. an overdue run), which would opt in via a data-attribute. */
+/* #1879: it had pill chrome and no height, so its own leading at 40px doubled
+   the box to 40px, measured. It is an Astryx `Badge` now — neutral is the
+   variant that keeps the exception-only rule above — so the box (20px off
+   `--spacing-5`), radius, padding, caption type and `nowrap` all come from the
+   component. Only the gap to the preceding text is product layout. */
 .maka-plan-card-countdown {
-  font: var(--maka-text-heading-5);
-  display: inline-block;
   margin-left: var(--space-1);
-  padding: 0 var(--space-1);
-  border-radius: var(--radius-pill);
-  background: oklch(from var(--foreground) l c h / 0.08);
-  color: var(--foreground-secondary);
-  letter-spacing: var(--tracking-normal);
 }
 
 .maka-plan-card-note {

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -510,8 +510,17 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   gap: var(--space-1);
 }
 
+/* #1879: `--h-control-sm` (24px), not `xs`. The floor is arithmetic under
+   `border-box`: a 20px line box plus 2 x var(--space-0-5) needs 24px, and at
+   `xs` the declared padding would have been squeezed out of the box entirely.
+   This one stays product CSS rather than becoming an Astryx `Badge` because it
+   truncates — `max-width` + ellipsis on a long skill name is behaviour Badge
+   does not have. */
 .maka-skill-governance-summary span {
   font: var(--maka-text-heading-5);
+  height: var(--h-control-sm);
+  display: inline-flex;
+  align-items: center;
   min-width: 0;
   max-width: 100%;
   overflow: hidden;

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -98,7 +98,15 @@
   list-style: none;
 }
 
+/* #1879: measured 29px natural — its 21px dot, not its 20px line box, is what
+   decides that today, so the defect here is latent rather than live: bump the
+   leading past 21px and the line box takes over and the stepper grows. Pinned
+   to `--h-control-lg` (32px) because that is the smallest rung that clears the
+   29px floor; `md` (28px) would clip the dot by a pixel. Costs 3px of height
+   on the hero stepper, which is the price of the box no longer being decided
+   by whichever of two children happens to be tallest. */
 .maka-firstrun-step {
+  height: var(--h-control-lg);
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -311,24 +311,12 @@
   color: var(--foreground-secondary);
 }
 
+/* #1879: an Astryx `Badge` now — box, radius, padding, caption type and the
+   per-state colour all come from the component, so the two `[data-state]`
+   overrides that used to tint it are variants at the call site. Only its place
+   in the step grid is product layout. */
 .maka-onboarding-setup-step-state {
-  font: var(--maka-text-heading-5);
   justify-self: end;
-  padding: var(--space-0-5) var(--space-1-5);
-  border-radius: var(--radius-pill);
-  background: var(--background-elevated);
-  color: var(--foreground-secondary);
-  white-space: nowrap;
-}
-
-.maka-onboarding-setup-steps > li[data-state="active"] .maka-onboarding-setup-step-state {
-  background: oklch(from var(--nav-active) l c h / 0.12);
-  color: var(--nav-active);
-}
-
-.maka-onboarding-setup-steps > li[data-state="warning"] .maka-onboarding-setup-step-state {
-  background: oklch(from var(--destructive-text) l c h / 0.12);
-  color: var(--destructive-text);
 }
 
 @media (max-width: 620px) {

--- a/apps/desktop/src/renderer/styles/plan-mode.css
+++ b/apps/desktop/src/renderer/styles/plan-mode.css
@@ -52,35 +52,21 @@
   color: var(--muted-foreground);
 }
 
+/* #1879: both meta pills are Astryx `Badge`s now, so the box, radius, padding,
+   caption type and per-state colour all come from the component. The revision
+   pill is the one place where product CSS still has something to say: a
+   revision number is a figure you compare across renders, so it keeps the
+   tabular figures the neutral variant does not carry. The mono stack it also
+   wants is NOT declared here — the figure is a `<code>` at the call site, and
+   `:where(code, kbd, samp, pre)` in maka-tokens.css is the one monospace
+   authority in the renderer. Naming the family here would be a second one.
+   Before this it was also the chip the derived scan could not see — its
+   leading lived in one rule and its pill chrome in another — and it has no
+   rule to miss now. */
 .plan-proposal-revision {
-  font: var(--maka-text-supporting);
-  color: var(--muted-foreground);
-  padding: var(--space-0-5) var(--space-1-5);
-  border-radius: var(--radius-pill);
-  background: var(--foreground-5);
   font-variant-numeric: tabular-nums;
 }
 
-.plan-proposal-status {
-  font: var(--maka-text-supporting);
-  padding: var(--space-0-5) var(--space-1-5);
-  border-radius: var(--radius-pill);
-}
-
-.plan-proposal-status[data-status="pending_approval"] {
-  background: oklch(from var(--status-running) l c h / 0.10);
-  color: var(--foreground);
-}
-
-.plan-proposal-status[data-status="approved"] {
-  background: oklch(from var(--success) l c h / 0.12);
-  color: var(--success-text);
-}
-
-.plan-proposal-status[data-status="stale"] {
-  background: var(--foreground-5);
-  color: var(--muted-foreground);
-}
 
 .plan-proposal-overview {
   font: var(--maka-text-body);

--- a/apps/desktop/src/renderer/styles/quote-chip.css
+++ b/apps/desktop/src/renderer/styles/quote-chip.css
@@ -7,6 +7,10 @@
    neutral state tokens. Cursor: styles/native-cursor.css. */
 .maka-quote-action {
   font: var(--maka-text-supporting);
+  /* #1879: --h-control-lg, not xs. The floor is arithmetic: a 20px line box
+     plus 2 × var(--space-1) padding plus two hairlines needs 30px, and this is
+     a pointer target rather than a decorative badge. */
+  height: var(--h-control-lg);
   position: fixed;
   transform: translateX(-50%);
   z-index: var(--z-panel-action);

--- a/apps/desktop/src/renderer/styles/settings/about.css
+++ b/apps/desktop/src/renderer/styles/settings/about.css
@@ -45,21 +45,14 @@
   letter-spacing: var(--tracking-normal);
 }
 
-.settingsAboutVersion {
-  font: var(--maka-text-code);
-  color: var(--foreground-secondary);
-  padding: var(--space-0-5) var(--space-2);
-  border-radius: var(--radius-pill);
-  background: oklch(from var(--foreground) l c h / 0.05);
-}
-
-.settingsAboutChannel {
-  font: var(--maka-text-heading-5);
-  color: var(--brand-deep);
-  padding: var(--space-0-5) var(--space-2);
-  border-radius: var(--radius-pill);
-  background: oklch(from var(--brand-deep) l c h / 0.10);
-}
+/* #1879: both hero pills are Astryx `Badge`s, and neither has a product rule
+   left. The version keeps the mono stack — a version string is read digit by
+   digit — but takes it from being a `<code>` inside the badge rather than from
+   a rule here: `:where(code, kbd, samp, pre)` in maka-tokens.css is the one
+   monospace authority in the renderer, and it composes the roles a second time
+   against that family, so nothing else about the badge's type moves. The
+   channel pill was a hand-tinted `--brand-deep` wash; `blue` is the tinted
+   variant that keeps it distinguishable from the neutral version pill. */
 
 .settingsAboutTagline {
   font: var(--maka-text-body);

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -359,9 +359,14 @@
   min-width: 0;
 }
 
+/* #1879: `min-height` is not a pin — measured, the leading pushed both of
+   these from 34px to 40px, so the filters row still moved. Now a real height
+   on the tier their neighbours already measure at: the TextInput and the
+   Selector field in this same row are both 32px, i.e. `--h-control-lg`.
+   Loses 2px and lands on the row's shared centreline. */
 .settingsUsageDetailToggle {
   font: var(--maka-text-label);
-  min-height: 34px;
+  height: var(--h-control-lg);
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
@@ -370,10 +375,12 @@
   white-space: nowrap;
 }
 
+/* #1879: same `min-height` → `height` fix as the toggle above it, same
+   measured 34px → 40px leading push, same 32px neighbour tier. */
 .settingsUsageRecordCount {
   font: var(--maka-text-supporting);
   font-variant-numeric: tabular-nums;
-  min-height: 34px;
+  height: var(--h-control-lg);
   display: inline-flex;
   align-items: center;
   color: var(--muted-foreground);

--- a/apps/desktop/src/renderer/styles/settings/memory.css
+++ b/apps/desktop/src/renderer/styles/settings/memory.css
@@ -174,6 +174,11 @@
     font: var(--maka-text-supporting);
     color: var(--muted-foreground);
   }
+/* #1879 leaves this pill unpinned on purpose. It carries the chip chrome the
+   sweep looks for, but `flex-wrap: wrap` below is load-bearing — the buttons
+   flow to a second line INSIDE the pill on the floor column — so a pinned
+   height would clip them. Same call as `.maka-plan-card-run`: wrapping
+   capability is what disqualifies a box from the single-line family. */
 .settingsMemoryBackupCandidate {
     font: var(--maka-text-supporting);
     display: inline-flex;
@@ -296,21 +301,19 @@
     min-width: 0;
   }
 
+/* #1879: an Astryx `Badge` — the active/archived distinction it drew with a
+   border and a selected-state wash is `blue` vs `neutral`. It was also the one
+   chip left that the pill-radius scan could not see, and it has no rule to be
+   missed in now.
+
+   `width: max-content` is not redundant with `max-width`. The card above is
+   `display: grid`, so this Badge is a grid item: it is blockified (its
+   `inline-flex` computes to `flex`) and `justify-self` resolves to `stretch`,
+   which measured takes it to the full card width with its label centred.
+   `max-width` caps that; only `max-content` makes it hug its text. */
 .settingsMemoryPromptScope {
-    font: var(--maka-text-supporting);
     width: max-content;
     max-width: 100%;
-    padding: var(--space-0-5) var(--space-1-5);
-    border: var(--border-width-hairline) solid var(--foreground-10);
-    border-radius: var(--radius-control);
-    background: var(--foreground-5);
-    color: var(--foreground-secondary);
-  }
-
-.settingsMemoryPromptScope[data-active="true"] {
-    border-color: var(--border-strong);
-    background: var(--state-selected-bg);
-    color: var(--foreground-secondary);
   }
 
 .settingsMemoryDirtyState[data-dirty="true"] {

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -197,6 +197,16 @@
     gap: var(--space-1-5);
   }
 
+/* #1879: unpinned on purpose, and it is the one row where that call was got
+   wrong first. It looks like a chip — pill radius, padding, supporting leading
+   — but it is a compound container holding a label plus a status Badge, and
+   the label wraps. An earlier revision pinned it to `--h-control-md` and added
+   `white-space: nowrap` to make the pin safe. That inverts the invariant: on
+   Windows and Linux all five rows read `Unsupported on this platform`, and
+   measured, that string on one line is 317px in a 260px column — 57px past the
+   card border. Wrapping is the correct behaviour, so its height must track its
+   content, exactly like `.maka-plan-card-run`. The 20px Badge inside it is
+   what carries the box #1879 was about. */
 .settingsCapabilityOsPermissions li {
     font: var(--maka-text-supporting);
     display: inline-flex;
@@ -207,33 +217,6 @@
     border-radius: var(--radius-pill);
     background: var(--background);
     color: var(--foreground-secondary);
-  }
-
-.settingsCapabilityOsPermissions li em {
-    font: var(--maka-text-supporting);
-    font-style: normal;
-    padding: 1px var(--space-1-5);
-    border-radius: var(--radius-pill);
-    background: var(--foreground-5);
-    color: var(--foreground-secondary);
-  }
-
-/* success chips fall through to the neutral base above — granted is the
-   expected state and doesn't need a green pill. */
-
-.settingsCapabilityOsPermissions li em[data-tone="warning"] {
-    color: var(--warning-text, var(--info-text));
-    background: oklch(from var(--warning, var(--info)) l c h / 0.10);
-  }
-
-.settingsCapabilityOsPermissions li em[data-tone="destructive"] {
-    color: var(--destructive-text);
-    background: oklch(from var(--destructive) l c h / 0.10);
-  }
-
-.settingsCapabilityOsPermissions li em[data-tone="info"] {
-    color: var(--info-text);
-    background: oklch(from var(--info) l c h / 0.10);
   }
 
 /* #1361: `min-width: 0` on the guidance stack and its tracks. A grid item
@@ -422,14 +405,12 @@
     color: var(--foreground-secondary);
   }
 
+/* #1879: an Astryx `Badge` — the neutral pill it drew by hand is the default
+   variant, so the box, radius, padding and caption type all left with the old
+   rule. `letter-spacing` is the one thing that did not: Badge has no opinion
+   on tracking, and this is a wide-tracked micro-label. Additive, not a
+   restatement, which is the line between extending a component and racing it. */
 .settingsOsPermissionImpactLabel {
-    font: var(--maka-text-heading-5);
-    display: inline-flex;
-    align-items: center;
-    padding: 1px var(--space-1-5);
-    border-radius: var(--radius-pill);
-    background: oklch(from var(--foreground) l c h / 0.05);
-    color: var(--muted-foreground);
     letter-spacing: var(--tracking-wider);
   }
 

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -67,18 +67,6 @@
   color: var(--muted-foreground);
 }
 
-/* category / preview / login badges — compact squared corners, never pills */
-.providerCatalogBadge {
-  font: var(--maka-text-heading-5);
-  flex: 0 0 auto;
-  width: fit-content;
-  border-radius: var(--radius-control);
-  background: var(--foreground-5);
-  color: var(--foreground-secondary);
-  padding: var(--space-0-5) var(--space-1-5);
-  font-style: normal;
-}
-
 .providerEditor {
   display: grid;
   gap: var(--space-3);
@@ -336,13 +324,24 @@
   overflow: auto;
 }
 
+/* #1879: a `font:` role used to sit here and restate the type Badge already
+   composes from `--text-supporting-*` and `--font-weight-medium`. Naming a
+   role on a component that owns its own type is the same race as pinning its
+   box; the caption tier survives the deletion and the weight lands back on
+   Badge's medium. Only `letter-spacing` is additive — Badge has no opinion on
+   tracking. */
 .providerOAuthCardBadge {
-  font: var(--maka-text-heading-5);
   letter-spacing: var(--tracking-wide);
 }
 
+/* A colour override on a component's own surface, kept deliberately rather
+   than expressed as a `variant`: the state is "already logged in", which reads
+   quieter than the default pill, and Astryx has no quieter neutral to name —
+   its `neutral` and `gray` resolve to the same two tokens in the maka theme
+   (astryx-theme/maka.css). Extending a component where its vocabulary stops is
+   not the same as racing it where it does not. */
 .providerOAuthCard[data-logged-in="true"] .providerOAuthCardBadge {
-  background: var(--foreground-5);
+  background-color: var(--foreground-5);
   color: var(--foreground-secondary);
 }
 

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -134,21 +134,36 @@
   margin-block-start: var(--space-1);
 }
 
+/* #1879: this rule used to force `height: 34px` onto an Astryx Button. It is a
+   `<Button size="md">` now (session-sidebar-nav.tsx), so the 32px comes from
+   the component's own `--size-element-md` — the same token the 32px nav rows
+   it stacks under already read. Overriding a component's size from product CSS
+   is the drift the control ruler exists to end; declaring no height here is
+   what makes the two agree by derivation instead of by coincidence. */
 .maka-sidebar-update-button {
   font: var(--maka-text-heading-4);
   position: relative;
   min-width: 0;
-  height: 34px;
   display: inline-grid;
   grid-template-columns: auto;
   align-items: center;
   gap: var(--space-1);
-  border: 0;
-  border-radius: var(--radius-pill);
+  /* Astryx Button reads `--_button-radius` for its own shape (Carousel and
+     Thumbnail set it the same way); declaring `border-radius` here would be a
+     product rule racing the component again. */
+  --_button-radius: var(--radius-pill);
   padding: 0 var(--space-3);
-  background: var(--control);
+  /* `background-color`, not the `background` shorthand — here and in EVERY
+     state rule below. The shorthand also resets `background-image`, which is
+     where Button's ghost variant keeps its hover and pressed overlays, so a
+     single shorthand anywhere in this file cancels the `variant` the component
+     was given. Product CSS is in the last cascade layer, so it wins that reset
+     regardless of specificity; fixing only the base rule left the overlays
+     dead on hover and in both download states, which is where they are most
+     visible. `border: 0` and `box-shadow: none` used to sit here too; both
+     restated what Button already computes. */
+  background-color: var(--control);
   color: var(--control-foreground);
-  box-shadow: none;
   overflow: hidden;
   -webkit-app-region: no-drag;
   transition:
@@ -162,12 +177,12 @@
 
 .maka-sidebar-update-button[data-update-state="downloading"] {
   cursor: default;
-  background: oklch(from var(--control) calc(l + 0.04) calc(c * 0.68) h);
+  background-color: oklch(from var(--control) calc(l + 0.04) calc(c * 0.68) h);
   opacity: 1;
 }
 
 .maka-sidebar-update-button[data-update-state="downloaded"] {
-  background: var(--control);
+  background-color: var(--control);
 }
 
 .maka-sidebar-update-progress {
@@ -175,16 +190,16 @@
   inset: 0;
   transform: scaleX(var(--maka-update-progress, 0));
   transform-origin: left center;
-  background: oklch(from var(--control) calc(l - 0.08) c h);
+  background-color: oklch(from var(--control) calc(l - 0.08) c h);
   transition: transform var(--duration-base) var(--ease-out-strong);
 }
 
 .maka-sidebar-update-button:hover {
-  background: oklch(from var(--control) calc(l - 0.04) c h);
+  background-color: oklch(from var(--control) calc(l - 0.04) c h);
 }
 
 .maka-sidebar-update-button:disabled:hover {
-  background: oklch(from var(--control) calc(l + 0.04) calc(c * 0.68) h);
+  background-color: oklch(from var(--control) calc(l + 0.04) calc(c * 0.68) h);
 }
 
 .maka-sidebar-update-button:focus-visible {
@@ -283,16 +298,19 @@
   border-bottom-color: var(--focus-ring);
 }
 
+/* #1879: an Astryx `Badge variant="yellow"` now. Box, radius, padding and
+   caption type all come from the component (20px off `--spacing-5`), so the
+   only thing product CSS still owns is that it must not be squeezed by the
+   row's flex layout. */
 .maka-list-row-stale-pill {
-  font: var(--maka-text-heading-5);
   flex-shrink: 0;
-  padding: 1px var(--space-1-5);
-  border-radius: var(--radius-pill);
-  background: oklch(from var(--warning, var(--info)) l c h / 0.18);
-  color: var(--warning-text, var(--info-text));
 }
 
 /* ⌘N hint on the 新任务 row — quiet text, no chip chrome. */
+/* #1879: no chrome, but still a box, and it had no height of its own —
+   measured, its own leading at 40px took it from 20px to 40px and pushed the
+   32px nav row with it. Pinned to `--h-control-xs` (20px), which is what the
+   supporting leading already resolves to, so nothing moves today. */
 .maka-nav-kbd {
   /* A <kbd> composes the mono variant of every role (maka-tokens.css anchors
      the role table on the code group too), and this hint has always opted out
@@ -301,6 +319,9 @@
      opt-out stays one declaration instead of reopening the triplet. */
   --maka-font-family: var(--font-family-body);
   font: var(--maka-text-supporting);
+  height: var(--h-control-xs);
+  display: inline-flex;
+  align-items: center;
   margin-left: auto;
   padding: 0;
   border: 0;

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -6,6 +6,7 @@ import { Markdown } from './markdown.js';
 import { formatAbsoluteTimestamp, formatClockTime, turnAbortMarkerLabel } from './chat-display-helpers.js';
 import { prepareSmoothStreamText, useSmoothStreamContent } from './smooth-stream.js';
 import {
+  Badge,
   Button as UiButton,
   ChatMessage,
   ChatMessageBubble,
@@ -796,14 +797,24 @@ function StreamingAssistantBubble(props: { text: string; live: boolean; truncate
     <ChatMessageBubble variant="ghost" className="maka-chat-message-bubble maka-chat-message-bubble-assistant maka-bubble-streaming">
       <Markdown text={displayed} streaming density="compact" />
       {props.truncated && (
-        <div
-          className="maka-turn-truncation-badge"
-          role="status"
-          aria-live="polite"
-          title={copy.outputTruncatedTitle}
-        >
-          {copy.truncated}
-        </div>
+        <Tooltip content={copy.outputTruncatedTitle}>
+          {/* Colour-name archive, not the semantic one: Astryx paints
+              `warning` as a solid dark-mode-invariant fill and `yellow` as a
+              tint. This note replaced a 5% wash with a hairline; a solid block
+              inside the message body would outweigh the message. */}
+          <Badge
+            variant="yellow"
+            label={copy.truncated}
+            className="maka-turn-truncation-badge"
+            role="status"
+            aria-live="polite"
+            /* Same reason as the stale pill: the Tooltip's popover is
+               `display: none` until hovered, so `aria-describedby` computes to
+               nothing and the `title` this replaced was the only description
+               this badge ever had. Announced with the reason attached. */
+            aria-label={`${copy.truncated}. ${copy.outputTruncatedTitle}`}
+          />
+        </Tooltip>
       )}
     </ChatMessageBubble>
   );

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -459,7 +459,7 @@ export function PlanReminderPanel(props: {
                             {reminder.nextRunAt ? (
                               <>
                                 {copy.page.nextRun(formatReminderTime(reminder.nextRunAt, locale))}
-                                <span className="maka-plan-card-countdown">{formatReminderCountdown(reminder.nextRunAt, locale)}</span>
+                                <Badge className="maka-plan-card-countdown" label={formatReminderCountdown(reminder.nextRunAt, locale)} />
                               </>
                             ) : reminder.lastRun ? (
                               copy.page.recentRun(formatReminderTime(reminder.lastRun.at, locale))

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -27,6 +27,7 @@ import {
   Trash2,
 } from './icons.js';
 import { Badge } from '@astryxdesign/core/Badge';
+import { Tooltip } from '@astryxdesign/core/Tooltip';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
 import { MoreMenu } from '@astryxdesign/core/MoreMenu';
 import {
@@ -688,13 +689,25 @@ const SessionItemEndContent = memo(function SessionItemEndContent(props: {
   return (
     <EndContentHitTarget className="maka-session-row-end">
       {props.stale && (
-        <span
-          className="maka-list-row-stale-pill"
-          title={copy.staleTitle}
-          aria-label={copy.staleAriaLabel}
-        >
-          {copy.stale}
-        </span>
+        <Tooltip content={copy.staleTitle}>
+          {/* `yellow`, not `warning`. Astryx keeps two archives: the semantic
+              names paint a solid saturated fill (maka's `warning` is a flat
+              #ffce2f that does not adapt to dark mode), the colour names paint
+              a tint. This pill sits on every stale row in the rail, where the
+              chrome it replaced was an 18% wash — a solid block on each row
+              reads as an alert the state does not mean. */}
+          <Badge
+            variant="yellow"
+            label={copy.stale}
+            className="maka-list-row-stale-pill"
+            /* The reason belongs in the name, not only in the Tooltip. `title`
+               used to carry it, and a screen reader read it as the accessible
+               description; Astryx's Tooltip points `aria-describedby` at a
+               popover that is `display: none` until hovered, so off the mouse
+               the description computes to empty. */
+            aria-label={`${copy.staleAriaLabel}. ${copy.staleTitle}`}
+          />
+        </Tooltip>
       )}
       {props.worktree && (
         <FolderGit2

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -97,7 +97,11 @@ export function SessionSidebarFooter(props: {
           data-update-state={props.updateReminder.state}
           style={{ '--maka-update-progress': String(Math.max(0, Math.min(100, props.updateReminder.progressPercent ?? 0)) / 100) } as CSSProperties}
           label={updateTitle}
-          size="sm"
+          // #1879: was `sm` with a 34px height forced from product CSS. Astryx
+          // sizes Button off --size-element-* (sm 28 / md 32), so `md` IS the
+          // 32px this button wants, and the CSS height is gone rather than
+          // fighting the component's own size token.
+          size="md"
           variant="ghost"
           width="100%"
           onClick={props.onOpenUpdate}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -71,7 +71,13 @@
 
 .maka-quote-chip { display: inline-flex; gap: 4px; padding-left: 8px; background: var(--foreground-alpha-6); box-shadow: inset 0 0 0 1px var(--foreground-alpha-12); }
 .maka-quote-chip-expanded { width: 100%; max-width: 100%; align-items: flex-start; padding-block: 4px; border-radius: var(--radius-surface); }
-.maka-quote-chip-collapsed { max-width: 240px; align-items: center; padding-block: 2px; border-radius: var(--radius-pill); }
+/* #1879: measured 24px natural — a 20px line box plus 2 x 2px padding — and
+   `--h-control-sm` IS 24, so the pin is pixel-neutral today and load-bearing
+   the next time a leading moves. This is the collapsed state only; the
+   expanded twin above wraps to many lines and must keep growing. The chip's
+   type lives on `.maka-quote-chip-text`, which is why the derived scan needed
+   two arms rather than three to see it at all. */
+.maka-quote-chip-collapsed { height: var(--h-control-sm); max-width: 240px; align-items: center; padding-block: 2px; border-radius: var(--radius-pill); }
 .maka-quote-chip-removable { padding-right: 2px; }
 .maka-quote-chip-readonly { padding-right: 8px; }
 .maka-quote-chip-icon { width: 12px; height: 12px; flex: 0 0 auto; color: var(--muted-foreground); }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -113,9 +113,11 @@
 .maka-turn-processing-spinner { flex: 0 0 auto; animation: maka-spin 1s linear infinite; }
 .maka-turn-indicator-text { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .maka-turn-continuing { opacity: 0.7; animation: maka-stream-fade-in var(--duration-emphasized) var(--ease-out-strong) both; }
-.maka-turn-truncation-badge {
-  font: var(--maka-text-supporting);
- display: inline-block; margin-top: 6px; border: 1px solid oklch(from var(--warning) l c h / 0.24); border-radius: var(--radius-control); padding-inline: 4px; color: var(--warning-text, var(--info-text)); background: oklch(from var(--warning) l c h / 0.05); cursor: help; }
+/* #1879: an Astryx `Badge variant="yellow"` now — the warning tone it used to
+   draw by hand (hairline + 5% wash) is a variant, and the box comes with it.
+   Product CSS keeps only what is layout: it is a block-level note under the
+   bubble, so it needs its own line and the gap above it. */
+.maka-turn-truncation-badge { display: flex; width: fit-content; margin-top: 6px; cursor: help; }
 .maka-deep-thinking { min-width: 0; }
 
 @keyframes maka-spin { to { transform: rotate(360deg); } }
@@ -363,8 +365,10 @@
   font: var(--maka-text-supporting);
   display: inline-flex;
   min-width: 22px;
-  height: 18px;
+  /* #1879: was a bare 18px, below the 20px line box it renders. */
+  height: var(--h-control-xs);
   align-items: center;
+  white-space: nowrap;
   justify-content: center;
   padding-inline: var(--space-1-5);
   border-radius: var(--radius-pill);
@@ -498,9 +502,18 @@
 .maka-tool-terminal-cmd {
   font: var(--maka-text-heading-5);
  min-width: 0; flex: 1 1 auto; overflow: hidden; background: transparent; color: var(--foreground); text-overflow: ellipsis; white-space: nowrap; }
+/* Pinned like every other pill in the scan, even though the whole
+   `.maka-tool-terminal-*` family is currently unreachable:
+   `previewVariants({part: 'terminal-*'})` has no call site — `TerminalPreview`
+   renders `maka-tool-output-stack` / `ShellOutputBody` / `ToolCodeBlock`
+   instead — and `check-dead-css` cannot see that because the literals still
+   exist in `previewVariants`. The alternative is an exemption whose reason is
+   "nothing renders this", which is a fact about call sites recorded in a
+   stylesheet and would outlive the day someone wires the family back up.
+   Deleting the family is its own change. */
 .maka-tool-terminal-exit {
   font: var(--maka-text-heading-5);
- padding: 1px var(--space-1-5); border-radius: var(--radius-pill); background: var(--foreground-5); color: var(--foreground-secondary); letter-spacing: 0.04em; }
+ height: var(--h-control-sm); display: inline-flex; align-items: center; white-space: nowrap; padding: 1px var(--space-1-5); border-radius: var(--radius-pill); background: var(--foreground-5); color: var(--foreground-secondary); letter-spacing: 0.04em; }
 .maka-tool-terminal-exit[data-ok="true"] { background: oklch(from var(--success) l c h / 0.14); color: var(--success); }
 .maka-tool-terminal-exit[data-ok="false"] { background: oklch(from var(--destructive) l c h / 0.14); color: var(--destructive); }
 .maka-tool-terminal-empty {


### PR DESCRIPTION
## Summary

Closes #1879.

The issue asked for pinned box heights so a `line-height` change can no longer move layout. Pinning was the right diagnosis and — for most of the family — the wrong owner. Astryx already ships `Badge`, and its box IS the recipe these chips hand-wrote: 20px off `--spacing-5`, pill radius, supporting tier, `align-items: center`, `nowrap`. Twelve chips are `<Badge variant=...>` at the call site now, and their height, chrome and per-state colour left product CSS with them. Net **+347 / −304** across 27 files: the conversion pays for the guards.

What stays product CSS is what Badge does not do — a chip with no chrome at all (`.maka-message-time-inline`, `.maka-nav-kbd`), one that truncates (`.maka-skill-governance-summary span`), and the compound permission pill that holds a Badge *inside* it. Those keep a `--h-control-*` pin.

### Three defects the first revision shipped

**Eleven pins sat below their own arithmetic floor.** The floor rule (line box + padding + border, under `border-box`) was applied by hand in four CSS comments and skipped everywhere else. Measured live, those chips were 2–4px shorter than they read and their declared vertical padding was vertically inert:

```
settingsAboutVersion  pinned 20  natural 24   pad 2/2   ink 上 0.5px
maka-list-row-stale-pill     20         22    pad 1/1
maka-turn-truncation-badge   20         22    border 1/1   scroll 19 > client 18
```

Not a clipping bug — the line box centres and the ink fits, verified including CJK — but an undocumented shrink. The rule now lives in the e2e, not in prose: a chip's `height: auto` natural height must fit its pinned tier.

**The derived scan was a narrower whitelist.** Three independent bypasses, all now closed and mutation-verified:

| bypass | consequence |
|---|---|
| three features required in ONE rule body | `.plan-proposal-revision` was invisible, five lines from a chip the scan caught |
| "declared anywhere" instead of the effective declaration | `height: var(--h-control-xs); … height: auto` passed both checks while the browser saw no pin |
| `parseCssBlocks` keyed multi-line selector lists by their last line | two exemptions matched zero rules; appending an exempt selector to a group exempted the whole group |

**The containment assertion was inert twice over.** It read `scrollHeight`/`clientHeight` *after* restoring the stressed leading, and on an `overflow: visible` box the two are equal regardless. Replaced with the floor measure, which can actually fail.

### Astryx layering

- `--h-control-md/lg/xl` now **derive** from `--size-element-sm/md/lg` instead of restating 28/32/36, so a chip and the Astryx control beside it can no longer agree by coincidence. Verified live: `md` → 28, `lg` → 32.
- The three composer `.astryx-selector` rules were forcing an Astryx `Selector` to 24px — below its own smallest tier (`--size-element-sm` = 28) — and desyncing it from `ModelChipStatic`, the inert state of the same chip, a `Button size="sm"` at 28px. The pill changed height when it became clickable. Both declare no height now. Their contract exemption previously read *"declaring a height here would reintroduce the override #1879 removed"* while the rule declared exactly that; the reason is true of every entry under it now.
- `.maka-sidebar-update-button` used the `background` shorthand, which also resets `background-image` — where Astryx ghost keeps its hover and pressed overlays. The `variant` the component was passed had been silently cancelled. Radius moves to `--_button-radius`; four declarations that restated Button's own computed values are gone.

### What was tried and reverted

Widening the scan to `--radius-control` so squared badges were covered: it reported **27 offenders** including `pre` blocks, failure banners, sidebar rows and buttons — every one a box a pin would clip. `--radius-control` is this repo's general control shape, not a chip signal. The squared chips that motivated it are `Badge`s now, so that population is empty rather than unguarded.

## Verification

`npm run lint` 0 · `npm --workspace @maka/desktop run typecheck` 0 · desktop tests **1325 pass** · ui tests **239 pass** · e2e **73/73** · contract **15/15** · `check-dead-css --check` clean · `astryx:theme --check` current.

`npm run format:check` fails on `scripts/check-console.mjs`, which this branch does not touch (`git diff main...HEAD -- scripts/check-console.mjs` is empty) — inherited from #1880.

Every guard mutation-verified with `cp` backup/restore:

| mutation | result |
|---|---|
| `height: var(--h-control-xs); … height: auto` | ✖ 2 (passed the previous revision) |
| chip split across two rules | ✖ 2 |
| exempt selector appended to a group | ✖ 2 |
| plain unpinned chip | ✖ 1 |
| pinned but `display: block` | ✖ 1 |
| `height` added to a wrapping box | ✖ 1 |
| chrome-less chip unpinned | ✖ 1 |
| tier below its own floor (e2e) | ✖ `Received: 28` vs ≤ 20 |
| pin removed entirely (e2e) | ✖ |

All restored green. The first attempt at the floor mutation was ineffective — the injected `padding-block` was overridden by a later `padding: 0` in the same rule — and was redone rather than counted.

### Live evidence

Plan reminders: the countdown chip is now the same object as the `已触发` / `已暂停` badges it sits beside, which is the convergence the component swap buys.

<img width="2480" height="1640" alt="image" src="https://github.com/user-attachments/assets/f16d61a1-9b47-49c2-afd7-a698177d83c4" />

Permissions: `影响功能` is a neutral Badge; the status chips route through the same `statusBadgeVariant` seam as the rest of Settings.

<img width="2480" height="1640" alt="image" src="https://github.com/user-attachments/assets/4b6131d8-9d02-41e4-a6b2-914621df1a03" />

## Review focus

The visual direction was chosen against a side-by-side render of every affected chip in both colour schemes. Two deliberate appearance changes worth a second opinion:

- `.providerCatalogBadge` had a comment reading *"compact squared corners, never pills"*. Badge hardcodes `--radius-full` with no radius prop, so that intent is retired rather than kept as an override.
- The permission capability chip had a note that a granted permission *"doesn't need a green pill"* and fell through to neutral. One tone table for the page beat a per-chip exception, so `granted` reads `success` like every other status badge in Settings.

