### PR TITLE
fix(desktop): keep latest onboarding snapshot handoff

### DIFF
--- a/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
+++ b/apps/desktop/src/main/__tests__/use-onboarding-snapshot.test.ts
@@ -217,16 +217,38 @@ describe('createOnboardingSnapshotPoller', () => {
 });
 
 describe('onboarding mounted snapshot handoff', () => {
-  it('latches B when B and a later C are reduced before React commits', () => {
+  it('keeps a session created while mounted snapshots wait for React to commit', () => {
     const snapshotA = READY_SNAPSHOT;
-    const snapshotB = { ...READY_SNAPSHOT, defaultSlug: 'b' };
-    const snapshotC = { ...READY_SNAPSHOT, defaultSlug: 'c' };
+    const snapshotB = { ...READY_SNAPSHOT };
+    const snapshotC: OnboardingSnapshot = {
+      ...READY_SNAPSHOT,
+      sessions: [
+        {
+          id: 'created-during-bootstrap',
+          name: 'New session',
+          isFlagged: false,
+          isArchived: false,
+          labels: [],
+          hasUnread: false,
+          status: 'active' as const,
+          backend: 'fake',
+          llmConnectionSlug: 'default',
+          connectionLocked: false,
+          model: 'fake-model',
+          permissionMode: 'ask' as const,
+          projectId: null,
+        },
+      ],
+    };
 
     const afterB = advanceOnboardingSnapshotState(createOnboardingSnapshotState(snapshotA), snapshotB);
     const afterC = advanceOnboardingSnapshotState(afterB, snapshotC);
 
     assert.equal(afterC.snapshot, snapshotC);
-    assert.equal(afterC.firstMountedSnapshot, snapshotB);
+    assert.deepEqual(
+      afterC.mountedSnapshotHandoff?.sessions.map(({ id }) => id),
+      ['created-during-bootstrap'],
+    );
   });
 });
 

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1101,7 +1101,7 @@ function AppShellContent({
     if (
       onboarding.error &&
       !initialOnboardingSnapshot &&
-      !onboarding.firstMountedSnapshot &&
+      !onboarding.mountedSnapshotHandoff &&
       !bootstrapFallbackStartedRef.current
     ) {
       bootstrapFallbackStartedRef.current = true;
@@ -1117,10 +1117,10 @@ function AppShellContent({
     } else if (
       !bootstrapFallbackStartedRef.current &&
       !mountedSnapshotSeededRef.current &&
-      onboarding.firstMountedSnapshot
+      onboarding.mountedSnapshotHandoff
     ) {
       mountedSnapshotSeededRef.current = true;
-      snapshot = onboarding.firstMountedSnapshot;
+      snapshot = onboarding.mountedSnapshotHandoff;
       releaseSelectionLease = true;
     }
     if (!snapshot) return;
@@ -1135,7 +1135,7 @@ function AppShellContent({
     setConnections(snapshot.connections);
     setDefaultConnection(snapshot.defaultSlug);
     if (releaseSelectionLease) bootstrapSelectionLease.release();
-  }, [initialOnboardingSnapshot, onboarding.firstMountedSnapshot, onboarding.error]);
+  }, [initialOnboardingSnapshot, onboarding.mountedSnapshotHandoff, onboarding.error]);
   // PR110c (@kenji review): suppress hero AND the fallback EmptyChatHero
   // while the initial snapshot is in flight. Otherwise sessions.length===0
   // + snapshot===null flashes the prompt-suggestion EmptyChatHero before

--- a/apps/desktop/src/renderer/use-onboarding-snapshot.ts
+++ b/apps/desktop/src/renderer/use-onboarding-snapshot.ts
@@ -29,8 +29,8 @@ import { getOnboardingCopy } from './locales/onboarding-copy.js';
  */
 export interface UseOnboardingSnapshotResult {
   snapshot: OnboardingSnapshot | null;
-  /** First successful mounted pull, latched until AppShell consumes the bootstrap handoff. */
-  firstMountedSnapshot: OnboardingSnapshot | null;
+  /** Latest mounted pull, handed to AppShell once for bootstrap reconciliation. */
+  mountedSnapshotHandoff: OnboardingSnapshot | null;
   error: string | null;
   refresh: () => void;
   /** Sessions from the snapshot — populated on first load, before the separate sessions:list IPC. */
@@ -54,20 +54,20 @@ export interface UseOnboardingSnapshotDeps {
 
 export interface OnboardingSnapshotState {
   snapshot: OnboardingSnapshot | null;
-  firstMountedSnapshot: OnboardingSnapshot | null;
+  mountedSnapshotHandoff: OnboardingSnapshot | null;
 }
 
 export function createOnboardingSnapshotState(initialSnapshot: OnboardingSnapshot | null): OnboardingSnapshotState {
-  return { snapshot: initialSnapshot, firstMountedSnapshot: null };
+  return { snapshot: initialSnapshot, mountedSnapshotHandoff: null };
 }
 
 export function advanceOnboardingSnapshotState(
-  current: OnboardingSnapshotState,
+  _current: OnboardingSnapshotState,
   next: OnboardingSnapshot,
 ): OnboardingSnapshotState {
   return {
     snapshot: next,
-    firstMountedSnapshot: current.firstMountedSnapshot ?? next,
+    mountedSnapshotHandoff: next,
   };
 }
 
@@ -133,7 +133,7 @@ export function useOnboardingSnapshotImpl(
 
   return {
     snapshot: snapshotState.snapshot,
-    firstMountedSnapshot: snapshotState.firstMountedSnapshot,
+    mountedSnapshotHandoff: snapshotState.mountedSnapshotHandoff,
     error,
     refresh,
     getSessions,


### PR DESCRIPTION
## Summary

The desktop bootstrap latched the first mounted onboarding snapshot until AppShell consumed it. If a session was created and a newer snapshot arrived before React committed, AppShell still seeded the older empty session list. The conversation rendered, but the sidebar never showed the unassigned-project entry.

Keep the latest mounted snapshot as the one-time bootstrap handoff and add a regression test for a session created between two pre-commit snapshot reductions. This fixes the flaky `project-management.spec.ts` failure without adding retries or changing the E2E timeout.

Closes #1923

## Verification

- `npm --workspace @maka/desktop run test -- src/main/__tests__/use-onboarding-snapshot.test.ts`: 10 passed
- `npm --workspace @maka/desktop run build:main`: passed
- focused `project-management.spec.ts`, 50 serial repeats: 50 passed
- `npm --workspace @maka/desktop run test:e2e`: 89 passed
- `npm run lint`: passed
- `npm run format:check`: passed
- `npm --workspace @maka/desktop run typecheck`: passed
- `npm --workspace @maka/desktop test`: 1364 passed
- `git diff --check`: passed