### PR TITLE
feat(runtime-host): execute hosted web research

### DIFF
--- a/packages/core/src/web-search.ts
+++ b/packages/core/src/web-search.ts
@@ -3,9 +3,9 @@
  * paths. One configured provider handles a query; failures are returned as
  * closed reasons rather than silently rotating providers.
  *
- * Main owns credentials, provider calls, and the incognito gate. Renderer
- * results contain normalized title, URL, and snippet fields and never expose
- * cleartext credentials or raw provider errors.
+ * The active execution owner controls credentials, provider calls, and the
+ * incognito gate. Renderer results contain normalized title, URL, and snippet
+ * fields and never expose cleartext credentials or raw provider errors.
  */
 
 /** Closed enum of providers V0.1 will accept. */

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -62,6 +62,7 @@ const RESPONSE_TEXT = 'Hosted real-model execution completed.';
 const SUMMARY_TEXT = '## Goal\nContinue hosted real-model execution.';
 const CLIENT_CAPABILITY_RESULT_TEXT = 'HOSTED_CLIENT_CAPABILITY_RESULT_SENTINEL';
 const CHILD_AGENT_RESULT_TEXT = 'HOSTED_CHILD_AGENT_RESULT_SENTINEL';
+const WEB_RESEARCH_CHILD_RESULT_TEXT = 'HOSTED_WEB_RESEARCH_RESULT_SENTINEL';
 const execFileAsync = promisify(execFile);
 
 test('backend creation aborts a stalled canonical connection read', async () => {
@@ -676,6 +677,7 @@ test('production Host executes a canonical ai-sdk Session against a real provide
       'Skill',
       'SkillSearch',
       'StopBackgroundTask',
+      'WebSearch',
       'Write',
       'WriteStdin',
       'load_tools',
@@ -869,20 +871,28 @@ test('production Host executes a durable runnable child with an exact tool ceili
     );
 
     const requests = provider.requests.filter((request) => request.body.stream === true);
-    assert.equal(requests.length, 4);
+    assert.equal(requests.length, 7);
     assert.ok(toolNames(requests[0]?.body).includes('load_tools'));
     assert.equal(toolNames(requests[0]?.body).includes('agent_spawn'), false);
     assert.ok(toolNames(requests[1]?.body).includes('agent_spawn'));
     assert.deepEqual(toolParameterEnum(requests[1]?.body, 'agent_spawn', 'profile'), [
       'local_read',
+      'web_research',
       'implementation',
     ]);
     assert.deepEqual(toolNames(requests[2]?.body), ['Glob', 'Grep', 'Read']);
     assert.ok(toolNames(requests[3]?.body).includes('agent_spawn'));
+    assert.deepEqual(toolNames(requests[4]?.body), ['WebSearch']);
+    assert.deepEqual(toolNames(requests[5]?.body), ['WebSearch']);
+    assert.ok(toolNames(requests[6]?.body).includes('agent_spawn'));
 
     const sessions = await execution.sessionStore.listForRecovery();
-    const child = sessions.find((session) => session.id !== parent.id);
+    const child = sessions.find((session) => session.subagentRuntime?.profile === 'local_read');
+    const webChild = sessions.find(
+      (session) => session.subagentRuntime?.profile === 'web_research',
+    );
     assert.ok(child);
+    assert.ok(webChild);
     assert.equal(child?.subagentRuntime?.profile, 'local_read');
     assert.equal(child?.subagentParent?.parentSessionId, parent.id);
     if (!child) return;
@@ -897,6 +907,31 @@ test('production Host executes a durable runnable child with an exact tool ceili
       childMessages.find((message) => message.type === 'assistant')?.text,
       CHILD_AGENT_RESULT_TEXT,
     );
+    if (!webChild) return;
+    const webChildRuns = await execution.agentRunStore.listSessionRuns(webChild.id);
+    assert.equal(webChildRuns.length, 1);
+    assert.equal(webChildRuns[0]?.status, 'completed');
+    const webChildMessages = await execution.sessionStore.readMessagesSnapshot(webChild.id);
+    assert.equal(
+      webChildMessages.find((message) => message.type === 'assistant')?.text,
+      WEB_RESEARCH_CHILD_RESULT_TEXT,
+    );
+    const webChildEvents = await execution.runtimeEventStore.readRuntimeEvents(
+      webChild.id,
+      webChildRuns[0]!.runId,
+    );
+    const searchResult = webChildEvents.find(
+      (event) => event.content?.kind === 'function_response' && event.content.name === 'WebSearch',
+    );
+    assert.ok(searchResult?.content?.kind === 'function_response');
+    assert.deepEqual(decodeCanonicalToolResultContent(searchResult.content.result), {
+      kind: 'web_search_error',
+      ok: false,
+      provider: 'tavily',
+      query: 'latest hosted web result',
+      reason: 'not_configured',
+      message: 'Enable web search before using this tool.',
+    });
     const artifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
     const childArtifacts = await artifacts.listTurnArtifacts(child.id, childRuns[0]!.turnId);
     assert.equal(childArtifacts.length, 1);
@@ -1052,6 +1087,7 @@ test('production Host publishes and retires an implementation child patch', asyn
     assert.ok(toolNames(requests[1]?.body).includes('agent_spawn'));
     assert.deepEqual(toolParameterEnum(requests[1]?.body, 'agent_spawn', 'profile'), [
       'local_read',
+      'web_research',
       'implementation',
     ]);
     assert.deepEqual(toolNames(requests[2]?.body), [
@@ -2087,6 +2123,29 @@ async function handleProviderRequest(
   if (flow.kind === 'child_agent' && streamRequestIndex === 3) {
     assert.deepEqual(toolNames(body), ['Glob', 'Grep', 'Read']);
     respondProviderText(response, CHILD_AGENT_RESULT_TEXT);
+    return;
+  }
+  if (flow.kind === 'child_agent' && streamRequestIndex === 4) {
+    assert.ok(toolNames(body).includes('agent_spawn'));
+    respondProviderToolCall(response, streamRequestIndex, 'agent_spawn', {
+      profile: 'web_research',
+      task: 'Find one current hosted web result.',
+      isolation: 'same_workspace',
+      write_back: 'summary',
+    });
+    return;
+  }
+  if (flow.kind === 'child_agent' && streamRequestIndex === 5) {
+    assert.deepEqual(toolNames(body), ['WebSearch']);
+    respondProviderToolCall(response, streamRequestIndex, 'WebSearch', {
+      query: 'latest hosted web result',
+      limit: 1,
+    });
+    return;
+  }
+  if (flow.kind === 'child_agent' && streamRequestIndex === 6) {
+    assert.deepEqual(toolNames(body), ['WebSearch']);
+    respondProviderText(response, WEB_RESEARCH_CHILD_RESULT_TEXT);
     return;
   }
   if (flow.kind === 'implementation_child_agent' && streamRequestIndex === 3) {

--- a/packages/runtime-host/src/__tests__/web-search-tool.test.ts
+++ b/packages/runtime-host/src/__tests__/web-search-tool.test.ts
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createDefaultRuntimePolicy } from '@maka/core/runtime-policy';
+import type { MakaToolContext, ProxiedFetchProxy } from '@maka/runtime';
+import type {
+  ResolveWebSearchExecutionResult,
+  RuntimePolicyOperationCoordinator,
+} from '@maka/storage/runtime-policy-stores';
+import { createHostWebSearchTool } from '../server/web-search-tool.js';
+
+test('Host WebSearch fails closed before transport creation for unavailable policy states', async () => {
+  const states: readonly ResolveWebSearchExecutionResult[] = [
+    { kind: 'privacy_mode' },
+    { kind: 'disabled', provider: 'tavily' },
+    {
+      kind: 'credential_not_configured',
+      status: {
+        locator: { scope: 'web_search', provider: 'tavily', kind: 'api_key' },
+        configured: false,
+        credentialId: null,
+        revision: null,
+        updatedAt: null,
+      },
+    },
+  ];
+
+  for (const state of states) {
+    let transportCreated = false;
+    const tool = createHostWebSearchTool({
+      policy: resolver(state),
+      createFetchTransport: () => {
+        transportCreated = true;
+        throw new Error('transport must not be created');
+      },
+    });
+    const result = (await tool.impl({ query: 'current result' }, {} as MakaToolContext)) as {
+      kind: string;
+      reason: string;
+    };
+    assert.equal(result.kind, 'web_search_error');
+    assert.equal(
+      result.reason,
+      state.kind === 'privacy_mode' ? 'incognito_active' : 'not_configured',
+    );
+    assert.equal(transportCreated, false);
+  }
+});
+
+test('Host WebSearch consumes one canonical credential/proxy snapshot and closes transport', async () => {
+  const networkProxy = {
+    ...createDefaultRuntimePolicy().networkProxy,
+    enabled: true,
+    protocol: 'https' as const,
+    host: 'proxy.example',
+    port: 8443,
+    authEnabled: true,
+    username: 'proxy-user',
+    bypassList: ['one.example'],
+    autoBypassDomains: ['two.example'],
+  };
+  let proxy: ProxiedFetchProxy | null | undefined;
+  let closed = 0;
+  let providerBody: Record<string, unknown> | undefined;
+  const tool = createHostWebSearchTool({
+    policy: resolver({
+      kind: 'ready',
+      provider: 'tavily',
+      networkProxy,
+      secretMaterial: {
+        webSearch: {
+          locator: { scope: 'web_search', provider: 'tavily', kind: 'api_key' },
+          credentialId: 'web-search-credential',
+          revision: 3,
+          secret: 'tavily-secret',
+        },
+        networkProxy: {
+          locator: { scope: 'network_proxy', kind: 'password' },
+          credentialId: 'proxy-credential',
+          revision: 4,
+          secret: 'proxy-secret',
+        },
+      },
+    }),
+    createFetchTransport: (candidate) => {
+      proxy = candidate;
+      return {
+        fetch: async (_input, init) => {
+          providerBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+          return Response.json({
+            results: [
+              {
+                title: 'Maka',
+                url: 'https://maka.example/current',
+                content: 'Current information.',
+              },
+            ],
+          });
+        },
+        close: async () => {
+          closed += 1;
+        },
+      };
+    },
+  });
+
+  const result = await tool.impl({ query: ' latest Maka ', limit: 1 }, {} as MakaToolContext);
+  assert.deepEqual(proxy, {
+    enabled: true,
+    type: 'https',
+    host: 'proxy.example',
+    port: 8443,
+    username: 'proxy-user',
+    password: 'proxy-secret',
+    bypassList: ['one.example', 'two.example'],
+  });
+  assert.deepEqual(providerBody, {
+    api_key: 'tavily-secret',
+    query: 'latest Maka',
+    max_results: 1,
+    search_depth: 'basic',
+  });
+  assert.equal(closed, 1);
+  assert.deepEqual(result, {
+    kind: 'web_search',
+    provider: 'tavily',
+    query: 'latest Maka',
+    rows: [
+      {
+        title: 'Maka',
+        url: 'https://maka.example/current',
+        snippet: 'Current information.',
+        source: 'maka.example',
+      },
+    ],
+  });
+  assert.doesNotMatch(JSON.stringify(result), /tavily-secret|proxy-secret/);
+});
+
+test('Host WebSearch closes its transport when the owning turn is cancelled', async () => {
+  const abort = new AbortController();
+  let closed = false;
+  const tool = createHostWebSearchTool({
+    policy: resolver(readyDirectExecution()),
+    createFetchTransport: () => ({
+      fetch: async (_input, init) =>
+        await new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        }),
+      close: async () => {
+        closed = true;
+      },
+    }),
+  });
+  const running = Promise.resolve(
+    tool.impl({ query: 'cancel me' }, {
+      abortSignal: abort.signal,
+    } as MakaToolContext),
+  );
+  const reason = new DOMException('Turn stopped', 'AbortError');
+  abort.abort(reason);
+  await assert.rejects(running, (error: unknown) => error === reason);
+  assert.equal(closed, true);
+});
+
+function resolver(
+  result: ResolveWebSearchExecutionResult,
+): Pick<RuntimePolicyOperationCoordinator, 'resolveWebSearchExecution'> {
+  return { resolveWebSearchExecution: async () => result };
+}
+
+function readyDirectExecution(): ResolveWebSearchExecutionResult {
+  return {
+    kind: 'ready',
+    provider: 'tavily',
+    networkProxy: createDefaultRuntimePolicy().networkProxy,
+    secretMaterial: {
+      webSearch: {
+        locator: { scope: 'web_search', provider: 'tavily', kind: 'api_key' },
+        credentialId: 'web-search-credential',
+        revision: 1,
+        secret: 'tavily-secret',
+      },
+    },
+  };
+}

--- a/packages/runtime-host/src/server/child-agent-composition.ts
+++ b/packages/runtime-host/src/server/child-agent-composition.ts
@@ -41,10 +41,11 @@ export interface HostChildAgentToolComposition {
 export function createHostChildAgentToolComposition(input: {
   readonly taskLedger: TaskLedgerStore;
   readonly builtinTools: BuildBuiltinToolsOptions;
+  readonly hostTools?: readonly MakaTool[];
   readonly worktreePatchWriteBackAvailable?: boolean;
 }): HostChildAgentToolComposition {
   const builtinTools = buildBuiltinTools(input.builtinTools);
-  const childTools = buildChildAgentTools(builtinTools);
+  const childTools = buildChildAgentTools([...builtinTools, ...(input.hostTools ?? [])]);
   const definitions = listRunnableBuiltinAgentDefinitions({
     tools: childTools,
     worktreeChildExecutorAvailable: input.worktreePatchWriteBackAvailable,

--- a/packages/runtime-host/src/server/connection-effect-coordinator.ts
+++ b/packages/runtime-host/src/server/connection-effect-coordinator.ts
@@ -3,7 +3,6 @@ import type {
   ConnectionModelDiscoveryResult,
   ConnectionTestErrorClass,
   ConnectionTestSummary,
-  RuntimePolicy,
 } from '@maka/core/runtime-policy';
 import {
   createConnectionEffectFetchTransport,
@@ -38,6 +37,7 @@ import type {
 } from '../protocol/index.js';
 import type { ConnectionEffectOperationHandlerMap } from './operation-dispatcher.js';
 import { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js';
+import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
 
 type ModelDiscoveryRunner = (
   connection: ConnectionCatalogEntry,
@@ -213,7 +213,7 @@ export class HostConnectionEffectCoordinator {
     run: (fetch: typeof globalThis.fetch) => Promise<T>,
   ): Promise<T> {
     const transport = this.#createTransport(
-      toProxySnapshot(prepared.networkProxy, prepared.secretMaterial),
+      toRuntimePolicyProxy(prepared.networkProxy, prepared.secretMaterial.networkProxy?.secret),
     );
     try {
       return await run(transport.fetch);
@@ -283,29 +283,6 @@ function projectSuperseded(
 
 function connectionSecret(material: RuntimePolicyOperationSecretMaterial): string {
   return material.connection?.secret ?? '';
-}
-
-function toProxySnapshot(
-  proxy: RuntimePolicy['networkProxy'],
-  material: RuntimePolicyOperationSecretMaterial,
-): ConnectionEffectProxySnapshot | null {
-  if (!proxy.enabled) return null;
-  if (proxy.authEnabled && !material.networkProxy) {
-    throw new Error('Connection effect proxy admission omitted credential material');
-  }
-  return {
-    enabled: true,
-    type: proxy.protocol,
-    host: proxy.host,
-    port: proxy.port,
-    ...(proxy.authEnabled
-      ? {
-          username: proxy.username,
-          password: material.networkProxy!.secret,
-        }
-      : {}),
-    bypassList: [...new Set([...proxy.bypassList, ...proxy.autoBypassDomains])],
-  };
 }
 
 function projectConnectionTest(

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -66,6 +66,7 @@ import { HostSkillCatalogCoordinator } from './skill-catalog-coordinator.js';
 import { SkillCatalogRepository } from './skill-catalog-repository.js';
 import { HostTaskLedgerCoordinator } from './task-ledger-coordinator.js';
 import { HostUsagePricingCoordinator } from './usage-pricing-coordinator.js';
+import { createHostWebSearchTool } from './web-search-tool.js';
 
 export async function createExecutionRuntimeHostComposition(
   context: RuntimeHostCompositionContext,
@@ -157,9 +158,11 @@ export async function createExecutionRuntimeHostComposition(
       ...(sandboxManager ? { sandboxManager } : {}),
       ...(filesystemWorker ? { filesystemWorker } : {}),
     };
+    const hostTools = [createHostWebSearchTool({ policy: runtimePolicyStores.operations })];
     const childAgentTools = createHostChildAgentToolComposition({
       taskLedger,
       builtinTools,
+      hostTools,
       worktreePatchWriteBackAvailable: true,
     });
     const openedGraphControlStore = createAgentGraphControlStore(
@@ -289,6 +292,7 @@ export async function createExecutionRuntimeHostComposition(
         automationTool: requireAutomationCoordinator(automations).modelTool,
         goalTools: requireGoal(goal).tools,
         builtinTools,
+        hostTools,
         parentAgentTools: childAgentTools.parentTools,
         childAgents: bindHostChildAgentBackend(
           requireSessionManager(manager),

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -72,6 +72,7 @@ import {
   type HostOAuthExecutionBinding,
 } from './oauth-execution-authority.js';
 import type { HostChildAgentBackendCapabilities } from './child-agent-composition.js';
+import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
 
 const CHILD_INSTRUCTION_BOUNDARY = [
   'A child agent inherits the current session permission, privacy, workspace, and skill constraints.',
@@ -107,6 +108,7 @@ export interface HostExecutionModelCompositionInput {
   readonly now?: () => Date;
   readonly clientCapabilities?: Pick<ClientCapabilitySnapshot, 'tools' | 'groups'>;
   readonly builtinTools?: BuildBuiltinToolsOptions;
+  readonly hostTools?: readonly MakaTool[];
   readonly automationTool?: MakaTool;
   readonly goalTools?: readonly MakaTool[];
   readonly parentAgentTools?: readonly MakaTool[];
@@ -123,6 +125,7 @@ export function createHostExecutionModelComposition(
         input.taskLedger,
         inventoryFor,
         input.builtinTools,
+        input.hostTools,
         input.automationTool,
         input.goalTools,
         input.parentAgentTools,
@@ -217,6 +220,7 @@ export interface HostAiSdkBackendInput {
   readonly clientCapabilities: HostClientCapabilityCoordinator;
   readonly runtimeCommitSink?: RuntimeCommitSink;
   readonly builtinTools?: BuildBuiltinToolsOptions;
+  readonly hostTools?: readonly MakaTool[];
   readonly automationTool?: MakaTool;
   readonly goalTools?: readonly MakaTool[];
   readonly parentAgentTools?: readonly MakaTool[];
@@ -278,7 +282,7 @@ export function createHostGoalEvaluator(input: HostGoalEvaluatorInput): GoalEval
       ]);
       const pricing = buildPricingLookup(pricingSnapshot.overrides);
       const transport = createFetchTransport(
-        toProxySettings(target.networkProxy, target.proxySecret),
+        toRuntimePolicyProxy(target.networkProxy, target.proxySecret),
       );
       let apiKey = target.apiKey;
       let modelFetch: typeof fetch = transport.fetch;
@@ -410,7 +414,9 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
     input.context.abortSignal,
   );
   const pricing = buildPricingLookup(pricingSnapshot.overrides);
-  const transport = createFetchTransport(toProxySettings(target.networkProxy, target.proxySecret));
+  const transport = createFetchTransport(
+    toRuntimePolicyProxy(target.networkProxy, target.proxySecret),
+  );
   let apiKey = target.apiKey;
   let modelFetch: typeof fetch = transport.fetch;
   const oauthBinding = target.oauthBinding;
@@ -454,6 +460,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
       ...(input.context.tools ? { boundTools: input.context.tools } : {}),
       ...(clientCapabilities ? { clientCapabilities } : {}),
       ...(input.builtinTools ? { builtinTools: input.builtinTools } : {}),
+      ...(input.hostTools ? { hostTools: input.hostTools } : {}),
       ...(input.automationTool ? { automationTool: input.automationTool } : {}),
       ...(input.goalTools ? { goalTools: input.goalTools } : {}),
       ...(input.parentAgentTools ? { parentAgentTools: input.parentAgentTools } : {}),
@@ -803,7 +810,7 @@ async function resolveExecutionTarget(
   if (provider.authKind === 'oauth_token') {
     const material = resolved.secretMaterial.connection;
     if (!material) throw new Error('Runtime Host OAuth credential is not configured');
-    const refreshProxy = toProxySettings(
+    const refreshProxy = toRuntimePolicyProxy(
       resolved.networkProxy,
       resolved.secretMaterial.networkProxy?.secret,
     );
@@ -839,6 +846,7 @@ function buildDefaultHostTools(
   taskLedger: TaskLedgerStore,
   inventoryFor: SkillInventoryResolver,
   builtinOptions?: BuildBuiltinToolsOptions,
+  hostTools: readonly MakaTool[] = [],
   automationTool?: MakaTool,
   goalTools: readonly MakaTool[] = [],
   parentAgentTools: readonly MakaTool[] = [],
@@ -848,6 +856,7 @@ function buildDefaultHostTools(
   const taskTools = buildTaskLedgerTools({ store: taskLedger });
   const toolNames = [
     ...builtins.map((tool) => tool.name),
+    ...hostTools.map((tool) => tool.name),
     question.name,
     'Skill',
     'SkillSearch',
@@ -860,6 +869,7 @@ function buildDefaultHostTools(
   const shadowTracker = new SkillShadowSelectionTracker();
   return [
     ...builtins,
+    ...hostTools,
     question,
     buildSkillAgentToolFromInventory(inventoryFor, skillHost, {
       shadowTracker,
@@ -921,21 +931,6 @@ function renderMemoryPrompt(body: string): string {
     body,
     '</local-memory>',
   ].join('\n');
-}
-
-function toProxySettings(
-  proxy: ResolvedExecutionTarget['networkProxy'],
-  password: string | undefined,
-): ProxiedFetchProxy | null {
-  if (!proxy.enabled) return null;
-  return {
-    enabled: true,
-    type: proxy.protocol,
-    host: proxy.host,
-    port: proxy.port,
-    ...(proxy.authEnabled ? { username: proxy.username, password: password ?? '' } : {}),
-    bypassList: [...new Set([...proxy.bypassList, ...proxy.autoBypassDomains])],
-  };
 }
 
 function renderTaskLedgerTail(

--- a/packages/runtime-host/src/server/oauth-coordinator.ts
+++ b/packages/runtime-host/src/server/oauth-coordinator.ts
@@ -1,7 +1,6 @@
 import { randomBytes } from 'node:crypto';
 import { createServer, type Server } from 'node:http';
 import { constantTimeStringEqual, parsePastedAuthorization } from '@maka/core/oauth-subscription';
-import type { RuntimePolicy } from '@maka/core/runtime-policy';
 import {
   buildOAuthLoginAuthorization,
   createProxiedFetchTransport,
@@ -10,7 +9,6 @@ import {
   pollXaiDeviceAuthorization,
   serializeOAuthSubscriptionTokens,
   startXaiDeviceAuthorization,
-  type ProxiedFetchProxy,
 } from '@maka/runtime';
 import {
   RuntimePolicyStoreError,
@@ -35,6 +33,7 @@ import {
 } from './client-capability-coordinator.js';
 import type { OAuthOperationHandlerMap } from './operation-dispatcher.js';
 import type { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js';
+import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
 
 const CODEX_CALLBACK_HOST = '127.0.0.1';
 const CODEX_CALLBACK_PORT = 1455;
@@ -291,7 +290,7 @@ export class HostOAuthCoordinator {
     let loopback: LoopbackClaim | undefined;
     try {
       transport = createProxiedFetchTransport(
-        toProxySettings(
+        toRuntimePolicyProxy(
           attempt.ticket.networkProxy,
           attempt.ticket.secretMaterial.networkProxy?.secret,
         ),
@@ -670,21 +669,6 @@ async function withDeadline<T>(
 
 function isCommitOutcomeUnknown(error: unknown): error is RuntimePolicyStoreError {
   return error instanceof RuntimePolicyStoreError && error.code === 'commit_outcome_unknown';
-}
-
-function toProxySettings(
-  proxy: RuntimePolicy['networkProxy'],
-  password: string | undefined,
-): ProxiedFetchProxy | null {
-  if (!proxy.enabled) return null;
-  return {
-    enabled: true,
-    type: proxy.protocol,
-    host: proxy.host,
-    port: proxy.port,
-    ...(proxy.authEnabled ? { username: proxy.username, password: password ?? '' } : {}),
-    bypassList: [...new Set([...proxy.bypassList, ...proxy.autoBypassDomains])],
-  };
 }
 
 function authorizationInProgress(): OperationOutcome<'oauth.login.start'> {

--- a/packages/runtime-host/src/server/runtime-policy-proxy.ts
+++ b/packages/runtime-host/src/server/runtime-policy-proxy.ts
@@ -1,0 +1,20 @@
+import type { RuntimePolicy } from '@maka/core/runtime-policy';
+import type { ProxiedFetchProxy } from '@maka/runtime';
+
+export function toRuntimePolicyProxy(
+  proxy: RuntimePolicy['networkProxy'],
+  password: string | undefined,
+): ProxiedFetchProxy | null {
+  if (!proxy.enabled) return null;
+  if (proxy.authEnabled && password === undefined) {
+    throw new Error('Network proxy execution admission omitted its credential');
+  }
+  return {
+    enabled: true,
+    type: proxy.protocol,
+    host: proxy.host,
+    port: proxy.port,
+    ...(proxy.authEnabled ? { username: proxy.username, password } : {}),
+    bypassList: [...new Set([...proxy.bypassList, ...proxy.autoBypassDomains])],
+  };
+}

--- a/packages/runtime-host/src/server/web-search-tool.ts
+++ b/packages/runtime-host/src/server/web-search-tool.ts
@@ -1,0 +1,72 @@
+import {
+  buildWebSearchTool,
+  createProxiedFetchTransport,
+  queryTavily,
+  type MakaTool,
+  type ProxiedFetchProxy,
+  type ProxiedFetchTransport,
+} from '@maka/runtime';
+import type { RuntimePolicyOperationCoordinator } from '@maka/storage/runtime-policy-stores';
+import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
+
+export function createHostWebSearchTool(input: {
+  readonly policy: Pick<RuntimePolicyOperationCoordinator, 'resolveWebSearchExecution'>;
+  readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
+}): MakaTool {
+  const createFetchTransport = input.createFetchTransport ?? createProxiedFetchTransport;
+  return buildWebSearchTool({
+    search: async ({ query, limit, abortSignal }) => {
+      const resolved = await input.policy.resolveWebSearchExecution();
+      switch (resolved.kind) {
+        case 'privacy_mode':
+          return {
+            ok: false,
+            reason: 'incognito_active',
+            message: 'Web search is disabled while privacy mode is active.',
+          };
+        case 'disabled':
+          return {
+            ok: false,
+            reason: 'not_configured',
+            message: 'Enable web search before using this tool.',
+          };
+        case 'credential_not_configured':
+          return {
+            ok: false,
+            reason: 'not_configured',
+            message:
+              resolved.status.locator.scope === 'network_proxy'
+                ? 'Configure the network proxy credential before using web search.'
+                : 'Configure a Tavily API key before using web search.',
+          };
+        case 'ready': {
+          if (resolved.provider !== 'tavily') {
+            return {
+              ok: false,
+              reason: 'unsupported_provider',
+              message: 'The configured web search provider is not supported by this Host.',
+            };
+          }
+          const apiKey = resolved.secretMaterial.webSearch.secret;
+          const transport = createFetchTransport(
+            toRuntimePolicyProxy(
+              resolved.networkProxy,
+              resolved.secretMaterial.networkProxy?.secret,
+            ),
+          );
+          try {
+            return await queryTavily({
+              apiKey,
+              query,
+              limit,
+              fetch: transport.fetch,
+              ...(abortSignal ? { abortSignal } : {}),
+            });
+          } finally {
+            await transport.close();
+          }
+        }
+      }
+    },
+  });
+}

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10010,6 +10010,45 @@ describe('AiSdkBackend tool execution', () => {
     assert.equal(JSON.stringify(telemetry).includes('correct-horse-battery-staple'), false);
   });
 
+  test('WebSearch telemetry never copies the user-derived query', async () => {
+    const telemetry: Array<{ argsSummary?: string }> = [];
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header('bypass'),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'claude-sonnet-4-5-20250929',
+      modelFactory: () => ({}),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      recordToolInvocation: (record) => {
+        telemetry.push({ argsSummary: record.argsSummary });
+      },
+    });
+    const tool: MakaTool = {
+      name: 'WebSearch',
+      description: 'search web',
+      parameters: {},
+      impl: async () => ({
+        kind: 'web_search',
+        provider: 'tavily',
+        query: 'PRIVATE_QUERY_SENTINEL',
+        rows: [],
+      }),
+    };
+    const execute = runtimeExecute(backend, tool, 'turn-1', { push: () => {} });
+
+    await execute(
+      { query: 'PRIVATE_QUERY_SENTINEL', limit: 3 },
+      { toolCallId: 'tool-web-search', abortSignal: new AbortController().signal },
+    );
+
+    assert.deepEqual(telemetry, [{ argsSummary: '{"limit":3}' }]);
+    assert.doesNotMatch(JSON.stringify(telemetry), /PRIVATE_QUERY_SENTINEL/);
+  });
+
   test('tool failure telemetry classifies and redacts generic implementation errors', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/tavily-search.test.ts
+++ b/packages/runtime/src/__tests__/tavily-search.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { queryTavily } from '../tavily-search.js';
+
+test('Tavily search sends one bounded request and projects only safe rows', async () => {
+  let requestBody: Record<string, unknown> | undefined;
+  const result = await queryTavily({
+    apiKey: 'tavily-secret',
+    query: ' current results ',
+    limit: 2,
+    fetch: async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return Response.json({
+        results: [
+          {
+            title: 'A'.repeat(300),
+            url: 'https://one.example/article',
+            content: 'S'.repeat(500),
+          },
+          { title: 'unsafe', url: 'file:///private/result', content: 'discarded' },
+          {
+            title: 'credential URL',
+            url: 'https://user:password@example.com',
+            content: 'discarded',
+          },
+          { title: 'malformed', url: 'https://[invalid', content: 'discarded' },
+          {
+            title: 'oversized after normalization',
+            url: `https://unicode.example/${'汉'.repeat(2_000)}`,
+            content: 'discarded',
+          },
+          { title: 'Second', url: 'http://two.example/result', content: 'two' },
+          { title: 'Third', url: 'https://three.example/result', content: 'three' },
+        ],
+      });
+    },
+  });
+
+  assert.deepEqual(requestBody, {
+    api_key: 'tavily-secret',
+    query: 'current results',
+    max_results: 2,
+    search_depth: 'basic',
+  });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.results.length, 2);
+  assert.equal(result.results[0]?.title.length, 240);
+  assert.equal(result.results[0]?.snippet.length, 400);
+  assert.equal(result.results[0]?.source, 'one.example');
+  assert.equal(result.results[1]?.source, 'two.example');
+  assert.doesNotMatch(JSON.stringify(result), /tavily-secret/);
+});
+
+test('Tavily search fails closed over oversized or invalid provider responses', async () => {
+  for (const body of [
+    JSON.stringify({ results: [{ content: 'x'.repeat(256) }] }),
+    JSON.stringify({ answer: 'unexpected response shape' }),
+    'not-json',
+  ]) {
+    const result = await queryTavily({
+      apiKey: 'tavily-secret',
+      query: 'bounded response',
+      limit: 5,
+      responseMaxBytes: 64,
+      fetch: async () => new Response(body, { status: 200 }),
+    });
+    assert.deepEqual(result, {
+      ok: false,
+      reason: 'network_error',
+      message: 'The Tavily request failed.',
+    });
+  }
+});
+
+test('Tavily search distinguishes its timeout from caller cancellation', async () => {
+  const waitForAbort: typeof fetch = async (_input, init) =>
+    await new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      assert.ok(signal);
+      signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+    });
+
+  const timedOut = await queryTavily({
+    apiKey: 'tavily-secret',
+    query: 'slow search',
+    limit: 5,
+    timeoutMs: 5,
+    fetch: waitForAbort,
+  });
+  assert.equal(timedOut.ok, false);
+  if (!timedOut.ok) assert.equal(timedOut.reason, 'timeout');
+
+  const abort = new AbortController();
+  const cancelled = queryTavily({
+    apiKey: 'tavily-secret',
+    query: 'cancelled search',
+    limit: 5,
+    abortSignal: abort.signal,
+    fetch: waitForAbort,
+  });
+  const reason = new DOMException('Parent turn stopped', 'AbortError');
+  abort.abort(reason);
+  await assert.rejects(cancelled, (error) => error === reason);
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -400,6 +400,8 @@ export type {
 } from './pi-agent-backend.js';
 
 export { buildBuiltinTools } from './builtin-tools.js';
+export { queryTavily } from './tavily-search.js';
+export { buildWebSearchTool } from './web-search-tool.js';
 export type {
   BuildBuiltinToolsOptions,
   MakaTool as BuiltinMakaTool,

--- a/packages/runtime/src/tavily-search.ts
+++ b/packages/runtime/src/tavily-search.ts
@@ -1,0 +1,201 @@
+import {
+  WEB_SEARCH_MAX_LIMIT,
+  normalizeWebSearchLimit,
+  normalizeWebSearchQuery,
+  type WebSearchResponse,
+  type WebSearchResultRow,
+} from '@maka/core';
+
+const TAVILY_ENDPOINT = 'https://api.tavily.com/search';
+const TAVILY_TIMEOUT_MS = 10_000;
+const TAVILY_RESPONSE_MAX_BYTES = 1_048_576;
+const TAVILY_RESULT_URL_MAX_CHARS = 2_048;
+const TAVILY_RESULT_TITLE_MAX_CHARS = 240;
+const TAVILY_RESULT_SNIPPET_MAX_CHARS = 400;
+
+interface TavilyRawResult {
+  readonly title?: unknown;
+  readonly url?: unknown;
+  readonly content?: unknown;
+}
+
+interface TavilyRawResponse {
+  readonly results?: unknown;
+}
+
+interface QueryTavilyInput {
+  readonly apiKey: string;
+  readonly query: string;
+  readonly limit: number;
+  readonly fetch?: typeof globalThis.fetch;
+  readonly abortSignal?: AbortSignal;
+  readonly timeoutMs?: number;
+  readonly responseMaxBytes?: number;
+}
+
+/** Executes one bounded Tavily request without logging query or credential material. */
+export async function queryTavily(input: QueryTavilyInput): Promise<WebSearchResponse> {
+  const apiKey = input.apiKey.trim();
+  if (apiKey.length === 0) {
+    return {
+      ok: false,
+      reason: 'not_configured',
+      message: 'Configure a Tavily API key before using web search.',
+    };
+  }
+  const query = normalizeWebSearchQuery(input.query);
+  if (!query) {
+    return { ok: false, reason: 'invalid_query', message: 'Web search requires a valid query.' };
+  }
+
+  const externalSignal = input.abortSignal;
+  if (externalSignal?.aborted) throw abortReason(externalSignal);
+  const timeoutMs = input.timeoutMs ?? TAVILY_TIMEOUT_MS;
+  const controller = new AbortController();
+  let timedOut = false;
+  const onExternalAbort = () => controller.abort(abortReason(externalSignal!));
+  externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort(new DOMException('Tavily request timed out', 'TimeoutError'));
+  }, timeoutMs);
+
+  try {
+    const limit = Math.min(WEB_SEARCH_MAX_LIMIT, normalizeWebSearchLimit(input.limit));
+    const response = await (input.fetch ?? globalThis.fetch)(TAVILY_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        api_key: apiKey,
+        query,
+        max_results: limit,
+        search_depth: 'basic',
+      }),
+      signal: controller.signal,
+    });
+    if (response.status === 401 || response.status === 403) {
+      return {
+        ok: false,
+        reason: 'invalid_credentials',
+        message: 'Tavily rejected the configured API key.',
+      };
+    }
+    if (response.status === 429) {
+      return {
+        ok: false,
+        reason: 'rate_limited',
+        message: 'Tavily rate-limited the search request.',
+      };
+    }
+    if (!response.ok) {
+      return {
+        ok: false,
+        reason: 'network_error',
+        message: `Tavily returned HTTP ${response.status}.`,
+      };
+    }
+    const body = await readBoundedJson(
+      response,
+      input.responseMaxBytes ?? TAVILY_RESPONSE_MAX_BYTES,
+    );
+    const results = mapTavilyRows(body, limit);
+    if (!results) throw new Error('Tavily response shape is invalid');
+    return { ok: true, results };
+  } catch (error) {
+    if (externalSignal?.aborted) throw abortReason(externalSignal);
+    if (timedOut) {
+      return {
+        ok: false,
+        reason: 'timeout',
+        message: `Tavily did not respond within ${Math.round(timeoutMs / 1_000)} seconds.`,
+      };
+    }
+    return {
+      ok: false,
+      reason: 'network_error',
+      message: 'The Tavily request failed.',
+    };
+  } finally {
+    clearTimeout(timeout);
+    externalSignal?.removeEventListener('abort', onExternalAbort);
+  }
+}
+
+function mapTavilyRows(raw: unknown, limit: number): WebSearchResultRow[] | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const candidates = (raw as TavilyRawResponse).results;
+  if (!Array.isArray(candidates)) return null;
+
+  const rows: WebSearchResultRow[] = [];
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const rawRow = candidate as TavilyRawResult;
+    const location = normalizeResultLocation(rawRow.url);
+    if (!location) continue;
+    rows.push({
+      provider: 'tavily',
+      title: safeString(rawRow.title, location.url).slice(0, TAVILY_RESULT_TITLE_MAX_CHARS),
+      url: location.url,
+      snippet: safeString(rawRow.content).slice(0, TAVILY_RESULT_SNIPPET_MAX_CHARS),
+      source: location.source,
+    });
+    if (rows.length >= limit) break;
+  }
+  return rows;
+}
+
+async function readBoundedJson(response: Response, maxBytes: number): Promise<unknown> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new Error('Tavily response byte limit is invalid');
+  }
+  if (!response.body) return undefined;
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel('Tavily response exceeded its byte limit');
+        throw new Error('Tavily response exceeded its byte limit');
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return JSON.parse(
+    Buffer.concat(
+      chunks.map((chunk) => Buffer.from(chunk)),
+      total,
+    ).toString('utf8'),
+  );
+}
+
+function safeString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function normalizeResultLocation(
+  value: unknown,
+): { readonly url: string; readonly source: string } | null {
+  if (typeof value !== 'string' || value.length > TAVILY_RESULT_URL_MAX_CHARS) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    if (url.username || url.password || !url.hostname) return null;
+    const normalized = url.toString();
+    if (normalized.length > TAVILY_RESULT_URL_MAX_CHARS) return null;
+    return { url: normalized, source: url.hostname };
+  } catch {
+    return null;
+  }
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('Tavily request was aborted', 'AbortError');
+}

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -2338,10 +2338,19 @@ function providerToolErrorMessage(output: unknown): string | undefined {
 }
 
 function summarizeArgs(toolName: string, args: unknown): string {
-  const projected = projectToolActivityArgs(toolName, args);
+  const projected =
+    toolName === 'WebSearch'
+      ? projectWebSearchTelemetryArgs(args)
+      : projectToolActivityArgs(toolName, args);
   const raw = typeof projected === 'string' ? projected : JSON.stringify(projected ?? null);
   const text = toolName === 'WriteStdin' ? raw : redactSecrets(raw);
   return text.length <= 512 ? text : `${text.slice(0, 511)}…`;
+}
+
+function projectWebSearchTelemetryArgs(args: unknown): Record<string, number> {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return {};
+  const limit = (args as { limit?: unknown }).limit;
+  return typeof limit === 'number' && Number.isFinite(limit) ? { limit } : {};
 }
 
 function summarizePersistedArgs(args: unknown): string {

--- a/packages/runtime/src/web-search-tool.ts
+++ b/packages/runtime/src/web-search-tool.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import {
+  WEB_SEARCH_DEFAULT_LIMIT,
+  WEB_SEARCH_MAX_LIMIT,
+  normalizeWebSearchLimit,
+  normalizeWebSearchQuery,
+  type WebSearchErrorReason,
+  type WebSearchResponse,
+} from '@maka/core';
+import type { MakaTool } from './tool-runtime.js';
+
+const WEB_SEARCH_TOOL_NAME = 'WebSearch';
+
+interface WebSearchExecutor {
+  search(input: {
+    readonly query: string;
+    readonly limit: number;
+    readonly abortSignal?: AbortSignal;
+  }): Promise<WebSearchResponse>;
+}
+
+/** Builds the canonical model tool while leaving policy and transport ownership to its executor. */
+export function buildWebSearchTool(executor: WebSearchExecutor): MakaTool {
+  return {
+    name: WEB_SEARCH_TOOL_NAME,
+    categoryHint: 'web_read',
+    displayName: 'Web search',
+    description:
+      'Query the live web through the configured search provider. Returns bounded source rows. Use it only when the task requires current external information.',
+    parameters: z
+      .object({
+        query: z.string().min(1).max(200).describe('Search query, max 200 characters.'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(WEB_SEARCH_MAX_LIMIT)
+          .optional()
+          .describe(`Maximum result count; defaults to ${WEB_SEARCH_DEFAULT_LIMIT}.`),
+      })
+      .strict(),
+    impl: async ({ query, limit }, context) => {
+      const normalizedQuery = normalizeWebSearchQuery(query);
+      if (!normalizedQuery) {
+        return webSearchError('invalid_query', 'Web search requires a valid query.');
+      }
+      const response = await executor.search({
+        query: normalizedQuery,
+        limit: normalizeWebSearchLimit(limit),
+        ...(context.abortSignal ? { abortSignal: context.abortSignal } : {}),
+      });
+      if (!response.ok) return webSearchError(response.reason, response.message, normalizedQuery);
+      return {
+        kind: 'web_search' as const,
+        provider: 'tavily' as const,
+        query: normalizedQuery,
+        rows: response.results.map((row) => ({
+          title: row.title,
+          url: row.url,
+          snippet: row.snippet,
+          source: row.source,
+        })),
+      };
+    },
+  };
+}
+
+function webSearchError(reason: WebSearchErrorReason, message: string, query?: string) {
+  return {
+    kind: 'web_search_error' as const,
+    ok: false as const,
+    provider: 'tavily' as const,
+    ...(query ? { query } : {}),
+    reason,
+    message,
+  };
+}

--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -1703,6 +1703,95 @@ describe('runtime policy stores', () => {
     });
   });
 
+  test('resolves one atomic WebSearch policy, credential, and proxy execution snapshot', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      assert.deepEqual(await stores.operations.resolveWebSearchExecution(), {
+        kind: 'disabled',
+        provider: 'tavily',
+      });
+
+      const enabled = await stores.runtimePolicy.mutate({
+        expectedRevision: 0,
+        operation: {
+          kind: 'set_web_search',
+          value: { enabled: true, defaultProvider: 'tavily' },
+        },
+      });
+      assert.equal(enabled.kind, 'committed');
+      const missingSearchCredential = await stores.operations.resolveWebSearchExecution();
+      assert.equal(missingSearchCredential.kind, 'credential_not_configured');
+      if (missingSearchCredential.kind !== 'credential_not_configured') return;
+      assert.deepEqual(missingSearchCredential.status.locator, {
+        scope: 'web_search',
+        provider: 'tavily',
+        kind: 'api_key',
+      });
+
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: missingSearchCredential.status.locator,
+            expected: null,
+            secret: 'tavily-execution-secret',
+          })
+        ).kind,
+        'committed',
+      );
+      const direct = await stores.operations.resolveWebSearchExecution();
+      assert.equal(direct.kind, 'ready');
+      if (direct.kind !== 'ready') return;
+      assert.equal(direct.secretMaterial.webSearch?.secret, 'tavily-execution-secret');
+      assert.equal(direct.secretMaterial.networkProxy, undefined);
+      assert.equal(direct.networkProxy.enabled, false);
+
+      const proxied = await stores.runtimePolicy.mutate({
+        expectedRevision: 1,
+        operation: {
+          kind: 'set_network_proxy',
+          value: {
+            ...direct.networkProxy,
+            enabled: true,
+            host: 'proxy.example',
+            port: 8443,
+            authEnabled: true,
+            username: 'proxy-user',
+          },
+        },
+      });
+      assert.equal(proxied.kind, 'committed');
+      const missingProxyCredential = await stores.operations.resolveWebSearchExecution();
+      assert.equal(missingProxyCredential.kind, 'credential_not_configured');
+      if (missingProxyCredential.kind !== 'credential_not_configured') return;
+      assert.deepEqual(missingProxyCredential.status.locator, proxyCredential());
+
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: proxyCredential(),
+            expected: null,
+            secret: 'proxy-execution-secret',
+          })
+        ).kind,
+        'committed',
+      );
+      const ready = await stores.operations.resolveWebSearchExecution();
+      assert.equal(ready.kind, 'ready');
+      if (ready.kind !== 'ready') return;
+      assert.equal(ready.secretMaterial.webSearch?.secret, 'tavily-execution-secret');
+      assert.equal(ready.secretMaterial.networkProxy?.secret, 'proxy-execution-secret');
+      assert.equal(ready.networkProxy.host, 'proxy.example');
+
+      const privatePolicy = await stores.runtimePolicy.mutate({
+        expectedRevision: 2,
+        operation: { kind: 'set_privacy', value: { incognitoActive: true } },
+      });
+      assert.equal(privatePolicy.kind, 'committed');
+      assert.deepEqual(await stores.operations.resolveWebSearchExecution(), {
+        kind: 'privacy_mode',
+      });
+    });
+  });
+
   test('removes credentials only for a matching connection revision and converges on partial retries', async () => {
     await withInteractiveOwner(async ({ stores }) => {
       const original = await createConnection(

--- a/packages/storage/src/runtime-policy-stores.ts
+++ b/packages/storage/src/runtime-policy-stores.ts
@@ -50,6 +50,7 @@ export type {
   RuntimePolicyOperationCoordinator,
   RuntimePolicyOperationSecretMaterial,
   ResolveExecutionConnectionResult,
+  ResolveWebSearchExecutionResult,
   UnavailableProviderActionAvailability,
 } from './runtime-policy/operations.js';
 
@@ -202,6 +203,7 @@ function createWriterFacade(coordinator: RuntimePolicyCoordinator): RuntimePolic
     operations: {
       resolveExecutionConnection: (connectionSlug) =>
         coordinator.resolveExecutionConnection(connectionSlug),
+      resolveWebSearchExecution: () => coordinator.resolveWebSearchExecution(),
       compareAndSetOAuthCredential: (input) => coordinator.compareAndSetOAuthCredential(input),
       beginInteractiveOAuthLogin: (connectionId) =>
         coordinator.beginInteractiveOAuthLogin(connectionId),

--- a/packages/storage/src/runtime-policy/coordinator.ts
+++ b/packages/storage/src/runtime-policy/coordinator.ts
@@ -69,6 +69,7 @@ import {
   type RuntimePolicyCredentialMaterial,
   type RuntimePolicyOperationSecretMaterial,
   type ResolveExecutionConnectionResult,
+  type ResolveWebSearchExecutionResult,
 } from './operations.js';
 import { policySnapshot, RuntimePolicyDocumentOwner } from './policy-document.js';
 import { SerializedOperationLane } from '../serialized-operation-lane.js';
@@ -527,6 +528,55 @@ export class RuntimePolicyCoordinator {
         connection: structuredClone(connection),
         secretMaterial: prepared.secretMaterial,
         networkProxy: structuredClone(prepared.networkProxy),
+      });
+    });
+  }
+
+  resolveWebSearchExecution(): Promise<ResolveWebSearchExecutionResult> {
+    return this.inLane(async (root) => {
+      const policy = (await this.policy.read(root)).policy;
+      if (policy.privacy.incognitoActive) {
+        return deepFreeze({ kind: 'privacy_mode' as const });
+      }
+
+      const provider = policy.webSearch.defaultProvider;
+      if (!policy.webSearch.enabled) {
+        return deepFreeze({ kind: 'disabled' as const, provider });
+      }
+
+      const vault = await this.vault.read(root);
+      const locator = { scope: 'web_search', provider, kind: 'api_key' } as const;
+      const webSearchCredential = findCredential(vault, locator);
+      if (!webSearchCredential) {
+        return deepFreeze({
+          kind: 'credential_not_configured' as const,
+          status: credentialStatus(vault, locator),
+        });
+      }
+
+      const proxyLocator = requiresNetworkProxyCredential(policy.networkProxy)
+        ? networkProxyCredentialLocator()
+        : null;
+      let proxyCredential: RuntimePolicyCredentialMaterial | undefined;
+      if (proxyLocator) {
+        const entry = findCredential(vault, proxyLocator);
+        if (!entry) {
+          return deepFreeze({
+            kind: 'credential_not_configured' as const,
+            status: credentialStatus(vault, proxyLocator),
+          });
+        }
+        proxyCredential = credentialMaterial(entry);
+      }
+
+      return deepFreeze({
+        kind: 'ready' as const,
+        provider,
+        secretMaterial: {
+          webSearch: credentialMaterial(webSearchCredential),
+          ...(proxyCredential ? { networkProxy: proxyCredential } : {}),
+        },
+        networkProxy: structuredClone(policy.networkProxy),
       });
     });
   }

--- a/packages/storage/src/runtime-policy/operations.ts
+++ b/packages/storage/src/runtime-policy/operations.ts
@@ -29,6 +29,23 @@ export interface RuntimePolicyOperationSecretMaterial {
   readonly networkProxy?: RuntimePolicyCredentialMaterial;
 }
 
+export type ResolveWebSearchExecutionResult =
+  | { readonly kind: 'privacy_mode' }
+  | {
+      readonly kind: 'disabled';
+      readonly provider: RuntimePolicy['webSearch']['defaultProvider'];
+    }
+  | { readonly kind: 'credential_not_configured'; readonly status: CredentialStatus }
+  | {
+      readonly kind: 'ready';
+      readonly provider: RuntimePolicy['webSearch']['defaultProvider'];
+      readonly secretMaterial: {
+        readonly webSearch: RuntimePolicyCredentialMaterial;
+        readonly networkProxy?: RuntimePolicyCredentialMaterial;
+      };
+      readonly networkProxy: RuntimePolicy['networkProxy'];
+    };
+
 export type OAuthCredentialLocator = Omit<
   Extract<CredentialLocator, { scope: 'connection' }>,
   'kind'
@@ -153,6 +170,7 @@ export type ResolveExecutionConnectionResult =
 
 export interface RuntimePolicyOperationCoordinator {
   resolveExecutionConnection(connectionSlug: string): Promise<ResolveExecutionConnectionResult>;
+  resolveWebSearchExecution(): Promise<ResolveWebSearchExecutionResult>;
   compareAndSetOAuthCredential(
     input: CompareAndSetOAuthCredentialInput,
   ): Promise<CompareAndSetOAuthCredentialResult>;


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Add Host-owned WebSearch execution backed by one canonical Runtime Policy, credential, privacy, and proxy snapshot.
- Compose the Host WebSearch tool into root execution and the exact `web_research` child profile, making hosted web research runnable without widening other child tool ceilings.
- Add a bounded and cancellable Tavily client with fail-closed response handling, normalized safe HTTP(S) rows, immutable per-call proxy transport, and guaranteed transport cleanup.
- Keep user-derived search queries out of usage telemetry and consolidate Runtime Policy proxy projection across Host network consumers.

## Behavior

- Privacy mode, disabled search, missing Tavily credentials, and missing proxy credentials fail before provider transport creation.
- A ready call consumes one atomic execution snapshot and never exposes cleartext credentials to Clients or tool results.
- `web_research` receives only `WebSearch`; `local_read` and `implementation` retain their existing exact ceilings.
- Hosted execution persists the canonical WebSearch result and preserves cancellation through the owning Turn.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`
- `npm run test:dist`
- Live Tavily smoke tests through both the direct Runtime client and the canonical Storage-to-Host tool path

## Scope

- Production Client entrypoints remain unchanged.
- The existing Desktop embedded WebSearch path remains in place for the later Client cutover.
- The experimental wire protocol remains `v0`; this slice adds no wire operations.

Part of #1167.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 摘要

- 增加 Host-owned WebSearch 执行路径，从 canonical Runtime Policy、凭据、隐私与代理状态中解析一份原子快照。
- 将 Host WebSearch 工具组合到 root execution 与精确的 `web_research` child profile，使 hosted web research 可以运行，同时不扩大其他 child 的工具上限。
- 增加有界、可取消的 Tavily client；provider 响应失败闭合，仅投影规范化且安全的 HTTP(S) 结果，每次调用使用不可变代理 transport，并保证释放资源。
- usage telemetry 不记录用户派生的搜索 query，并统一 Runtime Host 各网络调用方的 Runtime Policy 代理投影。

## 行为

- 隐私模式、WebSearch 未启用、缺少 Tavily 凭据或缺少代理凭据时，均在创建 provider transport 前失败。
- 可执行调用只消费一份原子 execution snapshot；Client 与工具结果都不会获得明文凭据。
- `web_research` 只获得 `WebSearch`；`local_read` 与 `implementation` 继续保持原有精确工具上限。
- Hosted execution 持久化 canonical WebSearch 结果，并沿所属 Turn 传递取消。

## 验证

- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`
- `npm run test:dist`
- 通过 direct Runtime client 与 canonical Storage-to-Host 工具路径分别完成真实 Tavily smoke test

## 范围

- production Client entrypoint 保持不变。
- Desktop 现有 embedded WebSearch 路径保留到后续 Client cutover。
- 实验 wire protocol 继续保持 `v0`；本 slice 不增加 wire operation。

属于 #1167 的一部分。

</details>
