### PR TITLE
fix: rebuild Daily Review around activity ranges

### DIFF
--- a/apps/desktop/e2e/floating-layers.spec.ts
+++ b/apps/desktop/e2e/floating-layers.spec.ts
@@ -43,7 +43,7 @@ test('daily review uses the canonical time field and persists its value', async 
   const settings = page.getByRole('main', { name: '设置内容' });
   await settingsNavigation.getByRole('button', { name: '每日回顾', exact: true }).click();
 
-  const time = settings.getByRole('textbox', { name: '每日回顾执行时间' });
+  const time = settings.getByRole('textbox', { name: '执行时间' });
   await expect(time).toHaveValue('08:00');
   await time.fill('08:05');
   await time.blur();
@@ -52,7 +52,7 @@ test('daily review uses the canonical time field and persists its value', async 
   await settingsNavigation.getByRole('button', { name: '通用', exact: true }).click();
   await settingsNavigation.getByRole('button', { name: '每日回顾', exact: true }).click();
   const persistedTime = settings.getByRole('textbox', {
-    name: '每日回顾执行时间',
+    name: '执行时间',
   });
   await expect(persistedTime).toHaveValue('08:05');
 
@@ -66,7 +66,7 @@ test('daily review uses the canonical time field and persists its value', async 
   await settingsNavigation.getByRole('button', { name: '通用', exact: true }).click();
   await settingsNavigation.getByRole('button', { name: '每日回顾', exact: true }).click();
   await expect(
-    settings.getByRole('textbox', { name: '每日回顾执行时间' }),
+    settings.getByRole('textbox', { name: '执行时间' }),
   ).toHaveValue('08:05');
 });
 

--- a/apps/desktop/e2e/sidebar-navigation.spec.ts
+++ b/apps/desktop/e2e/sidebar-navigation.spec.ts
@@ -177,6 +177,10 @@ test('scheduled-task hub restores the last selected child module', async ({ wind
   await expect(selector).toHaveAccessibleName('定时任务内容：计划提醒');
   await selector.getByRole('button', { name: '每日回顾' }).click();
   await expect(selector).toHaveAccessibleName('定时任务内容：每日回顾');
+  await expect(page.getByRole('radiogroup', { name: '时间范围切换' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '生成分析' })).toBeVisible();
+  await expect(page.getByText('模型使用', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('工具调用', { exact: true })).toHaveCount(0);
 
   await sidebar.getByRole('button', { name: '扩展', exact: true }).click();
   await scheduledTasks.click();

--- a/apps/desktop/src/main/__tests__/daily-review-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-actions.test.ts
@@ -1,0 +1,18 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { dailyReviewExportDefaultName } from '../../renderer/daily-review-actions.js';
+
+describe('Daily Review export naming', () => {
+  it('uses the archive identity instead of guessing from localized text', () => {
+    assert.equal(
+      dailyReviewExportDefaultName({
+        range: 7,
+        day: {
+          fromMs: new Date(2026, 6, 30, 12).getTime(),
+          toMs: new Date(2026, 7, 5, 12).getTime(),
+        },
+      }),
+      'maka-daily-review-2026-07-30-7d.md',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/daily-review-archive-store.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-archive-store.test.ts
@@ -8,6 +8,10 @@ import type { DailyReviewArchive } from '@maka/core';
 import { createDailyReviewArchiveStore } from '../daily-review-archive-store.js';
 
 const roots: string[] = [];
+const DAY = {
+  fromMs: new Date(2026, 7, 3, 0, 0, 0, 0).getTime(),
+  toMs: new Date(2026, 7, 4, 0, 0, 0, 0).getTime(),
+};
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
@@ -22,7 +26,7 @@ async function aRoot(): Promise<string> {
 function anArchive(id = '2026-08-03-1d'): DailyReviewArchive {
   return {
     id,
-    day: { fromMs: 1, toMs: 2 },
+    day: DAY,
     range: 1,
     status: 'ok',
     generatedAt: 3,
@@ -42,7 +46,7 @@ describe('Daily Review archive migration', () => {
       join(archiveRoot, '2026-08-03-deep.json'),
       JSON.stringify({
         id: '2026-08-03-deep',
-        day: { fromMs: 1, toMs: 2 },
+        day: DAY,
         mode: 'deep',
         status: 'ok',
         generatedAt: 3,

--- a/apps/desktop/src/main/__tests__/daily-review-archive-store.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-archive-store.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, it } from 'node:test';
+import type { DailyReviewArchive } from '@maka/core';
 
 import { createDailyReviewArchiveStore } from '../daily-review-archive-store.js';
 
@@ -16,6 +17,20 @@ async function aRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'maka-daily-review-store-'));
   roots.push(root);
   return root;
+}
+
+function anArchive(id = '2026-08-03-1d'): DailyReviewArchive {
+  return {
+    id,
+    day: { fromMs: 1, toMs: 2 },
+    range: 1,
+    status: 'ok',
+    generatedAt: 3,
+    trigger: 'manual',
+    modelKey: '',
+    sections: { summary: 'healthy' },
+    totals: { sessionCount: 1, requestCount: 2, totalTokens: 3, costUsd: 4, errorCount: 0 },
+  };
 }
 
 describe('Daily Review archive migration', () => {
@@ -63,5 +78,31 @@ describe('Daily Review archive migration', () => {
       JSON.parse(await readFile(join(root, 'daily-reviews', 'config.json'), 'utf8')),
       next,
     );
+  });
+});
+
+describe('Daily Review archive corruption recovery', () => {
+  it('keeps healthy archives available when a sibling file is corrupt', async () => {
+    const root = await aRoot();
+    const store = createDailyReviewArchiveStore(root);
+    await store.putArchive(anArchive());
+    await writeFile(
+      join(root, 'daily-reviews', 'archive', '2026-08-02-1d.json'),
+      '{"id":"2026-08-02-1d"',
+    );
+
+    assert.deepEqual((await store.listArchives()).map((archive) => archive.id), [
+      '2026-08-03-1d',
+    ]);
+  });
+
+  it('treats a corrupt canonical archive as missing so generation can replace it', async () => {
+    const root = await aRoot();
+    const archiveRoot = join(root, 'daily-reviews', 'archive');
+    await mkdir(archiveRoot, { recursive: true });
+    await writeFile(join(archiveRoot, '2026-08-03-1d.json'), '{');
+
+    const store = createDailyReviewArchiveStore(root);
+    assert.equal(await store.getArchive('2026-08-03-1d'), null);
   });
 });

--- a/apps/desktop/src/main/__tests__/daily-review-archive-store.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-archive-store.test.ts
@@ -1,0 +1,67 @@
+import { strict as assert } from 'node:assert';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+import { createDailyReviewArchiveStore } from '../daily-review-archive-store.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function aRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-daily-review-store-'));
+  roots.push(root);
+  return root;
+}
+
+describe('Daily Review archive migration', () => {
+  it('reads a legacy deep archive through the range contract', async () => {
+    const root = await aRoot();
+    const archiveRoot = join(root, 'daily-reviews', 'archive');
+    await mkdir(archiveRoot, { recursive: true });
+    await writeFile(
+      join(archiveRoot, '2026-08-03-deep.json'),
+      JSON.stringify({
+        id: '2026-08-03-deep',
+        day: { fromMs: 1, toMs: 2 },
+        mode: 'deep',
+        status: 'ok',
+        generatedAt: 3,
+        trigger: 'manual',
+        modelKey: '',
+        sections: { summary: 'legacy' },
+        totals: { sessionCount: 1, requestCount: 2, totalTokens: 3, costUsd: 4, errorCount: 0 },
+      }),
+    );
+
+    const store = createDailyReviewArchiveStore(root);
+    const archive = await store.getArchive('2026-08-03-deep');
+    assert.equal(archive?.range, 7);
+    assert.equal(archive?.sections.summary, 'legacy');
+    assert.deepEqual((await store.listArchives()).map((item) => item.range), [7]);
+  });
+
+  it('persists only the three canonical settings', async () => {
+    const root = await aRoot();
+    const store = createDailyReviewArchiveStore(root);
+    const next = await store.setConfig({
+      enabled: true,
+      executeTime: '07:45',
+      modelKey: 'openai::gpt-5',
+    });
+
+    assert.deepEqual(next, {
+      enabled: true,
+      executeTime: '07:45',
+      modelKey: 'openai::gpt-5',
+    });
+    assert.deepEqual(
+      JSON.parse(await readFile(join(root, 'daily-reviews', 'config.json'), 'utf8')),
+      next,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/daily-review-archive-store.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-archive-store.test.ts
@@ -96,6 +96,20 @@ describe('Daily Review archive corruption recovery', () => {
     ]);
   });
 
+  it('keeps healthy archives available when a sibling has an invalid schema', async () => {
+    const root = await aRoot();
+    const store = createDailyReviewArchiveStore(root);
+    await store.putArchive(anArchive());
+    await writeFile(
+      join(root, 'daily-reviews', 'archive', '2026-08-02-1d.json'),
+      JSON.stringify({ id: '2026-08-02-1d', range: 1 }),
+    );
+
+    assert.deepEqual((await store.listArchives()).map((archive) => archive.id), [
+      '2026-08-03-1d',
+    ]);
+  });
+
   it('treats a corrupt canonical archive as missing so generation can replace it', async () => {
     const root = await aRoot();
     const archiveRoot = join(root, 'daily-reviews', 'archive');

--- a/apps/desktop/src/main/__tests__/daily-review-idempotency.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-idempotency.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createDailyReviewMainService } from '../daily-review-main.js';
+
+const emptyUsageSummary = {
+  range: { from: 0, to: 0 },
+  totalRequests: 0,
+  totalCostUsd: 0,
+  totalTokens: {
+    input: 0,
+    output: 0,
+    cacheMiss: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    reasoning: 0,
+    total: 0,
+  },
+  cacheHitRequests: 0,
+  cacheCreateRequests: 0,
+  errorRequests: 0,
+};
+
+function createService(archiveStore: Record<string, unknown>) {
+  return createDailyReviewMainService({
+    archiveStore: {
+      getConfig: async () => ({ enabled: true, executeTime: '08:00', modelKey: '' }),
+      prune: async () => undefined,
+      ...archiveStore,
+    },
+    telemetryRepo: {
+      summary: () => emptyUsageSummary,
+      buckets: () => [],
+    },
+    modelCallLedger: {
+      read: () => ({ attempts: [], unreadableRecords: 0 }),
+      pendingReprojections: () => [],
+    },
+    ensureUsageReady: async () => undefined,
+    listSessions: async () => [],
+    connectionStore: {},
+    resolveConnectionSecret: async () => null,
+    buildSubscriptionModelFetch: () => undefined,
+  } as unknown as Parameters<typeof createDailyReviewMainService>[0]);
+}
+
+test('Daily Review run reuses an existing archive', async (t) => {
+  t.mock.timers.enable({ apis: ['Date'], now: new Date(2026, 7, 3, 9, 0, 0).getTime() });
+  let writes = 0;
+  const service = createService({
+    getArchive: async () => ({}),
+    putArchive: async () => {
+      writes += 1;
+    },
+  });
+
+  try {
+    const result = await service.run({ range: 1, trigger: 'manual' });
+
+    assert.equal(result.archiveId, '2026-08-03-1d');
+    assert.equal(writes, 0);
+  } finally {
+    t.mock.timers.reset();
+  }
+});
+
+test('Daily Review run coalesces concurrent generation for the same archive', async (t) => {
+  t.mock.timers.enable({ apis: ['Date'], now: new Date(2026, 7, 3, 9, 0, 0).getTime() });
+  let writes = 0;
+  let releaseWrite!: () => void;
+  let notifyWriteStarted!: () => void;
+  const writeStarted = new Promise<void>((resolve) => {
+    notifyWriteStarted = resolve;
+  });
+  const writeReleased = new Promise<void>((resolve) => {
+    releaseWrite = resolve;
+  });
+  const service = createService({
+    getArchive: async () => null,
+    putArchive: async () => {
+      writes += 1;
+      notifyWriteStarted();
+      await writeReleased;
+    },
+  });
+
+  try {
+    const first = service.run({ range: 7, trigger: 'manual' });
+    await writeStarted;
+    const second = service.run({ range: 7, trigger: 'manual' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    releaseWrite();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    assert.deepEqual(secondResult, firstResult);
+    assert.equal(writes, 1);
+  } finally {
+    releaseWrite();
+    t.mock.timers.reset();
+  }
+});

--- a/apps/desktop/src/main/__tests__/daily-review-idempotency.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-idempotency.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { createDailyReviewMainService } from '../daily-review-main.js';
+import {
+  createDailyReviewMainService,
+  parseDailyReviewSections,
+} from '../daily-review-main.js';
 
 const emptyUsageSummary = {
   range: { from: 0, to: 0 },
@@ -43,11 +46,27 @@ function createService(archiveStore: Record<string, unknown>) {
   } as unknown as Parameters<typeof createDailyReviewMainService>[0]);
 }
 
+test('Daily Review rejects model output without a usable section', () => {
+  for (const output of ['', '{}', '[]', 'null', '{"summary":42}', '{"summary":"  "}']) {
+    assert.throws(() => parseDailyReviewSections(output));
+  }
+  assert.deepEqual(parseDailyReviewSections('plain text fallback'), {
+    summary: 'plain text fallback',
+  });
+});
+
 test('Daily Review run reuses an existing archive', async (t) => {
   t.mock.timers.enable({ apis: ['Date'], now: new Date(2026, 7, 3, 9, 0, 0).getTime() });
   let writes = 0;
   const service = createService({
-    getArchive: async () => ({ status: 'ok' }),
+    getArchive: async () => ({
+      status: 'ok',
+      range: 1,
+      day: {
+        fromMs: new Date(2026, 7, 3, 0, 0, 0, 0).getTime(),
+        toMs: new Date(2026, 7, 4, 0, 0, 0, 0).getTime(),
+      },
+    }),
     putArchive: async () => {
       writes += 1;
     },
@@ -78,6 +97,28 @@ test('Daily Review run retries every non-success archive status', async (t) => {
       await service.run({ range: 1, trigger: 'manual' });
       assert.equal(writes, 1, `${status} should remain retryable`);
     }
+  } finally {
+    t.mock.timers.reset();
+  }
+});
+
+test('Daily Review run replaces an ok archive for a different resolved day', async (t) => {
+  t.mock.timers.enable({ apis: ['Date'], now: new Date(2026, 7, 3, 9, 0, 0).getTime() });
+  let writes = 0;
+  const service = createService({
+    getArchive: async () => ({
+      status: 'ok',
+      range: 1,
+      day: { fromMs: 1, toMs: 2 },
+    }),
+    putArchive: async () => {
+      writes += 1;
+    },
+  });
+
+  try {
+    await service.run({ range: 1, trigger: 'manual' });
+    assert.equal(writes, 1);
   } finally {
     t.mock.timers.reset();
   }

--- a/apps/desktop/src/main/__tests__/daily-review-idempotency.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-idempotency.test.ts
@@ -47,7 +47,7 @@ test('Daily Review run reuses an existing archive', async (t) => {
   t.mock.timers.enable({ apis: ['Date'], now: new Date(2026, 7, 3, 9, 0, 0).getTime() });
   let writes = 0;
   const service = createService({
-    getArchive: async () => ({}),
+    getArchive: async () => ({ status: 'ok' }),
     putArchive: async () => {
       writes += 1;
     },
@@ -58,6 +58,26 @@ test('Daily Review run reuses an existing archive', async (t) => {
 
     assert.equal(result.archiveId, '2026-08-03-1d');
     assert.equal(writes, 0);
+  } finally {
+    t.mock.timers.reset();
+  }
+});
+
+test('Daily Review run retries every non-success archive status', async (t) => {
+  t.mock.timers.enable({ apis: ['Date'], now: new Date(2026, 7, 3, 9, 0, 0).getTime() });
+  try {
+    for (const status of ['no_data', 'no_model', 'failed', 'skipped']) {
+      let writes = 0;
+      const service = createService({
+        getArchive: async () => ({ status }),
+        putArchive: async () => {
+          writes += 1;
+        },
+      });
+
+      await service.run({ range: 1, trigger: 'manual' });
+      assert.equal(writes, 1, `${status} should remain retryable`);
+    }
   } finally {
     t.mock.timers.reset();
   }

--- a/apps/desktop/src/main/__tests__/daily-review-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-scheduler.test.ts
@@ -4,6 +4,10 @@ import { createDailyReviewMainService } from '../daily-review-main.js';
 
 test('Daily Review scheduler targets the previous complete local day without overwriting it', async (t) => {
   const scheduledAt = new Date(2026, 7, 3, 8, 0, 0, 0);
+  const previousDay = {
+    fromMs: new Date(2026, 7, 2, 0, 0, 0, 0).getTime(),
+    toMs: new Date(2026, 7, 3, 0, 0, 0, 0).getTime(),
+  };
   t.mock.timers.enable({ apis: ['Date'], now: scheduledAt.getTime() });
   let resolveChecked!: () => void;
   const checked = new Promise<void>((resolve) => {
@@ -36,11 +40,28 @@ test('Daily Review scheduler targets the previous complete local day without ove
       getArchive: async (archiveId: string) => {
         checkedArchiveId = archiveId;
         resolveChecked();
-        return { status: 'ok' };
+        return {
+          id: archiveId,
+          day: previousDay,
+          range: 1,
+          status: 'ok',
+          generatedAt: scheduledAt.getTime(),
+          trigger: 'cron',
+          modelKey: '',
+          sections: { summary: 'existing' },
+          totals: {
+            sessionCount: 0,
+            requestCount: 0,
+            totalTokens: 0,
+            costUsd: 0,
+            errorCount: 0,
+          },
+        };
       },
       putArchive: async () => {
         writes += 1;
       },
+      prune: async () => undefined,
     },
     telemetryRepo: {
       summary: () => emptySummary,
@@ -60,6 +81,7 @@ test('Daily Review scheduler targets the previous complete local day without ove
   try {
     service.startScheduler();
     await checked;
+    await new Promise<void>((resolve) => setImmediate(resolve));
     assert.equal(checkedArchiveId, '2026-08-02-1d');
     assert.equal(writes, 0);
   } finally {

--- a/apps/desktop/src/main/__tests__/daily-review-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-scheduler.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createDailyReviewMainService } from '../daily-review-main.js';
+
+test('Daily Review scheduler targets the previous complete local day without overwriting it', async (t) => {
+  const scheduledAt = new Date(2026, 7, 3, 8, 0, 0, 0);
+  t.mock.timers.enable({ apis: ['Date'], now: scheduledAt.getTime() });
+  let resolveChecked!: () => void;
+  const checked = new Promise<void>((resolve) => {
+    resolveChecked = resolve;
+  });
+  let checkedArchiveId = '';
+  let writes = 0;
+
+  const emptySummary = {
+    range: { from: 0, to: 0 },
+    totalRequests: 0,
+    totalCostUsd: 0,
+    totalTokens: {
+      input: 0,
+      output: 0,
+      cacheMiss: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      total: 0,
+    },
+    cacheHitRequests: 0,
+    cacheCreateRequests: 0,
+    errorRequests: 0,
+  };
+
+  const service = createDailyReviewMainService({
+    archiveStore: {
+      getConfig: async () => ({ enabled: true, executeTime: '08:00', modelKey: '' }),
+      getArchive: async (archiveId: string) => {
+        checkedArchiveId = archiveId;
+        resolveChecked();
+        return {};
+      },
+      putArchive: async () => {
+        writes += 1;
+      },
+    },
+    telemetryRepo: {
+      summary: () => emptySummary,
+      buckets: () => [],
+    },
+    modelCallLedger: {
+      read: () => ({ attempts: [], unreadableRecords: 0 }),
+      pendingReprojections: () => [],
+    },
+    ensureUsageReady: async () => undefined,
+    listSessions: async () => [],
+    connectionStore: {},
+    resolveConnectionSecret: async () => null,
+    buildSubscriptionModelFetch: () => undefined,
+  } as unknown as Parameters<typeof createDailyReviewMainService>[0]);
+
+  try {
+    service.startScheduler();
+    await checked;
+    assert.equal(checkedArchiveId, '2026-08-02-1d');
+    assert.equal(writes, 0);
+  } finally {
+    service.stopScheduler();
+    t.mock.timers.reset();
+  }
+});

--- a/apps/desktop/src/main/__tests__/daily-review-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-scheduler.test.ts
@@ -36,7 +36,7 @@ test('Daily Review scheduler targets the previous complete local day without ove
       getArchive: async (archiveId: string) => {
         checkedArchiveId = archiveId;
         resolveChecked();
-        return {};
+        return { status: 'ok' };
       },
       putArchive: async () => {
         writes += 1;

--- a/apps/desktop/src/main/daily-review-archive-store.ts
+++ b/apps/desktop/src/main/daily-review-archive-store.ts
@@ -93,9 +93,9 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
       throw error;
     }
     try {
-      const parsed = JSON.parse(raw) as Parameters<typeof normalizeDailyReviewArchive>[0];
-      if (parsed.id !== id) throw new Error(`Daily Review archive id mismatch: ${id}`);
-      return normalizeDailyReviewArchive(parsed);
+      const archive = normalizeDailyReviewArchive(JSON.parse(raw));
+      if (archive.id !== id) throw new Error(`Daily Review archive id mismatch: ${id}`);
+      return archive;
     } catch {
       return null;
     }

--- a/apps/desktop/src/main/daily-review-archive-store.ts
+++ b/apps/desktop/src/main/daily-review-archive-store.ts
@@ -1,5 +1,6 @@
-import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { mkdir, open, readdir, readFile, rename, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import {
   DEFAULT_DAILY_REVIEW_CONFIG,
   dailyReviewArchiveToSummary,
@@ -58,7 +59,7 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
         ...patch,
       });
       await mkdir(this.root, { recursive: true, mode: 0o700 });
-      await writeFile(this.configPath, JSON.stringify(next, null, 2) + '\n', { encoding: 'utf8', mode: 0o600 });
+      await writeJsonAtomically(this.configPath, next);
     });
     return next;
   }
@@ -67,10 +68,7 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
     assertArchiveId(archive.id);
     await this.withQueue(async () => {
       await mkdir(this.archiveRoot, { recursive: true, mode: 0o700 });
-      await writeFile(this.archivePath(archive.id), JSON.stringify(archive, null, 2) + '\n', {
-        encoding: 'utf8',
-        mode: 0o600,
-      });
+      await writeJsonAtomically(this.archivePath(archive.id), archive);
     });
     return archive;
   }
@@ -87,14 +85,19 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
 
   async getArchive(id: string): Promise<DailyReviewArchive | null> {
     assertReadableArchiveId(id);
+    let raw: string;
     try {
-      const raw = await readFile(this.archivePath(id), 'utf8');
-      const parsed = JSON.parse(raw) as Parameters<typeof normalizeDailyReviewArchive>[0];
-      if (parsed.id !== id) throw new Error(`Daily Review archive id mismatch: ${id}`);
-      return normalizeDailyReviewArchive(parsed);
+      raw = await readFile(this.archivePath(id), 'utf8');
     } catch (error) {
       if (isNotFound(error)) return null;
       throw error;
+    }
+    try {
+      const parsed = JSON.parse(raw) as Parameters<typeof normalizeDailyReviewArchive>[0];
+      if (parsed.id !== id) throw new Error(`Daily Review archive id mismatch: ${id}`);
+      return normalizeDailyReviewArchive(parsed);
+    } catch {
+      return null;
     }
   }
 
@@ -142,6 +145,30 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
     } finally {
       release();
     }
+  }
+}
+
+async function writeJsonAtomically(path: string, value: unknown): Promise<void> {
+  const temporaryPath = `${path}.${randomUUID()}.tmp`;
+  let file: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    file = await open(temporaryPath, 'wx', 0o600);
+    await file.writeFile(`${JSON.stringify(value, null, 2)}\n`, 'utf8');
+    await file.sync();
+    await file.close();
+    file = undefined;
+    await rename(temporaryPath, path);
+    if (process.platform !== 'win32') {
+      const directory = await open(dirname(path), 'r');
+      try {
+        await directory.sync();
+      } finally {
+        await directory.close();
+      }
+    }
+  } finally {
+    await file?.close().catch(() => undefined);
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
   }
 }
 

--- a/apps/desktop/src/main/daily-review-archive-store.ts
+++ b/apps/desktop/src/main/daily-review-archive-store.ts
@@ -3,13 +3,15 @@ import { join } from 'node:path';
 import {
   DEFAULT_DAILY_REVIEW_CONFIG,
   dailyReviewArchiveToSummary,
+  normalizeDailyReviewArchive,
   normalizeDailyReviewConfig,
   type DailyReviewArchive,
   type DailyReviewArchiveSummary,
   type DailyReviewConfig,
 } from '@maka/core';
 
-const ARCHIVE_ID_PATTERN = /^\d{4}-\d{2}-\d{2}-(daily|deep)$/;
+const ARCHIVE_ID_PATTERN = /^\d{4}-\d{2}-\d{2}-(1d|7d|30d)$/;
+const READABLE_ARCHIVE_ID_PATTERN = /^\d{4}-\d{2}-\d{2}-(1d|7d|30d|daily|deep)$/;
 
 export interface DailyReviewArchiveStore {
   getConfig(): Promise<DailyReviewConfig>;
@@ -54,8 +56,6 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
       next = normalizeDailyReviewConfig({
         ...current,
         ...patch,
-        sections: { ...current.sections, ...patch.sections },
-        externalNotify: { ...current.externalNotify, ...patch.externalNotify },
       });
       await mkdir(this.root, { recursive: true, mode: 0o700 });
       await writeFile(this.configPath, JSON.stringify(next, null, 2) + '\n', { encoding: 'utf8', mode: 0o600 });
@@ -86,12 +86,12 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
   }
 
   async getArchive(id: string): Promise<DailyReviewArchive | null> {
-    assertArchiveId(id);
+    assertReadableArchiveId(id);
     try {
       const raw = await readFile(this.archivePath(id), 'utf8');
-      const parsed = JSON.parse(raw) as DailyReviewArchive;
+      const parsed = JSON.parse(raw) as Parameters<typeof normalizeDailyReviewArchive>[0];
       if (parsed.id !== id) throw new Error(`Daily Review archive id mismatch: ${id}`);
-      return parsed;
+      return normalizeDailyReviewArchive(parsed);
     } catch (error) {
       if (isNotFound(error)) return null;
       throw error;
@@ -99,7 +99,7 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
   }
 
   async deleteArchive(id: string): Promise<void> {
-    assertArchiveId(id);
+    assertReadableArchiveId(id);
     await rm(this.archivePath(id), { force: true });
   }
 
@@ -118,7 +118,7 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
       return entries
         .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
         .map((entry) => entry.name.slice(0, -'.json'.length))
-        .filter((id) => ARCHIVE_ID_PATTERN.test(id));
+        .filter((id) => READABLE_ARCHIVE_ID_PATTERN.test(id));
     } catch (error) {
       if (isNotFound(error)) return [];
       throw error;
@@ -126,7 +126,7 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
   }
 
   private archivePath(id: string): string {
-    assertArchiveId(id);
+    assertReadableArchiveId(id);
     return join(this.archiveRoot, `${id}.json`);
   }
 
@@ -142,6 +142,12 @@ class FileDailyReviewArchiveStore implements DailyReviewArchiveStore {
     } finally {
       release();
     }
+  }
+}
+
+function assertReadableArchiveId(id: string): void {
+  if (!READABLE_ARCHIVE_ID_PATTERN.test(id)) {
+    throw new Error(`Invalid Daily Review archive id: ${id}`);
   }
 }
 

--- a/apps/desktop/src/main/daily-review-ipc-main.ts
+++ b/apps/desktop/src/main/daily-review-ipc-main.ts
@@ -1,9 +1,10 @@
 import { ipcMain } from 'electron';
 import type {
   DailyReviewConfig,
-  DailyReviewMode,
+  DailyReviewRange,
   DailyReviewSummary,
 } from '@maka/core';
+import { DAILY_REVIEW_RANGES } from '@maka/core';
 import { tryResult } from '@maka/core/result';
 import type { createMainWindowController } from './main-window.js';
 import type { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
@@ -70,10 +71,10 @@ export function registerDailyReviewIpc(deps: DailyReviewIpcDeps): void {
   );
   ipcMain.handle(
     'daily-review:runOnce',
-    (_event, input: { mode?: DailyReviewMode; day?: number; modelKey?: string } | undefined) =>
+    (_event, input: { range?: DailyReviewRange; offsetDays?: number; modelKey?: string } | undefined) =>
       deps.dailyReview.run({
-        mode: input?.mode === 'deep' ? 'deep' : 'daily',
-        day: Number.isFinite(input?.day) ? Math.trunc(input!.day!) : undefined,
+        range: DAILY_REVIEW_RANGES.includes(input?.range as DailyReviewRange) ? input!.range! : 1,
+        offsetDays: Number.isFinite(input?.offsetDays) ? Math.trunc(input!.offsetDays!) : undefined,
         modelKeyOverride: typeof input?.modelKey === 'string' ? input.modelKey : undefined,
         trigger: 'manual',
       }),

--- a/apps/desktop/src/main/daily-review-main.ts
+++ b/apps/desktop/src/main/daily-review-main.ts
@@ -61,6 +61,7 @@ interface DailyReviewMainServiceDeps {
 export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): DailyReviewMainService {
   let schedulerTimer: NodeJS.Timeout | null = null;
   let schedulerLastMinuteKey: string | null = null;
+  const inFlightRuns = new Map<string, Promise<{ archiveId: string }>>();
 
   async function buildSummaryForRange(offsetDays: number, daySpan: number): Promise<DailyReviewSummary> {
     await deps.ensureUsageReady();
@@ -126,12 +127,39 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
     const effectiveModelKey = modelKeyOverride ? modelKeyOverride : config.modelKey;
     const summary = await buildSummaryForRange(input.offsetDays ?? 0, range);
     const archiveId = dailyReviewArchiveId(summary.day, range);
+    if (await deps.archiveStore.getArchive(archiveId)) return { archiveId };
+
+    const inFlight = inFlightRuns.get(archiveId);
+    if (inFlight) return inFlight;
+    const pending = generateArchive({
+      archiveId,
+      effectiveModelKey,
+      range,
+      summary,
+      trigger: input.trigger,
+    });
+    inFlightRuns.set(archiveId, pending);
+    try {
+      return await pending;
+    } finally {
+      if (inFlightRuns.get(archiveId) === pending) inFlightRuns.delete(archiveId);
+    }
+  }
+
+  async function generateArchive(input: {
+    archiveId: string;
+    effectiveModelKey: string;
+    range: DailyReviewRange;
+    summary: DailyReviewSummary;
+    trigger: DailyReviewTrigger;
+  }): Promise<{ archiveId: string }> {
+    const { archiveId, effectiveModelKey, range, summary, trigger } = input;
     const baseArchive: Omit<DailyReviewArchive, 'status' | 'sections' | 'errorMessage'> = {
       id: archiveId,
       day: summary.day,
       range,
       generatedAt: Date.now(),
-      trigger: input.trigger,
+      trigger,
       modelKey: effectiveModelKey,
       totals: summary.totals,
     };
@@ -256,14 +284,7 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
     const mm = String(now.getMinutes()).padStart(2, '0');
     if (`${hh}:${mm}` !== config.executeTime) return;
 
-    await runIfMissing(1, -1);
-  }
-
-  async function runIfMissing(range: DailyReviewRange, offsetDays: number): Promise<void> {
-    const summary = await buildSummaryForRange(offsetDays, range);
-    const id = dailyReviewArchiveId(summary.day, range);
-    if (await deps.archiveStore.getArchive(id)) return;
-    await run({ range, offsetDays, trigger: 'cron' });
+    await run({ range: 1, offsetDays: -1, trigger: 'cron' });
   }
 
   return {

--- a/apps/desktop/src/main/daily-review-main.ts
+++ b/apps/desktop/src/main/daily-review-main.ts
@@ -13,8 +13,7 @@ import {
 import type {
   DailyReviewArchive,
   DailyReviewArchiveSectionContent,
-  DailyReviewConfig,
-  DailyReviewMode,
+  DailyReviewRange,
   DailyReviewSummary,
   DailyReviewTrigger,
   SessionSummary,
@@ -35,8 +34,8 @@ type ModelCallLedger = ReturnType<typeof createSqliteModelCallLedger>;
 export interface DailyReviewMainService {
   buildSummaryForRange(offsetDays: number, daySpan: number): Promise<DailyReviewSummary>;
   run(input: {
-    mode: DailyReviewMode;
-    day?: number;
+    range: DailyReviewRange;
+    offsetDays?: number;
     trigger: DailyReviewTrigger;
     modelKeyOverride?: string;
   }): Promise<{ archiveId: string }>;
@@ -116,21 +115,21 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
   }
 
   async function run(input: {
-    mode: DailyReviewMode;
-    day?: number;
+    range: DailyReviewRange;
+    offsetDays?: number;
     trigger: DailyReviewTrigger;
     modelKeyOverride?: string;
   }): Promise<{ archiveId: string }> {
     const config = await deps.archiveStore.getConfig();
-    const mode = input.mode === 'deep' ? 'deep' : 'daily';
+    const range = input.range;
     const modelKeyOverride = input.modelKeyOverride?.trim();
     const effectiveModelKey = modelKeyOverride ? modelKeyOverride : config.modelKey;
-    const summary = await buildSummaryForRange(input.day ?? 0, mode === 'deep' ? 7 : 1);
-    const archiveId = dailyReviewArchiveId(summary.day, mode);
+    const summary = await buildSummaryForRange(input.offsetDays ?? 0, range);
+    const archiveId = dailyReviewArchiveId(summary.day, range);
     const baseArchive: Omit<DailyReviewArchive, 'status' | 'sections' | 'errorMessage'> = {
       id: archiveId,
       day: summary.day,
-      mode,
+      range,
       generatedAt: Date.now(),
       trigger: input.trigger,
       modelKey: effectiveModelKey,
@@ -141,7 +140,7 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
       await deps.archiveStore.putArchive({
         ...baseArchive,
         status: 'no_data',
-        sections: buildRuleBasedDailyReviewSections(summary, config, mode),
+        sections: buildRuleBasedDailyReviewSections(summary, range),
         errorMessage: '没有可用于生成回顾的本地活动数据。',
       });
       await deps.archiveStore.prune(DAILY_REVIEW_ARCHIVE_LIMIT);
@@ -154,7 +153,7 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
         await deps.archiveStore.putArchive({
           ...baseArchive,
           status: 'no_model',
-          sections: buildRuleBasedDailyReviewSections(summary, config, mode),
+          sections: buildRuleBasedDailyReviewSections(summary, range),
           errorMessage: '未配置可用的分析模型。',
         });
         await deps.archiveStore.prune(DAILY_REVIEW_ARCHIVE_LIMIT);
@@ -163,8 +162,7 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
 
       const sections = await generateSections({
         summary,
-        config,
-        mode,
+        range,
         connection: modelContext.connection,
         apiKey: modelContext.apiKey,
         modelId: modelContext.modelId,
@@ -179,7 +177,7 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
       await deps.archiveStore.putArchive({
         ...baseArchive,
         status: 'failed',
-        sections: buildRuleBasedDailyReviewSections(summary, config, mode),
+        sections: buildRuleBasedDailyReviewSections(summary, range),
         errorMessage: generalizedErrorMessageChinese(error, '每日回顾生成失败'),
       });
     }
@@ -206,8 +204,7 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
 
   async function generateSections(input: {
     summary: DailyReviewSummary;
-    config: DailyReviewConfig;
-    mode: DailyReviewMode;
+    range: DailyReviewRange;
     connection: LlmConnection;
     apiKey: string | null;
     modelId: string;
@@ -223,11 +220,11 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
         modelId: input.modelId,
         fetch: modelFetch,
       }),
-      instructions: dailyReviewSystemPrompt(input.config),
-      prompt: dailyReviewUserPrompt(input.summary, input.config, input.mode),
+      instructions: dailyReviewSystemPrompt(),
+      prompt: dailyReviewUserPrompt(input.summary, input.range),
       providerOptions: buildProviderOptions(input.connection, input.modelId),
     });
-    return parseDailyReviewSections(result.text, input.config);
+    return parseDailyReviewSections(result.text);
   }
 
   function startScheduler(): void {
@@ -259,15 +256,14 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
     const mm = String(now.getMinutes()).padStart(2, '0');
     if (`${hh}:${mm}` !== config.executeTime) return;
 
-    await runIfMissing('daily');
-    if (config.deepEnabled) await runIfMissing('deep');
+    await runIfMissing(1, -1);
   }
 
-  async function runIfMissing(mode: DailyReviewMode): Promise<void> {
-    const summary = await buildSummaryForRange(0, mode === 'deep' ? 7 : 1);
-    const id = dailyReviewArchiveId(summary.day, mode);
+  async function runIfMissing(range: DailyReviewRange, offsetDays: number): Promise<void> {
+    const summary = await buildSummaryForRange(offsetDays, range);
+    const id = dailyReviewArchiveId(summary.day, range);
     if (await deps.archiveStore.getArchive(id)) return;
-    await run({ mode, trigger: 'cron' });
+    await run({ range, offsetDays, trigger: 'cron' });
   }
 
   return {
@@ -289,26 +285,20 @@ function parseModelKey(modelKey: string): { slug: string; modelId: string } | nu
   };
 }
 
-function dailyReviewSystemPrompt(config: DailyReviewConfig): string {
-  const enabled = Object.entries(config.sections)
-    .filter(([, value]) => value)
-    .map(([key]) => key)
-    .join(', ');
+function dailyReviewSystemPrompt(): string {
   return [
     '你是 Maka 的每日回顾分析器。只基于输入的本地统计和会话预览生成回顾，不编造未出现的事实。',
     '输出 JSON，不要 Markdown fence。JSON 顶层字段只允许 summary、gaps、usage、code，值为中文字符串。',
-    `启用栏目：${enabled || 'summary'}。未启用栏目可以省略。`,
+    '生成适用的栏目；没有可靠内容的栏目省略。',
   ].join('\n');
 }
 
 function dailyReviewUserPrompt(
   summary: DailyReviewSummary,
-  config: DailyReviewConfig,
-  mode: DailyReviewMode,
+  range: DailyReviewRange,
 ): string {
   return JSON.stringify({
-    mode,
-    includeClaudeCode: config.includeClaudeCode,
+    rangeDays: range,
     day: summary.day,
     totals: summary.totals,
     sessions: summary.sessions.map((session) => ({
@@ -318,21 +308,21 @@ function dailyReviewUserPrompt(
     })),
     topModels: summary.topModels,
     topTools: summary.topTools,
-    instruction: mode === 'deep'
-      ? '生成更深入的多日工作复盘：趋势、遗漏、风险、下一步。'
-      : '生成当天工作回顾：发生了什么、遗漏什么、用量洞察、代码建议。',
+    instruction: range === 1
+      ? '生成当天工作分析：发生了什么、遗漏什么、用量洞察、代码建议。'
+      : `生成最近 ${range} 天的工作分析：趋势、遗漏、风险、下一步。`,
   });
 }
 
-function parseDailyReviewSections(text: string, config: DailyReviewConfig): DailyReviewArchiveSectionContent {
+function parseDailyReviewSections(text: string): DailyReviewArchiveSectionContent {
   const trimmed = text.trim();
   try {
     const parsed = JSON.parse(trimmed) as Record<string, unknown>;
     return {
-      ...(config.sections.summary && typeof parsed.summary === 'string' ? { summary: parsed.summary.trim() } : {}),
-      ...(config.sections.gaps && typeof parsed.gaps === 'string' ? { gaps: parsed.gaps.trim() } : {}),
-      ...(config.sections.usage && typeof parsed.usage === 'string' ? { usage: parsed.usage.trim() } : {}),
-      ...(config.sections.code && typeof parsed.code === 'string' ? { code: parsed.code.trim() } : {}),
+      ...(typeof parsed.summary === 'string' ? { summary: parsed.summary.trim() } : {}),
+      ...(typeof parsed.gaps === 'string' ? { gaps: parsed.gaps.trim() } : {}),
+      ...(typeof parsed.usage === 'string' ? { usage: parsed.usage.trim() } : {}),
+      ...(typeof parsed.code === 'string' ? { code: parsed.code.trim() } : {}),
     };
   } catch {
     return { summary: trimmed };
@@ -341,8 +331,7 @@ function parseDailyReviewSections(text: string, config: DailyReviewConfig): Dail
 
 function buildRuleBasedDailyReviewSections(
   summary: DailyReviewSummary,
-  config: DailyReviewConfig,
-  mode: DailyReviewMode,
+  range: DailyReviewRange,
 ): DailyReviewArchiveSectionContent {
   const sections: {
     summary?: string;
@@ -350,25 +339,13 @@ function buildRuleBasedDailyReviewSections(
     usage?: string;
     code?: string;
   } = {};
-  if (config.sections.summary) {
-    sections.summary = `${mode === 'deep' ? '深度分析' : '每日回顾'}覆盖 ${summary.totals.sessionCount} 个对话、${summary.totals.requestCount} 次请求、${summary.totals.totalTokens} tokens。`;
-  }
-  if (config.sections.gaps) {
-    sections.gaps = summary.totals.errorCount > 0
-      ? `发现 ${summary.totals.errorCount} 次错误请求，建议回看失败上下文。`
-      : '未从本地统计中发现明确失败请求。';
-  }
-  if (config.sections.usage) {
-    const topModel = summary.topModels[0];
-    sections.usage = topModel
-      ? `使用最多的模型是 ${topModel.label}，共 ${topModel.requests} 次请求。`
-      : '暂无模型使用统计。';
-  }
-  if (config.sections.code) {
-    const topTool = summary.topTools[0];
-    sections.code = topTool
-      ? `高频工具：${topTool.label}（${topTool.requests} 次）。建议优先复盘相关改动产物。`
-      : '暂无工具调用统计可形成代码建议。';
-  }
+  sections.summary = `${range} 天范围覆盖 ${summary.totals.sessionCount} 个对话、${summary.totals.requestCount} 次请求、${summary.totals.totalTokens} tokens。`;
+  sections.gaps = summary.totals.errorCount > 0
+    ? `发现 ${summary.totals.errorCount} 次错误请求，建议回看失败上下文。`
+    : '未从本地统计中发现明确失败请求。';
+  const topModel = summary.topModels[0];
+  if (topModel) sections.usage = `使用最多的模型是 ${topModel.label}，共 ${topModel.requests} 次请求。`;
+  const topTool = summary.topTools[0];
+  if (topTool) sections.code = `高频工具：${topTool.label}（${topTool.requests} 次）。建议优先复盘相关改动产物。`;
   return sections;
 }

--- a/apps/desktop/src/main/daily-review-main.ts
+++ b/apps/desktop/src/main/daily-review-main.ts
@@ -128,7 +128,14 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
     const summary = await buildSummaryForRange(input.offsetDays ?? 0, range);
     const archiveId = dailyReviewArchiveId(summary.day, range);
     const existingArchive = await deps.archiveStore.getArchive(archiveId);
-    if (existingArchive?.status === 'ok') return { archiveId };
+    if (
+      existingArchive?.status === 'ok'
+      && existingArchive.range === range
+      && existingArchive.day.fromMs === summary.day.fromMs
+      && existingArchive.day.toMs === summary.day.toMs
+    ) {
+      return { archiveId };
+    }
 
     const inFlight = inFlightRuns.get(archiveId);
     if (inFlight) return inFlight;
@@ -336,19 +343,24 @@ function dailyReviewUserPrompt(
   });
 }
 
-function parseDailyReviewSections(text: string): DailyReviewArchiveSectionContent {
+export function parseDailyReviewSections(text: string): DailyReviewArchiveSectionContent {
   const trimmed = text.trim();
+  let sections: DailyReviewArchiveSectionContent;
   try {
-    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-    return {
-      ...(typeof parsed.summary === 'string' ? { summary: parsed.summary.trim() } : {}),
-      ...(typeof parsed.gaps === 'string' ? { gaps: parsed.gaps.trim() } : {}),
-      ...(typeof parsed.usage === 'string' ? { usage: parsed.usage.trim() } : {}),
-      ...(typeof parsed.code === 'string' ? { code: parsed.code.trim() } : {}),
-    };
+    const parsed: unknown = JSON.parse(trimmed);
+    sections = parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? {
+          ...('summary' in parsed && typeof parsed.summary === 'string' ? { summary: parsed.summary.trim() } : {}),
+          ...('gaps' in parsed && typeof parsed.gaps === 'string' ? { gaps: parsed.gaps.trim() } : {}),
+          ...('usage' in parsed && typeof parsed.usage === 'string' ? { usage: parsed.usage.trim() } : {}),
+          ...('code' in parsed && typeof parsed.code === 'string' ? { code: parsed.code.trim() } : {}),
+        }
+      : {};
   } catch {
-    return { summary: trimmed };
+    sections = { summary: trimmed };
   }
+  if (Object.values(sections).some((content) => content.length > 0)) return sections;
+  throw new Error('Daily Review model returned no usable sections');
 }
 
 function buildRuleBasedDailyReviewSections(

--- a/apps/desktop/src/main/daily-review-main.ts
+++ b/apps/desktop/src/main/daily-review-main.ts
@@ -127,7 +127,8 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
     const effectiveModelKey = modelKeyOverride ? modelKeyOverride : config.modelKey;
     const summary = await buildSummaryForRange(input.offsetDays ?? 0, range);
     const archiveId = dailyReviewArchiveId(summary.day, range);
-    if (await deps.archiveStore.getArchive(archiveId)) return { archiveId };
+    const existingArchive = await deps.archiveStore.getArchive(archiveId);
+    if (existingArchive?.status === 'ok') return { archiveId };
 
     const inFlight = inFlightRuns.get(archiveId);
     if (inFlight) return inFlight;

--- a/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
@@ -275,9 +275,9 @@ export async function writeDailyReviewArchives(workspaceRoot: string, now: numbe
   const dayFromMs = Date.UTC(2026, 4, 21, 0, 0, 0);
   const dayToMs = Date.UTC(2026, 4, 22, 0, 0, 0);
   const daily: DailyReviewArchive = {
-    id: '2026-05-21-daily',
+    id: '2026-05-21-1d',
     day: { fromMs: dayFromMs, toMs: dayToMs },
-    mode: 'daily',
+    range: 1,
     status: 'ok',
     generatedAt: now - 10 * 60_000,
     trigger: 'manual',
@@ -298,8 +298,9 @@ export async function writeDailyReviewArchives(workspaceRoot: string, now: numbe
   };
   const deep: DailyReviewArchive = {
     ...daily,
-    id: '2026-05-21-deep',
-    mode: 'deep',
+    id: '2026-05-15-7d',
+    day: { fromMs: Date.UTC(2026, 4, 15, 0, 0, 0), toMs: dayToMs },
+    range: 7,
     generatedAt: now - 5 * 60_000,
     trigger: 'cron',
     totals: {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -66,7 +66,7 @@ import type {
   VoiceRealtimeClientSession,
   DailyReviewArchiveSummary,
   DailyReviewConfig,
-  DailyReviewMode,
+  DailyReviewRange,
   DailyReviewSummary,
   WebSearchProvider,
   WebSearchResponse,
@@ -618,7 +618,7 @@ export interface MakaBridge {
     day(offsetDays: number, daySpan?: number): Promise<Result<DailyReviewSummary>>;
     getConfig?(): Promise<DailyReviewConfig>;
     setConfig?(patch: Partial<DailyReviewConfig>): Promise<DailyReviewConfig>;
-    runOnce?(input: { mode: DailyReviewMode; day?: number; modelKey?: string }): Promise<{ archiveId: string }>;
+    runOnce?(input: { range: DailyReviewRange; offsetDays?: number; modelKey?: string }): Promise<{ archiveId: string }>;
     list?(): Promise<DailyReviewArchiveSummary[]>;
     get?(archiveId: string): Promise<DailyReviewArchive | null>;
     delete?(archiveId: string): Promise<void>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -78,7 +78,7 @@ import type {
   VoiceFinishCaptureResult,
   VoiceRealtimeClientSession,
   DailyReviewConfig,
-  DailyReviewMode,
+  DailyReviewRange,
   DailyReviewSummary,
   WebSearchProvider,
   WebSearchResponse,
@@ -959,7 +959,7 @@ const makaBridge = {
     setConfig(patch: Partial<DailyReviewConfig>): Promise<DailyReviewConfig> {
       return ipcRenderer.invoke('daily-review:setConfig', patch);
     },
-    runOnce(input: { mode: DailyReviewMode; day?: number; modelKey?: string }): Promise<{ archiveId: string }> {
+    runOnce(input: { range: DailyReviewRange; offsetDays?: number; modelKey?: string }): Promise<{ archiveId: string }> {
       return ipcRenderer.invoke('daily-review:runOnce', input);
     },
     list(): Promise<DailyReviewArchiveSummary[]> {

--- a/apps/desktop/src/renderer/app-shell-command-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-command-actions.ts
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from 'react';
 import type {
+  DailyReviewRange,
   DailyReviewSummary,
   LlmConnection,
   PermissionMode,
@@ -66,7 +67,12 @@ export interface AppShellCommandListOptions {
   openSkillsFolder: () => Promise<void>;
   openWorkspaceFolder: () => Promise<void>;
   refreshConnections: () => Promise<void>;
-  saveDailyReviewMarkdown: (input: { markdown: string; label: string; summary: DailyReviewSummary }) => Promise<void>;
+  saveDailyReviewMarkdown: (input: {
+    range: DailyReviewRange;
+    markdown: string;
+    label: string;
+    summary: DailyReviewSummary;
+  }) => Promise<void>;
   setNavSelection: (selection: NavSelection) => void;
   setPermissionMode: (mode: PermissionMode) => Promise<void>;
   setThemePref: (themePref: ThemePreference) => void;
@@ -290,7 +296,7 @@ export function buildAppShellCommandList(
       try {
         const summary = await dailyReviewBridge.fetchDay(0, 1);
         const markdown = formatDailyReviewMarkdown(summary, copy.today, options.uiLocale);
-        await saveDailyReviewMarkdown({ markdown, label: copy.today, summary });
+        await saveDailyReviewMarkdown({ range: 1, markdown, label: copy.today, summary });
       } catch (err) {
         toastApi.error(
           copy.saveFailedTitle,

--- a/apps/desktop/src/renderer/app-shell-command-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-command-actions.ts
@@ -1,6 +1,5 @@
 import { useMemo, useRef } from 'react';
 import type {
-  DailyReviewRange,
   DailyReviewSummary,
   LlmConnection,
   PermissionMode,
@@ -12,7 +11,7 @@ import type {
   UiLocale,
 } from '@maka/core';
 import { formatDailyReviewMarkdown } from '@maka/ui';
-import type { NavSelection } from '@maka/ui';
+import type { DailyReviewMarkdownActionInput, NavSelection } from '@maka/ui';
 import { buildCommandList, buildSessionCommands } from './command-palette-commands.js';
 import type { Command } from './command-palette-types.js';
 import { renderConversationMarkdown } from './conversation-markdown.js';
@@ -67,12 +66,7 @@ export interface AppShellCommandListOptions {
   openSkillsFolder: () => Promise<void>;
   openWorkspaceFolder: () => Promise<void>;
   refreshConnections: () => Promise<void>;
-  saveDailyReviewMarkdown: (input: {
-    range: DailyReviewRange;
-    markdown: string;
-    label: string;
-    summary: DailyReviewSummary;
-  }) => Promise<void>;
+  saveDailyReviewMarkdown: (input: DailyReviewMarkdownActionInput) => Promise<void>;
   setNavSelection: (selection: NavSelection) => void;
   setPermissionMode: (mode: PermissionMode) => Promise<void>;
   setThemePref: (themePref: ThemePreference) => void;
@@ -296,7 +290,13 @@ export function buildAppShellCommandList(
       try {
         const summary = await dailyReviewBridge.fetchDay(0, 1);
         const markdown = formatDailyReviewMarkdown(summary, copy.today, options.uiLocale);
-        await saveDailyReviewMarkdown({ range: 1, markdown, label: copy.today, summary });
+        await saveDailyReviewMarkdown({
+          day: summary.day,
+          range: 1,
+          totals: summary.totals,
+          markdown,
+          label: copy.today,
+        });
       } catch (err) {
         toastApi.error(
           copy.saveFailedTitle,

--- a/apps/desktop/src/renderer/app-shell-daily-review-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-daily-review-actions.ts
@@ -1,4 +1,5 @@
-import type { DailyReviewRange, DailyReviewSummary, UiLocale } from '@maka/core';
+import type { UiLocale } from '@maka/core';
+import type { DailyReviewMarkdownActionInput } from '@maka/ui';
 import { dailyReviewActionErrorMessage, dailyReviewExportDefaultName } from './daily-review-actions';
 import { getShellCopy } from './locales/shell-copy.js';
 
@@ -13,21 +14,14 @@ type ComposerAppendHandle = {
   appendText(text: string): void;
 };
 
-type DailyReviewMarkdownInput = {
-  range: DailyReviewRange;
-  markdown: string;
-  label: string;
-  summary: DailyReviewSummary;
-};
-
 type DailyReviewFeedbackOptions = {
   shouldShowFeedback?: () => boolean;
 };
 
 export interface AppShellDailyReviewActions {
-  copyDailyReviewMarkdown(input: DailyReviewMarkdownInput, options?: DailyReviewFeedbackOptions): Promise<void>;
-  appendDailyReviewMarkdown(input: DailyReviewMarkdownInput): void;
-  saveDailyReviewMarkdown(input: DailyReviewMarkdownInput, options?: DailyReviewFeedbackOptions): Promise<void>;
+  copyDailyReviewMarkdown(input: DailyReviewMarkdownActionInput, options?: DailyReviewFeedbackOptions): Promise<void>;
+  appendDailyReviewMarkdown(input: DailyReviewMarkdownActionInput): void;
+  saveDailyReviewMarkdown(input: DailyReviewMarkdownActionInput, options?: DailyReviewFeedbackOptions): Promise<void>;
 }
 
 export function createAppShellDailyReviewActions(deps: {
@@ -38,14 +32,14 @@ export function createAppShellDailyReviewActions(deps: {
   const { uiLocale, composerRef, toastApi } = deps;
   const copy = getShellCopy(uiLocale).commandActions;
 
-  async function copyDailyReviewMarkdown(input: DailyReviewMarkdownInput, options: DailyReviewFeedbackOptions = {}) {
+  async function copyDailyReviewMarkdown(input: DailyReviewMarkdownActionInput, options: DailyReviewFeedbackOptions = {}) {
     const shouldShowFeedback = options.shouldShowFeedback ?? (() => true);
     try {
       await navigator.clipboard.writeText(input.markdown);
       if (shouldShowFeedback()) {
         toastApi.success(
           copy.reviewCopied(input.label),
-          copy.reviewSummary(input.summary.totals.sessionCount, input.summary.totals.requestCount),
+          copy.reviewSummary(input.totals.sessionCount, input.totals.requestCount),
         );
       }
     } catch (error) {
@@ -55,26 +49,26 @@ export function createAppShellDailyReviewActions(deps: {
     }
   }
 
-  function appendDailyReviewMarkdown(input: DailyReviewMarkdownInput): void {
+  function appendDailyReviewMarkdown(input: DailyReviewMarkdownActionInput): void {
     composerRef.current?.appendText(input.markdown);
     toastApi.success(
       copy.reviewPasted(input.label),
-      copy.reviewSummary(input.summary.totals.sessionCount, input.summary.totals.requestCount),
+      copy.reviewSummary(input.totals.sessionCount, input.totals.requestCount),
     );
   }
 
-  async function saveDailyReviewMarkdown(input: DailyReviewMarkdownInput, options: DailyReviewFeedbackOptions = {}) {
+  async function saveDailyReviewMarkdown(input: DailyReviewMarkdownActionInput, options: DailyReviewFeedbackOptions = {}) {
     const shouldShowFeedback = options.shouldShowFeedback ?? (() => true);
     try {
       const result = await window.maka.dailyReview.saveMarkdownToFile({
         markdown: input.markdown,
-        defaultName: dailyReviewExportDefaultName({ range: input.range, day: input.summary.day }),
+        defaultName: dailyReviewExportDefaultName({ range: input.range, day: input.day }),
       });
       if (result.ok) {
         if (shouldShowFeedback()) {
           toastApi.success(
             copy.reviewSaved(input.label),
-            copy.reviewSummary(input.summary.totals.sessionCount, input.summary.totals.requestCount),
+            copy.reviewSummary(input.totals.sessionCount, input.totals.requestCount),
           );
         }
       } else if (result.reason === 'canceled') {

--- a/apps/desktop/src/renderer/app-shell-daily-review-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-daily-review-actions.ts
@@ -1,4 +1,4 @@
-import type { DailyReviewSummary, UiLocale } from '@maka/core';
+import type { DailyReviewRange, DailyReviewSummary, UiLocale } from '@maka/core';
 import { dailyReviewActionErrorMessage, dailyReviewExportDefaultName } from './daily-review-actions';
 import { getShellCopy } from './locales/shell-copy.js';
 
@@ -14,6 +14,7 @@ type ComposerAppendHandle = {
 };
 
 type DailyReviewMarkdownInput = {
+  range: DailyReviewRange;
   markdown: string;
   label: string;
   summary: DailyReviewSummary;
@@ -67,7 +68,7 @@ export function createAppShellDailyReviewActions(deps: {
     try {
       const result = await window.maka.dailyReview.saveMarkdownToFile({
         markdown: input.markdown,
-        defaultName: dailyReviewExportDefaultName(input.label),
+        defaultName: dailyReviewExportDefaultName({ range: input.range, day: input.summary.day }),
       });
       if (result.ok) {
         if (shouldShowFeedback()) {

--- a/apps/desktop/src/renderer/app-shell-daily-review-bridge.ts
+++ b/apps/desktop/src/renderer/app-shell-daily-review-bridge.ts
@@ -1,7 +1,7 @@
-import type { DailyReviewConfig, DailyReviewRange, LlmConnection, UiLocale } from '@maka/core';
+import type { DailyReviewRange, UiLocale } from '@maka/core';
 import { getShellRemainingCopy } from './locales/shell-remaining-copy.js';
 
-export function createAppShellDailyReviewBridge(_connections: readonly LlmConnection[], locale: UiLocale = 'zh') {
+export function createAppShellDailyReviewBridge(locale: UiLocale = 'zh') {
   const copy = getShellRemainingCopy(locale).dailyReview;
   return {
     async fetchDay(offsetDays: number, daySpan?: number) {
@@ -25,21 +25,6 @@ export function createAppShellDailyReviewBridge(_connections: readonly LlmConnec
       const archive = await getArchive(archiveId);
       if (!archive) throw new Error(copy.archiveMissing);
       return archive;
-    },
-    deleteArchive(archiveId: string) {
-      const deleteArchive = window.maka.dailyReview.deleteArchive;
-      if (!deleteArchive) throw new Error(copy.historyUnavailable);
-      return deleteArchive(archiveId);
-    },
-    fetchConfig() {
-      const getConfig = window.maka.dailyReview.getConfig;
-      if (!getConfig) throw new Error(copy.settingsUnavailable);
-      return getConfig();
-    },
-    updateConfig(patch: Partial<DailyReviewConfig>) {
-      const setConfig = window.maka.dailyReview.setConfig;
-      if (!setConfig) throw new Error(copy.settingsUnavailable);
-      return setConfig(patch);
     },
   };
 }

--- a/apps/desktop/src/renderer/app-shell-daily-review-bridge.ts
+++ b/apps/desktop/src/renderer/app-shell-daily-review-bridge.ts
@@ -1,24 +1,18 @@
-import type { DailyReviewConfig, DailyReviewMode, LlmConnection, UiLocale } from '@maka/core';
-import {
-  buildDailyReviewRunModelOptions,
-  DAILY_REVIEW_CONFIG_MODEL_VALUE,
-} from './daily-review-actions';
+import type { DailyReviewConfig, DailyReviewRange, LlmConnection, UiLocale } from '@maka/core';
 import { getShellRemainingCopy } from './locales/shell-remaining-copy.js';
 
-export function createAppShellDailyReviewBridge(connections: readonly LlmConnection[], locale: UiLocale = 'zh') {
+export function createAppShellDailyReviewBridge(_connections: readonly LlmConnection[], locale: UiLocale = 'zh') {
   const copy = getShellRemainingCopy(locale).dailyReview;
   return {
-    modelOptions: buildDailyReviewRunModelOptions(connections, locale),
     async fetchDay(offsetDays: number, daySpan?: number) {
       const result = await window.maka.dailyReview.day(offsetDays, daySpan);
       if (!result.ok) throw new Error(result.error.message);
       return result.data;
     },
-    runOnce(input: { mode: DailyReviewMode; modelKey?: string }) {
+    runOnce(input: { range: DailyReviewRange; offsetDays?: number }) {
       const runOnce = window.maka.dailyReview.runOnce;
       if (!runOnce) throw new Error(copy.unavailable);
-      const modelKey = input.modelKey === DAILY_REVIEW_CONFIG_MODEL_VALUE ? undefined : input.modelKey;
-      return runOnce({ ...input, modelKey });
+      return runOnce(input);
     },
     listArchives() {
       const listArchives = window.maka.dailyReview.listArchives;

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -560,7 +560,7 @@ function AppShellContent({
   // PR-DAILY-REVIEW-MVP-0: bridge for the main Daily Review module.
   // Memoized so the panel's `useEffect` cleanup keys
   // off a stable reference instead of refetching on every render.
-  const dailyReviewBridge = useMemo(() => createAppShellDailyReviewBridge(connections, uiLocale), [connections, uiLocale]);
+  const dailyReviewBridge = useMemo(() => createAppShellDailyReviewBridge(uiLocale), [uiLocale]);
   const {
     appendDailyReviewMarkdown,
     copyDailyReviewMarkdown,

--- a/apps/desktop/src/renderer/daily-review-actions.ts
+++ b/apps/desktop/src/renderer/daily-review-actions.ts
@@ -1,10 +1,6 @@
-import type { LlmConnection, UiLocale } from '@maka/core';
-import type { SelectorOptionData } from '@astryxdesign/core/Selector';
+import type { UiLocale } from '@maka/core';
 import { generalizedErrorMessage, generalizedErrorMessageChinese } from '@maka/core';
-import { buildCatalogDailyReviewModelOptions } from './model-catalog-choices.js';
 import { getShellRemainingCopy } from './locales/shell-remaining-copy.js';
-
-export const DAILY_REVIEW_CONFIG_MODEL_VALUE = '__maka_daily_review_config_model__';
 
 export function dailyReviewExportDefaultName(label: string): string {
   const zh = getShellRemainingCopy('zh').dailyReview;
@@ -27,22 +23,4 @@ export function dailyReviewExportDefaultName(label: string): string {
 
 export function dailyReviewActionErrorMessage(error: unknown, fallback: string, locale: UiLocale): string {
   return locale === 'zh' ? generalizedErrorMessageChinese(error, fallback) : generalizedErrorMessage(error, fallback);
-}
-
-export function buildDailyReviewRunModelOptions(
-  connections: readonly LlmConnection[],
-  locale: UiLocale = 'zh',
-): SelectorOptionData[] {
-  const copy = getShellRemainingCopy(locale).dailyReview;
-  return [
-    // Compact default option for the panel's inline 分析模型 picker — a run
-    // with no explicit override falls back to the model configured in Settings.
-    {
-      value: DAILY_REVIEW_CONFIG_MODEL_VALUE,
-      label: copy.followSettings,
-    },
-    ...buildCatalogDailyReviewModelOptions(connections, '', locale).map(
-      ([value, label]) => ({ value, label }),
-    ),
-  ];
 }

--- a/apps/desktop/src/renderer/daily-review-actions.ts
+++ b/apps/desktop/src/renderer/daily-review-actions.ts
@@ -1,24 +1,14 @@
-import type { UiLocale } from '@maka/core';
-import { generalizedErrorMessage, generalizedErrorMessageChinese } from '@maka/core';
-import { getShellRemainingCopy } from './locales/shell-remaining-copy.js';
+import type { DailyReviewArchive, UiLocale } from '@maka/core';
+import {
+  dailyReviewArchiveId,
+  generalizedErrorMessage,
+  generalizedErrorMessageChinese,
+} from '@maka/core';
 
-export function dailyReviewExportDefaultName(label: string): string {
-  const zh = getShellRemainingCopy('zh').dailyReview;
-  const en = getShellRemainingCopy('en').dailyReview;
-  const today = new Date();
-  const yyyy = today.getFullYear();
-  const mm = String(today.getMonth() + 1).padStart(2, '0');
-  const dd = String(today.getDate()).padStart(2, '0');
-  const scope = label.includes('30')
-    ? '30d'
-    : label.includes('7')
-      ? '7d'
-      : label === zh.yesterday || label === en.yesterday
-        ? 'yesterday'
-        : label === zh.today || label === en.today
-          ? 'today'
-          : 'day';
-  return `maka-daily-review-${scope}-${yyyy}-${mm}-${dd}.md`;
+export function dailyReviewExportDefaultName(
+  input: Pick<DailyReviewArchive, 'day' | 'range'>,
+): string {
+  return `maka-daily-review-${dailyReviewArchiveId(input.day, input.range)}.md`;
 }
 
 export function dailyReviewActionErrorMessage(error: unknown, fallback: string, locale: UiLocale): string {

--- a/apps/desktop/src/renderer/locales/settings-daily-review-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-daily-review-copy.ts
@@ -1,58 +1,63 @@
-import type { DailyReviewMode, UiCatalog, UiLocale } from '@maka/core';
-
-type DailyReviewSection = 'summary' | 'gaps' | 'usage' | 'code';
+import type { UiCatalog, UiLocale } from '@maka/core';
 
 export type DailyReviewSettingsCopy = {
   defaultModel: string;
   saveFailed: string;
-  runSuccess: Record<DailyReviewMode, string>;
-  runSuccessDetail: string;
-  runFailed: string;
   aria: string;
   unavailable: string;
   loadFailed(error: string): string;
+  scheduleTitle: string;
+  scheduleDescription: string;
   enabled: string;
   enabledHelp: string;
   executeTime: string;
   executeTimeHelp: string;
-  executeTimeAria: string;
   executeTimePlaceholder: string;
   executeTimeInvalid: string;
-  sections: Record<DailyReviewSection, { title: string; detail: string }>;
-  deep: string;
-  deepHelp: string;
+  analysisTitle: string;
+  analysisDescription: string;
   model: string;
   modelHelp: string;
-  modelAria: string;
-  includeCli: string;
-  includeCliHelp: string;
-  notify: string;
-  notifyHelp: string;
-  actionsAria: string;
-  generating: string;
-  generateDeep: string;
-  generateDaily: string;
-  open: string;
 };
 
 const SETTINGS_DAILY_REVIEW_COPY = {
   zh: {
-    defaultModel: '跟随对话默认', saveFailed: '保存每日回顾设置失败', runSuccess: { daily: '已生成每日回顾', deep: '已生成深度分析' }, runSuccessDetail: '可在「每日回顾」面板查看。', runFailed: '生成回顾失败',
-    aria: '每日回顾', unavailable: '当前版本仅本地数字聚合，定时生成 / LLM 摘要尚未连接到后端。', loadFailed: (error) => `读取每日回顾设置失败：${error}`,
-    enabled: '启用每日回顾', enabledHelp: '每天自动分析前一天的工作内容，提供摘要与建议。', executeTime: '执行时间', executeTimeHelp: '默认 08:00 本地时间触发。', executeTimeAria: '每日回顾执行时间', executeTimePlaceholder: 'HH:mm', executeTimeInvalid: '请输入 24 小时制时间，例如 08:00。',
-    sections: { summary: { title: '对话摘要', detail: '昨天聊了什么，关键结论是什么。' }, gaps: { title: '遗漏提醒', detail: '开始但未完成的讨论、可能忽略的要点。' }, usage: { title: '使用洞察', detail: '模型选择、Token 消耗、工具使用效率。' }, code: { title: '代码建议', detail: '基于对话中的代码讨论，给出优化建议。' } },
-    deep: '深度分析', deepHelp: '消耗更多资源，对更长时间周期进行深入调研。', model: '分析模型', modelHelp: '用于生成回顾和分析的模型连接；默认跟随当前对话默认模型。', modelAria: '分析模型连接',
-    includeCli: '包含 Claude Code CLI 会话', includeCliHelp: '将已同步的 Claude Code 对话纳入分析范围。', notify: '生成后发送外部通知', notifyHelp: '当前运行时尚未接入报告自动推送。机器人通道可以在「机器人对话」里配置，但每日回顾不会假装已发送。',
-    actionsAria: '每日回顾操作', generating: '生成中…', generateDeep: '生成深度分析', generateDaily: '生成每日回顾', open: '打开每日回顾',
+    defaultModel: '跟随对话默认',
+    saveFailed: '保存每日回顾设置失败',
+    aria: '每日回顾',
+    unavailable: '当前版本无法读取每日回顾设置。',
+    loadFailed: (error) => `读取每日回顾设置失败：${error}`,
+    scheduleTitle: '定时分析',
+    scheduleDescription: '按本地时间自动分析前一个完整自然日的活动。',
+    enabled: '启用定时分析',
+    enabledHelp: '每天生成一份昨日活动分析。',
+    executeTime: '执行时间',
+    executeTimeHelp: '使用 24 小时制的本地时间。',
+    executeTimePlaceholder: 'HH:mm',
+    executeTimeInvalid: '请输入 24 小时制时间，例如 08:00。',
+    analysisTitle: '分析',
+    analysisDescription: '选择用于生成固定结构报告的模型。',
+    model: '分析模型',
+    modelHelp: '未指定时跟随当前对话的默认模型。',
   },
   en: {
-    defaultModel: 'Follow conversation default', saveFailed: 'Failed to save Daily Review settings', runSuccess: { daily: 'Daily Review generated', deep: 'Deep analysis generated' }, runSuccessDetail: 'View it in the Daily Review panel.', runFailed: 'Failed to generate review',
-    aria: 'Daily Review', unavailable: 'This version supports local numeric aggregation only. Scheduled generation and LLM summaries are not connected to the backend.', loadFailed: (error) => `Failed to load Daily Review settings: ${error}`,
-    enabled: 'Enable Daily Review', enabledHelp: 'Automatically analyze the previous day’s work and provide summaries and suggestions.', executeTime: 'Run time', executeTimeHelp: 'Runs at 08:00 local time by default.', executeTimeAria: 'Daily Review run time', executeTimePlaceholder: 'HH:mm', executeTimeInvalid: 'Enter a 24-hour time, for example 08:00.',
-    sections: { summary: { title: 'Conversation summary', detail: 'What you discussed yesterday and the key conclusions.' }, gaps: { title: 'Missed items', detail: 'Discussions that started but did not finish and points that may have been overlooked.' }, usage: { title: 'Usage insights', detail: 'Model choices, token consumption, and tool-use efficiency.' }, code: { title: 'Code suggestions', detail: 'Optimization suggestions based on code discussed in conversations.' } },
-    deep: 'Deep analysis', deepHelp: 'Use more resources to investigate a longer time period.', model: 'Analysis model', modelHelp: 'The model connection used for reviews and analysis; follows the current conversation default unless changed.', modelAria: 'Analysis model connection',
-    includeCli: 'Include Claude Code CLI sessions', includeCliHelp: 'Include synced Claude Code conversations in the analysis.', notify: 'Send an external notification after generation', notifyHelp: 'Automatic report delivery is not connected yet. Bot channels can be configured under Bot chat, but Daily Review will not claim a report was sent.',
-    actionsAria: 'Daily Review actions', generating: 'Generating…', generateDeep: 'Generate deep analysis', generateDaily: 'Generate Daily Review', open: 'Open Daily Review',
+    defaultModel: 'Follow conversation default',
+    saveFailed: 'Failed to save Daily Review settings',
+    aria: 'Daily Review',
+    unavailable: 'Daily Review settings are unavailable in this build.',
+    loadFailed: (error) => `Failed to load Daily Review settings: ${error}`,
+    scheduleTitle: 'Schedule',
+    scheduleDescription: 'Analyze the previous complete local day automatically.',
+    enabled: 'Enable scheduled analysis',
+    enabledHelp: 'Generate an analysis of yesterday’s activity each day.',
+    executeTime: 'Run time',
+    executeTimeHelp: 'Uses your local time in 24-hour format.',
+    executeTimePlaceholder: 'HH:mm',
+    executeTimeInvalid: 'Enter a 24-hour time, for example 08:00.',
+    analysisTitle: 'Analysis',
+    analysisDescription: 'Choose the model used to generate the fixed report structure.',
+    model: 'Analysis model',
+    modelHelp: 'Follows the current conversation default when unspecified.',
   },
 } satisfies UiCatalog<DailyReviewSettingsCopy>;
 

--- a/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
@@ -1,27 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Banner, Card, Item } from '@astryxdesign/core';
-import type { DailyReviewConfig, DailyReviewMode, LlmConnection } from '@maka/core';
-import {
-  Button,
-  Selector,
-  Switch,
-  TextInput,
-  useMountedRef,
-  useToast,
-  useUiLocale,
-} from '@maka/ui';
+import { Banner, Divider, Heading, HStack, Text, VStack } from '@astryxdesign/core';
+import type { DailyReviewConfig, LlmConnection } from '@maka/core';
+import { FormLayout, Selector, Switch, TextInput, useMountedRef, useToast, useUiLocale } from '@maka/ui';
 import { buildCatalogDailyReviewModelOptions } from '../model-catalog-choices';
 import { getDailyReviewSettingsCopy, type DailyReviewSettingsCopy } from '../locales/settings-daily-review-copy';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { useActionGuard } from './use-action-guard';
-
-/**
- * PR-DAILY-REVIEW-MVP-0 follow-up: Settings → 每日回顾 is no longer
- * a roadmap page. The sidebar panel handles browsing/usage; this
- * page summarizes what it does, the privacy boundary, and offers a
- * one-click jump to the sidebar.
- */
-const DAILY_REVIEW_SECTION_KEYS = ['summary', 'gaps', 'usage', 'code'] as const;
 
 const DAILY_REVIEW_DEFAULT_MODEL_VALUE = '__maka_daily_review_default_model__';
 
@@ -31,65 +15,67 @@ function buildDailyReviewModelOptions(
   copy: DailyReviewSettingsCopy,
   locale: 'zh' | 'en',
 ): Array<{ value: string; label: string }> {
-  const options: Array<{ value: string; label: string }> = [
+  return [
     { value: DAILY_REVIEW_DEFAULT_MODEL_VALUE, label: copy.defaultModel },
+    ...buildCatalogDailyReviewModelOptions(connections, currentModelKey, locale).map(([value, label]) => ({
+      value,
+      label,
+    })),
   ];
-  options.push(
-    ...buildCatalogDailyReviewModelOptions(
-      connections,
-      currentModelKey.trim() === DAILY_REVIEW_DEFAULT_MODEL_VALUE ? '' : currentModelKey,
-      locale,
-    ).map(([value, label]) => ({ value, label })),
-  );
-  return options;
 }
 
-export function DailyReviewSettingsPage(props: { connections: readonly LlmConnection[]; onOpenDailyReview?: () => void }) {
+function SettingsSection(props: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <VStack gap={5}>
+      <VStack gap={1}>
+        <Heading level={2}>{props.title}</Heading>
+        <Text type="supporting" color="secondary">{props.description}</Text>
+      </VStack>
+      {props.children}
+    </VStack>
+  );
+}
+
+export function DailyReviewSettingsPage(props: { connections: readonly LlmConnection[] }) {
   const locale = useUiLocale();
   const copy = getDailyReviewSettingsCopy(locale);
   const toast = useToast();
   const dailyReviewIpc = window.maka.dailyReview;
   const hasConfigIpc = Boolean(dailyReviewIpc.getConfig && dailyReviewIpc.setConfig);
-  const hasRunOnceIpc = Boolean(dailyReviewIpc.runOnce);
-
   const [config, setConfig] = useState<DailyReviewConfig | null>(null);
-  const [loading, setLoading] = useState<boolean>(hasConfigIpc);
+  const [loading, setLoading] = useState(hasConfigIpc);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [savingKey, setSavingKey] = useState<string | null>(null);
-  const [runningMode, setRunningMode] = useState<DailyReviewMode | null>(null);
   const [executeTimeDraft, setExecuteTimeDraft] = useState('08:00');
   const [executeTimeInvalid, setExecuteTimeInvalid] = useState(false);
   const mountedRef = useMountedRef();
   const saveConfigGuard = useActionGuard<string>();
-  const runModeGuard = useActionGuard<DailyReviewMode>();
 
   useEffect(() => {
     if (!hasConfigIpc || !dailyReviewIpc.getConfig) {
-      setConfig(null);
       setLoading(false);
       return;
     }
     let cancelled = false;
     setLoading(true);
     setLoadError(null);
-    dailyReviewIpc
-      .getConfig()
-      .then((next) => {
-        if (!cancelled && mountedRef.current) {
-          setConfig(next);
-          setLoading(false);
-        }
-      })
-      .catch((err: unknown) => {
-        if (!cancelled && mountedRef.current) {
-          setLoadError(settingsActionErrorMessage(err, locale));
-          setLoading(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [hasConfigIpc, dailyReviewIpc, locale]);
+    dailyReviewIpc.getConfig().then((next) => {
+      if (!cancelled && mountedRef.current) {
+        setConfig(next);
+        setLoading(false);
+      }
+    }).catch((error: unknown) => {
+      if (!cancelled && mountedRef.current) {
+        setLoadError(settingsActionErrorMessage(error, locale));
+        setLoading(false);
+      }
+    });
+    return () => { cancelled = true; };
+  }, [dailyReviewIpc, hasConfigIpc, locale, mountedRef]);
 
   useEffect(() => {
     setExecuteTimeDraft(config?.executeTime ?? '08:00');
@@ -103,91 +89,52 @@ export function DailyReviewSettingsPage(props: { connections: readonly LlmConnec
     try {
       const next = await dailyReviewIpc.setConfig(patch);
       if (mountedRef.current && saveConfigGuard.current === key) setConfig(next);
-    } catch (err) {
+    } catch (error) {
       if (mountedRef.current && saveConfigGuard.current === key) {
-        toast.error(copy.saveFailed, settingsActionErrorMessage(err, locale));
+        toast.error(copy.saveFailed, settingsActionErrorMessage(error, locale));
       }
     } finally {
-      if (saveConfigGuard.current === key) {
-        saveConfigGuard.finish();
-      }
+      if (saveConfigGuard.current === key) saveConfigGuard.finish();
       if (mountedRef.current) setSavingKey(null);
     }
   }
 
-  async function triggerRun(mode: DailyReviewMode) {
-    if (!dailyReviewIpc.runOnce || runModeGuard.current !== null) return;
-    runModeGuard.begin(mode);
-    setRunningMode(mode);
-    try {
-      await dailyReviewIpc.runOnce({ mode });
-      if (mountedRef.current && runModeGuard.current === mode) {
-        toast.success(copy.runSuccess[mode], copy.runSuccessDetail);
-      }
-    } catch (err) {
-      if (mountedRef.current && runModeGuard.current === mode) {
-        toast.error(copy.runFailed, settingsActionErrorMessage(err, locale));
-      }
-    } finally {
-      if (runModeGuard.current === mode) {
-        runModeGuard.finish();
-      }
-      if (mountedRef.current) setRunningMode(null);
-    }
-  }
-
-  const effectiveConfig = config;
-  const formDisabled = !hasConfigIpc || loading || Boolean(loadError) || !effectiveConfig || savingKey !== null;
   const modelOptions = useMemo(
-    () => buildDailyReviewModelOptions(props.connections, effectiveConfig?.modelKey ?? '', copy, locale),
-    [copy, effectiveConfig?.modelKey, locale, props.connections],
+    () => buildDailyReviewModelOptions(props.connections, config?.modelKey ?? '', copy, locale),
+    [config?.modelKey, copy, locale, props.connections],
   );
-  const selectedModelValue = effectiveConfig?.modelKey?.trim()
-    ? effectiveConfig.modelKey.trim()
-    : DAILY_REVIEW_DEFAULT_MODEL_VALUE;
+  const formDisabled = !hasConfigIpc || loading || Boolean(loadError) || !config || savingKey !== null;
+  const scheduleDisabled = formDisabled;
+  const selectedModelValue = config?.modelKey.trim() || DAILY_REVIEW_DEFAULT_MODEL_VALUE;
 
   return (
-    <section className="settingsFeatureStatusPage" aria-label={copy.aria}>
-      {/* Detail audit: the always-on feature banner repeated the page
-          subtitle — report by exception instead: only the not-wired
-          fallback state warrants a banner. */}
-      {!hasConfigIpc && (
-        <Banner status="info" title={copy.unavailable} />
-      )}
-      {loadError ? (
-        <Banner
-          status="error"
-          className="settingsSurfaceAlert"
-          title={copy.loadFailed(loadError)} />
-      ) : null}
-      <Card padding={0} className="settingsRows">
-        <Item
-          label={copy.enabled}
-          description={copy.enabledHelp}
-          endContent={<Switch
-            label={copy.enabled}
-            isLabelHidden
-            value={effectiveConfig?.enabled ?? false}
-            isDisabled={formDisabled || savingKey === 'enabled'}
-            onChange={(enabled) => void patchConfig('enabled', { enabled })}
-          />}
-        />
+    <VStack className="settingsFormPage" gap={8} aria-label={copy.aria}>
+      {!hasConfigIpc ? <Banner status="info" title={copy.unavailable} /> : null}
+      {loadError ? <Banner status="error" title={copy.loadFailed(loadError)} /> : null}
 
-        <Item
-          label={copy.executeTime}
-          description={copy.executeTimeHelp}
-          endContent={<TextInput
-            label={copy.executeTimeAria}
-            isLabelHidden
+      <SettingsSection title={copy.scheduleTitle} description={copy.scheduleDescription}>
+        <FormLayout className="settingsFormLayout">
+          <HStack justify="between" align="center" gap={6}>
+            <VStack gap={1}>
+              <Text type="body">{copy.enabled}</Text>
+              <Text type="supporting" color="secondary">{copy.enabledHelp}</Text>
+            </VStack>
+            <Switch
+              label={copy.enabled}
+              isLabelHidden
+              value={config?.enabled ?? false}
+              isDisabled={formDisabled}
+              onChange={(enabled) => void patchConfig('enabled', { enabled })}
+            />
+          </HStack>
+          <TextInput
+            label={copy.executeTime}
+            description={copy.executeTimeHelp}
             value={executeTimeDraft}
-            isDisabled={formDisabled || savingKey === 'executeTime'}
+            isDisabled={scheduleDisabled}
             placeholder={copy.executeTimePlaceholder}
-            width={140}
-            status={
-              executeTimeInvalid
-                ? { type: 'error', message: copy.executeTimeInvalid }
-                : undefined
-            }
+            width="100%"
+            status={executeTimeInvalid ? { type: 'error', message: copy.executeTimeInvalid } : undefined}
             onChange={(executeTime) => {
               setExecuteTimeDraft(executeTime);
               setExecuteTimeInvalid(false);
@@ -195,120 +142,31 @@ export function DailyReviewSettingsPage(props: { connections: readonly LlmConnec
             onBlur={() => {
               if (!/^(?:[01]\d|2[0-3]):[0-5]\d$/u.test(executeTimeDraft)) {
                 setExecuteTimeInvalid(true);
-                return;
-              }
-              if (executeTimeDraft !== effectiveConfig?.executeTime) {
-                void patchConfig('executeTime', {
-                  executeTime: executeTimeDraft,
-                });
+              } else if (executeTimeDraft !== config?.executeTime) {
+                void patchConfig('executeTime', { executeTime: executeTimeDraft });
               }
             }}
-          />}
-        />
-
-        {DAILY_REVIEW_SECTION_KEYS.map((key) => (
-          <Item
-            key={key}
-            label={copy.sections[key].title}
-            description={copy.sections[key].detail}
-            endContent={<Switch
-              label={copy.sections[key].title}
-              isLabelHidden
-              value={effectiveConfig?.sections[key] ?? false}
-              isDisabled={formDisabled || savingKey === `section:${key}` || !(effectiveConfig?.enabled ?? false)}
-              onChange={(next) =>
-                void patchConfig(`section:${key}`, {
-                  sections: {
-                    ...(effectiveConfig?.sections ?? { summary: false, gaps: false, usage: false, code: false }),
-                    [key]: next,
-                  },
-                })
-              }
-            />}
           />
-        ))}
+        </FormLayout>
+      </SettingsSection>
 
-        <Item
-          label={copy.deep}
-          description={copy.deepHelp}
-          endContent={<Switch
-            label={copy.deep}
-            isLabelHidden
-            value={effectiveConfig?.deepEnabled ?? false}
-            isDisabled={formDisabled || savingKey === 'deepEnabled'}
-            onChange={(deepEnabled) => void patchConfig('deepEnabled', { deepEnabled })}
-          />}
-        />
+      <Divider />
 
-        <Item
-          label={copy.model}
-          description={copy.modelHelp}
-          endContent={<Selector
+      <SettingsSection title={copy.analysisTitle} description={copy.analysisDescription}>
+        <FormLayout className="settingsFormLayout">
+          <Selector
             value={selectedModelValue}
-            label={copy.modelAria}
-            isLabelHidden
+            label={copy.model}
+            description={copy.modelHelp}
             options={modelOptions}
-            isDisabled={formDisabled || savingKey === 'modelKey' || modelOptions.length === 0}
-            width={320}
-            onChange={(value) => {
-              void patchConfig('modelKey', {
-                modelKey: value === DAILY_REVIEW_DEFAULT_MODEL_VALUE ? '' : value,
-              });
-            }}
-          />}
-        />
-
-        <Item
-          label={copy.includeCli}
-          description={copy.includeCliHelp}
-          endContent={<Switch
-            label={copy.includeCli}
-            isLabelHidden
-            value={effectiveConfig?.includeClaudeCode ?? false}
-            isDisabled={formDisabled || savingKey === 'includeClaudeCode'}
-            onChange={(includeClaudeCode) => void patchConfig('includeClaudeCode', { includeClaudeCode })}
-          />}
-        />
-
-        <Item
-          label={copy.notify}
-          description={copy.notifyHelp}
-          endContent={<Switch
-            label={copy.notify}
-            isLabelHidden
-            value={false}
-            isDisabled={true}
-            onChange={() => undefined}
-          />}
-        />
-      </Card>
-      {(props.onOpenDailyReview || hasRunOnceIpc) && (
-        <div className="settingsPageFooterActions" role="toolbar" aria-label={copy.actionsAria}>
-          {hasRunOnceIpc && (
-            <>
-              <Button
-                variant="secondary"
-                onClick={() => void triggerRun('deep')}
-                isDisabled={runningMode !== null}
-                label={runningMode === 'deep' ? copy.generating : copy.generateDeep}
-              />
-              <Button
-                variant="secondary"
-                onClick={() => void triggerRun('daily')}
-                isDisabled={runningMode !== null}
-                label={runningMode === 'daily' ? copy.generating : copy.generateDaily}
-              />
-            </>
-          )}
-          {props.onOpenDailyReview && (
-            <Button
-              variant="primary"
-              onClick={props.onOpenDailyReview}
-              label={copy.open}
-            />
-          )}
-        </div>
-      )}
-    </section>
+            isDisabled={formDisabled || modelOptions.length === 0}
+            width="100%"
+            onChange={(value) => void patchConfig('modelKey', {
+              modelKey: value === DAILY_REVIEW_DEFAULT_MODEL_VALUE ? '' : value,
+            })}
+          />
+        </FormLayout>
+      </SettingsSection>
+    </VStack>
   );
 }

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -463,7 +463,7 @@ function SettingsPage(props: {
         />
       );
     case 'daily-review':
-      return <DailyReviewSettingsPage connections={props.connections} onOpenDailyReview={props.onOpenDailyReview} />;
+      return <DailyReviewSettingsPage connections={props.connections} />;
     case 'voice':
       return (
         <VoiceModelsSettingsPage

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -1,333 +1,89 @@
-/* Unboxed (maintainer 2026-07-18): the outer card chrome wrapped the whole
-   每日回顾 module in a second frame the MCP page never had — the inner surfaces
-   (report bodies, stat tiles, alerts) already carry their own borders, so the
-   wrapper read as a box-in-box. Plain layout container now; padding 0 so
-   content sits flush with the module header like the skills / MCP pages. Width
-   converged 980 -> 900 to track the module header's `min(100%, 900px)` measure.
-
-   IA redesign (2026-07-18): the PageHeader now lives INSIDE the panel (so the
-   生成 actions ride its actions slot with the panel's run state), followed by a
-   single time-scope row, the always-on 概览 section, and the stacked 报告
-   section. The old two-floating-control-rows + broken master-detail layout is
-   gone. */
 .maka-module-main .maka-daily-review-panel {
-    width: min(100%, 900px);
-    margin-inline: auto;
-    padding: 0;
-  }
+  width: min(100%, 900px);
+  margin-inline: auto;
+}
 
 .maka-daily-review-panel {
   min-height: 0;
   overflow: auto;
-  display: grid;
-  align-content: start;
-  gap: var(--space-5);
-  padding: var(--space-4) var(--space-5) var(--space-5);
+  padding: var(--space-4) var(--space-5) var(--space-6);
 }
 
-/* ── PageHeader actions: the 生成 cluster ───────────────────────────────
-   The analysis-model select is a COMPACT generation option that sits with the
-   two 生成 buttons (not a page-wide row). `width="compact"` caps the trigger;
-   this only handles the cluster's flow + wrap. */
-.maka-daily-review-generate {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  /* Single row on desktop: the three run controls stay together and the
-     subtitle column shrinks + wraps beside them (nowrap + flex:none keeps the
-     browser from collapsing the cluster onto a second line while free header
-     width still exists). The ≤820px module breakpoint re-enables wrap once the
-     header stacks into a grid and the cluster owns a full row. */
-  flex-wrap: nowrap;
-  gap: var(--space-2);
-  flex: none;
-}
-
-@media (max-width: 820px) {
-  .maka-daily-review-generate {
-    flex-wrap: wrap;
-    justify-content: flex-start;
-  }
-}
-
-.maka-daily-review-quick-run {
-  white-space: nowrap;
-}
-
-/* ── One time-scope row: range segmented + day stepper as ONE cluster ──── */
-.maka-daily-review-scope {
-  display: flex;
-  align-items: center;
-  /* Range picker + stepper are one time-control cluster on the left — they are
-     both time navigation, so they read as a single group (was two widgets at
-     opposite page corners). */
-  justify-content: flex-start;
-  flex-wrap: wrap;
-  gap: var(--space-3);
-}
-
-.maka-daily-review-range-tabs,
-.maka-daily-review-actions {
-  display: flex;
-  gap: var(--space-1);
+.maka-daily-review-toolbar {
   min-width: 0;
 }
 
-.maka-daily-review-scope-stepper {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-  min-width: 0;
-}
-
-.maka-daily-review-day {
-  font: var(--maka-text-heading-4);
+.maka-daily-review-range-label {
+  min-width: 9rem;
   text-align: center;
   font-variant-numeric: tabular-nums;
-  letter-spacing: var(--tracking-normal);
-  color: var(--foreground);
 }
 
-/* ── 概览 section (always rendered) ─────────────────────────────────────── */
-.maka-daily-review-overview {
+.maka-daily-review-metrics {
   display: grid;
-  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+  border-block: var(--border-width-hairline) solid var(--foreground-10);
 }
 
-/* Export row sits in the 概览 SectionHeader action slot, right-aligned. */
-.maka-daily-review-actions {
-  justify-content: flex-end;
-  flex-wrap: wrap;
+.maka-daily-review-metric {
+  min-width: 0;
+  padding: var(--space-3) var(--space-4);
 }
 
-.maka-daily-review-copy,
-.maka-daily-review-append,
-.maka-daily-review-save {
-  white-space: nowrap;
+.maka-daily-review-metric + .maka-daily-review-metric {
+  border-inline-start: var(--border-width-hairline) solid var(--foreground-10);
 }
 
-.maka-daily-review-totals {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
-    gap: var(--space-1);
-  }
-.maka-module-main .maka-daily-review-totals {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  }
-/* Convergence R4: recipe lives in the StatTile primitive; density override
-   only (tight strip cells). */
-.maka-daily-review-totals-cell {
-    gap: 1px;
-    padding: var(--space-1) var(--space-2);
-  }
-.maka-daily-review-totals-cell[data-tone="destructive"] {
-    border-color: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.35);
-    background: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.06);
+.maka-daily-review-metric[data-tone='error'] {
+  color: var(--destructive, var(--foreground));
+}
+
+.maka-daily-review-report-prose {
+  color: var(--foreground-secondary);
+  overflow-wrap: anywhere;
+}
+
+.maka-daily-review-report-prose p,
+.maka-daily-review-report-prose ul,
+.maka-daily-review-report-prose ol {
+  margin: 0 0 var(--space-2);
+}
+
+.maka-daily-review-report-prose :last-child {
+  margin-bottom: 0;
+}
+
+.maka-daily-review-report-prose ul,
+.maka-daily-review-report-prose ol {
+  padding-inline-start: var(--space-5);
+}
+
+.maka-daily-review-report-prose ul {
+  list-style: disc;
+}
+
+.maka-daily-review-report-prose ol {
+  list-style: decimal;
+}
+
+@media (max-width: 560px) {
+  .maka-daily-review-panel {
+    padding-inline: var(--space-3);
   }
 
-/* Convergence (maintainer 2026-07-18): all section titles render through the
-   SectionHeader primitive (as="h4" accent), so the page shares one
-   section-header language. The wrapper keeps only the between-section divider
-   rhythm; divider token `--foreground-10` matches the module dividers. */
-.maka-daily-review-section {
-    display: grid;
-    gap: var(--space-2);
-    padding: var(--space-3) 0 0;
+  .maka-daily-review-range-label {
+    min-width: 0;
+  }
+
+  .maka-daily-review-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .maka-daily-review-metric:nth-child(odd) {
+    border-inline-start: 0;
+  }
+
+  .maka-daily-review-metric:nth-child(n + 3) {
     border-top: var(--border-width-hairline) solid var(--foreground-10);
   }
-.maka-daily-review-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: var(--space-1);
-  }
-.maka-daily-review-list-item {
-    display: grid;
-    gap: var(--space-0-5);
-    padding: var(--space-1-5) var(--space-2-5);
-    border-radius: var(--radius-surface);
-    background: transparent;
-  }
-
-.maka-daily-review-session-name {
-    font: var(--maka-text-label);
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-.maka-daily-review-session-time {
-    font: var(--maka-text-supporting);
-    color: var(--muted-foreground);
-    white-space: nowrap;
-    font-variant-numeric: tabular-nums;
-  }
-
-.maka-daily-review-session-preview {
-    font: var(--maka-text-body);
-    min-width: 0;
-    color: var(--muted-foreground);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-.maka-daily-review-top-label {
-    font: var(--maka-text-label);
-    color: var(--foreground);
-  }
-
-.maka-daily-review-top-meta {
-    font: var(--maka-text-supporting);
-    color: var(--muted-foreground);
-    font-variant-numeric: tabular-nums;
-  }
-
-.maka-daily-review-loading {
-    display: grid;
-    gap: var(--space-2);
-    padding: var(--space-2) var(--space-1);
-  }
-
-/* Keep the Astryx empty state in flow inside the daily-review panel. */
-.maka-daily-review-panel .maka-daily-review-summary-empty {
-  position: static;
-  left: auto;
-  top: auto;
-  width: 100%;
-  transform: none;
-  min-height: 120px;
-  align-content: center;
-}
-
-/* Convergence (maintainer 2026-07-18): the retry alert re-implemented the
-   warning surface by hand; the `warning` variant already owns border / tint /
-   radius / padding + the description↔action split, so the shared primitive
-   renders it. Only the retry button keeps `flex: none` so it never shrinks. */
-.maka-daily-review-alert-retry {
-  flex: none;
-}
-
-/* ── 报告 section: stacked, newest-first, expand-in-place surfaces ──────── */
-.maka-daily-review-reports {
-    display: grid;
-    gap: var(--space-2-5);
-    padding: var(--space-4) 0 0;
-    border-top: var(--border-width-hairline) solid var(--foreground-10);
-  }
-
-.maka-daily-review-archive-count {
-    font: var(--maka-text-supporting);
-    color: var(--muted-foreground);
-    font-variant-numeric: tabular-nums;
-  }
-
-.maka-daily-review-report-trigger {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: var(--space-2-5);
-    min-width: 0;
-    width: 100%;
-  }
-
-.maka-daily-review-report-heading {
-    display: grid;
-    gap: var(--space-0-5);
-    min-width: 0;
-  }
-
-.maka-daily-review-report-title {
-    font: var(--maka-text-heading-4);
-    min-width: 0;
-    color: var(--foreground);
-    letter-spacing: var(--tracking-normal);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-.maka-daily-review-archive-row-meta {
-    font: var(--maka-text-supporting);
-    min-width: 0;
-    color: var(--muted-foreground);
-    font-variant-numeric: tabular-nums;
-    overflow-wrap: anywhere;
-  }
-
-/* Exception-only status chip (#651): only failed / no_model raise it, so it
-   never shrinks against the report title. */
-.maka-daily-review-report-status {
-    flex: none;
-  }
-
-/* Expanded body: sits under the meta head inside the same surface, separated
-   by a hairline so it reads as the report's continuation, not a nested card. */
-.maka-daily-review-report-body {
-    display: grid;
-    gap: var(--space-2);
-    min-width: 0;
-  }
-
-.maka-daily-review-archive-empty {
-    font: var(--maka-text-body);
-    color: var(--muted-foreground);
-  }
-
-.maka-daily-review-archive-error {
-    font: var(--maka-text-body);
-    margin: 0;
-    color: var(--destructive, var(--foreground));
-  }
-
-.maka-daily-review-archive-sections {
-    display: grid;
-    /* Section rhythm: the four report blocks (对话摘要/遗漏提醒/使用洞察/
-       代码建议) divide with 16px + hairline BETWEEN sections so they don't
-       read as one undifferentiated slab. */
-    gap: var(--space-3);
-  }
-
-.maka-daily-review-archive-section {
-    display: grid;
-    gap: var(--space-1-5);
-  }
-
-.maka-daily-review-archive-section + .maka-daily-review-archive-section {
-    border-top: var(--border-width-hairline) solid var(--foreground-10);
-    padding-top: var(--space-3);
-  }
-
-/* Markdown-rendered report body: restore list markers after the shared reset
-   and keep block rhythm tight. */
-.maka-daily-review-archive-section-body {
-    font: var(--maka-text-body);
-    color: var(--foreground-secondary);
-    overflow-wrap: anywhere;
-  }
-
-.maka-daily-review-archive-section-body p {
-    margin: 0 0 var(--space-1-5);
-  }
-
-.maka-daily-review-archive-section-body p:last-child,
-.maka-daily-review-archive-section-body ul:last-child,
-.maka-daily-review-archive-section-body ol:last-child {
-    margin-bottom: 0;
-  }
-
-.maka-daily-review-archive-section-body ul,
-.maka-daily-review-archive-section-body ol {
-    margin: 0 0 var(--space-1-5);
-    padding-left: var(--space-5);
-  }
-
-.maka-daily-review-archive-section-body ul { list-style: disc; }
-.maka-daily-review-archive-section-body ol { list-style: decimal; }
-.maka-daily-review-inline-empty {
-  font: var(--maka-text-body);
-  margin: 0;
-  color: var(--muted-foreground);
 }

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -9,6 +9,39 @@
   padding: var(--space-4) var(--space-5) var(--space-6);
 }
 
+.maka-daily-review-route-frame {
+  min-width: 0;
+}
+
+.maka-daily-review-report,
+.maka-daily-review-content {
+  min-width: 0;
+  animation: maka-daily-review-enter var(--duration-fast, 175ms)
+    var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1)) both;
+}
+
+.maka-daily-review-content {
+  display: grid;
+  gap: var(--space-5);
+}
+
+@keyframes maka-daily-review-enter {
+  from {
+    opacity: 0.9;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .maka-daily-review-report,
+  .maka-daily-review-content {
+    animation: none;
+  }
+}
+
 .maka-daily-review-toolbar {
   min-width: 0;
 }

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -67,10 +67,6 @@
   border-inline-start: var(--border-width-hairline) solid var(--foreground-10);
 }
 
-.maka-daily-review-metric[data-tone='error'] {
-  color: var(--destructive, var(--foreground));
-}
-
 .maka-daily-review-report-prose {
   color: var(--foreground-secondary);
   overflow-wrap: anywhere;

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -79,30 +79,6 @@
   margin: 0;
 }
 
-/* PR daily-review-bundled (WAWQAQ msg `afbe542d` 2026-06-25 +
-   @kenji audit finding #6): the Daily Review settings page used to
-   stack a banner + intro hero card + settings rows + "try it now"
-   hero card — too much promo chrome for a workbench settings
-   surface. The unified `.settingsPageFooterActions` is a single
-   right-aligned action row that the page renders below the rows
-   (open Daily Review · generate now · deep). Keep the action set
-   visible and uniform regardless of how many ops the page exposes. */
-.settingsPageFooterActions {
-  display: flex;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  margin-top: var(--space-4);
-}
-
-/* PR audit2-bundled (@kenji audit #5 msg `e4cfbfb0`): names for the
-   inline `style={{ marginTop: N }}` patches that were sprinkled around
-   settings surfaces. Keeps the spacing decision discoverable + locked
-   in the design token surface instead of buried in JSX. */
-.settingsSurfaceAlert {
-  margin-top: var(--space-3);
-}
-
 .settingsLoadingSkeleton {
   padding: var(--space-2) 0;
   max-width: 540px;

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -424,8 +424,8 @@
      vertically (column / align-items: flex-end / 6px gap), which read
      as "two separate options" rather than a primary + secondary pair.
      Lay them out horizontally with the primary "请求授权" on the right
-     so the eye-tracking matches `.settingsPageFooterActions` and the
-     reference Settings rows elsewhere. The two buttons share size="sm"
+     so the eye-tracking matches the reference Settings rows elsewhere.
+     The two buttons share size="sm"
      so the row height stays flush; the secondary "前往系统设置" uses
      `variant="ghost"` (less competing chrome) so the primary visibly
      anchors the row. */

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -525,7 +525,7 @@ export const ScheduledDailyReview: Story = {
     week.click();
     const earlier = await waitForStoryButton(
       canvasElement,
-      (candidate) => candidate.getAttribute('aria-label')?.includes('前一天') === true,
+      (candidate) => candidate.getAttribute('aria-label') === '查看更早一天',
     );
     earlier.click();
     await waitForStoryText(canvasElement, '最近 7 天（往前 1 天）');

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -511,6 +511,13 @@ export const ScheduledDailyReview: Story = {
       }}
     />
   ),
+  play: async ({ canvasElement }) => {
+    const overview = await waitForStorySelector<HTMLElement>(
+      canvasElement,
+      '[aria-label="今天概览"]',
+    );
+    await expect(overview.textContent).not.toContain('错误');
+  },
 };
 
 // Real path: sidebar → scheduled tasks → Daily Review while saved reports load.

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -494,12 +494,14 @@ export const ScheduledDailyReview: Story = {
 
 // Real path at a narrow desktop window. The metrics collapse to two columns
 // while the Astryx controls keep their native wrapping behavior.
+// Real path: sidebar → scheduled tasks → Daily Review at a narrow window.
 export const ScheduledDailyReviewNarrow: Story = {
   ...ScheduledDailyReview,
   parameters: { viewport: { defaultViewport: 'mobile2' } },
 };
 
 // Real path after an analysis exists and the user opens its dedicated detail route.
+// Real path: sidebar → scheduled tasks → Daily Review → view analysis.
 export const ScheduledDailyReviewReport: Story = {
   render: () => (
     <ScheduledDailyReviewSurface

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -12,7 +12,7 @@ import {
   ToastProvider,
   useUiLocale,
 } from '@maka/ui';
-import type { ComponentProps, ReactNode } from 'react';
+import { type ComponentProps, type ReactNode, useState } from 'react';
 import { AppShellWorkspaceTopActions } from '../src/renderer/app-shell-chrome-actions';
 import { AppShellDetailPanel } from '../src/renderer/app-shell-detail-panel';
 import { McpPage } from '../src/renderer/mcp-page';
@@ -413,7 +413,12 @@ function ScheduledPlanRemindersSurface(props: { reminders?: PlanReminder[] }) {
   );
 }
 
-function ScheduledDailyReviewSurface(props: { bridge: DailyReviewBridge }) {
+function ScheduledDailyReviewSurface(
+  props: { bridge: DailyReviewBridge } & Pick<
+    ComponentProps<typeof DailyReviewPage>,
+    'onCopyMarkdown' | 'onAppendMarkdown' | 'onSaveMarkdown'
+  >,
+) {
   const copy = getSharedUiCopy(useUiLocale()).moduleHubs.automations;
   return (
     <ModuleSurface agentsView="daily-review">
@@ -424,6 +429,9 @@ function ScheduledDailyReviewSurface(props: { bridge: DailyReviewBridge }) {
           badge: <ModuleHubSelector hub="automations" value="daily-review" onChange={() => {}} />,
         }}
         bridge={props.bridge}
+        onCopyMarkdown={props.onCopyMarkdown}
+        onAppendMarkdown={props.onAppendMarkdown}
+        onSaveMarkdown={props.onSaveMarkdown}
       />
     </ModuleSurface>
   );
@@ -642,30 +650,69 @@ export const ScheduledDailyReviewNarrow: Story = {
 // Real path after an analysis exists and the user opens its dedicated detail route.
 // Real path: sidebar → scheduled tasks → Daily Review → view analysis.
 export const ScheduledDailyReviewReport: Story = {
-  render: () => (
-    <ScheduledDailyReviewSurface
-      bridge={{
-        fetchDay: async () => DAILY_REVIEW_SUMMARY,
-        listArchives: async () => [{
-          id: DAILY_REVIEW_ARCHIVE.id,
-          day: DAILY_REVIEW_ARCHIVE.day,
-          range: DAILY_REVIEW_ARCHIVE.range,
-          status: DAILY_REVIEW_ARCHIVE.status,
-          generatedAt: DAILY_REVIEW_ARCHIVE.generatedAt,
-          trigger: DAILY_REVIEW_ARCHIVE.trigger,
-          modelKey: DAILY_REVIEW_ARCHIVE.modelKey,
-          totals: DAILY_REVIEW_ARCHIVE.totals,
-        }],
-        getArchive: async () => DAILY_REVIEW_ARCHIVE,
-      }}
-    />
-  ),
+  render: function Render() {
+    const [savedInput, setSavedInput] = useState<unknown>(null);
+    const staleSummary = {
+      ...DAILY_REVIEW_SUMMARY,
+      day: {
+        fromMs: DAILY_REVIEW_SUMMARY.day.fromMs - 86_400_000,
+        toMs: DAILY_REVIEW_SUMMARY.day.toMs - 86_400_000,
+      },
+      totals: { ...DAILY_REVIEW_SUMMARY.totals, requestCount: 999 },
+    };
+    return (
+      <>
+        <ScheduledDailyReviewSurface
+          bridge={{
+            fetchDay: async (_offsetDays, range) => range === 1 ? DAILY_REVIEW_SUMMARY : staleSummary,
+            listArchives: async () => [{
+              id: DAILY_REVIEW_ARCHIVE.id,
+              day: DAILY_REVIEW_ARCHIVE.day,
+              range: DAILY_REVIEW_ARCHIVE.range,
+              status: DAILY_REVIEW_ARCHIVE.status,
+              generatedAt: DAILY_REVIEW_ARCHIVE.generatedAt,
+              trigger: DAILY_REVIEW_ARCHIVE.trigger,
+              modelKey: DAILY_REVIEW_ARCHIVE.modelKey,
+              totals: DAILY_REVIEW_ARCHIVE.totals,
+            }],
+            getArchive: async () => {
+              await new Promise((resolve) => globalThis.setTimeout(resolve, 100));
+              return DAILY_REVIEW_ARCHIVE;
+            },
+          }}
+          onSaveMarkdown={(input) => setSavedInput(input)}
+        />
+        <output data-testid="daily-review-saved-input" hidden>
+          {savedInput ? JSON.stringify(savedInput) : ''}
+        </output>
+      </>
+    );
+  },
   play: async ({ canvasElement }) => {
-    const button = await waitForStoryButton(
+    const view = await waitForStoryButton(
       canvasElement,
       (candidate) => candidate.textContent?.includes('查看分析') === true,
     );
-    button.click();
+    view.click();
+    const recent7Days = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.includes('最近 7 天') === true,
+    );
+    recent7Days.click();
+    await waitForStoryText(canvasElement, '返回活动');
+    const save = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.trim() === '保存',
+    );
+    save.click();
+    const output = await waitForStorySelector<HTMLOutputElement>(
+      canvasElement,
+      '[data-testid="daily-review-saved-input"]',
+    );
+    await waitForStoryText(output, 'markdown');
+    const input = JSON.parse(output.textContent ?? '') as Record<string, unknown>;
+    await expect(input.day).toEqual(DAILY_REVIEW_ARCHIVE.day);
+    await expect(input.totals).toEqual(DAILY_REVIEW_ARCHIVE.totals);
   },
 };
 

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 import type { DailyReviewArchive, DailyReviewSummary, PlanReminder } from '@maka/core';
 import type { McpConfigFile, McpServerStatus } from '@maka/core/mcp';
 import {
@@ -440,6 +441,26 @@ async function waitForStoryButton(
   throw new Error('Story action button did not render');
 }
 
+async function waitForStorySelector<T extends Element>(
+  canvasElement: HTMLElement,
+  selector: string,
+): Promise<T> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const element = canvasElement.querySelector<T>(selector);
+    if (element) return element;
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
+  }
+  throw new Error(`Story selector did not render: ${selector}`);
+}
+
+async function waitForStoryText(canvasElement: HTMLElement, text: string): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (canvasElement.textContent?.includes(text)) return;
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
+  }
+  throw new Error(`Story text did not render: ${text}`);
+}
+
 // Real path: sidebar → 扩展 → 技能, with several installed skills.
 export const ExtensionsSkillsInstalled: Story = {
   render: () => <ExtensionsSkillsSurface skills={INSTALLED_SKILLS} />,
@@ -492,6 +513,53 @@ export const ScheduledDailyReview: Story = {
   ),
 };
 
+// Real path: sidebar → scheduled tasks → Daily Review while saved reports load.
+export const ScheduledDailyReviewArchivesLoading: Story = {
+  render: () => (
+    <ScheduledDailyReviewSurface
+      bridge={{
+        fetchDay: async () => DAILY_REVIEW_SUMMARY,
+        listArchives: async () => new Promise(() => undefined),
+        runOnce: async () => ({ archiveId: DAILY_REVIEW_ARCHIVE.id }),
+        getArchive: async () => DAILY_REVIEW_ARCHIVE,
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForStorySelector(canvasElement, '.maka-daily-review-content');
+    const generate = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.includes('生成分析') === true,
+    );
+    await expect(generate.disabled).toBe(true);
+  },
+};
+
+// Real path: sidebar → scheduled tasks → Daily Review after saved reports fail to load.
+export const ScheduledDailyReviewArchivesFailed: Story = {
+  render: () => (
+    <ScheduledDailyReviewSurface
+      bridge={{
+        fetchDay: async () => DAILY_REVIEW_SUMMARY,
+        listArchives: async () => {
+          throw new Error('archive fixture unavailable');
+        },
+        runOnce: async () => ({ archiveId: DAILY_REVIEW_ARCHIVE.id }),
+        getArchive: async () => DAILY_REVIEW_ARCHIVE,
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForStorySelector(canvasElement, '.maka-daily-review-content');
+    await waitForStoryText(canvasElement, '每日回顾刷新失败');
+    const generate = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.includes('生成分析') === true,
+    );
+    await expect(generate.disabled).toBe(true);
+  },
+};
+
 // Real path: sidebar → scheduled tasks → Daily Review while a new range loads.
 export const ScheduledDailyReviewRefreshing: Story = {
   render: () => (
@@ -510,9 +578,16 @@ export const ScheduledDailyReviewRefreshing: Story = {
   play: async ({ canvasElement }) => {
     const button = await waitForStoryButton(
       canvasElement,
-      (candidate) => candidate.textContent?.includes('本周') === true,
+      (candidate) => candidate.textContent?.includes('最近 7 天') === true,
     );
     button.click();
+    const content = await waitForStorySelector<HTMLElement>(
+      canvasElement,
+      '.maka-daily-review-content',
+    );
+    await expect(button.getAttribute('aria-checked')).toBe('true');
+    await expect(content.getAttribute('aria-busy')).toBe('true');
+    await expect(canvasElement.querySelector('.astryx-skeleton')).toBeNull();
   },
 };
 

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -517,6 +517,39 @@ export const ScheduledDailyReview: Story = {
       '[aria-label="今天概览"]',
     );
     await expect(overview.textContent).not.toContain('错误');
+
+    const week = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.includes('最近 7 天') === true,
+    );
+    week.click();
+    const earlier = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.getAttribute('aria-label')?.includes('前一天') === true,
+    );
+    earlier.click();
+    await waitForStoryText(canvasElement, '最近 7 天（往前 1 天）');
+  },
+};
+
+// Real path: sidebar → scheduled tasks → Daily Review after the initial activity request fails.
+export const ScheduledDailyReviewInitialLoadFailed: Story = {
+  render: () => (
+    <ScheduledDailyReviewSurface
+      bridge={{
+        fetchDay: async () => {
+          throw new Error('activity fixture unavailable');
+        },
+        listArchives: async () => [],
+        runOnce: async () => ({ archiveId: DAILY_REVIEW_ARCHIVE.id }),
+        getArchive: async () => DAILY_REVIEW_ARCHIVE,
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForStoryText(canvasElement, '每日回顾刷新失败');
+    await expect(canvasElement.querySelector('[aria-busy="true"]')).toBeNull();
+    await expect(canvasElement.querySelector('.astryx-skeleton')).toBeNull();
   },
 };
 

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -5,6 +5,8 @@ import type { McpConfigFile, McpServerStatus } from '@maka/core/mcp';
 import {
   AutomationsPage,
   DailyReviewPage,
+  formatDailyReviewArchiveTitle,
+  getDailyReviewCopy,
   getSharedUiCopy,
   ModuleHubSelector,
   SkillsPage,
@@ -712,7 +714,18 @@ export const ScheduledDailyReviewReport: Story = {
     await waitForStoryText(output, 'markdown');
     const input = JSON.parse(output.textContent ?? '') as Record<string, unknown>;
     await expect(input.day).toEqual(DAILY_REVIEW_ARCHIVE.day);
+    await expect(input.range).toBe(DAILY_REVIEW_ARCHIVE.range);
     await expect(input.totals).toEqual(DAILY_REVIEW_ARCHIVE.totals);
+    const archiveCopy = getDailyReviewCopy('zh');
+    const expectedMarkdown = [
+      `# ${formatDailyReviewArchiveTitle(DAILY_REVIEW_ARCHIVE, 'zh')}`,
+      ...(['summary', 'gaps', 'usage', 'code'] as const).flatMap((key) => [
+        '',
+        `## ${archiveCopy.archive.section[key]}`,
+        DAILY_REVIEW_ARCHIVE.sections[key],
+      ]),
+    ].join('\n');
+    await expect(input.markdown).toBe(expectedMarkdown);
   },
 };
 

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -668,3 +668,32 @@ export const ScheduledDailyReviewReport: Story = {
     button.click();
   },
 };
+
+// Real path: sidebar → scheduled tasks → Daily Review after a recoverable generation failure.
+export const ScheduledDailyReviewRetryableArchive: Story = {
+  render: () => {
+    const retryableArchive = {
+      ...DAILY_REVIEW_ARCHIVE,
+      status: 'failed' as const,
+      errorMessage: 'temporary fixture failure',
+    };
+    return (
+      <ScheduledDailyReviewSurface
+        bridge={{
+          fetchDay: async () => DAILY_REVIEW_SUMMARY,
+          listArchives: async () => [retryableArchive],
+          runOnce: async () => ({ archiveId: DAILY_REVIEW_ARCHIVE.id }),
+          getArchive: async () => DAILY_REVIEW_ARCHIVE,
+        }}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const retry = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.includes('重新生成') === true,
+    );
+    retry.click();
+    await waitForStoryText(canvasElement, '返回活动');
+  },
+};

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -492,6 +492,30 @@ export const ScheduledDailyReview: Story = {
   ),
 };
 
+// Real path: sidebar → scheduled tasks → Daily Review while a new range loads.
+export const ScheduledDailyReviewRefreshing: Story = {
+  render: () => (
+    <ScheduledDailyReviewSurface
+      bridge={{
+        fetchDay: async (_offsetDays, range) => {
+          if (range === 1) return DAILY_REVIEW_SUMMARY;
+          return new Promise<DailyReviewSummary>(() => undefined);
+        },
+        listArchives: async () => [],
+        runOnce: async () => ({ archiveId: DAILY_REVIEW_ARCHIVE.id }),
+        getArchive: async () => DAILY_REVIEW_ARCHIVE,
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const button = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.includes('本周') === true,
+    );
+    button.click();
+  },
+};
+
 // Real path at a narrow desktop window. The metrics collapse to two columns
 // while the Astryx controls keep their native wrapping behavior.
 // Real path: sidebar → scheduled tasks → Daily Review at a narrow window.

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { DailyReviewSummary, PlanReminder } from '@maka/core';
+import type { DailyReviewArchive, DailyReviewSummary, PlanReminder } from '@maka/core';
 import type { McpConfigFile, McpServerStatus } from '@maka/core/mcp';
 import {
   AutomationsPage,
@@ -244,6 +244,23 @@ const DAILY_REVIEW_SUMMARY: DailyReviewSummary = {
   ],
 };
 
+const DAILY_REVIEW_ARCHIVE: DailyReviewArchive = {
+  id: '2026-07-01-1d',
+  day: DAILY_REVIEW_SUMMARY.day,
+  range: 1,
+  status: 'ok',
+  generatedAt: NOW - 5 * 60_000,
+  trigger: 'manual',
+  modelKey: 'openai::gpt-5',
+  totals: DAILY_REVIEW_SUMMARY.totals,
+  sections: {
+    summary: '今天聚焦 Daily Review 的信息架构和页面重构，完成了时间范围、活动概览与报告详情的职责拆分。',
+    gaps: '报告导出仍需在真实桌面环境验证文件保存路径。',
+    usage: '共完成 42 次模型请求，主要活动集中在六个对话中。',
+    code: '继续让设置页只承载持久配置，把即时动作留在功能主页面。',
+  },
+};
+
 type DailyReviewBridge = NonNullable<ComponentProps<typeof DailyReviewPage>['bridge']>;
 
 const configuredMcpConfig: McpConfigFile = {
@@ -411,6 +428,18 @@ function ScheduledDailyReviewSurface(props: { bridge: DailyReviewBridge }) {
   );
 }
 
+async function waitForStoryButton(
+  canvasElement: HTMLElement,
+  predicate: (button: HTMLButtonElement) => boolean,
+): Promise<HTMLButtonElement> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const button = Array.from(canvasElement.querySelectorAll<HTMLButtonElement>('button')).find(predicate);
+    if (button) return button;
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
+  }
+  throw new Error('Story action button did not render');
+}
+
 // Real path: sidebar → 扩展 → 技能, with several installed skills.
 export const ExtensionsSkillsInstalled: Story = {
   render: () => <ExtensionsSkillsSurface skills={INSTALLED_SKILLS} />,
@@ -453,8 +482,48 @@ export const ScheduledPlanRemindersLongContent: Story = {
 export const ScheduledDailyReview: Story = {
   render: () => (
     <ScheduledDailyReviewSurface
-      bridge={{ fetchDay: async () => DAILY_REVIEW_SUMMARY }}
+      bridge={{
+        fetchDay: async () => DAILY_REVIEW_SUMMARY,
+        listArchives: async () => [],
+        runOnce: async () => ({ archiveId: DAILY_REVIEW_ARCHIVE.id }),
+        getArchive: async () => DAILY_REVIEW_ARCHIVE,
+      }}
     />
   ),
 };
 
+// Real path at a narrow desktop window. The metrics collapse to two columns
+// while the Astryx controls keep their native wrapping behavior.
+export const ScheduledDailyReviewNarrow: Story = {
+  ...ScheduledDailyReview,
+  parameters: { viewport: { defaultViewport: 'mobile2' } },
+};
+
+// Real path after an analysis exists and the user opens its dedicated detail route.
+export const ScheduledDailyReviewReport: Story = {
+  render: () => (
+    <ScheduledDailyReviewSurface
+      bridge={{
+        fetchDay: async () => DAILY_REVIEW_SUMMARY,
+        listArchives: async () => [{
+          id: DAILY_REVIEW_ARCHIVE.id,
+          day: DAILY_REVIEW_ARCHIVE.day,
+          range: DAILY_REVIEW_ARCHIVE.range,
+          status: DAILY_REVIEW_ARCHIVE.status,
+          generatedAt: DAILY_REVIEW_ARCHIVE.generatedAt,
+          trigger: DAILY_REVIEW_ARCHIVE.trigger,
+          modelKey: DAILY_REVIEW_ARCHIVE.modelKey,
+          totals: DAILY_REVIEW_ARCHIVE.totals,
+        }],
+        getArchive: async () => DAILY_REVIEW_ARCHIVE,
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const button = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.includes('查看分析') === true,
+    );
+    button.click();
+  },
+};

--- a/apps/desktop/stories/product-smoke-manifest.json
+++ b/apps/desktop/stories/product-smoke-manifest.json
@@ -80,6 +80,17 @@
       "viewports": ["wide", "compact", "floor"],
       "colorSchemes": ["light", "dark"]
     },
+    "dailyReviewSettingsBounds": {
+      "storyId": "product-settings-pages--daily-review-model-selector-open-narrow",
+      "productionHost": "SettingsSurface > DailyReviewSettingsPage",
+      "state": "Time input and open analysis-model selector at the minimum window width",
+      "viewports": ["floor"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "wide": "The floor contract is the stricter horizontal-containment case.",
+        "compact": "The floor contract is the stricter horizontal-containment case."
+      }
+    },
     "sessionContext": {
       "storyId": "product-shell-official-appshell--session-context-layer",
       "productionHost": "AppShell > ChatView",

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -795,7 +795,9 @@ async function openDailyReviewModelSelector(canvasElement: HTMLElement): Promise
   );
   selector.click();
   await waitForStoryCondition(
-    () => document.querySelector<HTMLElement>('[role="listbox"]')?.offsetParent !== null,
+    () => document.querySelector<HTMLElement>('[role="listbox"]')
+      ?.closest<HTMLElement>('[popover]')
+      ?.matches(':popover-open') === true,
     'Daily Review model selector did not open',
   );
   return selector;
@@ -827,6 +829,8 @@ function assertDailyReviewSettingsBounds(
   const valid =
     withinHorizontally(timeRect, timeForm.getBoundingClientRect())
     && withinHorizontally(selectorRect, selectorForm.getBoundingClientRect())
+    && popoverRect.width > 0
+    && popoverRect.height > 0
     && withinHorizontally(popoverRect, pageRect)
     && popoverRect.left >= -1
     && popoverRect.right <= window.innerWidth + 1

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -788,6 +788,54 @@ async function waitForStoryCondition(predicate: () => boolean, errorMessage: str
   throw new Error(errorMessage);
 }
 
+async function openDailyReviewModelSelector(canvasElement: HTMLElement): Promise<HTMLButtonElement> {
+  const selector = await waitForStoryButton(
+    canvasElement,
+    (candidate) => candidate.textContent?.includes('跟随对话默认') === true,
+  );
+  selector.click();
+  await waitForStoryCondition(
+    () => document.querySelector<HTMLElement>('[role="listbox"]')?.offsetParent !== null,
+    'Daily Review model selector did not open',
+  );
+  return selector;
+}
+
+function assertDailyReviewSettingsBounds(
+  canvasElement: HTMLElement,
+  selector: HTMLButtonElement,
+): void {
+  const time = canvasElement.querySelector<HTMLInputElement>('input[type="text"]');
+  const page = canvasElement.querySelector<HTMLElement>('.settingsFormPage');
+  const timeForm = time?.closest<HTMLElement>('.settingsFormLayout');
+  const selectorForm = selector.closest<HTMLElement>('.settingsFormLayout');
+  const listbox = document.querySelector<HTMLElement>('[role="listbox"]');
+  const popover = listbox?.closest<HTMLElement>('[popover]');
+  if (!time || !page || !timeForm || !selectorForm || !popover) {
+    throw new Error('Daily Review bounds contract could not resolve its production elements');
+  }
+
+  const withinHorizontally = (inner: DOMRect, outer: DOMRect) =>
+    inner.left >= outer.left - 1 && inner.right <= outer.right + 1;
+  const timeRect = time.getBoundingClientRect();
+  const selectorRect = selector.getBoundingClientRect();
+  const popoverRect = popover.getBoundingClientRect();
+  const pageRect = page.getBoundingClientRect();
+  const doesNotCoverTrigger =
+    popoverRect.top >= selectorRect.bottom - 1
+    || popoverRect.bottom <= selectorRect.top + 1;
+  const valid =
+    withinHorizontally(timeRect, timeForm.getBoundingClientRect())
+    && withinHorizontally(selectorRect, selectorForm.getBoundingClientRect())
+    && withinHorizontally(popoverRect, pageRect)
+    && popoverRect.left >= -1
+    && popoverRect.right <= window.innerWidth + 1
+    && doesNotCoverTrigger;
+  if (!valid) {
+    throw new Error(`Daily Review controls overflow at ${window.innerWidth}px`);
+  }
+}
+
 // Real path: sidebar footer 设置 → 模型.
 export const Models: Story = {
   decorators: [withSettingsBridge],
@@ -890,11 +938,18 @@ export const DailyReviewModelSelectorOpen: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="daily-review" />,
   play: async ({ canvasElement }) => {
-    const selector = await waitForStoryButton(
-      canvasElement,
-      (candidate) => candidate.textContent?.includes('跟随对话默认') === true,
-    );
-    selector.click();
+    await openDailyReviewModelSelector(canvasElement);
+  },
+};
+
+// Real path: Settings → Daily Review → Analysis model at the minimum window width.
+export const DailyReviewModelSelectorOpenNarrow: Story = {
+  decorators: [withSettingsBridge],
+  parameters: { viewport: { defaultViewport: 'mobile2' } },
+  render: () => <SettingsStory section="daily-review" />,
+  play: async ({ canvasElement }) => {
+    const selector = await openDailyReviewModelSelector(canvasElement);
+    assertDailyReviewSettingsBounds(canvasElement, selector);
   },
 };
 // Real path: 设置 → 数据.

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -876,6 +876,25 @@ export const DailyReview: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="daily-review" />,
 };
+
+// Real path at a narrow desktop window.
+export const DailyReviewNarrow: Story = {
+  ...DailyReview,
+  parameters: { viewport: { defaultViewport: 'mobile2' } },
+};
+
+// Real path with the Astryx model selector expanded.
+export const DailyReviewModelSelectorOpen: Story = {
+  decorators: [withSettingsBridge],
+  render: () => <SettingsStory section="daily-review" />,
+  play: async ({ canvasElement }) => {
+    const selector = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.includes('跟随对话默认') === true,
+    );
+    selector.click();
+  },
+};
 // Real path: 设置 → 数据.
 export const Data: Story = {
   decorators: [withSettingsBridge],

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -878,12 +878,14 @@ export const DailyReview: Story = {
 };
 
 // Real path at a narrow desktop window.
+// Real path: Settings → Daily Review at a narrow window.
 export const DailyReviewNarrow: Story = {
   ...DailyReview,
   parameters: { viewport: { defaultViewport: 'mobile2' } },
 };
 
 // Real path with the Astryx model selector expanded.
+// Real path: Settings → Daily Review → Analysis model.
 export const DailyReviewModelSelectorOpen: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="daily-review" />,

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { userEvent } from 'storybook/test';
 import { ToastProvider } from '@maka/ui';
 import type {
   AppSettings,
@@ -793,11 +794,9 @@ async function openDailyReviewModelSelector(canvasElement: HTMLElement): Promise
     canvasElement,
     (candidate) => candidate.textContent?.includes('跟随对话默认') === true,
   );
-  selector.click();
+  await userEvent.click(selector);
   await waitForStoryCondition(
-    () => document.querySelector<HTMLElement>('[role="listbox"]')
-      ?.closest<HTMLElement>('[popover]')
-      ?.matches(':popover-open') === true,
+    () => selector.getAttribute('aria-expanded') === 'true',
     'Daily Review model selector did not open',
   );
   return selector;

--- a/packages/core/src/__tests__/daily-review.test.ts
+++ b/packages/core/src/__tests__/daily-review.test.ts
@@ -255,11 +255,22 @@ describe('Daily Review range contract', () => {
       { ...valid, modelKey: 42 },
       { ...valid, sections: { summary: 42 } },
       { ...valid, totals: { requestCount: 2 } },
+      { ...valid, range: 7 },
+      { ...valid, id: '2026-02-30-1d' },
     ];
 
     for (const archive of invalid) {
       assert.throws(() => normalizeDailyReviewArchive(archive));
     }
+
+    const { range: _range, ...legacy } = valid;
+    assert.throws(() =>
+      normalizeDailyReviewArchive({
+        ...legacy,
+        id: '2026-08-03-daily',
+        mode: 'deep',
+      }),
+    );
   });
 
   it('keeps only the three settings that control real behavior', () => {

--- a/packages/core/src/__tests__/daily-review.test.ts
+++ b/packages/core/src/__tests__/daily-review.test.ts
@@ -4,7 +4,10 @@ import { describe, it } from 'node:test';
 import {
   DAILY_REVIEW_LIST_LIMIT,
   buildDailyReviewSummary,
+  dailyReviewArchiveId,
   dailyUsageQuery,
+  normalizeDailyReviewArchive,
+  normalizeDailyReviewConfig,
   localDayBoundsAt,
   localDayBoundsForInstant,
   pickDailyReviewSessions,
@@ -187,5 +190,61 @@ describe('DAILY_REVIEW_LIST_LIMIT', () => {
     assert.ok(Number.isInteger(DAILY_REVIEW_LIST_LIMIT));
     assert.ok(DAILY_REVIEW_LIST_LIMIT > 0);
     assert.ok(DAILY_REVIEW_LIST_LIMIT <= 32);
+  });
+});
+
+describe('Daily Review range contract', () => {
+  const day = {
+    fromMs: new Date(2026, 7, 3, 0, 0, 0, 0).getTime(),
+    toMs: new Date(2026, 7, 4, 0, 0, 0, 0).getTime(),
+  };
+
+  it('writes one archive identity for each supported range', () => {
+    assert.equal(dailyReviewArchiveId(day, 1), '2026-08-03-1d');
+    assert.equal(dailyReviewArchiveId(day, 7), '2026-08-03-7d');
+    assert.equal(dailyReviewArchiveId(day, 30), '2026-08-03-30d');
+  });
+
+  it('maps legacy modes onto the range contract when reading', () => {
+    const legacy = normalizeDailyReviewArchive({
+      id: '2026-08-03-deep',
+      day,
+      mode: 'deep',
+      status: 'ok',
+      generatedAt: day.toMs,
+      trigger: 'manual',
+      modelKey: '',
+      sections: { summary: 'Seven days' },
+      totals: {
+        sessionCount: 1,
+        requestCount: 2,
+        totalTokens: 3,
+        costUsd: 0.04,
+        errorCount: 0,
+      },
+    });
+
+    assert.equal(legacy.range, 7);
+    assert.equal(legacy.id, '2026-08-03-deep');
+    assert.equal(legacy.sections.summary, 'Seven days');
+  });
+
+  it('keeps only the three settings that control real behavior', () => {
+    assert.deepEqual(
+      normalizeDailyReviewConfig({
+        enabled: true,
+        executeTime: '09:30',
+        modelKey: 'openai::gpt-5',
+        sections: { summary: false, gaps: false, usage: false, code: false },
+        deepEnabled: true,
+        includeClaudeCode: true,
+        externalNotify: { enabled: true, channelId: 'unused' },
+      }),
+      {
+        enabled: true,
+        executeTime: '09:30',
+        modelKey: 'openai::gpt-5',
+      },
+    );
   });
 });

--- a/packages/core/src/__tests__/daily-review.test.ts
+++ b/packages/core/src/__tests__/daily-review.test.ts
@@ -229,6 +229,39 @@ describe('Daily Review range contract', () => {
     assert.equal(legacy.sections.summary, 'Seven days');
   });
 
+  it('rejects structurally invalid canonical archives', () => {
+    const valid = {
+      id: '2026-08-03-1d',
+      day,
+      range: 1,
+      status: 'ok',
+      generatedAt: day.toMs,
+      trigger: 'manual',
+      modelKey: '',
+      sections: { summary: 'Today' },
+      totals: {
+        sessionCount: 1,
+        requestCount: 2,
+        totalTokens: 3,
+        costUsd: 0.04,
+        errorCount: 0,
+      },
+    };
+    const invalid = [
+      { ...valid, day: undefined },
+      { ...valid, status: 'unknown' },
+      { ...valid, generatedAt: Number.NaN },
+      { ...valid, trigger: 'unknown' },
+      { ...valid, modelKey: 42 },
+      { ...valid, sections: { summary: 42 } },
+      { ...valid, totals: { requestCount: 2 } },
+    ];
+
+    for (const archive of invalid) {
+      assert.throws(() => normalizeDailyReviewArchive(archive));
+    }
+  });
+
   it('keeps only the three settings that control real behavior', () => {
     assert.deepEqual(
       normalizeDailyReviewConfig({

--- a/packages/core/src/__tests__/daily-review.test.ts
+++ b/packages/core/src/__tests__/daily-review.test.ts
@@ -254,6 +254,8 @@ describe('Daily Review range contract', () => {
       { ...valid, trigger: 'unknown' },
       { ...valid, modelKey: 42 },
       { ...valid, sections: { summary: 42 } },
+      { ...valid, sections: {} },
+      { ...valid, sections: { summary: '   ' } },
       { ...valid, totals: { requestCount: 2 } },
       { ...valid, range: 7 },
       { ...valid, id: '2026-02-30-1d' },
@@ -269,6 +271,14 @@ describe('Daily Review range contract', () => {
         ...legacy,
         id: '2026-08-03-daily',
         mode: 'deep',
+      }),
+    );
+    assert.throws(() =>
+      normalizeDailyReviewArchive({
+        ...legacy,
+        id: '2026-08-03-deep',
+        mode: 'deep',
+        sections: {},
       }),
     );
   });

--- a/packages/core/src/daily-review.ts
+++ b/packages/core/src/daily-review.ts
@@ -183,25 +183,14 @@ export function dailyUsageQuery(day: DayRangeMs): UsageQuery {
   return { range: { from: day.fromMs, to: day.toMs } };
 }
 
-/** Default cap for "today's sessions" / "top tools" / "top models" lists. */
+/** Default cap for activity sessions and generated report evidence. */
 export const DAILY_REVIEW_LIST_LIMIT = 8;
 
 /**
  * PR-DAILY-REVIEW-FULL-0 — config + archive contract.
  *
- * Adds the missing pieces on top of MVP-0: a scheduled run, LLM-
- * generated narrative sections, a persisted archive of past reports,
- * and a 深度分析 (deep-analysis) mode. The locked interface is
- * documented in the project thread; this file is the single source
- * of truth used by core, main, preload, and renderer.
- *
- * borrow: external reference's "every morning auto-summary" + Settings
- * sub-toggles for content categories (对话摘要 / 遗漏提醒 / 使用洞察 /
- * 代码建议).
- *
- * diverge: archive lives on disk as plain JSON files in the workspace
- * (no DB), no cloud sync, manual + cron run the same pipeline, model
- * selection reuses the existing connection picker.
+ * One range contract shared by core, main, preload, and renderer. Archives
+ * remain local JSON files; manual and scheduled runs use the same pipeline.
  */
 
 export type DailyReviewRange = 1 | 7 | 30;

--- a/packages/core/src/daily-review.ts
+++ b/packages/core/src/daily-review.ts
@@ -343,12 +343,16 @@ export function normalizeDailyReviewArchive(input: unknown): DailyReviewArchive 
   if (!DAILY_REVIEW_ARCHIVE_STATUSES.includes(input.status as DailyReviewArchiveStatus)) {
     throw invalidDailyReviewArchive('status');
   }
+  const status = input.status as DailyReviewArchiveStatus;
   if (!isFiniteNumber(input.generatedAt)) throw invalidDailyReviewArchive('generatedAt');
   if (input.trigger !== 'cron' && input.trigger !== 'manual') {
     throw invalidDailyReviewArchive('trigger');
   }
   if (typeof input.modelKey !== 'string') throw invalidDailyReviewArchive('modelKey');
   const sections = normalizeDailyReviewArchiveSections(input.sections);
+  if (status === 'ok' && !Object.values(sections).some((content) => content.trim().length > 0)) {
+    throw invalidDailyReviewArchive('sections');
+  }
   const totals = normalizeDailyReviewArchiveTotals(input.totals);
   if (input.errorMessage !== undefined && typeof input.errorMessage !== 'string') {
     throw invalidDailyReviewArchive('errorMessage');
@@ -358,7 +362,7 @@ export function normalizeDailyReviewArchive(input: unknown): DailyReviewArchive 
     id: input.id,
     day,
     range,
-    status: input.status as DailyReviewArchiveStatus,
+    status,
     generatedAt: input.generatedAt,
     trigger: input.trigger,
     modelKey: input.modelKey,

--- a/packages/core/src/daily-review.ts
+++ b/packages/core/src/daily-review.ts
@@ -307,32 +307,103 @@ export function dailyReviewArchiveId(day: DayRangeMs, range: DailyReviewRange): 
   return `${yyyy}-${mm}-${dd}-${range}d`;
 }
 
-type LegacyDailyReviewArchive = Omit<DailyReviewArchive, 'range'> & {
-  readonly mode: 'daily' | 'deep';
-};
-
 /** Maps the retired daily/deep read format onto the one range contract. */
-export function normalizeDailyReviewArchive(
-  archive: DailyReviewArchive | LegacyDailyReviewArchive,
-): DailyReviewArchive {
-  if ('range' in archive) {
-    if (!DAILY_REVIEW_RANGES.includes(archive.range)) {
-      throw new Error(`Invalid Daily Review range: ${String(archive.range)}`);
+export function normalizeDailyReviewArchive(input: unknown): DailyReviewArchive {
+  if (!isRecord(input)) throw invalidDailyReviewArchive('record');
+  let range: DailyReviewRange;
+  if ('range' in input) {
+    if (!DAILY_REVIEW_RANGES.includes(input.range as DailyReviewRange)) {
+      throw invalidDailyReviewArchive('range');
     }
-    return archive;
+    range = input.range as DailyReviewRange;
+  } else if (input.mode === 'daily' || input.mode === 'deep') {
+    range = input.mode === 'deep' ? 7 : 1;
+  } else {
+    throw invalidDailyReviewArchive('range');
+  }
+
+  if (typeof input.id !== 'string' || input.id.length === 0) {
+    throw invalidDailyReviewArchive('id');
+  }
+  if (
+    !isRecord(input.day) ||
+    !isFiniteNumber(input.day.fromMs) ||
+    !isFiniteNumber(input.day.toMs) ||
+    input.day.toMs <= input.day.fromMs
+  ) {
+    throw invalidDailyReviewArchive('day');
+  }
+  if (!DAILY_REVIEW_ARCHIVE_STATUSES.includes(input.status as DailyReviewArchiveStatus)) {
+    throw invalidDailyReviewArchive('status');
+  }
+  if (!isFiniteNumber(input.generatedAt)) throw invalidDailyReviewArchive('generatedAt');
+  if (input.trigger !== 'cron' && input.trigger !== 'manual') {
+    throw invalidDailyReviewArchive('trigger');
+  }
+  if (typeof input.modelKey !== 'string') throw invalidDailyReviewArchive('modelKey');
+  const sections = normalizeDailyReviewArchiveSections(input.sections);
+  const totals = normalizeDailyReviewArchiveTotals(input.totals);
+  if (input.errorMessage !== undefined && typeof input.errorMessage !== 'string') {
+    throw invalidDailyReviewArchive('errorMessage');
+  }
+
+  return {
+    id: input.id,
+    day: { fromMs: input.day.fromMs, toMs: input.day.toMs },
+    range,
+    status: input.status as DailyReviewArchiveStatus,
+    generatedAt: input.generatedAt,
+    trigger: input.trigger,
+    modelKey: input.modelKey,
+    sections,
+    totals,
+    errorMessage: input.errorMessage,
+  };
+}
+
+function normalizeDailyReviewArchiveSections(input: unknown): DailyReviewArchiveSectionContent {
+  if (!isRecord(input)) throw invalidDailyReviewArchive('sections');
+  const sections: Record<string, string> = {};
+  for (const key of DAILY_REVIEW_SECTION_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    if (typeof value !== 'string') throw invalidDailyReviewArchive(`sections.${key}`);
+    sections[key] = value;
+  }
+  return sections;
+}
+
+function normalizeDailyReviewArchiveTotals(input: unknown): DailyReviewTotals {
+  if (!isRecord(input)) throw invalidDailyReviewArchive('totals');
+  for (const key of ['sessionCount', 'requestCount', 'totalTokens', 'errorCount'] as const) {
+    if (!isNonNegativeInteger(input[key])) throw invalidDailyReviewArchive(`totals.${key}`);
+  }
+  if (!isFiniteNumber(input.costUsd) || input.costUsd < 0) {
+    throw invalidDailyReviewArchive('totals.costUsd');
   }
   return {
-    id: archive.id,
-    day: archive.day,
-    range: archive.mode === 'deep' ? 7 : 1,
-    status: archive.status,
-    generatedAt: archive.generatedAt,
-    trigger: archive.trigger,
-    modelKey: archive.modelKey,
-    sections: archive.sections,
-    totals: archive.totals,
-    errorMessage: archive.errorMessage,
+    sessionCount: input.sessionCount as number,
+    requestCount: input.requestCount as number,
+    totalTokens: input.totalTokens as number,
+    costUsd: input.costUsd,
+    errorCount: input.errorCount as number,
   };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return isFiniteNumber(value) && Number.isInteger(value) && value >= 0;
+}
+
+function invalidDailyReviewArchive(field: string): Error {
+  return new Error(`Invalid Daily Review archive ${field}`);
 }
 
 /** Strips the section bodies down to a lightweight history-list row. */

--- a/packages/core/src/daily-review.ts
+++ b/packages/core/src/daily-review.ts
@@ -311,13 +311,16 @@ export function dailyReviewArchiveId(day: DayRangeMs, range: DailyReviewRange): 
 export function normalizeDailyReviewArchive(input: unknown): DailyReviewArchive {
   if (!isRecord(input)) throw invalidDailyReviewArchive('record');
   let range: DailyReviewRange;
+  let expectedIdSuffix: string;
   if ('range' in input) {
     if (!DAILY_REVIEW_RANGES.includes(input.range as DailyReviewRange)) {
       throw invalidDailyReviewArchive('range');
     }
     range = input.range as DailyReviewRange;
+    expectedIdSuffix = `${range}d`;
   } else if (input.mode === 'daily' || input.mode === 'deep') {
     range = input.mode === 'deep' ? 7 : 1;
+    expectedIdSuffix = input.mode;
   } else {
     throw invalidDailyReviewArchive('range');
   }
@@ -332,6 +335,10 @@ export function normalizeDailyReviewArchive(input: unknown): DailyReviewArchive 
     input.day.toMs <= input.day.fromMs
   ) {
     throw invalidDailyReviewArchive('day');
+  }
+  const day = { fromMs: input.day.fromMs, toMs: input.day.toMs };
+  if (!hasValidDailyReviewArchiveId(input.id, expectedIdSuffix)) {
+    throw invalidDailyReviewArchive('id');
   }
   if (!DAILY_REVIEW_ARCHIVE_STATUSES.includes(input.status as DailyReviewArchiveStatus)) {
     throw invalidDailyReviewArchive('status');
@@ -349,7 +356,7 @@ export function normalizeDailyReviewArchive(input: unknown): DailyReviewArchive 
 
   return {
     id: input.id,
-    day: { fromMs: input.day.fromMs, toMs: input.day.toMs },
+    day,
     range,
     status: input.status as DailyReviewArchiveStatus,
     generatedAt: input.generatedAt,
@@ -400,6 +407,18 @@ function isFiniteNumber(value: unknown): value is number {
 
 function isNonNegativeInteger(value: unknown): value is number {
   return isFiniteNumber(value) && Number.isInteger(value) && value >= 0;
+}
+
+function hasValidDailyReviewArchiveId(id: string, suffix: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})-(1d|7d|30d|daily|deep)$/.exec(id);
+  if (!match || match[4] !== suffix) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+  );
 }
 
 function invalidDailyReviewArchive(field: string): Error {

--- a/packages/core/src/daily-review.ts
+++ b/packages/core/src/daily-review.ts
@@ -204,9 +204,9 @@ export const DAILY_REVIEW_LIST_LIMIT = 8;
  * selection reuses the existing connection picker.
  */
 
-export type DailyReviewMode = 'daily' | 'deep';
+export type DailyReviewRange = 1 | 7 | 30;
 
-export const DAILY_REVIEW_MODES: readonly DailyReviewMode[] = ['daily', 'deep'] as const;
+export const DAILY_REVIEW_RANGES: readonly DailyReviewRange[] = [1, 7, 30] as const;
 
 export type DailyReviewSectionKey = 'summary' | 'gaps' | 'usage' | 'code';
 
@@ -217,32 +217,16 @@ export const DAILY_REVIEW_SECTION_KEYS: readonly DailyReviewSectionKey[] = [
   'code',
 ] as const;
 
-export interface DailyReviewSectionToggles {
-  readonly summary: boolean;
-  readonly gaps: boolean;
-  readonly usage: boolean;
-  readonly code: boolean;
-}
-
-export interface DailyReviewExternalNotify {
-  readonly enabled: boolean;
-  readonly channelId?: string;
-}
-
 export interface DailyReviewConfig {
   readonly enabled: boolean;
   /** Local-TZ HH:mm string, e.g. "08:00". */
   readonly executeTime: string;
-  readonly sections: DailyReviewSectionToggles;
-  readonly deepEnabled: boolean;
   /**
    * Composite model key (e.g. `connectionSlug::modelId`). Empty string
    * means "use the chat default model". The pipeline treats empty as
    * "no explicit model selected".
    */
   readonly modelKey: string;
-  readonly includeClaudeCode: boolean;
-  readonly externalNotify: DailyReviewExternalNotify;
 }
 
 export type DailyReviewArchiveStatus = 'ok' | 'no_model' | 'no_data' | 'failed' | 'skipped';
@@ -265,10 +249,10 @@ export interface DailyReviewArchiveSectionContent {
 }
 
 export interface DailyReviewArchive {
-  /** Stable id: `YYYY-MM-DD-{mode}`. Same-day re-runs overwrite. */
+  /** Stable id: `YYYY-MM-DD-{range}d`. Re-runs for the same range overwrite. */
   readonly id: string;
   readonly day: DayRangeMs;
-  readonly mode: DailyReviewMode;
+  readonly range: DailyReviewRange;
   readonly status: DailyReviewArchiveStatus;
   readonly generatedAt: number;
   readonly trigger: DailyReviewTrigger;
@@ -282,7 +266,7 @@ export interface DailyReviewArchive {
 export interface DailyReviewArchiveSummary {
   readonly id: string;
   readonly day: DayRangeMs;
-  readonly mode: DailyReviewMode;
+  readonly range: DailyReviewRange;
   readonly status: DailyReviewArchiveStatus;
   readonly generatedAt: number;
   readonly trigger: DailyReviewTrigger;
@@ -294,16 +278,7 @@ export interface DailyReviewArchiveSummary {
 export const DEFAULT_DAILY_REVIEW_CONFIG: DailyReviewConfig = {
   enabled: false,
   executeTime: '08:00',
-  sections: {
-    summary: true,
-    gaps: true,
-    usage: false,
-    code: false,
-  },
-  deepEnabled: false,
   modelKey: '',
-  includeClaudeCode: false,
-  externalNotify: { enabled: false },
 };
 
 const EXECUTE_TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
@@ -315,45 +290,60 @@ export function isDailyReviewExecuteTime(value: unknown): value is string {
 
 /** Coerces an arbitrary partial config to a fully-valid `DailyReviewConfig`. */
 export function normalizeDailyReviewConfig(
-  input: Partial<DailyReviewConfig> | null | undefined,
+  input:
+    | (Partial<DailyReviewConfig> & {
+        readonly sections?: unknown;
+        readonly deepEnabled?: unknown;
+        readonly includeClaudeCode?: unknown;
+        readonly externalNotify?: unknown;
+      })
+    | null
+    | undefined,
 ): DailyReviewConfig {
   const base = DEFAULT_DAILY_REVIEW_CONFIG;
   if (!input) return base;
-  const sections = input.sections ?? base.sections;
-  const externalNotify = input.externalNotify ?? base.externalNotify;
   return {
     enabled: typeof input.enabled === 'boolean' ? input.enabled : base.enabled,
     executeTime: isDailyReviewExecuteTime(input.executeTime) ? input.executeTime : base.executeTime,
-    sections: {
-      summary: typeof sections.summary === 'boolean' ? sections.summary : base.sections.summary,
-      gaps: typeof sections.gaps === 'boolean' ? sections.gaps : base.sections.gaps,
-      usage: typeof sections.usage === 'boolean' ? sections.usage : base.sections.usage,
-      code: typeof sections.code === 'boolean' ? sections.code : base.sections.code,
-    },
-    deepEnabled: typeof input.deepEnabled === 'boolean' ? input.deepEnabled : base.deepEnabled,
     modelKey: typeof input.modelKey === 'string' ? input.modelKey : base.modelKey,
-    includeClaudeCode:
-      typeof input.includeClaudeCode === 'boolean'
-        ? input.includeClaudeCode
-        : base.includeClaudeCode,
-    externalNotify: {
-      enabled:
-        typeof externalNotify.enabled === 'boolean'
-          ? externalNotify.enabled
-          : base.externalNotify.enabled,
-      channelId:
-        typeof externalNotify.channelId === 'string' ? externalNotify.channelId : undefined,
-    },
   };
 }
 
-/** Builds the canonical archive id for a given day + mode. */
-export function dailyReviewArchiveId(day: DayRangeMs, mode: DailyReviewMode): string {
+/** Builds the canonical archive id for a given range. */
+export function dailyReviewArchiveId(day: DayRangeMs, range: DailyReviewRange): string {
   const d = new Date(day.fromMs);
   const yyyy = d.getFullYear();
   const mm = String(d.getMonth() + 1).padStart(2, '0');
   const dd = String(d.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}-${mode}`;
+  return `${yyyy}-${mm}-${dd}-${range}d`;
+}
+
+type LegacyDailyReviewArchive = Omit<DailyReviewArchive, 'range'> & {
+  readonly mode: 'daily' | 'deep';
+};
+
+/** Maps the retired daily/deep read format onto the one range contract. */
+export function normalizeDailyReviewArchive(
+  archive: DailyReviewArchive | LegacyDailyReviewArchive,
+): DailyReviewArchive {
+  if ('range' in archive) {
+    if (!DAILY_REVIEW_RANGES.includes(archive.range)) {
+      throw new Error(`Invalid Daily Review range: ${String(archive.range)}`);
+    }
+    return archive;
+  }
+  return {
+    id: archive.id,
+    day: archive.day,
+    range: archive.mode === 'deep' ? 7 : 1,
+    status: archive.status,
+    generatedAt: archive.generatedAt,
+    trigger: archive.trigger,
+    modelKey: archive.modelKey,
+    sections: archive.sections,
+    totals: archive.totals,
+    errorMessage: archive.errorMessage,
+  };
 }
 
 /** Strips the section bodies down to a lightweight history-list row. */
@@ -363,7 +353,7 @@ export function dailyReviewArchiveToSummary(
   return {
     id: archive.id,
     day: archive.day,
-    mode: archive.mode,
+    range: archive.range,
     status: archive.status,
     generatedAt: archive.generatedAt,
     trigger: archive.trigger,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1676,10 +1676,8 @@ export type {
   DailyReviewArchiveStatus,
   DailyReviewArchiveSummary,
   DailyReviewConfig,
-  DailyReviewExternalNotify,
-  DailyReviewMode,
+  DailyReviewRange,
   DailyReviewSectionKey,
-  DailyReviewSectionToggles,
   DailyReviewSessionRow,
   DailyReviewSummary,
   DailyReviewTopEntry,
@@ -1690,7 +1688,7 @@ export type {
 export {
   DAILY_REVIEW_ARCHIVE_STATUSES,
   DAILY_REVIEW_LIST_LIMIT,
-  DAILY_REVIEW_MODES,
+  DAILY_REVIEW_RANGES,
   DAILY_REVIEW_SECTION_KEYS,
   DEFAULT_DAILY_REVIEW_CONFIG,
   buildDailyReviewSummary,
@@ -1701,6 +1699,7 @@ export {
   localDayBoundsAt,
   localDayBoundsForInstant,
   normalizeDailyReviewConfig,
+  normalizeDailyReviewArchive,
   pickDailyReviewSessions,
   pickDailyReviewTopEntries,
 } from './daily-review.js';

--- a/packages/ui/src/__tests__/daily-review-panel.test.tsx
+++ b/packages/ui/src/__tests__/daily-review-panel.test.tsx
@@ -33,8 +33,8 @@ describe('Daily Review activity surface', () => {
     const markup = renderPanel();
 
     assert.match(markup, />今日</);
-    assert.match(markup, />本周</);
-    assert.match(markup, />本月</);
+    assert.match(markup, />最近 7 天</);
+    assert.match(markup, />最近 30 天</);
     assert.match(markup, />生成分析</);
     assert.doesNotMatch(markup, /生成每日回顾|生成深度分析|分析模型/);
   });

--- a/packages/ui/src/__tests__/daily-review-panel.test.tsx
+++ b/packages/ui/src/__tests__/daily-review-panel.test.tsx
@@ -1,0 +1,49 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { DailyReviewPanel } from '../daily-review-panel.js';
+import { LocaleProvider } from '../locale-context.js';
+
+function renderPanel(): string {
+  return renderToStaticMarkup(
+    <LocaleProvider locale="zh">
+      <DailyReviewPanel
+        bridge={{
+          fetchDay: async () => ({
+            day: { fromMs: 0, toMs: 1 },
+            totals: { sessionCount: 0, requestCount: 0, totalTokens: 0, costUsd: 0, errorCount: 0 },
+            sessions: [],
+            topModels: [],
+            topTools: [],
+          }),
+          runOnce: async () => ({ archiveId: '1970-01-01-1d' }),
+          listArchives: async () => [],
+          getArchive: async () => {
+            throw new Error('No archive');
+          },
+        }}
+      />
+    </LocaleProvider>,
+  );
+}
+
+describe('Daily Review activity surface', () => {
+  it('offers one range-based analysis action without the retired modes', () => {
+    const markup = renderPanel();
+
+    assert.match(markup, />今日</);
+    assert.match(markup, />本周</);
+    assert.match(markup, />本月</);
+    assert.match(markup, />生成分析</);
+    assert.doesNotMatch(markup, /生成每日回顾|生成深度分析|分析模型/);
+  });
+
+  it('does not render report history or model and tool rankings on the activity route', () => {
+    const markup = renderPanel();
+
+    assert.doesNotMatch(markup, />报告</);
+    assert.doesNotMatch(markup, />模型使用</);
+    assert.doesNotMatch(markup, />工具调用</);
+  });
+});

--- a/packages/ui/src/__tests__/daily-review-view-state.test.ts
+++ b/packages/ui/src/__tests__/daily-review-view-state.test.ts
@@ -5,6 +5,7 @@ import type { DailyReviewSummary } from '@maka/core';
 import {
   createDailyReviewActivityState,
   dailyReviewActivityReducer,
+  shiftDailyReviewScope,
 } from '../daily-review-view-state.js';
 
 const today: DailyReviewSummary = {
@@ -89,5 +90,18 @@ describe('Daily Review resolved view continuity', () => {
     });
 
     assert.equal(staleResult, pendingMonth);
+  });
+});
+
+describe('Daily Review range navigation', () => {
+  it('moves rolling ranges one day at a time', () => {
+    assert.deepEqual(shiftDailyReviewScope({ range: 7, offsetDays: 0 }, -1), {
+      range: 7,
+      offsetDays: -1,
+    });
+    assert.deepEqual(shiftDailyReviewScope({ range: 30, offsetDays: -2 }, 1), {
+      range: 30,
+      offsetDays: -1,
+    });
   });
 });

--- a/packages/ui/src/__tests__/daily-review-view-state.test.ts
+++ b/packages/ui/src/__tests__/daily-review-view-state.test.ts
@@ -1,0 +1,93 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { DailyReviewSummary } from '@maka/core';
+
+import {
+  createDailyReviewActivityState,
+  dailyReviewActivityReducer,
+} from '../daily-review-view-state.js';
+
+const today: DailyReviewSummary = {
+  day: { fromMs: 0, toMs: 1 },
+  totals: { sessionCount: 1, requestCount: 2, totalTokens: 3, costUsd: 0, errorCount: 0 },
+  sessions: [],
+  topModels: [],
+  topTools: [],
+};
+
+describe('Daily Review resolved view continuity', () => {
+  it('keeps the resolved content while a different scope is loading', () => {
+    const resolved = dailyReviewActivityReducer(
+      createDailyReviewActivityState({ range: 1, offsetDays: 0 }),
+      { type: 'resolved', scope: { range: 1, offsetDays: 0 }, summary: today },
+    );
+
+    const pending = dailyReviewActivityReducer(resolved, {
+      type: 'selected',
+      scope: { range: 7, offsetDays: 0 },
+    });
+
+    assert.deepEqual(pending.selection, { range: 7, offsetDays: 0 });
+    assert.equal(pending.pendingScopeKey, '0:7');
+    assert.equal(pending.resolvedView?.summary, today);
+    assert.equal(pending.resolvedView?.scopeKey, '0:1');
+  });
+
+  it('replaces the visible content atomically when the selected scope resolves', () => {
+    const week = { ...today, day: { fromMs: 10, toMs: 20 } };
+    const pending = dailyReviewActivityReducer(
+      createDailyReviewActivityState({ range: 1, offsetDays: 0 }),
+      { type: 'selected', scope: { range: 7, offsetDays: 0 } },
+    );
+
+    const resolved = dailyReviewActivityReducer(pending, {
+      type: 'resolved',
+      scope: { range: 7, offsetDays: 0 },
+      summary: week,
+    });
+
+    assert.equal(resolved.pendingScopeKey, null);
+    assert.equal(resolved.resolvedView?.summary, week);
+    assert.equal(resolved.resolvedView?.scopeKey, '0:7');
+  });
+
+  it('retains the last resolved content when a refresh fails', () => {
+    const resolved = dailyReviewActivityReducer(
+      createDailyReviewActivityState({ range: 1, offsetDays: 0 }),
+      { type: 'resolved', scope: { range: 1, offsetDays: 0 }, summary: today },
+    );
+    const pending = dailyReviewActivityReducer(resolved, {
+      type: 'selected',
+      scope: { range: 30, offsetDays: 0 },
+    });
+
+    const failed = dailyReviewActivityReducer(pending, {
+      type: 'rejected',
+      scope: { range: 30, offsetDays: 0 },
+      error: '读取失败',
+    });
+
+    assert.equal(failed.pendingScopeKey, null);
+    assert.equal(failed.resolvedView, resolved.resolvedView);
+    assert.equal(failed.error, '读取失败');
+  });
+
+  it('ignores a result for a scope that is no longer selected', () => {
+    const pendingWeek = dailyReviewActivityReducer(
+      createDailyReviewActivityState({ range: 1, offsetDays: 0 }),
+      { type: 'selected', scope: { range: 7, offsetDays: 0 } },
+    );
+    const pendingMonth = dailyReviewActivityReducer(pendingWeek, {
+      type: 'selected',
+      scope: { range: 30, offsetDays: 0 },
+    });
+
+    const staleResult = dailyReviewActivityReducer(pendingMonth, {
+      type: 'resolved',
+      scope: { range: 7, offsetDays: 0 },
+      summary: today,
+    });
+
+    assert.equal(staleResult, pendingMonth);
+  });
+});

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -11,7 +11,7 @@ export type { ModuleHubHeader } from './module-hub-selector.js';
 export { SearchModal } from './search-modal.js';
 export { SessionListPanel } from './session-list-panel.js';
 export type { SessionViewMode } from './session-list-panel.js';
-export type { BundledSkillCatalogEntry, ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry, SkillGovernanceDetails } from './module-panel-types.js';
+export type { BundledSkillCatalogEntry, DailyReviewMarkdownActionInput, ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry, SkillGovernanceDetails } from './module-panel-types.js';
 export { describeLoadToolResult, formatRedactedJson, formatToolIntent, loadToolDisplayName } from './tool-format.js';
 export { formatBytes, ToolActivity, ToolTrow } from './tool-activity.js';
 export { ToolResultPreview } from './tool-activity/tool-result-preview.js';

--- a/packages/ui/src/daily-review-copy.ts
+++ b/packages/ui/src/daily-review-copy.ts
@@ -47,6 +47,7 @@ export interface DailyReviewCopy {
   page: {
     title: string;
     generateAnalysis: string;
+    retryAnalysis: string;
     viewAnalysis: string;
     backToActivity: string;
     timeRange: string;
@@ -104,7 +105,7 @@ const DAILY_REVIEW_COPY = {
       ariaLabel: '回顾导出操作', copyTitle: '复制为 Markdown 摘要，方便分享 / 贴到笔记', copying: '复制中…', copy: '复制', appendTitle: '追加到当前输入框草稿', appending: '追加中…', append: '粘到输入框', saveTitle: '保存为 Markdown 文件', saving: '保存中…', save: '保存',
     },
     page: {
-      title: '每日回顾', generateAnalysis: '生成分析', viewAnalysis: '查看分析', backToActivity: '返回活动', timeRange: '时间范围', rangeOptions: [['1', '今日'], ['7', '最近 7 天'], ['30', '最近 30 天']], rangeSwitch: '时间范围切换',
+      title: '每日回顾', generateAnalysis: '生成分析', retryAnalysis: '重新生成', viewAnalysis: '查看分析', backToActivity: '返回活动', timeRange: '时间范围', rangeOptions: [['1', '今日'], ['7', '最近 7 天'], ['30', '最近 30 天']], rangeSwitch: '时间范围切换',
     },
     overview: {
       ariaLabel: (label) => `${label}概览`, refreshFailed: (error) => `每日回顾刷新失败：${error}`, retry: '重试', conversations: '对话', requests: '请求', tokens: 'Token', cost: '费用', activeConversations: '活跃对话',
@@ -138,7 +139,7 @@ const DAILY_REVIEW_COPY = {
       ariaLabel: 'Review export actions', copyTitle: 'Copy a Markdown summary to share or add to notes', copying: 'Copying…', copy: 'Copy', appendTitle: 'Append to the current composer draft', appending: 'Appending…', append: 'Add to composer', saveTitle: 'Save as a Markdown file', saving: 'Saving…', save: 'Save',
     },
     page: {
-      title: 'Daily review', generateAnalysis: 'Generate analysis', viewAnalysis: 'View analysis', backToActivity: 'Back to activity', timeRange: 'Time range', rangeOptions: [['1', 'Today'], ['7', 'Last 7 days'], ['30', 'Last 30 days']], rangeSwitch: 'Change time range',
+      title: 'Daily review', generateAnalysis: 'Generate analysis', retryAnalysis: 'Generate again', viewAnalysis: 'View analysis', backToActivity: 'Back to activity', timeRange: 'Time range', rangeOptions: [['1', 'Today'], ['7', 'Last 7 days'], ['30', 'Last 30 days']], rangeSwitch: 'Change time range',
     },
     overview: {
       ariaLabel: (label) => `${label} overview`, refreshFailed: (error) => `Failed to refresh daily review: ${error}`, retry: 'Retry', conversations: 'Conversations', requests: 'Requests', tokens: 'Tokens', cost: 'Cost', activeConversations: 'Active conversations',

--- a/packages/ui/src/daily-review-copy.ts
+++ b/packages/ui/src/daily-review-copy.ts
@@ -55,31 +55,14 @@ export interface DailyReviewCopy {
   };
   overview: {
     ariaLabel: (label: string) => string;
-    title: string;
     refreshFailed: (error: string) => string;
     retry: string;
-    readFailed: string;
     conversations: string;
     requests: string;
     tokens: string;
     cost: string;
     errors: string;
     activeConversations: string;
-    activeConversationList: string;
-    modelUsage: string;
-    toolCalls: string;
-  };
-  reports: {
-    title: string;
-    count: (count: number) => string;
-    readFailed: (error: string) => string;
-    emptyTitle: string;
-    emptyBody: string;
-    historyAriaLabel: string;
-  };
-  list: {
-    ariaLabel: (title: string) => string;
-    requestCount: (count: number) => string;
   };
   errorFallback: string;
   markdown: {
@@ -122,15 +105,11 @@ const DAILY_REVIEW_COPY = {
       ariaLabel: '回顾导出操作', copyTitle: '复制为 Markdown 摘要，方便分享 / 贴到笔记', copying: '复制中…', copy: '复制', appendTitle: '追加到当前输入框草稿', appending: '追加中…', append: '粘到输入框', saveTitle: '保存为 Markdown 文件', saving: '保存中…', save: '保存',
     },
     page: {
-      title: '每日回顾', generateAnalysis: '生成分析', viewAnalysis: '查看分析', backToActivity: '返回活动', timeRange: '时间范围', rangeOptions: [['1', '今日'], ['7', '本周'], ['30', '本月']], rangeSwitch: '时间范围切换',
+      title: '每日回顾', generateAnalysis: '生成分析', viewAnalysis: '查看分析', backToActivity: '返回活动', timeRange: '时间范围', rangeOptions: [['1', '今日'], ['7', '最近 7 天'], ['30', '最近 30 天']], rangeSwitch: '时间范围切换',
     },
     overview: {
-      ariaLabel: (label) => `${label}概览`, title: '概览', refreshFailed: (error) => `每日回顾刷新失败：${error}`, retry: '重试', readFailed: '读取失败', conversations: '对话', requests: '请求', tokens: 'Token', cost: '费用', errors: '错误', activeConversations: '活跃对话', activeConversationList: '活跃对话列表', modelUsage: '模型使用', toolCalls: '工具调用',
+      ariaLabel: (label) => `${label}概览`, refreshFailed: (error) => `每日回顾刷新失败：${error}`, retry: '重试', conversations: '对话', requests: '请求', tokens: 'Token', cost: '费用', errors: '错误', activeConversations: '活跃对话',
     },
-    reports: {
-      title: '报告', count: (count) => `${count} 份`, readFailed: (error) => `回顾报告读取失败：${error}`, emptyTitle: '还没有生成报告', emptyBody: '点击「生成每日回顾」后，报告会保存到本机并显示在这里。', historyAriaLabel: '回顾报告历史',
-    },
-    list: { ariaLabel: (title) => `${title}列表`, requestCount: (count) => `${count} 次` },
     errorFallback: '每日回顾暂时不可用，请稍后重试。',
     markdown: {
       separator: '：', title: (dayLabel) => `# Maka · 每日回顾 · ${dayLabel}`, conversations: '对话', requests: '请求', tokens: 'Token', cost: '费用', errors: '错误', activeConversations: '活跃对话', modelUsage: '模型使用', toolCalls: '工具调用', requestCount: (count) => `${count} 次`,
@@ -160,15 +139,11 @@ const DAILY_REVIEW_COPY = {
       ariaLabel: 'Review export actions', copyTitle: 'Copy a Markdown summary to share or add to notes', copying: 'Copying…', copy: 'Copy', appendTitle: 'Append to the current composer draft', appending: 'Appending…', append: 'Add to composer', saveTitle: 'Save as a Markdown file', saving: 'Saving…', save: 'Save',
     },
     page: {
-      title: 'Daily review', generateAnalysis: 'Generate analysis', viewAnalysis: 'View analysis', backToActivity: 'Back to activity', timeRange: 'Time range', rangeOptions: [['1', 'Today'], ['7', 'This week'], ['30', 'This month']], rangeSwitch: 'Change time range',
+      title: 'Daily review', generateAnalysis: 'Generate analysis', viewAnalysis: 'View analysis', backToActivity: 'Back to activity', timeRange: 'Time range', rangeOptions: [['1', 'Today'], ['7', 'Last 7 days'], ['30', 'Last 30 days']], rangeSwitch: 'Change time range',
     },
     overview: {
-      ariaLabel: (label) => `${label} overview`, title: 'Overview', refreshFailed: (error) => `Failed to refresh daily review: ${error}`, retry: 'Retry', readFailed: 'Failed to load', conversations: 'Conversations', requests: 'Requests', tokens: 'Tokens', cost: 'Cost', errors: 'Errors', activeConversations: 'Active conversations', activeConversationList: 'Active conversation list', modelUsage: 'Model usage', toolCalls: 'Tool calls',
+      ariaLabel: (label) => `${label} overview`, refreshFailed: (error) => `Failed to refresh daily review: ${error}`, retry: 'Retry', conversations: 'Conversations', requests: 'Requests', tokens: 'Tokens', cost: 'Cost', errors: 'Errors', activeConversations: 'Active conversations',
     },
-    reports: {
-      title: 'Reports', count: (count) => `${count} ${count === 1 ? 'report' : 'reports'}`, readFailed: (error) => `Failed to load review reports: ${error}`, emptyTitle: 'No reports yet', emptyBody: 'Generate a daily review to save a local report and show it here.', historyAriaLabel: 'Review report history',
-    },
-    list: { ariaLabel: (title) => `${title} list`, requestCount: (count) => `${count} ${count === 1 ? 'request' : 'requests'}` },
     errorFallback: 'Daily review is temporarily unavailable. Try again later.',
     markdown: {
       separator: ':', title: (dayLabel) => `# Maka · Daily review · ${dayLabel}`, conversations: 'Conversations', requests: 'Requests', tokens: 'Tokens', cost: 'Cost', errors: 'Errors', activeConversations: 'Active conversations', modelUsage: 'Model usage', toolCalls: 'Tool calls', requestCount: (count) => `${count} ${count === 1 ? 'request' : 'requests'}`,

--- a/packages/ui/src/daily-review-copy.ts
+++ b/packages/ui/src/daily-review-copy.ts
@@ -7,8 +7,8 @@ export interface DailyReviewCopy {
     section: Record<ArchiveSectionKey, string>;
     status: Record<DailyReviewArchive['status'], string>;
     trigger: Record<DailyReviewArchive['trigger'], string>;
-    mode: { daily: string; deep: string };
-    title: (date: string, mode: string) => string;
+    title: (date: string, range: string) => string;
+    range: Record<DailyReviewArchive['range'], string>;
     generated: (trigger: string, time: string) => string;
     sessionCount: (count: number) => string;
     defaultModel: string;
@@ -46,12 +46,9 @@ export interface DailyReviewCopy {
   };
   page: {
     title: string;
-    subtitle: string;
-    generateAriaLabel: string;
-    analysisModel: string;
-    generating: string;
-    generateDaily: string;
-    generateDeep: string;
+    generateAnalysis: string;
+    viewAnalysis: string;
+    backToActivity: string;
     timeRange: string;
     rangeOptions: ReadonlyArray<readonly [string, string]>;
     rangeSwitch: string;
@@ -106,8 +103,8 @@ const DAILY_REVIEW_COPY = {
       section: { summary: '对话摘要', gaps: '遗漏提醒', usage: '使用洞察', code: '代码建议' },
       status: { ok: '已生成', no_model: '缺少模型', no_data: '无数据', failed: '生成失败', skipped: '已跳过' },
       trigger: { cron: '定时', manual: '手动' },
-      mode: { daily: '每日回顾', deep: '深度分析' },
       title: (date, mode) => `${date} · ${mode}`,
+      range: { 1: '单日', 7: '7 天', 30: '30 天' },
       generated: (trigger, time) => `${trigger}生成 ${time}`,
       sessionCount: (count) => `${count} 对话`,
       defaultModel: '默认对话模型',
@@ -125,7 +122,7 @@ const DAILY_REVIEW_COPY = {
       ariaLabel: '回顾导出操作', copyTitle: '复制为 Markdown 摘要，方便分享 / 贴到笔记', copying: '复制中…', copy: '复制', appendTitle: '追加到当前输入框草稿', appending: '追加中…', append: '粘到输入框', saveTitle: '保存为 Markdown 文件', saving: '保存中…', save: '保存',
     },
     page: {
-      title: '每日回顾', subtitle: '自动汇总本机对话，生成摘要、遗漏提醒与深度分析；可在设置中开启定时执行。', generateAriaLabel: '生成回顾', analysisModel: '分析模型', generating: '生成中…', generateDaily: '生成每日回顾', generateDeep: '生成深度分析', timeRange: '时间范围', rangeOptions: [['1', '今日'], ['7', '本周'], ['30', '本月']], rangeSwitch: '时间范围切换',
+      title: '每日回顾', generateAnalysis: '生成分析', viewAnalysis: '查看分析', backToActivity: '返回活动', timeRange: '时间范围', rangeOptions: [['1', '今日'], ['7', '本周'], ['30', '本月']], rangeSwitch: '时间范围切换',
     },
     overview: {
       ariaLabel: (label) => `${label}概览`, title: '概览', refreshFailed: (error) => `每日回顾刷新失败：${error}`, retry: '重试', readFailed: '读取失败', conversations: '对话', requests: '请求', tokens: 'Token', cost: '费用', errors: '错误', activeConversations: '活跃对话', activeConversationList: '活跃对话列表', modelUsage: '模型使用', toolCalls: '工具调用',
@@ -144,8 +141,8 @@ const DAILY_REVIEW_COPY = {
       section: { summary: 'Conversation summary', gaps: 'Missed items', usage: 'Usage insights', code: 'Code suggestions' },
       status: { ok: 'Generated', no_model: 'Model unavailable', no_data: 'No data', failed: 'Generation failed', skipped: 'Skipped' },
       trigger: { cron: 'Scheduled', manual: 'Manual' },
-      mode: { daily: 'Daily review', deep: 'Deep analysis' },
       title: (date, mode) => `${date} · ${mode}`,
+      range: { 1: '1 day', 7: '7 days', 30: '30 days' },
       generated: (trigger, time) => `${trigger} · ${time}`,
       sessionCount: (count) => `${count} ${count === 1 ? 'conversation' : 'conversations'}`,
       defaultModel: 'Default conversation model',
@@ -163,7 +160,7 @@ const DAILY_REVIEW_COPY = {
       ariaLabel: 'Review export actions', copyTitle: 'Copy a Markdown summary to share or add to notes', copying: 'Copying…', copy: 'Copy', appendTitle: 'Append to the current composer draft', appending: 'Appending…', append: 'Add to composer', saveTitle: 'Save as a Markdown file', saving: 'Saving…', save: 'Save',
     },
     page: {
-      title: 'Daily review', subtitle: 'Summarize local conversations into highlights, missed items, and deeper analysis. Scheduled runs can be enabled in Settings.', generateAriaLabel: 'Generate review', analysisModel: 'Analysis model', generating: 'Generating…', generateDaily: 'Generate daily review', generateDeep: 'Generate deep analysis', timeRange: 'Time range', rangeOptions: [['1', 'Today'], ['7', 'This week'], ['30', 'This month']], rangeSwitch: 'Change time range',
+      title: 'Daily review', generateAnalysis: 'Generate analysis', viewAnalysis: 'View analysis', backToActivity: 'Back to activity', timeRange: 'Time range', rangeOptions: [['1', 'Today'], ['7', 'This week'], ['30', 'This month']], rangeSwitch: 'Change time range',
     },
     overview: {
       ariaLabel: (label) => `${label} overview`, title: 'Overview', refreshFailed: (error) => `Failed to refresh daily review: ${error}`, retry: 'Retry', readFailed: 'Failed to load', conversations: 'Conversations', requests: 'Requests', tokens: 'Tokens', cost: 'Cost', errors: 'Errors', activeConversations: 'Active conversations', activeConversationList: 'Active conversation list', modelUsage: 'Model usage', toolCalls: 'Tool calls',

--- a/packages/ui/src/daily-review-copy.ts
+++ b/packages/ui/src/daily-review-copy.ts
@@ -61,7 +61,6 @@ export interface DailyReviewCopy {
     requests: string;
     tokens: string;
     cost: string;
-    errors: string;
     activeConversations: string;
   };
   errorFallback: string;
@@ -108,7 +107,7 @@ const DAILY_REVIEW_COPY = {
       title: '每日回顾', generateAnalysis: '生成分析', viewAnalysis: '查看分析', backToActivity: '返回活动', timeRange: '时间范围', rangeOptions: [['1', '今日'], ['7', '最近 7 天'], ['30', '最近 30 天']], rangeSwitch: '时间范围切换',
     },
     overview: {
-      ariaLabel: (label) => `${label}概览`, refreshFailed: (error) => `每日回顾刷新失败：${error}`, retry: '重试', conversations: '对话', requests: '请求', tokens: 'Token', cost: '费用', errors: '错误', activeConversations: '活跃对话',
+      ariaLabel: (label) => `${label}概览`, refreshFailed: (error) => `每日回顾刷新失败：${error}`, retry: '重试', conversations: '对话', requests: '请求', tokens: 'Token', cost: '费用', activeConversations: '活跃对话',
     },
     errorFallback: '每日回顾暂时不可用，请稍后重试。',
     markdown: {
@@ -142,7 +141,7 @@ const DAILY_REVIEW_COPY = {
       title: 'Daily review', generateAnalysis: 'Generate analysis', viewAnalysis: 'View analysis', backToActivity: 'Back to activity', timeRange: 'Time range', rangeOptions: [['1', 'Today'], ['7', 'Last 7 days'], ['30', 'Last 30 days']], rangeSwitch: 'Change time range',
     },
     overview: {
-      ariaLabel: (label) => `${label} overview`, refreshFailed: (error) => `Failed to refresh daily review: ${error}`, retry: 'Retry', conversations: 'Conversations', requests: 'Requests', tokens: 'Tokens', cost: 'Cost', errors: 'Errors', activeConversations: 'Active conversations',
+      ariaLabel: (label) => `${label} overview`, refreshFailed: (error) => `Failed to refresh daily review: ${error}`, retry: 'Retry', conversations: 'Conversations', requests: 'Requests', tokens: 'Tokens', cost: 'Cost', activeConversations: 'Active conversations',
     },
     errorFallback: 'Daily review is temporarily unavailable. Try again later.',
     markdown: {

--- a/packages/ui/src/daily-review-helpers.ts
+++ b/packages/ui/src/daily-review-helpers.ts
@@ -20,14 +20,12 @@
 import type {
   DailyReviewArchive,
   DailyReviewArchiveSummary,
+  DailyReviewRange,
   DailyReviewSummary,
   UiLocale,
 } from '@maka/core';
 import { generalizedErrorMessage, generalizedErrorMessageChinese, uiLocaleToIntlLocale } from '@maka/core';
 import { getDailyReviewCopy } from './daily-review-copy.js';
-
-/** Visible day-range options on the Daily Review panel. */
-export type DailyReviewRange = 1 | 7 | 30;
 
 export function dailyReviewScopeKey(offsetDays: number, range: DailyReviewRange): string {
   return `${offsetDays}:${range}`;
@@ -44,10 +42,11 @@ export function formatDailyReviewArchiveTitle(
   archive: DailyReviewArchive | DailyReviewArchiveSummary,
   locale: UiLocale,
 ): string {
-  const copy = getDailyReviewCopy(locale).archive;
+  const copy = getDailyReviewCopy(locale);
   const d = new Date(archive.day.fromMs);
   const date = d.toLocaleDateString(uiLocaleToIntlLocale(locale), { month: '2-digit', day: '2-digit' });
-  return copy.title(date, archive.mode === 'deep' ? copy.mode.deep : copy.mode.daily);
+  const rangeLabel = copy.archive.range[archive.range];
+  return copy.archive.title(date, rangeLabel);
 }
 
 export function formatDailyReviewArchiveGeneratedAt(generatedAt: number, locale: UiLocale): string {

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -1,63 +1,48 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useMountedRef } from './use-mounted-ref.js';
-import { CalendarDays, ChevronLeft, ChevronRight } from './icons.js';
 import type {
   DailyReviewArchive,
+  DailyReviewArchiveSectionContent,
   DailyReviewArchiveSummary,
-  DailyReviewMode,
+  DailyReviewRange,
+  DailyReviewSectionKey,
   DailyReviewSummary,
-  DailyReviewTopEntry,
 } from '@maka/core';
-import { uiLocaleToIntlLocale } from '@maka/core';
+import { DAILY_REVIEW_RANGES, uiLocaleToIntlLocale } from '@maka/core';
 import {
-  type DailyReviewRange,
+  Banner,
+  Button,
+  Divider,
+  EmptyState,
+  Heading,
+  HStack,
+  List,
+  ListItem,
+  SegmentedControl,
+  SegmentedControlItem,
+  Skeleton,
+  StackItem,
+  Text,
+  VStack,
+} from '@astryxdesign/core';
+import { ArrowLeft, CalendarDays, ChevronLeft, ChevronRight } from './icons.js';
+import {
   dailyReviewPanelErrorMessage,
   dailyReviewScopeKey,
   formatDailyReviewArchiveGeneratedAt,
   formatDailyReviewArchiveTitle,
-  formatDailyReviewMarkdown,
   formatDailyReviewModelLabel,
 } from './daily-review-helpers.js';
-import {
-  Badge,
-  Banner,
-  type BadgeProps,
-  Button as UiButton,
-  Collapsible,
-  CollapsibleGroup,
-  EmptyState,
-  IconButton,
-  Item,
-  SegmentedControl,
-  SegmentedControlItem,
-  Selector,
-  type SelectorOptionData,
-  Skeleton,
-} from '@astryxdesign/core';
-import { StatTile } from './primitives/stat-tile.js';
-import { SectionHeader } from './primitives/section-header.js';
-import { PageHeader } from './primitives/page-header.js';
 import type { DailyReviewBridge, DailyReviewMarkdownActionInput } from './module-panel-types.js';
 import type { ModuleHubHeader } from './module-hub-selector.js';
-import { RelativeTime } from './relative-time.js';
-import { Markdown } from './markdown.js';
-import { useUiLocale } from './locale-context.js';
 import { getDailyReviewCopy } from './daily-review-copy.js';
+import { Markdown } from './markdown.js';
+import { RelativeTime } from './relative-time.js';
+import { useUiLocale } from './locale-context.js';
+import { useMountedRef } from './use-mounted-ref.js';
 
-type DailyReviewArchiveSectionKey = keyof DailyReviewArchive['sections'];
-
-const EMPTY_MODEL_OPTIONS: SelectorOptionData[] = [];
-
-// Archive-status Badge tone. ok = generated cleanly (success), failed /
-// no_model = the run could not produce a report (destructive). no_data /
-// skipped are expected non-events and stay neutral (exception-only color).
-function dailyReviewArchiveBadgeVariant(status: DailyReviewArchive['status']): BadgeProps['variant'] {
-  // Status-color restraint (#651 rule): 已生成 is the EXPECTED outcome —
-  // neutral ink, matching 健康 正常 and 权限 已授权. Color stays reserved
-  // for the failures that need attention.
-  if (status === 'failed' || status === 'no_model') return 'error';
-  return 'neutral';
-}
+type DailyReviewRoute =
+  | { kind: 'activity' }
+  | { kind: 'report'; archive: DailyReviewArchive };
 
 export function DailyReviewPanel(props: {
   bridge: DailyReviewBridge;
@@ -70,79 +55,50 @@ export function DailyReviewPanel(props: {
   const locale = useUiLocale();
   const copy = getDailyReviewCopy(locale);
   const intlLocale = uiLocaleToIntlLocale(locale);
-  const [offsetDays, setOffsetDays] = useState(0);
-  // PR-DAILY-REVIEW-RANGE-0: 今日 / 本周 / 本月 tabs that map to a
-  // 1 / 7 / 30 day aggregation. When span > 1, the day-stepper
-  // navigates by the same span (一个 30 天 window steps back 30 days).
-  const [range, setRange] = useState<DailyReviewRange>(1);
-  const [summary, setSummary] = useState<DailyReviewSummary | null>(null);
-  const [summaryScopeKey, setSummaryScopeKey] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [reloadToken, setReloadToken] = useState(0);
-  const [pendingDailyReviewAction, setPendingDailyReviewAction] = useState<string | null>(null);
-  const [archives, setArchives] = useState<DailyReviewArchiveSummary[]>([]);
-  const [selectedArchiveId, setSelectedArchiveId] = useState<string | null>(null);
-  const [selectedArchive, setSelectedArchive] = useState<DailyReviewArchive | null>(null);
-  const [archiveLoading, setArchiveLoading] = useState(false);
-  const [archiveError, setArchiveError] = useState<string | null>(null);
-  const [archiveReloadToken, setArchiveReloadToken] = useState(0);
-  const modelOptions = useMemo(() => props.bridge.modelOptions ?? EMPTY_MODEL_OPTIONS, [props.bridge.modelOptions]);
-  const [selectedModelKey, setSelectedModelKey] = useState<string>(modelOptions[0]?.value ?? '');
-  const dailyReviewMountedRef = useMountedRef();
-  const summaryScopeKeyRef = useRef<string | null>(null);
-  const pendingDailyReviewActionRef = useRef<string | null>(null);
-  const archiveLoadRequestRef = useRef(0);
-  // PR-582-FOLLOWUP: bridge methods (fetchDay, listArchives, getArchive)
-  // are thin IPC wrappers that don't depend on the connections array.
-  // Track the latest bridge via ref so effects don't re-fire when the
-  // bridge object is recreated due to an unrelated connections change
-  // (e.g. updatedAt timestamp bump from a provider status refresh).
+  const mounted = useMountedRef();
   const bridgeRef = useRef(props.bridge);
   bridgeRef.current = props.bridge;
-  const currentSummaryScopeKey = dailyReviewScopeKey(offsetDays, range);
-  const visibleSummary = summaryScopeKey === currentSummaryScopeKey ? summary : null;
-  const canLoadArchives = Boolean(props.bridge.listArchives && props.bridge.getArchive);
 
-  useEffect(() => {
-    return () => {
-      pendingDailyReviewActionRef.current = null;
-      archiveLoadRequestRef.current += 1;
-    };
-  }, []);
+  const [range, setRange] = useState<DailyReviewRange>(1);
+  const [offsetDays, setOffsetDays] = useState(0);
+  const [summary, setSummary] = useState<DailyReviewSummary | null>(null);
+  const [summaryScopeKey, setSummaryScopeKey] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const [archives, setArchives] = useState<DailyReviewArchiveSummary[]>([]);
+  const [archivesReloadToken, setArchivesReloadToken] = useState(0);
+  const [route, setRoute] = useState<DailyReviewRoute>({ kind: 'activity' });
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
 
-  function chooseDailyReviewArchive(archiveId: string | null) {
-    archiveLoadRequestRef.current += 1;
-    setSelectedArchiveId(archiveId);
-    setSelectedArchive(null);
-    setArchiveLoading(Boolean(props.bridge.getArchive));
-    setArchiveError(null);
-  }
+  const scopeKey = dailyReviewScopeKey(offsetDays, range);
+  const visibleSummary = summaryScopeKey === scopeKey ? summary : null;
+  const currentArchive = useMemo(() => {
+    if (!visibleSummary) return null;
+    return archives.find((archive) =>
+      archive.range === range
+      && archive.day.fromMs === visibleSummary.day.fromMs
+      && archive.day.toMs === visibleSummary.day.toMs,
+    ) ?? null;
+  }, [archives, range, visibleSummary]);
 
   useEffect(() => {
     let cancelled = false;
-    const scopeKey = dailyReviewScopeKey(offsetDays, range);
+    const requestedScope = dailyReviewScopeKey(offsetDays, range);
     setLoading(true);
     setError(null);
-    bridgeRef.current
-      .fetchDay(offsetDays, range)
-      .then((next) => {
-        if (cancelled) return;
-        setSummary(next);
-        summaryScopeKeyRef.current = scopeKey;
-        setSummaryScopeKey(scopeKey);
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        if (summaryScopeKeyRef.current !== scopeKey) {
-          summaryScopeKeyRef.current = null;
-          setSummary(null);
-          setSummaryScopeKey(null);
-        }
-        setError(dailyReviewPanelErrorMessage(err, locale));
-        setLoading(false);
-      });
+    bridgeRef.current.fetchDay(offsetDays, range).then((next) => {
+      if (cancelled) return;
+      setSummary(next);
+      setSummaryScopeKey(requestedScope);
+      setLoading(false);
+    }).catch((nextError: unknown) => {
+      if (cancelled) return;
+      setSummary(null);
+      setSummaryScopeKey(null);
+      setError(dailyReviewPanelErrorMessage(nextError, locale));
+      setLoading(false);
+    });
     return () => {
       cancelled = true;
     };
@@ -152,568 +108,307 @@ export function DailyReviewPanel(props: {
     const listArchives = bridgeRef.current.listArchives;
     if (!listArchives) {
       setArchives([]);
-      setSelectedArchiveId(null);
-      setSelectedArchive(null);
       return;
     }
     let cancelled = false;
-    setArchiveError(null);
-    listArchives()
-      .then((next) => {
-        if (cancelled) return;
-        setArchives(next);
-        setSelectedArchiveId((current) => {
-          if (current && next.some((archive) => archive.id === current)) return current;
-          return next[0]?.id ?? null;
-        });
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setArchiveError(dailyReviewPanelErrorMessage(err, locale));
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [archiveReloadToken, locale]);
-
-  useEffect(() => {
-    const getArchive = bridgeRef.current.getArchive;
-    if (!getArchive || !selectedArchiveId) {
-      archiveLoadRequestRef.current += 1;
-      setSelectedArchive(null);
-      setArchiveLoading(false);
-      return;
-    }
-    let cancelled = false;
-    const archiveId = selectedArchiveId;
-    const archiveRequestId = ++archiveLoadRequestRef.current;
-    setSelectedArchive(null);
-    setArchiveLoading(true);
-    setArchiveError(null);
-    getArchive(archiveId)
-      .then((next) => {
-        if (cancelled) return;
-        if (archiveLoadRequestRef.current !== archiveRequestId) return;
-        setSelectedArchive(next);
-        setArchiveLoading(false);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        if (archiveLoadRequestRef.current !== archiveRequestId) return;
-        setSelectedArchive(null);
-        setArchiveError(dailyReviewPanelErrorMessage(err, locale));
-        setArchiveLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [archiveReloadToken, locale, selectedArchiveId]);
-
-  useEffect(() => {
-    if (modelOptions.length === 0) {
-      setSelectedModelKey('');
-      return;
-    }
-    setSelectedModelKey((current) => {
-      if (modelOptions.some((option) => option.value === current)) return current;
-      return modelOptions[0]?.value ?? '';
+    listArchives().then((next) => {
+      if (!cancelled) setArchives(next);
+    }).catch(() => {
+      if (!cancelled) setArchives([]);
     });
-  }, [modelOptions]);
+    return () => {
+      cancelled = true;
+    };
+  }, [archivesReloadToken]);
 
-  const dayLabel = (() => {
+  const rangeLabel = (() => {
     if (range === 1) {
       if (offsetDays === 0) return copy.date.today;
       if (offsetDays === -1) return copy.date.yesterday;
       return copy.date.daysAgo(-offsetDays);
     }
-    const rangeText = range === 7 ? copy.date.recent7Days : copy.date.recent30Days;
-    if (offsetDays === 0) return rangeText;
-    return copy.date.shiftedRange(rangeText, -offsetDays);
+    const base = range === 7 ? copy.date.recent7Days : copy.date.recent30Days;
+    return offsetDays === 0 ? base : copy.date.shiftedRange(base, -offsetDays);
   })();
 
-  // Stepper step matches the range size — for 7-day mode the user
-  // skips a whole week at a time, not a single day.
-  const stepperLabel = range === 1 ? copy.date.unit.day : range === 7 ? copy.date.unit.week : copy.date.unit.month;
-  // IA restructure: the 概览 section is ALWAYS rendered (honest zeros +
-  // this one inline hint) so a no-activity scope no longer collapses the
-  // page to a floating orphan line at the bottom. The hint absorbs the old
-  // bottom-of-page orphan into the 概览 header's flow. Copy keeps the endorsed
-  // waiting-state framing (等待记录今天活动 / 无活动 — visible-copy-hygiene).
-  const emptyOverviewTitle = offsetDays === 0 && range === 1
-    ? copy.emptyOverview.todayTitle
-    : copy.emptyOverview.rangeTitle(dayLabel);
-  const emptyOverviewBody = offsetDays === 0 && range === 1
-    ? copy.emptyOverview.todayBody
-    : copy.emptyOverview.rangeBody(dayLabel);
+  function changeRange(value: string) {
+    const next = Number(value) as DailyReviewRange;
+    if (!DAILY_REVIEW_RANGES.includes(next)) return;
+    setRange(next);
+    setOffsetDays(0);
+    setRoute({ kind: 'activity' });
+  }
 
-  async function runDailyReviewAction(actionKey: string, action: () => void | Promise<void>) {
-    if (pendingDailyReviewActionRef.current !== null) return;
-    pendingDailyReviewActionRef.current = actionKey;
-    setPendingDailyReviewAction(actionKey);
+  async function openArchive(summaryRow: DailyReviewArchiveSummary) {
+    const getArchive = props.bridge.getArchive;
+    if (!getArchive || pendingAction !== null) return;
+    setPendingAction('open');
     try {
-      await action();
+      const archive = await getArchive(summaryRow.id);
+      if (mounted.current) setRoute({ kind: 'report', archive });
+    } catch (nextError) {
+      if (mounted.current) setError(dailyReviewPanelErrorMessage(nextError, locale));
     } finally {
-      if (pendingDailyReviewActionRef.current === actionKey) {
-        pendingDailyReviewActionRef.current = null;
-        if (dailyReviewMountedRef.current) setPendingDailyReviewAction(null);
-      }
+      if (mounted.current) setPendingAction(null);
     }
   }
 
-  function isDailyReviewActionCurrent(actionKey: string): boolean {
-    return dailyReviewMountedRef.current && pendingDailyReviewActionRef.current === actionKey;
-  }
-
-  const dailyReviewActionBusy = pendingDailyReviewAction !== null;
-  const hasDailyReviewActions = Boolean(props.onCopyMarkdown || props.onAppendMarkdown || props.onSaveMarkdown);
-  const canManualRun = Boolean(props.bridge.runOnce);
-
-  async function triggerManualRun(mode: DailyReviewMode) {
+  async function generateAnalysis() {
     const runOnce = props.bridge.runOnce;
-    if (!runOnce) return;
-    const actionKey = `run:${mode}`;
-    await runDailyReviewAction(actionKey, async () => {
-      try {
-        const result = await runOnce({ mode, modelKey: selectedModelKey });
-        if (!isDailyReviewActionCurrent(actionKey)) return;
-        chooseDailyReviewArchive(result.archiveId);
-        setArchiveReloadToken((n) => n + 1);
-        setReloadToken((n) => n + 1);
-      } catch (err) {
-        if (isDailyReviewActionCurrent(actionKey)) setError(dailyReviewPanelErrorMessage(err, locale));
-      }
-    });
+    const getArchive = props.bridge.getArchive;
+    if (!runOnce || !getArchive || pendingAction !== null) return;
+    setPendingAction('generate');
+    setError(null);
+    try {
+      const result = await runOnce({ range, offsetDays });
+      const archive = await getArchive(result.archiveId);
+      if (!mounted.current) return;
+      setArchivesReloadToken((value) => value + 1);
+      setRoute({ kind: 'report', archive });
+    } catch (nextError) {
+      if (mounted.current) setError(dailyReviewPanelErrorMessage(nextError, locale));
+    } finally {
+      if (mounted.current) setPendingAction(null);
+    }
   }
 
-  // Export actions ride with the 概览 stats they serialize; the guard keeps
-  // them off an all-zero scope (nothing to export). Shape pinned by the
-  // daily-review-copy-feedback contract — do not restructure the condition.
-  const overviewActions =
-    visibleSummary && visibleSummary.totals.sessionCount + visibleSummary.totals.requestCount > 0 && hasDailyReviewActions ? (
-      <div className="maka-daily-review-actions" aria-label={copy.export.ariaLabel}>
-        {props.onCopyMarkdown && (
-          <UiButton
-            variant="secondary"
-            size="sm"
-            className="maka-daily-review-copy"
-            onClick={() => void runDailyReviewAction('copy', async () => {
-              const md = formatDailyReviewMarkdown(visibleSummary, dayLabel, locale);
-              await props.onCopyMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });
-            })}
-            isDisabled={dailyReviewActionBusy}
-            data-pending={pendingDailyReviewAction === 'copy' ? 'true' : undefined}
-            aria-busy={pendingDailyReviewAction === 'copy' ? 'true' : undefined}
-            tooltip={copy.export.copyTitle}
-            label={pendingDailyReviewAction === 'copy' ? copy.export.copying : copy.export.copy}
-          />
-        )}
-        {props.onAppendMarkdown && (
-          <UiButton
-            variant="secondary"
-            size="sm"
-            className="maka-daily-review-append"
-            onClick={() => void runDailyReviewAction('append', async () => {
-              const md = formatDailyReviewMarkdown(visibleSummary, dayLabel, locale);
-              await props.onAppendMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });
-            })}
-            isDisabled={dailyReviewActionBusy}
-            data-pending={pendingDailyReviewAction === 'append' ? 'true' : undefined}
-            aria-busy={pendingDailyReviewAction === 'append' ? 'true' : undefined}
-            tooltip={copy.export.appendTitle}
-            label={pendingDailyReviewAction === 'append' ? copy.export.appending : copy.export.append}
-          />
-        )}
-        {props.onSaveMarkdown && (
-          <UiButton
-            variant="secondary"
-            size="sm"
-            className="maka-daily-review-save"
-            onClick={() => void runDailyReviewAction('save', async () => {
-              const md = formatDailyReviewMarkdown(visibleSummary, dayLabel, locale);
-              await props.onSaveMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });
-            })}
-            isDisabled={dailyReviewActionBusy}
-            data-pending={pendingDailyReviewAction === 'save' ? 'true' : undefined}
-            aria-busy={pendingDailyReviewAction === 'save' ? 'true' : undefined}
-            tooltip={copy.export.saveTitle}
-            label={pendingDailyReviewAction === 'save' ? copy.export.saving : copy.export.save}
-          />
-        )}
-      </div>
-    ) : null;
+  if (route.kind === 'report') {
+    return (
+      <DailyReviewReport
+        archive={route.archive}
+        summary={visibleSummary}
+        onBack={() => setRoute({ kind: 'activity' })}
+        onCopyMarkdown={props.onCopyMarkdown}
+        onAppendMarkdown={props.onAppendMarkdown}
+        onSaveMarkdown={props.onSaveMarkdown}
+      />
+    );
+  }
+
+  const totals = visibleSummary?.totals;
+  const hasActivity = Boolean(totals && totals.sessionCount + totals.requestCount > 0);
+  const canAnalyze = Boolean(props.bridge.runOnce && props.bridge.getArchive);
 
   return (
-    <div className="maka-daily-review-panel" data-loading={loading ? 'true' : undefined}>
-      {/* IA redesign (owner: 每日回顾 页面很乱): the PageHeader is THE page
-          shell — title + subtitle, and the 生成 actions ride its actions slot
-          (same pattern as the skills page's 添加). The analysis-model select is
-          now a COMPACT generation option inside that same cluster, not a
-          page-wide row. */}
-      <PageHeader
-        className="maka-module-main-header"
-        as="h2"
-        title={props.hubHeader?.title ?? copy.page.title}
-        subtitle={props.hubHeader?.subtitle ?? copy.page.subtitle}
-        badge={props.hubHeader?.badge}
-        headingRowClassName={props.hubHeader ? 'maka-module-hub-heading' : undefined}
-        actions={canManualRun ? (
-          <div className="maka-daily-review-generate" role="group" aria-label={copy.page.generateAriaLabel}>
-            {modelOptions.length > 0 && (
-              <Selector
-                value={selectedModelKey}
-                label={copy.page.analysisModel}
-                isLabelHidden
-                options={modelOptions}
-                onChange={setSelectedModelKey}
-                isDisabled={dailyReviewActionBusy}
-                width={140}
-              />
-            )}
-            <UiButton
-              variant="primary"
-              size="sm"
-              className="maka-daily-review-quick-run"
-              onClick={() => void triggerManualRun('daily')}
-              isDisabled={dailyReviewActionBusy}
-              data-pending={pendingDailyReviewAction === 'run:daily' ? 'true' : undefined}
-              aria-busy={pendingDailyReviewAction === 'run:daily' ? 'true' : undefined}
-              label={pendingDailyReviewAction === 'run:daily' ? copy.page.generating : copy.page.generateDaily}
-            />
-            <UiButton
-              variant="secondary"
-              size="sm"
-              className="maka-daily-review-quick-run"
-              onClick={() => void triggerManualRun('deep')}
-              isDisabled={dailyReviewActionBusy}
-              data-pending={pendingDailyReviewAction === 'run:deep' ? 'true' : undefined}
-              aria-busy={pendingDailyReviewAction === 'run:deep' ? 'true' : undefined}
-              label={pendingDailyReviewAction === 'run:deep' ? copy.page.generating : copy.page.generateDeep}
-            />
-          </div>
-        ) : undefined}
-      />
-
-      {/* One time-scope row directly under the header: the 今日/本周/本月
-          segmented + the day-stepper are BOTH time navigation, so they form a
-          single visual cluster (was two floating rows at opposite corners). */}
-      <div className="maka-daily-review-scope" aria-label={copy.page.timeRange}>
+    <VStack className="maka-daily-review-panel" gap={5} data-loading={loading ? 'true' : undefined}>
+      <HStack gap={4} vAlign="start" wrap="wrap">
+        <StackItem size="fill">
+          <VStack gap={1}>
+            <HStack gap={2} vAlign="center" wrap="wrap" className={props.hubHeader ? 'maka-module-hub-heading' : undefined}>
+              <Heading level={2}>{props.hubHeader?.title ?? copy.page.title}</Heading>
+              {props.hubHeader?.badge}
+            </HStack>
+          </VStack>
+        </StackItem>
         <SegmentedControl
           value={String(range)}
-          onChange={(v) => {
-            setRange(Number(v) as DailyReviewRange);
-            setOffsetDays(0);
-          }}
+          onChange={changeRange}
           label={copy.page.rangeSwitch}
-          className="maka-daily-review-range-tabs"
+          size="sm"
         >
           {copy.page.rangeOptions.map(([value, label]) => (
             <SegmentedControlItem key={value} value={value} label={label} />
           ))}
         </SegmentedControl>
-        <div className="maka-daily-review-scope-stepper">
-          <IconButton
-            variant="ghost"
-            size="sm"
-            className="maka-daily-review-stepper"
-            onClick={() => setOffsetDays((n) => n - range)}
-            label={copy.date.earlier(stepperLabel)}
-            icon={<ChevronLeft aria-hidden="true" />}
-          />
-          <div className="maka-daily-review-day">{dayLabel}</div>
-          <IconButton
-            variant="ghost"
-            size="sm"
-            className="maka-daily-review-stepper"
-            onClick={() => setOffsetDays((n) => Math.min(0, n + range))}
-            isDisabled={offsetDays >= 0}
-            label={copy.date.later(stepperLabel)}
-            icon={<ChevronRight aria-hidden="true" />}
-          />
-        </div>
-      </div>
+      </HStack>
 
-      {/* 概览 — ALWAYS rendered for the selected scope. Honest zeros + one
-          inline hint replace the old bottom orphan line, so a no-activity
-          scope no longer collapses the page to nothing. */}
-      <section className="maka-daily-review-overview" aria-label={copy.overview.ariaLabel(dayLabel)}>
-        <SectionHeader as="h4" accent title={copy.overview.title} action={overviewActions} />
-        {error && visibleSummary ? (
-          <Banner
-            status="warning"
-            className="maka-daily-review-alert"
-            title={copy.overview.refreshFailed(error)}
-            endContent={<UiButton
-                variant="ghost"
-                size="sm"
-                className="maka-daily-review-alert-retry"
-                onClick={() => setReloadToken((n) => n + 1)}
-                isDisabled={loading}
-                label={copy.overview.retry}
-              />}
+      <HStack className="maka-daily-review-toolbar" gap={2} vAlign="center" wrap="wrap" role="toolbar" aria-label={copy.page.timeRange}>
+        <Button
+          variant="ghost"
+          size="sm"
+          isIconOnly
+          icon={<ChevronLeft />}
+          label={copy.date.earlier(range === 1 ? copy.date.unit.day : range === 7 ? copy.date.unit.week : copy.date.unit.month)}
+          onClick={() => setOffsetDays((value) => value - range)}
+        />
+        <Text type="label" weight="semibold" className="maka-daily-review-range-label">{rangeLabel}</Text>
+        <Button
+          variant="ghost"
+          size="sm"
+          isIconOnly
+          icon={<ChevronRight />}
+          label={copy.date.later(range === 1 ? copy.date.unit.day : range === 7 ? copy.date.unit.week : copy.date.unit.month)}
+          isDisabled={offsetDays >= 0}
+          onClick={() => setOffsetDays((value) => Math.min(0, value + range))}
+        />
+        <StackItem size="fill" />
+        {currentArchive ? (
+          <Button
+            variant="primary"
+            size="sm"
+            label={copy.page.viewAnalysis}
+            isLoading={pendingAction === 'open'}
+            isDisabled={pendingAction !== null}
+            onClick={() => void openArchive(currentArchive)}
+          />
+        ) : canAnalyze ? (
+          <Button
+            variant="primary"
+            size="sm"
+            label={copy.page.generateAnalysis}
+            isLoading={pendingAction === 'generate'}
+            isDisabled={pendingAction !== null || !visibleSummary || !hasActivity}
+            onClick={() => void generateAnalysis()}
           />
         ) : null}
+      </HStack>
 
-        {error && !visibleSummary ? (
-          <EmptyState
-            icon={<CalendarDays />}
-            title={copy.overview.readFailed}
-            description={error}
-            actions={<UiButton variant="primary" label={copy.overview.retry} onClick={() => setReloadToken((n) => n + 1)} />}
-            className="maka-daily-review-summary-empty"
-          />
-        ) : !visibleSummary ? (
-          <div className="maka-daily-review-loading" aria-busy="true">
-            <Skeleton width="60%" height={12} radius="rounded" index={0} />
-            <Skeleton width="90%" height={12} radius="rounded" index={1} />
-            <Skeleton width="75%" height={12} radius="rounded" index={2} />
+      <Divider />
+
+      {error ? (
+        <Banner
+          status="warning"
+          title={copy.overview.refreshFailed(error)}
+          endContent={<Button variant="ghost" size="sm" label={copy.overview.retry} onClick={() => setReloadToken((value) => value + 1)} />}
+        />
+      ) : null}
+
+      {loading || !visibleSummary ? (
+        <VStack gap={3} aria-busy="true">
+          <Skeleton width="100%" height={64} radius="rounded" index={0} />
+          <Skeleton width="100%" height={48} radius="rounded" index={1} />
+          <Skeleton width="100%" height={48} radius="rounded" index={2} />
+        </VStack>
+      ) : (
+        <>
+          <div className="maka-daily-review-metrics" aria-label={copy.overview.ariaLabel(rangeLabel)}>
+            <DailyReviewMetric label={copy.overview.conversations} value={totals?.sessionCount.toString() ?? '0'} />
+            <DailyReviewMetric label={copy.overview.requests} value={totals?.requestCount.toString() ?? '0'} />
+            <DailyReviewMetric label={copy.overview.tokens} value={(totals?.totalTokens ?? 0).toLocaleString(intlLocale)} />
+            <DailyReviewMetric label={copy.overview.cost} value={`$${(totals?.costUsd ?? 0).toFixed(2)}`} />
+            {(totals?.errorCount ?? 0) > 0 ? (
+              <DailyReviewMetric label={copy.overview.errors} value={totals!.errorCount.toString()} tone="error" />
+            ) : null}
           </div>
-        ) : (
-          <>
-            <div className="maka-daily-review-totals">
-              <DailyReviewTotalsCell label={copy.overview.conversations} value={visibleSummary.totals.sessionCount.toString()} />
-              <DailyReviewTotalsCell label={copy.overview.requests} value={visibleSummary.totals.requestCount.toString()} />
-              <DailyReviewTotalsCell
-                label={copy.overview.tokens}
-                value={visibleSummary.totals.totalTokens.toLocaleString(intlLocale)}
-              />
-              <DailyReviewTotalsCell
-                label={copy.overview.cost}
-                value={`$${visibleSummary.totals.costUsd.toFixed(2)}`}
-              />
-              {visibleSummary.totals.errorCount > 0 && (
-                <DailyReviewTotalsCell
-                  label={copy.overview.errors}
-                  value={visibleSummary.totals.errorCount.toString()}
-                  tone="error"
-                />
-              )}
-            </div>
 
-            {visibleSummary.totals.sessionCount === 0 && visibleSummary.totals.requestCount === 0 ? (
-              <p className="maka-daily-review-inline-empty">{emptyOverviewTitle} · {emptyOverviewBody}</p>
+          <VStack gap={2}>
+            <Heading level={3}>{copy.overview.activeConversations}</Heading>
+            {visibleSummary.sessions.length > 0 ? (
+              <List density="balanced" hasDividers>
+                {visibleSummary.sessions.map((session) => (
+                  <ListItem
+                    key={session.id}
+                    label={session.name}
+                    description={session.lastMessagePreview}
+                    endContent={<RelativeTime ts={session.lastMessageAt} />}
+                    onClick={props.onSelectSession ? () => props.onSelectSession?.(session.id) : undefined}
+                  />
+                ))}
+              </List>
             ) : (
-              <>
-                {visibleSummary.sessions.length > 0 && (
-                  <section className="maka-daily-review-section" aria-label={copy.overview.activeConversations}>
-                    <SectionHeader as="h4" accent title={copy.overview.activeConversations} />
-                    <ul className="maka-daily-review-list" aria-label={copy.overview.activeConversationList}>
-                      {visibleSummary.sessions.map((session) => (
-                        <li key={session.id}>
-                          <Item
-                            density="compact"
-                            onClick={() => props.onSelectSession?.(session.id)}
-                            isDisabled={!props.onSelectSession}
-                            label={<span className="maka-daily-review-session-name">{session.name}</span>}
-                            description={session.lastMessagePreview ? (
-                              <span className="maka-daily-review-session-preview">
-                                {session.lastMessagePreview}
-                              </span>
-                            ) : undefined}
-                            endContent={<RelativeTime
-                              ts={session.lastMessageAt}
-                              className="maka-daily-review-session-time"
-                            />}
-                          />
-                        </li>
-                      ))}
-                    </ul>
-                  </section>
-                )}
-
-                {visibleSummary.topModels.length > 0 && (
-                  <DailyReviewTopList title={copy.overview.modelUsage} entries={visibleSummary.topModels} />
-                )}
-
-                {visibleSummary.topTools.length > 0 && (
-                  <DailyReviewTopList title={copy.overview.toolCalls} entries={visibleSummary.topTools} />
-                )}
-              </>
+              <EmptyState
+                icon={<CalendarDays />}
+                title={offsetDays === 0 && range === 1 ? copy.emptyOverview.todayTitle : copy.emptyOverview.rangeTitle(rangeLabel)}
+                description={offsetDays === 0 && range === 1 ? copy.emptyOverview.todayBody : copy.emptyOverview.rangeBody(rangeLabel)}
+              />
             )}
-          </>
-        )}
-      </section>
-
-      {/* 报告 — stacked, newest-first. Each report is a full-width surface
-          whose meta header (date · 模式 · N 对话 · 触发+时间 · 模型) is always
-          visible; the selected one expands its four content sections below.
-          This replaces the broken left-list / right-body master-detail that
-          left the list column half-empty. Body loads stay single-selection
-          (getArchive) — the archive-body-load contract pins that lazy path. */}
-      {canLoadArchives && (
-        <section className="maka-daily-review-reports" aria-label={copy.reports.title}>
-          <SectionHeader
-            as="h4"
-            accent
-            title={copy.reports.title}
-            count={<span className="maka-daily-review-archive-count">{copy.reports.count(archives.length)}</span>}
-          />
-          {archiveError && (
-            <Banner
-              status="warning"
-              className="maka-daily-review-alert"
-              title={copy.reports.readFailed(archiveError)}
-              endContent={<UiButton
-                  variant="ghost"
-                  size="sm"
-                  className="maka-daily-review-alert-retry"
-                  onClick={() => setArchiveReloadToken((n) => n + 1)}
-                  isDisabled={archiveLoading}
-                  label={copy.overview.retry}
-                />}
-            />
-          )}
-          {archives.length === 0 && !archiveError ? (
-            <EmptyState
-              icon={<CalendarDays />}
-              title={copy.reports.emptyTitle}
-              description={copy.reports.emptyBody}
-              actions={canManualRun ? <UiButton variant="primary" label={copy.page.generateDaily} onClick={() => void triggerManualRun('daily')} isDisabled={dailyReviewActionBusy} /> : undefined}
-              className="maka-daily-review-summary-empty"
-            />
-          ) : (
-            <CollapsibleGroup
-              type="single"
-              value={selectedArchiveId ?? ''}
-              onChange={(value) => chooseDailyReviewArchive(typeof value === 'string' && value ? value : null)}
-              hasDividers
-              density="balanced"
-              role="list"
-              aria-label={copy.reports.historyAriaLabel}
-            >
-              {archives.map((archive) => {
-                // Status color is exception-only (#651): 已生成 / 无数据 / 已跳过
-                // are EXPECTED outcomes and stay as muted prose meta. Only a
-                // failed / no_model run raises a colored Badge that needs eyes.
-                const exceptional = archive.status === 'failed' || archive.status === 'no_model';
-                const meta = [
-                  copy.archive.sessionCount(archive.totals.sessionCount),
-                  copy.archive.generated(copy.archive.trigger[archive.trigger], formatDailyReviewArchiveGeneratedAt(archive.generatedAt, locale)),
-                  archive.modelKey ? formatDailyReviewModelLabel(archive.modelKey) : copy.archive.defaultModel,
-                ].join(' · ');
-                return (
-                  <Collapsible
-                    key={archive.id}
-                    value={archive.id}
-                    role="listitem"
-                    trigger={(
-                      <span className="maka-daily-review-report-trigger">
-                        <span className="maka-daily-review-report-heading">
-                          <span className="maka-daily-review-report-title">
-                            {formatDailyReviewArchiveTitle(archive, locale)}
-                          </span>
-                          <span className="maka-daily-review-archive-row-meta">{meta}</span>
-                        </span>
-                        {exceptional && (
-                          <Badge
-                            variant={dailyReviewArchiveBadgeVariant(archive.status)}
-                            className="maka-daily-review-report-status"
-                            data-status={archive.status}
-                            label={copy.archive.status[archive.status]}
-                          />
-                        )}
-                      </span>
-                    )}
-                  >
-                    <DailyReviewArchiveBody archive={selectedArchive} loading={archiveLoading} />
-                  </Collapsible>
-                );
-              })}
-            </CollapsibleGroup>
-          )}
-        </section>
+          </VStack>
+        </>
       )}
-    </div>
+    </VStack>
   );
 }
 
-function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loading: boolean }) {
+function DailyReviewMetric(props: { label: string; value: string; tone?: 'error' }) {
+  return (
+    <VStack className="maka-daily-review-metric" gap={0} data-tone={props.tone}>
+      <Text type="supporting" color="secondary">{props.label}</Text>
+      <Text type="large" weight="semibold">{props.value}</Text>
+    </VStack>
+  );
+}
+
+function DailyReviewReport(props: {
+  archive: DailyReviewArchive;
+  summary: DailyReviewSummary | null;
+  onBack(): void;
+  onCopyMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
+  onAppendMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
+  onSaveMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
+}) {
   const locale = useUiLocale();
   const copy = getDailyReviewCopy(locale);
-  if (props.loading) {
-    return (
-      <div className="maka-daily-review-report-body" aria-busy="true">
-        <Skeleton width="58%" height={12} radius="rounded" index={0} />
-        <Skeleton width="92%" height={12} radius="rounded" index={1} />
-        <Skeleton width="74%" height={12} radius="rounded" index={2} />
-      </div>
-    );
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const title = formatDailyReviewArchiveTitle(props.archive, locale);
+  const sections = reportSections(props.archive.sections);
+  const markdown = formatArchiveMarkdown(title, sections, copy.archive.section);
+  const meta = [
+    formatDailyReviewArchiveGeneratedAt(props.archive.generatedAt, locale),
+    props.archive.modelKey ? formatDailyReviewModelLabel(props.archive.modelKey) : copy.archive.defaultModel,
+  ].join(' · ');
+
+  async function runAction(key: string, action: (() => Promise<void> | void) | undefined) {
+    if (!action || pendingAction !== null) return;
+    setPendingAction(key);
+    try {
+      await action();
+    } finally {
+      setPendingAction(null);
+    }
   }
-  if (!props.archive) {
-    return (
-      <div className="maka-daily-review-report-body maka-daily-review-archive-empty">
-        {copy.archive.opening}
-      </div>
-    );
-  }
-  const archive = props.archive;
-  const sections = (Object.keys(copy.archive.section) as DailyReviewArchiveSectionKey[])
-    .map((key) => {
-      const content = archive.sections[key]?.trim();
-      return content ? { key, content } : null;
-    })
-    .filter((entry): entry is { key: DailyReviewArchiveSectionKey; content: string } => entry !== null);
-  // The report's date / 模式 / 触发 / 时间 / 模型 meta now lives in the surface
-  // head above this body (no repeated header, no 已生成 status chip on the
-  // expected state) — the body carries only the report substance.
+
+  const actionInput = props.summary ? { markdown, label: title, summary: props.summary } : null;
   return (
-    <div className="maka-daily-review-report-body" aria-label={formatDailyReviewArchiveTitle(archive, locale)}>
-      {archive.errorMessage && (
-        <p className="maka-daily-review-archive-error">{archive.errorMessage}</p>
-      )}
+    <VStack className="maka-daily-review-panel maka-daily-review-report" gap={5}>
+      <HStack gap={2} vAlign="center" wrap="wrap">
+        <Button variant="ghost" size="sm" icon={<ArrowLeft />} label={copy.page.backToActivity} onClick={props.onBack} />
+        <StackItem size="fill" />
+        {actionInput && props.onCopyMarkdown ? (
+          <Button variant="secondary" size="sm" label={pendingAction === 'copy' ? copy.export.copying : copy.export.copy} isDisabled={pendingAction !== null} onClick={() => void runAction('copy', () => props.onCopyMarkdown?.(actionInput))} />
+        ) : null}
+        {actionInput && props.onAppendMarkdown ? (
+          <Button variant="secondary" size="sm" label={pendingAction === 'append' ? copy.export.appending : copy.export.append} isDisabled={pendingAction !== null} onClick={() => void runAction('append', () => props.onAppendMarkdown?.(actionInput))} />
+        ) : null}
+        {actionInput && props.onSaveMarkdown ? (
+          <Button variant="secondary" size="sm" label={pendingAction === 'save' ? copy.export.saving : copy.export.save} isDisabled={pendingAction !== null} onClick={() => void runAction('save', () => props.onSaveMarkdown?.(actionInput))} />
+        ) : null}
+      </HStack>
+      <VStack gap={1}>
+        <Heading level={2}>{title}</Heading>
+        <Text type="supporting" color="secondary">{meta}</Text>
+      </VStack>
+      {props.archive.status !== 'ok' ? (
+        <Banner
+          status={props.archive.status === 'failed' || props.archive.status === 'no_model' ? 'error' : 'info'}
+          title={copy.archive.status[props.archive.status]}
+          description={props.archive.errorMessage}
+        />
+      ) : null}
+      <Divider />
       {sections.length > 0 ? (
-        <div className="maka-daily-review-archive-sections">
-          {sections.map((section) => (
-            <section key={section.key} className="maka-daily-review-archive-section">
-              <SectionHeader as="h4" accent title={copy.archive.section[section.key]} />
-              {/* Reports are LLM-generated markdown — bullet lists and
-                  inline code rendered as flat pre-wrap text read as mush.
-                  Reuse the shared Markdown pipeline (same one chat uses). */}
-              <div className="maka-daily-review-archive-section-body">
+        <VStack gap={6}>
+          {sections.map((section, index) => (
+            <VStack key={section.key} gap={2}>
+              {index > 0 ? <Divider /> : null}
+              <Heading level={3}>{copy.archive.section[section.key]}</Heading>
+              <div className="maka-daily-review-report-prose">
                 <Markdown text={section.content} />
               </div>
-            </section>
+            </VStack>
           ))}
-        </div>
+        </VStack>
       ) : (
-        <p className="maka-daily-review-archive-empty">
-          {copy.archive.noContent}
-        </p>
+        <EmptyState title={copy.archive.noContent} />
       )}
-    </div>
+    </VStack>
   );
 }
 
-function DailyReviewTotalsCell(props: { label: string; value: string; tone?: 'error' }) {
-  // Convergence R4: shared StatTile, filled emphasis; the error tone maps
-  // to the primitive's destructive ink + this cell's tinted wash (CSS).
-  return (
-    <StatTile
-      className="maka-daily-review-totals-cell"
-      emphasis="filled"
-      label={props.label}
-      value={props.value}
-      tone={props.tone === 'error' ? 'destructive' : 'neutral'}
-    />
-  );
+function reportSections(sections: DailyReviewArchiveSectionContent): Array<{
+  key: DailyReviewSectionKey;
+  content: string;
+}> {
+  const keys: DailyReviewSectionKey[] = ['summary', 'gaps', 'usage', 'code'];
+  return keys.flatMap((key) => {
+    const content = sections[key]?.trim();
+    return content ? [{ key, content }] : [];
+  });
 }
 
-function DailyReviewTopList(props: { title: string; entries: ReadonlyArray<DailyReviewTopEntry> }) {
-  const locale = useUiLocale();
-  const copy = getDailyReviewCopy(locale);
-  return (
-    <section className="maka-daily-review-section" aria-label={props.title}>
-      <SectionHeader as="h4" accent title={props.title} />
-      <ul className="maka-daily-review-list" aria-label={copy.list.ariaLabel(props.title)}>
-        {props.entries.map((entry) => (
-          <li key={entry.key} className="maka-daily-review-list-item">
-            <span className="maka-daily-review-top-label">{entry.label}</span>
-            <span className="maka-daily-review-top-meta">
-              {copy.list.requestCount(entry.requests)} · {entry.totalTokens.toLocaleString(uiLocaleToIntlLocale(locale))} tok
-              {entry.costUsd > 0 ? ` · $${entry.costUsd.toFixed(2)}` : ''}
-            </span>
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
+function formatArchiveMarkdown(
+  title: string,
+  sections: ReadonlyArray<{ key: DailyReviewSectionKey; content: string }>,
+  labels: Record<DailyReviewSectionKey, string>,
+): string {
+  return [`# ${title}`, ...sections.flatMap((section) => ['', `## ${labels[section.key]}`, section.content])].join('\n');
 }

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import type {
   DailyReviewArchive,
   DailyReviewArchiveSectionContent,
@@ -39,6 +39,11 @@ import { Markdown } from './markdown.js';
 import { RelativeTime } from './relative-time.js';
 import { useUiLocale } from './locale-context.js';
 import { useMountedRef } from './use-mounted-ref.js';
+import {
+  createDailyReviewActivityState,
+  dailyReviewActivityReducer,
+  type DailyReviewScope,
+} from './daily-review-view-state.js';
 
 type DailyReviewRoute =
   | { kind: 'activity' }
@@ -59,20 +64,25 @@ export function DailyReviewPanel(props: {
   const bridgeRef = useRef(props.bridge);
   bridgeRef.current = props.bridge;
 
-  const [range, setRange] = useState<DailyReviewRange>(1);
-  const [offsetDays, setOffsetDays] = useState(0);
-  const [summary, setSummary] = useState<DailyReviewSummary | null>(null);
-  const [summaryScopeKey, setSummaryScopeKey] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [activityState, dispatchActivity] = useReducer(
+    dailyReviewActivityReducer,
+    { range: 1, offsetDays: 0 },
+    createDailyReviewActivityState,
+  );
   const [reloadToken, setReloadToken] = useState(0);
   const [archives, setArchives] = useState<DailyReviewArchiveSummary[]>([]);
   const [archivesReloadToken, setArchivesReloadToken] = useState(0);
   const [route, setRoute] = useState<DailyReviewRoute>({ kind: 'activity' });
   const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
+  const { range, offsetDays } = activityState.selection;
   const scopeKey = dailyReviewScopeKey(offsetDays, range);
-  const visibleSummary = summaryScopeKey === scopeKey ? summary : null;
+  const resolvedView = activityState.resolvedView;
+  const displayedSummary = resolvedView?.summary ?? null;
+  const visibleSummary = resolvedView?.scopeKey === scopeKey ? resolvedView.summary : null;
+  const loading = activityState.pendingScopeKey !== null;
+  const error = actionError ?? activityState.error;
   const currentArchive = useMemo(() => {
     if (!visibleSummary) return null;
     return archives.find((archive) =>
@@ -84,20 +94,18 @@ export function DailyReviewPanel(props: {
 
   useEffect(() => {
     let cancelled = false;
-    const requestedScope = dailyReviewScopeKey(offsetDays, range);
-    setLoading(true);
-    setError(null);
+    const requestedScope = { range, offsetDays };
+    dispatchActivity({ type: 'selected', scope: requestedScope });
     bridgeRef.current.fetchDay(offsetDays, range).then((next) => {
       if (cancelled) return;
-      setSummary(next);
-      setSummaryScopeKey(requestedScope);
-      setLoading(false);
+      dispatchActivity({ type: 'resolved', scope: requestedScope, summary: next });
     }).catch((nextError: unknown) => {
       if (cancelled) return;
-      setSummary(null);
-      setSummaryScopeKey(null);
-      setError(dailyReviewPanelErrorMessage(nextError, locale));
-      setLoading(false);
+      dispatchActivity({
+        type: 'rejected',
+        scope: requestedScope,
+        error: dailyReviewPanelErrorMessage(nextError, locale),
+      });
     });
     return () => {
       cancelled = true;
@@ -121,22 +129,29 @@ export function DailyReviewPanel(props: {
     };
   }, [archivesReloadToken]);
 
-  const rangeLabel = (() => {
-    if (range === 1) {
-      if (offsetDays === 0) return copy.date.today;
-      if (offsetDays === -1) return copy.date.yesterday;
-      return copy.date.daysAgo(-offsetDays);
+  const rangeLabel = formatScopeLabel(activityState.selection);
+  const displayedRangeLabel = resolvedView ? formatScopeLabel(resolvedView.scope) : rangeLabel;
+
+  function formatScopeLabel(scope: DailyReviewScope): string {
+    if (scope.range === 1) {
+      if (scope.offsetDays === 0) return copy.date.today;
+      if (scope.offsetDays === -1) return copy.date.yesterday;
+      return copy.date.daysAgo(-scope.offsetDays);
     }
-    const base = range === 7 ? copy.date.recent7Days : copy.date.recent30Days;
-    return offsetDays === 0 ? base : copy.date.shiftedRange(base, -offsetDays);
-  })();
+    const base = scope.range === 7 ? copy.date.recent7Days : copy.date.recent30Days;
+    return scope.offsetDays === 0 ? base : copy.date.shiftedRange(base, -scope.offsetDays);
+  }
+
+  function selectScope(scope: DailyReviewScope) {
+    setActionError(null);
+    dispatchActivity({ type: 'selected', scope });
+    setRoute({ kind: 'activity' });
+  }
 
   function changeRange(value: string) {
     const next = Number(value) as DailyReviewRange;
     if (!DAILY_REVIEW_RANGES.includes(next)) return;
-    setRange(next);
-    setOffsetDays(0);
-    setRoute({ kind: 'activity' });
+    selectScope({ range: next, offsetDays: 0 });
   }
 
   async function openArchive(summaryRow: DailyReviewArchiveSummary) {
@@ -147,7 +162,7 @@ export function DailyReviewPanel(props: {
       const archive = await getArchive(summaryRow.id);
       if (mounted.current) setRoute({ kind: 'report', archive });
     } catch (nextError) {
-      if (mounted.current) setError(dailyReviewPanelErrorMessage(nextError, locale));
+      if (mounted.current) setActionError(dailyReviewPanelErrorMessage(nextError, locale));
     } finally {
       if (mounted.current) setPendingAction(null);
     }
@@ -158,7 +173,7 @@ export function DailyReviewPanel(props: {
     const getArchive = props.bridge.getArchive;
     if (!runOnce || !getArchive || pendingAction !== null) return;
     setPendingAction('generate');
-    setError(null);
+    setActionError(null);
     try {
       const result = await runOnce({ range, offsetDays });
       const archive = await getArchive(result.archiveId);
@@ -166,7 +181,7 @@ export function DailyReviewPanel(props: {
       setArchivesReloadToken((value) => value + 1);
       setRoute({ kind: 'report', archive });
     } catch (nextError) {
-      if (mounted.current) setError(dailyReviewPanelErrorMessage(nextError, locale));
+      if (mounted.current) setActionError(dailyReviewPanelErrorMessage(nextError, locale));
     } finally {
       if (mounted.current) setPendingAction(null);
     }
@@ -174,23 +189,30 @@ export function DailyReviewPanel(props: {
 
   if (route.kind === 'report') {
     return (
-      <DailyReviewReport
-        archive={route.archive}
-        summary={visibleSummary}
-        onBack={() => setRoute({ kind: 'activity' })}
-        onCopyMarkdown={props.onCopyMarkdown}
-        onAppendMarkdown={props.onAppendMarkdown}
-        onSaveMarkdown={props.onSaveMarkdown}
-      />
+      <VStack className="maka-daily-review-panel" gap={5}>
+        <div key="report" className="maka-daily-review-route-frame">
+          <DailyReviewReport
+            archive={route.archive}
+            summary={visibleSummary}
+            onBack={() => setRoute({ kind: 'activity' })}
+            onCopyMarkdown={props.onCopyMarkdown}
+            onAppendMarkdown={props.onAppendMarkdown}
+            onSaveMarkdown={props.onSaveMarkdown}
+          />
+        </div>
+      </VStack>
     );
   }
 
-  const totals = visibleSummary?.totals;
-  const hasActivity = Boolean(totals && totals.sessionCount + totals.requestCount > 0);
+  const totals = displayedSummary?.totals;
+  const currentTotals = visibleSummary?.totals;
+  const hasActivity = Boolean(currentTotals && currentTotals.sessionCount + currentTotals.requestCount > 0);
   const canAnalyze = Boolean(props.bridge.runOnce && props.bridge.getArchive);
 
   return (
-    <VStack className="maka-daily-review-panel" gap={5} data-loading={loading ? 'true' : undefined}>
+    <VStack className="maka-daily-review-panel" gap={5}>
+      <div key="activity" className="maka-daily-review-route-frame">
+      <VStack gap={5} data-loading={loading ? 'true' : undefined}>
       <HStack gap={4} vAlign="start" wrap="wrap">
         <StackItem size="fill">
           <VStack gap={1}>
@@ -219,7 +241,7 @@ export function DailyReviewPanel(props: {
           isIconOnly
           icon={<ChevronLeft />}
           label={copy.date.earlier(range === 1 ? copy.date.unit.day : range === 7 ? copy.date.unit.week : copy.date.unit.month)}
-          onClick={() => setOffsetDays((value) => value - range)}
+          onClick={() => selectScope({ range, offsetDays: offsetDays - range })}
         />
         <Text type="label" weight="semibold" className="maka-daily-review-range-label">{rangeLabel}</Text>
         <Button
@@ -229,7 +251,7 @@ export function DailyReviewPanel(props: {
           icon={<ChevronRight />}
           label={copy.date.later(range === 1 ? copy.date.unit.day : range === 7 ? copy.date.unit.week : copy.date.unit.month)}
           isDisabled={offsetDays >= 0}
-          onClick={() => setOffsetDays((value) => Math.min(0, value + range))}
+          onClick={() => selectScope({ range, offsetDays: Math.min(0, offsetDays + range) })}
         />
         <StackItem size="fill" />
         {currentArchive ? (
@@ -259,19 +281,33 @@ export function DailyReviewPanel(props: {
         <Banner
           status="warning"
           title={copy.overview.refreshFailed(error)}
-          endContent={<Button variant="ghost" size="sm" label={copy.overview.retry} onClick={() => setReloadToken((value) => value + 1)} />}
+          endContent={<Button
+            variant="ghost"
+            size="sm"
+            label={copy.overview.retry}
+            onClick={() => {
+              setActionError(null);
+              dispatchActivity({ type: 'selected', scope: activityState.selection });
+              setReloadToken((value) => value + 1);
+            }}
+          />}
         />
       ) : null}
 
-      {loading || !visibleSummary ? (
+      {!displayedSummary ? (
         <VStack gap={3} aria-busy="true">
           <Skeleton width="100%" height={64} radius="rounded" index={0} />
           <Skeleton width="100%" height={48} radius="rounded" index={1} />
           <Skeleton width="100%" height={48} radius="rounded" index={2} />
         </VStack>
       ) : (
-        <>
-          <div className="maka-daily-review-metrics" aria-label={copy.overview.ariaLabel(rangeLabel)}>
+        <div
+          key={resolvedView?.scopeKey}
+          className="maka-daily-review-content"
+          aria-busy={loading}
+          data-refreshing={loading ? 'true' : undefined}
+        >
+          <div className="maka-daily-review-metrics" aria-label={copy.overview.ariaLabel(displayedRangeLabel)}>
             <DailyReviewMetric label={copy.overview.conversations} value={totals?.sessionCount.toString() ?? '0'} />
             <DailyReviewMetric label={copy.overview.requests} value={totals?.requestCount.toString() ?? '0'} />
             <DailyReviewMetric label={copy.overview.tokens} value={(totals?.totalTokens ?? 0).toLocaleString(intlLocale)} />
@@ -283,9 +319,9 @@ export function DailyReviewPanel(props: {
 
           <VStack gap={2}>
             <Heading level={3}>{copy.overview.activeConversations}</Heading>
-            {visibleSummary.sessions.length > 0 ? (
+            {displayedSummary.sessions.length > 0 ? (
               <List density="balanced" hasDividers>
-                {visibleSummary.sessions.map((session) => (
+                {displayedSummary.sessions.map((session) => (
                   <ListItem
                     key={session.id}
                     label={session.name}
@@ -298,13 +334,15 @@ export function DailyReviewPanel(props: {
             ) : (
               <EmptyState
                 icon={<CalendarDays />}
-                title={offsetDays === 0 && range === 1 ? copy.emptyOverview.todayTitle : copy.emptyOverview.rangeTitle(rangeLabel)}
-                description={offsetDays === 0 && range === 1 ? copy.emptyOverview.todayBody : copy.emptyOverview.rangeBody(rangeLabel)}
+                title={resolvedView?.scope.offsetDays === 0 && resolvedView.scope.range === 1 ? copy.emptyOverview.todayTitle : copy.emptyOverview.rangeTitle(displayedRangeLabel)}
+                description={resolvedView?.scope.offsetDays === 0 && resolvedView.scope.range === 1 ? copy.emptyOverview.todayBody : copy.emptyOverview.rangeBody(displayedRangeLabel)}
               />
             )}
           </VStack>
-        </>
+        </div>
       )}
+      </VStack>
+      </div>
     </VStack>
   );
 }
@@ -349,7 +387,7 @@ function DailyReviewReport(props: {
 
   const actionInput = props.summary ? { markdown, label: title, summary: props.summary } : null;
   return (
-    <VStack className="maka-daily-review-panel maka-daily-review-report" gap={5}>
+    <VStack className="maka-daily-review-report" gap={5}>
       <HStack gap={2} vAlign="center" wrap="wrap">
         <Button variant="ghost" size="sm" icon={<ArrowLeft />} label={copy.page.backToActivity} onClick={props.onBack} />
         <StackItem size="fill" />

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -207,7 +207,6 @@ export function DailyReviewPanel(props: {
         <div key="report" className="maka-daily-review-route-frame">
           <DailyReviewReport
             archive={route.archive}
-            summary={visibleSummary}
             onBack={() => setRoute({ kind: 'activity' })}
             onCopyMarkdown={props.onCopyMarkdown}
             onAppendMarkdown={props.onAppendMarkdown}
@@ -379,7 +378,6 @@ function DailyReviewMetric(props: { label: string; value: string }) {
 
 function DailyReviewReport(props: {
   archive: DailyReviewArchive;
-  summary: DailyReviewSummary | null;
   onBack(): void;
   onCopyMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
   onAppendMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
@@ -406,21 +404,25 @@ function DailyReviewReport(props: {
     }
   }
 
-  const actionInput = props.summary
-    ? { range: props.archive.range, markdown, label: title, summary: props.summary }
-    : null;
+  const actionInput = {
+    day: props.archive.day,
+    range: props.archive.range,
+    totals: props.archive.totals,
+    markdown,
+    label: title,
+  };
   return (
     <VStack className="maka-daily-review-report" gap={5}>
       <HStack gap={2} vAlign="center" wrap="wrap">
         <Button variant="ghost" size="sm" icon={<ArrowLeft />} label={copy.page.backToActivity} onClick={props.onBack} />
         <StackItem size="fill" />
-        {actionInput && props.onCopyMarkdown ? (
+        {props.onCopyMarkdown ? (
           <Button variant="secondary" size="sm" label={pendingAction === 'copy' ? copy.export.copying : copy.export.copy} isDisabled={pendingAction !== null} onClick={() => void runAction('copy', () => props.onCopyMarkdown?.(actionInput))} />
         ) : null}
-        {actionInput && props.onAppendMarkdown ? (
+        {props.onAppendMarkdown ? (
           <Button variant="secondary" size="sm" label={pendingAction === 'append' ? copy.export.appending : copy.export.append} isDisabled={pendingAction !== null} onClick={() => void runAction('append', () => props.onAppendMarkdown?.(actionInput))} />
         ) : null}
-        {actionInput && props.onSaveMarkdown ? (
+        {props.onSaveMarkdown ? (
           <Button variant="secondary" size="sm" label={pendingAction === 'save' ? copy.export.saving : copy.export.save} isDisabled={pendingAction !== null} onClick={() => void runAction('save', () => props.onSaveMarkdown?.(actionInput))} />
         ) : null}
       </HStack>

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -335,9 +335,6 @@ export function DailyReviewPanel(props: {
             <DailyReviewMetric label={copy.overview.requests} value={totals?.requestCount.toString() ?? '0'} />
             <DailyReviewMetric label={copy.overview.tokens} value={(totals?.totalTokens ?? 0).toLocaleString(intlLocale)} />
             <DailyReviewMetric label={copy.overview.cost} value={`$${(totals?.costUsd ?? 0).toFixed(2)}`} />
-            {(totals?.errorCount ?? 0) > 0 ? (
-              <DailyReviewMetric label={copy.overview.errors} value={totals!.errorCount.toString()} tone="error" />
-            ) : null}
           </div>
 
           <VStack gap={2}>
@@ -370,9 +367,9 @@ export function DailyReviewPanel(props: {
   );
 }
 
-function DailyReviewMetric(props: { label: string; value: string; tone?: 'error' }) {
+function DailyReviewMetric(props: { label: string; value: string }) {
   return (
-    <VStack className="maka-daily-review-metric" gap={0} data-tone={props.tone}>
+    <VStack className="maka-daily-review-metric" gap={0}>
       <Text type="supporting" color="secondary">{props.label}</Text>
       <Text type="large" weight="semibold">{props.value}</Text>
     </VStack>

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -272,7 +272,7 @@ export function DailyReviewPanel(props: {
           onClick={() => selectScope(shiftDailyReviewScope({ range, offsetDays }, 1))}
         />
         <StackItem size="fill" />
-        {currentArchive ? (
+        {currentArchive?.status === 'ok' ? (
           <Button
             variant="primary"
             size="sm"
@@ -285,7 +285,7 @@ export function DailyReviewPanel(props: {
           <Button
             variant="primary"
             size="sm"
-            label={copy.page.generateAnalysis}
+            label={currentArchive ? copy.page.retryAnalysis : copy.page.generateAnalysis}
             isLoading={pendingAction === 'generate'}
             isDisabled={
               archiveState.status !== 'ready'

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -42,6 +42,7 @@ import { useMountedRef } from './use-mounted-ref.js';
 import {
   createDailyReviewActivityState,
   dailyReviewActivityReducer,
+  shiftDailyReviewScope,
   type DailyReviewScope,
 } from './daily-review-view-state.js';
 
@@ -257,8 +258,8 @@ export function DailyReviewPanel(props: {
           size="sm"
           isIconOnly
           icon={<ChevronLeft />}
-          label={copy.date.earlier(range === 1 ? copy.date.unit.day : range === 7 ? copy.date.unit.week : copy.date.unit.month)}
-          onClick={() => selectScope({ range, offsetDays: offsetDays - range })}
+          label={copy.date.earlier(copy.date.unit.day)}
+          onClick={() => selectScope(shiftDailyReviewScope({ range, offsetDays }, -1))}
         />
         <Text type="label" weight="semibold" className="maka-daily-review-range-label">{rangeLabel}</Text>
         <Button
@@ -266,9 +267,9 @@ export function DailyReviewPanel(props: {
           size="sm"
           isIconOnly
           icon={<ChevronRight />}
-          label={copy.date.later(range === 1 ? copy.date.unit.day : range === 7 ? copy.date.unit.week : copy.date.unit.month)}
+          label={copy.date.later(copy.date.unit.day)}
           isDisabled={offsetDays >= 0}
-          onClick={() => selectScope({ range, offsetDays: Math.min(0, offsetDays + range) })}
+          onClick={() => selectScope(shiftDailyReviewScope({ range, offsetDays }, 1))}
         />
         <StackItem size="fill" />
         {currentArchive ? (
@@ -317,13 +318,13 @@ export function DailyReviewPanel(props: {
         />
       ) : null}
 
-      {!displayedSummary ? (
+      {!displayedSummary && loading ? (
         <VStack gap={3} aria-busy="true">
           <Skeleton width="100%" height={64} radius="rounded" index={0} />
           <Skeleton width="100%" height={48} radius="rounded" index={1} />
           <Skeleton width="100%" height={48} radius="rounded" index={2} />
         </VStack>
-      ) : (
+      ) : displayedSummary ? (
         <div
           key={resolvedView?.scopeKey}
           className="maka-daily-review-content"
@@ -360,7 +361,7 @@ export function DailyReviewPanel(props: {
             )}
           </VStack>
         </div>
-      )}
+      ) : null}
       </VStack>
       </div>
     </VStack>

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -7,7 +7,7 @@ import type {
   DailyReviewSectionKey,
   DailyReviewSummary,
 } from '@maka/core';
-import { DAILY_REVIEW_RANGES, uiLocaleToIntlLocale } from '@maka/core';
+import { DAILY_REVIEW_RANGES, DAILY_REVIEW_SECTION_KEYS, uiLocaleToIntlLocale } from '@maka/core';
 import {
   Banner,
   Button,
@@ -49,6 +49,11 @@ type DailyReviewRoute =
   | { kind: 'activity' }
   | { kind: 'report'; archive: DailyReviewArchive };
 
+type DailyReviewArchiveState =
+  | { status: 'loading' }
+  | { status: 'ready'; archives: DailyReviewArchiveSummary[] }
+  | { status: 'error'; error: string };
+
 export function DailyReviewPanel(props: {
   bridge: DailyReviewBridge;
   hubHeader?: ModuleHubHeader;
@@ -70,7 +75,7 @@ export function DailyReviewPanel(props: {
     createDailyReviewActivityState,
   );
   const [reloadToken, setReloadToken] = useState(0);
-  const [archives, setArchives] = useState<DailyReviewArchiveSummary[]>([]);
+  const [archiveState, setArchiveState] = useState<DailyReviewArchiveState>({ status: 'loading' });
   const [archivesReloadToken, setArchivesReloadToken] = useState(0);
   const [route, setRoute] = useState<DailyReviewRoute>({ kind: 'activity' });
   const [pendingAction, setPendingAction] = useState<string | null>(null);
@@ -82,15 +87,17 @@ export function DailyReviewPanel(props: {
   const displayedSummary = resolvedView?.summary ?? null;
   const visibleSummary = resolvedView?.scopeKey === scopeKey ? resolvedView.summary : null;
   const loading = activityState.pendingScopeKey !== null;
-  const error = actionError ?? activityState.error;
+  const error = actionError
+    ?? activityState.error
+    ?? (archiveState.status === 'error' ? archiveState.error : null);
   const currentArchive = useMemo(() => {
-    if (!visibleSummary) return null;
-    return archives.find((archive) =>
+    if (!visibleSummary || archiveState.status !== 'ready') return null;
+    return archiveState.archives.find((archive) =>
       archive.range === range
       && archive.day.fromMs === visibleSummary.day.fromMs
       && archive.day.toMs === visibleSummary.day.toMs,
     ) ?? null;
-  }, [archives, range, visibleSummary]);
+  }, [archiveState, range, visibleSummary]);
 
   useEffect(() => {
     let cancelled = false;
@@ -115,19 +122,25 @@ export function DailyReviewPanel(props: {
   useEffect(() => {
     const listArchives = bridgeRef.current.listArchives;
     if (!listArchives) {
-      setArchives([]);
+      setArchiveState({ status: 'ready', archives: [] });
       return;
     }
     let cancelled = false;
+    setArchiveState({ status: 'loading' });
     listArchives().then((next) => {
-      if (!cancelled) setArchives(next);
-    }).catch(() => {
-      if (!cancelled) setArchives([]);
+      if (!cancelled) setArchiveState({ status: 'ready', archives: next });
+    }).catch((nextError: unknown) => {
+      if (!cancelled) {
+        setArchiveState({
+          status: 'error',
+          error: dailyReviewPanelErrorMessage(nextError, locale),
+        });
+      }
     });
     return () => {
       cancelled = true;
     };
-  }, [archivesReloadToken]);
+  }, [archivesReloadToken, locale]);
 
   const rangeLabel = formatScopeLabel(activityState.selection);
   const displayedRangeLabel = resolvedView ? formatScopeLabel(resolvedView.scope) : rangeLabel;
@@ -207,7 +220,11 @@ export function DailyReviewPanel(props: {
   const totals = displayedSummary?.totals;
   const currentTotals = visibleSummary?.totals;
   const hasActivity = Boolean(currentTotals && currentTotals.sessionCount + currentTotals.requestCount > 0);
-  const canAnalyze = Boolean(props.bridge.runOnce && props.bridge.getArchive);
+  const canAnalyze = Boolean(
+    props.bridge.runOnce
+    && props.bridge.listArchives
+    && props.bridge.getArchive,
+  );
 
   return (
     <VStack className="maka-daily-review-panel" gap={5}>
@@ -269,7 +286,12 @@ export function DailyReviewPanel(props: {
             size="sm"
             label={copy.page.generateAnalysis}
             isLoading={pendingAction === 'generate'}
-            isDisabled={pendingAction !== null || !visibleSummary || !hasActivity}
+            isDisabled={
+              archiveState.status !== 'ready'
+              || pendingAction !== null
+              || !visibleSummary
+              || !hasActivity
+            }
             onClick={() => void generateAnalysis()}
           />
         ) : null}
@@ -289,6 +311,7 @@ export function DailyReviewPanel(props: {
               setActionError(null);
               dispatchActivity({ type: 'selected', scope: activityState.selection });
               setReloadToken((value) => value + 1);
+              setArchivesReloadToken((value) => value + 1);
             }}
           />}
         />
@@ -385,7 +408,9 @@ function DailyReviewReport(props: {
     }
   }
 
-  const actionInput = props.summary ? { markdown, label: title, summary: props.summary } : null;
+  const actionInput = props.summary
+    ? { range: props.archive.range, markdown, label: title, summary: props.summary }
+    : null;
   return (
     <VStack className="maka-daily-review-report" gap={5}>
       <HStack gap={2} vAlign="center" wrap="wrap">
@@ -436,8 +461,7 @@ function reportSections(sections: DailyReviewArchiveSectionContent): Array<{
   key: DailyReviewSectionKey;
   content: string;
 }> {
-  const keys: DailyReviewSectionKey[] = ['summary', 'gaps', 'usage', 'code'];
-  return keys.flatMap((key) => {
+  return DAILY_REVIEW_SECTION_KEYS.flatMap((key) => {
     const content = sections[key]?.trim();
     return content ? [{ key, content }] : [];
   });

--- a/packages/ui/src/daily-review-view-state.ts
+++ b/packages/ui/src/daily-review-view-state.ts
@@ -1,0 +1,67 @@
+import type { DailyReviewRange, DailyReviewSummary } from '@maka/core';
+import { dailyReviewScopeKey } from './daily-review-helpers.js';
+
+export interface DailyReviewScope {
+  readonly range: DailyReviewRange;
+  readonly offsetDays: number;
+}
+
+export interface DailyReviewResolvedView {
+  readonly scope: DailyReviewScope;
+  readonly scopeKey: string;
+  readonly summary: DailyReviewSummary;
+}
+
+export interface DailyReviewActivityState {
+  readonly selection: DailyReviewScope;
+  readonly resolvedView: DailyReviewResolvedView | null;
+  readonly pendingScopeKey: string | null;
+  readonly error: string | null;
+}
+
+export type DailyReviewActivityAction =
+  | { readonly type: 'selected'; readonly scope: DailyReviewScope }
+  | { readonly type: 'resolved'; readonly scope: DailyReviewScope; readonly summary: DailyReviewSummary }
+  | { readonly type: 'rejected'; readonly scope: DailyReviewScope; readonly error: string };
+
+export function createDailyReviewActivityState(scope: DailyReviewScope): DailyReviewActivityState {
+  return {
+    selection: scope,
+    resolvedView: null,
+    pendingScopeKey: scopeKey(scope),
+    error: null,
+  };
+}
+
+export function dailyReviewActivityReducer(
+  state: DailyReviewActivityState,
+  action: DailyReviewActivityAction,
+): DailyReviewActivityState {
+  const actionScopeKey = scopeKey(action.scope);
+  if (action.type === 'selected') {
+    return {
+      ...state,
+      selection: action.scope,
+      pendingScopeKey: actionScopeKey,
+      error: null,
+    };
+  }
+  if (state.pendingScopeKey !== actionScopeKey) return state;
+  if (action.type === 'rejected') {
+    return { ...state, pendingScopeKey: null, error: action.error };
+  }
+  return {
+    ...state,
+    resolvedView: {
+      scope: action.scope,
+      scopeKey: actionScopeKey,
+      summary: action.summary,
+    },
+    pendingScopeKey: null,
+    error: null,
+  };
+}
+
+function scopeKey(scope: DailyReviewScope): string {
+  return dailyReviewScopeKey(scope.offsetDays, scope.range);
+}

--- a/packages/ui/src/daily-review-view-state.ts
+++ b/packages/ui/src/daily-review-view-state.ts
@@ -33,6 +33,16 @@ export function createDailyReviewActivityState(scope: DailyReviewScope): DailyRe
   };
 }
 
+export function shiftDailyReviewScope(
+  scope: DailyReviewScope,
+  direction: -1 | 1,
+): DailyReviewScope {
+  return {
+    ...scope,
+    offsetDays: Math.min(0, scope.offsetDays + direction),
+  };
+}
+
 export function dailyReviewActivityReducer(
   state: DailyReviewActivityState,
   action: DailyReviewActivityAction,

--- a/packages/ui/src/module-panel-types.ts
+++ b/packages/ui/src/module-panel-types.ts
@@ -171,8 +171,9 @@ export interface DailyReviewBridge {
  * identity from presentation text.
  */
 export type DailyReviewMarkdownActionInput = {
+  day: DailyReviewArchive['day'];
   range: DailyReviewRange;
+  totals: DailyReviewArchive['totals'];
   markdown: string;
   label: string;
-  summary: DailyReviewSummary;
 };

--- a/packages/ui/src/module-panel-types.ts
+++ b/packages/ui/src/module-panel-types.ts
@@ -1,7 +1,6 @@
 import type {
   DailyReviewArchive,
   DailyReviewArchiveSummary,
-  DailyReviewConfig,
   DailyReviewRange,
   DailyReviewSummary,
   PlanReminderDeliveryTarget,
@@ -164,21 +163,15 @@ export interface DailyReviewBridge {
   runOnce?(opts: { range: DailyReviewRange; offsetDays?: number }): Promise<{ archiveId: string }>;
   listArchives?(): Promise<DailyReviewArchiveSummary[]>;
   getArchive?(archiveId: string): Promise<DailyReviewArchive>;
-  deleteArchive?(archiveId: string): Promise<void>;
-  fetchConfig?(): Promise<DailyReviewConfig>;
-  updateConfig?(patch: Partial<DailyReviewConfig>): Promise<DailyReviewConfig>;
 }
 
 /**
- * Local-only daily summary view. Renders today by default; the
- * left/right arrows step through `offsetDays`. No LLM call — the
- * bullet list of sessions / top tools / top models is the whole
- * value-prop. Future PR can layer a generated narrative on top.
- *
- * borrow: external "today" digest concept (read-only summary).
- * diverge: no cron, no auto-push, no memory promotion (privacy default).
+ * Markdown generated from a Daily Review range. The range and resolved day are
+ * carried separately from the localized label so save actions never infer
+ * identity from presentation text.
  */
 export type DailyReviewMarkdownActionInput = {
+  range: DailyReviewRange;
   markdown: string;
   label: string;
   summary: DailyReviewSummary;

--- a/packages/ui/src/module-panel-types.ts
+++ b/packages/ui/src/module-panel-types.ts
@@ -2,13 +2,11 @@ import type {
   DailyReviewArchive,
   DailyReviewArchiveSummary,
   DailyReviewConfig,
-  DailyReviewMode,
+  DailyReviewRange,
   DailyReviewSummary,
-  DailyReviewTopEntry,
   PlanReminderDeliveryTarget,
   PlanReminderRecurrence,
 } from '@maka/core';
-import type { SelectorOptionData } from '@astryxdesign/core/Selector';
 
 export interface SkillEntry {
   kind?: 'skill' | 'discovery_diagnostic';
@@ -163,8 +161,7 @@ export interface DailyReviewBridge {
    * for presence before exposing the matching UI. When undefined, the
    * panel still works as the MVP telemetry view.
    */
-  runOnce?(opts: { mode: DailyReviewMode; modelKey?: string }): Promise<{ archiveId: string }>;
-  modelOptions?: SelectorOptionData[];
+  runOnce?(opts: { range: DailyReviewRange; offsetDays?: number }): Promise<{ archiveId: string }>;
   listArchives?(): Promise<DailyReviewArchiveSummary[]>;
   getArchive?(archiveId: string): Promise<DailyReviewArchive>;
   deleteArchive?(archiveId: string): Promise<void>;


### PR DESCRIPTION
## Summary

- rebuild Daily Review from Astryx primitives as a focused activity-analysis surface with Today, rolling 7-day, and rolling 30-day ranges
- keep the last resolved activity view mounted while another range loads, then replace it atomically with a subtle Astryx-token fade
- gate analysis on an explicit archive resource state so loading and failures cannot create duplicate reports
- derive exported filenames from the canonical archive range and day instead of localized presentation text
- move generated reports into a dedicated detail route and remove report history, model/tool rankings, daily/deep modes, section toggles, and disconnected settings
- schedule the previous complete local day, keep legacy daily/deep archives readable, and persist only the three settings backed by real behavior

Closes #1902

## Verification

Live Electron fixture:

<img width="2480" height="1640" alt="Daily Review live Electron activity surface" src="https://github.com/user-attachments/assets/7e0b7902-e906-49df-96d7-132ef3fd0f06" />

- `npm run lint`
- `npm run format:check`
- `npm run typecheck --workspace=@maka/core`
- `npm run typecheck --workspace=@maka/ui`
- `npm run typecheck --workspace=@maka/desktop`
- `npm run typecheck:stories --workspace=@maka/desktop`
- `npm run test:dist --workspace=@maka/core` (691 passed)
- `npm test --workspace=@maka/ui` (including archive loading/failure gates and refresh continuity)
- `npm run test:dist --workspace=@maka/desktop` (1368 passed)
- `node scripts/check-story-annotations.mjs`
- `node scripts/check-dead-css.mjs`
- full static Storybook product smoke (59 manifest checks and 61 catalog render jobs)
- Storybook floor-width contract covers the time input and open model selector in light and dark themes
- production Electron build and live fixture launch confirm the stable page shell and no renderer error boundary

## Migration

Existing `daily` and `deep` archive files remain readable and map to 1-day and 7-day ranges. New writes use `{date}-{range}d` identities. Legacy configuration fields are ignored when read and are removed on the next save.
