### PR TITLE
feat(runtime-host): expose agent graph client operations

### DIFF
--- a/docs/architecture/agent-graph-stream-scheduling-draft.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.md
@@ -456,7 +456,9 @@ reconcile_history_not_persisted
 
 The timeline is therefore replayable and useful for diagnosis without pretending to be a new authority. Each event points back to the store that owns the underlying fact.
 
-## Desktop product wiring
+## Client access and Desktop product wiring
+
+Runtime Host exposes the durable Graph projection through bounded `agent.graph.query` and `agent.graph.operator.query` operations. Clients use `agent.graph.stop` for explicit operator control; closing a connection or Session subscription never stops the Graph. A client that needs a coherent live view opens the root Session subscription before its first query. `subscription.agent_graph_changed` then shares that subscription's ordered sequence with Session updates and tells the client to query the projection again. It is an invalidation hint, not a replay log or a second source of truth. Query results report omitted data and continuation cursors instead of growing without a bound.
 
 Desktop composes the current host-managed Graph profile:
 
@@ -469,7 +471,7 @@ Desktop composes the current host-managed Graph profile:
 - stopping the Graph aborts reconciliation and stops known child Sessions through Runtime;
 - startup first repairs interrupted Runtime state, then wakes and Graph schedules.
 
-Renderer invalidations are hints. A reconnecting client calls `getSnapshot()` and reads durable state; it does not replay process-local notifications as facts.
+Renderer invalidations follow the same contract. A reconnecting client queries the durable projection again; it does not replay process-local notifications as facts.
 
 The current panel is an operational view, not a node-and-edge authoring canvas. The main Agent remains the topology author through typed schedule updates.
 

--- a/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
@@ -453,7 +453,9 @@ reconcile_history_not_persisted
 
 因此 timeline 可以 replay、可以用于诊断，却不会冒充新的 authority。每个 event 都能指回真正拥有 underlying fact 的 store。
 
-## Desktop 产品接线
+## Client 访问与 Desktop 产品接线
+
+Runtime Host 通过有界的 `agent.graph.query` 与 `agent.graph.operator.query` operation 暴露持久化 Graph projection。Client 通过 `agent.graph.stop` 显式控制 Graph；关闭连接或 Session subscription 永远不会停止 Graph。需要一致 live view 的 client，应先为 root Session 建立 subscription，再执行首次 query。此后，`subscription.agent_graph_changed` 与 Session update 共用该 subscription 的有序 sequence，并通知 client 重新查询 projection。它只是 invalidation hint，不是 replay log，也不是第二套 source of truth。Query result 通过 omitted data 与 continuation cursor 表达边界，而不会无限增长。
 
 Desktop 组合了当前 host-managed Graph profile：
 
@@ -466,7 +468,7 @@ Desktop 组合了当前 host-managed Graph profile：
 - Stop Graph 会 abort reconciliation，并通过 Runtime 停止已知 child Session；
 - Startup 先 repair interrupted Runtime state，再恢复 wake 与 Graph schedule。
 
-Renderer invalidation 只是 hint。重新连接的 client 调用 `getSnapshot()` 读取持久 state，不把进程内 notification replay 成事实。
+Renderer invalidation 遵循同一契约。重新连接的 client 会重新查询持久化 projection，不把进程内 notification replay 成事实。
 
 当前 panel 是 operational view，不是 node-and-edge authoring canvas。主 Agent 仍通过 typed schedule update 编写 topology。
 

--- a/packages/core/src/agent-graph-client-projection.ts
+++ b/packages/core/src/agent-graph-client-projection.ts
@@ -54,6 +54,10 @@ export class AgentGraphClientProjectionConflictError extends Error {
   readonly name = 'AgentGraphClientProjectionConflictError';
 }
 
+export class AgentGraphClientTerminalCursorError extends Error {
+  readonly name = 'AgentGraphClientTerminalCursorError';
+}
+
 export interface CommitAgentGraphClientProjectionRequest {
   schemaVersion: typeof AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION;
   graphId: string;

--- a/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
@@ -1,0 +1,377 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { SessionHeader } from '@maka/core';
+import {
+  AgentGraphOperatorNotFoundError,
+  agentGraphIdForRootSession,
+  decodeAgentGraphTerminalCursor,
+  type AgentGraphClientActivity,
+  type AgentGraphClientChangedListener,
+  type AgentGraphClientSnapshot as RuntimeAgentGraphClientSnapshot,
+  type AgentGraphCoordinator,
+  type AgentGraphOperatorInspection as RuntimeAgentGraphOperatorInspection,
+} from '@maka/runtime';
+import {
+  AGENT_GRAPH_RESULT_MAX_BYTES,
+  decodeAgentGraphClientSnapshot,
+  decodeAgentGraphOperatorInspection,
+} from '../protocol/index.js';
+import {
+  HostAgentGraphCoordinator,
+  projectAgentGraphClientSnapshot,
+  projectAgentGraphOperatorInspection,
+} from '../server/agent-graph-coordinator.js';
+import type { ConnectionContext } from '../server/operation-dispatcher.js';
+
+const fingerprint = `sha256:${'a'.repeat(64)}`;
+
+describe('Host Agent Graph coordinator', () => {
+  test('serves query, inspection, stop, and forwards invalidation without owning graph lifetime', async () => {
+    const snapshot = graphSnapshot();
+    const inspection = operatorInspection(snapshot);
+    let stoppedRoot: string | undefined;
+    let listener: AgentGraphClientChangedListener | undefined;
+    let unsubscribed = false;
+    const invalidations: unknown[] = [];
+    const coordinator = new HostAgentGraphCoordinator({
+      authority: {
+        getSnapshot: async () => snapshot,
+        inspectOperator: async () => inspection,
+        stop: async (rootSessionId) => {
+          stoppedRoot = rootSessionId;
+        },
+        subscribeAll: (candidate) => {
+          listener = candidate;
+          return () => {
+            unsubscribed = true;
+          };
+        },
+      } satisfies GraphAuthority,
+      sessions: { readHeaderSnapshot: async () => rootHeader() },
+      continuity: { enqueueAgentGraphChanged: (event) => invalidations.push(event) },
+    });
+
+    const queried = await coordinator.handlers['agent.graph.query'](
+      { rootSessionId: 'root-1' },
+      context(),
+    );
+    assert.equal(queried.ok, true);
+    if (!queried.ok) return;
+    assert.equal(queried.result.rootSessionId, 'root-1');
+
+    const inspected = await coordinator.handlers['agent.graph.operator.query'](
+      { rootSessionId: 'root-1', operatorId: 'operator-1' },
+      context(),
+    );
+    assert.equal(inspected.ok, true);
+    if (!inspected.ok) return;
+    assert.equal(inspected.result.operator.operatorId, 'operator-1');
+
+    const stopped = await coordinator.handlers['agent.graph.stop'](
+      { rootSessionId: 'root-1' },
+      context(),
+    );
+    assert.deepEqual(stopped, {
+      ok: true,
+      result: { rootSessionId: 'root-1', graphId: snapshot.graphId },
+    });
+    assert.equal(stoppedRoot, 'root-1');
+
+    await listener?.({
+      schemaVersion: 1,
+      rootSessionId: 'root-1',
+      graphId: snapshot.graphId,
+      reason: 'runtime_activity',
+    });
+    assert.deepEqual(invalidations, [
+      {
+        rootSessionId: 'root-1',
+        graphId: snapshot.graphId,
+        reason: 'runtime_activity',
+      },
+    ]);
+
+    coordinator.close();
+    assert.equal(unsubscribed, true);
+  });
+
+  test('returns stable root, archive, operator, and cursor failures', async () => {
+    const snapshot = graphSnapshot();
+    const authority = {
+      getSnapshot: async () => snapshot,
+      inspectOperator: async () => {
+        throw new AgentGraphOperatorNotFoundError(snapshot.graphId, 'missing-operator');
+      },
+      stop: async () => undefined,
+      subscribeAll: () => () => undefined,
+    } satisfies GraphAuthority;
+
+    const child = new HostAgentGraphCoordinator({
+      authority,
+      sessions: {
+        readHeaderSnapshot: async () =>
+          rootHeader({
+            subagentParent: {
+              kind: 'subagent',
+              parentSessionId: 'parent-1',
+              spawnedBy: {
+                parentRunId: 'parent-run',
+                parentTurnId: 'parent-turn',
+                toolCallId: 'tool-call',
+              },
+              lifecycle: 'foreground',
+            },
+          }),
+      },
+      continuity: { enqueueAgentGraphChanged: () => undefined },
+    });
+    const childQuery = await child.handlers['agent.graph.query'](
+      { rootSessionId: 'root-1' },
+      context(),
+    );
+    assert.equal(childQuery.ok, false);
+    if (!childQuery.ok) assert.equal(childQuery.error.code, 'operation_conflict');
+    child.close();
+
+    const archived = new HostAgentGraphCoordinator({
+      authority,
+      sessions: {
+        readHeaderSnapshot: async () =>
+          rootHeader({ isArchived: true, status: 'archived', archivedAt: 2 }),
+      },
+      continuity: { enqueueAgentGraphChanged: () => undefined },
+    });
+    const archivedStop = await archived.handlers['agent.graph.stop'](
+      { rootSessionId: 'root-1' },
+      context(),
+    );
+    assert.equal(archivedStop.ok, false);
+    if (!archivedStop.ok) assert.equal(archivedStop.error.code, 'session_archived');
+
+    const missingOperator = await archived.handlers['agent.graph.operator.query'](
+      { rootSessionId: 'root-1', operatorId: 'missing-operator' },
+      context(),
+    );
+    assert.equal(missingOperator.ok, false);
+    if (!missingOperator.ok) assert.equal(missingOperator.error.code, 'not_found');
+
+    const invalidCursor = await archived.handlers['agent.graph.query'](
+      { rootSessionId: 'root-1', terminalCursor: 'Y3Vyc29y' },
+      context(),
+    );
+    assert.equal(invalidCursor.ok, false);
+    if (!invalidCursor.ok) assert.equal(invalidCursor.error.code, 'invalid_request');
+    archived.close();
+  });
+
+  test('bounds large snapshots while preserving omission and terminal continuation', () => {
+    const source = graphSnapshot();
+    source.operators = Array.from({ length: 40 }, (_, index) =>
+      graphOperator(`operator-${index}`, index),
+    );
+    source.edges = Array.from({ length: 200 }, (_, index) => ({
+      edgeId: `edge-${index}`,
+      fromOperatorId: `operator-${index % 40}`,
+      toOperatorId: `operator-${(index + 1) % 40}`,
+    }));
+    source.recentActivity = Array.from({ length: 64 }, (_, index) => activity(index));
+    source.terminalHistory = {
+      records: Array.from({ length: 64 }, (_, index) => terminalActivity(index)),
+    };
+
+    const projected = projectAgentGraphClientSnapshot(source);
+    assert.ok(Buffer.byteLength(JSON.stringify(projected), 'utf8') <= AGENT_GRAPH_RESULT_MAX_BYTES);
+    assert.doesNotThrow(() => decodeAgentGraphClientSnapshot(projected));
+    assert.ok(projected.omitted.operators >= 8);
+    assert.ok(projected.omitted.edges > 0);
+    assert.ok(projected.omitted.recentActivity > 0);
+    assert.ok(projected.terminalHistory.records.length > 0);
+    assert.ok(projected.terminalHistory.nextCursor);
+    const cursor = decodeAgentGraphTerminalCursor(projected.terminalHistory.nextCursor!);
+    assert.equal(cursor.recordId, projected.terminalHistory.records.at(-1)?.recordId);
+  });
+
+  test('bounds a large operator inspection without changing its identity', () => {
+    const snapshot = graphSnapshot();
+    const source = operatorInspection(snapshot);
+    source.inboundEdges = Array.from({ length: 100 }, (_, index) => ({
+      edgeId: `edge-in-${index}`,
+      fromOperatorId: `upstream-${index}`,
+      toOperatorId: 'operator-1',
+    }));
+    source.outboundEdges = Array.from({ length: 100 }, (_, index) => ({
+      edgeId: `edge-out-${index}`,
+      fromOperatorId: 'operator-1',
+      toOperatorId: `downstream-${index}`,
+    }));
+    source.recentRecords = Array.from({ length: 128 }, (_, index) => activity(index));
+
+    const projected = projectAgentGraphOperatorInspection(source);
+    assert.ok(Buffer.byteLength(JSON.stringify(projected), 'utf8') <= AGENT_GRAPH_RESULT_MAX_BYTES);
+    assert.equal(projected.operator.operatorId, 'operator-1');
+    assert.ok(projected.omitted.inboundEdges >= 36);
+    assert.ok(projected.omitted.outboundEdges >= 36);
+    assert.ok(projected.omitted.records >= 96);
+    assert.doesNotThrow(() => decodeAgentGraphOperatorInspection(projected));
+  });
+});
+
+type GraphAuthority = Pick<
+  AgentGraphCoordinator,
+  'getSnapshot' | 'inspectOperator' | 'stop' | 'subscribeAll'
+>;
+
+function graphSnapshot(): RuntimeAgentGraphClientSnapshot {
+  return {
+    schemaVersion: 1,
+    rootSessionId: 'root-1',
+    graphId: agentGraphIdForRootSession('root-1'),
+    snapshotVersion: fingerprint,
+    status: 'active',
+    scheduleRevision: 1,
+    topologyFingerprint: fingerprint,
+    closed: false,
+    latestEventTime: 10,
+    operators: [graphOperator('operator-1', 1)],
+    edges: [],
+    work: [],
+    stoppedTargets: [],
+    claims: [],
+    recentControlDecisions: [],
+    recentActivity: [activity(1)],
+    terminalHistory: { records: [] },
+    omitted: {
+      operators: 0,
+      edges: 0,
+      work: 0,
+      stoppedTargets: 0,
+      claims: 0,
+      controlDecisions: 0,
+      recentActivity: 0,
+    },
+  };
+}
+
+function graphOperator(operatorId: string, index: number) {
+  return {
+    operatorId,
+    childSessionId: `child-${index}`,
+    provisionId: `provision-${index}`,
+    agentId: `agent-${index}`,
+    provisionedAt: index,
+    status: 'running' as const,
+    inboundEdgeIds: Array.from({ length: 64 }, (_, item) => `edge-in-${index}-${item}`),
+    outboundEdgeIds: Array.from({ length: 64 }, (_, item) => `edge-out-${index}-${item}`),
+    scheduledWorkIds: Array.from({ length: 64 }, (_, item) => `work-${index}-${item}`),
+    readiness: [
+      {
+        readinessId: `readiness-${index}`,
+        policyKind: 'all_settled' as const,
+        status: 'waiting' as const,
+        waitingFor: [
+          {
+            kind: 'input_route' as const,
+            upstreamOperatorIds: Array.from(
+              { length: 16 },
+              (_, item) => `upstream-${index}-${item}`,
+            ),
+          },
+        ],
+        omittedWaitingFor: 0,
+      },
+    ],
+    omitted: {
+      inboundEdgeIds: 0,
+      outboundEdgeIds: 0,
+      scheduledWorkIds: 0,
+      readiness: 0,
+      readinessWaits: 0,
+    },
+    currentActivation: {
+      activationId: `activation-${index}`,
+      status: 'running' as const,
+      recordCount: 1,
+      firstEventTime: index,
+      lastEventTime: index,
+      run: {
+        sessionId: `child-${index}`,
+        agentRunId: `run-${index}`,
+        turnId: `turn-${index}`,
+      },
+    },
+  };
+}
+
+function operatorInspection(
+  snapshot: RuntimeAgentGraphClientSnapshot,
+): RuntimeAgentGraphOperatorInspection {
+  return {
+    schemaVersion: 1,
+    rootSessionId: snapshot.rootSessionId,
+    graphId: snapshot.graphId,
+    snapshotVersion: snapshot.snapshotVersion,
+    operator: snapshot.operators[0]!,
+    inboundEdges: [],
+    outboundEdges: [],
+    work: [],
+    claims: [],
+    activations: [],
+    recentRecords: [],
+    omitted: {
+      inboundEdges: 0,
+      outboundEdges: 0,
+      work: 0,
+      claims: 0,
+      activations: 0,
+      records: 0,
+    },
+  };
+}
+
+function activity(index: number): AgentGraphClientActivity {
+  return {
+    recordId: `record-${index}`,
+    operatorId: `operator-${index % 40}`,
+    activationId: `activation-${index}`,
+    eventTime: index,
+    facets: ['message'],
+    signals: [],
+    run: {
+      sessionId: `child-${index % 40}`,
+      agentRunId: `run-${index}`,
+      turnId: `turn-${index}`,
+    },
+  };
+}
+
+function terminalActivity(index: number): AgentGraphClientActivity {
+  return {
+    ...activity(index),
+    facets: ['completed'],
+    signals: [{ kind: 'terminal', status: 'completed' }],
+  };
+}
+
+function rootHeader(overrides: Partial<SessionHeader> = {}): SessionHeader {
+  return {
+    id: 'root-1',
+    label: 'Root',
+    model: 'fake',
+    provider: 'fake',
+    createdAt: 1,
+    lastUsedAt: 1,
+    status: 'active',
+    isArchived: false,
+    ...overrides,
+  } as SessionHeader;
+}
+
+function context(): ConnectionContext {
+  return {
+    hostEpoch: 'epoch-1',
+    connectionId: 'connection-1',
+    surface: 'tui',
+    principal: 'local_os_user',
+    acquireResidency: () => ({ release() {} }),
+  };
+}

--- a/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import type { SessionHeader } from '@maka/core';
 import {
-  AgentGraphOperatorNotFoundError,
+  AgentGraphClientOperationError,
   agentGraphIdForRootSession,
   decodeAgentGraphTerminalCursor,
   type AgentGraphClientActivity,
@@ -47,7 +46,6 @@ describe('Host Agent Graph coordinator', () => {
           };
         },
       } satisfies GraphAuthority,
-      sessions: { readHeaderSnapshot: async () => rootHeader() },
       continuity: { enqueueAgentGraphChanged: (event) => invalidations.push(event) },
     });
 
@@ -96,33 +94,29 @@ describe('Host Agent Graph coordinator', () => {
   });
 
   test('returns stable root, archive, operator, and cursor failures', async () => {
-    const snapshot = graphSnapshot();
     const authority = {
-      getSnapshot: async () => snapshot,
-      inspectOperator: async () => {
-        throw new AgentGraphOperatorNotFoundError(snapshot.graphId, 'missing-operator');
+      getSnapshot: async (_rootSessionId: string, options?: { terminalCursor?: string }) => {
+        throw new AgentGraphClientOperationError(
+          options?.terminalCursor ? 'invalid_request' : 'operation_conflict',
+          options?.terminalCursor
+            ? 'Agent graph terminal activity cursor is stale or invalid'
+            : 'Agent graph client operations are available only to root Sessions',
+        );
       },
-      stop: async () => undefined,
+      inspectOperator: async () => {
+        throw new AgentGraphClientOperationError('not_found', 'Agent graph operator was not found');
+      },
+      stop: async () => {
+        throw new AgentGraphClientOperationError(
+          'session_archived',
+          'Archived Sessions cannot supervise an agent graph',
+        );
+      },
       subscribeAll: () => () => undefined,
     } satisfies GraphAuthority;
 
     const child = new HostAgentGraphCoordinator({
       authority,
-      sessions: {
-        readHeaderSnapshot: async () =>
-          rootHeader({
-            subagentParent: {
-              kind: 'subagent',
-              parentSessionId: 'parent-1',
-              spawnedBy: {
-                parentRunId: 'parent-run',
-                parentTurnId: 'parent-turn',
-                toolCallId: 'tool-call',
-              },
-              lifecycle: 'foreground',
-            },
-          }),
-      },
       continuity: { enqueueAgentGraphChanged: () => undefined },
     });
     const childQuery = await child.handlers['agent.graph.query'](
@@ -131,44 +125,41 @@ describe('Host Agent Graph coordinator', () => {
     );
     assert.equal(childQuery.ok, false);
     if (!childQuery.ok) assert.equal(childQuery.error.code, 'operation_conflict');
-    child.close();
 
-    const archived = new HostAgentGraphCoordinator({
-      authority,
-      sessions: {
-        readHeaderSnapshot: async () =>
-          rootHeader({ isArchived: true, status: 'archived', archivedAt: 2 }),
-      },
-      continuity: { enqueueAgentGraphChanged: () => undefined },
-    });
-    const archivedStop = await archived.handlers['agent.graph.stop'](
+    const archivedStop = await child.handlers['agent.graph.stop'](
       { rootSessionId: 'root-1' },
       context(),
     );
     assert.equal(archivedStop.ok, false);
     if (!archivedStop.ok) assert.equal(archivedStop.error.code, 'session_archived');
 
-    const missingOperator = await archived.handlers['agent.graph.operator.query'](
+    const missingOperator = await child.handlers['agent.graph.operator.query'](
       { rootSessionId: 'root-1', operatorId: 'missing-operator' },
       context(),
     );
     assert.equal(missingOperator.ok, false);
     if (!missingOperator.ok) assert.equal(missingOperator.error.code, 'not_found');
 
-    const invalidCursor = await archived.handlers['agent.graph.query'](
+    const invalidCursor = await child.handlers['agent.graph.query'](
       { rootSessionId: 'root-1', terminalCursor: 'Y3Vyc29y' },
       context(),
     );
     assert.equal(invalidCursor.ok, false);
     if (!invalidCursor.ok) assert.equal(invalidCursor.error.code, 'invalid_request');
-    archived.close();
+    child.close();
   });
 
   test('bounds large snapshots while preserving omission and terminal continuation', () => {
     const source = graphSnapshot();
-    source.operators = Array.from({ length: 40 }, (_, index) =>
-      graphOperator(`operator-${index}`, index),
-    );
+    source.operators = Array.from({ length: 40 }, (_, index) => {
+      const operator = graphOperator(`operator-${index}`, index);
+      const status = index < 8 ? ('running' as const) : ('completed' as const);
+      return {
+        ...operator,
+        status,
+        currentActivation: { ...operator.currentActivation, status },
+      };
+    });
     source.edges = Array.from({ length: 200 }, (_, index) => ({
       edgeId: `edge-${index}`,
       fromOperatorId: `operator-${index % 40}`,
@@ -176,15 +167,38 @@ describe('Host Agent Graph coordinator', () => {
     }));
     source.recentActivity = Array.from({ length: 64 }, (_, index) => activity(index));
     source.terminalHistory = {
-      records: Array.from({ length: 64 }, (_, index) => terminalActivity(index)),
+      records: Array.from({ length: 64 }, (_, index) => terminalActivity(63 - index)),
     };
 
     const projected = projectAgentGraphClientSnapshot(source);
     assert.ok(Buffer.byteLength(JSON.stringify(projected), 'utf8') <= AGENT_GRAPH_RESULT_MAX_BYTES);
     assert.doesNotThrow(() => decodeAgentGraphClientSnapshot(projected));
-    assert.ok(projected.omitted.operators >= 8);
-    assert.ok(projected.omitted.edges > 0);
-    assert.ok(projected.omitted.recentActivity > 0);
+    assert.equal(projected.operators.length + projected.omitted.operators, source.operators.length);
+    assert.equal(projected.edges.length + projected.omitted.edges, source.edges.length);
+    assert.equal(
+      projected.recentActivity.length + projected.omitted.recentActivity,
+      source.recentActivity.length,
+    );
+    assert.deepEqual(
+      projected.operators.slice(0, 8).map((operator) => operator.operatorId),
+      Array.from({ length: 8 }, (_, index) => `operator-${index}`),
+      'byte fitting must retain every live operator before terminal operators',
+    );
+    assert.deepEqual(
+      projected.recentActivity.map((record) => record.recordId),
+      source.recentActivity
+        .slice(source.recentActivity.length - projected.recentActivity.length)
+        .map((record) => record.recordId),
+      'byte fitting must retain the latest recent activity',
+    );
+    const firstOperator = projected.operators[0]!;
+    assert.equal(
+      firstOperator.inboundEdgeIds.length + firstOperator.omitted.inboundEdgeIds,
+      source.operators[0]!.inboundEdgeIds.length,
+    );
+    assert.deepEqual(firstOperator.readiness[0]?.waitingFor, []);
+    assert.equal(firstOperator.readiness[0]?.omittedWaitingFor, 1);
+    assert.equal(firstOperator.omitted.readinessWaits, 1);
     assert.ok(projected.terminalHistory.records.length > 0);
     assert.ok(projected.terminalHistory.nextCursor);
     const cursor = decodeAgentGraphTerminalCursor(projected.terminalHistory.nextCursor!);
@@ -209,10 +223,44 @@ describe('Host Agent Graph coordinator', () => {
     const projected = projectAgentGraphOperatorInspection(source);
     assert.ok(Buffer.byteLength(JSON.stringify(projected), 'utf8') <= AGENT_GRAPH_RESULT_MAX_BYTES);
     assert.equal(projected.operator.operatorId, 'operator-1');
-    assert.ok(projected.omitted.inboundEdges >= 36);
-    assert.ok(projected.omitted.outboundEdges >= 36);
-    assert.ok(projected.omitted.records >= 96);
+    assert.equal(
+      projected.inboundEdges.length + projected.omitted.inboundEdges,
+      source.inboundEdges.length,
+    );
+    assert.equal(
+      projected.outboundEdges.length + projected.omitted.outboundEdges,
+      source.outboundEdges.length,
+    );
+    assert.equal(
+      projected.recentRecords.length + projected.omitted.records,
+      source.recentRecords.length,
+    );
+    assert.deepEqual(
+      projected.inboundEdges.map((edge) => edge.edgeId),
+      source.inboundEdges
+        .slice(source.inboundEdges.length - projected.inboundEdges.length)
+        .map((edge) => edge.edgeId),
+    );
+    assert.deepEqual(
+      projected.recentRecords.map((record) => record.recordId),
+      source.recentRecords
+        .slice(source.recentRecords.length - projected.recentRecords.length)
+        .map((record) => record.recordId),
+    );
     assert.doesNotThrow(() => decodeAgentGraphOperatorInspection(projected));
+  });
+
+  test('projects only allowlisted Runtime fields onto the wire', () => {
+    const source = graphSnapshot();
+    Object.assign(source.operators[0]!, { privatePrompt: 'operator-secret' });
+    Object.assign(source.operators[0]!.readiness[0]!, {
+      privatePolicy: 'readiness-secret',
+    });
+    Object.assign(source.recentActivity[0]!, { privatePayload: 'activity-secret' });
+
+    const projected = projectAgentGraphClientSnapshot(source);
+    assert.equal(JSON.stringify(projected).includes('secret'), false);
+    assert.doesNotThrow(() => decodeAgentGraphClientSnapshot(projected));
   });
 });
 
@@ -350,20 +398,6 @@ function terminalActivity(index: number): AgentGraphClientActivity {
     facets: ['completed'],
     signals: [{ kind: 'terminal', status: 'completed' }],
   };
-}
-
-function rootHeader(overrides: Partial<SessionHeader> = {}): SessionHeader {
-  return {
-    id: 'root-1',
-    label: 'Root',
-    model: 'fake',
-    provider: 'fake',
-    createdAt: 1,
-    lastUsedAt: 1,
-    status: 'active',
-    isArchived: false,
-    ...overrides,
-  } as SessionHeader;
 }
 
 function context(): ConnectionContext {

--- a/packages/runtime-host/src/__tests__/agent-graph-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-protocol.test.ts
@@ -1,0 +1,282 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  AGENT_GRAPH_MAX_OPERATORS,
+  AGENT_GRAPH_OPERATION_SPECS,
+  AGENT_GRAPH_RESULT_MAX_BYTES,
+  decodeAgentGraphClientSnapshot,
+  decodeAgentGraphOperatorInspection,
+  decodeAgentGraphOperatorQueryInput,
+  decodeAgentGraphQueryInput,
+  decodeAgentGraphStopInput,
+  decodeAgentGraphStopResult,
+  decodeHostFrame,
+  type AgentGraphClientSnapshot,
+  type AgentGraphOperatorInspection,
+  RuntimeHostProtocolError,
+} from '../protocol/index.js';
+
+const fingerprint = `sha256:${'a'.repeat(64)}` as const;
+
+describe('Agent Graph Client protocol', () => {
+  test('declares bounded ready query, inspection, and stop operations', () => {
+    assert.deepEqual(Object.keys(AGENT_GRAPH_OPERATION_SPECS), [
+      'agent.graph.query',
+      'agent.graph.operator.query',
+      'agent.graph.stop',
+    ]);
+    assert.equal(AGENT_GRAPH_OPERATION_SPECS['agent.graph.query'].mode, 'query');
+    assert.equal(AGENT_GRAPH_OPERATION_SPECS['agent.graph.operator.query'].mode, 'query');
+    assert.equal(AGENT_GRAPH_OPERATION_SPECS['agent.graph.stop'].mode, 'control');
+    for (const spec of Object.values(AGENT_GRAPH_OPERATION_SPECS)) {
+      assert.equal(spec.availability, 'ready');
+      assert.ok(spec.errors.includes('not_found'));
+      assert.ok(spec.errors.includes('operation_conflict'));
+      assert.ok(spec.errors.includes('internal_failure'));
+    }
+  });
+
+  test('round-trips canonical inputs and bounded projections', () => {
+    assert.deepEqual(decodeAgentGraphQueryInput({ rootSessionId: 'root-1' }), {
+      rootSessionId: 'root-1',
+    });
+    assert.deepEqual(
+      decodeAgentGraphQueryInput({ rootSessionId: 'root-1', terminalCursor: 'Y3Vyc29y' }),
+      { rootSessionId: 'root-1', terminalCursor: 'Y3Vyc29y' },
+    );
+    assert.deepEqual(
+      decodeAgentGraphOperatorQueryInput({ rootSessionId: 'root-1', operatorId: 'operator:1' }),
+      { rootSessionId: 'root-1', operatorId: 'operator:1' },
+    );
+    assert.deepEqual(decodeAgentGraphStopInput({ rootSessionId: 'root-1' }), {
+      rootSessionId: 'root-1',
+    });
+    assert.deepEqual(
+      decodeAgentGraphStopResult({ rootSessionId: 'root-1', graphId: 'agent_graph_1' }),
+      { rootSessionId: 'root-1', graphId: 'agent_graph_1' },
+    );
+
+    const snapshot = graphSnapshot();
+    const inspection = operatorInspection(snapshot);
+    assert.deepEqual(decodeAgentGraphClientSnapshot(snapshot), snapshot);
+    assert.deepEqual(decodeAgentGraphOperatorInspection(inspection), inspection);
+    AGENT_GRAPH_OPERATION_SPECS['agent.graph.query'].assertOutputForInput?.(
+      { rootSessionId: 'root-1' },
+      snapshot,
+    );
+    AGENT_GRAPH_OPERATION_SPECS['agent.graph.operator.query'].assertOutputForInput?.(
+      { rootSessionId: 'root-1', operatorId: 'operator:1' },
+      inspection,
+    );
+  });
+
+  test('rejects unknown nested fields, invalid correlation, and unbounded pages', () => {
+    const snapshot = graphSnapshot();
+    assertInvalid(() =>
+      decodeAgentGraphClientSnapshot({
+        ...snapshot,
+        operators: [{ ...snapshot.operators[0], privatePrompt: 'secret' }],
+      }),
+    );
+    assertInvalid(() =>
+      decodeAgentGraphClientSnapshot({
+        ...snapshot,
+        operators: Array.from({ length: AGENT_GRAPH_MAX_OPERATORS + 1 }, (_, index) => ({
+          ...snapshot.operators[0],
+          operatorId: `operator-${index}`,
+        })),
+      }),
+    );
+    assertInvalid(() =>
+      decodeAgentGraphQueryInput({ rootSessionId: 'root-1', terminalCursor: 'not/base64' }),
+    );
+    assertInvalid(() =>
+      AGENT_GRAPH_OPERATION_SPECS['agent.graph.query'].assertOutputForInput?.(
+        { rootSessionId: 'another-root' },
+        snapshot,
+      ),
+    );
+    assertInvalid(() =>
+      AGENT_GRAPH_OPERATION_SPECS['agent.graph.operator.query'].assertOutputForInput?.(
+        { rootSessionId: 'root-1', operatorId: 'another-operator' },
+        operatorInspection(snapshot),
+      ),
+    );
+    assertInvalid(() =>
+      decodeAgentGraphClientSnapshot({
+        ...snapshot,
+        snapshotVersion: 'not-a-fingerprint',
+      }),
+    );
+  });
+
+  test('decodes graph invalidation on the existing Session subscription sequence', () => {
+    const frame = {
+      kind: 'subscription.agent_graph_changed' as const,
+      hostEpoch: 'epoch-1',
+      subscriptionId: 'subscription-1',
+      sequence: 3,
+      rootSessionId: 'root-1',
+      graphId: 'agent_graph_1',
+      reason: 'runtime_activity' as const,
+    };
+    assert.deepEqual(decodeHostFrame(frame), frame);
+    assertInvalid(() => decodeHostFrame({ ...frame, reason: 'payload_changed' }));
+    assertInvalid(() => decodeHostFrame({ ...frame, runtimePayload: { text: 'secret' } }));
+  });
+
+  test('rejects an encoded projection above the operation result budget', () => {
+    const snapshot = graphSnapshot();
+    const oversized = {
+      ...snapshot,
+      finish: {
+        resultIds: [],
+        reason: 'x'.repeat(AGENT_GRAPH_RESULT_MAX_BYTES),
+        revision: 1,
+        committedAt: 1,
+      },
+    };
+    assertInvalid(() => decodeAgentGraphClientSnapshot(oversized));
+  });
+});
+
+function graphSnapshot(): AgentGraphClientSnapshot {
+  return {
+    schemaVersion: 1,
+    rootSessionId: 'root-1',
+    graphId: 'agent_graph_1',
+    snapshotVersion: fingerprint,
+    status: 'active',
+    scheduleRevision: 1,
+    topologyFingerprint: fingerprint,
+    closed: false,
+    latestEventTime: 10,
+    operators: [
+      {
+        operatorId: 'operator:1',
+        childSessionId: 'child-1',
+        provisionId: 'provision:1',
+        agentId: 'agent:1',
+        provisionedAt: 1,
+        status: 'blocked',
+        inboundEdgeIds: ['edge:1'],
+        outboundEdgeIds: [],
+        scheduledWorkIds: ['work:1'],
+        readiness: [
+          {
+            readinessId: 'readiness:1',
+            policyKind: 'map',
+            status: 'waiting',
+            waitingFor: [{ kind: 'input_route', upstreamOperatorIds: ['operator:0'] }],
+            omittedWaitingFor: 0,
+          },
+        ],
+        omitted: {
+          inboundEdgeIds: 0,
+          outboundEdgeIds: 0,
+          scheduledWorkIds: 0,
+          readiness: 0,
+          readinessWaits: 0,
+        },
+        currentActivation: {
+          activationId: 'activation:1',
+          status: 'running',
+          recordCount: 1,
+          firstEventTime: 10,
+          lastEventTime: 10,
+          run: { sessionId: 'child-1', agentRunId: 'run:1', turnId: 'turn:1' },
+        },
+      },
+    ],
+    edges: [{ edgeId: 'edge:1', fromOperatorId: 'operator:0', toOperatorId: 'operator:1' }],
+    work: [
+      {
+        workId: 'work:1',
+        target: { kind: 'operator', operatorId: 'operator:1' },
+        inputIds: ['record:1'],
+        status: 'requested',
+        instructionPreview: 'Inspect the result.',
+        instructionTruncated: false,
+        revision: 1,
+        committedAt: 1,
+      },
+    ],
+    stoppedTargets: [],
+    claims: [
+      {
+        claimId: 'claim:1',
+        intentId: 'intent:1',
+        operatorId: 'operator:1',
+        childSessionId: 'child-1',
+        run: { sessionId: 'child-1', agentRunId: 'run:1', turnId: 'turn:1' },
+        admissionState: 'executing',
+        claimedAt: 2,
+      },
+    ],
+    recentControlDecisions: [],
+    recentActivity: [activity()],
+    terminalHistory: { records: [] },
+    omitted: {
+      operators: 0,
+      edges: 0,
+      work: 0,
+      stoppedTargets: 0,
+      claims: 0,
+      controlDecisions: 0,
+      recentActivity: 0,
+    },
+  };
+}
+
+function operatorInspection(snapshot: AgentGraphClientSnapshot): AgentGraphOperatorInspection {
+  return {
+    schemaVersion: 1,
+    rootSessionId: snapshot.rootSessionId,
+    graphId: snapshot.graphId,
+    snapshotVersion: snapshot.snapshotVersion,
+    operator: snapshot.operators[0]!,
+    inboundEdges: snapshot.edges,
+    outboundEdges: [],
+    work: snapshot.work,
+    claims: snapshot.claims,
+    activations: [
+      {
+        activationId: 'activation:1',
+        status: 'running',
+        recordCount: 1,
+        firstEventTime: 10,
+        lastEventTime: 10,
+        lastRecordId: 'record:1',
+        run: { sessionId: 'child-1', agentRunId: 'run:1', turnId: 'turn:1' },
+      },
+    ],
+    recentRecords: [activity()],
+    omitted: {
+      inboundEdges: 0,
+      outboundEdges: 0,
+      work: 0,
+      claims: 0,
+      activations: 0,
+      records: 0,
+    },
+  };
+}
+
+function activity() {
+  return {
+    recordId: 'record:1',
+    operatorId: 'operator:1',
+    activationId: 'activation:1',
+    eventTime: 10,
+    facets: ['permission_request'] as const,
+    signals: [{ kind: 'attention', reason: 'permission_request' }] as const,
+    run: { sessionId: 'child-1', agentRunId: 'run:1', turnId: 'turn:1' },
+  };
+}
+
+function assertInvalid(operation: () => unknown): void {
+  assert.throws(
+    operation,
+    (error: unknown) => error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame',
+  );
+}

--- a/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
@@ -3,7 +3,6 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import type { SessionHeader } from '@maka/core';
 import {
   agentGraphIdForRootSession,
   type AgentGraphClientChangedListener,
@@ -55,7 +54,6 @@ test('two UDS Clients query and control one Agent graph through Session invalida
       );
       const graph = new HostAgentGraphCoordinator({
         authority,
-        sessions: { readHeaderSnapshot: async () => sessionHeader() },
         continuity,
       });
       return {
@@ -153,6 +151,7 @@ class FakeAgentGraphAuthority implements GraphAuthority {
   }
 
   async stop(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 2_100));
     this.stopCount += 1;
     this.#snapshot.status = 'stopped';
     for (const listener of this.#listeners) {
@@ -255,31 +254,6 @@ function inspection(source: AgentGraphClientSnapshot): AgentGraphOperatorInspect
       activations: 0,
       records: 0,
     },
-  };
-}
-
-function sessionHeader(): SessionHeader {
-  return {
-    id: ROOT_SESSION_ID,
-    workspaceRoot: '/workspace',
-    cwd: '/workspace',
-    createdAt: 1,
-    lastUsedAt: 1,
-    name: 'Root',
-    titleIsManual: false,
-    isFlagged: false,
-    labels: [],
-    isArchived: false,
-    status: 'active',
-    hasUnread: false,
-    backend: 'fake',
-    llmConnectionSlug: 'fake',
-    connectionLocked: false,
-    model: 'fake',
-    permissionMode: 'explore',
-    collaborationMode: 'agent',
-    orchestrationMode: 'default',
-    schemaVersion: 1,
   };
 }
 

--- a/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
@@ -1,0 +1,315 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { SessionHeader } from '@maka/core';
+import {
+  agentGraphIdForRootSession,
+  type AgentGraphClientChangedListener,
+  type AgentGraphClientSnapshot,
+  type AgentGraphCoordinator,
+  type AgentGraphOperatorInspection,
+} from '@maka/runtime';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import {
+  connectRuntimeHost,
+  type RuntimeHostConnection,
+  type RuntimeHostSessionSubscription,
+} from '../client/index.js';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '../protocol/index.js';
+import { HostAgentGraphCoordinator } from '../server/agent-graph-coordinator.js';
+import type { CanonicalSessionProjection } from '../server/canonical-session-projection.js';
+import { RuntimeHostKernel } from '../server/host-kernel.js';
+import { createUnavailableDomainOperationHandlers } from '../server/operation-dispatcher.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+import { SessionContinuityCoordinator } from '../server/session-continuity-coordinator.js';
+
+const ROOT_SESSION_ID = 'root-1';
+const GRAPH_ID = agentGraphIdForRootSession(ROOT_SESSION_ID);
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+
+test('two UDS Clients query and control one Agent graph through Session invalidation', {
+  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+  timeout: 10_000,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-agent-graph-two-client-'));
+  const root = join(base, 'interactive');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  const authority = new FakeAgentGraphAuthority();
+  const host = await RuntimeHostKernel.start({
+    owner,
+    idleGraceMs: 10_000,
+    compositionFactory: async (context) => {
+      const continuity = new SessionContinuityCoordinator(
+        context.hostEpoch,
+        async (sessionId) => (sessionId === ROOT_SESSION_ID ? canonical(context.hostEpoch) : null),
+        new SessionAdmissionGate(),
+        context.requestDrain,
+      );
+      const graph = new HostAgentGraphCoordinator({
+        authority,
+        sessions: { readHeaderSnapshot: async () => sessionHeader() },
+        continuity,
+      });
+      return {
+        handlers: {
+          ...createUnavailableDomainOperationHandlers(),
+          ...continuity.handlers,
+          ...graph.handlers,
+        },
+        continuity,
+        beginDrain: () => undefined,
+        recover: async () => undefined,
+        close: async () => {
+          graph.close();
+          continuity.close();
+        },
+      };
+    },
+  });
+  let desktop: RuntimeHostConnection | undefined;
+  let tui: RuntimeHostConnection | undefined;
+  let subscription: RuntimeHostSessionSubscription | undefined;
+  try {
+    desktop = await connect(root, 'desktop');
+    tui = await connect(root, 'tui');
+    subscription = await desktop.openSessionSubscription({ sessionId: ROOT_SESSION_ID });
+
+    const [desktopSnapshot, tuiSnapshot] = await Promise.all([
+      desktop.request('agent.graph.query', { rootSessionId: ROOT_SESSION_ID }),
+      tui.request('agent.graph.query', { rootSessionId: ROOT_SESSION_ID }),
+    ]);
+    assert.equal(desktopSnapshot.snapshotVersion, tuiSnapshot.snapshotVersion);
+    assert.equal(desktopSnapshot.status, 'active');
+
+    const inspection = await tui.request('agent.graph.operator.query', {
+      rootSessionId: ROOT_SESSION_ID,
+      operatorId: 'operator-1',
+    });
+    assert.equal(inspection.operator.childSessionId, 'child-1');
+
+    await tui.close();
+    tui = undefined;
+    assert.equal(authority.stopCount, 0);
+    assert.equal(
+      (await desktop.request('agent.graph.query', { rootSessionId: ROOT_SESSION_ID })).status,
+      'active',
+    );
+
+    tui = await connect(root, 'tui');
+    const stopped = await tui.request('agent.graph.stop', { rootSessionId: ROOT_SESSION_ID });
+    assert.deepEqual(stopped, { rootSessionId: ROOT_SESSION_ID, graphId: GRAPH_ID });
+    assert.equal(authority.stopCount, 1);
+
+    const invalidation = await withTimeout(
+      subscription[Symbol.asyncIterator]().next(),
+      2_000,
+      'Agent graph invalidation did not arrive',
+    );
+    assert.equal(invalidation.done, false);
+    assert.deepEqual(invalidation.value, {
+      kind: 'subscription.agent_graph_changed',
+      hostEpoch: desktop.hostEpoch,
+      subscriptionId: subscription.subscriptionId,
+      sequence: 1,
+      rootSessionId: ROOT_SESSION_ID,
+      graphId: GRAPH_ID,
+      reason: 'stopped',
+    });
+    assert.equal(
+      (await desktop.request('agent.graph.query', { rootSessionId: ROOT_SESSION_ID })).status,
+      'stopped',
+    );
+  } finally {
+    await Promise.allSettled([subscription?.close(), desktop?.close(), tui?.close()]);
+    await host.close().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+type GraphAuthority = Pick<
+  AgentGraphCoordinator,
+  'getSnapshot' | 'inspectOperator' | 'stop' | 'subscribeAll'
+>;
+
+class FakeAgentGraphAuthority implements GraphAuthority {
+  readonly #listeners = new Set<AgentGraphClientChangedListener>();
+  #snapshot = snapshot();
+  stopCount = 0;
+
+  async getSnapshot(): Promise<AgentGraphClientSnapshot> {
+    return structuredClone(this.#snapshot);
+  }
+
+  async inspectOperator(): Promise<AgentGraphOperatorInspection> {
+    return inspection(this.#snapshot);
+  }
+
+  async stop(): Promise<void> {
+    this.stopCount += 1;
+    this.#snapshot.status = 'stopped';
+    for (const listener of this.#listeners) {
+      await listener({
+        schemaVersion: 1,
+        rootSessionId: ROOT_SESSION_ID,
+        graphId: GRAPH_ID,
+        reason: 'stopped',
+      });
+    }
+  }
+
+  subscribeAll(listener: AgentGraphClientChangedListener): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+}
+
+async function connect(
+  rootPath: string,
+  surface: 'desktop' | 'tui',
+): Promise<RuntimeHostConnection> {
+  const result = await connectRuntimeHost({ rootPath, surface, protocol: PROTOCOL });
+  assert.equal(result.kind, 'connected');
+  if (result.kind !== 'connected') throw new Error('Runtime Host did not accept the Client');
+  return result.connection;
+}
+
+function snapshot(): AgentGraphClientSnapshot {
+  const version = `sha256:${'a'.repeat(64)}`;
+  return {
+    schemaVersion: 1,
+    rootSessionId: ROOT_SESSION_ID,
+    graphId: GRAPH_ID,
+    snapshotVersion: version,
+    status: 'active',
+    scheduleRevision: 1,
+    topologyFingerprint: version,
+    closed: false,
+    operators: [operator()],
+    edges: [],
+    work: [],
+    stoppedTargets: [],
+    claims: [],
+    recentControlDecisions: [],
+    recentActivity: [],
+    terminalHistory: { records: [] },
+    omitted: {
+      operators: 0,
+      edges: 0,
+      work: 0,
+      stoppedTargets: 0,
+      claims: 0,
+      controlDecisions: 0,
+      recentActivity: 0,
+    },
+  };
+}
+
+function operator() {
+  return {
+    operatorId: 'operator-1',
+    childSessionId: 'child-1',
+    provisionId: 'provision-1',
+    agentId: 'agent-1',
+    provisionedAt: 1,
+    status: 'running' as const,
+    inboundEdgeIds: [],
+    outboundEdgeIds: [],
+    scheduledWorkIds: [],
+    readiness: [],
+    omitted: {
+      inboundEdgeIds: 0,
+      outboundEdgeIds: 0,
+      scheduledWorkIds: 0,
+      readiness: 0,
+      readinessWaits: 0,
+    },
+  };
+}
+
+function inspection(source: AgentGraphClientSnapshot): AgentGraphOperatorInspection {
+  return {
+    schemaVersion: 1,
+    rootSessionId: source.rootSessionId,
+    graphId: source.graphId,
+    snapshotVersion: source.snapshotVersion,
+    operator: source.operators[0]!,
+    inboundEdges: [],
+    outboundEdges: [],
+    work: [],
+    claims: [],
+    activations: [],
+    recentRecords: [],
+    omitted: {
+      inboundEdges: 0,
+      outboundEdges: 0,
+      work: 0,
+      claims: 0,
+      activations: 0,
+      records: 0,
+    },
+  };
+}
+
+function sessionHeader(): SessionHeader {
+  return {
+    id: ROOT_SESSION_ID,
+    workspaceRoot: '/workspace',
+    cwd: '/workspace',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Root',
+    titleIsManual: false,
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    hasUnread: false,
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    connectionLocked: false,
+    model: 'fake',
+    permissionMode: 'explore',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+    schemaVersion: 1,
+  };
+}
+
+function canonical(hostEpoch: string): CanonicalSessionProjection {
+  return {
+    session: {
+      sessionId: ROOT_SESSION_ID,
+      metadataRevision: 1,
+      status: 'active',
+      createdAt: 1,
+      lastUsedAt: 1,
+      isArchived: false,
+    },
+    rootTurn: null,
+    goal: null,
+    queue: { hostEpoch, queueRevision: 0, steering: [], followup: [] },
+    interactions: { pending: [] },
+  };
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -45,6 +45,9 @@ describe('Runtime Host bootstrap protocol', () => {
   test('keeps the experimental protocol at v0 with the declared authority operations', () => {
     assert.equal(RUNTIME_HOST_PROTOCOL_VERSION, 0);
     assert.deepEqual(Object.keys(HOST_OPERATION_SPECS).sort(), [
+      'agent.graph.operator.query',
+      'agent.graph.query',
+      'agent.graph.stop',
       'artifact.delete',
       'artifact.query',
       'automation.mutate',

--- a/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
@@ -294,6 +294,45 @@ test('rejects a live event that is not owned by the canonical root', async () =>
   coordinator.close();
 });
 
+test('coalesces Agent graph invalidations onto the Session subscription sequence', async () => {
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+  );
+  const sink = new RecordingSink();
+  const connection = coordinator.attachConnection('connection-1', sink);
+  const opened = await open(coordinator, 'connection-1');
+  connection.activate(opened.subscriptionId);
+
+  coordinator.enqueueAgentGraphChanged({
+    rootSessionId: SESSION_ID,
+    graphId: 'agent_graph_1',
+    reason: 'observation',
+  });
+  coordinator.enqueueAgentGraphChanged({
+    rootSessionId: SESSION_ID,
+    graphId: 'agent_graph_1',
+    reason: 'stopped',
+  });
+  await waitFor(() => sink.frames.length === 1);
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(1));
+  await waitFor(() => sink.frames.length === 2);
+
+  assert.deepEqual(sink.frames[0], {
+    kind: 'subscription.agent_graph_changed',
+    hostEpoch: HOST_EPOCH,
+    subscriptionId: opened.subscriptionId,
+    sequence: 1,
+    rootSessionId: SESSION_ID,
+    graphId: 'agent_graph_1',
+    reason: 'stopped',
+  });
+  assert.equal(sink.frames[1]?.kind, 'subscription.session_delta');
+  assert.equal(sink.frames[1]?.sequence, 2);
+  coordinator.close();
+});
+
 test('slow subscriber receives a terminal eviction without delaying another subscriber', async () => {
   const coordinator = new SessionContinuityCoordinator(
     HOST_EPOCH,

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -96,7 +96,7 @@ test('isolates a sequence gap and continues requests on the same connection', as
 });
 
 test('rejects epoch and Session correlation changes per subscription', async () => {
-  for (const changed of ['epoch', 'session'] as const) {
+  for (const changed of ['epoch', 'session', 'graph'] as const) {
     await withProtocolPeer(
       async (transport, hostEpoch) => {
         const request = await acceptConnectionAndReadOpen(transport, hostEpoch);
@@ -107,14 +107,26 @@ test('rejects epoch and Session correlation changes per subscription', async () 
           ok: true,
           result: opened,
         });
-        await transport.write({
-          ...deltaFrame(
-            changed === 'epoch' ? 'different-epoch' : hostEpoch,
-            opened.subscriptionId,
-            1,
-          ),
-          ...(changed === 'session' ? { sessionId: 'session-2' } : {}),
-        });
+        await transport.write(
+          changed === 'graph'
+            ? {
+                kind: 'subscription.agent_graph_changed',
+                hostEpoch,
+                subscriptionId: opened.subscriptionId,
+                sequence: 1,
+                rootSessionId: 'session-2',
+                graphId: 'agent_graph_1',
+                reason: 'observation',
+              }
+            : {
+                ...deltaFrame(
+                  changed === 'epoch' ? 'different-epoch' : hostEpoch,
+                  opened.subscriptionId,
+                  1,
+                ),
+                ...(changed === 'session' ? { sessionId: 'session-2' } : {}),
+              },
+        );
         await answerClose(transport, opened.subscriptionId);
         await answerStatus(transport, hostEpoch);
       },

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -358,6 +358,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
             case 'subscription.session_projection':
             case 'subscription.session_delta':
             case 'subscription.session_event':
+            case 'subscription.agent_graph_changed':
             case 'subscription.closed':
               this.#acceptSubscriptionFrame(frame);
               continue;

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -723,9 +723,10 @@ function requireTimeout(value: number, label: string): number {
 
 function defaultRequestTimeoutMs(operation: DirectRequestOperationKey): number | undefined {
   switch (operation) {
+    case 'agent.graph.stop':
     case 'connection.models.fetch':
     case 'connection.test.run':
-      // Completion effects own provider deadlines and may wait behind same-connection FIFO work.
+      // Completion effects own their deadlines and may wait for admitted work to settle.
       return undefined;
     default:
       return DEFAULT_REQUEST_TIMEOUT_MS;

--- a/packages/runtime-host/src/client/session-subscription.ts
+++ b/packages/runtime-host/src/client/session-subscription.ts
@@ -157,6 +157,14 @@ export class ClientSessionSubscription
         'correlation_changed',
         'Session subscription frame identity changed',
       );
+    } else if (
+      frame.kind === 'subscription.agent_graph_changed' &&
+      frame.rootSessionId !== this.#expectedSessionId
+    ) {
+      throw new RuntimeHostSubscriptionError(
+        'correlation_changed',
+        'Session subscription Agent graph identity changed',
+      );
     }
 
     this.#offer(frame);

--- a/packages/runtime-host/src/protocol/agent-graph.ts
+++ b/packages/runtime-host/src/protocol/agent-graph.ts
@@ -1,0 +1,1163 @@
+import {
+  requireCount,
+  requireEncodedByteLimit,
+  requireEntityId,
+  requireExactRecord,
+  requireShapedRecord,
+  requireUtf8String,
+} from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const AGENT_GRAPH_CLIENT_SCHEMA_VERSION = 1 as const;
+export const AGENT_GRAPH_RESULT_MAX_BYTES = 48 * 1024;
+export const AGENT_GRAPH_TERMINAL_CURSOR_MAX_BYTES = 2 * 1024;
+export const AGENT_GRAPH_MAX_OPERATORS = 32;
+export const AGENT_GRAPH_MAX_EDGES = 64;
+export const AGENT_GRAPH_MAX_WORK = 32;
+export const AGENT_GRAPH_MAX_STOPPED_TARGETS = 16;
+export const AGENT_GRAPH_MAX_CLAIMS = 32;
+export const AGENT_GRAPH_MAX_CONTROL_DECISIONS = 16;
+export const AGENT_GRAPH_MAX_ACTIVITY = 32;
+export const AGENT_GRAPH_MAX_TERMINAL_ACTIVITY = 32;
+export const AGENT_GRAPH_MAX_OPERATOR_REFS = 16;
+export const AGENT_GRAPH_MAX_OPERATOR_READINESS = 2;
+export const AGENT_GRAPH_MAX_READINESS_WAITS = 4;
+export const AGENT_GRAPH_MAX_INPUT_ROUTE_OPERATORS = 4;
+export const AGENT_GRAPH_MAX_WORK_INPUTS = 64;
+export const AGENT_GRAPH_MAX_CONTROL_REFS = 64;
+export const AGENT_GRAPH_MAX_INSPECTION_EDGES = 64;
+export const AGENT_GRAPH_MAX_INSPECTION_WORK = 32;
+export const AGENT_GRAPH_MAX_INSPECTION_CLAIMS = 32;
+export const AGENT_GRAPH_MAX_INSPECTION_ACTIVATIONS = 32;
+export const AGENT_GRAPH_MAX_INSPECTION_RECORDS = 32;
+
+const AGENT_GRAPH_INSTRUCTION_PREVIEW_MAX_BYTES = 2 * 1024;
+const AGENT_GRAPH_REASON_MAX_BYTES = 12 * 1024;
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'not_found',
+  'operation_conflict',
+  'invalid_request',
+  'persistence_failed',
+  'internal_failure',
+] as const;
+
+const STOP_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'not_found',
+  'session_archived',
+  'operation_conflict',
+  'internal_failure',
+] as const;
+
+export type AgentGraphActivationStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'aborted'
+  | 'cancelled';
+
+export type AgentGraphClientOperatorStatus =
+  | 'not_started'
+  | 'waiting'
+  | 'runnable'
+  | 'blocked'
+  | AgentGraphActivationStatus;
+
+export type AgentGraphClientStatus =
+  | 'empty'
+  | 'active'
+  | 'closing'
+  | 'waiting'
+  | 'stopped'
+  | 'failed'
+  | 'completed';
+
+export type AgentGraphRecordFacet =
+  | 'message'
+  | 'thinking'
+  | 'error'
+  | 'tool_call'
+  | 'tool_dispatch'
+  | 'tool_result'
+  | 'artifact_update'
+  | 'permission_request'
+  | 'permission_decision'
+  | 'user_question_request'
+  | 'transfer'
+  | 'usage'
+  | 'completed'
+  | 'failed'
+  | 'aborted'
+  | 'cancelled'
+  | 'runtime_fact';
+
+export type AgentGraphSupervisorSignal =
+  | { readonly kind: 'attention'; readonly reason: 'permission_request' | 'user_question_request' }
+  | {
+      readonly kind: 'terminal';
+      readonly status: 'completed' | 'failed' | 'aborted' | 'cancelled';
+    };
+
+export type AgentGraphReadinessWait =
+  | { readonly kind: 'input_route'; readonly upstreamOperatorIds: readonly string[] }
+  | {
+      readonly kind: 'activation_missing' | 'activation_running';
+      readonly operatorId: string;
+      readonly activationId: string;
+    };
+
+export interface AgentGraphClientRunRef {
+  readonly sessionId: string;
+  readonly agentRunId: string;
+  readonly turnId?: string;
+}
+
+export interface AgentGraphClientOperator {
+  readonly operatorId: string;
+  readonly childSessionId: string;
+  readonly provisionId: string;
+  readonly agentId: string;
+  readonly provisionedAt: number;
+  readonly status: AgentGraphClientOperatorStatus;
+  readonly inboundEdgeIds: readonly string[];
+  readonly outboundEdgeIds: readonly string[];
+  readonly scheduledWorkIds: readonly string[];
+  readonly readiness: readonly {
+    readonly readinessId: string;
+    readonly policyKind: 'map' | 'all_settled';
+    readonly status: 'waiting' | 'runnable';
+    readonly waitingFor: readonly AgentGraphReadinessWait[];
+    readonly omittedWaitingFor: number;
+  }[];
+  readonly omitted: {
+    readonly inboundEdgeIds: number;
+    readonly outboundEdgeIds: number;
+    readonly scheduledWorkIds: number;
+    readonly readiness: number;
+    readonly readinessWaits: number;
+  };
+  readonly currentActivation?: {
+    readonly activationId: string;
+    readonly status: AgentGraphActivationStatus;
+    readonly recordCount: number;
+    readonly firstEventTime: number;
+    readonly lastEventTime: number;
+    readonly terminalRecordId?: string;
+    readonly run: AgentGraphClientRunRef;
+  };
+}
+
+export interface AgentGraphClientEdge {
+  readonly edgeId: string;
+  readonly fromOperatorId: string;
+  readonly toOperatorId: string;
+}
+
+export interface AgentGraphClientScheduledWork {
+  readonly workId: string;
+  readonly target:
+    | { readonly kind: 'agent'; readonly agentId: string }
+    | { readonly kind: 'operator'; readonly operatorId: string };
+  readonly inputIds: readonly string[];
+  readonly replaces?: string;
+  readonly status: 'requested' | 'stopped' | 'superseded';
+  readonly instructionPreview: string;
+  readonly instructionTruncated: boolean;
+  readonly revision: number;
+  readonly committedAt: number;
+}
+
+export interface AgentGraphClientStoppedTarget {
+  readonly targetId: string;
+  readonly reason: string;
+  readonly revision: number;
+  readonly committedAt: number;
+}
+
+export interface AgentGraphClientFinish {
+  readonly resultIds: readonly string[];
+  readonly reason: string;
+  readonly revision: number;
+  readonly committedAt: number;
+}
+
+export interface AgentGraphClientControlDecision {
+  readonly updateId: string;
+  readonly revision: number;
+  readonly committedAt: number;
+  readonly source: {
+    readonly sessionId: string;
+    readonly agentRunId: string;
+    readonly turnId: string;
+    readonly toolCallId: string;
+  };
+  readonly addedWorkIds: readonly string[];
+  readonly stoppedTargetIds: readonly string[];
+  readonly selectedResultIds: readonly string[];
+}
+
+export interface AgentGraphClientClaimRef {
+  readonly claimId: string;
+  readonly intentId: string;
+  readonly operatorId: string;
+  readonly childSessionId: string;
+  readonly run: AgentGraphClientRunRef;
+  readonly admissionState: 'claimed' | 'executing' | 'cancelled';
+  readonly claimedAt: number;
+}
+
+export interface AgentGraphClientActivity {
+  readonly recordId: string;
+  readonly operatorId: string;
+  readonly activationId: string;
+  readonly eventTime: number;
+  readonly facets: readonly AgentGraphRecordFacet[];
+  readonly signals: readonly AgentGraphSupervisorSignal[];
+  readonly run: AgentGraphClientRunRef;
+}
+
+export interface AgentGraphClientSnapshot {
+  readonly schemaVersion: typeof AGENT_GRAPH_CLIENT_SCHEMA_VERSION;
+  readonly rootSessionId: string;
+  readonly graphId: string;
+  readonly snapshotVersion: `sha256:${string}`;
+  readonly status: AgentGraphClientStatus;
+  readonly scheduleRevision: number;
+  readonly topologyFingerprint: `sha256:${string}`;
+  readonly closed: boolean;
+  readonly latestEventTime?: number;
+  readonly operators: readonly AgentGraphClientOperator[];
+  readonly edges: readonly AgentGraphClientEdge[];
+  readonly work: readonly AgentGraphClientScheduledWork[];
+  readonly stoppedTargets: readonly AgentGraphClientStoppedTarget[];
+  readonly finish?: AgentGraphClientFinish;
+  readonly claims: readonly AgentGraphClientClaimRef[];
+  readonly recentControlDecisions: readonly AgentGraphClientControlDecision[];
+  readonly recentActivity: readonly AgentGraphClientActivity[];
+  readonly terminalHistory: {
+    readonly records: readonly AgentGraphClientActivity[];
+    readonly nextCursor?: string;
+  };
+  readonly omitted: {
+    readonly operators: number;
+    readonly edges: number;
+    readonly work: number;
+    readonly stoppedTargets: number;
+    readonly claims: number;
+    readonly controlDecisions: number;
+    readonly recentActivity: number;
+  };
+}
+
+export interface AgentGraphOperatorInspection {
+  readonly schemaVersion: typeof AGENT_GRAPH_CLIENT_SCHEMA_VERSION;
+  readonly rootSessionId: string;
+  readonly graphId: string;
+  readonly snapshotVersion: `sha256:${string}`;
+  readonly operator: AgentGraphClientOperator;
+  readonly inboundEdges: readonly AgentGraphClientEdge[];
+  readonly outboundEdges: readonly AgentGraphClientEdge[];
+  readonly work: readonly AgentGraphClientScheduledWork[];
+  readonly claims: readonly AgentGraphClientClaimRef[];
+  readonly activations: readonly {
+    readonly activationId: string;
+    readonly status: AgentGraphActivationStatus;
+    readonly recordCount: number;
+    readonly firstEventTime: number;
+    readonly lastEventTime: number;
+    readonly lastRecordId: string;
+    readonly terminalRecordId?: string;
+    readonly run: AgentGraphClientRunRef;
+  }[];
+  readonly recentRecords: readonly AgentGraphClientActivity[];
+  readonly omitted: {
+    readonly inboundEdges: number;
+    readonly outboundEdges: number;
+    readonly work: number;
+    readonly claims: number;
+    readonly activations: number;
+    readonly records: number;
+  };
+}
+
+export interface AgentGraphQueryInput {
+  readonly rootSessionId: string;
+  readonly terminalCursor?: string;
+}
+
+export interface AgentGraphOperatorQueryInput {
+  readonly rootSessionId: string;
+  readonly operatorId: string;
+}
+
+export interface AgentGraphStopInput {
+  readonly rootSessionId: string;
+}
+
+export interface AgentGraphStopResult {
+  readonly rootSessionId: string;
+  readonly graphId: string;
+}
+
+export const AGENT_GRAPH_OPERATION_SPECS = {
+  'agent.graph.query': defineOperation<
+    AgentGraphQueryInput,
+    AgentGraphClientSnapshot,
+    (typeof QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeAgentGraphQueryInput,
+    decodeOutput: decodeAgentGraphClientSnapshot,
+    assertOutputForInput: (input, output) => assertRootIdentity(input.rootSessionId, output),
+  }),
+  'agent.graph.operator.query': defineOperation<
+    AgentGraphOperatorQueryInput,
+    AgentGraphOperatorInspection,
+    (typeof QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeAgentGraphOperatorQueryInput,
+    decodeOutput: decodeAgentGraphOperatorInspection,
+    assertOutputForInput: (input, output) => {
+      assertRootIdentity(input.rootSessionId, output);
+      if (output.operator.operatorId !== input.operatorId) {
+        throw invalidProtocolFrame('Agent graph operator result changed request identity');
+      }
+    },
+  }),
+  'agent.graph.stop': defineOperation<
+    AgentGraphStopInput,
+    AgentGraphStopResult,
+    (typeof STOP_ERRORS)[number]
+  >({
+    mode: 'control',
+    availability: 'ready',
+    errors: STOP_ERRORS,
+    decodeInput: decodeAgentGraphStopInput,
+    decodeOutput: decodeAgentGraphStopResult,
+    assertOutputForInput: (input, output) => assertRootIdentity(input.rootSessionId, output),
+  }),
+} as const;
+
+export function decodeAgentGraphQueryInput(value: unknown): AgentGraphQueryInput {
+  const record = requireShapedRecord(
+    value,
+    'agent.graph.query input',
+    ['rootSessionId'],
+    ['terminalCursor'],
+  );
+  return {
+    rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId'),
+    ...(record.terminalCursor === undefined
+      ? {}
+      : { terminalCursor: requireCursor(record.terminalCursor) }),
+  };
+}
+
+export function decodeAgentGraphOperatorQueryInput(value: unknown): AgentGraphOperatorQueryInput {
+  const record = requireExactRecord(value, 'agent.graph.operator.query input', [
+    'rootSessionId',
+    'operatorId',
+  ]);
+  return {
+    rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId'),
+    operatorId: requireOpaqueIdentity(record.operatorId, 'operatorId'),
+  };
+}
+
+export function decodeAgentGraphStopInput(value: unknown): AgentGraphStopInput {
+  const record = requireExactRecord(value, 'agent.graph.stop input', ['rootSessionId']);
+  return { rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId') };
+}
+
+export function decodeAgentGraphStopResult(value: unknown): AgentGraphStopResult {
+  const record = requireExactRecord(value, 'agent.graph.stop result', ['rootSessionId', 'graphId']);
+  return {
+    rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId'),
+    graphId: requireOpaqueIdentity(record.graphId, 'graphId'),
+  };
+}
+
+export function decodeAgentGraphClientSnapshot(value: unknown): AgentGraphClientSnapshot {
+  requireEncodedByteLimit(value, 'agent.graph.query result', AGENT_GRAPH_RESULT_MAX_BYTES);
+  const record = requireShapedRecord(
+    value,
+    'agent graph snapshot',
+    [
+      'schemaVersion',
+      'rootSessionId',
+      'graphId',
+      'snapshotVersion',
+      'status',
+      'scheduleRevision',
+      'topologyFingerprint',
+      'closed',
+      'operators',
+      'edges',
+      'work',
+      'stoppedTargets',
+      'claims',
+      'recentControlDecisions',
+      'recentActivity',
+      'terminalHistory',
+      'omitted',
+    ],
+    ['latestEventTime', 'finish'],
+  );
+  requireSchemaVersion(record.schemaVersion);
+  const snapshot: AgentGraphClientSnapshot = {
+    schemaVersion: AGENT_GRAPH_CLIENT_SCHEMA_VERSION,
+    rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId'),
+    graphId: requireOpaqueIdentity(record.graphId, 'graphId'),
+    snapshotVersion: requireFingerprint(record.snapshotVersion, 'snapshotVersion'),
+    status: requireGraphStatus(record.status),
+    scheduleRevision: requireCount(record.scheduleRevision, 'scheduleRevision'),
+    topologyFingerprint: requireFingerprint(record.topologyFingerprint, 'topologyFingerprint'),
+    closed: requireBoolean(record.closed, 'closed'),
+    ...(record.latestEventTime === undefined
+      ? {}
+      : { latestEventTime: requireCount(record.latestEventTime, 'latestEventTime') }),
+    operators: decodeArray(
+      record.operators,
+      'agent graph operators',
+      AGENT_GRAPH_MAX_OPERATORS,
+      decodeOperator,
+    ),
+    edges: decodeArray(record.edges, 'agent graph edges', AGENT_GRAPH_MAX_EDGES, decodeEdge),
+    work: decodeArray(record.work, 'agent graph work', AGENT_GRAPH_MAX_WORK, decodeWork),
+    stoppedTargets: decodeArray(
+      record.stoppedTargets,
+      'agent graph stopped targets',
+      AGENT_GRAPH_MAX_STOPPED_TARGETS,
+      decodeStoppedTarget,
+    ),
+    ...(record.finish === undefined ? {} : { finish: decodeFinish(record.finish) }),
+    claims: decodeArray(record.claims, 'agent graph claims', AGENT_GRAPH_MAX_CLAIMS, decodeClaim),
+    recentControlDecisions: decodeArray(
+      record.recentControlDecisions,
+      'agent graph control decisions',
+      AGENT_GRAPH_MAX_CONTROL_DECISIONS,
+      decodeControlDecision,
+    ),
+    recentActivity: decodeArray(
+      record.recentActivity,
+      'agent graph recent activity',
+      AGENT_GRAPH_MAX_ACTIVITY,
+      decodeActivity,
+    ),
+    terminalHistory: decodeTerminalHistory(record.terminalHistory),
+    omitted: decodeSnapshotOmitted(record.omitted),
+  };
+  assertUnique(snapshot.operators, (item) => item.operatorId, 'agent graph operator');
+  assertUnique(snapshot.edges, (item) => item.edgeId, 'agent graph edge');
+  assertUnique(snapshot.work, (item) => item.workId, 'agent graph work');
+  assertUnique(snapshot.claims, (item) => item.claimId, 'agent graph claim');
+  return snapshot;
+}
+
+export function decodeAgentGraphOperatorInspection(value: unknown): AgentGraphOperatorInspection {
+  requireEncodedByteLimit(value, 'agent.graph.operator.query result', AGENT_GRAPH_RESULT_MAX_BYTES);
+  const record = requireExactRecord(value, 'agent graph operator inspection', [
+    'schemaVersion',
+    'rootSessionId',
+    'graphId',
+    'snapshotVersion',
+    'operator',
+    'inboundEdges',
+    'outboundEdges',
+    'work',
+    'claims',
+    'activations',
+    'recentRecords',
+    'omitted',
+  ]);
+  requireSchemaVersion(record.schemaVersion);
+  const inspection: AgentGraphOperatorInspection = {
+    schemaVersion: AGENT_GRAPH_CLIENT_SCHEMA_VERSION,
+    rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId'),
+    graphId: requireOpaqueIdentity(record.graphId, 'graphId'),
+    snapshotVersion: requireFingerprint(record.snapshotVersion, 'snapshotVersion'),
+    operator: decodeOperator(record.operator),
+    inboundEdges: decodeArray(
+      record.inboundEdges,
+      'agent graph inbound edges',
+      AGENT_GRAPH_MAX_INSPECTION_EDGES,
+      decodeEdge,
+    ),
+    outboundEdges: decodeArray(
+      record.outboundEdges,
+      'agent graph outbound edges',
+      AGENT_GRAPH_MAX_INSPECTION_EDGES,
+      decodeEdge,
+    ),
+    work: decodeArray(
+      record.work,
+      'agent graph inspection work',
+      AGENT_GRAPH_MAX_INSPECTION_WORK,
+      decodeWork,
+    ),
+    claims: decodeArray(
+      record.claims,
+      'agent graph inspection claims',
+      AGENT_GRAPH_MAX_INSPECTION_CLAIMS,
+      decodeClaim,
+    ),
+    activations: decodeArray(
+      record.activations,
+      'agent graph activations',
+      AGENT_GRAPH_MAX_INSPECTION_ACTIVATIONS,
+      decodeActivation,
+    ),
+    recentRecords: decodeArray(
+      record.recentRecords,
+      'agent graph inspection records',
+      AGENT_GRAPH_MAX_INSPECTION_RECORDS,
+      decodeActivity,
+    ),
+    omitted: decodeInspectionOmitted(record.omitted),
+  };
+  assertUnique(inspection.inboundEdges, (item) => item.edgeId, 'agent graph inbound edge');
+  assertUnique(inspection.outboundEdges, (item) => item.edgeId, 'agent graph outbound edge');
+  assertUnique(inspection.work, (item) => item.workId, 'agent graph inspection work');
+  assertUnique(inspection.claims, (item) => item.claimId, 'agent graph inspection claim');
+  assertUnique(inspection.activations, (item) => item.activationId, 'agent graph activation');
+  return inspection;
+}
+
+function decodeOperator(value: unknown): AgentGraphClientOperator {
+  const record = requireShapedRecord(
+    value,
+    'agent graph operator',
+    [
+      'operatorId',
+      'childSessionId',
+      'provisionId',
+      'agentId',
+      'provisionedAt',
+      'status',
+      'inboundEdgeIds',
+      'outboundEdgeIds',
+      'scheduledWorkIds',
+      'readiness',
+      'omitted',
+    ],
+    ['currentActivation'],
+  );
+  return {
+    operatorId: requireOpaqueIdentity(record.operatorId, 'operatorId'),
+    childSessionId: requireEntityId(record.childSessionId, 'childSessionId'),
+    provisionId: requireOpaqueIdentity(record.provisionId, 'provisionId'),
+    agentId: requireOpaqueIdentity(record.agentId, 'agentId'),
+    provisionedAt: requireCount(record.provisionedAt, 'provisionedAt'),
+    status: requireOperatorStatus(record.status),
+    inboundEdgeIds: decodeIdentityArray(
+      record.inboundEdgeIds,
+      'inboundEdgeIds',
+      AGENT_GRAPH_MAX_OPERATOR_REFS,
+    ),
+    outboundEdgeIds: decodeIdentityArray(
+      record.outboundEdgeIds,
+      'outboundEdgeIds',
+      AGENT_GRAPH_MAX_OPERATOR_REFS,
+    ),
+    scheduledWorkIds: decodeIdentityArray(
+      record.scheduledWorkIds,
+      'scheduledWorkIds',
+      AGENT_GRAPH_MAX_OPERATOR_REFS,
+    ),
+    readiness: decodeArray(
+      record.readiness,
+      'agent graph operator readiness',
+      AGENT_GRAPH_MAX_OPERATOR_READINESS,
+      decodeReadiness,
+    ),
+    omitted: decodeOperatorOmitted(record.omitted),
+    ...(record.currentActivation === undefined
+      ? {}
+      : { currentActivation: decodeCurrentActivation(record.currentActivation) }),
+  };
+}
+
+function decodeReadiness(value: unknown): AgentGraphClientOperator['readiness'][number] {
+  const record = requireExactRecord(value, 'agent graph readiness', [
+    'readinessId',
+    'policyKind',
+    'status',
+    'waitingFor',
+    'omittedWaitingFor',
+  ]);
+  if (record.policyKind !== 'map' && record.policyKind !== 'all_settled') {
+    throw invalidProtocolFrame('Invalid agent graph readiness policy');
+  }
+  if (record.status !== 'waiting' && record.status !== 'runnable') {
+    throw invalidProtocolFrame('Invalid agent graph readiness status');
+  }
+  return {
+    readinessId: requireOpaqueIdentity(record.readinessId, 'readinessId'),
+    policyKind: record.policyKind,
+    status: record.status,
+    waitingFor: decodeArray(
+      record.waitingFor,
+      'agent graph readiness waits',
+      AGENT_GRAPH_MAX_READINESS_WAITS,
+      decodeReadinessWait,
+    ),
+    omittedWaitingFor: requireCount(record.omittedWaitingFor, 'omittedWaitingFor'),
+  };
+}
+
+function decodeReadinessWait(value: unknown): AgentGraphReadinessWait {
+  const record = requireShapedRecord(
+    value,
+    'agent graph readiness wait',
+    ['kind'],
+    ['upstreamOperatorIds', 'operatorId', 'activationId'],
+  );
+  if (record.kind === 'input_route') {
+    requireExactRecord(record, 'agent graph input route wait', ['kind', 'upstreamOperatorIds']);
+    return {
+      kind: record.kind,
+      upstreamOperatorIds: decodeIdentityArray(
+        record.upstreamOperatorIds,
+        'upstreamOperatorIds',
+        AGENT_GRAPH_MAX_INPUT_ROUTE_OPERATORS,
+      ),
+    };
+  }
+  if (record.kind === 'activation_missing' || record.kind === 'activation_running') {
+    requireExactRecord(record, 'agent graph activation wait', [
+      'kind',
+      'operatorId',
+      'activationId',
+    ]);
+    return {
+      kind: record.kind,
+      operatorId: requireOpaqueIdentity(record.operatorId, 'operatorId'),
+      activationId: requireOpaqueIdentity(record.activationId, 'activationId'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid agent graph readiness wait kind');
+}
+
+function decodeCurrentActivation(
+  value: unknown,
+): NonNullable<AgentGraphClientOperator['currentActivation']> {
+  const record = requireShapedRecord(
+    value,
+    'agent graph current activation',
+    ['activationId', 'status', 'recordCount', 'firstEventTime', 'lastEventTime', 'run'],
+    ['terminalRecordId'],
+  );
+  return {
+    activationId: requireOpaqueIdentity(record.activationId, 'activationId'),
+    status: requireActivationStatus(record.status),
+    recordCount: requireCount(record.recordCount, 'recordCount'),
+    firstEventTime: requireCount(record.firstEventTime, 'firstEventTime'),
+    lastEventTime: requireCount(record.lastEventTime, 'lastEventTime'),
+    ...(record.terminalRecordId === undefined
+      ? {}
+      : {
+          terminalRecordId: requireOpaqueIdentity(record.terminalRecordId, 'terminalRecordId'),
+        }),
+    run: decodeRunRef(record.run),
+  };
+}
+
+function decodeEdge(value: unknown): AgentGraphClientEdge {
+  const record = requireExactRecord(value, 'agent graph edge', [
+    'edgeId',
+    'fromOperatorId',
+    'toOperatorId',
+  ]);
+  return {
+    edgeId: requireOpaqueIdentity(record.edgeId, 'edgeId'),
+    fromOperatorId: requireOpaqueIdentity(record.fromOperatorId, 'fromOperatorId'),
+    toOperatorId: requireOpaqueIdentity(record.toOperatorId, 'toOperatorId'),
+  };
+}
+
+function decodeWork(value: unknown): AgentGraphClientScheduledWork {
+  const record = requireShapedRecord(
+    value,
+    'agent graph work',
+    [
+      'workId',
+      'target',
+      'inputIds',
+      'status',
+      'instructionPreview',
+      'instructionTruncated',
+      'revision',
+      'committedAt',
+    ],
+    ['replaces'],
+  );
+  if (
+    record.status !== 'requested' &&
+    record.status !== 'stopped' &&
+    record.status !== 'superseded'
+  ) {
+    throw invalidProtocolFrame('Invalid agent graph work status');
+  }
+  return {
+    workId: requireOpaqueIdentity(record.workId, 'workId'),
+    target: decodeWorkTarget(record.target),
+    inputIds: decodeIdentityArray(record.inputIds, 'inputIds', AGENT_GRAPH_MAX_WORK_INPUTS),
+    ...(record.replaces === undefined
+      ? {}
+      : { replaces: requireOpaqueIdentity(record.replaces, 'replaces') }),
+    status: record.status,
+    instructionPreview: requireUtf8String(
+      record.instructionPreview,
+      'instructionPreview',
+      AGENT_GRAPH_INSTRUCTION_PREVIEW_MAX_BYTES,
+    ),
+    instructionTruncated: requireBoolean(record.instructionTruncated, 'instructionTruncated'),
+    revision: requireCount(record.revision, 'revision'),
+    committedAt: requireCount(record.committedAt, 'committedAt'),
+  };
+}
+
+function decodeWorkTarget(value: unknown): AgentGraphClientScheduledWork['target'] {
+  const record = requireShapedRecord(
+    value,
+    'agent graph work target',
+    ['kind'],
+    ['agentId', 'operatorId'],
+  );
+  if (record.kind === 'agent') {
+    requireExactRecord(record, 'agent graph agent target', ['kind', 'agentId']);
+    return { kind: record.kind, agentId: requireOpaqueIdentity(record.agentId, 'agentId') };
+  }
+  if (record.kind === 'operator') {
+    requireExactRecord(record, 'agent graph operator target', ['kind', 'operatorId']);
+    return {
+      kind: record.kind,
+      operatorId: requireOpaqueIdentity(record.operatorId, 'operatorId'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid agent graph work target');
+}
+
+function decodeStoppedTarget(value: unknown): AgentGraphClientStoppedTarget {
+  const record = requireExactRecord(value, 'agent graph stopped target', [
+    'targetId',
+    'reason',
+    'revision',
+    'committedAt',
+  ]);
+  return {
+    targetId: requireOpaqueIdentity(record.targetId, 'targetId'),
+    reason: requireUtf8String(record.reason, 'stop reason', AGENT_GRAPH_REASON_MAX_BYTES),
+    revision: requireCount(record.revision, 'revision'),
+    committedAt: requireCount(record.committedAt, 'committedAt'),
+  };
+}
+
+function decodeFinish(value: unknown): AgentGraphClientFinish {
+  const record = requireExactRecord(value, 'agent graph finish', [
+    'resultIds',
+    'reason',
+    'revision',
+    'committedAt',
+  ]);
+  return {
+    resultIds: decodeIdentityArray(record.resultIds, 'resultIds', AGENT_GRAPH_MAX_CONTROL_REFS),
+    reason: requireUtf8String(record.reason, 'finish reason', AGENT_GRAPH_REASON_MAX_BYTES),
+    revision: requireCount(record.revision, 'revision'),
+    committedAt: requireCount(record.committedAt, 'committedAt'),
+  };
+}
+
+function decodeControlDecision(value: unknown): AgentGraphClientControlDecision {
+  const record = requireExactRecord(value, 'agent graph control decision', [
+    'updateId',
+    'revision',
+    'committedAt',
+    'source',
+    'addedWorkIds',
+    'stoppedTargetIds',
+    'selectedResultIds',
+  ]);
+  const source = requireExactRecord(record.source, 'agent graph control source', [
+    'sessionId',
+    'agentRunId',
+    'turnId',
+    'toolCallId',
+  ]);
+  return {
+    updateId: requireOpaqueIdentity(record.updateId, 'updateId'),
+    revision: requireCount(record.revision, 'revision'),
+    committedAt: requireCount(record.committedAt, 'committedAt'),
+    source: {
+      sessionId: requireEntityId(source.sessionId, 'sessionId'),
+      agentRunId: requireOpaqueIdentity(source.agentRunId, 'agentRunId'),
+      turnId: requireOpaqueIdentity(source.turnId, 'turnId'),
+      toolCallId: requireOpaqueIdentity(source.toolCallId, 'toolCallId'),
+    },
+    addedWorkIds: decodeIdentityArray(
+      record.addedWorkIds,
+      'addedWorkIds',
+      AGENT_GRAPH_MAX_CONTROL_REFS,
+    ),
+    stoppedTargetIds: decodeIdentityArray(
+      record.stoppedTargetIds,
+      'stoppedTargetIds',
+      AGENT_GRAPH_MAX_CONTROL_REFS,
+    ),
+    selectedResultIds: decodeIdentityArray(
+      record.selectedResultIds,
+      'selectedResultIds',
+      AGENT_GRAPH_MAX_CONTROL_REFS,
+    ),
+  };
+}
+
+function decodeClaim(value: unknown): AgentGraphClientClaimRef {
+  const record = requireExactRecord(value, 'agent graph claim', [
+    'claimId',
+    'intentId',
+    'operatorId',
+    'childSessionId',
+    'run',
+    'admissionState',
+    'claimedAt',
+  ]);
+  if (
+    record.admissionState !== 'claimed' &&
+    record.admissionState !== 'executing' &&
+    record.admissionState !== 'cancelled'
+  ) {
+    throw invalidProtocolFrame('Invalid agent graph claim admission state');
+  }
+  return {
+    claimId: requireOpaqueIdentity(record.claimId, 'claimId'),
+    intentId: requireOpaqueIdentity(record.intentId, 'intentId'),
+    operatorId: requireOpaqueIdentity(record.operatorId, 'operatorId'),
+    childSessionId: requireEntityId(record.childSessionId, 'childSessionId'),
+    run: decodeRunRef(record.run),
+    admissionState: record.admissionState,
+    claimedAt: requireCount(record.claimedAt, 'claimedAt'),
+  };
+}
+
+function decodeActivity(value: unknown): AgentGraphClientActivity {
+  const record = requireExactRecord(value, 'agent graph activity', [
+    'recordId',
+    'operatorId',
+    'activationId',
+    'eventTime',
+    'facets',
+    'signals',
+    'run',
+  ]);
+  return {
+    recordId: requireOpaqueIdentity(record.recordId, 'recordId'),
+    operatorId: requireOpaqueIdentity(record.operatorId, 'operatorId'),
+    activationId: requireOpaqueIdentity(record.activationId, 'activationId'),
+    eventTime: requireCount(record.eventTime, 'eventTime'),
+    facets: decodeArray(record.facets, 'agent graph activity facets', 18, requireFacet),
+    signals: decodeArray(record.signals, 'agent graph activity signals', 2, decodeSignal),
+    run: decodeRunRef(record.run),
+  };
+}
+
+function decodeActivation(value: unknown): AgentGraphOperatorInspection['activations'][number] {
+  const record = requireShapedRecord(
+    value,
+    'agent graph activation',
+    [
+      'activationId',
+      'status',
+      'recordCount',
+      'firstEventTime',
+      'lastEventTime',
+      'lastRecordId',
+      'run',
+    ],
+    ['terminalRecordId'],
+  );
+  return {
+    activationId: requireOpaqueIdentity(record.activationId, 'activationId'),
+    status: requireActivationStatus(record.status),
+    recordCount: requireCount(record.recordCount, 'recordCount'),
+    firstEventTime: requireCount(record.firstEventTime, 'firstEventTime'),
+    lastEventTime: requireCount(record.lastEventTime, 'lastEventTime'),
+    lastRecordId: requireOpaqueIdentity(record.lastRecordId, 'lastRecordId'),
+    ...(record.terminalRecordId === undefined
+      ? {}
+      : {
+          terminalRecordId: requireOpaqueIdentity(record.terminalRecordId, 'terminalRecordId'),
+        }),
+    run: decodeRunRef(record.run),
+  };
+}
+
+function decodeRunRef(value: unknown): AgentGraphClientRunRef {
+  const record = requireShapedRecord(
+    value,
+    'agent graph run reference',
+    ['sessionId', 'agentRunId'],
+    ['turnId'],
+  );
+  return {
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    agentRunId: requireOpaqueIdentity(record.agentRunId, 'agentRunId'),
+    ...(record.turnId === undefined
+      ? {}
+      : { turnId: requireOpaqueIdentity(record.turnId, 'turnId') }),
+  };
+}
+
+function decodeSignal(value: unknown): AgentGraphSupervisorSignal {
+  const record = requireShapedRecord(value, 'agent graph signal', ['kind'], ['reason', 'status']);
+  if (record.kind === 'attention') {
+    requireExactRecord(record, 'agent graph attention signal', ['kind', 'reason']);
+    if (record.reason !== 'permission_request' && record.reason !== 'user_question_request') {
+      throw invalidProtocolFrame('Invalid agent graph attention reason');
+    }
+    return { kind: record.kind, reason: record.reason };
+  }
+  if (record.kind === 'terminal') {
+    requireExactRecord(record, 'agent graph terminal signal', ['kind', 'status']);
+    if (
+      record.status !== 'completed' &&
+      record.status !== 'failed' &&
+      record.status !== 'aborted' &&
+      record.status !== 'cancelled'
+    ) {
+      throw invalidProtocolFrame('Invalid agent graph terminal status');
+    }
+    return { kind: record.kind, status: record.status };
+  }
+  throw invalidProtocolFrame('Invalid agent graph signal kind');
+}
+
+function decodeTerminalHistory(value: unknown): AgentGraphClientSnapshot['terminalHistory'] {
+  const record = requireShapedRecord(
+    value,
+    'agent graph terminal history',
+    ['records'],
+    ['nextCursor'],
+  );
+  return {
+    records: decodeArray(
+      record.records,
+      'agent graph terminal activity',
+      AGENT_GRAPH_MAX_TERMINAL_ACTIVITY,
+      decodeActivity,
+    ),
+    ...(record.nextCursor === undefined ? {} : { nextCursor: requireCursor(record.nextCursor) }),
+  };
+}
+
+function decodeOperatorOmitted(value: unknown): AgentGraphClientOperator['omitted'] {
+  const record = requireExactRecord(value, 'agent graph operator omitted counts', [
+    'inboundEdgeIds',
+    'outboundEdgeIds',
+    'scheduledWorkIds',
+    'readiness',
+    'readinessWaits',
+  ]);
+  return {
+    inboundEdgeIds: requireCount(record.inboundEdgeIds, 'omitted inboundEdgeIds'),
+    outboundEdgeIds: requireCount(record.outboundEdgeIds, 'omitted outboundEdgeIds'),
+    scheduledWorkIds: requireCount(record.scheduledWorkIds, 'omitted scheduledWorkIds'),
+    readiness: requireCount(record.readiness, 'omitted readiness'),
+    readinessWaits: requireCount(record.readinessWaits, 'omitted readinessWaits'),
+  };
+}
+
+function decodeSnapshotOmitted(value: unknown): AgentGraphClientSnapshot['omitted'] {
+  const record = requireExactRecord(value, 'agent graph snapshot omitted counts', [
+    'operators',
+    'edges',
+    'work',
+    'stoppedTargets',
+    'claims',
+    'controlDecisions',
+    'recentActivity',
+  ]);
+  return {
+    operators: requireCount(record.operators, 'omitted operators'),
+    edges: requireCount(record.edges, 'omitted edges'),
+    work: requireCount(record.work, 'omitted work'),
+    stoppedTargets: requireCount(record.stoppedTargets, 'omitted stoppedTargets'),
+    claims: requireCount(record.claims, 'omitted claims'),
+    controlDecisions: requireCount(record.controlDecisions, 'omitted controlDecisions'),
+    recentActivity: requireCount(record.recentActivity, 'omitted recentActivity'),
+  };
+}
+
+function decodeInspectionOmitted(value: unknown): AgentGraphOperatorInspection['omitted'] {
+  const record = requireExactRecord(value, 'agent graph inspection omitted counts', [
+    'inboundEdges',
+    'outboundEdges',
+    'work',
+    'claims',
+    'activations',
+    'records',
+  ]);
+  return {
+    inboundEdges: requireCount(record.inboundEdges, 'omitted inboundEdges'),
+    outboundEdges: requireCount(record.outboundEdges, 'omitted outboundEdges'),
+    work: requireCount(record.work, 'omitted work'),
+    claims: requireCount(record.claims, 'omitted claims'),
+    activations: requireCount(record.activations, 'omitted activations'),
+    records: requireCount(record.records, 'omitted records'),
+  };
+}
+
+function decodeIdentityArray(value: unknown, label: string, maxItems: number): string[] {
+  const identities = decodeArray(value, label, maxItems, (item) =>
+    requireOpaqueIdentity(item, label),
+  );
+  assertUnique(identities, (item) => item, label);
+  return identities;
+}
+
+function decodeArray<T>(
+  value: unknown,
+  label: string,
+  maxItems: number,
+  decode: (item: unknown) => T,
+): T[] {
+  if (!Array.isArray(value) || value.length > maxItems) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value.map(decode);
+}
+
+function assertUnique<T>(items: readonly T[], key: (item: T) => string, label: string): void {
+  if (new Set(items.map(key)).size !== items.length) {
+    throw invalidProtocolFrame(`Duplicate ${label} identity`);
+  }
+}
+
+function assertRootIdentity(
+  rootSessionId: string,
+  output: { readonly rootSessionId: string },
+): void {
+  if (output.rootSessionId !== rootSessionId) {
+    throw invalidProtocolFrame('Agent graph result changed request identity');
+  }
+}
+
+function requireSchemaVersion(value: unknown): void {
+  if (value !== AGENT_GRAPH_CLIENT_SCHEMA_VERSION) {
+    throw invalidProtocolFrame('Unsupported agent graph client schema');
+  }
+}
+
+function requireBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== 'boolean') throw invalidProtocolFrame(`Invalid ${label}`);
+  return value;
+}
+
+function requireOpaqueIdentity(value: unknown, label: string): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > 256 ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function requireFingerprint(value: unknown, label: string): `sha256:${string}` {
+  if (typeof value !== 'string' || !/^sha256:[a-f0-9]{64}$/.test(value)) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value as `sha256:${string}`;
+}
+
+function requireCursor(value: unknown): string {
+  const cursor = requireUtf8String(
+    value,
+    'agent graph terminal cursor',
+    AGENT_GRAPH_TERMINAL_CURSOR_MAX_BYTES,
+  );
+  if (!/^[A-Za-z0-9_-]+$/.test(cursor)) {
+    throw invalidProtocolFrame('Invalid agent graph terminal cursor');
+  }
+  return cursor;
+}
+
+function requireActivationStatus(value: unknown): AgentGraphActivationStatus {
+  if (
+    value === 'running' ||
+    value === 'completed' ||
+    value === 'failed' ||
+    value === 'aborted' ||
+    value === 'cancelled'
+  ) {
+    return value;
+  }
+  throw invalidProtocolFrame('Invalid agent graph activation status');
+}
+
+function requireOperatorStatus(value: unknown): AgentGraphClientOperatorStatus {
+  if (
+    value === 'not_started' ||
+    value === 'waiting' ||
+    value === 'runnable' ||
+    value === 'blocked'
+  ) {
+    return value;
+  }
+  return requireActivationStatus(value);
+}
+
+function requireGraphStatus(value: unknown): AgentGraphClientStatus {
+  if (
+    value === 'empty' ||
+    value === 'active' ||
+    value === 'closing' ||
+    value === 'waiting' ||
+    value === 'stopped' ||
+    value === 'failed' ||
+    value === 'completed'
+  ) {
+    return value;
+  }
+  throw invalidProtocolFrame('Invalid agent graph status');
+}
+
+function requireFacet(value: unknown): AgentGraphRecordFacet {
+  if (
+    value === 'message' ||
+    value === 'thinking' ||
+    value === 'error' ||
+    value === 'tool_call' ||
+    value === 'tool_dispatch' ||
+    value === 'tool_result' ||
+    value === 'artifact_update' ||
+    value === 'permission_request' ||
+    value === 'permission_decision' ||
+    value === 'user_question_request' ||
+    value === 'transfer' ||
+    value === 'usage' ||
+    value === 'completed' ||
+    value === 'failed' ||
+    value === 'aborted' ||
+    value === 'cancelled' ||
+    value === 'runtime_fact'
+  ) {
+    return value;
+  }
+  throw invalidProtocolFrame('Invalid agent graph record facet');
+}

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -24,6 +24,7 @@ import {
 } from './operations.js';
 
 export { RuntimeHostProtocolError } from './errors.js';
+export * from './agent-graph.js';
 export * from './interaction.js';
 export * from './automation.js';
 export * from './client-capability.js';

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -1,4 +1,5 @@
 import { ARTIFACT_OPERATION_SPECS } from './artifact.js';
+import { AGENT_GRAPH_OPERATION_SPECS } from './agent-graph.js';
 import { AUTOMATION_OPERATION_SPECS } from './automation.js';
 import { requireExactRecord, requireId, requireRecord, requireString } from './codec.js';
 import { CONNECTION_EFFECT_OPERATION_SPECS } from './connection-effects.js';
@@ -89,6 +90,7 @@ export type {
   TurnStopInput,
 } from './turn.js';
 export * from './connection-effects.js';
+export * from './agent-graph.js';
 export * from './execution-inspect.js';
 export * from './client-capability.js';
 export * from './goal.js';
@@ -104,6 +106,7 @@ export * from './usage-pricing.js';
 
 export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   HOST_STATUS_OPERATION_SPECS,
+  AGENT_GRAPH_OPERATION_SPECS,
   GOAL_OPERATION_SPECS,
   TURN_OPERATION_SPECS,
   CONNECTION_EFFECT_OPERATION_SPECS,

--- a/packages/runtime-host/src/protocol/session-continuity.ts
+++ b/packages/runtime-host/src/protocol/session-continuity.ts
@@ -154,6 +154,15 @@ export interface SessionEventFrame extends SubscriptionEnvelope {
   event: SessionToolEvent;
 }
 
+export type AgentGraphChangedReason = 'observation' | 'runtime_activity' | 'reconciled' | 'stopped';
+
+export interface AgentGraphChangedFrame extends SubscriptionEnvelope {
+  kind: 'subscription.agent_graph_changed';
+  rootSessionId: string;
+  graphId: string;
+  reason: AgentGraphChangedReason;
+}
+
 export interface SubscriptionClosedFrame extends SubscriptionEnvelope {
   kind: 'subscription.closed';
   reason: 'slow_consumer' | 'session_removed';
@@ -163,6 +172,7 @@ export type SubscriptionFrame =
   | SessionProjectionFrame
   | SessionDeltaFrame
   | SessionEventFrame
+  | AgentGraphChangedFrame
   | SubscriptionClosedFrame;
 
 const SUBSCRIPTION_OPEN_ERRORS = [
@@ -247,6 +257,23 @@ export function decodeSubscriptionFrame(value: unknown): SubscriptionFrame {
       runId: requireEntityId(record.runId, 'runId'),
       event: decodeSessionToolEvent(record.event),
     };
+  } else if (record.kind === 'subscription.agent_graph_changed') {
+    assertExactKeys(record, 'Agent graph changed frame', [
+      'kind',
+      'hostEpoch',
+      'subscriptionId',
+      'sequence',
+      'rootSessionId',
+      'graphId',
+      'reason',
+    ]);
+    frame = {
+      kind: record.kind,
+      ...envelope,
+      rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId'),
+      graphId: requireEntityId(record.graphId, 'graphId'),
+      reason: requireAgentGraphChangedReason(record.reason),
+    };
   } else if (record.kind === 'subscription.closed') {
     assertExactKeys(record, 'subscription closed frame', [
       'kind',
@@ -270,6 +297,7 @@ export function isSubscriptionFrameKind(value: unknown): value is SubscriptionFr
     value === 'subscription.session_projection' ||
     value === 'subscription.session_delta' ||
     value === 'subscription.session_event' ||
+    value === 'subscription.agent_graph_changed' ||
     value === 'subscription.closed'
   );
 }
@@ -648,4 +676,16 @@ function requireSessionLifecycleStatus(value: unknown): SessionLifecycleStatus {
   )
     return value;
   throw invalidProtocolFrame('Invalid Session lifecycle status');
+}
+
+function requireAgentGraphChangedReason(value: unknown): AgentGraphChangedReason {
+  if (
+    value === 'observation' ||
+    value === 'runtime_activity' ||
+    value === 'reconciled' ||
+    value === 'stopped'
+  ) {
+    return value;
+  }
+  throw invalidProtocolFrame('Invalid Agent graph changed reason');
 }

--- a/packages/runtime-host/src/server/agent-graph-coordinator.ts
+++ b/packages/runtime-host/src/server/agent-graph-coordinator.ts
@@ -1,8 +1,6 @@
-import type { SessionHeader } from '@maka/core/session';
 import {
-  AgentGraphOperatorNotFoundError,
+  AgentGraphClientOperationError,
   agentGraphIdForRootSession,
-  decodeAgentGraphTerminalCursor,
   encodeAgentGraphTerminalCursor,
   type AgentGraphClientChangedEvent,
   type AgentGraphClientOperator as RuntimeAgentGraphClientOperator,
@@ -46,10 +44,6 @@ type AgentGraphAuthority = Pick<
   'getSnapshot' | 'inspectOperator' | 'stop' | 'subscribeAll'
 >;
 
-type SessionReader = {
-  readHeaderSnapshot(sessionId: string): Promise<SessionHeader>;
-};
-
 type GraphContinuity = Pick<SessionContinuityCoordinator, 'enqueueAgentGraphChanged'>;
 
 type Mutable<T> = {
@@ -60,25 +54,11 @@ type Mutable<T> = {
       : T[K];
 };
 
-type RootOperationFailureCode =
-  | 'not_found'
-  | 'session_archived'
-  | 'operation_conflict'
-  | 'invalid_request';
+type RootOperationFailureCode = AgentGraphClientOperationError['code'];
 
 type GraphQueryFailureCode =
   | Exclude<RootOperationFailureCode, 'session_archived'>
   | 'persistence_failed';
-
-class RootOperationError extends Error {
-  constructor(
-    readonly code: RootOperationFailureCode,
-    message: string,
-  ) {
-    super(message);
-    this.name = 'RootOperationError';
-  }
-}
 
 /** Client-facing Runtime Host adapter over the durable Agent Graph read model. */
 export class HostAgentGraphCoordinator {
@@ -89,16 +69,13 @@ export class HostAgentGraphCoordinator {
   };
 
   readonly #authority: AgentGraphAuthority;
-  readonly #sessions: SessionReader;
   #unsubscribe: (() => void) | undefined;
 
   constructor(options: {
     authority: AgentGraphAuthority;
-    sessions: SessionReader;
     continuity: GraphContinuity;
   }) {
     this.#authority = options.authority;
-    this.#sessions = options.sessions;
     this.#unsubscribe = options.authority.subscribeAll((event) =>
       options.continuity.enqueueAgentGraphChanged(projectChangedEvent(event)),
     );
@@ -111,21 +88,6 @@ export class HostAgentGraphCoordinator {
 
   async #query(input: AgentGraphQueryInput): Promise<OperationOutcome<'agent.graph.query'>> {
     try {
-      await this.#assertRoot(input.rootSessionId, true);
-      if (input.terminalCursor) {
-        let cursor: ReturnType<typeof decodeAgentGraphTerminalCursor>;
-        try {
-          cursor = decodeAgentGraphTerminalCursor(input.terminalCursor);
-        } catch {
-          throw new RootOperationError('invalid_request', 'Agent graph terminal cursor is invalid');
-        }
-        if (cursor.graphId !== agentGraphIdForRootSession(input.rootSessionId)) {
-          throw new RootOperationError(
-            'invalid_request',
-            'Agent graph terminal cursor belongs to another root Session',
-          );
-        }
-      }
       const snapshot = await this.#authority.getSnapshot(input.rootSessionId, {
         ...(input.terminalCursor ? { terminalCursor: input.terminalCursor } : {}),
       });
@@ -139,23 +101,18 @@ export class HostAgentGraphCoordinator {
     input: AgentGraphOperatorQueryInput,
   ): Promise<OperationOutcome<'agent.graph.operator.query'>> {
     try {
-      await this.#assertRoot(input.rootSessionId, true);
       const inspection = await this.#authority.inspectOperator(
         input.rootSessionId,
         input.operatorId,
       );
       return { ok: true, result: projectInspection(inspection) };
     } catch (error) {
-      if (error instanceof AgentGraphOperatorNotFoundError) {
-        return failure('not_found', 'Agent graph operator was not found');
-      }
       return graphQueryFailure(error);
     }
   }
 
   async #stop(input: AgentGraphStopInput): Promise<OperationOutcome<'agent.graph.stop'>> {
     try {
-      await this.#assertRoot(input.rootSessionId, false);
       await this.#authority.stop(input.rootSessionId);
       return {
         ok: true,
@@ -165,38 +122,14 @@ export class HostAgentGraphCoordinator {
         },
       };
     } catch (error) {
-      if (error instanceof RootOperationError || isSessionNotFoundError(error)) {
-        const code = error instanceof RootOperationError ? error.code : 'not_found';
+      if (error instanceof AgentGraphClientOperationError || isSessionNotFoundError(error)) {
+        const code = error instanceof AgentGraphClientOperationError ? error.code : 'not_found';
         if (code === 'invalid_request') {
           return failure('internal_failure', 'Agent graph stop failed');
         }
         return failure(code, error instanceof Error ? error.message : 'Session was not found');
       }
       return failure('internal_failure', 'Agent graph stop failed');
-    }
-  }
-
-  async #assertRoot(rootSessionId: string, allowArchived: boolean): Promise<void> {
-    let header: SessionHeader;
-    try {
-      header = await this.#sessions.readHeaderSnapshot(rootSessionId);
-    } catch (error) {
-      if (isSessionNotFoundError(error)) {
-        throw new RootOperationError('not_found', 'Session was not found');
-      }
-      throw error;
-    }
-    if (header.subagentParent) {
-      throw new RootOperationError(
-        'operation_conflict',
-        'Agent graph Client operations require a root Session',
-      );
-    }
-    if (!allowArchived && (header.isArchived || header.status === 'archived')) {
-      throw new RootOperationError(
-        'session_archived',
-        'Archived Sessions cannot stop Agent graph execution',
-      );
     }
   }
 }
@@ -233,19 +166,21 @@ function projectSnapshot(snapshot: RuntimeAgentGraphClientSnapshot): AgentGraphC
       ? {}
       : { latestEventTime: snapshot.latestEventTime }),
     operators,
-    edges: candidateEdges.slice(0, AGENT_GRAPH_MAX_EDGES).map(clone),
-    work: snapshot.work.slice(0, AGENT_GRAPH_MAX_WORK).map(clone),
-    stoppedTargets: snapshot.stoppedTargets.slice(-AGENT_GRAPH_MAX_STOPPED_TARGETS).map(clone),
-    ...(snapshot.finish ? { finish: clone(snapshot.finish) } : {}),
-    claims: snapshot.claims.slice(-AGENT_GRAPH_MAX_CLAIMS).map(clone),
+    edges: candidateEdges.slice(0, AGENT_GRAPH_MAX_EDGES).map(projectEdge),
+    work: snapshot.work.slice(0, AGENT_GRAPH_MAX_WORK).map(projectWork),
+    stoppedTargets: snapshot.stoppedTargets
+      .slice(-AGENT_GRAPH_MAX_STOPPED_TARGETS)
+      .map(projectStoppedTarget),
+    ...(snapshot.finish ? { finish: projectFinish(snapshot.finish) } : {}),
+    claims: snapshot.claims.slice(-AGENT_GRAPH_MAX_CLAIMS).map(projectClaim),
     recentControlDecisions: snapshot.recentControlDecisions
       .slice(-AGENT_GRAPH_MAX_CONTROL_DECISIONS)
-      .map(clone),
-    recentActivity: snapshot.recentActivity.slice(-AGENT_GRAPH_MAX_ACTIVITY).map(clone),
+      .map(projectControlDecision),
+    recentActivity: snapshot.recentActivity.slice(-AGENT_GRAPH_MAX_ACTIVITY).map(projectActivity),
     terminalHistory: {
       records: snapshot.terminalHistory.records
         .slice(0, AGENT_GRAPH_MAX_TERMINAL_ACTIVITY)
-        .map(clone),
+        .map(projectActivity),
       ...(snapshot.terminalHistory.nextCursor
         ? { nextCursor: snapshot.terminalHistory.nextCursor }
         : {}),
@@ -286,12 +221,18 @@ function projectInspection(
     graphId: inspection.graphId,
     snapshotVersion: requireFingerprint(inspection.snapshotVersion),
     operator: projectOperator(inspection.operator),
-    inboundEdges: inspection.inboundEdges.slice(-AGENT_GRAPH_MAX_INSPECTION_EDGES).map(clone),
-    outboundEdges: inspection.outboundEdges.slice(-AGENT_GRAPH_MAX_INSPECTION_EDGES).map(clone),
-    work: inspection.work.slice(-AGENT_GRAPH_MAX_INSPECTION_WORK).map(clone),
-    claims: inspection.claims.slice(-AGENT_GRAPH_MAX_INSPECTION_CLAIMS).map(clone),
-    activations: inspection.activations.slice(-AGENT_GRAPH_MAX_INSPECTION_ACTIVATIONS).map(clone),
-    recentRecords: inspection.recentRecords.slice(-AGENT_GRAPH_MAX_INSPECTION_RECORDS).map(clone),
+    inboundEdges: inspection.inboundEdges.slice(-AGENT_GRAPH_MAX_INSPECTION_EDGES).map(projectEdge),
+    outboundEdges: inspection.outboundEdges
+      .slice(-AGENT_GRAPH_MAX_INSPECTION_EDGES)
+      .map(projectEdge),
+    work: inspection.work.slice(-AGENT_GRAPH_MAX_INSPECTION_WORK).map(projectWork),
+    claims: inspection.claims.slice(-AGENT_GRAPH_MAX_INSPECTION_CLAIMS).map(projectClaim),
+    activations: inspection.activations
+      .slice(-AGENT_GRAPH_MAX_INSPECTION_ACTIVATIONS)
+      .map(projectActivation),
+    recentRecords: inspection.recentRecords
+      .slice(-AGENT_GRAPH_MAX_INSPECTION_RECORDS)
+      .map(projectActivity),
     omitted: {
       inboundEdges:
         inspection.omitted.inboundEdges +
@@ -326,9 +267,13 @@ function projectOperator(
         wait.kind !== 'input_route' ||
         wait.upstreamOperatorIds.length <= AGENT_GRAPH_MAX_INPUT_ROUTE_OPERATORS,
     );
-    const waitingFor = eligibleWaits.slice(0, AGENT_GRAPH_MAX_READINESS_WAITS).map(clone);
+    const waitingFor = eligibleWaits
+      .slice(0, AGENT_GRAPH_MAX_READINESS_WAITS)
+      .map(projectReadinessWait);
     return {
-      ...clone(entry),
+      readinessId: entry.readinessId,
+      policyKind: entry.policyKind,
+      status: entry.status,
       waitingFor,
       omittedWaitingFor: entry.omittedWaitingFor + entry.waitingFor.length - waitingFor.length,
     };
@@ -346,7 +291,12 @@ function projectOperator(
   const outboundEdgeIds = operator.outboundEdgeIds.slice(-AGENT_GRAPH_MAX_OPERATOR_REFS);
   const scheduledWorkIds = operator.scheduledWorkIds.slice(-AGENT_GRAPH_MAX_OPERATOR_REFS);
   return {
-    ...clone(operator),
+    operatorId: operator.operatorId,
+    childSessionId: operator.childSessionId,
+    provisionId: operator.provisionId,
+    agentId: operator.agentId,
+    provisionedAt: operator.provisionedAt,
+    status: operator.status,
     inboundEdgeIds,
     outboundEdgeIds,
     scheduledWorkIds,
@@ -363,6 +313,160 @@ function projectOperator(
       readiness: operator.omitted.readiness + operator.readiness.length - readiness.length,
       readinessWaits: operator.omitted.readinessWaits + extraOmittedWaits + omittedReadinessWaits,
     },
+    ...(operator.currentActivation
+      ? {
+          currentActivation: {
+            activationId: operator.currentActivation.activationId,
+            status: operator.currentActivation.status,
+            recordCount: operator.currentActivation.recordCount,
+            firstEventTime: operator.currentActivation.firstEventTime,
+            lastEventTime: operator.currentActivation.lastEventTime,
+            ...(operator.currentActivation.terminalRecordId
+              ? { terminalRecordId: operator.currentActivation.terminalRecordId }
+              : {}),
+            run: projectRunRef(operator.currentActivation.run),
+          },
+        }
+      : {}),
+  };
+}
+
+function projectReadinessWait(
+  wait: RuntimeAgentGraphClientOperator['readiness'][number]['waitingFor'][number],
+): Mutable<AgentGraphClientOperator['readiness'][number]['waitingFor'][number]> {
+  return wait.kind === 'input_route'
+    ? { kind: wait.kind, upstreamOperatorIds: [...wait.upstreamOperatorIds] }
+    : {
+        kind: wait.kind,
+        operatorId: wait.operatorId,
+        activationId: wait.activationId,
+      };
+}
+
+function projectEdge(
+  edge: RuntimeAgentGraphClientSnapshot['edges'][number],
+): Mutable<AgentGraphClientSnapshot['edges'][number]> {
+  return {
+    edgeId: edge.edgeId,
+    fromOperatorId: edge.fromOperatorId,
+    toOperatorId: edge.toOperatorId,
+  };
+}
+
+function projectWork(
+  work: RuntimeAgentGraphClientSnapshot['work'][number],
+): Mutable<AgentGraphClientSnapshot['work'][number]> {
+  return {
+    workId: work.workId,
+    target:
+      work.target.kind === 'agent'
+        ? { kind: work.target.kind, agentId: work.target.agentId }
+        : { kind: work.target.kind, operatorId: work.target.operatorId },
+    inputIds: [...work.inputIds],
+    ...(work.replaces ? { replaces: work.replaces } : {}),
+    status: work.status,
+    instructionPreview: work.instructionPreview,
+    instructionTruncated: work.instructionTruncated,
+    revision: work.revision,
+    committedAt: work.committedAt,
+  };
+}
+
+function projectStoppedTarget(
+  target: RuntimeAgentGraphClientSnapshot['stoppedTargets'][number],
+): Mutable<AgentGraphClientSnapshot['stoppedTargets'][number]> {
+  return {
+    targetId: target.targetId,
+    reason: target.reason,
+    revision: target.revision,
+    committedAt: target.committedAt,
+  };
+}
+
+function projectFinish(
+  finish: NonNullable<RuntimeAgentGraphClientSnapshot['finish']>,
+): Mutable<NonNullable<AgentGraphClientSnapshot['finish']>> {
+  return {
+    resultIds: [...finish.resultIds],
+    reason: finish.reason,
+    revision: finish.revision,
+    committedAt: finish.committedAt,
+  };
+}
+
+function projectClaim(
+  claim: RuntimeAgentGraphClientSnapshot['claims'][number],
+): Mutable<AgentGraphClientSnapshot['claims'][number]> {
+  return {
+    claimId: claim.claimId,
+    intentId: claim.intentId,
+    operatorId: claim.operatorId,
+    childSessionId: claim.childSessionId,
+    run: projectRunRef(claim.run),
+    admissionState: claim.admissionState,
+    claimedAt: claim.claimedAt,
+  };
+}
+
+function projectControlDecision(
+  decision: RuntimeAgentGraphClientSnapshot['recentControlDecisions'][number],
+): Mutable<AgentGraphClientSnapshot['recentControlDecisions'][number]> {
+  return {
+    updateId: decision.updateId,
+    revision: decision.revision,
+    committedAt: decision.committedAt,
+    source: {
+      sessionId: decision.source.sessionId,
+      agentRunId: decision.source.agentRunId,
+      turnId: decision.source.turnId,
+      toolCallId: decision.source.toolCallId,
+    },
+    addedWorkIds: [...decision.addedWorkIds],
+    stoppedTargetIds: [...decision.stoppedTargetIds],
+    selectedResultIds: [...decision.selectedResultIds],
+  };
+}
+
+function projectActivity(
+  activity: RuntimeAgentGraphClientSnapshot['recentActivity'][number],
+): Mutable<AgentGraphClientSnapshot['recentActivity'][number]> {
+  return {
+    recordId: activity.recordId,
+    operatorId: activity.operatorId,
+    activationId: activity.activationId,
+    eventTime: activity.eventTime,
+    facets: [...activity.facets],
+    signals: activity.signals.map((signal) =>
+      signal.kind === 'attention'
+        ? { kind: signal.kind, reason: signal.reason }
+        : { kind: signal.kind, status: signal.status },
+    ),
+    run: projectRunRef(activity.run),
+  };
+}
+
+function projectActivation(
+  activation: RuntimeAgentGraphOperatorInspection['activations'][number],
+): Mutable<AgentGraphOperatorInspection['activations'][number]> {
+  return {
+    activationId: activation.activationId,
+    status: activation.status,
+    recordCount: activation.recordCount,
+    firstEventTime: activation.firstEventTime,
+    lastEventTime: activation.lastEventTime,
+    lastRecordId: activation.lastRecordId,
+    ...(activation.terminalRecordId ? { terminalRecordId: activation.terminalRecordId } : {}),
+    run: projectRunRef(activation.run),
+  };
+}
+
+function projectRunRef(
+  run: RuntimeAgentGraphClientSnapshot['recentActivity'][number]['run'],
+): Mutable<AgentGraphClientSnapshot['recentActivity'][number]['run']> {
+  return {
+    sessionId: run.sessionId,
+    agentRunId: run.agentRunId,
+    ...(run.turnId ? { turnId: run.turnId } : {}),
   };
 }
 
@@ -476,7 +580,7 @@ function graphQueryFailure(error: unknown): {
   ok: false;
   error: { code: GraphQueryFailureCode; message: string };
 } {
-  if (error instanceof RootOperationError) {
+  if (error instanceof AgentGraphClientOperationError) {
     return error.code === 'session_archived'
       ? failure('operation_conflict', error.message)
       : failure(error.code, error.message);
@@ -501,8 +605,4 @@ function requireFingerprint(value: string): `sha256:${string}` {
 
 function encodedBytes(value: unknown): number {
   return Buffer.byteLength(JSON.stringify(value), 'utf8');
-}
-
-function clone<T>(value: T): Mutable<T> {
-  return structuredClone(value) as Mutable<T>;
 }

--- a/packages/runtime-host/src/server/agent-graph-coordinator.ts
+++ b/packages/runtime-host/src/server/agent-graph-coordinator.ts
@@ -1,0 +1,508 @@
+import type { SessionHeader } from '@maka/core/session';
+import {
+  AgentGraphOperatorNotFoundError,
+  agentGraphIdForRootSession,
+  decodeAgentGraphTerminalCursor,
+  encodeAgentGraphTerminalCursor,
+  type AgentGraphClientChangedEvent,
+  type AgentGraphClientOperator as RuntimeAgentGraphClientOperator,
+  type AgentGraphClientSnapshot as RuntimeAgentGraphClientSnapshot,
+  type AgentGraphCoordinator,
+  type AgentGraphOperatorInspection as RuntimeAgentGraphOperatorInspection,
+} from '@maka/runtime';
+import { isSessionNotFoundError } from '@maka/storage/execution-stores';
+import {
+  AGENT_GRAPH_MAX_ACTIVITY,
+  AGENT_GRAPH_MAX_CLAIMS,
+  AGENT_GRAPH_MAX_CONTROL_DECISIONS,
+  AGENT_GRAPH_MAX_EDGES,
+  AGENT_GRAPH_MAX_INPUT_ROUTE_OPERATORS,
+  AGENT_GRAPH_MAX_INSPECTION_ACTIVATIONS,
+  AGENT_GRAPH_MAX_INSPECTION_CLAIMS,
+  AGENT_GRAPH_MAX_INSPECTION_EDGES,
+  AGENT_GRAPH_MAX_INSPECTION_RECORDS,
+  AGENT_GRAPH_MAX_INSPECTION_WORK,
+  AGENT_GRAPH_MAX_OPERATORS,
+  AGENT_GRAPH_MAX_OPERATOR_READINESS,
+  AGENT_GRAPH_MAX_OPERATOR_REFS,
+  AGENT_GRAPH_MAX_READINESS_WAITS,
+  AGENT_GRAPH_MAX_STOPPED_TARGETS,
+  AGENT_GRAPH_MAX_TERMINAL_ACTIVITY,
+  AGENT_GRAPH_MAX_WORK,
+  AGENT_GRAPH_RESULT_MAX_BYTES,
+  type AgentGraphClientOperator,
+  type AgentGraphClientSnapshot,
+  type AgentGraphOperatorInspection,
+  type AgentGraphOperatorQueryInput,
+  type AgentGraphQueryInput,
+  type AgentGraphStopInput,
+  type OperationOutcome,
+} from '../protocol/index.js';
+import type { AgentGraphOperationHandlerMap } from './operation-dispatcher.js';
+import type { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
+
+type AgentGraphAuthority = Pick<
+  AgentGraphCoordinator,
+  'getSnapshot' | 'inspectOperator' | 'stop' | 'subscribeAll'
+>;
+
+type SessionReader = {
+  readHeaderSnapshot(sessionId: string): Promise<SessionHeader>;
+};
+
+type GraphContinuity = Pick<SessionContinuityCoordinator, 'enqueueAgentGraphChanged'>;
+
+type Mutable<T> = {
+  -readonly [K in keyof T]: T[K] extends readonly (infer Item)[]
+    ? Mutable<Item>[]
+    : T[K] extends object
+      ? Mutable<T[K]>
+      : T[K];
+};
+
+type RootOperationFailureCode =
+  | 'not_found'
+  | 'session_archived'
+  | 'operation_conflict'
+  | 'invalid_request';
+
+type GraphQueryFailureCode =
+  | Exclude<RootOperationFailureCode, 'session_archived'>
+  | 'persistence_failed';
+
+class RootOperationError extends Error {
+  constructor(
+    readonly code: RootOperationFailureCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RootOperationError';
+  }
+}
+
+/** Client-facing Runtime Host adapter over the durable Agent Graph read model. */
+export class HostAgentGraphCoordinator {
+  readonly handlers: AgentGraphOperationHandlerMap = {
+    'agent.graph.query': (input) => this.#query(input),
+    'agent.graph.operator.query': (input) => this.#queryOperator(input),
+    'agent.graph.stop': (input) => this.#stop(input),
+  };
+
+  readonly #authority: AgentGraphAuthority;
+  readonly #sessions: SessionReader;
+  #unsubscribe: (() => void) | undefined;
+
+  constructor(options: {
+    authority: AgentGraphAuthority;
+    sessions: SessionReader;
+    continuity: GraphContinuity;
+  }) {
+    this.#authority = options.authority;
+    this.#sessions = options.sessions;
+    this.#unsubscribe = options.authority.subscribeAll((event) =>
+      options.continuity.enqueueAgentGraphChanged(projectChangedEvent(event)),
+    );
+  }
+
+  close(): void {
+    this.#unsubscribe?.();
+    this.#unsubscribe = undefined;
+  }
+
+  async #query(input: AgentGraphQueryInput): Promise<OperationOutcome<'agent.graph.query'>> {
+    try {
+      await this.#assertRoot(input.rootSessionId, true);
+      if (input.terminalCursor) {
+        let cursor: ReturnType<typeof decodeAgentGraphTerminalCursor>;
+        try {
+          cursor = decodeAgentGraphTerminalCursor(input.terminalCursor);
+        } catch {
+          throw new RootOperationError('invalid_request', 'Agent graph terminal cursor is invalid');
+        }
+        if (cursor.graphId !== agentGraphIdForRootSession(input.rootSessionId)) {
+          throw new RootOperationError(
+            'invalid_request',
+            'Agent graph terminal cursor belongs to another root Session',
+          );
+        }
+      }
+      const snapshot = await this.#authority.getSnapshot(input.rootSessionId, {
+        ...(input.terminalCursor ? { terminalCursor: input.terminalCursor } : {}),
+      });
+      return { ok: true, result: projectSnapshot(snapshot) };
+    } catch (error) {
+      return graphQueryFailure(error);
+    }
+  }
+
+  async #queryOperator(
+    input: AgentGraphOperatorQueryInput,
+  ): Promise<OperationOutcome<'agent.graph.operator.query'>> {
+    try {
+      await this.#assertRoot(input.rootSessionId, true);
+      const inspection = await this.#authority.inspectOperator(
+        input.rootSessionId,
+        input.operatorId,
+      );
+      return { ok: true, result: projectInspection(inspection) };
+    } catch (error) {
+      if (error instanceof AgentGraphOperatorNotFoundError) {
+        return failure('not_found', 'Agent graph operator was not found');
+      }
+      return graphQueryFailure(error);
+    }
+  }
+
+  async #stop(input: AgentGraphStopInput): Promise<OperationOutcome<'agent.graph.stop'>> {
+    try {
+      await this.#assertRoot(input.rootSessionId, false);
+      await this.#authority.stop(input.rootSessionId);
+      return {
+        ok: true,
+        result: {
+          rootSessionId: input.rootSessionId,
+          graphId: agentGraphIdForRootSession(input.rootSessionId),
+        },
+      };
+    } catch (error) {
+      if (error instanceof RootOperationError || isSessionNotFoundError(error)) {
+        const code = error instanceof RootOperationError ? error.code : 'not_found';
+        if (code === 'invalid_request') {
+          return failure('internal_failure', 'Agent graph stop failed');
+        }
+        return failure(code, error instanceof Error ? error.message : 'Session was not found');
+      }
+      return failure('internal_failure', 'Agent graph stop failed');
+    }
+  }
+
+  async #assertRoot(rootSessionId: string, allowArchived: boolean): Promise<void> {
+    let header: SessionHeader;
+    try {
+      header = await this.#sessions.readHeaderSnapshot(rootSessionId);
+    } catch (error) {
+      if (isSessionNotFoundError(error)) {
+        throw new RootOperationError('not_found', 'Session was not found');
+      }
+      throw error;
+    }
+    if (header.subagentParent) {
+      throw new RootOperationError(
+        'operation_conflict',
+        'Agent graph Client operations require a root Session',
+      );
+    }
+    if (!allowArchived && (header.isArchived || header.status === 'archived')) {
+      throw new RootOperationError(
+        'session_archived',
+        'Archived Sessions cannot stop Agent graph execution',
+      );
+    }
+  }
+}
+
+export function projectAgentGraphClientSnapshot(
+  snapshot: RuntimeAgentGraphClientSnapshot,
+): AgentGraphClientSnapshot {
+  return projectSnapshot(snapshot);
+}
+
+export function projectAgentGraphOperatorInspection(
+  inspection: RuntimeAgentGraphOperatorInspection,
+): AgentGraphOperatorInspection {
+  return projectInspection(inspection);
+}
+
+function projectSnapshot(snapshot: RuntimeAgentGraphClientSnapshot): AgentGraphClientSnapshot {
+  const operators = snapshot.operators.slice(0, AGENT_GRAPH_MAX_OPERATORS).map(projectOperator);
+  const visibleOperatorIds = new Set(operators.map((operator) => operator.operatorId));
+  const candidateEdges = snapshot.edges.filter(
+    (edge) =>
+      visibleOperatorIds.has(edge.fromOperatorId) && visibleOperatorIds.has(edge.toOperatorId),
+  );
+  const projected: Mutable<AgentGraphClientSnapshot> = {
+    schemaVersion: 1,
+    rootSessionId: snapshot.rootSessionId,
+    graphId: snapshot.graphId,
+    snapshotVersion: requireFingerprint(snapshot.snapshotVersion),
+    status: snapshot.status,
+    scheduleRevision: snapshot.scheduleRevision,
+    topologyFingerprint: requireFingerprint(snapshot.topologyFingerprint),
+    closed: snapshot.closed,
+    ...(snapshot.latestEventTime === undefined
+      ? {}
+      : { latestEventTime: snapshot.latestEventTime }),
+    operators,
+    edges: candidateEdges.slice(0, AGENT_GRAPH_MAX_EDGES).map(clone),
+    work: snapshot.work.slice(0, AGENT_GRAPH_MAX_WORK).map(clone),
+    stoppedTargets: snapshot.stoppedTargets.slice(-AGENT_GRAPH_MAX_STOPPED_TARGETS).map(clone),
+    ...(snapshot.finish ? { finish: clone(snapshot.finish) } : {}),
+    claims: snapshot.claims.slice(-AGENT_GRAPH_MAX_CLAIMS).map(clone),
+    recentControlDecisions: snapshot.recentControlDecisions
+      .slice(-AGENT_GRAPH_MAX_CONTROL_DECISIONS)
+      .map(clone),
+    recentActivity: snapshot.recentActivity.slice(-AGENT_GRAPH_MAX_ACTIVITY).map(clone),
+    terminalHistory: {
+      records: snapshot.terminalHistory.records
+        .slice(0, AGENT_GRAPH_MAX_TERMINAL_ACTIVITY)
+        .map(clone),
+      ...(snapshot.terminalHistory.nextCursor
+        ? { nextCursor: snapshot.terminalHistory.nextCursor }
+        : {}),
+    },
+    omitted: {
+      operators: snapshot.omitted.operators + snapshot.operators.length - operators.length,
+      edges:
+        snapshot.omitted.edges +
+        snapshot.edges.length -
+        Math.min(candidateEdges.length, AGENT_GRAPH_MAX_EDGES),
+      work: snapshot.omitted.work + Math.max(0, snapshot.work.length - AGENT_GRAPH_MAX_WORK),
+      stoppedTargets:
+        snapshot.omitted.stoppedTargets +
+        Math.max(0, snapshot.stoppedTargets.length - AGENT_GRAPH_MAX_STOPPED_TARGETS),
+      claims:
+        snapshot.omitted.claims + Math.max(0, snapshot.claims.length - AGENT_GRAPH_MAX_CLAIMS),
+      controlDecisions:
+        snapshot.omitted.controlDecisions +
+        Math.max(0, snapshot.recentControlDecisions.length - AGENT_GRAPH_MAX_CONTROL_DECISIONS),
+      recentActivity:
+        snapshot.omitted.recentActivity +
+        Math.max(0, snapshot.recentActivity.length - AGENT_GRAPH_MAX_ACTIVITY),
+    },
+  };
+  if (snapshot.terminalHistory.records.length > projected.terminalHistory.records.length) {
+    updateTerminalCursor(projected);
+  }
+  fitSnapshot(projected);
+  return projected;
+}
+
+function projectInspection(
+  inspection: RuntimeAgentGraphOperatorInspection,
+): AgentGraphOperatorInspection {
+  const projected: Mutable<AgentGraphOperatorInspection> = {
+    schemaVersion: 1,
+    rootSessionId: inspection.rootSessionId,
+    graphId: inspection.graphId,
+    snapshotVersion: requireFingerprint(inspection.snapshotVersion),
+    operator: projectOperator(inspection.operator),
+    inboundEdges: inspection.inboundEdges.slice(-AGENT_GRAPH_MAX_INSPECTION_EDGES).map(clone),
+    outboundEdges: inspection.outboundEdges.slice(-AGENT_GRAPH_MAX_INSPECTION_EDGES).map(clone),
+    work: inspection.work.slice(-AGENT_GRAPH_MAX_INSPECTION_WORK).map(clone),
+    claims: inspection.claims.slice(-AGENT_GRAPH_MAX_INSPECTION_CLAIMS).map(clone),
+    activations: inspection.activations.slice(-AGENT_GRAPH_MAX_INSPECTION_ACTIVATIONS).map(clone),
+    recentRecords: inspection.recentRecords.slice(-AGENT_GRAPH_MAX_INSPECTION_RECORDS).map(clone),
+    omitted: {
+      inboundEdges:
+        inspection.omitted.inboundEdges +
+        Math.max(0, inspection.inboundEdges.length - AGENT_GRAPH_MAX_INSPECTION_EDGES),
+      outboundEdges:
+        inspection.omitted.outboundEdges +
+        Math.max(0, inspection.outboundEdges.length - AGENT_GRAPH_MAX_INSPECTION_EDGES),
+      work:
+        inspection.omitted.work +
+        Math.max(0, inspection.work.length - AGENT_GRAPH_MAX_INSPECTION_WORK),
+      claims:
+        inspection.omitted.claims +
+        Math.max(0, inspection.claims.length - AGENT_GRAPH_MAX_INSPECTION_CLAIMS),
+      activations:
+        inspection.omitted.activations +
+        Math.max(0, inspection.activations.length - AGENT_GRAPH_MAX_INSPECTION_ACTIVATIONS),
+      records:
+        inspection.omitted.records +
+        Math.max(0, inspection.recentRecords.length - AGENT_GRAPH_MAX_INSPECTION_RECORDS),
+    },
+  };
+  fitInspection(projected);
+  return projected;
+}
+
+function projectOperator(
+  operator: RuntimeAgentGraphClientOperator,
+): Mutable<AgentGraphClientOperator> {
+  const readiness = operator.readiness.slice(0, AGENT_GRAPH_MAX_OPERATOR_READINESS).map((entry) => {
+    const eligibleWaits = entry.waitingFor.filter(
+      (wait) =>
+        wait.kind !== 'input_route' ||
+        wait.upstreamOperatorIds.length <= AGENT_GRAPH_MAX_INPUT_ROUTE_OPERATORS,
+    );
+    const waitingFor = eligibleWaits.slice(0, AGENT_GRAPH_MAX_READINESS_WAITS).map(clone);
+    return {
+      ...clone(entry),
+      waitingFor,
+      omittedWaitingFor: entry.omittedWaitingFor + entry.waitingFor.length - waitingFor.length,
+    };
+  });
+  const extraOmittedWaits = operator.readiness
+    .slice(0, AGENT_GRAPH_MAX_OPERATOR_READINESS)
+    .reduce((count, entry, index) => {
+      const visible = readiness[index]?.waitingFor.length ?? 0;
+      return count + entry.waitingFor.length - visible;
+    }, 0);
+  const omittedReadinessWaits = operator.readiness
+    .slice(AGENT_GRAPH_MAX_OPERATOR_READINESS)
+    .reduce((count, entry) => count + entry.waitingFor.length, 0);
+  const inboundEdgeIds = operator.inboundEdgeIds.slice(-AGENT_GRAPH_MAX_OPERATOR_REFS);
+  const outboundEdgeIds = operator.outboundEdgeIds.slice(-AGENT_GRAPH_MAX_OPERATOR_REFS);
+  const scheduledWorkIds = operator.scheduledWorkIds.slice(-AGENT_GRAPH_MAX_OPERATOR_REFS);
+  return {
+    ...clone(operator),
+    inboundEdgeIds,
+    outboundEdgeIds,
+    scheduledWorkIds,
+    readiness,
+    omitted: {
+      inboundEdgeIds:
+        operator.omitted.inboundEdgeIds + operator.inboundEdgeIds.length - inboundEdgeIds.length,
+      outboundEdgeIds:
+        operator.omitted.outboundEdgeIds + operator.outboundEdgeIds.length - outboundEdgeIds.length,
+      scheduledWorkIds:
+        operator.omitted.scheduledWorkIds +
+        operator.scheduledWorkIds.length -
+        scheduledWorkIds.length,
+      readiness: operator.omitted.readiness + operator.readiness.length - readiness.length,
+      readinessWaits: operator.omitted.readinessWaits + extraOmittedWaits + omittedReadinessWaits,
+    },
+  };
+}
+
+function fitSnapshot(snapshot: Mutable<AgentGraphClientSnapshot>): void {
+  while (encodedBytes(snapshot) > AGENT_GRAPH_RESULT_MAX_BYTES) {
+    if (snapshot.terminalHistory.records.length > 1) {
+      snapshot.terminalHistory.records.pop();
+      updateTerminalCursor(snapshot);
+      continue;
+    }
+    if (snapshot.recentActivity.shift()) {
+      snapshot.omitted.recentActivity += 1;
+      continue;
+    }
+    if (snapshot.recentControlDecisions.shift()) {
+      snapshot.omitted.controlDecisions += 1;
+      continue;
+    }
+    if (snapshot.stoppedTargets.shift()) {
+      snapshot.omitted.stoppedTargets += 1;
+      continue;
+    }
+    if (snapshot.claims.shift()) {
+      snapshot.omitted.claims += 1;
+      continue;
+    }
+    const terminalWorkIndex = snapshot.work.findIndex((entry) => entry.status !== 'requested');
+    const removedWork = snapshot.work.splice(
+      terminalWorkIndex < 0 ? snapshot.work.length - 1 : terminalWorkIndex,
+      1,
+    )[0];
+    if (removedWork) {
+      snapshot.omitted.work += 1;
+      continue;
+    }
+    if (snapshot.edges.pop()) {
+      snapshot.omitted.edges += 1;
+      continue;
+    }
+    const terminalOperatorIndex = snapshot.operators.findIndex((entry) =>
+      ['completed', 'failed', 'aborted', 'cancelled'].includes(entry.status),
+    );
+    const operator = snapshot.operators.splice(
+      terminalOperatorIndex < 0 ? snapshot.operators.length - 1 : terminalOperatorIndex,
+      1,
+    )[0];
+    if (operator) {
+      snapshot.omitted.operators += 1;
+      const retainedEdges = snapshot.edges.filter(
+        (edge) =>
+          edge.fromOperatorId !== operator.operatorId && edge.toOperatorId !== operator.operatorId,
+      );
+      snapshot.omitted.edges += snapshot.edges.length - retainedEdges.length;
+      snapshot.edges = retainedEdges;
+      continue;
+    }
+    throw new Error('Agent graph snapshot cannot fit the Runtime Host wire limit');
+  }
+}
+
+function fitInspection(inspection: Mutable<AgentGraphOperatorInspection>): void {
+  while (encodedBytes(inspection) > AGENT_GRAPH_RESULT_MAX_BYTES) {
+    if (inspection.recentRecords.shift()) {
+      inspection.omitted.records += 1;
+      continue;
+    }
+    if (inspection.activations.shift()) {
+      inspection.omitted.activations += 1;
+      continue;
+    }
+    if (inspection.claims.shift()) {
+      inspection.omitted.claims += 1;
+      continue;
+    }
+    if (inspection.work.shift()) {
+      inspection.omitted.work += 1;
+      continue;
+    }
+    if (inspection.inboundEdges.shift()) {
+      inspection.omitted.inboundEdges += 1;
+      continue;
+    }
+    if (inspection.outboundEdges.shift()) {
+      inspection.omitted.outboundEdges += 1;
+      continue;
+    }
+    throw new Error('Agent graph operator inspection cannot fit the Runtime Host wire limit');
+  }
+}
+
+function updateTerminalCursor(snapshot: Mutable<AgentGraphClientSnapshot>): void {
+  const last = snapshot.terminalHistory.records.at(-1);
+  if (last) {
+    snapshot.terminalHistory.nextCursor = encodeAgentGraphTerminalCursor(snapshot.graphId, last);
+  }
+}
+
+function projectChangedEvent(event: AgentGraphClientChangedEvent): {
+  rootSessionId: string;
+  graphId: string;
+  reason: AgentGraphClientChangedEvent['reason'];
+} {
+  return {
+    rootSessionId: event.rootSessionId,
+    graphId: event.graphId,
+    reason: event.reason,
+  };
+}
+
+function graphQueryFailure(error: unknown): {
+  ok: false;
+  error: { code: GraphQueryFailureCode; message: string };
+} {
+  if (error instanceof RootOperationError) {
+    return error.code === 'session_archived'
+      ? failure('operation_conflict', error.message)
+      : failure(error.code, error.message);
+  }
+  if (isSessionNotFoundError(error)) return failure('not_found', 'Session was not found');
+  return failure('persistence_failed', 'Agent graph projection is unavailable');
+}
+
+function failure<Code extends RootOperationFailureCode | 'persistence_failed' | 'internal_failure'>(
+  code: Code,
+  message: string,
+): { ok: false; error: { code: Code; message: string } } {
+  return { ok: false, error: { code, message } };
+}
+
+function requireFingerprint(value: string): `sha256:${string}` {
+  if (!/^sha256:[a-f0-9]{64}$/.test(value)) {
+    throw new Error('Agent graph projection contains an invalid fingerprint');
+  }
+  return value as `sha256:${string}`;
+}
+
+function encodedBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+function clone<T>(value: T): Mutable<T> {
+  return structuredClone(value) as Mutable<T>;
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -43,6 +43,7 @@ import {
 } from './child-agent-composition.js';
 import { HostCanonicalPermissionOutcomeReader } from './canonical-permission-outcome-reader.js';
 import { HostArtifactCoordinator } from './artifact-coordinator.js';
+import { HostAgentGraphCoordinator } from './agent-graph-coordinator.js';
 import { HostAutomationCoordinator } from './automation-coordinator.js';
 import { recoverClientCapabilityOutcomes } from './client-capability-recovery.js';
 import { HostConnectionEffectCoordinator } from './connection-effect-coordinator.js';
@@ -88,6 +89,7 @@ export async function createExecutionRuntimeHostComposition(
   let automationStore:
     | Awaited<ReturnType<typeof openInteractiveAutomationAuthorityForWrite>>
     | undefined;
+  let graphClient: HostAgentGraphCoordinator | undefined;
   try {
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,
@@ -379,6 +381,11 @@ export async function createExecutionRuntimeHostComposition(
         void requireGraphSupervisorWake(graphSupervisorWake).notify(rootSessionId, result);
       },
     });
+    graphClient = new HostAgentGraphCoordinator({
+      authority: graphCoordinator,
+      sessions: stores.sessionStore,
+      continuity: continuityCoordinator,
+    });
     const observeBackendInvalidation = (completion: Promise<void>) => {
       void completion.catch(() => {
         backendInvalidationPoisoned = true;
@@ -575,6 +582,7 @@ export async function createExecutionRuntimeHostComposition(
       ...requireGoal(goal).handlers,
       ...sessionCatalog.handlers,
       ...executionInspect.handlers,
+      ...graphClient.handlers,
       ...sessionRevisions.handlers,
       ...sessionRetirement.handlers,
       ...messages.handlers,
@@ -651,6 +659,11 @@ export async function createExecutionRuntimeHostComposition(
         }
         try {
           await graphSupervisorWake?.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
+          graphClient?.close();
         } catch (error) {
           errors.push(error);
         }
@@ -786,6 +799,11 @@ export async function createExecutionRuntimeHostComposition(
     };
   } catch (error) {
     const errors: unknown[] = [error];
+    try {
+      graphClient?.close();
+    } catch (closeError) {
+      errors.push(closeError);
+    }
     try {
       graphControlStore?.close();
     } catch (closeError) {

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -383,7 +383,6 @@ export async function createExecutionRuntimeHostComposition(
     });
     graphClient = new HostAgentGraphCoordinator({
       authority: graphCoordinator,
-      sessions: stores.sessionStore,
       continuity: continuityCoordinator,
     });
     const observeBackendInvalidation = (completion: Promise<void>) => {

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -50,6 +50,7 @@ export type MessageOperationKey = Extract<
 export type InteractionOperationKey = Extract<OperationKey, `interaction.${string}`>;
 export type GoalOperationKey = Extract<OperationKey, `goal.${string}`>;
 export type ExecutionInspectOperationKey = Extract<OperationKey, `execution.inspect.${string}`>;
+export type AgentGraphOperationKey = Extract<OperationKey, `agent.graph.${string}`>;
 export type SessionContinuityOperationKey = Extract<
   OperationKey,
   'subscription.open' | 'subscription.close'
@@ -89,6 +90,7 @@ export type ExecutionInspectOperationHandlerMap = Pick<
   OperationHandlerMap,
   ExecutionInspectOperationKey
 >;
+export type AgentGraphOperationHandlerMap = Pick<OperationHandlerMap, AgentGraphOperationKey>;
 export type SessionContinuityOperationHandlerMap = Pick<
   OperationHandlerMap,
   SessionContinuityOperationKey

--- a/packages/runtime-host/src/server/session-continuity-coordinator.ts
+++ b/packages/runtime-host/src/server/session-continuity-coordinator.ts
@@ -6,6 +6,8 @@ import {
   RUNTIME_HOST_MAX_FRAME_BYTES,
   SESSION_LIVE_DELTA_MAX_BYTES,
   SESSION_TOOL_NAME_MAX_BYTES,
+  type AgentGraphChangedFrame,
+  type AgentGraphChangedReason,
   type SessionAssistantDelta,
   type SessionContinuitySnapshot,
   type SessionDeltaFrame,
@@ -93,6 +95,14 @@ interface PendingRefresh {
   inFlight: boolean;
 }
 
+interface PendingAgentGraphChange {
+  event: {
+    rootSessionId: string;
+    graphId: string;
+    reason: AgentGraphChangedReason;
+  };
+}
+
 export class SessionContinuityCoordinator implements SessionContinuityService {
   readonly handlers: SessionContinuityOperationHandlerMap = {
     'subscription.open': async (input, context) => {
@@ -116,6 +126,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
   readonly #sessions = new Map<string, SessionProjectionState>();
   readonly #subscriptions = new Map<string, Subscriber>();
   readonly #pendingRefreshes = new Map<string, PendingRefresh>();
+  readonly #pendingAgentGraphChanges = new Map<string, PendingAgentGraphChange>();
   readonly #hostEpoch: string;
   readonly #readCanonical: ReadCanonicalSessionProjection;
   #closed = false;
@@ -203,6 +214,46 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
           this.onPublicationFailure(error);
         },
       );
+  }
+
+  /** Coalesce process-local graph invalidations onto the root Session sequence. */
+  enqueueAgentGraphChanged(event: {
+    rootSessionId: string;
+    graphId: string;
+    reason: AgentGraphChangedReason;
+  }): void {
+    if (this.#closed) return;
+    const pending = this.#pendingAgentGraphChanges.get(event.rootSessionId);
+    if (pending) {
+      pending.event = { ...event };
+      return;
+    }
+    const change: PendingAgentGraphChange = { event: { ...event } };
+    this.#pendingAgentGraphChanges.set(event.rootSessionId, change);
+    void this.sessionAdmission
+      .enqueueDetached(event.rootSessionId, () => {
+        if (this.#pendingAgentGraphChanges.get(event.rootSessionId) !== change) return;
+        this.#pendingAgentGraphChanges.delete(event.rootSessionId);
+        if (this.#closed) return;
+        const state = this.#sessions.get(event.rootSessionId);
+        if (!state) return;
+        for (const subscriber of state.subscribers.values()) {
+          const frame: AgentGraphChangedFrame = {
+            kind: 'subscription.agent_graph_changed',
+            hostEpoch: this.#hostEpoch,
+            subscriptionId: subscriber.subscriptionId,
+            sequence: subscriber.nextSequence,
+            ...change.event,
+          };
+          this.#enqueue(subscriber, frame);
+        }
+      })
+      .catch((error: unknown) => {
+        if (this.#pendingAgentGraphChanges.get(event.rootSessionId) === change) {
+          this.#pendingAgentGraphChanges.delete(event.rootSessionId);
+        }
+        this.onPublicationFailure(error);
+      });
   }
 
   async holdTerminalPublication(
@@ -362,6 +413,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     this.#sessions.clear();
     this.#subscriptions.clear();
     this.#pendingRefreshes.clear();
+    this.#pendingAgentGraphChanges.clear();
   }
 
   async #open(

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -29,10 +29,12 @@ import { SessionActivityRegistry } from '../goal-turn-lifecycle.js';
 import { AgentGraphSupervisorWakeCoordinator } from '../agent-graph-supervisor-wake.js';
 import type { MakaTool, MakaToolContext } from '../tool-runtime.js';
 import {
+  AgentGraphClientOperationError,
   AgentGraphCoordinator,
   agentGraphIdForRootSession,
   type AgentGraphCoordinatorInput,
 } from '../stream-graph-coordinator.js';
+import { encodeAgentGraphTerminalCursor } from '../stream-graph-read-model.js';
 import {
   UPDATE_AGENT_GRAPH_TOOL_NAME,
   YIELD_AGENT_GRAPH_TOOL_NAME,
@@ -263,13 +265,32 @@ describe('host-managed agent graph coordinator', () => {
       assert.equal(inspection.claims.length, 1);
       assert.equal(inspection.activations.length, 1);
       assert.deepEqual(delayedControlStore.projectionReadCounts(), {
+        snapshot: readsBeforeInspection.snapshot + 1,
         composite: readsBeforeInspection.composite + 1,
         operator: readsBeforeInspection.operator,
+        terminal: readsBeforeInspection.terminal,
       });
       assert.equal(
         graphRuntimeHistoryReads,
         historyReadsBeforeClient,
         'client reads must use the materialized SQLite projection',
+      );
+      const readsBeforeInvalidCursor = delayedControlStore.projectionReadCounts();
+      const commitsBeforeInvalidCursor = delayedControlStore.projectionCommits.length;
+      await assert.rejects(
+        coordinator.getSnapshot(rootSession.id, { terminalCursor: 'invalid-cursor' }),
+        (error: unknown) =>
+          error instanceof AgentGraphClientOperationError && error.code === 'invalid_request',
+      );
+      assert.deepEqual(
+        delayedControlStore.projectionReadCounts(),
+        readsBeforeInvalidCursor,
+        'invalid cursors must fail before reading or repairing the materialized projection',
+      );
+      assert.equal(
+        delayedControlStore.projectionCommits.length,
+        commitsBeforeInvalidCursor,
+        'invalid cursors must fail before committing a repaired materialized projection',
       );
       await new Promise<void>((resolve) => setImmediate(resolve));
       assert.ok(clientEvents.includes('reconciled'));
@@ -294,6 +315,16 @@ describe('host-managed agent graph coordinator', () => {
         ).records.length,
         1,
         'the authoritative RuntimeEvent fold must populate terminal history',
+      );
+      await assert.rejects(
+        coordinator.getSnapshot(rootSession.id, {
+          terminalCursor: encodeAgentGraphTerminalCursor(graphId, {
+            recordId: 'missing-terminal-record',
+            eventTime: 1,
+          }),
+        }),
+        (error: unknown) =>
+          error instanceof AgentGraphClientOperationError && error.code === 'invalid_request',
       );
       await assert.rejects(
         coordinator.toolsForSession(childSessions[0]!.id),
@@ -922,7 +953,12 @@ function createCoordinator(input: {
 function createDelayableControlStore(store: ReturnType<typeof createSqliteSessionMetadataStore>): {
   store: ReturnType<typeof createSqliteSessionMetadataStore>;
   projectionCommits: Array<Parameters<typeof store.commitAgentGraphClientProjection>[0]>;
-  projectionReadCounts(): { composite: number; operator: number };
+  projectionReadCounts(): {
+    snapshot: number;
+    composite: number;
+    operator: number;
+    terminal: number;
+  };
   failProjectionCommits(error: unknown): void;
   failNextProjectionCommits(count: number, error: unknown): void;
   holdNextCommit(): { started: Promise<void>; release(): void };
@@ -936,8 +972,10 @@ function createDelayableControlStore(store: ReturnType<typeof createSqliteSessio
   const projectionCommits: Array<Parameters<typeof store.commitAgentGraphClientProjection>[0]> = [];
   let projectionFailure: unknown;
   let remainingProjectionFailures: number | 'always' = 0;
+  let snapshotProjectionReads = 0;
   let compositeProjectionReads = 0;
   let operatorProjectionReads = 0;
+  let terminalActivityReads = 0;
   const proxy = new Proxy(store, {
     get(target, property) {
       if (property === 'commitAgentGraphScheduleUpdate') {
@@ -980,6 +1018,20 @@ function createDelayableControlStore(store: ReturnType<typeof createSqliteSessio
           return target.readAgentGraphClientOperatorProjection(...args);
         };
       }
+      if (property === 'readAgentGraphClientProjection') {
+        return async (...args: Parameters<typeof target.readAgentGraphClientProjection>) => {
+          snapshotProjectionReads += 1;
+          return target.readAgentGraphClientProjection(...args);
+        };
+      }
+      if (property === 'listAgentGraphClientTerminalActivities') {
+        return async (
+          ...args: Parameters<typeof target.listAgentGraphClientTerminalActivities>
+        ) => {
+          terminalActivityReads += 1;
+          return target.listAgentGraphClientTerminalActivities(...args);
+        };
+      }
       const value = Reflect.get(target, property, target);
       return typeof value === 'function' ? value.bind(target) : value;
     },
@@ -988,8 +1040,10 @@ function createDelayableControlStore(store: ReturnType<typeof createSqliteSessio
     store: proxy,
     projectionCommits,
     projectionReadCounts: () => ({
+      snapshot: snapshotProjectionReads,
       composite: compositeProjectionReads,
       operator: operatorProjectionReads,
+      terminal: terminalActivityReads,
     }),
     failProjectionCommits(error) {
       projectionFailure = error;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -237,6 +237,7 @@ export type {
 } from './stream-graph-read-model.js';
 export {
   AgentGraphCoordinator,
+  AgentGraphOperatorNotFoundError,
   agentGraphIdForRootSession,
   topologyFromProvisions,
 } from './stream-graph-coordinator.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -236,12 +236,13 @@ export type {
   BuildAgentGraphClientReadModelInput,
 } from './stream-graph-read-model.js';
 export {
+  AgentGraphClientOperationError,
   AgentGraphCoordinator,
-  AgentGraphOperatorNotFoundError,
   agentGraphIdForRootSession,
   topologyFromProvisions,
 } from './stream-graph-coordinator.js';
 export type {
+  AgentGraphClientOperationErrorCode,
   AgentGraphClientChangedEvent,
   AgentGraphClientChangedListener,
   AgentGraphClientChangedReason,

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -12,6 +12,7 @@ import type {
 import {
   AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
   AgentGraphClientProjectionConflictError,
+  AgentGraphClientTerminalCursorError,
   decodeAgentGraphIntentClaim,
 } from '@maka/core';
 import type { MakaTool } from './tool-runtime.js';
@@ -151,14 +152,20 @@ export type AgentGraphClientChangedListener = (
   event: AgentGraphClientChangedEvent,
 ) => void | Promise<void>;
 
-export class AgentGraphOperatorNotFoundError extends Error {
-  readonly name = 'AgentGraphOperatorNotFoundError';
+export type AgentGraphClientOperationErrorCode =
+  | 'not_found'
+  | 'session_archived'
+  | 'operation_conflict'
+  | 'invalid_request';
+
+export class AgentGraphClientOperationError extends Error {
+  readonly name = 'AgentGraphClientOperationError';
 
   constructor(
-    readonly graphId: string,
-    readonly operatorId: string,
+    readonly code: AgentGraphClientOperationErrorCode,
+    message: string,
   ) {
-    super(`Agent graph operator ${operatorId} was not found in ${graphId}`);
+    super(message);
   }
 }
 
@@ -235,32 +242,53 @@ export class AgentGraphCoordinator {
   ): Promise<AgentGraphClientSnapshot> {
     await this.#assertRootGraphReader(rootSessionId);
     const graphId = agentGraphIdForRootSession(rootSessionId);
+    let before: ReturnType<typeof decodeAgentGraphTerminalCursor> | undefined;
+    try {
+      before = options.terminalCursor
+        ? decodeAgentGraphTerminalCursor(options.terminalCursor)
+        : undefined;
+    } catch {
+      throw new AgentGraphClientOperationError(
+        'invalid_request',
+        'Agent graph terminal cursor is invalid',
+      );
+    }
+    if (before && before.graphId !== graphId) {
+      throw new AgentGraphClientOperationError(
+        'invalid_request',
+        'Agent graph terminal cursor belongs to another root Session',
+      );
+    }
     const record = await this.#readOrRebuildClientProjection(rootSessionId, graphId);
     const snapshot = decodeMaterializedAgentGraphClientSnapshot(record.payload, {
       rootSessionId,
       graphId,
       snapshotVersion: record.snapshotVersion,
     });
-    const before = options.terminalCursor
-      ? decodeAgentGraphTerminalCursor(options.terminalCursor)
-      : undefined;
-    if (before && before.graphId !== graphId) {
-      throw new Error('Agent graph terminal history cursor belongs to another graph');
+    let terminalPage: Awaited<
+      ReturnType<AgentGraphClientProjectionStore['listAgentGraphClientTerminalActivities']>
+    >;
+    try {
+      terminalPage = await this.#input.controlStore.listAgentGraphClientTerminalActivities(
+        graphId,
+        {
+          limit: AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
+          ...(before
+            ? {
+                before: {
+                  eventTime: before.eventTime,
+                  recordId: before.recordId,
+                },
+              }
+            : {}),
+        },
+      );
+    } catch (error) {
+      if (error instanceof AgentGraphClientTerminalCursorError) {
+        throw new AgentGraphClientOperationError('invalid_request', error.message);
+      }
+      throw error;
     }
-    const terminalPage = await this.#input.controlStore.listAgentGraphClientTerminalActivities(
-      graphId,
-      {
-        limit: AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
-        ...(before
-          ? {
-              before: {
-                eventTime: before.eventTime,
-                recordId: before.recordId,
-              },
-            }
-          : {}),
-      },
-    );
     snapshot.terminalHistory = materializedAgentGraphTerminalHistoryPage(
       graphId,
       terminalPage.records.map((activity) =>
@@ -325,7 +353,10 @@ export class AgentGraphCoordinator {
       throw new Error(`Invalid materialized agent graph projection ${graphId}`);
     }
     if (!operator) {
-      throw new AgentGraphOperatorNotFoundError(graphId, operatorId);
+      throw new AgentGraphClientOperationError(
+        'not_found',
+        `Agent graph operator ${operatorId} was not found in ${graphId}`,
+      );
     }
     const inspection = decodeMaterializedAgentGraphOperatorInspection(operator.payload, {
       rootSessionId,
@@ -920,7 +951,10 @@ export class AgentGraphCoordinator {
   async #assertRootSupervisor(rootSessionId: string): Promise<SessionHeader> {
     const header = await this.#assertRootGraphReader(rootSessionId);
     if (header.isArchived || header.status === 'archived') {
-      throw new Error('Archived Sessions cannot supervise an agent graph');
+      throw new AgentGraphClientOperationError(
+        'session_archived',
+        'Archived Sessions cannot supervise an agent graph',
+      );
     }
     return header;
   }
@@ -928,7 +962,8 @@ export class AgentGraphCoordinator {
   async #assertRootGraphReader(rootSessionId: string): Promise<SessionHeader> {
     if (this.#closed) throw new Error('Agent graph coordinator is closed');
     if (this.#input.rootSessionId && rootSessionId !== this.#input.rootSessionId) {
-      throw new Error(
+      throw new AgentGraphClientOperationError(
+        'operation_conflict',
         `Agent graph coordinator is scoped to root Session ${this.#input.rootSessionId}`,
       );
     }
@@ -937,7 +972,10 @@ export class AgentGraphCoordinator {
       throw new Error(`Session store returned ${header.id}, expected ${rootSessionId}`);
     }
     if (header.subagentParent) {
-      throw new Error('Agent graph client reads are available only to root Sessions');
+      throw new AgentGraphClientOperationError(
+        'operation_conflict',
+        'Agent graph client operations are available only to root Sessions',
+      );
     }
     return header;
   }

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -151,6 +151,17 @@ export type AgentGraphClientChangedListener = (
   event: AgentGraphClientChangedEvent,
 ) => void | Promise<void>;
 
+export class AgentGraphOperatorNotFoundError extends Error {
+  readonly name = 'AgentGraphOperatorNotFoundError';
+
+  constructor(
+    readonly graphId: string,
+    readonly operatorId: string,
+  ) {
+    super(`Agent graph operator ${operatorId} was not found in ${graphId}`);
+  }
+}
+
 interface AgentGraphClientSubscription {
   rootSessionId?: string;
   listener: AgentGraphClientChangedListener;
@@ -314,7 +325,7 @@ export class AgentGraphCoordinator {
       throw new Error(`Invalid materialized agent graph projection ${graphId}`);
     }
     if (!operator) {
-      throw new Error(`Agent graph operator ${operatorId} was not found`);
+      throw new AgentGraphOperatorNotFoundError(graphId, operatorId);
     }
     const inspection = decodeMaterializedAgentGraphOperatorInspection(operator.payload, {
       rootSessionId,

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -6,6 +6,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { describe, test } from 'node:test';
 import { Worker } from 'node:worker_threads';
 import {
+  AgentGraphClientTerminalCursorError,
   canReadPath,
   createReadOnlyPermissionProfile,
   createWorkspaceWritePermissionProfile,
@@ -2318,7 +2319,7 @@ describe('SQLite agent graph client projections', () => {
           limit: 2,
           before: { eventTime: 99, recordId: 'record-2' },
         }),
-        /stale or invalid/,
+        (error: unknown) => error instanceof AgentGraphClientTerminalCursorError,
       );
 
       await store.commitAgentGraphClientProjection({

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -7,6 +7,7 @@ import type { DatabaseSync } from 'node:sqlite';
 import {
   AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
   AgentGraphClientProjectionConflictError,
+  AgentGraphClientTerminalCursorError,
   assessSandboxBoundaryExpansion,
   assertExecutionBoundaryCapacity,
   assertAgentGraphScheduleUpdateRequest,
@@ -2141,7 +2142,9 @@ export class SqliteSessionMetadataStore {
         `)
         .get(graphId, input.before.recordId) as { eventTime?: unknown } | undefined;
       if (cursor?.eventTime !== input.before.eventTime) {
-        throw new Error('Agent graph terminal activity cursor is stale or invalid');
+        throw new AgentGraphClientTerminalCursorError(
+          'Agent graph terminal activity cursor is stale or invalid',
+        );
       }
     }
     const rows = this.db


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Expose bounded `agent.graph.query`, `agent.graph.operator.query`, and `agent.graph.stop` operations through Runtime Host while keeping durable Graph state in its existing Runtime authority.
- Publish `subscription.agent_graph_changed` on the root Session subscription sequence so clients can invalidate and reload their projection without treating process-local notifications as replay state.
- Keep Graph lifetime independent from client connections: disconnecting does not stop execution, while an explicit stop is shared by every client observing the Session.
- Enforce strict recursive wire decoding, stable failure codes, omission accounting, result byte limits, and terminal-history continuation without changing the experimental v0 wire version.
- Document the client contract and cover projection bounds, protocol rejection, continuity ordering, and a two-client UDS query/disconnect/reconnect/stop flow.

## Validation

- `npm test`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

Part of #1167. Related to #853.

</details>

<details>
<summary>中文</summary>

## 概要

- 通过 Runtime Host 暴露有界的 `agent.graph.query`、`agent.graph.operator.query` 与 `agent.graph.stop` operation，同时让持久化 Graph state 继续由现有 Runtime authority 持有。
- 在 root Session subscription 的统一 sequence 上发布 `subscription.agent_graph_changed`，使客户端能够失效并重新加载 projection，而不会把进程内通知误当成 replay state。
- Graph 生命周期与客户端连接解耦：断开连接不会停止执行；显式 stop 则会由所有正在观察该 Session 的客户端共同看到。
- 强制严格的递归 wire decoding、稳定错误码、omission accounting、结果字节上限与 terminal-history continuation，并保持实验性 wire protocol 为 v0。
- 补充客户端契约文档，并覆盖 projection 边界、协议拒绝、continuity 排序，以及双客户端 UDS query/disconnect/reconnect/stop 流程。

## 验证

- `npm test`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

属于 #1167 的一部分，关联 #853。

</details>
