### PR TITLE
feat(runtime-host): compose hosted child agents

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -9,6 +9,7 @@ import {
   createBypassExecutionBoundary,
   createManagedExecutionBoundary,
   createWorkspaceWritePermissionProfile,
+  decodeCanonicalToolResultContent,
   type ModelCallKind,
   type RuntimeEvent,
 } from '@maka/core';
@@ -25,6 +26,7 @@ import {
   type ProxiedFetchTransport,
   type RunTraceEvent,
   type ScannedSkill,
+  buildParentAgentTools,
 } from '@maka/runtime';
 import { createSqliteRuntimeStore } from '@maka/storage';
 import { openInteractiveArtifactStoreForWrite } from '@maka/storage/artifact-stores';
@@ -57,6 +59,7 @@ const API_KEY = 'hosted-provider-key';
 const RESPONSE_TEXT = 'Hosted real-model execution completed.';
 const SUMMARY_TEXT = '## Goal\nContinue hosted real-model execution.';
 const CLIENT_CAPABILITY_RESULT_TEXT = 'HOSTED_CLIENT_CAPABILITY_RESULT_SENTINEL';
+const CHILD_AGENT_RESULT_TEXT = 'HOSTED_CHILD_AGENT_RESULT_SENTINEL';
 
 test('backend creation aborts a stalled canonical connection read', async () => {
   const abort = new AbortController();
@@ -672,6 +675,7 @@ test('production Host executes a canonical ai-sdk Session against a real provide
       'StopBackgroundTask',
       'Write',
       'WriteStdin',
+      'load_tools',
       'task_create',
       'task_get',
       'task_list',
@@ -746,6 +750,168 @@ test('production Host executes a canonical ai-sdk Session against a real provide
     assert.equal(failedTerminal.status, 'failed');
     assert.equal(provider.requests.length, requestsBeforeArtifactFailure);
     assert.equal(drainRequests, 1);
+  } finally {
+    try {
+      await composition?.close();
+    } finally {
+      try {
+        await owner.close();
+      } finally {
+        await provider.close();
+        await rm(base, { recursive: true, force: true });
+      }
+    }
+  }
+});
+
+test('production Host executes a durable runnable child with an exact tool ceiling', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-child-agent-'));
+  const root = join(base, 'interactive');
+  const project = join(base, 'project');
+  const provider = await startProvider();
+  provider.configureChildAgentFlow();
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  const context: ConnectionContext = {
+    hostEpoch: 'child-agent-test-epoch',
+    connectionId: 'child-agent-test-client',
+    surface: 'tui',
+    principal: 'local_os_user',
+    acquireResidency: () => ({ release() {} }),
+  };
+  let composition: Awaited<ReturnType<typeof createExecutionRuntimeHostComposition>> | undefined;
+  try {
+    await mkdir(project);
+    await writeFile(join(project, 'README.md'), '# Hosted child fixture\n');
+    const policy = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    const created = await policy.connectionCatalog.create({
+      expectedCatalogRevision: 0,
+      connection: {
+        slug: 'hosted-child-provider',
+        name: 'Hosted child provider',
+        providerType: 'moonshot',
+        baseUrl: provider.baseUrl,
+        enabled: true,
+        enabledModelIds: [MODEL_ID],
+      },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed') return;
+    const connection = created.snapshot.connections[0];
+    assert.ok(connection);
+    if (!connection) return;
+    assert.equal(
+      (
+        await policy.credentialVault.set({
+          locator: {
+            scope: 'connection',
+            connectionId: connection.connectionId,
+            kind: 'api_key',
+          },
+          expected: null,
+          secret: API_KEY,
+        })
+      ).kind,
+      'committed',
+    );
+    await publishConnectionModel(policy, connection.connectionId, MODEL_ID, 32_768);
+
+    const execution = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const parent = await execution.sessionStore.create({
+      cwd: project,
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'hosted-child-provider',
+      model: MODEL_ID,
+      permissionMode: 'bypass',
+    });
+    composition = await createExecutionRuntimeHostComposition({
+      owner,
+      hostEpoch: context.hostEpoch,
+      acquireResidency: context.acquireResidency,
+      retainUntilProcessExit: () => undefined,
+      requestDrain: () => undefined,
+    });
+    await composition.recover();
+
+    const turnId = 'hosted-child-parent-turn';
+    const terminal = await waitForTerminal(
+      composition,
+      parent.id,
+      turnId,
+      await startTurn(
+        composition,
+        parent.id,
+        turnId,
+        'Delegate this bounded read-only task.',
+        context,
+      ),
+      context,
+    );
+    const parentRun = await execution.agentRunStore.readRun(parent.id, terminal.runId);
+    const parentRunEvents = await execution.agentRunStore.readEvents(parent.id, terminal.runId);
+    assert.equal(
+      terminal.status,
+      'completed',
+      JSON.stringify({
+        terminal,
+        parentRun,
+        parentRunEvents,
+        requests: provider.requests.map((request) => ({
+          stream: request.body.stream,
+          tools: toolNames(request.body),
+        })),
+      }),
+    );
+
+    const requests = provider.requests.filter((request) => request.body.stream === true);
+    assert.equal(requests.length, 4);
+    assert.ok(toolNames(requests[0]?.body).includes('load_tools'));
+    assert.equal(toolNames(requests[0]?.body).includes('agent_spawn'), false);
+    assert.ok(toolNames(requests[1]?.body).includes('agent_spawn'));
+    assert.deepEqual(toolParameterEnum(requests[1]?.body, 'agent_spawn', 'profile'), [
+      'local_read',
+    ]);
+    assert.deepEqual(toolNames(requests[2]?.body), ['Glob', 'Grep', 'Read']);
+    assert.ok(toolNames(requests[3]?.body).includes('agent_spawn'));
+
+    const sessions = await execution.sessionStore.listForRecovery();
+    const child = sessions.find((session) => session.id !== parent.id);
+    assert.ok(child);
+    assert.equal(child?.subagentRuntime?.profile, 'local_read');
+    assert.equal(child?.subagentParent?.parentSessionId, parent.id);
+    if (!child) return;
+    assert.equal(child.subagentWorkspace, undefined);
+    assert.equal(child.cwd, project);
+    const childRuns = await execution.agentRunStore.listSessionRuns(child.id);
+    assert.equal(childRuns.length, 1);
+    assert.equal(childRuns[0]?.status, 'completed');
+    assert.equal(childRuns[0]?.parentRunId, undefined);
+    const childMessages = await execution.sessionStore.readMessagesSnapshot(child.id);
+    assert.equal(
+      childMessages.find((message) => message.type === 'assistant')?.text,
+      CHILD_AGENT_RESULT_TEXT,
+    );
+    const artifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
+    const childArtifacts = await artifacts.listTurnArtifacts(child.id, childRuns[0]!.turnId);
+    assert.equal(childArtifacts.length, 1);
+    assert.equal(childArtifacts[0]?.source, 'provider_request_capture');
+    const parentRuntimeEvents = await execution.runtimeEventStore.readRuntimeEvents(
+      parent.id,
+      terminal.runId,
+    );
+    const spawnResult = parentRuntimeEvents.find(
+      (event) =>
+        event.content?.kind === 'function_response' && event.content.name === 'agent_spawn',
+    );
+    assert.ok(spawnResult?.content?.kind === 'function_response');
+    const typedSpawnResult = decodeCanonicalToolResultContent(spawnResult.content.result);
+    assert.equal(typedSpawnResult.kind, 'subagent');
+    assert.deepEqual(
+      (typedSpawnResult as { artifactIds?: readonly string[] }).artifactIds,
+      childArtifacts.map((artifact) => artifact.id),
+    );
   } finally {
     try {
       await composition?.close();
@@ -1113,6 +1279,7 @@ test('a bound tool ceiling excludes dynamic Client Capability tools', () => {
     memory: {} as HostMemoryCoordinator,
     taskLedger: {} as TaskLedgerStore,
     boundTools: [boundTool],
+    parentAgentTools: buildParentAgentTools(),
     automationTool,
     builtinTools: {},
     clientCapabilities: {
@@ -1132,6 +1299,30 @@ test('a bound tool ceiling excludes dynamic Client Capability tools', () => {
     composition.toolAvailability.groups?.some((group) => group.id === 'client_fixture'),
     false,
   );
+});
+
+test('root model composition defers the canonical parent-agent tool group', () => {
+  const parentAgentTools = buildParentAgentTools();
+  const composition = createHostExecutionModelComposition({
+    policy: {
+      getSnapshot: async () => ({
+        revision: 0,
+        policy: createDefaultRuntimePolicy(),
+      }),
+    },
+    skills: {
+      readCanonicalModelInventory: async () => ({ inventory: [] }),
+    } as unknown as HostSkillCatalogCoordinator,
+    memory: {} as HostMemoryCoordinator,
+    taskLedger: {} as TaskLedgerStore,
+    parentAgentTools,
+  });
+
+  assert.deepEqual(
+    composition.toolAvailability.groups?.find((group) => group.id === 'agent')?.toolNames,
+    ['agent_spawn', 'agent_swarm', 'agent_list', 'agent_output'],
+  );
+  assert.ok(parentAgentTools.every((tool) => composition.tools.includes(tool)));
 });
 
 function skillFixture(id: string, description: string, content: string): ScannedSkill {
@@ -1252,6 +1443,7 @@ async function publishConnectionModel(
   policy: RuntimePolicyStoresWriter,
   connectionId: string,
   modelId: string,
+  contextWindow = 3_072,
 ): Promise<void> {
   const prepared = await policy.operations.beginModelFetch(connectionId);
   assert.equal(prepared.kind, 'ready');
@@ -1261,7 +1453,7 @@ async function publishConnectionModel(
       {
         id: modelId,
         capabilities: { chat: true, functionCalling: true },
-        contextWindow: 3_072,
+        contextWindow,
         maxOutputTokens: 64,
       },
     ],
@@ -1495,27 +1687,47 @@ function toolNames(body: Record<string, unknown> | undefined): string[] {
     .sort();
 }
 
+function toolParameterEnum(
+  body: Record<string, unknown> | undefined,
+  toolName: string,
+  property: string,
+): unknown {
+  const tools = Array.isArray(body?.tools) ? body.tools : [];
+  const tool = tools.find((candidate) => {
+    if (!candidate || typeof candidate !== 'object') return false;
+    const fn = (candidate as { function?: unknown }).function;
+    return Boolean(fn && typeof fn === 'object' && (fn as { name?: unknown }).name === toolName);
+  }) as { function?: { parameters?: { properties?: Record<string, unknown> } } } | undefined;
+  const schema = tool?.function?.parameters?.properties?.[property];
+  return schema && typeof schema === 'object' ? (schema as { enum?: unknown }).enum : undefined;
+}
+
 interface ProviderRequest {
   readonly url: string;
   readonly authorization: string | undefined;
   readonly body: Record<string, unknown>;
 }
 
+type ProviderFlow =
+  | { readonly kind: 'default' }
+  | {
+      readonly kind: 'client_capability';
+      readonly groupId: string;
+      readonly toolName: string;
+    }
+  | { readonly kind: 'child_agent' };
+
 async function startProvider(): Promise<{
   readonly baseUrl: string;
   readonly requests: ProviderRequest[];
   configureClientCapability(input: { groupId: string; toolName: string }): void;
+  configureChildAgentFlow(): void;
   close(): Promise<void>;
 }> {
   const requests: ProviderRequest[] = [];
-  let clientCapability:
-    | {
-        readonly groupId: string;
-        readonly toolName: string;
-      }
-    | undefined;
+  let flow: ProviderFlow = { kind: 'default' };
   const server = createServer((request, response) => {
-    void handleProviderRequest(request, response, requests, clientCapability).catch((error) => {
+    void handleProviderRequest(request, response, requests, flow).catch((error) => {
       response.destroy(error as Error);
     });
   });
@@ -1526,9 +1738,12 @@ async function startProvider(): Promise<{
     baseUrl: `http://127.0.0.1:${address.port}/v1`,
     requests,
     configureClientCapability: (input) => {
-      if (clientCapability)
-        throw new Error('Client Capability provider flow is already configured');
-      clientCapability = { ...input };
+      if (flow.kind !== 'default') throw new Error('Provider flow is already configured');
+      flow = { kind: 'client_capability', ...input };
+    },
+    configureChildAgentFlow: () => {
+      if (flow.kind !== 'default') throw new Error('Provider flow is already configured');
+      flow = { kind: 'child_agent' };
     },
     close: () => closeServer(server),
   };
@@ -1538,12 +1753,7 @@ async function handleProviderRequest(
   request: IncomingMessage,
   response: ServerResponse,
   requests: ProviderRequest[],
-  clientCapability:
-    | {
-        readonly groupId: string;
-        readonly toolName: string;
-      }
-    | undefined,
+  flow: ProviderFlow,
 ): Promise<void> {
   assert.equal(request.method, 'POST');
   const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
@@ -1573,20 +1783,45 @@ async function handleProviderRequest(
     return;
   }
   const streamRequestIndex = requests.filter((candidate) => candidate.body.stream === true).length;
-  if (clientCapability && streamRequestIndex === 1) {
+  if (flow.kind === 'child_agent' && streamRequestIndex === 1) {
     assert.ok(toolNames(body).includes('load_tools'));
-    respondProviderToolCall(response, streamRequestIndex, 'load_tools', {
-      group: clientCapability.groupId,
+    assert.equal(toolNames(body).includes('agent_spawn'), false);
+    respondProviderToolCall(response, streamRequestIndex, 'load_tools', { group: 'agent' });
+    return;
+  }
+  if (flow.kind === 'child_agent' && streamRequestIndex === 2) {
+    assert.ok(toolNames(body).includes('agent_spawn'));
+    respondProviderToolCall(response, streamRequestIndex, 'agent_spawn', {
+      profile: 'local_read',
+      task: 'Inspect the hosted child execution boundary without changing files.',
+      isolation: 'same_workspace',
+      write_back: 'summary',
     });
     return;
   }
-  if (clientCapability && streamRequestIndex === 2) {
-    assert.ok(toolNames(body).includes(clientCapability.toolName));
-    respondProviderToolCall(response, streamRequestIndex, clientCapability.toolName, {
+  if (flow.kind === 'child_agent' && streamRequestIndex === 3) {
+    assert.deepEqual(toolNames(body), ['Glob', 'Grep', 'Read']);
+    respondProviderText(response, CHILD_AGENT_RESULT_TEXT);
+    return;
+  }
+  if (flow.kind === 'client_capability' && streamRequestIndex === 1) {
+    assert.ok(toolNames(body).includes('load_tools'));
+    respondProviderToolCall(response, streamRequestIndex, 'load_tools', {
+      group: flow.groupId,
+    });
+    return;
+  }
+  if (flow.kind === 'client_capability' && streamRequestIndex === 2) {
+    assert.ok(toolNames(body).includes(flow.toolName));
+    respondProviderToolCall(response, streamRequestIndex, flow.toolName, {
       url: 'https://example.test/client-capability',
     });
     return;
   }
+  respondProviderText(response, RESPONSE_TEXT);
+}
+
+function respondProviderText(response: ServerResponse, text: string): void {
   response.writeHead(200, { 'content-type': 'text/event-stream' });
   response.write(
     `data: ${JSON.stringify({
@@ -1597,7 +1832,7 @@ async function handleProviderRequest(
       choices: [
         {
           index: 0,
-          delta: { role: 'assistant', content: RESPONSE_TEXT },
+          delta: { role: 'assistant', content: text },
           finish_reason: null,
         },
       ],

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -700,6 +700,7 @@ describe('Runtime Host bootstrap protocol', () => {
           attachments: [attachment],
           quotes,
         },
+        turnOrchestration: { mode: 'swarm', source: 'host_api' } as const,
       },
     };
     const start = decodeClientFrame(JSON.parse(encodeProtocolFrame(startWire).toString('utf8')));
@@ -710,6 +711,7 @@ describe('Runtime Host bootstrap protocol', () => {
         sessionId: 'session-1',
         turnId: 'turn-1',
         content: { text: 'model text', attachments: [attachment], quotes },
+        turnOrchestration: { mode: 'swarm', source: 'host_api' },
       },
     });
     assert.notEqual(start.input.content.quotes, quotes);
@@ -735,6 +737,32 @@ describe('Runtime Host bootstrap protocol', () => {
           requestId: 'legacy-start',
           operation: 'turn.start',
           input: { sessionId: 'session-1', turnId: 'turn-1', text: 'legacy' },
+        }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          ...startWire,
+          input: {
+            ...startWire.input,
+            turnOrchestration: { mode: 'parallel', source: 'host_api' },
+          },
+        }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          ...startWire,
+          input: {
+            ...startWire.input,
+            turnOrchestration: {
+              mode: 'swarm',
+              source: 'host_api',
+              inherited: true,
+            },
+          },
         }),
       isInvalidFrame,
     );

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -55,6 +55,54 @@ const NO_GOAL_ROOT_AUTHORITY: HostGoalRootAuthority = {
   matchesActive: () => false,
 };
 
+test('turn.start durably applies one exact per-Turn orchestration override', async () => {
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+  });
+  const input = {
+    sessionId: fixture.sessionId,
+    turnId: 'turn-hosted-swarm-override',
+    content: { text: 'Use the hosted swarm override.' },
+    turnOrchestration: { mode: 'swarm' as const, source: 'host_api' as const },
+  };
+  try {
+    const started = await fixture.coordinator.handlers['turn.start'](
+      input,
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(started.ok, true);
+    if (!started.ok) return;
+
+    const run = await fixture.stores.agentRunStore.readRun(fixture.sessionId, started.result.runId);
+    assert.equal(run.orchestrationMode, 'swarm');
+    assert.equal(run.orchestrationSource, 'turn_override');
+    assert.equal(run.agentSwarmAuthorization, 'turn_override');
+    assert.deepEqual(
+      (await fixture.stores.agentRunStore.readRootTurnAdmission(fixture.sessionId, input.turnId))
+        ?.turnOrchestration,
+      input.turnOrchestration,
+    );
+
+    const exactRetry = await fixture.coordinator.handlers['turn.start'](
+      input,
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(exactRetry.ok, true);
+
+    const conflict = await fixture.coordinator.handlers['turn.start'](
+      {
+        ...input,
+        turnOrchestration: { mode: 'default', source: 'host_api' },
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(conflict.ok, false);
+    if (!conflict.ok) assert.equal(conflict.error.code, 'operation_conflict');
+  } finally {
+    await fixture.dispose();
+  }
+});
+
 test('hosted Automation roots preserve one admission, UserMessage, and AgentRun identity', async () => {
   let recoveryValidationCount = 0;
   const fixture = await createFailureFixture({

--- a/packages/runtime-host/src/protocol/turn.ts
+++ b/packages/runtime-host/src/protocol/turn.ts
@@ -4,11 +4,17 @@ import {
   isCanonicalAttachmentRef,
   type MessageContent,
 } from '@maka/core/events';
+import {
+  isOrchestrationMode,
+  isTurnOrchestrationSource,
+  type TurnOrchestration,
+} from '@maka/core/orchestration';
 import { invalidProtocolFrame } from './errors.js';
 import {
   assertExactKeys,
   requireEntityId,
   requireExactRecord,
+  requireShapedRecord,
   requireId,
   requireRecord,
   requireString,
@@ -19,6 +25,7 @@ export interface TurnStartInput {
   sessionId: string;
   turnId: string;
   content: MessageContent;
+  turnOrchestration?: TurnOrchestration;
 }
 
 export type { MessageContent };
@@ -121,12 +128,28 @@ export const TURN_OPERATION_SPECS = {
 } as const;
 
 function decodeTurnStartInput(value: unknown): TurnStartInput {
-  const record = requireExactRecord(value, 'turn.start input', ['sessionId', 'turnId', 'content']);
+  const record = requireShapedRecord(
+    value,
+    'turn.start input',
+    ['sessionId', 'turnId', 'content'],
+    ['turnOrchestration'],
+  );
   return {
     sessionId: requireEntityId(record.sessionId, 'sessionId'),
     turnId: requireEntityId(record.turnId, 'turnId'),
     content: decodeMessageContent(record.content),
+    ...(record.turnOrchestration !== undefined
+      ? { turnOrchestration: decodeTurnOrchestration(record.turnOrchestration) }
+      : {}),
   };
+}
+
+function decodeTurnOrchestration(value: unknown): TurnOrchestration {
+  const record = requireExactRecord(value, 'Turn orchestration', ['mode', 'source']);
+  if (!isOrchestrationMode(record.mode) || !isTurnOrchestrationSource(record.source)) {
+    throw invalidProtocolFrame('Invalid Turn orchestration');
+  }
+  return { mode: record.mode, source: record.source };
 }
 
 export function decodeMessageContent(value: unknown): MessageContent {

--- a/packages/runtime-host/src/server/child-agent-composition.ts
+++ b/packages/runtime-host/src/server/child-agent-composition.ts
@@ -1,0 +1,84 @@
+import type { TaskLedgerStore } from '@maka/core/task-ledger';
+import {
+  AiSdkBackend,
+  buildBuiltinTools,
+  buildChildAgentTools,
+  buildParentAgentTools,
+  listRunnableBuiltinAgentDefinitions,
+  type BuildBuiltinToolsOptions,
+  type MakaTool,
+  type SessionManager,
+} from '@maka/runtime';
+
+type ChildAgentAuthority = Pick<
+  SessionManager,
+  | 'spawnChildAgent'
+  | 'spawnChildSession'
+  | 'prepareChildAgentResume'
+  | 'resumeChildAgent'
+  | 'retryChildAgent'
+  | 'listChildAgents'
+  | 'readChildAgentOutput'
+>;
+
+export type HostChildAgentBackendCapabilities = Pick<
+  ConstructorParameters<typeof AiSdkBackend>[0],
+  | 'spawnChildAgent'
+  | 'spawnChildSession'
+  | 'prepareChildAgentResume'
+  | 'resumeChildAgent'
+  | 'retryChildAgent'
+  | 'listChildAgents'
+  | 'readChildAgentOutput'
+>;
+
+export interface HostChildAgentToolComposition {
+  readonly parentTools: readonly MakaTool[];
+  readonly childTools: readonly MakaTool[];
+}
+
+/** Composes the parent control tools and the exact catalog-child capability union. */
+export function createHostChildAgentToolComposition(input: {
+  readonly taskLedger: TaskLedgerStore;
+  readonly builtinTools: BuildBuiltinToolsOptions;
+}): HostChildAgentToolComposition {
+  const builtinTools = buildBuiltinTools(input.builtinTools);
+  const childTools = buildChildAgentTools(builtinTools);
+  const definitions = listRunnableBuiltinAgentDefinitions({ tools: childTools });
+  return Object.freeze({
+    parentTools: Object.freeze(
+      buildParentAgentTools({ taskLedger: input.taskLedger, definitions }),
+    ),
+    childTools: Object.freeze(childTools),
+  });
+}
+
+/** Binds one root backend to the child authority of its owning Session. */
+export function bindHostChildAgentBackend(
+  authority: ChildAgentAuthority,
+  parentSessionId: string,
+): HostChildAgentBackendCapabilities {
+  return {
+    spawnChildAgent: (input) => authority.spawnChildAgent(parentSessionId, input),
+    spawnChildSession: (input) =>
+      authority.spawnChildSession(parentSessionId, {
+        spawnedBy: {
+          parentRunId: input.parentRunId,
+          parentTurnId: input.parentTurnId,
+          toolCallId: input.toolCallId,
+        },
+        agentProfile: input.agentProfile,
+        prompt: input.prompt,
+        ...(input.swarm ? { swarm: input.swarm } : {}),
+        abortSignal: input.abortSignal,
+        ...(input.onReady ? { onReady: input.onReady } : {}),
+        ...(input.onEvent ? { onEvent: input.onEvent } : {}),
+      }),
+    prepareChildAgentResume: (sourceRunId) =>
+      authority.prepareChildAgentResume(parentSessionId, sourceRunId),
+    resumeChildAgent: (input) => authority.resumeChildAgent(parentSessionId, input),
+    retryChildAgent: (input) => authority.retryChildAgent(parentSessionId, input),
+    listChildAgents: () => authority.listChildAgents(parentSessionId),
+    readChildAgentOutput: (input) => authority.readChildAgentOutput(parentSessionId, input),
+  };
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -31,6 +31,10 @@ import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledge
 import { openInteractiveShellRunStoreForWrite } from '@maka/storage/shell-run-authority';
 import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
 import { CanonicalSessionProjectionReader } from './canonical-session-projection.js';
+import {
+  bindHostChildAgentBackend,
+  createHostChildAgentToolComposition,
+} from './child-agent-composition.js';
 import { HostCanonicalPermissionOutcomeReader } from './canonical-permission-outcome-reader.js';
 import { HostArtifactCoordinator } from './artifact-coordinator.js';
 import { HostAutomationCoordinator } from './automation-coordinator.js';
@@ -101,6 +105,7 @@ export async function createExecutionRuntimeHostComposition(
     const runtimePolicyActivation = new RuntimePolicyActivationGate();
     const sessionAdmission = new SessionAdmissionGate();
     let runtimeResources: HostRuntimeResourceCoordinator | undefined;
+    let manager: SessionManager | undefined;
     const shellRuns = new ShellRunProcessManager({
       store: openedShellRunStore,
       newId: randomUUID,
@@ -128,6 +133,30 @@ export async function createExecutionRuntimeHostComposition(
       sessionAdmission,
       stores.sessionStore,
     );
+    runtimeResources = new HostRuntimeResourceCoordinator({
+      manager: shellRuns,
+      sessions: {
+        listShellRunUpdates: (sessionId) =>
+          requireSessionManager(manager).listShellRunUpdates(sessionId),
+      },
+      sessionHeaders: stores.sessionStore,
+      sessionAdmission,
+      acquireResidency: context.acquireResidency,
+      requestDrain: context.requestDrain,
+    });
+    const builtinTools = {
+      shellRuns: runtimeResources,
+      runtimeResources,
+      backgroundTasks: runtimeResources,
+      ptyControls: runtimeResources,
+      snapshotImage: createReadImageSnapshotter(openedArtifactStore),
+      ...(sandboxManager ? { sandboxManager } : {}),
+      ...(filesystemWorker ? { filesystemWorker } : {}),
+    };
+    const childAgentTools = createHostChildAgentToolComposition({
+      taskLedger,
+      builtinTools,
+    });
     const openedGraphControlStore = createAgentGraphControlStore(
       context.owner.capability.canonicalPath,
     );
@@ -254,15 +283,12 @@ export async function createExecutionRuntimeHostComposition(
         clientCapabilities: requireClientCapabilities(clientCapabilities),
         automationTool: requireAutomationCoordinator(automations).modelTool,
         goalTools: requireGoal(goal).tools,
-        builtinTools: {
-          shellRuns: requireRuntimeResources(runtimeResources),
-          runtimeResources: requireRuntimeResources(runtimeResources),
-          backgroundTasks: requireRuntimeResources(runtimeResources),
-          ptyControls: requireRuntimeResources(runtimeResources),
-          snapshotImage: createReadImageSnapshotter(openedArtifactStore),
-          ...(sandboxManager ? { sandboxManager } : {}),
-          ...(filesystemWorker ? { filesystemWorker } : {}),
-        },
+        builtinTools,
+        parentAgentTools: childAgentTools.parentTools,
+        childAgents: bindHostChildAgentBackend(
+          requireSessionManager(manager),
+          backendContext.sessionId,
+        ),
         runtimeCommitSink: stores.runtimeEventStore,
         requestDrain: context.requestDrain,
       }),
@@ -275,7 +301,7 @@ export async function createExecutionRuntimeHostComposition(
       stopSession: (sessionId, input) =>
         requireRootCoordinator(rootCoordinator).stopSession(sessionId, input),
     };
-    const manager = new SessionManager({
+    manager = new SessionManager({
       store: stores.sessionStore,
       runStore: stores.agentRunStore,
       runtimeEventStore: stores.runtimeEventStore,
@@ -298,14 +324,9 @@ export async function createExecutionRuntimeHostComposition(
       interactionAuthority: interactions,
       canonicalPermissionOutcomes,
       shellRuns,
-    });
-    runtimeResources = new HostRuntimeResourceCoordinator({
-      manager: shellRuns,
-      sessions: manager,
-      sessionHeaders: stores.sessionStore,
-      sessionAdmission,
-      acquireResidency: context.acquireResidency,
-      requestDrain: context.requestDrain,
+      childTools: childAgentTools.childTools,
+      listArtifactsForTurn: (sessionId, turnId) =>
+        openedArtifactStore.listTurnArtifacts(sessionId, turnId),
     });
     const graphCoordinator = new AgentGraphCoordinator({
       sessionStore: stores.sessionStore,
@@ -751,11 +772,9 @@ function requireAutomationCoordinator(
   return coordinator;
 }
 
-function requireRuntimeResources(
-  coordinator: HostRuntimeResourceCoordinator | undefined,
-): HostRuntimeResourceCoordinator {
-  if (!coordinator) throw new Error('Runtime Host Runtime Resource coordinator is not composed');
-  return coordinator;
+function requireSessionManager(manager: SessionManager | undefined): SessionManager {
+  if (!manager) throw new Error('Runtime Host SessionManager is not composed');
+  return manager;
 }
 
 function requireGoal(coordinator: HostGoalCoordinator | undefined): HostGoalCoordinator {

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -71,6 +71,7 @@ import {
   type HostOAuthExecutionAuthority,
   type HostOAuthExecutionBinding,
 } from './oauth-execution-authority.js';
+import type { HostChildAgentBackendCapabilities } from './child-agent-composition.js';
 
 const CHILD_INSTRUCTION_BOUNDARY = [
   'A child agent inherits the current session permission, privacy, workspace, and skill constraints.',
@@ -108,6 +109,7 @@ export interface HostExecutionModelCompositionInput {
   readonly builtinTools?: BuildBuiltinToolsOptions;
   readonly automationTool?: MakaTool;
   readonly goalTools?: readonly MakaTool[];
+  readonly parentAgentTools?: readonly MakaTool[];
 }
 
 /** Composes one Host-owned prompt and pure tool surface from canonical authorities. */
@@ -123,6 +125,7 @@ export function createHostExecutionModelComposition(
         input.builtinTools,
         input.automationTool,
         input.goalTools,
+        input.parentAgentTools,
       );
   const productSurface = projectEffectiveProductToolSurface({
     host: 'runtime-host',
@@ -216,6 +219,8 @@ export interface HostAiSdkBackendInput {
   readonly builtinTools?: BuildBuiltinToolsOptions;
   readonly automationTool?: MakaTool;
   readonly goalTools?: readonly MakaTool[];
+  readonly parentAgentTools?: readonly MakaTool[];
+  readonly childAgents?: HostChildAgentBackendCapabilities;
   readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
 }
 
@@ -451,6 +456,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
       ...(input.builtinTools ? { builtinTools: input.builtinTools } : {}),
       ...(input.automationTool ? { automationTool: input.automationTool } : {}),
       ...(input.goalTools ? { goalTools: input.goalTools } : {}),
+      ...(input.parentAgentTools ? { parentAgentTools: input.parentAgentTools } : {}),
       skillBudget: {
         contextWindow: resolveSelectedModelContextWindow(target.connection, target.model),
       },
@@ -591,6 +597,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
         modelFactory,
         tools: [...modelComposition.tools],
         toolAvailability: modelComposition.toolAvailability,
+        ...(!input.context.tools && input.childAgents ? input.childAgents : {}),
         providerOptions,
         contextBudget: buildDefaultContextBudgetPolicy(target.connection, {
           name: 'runtime-host-default-history-budget',
@@ -834,6 +841,7 @@ function buildDefaultHostTools(
   builtinOptions?: BuildBuiltinToolsOptions,
   automationTool?: MakaTool,
   goalTools: readonly MakaTool[] = [],
+  parentAgentTools: readonly MakaTool[] = [],
 ): MakaTool[] {
   const builtins = builtinOptions ? buildBuiltinTools(builtinOptions) : [];
   const question = buildAskUserQuestionTool();
@@ -846,6 +854,7 @@ function buildDefaultHostTools(
     ...taskTools.map((tool) => tool.name),
     ...(automationTool ? [automationTool.name] : []),
     ...goalTools.map((tool) => tool.name),
+    ...parentAgentTools.map((tool) => tool.name),
   ];
   const skillHost = buildHostCapabilitiesFromBinding(toolNames);
   const shadowTracker = new SkillShadowSelectionTracker();
@@ -861,6 +870,7 @@ function buildDefaultHostTools(
     ...taskTools,
     ...(automationTool ? [automationTool] : []),
     ...goalTools,
+    ...parentAgentTools,
   ];
 }
 

--- a/packages/runtime-host/src/server/root-admission-owner.ts
+++ b/packages/runtime-host/src/server/root-admission-owner.ts
@@ -99,6 +99,7 @@ function sameRootAdmission(left: RootTurnAdmission, right: RootTurnAdmission): b
     left.runId === right.runId &&
     left.userMessageId === right.userMessageId &&
     isDeepStrictEqual(left.execution, right.execution) &&
+    isDeepStrictEqual(left.turnOrchestration, right.turnOrchestration) &&
     left.previousRootTurnId === right.previousRootTurnId &&
     messageContentsEqual(left.normalizedInput, right.normalizedInput) &&
     left.sourceMessages.length === right.sourceMessages.length &&
@@ -127,6 +128,9 @@ function snapshotAdmission(admission: RootTurnAdmission): RootTurnAdmission {
   return Object.freeze({
     ...admission,
     execution: Object.freeze({ ...admission.execution }),
+    ...(admission.turnOrchestration
+      ? { turnOrchestration: Object.freeze({ ...admission.turnOrchestration }) }
+      : {}),
     normalizedInput: snapshotMessageContent(admission.normalizedInput),
     sourceMessages: Object.freeze(sourceMessages),
   });

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -364,6 +364,9 @@ export class RootTurnCoordinator {
         sessionId,
         turnId: admission.turnId,
         content: normalizeMessageContent(admission.normalizedInput),
+        ...(admission.turnOrchestration
+          ? { turnOrchestration: { ...admission.turnOrchestration } }
+          : {}),
       };
       const disposition = await this.sessionAdmission.run(sessionId, (lease) =>
         this.prepareAdmittedTurn(input, admission, this.acquireRecoveryResidency, lease),
@@ -962,6 +965,7 @@ export class RootTurnCoordinator {
       const canonicalInput: TurnStartInput = {
         ...input,
         content: normalizeMessageContent(input.content),
+        ...(input.turnOrchestration ? { turnOrchestration: { ...input.turnOrchestration } } : {}),
       };
       const activeAtEntry = this.#activeBySession.has(input.sessionId);
       let reservation = activeAtEntry ? undefined : this.reserveRootTurn(input.sessionId);
@@ -982,6 +986,7 @@ export class RootTurnCoordinator {
           }
           if (
             !messageContentsEqual(existing.normalizedInput, canonicalInput.content) ||
+            !isDeepStrictEqual(existing.turnOrchestration, canonicalInput.turnOrchestration) ||
             existing.sourceMessages.length !== 0
           ) {
             return completedStart(
@@ -1057,6 +1062,9 @@ export class RootTurnCoordinator {
           proposedUserMessageId: randomUUID(),
           execution: { kind: 'external_message' },
           normalizedInput: canonicalInput.content,
+          ...(canonicalInput.turnOrchestration
+            ? { turnOrchestration: canonicalInput.turnOrchestration }
+            : {}),
           sourceMessages: [],
           admittedAt: Date.now(),
         });
@@ -1067,6 +1075,10 @@ export class RootTurnCoordinator {
         }
         if (
           !messageContentsEqual(admission.admission.normalizedInput, canonicalInput.content) ||
+          !isDeepStrictEqual(
+            admission.admission.turnOrchestration,
+            canonicalInput.turnOrchestration,
+          ) ||
           admission.admission.sourceMessages.length !== 0
         ) {
           return completedStart(
@@ -1214,6 +1226,14 @@ export class RootTurnCoordinator {
   ): Promise<TurnStartDisposition> {
     if (admission.sessionId !== input.sessionId || admission.turnId !== input.turnId) {
       throw new Error('Root Turn admission identity does not match its input');
+    }
+    if (
+      !messageContentsEqual(admission.normalizedInput, input.content) ||
+      !isDeepStrictEqual(admission.turnOrchestration, input.turnOrchestration)
+    ) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Root Turn admission payload does not match its input',
+      );
     }
     const { runId } = admission;
     const existingRun = await this.readRunIfPresent(input.sessionId, runId);
@@ -1380,6 +1400,7 @@ export class RootTurnCoordinator {
             {
               turnId: input.turnId,
               ...normalizeMessageContent(input.content),
+              ...(input.turnOrchestration ? { turnOrchestration: input.turnOrchestration } : {}),
               ...(messageOrigin ? { origin: messageOrigin } : {}),
             },
             {

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -63,6 +63,48 @@ describe('subagent tools', () => {
     ]);
   });
 
+  test('parent tools advertise only definitions runnable in their composition', () => {
+    const tools = buildParentAgentTools({ definitions: [LOCAL_READ_AGENT_DEFINITION] });
+    const spawn = tools.find((tool) => tool.name === AGENT_SPAWN_TOOL_NAME);
+    const swarm = tools.find((tool) => tool.name === AGENT_SWARM_TOOL_NAME);
+    expect(spawn).toBeDefined();
+    expect(swarm).toBeDefined();
+    const spawnSchema = spawn!.parameters as {
+      safeParse(input: unknown): { success: boolean };
+    };
+    const swarmSchema = swarm!.parameters as {
+      safeParse(input: unknown): { success: boolean };
+    };
+
+    expect(
+      spawnSchema.safeParse({ profile: LOCAL_READ_AGENT_PROFILE, task: 'Inspect the repo.' })
+        .success,
+    ).toBe(true);
+    expect(
+      spawnSchema.safeParse({ profile: WEB_RESEARCH_AGENT_PROFILE, task: 'Search the web.' })
+        .success,
+    ).toBe(false);
+    expect(
+      spawnSchema.safeParse({ profile: IMPLEMENTATION_AGENT_PROFILE, task: 'Change a file.' })
+        .success,
+    ).toBe(false);
+    expect(
+      swarmSchema.safeParse({
+        items: [{ item_id: 'local', profile: LOCAL_READ_AGENT_PROFILE, task: 'Inspect it.' }],
+      }).success,
+    ).toBe(true);
+    expect(
+      swarmSchema.safeParse({
+        items: [{ item_id: 'web', profile: WEB_RESEARCH_AGENT_PROFILE, task: 'Search it.' }],
+      }).success,
+    ).toBe(false);
+
+    expect(buildParentAgentTools({ definitions: [] }).map((tool) => tool.name)).toEqual([
+      AGENT_LIST_TOOL_NAME,
+      AGENT_OUTPUT_TOOL_NAME,
+    ]);
+  });
+
   test('agent_spawn advertises task_id only when task binding is available', async () => {
     const advertisedProperties = async (tool: MakaTool) => {
       const schema = (await zodSchema(tool.parameters as never).jsonSchema) as {
@@ -485,6 +527,7 @@ describe('subagent tools', () => {
             content: { kind: 'text', text: 'secret body' },
           });
           return {
+            profile: input.agentProfile,
             childSessionId: 'child-session',
             agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
             agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
@@ -494,6 +537,7 @@ describe('subagent tools', () => {
             permissionMode: 'explore',
             summary: 'done',
             artifactIds: [],
+            internalField: 'must not cross the tool result boundary',
           };
         },
       },

--- a/packages/runtime/src/agent-catalog.ts
+++ b/packages/runtime/src/agent-catalog.ts
@@ -198,6 +198,29 @@ export function getBuiltinAgentDefinitionByProfile(profile: string): AgentDefini
   return BUILTIN_AGENT_DEFINITIONS.find((definition) => definition.profile === profile);
 }
 
+export function agentProfilesForDefinitions(
+  definitions: readonly AgentDefinition[],
+): [AgentProfile, ...AgentProfile[]] {
+  const profiles = definitions.map((definition) => definition.profile);
+  if (profiles.length === 0) throw new Error('At least one agent definition is required');
+  if (new Set(profiles).size !== profiles.length) {
+    throw new Error('Agent definitions must have unique profiles');
+  }
+  return profiles as [AgentProfile, ...AgentProfile[]];
+}
+
+export function requireAgentDefinitionByProfile(
+  definitions: readonly AgentDefinition[],
+  profile: string,
+): AgentDefinition {
+  const definition = definitions.find((candidate) => candidate.profile === profile);
+  if (!definition) {
+    const available = definitions.map((candidate) => candidate.profile).join(', ');
+    throw new Error(`Unknown agent profile "${profile}". Available profiles: ${available}.`);
+  }
+  return definition;
+}
+
 export function requireBuiltinAgentDefinition(id: string): AgentDefinition {
   const definition = getBuiltinAgentDefinition(id);
   if (!definition) {
@@ -208,12 +231,20 @@ export function requireBuiltinAgentDefinition(id: string): AgentDefinition {
 }
 
 export function requireBuiltinAgentDefinitionByProfile(profile: string): AgentDefinition {
-  const definition = getBuiltinAgentDefinitionByProfile(profile);
-  if (!definition) {
-    const available = BUILTIN_AGENT_DEFINITIONS.map((agent) => agent.profile).join(', ');
-    throw new Error(`Unknown agent profile "${profile}". Available profiles: ${available}.`);
-  }
-  return definition;
+  return requireAgentDefinitionByProfile(BUILTIN_AGENT_DEFINITIONS, profile);
+}
+
+export function listRunnableBuiltinAgentDefinitions(
+  options: AgentDefinitionListOptions,
+): AgentDefinition[] {
+  return BUILTIN_AGENT_DEFINITIONS.filter(
+    (definition) =>
+      evaluateAgentDefinitionAvailability({
+        definition,
+        tools: options.tools ?? [],
+        worktreeChildExecutorAvailable: options.worktreeChildExecutorAvailable,
+      }).status === 'available',
+  );
 }
 
 export function evaluateAgentDefinitionToolAccess(

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -11,8 +11,9 @@ import {
   AGENT_WORKSPACE_WORKTREE,
   AGENT_WRITE_BACK_PATCH,
   AGENT_WRITE_BACK_SUMMARY,
-  BUILTIN_AGENT_PROFILES,
-  requireBuiltinAgentDefinitionByProfile,
+  BUILTIN_AGENT_DEFINITIONS,
+  agentProfilesForDefinitions,
+  requireAgentDefinitionByProfile,
   type AgentDefinition,
 } from './agent-catalog.js';
 import {
@@ -114,9 +115,12 @@ export function buildAgentSwarmTool(
     now?: () => number;
     adaptiveSwarmPolicy?: AdaptiveSwarmPolicy;
     itemTimeoutMs?: number;
+    definitions?: readonly AgentDefinition[];
   } = {},
 ): MakaTool<AgentSwarmToolInput, AgentSwarmToolResult> {
   const now = deps.now ?? Date.now;
+  const definitions = deps.definitions ?? BUILTIN_AGENT_DEFINITIONS;
+  const profiles = agentProfilesForDefinitions(definitions);
   const itemTimeoutMs = normalizeItemTimeoutMs(
     deps.itemTimeoutMs ?? AGENT_SWARM_DEFAULT_ITEM_TIMEOUT_MS,
   );
@@ -129,11 +133,11 @@ export function buildAgentSwarmTool(
       'Use resume_run_ids to continue terminal child AgentRuns by runId; resumed children are ordered before new items.',
       'Use this only when every item can run independently. Results return in input order; you remain responsible for semantic synthesis.',
     ].join(' '),
-    parameters: agentSwarmInputSchema(),
+    parameters: agentSwarmInputSchema(definitions, profiles),
     executionSemantics: 'exclusive_step',
     categoryHint: 'subagent',
     impl: async (input, ctx) => {
-      const prepared = await prepareAgentSwarmInput(input, ctx);
+      const prepared = await prepareAgentSwarmInput(input, ctx, definitions);
       if (prepared.items.some((item) => item.mode === 'spawn') && !ctx.spawnChildSession) {
         throw new Error('spawnChildSession capability is unavailable in this runtime context');
       }
@@ -407,7 +411,10 @@ function traceAgentSwarm(
   });
 }
 
-function agentSwarmInputSchema() {
+function agentSwarmInputSchema(
+  definitions: readonly AgentDefinition[],
+  profiles: ReturnType<typeof agentProfilesForDefinitions>,
+) {
   const itemSchema = z
     .object({
       item_id: z
@@ -416,7 +423,7 @@ function agentSwarmInputSchema() {
         .max(TASK_ID_MAX_CHARS)
         .refine(isSafeTaskId)
         .describe('Stable item id (letters, digits, dot, underscore, colon, or dash).'),
-      profile: z.enum(BUILTIN_AGENT_PROFILES).describe('Child agent profile.'),
+      profile: z.enum(profiles).describe('Child agent profile.'),
       task: z
         .string()
         .min(1)
@@ -432,7 +439,7 @@ function agentSwarmInputSchema() {
         .describe('Requested child workspace isolation.'),
     })
     .superRefine((input, ctx) => {
-      addAgentContractIssues(input, ctx);
+      addAgentContractIssues(input, ctx, definitions);
     });
 
   const explicitItemsSchema = z
@@ -468,7 +475,7 @@ function agentSwarmInputSchema() {
           `Shared task template for string items; every ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER} occurrence is replaced.`,
         ),
       profile: z
-        .enum(BUILTIN_AGENT_PROFILES)
+        .enum(profiles)
         .optional()
         .describe('Shared child profile for prompt_template string items.'),
       resume_run_ids: z
@@ -584,8 +591,12 @@ function agentSwarmInputSchema() {
     });
 }
 
-function addAgentContractIssues(input: AgentSwarmExplicitItemInput, ctx: z.RefinementCtx): void {
-  const definition = requireBuiltinAgentDefinitionByProfile(input.profile);
+function addAgentContractIssues(
+  input: AgentSwarmExplicitItemInput,
+  ctx: z.RefinementCtx,
+  definitions: readonly AgentDefinition[],
+): void {
+  const definition = requireAgentDefinitionByProfile(definitions, input.profile);
   const writeBack = input.write_back ?? definition.contract.defaultWriteBack;
   if (!definition.contract.supportedWriteBack.some((mode) => mode === writeBack)) {
     ctx.addIssue({
@@ -607,11 +618,12 @@ function addAgentContractIssues(input: AgentSwarmExplicitItemInput, ctx: z.Refin
 async function prepareAgentSwarmInput(
   input: AgentSwarmToolInput,
   ctx: MakaToolContext,
+  definitions: readonly AgentDefinition[],
 ): Promise<{
   readonly items: readonly PreparedAgentSwarmItem[];
   readonly maxConcurrency: number;
 }> {
-  const preflight = preflightAgentSwarmInput(input);
+  const preflight = preflightAgentSwarmInput(input, definitions);
   if (preflight.items.length > 0 && !ctx.spawnChildSession) {
     throw new Error('spawnChildSession capability is unavailable in this runtime context');
   }
@@ -624,7 +636,7 @@ async function prepareAgentSwarmInput(
       if (prepared.sourceRunId !== item.sourceRunId) {
         throw new Error(`Child AgentRun resume identity changed for ${item.sourceRunId}`);
       }
-      const definition = requireBuiltinAgentDefinitionByProfile(prepared.profile);
+      const definition = requireAgentDefinitionByProfile(definitions, prepared.profile);
       if (definition.id !== prepared.agentId || definition.name !== prepared.agentName) {
         throw new Error(`Child AgentRun resume profile changed for ${item.sourceRunId}`);
       }
@@ -656,7 +668,10 @@ async function prepareAgentSwarmInput(
   };
 }
 
-function preflightAgentSwarmInput(input: AgentSwarmToolInput): {
+function preflightAgentSwarmInput(
+  input: AgentSwarmToolInput,
+  definitions: readonly AgentDefinition[],
+): {
   readonly items: readonly PreparedAgentSwarmItem[];
   readonly resumes: readonly PendingAgentSwarmResume[];
   readonly maxConcurrency: number;
@@ -716,7 +731,7 @@ function preflightAgentSwarmInput(input: AgentSwarmToolInput): {
       throw new Error(`Agent swarm item "${item.item_id}" has an invalid task.`);
     }
 
-    const definition = requireBuiltinAgentDefinitionByProfile(item.profile);
+    const definition = requireAgentDefinitionByProfile(definitions, item.profile);
     const writeBack = item.write_back ?? definition.contract.defaultWriteBack;
     if (!definition.contract.supportedWriteBack.some((mode) => mode === writeBack)) {
       throw new Error(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -699,6 +699,7 @@ export {
   getBuiltinAgentDefinition,
   getBuiltinAgentDefinitionByProfile,
   listBuiltinAgentDefinitions,
+  listRunnableBuiltinAgentDefinitions,
   requireBuiltinAgentDefinition,
   requireBuiltinAgentDefinitionByProfile,
 } from './agent-catalog.js';

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   TASK_ID_MAX_CHARS,
+  decodeCanonicalToolResultContent,
   isSafeTaskId,
   type TaskLedgerStore,
   type ToolResultContent,
@@ -12,9 +13,10 @@ import {
   AGENT_WRITE_BACK_PATCH,
   AGENT_WRITE_BACK_SUMMARY,
   BUILTIN_AGENT_DEFINITIONS,
-  BUILTIN_AGENT_PROFILES,
+  agentProfilesForDefinitions,
   buildToolsForAgentDefinition,
-  requireBuiltinAgentDefinitionByProfile,
+  requireAgentDefinitionByProfile,
+  type AgentDefinition,
 } from './agent-catalog.js';
 import { AGENT_SWARM_TOOL_NAME, buildAgentSwarmTool } from './agent-swarm-tools.js';
 import { ChildAgentProgressProjector } from './child-agent-progress.js';
@@ -64,7 +66,9 @@ export function buildChildAgentTools(tools: readonly MakaTool[]): MakaTool[] {
   return out;
 }
 
-export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = {}): MakaTool<
+export function buildSubagentSpawnTool(
+  deps: { taskLedger?: TaskLedgerStore; definitions?: readonly AgentDefinition[] } = {},
+): MakaTool<
   {
     profile: string;
     task: string;
@@ -74,6 +78,8 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
   },
   unknown
 > {
+  const definitions = deps.definitions ?? BUILTIN_AGENT_DEFINITIONS;
+  const profiles = agentProfilesForDefinitions(definitions);
   return {
     name: AGENT_SPAWN_TOOL_NAME,
     displayName: 'Agent',
@@ -81,7 +87,7 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
       'Run a foreground catalog child agent for a bounded task and return its explicit result.',
     parameters: z
       .object({
-        profile: z.enum(BUILTIN_AGENT_PROFILES).describe('Child agent profile.'),
+        profile: z.enum(profiles).describe('Child agent profile.'),
         task: z.string().min(1).max(60_000).describe('Bounded task for the selected child agent.'),
         write_back: z
           .enum(AGENT_SPAWN_WRITE_BACK_MODES)
@@ -109,7 +115,7 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
       })
       .strict()
       .superRefine((input, ctx) => {
-        const definition = requireBuiltinAgentDefinitionByProfile(input.profile);
+        const definition = requireAgentDefinitionByProfile(definitions, input.profile);
         const requestedWriteBack = input.write_back ?? definition.contract.defaultWriteBack;
         if (!definition.contract.supportedWriteBack.some((mode) => mode === requestedWriteBack)) {
           ctx.addIssue({
@@ -129,7 +135,7 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
       }),
     categoryHint: 'subagent',
     impl: async (input, ctx) => {
-      const definition = requireBuiltinAgentDefinitionByProfile(input.profile);
+      const definition = requireAgentDefinitionByProfile(definitions, input.profile);
       const requestedWriteBack = input.write_back ?? definition.contract.defaultWriteBack;
       if (!definition.contract.supportedWriteBack.some((mode) => mode === requestedWriteBack)) {
         throw new Error(
@@ -164,32 +170,34 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
       const progress = new ChildAgentProgressProjector(ctx);
       ctx.emitOutput('stdout', `Starting child agent: ${definition.name}\n`);
       try {
-        result = (await ctx.spawnChildSession({
-          agentProfile: definition.profile,
-          prompt: input.task,
-          ...(boundTask
-            ? {
-                onReady: async ({ childSessionId, turnId, agentId }) => {
-                  const owner = {
-                    actor: 'child_agent' as const,
-                    sessionId: childSessionId,
-                    agentId,
-                    turnId,
-                  };
-                  await deps.taskLedger!.claim(ctx.sessionId, boundTask.id, owner, {
-                    runId: ctx.runId,
-                    turnId: ctx.turnId,
-                    toolCallId: ctx.toolCallId,
-                    source: 'system',
-                    actor: 'main_agent',
-                    reason: `assigned to child agent ${agentId}`,
-                  });
-                  claimedOwner = owner;
-                },
-              }
-            : {}),
-          onEvent: (event) => progress.observe(event),
-        })) as Omit<SubagentToolResult, 'kind'>;
+        result = projectSubagentToolResult(
+          await ctx.spawnChildSession({
+            agentProfile: definition.profile,
+            prompt: input.task,
+            ...(boundTask
+              ? {
+                  onReady: async ({ childSessionId, turnId, agentId }) => {
+                    const owner = {
+                      actor: 'child_agent' as const,
+                      sessionId: childSessionId,
+                      agentId,
+                      turnId,
+                    };
+                    await deps.taskLedger!.claim(ctx.sessionId, boundTask.id, owner, {
+                      runId: ctx.runId,
+                      turnId: ctx.turnId,
+                      toolCallId: ctx.toolCallId,
+                      source: 'system',
+                      actor: 'main_agent',
+                      reason: `assigned to child agent ${agentId}`,
+                    });
+                    claimedOwner = owner;
+                  },
+                }
+              : {}),
+            onEvent: (event) => progress.observe(event),
+          }),
+        );
       } catch (error) {
         ctx.emitOutput(
           'stderr',
@@ -247,6 +255,33 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
       } satisfies SubagentToolResult;
     },
   };
+}
+
+function projectSubagentToolResult(value: unknown): Omit<SubagentToolResult, 'kind'> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Child agent returned an invalid result');
+  }
+  const raw = value as Record<string, unknown>;
+  const decoded = decodeCanonicalToolResultContent({
+    kind: 'subagent',
+    ...(raw.childSessionId !== undefined ? { childSessionId: raw.childSessionId } : {}),
+    ...(raw.agentId !== undefined ? { agentId: raw.agentId } : {}),
+    agentName: raw.agentName,
+    turnId: raw.turnId,
+    ...(raw.runId !== undefined ? { runId: raw.runId } : {}),
+    status: raw.status,
+    permissionMode: raw.permissionMode,
+    summary: raw.summary,
+    artifactIds: raw.artifactIds,
+    ...(raw.startedAt !== undefined ? { startedAt: raw.startedAt } : {}),
+    ...(raw.completedAt !== undefined ? { completedAt: raw.completedAt } : {}),
+    ...(raw.durationMs !== undefined ? { durationMs: raw.durationMs } : {}),
+    ...(raw.eventCount !== undefined ? { eventCount: raw.eventCount } : {}),
+    ...(raw.failureClass !== undefined ? { failureClass: raw.failureClass } : {}),
+  });
+  if (decoded.kind !== 'subagent') throw new Error('Child agent returned an invalid result');
+  const { kind: _kind, ...result } = decoded as SubagentToolResult;
+  return result;
 }
 
 function boundedChildError(error: unknown): string {
@@ -412,6 +447,14 @@ export function buildSubagentProjectionTools(): MakaTool[] {
   return [buildSubagentListTool(), buildSubagentOutputTool()];
 }
 
-export function buildParentAgentTools(deps: { taskLedger?: TaskLedgerStore } = {}): MakaTool[] {
-  return [buildSubagentSpawnTool(deps), buildAgentSwarmTool(), ...buildSubagentProjectionTools()];
+export function buildParentAgentTools(
+  deps: { taskLedger?: TaskLedgerStore; definitions?: readonly AgentDefinition[] } = {},
+): MakaTool[] {
+  const definitions = deps.definitions ?? BUILTIN_AGENT_DEFINITIONS;
+  return [
+    ...(definitions.length > 0
+      ? [buildSubagentSpawnTool({ ...deps, definitions }), buildAgentSwarmTool({ definitions })]
+      : []),
+    ...buildSubagentProjectionTools(),
+  ];
 }

--- a/packages/storage/src/__tests__/artifact-store.test.ts
+++ b/packages/storage/src/__tests__/artifact-store.test.ts
@@ -80,6 +80,35 @@ describe('SQLite Artifact store', () => {
     });
   });
 
+  test('lists only live Artifacts committed by one exact Turn', async () => {
+    await withWorkspace(async (root) => {
+      const authority = createArtifactStoreWriteAuthority(root);
+      await authority.recover();
+      const { store } = authority;
+      await store.create({ ...artifactInput('turn-a-new', 'new', 30), turnId: 'turn-a' });
+      await store.create({ ...artifactInput('turn-b', 'other turn', 20), turnId: 'turn-b' });
+      await store.create({
+        ...artifactInput('turn-a-old', 'old', 10),
+        turnId: 'turn-a',
+      });
+      await store.create({
+        ...artifactInput('other-session', 'other session', 40),
+        sessionId: 'session-2',
+        turnId: 'turn-a',
+      });
+
+      assert.deepEqual(
+        (await store.listTurnArtifacts('session-1', 'turn-a')).map((record) => record.id),
+        ['turn-a-new', 'turn-a-old'],
+      );
+      await store.deleteUserArtifactInSession('session-1', 'turn-a-new');
+      assert.deepEqual(
+        (await store.listTurnArtifacts('session-1', 'turn-a')).map((record) => record.id),
+        ['turn-a-old'],
+      );
+    });
+  });
+
   test('persists and reopens bounded synthetic turn keys', async () => {
     await withWorkspace(async (root) => {
       for (const [id, turnId] of [

--- a/packages/storage/src/__tests__/execution-stores.test.ts
+++ b/packages/storage/src/__tests__/execution-stores.test.ts
@@ -298,6 +298,7 @@ describe('execution stores', () => {
             displayText: 'hello',
             attachments: [mutableAttachment, notesAttachment],
           },
+          turnOrchestration: { mode: 'swarm', source: 'host_api' },
           sourceMessages: [
             {
               messageId: 'source-1',
@@ -316,6 +317,11 @@ describe('execution stores', () => {
         mutableAttachment.name = 'mutated.png';
         assert.equal(first.admission.normalizedInput.attachments?.[0]?.name, 'chart.png');
         assert.equal(Object.isFrozen(first.admission), true);
+        assert.deepEqual(first.admission.turnOrchestration, {
+          mode: 'swarm',
+          source: 'host_api',
+        });
+        assert.equal(Object.isFrozen(first.admission.turnOrchestration), true);
         assert.equal(Object.isFrozen(first.admission.normalizedInput.attachments?.[0]?.ref), true);
         assert.deepEqual(await stores.agentRunStore.listSessionRuns(session.id), []);
 
@@ -331,6 +337,7 @@ describe('execution stores', () => {
             displayText: 'hello',
             attachments: [chartAttachment, notesAttachment],
           },
+          turnOrchestration: { mode: 'swarm', source: 'host_api' },
           sourceMessages: [
             {
               messageId: 'source-1',
@@ -353,6 +360,35 @@ describe('execution stores', () => {
           chartAttachment,
           notesAttachment,
         ]);
+
+        const orchestrationConflict = await stores.agentRunStore.admitRootTurn({
+          sessionId: session.id,
+          turnId: 'turn-1',
+          proposedRunId: 'run-never-used',
+          proposedUserMessageId: 'message-never-used',
+          execution: { kind: 'external_message' },
+          previousRootTurnId: null,
+          normalizedInput: {
+            text: '<model>hello</model>',
+            displayText: 'hello',
+            attachments: [chartAttachment, notesAttachment],
+          },
+          turnOrchestration: { mode: 'default', source: 'host_api' },
+          sourceMessages: [
+            {
+              messageId: 'source-1',
+              content: {
+                text: '<model>hello</model>',
+                displayText: 'hello',
+                attachments: [chartAttachment, notesAttachment],
+              },
+              placement: 'current_turn',
+              disposition: 'steering',
+            },
+          ],
+          admittedAt: 20,
+        });
+        assert.equal(orchestrationConflict.kind, 'conflict');
 
         const stored = await stores.agentRunStore.readRootTurnAdmission(session.id, 'turn-1');
         assert.deepEqual(stored, first.admission);
@@ -696,6 +732,17 @@ describe('execution stores', () => {
           sourceMessages: [turnStartedSource],
         },
         {
+          name: 'child-with-turn-orchestration',
+          userMessageId: 'message-1',
+          execution: {
+            kind: 'linked_child_initial' as const,
+            agentId: 'agent',
+            agentName: 'Agent',
+          },
+          turnOrchestration: { mode: 'swarm' as const, source: 'host_api' as const },
+          sourceMessages: [],
+        },
+        {
           name: 'resume-self-source',
           userMessageId: 'message-1',
           execution: {
@@ -740,6 +787,9 @@ describe('execution stores', () => {
               execution: invalid.execution,
               previousRootTurnId: null,
               normalizedInput,
+              ...('turnOrchestration' in invalid
+                ? { turnOrchestration: invalid.turnOrchestration }
+                : {}),
               sourceMessages: invalid.sourceMessages,
               admittedAt: 10,
             }),
@@ -760,6 +810,9 @@ describe('execution stores', () => {
             execution: invalid.execution,
             previousRootTurnId: null,
             normalizedInput,
+            ...('turnOrchestration' in invalid
+              ? { turnOrchestration: invalid.turnOrchestration }
+              : {}),
             sourceMessages: invalid.sourceMessages,
             admittedAt: 10,
           })}\n`,
@@ -1128,6 +1181,7 @@ describe('execution stores', () => {
         execution: { kind: 'external_message' },
         previousRootTurnId: null,
         normalizedInput: { text: 'hello' },
+        turnOrchestration: { mode: 'graph', source: 'host_api' },
         sourceMessages: [],
         admittedAt: 10,
       });
@@ -1136,6 +1190,7 @@ describe('execution stores', () => {
       const path = join(root, 'sessions', 'session-schema', 'turn-admissions', 'turn-1.json');
       const v1 = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>;
       assert.equal(v1.schemaVersion, 1);
+      assert.deepEqual(v1.turnOrchestration, { mode: 'graph', source: 'host_api' });
       assert.deepEqual(
         await createAgentRunStore(root).readRootTurnAdmission('session-schema', 'turn-1'),
         admitted.admission,

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -62,6 +62,11 @@ import {
   type RuntimeEvent,
   type RuntimeEventStore,
 } from '@maka/core';
+import {
+  isOrchestrationMode,
+  isTurnOrchestrationSource,
+  type TurnOrchestration,
+} from '@maka/core/orchestration';
 
 const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 const EXCLUSIVE_TEMP_SUFFIX_PATTERN =
@@ -90,6 +95,7 @@ export interface RootTurnAdmission {
   execution: RootExecutionDescriptor;
   previousRootTurnId: string | null;
   normalizedInput: MessageContent;
+  turnOrchestration?: TurnOrchestration;
   sourceMessages: readonly RootTurnSourceMessage[];
   admittedAt: number;
 }
@@ -102,6 +108,7 @@ export interface AdmitRootTurnInput {
   execution: RootExecutionDescriptor;
   previousRootTurnId: string | null;
   normalizedInput: MessageContent;
+  turnOrchestration?: TurnOrchestration;
   sourceMessages: readonly RootTurnSourceMessage[];
   admittedAt: number;
 }
@@ -678,6 +685,7 @@ class FileAgentRunStore implements DurableAgentRunStore {
       input.normalizedInput,
       input.sourceMessages,
     );
+    const turnOrchestration = normalizeTurnOrchestration(input.turnOrchestration);
     if (!Number.isSafeInteger(input.admittedAt) || input.admittedAt < 0) {
       throw new Error('Invalid root turn admission timestamp');
     }
@@ -690,6 +698,7 @@ class FileAgentRunStore implements DurableAgentRunStore {
       execution: normalizeRootExecutionDescriptor(input.execution),
       previousRootTurnId: input.previousRootTurnId,
       normalizedInput,
+      ...(turnOrchestration ? { turnOrchestration } : {}),
       sourceMessages,
       admittedAt: input.admittedAt,
     };
@@ -1754,6 +1763,7 @@ function normalizeAdmitRootTurnInput(input: AdmitRootTurnInput): RootTurnAdmissi
     input.normalizedInput,
     input.sourceMessages,
   );
+  const turnOrchestration = normalizeTurnOrchestration(input.turnOrchestration);
   const admission: RootTurnAdmission = {
     schemaVersion: ROOT_TURN_ADMISSION_SCHEMA_VERSION,
     sessionId: input.sessionId,
@@ -1763,6 +1773,7 @@ function normalizeAdmitRootTurnInput(input: AdmitRootTurnInput): RootTurnAdmissi
     execution: normalizeRootExecutionDescriptor(input.execution),
     previousRootTurnId: input.previousRootTurnId,
     normalizedInput,
+    ...(turnOrchestration ? { turnOrchestration } : {}),
     sourceMessages,
     admittedAt: input.admittedAt,
   };
@@ -2840,18 +2851,7 @@ function normalizeRootTurnAdmission(
         record.previousRootTurnId !== turnId)) &&
     Number.isSafeInteger(record.admittedAt) &&
     (record.admittedAt as number) >= 0 &&
-    hasExactKeys(record, [
-      'schemaVersion',
-      'sessionId',
-      'turnId',
-      'runId',
-      'userMessageId',
-      'execution',
-      'previousRootTurnId',
-      'normalizedInput',
-      'sourceMessages',
-      'admittedAt',
-    ]);
+    hasRootTurnAdmissionKeys(record);
   if (!valid) {
     throw new Error(`Invalid root turn admission for turn ${turnId}: malformed fields`);
   }
@@ -2859,6 +2859,7 @@ function normalizeRootTurnAdmission(
     record.normalizedInput,
     record.sourceMessages,
   );
+  const turnOrchestration = normalizeTurnOrchestration(record.turnOrchestration);
   const admission: RootTurnAdmission = {
     schemaVersion: ROOT_TURN_ADMISSION_SCHEMA_VERSION,
     sessionId,
@@ -2868,6 +2869,7 @@ function normalizeRootTurnAdmission(
     execution: normalizeRootExecutionDescriptor(record.execution),
     previousRootTurnId: record.previousRootTurnId as string | null,
     normalizedInput,
+    ...(turnOrchestration ? { turnOrchestration } : {}),
     sourceMessages,
     admittedAt: record.admittedAt as number,
   };
@@ -3077,6 +3079,7 @@ function rootTurnAdmissionPayloadsEqual(
 ): boolean {
   return (
     isDeepStrictEqual(left.execution, right.execution) &&
+    isDeepStrictEqual(left.turnOrchestration, right.turnOrchestration) &&
     messageContentsEqual(left.normalizedInput, right.normalizedInput) &&
     left.sourceMessages.length === right.sourceMessages.length &&
     left.sourceMessages.every((source, index) => {
@@ -3105,6 +3108,11 @@ function assertRootTurnAdmissionSerializedSize(serialized: string): void {
 function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
   const execution = admission.execution;
   const providerRetry = execution.kind === 'linked_child_provider_retry';
+  if (admission.turnOrchestration && execution.kind !== 'external_message') {
+    throw new Error(
+      'Invalid root turn admission contract: only external messages may override orchestration',
+    );
+  }
   if ((admission.userMessageId === null) !== providerRetry) {
     throw new Error(
       'Invalid root turn admission contract: only linked child provider retry omits UserMessage',
@@ -3158,6 +3166,7 @@ function deepFreezeRootTurnAdmission(admission: RootTurnAdmission): RootTurnAdmi
     Object.freeze(admission.execution.claim);
   }
   Object.freeze(admission.execution);
+  if (admission.turnOrchestration) Object.freeze(admission.turnOrchestration);
   deepFreezeRootTurnMessageContent(admission.normalizedInput);
   for (const sourceMessage of admission.sourceMessages) {
     deepFreezeRootTurnMessageContent(sourceMessage.content);
@@ -3165,6 +3174,35 @@ function deepFreezeRootTurnAdmission(admission: RootTurnAdmission): RootTurnAdmi
   }
   Object.freeze(admission.sourceMessages);
   return Object.freeze(admission);
+}
+
+function normalizeTurnOrchestration(value: unknown): TurnOrchestration | undefined {
+  if (value === undefined) return undefined;
+  if (
+    !isPlainRecord(value) ||
+    !hasExactKeys(value, ['mode', 'source']) ||
+    !isOrchestrationMode(value.mode) ||
+    !isTurnOrchestrationSource(value.source)
+  ) {
+    throw new Error('Invalid root turn orchestration');
+  }
+  return Object.freeze({ mode: value.mode, source: value.source });
+}
+
+function hasRootTurnAdmissionKeys(record: Record<string, unknown>): boolean {
+  const keys = [
+    'schemaVersion',
+    'sessionId',
+    'turnId',
+    'runId',
+    'userMessageId',
+    'execution',
+    'previousRootTurnId',
+    'normalizedInput',
+    'sourceMessages',
+    'admittedAt',
+  ];
+  return hasExactKeys(record, keys) || hasExactKeys(record, [...keys, 'turnOrchestration']);
 }
 
 function normalizeRootExecutionDescriptor(value: unknown): RootExecutionDescriptor {

--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -185,6 +185,7 @@ export interface ArtifactAuthorityStore extends ArtifactStore {
     sessionId: string,
     options: { offset: number; limit: number },
   ): Promise<ArtifactListPage>;
+  listTurnArtifacts(sessionId: string, turnId: string): Promise<ArtifactRecord[]>;
   getInSession(sessionId: string, artifactId: string): Promise<ArtifactSessionEntry>;
   readTextInSession(
     sessionId: string,
@@ -608,6 +609,18 @@ class SqliteArtifactStore implements ArtifactAuthorityStore {
         records: snapshot.records.slice(offset, offset + limit).map((record) => ({ ...record })),
         total: snapshot.records.length,
       };
+    });
+  }
+
+  async listTurnArtifacts(sessionId: string, turnId: string): Promise<ArtifactRecord[]> {
+    assertCanonicalArtifactEntityId(sessionId, 'sessionId');
+    assertArtifactTurnKey(turnId);
+    return this.enqueue(async () => {
+      await this.load();
+      const snapshot = this.sessionSnapshots.get(sessionId) ?? EMPTY_SESSION_SNAPSHOT;
+      return snapshot.records
+        .filter((record) => record.turnId === turnId && record.status !== 'deleted')
+        .map((record) => ({ ...record }));
     });
   }
 

--- a/packages/storage/src/artifact-stores.ts
+++ b/packages/storage/src/artifact-stores.ts
@@ -38,6 +38,7 @@ export interface InteractiveArtifactStoreWriter extends DurableArtifactAttachmen
   ): Promise<ConversationArtifactCopyResult>;
   purgeSessionArtifacts(sessionId: string): Promise<void>;
   listPage: ArtifactAuthorityStore['listPage'];
+  listTurnArtifacts: ArtifactAuthorityStore['listTurnArtifacts'];
   getInSession: ArtifactAuthorityStore['getInSession'];
   readTextInSession: ArtifactAuthorityStore['readTextInSession'];
   readBinaryInSession: ArtifactAuthorityStore['readBinaryInSession'];
@@ -169,6 +170,7 @@ function createWriterFacade(
     access: 'write',
     [writerBrand]: true,
     listPage: (sessionId, options) => run(() => store.listPage(sessionId, options)),
+    listTurnArtifacts: (sessionId, turnId) => run(() => store.listTurnArtifacts(sessionId, turnId)),
     getInSession: (sessionId, artifactId) => run(() => store.getInSession(sessionId, artifactId)),
     readTextInSession: (sessionId, artifactId, options) =>
       run(() => store.readTextInSession(sessionId, artifactId, options)),


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Compose Runtime Host parent-agent tools with the existing linked child Session authority.
- Publish only child profiles that the current Host composition can run; `local_read` is runnable, while incomplete profiles remain discoverable but unavailable.
- Persist turn-scoped orchestration options and return exact committed Artifact IDs through canonical child results.

## Behavior

- Root turns can load the canonical `agent_*` tool group through the existing deferred tool path.
- Spawn, resume, retry, list, and output operations use the Host-owned Session and AgentRun lifecycle.
- Child activations receive a fixed non-recursive tool ceiling.
- Exact `turn.start` retries preserve their admitted orchestration options, while conflicting retries fail closed.
- `web_research` and `implementation` are not advertised as spawnable until their Host capabilities and lifecycle contracts are complete.

## Validation

- Full Storage, Runtime, and Runtime Host test suites
- Repository build, format, lint, and typecheck
- `git diff --check`

Part of #1167.

</details>

<details>
<summary>中文</summary>

## 概要

- 将 Runtime Host 的父 Agent 工具接入现有的关联子 Session 权威。
- 只发布当前 Host 组合真正可运行的子 Agent profile；`local_read` 可运行，尚未完成的 profile 仍可发现但明确不可用。
- 持久化 Turn 范围的编排选项，并通过规范化的子 Agent 结果返回精确的已提交 Artifact ID。

## 行为

- Root Turn 可通过现有的延迟工具路径加载规范化的 `agent_*` 工具组。
- Spawn、resume、retry、list 与 output 操作复用 Host 持有的 Session 和 AgentRun 生命周期。
- 子 Agent activation 使用固定且不可递归的工具上限。
- 相同的 `turn.start` 重试保留已准入的编排选项，语义冲突的重试会关闭失败。
- 在对应 Host 能力和生命周期契约完成前，`web_research` 与 `implementation` 不会被公布为可 spawn。

## 验证

- Storage、Runtime 与 Runtime Host 完整测试套件
- 仓库构建、格式检查、lint 与类型检查
- `git diff --check`

#1167 的一部分。

</details>
