### PR TITLE
feat(runtime-host): serve live execution inspection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11640,6 +11640,7 @@
         "@maka/core": "0.1.0",
         "@maka/headless": "0.1.0",
         "@maka/runtime": "0.1.0",
+        "@maka/runtime-host": "0.1.0",
         "@maka/storage": "0.1.0"
       },
       "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",
     "build": "tsc -p tsconfig.json && node scripts/chmod-bin.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "pretest": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build",
+    "pretest": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/runtime-host run build",
     "test": "npm run clean && npm run build && npm run test:dist",
     "test:dist": "node --test \"dist/**/*.test.js\""
   },
@@ -23,6 +23,7 @@
     "@maka/core": "0.1.0",
     "@maka/headless": "0.1.0",
     "@maka/runtime": "0.1.0",
+    "@maka/runtime-host": "0.1.0",
     "@maka/storage": "0.1.0"
   }
 }

--- a/packages/cli/src/__tests__/inspect-command.test.ts
+++ b/packages/cli/src/__tests__/inspect-command.test.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { AgentRunHeader } from '@maka/core';
 import { createInMemoryTaskRunStore, runTaskOnce } from '@maka/headless';
+import type { SessionInspectDocument } from '@maka/runtime';
+import type { RuntimeHostConnection } from '@maka/runtime-host/client';
 import { createSessionStore } from '@maka/storage';
 import {
   createLegacyAgentRunStoreForTest,
@@ -24,6 +26,7 @@ import {
   inspectResolvedTarget,
   resolveInspectTarget,
   runMakaInspectCli,
+  type InspectCommandDependencies,
   withInspectCommandStores,
 } from '../inspect-command.js';
 
@@ -241,6 +244,90 @@ describe('inspect CLI storage authority boundary', () => {
       }
     });
   });
+
+  test('routes an exclusively locked Interactive root through the existing Runtime Host', async () => {
+    await withDiskRoot('maka-inspect-live-host-', async (root) => {
+      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      const writer = await openInteractiveExecutionStoresForWrite(owner.lease);
+      const session = await writer.sessionStore.create(sessionInput('Live Host session'));
+      const requests: string[] = [];
+      const connection = {
+        request: async (operation: string) => {
+          requests.push(operation);
+          if (operation === 'execution.inspect.resolve') {
+            return {
+              status: 'resolved',
+              candidates: [{ kind: 'session', id: session.id }],
+              truncated: false,
+            };
+          }
+          if (operation === 'execution.inspect.query') {
+            return { kind: 'session', document: sessionInspectDocument(session.id) };
+          }
+          throw new Error(`Unexpected operation: ${operation}`);
+        },
+        close: async () => undefined,
+      } as unknown as RuntimeHostConnection;
+      const dependencies: InspectCommandDependencies = {
+        connectExistingHost: (async () => ({
+          kind: 'connected',
+          connection,
+          registration: {
+            kind: 'maka-runtime-host',
+            schemaVersion: 1,
+            rootId: capability.rootId,
+            hostEpoch: 'host-1',
+            endpoint: '/tmp/runtime-host.sock',
+            protocolMin: 0,
+            protocolMax: 0,
+            state: 'ready',
+            pid: 1,
+            createdAt: new Date(0).toISOString(),
+          },
+        })) as InspectCommandDependencies['connectExistingHost'],
+      };
+      const output = captureIo();
+      try {
+        assert.equal(
+          await runMakaInspectCli([session.id, '--store', root, '--json'], output.io, dependencies),
+          0,
+        );
+        assert.equal(output.stderr(), '');
+        assert.equal((JSON.parse(output.stdout()) as { kind: string }).kind, 'session');
+        assert.deepEqual(requests, ['execution.inspect.resolve', 'execution.inspect.query']);
+      } finally {
+        await writer.sessionStore.close?.();
+        await owner.close();
+      }
+    });
+  });
+
+  test('reports an unavailable live Host without exposing a stack', async () => {
+    await withDiskRoot('maka-inspect-live-host-unavailable-', async (root) => {
+      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      const output = captureIo();
+      try {
+        const dependencies: InspectCommandDependencies = {
+          connectExistingHost: (async () => ({
+            kind: 'unavailable',
+            reason: 'connect_failed',
+          })) as InspectCommandDependencies['connectExistingHost'],
+        };
+        assert.equal(
+          await runMakaInspectCli(['missing', '--store', root], output.io, dependencies),
+          1,
+        );
+        assert.match(output.stderr(), /Runtime Host is unavailable \(connect_failed\)/);
+        assert.doesNotMatch(output.stderr(), /LiveInspectError|\n\s+at /);
+      } finally {
+        await owner.close();
+      }
+    });
+  });
 });
 
 type InspectCommandTestStores = {
@@ -279,6 +366,23 @@ function runHeader(sessionId: string, runId: string): AgentRunHeader {
     createdAt: 1,
     updatedAt: 2,
     completedAt: 2,
+  };
+}
+
+function sessionInspectDocument(sessionId: string): SessionInspectDocument {
+  return {
+    schemaVersion: 'maka.session_inspect.v1',
+    kind: 'session',
+    session: {
+      sessionId,
+      name: 'Live Host session',
+      status: 'active',
+      createdAt: 1,
+      lastUsedAt: 1,
+      isArchived: false,
+    },
+    agentRuns: [],
+    diagnostics: [],
   };
 }
 

--- a/packages/cli/src/inspect-backend.ts
+++ b/packages/cli/src/inspect-backend.ts
@@ -1,0 +1,68 @@
+import type { TaskRunInspectDocument } from '@maka/headless';
+import type { AgentRunInspectDocument, SessionInspectDocument } from '@maka/runtime';
+
+export const INSPECT_RESOLUTION_SCHEMA_VERSION = 'maka.inspect_resolution.v1' as const;
+
+export type InspectEntityKind = 'session' | 'agent-run' | 'task-run';
+
+export type InspectCandidate =
+  | { readonly kind: 'session'; readonly id: string }
+  | { readonly kind: 'agent-run'; readonly id: string; readonly sessionId: string }
+  | { readonly kind: 'task-run'; readonly id: string };
+
+export type InspectCandidateDescriptor = InspectCandidate;
+
+export interface InspectResolutionQuery {
+  readonly id: string;
+  readonly requestedKind?: InspectEntityKind;
+  readonly sessionId?: string;
+}
+
+export interface InspectResolutionDocument {
+  readonly schemaVersion: typeof INSPECT_RESOLUTION_SCHEMA_VERSION;
+  readonly kind: 'inspect_resolution';
+  readonly query: InspectResolutionQuery;
+  readonly status: 'not_found' | 'ambiguous';
+  readonly candidates: readonly InspectCandidateDescriptor[];
+  readonly candidatesTruncated?: boolean;
+}
+
+export type InspectDocument =
+  | SessionInspectDocument
+  | AgentRunInspectDocument
+  | TaskRunInspectDocument;
+
+export type InspectResolution =
+  | { readonly status: 'resolved'; readonly candidate: InspectCandidate }
+  | {
+      readonly status: 'not_found' | 'ambiguous';
+      readonly document: InspectResolutionDocument;
+    };
+
+export interface InspectCommandBackend {
+  resolve(query: InspectResolutionQuery): Promise<InspectResolution>;
+  inspect(candidate: InspectCandidate): Promise<InspectDocument>;
+}
+
+export function inspectResolutionFailure(
+  query: InspectResolutionQuery,
+  status: 'not_found' | 'ambiguous',
+  candidates: readonly InspectCandidateDescriptor[],
+  truncated = false,
+): Extract<InspectResolution, { status: 'not_found' | 'ambiguous' }> {
+  return {
+    status,
+    document: {
+      schemaVersion: INSPECT_RESOLUTION_SCHEMA_VERSION,
+      kind: 'inspect_resolution',
+      query: {
+        id: query.id,
+        ...(query.requestedKind ? { requestedKind: query.requestedKind } : {}),
+        ...(query.sessionId ? { sessionId: query.sessionId } : {}),
+      },
+      status,
+      candidates: [...candidates],
+      ...(truncated ? { candidatesTruncated: true } : {}),
+    },
+  };
+}

--- a/packages/cli/src/inspect-command.ts
+++ b/packages/cli/src/inspect-command.ts
@@ -1,10 +1,9 @@
 import { resolve } from 'node:path';
-import type { AgentRunHeader, SessionHeader } from '@maka/core';
+import type { SessionHeader } from '@maka/core';
 import {
   inspectTaskRun,
   openHeadlessStorageForRead,
   renderTaskRunInspectTree,
-  type TaskRunInspectDocument,
   type TaskRunReader,
 } from '@maka/headless';
 import {
@@ -14,8 +13,6 @@ import {
   renderSessionInspectTree,
   type RuntimeEventInspectReader,
   type SessionAgentRunInspectReader,
-  type AgentRunInspectDocument,
-  type SessionInspectDocument,
 } from '@maka/runtime';
 import {
   openInteractiveExecutionStoresForRead,
@@ -27,36 +24,36 @@ import {
   tryAcquireInteractiveRootReader,
 } from '@maka/storage/root-authority';
 import { resolveMakaWorkspaceRoot } from './workspace-root.js';
+import {
+  inspectResolutionFailure,
+  type InspectCandidate,
+  type InspectCommandBackend,
+  type InspectDocument,
+  type InspectEntityKind,
+  type InspectResolution,
+  type InspectResolutionDocument,
+} from './inspect-backend.js';
+import {
+  connectLiveInspectBackend,
+  defaultInspectCommandDependencies,
+  LiveInspectError,
+  type InspectCommandDependencies,
+} from './live-inspect-backend.js';
 
-export const INSPECT_RESOLUTION_SCHEMA_VERSION = 'maka.inspect_resolution.v1' as const;
+export type { InspectCommandDependencies } from './live-inspect-backend.js';
+export { INSPECT_RESOLUTION_SCHEMA_VERSION } from './inspect-backend.js';
+export type {
+  InspectCandidate,
+  InspectCandidateDescriptor,
+  InspectCommandBackend,
+  InspectDocument,
+  InspectEntityKind,
+  InspectResolution,
+  InspectResolutionDocument,
+} from './inspect-backend.js';
 
 const isStorageRootAuthorityError = (error: unknown): error is StorageRootAuthorityError =>
   error instanceof StorageRootAuthorityError;
-
-export type InspectEntityKind = 'session' | 'agent-run' | 'task-run';
-
-export interface InspectCandidateDescriptor {
-  kind: InspectEntityKind;
-  id: string;
-  sessionId?: string;
-}
-
-export interface InspectResolutionDocument {
-  schemaVersion: typeof INSPECT_RESOLUTION_SCHEMA_VERSION;
-  kind: 'inspect_resolution';
-  query: {
-    id: string;
-    requestedKind?: InspectEntityKind;
-    sessionId?: string;
-  };
-  status: 'not_found' | 'ambiguous';
-  candidates: InspectCandidateDescriptor[];
-}
-
-export type InspectDocument =
-  | SessionInspectDocument
-  | AgentRunInspectDocument
-  | TaskRunInspectDocument;
 
 interface InspectSessionReader {
   list(): Promise<readonly { id: string }[]>;
@@ -69,27 +66,6 @@ export interface InspectCommandStores {
   runtimeEventStore: RuntimeEventInspectReader;
   taskRunStore?: TaskRunReader;
 }
-
-interface SessionCandidate extends InspectCandidateDescriptor {
-  kind: 'session';
-  header: SessionHeader;
-}
-
-interface AgentRunCandidate extends InspectCandidateDescriptor {
-  kind: 'agent-run';
-  sessionId: string;
-  header: AgentRunHeader;
-}
-
-interface TaskRunCandidate extends InspectCandidateDescriptor {
-  kind: 'task-run';
-}
-
-type InspectCandidate = SessionCandidate | AgentRunCandidate | TaskRunCandidate;
-
-export type InspectResolution =
-  | { status: 'resolved'; candidate: InspectCandidate }
-  | { status: 'not_found' | 'ambiguous'; document: InspectResolutionDocument };
 
 export async function resolveInspectTarget(
   stores: InspectCommandStores,
@@ -114,24 +90,7 @@ export async function resolveInspectTarget(
   candidates.sort(compareCandidates);
   if (candidates.length === 1) return { status: 'resolved', candidate: candidates[0]! };
   const status = candidates.length === 0 ? 'not_found' : 'ambiguous';
-  return {
-    status,
-    document: {
-      schemaVersion: INSPECT_RESOLUTION_SCHEMA_VERSION,
-      kind: 'inspect_resolution',
-      query: {
-        id: query.id,
-        ...(query.requestedKind ? { requestedKind: query.requestedKind } : {}),
-        ...(query.sessionId ? { sessionId: query.sessionId } : {}),
-      },
-      status,
-      candidates: candidates.map(({ kind, id, sessionId }) => ({
-        kind,
-        id,
-        ...(sessionId ? { sessionId } : {}),
-      })),
-    },
-  };
+  return inspectResolutionFailure(query, status, candidates);
 }
 
 export async function inspectResolvedTarget(
@@ -158,7 +117,6 @@ export async function inspectResolvedTarget(
     return inspectAgentRunDocument(stores.agentRunStore, stores.runtimeEventStore, {
       sessionId: candidate.sessionId,
       agentRunId: candidate.id,
-      header: candidate.header,
       isFatalReadError: isStorageRootAuthorityError,
     });
   }
@@ -168,7 +126,6 @@ export async function inspectResolvedTarget(
     stores.runtimeEventStore,
     candidate.id,
     {
-      header: candidate.header,
       isFatalReadError: isStorageRootAuthorityError,
     },
   );
@@ -182,6 +139,7 @@ export interface InspectCommandIo {
 export async function runMakaInspectCli(
   args: string[],
   io: InspectCommandIo = process,
+  dependencies: InspectCommandDependencies = defaultInspectCommandDependencies,
 ): Promise<number> {
   let parsed: ParsedInspectArgs;
   try {
@@ -198,23 +156,28 @@ export async function runMakaInspectCli(
     io.stderr.write(`${inspectUsage()}\n`);
     return 2;
   }
+  const targetId = parsed.id;
 
   const storageRoot = parsed.store ? resolve(parsed.store) : resolveMakaWorkspaceRoot();
-  const result = await withInspectCommandStores(storageRoot, async (stores) => {
-    const resolution = await resolveInspectTarget(stores, {
-      id: parsed.id!,
+  const result = await withInspectCommandBackend(storageRoot, dependencies, async (backend) => {
+    const resolution = await backend.resolve({
+      id: targetId,
       ...(parsed.kind ? { requestedKind: parsed.kind } : {}),
       ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
     });
     if (resolution.status !== 'resolved') return resolution;
     return {
       status: 'inspected' as const,
-      document: await inspectResolvedTarget(stores, resolution.candidate),
+      document: await backend.inspect(resolution.candidate),
     };
   }).catch((error: unknown) => {
-    if (!isStorageRootAuthorityError(error)) throw error;
+    if (!isStorageRootAuthorityError(error) && !(error instanceof LiveInspectError)) throw error;
     io.stderr.write(
-      `maka inspect: ${formatInspectAuthorityError(error, parsed.store === undefined)}\n`,
+      `maka inspect: ${
+        error instanceof LiveInspectError
+          ? error.message
+          : formatInspectAuthorityError(error, parsed.store === undefined)
+      }\n`,
     );
     return undefined;
   });
@@ -239,6 +202,30 @@ export async function runMakaInspectCli(
     io.stdout.write(renderSessionInspectTree(document));
   }
   return 0;
+}
+
+async function withInspectCommandBackend<T>(
+  storageRoot: string,
+  dependencies: InspectCommandDependencies,
+  operation: (backend: InspectCommandBackend) => Promise<T>,
+): Promise<T> {
+  try {
+    return await withInspectCommandStores(storageRoot, (stores) =>
+      operation({
+        resolve: (query) => resolveInspectTarget(stores, query),
+        inspect: (candidate) => inspectResolvedTarget(stores, candidate),
+      }),
+    );
+  } catch (error) {
+    if (!isStorageRootAuthorityError(error) || error.code !== 'lock_failed') throw error;
+  }
+
+  const live = await connectLiveInspectBackend(storageRoot, dependencies);
+  try {
+    return await operation(live.backend);
+  } finally {
+    await live.close();
+  }
 }
 
 export async function withInspectCommandStores<T>(
@@ -345,16 +332,16 @@ function isInspectEntityKind(value: string): value is InspectEntityKind {
 async function findSessionCandidates(
   store: InspectSessionReader,
   id: string,
-): Promise<SessionCandidate[]> {
+): Promise<Array<Extract<InspectCandidate, { kind: 'session' }>>> {
   const summaries = await store.list();
   if (!summaries.some((session) => session.id === id)) return [];
-  return [{ kind: 'session', id, header: await store.readHeader(id) }];
+  return [{ kind: 'session', id }];
 }
 
 async function findTaskRunCandidates(
   store: TaskRunReader | undefined,
   id: string,
-): Promise<TaskRunCandidate[]> {
+): Promise<Array<Extract<InspectCandidate, { kind: 'task-run' }>>> {
   if (!store) return [];
   const records = await store.readEventRecords(id);
   return records.length > 0 ? [{ kind: 'task-run', id }] : [];
@@ -364,11 +351,11 @@ async function findAgentRunCandidates(
   stores: Pick<InspectCommandStores, 'sessionStore' | 'agentRunStore'>,
   id: string,
   sessionId?: string,
-): Promise<AgentRunCandidate[]> {
+): Promise<Array<Extract<InspectCandidate, { kind: 'agent-run' }>>> {
   if (sessionId) {
     try {
-      const header = await stores.agentRunStore.readRun(sessionId, id);
-      return [{ kind: 'agent-run', id, sessionId, header }];
+      await stores.agentRunStore.readRun(sessionId, id);
+      return [{ kind: 'agent-run', id, sessionId }];
     } catch (error) {
       if (isNotFound(error)) return [];
       throw error;
@@ -378,11 +365,11 @@ async function findAgentRunCandidates(
   const runLists = await Promise.all(
     sessions.map((session) => stores.agentRunStore.listSessionRuns(session.id)),
   );
-  const candidates: AgentRunCandidate[] = [];
+  const candidates: Array<Extract<InspectCandidate, { kind: 'agent-run' }>> = [];
   runLists.forEach((runs) => {
     for (const header of runs) {
       if (header.runId === id) {
-        candidates.push({ kind: 'agent-run', id, sessionId: header.sessionId, header });
+        candidates.push({ kind: 'agent-run', id, sessionId: header.sessionId });
       }
     }
   });
@@ -390,7 +377,12 @@ async function findAgentRunCandidates(
 }
 
 function compareCandidates(a: InspectCandidate, b: InspectCandidate): number {
-  return a.kind.localeCompare(b.kind) || (a.sessionId ?? '').localeCompare(b.sessionId ?? '');
+  return (
+    a.kind.localeCompare(b.kind) ||
+    (a.kind === 'agent-run' ? a.sessionId : '').localeCompare(
+      b.kind === 'agent-run' ? b.sessionId : '',
+    )
+  );
 }
 
 function renderResolutionFailure(document: InspectResolutionDocument): string {
@@ -405,6 +397,7 @@ function renderResolutionFailure(document: InspectResolutionDocument): string {
   return [
     `Inspect target ${document.query.id} is ambiguous:`,
     ...candidates,
+    ...(document.candidatesTruncated ? ['  - additional candidates omitted'] : []),
     'Choose one with --kind session|agent-run|task-run; add --session <id> for a duplicate AgentRun id.',
   ].join('\n');
 }

--- a/packages/cli/src/live-inspect-backend.ts
+++ b/packages/cli/src/live-inspect-backend.ts
@@ -1,0 +1,123 @@
+import {
+  connectExistingRuntimeHost,
+  type ConnectRuntimeHostResult,
+  type RuntimeHostConnection,
+} from '@maka/runtime-host/client';
+import {
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  type ExecutionInspectResolveInput,
+} from '@maka/runtime-host/protocol';
+import type { InspectCandidate, InspectCommandBackend } from './inspect-backend.js';
+import { inspectResolutionFailure } from './inspect-backend.js';
+
+export interface InspectCommandDependencies {
+  connectExistingHost: typeof connectExistingRuntimeHost;
+}
+
+export const defaultInspectCommandDependencies: InspectCommandDependencies = {
+  connectExistingHost: connectExistingRuntimeHost,
+};
+
+export class LiveInspectError extends Error {
+  readonly name = 'LiveInspectError';
+}
+
+export async function connectLiveInspectBackend(
+  storageRoot: string,
+  dependencies: InspectCommandDependencies,
+): Promise<{ backend: InspectCommandBackend; close(): Promise<void> }> {
+  let connected: ConnectRuntimeHostResult;
+  try {
+    connected = await dependencies.connectExistingHost({
+      rootPath: storageRoot,
+      surface: 'inspect',
+      protocol: {
+        min: RUNTIME_HOST_PROTOCOL_VERSION,
+        max: RUNTIME_HOST_PROTOCOL_VERSION,
+      },
+    });
+  } catch (error) {
+    throw new LiveInspectError(
+      `Interactive storage is locked and the existing Runtime Host control plane could not be validated: ${errorMessage(error)}`,
+    );
+  }
+  if (connected.kind !== 'connected') {
+    throw new LiveInspectError(liveHostUnavailableMessage(connected));
+  }
+  return {
+    backend: hostInspectBackend(connected.connection),
+    close: () => connected.connection.close().catch(() => undefined),
+  };
+}
+
+function hostInspectBackend(connection: RuntimeHostConnection): InspectCommandBackend {
+  const request = async <T>(operation: () => Promise<T>): Promise<T> => {
+    try {
+      return await operation();
+    } catch (error) {
+      throw new LiveInspectError(`Live Runtime Host inspection failed: ${errorMessage(error)}`);
+    }
+  };
+  return {
+    resolve: async (query) => {
+      if (query.requestedKind === 'task-run') {
+        return inspectResolutionFailure(query, 'not_found', []);
+      }
+      const input: ExecutionInspectResolveInput = {
+        id: query.id,
+        ...(query.requestedKind
+          ? { requestedKind: query.requestedKind === 'agent-run' ? 'agent_run' : 'session' }
+          : {}),
+        ...(query.sessionId ? { sessionId: query.sessionId } : {}),
+      };
+      const result = await request(() => connection.request('execution.inspect.resolve', input));
+      const candidates: InspectCandidate[] = result.candidates.map((candidate) =>
+        candidate.kind === 'agent_run'
+          ? {
+              kind: 'agent-run',
+              id: candidate.id,
+              sessionId: candidate.sessionId,
+            }
+          : { kind: 'session', id: candidate.id },
+      );
+      if (result.status === 'resolved') {
+        return { status: 'resolved', candidate: candidates[0]! };
+      }
+      return inspectResolutionFailure(query, result.status, candidates, result.truncated);
+    },
+    inspect: async (candidate) => {
+      if (candidate.kind === 'task-run') {
+        throw new LiveInspectError('TaskRun inspection requires a Headless storage root');
+      }
+      const result = await request(() =>
+        connection.request(
+          'execution.inspect.query',
+          candidate.kind === 'session'
+            ? { kind: 'session', sessionId: candidate.id }
+            : {
+                kind: 'agent_run',
+                sessionId: candidate.sessionId,
+                agentRunId: candidate.id,
+              },
+        ),
+      );
+      return result.document;
+    },
+  };
+}
+
+function liveHostUnavailableMessage(
+  result: Exclude<ConnectRuntimeHostResult, { kind: 'connected' }>,
+): string {
+  if (result.kind === 'incompatible') {
+    return 'Interactive storage is locked by an incompatible Runtime Host';
+  }
+  if (result.kind === 'draining') {
+    return 'Interactive storage is locked by a draining Runtime Host';
+  }
+  return `Interactive storage is locked but its Runtime Host is unavailable (${result.reason})`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "./runtime-policy": "./dist/runtime-policy.js",
     "./goal": "./dist/goal.js",
     "./execution-evidence": "./dist/execution-evidence.js",
+    "./execution-inspect": "./dist/execution-inspect.js",
     "./events": "./dist/events.js",
     "./interaction": "./dist/interaction.js",
     "./session": "./dist/session.js",

--- a/packages/core/src/execution-inspect.ts
+++ b/packages/core/src/execution-inspect.ts
@@ -1,0 +1,390 @@
+import { AGENT_RUN_STATUSES, type AgentRunHeader } from './agent-run.js';
+import { EXECUTION_LOG_LEDGERS, type ExecutionLogCoverage } from './execution-evidence.js';
+import { SESSION_STATUSES, type SessionHeader } from './session.js';
+
+export const AGENT_RUN_INSPECT_DOCUMENT_VERSION = 'maka.agent_run_inspect.v1' as const;
+export const SESSION_INSPECT_DOCUMENT_VERSION = 'maka.session_inspect.v1' as const;
+
+export type ExecutionInspectSeverity = 'error' | 'warning' | 'info';
+
+export interface ExecutionInspectDiagnostic {
+  severity: ExecutionInspectSeverity;
+  code: string;
+  message: string;
+  sessionId: string;
+  agentRunId?: string;
+  turnId?: string;
+  eventId?: string;
+}
+
+export interface AgentRunInspectIdentity {
+  sessionId: string;
+  agentRunId: string;
+  invocationId?: string;
+  turnId: string;
+  parentRunId?: string;
+  resumedFromRunId?: string;
+  retriedFromRunId?: string;
+  parentTurnId?: string;
+  agentId?: string;
+  status: AgentRunHeader['status'];
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  failureClass?: string;
+  abortSource?: string;
+}
+
+export interface AgentRunInspectToolFact {
+  toolCallId: string;
+  toolName: string;
+  eventId: string;
+}
+
+export interface AgentRunInspectToolSummary {
+  callCount: number;
+  responseCount: number;
+  errorResponseCount: number;
+  callsWithoutResponse: AgentRunInspectToolFact[];
+  responsesWithoutCall: AgentRunInspectToolFact[];
+}
+
+export interface AgentRunInspectCompactionCheckpoint {
+  eventId: string;
+  validation: 'shape_valid' | 'invalid';
+  checkpointId?: string;
+  policyVersion?: string;
+  sourceCoverage?: ExecutionLogCoverage;
+}
+
+export interface AgentRunInspectSourceHealth {
+  runtimeLedger: 'present' | 'missing' | 'read_failed';
+  runtimeTerminalPresent: boolean;
+  operationalTerminalPresent: boolean;
+  statusConsistency: 'consistent' | 'inconsistent' | 'incomplete';
+}
+
+export interface AgentRunInspectDocument {
+  schemaVersion: typeof AGENT_RUN_INSPECT_DOCUMENT_VERSION;
+  kind: 'agent_run';
+  agentRun: AgentRunInspectIdentity;
+  sources: {
+    operationalEventCount: number;
+    runtimeEventCount: number;
+    runtimeCoverage?: ExecutionLogCoverage;
+    health: AgentRunInspectSourceHealth;
+  };
+  tools: AgentRunInspectToolSummary;
+  compactionCheckpoints: AgentRunInspectCompactionCheckpoint[];
+  diagnostics: ExecutionInspectDiagnostic[];
+}
+
+export interface SessionInspectSummary {
+  sessionId: string;
+  name: string;
+  status: SessionHeader['status'];
+  createdAt: number;
+  lastUsedAt: number;
+  lastMessageAt?: number;
+  isArchived: boolean;
+  parentSessionId?: string;
+  branchOfTurnId?: string;
+  revisionRootSessionId?: string;
+  revisionParentSessionId?: string;
+  revisionOfTurnId?: string;
+  revisionIndex?: number;
+  revisionState?: 'preparing' | 'committed';
+}
+
+export interface SessionInspectDocument {
+  schemaVersion: typeof SESSION_INSPECT_DOCUMENT_VERSION;
+  kind: 'session';
+  session: SessionInspectSummary;
+  agentRuns: AgentRunInspectDocument[];
+  diagnostics: ExecutionInspectDiagnostic[];
+}
+
+export function isAgentRunInspectDocument(value: unknown): value is AgentRunInspectDocument {
+  if (
+    !hasShape(
+      value,
+      [
+        'schemaVersion',
+        'kind',
+        'agentRun',
+        'sources',
+        'tools',
+        'compactionCheckpoints',
+        'diagnostics',
+      ],
+      [],
+    ) ||
+    value.schemaVersion !== AGENT_RUN_INSPECT_DOCUMENT_VERSION ||
+    value.kind !== 'agent_run' ||
+    !isAgentRunIdentity(value.agentRun) ||
+    !isAgentRunSources(value.sources) ||
+    !isToolSummary(value.tools) ||
+    !Array.isArray(value.compactionCheckpoints) ||
+    !value.compactionCheckpoints.every(isCompactionCheckpoint) ||
+    !Array.isArray(value.diagnostics)
+  ) {
+    return false;
+  }
+  const { sessionId, agentRunId, turnId } = value.agentRun;
+  return value.diagnostics.every(
+    (item) =>
+      isDiagnostic(item) &&
+      item.sessionId === sessionId &&
+      item.agentRunId === agentRunId &&
+      item.turnId === turnId,
+  );
+}
+
+export function isSessionInspectDocument(value: unknown): value is SessionInspectDocument {
+  if (
+    !hasShape(value, ['schemaVersion', 'kind', 'session', 'agentRuns', 'diagnostics'], []) ||
+    value.schemaVersion !== SESSION_INSPECT_DOCUMENT_VERSION ||
+    value.kind !== 'session' ||
+    !isSessionSummary(value.session) ||
+    !Array.isArray(value.agentRuns) ||
+    !Array.isArray(value.diagnostics)
+  ) {
+    return false;
+  }
+  const { sessionId } = value.session;
+  if (
+    !value.agentRuns.every(
+      (item) => isAgentRunInspectDocument(item) && item.agentRun.sessionId === sessionId,
+    )
+  ) {
+    return false;
+  }
+  const runTurns = new Map(
+    value.agentRuns.map((item) => [item.agentRun.agentRunId, item.agentRun.turnId]),
+  );
+  return value.diagnostics.every(
+    (item) =>
+      isDiagnostic(item) &&
+      item.sessionId === sessionId &&
+      item.agentRunId !== undefined &&
+      item.turnId === runTurns.get(item.agentRunId),
+  );
+}
+
+function isAgentRunIdentity(value: unknown): value is AgentRunInspectIdentity {
+  return (
+    hasShape(
+      value,
+      ['sessionId', 'agentRunId', 'turnId', 'status', 'createdAt', 'updatedAt'],
+      [
+        'invocationId',
+        'parentRunId',
+        'resumedFromRunId',
+        'retriedFromRunId',
+        'parentTurnId',
+        'agentId',
+        'completedAt',
+        'failureClass',
+        'abortSource',
+      ],
+    ) &&
+    isString(value.sessionId) &&
+    isString(value.agentRunId) &&
+    isString(value.turnId) &&
+    AGENT_RUN_STATUSES.includes(value.status as (typeof AGENT_RUN_STATUSES)[number]) &&
+    isCount(value.createdAt) &&
+    isCount(value.updatedAt) &&
+    isOptionalCount(value.completedAt) &&
+    [
+      value.invocationId,
+      value.parentRunId,
+      value.resumedFromRunId,
+      value.retriedFromRunId,
+      value.parentTurnId,
+      value.agentId,
+      value.failureClass,
+      value.abortSource,
+    ].every(isOptionalString)
+  );
+}
+
+function isAgentRunSources(value: unknown): boolean {
+  return (
+    hasShape(
+      value,
+      ['operationalEventCount', 'runtimeEventCount', 'health'],
+      ['runtimeCoverage'],
+    ) &&
+    isCount(value.operationalEventCount) &&
+    isCount(value.runtimeEventCount) &&
+    (value.runtimeCoverage === undefined || isCoverage(value.runtimeCoverage)) &&
+    hasShape(
+      value.health,
+      [
+        'runtimeLedger',
+        'runtimeTerminalPresent',
+        'operationalTerminalPresent',
+        'statusConsistency',
+      ],
+      [],
+    ) &&
+    (value.health.runtimeLedger === 'present' ||
+      value.health.runtimeLedger === 'missing' ||
+      value.health.runtimeLedger === 'read_failed') &&
+    typeof value.health.runtimeTerminalPresent === 'boolean' &&
+    typeof value.health.operationalTerminalPresent === 'boolean' &&
+    (value.health.statusConsistency === 'consistent' ||
+      value.health.statusConsistency === 'inconsistent' ||
+      value.health.statusConsistency === 'incomplete')
+  );
+}
+
+function isToolSummary(value: unknown): boolean {
+  return (
+    hasShape(
+      value,
+      [
+        'callCount',
+        'responseCount',
+        'errorResponseCount',
+        'callsWithoutResponse',
+        'responsesWithoutCall',
+      ],
+      [],
+    ) &&
+    isCount(value.callCount) &&
+    isCount(value.responseCount) &&
+    isCount(value.errorResponseCount) &&
+    Array.isArray(value.callsWithoutResponse) &&
+    value.callsWithoutResponse.every(isToolFact) &&
+    Array.isArray(value.responsesWithoutCall) &&
+    value.responsesWithoutCall.every(isToolFact)
+  );
+}
+
+function isToolFact(value: unknown): boolean {
+  return (
+    hasShape(value, ['toolCallId', 'toolName', 'eventId'], []) &&
+    typeof value.toolCallId === 'string' &&
+    typeof value.toolName === 'string' &&
+    typeof value.eventId === 'string'
+  );
+}
+
+function isCompactionCheckpoint(value: unknown): boolean {
+  return (
+    hasShape(
+      value,
+      ['eventId', 'validation'],
+      ['checkpointId', 'policyVersion', 'sourceCoverage'],
+    ) &&
+    typeof value.eventId === 'string' &&
+    (value.validation === 'shape_valid' || value.validation === 'invalid') &&
+    isOptionalString(value.checkpointId) &&
+    isOptionalString(value.policyVersion) &&
+    (value.sourceCoverage === undefined || isCoverage(value.sourceCoverage))
+  );
+}
+
+function isDiagnostic(value: unknown): value is ExecutionInspectDiagnostic {
+  return (
+    hasShape(
+      value,
+      ['severity', 'code', 'message', 'sessionId'],
+      ['agentRunId', 'turnId', 'eventId'],
+    ) &&
+    (value.severity === 'error' || value.severity === 'warning' || value.severity === 'info') &&
+    isString(value.code) &&
+    isString(value.message) &&
+    isString(value.sessionId) &&
+    isOptionalString(value.agentRunId) &&
+    isOptionalString(value.turnId) &&
+    isOptionalString(value.eventId)
+  );
+}
+
+function isSessionSummary(value: unknown): value is SessionInspectSummary {
+  return (
+    hasShape(
+      value,
+      ['sessionId', 'name', 'status', 'createdAt', 'lastUsedAt', 'isArchived'],
+      [
+        'lastMessageAt',
+        'parentSessionId',
+        'branchOfTurnId',
+        'revisionRootSessionId',
+        'revisionParentSessionId',
+        'revisionOfTurnId',
+        'revisionIndex',
+        'revisionState',
+      ],
+    ) &&
+    isString(value.sessionId) &&
+    typeof value.name === 'string' &&
+    SESSION_STATUSES.includes(value.status as (typeof SESSION_STATUSES)[number]) &&
+    isCount(value.createdAt) &&
+    isCount(value.lastUsedAt) &&
+    isOptionalCount(value.lastMessageAt) &&
+    typeof value.isArchived === 'boolean' &&
+    [
+      value.parentSessionId,
+      value.branchOfTurnId,
+      value.revisionRootSessionId,
+      value.revisionParentSessionId,
+      value.revisionOfTurnId,
+    ].every(isOptionalString) &&
+    isOptionalCount(value.revisionIndex) &&
+    (value.revisionState === undefined ||
+      value.revisionState === 'preparing' ||
+      value.revisionState === 'committed')
+  );
+}
+
+function isCoverage(value: unknown): boolean {
+  return (
+    hasShape(value, ['highWater'], ['lowWater', 'eventCount']) &&
+    isCursor(value.highWater) &&
+    (value.lowWater === undefined || isCursor(value.lowWater)) &&
+    isOptionalCount(value.eventCount)
+  );
+}
+
+function isCursor(value: unknown): boolean {
+  return (
+    hasShape(value, ['ledger', 'streamId', 'sequence'], ['eventId']) &&
+    EXECUTION_LOG_LEDGERS.includes(value.ledger as (typeof EXECUTION_LOG_LEDGERS)[number]) &&
+    isString(value.streamId) &&
+    isCount(value.sequence) &&
+    isOptionalString(value.eventId)
+  );
+}
+
+function hasShape<Required extends string, Optional extends string>(
+  value: unknown,
+  required: readonly Required[],
+  optional: readonly Optional[],
+): value is Record<Required, unknown> & Partial<Record<Optional, unknown>> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const allowed = new Set<string>([...required, ...optional]);
+  return (
+    required.every((key) => Object.hasOwn(record, key)) &&
+    Object.keys(record).every((key) => allowed.has(key))
+  );
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+function isCount(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function isOptionalCount(value: unknown): boolean {
+  return value === undefined || isCount(value);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export * from './agent-graph-supervisor-wake.js';
 export * from './agent-graph-timeline.js';
 export * from './runtime-policy.js';
 export * from './goal.js';
+export * from './execution-inspect.js';
 export * from './interaction.js';
 export * from './project.js';
 export * from './subagent-workspace.js';

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -72,6 +72,7 @@ const allowedExternalImports = {
     '@maka/core/automation',
     '@maka/core/collaboration',
     '@maka/core/events',
+    '@maka/core/execution-inspect',
     '@maka/core/goal',
     '@maka/core/interaction',
     '@maka/core/local-memory',

--- a/packages/runtime-host/src/__tests__/execution-inspect-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-inspect-coordinator.test.ts
@@ -1,0 +1,277 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { AgentRunEvent, AgentRunHeader } from '@maka/core';
+import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import {
+  EXECUTION_INSPECT_EVIDENCE_MAX_BYTES,
+  EXECUTION_INSPECT_SESSION_MAX_RUNS,
+} from '../protocol/index.js';
+import { HostExecutionInspectCoordinator } from '../server/execution-inspect-coordinator.js';
+
+describe('HostExecutionInspectCoordinator', () => {
+  test('resolves duplicate AgentRun identities and returns canonical evidence documents', async () => {
+    await withCoordinator(async ({ stores, coordinator }) => {
+      const first = await stores.sessionStore.create(sessionInput('First'));
+      const second = await stores.sessionStore.create(sessionInput('Second'));
+      await stores.agentRunStore.createRun(runHeader(first.id, 'shared-run', 1));
+      await stores.agentRunStore.createRun(runHeader(second.id, 'shared-run', 2));
+      await stores.agentRunStore.createRun(runHeader(second.id, first.id, 3));
+
+      const crossKind = await coordinator.handlers['execution.inspect.resolve'](
+        { id: first.id },
+        connectionContext(),
+      );
+      assert.equal(crossKind.ok, true);
+      if (!crossKind.ok) return;
+      assert.equal(crossKind.result.status, 'ambiguous');
+      assert.deepEqual(
+        crossKind.result.candidates.map((candidate) => candidate.kind),
+        ['agent_run', 'session'],
+      );
+
+      const ambiguous = await coordinator.handlers['execution.inspect.resolve'](
+        { id: 'shared-run', requestedKind: 'agent_run' },
+        connectionContext(),
+      );
+      assert.equal(ambiguous.ok, true);
+      if (!ambiguous.ok) return;
+      assert.equal(ambiguous.result.status, 'ambiguous');
+      assert.deepEqual(
+        ambiguous.result.candidates.map((candidate) =>
+          candidate.kind === 'agent_run' ? candidate.sessionId : undefined,
+        ),
+        [first.id, second.id].sort(),
+      );
+
+      const resolved = await coordinator.handlers['execution.inspect.resolve'](
+        { id: 'shared-run', requestedKind: 'agent_run', sessionId: second.id },
+        connectionContext(),
+      );
+      assert.equal(resolved.ok, true);
+      if (!resolved.ok) return;
+      assert.equal(resolved.result.status, 'resolved');
+
+      const run = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'agent_run', sessionId: second.id, agentRunId: 'shared-run' },
+        connectionContext(),
+      );
+      assert.equal(run.ok, true);
+      if (!run.ok || run.result.kind !== 'agent_run') return;
+      assert.equal(run.result.document.agentRun.sessionId, second.id);
+      assert.equal(run.result.document.agentRun.agentRunId, 'shared-run');
+
+      const session = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'session', sessionId: first.id },
+        connectionContext(),
+      );
+      assert.equal(session.ok, true);
+      if (!session.ok || session.result.kind !== 'session') return;
+      assert.equal(session.result.document.session.sessionId, first.id);
+      assert.deepEqual(
+        session.result.document.agentRuns.map((document) => document.agentRun.agentRunId),
+        ['shared-run'],
+      );
+    });
+  });
+
+  test('bounds live Session inspection and reports missing evidence without mutation', async () => {
+    await withCoordinator(async ({ stores, coordinator }) => {
+      const session = await stores.sessionStore.create(sessionInput('Large'));
+      for (let index = 0; index <= EXECUTION_INSPECT_SESSION_MAX_RUNS; index += 1) {
+        await stores.agentRunStore.createRun(runHeader(session.id, `run-${index}`, index));
+      }
+
+      const oversized = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'session', sessionId: session.id },
+        connectionContext(),
+      );
+      assert.deepEqual(oversized, {
+        ok: false,
+        error: {
+          code: 'invalid_request',
+          message:
+            'Session inspection exceeds the live Host run limit; inspect one AgentRun instead',
+        },
+      });
+      const missing = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'agent_run', sessionId: session.id, agentRunId: 'missing' },
+        connectionContext(),
+      );
+      assert.equal(missing.ok, false);
+      if (missing.ok) return;
+      assert.equal(missing.error.code, 'not_found');
+    });
+  });
+
+  test('rejects oversized evidence at the bounded Store read boundary', async () => {
+    await withCoordinator(async ({ stores, coordinator }) => {
+      const session = await stores.sessionStore.create(sessionInput('Large evidence'));
+      await stores.agentRunStore.createRun(runHeader(session.id, 'large-run', 1));
+      await stores.agentRunStore.appendEvent(session.id, 'large-run', {
+        type: 'run_started',
+        id: 'large-event',
+        sessionId: session.id,
+        runId: 'large-run',
+        turnId: 'turn-large-run',
+        ts: 1,
+        data: { payload: 'x'.repeat(EXECUTION_INSPECT_EVIDENCE_MAX_BYTES) },
+      });
+
+      const result = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'agent_run', sessionId: session.id, agentRunId: 'large-run' },
+        connectionContext(),
+      );
+
+      assert.deepEqual(result, {
+        ok: false,
+        error: {
+          code: 'invalid_request',
+          message:
+            'AgentRun inspection exceeds the live Host evidence limit; stop the Host to inspect it offline',
+        },
+      });
+    });
+  });
+
+  test('accepts evidence that exactly consumes the shared byte budget before an empty ledger', async () => {
+    await withCoordinator(async ({ stores, coordinator }) => {
+      const session = await stores.sessionStore.create(sessionInput('Exact evidence budget'));
+      await stores.agentRunStore.createRun(runHeader(session.id, 'exact-run', 1));
+      const baseEvent: AgentRunEvent = {
+        type: 'run_started',
+        id: 'exact-event',
+        sessionId: session.id,
+        runId: 'exact-run',
+        turnId: 'turn-exact-run',
+        ts: 1,
+        data: { payload: '' },
+      };
+      const baseBytes = Buffer.byteLength(JSON.stringify(baseEvent), 'utf8');
+      assert.ok(baseBytes < EXECUTION_INSPECT_EVIDENCE_MAX_BYTES);
+      const event: AgentRunEvent = {
+        ...baseEvent,
+        data: {
+          payload: 'x'.repeat(EXECUTION_INSPECT_EVIDENCE_MAX_BYTES - baseBytes),
+        },
+      };
+      await stores.agentRunStore.appendEvent(session.id, 'exact-run', event);
+
+      const exact = await stores.agentRunStore.readEventsBounded(session.id, 'exact-run', {
+        maxRecords: 1,
+        maxBytes: EXECUTION_INSPECT_EVIDENCE_MAX_BYTES,
+      });
+      assert.equal(exact.status, 'complete');
+      const oneByteShort = await stores.agentRunStore.readEventsBounded(session.id, 'exact-run', {
+        maxRecords: 1,
+        maxBytes: EXECUTION_INSPECT_EVIDENCE_MAX_BYTES - 1,
+      });
+      assert.equal(oneByteShort.status, 'limit_exceeded');
+
+      const result = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'agent_run', sessionId: session.id, agentRunId: 'exact-run' },
+        connectionContext(),
+      );
+      assert.equal(result.ok, true);
+    });
+  });
+
+  test('shares one evidence budget across every AgentRun in a Session query', async () => {
+    await withCoordinator(async ({ stores, coordinator }) => {
+      const session = await stores.sessionStore.create(sessionInput('Aggregate evidence'));
+      const payload = 'x'.repeat(Math.ceil(EXECUTION_INSPECT_EVIDENCE_MAX_BYTES / 2));
+      for (const [index, runId] of ['aggregate-run-1', 'aggregate-run-2'].entries()) {
+        await stores.agentRunStore.createRun(runHeader(session.id, runId, index + 1));
+        await stores.agentRunStore.appendEvent(session.id, runId, {
+          type: 'run_started',
+          id: `aggregate-event-${index + 1}`,
+          sessionId: session.id,
+          runId,
+          turnId: `turn-${runId}`,
+          ts: index + 1,
+          data: { payload },
+        });
+      }
+
+      const individual = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'agent_run', sessionId: session.id, agentRunId: 'aggregate-run-1' },
+        connectionContext(),
+      );
+      assert.equal(individual.ok, true);
+
+      const aggregate = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'session', sessionId: session.id },
+        connectionContext(),
+      );
+      assert.deepEqual(aggregate, {
+        ok: false,
+        error: {
+          code: 'invalid_request',
+          message:
+            'Session inspection exceeds the live Host evidence limit; stop the Host to inspect it offline',
+        },
+      });
+    });
+  });
+});
+
+function sessionInput(name: string) {
+  return {
+    cwd: '/tmp/workspace',
+    name,
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    model: 'fake-model',
+    permissionMode: 'ask',
+  } as const;
+}
+
+function runHeader(sessionId: string, runId: string, createdAt: number): AgentRunHeader {
+  return {
+    sessionId,
+    runId,
+    turnId: `turn-${runId}`,
+    status: 'completed',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/tmp/workspace',
+    permissionMode: 'ask',
+    createdAt,
+    updatedAt: createdAt,
+    completedAt: createdAt,
+  };
+}
+
+function connectionContext() {
+  return {
+    hostEpoch: 'host-1',
+    connectionId: 'connection-1',
+    surface: 'inspect' as const,
+    principal: 'local_os_user' as const,
+    acquireResidency: () => ({ release: () => undefined }),
+  };
+}
+
+async function withCoordinator(
+  run: (input: {
+    stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>>;
+    coordinator: HostExecutionInspectCoordinator;
+  }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-host-inspect-'));
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+  try {
+    await run({ stores, coordinator: new HostExecutionInspectCoordinator(stores) });
+  } finally {
+    await stores.sessionStore.close?.();
+    await owner.close();
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/packages/runtime-host/src/__tests__/execution-inspect-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-inspect-protocol.test.ts
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { AgentRunInspectDocument, SessionInspectDocument } from '@maka/runtime';
+import {
+  decodeClientFrame,
+  decodeHostFrame,
+  EXECUTION_INSPECT_CANDIDATE_MAX_ITEMS,
+  EXECUTION_INSPECT_RESULT_MAX_BYTES,
+  HOST_OPERATION_SPECS,
+  RuntimeHostProtocolError,
+} from '../protocol/index.js';
+
+describe('execution inspect protocol', () => {
+  test('decodes closed resolution and evidence query shapes', () => {
+    assert.deepEqual(
+      decodeClientFrame({
+        requestId: 'request-resolve',
+        operation: 'execution.inspect.resolve',
+        input: { id: 'run-1', requestedKind: 'agent_run', sessionId: 'session-1' },
+      }),
+      {
+        requestId: 'request-resolve',
+        operation: 'execution.inspect.resolve',
+        input: { id: 'run-1', requestedKind: 'agent_run', sessionId: 'session-1' },
+      },
+    );
+    assert.deepEqual(
+      decodeHostFrame({
+        requestId: 'request-query',
+        operation: 'execution.inspect.query',
+        ok: true,
+        result: { kind: 'agent_run', document: agentRunDocument() },
+      }),
+      {
+        requestId: 'request-query',
+        operation: 'execution.inspect.query',
+        ok: true,
+        result: { kind: 'agent_run', document: agentRunDocument() },
+      },
+    );
+  });
+
+  test('rejects open shapes, inconsistent resolution, and oversized payloads', () => {
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          requestId: 'request-open',
+          operation: 'execution.inspect.query',
+          input: { kind: 'session', sessionId: 'session-1', rawStore: true },
+        }),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'request-status',
+          operation: 'execution.inspect.resolve',
+          ok: true,
+          result: { status: 'resolved', candidates: [], truncated: false },
+        }),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'request-page',
+          operation: 'execution.inspect.resolve',
+          ok: true,
+          result: {
+            status: 'ambiguous',
+            candidates: Array.from(
+              { length: EXECUTION_INSPECT_CANDIDATE_MAX_ITEMS + 1 },
+              (_, index) => ({
+                kind: 'agent_run',
+                id: 'run-1',
+                sessionId: `session-${index}`,
+              }),
+            ),
+            truncated: true,
+          },
+        }),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'request-open-document',
+          operation: 'execution.inspect.query',
+          ok: true,
+          result: {
+            kind: 'agent_run',
+            document: { ...agentRunDocument(), rawEvidence: true },
+          },
+        }),
+      isProtocolError,
+    );
+    const oversized = sessionDocument('session-1');
+    oversized.diagnostics.push({
+      severity: 'warning',
+      code: 'oversized',
+      message: 'x'.repeat(EXECUTION_INSPECT_RESULT_MAX_BYTES),
+      sessionId: 'session-1',
+    });
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'request-oversized-document',
+          operation: 'execution.inspect.query',
+          ok: true,
+          result: { kind: 'session', document: oversized },
+        }),
+      isProtocolError,
+    );
+  });
+
+  test('correlates evidence output with the requested identity', () => {
+    assert.throws(
+      () =>
+        HOST_OPERATION_SPECS['execution.inspect.query'].assertOutputForInput?.(
+          { kind: 'session', sessionId: 'session-1' },
+          { kind: 'session', document: sessionDocument('different-session') },
+        ),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'request-nested-identity',
+          operation: 'execution.inspect.query',
+          ok: true,
+          result: {
+            kind: 'session',
+            document: {
+              ...sessionDocument('session-1'),
+              agentRuns: [agentRunDocument('different-session')],
+            },
+          },
+        }),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        HOST_OPERATION_SPECS['execution.inspect.resolve'].assertOutputForInput?.(
+          { id: 'run-1', requestedKind: 'agent_run', sessionId: 'session-1' },
+          {
+            status: 'resolved',
+            candidates: [{ kind: 'agent_run', id: 'run-1', sessionId: 'session-2' }],
+            truncated: false,
+          },
+        ),
+      isProtocolError,
+    );
+  });
+});
+
+function agentRunDocument(sessionId = 'session-1', agentRunId = 'run-1'): AgentRunInspectDocument {
+  return {
+    schemaVersion: 'maka.agent_run_inspect.v1',
+    kind: 'agent_run',
+    agentRun: {
+      sessionId,
+      agentRunId,
+      turnId: 'turn-1',
+      status: 'completed',
+      createdAt: 1,
+      updatedAt: 2,
+      completedAt: 2,
+    },
+    sources: {
+      operationalEventCount: 0,
+      runtimeEventCount: 0,
+      health: {
+        runtimeLedger: 'missing',
+        runtimeTerminalPresent: false,
+        operationalTerminalPresent: false,
+        statusConsistency: 'incomplete',
+      },
+    },
+    tools: {
+      callCount: 1,
+      responseCount: 0,
+      errorResponseCount: 0,
+      callsWithoutResponse: [
+        {
+          toolCallId: 'provider.call:1',
+          toolName: 'Read',
+          eventId: 'provider/event:1',
+        },
+      ],
+      responsesWithoutCall: [],
+    },
+    compactionCheckpoints: [],
+    diagnostics: [],
+  };
+}
+
+function sessionDocument(sessionId: string): SessionInspectDocument {
+  return {
+    schemaVersion: 'maka.session_inspect.v1',
+    kind: 'session',
+    session: {
+      sessionId,
+      name: 'Session',
+      status: 'active',
+      createdAt: 1,
+      lastUsedAt: 2,
+      isArchived: false,
+    },
+    agentRuns: [],
+    diagnostics: [],
+  };
+}
+
+function isProtocolError(error: unknown): boolean {
+  return error instanceof RuntimeHostProtocolError;
+}

--- a/packages/runtime-host/src/__tests__/execution-inspect-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-inspect-uds.test.ts
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+import { fork, type ChildProcess } from 'node:child_process';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
+import {
+  resolveRootControlNamespace,
+  resolveStorageRoot,
+  tryAcquireInteractiveRootOwner,
+  tryAcquireInteractiveRootReader,
+} from '@maka/storage/root-authority';
+import { connectExistingRuntimeHost } from '../client/index.js';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '../protocol/index.js';
+
+const PROCESS_TIMEOUT_MS = 10_000;
+
+test('a live Host serves Interactive inspection over its real UDS while retaining exclusive ownership', {
+  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+  timeout: 60_000,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-inspect-'));
+  const root = join(base, 'root');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) throw new Error('Unable to seed Interactive inspection root');
+  const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+  const session = await stores.sessionStore.create({
+    cwd: root,
+    name: 'Live inspection',
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    model: 'fake-model',
+    permissionMode: 'ask',
+  });
+  await stores.sessionStore.close?.();
+  await owner.close();
+
+  let host: ChildProcess | undefined;
+  try {
+    host = await startHost(root, capability.rootId);
+    assert.equal(await tryAcquireInteractiveRootReader(capability), undefined);
+
+    const connected = await connectExistingRuntimeHost({
+      rootPath: root,
+      surface: 'inspect',
+      protocol: {
+        min: RUNTIME_HOST_PROTOCOL_VERSION,
+        max: RUNTIME_HOST_PROTOCOL_VERSION,
+      },
+    });
+    assert.equal(connected.kind, 'connected');
+    if (connected.kind !== 'connected') throw new Error('Live inspection did not connect');
+    try {
+      assert.deepEqual(
+        await connected.connection.request('execution.inspect.resolve', { id: session.id }),
+        {
+          status: 'resolved',
+          candidates: [{ kind: 'session', id: session.id }],
+          truncated: false,
+        },
+      );
+      const inspected = await connected.connection.request('execution.inspect.query', {
+        kind: 'session',
+        sessionId: session.id,
+      });
+      assert.equal(inspected.kind, 'session');
+      if (inspected.kind !== 'session') return;
+      assert.equal(inspected.document.session.sessionId, session.id);
+      assert.equal(inspected.document.session.name, 'Live inspection');
+    } finally {
+      await connected.connection.close();
+    }
+
+    await stopHost(host);
+    host = undefined;
+    const offlineReader = await tryAcquireInteractiveRootReader(capability);
+    assert.ok(offlineReader);
+    await offlineReader?.close();
+  } finally {
+    await terminateHost(host);
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await removePosixEndpointDirectories(capability.rootId);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+async function startHost(root: string, rootId: string): Promise<ChildProcess> {
+  const child = fork(
+    new URL('./fixtures/execution-host.js', import.meta.url),
+    [root, rootId, '60000'],
+    {
+      stdio: ['ignore', 'ignore', 'inherit', 'ipc'],
+    },
+  );
+  try {
+    await withTimeout(
+      new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          child.off('error', onError);
+          child.off('exit', onExit);
+          child.off('message', onMessage);
+        };
+        const onError = (error: Error) => {
+          cleanup();
+          reject(error);
+        };
+        const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+          cleanup();
+          reject(new Error(`execution Host exited before readiness: ${code ?? signal}`));
+        };
+        const onMessage = (message: unknown) => {
+          if (
+            message &&
+            typeof message === 'object' &&
+            (message as { type?: unknown }).type === 'ready'
+          ) {
+            cleanup();
+            resolve();
+          }
+        };
+        child.once('error', onError);
+        child.once('exit', onExit);
+        child.on('message', onMessage);
+      }),
+      PROCESS_TIMEOUT_MS,
+      'execution Host did not become ready',
+    );
+    return child;
+  } catch (error) {
+    await terminateChild(child);
+    throw error;
+  }
+}
+
+async function stopHost(child: ChildProcess): Promise<void> {
+  if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+  const exit = await withTimeout(
+    waitForExit(child),
+    PROCESS_TIMEOUT_MS,
+    'execution Host did not stop',
+  );
+  assert.deepEqual(exit, { code: 0, signal: null });
+}
+
+async function terminateHost(child: ChildProcess | undefined): Promise<void> {
+  if (child) await terminateChild(child);
+}
+
+async function terminateChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+  await withTimeout(waitForExit(child), PROCESS_TIMEOUT_MS, 'execution Host did not exit').then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
+function waitForExit(
+  child: ChildProcess,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      child.off('error', onError);
+      child.off('exit', onExit);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ code, signal });
+    };
+    child.once('error', onError);
+    child.once('exit', onExit);
+  });
+}
+
+async function removePosixEndpointDirectories(rootId: string): Promise<void> {
+  if (process.platform === 'win32' || typeof process.getuid !== 'function') return;
+  const prefix = `m-${process.getuid()}-${Buffer.from(rootId, 'hex').toString('base64url')}-`;
+  const entries = await readdir('/tmp', { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (entry.isDirectory() && entry.name.startsWith(prefix)) {
+        await rm(join('/tmp', entry.name), { recursive: true, force: true });
+      }
+    }),
+  );
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  return Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    }),
+  ]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -61,6 +61,8 @@ describe('Runtime Host bootstrap protocol', () => {
       'credential.vault.delete',
       'credential.vault.query',
       'credential.vault.set',
+      'execution.inspect.query',
+      'execution.inspect.resolve',
       'goal.control',
       'goal.query',
       'host.status',

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -2,7 +2,9 @@ import { randomUUID } from 'node:crypto';
 import { connect } from 'node:net';
 import { performance } from 'node:perf_hooks';
 import {
+  discoverMarkedStorageRoot,
   prepareStorageRootControlDirectory,
+  resolveExistingStorageRootControlDirectory,
   resolveStorageRoot,
   type StorageRootCapability,
 } from '@maka/storage/root-authority';
@@ -479,29 +481,65 @@ function isClientCapabilityMutation(operation: unknown): boolean {
 export async function connectRuntimeHost(
   input: ConnectRuntimeHostInput,
 ): Promise<ConnectRuntimeHostResult> {
-  validateProtocolRange(input.protocol);
-  const connectTimeoutMs = requireTimeout(
-    input.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
-    'connectTimeoutMs',
-  );
-  const handshakeTimeoutMs = requireTimeout(
-    input.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS,
-    'handshakeTimeoutMs',
-  );
-  const clientInstanceId = requireClientInstanceId(input.clientInstanceId ?? randomUUID());
+  const normalized = normalizeConnectRuntimeHostInput(input);
   const capability = await resolveStorageRoot({
     path: input.rootPath,
     kind: 'interactive',
   });
   const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
-  const result = await connectResolvedRuntimeHost({
-    ...input,
-    clientInstanceId,
-    connectTimeoutMs,
-    handshakeTimeoutMs,
-    capability,
-    controlDirectory,
-  });
+  return finalizeConnectRuntimeHostResult(
+    await connectResolvedRuntimeHost({
+      ...input,
+      ...normalized,
+      capability,
+      controlDirectory,
+    }),
+  );
+}
+
+/** Connects only through an already published Host control plane and performs no filesystem writes. */
+export async function connectExistingRuntimeHost(
+  input: ConnectRuntimeHostInput,
+): Promise<ConnectRuntimeHostResult> {
+  const normalized = normalizeConnectRuntimeHostInput(input);
+  const discovered = await discoverMarkedStorageRoot({ path: input.rootPath });
+  if (discovered.kind !== 'interactive') {
+    return { kind: 'unavailable', reason: 'root_mismatch' };
+  }
+  const capability = discovered;
+  const { controlDirectory } = await resolveExistingStorageRootControlDirectory(capability);
+  return finalizeConnectRuntimeHostResult(
+    await connectResolvedRuntimeHost({
+      ...input,
+      ...normalized,
+      capability,
+      controlDirectory,
+    }),
+  );
+}
+
+function normalizeConnectRuntimeHostInput(input: ConnectRuntimeHostInput): {
+  clientInstanceId: string;
+  connectTimeoutMs: number;
+  handshakeTimeoutMs: number;
+} {
+  validateProtocolRange(input.protocol);
+  return {
+    clientInstanceId: requireClientInstanceId(input.clientInstanceId ?? randomUUID()),
+    connectTimeoutMs: requireTimeout(
+      input.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
+      'connectTimeoutMs',
+    ),
+    handshakeTimeoutMs: requireTimeout(
+      input.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS,
+      'handshakeTimeoutMs',
+    ),
+  };
+}
+
+function finalizeConnectRuntimeHostResult(
+  result: ConnectResolvedRuntimeHostResult,
+): ConnectRuntimeHostResult {
   if (result.kind === 'election_deadline_elapsed') {
     return {
       kind: 'unavailable',

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -1,5 +1,6 @@
 export {
   connectRuntimeHost,
+  connectExistingRuntimeHost,
   RuntimeHostOperationError,
   type ConnectRuntimeHostInput,
   type ConnectRuntimeHostResult,

--- a/packages/runtime-host/src/protocol/execution-inspect.ts
+++ b/packages/runtime-host/src/protocol/execution-inspect.ts
@@ -1,0 +1,266 @@
+import {
+  isAgentRunInspectDocument,
+  isSessionInspectDocument,
+  type AgentRunInspectDocument,
+  type SessionInspectDocument,
+} from '@maka/core/execution-inspect';
+import {
+  requireEncodedByteLimit,
+  requireEntityId,
+  requireExactRecord,
+  requireShapedRecord,
+} from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const EXECUTION_INSPECT_CANDIDATE_MAX_ITEMS = 32;
+export const EXECUTION_INSPECT_SESSION_MAX_RUNS = 64;
+export const EXECUTION_INSPECT_RESULT_MAX_BYTES = 48 * 1024;
+export const EXECUTION_INSPECT_EVIDENCE_MAX_RECORDS = 4096;
+export const EXECUTION_INSPECT_EVIDENCE_MAX_BYTES = 512 * 1024;
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'not_found',
+  'invalid_request',
+  'persistence_failed',
+  'internal_failure',
+] as const;
+
+export type ExecutionInspectEntityKind = 'session' | 'agent_run';
+
+export type ExecutionInspectCandidate =
+  | { readonly kind: 'session'; readonly id: string }
+  | { readonly kind: 'agent_run'; readonly id: string; readonly sessionId: string };
+
+export interface ExecutionInspectResolveInput {
+  readonly id: string;
+  readonly requestedKind?: ExecutionInspectEntityKind;
+  readonly sessionId?: string;
+}
+
+export interface ExecutionInspectResolveResult {
+  readonly status: 'resolved' | 'not_found' | 'ambiguous';
+  readonly candidates: readonly ExecutionInspectCandidate[];
+  readonly truncated: boolean;
+}
+
+export type ExecutionInspectQueryInput =
+  | { readonly kind: 'session'; readonly sessionId: string }
+  | {
+      readonly kind: 'agent_run';
+      readonly sessionId: string;
+      readonly agentRunId: string;
+    };
+
+export type ExecutionInspectQueryResult =
+  | { readonly kind: 'session'; readonly document: SessionInspectDocument }
+  | { readonly kind: 'agent_run'; readonly document: AgentRunInspectDocument };
+
+export const EXECUTION_INSPECT_OPERATION_SPECS = {
+  'execution.inspect.resolve': defineOperation<
+    ExecutionInspectResolveInput,
+    ExecutionInspectResolveResult,
+    (typeof QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeExecutionInspectResolveInput,
+    decodeOutput: decodeExecutionInspectResolveResult,
+    assertOutputForInput: assertResolveOutputForInput,
+  }),
+  'execution.inspect.query': defineOperation<
+    ExecutionInspectQueryInput,
+    ExecutionInspectQueryResult,
+    (typeof QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeExecutionInspectQueryInput,
+    decodeOutput: decodeExecutionInspectQueryResult,
+    assertOutputForInput: assertQueryOutputForInput,
+  }),
+} as const;
+
+export function decodeExecutionInspectResolveInput(value: unknown): ExecutionInspectResolveInput {
+  const record = requireShapedRecord(
+    value,
+    'execution.inspect.resolve input',
+    ['id'],
+    ['requestedKind', 'sessionId'],
+  );
+  const requestedKind =
+    record.requestedKind === undefined
+      ? undefined
+      : requireExecutionInspectEntityKind(record.requestedKind);
+  const sessionId =
+    record.sessionId === undefined
+      ? undefined
+      : requireEntityId(record.sessionId, 'inspect Session id');
+  if (sessionId !== undefined && requestedKind !== 'agent_run') {
+    throw invalidProtocolFrame('Inspect Session filter requires AgentRun kind');
+  }
+  return {
+    id: requireEntityId(record.id, 'inspect target id'),
+    ...(requestedKind ? { requestedKind } : {}),
+    ...(sessionId ? { sessionId } : {}),
+  };
+}
+
+export function decodeExecutionInspectResolveResult(value: unknown): ExecutionInspectResolveResult {
+  requireEncodedByteLimit(
+    value,
+    'execution.inspect.resolve result',
+    EXECUTION_INSPECT_RESULT_MAX_BYTES,
+  );
+  const record = requireExactRecord(value, 'execution.inspect.resolve result', [
+    'status',
+    'candidates',
+    'truncated',
+  ]);
+  if (!Array.isArray(record.candidates)) {
+    throw invalidProtocolFrame('Invalid execution inspect candidates');
+  }
+  if (record.candidates.length > EXECUTION_INSPECT_CANDIDATE_MAX_ITEMS) {
+    throw invalidProtocolFrame('Execution inspect candidate page exceeds its item limit');
+  }
+  if (typeof record.truncated !== 'boolean') {
+    throw invalidProtocolFrame('Invalid execution inspect candidate truncation');
+  }
+  const status = requireResolveStatus(record.status);
+  const candidates = record.candidates.map(decodeExecutionInspectCandidate);
+  const expectedStatus =
+    candidates.length === 0 && !record.truncated
+      ? 'not_found'
+      : candidates.length === 1 && !record.truncated
+        ? 'resolved'
+        : 'ambiguous';
+  if (status !== expectedStatus) {
+    throw invalidProtocolFrame('Execution inspect resolution status does not match candidates');
+  }
+  return { status, candidates, truncated: record.truncated };
+}
+
+export function decodeExecutionInspectQueryInput(value: unknown): ExecutionInspectQueryInput {
+  const record = requireShapedRecord(
+    value,
+    'execution.inspect.query input',
+    ['kind', 'sessionId'],
+    ['agentRunId'],
+  );
+  const sessionId = requireEntityId(record.sessionId, 'inspect Session id');
+  if (record.kind === 'session') {
+    requireExactRecord(record, 'Session inspect query', ['kind', 'sessionId']);
+    return { kind: 'session', sessionId };
+  }
+  if (record.kind === 'agent_run') {
+    requireExactRecord(record, 'AgentRun inspect query', ['kind', 'sessionId', 'agentRunId']);
+    return {
+      kind: 'agent_run',
+      sessionId,
+      agentRunId: requireEntityId(record.agentRunId, 'inspect AgentRun id'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid execution inspect query kind');
+}
+
+export function decodeExecutionInspectQueryResult(value: unknown): ExecutionInspectQueryResult {
+  requireEncodedByteLimit(
+    value,
+    'execution.inspect.query result',
+    EXECUTION_INSPECT_RESULT_MAX_BYTES,
+  );
+  const record = requireExactRecord(value, 'execution.inspect.query result', ['kind', 'document']);
+  if (record.kind === 'session') {
+    if (
+      !isSessionInspectDocument(record.document) ||
+      record.document.agentRuns.length > EXECUTION_INSPECT_SESSION_MAX_RUNS
+    ) {
+      throw invalidProtocolFrame('Invalid Session inspect document');
+    }
+    return { kind: 'session', document: record.document };
+  }
+  if (record.kind === 'agent_run') {
+    if (!isAgentRunInspectDocument(record.document)) {
+      throw invalidProtocolFrame('Invalid AgentRun inspect document');
+    }
+    return { kind: 'agent_run', document: record.document };
+  }
+  throw invalidProtocolFrame('Invalid execution inspect query result kind');
+}
+
+function decodeExecutionInspectCandidate(value: unknown): ExecutionInspectCandidate {
+  const record = requireShapedRecord(
+    value,
+    'execution inspect candidate',
+    ['kind', 'id'],
+    ['sessionId'],
+  );
+  const kind = requireExecutionInspectEntityKind(record.kind);
+  const sessionId =
+    record.sessionId === undefined
+      ? undefined
+      : requireEntityId(record.sessionId, 'candidate Session id');
+  const id = requireEntityId(record.id, 'candidate id');
+  if (kind === 'agent_run') {
+    if (sessionId === undefined) {
+      throw invalidProtocolFrame('AgentRun inspect candidate requires a Session identity');
+    }
+    return { kind, id, sessionId };
+  }
+  if (sessionId !== undefined) {
+    throw invalidProtocolFrame(
+      'Session inspect candidate cannot include a parent Session identity',
+    );
+  }
+  return { kind, id };
+}
+
+function assertResolveOutputForInput(
+  input: ExecutionInspectResolveInput,
+  output: ExecutionInspectResolveResult,
+): void {
+  for (const candidate of output.candidates) {
+    if (
+      candidate.id !== input.id ||
+      (input.requestedKind !== undefined && candidate.kind !== input.requestedKind) ||
+      (input.sessionId !== undefined &&
+        (candidate.kind !== 'agent_run' || candidate.sessionId !== input.sessionId))
+    ) {
+      throw invalidProtocolFrame('Execution inspect resolution changed request identity');
+    }
+  }
+}
+
+function assertQueryOutputForInput(
+  input: ExecutionInspectQueryInput,
+  output: ExecutionInspectQueryResult,
+): void {
+  if (input.kind === 'session') {
+    if (output.kind !== 'session' || output.document.session.sessionId !== input.sessionId) {
+      throw invalidProtocolFrame('Session inspect result changed request identity');
+    }
+    return;
+  }
+  if (
+    output.kind !== 'agent_run' ||
+    output.document.agentRun.sessionId !== input.sessionId ||
+    output.document.agentRun.agentRunId !== input.agentRunId
+  ) {
+    throw invalidProtocolFrame('AgentRun inspect result changed request identity');
+  }
+}
+
+function requireExecutionInspectEntityKind(value: unknown): ExecutionInspectEntityKind {
+  if (value === 'session' || value === 'agent_run') return value;
+  throw invalidProtocolFrame('Invalid execution inspect entity kind');
+}
+
+function requireResolveStatus(value: unknown): ExecutionInspectResolveResult['status'] {
+  if (value === 'resolved' || value === 'not_found' || value === 'ambiguous') return value;
+  throw invalidProtocolFrame('Invalid execution inspect resolution status');
+}

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -28,6 +28,7 @@ export * from './interaction.js';
 export * from './automation.js';
 export * from './client-capability.js';
 export * from './goal.js';
+export * from './execution-inspect.js';
 export * from './message.js';
 export * from './operations.js';
 export * from './runtime-resource.js';

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -2,6 +2,7 @@ import { ARTIFACT_OPERATION_SPECS } from './artifact.js';
 import { AUTOMATION_OPERATION_SPECS } from './automation.js';
 import { requireExactRecord, requireId, requireRecord, requireString } from './codec.js';
 import { CONNECTION_EFFECT_OPERATION_SPECS } from './connection-effects.js';
+import { EXECUTION_INSPECT_OPERATION_SPECS } from './execution-inspect.js';
 import { CLIENT_CAPABILITY_OPERATION_SPECS } from './client-capability.js';
 import { invalidProtocolFrame } from './errors.js';
 import { HOST_STATUS_OPERATION_SPECS } from './host-status.js';
@@ -88,6 +89,7 @@ export type {
   TurnStopInput,
 } from './turn.js';
 export * from './connection-effects.js';
+export * from './execution-inspect.js';
 export * from './client-capability.js';
 export * from './goal.js';
 export * from './memory.js';
@@ -105,6 +107,7 @@ export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   GOAL_OPERATION_SPECS,
   TURN_OPERATION_SPECS,
   CONNECTION_EFFECT_OPERATION_SPECS,
+  EXECUTION_INSPECT_OPERATION_SPECS,
   RUNTIME_POLICY_OPERATION_SPECS,
   RUNTIME_RESOURCE_OPERATION_SPECS,
   AUTOMATION_OPERATION_SPECS,

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -38,6 +38,7 @@ import { recoverClientCapabilityOutcomes } from './client-capability-recovery.js
 import { HostConnectionEffectCoordinator } from './connection-effect-coordinator.js';
 import { HostClientCapabilityCoordinator } from './client-capability-coordinator.js';
 import { createHostAiSdkBackend, createHostGoalEvaluator } from './execution-model-composition.js';
+import { HostExecutionInspectCoordinator } from './execution-inspect-coordinator.js';
 import { HostGoalCoordinator } from './goal-coordinator.js';
 import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './host-kernel.js';
 import { HostInteractionCoordinator } from './interaction-coordinator.js';
@@ -431,6 +432,7 @@ export async function createExecutionRuntimeHostComposition(
       continuity: continuityCoordinator,
       requestDrain: context.requestDrain,
     });
+    const executionInspect = new HostExecutionInspectCoordinator(stores);
     const sessionRevisions = new HostSessionRevisionCoordinator({
       stores,
       artifacts: openedArtifactStore,
@@ -468,6 +470,7 @@ export async function createExecutionRuntimeHostComposition(
       ...coordinator.handlers,
       ...requireGoal(goal).handlers,
       ...sessionCatalog.handlers,
+      ...executionInspect.handlers,
       ...sessionRevisions.handlers,
       ...sessionRetirement.handlers,
       ...messages.handlers,

--- a/packages/runtime-host/src/server/execution-inspect-coordinator.ts
+++ b/packages/runtime-host/src/server/execution-inspect-coordinator.ts
@@ -1,0 +1,287 @@
+import {
+  inspectAgentRunDocument,
+  inspectSessionDocument,
+  type AgentRunInspectDocument,
+  type SessionInspectDocument,
+} from '@maka/runtime';
+import {
+  isSessionNotFoundError,
+  type BoundedEvidenceReadResult,
+  type EvidenceReadBudget,
+  type ExecutionAgentRunReader,
+  type ExecutionRuntimeEventReader,
+  type ExecutionSessionWriter,
+} from '@maka/storage/execution-stores';
+import {
+  EXECUTION_INSPECT_CANDIDATE_MAX_ITEMS,
+  EXECUTION_INSPECT_EVIDENCE_MAX_BYTES,
+  EXECUTION_INSPECT_EVIDENCE_MAX_RECORDS,
+  EXECUTION_INSPECT_RESULT_MAX_BYTES,
+  EXECUTION_INSPECT_SESSION_MAX_RUNS,
+  type ExecutionInspectCandidate,
+  type ExecutionInspectQueryInput,
+  type ExecutionInspectQueryResult,
+  type ExecutionInspectResolveInput,
+  type OperationOutcome,
+} from '../protocol/index.js';
+import type { ExecutionInspectOperationHandlerMap } from './operation-dispatcher.js';
+
+interface InspectStores {
+  readonly sessionStore: Pick<ExecutionSessionWriter, 'readHeaderSnapshot'>;
+  readonly agentRunStore: Pick<
+    ExecutionAgentRunReader,
+    'readRun' | 'findRunsById' | 'listSessionRunsBounded' | 'readEventsBounded'
+  >;
+  readonly runtimeEventStore: Pick<ExecutionRuntimeEventReader, 'readRuntimeEventsBounded'>;
+}
+
+/** Host-owned, payload-safe read model for live Interactive execution evidence. */
+export class HostExecutionInspectCoordinator {
+  readonly handlers: ExecutionInspectOperationHandlerMap = {
+    'execution.inspect.resolve': (input) => this.#resolve(input),
+    'execution.inspect.query': (input) => this.#query(input),
+  };
+
+  readonly #stores: InspectStores;
+
+  constructor(stores: InspectStores) {
+    this.#stores = stores;
+  }
+
+  async #resolve(
+    input: ExecutionInspectResolveInput,
+  ): Promise<OperationOutcome<'execution.inspect.resolve'>> {
+    try {
+      const [sessionCandidates, runSearch] = await Promise.all([
+        input.requestedKind === 'agent_run' ? [] : this.#findSession(input.id),
+        input.requestedKind === 'session'
+          ? { runs: [], truncated: false }
+          : input.sessionId
+            ? this.#findRunInSession(input.sessionId, input.id)
+            : this.#stores.agentRunStore.findRunsById(
+                input.id,
+                input.requestedKind === undefined
+                  ? EXECUTION_INSPECT_CANDIDATE_MAX_ITEMS - 1
+                  : EXECUTION_INSPECT_CANDIDATE_MAX_ITEMS,
+              ),
+      ]);
+      const candidates = [
+        ...runSearch.runs.map(
+          (run): ExecutionInspectCandidate => ({
+            kind: 'agent_run',
+            id: run.runId,
+            sessionId: run.sessionId,
+          }),
+        ),
+        ...sessionCandidates,
+      ].sort(compareCandidates);
+      const truncated = runSearch.truncated;
+      const status =
+        candidates.length === 0 && !truncated
+          ? 'not_found'
+          : candidates.length === 1 && !truncated
+            ? 'resolved'
+            : 'ambiguous';
+      return { ok: true, result: { status, candidates, truncated } };
+    } catch {
+      return failure(
+        'execution.inspect.resolve',
+        'persistence_failed',
+        'Execution evidence is unavailable',
+      );
+    }
+  }
+
+  async #query(
+    input: ExecutionInspectQueryInput,
+  ): Promise<OperationOutcome<'execution.inspect.query'>> {
+    try {
+      const result =
+        input.kind === 'agent_run'
+          ? await this.#inspectAgentRun(input.sessionId, input.agentRunId)
+          : await this.#inspectSession(input.sessionId);
+      if (result === undefined) {
+        return failure('execution.inspect.query', 'not_found', 'Execution evidence was not found');
+      }
+      if (encodedBytes(result) > EXECUTION_INSPECT_RESULT_MAX_BYTES) {
+        return failure(
+          'execution.inspect.query',
+          'invalid_request',
+          input.kind === 'session'
+            ? 'Session inspection exceeds the live Host result limit; inspect one AgentRun instead'
+            : 'AgentRun inspection exceeds the live Host result limit',
+        );
+      }
+      return { ok: true, result };
+    } catch (error) {
+      if (error instanceof InspectQueryTooLargeError) {
+        return failure('execution.inspect.query', 'invalid_request', error.message);
+      }
+      return failure(
+        'execution.inspect.query',
+        'persistence_failed',
+        'Execution evidence is unavailable',
+      );
+    }
+  }
+
+  async #findSession(id: string): Promise<ExecutionInspectCandidate[]> {
+    try {
+      const header = await this.#stores.sessionStore.readHeaderSnapshot(id);
+      return [{ kind: 'session', id: header.id }];
+    } catch (error) {
+      if (isMissing(error)) return [];
+      throw error;
+    }
+  }
+
+  async #findRunInSession(sessionId: string, runId: string) {
+    try {
+      const run = await this.#stores.agentRunStore.readRun(sessionId, runId);
+      return { runs: [run], truncated: false };
+    } catch (error) {
+      if (isMissing(error)) return { runs: [], truncated: false };
+      throw error;
+    }
+  }
+
+  async #inspectAgentRun(
+    sessionId: string,
+    agentRunId: string,
+  ): Promise<ExecutionInspectQueryResult | undefined> {
+    let header;
+    try {
+      header = await this.#stores.agentRunStore.readRun(sessionId, agentRunId);
+    } catch (error) {
+      if (isMissing(error)) return undefined;
+      throw error;
+    }
+    const document: AgentRunInspectDocument = await inspectAgentRunDocument(
+      ...this.#budgetedReaders('AgentRun'),
+      {
+        sessionId,
+        agentRunId,
+        header,
+        isFatalReadError: isInspectQueryTooLargeError,
+      },
+    );
+    return { kind: 'agent_run', document };
+  }
+
+  async #inspectSession(sessionId: string): Promise<ExecutionInspectQueryResult | undefined> {
+    let header;
+    try {
+      header = await this.#stores.sessionStore.readHeaderSnapshot(sessionId);
+    } catch (error) {
+      if (isMissing(error)) return undefined;
+      throw error;
+    }
+    const runPage = await this.#stores.agentRunStore.listSessionRunsBounded(
+      sessionId,
+      EXECUTION_INSPECT_SESSION_MAX_RUNS,
+    );
+    if (runPage.truncated) {
+      throw new InspectQueryTooLargeError(
+        'Session inspection exceeds the live Host run limit; inspect one AgentRun instead',
+      );
+    }
+    const readers = this.#budgetedReaders('Session');
+    const document: SessionInspectDocument = await inspectSessionDocument(
+      { readHeader: (id) => this.#stores.sessionStore.readHeaderSnapshot(id) },
+      {
+        ...readers[0],
+        listSessionRuns: async () => [...runPage.runs],
+      },
+      readers[1],
+      sessionId,
+      {
+        header,
+        runHeaders: runPage.runs,
+        isFatalReadError: isInspectQueryTooLargeError,
+      },
+    );
+    return { kind: 'session', document };
+  }
+
+  #budgetedReaders(label: 'AgentRun' | 'Session') {
+    const budget = new InspectEvidenceBudget(label);
+    return [
+      {
+        readRun: (sessionId: string, runId: string) =>
+          this.#stores.agentRunStore.readRun(sessionId, runId),
+        readEvents: (sessionId: string, runId: string) =>
+          budget.read((remaining) =>
+            this.#stores.agentRunStore.readEventsBounded(sessionId, runId, remaining),
+          ),
+      },
+      {
+        readRuntimeEvents: (sessionId: string, runId: string) =>
+          budget.read((remaining) =>
+            this.#stores.runtimeEventStore.readRuntimeEventsBounded(sessionId, runId, remaining),
+          ),
+      },
+    ] as const;
+  }
+}
+
+class InspectQueryTooLargeError extends Error {
+  readonly name = 'InspectQueryTooLargeError';
+}
+
+class InspectEvidenceBudget {
+  #remainingRecords = EXECUTION_INSPECT_EVIDENCE_MAX_RECORDS;
+  #remainingBytes = EXECUTION_INSPECT_EVIDENCE_MAX_BYTES;
+
+  constructor(private readonly label: 'AgentRun' | 'Session') {}
+
+  async read<T>(
+    operation: (budget: EvidenceReadBudget) => Promise<BoundedEvidenceReadResult<T>>,
+  ): Promise<T[]> {
+    const result = await operation({
+      maxRecords: this.#remainingRecords,
+      maxBytes: this.#remainingBytes,
+    });
+    if (result.status === 'limit_exceeded') this.#throwExceeded();
+    this.#remainingRecords -= result.sourceRecordCount;
+    this.#remainingBytes -= result.storedBytes;
+    return [...result.records];
+  }
+
+  #throwExceeded(): never {
+    throw new InspectQueryTooLargeError(
+      `${this.label} inspection exceeds the live Host evidence limit; stop the Host to inspect it offline`,
+    );
+  }
+}
+
+function encodedBytes(result: ExecutionInspectQueryResult): number {
+  return Buffer.byteLength(JSON.stringify(result), 'utf8');
+}
+
+function compareCandidates(
+  left: ExecutionInspectCandidate,
+  right: ExecutionInspectCandidate,
+): number {
+  return (
+    left.kind.localeCompare(right.kind) ||
+    (left.kind === 'agent_run' ? left.sessionId : '').localeCompare(
+      right.kind === 'agent_run' ? right.sessionId : '',
+    )
+  );
+}
+
+function isMissing(error: unknown): boolean {
+  return isSessionNotFoundError(error) || (error as NodeJS.ErrnoException)?.code === 'ENOENT';
+}
+
+function isInspectQueryTooLargeError(error: unknown): boolean {
+  return error instanceof InspectQueryTooLargeError;
+}
+
+function failure<K extends 'execution.inspect.resolve' | 'execution.inspect.query'>(
+  _operation: K,
+  code: Extract<OperationOutcome<K>, { ok: false }>['error']['code'],
+  message: string,
+): OperationOutcome<K> {
+  return { ok: false, error: { code, message } } as OperationOutcome<K>;
+}

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -49,6 +49,7 @@ export type MessageOperationKey = Extract<
 >;
 export type InteractionOperationKey = Extract<OperationKey, `interaction.${string}`>;
 export type GoalOperationKey = Extract<OperationKey, `goal.${string}`>;
+export type ExecutionInspectOperationKey = Extract<OperationKey, `execution.inspect.${string}`>;
 export type SessionContinuityOperationKey = Extract<
   OperationKey,
   'subscription.open' | 'subscription.close'
@@ -84,6 +85,10 @@ export type ConnectionEffectOperationHandlerMap = Pick<
 export type MessageOperationHandlerMap = Pick<OperationHandlerMap, MessageOperationKey>;
 export type InteractionOperationHandlerMap = Pick<OperationHandlerMap, InteractionOperationKey>;
 export type GoalOperationHandlerMap = Pick<OperationHandlerMap, GoalOperationKey>;
+export type ExecutionInspectOperationHandlerMap = Pick<
+  OperationHandlerMap,
+  ExecutionInspectOperationKey
+>;
 export type SessionContinuityOperationHandlerMap = Pick<
   OperationHandlerMap,
   SessionContinuityOperationKey

--- a/packages/runtime/src/agent-run-inspect.ts
+++ b/packages/runtime/src/agent-run-inspect.ts
@@ -65,6 +65,7 @@ export interface InspectAgentRunOptions {
   runId: string;
   header?: AgentRunHeader;
   isFatalReadError?: (error: unknown) => boolean;
+  includeModelReplay?: boolean;
 }
 
 export type AgentRunInspectReader = Pick<AgentRunStore, 'readRun' | 'readEvents'>;
@@ -139,7 +140,9 @@ export async function inspectAgentRunReadModel(
   }
 
   const modelReplay =
-    runtimeEvents.length > 0 ? buildRuntimeEventModelReplayPlan(runtimeEvents) : undefined;
+    runtimeEvents.length > 0 && options.includeModelReplay !== false
+      ? buildRuntimeEventModelReplayPlan(runtimeEvents)
+      : undefined;
 
   const statusConsistency = computeStatusConsistency(
     header,

--- a/packages/runtime/src/execution-inspect.ts
+++ b/packages/runtime/src/execution-inspect.ts
@@ -1,10 +1,21 @@
 import type { AgentRunHeader, RuntimeEvent, SessionHeader } from '@maka/core';
+import {
+  AGENT_RUN_INSPECT_DOCUMENT_VERSION,
+  SESSION_INSPECT_DOCUMENT_VERSION,
+  type AgentRunInspectCompactionCheckpoint,
+  type AgentRunInspectDocument,
+  type AgentRunInspectIdentity,
+  type AgentRunInspectToolFact,
+  type AgentRunInspectToolSummary,
+  type ExecutionInspectDiagnostic,
+  type ExecutionInspectSeverity,
+  type SessionInspectDocument,
+} from '@maka/core/execution-inspect';
 import type { ExecutionLogCoverage } from '@maka/core/execution-evidence';
 import {
   inspectAgentRunReadModel,
   type AgentRunInspectReader,
   type AgentRunInspectDiagnostic as SourceDiagnostic,
-  type AgentRunInspectSourceHealth,
   type InspectAgentRunOptions,
   type RuntimeEventInspectReader,
   type SessionAgentRunInspectReader,
@@ -14,107 +25,13 @@ import {
   type HistoryCompactCheckpoint,
 } from './history-compact-checkpoint.js';
 
-export const AGENT_RUN_INSPECT_DOCUMENT_VERSION = 'maka.agent_run_inspect.v1' as const;
-export const SESSION_INSPECT_DOCUMENT_VERSION = 'maka.session_inspect.v1' as const;
-
-export type ExecutionInspectSeverity = 'error' | 'warning' | 'info';
-
-export interface ExecutionInspectDiagnostic {
-  severity: ExecutionInspectSeverity;
-  code: string;
-  message: string;
-  sessionId: string;
-  agentRunId?: string;
-  turnId?: string;
-  eventId?: string;
-}
-
-export interface AgentRunInspectIdentity {
-  sessionId: string;
-  agentRunId: string;
-  invocationId?: string;
-  turnId: string;
-  parentRunId?: string;
-  resumedFromRunId?: string;
-  retriedFromRunId?: string;
-  parentTurnId?: string;
-  agentId?: string;
-  status: AgentRunHeader['status'];
-  createdAt: number;
-  updatedAt: number;
-  completedAt?: number;
-  failureClass?: string;
-  abortSource?: string;
-}
-
-export interface AgentRunInspectToolFact {
-  toolCallId: string;
-  toolName: string;
-  eventId: string;
-}
-
-export interface AgentRunInspectToolSummary {
-  callCount: number;
-  responseCount: number;
-  errorResponseCount: number;
-  callsWithoutResponse: AgentRunInspectToolFact[];
-  responsesWithoutCall: AgentRunInspectToolFact[];
-}
-
-export interface AgentRunInspectCompactionCheckpoint {
-  eventId: string;
-  validation: 'shape_valid' | 'invalid';
-  checkpointId?: string;
-  policyVersion?: string;
-  sourceCoverage?: ExecutionLogCoverage;
-}
-
-export interface AgentRunInspectDocument {
-  schemaVersion: typeof AGENT_RUN_INSPECT_DOCUMENT_VERSION;
-  kind: 'agent_run';
-  agentRun: AgentRunInspectIdentity;
-  sources: {
-    operationalEventCount: number;
-    runtimeEventCount: number;
-    runtimeCoverage?: ExecutionLogCoverage;
-    health: AgentRunInspectSourceHealth;
-  };
-  tools: AgentRunInspectToolSummary;
-  compactionCheckpoints: AgentRunInspectCompactionCheckpoint[];
-  diagnostics: ExecutionInspectDiagnostic[];
-}
-
-export interface SessionInspectSummary {
-  sessionId: string;
-  name: string;
-  status: SessionHeader['status'];
-  createdAt: number;
-  lastUsedAt: number;
-  lastMessageAt?: number;
-  isArchived: boolean;
-  parentSessionId?: string;
-  branchOfTurnId?: string;
-  revisionRootSessionId?: string;
-  revisionParentSessionId?: string;
-  revisionOfTurnId?: string;
-  revisionIndex?: number;
-  revisionState?: 'preparing' | 'committed';
-}
-
-export interface SessionInspectDocument {
-  schemaVersion: typeof SESSION_INSPECT_DOCUMENT_VERSION;
-  kind: 'session';
-  session: SessionInspectSummary;
-  agentRuns: AgentRunInspectDocument[];
-  diagnostics: ExecutionInspectDiagnostic[];
-}
-
 export interface SessionHeaderReader {
   readHeader(sessionId: string): Promise<SessionHeader>;
 }
 
 export interface InspectSessionDocumentOptions {
   header?: SessionHeader;
+  runHeaders?: readonly AgentRunHeader[];
   isFatalReadError?: InspectAgentRunOptions['isFatalReadError'];
 }
 
@@ -133,6 +50,7 @@ export async function inspectAgentRunDocument(
     runId: input.agentRunId,
     ...(input.header ? { header: input.header } : {}),
     ...(input.isFatalReadError ? { isFatalReadError: input.isFatalReadError } : {}),
+    includeModelReplay: false,
   });
   const diagnostics = model.diagnostics.map((item) => sourceDiagnostic(model.header, item));
   const tools = inspectTools(model.header, model.runtimeEvents, diagnostics);
@@ -167,7 +85,7 @@ export async function inspectSessionDocument(
   options: InspectSessionDocumentOptions = {},
 ): Promise<SessionInspectDocument> {
   const resolvedHeader = options.header ?? (await sessionStore.readHeader(sessionId));
-  const runHeaders = await runStore.listSessionRuns(sessionId);
+  const runHeaders = options.runHeaders ?? (await runStore.listSessionRuns(sessionId));
   const agentRuns: AgentRunInspectDocument[] = [];
   for (const runHeader of runHeaders) {
     agentRuns.push(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1257,13 +1257,17 @@ export type {
 
 // execution-inspect.ts — payload-safe, versioned CLI inspection documents.
 export {
-  AGENT_RUN_INSPECT_DOCUMENT_VERSION,
-  SESSION_INSPECT_DOCUMENT_VERSION,
   inspectAgentRunDocument,
   inspectSessionDocument,
   renderAgentRunInspectTree,
   renderSessionInspectTree,
 } from './execution-inspect.js';
+export {
+  AGENT_RUN_INSPECT_DOCUMENT_VERSION,
+  SESSION_INSPECT_DOCUMENT_VERSION,
+  isAgentRunInspectDocument,
+  isSessionInspectDocument,
+} from '@maka/core/execution-inspect';
 export type {
   AgentRunInspectCompactionCheckpoint,
   AgentRunInspectDocument,
@@ -1272,10 +1276,12 @@ export type {
   AgentRunInspectToolSummary,
   ExecutionInspectDiagnostic,
   ExecutionInspectSeverity,
-  InspectSessionDocumentOptions,
-  SessionHeaderReader,
   SessionInspectDocument,
   SessionInspectSummary,
+} from '@maka/core/execution-inspect';
+export type {
+  InspectSessionDocumentOptions,
+  SessionHeaderReader,
 } from './execution-inspect.js';
 
 // model-history.ts — policy-driven model-history projection.

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -57,6 +57,66 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('finds a duplicate run identity across sessions with a bounded result', async () => {
+    await withStore(async (store) => {
+      await store.createRun(makeHeader({ sessionId: 'session-c', runId: 'shared-run' }));
+      await store.createRun(makeHeader({ sessionId: 'session-a', runId: 'shared-run' }));
+      await store.createRun(makeHeader({ sessionId: 'session-b', runId: 'shared-run' }));
+      await store.createRun(makeHeader({ sessionId: 'session-a', runId: 'other-run' }));
+
+      const bounded = await store.findRunsById('shared-run', 2);
+      assert.equal(bounded.truncated, true);
+      assert.deepEqual(
+        bounded.runs.map((run) => run.sessionId),
+        ['session-a', 'session-b'],
+      );
+      assert.deepEqual(await store.findRunsById('missing-run', 2), {
+        runs: [],
+        truncated: false,
+      });
+      await assert.rejects(() => store.findRunsById('shared-run', 0), RangeError);
+    });
+  });
+
+  it('bounds Session headers and evidence before returning records', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader({ runId: 'run-2', createdAt: 2 }));
+      await runStore.createRun(makeHeader({ runId: 'run-1', createdAt: 1 }));
+      assert.deepEqual(await runStore.listSessionRunsBounded('session-1', 1), {
+        runs: [makeHeader({ runId: 'run-1', createdAt: 1 })],
+        truncated: true,
+      });
+
+      await runStore.appendEvent('session-1', 'run-1', makeEvent({ id: 'event-1' }));
+      await runStore.appendEvent('session-1', 'run-1', makeEvent({ id: 'event-2', ts: 2 }));
+      assert.deepEqual(
+        await runStore.readEventsBounded('session-1', 'run-1', {
+          maxRecords: 1,
+          maxBytes: 1024,
+        }),
+        { status: 'limit_exceeded' },
+      );
+
+      await runtimeEventStore.appendRuntimeEvent(
+        'session-1',
+        'run-1',
+        makeRuntimeEvent({ id: 'runtime-1' }),
+      );
+      const runtimeResult = await runtimeEventStore.readRuntimeEventsBounded('session-1', 'run-1', {
+        maxRecords: 2,
+        maxBytes: 1024,
+      });
+      assert.equal(runtimeResult.status, 'complete');
+      if (runtimeResult.status !== 'complete') return;
+      assert.deepEqual(
+        runtimeResult.records.map((event) => event.id),
+        ['runtime-1'],
+      );
+      assert.equal(runtimeResult.sourceRecordCount, 1);
+      assert.ok(runtimeResult.storedBytes > 0);
+    });
+  });
+
   it('rejects duplicate run creation without replacing the existing header', async () => {
     await withStore(async (store) => {
       const original = makeHeader({ invocationId: 'invocation-original' });

--- a/packages/storage/src/__tests__/root-authority.test.ts
+++ b/packages/storage/src/__tests__/root-authority.test.ts
@@ -30,6 +30,7 @@ import {
   prepareStorageRootIdentityRepair,
   repairStorageRootIdentity,
   resolveExistingStorageRoot,
+  resolveExistingStorageRootControlDirectory,
   resolveRootControlNamespace,
   resolveStorageRoot,
   runWithStorageRootLease,
@@ -688,6 +689,38 @@ describe('storage root authority', () => {
           error.code === 'lock_failed' &&
           error.cause instanceof Error,
       );
+    });
+  });
+
+  test('does not create a missing control directory while resolving an existing Host', async () => {
+    await withRoots(async ({ root }) => {
+      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const controlDirectory = join(resolveRootControlNamespace(), capability.rootId);
+      await rm(controlDirectory, { recursive: true, force: true });
+
+      await assert.rejects(
+        () => resolveExistingStorageRootControlDirectory(capability),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'control_io_failed',
+      );
+      await assert.rejects(lstat(controlDirectory), { code: 'ENOENT' });
+    });
+  });
+
+  test('validates an existing control directory without repairing its permissions', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withRoots(async ({ root }) => {
+      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
+      await chmod(controlDirectory, 0o755);
+
+      await assert.rejects(
+        () => resolveExistingStorageRootControlDirectory(capability),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'insecure_control_directory',
+      );
+      assert.equal((await lstat(controlDirectory)).mode & 0o777, 0o755);
     });
   });
 

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import type { Dirent } from 'node:fs';
 import {
   appendFile,
   link,
@@ -8,6 +9,7 @@ import {
   readdir,
   rename,
   rm,
+  stat,
   unlink,
   writeFile,
 } from 'node:fs/promises';
@@ -31,6 +33,12 @@ import {
   type OperationalStateDatabaseLease,
   type OperationalStoreCutoverFailpoint,
 } from './operational-state-store.js';
+import {
+  assertEvidenceReadBudget,
+  measureEvidenceRows,
+  type BoundedEvidenceReadResult,
+  type EvidenceReadBudget,
+} from './bounded-evidence.js';
 import {
   DurableStoreWriteError,
   decodeAgentGraphIntentClaim,
@@ -123,6 +131,13 @@ export interface RootTurnAdmissionStore {
 }
 
 export interface DurableAgentRunStore extends AgentRunStore, RootTurnAdmissionStore {
+  findRunsById(runId: string, limit: number): Promise<AgentRunIdentitySearchResult>;
+  listSessionRunsBounded(sessionId: string, limit: number): Promise<AgentRunIdentitySearchResult>;
+  readEventsBounded(
+    sessionId: string,
+    runId: string,
+    budget: EvidenceReadBudget,
+  ): Promise<BoundedEvidenceReadResult<AgentRunEvent>>;
   listSessionRunsForRecovery(sessionId: string): Promise<AgentRunHeader[]>;
   readEventsForRecovery(sessionId: string, runId: string): Promise<AgentRunEvent[]>;
   readEventsForEvidence(sessionId: string, runId: string): Promise<AgentRunEvent[]>;
@@ -140,12 +155,24 @@ export interface DurableAgentRunStore extends AgentRunStore, RootTurnAdmissionSt
   close?(): void;
 }
 
+export interface AgentRunIdentitySearchResult {
+  readonly runs: readonly AgentRunHeader[];
+  readonly truncated: boolean;
+}
+
+export type { BoundedEvidenceReadResult, EvidenceReadBudget } from './bounded-evidence.js';
+
 export interface ConversationCopyRuntimeEventBatch {
   readonly runId: string;
   readonly events: readonly RuntimeEvent[];
 }
 
 export interface DurableRuntimeEventStore extends RuntimeEventStore {
+  readRuntimeEventsBounded(
+    sessionId: string,
+    runId: string,
+    budget: EvidenceReadBudget,
+  ): Promise<BoundedEvidenceReadResult<RuntimeEvent>>;
   importConversationCopyRuntimeEvents(
     sessionId: string,
     batches: readonly ConversationCopyRuntimeEventBatch[],
@@ -293,6 +320,55 @@ class SqliteAgentRunStore implements DurableAgentRunStore {
     return this.listSessionRunsForRecovery(sessionId);
   }
 
+  async findRunsById(runId: string, limit: number): Promise<AgentRunIdentitySearchResult> {
+    assertSafeId(runId, 'Invalid run id');
+    assertIdentitySearchLimit(limit);
+    await this.#ready;
+    const rows = this.#lease.database
+      .prepare(`
+        SELECT session_id, record_json
+        FROM core_agent_runs
+        WHERE run_id = ?
+        ORDER BY session_id
+        LIMIT ?
+      `)
+      .all(runId, limit + 1) as Array<{ session_id?: unknown; record_json?: unknown }>;
+    const truncated = rows.length > limit;
+    const runs = rows.slice(0, limit).map((row) => {
+      if (typeof row.session_id !== 'string' || typeof row.record_json !== 'string') {
+        throw new Error('Invalid SQLite AgentRun identity row');
+      }
+      return normalizeAgentRunHeader(JSON.parse(row.record_json), row.session_id, runId);
+    });
+    return { runs, truncated };
+  }
+
+  async listSessionRunsBounded(
+    sessionId: string,
+    limit: number,
+  ): Promise<AgentRunIdentitySearchResult> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertIdentitySearchLimit(limit);
+    await this.#ready;
+    const rows = this.#lease.database
+      .prepare(`
+        SELECT run_id, record_json
+        FROM core_agent_runs
+        WHERE session_id = ?
+        ORDER BY created_at, run_id
+        LIMIT ?
+      `)
+      .all(sessionId, limit + 1) as Array<{ run_id?: unknown; record_json?: unknown }>;
+    const truncated = rows.length > limit;
+    const runs = rows.slice(0, limit).map((row) => {
+      if (typeof row.run_id !== 'string' || typeof row.record_json !== 'string') {
+        throw new Error('Invalid SQLite AgentRun row');
+      }
+      return normalizeAgentRunHeader(JSON.parse(row.record_json), sessionId, row.run_id);
+    });
+    return { runs, truncated };
+  }
+
   async listSessionRunsForRecovery(sessionId: string): Promise<AgentRunHeader[]> {
     assertSafeId(sessionId, 'Invalid session id');
     await this.#ready;
@@ -344,6 +420,37 @@ class SqliteAgentRunStore implements DurableAgentRunStore {
 
   async readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
     return this.readEventsForRecovery(sessionId, runId);
+  }
+
+  async readEventsBounded(
+    sessionId: string,
+    runId: string,
+    budget: EvidenceReadBudget,
+  ): Promise<BoundedEvidenceReadResult<AgentRunEvent>> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    assertEvidenceReadBudget(budget);
+    await this.#ready;
+    const rows = this.#lease.database
+      .prepare(`
+        SELECT length(CAST(record_json AS BLOB)) AS stored_bytes
+        FROM core_agent_run_events
+        WHERE session_id = ? AND run_id = ?
+        ORDER BY sequence
+        LIMIT ?
+      `)
+      .all(sessionId, runId, budget.maxRecords + 1) as Array<{ stored_bytes?: unknown }>;
+    const measurement = measureEvidenceRows(
+      rows,
+      budget,
+      'Invalid SQLite AgentRun evidence measurement row',
+    );
+    if (!measurement) return { status: 'limit_exceeded' };
+    return {
+      status: 'complete',
+      records: readSqliteAgentRunEventsForEvidence(this.#lease.database, sessionId, runId),
+      ...measurement,
+    };
   }
 
   async readEventsForRecovery(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
@@ -750,6 +857,67 @@ class FileAgentRunStore implements DurableAgentRunStore {
     return headers.sort((a, b) => a.createdAt - b.createdAt || a.runId.localeCompare(b.runId));
   }
 
+  async findRunsById(runId: string, limit: number): Promise<AgentRunIdentitySearchResult> {
+    assertSafeId(runId, 'Invalid run id');
+    assertIdentitySearchLimit(limit);
+    let sessions;
+    try {
+      sessions = await readdir(this.sessionsRoot, { withFileTypes: true });
+    } catch (error) {
+      if (isMissingFile(error)) return { runs: [], truncated: false };
+      throw error;
+    }
+    const runs: AgentRunHeader[] = [];
+    for (const entry of sessions.sort((a, b) => a.name.localeCompare(b.name))) {
+      if (!entry.isDirectory() || !isSafeId(entry.name)) continue;
+      try {
+        runs.push(await this.readRunUnlocked(entry.name, runId));
+      } catch (error) {
+        if (isMissingFile(error)) continue;
+        throw error;
+      }
+      if (runs.length > limit) {
+        return { runs: runs.slice(0, limit), truncated: true };
+      }
+    }
+    return { runs, truncated: false };
+  }
+
+  async listSessionRunsBounded(
+    sessionId: string,
+    limit: number,
+  ): Promise<AgentRunIdentitySearchResult> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertIdentitySearchLimit(limit);
+    let entries;
+    try {
+      entries = await readdir(this.runsRoot(sessionId), { withFileTypes: true });
+    } catch (error) {
+      if (isMissingFile(error)) return { runs: [], truncated: false };
+      throw error;
+    }
+    const runs: AgentRunHeader[] = [];
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+      if (!entry.isDirectory() || !isSafeId(entry.name)) continue;
+      try {
+        runs.push(await this.readRunUnlocked(sessionId, entry.name));
+      } catch {
+        // Malformed run folders should not hide the rest of the session.
+      }
+      if (runs.length > limit) break;
+    }
+    const truncated = runs.length > limit;
+    return {
+      runs: runs
+        .slice(0, limit)
+        .sort(
+          (left, right) =>
+            left.createdAt - right.createdAt || left.runId.localeCompare(right.runId),
+        ),
+      truncated,
+    };
+  }
+
   async listSessionRunsForRecovery(sessionId: string): Promise<AgentRunHeader[]> {
     assertSafeId(sessionId, 'Invalid session id');
     const runsRoot = this.runsRoot(sessionId);
@@ -830,6 +998,32 @@ class FileAgentRunStore implements DurableAgentRunStore {
 
   async readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
     return this.readEventsWithPolicy(sessionId, runId, false);
+  }
+
+  async readEventsBounded(
+    sessionId: string,
+    runId: string,
+    budget: EvidenceReadBudget,
+  ): Promise<BoundedEvidenceReadResult<AgentRunEvent>> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    assertEvidenceReadBudget(budget);
+    const path = this.eventsPath(sessionId, runId);
+    let storedBytes = 0;
+    try {
+      storedBytes = (await stat(path)).size;
+    } catch (error) {
+      if (!isMissingFile(error)) throw error;
+    }
+    if (storedBytes > budget.maxBytes) return { status: 'limit_exceeded' };
+    const records = await this.readEventsWithPolicy(sessionId, runId, false, true);
+    if (records.length > budget.maxRecords) return { status: 'limit_exceeded' };
+    return {
+      status: 'complete',
+      records,
+      sourceRecordCount: records.length,
+      storedBytes,
+    };
   }
 
   async readEventsForRecovery(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
@@ -2070,6 +2264,41 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
     return mergeRuntimePartialSnapshots(events, visiblePartials);
   }
 
+  async readRuntimeEventsBounded(
+    sessionId: string,
+    runId: string,
+    budget: EvidenceReadBudget,
+  ): Promise<BoundedEvidenceReadResult<RuntimeEvent>> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    assertEvidenceReadBudget(budget);
+    let storedBytes = await fileSizeOrZero(this.runtimeEventsPath(sessionId, runId));
+    let partialEntries: Dirent[];
+    try {
+      partialEntries = await readdir(this.runtimePartialsDir(sessionId, runId), {
+        withFileTypes: true,
+      });
+    } catch (error) {
+      if (!isMissingFile(error)) throw error;
+      partialEntries = [];
+    }
+    for (const entry of partialEntries) {
+      if (!entry.isFile() || !entry.name.endsWith('.partial')) continue;
+      storedBytes += await fileSizeOrZero(
+        join(this.runtimePartialsDir(sessionId, runId), entry.name),
+      );
+      if (storedBytes > budget.maxBytes) return { status: 'limit_exceeded' };
+    }
+    const records = await this.readRuntimeEvents(sessionId, runId);
+    if (records.length > budget.maxRecords) return { status: 'limit_exceeded' };
+    return {
+      status: 'complete',
+      records,
+      sourceRecordCount: records.length,
+      storedBytes,
+    };
+  }
+
   async readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
@@ -2578,6 +2807,12 @@ function assertSafeId(value: string, message: string): void {
   if (!isSafeId(value)) throw new Error(message);
 }
 
+function assertIdentitySearchLimit(limit: number): void {
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 256) {
+    throw new RangeError('AgentRun identity search limit must be an integer between 1 and 256');
+  }
+}
+
 function isSafeId(value: string): boolean {
   return SAFE_ID_PATTERN.test(value);
 }
@@ -3072,6 +3307,15 @@ async function syncDirectoryIfPresent(path: string): Promise<void> {
     await syncDirectory(path);
   } catch (error) {
     if (!isMissingFile(error)) throw error;
+  }
+}
+
+async function fileSizeOrZero(path: string): Promise<number> {
+  try {
+    return (await stat(path)).size;
+  } catch (error) {
+    if (isMissingFile(error)) return 0;
+    throw error;
   }
 }
 

--- a/packages/storage/src/bounded-evidence.ts
+++ b/packages/storage/src/bounded-evidence.ts
@@ -1,0 +1,43 @@
+export interface EvidenceReadBudget {
+  readonly maxRecords: number;
+  readonly maxBytes: number;
+}
+
+export type BoundedEvidenceReadResult<T> =
+  | {
+      readonly status: 'complete';
+      readonly records: readonly T[];
+      readonly sourceRecordCount: number;
+      readonly storedBytes: number;
+    }
+  | { readonly status: 'limit_exceeded' };
+
+export function assertEvidenceReadBudget(budget: EvidenceReadBudget): void {
+  if (!Number.isSafeInteger(budget.maxRecords) || budget.maxRecords < 0) {
+    throw new RangeError('Evidence record limit must be a non-negative integer');
+  }
+  if (!Number.isSafeInteger(budget.maxBytes) || budget.maxBytes < 0) {
+    throw new RangeError('Evidence byte limit must be a non-negative integer');
+  }
+}
+
+export function measureEvidenceRows(
+  rows: readonly { stored_bytes?: unknown }[],
+  budget: EvidenceReadBudget,
+  invalidRowMessage: string,
+): { readonly sourceRecordCount: number; readonly storedBytes: number } | undefined {
+  if (rows.length > budget.maxRecords) return undefined;
+  let storedBytes = 0;
+  for (const row of rows) {
+    if (
+      typeof row.stored_bytes !== 'number' ||
+      !Number.isSafeInteger(row.stored_bytes) ||
+      row.stored_bytes < 0
+    ) {
+      throw new Error(invalidRowMessage);
+    }
+    storedBytes += row.stored_bytes;
+    if (!Number.isSafeInteger(storedBytes) || storedBytes > budget.maxBytes) return undefined;
+  }
+  return { sourceRecordCount: rows.length, storedBytes };
+}

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -12,10 +12,13 @@ import type {
 } from '@maka/core';
 import {
   createSqliteAgentRunStore,
+  type AgentRunIdentitySearchResult,
   type AdmitRootTurnInput,
   type AdmitRootTurnResult,
+  type BoundedEvidenceReadResult,
   type DurableAgentRunStore,
   type DurableRuntimeEventStore,
+  type EvidenceReadBudget,
   type RootTurnAdmission,
   type RootTurnSourceMessageReceipt,
 } from './agent-run-store.js';
@@ -71,8 +74,11 @@ export {
 } from './sqlite-session-metadata-store.js';
 
 export type {
+  AgentRunIdentitySearchResult,
   AdmitRootTurnInput,
   AdmitRootTurnResult,
+  BoundedEvidenceReadResult,
+  EvidenceReadBudget,
   ImmutableSteeringMessageProof,
   RootTurnAdmission,
   RootTurnAdmissionStore,
@@ -135,8 +141,15 @@ export interface ExecutionSessionReader {
 
 export interface ExecutionAgentRunReader {
   readRun(sessionId: string, runId: string): Promise<AgentRunHeader>;
+  findRunsById(runId: string, limit: number): Promise<AgentRunIdentitySearchResult>;
   listSessionRuns(sessionId: string): Promise<AgentRunHeader[]>;
+  listSessionRunsBounded(sessionId: string, limit: number): Promise<AgentRunIdentitySearchResult>;
   readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]>;
+  readEventsBounded(
+    sessionId: string,
+    runId: string,
+    budget: EvidenceReadBudget,
+  ): Promise<BoundedEvidenceReadResult<AgentRunEvent>>;
   readEventProjection(
     sessionId: string,
     type: AgentRunEventType,
@@ -150,6 +163,11 @@ export interface ExecutionAgentRunReader {
 
 export interface ExecutionRuntimeEventReader {
   readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
+  readRuntimeEventsBounded(
+    sessionId: string,
+    runId: string,
+    budget: EvidenceReadBudget,
+  ): Promise<BoundedEvidenceReadResult<RuntimeEvent>>;
   readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
   readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]>;
 }
@@ -374,12 +392,17 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
       updateRun: (sessionId, runId, patch, options) =>
         run(() => agentRunStore.updateRun(sessionId, runId, patch, options)),
       readRun: (sessionId, runId) => run(() => agentRunStore.readRun(sessionId, runId)),
+      findRunsById: (runId, limit) => run(() => agentRunStore.findRunsById(runId, limit)),
       listSessionRuns: (sessionId) => run(() => agentRunStore.listSessionRuns(sessionId)),
+      listSessionRunsBounded: (sessionId, limit) =>
+        run(() => agentRunStore.listSessionRunsBounded(sessionId, limit)),
       listSessionRunsForRecovery: (sessionId) =>
         run(() => agentRunStore.listSessionRunsForRecovery(sessionId)),
       appendEvent: (sessionId, runId, event, options) =>
         run(() => agentRunStore.appendEvent(sessionId, runId, event, options)),
       readEvents: (sessionId, runId) => run(() => agentRunStore.readEvents(sessionId, runId)),
+      readEventsBounded: (sessionId, runId, budget) =>
+        run(() => agentRunStore.readEventsBounded(sessionId, runId, budget)),
       readEventsForRecovery: (sessionId, runId) =>
         run(() => agentRunStore.readEventsForRecovery(sessionId, runId)),
       readEventsForEvidence: (sessionId, runId) =>
@@ -408,6 +431,8 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
         run(() => runtimeEventStore.ensureTerminalRuntimeEventDurable(sessionId, runId, event)),
       readRuntimeEvents: (sessionId, runId) =>
         run(() => runtimeEventStore.readRuntimeEvents(sessionId, runId)),
+      readRuntimeEventsBounded: (sessionId, runId, budget) =>
+        run(() => runtimeEventStore.readRuntimeEventsBounded(sessionId, runId, budget)),
       readImmutableRuntimeEvents: (sessionId, runId) =>
         run(() => runtimeEventStore.readImmutableRuntimeEvents(sessionId, runId)),
       readSessionRuntimeEvents: (sessionId) =>
@@ -499,8 +524,13 @@ async function openExecutionStoresForRead<K extends StorageRootKind, E extends o
     },
     agentRunStore: {
       readRun: (sessionId, runId) => run(() => agentRunStore.readRun(sessionId, runId)),
+      findRunsById: (runId, limit) => run(() => agentRunStore.findRunsById(runId, limit)),
       listSessionRuns: (sessionId) => run(() => agentRunStore.listSessionRuns(sessionId)),
+      listSessionRunsBounded: (sessionId, limit) =>
+        run(() => agentRunStore.listSessionRunsBounded(sessionId, limit)),
       readEvents: (sessionId, runId) => run(() => agentRunStore.readEvents(sessionId, runId)),
+      readEventsBounded: (sessionId, runId, budget) =>
+        run(() => agentRunStore.readEventsBounded(sessionId, runId, budget)),
       readEventProjection: (sessionId, type) =>
         run(() => agentRunStore.readEventProjection(sessionId, type)),
       readRootTurnAdmission: (sessionId, turnId) =>
@@ -511,6 +541,8 @@ async function openExecutionStoresForRead<K extends StorageRootKind, E extends o
     runtimeEventStore: {
       readRuntimeEvents: (sessionId, runId) =>
         run(() => runtimeEventStore.readRuntimeEvents(sessionId, runId)),
+      readRuntimeEventsBounded: (sessionId, runId, budget) =>
+        run(() => runtimeEventStore.readRuntimeEventsBounded(sessionId, runId, budget)),
       readImmutableRuntimeEvents: (sessionId, runId) =>
         run(() => runtimeEventStore.readImmutableRuntimeEvents(sessionId, runId)),
       readSessionRuntimeEvents: (sessionId) =>

--- a/packages/storage/src/root-authority.ts
+++ b/packages/storage/src/root-authority.ts
@@ -510,6 +510,25 @@ export async function prepareStorageRootControlDirectory(
   );
 }
 
+export async function resolveExistingStorageRootControlDirectory(
+  capability: StorageRootCapability,
+): Promise<{ controlRoot: string; controlDirectory: string }> {
+  return withAuthorityFailure(
+    'control_io_failed',
+    'Unable to validate the existing Runtime Host control directory',
+    async () => {
+      const record = requireCapability(capability, capability.kind);
+      await assertRootIdentity(record);
+      const controlRoot = resolve(resolveRootControlNamespace());
+      const controlDirectory = join(controlRoot, record.rootId);
+      await assertPrivateDirectory(controlRoot);
+      await assertPrivateDirectory(controlDirectory);
+      await assertRootIdentity(record);
+      return { controlRoot, controlDirectory };
+    },
+  );
+}
+
 export async function prepareArtifactWriterBootstrapAuthority(
   path: string,
 ): Promise<ArtifactWriterBootstrapAuthority> {
@@ -1236,6 +1255,29 @@ async function ensurePrivateDirectory(path: string): Promise<void> {
   await chmod(path, 0o700);
   directoryStat = await lstat(path);
   if (!directoryStat.isDirectory() || (directoryStat.mode & 0o077) !== 0) {
+    throw new StorageRootAuthorityError(
+      'insecure_control_directory',
+      `Runtime Host control path is not private: ${path}`,
+    );
+  }
+}
+
+async function assertPrivateDirectory(path: string): Promise<void> {
+  const directoryStat = await lstat(path);
+  if (!directoryStat.isDirectory()) {
+    throw new StorageRootAuthorityError(
+      'insecure_control_directory',
+      `Runtime Host control path is not a directory: ${path}`,
+    );
+  }
+  if (process.platform === 'win32') return;
+  if (typeof process.getuid === 'function' && directoryStat.uid !== process.getuid()) {
+    throw new StorageRootAuthorityError(
+      'insecure_control_directory',
+      `Runtime Host control path is not owned by the current user: ${path}`,
+    );
+  }
+  if ((directoryStat.mode & 0o077) !== 0) {
     throw new StorageRootAuthorityError(
       'insecure_control_directory',
       `Runtime Host control path is not private: ${path}`,

--- a/packages/storage/src/runtime-event-transfer.ts
+++ b/packages/storage/src/runtime-event-transfer.ts
@@ -1,7 +1,11 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { decodePersistedRuntimeEvent, type RuntimeEvent } from '@maka/core';
-import { createRuntimeEventStore } from './agent-run-store.js';
+import {
+  createRuntimeEventStore,
+  type BoundedEvidenceReadResult,
+  type EvidenceReadBudget,
+} from './agent-run-store.js';
 import { classifyJsonRecord } from './json-prefix.js';
 import type { SqliteRuntimeStore } from './sqlite-runtime-store.js';
 import { createSqliteRuntimeStore } from './sqlite-runtime-store.js';
@@ -33,6 +37,11 @@ export interface RuntimeEventExportSource {
 }
 
 export interface RuntimeEventReadStore extends RuntimeEventExportSource {
+  readRuntimeEventsBounded(
+    sessionId: string,
+    runId: string,
+    budget: EvidenceReadBudget,
+  ): Promise<BoundedEvidenceReadResult<RuntimeEvent>>;
   readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
   readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]>;
 }
@@ -122,6 +131,8 @@ function asRuntimeEventReader(store: RuntimeEventReadStore): RuntimeEventReadSto
   return Object.freeze({
     readRuntimeEvents: (sessionId: string, runId: string) =>
       store.readRuntimeEvents(sessionId, runId),
+    readRuntimeEventsBounded: (sessionId: string, runId: string, budget: EvidenceReadBudget) =>
+      store.readRuntimeEventsBounded(sessionId, runId, budget),
     readImmutableRuntimeEvents: (sessionId: string, runId: string) =>
       store.readImmutableRuntimeEvents(sessionId, runId),
     readSessionRuntimeEvents: (sessionId: string) => store.readSessionRuntimeEvents(sessionId),

--- a/packages/storage/src/sqlite-core-execution-schema.ts
+++ b/packages/storage/src/sqlite-core-execution-schema.ts
@@ -15,6 +15,9 @@ export function migrateSqliteCoreExecutionDatabase(db: DatabaseSync): void {
     CREATE INDEX IF NOT EXISTS core_agent_runs_session_order
       ON core_agent_runs(session_id, created_at, run_id);
 
+    CREATE INDEX IF NOT EXISTS core_agent_runs_identity
+      ON core_agent_runs(run_id, session_id);
+
     CREATE TABLE IF NOT EXISTS core_agent_run_events (
       session_id TEXT NOT NULL,
       run_id TEXT NOT NULL,

--- a/packages/storage/src/sqlite-runtime-store.ts
+++ b/packages/storage/src/sqlite-runtime-store.ts
@@ -66,6 +66,12 @@ import type {
   ConversationCopyRuntimeEventBatch,
   ImmutableSteeringMessageProof,
 } from './agent-run-store.js';
+import {
+  assertEvidenceReadBudget,
+  measureEvidenceRows,
+  type BoundedEvidenceReadResult,
+  type EvidenceReadBudget,
+} from './bounded-evidence.js';
 import type { OperationalStateDatabaseLease } from './operational-state-store.js';
 import { immutableSteeringMessageId, isRuntimeStorageSafeId } from './runtime-event-invariants.js';
 import { assertNoReservedWorkspaceAuthorityAppend } from './runtime-event-authority.js';
@@ -449,7 +455,50 @@ export class SqliteRuntimeStore
   }
 
   async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
-    const immutable = await this.readImmutableRuntimeEvents(sessionId, runId);
+    return this.readRuntimeEventsSync(sessionId, runId);
+  }
+
+  async readRuntimeEventsBounded(
+    sessionId: string,
+    runId: string,
+    budget: EvidenceReadBudget,
+  ): Promise<BoundedEvidenceReadResult<RuntimeEvent>> {
+    assertEvidenceReadBudget(budget);
+    const rows = this.db
+      .prepare(`
+        SELECT stored_bytes
+        FROM (
+          SELECT length(CAST(payload_json AS BLOB)) AS stored_bytes
+          FROM runtime_events
+          WHERE session_id = ? AND run_id = ?
+          UNION ALL
+          SELECT
+            length(CAST(payload_json AS BLOB)) +
+            length(CAST(text_content AS BLOB)) +
+            coalesce(length(CAST(after_event_id AS BLOB)), 0) AS stored_bytes
+          FROM runtime_partial_snapshots
+          WHERE session_id = ? AND run_id = ?
+        )
+        LIMIT ?
+      `)
+      .all(sessionId, runId, sessionId, runId, budget.maxRecords + 1) as Array<{
+      stored_bytes?: unknown;
+    }>;
+    const measurement = measureEvidenceRows(
+      rows,
+      budget,
+      'Invalid SQLite RuntimeEvent evidence measurement row',
+    );
+    if (!measurement) return { status: 'limit_exceeded' };
+    return {
+      status: 'complete',
+      records: this.readRuntimeEventsSync(sessionId, runId),
+      ...measurement,
+    };
+  }
+
+  private readRuntimeEventsSync(sessionId: string, runId: string): RuntimeEvent[] {
+    const immutable = this.readImmutableRuntimeEventsSync(sessionId, runId);
     const partials = this.db
       .prepare(`
       SELECT stream_key, session_id, invocation_id, run_id, turn_id,
@@ -484,6 +533,10 @@ export class SqliteRuntimeStore
   }
 
   async readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
+    return this.readImmutableRuntimeEventsSync(sessionId, runId);
+  }
+
+  private readImmutableRuntimeEventsSync(sessionId: string, runId: string): RuntimeEvent[] {
     const rows = this.db
       .prepare(`
       SELECT event_id, session_id, invocation_id, run_id, turn_id, payload_json


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- add versioned, canonical Session and AgentRun inspection documents
- expose bounded `execution.inspect.resolve` and `execution.inspect.query` operations through the running Runtime Host
- route Interactive `maka inspect` through an already-running Host while preserving the existing read-only offline path for idle and Headless roots
- add indexed and bounded Store reads so live inspection rejects oversized Session or evidence inputs before loading their full contents

## Why

`maka inspect` previously opened Interactive Stores directly. When the Runtime Host owned the root, inspection failed at the writer lock instead of observing the live canonical evidence. This change gives inspection a read-only Host path without adding another writer or a generic Store RPC.

## Safety boundaries

- live inspection only connects to an existing compatible Host; it never spawns, repairs, or replaces one
- Session inspection is limited to 64 AgentRuns
- each query shares a 4,096-record / 512 KiB evidence budget and returns at most 48 KiB
- duplicate AgentRun identities resolve explicitly instead of selecting an arbitrary Session
- offline Headless inspection remains read-only

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:stale`
- `npm run test:scripts`
- `npm --workspace @maka/storage test`
- `npm --workspace @maka/runtime-host test`
- `git diff --check upstream/main`

Part of #1167.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 增加带版本的规范化 Session 与 AgentRun 检查文档
- 通过正在运行的 Runtime Host 提供有界的 `execution.inspect.resolve` 和 `execution.inspect.query` 操作
- Interactive 根由 Host 持有时，将 `maka inspect` 路由到现有 Host；空闲根和 Headless 根继续使用原有只读离线路径
- 增加带索引且有界的 Store 读取，在载入完整内容前拒绝过大的 Session 或证据输入

## 原因

此前 `maka inspect` 会直接打开 Interactive Store。当 Runtime Host 已持有该根时，检查会在 writer lock 处失败，无法观察实时的规范证据。本改动提供只读 Host 路径，不会引入第二个 writer，也不会增加通用 Store RPC。

## 安全边界

- 实时检查只连接已经存在且兼容的 Host，不会启动、修复或替换 Host
- Session 检查最多包含 64 个 AgentRun
- 每次查询共享 4,096 条记录 / 512 KiB 的证据预算，返回结果不超过 48 KiB
- AgentRun identity 重复时显式返回候选项，不会任意选择一个 Session
- Headless 离线检查继续保持只读

## 验证

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:stale`
- `npm run test:scripts`
- `npm --workspace @maka/storage test`
- `npm --workspace @maka/runtime-host test`
- `git diff --check upstream/main`

#1167 的一部分。

</details>
