### PR TITLE
fix(desktop): focus onboarding on first-task activation

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -227,6 +227,7 @@ async function withE2eWindow(
 
 export const test = base.extend<{
   window: Page;
+  firstRunWindow: Page;
   modelPickerLongWindow: Page;
   longTranscriptWindow: Page;
   sidebarLongSessionsWindow: Page;
@@ -247,6 +248,19 @@ export const test = base.extend<{
   // Used by chat / session / settings / attachment specs.
   window: async ({}, use) => {
     await withE2eWindow({ seed: true, readinessSelector: COMPOSER_INPUT, locale: 'zh' }, use);
+  },
+  // No connection: the real main process derives `needs_connection`, and the
+  // renderer replaces the empty chat with the first-task activation card.
+  firstRunWindow: async ({}, use) => {
+    await withE2eWindow(
+      {
+        seed: false,
+        readinessSelector: '[data-maka-contract="onboarding-card"]',
+        e2eFixtureScenario: 'first-run',
+        locale: 'zh',
+      },
+      use,
+    );
   },
   modelPickerLongWindow: async ({}, use) => {
     await withE2eWindow(

--- a/apps/desktop/e2e/onboarding.spec.ts
+++ b/apps/desktop/e2e/onboarding.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from './fixtures';
+
+test('first run leads directly to the shared provider setup page', async ({ firstRunWindow: page }) => {
+  const onboarding = page.locator('[data-maka-contract="onboarding-card"]');
+
+  await expect(onboarding.getByRole('heading', { name: '接入一个 AI，开始第一项任务。' })).toBeVisible();
+  await expect(onboarding.locator('.maka-onboarding-provider-row')).toHaveCount(4);
+
+  await onboarding.locator('.maka-onboarding-provider-row[data-provider="opencode-free"]').click();
+
+  await expect(page.locator('[data-maka-contract="provider-setup"]')).toBeVisible();
+  await expect(page.getByLabel('设置内容')).toBeVisible();
+});

--- a/apps/desktop/e2e/onboarding.spec.ts
+++ b/apps/desktop/e2e/onboarding.spec.ts
@@ -1,6 +1,6 @@
-import { test, expect } from './fixtures';
+import { COMPOSER_INPUT, test, expect } from './fixtures';
 
-test('first run leads directly to the shared provider setup page', async ({ firstRunWindow: page }) => {
+test('first run connects a provider and starts the first task without workspace defaults', async ({ firstRunWindow: page }) => {
   const onboarding = page.locator('[data-maka-contract="onboarding-card"]');
 
   await expect(onboarding.getByRole('heading', { name: '接入一个 AI，开始第一项任务。' })).toBeVisible();
@@ -20,4 +20,54 @@ test('first run leads directly to the shared provider setup page', async ({ firs
 
   await expect(page.locator('[data-maka-contract="provider-setup"]')).toBeVisible();
   await expect(page.getByLabel('设置内容')).toBeVisible();
+
+  await page.getByRole('button', { name: '保存供应商', exact: true }).click();
+  await expect(page.locator('[data-maka-contract="connection-detail"]')).toBeVisible();
+
+  // The production migration is removing workspace defaults. Reproduce that
+  // boundary deterministically while preserving the provider's enabled model
+  // inventory: the old onboarding state machine gets stuck here even though a
+  // new session can name this connection and model explicitly.
+  await page.evaluate(async () => {
+    await window.maka.connections.update('opencode-free', { defaultModel: '' });
+  });
+  await expect
+    .poll(() =>
+      page.evaluate(async () => {
+        const connection = (await window.maka.connections.list()).find(
+          (candidate) => candidate.slug === 'opencode-free',
+        );
+        return {
+          defaultSlug: await window.maka.connections.getDefault(),
+          defaultModel: connection?.defaultModel,
+          enabledModelIds: connection?.enabledModelIds,
+        };
+      }),
+    )
+    .toEqual({
+      defaultSlug: null,
+      defaultModel: '',
+      enabledModelIds: ['big-pickle'],
+    });
+  await page.getByRole('button', { name: '返回应用', exact: true }).click();
+
+  await expect(onboarding).toHaveCount(0);
+  await expect(page.locator(COMPOSER_INPUT)).toBeVisible();
+  await expect(page.getByRole('button', { name: /选择新对话模型/ })).toHaveAccessibleName(
+    /Big Pickle/,
+  );
+
+  await page.locator(COMPOSER_INPUT).fill('完成首次任务');
+  await page.locator(COMPOSER_INPUT).press('Enter');
+  await expect
+    .poll(() =>
+      page.evaluate(async () => {
+        const sessions = await window.maka.sessions.list();
+        return sessions.map((session) => ({
+          connectionSlug: session.llmConnectionSlug,
+          model: session.model,
+        }));
+      }),
+    )
+    .toContainEqual({ connectionSlug: 'opencode-free', model: 'big-pickle' });
 });

--- a/apps/desktop/e2e/onboarding.spec.ts
+++ b/apps/desktop/e2e/onboarding.spec.ts
@@ -6,6 +6,16 @@ test('first run leads directly to the shared provider setup page', async ({ firs
   await expect(onboarding.getByRole('heading', { name: '接入一个 AI，开始第一项任务。' })).toBeVisible();
   await expect(onboarding.locator('.maka-onboarding-provider-row')).toHaveCount(4);
 
+  await page.setViewportSize({ width: 480, height: 900 });
+  const cardRect = await onboarding.boundingBox();
+  const layoutRect = await page.locator('[data-chat-scroll-container="true"]').boundingBox();
+  expect(cardRect).not.toBeNull();
+  expect(layoutRect).not.toBeNull();
+  expect(cardRect?.x).toBeGreaterThanOrEqual(layoutRect?.x ?? 0);
+  expect((cardRect?.x ?? 0) + (cardRect?.width ?? 0)).toBeLessThanOrEqual(
+    (layoutRect?.x ?? 0) + (layoutRect?.width ?? 0),
+  );
+
   await onboarding.locator('.maka-onboarding-provider-row[data-provider="opencode-free"]').click();
 
   await expect(page.locator('[data-maka-contract="provider-setup"]')).toBeVisible();

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -370,9 +370,9 @@ test('carries keyboard focus down and back up every level', async ({ window: pag
   // Every level takes focus to its own first control, so arriving anywhere
   // leaves the ring somewhere usable instead of on document.body.
   await expect(search).toBeFocused();
-  await search.fill('SiliconFlow');
+  await search.fill('OpenAI');
 
-  await page.getByRole('button', { name: /添加模型供应商：SiliconFlow/ }).focus();
+  await page.getByRole('button', { name: /添加模型供应商：OpenAI/ }).focus();
   await page.keyboard.press('Enter');
   await expect(page.getByRole('textbox', { name: /API Key/ })).toBeFocused();
 
@@ -380,7 +380,7 @@ test('carries keyboard focus down and back up every level', async ({ window: pag
   // it: the filter is browsing state held by the panel, so unmounting the
   // catalog does not throw it away.
   await page.getByRole('button', { name: '返回服务商列表', exact: true }).click();
-  await expect(search).toHaveValue('SiliconFlow');
+  await expect(search).toHaveValue('OpenAI');
   await expect(search).toBeFocused();
 
   await page.getByRole('button', { name: '返回模型连接', exact: true }).click();

--- a/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
@@ -66,7 +66,7 @@ function createActionsDeps() {
     showModelSetupToast: () => undefined,
     toastApi: { error: () => undefined, info: () => undefined },
     upsertSessionSummary: () => undefined,
-    validPendingNewChatModel: null,
+    newChatModel: null,
     pendingNewChatThinkingLevel: null,
     newChatCollaborationMode: 'agent' as const,
     newChatOrchestrationMode: 'default' as const,
@@ -75,6 +75,43 @@ function createActionsDeps() {
 }
 
 describe('composer first-send cleanup', () => {
+  it('passes the effective offered model when creating the first session', async () => {
+    let createInput: unknown;
+    const restoreWindow = installWindow({
+      sessions: {
+        create: async (input: unknown) => {
+          createInput = input;
+          return { id: 'session-1' };
+        },
+        send: async () => ({
+          ok: true,
+          attachments: [],
+          skillInvocation: { loaded: [], failed: [] },
+        }),
+        readMessages: async () => [],
+      },
+    });
+
+    try {
+      const deps = {
+        ...createActionsDeps(),
+        newChatModel: {
+          llmConnectionSlug: 'opencode-free',
+          model: 'mimo-v2.5-free',
+        },
+      };
+      assert.equal(await createAppShellChatActions(deps).send('hello'), true);
+    } finally {
+      restoreWindow();
+    }
+
+    assert.equal(
+      (createInput as { llmConnectionSlug?: unknown }).llmConnectionSlug,
+      'opencode-free',
+    );
+    assert.equal((createInput as { model?: unknown }).model, 'mimo-v2.5-free');
+  });
+
   it('forwards an explicit no-project selection when creating the first session', async () => {
     let createInput: unknown;
     const restoreWindow = installWindow({

--- a/apps/desktop/src/main/__tests__/astryx-component-behavior.test.ts
+++ b/apps/desktop/src/main/__tests__/astryx-component-behavior.test.ts
@@ -31,6 +31,11 @@ type RendererComponents = {
     onAddProvider(): void;
     onBrowseProviders(): void;
   }): ReactNode;
+  ProviderCatalogPage(props: {
+    filter: { query: string; category: 'recommended' };
+    onFilterChange(filter: { query: string; category: 'recommended' }): void;
+    onPick(): void;
+  }): ReactNode;
   ToastProvider(props: { children: ReactNode }): ReactNode;
   UsageSettingsPage(props: {
     settings: AppSettings;
@@ -138,6 +143,18 @@ describe('Astryx component behavior', () => {
     assert.doesNotMatch(markup, /配置 AI 进度|当前步骤|待完成/);
   });
 
+  it('keeps routine provider metadata out of badges', async () => {
+    const { LocaleProvider, ProviderCatalogPage } = await rendererComponents;
+    const markup = renderWithLocale(LocaleProvider, createElement(ProviderCatalogPage, {
+      filter: { query: '', category: 'recommended' },
+      onFilterChange: () => undefined,
+      onPick: () => undefined,
+    }));
+
+    assert.match(markup, /data-maka-contract="provider-catalog"/);
+    assert.doesNotMatch(markup, /astryx-badge/);
+  });
+
   it('opens WeChat advanced settings only when advanced values already exist', async () => {
     const { BotWeChatFields, LocaleProvider, ToastProvider } = await rendererComponents;
     const channel: BotChannelSettings = {
@@ -218,6 +235,7 @@ async function importRendererComponents(): Promise<RendererComponents> {
         "export { BotWeChatFields } from './apps/desktop/src/renderer/settings/bot-wechat-login.tsx';",
         "export { KeyboardHelpModal } from './apps/desktop/src/renderer/keyboard-help.tsx';",
         "export { OnboardingHero } from './apps/desktop/src/renderer/OnboardingHero.tsx';",
+        "export { ProviderCatalogPage } from './apps/desktop/src/renderer/settings/provider-catalog-page.tsx';",
         "export { UsageSettingsPage } from './apps/desktop/src/renderer/settings/usage-settings-page.tsx';",
         "export { LocaleProvider } from './packages/ui/dist/locale-context.js';",
         "export { ToastProvider } from './packages/ui/dist/toast.js';",

--- a/apps/desktop/src/main/__tests__/astryx-component-behavior.test.ts
+++ b/apps/desktop/src/main/__tests__/astryx-component-behavior.test.ts
@@ -107,6 +107,22 @@ describe('Astryx component behavior', () => {
     assert.equal(markup.match(/<li[^>]*data-provider=/g)?.length, 4);
   });
 
+  it('shows the product-recommended providers first during onboarding', async () => {
+    const { LocaleProvider, OnboardingHero } = await rendererComponents;
+    const markup = renderWithLocale(LocaleProvider, createElement(OnboardingHero, {
+      state: { kind: 'needs_connection' },
+      onOpenSettings: () => undefined,
+      onOpenConnectionDetail: () => undefined,
+      onAddProvider: () => undefined,
+      onBrowseProviders: () => undefined,
+    }));
+
+    const providerTypes = [...markup.matchAll(/<li[^>]*data-provider="([^"]+)"/g)].map(
+      (match) => match[1],
+    );
+    assert.deepEqual(providerTypes, ['opencode-free', 'opencode-go', 'openai', 'anthropic']);
+  });
+
   it('shows the current connection recovery without a progress checklist', async () => {
     const { LocaleProvider, OnboardingHero } = await rendererComponents;
     const markup = renderWithLocale(LocaleProvider, createElement(OnboardingHero, {

--- a/apps/desktop/src/main/__tests__/astryx-component-behavior.test.ts
+++ b/apps/desktop/src/main/__tests__/astryx-component-behavior.test.ts
@@ -27,6 +27,7 @@ type RendererComponents = {
   OnboardingHero(props: {
     state: OnboardingState;
     onOpenSettings(): void;
+    onOpenConnectionDetail(connectionSlug: string): void;
     onAddProvider(): void;
     onBrowseProviders(): void;
   }): ReactNode;
@@ -94,14 +95,31 @@ describe('Astryx component behavior', () => {
     const markup = renderWithLocale(LocaleProvider, createElement(OnboardingHero, {
       state: { kind: 'needs_connection' },
       onOpenSettings: () => undefined,
+      onOpenConnectionDetail: () => undefined,
       onAddProvider: () => undefined,
       onBrowseProviders: () => undefined,
     }));
 
     assert.match(
       markup,
-      /maka-firstrun-row[^>]*>[\s\S]*?<button type="button"[^>]*>[\s\S]*?OpenCode Zen[\s\S]*?<\/button>/,
+      /data-provider="opencode-free"[^>]*>[\s\S]*?<button type="button"[^>]*>[\s\S]*?OpenCode Zen[\s\S]*?<\/button>/,
     );
+    assert.equal(markup.match(/<li[^>]*data-provider=/g)?.length, 4);
+  });
+
+  it('shows the current connection recovery without a progress checklist', async () => {
+    const { LocaleProvider, OnboardingHero } = await rendererComponents;
+    const markup = renderWithLocale(LocaleProvider, createElement(OnboardingHero, {
+      state: { kind: 'needs_connection_credentials', connectionSlug: 'anthropic-live' },
+      onOpenSettings: () => undefined,
+      onOpenConnectionDetail: () => undefined,
+      onAddProvider: () => undefined,
+      onBrowseProviders: () => undefined,
+    }));
+
+    assert.match(markup, /data-maka-contract="onboarding-card"/);
+    assert.match(markup, /<button[^>]*data-connection-slug="anthropic-live"/);
+    assert.doesNotMatch(markup, /配置 AI 进度|当前步骤|待完成/);
   });
 
   it('opens WeChat advanced settings only when advanced values already exist', async () => {

--- a/apps/desktop/src/main/__tests__/chat-shell-layout-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-shell-layout-contract.test.ts
@@ -29,6 +29,14 @@ async function readCss(name: string): Promise<string> {
 }
 
 describe('chat shell layout contracts', () => {
+  it('renders the onboarding wordmark in the fixed Maka brand color', async () => {
+    const css = await readCss('onboarding.css');
+    const body = cssRuleBody(css, '.maka-onboarding-wordmark');
+    assert.ok(body != null, '.maka-onboarding-wordmark must exist');
+    assert.match(body!, /color:\s*var\(--maka-brand\)/);
+    assert.doesNotMatch(body!, /opacity\s*:/, 'the identity color must not be muted');
+  });
+
   /**
    * #1897 / #1910. The mode marks' entire visual contract lives in this one
    * rule, and nothing else can see it: the `@maka/ui` SSR tests never load a

--- a/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
+++ b/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
@@ -140,6 +140,23 @@ describe('model catalog picker helpers', () => {
     );
   });
 
+  it('offers the normalized fallback for legacy Codex-only inventory', async () => {
+    const { buildCatalogChatModelChoices } = await importModelCatalogChoices();
+    const choices = buildCatalogChatModelChoices([
+      connection({
+        slug: 'codex-account',
+        providerType: 'openai-codex',
+        defaultModel: 'gpt-5-codex',
+        enabledModelIds: ['gpt-5-codex'],
+        models: [{ id: 'gpt-5-codex' }],
+      }),
+    ]);
+
+    assert.deepEqual(choices.map(choiceIdentity), [
+      'codex-account:openai-codex:gpt-5.6-sol',
+    ]);
+  });
+
   it('projects enabled models across wired providers without collapsing provider identities', async () => {
     const { buildCatalogChatModelChoices, buildCatalogModelChoices } =
       await importModelCatalogChoices();

--- a/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
+++ b/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
@@ -21,6 +21,17 @@ type ModelCatalogChoicesModule = {
   pickCatalogDefaultChatModel(connection: LlmConnection):
     | { llmConnectionSlug: string; model: string }
     | undefined;
+  pickNewChatModel(input: {
+    pending: { llmConnectionSlug: string; model: string } | null;
+    activationCandidate?: { llmConnectionSlug: string; model: string };
+    catalogDefault: { llmConnectionSlug: string; model: string } | undefined;
+    choices: Array<{
+      connectionSlug: string;
+      providerType: LlmConnection['providerType'];
+      model: string;
+      label: string;
+    }>;
+  }): { llmConnectionSlug: string; model: string } | undefined;
   buildCatalogDailyReviewModelOptions(
     connections: readonly LlmConnection[],
     currentModelKey: string,
@@ -81,6 +92,54 @@ function choiceIdentity(choice: {
 }
 
 describe('model catalog picker helpers', () => {
+  it('uses the first offered model when no user or workspace preference exists', async () => {
+    const { pickNewChatModel } = await importModelCatalogChoices();
+    assert.deepEqual(
+      pickNewChatModel({
+        pending: null,
+        catalogDefault: undefined,
+        choices: [
+          {
+            connectionSlug: 'opencode-free',
+            providerType: 'opencode-free',
+            model: 'mimo-v2.5-free',
+            label: 'MiMo V2.5 Free',
+          },
+        ],
+      }),
+      { llmConnectionSlug: 'opencode-free', model: 'mimo-v2.5-free' },
+    );
+  });
+
+  it('uses the readiness-checked activation candidate before an unverified first choice', async () => {
+    const { pickNewChatModel } = await importModelCatalogChoices();
+    assert.deepEqual(
+      pickNewChatModel({
+        pending: null,
+        activationCandidate: {
+          llmConnectionSlug: 'ready-second',
+          model: 'ready-model',
+        },
+        catalogDefault: undefined,
+        choices: [
+          {
+            connectionSlug: 'missing-key-first',
+            providerType: 'anthropic',
+            model: 'unusable-model',
+            label: 'Unusable',
+          },
+          {
+            connectionSlug: 'ready-second',
+            providerType: 'opencode-free',
+            model: 'ready-model',
+            label: 'Ready',
+          },
+        ],
+      }),
+      { llmConnectionSlug: 'ready-second', model: 'ready-model' },
+    );
+  });
+
   it('projects enabled models across wired providers without collapsing provider identities', async () => {
     const { buildCatalogChatModelChoices, buildCatalogModelChoices } =
       await importModelCatalogChoices();

--- a/apps/desktop/src/main/__tests__/onboarding-hero-copy.test.ts
+++ b/apps/desktop/src/main/__tests__/onboarding-hero-copy.test.ts
@@ -5,23 +5,21 @@ import { getOnboardingHeroCopy } from '../../renderer/onboarding-hero-copy.js';
 import { getOnboardingCopy } from '../../renderer/locales/onboarding-copy.js';
 
 const configuredStates: OnboardingState[] = [
-  { kind: 'ready_empty', defaultConnectionSlug: 'a', defaultModel: 'm' },
-  { kind: 'ready_with_history', defaultConnectionSlug: 'a', defaultModel: 'm' },
+  { kind: 'ready_empty', connectionSlug: 'a', model: 'm' },
+  { kind: 'ready_with_history', connectionSlug: 'a', model: 'm' },
 ];
 
 describe('onboarding hero copy', () => {
   const onboardingStates: OnboardingState[] = [
     { kind: 'needs_connection' },
-    { kind: 'needs_default_connection' },
     { kind: 'needs_connection_credentials', connectionSlug: 'anthropic-live' },
-    { kind: 'needs_default_model', connectionSlug: 'openai-live' },
+    { kind: 'needs_model', connectionSlug: 'openai-live' },
     { kind: 'blocked', reason: 'all_connections_unhealthy' },
   ];
 
   it('maps each incomplete state to its shortest recovery destination', () => {
     const expectedTargets = [
       { kind: 'provider_catalog' },
-      { kind: 'models' },
       { kind: 'connection', connectionSlug: 'anthropic-live' },
       { kind: 'connection', connectionSlug: 'openai-live' },
       { kind: 'models' },
@@ -38,7 +36,7 @@ describe('onboarding hero copy', () => {
 
   it('keeps connection slugs as metadata instead of interpolating them into copy', () => {
     for (const state of onboardingStates) {
-      if (state.kind !== 'needs_connection_credentials' && state.kind !== 'needs_default_model') continue;
+      if (state.kind !== 'needs_connection_credentials' && state.kind !== 'needs_model') continue;
       for (const locale of ['zh', 'en'] as const) {
         const copy = getOnboardingHeroCopy(state, locale);
         assert.ok(copy);
@@ -50,10 +48,9 @@ describe('onboarding hero copy', () => {
 
   it('names the recovery action instead of the Settings container', () => {
     const labels = onboardingStates.map((state) => getOnboardingHeroCopy(state, 'zh')?.cta.label);
-    assert.match(labels[1] ?? '', /默认/);
-    assert.match(labels[2] ?? '', /凭据/);
-    assert.match(labels[3] ?? '', /模型/);
-    assert.match(labels[4] ?? '', /修复/);
+    assert.match(labels[1] ?? '', /凭据/);
+    assert.match(labels[2] ?? '', /模型/);
+    assert.match(labels[3] ?? '', /修复/);
     assert.equal(getOnboardingCopy('zh').skip, '跳过引导');
   });
 

--- a/apps/desktop/src/main/__tests__/onboarding-hero-copy.test.ts
+++ b/apps/desktop/src/main/__tests__/onboarding-hero-copy.test.ts
@@ -1,10 +1,8 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import type { OnboardingState } from '@maka/core';
-import {
-  getOnboardingHeroCopy,
-  getOnboardingSetupSteps,
-} from '../../renderer/onboarding-hero-copy.js';
+import { getOnboardingHeroCopy } from '../../renderer/onboarding-hero-copy.js';
+import { getOnboardingCopy } from '../../renderer/locales/onboarding-copy.js';
 
 const configuredStates: OnboardingState[] = [
   { kind: 'ready_empty', defaultConnectionSlug: 'a', defaultModel: 'm' },
@@ -20,12 +18,19 @@ describe('onboarding hero copy', () => {
     { kind: 'blocked', reason: 'all_connections_unhealthy' },
   ];
 
-  it('maps incomplete states to the models recovery flow', () => {
-    for (const state of onboardingStates) {
+  it('maps each incomplete state to its shortest recovery destination', () => {
+    const expectedTargets = [
+      { kind: 'provider_catalog' },
+      { kind: 'models' },
+      { kind: 'connection', connectionSlug: 'anthropic-live' },
+      { kind: 'connection', connectionSlug: 'openai-live' },
+      { kind: 'models' },
+    ];
+    for (const [index, state] of onboardingStates.entries()) {
       const copy = getOnboardingHeroCopy(state, 'zh');
       assert.ok(copy, state.kind);
       assert.equal(copy.kind, state.kind);
-      assert.equal(copy.cta.settingsSection, 'models');
+      assert.deepEqual(copy.cta.target, expectedTargets[index]);
       assert.match(`${copy.title}${copy.body}${copy.cta.label}`, /[一-鿿]/);
       assert.equal(copy.tone, state.kind === 'blocked' ? 'destructive' : undefined);
     }
@@ -43,10 +48,18 @@ describe('onboarding hero copy', () => {
     }
   });
 
-  it('does not render onboarding copy or steps for configured users', () => {
+  it('names the recovery action instead of the Settings container', () => {
+    const labels = onboardingStates.map((state) => getOnboardingHeroCopy(state, 'zh')?.cta.label);
+    assert.match(labels[1] ?? '', /默认/);
+    assert.match(labels[2] ?? '', /凭据/);
+    assert.match(labels[3] ?? '', /模型/);
+    assert.match(labels[4] ?? '', /修复/);
+    assert.equal(getOnboardingCopy('zh').skip, '跳过引导');
+  });
+
+  it('does not render onboarding copy for configured users', () => {
     for (const state of configuredStates) {
       assert.equal(getOnboardingHeroCopy(state, 'zh'), null);
-      assert.equal(getOnboardingSetupSteps(state, 'zh'), null);
     }
   });
 

--- a/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
+++ b/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
@@ -23,8 +23,8 @@ import type { OnboardingSnapshot } from '../../preload/bridge-contract.js';
 const READY_SNAPSHOT: OnboardingSnapshot = {
   state: {
     kind: 'ready_empty',
-    defaultConnectionSlug: 'a',
-    defaultModel: 'm',
+    connectionSlug: 'a',
+    model: 'm',
   } as OnboardingState,
   milestones: [],
   sessions: [],
@@ -253,15 +253,14 @@ describe('onboarding mounted snapshot handoff', () => {
 });
 
 describe('isSetupRequired', () => {
-  it('returns true for the four needs_* variants', () => {
+  it('returns true for the three needs_* variants', () => {
     for (const kind of [
       'needs_connection',
-      'needs_default_connection',
       'needs_connection_credentials',
-      'needs_default_model',
+      'needs_model',
     ] as const) {
       const state =
-        kind === 'needs_connection_credentials' || kind === 'needs_default_model'
+        kind === 'needs_connection_credentials' || kind === 'needs_model'
           ? ({ kind, connectionSlug: 'a' } as OnboardingState)
           : ({ kind } as OnboardingState);
       assert.equal(isSetupRequired(state), true, `${kind} should be setup-required`);
@@ -271,13 +270,13 @@ describe('isSetupRequired', () => {
   it('returns false for ready_empty / ready_with_history / blocked / undefined', () => {
     const ready: OnboardingState = {
       kind: 'ready_empty',
-      defaultConnectionSlug: 'a',
-      defaultModel: 'm',
+      connectionSlug: 'a',
+      model: 'm',
     };
     const withHistory: OnboardingState = {
       kind: 'ready_with_history',
-      defaultConnectionSlug: 'a',
-      defaultModel: 'm',
+      connectionSlug: 'a',
+      model: 'm',
     };
     const blocked: OnboardingState = { kind: 'blocked', reason: 'all_connections_unhealthy' };
     assert.equal(isSetupRequired(ready), false);

--- a/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
+++ b/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
@@ -43,7 +43,7 @@ const NEEDS_CONNECTION_SNAPSHOT: OnboardingSnapshot = {
 
 describe('getOnboardingActivationCandidate', () => {
   it('exposes the readiness-checked pair during an unsettled first activation', () => {
-    assert.deepEqual(getOnboardingActivationCandidate(READY_SNAPSHOT), {
+    assert.deepEqual(getOnboardingActivationCandidate(READY_SNAPSHOT, false), {
       llmConnectionSlug: 'a',
       model: 'm',
     });
@@ -51,22 +51,32 @@ describe('getOnboardingActivationCandidate', () => {
 
   it('does not influence ordinary new tasks after workspace history exists', () => {
     assert.equal(
-      getOnboardingActivationCandidate({
-        ...READY_SNAPSHOT,
-        state: { kind: 'ready_with_history', connectionSlug: 'a', model: 'm' },
-      }),
+      getOnboardingActivationCandidate(
+        {
+          ...READY_SNAPSHOT,
+          state: { kind: 'ready_with_history', connectionSlug: 'a', model: 'm' },
+        },
+        false,
+      ),
       undefined,
     );
   });
 
   it('does not influence the composer after onboarding is settled', () => {
     assert.equal(
-      getOnboardingActivationCandidate({
-        ...READY_SNAPSHOT,
-        milestones: [{ id: 'initial_onboarding', skippedAt: 1 }],
-      }),
+      getOnboardingActivationCandidate(
+        {
+          ...READY_SNAPSHOT,
+          milestones: [{ id: 'initial_onboarding', skippedAt: 1 }],
+        },
+        false,
+      ),
       undefined,
     );
+  });
+
+  it('does not trust a stale ready-empty snapshot after local history appears', () => {
+    assert.equal(getOnboardingActivationCandidate(READY_SNAPSHOT, true), undefined);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
+++ b/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
@@ -16,6 +16,7 @@ import {
   advanceOnboardingSnapshotState,
   createOnboardingSnapshotPoller,
   createOnboardingSnapshotState,
+  getOnboardingActivationCandidate,
   isSetupRequired,
 } from '../../renderer/use-onboarding-snapshot.js';
 import type { OnboardingSnapshot } from '../../preload/bridge-contract.js';
@@ -39,6 +40,35 @@ const NEEDS_CONNECTION_SNAPSHOT: OnboardingSnapshot = {
   connections: [],
   defaultSlug: null,
 };
+
+describe('getOnboardingActivationCandidate', () => {
+  it('exposes the readiness-checked pair during an unsettled first activation', () => {
+    assert.deepEqual(getOnboardingActivationCandidate(READY_SNAPSHOT), {
+      llmConnectionSlug: 'a',
+      model: 'm',
+    });
+  });
+
+  it('does not influence ordinary new tasks after workspace history exists', () => {
+    assert.equal(
+      getOnboardingActivationCandidate({
+        ...READY_SNAPSHOT,
+        state: { kind: 'ready_with_history', connectionSlug: 'a', model: 'm' },
+      }),
+      undefined,
+    );
+  });
+
+  it('does not influence the composer after onboarding is settled', () => {
+    assert.equal(
+      getOnboardingActivationCandidate({
+        ...READY_SNAPSHOT,
+        milestones: [{ id: 'initial_onboarding', skippedAt: 1 }],
+      }),
+      undefined,
+    );
+  });
+});
 
 describe('createOnboardingSnapshotPoller', () => {
   it('routes a successful getSnapshot to onSnapshot', async () => {

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -304,7 +304,7 @@ function OnboardingCard(props: {
 }) {
   const copy = getOnboardingCopy(useUiLocale());
   return (
-    <Center width="100%">
+    <Center width="100%" className="maka-onboarding-center">
       <VStack gap={4} hAlign="center" width="min(460px, 100%)" className="maka-onboarding">
         <MakaWordmark width={112} className="maka-onboarding-wordmark" />
         <Card

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -13,7 +13,7 @@ import {
   type SettingsSection,
 } from '@maka/core';
 import { Button, MakaWordmark, useUiLocale } from '@maka/ui';
-import { AlertCircle, ChevronRight, Cpu, KeyRound, Settings as SettingsIcon } from '@maka/ui/icons';
+import { AlertCircle, ChevronRight, Cpu, KeyRound } from '@maka/ui/icons';
 import {
   Banner,
   Card,
@@ -63,14 +63,6 @@ export function OnboardingHero(props: OnboardingHeroProps) {
           onSkip={props.onSkip}
         />
       );
-    case 'needs_default_connection':
-      return (
-        <RecoveryCard
-          state={state}
-          icon={<SettingsIcon size={14} aria-hidden="true" />}
-          {...recoveryCallbacks(props)}
-        />
-      );
     case 'needs_connection_credentials':
       return (
         <RecoveryCard
@@ -80,7 +72,7 @@ export function OnboardingHero(props: OnboardingHeroProps) {
           {...recoveryCallbacks(props)}
         />
       );
-    case 'needs_default_model':
+    case 'needs_model':
       return (
         <RecoveryCard
           state={state}
@@ -279,11 +271,9 @@ function activateTarget(
 
 function refreshLabel(state: RecoveryState, copy: ReturnType<typeof getOnboardingCopy>) {
   switch (state.kind) {
-    case 'needs_default_connection':
-      return copy.refresh.connection;
     case 'needs_connection_credentials':
       return copy.refresh.credentials;
-    case 'needs_default_model':
+    case 'needs_model':
       return copy.refresh.model;
     case 'blocked':
       return copy.refresh.blocked;

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -1,593 +1,351 @@
 // apps/desktop/src/renderer/OnboardingHero.tsx
 //
-// Setup hero rendered in place of the chat surface when the workspace
-// has no sessions yet AND the provider setup is incomplete (PR110c
-// rewrite). Routes purely off the `OnboardingState` projection from
-// `@maka/core/onboarding` — never re-derives provider readiness, never
-// lists connections directly.
-//
-// A configured user is not an onboarding case: `ready_empty` and
-// `ready_with_history` both render nothing here and land on the normal
-// empty chat with the one real Composer.
-//
-// @kenji + @xuan PR110c review gates:
-//   - Each `OnboardingState.kind` has an explicit branch with a
-//     diagnostic Chinese copy + Settings deep-link CTA. NO inline
-//     editors (credential entry / model picker live in Settings).
-//   - `blocked: all_connections_unhealthy` MUST have a labeled
-//     fallback branch — no generic `default` swallowing it.
-//   - `ready_with_history` MUST NOT render this hero (caller decides).
-//   - Raw `state.kind` strings MUST NOT appear in rendered text;
-//     copy is in Chinese with no enum identifier leakage.
-//   - For `needs_connection_credentials` / `needs_default_model`,
-//     `connectionSlug` is shown as a slug literal (no
-//     `connectionName` promise) until sanitized display data is
-//     wired in a later PR.
+// First-run recovery rendered in place of the empty chat while setup is
+// incomplete. The core state machine owns what is missing; this component
+// shows only the shortest next action. Provider configuration remains owned
+// by Settings, and a ready workspace returns to the ordinary Composer.
 
-import { ChevronRight, KeyRound, Settings as SettingsIcon, Cpu, AlertCircle } from '@maka/ui/icons';
-import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
-import { RECOMMENDED_PROVIDER_TYPES, type LlmConnection, type OnboardingState, type ProviderType, type SettingsSection } from '@maka/core';
 import {
-  Badge,
-  type BadgeVariant,
-  Button,
-  useMountedRef,
-  useUiLocale,
-} from '@maka/ui';
-import { Item } from '@astryxdesign/core/Item';
-import { ProviderLogo, providerDisplay } from './settings/provider-display';
-import { getOnboardingHeroCopy, getOnboardingSetupSteps, type OnboardingSetupStep, type OnboardingSetupStepState } from './onboarding-hero-copy';
+  RECOMMENDED_PROVIDER_TYPES,
+  type LlmConnection,
+  type OnboardingState,
+  type ProviderType,
+  type SettingsSection,
+} from '@maka/core';
+import { Button, MakaWordmark, useUiLocale } from '@maka/ui';
+import { AlertCircle, ChevronRight, Cpu, KeyRound, Settings as SettingsIcon } from '@maka/ui/icons';
+import {
+  Banner,
+  Card,
+  Center,
+  Code,
+  Heading,
+  HStack,
+  List,
+  ListItem,
+  Text,
+  VStack,
+} from '@astryxdesign/core';
+import type { ReactNode } from 'react';
 import { getOnboardingCopy } from './locales/onboarding-copy';
+import { getOnboardingHeroCopy, type OnboardingHeroCopy } from './onboarding-hero-copy';
+import { ProviderLogo, providerDisplay } from './settings/provider-display';
+
+const FIRST_RUN_PROVIDER_TYPES = RECOMMENDED_PROVIDER_TYPES.slice(0, 4);
 
 export interface OnboardingHeroProps {
   state: OnboardingState;
   /** Open Settings with a specific section preselected. */
   onOpenSettings: (section?: SettingsSection) => void;
-  /** Open Settings → 模型 with the create-connection dialog for this provider. */
+  /** Open the detail route for the connection that needs recovery. */
+  onOpenConnectionDetail: (connectionSlug: string) => void;
+  /** Open Settings → Models with setup focused on this provider. */
   onAddProvider: (providerType: ProviderType) => void;
   /** Open the shared Settings provider catalog. */
   onBrowseProviders: () => void;
-  /**
-   * PR-ONBOARDING-EARLY-COPY-0: current connection list so the
-   * credentials / model heroes can resolve a `connectionSlug` to a
-   * human-friendly name. Optional; falls back to slug if missing.
-   */
+  /** Resolve a state slug to a human-friendly label when possible. */
   connections?: ReadonlyArray<LlmConnection>;
-  /**
-   * PR-ONBOARDING-EARLY-COPY-0: refresh handler so env-bootstrap
-   * users who finished their setup outside the UI can re-query
-   * the snapshot without restarting. Optional.
-   */
+  /** Re-query setup state after an out-of-band configuration change. */
   onRefreshConnections?: () => Promise<void> | void;
-  /**
-   * Skip the initial onboarding and enter the app. Writes
-   * `initial_onboarding` milestone as `skipped`. Every branch this
-   * hero still renders is a setup branch, so the skip affordance is
-   * always meaningful.
-   */
+  /** Permanently skip the initial guide and enter the app. */
   onSkip?: () => Promise<void> | void;
 }
 
 export function OnboardingHero(props: OnboardingHeroProps) {
   const { state } = props;
-  const [refreshConnectionsPending, setRefreshConnectionsPending] = useState(false);
-  const onboardingMountedRef = useMountedRef();
-  const refreshConnectionsPendingRef = useRef(false);
-
-  useEffect(() => {
-    return () => {
-      refreshConnectionsPendingRef.current = false;
-    };
-  }, []);
-
-  const runRefreshConnections = useCallback(async () => {
-    if (!props.onRefreshConnections || refreshConnectionsPendingRef.current) return;
-    refreshConnectionsPendingRef.current = true;
-    setRefreshConnectionsPending(true);
-    try {
-      await props.onRefreshConnections();
-    } finally {
-      refreshConnectionsPendingRef.current = false;
-      if (onboardingMountedRef.current) setRefreshConnectionsPending(false);
-    }
-  }, [props.onRefreshConnections]);
-
   switch (state.kind) {
     case 'needs_connection':
       return (
-        <NeedsConnectionHero
+        <NeedsConnectionCard
           onAddProvider={props.onAddProvider}
           onBrowseProviders={props.onBrowseProviders}
-          onRefreshConnections={props.onRefreshConnections ? runRefreshConnections : undefined}
-          refreshConnectionsPending={refreshConnectionsPending}
+          onRefreshConnections={props.onRefreshConnections}
           onSkip={props.onSkip}
         />
       );
     case 'needs_default_connection':
       return (
-        <NeedsDefaultConnectionHero
-          onOpenSettings={props.onOpenSettings}
-          onRefreshConnections={props.onRefreshConnections ? runRefreshConnections : undefined}
-          refreshConnectionsPending={refreshConnectionsPending}
-          onSkip={props.onSkip}
+        <RecoveryCard
+          state={state}
+          icon={<SettingsIcon size={14} aria-hidden="true" />}
+          {...recoveryCallbacks(props)}
         />
       );
     case 'needs_connection_credentials':
       return (
-        <NeedsConnectionCredentialsHero
-          connectionSlug={state.connectionSlug}
-          connections={props.connections}
-          onOpenSettings={props.onOpenSettings}
-          onRefreshConnections={props.onRefreshConnections ? runRefreshConnections : undefined}
-          refreshConnectionsPending={refreshConnectionsPending}
-          onSkip={props.onSkip}
+        <RecoveryCard
+          state={state}
+          icon={<KeyRound size={14} aria-hidden="true" />}
+          connection={connectionLabel(state.connectionSlug, props.connections)}
+          {...recoveryCallbacks(props)}
         />
       );
     case 'needs_default_model':
       return (
-        <NeedsDefaultModelHero
-          connectionSlug={state.connectionSlug}
-          connections={props.connections}
-          onOpenSettings={props.onOpenSettings}
-          onRefreshConnections={props.onRefreshConnections ? runRefreshConnections : undefined}
-          refreshConnectionsPending={refreshConnectionsPending}
-          onSkip={props.onSkip}
+        <RecoveryCard
+          state={state}
+          icon={<Cpu size={14} aria-hidden="true" />}
+          connection={connectionLabel(state.connectionSlug, props.connections)}
+          {...recoveryCallbacks(props)}
+        />
+      );
+    case 'blocked':
+      acknowledgeBlockedReason(state.reason);
+      return (
+        <RecoveryCard
+          state={state}
+          icon={<AlertCircle size={14} aria-hidden="true" />}
+          {...recoveryCallbacks(props)}
         />
       );
     case 'ready_empty':
-      // A configured user with no sessions yet gets the daily empty
-      // chat — wordmark hero plus the one real Composer — not a
-      // first-run chat panel of its own. This branch used to render
-      // `ReadyEmptyHero`, a second composer that re-implemented the
-      // textarea, the `/` mention popup, Skill chips, file import and
-      // the IME composition guard, and drifted from the real one
-      // (`PR-FE-BUG-HUNT-0`: Enter committed an unfinished IME
-      // composition). The caller gates on this the same way it gates
-      // `ready_with_history`; rendering nothing here is the fallback.
-      return null;
-    case 'blocked':
-      // `blocked.reason` is `'all_connections_unhealthy'` in PR110a's
-      // closed enum; if a future PR extends it, this assignment will
-      // fail to compile (assertNever), forcing a labeled branch
-      // rather than a silent fallthrough.
-      return (
-        <BlockedHero
-          reason={state.reason}
-          onOpenSettings={props.onOpenSettings}
-          onRefreshConnections={props.onRefreshConnections ? runRefreshConnections : undefined}
-          refreshConnectionsPending={refreshConnectionsPending}
-          onSkip={props.onSkip}
-        />
-      );
     case 'ready_with_history':
-      // The renderer caller decides which hero to render; this
-      // component is only mounted when sessions.length === 0. Showing
-      // ready_with_history at all means the caller bypassed the gate
-      // — render nothing so the existing chat surface takes over.
       return null;
     default:
       return assertNever(state);
   }
 }
 
-/**
- * PR-ONBOARDING-EARLY-COPY-0: resolve a slug to its persisted
- * connection name. Falls back to the raw slug when the lookup misses
- * (e.g. snapshot raced ahead of the connection list refresh).
- */
+function recoveryCallbacks(props: OnboardingHeroProps) {
+  return {
+    onOpenSettings: props.onOpenSettings,
+    onOpenConnectionDetail: props.onOpenConnectionDetail,
+    onBrowseProviders: props.onBrowseProviders,
+    onRefreshConnections: props.onRefreshConnections,
+    onSkip: props.onSkip,
+  };
+}
+
 function connectionLabel(
   slug: string,
   connections?: ReadonlyArray<LlmConnection>,
 ): { name: string; isFallback: boolean } {
-  if (!connections) return { name: slug, isFallback: true };
-  const match = connections.find((c) => c.slug === slug);
-  if (!match || !match.name) return { name: slug, isFallback: true };
-  return { name: match.name, isFallback: false };
+  const match = connections?.find((connection) => connection.slug === slug);
+  return match?.name
+    ? { name: match.name, isFallback: false }
+    : { name: slug, isFallback: true };
 }
 
-function NeedsConnectionHero(props: {
+function NeedsConnectionCard(props: {
   onAddProvider: (providerType: ProviderType) => void;
   onBrowseProviders: () => void;
-  onRefreshConnections?: () => void;
-  refreshConnectionsPending?: boolean;
+  onRefreshConnections?: () => Promise<void> | void;
   onSkip?: () => Promise<void> | void;
 }) {
   const locale = useUiLocale();
   const copy = getOnboardingCopy(locale);
-  const hero = getOnboardingHeroCopy({ kind: 'needs_connection' }, locale)!;
-  const setupSteps = getOnboardingSetupSteps({ kind: 'needs_connection' }, locale);
+  const hero = getOnboardingHeroCopy({ kind: 'needs_connection' }, locale);
+  if (!hero) return null;
+
   return (
-    <section className="maka-onboarding maka-firstrun" aria-label={hero.eyebrow}>
-      {/* Selection-led layout: a big title sets the hierarchy, the three
-          setup steps compress to one quiet stepper line (context, not the
-          subject), and the provider list is the clear primary action. */}
-      <h1 className="maka-firstrun-title">{hero.title}</h1>
-      <p className="maka-firstrun-sub">{copy.needsConnection.subtitle}</p>
-
-      {setupSteps && <FirstRunStepper steps={setupSteps} />}
-
-      <div className="maka-firstrun-pick">
-        <span className="maka-firstrun-pick-label">{copy.needsConnection.pickLabel}</span>
-        <span className="maka-firstrun-pick-hint">{copy.needsConnection.pickHint}</span>
-      </div>
-
-      {/* The list scrolls vertically (CSS max-height) so it scales as more
-          providers are added without pushing the footer off-screen. */}
-      <div className="maka-firstrun-list">
-        <ul role="list">
-          {RECOMMENDED_PROVIDER_TYPES.map((type) => {
+    <OnboardingCard
+      label={hero.eyebrow}
+      eyebrow={hero.eyebrow}
+      title={hero.title}
+      body={hero.body}
+      onSkip={props.onSkip}
+    >
+      <VStack gap={3} width="100%" className="maka-onboarding-provider-group">
+        <Text weight="medium">{copy.needsConnection.pickLabel}</Text>
+        <List hasDividers density="balanced" className="maka-onboarding-provider-list">
+          {FIRST_RUN_PROVIDER_TYPES.map((type) => {
             const display = providerDisplay(type, locale);
             return (
-              <li key={type}>
-                <Item
-                  className="maka-firstrun-row"
-                  startContent={<ProviderLogo type={type} compact />}
-                  label={display.name}
-                  description={display.description}
-                  endContent={<ChevronRight size={16} aria-hidden="true" />}
-                  onClick={() => props.onAddProvider(type)}
-                />
-              </li>
+              <ListItem
+                key={type}
+                className="maka-onboarding-provider-row"
+                data-provider={type}
+                startContent={<ProviderLogo type={type} compact />}
+                label={display.name}
+                description={display.description}
+                endContent={<ChevronRight size={16} aria-hidden="true" />}
+                onClick={() => props.onAddProvider(type)}
+              />
             );
           })}
-        </ul>
-      </div>
-
-      {/* Designer audit P2-15: the footer's primary 打开设置·模型 button
-          duplicated what clicking any provider row above already does (the
-          list header even says 点一个进入设置). One affordance per action —
-          the footer keeps only genuinely distinct paths. */}
-      <footer
-        className="maka-onboarding-footer"
-        data-maka-contract="onboarding-actions"
-      >
-        <Button variant="secondary" onClick={props.onBrowseProviders} label={copy.needsConnection.browseProviders} />
-        {props.onRefreshConnections && (
+        </List>
+        <VStack gap={1.5} width="100%">
           <Button
             variant="secondary"
-            onClick={props.onRefreshConnections}
-            isDisabled={props.refreshConnectionsPending === true}
-            aria-busy={props.refreshConnectionsPending === true ? 'true' : undefined}
-            label={props.refreshConnectionsPending === true ? copy.refresh.pending : copy.refresh.connection}
+            size="lg"
+            width="100%"
+            onClick={props.onBrowseProviders}
+            label={copy.needsConnection.browseProviders}
           />
-        )}
-        {props.onSkip && <SkipButton onSkip={props.onSkip} />}
-      </footer>
-    </section>
+          {props.onRefreshConnections && (
+            <Button
+              variant="ghost"
+              width="100%"
+              clickAction={async () => props.onRefreshConnections?.()}
+              label={copy.refresh.connection}
+            />
+          )}
+        </VStack>
+      </VStack>
+    </OnboardingCard>
   );
 }
 
-/**
- * Compact "where you are" stepper for the first-run hero: numbered nodes
- * joined by connectors, the active step lit with the brand accent and the
- * rest outlined. Stays one quiet line so the provider list keeps the lead.
- */
-function FirstRunStepper({ steps }: { steps: readonly OnboardingSetupStep[] }) {
-  const copy = getOnboardingCopy(useUiLocale());
-  return (
-    <ol className="maka-firstrun-stepper" aria-label={copy.setupProgressLabel}>
-      {steps.map((step, index) => (
-        <Fragment key={`${step.label}-${index}`}>
-          {index > 0 && <li className="maka-firstrun-step-line" aria-hidden="true" />}
-          <li className="maka-firstrun-step" data-state={step.state}>
-            <span className="maka-firstrun-step-dot" aria-hidden="true">{index + 1}</span>
-            <span className="maka-firstrun-step-label">{step.label}</span>
-          </li>
-        </Fragment>
-      ))}
-    </ol>
-  );
-}
+type RecoveryState = Exclude<
+  OnboardingState,
+  { kind: 'needs_connection' | 'ready_empty' | 'ready_with_history' }
+>;
 
-function NeedsDefaultConnectionHero(props: {
+function RecoveryCard(props: {
+  state: RecoveryState;
+  icon: ReactNode;
+  connection?: { name: string; isFallback: boolean };
   onOpenSettings: (section?: SettingsSection) => void;
-  onRefreshConnections?: () => void;
-  refreshConnectionsPending?: boolean;
+  onOpenConnectionDetail: (connectionSlug: string) => void;
+  onBrowseProviders: () => void;
+  onRefreshConnections?: () => Promise<void> | void;
   onSkip?: () => Promise<void> | void;
 }) {
   const locale = useUiLocale();
   const copy = getOnboardingCopy(locale);
-  const hero = getOnboardingHeroCopy({ kind: 'needs_default_connection' }, locale)!;
-  return (
-    <SetupHero
-      icon={<SettingsIcon size={14} aria-hidden="true" />}
-      eyebrow={hero.eyebrow}
-      title={hero.title}
-      body={hero.body}
-      setupSteps={getOnboardingSetupSteps({ kind: 'needs_default_connection' }, locale)}
-      primaryCta={{ label: hero.cta.label, onClick: () => props.onOpenSettings(hero.cta.settingsSection) }}
-      secondaryCta={
-        props.onRefreshConnections
-          ? {
-            label: props.refreshConnectionsPending === true ? copy.refresh.pending : copy.refresh.connection,
-            onClick: props.onRefreshConnections,
-            disabled: props.refreshConnectionsPending === true,
-            busy: props.refreshConnectionsPending === true,
-          }
-          : undefined
-      }
-      onSkip={props.onSkip}
-    />
-  );
-}
+  const hero = getOnboardingHeroCopy(props.state, locale);
+  if (!hero) return null;
 
-function NeedsConnectionCredentialsHero(props: {
-  connectionSlug: string;
-  connections?: ReadonlyArray<LlmConnection>;
-  onOpenSettings: (section?: SettingsSection) => void;
-  onRefreshConnections?: () => void;
-  refreshConnectionsPending?: boolean;
-  onSkip?: () => Promise<void> | void;
-}) {
-  const locale = useUiLocale();
-  const copy = getOnboardingCopy(locale);
-  const state = { kind: 'needs_connection_credentials', connectionSlug: props.connectionSlug } as const;
-  const hero = getOnboardingHeroCopy(state, locale)!;
-  const { name, isFallback } = connectionLabel(props.connectionSlug, props.connections);
   return (
-    <SetupHero
-      icon={<KeyRound size={14} aria-hidden="true" />}
+    <OnboardingCard
+      label={hero.eyebrow}
       eyebrow={hero.eyebrow}
+      icon={props.icon}
       title={hero.title}
-      body={
+      body={(
         <>
-          {hero.body} {copy.connectionLabel}:{' '}
-          {isFallback ? (
-            <code className="maka-onboarding-slug">{name}</code>
-          ) : (
-            <strong>{name}</strong>
+          {hero.body}
+          {props.connection && (
+            <>
+              {' '}{copy.connectionLabel}:{' '}
+              {props.connection.isFallback ? (
+                <Code>{props.connection.name}</Code>
+              ) : (
+                <strong>{props.connection.name}</strong>
+              )}
+            </>
           )}
         </>
-      }
-      setupSteps={getOnboardingSetupSteps(state, locale)}
-      primaryCta={{ label: hero.cta.label, onClick: () => props.onOpenSettings(hero.cta.settingsSection) }}
-      secondaryCta={
-        props.onRefreshConnections
-          ? {
-            label: props.refreshConnectionsPending === true ? copy.refresh.pending : copy.refresh.credentials,
-            onClick: props.onRefreshConnections,
-            disabled: props.refreshConnectionsPending === true,
-            busy: props.refreshConnectionsPending === true,
-          }
-          : undefined
-      }
+      )}
+      tone={hero.tone}
       onSkip={props.onSkip}
-    />
-  );
-}
-
-function NeedsDefaultModelHero(props: {
-  connectionSlug: string;
-  connections?: ReadonlyArray<LlmConnection>;
-  onOpenSettings: (section?: SettingsSection) => void;
-  onRefreshConnections?: () => void;
-  refreshConnectionsPending?: boolean;
-  onSkip?: () => Promise<void> | void;
-}) {
-  const locale = useUiLocale();
-  const copy = getOnboardingCopy(locale);
-  const state = { kind: 'needs_default_model', connectionSlug: props.connectionSlug } as const;
-  const hero = getOnboardingHeroCopy(state, locale)!;
-  const { name, isFallback } = connectionLabel(props.connectionSlug, props.connections);
-  return (
-    <SetupHero
-      icon={<Cpu size={14} aria-hidden="true" />}
-      eyebrow={hero.eyebrow}
-      title={hero.title}
-      body={
-        <>
-          {hero.body} {copy.connectionLabel}:{' '}
-          {isFallback ? (
-            <code className="maka-onboarding-slug">{name}</code>
-          ) : (
-            <strong>{name}</strong>
-          )}
-        </>
-      }
-      setupSteps={getOnboardingSetupSteps(state, locale)}
-      primaryCta={{ label: hero.cta.label, onClick: () => props.onOpenSettings(hero.cta.settingsSection) }}
-      secondaryCta={
-        props.onRefreshConnections
-          ? {
-            label: props.refreshConnectionsPending === true ? copy.refresh.pending : copy.refresh.model,
-            onClick: props.onRefreshConnections,
-            disabled: props.refreshConnectionsPending === true,
-            busy: props.refreshConnectionsPending === true,
-          }
-          : undefined
-      }
-      onSkip={props.onSkip}
-    />
-  );
-}
-
-function BlockedHero(props: {
-  reason: 'all_connections_unhealthy';
-  onOpenSettings: (section?: SettingsSection) => void;
-  onRefreshConnections?: () => void;
-  refreshConnectionsPending?: boolean;
-  onSkip?: () => Promise<void> | void;
-}) {
-  // The reason is destructured to satisfy exhaustive type-checking;
-  // when PR-future extends the enum, this branch must update too.
-  void props.reason;
-  const locale = useUiLocale();
-  const copy = getOnboardingCopy(locale);
-  const state = { kind: 'blocked', reason: props.reason } as const;
-  const hero = getOnboardingHeroCopy(state, locale)!;
-  return (
-    <SetupHero
-      icon={<AlertCircle size={14} aria-hidden="true" />}
-      eyebrow={hero.eyebrow}
-      title={hero.title}
-      body={hero.body}
-      setupSteps={getOnboardingSetupSteps(state, locale)}
-      primaryCta={{ label: hero.cta.label, onClick: () => props.onOpenSettings(hero.cta.settingsSection) }}
-      secondaryCta={
-        props.onRefreshConnections
-          ? {
-            label: props.refreshConnectionsPending === true ? copy.refresh.pending : copy.refresh.blocked,
-            onClick: props.onRefreshConnections,
-            disabled: props.refreshConnectionsPending === true,
-            busy: props.refreshConnectionsPending === true,
-          }
-          : undefined
-      }
-      onSkip={props.onSkip}
-      // PR-UI-LAYOUT-25: 'destructive' (vs the previous 'warning') so
-      // the user sees "all connections unhealthy" at full gravity —
-      // distinct from "missing default model" or "needs reauth" which
-      // are recoverable yellow states.
-      tone="destructive"
-    />
-  );
-}
-
-function SkipButton(props: { onSkip: () => Promise<void> | void; label?: string }) {
-  const copy = getOnboardingCopy(useUiLocale());
-  const [pending, setPending] = useState(false);
-  const mountedRef = useMountedRef();
-  const onClick = useCallback(async () => {
-    if (pending) return;
-    setPending(true);
-    try {
-      await props.onSkip();
-    } finally {
-      if (mountedRef.current) setPending(false);
-    }
-  }, [pending, props]);
-  return (
-    <Button
-      variant="secondary"
-      onClick={onClick}
-      isDisabled={pending}
-      aria-busy={pending ? 'true' : undefined}
-      label={pending ? copy.skipping : (props.label ?? copy.skip)}
-    />
-  );
-}
-
-interface SetupHeroProps {
-  icon: React.ReactNode;
-  eyebrow: string;
-  title: string;
-  body: React.ReactNode;
-  setupSteps?: readonly OnboardingSetupStep[] | null;
-  primaryCta: { label: string; onClick: () => void };
-  /**
-   * PR-ONBOARDING-EARLY-COPY-0: optional ghost-style secondary action
-   * sitting next to the primary CTA. Used by the early-onboarding
-   * branches to expose a "已经配好了？刷新检测" affordance so a user
-   * with env-bootstrap connections is not stuck behind a stale
-   * snapshot. Hidden when not provided so existing call sites are
-   * unchanged.
-   */
-  secondaryCta?: { label: string; onClick: () => void; disabled?: boolean; busy?: boolean };
-  /**
-   * Optional skip affordance for the `needs_*` / `blocked` branches.
-   * Renders as a ghost button after the secondary CTA. Lets the user
-   * enter the app without configuring a provider.
-   */
-  onSkip?: () => Promise<void> | void;
-  /**
-   * PR-UI-LAYOUT-25 (@yuejing 2026-05-22): extended from `'warning'`
-   * only to also accept `'destructive'` so a blocked-state hero
-   * ("all_connections_unhealthy") reads with genuine gravity
-   * instead of "yellow warning". CSS rules for
-   * `.maka-onboarding-setup[data-tone="destructive"]` paint the
-   * eyebrow + headline in destructive tone.
-   */
-  tone?: 'warning' | 'destructive';
-}
-
-function SetupHero(props: SetupHeroProps) {
-  return (
-    <section
-      className="maka-onboarding maka-onboarding-setup"
-      data-tone={props.tone}
-      aria-label={props.eyebrow}
     >
-      <header>
-        <span className="maka-onboarding-eyebrow">
-          {props.icon}
-          <span>{props.eyebrow}</span>
-        </span>
-        <h1>{props.title}</h1>
-        <p>{props.body}</p>
-      </header>
-      {props.setupSteps && <SetupProgress steps={props.setupSteps} />}
-      <footer
-        className="maka-onboarding-footer"
-        data-maka-contract="onboarding-actions"
-      >
+      <VStack gap={1.5} width="100%" className="maka-onboarding-actions">
         <Button
           variant="primary"
-          onClick={props.primaryCta.onClick}
-          label={props.primaryCta.label}
+          size="lg"
+          width="100%"
+          data-connection-slug={hero.cta.target.kind === 'connection'
+            ? hero.cta.target.connectionSlug
+            : undefined}
+          onClick={() => activateTarget(hero.cta.target, props)}
+          label={hero.cta.label}
         />
-        {props.secondaryCta && (
+        {props.onRefreshConnections && (
           <Button
-            variant="secondary"
-            onClick={props.secondaryCta.onClick}
-            isDisabled={props.secondaryCta.disabled === true}
-            aria-busy={props.secondaryCta.busy === true ? 'true' : undefined}
-            label={props.secondaryCta.label}
+            variant="ghost"
+            width="100%"
+            clickAction={async () => props.onRefreshConnections?.()}
+            label={refreshLabel(props.state, copy)}
           />
         )}
-        {props.onSkip && <SkipButton onSkip={props.onSkip} />}
-      </footer>
-    </section>
+      </VStack>
+    </OnboardingCard>
   );
 }
 
-/* #1879: the per-step state pill is an Astryx `Badge`. `active` and `warning`
-   were the only two states product CSS ever tinted; the other two were the
-   untinted default, which is what `neutral` is.
-   Colour names rather than the semantic `info`/`error`: Astryx paints the
-   semantic archive as solid saturated fills and the colour archive as tints,
-   and these two states were a 12% wash. A solid red step in a setup checklist
-   reads as a failure; the state means "needs your attention". */
-const SETUP_STEP_VARIANT: Record<OnboardingSetupStepState, BadgeVariant> = {
-  done: 'neutral',
-  active: 'blue',
-  pending: 'neutral',
-  warning: 'red',
-};
+function activateTarget(
+  target: OnboardingHeroCopy['cta']['target'],
+  callbacks: {
+    onOpenSettings: (section?: SettingsSection) => void;
+    onOpenConnectionDetail: (connectionSlug: string) => void;
+    onBrowseProviders: () => void;
+  },
+) {
+  switch (target.kind) {
+    case 'provider_catalog':
+      callbacks.onBrowseProviders();
+      return;
+    case 'models':
+      callbacks.onOpenSettings('models');
+      return;
+    case 'connection':
+      callbacks.onOpenConnectionDetail(target.connectionSlug);
+      return;
+    default:
+      return assertNever(target);
+  }
+}
 
-function SetupProgress(props: { steps: readonly OnboardingSetupStep[] }) {
+function refreshLabel(state: RecoveryState, copy: ReturnType<typeof getOnboardingCopy>) {
+  switch (state.kind) {
+    case 'needs_default_connection':
+      return copy.refresh.connection;
+    case 'needs_connection_credentials':
+      return copy.refresh.credentials;
+    case 'needs_default_model':
+      return copy.refresh.model;
+    case 'blocked':
+      return copy.refresh.blocked;
+    default:
+      return assertNever(state);
+  }
+}
+
+function OnboardingCard(props: {
+  label: string;
+  eyebrow: string;
+  icon?: ReactNode;
+  title: string;
+  body: ReactNode;
+  tone?: 'destructive';
+  onSkip?: () => Promise<void> | void;
+  children: ReactNode;
+}) {
   const copy = getOnboardingCopy(useUiLocale());
   return (
-    <ol className="maka-onboarding-setup-steps" aria-label={copy.setupProgressLabel}>
-      {props.steps.map((step, index) => (
-        <li key={`${step.label}-${index}`} data-state={step.state}>
-          <span className="maka-onboarding-setup-step-marker" aria-hidden="true">
-            {index + 1}
-          </span>
-          <span className="maka-onboarding-setup-step-copy">
-            <strong>{step.label}</strong>
-            <small>{step.detail}</small>
-          </span>
-          <Badge
-            className="maka-onboarding-setup-step-state"
-            variant={SETUP_STEP_VARIANT[step.state]}
-            label={copy.setupStatus[step.state]}
+    <Center width="100%">
+      <VStack gap={4} hAlign="center" width="min(460px, 100%)" className="maka-onboarding">
+        <MakaWordmark width={112} className="maka-onboarding-wordmark" />
+        <Card
+          width="100%"
+          padding={6}
+          className="maka-onboarding-card"
+          data-maka-contract="onboarding-card"
+        >
+          <VStack as="section" gap={5} width="100%" aria-label={props.label}>
+            <VStack gap={2} width="100%" className="maka-onboarding-header">
+              {props.tone === 'destructive' ? (
+                <Banner status="error" title={props.eyebrow} />
+              ) : (
+                <HStack gap={1.5} vAlign="center">
+                  {props.icon}
+                  <Text type="supporting" color="secondary">{props.eyebrow}</Text>
+                </HStack>
+              )}
+              <Heading level={1}>{props.title}</Heading>
+              <Text color="secondary">{props.body}</Text>
+            </VStack>
+            {props.children}
+          </VStack>
+        </Card>
+        {props.onSkip && (
+          <Button
+            variant="ghost"
+            clickAction={async () => props.onSkip?.()}
+            label={copy.skip}
           />
-        </li>
-      ))}
-    </ol>
+        )}
+      </VStack>
+    </Center>
   );
 }
 
-/**
- * Exhaustive switch helper. If `OnboardingState` ever grows a new
- * variant without a matching `case`, this call site fails to compile
- * — preventing a silent fallthrough that would render no hero or a
- * generic placeholder for the missing state.
- */
-function assertNever(state: never): never {
-  // The runtime fallback should never execute. We still log a
-  // generalized error class (no raw `state.kind` leak) to surface the
-  // gap in dev builds without breaking the chat surface.
-  void state;
-  throw new Error('OnboardingHero: unexhausted OnboardingState variant');
+function assertNever(value: never): never {
+  void value;
+  throw new Error('OnboardingHero: unexhausted state');
+}
+
+function acknowledgeBlockedReason(reason: 'all_connections_unhealthy') {
+  void reason;
 }

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -146,7 +146,7 @@ export function createAppShellChatActions(deps: {
   showModelSetupToast: (description: string, reason?: string) => void;
   toastApi: ToastApi;
   upsertSessionSummary: (session: SessionSummary) => void;
-  validPendingNewChatModel: PendingNewChatModel;
+  newChatModel: PendingNewChatModel;
   pendingNewChatThinkingLevel: PendingNewChatThinkingLevel;
   newChatCollaborationMode: CollaborationMode;
   newChatOrchestrationMode: OrchestrationMode;
@@ -176,7 +176,7 @@ export function createAppShellChatActions(deps: {
     showModelSetupToast,
     toastApi,
     upsertSessionSummary,
-    validPendingNewChatModel,
+    newChatModel,
     pendingNewChatThinkingLevel,
     newChatCollaborationMode,
     newChatOrchestrationMode,
@@ -300,10 +300,10 @@ export function createAppShellChatActions(deps: {
           // Omit permissionMode so main.ts's sessions:create resolves the
           // configured chatDefaults.permissionMode as the single authority.
           name: DEFAULT_SESSION_NAME,
-          ...(validPendingNewChatModel
+          ...(newChatModel
             ? {
-                llmConnectionSlug: validPendingNewChatModel.llmConnectionSlug,
-                model: validPendingNewChatModel.model,
+                llmConnectionSlug: newChatModel.llmConnectionSlug,
+                model: newChatModel.model,
               }
             : {}),
           ...(pendingNewChatThinkingLevel ? { thinkingLevel: pendingNewChatThinkingLevel } : {}),

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -320,7 +320,10 @@ function AppShellContent({
   const onboarding = useOnboardingSnapshot(initialOnboardingSnapshot);
   const onboardingState = onboarding.snapshot?.state;
   const onboardingSettled = hasSettledInitialOnboarding(onboarding.snapshot?.milestones ?? []);
-  const onboardingActivationCandidate = getOnboardingActivationCandidate(onboarding.snapshot);
+  const onboardingActivationCandidate = getOnboardingActivationCandidate(
+    onboarding.snapshot,
+    sessions.length > 0,
+  );
   const {
     settingsOpen,
     settingsRequestedSection,

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2538,6 +2538,7 @@ function AppShellContent({
                   if (section) openSettingsSection(section);
                   else openSettings();
                 }}
+                onOpenConnectionDetail={openConnectionDetail}
                 onAddProvider={openProviderCreate}
                 onBrowseProviders={openProviderCatalog}
                 connections={connections}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -317,6 +317,16 @@ function AppShellContent({
     refreshConnections,
     handleConnectionEvent,
   } = useShellConnections({ toastApi, uiLocale });
+  const onboarding = useOnboardingSnapshot(initialOnboardingSnapshot);
+  const onboardingState = onboarding.snapshot?.state;
+  const onboardingSettled = hasSettledInitialOnboarding(onboarding.snapshot?.milestones ?? []);
+  const onboardingActivationCandidate =
+    onboardingState?.kind === 'ready_empty' || onboardingState?.kind === 'ready_with_history'
+      ? {
+          llmConnectionSlug: onboardingState.connectionSlug,
+          model: onboardingState.model,
+        }
+      : undefined;
   const {
     settingsOpen,
     settingsRequestedSection,
@@ -622,7 +632,6 @@ function AppShellContent({
     newChatModelLabel,
     newChatThinkingLevels,
     newChatThinkingLevel,
-    validPendingNewChatModel,
     setPendingNewChatModel,
     pendingNewChatThinkingLevel,
     setPendingNewChatThinkingLevel,
@@ -632,6 +641,7 @@ function AppShellContent({
     connections,
     connectionsRevision,
     defaultConnection,
+    activationCandidate: onboardingActivationCandidate,
     activeSession,
     // Only trust the loaded transcript once the active session's
     // messages finished loading; during the load the list may still be
@@ -1076,12 +1086,9 @@ function AppShellContent({
   // `sessions:changed` + `connections:event`. The hero renders only
   // when sessions.length === 0; any session (including archived /
   // aborted) takes over with the existing chat surface.
-  const onboarding = useOnboardingSnapshot(initialOnboardingSnapshot);
   // Re-entrancy lock only — a ref, not state, because nothing renders
   // from it (#1433 removed its last reader with the first-run hero).
   const sessionStartPendingRef = useRef(false);
-  const onboardingState = onboarding.snapshot?.state;
-  const onboardingSettled = hasSettledInitialOnboarding(onboarding.snapshot?.milestones ?? []);
   // Seed sessions from the onboarding snapshot on first load — the snapshot
   // already fetches the session list + connections internally, so separate
   // `sessions:list` / `connections:list` / `getDefault` IPCs are redundant.
@@ -1369,7 +1376,7 @@ function AppShellContent({
     showModelSetupToast,
     toastApi,
     upsertSessionSummary,
-    validPendingNewChatModel,
+    newChatModel: newChatModel ?? null,
     pendingNewChatThinkingLevel: newChatThinkingLevel ?? null,
     newChatCollaborationMode: newChatPlanModeActive ? 'plan' : 'agent',
     newChatOrchestrationMode: newChatGraphModeActive

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -72,7 +72,7 @@ import {
   usePlanModeState,
 } from './plan-mode-panel';
 import { McpPage } from './mcp-page';
-import { useOnboardingSnapshot } from './use-onboarding-snapshot';
+import { getOnboardingActivationCandidate, useOnboardingSnapshot } from './use-onboarding-snapshot';
 import type { AppUpdateStatus, OnboardingSnapshot } from '../preload/bridge-contract.js';
 import { ProviderLogo } from './settings/provider-display';
 import { ProviderBrandMark } from './settings/provider-brand-marks';
@@ -320,13 +320,7 @@ function AppShellContent({
   const onboarding = useOnboardingSnapshot(initialOnboardingSnapshot);
   const onboardingState = onboarding.snapshot?.state;
   const onboardingSettled = hasSettledInitialOnboarding(onboarding.snapshot?.milestones ?? []);
-  const onboardingActivationCandidate =
-    onboardingState?.kind === 'ready_empty' || onboardingState?.kind === 'ready_with_history'
-      ? {
-          llmConnectionSlug: onboardingState.connectionSlug,
-          model: onboardingState.model,
-        }
-      : undefined;
+  const onboardingActivationCandidate = getOnboardingActivationCandidate(onboarding.snapshot);
   const {
     settingsOpen,
     settingsRequestedSection,

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -31,6 +31,7 @@ interface ChatMessageSurfaceProps extends Omit<
   onboardingState: OnboardingState | undefined;
   isOnboardingLoading: boolean;
   onOpenSettings: (section?: SettingsSection) => void;
+  onOpenConnectionDetail: (connectionSlug: string) => void;
   onAddProvider: (providerType: ProviderType) => void;
   onBrowseProviders: () => void;
   connections: LlmConnection[];
@@ -44,6 +45,7 @@ export function ChatMessageSurface({
   onboardingState,
   isOnboardingLoading,
   onOpenSettings,
+  onOpenConnectionDetail,
   onAddProvider,
   onBrowseProviders,
   connections,
@@ -66,6 +68,7 @@ export function ChatMessageSurface({
         <OnboardingHero
           state={onboardingState}
           onOpenSettings={onOpenSettings}
+          onOpenConnectionDetail={onOpenConnectionDetail}
           onAddProvider={onAddProvider}
           onBrowseProviders={onBrowseProviders}
           connections={connections}

--- a/apps/desktop/src/renderer/locales/onboarding-copy.ts
+++ b/apps/desktop/src/renderer/locales/onboarding-copy.ts
@@ -35,23 +35,17 @@ const ONBOARDING_COPY_BY_LOCALE: UiCatalog<OnboardingCatalog> = {
         body: 'Maka 在本地运行，使用你自己的模型账号或 API key。先选一个常用服务商。',
         cta: { label: '浏览全部服务商' },
       },
-      needs_default_connection: {
-        eyebrow: '还差一步',
-        title: '选一个默认连接。',
-        body: 'Maka 需要知道新任务默认使用哪个已配置连接。',
-        cta: { label: '选择默认连接' },
-      },
       needs_connection_credentials: {
         eyebrow: '继续设置连接',
         title: '补齐这个连接的凭据。',
         body: '添加 API key 或完成账号登录，Maka 才能调用模型。',
         cta: { label: '配置连接凭据' },
       },
-      needs_default_model: {
+      needs_model: {
         eyebrow: '继续设置连接',
-        title: '为这个连接选择默认模型。',
-        body: '选择一个可用于对话的模型，新任务就可以开始了。',
-        cta: { label: '选择默认模型' },
+        title: '为这个连接启用一个可用模型。',
+        body: '启用一个可用于对话的模型，新任务就可以开始了。',
+        cta: { label: '选择可用模型' },
       },
       blocked: {
         eyebrow: '连接需要处理',
@@ -83,23 +77,17 @@ const ONBOARDING_COPY_BY_LOCALE: UiCatalog<OnboardingCatalog> = {
         body: 'Maka runs locally with your own model account or API key. Choose a common provider to continue.',
         cta: { label: 'Browse all providers' },
       },
-      needs_default_connection: {
-        eyebrow: 'One step left',
-        title: 'Choose a default connection.',
-        body: 'Maka needs to know which configured connection new tasks should use.',
-        cta: { label: 'Choose default connection' },
-      },
       needs_connection_credentials: {
         eyebrow: 'Continue connection setup',
         title: 'Add credentials for this connection.',
         body: 'Add an API key or finish account sign-in so Maka can call the model.',
         cta: { label: 'Configure credentials' },
       },
-      needs_default_model: {
+      needs_model: {
         eyebrow: 'Continue connection setup',
-        title: 'Choose a default model for this connection.',
-        body: 'Choose a conversation-capable model and your first task can begin.',
-        cta: { label: 'Choose default model' },
+        title: 'Enable an available model for this connection.',
+        body: 'Enable a conversation-capable model and your first task can begin.',
+        cta: { label: 'Choose an available model' },
       },
       blocked: {
         eyebrow: 'Connection needs attention',

--- a/apps/desktop/src/renderer/locales/onboarding-copy.ts
+++ b/apps/desktop/src/renderer/locales/onboarding-copy.ts
@@ -1,23 +1,21 @@
 import type { OnboardingState, UiCatalog, UiLocale } from '@maka/core';
-import type { OnboardingHeroCopy, OnboardingSetupStep } from '../onboarding-hero-copy.js';
+import type { OnboardingHeroCopy } from '../onboarding-hero-copy.js';
 
-// Setup states only. `ready_empty` and `ready_with_history` render no hero
-// (#1433): a configured user lands on the normal empty chat.
 type VisibleOnboardingKind = Exclude<OnboardingState['kind'], 'ready_with_history' | 'ready_empty'>;
+type LocalizedOnboardingHeroCopy = Omit<
+  OnboardingHeroCopy,
+  'kind' | 'connectionSlug' | 'cta'
+> & {
+  cta: Pick<OnboardingHeroCopy['cta'], 'label'>;
+};
 
 export interface OnboardingCatalog {
-  hero: Record<VisibleOnboardingKind, Omit<OnboardingHeroCopy, 'kind' | 'connectionSlug'>>;
-  setupSteps: Record<VisibleOnboardingKind, readonly OnboardingSetupStep[]>;
-  setupProgressLabel: string;
-  setupStatus: Record<OnboardingSetupStep['state'], string>;
+  hero: Record<VisibleOnboardingKind, LocalizedOnboardingHeroCopy>;
   needsConnection: {
-    subtitle: string;
     pickLabel: string;
-    pickHint: string;
     browseProviders: string;
   };
   refresh: {
-    pending: string;
     connection: string;
     credentials: string;
     model: string;
@@ -25,7 +23,6 @@ export interface OnboardingCatalog {
   };
   connectionLabel: string;
   skip: string;
-  skipping: string;
   snapshotErrorFallback: string;
 }
 
@@ -34,162 +31,96 @@ const ONBOARDING_COPY_BY_LOCALE: UiCatalog<OnboardingCatalog> = {
     hero: {
       needs_connection: {
         eyebrow: '欢迎使用 Maka',
-        title: '不只是聊天，搞定真事。',
-        body: '本地运行、走你自己的 API key、对每一步可见可控。点常见接入卡片进入「设置 · 模型」添加它的 key。',
-        cta: { label: '打开设置 · 模型', settingsSection: 'models' },
+        title: '接入一个 AI，开始第一项任务。',
+        body: 'Maka 在本地运行，使用你自己的模型账号或 API key。先选一个常用服务商。',
+        cta: { label: '浏览全部服务商' },
       },
       needs_default_connection: {
-        eyebrow: '选择默认模型连接',
-        title: '选一个连接作为默认。',
-        body: '你已经配置了至少一个模型连接，但还没设为默认。请到「设置 · 模型」挑一个作为默认连接，再开始对话。',
-        cta: { label: '打开设置 · 模型', settingsSection: 'models' },
+        eyebrow: '还差一步',
+        title: '选一个默认连接。',
+        body: 'Maka 需要知道新任务默认使用哪个已配置连接。',
+        cta: { label: '选择默认连接' },
       },
       needs_connection_credentials: {
-        eyebrow: '补齐凭据',
-        title: '为这个连接配置 API key。',
-        body: '默认连接等待填写 API key。请到「设置 · 模型」打开该连接，补齐密钥后再开始对话。',
-        cta: { label: '打开设置 · 模型', settingsSection: 'models' },
+        eyebrow: '继续设置连接',
+        title: '补齐这个连接的凭据。',
+        body: '添加 API key 或完成账号登录，Maka 才能调用模型。',
+        cta: { label: '配置连接凭据' },
       },
       needs_default_model: {
-        eyebrow: '选择默认模型',
-        title: '为这个连接选一个可用模型。',
-        body: '默认连接还没绑定可用模型。请到「设置 · 模型」给它选一个，再开始对话。',
-        cta: { label: '打开设置 · 模型', settingsSection: 'models' },
+        eyebrow: '继续设置连接',
+        title: '为这个连接选择默认模型。',
+        body: '选择一个可用于对话的模型，新任务就可以开始了。',
+        cta: { label: '选择默认模型' },
       },
       blocked: {
-        eyebrow: '等待恢复模型连接',
-        title: '当前没有通过验证的模型连接。',
-        body: '请到「设置 · 模型」查看每个连接的状态，重新测试或重新登录后再开始对话。',
-        cta: { label: '打开设置 · 模型', settingsSection: 'models' },
+        eyebrow: '连接需要处理',
+        title: '模型连接暂时不可用。',
+        body: '现有连接都没有通过验证。检查凭据、登录状态或网络后重新测试。',
+        cta: { label: '修复模型连接' },
         tone: 'destructive',
       },
     },
-    setupSteps: {
-      needs_connection: [
-        { label: '选择 AI 接入', detail: '从 Claude、OpenAI、GLM、本地 Ollama 等连接开始。', state: 'active' },
-        { label: '补齐认证', detail: '使用 API key 或已接入的 OAuth 登录，不写入聊天记录。', state: 'pending' },
-        { label: '测试并设默认', detail: '拉取模型、通过测试，再回到这里开始第一条对话。', state: 'pending' },
-      ],
-      needs_default_connection: [
-        { label: '已有可用连接', detail: '至少一个真实模型连接已经通过基础检查。', state: 'done' },
-        { label: '设为默认', detail: '选择新会话默认使用的连接，避免发送时猜测。', state: 'active' },
-        { label: '开始对话', detail: '默认连接生效后，这一屏会让位给下方的消息输入框。', state: 'pending' },
-      ],
-      needs_connection_credentials: [
-        { label: '连接已选定', detail: '默认连接已定位，接下来只处理认证。', state: 'done' },
-        { label: '补齐认证', detail: '填写 API key 或完成对应账号登录。', state: 'active' },
-        { label: '测试并设默认模型', detail: '测试通过后再选择可用于聊天的模型。', state: 'pending' },
-      ],
-      needs_default_model: [
-        { label: '认证已就绪', detail: '连接已经能访问供应商，下一步是模型选择。', state: 'done' },
-        { label: '选择聊天模型', detail: '从实时模型列表里选一个可发送对话的模型。', state: 'active' },
-        { label: '刷新检测', detail: '保存后回到这里刷新，Maka 会把这一屏换成消息输入框。', state: 'pending' },
-      ],
-      blocked: [
-        { label: '连接测试失败', detail: '现有真实连接都还不能稳定发送。', state: 'warning' },
-        { label: '修复认证或网络', detail: '重新登录、更新 key，或检查代理 / 供应商状态。', state: 'active' },
-        { label: '重新测试', detail: '测试通过后再继续首条对话。', state: 'pending' },
-      ],
-    },
-    setupProgressLabel: '配置 AI 进度',
-    setupStatus: { done: '已完成', active: '当前步骤', pending: '待完成', warning: '需要处理' },
     needsConnection: {
-      subtitle: '本地运行 · 自带 key · 每一步可见可控',
-      pickLabel: '选择你的 AI',
-      pickHint: '点一个进入设置，填它的 key',
+      pickLabel: '选择常用服务商',
       browseProviders: '浏览全部服务商',
     },
     refresh: {
-      pending: '刷新中…',
-      connection: '已经设好了？刷新检测',
-      credentials: '已经填好了？刷新检测',
-      model: '已经选好了？刷新检测',
-      blocked: '已经修好了？刷新检测',
+      connection: '重新检测连接',
+      credentials: '重新检测凭据',
+      model: '重新检测模型',
+      blocked: '重新检测连接',
     },
     connectionLabel: '连接',
-    skip: '跳过，先逛逛',
-    skipping: '跳过中…',
+    skip: '跳过引导',
     snapshotErrorFallback: '首次使用状态暂时不可用，请稍后重试。',
   },
   en: {
     hero: {
       needs_connection: {
         eyebrow: 'Welcome to Maka',
-        title: 'Go beyond chat. Get real work done.',
-        body: 'Run locally, bring your own API key, and keep every step visible and controllable. Choose a provider to add its key in Settings · Models.',
-        cta: { label: 'Open Settings · Models', settingsSection: 'models' },
+        title: 'Connect an AI and start your first task.',
+        body: 'Maka runs locally with your own model account or API key. Choose a common provider to continue.',
+        cta: { label: 'Browse all providers' },
       },
       needs_default_connection: {
-        eyebrow: 'Choose a default model connection',
-        title: 'Choose a connection as the default.',
-        body: 'At least one model connection is configured, but none is the default. Choose one in Settings · Models before starting a conversation.',
-        cta: { label: 'Open Settings · Models', settingsSection: 'models' },
+        eyebrow: 'One step left',
+        title: 'Choose a default connection.',
+        body: 'Maka needs to know which configured connection new tasks should use.',
+        cta: { label: 'Choose default connection' },
       },
       needs_connection_credentials: {
-        eyebrow: 'Add credentials',
-        title: 'This connection still needs an API key.',
-        body: 'The default connection has no usable credentials. Open it in Settings · Models and add its API key before starting a conversation.',
-        cta: { label: 'Open Settings · Models', settingsSection: 'models' },
+        eyebrow: 'Continue connection setup',
+        title: 'Add credentials for this connection.',
+        body: 'Add an API key or finish account sign-in so Maka can call the model.',
+        cta: { label: 'Configure credentials' },
       },
       needs_default_model: {
-        eyebrow: 'Choose a default model',
-        title: 'This connection has no default model.',
-        body: 'The connection is ready, but it has no model selected for conversations. Choose one in Settings · Models.',
-        cta: { label: 'Open Settings · Models', settingsSection: 'models' },
+        eyebrow: 'Continue connection setup',
+        title: 'Choose a default model for this connection.',
+        body: 'Choose a conversation-capable model and your first task can begin.',
+        cta: { label: 'Choose default model' },
       },
       blocked: {
-        eyebrow: 'Restore a model connection',
-        title: 'No model connection is currently verified.',
-        body: 'Open Settings · Models to inspect each connection, then retest or sign in again before starting a conversation.',
-        cta: { label: 'Open Settings · Models', settingsSection: 'models' },
+        eyebrow: 'Connection needs attention',
+        title: 'Model connections are temporarily unavailable.',
+        body: 'No existing connection passed verification. Check credentials, sign-in status, or network access, then test again.',
+        cta: { label: 'Fix model connections' },
         tone: 'destructive',
       },
     },
-    setupSteps: {
-      needs_connection: [
-        { label: 'Choose an AI provider', detail: 'Start with Claude, OpenAI, GLM, local Ollama, or another connection.', state: 'active' },
-        { label: 'Add authentication', detail: 'Use an API key or supported OAuth login. Credentials are not written to chat history.', state: 'pending' },
-        { label: 'Test and set default', detail: 'Load models, pass the connection test, then return for your first conversation.', state: 'pending' },
-      ],
-      needs_default_connection: [
-        { label: 'Connection available', detail: 'At least one real model connection passed its basic checks.', state: 'done' },
-        { label: 'Set as default', detail: 'Choose the connection new sessions use by default.', state: 'active' },
-        { label: 'Start a conversation', detail: 'Once saved, this screen gives way to the message input below.', state: 'pending' },
-      ],
-      needs_connection_credentials: [
-        { label: 'Connection selected', detail: 'The default connection is known; only authentication remains.', state: 'done' },
-        { label: 'Add authentication', detail: 'Enter an API key or finish the matching account login.', state: 'active' },
-        { label: 'Test and choose a model', detail: 'After the test passes, choose a model that can handle chat.', state: 'pending' },
-      ],
-      needs_default_model: [
-        { label: 'Authentication ready', detail: 'The provider is reachable; the next step is model selection.', state: 'done' },
-        { label: 'Choose a chat model', detail: 'Select a conversation-capable model from the live model list.', state: 'active' },
-        { label: 'Refresh status', detail: 'Save, return here, and Maka will swap this screen for the message input.', state: 'pending' },
-      ],
-      blocked: [
-        { label: 'Connection tests failed', detail: 'None of the configured connections can send reliably yet.', state: 'warning' },
-        { label: 'Fix authentication or network', detail: 'Sign in again, update the key, or check the proxy and provider status.', state: 'active' },
-        { label: 'Test again', detail: 'Continue to the first conversation after a test passes.', state: 'pending' },
-      ],
-    },
-    setupProgressLabel: 'AI setup progress',
-    setupStatus: { done: 'Completed', active: 'Current step', pending: 'Pending', warning: 'Needs attention' },
     needsConnection: {
-      subtitle: 'Local runtime · Your own key · Every step visible and controllable',
-      pickLabel: 'Choose your AI',
-      pickHint: 'Choose one to open Settings and add its key',
+      pickLabel: 'Choose a common provider',
       browseProviders: 'Browse all providers',
     },
     refresh: {
-      pending: 'Refreshing…',
-      connection: 'Already set it? Refresh status',
-      credentials: 'Already added it? Refresh status',
-      model: 'Already selected one? Refresh status',
-      blocked: 'Already fixed it? Refresh status',
+      connection: 'Check connections again',
+      credentials: 'Check credentials again',
+      model: 'Check models again',
+      blocked: 'Check connections again',
     },
     connectionLabel: 'Connection',
-    skip: 'Skip and explore',
-    skipping: 'Skipping…',
+    skip: 'Skip onboarding',
     snapshotErrorFallback: 'First-run status is temporarily unavailable. Try again later.',
   },
 };

--- a/apps/desktop/src/renderer/locales/settings-provider-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-provider-copy.ts
@@ -89,7 +89,7 @@ const zhCopy = {
   catalog: {
     unavailable: '未开放',
     wiredTitle: (name: string) => `${name}（请从账号连接登录）`,
-    unwiredTitle: (name: string) => `${name}（账号登录暂未接入聊天发送）`, cardAria: (name: string, badge: string | undefined, description: string) => `添加模型供应商：${name}${badge ? `，标签：${badge}` : ''}，${description}`,
+    unwiredTitle: (name: string) => `${name}（账号登录暂未接入聊天发送）`, cardAria: (name: string, description: string) => `添加模型供应商：${name}，${description}`,
   },
   add: {
     invalidSlug: '连接标识格式不正确', duplicateSlug: '连接标识已存在', cloudflareAccount: '请填写 Cloudflare Account ID', endpointRequired: '这个供应商需要填写服务地址',
@@ -114,7 +114,7 @@ const zhCopy = {
     logoutTitle: (name: string) => `退出 ${name} 登录？`,
   },
   oauthSection: {
-    available: '可用', signedIn: '已登录', claudeDescription: 'Claude Pro / Max 订阅账号登录。', codexDescription: 'ChatGPT Plus / Pro 订阅账号登录。', xaiDescription: 'SuperGrok / X Premium 账号登录。',
+    signedIn: '已登录', claudeDescription: 'Claude Pro / Max 订阅账号登录。', codexDescription: 'ChatGPT Plus / Pro 订阅账号登录。', xaiDescription: 'SuperGrok / X Premium 账号登录。',
     copilotDescription: '导入兼容 GitHub 凭据连接 Copilot 订阅。', serviceUnavailable: '登录服务暂时不可用，请检查网络后重试。',
     aria: 'OAuth 登录',
     staleState: 'OAuth 登录状态暂时没刷新成功，已保留上一次状态。', claudeSubtitle: '登录 Claude Pro / Max 后，会同步成模型连接。',
@@ -124,7 +124,7 @@ const zhCopy = {
     copilotSetup: '请配置具有 Copilot Requests 权限的 fine-grained PAT；普通 gh auth login 可能不包含该权限。', importing: '导入中…',
     reimport: '重新导入', importCredential: '导入兼容凭据', verifying: '验证中…', reverify: '重新验证', removing: '移除中…', removeLocal: '移除本地登录',
     loadingAccount: '正在加载账号状态…', authorizing: '请在弹出的浏览器窗口完成登录。', refreshing: '正在刷新访问令牌…', refreshTokenFailed: '令牌刷新失败，请重新登录。',
-    cardAria: (name: string, badge: string, description: string) => `打开 OAuth 登录：${name}，状态：${badge}，${description.replace(/[。.!！？?]+$/u, '')}`,
+    cardAria: (name: string, status: string | undefined, description: string) => `打开 OAuth 登录：${name}${status ? `，状态：${status}` : ''}，${description.replace(/[。.!！？?]+$/u, '')}`,
     connectTitle: (name: string) => `连接 ${name}`, login: (name: string) => `登录 ${name}`, signedOut: (name: string) => `${name} 尚未登录。`,
     storageFailed: (name: string) => `${name} 本地凭据读取失败，请重新登录。`, providerUnavailable: (name: string) => `${name} 已登录，但当前 provider 状态不可用。`,
   },
@@ -230,7 +230,7 @@ const enCopy: ProviderSettingsCopy = {
   catalog: {
     unavailable: 'Unavailable',
     wiredTitle: (name: string) => `${name} (sign in under account connections)`,
-    unwiredTitle: (name: string) => `${name} (account sign-in not connected to chat)`, cardAria: (name: string, badge: string | undefined, description: string) => `Add model provider: ${name}${badge ? `; badge: ${badge}` : ''}; ${description}`,
+    unwiredTitle: (name: string) => `${name} (account sign-in not connected to chat)`, cardAria: (name: string, description: string) => `Add model provider: ${name}; ${description}`,
   },
   add: {
     invalidSlug: 'The connection identifier format is invalid', duplicateSlug: 'Connection identifier already exists', cloudflareAccount: 'Enter the Cloudflare Account ID', endpointRequired: 'This provider requires a service URL',
@@ -255,7 +255,7 @@ const enCopy: ProviderSettingsCopy = {
     logoutTitle: (name: string) => `Sign out of ${name}?`,
   },
   oauthSection: {
-    available: 'Available', signedIn: 'Signed in', claudeDescription: 'Sign in with a Claude Pro / Max subscription.', codexDescription: 'Sign in with a ChatGPT Plus / Pro subscription.', xaiDescription: 'Sign in with SuperGrok or X Premium.',
+    signedIn: 'Signed in', claudeDescription: 'Sign in with a Claude Pro / Max subscription.', codexDescription: 'Sign in with a ChatGPT Plus / Pro subscription.', xaiDescription: 'Sign in with SuperGrok or X Premium.',
     copilotDescription: 'Import compatible GitHub credentials to connect a Copilot subscription.', serviceUnavailable: 'The sign-in service is temporarily unavailable. Check the network and try again.',
     aria: 'OAuth sign-in',
     staleState: 'OAuth sign-in status could not be refreshed. The last known state is preserved. ', claudeSubtitle: 'After Claude Pro / Max sign-in, the account is synchronized as a model connection.',
@@ -265,7 +265,7 @@ const enCopy: ProviderSettingsCopy = {
     copilotSetup: 'Configure a fine-grained PAT with Copilot Requests permission. A normal gh auth login may not include it.', importing: 'Importing…',
     reimport: 'Reimport', importCredential: 'Import compatible credentials', verifying: 'Verifying…', reverify: 'Verify again', removing: 'Removing…', removeLocal: 'Remove local sign-in',
     loadingAccount: 'Loading account status…', authorizing: 'Complete sign-in in the browser window.', refreshing: 'Refreshing access token…', refreshTokenFailed: 'Token refresh failed. Sign in again.',
-    cardAria: (name: string, badge: string, description: string) => `Open OAuth sign-in: ${name}; status: ${badge}; ${description.replace(/[。.!！？?]+$/u, '')}`,
+    cardAria: (name: string, status: string | undefined, description: string) => `Open OAuth sign-in: ${name}${status ? `; status: ${status}` : ''}; ${description.replace(/[。.!！？?]+$/u, '')}`,
     connectTitle: (name: string) => `Connect ${name}`, login: (name: string) => `Sign in to ${name}`, signedOut: (name: string) => `${name} is signed out.`,
     storageFailed: (name: string) => `Could not read local credentials for ${name}. Sign in again.`, providerUnavailable: (name: string) => `${name} is signed in, but the provider status is currently unavailable.`,
   },

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -110,7 +110,6 @@
   --link: var(--accent);
   --focus-ring: var(--accent);
   --status-running: var(--accent);
-  --nav-active: var(--accent);
   /* Cool info blue (h240, azure-family — see the blue-info alt themes at
      :773 nord h200 / :817 azure h240). Was amber h70, which collided with
      --warning's orange h55 (info + warning were indistinguishable). Blue is
@@ -771,7 +770,6 @@
   --link: var(--accent);
   --focus-ring: var(--accent);
   --status-running: var(--accent);
-  --nav-active: var(--accent);
   --info: oklch(0.74 0.13 240);         /* blue — see light-mode note */
   --success: oklch(0.60 0.17 145);
   --destructive: oklch(0.70 0.19 22);

--- a/apps/desktop/src/renderer/model-catalog-choices.ts
+++ b/apps/desktop/src/renderer/model-catalog-choices.ts
@@ -15,6 +15,39 @@ import { getShellRemainingCopy } from './locales/shell-remaining-copy.js';
 
 const DAILY_REVIEW_MODEL_KEY_SEPARATOR = '::';
 
+export function pickNewChatModel(input: {
+  pending: { llmConnectionSlug: string; model: string } | null;
+  activationCandidate?: { llmConnectionSlug: string; model: string };
+  catalogDefault: { llmConnectionSlug: string; model: string } | undefined;
+  choices: readonly ChatModelChoice[];
+}): { llmConnectionSlug: string; model: string } | undefined {
+  const pending =
+    input.pending &&
+    input.choices.some(
+      (choice) =>
+        choice.connectionSlug === input.pending?.llmConnectionSlug &&
+        choice.model === input.pending.model,
+    )
+      ? input.pending
+      : null;
+  if (pending) return pending;
+  const activationCandidate =
+    input.activationCandidate &&
+    input.choices.some(
+      (choice) =>
+        choice.connectionSlug === input.activationCandidate?.llmConnectionSlug &&
+        choice.model === input.activationCandidate.model,
+    )
+      ? input.activationCandidate
+      : undefined;
+  if (activationCandidate) return activationCandidate;
+  if (input.catalogDefault) return input.catalogDefault;
+  const first = input.choices[0];
+  return first
+    ? { llmConnectionSlug: first.connectionSlug, model: first.model }
+    : undefined;
+}
+
 export function buildCatalogRecommendedDefaultModel(providerType: ProviderType): string {
   const entry = selectableCatalogEntries({
     slug: providerType,

--- a/apps/desktop/src/renderer/model-catalog-choices.ts
+++ b/apps/desktop/src/renderer/model-catalog-choices.ts
@@ -4,6 +4,7 @@ import {
   buildConnectionModelCatalogEntries,
   connectionEnabledModelIds,
   isWiredOAuthProvider,
+  normalizeOpenAiCodexConnection,
   type LlmConnection,
   type ModelCatalogEntry,
   type ProviderType,
@@ -67,7 +68,8 @@ export function pickCatalogDefaultChatModel(connection: Pick<
 
 export function buildCatalogChatModelChoices(connections: readonly LlmConnection[]): ChatModelChoice[] {
   const choices: ChatModelChoice[] = [];
-  for (const connection of connections) {
+  for (const rawConnection of connections) {
+    const connection = normalizeOpenAiCodexConnection(rawConnection);
     if (!isModelConsumerConnection(connection)) continue;
     // Only non-OAuth connections get their user-chosen name surfaced in the
     // menu heading — see `ChatModelChoice.connectionName`. OAuth providers'

--- a/apps/desktop/src/renderer/onboarding-hero-copy.ts
+++ b/apps/desktop/src/renderer/onboarding-hero-copy.ts
@@ -37,12 +37,6 @@ export function getOnboardingHeroCopy(
         ...copy.hero.needs_connection,
         cta: { ...copy.hero.needs_connection.cta, target: { kind: 'provider_catalog' } },
       };
-    case 'needs_default_connection':
-      return {
-        kind: state.kind,
-        ...copy.hero.needs_default_connection,
-        cta: { ...copy.hero.needs_default_connection.cta, target: { kind: 'models' } },
-      };
     case 'needs_connection_credentials':
       return {
         kind: state.kind,
@@ -53,13 +47,13 @@ export function getOnboardingHeroCopy(
           target: { kind: 'connection', connectionSlug: state.connectionSlug },
         },
       };
-    case 'needs_default_model':
+    case 'needs_model':
       return {
         kind: state.kind,
-        ...copy.hero.needs_default_model,
+        ...copy.hero.needs_model,
         connectionSlug: state.connectionSlug,
         cta: {
-          ...copy.hero.needs_default_model.cta,
+          ...copy.hero.needs_model.cta,
           target: { kind: 'connection', connectionSlug: state.connectionSlug },
         },
       };

--- a/apps/desktop/src/renderer/onboarding-hero-copy.ts
+++ b/apps/desktop/src/renderer/onboarding-hero-copy.ts
@@ -1,117 +1,75 @@
-/**
- * Pure copy + CTA mapping for `OnboardingHero` (PR110c).
- *
- * Extracted so the per-`OnboardingState.kind` branches can be unit-
- * tested without JSX / React. The hero component consumes this
- * helper and renders the matching structure.
- *
- * @kenji + @xuan PR110c review gates:
- *   - Every `OnboardingState.kind` has an explicit branch — no
- *     generic default. `blocked: all_connections_unhealthy` MUST
- *     produce a labeled fallback.
- *   - Copy is Chinese; raw `state.kind` strings MUST NOT appear in
- *     `title`, `body`, `cta.label`, or `eyebrow`.
- *   - For `needs_connection_credentials` / `needs_default_model`,
- *     `connectionSlug` may appear in the body as a slug literal but
- *     `connectionName` / model list must NOT be promised until
- *     sanitized display data is wired in a later PR.
- *   - `ready_with_history` returns `null` — the caller MUST NOT
- *     mount the hero for that state (the existing chat surface
- *     takes over). Since #1433 `ready_empty` returns `null` for the
- *     same reason: a configured user with no sessions is not an
- *     onboarding case and lands on the normal empty chat.
- */
-
-import type { OnboardingState, SettingsSection, UiLocale } from '@maka/core';
+import type { OnboardingState, UiLocale } from '@maka/core';
 import { getOnboardingCopy } from './locales/onboarding-copy.js';
 
+export type OnboardingActionTarget =
+  | { kind: 'provider_catalog' }
+  | { kind: 'models' }
+  | { kind: 'connection'; connectionSlug: string };
+
 export interface OnboardingHeroCopy {
-  /** `OnboardingState.kind` echoed verbatim — useful for tests +
-   * tooling. Never rendered to the user. */
+  /** Echoed for tests and tooling; never rendered as user copy. */
   kind: OnboardingState['kind'];
   eyebrow: string;
   title: string;
-  /**
-   * Plain-text body. The actual hero component may render this with
-   * inline emphasis / `<code>` for the slug; the test surface uses
-   * the plain string.
-   */
   body: string;
-  /**
-   * Slug to highlight in the body, if any (rendered as `<code>` by
-   * the component). Currently only set for the two per-connection
-   * variants. PR110c does NOT promise a `connectionName` — only the
-   * raw slug literal.
-   */
   connectionSlug?: string;
   cta: {
     label: string;
-    settingsSection: SettingsSection;
+    target: OnboardingActionTarget;
   };
-  tone?: 'warning' | 'destructive';
+  tone?: 'destructive';
 }
 
-export type OnboardingSetupStepState = 'done' | 'active' | 'pending' | 'warning';
-
-export interface OnboardingSetupStep {
-  label: string;
-  detail: string;
-  state: OnboardingSetupStepState;
-}
-
-export function getOnboardingHeroCopy(state: OnboardingState, locale: UiLocale): OnboardingHeroCopy | null {
+/**
+ * The renderer view model for the one action that unblocks each onboarding
+ * state. Ready states deliberately return null so the ordinary empty chat or
+ * session history takes over.
+ */
+export function getOnboardingHeroCopy(
+  state: OnboardingState,
+  locale: UiLocale,
+): OnboardingHeroCopy | null {
   const copy = getOnboardingCopy(locale);
   switch (state.kind) {
     case 'needs_connection':
-      return { kind: state.kind, ...copy.hero.needs_connection };
+      return {
+        kind: state.kind,
+        ...copy.hero.needs_connection,
+        cta: { ...copy.hero.needs_connection.cta, target: { kind: 'provider_catalog' } },
+      };
     case 'needs_default_connection':
-      return { kind: state.kind, ...copy.hero.needs_default_connection };
+      return {
+        kind: state.kind,
+        ...copy.hero.needs_default_connection,
+        cta: { ...copy.hero.needs_default_connection.cta, target: { kind: 'models' } },
+      };
     case 'needs_connection_credentials':
       return {
         kind: state.kind,
         ...copy.hero.needs_connection_credentials,
         connectionSlug: state.connectionSlug,
+        cta: {
+          ...copy.hero.needs_connection_credentials.cta,
+          target: { kind: 'connection', connectionSlug: state.connectionSlug },
+        },
       };
     case 'needs_default_model':
       return {
         kind: state.kind,
         ...copy.hero.needs_default_model,
         connectionSlug: state.connectionSlug,
+        cta: {
+          ...copy.hero.needs_default_model.cta,
+          target: { kind: 'connection', connectionSlug: state.connectionSlug },
+        },
       };
     case 'blocked':
-      // `blocked.reason` is `'all_connections_unhealthy'` in PR110a's
-      // closed enum. The labeled branch keeps the assertion explicit
-      // — a future enum extension fails to compile rather than
-      // silently fallthrough.
-      void state.reason;
-      return { kind: state.kind, ...copy.hero.blocked };
-    case 'ready_empty':
-    case 'ready_with_history':
-      // The renderer caller decides which surface to mount; this
-      // helper returning `null` is the explicit "do not render"
-      // signal. The normal empty chat / session list takes over.
-      return null;
-    default:
-      return assertNever(state);
-  }
-}
-
-export function getOnboardingSetupSteps(
-  state: OnboardingState,
-  locale: UiLocale,
-): readonly OnboardingSetupStep[] | null {
-  const copy = getOnboardingCopy(locale);
-  switch (state.kind) {
-    case 'needs_connection':
-      return copy.setupSteps.needs_connection;
-    case 'needs_default_connection':
-      return copy.setupSteps.needs_default_connection;
-    case 'needs_connection_credentials':
-      return copy.setupSteps.needs_connection_credentials;
-    case 'needs_default_model':
-      return copy.setupSteps.needs_default_model;
-    case 'blocked':
-      return copy.setupSteps.blocked;
+      acknowledgeBlockedReason(state.reason);
+      return {
+        kind: state.kind,
+        ...copy.hero.blocked,
+        cta: { ...copy.hero.blocked.cta, target: { kind: 'models' } },
+      };
     case 'ready_empty':
     case 'ready_with_history':
       return null;
@@ -123,4 +81,8 @@ export function getOnboardingSetupSteps(
 function assertNever(state: never): never {
   void state;
   throw new Error('getOnboardingHeroCopy: unexhausted OnboardingState variant');
+}
+
+function acknowledgeBlockedReason(reason: 'all_connections_unhealthy') {
+  void reason;
 }

--- a/apps/desktop/src/renderer/settings/provider-catalog-page.tsx
+++ b/apps/desktop/src/renderer/settings/provider-catalog-page.tsx
@@ -1,8 +1,6 @@
 import {
-  Badge,
   Banner,
   EmptyState,
-  HStack,
   List,
   ListItem,
   Selector,
@@ -127,14 +125,9 @@ export function ProviderCatalogPage(props: {
               data-status="ready"
               data-logged-in={card.isLoggedIn ? 'true' : undefined}
               startContent={<ProviderLogo type={card.providerType} />}
-              label={<span aria-label={providerCopy.oauthSection.cardAria(card.name, card.badge, card.description)}>{card.name}</span>}
+              label={<span aria-label={providerCopy.oauthSection.cardAria(card.name, card.status, card.description)}>{card.name}</span>}
               description={card.description}
-              endContent={(
-                <HStack gap={2} vAlign="center">
-                  <Badge variant={card.isLoggedIn ? 'neutral' : 'info'} label={card.badge} />
-                  <ChevronRight size={15} aria-hidden="true" />
-                </HStack>
-              )}
+              endContent={<ChevronRight size={15} aria-hidden="true" />}
               onClick={() => props.onPick({
                 method: 'account',
                 cardId: card.id,
@@ -152,14 +145,9 @@ export function ProviderCatalogPage(props: {
                 data-provider={type}
                 data-status="ready"
                 startContent={<ProviderLogo type={type} />}
-                label={<span aria-label={catalogCopy.cardAria(display.name, display.badge, display.description)}>{display.name}</span>}
+                label={<span aria-label={catalogCopy.cardAria(display.name, display.description)}>{display.name}</span>}
                 description={display.description}
-                endContent={(
-                  <HStack gap={2} vAlign="center">
-                    {display.badge && <Badge variant="neutral" label={display.badge} />}
-                    <ChevronRight size={15} aria-hidden="true" />
-                  </HStack>
-                )}
+                endContent={<ChevronRight size={15} aria-hidden="true" />}
                 onClick={() => props.onPick({ method: 'credentials', providerType: type, name: display.name })}
               />
             );

--- a/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
+++ b/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
@@ -25,8 +25,8 @@ export interface OAuthCard {
   name: string;
   /** Account email once signed in, the static pitch otherwise. */
   description: string;
-  /** 已登录 once signed in, 可用 otherwise. */
-  badge: string;
+  /** A meaningful account state; routine availability stays in the description. */
+  status?: string;
   isLoggedIn: boolean;
 }
 
@@ -51,10 +51,10 @@ export function useOAuthCards(props: { query?: string }) {
   const mountedRef = useMountedRef();
   const refreshTicketRef = useRef(0);
   // PR-OAUTH-CARD-LIVE-STATE-0 (WAWQAQ msg d79fd115 follow-up): before this
-  // lift the cards stayed at the static "可用 / 预览" label even after the
-  // user finished the OAuth flow — there was no parent re-fetch. Each service
-  // now carries a runtimeState + email so its row can show "已登录" and the
-  // account email inline, re-fetched whenever a login step closes (success OR
+  // lift the cards stayed at their static catalog copy even after the user
+  // finished the OAuth flow — there was no parent re-fetch. Each service now
+  // carries a runtimeState + email so its row can show the account email inline,
+  // re-fetched whenever a login step closes (success OR
   // cancel — the user may have signed out from inside it).
   const [cardStates, setCardStates] = useState<Record<OAuthCardId, SubscriptionSnapshot | null>>({
     claude: null,
@@ -151,7 +151,7 @@ export function useOAuthCards(props: { query?: string }) {
         providerType: card.providerType,
         name: card.name,
         description: isLoggedIn && snapshot?.email ? snapshot.email : card.description,
-        badge: isLoggedIn ? copy.signedIn : card.statusLabel,
+        ...(isLoggedIn ? { status: copy.signedIn } : {}),
         isLoggedIn,
       };
     });
@@ -183,13 +183,12 @@ function modelOAuthCards(copy: ProviderSettingsCopy['oauthSection']): ReadonlyAr
   providerType: ProviderType;
   name: string;
   description: string;
-  statusLabel: string;
 }> {
   return [
-    { id: 'claude', providerType: 'claude-subscription', name: 'Claude Code', description: copy.claudeDescription, statusLabel: copy.available },
-    { id: 'codex', providerType: 'openai-codex', name: 'OpenAI Codex', description: copy.codexDescription, statusLabel: copy.available },
-    { id: 'github-copilot', providerType: 'github-copilot', name: 'GitHub Copilot', description: copy.copilotDescription, statusLabel: copy.available },
-    { id: 'xai', providerType: 'xai-oauth', name: 'xAI Grok', description: copy.xaiDescription, statusLabel: copy.available },
+    { id: 'claude', providerType: 'claude-subscription', name: 'Claude Code', description: copy.claudeDescription },
+    { id: 'codex', providerType: 'openai-codex', name: 'OpenAI Codex', description: copy.codexDescription },
+    { id: 'github-copilot', providerType: 'github-copilot', name: 'GitHub Copilot', description: copy.copilotDescription },
+    { id: 'xai', providerType: 'xai-oauth', name: 'xAI Grok', description: copy.xaiDescription },
   ];
 }
 

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -1,403 +1,46 @@
-/* Onboarding hero — first-run, no real connection configured. */
 .maka-onboarding {
-  width: min(var(--maka-chat-measure), 100%);
-  margin: auto;
-  padding: var(--space-3) var(--space-4) var(--space-4);
-  display: grid;
-  gap: var(--space-2-5);
+  min-width: 0;
+}
+
+.maka-onboarding-wordmark {
   color: var(--foreground);
+  opacity: var(--opacity-subtle);
 }
 
-/* PR-AUDIT-CLEANUP-BATCH-2 (WAWQAQ msg `01efbebb`): deleted unused
-   `@keyframes maka-agents-slide-up` and `@keyframes maka-agents-fade-in`.
-   Both were referenced only from rules that previous PRs removed
-   (PR-ONBOARDING-HERO-STAGGER-0 + PR-FRONTEND-AUDIT-CLEANUP-0 F1).
-   decorative entrance keyframes are retired by issue #406 gap 3. */
-
-.maka-onboarding header {
-  display: grid;
-  gap: var(--space-1);
-  justify-items: start;
-  text-align: left;
-}
-
-.maka-onboarding-eyebrow {
-  display: none;
-}
-
-.maka-onboarding header h1 {
-  font: var(--maka-text-heading-3);
-  margin: 0;
-  max-width: 32ch;
-  color: var(--foreground);
-  letter-spacing: var(--tracking-normal);
-}
-
-.maka-onboarding header p {
-  display: none;
-}
-
-/* ============================================================
-   First-run hero (needs_connection) — selection-led redesign.
-   Scoped via `.maka-firstrun` so the other onboarding hero states
-   (SetupHero) keep their existing layout. Title leads, the three
-   setup steps compress to one quiet stepper line, and the provider
-   list is the clear subject.
-   ============================================================ */
-.maka-firstrun {
-  width: min(600px, 100%);
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-/* PR-FIRSTRUN-FOLD-0: keep the primary CTA above the fold at the default
-   1280x800 window. Three stacked paddings (home-surface chatContent
-   clamp(72px,10vh,116px) + onboarding-stack clamp(40px,7vh,76px) + a 56vh
-   provider list) pushed the footer button below the viewport, so the very
-   first screen rendered a half-clipped CTA. First-run flattens the outer
-   padding stack; the other onboarding states keep their centered rhythm. */
-.mainColumn[data-home-surface="true"] .maka-chatContent:has(.maka-firstrun) {
-  padding-top: clamp(var(--space-6), 3.5vh, var(--space-10));
-  align-content: start;
-}
-
-.maka-onboarding-surface:has(.maka-firstrun) {
-  min-height: 0;
-  padding-top: clamp(var(--space-3), 2vh, var(--space-6));
-}
-
-/* PR-FRONTEND-AUDIT-CLEANUP-0 F1 (WAWQAQ msg `dde696a1`): the earlier
-   `maka-agents-fade-in var(--duration-base)` block + nth-child delay ladder was
-   completely overridden by the `maka-card-enter var(--duration-large)` block below,
-   plus that block's own delay ladder. The dead rules silently caused
-   any "polish" attempt on the upper block to look like a no-op. Deleted. */
-
-.maka-firstrun-title {
-  font: var(--maka-text-display-3);
-  margin: 0;
-  max-width: none;
-  letter-spacing: var(--tracking-normal);
-  color: var(--foreground);
-}
-
-.maka-firstrun-sub {
-  font: var(--maka-text-body);
-  margin: var(--space-2) 0 0;
-  color: var(--muted-foreground);
-}
-
-/* --- compact stepper (numbered nodes + connectors) --- */
-.maka-firstrun-stepper {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0;
-  margin: var(--space-6) 0 0;
-  padding: 0;
-  list-style: none;
-}
-
-/* #1879: measured 29px natural — its 21px dot, not its 20px line box, is what
-   decides that today, so the defect here is latent rather than live: bump the
-   leading past 21px and the line box takes over and the stepper grows. Pinned
-   to `--h-control-lg` (32px) because that is the smallest rung that clears the
-   29px floor; `md` (28px) would clip the dot by a pixel. Costs 3px of height
-   on the hero stepper, which is the price of the box no longer being decided
-   by whichever of two children happens to be tallest. */
-.maka-firstrun-step {
-  height: var(--h-control-lg);
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-1) var(--space-2-5) var(--space-1) var(--space-1-5);
-  border-radius: var(--radius-pill);
-}
-
-.maka-firstrun-step-dot {
-  font: var(--maka-text-heading-5);
-  display: inline-grid;
-  place-items: center;
-  width: 21px;
-  height: 21px;
-  border-radius: var(--radius-pill);
-  border: var(--border-width-hairline) solid var(--border-strong);
-  color: var(--muted-foreground);
-}
-
-.maka-firstrun-step-label {
-  font: var(--maka-text-body);
-  color: var(--muted-foreground);
-  white-space: nowrap;
-}
-
-.maka-firstrun-step[data-state="active"] {
-  background: oklch(from var(--nav-active) l c h / 0.12);
-}
-.maka-firstrun-step[data-state="active"] .maka-firstrun-step-dot {
-  background: var(--nav-active);
-  border-color: var(--nav-active);
-  color: var(--background);
-}
-.maka-firstrun-step[data-state="active"] .maka-firstrun-step-label {
-  font: var(--maka-text-heading-4);
-  color: var(--foreground);
-}
-
-.maka-firstrun-step[data-state="done"] .maka-firstrun-step-dot {
-  background: var(--foreground-8);
-  border-color: transparent;
-  color: var(--foreground-secondary);
-}
-
-.maka-firstrun-step[data-state="warning"] .maka-firstrun-step-dot {
-  border-color: var(--warning);
-  color: var(--warning-text);
-}
-
-.maka-firstrun-step-line {
-  width: 20px;
-  height: 1.5px;
-  flex: 0 0 auto;
-  margin: 0 var(--space-0-5);
-  border-radius: var(--radius-control);
-  background: var(--border-strong);
-}
-
-/* --- section label above the provider list --- */
-.maka-firstrun-pick {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-2-5);
-  margin: var(--space-8) 0 var(--space-3);
-}
-.maka-firstrun-pick-label {
-  font: var(--maka-text-heading-4);
-  color: var(--foreground);
-}
-.maka-firstrun-pick-hint {
-  font: var(--maka-text-body);
-  color: var(--muted-foreground);
-}
-
-/* --- provider list panel (scrolls vertically as the list grows) --- */
-.maka-firstrun-list {
-  border: var(--border-width-hairline) solid var(--border);
-  border-radius: var(--radius-surface);
+.maka-onboarding-card {
   overflow: hidden;
-  background: var(--background-elevated);
 }
 
-/* Designer audit P2-15: the height clamp cut the last visible provider row
-   in half with no cue that the list scrolls — it read as broken clipping.
-   A bottom fade signals "more below". The cue must retire at scroll end:
-   an always-on fade veils the last row and reads as broken dimming. The
-   fade therefore lives on the scroller itself as a sticky ::after, and a
-   scroll-state container query (Chromium 133+, Electron 43) drops it once
-   the list can no longer scroll down — including when the list fits and
-   never overflows. */
-.maka-firstrun-list ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  /* PR-FIRSTRUN-FOLD-0: 56vh let the list eat the CTA's room at short
-     windows. The clamp keeps all six compact rows visible at 800px-tall
-     windows while still bounding growth as more providers are added. */
-  max-height: clamp(240px, 42vh, 420px);
+.maka-onboarding-header h1 {
+  text-wrap: balance;
+}
+
+.maka-onboarding-header p {
+  text-wrap: pretty;
+}
+
+.maka-onboarding-provider-group,
+.maka-onboarding-actions {
+  min-width: 0;
+}
+
+.maka-onboarding-provider-list {
+  max-height: min(320px, 42vh);
   overflow-y: auto;
-  container-type: scroll-state;
-}
-.maka-firstrun-list ul::after {
-  content: "";
-  display: block;
-  /* Sticky pins the fade to the scrollport's bottom edge while more
-     content follows; margin-top pulls the last row back up under it so the
-     pseudo adds no scrollable height. pointer-events none keeps rows
-     clickable. */
-  position: sticky;
-  bottom: 0;
-  /* 56px: tall enough to fully veil a half-clipped row's text — at 28px the
-     cut row stayed half-legible under the fade and still read as broken.
-     margin-top derives from the same local var so the two never drift. */
-  --firstrun-fade-height: 56px;
-  height: var(--firstrun-fade-height);
-  margin-top: calc(-1 * var(--firstrun-fade-height));
-  border-radius: 0 0 var(--radius-surface) var(--radius-surface);
-  background: linear-gradient(to bottom, oklch(from var(--background-elevated) l c h / 0), var(--background-elevated));
-  pointer-events: none;
-  transition: opacity var(--duration-quick) var(--ease-out-strong);
-}
-@container not scroll-state(scrollable: bottom) {
-  .maka-firstrun-list ul::after {
-    opacity: 0;
-  }
-}
-.maka-firstrun-list li + li {
-  border-top: var(--border-width-hairline) solid var(--border);
+  overscroll-behavior: contain;
 }
 
-.maka-firstrun .maka-onboarding-footer {
-  margin-top: var(--space-6);
-}
-
-.maka-onboarding-footer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-2);
-}
-
-.maka-onboarding-setup-steps {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: var(--space-0-5);
-}
-
-.maka-onboarding-setup-steps > li {
-  min-width: 0;
-  display: grid;
-  grid-template-columns: 18px minmax(0, 1fr) max-content;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-1) var(--space-2);
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-}
-
-.maka-onboarding-setup-steps > li[data-state="active"] {
-  border-color: oklch(from var(--nav-active) l c h / 0.34);
-  background: oklch(from var(--nav-active) l c h / 0.06);
-}
-
-.maka-onboarding-setup-steps > li[data-state="warning"] {
-  border-color: oklch(from var(--destructive-text) l c h / 0.30);
-  background: oklch(from var(--destructive-text) l c h / 0.06);
-}
-
-.maka-onboarding-setup-steps > li[data-state="done"] {
-  border-color: oklch(from var(--success, var(--status-running)) l c h / 0.28);
-}
-
-.maka-onboarding-setup-step-marker {
-  font: var(--maka-text-heading-5);
-  width: 18px;
-  height: 18px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-pill);
-  background: var(--background-elevated);
-  color: var(--foreground-secondary);
-}
-
-.maka-onboarding-setup-steps > li[data-state="active"] .maka-onboarding-setup-step-marker {
-  background: var(--nav-active);
-  color: var(--control-foreground);
-}
-
-.maka-onboarding-setup-steps > li[data-state="warning"] .maka-onboarding-setup-step-marker {
-  background: var(--destructive-text);
-  color: var(--background);
-}
-
-.maka-onboarding-setup-step-copy {
-  min-width: 0;
-  display: grid;
-  gap: var(--space-0-5);
-}
-
-.maka-onboarding-setup-step-copy strong {
-  font: var(--maka-text-heading-5);
-  color: var(--foreground);
-}
-
-.maka-onboarding-setup-step-copy small {
-  font: var(--maka-text-supporting);
-  color: var(--foreground-secondary);
-}
-
-/* #1879: an Astryx `Badge` now — box, radius, padding, caption type and the
-   per-state colour all come from the component, so the two `[data-state]`
-   overrides that used to tint it are variants at the call site. Only its place
-   in the step grid is product layout. */
-.maka-onboarding-setup-step-state {
-  justify-self: end;
-}
-
-@media (max-width: 620px) {
-  .maka-onboarding-setup-steps > li {
-    grid-template-columns: 24px minmax(0, 1fr);
-  }
-
-  .maka-onboarding-setup-step-state {
-    grid-column: 2;
-    justify-self: start;
-  }
-}
-/* PR110c: extended OnboardingHero variants. The setup variants
-   reuse the base `.maka-onboarding` chrome but skip the provider
-   grid; we add a compact body + a single CTA.
-   PR-UI-LAYOUT-25: clearer tone treatment on the warm canvas.
-   - Headline color stays neutral for `setup` (default), shifts
-     warm/amber for `warning` (info family), shifts destructive
-     for `blocked` so a stranded user immediately sees gravity. */
-.maka-onboarding-setup header h1 {
-  font: var(--maka-text-heading-2);
-}
-/* No leading here on purpose: this paragraph declares no size either, so it
-   takes the body tier whole from `body` in maka-tokens.css. Naming the leading
-   without the size is the split this branch exists to end — it pins a ratio
-   that stops matching the moment anything above changes the size. */
-.maka-onboarding-setup header p {
-  margin-top: var(--space-2);
-  color: var(--foreground-secondary);
-}
-.maka-onboarding-setup[data-tone="warning"] header h1 {
-  color: var(--warning, var(--info-text));
-}
-.maka-onboarding-setup[data-tone="destructive"] header h1 {
-  color: var(--destructive-text);
-}
-
-/* PR-UI-LAYOUT-25: setup hero eyebrow icon picks up the tone for
- * each variant so the visual hierarchy reads (icon tone → headline
- * tone → body) instead of relying on copy alone. */
-.maka-onboarding-setup[data-tone="warning"] .maka-onboarding-eyebrow {
-  color: var(--info-text);
-}
-.maka-onboarding-setup[data-tone="destructive"] .maka-onboarding-eyebrow {
-  color: var(--destructive-text);
-}
-
-.maka-onboarding-slug {
-  font: var(--maka-text-code);
-  padding: var(--space-0-5) var(--space-1-5);
-  /* PR-UI-LAYOUT-25: slug radius 6 → 8 to join the form input
-   * family (same chrome as inline code badges). */
-  border-radius: var(--radius-surface);
-  background: var(--foreground-5, oklch(from var(--foreground) l c h / 0.06));
-  color: var(--foreground-secondary);
-}
-
-/* @kenji PR110c review: loading slot rendered while the first
-   onboarding snapshot resolves. Empty visual — just blocks the
-   default EmptyChatHero so the user doesn't see prompt suggestions
-   flash before the state-routed hero mounts. */
+/* The snapshot slot blocks the ordinary empty-chat hero while main resolves
+   onboarding state. Its shape previews the single card that will replace it. */
 .maka-onboarding-loading {
   position: relative;
-  width: min(620px, calc(100% - 48px));
-  min-height: 132px;
+  width: min(460px, calc(100% - 32px));
+  min-height: 196px;
   margin: auto;
   overflow: hidden;
   border: var(--border-width-hairline) solid var(--border-strong);
   border-radius: var(--radius-modal);
   background: var(--foreground-5);
-  box-shadow:
-    0 0 0 1px oklch(from var(--foreground) l c h / 0.03),
-    0 10px 24px oklch(from var(--foreground) l c h / 0.06);
 }
 
 .maka-onboarding-loading::before,
@@ -405,45 +48,38 @@
   content: "";
   position: absolute;
   left: 24px;
-  right: 24px;
   border-radius: var(--radius-pill);
-  background: linear-gradient(
-    90deg,
-    var(--foreground-8),
-    oklch(from var(--foreground) l c h / 0.16),
-    var(--foreground-8)
-  );
+  background: var(--foreground-8);
 }
 
 .maka-onboarding-loading::before {
-  top: 34px;
-  width: min(280px, calc(100% - 48px));
+  top: 32px;
+  width: min(240px, calc(100% - 48px));
   height: 16px;
 }
 
 .maka-onboarding-loading::after {
-  top: 66px;
-  width: min(460px, calc(100% - 48px));
+  top: 64px;
+  width: min(360px, calc(100% - 48px));
   height: 12px;
-  opacity: var(--opacity-muted);
 }
 
-/* Page-level frame for the setup hero. The hero card itself sizes to its
-   content; this owns the viewport rhythm around it. Relocated from
-   tool-stream.css — issue #546 PR1. */
 .maka-onboarding-surface {
   display: grid;
-  align-content: start;
-  justify-items: center;
+  place-items: center;
   width: 100%;
   min-height: calc(100dvh - 84px);
-  padding: clamp(var(--space-10), 7vh, 76px) var(--space-6) var(--space-12);
+  padding: var(--space-8) var(--space-6);
 }
 
-.maka-firstrun-row { padding: 8px 14px; }
-
-@media (max-width: 760px) {
+@media (max-width: 560px) {
   .maka-onboarding-surface {
-    padding: var(--space-6) var(--space-4) var(--space-8);
+    padding: var(--space-6) var(--space-4);
+  }
+}
+
+@media (max-height: 720px) {
+  .maka-onboarding-surface {
+    align-items: start;
   }
 }

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -3,8 +3,7 @@
 }
 
 .maka-onboarding-wordmark {
-  color: var(--foreground);
-  opacity: var(--opacity-subtle);
+  color: var(--maka-brand);
 }
 
 .maka-onboarding-card {

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -2,6 +2,10 @@
   min-width: 0;
 }
 
+.maka-onboarding-center {
+  min-width: 0;
+}
+
 .maka-onboarding-wordmark {
   color: var(--maka-brand);
 }

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -29,6 +29,14 @@
   overscroll-behavior: contain;
 }
 
+/* ChatLayout always paints its frosted composer dock, even when the Composer
+   itself is hidden. Onboarding owns the whole empty surface, so that dock has
+   no content to support and would blur the card actions behind it. Derive the
+   opt-out from the mounted surface instead of duplicating onboarding state. */
+.maka-chat-layout:has(.maka-onboarding-surface) > :last-child {
+  display: none;
+}
+
 /* The snapshot slot blocks the ordinary empty-chat hero while main resolves
    onboarding state. Its shape previews the single card that will replace it. */
 .maka-onboarding-loading {

--- a/apps/desktop/src/renderer/use-onboarding-snapshot.ts
+++ b/apps/desktop/src/renderer/use-onboarding-snapshot.ts
@@ -64,9 +64,11 @@ export interface OnboardingSnapshotState {
  */
 export function getOnboardingActivationCandidate(
   snapshot: Pick<OnboardingSnapshot, 'state' | 'milestones'> | null,
+  hasWorkspaceHistory: boolean,
 ): { llmConnectionSlug: string; model: string } | undefined {
   if (
     snapshot?.state.kind !== 'ready_empty' ||
+    hasWorkspaceHistory ||
     hasSettledInitialOnboarding(snapshot.milestones)
   ) {
     return undefined;

--- a/apps/desktop/src/renderer/use-onboarding-snapshot.ts
+++ b/apps/desktop/src/renderer/use-onboarding-snapshot.ts
@@ -14,7 +14,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { generalizedErrorMessage, generalizedErrorMessageChinese, type LlmConnection, type OnboardingState, type SessionSummary, type UiLocale } from '@maka/core';
+import { generalizedErrorMessage, generalizedErrorMessageChinese, hasSettledInitialOnboarding, type LlmConnection, type OnboardingState, type SessionSummary, type UiLocale } from '@maka/core';
 import { useUiLocale } from '@maka/ui';
 import type { OnboardingSnapshot } from '../preload/bridge-contract.js';
 import { getOnboardingCopy } from './locales/onboarding-copy.js';
@@ -55,6 +55,26 @@ export interface UseOnboardingSnapshotDeps {
 export interface OnboardingSnapshotState {
   snapshot: OnboardingSnapshot | null;
   mountedSnapshotHandoff: OnboardingSnapshot | null;
+}
+
+/**
+ * The core readiness pair may seed only the unfinished first task. Once the
+ * guide is settled or workspace history exists, normal Composer preference
+ * rules own new-task selection again.
+ */
+export function getOnboardingActivationCandidate(
+  snapshot: Pick<OnboardingSnapshot, 'state' | 'milestones'> | null,
+): { llmConnectionSlug: string; model: string } | undefined {
+  if (
+    snapshot?.state.kind !== 'ready_empty' ||
+    hasSettledInitialOnboarding(snapshot.milestones)
+  ) {
+    return undefined;
+  }
+  return {
+    llmConnectionSlug: snapshot.state.connectionSlug,
+    model: snapshot.state.model,
+  };
 }
 
 export function createOnboardingSnapshotState(initialSnapshot: OnboardingSnapshot | null): OnboardingSnapshotState {

--- a/apps/desktop/src/renderer/use-onboarding-snapshot.ts
+++ b/apps/desktop/src/renderer/use-onboarding-snapshot.ts
@@ -255,8 +255,7 @@ export function isSetupRequired(state: OnboardingState | undefined): boolean {
   if (!state) return false;
   return (
     state.kind === 'needs_connection' ||
-    state.kind === 'needs_default_connection' ||
     state.kind === 'needs_connection_credentials' ||
-    state.kind === 'needs_default_model'
+    state.kind === 'needs_model'
   );
 }

--- a/apps/desktop/src/renderer/use-shell-chat-model.ts
+++ b/apps/desktop/src/renderer/use-shell-chat-model.ts
@@ -3,12 +3,12 @@ import type { LlmConnection, SessionSummary, SettingsSection, ThinkingLevel, UiL
 import { thinkingVariantsForModel } from '@maka/core';
 import type { ChatModelChoice } from '@maka/ui';
 import { deriveSessionHealthNotice } from './session-health-notice';
-import { pickCatalogDefaultChatModel } from './model-catalog-choices';
+import { pickCatalogDefaultChatModel, pickNewChatModel } from './model-catalog-choices';
 import { buildChatModelChoices, chatModelChoiceLabel, normalizeActiveChatModel } from './chat-model-selection';
 import type { ComposerDefaults } from './composer-defaults';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
 
-type NewChatModel = { llmConnectionSlug: string; model: string };
+export type NewChatModel = { llmConnectionSlug: string; model: string };
 
 export type SessionHealthNoticeView = {
   tone: 'info' | 'warning' | 'destructive';
@@ -45,6 +45,7 @@ export function useShellChatModel(options: {
    */
   connectionsRevision: number;
   defaultConnection: string | null;
+  activationCandidate?: NewChatModel;
   activeSession: SessionSummary | undefined;
   /**
    * True when the active session's loaded transcript already contains a
@@ -69,14 +70,13 @@ export function useShellChatModel(options: {
   newChatModelLabel: string | undefined;
   newChatThinkingLevels: readonly ThinkingLevel[];
   newChatThinkingLevel: ThinkingLevel | undefined;
-  validPendingNewChatModel: NewChatModel | null;
   pendingNewChatModel: NewChatModel | null;
   setPendingNewChatModel: (next: NewChatModel | null) => void;
   pendingNewChatThinkingLevel: ThinkingLevel | null;
   setPendingNewChatThinkingLevel: (next: ThinkingLevel | null) => void;
   sessionHealthNotice: SessionHealthNoticeView | undefined;
 } {
-  const { uiLocale, connections, connectionsRevision, defaultConnection, activeSession, activeSessionHasUserMessage, persistedComposerDefaults, openSettingsSection } = options;
+  const { uiLocale, connections, connectionsRevision, defaultConnection, activationCandidate, activeSession, activeSessionHasUserMessage, persistedComposerDefaults, openSettingsSection } = options;
   const conversationCopy = getDesktopConversationCopy(uiLocale);
   // Persisted composer defaults seed the empty-state model so the home view is
   // populated before the async `app:info` round-trip completes on mount.
@@ -94,24 +94,22 @@ export function useShellChatModel(options: {
     [connections],
   );
   // Home / empty-state composer: which model the next NEW chat starts with.
-  // Null = follow the default connection; a pick overrides it (sticky until
-  // changed) and is forwarded to sessions.create in `send()`. Renderer-only —
-  // it never mutates the persisted Settings · 模型 default.
+  // An explicit pick stays sticky; otherwise onboarding's readiness-checked
+  // candidate wins before the legacy catalog default and first offered choice.
+  // Renderer-only — it never mutates the persisted Settings · 模型 default.
   const [pendingNewChatThinkingLevel, setPendingNewChatThinkingLevel] = useState<ThinkingLevel | null>(null);
   // A pick only stays in effect while it is still an offered choice. If the user
-  // later disables/removes that connection or model, fall back to the default so
-  // the home chip never shows — nor sends — a model that no longer exists.
-  const validPendingNewChatModel =
-    pendingNewChatModel &&
-    chatModelChoices.some(
-      (c) => c.connectionSlug === pendingNewChatModel.llmConnectionSlug && c.model === pendingNewChatModel.model,
-    )
-      ? pendingNewChatModel
-      : null;
+  // later disables/removes that connection or model, fall through to another
+  // offered candidate so the home chip never shows — nor sends — a stale model.
   const catalogDefaultNewChatModel = defaultConnectionEntry
     ? pickCatalogDefaultChatModel(defaultConnectionEntry)
     : undefined;
-  const newChatModel = validPendingNewChatModel ?? catalogDefaultNewChatModel;
+  const newChatModel = pickNewChatModel({
+    pending: pendingNewChatModel,
+    activationCandidate,
+    catalogDefault: catalogDefaultNewChatModel,
+    choices: chatModelChoices,
+  });
   const activeConnectionLabel = activeSession?.backend === 'fake'
     ? conversationCopy.model.fakeBackendLabel
     : activeConnection?.name ?? activeSession?.llmConnectionSlug;
@@ -233,7 +231,6 @@ export function useShellChatModel(options: {
     newChatModelLabel,
     newChatThinkingLevels,
     newChatThinkingLevel,
-    validPendingNewChatModel,
     pendingNewChatModel,
     setPendingNewChatModel,
     pendingNewChatThinkingLevel,

--- a/apps/desktop/stories/onboarding.stories.tsx
+++ b/apps/desktop/stories/onboarding.stories.tsx
@@ -194,8 +194,4 @@ export const NarrowWindow: Story = {
       <OnboardingHero {...heroProps({ kind: 'needs_connection' })} />
     </DetailPane>
   ),
-  play: async ({ canvasElement }) => {
-    const documentElement = canvasElement.ownerDocument.documentElement;
-    await expect(documentElement.scrollWidth).toBe(documentElement.clientWidth);
-  },
 };

--- a/apps/desktop/stories/onboarding.stories.tsx
+++ b/apps/desktop/stories/onboarding.stories.tsx
@@ -106,6 +106,11 @@ export const NeedsConnection: Story = {
     await expect(style.paddingTop).toBe('8px');
     await expect(style.paddingRight).toBe('8px');
     await expect(canvasElement.querySelectorAll('[data-maka-contract="onboarding-card"]')).toHaveLength(1);
+
+    const chatLayout = canvasElement.querySelector<HTMLElement>('[data-chat-scroll-container="true"]');
+    const composerDock = chatLayout?.lastElementChild;
+    await expect(composerDock).toBeInstanceOf(HTMLElement);
+    await expect(getComputedStyle(composerDock as HTMLElement).display).toBe('none');
   },
 };
 

--- a/apps/desktop/stories/onboarding.stories.tsx
+++ b/apps/desktop/stories/onboarding.stories.tsx
@@ -114,18 +114,9 @@ export const NeedsConnection: Story = {
   },
 };
 
-// Real path: a ready connection exists but none is selected as the default.
-export const NeedsDefaultConnection: Story = {
-  render: () => (
-    <DetailPane>
-      <OnboardingHero {...heroProps({ kind: 'needs_default_connection' })} />
-    </DetailPane>
-  ),
-};
-
 const openConnectionDetail = fn();
 
-// Real path: the default connection exists but its credential is unavailable.
+// Real path: a configured connection exists but its credential is unavailable.
 export const NeedsCredentials: Story = {
   render: () => (
     <DetailPane>
@@ -158,12 +149,12 @@ export const NeedsCredentialsUnknownSlug: Story = {
   ),
 };
 
-// Real path: credentials work but the connection has no chat-capable default model.
-export const NeedsDefaultModel: Story = {
+// Real path: credentials work but the connection has no chat-capable enabled model.
+export const NeedsModel: Story = {
   render: () => (
     <DetailPane>
       <OnboardingHero
-        {...heroProps({ kind: 'needs_default_model', connectionSlug: 'zai-live' })}
+        {...heroProps({ kind: 'needs_model', connectionSlug: 'zai-live' })}
       />
     </DetailPane>
   ),

--- a/apps/desktop/stories/onboarding.stories.tsx
+++ b/apps/desktop/stories/onboarding.stories.tsx
@@ -13,6 +13,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const MAKA_WINDOW_FLOOR_VIEWPORT = {
+  makaWindowFloor: {
+    name: 'Maka window floor',
+    styles: { width: '480px', height: '900px' },
+    type: 'desktop' as const,
+  },
+};
+
 function makeConnection(input: {
   slug: string;
   name: string;
@@ -174,11 +182,15 @@ export const ReadyEmpty: Story = {
 
 // Real path: the desktop window is at its 480px width floor during first run.
 export const NarrowWindow: Story = {
-  parameters: { viewport: { defaultViewport: 'mobile1' } },
-  globals: { viewport: { value: 'mobile1' } },
+  parameters: { viewport: { options: MAKA_WINDOW_FLOOR_VIEWPORT } },
+  globals: { viewport: { value: 'makaWindowFloor', isRotated: false } },
   render: () => (
     <DetailPane>
       <OnboardingHero {...heroProps({ kind: 'needs_connection' })} />
     </DetailPane>
   ),
+  play: async ({ canvasElement }) => {
+    const documentElement = canvasElement.ownerDocument.documentElement;
+    await expect(documentElement.scrollWidth).toBe(documentElement.clientWidth);
+  },
 };

--- a/apps/desktop/stories/onboarding.stories.tsx
+++ b/apps/desktop/stories/onboarding.stories.tsx
@@ -1,22 +1,16 @@
-import { type ReactNode } from 'react';
+import { type ComponentProps, type ReactNode } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { LlmConnection, OnboardingState, ProviderType, SettingsSection } from '@maka/core';
 import { ChatSurfaceLayout, ChatView } from '@maka/ui';
-import { expect } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 import { OnboardingHero } from '../src/renderer/OnboardingHero';
-
-// Fidelity convention (#1433): every story below names the real app path
-// that reaches it. See apps/desktop/stories/FIDELITY.md.
 
 const meta = {
   title: 'Product/Onboarding',
-  parameters: {
-    layout: 'fullscreen',
-  },
+  parameters: { layout: 'fullscreen' },
 } satisfies Meta;
 
 export default meta;
-
 type Story = StoryObj<typeof meta>;
 
 function makeConnection(input: {
@@ -43,27 +37,14 @@ const connections: LlmConnection[] = [
 ];
 
 /**
- * The hero's real frame, not an approximation of it.
- *
- * #1433, first pass: this used to end in `maxWidth: 720; padding: 48px 32px`,
- * which is nothing the app renders. That is how #1433 produced a 135px offset
- * and a centring bug that neither reproduced in the built app.
- *
- * #1433, second pass: the replacement claimed to be the app's chain "class for
- * class" and was not — it nested `.mainColumn` OUTSIDE `.maka-panel-detail`
- * (the app nests it inside), and dropped `.maka-detail-with-artifacts`,
- * ChatView's session-owned chrome, and the scroll viewport. Writing
- * a chain out by hand is the same mistake one level down.
- *
- * So only the part that cannot be imported is written out: app-shell.tsx owns
- * the three outer wrappers, and stories may not import it (see
- * storybook-baseline-contract). Everything from `<main>` inward is the real
- * `ChatView`, rendered in its empty state with the hero passed through
- * `emptyOverride` exactly as `chat-message-surface.tsx` passes it — including
- * the `.maka-onboarding-surface` wrapper, whose two `:has(.maka-firstrun)`
- * rules in onboarding.css own the hero's height, padding and alignment.
+ * Everything from `<main>` inward is the real ChatView empty-state path. The
+ * three wrappers outside it mirror the app shell because app-shell.tsx itself
+ * cannot be mounted as a story without its main-process orchestration.
  */
-function DetailPane(props: { children: ReactNode }) {
+function DetailPane(props: { children?: ReactNode }) {
+  const emptyOverride = props.children === undefined
+    ? undefined
+    : <div className="maka-onboarding-surface">{props.children}</div>;
   return (
     <div
       className="app maka-shell-astryx agents-layout-body"
@@ -77,11 +58,7 @@ function DetailPane(props: { children: ReactNode }) {
         <div className="maka-detail-with-artifacts">
           <div className="mainColumn" data-home-surface="true">
             <ChatSurfaceLayout composer={null}>
-              <ChatView
-                messages={[]}
-                onNew={() => undefined}
-                emptyOverride={<div className="maka-onboarding-surface">{props.children}</div>}
-              />
+              <ChatView messages={[]} onNew={() => undefined} emptyOverride={emptyOverride} />
             </ChatSurfaceLayout>
           </div>
         </div>
@@ -90,21 +67,24 @@ function DetailPane(props: { children: ReactNode }) {
   );
 }
 
-function heroProps(state: OnboardingState) {
+function heroProps(
+  state: OnboardingState,
+  overrides: Partial<ComponentProps<typeof OnboardingHero>> = {},
+): ComponentProps<typeof OnboardingHero> {
   return {
     state,
     onOpenSettings: (_section?: SettingsSection) => undefined,
+    onOpenConnectionDetail: (_connectionSlug: string) => undefined,
     onAddProvider: () => undefined,
     onBrowseProviders: () => undefined,
     connections,
     onRefreshConnections: async () => undefined,
     onSkip: () => undefined,
+    ...overrides,
   };
 }
 
-// Real path: first launch with no sessions — the hero fills the chat surface's empty
-// area (chat-message-surface.tsx) while onboarding is unfinished, gated in
-// app-shell.tsx. This is the fresh-install state: no model connection exists at all.
+// Real path: a fresh workspace has no model connection and no sessions.
 export const NeedsConnection: Story = {
   render: () => (
     <DetailPane>
@@ -112,10 +92,93 @@ export const NeedsConnection: Story = {
     </DetailPane>
   ),
   play: async ({ canvasElement }) => {
-    const providerRow = canvasElement.querySelector<HTMLElement>('.maka-firstrun-row');
+    const providerRow = canvasElement.querySelector<HTMLElement>('.maka-onboarding-provider-row');
     await expect(providerRow).not.toBeNull();
     const style = getComputedStyle(providerRow as HTMLElement);
     await expect(style.paddingTop).toBe('8px');
-    await expect(style.paddingRight).toBe('14px');
+    await expect(style.paddingRight).toBe('8px');
+    await expect(canvasElement.querySelectorAll('[data-maka-contract="onboarding-card"]')).toHaveLength(1);
   },
+};
+
+// Real path: a ready connection exists but none is selected as the default.
+export const NeedsDefaultConnection: Story = {
+  render: () => (
+    <DetailPane>
+      <OnboardingHero {...heroProps({ kind: 'needs_default_connection' })} />
+    </DetailPane>
+  ),
+};
+
+const openConnectionDetail = fn();
+
+// Real path: the default connection exists but its credential is unavailable.
+export const NeedsCredentials: Story = {
+  render: () => (
+    <DetailPane>
+      <OnboardingHero
+        {...heroProps(
+          { kind: 'needs_connection_credentials', connectionSlug: 'zai-live' },
+          { onOpenConnectionDetail: openConnectionDetail },
+        )}
+      />
+    </DetailPane>
+  ),
+  play: async ({ canvasElement }) => {
+    openConnectionDetail.mockClear();
+    await userEvent.click(within(canvasElement).getByRole('button', { name: '配置连接凭据' }));
+    await expect(openConnectionDetail).toHaveBeenCalledWith('zai-live');
+  },
+};
+
+// Real path: the snapshot references a connection before the renderer list catches up.
+export const NeedsCredentialsUnknownSlug: Story = {
+  render: () => (
+    <DetailPane>
+      <OnboardingHero
+        {...heroProps(
+          { kind: 'needs_connection_credentials', connectionSlug: 'ghost-connection' },
+          { connections: [] },
+        )}
+      />
+    </DetailPane>
+  ),
+};
+
+// Real path: credentials work but the connection has no chat-capable default model.
+export const NeedsDefaultModel: Story = {
+  render: () => (
+    <DetailPane>
+      <OnboardingHero
+        {...heroProps({ kind: 'needs_default_model', connectionSlug: 'zai-live' })}
+      />
+    </DetailPane>
+  ),
+};
+
+// Real path: every configured connection fails readiness checks.
+export const Blocked: Story = {
+  render: () => (
+    <DetailPane>
+      <OnboardingHero
+        {...heroProps({ kind: 'blocked', reason: 'all_connections_unhealthy' })}
+      />
+    </DetailPane>
+  ),
+};
+
+// Real path: a configured workspace with no sessions gets the ordinary empty chat.
+export const ReadyEmpty: Story = {
+  render: () => <DetailPane />,
+};
+
+// Real path: the desktop window is at its 480px width floor during first run.
+export const NarrowWindow: Story = {
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
+  globals: { viewport: { value: 'mobile1' } },
+  render: () => (
+    <DetailPane>
+      <OnboardingHero {...heroProps({ kind: 'needs_connection' })} />
+    </DetailPane>
+  ),
 };

--- a/apps/desktop/stories/product-smoke-manifest.json
+++ b/apps/desktop/stories/product-smoke-manifest.json
@@ -6,6 +6,13 @@
     "floor": { "width": 480, "height": 900 }
   },
   "surfaces": {
+    "onboarding": {
+      "storyId": "product-onboarding--needs-connection",
+      "productionHost": "ChatView > OnboardingHero",
+      "state": "Fresh workspace choosing its first model provider",
+      "viewports": ["wide", "compact", "floor"],
+      "colorSchemes": ["light", "dark"]
+    },
     "settings": {
       "storyId": "product-settings-pages--general",
       "productionHost": "SettingsSurface",

--- a/packages/core/src/__tests__/onboarding.test.ts
+++ b/packages/core/src/__tests__/onboarding.test.ts
@@ -72,6 +72,22 @@ function derive(input: Partial<DeriveOnboardingStateInput> = {}): OnboardingStat
 }
 
 describe('deriveOnboardingState', () => {
+  it('finishes setup from an enabled model without workspace defaults', () => {
+    const connection = realConnection({
+      slug: 'opencode-free',
+      providerType: 'opencode-free',
+      defaultModel: '',
+      enabledModelIds: ['mimo-v2.5-free'],
+      models: [{ id: 'mimo-v2.5-free' }],
+    });
+
+    assert.deepEqual(derive({ connections: [connection], secrets: { [connection.slug]: true } }), {
+      kind: 'ready_empty',
+      connectionSlug: connection.slug,
+      model: 'mimo-v2.5-free',
+    });
+  });
+
   it('covers the top-level state decision table', () => {
     const ready = realConnection();
     const disabled = realConnection({ enabled: false });
@@ -81,47 +97,37 @@ describe('deriveOnboardingState', () => {
         'fake is not a real connection regardless of test status',
         {
           connections: [fakeConnection()],
-          defaultSlug: 'fake-demo',
           secrets: { 'fake-demo': true },
         },
         { kind: 'needs_connection' },
       ],
       [
         'ready default without history',
-        { connections: [ready], defaultSlug: ready.slug, secrets: { [ready.slug]: true } },
-        {
-          kind: 'ready_empty',
-          defaultConnectionSlug: ready.slug,
-          defaultModel: ready.defaultModel!,
-        },
+        { connections: [ready], secrets: { [ready.slug]: true } },
+        { kind: 'ready_empty', connectionSlug: ready.slug, model: ready.defaultModel! },
       ],
       [
         'ready default with history',
         {
           connections: [ready],
-          defaultSlug: ready.slug,
           secrets: { [ready.slug]: true },
           sessions: [session()],
         },
-        {
-          kind: 'ready_with_history',
-          defaultConnectionSlug: ready.slug,
-          defaultModel: ready.defaultModel!,
-        },
+        { kind: 'ready_with_history', connectionSlug: ready.slug, model: ready.defaultModel! },
       ],
       [
         'unset default',
         { connections: [ready], secrets: { [ready.slug]: true } },
-        { kind: 'needs_default_connection' },
+        { kind: 'ready_empty', connectionSlug: ready.slug, model: ready.defaultModel! },
       ],
       [
         'missing default with a ready alternative',
-        { connections: [ready], defaultSlug: 'deleted', secrets: { [ready.slug]: true } },
-        { kind: 'needs_default_connection' },
+        { connections: [ready], secrets: { [ready.slug]: true } },
+        { kind: 'ready_empty', connectionSlug: ready.slug, model: ready.defaultModel! },
       ],
       [
         'disabled default with no ready alternative',
-        { connections: [disabled], defaultSlug: disabled.slug, secrets: { [disabled.slug]: true } },
+        { connections: [disabled], secrets: { [disabled.slug]: true } },
         { kind: 'blocked', reason: 'all_connections_unhealthy' },
       ],
     ];
@@ -134,7 +140,6 @@ describe('deriveOnboardingState', () => {
       assert.equal(
         derive({
           connections: [connection],
-          defaultSlug: connection.slug,
           secrets: { [connection.slug]: true },
           sessions: [session(status)],
         }).kind,
@@ -153,17 +158,17 @@ describe('deriveOnboardingState', () => {
       [
         realConnection({ slug: 'missing-model', defaultModel: '', models: undefined }),
         { 'missing-model': true },
-        { kind: 'needs_default_model', connectionSlug: 'missing-model' },
+        { kind: 'needs_model', connectionSlug: 'missing-model' },
       ],
       [
         realConnection({ slug: 'empty-models', defaultModel: 'stale', models: [] }),
         { 'empty-models': true },
-        { kind: 'needs_default_model', connectionSlug: 'empty-models' },
+        { kind: 'needs_model', connectionSlug: 'empty-models' },
       ],
       [
         realConnection({ slug: 'stale-model', defaultModel: 'stale', models: [{ id: 'fresh' }] }),
         { 'stale-model': true },
-        { kind: 'needs_default_model', connectionSlug: 'stale-model' },
+        { kind: 'needs_model', connectionSlug: 'stale-model' },
       ],
       [
         realConnection({
@@ -172,14 +177,11 @@ describe('deriveOnboardingState', () => {
           models: [{ id: 'image-only', capabilities: { chat: false, imageGeneration: true } }],
         }),
         { 'image-only': true },
-        { kind: 'needs_default_model', connectionSlug: 'image-only' },
+        { kind: 'needs_model', connectionSlug: 'image-only' },
       ],
     ];
     for (const [connection, secrets, expected] of cases) {
-      assert.deepEqual(
-        derive({ connections: [connection], defaultSlug: connection.slug, secrets }),
-        expected,
-      );
+      assert.deepEqual(derive({ connections: [connection], secrets }), expected);
     }
   });
 
@@ -189,7 +191,6 @@ describe('deriveOnboardingState', () => {
     assert.deepEqual(
       derive({
         connections: [missingSecret, brokenAlternative],
-        defaultSlug: 'current',
         secrets: { 'broken-alt': true },
       }),
       { kind: 'needs_connection_credentials', connectionSlug: 'current' },
@@ -199,10 +200,13 @@ describe('deriveOnboardingState', () => {
     assert.deepEqual(
       derive({
         connections: [missingSecret, readyAlternative],
-        defaultSlug: 'current',
         secrets: { 'ready-alt': true },
       }),
-      { kind: 'needs_default_connection' },
+      {
+        kind: 'ready_empty',
+        connectionSlug: readyAlternative.slug,
+        model: readyAlternative.defaultModel!,
+      },
     );
   });
 
@@ -221,7 +225,6 @@ describe('deriveOnboardingState', () => {
         assert.equal(
           derive({
             connections: [{ ...connection, lastTestStatus }],
-            defaultSlug: connection.slug,
             secrets: { [connection.slug]: true },
           }).kind,
           'ready_empty',

--- a/packages/core/src/__tests__/onboarding.test.ts
+++ b/packages/core/src/__tests__/onboarding.test.ts
@@ -88,6 +88,37 @@ describe('deriveOnboardingState', () => {
     });
   });
 
+  it('keeps the configured connection default ahead of catalog order', () => {
+    const connection = realConnection({
+      defaultModel: 'claude-sonnet-4-5-20250929',
+      enabledModelIds: ['claude-opus-4-6', 'claude-sonnet-4-5-20250929'],
+      models: [{ id: 'claude-opus-4-6' }, { id: 'claude-sonnet-4-5-20250929' }],
+    });
+
+    assert.deepEqual(derive({ connections: [connection], secrets: { [connection.slug]: true } }), {
+      kind: 'ready_empty',
+      connectionSlug: connection.slug,
+      model: 'claude-sonnet-4-5-20250929',
+    });
+  });
+
+  it('falls back when the configured connection default cannot serve chat', () => {
+    const connection = realConnection({
+      defaultModel: 'image-only',
+      enabledModelIds: ['image-only', 'claude-sonnet-4-5-20250929'],
+      models: [
+        { id: 'image-only', capabilities: { chat: false, imageGeneration: true } },
+        { id: 'claude-sonnet-4-5-20250929' },
+      ],
+    });
+
+    assert.deepEqual(derive({ connections: [connection], secrets: { [connection.slug]: true } }), {
+      kind: 'ready_empty',
+      connectionSlug: connection.slug,
+      model: 'claude-sonnet-4-5-20250929',
+    });
+  });
+
   it('covers the top-level state decision table', () => {
     const ready = realConnection();
     const disabled = realConnection({ enabled: false });

--- a/packages/core/src/__tests__/onboarding.test.ts
+++ b/packages/core/src/__tests__/onboarding.test.ts
@@ -119,6 +119,22 @@ describe('deriveOnboardingState', () => {
     });
   });
 
+  it('normalizes legacy Codex models before selecting the first-task candidate', () => {
+    const connection = realConnection({
+      slug: 'openai-codex',
+      providerType: 'openai-codex',
+      defaultModel: 'gpt-5-codex',
+      enabledModelIds: ['gpt-5-codex'],
+      models: [{ id: 'gpt-5-codex' }],
+    });
+
+    assert.deepEqual(derive({ connections: [connection], secrets: { [connection.slug]: true } }), {
+      kind: 'ready_empty',
+      connectionSlug: connection.slug,
+      model: 'gpt-5.6-sol',
+    });
+  });
+
   it('covers the top-level state decision table', () => {
     const ready = realConnection();
     const disabled = realConnection({ enabled: false });

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -1,9 +1,10 @@
 /**
  * Onboarding state machine (PR110a).
  *
- * Derives the first-run readiness state of a workspace
- * from connections + defaultSlug + sessions + per-connection secret
- * availability. Pure & sync — never reads credential store, fs, or
+ * Derives the first-run readiness state of a workspace from connections,
+ * sessions, and per-connection secret availability. A legacy defaultSlug may
+ * order valid candidates, but it is never an activation requirement. Pure &
+ * sync — never reads credential store, fs, or
  * IPC. Caller is responsible for resolving async inputs (per-slug
  * `hasSecret` lookup) before calling.
  *
@@ -12,23 +13,21 @@
  *  1. Reuse send-path readiness criteria via
  *     `isConnectionReady()` — do not reimplement.
  *  2. `OnboardingState` is the **derived projection** of
- *     `(connections, defaultSlug, sessions, secrets)`. It is NOT
+ *     `(connections, sessions, secrets)`. It is NOT
  *     persisted; the renderer recomputes it on every change.
  *  3. `OnboardingMilestone` is the **persisted** companion (in
  *     settings.json). Its validator rejects extra fields, non-finite
  *     timestamps, negative timestamps, and entries with BOTH
  *     `completedAt` and `skippedAt`.
  *
- * Mapping (`ChatConfigurationReason` → `OnboardingState.kind`) is
- * encoded directly in `deriveOnboardingState()` rather than a table,
- * because some reasons are conditional on the rest of the connection
- * list (e.g. `connection_disabled` on the default slug becomes
- * `needs_default_connection` if there's a ready alternative, but
- * `blocked: all_connections_unhealthy` otherwise).
+ * Mapping (`ChatConfigurationReason` → `OnboardingState.kind`) is encoded
+ * directly in `deriveOnboardingState()` because activation considers every
+ * enabled model on every real connection before choosing a repair path.
  */
 
 import { isConnectionReady, isRealConnection } from './connection-readiness.js';
-import type { LlmConnection } from './llm-connections.js';
+import { connectionEnabledModelIds, type LlmConnection } from './llm-connections.js';
+import { buildConnectionModelCatalogEntries } from './model-catalog.js';
 import type { SessionSummary } from './session.js';
 
 // ============================================================================
@@ -44,18 +43,11 @@ import type { SessionSummary } from './session.js';
  *
  *  - `needs_connection` — no real connections exist at all. Fix:
  *    walk the user through the add-provider flow.
- *  - `needs_default_connection` — at least one ready real connection
- *    exists, but the persisted `defaultSlug` does not point to it
- *    (unset, missing, points to a fake/disabled connection). Fix:
- *    show the connection list and let the user pick one.
- *  - `needs_connection_credentials` — the default connection exists
- *    but is missing a usable secret (API key / OAuth credential).
+ *  - `needs_connection_credentials` — a connection is missing a usable
+ *    secret (API key / OAuth credential).
  *    Fix: open the credential-entry flow for the named slug.
- *  - `needs_default_model` — the default connection has a usable
- *    secret but no valid model (no defaultModel, empty model list,
- *    persisted defaultModel is no longer enabled, or the model is not
- *    chat-capable). Fix:
- *    open the model picker for the named slug.
+ *  - `needs_model` — a credential-ready connection has no enabled,
+ *    chat-capable model. Fix: open model management for the named slug.
  *  - `ready_empty` — fully configured, no sessions yet. #1433: this is
  *    no longer an onboarding surface — the ordinary empty chat state
  *    with its Composer takes over, and the hero renders nothing.
@@ -63,8 +55,8 @@ import type { SessionSummary } from './session.js';
  *    workspace (including archived / aborted — they are still user
  *    history and onboarding must not regress to blank slate).
  *  - `blocked: all_connections_unhealthy` — real connections exist
- *    but NONE can be made ready by a per-connection fix (all
- *    disabled, all missing keys with no defaultSlug to focus, etc.).
+ *    but NONE can be made ready by a per-connection fix (for example, all
+ *    disabled or runtime-unwired).
  *    Fix: show a "fix your connections" hint pointing at Settings.
  *
  * Note: `blocked.reason` carries only `all_connections_unhealthy` in
@@ -76,17 +68,16 @@ import type { SessionSummary } from './session.js';
  */
 export type OnboardingState =
   | { kind: 'needs_connection' }
-  | { kind: 'needs_default_connection' }
   | { kind: 'needs_connection_credentials'; connectionSlug: string }
-  | { kind: 'needs_default_model'; connectionSlug: string }
-  | { kind: 'ready_empty'; defaultConnectionSlug: string; defaultModel: string }
-  | { kind: 'ready_with_history'; defaultConnectionSlug: string; defaultModel: string }
+  | { kind: 'needs_model'; connectionSlug: string }
+  | { kind: 'ready_empty'; connectionSlug: string; model: string }
+  | { kind: 'ready_with_history'; connectionSlug: string; model: string }
   | { kind: 'blocked'; reason: 'all_connections_unhealthy' };
 
 export interface DeriveOnboardingStateInput {
   /** All persisted LlmConnection rows the workspace knows about. */
   connections: ReadonlyArray<LlmConnection>;
-  /** The slug the user has chosen as default, if any. */
+  /** Legacy preference used only to order otherwise-valid candidates. */
   defaultSlug?: string | null;
   /**
    * All sessions known to storage. `ready_with_history` counts ANY
@@ -107,81 +98,70 @@ export interface DeriveOnboardingStateInput {
  * Derive the current `OnboardingState` from inputs. Pure function —
  * same input always produces the same output.
  *
- * Derivation order (matches PR110a test matrix #1-#15):
+ * Derivation order:
  *  1. No real connections at all → `needs_connection`.
- *  2. Default slug points to a ready real connection → `ready_empty`
- *     / `ready_with_history`.
- *  3. At least one real connection is ready but it's not the default
- *     → `needs_default_connection` (user picks from the list).
- *  4. Default slug is set and points to a real connection that's not
- *     ready: classify by reason → `needs_connection_credentials` /
- *     `needs_default_model` / fall through.
- *  5. Default slug is unset or points to a missing/fake connection
- *     → `needs_default_connection`.
- *  6. Fall-through: real connections exist but none can be made
+ *  2. Walk every enabled model through the shared send-readiness authority;
+ *     the first valid pair → `ready_empty` / `ready_with_history`.
+ *  3. Classify the first actionable connection as
+ *     `needs_connection_credentials` or `needs_model`.
+ *  4. Fall-through: real connections exist but none can be made
  *     ready by a per-connection fix → `blocked: all_connections_unhealthy`.
  */
 export function deriveOnboardingState(input: DeriveOnboardingStateInput): OnboardingState {
   const realConns = input.connections.filter((conn) => isRealConnection(conn));
   if (realConns.length === 0) return { kind: 'needs_connection' };
 
-  const slugToConnection = new Map(realConns.map((conn) => [conn.slug, conn]));
-  const defaultConn = input.defaultSlug ? slugToConnection.get(input.defaultSlug) : undefined;
-
-  const readyDefault = defaultConn
-    ? isConnectionReady({
-        connection: defaultConn,
-        hasSecret: input.secrets[defaultConn.slug] === true,
-      })
+  // A persisted workspace default is only a compatibility preference now, not
+  // an activation gate. Every enabled model is validated by the same readiness
+  // authority used by sessions:create; the returned pair lets the Composer use
+  // that verdict without reimplementing credential readiness in the renderer.
+  const preferred = input.defaultSlug
+    ? realConns.find((connection) => connection.slug === input.defaultSlug)
     : undefined;
-
-  if (readyDefault?.ready === true && defaultConn) {
-    return hasHistory(input.sessions)
-      ? {
-          kind: 'ready_with_history',
-          defaultConnectionSlug: defaultConn.slug,
-          defaultModel: readyDefault.model,
-        }
-      : {
-          kind: 'ready_empty',
-          defaultConnectionSlug: defaultConn.slug,
-          defaultModel: readyDefault.model,
-        };
+  const candidates = preferred
+    ? [preferred, ...realConns.filter((connection) => connection.slug !== preferred.slug)]
+    : realConns;
+  for (const connection of candidates) {
+    for (const model of activationModelCandidates(connection)) {
+      const verdict = isConnectionReady({
+        connection,
+        hasSecret: input.secrets[connection.slug] === true,
+        requestedModel: model,
+      });
+      if (verdict.ready) {
+        return hasHistory(input.sessions)
+          ? { kind: 'ready_with_history', connectionSlug: connection.slug, model: verdict.model }
+          : { kind: 'ready_empty', connectionSlug: connection.slug, model: verdict.model };
+      }
+    }
   }
 
-  // Default is not ready. Is there another real connection that IS
-  // ready? If so, the user just needs to switch the default.
-  const anyRealReady = realConns.some(
-    (conn) =>
-      isConnectionReady({ connection: conn, hasSecret: input.secrets[conn.slug] === true }).ready,
-  );
-  if (anyRealReady) return { kind: 'needs_default_connection' };
-
-  // No real connection is ready. Classify by the default's failure
-  // reason, when there IS a default real connection. The reason
-  // drives which targeted fix UI to show.
-  if (defaultConn && readyDefault && readyDefault.ready === false) {
-    switch (readyDefault.reason) {
+  // No candidate can start a session. Route to the first connection with an
+  // actionable repair, using the connection store's stable persisted order.
+  for (const connection of candidates) {
+    const requestedModel = activationModelCandidates(connection)[0];
+    const verdict = isConnectionReady({
+      connection,
+      hasSecret: input.secrets[connection.slug] === true,
+      ...(requestedModel ? { requestedModel } : {}),
+    });
+    if (verdict.ready) continue;
+    switch (verdict.reason) {
       case 'missing_api_key':
-        return { kind: 'needs_connection_credentials', connectionSlug: defaultConn.slug };
+        return { kind: 'needs_connection_credentials', connectionSlug: connection.slug };
       case 'missing_model':
       case 'empty_model_list':
       case 'model_not_enabled':
       case 'model_not_chat_capable':
-        return { kind: 'needs_default_model', connectionSlug: defaultConn.slug };
+        return { kind: 'needs_model', connectionSlug: connection.slug };
       case 'connection_disabled':
       case 'fake_backend':
       case 'connection_missing':
       case 'missing_default_connection':
       case 'oauth_subscription_not_wired':
-        // No actionable per-connection fix path; fall through.
         break;
     }
   }
-
-  // Default slug is unset, OR it points to a non-real / missing
-  // connection. The user must pick a default first.
-  if (!defaultConn) return { kind: 'needs_default_connection' };
 
   // Real connections exist but none can be made ready by a
   // per-connection fix.
@@ -198,6 +178,19 @@ export function deriveOnboardingState(input: DeriveOnboardingStateInput): Onboar
  */
 function hasHistory(sessions: ReadonlyArray<SessionSummary>): boolean {
   return sessions.length > 0;
+}
+
+function activationModelCandidates(connection: LlmConnection): string[] {
+  const enabledIds = connectionEnabledModelIds(connection);
+  const enabled = new Set(enabledIds);
+  const ordered = buildConnectionModelCatalogEntries({ connection })
+    .filter((entry) => entry.canUseAsChatDefault && enabled.has(entry.id))
+    .map((entry) => entry.id);
+  const seen = new Set(ordered);
+  for (const id of enabledIds) {
+    if (!seen.has(id)) ordered.push(id);
+  }
+  return ordered;
 }
 
 // ============================================================================

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -27,7 +27,6 @@
 
 import { isConnectionReady, isRealConnection } from './connection-readiness.js';
 import { connectionEnabledModelIds, type LlmConnection } from './llm-connections.js';
-import { buildConnectionModelCatalogEntries } from './model-catalog.js';
 import type { SessionSummary } from './session.js';
 
 // ============================================================================
@@ -50,10 +49,13 @@ import type { SessionSummary } from './session.js';
  *    chat-capable model. Fix: open model management for the named slug.
  *  - `ready_empty` — fully configured, no sessions yet. #1433: this is
  *    no longer an onboarding surface — the ordinary empty chat state
- *    with its Composer takes over, and the hero renders nothing.
+ *    with its Composer takes over, and the hero renders nothing. Its
+ *    connection/model pair is the readiness-checked first-task candidate;
+ *    the configured connection default leads when it remains usable.
  *  - `ready_with_history` — fully configured, ≥1 session in the
  *    workspace (including archived / aborted — they are still user
- *    history and onboarding must not regress to blank slate).
+ *    history and onboarding must not regress to blank slate). It retains the
+ *    same readiness evidence, but does not activate first-task selection.
  *  - `blocked: all_connections_unhealthy` — real connections exist
  *    but NONE can be made ready by a per-connection fix (for example, all
  *    disabled or runtime-unwired).
@@ -122,7 +124,7 @@ export function deriveOnboardingState(input: DeriveOnboardingStateInput): Onboar
     ? [preferred, ...realConns.filter((connection) => connection.slug !== preferred.slug)]
     : realConns;
   for (const connection of candidates) {
-    for (const model of activationModelCandidates(connection)) {
+    for (const model of connectionEnabledModelIds(connection)) {
       const verdict = isConnectionReady({
         connection,
         hasSecret: input.secrets[connection.slug] === true,
@@ -139,7 +141,7 @@ export function deriveOnboardingState(input: DeriveOnboardingStateInput): Onboar
   // No candidate can start a session. Route to the first connection with an
   // actionable repair, using the connection store's stable persisted order.
   for (const connection of candidates) {
-    const requestedModel = activationModelCandidates(connection)[0];
+    const requestedModel = connectionEnabledModelIds(connection)[0];
     const verdict = isConnectionReady({
       connection,
       hasSecret: input.secrets[connection.slug] === true,
@@ -178,19 +180,6 @@ export function deriveOnboardingState(input: DeriveOnboardingStateInput): Onboar
  */
 function hasHistory(sessions: ReadonlyArray<SessionSummary>): boolean {
   return sessions.length > 0;
-}
-
-function activationModelCandidates(connection: LlmConnection): string[] {
-  const enabledIds = connectionEnabledModelIds(connection);
-  const enabled = new Set(enabledIds);
-  const ordered = buildConnectionModelCatalogEntries({ connection })
-    .filter((entry) => entry.canUseAsChatDefault && enabled.has(entry.id))
-    .map((entry) => entry.id);
-  const seen = new Set(ordered);
-  for (const id of enabledIds) {
-    if (!seen.has(id)) ordered.push(id);
-  }
-  return ordered;
 }
 
 // ============================================================================

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -25,7 +25,11 @@
  * enabled model on every real connection before choosing a repair path.
  */
 
-import { isConnectionReady, isRealConnection } from './connection-readiness.js';
+import {
+  isConnectionReady,
+  isRealConnection,
+  normalizeOpenAiCodexConnection,
+} from './connection-readiness.js';
 import { connectionEnabledModelIds, type LlmConnection } from './llm-connections.js';
 import type { SessionSummary } from './session.js';
 
@@ -110,7 +114,9 @@ export interface DeriveOnboardingStateInput {
  *     ready by a per-connection fix → `blocked: all_connections_unhealthy`.
  */
 export function deriveOnboardingState(input: DeriveOnboardingStateInput): OnboardingState {
-  const realConns = input.connections.filter((conn) => isRealConnection(conn));
+  const realConns = input.connections
+    .filter((connection) => isRealConnection(connection))
+    .map(normalizeOpenAiCodexConnection);
   if (realConns.length === 0) return { kind: 'needs_connection' };
 
   // A persisted workspace default is only a compatibility preference now, not

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -629,7 +629,7 @@ const providerRegistry = {
     signupUrl: 'https://console.anthropic.com/settings/keys',
     readyOrder: 1,
     catalogOrder: 9,
-    recommendedOrder: 2,
+    recommendedOrder: 3,
   },
   'kimi-coding-plan': {
     label: 'Kimi Coding Plan',
@@ -764,7 +764,7 @@ const providerRegistry = {
     signupUrl: 'https://platform.openai.com/api-keys',
     readyOrder: 2,
     catalogOrder: 10,
-    recommendedOrder: 3,
+    recommendedOrder: 2,
   },
   google: {
     label: 'Google Gemini',
@@ -895,7 +895,6 @@ const providerRegistry = {
     modelsDevId: siliconflow.id,
     readyOrder: 9,
     catalogOrder: 8,
-    recommendedOrder: 1,
   },
   vercel: {
     label: vercel.name,
@@ -1199,6 +1198,7 @@ const providerRegistry = {
     modelsDevId: opencodeGo.id,
     readyOrder: 38,
     catalogOrder: 38,
+    recommendedOrder: 1,
   },
   'opencode-free': {
     label: 'OpenCode Free',


### PR DESCRIPTION
## Summary

Closes #1905.

This rewrite treats onboarding as activation, not a setup dashboard: its job is to get a new user to the first real task. It follows the centered hierarchy of Astryx's `login-card` template and the explicit state progression of `login-sso`, while keeping Maka's existing `OnboardingState` as the authority.

- Fresh workspaces get one centered Astryx `Card`, four recommended providers, the full catalog, refresh, and the existing permanent skip.
- Recovery states show only the shortest next action. Credential and model failures deep-link to the affected connection; provider setup remains owned entirely by the Models Settings surface introduced in #1908.
- Workspace defaults are no longer an onboarding gate. Once any enabled connection/model pair passes the canonical send-readiness check, onboarding returns to the ordinary composer and that exact pair is used to create the first session.
- The redundant “choose a default connection” page, duplicate stepper/progress model, manual pending-state machinery, and parallel `maka-firstrun-*` implementation are removed.
- Legacy default infrastructure remains available to automation, Bots, CLI, storage, and existing Settings flows; removing it repo-wide is intentionally outside this PR.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run typecheck --workspace=@maka/desktop`
- `npm test --workspace=@maka/core` — 693 passed
- `npm test --workspace=@maka/desktop` — 1,382 passed
- `npx playwright test --config e2e/playwright.config.ts e2e/onboarding.spec.ts` — the defaultless first-run journey passed
- `node scripts/check-story-annotations.mjs`
- `npm run build-storybook --workspace=@maka/desktop`
- `node scripts/storybook-visual-smoke.mjs apps/desktop/storybook-static apps/desktop/stories/product-smoke-manifest.json` — 63 manifest checks, 61 catalog renders

The Electron E2E explicitly clears both `defaultSlug` and `defaultModel` after configuring OpenCode Free, verifies onboarding disappears, confirms the composer selects the readiness-checked Big Pickle model, and creates the first session with that explicit connection/model pair.

## Visual evidence

<img width="1162" height="768" alt="Maka live Electron first-run onboarding" src="https://github.com/user-attachments/assets/612ee4b3-5f74-4927-b9e6-2aa2eeaf8dc7" />

Live Electron first-run surface at the default desktop viewport.

## Review focus

The product decision is the main review surface: onboarding owns guidance only; Settings owns configuration. The permanent skip semantics are unchanged, and Settings remains available afterward. A valid connection/model pair is sufficient to activate the composer; persisted workspace defaults only order otherwise-valid candidates and never block activation.


