### PR TITLE
fix: repair CI broken by #1880 (format + platform-independent e2e signal)

### DIFF
--- a/apps/desktop/e2e/storage-root-conflict.spec.ts
+++ b/apps/desktop/e2e/storage-root-conflict.spec.ts
@@ -10,32 +10,39 @@ import { closeElectronApplication } from '../../../scripts/electron-lifecycle.mj
 const DESKTOP_ROOT = process.cwd();
 
 /**
- * Prove the app parked at the modal repair dialog — the only success signal
- * this test accepts.
+ * Startup signal the main process prints synchronously right before showing
+ * the repair modal (see `confirmDesktopStorageRootRepair` in boot.ts). It is
+ * an explicit contract between the app and this test: it can only be printed
+ * after `ready` — the whole boot module runs inside the `whenReady` callback —
+ * and only when the root-identity gate fired, so seeing it proves both
+ * invariants at once.
  *
- * The dialog can only appear after ready: the whole boot module runs inside
- * the `whenReady` callback, so a modal dialog being up simultaneously proves
- * (a) ready was reached and (b) the root-identity gate fired and is holding
- * before any store/db write. On macOS the dialog's modal loop stops answering
- * CDP evaluation, so an evaluate that never settles within the deadline is the
- * observable form of "dialog is open". A deadlocked main process (the
- * regression this test guards) answers every evaluate with `isReady() ===
- * false` forever, and a future removal of the gate would make evaluate answer
- * `true` — both must fail, only the parked dialog may pass.
+ * CDP evaluation is deliberately not the success signal: macOS modal loops
+ * block CDP evaluation while Linux modal dialogs keep answering it, so no
+ * evaluate-based heuristic is portable. A deadlocked main process (the
+ * regression this test guards) never reaches the gate, so the signal never
+ * appears; a future removal of the gate skips the signal too.
  */
-async function appParkedAtRepairDialog(app: ElectronApplication): Promise<boolean> {
-  for (let attempt = 0; attempt < 40; attempt += 1) {
-    const outcome = await Promise.race([
-      app
-        .evaluate(({ app: electronApp }) => electronApp.isReady())
-        .then((ready) => (ready ? 'ready' : 'not-ready'))
-        .catch(() => 'evaluate-error'),
-      new Promise<string>((resolve) => setTimeout(() => resolve('modal-dialog'), 1_000)),
-    ]);
-    if (outcome === 'modal-dialog') return true;
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  return false;
+const REPAIR_GATE_SIGNAL = '[storage-root] root-identity conflict; parking at repair dialog';
+
+async function appParkedAtRepairGate(app: ElectronApplication): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        resolve(false);
+      }
+    }, 30_000);
+    app.on('console', (message) => {
+      if (settled) return;
+      if (message.text().includes(REPAIR_GATE_SIGNAL)) {
+        settled = true;
+        clearTimeout(timeout);
+        resolve(true);
+      }
+    });
+  });
 }
 
 /**
@@ -74,9 +81,9 @@ test('parks at the storage-root repair dialog and writes nothing before the answ
       env: buildFixtureEnv(userDataDir, homeDir, {}),
     });
 
-    // The app must park at the dialog — before this fix the main process
-    // deadlocked in module evaluation and no dialog ever appeared.
-    expect(await appParkedAtRepairDialog(app)).toBe(true);
+    // The gate signal is printed only after ready and only when the conflict
+    // fired; a deadlocked main process (the regression) never prints it.
+    expect(await appParkedAtRepairGate(app)).toBe(true);
 
     // While the dialog is unanswered, no store/db files may be created in
     // the workspace: the root-identity gate must precede all storage.

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -215,6 +215,10 @@ async function confirmDesktopStorageRootRepair(): Promise<boolean> {
   if (!app.isReady()) {
     throw new Error('storage-root repair dialog requires app ready');
   }
+  // Explicit startup contract for the storage-root-conflict E2E: printed
+  // synchronously before the modal, so the test can observe the gate firing
+  // on any platform (macOS modal loops block CDP evaluation, Linux does not).
+  console.log('[storage-root] root-identity conflict; parking at repair dialog');
   const isChinese = resolveSystemUiLocale(app.getPreferredSystemLanguages()) === 'zh';
   const { response } = await dialog.showMessageBox({
     type: 'warning',

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -34,7 +34,10 @@ const ALLOW = new Map([
     'apps/desktop/src/renderer/error-boundary.tsx',
     'React error boundary; DevTools-only, surfaces uncaught render errors.',
   ],
-  ['apps/desktop/src/main/main.ts', 'thin ESM entry; pre-ready config, [startup] ready/fatal diagnostics (moved from boot, PR1880).'],
+  [
+    'apps/desktop/src/main/main.ts',
+    'thin ESM entry; pre-ready config, [startup] ready/fatal diagnostics (moved from boot, PR1880).',
+  ],
   [
     'apps/desktop/src/main/boot.ts',
     'startup chain diagnostics (e2e-fixture fatal/scenario, window create failure, repair/cleanup paths); no secrets (moved from main.ts, PR1880).',


### PR DESCRIPTION
## Summary

PR #1880 merged with its own CI red, breaking `main` (run 30734948700). Both failures come from #1880's changes:

1. `typecheck` job: `scripts/check-console.mjs` — the new `main.ts` allow-list entry exceeded the line width and was never formatted (`npm run format:check` fails).
2. `e2e` job: the new `storage-root-conflict.spec.ts` regression test treats "CDP evaluate never settles within 1s" as proof the repair dialog is open. That holds only on macOS, where modal loops block CDP evaluation; on Linux CI the modal keeps answering evaluation, so the test failed even though the app parked correctly — and a deadlocked main process (the exact regression the test guards) would have been accepted as a pass on Linux. The signal is fundamentally platform-dependent: macOS and Linux modal dialogs behave oppositely under CDP evaluation, so no evaluate-based heuristic can be portable.

Fix: replace the heuristic with an explicit contract. `boot.ts` prints `[storage-root] root-identity conflict; parking at repair dialog` synchronously before the modal — only reachable after `ready` and only when the root-identity gate fired — and the test waits for that console event (Playwright forwards main-process console via CDP). The workspace write-free assertion is unchanged. Deadlock and gate-removal never print the signal, so both still fail the test on every platform.

Also: `main` has no branch protection (404 on the protection API), which is why #1880 could merge with red checks.

## Verification

- `npm run format:check` — clean (1381 files)
- `npm run lint` — clean (2252 files)
- `npm run typecheck` — clean (all workspaces)
- Full desktop e2e: 73 passed, including the rewritten `storage-root-conflict` test (macOS, 5.5s)
- RED check: removing the boot log line makes the test fail (signal missing → fail), confirming the test still catches gate absence/deadlock
- The decisive Linux behavior is verified by this PR's own CI run, which failed on `main` and must now pass
