### PR TITLE
fix: tell a refused tool call what to do next, not just what went wrong

### DIFF
--- a/packages/cli/src/cli-goal-continuation.ts
+++ b/packages/cli/src/cli-goal-continuation.ts
@@ -4,6 +4,7 @@ import {
   SessionActivityRegistry,
   drainGoalTurn,
   type GoalContinuationDeps,
+  type GoalControlStanding,
   type GoalState,
   type GoalObservedTurnStart,
   type GoalObservedTurnSettler,
@@ -61,6 +62,14 @@ export class CliGoalContinuation {
 
   mutateGoal(sessionId: string, turnId: string, mutate: () => GoalState): GoalState | undefined {
     return this.coordinator.mutateGoal(sessionId, turnId, mutate);
+  }
+
+  activationStanding(sessionId: string, turnId: string): GoalControlStanding {
+    return this.coordinator.activationStanding(sessionId, turnId);
+  }
+
+  mutationStanding(sessionId: string, turnId: string): GoalControlStanding {
+    return this.coordinator.mutationStanding(sessionId, turnId);
   }
 
   async runAutomationTurn(input: {

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -680,7 +680,9 @@ describe('AgentSwarm adapter', () => {
 
     await assert.rejects(
       Promise.resolve(tool.impl({ items: [swarmItem(0)] }, context())),
-      /spawnChildSession capability is unavailable/,
+      // The sentence names the tool and what to do instead, rather than a host
+      // capability the model has no way to provide.
+      /agent_swarm cannot start new child agents in this session/,
     );
   });
 

--- a/packages/runtime/src/__tests__/goal-continuation.test.ts
+++ b/packages/runtime/src/__tests__/goal-continuation.test.ts
@@ -280,7 +280,7 @@ describe('GoalContinuationCoordinator settlement', () => {
       await set.impl({ condition: 'replacement' }, goalToolContext('turn-old')),
     );
 
-    assert.match(output, /no longer owns Goal activation/);
+    assert.match(output, /Call GoalStatus/);
     assert.equal(manager.get(SESSION)?.status, 'cleared');
     assert.equal(manager.get(SESSION)?.condition, 'first');
   });
@@ -302,7 +302,7 @@ describe('GoalContinuationCoordinator settlement', () => {
       await set.impl({ condition: 'replacement' }, goalToolContext('turn-old')),
     );
 
-    assert.match(output, /no longer owns Goal activation/);
+    assert.match(output, /Call GoalStatus/);
     assert.equal(manager.get(SESSION)?.condition, 'paused goal');
     assert.equal(manager.get(SESSION)?.status, 'cleared');
   });
@@ -324,14 +324,8 @@ describe('GoalContinuationCoordinator settlement', () => {
     registerObservedTurn(coordinator, SESSION, 'turn-replacement');
     await set.impl({ condition: 'replacement' }, goalToolContext('turn-replacement'));
 
-    assert.match(
-      String(await pause.impl({}, goalToolContext('turn-old'))),
-      /no longer owns Goal control/,
-    );
-    assert.match(
-      String(await clear.impl({}, goalToolContext('turn-old'))),
-      /no longer owns Goal control/,
-    );
+    assert.match(String(await pause.impl({}, goalToolContext('turn-old'))), /Call GoalStatus/);
+    assert.match(String(await clear.impl({}, goalToolContext('turn-old'))), /Call GoalStatus/);
     assert.equal(manager.get(SESSION)?.condition, 'replacement');
     assert.equal(manager.get(SESSION)?.status, 'active');
   });
@@ -352,7 +346,7 @@ describe('GoalContinuationCoordinator settlement', () => {
         await set.impl({ condition: 'must not exist' }, goalToolContext('turn-deleted')),
       );
 
-      assert.match(output, /no longer owns Goal activation/);
+      assert.match(output, /Call GoalStatus/);
       assert.equal(manager.get(SESSION), undefined);
     });
 
@@ -374,7 +368,7 @@ describe('GoalContinuationCoordinator settlement', () => {
       manager.pause(SESSION);
       const output = String(await resume.impl({}, goalToolContext('turn-archived')));
 
-      assert.match(output, /no longer owns Goal activation/);
+      assert.match(output, /Call GoalStatus/);
       assert.equal(manager.get(SESSION)?.condition, 'replacement');
       assert.equal(manager.get(SESSION)?.status, 'paused');
     });

--- a/packages/runtime/src/__tests__/goal-continuation.test.ts
+++ b/packages/runtime/src/__tests__/goal-continuation.test.ts
@@ -394,6 +394,102 @@ describe('GoalContinuationCoordinator settlement', () => {
     });
   });
 
+  /**
+   * Every cause the refusal text can name, produced by the real coordinator.
+   *
+   * The refusal-text suite drives these through a fake whose `activationStanding`
+   * and `mutationStanding` return whatever they are handed, which proves the
+   * sentences and nothing about whether the coordinator can reach them. Three of
+   * the five had no test that it can, and one of those three could not: the
+   * shutdown sentence was written for a branch that `dispose()` had already made
+   * unreachable, and the turn read a different sentence that was false about it.
+   */
+  describe('every decline cause is reachable from the real coordinator', () => {
+    test('a shut-down coordinator says so, instead of denying the turn was registered', async () => {
+      const { manager, coordinator } = setup();
+      registerObservedTurn(coordinator, SESSION, 'turn-live');
+      const tools = goalToolsFor(manager, coordinator);
+      const set = tools.find((tool) => tool.name === GOAL_SET_TOOL_NAME);
+      const clear = tools.find((tool) => tool.name === GOAL_CLEAR_TOOL_NAME);
+      assert.ok(set);
+      assert.ok(clear);
+      await set.impl({ condition: 'ship' }, goalToolContext('turn-live'));
+
+      coordinator.dispose();
+      const output = String(await clear.impl({}, goalToolContext('turn-live')));
+
+      assert.match(output, /the goal system is shutting down/);
+      // The sentence this turn used to get. It was registered under the Goal
+      // boundary — it armed the goal it is now trying to clear.
+      assert.doesNotMatch(output, /does not run under the session goal boundary/);
+    });
+
+    test('a turn already bound to a goal is not told it tried to arm a second one', async () => {
+      const { manager, coordinator } = setup();
+      // Two things have to hold at once, and neither involves the model arming
+      // anything. `beginObservedTurn` binds the lease by itself when a goal is
+      // already active, and only `mutateGoal` releases it — so the pause has to
+      // come from somewhere that is not a Goal tool. The autonomous evaluation
+      // loop and the host-side pause control are both exactly that.
+      manager.create(SESSION, 'ship');
+      registerObservedTurn(coordinator, SESSION, 'turn-inherited');
+      manager.pause(SESSION);
+
+      const resume = goalToolsFor(manager, coordinator).find(
+        (tool) => tool.name === GOAL_RESUME_TOOL_NAME,
+      );
+      assert.ok(resume);
+      const output = String(await resume.impl({}, goalToolContext('turn-inherited')));
+
+      assert.equal(manager.get(SESSION)?.status, 'paused');
+      // GoalResume asked to arm nothing, and this turn armed nothing.
+      assert.doesNotMatch(output, /arm a second one/);
+      assert.doesNotMatch(output, /already armed/);
+      assert.match(output, /already bound to a goal/);
+      assert.match(output, /Do not call GoalResume again in this turn/);
+    });
+
+    test('GoalSet on a turn that is still bound to a finished goal is refused as a second arming', async () => {
+      const { manager, coordinator } = setup();
+      manager.create(SESSION, 'first');
+      registerObservedTurn(coordinator, SESSION, 'turn-inherited');
+      // Same shape: the goal reaches a terminal status without passing through
+      // `mutateGoal`, so the turn keeps the lease it was bound to at
+      // registration and GoalSet gets past its own unfinished-goal guard.
+      manager.clear(SESSION);
+
+      const set = goalToolsFor(manager, coordinator).find(
+        (tool) => tool.name === GOAL_SET_TOOL_NAME,
+      );
+      assert.ok(set);
+      const output = String(
+        await set.impl({ condition: 'second' }, goalToolContext('turn-inherited')),
+      );
+
+      assert.match(output, /cannot arm a second one/);
+      assert.match(output, /Call GoalStatus/);
+      assert.equal(manager.get(SESSION)?.status, 'cleared');
+    });
+
+    test('a turn that started before the goal existed is told that, not that it is unregistered', async () => {
+      const { manager, coordinator } = setup();
+      registerObservedTurn(coordinator, SESSION, 'turn-early');
+      registerObservedTurn(coordinator, SESSION, 'turn-later');
+      const tools = goalToolsFor(manager, coordinator);
+      const set = tools.find((tool) => tool.name === GOAL_SET_TOOL_NAME);
+      const clear = tools.find((tool) => tool.name === GOAL_CLEAR_TOOL_NAME);
+      assert.ok(set);
+      assert.ok(clear);
+
+      await set.impl({ condition: 'later goal' }, goalToolContext('turn-later'));
+      const output = String(await clear.impl({}, goalToolContext('turn-early')));
+
+      assert.match(output, /began before the current goal existed/);
+      assert.match(output, /Do not call this tool again in this turn/);
+      assert.equal(manager.get(SESSION)?.status, 'active');
+    });
+  });
+
   test('closed sessions reject fresh turns until explicitly reopened', () => {
     const { coordinator } = setup();
     coordinator.beginSessionClose(SESSION, 'archive').commit();

--- a/packages/runtime/src/__tests__/goal-continuation.test.ts
+++ b/packages/runtime/src/__tests__/goal-continuation.test.ts
@@ -280,6 +280,11 @@ describe('GoalContinuationCoordinator settlement', () => {
       await set.impl({ condition: 'replacement' }, goalToolContext('turn-old')),
     );
 
+    // A real race: another turn armed and cleared a goal, so the generation
+    // this turn observed is gone. Reading the current goal is worth doing and
+    // can change what the model does next, so this is where a look-again
+    // instruction is honest.
+    assert.match(output, /the session goal changed while this turn was running/);
     assert.match(output, /Call GoalStatus/);
     assert.equal(manager.get(SESSION)?.status, 'cleared');
     assert.equal(manager.get(SESSION)?.condition, 'first');
@@ -302,7 +307,7 @@ describe('GoalContinuationCoordinator settlement', () => {
       await set.impl({ condition: 'replacement' }, goalToolContext('turn-old')),
     );
 
-    assert.match(output, /Call GoalStatus/);
+    assert.match(output, /the session goal changed while this turn was running/);
     assert.equal(manager.get(SESSION)?.condition, 'paused goal');
     assert.equal(manager.get(SESSION)?.status, 'cleared');
   });
@@ -324,8 +329,14 @@ describe('GoalContinuationCoordinator settlement', () => {
     registerObservedTurn(coordinator, SESSION, 'turn-replacement');
     await set.impl({ condition: 'replacement' }, goalToolContext('turn-replacement'));
 
-    assert.match(String(await pause.impl({}, goalToolContext('turn-old'))), /Call GoalStatus/);
-    assert.match(String(await clear.impl({}, goalToolContext('turn-old'))), /Call GoalStatus/);
+    assert.match(
+      String(await pause.impl({}, goalToolContext('turn-old'))),
+      /the session goal changed while this turn was running/,
+    );
+    assert.match(
+      String(await clear.impl({}, goalToolContext('turn-old'))),
+      /the session goal changed while this turn was running/,
+    );
     assert.equal(manager.get(SESSION)?.condition, 'replacement');
     assert.equal(manager.get(SESSION)?.status, 'active');
   });
@@ -346,7 +357,14 @@ describe('GoalContinuationCoordinator settlement', () => {
         await set.impl({ condition: 'must not exist' }, goalToolContext('turn-deleted')),
       );
 
-      assert.match(output, /Call GoalStatus/);
+      // The loop this replaced: the session was closed and removed, so this
+      // turn has no registration and never will. Told to call GoalStatus and
+      // retry "if there is still no active goal", the model gets "No goal set
+      // for this session", satisfies the condition, retries, and receives the
+      // identical refusal forever. The refusal must not ask for that.
+      assert.match(output, /does not run under the session goal boundary/);
+      assert.match(output, /Do not call this tool again in this turn/);
+      assert.doesNotMatch(output, /call GoalSet again/i);
       assert.equal(manager.get(SESSION), undefined);
     });
 
@@ -368,7 +386,9 @@ describe('GoalContinuationCoordinator settlement', () => {
       manager.pause(SESSION);
       const output = String(await resume.impl({}, goalToolContext('turn-archived')));
 
-      assert.match(output, /Call GoalStatus/);
+      assert.match(output, /does not run under the session goal boundary/);
+      assert.match(output, /Do not call this tool again in this turn/);
+      assert.doesNotMatch(output, /call GoalResume again/i);
       assert.equal(manager.get(SESSION)?.condition, 'replacement');
       assert.equal(manager.get(SESSION)?.status, 'paused');
     });

--- a/packages/runtime/src/__tests__/non-cu-tool-refusal-text.test.ts
+++ b/packages/runtime/src/__tests__/non-cu-tool-refusal-text.test.ts
@@ -193,7 +193,8 @@ describe('E1 — capability-missing refusals name the tool and a fallback', () =
 describe('E2 — goal turn-ownership refusals', () => {
   function goalTools(
     seed: 'active' | 'paused' | undefined,
-    reason: GoalControlDecline,
+    gates: { activation: GoalControlDecline; mutation: GoalControlDecline },
+    isAvailable?: () => boolean,
   ): MakaTool[] {
     const goalManager = new GoalManager({ generateId: () => 'g-1', now: () => 1000 });
     if (seed) {
@@ -206,12 +207,18 @@ describe('E2 — goal turn-ownership refusals', () => {
       // old text described this with two different internal nouns ("Goal
       // activation" vs "Goal control") and no recovery step; the version after
       // that asserted one cause and prescribed a retry for all of them.
+      //
+      // The two gates answer separately on purpose. A stub that returns the
+      // same reason from both cannot see a tool wired to the wrong one, and
+      // routing GoalClear through the activation gate would then leave every
+      // test green while the model was told it "cannot arm a second one".
       goalContinuation: {
         activateGoal: () => undefined,
         mutateGoal: () => undefined,
-        activationStanding: () => ({ kind: 'declined', reason }),
-        mutationStanding: () => ({ kind: 'declined', reason }),
+        activationStanding: () => ({ kind: 'declined', reason: gates.activation }),
+        mutationStanding: () => ({ kind: 'declined', reason: gates.mutation }),
       } as never,
+      ...(isAvailable ? { isAvailable } : {}),
       now: () => 1000,
     });
   }
@@ -229,7 +236,9 @@ describe('E2 — goal turn-ownership refusals', () => {
     args: Record<string, unknown>,
     reason: GoalControlDecline,
   ): Promise<string> {
-    const tool = goalTools(seed, reason).find((candidate) => candidate.name === name)!;
+    const tool = goalTools(seed, { activation: reason, mutation: reason }).find(
+      (candidate) => candidate.name === name,
+    )!;
     return String(await tool.impl(args as never, ctx()));
   }
 
@@ -273,9 +282,9 @@ describe('E2 — goal turn-ownership refusals', () => {
     }
   }
 
-  test('a turn that already armed a goal is told so, and reading it is still useful', async () => {
+  test('a turn that is already bound to a goal is told so, and reading it is still useful', async () => {
     // The one permanent cause where GoalStatus does tell the model something
-    // it does not know: the goal it is asking about exists, and it set it.
+    // it does not know: a goal exists and this turn is bound to it.
     const text = await refusal(
       GOAL_SET_TOOL_NAME,
       undefined,
@@ -283,14 +292,74 @@ describe('E2 — goal turn-ownership refusals', () => {
       'goal_already_armed',
     );
 
-    assert.ok(/already armed a goal/.test(text), text);
+    assert.ok(/already bound to a goal/.test(text), text);
     assert.ok(text.includes(GOAL_STATUS_TOOL_NAME), text);
     assert.ok(!/call GoalSet again/i.test(text), text);
+  });
+
+  test('GoalResume is not told it tried to arm a second goal', async () => {
+    // `goal_already_armed` comes from the activation gate, and GoalResume goes
+    // through that gate — but it asked to arm nothing, and the turn may hold
+    // the lease only because it started while a goal was active. The cause is
+    // shared; what there is to say about it is not.
+    const text = await refusal('GoalResume', 'paused', {}, 'goal_already_armed');
+
+    assert.ok(!/arm a second one/.test(text), `GoalResume armed nothing: ${text}`);
+    assert.ok(!/already armed/.test(text), `the lease can be inherited, not armed: ${text}`);
+    assert.ok(/already bound to a goal/.test(text), text);
+    assert.ok(text.includes(GOAL_STATUS_TOOL_NAME), text);
+    assert.ok(/Do not call GoalResume again in this turn/.test(text), text);
+  });
+
+  test('each tool reports the gate it actually goes through', async () => {
+    // GoalSet and GoalResume are activations; GoalClear and GoalPause mutate
+    // the generation the turn observed. Wiring one to the other gate produces a
+    // refusal about the wrong thing, and a stub that answers both gates
+    // identically cannot tell.
+    const split = { activation: 'goal_already_armed', mutation: 'goal_not_observed' } as const;
+    const say = async (
+      name: string,
+      seed: 'active' | 'paused' | undefined,
+      args: Record<string, unknown> = {},
+    ) =>
+      String(
+        await goalTools(seed, split)
+          .find((candidate) => candidate.name === name)!
+          .impl(args as never, ctx()),
+      );
+
+    const activates = /already bound to a goal/;
+    const mutates = /began before the current goal existed/;
+    assert.match(await say(GOAL_SET_TOOL_NAME, undefined, { condition: 'x' }), activates);
+    assert.match(await say('GoalResume', 'paused'), activates);
+    assert.match(await say('GoalClear', 'active'), mutates);
+    assert.match(await say('GoalPause', 'active'), mutates);
+  });
+
+  test('a shut-down goal authority does not invite the model to keep calling', async () => {
+    // `beginDrain` is one-way: the flag is set once, the continuation
+    // coordinator is disposed with it, and nothing clears it. "Goal authority
+    // is unavailable." read as a passing condition worth another call.
+    const tools = goalTools(
+      'active',
+      { activation: 'goal_changed', mutation: 'goal_changed' },
+      () => false,
+    );
+    for (const name of ['GoalClear', 'GoalPause', GOAL_SET_TOOL_NAME]) {
+      const args = name === GOAL_SET_TOOL_NAME ? { condition: 'x' } : {};
+      const text = String(
+        await tools.find((candidate) => candidate.name === name)!.impl(args as never, ctx()),
+      );
+      assertNoHostInternals(text);
+      assert.ok(/Do not call this tool again/.test(text), `${name}: ${text}`);
+      assert.ok(!/^Goal authority is unavailable\.$/.test(text), `${name}: ${text}`);
+      assert.ok(!text.includes(GOAL_STATUS_TOOL_NAME), `${name}: ${text}`);
+    }
   });
 });
 
 describe('E3 — an internal filesystem mismatch does not read as an argument complaint', () => {
-  async function refuseWith(name: string, args: unknown): Promise<string> {
+  async function failureOf(name: string, args: unknown): Promise<Error> {
     const cwd = await workspace();
     const tools = buildBuiltinTools({
       // Answer every request with a well-formed result of some other
@@ -302,8 +371,8 @@ describe('E3 — an internal filesystem mismatch does not read as an argument co
       } as never,
     });
     const tool = tools.find((candidate) => candidate.name === name)!;
-    return await refusalOf(() =>
-      tool.impl(
+    try {
+      await tool.impl(
         args as never,
         {
           sessionId: 'session-1',
@@ -318,8 +387,16 @@ describe('E3 — an internal filesystem mismatch does not read as an argument co
           abortSignal: NO_ABORT,
           emitOutput: () => {},
         } as never,
-      ),
-    );
+      );
+    } catch (error) {
+      assert.ok(error instanceof Error, String(error));
+      return error;
+    }
+    throw new Error('expected the call to be refused');
+  }
+
+  async function refuseWith(name: string, args: unknown): Promise<string> {
+    return (await failureOf(name, args)).message;
   }
 
   test('Edit does not claim the file is unchanged, and rules out the old_string retry', async () => {
@@ -355,11 +432,39 @@ describe('E3 — an internal filesystem mismatch does not read as an argument co
     assertNoHostInternals(grep);
     assert.ok(!/no matches were produced/.test(grep), `must not read as an empty result: ${grep}`);
     assert.ok(/does not mean the pattern is absent/.test(grep), grep);
-    assert.ok(grep.includes('Bash'), `must offer a way out: ${grep}`);
+
+    // The fallback may not be prescribed outright. `local_read` children are
+    // given Read, Glob and Grep and nothing else, so "use Bash to do the same
+    // work" is, for the caller most likely to be running a bare Grep, an
+    // instruction it cannot follow — and the refusal then leaves it with no
+    // move at all. Offer the shell on a condition the model can check, and end
+    // on something every caller can do.
+    assert.ok(!/use Bash/.test(grep), `must not prescribe a tool the caller may not have: ${grep}`);
+    assert.ok(/shell tool if you have one/.test(grep), grep);
+    assert.ok(/otherwise report that Grep is failing/.test(grep), grep);
 
     const glob = await refuseWith('Glob', { pattern: '**/*.ts' });
     assertNoHostInternals(glob);
     assert.ok(/does not mean no files match/.test(glob), glob);
+  });
+
+  test('the worker-protocol violation still reaches an operator', async () => {
+    // The model-facing sentence cannot name the worker, but an operator reading
+    // a log needs to know this was a mismatched result and not, say, a missing
+    // file. It travels as the cause, which is out of the model's sight and in
+    // every stack trace.
+    for (const [name, args] of [
+      ['Grep', { pattern: 'needle' }],
+      ['Glob', { pattern: '**/*.ts' }],
+      ['Read', { path: 'a.txt' }],
+      ['Write', { path: 'a.txt', content: 'x' }],
+      ['Edit', { path: 'a.txt', old_string: 'x', new_string: 'y' }],
+    ] as const) {
+      const error = await failureOf(name, args);
+      assertNoHostInternals(error.message);
+      assert.ok(error.cause instanceof Error, `${name} lost the operator signal`);
+      assert.equal(error.cause.message, `Filesystem worker returned a mismatched ${name} result.`);
+    }
   });
 });
 
@@ -372,6 +477,27 @@ describe('E5 — background task refs and capacity', () => {
     });
     const text = await refusalOf(() =>
       manager.stopBackgroundTask('session-1', 'task-3-secret-value', NO_ABORT),
+    );
+    assert.ok(text.includes('maka://runtime/background-tasks/<id>'), text);
+    assert.ok(!text.includes('task-3-secret-value'), `must not echo the rejected ref: ${text}`);
+  });
+
+  test('the Read({ref}) path gets the canonical form too', async () => {
+    // `classifyRuntimeResourceRef` waves through anything shaped
+    // `maka://runtime/<something>`, so a mistyped path segment lands here and
+    // not on `stopBackgroundTask`. This is the likeliest place to mistype a
+    // ref, and it was the one still echoing the rejected string back.
+    const manager = new ShellRunProcessManager({
+      store: createSqliteShellRunStore(await workspace()),
+      newId: () => 'shell-run-1',
+      now: () => 1,
+    });
+    const text = await refusalOf(() =>
+      manager.readRuntimeResource(
+        'session-1',
+        'maka://runtime/backgroundtasks/task-3-secret-value',
+        NO_ABORT,
+      ),
     );
     assert.ok(text.includes('maka://runtime/background-tasks/<id>'), text);
     assert.ok(!text.includes('task-3-secret-value'), `must not echo the rejected ref: ${text}`);

--- a/packages/runtime/src/__tests__/non-cu-tool-refusal-text.test.ts
+++ b/packages/runtime/src/__tests__/non-cu-tool-refusal-text.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Model-facing refusal text for the non-Computer-Use tool families.
+ *
+ * Every assertion here is about what the model can *do* after reading a
+ * refusal, not about an exact sentence. The shared defect these guard against
+ * is a refusal that names a host-internal concept (an injected capability
+ * function, a scope rule, a worker) and offers no next action, which leaves the
+ * model with nothing to try but the same call again.
+ */
+
+import { strict as assert } from 'node:assert';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, describe, test } from 'node:test';
+import { createManagedExecutionBoundary, createWorkspaceWritePermissionProfile } from '@maka/core';
+import { createSqliteShellRunStore } from '@maka/storage';
+
+import { buildBuiltinTools } from '../builtin-tools.js';
+import {
+  AGENT_LIST_TOOL_NAME,
+  AGENT_OUTPUT_TOOL_NAME,
+  AGENT_SPAWN_TOOL_NAME,
+  buildSubagentOutputTool,
+  buildSubagentProjectionTools,
+  buildSubagentSpawnTool,
+} from '../subagent-tools.js';
+import { AGENT_SWARM_TOOL_NAME, buildAgentSwarmTool } from '../agent-swarm-tools.js';
+import { buildAskUserQuestionTool } from '../ask-user-question-tool.js';
+import { buildRequestSandboxBoundaryTool } from '../sandbox-boundary-tool.js';
+import { buildGoalTools, GOAL_SET_TOOL_NAME, GOAL_STATUS_TOOL_NAME } from '../goal-tools.js';
+import { GoalManager } from '../goal-state.js';
+import { ShellRunProcessManager } from '../shell-run-manager.js';
+import type { MakaTool, MakaToolContext } from '../tool-runtime.js';
+
+const NO_ABORT = new AbortController().signal;
+const TEMPORARY_WORKSPACES = new Set<string>();
+
+after(async () => {
+  await Promise.all(
+    [...TEMPORARY_WORKSPACES].map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+async function workspace(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'maka-refusal-text-'));
+  TEMPORARY_WORKSPACES.add(path);
+  return path;
+}
+
+function ctx(extra: Partial<MakaToolContext> = {}): MakaToolContext {
+  return {
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    cwd: '/tmp',
+    toolCallId: 'tool-1',
+    abortSignal: NO_ABORT,
+    emitOutput: () => {},
+    ...extra,
+  } as MakaToolContext;
+}
+
+async function refusalOf(run: () => unknown | Promise<unknown>): Promise<string> {
+  try {
+    await run();
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error('expected the call to be refused');
+}
+
+/** Host-internal identifiers that must never reach the model. */
+const HOST_INTERNAL_WORDS = [
+  'spawnChildSession',
+  'spawnChildAgent',
+  'listChildAgents',
+  'readChildAgentOutput',
+  'retryChildAgent',
+  'prepareChildAgentResume',
+  'requestSandboxBoundary',
+  'askUserQuestion',
+  'runtime context',
+  'AgentRun',
+  'Filesystem worker',
+];
+
+function assertNoHostInternals(text: string): void {
+  for (const word of HOST_INTERNAL_WORDS) {
+    assert.ok(!text.includes(word), `refusal must not mention host internal "${word}": ${text}`);
+  }
+}
+
+/**
+ * A usable refusal names the tool the model actually called and tells it what
+ * to do next. "Do something else" only counts if the text points at a concrete
+ * alternative: another tool name, a parameter, or plain reply text.
+ */
+function assertActionable(text: string, toolName: string, alternatives: readonly string[]): void {
+  assertNoHostInternals(text);
+  assert.ok(text.includes(toolName), `refusal must name the tool ${toolName}: ${text}`);
+  assert.ok(
+    alternatives.some((alternative) => text.includes(alternative)),
+    `refusal must point at one of ${alternatives.join(' / ')}: ${text}`,
+  );
+}
+
+describe('E1 — capability-missing refusals name the tool and a fallback', () => {
+  test('agent_spawn', async () => {
+    const tool = buildSubagentSpawnTool();
+    const text = await refusalOf(() =>
+      tool.impl({ profile: 'local_read', task: 'look at a file' }, ctx()),
+    );
+    assertActionable(text, AGENT_SPAWN_TOOL_NAME, ['yourself']);
+  });
+
+  test('agent_list', async () => {
+    const tool = buildSubagentProjectionTools().find(
+      (candidate) => candidate.name === AGENT_LIST_TOOL_NAME,
+    ) as MakaTool;
+    const text = await refusalOf(() => tool.impl({}, ctx()));
+    assertActionable(text, AGENT_LIST_TOOL_NAME, [AGENT_SPAWN_TOOL_NAME]);
+  });
+
+  test('agent_output', async () => {
+    const tool = buildSubagentOutputTool();
+    const text = await refusalOf(() => tool.impl({ locator: 'legacy_run', run_id: 'r' }, ctx()));
+    assertActionable(text, AGENT_OUTPUT_TOOL_NAME, [AGENT_SPAWN_TOOL_NAME, AGENT_SWARM_TOOL_NAME]);
+  });
+
+  test('agent_swarm spawn', async () => {
+    const tool = buildAgentSwarmTool();
+    const text = await refusalOf(() =>
+      tool.impl(
+        {
+          items: [
+            {
+              item_id: 'item-0',
+              profile: 'local_read',
+              task: 'task-0',
+              write_back: 'summary',
+              isolation: 'same_workspace',
+            },
+          ],
+        },
+        ctx(),
+      ),
+    );
+    assertActionable(text, AGENT_SWARM_TOOL_NAME, ['yourself']);
+  });
+
+  test('agent_swarm resume points at the parameter to drop', async () => {
+    const tool = buildAgentSwarmTool();
+    const text = await refusalOf(() =>
+      tool.impl(
+        { resume_run_ids: ['run-1'] } as never,
+        ctx({ spawnChildSession: (async () => ({})) as never }),
+      ),
+    );
+    assertActionable(text, AGENT_SWARM_TOOL_NAME, ['resume_run_ids']);
+  });
+
+  test('AskUserQuestion', async () => {
+    const tool = buildAskUserQuestionTool();
+    const text = await refusalOf(() =>
+      tool.impl(
+        {
+          questions: [{ question: 'a?', options: [{ label: 'one' }, { label: 'two' }] }] as never,
+        },
+        ctx(),
+      ),
+    );
+    assertActionable(text, 'AskUserQuestion', ['reply text']);
+  });
+
+  test('request_sandbox_boundary', async () => {
+    const tool = buildRequestSandboxBoundaryTool();
+    const text = await refusalOf(() =>
+      tool.impl({ expansion: {} as never, justification: 'need it' }, ctx()),
+    );
+    assertActionable(text, 'request_sandbox_boundary', ['tell the user']);
+  });
+});
+
+describe('E2 — goal turn-ownership refusals', () => {
+  function goalTools(seed?: 'active' | 'paused'): MakaTool[] {
+    const goalManager = new GoalManager({ generateId: () => 'g-1', now: () => 1000 });
+    if (seed) {
+      goalManager.create('session-1', 'tests pass', {});
+      if (seed === 'paused') goalManager.pause('session-1');
+    }
+    return buildGoalTools({
+      goalManager,
+      // Both authorization gates decline. This is the exact case the old text
+      // described with two different internal nouns ("Goal activation" vs
+      // "Goal control") and no recovery step.
+      goalContinuation: { activateGoal: () => undefined, mutateGoal: () => undefined } as never,
+      now: () => 1000,
+    });
+  }
+
+  const gates: ReadonlyArray<[string, 'active' | 'paused' | undefined, Record<string, unknown>]> = [
+    [GOAL_SET_TOOL_NAME, undefined, { condition: 'tests pass' }],
+    ['GoalClear', 'active', {}],
+    ['GoalPause', 'active', {}],
+    ['GoalResume', 'paused', {}],
+  ];
+
+  for (const [name, seed, args] of gates) {
+    test(`${name} declines with a checkable next action`, async () => {
+      const tool = goalTools(seed).find((candidate) => candidate.name === name)!;
+      const text = String(await tool.impl(args as never, ctx()));
+
+      // The gate really fired, rather than an earlier "no goal" branch.
+      assert.ok(/changed while this turn was running/.test(text), text);
+      // Recovery: one named tool the model can actually call.
+      assert.ok(text.includes(GOAL_STATUS_TOOL_NAME), `must point at GoalStatus: ${text}`);
+      // The two internal nouns are gone, and with them the false distinction.
+      assert.ok(!/owns Goal (activation|control)/.test(text), text);
+    });
+  }
+});
+
+describe('E3 — an internal filesystem mismatch does not read as an argument complaint', () => {
+  async function refuseWith(name: string, args: unknown): Promise<string> {
+    const cwd = await workspace();
+    const tools = buildBuiltinTools({
+      // Answer every request with a result of the wrong kind, which is the
+      // exact condition the old "Filesystem worker returned a mismatched X
+      // result." message described.
+      filesystemWorker: { execute: async () => ({ kind: 'glob', files: [] }) } as never,
+    });
+    const tool = tools.find((candidate) => candidate.name === name)!;
+    return await refusalOf(() =>
+      tool.impl(
+        args as never,
+        {
+          sessionId: 'session-1',
+          turnId: 'turn-1',
+          toolCallId: `tool-${name}`,
+          cwd,
+          permissionMode: 'ask',
+          executionBoundary: createManagedExecutionBoundary(
+            createWorkspaceWritePermissionProfile(),
+            0,
+          ),
+          abortSignal: NO_ABORT,
+          emitOutput: () => {},
+        } as never,
+      ),
+    );
+  }
+
+  test('Edit says the file is unchanged and that old_string is not the problem', async () => {
+    const text = await refuseWith('Edit', {
+      path: 'a.txt',
+      old_string: 'x',
+      new_string: 'y',
+    });
+    assertNoHostInternals(text);
+    assert.ok(text.includes('Edit'), text);
+    assert.ok(/unchanged/.test(text), text);
+    assert.ok(text.includes('old_string'), `must rule out the old_string retry: ${text}`);
+    assert.ok(text.includes('Bash'), `must offer a way out: ${text}`);
+  });
+
+  test('Write says nothing was written and offers a way out', async () => {
+    const text = await refuseWith('Write', { path: 'a.txt', content: 'x' });
+    assertNoHostInternals(text);
+    assert.ok(/nothing was written/.test(text), text);
+    assert.ok(text.includes('Bash'), text);
+  });
+});
+
+describe('E5 — background task refs and capacity', () => {
+  test('a bad ref gets the canonical form instead of an echo', async () => {
+    const manager = new ShellRunProcessManager({
+      store: createSqliteShellRunStore(await workspace()),
+      newId: () => 'shell-run-1',
+      now: () => 1,
+    });
+    const text = await refusalOf(() =>
+      manager.stopBackgroundTask('session-1', 'task-3-secret-value', NO_ABORT),
+    );
+    assert.ok(text.includes('maka://runtime/background-tasks/<id>'), text);
+    assert.ok(!text.includes('task-3-secret-value'), `must not echo the rejected ref: ${text}`);
+  });
+
+  test('a full shell slot names StopBackgroundTask', async () => {
+    const cwd = await workspace();
+    const manager = new ShellRunProcessManager({
+      store: createSqliteShellRunStore(cwd),
+      newId: () => 'shell-run-1',
+      now: () => 1,
+      maxLiveShellRuns: 0,
+    });
+    const text = await refusalOf(() =>
+      manager.runBackgroundBash({
+        sessionId: 'session-1',
+        sourceRunId: 'run-1',
+        sourceTurnId: 'turn-1',
+        sourceToolCallId: 'tool-1',
+        cwd,
+        command: 'true',
+        emitOutput: () => {},
+        abortSignal: NO_ABORT,
+      } as never),
+    );
+    assert.ok(text.includes('StopBackgroundTask'), text);
+  });
+
+  test('a full PTY slot names StopBackgroundTask', async () => {
+    const cwd = await workspace();
+    const manager = new ShellRunProcessManager({
+      store: createSqliteShellRunStore(cwd),
+      newId: () => 'shell-run-1',
+      now: () => 1,
+      maxLivePtyRuns: 0,
+    });
+    const text = await refusalOf(() =>
+      manager.runBackgroundBash({
+        sessionId: 'session-1',
+        sourceRunId: 'run-1',
+        sourceTurnId: 'turn-1',
+        sourceToolCallId: 'tool-1',
+        cwd,
+        command: 'true',
+        pty: true,
+        emitOutput: () => {},
+        abortSignal: NO_ABORT,
+      } as never),
+    );
+    assert.ok(text.includes('StopBackgroundTask'), text);
+    assert.ok(/PTY/.test(text), text);
+  });
+});
+
+describe('E6 — agent_output locator rejections name the missing fields', () => {
+  const cases: ReadonlyArray<[string, readonly string[]]> = [
+    ['child_session_latest', ['child_session_id']],
+    ['child_session_run', ['child_session_id', 'run_id']],
+    ['legacy_run', ['run_id']],
+    ['legacy_turn', ['turn_id']],
+  ];
+
+  for (const [locator, fields] of cases) {
+    test(`locator=${locator}`, () => {
+      const schema = buildSubagentOutputTool().parameters as unknown as {
+        safeParse: (value: unknown) => {
+          success: boolean;
+          error?: { issues: Array<{ message: string }> };
+        };
+      };
+      const parsed = schema.safeParse({ locator });
+      assert.equal(parsed.success, false);
+      const message = (parsed.error?.issues ?? []).map((issue) => issue.message).join(' | ');
+      for (const field of fields) {
+        assert.ok(message.includes(field), `expected ${field} in: ${message}`);
+      }
+      assert.ok(!/matching identity fields/.test(message), message);
+    });
+  }
+});

--- a/packages/runtime/src/__tests__/non-cu-tool-refusal-text.test.ts
+++ b/packages/runtime/src/__tests__/non-cu-tool-refusal-text.test.ts
@@ -29,6 +29,7 @@ import { AGENT_SWARM_TOOL_NAME, buildAgentSwarmTool } from '../agent-swarm-tools
 import { buildAskUserQuestionTool } from '../ask-user-question-tool.js';
 import { buildRequestSandboxBoundaryTool } from '../sandbox-boundary-tool.js';
 import { buildGoalTools, GOAL_SET_TOOL_NAME, GOAL_STATUS_TOOL_NAME } from '../goal-tools.js';
+import type { GoalControlDecline } from '../goal-continuation.js';
 import { GoalManager } from '../goal-state.js';
 import { ShellRunProcessManager } from '../shell-run-manager.js';
 import type { MakaTool, MakaToolContext } from '../tool-runtime.js';
@@ -159,7 +160,15 @@ describe('E1 — capability-missing refusals name the tool and a fallback', () =
     assertActionable(text, AGENT_SWARM_TOOL_NAME, ['resume_run_ids']);
   });
 
-  test('AskUserQuestion', async () => {
+  // ToolRuntime injects `askUserQuestion` and `requestSandboxBoundary`
+  // unconditionally — unlike `listChildAgents` and `readChildAgentOutput`
+  // beside them, which are spread only when present — so these two branches
+  // cannot fire through it. Availability is decided when the tool set is
+  // assembled: the CLI adds both only on the TUI surface. The guards stay
+  // because the context type declares the callbacks optional and an embedder
+  // may build one without them; these two tests cover that contract, not a
+  // production path.
+  test('AskUserQuestion on a context that does not carry the callback', async () => {
     const tool = buildAskUserQuestionTool();
     const text = await refusalOf(() =>
       tool.impl(
@@ -172,7 +181,7 @@ describe('E1 — capability-missing refusals name the tool and a fallback', () =
     assertActionable(text, 'AskUserQuestion', ['reply text']);
   });
 
-  test('request_sandbox_boundary', async () => {
+  test('request_sandbox_boundary on a context that does not carry the callback', async () => {
     const tool = buildRequestSandboxBoundaryTool();
     const text = await refusalOf(() =>
       tool.impl({ expansion: {} as never, justification: 'need it' }, ctx()),
@@ -182,7 +191,10 @@ describe('E1 — capability-missing refusals name the tool and a fallback', () =
 });
 
 describe('E2 — goal turn-ownership refusals', () => {
-  function goalTools(seed?: 'active' | 'paused'): MakaTool[] {
+  function goalTools(
+    seed: 'active' | 'paused' | undefined,
+    reason: GoalControlDecline,
+  ): MakaTool[] {
     const goalManager = new GoalManager({ generateId: () => 'g-1', now: () => 1000 });
     if (seed) {
       goalManager.create('session-1', 'tests pass', {});
@@ -190,10 +202,16 @@ describe('E2 — goal turn-ownership refusals', () => {
     }
     return buildGoalTools({
       goalManager,
-      // Both authorization gates decline. This is the exact case the old text
-      // described with two different internal nouns ("Goal activation" vs
-      // "Goal control") and no recovery step.
-      goalContinuation: { activateGoal: () => undefined, mutateGoal: () => undefined } as never,
+      // Both authorization gates decline, and the coordinator reports why. The
+      // old text described this with two different internal nouns ("Goal
+      // activation" vs "Goal control") and no recovery step; the version after
+      // that asserted one cause and prescribed a retry for all of them.
+      goalContinuation: {
+        activateGoal: () => undefined,
+        mutateGoal: () => undefined,
+        activationStanding: () => ({ kind: 'declined', reason }),
+        mutationStanding: () => ({ kind: 'declined', reason }),
+      } as never,
       now: () => 1000,
     });
   }
@@ -205,29 +223,83 @@ describe('E2 — goal turn-ownership refusals', () => {
     ['GoalResume', 'paused', {}],
   ];
 
-  for (const [name, seed, args] of gates) {
-    test(`${name} declines with a checkable next action`, async () => {
-      const tool = goalTools(seed).find((candidate) => candidate.name === name)!;
-      const text = String(await tool.impl(args as never, ctx()));
+  async function refusal(
+    name: string,
+    seed: 'active' | 'paused' | undefined,
+    args: Record<string, unknown>,
+    reason: GoalControlDecline,
+  ): Promise<string> {
+    const tool = goalTools(seed, reason).find((candidate) => candidate.name === name)!;
+    return String(await tool.impl(args as never, ctx()));
+  }
 
-      // The gate really fired, rather than an earlier "no goal" branch.
-      assert.ok(/changed while this turn was running/.test(text), text);
-      // Recovery: one named tool the model can actually call.
+  for (const [name, seed, args] of gates) {
+    test(`${name} points at GoalStatus when the goal really did change`, async () => {
+      const text = await refusal(name, seed, args, 'goal_changed');
+
+      assertNoHostInternals(text);
+      // Recovery: one named tool the model can actually call, and reading is
+      // always available.
       assert.ok(text.includes(GOAL_STATUS_TOOL_NAME), `must point at GoalStatus: ${text}`);
       // The two internal nouns are gone, and with them the false distinction.
       assert.ok(!/owns Goal (activation|control)/.test(text), text);
     });
+
+    for (const reason of [
+      'turn_not_registered',
+      'coordinator_disposed',
+      'goal_not_observed',
+    ] as const) {
+      test(`${name} does not prescribe a retry it cannot satisfy (${reason})`, async () => {
+        const text = await refusal(name, seed, args, reason);
+
+        assertNoHostInternals(text);
+        // The whole point. These causes are settled facts about this turn, so
+        // a re-read tells the model nothing new and the same call returns the
+        // same refusal. Asking for either builds an unbounded loop.
+        assert.ok(
+          text.includes('Do not call this tool again in this turn'),
+          `must say the retry is pointless: ${text}`,
+        );
+        assert.ok(
+          !new RegExp(`call ${name} again`, 'i').test(text),
+          `must not ask for the call that cannot succeed: ${text}`,
+        );
+        assert.ok(
+          !text.includes(GOAL_STATUS_TOOL_NAME),
+          `must not send the model to read state that cannot change the outcome: ${text}`,
+        );
+      });
+    }
   }
+
+  test('a turn that already armed a goal is told so, and reading it is still useful', async () => {
+    // The one permanent cause where GoalStatus does tell the model something
+    // it does not know: the goal it is asking about exists, and it set it.
+    const text = await refusal(
+      GOAL_SET_TOOL_NAME,
+      undefined,
+      { condition: 'x' },
+      'goal_already_armed',
+    );
+
+    assert.ok(/already armed a goal/.test(text), text);
+    assert.ok(text.includes(GOAL_STATUS_TOOL_NAME), text);
+    assert.ok(!/call GoalSet again/i.test(text), text);
+  });
 });
 
 describe('E3 — an internal filesystem mismatch does not read as an argument complaint', () => {
   async function refuseWith(name: string, args: unknown): Promise<string> {
     const cwd = await workspace();
     const tools = buildBuiltinTools({
-      // Answer every request with a result of the wrong kind, which is the
-      // exact condition the old "Filesystem worker returned a mismatched X
-      // result." message described.
-      filesystemWorker: { execute: async () => ({ kind: 'glob', files: [] }) } as never,
+      // Answer every request with a well-formed result of some other
+      // operation, which is the exact condition this branch exists for. Keyed
+      // off the request so a Glob request does not get a Glob answer back.
+      filesystemWorker: {
+        execute: async ({ operation }: { operation: { kind: string } }) =>
+          operation.kind === 'glob' ? { kind: 'grep', matches: [] } : { kind: 'glob', files: [] },
+      } as never,
     });
     const tool = tools.find((candidate) => candidate.name === name)!;
     return await refusalOf(() =>
@@ -250,7 +322,7 @@ describe('E3 — an internal filesystem mismatch does not read as an argument co
     );
   }
 
-  test('Edit says the file is unchanged and that old_string is not the problem', async () => {
+  test('Edit does not claim the file is unchanged, and rules out the old_string retry', async () => {
     const text = await refuseWith('Edit', {
       path: 'a.txt',
       old_string: 'x',
@@ -258,16 +330,36 @@ describe('E3 — an internal filesystem mismatch does not read as an argument co
     });
     assertNoHostInternals(text);
     assert.ok(text.includes('Edit'), text);
-    assert.ok(/unchanged/.test(text), text);
+    // The branch fires on a mislabelled success. Real failures throw, so this
+    // code has no idea whether the edit landed, and saying it did not is a
+    // claim about a file nothing here looked at.
+    assert.ok(/cannot tell whether/.test(text), `must not assert disk state: ${text}`);
+    assert.ok(!/the file is unchanged/.test(text), `must not assert disk state: ${text}`);
     assert.ok(text.includes('old_string'), `must rule out the old_string retry: ${text}`);
-    assert.ok(text.includes('Bash'), `must offer a way out: ${text}`);
+    assert.ok(/Read the file/.test(text), `must send the model to look: ${text}`);
   });
 
-  test('Write says nothing was written and offers a way out', async () => {
+  test('Write does not claim nothing reached the disk', async () => {
     const text = await refuseWith('Write', { path: 'a.txt', content: 'x' });
     assertNoHostInternals(text);
-    assert.ok(/nothing was written/.test(text), text);
-    assert.ok(text.includes('Bash'), text);
+    assert.ok(/cannot tell whether the file was written/.test(text), text);
+    assert.ok(!/nothing was written/.test(text), `must not assert disk state: ${text}`);
+    assert.ok(/unknown state/.test(text), text);
+  });
+
+  test('a failed search does not read as a search that found nothing', async () => {
+    // "Grep could not be completed inside Maka, so no matches were produced"
+    // reads as a successful empty search, and a model that takes it that way
+    // concludes the pattern is absent from the repository.
+    const grep = await refuseWith('Grep', { pattern: 'needle' });
+    assertNoHostInternals(grep);
+    assert.ok(!/no matches were produced/.test(grep), `must not read as an empty result: ${grep}`);
+    assert.ok(/does not mean the pattern is absent/.test(grep), grep);
+    assert.ok(grep.includes('Bash'), `must offer a way out: ${grep}`);
+
+    const glob = await refuseWith('Glob', { pattern: '**/*.ts' });
+    assertNoHostInternals(glob);
+    assert.ok(/does not mean no files match/.test(glob), glob);
   });
 });
 
@@ -305,7 +397,12 @@ describe('E5 — background task refs and capacity', () => {
         abortSignal: NO_ABORT,
       } as never),
     );
+    // The counters are manager-wide and StopBackgroundTask takes a
+    // session-scoped ref, so the session that hits the cap may own none of the
+    // runs holding it. The sentence may offer that move, but not promise it.
     assert.ok(text.includes('StopBackgroundTask'), text);
+    assert.ok(/shared across sessions/.test(text), `must not promise an unavailable move: ${text}`);
+    assert.ok(/wait for a running task to finish/.test(text), text);
   });
 
   test('a full PTY slot names StopBackgroundTask', async () => {
@@ -331,6 +428,7 @@ describe('E5 — background task refs and capacity', () => {
     );
     assert.ok(text.includes('StopBackgroundTask'), text);
     assert.ok(/PTY/.test(text), text);
+    assert.ok(/shared across sessions/.test(text), text);
   });
 });
 

--- a/packages/runtime/src/__tests__/non-cu-tool-refusal-text.test.ts
+++ b/packages/runtime/src/__tests__/non-cu-tool-refusal-text.test.ts
@@ -21,6 +21,7 @@ import {
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,
+  buildChildAgentTools,
   buildSubagentOutputTool,
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
@@ -30,6 +31,7 @@ import { buildAskUserQuestionTool } from '../ask-user-question-tool.js';
 import { buildRequestSandboxBoundaryTool } from '../sandbox-boundary-tool.js';
 import { buildGoalTools, GOAL_SET_TOOL_NAME, GOAL_STATUS_TOOL_NAME } from '../goal-tools.js';
 import type { GoalControlDecline } from '../goal-continuation.js';
+import { GoalContinuationCoordinator } from '../goal-continuation.js';
 import { GoalManager } from '../goal-state.js';
 import { ShellRunProcessManager } from '../shell-run-manager.js';
 import type { MakaTool, MakaToolContext } from '../tool-runtime.js';
@@ -62,10 +64,14 @@ function ctx(extra: Partial<MakaToolContext> = {}): MakaToolContext {
 }
 
 async function refusalOf(run: () => unknown | Promise<unknown>): Promise<string> {
+  return (await errorOf(run)).message;
+}
+
+async function errorOf(run: () => unknown | Promise<unknown>): Promise<Error> {
   try {
     await run();
   } catch (error) {
-    return error instanceof Error ? error.message : String(error);
+    return error instanceof Error ? error : new Error(String(error));
   }
   throw new Error('expected the call to be refused');
 }
@@ -158,6 +164,92 @@ describe('E1 — capability-missing refusals name the tool and a fallback', () =
       ),
     );
     assertActionable(text, AGENT_SWARM_TOOL_NAME, ['resume_run_ids']);
+  });
+
+  test('agent_swarm resume does not point at new items when new items are gone too', async () => {
+    // The shape ToolRuntime actually produces. `buildChildAgentContext`
+    // returns `{}` wholesale when `getCurrentRunId()` is falsy, so spawn and
+    // resume leave together; "drop resume_run_ids and send that work as new
+    // items instead" then walks the model into the spawn refusal, which tells
+    // it retrying fails the same way. Following the advice is the assertion.
+    const tool = buildAgentSwarmTool();
+    const context = ctx();
+    assert.equal(context.spawnChildSession, undefined, 'this test needs the no-capability shape');
+
+    const text = await refusalOf(() => tool.impl({ resume_run_ids: ['run-1'] } as never, context));
+    assertNoHostInternals(text);
+    assert.ok(
+      !/Drop resume_run_ids and send that work as new items/.test(text),
+      `must not prescribe a move this context cannot make: ${text}`,
+    );
+    assert.ok(/do it yourself with the tools you already have/.test(text), text);
+
+    const followed = await refusalOf(() =>
+      tool.impl(
+        {
+          items: [
+            {
+              item_id: 'item-0',
+              profile: 'local_read',
+              task: 'task-0',
+              write_back: 'summary',
+              isolation: 'same_workspace',
+            },
+          ],
+        },
+        context,
+      ),
+    );
+    assert.ok(
+      /Retrying agent_swarm will fail the same way/.test(followed),
+      `the prescribed move really is a dead end here: ${followed}`,
+    );
+  });
+
+  test('the missing host callback still reaches an operator', async () => {
+    // Three distinct failures used to be three distinct sentences naming the
+    // callback. The sentences merged into model-facing advice; the callback
+    // name has to keep travelling, or a log cannot tell them apart.
+    const tool = buildAgentSwarmTool();
+    const spawn = await errorOf(() =>
+      tool.impl(
+        {
+          items: [
+            {
+              item_id: 'item-0',
+              profile: 'local_read',
+              task: 'task-0',
+              write_back: 'summary',
+              isolation: 'same_workspace',
+            },
+          ],
+        },
+        ctx(),
+      ),
+    );
+    assert.equal(
+      (spawn.cause as Error | undefined)?.message,
+      'spawnChildSession capability is unavailable in this runtime context',
+    );
+
+    const resume = await errorOf(() =>
+      tool.impl(
+        { resume_run_ids: ['run-1'] } as never,
+        ctx({ spawnChildSession: (async () => ({})) as never }),
+      ),
+    );
+    assert.equal(
+      (resume.cause as Error | undefined)?.message,
+      'Child AgentRun resume capability is unavailable in this runtime context',
+    );
+
+    const spawned = await errorOf(() =>
+      buildSubagentSpawnTool().impl({ profile: 'local_read', task: 'look' }, ctx()),
+    );
+    assert.equal(
+      (spawned.cause as Error | undefined)?.message,
+      'spawnChildSession capability is unavailable in this runtime context',
+    );
   });
 
   // ToolRuntime injects `askUserQuestion` and `requestSandboxBoundary`
@@ -283,8 +375,10 @@ describe('E2 — goal turn-ownership refusals', () => {
   }
 
   test('a turn that is already bound to a goal is told so, and reading it is still useful', async () => {
-    // The one permanent cause where GoalStatus does tell the model something
-    // it does not know: a goal exists and this turn is bound to it.
+    // GoalStatus does tell the model something it does not know here — that a
+    // goal exists and this turn is bound to it — so it is still offered. It is
+    // offered as the last step, not as a way back to GoalSet, because the
+    // binding cannot be undone within the turn (see E2b).
     const text = await refusal(
       GOAL_SET_TOOL_NAME,
       undefined,
@@ -294,7 +388,7 @@ describe('E2 — goal turn-ownership refusals', () => {
 
     assert.ok(/already bound to a goal/.test(text), text);
     assert.ok(text.includes(GOAL_STATUS_TOOL_NAME), text);
-    assert.ok(!/call GoalSet again/i.test(text), text);
+    assert.ok(/do not call GoalSet again in this turn/.test(text), text);
   });
 
   test('GoalResume is not told it tried to arm a second goal', async () => {
@@ -355,6 +449,105 @@ describe('E2 — goal turn-ownership refusals', () => {
       assert.ok(!/^Goal authority is unavailable\.$/.test(text), `${name}: ${text}`);
       assert.ok(!text.includes(GOAL_STATUS_TOOL_NAME), `${name}: ${text}`);
     }
+  });
+});
+
+/**
+ * The seam E2 cannot reach.
+ *
+ * E2 hands `buildGoalTools` a stub whose `activationStanding` returns a chosen
+ * cause, which settles what the sentence says about a cause but not whether
+ * that cause can be got out of. Only the real coordinator knows that, because
+ * the answer lives in when `observedControlLease` is rewritten — once at
+ * `beginObservedTurn`, and after that only by a mutation that succeeded.
+ *
+ * So these drive `GoalContinuationCoordinator` and `GoalManager` themselves,
+ * take the refusal the model would read, and then do what a model that believed
+ * it would do.
+ */
+describe('E2b — the goal refusals that a real coordinator produces are read to the end', () => {
+  function realGoalTools() {
+    let id = 0;
+    const goalManager = new GoalManager({ generateId: () => `g-${++id}`, now: () => 1000 });
+    const coordinator = new GoalContinuationCoordinator({
+      goalManager,
+      evaluator: { evaluate: async () => '{}', close: async () => {} },
+      getRecentContext: async () => 'recent context',
+      admitTurn: () => ({ kind: 'unavailable', reason: 'not in this test' }),
+      scheduler: { setTimeout: () => 0, clearTimeout: () => {} },
+    } as never);
+    const tools = buildGoalTools({ goalManager, goalContinuation: coordinator, now: () => 1000 });
+    return {
+      coordinator,
+      call: (name: string, turnId: string, args: Record<string, unknown> = {}) =>
+        String(
+          tools.find((candidate) => candidate.name === name)!.impl(args as never, ctx({ turnId })),
+        ),
+    };
+  }
+
+  test('goal_changed does not invite a GoalSet that declines forever', () => {
+    const { coordinator, call } = realGoalTools();
+    // One turn registers before any goal exists; a second arms one and clears
+    // it. The lease has moved on, nothing is active, and the first turn is now
+    // past the "unfinished goal is active" guard and into the gate.
+    coordinator.beginObservedTurn('session-1', 'turn-a');
+    coordinator.beginObservedTurn('session-1', 'turn-b');
+    call(GOAL_SET_TOOL_NAME, 'turn-b', { condition: 'someone else' });
+    call('GoalClear', 'turn-b');
+    assert.equal(
+      (coordinator.activationStanding('session-1', 'turn-a') as { reason?: string }).reason,
+      'goal_changed',
+      'the scenario must really produce goal_changed',
+    );
+
+    const first = call(GOAL_SET_TOOL_NAME, 'turn-a', { condition: 'mine' });
+    assertNoHostInternals(first);
+    // Reading is still worth doing, and is still offered.
+    assert.ok(first.includes(GOAL_STATUS_TOOL_NAME), first);
+
+    // The whole finding: a model that does what the sentence says next must not
+    // arrive back at this call. `mutateGoal` is what refreshes the observed
+    // lease, and every mutation this turn can reach declines too, so nothing
+    // the model calls changes the answer.
+    assert.ok(
+      /do not call GoalSet again in this turn/.test(first),
+      `goal_changed is permanent within the turn and must say so: ${first}`,
+    );
+    assert.equal(call(GOAL_SET_TOOL_NAME, 'turn-a', { condition: 'mine' }), first);
+    call('GoalClear', 'turn-a');
+    assert.equal(
+      call(GOAL_SET_TOOL_NAME, 'turn-a', { condition: 'mine' }),
+      first,
+      'no call available to this turn can change the refusal',
+    );
+  });
+
+  test('the GoalSet arm of goal_already_armed does not invite a retry either', () => {
+    const { coordinator, call } = realGoalTools();
+    // Reachable from GoalSet only once the armed goal has left `active` —
+    // otherwise the "unfinished goal is active" guard answers first. A later
+    // turn clears it, which leaves turn-a holding a controlLease it cannot
+    // release: releasing it needs a mutation, and the moved lease declines
+    // every mutation this turn makes.
+    coordinator.beginObservedTurn('session-1', 'turn-a');
+    call(GOAL_SET_TOOL_NAME, 'turn-a', { condition: 'mine' });
+    coordinator.beginObservedTurn('session-1', 'turn-c');
+    call('GoalClear', 'turn-c');
+    assert.equal(
+      (coordinator.activationStanding('session-1', 'turn-a') as { reason?: string }).reason,
+      'goal_already_armed',
+    );
+
+    const first = call(GOAL_SET_TOOL_NAME, 'turn-a', { condition: 'again' });
+    assertNoHostInternals(first);
+    assert.ok(/already bound to a goal/.test(first), first);
+    assert.ok(
+      /do not call GoalSet again in this turn/.test(first),
+      `goal_already_armed is permanent within the turn and must say so: ${first}`,
+    );
+    call('GoalClear', 'turn-a');
+    assert.equal(call(GOAL_SET_TOOL_NAME, 'turn-a', { condition: 'again' }), first);
   });
 });
 
@@ -448,6 +641,25 @@ describe('E3 — an internal filesystem mismatch does not read as an argument co
     assert.ok(/does not mean no files match/.test(glob), glob);
   });
 
+  test('every one of them says whose fault it is not', async () => {
+    // The sentence that keeps a model from "fixing" arguments that were fine.
+    // Nothing asserted it, so it could have been dropped from all five
+    // messages without turning a test red.
+    for (const [name, args] of [
+      ['Grep', { pattern: 'needle' }],
+      ['Glob', { pattern: '**/*.ts' }],
+      ['Read', { path: 'a.txt' }],
+      ['Write', { path: 'a.txt', content: 'x' }],
+      ['Edit', { path: 'a.txt', old_string: 'x', new_string: 'y' }],
+    ] as const) {
+      const text = await refuseWith(name, args);
+      assert.ok(
+        text.includes('This is an internal failure, not a problem with your arguments'),
+        `${name} must not read as an argument complaint: ${text}`,
+      );
+    }
+  });
+
   test('the worker-protocol violation still reaches an operator', async () => {
     // The model-facing sentence cannot name the worker, but an operator reading
     // a log needs to know this was a mismatched result and not, say, a missing
@@ -475,11 +687,22 @@ describe('E5 — background task refs and capacity', () => {
       newId: () => 'shell-run-1',
       now: () => 1,
     });
-    const text = await refusalOf(() =>
+    const error = await errorOf(() =>
       manager.stopBackgroundTask('session-1', 'task-3-secret-value', NO_ABORT),
     );
-    assert.ok(text.includes('maka://runtime/background-tasks/<id>'), text);
-    assert.ok(!text.includes('task-3-secret-value'), `must not echo the rejected ref: ${text}`);
+    assert.ok(error.message.includes('maka://runtime/background-tasks/<id>'), error.message);
+    assert.ok(
+      !error.message.includes('task-3-secret-value'),
+      `must not echo the rejected ref: ${error.message}`,
+    );
+    // The ref itself is the only thing that distinguishes this failure from the
+    // other two call sites in a log, so it travels as the cause rather than
+    // being dropped — the same split `builtin-tools.ts` uses.
+    assert.ok(error.cause instanceof Error, 'the rejected ref must still reach an operator');
+    assert.equal(
+      (error.cause as Error).message,
+      'Unsupported runtime background task ref: task-3-secret-value',
+    );
   });
 
   test('the Read({ref}) path gets the canonical form too', async () => {
@@ -503,7 +726,43 @@ describe('E5 — background task refs and capacity', () => {
     assert.ok(!text.includes('task-3-secret-value'), `must not echo the rejected ref: ${text}`);
   });
 
-  test('a full shell slot names StopBackgroundTask', async () => {
+  /**
+   * The seam the earlier version of these tests could not see.
+   *
+   * A refusal is read by whichever agent made the call, and `Bash` is on the
+   * `implementation` child list, so a child agent reaches the manager-wide cap
+   * exactly like a parent does. `buildToolsForAgentDefinition` is a strict name
+   * allowlist, so the child's schema is decided here and nowhere else. Asserting
+   * against a hand-written list of names would restate the message; asking the
+   * real builder which names a child never receives is what catches the next
+   * refusal that reaches for one.
+   */
+  const parentTools = buildBuiltinTools({
+    backgroundTasks: { stopBackgroundTask: async () => ({}) } as never,
+    ptyControls: { writeStdin: async () => ({}) } as never,
+  });
+  const childToolNames = new Set(buildChildAgentTools(parentTools).map((tool) => tool.name));
+  const parentOnlyToolNames = parentTools
+    .map((tool) => tool.name)
+    .filter((name) => !childToolNames.has(name));
+
+  function assertNamesNoToolAChildLacks(text: string): void {
+    // Guards the guard: if `Bash` ever leaves the child lists, a child can no
+    // longer reach this refusal and the assertion below stops meaning anything.
+    assert.ok(childToolNames.has('Bash'), 'a child agent must still be able to run Bash');
+    assert.ok(
+      parentOnlyToolNames.includes('StopBackgroundTask'),
+      'StopBackgroundTask must still be a parent-only tool for this test to bite',
+    );
+    for (const name of parentOnlyToolNames) {
+      assert.ok(
+        !text.includes(name),
+        `refusal names ${name}, which no child agent receives: ${text}`,
+      );
+    }
+  }
+
+  test('a full shell slot does not send the caller to a tool it may not have', async () => {
     const cwd = await workspace();
     const manager = new ShellRunProcessManager({
       store: createSqliteShellRunStore(cwd),
@@ -523,15 +782,14 @@ describe('E5 — background task refs and capacity', () => {
         abortSignal: NO_ABORT,
       } as never),
     );
-    // The counters are manager-wide and StopBackgroundTask takes a
-    // session-scoped ref, so the session that hits the cap may own none of the
-    // runs holding it. The sentence may offer that move, but not promise it.
-    assert.ok(text.includes('StopBackgroundTask'), text);
+    assertNamesNoToolAChildLacks(text);
+    // The counters are manager-wide, so the session that hits the cap may own
+    // none of the runs holding it: the move that always exists is waiting.
     assert.ok(/shared across sessions/.test(text), `must not promise an unavailable move: ${text}`);
-    assert.ok(/wait for a running task to finish/.test(text), text);
+    assert.ok(/Wait for a running background task to finish/.test(text), text);
   });
 
-  test('a full PTY slot names StopBackgroundTask', async () => {
+  test('a full PTY slot does not send the caller to a tool it may not have', async () => {
     const cwd = await workspace();
     const manager = new ShellRunProcessManager({
       store: createSqliteShellRunStore(cwd),
@@ -552,9 +810,13 @@ describe('E5 — background task refs and capacity', () => {
         abortSignal: NO_ABORT,
       } as never),
     );
-    assert.ok(text.includes('StopBackgroundTask'), text);
+    assertNamesNoToolAChildLacks(text);
     assert.ok(/PTY/.test(text), text);
     assert.ok(/shared across sessions/.test(text), text);
+    // The one move that is both available and immediate: the same command
+    // without `pty`, which the caller reaches by dropping a parameter it
+    // already knows about rather than by finding a tool.
+    assert.ok(/non-interactive background task/.test(text), text);
   });
 });
 

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -1104,7 +1104,12 @@ describe('ShellRunProcessManager', () => {
           'maka://runtime/background-tasks/%2Funsafe',
           NO_ABORT,
         ),
-      /Unsupported runtime resource ref/,
+      // Same reply as the other two ref-parse sites: the canonical form and
+      // where to get it, and no echo of the rejected string.
+      (error: unknown) =>
+        error instanceof Error &&
+        /maka:\/\/runtime\/background-tasks\/<id>/.test(error.message) &&
+        !error.message.includes('%2Funsafe'),
     );
   });
 

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -2132,7 +2132,8 @@ describe('ShellRunProcessManager', () => {
               pty: true,
             }),
           ),
-        /Live PTY capacity is full \(1\)/,
+        // Names the tool that frees a slot, which the old wording did not.
+        /No free interactive \(PTY\) background task slot: 1 are already running.*StopBackgroundTask/s,
       );
 
       const pipeRun = await manager.runBackgroundBash(
@@ -2153,7 +2154,7 @@ describe('ShellRunProcessManager', () => {
               command: waitForeverCommand(),
             }),
           ),
-        /Live background task capacity is full \(2\)/,
+        /No free background task slot: 2 are already running.*StopBackgroundTask/s,
       );
 
       await manager.stopBackgroundTask('session-1', ptyRun.ref, NO_ABORT);

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -2132,8 +2132,11 @@ describe('ShellRunProcessManager', () => {
               pty: true,
             }),
           ),
-        // Names the tool that frees a slot, which the old wording did not.
-        /No free interactive \(PTY\) background task slot: 1 are already running.*StopBackgroundTask/s,
+        // Names the tool that frees a slot, which the old wording did not —
+        // and offers it as a condition rather than a promise, because the
+        // counter is manager-wide while StopBackgroundTask takes a
+        // session-scoped ref.
+        /No free interactive \(PTY\) background task slot: the runtime is at its limit of 1 .*StopBackgroundTask if you started any, or wait for a running task to finish/s,
       );
 
       const pipeRun = await manager.runBackgroundBash(
@@ -2154,7 +2157,7 @@ describe('ShellRunProcessManager', () => {
               command: waitForeverCommand(),
             }),
           ),
-        /No free background task slot: 2 are already running.*StopBackgroundTask/s,
+        /No free background task slot: the runtime is at its limit of 2 .*StopBackgroundTask if you started any, or wait for a running task to finish/s,
       );
 
       await manager.stopBackgroundTask('session-1', ptyRun.ref, NO_ABORT);

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -2137,11 +2137,12 @@ describe('ShellRunProcessManager', () => {
               pty: true,
             }),
           ),
-        // Names the tool that frees a slot, which the old wording did not —
-        // and offers it as a condition rather than a promise, because the
-        // counter is manager-wide while StopBackgroundTask takes a
-        // session-scoped ref.
-        /No free interactive \(PTY\) background task slot: the runtime is at its limit of 1 .*StopBackgroundTask if you started any, or wait for a running task to finish/s,
+        // Names no tool at all. The counters are manager-wide, and the caller
+        // that most often hits this cap is a child agent, whose tool list is a
+        // strict allowlist that carries Bash but not StopBackgroundTask. The
+        // sentence describes the move instead; `non-cu-tool-refusal-text.test`
+        // asserts that against the real child tool set.
+        /No free interactive \(PTY\) background task slot: the runtime is at its limit of 1 .*Run this command as a non-interactive background task/s,
       );
 
       const pipeRun = await manager.runBackgroundBash(
@@ -2162,7 +2163,7 @@ describe('ShellRunProcessManager', () => {
               command: waitForeverCommand(),
             }),
           ),
-        /No free background task slot: the runtime is at its limit of 2 .*StopBackgroundTask if you started any, or wait for a running task to finish/s,
+        /No free background task slot: the runtime is at its limit of 2 .*Wait for a running background task to finish and try again/s,
       );
 
       await manager.stopBackgroundTask('session-1', ptyRun.ref, NO_ABORT);

--- a/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sandbox-boundary.test.ts
@@ -17,7 +17,10 @@ import type {
 } from '@maka/core/backend-types';
 import type { SandboxBoundaryRequestEvent } from '@maka/core/events';
 
-import { buildRequestSandboxBoundaryTool } from '../sandbox-boundary-tool.js';
+import {
+  buildRequestSandboxBoundaryTool,
+  SANDBOX_BOUNDARY_UNAVAILABLE,
+} from '../sandbox-boundary-tool.js';
 import { FilesystemWorkerClientError } from '../filesystem-worker/client.js';
 import { SandboxCommandError } from '../sandbox/errors.js';
 import { ToolRuntime, type MakaTool, type ToolRuntimeInput } from '../tool-runtime.js';
@@ -725,6 +728,48 @@ describe('ToolRuntime session sandbox boundary', () => {
       kind: 'text',
       text: 'Command sandbox failed: requires_bypass.',
       sandboxFailure: { reason: 'requires_bypass' },
+    });
+  });
+
+  test('a surface without boundary storage refuses with the same sentence the tool carries', async () => {
+    // The tool's own guard on `context.requestSandboxBoundary` cannot fire
+    // here: ToolRuntime injects that callback unconditionally. This is the
+    // branch a model actually reaches, and it used to say something different
+    // from the tool the model called.
+    const runtime = new ToolRuntime({
+      sessionId: 'session-1',
+      header: header(),
+      connection: { providerType: 'openai', slug: 'test' } as never,
+      modelId: 'test',
+      appendMessage: async () => {},
+      readExecutionBoundary: async () => ({
+        kind: 'managed',
+        profile: createWorkspaceWritePermissionProfile(),
+        revision: 0,
+      }),
+      newId: nextId(),
+      now: () => 1,
+      getPermissionPauseTarget: () => null,
+    });
+
+    const settlement = await runtime.settleToolCall({
+      tool: buildRequestSandboxBoundaryTool() as unknown as MakaTool,
+      turnId: 'turn-1',
+      toolCallId: 'call-boundary-unavailable',
+      input: {
+        expansion: { kind: 'path', path: join(process.cwd(), 'x'), access: 'write' },
+        justification: 'need it',
+      },
+      abortSignal: new AbortController().signal,
+      eventSink: {
+        push: () => {},
+        pushAndWaitUntilConsumed: async () => {},
+      },
+    });
+
+    assert.deepEqual(settlement.modelOutput, {
+      type: 'error-text',
+      value: `Error: ${SANDBOX_BOUNDARY_UNAVAILABLE}`,
     });
   });
 });

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -246,7 +246,15 @@ export function buildAgentSwarmTool(
                     onEvent: (event) => progressProjectors[index]!.observe(event),
                   })) as SpawnChildAgentResult)
                 : (() => {
-                    throw new Error('retryChildAgent capability is unavailable');
+                    // Defensive: the scheduler only asks for a retry when the
+                    // retry capability is present (see the `rate_limited`
+                    // branch below), so this cannot fire from a swarm run
+                    // today. It still has to be a sentence a model can act on
+                    // rather than the name of a missing host callback.
+                    throw new Error(
+                      'agent_swarm cannot retry a failed child run in this session. ' +
+                        'The item was not retried; send it again as a new item instead.',
+                    );
                   })()
               : item.mode === 'resume'
                 ? ((await ctx.resumeChildAgent!({

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -47,6 +47,47 @@ const AGENT_SWARM_ISOLATION_MODES = [
 const AGENT_SWARM_TASK_MAX_CHARS = 60_000;
 const AGENT_SWARM_ERROR_MAX_CHARS = 1_000;
 
+/**
+ * The two capability refusals `agent_swarm` can raise before anything runs.
+ *
+ * Both are thrown from two places — the preflight in `prepareAgentSwarmInput`
+ * and the guard in `impl` — so they are built here once. The model reads the
+ * message; an operator reads the `cause`, which still names the host callback
+ * that was missing. Collapsing the two failures into one indistinguishable
+ * sentence would have cost the log the only thing it had.
+ *
+ * The resume advice has to ask whether spawning is available before it
+ * prescribes it. `ToolRuntime.buildChildAgentContext` returns `{}` wholesale
+ * when `getCurrentRunId()` is falsy, so in the runtime that ships, spawn and
+ * resume disappear together: "drop resume_run_ids and send that work as new
+ * items instead" would then walk the model straight into the spawn refusal,
+ * which tells it that retrying fails the same way. An embedder that assembles
+ * its own context can supply one without the other, so the branch is a real
+ * question about state, not a constant — it is asked, not assumed.
+ */
+const AGENT_SWARM_NO_SPAWN =
+  'agent_swarm cannot start new child agents in this session, so nothing ran. ' +
+  'Retrying agent_swarm will fail the same way — do the items yourself with the tools you already have.';
+
+function agentSwarmSpawnUnavailable(): Error {
+  return new Error(AGENT_SWARM_NO_SPAWN, {
+    cause: new Error('spawnChildSession capability is unavailable in this runtime context'),
+  });
+}
+
+function agentSwarmResumeUnavailable(ctx: Pick<MakaToolContext, 'spawnChildSession'>): Error {
+  return new Error(
+    'agent_swarm cannot resume earlier child runs in this session, so nothing ran. ' +
+      (ctx.spawnChildSession
+        ? 'Drop resume_run_ids and send that work as new items instead.'
+        : 'This session cannot start new child agents either, so sending that work as new items ' +
+          'will fail the same way — do it yourself with the tools you already have.'),
+    {
+      cause: new Error('Child AgentRun resume capability is unavailable in this runtime context'),
+    },
+  );
+}
+
 export interface AgentSwarmExplicitItemInput {
   item_id: string;
   profile?: string;
@@ -143,19 +184,13 @@ export function buildAgentSwarmTool(
     impl: async (input, ctx) => {
       const prepared = await prepareAgentSwarmInput(input, ctx, definitions);
       if (prepared.items.some((item) => item.mode === 'spawn') && !ctx.spawnChildSession) {
-        throw new Error(
-          'agent_swarm cannot start new child agents in this session, so nothing ran. ' +
-            'Retrying agent_swarm will fail the same way — do the items yourself with the tools you already have.',
-        );
+        throw agentSwarmSpawnUnavailable();
       }
       if (
         prepared.items.some((item) => item.mode === 'resume') &&
         (!ctx.prepareChildAgentResume || !ctx.resumeChildAgent)
       ) {
-        throw new Error(
-          'agent_swarm cannot resume earlier child runs in this session, so nothing ran. ' +
-            'Drop resume_run_ids and send that work as new items instead.',
-        );
+        throw agentSwarmResumeUnavailable(ctx);
       }
 
       const startedAt = now();
@@ -254,6 +289,7 @@ export function buildAgentSwarmTool(
                     throw new Error(
                       'agent_swarm cannot retry a failed child run in this session. ' +
                         'The item was not retried; send it again as a new item instead.',
+                      { cause: new Error('retryChildAgent capability is unavailable') },
                     );
                   })()
               : item.mode === 'resume'
@@ -681,16 +717,10 @@ async function prepareAgentSwarmInput(
   const presetProfiles = await readAvailablePresetProfiles(input, ctx);
   const preflight = preflightAgentSwarmInput(input, definitions, presetProfiles);
   if (preflight.items.length > 0 && !ctx.spawnChildSession) {
-    throw new Error(
-      'agent_swarm cannot start new child agents in this session, so nothing ran. ' +
-        'Retrying agent_swarm will fail the same way — do the items yourself with the tools you already have.',
-    );
+    throw agentSwarmSpawnUnavailable();
   }
   if (preflight.resumes.length > 0 && (!ctx.prepareChildAgentResume || !ctx.resumeChildAgent)) {
-    throw new Error(
-      'agent_swarm cannot resume earlier child runs in this session, so nothing ran. ' +
-        'Drop resume_run_ids and send that work as new items instead.',
-    );
+    throw agentSwarmResumeUnavailable(ctx);
   }
   const resumes = await Promise.all(
     preflight.resumes.map(async (item): Promise<PreparedAgentSwarmItem> => {

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -143,13 +143,19 @@ export function buildAgentSwarmTool(
     impl: async (input, ctx) => {
       const prepared = await prepareAgentSwarmInput(input, ctx, definitions);
       if (prepared.items.some((item) => item.mode === 'spawn') && !ctx.spawnChildSession) {
-        throw new Error('spawnChildSession capability is unavailable in this runtime context');
+        throw new Error(
+          'agent_swarm cannot start new child agents in this session, so nothing ran. ' +
+            'Retrying agent_swarm will fail the same way — do the items yourself with the tools you already have.',
+        );
       }
       if (
         prepared.items.some((item) => item.mode === 'resume') &&
         (!ctx.prepareChildAgentResume || !ctx.resumeChildAgent)
       ) {
-        throw new Error('Child AgentRun resume capability is unavailable in this runtime context');
+        throw new Error(
+          'agent_swarm cannot resume earlier child runs in this session, so nothing ran. ' +
+            'Drop resume_run_ids and send that work as new items instead.',
+        );
       }
 
       const startedAt = now();
@@ -667,10 +673,16 @@ async function prepareAgentSwarmInput(
   const presetProfiles = await readAvailablePresetProfiles(input, ctx);
   const preflight = preflightAgentSwarmInput(input, definitions, presetProfiles);
   if (preflight.items.length > 0 && !ctx.spawnChildSession) {
-    throw new Error('spawnChildSession capability is unavailable in this runtime context');
+    throw new Error(
+      'agent_swarm cannot start new child agents in this session, so nothing ran. ' +
+        'Retrying agent_swarm will fail the same way — do the items yourself with the tools you already have.',
+    );
   }
   if (preflight.resumes.length > 0 && (!ctx.prepareChildAgentResume || !ctx.resumeChildAgent)) {
-    throw new Error('Child AgentRun resume capability is unavailable in this runtime context');
+    throw new Error(
+      'agent_swarm cannot resume earlier child runs in this session, so nothing ran. ' +
+        'Drop resume_run_ids and send that work as new items instead.',
+    );
   }
   const resumes = await Promise.all(
     preflight.resumes.map(async (item): Promise<PreparedAgentSwarmItem> => {

--- a/packages/runtime/src/ask-user-question-tool.ts
+++ b/packages/runtime/src/ask-user-question-tool.ts
@@ -25,6 +25,11 @@ export function buildAskUserQuestionTool(): MakaTool<
       questions: z.array(questionSchema).min(1).max(3),
     }),
     impl: ({ questions }, context) => {
+      // Unreachable from any ToolRuntime-driven call: ToolRuntime injects
+      // `askUserQuestion` into every tool context unconditionally, so this
+      // guard answers only an embedder that assembles its own MakaToolContext.
+      // It is kept, and worded for a model, because that embedder exists and
+      // its caller is still a model.
       if (!context.askUserQuestion)
         throw new Error(
           'AskUserQuestion is not available on this surface, so the user was not asked anything. ' +

--- a/packages/runtime/src/ask-user-question-tool.ts
+++ b/packages/runtime/src/ask-user-question-tool.ts
@@ -26,7 +26,10 @@ export function buildAskUserQuestionTool(): MakaTool<
     }),
     impl: ({ questions }, context) => {
       if (!context.askUserQuestion)
-        throw new Error('AskUserQuestion is unavailable on this surface');
+        throw new Error(
+          'AskUserQuestion is not available on this surface, so the user was not asked anything. ' +
+            'Retrying will fail the same way — write the question and its options as ordinary reply text and wait for the user to answer.',
+        );
       return context.askUserQuestion(questions);
     },
   };

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -72,6 +72,22 @@ import {
 // watchdog is paused during tool execution.
 const GREP_TIMEOUT_MS = 120_000;
 
+/**
+ * The filesystem worker answered with a different operation's result than the
+ * one that was requested. Naming the worker told the model about an internal
+ * component it cannot address, and the wording read like an argument
+ * complaint — on Edit the likeliest reaction was another `old_string` guess,
+ * which can never fix this. Say what did not happen, that the arguments were
+ * not the cause, and what to do next.
+ */
+function internalFilesystemFailure(tool: string, unchanged: string, extra?: string): Error {
+  return new Error(
+    `${tool} could not be completed inside Maka, so ${unchanged}. ` +
+      `This is an internal failure, not a problem with your arguments${extra ? ` — ${extra}` : ''}. ` +
+      `Retry the same ${tool} call once; if it fails again, use Bash to do the same work.`,
+  );
+}
+
 export interface BuildBuiltinToolsOptions {
   shellRuns?: ShellRunLauncher;
   runtimeResources?: RuntimeResourceReader;
@@ -275,8 +291,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
             });
             return { kind: 'image' as const, mimeType: result.mimeType, ref };
           }
-          if (result.kind !== 'read')
-            throw new Error('Filesystem worker returned a mismatched Read result.');
+          if (result.kind !== 'read') throw internalFilesystemFailure('Read', 'nothing was read');
           return { content: result.content };
         }
         const { path: resolvedPath } = await executor.resolveExistingPath({
@@ -340,7 +355,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
               ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
             });
             if (result.kind !== 'write')
-              throw new Error('Filesystem worker returned a mismatched Write result.');
+              throw internalFilesystemFailure('Write', 'nothing was written to disk');
             return { ok: result.ok, path: result.path, bytes: result.bytes };
           }
           const { path: resolvedPath } = await executor.resolveWritablePath({
@@ -392,7 +407,11 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
               ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
             });
             if (result.kind !== 'edit')
-              throw new Error('Filesystem worker returned a mismatched Edit result.');
+              throw internalFilesystemFailure(
+                'Edit',
+                'the file is unchanged',
+                'a different old_string will not help',
+              );
             return {
               ok: result.ok,
               path: result.path,
@@ -465,7 +484,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
               ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
             });
             if (result.kind !== 'format_json') {
-              throw new Error('Filesystem worker returned a mismatched FormatJson result.');
+              throw internalFilesystemFailure('FormatJson', 'the file is unchanged');
             }
             return result;
           }
@@ -545,7 +564,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
             ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
           });
           if (result.kind !== 'glob')
-            throw new Error('Filesystem worker returned a mismatched Glob result.');
+            throw internalFilesystemFailure('Glob', 'no file list was produced');
           return { files: result.files };
         }
         const { path: base } = await executor.resolveExistingPath({
@@ -588,7 +607,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
             ...(abortSignal ? { abortSignal } : {}),
           });
           if (result.kind !== 'grep')
-            throw new Error('Filesystem worker returned a mismatched Grep result.');
+            throw internalFilesystemFailure('Grep', 'no matches were produced');
           return { matches: result.matches };
         }
         const { path: searchPath } = await executor.resolveExistingPath({

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -73,18 +73,42 @@ import {
 const GREP_TIMEOUT_MS = 120_000;
 
 /**
- * The filesystem worker answered with a different operation's result than the
- * one that was requested. Naming the worker told the model about an internal
- * component it cannot address, and the wording read like an argument
- * complaint — on Edit the likeliest reaction was another `old_string` guess,
- * which can never fix this. Say what did not happen, that the arguments were
- * not the cause, and what to do next.
+ * The filesystem worker answered with a well-formed result of a different
+ * operation than the one that was requested.
+ *
+ * Naming the worker told the model about an internal component it cannot
+ * address, and the original wording read like an argument complaint — on Edit
+ * the likeliest reaction was another `old_string` guess, which can never fix
+ * this. But the replacement has to be careful about two things it cannot say.
+ *
+ * It cannot say the write did not land. Real failures throw; this branch fires
+ * on a mislabelled success, and a mislabelled success is still a success as far
+ * as the disk is concerned. "Nothing was written to disk" is a claim about a
+ * file this code did not look at.
+ *
+ * And it cannot phrase a failed read as an empty one. "Grep could not be
+ * completed inside Maka, so no matches were produced" reads as a search that
+ * ran and found nothing, and a model that takes it that way concludes the
+ * pattern is absent from the repository — the opposite of what happened.
+ *
+ * So a read says no result came back, and says what that does not mean. A write
+ * says Maka cannot tell what happened to the file, and sends the model to look
+ * rather than to retry a call that may have already taken effect.
  */
-function internalFilesystemFailure(tool: string, unchanged: string, extra?: string): Error {
+function internalFilesystemReadFailure(tool: string, missing: string, notMeaning: string): Error {
   return new Error(
-    `${tool} could not be completed inside Maka, so ${unchanged}. ` +
-      `This is an internal failure, not a problem with your arguments${extra ? ` — ${extra}` : ''}. ` +
+    `${tool} could not be completed inside Maka, so ${missing}. ` +
+      `This is an internal failure, not a problem with your arguments, and it does not mean ${notMeaning}. ` +
       `Retry the same ${tool} call once; if it fails again, use Bash to do the same work.`,
+  );
+}
+
+function internalFilesystemWriteFailure(tool: string, subject: string, extra?: string): Error {
+  return new Error(
+    `${tool} could not be completed inside Maka. Maka cannot tell whether ${subject}, ` +
+      `so treat the file as being in an unknown state. ` +
+      `This is an internal failure, not a problem with your arguments${extra ? ` — ${extra}` : ''}. ` +
+      `Read the file to find out what it now contains before writing to it again.`,
   );
 }
 
@@ -291,7 +315,12 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
             });
             return { kind: 'image' as const, mimeType: result.mimeType, ref };
           }
-          if (result.kind !== 'read') throw internalFilesystemFailure('Read', 'nothing was read');
+          if (result.kind !== 'read')
+            throw internalFilesystemReadFailure(
+              'Read',
+              'no file content came back',
+              'the file is empty or missing',
+            );
           return { content: result.content };
         }
         const { path: resolvedPath } = await executor.resolveExistingPath({
@@ -355,7 +384,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
               ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
             });
             if (result.kind !== 'write')
-              throw internalFilesystemFailure('Write', 'nothing was written to disk');
+              throw internalFilesystemWriteFailure('Write', 'the file was written');
             return { ok: result.ok, path: result.path, bytes: result.bytes };
           }
           const { path: resolvedPath } = await executor.resolveWritablePath({
@@ -407,9 +436,9 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
               ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
             });
             if (result.kind !== 'edit')
-              throw internalFilesystemFailure(
+              throw internalFilesystemWriteFailure(
                 'Edit',
-                'the file is unchanged',
+                'the edit was applied',
                 'a different old_string will not help',
               );
             return {
@@ -484,7 +513,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
               ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
             });
             if (result.kind !== 'format_json') {
-              throw internalFilesystemFailure('FormatJson', 'the file is unchanged');
+              throw internalFilesystemWriteFailure('FormatJson', 'the file was rewritten');
             }
             return result;
           }
@@ -564,7 +593,11 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
             ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
           });
           if (result.kind !== 'glob')
-            throw internalFilesystemFailure('Glob', 'no file list was produced');
+            throw internalFilesystemReadFailure(
+              'Glob',
+              'no file list came back',
+              'no files match the pattern',
+            );
           return { files: result.files };
         }
         const { path: base } = await executor.resolveExistingPath({
@@ -607,7 +640,11 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
             ...(abortSignal ? { abortSignal } : {}),
           });
           if (result.kind !== 'grep')
-            throw internalFilesystemFailure('Grep', 'no matches were produced');
+            throw internalFilesystemReadFailure(
+              'Grep',
+              'no search result came back',
+              'the pattern is absent',
+            );
           return { matches: result.matches };
         }
         const { path: searchPath } = await executor.resolveExistingPath({

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -94,12 +94,29 @@ const GREP_TIMEOUT_MS = 120_000;
  * So a read says no result came back, and says what that does not mean. A write
  * says Maka cannot tell what happened to the file, and sends the model to look
  * rather than to retry a call that may have already taken effect.
+ *
+ * Neither may name Bash. Read, Glob and Grep are the entire tool set of a
+ * `local_read` child (`agent-catalog.ts`), and `buildToolsForAgentDefinition`
+ * hands that child those three tools and nothing else. "Use Bash to do the same
+ * work" is, for the caller most likely to be running a bare Grep, an
+ * instruction it cannot carry out — a dead end dressed as a way out. The
+ * fallback is therefore offered on a condition the model can check for itself,
+ * and the sentence ends on a move that is available to every caller.
+ *
+ * The worker-protocol violation itself still has to reach an operator, so it
+ * travels as the `cause`: out of the model's sight, in every log and stack.
  */
+function mismatchedWorkerResult(tool: string): Error {
+  return new Error(`Filesystem worker returned a mismatched ${tool} result.`);
+}
+
 function internalFilesystemReadFailure(tool: string, missing: string, notMeaning: string): Error {
   return new Error(
     `${tool} could not be completed inside Maka, so ${missing}. ` +
       `This is an internal failure, not a problem with your arguments, and it does not mean ${notMeaning}. ` +
-      `Retry the same ${tool} call once; if it fails again, use Bash to do the same work.`,
+      `Retry the same ${tool} call once. If it fails again, stop calling ${tool}: do the same ` +
+      `work with a shell tool if you have one, and otherwise report that ${tool} is failing inside Maka.`,
+    { cause: mismatchedWorkerResult(tool) },
   );
 }
 
@@ -109,6 +126,7 @@ function internalFilesystemWriteFailure(tool: string, subject: string, extra?: s
       `so treat the file as being in an unknown state. ` +
       `This is an internal failure, not a problem with your arguments${extra ? ` — ${extra}` : ''}. ` +
       `Read the file to find out what it now contains before writing to it again.`,
+    { cause: mismatchedWorkerResult(tool) },
   );
 }
 

--- a/packages/runtime/src/goal-continuation.ts
+++ b/packages/runtime/src/goal-continuation.ts
@@ -129,12 +129,17 @@ export type GoalObservedTurnStart =
  * turn that no later call within it can change, which is the distinction a
  * refusal has to carry: telling a caller to look again and retry is only honest
  * when looking again can produce a different answer.
+ *
+ * `goal_already_armed` is named for the common case, not the only one. A turn
+ * holds a control lease either because it armed a goal or because
+ * `beginObservedTurn` bound it to a goal that was already active — the second
+ * turn armed nothing, so the refusal built from this must not say it did.
  */
 export type GoalControlDecline =
   | /** This turn was never registered under a Goal boundary, or its registration is gone. */
   'turn_not_registered'
   | /** Goal continuation is shutting down. */ 'coordinator_disposed'
-  | /** This turn already armed a goal. */ 'goal_already_armed'
+  | /** This turn already holds a goal control lease. */ 'goal_already_armed'
   | /** This turn started before the goal it is trying to change existed. */ 'goal_not_observed'
   | /** The goal generation this turn observed is no longer the current one. */ 'goal_changed';
 
@@ -214,12 +219,21 @@ export class GoalContinuationCoordinator {
    * and told the caller to look and try again. For the other causes there is
    * nothing to look at: the turn is not registered, or a later turn owns the
    * lane, and no amount of re-reading changes that within this turn.
+   *
+   * Shutdown has to be asked about before the lane lookup, not after it.
+   * `dispose()` sets the flag and clears `lanes` in the same synchronous step,
+   * so a shut-down coordinator answers every `lanes.get` with `undefined`; an
+   * `isCurrent` check placed below that lookup can only ever see a lane that is
+   * still in the map, which makes its second clause trivially true and its
+   * first one unreachable. The refusal built from the earlier answer then told
+   * a turn that really had been registered under the Goal boundary that it
+   * never was.
    */
   activationStanding(sessionId: string, turnId: string): GoalControlStanding {
+    if (this.disposed) return declined('coordinator_disposed');
     const lane = this.lanes.get(sessionId);
     const registration = lane?.turns.get(turnId);
     if (!lane || !registration) return declined('turn_not_registered');
-    if (!this.isCurrent(lane)) return declined('coordinator_disposed');
     if (registration.controlLease !== undefined) return declined('goal_already_armed');
     if (this.deps.goalManager.getControlLease(sessionId) !== registration.observedControlLease) {
       return declined('goal_changed');
@@ -229,10 +243,10 @@ export class GoalContinuationCoordinator {
 
   /** The same question for a mutation of the generation this turn observed. */
   mutationStanding(sessionId: string, turnId: string): GoalControlStanding {
+    if (this.disposed) return declined('coordinator_disposed');
     const lane = this.lanes.get(sessionId);
     const registration = lane?.turns.get(turnId);
     if (!lane || !registration) return declined('turn_not_registered');
-    if (!this.isCurrent(lane)) return declined('coordinator_disposed');
     const controlLease = registration.controlLease ?? registration.observedControlLease;
     if (!controlLease) return declined('goal_not_observed');
     if (!this.deps.goalManager.matchesControlLease(sessionId, controlLease)) {

--- a/packages/runtime/src/goal-continuation.ts
+++ b/packages/runtime/src/goal-continuation.ts
@@ -122,6 +122,30 @@ export type GoalObservedTurnStart =
   | { kind: 'registered'; settle: GoalObservedTurnSettler }
   | { kind: 'unavailable'; reason: string };
 
+/**
+ * Why a turn does not hold the right to change its session's goal.
+ *
+ * Only `goal_changed` describes a race. The rest are settled facts about this
+ * turn that no later call within it can change, which is the distinction a
+ * refusal has to carry: telling a caller to look again and retry is only honest
+ * when looking again can produce a different answer.
+ */
+export type GoalControlDecline =
+  | /** This turn was never registered under a Goal boundary, or its registration is gone. */
+  'turn_not_registered'
+  | /** Goal continuation is shutting down. */ 'coordinator_disposed'
+  | /** This turn already armed a goal. */ 'goal_already_armed'
+  | /** This turn started before the goal it is trying to change existed. */ 'goal_not_observed'
+  | /** The goal generation this turn observed is no longer the current one. */ 'goal_changed';
+
+export type GoalControlStanding =
+  | { kind: 'held' }
+  | { kind: 'declined'; reason: GoalControlDecline };
+
+function declined(reason: GoalControlDecline): GoalControlStanding {
+  return { kind: 'declined', reason };
+}
+
 export class GoalContinuationCoordinator {
   private readonly lanes = new Map<string, SessionLane>();
   private readonly activeDrains = new Set<Promise<void>>();
@@ -181,23 +205,51 @@ export class GoalContinuationCoordinator {
     };
   }
 
+  /**
+   * Why this turn may not arm a Goal, or that it may.
+   *
+   * Split out because the refusal a model reads has to name a cause. Every
+   * check below used to collapse into one `undefined`, and the sentence built
+   * from it asserted the one cause that is recoverable — a concurrent change —
+   * and told the caller to look and try again. For the other causes there is
+   * nothing to look at: the turn is not registered, or a later turn owns the
+   * lane, and no amount of re-reading changes that within this turn.
+   */
+  activationStanding(sessionId: string, turnId: string): GoalControlStanding {
+    const lane = this.lanes.get(sessionId);
+    const registration = lane?.turns.get(turnId);
+    if (!lane || !registration) return declined('turn_not_registered');
+    if (!this.isCurrent(lane)) return declined('coordinator_disposed');
+    if (registration.controlLease !== undefined) return declined('goal_already_armed');
+    if (this.deps.goalManager.getControlLease(sessionId) !== registration.observedControlLease) {
+      return declined('goal_changed');
+    }
+    return { kind: 'held' };
+  }
+
+  /** The same question for a mutation of the generation this turn observed. */
+  mutationStanding(sessionId: string, turnId: string): GoalControlStanding {
+    const lane = this.lanes.get(sessionId);
+    const registration = lane?.turns.get(turnId);
+    if (!lane || !registration) return declined('turn_not_registered');
+    if (!this.isCurrent(lane)) return declined('coordinator_disposed');
+    const controlLease = registration.controlLease ?? registration.observedControlLease;
+    if (!controlLease) return declined('goal_not_observed');
+    if (!this.deps.goalManager.matchesControlLease(sessionId, controlLease)) {
+      return declined('goal_changed');
+    }
+    return { kind: 'held' };
+  }
+
   /** Execute and bind one Goal activation only while this exact turn owns the right to do so. */
   activateGoal(
     sessionId: string,
     turnId: string,
     activate: () => GoalState,
   ): GoalState | undefined {
-    const lane = this.lanes.get(sessionId);
-    const registration = lane?.turns.get(turnId);
-    if (
-      !lane ||
-      !this.isCurrent(lane) ||
-      !registration ||
-      registration.controlLease !== undefined ||
-      this.deps.goalManager.getControlLease(sessionId) !== registration.observedControlLease
-    ) {
-      return undefined;
-    }
+    if (this.activationStanding(sessionId, turnId).kind !== 'held') return undefined;
+    const registration = this.lanes.get(sessionId)?.turns.get(turnId);
+    if (!registration) return undefined;
     const goal = activate();
     registration.controlLease = this.deps.goalManager.getControlLease(sessionId);
     if (registration.checkpoint) registration.checkpoint = goalCheckpoint(goal);
@@ -206,18 +258,11 @@ export class GoalContinuationCoordinator {
 
   /** Mutate the exact Goal generation observed by this turn. */
   mutateGoal(sessionId: string, turnId: string, mutate: () => GoalState): GoalState | undefined {
+    if (this.mutationStanding(sessionId, turnId).kind !== 'held') return undefined;
     const lane = this.lanes.get(sessionId);
     const registration = lane?.turns.get(turnId);
     const controlLease = registration?.controlLease ?? registration?.observedControlLease;
-    if (
-      !lane ||
-      !this.isCurrent(lane) ||
-      !registration ||
-      !controlLease ||
-      !this.deps.goalManager.matchesControlLease(sessionId, controlLease)
-    ) {
-      return undefined;
-    }
+    if (!lane || !registration || !controlLease) return undefined;
 
     const goal = mutate();
     this.abortEvaluation(lane, 'Goal lifecycle changed during evaluation');

--- a/packages/runtime/src/goal-tools.ts
+++ b/packages/runtime/src/goal-tools.ts
@@ -117,7 +117,10 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<
         }).goal;
       });
       if (!goal) {
-        return 'Goal not set: this turn no longer owns Goal activation.';
+        return (
+          'Goal not set: the session goal changed while this turn was running, so nothing was armed. ' +
+          'Call GoalStatus to see the current goal, then call GoalSet again only if there is still no active goal.'
+        );
       }
       const limits = [
         `max ${goal.maxIterations} turns`,
@@ -150,7 +153,10 @@ function buildGoalClearTool(deps: GoalToolsDeps): MakaTool<Record<string, never>
         return deps.goalManager.clear(ctx.sessionId)!;
       });
       if (!goal) {
-        return 'Goal not cleared: this turn no longer owns Goal control.';
+        return (
+          'Goal not cleared: the session goal changed while this turn was running. ' +
+          'Call GoalStatus to see whether it is already gone before calling GoalClear again.'
+        );
       }
       return `Goal cleared: "${goal.condition}" after ${goal.iterations} turn(s).`;
     },
@@ -174,7 +180,10 @@ function buildGoalPauseTool(deps: GoalToolsDeps): MakaTool<Record<string, never>
         return deps.goalManager.pause(ctx.sessionId)!;
       });
       if (!goal) {
-        return 'Goal not paused: this turn no longer owns Goal control.';
+        return (
+          'Goal not paused: the session goal changed while this turn was running. ' +
+          'Call GoalStatus to see its current status before calling GoalPause again.'
+        );
       }
       return `Goal paused: "${goal.condition}" at turn ${goal.iterations}. Use GoalResume to continue.`;
     },
@@ -196,7 +205,10 @@ function buildGoalResumeTool(deps: GoalToolsDeps): MakaTool<Record<string, never
         return deps.goalManager.resume(ctx.sessionId)!;
       });
       if (!goal) {
-        return 'Goal not resumed: this turn no longer owns Goal activation.';
+        return (
+          'Goal not resumed: the session goal changed while this turn was running. ' +
+          'Call GoalStatus to see its current status before calling GoalResume again.'
+        );
       }
       return `Goal resumed: "${goal.condition}". Autonomous continuation re-enabled.`;
     },

--- a/packages/runtime/src/goal-tools.ts
+++ b/packages/runtime/src/goal-tools.ts
@@ -40,8 +40,19 @@ export const GOAL_RESUME_TOOL_NAME = 'GoalResume';
  * sentence says the turn cannot do this and asks the model to move on. Reading
  * the goal is always safe, so GoalStatus is still offered where it would tell
  * the model something it does not know.
+ *
+ * The advice also has to know which tool it is answering. `goal_already_armed`
+ * is produced by the activation gate, and GoalResume goes through that gate too
+ * — so a turn that arrived while a goal was active, paused it and then tried to
+ * resume it read "this turn cannot arm a second one" in reply to a request that
+ * asked to arm nothing. Same cause, different thing to say about it.
+ *
+ * "Already armed" was also the wrong noun for the cause. A turn holds the lease
+ * either because it armed a goal or because `beginObservedTurn` bound it to a
+ * goal that was already active — the second turn never armed anything. What the
+ * gate observes is a binding, so that is what the sentence names.
  */
-function declineAdvice(reason: GoalControlDecline): string {
+function declineAdvice(reason: GoalControlDecline, tool: string): string {
   switch (reason) {
     case 'goal_changed':
       return (
@@ -49,10 +60,12 @@ function declineAdvice(reason: GoalControlDecline): string {
         'Call GoalStatus to see the current goal, then act on what it reports.'
       );
     case 'goal_already_armed':
-      return (
-        'this turn has already armed a goal. Call GoalStatus to see it. ' +
-        'This turn cannot arm a second one.'
-      );
+      return tool === GOAL_SET_TOOL_NAME
+        ? 'this turn is already bound to a goal, so it cannot arm a second one. ' +
+            'Call GoalStatus to see the current goal.'
+        : 'this turn is already bound to a goal, and a turn can bind only once, so ' +
+            `${tool} cannot take another. Call GoalStatus to see the current goal. ` +
+            `Do not call ${tool} again in this turn; report what GoalStatus shows.`;
     case 'coordinator_disposed':
       return (
         'the goal system is shutting down, so it can no longer be changed. ' +
@@ -71,6 +84,20 @@ function declineAdvice(reason: GoalControlDecline): string {
   }
 }
 
+/**
+ * Shown when the enclosing Goal authority has stopped accepting mutations.
+ *
+ * Its only producer is `GoalCoordinator.beginDrain`, which is one-way: the flag
+ * is set once, the continuation coordinator is disposed alongside it, and
+ * nothing clears it. "Goal authority is unavailable." left the model free to
+ * read that as a passing condition and call again for the rest of the turn, so
+ * the replacement says the door does not reopen and names the move that is
+ * always left.
+ */
+const GOAL_AUTHORITY_GONE =
+  'Goal authority has been shut down, so goals can no longer be set or changed, and it will not ' +
+  'come back. Do not call this tool again; say what you were trying to change.';
+
 export interface GoalToolsDeps {
   goalManager: GoalManager;
   /** Owns atomic turn authorization for every model-triggered Goal mutation. */
@@ -80,7 +107,12 @@ export interface GoalToolsDeps {
   >;
   /** Current cumulative token count for a session (baseline for budget). */
   getTokenCount?: (sessionId: string) => number;
-  /** Reject new model-owned mutations while the enclosing authority drains. */
+  /**
+   * Reject new model-owned mutations while the enclosing authority drains.
+   *
+   * One-way by contract: once this returns false it must never return true
+   * again. `GOAL_AUTHORITY_GONE` tells the model the door does not reopen.
+   */
   isAvailable?: () => boolean;
   now?: () => number;
 }
@@ -150,7 +182,7 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<
         ),
     }),
     impl: (input, ctx) => {
-      if (deps.isAvailable?.() === false) return 'Goal authority is unavailable.';
+      if (deps.isAvailable?.() === false) return GOAL_AUTHORITY_GONE;
       const existing = deps.goalManager.get(ctx.sessionId);
       if (existing && !TERMINAL_GOAL_STATUSES.has(existing.status)) {
         return (
@@ -172,7 +204,7 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<
         // answer the attempt acted on.
         const standing = deps.goalContinuation.activationStanding(ctx.sessionId, ctx.turnId);
         const cause = standing.kind === 'declined' ? standing.reason : 'goal_changed';
-        return `Goal not set: ${declineAdvice(cause)}`;
+        return `Goal not set: ${declineAdvice(cause, GOAL_SET_TOOL_NAME)}`;
       }
       const limits = [
         `max ${goal.maxIterations} turns`,
@@ -196,7 +228,7 @@ function buildGoalClearTool(deps: GoalToolsDeps): MakaTool<Record<string, never>
     description: 'Clear the active goal, stopping autonomous execution after the current turn.',
     parameters: z.object({}),
     impl: (_input, ctx) => {
-      if (deps.isAvailable?.() === false) return 'Goal authority is unavailable.';
+      if (deps.isAvailable?.() === false) return GOAL_AUTHORITY_GONE;
       const current = deps.goalManager.get(ctx.sessionId);
       if (!current || TERMINAL_GOAL_STATUSES.has(current.status)) {
         return 'No active goal to clear.';
@@ -207,7 +239,7 @@ function buildGoalClearTool(deps: GoalToolsDeps): MakaTool<Record<string, never>
       if (!goal) {
         const standing = deps.goalContinuation.mutationStanding(ctx.sessionId, ctx.turnId);
         const cause = standing.kind === 'declined' ? standing.reason : 'goal_changed';
-        return `Goal not cleared: ${declineAdvice(cause)}`;
+        return `Goal not cleared: ${declineAdvice(cause, GOAL_CLEAR_TOOL_NAME)}`;
       }
       return `Goal cleared: "${goal.condition}" after ${goal.iterations} turn(s).`;
     },
@@ -222,7 +254,7 @@ function buildGoalPauseTool(deps: GoalToolsDeps): MakaTool<Record<string, never>
       'Pause the active goal. Autonomous continuation stops until GoalResume is called; state is preserved.',
     parameters: z.object({}),
     impl: (_input, ctx) => {
-      if (deps.isAvailable?.() === false) return 'Goal authority is unavailable.';
+      if (deps.isAvailable?.() === false) return GOAL_AUTHORITY_GONE;
       const current = deps.goalManager.get(ctx.sessionId);
       if (!current || (current.status !== 'active' && current.status !== 'waiting')) {
         return 'No active goal to pause.';
@@ -233,7 +265,7 @@ function buildGoalPauseTool(deps: GoalToolsDeps): MakaTool<Record<string, never>
       if (!goal) {
         const standing = deps.goalContinuation.mutationStanding(ctx.sessionId, ctx.turnId);
         const cause = standing.kind === 'declined' ? standing.reason : 'goal_changed';
-        return `Goal not paused: ${declineAdvice(cause)}`;
+        return `Goal not paused: ${declineAdvice(cause, GOAL_PAUSE_TOOL_NAME)}`;
       }
       return `Goal paused: "${goal.condition}" at turn ${goal.iterations}. Use GoalResume to continue.`;
     },
@@ -247,7 +279,7 @@ function buildGoalResumeTool(deps: GoalToolsDeps): MakaTool<Record<string, never
     description: 'Resume a paused goal, re-enabling autonomous continuation.',
     parameters: z.object({}),
     impl: (_input, ctx) => {
-      if (deps.isAvailable?.() === false) return 'Goal authority is unavailable.';
+      if (deps.isAvailable?.() === false) return GOAL_AUTHORITY_GONE;
       if (deps.goalManager.get(ctx.sessionId)?.status !== 'paused') {
         return 'No paused goal to resume.';
       }
@@ -257,7 +289,7 @@ function buildGoalResumeTool(deps: GoalToolsDeps): MakaTool<Record<string, never
       if (!goal) {
         const standing = deps.goalContinuation.activationStanding(ctx.sessionId, ctx.turnId);
         const cause = standing.kind === 'declined' ? standing.reason : 'goal_changed';
-        return `Goal not resumed: ${declineAdvice(cause)}`;
+        return `Goal not resumed: ${declineAdvice(cause, GOAL_RESUME_TOOL_NAME)}`;
       }
       return `Goal resumed: "${goal.condition}". Autonomous continuation re-enabled.`;
     },

--- a/packages/runtime/src/goal-tools.ts
+++ b/packages/runtime/src/goal-tools.ts
@@ -36,10 +36,26 @@ export const GOAL_RESUME_TOOL_NAME = 'GoalResume';
  * for this session", satisfies the condition, retries, and receives the
  * identical refusal, forever.
  *
- * So a retry is prescribed only where a retry can succeed. Everywhere else the
- * sentence says the turn cannot do this and asks the model to move on. Reading
- * the goal is always safe, so GoalStatus is still offered where it would tell
- * the model something it does not know.
+ * So a retry is prescribed only where a retry can succeed — and that turned out
+ * to be nowhere. `goal_changed` reads like a race, and it is one, but the loser
+ * of that race cannot re-enter it: `observedControlLease` is written once in
+ * `beginObservedTurn` and refreshed only by a mutation that succeeds, so once
+ * the lease has moved on, every gate this turn passes through declines with the
+ * same cause until the turn ends. Driven against the real coordinator — one
+ * turn registers, a second arms a goal and clears it — GoalSet declines
+ * `goal_changed` on the first call and on the fourth, and GoalStatus in between
+ * reports a goal that only makes the model want to call again.
+ *
+ * `goal_already_armed` is the same shape. It is reachable from GoalSet only
+ * once the armed goal has left `active` — otherwise the "unfinished goal is
+ * active" guard answers first — and by then `registration.controlLease` is set
+ * and nothing this turn can call will clear it, because clearing it requires a
+ * mutation that the moved lease also declines.
+ *
+ * Every branch therefore ends by closing the retry. Reading the goal is still
+ * safe, so GoalStatus is still offered where it would tell the model something
+ * it does not know; it is offered as the last thing to do, not as a step on the
+ * way back to the call that just failed.
  *
  * The advice also has to know which tool it is answering. `goal_already_armed`
  * is produced by the activation gate, and GoalResume goes through that gate too
@@ -56,13 +72,15 @@ function declineAdvice(reason: GoalControlDecline, tool: string): string {
   switch (reason) {
     case 'goal_changed':
       return (
-        'the session goal changed while this turn was running. ' +
-        'Call GoalStatus to see the current goal, then act on what it reports.'
+        'the session goal changed while this turn was running, and this turn can act only on the ' +
+        'goal it observed. Call GoalStatus to see the current goal, then report what it shows; ' +
+        `do not call ${tool} again in this turn, because it will decline the same way.`
       );
     case 'goal_already_armed':
       return tool === GOAL_SET_TOOL_NAME
-        ? 'this turn is already bound to a goal, so it cannot arm a second one. ' +
-            'Call GoalStatus to see the current goal.'
+        ? 'this turn is already bound to a goal, and a turn can bind only once, so it cannot arm ' +
+            'a second one. Call GoalStatus to see that goal, then report what it shows; do not ' +
+            'call GoalSet again in this turn, because it will decline the same way.'
         : 'this turn is already bound to a goal, and a turn can bind only once, so ' +
             `${tool} cannot take another. Call GoalStatus to see the current goal. ` +
             `Do not call ${tool} again in this turn; report what GoalStatus shows.`;

--- a/packages/runtime/src/goal-tools.ts
+++ b/packages/runtime/src/goal-tools.ts
@@ -15,7 +15,7 @@ import {
   type GoalManager,
   type GoalState,
 } from './goal-state.js';
-import type { GoalContinuationCoordinator } from './goal-continuation.js';
+import type { GoalContinuationCoordinator, GoalControlDecline } from './goal-continuation.js';
 
 export const GOAL_SET_TOOL_NAME = 'GoalSet';
 export const GOAL_CLEAR_TOOL_NAME = 'GoalClear';
@@ -23,10 +23,61 @@ export const GOAL_STATUS_TOOL_NAME = 'GoalStatus';
 export const GOAL_PAUSE_TOOL_NAME = 'GoalPause';
 export const GOAL_RESUME_TOOL_NAME = 'GoalResume';
 
+/**
+ * What a declined Goal mutation tells the model to do next.
+ *
+ * These four tools all failed the same way and said so in one sentence: the
+ * turn no longer owns Goal control. Opaque, but it asked for nothing. Replacing
+ * it with a single cause and a retry made it worse, because only one of the
+ * causes is a race. A turn that was never registered under a Goal boundary —
+ * every turn started with `goalBoundary: 'none'`, and every turn whose session
+ * was closed and removed — declines permanently. Told to call GoalStatus and
+ * then retry "if there is still no active goal", such a turn gets "No goal set
+ * for this session", satisfies the condition, retries, and receives the
+ * identical refusal, forever.
+ *
+ * So a retry is prescribed only where a retry can succeed. Everywhere else the
+ * sentence says the turn cannot do this and asks the model to move on. Reading
+ * the goal is always safe, so GoalStatus is still offered where it would tell
+ * the model something it does not know.
+ */
+function declineAdvice(reason: GoalControlDecline): string {
+  switch (reason) {
+    case 'goal_changed':
+      return (
+        'the session goal changed while this turn was running. ' +
+        'Call GoalStatus to see the current goal, then act on what it reports.'
+      );
+    case 'goal_already_armed':
+      return (
+        'this turn has already armed a goal. Call GoalStatus to see it. ' +
+        'This turn cannot arm a second one.'
+      );
+    case 'coordinator_disposed':
+      return (
+        'the goal system is shutting down, so it can no longer be changed. ' +
+        'Do not call this tool again in this turn; say what you were trying to change.'
+      );
+    case 'goal_not_observed':
+      return (
+        'this turn began before the current goal existed, so it cannot change it. ' +
+        'Do not call this tool again in this turn; say what you were trying to change.'
+      );
+    case 'turn_not_registered':
+      return (
+        'this turn does not run under the session goal boundary, so it cannot change the goal. ' +
+        'Do not call this tool again in this turn; say what you were trying to change.'
+      );
+  }
+}
+
 export interface GoalToolsDeps {
   goalManager: GoalManager;
   /** Owns atomic turn authorization for every model-triggered Goal mutation. */
-  goalContinuation: Pick<GoalContinuationCoordinator, 'activateGoal' | 'mutateGoal'>;
+  goalContinuation: Pick<
+    GoalContinuationCoordinator,
+    'activateGoal' | 'mutateGoal' | 'activationStanding' | 'mutationStanding'
+  >;
   /** Current cumulative token count for a session (baseline for budget). */
   getTokenCount?: (sessionId: string) => number;
   /** Reject new model-owned mutations while the enclosing authority drains. */
@@ -117,10 +168,11 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<
         }).goal;
       });
       if (!goal) {
-        return (
-          'Goal not set: the session goal changed while this turn was running, so nothing was armed. ' +
-          'Call GoalStatus to see the current goal, then call GoalSet again only if there is still no active goal.'
-        );
+        // Nothing was mutated on this path, so asking now returns the same
+        // answer the attempt acted on.
+        const standing = deps.goalContinuation.activationStanding(ctx.sessionId, ctx.turnId);
+        const cause = standing.kind === 'declined' ? standing.reason : 'goal_changed';
+        return `Goal not set: ${declineAdvice(cause)}`;
       }
       const limits = [
         `max ${goal.maxIterations} turns`,
@@ -153,10 +205,9 @@ function buildGoalClearTool(deps: GoalToolsDeps): MakaTool<Record<string, never>
         return deps.goalManager.clear(ctx.sessionId)!;
       });
       if (!goal) {
-        return (
-          'Goal not cleared: the session goal changed while this turn was running. ' +
-          'Call GoalStatus to see whether it is already gone before calling GoalClear again.'
-        );
+        const standing = deps.goalContinuation.mutationStanding(ctx.sessionId, ctx.turnId);
+        const cause = standing.kind === 'declined' ? standing.reason : 'goal_changed';
+        return `Goal not cleared: ${declineAdvice(cause)}`;
       }
       return `Goal cleared: "${goal.condition}" after ${goal.iterations} turn(s).`;
     },
@@ -180,10 +231,9 @@ function buildGoalPauseTool(deps: GoalToolsDeps): MakaTool<Record<string, never>
         return deps.goalManager.pause(ctx.sessionId)!;
       });
       if (!goal) {
-        return (
-          'Goal not paused: the session goal changed while this turn was running. ' +
-          'Call GoalStatus to see its current status before calling GoalPause again.'
-        );
+        const standing = deps.goalContinuation.mutationStanding(ctx.sessionId, ctx.turnId);
+        const cause = standing.kind === 'declined' ? standing.reason : 'goal_changed';
+        return `Goal not paused: ${declineAdvice(cause)}`;
       }
       return `Goal paused: "${goal.condition}" at turn ${goal.iterations}. Use GoalResume to continue.`;
     },
@@ -205,10 +255,9 @@ function buildGoalResumeTool(deps: GoalToolsDeps): MakaTool<Record<string, never
         return deps.goalManager.resume(ctx.sessionId)!;
       });
       if (!goal) {
-        return (
-          'Goal not resumed: the session goal changed while this turn was running. ' +
-          'Call GoalStatus to see its current status before calling GoalResume again.'
-        );
+        const standing = deps.goalContinuation.activationStanding(ctx.sessionId, ctx.turnId);
+        const cause = standing.kind === 'declined' ? standing.reason : 'goal_changed';
+        return `Goal not resumed: ${declineAdvice(cause)}`;
       }
       return `Goal resumed: "${goal.condition}". Autonomous continuation re-enabled.`;
     },

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1567,6 +1567,8 @@ export {
 export type {
   GoalContinuationDeps,
   GoalContinuationScheduler,
+  GoalControlDecline,
+  GoalControlStanding,
   GoalObservedTurnStart,
   GoalObservedTurnSettler,
   GoalSessionCloseOperation,

--- a/packages/runtime/src/sandbox-boundary-tool.ts
+++ b/packages/runtime/src/sandbox-boundary-tool.ts
@@ -20,7 +20,10 @@ export function buildRequestSandboxBoundaryTool(): MakaTool<
       .strict(),
     impl: ({ expansion, justification }, context) => {
       if (!context.requestSandboxBoundary) {
-        throw new Error('Sandbox boundary expansion is unavailable on this surface');
+        throw new Error(
+          'request_sandbox_boundary is not available on this surface, so the sandbox was not widened. ' +
+            'Retrying will fail the same way — redo the work inside the paths already allowed, or tell the user which path needs access.',
+        );
       }
       return context.requestSandboxBoundary(expansion, justification);
     },

--- a/packages/runtime/src/sandbox-boundary-tool.ts
+++ b/packages/runtime/src/sandbox-boundary-tool.ts
@@ -4,6 +4,20 @@ import { z } from 'zod';
 import { sandboxBoundaryExpansionSchema } from './sandbox-boundary-declaration.js';
 import type { MakaTool } from './tool-runtime.js';
 
+/**
+ * Refusal for a `request_sandbox_boundary` call that cannot be carried out.
+ *
+ * Shared with `ToolRuntime.requestSandboxBoundary`, which is where the
+ * production form of this failure is decided: ToolRuntime injects the context
+ * callback unconditionally, so the guard below answers only an embedder that
+ * assembles its own tool context. Two conditions, one thing to say, one place
+ * to say it.
+ */
+export const SANDBOX_BOUNDARY_UNAVAILABLE =
+  'request_sandbox_boundary is not available on this surface, so the sandbox was not widened. ' +
+  'Retrying will fail the same way — redo the work inside the paths already allowed, or tell the ' +
+  'user which path needs access.';
+
 export function buildRequestSandboxBoundaryTool(): MakaTool<
   { expansion: SandboxBoundaryExpansion; justification: string },
   SandboxBoundarySettlement
@@ -20,10 +34,7 @@ export function buildRequestSandboxBoundaryTool(): MakaTool<
       .strict(),
     impl: ({ expansion, justification }, context) => {
       if (!context.requestSandboxBoundary) {
-        throw new Error(
-          'request_sandbox_boundary is not available on this surface, so the sandbox was not widened. ' +
-            'Retrying will fail the same way — redo the work inside the paths already allowed, or tell the user which path needs access.',
-        );
+        throw new Error(SANDBOX_BOUNDARY_UNAVAILABLE);
       }
       return context.requestSandboxBoundary(expansion, justification);
     },

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -76,6 +76,12 @@ type LifecycleCause = 'timeout' | 'cancel' | 'shutdown';
  * back taught the model nothing (and could carry command text back into the
  * transcript); the canonical shape and where to obtain it are the only useful
  * reply. Keep this in sync with the `ref` description in shell-tools.ts.
+ *
+ * `Read({ ref })` reaches this through `resourceDetail`, not through
+ * `stopBackgroundTask`: `classifyRuntimeResourceRef` waves through anything
+ * shaped `maka://runtime/<something>`, so a mistyped path segment gets all the
+ * way here. That is the likeliest place to mistype a ref, and it was the one
+ * still echoing.
  */
 const BACKGROUND_TASK_REF_HELP =
   'That is not a runtime background task ref. Use the ref exactly as it was returned when the ' +
@@ -1479,7 +1485,7 @@ export class ShellRunProcessManager
     abortSignal: AbortSignal,
   ): Promise<ShellRunToolResult> {
     const target = parseShellRunResourceRef(ref);
-    if (!target) throw new Error(`Unsupported runtime resource ref: ${ref}`);
+    if (!target) throw new Error(BACKGROUND_TASK_REF_HELP);
     const live = this.liveResource(sessionId, target.shellRunId);
     let record: ShellRunRecord;
     if (live) {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -1731,16 +1731,26 @@ export class ShellRunProcessManager
   }
 
   private reserveSlot(mode: ShellMode): ShellRunSlotReservation {
+    // The counters are manager-wide and `StopBackgroundTask` takes a
+    // session-scoped ref, so the session that hits the cap may own none of the
+    // runs holding it. Saying "stop one" flatly would promise a move that can
+    // be unavailable; this offers it as a condition and names waiting as the
+    // path that always exists.
     if (this.reservedShellRuns >= this.maxLiveShellRuns) {
       throw new Error(
-        `No free background task slot: ${this.maxLiveShellRuns} are already running. ` +
-          'Stop one with StopBackgroundTask, or wait for one to finish, before starting another.',
+        `No free background task slot: the runtime is at its limit of ${this.maxLiveShellRuns} ` +
+          'live background tasks. The limit is shared across sessions, so some of them may not be ' +
+          'yours. Stop one of yours with StopBackgroundTask if you started any, or wait for a ' +
+          'running task to finish.',
       );
     }
     if (mode === 'pty' && this.reservedPtyRuns >= this.maxLivePtyRuns) {
       throw new Error(
-        `No free interactive (PTY) background task slot: ${this.maxLivePtyRuns} are already running. ` +
-          'Stop one with StopBackgroundTask, or wait for one to finish, before starting another.',
+        `No free interactive (PTY) background task slot: the runtime is at its limit of ` +
+          `${this.maxLivePtyRuns} live interactive tasks. The limit is shared across sessions, so ` +
+          'some of them may not be yours. Stop one of yours with StopBackgroundTask if you started ' +
+          'any, or wait for a running task to finish. A non-interactive background task does not ' +
+          'use this limit.',
       );
     }
     this.reservedShellRuns += 1;

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -70,6 +70,16 @@ import { CompletionLatch } from './completion-latch.js';
 import { closeChildFdSources } from './child-fd-input.js';
 
 type LifecycleCause = 'timeout' | 'cancel' | 'shutdown';
+
+/**
+ * Shown whenever a `ref` argument does not parse. Echoing the rejected string
+ * back taught the model nothing (and could carry command text back into the
+ * transcript); the canonical shape and where to obtain it are the only useful
+ * reply. Keep this in sync with the `ref` description in shell-tools.ts.
+ */
+const BACKGROUND_TASK_REF_HELP =
+  'That is not a runtime background task ref. Use the ref exactly as it was returned when the ' +
+  'background task started — the form is maka://runtime/background-tasks/<id>.';
 type DriverExit =
   | { mode: 'pipes'; value: PipeProcessExit }
   | { mode: 'pty'; value: PtyProcessExit };
@@ -281,7 +291,7 @@ export class ShellRunProcessManager
   async writeStdin(input: ShellRunWriteInput): Promise<ShellRunToolResult> {
     validateWriteStdinInput(input);
     const target = parseShellRunResourceRef(input.ref);
-    if (!target) throw new Error(`Unsupported runtime background task ref: ${input.ref}`);
+    if (!target) throw new Error(BACKGROUND_TASK_REF_HELP);
     const live = this.liveResource(input.sessionId, target.shellRunId);
     if (!live) return this.writeStdinWithoutLive(input, target.shellRunId);
     if (live.mode !== 'pty') throw new Error('WriteStdin requires a PTY background task ref');
@@ -425,7 +435,7 @@ export class ShellRunProcessManager
     abortSignal: AbortSignal,
   ): Promise<ToolResultContent> {
     const target = parseShellRunResourceRef(ref);
-    if (!target) throw new Error(`Unsupported runtime background task ref: ${ref}`);
+    if (!target) throw new Error(BACKGROUND_TASK_REF_HELP);
     const live = this.liveResource(sessionId, target.shellRunId);
     if (!live) return this.stopWithoutLive(sessionId, target.shellRunId, abortSignal);
     if (live.driverExit) {
@@ -1722,10 +1732,16 @@ export class ShellRunProcessManager
 
   private reserveSlot(mode: ShellMode): ShellRunSlotReservation {
     if (this.reservedShellRuns >= this.maxLiveShellRuns) {
-      throw new Error(`Live background task capacity is full (${this.maxLiveShellRuns})`);
+      throw new Error(
+        `No free background task slot: ${this.maxLiveShellRuns} are already running. ` +
+          'Stop one with StopBackgroundTask, or wait for one to finish, before starting another.',
+      );
     }
     if (mode === 'pty' && this.reservedPtyRuns >= this.maxLivePtyRuns) {
-      throw new Error(`Live PTY capacity is full (${this.maxLivePtyRuns})`);
+      throw new Error(
+        `No free interactive (PTY) background task slot: ${this.maxLivePtyRuns} are already running. ` +
+          'Stop one with StopBackgroundTask, or wait for one to finish, before starting another.',
+      );
     }
     this.reservedShellRuns += 1;
     if (mode === 'pty') this.reservedPtyRuns += 1;

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -86,6 +86,19 @@ type LifecycleCause = 'timeout' | 'cancel' | 'shutdown';
 const BACKGROUND_TASK_REF_HELP =
   'That is not a runtime background task ref. Use the ref exactly as it was returned when the ' +
   'background task started — the form is maka://runtime/background-tasks/<id>.';
+
+/**
+ * The model reads {@link BACKGROUND_TASK_REF_HELP}; an operator reads the
+ * `cause`. Dropping the rejected string outright would have made three call
+ * sites indistinguishable in a log, so it travels the way `builtin-tools.ts`
+ * carries its worker-protocol violations: out of the transcript, in every
+ * stack.
+ */
+function backgroundTaskRefError(ref: string): Error {
+  return new Error(BACKGROUND_TASK_REF_HELP, {
+    cause: new Error(`Unsupported runtime background task ref: ${ref}`),
+  });
+}
 type DriverExit =
   | { mode: 'pipes'; value: PipeProcessExit }
   | { mode: 'pty'; value: PtyProcessExit };
@@ -297,7 +310,7 @@ export class ShellRunProcessManager
   async writeStdin(input: ShellRunWriteInput): Promise<ShellRunToolResult> {
     validateWriteStdinInput(input);
     const target = parseShellRunResourceRef(input.ref);
-    if (!target) throw new Error(BACKGROUND_TASK_REF_HELP);
+    if (!target) throw backgroundTaskRefError(input.ref);
     const live = this.liveResource(input.sessionId, target.shellRunId);
     if (!live) return this.writeStdinWithoutLive(input, target.shellRunId);
     if (live.mode !== 'pty') throw new Error('WriteStdin requires a PTY background task ref');
@@ -441,7 +454,7 @@ export class ShellRunProcessManager
     abortSignal: AbortSignal,
   ): Promise<ToolResultContent> {
     const target = parseShellRunResourceRef(ref);
-    if (!target) throw new Error(BACKGROUND_TASK_REF_HELP);
+    if (!target) throw backgroundTaskRefError(ref);
     const live = this.liveResource(sessionId, target.shellRunId);
     if (!live) return this.stopWithoutLive(sessionId, target.shellRunId, abortSignal);
     if (live.driverExit) {
@@ -1485,7 +1498,7 @@ export class ShellRunProcessManager
     abortSignal: AbortSignal,
   ): Promise<ShellRunToolResult> {
     const target = parseShellRunResourceRef(ref);
-    if (!target) throw new Error(BACKGROUND_TASK_REF_HELP);
+    if (!target) throw backgroundTaskRefError(ref);
     const live = this.liveResource(sessionId, target.shellRunId);
     let record: ShellRunRecord;
     if (live) {
@@ -1737,26 +1750,32 @@ export class ShellRunProcessManager
   }
 
   private reserveSlot(mode: ShellMode): ShellRunSlotReservation {
-    // The counters are manager-wide and `StopBackgroundTask` takes a
-    // session-scoped ref, so the session that hits the cap may own none of the
-    // runs holding it. Saying "stop one" flatly would promise a move that can
-    // be unavailable; this offers it as a condition and names waiting as the
-    // path that always exists.
+    // The counters are manager-wide, so the session that hits the cap may own
+    // none of the runs holding it. Hedging on ownership — "stop one of yours
+    // if you started any" — is the wrong hedge, because the caller that most
+    // often hits this cap does not have the tool either. `Bash` reaches this
+    // path from a child agent, and `buildToolsForAgentDefinition` is a strict
+    // name allowlist: the `implementation` definition is granted Read, Glob,
+    // Grep, Write, Edit and Bash, and neither StopBackgroundTask nor
+    // WriteStdin is on any child list. Naming the tool would send that caller
+    // to look for a schema entry it does not have. So the refusal describes
+    // the action instead of naming the tool, and leads with waiting, which is
+    // the one move available to every caller.
     if (this.reservedShellRuns >= this.maxLiveShellRuns) {
       throw new Error(
         `No free background task slot: the runtime is at its limit of ${this.maxLiveShellRuns} ` +
           'live background tasks. The limit is shared across sessions, so some of them may not be ' +
-          'yours. Stop one of yours with StopBackgroundTask if you started any, or wait for a ' +
-          'running task to finish.',
+          'yours. Wait for a running background task to finish and try again, or, if you have a ' +
+          'tool for stopping background tasks, stop one you started.',
       );
     }
     if (mode === 'pty' && this.reservedPtyRuns >= this.maxLivePtyRuns) {
       throw new Error(
         `No free interactive (PTY) background task slot: the runtime is at its limit of ` +
           `${this.maxLivePtyRuns} live interactive tasks. The limit is shared across sessions, so ` +
-          'some of them may not be yours. Stop one of yours with StopBackgroundTask if you started ' +
-          'any, or wait for a running task to finish. A non-interactive background task does not ' +
-          'use this limit.',
+          'some of them may not be yours. Run this command as a non-interactive background task, ' +
+          'which does not use this limit, or wait for a running interactive task to finish and ' +
+          'try again.',
       );
     }
     this.reservedShellRuns += 1;

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -43,6 +43,18 @@ const AGENT_SPAWN_ISOLATION_MODES = [
 ] as const;
 const CHILD_PROGRESS_ERROR_MAX_CHARS = 1_000;
 
+/**
+ * Which schema fields each `agent_output` locator needs. A rejection that only
+ * says "its matching identity fields" leaves the model guessing which of the
+ * four optional id fields to add, so name them.
+ */
+const LOCATOR_REQUIRED_FIELDS = {
+  child_session_latest: 'child_session_id',
+  child_session_run: 'child_session_id and run_id',
+  legacy_run: 'run_id',
+  legacy_turn: 'turn_id',
+} as const satisfies Record<string, string>;
+
 type SubagentToolResult = Extract<ToolResultContent, { kind: 'subagent' }>;
 
 export function buildChildAgentTools(tools: readonly MakaTool[]): MakaTool[] {
@@ -168,7 +180,10 @@ export function buildSubagentSpawnTool(
         );
       }
       if (!ctx.spawnChildSession) {
-        throw new Error('spawnChildSession capability is unavailable in this runtime context');
+        throw new Error(
+          'agent_spawn is not available in this session, so no child agent was started. ' +
+            'Retrying agent_spawn will fail the same way — do the task yourself with the tools you already have.',
+        );
       }
       const boundTask = input.task_id
         ? await deps.taskLedger?.get(ctx.sessionId, input.task_id)
@@ -350,7 +365,10 @@ export function buildSubagentListTool(): MakaTool<Record<string, never>, unknown
     categoryHint: 'read',
     impl: async (_input, ctx) => {
       if (!ctx.listChildAgents) {
-        throw new Error('listChildAgents capability is unavailable in this runtime context');
+        throw new Error(
+          'agent_list is not available in this session, so no agent catalog or child run list could be read. ' +
+            'Retrying agent_list will fail the same way — pick a child agent profile from the agent_spawn schema instead.',
+        );
       }
       return await ctx.listChildAgents();
     },
@@ -410,7 +428,7 @@ export function buildSubagentOutputTool(): MakaTool<
           if (!valid) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              message: `locator=${input.locator} requires its matching identity fields`,
+              message: `locator=${input.locator} requires ${LOCATOR_REQUIRED_FIELDS[input.locator]}.`,
             });
           }
           return;
@@ -435,7 +453,10 @@ export function buildSubagentOutputTool(): MakaTool<
     categoryHint: 'read',
     impl: async (input, ctx) => {
       if (!ctx.readChildAgentOutput) {
-        throw new Error('readChildAgentOutput capability is unavailable in this runtime context');
+        throw new Error(
+          'agent_output is not available in this session, so no child output could be read. ' +
+            'Retrying agent_output will fail the same way — use the summary the agent_spawn or agent_swarm call already returned for that child.',
+        );
       }
       const explicitLocator =
         input.locator === 'child_session_latest'

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -183,6 +183,9 @@ export function buildSubagentSpawnTool(
         throw new Error(
           'agent_spawn is not available in this session, so no child agent was started. ' +
             'Retrying agent_spawn will fail the same way — do the task yourself with the tools you already have.',
+          {
+            cause: new Error('spawnChildSession capability is unavailable in this runtime context'),
+          },
         );
       }
       const boundTask = input.task_id
@@ -364,10 +367,17 @@ export function buildSubagentListTool(): MakaTool<Record<string, never>, unknown
     parameters: z.object({}),
     categoryHint: 'read',
     impl: async (_input, ctx) => {
+      // Not reachable from the desktop app or the CLI: both pass
+      // `listChildAgents` to ToolRuntime unconditionally
+      // (`session-stream.ts`, `runtime-bootstrap.ts`), and ToolRuntime hands
+      // it straight to the tool context. `harbor-cell.ts` passes it only when
+      // its own context carries one, so a headless embedder can still land
+      // here — which is why this stays a sentence rather than being deleted.
       if (!ctx.listChildAgents) {
         throw new Error(
           'agent_list is not available in this session, so no agent catalog or child run list could be read. ' +
             'Retrying agent_list will fail the same way — pick a child agent profile from the agent_spawn schema instead.',
+          { cause: new Error('listChildAgents capability is unavailable in this runtime context') },
         );
       }
       return await ctx.listChildAgents();
@@ -453,9 +463,15 @@ export function buildSubagentOutputTool(): MakaTool<
     categoryHint: 'read',
     impl: async (input, ctx) => {
       if (!ctx.readChildAgentOutput) {
+        // Same reachability as `agent_list` above.
         throw new Error(
           'agent_output is not available in this session, so no child output could be read. ' +
             'Retrying agent_output will fail the same way — use the summary the agent_spawn or agent_swarm call already returned for that child.',
+          {
+            cause: new Error(
+              'readChildAgentOutput capability is unavailable in this runtime context',
+            ),
+          },
         );
       }
       const explicitLocator =

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -1856,6 +1856,11 @@ export class ToolRuntime {
       // guards the same condition, but ToolRuntime injects the callback
       // unconditionally a few lines above, so that guard answers only an
       // embedder that builds its own context — never a production tool call.
+      //
+      // This one does fire in production. The desktop app supplies both store
+      // callbacks unconditionally (`session-stream.ts`), but the CLI supplies
+      // them only on the `tui` surface (`runtime-bootstrap.ts`), so every
+      // non-TUI CLI surface reaches here for any call that is not a hosted run.
       throw new Error(SANDBOX_BOUNDARY_UNAVAILABLE);
     }
     const normalized = await normalizeSandboxBoundaryExpansion(expansion, this.input.header.cwd);

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -66,6 +66,7 @@ import type { AgentProfile } from './agent-catalog.js';
 import type { SubagentExecutionRef } from './subagent-execution.js';
 import { sandboxErrorMetadata, serializeSandboxError } from './sandbox/errors.js';
 import { normalizeSandboxBoundaryExpansion } from './sandbox-boundary-path.js';
+import { SANDBOX_BOUNDARY_UNAVAILABLE } from './sandbox-boundary-tool.js';
 import {
   RuntimeInteractionAdmissionRejectedError,
   RuntimeInteractionClosedError,
@@ -1851,7 +1852,11 @@ export class ToolRuntime {
       !hostedRun &&
       (!this.input.createSandboxBoundaryRequest || !this.input.settleSandboxBoundaryRequest)
     ) {
-      throw new Error('Sandbox boundary expansion is unavailable on this surface');
+      // This is the sentence a model actually reads. `sandbox-boundary-tool.ts`
+      // guards the same condition, but ToolRuntime injects the callback
+      // unconditionally a few lines above, so that guard answers only an
+      // embedder that builds its own context — never a production tool call.
+      throw new Error(SANDBOX_BOUNDARY_UNAVAILABLE);
     }
     const normalized = await normalizeSandboxBoundaryExpansion(expansion, this.input.header.cwd);
     const normalizedJustification = justification.trim();


### PR DESCRIPTION
## The measurement

A refusal that names only its cause is a refusal a model re-sends. Across recorded runs:

- refusals with no next move came back as identical retries
- refusals naming an internal noun the model has no verb for came back as retries of the same call with different arguments — guessing the schema, because the sentence gave it nothing else to try

## What changed

| Refusal | Said | Now says |
|---|---|---|
| `agent_spawn` / `agent_list` / `agent_output` / `agent_swarm` | "capability is unavailable in this runtime context" | retrying fails the same way; do the task with the tools already in hand |
| the four Goal declines | "this turn no longer owns Goal activation" | names which of five causes it is, and asks for a retry only where a retry can succeed |
| "Goal authority is unavailable." | reads as a passing condition | its only producer is one-way, so it says the door does not reopen |
| `agent_output` locator | "its matching identity fields" | names the fields that locator needs |
| `Read` / `Glob` / `Grep` on an internal fs mismatch | read as an empty result — "no matches were produced" | says no result came back, and what that does not mean |
| `Edit` / `Write` on an internal fs mismatch | read as a complaint about `old_string` | Maka cannot tell whether it landed; read the file before writing again |
| malformed background-task ref, on all three paths | echoed the model's own text back | the canonical form and where to get it |
| full shell / PTY slot | nothing about how to free one | names `StopBackgroundTask`, and says the limit is shared |
| `request_sandbox_boundary` | one sentence in the tool, a different one in ToolRuntime | one constant, and the ToolRuntime path is the one a model reaches |

A model cannot make a runtime context available, and it has no verb for owning a turn. Those sentences were describing host state machines to something that can only make tool calls.

## What a refusal may not do

Two rules the second pass enforces, because the first pass broke both.

It may not prescribe a move the caller does not have. `local_read` children get Read, Glob and Grep and nothing else, so a Grep failure ending "use Bash to do the same work" is a dead end dressed as a way out. The shell is offered on a condition the model can check for itself, and the sentence ends on something every caller can do.

It may not assert what the code cannot observe. The filesystem branch fires on a mislabelled success, so it does not know whether the write landed and does not say. Only `goal_changed` describes a race, so only `goal_changed` asks the model to look again; the other four causes say the turn cannot do this and to move on. The worker-protocol violation still reaches an operator, as the Error `cause`.

## Reachability

Three of the five Goal decline causes had no test that the real coordinator can produce them, and one of the three could not: `coordinator_disposed` sat below a lane lookup that `dispose()` had already made fail, so the shutdown sentence was unreachable and the turn read a sentence that was false about it. Every cause is now produced by a real `GoalContinuationCoordinator`, and the two authorization gates answer separately in the stub so a tool wired to the wrong one fails.

## Not included on purpose

`automation-tools.ts` has the same defect — "not found, not owned, or not active" collapses three independent causes into one — but its authority interface went async and session-scoped upstream since this was written. Porting it is a rewrite rather than a hunk, so it comes separately.

`tool-runtime.ts:776` writes the Computer Use approval summary into the model-facing `tool_call` record on the AI SDK path. Same family of defect, different surface, and it feeds the durable args hash as well; it needs its own change.
