### PR TITLE
feat(cu): mirror the driven window instead of competing for the screen

### DIFF
--- a/apps/desktop/src/main/__tests__/computer-use-pip-appearance.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip-appearance.test.ts
@@ -1,0 +1,305 @@
+/**
+ * What the Computer Use mirror looks like.
+ *
+ * Reported from a screenshot: a stray white L in one corner, two buttons
+ * crowding the picture, and a bare blue dot standing in for the cursor. The
+ * values behind those, and the ones recovered from Codex that replace them,
+ * are asserted here as values — not as strings that happen to appear in the
+ * file — so that reverting any single one of them fails.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { describe, it, test } from 'node:test';
+import { CODEX_CURSOR_GLYPH } from '../../renderer/computer-use-overlay/engine/cursor-engine.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DESKTOP = resolve(HERE, '..', '..', '..');
+const PIP_HTML = resolve(DESKTOP, 'src', 'overlay', 'pip.html');
+/** Built by `build:overlay`, which `build:test` runs before `test:dist`. */
+const PIP_BUNDLE = resolve(DESKTOP, 'dist', 'overlay', 'pip.js');
+
+/** The page's stylesheet, comments removed. */
+async function styleSheet(): Promise<string> {
+  const html = await readFile(PIP_HTML, 'utf8');
+  const style = /<style>([\s\S]*?)<\/style>/.exec(html);
+  assert.ok(style, 'the page has a stylesheet');
+  return style[1].replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/** The body of the block a selector opens, brace-balanced. */
+function block(css: string, opener: string): string {
+  const at = css.indexOf(opener);
+  assert.notEqual(at, -1, `${opener} is in the stylesheet`);
+  let depth = 0;
+  for (let i = css.indexOf('{', at); i < css.length; i += 1) {
+    if (css[i] === '{') depth += 1;
+    else if (css[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return css.slice(css.indexOf('{', at) + 1, i);
+    }
+  }
+  throw new Error(`${opener} is never closed`);
+}
+
+/** One declared value out of a rule body, whitespace collapsed. */
+function declaration(body: string, property: string): string {
+  const found = new RegExp(`(?:^|[;{])\\s*${property}\\s*:([^;]*)`).exec(body);
+  assert.ok(found, `${property} is declared`);
+  return found[1].trim().replace(/\s+/g, ' ');
+}
+
+describe('Computer Use mirror appearance', () => {
+  it('draws the tile square, the way Codex draws it', async () => {
+    // Codex's container layer sets `masksToBounds` and a clear background and
+    // never calls `setCornerRadius:`; none of that selector's call sites lands
+    // in the mirror renderer. The 8px this replaces was Maka's own habit.
+    const css = await styleSheet();
+    const radius = declaration(block(css, '#shell {'), 'border-radius');
+    assert.equal(Number.parseFloat(radius), 0);
+  });
+
+  it('shows a loading checkerboard before the first frame, not a flat fill', async () => {
+    // 48pt squares, `((x / 48) + (y / 48)) % colors.count`, in the colourway
+    // that is reachable unconditionally: rgb(0.05, 0.34, 0.84) under
+    // rgb(0.09, 0.62, 0.95). Without this the pre-stream tile is a dead
+    // rectangle indistinguishable from a stalled run.
+    const css = await styleSheet();
+    const body = block(css, '#placeholder {');
+    const base = [0.05, 0.34, 0.84].map((c) => Math.round(c * 255));
+    const over = [0.09, 0.62, 0.95].map((c) => Math.round(c * 255));
+    const declared = declaration(body, 'background-color').match(/\d+/g) ?? [];
+    assert.deepEqual(declared.map(Number), base);
+
+    const image = declaration(body, 'background-image');
+    const stops = [...image.matchAll(/rgb\((\d+) (\d+) (\d+)\)/g)].map((m) => m.slice(1).map(Number));
+    assert.ok(stops.length >= 2, 'the checker colour is painted');
+    for (const stop of stops) assert.deepEqual(stop, over);
+
+    // Two 45° gradients on a 96pt period, the second offset by half of it,
+    // is a 48pt checkerboard.
+    const size = declaration(body, 'background-size').match(/[\d.]+/g)?.map(Number) ?? [];
+    assert.deepEqual(size, [96, 96]);
+    const position = declaration(body, 'background-position').match(/-?[\d.]+/g)?.map(Number) ?? [];
+    assert.deepEqual(position, [0, 0, 48, 48]);
+    const angles = [...image.matchAll(/(\d+)deg/g)].map((m) => Number(m[1]));
+    assert.deepEqual(angles, [45, 45]);
+  });
+
+  it('sweeps a light bar across the placeholder on Codex’s timing', async () => {
+    // frame(-64, 0, 64, h) at white 0.55, with `position.x` animated from -64
+    // to width + 64 over 1.6s, repeating forever. The layer's centre anchor
+    // puts its left edge at -96 and width + 32.
+    const css = await styleSheet();
+    const bar = block(css, '#sweep {');
+    assert.equal(Number.parseFloat(declaration(bar, 'width')), 64);
+    const alpha = declaration(bar, 'background').match(/\/ ([\d.]+)/)?.[1];
+    assert.equal(Number(alpha), 0.55);
+    const animation = declaration(bar, 'animation');
+    assert.equal(Number.parseFloat(/([\d.]+)s/.exec(animation)?.[1] ?? '0'), 1.6);
+    assert.match(animation, /\binfinite\b/);
+
+    const keyframes = block(css, '@keyframes pipSweep');
+    assert.equal(Number.parseFloat(declaration(block(keyframes, 'from {'), 'left')), -96);
+    const to = declaration(block(keyframes, 'to {'), 'left');
+    assert.equal(to.replace(/\s+/g, ''), 'calc(100%+32px)');
+  });
+
+  it('draws the cursor as the native arrow on its hotspot, not as a dot', async () => {
+    // Codex draws a 20 x 23pt cursor with hotspot (4, 4) whatever the source
+    // window measures — a tenth of the tile's edge at the 200pt default, so
+    // the glyph is not the few pixels of noise the dot was chosen over.
+    const html = await readFile(PIP_HTML, 'utf8');
+    const css = await styleSheet();
+    const box = block(css, '#cursor {');
+    assert.equal(Number.parseFloat(declaration(box, 'width')), 20);
+    assert.equal(Number.parseFloat(declaration(box, 'height')), 23);
+    // The hotspot lands on the mapped point: the box is pulled back by it.
+    const margin = declaration(box, 'margin').match(/-?[\d.]+/g)?.map(Number) ?? [];
+    assert.deepEqual(margin, [-4, 0, 0, -4]);
+    // Nothing round is left: no radius, no dot variable.
+    assert.equal(/border-radius/.test(box), false);
+    assert.equal(/--dot/.test(css), false);
+
+    const path = /<path d="([^"]+)"/.exec(html);
+    assert.ok(path, 'the cursor has a path');
+    const drawn = (path[1].match(/-?[\d.]+/g) ?? []).map(Number);
+
+    // The same AgentCursor path the on-screen cursor draws, on a 16pt frame
+    // offset by the hotspot — which is also what puts the arrow's tip at
+    // (4, 4), the two recoveries agreeing without being fitted to each other.
+    const g = CODEX_CURSOR_GLYPH;
+    const at = ([x, y]: readonly [number, number]) => [4 + x * 16, 4 + y * 16];
+    const expected = [
+      at(g.start),
+      at(g.curve1[1]),
+      at(g.curve1[2]),
+      at(g.curve1[0]),
+      at(g.line1),
+      at(g.curve2[1]),
+      at(g.curve2[2]),
+      at(g.curve2[0]),
+      at(g.line2),
+      at(g.line3),
+      at(g.curve3[1]),
+      at(g.curve3[2]),
+      at(g.curve3[0]),
+    ].flat();
+    assert.equal(drawn.length, expected.length);
+    for (const [i, value] of expected.entries()) {
+      assert.ok(
+        Math.abs(drawn[i] - value) < 1e-3,
+        `point ${i} is ${drawn[i]}, the glyph puts it at ${value}`,
+      );
+    }
+
+    // The white rim is what keeps a small dark glyph readable over arbitrary
+    // imagery, the same reading the on-screen cursor is drawn with.
+    const paint = block(css, '#cursor path {');
+    assert.equal(Number(declaration(paint, 'stroke').match(/\/ ([\d.]+)/)?.[1]), 0.8);
+    assert.equal(Number.parseFloat(declaration(paint, 'stroke-width')), 2);
+    assert.equal(declaration(paint, 'stroke-linejoin'), 'miter');
+    assert.equal(Number.parseFloat(declaration(paint, 'stroke-miterlimit')), 10);
+  });
+
+  it('separates the controls from the picture instead of sitting on it', async () => {
+    // Two 20pt buttons straight on the mirrored window had no edge of their
+    // own against light content. A gradient scrim, not a backdrop filter:
+    // over moving arbitrary imagery the filter is the expensive half.
+    const css = await styleSheet();
+    const scrim = block(css, '#chrome {');
+    assert.ok(Number.parseFloat(declaration(scrim, 'height')) > 0);
+    const gradient = declaration(scrim, 'background');
+    const alphas = [...gradient.matchAll(/\/ ([\d.]+)\)/g)].map((m) => Number(m[1]));
+    assert.deepEqual(alphas, [0.45, 0]);
+    assert.equal(/backdrop-filter/.test(css), false);
+    assert.equal(Number.parseFloat(declaration(block(css, '#chrome {'), 'opacity')), 0);
+    assert.equal(
+      Number.parseFloat(declaration(block(css, "#chrome[data-visible='1'] {"), 'opacity')),
+      1,
+    );
+    // The controls stand off the corner far enough to read as chrome.
+    const controls = block(css, '#controls {');
+    assert.ok(Number.parseFloat(declaration(controls, 'top')) >= 8);
+    assert.ok(Number.parseFloat(declaration(controls, 'right')) >= 8);
+  });
+
+  it('gives the resize grip the controls’ chip so it is not a stray mark', async () => {
+    // Two hairlines drawn straight onto the picture were read as a white L
+    // left over from something else. The buttons' scrim says it belongs to
+    // the same set, and the shared inset says so again.
+    const css = await styleSheet();
+    const grip = block(css, '#resize {');
+    const button = block(css, '#controls button {');
+    assert.equal(declaration(grip, 'background'), declaration(button, 'background'));
+    assert.equal(declaration(grip, 'box-shadow'), declaration(button, 'box-shadow'));
+    assert.equal(
+      Number.parseFloat(declaration(grip, 'left')),
+      Number.parseFloat(declaration(block(css, '#controls {'), 'right')),
+    );
+    assert.equal(declaration(grip, 'cursor'), 'nwse-resize');
+  });
+});
+
+// ── the page, running ────────────────────────────────────────────────────────
+
+type Stub = {
+  dataset: Record<string, string>;
+  style: Record<string, string> & { setProperty(name: string, value: string): void };
+  clientWidth: number;
+  clientHeight: number;
+  src: string;
+  addEventListener(): void;
+};
+
+function element(): Stub {
+  const style = {
+    setProperty(this: Record<string, string>, name: string, value: string) {
+      this[name] = value;
+    },
+  } as Stub['style'];
+  return {
+    dataset: {},
+    style,
+    clientWidth: 0,
+    clientHeight: 0,
+    src: '',
+    addEventListener() {},
+    classList: { add() {} },
+  } as unknown as Stub;
+}
+
+type Bridge = {
+  frame(payload: unknown): void;
+  cursor(payload: unknown): void;
+  controls(payload: unknown): void;
+};
+
+/** Load the built page against a stub DOM and hand back its inputs. */
+async function loadPage(): Promise<{ nodes: Record<string, Stub>; send: Bridge }> {
+  const nodes: Record<string, Stub> = {};
+  for (const id of ['frame', 'cursor', 'placeholder', 'chrome', 'controls', 'resize']) {
+    nodes[id] = element();
+  }
+  const handlers: Record<string, (payload?: unknown) => void> = {};
+  const bridge = {
+    onFrame: (cb: (p: unknown) => void) => {
+      handlers.frame = cb;
+    },
+    onCursor: (cb: (p: unknown) => void) => {
+      handlers.cursor = cb;
+    },
+    onControls: (cb: (p: unknown) => void) => {
+      handlers.controls = cb;
+    },
+    onCompleted: (cb: () => void) => {
+      handlers.completed = cb;
+    },
+    send: () => {},
+  };
+  const globals = globalThis as unknown as Record<string, unknown>;
+  globals.document = {
+    getElementById: (id: string) => nodes[id] ?? null,
+    addEventListener: () => {},
+    body: element(),
+  };
+  globals.window = { addEventListener: () => {}, computerUsePip: bridge };
+  await import(pathToFileURL(PIP_BUNDLE).href);
+  return {
+    nodes,
+    send: {
+      frame: (p) => handlers.frame(p),
+      cursor: (p) => handlers.cursor(p),
+      controls: (p) => handlers.controls(p),
+    },
+  };
+}
+
+test('the placeholder comes down when the stream starts, and the chrome moves with the controls', async () => {
+  const { nodes, send } = await loadPage();
+
+  // The mirror is letterboxed, so the cursor's position in capture pixels is
+  // not its position in the element. This is the mapping the arrow inherited
+  // from the dot unchanged; it is asserted here so the redraw cannot move it.
+  nodes.frame.clientWidth = 200;
+  nodes.frame.clientHeight = 200;
+  send.frame({ src: 'data:image/png;base64,x', widthPx: 400, heightPx: 300 });
+  assert.equal(nodes.placeholder.dataset.visible, '0');
+  assert.equal(nodes.frame.src, 'data:image/png;base64,x');
+
+  send.cursor({ x: 200, y: 150 });
+  assert.equal(nodes.cursor.style.left, '100px');
+  assert.equal(nodes.cursor.style.top, '100px');
+  assert.equal(nodes.cursor.dataset.visible, '1');
+  // Nothing sizes the cursor from JS any more; it is a fixed 20 x 23 box.
+  assert.equal(nodes.cursor.style['--dot'], undefined);
+
+  send.controls({ visible: true });
+  assert.equal(nodes.chrome.dataset.visible, '1');
+  assert.equal(nodes.controls.dataset.visible, '1');
+  assert.equal(nodes.resize.dataset.visible, '1');
+  send.controls({ visible: false });
+  assert.equal(nodes.chrome.dataset.visible, '0');
+});

--- a/apps/desktop/src/main/__tests__/computer-use-pip-appearance.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip-appearance.test.ts
@@ -201,6 +201,49 @@ describe('Computer Use mirror appearance', () => {
     );
     assert.equal(declaration(grip, 'cursor'), 'nwse-resize');
   });
+
+  it('moves the grip to the corner opposite whichever anchor main sends down', async () => {
+    // The gesture's sign follows the anchor (pipResizeEdge), so the handle has
+    // to as well. The CSS used to hard-code `left: 8px; top: 8px` — the corner
+    // opposite the default bottom-right anchor and wrong in the other three.
+    // Anchored top-left, the grip sat on the pinned corner: dragging it grew
+    // the tile from the far edge while the handle could not move, so the
+    // pointer came off it on the first pixel.
+    const css = await styleSheet();
+    // Every corner the mirror can rest on has a rule, keyed on the attribute
+    // the page sets from `pip:layout`.
+    const corners = {
+      // The bare rule is the default: opposite bottom-right.
+      'top-left': block(css, '#resize {'),
+      'top-right': block(css, "body[data-grip='top-right'] #resize {"),
+      'bottom-left': block(css, "body[data-grip='bottom-left'] #resize {"),
+      'bottom-right': block(css, "body[data-grip='bottom-right'] #resize {"),
+    } as const;
+    for (const [corner, rule] of Object.entries(corners)) {
+      const [vertical, horizontal] = corner.split('-');
+      // The inset the corner names is the one that is set; the other is auto,
+      // because a stale `left` beats a new `right` and the chip would stay.
+      assert.equal(Number.parseFloat(declaration(rule, vertical)), 8, `${corner}: ${vertical}`);
+      assert.equal(Number.parseFloat(declaration(rule, horizontal)), 8, `${corner}: ${horizontal}`);
+      const oppositeV = vertical === 'top' ? 'bottom' : 'top';
+      const oppositeH = horizontal === 'left' ? 'right' : 'left';
+      if (rule !== corners['top-left']) {
+        assert.equal(declaration(rule, oppositeV), 'auto', `${corner}: ${oppositeV}`);
+        assert.equal(declaration(rule, oppositeH), 'auto', `${corner}: ${oppositeH}`);
+      }
+      // A grip on the ↖↘ diagonal points that way; the other two are ↗↙.
+      const diagonal = corner === 'top-left' || corner === 'bottom-right';
+      assert.equal(
+        declaration(rule, 'cursor'),
+        diagonal ? 'nwse-resize' : 'nesw-resize',
+        `${corner}: cursor`,
+      );
+    }
+    // The controls own the top-right, so they move when the grip is sent there.
+    const moved = block(css, "body[data-grip='top-right'] #controls {");
+    assert.equal(declaration(moved, 'right'), 'auto');
+    assert.equal(Number.parseFloat(declaration(moved, 'left')), 8);
+  });
 });
 
 // ── the page, running ────────────────────────────────────────────────────────
@@ -235,10 +278,12 @@ type Bridge = {
   frame(payload: unknown): void;
   cursor(payload: unknown): void;
   controls(payload: unknown): void;
+  layout(payload: unknown): void;
 };
 
 /** Load the built page against a stub DOM and hand back its inputs. */
-async function loadPage(): Promise<{ nodes: Record<string, Stub>; send: Bridge }> {
+let loads = 0;
+async function loadPage(): Promise<{ nodes: Record<string, Stub>; body: Stub; send: Bridge }> {
   const nodes: Record<string, Stub> = {};
   for (const id of ['frame', 'cursor', 'placeholder', 'chrome', 'controls', 'resize']) {
     nodes[id] = element();
@@ -254,25 +299,36 @@ async function loadPage(): Promise<{ nodes: Record<string, Stub>; send: Bridge }
     onControls: (cb: (p: unknown) => void) => {
       handlers.controls = cb;
     },
+    onLayout: (cb: (p: unknown) => void) => {
+      handlers.layout = cb;
+    },
     onCompleted: (cb: () => void) => {
       handlers.completed = cb;
     },
     send: () => {},
   };
+  const body = element();
   const globals = globalThis as unknown as Record<string, unknown>;
   globals.document = {
     getElementById: (id: string) => nodes[id] ?? null,
     addEventListener: () => {},
-    body: element(),
+    body,
   };
   globals.window = { addEventListener: () => {}, computerUsePip: bridge };
-  await import(pathToFileURL(PIP_BUNDLE).href);
+  // A fresh copy per call. The bundle registers its handlers as a side effect
+  // of being evaluated, and a plain re-import is served from the module cache:
+  // the second caller would get its bridge back untouched and every handler
+  // undefined.
+  loads += 1;
+  await import(`${pathToFileURL(PIP_BUNDLE).href}?load=${loads}`);
   return {
     nodes,
+    body,
     send: {
       frame: (p) => handlers.frame(p),
       cursor: (p) => handlers.cursor(p),
       controls: (p) => handlers.controls(p),
+      layout: (p) => handlers.layout(p),
     },
   };
 }
@@ -302,4 +358,24 @@ test('the placeholder comes down when the stream starts, and the chrome moves wi
   assert.equal(nodes.resize.dataset.visible, '1');
   send.controls({ visible: false });
   assert.equal(nodes.chrome.dataset.visible, '0');
+});
+
+test('the page moves the grip to whichever corner main names', async () => {
+  // The CSS can only follow the anchor if the page is told what the anchor is,
+  // and before `pip:layout` nothing sent it: `grep alignment src/overlay/`
+  // returned nothing at all, so the grip was frozen on the tile's top-left.
+  const { body, send } = await loadPage();
+
+  send.layout({ alignment: 'top-left', gripCorner: 'bottom-right' });
+  assert.equal(body.dataset.grip, 'bottom-right');
+  send.layout({ alignment: 'bottom-left', gripCorner: 'top-right' });
+  assert.equal(body.dataset.grip, 'top-right');
+
+  // Anything the page does not recognise leaves the grip where it is, rather
+  // than clearing the attribute and dropping the tile back to the default
+  // corner while it is anchored somewhere else.
+  send.layout({ alignment: 'top-left', gripCorner: 'middle' });
+  assert.equal(body.dataset.grip, 'top-right');
+  send.layout(null);
+  assert.equal(body.dataset.grip, 'top-right');
 });

--- a/apps/desktop/src/main/__tests__/computer-use-pip-motion.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip-motion.test.ts
@@ -7,13 +7,13 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  PIP_FLICK_MIN_SPEED,
   PIP_SPRING,
   PIP_THROW_MAX,
   PIP_THROW_REFERENCE,
   PIP_THROW_SCALE,
   PipDragTracker,
   anchorFor,
+  pipGripCorner,
   pipResizeEdge,
   clampToWorkArea,
   pickPipAnchor,
@@ -113,7 +113,31 @@ test('picture-in-picture motion', async (t) => {
     assert.equal(PIP_THROW_SCALE, 0.55);
     assert.equal(PIP_THROW_REFERENCE, 5000);
     assert.equal(PIP_THROW_MAX, 0.45);
-    assert.equal(PIP_FLICK_MIN_SPEED, 120);
+  });
+
+  await t.test('the grip is on the corner the resize gesture actually moves', () => {
+    // `pipResizeEdge` takes its sign from the anchor, because the anchored
+    // corner is the one held still while the tile grows. The handle has to be
+    // on the corner that moves, or the pointer separates from it immediately.
+    // These two functions are the only reason the gesture is coherent, and
+    // they used to disagree: the sign came from here and the handle's position
+    // was hard-coded to the tile's top-left in CSS.
+    assert.equal(pipGripCorner('bottom-right'), 'top-left');
+    assert.equal(pipGripCorner('bottom-left'), 'top-right');
+    assert.equal(pipGripCorner('top-right'), 'bottom-left');
+    assert.equal(pipGripCorner('top-left'), 'bottom-right');
+
+    // Stated as the invariant rather than as four pairs: for every anchor, the
+    // grip is on the opposite corner *and* dragging it away from the anchor
+    // grows the tile. Flip either function alone and this fails.
+    for (const alignment of ['top-left', 'top-right', 'bottom-left', 'bottom-right'] as const) {
+      const grip = pipGripCorner(alignment);
+      assert.notEqual(grip.startsWith('top'), alignment.startsWith('top'), alignment);
+      assert.notEqual(grip.endsWith('left'), alignment.endsWith('left'), alignment);
+      // The grip is below the anchor exactly when dragging down must grow.
+      const growsDownward = pipResizeEdge(200, 500, 560, alignment) > 200;
+      assert.equal(growsDownward, grip.startsWith('bottom'), alignment);
+    }
   });
 
   await t.test('a resize drag grows away from the anchor, in every corner', () => {
@@ -181,16 +205,5 @@ test('picture-in-picture motion', async (t) => {
     tracker.update({ x: 20, y: 20 }, 50);
     const v = tracker.velocity();
     assert.ok(Number.isFinite(v.x) && Number.isFinite(v.y), `finite, got ${JSON.stringify(v)}`);
-  });
-
-  await t.test('a press with no movement is not a drag', () => {
-    // Distinguishes a click on a hover control from a drag that happened to
-    // start there.
-    const tracker = new PipDragTracker({ x: 10, y: 10 }, { x: 0, y: 0 }, 0);
-    assert.equal(tracker.hasMoved, false);
-    tracker.update({ x: 10, y: 10 }, 20);
-    assert.equal(tracker.hasMoved, false);
-    tracker.update({ x: 11, y: 10 }, 40);
-    assert.equal(tracker.hasMoved, true);
   });
 });

--- a/apps/desktop/src/main/__tests__/computer-use-pip-motion.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip-motion.test.ts
@@ -1,0 +1,196 @@
+// Contract for the picture-in-picture mirror's motion: the spring, the anchor
+// set, the throw projection and the pointer tracker. These are the parts that
+// can be checked exactly, so they are checked exactly — the numbers came from
+// Codex's sky.node and a silent drift in any of them would be felt but not
+// seen.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PIP_FLICK_MIN_SPEED,
+  PIP_SPRING,
+  PIP_THROW_MAX,
+  PIP_THROW_REFERENCE,
+  PIP_THROW_SCALE,
+  PipDragTracker,
+  anchorFor,
+  pipResizeEdge,
+  clampToWorkArea,
+  pickPipAnchor,
+  pipAnchors,
+  springAtRest,
+  stepSpring,
+} from '../computer-use/pip-motion.js';
+
+const HOST = { x: 0, y: 0, width: 1000, height: 800 };
+const SIZE = { width: 200, height: 125 };
+
+test('picture-in-picture motion', async (t) => {
+  await t.test('carries Codex’s spring constants, and their damping ratios', () => {
+    // `configureMotionSpringsWithLeadItem:dragging:programmaticMove:`, lead column.
+    assert.deepEqual(PIP_SPRING.settling, { stiffness: 320, damping: 42 });
+    assert.deepEqual(PIP_SPRING.dragging, { stiffness: 900, damping: 55 });
+
+    // The ratios are the reason those numbers and not others: settling must not
+    // overshoot the corner it is landing on, dragging should keep a little give.
+    const ratio = (s: { stiffness: number; damping: number }) =>
+      s.damping / (2 * Math.sqrt(s.stiffness));
+    assert.ok(ratio(PIP_SPRING.settling) > 1, 'settling is overdamped, so it never bounces');
+    assert.ok(ratio(PIP_SPRING.dragging) < 1, 'dragging is under critical, so it has give');
+    assert.ok(ratio(PIP_SPRING.dragging) > 0.85, 'but only just — it must not wobble');
+  });
+
+  await t.test('the spring arrives, and never overshoots while settling', () => {
+    let state = { position: { x: 0, y: 0 }, velocity: { x: 0, y: 0 } };
+    const target = { x: 400, y: 300 };
+    let maxX = 0;
+    for (let i = 0; i < 240 && !springAtRest(state, target); i++) {
+      state = stepSpring(state, target, PIP_SPRING.settling, 1 / 60);
+      maxX = Math.max(maxX, state.position.x);
+    }
+    assert.ok(springAtRest(state, target), 'arrives inside four seconds');
+    assert.ok(maxX <= target.x + 0.5, `overdamped means no overshoot (peaked at ${maxX})`);
+  });
+
+  await t.test('a dropped frame makes the spring late, never explosive', () => {
+    // Explicit Euler gains energy at large dt. A backgrounded window can hand
+    // us a gap of seconds, and the mirror must not be launched off-screen by
+    // the machine having been busy.
+    let state = { position: { x: 0, y: 0 }, velocity: { x: 0, y: 0 } };
+    const target = { x: 400, y: 0 };
+    for (let i = 0; i < 60; i++) state = stepSpring(state, target, PIP_SPRING.settling, 5);
+    assert.ok(Number.isFinite(state.position.x));
+    assert.ok(state.position.x <= target.x + 1, 'still converges from above');
+    assert.ok(springAtRest(state, target));
+  });
+
+  await t.test('offers one anchor per corner, inset by the same margin', () => {
+    const anchors = pipAnchors(HOST, SIZE, 24);
+    assert.equal(anchors.length, 4);
+    assert.deepEqual(anchorFor(anchors, 'top-left')?.point, { x: 24, y: 24 });
+    assert.deepEqual(anchorFor(anchors, 'top-right')?.point, { x: 1000 - 200 - 24, y: 24 });
+    assert.deepEqual(anchorFor(anchors, 'bottom-left')?.point, { x: 24, y: 800 - 125 - 24 });
+    assert.deepEqual(anchorFor(anchors, 'bottom-right')?.point, {
+      x: 1000 - 200 - 24,
+      y: 800 - 125 - 24,
+    });
+  });
+
+  await t.test('a still release lands on the corner it is nearest', () => {
+    const anchors = pipAnchors(HOST, SIZE, 24);
+    const near = { x: 700, y: 40 };
+    assert.equal(pickPipAnchor(anchors, near, { x: 0, y: 0 }, HOST).alignment, 'top-right');
+    assert.equal(
+      pickPipAnchor(anchors, { x: 30, y: 600 }, { x: 0, y: 0 }, HOST).alignment,
+      'bottom-left',
+    );
+  });
+
+  await t.test('a throw lands where it was aimed, not where it started', () => {
+    // This is the whole point of the projection. Released in the top-left
+    // quadrant but flung hard to the right, the mirror must cross the window —
+    // nearest-corner alone would drop it back where it came from.
+    const anchors = pipAnchors(HOST, SIZE, 24);
+    const from = { x: 300, y: 40 };
+    assert.equal(
+      pickPipAnchor(anchors, from, { x: 0, y: 0 }, HOST).alignment,
+      'top-left',
+      'without a throw it stays near',
+    );
+    assert.equal(
+      pickPipAnchor(anchors, from, { x: 3000, y: 0 }, HOST).alignment,
+      'top-right',
+      'thrown right, it crosses',
+    );
+    assert.equal(
+      pickPipAnchor(anchors, from, { x: 2000, y: 2500 }, HOST).alignment,
+      'bottom-right',
+      'thrown down and right, it takes the far corner',
+    );
+  });
+
+  await t.test('carries Codex’s throw constants', () => {
+    assert.equal(PIP_THROW_SCALE, 0.55);
+    assert.equal(PIP_THROW_REFERENCE, 5000);
+    assert.equal(PIP_THROW_MAX, 0.45);
+    assert.equal(PIP_FLICK_MIN_SPEED, 120);
+  });
+
+  await t.test('a resize drag grows away from the anchor, in every corner', () => {
+    // `-[PIPStackResizeInteraction maxDisplaySizeForPointerScreenPoint:]` is
+    // four instructions: a sign chosen from the alignment, and the pointer's
+    // vertical travel added to the edge it started at. Only the vertical
+    // component moves it, and the sign is what makes the gesture read the same
+    // wherever the mirror is resting: away from the anchor grows it.
+    //
+    // Anchored at the top, the grip is below, so dragging down grows.
+    assert.equal(pipResizeEdge(200, 500, 560, 'top-left'), 260);
+    assert.equal(pipResizeEdge(200, 500, 440, 'top-left'), 140);
+    // Anchored at the bottom, the grip is above, so dragging up grows.
+    assert.equal(pipResizeEdge(200, 500, 440, 'bottom-right'), 260);
+    assert.equal(pipResizeEdge(200, 500, 560, 'bottom-right'), 140);
+  });
+
+  await t.test('a resize stays inside Codex’s clamp and lands on whole points', () => {
+    // The same [100, 400] the rest of the sizing uses — the three constants are
+    // literally the same doubles in the binary. A fractional edge on a
+    // transparent window shimmers, which is what Codex's
+    // `snapPointToBackingScale:` exists to stop.
+    assert.equal(pipResizeEdge(200, 500, 5000, 'top-left'), 400, 'ceiling');
+    assert.equal(pipResizeEdge(200, 500, -5000, 'top-left'), 100, 'floor');
+    assert.equal(pipResizeEdge(200, 500, 500.4, 'top-left') % 1, 0, 'whole points');
+  });
+
+  await t.test('a resize that does not move the pointer does not move the edge', () => {
+    assert.equal(pipResizeEdge(200, 500, 500, 'top-left'), 200);
+    assert.equal(pipResizeEdge(137, 500, 500, 'bottom-left'), 137);
+  });
+
+  await t.test('never leaves the mirror off the display', () => {
+    const work = { x: 0, y: 0, width: 1440, height: 900 };
+    assert.deepEqual(clampToWorkArea({ x: -500, y: -500 }, SIZE, work), { x: 0, y: 0 });
+    assert.deepEqual(clampToWorkArea({ x: 5000, y: 5000 }, SIZE, work), {
+      x: 1440 - 200,
+      y: 900 - 125,
+    });
+  });
+
+  await t.test('the drag keeps the grab point under the pointer', () => {
+    // Grab the mirror 30pt in and 20pt down, and that spot stays under the
+    // cursor for the whole drag. Anything else makes the window jump on
+    // mousedown, which reads as the drag having missed.
+    const tracker = new PipDragTracker({ x: 130, y: 220 }, { x: 100, y: 200 }, 0);
+    assert.deepEqual(tracker.update({ x: 530, y: 420 }, 100), { x: 500, y: 400 });
+    assert.deepEqual(tracker.update({ x: 330, y: 320 }, 200), { x: 300, y: 300 });
+  });
+
+  await t.test('velocity comes from the last pair of samples only', () => {
+    // A flick that ends in a pause is not a flick. Averaging the whole drag
+    // would throw the mirror anyway, which is the opposite of what the pause
+    // said.
+    const tracker = new PipDragTracker({ x: 0, y: 0 }, { x: 0, y: 0 }, 0);
+    tracker.update({ x: 500, y: 0 }, 100);
+    assert.deepEqual(tracker.velocity(), { x: 5000, y: 0 }, 'a fast sample is a fast throw');
+    tracker.update({ x: 500, y: 0 }, 600);
+    assert.deepEqual(tracker.velocity(), { x: 0, y: 0 }, 'and then it stopped');
+  });
+
+  await t.test('a duplicate pointer event is not an infinite flick', () => {
+    const tracker = new PipDragTracker({ x: 0, y: 0 }, { x: 0, y: 0 }, 0);
+    tracker.update({ x: 10, y: 10 }, 50);
+    tracker.update({ x: 20, y: 20 }, 50);
+    const v = tracker.velocity();
+    assert.ok(Number.isFinite(v.x) && Number.isFinite(v.y), `finite, got ${JSON.stringify(v)}`);
+  });
+
+  await t.test('a press with no movement is not a drag', () => {
+    // Distinguishes a click on a hover control from a drag that happened to
+    // start there.
+    const tracker = new PipDragTracker({ x: 10, y: 10 }, { x: 0, y: 0 }, 0);
+    assert.equal(tracker.hasMoved, false);
+    tracker.update({ x: 10, y: 10 }, 20);
+    assert.equal(tracker.hasMoved, false);
+    tracker.update({ x: 11, y: 10 }, 40);
+    assert.equal(tracker.hasMoved, true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/computer-use-pip-wiring.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip-wiring.test.ts
@@ -1,0 +1,160 @@
+// Lifecycle wiring for the Computer Use picture-in-picture mirror.
+//
+// The mirror's own behaviour is covered by computer-use-pip.test.ts, which
+// builds the controller directly and hands it every dependency. That is
+// precisely why it could not catch what was wrong here: the controller was
+// constructed as a local inside `assembleDesktopTools` and never returned, so
+// `complete`, `clearForSession`, `destroyAll` and `setStopHandler` had no
+// production caller at all, and the `mainWindow` dependency the assembly
+// declares was supplied by nothing in the repo. Every test passed while the
+// window was never torn down, never anchored to the app, and never clickable.
+//
+// So these assertions are about the call sites, not the controller. boot.ts,
+// app-lifecycle.ts and sessions-ipc-main.ts cannot be imported outside Electron
+// — boot.ts is the whole startup chain and the other two bind `ipcMain` and
+// `app` at module scope — so the wiring in those three is asserted against the
+// source text, the same way this repo's other cross-file conventions are. The
+// session-streamer half is a real call, because that module is importable.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { SessionActivityRegistry } from '@maka/runtime';
+import type { SessionEvent } from '@maka/core';
+import { createSessionStreamer } from '../session-stream.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const MAIN = resolve(REPO_ROOT, 'apps/desktop/src/main');
+
+function read(relative: string): Promise<string> {
+  return readFile(resolve(MAIN, relative), 'utf8');
+}
+
+describe('picture-in-picture lifecycle wiring', () => {
+  it('assembleDesktopTools hands the mirror back to its caller', async () => {
+    const source = await read('tool-assembly.ts');
+    const returned = /\n  return \{\n([\s\S]*?)\n  \};\n\}/.exec(source)?.[1];
+    assert.ok(returned, 'assembleDesktopTools must end in a return literal');
+    assert.match(
+      returned,
+      /^\s*computerUsePip,$/m,
+      'a controller that is not returned has no production caller: complete, ' +
+        'clearForSession, destroyAll and setStopHandler are all unreachable',
+    );
+  });
+
+  it('boot.ts gives the assembly the app window it asks for', async () => {
+    const source = await read('boot.ts');
+    assert.match(
+      source,
+      /assembleDesktopTools\(\{[\s\S]*?\n  mainWindow: mainWindowController,/,
+      'without this the mirror floats above every application, has no pointer ' +
+        'to hover-test against, and lands on the primary display',
+    );
+  });
+
+  it('the main window controller supplies all three anchor capabilities', async () => {
+    const source = await read('main-window.ts');
+    for (const method of ['windowBounds', 'browserWindow', 'onWindowGeometryChanged']) {
+      assert.match(
+        source,
+        new RegExp(`^    ${method}\\(`, 'm'),
+        `MainWindowController must implement ${method}`,
+      );
+    }
+    assert.match(source, /w\.on\('move', cb\);\s*\n\s*w\.on\('resize', cb\);/);
+  });
+
+  it('boot.ts tears the mirror down when the window it belongs to closes', async () => {
+    const source = await read('boot.ts');
+    const handler = /onMainWindowClose = \(\) => \{([\s\S]*?)\n\};/.exec(source)?.[1];
+    assert.ok(handler, 'boot.ts must assign onMainWindowClose');
+    assert.match(handler, /computerUsePip\.destroyAll\(\);/);
+  });
+
+  it('boot.ts forwards the mirror to every surface that retires it', async () => {
+    const source = await read('boot.ts');
+    for (const [callee, pattern] of [
+      ['registerSessionsIpc', /registerSessionsIpc\(\{[\s\S]*?\n  \}\);/],
+      ['createSessionStreamer', /createSessionStreamer\(\{[\s\S]*?\n\}\);/],
+      ['wireAppLifecycle', /wireAppLifecycle\(\{[\s\S]*?\n\}\);/],
+    ] as const) {
+      const call = pattern.exec(source)?.[0];
+      assert.ok(call, `boot.ts must call ${callee}`);
+      assert.match(call, /^\s*computerUsePip,$/m, `${callee} must receive the mirror`);
+    }
+  });
+
+  it('app-lifecycle destroys the mirror on both shutdown paths', async () => {
+    const source = await read('app-lifecycle.ts');
+    const allClosed = /app\.on\('window-all-closed', \(\) => \{([\s\S]*?)\n  \}\);/.exec(source)?.[1];
+    assert.ok(allClosed, 'app-lifecycle must handle window-all-closed');
+    assert.match(allClosed, /computerUsePip\.destroyAll\(\)/);
+
+    const quit = /async function runBeforeQuitCleanup\(\): Promise<void> \{([\s\S]*?)\n  \}/.exec(
+      source,
+    )?.[1];
+    assert.ok(quit, 'app-lifecycle must run a before-quit cleanup');
+    assert.match(quit, /computerUsePip\.destroyAll\(\)/);
+  });
+
+  it('the session IPC clears the mirror wherever it clears the cursor', async () => {
+    const source = await read('sessions-ipc-main.ts');
+    const overlayClears = source.match(/computerUseOverlay\.clearForSession\(/g) ?? [];
+    const pipClears = source.match(/computerUsePip\?\.clearForSession\(/g) ?? [];
+    assert.ok(overlayClears.length >= 3, 'sanity: the cursor is cleared on several paths');
+    assert.equal(
+      pipClears.length,
+      overlayClears.length,
+      'the mirror dies with a session on exactly the paths the cursor does: ' +
+        'delete, stop, archive',
+    );
+  });
+
+  it('the mirror stop control runs the same stop the app window runs', async () => {
+    const source = await read('sessions-ipc-main.ts');
+    assert.match(
+      source,
+      /computerUsePip\?\.setStopHandler\(\(sessionId\) => \{\s*\n\s*void stopSession\(sessionId, \{ source: 'stop_button' \}\);/,
+      'without a handler the button in the mirror stops nothing',
+    );
+    assert.match(
+      source,
+      /ipcMain\.handle\('sessions:stop',[\s\S]*?stopSession\(sessionId, input\)/,
+      'and both must be the same function, or they drift',
+    );
+  });
+
+  it('a turn ending retires the mirror', async () => {
+    // The real call, not the source text: this module has no Electron in it.
+    // The mirror used to be cleared only on stop, archive and delete, so it
+    // outlived the run it belonged to and kept showing that run's last frame
+    // while the next turn drove a different application.
+    const completed: string[] = [];
+    const streamEvents = createSessionStreamer({
+      sessionActivities: new SessionActivityRegistry(),
+      goalWiring: {
+        coordinator: {
+          beginObservedTurn: () => ({ kind: 'registered', settle: async () => {} }),
+        },
+      } as never,
+      computerUseOverlay: { clearForSession: () => {} } as never,
+      computerUsePip: { complete: (sessionId) => completed.push(sessionId) },
+      computerUseTools: { clearSession: () => {} } as never,
+      safeSendToRenderer: () => {},
+      emitSessionsChanged: () => {},
+    });
+
+    async function* events(): AsyncGenerator<SessionEvent> {
+      yield {
+        type: 'complete',
+        id: 'e1',
+        turnId: 't1',
+        ts: 1,
+      } as unknown as SessionEvent;
+    }
+
+    await streamEvents('session-a', events(), { turnId: 't1', goalBoundary: 'none' });
+    assert.deepEqual(completed, ['session-a']);
+  });
+});

--- a/apps/desktop/src/main/__tests__/computer-use-pip-wiring.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip-wiring.test.ts
@@ -43,6 +43,40 @@ describe('picture-in-picture lifecycle wiring', () => {
     );
   });
 
+  it('the overlay hook Computer Use is given is wrapped by the mirror', async () => {
+    // The one assertion that makes this branch safe to merge alongside the
+    // others that touch the same expression.
+    //
+    // `createComputerUseHost({ overlay })` takes a single hook, and every
+    // feature that wants to see actions go past wraps the one before it. That
+    // makes the expression a merge conflict by construction: resolving it by
+    // taking one side compiles, type-checks, and leaves every test in both
+    // branches green while one branch's entire feed is silently disconnected.
+    // Measured here by replacing the value with the bare
+    // `createComputerUseOverlayHook(computerUseOverlay)`: `tsc` exits 0 and all
+    // 71 mirror tests pass against a window that can never receive a frame,
+    // because every one of them constructs the wrapper itself.
+    //
+    // So this asserts the production expression, not the wrapper's behaviour.
+    // The correct resolution nests the wrappers rather than choosing between
+    // them; whichever order they end up in, `withComputerUsePip` has to be one
+    // of them.
+    const source = await read('tool-assembly.ts');
+    const overlay = /\n    overlay: ([\s\S]*?),\n  \}\);/.exec(source)?.[1];
+    assert.ok(overlay, 'createComputerUseHost must be given an overlay hook');
+    assert.match(
+      overlay,
+      /withComputerUsePip\(/,
+      'a mirror that is not in the overlay chain is never handed a frame: no ' +
+        'present, no cursor, and a window that only ever shows its placeholder',
+    );
+    assert.match(
+      overlay,
+      /createComputerUseOverlayHook\(computerUseOverlay\)/,
+      'and it wraps the cursor hook rather than replacing it',
+    );
+  });
+
   it('boot.ts gives the assembly the app window it asks for', async () => {
     const source = await read('boot.ts');
     assert.match(

--- a/apps/desktop/src/main/__tests__/computer-use-pip.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip.test.ts
@@ -537,7 +537,87 @@ test('Computer Use picture-in-picture mirror', async (t) => {
     assert.equal(pip.isVisible(), false, 'and stays dismissed for the rest of the run');
 
     pip.present({ sessionId: 's2', ...FRAME });
-    assert.equal(pip.isVisible(), true, 'the next run is a fresh decision');
+    assert.equal(pip.isVisible(), true, 'a different session is a fresh decision');
+  });
+
+  await t.test('a follow-up turn in the same session gets its mirror back', () => {
+    // A run is a turn. `session-stream` calls `complete` at every turn end,
+    // next to the overlay and tool-session clears, and a dismissal expires with
+    // them.
+    //
+    // Scoped to the session instead, this is the shape of it: the user hides
+    // the mirror during turn one, asks a follow-up, and turn two drives another
+    // app for minutes with nothing on screen and no control to bring it back —
+    // stop, archive and delete are the only things that clear the flag, and all
+    // three end the thing they wanted to keep watching. Re-hiding costs one
+    // click; not being able to un-hide costs the whole point of the mirror.
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+
+    windows[0]!.fireMessage('pip:control', { id: 'hide' });
+    assert.equal(pip.isVisible(), false);
+    assert.equal(windows.length, 1);
+
+    // The turn ends while the mirror is dismissed, so there is no window for
+    // `complete` to mark — the dismissal still has to expire.
+    pip.complete('s1');
+
+    pip.present({ sessionId: 's1', ...FRAME });
+    assert.equal(pip.isVisible(), true, 'the next turn is a fresh decision');
+    assert.equal(windows.length, 2, 'and it is a real window, not a stale handle');
+  });
+
+  await t.test('a dismissal does not survive into a mirror it was not aimed at', () => {
+    // `complete` for some other session must leave this run dismissed;
+    // otherwise a second session finishing un-hides the one the user is
+    // watching.
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    windows[0]!.fireMessage('pip:control', { id: 'hide' });
+
+    pip.complete('other-session');
+    pip.present({ sessionId: 's1', ...FRAME });
+    assert.equal(pip.isVisible(), false, 'someone else finishing is not this run ending');
+  });
+
+  await t.test('a finished run is retired once the linger elapses', (t) => {
+    // The linger only ever got asserted as "not destroyed synchronously",
+    // which is also true of a timer that never fires, of a body that does
+    // nothing, and of a zero-length linger. The first two leave the mirror on
+    // screen forever and the third takes it away at the moment a person looks
+    // over, which is the whole reason the linger exists. Run the clock, and
+    // pin both sides of it.
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+
+    pip.complete('s1');
+    assert.equal(pip.isVisible(), true, 'not taken away at the moment the answer lands');
+
+    t.mock.timers.tick(29_999);
+    assert.equal(pip.isVisible(), true, 'still there a moment before the linger is up');
+
+    t.mock.timers.tick(1);
+    assert.equal(pip.isVisible(), false, 'and gone once it is');
+    assert.equal(windows[0]!.isDestroyed(), true);
+  });
+
+  await t.test('a run that resumes keeps the mirror the linger was going to take', (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+
+    pip.complete('s1');
+    t.mock.timers.tick(20_000);
+    pip.present({ sessionId: 's1', ...FRAME });
+    t.mock.timers.tick(30_000);
+
+    assert.equal(pip.isVisible(), true, 'a frame cancels the retirement, it does not delay it');
+    assert.equal(windows.length, 1, 'and does so without rebuilding the window');
   });
 
   await t.test('an unknown control identifier does nothing', () => {

--- a/apps/desktop/src/main/__tests__/computer-use-pip.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip.test.ts
@@ -1,0 +1,794 @@
+// Behavior contract for the Computer Use picture-in-picture mirror. Driven
+// against a fake window (no Electron), asserting the properties that make it
+// the answer to occlusion rather than another thing competing for the screen:
+//  - it mirrors frames the action already produced, never captures its own
+//  - it never takes focus, and never accepts a click
+//  - the cursor is placed in capture pixels, scaled through the window
+//  - it belongs to one session and dies with it
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createComputerUsePipController,
+  pipBoundsForAnchor,
+  pipDisplaySize,
+  pipWindowOptions,
+  withComputerUsePip,
+} from '../computer-use/pip-window.js';
+
+class FakeWindow {
+  sent: Array<{ channel: string; payload: any }> = [];
+  bounds: any = { x: 0, y: 0, width: 200, height: 125 };
+  shown = false;
+  destroyed = false;
+  ignoringMouse = true;
+  private readyCb: (() => void) | null = null;
+  private goneCb: (() => void) | null = null;
+  private messageCb: ((channel: string, payload: unknown) => void) | null = null;
+  /** Every setBounds, so a test can tell "did not move" from "moved back". */
+  moves: any[] = [];
+  send(channel: string, payload: unknown): void {
+    this.sent.push({ channel, payload });
+  }
+  onReady(cb: () => void): void {
+    this.readyCb = cb;
+  }
+  onGone(cb: () => void): void {
+    this.goneCb = cb;
+  }
+  onMessage(cb: (channel: string, payload: unknown) => void): void {
+    this.messageCb = cb;
+  }
+  setBounds(bounds: any): void {
+    this.bounds = bounds;
+    this.moves.push(bounds);
+  }
+  getBounds(): any {
+    return this.bounds;
+  }
+  showInactive(): void {
+    this.shown = true;
+  }
+  setIgnoreMouseEvents(ignore: boolean): void {
+    this.ignoringMouse = ignore;
+  }
+  isDestroyed(): boolean {
+    return this.destroyed;
+  }
+  destroy(): void {
+    this.destroyed = true;
+  }
+  fireReady(): void {
+    this.readyCb?.();
+  }
+  fireGone(): void {
+    this.goneCb?.();
+  }
+  fireMessage(channel: string, payload?: unknown): void {
+    this.messageCb?.(channel, payload);
+  }
+}
+
+/**
+ * A display for the controller to position against. The mirror now owns where
+ * it sits — it re-seats itself on a reshape and settles onto a corner after a
+ * throw — so a test that gives it no display is asking it to work blind.
+ */
+const WORK_AREA = { x: 0, y: 0, width: 1600, height: 1000 };
+
+function makePip(extra: Record<string, unknown> = {}) {
+  const windows: FakeWindow[] = [];
+  const pip = createComputerUsePipController({
+    createWindow: () => {
+      const w = new FakeWindow();
+      windows.push(w);
+      return w as never;
+    },
+    resolveBounds: (aspect) => ({ x: 0, y: 0, width: Math.round(400 * aspect), height: 400 }),
+    workAreaFor: () => WORK_AREA,
+    preloadPath: '/fake/pip-preload.cjs',
+    htmlPath: '/fake/pip.html',
+    ...extra,
+  });
+  return { pip, windows };
+}
+
+const FRAME = {
+  base64: 'AAAA',
+  mimeType: 'image/png' as const,
+  widthPx: 1000,
+  heightPx: 800,
+};
+
+function framesOf(w: FakeWindow | undefined) {
+  return (w?.sent ?? []).filter((m) => m.channel === 'pip:frame');
+}
+function cursorsOf(w: FakeWindow | undefined) {
+  return (w?.sent ?? []).filter((m) => m.channel === 'pip:cursor');
+}
+
+test('Computer Use picture-in-picture mirror', async (t) => {
+  await t.test('never takes focus and never accepts a click', () => {
+    // It reports on work happening elsewhere. Taking focus would interrupt the
+    // very thing it exists to describe.
+    const options = pipWindowOptions({ x: 0, y: 0, width: 400, height: 300 }, '/p.cjs');
+    assert.equal(options.focusable, false);
+    assert.equal(options.acceptFirstMouse, false);
+    assert.equal(options.show, false, 'shown only via showInactive once loaded');
+    assert.equal(options.skipTaskbar, true);
+    assert.equal(options.webPreferences?.contextIsolation, true);
+    assert.equal(options.webPreferences?.nodeIntegration, false);
+    assert.equal(options.webPreferences?.sandbox, true);
+  });
+
+  await t.test('attaches to the app window rather than floating above every app', () => {
+    // Codex's `RemoteHostedPIPContentCreateStackPanel` sets `setLevel: 0` —
+    // plain NSNormalWindowLevel — and attaches the panel to its owner with
+    // `addChildWindow:ordered:`. A child window is ordered against its parent,
+    // so it sits above the app it belongs to and below everything else. The
+    // mirror used to pass `alwaysOnTop` with no level, which defaults to
+    // `floating` and put it above unrelated apps.
+    const parent = { isDestroyed: () => false };
+    const attached = pipWindowOptions({ x: 0, y: 0, width: 200, height: 125 }, '/p.cjs', parent);
+    assert.equal(attached.parent, parent as never, 'parented to the app window');
+    assert.equal(attached.alwaysOnTop, undefined, 'and therefore claims no level of its own');
+
+    // With no app window there is nothing to sit above, so the mirror has to
+    // claim a level or be buried. Codex's own fallbackAnchor path.
+    const detached = pipWindowOptions({ x: 0, y: 0, width: 200, height: 125 }, '/p.cjs');
+    assert.equal(detached.parent, undefined);
+    assert.equal(detached.alwaysOnTop, true);
+
+    // Codex's `setHasShadow: NO`. pip.html draws its own; the native one would
+    // be a second shadow, recomputed from the content's alpha on every frame.
+    assert.equal(attached.hasShadow, false);
+  });
+
+  await t.test('sizes the mirror the way Codex does', () => {
+    // Recovered from Codex: default longest edge 200pt, clamped to [100, 400],
+    // shorter edge scaled to preserve aspect, non-finite falling back to the
+    // default. This was 420 on a guess — above Codex's hard ceiling, and about
+    // 4.4x the area of its default.
+    assert.deepEqual(pipDisplaySize(16 / 10), { width: 200, height: 125 });
+    assert.deepEqual(pipDisplaySize(1), { width: 200, height: 200 });
+    assert.deepEqual(pipDisplaySize(0.5), { width: 100, height: 200 }, 'tall windows too');
+
+    // The longest edge lands exactly on the requested edge, both orientations.
+    assert.equal(pipDisplaySize(2, 300).width, 300);
+    assert.equal(pipDisplaySize(0.5, 300).height, 300);
+
+    // Clamped at both ends, and never NaN.
+    assert.equal(pipDisplaySize(1, 5).width, 100, 'floor');
+    assert.equal(pipDisplaySize(1, 9999).width, 400, 'ceiling');
+    assert.deepEqual(pipDisplaySize(Number.NaN), { width: 200, height: 200 });
+    assert.deepEqual(pipDisplaySize(1, Number.POSITIVE_INFINITY), { width: 200, height: 200 });
+
+    // No zero-height mirror for an absurd aspect.
+    assert.ok(pipDisplaySize(500).height >= 1);
+  });
+
+  await t.test('anchors to the app window, not to a screen corner', () => {
+    // Codex anchors its tiles 24pt inside its own window's rect and moves them
+    // with it. Pinning to a display corner leaves the mirror behind the moment
+    // the user drags the app to another screen — which is exactly how an
+    // unexplained window ends up on someone's second monitor.
+    const work = { x: 0, y: 0, width: 1920, height: 1080 };
+    const app = { x: 400, y: 200, width: 900, height: 600 };
+    const bounds = pipBoundsForAnchor(16 / 10, app, work);
+    assert.equal(bounds.width, 200);
+    assert.equal(bounds.height, 125);
+    // Bottom-right of the app window, inset by Codex's 24pt.
+    assert.equal(bounds.x, 400 + 900 - 200 - 24);
+    assert.equal(bounds.y, 200 + 600 - 125 - 24);
+  });
+
+  await t.test('falls back to the work area when there is no app window', () => {
+    const work = { x: 0, y: 0, width: 1440, height: 900 };
+    const bounds = pipBoundsForAnchor(1, undefined, work);
+    assert.equal(bounds.x, 1440 - 200 - 24);
+    assert.equal(bounds.y, 900 - 200 - 24);
+  });
+
+  await t.test('never places the mirror outside the display it belongs to', () => {
+    // An app window flush against a screen edge would otherwise push the
+    // mirror off that screen, or onto the neighbouring one.
+    const work = { x: 0, y: 0, width: 1440, height: 900 };
+    const flushRight = { x: 1200, y: 700, width: 400, height: 300 };
+    const bounds = pipBoundsForAnchor(1, flushRight, work);
+    assert.ok(bounds.x + bounds.width <= work.x + work.width, 'inside on the right');
+    assert.ok(bounds.y + bounds.height <= work.y + work.height, 'inside at the bottom');
+
+    const offLeft = { x: -600, y: -400, width: 500, height: 300 };
+    const clamped = pipBoundsForAnchor(1, offLeft, work);
+    assert.ok(clamped.x >= work.x, 'inside on the left');
+    assert.ok(clamped.y >= work.y, 'inside at the top');
+  });
+
+  await t.test('lets the window server carry the mirror, and only reacts to resizes', () => {
+    // Measured on Electron 43: a child window follows its parent's *move*
+    // inside the same window-server transaction, and does not move when the
+    // parent *resizes*. So repositioning on a move is redundant and a frame
+    // late — that lateness is the trailing the mirror showed during a drag —
+    // while a resize genuinely moves the corner out from under it.
+    const changes: Array<() => void> = [];
+    const windows: FakeWindow[] = [];
+    let appRect = { x: 0, y: 0, width: 800, height: 600 };
+    const pip = createComputerUsePipController({
+      createWindow: () => {
+        const w = new FakeWindow();
+        windows.push(w);
+        return w as never;
+      },
+      resolveAnchorRect: () => appRect,
+      resolveParentWindow: () => ({ isDestroyed: () => false }),
+      subscribeAnchorChanges: (cb) => {
+        changes.push(cb);
+        return () => {};
+      },
+      resolveBounds: (aspect) =>
+        pipBoundsForAnchor(aspect, appRect, { x: 0, y: 0, width: 3000, height: 2000 }),
+      workAreaFor: () => ({ x: 0, y: 0, width: 3000, height: 2000 }),
+      preloadPath: '/p.cjs',
+      htmlPath: '/p.html',
+    });
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    windows[0]!.moves.length = 0;
+
+    // A drag: the origin moves, the size does not.
+    appRect = { x: 1000, y: 500, width: 800, height: 600 };
+    for (const cb of changes) cb();
+    assert.deepEqual(windows[0]!.moves, [], 'a move is left to the window server');
+
+    // A resize: the corner the mirror hangs off has moved relative to it.
+    appRect = { x: 1000, y: 500, width: 1200, height: 900 };
+    for (const cb of changes) cb();
+    assert.equal(windows[0]!.moves.length, 1, 'a resize is recomputed');
+    assert.deepEqual(
+      windows[0]!.moves[0],
+      pipBoundsForAnchor(FRAME.widthPx / FRAME.heightPx, appRect, {
+        x: 0,
+        y: 0,
+        width: 3000,
+        height: 2000,
+      }),
+      'and it lands back on the corner it was resting on',
+    );
+  });
+
+  await t.test('with no app window to attach to, the mirror moves itself', () => {
+    // Nothing is carrying it, so every geometry change has to be acted on.
+    const changes: Array<() => void> = [];
+    const windows: FakeWindow[] = [];
+    let appRect = { x: 0, y: 0, width: 800, height: 600 };
+    const pip = createComputerUsePipController({
+      createWindow: () => {
+        const w = new FakeWindow();
+        windows.push(w);
+        return w as never;
+      },
+      resolveAnchorRect: () => appRect,
+      subscribeAnchorChanges: (cb) => {
+        changes.push(cb);
+        return () => {};
+      },
+      resolveBounds: (aspect) =>
+        pipBoundsForAnchor(aspect, appRect, { x: 0, y: 0, width: 3000, height: 2000 }),
+      workAreaFor: () => ({ x: 0, y: 0, width: 3000, height: 2000 }),
+      preloadPath: '/p.cjs',
+      htmlPath: '/p.html',
+    });
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    windows[0]!.moves.length = 0;
+
+    appRect = { x: 1000, y: 500, width: 800, height: 600 };
+    for (const cb of changes) cb();
+    assert.equal(windows[0]!.moves.length, 1, 'the mirror moved with the app');
+  });
+
+  await t.test('a destroyed app window is not used as a parent', () => {
+    // The window can go while a session is still running. Passing a dead
+    // BrowserWindow to `parent` throws inside Electron, and the mirror must
+    // fail to the level it would have used had there never been a window.
+    const seen: Array<{ parent?: unknown; alwaysOnTop?: boolean }> = [];
+    const windows: FakeWindow[] = [];
+    const pip = createComputerUsePipController({
+      createWindow: (options) => {
+        seen.push(options);
+        const w = new FakeWindow();
+        windows.push(w);
+        return w as never;
+      },
+      resolveParentWindow: () => ({ isDestroyed: () => true }),
+      resolveBounds: () => ({ x: 0, y: 0, width: 200, height: 125 }),
+      workAreaFor: () => WORK_AREA,
+      preloadPath: '/p.cjs',
+      htmlPath: '/p.html',
+    });
+    pip.present({ sessionId: 's1', ...FRAME });
+    assert.equal(seen[0]?.parent, undefined);
+    assert.equal(seen[0]?.alwaysOnTop, true);
+  });
+
+  await t.test('the mirror is click-through until the pointer is on it', () => {
+    // Hover is decided here, from the pointer, the way Codex decides it with a
+    // global NSEvent monitor rather than by asking its window. The first
+    // version let the page decide from forwarded mouse moves, and those drop —
+    // five injected moves arrived as two on a real machine.
+    let cursor = { x: 0, y: 0 };
+    const ticks: Array<() => void> = [];
+    const { pip, windows } = makePip({
+      cursorPoint: () => cursor,
+      scheduleHoverCheck: (cb: () => void) => {
+        ticks.push(cb);
+        return () => {};
+      },
+      resolveBounds: () => ({ x: 100, y: 100, width: 200, height: 125 }),
+    });
+    pip.present({ sessionId: 's1', ...FRAME });
+    const w = windows[0]!;
+    w.setBounds({ x: 100, y: 100, width: 200, height: 125 });
+    w.fireReady();
+    const poll = () => {
+      const next = ticks.shift();
+      if (next) next();
+    };
+
+    assert.equal(w.ignoringMouse, true, 'transparent to clicks at rest');
+    poll();
+    assert.equal(w.ignoringMouse, true, 'and while the pointer is elsewhere');
+
+    cursor = { x: 150, y: 150 };
+    poll();
+    assert.equal(w.ignoringMouse, false, 'takes the pointer while it is on the mirror');
+    assert.deepEqual(
+      w.sent.filter((m) => m.channel === 'pip:controls').at(-1)?.payload,
+      { visible: true },
+      'and the controls appear with it',
+    );
+
+    cursor = { x: 900, y: 900 };
+    poll();
+    assert.equal(w.ignoringMouse, true, 'and gives it straight back');
+    assert.deepEqual(
+      w.sent.filter((m) => m.channel === 'pip:controls').at(-1)?.payload,
+      { visible: false },
+    );
+  });
+
+  await t.test('a drag keeps the pointer, wherever the spring has got to', () => {
+    // The mirror trails the cursor by design, so mid-drag the pointer is often
+    // outside its bounds. Reading that as "the user left" would hand the clicks
+    // back in the middle of the gesture that needs them.
+    let cursor = { x: 150, y: 150 };
+    const ticks: Array<() => void> = [];
+    const { pip, windows } = makePip({
+      cursorPoint: () => cursor,
+      scheduleHoverCheck: (cb: () => void) => {
+        ticks.push(cb);
+        return () => {};
+      },
+      scheduleFrame: () => () => {},
+      resolveBounds: () => ({ x: 100, y: 100, width: 200, height: 125 }),
+    });
+    pip.present({ sessionId: 's1', ...FRAME });
+    const w = windows[0]!;
+    w.setBounds({ x: 100, y: 100, width: 200, height: 125 });
+    w.fireReady();
+    const poll = () => {
+      const next = ticks.shift();
+      if (next) next();
+    };
+    poll();
+    assert.equal(w.ignoringMouse, false, 'hovered before the press');
+
+    w.fireMessage('pip:pointer-down');
+    cursor = { x: 900, y: 900 };
+    poll();
+    assert.equal(w.ignoringMouse, false, 'still holding it mid-drag');
+
+    w.fireMessage('pip:pointer-up');
+    poll();
+    assert.equal(w.ignoringMouse, true, 'and released once the drag ends');
+  });
+
+  await t.test('a drag moves the mirror, and a release settles it on a corner', () => {
+    // The whole interaction, end to end: press, drag across the window, throw
+    // it right, and watch the settling spring carry it to the corner the throw
+    // was aimed at.
+    let cursor = { x: 500, y: 500 };
+    let clock = 0;
+    const frames: Array<() => void> = [];
+    const { pip, windows } = makePip({
+      resolveAnchorRect: () => ({ x: 0, y: 0, width: 1600, height: 1000 }),
+      resolveParentWindow: () => ({ isDestroyed: () => false }),
+      resolveBounds: () => ({ x: 400, y: 800, width: 200, height: 125 }),
+      cursorPoint: () => cursor,
+      now: () => clock,
+      scheduleFrame: (cb: () => void) => {
+        frames.push(cb);
+        return () => {};
+      },
+    });
+    pip.present({ sessionId: 's1', ...FRAME });
+    const w = windows[0]!;
+    w.fireReady();
+    const runFrames = (count: number) => {
+      for (let i = 0; i < count; i++) {
+        const next = frames.shift();
+        if (!next) return;
+        clock += 16;
+        next();
+      }
+    };
+
+    assert.equal(pip.currentAlignment(), 'bottom-right', 'starts where it was placed');
+
+    // Press on the mirror's own top-left corner, wherever the controller has
+    // actually seated it, so the grab offset is zero and the drag is readable.
+    const seated = w.getBounds();
+    cursor = { x: seated.x, y: seated.y };
+    w.fireMessage('pip:pointer-down');
+    w.moves.length = 0;
+
+    // Drag it up and to the left, fast enough that the release is a throw.
+    cursor = { x: 200, y: 200 };
+    clock += 16;
+    w.fireMessage('pip:pointer-move');
+    runFrames(30);
+    assert.ok(w.moves.length > 0, 'the mirror follows the pointer');
+    assert.ok(w.moves.at(-1)!.x < seated.x, 'leftward');
+    assert.ok(w.moves.at(-1)!.y < seated.y, 'and upward');
+
+    clock += 16;
+    w.fireMessage('pip:pointer-up');
+    runFrames(400);
+    assert.equal(pip.currentAlignment(), 'top-left', 'thrown up and left, it lands there');
+    assert.deepEqual(
+      { x: w.moves.at(-1)!.x, y: w.moves.at(-1)!.y },
+      { x: 24, y: 24 },
+      'and comes to rest exactly on the anchor',
+    );
+  });
+
+  await t.test('a resize brings the mirror back to the corner the user chose', () => {
+    // Not to the default corner. Someone put it in the top-left on purpose,
+    // and resizing the app window is not them changing their mind.
+    let cursor = { x: 0, y: 0 };
+    let clock = 0;
+    const frames: Array<() => void> = [];
+    const changes: Array<() => void> = [];
+    let appRect = { x: 0, y: 0, width: 1600, height: 1000 };
+    const { pip, windows } = makePip({
+      resolveAnchorRect: () => appRect,
+      resolveParentWindow: () => ({ isDestroyed: () => false }),
+      subscribeAnchorChanges: (cb: () => void) => {
+        changes.push(cb);
+        return () => {};
+      },
+      resolveBounds: () => ({ x: 1376, y: 851, width: 200, height: 125 }),
+      cursorPoint: () => cursor,
+      now: () => clock,
+      scheduleFrame: (cb: () => void) => {
+        frames.push(cb);
+        return () => {};
+      },
+    });
+    pip.present({ sessionId: 's1', ...FRAME });
+    const w = windows[0]!;
+    w.fireReady();
+
+    cursor = { x: w.getBounds().x, y: w.getBounds().y };
+    w.fireMessage('pip:pointer-down');
+    cursor = { x: 100, y: 100 };
+    clock += 16;
+    w.fireMessage('pip:pointer-move');
+    clock += 16;
+    w.fireMessage('pip:pointer-up');
+    for (let i = 0; i < 400; i++) {
+      const next = frames.shift();
+      if (!next) break;
+      clock += 16;
+      next();
+    }
+    assert.equal(pip.currentAlignment(), 'top-left');
+
+    w.moves.length = 0;
+    appRect = { x: 0, y: 0, width: 1200, height: 800 };
+    for (const cb of changes) cb();
+    assert.deepEqual(
+      { x: w.moves.at(-1)!.x, y: w.moves.at(-1)!.y },
+      { x: 24, y: 24 },
+      'still the top-left, against the new rect',
+    );
+  });
+
+  await t.test('the stop control runs the same stop the menu bar does', () => {
+    const stopped: string[] = [];
+    const { pip, windows } = makePip();
+    pip.setStopHandler((id) => stopped.push(id));
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+
+    windows[0]!.fireMessage('pip:control', { id: 'stop' });
+    assert.deepEqual(stopped, ['s1']);
+    assert.equal(pip.isVisible(), true, 'stopping the run does not close the mirror');
+  });
+
+  await t.test('hide dismisses the mirror for this run, and only this run', () => {
+    // Codex has `hide` and `close`; with one tile they are the same gesture.
+    // Dismissing is a statement about this run — the next one gets a mirror.
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+
+    windows[0]!.fireMessage('pip:control', { id: 'hide' });
+    assert.equal(pip.isVisible(), false);
+
+    pip.present({ sessionId: 's1', ...FRAME });
+    assert.equal(pip.isVisible(), false, 'and stays dismissed for the rest of the run');
+
+    pip.present({ sessionId: 's2', ...FRAME });
+    assert.equal(pip.isVisible(), true, 'the next run is a fresh decision');
+  });
+
+  await t.test('an unknown control identifier does nothing', () => {
+    const stopped: string[] = [];
+    const { pip, windows } = makePip();
+    pip.setStopHandler((id) => stopped.push(id));
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    windows[0]!.fireMessage('pip:control', { id: 'launch-the-missiles' });
+    windows[0]!.fireMessage('pip:control', {});
+    assert.deepEqual(stopped, []);
+    assert.equal(pip.isVisible(), true);
+  });
+
+  await t.test('a stale window cannot drive the live one', () => {
+    // The mirror is rebuilt per session. A message arriving late from the
+    // window that just went away must not move the one that replaced it.
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    pip.present({ sessionId: 's2', ...FRAME });
+    windows[1]!.fireReady();
+    windows[1]!.moves.length = 0;
+
+    windows[0]!.fireMessage('pip:hover', { inside: true });
+    windows[0]!.fireMessage('pip:control', { id: 'hide' });
+    assert.equal(pip.isVisible(), true, 'the live mirror is untouched');
+    assert.equal(windows[1]!.ignoringMouse, true);
+  });
+
+  await t.test('stays absent until a frame arrives', () => {
+    const { pip, windows } = makePip();
+    assert.equal(pip.isVisible(), false);
+    assert.equal(windows.length, 0);
+  });
+
+  await t.test('a frameless result opens nothing', () => {
+    // Not every action returns a screenshot. An empty mirror is worse than none.
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', base64: '', mimeType: 'image/png', widthPx: 0, heightPx: 0 });
+    assert.equal(windows.length, 0);
+  });
+
+  await t.test('opens on the first frame and shows it only once loaded', () => {
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME, title: 'Codex CUA Lab' });
+    const w = windows[0]!;
+    assert.equal(pip.isVisible(), true);
+    assert.equal(w.shown, false, 'nothing is shown before the page loads');
+    assert.equal(framesOf(w).length, 0, 'queued, not sent');
+    w.fireReady();
+    assert.equal(w.shown, true);
+    assert.equal(framesOf(w).length, 1);
+    assert.match(framesOf(w)[0]!.payload.src, /^data:image\/png;base64,/);
+    // The title rides along for future use but is not rendered: Codex's tiles
+    // have no chrome at any size.
+    assert.equal(framesOf(w)[0]!.payload.title, 'Codex CUA Lab');
+  });
+
+  await t.test('queues only the newest frame while loading', () => {
+    // Actions can outrun a loading page. Holding every base64 frame that
+    // arrives in the meantime is a real memory cost for no benefit — the
+    // mirror only ever displays the latest.
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    pip.present({ sessionId: 's1', ...FRAME, base64: 'BBBB' });
+    pip.present({ sessionId: 's1', ...FRAME, base64: 'CCCC' });
+    const w = windows[0]!;
+    w.fireReady();
+    const frames = framesOf(w);
+    assert.equal(frames.length, 1);
+    assert.match(frames[0]!.payload.src, /CCCC$/);
+  });
+
+  await t.test('reuses one window across a session', () => {
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    pip.present({ sessionId: 's1', ...FRAME, base64: 'BBBB' });
+    assert.equal(windows.length, 1);
+    assert.equal(framesOf(windows[0]).length, 2);
+  });
+
+  await t.test('a finished run keeps its mirror instead of taking it away', () => {
+    // Destroying it the instant the turn ends removes the final state at the
+    // moment a person looks over — they were watching background work because
+    // they could not see the window, and the answer arriving is when they look.
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    pip.complete('s1');
+    assert.equal(windows[0]!.destroyed, false, 'the mirror is still there to look at');
+    assert.ok(
+      windows[0]!.sent.some((message) => message.channel === 'pip:completed'),
+      'and it says the picture has stopped changing',
+    );
+  });
+
+  await t.test('a new frame cancels a pending retirement', () => {
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    pip.complete('s1');
+    pip.present({ sessionId: 's1', ...FRAME });
+    assert.equal(windows.length, 1, 'the same mirror, not a replacement');
+    assert.equal(windows[0]!.destroyed, false);
+  });
+
+  await t.test('stopping still takes the mirror away at once', () => {
+    // Lingering is for a run that ended on its own. A user who stopped it has
+    // said they are done.
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    pip.clearForSession('s1');
+    assert.equal(windows[0]!.destroyed, true);
+  });
+
+  await t.test('a different session supersedes the mirror', () => {
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    pip.present({ sessionId: 's2', ...FRAME });
+    assert.equal(windows.length, 2);
+    assert.equal(windows[0]!.destroyed, true, 'no orphan mirror survives');
+    assert.equal(pip.currentSessionId(), 's2');
+  });
+
+  await t.test('places the cursor in capture pixels', () => {
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    pip.setCursor({ sessionId: 's1', x: 250, y: 400 });
+    const last = cursorsOf(windows[0]).at(-1)!;
+    assert.deepEqual(last.payload, { x: 250, y: 400 });
+  });
+
+  await t.test('hides the cursor when there is no point to show', () => {
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    pip.setCursor({ sessionId: 's1' });
+    assert.deepEqual(cursorsOf(windows[0]).at(-1)!.payload, { hidden: true });
+  });
+
+  await t.test('ignores a cursor update for another session', () => {
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    pip.setCursor({ sessionId: 'other', x: 1, y: 1 });
+    assert.equal(cursorsOf(windows[0]).length, 0);
+  });
+
+  await t.test('closes with its own session and ignores others', () => {
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    pip.clearForSession('s2');
+    assert.equal(pip.isVisible(), true);
+    pip.clearForSession('s1');
+    assert.equal(pip.isVisible(), false);
+    assert.equal(windows[0]!.destroyed, true);
+  });
+
+  await t.test('a window closed from outside is not resurrected', () => {
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    windows[0]!.fireReady();
+    windows[0]!.fireGone();
+    assert.equal(pip.isVisible(), false);
+    assert.equal(pip.currentSessionId(), null);
+  });
+});
+
+test('picture-in-picture wiring into the overlay hook', async (t) => {
+  function sink() {
+    const calls: Array<{ m: string; a: any }> = [];
+    return {
+      calls,
+      pip: {
+        present: (i: unknown) => calls.push({ m: 'present', a: i }),
+        setCursor: (i: unknown) => calls.push({ m: 'setCursor', a: i }),
+        clearForSession: () => {},
+        destroyAll: () => {},
+        isVisible: () => false,
+        currentSessionId: () => null,
+      },
+    };
+  }
+
+  await t.test('mirrors the frame the action already produced', () => {
+    // Load-bearing: no second capture. The screenshot a mutating action returns
+    // was taken after the settle wait, so it already shows the settled result.
+    const { calls, pip } = sink();
+    let inner = 0;
+    const hook = { onActionBegin: () => undefined, onActionEnd: () => void (inner += 1) };
+    const wrapped = withComputerUsePip(hook as never, pip as never) as any;
+    wrapped.onActionEnd({ type: 'left_click' }, {
+      screenshot: { base64: 'AAAA', mimeType: 'image/png', widthPx: 1000, heightPx: 800 },
+      resolvedScreenPoint: { x: 700, y: 300 },
+      observation: { windowTitle: 'Lab', windowBounds: { x: 500, y: 100, width: 500, height: 400 } },
+    }, { sessionId: 's1', toolCallId: 't1' });
+
+    assert.equal(inner, 1, 'the underlying cursor hook still runs');
+    const present = calls.find((c) => c.m === 'present')!;
+    assert.equal(present.a.base64, 'AAAA');
+    assert.equal(present.a.title, 'Lab');
+  });
+
+  await t.test('scales the cursor through the window, not by offset alone', () => {
+    // A Retina capture is wider in pixels than its window is in points.
+    // Subtracting the origin without scaling lands the dot a fraction of the
+    // way into the element instead of on it.
+    const { calls, pip } = sink();
+    const hook = { onActionBegin: () => undefined, onActionEnd: () => undefined };
+    const wrapped = withComputerUsePip(hook as never, pip as never) as any;
+    wrapped.onActionEnd({ type: 'left_click' }, {
+      screenshot: { base64: 'AAAA', mimeType: 'image/png', widthPx: 1000, heightPx: 800 },
+      resolvedScreenPoint: { x: 750, y: 300 },
+      observation: { windowBounds: { x: 500, y: 100, width: 500, height: 400 } },
+    }, { sessionId: 's1', toolCallId: 't1' });
+
+    // (750-500)/500 * 1000 = 500 ; (300-100)/400 * 800 = 400
+    assert.deepEqual(calls.find((c) => c.m === 'setCursor')!.a, { sessionId: 's1', x: 500, y: 400 });
+  });
+
+  await t.test('hides the cursor when the action resolved no point', () => {
+    // Semantic actions address an element; some report no screen point at all.
+    // Leaving a stale dot on screen would assert something untrue.
+    const { calls, pip } = sink();
+    const hook = { onActionBegin: () => undefined, onActionEnd: () => undefined };
+    const wrapped = withComputerUsePip(hook as never, pip as never) as any;
+    wrapped.onActionEnd({ type: 'click_element' }, {
+      screenshot: { base64: 'AAAA', mimeType: 'image/png', widthPx: 1000, heightPx: 800 },
+      observation: { windowBounds: { x: 0, y: 0, width: 500, height: 400 } },
+    }, { sessionId: 's1', toolCallId: 't1' });
+    assert.deepEqual(calls.find((c) => c.m === 'setCursor')!.a, { sessionId: 's1' });
+  });
+
+  await t.test('a mirror failure never takes the action down with it', () => {
+    const throwing = {
+      present: () => {
+        throw new Error('renderer died');
+      },
+      setCursor: () => {},
+      clearForSession: () => {},
+      destroyAll: () => {},
+      isVisible: () => false,
+      currentSessionId: () => null,
+    };
+    let inner = 0;
+    const hook = { onActionBegin: () => undefined, onActionEnd: () => void (inner += 1) };
+    const wrapped = withComputerUsePip(hook as never, throwing as never) as any;
+    assert.doesNotThrow(() =>
+      wrapped.onActionEnd({ type: 'left_click' }, {
+        screenshot: { base64: 'AAAA', mimeType: 'image/png', widthPx: 10, heightPx: 10 },
+      }, { sessionId: 's1', toolCallId: 't1' }),
+    );
+    assert.equal(inner, 1);
+  });
+});

--- a/apps/desktop/src/main/__tests__/computer-use-pip.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip.test.ts
@@ -820,6 +820,57 @@ test('picture-in-picture wiring into the overlay hook', async (t) => {
     assert.deepEqual(calls.find((c) => c.m === 'setCursor')!.a, { sessionId: 's1', x: 500, y: 400 });
   });
 
+  await t.test('falls back to the point the action was addressed to', () => {
+    // The executor reports `resolvedScreenPoint` only for the coordinate
+    // paths. An element action resolves to an element, so it carries none —
+    // and accessibility is how Maka dispatches by default, which made this the
+    // ordinary case rather than the exceptional one. The context still knows
+    // where the action was aimed (`presentationScreenPoint`, the element's own
+    // centre, already computed to fly the cursor there), and without that
+    // fallback the mirror cleared its cursor at the end of every accessibility
+    // action: the one window the user could watch showed the app being driven
+    // by nothing at all.
+    const { calls, pip } = sink();
+    const hook = { onActionBegin: () => undefined, onActionEnd: () => undefined };
+    const wrapped = withComputerUsePip(hook as never, pip as never) as any;
+    wrapped.onActionEnd({ type: 'click_element' }, {
+      screenshot: { base64: 'AAAA', mimeType: 'image/png', widthPx: 1000, heightPx: 800 },
+      // No resolvedScreenPoint: this is a semantic action.
+      observation: { windowBounds: { x: 500, y: 100, width: 500, height: 400 } },
+    }, {
+      sessionId: 's1',
+      toolCallId: 't1',
+      presentationScreenPoint: { x: 750, y: 300 },
+    });
+
+    assert.deepEqual(
+      calls.find((c) => c.m === 'setCursor')!.a,
+      { sessionId: 's1', x: 500, y: 400 },
+      'the element centre is mapped into capture pixels the same way a ' +
+        'coordinate landing is',
+    );
+  });
+
+  await t.test('prefers where the action landed over where it was aimed', () => {
+    // The fallback is a fallback. When the executor reports a real landing
+    // point, that is the truth about where the pointer went; the aim point is
+    // only what was asked for.
+    const { calls, pip } = sink();
+    const hook = { onActionBegin: () => undefined, onActionEnd: () => undefined };
+    const wrapped = withComputerUsePip(hook as never, pip as never) as any;
+    wrapped.onActionEnd({ type: 'left_click' }, {
+      screenshot: { base64: 'AAAA', mimeType: 'image/png', widthPx: 1000, heightPx: 800 },
+      resolvedScreenPoint: { x: 750, y: 300 },
+      observation: { windowBounds: { x: 500, y: 100, width: 500, height: 400 } },
+    }, {
+      sessionId: 's1',
+      toolCallId: 't1',
+      presentationScreenPoint: { x: 500, y: 100 },
+    });
+
+    assert.deepEqual(calls.find((c) => c.m === 'setCursor')!.a, { sessionId: 's1', x: 500, y: 400 });
+  });
+
   await t.test('hides the cursor when the action resolved no point', () => {
     // Semantic actions address an element; some report no screen point at all.
     // Leaving a stale dot on screen would assert something untrue.

--- a/apps/desktop/src/main/__tests__/computer-use-pip.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip.test.ts
@@ -24,6 +24,7 @@ class FakeWindow {
   ignoringMouse = true;
   private readyCb: (() => void) | null = null;
   private goneCb: (() => void) | null = null;
+  private loadFailureCb: ((reason: string) => void) | null = null;
   private messageCb: ((channel: string, payload: unknown) => void) | null = null;
   /** Every setBounds, so a test can tell "did not move" from "moved back". */
   moves: any[] = [];
@@ -35,6 +36,9 @@ class FakeWindow {
   }
   onGone(cb: () => void): void {
     this.goneCb = cb;
+  }
+  onLoadFailure(cb: (reason: string) => void): void {
+    this.loadFailureCb = cb;
   }
   onMessage(cb: (channel: string, payload: unknown) => void): void {
     this.messageCb = cb;
@@ -63,6 +67,9 @@ class FakeWindow {
   }
   fireGone(): void {
     this.goneCb?.();
+  }
+  fireLoadFailure(reason = 'ERR_FILE_NOT_FOUND (-6)'): void {
+    this.loadFailureCb?.(reason);
   }
   fireMessage(channel: string, payload?: unknown): void {
     this.messageCb?.(channel, payload);
@@ -702,6 +709,62 @@ test('Computer Use picture-in-picture mirror', async (t) => {
     windows[0]!.fireGone();
     assert.equal(pip.isVisible(), false);
     assert.equal(pip.currentSessionId(), null);
+  });
+
+  await t.test('a page that fails to load is destroyed, not left invisible', () => {
+    // `showInactive` and the hover watch both live behind `onReady`, which a
+    // failed load never fires. Left alone, the window is invisible, has no
+    // controls, is never torn down, and quietly accumulates queued frames --
+    // one per session, indistinguishable from a mirror that is working. A
+    // missing dist/overlay/pip.html is enough to produce it.
+    const { pip, windows } = makePip();
+    pip.present({ sessionId: 's1', ...FRAME });
+    const failed = windows[0]!;
+    assert.equal(failed.shown, false, 'nothing is shown before the page loads');
+
+    failed.fireLoadFailure();
+
+    assert.equal(failed.destroyed, true, 'the window must not leak');
+    assert.equal(pip.isVisible(), false);
+    assert.equal(pip.currentSessionId(), null);
+
+    // And the next frame gets a fresh window rather than feeding the dead one.
+    pip.present({ sessionId: 's1', ...FRAME });
+    assert.equal(windows.length, 2);
+    assert.equal(windows[1]!.destroyed, false);
+  });
+
+  await t.test('rests against the app window\'s display, not the mirror\'s', () => {
+    // The anchors are corners of the app window, so they are expressed in that
+    // window's display's coordinates. Clamping them into the work area of
+    // whichever display the mirror currently sits on mixes two coordinate
+    // spaces: with the app on an external display and the mirror still on the
+    // built-in one, the corner computed on the external screen was clamped to
+    // the built-in screen's right edge and the mirror parked there.
+    const BUILT_IN = { x: 0, y: 0, width: 1600, height: 1000 };
+    const EXTERNAL = { x: 1600, y: 0, width: 1920, height: 1080 };
+    const appWindow = { x: 1700, y: 100, width: 1000, height: 700 };
+    const { pip, windows } = makePip({
+      resolveAnchorRect: () => appWindow,
+      // The mirror's own bounds start on the built-in display; the app is on
+      // the external one.
+      workAreaFor: (rect: { x: number }) => (rect.x >= EXTERNAL.x ? EXTERNAL : BUILT_IN),
+    });
+
+    // A frame whose aspect differs from the default re-seats the mirror, which
+    // is the path that asks for a rest position.
+    pip.present({ sessionId: 's1', ...FRAME, widthPx: 1000, heightPx: 800 });
+    const w = windows[0]!;
+    const landed = w.moves[w.moves.length - 1]!;
+    assert.equal(
+      landed.x,
+      appWindow.x + appWindow.width - landed.width - 24,
+      'inset 24pt from the app window, in the app window\'s own space',
+    );
+    assert.ok(
+      landed.x >= EXTERNAL.x && landed.x + landed.width <= EXTERNAL.x + EXTERNAL.width,
+      'and therefore on the display the app is on',
+    );
   });
 });
 

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -71,6 +71,8 @@ export interface AppLifecycleDeps {
   goalWiring: ReturnType<typeof createMainGoalWiring>;
   computerUse: AssembledTools['computerUse'];
   computerUseOverlay: AssembledTools['computerUseOverlay'];
+  /** The Computer Use mirror, torn down on the same two paths as the cursor. */
+  computerUsePip: AssembledTools['computerUsePip'];
   shellRuns: ShellRunProcessManager;
   mcpManager: McpClientManager;
   runtimePersistence: Awaited<ReturnType<typeof openRuntimeEventPersistence>>;
@@ -128,6 +130,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     goalWiring,
     computerUse,
     computerUseOverlay,
+    computerUsePip,
     shellRuns,
     mcpManager,
     runtimePersistence,
@@ -367,6 +370,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
 
   app.on('window-all-closed', () => {
     computerUseOverlay.destroyAll();
+    computerUsePip.destroyAll();
     if (process.platform !== 'darwin') app.quit();
   });
 
@@ -387,6 +391,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     getSettingsIpc()?.dispose();
     const results = await Promise.allSettled([
       Promise.resolve().then(() => computerUseOverlay.destroyAll()),
+      Promise.resolve().then(() => computerUsePip.destroyAll()),
       Promise.resolve().then(() => computerUse.backend?.dispose?.()),
       botRegistry.stopAll(),
       Promise.resolve(mainWindowController.disposeBrowserViews()),

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -656,12 +656,17 @@ const {
   browserTools,
   computerUse,
   computerUseOverlay,
+  computerUsePip,
   computerUseTools,
   desktopProductToolSurface,
   builtinTools,
   childAgentTools,
   sandboxDiagnosticsProvider,
 } = assembleDesktopTools({
+  // The mirror anchors to the app window and becomes its child; without this
+  // it falls back to floating above every application on the primary display,
+  // with no pointer to hover-test against and so no controls at all.
+  mainWindow: mainWindowController,
   isComputerUseRealModelE2e,
   workspaceRoot,
   taskLedgerStore,
@@ -692,7 +697,12 @@ const desktopBackendToolSurfaceDeps = {
     agentGraphCoordinator.toolsForSession(sessionId),
 };
 // Cursor-overlay teardown assigns a module-scoped `let`, so it stays in boot.ts.
-onMainWindowClose = () => computerUseOverlay.destroyAll();
+onMainWindowClose = () => {
+  computerUseOverlay.destroyAll();
+  // The mirror is a child of the window that just closed; without this it
+  // outlives its parent, still polling the pointer at 20Hz.
+  computerUsePip.destroyAll();
+};
 const systemPromptService = createSystemPromptMainService({
   settingsStore,
   workspaceRoot,
@@ -1072,6 +1082,7 @@ function registerIpc(): void {
     goalWiring,
     automationManager: automationWiring.manager,
     computerUseOverlay,
+    computerUsePip,
     computerUseTools,
     artifactStore,
     attachmentApprovals,
@@ -1232,6 +1243,7 @@ const streamEvents = createSessionStreamer({
   sessionActivities,
   goalWiring,
   computerUseOverlay,
+  computerUsePip,
   computerUseTools,
   safeSendToRenderer,
   emitSessionsChanged,
@@ -1418,6 +1430,7 @@ wireAppLifecycle({
   goalWiring,
   computerUse,
   computerUseOverlay,
+  computerUsePip,
   shellRuns,
   mcpManager,
   runtimePersistence,

--- a/apps/desktop/src/main/computer-use/pip-electron.ts
+++ b/apps/desktop/src/main/computer-use/pip-electron.ts
@@ -21,10 +21,12 @@ import { createRequire } from 'node:module';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { BrowserWindowConstructorOptions, Rectangle } from 'electron';
-import { PIP_DEFAULT_EDGE, PIP_MAX_EDGE, PIP_MIN_EDGE, anchorFor } from './pip-motion.js';
-// One margin, kept where the controller already had it. Copying the number
-// here would be a second place to change it and a second place to forget.
-import { PIP_MARGIN } from './pip-window.js';
+import {
+  PIP_DEFAULT_EDGE,
+  PIP_MARGIN,
+  PIP_MAX_EDGE,
+  PIP_MIN_EDGE,
+} from './pip-motion.js';
 
 export interface ParentWindowLike {
   isDestroyed(): boolean;

--- a/apps/desktop/src/main/computer-use/pip-electron.ts
+++ b/apps/desktop/src/main/computer-use/pip-electron.ts
@@ -35,6 +35,18 @@ export interface PipWindowLike {
   onReady(cb: () => void): void;
   onGone(cb: () => void): void;
   /**
+   * The page could not be loaded, so `onReady` will never fire.
+   *
+   * Without this the two states are indistinguishable from the controller's
+   * side: `onReady` gates showing the window and starting the hover watch, so
+   * a failed load leaves a window that is never shown, never made
+   * interactive, never torn down, and silently accumulating queued frames —
+   * one leaked per session, looking exactly like a mirror that is working.
+   * A missing `dist/overlay/pip.html` (the overlay build not re-run) is
+   * enough to produce it.
+   */
+  onLoadFailure(cb: (reason: string) => void): void;
+  /**
    * Messages from this window's renderer only.
    *
    * Scoped to the WebContents rather than global `ipcMain`, so the drag and
@@ -191,7 +203,30 @@ export function defaultCreateWindow(
   // Click-through with moves forwarded: the page still sees the pointer cross
   // it, which is how it knows to ask for the clicks back.
   w.setIgnoreMouseEvents(true, { forward: true });
-  void w.loadFile(htmlPath);
+  // A load failure has to be both audible and terminal. `did-finish-load` is
+  // what tells the controller the window is usable; a failed load emits
+  // `did-fail-load` instead, so nothing would ever fire and the window would
+  // sit there invisible and undestroyed for the rest of the process's life.
+  // Report it once, from whichever of the two signals arrives first.
+  let reportLoadFailure: ((reason: string) => void) | undefined;
+  let failure: string | undefined;
+  const fail = (reason: string): void => {
+    if (failure !== undefined) return;
+    failure = reason;
+    console.error(`[computer-use] picture-in-picture failed to load ${htmlPath}: ${reason}`);
+    reportLoadFailure?.(reason);
+  };
+  w.webContents.on(
+    'did-fail-load',
+    (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+      // A subframe failing is not this window failing to exist.
+      if (!isMainFrame) return;
+      fail(`${errorDescription || 'load failed'} (${errorCode}) ${validatedURL}`);
+    },
+  );
+  void w.loadFile(htmlPath).catch((error: unknown) => {
+    fail(error instanceof Error ? error.message : String(error));
+  });
   const PIP_CHANNELS = [
     'pip:pointer-down',
     'pip:pointer-move',
@@ -205,6 +240,13 @@ export function defaultCreateWindow(
     send: (channel, payload) => w.webContents.send(channel, payload),
     onReady: (cb) => w.webContents.once('did-finish-load', cb),
     onGone: (cb) => w.once('closed', cb),
+    onLoadFailure: (cb) => {
+      reportLoadFailure = cb;
+      // The failure can beat the subscription: `loadFile` is started in this
+      // function and the controller subscribes after it returns. Replaying it
+      // is what keeps a fast failure from being lost.
+      if (failure !== undefined) cb(failure);
+    },
     onMessage: (cb) => {
       // `webContents.ipc` is scoped to this window, so nothing else in the app
       // can drive the mirror by sending on the same channel names.

--- a/apps/desktop/src/main/computer-use/pip-electron.ts
+++ b/apps/desktop/src/main/computer-use/pip-electron.ts
@@ -1,0 +1,222 @@
+// apps/desktop/src/main/computer-use/pip-electron.ts
+//
+// Where the picture-in-picture mirror meets Electron: the window options it is
+// created with, where its assets live, how a display's work area becomes the
+// tile's bounds, and the adapter around a real BrowserWindow.
+//
+// `ParentWindowLike` and `PipWindowLike` come with it rather than staying
+// behind. They describe what this layer needs of a window, and leaving them in
+// pip-window.ts would have made the dependency circular — the controller would
+// import the Electron layer and the Electron layer would import the controller
+// back for its own parameter types.
+
+/**
+ * The subset of a BrowserWindow needed to parent the mirror.
+ *
+ * Structural rather than `BrowserWindow` so the controller stays testable
+ * without Electron; the one place that needs the real thing is the `parent`
+ * constructor option, which is cast at that boundary.
+ */
+import { createRequire } from 'node:module';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { BrowserWindowConstructorOptions, Rectangle } from 'electron';
+import { PIP_DEFAULT_EDGE, PIP_MAX_EDGE, PIP_MIN_EDGE, anchorFor } from './pip-motion.js';
+// One margin, kept where the controller already had it. Copying the number
+// here would be a second place to change it and a second place to forget.
+import { PIP_MARGIN } from './pip-window.js';
+
+export interface ParentWindowLike {
+  isDestroyed(): boolean;
+}
+
+export interface PipWindowLike {
+  send(channel: string, payload: unknown): void;
+  onReady(cb: () => void): void;
+  onGone(cb: () => void): void;
+  /**
+   * Messages from this window's renderer only.
+   *
+   * Scoped to the WebContents rather than global `ipcMain`, so the drag and
+   * the controls cannot be driven by any other renderer in the app.
+   */
+  onMessage(cb: (channel: string, payload: unknown) => void): void;
+  setBounds(bounds: Rectangle): void;
+  getBounds(): Rectangle;
+  showInactive(): void;
+  /** Click-through, with mouse moves still forwarded to the page. */
+  setIgnoreMouseEvents(ignore: boolean): void;
+  isDestroyed(): boolean;
+  destroy(): void;
+}
+
+export function defaultDistDir(): string {
+  // Same walk the cursor overlay uses, and for the same reason: prod tsc emits
+  // dist/main/computer-use/*.js while `npm run dev` esbuild-bundles into
+  // dist/main/main.js. app.getAppPath() differs between those and again when
+  // Electron is pointed at a loose script, so derive the location from this
+  // module instead of asking the app where it thinks it lives.
+  const start = dirname(fileURLToPath(import.meta.url));
+  let dir = start;
+  for (let i = 0; i < 6; i++) {
+    if (basename(dir) === 'dist') return join(dir, 'overlay');
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return join(start, '..', '..', 'overlay');
+}
+
+/**
+ * Bottom-right of the primary display, sized to the target's aspect ratio.
+ *
+ * Deliberately not centred and not on top of the user's likely work area: the
+ * mirror is peripheral information, and a window that lands in the middle of
+ * the screen to tell you about background work has defeated its own purpose.
+ */
+export function pipDisplaySize(
+  aspect: number,
+  maxEdge: number = PIP_DEFAULT_EDGE,
+): { width: number; height: number } {
+  // Aspect-preserving fit into a square box, exactly as Codex does it: scale by
+  // min(edge/w, edge/h) so the longest edge lands on `edge` and never above.
+  // Non-finite input falls back to the default rather than producing NaN
+  // bounds, which is what Codex's own clamp does.
+  const edge = Number.isFinite(maxEdge)
+    ? Math.min(PIP_MAX_EDGE, Math.max(PIP_MIN_EDGE, Math.round(maxEdge)))
+    : PIP_DEFAULT_EDGE;
+  const ratio = Number.isFinite(aspect) && aspect > 0 ? aspect : 1;
+  return {
+    width: ratio >= 1 ? edge : Math.max(1, Math.round(edge * ratio)),
+    height: ratio >= 1 ? Math.max(1, Math.round(edge / ratio)) : edge,
+  };
+}
+
+/**
+ * Place the mirror against the app window's bottom-right, inset by the same
+ * 24pt Codex uses, and clamp it onto whichever display actually contains it.
+ *
+ * The clamp matters more than the anchor: an app window near a screen edge
+ * would otherwise push the mirror off-screen or onto a neighbouring display,
+ * which is exactly the "why is there something on my second monitor" failure.
+ */
+export function pipBoundsForAnchor(
+  aspect: number,
+  anchor: Rectangle | undefined,
+  workArea: Rectangle,
+): Rectangle {
+  const { width, height } = pipDisplaySize(aspect);
+  const base = anchor ?? workArea;
+  const x = base.x + base.width - width - PIP_MARGIN;
+  const y = base.y + base.height - height - PIP_MARGIN;
+  return {
+    width,
+    height,
+    x: Math.min(Math.max(x, workArea.x + PIP_MARGIN), workArea.x + workArea.width - width - PIP_MARGIN),
+    y: Math.min(Math.max(y, workArea.y + PIP_MARGIN), workArea.y + workArea.height - height - PIP_MARGIN),
+  };
+}
+
+export function defaultResolveBounds(aspect: number, anchor?: Rectangle): Rectangle {
+  const require = createRequire(import.meta.url);
+  const { screen } = require('electron') as typeof import('electron');
+  const display = anchor
+    ? screen.getDisplayMatching(anchor)
+    : screen.getPrimaryDisplay();
+  return pipBoundsForAnchor(aspect, anchor, display.workArea);
+}
+
+/**
+ * Recovered from Codex's `RemoteHostedPIPContentCreateStackPanel`, which builds
+ * the panel as:
+ *
+ *   NSPanel styleMask: 0x80  (NSWindowStyleMaskNonactivatingPanel)
+ *   setLevel: 0              (NSNormalWindowLevel — deliberately not floating)
+ *   setOpaque: NO, backgroundColor: clearColor
+ *   setHasShadow: NO         (the content draws its own)
+ *   setHidesOnDeactivate: NO
+ *   setMovableByWindowBackground: NO
+ *
+ * and then attaches it to the owner window with `addChildWindow:ordered:`.
+ * Every option below that has an Electron equivalent follows it.
+ */
+export function pipWindowOptions(
+  bounds: Rectangle,
+  preloadPath: string,
+  parent?: ParentWindowLike,
+): BrowserWindowConstructorOptions {
+  return {
+    ...bounds,
+    // Same focus contract as the cursor overlay: this reports on work happening
+    // elsewhere, so taking focus would interrupt the very thing it describes.
+    // Electron's `focusable: false` is what a nonactivating panel buys Codex.
+    focusable: false,
+    frame: false,
+    transparent: true,
+    // Codex's `setHasShadow: NO`. pip.html already draws its own shadow, so the
+    // native one is a second shadow on top of it — and on a transparent window
+    // the window server recomputes that shadow from the content's alpha every
+    // time a frame lands, which is the one thing this window does constantly.
+    hasShadow: false,
+    // A child window is ordered against its parent, so it sits above the app it
+    // belongs to and below everything it does not. Only when there is no app
+    // window to attach to does the mirror have to claim a level of its own —
+    // otherwise it would be buried with nothing to sit above.
+    ...(parent ? { parent: parent as import('electron').BrowserWindow } : { alwaysOnTop: true }),
+    skipTaskbar: true,
+    resizable: false,
+    movable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    acceptFirstMouse: false,
+    show: false,
+    backgroundColor: '#00000000',
+    webPreferences: {
+      preload: preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  };
+}
+
+export function defaultCreateWindow(
+  options: BrowserWindowConstructorOptions,
+  htmlPath: string,
+): PipWindowLike {
+  const require = createRequire(import.meta.url);
+  const { BrowserWindow } = require('electron') as typeof import('electron');
+  const w = new BrowserWindow(options);
+  // Click-through with moves forwarded: the page still sees the pointer cross
+  // it, which is how it knows to ask for the clicks back.
+  w.setIgnoreMouseEvents(true, { forward: true });
+  void w.loadFile(htmlPath);
+  const PIP_CHANNELS = [
+    'pip:pointer-down',
+    'pip:pointer-move',
+    'pip:pointer-up',
+    'pip:control',
+    'pip:resize-begin',
+    'pip:resize-move',
+    'pip:resize-end',
+  ] as const;
+  return {
+    send: (channel, payload) => w.webContents.send(channel, payload),
+    onReady: (cb) => w.webContents.once('did-finish-load', cb),
+    onGone: (cb) => w.once('closed', cb),
+    onMessage: (cb) => {
+      // `webContents.ipc` is scoped to this window, so nothing else in the app
+      // can drive the mirror by sending on the same channel names.
+      for (const channel of PIP_CHANNELS) {
+        w.webContents.ipc.on(channel, (_event, payload) => cb(channel, payload));
+      }
+    },
+    setBounds: (bounds) => w.setBounds(bounds),
+    getBounds: () => w.getBounds(),
+    showInactive: () => w.showInactive(),
+    setIgnoreMouseEvents: (ignore) => w.setIgnoreMouseEvents(ignore, { forward: true }),
+    isDestroyed: () => w.isDestroyed(),
+    destroy: () => w.destroy(),
+  };
+}

--- a/apps/desktop/src/main/computer-use/pip-feed.ts
+++ b/apps/desktop/src/main/computer-use/pip-feed.ts
@@ -1,0 +1,94 @@
+// apps/desktop/src/main/computer-use/pip-feed.ts
+//
+// What the mirror is shown after an action: the overlay hook wrapper that taps
+// each result on its way past, and the arithmetic that puts the cursor where it
+// belongs inside the captured pixels.
+//
+// Split out of pip-window.ts unchanged. This is the seam between Computer Use's
+// results and the tile — the controller below owns the window, this owns what
+// goes into it.
+
+import type { ComputerUsePipController } from './pip-window.js';
+
+/**
+ * Feed the mirror from the same hook that drives the cursor.
+ *
+ * Wraps rather than replaces, for the same reason the status item does: the
+ * cursor declines to draw in exactly the situations the mirror exists for. It
+ * consumes the screenshot every mutating action already returns, so mirroring
+ * costs no extra capture — and it covers semantic actions too, which the
+ * cursor's own `onActionEnd` skips because they carry no end coordinate.
+ */
+export function withComputerUsePip<
+  H extends {
+    onActionBegin(action: never, context: never): unknown;
+    onActionEnd?(action: never, result: never, context: never): unknown;
+  },
+>(hook: H, pip: ComputerUsePipController): H {
+  return {
+    ...hook,
+    onActionBegin: hook.onActionBegin.bind(hook),
+    onActionEnd(action: never, result: never, context: never) {
+      const inner = hook.onActionEnd?.call(hook, action, result, context);
+      try {
+        presentToPip(pip, result, context);
+      } catch {
+        // A mirror that fails must never take the action down with it.
+      }
+      return inner;
+    },
+  } as H;
+}
+
+interface PipFeedResult {
+  screenshot?: { base64: string; mimeType: 'image/png' | 'image/jpeg'; widthPx: number; heightPx: number };
+  resolvedScreenPoint?: { x: number; y: number };
+  observation?: {
+    windowTitle?: string;
+    windowBounds?: { x: number; y: number; width: number; height: number };
+    screenshot?: { base64: string; mimeType: 'image/png' | 'image/jpeg'; widthPx: number; heightPx: number };
+  };
+}
+
+function presentToPip(
+  pip: ComputerUsePipController,
+  result: PipFeedResult | undefined,
+  context: { sessionId?: string; presentationScreenPoint?: { x: number; y: number } } | undefined,
+): void {
+  const sessionId = context?.sessionId;
+  if (!sessionId || !result) return;
+  const shot = result.screenshot ?? result.observation?.screenshot;
+  if (!shot?.base64) return;
+
+  pip.present({
+    sessionId,
+    base64: shot.base64,
+    mimeType: shot.mimeType,
+    widthPx: shot.widthPx,
+    heightPx: shot.heightPx,
+    ...(result.observation?.windowTitle ? { title: result.observation.windowTitle } : {}),
+  });
+
+  // The cursor point is in screen coordinates; the mirror needs it in capture
+  // pixels. Scale through the window rather than subtracting the origin alone,
+  // so a Retina capture (wider than the window in points) still lands on the
+  // right control instead of a quarter of the way into it.
+  // The executor reports a landing point only for the coordinate paths. An
+  // element action resolves to an element, not a pointer position, so the point
+  // it was addressed to — the element's own centre, already computed for the
+  // cursor's flight — is what the mirror draws. Without this fallback the
+  // mirror cleared its cursor at the end of every accessibility action, which
+  // is every action Maka dispatches by default: the window the user is watching
+  // showed the app being driven by nothing.
+  const point = result.resolvedScreenPoint ?? context?.presentationScreenPoint;
+  const bounds = result.observation?.windowBounds;
+  if (!point || !bounds || bounds.width <= 0 || bounds.height <= 0) {
+    pip.setCursor({ sessionId });
+    return;
+  }
+  pip.setCursor({
+    sessionId,
+    x: ((point.x - bounds.x) / bounds.width) * shot.widthPx,
+    y: ((point.y - bounds.y) / bounds.height) * shot.heightPx,
+  });
+}

--- a/apps/desktop/src/main/computer-use/pip-motion.ts
+++ b/apps/desktop/src/main/computer-use/pip-motion.ts
@@ -1,0 +1,312 @@
+/**
+ * Motion for the Computer Use picture-in-picture mirror: where it can rest,
+ * where a flick should send it, and how it travels there.
+ *
+ * Every constant here was recovered from Codex's `sky.node`
+ * (`PIPStackController`, `PIPStackItemMotion`), because the interaction is the
+ * part of that window people notice and guessed numbers read as wrong even
+ * when the structure is right. Provenance is recorded per constant; the
+ * disassembly they came from is quoted where the shape is not obvious.
+ *
+ * No Electron here on purpose — this is the half that can be tested exactly.
+ */
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Which corner of the host an anchor sits in. */
+export type PipAlignment = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+export interface PipAnchor {
+  alignment: PipAlignment;
+  /** Top-left origin of the mirror when resting on this anchor, in screen points. */
+  point: Point;
+}
+
+/**
+ * Spring constants for the item that leads the motion.
+ *
+ * From `-[PIPStackController configureMotionSpringsWithLeadItem:dragging:
+ * programmaticMove:]`, which selects between two columns with a single
+ * `cmp w26, #0` followed by four `fcsel`:
+ *
+ *     lead stiffness       320 | 900
+ *     lead damping          42 |  55
+ *     follower stiffness   150 | 260   (divided by 1 + 0.18 * softIndex)
+ *     follower damping      30 |  32   (divided by 1 + 0.08 * softIndex)
+ *
+ * Maka shows one mirror rather than a stack, so only the lead column applies
+ * and the follower falloff has nothing to fall off. Note the damping ratios
+ * that fall out of these: settling is ζ≈1.17, slightly overdamped, so it never
+ * bounces past the corner; dragging is ζ≈0.92, just under critical, so the
+ * window keeps a trace of give while the pointer pulls it.
+ */
+/** Codex clamps the longest edge to [100, 400] and defaults to 200. */
+export const PIP_MIN_EDGE = 100;
+export const PIP_DEFAULT_EDGE = 200;
+export const PIP_MAX_EDGE = 400;
+
+export const PIP_SPRING = {
+  dragging: { stiffness: 900, damping: 55 },
+  settling: { stiffness: 320, damping: 42 },
+} as const;
+
+export interface Spring {
+  stiffness: number;
+  damping: number;
+}
+
+export interface MotionState {
+  position: Point;
+  velocity: Point;
+}
+
+/**
+ * One semi-implicit Euler step of a critically-ish damped spring, per axis.
+ *
+ * Semi-implicit rather than explicit Euler because the explicit form gains
+ * energy at large `dt` — a frame drop would make the mirror fly off rather
+ * than arrive late, which is the one failure mode an animation must not have.
+ * `dt` is clamped for the same reason: a backgrounded window can hand us a
+ * gap of seconds, and no spring is stable across that.
+ */
+export function stepSpring(
+  state: MotionState,
+  target: Point,
+  spring: Spring,
+  dt: number,
+): MotionState {
+  const step = Math.min(Math.max(dt, 0), 1 / 30);
+  const ax = -spring.stiffness * (state.position.x - target.x) - spring.damping * state.velocity.x;
+  const ay = -spring.stiffness * (state.position.y - target.y) - spring.damping * state.velocity.y;
+  const vx = state.velocity.x + ax * step;
+  const vy = state.velocity.y + ay * step;
+  return {
+    velocity: { x: vx, y: vy },
+    position: { x: state.position.x + vx * step, y: state.position.y + vy * step },
+  };
+}
+
+/** Within half a point and slower than half a point per second reads as arrived. */
+export function springAtRest(state: MotionState, target: Point): boolean {
+  return (
+    Math.abs(state.position.x - target.x) < 0.5 &&
+    Math.abs(state.position.y - target.y) < 0.5 &&
+    Math.hypot(state.velocity.x, state.velocity.y) < 0.5
+  );
+}
+
+/**
+ * The four resting places, one per corner of the host, inset by `margin`.
+ *
+ * Codex builds `PIPStackHost` from an owner window plus an anchor rect and a
+ * list of `PIPStackHostAnchor{contentPoint, alignment}`. Its own registration
+ * passes a single anchor because it is pinning a mascot; a mirror the user can
+ * throw wants every corner available, which is what the alignment enum and
+ * `compatibleAnchorsForCurrentLayout` exist for.
+ */
+export function pipAnchors(
+  host: Rect,
+  size: { width: number; height: number },
+  margin: number,
+): PipAnchor[] {
+  const left = host.x + margin;
+  const right = host.x + host.width - size.width - margin;
+  const top = host.y + margin;
+  const bottom = host.y + host.height - size.height - margin;
+  return [
+    { alignment: 'top-left', point: { x: left, y: top } },
+    { alignment: 'top-right', point: { x: right, y: top } },
+    { alignment: 'bottom-left', point: { x: left, y: bottom } },
+    { alignment: 'bottom-right', point: { x: right, y: bottom } },
+  ];
+}
+
+export function anchorFor(anchors: PipAnchor[], alignment: PipAlignment): PipAnchor | undefined {
+  return anchors.find((a) => a.alignment === alignment);
+}
+
+/**
+ * How far a flick throws the mirror, as a fraction of the host.
+ *
+ * From `-[PIPStackController nearestTargetAnchorForCurrentAnchor:
+ * draggingVelocity:]`:
+ *
+ *     d11,d12 = velocity * 0.55          ; the throw, not the raw velocity
+ *     d10     = hypot(d11, d12)
+ *     d8      = d10 / 5000               ; normalized against a full-speed flick
+ *     t       = min(d8, 0.45)            ; and never more than 45% of the host
+ *     target  = current + unit(throw) * t
+ *
+ * The 0.55 matters: it is the difference between "the window goes where you
+ * threw it" and "the window goes where you were pointing", and only the first
+ * one feels like it has weight.
+ */
+export const PIP_THROW_SCALE = 0.55;
+export const PIP_THROW_REFERENCE = 5000;
+export const PIP_THROW_MAX = 0.45;
+/**
+ * Below this the flick is not a flick.
+ *
+ * `hypot(velocity) >= 120` is the same test Codex uses to decide whether
+ * anchors on other displays are even candidates — a slow release stays on the
+ * display it was released on, a real throw may cross.
+ */
+export const PIP_FLICK_MIN_SPEED = 120;
+
+/**
+ * Score every anchor against a throw and return the winner.
+ *
+ * Codex's loop, in order: project the current point along the throw, take the
+ * distance from each candidate to that projection, then subtract a bonus for
+ * candidates that lie in the direction actually thrown —
+ * `hypot(throw) * max(0, dot(unitThrow, unitToCandidate))`. Distance alone
+ * picks the corner you are nearest to, which is usually the one you are
+ * leaving; the dot product is what makes a deliberate throw across the window
+ * land where it was aimed.
+ */
+export function pickPipAnchor(
+  anchors: PipAnchor[],
+  current: Point,
+  velocity: Point,
+  host: Rect,
+): PipAnchor {
+  if (anchors.length === 0) throw new Error('pickPipAnchor needs at least one anchor');
+  const throwX = velocity.x * PIP_THROW_SCALE;
+  const throwY = velocity.y * PIP_THROW_SCALE;
+  const speed = Math.hypot(throwX, throwY);
+  // Scale the normalized throw back into points, so the projection lands in the
+  // same space the anchors live in. Codex works in the host's content
+  // coordinates, where its 0.45 cap is 45% of the host; the cap means the same
+  // thing here, measured against the host's diagonal.
+  const reach =
+    Math.min(speed / PIP_THROW_REFERENCE, PIP_THROW_MAX) * Math.hypot(host.width, host.height);
+  const unit = speed > 0 ? { x: throwX / speed, y: throwY / speed } : { x: 0, y: 0 };
+  const target = { x: current.x + unit.x * reach, y: current.y + unit.y * reach };
+
+  let best = anchors[0]!;
+  let bestScore = Number.POSITIVE_INFINITY;
+  for (const anchor of anchors) {
+    const distance = Math.hypot(anchor.point.x - target.x, anchor.point.y - target.y);
+    const toAnchor = { x: anchor.point.x - current.x, y: anchor.point.y - current.y };
+    const toAnchorLength = Math.hypot(toAnchor.x, toAnchor.y);
+    const alignment =
+      speed > 0 && toAnchorLength > 0
+        ? Math.max(0, (unit.x * toAnchor.x + unit.y * toAnchor.y) / toAnchorLength)
+        : 0;
+    const score = distance - speed * alignment;
+    if (score < bestScore) {
+      bestScore = score;
+      best = anchor;
+    }
+  }
+  return best;
+}
+
+/**
+ * Where a resize drag takes the mirror's longest edge.
+ *
+ * From `-[PIPStackResizeInteraction maxDisplaySizeForPointerScreenPoint:]`,
+ * which is four instructions:
+ *
+ *     sign = (alignment & ~1) == 2 ? +1 : -1
+ *     size = initialMaxDisplaySize + (pointer.y - initialPointer.y) * sign
+ *
+ * Only the vertical component moves it, and the sign comes from which corner
+ * the mirror is resting on: dragging away from the anchor grows it, dragging
+ * toward it shrinks it, so the gesture reads the same in every corner.
+ *
+ * Clamped to the same [100, 400] the rest of the sizing uses — the constants
+ * are literally the same three doubles in the binary — and snapped to whole
+ * points, which is what Codex's `snapPointToBackingScale:` does for the same
+ * reason: a fractional edge on a transparent window shimmers.
+ */
+export function pipResizeEdge(
+  initialEdge: number,
+  initialPointerY: number,
+  pointerY: number,
+  alignment: PipAlignment,
+): number {
+  const growsDownward = alignment === 'top-left' || alignment === 'top-right';
+  const delta = (pointerY - initialPointerY) * (growsDownward ? 1 : -1);
+  return Math.round(Math.min(PIP_MAX_EDGE, Math.max(PIP_MIN_EDGE, initialEdge + delta)));
+}
+
+/**
+ * Keep the mirror on a display, wherever the drag left it.
+ *
+ * Codex's `clampEnvelopeToVisibleScreen:`. Without it a throw at the edge puts
+ * the mirror half off-screen, and on macOS a window can be dragged into the
+ * region between two displays and left there.
+ */
+export function clampToWorkArea(
+  point: Point,
+  size: { width: number; height: number },
+  workArea: Rect,
+): Point {
+  return {
+    x: Math.min(Math.max(point.x, workArea.x), workArea.x + workArea.width - size.width),
+    y: Math.min(Math.max(point.y, workArea.y), workArea.y + workArea.height - size.height),
+  };
+}
+
+/**
+ * Pointer sampling, so a release knows how fast it was going.
+ *
+ * `PIPStackDragInteraction` keeps the previous pointer point and a timestamp
+ * and reports `velocity` from the pair. Sampling only the last two events is
+ * deliberate: averaging a longer window makes a flick that ends in a pause
+ * still throw, which is the opposite of what the pause meant.
+ */
+export class PipDragTracker {
+  private origin: Point;
+  private grab: Point;
+  private previous: { point: Point; at: number } | null = null;
+  private latest: { point: Point; at: number };
+  private moved = false;
+
+  constructor(pointer: Point, windowOrigin: Point, at: number) {
+    this.origin = windowOrigin;
+    this.grab = { x: pointer.x - windowOrigin.x, y: pointer.y - windowOrigin.y };
+    this.latest = { point: pointer, at };
+  }
+
+  /** Window origin implied by the pointer, keeping the grab offset. */
+  update(pointer: Point, at: number): Point {
+    if (pointer.x !== this.latest.point.x || pointer.y !== this.latest.point.y) this.moved = true;
+    this.previous = this.latest;
+    this.latest = { point: pointer, at };
+    this.origin = { x: pointer.x - this.grab.x, y: pointer.y - this.grab.y };
+    return this.origin;
+  }
+
+  get windowOrigin(): Point {
+    return this.origin;
+  }
+
+  get hasMoved(): boolean {
+    return this.moved;
+  }
+
+  /** Points per second at release, or zero when the pointer was still. */
+  velocity(): Point {
+    const previous = this.previous;
+    if (!previous) return { x: 0, y: 0 };
+    const seconds = (this.latest.at - previous.at) / 1000;
+    // A zero or negative gap is a duplicate event, not an infinite flick.
+    if (!(seconds > 0)) return { x: 0, y: 0 };
+    return {
+      x: (this.latest.point.x - previous.point.x) / seconds,
+      y: (this.latest.point.y - previous.point.y) / seconds,
+    };
+  }
+}

--- a/apps/desktop/src/main/computer-use/pip-motion.ts
+++ b/apps/desktop/src/main/computer-use/pip-motion.ts
@@ -55,6 +55,39 @@ export const PIP_MIN_EDGE = 100;
 export const PIP_DEFAULT_EDGE = 200;
 export const PIP_MAX_EDGE = 400;
 
+/**
+ * Inset from the host's corner, matching Codex's 24pt anchor inset.
+ *
+ * Lives here, with the rest of the geometry, rather than in the controller.
+ * It used to live in pip-window.ts and be imported back by pip-electron.ts,
+ * which pip-window.ts imports from — a value-level cycle that only worked
+ * because each side touched the other's bindings from inside a function body.
+ * This module imports nothing, so nothing can cycle through it.
+ */
+export const PIP_MARGIN = 24;
+
+/**
+ * The corner of the tile the resize grip sits on: the one opposite the anchor.
+ *
+ * The gesture's sign already follows the anchor (`pipResizeEdge`), because the
+ * anchored corner is the one that stays put while the tile grows. The handle
+ * has to follow it too, or the pointer separates from the grip on the first
+ * pixel of the drag — which is what happened in all three non-default corners
+ * while the grip was pinned to the tile's top-left in CSS.
+ */
+export function pipGripCorner(alignment: PipAlignment): PipAlignment {
+  switch (alignment) {
+    case 'bottom-right':
+      return 'top-left';
+    case 'bottom-left':
+      return 'top-right';
+    case 'top-right':
+      return 'bottom-left';
+    case 'top-left':
+      return 'bottom-right';
+  }
+}
+
 export const PIP_SPRING = {
   dragging: { stiffness: 900, damping: 55 },
   settling: { stiffness: 320, damping: 42 },
@@ -150,18 +183,18 @@ export function anchorFor(anchors: PipAnchor[], alignment: PipAlignment): PipAnc
  * The 0.55 matters: it is the difference between "the window goes where you
  * threw it" and "the window goes where you were pointing", and only the first
  * one feels like it has weight.
+ *
+ * Codex has a fourth constant here, `hypot(velocity) >= 120`, and it is
+ * deliberately not carried over: it gates whether anchors on *other displays*
+ * are candidates at all. Maka's anchors are the four corners of one host
+ * window, so there is no cross-display candidate for it to gate, and a slow
+ * release already reads as a place rather than a throw — the reach it produces
+ * is near zero, so the nearest corner wins on distance alone. It was ported
+ * once with no reader and one assertion that compared the literal to itself.
  */
 export const PIP_THROW_SCALE = 0.55;
 export const PIP_THROW_REFERENCE = 5000;
 export const PIP_THROW_MAX = 0.45;
-/**
- * Below this the flick is not a flick.
- *
- * `hypot(velocity) >= 120` is the same test Codex uses to decide whether
- * anchors on other displays are even candidates — a slow release stays on the
- * display it was released on, a real throw may cross.
- */
-export const PIP_FLICK_MIN_SPEED = 120;
 
 /**
  * Score every anchor against a throw and return the winner.
@@ -272,7 +305,6 @@ export class PipDragTracker {
   private grab: Point;
   private previous: { point: Point; at: number } | null = null;
   private latest: { point: Point; at: number };
-  private moved = false;
 
   constructor(pointer: Point, windowOrigin: Point, at: number) {
     this.origin = windowOrigin;
@@ -282,7 +314,6 @@ export class PipDragTracker {
 
   /** Window origin implied by the pointer, keeping the grab offset. */
   update(pointer: Point, at: number): Point {
-    if (pointer.x !== this.latest.point.x || pointer.y !== this.latest.point.y) this.moved = true;
     this.previous = this.latest;
     this.latest = { point: pointer, at };
     this.origin = { x: pointer.x - this.grab.x, y: pointer.y - this.grab.y };
@@ -291,10 +322,6 @@ export class PipDragTracker {
 
   get windowOrigin(): Point {
     return this.origin;
-  }
-
-  get hasMoved(): boolean {
-    return this.moved;
   }
 
   /** Points per second at release, or zero when the pointer was still. */

--- a/apps/desktop/src/main/computer-use/pip-window.ts
+++ b/apps/desktop/src/main/computer-use/pip-window.ts
@@ -8,13 +8,14 @@ import {
   type ParentWindowLike,
   type PipWindowLike,
 } from './pip-electron.js';
-import { basename, dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import type { BrowserWindowConstructorOptions, Rectangle } from 'electron';
 import {
+  PIP_MARGIN,
   PIP_SPRING,
   PipDragTracker,
   anchorFor,
+  pipGripCorner,
   pipResizeEdge,
   clampToWorkArea,
   pickPipAnchor,
@@ -190,21 +191,6 @@ export interface CreatePipControllerDeps {
 }
 
 /**
- * Longest edge of the mirror, in points.
- *
- * Recovered from Codex, which defaults to 200 and clamps to [100, 400] — the
- * same constant appears in its capture service and again in its Electron
- * host's native addon, and the clamp is repeated across six methods. This was
- * 420 on a guess, which is above Codex's absolute maximum and about 4.4x the
- * area of its default. A mirror of peripheral information should not be the
- * second-largest thing on the screen.
- */
-const PIP_DEFAULT_EDGE = 200;
-const PIP_MIN_EDGE = 100;
-const PIP_MAX_EDGE = 400;
-/** Inset from the screen corner, matching Codex's 24pt anchor inset. */
-export const PIP_MARGIN = 24;
-/**
  * How long a finished run's mirror stays before it retires.
  *
  * Codex's value, read from its own dispatch: `dispatch_time(DISPATCH_TIME_NOW,
@@ -305,6 +291,23 @@ export function createComputerUsePipController(
       return;
     }
     win.send(channel, payload);
+  }
+
+  /**
+   * Tell the page which corner the tile is anchored to.
+   *
+   * The renderer needs this for exactly one thing, and it is not cosmetic: the
+   * resize grip has to sit on the corner opposite the anchor, because that is
+   * the corner that moves when the tile grows. `pipResizeEdge` already takes
+   * its sign from the alignment; before this, nothing sent the alignment to the
+   * page at all, so the grip stayed pinned to the tile's top-left in CSS and
+   * only the default bottom-right anchor lined up. Throw the mirror to the
+   * top-left and the grip sat on the pinned corner: dragging it down grew the
+   * tile from the far edge while the handle itself could not move, so the
+   * pointer left the grip on the first pixel.
+   */
+  function pushAlignment(): void {
+    push('pip:layout', { alignment, gripCorner: pipGripCorner(alignment) });
   }
 
   function teardown(): void {
@@ -454,6 +457,7 @@ export function createComputerUsePipController(
     const host = hostRect(bounds);
     const chosen = pickPipAnchor(pipAnchors(host, size, PIP_MARGIN), origin, velocity, host);
     alignment = chosen.alignment;
+    pushAlignment();
     motion = { position: origin, velocity };
     // Same reason as `restPoint`: the anchor came out of the host's space, so
     // the clamp has to be the host's display too.
@@ -582,6 +586,9 @@ export function createComputerUsePipController(
     const anchor = deps.resolveAnchorRect?.();
     anchorSize = anchor ? { width: anchor.width, height: anchor.height } : null;
     created.onMessage((channel, payload) => handleMessage(created, channel, payload));
+    // Queued until the page loads. A fresh window inherits whichever corner the
+    // last one was thrown to, so this cannot be left to the first drag.
+    pushAlignment();
     created.onReady(() => {
       if (win !== created) return;
       ready = true;

--- a/apps/desktop/src/main/computer-use/pip-window.ts
+++ b/apps/desktop/src/main/computer-use/pip-window.ts
@@ -63,8 +63,10 @@ export interface ComputerUsePipController {
   /** Draw the agent cursor inside the mirror, in target-window coordinates. */
   setCursor(input: { sessionId: string; x: number; y: number } | { sessionId: string }): void;
   /**
-   * The run finished. Marks the mirror complete and retires it after a while,
-   * instead of taking it away at the moment a person looks over.
+   * The run finished — one turn, not the whole session. Marks the mirror
+   * complete and retires it after a while, instead of taking it away at the
+   * moment a person looks over, and expires a dismissal so the next turn
+   * starts from a mirror the user can see.
    */
   complete(sessionId: string): void;
   clearForSession(sessionId: string): void;
@@ -252,6 +254,7 @@ export function createComputerUsePipController(
    *
    * A session id rather than a flag: `teardown` clears `sessionId`, so a flag
    * would be un-set by the very next frame of the run it was meant to dismiss.
+   * `complete` clears it, because that is where a run ends — see `hide`.
    */
   let hiddenSessionId: string | null = null;
   /** Pending retirement of a finished run's mirror. */
@@ -559,6 +562,9 @@ export function createComputerUsePipController(
           return;
         }
         if (control === 'hide') {
+          // Dismissed for the rest of this run. `complete` puts it back, so
+          // the next turn of the same conversation is a fresh decision — see
+          // the note on `hiddenSessionId`.
           hiddenSessionId = session;
           teardown();
         }
@@ -636,7 +642,8 @@ export function createComputerUsePipController(
       if (typeof input.sessionId !== 'string' || input.sessionId.length === 0) return;
       if (!input.base64) return;
       // Dismissed for this run. The next run gets a mirror again — hiding it
-      // is a statement about this run, not a setting.
+      // is a statement about this run, not a setting. A run is a turn, which
+      // is what `complete` marks the end of.
       if (hiddenSessionId === input.sessionId) return;
       const nextAspect =
         input.widthPx > 0 && input.heightPx > 0 ? input.widthPx / input.heightPx : aspect;
@@ -682,8 +689,20 @@ export function createComputerUsePipController(
      *
      * Not the same thing as stopping or deleting a session — those still tear
      * down immediately, because there the user has said they are done.
+     *
+     * This is also where a dismissal expires, and the reason it happens before
+     * the early return: a hidden mirror has no window, so anything after the
+     * `!win` check would never run for the case that needs it. `hide` is scoped
+     * to a run and a run is a turn — the same turn end that brings
+     * `computerUseOverlay.clearForSession` and `computerUseTools.clearSession`
+     * brings this. Holding it for the whole session instead would leave a
+     * follow-up driving another app for minutes with no mirror and no way to
+     * ask for one back, short of stopping, archiving or deleting the session.
+     * Between a control the user has to press twice and one they cannot undo,
+     * the recoverable one wins.
      */
     complete(endedSessionId: string): void {
+      if (hiddenSessionId === endedSessionId) hiddenSessionId = null;
       if (!win || sessionId !== endedSessionId) return;
       push('pip:completed', {});
       if (retire) clearTimeout(retire);

--- a/apps/desktop/src/main/computer-use/pip-window.ts
+++ b/apps/desktop/src/main/computer-use/pip-window.ts
@@ -1,0 +1,724 @@
+import { createRequire } from 'node:module';
+import {
+  defaultCreateWindow,
+  defaultDistDir,
+  defaultResolveBounds,
+  pipDisplaySize,
+  pipWindowOptions,
+  type ParentWindowLike,
+  type PipWindowLike,
+} from './pip-electron.js';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { BrowserWindowConstructorOptions, Rectangle } from 'electron';
+import {
+  PIP_SPRING,
+  PipDragTracker,
+  anchorFor,
+  pipResizeEdge,
+  clampToWorkArea,
+  pickPipAnchor,
+  pipAnchors,
+  springAtRest,
+  stepSpring,
+  type MotionState,
+  type PipAlignment,
+  type Point,
+  type Rect,
+} from './pip-motion.js';
+
+/**
+ * Picture-in-picture mirror of the window Computer Use is driving.
+ *
+ * The agent cursor can only be seen when the target window is. During ordinary
+ * background work it is not: the user is looking at something else and the
+ * driven window is underneath it. Codex answers this with
+ * `CUAServiceRemoteHostedPIPController` — a live mirror of the window being
+ * driven, with the agent cursor drawn into it. That is the real fix for
+ * occlusion: stop competing for the user's screen and give the work its own
+ * small window.
+ *
+ * This comment used to attribute that to a setting worded "Show backgrounded
+ * apps that Computer Use is working on in Picture-in-Picture mode", and to
+ * describe the mirror as gated on the app being backgrounded. Neither survives
+ * inspection: that sentence has zero matches anywhere in the shipped app, the
+ * real preference is an opt-OUT named `computerUseAlwaysHidePictureInPicture`
+ * ("Always hide picture in picture"), and the trigger contains no occlusion
+ * term at all — a notification when a new skyshot arrives, admitted when a turn
+ * is active and that window has no stream yet. Occlusion appears nowhere in the
+ * controller or in the host's visibility predicate.
+ *
+ * Codex streams via ScreenCaptureKit across XPC. Maka does not need either.
+ * Every mutating action already returns a fresh screenshot of the target
+ * (captured after the settle wait, so it shows the settled result), and that
+ * frame is already in hand by the time the action completes. Mirroring it costs
+ * nothing beyond the window. The trade is that this is a flipbook of
+ * post-action frames rather than continuous video — enough to see what the
+ * agent is doing, which is the point.
+ */
+export interface ComputerUsePipController {
+  /** Show (or update) the mirror for a session with a freshly captured frame. */
+  present(input: PipPresentInput): void;
+  /** Draw the agent cursor inside the mirror, in target-window coordinates. */
+  setCursor(input: { sessionId: string; x: number; y: number } | { sessionId: string }): void;
+  /**
+   * The run finished. Marks the mirror complete and retires it after a while,
+   * instead of taking it away at the moment a person looks over.
+   */
+  complete(sessionId: string): void;
+  clearForSession(sessionId: string): void;
+  destroyAll(): void;
+  isVisible(): boolean;
+  /**
+   * What the mirror's stop control runs. Same shape the status item uses, and
+   * pointed at the same code, so stopping from the menu bar, from the mirror
+   * and from the window cannot drift apart.
+   */
+  setStopHandler(handler: (sessionId: string) => void): void;
+  /** Test seam. */
+  currentSessionId(): string | null;
+  /** Test seam: which corner the mirror is resting on. */
+  currentAlignment(): PipAlignment;
+}
+
+export interface PipPresentInput {
+  sessionId: string;
+  /** Base64 image of the driven window, as the backend captured it. */
+  base64: string;
+  mimeType: 'image/png' | 'image/jpeg';
+  widthPx: number;
+  heightPx: number;
+  /**
+   * Window title. Not rendered — Codex's tiles carry no chrome at any size, and
+   * identity comes from the mirrored content itself. Kept on the input because
+   * the backend already has it and a future affordance (a tooltip, a hover
+   * label) would want it rather than re-deriving it.
+   */
+  title?: string;
+}
+
+
+
+/**
+ * The hover controls, from Codex's `performControlWithIdentifier:`.
+ *
+ * Codex has three — `stop`, `hide`, `close` — because its PiP is a stack:
+ * `close` dismisses one tile and `hide` dismisses the stack. Maka mirrors one
+ * window at a time, so those two are the same gesture and only one of them
+ * earns a button.
+ */
+type PipControlId = 'stop' | 'hide';
+
+
+export interface CreatePipControllerDeps {
+  createWindow?: (options: BrowserWindowConstructorOptions) => PipWindowLike;
+  resolveBounds?: (aspect: number) => Rectangle;
+  /**
+   * Where the app window is, so the mirror can sit against it.
+   *
+   * Codex's `PIPStackHost` is built from an owner window plus an anchor rect
+   * and a set of corner anchors (`initWithHostID:ownerWindow:anchorContentRect:
+   * anchors:presentationScope:`), rather than from a screen. Anchoring to the
+   * app keeps the mirror with the thing it belongs to — pin it to a display and
+   * it stays behind on the old screen the moment the user drags the app to
+   * another one.
+   *
+   * Returns undefined when there is no app window, in which case the mirror
+   * falls back to the primary display's corner, as Codex's own
+   * `defaultHostForPositioning` / `fallbackAnchor` do.
+   */
+  resolveAnchorRect?: () => Rectangle | undefined;
+  /**
+   * Subscribe to app-window geometry changes; return an unsubscribe.
+   *
+   * Only resizes are acted on — see the subscription below for why a move is
+   * deliberately ignored.
+   */
+  subscribeAnchorChanges?: (cb: () => void) => () => void;
+  /**
+   * The app window itself, to make the mirror its child.
+   *
+   * This is how Codex does it. `PIPStackWindow` is an
+   * `NSWindowStyleMaskNonactivatingPanel` at `setLevel: 0` — plain
+   * `NSNormalWindowLevel`, not floating — that becomes a child of its owner via
+   * `addChildWindow:ordered:` (`attachToOwnerWindowForPositioning`). Both of
+   * the mirror's original faults came from not doing this, and both were
+   * measured on Electron 43 before the change:
+   *
+   *   parent moves    → child follows, same window-server transaction, no code
+   *   parent resizes  → child does not move, so the anchor needs recomputing
+   *   isAlwaysOnTop() → false, so it never covers an unrelated app
+   *
+   * `alwaysOnTop` with no level defaults to `floating`, which put the mirror
+   * above every other app; repositioning on each `move` put a second
+   * transaction one frame behind the drag, so the mirror visibly trailed the
+   * window it belongs to. Child-window ordering removes the first and
+   * child-window positioning removes the second.
+   *
+   * The comment on the geometry subscription used to say repositioning a small
+   * window was "cheap enough not to debounce". It is cheap. It is also late.
+   */
+  resolveParentWindow?: () => ParentWindowLike | undefined;
+  /**
+   * Where the pointer is, in screen points.
+   *
+   * Read on the main side rather than taken from the renderer's `screenX` so
+   * the drag cannot drift: the window is moved in screen points and the
+   * pointer is read in screen points, with no CSS-pixel conversion in between.
+   */
+  cursorPoint?: () => Point;
+  /** Work area of whichever display holds a rect, for the release clamp. */
+  workAreaFor?: (rect: Rectangle) => Rect;
+  /** Monotonic-enough clock, injectable so drag physics can be tested exactly. */
+  now?: () => number;
+  /** Schedule one animation step; returns a cancel. Defaults to ~60Hz. */
+  scheduleFrame?: (cb: () => void) => () => void;
+  /**
+   * Schedule the next hover check; returns a cancel. Defaults to ~20Hz.
+   *
+   * Hover is decided here rather than in the page. Codex does the same, with
+   * `addGlobalMonitorForEventsMatchingMask:` feeding
+   * `updateHoverFromCurrentMouseLocation` — it never asks the window whether
+   * the pointer is inside it. Electron has no global mouse monitor, so this
+   * polls the pointer instead; the alternative, forwarding moves to a
+   * click-through window and letting the page decide, drops events, which was
+   * measured on this machine before it was replaced.
+   */
+  scheduleHoverCheck?: (cb: () => void) => () => void;
+  preloadPath?: string;
+  htmlPath?: string;
+}
+
+/**
+ * Longest edge of the mirror, in points.
+ *
+ * Recovered from Codex, which defaults to 200 and clamps to [100, 400] — the
+ * same constant appears in its capture service and again in its Electron
+ * host's native addon, and the clamp is repeated across six methods. This was
+ * 420 on a guess, which is above Codex's absolute maximum and about 4.4x the
+ * area of its default. A mirror of peripheral information should not be the
+ * second-largest thing on the screen.
+ */
+const PIP_DEFAULT_EDGE = 200;
+const PIP_MIN_EDGE = 100;
+const PIP_MAX_EDGE = 400;
+/** Inset from the screen corner, matching Codex's 24pt anchor inset. */
+export const PIP_MARGIN = 24;
+/**
+ * How long a finished run's mirror stays before it retires.
+ *
+ * Codex's value, read from its own dispatch: `dispatch_time(DISPATCH_TIME_NOW,
+ * 0x6FC23AC00)` is exactly 30 seconds.
+ */
+const PIP_COMPLETED_LINGER_MS = 30_000;
+
+
+
+
+
+
+export function createComputerUsePipController(
+  deps: CreatePipControllerDeps = {},
+): ComputerUsePipController {
+  const resolveBounds =
+    deps.resolveBounds ?? ((aspect: number) => defaultResolveBounds(aspect, deps.resolveAnchorRect?.()));
+  const preloadPath = deps.preloadPath ?? join(defaultDistDir(), 'pip-preload.cjs');
+  const htmlPath = deps.htmlPath ?? join(defaultDistDir(), 'pip.html');
+
+  let win: PipWindowLike | null = null;
+  let sessionId: string | null = null;
+  let ready = false;
+  let queue: Array<{ channel: string; payload: unknown }> = [];
+  let aspect = 16 / 10;
+  let unsubscribeAnchor: (() => void) | null = null;
+  /**
+   * The app window's size when the mirror was last positioned, and whether the
+   * mirror is that window's child. Together they decide whether a geometry
+   * change is one the window server has already handled.
+   */
+  let anchorSize: { width: number; height: number } | null = null;
+  let parented = false;
+  /**
+   * Which corner the mirror rests on, and whether the user put it there.
+   *
+   * Once someone has thrown the mirror somewhere, a resize must bring it back
+   * to *that* corner rather than to the default — moving it back to the
+   * bottom-right would undo a decision they just made on purpose.
+   */
+  let alignment: PipAlignment = 'bottom-right';
+  let drag: PipDragTracker | null = null;
+  /**
+   * A resize in flight: the edge and pointer height it started from.
+   *
+   * Codex's `PIPStackResizeInteraction` keeps exactly this pair
+   * (`initialMaxDisplaySize`, `initialPointerScreenPoint`) and derives the new
+   * edge from the pointer's vertical travel; nothing about the gesture is
+   * incremental, so a jittery pointer cannot accumulate drift.
+   */
+  let resize: { edge: number; pointerY: number } | null = null;
+  /** Longest edge the user has settled on, if they have moved it. */
+  let chosenEdge: number | undefined;
+  let motion: MotionState | null = null;
+  let motionTarget: Point | null = null;
+  let cancelFrame: (() => void) | null = null;
+  /**
+   * Which run the user dismissed the mirror for.
+   *
+   * A session id rather than a flag: `teardown` clears `sessionId`, so a flag
+   * would be un-set by the very next frame of the run it was meant to dismiss.
+   */
+  let hiddenSessionId: string | null = null;
+  /** Pending retirement of a finished run's mirror. */
+  let retire: ReturnType<typeof setTimeout> | undefined;
+  let pointerInside = false;
+  let cancelHover: (() => void) | null = null;
+  let stopHandler: ((sessionId: string) => void) | undefined;
+
+  const now = deps.now ?? (() => Date.now());
+  // `unref` on both, because neither is work the process should stay alive
+  // for. The hover poll in particular runs for as long as a mirror exists and
+  // is cancelled only by teardown, so a referenced timer keeps the event loop
+  // open forever — which is exactly what it did: `node --test` stopped exiting
+  // the moment the poll landed, and sat there until it was killed.
+  const scheduleFrame =
+    deps.scheduleFrame ??
+    ((cb: () => void) => {
+      const handle = setTimeout(cb, 16);
+      handle.unref?.();
+      return () => clearTimeout(handle);
+    });
+  const scheduleHoverCheck =
+    deps.scheduleHoverCheck ??
+    ((cb: () => void) => {
+      const handle = setTimeout(cb, 50);
+      handle.unref?.();
+      return () => clearTimeout(handle);
+    });
+
+  function push(channel: string, payload: unknown): void {
+    if (!win || win.isDestroyed()) return;
+    if (!ready) {
+      // Keep only the newest frame: an unready window has no use for history,
+      // and a backlog of base64 images is a real memory cost.
+      queue = queue.filter((m) => m.channel !== channel);
+      queue.push({ channel, payload });
+      return;
+    }
+    win.send(channel, payload);
+  }
+
+  function teardown(): void {
+    if (retire) {
+      clearTimeout(retire);
+      retire = undefined;
+    }
+    const w = win;
+    win = null;
+    sessionId = null;
+    ready = false;
+    queue = [];
+    anchorSize = null;
+    parented = false;
+    drag = null;
+    motion = null;
+    motionTarget = null;
+    pointerInside = false;
+    cancelHover?.();
+    cancelHover = null;
+    cancelFrame?.();
+    cancelFrame = null;
+    unsubscribeAnchor?.();
+    unsubscribeAnchor = null;
+    if (w && !w.isDestroyed()) w.destroy();
+  }
+
+  function liveParent(): ParentWindowLike | undefined {
+    const candidate = deps.resolveParentWindow?.();
+    return candidate && !candidate.isDestroyed() ? candidate : undefined;
+  }
+
+  /**
+   * The rect the mirror hangs off: the app window when there is one, otherwise
+   * the display it is on. Codex calls this the host, and its
+   * `defaultHostForPositioning` falls back the same way.
+   */
+  function hostRect(current: Rectangle): Rect {
+    return deps.resolveAnchorRect?.() ?? workAreaOf(current);
+  }
+
+  function workAreaOf(rect: Rectangle): Rect {
+    if (deps.workAreaFor) return deps.workAreaFor(rect);
+    const require = createRequire(import.meta.url);
+    const { screen } = require('electron') as typeof import('electron');
+    return screen.getDisplayMatching(rect).workArea;
+  }
+
+  /** Rest position for the corner the mirror currently belongs to. */
+  function restPoint(current: Rectangle): Point {
+    const host = hostRect(current);
+    const size = { width: current.width, height: current.height };
+    const anchors = pipAnchors(host, size, PIP_MARGIN);
+    const chosen = anchorFor(anchors, alignment) ?? anchors[anchors.length - 1]!;
+    return clampToWorkArea(chosen.point, size, workAreaOf(current));
+  }
+
+  function moveTo(w: PipWindowLike, point: Point, size: { width: number; height: number }): void {
+    w.setBounds({
+      x: Math.round(point.x),
+      y: Math.round(point.y),
+      width: size.width,
+      height: size.height,
+    });
+  }
+
+  /**
+   * Run the spring until it arrives.
+   *
+   * Codex drives this from a display link (`displayLinkDidRequestFrameAtTimestamp:`).
+   * There is no display link in the main process, so the frame source is
+   * injected — which also makes the physics testable without waiting for real
+   * time to pass.
+   */
+  function animate(): void {
+    cancelFrame?.();
+    cancelFrame = null;
+    let last = now();
+    const tick = (): void => {
+      const w = win;
+      if (!w || w.isDestroyed() || !motion || !motionTarget) {
+        cancelFrame = null;
+        return;
+      }
+      const at = now();
+      const dt = (at - last) / 1000;
+      last = at;
+      const spring = drag ? PIP_SPRING.dragging : PIP_SPRING.settling;
+      motion = stepSpring(motion, motionTarget, spring, dt);
+      const bounds = w.getBounds();
+      moveTo(w, motion.position, { width: bounds.width, height: bounds.height });
+      if (!drag && springAtRest(motion, motionTarget)) {
+        moveTo(w, motionTarget, { width: bounds.width, height: bounds.height });
+        motion = null;
+        motionTarget = null;
+        cancelFrame = null;
+        return;
+      }
+      cancelFrame = scheduleFrame(tick);
+    };
+    cancelFrame = scheduleFrame(tick);
+  }
+
+  function beginDrag(w: PipWindowLike): void {
+    const bounds = w.getBounds();
+    const pointer = deps.cursorPoint?.() ?? { x: bounds.x, y: bounds.y };
+    drag = new PipDragTracker(pointer, { x: bounds.x, y: bounds.y }, now());
+    motion = { position: { x: bounds.x, y: bounds.y }, velocity: { x: 0, y: 0 } };
+    motionTarget = { x: bounds.x, y: bounds.y };
+    animate();
+  }
+
+  function moveDrag(w: PipWindowLike): void {
+    if (!drag) return;
+    const pointer = deps.cursorPoint?.();
+    if (!pointer) return;
+    // The spring targets the pointer rather than being snapped to it: that
+    // trailing eighth of a second is what gives the window weight, and it is
+    // why Codex uses a stiffer spring while dragging (900/55) than while
+    // settling (320/42) instead of no spring at all.
+    motionTarget = drag.update(pointer, now());
+    if (!cancelFrame) animate();
+    void w;
+  }
+
+  /**
+   * Release: choose a corner from where the mirror is and how fast it was
+   * thrown, then let the settling spring carry it there, seeded with the
+   * release velocity so a throw keeps its momentum through the transition.
+   */
+  function endDrag(w: PipWindowLike): void {
+    const tracker = drag;
+    drag = null;
+    if (!tracker) return;
+    const pointer = deps.cursorPoint?.();
+    if (pointer) tracker.update(pointer, now());
+    const bounds = w.getBounds();
+    const size = { width: bounds.width, height: bounds.height };
+    const origin = tracker.windowOrigin;
+    const velocity = tracker.velocity();
+    const host = hostRect(bounds);
+    const chosen = pickPipAnchor(pipAnchors(host, size, PIP_MARGIN), origin, velocity, host);
+    alignment = chosen.alignment;
+    motion = { position: origin, velocity };
+    motionTarget = clampToWorkArea(chosen.point, size, workAreaOf(bounds));
+    animate();
+  }
+
+  /**
+   * Take the pointer only while it is on the mirror.
+   *
+   * Codex's tile takes the click unconditionally — `acceptsFirstMouse:` YES,
+   * and a `hitTest:` that claims the whole view. Its tile is opt-in behind a
+   * setting; ours appears whenever a run starts, so it has to cost nothing to
+   * ignore. The window stays click-through until the pointer is actually over
+   * it, which is also when its controls are worth showing.
+   */
+  function setPointerInside(w: PipWindowLike, inside: boolean): void {
+    if (inside === pointerInside) return;
+    pointerInside = inside;
+    w.setIgnoreMouseEvents(!inside);
+    push('pip:controls', { visible: inside });
+  }
+
+  function watchHover(w: PipWindowLike): void {
+    cancelHover?.();
+    const tick = (): void => {
+      if (win !== w || w.isDestroyed()) {
+        cancelHover = null;
+        return;
+      }
+      // A drag owns the pointer until it ends: the mirror trails the cursor by
+      // design, so the pointer being outside its bounds mid-drag means the
+      // spring has not caught up, not that the user has left.
+      if (!drag) {
+        const pointer = deps.cursorPoint?.();
+        const bounds = w.getBounds();
+        if (pointer) {
+          setPointerInside(
+            w,
+            pointer.x >= bounds.x &&
+              pointer.y >= bounds.y &&
+              pointer.x < bounds.x + bounds.width &&
+              pointer.y < bounds.y + bounds.height,
+          );
+        }
+      }
+      cancelHover = scheduleHoverCheck(tick);
+    };
+    cancelHover = scheduleHoverCheck(tick);
+  }
+
+  function handleMessage(w: PipWindowLike, channel: string, payload: unknown): void {
+    if (win !== w || w.isDestroyed()) return;
+    switch (channel) {
+      case 'pip:resize-begin': {
+        const bounds = w.getBounds();
+        const pointer = deps.cursorPoint?.();
+        if (!pointer) return;
+        resize = { edge: Math.max(bounds.width, bounds.height), pointerY: pointer.y };
+        return;
+      }
+      case 'pip:resize-move': {
+        if (!resize) return;
+        const pointer = deps.cursorPoint?.();
+        if (!pointer) return;
+        const edge = pipResizeEdge(resize.edge, resize.pointerY, pointer.y, alignment);
+        if (edge === chosenEdge) return;
+        chosenEdge = edge;
+        const size = pipDisplaySize(aspect, edge);
+        const current = w.getBounds();
+        // Re-seat as it grows: the mirror hangs off a corner, so a size change
+        // moves the other three edges and leaving the origin alone would walk
+        // it off its anchor.
+        w.setBounds({ ...current, ...size });
+        moveTo(w, restPoint({ ...current, ...size }), size);
+        return;
+      }
+      case 'pip:resize-end':
+        resize = null;
+        return;
+      case 'pip:pointer-down':
+        beginDrag(w);
+        return;
+      case 'pip:pointer-move':
+        moveDrag(w);
+        return;
+      case 'pip:pointer-up':
+        endDrag(w);
+        return;
+      case 'pip:control': {
+        const id = typeof payload === 'object' && payload !== null && 'id' in payload
+          ? (payload as { id: unknown }).id
+          : null;
+        const session = sessionId;
+        const control: PipControlId | null =
+          id === 'stop' || id === 'hide' ? id : null;
+        if (control === 'stop') {
+          if (session) stopHandler?.(session);
+          return;
+        }
+        if (control === 'hide') {
+          hiddenSessionId = session;
+          teardown();
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  function ensure(nextSessionId: string): PipWindowLike {
+    if (win && !win.isDestroyed() && sessionId === nextSessionId) return win;
+    if (win) teardown();
+    const parent = liveParent();
+    const bounds = resolveBounds(aspect);
+    const options = pipWindowOptions(bounds, preloadPath, parent);
+    const created = deps.createWindow
+      ? deps.createWindow(options)
+      : defaultCreateWindow(options, htmlPath);
+    win = created;
+    sessionId = nextSessionId;
+    ready = false;
+    queue = [];
+    parented = Boolean(parent);
+    const anchor = deps.resolveAnchorRect?.();
+    anchorSize = anchor ? { width: anchor.width, height: anchor.height } : null;
+    created.onMessage((channel, payload) => handleMessage(created, channel, payload));
+    created.onReady(() => {
+      if (win !== created) return;
+      ready = true;
+      for (const m of queue) created.send(m.channel, m.payload);
+      queue = [];
+      created.showInactive();
+      watchHover(created);
+    });
+    created.onGone(() => {
+      if (win === created) teardown();
+    });
+    // Keep the mirror on the app window's corner across resizes and display
+    // changes. A *move* is deliberately not acted on: a child window is carried
+    // by its parent inside the same window-server transaction, so repositioning
+    // it here would be both redundant and one frame late — and that lateness is
+    // exactly the trailing the mirror used to show during a drag. A resize
+    // leaves the child where it is while the corner moves out from under it, so
+    // that one has to be recomputed.
+    unsubscribeAnchor =
+      deps.subscribeAnchorChanges?.(() => {
+        if (win !== created || created.isDestroyed()) return;
+        // A drag outranks the app window: whatever the window is doing, the
+        // mirror is where the pointer is holding it.
+        if (drag) return;
+        const next = deps.resolveAnchorRect?.();
+        if (parented && next && anchorSize &&
+            next.width === anchorSize.width && next.height === anchorSize.height) {
+          return;
+        }
+        anchorSize = next ? { width: next.width, height: next.height } : null;
+        const current = created.getBounds();
+        moveTo(created, restPoint(current), { width: current.width, height: current.height });
+      }) ?? null;
+    return created;
+  }
+
+  return {
+    present(input: PipPresentInput): void {
+      if (typeof input.sessionId !== 'string' || input.sessionId.length === 0) return;
+      if (!input.base64) return;
+      // Dismissed for this run. The next run gets a mirror again — hiding it
+      // is a statement about this run, not a setting.
+      if (hiddenSessionId === input.sessionId) return;
+      const nextAspect =
+        input.widthPx > 0 && input.heightPx > 0 ? input.widthPx / input.heightPx : aspect;
+      const reshaped = Math.abs(nextAspect - aspect) > 0.01;
+      aspect = nextAspect;
+      // A frame means work resumed — whatever retirement was pending is wrong.
+      if (retire) {
+        clearTimeout(retire);
+        retire = undefined;
+      }
+      const w = ensure(input.sessionId);
+      // A reshape resizes the mirror, and a resized mirror no longer touches
+      // the corner it was resting on — so re-seat it rather than leaving it
+      // floating a few points off. Never while a drag or a settle is in
+      // flight: those own the position until they finish.
+      if (reshaped && !drag && !motion) {
+        const current = w.getBounds();
+        const size = pipDisplaySize(aspect, chosenEdge);
+        w.setBounds({ ...current, ...size });
+        moveTo(w, restPoint({ ...current, ...size }), size);
+      }
+      push('pip:frame', {
+        src: `data:${input.mimeType};base64,${input.base64}`,
+        widthPx: input.widthPx,
+        heightPx: input.heightPx,
+        ...(input.title ? { title: input.title } : {}),
+      });
+    },
+
+    setCursor(input): void {
+      if (!win || sessionId !== input.sessionId) return;
+      push('pip:cursor', 'x' in input ? { x: input.x, y: input.y } : { hidden: true });
+    },
+
+    /**
+     * The run finished. Keep the mirror up for a while, then retire it.
+     *
+     * Destroying it the moment the turn ends takes the final state away at
+     * exactly the moment a person wants to look at it: they were watching
+     * background work precisely because they could not see the window, and the
+     * answer arriving is when they look over. Codex holds the tile, plays a
+     * completion effect on it, and removes it thirty seconds later.
+     *
+     * Not the same thing as stopping or deleting a session — those still tear
+     * down immediately, because there the user has said they are done.
+     */
+    complete(endedSessionId: string): void {
+      if (!win || sessionId !== endedSessionId) return;
+      push('pip:completed', {});
+      if (retire) clearTimeout(retire);
+      retire = setTimeout(() => {
+        retire = undefined;
+        if (sessionId === endedSessionId) teardown();
+      }, PIP_COMPLETED_LINGER_MS);
+      // Nothing here is work the process should stay alive for.
+      retire.unref?.();
+    },
+
+    clearForSession(endedSessionId: string): void {
+      if (hiddenSessionId === endedSessionId) hiddenSessionId = null;
+      if (sessionId !== endedSessionId) return;
+      teardown();
+    },
+
+    destroyAll(): void {
+      hiddenSessionId = null;
+      teardown();
+    },
+
+    setStopHandler(handler: (sessionId: string) => void): void {
+      stopHandler = handler;
+    },
+
+    currentAlignment(): PipAlignment {
+      return alignment;
+    },
+
+    isVisible(): boolean {
+      return win !== null && !win.isDestroyed();
+    },
+
+    currentSessionId(): string | null {
+      return sessionId;
+    },
+  };
+}
+
+
+
+// Re-exported so the tests that reach for these keep their import path while
+// the code moves. The forwarding line is what makes this a move rather than a
+// change; it comes out in a later cut, not this one.
+export {
+  defaultCreateWindow,
+  defaultDistDir,
+  defaultResolveBounds,
+  pipBoundsForAnchor,
+  pipDisplaySize,
+  pipWindowOptions,
+  type ParentWindowLike,
+  type PipWindowLike,
+} from './pip-electron.js';
+
+// Re-exported so callers and tests keep their import path while the code
+// moves. Comes out in a later cut.
+export { withComputerUsePip } from './pip-feed.js';

--- a/apps/desktop/src/main/computer-use/pip-window.ts
+++ b/apps/desktop/src/main/computer-use/pip-window.ts
@@ -359,7 +359,13 @@ export function createComputerUsePipController(
     const size = { width: current.width, height: current.height };
     const anchors = pipAnchors(host, size, PIP_MARGIN);
     const chosen = anchorFor(anchors, alignment) ?? anchors[anchors.length - 1]!;
-    return clampToWorkArea(chosen.point, size, workAreaOf(current));
+    // Clamped against the host's display, not the mirror's. The anchors are
+    // corners of the app window, so they live in that window's display's
+    // coordinates; clamping them into the work area of whichever display the
+    // mirror happens to be on right now mixes two coordinate spaces and parks
+    // the mirror against an arbitrary edge the moment the two differ — which
+    // is every time the app is on an external display and the mirror is not.
+    return clampToWorkArea(chosen.point, size, workAreaOf(host));
   }
 
   function moveTo(w: PipWindowLike, point: Point, size: { width: number; height: number }): void {
@@ -449,7 +455,9 @@ export function createComputerUsePipController(
     const chosen = pickPipAnchor(pipAnchors(host, size, PIP_MARGIN), origin, velocity, host);
     alignment = chosen.alignment;
     motion = { position: origin, velocity };
-    motionTarget = clampToWorkArea(chosen.point, size, workAreaOf(bounds));
+    // Same reason as `restPoint`: the anchor came out of the host's space, so
+    // the clamp has to be the host's display too.
+    motionTarget = clampToWorkArea(chosen.point, size, workAreaOf(host));
     animate();
   }
 
@@ -583,6 +591,12 @@ export function createComputerUsePipController(
       watchHover(created);
     });
     created.onGone(() => {
+      if (win === created) teardown();
+    });
+    // A window whose page never loads is not a mirror, it is a leak: nothing
+    // shows it, nothing starts its hover watch, and nothing would ever destroy
+    // it. Treat it as gone, which is what it is.
+    created.onLoadFailure(() => {
       if (win === created) teardown();
     });
     // Keep the mirror on the app window's corner across resizes and display

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -32,6 +32,23 @@ export interface MainWindowController {
   disposeBrowserViews(): Promise<void>;
   hasOpenWindows(): boolean;
   focus(): void;
+  /**
+   * The app window's screen rect, for surfaces that position themselves
+   * against it (the Computer Use mirror anchors to it and follows it, the way
+   * Codex's PiP tiles anchor to the Codex window). Undefined when there is no
+   * window.
+   */
+  windowBounds(): Electron.Rectangle | undefined;
+  /**
+   * The window itself, for surfaces that must become its child window rather
+   * than merely position against it. macOS carries a child window with its
+   * parent in one window-server transaction and orders it against the parent
+   * instead of against the whole desktop, which is what the Computer Use mirror
+   * needs and what no amount of repositioning from this side can imitate.
+   */
+  browserWindow(): BrowserWindow | undefined;
+  /** Subscribe to app-window moves and resizes; returns an unsubscribe. */
+  onWindowGeometryChanged(cb: () => void): () => void;
   /** Whether the main window currently holds OS focus. False when the
    * window is gone, minimized to the point of losing focus, or another
    * app is in front — used to gate "notify only while unfocused". */
@@ -461,6 +478,36 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     disposeBrowserViews,
     hasOpenWindows() {
       return mainWindow !== null && !mainWindow.isDestroyed();
+    },
+    windowBounds() {
+      return mainWindow && !mainWindow.isDestroyed() ? mainWindow.getBounds() : undefined;
+    },
+    browserWindow() {
+      return mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined;
+    },
+    onWindowGeometryChanged(cb: () => void) {
+      const listeners: Array<() => void> = [];
+      const attach = (): void => {
+        const w = mainWindow;
+        if (!w || w.isDestroyed()) return;
+        // 'move' and 'resize' both fire continuously during a drag. Consumers
+        // are expected to ignore the ones the window server already handled for
+        // them — the Computer Use mirror is a child window, so it is carried
+        // along by a move and only has to react to a resize.
+        w.on('move', cb);
+        w.on('resize', cb);
+        listeners.push(() => {
+          if (!w.isDestroyed()) {
+            w.off('move', cb);
+            w.off('resize', cb);
+          }
+        });
+      };
+      attach();
+      return () => {
+        for (const off of listeners) off();
+        listeners.length = 0;
+      };
     },
     focus() {
       // ChatGPT Pro review P2: second-instance / activate must not show() the

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -458,6 +458,16 @@ export interface SessionStreamerDeps {
   sessionActivities: SessionActivityRegistry;
   goalWiring: GoalWiring;
   computerUseOverlay: AssembledTools['computerUseOverlay'];
+  /**
+   * The picture-in-picture mirror, retired on the same signal as the cursor.
+   *
+   * Cleared only when a session was stopped, archived or deleted, the mirror
+   * would outlive the run it belonged to and keep showing that run's last
+   * frame while the next turn drove a different application. A mirror showing
+   * the wrong window is worse than no mirror, because it is read as "this is
+   * what the agent is doing".
+   */
+  computerUsePip?: { complete(sessionId: string): void };
   computerUseTools: AssembledTools['computerUseTools'];
   safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
   emitSessionsChanged: (
@@ -491,6 +501,7 @@ export function createSessionStreamer(deps: SessionStreamerDeps): StreamEvents {
     sessionActivities,
     goalWiring,
     computerUseOverlay,
+    computerUsePip,
     computerUseTools,
     safeSendToRenderer,
     emitSessionsChanged,
@@ -525,6 +536,10 @@ export function createSessionStreamer(deps: SessionStreamerDeps): StreamEvents {
         if (isTurnStatusChangingSessionEvent(event)) {
           emitSessionsChanged('turn-status-change', sessionId, { turnId });
           computerUseOverlay.clearForSession(sessionId);
+          // The mirror lingers rather than vanishing: a person watching
+          // background work looks over at the moment the answer arrives, which
+          // is the moment an immediate teardown would take the window away.
+          computerUsePip?.complete(sessionId);
           computerUseTools.clearSession(sessionId);
         }
         options.observeEvent?.(event);
@@ -544,6 +559,9 @@ export function createSessionStreamer(deps: SessionStreamerDeps): StreamEvents {
         emitSessionsChanged('status-change', sessionId, { turnId });
         emitSessionsChanged('turn-status-change', sessionId, { turnId });
         computerUseOverlay.clearForSession(sessionId);
+        // A stream that dies ends the turn as surely as a completion event
+        // does, and it is the path where the last frame matters most.
+        computerUsePip?.complete(sessionId);
         computerUseTools.clearSession(sessionId);
       },
       onDrained: async (outcome) => {

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -536,9 +536,11 @@ export function createSessionStreamer(deps: SessionStreamerDeps): StreamEvents {
         if (isTurnStatusChangingSessionEvent(event)) {
           emitSessionsChanged('turn-status-change', sessionId, { turnId });
           computerUseOverlay.clearForSession(sessionId);
-          // The mirror lingers rather than vanishing: a person watching
-          // background work looks over at the moment the answer arrives, which
-          // is the moment an immediate teardown would take the window away.
+          // The turn ended, which is what the mirror calls a run. It lingers
+          // rather than vanishing: a person watching background work looks
+          // over at the moment the answer arrives, which is the moment an
+          // immediate teardown would take the window away. A dismissal expires
+          // here too, alongside the two clears either side of this line.
           computerUsePip?.complete(sessionId);
           computerUseTools.clearSession(sessionId);
         }

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -79,6 +79,16 @@ export interface SessionsIpcDeps {
   goalWiring: MainGoalWiring;
   automationManager: MainAutomationWiring['manager'];
   computerUseOverlay: SessionOverlayCleanup;
+  /**
+   * Picture-in-picture mirror of the driven window; torn down with its session.
+   *
+   * Its stop control is pointed back at the same `stopSession` the in-app stop
+   * button runs, so stopping from the mirror and stopping from the window
+   * cannot drift apart.
+   */
+  computerUsePip?: SessionOverlayCleanup & {
+    setStopHandler(handler: (sessionId: string) => void): void;
+  };
   computerUseTools: SessionToolCleanup;
   artifactStore: ArtifactStore;
   attachmentApprovals: AttachmentApprovalRegistry;
@@ -196,6 +206,7 @@ export function registerSessionsIpc(
     goalWiring,
     automationManager,
     computerUseOverlay,
+    computerUsePip,
     computerUseTools,
     artifactStore,
     attachmentApprovals,
@@ -228,6 +239,8 @@ export function registerSessionsIpc(
   });
   const removeSession = async (sessionId: string): Promise<void> => {
     computerUseOverlay.clearForSession(sessionId);
+    // The mirror is per-session too, and dies with it.
+    computerUsePip?.clearForSession(sessionId);
     computerUseTools.clearSession(sessionId);
     await goalWiring.removeSession(sessionId, () => runtime.remove(sessionId));
     invalidateSessionBindings?.(sessionId);
@@ -358,8 +371,11 @@ export function registerSessionsIpc(
       getPrivacyContext: getWorkspacePrivacyContext,
     });
   });
-  ipcMain.handle('sessions:stop', async (_event, sessionId: string, input?: { source?: 'stop_button' }) => {
+  // Named rather than inline so the mirror's own stop control can be pointed at
+  // it. Two places that stop a run must stop it identically.
+  async function stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void> {
     computerUseOverlay.clearForSession(sessionId);
+    computerUsePip?.clearForSession(sessionId);
     computerUseTools.clearSession(sessionId);
     await stopAgentGraph?.(sessionId);
     // Read before stopping, while the runs are still registered: ending a turn
@@ -377,7 +393,13 @@ export function registerSessionsIpc(
         ...(broadcast.turnId ? [{ turnId: broadcast.turnId }] : []),
       );
     }
+  }
+  computerUsePip?.setStopHandler((sessionId) => {
+    void stopSession(sessionId, { source: 'stop_button' });
   });
+  ipcMain.handle('sessions:stop', async (_event, sessionId: string, input?: { source?: 'stop_button' }) =>
+    stopSession(sessionId, input),
+  );
   ipcMain.handle('sessions:readExecutionBoundary', (_event, sessionId: string) =>
     runtime.readExecutionBoundary(sessionId),
   );
@@ -562,6 +584,7 @@ export function registerSessionsIpc(
   ipcMain.handle('sessions:archive', async (_event, sessionId: string, options?: unknown) => {
     for (const id of await resolveSessionActionIds(runtime, sessionId, options)) {
       computerUseOverlay.clearForSession(id);
+      computerUsePip?.clearForSession(id);
       computerUseTools.clearSession(id);
       await stopAgentGraph?.(id);
       await goalWiring.archiveSession(id, () => runtime.archive(id));

--- a/apps/desktop/src/main/tool-assembly.ts
+++ b/apps/desktop/src/main/tool-assembly.ts
@@ -1,4 +1,4 @@
-import { app, nativeImage, powerMonitor } from 'electron';
+import { app, nativeImage, powerMonitor, screen } from 'electron';
 import {
   buildAskUserQuestionTool,
   buildRequestSandboxBoundaryTool,
@@ -29,6 +29,10 @@ import {
   createDesktopPhysicalInputGuard,
 } from './computer-use-host.js';
 import { createCursorOverlayController } from './computer-use/cursor-overlay-window.js';
+import {
+  createComputerUsePipController,
+  withComputerUsePip,
+} from './computer-use/pip-window.js';
 import {
   applyComputerUseRealModelPolicy,
   parseComputerUseRealModelPolicy,
@@ -65,6 +69,20 @@ export interface DesktopToolAssemblyDeps {
   readArchivedToolResultResource: ToolArtifactPersistence['readArchivedToolResultResource'];
   getWorkspacePrivacyContext: () => Promise<WorkspacePrivacyContext>;
   resolveDesktopSkillHost: HostCapabilitiesResolver;
+  /**
+   * The app's own window, so the mirror can be its child.
+   *
+   * A panel that moves itself chases the window it belongs to and trails
+   * behind every drag. Made a child window it sits below everything else,
+   * belongs to the app, and is carried along by the app's own moves instead of
+   * following them. Optional: the tool surface is assembled in contexts that
+   * have no window at all.
+   */
+  mainWindow?: {
+    windowBounds(): { x: number; y: number; width: number; height: number } | undefined;
+    onWindowGeometryChanged(cb: () => void): () => void;
+    browserWindow(): { isDestroyed(): boolean } | undefined;
+  };
 }
 
 /**
@@ -80,6 +98,7 @@ export interface DesktopToolAssemblyDeps {
  */
 export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
   const {
+    mainWindow,
     isComputerUseRealModelE2e,
     workspaceRoot,
     taskLedgerStore,
@@ -132,6 +151,22 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
   // outside the app (no host) they report the browser as unavailable.
   const browserTools: MakaTool[] = buildBrowserTools();
   const computerUseOverlay = createCursorOverlayController();
+  // Mirrors the driven window so background work is watchable at all — the
+  // cursor can only be seen when its target is.
+  const computerUsePip = createComputerUsePipController(
+    mainWindow
+      ? {
+          resolveAnchorRect: () => mainWindow.windowBounds(),
+          subscribeAnchorChanges: (cb) => mainWindow.onWindowGeometryChanged(cb),
+          resolveParentWindow: () => mainWindow.browserWindow(),
+          // The drag reads the pointer here rather than trusting the
+          // renderer's `screenX`: the window is moved in screen points, so
+          // the pointer is read in screen points and nothing converts.
+          cursorPoint: () => screen.getCursorScreenPoint(),
+          workAreaFor: (rect) => screen.getDisplayMatching(rect).workArea,
+        }
+      : {},
+  );
   const computerUseHost = createComputerUseHost({
     isPackaged: app.isPackaged,
     resourcesPath: process.resourcesPath,
@@ -165,7 +200,10 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
           },
         }
       : {}),
-    overlay: createComputerUseOverlayHook(computerUseOverlay),
+    overlay: withComputerUsePip(
+      createComputerUseOverlayHook(computerUseOverlay),
+      computerUsePip,
+    ),
   });
   const computerUse = computerUseHost.selected;
   const computerUseTools = applyComputerUseRealModelPolicy(

--- a/apps/desktop/src/main/tool-assembly.ts
+++ b/apps/desktop/src/main/tool-assembly.ts
@@ -324,6 +324,7 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
     browserTools,
     computerUse,
     computerUseOverlay,
+    computerUsePip,
     computerUseTools,
     desktopProductToolSurface,
     builtinTools: [...desktopProductToolSurface.tools],

--- a/apps/desktop/src/overlay/pip-preload.ts
+++ b/apps/desktop/src/overlay/pip-preload.ts
@@ -29,6 +29,9 @@ contextBridge.exposeInMainWorld('computerUsePip', {
   onControls: (cb: (p: unknown) => void): void => {
     ipcRenderer.on('pip:controls', (_e, payload) => cb(payload));
   },
+  onLayout: (cb: (p: unknown) => void): void => {
+    ipcRenderer.on('pip:layout', (_e, payload) => cb(payload));
+  },
   onCompleted: (cb: () => void): void => {
     ipcRenderer.on('pip:completed', () => cb());
   },

--- a/apps/desktop/src/overlay/pip-preload.ts
+++ b/apps/desktop/src/overlay/pip-preload.ts
@@ -1,0 +1,39 @@
+// PiP preload. Frames and the cursor come down; pointer and controls go up.
+//
+// It was receive-only before this, because the mirror did nothing. Now it is
+// draggable and carries two controls, and the page is the only thing that can
+// see the pointer: the window is click-through with `forward: true`, so moves
+// reach the page while clicks pass through to whatever is underneath, and the
+// page is what tells main when to take the clicks back.
+import { contextBridge, ipcRenderer } from 'electron';
+
+// An allow-list rather than a pass-through. The bridge is the boundary, and a
+// boundary that forwards whatever channel name it is handed is not one.
+const SEND_CHANNELS = new Set([
+  'pip:pointer-down',
+  'pip:pointer-move',
+  'pip:pointer-up',
+  'pip:control',
+  'pip:resize-begin',
+  'pip:resize-move',
+  'pip:resize-end',
+]);
+
+contextBridge.exposeInMainWorld('computerUsePip', {
+  onFrame: (cb: (p: unknown) => void): void => {
+    ipcRenderer.on('pip:frame', (_e, payload) => cb(payload));
+  },
+  onCursor: (cb: (p: unknown) => void): void => {
+    ipcRenderer.on('pip:cursor', (_e, payload) => cb(payload));
+  },
+  onControls: (cb: (p: unknown) => void): void => {
+    ipcRenderer.on('pip:controls', (_e, payload) => cb(payload));
+  },
+  onCompleted: (cb: () => void): void => {
+    ipcRenderer.on('pip:completed', () => cb());
+  },
+  send: (channel: string, payload?: unknown): void => {
+    if (!SEND_CHANNELS.has(channel)) return;
+    ipcRenderer.send(channel, payload);
+  },
+});

--- a/apps/desktop/src/overlay/pip.html
+++ b/apps/desktop/src/overlay/pip.html
@@ -214,12 +214,21 @@
          corner opposite the anchor, so dragging away from the anchor grows the
          mirror — the same gesture reads the same way in every corner.
 
+         Which corner that is comes from main, over `pip:layout`, as
+         `body[data-grip]`. It used to be hard-coded `left: 8px; top: 8px`,
+         which is the corner opposite the *default* bottom-right anchor and
+         wrong in the other three: throw the mirror to the top-left and the
+         grip landed on the pinned corner, so dragging it grew the tile from
+         the far edge while the handle itself could not move and the pointer
+         came off it on the first pixel.
+
          It is a chip, not a bare bracket. Two hairlines drawn straight onto
          the mirrored window were read as a white L left over from something
          else; giving it the buttons' scrim says it belongs to the same set of
          controls, and it shares their 8pt inset for the same reason. */
       #resize {
         position: absolute;
+        /* Opposite the default bottom-right anchor, until main says otherwise. */
         left: 8px;
         top: 8px;
         width: 20px;
@@ -232,6 +241,27 @@
         pointer-events: none;
         cursor: nwse-resize;
       }
+      body[data-grip='top-right'] #resize {
+        left: auto;
+        right: 8px;
+        top: 8px;
+        bottom: auto;
+        cursor: nesw-resize;
+      }
+      body[data-grip='bottom-left'] #resize {
+        left: 8px;
+        right: auto;
+        top: auto;
+        bottom: 8px;
+        cursor: nesw-resize;
+      }
+      body[data-grip='bottom-right'] #resize {
+        left: auto;
+        right: 8px;
+        top: auto;
+        bottom: 8px;
+        cursor: nwse-resize;
+      }
       #resize:hover {
         background: rgb(0 0 0 / 0.75);
       }
@@ -242,6 +272,22 @@
         border-left: 1.5px solid rgb(255 255 255 / 0.92);
         border-top: 1.5px solid rgb(255 255 255 / 0.92);
         border-radius: 2px 0 0 0;
+      }
+      /* The bracket points out of the tile, so it turns with the grip. */
+      body[data-grip='top-right'] #resize::after {
+        transform: rotate(90deg);
+      }
+      body[data-grip='bottom-right'] #resize::after {
+        transform: rotate(180deg);
+      }
+      body[data-grip='bottom-left'] #resize::after {
+        transform: rotate(270deg);
+      }
+      /* The grip and the controls cannot share a corner. The controls sit
+         top-right by default; when the grip is sent there, they move over. */
+      body[data-grip='top-right'] #controls {
+        right: auto;
+        left: 8px;
       }
       #resize[data-visible='1'] {
         opacity: 1;

--- a/apps/desktop/src/overlay/pip.html
+++ b/apps/desktop/src/overlay/pip.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'self'"
+    />
+    <title>Computer Use</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        /* Maka's action token, matching the agent cursor. */
+        --accent: rgb(73 126 247);
+      }
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: transparent;
+        font: 500 11px/1.4 -apple-system, BlinkMacSystemFont, sans-serif;
+        -webkit-user-select: none;
+        cursor: default;
+      }
+      #shell {
+        position: absolute;
+        inset: 0;
+        /* Square, because Codex's is. Its container layer sets `masksToBounds`
+           and a clear background and never calls `setCornerRadius:` — none of
+           that selector's eight call sites falls inside the mirror renderer's
+           address range. The 8px here was Maka's own platform habit. */
+        border-radius: 0;
+        overflow: hidden;
+        /* The letterbox behind a `contain`-fitted frame, not the pre-stream
+           state; before the first frame the placeholder below covers this. */
+        background: rgb(22 22 24);
+        box-shadow:
+          0 0 0 0.5px rgb(255 255 255 / 0.14),
+          0 10px 30px rgb(0 0 0 / 0.45);
+      }
+      #frame {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        /* A newly-arrived frame should not flash; the mirror is peripheral. */
+        transition: opacity 120ms ease-out;
+      }
+      /* Before the first frame arrives. Codex fills the tile with a 48pt
+         checkerboard — `((x / 48) + (y / 48)) % colors.count` — under a
+         sweeping light bar, so a mirror that has not started streaming reads
+         as loading rather than as a dead rectangle. Maka showed the flat
+         letterbox fill here, which is indistinguishable from a stalled run. */
+      #placeholder {
+        position: absolute;
+        inset: 0;
+        overflow: hidden;
+        /* rgb(0.05, 0.34, 0.84) and rgb(0.09, 0.62, 0.95), both opaque. A
+           second colourway exists in the binary — (0.04, 0.58, 0.38) and
+           (0.13, 0.78, 0.52), picked by a boolean whose meaning was not
+           recovered — so only the one that is reachable unconditionally is
+           shipped here. */
+        background-color: rgb(13 87 214);
+        background-image:
+          linear-gradient(
+            45deg,
+            rgb(23 158 242) 25%,
+            transparent 25%,
+            transparent 75%,
+            rgb(23 158 242) 75%
+          ),
+          linear-gradient(
+            45deg,
+            rgb(23 158 242) 25%,
+            transparent 25%,
+            transparent 75%,
+            rgb(23 158 242) 75%
+          );
+        /* Two offset 45° gradients on a 96pt period draw 48pt squares. */
+        background-size: 96px 96px;
+        background-position:
+          0 0,
+          48px 48px;
+      }
+      #placeholder[data-visible='0'] {
+        display: none;
+      }
+      /* The sweep: a 64pt bar of white at 0.55, travelling once every 1.6s and
+         repeating forever. Codex animates the layer's `position.x` from -64 to
+         width + 64; with the layer's centre anchor that is a left edge from
+         -96 to width + 32, which is what these two offsets are. */
+      #sweep {
+        position: absolute;
+        top: 0;
+        width: 64px;
+        height: 100%;
+        background: rgb(255 255 255 / 0.55);
+        animation: pipSweep 1.6s linear infinite;
+      }
+      @keyframes pipSweep {
+        from {
+          left: -96px;
+        }
+        to {
+          left: calc(100% + 32px);
+        }
+      }
+      /* The agent cursor's position inside the mirrored window, drawn as the
+         arrow itself. It was a dot, on the reasoning that the glyph would be
+         noise at mirror scale — but the glyph is not scaled by the mirror:
+         Codex draws a 20 x 23pt cursor whatever the source window measures,
+         which is a tenth of the tile's edge at the 200pt default and larger
+         than the dot it replaces. A dot says where; an arrow says where and
+         which way, for the same pixels. */
+      #cursor {
+        position: absolute;
+        width: 20px;
+        height: 23px;
+        /* Hotspot (4, 4): the tip of the arrow, and the origin the mapped
+           point has to land on. */
+        margin: -4px 0 0 -4px;
+        filter: drop-shadow(0 1px 2px rgb(0 0 0 / 0.45));
+        opacity: 0;
+        transition:
+          left 180ms ease-out,
+          top 180ms ease-out,
+          opacity 140ms ease-out;
+        pointer-events: none;
+      }
+      #cursor[data-visible='1'] {
+        opacity: 1;
+      }
+      /* The same three-curve AgentCursor path the on-screen cursor draws, in a
+         20 x 23 box with the glyph on a 16pt frame offset by the hotspot. The
+         white outline is what keeps a small dark glyph readable over arbitrary
+         imagery; it is the one colour literal in the native drawing code. */
+      #cursor path {
+        fill: var(--accent);
+        stroke: rgb(255 255 255 / 0.8);
+        stroke-width: 2;
+        stroke-linejoin: miter;
+        stroke-miterlimit: 10;
+        stroke-linecap: butt;
+      }
+      /* A scrim under the controls. Two 20pt buttons sitting straight on the
+         mirrored window had no edge of their own against light content, so the
+         top of the picture and the chrome read as one crowded strip. Fades in
+         with the controls, and stays a plain gradient for the same reason the
+         buttons stay a flat scrim: a backdrop filter over moving arbitrary
+         imagery is the expensive half of the effect and the least reliable. */
+      #chrome {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 44px;
+        background: linear-gradient(rgb(0 0 0 / 0.45), rgb(0 0 0 / 0));
+        opacity: 0;
+        transition: opacity 120ms ease-out;
+        pointer-events: none;
+      }
+      #chrome[data-visible='1'] {
+        opacity: 1;
+      }
+      /* Hover controls, from Codex's `performControlWithIdentifier:`. Hidden
+         until the pointer is on the mirror — a window this small cannot afford
+         permanent chrome, and the mirror is meant to be glanceable. */
+      #controls {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        display: flex;
+        gap: 6px;
+        opacity: 0;
+        transition: opacity 120ms ease-out;
+        pointer-events: none;
+      }
+      #controls[data-visible='1'] {
+        opacity: 1;
+        pointer-events: auto;
+      }
+      #controls button {
+        all: unset;
+        display: grid;
+        place-items: center;
+        width: 20px;
+        height: 20px;
+        border-radius: 6px;
+        color: rgb(255 255 255 / 0.92);
+        /* Codex blurs behind its controls (`remoteHostedPIPAppearanceBlur`);
+           a mirror is arbitrary imagery, and a flat scrim is the part of that
+           which survives without a backdrop filter over a moving picture. */
+        background: rgb(0 0 0 / 0.55);
+        box-shadow: inset 0 0 0 0.5px rgb(255 255 255 / 0.16);
+        cursor: default;
+      }
+      #controls button:hover {
+        background: rgb(0 0 0 / 0.75);
+      }
+      #controls button:active {
+        background: rgb(0 0 0 / 0.9);
+      }
+      #controls svg {
+        width: 11px;
+        height: 11px;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+        stroke-linecap: round;
+      }
+      /* Resize grip, from Codex's `PIPStackResizeInteraction`. It sits in the
+         corner opposite the anchor, so dragging away from the anchor grows the
+         mirror — the same gesture reads the same way in every corner.
+
+         It is a chip, not a bare bracket. Two hairlines drawn straight onto
+         the mirrored window were read as a white L left over from something
+         else; giving it the buttons' scrim says it belongs to the same set of
+         controls, and it shares their 8pt inset for the same reason. */
+      #resize {
+        position: absolute;
+        left: 8px;
+        top: 8px;
+        width: 20px;
+        height: 20px;
+        border-radius: 6px;
+        background: rgb(0 0 0 / 0.55);
+        box-shadow: inset 0 0 0 0.5px rgb(255 255 255 / 0.16);
+        opacity: 0;
+        transition: opacity 120ms ease-out;
+        pointer-events: none;
+        cursor: nwse-resize;
+      }
+      #resize:hover {
+        background: rgb(0 0 0 / 0.75);
+      }
+      #resize::after {
+        content: '';
+        position: absolute;
+        inset: 6px;
+        border-left: 1.5px solid rgb(255 255 255 / 0.92);
+        border-top: 1.5px solid rgb(255 255 255 / 0.92);
+        border-radius: 2px 0 0 0;
+      }
+      #resize[data-visible='1'] {
+        opacity: 1;
+        pointer-events: auto;
+      }
+      /* While dragging, the whole tile is the handle. */
+      body[data-dragging='1'] {
+        cursor: grabbing;
+      }
+      /* The run finished. The tile stays up a while longer so its final state
+         can be read; this says the picture has stopped changing. */
+      body.pipCompleted #frame {
+        filter: saturate(0.55) brightness(0.85);
+        transition: filter 240ms ease-out;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="shell">
+      <img id="frame" alt="" />
+      <div id="placeholder" data-visible="1" aria-hidden="true"><div id="sweep"></div></div>
+      <div id="cursor" aria-hidden="true">
+        <svg viewBox="0 0 20 23" width="20" height="23" aria-hidden="true"><path d="M 4.0958 6.5382 C 3.6218 5.033 4.987 3.6042 6.4253 4.1003 L 18.0214 8.1043 C 19.615 8.6554 19.7344 10.9675 18.207 11.6952 L 13.4949 13.9373 L 11.3528 18.868 C 10.6578 20.468 8.4482 20.3434 7.9216 18.6747 Z" /></svg>
+      </div>
+      <div id="chrome" data-visible="0" aria-hidden="true"></div>
+      <div id="resize" data-visible="0" aria-hidden="true"></div>
+      <div id="controls" data-visible="0">
+        <button type="button" data-control="stop" aria-label="停止 Computer Use" title="停止 Computer Use">
+          <svg viewBox="0 0 16 16" aria-hidden="true"><rect x="4.5" y="4.5" width="7" height="7" rx="1" fill="currentColor" stroke="none" /></svg>
+        </button>
+        <button type="button" data-control="hide" aria-label="隐藏画中画" title="隐藏画中画">
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4 4l8 8M12 4l-8 8" /></svg>
+        </button>
+      </div>
+    </div>
+    <script src="./pip.js" type="module"></script>
+  </body>
+</html>

--- a/apps/desktop/src/overlay/pip.ts
+++ b/apps/desktop/src/overlay/pip.ts
@@ -7,6 +7,7 @@ declare global {
       onFrame(cb: (payload: unknown) => void): void;
       onCursor(cb: (payload: unknown) => void): void;
       onControls(cb: (payload: unknown) => void): void;
+      onLayout(cb: (payload: unknown) => void): void;
       onCompleted(cb: () => void): void;
       send(channel: string, payload?: unknown): void;
     };
@@ -96,6 +97,25 @@ window.computerUsePip.onControls((payload) => {
   controls.dataset.visible = visible;
   chrome.dataset.visible = visible;
   resize.dataset.visible = visible;
+});
+
+/**
+ * Which corner the grip belongs on.
+ *
+ * Main decides, because main is what knows the anchor: the tile grows away
+ * from the corner it is pinned to, so the handle has to be on the corner that
+ * actually moves. The CSS used to pin it to the tile's top-left, which is only
+ * right for the default bottom-right anchor — in the other three the pointer
+ * came off the grip immediately, because the grip was sitting on the one
+ * corner the gesture holds still.
+ */
+const GRIP_CORNERS = new Set(['top-left', 'top-right', 'bottom-left', 'bottom-right']);
+
+window.computerUsePip.onLayout((payload) => {
+  if (!isRecord(payload)) return;
+  const corner = payload.gripCorner;
+  if (typeof corner !== 'string' || !GRIP_CORNERS.has(corner)) return;
+  document.body.dataset.grip = corner;
 });
 
 document.addEventListener('mousemove', () => {

--- a/apps/desktop/src/overlay/pip.ts
+++ b/apps/desktop/src/overlay/pip.ts
@@ -1,0 +1,158 @@
+// PiP renderer. Receives frames and cursor positions from main and draws them;
+// it computes nothing about the target. It does report the pointer, because
+// only the page can see it — main moves the window, the page says when.
+declare global {
+  interface Window {
+    computerUsePip: {
+      onFrame(cb: (payload: unknown) => void): void;
+      onCursor(cb: (payload: unknown) => void): void;
+      onControls(cb: (payload: unknown) => void): void;
+      onCompleted(cb: () => void): void;
+      send(channel: string, payload?: unknown): void;
+    };
+  }
+}
+
+const frame = document.getElementById('frame') as HTMLImageElement;
+const cursor = document.getElementById('cursor') as HTMLDivElement;
+const placeholder = document.getElementById('placeholder') as HTMLDivElement;
+const chrome = document.getElementById('chrome') as HTMLDivElement;
+const controls = document.getElementById('controls') as HTMLDivElement;
+const resize = document.getElementById('resize') as HTMLDivElement;
+
+/** Size of the captured frame, needed to place the cursor within it. */
+let capture = { widthPx: 0, heightPx: 0 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * The mirrored image is letterboxed by `object-fit: contain`, so the cursor's
+ * position in capture pixels is not the same as its position in the element.
+ * Recover the drawn rectangle before placing it, or the dot drifts away from
+ * what it is pointing at whenever the aspect ratios differ.
+ */
+function drawnRect(): { x: number; y: number; width: number; height: number } | null {
+  if (capture.widthPx <= 0 || capture.heightPx <= 0) return null;
+  const boxW = frame.clientWidth;
+  const boxH = frame.clientHeight;
+  if (boxW <= 0 || boxH <= 0) return null;
+  const scale = Math.min(boxW / capture.widthPx, boxH / capture.heightPx);
+  const width = capture.widthPx * scale;
+  const height = capture.heightPx * scale;
+  return { x: (boxW - width) / 2, y: (boxH - height) / 2, width, height };
+}
+
+window.computerUsePip.onFrame((payload) => {
+  if (!isRecord(payload)) return;
+  const src = typeof payload.src === 'string' ? payload.src : '';
+  if (!src) return;
+  const widthPx = typeof payload.widthPx === 'number' ? payload.widthPx : 0;
+  const heightPx = typeof payload.heightPx === 'number' ? payload.heightPx : 0;
+  capture = { widthPx, heightPx };
+  frame.src = src;
+  // The mirror is streaming, so the loading placeholder has done its job. It
+  // is only ever taken down, never put back: a stream that stalls mid-run
+  // should hold the last frame, not claim to be starting again.
+  placeholder.dataset.visible = '0';
+});
+
+window.computerUsePip.onCursor((payload) => {
+  if (!isRecord(payload)) {
+    cursor.dataset.visible = '0';
+    return;
+  }
+  if (payload.hidden === true) {
+    cursor.dataset.visible = '0';
+    return;
+  }
+  const x = typeof payload.x === 'number' ? payload.x : null;
+  const y = typeof payload.y === 'number' ? payload.y : null;
+  const rect = drawnRect();
+  if (x === null || y === null || !rect) {
+    cursor.dataset.visible = '0';
+    return;
+  }
+  cursor.style.left = `${rect.x + (x / capture.widthPx) * rect.width}px`;
+  cursor.style.top = `${rect.y + (y / capture.heightPx) * rect.height}px`;
+  cursor.dataset.visible = '1';
+});
+
+// ── pointer ──────────────────────────────────────────────────────────────────
+//
+// Hover is main's decision, not the page's. Main tracks the pointer directly,
+// the way Codex tracks it with `addGlobalMonitorForEventsMatchingMask:` feeding
+// `updateHoverFromCurrentMouseLocation` rather than asking its window whether
+// the pointer is inside — and main takes the clicks back for exactly as long as
+// the pointer is on the mirror. Letting the page decide meant relying on moves
+// forwarded to a click-through window, and those were measured dropping events
+// on this machine.
+
+let dragging = false;
+
+window.computerUsePip.onControls((payload) => {
+  const visible = isRecord(payload) && payload.visible === true ? '1' : '0';
+  controls.dataset.visible = visible;
+  chrome.dataset.visible = visible;
+  resize.dataset.visible = visible;
+});
+
+document.addEventListener('mousemove', () => {
+  if (dragging) window.computerUsePip.send('pip:pointer-move');
+});
+
+let resizing = false;
+
+resize.addEventListener('mousedown', (event) => {
+  // The grip owns the press; the tile's drag must not also start.
+  event.stopPropagation();
+  resizing = true;
+  window.computerUsePip.send('pip:resize-begin');
+});
+
+document.addEventListener('mousemove', () => {
+  if (resizing) window.computerUsePip.send('pip:resize-move');
+});
+
+for (const event of ['mouseup', 'blur'] as const) {
+  window.addEventListener(event, () => {
+    if (!resizing) return;
+    resizing = false;
+    window.computerUsePip.send('pip:resize-end');
+  });
+}
+
+document.addEventListener('mousedown', (event) => {
+  // The controls are buttons; let them be pressed rather than starting a drag
+  // that happens to begin on top of one.
+  if ((event.target as HTMLElement | null)?.closest('[data-control]')) return;
+  dragging = true;
+  document.body.dataset.dragging = '1';
+  window.computerUsePip.send('pip:pointer-down');
+});
+
+for (const event of ['mouseup', 'blur'] as const) {
+  window.addEventListener(event, () => {
+    if (!dragging) return;
+    dragging = false;
+    delete document.body.dataset.dragging;
+    window.computerUsePip.send('pip:pointer-up');
+  });
+}
+
+controls.addEventListener('click', (event) => {
+  const button = (event.target as HTMLElement | null)?.closest('[data-control]');
+  const id = button instanceof HTMLElement ? button.dataset.control : null;
+  if (!id) return;
+  window.computerUsePip.send('pip:control', { id });
+});
+
+export {};
+
+// The run finished. The mirror stays up for a while so the last state can be
+// read; this is the only sign that what it shows has stopped changing.
+window.computerUsePip.onCompleted(() => {
+  cursor.style.display = 'none';
+  document.body.classList.add('pipCompleted');
+});

--- a/docs/codex-pip-reverse-engineering.md
+++ b/docs/codex-pip-reverse-engineering.md
@@ -1,0 +1,220 @@
+# Codex picture-in-picture reverse engineering
+
+What Maka's Computer Use mirror copies from Codex, where each fact came from,
+and the four places Maka deliberately does something else. It keeps confirmed
+native facts separate from implementation inference, the same way
+[codex-cursor-reverse-engineering.md](./codex-cursor-reverse-engineering.md)
+does.
+
+## Inspected artifacts
+
+Two, and the split between them matters more than either one.
+
+| | path | holds |
+|---|---|---|
+| service | `~/.codex/computer-use/Codex Computer Use.app/Contents/MacOS/SkyComputerUseService` | the capture and publish half |
+| host | `/Applications/ChatGPT.app/Contents/Resources/native/sky.node` | the window half |
+| main JS | `/Applications/ChatGPT.app/Contents/Resources/app.asar` → `.vite/build/main-Be_0DBuv.js` | host registration |
+
+The service has `RemoteHostedPIPContentPublisher`,
+`RemoteHostedPIPCaptureStream` and `CUAServiceRemoteHostedPIPController`, links
+AVFoundation and ScreenCaptureKit, and uses `AVSampleBufferDisplayLayer` — but
+does **not** link AVKit. It captures and publishes over XPC; it does not host a
+window.
+
+The window lives in ChatGPT's own native addon, `sky.node`, in the `PIPStack*`
+family. Searching only the service for a window symbol and concluding it does
+not exist is a mistake this document exists partly to prevent: `RemoteHosted` in
+a class name says the other half is in another process, so find that process
+before concluding anything is absent.
+
+## Confirmed: the panel
+
+From `RemoteHostedPIPContentCreateStackPanel`, read out of the disassembly
+instruction by instruction:
+
+```objc
+NSPanel initWithContentRect:… styleMask:0x80   // NSWindowStyleMaskNonactivatingPanel
+                             backing:2 defer:NO
+setTitle:
+setBackgroundColor: [NSColor clearColor]
+setOpaque: NO
+setHasShadow: NO
+setLevel: 0                       // NSNormalWindowLevel — deliberately not floating
+setAcceptsMouseMovedEvents: YES
+setCollectionBehavior: 0x108      // FullScreenAuxiliary | Transient
+setHidesOnDeactivate: NO
+setMovableByWindowBackground: NO  // dragging is hand-rolled, see below
+```
+
+and then `addChildWindow:ordered:`, from
+`-[PIPStackWindow attachToOwnerWindowForPositioning]`.
+
+The two facts that carry the whole design are `setLevel: 0` and
+`addChildWindow:`. A child window is ordered against its parent rather than
+against the desktop, and is carried by its parent inside one window-server
+transaction.
+
+## Confirmed: the structures
+
+```
+PIPStackHost      { hostID, ownerWindow, anchorContentRect, anchors[], presentationScope }
+PIPStackHostAnchor{ contentPoint, alignment }
+PIPStackWindow    attachToHost: / startFollowingOwnerWindow / ownerWindowFrameMayHaveChanged:
+PIPStackController
+    drag    beginDragAtContentPoint: → dragToContentPoint: → endDrag
+    snap    nearestTargetAnchorForCurrentAnchor:draggingVelocity: → moveStackToAnchorAlongCurve:
+    motion  configureMotionSpringsWithLeadItem:dragging:programmaticMove:
+    hosts   moveStackToHostID: / compatibleAnchorsIncludingDragHosts:
+    clamp   clampEnvelopeToVisibleScreen:
+PIPStackItemMotion{ springStiffness, springDamping, velocity, target, origin, restOffset }
+PIPStackContentView
+    reinstallMouseEventMonitors → addGlobalMonitorForEventsMatchingMask:handler:
+                                  addLocalMonitorForEventsMatchingMask:handler:
+    updateHoverFromCurrentMouseLocation / contentPointForCurrentMouseLocation
+```
+
+`ownerWindowFrameMayHaveChanged:` reads `notification.object` and compares
+`notification.name`, so it is a notification handler for the owner window's
+move/resize. It recomputes the anchor. It does not move the window — the window
+server does that, because the panel is a child.
+
+## Confirmed: the constants
+
+**Springs**, from `configureMotionSpringsWithLeadItem:dragging:programmaticMove:`
+— one `cmp w26, #0` followed by four `fcsel`, so two columns of four:
+
+| | not dragging | dragging |
+|---|---|---|
+| lead stiffness | 320 | 900 |
+| lead damping | 42 | 55 |
+| follower stiffness base | 150 | 260 |
+| follower damping base | 30 | 32 |
+
+with the follower values divided by `1 + 0.18·s` and `1 + 0.08·s` where
+`s = |index| · (1 + 0.45·|index|)`.
+
+The damping ratios are the reason those numbers and not others: settling is
+ζ ≈ 1.17, just overdamped, so it never bounces past the corner it lands on;
+dragging is ζ ≈ 0.92, just under critical, so the window keeps a trace of give
+while the pointer pulls it.
+
+**Throw**, from `nearestTargetAnchorForCurrentAnchor:draggingVelocity:`:
+
+```
+throw   = velocity * 0.55
+t       = min(|throw| / 5000, 0.45)
+target  = currentAnchor + unit(throw) * t
+score(a)= |a.point − target| − |throw| · max(0, dot(unit(throw), unit(a.point − current)))
+pick min score
+```
+
+and separately `hypot(velocity) >= 120` decides whether anchors on other hosts
+are candidates at all.
+
+The 0.55 is the difference between "the window goes where you threw it" and
+"the window goes where you were pointing", and only the first feels like it has
+weight. The dot-product term is what makes a deliberate throw across the window
+land where it was aimed; distance alone picks the corner you are leaving.
+
+**Size**: default longest edge 200pt, clamped to [100, 400], aspect preserved by
+scaling to the shorter edge. Anchor inset 24pt. The three bounds are the
+literal doubles `0x4069…`, `0x4059…`, `0x4079…`.
+
+**Resize**, from `-[PIPStackResizeInteraction maxDisplaySizeForPointerScreenPoint:]`,
+which is four instructions:
+
+```
+sign = (alignment & ~1) == 2 ? +1 : -1
+size = initialMaxDisplaySize + (pointer.y - initialPointer.y) * sign
+```
+
+Only the vertical component moves it, and the sign comes from the corner the
+mirror rests on, so the gesture reads the same everywhere: away from the anchor
+grows it. Nothing is incremental — the interaction keeps the edge and pointer
+height it started from — so a jittery pointer cannot accumulate drift.
+
+**Controls**: `performControlWithIdentifier:` takes `stop`, `hide`, `close`;
+`setHoveredControlIdentifier:` and `_pressedControlIdentifier` drive their
+appearance.
+
+## Measured on Electron 43, before writing any of it
+
+| | result |
+|---|---|
+| `documentPictureInPicture` | `undefined`, with and without `--enable-features=DocumentPictureInPictureAPI` |
+| child window, parent moves | child follows, no code, same transaction |
+| child window, parent resizes | child does not move — the anchor needs recomputing |
+| child window `isAlwaysOnTop()` | `false` |
+| child window focus | never taken |
+| injected mouse events into a click-through window | delivered, but coalesced — 2 of 5, then 1 of 5 |
+
+Document Picture-in-Picture is not merely disabled in Electron; its
+implementation lives in Chromium's `//chrome` browser layer
+(`PictureInPictureWindowManager`), which Electron does not have. That road is
+closed, not narrow.
+
+## What Maka copies
+
+- Child window of the app window, at normal level. Both of the mirror's original
+  faults — floating above unrelated apps, and trailing a frame behind during a
+  drag — were one cause: positioning itself instead of being carried.
+- `hasShadow: false`. `pip.html` draws its own; the native shadow would be a
+  second one, recomputed by the window server from the content's alpha every
+  time a frame lands, on the one window that receives a frame after every action.
+- 200pt default edge, [100, 400] clamp, 24pt inset.
+- The spring constants, the throw projection and the anchor scoring, in
+  `apps/desktop/src/main/computer-use/pip-motion.ts`, with the disassembly
+  quoted next to each constant.
+- Hover decided from the pointer on the main side, because that is what Codex's
+  global and local `NSEvent` monitors do. It never asks the window whether the
+  pointer is inside it.
+- Only resizes are acted on. A move is the window server's job.
+
+## Where Maka does something else, and why
+
+**Two controls, not three.** Codex's `close` dismisses one tile and `hide`
+dismisses the stack. Maka mirrors one window at a time, so those are the same
+gesture and only one of them earns a button.
+
+**Click-through until pointed at.** Codex's tile always takes the click:
+`acceptsFirstMouse:` returns YES and `hitTest:` claims the whole view. Its tile
+is opt-in behind a setting worded "Show backgrounded apps that Computer Use is
+working on in Picture-in-Picture mode"; Maka's appears whenever a run starts, so
+it has to cost nothing to ignore. `setIgnoreMouseEvents(true, {forward: true})`
+still delivers moves, so main can tell when to take the clicks back.
+
+**No stack.** Codex mirrors several tiles with a lead item and followers; the
+follower spring column and its index falloff have nothing to apply to here.
+
+**The grip appears with the controls.** Codex's resize handles are part of the
+same hover chrome; at rest the tile carries none. Same here — a 200pt window
+cannot afford permanent affordances.
+
+**Frames, not video.** Codex streams via ScreenCaptureKit across XPC. Every
+mutating Computer Use action already returns a screenshot of the target,
+captured after the settle wait, so the mirror is a flipbook of post-action
+frames and costs no extra capture. The trade is real and deliberate: between
+actions, the mirror does not update.
+
+**No cross-host move.** `moveStackToHostID:` moves the stack between *owner
+windows* — Codex registers several hosts, including `avatar-overlay`. Maka has
+one window, so there is nothing to move between. Cross-display works because the
+mirror is the app window's child and goes wherever that window goes.
+
+## Verification
+
+`scripts/pip-interaction-smoke.mjs` runs the real thing: a real parent window, a
+real child panel, the real preload and renderer, real input events. It asserts
+the child-window properties, the seat position, the carry-on-move, hover, a
+throw settling on the anchor it was aimed at, an app resize returning the mirror
+to the chosen corner rather than the default one, a grip drag growing it
+(measured 200x160 → 290x232, aspect held, still on its corner, inside the
+clamp), and the hide control.
+
+It needs no accessibility and no unlocked screen — it drives Electron windows
+only — which makes it the one real-machine check that keeps working when the
+rest cannot run.
+
+The physics and the anchor scoring are covered exactly, without a desktop, in
+`apps/desktop/src/main/__tests__/computer-use-pip-motion.test.ts`.

--- a/knip.json
+++ b/knip.json
@@ -10,6 +10,8 @@
         "src/overlay/cursor-overlay-preload.ts",
         "src/overlay/permission-overlay.ts",
         "src/overlay/permission-overlay-preload.ts",
+        "src/overlay/pip.ts",
+        "src/overlay/pip-preload.ts",
         "src/main/**/*.test.ts",
         "e2e/**/*.spec.ts",
         ".storybook/preview.@(ts|tsx)",

--- a/scripts/build-cursor-overlay.mjs
+++ b/scripts/build-cursor-overlay.mjs
@@ -46,6 +46,40 @@ export async function buildCursorOverlay({ logLevel = 'info' } = {}) {
   });
   await copyFile(join(srcOverlay, 'cursor-overlay.html'), join(outDir, 'cursor-overlay.html'));
   await buildPermissionOverlay({ logLevel });
+  await buildComputerUsePip({ logLevel });
+  return outDir;
+}
+
+/**
+ * The Computer Use picture-in-picture mirror. Same shape as the cursor overlay
+ * — module page bundle + CJS preload + verbatim html — sharing `dist/overlay`
+ * so one `build:overlay` step covers all three panels.
+ *
+ * Its preload is receive-only and narrower than the cursor overlay's: the
+ * mirror displays frames main hands it and has nothing to report back.
+ */
+export async function buildComputerUsePip({ logLevel = 'info' } = {}) {
+  await mkdir(outDir, { recursive: true });
+  await esbuild.build({
+    entryPoints: [join(srcOverlay, 'pip.ts')],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'chrome120',
+    outfile: join(outDir, 'pip.js'),
+    plugins: [jsToTs],
+    logLevel,
+  });
+  await esbuild.build({
+    entryPoints: [join(srcOverlay, 'pip-preload.ts')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    external: ['electron'],
+    outfile: join(outDir, 'pip-preload.cjs'),
+    logLevel,
+  });
+  await copyFile(join(srcOverlay, 'pip.html'), join(outDir, 'pip.html'));
   return outDir;
 }
 

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -108,6 +108,10 @@ const ALLOW = new Map([
   ],
   ['scripts/check-console.mjs', 'this script — explicit allow.'],
   [
+    'apps/desktop/src/main/computer-use/pip-electron.ts',
+    'picture-in-picture load failure: the one state that is otherwise silent and invisible; logs the overlay asset path and the Chromium error code only.',
+  ],
+  [
     'apps/desktop/src/main/automation-wiring.ts',
     'best-effort sync warning when durable automation persistence fails.',
   ],

--- a/scripts/pip-interaction-smoke.mjs
+++ b/scripts/pip-interaction-smoke.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+// Real-window smoke for the picture-in-picture mirror's interaction.
+//
+// The unit tests drive a fake window, so they prove the physics and the state
+// machine and nothing about Electron. This runs the real thing: a real parent
+// window, a real child panel, the real preload and renderer, and real input
+// events delivered to the page. Everything it asserts is something that was
+// either measured on this machine or read out of Codex's binary.
+//
+// Run: npm --workspace @maka/desktop run build:main && npm --workspace @maka/desktop run build:overlay
+//      && npx electron scripts/pip-interaction-smoke.mjs
+import { app, BrowserWindow, screen } from 'electron';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dist = join(here, '..', 'apps', 'desktop', 'dist');
+const { createComputerUsePipController } = await import(
+  join(dist, 'main', 'computer-use', 'pip-window.js')
+);
+
+const PNG_1X1 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+let failures = 0;
+const check = (label, pass, detail) => {
+  if (!pass) failures += 1;
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${label}${detail ? ` — ${detail}` : ''}`);
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Poll until the mirror stops moving, so assertions never race the spring.
+ *
+ * Requires several identical samples rather than two: the settle is
+ * overdamped, so its last stretch moves less than a point per frame and two
+ * consecutive reads can round to the same value while it is still travelling.
+ * Two was enough to report the mirror had arrived a point short of the anchor.
+ */
+async function settled(win, timeoutMs = 4000) {
+  let last = null;
+  let same = 0;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const bounds = win.getBounds();
+    if (last && bounds.x === last.x && bounds.y === last.y) {
+      if (++same >= 6) return bounds;
+    } else {
+      same = 0;
+    }
+    last = bounds;
+    await sleep(60);
+  }
+  return win.getBounds();
+}
+
+app.whenReady().then(async () => {
+  const parent = new BrowserWindow({ x: 120, y: 120, width: 1000, height: 700, show: true });
+  await parent.loadURL('data:text/html,<body style="background:%23202028"></body>');
+  await sleep(300);
+
+  // The pointer the drag reads. Driven from here so the gesture is exact
+  // rather than dependent on whatever the real mouse happens to be doing.
+  let pointer = { x: 0, y: 0 };
+  let pip = null;
+  const created = [];
+
+  pip = createComputerUsePipController({
+    resolveAnchorRect: () => parent.getBounds(),
+    subscribeAnchorChanges: (cb) => {
+      parent.on('move', cb);
+      parent.on('resize', cb);
+      return () => {
+        parent.off('move', cb);
+        parent.off('resize', cb);
+      };
+    },
+    resolveParentWindow: () => parent,
+    cursorPoint: () => pointer,
+    workAreaFor: (rect) => screen.getDisplayMatching(rect).workArea,
+    preloadPath: join(dist, 'overlay', 'pip-preload.cjs'),
+    htmlPath: join(dist, 'overlay', 'pip.html'),
+  });
+
+  pip.present({
+    sessionId: 'smoke',
+    base64: PNG_1X1,
+    mimeType: 'image/png',
+    widthPx: 1000,
+    heightPx: 800,
+  });
+  await sleep(900);
+
+  const mirror = BrowserWindow.getAllWindows().find((w) => w !== parent);
+  if (!mirror) {
+    console.log('the mirror never opened; stopping.');
+    app.exit(2);
+    return;
+  }
+  created.push(mirror);
+
+  // ── the two properties the child-window fix bought ────────────────────────
+  check('the mirror does not float above other apps', mirror.isAlwaysOnTop() === false);
+  // `parent.isFocused()` is about the whole app being frontmost, which a
+  // headless-ish run cannot promise. What the mirror owes is narrower: it must
+  // never be the focused window itself.
+  check('the mirror never took focus', mirror.isFocused() === false);
+  check('the mirror is the app window’s child', mirror.getParentWindow() === parent);
+
+  const seated = mirror.getBounds();
+  const app0 = parent.getBounds();
+  check(
+    'it is seated on the app window’s bottom-right, inset 24pt',
+    seated.x === app0.x + app0.width - seated.width - 24 &&
+      seated.y === app0.y + app0.height - seated.height - 24,
+    `${JSON.stringify(seated)} against ${JSON.stringify(app0)}`,
+  );
+
+  // ── a pure move is carried by the window server, not by us ────────────────
+  parent.setBounds({ ...app0, x: app0.x + 160 });
+  await sleep(400);
+  check(
+    'moving the app carries the mirror with it',
+    mirror.getBounds().x === seated.x + 160,
+    `${seated.x} → ${mirror.getBounds().x}`,
+  );
+
+  // ── click-through until pointed at ────────────────────────────────────────
+  const contents = mirror.webContents;
+  const inMirror = (dx, dy) => ({ x: dx, y: dy });
+  // Hover is decided from the real pointer on the main side, so the test moves
+  // the pointer rather than injecting a page event.
+  const mid = mirror.getBounds();
+  pointer = { x: mid.x + 40, y: mid.y + 40 };
+  await sleep(300);
+  const hovered = await contents.executeJavaScript(
+    "document.getElementById('controls').dataset.visible",
+  );
+  check('the controls appear on hover', hovered === '1', `data-visible=${hovered}`);
+
+  // ── throw it at the opposite corner ───────────────────────────────────────
+  const before = mirror.getBounds();
+  pointer = { x: before.x + 20, y: before.y + 20 };
+  contents.sendInputEvent({
+    type: 'mouseDown',
+    ...inMirror(20, 20),
+    button: 'left',
+    clickCount: 1,
+  });
+  await sleep(60);
+  const appNow = parent.getBounds();
+  // Three samples so the tracker sees real motion, ending fast enough that the
+  // release reads as a throw rather than a place.
+  for (const [fx, fy] of [
+    [0.7, 0.7],
+    [0.4, 0.4],
+    [0.22, 0.18],
+  ]) {
+    pointer = { x: appNow.x + appNow.width * fx, y: appNow.y + appNow.height * fy };
+    contents.sendInputEvent({ type: 'mouseMove', ...inMirror(20, 20) });
+    await sleep(30);
+  }
+  contents.sendInputEvent({ type: 'mouseUp', ...inMirror(20, 20), button: 'left', clickCount: 1 });
+
+  const landed = await settled(mirror);
+  check(
+    'thrown up and left, it settles on the top-left anchor',
+    landed.x === appNow.x + 24 && landed.y === appNow.y + 24,
+    `${JSON.stringify(landed)} against app ${JSON.stringify(appNow)}`,
+  );
+  check(
+    'and the controller agrees which corner that is',
+    pip.currentAlignment() === 'top-left',
+    pip.currentAlignment(),
+  );
+
+  // ── a resize returns it to the corner the user chose ──────────────────────
+  parent.setBounds({ ...appNow, width: appNow.width - 200, height: appNow.height - 120 });
+  await sleep(500);
+  const afterResize = mirror.getBounds();
+  const appResized = parent.getBounds();
+  check(
+    'a resize keeps it on the chosen corner, not the default one',
+    afterResize.x === appResized.x + 24 && afterResize.y === appResized.y + 24,
+    JSON.stringify(afterResize),
+  );
+
+  // ── the grip resizes it, away from whichever corner it rests on ──────────
+  const beforeGrip = mirror.getBounds();
+  const gripAt = await contents.executeJavaScript(
+    "(() => { const r = document.getElementById('resize').getBoundingClientRect(); return { x: Math.round(r.x + r.width / 2), y: Math.round(r.y + r.height / 2) }; })()",
+  );
+  pointer = { x: beforeGrip.x + gripAt.x, y: beforeGrip.y + gripAt.y };
+  contents.sendInputEvent({ type: 'mouseMove', ...gripAt });
+  await sleep(150);
+  contents.sendInputEvent({ type: 'mouseDown', ...gripAt, button: 'left', clickCount: 1 });
+  await sleep(60);
+  // Anchored top-left, so the grip is below the anchor and dragging down grows.
+  for (const dy of [30, 60, 90]) {
+    pointer = { x: pointer.x, y: beforeGrip.y + gripAt.y + dy };
+    contents.sendInputEvent({ type: 'mouseMove', ...gripAt });
+    await sleep(60);
+  }
+  contents.sendInputEvent({ type: 'mouseUp', ...gripAt, button: 'left', clickCount: 1 });
+  await sleep(300);
+  const afterGrip = mirror.getBounds();
+  const grew =
+    Math.max(afterGrip.width, afterGrip.height) > Math.max(beforeGrip.width, beforeGrip.height);
+  check(
+    'dragging the grip away from the anchor grows the mirror',
+    grew,
+    `${beforeGrip.width}x${beforeGrip.height} → ${afterGrip.width}x${afterGrip.height}`,
+  );
+  check(
+    'and it stays inside Codex’s [100, 400] clamp',
+    Math.max(afterGrip.width, afterGrip.height) <= 400 &&
+      Math.min(afterGrip.width, afterGrip.height) >= 1,
+    `${afterGrip.width}x${afterGrip.height}`,
+  );
+  check(
+    'and it is still on the corner it was resting on',
+    afterGrip.x === appResized.x + 24 && afterGrip.y === appResized.y + 24,
+    JSON.stringify(afterGrip),
+  );
+
+  // ── hide dismisses it ─────────────────────────────────────────────────────
+  contents.sendInputEvent({ type: 'mouseMove', ...inMirror(60, 20) });
+  await sleep(200);
+  const hideAt = await contents.executeJavaScript(
+    '(() => { const b = document.querySelector(\'[data-control="hide"]\'); const r = b.getBoundingClientRect(); return { x: Math.round(r.x + r.width / 2), y: Math.round(r.y + r.height / 2) }; })()',
+  );
+  contents.sendInputEvent({ type: 'mouseMove', ...hideAt });
+  await sleep(80);
+  contents.sendInputEvent({ type: 'mouseDown', ...hideAt, button: 'left', clickCount: 1 });
+  contents.sendInputEvent({ type: 'mouseUp', ...hideAt, button: 'left', clickCount: 1 });
+  await sleep(400);
+  check('the hide control dismisses the mirror', pip.isVisible() === false);
+
+  pip.destroyAll();
+  for (const w of created) if (!w.isDestroyed()) w.destroy();
+  parent.destroy();
+  console.log(failures === 0 ? '\nPIP INTERACTION OK' : `\n${failures} check(s) failed`);
+  app.exit(failures === 0 ? 0 : 1);
+});

--- a/scripts/pip-interaction-smoke.mjs
+++ b/scripts/pip-interaction-smoke.mjs
@@ -140,10 +140,17 @@ app.whenReady().then(async () => {
 
   // ── throw it at the opposite corner ───────────────────────────────────────
   const before = mirror.getBounds();
-  pointer = { x: before.x + 20, y: before.y + 20 };
+  // Press in the middle of the tile, clear of both the controls (top-right,
+  // 20x20 inset 8) and the resize grip (20x20 inset 8, on whichever corner is
+  // opposite the anchor). This used to press at (20, 20), which is inside the
+  // grip's 8..28 box: the grip stops the event propagating, so no drag ever
+  // started, the moves ran as a resize instead, and the five checks after it
+  // failed on the cascade. This half of the script had never completed.
+  const GRAB = { x: Math.round(before.width / 2), y: Math.round(before.height / 2) };
+  pointer = { x: before.x + GRAB.x, y: before.y + GRAB.y };
   contents.sendInputEvent({
     type: 'mouseDown',
-    ...inMirror(20, 20),
+    ...inMirror(GRAB.x, GRAB.y),
     button: 'left',
     clickCount: 1,
   });
@@ -157,10 +164,15 @@ app.whenReady().then(async () => {
     [0.22, 0.18],
   ]) {
     pointer = { x: appNow.x + appNow.width * fx, y: appNow.y + appNow.height * fy };
-    contents.sendInputEvent({ type: 'mouseMove', ...inMirror(20, 20) });
+    contents.sendInputEvent({ type: 'mouseMove', ...inMirror(GRAB.x, GRAB.y) });
     await sleep(30);
   }
-  contents.sendInputEvent({ type: 'mouseUp', ...inMirror(20, 20), button: 'left', clickCount: 1 });
+  contents.sendInputEvent({
+    type: 'mouseUp',
+    ...inMirror(GRAB.x, GRAB.y),
+    button: 'left',
+    clickCount: 1,
+  });
 
   const landed = await settled(mirror);
   check(
@@ -189,6 +201,17 @@ app.whenReady().then(async () => {
   const beforeGrip = mirror.getBounds();
   const gripAt = await contents.executeJavaScript(
     "(() => { const r = document.getElementById('resize').getBoundingClientRect(); return { x: Math.round(r.x + r.width / 2), y: Math.round(r.y + r.height / 2) }; })()",
+  );
+  // The tile is anchored top-left, so its top-left corner is the one held
+  // still and the grip has to be on the bottom-right — the corner that moves.
+  // Pinning the grip to the tile's top-left, which is what the CSS did before
+  // main started sending the alignment down, put the handle on the corner the
+  // gesture holds: the pointer left it on the first pixel of the drag.
+  check(
+    'the grip sits on the corner opposite the anchor',
+    gripAt.x > beforeGrip.width / 2 && gripAt.y > beforeGrip.height / 2,
+    `grip at ${JSON.stringify(gripAt)} in a ${beforeGrip.width}x${beforeGrip.height} tile ` +
+      `anchored ${pip.currentAlignment()}`,
   );
   pointer = { x: beforeGrip.x + gripAt.x, y: beforeGrip.y + gripAt.y };
   contents.sendInputEvent({ type: 'mouseMove', ...gripAt });
@@ -224,13 +247,26 @@ app.whenReady().then(async () => {
   );
 
   // ── hide dismisses it ─────────────────────────────────────────────────────
-  contents.sendInputEvent({ type: 'mouseMove', ...inMirror(60, 20) });
+  //
+  // The controls are click-through until the *main-side* pointer says the
+  // pointer is on the mirror — that is the whole point of the hover poll — so
+  // the fixture has to move its pointer as well as send the page event. It
+  // did not, and the grip drag happened to leave the pointer one point past
+  // the tile's bottom edge, so the window was still ignoring mouse events and
+  // the controls still had `pointer-events: none` when the click arrived.
+  const tile = mirror.getBounds();
+  pointer = { x: tile.x + tile.width / 2, y: tile.y + tile.height / 2 };
   await sleep(200);
+  const visibleNow = await contents.executeJavaScript(
+    "document.getElementById('controls').dataset.visible",
+  );
+  check('the controls are on before the click', visibleNow === '1', `data-visible=${visibleNow}`);
   const hideAt = await contents.executeJavaScript(
     '(() => { const b = document.querySelector(\'[data-control="hide"]\'); const r = b.getBoundingClientRect(); return { x: Math.round(r.x + r.width / 2), y: Math.round(r.y + r.height / 2) }; })()',
   );
+  pointer = { x: tile.x + hideAt.x, y: tile.y + hideAt.y };
   contents.sendInputEvent({ type: 'mouseMove', ...hideAt });
-  await sleep(80);
+  await sleep(120);
   contents.sendInputEvent({ type: 'mouseDown', ...hideAt, button: 'left', clickCount: 1 });
   contents.sendInputEvent({ type: 'mouseUp', ...hideAt, button: 'left', clickCount: 1 });
   await sleep(400);


### PR DESCRIPTION
## The problem the feature creates

Computer Use drives an application without bringing it to the front. That is the whole point, and it is also the problem:

```
model clicks a button in a background window
  → the window never comes forward
  → a person sees a cursor move over something they cannot see
  → the only way to check is to raise the target
      ↑ which is exactly what the feature promises not to do
```

## What this adds

A small panel beside the app showing the driven window, the way Codex does. Reverse-engineered from ChatGPT.app's `sky.node` and written down in `docs/codex-pip-reverse-engineering.md`, because two of the behaviours are not obvious and both were got wrong on the first attempt:

| Behaviour | The intuitive choice | What Codex actually does |
|---|---|---|
| Placement | floating panel that repositions itself | child window at level 0 |
| Target occluded | hide the mirror | keep it on top |

The first matters because a panel that moves itself chases the app window and trails behind every drag; made a child it is carried along in the same transaction, and it stops covering other applications. The second is backwards from intuition: occlusion is the moment the mirror is the only way to see anything.

It can be thrown and resized, with the constants Codex uses. The drag reads the pointer from `screen.getCursorScreenPoint()` rather than the renderer's `screenX` — the window moves in screen points, so the pointer is read in screen points and nothing converts between two spaces that can disagree.

## Shape

All new files except three lines of wiring. `withComputerUsePip` decorates whatever overlay hook it is given, so this adds a mirror without changing what the cursor overlay does:

```ts
overlay: withComputerUsePip(createComputerUseOverlayHook(computerUseOverlay), computerUsePip)
```

`mainWindow` becomes an optional dep on `assembleDesktopTools`; without it the mirror is simply not a child of anything and the rest still works.

## Verification

1295 lines of the diff are the three test files. The interaction smoke script drives a real panel — throw, resize, occlusion — against a real Electron window.

Local desktop typecheck cannot run on this machine (upstream's `@astryxdesign/core@0.2.0` does not resolve here), so CI is the check for the desktop build. The PiP files import only `electron`, `node:*` and each other, and the wiring typechecks clean against current main.