### PR TITLE
fix(test): terminate leaked workspace test processes

### DIFF
--- a/scripts/run-workspace-tests-parallel.mjs
+++ b/scripts/run-workspace-tests-parallel.mjs
@@ -8,7 +8,7 @@
  * `--workspaces a,b`: run only the selected workspace paths.
  *
  * Each workspace owns how its dist tests run via package.json `test:dist`.
- * This script only owns scheduling (parallel vs serial) and failure reporting.
+ * This script owns scheduling, bounded process residency, and failure reporting.
  */
 
 import { spawn as defaultSpawn } from 'node:child_process';
@@ -25,6 +25,10 @@ const defaultRepoRoot = dirname(dirname(scriptPath));
 // conservatism for root orchestration, not a claim that its suite shares FS
 // state with other packages.
 export const SERIAL_WORKSPACE_DIRS = ['packages/headless'];
+export const DEFAULT_WORKSPACE_TIMEOUT_MS = 15 * 60_000;
+
+const PROCESS_TERMINATION_GRACE_MS = 1_000;
+const PROCESS_TERMINATION_POLL_MS = 20;
 
 export function loadWorkspaceDirs(repoRoot, readFile = readFileSync) {
   const rootPkg = JSON.parse(readFile(join(repoRoot, 'package.json'), 'utf8'));
@@ -43,14 +47,29 @@ export function nameForDir(dir) {
   return dir.replace(/^(packages|apps)\//, '');
 }
 
-export function runWorkspace(dir, { repoRoot, spawn = defaultSpawn } = {}) {
+export async function runWorkspace(
+  dir,
+  {
+    repoRoot,
+    spawn = defaultSpawn,
+    signal,
+    timeoutMs = DEFAULT_WORKSPACE_TIMEOUT_MS,
+    terminateWorkspace = terminateWorkspaceProcess,
+  } = {},
+) {
   const name = nameForDir(dir);
+  if (signal?.aborted) throw workspaceRunCancelledError();
   // Package-owned contract: each workspace declares how dist tests run.
   const command = 'npm run test:dist';
   const cwd = join(repoRoot, dir);
   console.log(`\n[${name}] start: ${command}`);
-  return new Promise((resolvePromise, reject) => {
-    const child = spawn(command, { cwd, stdio: 'inherit', shell: true });
+  const child = spawn(command, {
+    cwd,
+    stdio: 'inherit',
+    shell: true,
+    detached: process.platform !== 'win32',
+  });
+  const completion = new Promise((resolvePromise, reject) => {
     let settled = false;
     const settle = (fn) => {
       if (settled) return;
@@ -71,10 +90,49 @@ export function runWorkspace(dir, { repoRoot, spawn = defaultSpawn } = {}) {
       });
     });
   });
+
+  let stopReason;
+  let requestStop;
+  const stopRequested = new Promise((_resolve, reject) => {
+    requestStop = (reason) => {
+      if (stopReason) return;
+      stopReason = reason;
+      reject(reason);
+    };
+  });
+  const onAbort = () => requestStop(workspaceRunCancelledError());
+  signal?.addEventListener('abort', onAbort, { once: true });
+  const timeout = Number.isFinite(timeoutMs)
+    ? setTimeout(
+        () => requestStop(new Error(`[${name}] timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      )
+    : undefined;
+  if (signal?.aborted) onAbort();
+
+  try {
+    return await Promise.race([completion, stopRequested]);
+  } catch (error) {
+    if (error === stopReason) {
+      try {
+        await terminateWorkspace(child);
+      } catch (terminationError) {
+        throw new AggregateError(
+          [error, terminationError],
+          `[${name}] failed to terminate its test process tree`,
+        );
+      }
+    }
+    throw error;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    signal?.removeEventListener('abort', onAbort);
+  }
 }
 
 async function runSerial(dirs, options) {
   for (const dir of dirs) {
+    if (options.signal?.aborted) throw workspaceRunCancelledError();
     await runWorkspace(dir, options);
   }
 }
@@ -84,6 +142,7 @@ async function runParallel(dirs, options, concurrency) {
   let nextIndex = 0;
   async function worker() {
     while (nextIndex < dirs.length) {
+      if (options.signal?.aborted) return;
       const dir = dirs[nextIndex++];
       try {
         await runWorkspace(dir, options);
@@ -94,6 +153,7 @@ async function runParallel(dirs, options, concurrency) {
   }
   const workerCount = Math.min(dirs.length, concurrency);
   await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  if (options.signal?.aborted) throw workspaceRunCancelledError();
   if (failures.length > 0) {
     const messages = failures.map((error) => error?.message ?? String(error));
     throw new Error(messages.join('\n'));
@@ -105,10 +165,20 @@ export async function runWorkspaceTests(options = {}) {
   const serialFlag = options.serial ?? false;
   const concurrency = options.concurrency ?? Number.POSITIVE_INFINITY;
   if (!(concurrency > 0)) throw new Error('concurrency must be greater than zero');
+  const workspaceTimeoutMs = options.workspaceTimeoutMs ?? DEFAULT_WORKSPACE_TIMEOUT_MS;
+  if (!(workspaceTimeoutMs > 0)) {
+    throw new Error('workspaceTimeoutMs must be greater than zero');
+  }
   const spawn = options.spawn ?? defaultSpawn;
   const workspaceDirs = options.workspaceDirs ?? loadWorkspaceDirs(repoRoot);
   const serialDirs = options.serialWorkspaceDirs ?? SERIAL_WORKSPACE_DIRS;
-  const runOptions = { repoRoot, spawn };
+  const runOptions = {
+    repoRoot,
+    spawn,
+    signal: options.signal,
+    timeoutMs: workspaceTimeoutMs,
+    terminateWorkspace: options.terminateWorkspace,
+  };
 
   if (serialFlag) {
     await runSerial(workspaceDirs, runOptions);
@@ -154,13 +224,107 @@ export function parseCliArgs(args, availableDirs) {
 async function main(args) {
   const availableDirs = loadWorkspaceDirs(defaultRepoRoot);
   const options = parseCliArgs(args, availableDirs);
-  await runWorkspaceTests(options);
-  console.log('\nAll workspace tests passed.');
+  const controller = new AbortController();
+  let receivedSignal;
+  const interrupt = () => {
+    receivedSignal = 'SIGINT';
+    controller.abort();
+  };
+  const terminate = () => {
+    receivedSignal = 'SIGTERM';
+    controller.abort();
+  };
+  process.once('SIGINT', interrupt);
+  process.once('SIGTERM', terminate);
+  try {
+    await runWorkspaceTests({ ...options, signal: controller.signal });
+    console.log('\nAll workspace tests passed.');
+  } catch (error) {
+    if (!receivedSignal) throw error;
+    console.error(`Workspace test run cancelled by ${receivedSignal}.`);
+    process.exitCode = receivedSignal === 'SIGINT' ? 130 : 143;
+  } finally {
+    process.off('SIGINT', interrupt);
+    process.off('SIGTERM', terminate);
+  }
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
   main(process.argv.slice(2)).catch((err) => {
     console.error(err.message);
     process.exitCode = 1;
+  });
+}
+
+function workspaceRunCancelledError() {
+  return new Error('Workspace test run cancelled');
+}
+
+async function terminateWorkspaceProcess(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const pid = child.pid;
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    child.kill('SIGKILL');
+    return;
+  }
+  if (process.platform === 'win32') {
+    await terminateWindowsProcessTree(pid, child);
+    return;
+  }
+
+  signalProcessGroup(pid, 'SIGTERM');
+  if (await waitForProcessGroupExit(pid, PROCESS_TERMINATION_GRACE_MS)) return;
+  signalProcessGroup(pid, 'SIGKILL');
+  if (await waitForProcessGroupExit(pid, PROCESS_TERMINATION_GRACE_MS)) return;
+  throw new Error(`workspace test process group ${pid} did not exit`);
+}
+
+function signalProcessGroup(pid, signal) {
+  try {
+    process.kill(-pid, signal);
+  } catch (error) {
+    if (!isMissingProcessError(error)) throw error;
+  }
+}
+
+async function waitForProcessGroupExit(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (isProcessGroupAlive(pid) && Date.now() < deadline) {
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, PROCESS_TERMINATION_POLL_MS));
+  }
+  return !isProcessGroupAlive(pid);
+}
+
+function isProcessGroupAlive(pid) {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    if (isMissingProcessError(error)) return false;
+    throw error;
+  }
+}
+
+function isMissingProcessError(error) {
+  return error instanceof Error && 'code' in error && error.code === 'ESRCH';
+}
+
+async function terminateWindowsProcessTree(pid, child) {
+  await new Promise((resolvePromise) => {
+    const killer = defaultSpawn('taskkill', ['/pid', String(pid), '/t', '/f'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      resolvePromise();
+    };
+    killer.once('error', () => {
+      child.kill('SIGKILL');
+      settle();
+    });
+    killer.once('close', settle);
   });
 }

--- a/scripts/run-workspace-tests-parallel.test.mjs
+++ b/scripts/run-workspace-tests-parallel.test.mjs
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 import { runWorkspaceTests } from './run-workspace-tests-parallel.mjs';
 
@@ -66,3 +69,121 @@ test('bounded parallel mode never exceeds its configured concurrency', async () 
 
   assert.equal(maxActive, 2);
 });
+
+test('cancellation terminates active workspace process trees and starts no queued work', async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), 'maka-workspace-runner-'));
+  const workspace = join(repoRoot, 'packages', 'fixture');
+  const pidFile = join(workspace, 'pids.json');
+  let pids;
+  try {
+    await mkdir(workspace, { recursive: true });
+    await writeFile(
+      join(workspace, 'package.json'),
+      JSON.stringify({
+        private: true,
+        scripts: { 'test:dist': 'node fixture.mjs' },
+      }),
+    );
+    await writeFile(
+      join(workspace, 'fixture.mjs'),
+      [
+        "import { spawn } from 'node:child_process';",
+        "import { writeFileSync } from 'node:fs';",
+        "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+        "writeFileSync(new URL('./pids.json', import.meta.url), JSON.stringify({ parent: process.pid, child: child.pid }));",
+        'setInterval(() => {}, 1000);',
+      ].join('\n'),
+    );
+
+    const controller = new AbortController();
+    const running = runWorkspaceTests({
+      repoRoot,
+      workspaceDirs: ['packages/fixture', 'packages/never-started'],
+      concurrency: 1,
+      signal: controller.signal,
+    });
+    void running.catch(() => undefined);
+    pids = await waitForPidFile(pidFile);
+    controller.abort();
+
+    await assert.rejects(running, /Workspace test run cancelled/);
+    await Promise.all([waitForProcessExit(pids.parent), waitForProcessExit(pids.child)]);
+  } finally {
+    terminateProcess(pids?.parent);
+    terminateProcess(pids?.child);
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('workspace timeout waits for process cleanup before reporting failure', async () => {
+  const child = new EventEmitter();
+  child.exitCode = null;
+  child.signalCode = null;
+  child.pid = 42;
+  let terminationStarted = false;
+  let terminationFinished = false;
+  const spawn = () => child;
+  const terminateWorkspace = async (target) => {
+    assert.equal(target, child);
+    terminationStarted = true;
+    await new Promise((resolvePromise) => setImmediate(resolvePromise));
+    terminationFinished = true;
+  };
+
+  await assert.rejects(
+    () =>
+      runWorkspaceTests({
+        repoRoot: '/repo',
+        workspaceDirs: ['packages/core'],
+        workspaceTimeoutMs: 10,
+        spawn,
+        terminateWorkspace,
+      }),
+    /\[core\] timed out after 10ms/,
+  );
+  assert.equal(terminationStarted, true);
+  assert.equal(terminationFinished, true);
+});
+
+async function waitForPidFile(path) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      const parsed = JSON.parse(await readFile(path, 'utf8'));
+      if (Number.isSafeInteger(parsed.parent) && Number.isSafeInteger(parsed.child)) return parsed;
+    } catch (error) {
+      if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) throw error;
+    }
+    await sleep(20);
+  }
+  throw new Error('workspace fixture did not publish its process ids');
+}
+
+async function waitForProcessExit(pid) {
+  const deadline = Date.now() + 2_000;
+  while (isProcessAlive(pid) && Date.now() < deadline) await sleep(20);
+  assert.equal(isProcessAlive(pid), false, `process ${pid} remained alive`);
+}
+
+function terminateProcess(pid) {
+  if (!pid || !isProcessAlive(pid)) return;
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch (error) {
+    if (!(error instanceof Error && 'code' in error && error.code === 'ESRCH')) throw error;
+  }
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

Prevent stalled or cancelled workspace test runs from leaving resident npm, shell, Node test, or fixture processes behind.

- Run each workspace test command in its own process group on POSIX.
- Propagate SIGINT and SIGTERM through an AbortSignal and stop every active workspace tree before the runner exits.
- Bound each workspace to 15 minutes as a final liveness guard; timeout reporting waits for process cleanup.
- Stop scheduling queued work after cancellation while preserving the existing aggregate-failure behavior for ordinary test failures.
- Use taskkill tree cleanup on Windows.

## Root cause

The parallel workspace runner waited on child close events without owning cancellation or a deadline. If a workspace process stalled, or the outer run was cancelled, that process tree could remain resident indefinitely and interfere with a later test run.

## Verification

- New behavior test launches a real npm to shell to Node fixture to grandchild process tree and proves cancellation removes every recorded process.
- Timeout regression proves failure is reported only after cleanup finishes.
- Targeted runner suite passed 20 consecutive runs.
- Real CLI SIGTERM path exited with status 143 and left no workspace process group behind.
- Full repository test suite passed.
- Format and lint passed.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

防止卡住或被取消的 workspace 测试留下常驻的 npm、shell、Node test 或 fixture 进程。

- 在 POSIX 上为每个 workspace 测试命令创建独立进程组。
- 通过 AbortSignal 传递 SIGINT 和 SIGTERM，并在 runner 退出前停止所有活动 workspace 进程树。
- 为每个 workspace 设置 15 分钟的最终存活上界；超时错误只会在进程清理完成后返回。
- 取消后不再调度排队中的 workspace，同时保留普通测试失败的聚合报告行为。
- Windows 使用 taskkill 清理整棵进程树。

## 根因

并行 workspace runner 只等待子进程 close 事件，没有取消所有权，也没有最终时间上界。当某个 workspace 进程卡住或外层运行被取消时，该进程树可能无限期驻留，并干扰之后的测试运行。

## 验证

- 新行为测试启动真实的 npm 到 shell 到 Node fixture 到孙进程链路，并证明取消后所有记录的进程均已退出。
- 超时回归证明只有在清理完成后才报告失败。
- runner 定向测试连续运行 20 次通过。
- 真实 CLI SIGTERM 路径以状态码 143 退出，且没有遗留 workspace 进程组。
- 完整仓库测试通过。
- Format 与 lint 通过。

</details>
