### PR TITLE
chore: format check-console.mjs so format:check passes on main

### DIFF
--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -34,7 +34,10 @@ const ALLOW = new Map([
     'apps/desktop/src/renderer/error-boundary.tsx',
     'React error boundary; DevTools-only, surfaces uncaught render errors.',
   ],
-  ['apps/desktop/src/main/main.ts', 'thin ESM entry; pre-ready config, [startup] ready/fatal diagnostics (moved from boot, PR1880).'],
+  [
+    'apps/desktop/src/main/main.ts',
+    'thin ESM entry; pre-ready config, [startup] ready/fatal diagnostics (moved from boot, PR1880).',
+  ],
   [
     'apps/desktop/src/main/boot.ts',
     'startup chain diagnostics (e2e-fixture fatal/scenario, window create failure, repair/cleanup paths); no secrets (moved from main.ts, PR1880).',


### PR DESCRIPTION
`format:check` fails on `main` itself.

The ALLOW entry added in #1880 is written on one line, and the formatter would break it across four:

```
- ['apps/desktop/src/main/main.ts', 'thin ESM entry; pre-ready config, [startup] ready/fatal diagnostics (moved from boot, PR1880).'],
+ [
+   'apps/desktop/src/main/main.ts',
+   'thin ESM entry; pre-ready config, [startup] ready/fatal diagnostics (moved from boot, PR1880).',
+ ],
```

Every open pull request inherits a red `typecheck` job from this, which has nothing to do with the change under review. Four lines, no behaviour.