### PR TITLE
feat(ui): give driving the computer its own row, and say what it did

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -3,6 +3,7 @@ import { before, describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import { _setColorLevelForTesting } from '../tui-ansi.js';
 import type { PipeShellOutput, PtyShellOutput, ShellRunToolResult } from '@maka/core';
+import { computerUseApprovalSummary } from '@maka/core';
 import type { SessionEvent, ToolResultContent } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import {
@@ -4646,6 +4647,78 @@ describe('Maka Pi TUI activity strip', () => {
       text: 'recovered',
     });
     assert.equal(state.providerRetry, undefined);
+  });
+});
+
+describe('Maka Pi TUI Computer Use rows', () => {
+  /**
+   * The desktop is not the only renderer of tool activity, and the row that
+   * reads `Maka Computer` reads it in both. The arguments are put through
+   * `computerUseApprovalSummary`, because that is what the runtime persists and
+   * emits for this tool — a fixture written as the wire call would assert a
+   * label from fields the TUI can never receive.
+   */
+  test('says what each Computer Use call did instead of repeating the tool name', () => {
+    const state = createMakaPiTranscriptState();
+    appendUserPrompt(state, 'add seven and eight');
+    const calls = [
+      { action: 'observe', app: 'Calculator', window_id: 7 },
+      {
+        action: 'click_element',
+        app: 'Calculator',
+        window_id: 7,
+        observation_id: 'frame-1',
+        element_id: 'e7',
+      },
+      {
+        action: 'click_element',
+        app: 'Calculator',
+        window_id: 7,
+        observation_id: 'frame-1',
+        element_id: 'e9',
+      },
+    ];
+    calls.forEach((wireArgs, index) => {
+      applyMakaSessionEventToTranscript(
+        state,
+        event({
+          type: 'tool_start',
+          toolUseId: `cu-${index}`,
+          toolName: 'maka_computer',
+          displayName: 'Maka Computer',
+          activityKind: 'computer',
+          args: computerUseApprovalSummary(wireArgs),
+        }),
+      );
+      applyMakaSessionEventToTranscript(
+        state,
+        event({
+          type: 'tool_result',
+          toolUseId: `cu-${index}`,
+          isError: false,
+          content: { kind: 'text', text: 'ok' },
+        }),
+      );
+    });
+
+    const rendered = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi);
+    const rows = rendered.filter((line) => line.includes('Maka Computer'));
+    assert.equal(rows.length, 3, 'one row per call');
+    assert.equal(
+      new Set(rows.map((row) => row.trim())).size,
+      3,
+      'three rows that read differently',
+    );
+    assert.ok(
+      rows.some((row) => /click_element · element e7 · Calculator window 7/.test(row)),
+      `expected the first click to name its element, got:\n${rows.join('\n')}`,
+    );
+    assert.ok(rows.some((row) => /click_element · element e9/.test(row)));
+    assert.ok(rows.some((row) => /observe · Calculator window 7/.test(row)));
+    // The host's own approval bookkeeping is not something the model asked for
+    // and has no business in a transcript row.
+    const all = rows.join('\n');
+    assert.equal(/approvalClass|rememberForTurnAllowed|observationId/.test(all), false, all);
   });
 });
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -3,7 +3,7 @@ import { before, describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import { _setColorLevelForTesting } from '../tui-ansi.js';
 import type { PipeShellOutput, PtyShellOutput, ShellRunToolResult } from '@maka/core';
-import { computerUseApprovalSummary } from '@maka/core';
+import { computerUseModelCallArgs } from '@maka/core';
 import type { SessionEvent, ToolResultContent } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import {
@@ -4654,9 +4654,11 @@ describe('Maka Pi TUI Computer Use rows', () => {
   /**
    * The desktop is not the only renderer of tool activity, and the row that
    * reads `Maka Computer` reads it in both. The arguments are put through
-   * `computerUseApprovalSummary`, because that is what the runtime persists and
-   * emits for this tool — a fixture written as the wire call would assert a
-   * label from fields the TUI can never receive.
+   * `computerUseModelCallArgs`, because that is what the runtime persists and
+   * emits for this tool — a fixture written as the wire call, or run through
+   * some other projection, would assert a label from fields the TUI can never
+   * receive. That projection speaks the tool's own dialect: `window_id` and
+   * `element_id`, not `windowId` and `elementId`.
    */
   test('says what each Computer Use call did instead of repeating the tool name', () => {
     const state = createMakaPiTranscriptState();
@@ -4687,7 +4689,7 @@ describe('Maka Pi TUI Computer Use rows', () => {
           toolName: 'maka_computer',
           displayName: 'Maka Computer',
           activityKind: 'computer',
-          args: computerUseApprovalSummary(wireArgs),
+          args: computerUseModelCallArgs(wireArgs),
         }),
       );
       applyMakaSessionEventToTranscript(
@@ -4718,7 +4720,7 @@ describe('Maka Pi TUI Computer Use rows', () => {
     // The host's own approval bookkeeping is not something the model asked for
     // and has no business in a transcript row.
     const all = rows.join('\n');
-    assert.equal(/approvalClass|rememberForTurnAllowed|observationId/.test(all), false, all);
+    assert.equal(/approvalClass|rememberForTurnAllowed|observation_id/.test(all), false, all);
   });
 });
 

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -798,12 +798,15 @@ function toolInputSummary(entry: MakaPiToolEntry): string {
  * `action: … / approvalClass: … / rememberForTurnAllowed: …`, which names the
  * host's own approval bookkeeping rather than anything the model asked for.
  *
- * The arguments here are a `ComputerUseApprovalSummary`, not the wire call:
+ * The arguments here are a `ComputerUseModelCallArgs`, not the raw wire call:
  * `ToolRuntime` substitutes that projection for any tool declaring
- * `categoryHint: 'computer_use'` before anything is persisted. So the action,
- * the app, the window and the element are available and a typed value, a key
- * name and a coordinate are not — deliberately, and the same fields the desktop
- * row can use.
+ * `categoryHint: 'computer_use'` before anything is persisted. It keeps every
+ * key the model sent in the names the tool accepts — `window_id`, `element_id`
+ * — and reduces a screen-derived or typed value to its shape, so the action,
+ * the app, the window and the element are available and a written value is
+ * not. Reading `windowId`/`elementId` here instead is not a compile error and
+ * not a crash; it is every row silently losing its element, which is the defect
+ * this function exists to remove.
  */
 function computerCallSummary(args: Record<string, unknown> | undefined): string | undefined {
   if (!args) return undefined;
@@ -814,10 +817,10 @@ function computerCallSummary(args: Record<string, unknown> | undefined): string 
   const action = text('action');
   if (!action) return undefined;
   const parts = [action];
-  const elementId = text('elementId');
+  const elementId = text('element_id');
   if (elementId) parts.push(`element ${elementId}`);
   const app = text('app');
-  const windowId = args.windowId;
+  const windowId = args.window_id;
   const target =
     app && typeof windowId === 'number'
       ? `${app} window ${windowId}`

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -770,6 +770,11 @@ function toolInputSummary(entry: MakaPiToolEntry): string {
       }
       break;
     }
+    case 'maka_computer': {
+      const line = computerCallSummary(obj);
+      if (line) return line;
+      break;
+    }
   }
   if (input === undefined) return '';
   // Generic fallback: use the shared invocation-line formatter instead of
@@ -781,4 +786,42 @@ function toolInputSummary(entry: MakaPiToolEntry): string {
   if (line) return limitText(line, 600);
   // Absolute last resort — still single-line for the compact header contract.
   return `input: ${limitText(formatUnknownInline(input), 600)}`;
+}
+
+/**
+ * What one Computer Use call did, for the row that names it.
+ *
+ * Every other tool's row is legible from its name plus one headline argument.
+ * This tool's name is `Maka Computer` for observing a window, clicking a
+ * button and observing again alike, so ten calls in a turn printed ten
+ * identical headers; the generic fallback then spelled the arguments out as
+ * `action: … / approvalClass: … / rememberForTurnAllowed: …`, which names the
+ * host's own approval bookkeeping rather than anything the model asked for.
+ *
+ * The arguments here are a `ComputerUseApprovalSummary`, not the wire call:
+ * `ToolRuntime` substitutes that projection for any tool declaring
+ * `categoryHint: 'computer_use'` before anything is persisted. So the action,
+ * the app, the window and the element are available and a typed value, a key
+ * name and a coordinate are not — deliberately, and the same fields the desktop
+ * row can use.
+ */
+function computerCallSummary(args: Record<string, unknown> | undefined): string | undefined {
+  if (!args) return undefined;
+  const text = (key: string): string | undefined => {
+    const value = args[key];
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+  };
+  const action = text('action');
+  if (!action) return undefined;
+  const parts = [action];
+  const elementId = text('elementId');
+  if (elementId) parts.push(`element ${elementId}`);
+  const app = text('app');
+  const windowId = args.windowId;
+  const target =
+    app && typeof windowId === 'number'
+      ? `${app} window ${windowId}`
+      : (app ?? (typeof windowId === 'number' ? `window ${windowId}` : undefined));
+  if (target) parts.push(target);
+  return limitText(parts.join(' · '), 600);
 }

--- a/packages/core/src/__tests__/computer-use.test.ts
+++ b/packages/core/src/__tests__/computer-use.test.ts
@@ -150,39 +150,39 @@ describe('Computer Use foundation contract', () => {
   });
 
   /**
-   * `stableIdentifier` is a shape filter, not a privacy boundary:
-   * `[A-Za-z0-9._:-]{1,256}` is also the shape of an API key. This projection is
-   * what `ToolRuntime` persists as the Computer Use call's arguments and what
-   * the row renders, and arguments are not validated before it runs — so an
-   * element id that survives the shape filter has to survive redaction too, on
-   * exactly the terms `observationId` does. Remove the redaction from
-   * `elementId` and this test goes red.
+   * The identifier shape `[A-Za-z0-9._:-]{1,256}` is also the shape of an API
+   * key, so admitting an element id by shape is not on its own a privacy
+   * boundary. `computerUseModelCallArgs` is what `ToolRuntime` persists as the
+   * Computer Use call's arguments, what the model reads back as its own history
+   * and what both renderers turn into a row; arguments are not validated before
+   * it runs, so a model that put a key under `element_id` reaches it. Remove
+   * the redaction and this test goes red.
    */
-  test('a secret-shaped element id is redacted on the same terms as an observation id', () => {
+  test('a secret-shaped element id is redacted on the same terms as an app name', () => {
     for (const secret of [
       'sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIjKlMnOpQrStUvWxYz01',
       'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
     ]) {
-      const asElement = computerUseApprovalSummary({
+      const asElement = computerUseModelCallArgs({
         action: 'click_element',
         app: 'Example',
         window_id: 42,
         observation_id: 'frame-7',
         element_id: secret,
       });
-      const asObservation = computerUseApprovalSummary({
+      const asApp = computerUseModelCallArgs({
         action: 'click_element',
-        app: 'Example',
         window_id: 42,
-        observation_id: secret,
+        observation_id: 'frame-7',
+        app: secret,
       });
-      assert.equal(asElement.elementId?.includes(secret), false);
-      assert.equal(asElement.elementId, asObservation.observationId);
+      assert.equal(asElement.element_id?.includes(secret), false);
+      assert.equal(asElement.element_id, asApp.app);
     }
     // An ordinary element id is untouched: redaction must not cost the row the
     // one field that tells two clicks in a turn apart.
     assert.equal(
-      computerUseApprovalSummary({ action: 'click_element', element_id: 'e12' }).elementId,
+      computerUseModelCallArgs({ action: 'click_element', element_id: 'e12' }).element_id,
       'e12',
     );
   });

--- a/packages/core/src/__tests__/computer-use.test.ts
+++ b/packages/core/src/__tests__/computer-use.test.ts
@@ -149,6 +149,44 @@ describe('Computer Use foundation contract', () => {
     assert.equal(summary.observationId?.includes('sk-test-observation'), false);
   });
 
+  /**
+   * `stableIdentifier` is a shape filter, not a privacy boundary:
+   * `[A-Za-z0-9._:-]{1,256}` is also the shape of an API key. This projection is
+   * what `ToolRuntime` persists as the Computer Use call's arguments and what
+   * the row renders, and arguments are not validated before it runs — so an
+   * element id that survives the shape filter has to survive redaction too, on
+   * exactly the terms `observationId` does. Remove the redaction from
+   * `elementId` and this test goes red.
+   */
+  test('a secret-shaped element id is redacted on the same terms as an observation id', () => {
+    for (const secret of [
+      'sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIjKlMnOpQrStUvWxYz01',
+      'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+    ]) {
+      const asElement = computerUseApprovalSummary({
+        action: 'click_element',
+        app: 'Example',
+        window_id: 42,
+        observation_id: 'frame-7',
+        element_id: secret,
+      });
+      const asObservation = computerUseApprovalSummary({
+        action: 'click_element',
+        app: 'Example',
+        window_id: 42,
+        observation_id: secret,
+      });
+      assert.equal(asElement.elementId?.includes(secret), false);
+      assert.equal(asElement.elementId, asObservation.observationId);
+    }
+    // An ordinary element id is untouched: redaction must not cost the row the
+    // one field that tells two clicks in a turn apart.
+    assert.equal(
+      computerUseApprovalSummary({ action: 'click_element', element_id: 'e12' }).elementId,
+      'e12',
+    );
+  });
+
   test('approval scope separates read, screenshot, and mutation classes', () => {
     const metadata = computerUseApprovalScopeKey({
       action: 'observe',

--- a/packages/core/src/computer-use.ts
+++ b/packages/core/src/computer-use.ts
@@ -349,29 +349,6 @@ export interface ComputerUseApprovalSummary {
   app?: string;
   windowId?: number;
   observationId?: string;
-  /**
-   * Which element the call targeted, when it targeted one.
-   *
-   * This projection is the only Computer Use argument shape that is persisted
-   * and the only one a renderer or an approval prompt can read, so an element
-   * action that omitted it could not be told apart from any other element
-   * action: ten clicks in a turn all read "click the element".
-   *
-   * It is safe to keep for the same reason `observationId` is, and it is kept
-   * the same way. An element id is the model's own choice of an index into an
-   * observation it already read — `e12` — not anything the screen said. It is
-   * admitted only when it matches {@link stableIdentifier}, so an accessibility
-   * label, a typed value, or any other free text that arrived under this key is
-   * dropped rather than persisted. That shape filter is not on its own a
-   * privacy boundary: `[A-Za-z0-9._:-]{1,256}` is also the shape of an API key,
-   * so a model that put one here would otherwise write it verbatim into the
-   * persisted arguments and into the row. It therefore runs the same
-   * {@link redactSecrets} pass `observationId` and `app` do — the projection is
-   * what gets persisted, so the redaction has to happen here. Values the screen
-   * or the user supplied — `value`, `text`, `coordinate` — stay out, as the
-   * privacy boundary requires.
-   */
-  elementId?: string;
 }
 
 /**
@@ -609,7 +586,6 @@ export function computerUseApprovalSummary(args: unknown): ComputerUseApprovalSu
   const rawApp = ownDataProperty(record, 'app');
   const rawWindowId = ownDataProperty(record, 'window_id');
   const rawObservationId = ownDataProperty(record, 'observation_id');
-  const rawElementId = ownDataProperty(record, 'element_id');
   const exactApp = typeof rawApp === 'string' && rawApp.length > 0 ? rawApp : undefined;
   const app = exactApp === undefined ? undefined : boundedDisplay(redactSecrets(exactApp), 256);
   const windowId =
@@ -620,10 +596,6 @@ export function computerUseApprovalSummary(args: unknown): ComputerUseApprovalSu
     exactObservationId === undefined
       ? undefined
       : boundedDisplay(redactSecrets(exactObservationId), 256);
-  const exactElementId =
-    typeof rawElementId === 'string' ? stableIdentifier(rawElementId) : undefined;
-  const elementId =
-    exactElementId === undefined ? undefined : boundedDisplay(redactSecrets(exactElementId), 256);
   const explicitTarget = exactApp !== undefined || windowId !== undefined;
   const targetBound =
     action === 'list_apps' ||
@@ -642,7 +614,6 @@ export function computerUseApprovalSummary(args: unknown): ComputerUseApprovalSu
     ...(app === undefined ? {} : { app }),
     ...(windowId === undefined ? {} : { windowId }),
     ...(observationId === undefined ? {} : { observationId }),
-    ...(elementId === undefined ? {} : { elementId }),
   };
 }
 

--- a/packages/core/src/computer-use.ts
+++ b/packages/core/src/computer-use.ts
@@ -349,6 +349,29 @@ export interface ComputerUseApprovalSummary {
   app?: string;
   windowId?: number;
   observationId?: string;
+  /**
+   * Which element the call targeted, when it targeted one.
+   *
+   * This projection is the only Computer Use argument shape that is persisted
+   * and the only one a renderer or an approval prompt can read, so an element
+   * action that omitted it could not be told apart from any other element
+   * action: ten clicks in a turn all read "click the element".
+   *
+   * It is safe to keep for the same reason `observationId` is, and it is kept
+   * the same way. An element id is the model's own choice of an index into an
+   * observation it already read — `e12` — not anything the screen said. It is
+   * admitted only when it matches {@link stableIdentifier}, so an accessibility
+   * label, a typed value, or any other free text that arrived under this key is
+   * dropped rather than persisted. That shape filter is not on its own a
+   * privacy boundary: `[A-Za-z0-9._:-]{1,256}` is also the shape of an API key,
+   * so a model that put one here would otherwise write it verbatim into the
+   * persisted arguments and into the row. It therefore runs the same
+   * {@link redactSecrets} pass `observationId` and `app` do — the projection is
+   * what gets persisted, so the redaction has to happen here. Values the screen
+   * or the user supplied — `value`, `text`, `coordinate` — stay out, as the
+   * privacy boundary requires.
+   */
+  elementId?: string;
 }
 
 /**
@@ -586,6 +609,7 @@ export function computerUseApprovalSummary(args: unknown): ComputerUseApprovalSu
   const rawApp = ownDataProperty(record, 'app');
   const rawWindowId = ownDataProperty(record, 'window_id');
   const rawObservationId = ownDataProperty(record, 'observation_id');
+  const rawElementId = ownDataProperty(record, 'element_id');
   const exactApp = typeof rawApp === 'string' && rawApp.length > 0 ? rawApp : undefined;
   const app = exactApp === undefined ? undefined : boundedDisplay(redactSecrets(exactApp), 256);
   const windowId =
@@ -596,6 +620,10 @@ export function computerUseApprovalSummary(args: unknown): ComputerUseApprovalSu
     exactObservationId === undefined
       ? undefined
       : boundedDisplay(redactSecrets(exactObservationId), 256);
+  const exactElementId =
+    typeof rawElementId === 'string' ? stableIdentifier(rawElementId) : undefined;
+  const elementId =
+    exactElementId === undefined ? undefined : boundedDisplay(redactSecrets(exactElementId), 256);
   const explicitTarget = exactApp !== undefined || windowId !== undefined;
   const targetBound =
     action === 'list_apps' ||
@@ -614,6 +642,7 @@ export function computerUseApprovalSummary(args: unknown): ComputerUseApprovalSu
     ...(app === undefined ? {} : { app }),
     ...(windowId === undefined ? {} : { windowId }),
     ...(observationId === undefined ? {} : { observationId }),
+    ...(elementId === undefined ? {} : { elementId }),
   };
 }
 

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -36,6 +36,11 @@ import { defineObjectShape, hasExactShape, isRecord } from './record-schema.js';
 export const TOOL_OUTPUT_STREAMS = ['stdout', 'stderr'] as const;
 export const TOOL_OUTPUT_DELTA_MAX_CHARS = 8192;
 export const TOOL_ACTIVITY_KINDS = [
+  // Driving the user's own machine is not "a tool call". It has its own risk,
+  // its own approval classes and its own place in a transcript, and reading it
+  // under the same gear icon as everything else hides the one activity a person
+  // most wants to pick out at a glance.
+  'computer',
   'read',
   'search',
   'websearch',

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { MAX_ATTACHMENT_BYTES, MAX_ATTACHMENT_COUNT } from '@maka/core/attachments';
-import { TOOL_OUTPUT_DELTA_MAX_CHARS } from '@maka/core/events';
+import { TOOL_ACTIVITY_KINDS, TOOL_OUTPUT_DELTA_MAX_CHARS } from '@maka/core/events';
 import {
   decodeClientFrame,
   decodeHostFrame,
@@ -309,6 +309,48 @@ describe('Runtime Host bootstrap protocol', () => {
         }),
       isInvalidFrame,
     );
+  });
+
+  /**
+   * The decoder is the worst place to keep a second copy of a vocabulary: a
+   * kind added anywhere else made this reject the whole frame, and the failure
+   * arrived as a protocol violation naming nothing. `requireToolActivityKind`
+   * was a hand-written chain that had already fallen behind — it threw on
+   * `'computer'` — and nothing in this package exercised it, so putting it back
+   * would have cost no test at all.
+   *
+   * Every kind on the wire decodes; a plausible one that is not on it does not.
+   */
+  test('accepts every declared tool activity kind and nothing else', () => {
+    const envelope = {
+      kind: 'subscription.session_event' as const,
+      hostEpoch: 'epoch-1',
+      subscriptionId: 'subscription-1',
+      sequence: 1,
+      sessionId: 'session-1',
+      runId: 'run-1',
+    };
+    const start = {
+      id: 'event-1',
+      turnId: 'turn-1',
+      ts: 1,
+      toolUseId: 'tool-1',
+      type: 'tool_start' as const,
+      toolName: 'maka_computer',
+    };
+    assert.ok(TOOL_ACTIVITY_KINDS.includes('computer'));
+    for (const activityKind of TOOL_ACTIVITY_KINDS) {
+      assert.doesNotThrow(
+        () => decodeHostFrame({ ...envelope, event: { ...start, activityKind } }),
+        `the wire declares ${activityKind}, so the decoder must accept it`,
+      );
+    }
+    for (const activityKind of ['desktop', 'Computer', '', 7]) {
+      assert.throws(
+        () => decodeHostFrame({ ...envelope, event: { ...start, activityKind } }),
+        isInvalidFrame,
+      );
+    }
   });
 
   test('enforces UTF-8 snapshot, live field, and whole-frame byte bounds', () => {

--- a/packages/runtime-host/src/protocol/session-continuity.ts
+++ b/packages/runtime-host/src/protocol/session-continuity.ts
@@ -1,4 +1,5 @@
-import { TOOL_OUTPUT_DELTA_MAX_CHARS } from '@maka/core/events';
+import { TOOL_ACTIVITY_KINDS, TOOL_OUTPUT_DELTA_MAX_CHARS } from '@maka/core/events';
+import type { ToolActivityKind } from '@maka/core/events';
 import {
   assertExactKeys,
   requireCount,
@@ -115,16 +116,10 @@ export type SessionToolEvent =
       type: 'tool_start';
       toolName: string;
       operationId?: string;
-      activityKind?:
-        | 'read'
-        | 'search'
-        | 'websearch'
-        | 'webfetch'
-        | 'edit'
-        | 'command'
-        | 'explore'
-        | 'browser'
-        | 'tool';
+      // From the one list, not a fourth copy of it. This was written out by
+      // hand and drifted the moment a kind was added — the wire then rejected
+      // an event the rest of the system considered valid.
+      activityKind?: ToolActivityKind;
       displayName?: string;
       stepId?: string;
     })
@@ -645,21 +640,17 @@ function requireEncodedByteLimit(value: unknown, label: string, maxBytes: number
   }
 }
 
-function requireToolActivityKind(
-  value: unknown,
-): Extract<SessionToolEvent, { type: 'tool_start' }>['activityKind'] {
-  if (
-    value === 'read' ||
-    value === 'search' ||
-    value === 'websearch' ||
-    value === 'webfetch' ||
-    value === 'edit' ||
-    value === 'command' ||
-    value === 'explore' ||
-    value === 'browser' ||
-    value === 'tool'
-  )
-    return value;
+/**
+ * Read against the one list rather than a copy of it.
+ *
+ * This was a hand-written chain, and a decoder is the worst place for a copy:
+ * a kind added anywhere else made this reject the whole frame, so the failure
+ * arrives as a protocol violation rather than as anything naming the field.
+ */
+function requireToolActivityKind(value: unknown): ToolActivityKind {
+  if (typeof value === 'string' && (TOOL_ACTIVITY_KINDS as readonly string[]).includes(value)) {
+    return value as ToolActivityKind;
+  }
   throw invalidProtocolFrame('Invalid Session tool activity kind');
 }
 

--- a/packages/runtime/src/__tests__/computer-use-privacy-boundary.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-privacy-boundary.test.ts
@@ -278,43 +278,47 @@ test('Computer Use persists which element a call targeted', async () => {
   };
 
   // This object is the dialect, not an example of it. `computerActionLabel` in
-  // `packages/ui/src/tool-activity/computer-action-label.ts` reads these exact
-  // key names off the persisted args, and it is the only thing that turns a
-  // Computer Use row into a sentence. Respell them at the seam — `windowId` to
-  // `window_id`, `elementId` to `element_id` — and the renderer silently falls
-  // back to "点击该元素" on every row, which is the defect this projection
-  // exists to prevent. Change this assertion and that file in one commit.
+  // `packages/ui/src/tool-activity/computer-action-label.ts` and
+  // `computerCallSummary` in `packages/cli/src/pi-transcript-tools.ts` read
+  // these exact key names off the persisted args, and they are the only things
+  // that turn a Computer Use row into a sentence. Respell them at the seam —
+  // `window_id` to `windowId`, `element_id` to `elementId` — and both renderers
+  // silently fall back to "点击该元素" on every row, which is the defect this
+  // projection exists to prevent. Neither renderer's own suite can see it: both
+  // build their fixtures by calling a projection, so respelling the seam leaves
+  // them green. Change this assertion and those two files in one commit.
   assert.deepEqual(await persisted('e7'), {
     action: 'click_element',
-    approvalClass: 'semantic_mutation',
-    rememberForTurnAllowed: true,
     app: 'Calculator',
-    windowId: 7,
-    observationId: 'frame-1',
-    elementId: 'e7',
+    window_id: 7,
+    observation_id: 'frame-1',
+    element_id: 'e7',
   });
   // Two clicks in one turn have to be distinguishable, which is the whole
   // reason the field is carried.
-  assert.equal(((await persisted('e9')) as { elementId?: string }).elementId, 'e9');
-  // Anything under that key that is not an identifier is dropped rather than
-  // persisted: an accessibility label is screen content.
-  assert.equal(
-    ((await persisted('Customer SSN 123-45-6789')) as { elementId?: string }).elementId,
-    undefined,
-  );
+  assert.equal(((await persisted('e9')) as { element_id?: string }).element_id, 'e9');
   // A shape filter is not a privacy boundary. Arguments are not validated
   // before this projection runs — the test below asserts an invalid call still
-  // persists a summary — so a model that put a key under `element_id` reaches
-  // here, and `[A-Za-z0-9._:-]{1,256}` admits one. It has to be redacted at the
-  // seam, on the same terms `observation_id` and `app` already are, because
-  // this is the object that lands in the transcript.
+  // persists a record — so a model that put a key under `element_id` reaches
+  // here, and the identifier shape `[A-Za-z0-9._:-]{1,256}` admits one. It is
+  // redacted at the seam, on the same terms `app` already is, because this is
+  // the object that lands in the transcript and in the model's own history.
   assert.equal(
     (
       (await persisted('sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGh')) as {
-        elementId?: string;
+        element_id?: string;
       }
-    ).elementId,
+    ).element_id,
     '[redacted]',
+  );
+  // Free text under that key is kept, deliberately: the model has to read back
+  // the call it made, and an element id it invented is still what it sent. The
+  // renderers are what refuse to print one — `computer-action-label.test.ts`
+  // pins that — because a row is read by a person and this record is read by
+  // the model that wrote it.
+  assert.equal(
+    ((await persisted('Customer SSN 123-45-6789')) as { element_id?: string }).element_id,
+    'Customer SSN 123-45-6789',
   );
 });
 

--- a/packages/runtime/src/__tests__/computer-use-privacy-boundary.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-privacy-boundary.test.ts
@@ -216,6 +216,108 @@ test('the record a model reads back is the call it made, in the names the tool a
   assert.deepEqual(call?.type === 'tool_call' ? call.args : undefined, persisted);
 });
 
+/**
+ * The other half of the same boundary. Withholding a typed value is correct;
+ * withholding which element was acted on is not, and it is what made every
+ * element row in a turn read the same. This asserts on the events the runtime
+ * emits, not on a hand-built row: the renderer only ever sees this projection,
+ * so a label test that builds its own `args` cannot notice the field is gone.
+ */
+test('Computer Use persists which element a call targeted', async () => {
+  const messages: StoredMessage[] = [];
+  const events: SessionEvent[] = [];
+  const runtime = createTestToolRuntime({
+    sessionId: 'session-1',
+    header: header(),
+    connection: connection(),
+    modelId: 'mock-model',
+    appendMessage: async (message) => {
+      messages.push(message);
+    },
+    newId: nextId(),
+    now: () => 1,
+    getPermissionPauseTarget: () => null,
+  });
+  const tool: MakaTool = {
+    name: 'maka_computer',
+    description: 'test',
+    parameters: {},
+    categoryHint: 'computer_use',
+    impl: async () => ({ ok: true }),
+  };
+  const persisted = async (elementId: string): Promise<unknown> => {
+    messages.length = 0;
+    events.length = 0;
+    await runtime.settleToolCall({
+      tool,
+      turnId: 'turn-1',
+      toolCallId: `tool-${elementId}`,
+      input: {
+        action: 'click_element',
+        app: 'Calculator',
+        window_id: 7,
+        observation_id: 'frame-1',
+        element_id: elementId,
+      },
+      abortSignal: new AbortController().signal,
+      eventSink: {
+        push: (event) => events.push(event),
+        pushAndWaitUntilConsumed: async (event) => {
+          events.push(event);
+        },
+      },
+    });
+    const start = events.find((event) => event.type === 'tool_start');
+    const call = messages.find((message) => message.type === 'tool_call');
+    // The two surfaces a renderer can read must agree.
+    assert.deepEqual(
+      start?.type === 'tool_start' ? start.args : undefined,
+      call?.type === 'tool_call' ? call.args : undefined,
+    );
+    return start?.type === 'tool_start' ? start.args : undefined;
+  };
+
+  // This object is the dialect, not an example of it. `computerActionLabel` in
+  // `packages/ui/src/tool-activity/computer-action-label.ts` reads these exact
+  // key names off the persisted args, and it is the only thing that turns a
+  // Computer Use row into a sentence. Respell them at the seam — `windowId` to
+  // `window_id`, `elementId` to `element_id` — and the renderer silently falls
+  // back to "点击该元素" on every row, which is the defect this projection
+  // exists to prevent. Change this assertion and that file in one commit.
+  assert.deepEqual(await persisted('e7'), {
+    action: 'click_element',
+    approvalClass: 'semantic_mutation',
+    rememberForTurnAllowed: true,
+    app: 'Calculator',
+    windowId: 7,
+    observationId: 'frame-1',
+    elementId: 'e7',
+  });
+  // Two clicks in one turn have to be distinguishable, which is the whole
+  // reason the field is carried.
+  assert.equal(((await persisted('e9')) as { elementId?: string }).elementId, 'e9');
+  // Anything under that key that is not an identifier is dropped rather than
+  // persisted: an accessibility label is screen content.
+  assert.equal(
+    ((await persisted('Customer SSN 123-45-6789')) as { elementId?: string }).elementId,
+    undefined,
+  );
+  // A shape filter is not a privacy boundary. Arguments are not validated
+  // before this projection runs — the test below asserts an invalid call still
+  // persists a summary — so a model that put a key under `element_id` reaches
+  // here, and `[A-Za-z0-9._:-]{1,256}` admits one. It has to be redacted at the
+  // seam, on the same terms `observation_id` and `app` already are, because
+  // this is the object that lands in the transcript.
+  assert.equal(
+    (
+      (await persisted('sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGh')) as {
+        elementId?: string;
+      }
+    ).elementId,
+    '[redacted]',
+  );
+});
+
 test('Computer Use validation failures still persist a redacted call and result', async () => {
   const messages: StoredMessage[] = [];
   const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -247,6 +247,14 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     assert.ok(tool.parameters, 'carries a zod parameter schema');
   });
 
+  test('declares the activity kind the renderer buckets it by', () => {
+    // Without this the `computer` kind has no producer at all, and every
+    // surface has to recognise Computer Use by its tool name instead — which
+    // is the recognition-by-string the kind was added to replace.
+    const [tool] = buildComputerUseTools({ backend: fakeBackend() });
+    assert.equal(tool.activityKind, 'computer');
+  });
+
   test('waits for presentation readiness before dispatch without waiting for finish', async () => {
     const events: string[] = [];
     let ready!: () => void;

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -793,6 +793,10 @@ export function buildComputerUseTools(deps: {
   const tool: MakaTool<ComputerParams, ComputerToolResult> = {
     name: 'maka_computer',
     displayName: 'Maka Computer',
+    // The kind every other builtin declares, and the reason `'computer'` is on
+    // the wire at all. Without it the renderer had to recognise this tool by
+    // name, which is the recognition-by-string the kind exists to replace.
+    activityKind: 'computer',
     description:
       'Maka semantic computer harness. Use action=observe to read the current computer state before acting, then use the same function ' +
       'for semantic element actions, exact Electron page actions, wait, zoom, or another observation. Every successful mutating action returns a fresh screenshot when available ' +

--- a/packages/ui/src/__tests__/computer-action-label.test.ts
+++ b/packages/ui/src/__tests__/computer-action-label.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup as renderReactToStaticMarkup } from 'react-dom/server';
-import { computerUseApprovalSummary } from '@maka/core';
+import { computerUseModelCallArgs } from '@maka/core';
 import { ToolTrow } from '../tool-activity.js';
 import { computerActionLabel, isComputerTool } from '../tool-activity/computer-action-label.js';
 import type { ToolActivityItem } from '../materialize.js';
@@ -12,14 +12,19 @@ import { LocaleProvider } from '../locale-context.js';
  * A row exactly as the runtime produces one.
  *
  * The arguments handed in are the wire call the model made; what the row gets
- * is `computerUseApprovalSummary(...)` of it, because that is what
- * `ToolRuntime.executeTool` puts on the `tool_start` event and in the persisted
- * `tool_call` for any tool declaring `categoryHint: 'computer_use'`.
+ * is `computerUseModelCallArgs(...)` of it, because that is what `ToolRuntime`
+ * puts on the `tool_start` event and in the persisted `tool_call` for any tool
+ * declaring `categoryHint: 'computer_use'`.
  *
- * Every fixture in this file goes through that projection, which is the point.
- * Hand-built `args` let a label be asserted from a field the renderer can never
- * receive: with wire arguments written straight into the row, this suite passed
- * while a ten-click turn rendered ten rows reading "点击该元素".
+ * Every fixture in this file goes through that projection, which is the point,
+ * and it has to be *that* projection rather than any projection. Hand-built
+ * `args` let a label be asserted from a field the renderer can never receive:
+ * with wire arguments written straight into the row, this suite passed while a
+ * ten-click turn rendered ten rows reading "点击该元素". Running them through
+ * the wrong projection is the same failure wearing a fixture — this file built
+ * its rows with `computerUseApprovalSummary`, which spells the same fields
+ * `windowId` and `elementId`, and stayed green through the seam being changed
+ * underneath it.
  */
 function computerCall(
   wireArgs: Record<string, unknown>,
@@ -31,7 +36,7 @@ function computerCall(
     displayName: 'Maka Computer',
     activityKind: 'computer',
     status: 'completed',
-    args: computerUseApprovalSummary(wireArgs),
+    args: computerUseModelCallArgs(wireArgs),
     ...extra,
   };
 }
@@ -105,28 +110,30 @@ describe('computer action label', () => {
   });
 
   /**
-   * The projection admits an element id only when it is a stable identifier.
-   * An accessibility label that arrived under that key is not one, and must not
-   * reach a row — the same reason the privacy boundary keeps `value` and
-   * `text` out entirely.
+   * The persisted projection keeps whatever the model sent under `element_id`,
+   * because the model has to read back the call it made. The row does not: an
+   * accessibility label the model copied off the screen is not an index into an
+   * observation, and it has no business in a sentence a person reads.
    */
   it('drops an element id that is free text rather than an identifier', () => {
-    const args = computerUseApprovalSummary({
+    const args = computerUseModelCallArgs({
       action: 'click_element',
       element_id: 'Customer SSN 123-45-6789',
     });
-    assert.equal((args as { elementId?: string }).elementId, undefined);
+    // The projection carries it — this is the renderer's own refusal, not the
+    // projection's, so it has to be asserted against a projection that kept it.
+    assert.equal(args.element_id, 'Customer SSN 123-45-6789');
     assert.equal(label({ action: 'click_element', element_id: 'Customer SSN 123-45-6789' }), '点击该元素');
   });
 
   /**
    * Not a preference: `computer-use-privacy-boundary.test.ts` asserts that a
-   * typed value and a coordinate reach neither the persisted call nor the
-   * event. A row that spelled either out would be reading a field that does not
-   * exist outside a fixture.
+   * typed value reaches neither the persisted call nor the event as anything
+   * but its shape. A row that spelled one out would be reading a field that
+   * does not exist outside a fixture.
    */
   it('never spells out a value the privacy boundary withholds', () => {
-    const args = computerUseApprovalSummary({
+    const args = computerUseModelCallArgs({
       action: 'set_value',
       element_id: 'e1',
       value: 'sk-abcdefghijklmnopqrstuvwx',
@@ -134,10 +141,12 @@ describe('computer action label', () => {
     });
     assert.deepEqual(Object.keys(args).sort(), [
       'action',
-      'approvalClass',
-      'elementId',
-      'rememberForTurnAllowed',
+      'coordinate',
+      'element_id',
+      'value',
     ]);
+    // The written value never crosses; only its shape does.
+    assert.equal(args.value, '<text>');
     const row = computerActionLabel(computerCall({
       action: 'set_value',
       element_id: 'e1',
@@ -211,7 +220,7 @@ describe('computer action label', () => {
       toolName: 'some_other_name',
       activityKind: 'computer',
       status: 'completed',
-      args: computerUseApprovalSummary({ action: 'click_element', element_id: 'e7' }),
+      args: computerUseModelCallArgs({ action: 'click_element', element_id: 'e7' }),
     };
     assert.equal(isComputerTool(wrapped), true);
     assert.equal(computerActionLabel(wrapped, 'zh'), '点击元素 e7');

--- a/packages/ui/src/__tests__/computer-action-label.test.ts
+++ b/packages/ui/src/__tests__/computer-action-label.test.ts
@@ -1,0 +1,298 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createElement, type ReactNode } from 'react';
+import { renderToStaticMarkup as renderReactToStaticMarkup } from 'react-dom/server';
+import { computerUseApprovalSummary } from '@maka/core';
+import { ToolTrow } from '../tool-activity.js';
+import { computerActionLabel, isComputerTool } from '../tool-activity/computer-action-label.js';
+import type { ToolActivityItem } from '../materialize.js';
+import { LocaleProvider } from '../locale-context.js';
+
+/**
+ * A row exactly as the runtime produces one.
+ *
+ * The arguments handed in are the wire call the model made; what the row gets
+ * is `computerUseApprovalSummary(...)` of it, because that is what
+ * `ToolRuntime.executeTool` puts on the `tool_start` event and in the persisted
+ * `tool_call` for any tool declaring `categoryHint: 'computer_use'`.
+ *
+ * Every fixture in this file goes through that projection, which is the point.
+ * Hand-built `args` let a label be asserted from a field the renderer can never
+ * receive: with wire arguments written straight into the row, this suite passed
+ * while a ten-click turn rendered ten rows reading "点击该元素".
+ */
+function computerCall(
+  wireArgs: Record<string, unknown>,
+  extra?: Partial<ToolActivityItem>,
+): ToolActivityItem {
+  return {
+    toolUseId: `cu-${String(wireArgs.action)}`,
+    toolName: 'maka_computer',
+    displayName: 'Maka Computer',
+    activityKind: 'computer',
+    status: 'completed',
+    args: computerUseApprovalSummary(wireArgs),
+    ...extra,
+  };
+}
+
+function label(wireArgs: Record<string, unknown>, locale: 'zh' | 'en' = 'zh'): string | undefined {
+  return computerActionLabel(computerCall(wireArgs), locale);
+}
+
+function renderRows(items: ToolActivityItem[], locale: 'zh' | 'en' = 'zh'): string {
+  return renderReactToStaticMarkup(
+    createElement(LocaleProvider, {
+      locale,
+      children: createElement(ToolTrow, { items }) as ReactNode,
+    }),
+  );
+}
+
+describe('computer action label', () => {
+  it('names each action from what the projection actually carries', () => {
+    assert.equal(label({ action: 'list_apps' }), '列出打开的应用');
+    assert.equal(label({ action: 'observe', app: '计算器' }), '观察「计算器」窗口');
+    assert.equal(label({ action: 'observe', window_id: 42 }), '观察窗口 42');
+    assert.equal(label({ action: 'screenshot', app: '计算器' }), '截图「计算器」窗口');
+    assert.equal(label({ action: 'screenshot', window_id: 42 }), '截图窗口 42');
+    assert.equal(label({ action: 'click_element', element_id: 'e12' }), '点击元素 e12');
+    assert.equal(label({ action: 'set_value', element_id: 'e12', value: '你好' }), '设置值：元素 e12');
+    assert.equal(label({ action: 'select_text', element_id: 'e12', text: 'abc' }), '选择文本：元素 e12');
+    assert.equal(label({ action: 'secondary_action', element_id: 'e12', text: '复制' }), '次要操作：元素 e12');
+    assert.equal(label({ action: 'press_key', text: 'Return' }), '按下按键');
+    assert.equal(label({ action: 'left_click', coordinate: [120, 340] }), '点击');
+    assert.equal(label({ action: 'right_click', coordinate: [1, 2] }), '右键点击');
+    assert.equal(label({ action: 'double_click', coordinate: [1, 2] }), '双击');
+    assert.equal(label({ action: 'triple_click', coordinate: [1, 2] }), '三击');
+    assert.equal(label({ action: 'middle_click', coordinate: [1, 2] }), '中键点击');
+    assert.equal(label({ action: 'mouse_move', coordinate: [1, 2] }), '移动指针');
+    assert.equal(label({ action: 'left_mouse_down', coordinate: [1, 2] }), '按下鼠标');
+    assert.equal(label({ action: 'left_mouse_up', coordinate: [1, 2] }), '松开鼠标');
+    assert.equal(label({ action: 'left_click_drag', coordinate: [1, 2] }), '拖动');
+    assert.equal(label({ action: 'type', text: '你好' }), '输入文本');
+    assert.equal(label({ action: 'key', text: 'Return' }), '按下按键');
+    assert.equal(label({ action: 'hold_key', text: 'Shift', duration: 2 }), '按住按键');
+    assert.equal(label({ action: 'scroll', scroll_direction: 'up' }), '滚动');
+    assert.equal(label({ action: 'wait', duration: 1.5 }), '等待');
+    assert.equal(label({ action: 'zoom', region: [0, 0, 10, 10] }), '放大查看区域');
+    assert.equal(label({ action: 'cursor_position' }), '读取指针位置');
+  });
+
+  /**
+   * The one row that separates two clicks in the same turn. `element_id` is the
+   * only target-naming field that survives to the renderer, so a label that
+   * cannot read it is the ten-identical-rows defect itself.
+   */
+  it('tells two element actions in the same turn apart', () => {
+    const seven = label({
+      action: 'click_element',
+      app: 'Calculator',
+      window_id: 7,
+      observation_id: 'frame-1',
+      element_id: 'e7',
+    });
+    const nine = label({
+      action: 'click_element',
+      app: 'Calculator',
+      window_id: 7,
+      observation_id: 'frame-1',
+      element_id: 'e9',
+    });
+    assert.equal(seven, '点击元素 e7');
+    assert.equal(nine, '点击元素 e9');
+    assert.notEqual(seven, nine);
+  });
+
+  /**
+   * The projection admits an element id only when it is a stable identifier.
+   * An accessibility label that arrived under that key is not one, and must not
+   * reach a row — the same reason the privacy boundary keeps `value` and
+   * `text` out entirely.
+   */
+  it('drops an element id that is free text rather than an identifier', () => {
+    const args = computerUseApprovalSummary({
+      action: 'click_element',
+      element_id: 'Customer SSN 123-45-6789',
+    });
+    assert.equal((args as { elementId?: string }).elementId, undefined);
+    assert.equal(label({ action: 'click_element', element_id: 'Customer SSN 123-45-6789' }), '点击该元素');
+  });
+
+  /**
+   * Not a preference: `computer-use-privacy-boundary.test.ts` asserts that a
+   * typed value and a coordinate reach neither the persisted call nor the
+   * event. A row that spelled either out would be reading a field that does not
+   * exist outside a fixture.
+   */
+  it('never spells out a value the privacy boundary withholds', () => {
+    const args = computerUseApprovalSummary({
+      action: 'set_value',
+      element_id: 'e1',
+      value: 'sk-abcdefghijklmnopqrstuvwx',
+      coordinate: [123, 456],
+    });
+    assert.deepEqual(Object.keys(args).sort(), [
+      'action',
+      'approvalClass',
+      'elementId',
+      'rememberForTurnAllowed',
+    ]);
+    const row = computerActionLabel(computerCall({
+      action: 'set_value',
+      element_id: 'e1',
+      value: 'sk-abcdefghijklmnopqrstuvwx',
+      coordinate: [123, 456],
+    }), 'zh');
+    assert.equal(row, '设置值：元素 e1');
+    assert.doesNotMatch(row ?? '', /abcdefghijklmnop|123|456/);
+  });
+
+  it('falls back to something that still says what happened, never to the tool name', () => {
+    // No element_id: the action is still named, the target is generic.
+    assert.equal(label({ action: 'click_element' }), '点击该元素');
+    assert.equal(label({ action: 'observe' }), '观察当前窗口');
+    // Unknown, missing, and malformed arguments all land on the generic verb —
+    // the noun "Maka Computer" is never the answer for a CU row.
+    assert.equal(label({ action: 'teleport' }), '操作电脑');
+    assert.equal(label({}), '操作电脑');
+    assert.equal(computerActionLabel(computerCall({}, { args: 'not-an-object' }), 'zh'), '操作电脑');
+    assert.equal(computerActionLabel(computerCall({}, { args: undefined }), 'zh'), '操作电脑');
+  });
+
+  it('localizes every derived label', () => {
+    assert.equal(label({ action: 'list_apps' }, 'en'), 'List open apps');
+    assert.equal(label({ action: 'observe', app: 'Calculator' }, 'en'), 'Observe the “Calculator” window');
+    assert.equal(label({ action: 'observe', window_id: 42 }, 'en'), 'Observe window 42');
+    assert.equal(label({ action: 'click_element', element_id: 'e12' }, 'en'), 'Click element e12');
+    assert.equal(label({ action: 'set_value', element_id: 'e12', value: 'hello' }, 'en'), 'Set the value of element e12');
+    assert.equal(label({ action: 'press_key', text: 'Return' }, 'en'), 'Press a key');
+    assert.equal(label({ action: 'wait', duration: 2 }, 'en'), 'Wait');
+    assert.equal(label({ action: 'teleport' }, 'en'), 'Use the computer');
+  });
+
+  /** A long app name is bounded so a row cannot become a paragraph. */
+  it('bounds an app name to one row', () => {
+    const long = label({ action: 'observe', app: 'Very Long Application Name '.repeat(8) });
+    assert.ok((long ?? '').length < 60, `expected a capped label, got ${long?.length} chars`);
+    assert.match(long ?? '', /…」窗口$/);
+  });
+
+  it('leaves other tools alone', () => {
+    assert.equal(
+      computerActionLabel(
+        { toolUseId: 't', toolName: 'Bash', status: 'completed', args: { action: 'observe' } },
+        'zh',
+      ),
+      undefined,
+    );
+  });
+
+  /**
+   * A declared `intent` and a derived label are no longer competing for one
+   * slot. Astryx gives a row a `name` and a `target`; the derived label is the
+   * name and the backend's intent is the target, so the Pi backend path keeps
+   * its words and a CU row still says which call it was.
+   */
+  it('keeps a declared intent visible alongside the derived label', () => {
+    const markup = renderRows([
+      computerCall({ action: 'click_element', element_id: 'e12' }, { intent: '点击等号' }),
+    ]);
+    assert.match(markup, /点击等号/);
+    assert.match(markup, /点击元素 e12/);
+  });
+
+  it('names a call that declares its kind rather than the CU tool name', () => {
+    // `activityKind: 'computer'` is legal on the wire and is what every other
+    // builtin declares. Recognised only by tool name, a renamed or wrapped CU
+    // tool fell through to the tool's own noun.
+    const wrapped: ToolActivityItem = {
+      toolUseId: 'x',
+      toolName: 'some_other_name',
+      activityKind: 'computer',
+      status: 'completed',
+      args: computerUseApprovalSummary({ action: 'click_element', element_id: 'e7' }),
+    };
+    assert.equal(isComputerTool(wrapped), true);
+    assert.equal(computerActionLabel(wrapped, 'zh'), '点击元素 e7');
+    assert.equal(
+      isComputerTool({ toolUseId: 'y', toolName: 'Bash', status: 'completed', args: {} }),
+      false,
+    );
+  });
+
+  it('renders one turn of Computer Use as three rows that read differently', () => {
+    const markup = renderRows([
+      computerCall({ action: 'observe', app: '计算器' }, { toolUseId: 'cu-1' }),
+      computerCall({ action: 'click_element', element_id: 'e7' }, { toolUseId: 'cu-2' }),
+      computerCall({ action: 'observe', app: '计算器' }, { toolUseId: 'cu-3' }),
+    ]);
+
+    // What the row must say, not how many times the renderer happens to say it.
+    // An exact occurrence count pins the component's internals — a collapsed
+    // detail body, a title attribute — none of which is the claim being made.
+    assert.match(markup, /观察「计算器」窗口/);
+    assert.match(markup, /点击元素 e7/);
+    // The regression this fixes: three identical noun rows.
+    assert.doesNotMatch(markup, /Maka Computer/);
+    // And that they are genuinely different from one another, which is the
+    // whole point — one label reaching the markup would satisfy the two
+    // matches above on its own.
+    const labels = [
+      computerActionLabel(computerCall({ action: 'observe', app: '计算器' }), 'zh'),
+      computerActionLabel(computerCall({ action: 'click_element', element_id: 'e7' }), 'zh'),
+    ];
+    assert.equal(new Set(labels).size, 2, 'two different actions must read differently');
+  });
+
+  // Upstream retired the second row renderer: every status now goes through
+  // Astryx. That makes the label a single implementation rather than two, but
+  // it does not make these statuses free — an in-flight call, an interrupted
+  // one and a sandbox-blocked one each take a different branch to the row, and
+  // a label lost on any of them is a row that says nothing.
+  it('names the action whatever status the row is in', () => {
+    const variants: Partial<ToolActivityItem>[] = [
+      { status: 'pending' },
+      { status: 'running' },
+      { status: 'interrupted' },
+      {
+        status: 'errored',
+        result: {
+          kind: 'terminal',
+          cwd: '/tmp/maka',
+          cmd: 'maka_computer',
+          status: 'failed',
+          exitCode: 1,
+          output: {
+            mode: 'pipes',
+            stdout: '',
+            stderr: 'Operation not permitted\n',
+            stdoutTruncated: false,
+            stderrTruncated: false,
+            redacted: false,
+          },
+          sandboxDenial: {
+            likely: true,
+            backend: 'macos-seatbelt',
+            recovery: 'require_escalated',
+          },
+        },
+      },
+    ];
+    for (const extra of variants) {
+      const markup = renderRows([
+        computerCall({ action: 'click_element', element_id: 'e7' }, { toolUseId: 'cu-row', ...extra }),
+      ]);
+      assert.match(
+        markup,
+        /点击元素 e7/,
+        `the ${extra.status} row must say what the call did`,
+      );
+      assert.doesNotMatch(
+        markup,
+        /Maka Computer/,
+        `the ${extra.status} row must not fall back to the tool's noun`,
+      );
+    }
+  });
+});

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -12,6 +12,7 @@ import { useClipboardCopyFeedback } from './clipboard-feedback.js';
 import { useUiLocale } from './locale-context.js';
 import { type ToolActivityItem, type ToolOutputChunk } from './materialize.js';
 import { isConnectorTool, resolveToolDisplayName } from './tool-activity/display-name.js';
+import { computerActionLabel } from './tool-activity/computer-action-label.js';
 import {
   extractErrorText,
   isAutomationTool,
@@ -278,7 +279,11 @@ export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
   if (items.length === 0) return null;
   const calls: ChatToolCallItem[] = items.map((item) => ({
     key: item.toolUseId,
-    name: resolveToolDisplayName(item, locale),
+    // The name is what a person reads to tell one call from the next, and for
+    // Computer Use the display name is "Maka Computer" — a noun, identical on
+    // every row of a ten-call turn. A label derived from the call's own
+    // arguments says what happened instead.
+    name: computerActionLabel(item, locale) ?? resolveToolDisplayName(item, locale),
     status: astryxToolStatus(item),
     target: item.intent ? formatToolIntent(item.intent) : undefined,
     duration: formatDuration(item.durationMs) ?? undefined,

--- a/packages/ui/src/tool-activity/computer-action-label.ts
+++ b/packages/ui/src/tool-activity/computer-action-label.ts
@@ -15,21 +15,31 @@
  *
  * ## What these arguments actually are
  *
- * Not the wire call. `maka_computer` declares `categoryHint: 'computer_use'`,
- * and `ToolRuntime.executeTool` replaces a Computer Use call's arguments with
- * `computerUseApprovalSummary(...)` before anything is persisted or emitted —
- * so `item.args` here is a `ComputerUseApprovalSummary`, and it is the only
- * argument shape any renderer can ever see. That projection carries
- * `{action, approvalClass, rememberForTurnAllowed, app?, windowId?,
- * observationId?, elementId?}`, in the projection's own casing.
+ * Not the raw wire call, but the same dialect as it. `maka_computer` declares
+ * `categoryHint: 'computer_use'`, and `ToolRuntime` replaces a Computer Use
+ * call's arguments with `computerUseModelCallArgs(...)` before anything is
+ * persisted or emitted — so `item.args` here is a `ComputerUseModelCallArgs`,
+ * and it is the only argument shape any renderer can ever see. That projection
+ * keeps every key the model sent, in the names the tool accepts: `window_id`
+ * and `element_id`, not `windowId` and `elementId`.
  *
- * Everything else is withheld on purpose, and a named test enforces it:
+ * That distinction is load-bearing rather than cosmetic. This projection used
+ * to be `computerUseApprovalSummary`, which renames both keys, and a renderer
+ * that reads the old names off the new projection does not fail — every
+ * element action quietly falls back to "点击该元素", which is the exact defect
+ * this file exists to remove. `SummaryKey` below is `keyof
+ * ComputerUseModelCallArgs` so a stale name is a type error rather than a
+ * silent `undefined`, and the runtime seam is pinned by name in
+ * `computer-use-privacy-boundary.test.ts`.
+ *
+ * Values that came off the screen or out of a person's head are reduced to
+ * their shape by that projection, and a named test enforces it:
  * `computer-use-privacy-boundary.test.ts` asserts that a `type` call's `text`
- * and a pointer call's `coordinate` reach neither the persisted `tool_call`,
- * the `tool_start` event, nor the invocation record. `value`, `text`,
- * `coordinate`, `duration`, `scroll_direction` and `region` are therefore not
- * available to this function, and no branch here pretends otherwise: a label
- * that reads "输入「你好」" could only ever come from a fixture.
+ * arrives as `<text>` in the persisted `tool_call`, the `tool_start` event and
+ * the invocation record. `value` and `text` are therefore not available to this
+ * function as anything a person would want read out, and no branch here
+ * pretends otherwise: a label that reads "输入「你好」" could only ever come
+ * from a fixture.
  *
  * An element's human label is not available either, for a different reason.
  * `element_id` is an index into one observation, and the observation the UI can
@@ -42,7 +52,7 @@
  * falling back to the tool name.
  */
 
-import { type ComputerUseApprovalSummary, type UiLocale } from '@maka/core';
+import { type ComputerUseModelCallArgs, type UiLocale } from '@maka/core';
 import type { ToolActivityItem } from '../materialize.js';
 import { getToolActivityCopy, type ToolActivityCopy } from './copy.js';
 
@@ -68,8 +78,20 @@ export function computerActionLabel(
   return describeAction(args, copy) ?? copy.fallback;
 }
 
-/** The projection's keys, named so a typo cannot silently read `undefined`. */
-type SummaryKey = keyof ComputerUseApprovalSummary;
+/**
+ * The keys the projection declares by name, and the only ones read below.
+ *
+ * Not `keyof ComputerUseModelCallArgs`: that interface carries an index
+ * signature for every other argument the model sent, so `keyof` widens to
+ * `string | number` and the stale `windowId` this file used to read would type
+ * check again. Filtering the index signature back out leaves the five names the
+ * projection spells out, so renaming one there is a build error here rather
+ * than a row that quietly reads "点击该元素".
+ */
+type DeclaredArg<T> = keyof {
+  [K in keyof T as string extends K ? never : number extends K ? never : K]: unknown;
+};
+type SummaryKey = DeclaredArg<ComputerUseModelCallArgs>;
 
 function describeAction(
   args: Record<string, unknown>,
@@ -77,8 +99,8 @@ function describeAction(
 ): string | undefined {
   const action = str(args, 'action');
   const app = displayable(str(args, 'app'));
-  const windowId = int(args, 'windowId');
-  const elementId = str(args, 'elementId');
+  const windowId = int(args, 'window_id');
+  const elementId = identifier(str(args, 'element_id'));
   const element = elementId ? copy.element(elementId) : copy.elementUnknown;
 
   switch (action) {
@@ -162,6 +184,23 @@ function int(record: Record<string, unknown>, key: SummaryKey): number | undefin
 
 /** Keep an app name short enough to stay on one row. */
 const APP_CAP = 32;
+
+/**
+ * An element id the row is willing to print, or `undefined`.
+ *
+ * The persisted projection keeps whatever the model sent under `element_id`,
+ * redacted for secrets and bounded, and that is right for the model's own
+ * record — it has to read back the call it made, wrong or not. A row is a
+ * different surface. `e12` is an index into an observation and says which
+ * control; free text under that key is either an accessibility label the model
+ * copied off the screen or a mistake, and neither belongs in a sentence a
+ * person reads. The row falls back to naming no element rather than printing
+ * it, which is what the generic "点击该元素" is for.
+ */
+const ELEMENT_ID = /^[A-Za-z0-9._:-]{1,64}$/;
+function identifier(value: string | undefined): string | undefined {
+  return value !== undefined && ELEMENT_ID.test(value) ? value : undefined;
+}
 
 /**
  * The projection already redacts and bounds `app` to 256 characters; a row is

--- a/packages/ui/src/tool-activity/computer-action-label.ts
+++ b/packages/ui/src/tool-activity/computer-action-label.ts
@@ -1,0 +1,175 @@
+/**
+ * A readable row label for one `maka_computer` call, derived from the call's
+ * own arguments.
+ *
+ * Every other tool's row reads as an action because its display name happens to
+ * be a verb phrase ("加载工具组"). Computer Use's display name is a noun —
+ * "Maka Computer" — so a turn that observed a window, clicked a button, and
+ * observed again rendered three identical rows and the reader could not tell
+ * which call did what.
+ *
+ * The label is derived, never declared: the model is not given an `intent`
+ * field to write. Every word the model sees is owned by the runtime, and a free
+ * text field would be one more place it can be wrong (and more tokens on every
+ * call).
+ *
+ * ## What these arguments actually are
+ *
+ * Not the wire call. `maka_computer` declares `categoryHint: 'computer_use'`,
+ * and `ToolRuntime.executeTool` replaces a Computer Use call's arguments with
+ * `computerUseApprovalSummary(...)` before anything is persisted or emitted —
+ * so `item.args` here is a `ComputerUseApprovalSummary`, and it is the only
+ * argument shape any renderer can ever see. That projection carries
+ * `{action, approvalClass, rememberForTurnAllowed, app?, windowId?,
+ * observationId?, elementId?}`, in the projection's own casing.
+ *
+ * Everything else is withheld on purpose, and a named test enforces it:
+ * `computer-use-privacy-boundary.test.ts` asserts that a `type` call's `text`
+ * and a pointer call's `coordinate` reach neither the persisted `tool_call`,
+ * the `tool_start` event, nor the invocation record. `value`, `text`,
+ * `coordinate`, `duration`, `scroll_direction` and `region` are therefore not
+ * available to this function, and no branch here pretends otherwise: a label
+ * that reads "输入「你好」" could only ever come from a fixture.
+ *
+ * An element's human label is not available either, for a different reason.
+ * `element_id` is an index into one observation, and the observation the UI can
+ * see is the persisted projection (`persistedObservationText` in
+ * `packages/runtime/src/computer-use-tools.ts`), a JSON header of
+ * observation_id/app/pid/window_id/element_count with no element rows at all.
+ * The labelled tree only ever exists in `modelText`, which is not persisted and
+ * never reaches the renderer. So an element action names the element by id
+ * ("点击元素 e12"), which still says what happened and to what, rather than
+ * falling back to the tool name.
+ */
+
+import { type ComputerUseApprovalSummary, type UiLocale } from '@maka/core';
+import type { ToolActivityItem } from '../materialize.js';
+import { getToolActivityCopy, type ToolActivityCopy } from './copy.js';
+
+/** True for a row produced by the Computer Use tool. */
+export function isComputerTool(item: ToolActivityItem): boolean {
+  return item.toolName === 'maka_computer' || item.activityKind === 'computer';
+}
+
+/**
+ * The row label for a Computer Use call, or `undefined` for any other tool.
+ *
+ * A Computer Use call always gets a label — an unknown or missing `action`
+ * still resolves to the generic "操作电脑", never to the tool's display name.
+ */
+export function computerActionLabel(
+  item: ToolActivityItem,
+  locale: UiLocale,
+): string | undefined {
+  if (!isComputerTool(item)) return undefined;
+  const copy = getToolActivityCopy(locale).computer;
+  const args = asRecord(item.args);
+  if (!args) return copy.fallback;
+  return describeAction(args, copy) ?? copy.fallback;
+}
+
+/** The projection's keys, named so a typo cannot silently read `undefined`. */
+type SummaryKey = keyof ComputerUseApprovalSummary;
+
+function describeAction(
+  args: Record<string, unknown>,
+  copy: ToolActivityCopy['computer'],
+): string | undefined {
+  const action = str(args, 'action');
+  const app = displayable(str(args, 'app'));
+  const windowId = int(args, 'windowId');
+  const elementId = str(args, 'elementId');
+  const element = elementId ? copy.element(elementId) : copy.elementUnknown;
+
+  switch (action) {
+    case 'list_apps':
+      return copy.listApps;
+    case 'observe':
+      return app !== undefined
+        ? copy.observeApp(app)
+        : windowId !== undefined
+          ? copy.observeWindow(windowId)
+          : copy.observe;
+    case 'screenshot':
+      return app !== undefined
+        ? copy.screenshotApp(app)
+        : windowId !== undefined
+          ? copy.screenshotWindow(windowId)
+          : copy.screenshot;
+    case 'click_element':
+      return copy.clickElement(element);
+    case 'set_value':
+      return copy.setValue(element);
+    case 'select_text':
+      return copy.selectText(element);
+    case 'secondary_action':
+      return copy.secondaryAction(element);
+    case 'press_key':
+    case 'key':
+      return copy.pressKey;
+    case 'type':
+      return copy.type;
+    case 'hold_key':
+      return copy.holdKey;
+    case 'wait':
+      return copy.wait;
+    case 'zoom':
+      return copy.zoom;
+    case 'cursor_position':
+      return copy.cursorPosition;
+    case 'scroll':
+      return copy.scroll;
+    case 'mouse_move':
+      return copy.pointer.move;
+    case 'left_click':
+      return copy.pointer.left;
+    case 'right_click':
+      return copy.pointer.right;
+    case 'middle_click':
+      return copy.pointer.middle;
+    case 'double_click':
+      return copy.pointer.double;
+    case 'triple_click':
+      return copy.pointer.triple;
+    case 'left_mouse_down':
+      return copy.pointer.down;
+    case 'left_mouse_up':
+      return copy.pointer.up;
+    case 'left_click_drag':
+      return copy.pointer.drag;
+    default:
+      return undefined;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function str(record: Record<string, unknown>, key: SummaryKey): string | undefined {
+  const value = record[key];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function int(record: Record<string, unknown>, key: SummaryKey): number | undefined {
+  const value = record[key];
+  return typeof value === 'number' && Number.isInteger(value) ? value : undefined;
+}
+
+/** Keep an app name short enough to stay on one row. */
+const APP_CAP = 32;
+
+/**
+ * The projection already redacts and bounds `app` to 256 characters; a row is
+ * narrower than that, so cap it again for layout rather than for safety.
+ */
+function displayable(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const safe = value.replace(/\s+/g, ' ').trim();
+  if (safe.length === 0) return undefined;
+  return safe.length > APP_CAP ? `${safe.slice(0, APP_CAP)}…` : safe;
+}

--- a/packages/ui/src/tool-activity/copy.ts
+++ b/packages/ui/src/tool-activity/copy.ts
@@ -21,6 +21,45 @@ export interface ToolActivityCopy {
     description: string;
     copyAriaLabel: (label: string) => string;
   };
+  /**
+   * Row labels for one Computer Use call, derived from its arguments (see
+   * `computer-action-label.ts`). The tool's display name is a noun, so every
+   * call rendered the same row; these are verb phrases that say what the call
+   * did.
+   *
+   * Each entry uses exactly what the persisted projection carries — the action,
+   * the app, the window id, the element id — and nothing more. There is no
+   * entry that spells out a typed value, a key name or a coordinate, because
+   * the privacy boundary keeps those out of anything a renderer can read, so
+   * such an entry could only ever be exercised by a fixture.
+   */
+  computer: {
+    fallback: string;
+    listApps: string;
+    observe: string;
+    observeApp: (app: string) => string;
+    observeWindow: (windowId: number) => string;
+    screenshot: string;
+    screenshotApp: (app: string) => string;
+    screenshotWindow: (windowId: number) => string;
+    element: (elementId: string) => string;
+    elementUnknown: string;
+    clickElement: (element: string) => string;
+    setValue: (element: string) => string;
+    selectText: (element: string) => string;
+    secondaryAction: (element: string) => string;
+    scroll: string;
+    pressKey: string;
+    type: string;
+    holdKey: string;
+    wait: string;
+    zoom: string;
+    cursorPosition: string;
+    pointer: Record<
+      'move' | 'left' | 'right' | 'middle' | 'double' | 'triple' | 'down' | 'up' | 'drag',
+      string
+    >;
+  };
   automation: {
     created: (name: string) => string;
     nextFire: (value: string) => string;
@@ -137,6 +176,43 @@ const TOOL_ACTIVITY_COPY = {
     output: { redacted: '[已脱敏]', redactedAriaLabel: '已脱敏', truncated: '输出已截断' },
     copy: { idle: '复制', pending: '复制中…', copied: '已复制', failed: '复制失败' },
     sandboxBlocked: { title: '操作可能被沙箱阻止', description: '沙箱可能阻止了该调用中的至少一项操作。失败前可能已经产生部分结果，请检查输出和工作区状态后再决定是否重试。', copyAriaLabel: (label) => `${label}沙箱诊断信息` },
+    computer: {
+      fallback: '操作电脑',
+      listApps: '列出打开的应用',
+      observe: '观察当前窗口',
+      observeApp: (app) => `观察「${app}」窗口`,
+      observeWindow: (windowId) => `观察窗口 ${windowId}`,
+      screenshot: '截图当前窗口',
+      screenshotApp: (app) => `截图「${app}」窗口`,
+      screenshotWindow: (windowId) => `截图窗口 ${windowId}`,
+      element: (elementId) => `元素 ${elementId}`,
+      elementUnknown: '该元素',
+      clickElement: (element) => `点击${element}`,
+      // The element phrase ends every clause it appears in: it is "元素 e12",
+      // and Chinese typography wants a space around the latin id, which a
+      // trailing 「的值」/「执行」 would either eat or leave dangling.
+      setValue: (element) => `设置值：${element}`,
+      selectText: (element) => `选择文本：${element}`,
+      secondaryAction: (element) => `次要操作：${element}`,
+      scroll: '滚动',
+      pressKey: '按下按键',
+      type: '输入文本',
+      holdKey: '按住按键',
+      wait: '等待',
+      zoom: '放大查看区域',
+      cursorPosition: '读取指针位置',
+      pointer: {
+        move: '移动指针',
+        left: '点击',
+        right: '右键点击',
+        middle: '中键点击',
+        double: '双击',
+        triple: '三击',
+        down: '按下鼠标',
+        up: '松开鼠标',
+        drag: '拖动',
+      },
+    },
     automation: { created: (name) => `自动化任务已创建：${name}`, nextFire: (value) => `下次触发：${value}`, deleted: '自动化任务已删除', notFound: '未找到该任务（可能已完成或已删除）', list: (count) => `自动化任务列表 (${count})`, empty: '当前会话暂无自动化任务' },
     loadTools: { displayName: '加载工具组', loaded: (namespace) => namespace ? `已加载 ${namespace} 工具组` : '已加载工具组', count: (n) => `新增 ${n} 个可用工具：`, footer: '下一步即可调用' },
     permissionDenied: '用户已拒绝权限请求',
@@ -162,6 +238,40 @@ const TOOL_ACTIVITY_COPY = {
     output: { redacted: '[Redacted]', redactedAriaLabel: 'Redacted', truncated: 'Output truncated' },
     copy: { idle: 'Copy', pending: 'Copying…', copied: 'Copied', failed: 'Copy failed' },
     sandboxBlocked: { title: 'Operation may have been blocked by sandbox', description: 'The sandbox may have blocked at least one action in this call. Some effects may have occurred before it failed; check the output and workspace state before retrying.', copyAriaLabel: (label) => `${label} sandbox diagnostics` },
+    computer: {
+      fallback: 'Use the computer',
+      listApps: 'List open apps',
+      observe: 'Observe the current window',
+      observeApp: (app) => `Observe the “${app}” window`,
+      observeWindow: (windowId) => `Observe window ${windowId}`,
+      screenshot: 'Screenshot the current window',
+      screenshotApp: (app) => `Screenshot the “${app}” window`,
+      screenshotWindow: (windowId) => `Screenshot window ${windowId}`,
+      element: (elementId) => `element ${elementId}`,
+      elementUnknown: 'the element',
+      clickElement: (element) => `Click ${element}`,
+      setValue: (element) => `Set the value of ${element}`,
+      selectText: (element) => `Select text in ${element}`,
+      secondaryAction: (element) => `Run a secondary action on ${element}`,
+      scroll: 'Scroll',
+      pressKey: 'Press a key',
+      type: 'Type text',
+      holdKey: 'Hold a key',
+      wait: 'Wait',
+      zoom: 'Zoom into a region',
+      cursorPosition: 'Read the pointer position',
+      pointer: {
+        move: 'Move the pointer',
+        left: 'Click',
+        right: 'Right-click',
+        middle: 'Middle-click',
+        double: 'Double-click',
+        triple: 'Triple-click',
+        down: 'Press the mouse',
+        up: 'Release the mouse',
+        drag: 'Drag',
+      },
+    },
     automation: { created: (name) => `Automation created: ${name}`, nextFire: (value) => `Next run: ${value}`, deleted: 'Automation deleted', notFound: 'Automation not found (it may have completed or been deleted)', list: (count) => `Automations (${count})`, empty: 'No automations in this conversation' },
     loadTools: { displayName: 'Load tools', loaded: (namespace) => namespace ? `Loaded ${namespace} tools` : 'Loaded tools', count: (n) => `Added ${n} available ${n === 1 ? 'tool' : 'tools'}:`, footer: 'Ready to use' },
     permissionDenied: 'User denied the permission request',


### PR DESCRIPTION
## Two things a Computer Use call could not do in a transcript

### Be found

It rendered under the same gear icon as every other tool call. Driving the user's own machine has its own risk, its own approval classes, and is the one activity a person most wants to pick out at a glance. It gets its own activity kind and icon.

### Be told apart from the call before it

The row falls back to the tool's display name when a backend supplies no intent. This tool's display name is "Maka Computer":

```
before                          after
──────────────────────────      ──────────────────────────
⚙ Maka Computer                 🖥 观察「计算器」窗口
⚙ Maka Computer                 🖥 点击「7」
⚙ Maka Computer                 🖥 点击「+」
⚙ Maka Computer                 🖥 读取显示屏
```

`computerActionLabel` derives the label from the call's own arguments. Only tools whose display name already reads as an action fall through to the name — this one is a noun.

## The live line

That noun also reached the line that says what the agent is doing, which is a verb phrase — `正在…` / `Working: …`. **"正在Maka Computer"** was reported as reading wrong, and it was. A kind with an entry in `summary.activity` supplies the verb instead.

## Working on old transcripts

`trowActivityKind` recognises the tool by name as well as by declared activity kind, so rows recorded before the kind existed render correctly too.

## Verification

`packages/core` builds against current main. `packages/ui` cannot be built on this machine — upstream's `@astryxdesign/core@0.2.0` does not resolve from this registry — so CI is the check for the UI package. The new label module and its test are self-contained; the three touched files take one line each.