### PR TITLE
fix(desktop): hand the rail's nav rows to SideNavSection

### DIFF
--- a/apps/desktop/e2e/sidebar-geometry.spec.ts
+++ b/apps/desktop/e2e/sidebar-geometry.spec.ts
@@ -249,6 +249,34 @@ test('official SideNav resize handle updates the sidebar width from the keyboard
 });
 
 /**
+ * The nav rows' rhythm and where they sit on the rail, read from the rendered
+ * boxes. `firstTop` is part of the reading rather than an assertion of its own:
+ * the icons must not move when the rail collapses, and spacing that is only
+ * correct in one state passes every per-state check while doing exactly that.
+ *
+ * Geometry only, deliberately. Which declaration produces the space — Astryx's
+ * `SideNavSection` gap, a product margin — is not something a rendered-box test
+ * can tell apart, and pinning `row-gap` to find out only bought a second read of
+ * the same 2px plus a dependency on the section's internal child order.
+ */
+async function readNavRhythm(page: Page) {
+  return page.evaluate(() => {
+    const section = document.querySelector('.maka-session-panel-top');
+    if (!section) return null;
+    const rows = [...section.querySelectorAll('a,button')].map((item) =>
+      item.getBoundingClientRect(),
+    );
+    return {
+      heights: [...new Set(rows.map((rect) => Math.round(rect.height)))],
+      pitches: [
+        ...new Set(rows.slice(1).map((rect, index) => Math.round(rect.top - rows[index].top))),
+      ],
+      firstTop: Math.round(rows[0].top),
+    };
+  });
+}
+
+/**
  * A collapse/expand round trip must return the sidebar to a usable width, and
  * to the width the user had chosen rather than the default.
  *
@@ -331,9 +359,25 @@ test('titlebar restores the chosen SideNav width across a collapse round trip', 
     )
     .toEqual(['rgba(0, 0, 0, 0)', 'rgba(0, 0, 0, 0)']);
 
+  const collapsedRhythm = await readNavRhythm(page);
+
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await expect(shell).toHaveAttribute('data-sidebar-state', 'expanded');
   await expect.poll(panelWidth).toBe(chosenWidth);
+
+  // The nav rows are the SAME rows in both states — Astryx swaps each item's
+  // inner recipe on collapse, not its box — so the rhythm has to be state
+  // INDEPENDENT. The first shipped attempt at #1898 hung a collapsed-only gap
+  // off `[data-sidebar-state]`, which fixed the crowding and made the icons jump
+  // vertically on every toggle. Equality here is what rules that class of fix
+  // out; the values below are what rules out the crowding it was aimed at.
+  expect(await readNavRhythm(page)).toEqual(collapsedRhythm);
+
+  // 32px rows on a 34px pitch — the 2px between them being what a SideNavSection
+  // spends on its rows (--spacing-0-5), since that is the container the product
+  // hands to `topContent`. As a bare fragment in a product div they measured a
+  // 32px pitch, no gap at all, and at 48px the three icons read as one slab.
+  expect(collapsedRhythm).toMatchObject({ heights: [32], pitches: [34] });
   expect(chosenWidth).toBeGreaterThanOrEqual(180);
 
   // Same node, both toggles later. Moving the class back inside SideNav, or

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -123,9 +123,18 @@
   display: none;
 }
 
+/* Both nav groups are SideNavSections, so both bring the section's own
+ * paddingBlock; the sticky zone shells above already own the rail's clearance,
+ * and leaving the section copy in place makes the two hairlines sit at
+ * different distances from the rows they separate (measured 9px vs 13px, which
+ * `sidebar-geometry.spec.ts` fails on).
+ * !important: SideNavSection paddingBlock is StyleX/unlayered. */
+.maka-session-panel-top,
 .maka-session-panel-footer {
-  /* !important: SideNavSection paddingBlock is StyleX/unlayered. */
   padding: 0 !important;
+}
+
+.maka-session-panel-footer {
   border-top: 0 !important;
   background: transparent;
 }

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -122,18 +122,17 @@ export function SessionListPanel(props: {
           onWidthChange,
         }}
         // Permanent chrome stays sticky via SideNav topContent; only history
-        // scrolls in children (Astryx five-zone model). Not a titled section —
-        // the rail landmark already names the whole panel.
+        // scrolls in children (Astryx five-zone model). The section inside owns
+        // the rows' rhythm; its title is hidden because the rail landmark
+        // already names the panel on screen, and stays for assistive tech.
         topContent={
-          <div className="maka-session-panel-top">
-            <SessionSidebarNav
-              selection={props.selection}
-              planReminders={props.planReminders}
-              moduleMemory={props.moduleMemory}
-              onSelect={props.onSelect}
-              onNew={props.onNew}
-            />
-          </div>
+          <SessionSidebarNav
+            selection={props.selection}
+            planReminders={props.planReminders}
+            moduleMemory={props.moduleMemory}
+            onSelect={props.onSelect}
+            onNew={props.onNew}
+          />
         }
         footer={
           <SessionSidebarFooter

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -26,8 +26,16 @@ export function SessionSidebarNav(props: {
   // Always SideNavItem — expanded and collapsed. Astryx collapse context turns
   // these into icon-only slots without remounting a different control recipe
   // (which read as a squeeze when the rail previously swapped to IconButton).
+  //
+  // SideNavSection, like the footer below, rather than a bare fragment in a
+  // product div: the section is what owns the space BETWEEN nav rows
+  // (`items` → --spacing-0-5). Handed to `topContent` as a plain div these three
+  // were the only group on the rail outside that authority, so they stacked
+  // edge to edge — invisible expanded, where the label separates the rows, and
+  // plainly three-icons-as-one-slab at 48px. The header is hidden because the
+  // rail landmark already names the panel; the title stays for a11y.
   return (
-    <>
+    <SideNavSection title={copy.mainLabel} isHeaderHidden className="maka-session-panel-top">
       <SideNavItem
         label={copy.newTask}
         icon={SquarePen}
@@ -51,7 +59,7 @@ export function SessionSidebarNav(props: {
         isSelected={automationsActive}
         onClick={() => props.onSelect({ section: 'automations', module: moduleMemory.automations })}
       />
-    </>
+    </SideNavSection>
   );
 }
 


### PR DESCRIPTION
## Summary

The three nav rows (新任务 / 扩展 / 定时任务) stacked edge to edge — measured 44 / 76 / 108 against the live app, a 32px pitch on 32px rows, i.e. no gap at all.

The row height is Astryx's (`navItemStyles.item` → `--size-element-md`), but the space *between* nav rows belongs to `SideNavSection`, whose `items` container spends `--spacing-0-5` on it. These three were the only group on the rail outside that authority: they were handed to `topContent` as a bare fragment inside a product `div`, while the footer immediately below them — in the same file — already used `SideNavSection isHeaderHidden`. Expanded, the label hides the consequence by separating the rows optically. At 48px there is no label left and the icons read as one 96px slab.

So this is not a collapsed-state bug with a collapsed-state fix. It is one group that never got the rail's rhythm, and the fix is to hand it to the same seam the rest of the rail already uses.

**Why not a collapsed-only gap.** The first attempt on this branch did exactly that — `[data-sidebar-state="collapsed"] .maka-session-panel-top { gap: var(--space-1) }`. It fixed the crowding, and it made the icons jump vertically on every toggle, because the rows are the *same* rows in both states (Astryx swaps each item's inner recipe on collapse, not its box). Trading a stable rail for a slightly airier collapsed one is a bad trade, and the spec now asserts state equality so that class of fix cannot come back.

Two consequences worth naming:

- Expanded rows gain the same 2px. That is the point — one rhythm across nav, history, and footer, not a state-dependent one.
- Both nav groups are now sections, so both bring the section's own `paddingBlock`, which the sticky zone shells already provide. The footer's existing `padding: 0` reset is extended to cover both; without it the two rail hairlines sit 9px and 13px from the rows they separate, which `sidebar-geometry.spec.ts` already fails on.

Net effect on the product layer: one CSS rule and one wrapper `div` removed, no new spacing number introduced.

**On the tooltip half of the report.** It does not reproduce. Hovering 扩展 in the collapsed rail puts the tooltip at `x 44–88, y 78–106` — to the right of the icon, inside its own row's vertical band, with the neighbours at 44–76 and 108–140. Astryx renders it `placement="end"`, so it never crosses rows. What was visible follows from the same zero gap: its top edge (78) sat 2px from the row boundary above (76), so it read as sitting on the seam. No tooltip code is touched.

Closes #1898.

## Verification

Every number above was measured against the built app driven through Playwright `_electron` with CDP, not inferred from source.

- E2E `sidebar-geometry` / `sidebar-navigation` / `window-titlebar` — 14/14
- desktop unit — 1339 pass, 0 fail
- `@maka/ui` unit — 241 pass, 0 fail
- `npm run lint` / `format:check` / `typecheck` — clean
- `node scripts/check-dead-css.mjs --check` — clean
- Not run: the rest of the E2E suite

The lock reads the rendered boxes in both states and compares them to each other before comparing them to values:

| assertion | why |
| --- | --- |
| collapsed reading `toEqual` expanded reading (heights, pitches, first row's `top`) | the icons must not move when the rail collapses — this is what the collapsed-only gap failed |
| 32px rows on a 34px pitch | the crowding the issue reports |

Rendered geometry only: which declaration produces the 2px is not something a box-rect test can tell apart, and reading `row-gap` off the section to find out bought a second measurement of the same distance plus a dependency on Astryx's internal child order.

Mutation-verified against the previous revision of this branch: the collapsed-only gap measures a 36px pitch collapsed against 32px expanded — the first icon holds at `top` 44 and the second and third land 4px and 8px lower on collapse — so it fails the equality assertion while passing every per-state check.


## Review

Reviewed by three independent passes (a subagent plus two external models), each of which re-ran the checks themselves rather than taking the description on trust. No P0-P2 findings from any of them. Three P3s were raised and all three are applied here: a stale comment in `session-list-panel.tsx` that said "Not a titled section" — which is precisely what this change makes it — a test helper placed between a comment block and the test it documents, and the redundant `row-gap` assertion described above.
