### PR TITLE
fix(ui): read session modes off the composer footer, not the context drawer

### DIFF
--- a/apps/desktop/e2e/composer-mode-surface.spec.ts
+++ b/apps/desktop/e2e/composer-mode-surface.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test, COMPOSER_INPUT } from './fixtures';
+
+/**
+ * #1897: leaving a session mode from the composer footer.
+ *
+ * The mark's shape — position after the model pair, ghost variant, icon,
+ * accessible name, and its absence from the drawer count — is unit-covered in
+ * `composer-quiet-chrome.test.tsx`, and its accent rule is pinned in
+ * `chat-shell-layout-contract.test.ts`. Do not re-lock any of that here.
+ *
+ * What only a real window can show is the behaviour behind the mark: a static
+ * render is byte-identical with and without its `onClick`, so the one thing the
+ * issue actually asks for — that removal stays available — is unverifiable
+ * anywhere else. Focus travels with it: the click unmounts the button, and
+ * without a handoff the keyboard user is left on `document.body`.
+ *
+ * One journey, both modes of input, because they exit through the same handler.
+ */
+test('a mode mark switches its mode off and hands focus back to the composer', async ({
+  window: page,
+}) => {
+  const plusMenu = page.locator('.maka-composer-plus-menu').getByRole('button');
+  const planMark = page.locator('.maka-composer-mode-button[data-mode="plan"]');
+
+  await plusMenu.click();
+  await page.getByRole('menuitemcheckbox', { name: 'Plan' }).click();
+  await expect(planMark).toBeVisible();
+  await expect(planMark).toHaveAccessibleName('Plan');
+  await page.keyboard.press('Escape');
+
+  // Pointer: the mark is the way out of the mode, and the ＋ menu agrees.
+  await planMark.click();
+  await expect(planMark).toHaveCount(0);
+  await expect(page.locator(COMPOSER_INPUT)).toBeFocused();
+  await plusMenu.click();
+  await expect(page.getByRole('menuitemcheckbox', { name: 'Plan' })).toHaveAttribute(
+    'aria-checked',
+    'false',
+  );
+
+  // Keyboard: same handler, so the same exit and the same focus handoff.
+  await page.getByRole('menuitemcheckbox', { name: 'Plan' }).click();
+  await expect(planMark).toBeVisible();
+  await page.keyboard.press('Escape');
+  await planMark.focus();
+  await page.keyboard.press('Enter');
+  await expect(planMark).toHaveCount(0);
+  await expect(page.locator(COMPOSER_INPUT)).toBeFocused();
+});

--- a/apps/desktop/src/main/__tests__/chat-shell-layout-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-shell-layout-contract.test.ts
@@ -15,6 +15,7 @@ import {
   stripCssComments,
   assertCssRuleDecls,
   cssMediaBody,
+  cssRuleBody,
 } from './css-test-helpers.js';
 
 const STYLES = resolve(REPO_ROOT, 'apps/desktop/src/renderer/styles');
@@ -28,6 +29,45 @@ async function readCss(name: string): Promise<string> {
 }
 
 describe('chat shell layout contracts', () => {
+  /**
+   * #1897 / #1910. The mode marks' entire visual contract lives in this one
+   * rule, and nothing else can see it: the `@maka/ui` SSR tests never load a
+   * stylesheet, and dead-CSS only asks whether the class is referenced. Delete
+   * the rule and an ON mode becomes indistinguishable from the inert ＋ beside
+   * it, with every other check still green — so pin the rule here.
+   *
+   * `background-color`, not `background`: composer.css is in the last cascade
+   * layer, so the shorthand's implicit `background-image: none` would beat the
+   * ghost button's own :hover / :active overlays from `astryx-components` and
+   * strip all pointer feedback from the one control that leaves a mode. The
+   * voice button carries the same pair for the same reason.
+   */
+  it('draws active-mode and voice marks in one accent without killing ghost feedback', async () => {
+    const css = await readCss('composer.css');
+    assertCssRuleDecls(
+      css,
+      '.maka-composer-mode-button',
+      [
+        /color:\s*var\(--accent\)/,
+        /background-color:\s*color-mix\([^;]*currentColor/,
+      ],
+      'every mode mark draws in the single product accent over a currentColor wash',
+    );
+    for (const selector of [
+      '.maka-composer-mode-button',
+      '.maka-composer-voice-button[data-state="recording"]',
+      '.maka-composer-voice-button[data-state="native_ready"]',
+    ]) {
+      const body = cssRuleBody(css, selector);
+      assert.ok(body != null, `${selector} must exist`);
+      assert.doesNotMatch(
+        body!,
+        /(^|[;{]\s*)background\s*:/,
+        `${selector} must not use the background shorthand — it suppresses the ghost hover overlay`,
+      );
+    }
+  });
+
   it('keeps ChatLayout flex contracts that kill the phantom dock range', async () => {
     const css = await readCss('chat-header.css');
     assertCssRuleDecls(

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -157,18 +157,27 @@
   border-color: transparent;
 }
 
-/* Mode ON marks are icon-only Tokens at the tail of the footer's left
-   controls (#1897) — session state, not context staged for the next send, so
-   they no longer live in the drawer. The wrapper only carries data-mode /
-   title for E2E and tooltips; no second pill geometry on top of Token chrome.
-   Keep a real box (not display:contents) so Playwright visibility and
-   title hover still work on the host, and never let a long model name
-   compress the mark away. */
+/* Mode ON marks sit at the tail of the footer's left controls (#1897) —
+   session state, not context staged for the next send, so they no longer live
+   in the drawer. They are the same ghost icon button as ＋ and permission, so
+   the toolbar reads as one row of controls rather than a row of controls plus
+   two coloured pills. The wrapper only carries data-mode for E2E; keep it a
+   real box (not display:contents) so Playwright visibility still works, and
+   never let a long model name compress the mark away. */
 .maka-composer-mode-indicator {
   display: inline-flex;
   align-items: center;
   flex: 0 0 auto;
   min-width: 0;
+}
+
+/* Maka blue is the single product accent (DESIGN.md), and it is exactly what
+   this is: an active state. Which mode it is comes from the icon, not a hue,
+   so all three marks share the one accent. The wash is derived from
+   currentColor, so a disabled mark dims both layers together. */
+.maka-composer-mode-button {
+  color: var(--accent);
+  background: color-mix(in srgb, currentColor 10%, transparent);
 }
 /* Model + thinking pair lives in left-controls (after permission), not send. */
 .maka-composer-left-controls .maka-model-selection-controls {

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -102,14 +102,19 @@
   justify-content: flex-end;
 }
 
+/* `background-color`, never the `background` shorthand: these rules sit in the
+   last cascade layer (cascade-layers.css), and the shorthand's implicit
+   `background-image: none` would beat the ghost button's own :hover / :active
+   overlay gradients from `astryx-components`, leaving the control with no
+   pointer feedback at all. */
 .maka-composer-voice-button[data-state="recording"] {
   color: var(--status-danger, var(--destructive));
-  background: color-mix(in srgb, currentColor 10%, transparent);
+  background-color: color-mix(in srgb, currentColor 10%, transparent);
 }
 
 .maka-composer-voice-button[data-state="native_ready"] {
   color: var(--status-running);
-  background: color-mix(in srgb, currentColor 10%, transparent);
+  background-color: color-mix(in srgb, currentColor 10%, transparent);
 }
 
 /* Quiet footer: ＋ and permission are both ghost icon buttons. */
@@ -159,25 +164,21 @@
 
 /* Mode ON marks sit at the tail of the footer's left controls (#1897) —
    session state, not context staged for the next send, so they no longer live
-   in the drawer. They are the same ghost icon button as ＋ and permission, so
-   the toolbar reads as one row of controls rather than a row of controls plus
-   two coloured pills. The wrapper only carries data-mode for E2E; keep it a
-   real box (not display:contents) so Playwright visibility still works, and
-   never let a long model name compress the mark away. */
-.maka-composer-mode-indicator {
-  display: inline-flex;
-  align-items: center;
-  flex: 0 0 auto;
-  min-width: 0;
-}
+   in the drawer.
 
-/* Maka blue is the single product accent (DESIGN.md), and it is exactly what
-   this is: an active state. Which mode it is comes from the icon, not a hue,
-   so all three marks share the one accent. The wash is derived from
-   currentColor, so a disabled mark dims both layers together. */
+   Maka blue is the single product accent (DESIGN.md), and an active mode is
+   exactly what it is for; which mode a mark is comes from its icon, not a hue,
+   so all three share the one accent. The wash derives from currentColor so a
+   disabled mark dims both layers together.
+
+   `background-color`, never the `background` shorthand — see the voice button
+   above: the shorthand would suppress the ghost button's hover and active
+   overlays and leave the one way out of a mode with no pointer feedback.
+   `flex: 0 0 auto` keeps a long model name from compressing the mark away. */
 .maka-composer-mode-button {
+  flex: 0 0 auto;
   color: var(--accent);
-  background: color-mix(in srgb, currentColor 10%, transparent);
+  background-color: color-mix(in srgb, currentColor 10%, transparent);
 }
 /* Model + thinking pair lives in left-controls (after permission), not send. */
 .maka-composer-left-controls .maka-model-selection-controls {

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -157,13 +157,17 @@
   border-color: transparent;
 }
 
-/* Mode ON marks are drawer Tokens; wrapper only carries data-mode / title for
-   E2E and tooltips — no second pill geometry on top of Token chrome.
+/* Mode ON marks are icon-only Tokens at the tail of the footer's left
+   controls (#1897) — session state, not context staged for the next send, so
+   they no longer live in the drawer. The wrapper only carries data-mode /
+   title for E2E and tooltips; no second pill geometry on top of Token chrome.
    Keep a real box (not display:contents) so Playwright visibility and
-   title hover still work on the host. */
+   title hover still work on the host, and never let a long model name
+   compress the mark away. */
 .maka-composer-mode-indicator {
   display: inline-flex;
   align-items: center;
+  flex: 0 0 auto;
   min-width: 0;
 }
 /* Model + thinking pair lives in left-controls (after permission), not send. */

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -749,8 +749,9 @@ export const PlanModeOn: Story = {
   render: () => <ComposedShell composer={{ planModeActive: true }} />,
 };
 
-// Real path: the same for the orchestration side. Swarm carries its own colour
-// and icon, so the two modes stay distinguishable at icon size.
+// Real path: the same for the orchestration side. All marks share the one
+// product accent, so the icon is what has to keep the modes distinguishable —
+// this story is where that carries its own weight.
 export const SwarmModeOn: Story = {
   render: () => <ComposedShell composer={{ swarmModeActive: true }} />,
 };

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -740,3 +740,44 @@ export const SessionContextLayer: Story = {
     />
   ),
 };
+
+// Real path: 开启 Plan Mode from the ＋ menu. The mode is session-scoped — it
+// survives the send — so it reads as a mark at the tail of the composer's
+// footer controls rather than as staged context in the drawer (#1897). It
+// trails the model + thinking pair so switching it never shifts those two.
+export const PlanModeOn: Story = {
+  render: () => <ComposedShell composer={{ planModeActive: true }} />,
+};
+
+// Real path: the same for the orchestration side. Swarm carries its own colour
+// and icon, so the two modes stay distinguishable at icon size.
+export const SwarmModeOn: Story = {
+  render: () => <ComposedShell composer={{ swarmModeActive: true }} />,
+};
+
+// Real path: Plan and Swarm are independent switches (collaborationMode vs
+// orchestrationMode), so both can be on at once. This is the widest the mode
+// tail ever gets next to a real model name.
+export const PlanAndSwarmModeOn: Story = {
+  render: () => (
+    <ComposedShell composer={{ planModeActive: true, swarmModeActive: true }} />
+  ),
+};
+
+// Real path: a mode is on AND context is staged for the next send. The point of
+// the story is the split: the drawer badge counts the two attachments only,
+// while Plan reads off the footer — the mode is not something the send consumes.
+export const ModeOnWithPendingAttachments: Story = {
+  render: () => (
+    <ComposedShell
+      composer={{
+        planModeActive: true,
+        pendingAttachments: [
+          { displayName: 'design-review.pdf', kind: 'pdf', size: 182_400 },
+          { displayName: 'composer.tsx', kind: 'code', size: 41_200 },
+        ],
+        onRemoveAttachment: noop,
+      }}
+    />
+  ),
+};

--- a/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
+++ b/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
@@ -118,15 +118,16 @@ describe('composer quiet chrome', () => {
     const modelIdx = leftControls.indexOf('maka-model-selection-controls');
     const modeIdx = leftControls.indexOf('maka-composer-mode-indicator');
     assert.ok(modelIdx >= 0 && modeIdx > modelIdx, 'modes must follow the model pair');
-    // Icon-only, and still nameable + removable: Astryx hides the label
-    // visually while keeping it as the token's accessible name.
+    // The mark is the same ghost icon button as ＋ and permission, named by
+    // its mode and identified by its icon — never by a hue.
     const planMark = leftControls.slice(
       leftControls.indexOf('data-mode="plan"'),
       leftControls.indexOf('data-mode="swarm"'),
     );
-    assert.match(planMark, /lucide-list-todo/, 'the mark is the mode icon');
-    assert.match(planMark, /aria-label="Plan"/, 'the hidden label names the token');
-    assert.match(planMark, /aria-label="Remove Plan"/, 'the way out stays reachable');
+    assert.match(planMark, /lucide-list-todo/, 'the icon says which mode it is');
+    assert.match(planMark, /aria-label="Plan"/, 'the button is named for the mode');
+    assert.match(planMark, /maka-composer-mode-button/, 'the way out stays reachable');
+    assert.doesNotMatch(planMark, /astryx-token/, 'a mode is not a coloured pill');
     // Modes alone stage nothing for the next send, so no drawer mounts.
     assert.doesNotMatch(markup, /maka-composer-context-drawer/);
   });

--- a/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
+++ b/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
@@ -9,6 +9,19 @@ function render(children: ReactNode): string {
   return renderToStaticMarkup(<LocaleProvider locale="zh">{children}</LocaleProvider>);
 }
 
+/**
+ * The one mode mark's own `<button>` tag and its contents, bounded by its
+ * closing tag. Assertions scoped to this cannot be satisfied by a later
+ * control that happens to carry the same attribute.
+ */
+function markPast(markup: string, mode: string): string {
+  const at = markup.indexOf(`data-mode="${mode}"`);
+  if (at < 0) return '';
+  const open = markup.lastIndexOf('<button', at);
+  const close = markup.indexOf('</button>', at);
+  return markup.slice(open, close < 0 ? undefined : close + '</button>'.length);
+}
+
 describe('composer quiet chrome', () => {
   it('keeps resting chrome to permission icon, plus menu, model, and send', () => {
     const markup = render(
@@ -101,6 +114,8 @@ describe('composer quiet chrome', () => {
         onPlanModeChange={() => {}}
         swarmModeActive
         onSwarmModeChange={() => {}}
+        graphModeActive
+        onGraphModeChange={() => {}}
         modelLabel="demo"
         modelChoices={[]}
         newChatThinkingLevels={['off', 'high']}
@@ -112,24 +127,35 @@ describe('composer quiet chrome', () => {
     const leftControls = markup.match(
       /maka-composer-left-controls[\s\S]*?maka-composer-right-controls/,
     )?.[0] ?? '';
-    assert.match(leftControls, /maka-composer-mode-indicator[^>]*data-mode="plan"/);
-    assert.match(leftControls, /maka-composer-mode-indicator[^>]*data-mode="swarm"/);
+    // All three modes read off the same slot — graph is not a special case.
+    for (const mode of ['plan', 'swarm', 'graph']) {
+      assert.match(leftControls, new RegExp(`data-mode="${mode}"`), `${mode} must mark the footer`);
+    }
     // Modes trail the model + thinking pair so toggling one never shifts them.
     const modelIdx = leftControls.indexOf('maka-model-selection-controls');
-    const modeIdx = leftControls.indexOf('maka-composer-mode-indicator');
+    const modeIdx = leftControls.indexOf('data-mode="plan"');
     assert.ok(modelIdx >= 0 && modeIdx > modelIdx, 'modes must follow the model pair');
     // The mark is the same ghost icon button as ＋ and permission, named by
-    // its mode and identified by its icon — never by a hue.
-    const planMark = leftControls.slice(
-      leftControls.indexOf('data-mode="plan"'),
-      leftControls.indexOf('data-mode="swarm"'),
-    );
+    // its mode and identified by its icon — never by a hue. Bound the slice to
+    // this one button so a later mark cannot satisfy it.
+    const planMark = markPast(leftControls, 'plan');
+    assert.match(planMark, /^<button/, 'the mark is the button itself, not a wrapper');
+    assert.match(planMark, /data-variant="ghost"/, 'same ghost variant as ＋ and permission');
     assert.match(planMark, /lucide-list-todo/, 'the icon says which mode it is');
     assert.match(planMark, /aria-label="Plan"/, 'the button is named for the mode');
-    assert.match(planMark, /maka-composer-mode-button/, 'the way out stays reachable');
+    assert.match(planMark, /maka-composer-mode-button/, 'the accent rule has a target');
     assert.doesNotMatch(planMark, /astryx-token/, 'a mode is not a coloured pill');
     // Modes alone stage nothing for the next send, so no drawer mounts.
     assert.doesNotMatch(markup, /maka-composer-context-drawer/);
+  });
+
+  it('drops a mode mark the host gave no way to switch off', () => {
+    // An active mode with no change handler would otherwise render a focusable,
+    // tooltipped button whose click is a silent no-op.
+    const markup = render(
+      <Composer onSend={() => true} onStop={() => {}} planModeActive modelLabel="demo" />,
+    );
+    assert.doesNotMatch(markup, /data-mode="plan"/);
   });
 
   it('counts only send-consumed context in the drawer badge, never modes', () => {
@@ -141,6 +167,8 @@ describe('composer quiet chrome', () => {
         onPlanModeChange={() => {}}
         swarmModeActive
         onSwarmModeChange={() => {}}
+        graphModeActive
+        onGraphModeChange={() => {}}
         pendingAttachments={[{ displayName: 'notes.md', kind: 'doc', size: 12 }]}
         onRemoveAttachment={() => {}}
         modelLabel="demo"
@@ -148,12 +176,19 @@ describe('composer quiet chrome', () => {
     );
 
     assert.match(markup, /maka-composer-context-drawer/);
-    // One attachment staged, two modes on — the badge reads 1.
-    const badge = markup.match(/astryx-badge[\s\S]*?<\/span>/)?.[0] ?? '';
-    assert.match(badge, />1</, `drawer badge must exclude modes, got: ${badge}`);
-    // The drawer itself carries no mode marks any more.
-    const drawer = markup.match(/maka-composer-context-drawer[\s\S]*?<\/div>/)?.[0] ?? '';
-    assert.doesNotMatch(drawer, /maka-composer-mode-indicator/);
+    // One attachment staged, three modes on — the badge reads 1. Match the
+    // badge's own text node, not the first badge-ish substring in the document.
+    const badge = /astryx-badge[^>]*>(\d+)</.exec(markup);
+    assert.ok(badge, 'the drawer must render a count badge');
+    assert.equal(badge![1], '1', 'the drawer badge must exclude modes');
+    // The drawer itself carries no mode marks any more. Bound the slice by the
+    // next footer landmark, not by the first </div>, which any card-shaped
+    // drawer item would end early.
+    const drawer = markup.slice(
+      markup.indexOf('maka-composer-context-drawer'),
+      markup.indexOf('maka-composer-left-controls'),
+    );
+    assert.doesNotMatch(drawer, /data-mode=/);
   });
 
   it('shows a single voice control only when the host wires capture', () => {

--- a/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
+++ b/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
@@ -92,24 +92,67 @@ describe('composer quiet chrome', () => {
     );
   });
 
-  it('surfaces active mode and skill selections as drawer tokens, not footer chips', () => {
+  it('reads active modes off the footer toolbar, after the model pair', () => {
     const markup = render(
       <Composer
         onSend={() => true}
         onStop={() => {}}
         planModeActive
         onPlanModeChange={() => {}}
-        mentionSkills={[{ id: 'pdf', name: 'PDF 工具' }]}
+        swarmModeActive
+        onSwarmModeChange={() => {}}
+        modelLabel="demo"
+        modelChoices={[]}
+        newChatThinkingLevels={['off', 'high']}
+        newChatThinkingLevel="high"
+        onNewChatThinkingLevelChange={() => {}}
+      />,
+    );
+
+    const leftControls = markup.match(
+      /maka-composer-left-controls[\s\S]*?maka-composer-right-controls/,
+    )?.[0] ?? '';
+    assert.match(leftControls, /maka-composer-mode-indicator[^>]*data-mode="plan"/);
+    assert.match(leftControls, /maka-composer-mode-indicator[^>]*data-mode="swarm"/);
+    // Modes trail the model + thinking pair so toggling one never shifts them.
+    const modelIdx = leftControls.indexOf('maka-model-selection-controls');
+    const modeIdx = leftControls.indexOf('maka-composer-mode-indicator');
+    assert.ok(modelIdx >= 0 && modeIdx > modelIdx, 'modes must follow the model pair');
+    // Icon-only, and still nameable + removable: Astryx hides the label
+    // visually while keeping it as the token's accessible name.
+    const planMark = leftControls.slice(
+      leftControls.indexOf('data-mode="plan"'),
+      leftControls.indexOf('data-mode="swarm"'),
+    );
+    assert.match(planMark, /lucide-list-todo/, 'the mark is the mode icon');
+    assert.match(planMark, /aria-label="Plan"/, 'the hidden label names the token');
+    assert.match(planMark, /aria-label="Remove Plan"/, 'the way out stays reachable');
+    // Modes alone stage nothing for the next send, so no drawer mounts.
+    assert.doesNotMatch(markup, /maka-composer-context-drawer/);
+  });
+
+  it('counts only send-consumed context in the drawer badge, never modes', () => {
+    const markup = render(
+      <Composer
+        onSend={() => true}
+        onStop={() => {}}
+        planModeActive
+        onPlanModeChange={() => {}}
+        swarmModeActive
+        onSwarmModeChange={() => {}}
+        pendingAttachments={[{ displayName: 'notes.md', kind: 'doc', size: 12 }]}
+        onRemoveAttachment={() => {}}
         modelLabel="demo"
       />,
     );
 
-    // Drawer mounts when there is staged context; mode indicator is a token.
     assert.match(markup, /maka-composer-context-drawer/);
-    assert.match(markup, /maka-composer-mode-indicator[^>]*data-mode="plan"/);
-    assert.match(markup, /astryx-token/);
-    // Legacy text mode-indicator button is gone from the footer.
-    assert.doesNotMatch(markup, /<button[^>]*maka-composer-mode-indicator/);
+    // One attachment staged, two modes on — the badge reads 1.
+    const badge = markup.match(/astryx-badge[\s\S]*?<\/span>/)?.[0] ?? '';
+    assert.match(badge, />1</, `drawer badge must exclude modes, got: ${badge}`);
+    // The drawer itself carries no mode marks any more.
+    const drawer = markup.match(/maka-composer-context-drawer[\s\S]*?<\/div>/)?.[0] ?? '';
+    assert.doesNotMatch(drawer, /maka-composer-mode-indicator/);
   });
 
   it('shows a single voice control only when the host wires capture', () => {

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -238,7 +238,7 @@ describe('localized conversation journey', () => {
     assert.match(markup, /aria-disabled="true"[^>]*>[\s\S]*?添加文件或目录|添加文件或目录[\s\S]*?aria-disabled="true"/);
   });
 
-  it('shows a Plan token in the drawer only while Plan is active', () => {
+  it('marks Plan on the footer toolbar only while Plan is active', () => {
     const on = render(
       'zh',
       <Composer onSend={() => {}} onStop={() => {}} planModeActive onPlanModeChange={() => {}} />,
@@ -252,7 +252,7 @@ describe('localized conversation journey', () => {
     assert.doesNotMatch(off, /maka-composer-mode-indicator/);
   });
 
-  it('keeps the active-mode token visible but non-removable with reason while streaming', () => {
+  it('keeps the active-mode mark visible but non-removable with reason while streaming', () => {
     const markup = render(
       'zh',
       <Composer

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -244,15 +244,15 @@ describe('localized conversation journey', () => {
       <Composer onSend={() => {}} onStop={() => {}} planModeActive onPlanModeChange={() => {}} />,
     );
     assert.match(on, /maka-composer-mode-indicator[^>]*data-mode="plan"/);
-    assert.match(on, /Plan 模式已启用|title="Plan 模式已启用/);
-    assert.match(on, /astryx-token/);
-    assert.match(on, /aria-label="Remove Plan"/);
+    assert.match(on, /Plan 模式已启用/);
+    assert.match(on, /maka-composer-mode-button/);
+    assert.match(on, /aria-label="Plan"/);
 
     const off = render('zh', <Composer onSend={() => {}} onStop={() => {}} onPlanModeChange={() => {}} />);
     assert.doesNotMatch(off, /maka-composer-mode-indicator/);
   });
 
-  it('keeps the active-mode mark visible but non-removable with reason while streaming', () => {
+  it('keeps the active-mode mark visible but inert with its reason while streaming', () => {
     const markup = render(
       'zh',
       <Composer
@@ -266,11 +266,13 @@ describe('localized conversation journey', () => {
     );
     assert.match(markup, /maka-composer-mode-indicator[^>]*data-mode="swarm"/);
     assert.match(markup, /等待流式输出结束/);
-    // Disabled reason keeps the remove control off the token.
-    assert.doesNotMatch(markup, /aria-label="Remove Swarm"/);
+    // The disabled reason replaces the tooltip and takes the button out of
+    // reach, so the mark reads as state without offering a way to act on it.
+    const mark = markup.slice(markup.indexOf('data-mode="swarm"'));
+    assert.match(mark, /aria-disabled="true"|disabled=""/);
   });
 
-  it('localizes the active Graph Mode token title', () => {
+  it('localizes the active Graph Mode tooltip', () => {
     const zh = render(
       'zh',
       <Composer

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -243,13 +243,13 @@ describe('localized conversation journey', () => {
       'zh',
       <Composer onSend={() => {}} onStop={() => {}} planModeActive onPlanModeChange={() => {}} />,
     );
-    assert.match(on, /maka-composer-mode-indicator[^>]*data-mode="plan"/);
+    assert.match(on, /data-mode="plan"/);
     assert.match(on, /Plan 模式已启用/);
     assert.match(on, /maka-composer-mode-button/);
     assert.match(on, /aria-label="Plan"/);
 
     const off = render('zh', <Composer onSend={() => {}} onStop={() => {}} onPlanModeChange={() => {}} />);
-    assert.doesNotMatch(off, /maka-composer-mode-indicator/);
+    assert.doesNotMatch(off, /data-mode=/);
   });
 
   it('keeps the active-mode mark visible but inert with its reason while streaming', () => {
@@ -264,12 +264,21 @@ describe('localized conversation journey', () => {
         onSwarmModeChange={() => {}}
       />,
     );
-    assert.match(markup, /maka-composer-mode-indicator[^>]*data-mode="swarm"/);
-    assert.match(markup, /等待流式输出结束/);
-    // The disabled reason replaces the tooltip and takes the button out of
-    // reach, so the mark reads as state without offering a way to act on it.
-    const mark = markup.slice(markup.indexOf('data-mode="swarm"'));
-    assert.match(mark, /aria-disabled="true"|disabled=""/);
+    assert.match(markup, /data-mode="swarm"/);
+    // Scope to the mark's own <button>: the same reason also reaches the ＋
+    // menu's aria-description, so a document-wide search would pass on that
+    // alone. Astryx renders a tooltip'd disabled button as aria-disabled — it
+    // stays focusable precisely so the reason remains reachable — never as the
+    // native attribute, so that is the one form to pin.
+    const at = markup.indexOf('data-mode="swarm"');
+    const mark = markup.slice(markup.lastIndexOf('<button', at), markup.indexOf('</button>', at));
+    assert.match(mark, /aria-disabled="true"/);
+    // …and the reason is what the button actually points at, rather than some
+    // other element on the page that happens to carry the same string.
+    const describedBy = /aria-describedby="([^"]+)"/.exec(mark)?.[1];
+    assert.ok(describedBy, 'a disabled mark must name its reason');
+    const tooltip = markup.slice(markup.indexOf(`id="${describedBy}"`));
+    assert.match(tooltip.slice(0, tooltip.indexOf('</div></div>')), /等待流式输出结束/);
   });
 
   it('localizes the active Graph Mode tooltip', () => {

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -67,6 +67,7 @@ import {
   type ChatComposerTrigger,
   type SearchableItem,
   type SearchSource,
+  type TokenColor,
 } from '@astryxdesign/core';
 import {
   DropdownMenu,
@@ -923,13 +924,76 @@ export const Composer = forwardRef<
         ? copy.switchDisabledPermission
         : undefined;
 
+  /**
+   * The drawer's contract is context staged for the *next send*: quotes,
+   * attachments and Skills are consumed when the message goes out, and this
+   * count tells the user how many such items are pending. Plan / Swarm / Graph
+   * are session-scoped modes that survive the send, so they are not counted
+   * here and no longer render inside the drawer (#1897) — they read as mode
+   * state on the footer toolbar instead.
+   */
   const drawerTokenCount =
     (props.pendingQuotes?.length ?? 0)
     + (props.pendingAttachments?.length ?? 0)
-    + skillDraft.skills.length
-    + (props.planModeActive ? 1 : 0)
-    + (props.swarmModeActive ? 1 : 0)
-    + (props.graphModeActive ? 1 : 0);
+    + skillDraft.skills.length;
+  /**
+   * The session modes that are currently on, in the order the ＋ menu lists
+   * them. The menu stays the switch — it turns each mode on *and* off; these
+   * marks are the resting state readout, plus one nearby way out. They sit at
+   * the tail of the footer's left controls, after the model and thinking
+   * pickers, so switching a mode never shifts those two.
+   */
+  const modes: ReadonlyArray<{
+    id: string;
+    active: boolean;
+    color: TokenColor;
+    icon: ReactNode;
+    label: string;
+    onTitle: string;
+    pending: boolean;
+    disabledReason: string | undefined;
+    onDeactivate(): void;
+  }> = [
+    {
+      id: 'plan',
+      active: props.planModeActive === true,
+      color: 'blue',
+      icon: <ListTodo size={13} aria-hidden="true" />,
+      label: copy.planModeLabel,
+      onTitle: copy.planModeOnTitle,
+      pending: props.planModePending === true,
+      disabledReason: props.planModeDisabledReason,
+      onDeactivate: () => { void props.onPlanModeChange?.(false); },
+    },
+    {
+      id: 'swarm',
+      active: props.swarmModeActive === true,
+      color: 'teal',
+      icon: <Network size={13} aria-hidden="true" />,
+      label: copy.swarmModeLabel,
+      onTitle: copy.swarmModeOnTitle,
+      pending: props.swarmModePending === true,
+      disabledReason: props.swarmModeDisabledReason,
+      onDeactivate: () => { void props.onSwarmModeChange?.(false); },
+    },
+    {
+      id: 'graph',
+      active: props.graphModeActive === true,
+      color: 'cyan',
+      icon: <Workflow size={13} aria-hidden="true" />,
+      label: copy.graphModeLabel,
+      onTitle: copy.graphModeOnTitle,
+      pending: props.graphModePending === true,
+      disabledReason: props.graphModeDisabledReason,
+      onDeactivate: () => { void props.onGraphModeChange?.(false); },
+    },
+  ];
+  const activeModes = modes
+    .filter((mode) => mode.active)
+    .map((mode) => ({
+      ...mode,
+      isDisabled: props.disabled === true || mode.pending || Boolean(mode.disabledReason),
+    }));
   const showPlusMenu = Boolean(
     props.onPickAttachments
     || props.mentionSkills
@@ -1036,75 +1100,6 @@ export const Composer = forwardRef<
                     }}
                   />
                 ))}
-                {props.planModeActive ? (
-                  <span
-                    className="maka-composer-mode-indicator"
-                    data-mode="plan"
-                    title={props.planModeDisabledReason ?? copy.planModeOnTitle}
-                  >
-                    <Token
-                      size="sm"
-                      color="blue"
-                      label={copy.planModeLabel}
-                      isDisabled={
-                        props.disabled
-                        || props.planModePending === true
-                        || Boolean(props.planModeDisabledReason)
-                      }
-                      onRemove={
-                        props.disabled || props.planModePending || props.planModeDisabledReason
-                          ? undefined
-                          : () => { void props.onPlanModeChange?.(false); }
-                      }
-                    />
-                  </span>
-                ) : null}
-                {props.swarmModeActive ? (
-                  <span
-                    className="maka-composer-mode-indicator"
-                    data-mode="swarm"
-                    title={props.swarmModeDisabledReason ?? copy.swarmModeOnTitle}
-                  >
-                    <Token
-                      size="sm"
-                      color="teal"
-                      label={copy.swarmModeLabel}
-                      isDisabled={
-                        props.disabled
-                        || props.swarmModePending === true
-                        || Boolean(props.swarmModeDisabledReason)
-                      }
-                      onRemove={
-                        props.disabled || props.swarmModePending || props.swarmModeDisabledReason
-                          ? undefined
-                          : () => { void props.onSwarmModeChange?.(false); }
-                      }
-                    />
-                  </span>
-                ) : null}
-                {props.graphModeActive ? (
-                  <span
-                    className="maka-composer-mode-indicator"
-                    data-mode="graph"
-                    title={props.graphModeDisabledReason ?? copy.graphModeOnTitle}
-                  >
-                    <Token
-                      size="sm"
-                      color="cyan"
-                      label={copy.graphModeLabel}
-                      isDisabled={
-                        props.disabled
-                        || props.graphModePending === true
-                        || Boolean(props.graphModeDisabledReason)
-                      }
-                      onRemove={
-                        props.disabled || props.graphModePending || props.graphModeDisabledReason
-                          ? undefined
-                          : () => { void props.onGraphModeChange?.(false); }
-                      }
-                    />
-                  </span>
-                ) : null}
               </div>
             </ChatComposerDrawer>
           ) : undefined}
@@ -1313,6 +1308,28 @@ export const Composer = forwardRef<
                   )}
                 </div>
               ) : null}
+              {/* Mode readouts sit after the model pair, so a mode turning on
+                  or off never nudges the model and thinking pickers (#1897).
+                  Icon-only Tokens: the label is kept for screen readers, and
+                  Astryx's own remove button is the way out. */}
+              {activeModes.map((mode) => (
+                <span
+                  key={mode.id}
+                  className="maka-composer-mode-indicator"
+                  data-mode={mode.id}
+                  title={mode.disabledReason ?? mode.onTitle}
+                >
+                  <Token
+                    size="sm"
+                    color={mode.color}
+                    icon={mode.icon}
+                    label={mode.label}
+                    isLabelHidden
+                    isDisabled={mode.isDisabled}
+                    onRemove={mode.isDisabled ? undefined : mode.onDeactivate}
+                  />
+                </span>
+              ))}
               {props.mentionSkills ? (
                 <ComposerSkillPicker
                   hideTrigger

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -948,52 +948,56 @@ export const Composer = forwardRef<
    * status is on the same file's Don't list.
    */
   const modes: ReadonlyArray<{
-    id: string;
+    id: 'plan' | 'swarm' | 'graph';
     active: boolean;
     icon: ReactNode;
     label: string;
     onTitle: string;
-    pending: boolean;
+    isDisabled: boolean;
     disabledReason: string | undefined;
     onDeactivate(): void;
   }> = [
     {
       id: 'plan',
-      active: props.planModeActive === true,
-      icon: <ListTodo size={13} aria-hidden="true" />,
+      active: props.planModeActive === true && props.onPlanModeChange !== undefined,
+      icon: <ListTodo size={15} aria-hidden="true" />,
       label: copy.planModeLabel,
       onTitle: copy.planModeOnTitle,
-      pending: props.planModePending === true,
+      isDisabled:
+        props.disabled === true
+        || props.planModePending === true
+        || Boolean(props.planModeDisabledReason),
       disabledReason: props.planModeDisabledReason,
       onDeactivate: () => { void props.onPlanModeChange?.(false); },
     },
     {
       id: 'swarm',
-      active: props.swarmModeActive === true,
-      icon: <Network size={13} aria-hidden="true" />,
+      active: props.swarmModeActive === true && props.onSwarmModeChange !== undefined,
+      icon: <Network size={15} aria-hidden="true" />,
       label: copy.swarmModeLabel,
       onTitle: copy.swarmModeOnTitle,
-      pending: props.swarmModePending === true,
+      isDisabled:
+        props.disabled === true
+        || props.swarmModePending === true
+        || Boolean(props.swarmModeDisabledReason),
       disabledReason: props.swarmModeDisabledReason,
       onDeactivate: () => { void props.onSwarmModeChange?.(false); },
     },
     {
       id: 'graph',
-      active: props.graphModeActive === true,
-      icon: <Workflow size={13} aria-hidden="true" />,
+      active: props.graphModeActive === true && props.onGraphModeChange !== undefined,
+      icon: <Workflow size={15} aria-hidden="true" />,
       label: copy.graphModeLabel,
       onTitle: copy.graphModeOnTitle,
-      pending: props.graphModePending === true,
+      isDisabled:
+        props.disabled === true
+        || props.graphModePending === true
+        || Boolean(props.graphModeDisabledReason),
       disabledReason: props.graphModeDisabledReason,
       onDeactivate: () => { void props.onGraphModeChange?.(false); },
     },
   ];
-  const activeModes = modes
-    .filter((mode) => mode.active)
-    .map((mode) => ({
-      ...mode,
-      isDisabled: props.disabled === true || mode.pending || Boolean(mode.disabledReason),
-    }));
+  const activeModes = modes.filter((mode) => mode.active);
   const showPlusMenu = Boolean(
     props.onPickAttachments
     || props.mentionSkills
@@ -1312,25 +1316,27 @@ export const Composer = forwardRef<
                   or off never nudges the model and thinking pickers (#1897).
                   Same ghost icon button as ＋ and permission two slots left —
                   a mode is state on this toolbar, not a coloured pill, and the
-                  icon carries which mode it is. Clicking it leaves the mode. */}
+                  icon carries which mode it is. Clicking it leaves the mode,
+                  which unmounts this button, so focus is handed back to the
+                  input exactly as removing a Skill token does; otherwise a
+                  keyboard user is dropped on `document.body`. */}
               {activeModes.map((mode) => (
-                <span
+                <IconButton
                   key={mode.id}
-                  className="maka-composer-mode-indicator"
+                  variant="ghost"
+                  type="button"
+                  size="sm"
+                  className="maka-composer-mode-button"
                   data-mode={mode.id}
-                >
-                  <IconButton
-                    variant="ghost"
-                    type="button"
-                    size="sm"
-                    className="maka-composer-mode-button"
-                    label={mode.label}
-                    tooltip={mode.disabledReason ?? mode.onTitle}
-                    isDisabled={mode.isDisabled}
-                    onClick={mode.onDeactivate}
-                    icon={mode.icon}
-                  />
-                </span>
+                  label={mode.label}
+                  tooltip={mode.disabledReason ?? mode.onTitle}
+                  isDisabled={mode.isDisabled}
+                  onClick={() => {
+                    mode.onDeactivate();
+                    window.requestAnimationFrame(() => focusInput());
+                  }}
+                  icon={mode.icon}
+                />
               ))}
               {props.mentionSkills ? (
                 <ComposerSkillPicker

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -67,7 +67,6 @@ import {
   type ChatComposerTrigger,
   type SearchableItem,
   type SearchSource,
-  type TokenColor,
 } from '@astryxdesign/core';
 import {
   DropdownMenu,
@@ -942,11 +941,15 @@ export const Composer = forwardRef<
    * marks are the resting state readout, plus one nearby way out. They sit at
    * the tail of the footer's left controls, after the model and thinking
    * pickers, so switching a mode never shifts those two.
+   *
+   * Which mode a mark is comes from its icon, never from a hue. Maka blue is
+   * the single product accent (DESIGN.md), so a per-mode colour would be a
+   * second and third accent carrying no semantic — and a coloured pill per
+   * status is on the same file's Don't list.
    */
   const modes: ReadonlyArray<{
     id: string;
     active: boolean;
-    color: TokenColor;
     icon: ReactNode;
     label: string;
     onTitle: string;
@@ -957,7 +960,6 @@ export const Composer = forwardRef<
     {
       id: 'plan',
       active: props.planModeActive === true,
-      color: 'blue',
       icon: <ListTodo size={13} aria-hidden="true" />,
       label: copy.planModeLabel,
       onTitle: copy.planModeOnTitle,
@@ -968,7 +970,6 @@ export const Composer = forwardRef<
     {
       id: 'swarm',
       active: props.swarmModeActive === true,
-      color: 'teal',
       icon: <Network size={13} aria-hidden="true" />,
       label: copy.swarmModeLabel,
       onTitle: copy.swarmModeOnTitle,
@@ -979,7 +980,6 @@ export const Composer = forwardRef<
     {
       id: 'graph',
       active: props.graphModeActive === true,
-      color: 'cyan',
       icon: <Workflow size={13} aria-hidden="true" />,
       label: copy.graphModeLabel,
       onTitle: copy.graphModeOnTitle,
@@ -1310,23 +1310,25 @@ export const Composer = forwardRef<
               ) : null}
               {/* Mode readouts sit after the model pair, so a mode turning on
                   or off never nudges the model and thinking pickers (#1897).
-                  Icon-only Tokens: the label is kept for screen readers, and
-                  Astryx's own remove button is the way out. */}
+                  Same ghost icon button as ＋ and permission two slots left —
+                  a mode is state on this toolbar, not a coloured pill, and the
+                  icon carries which mode it is. Clicking it leaves the mode. */}
               {activeModes.map((mode) => (
                 <span
                   key={mode.id}
                   className="maka-composer-mode-indicator"
                   data-mode={mode.id}
-                  title={mode.disabledReason ?? mode.onTitle}
                 >
-                  <Token
+                  <IconButton
+                    variant="ghost"
+                    type="button"
                     size="sm"
-                    color={mode.color}
-                    icon={mode.icon}
+                    className="maka-composer-mode-button"
                     label={mode.label}
-                    isLabelHidden
+                    tooltip={mode.disabledReason ?? mode.onTitle}
                     isDisabled={mode.isDisabled}
-                    onRemove={mode.isDisabled ? undefined : mode.onDeactivate}
+                    onClick={mode.onDeactivate}
+                    icon={mode.icon}
                   />
                 </span>
               ))}


### PR DESCRIPTION
## Summary

The composer drawer's contract is context staged for the *next send*. Quotes, attachments and Skills are consumed when the message goes out, and `drawerTokenCount` tells the user how many such items are pending. Plan, Swarm and Graph are session-scoped modes that survive the send, so rendering them there inflated that count with things the send never consumes, and gave a persistent mode the visual weight of a transient attachment. Turning Plan on with nothing staged also mounted the whole drawer, growing the card by ~200px to hold one pill.

The three mode marks move to the tail of the footer's left controls, **after** the model and thinking pickers. Placing them last is the point: a mode turning on or off never nudges those two, which it would if the marks sat before them.

Once they landed next to ＋ and permission, the colours they had inherited stopped being defensible, so the second commit fixes them too. `blue` / `teal` / `cyan` came from Astryx's stock Token palette — `makaTheme.ts` maps nothing onto it — while `DESIGN.md` states that Maka blue is the single product accent and lists "don't introduce another accent" and "don't turn every status into a coloured pill" under Don't. The hues were not carrying semantics either: the palette's meanings are info / success / warning / destructive, and "which mode this is" is not among them. Teal and cyan were a mode index, and they are close enough that Swarm and Graph were hard to separate at icon size.

So the marks are now ghost `IconButton`s — the same primitive as the ＋ and permission buttons they sit beside — tinted with `--accent` over a `currentColor`-derived wash, so a disabled mark dims both layers together. Which mode a mark is comes from its icon. Clicking one leaves the mode, and its tooltip says so; a disabled reason replaces that tooltip and takes the button out of reach.

The ＋ menu is unchanged and remains the switch that turns each mode on *and* off. The footer mark is the resting readout plus one nearby exit — the same reading as the permission icon two slots to its left.

Two judgement calls worth naming:

- **Graph moves with Plan and Swarm.** The issue names the first two, but all three render from one block and share the same miscount; leaving Graph in the drawer would be a new inconsistency rather than a smaller diff.
- **The marks stay visible while streaming.** The model pickers hide entirely mid-turn, but a session mode is exactly what a user needs to see while output is running. `planModeDisabledReason` and friends already disable the button and surface their reason in its tooltip, so nothing becomes actionable that shouldn't be.

One correction to the issue: it says `onRemove` is the only way to leave a mode from the composer. The ＋ menu's checkbox items already toggle both directions, so moving the mark never risked stranding a user in a mode.

The Skill token beside these still uses `purple`, which is off-palette for the same reason. That predates this PR and is left alone here; worth its own issue.

Closes #1897

## Verification

Before/after and all four colour candidates were captured from the built app driven through Playwright `_electron` on the fake backend, with the modes toggled through the real ＋ menu, and composed with ImageMagick. Before: Plan + Swarm stack as full pills in the drawer, pushing the card ~200px taller. After: two accent-tinted icon buttons sit after `Claude Sonnet 4.5 / 默认`, card height unchanged, tooltip reading `Plan 模式已启用，点击关闭`.

- `npm run lint` / `format:check` — clean
- `typecheck` (`@maka/desktop`, all four projects) — clean
- `node scripts/check-dead-css.mjs --check` — clean
- `@maka/ui` unit — 240 pass, 0 fail
- `@maka/desktop` unit — 1339 pass, 0 fail
- desktop E2E — 85/85 (macOS), run again after the colour commit

Contract locks added to `composer-quiet-chrome.test.tsx`:

| lock | what it holds |
| --- | --- |
| modes render inside `maka-composer-left-controls`, at an index after `maka-model-selection-controls` | the marks trail the model pair, so toggling never shifts it |
| the Plan mark carries `lucide-list-todo`, `aria-label="Plan"`, and `maka-composer-mode-button` | identified by icon, named for the mode, still the way out |
| the Plan mark carries no `astryx-token` | a mode is not a coloured pill |
| modes alone mount no `maka-composer-context-drawer` | a mode is not staged context |
| one attachment + two modes on → drawer badge reads `1` | the count excludes modes |

`conversation-localization.test.tsx` keeps its existing coverage — localized tooltips per mode, and the streaming case where the mark stays visible while its button goes inert — retargeted at the new position and primitive.

No new E2E: this is a renderer-only move, and the one E2E that reads the drawer (`quote-companion`) covers quotes, which still live there.

## Third commit: what three-way review found

A subagent, Codex and `kimi-coding/k3-256k` reviewed this branch independently. Each found something the other two missed, and k3's mutation testing showed two of the contracts here were theatre. All findings were adjudicated against the code before any edit; the ones that survived:

**The marks had no hover or press feedback.** `background:` is a shorthand, so it carried an implicit `background-image: none`, and `composer.css` sits in the last cascade layer — that beat the ghost button's own `:hover` / `:active` overlay gradients from `astryx-components`. Measured through CDP rather than inferred: the mark resolved `background-image: none` on hover where the ＋ beside it resolved a gradient, making the one control that leaves a mode the only dead one on the row. Now `background-color`, and so is the voice button, which is where the pattern was copied from and which carried the same bug. k3 argued this was not a finding because it matched the voice button's existing pattern; that the same bug exists elsewhere does not make it not a bug, so both are fixed.

**Leaving a mode dropped focus on `document.body`,** because the click unmounts the button. Removing a Skill token 200 lines up already hands focus back to the input; the modes now do the same.

**An active mode with no change handler rendered a focusable, tooltipped button whose click was a silent no-op.** Gated on the handler, as the ＋ menu's row already was.

**The marks were 13px** where every sibling ghost icon on this toolbar — ＋, permission, mic, and the same three glyphs inside the ＋ menu — is 15px.

**Two locks did not lock anything.** Mutation-verified: deleting the accent rule outright left 240 unit tests, 1339 desktop tests and the dead-CSS gate green; deleting the deactivate handler was equally invisible, because a static render is byte-identical with and without it. The accent rule is now pinned in the existing CSS text-contract seam (`chat-shell-layout-contract.test.ts`) together with a ban on the `background` shorthand for both marks, and "removal stays available" — the one thing #1897 asks for — is covered by one representative E2E journey over pointer, keyboard and the focus handoff.

**The remaining assertions were scoped to the document rather than to the thing they name.** The streaming case now reads the mark's own `<button>` and follows its `aria-describedby` to the reason; the badge matches its own text node; the drawer slice is bounded by the next footer landmark instead of the first `</div>`. Graph joins Plan and Swarm in the position and count cases.

Also simplified: the wrapper `<span>` is gone — `data-mode` rides the button, as the voice button's `data-state` already does — and `activeModes` folds back into one filter, removing the `pending` field and a whole spread-map pass.

Pushed back on two: `aria-pressed` does not apply (the mark only switches off, it never switches on), and renaming the accessible name to "退出 Plan Mode" is unnecessary since the action is carried by the tooltip while the label says what the control is.

### Mutation evidence for the new locks

| mutation | result |
| --- | --- |
| delete the `.maka-composer-mode-button` rule | CSS contract fails ✓ |
| swap `background-color` back to the `background` shorthand | CSS contract fails ✓ |
| delete `mode.onDeactivate()` from the click | E2E fails ✓ |
| delete the `requestAnimationFrame(focusInput)` handoff | E2E fails ✓ |
| drop the handler gate on `active` | unit contract fails ✓ |

Final: lint / format:check / typecheck / dead-css clean, `@maka/ui` 241, `@maka/desktop` 1340, E2E 86/86.

## Review focus

Stories for the four states are in `app-shell.stories.tsx` (`PlanModeOn`, `SwarmModeOn`, `PlanAndSwarmModeOn`, `ModeOnWithPendingAttachments`). The last one is the interesting one: it is the split the issue is about — the badge counts the two attachments, Plan reads off the footer.
