### PR TITLE
fix(runtime-host): retire Agent Graph state with Sessions

### DIFF
--- a/packages/runtime-host/src/__tests__/session-retirement-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-retirement-coordinator.test.ts
@@ -2,9 +2,12 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { describe, test } from 'node:test';
-import type { CreateSessionInput } from '@maka/core';
+import type { AgentGraphOperatorProvisionRequest, CreateSessionInput } from '@maka/core';
+import { agentGraphIdForRootSession } from '@maka/runtime';
 import { createSessionStore } from '@maka/storage';
+import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import {
   HostAutomationSessionBusyError,
   type HostAutomationSessionRetirement,
@@ -95,6 +98,199 @@ describe('Host Session retirement coordinator', () => {
         removed,
       );
       assert.equal(harness.actions.disposed.length, disposeCount);
+    });
+  });
+
+  test('retires graph operators with their root family and purges graph sidecars', async () => {
+    await withHarness(async (harness) => {
+      const childSessionIds = [
+        await createClosedGraphOperator(harness, harness.rootId, 'a'),
+        await createClosedGraphOperator(harness, harness.revisionId, 'b'),
+      ];
+
+      const child = await harness.store.readHeaderRecordSnapshot(childSessionIds[0]!);
+      for (const outcome of [
+        await harness.coordinator.handlers['session.lifecycle.set'](
+          { sessionId: child.header.id, state: 'archived' },
+          CONNECTION_CONTEXT,
+        ),
+        await harness.coordinator.handlers['session.remove'](
+          { sessionId: child.header.id, expectedRevision: child.revision },
+          CONNECTION_CONTEXT,
+        ),
+      ]) {
+        assert.equal(outcome.ok, false);
+        if (!outcome.ok) assert.equal(outcome.error.code, 'operation_conflict');
+      }
+      assert.equal((await harness.store.readHeaderSnapshot(child.header.id)).status, 'active');
+
+      const archived = await harness.coordinator.handlers['session.lifecycle.set'](
+        { sessionId: harness.revisionId, state: 'archived' },
+        CONNECTION_CONTEXT,
+      );
+      assert.equal(archived.ok, true);
+      for (const childSessionId of childSessionIds) {
+        assert.equal((await harness.store.readHeaderSnapshot(childSessionId)).status, 'archived');
+      }
+
+      const restored = await harness.coordinator.handlers['session.lifecycle.set'](
+        { sessionId: harness.revisionId, state: 'active' },
+        CONNECTION_CONTEXT,
+      );
+      assert.equal(restored.ok, true);
+      for (const childSessionId of childSessionIds) {
+        assert.equal((await harness.store.readHeaderSnapshot(childSessionId)).status, 'active');
+      }
+
+      const target = await harness.store.readHeaderRecordSnapshot(harness.revisionId);
+      const removed = await harness.coordinator.handlers['session.remove'](
+        { sessionId: harness.revisionId, expectedRevision: target.revision },
+        CONNECTION_CONTEXT,
+      );
+      assert.deepEqual(removed, {
+        ok: true,
+        result: { kind: 'removed', sessionId: harness.revisionId },
+      });
+      for (const sessionId of [...harness.familyIds, ...childSessionIds]) {
+        assert.deepEqual(await harness.store.probeSessionRemoval(sessionId), { kind: 'removed' });
+      }
+      const graphIds = harness.familyIds.map(agentGraphIdForRootSession);
+      await waitFor(
+        async () =>
+          (
+            await Promise.all(
+              graphIds.map((graphId) => harness.graphStore.listAgentGraphScheduleUpdates(graphId)),
+            )
+          ).every((updates) => updates.length === 0),
+        'Agent Graph sidecar cleanup did not run',
+      );
+      for (const graphId of graphIds) {
+        assert.deepEqual(await harness.graphStore.listAgentGraphOperatorProvisions(graphId), []);
+      }
+      assert.ok(harness.actions.purgedAgentGraphs.includes(harness.rootId));
+      assert.ok(harness.actions.purgedAgentGraphs.includes(harness.revisionId));
+    });
+  });
+
+  test('recovers graph operators orphaned by legacy root-only retirement', async () => {
+    await withHarness(async (harness) => {
+      const childSessionId = await createClosedGraphOperator(harness, harness.rootId, 'a');
+      const database = new DatabaseSync(join(harness.workspaceRoot, 'runtime.sqlite'));
+      try {
+        database.exec('BEGIN IMMEDIATE');
+        for (const sessionId of harness.familyIds) {
+          database.prepare('DELETE FROM session_metadata WHERE session_id = ?').run(sessionId);
+          database
+            .prepare(`
+              INSERT INTO session_metadata_tombstones(
+                session_id,
+                deleted_at,
+                retirement_unit_id,
+                cleanup_pending
+              )
+              VALUES (?, ?, ?, 0)
+            `)
+            .run(sessionId, 1, harness.rootId);
+        }
+        database.exec('COMMIT');
+      } catch (error) {
+        database.exec('ROLLBACK');
+        throw error;
+      } finally {
+        database.close();
+      }
+      for (const sessionId of harness.familyIds) {
+        await harness.store.purgeRemovedSessionTranscript(sessionId);
+      }
+
+      await harness.coordinator.recover();
+
+      await waitFor(
+        async () =>
+          (await harness.store.probeSessionRemoval(childSessionId)).kind === 'removed' &&
+          (await harness.store.listPendingSessionRetirementCleanupIds()).length === 0,
+        'Legacy Agent Graph retirement did not converge',
+      );
+      const graphId = agentGraphIdForRootSession(harness.rootId);
+      assert.deepEqual(await harness.graphStore.listAgentGraphScheduleUpdates(graphId), []);
+      assert.deepEqual(await harness.graphStore.listAgentGraphOperatorProvisions(graphId), []);
+      assert.ok(harness.actions.purgedAgentGraphs.includes(harness.rootId));
+    });
+  });
+
+  test('recovers legacy graph sidecars without operator provisions', async () => {
+    await withHarness(async (harness) => {
+      const projectionGraphId = agentGraphIdForRootSession(harness.rootId);
+      const finishedGraphId = agentGraphIdForRootSession(harness.revisionId);
+      await harness.graphStore.commitAgentGraphClientProjection({
+        schemaVersion: 1,
+        graphId: projectionGraphId,
+        rootSessionId: harness.rootId,
+        expectedSnapshotVersion: null,
+        snapshotVersion: 'projection-only-snapshot',
+        snapshot: { status: 'idle' },
+        replaceOperators: true,
+        operators: [],
+        terminalActivities: [],
+        activityRecords: [],
+      });
+      await harness.graphStore.commitAgentGraphScheduleUpdate({
+        schemaVersion: 1,
+        updateId: `graph_update_${'7'.repeat(32)}`,
+        updateFingerprint: `sha256:${'8'.repeat(64)}`,
+        graphId: finishedGraphId,
+        source: {
+          sessionId: harness.revisionId,
+          runId: 'legacy-finish-run',
+          turnId: 'legacy-finish-turn',
+          toolCallId: 'legacy-finish-call',
+        },
+        addWork: [],
+        stop: [],
+        finish: { resultIds: ['legacy-result'], reason: 'The result is complete.' },
+      });
+
+      const database = new DatabaseSync(join(harness.workspaceRoot, 'runtime.sqlite'));
+      try {
+        database.exec('BEGIN IMMEDIATE');
+        for (const sessionId of harness.familyIds) {
+          database.prepare('DELETE FROM session_metadata WHERE session_id = ?').run(sessionId);
+          database
+            .prepare(`
+              INSERT INTO session_metadata_tombstones(
+                session_id,
+                deleted_at,
+                retirement_unit_id,
+                cleanup_pending
+              )
+              VALUES (?, ?, ?, 0)
+            `)
+            .run(sessionId, 1, harness.rootId);
+        }
+        database.exec('COMMIT');
+      } catch (error) {
+        database.exec('ROLLBACK');
+        throw error;
+      } finally {
+        database.close();
+      }
+      for (const sessionId of harness.familyIds) {
+        await harness.store.purgeRemovedSessionTranscript(sessionId);
+      }
+
+      await harness.coordinator.recover();
+
+      await waitFor(
+        async () => (await harness.store.listPendingSessionRetirementCleanupIds()).length === 0,
+        'Legacy Agent Graph sidecar cleanup did not converge',
+      );
+      assert.equal(
+        await harness.graphStore.readAgentGraphClientProjection(projectionGraphId),
+        undefined,
+      );
+      assert.deepEqual(await harness.graphStore.listAgentGraphScheduleUpdates(finishedGraphId), []);
+      assert.ok(harness.actions.purgedAgentGraphs.includes(harness.rootId));
+      assert.ok(harness.actions.purgedAgentGraphs.includes(harness.revisionId));
     });
   });
 
@@ -417,6 +613,11 @@ describe('Host Session retirement coordinator', () => {
         { ok: true, result: { kind: 'removed', sessionId: harness.rootId } },
       );
       assert.equal(harness.actions.drains, 1);
+      await waitFor(
+        async () => (await harness.store.listPendingSessionRetirementCleanupIds()).length === 0,
+        'tombstone retry did not recover the retirement-unit cleanup',
+      );
+      assert.deepEqual(new Set(harness.actions.purgedArtifacts), new Set(harness.familyIds));
     });
   });
 
@@ -450,6 +651,7 @@ interface RetirementActions {
   readonly purgedArtifacts: string[];
   readonly purgedTasks: string[];
   readonly purgedOperationalState: string[];
+  readonly purgedAgentGraphs: string[];
   readonly retiredWorktrees: string[];
   readonly finalizedWorkspacePatches: string[];
   readonly retiredGraphWakes: string[];
@@ -465,6 +667,7 @@ async function withHarness(
 ): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'maka-session-retirement-'));
   const store = createSessionStore(root);
+  const graphStore = createAgentGraphControlStore(root);
   let coordinator: HostSessionRetirementCoordinator | undefined;
   try {
     const rootSession = await store.create(sessionInput('Revision root'));
@@ -486,6 +689,7 @@ async function withHarness(
       purgedArtifacts: [],
       purgedTasks: [],
       purgedOperationalState: [],
+      purgedAgentGraphs: [],
       retiredWorktrees: [],
       finalizedWorkspacePatches: [],
       retiredGraphWakes: [],
@@ -506,7 +710,9 @@ async function withHarness(
       automation: new Set<string>(),
     };
     const harness: RetirementHarness = {
+      workspaceRoot: root,
       store,
+      graphStore,
       rootId: rootSession.id,
       revisionId: revision.id,
       familyIds: [rootSession.id, revision.id],
@@ -535,6 +741,8 @@ async function withHarness(
         probeSessionRemoval: (sessionId) => store.probeSessionRemoval(sessionId),
         readCatalogRecord: (sessionId) => store.readCatalogRecord(sessionId),
         readHeaderRecordSnapshot: (sessionId) => store.readHeaderRecordSnapshot(sessionId),
+        reconcileOrphanedAgentGraphRetirements: () =>
+          store.reconcileOrphanedAgentGraphRetirements(),
         listPendingSessionRetirementCleanupIds: (sessionId) =>
           store.listPendingSessionRetirementCleanupIds(sessionId),
         purgeRemovedSessionTranscript: (sessionId) =>
@@ -637,6 +845,10 @@ async function withHarness(
       purgeOperationalState: async (sessionId) => {
         actions.purgedOperationalState.push(sessionId);
       },
+      purgeAgentGraphState: async (sessionId) => {
+        actions.purgedAgentGraphs.push(sessionId);
+        await graphStore.purgeAgentGraphControlState(agentGraphIdForRootSession(sessionId));
+      },
       worktrees: {
         retire: async (binding) => {
           if (harness.retireWorktree) return harness.retireWorktree(binding);
@@ -651,13 +863,16 @@ async function withHarness(
     await operation(harness);
   } finally {
     await coordinator?.close();
+    graphStore.close();
     await store.close?.();
     await rm(root, { recursive: true, force: true });
   }
 }
 
 interface RetirementHarness {
+  readonly workspaceRoot: string;
   readonly store: ReturnType<typeof createSessionStore>;
+  readonly graphStore: ReturnType<typeof createAgentGraphControlStore>;
   readonly rootId: string;
   readonly revisionId: string;
   readonly familyIds: readonly string[];
@@ -741,4 +956,100 @@ function sessionInput(
     labels: [],
     ...overrides,
   };
+}
+
+async function createClosedGraphOperator(
+  harness: RetirementHarness,
+  rootSessionId: string,
+  seed: 'a' | 'b',
+): Promise<string> {
+  const identity = (suffix: string) => `${seed.repeat(31)}${suffix}`;
+  const graphId = agentGraphIdForRootSession(rootSessionId);
+  const workId = `graph_work_${identity('1')}`;
+  const operatorId = `graph_operator_${identity('2')}`;
+  const rootRunId = `root-run-${seed}`;
+  const rootTurnId = `root-turn-${seed}`;
+  await harness.graphStore.commitAgentGraphScheduleUpdate({
+    schemaVersion: 1,
+    updateId: `graph_update_${identity('3')}`,
+    updateFingerprint: `sha256:${seed.repeat(63)}4`,
+    graphId,
+    source: {
+      sessionId: rootSessionId,
+      runId: rootRunId,
+      turnId: rootTurnId,
+      toolCallId: 'schedule-call',
+    },
+    addWork: [
+      {
+        workId,
+        target: { kind: 'agent', agentId: 'implementation' },
+        instruction: 'Implement the assigned task.',
+        inputIds: [],
+      },
+    ],
+    stop: [],
+  });
+  const request: AgentGraphOperatorProvisionRequest = {
+    schemaVersion: 1,
+    provisionId: `graph_provision_${identity('5')}`,
+    provisionFingerprint: `sha256:${seed.repeat(63)}6`,
+    graphId,
+    workId,
+    agentId: 'implementation',
+    operatorId,
+    initialTurnId: `operator-turn-${seed}`,
+    initialRunId: `operator-run-${seed}`,
+    edges: [],
+  };
+  const child = await harness.store.createAgentGraphOperator(
+    sessionInput('Graph operator', {
+      permissionMode: 'execute',
+      subagentParent: {
+        kind: 'subagent',
+        parentSessionId: rootSessionId,
+        spawnedBy: {
+          parentRunId: rootRunId,
+          parentTurnId: rootTurnId,
+          toolCallId: 'schedule-call',
+        },
+        graph: { graphId, workId, operatorId },
+        lifecycle: 'foreground',
+      },
+      subagentRuntime: {
+        schemaVersion: 1,
+        definitionVersion: 1,
+        agentId: 'implementation',
+        agentName: 'Implementation',
+        profile: 'implementation',
+        systemPrompt: 'Implement the assigned task.',
+        toolNames: ['Read', 'Write'],
+        categoryPolicy: {},
+      },
+      subagentSpawn: {
+        schemaVersion: 1,
+        requestFingerprint: seed.repeat(64),
+        initialTurnId: request.initialTurnId,
+        initialRunId: request.initialRunId,
+      },
+    }),
+    request,
+    1,
+  );
+  await harness.graphStore.commitAgentGraphScheduleUpdate({
+    schemaVersion: 1,
+    updateId: `graph_update_${identity('8')}`,
+    updateFingerprint: `sha256:${seed.repeat(63)}9`,
+    graphId,
+    source: {
+      sessionId: rootSessionId,
+      runId: rootRunId,
+      turnId: rootTurnId,
+      toolCallId: 'finish-call',
+    },
+    addWork: [],
+    stop: [],
+    finish: { resultIds: ['operator-result'], reason: 'complete' },
+  });
+  return child.header.id;
 }

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -3,6 +3,7 @@ import { filterModelVisibleTaskLedgerTasks } from '@maka/core/task-ledger';
 import {
   AgentGraphCoordinator,
   AgentGraphSupervisorWakeCoordinator,
+  agentGraphIdForRootSession,
   BackendRegistry,
   createBuiltinSandboxManager,
   createFilesystemWorkerLaunchSpecProvider,
@@ -567,6 +568,11 @@ export async function createExecutionRuntimeHostComposition(
       artifacts: openedArtifactStore,
       taskLedger: taskLedgerStore,
       purgeOperationalState: (sessionId) => stores.purgeConversationOperationalState(sessionId),
+      purgeAgentGraphState: async (sessionId) => {
+        await openedGraphControlStore.purgeAgentGraphControlState(
+          agentGraphIdForRootSession(sessionId),
+        );
+      },
       worktrees: worktreeChildExecutor,
       requestDrain: context.requestDrain,
     });
@@ -604,13 +610,13 @@ export async function createExecutionRuntimeHostComposition(
         await requireMemory(memory).recover();
         await skills.recover();
         await openedArtifactStore.recover();
+        await sessionRetirement.recover();
         const sessions = await stores.sessionStore.listForRecovery();
         await worktreeChildExecutor.recover(
           sessions.flatMap((session) =>
             session.subagentWorkspace ? [session.subagentWorkspace] : [],
           ),
         );
-        await sessionRetirement.recover();
         await sessionRevisions.recover();
         for (const session of sessions) {
           await stores.runtimeEventStore.repairImmutableSteeringMessageProofsForRecovery(
@@ -697,11 +703,6 @@ export async function createExecutionRuntimeHostComposition(
           }
         }
         try {
-          openedGraphControlStore.close();
-        } catch (error) {
-          errors.push(error);
-        }
-        try {
           await messages.close();
         } catch (error) {
           errors.push(error);
@@ -748,6 +749,11 @@ export async function createExecutionRuntimeHostComposition(
         }
         try {
           await sessionRetirement.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
+          openedGraphControlStore.close();
         } catch (error) {
           errors.push(error);
         }

--- a/packages/runtime-host/src/server/session-retirement-coordinator.ts
+++ b/packages/runtime-host/src/server/session-retirement-coordinator.ts
@@ -11,7 +11,7 @@ import {
   type ExecutionSessionWriter,
   type SessionHeaderSnapshot,
 } from '@maka/storage/execution-stores';
-import type { SessionManager } from '@maka/runtime';
+import { agentGraphIdForRootSession, type SessionManager } from '@maka/runtime';
 import type { InteractiveTaskLedgerWriter } from '@maka/storage/task-ledger-authority';
 import {
   type OperationOutcome,
@@ -44,6 +44,7 @@ type RetirementStores = Pick<
   | 'probeSessionRemoval'
   | 'readCatalogRecord'
   | 'readHeaderRecordSnapshot'
+  | 'reconcileOrphanedAgentGraphRetirements'
   | 'listPendingSessionRetirementCleanupIds'
   | 'purgeRemovedSessionTranscript'
   | 'completeSessionRetirementCleanup'
@@ -95,6 +96,7 @@ export interface HostSessionRetirementCoordinatorOptions {
   readonly artifacts: Pick<InteractiveArtifactStoreWriter, 'purgeSessionArtifacts'>;
   readonly taskLedger: Pick<InteractiveTaskLedgerWriter, 'purgeConversationTaskLedger'>;
   readonly purgeOperationalState: (sessionId: string) => Promise<void>;
+  readonly purgeAgentGraphState: (sessionId: string) => Promise<void>;
   readonly worktrees?: Pick<SubagentWorktreeExecutor, 'retire'>;
   readonly requestDrain: () => void;
 }
@@ -145,6 +147,7 @@ export class HostSessionRetirementCoordinator {
   readonly #artifacts: HostSessionRetirementCoordinatorOptions['artifacts'];
   readonly #taskLedger: HostSessionRetirementCoordinatorOptions['taskLedger'];
   readonly #purgeOperationalState: HostSessionRetirementCoordinatorOptions['purgeOperationalState'];
+  readonly #purgeAgentGraphState: HostSessionRetirementCoordinatorOptions['purgeAgentGraphState'];
   readonly #worktrees: HostSessionRetirementCoordinatorOptions['worktrees'];
   readonly #requestDrain: () => void;
   readonly #cleanupQueue = new Set<string>();
@@ -169,11 +172,13 @@ export class HostSessionRetirementCoordinator {
     this.#artifacts = options.artifacts;
     this.#taskLedger = options.taskLedger;
     this.#purgeOperationalState = options.purgeOperationalState;
+    this.#purgeAgentGraphState = options.purgeAgentGraphState;
     this.#worktrees = options.worktrees;
     this.#requestDrain = options.requestDrain;
   }
 
   async recover(): Promise<void> {
+    await this.#stores.reconcileOrphanedAgentGraphRetirements();
     this.#scheduleCleanup(await this.#stores.listPendingSessionRetirementCleanupIds());
   }
 
@@ -257,7 +262,13 @@ export class HostSessionRetirementCoordinator {
       return removeFailure('persistence_failed', 'Session removal state is unavailable');
     }
     if (probe.kind === 'removed') {
-      this.#scheduleCleanup([input.sessionId]);
+      try {
+        this.#scheduleCleanup(
+          await this.#stores.listPendingSessionRetirementCleanupIds(input.sessionId),
+        );
+      } catch {
+        this.#requestDrain();
+      }
       return removeSuccess(input.sessionId);
     }
     if (probe.kind === 'absent') return removeFailure('not_found', 'Session does not exist');
@@ -339,14 +350,32 @@ export class HostSessionRetirementCoordinator {
     if (target.kind !== 'present') {
       throw new SessionRetirementMissingSessionError(target.kind);
     }
+    if (target.record.header.subagentParent?.graph) {
+      throw new SessionMetadataConflictError(
+        'Agent Graph operator Sessions retire with their root Session',
+      );
+    }
     const familyId = sessionRevisionFamilyId(target.record.header);
     const headers = await this.#stores.listHeaders();
+    const roots = headers.filter(
+      (header) =>
+        header.conversationCopy?.state !== 'preparing' &&
+        !header.subagentParent &&
+        sessionRevisionFamilyId(header) === familyId,
+    );
+    const graphRoots = new Map(
+      roots.map((header) => [header.id, agentGraphIdForRootSession(header.id)]),
+    );
     const members = headers
-      .filter(
-        (header) =>
-          header.conversationCopy?.state !== 'preparing' &&
-          sessionRevisionFamilyId(header) === familyId,
-      )
+      .filter((header) => {
+        if (header.conversationCopy?.state === 'preparing') return false;
+        if (sessionRevisionFamilyId(header) === familyId) return true;
+        const parent = header.subagentParent;
+        return (
+          parent?.graph !== undefined &&
+          parent.graph.graphId === graphRoots.get(parent.parentSessionId)
+        );
+      })
       .map((header) => header.id);
     if (!members.includes(sessionId)) members.push(sessionId);
     return [...new Set(members)].sort();
@@ -441,6 +470,7 @@ export class HostSessionRetirementCoordinator {
         },
         sessionId,
       ),
+      this.#purgeAgentGraphState(sessionId),
       ...(worktree && this.#worktrees ? [this.#worktrees.retire(worktree)] : []),
     ]);
     const failures = outcomes.flatMap((outcome) =>

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -26,6 +26,7 @@ import {
   createSqliteRuntimeStore,
   SQLITE_RUNTIME_SCHEMA_VERSION,
 } from '../sqlite-runtime-store.js';
+import { SQLITE_AGENT_GRAPH_CONTROL_TABLES } from '../sqlite-session-metadata-schema.js';
 
 describe('SqliteSessionMetadataStore', () => {
   test('round-trips every SessionHeader field and reopens the same schema', async () => {
@@ -56,6 +57,18 @@ describe('SqliteSessionMetadataStore', () => {
       }
       const schema = new DatabaseSync(path);
       try {
+        const graphTables = schema
+          .prepare(`
+            SELECT name
+            FROM sqlite_schema
+            WHERE type = 'table' AND name GLOB 'agent_graph_*'
+            ORDER BY name
+          `)
+          .all() as unknown as Array<{ readonly name: string }>;
+        assert.deepEqual(
+          graphTables.map(({ name }) => name),
+          [...SQLITE_AGENT_GRAPH_CONTROL_TABLES].sort(),
+        );
         assert.deepEqual(
           schema.prepare('PRAGMA foreign_key_list(agent_graph_client_operator_projections)').all(),
           [],
@@ -2066,6 +2079,231 @@ describe('SQLite agent graph operator provisions', () => {
     }
   });
 
+  test('retires a graph root with its operator and purges only that graph control state', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNow(800) });
+    try {
+      const root = await store.create(
+        fullHeader({
+          id: 'supervisor-session',
+          parentSessionId: undefined,
+          branchOfTurnId: undefined,
+          revisionRootSessionId: undefined,
+          revisionParentSessionId: undefined,
+          revisionOfTurnId: undefined,
+          revisionIndex: undefined,
+          revisionState: undefined,
+          status: 'active',
+          blockedReason: undefined,
+        }),
+      );
+      await store.commitAgentGraphScheduleUpdate({
+        schemaVersion: 1,
+        updateId: `graph_update_${'1'.repeat(32)}`,
+        updateFingerprint: `sha256:${'2'.repeat(64)}`,
+        graphId: 'graph-1',
+        source: {
+          sessionId: root.header.id,
+          runId: 'supervisor-run',
+          turnId: 'supervisor-turn',
+          toolCallId: 'schedule-tool',
+        },
+        addWork: [
+          {
+            workId: `graph_work_${'3'.repeat(32)}`,
+            target: { kind: 'agent', agentId: 'local-read' },
+            instruction: 'Inspect the input.',
+            inputIds: [],
+          },
+        ],
+        stop: [],
+      });
+      const child = await store.createAgentGraphOperator(
+        graphChildHeader(),
+        graphProvisionRequest(),
+        1,
+      );
+      await store.claimAgentGraphIntent({
+        schemaVersion: 1,
+        claimId: `graph_claim_${'a'.repeat(32)}`,
+        graphId: 'graph-1',
+        intentId: `graph_intent_${'b'.repeat(32)}`,
+        intentFingerprint: `sha256:${'c'.repeat(64)}`,
+        readinessContextFingerprint: `sha256:${'d'.repeat(64)}`,
+        targetOperatorId: graphProvisionRequest().operatorId,
+        targetSessionId: child.record.header.id,
+        targetTurnId: 'graph-turn',
+        targetRunId: 'graph-run',
+      });
+      await store.claimAgentGraphSupervisorWake({
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        wakeId: 'graph-wake',
+        snapshotVersion: 'snapshot-1',
+        rootSessionId: root.header.id,
+      });
+      await store.beginAgentGraphSupervisorWakeAttempt({
+        graphId: 'graph-1',
+        wakeId: 'graph-wake',
+        attemptId: 'graph-attempt',
+        turnId: 'supervisor-wake-turn',
+      });
+      await store.commitAgentGraphClientProjection({
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        rootSessionId: root.header.id,
+        expectedSnapshotVersion: null,
+        snapshotVersion: 'snapshot-1',
+        snapshot: { status: 'running' },
+        replaceOperators: true,
+        operators: [{ operatorId: graphProvisionRequest().operatorId, payload: {} }],
+        terminalActivities: [
+          { recordId: 'terminal-record', eventTime: 1, payload: { status: 'completed' } },
+        ],
+        activityRecords: [{ recordId: 'terminal-record', eventTime: 1 }],
+      });
+      await store.commitAgentGraphScheduleUpdate({
+        schemaVersion: 1,
+        updateId: `graph_update_${'7'.repeat(32)}`,
+        updateFingerprint: `sha256:${'8'.repeat(64)}`,
+        graphId: 'graph-2',
+        source: {
+          sessionId: 'other-supervisor',
+          runId: 'other-run',
+          turnId: 'other-turn',
+          toolCallId: 'other-tool',
+        },
+        addWork: [],
+        stop: [{ targetId: 'other-target', reason: 'done' }],
+      });
+
+      await assert.rejects(
+        store.removeVersioned([
+          { sessionId: child.record.header.id, expectedVersion: child.record.metadataVersion },
+        ]),
+        /Cannot remove graph operator Session graph-child/,
+      );
+      await assert.rejects(
+        store.removeVersioned([
+          { sessionId: root.header.id, expectedVersion: root.metadataVersion },
+        ]),
+        /graph operator graph-child is outside the retirement unit/,
+      );
+      assert.deepEqual(
+        await store.removeVersioned([
+          { sessionId: root.header.id, expectedVersion: root.metadataVersion },
+          { sessionId: child.record.header.id, expectedVersion: child.record.metadataVersion },
+        ]),
+        ['graph-child', 'supervisor-session'],
+      );
+      assert.equal(await store.has(root.header.id), false);
+      assert.equal(await store.has(child.record.header.id), false);
+      assert.equal((await store.listAgentGraphOperatorProvisions('graph-1')).length, 1);
+
+      assert.equal(await store.purgeAgentGraphControlState('graph-1'), 9);
+      assert.deepEqual(await store.listAgentGraphOperatorProvisions('graph-1'), []);
+      assert.deepEqual(await store.listAgentGraphScheduleUpdates('graph-1'), []);
+      assert.deepEqual(await store.listAgentGraphIntentClaims('graph-1'), []);
+      assert.equal(await store.readAgentGraphSupervisorWake('graph-1', 'graph-wake'), undefined);
+      assert.equal(await store.readAgentGraphClientProjection('graph-1'), undefined);
+      assert.deepEqual(
+        await store.listAgentGraphClientTerminalActivities('graph-1', { limit: 1 }),
+        { records: [], hasMore: false },
+      );
+      assert.equal(await store.purgeAgentGraphControlState('graph-1'), 0);
+      assert.equal((await store.listAgentGraphScheduleUpdates('graph-2')).length, 1);
+    } finally {
+      store.close();
+    }
+  });
+
+  test('reconciles graph operators orphaned by legacy root-only retirement', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-agent-graph-orphan-'));
+    const path = join(root, 'runtime.sqlite');
+    try {
+      const store = createSqliteSessionMetadataStore(path, { now: () => 900 });
+      const supervisor = await store.create(
+        fullHeader({
+          id: 'supervisor-session',
+          parentSessionId: undefined,
+          branchOfTurnId: undefined,
+          revisionRootSessionId: undefined,
+          revisionParentSessionId: undefined,
+          revisionOfTurnId: undefined,
+          revisionIndex: undefined,
+          revisionState: undefined,
+          status: 'active',
+          blockedReason: undefined,
+        }),
+      );
+      await store.commitAgentGraphScheduleUpdate({
+        schemaVersion: 1,
+        updateId: `graph_update_${'1'.repeat(32)}`,
+        updateFingerprint: `sha256:${'2'.repeat(64)}`,
+        graphId: 'graph-1',
+        source: {
+          sessionId: supervisor.header.id,
+          runId: 'supervisor-run',
+          turnId: 'supervisor-turn',
+          toolCallId: 'schedule-tool',
+        },
+        addWork: [
+          {
+            workId: graphProvisionRequest().workId,
+            target: { kind: 'agent', agentId: graphProvisionRequest().agentId },
+            instruction: 'Inspect the input.',
+            inputIds: [],
+          },
+        ],
+        stop: [],
+      });
+      await store.createAgentGraphOperator(graphChildHeader(), graphProvisionRequest(), 1);
+      store.close();
+
+      const legacy = new DatabaseSync(path);
+      try {
+        legacy.exec('BEGIN IMMEDIATE');
+        legacy
+          .prepare('DELETE FROM session_metadata WHERE session_id = ?')
+          .run(supervisor.header.id);
+        legacy
+          .prepare(`
+            INSERT INTO session_metadata_tombstones(
+              session_id,
+              deleted_at,
+              retirement_unit_id,
+              cleanup_pending
+            )
+            VALUES (?, ?, ?, 0)
+          `)
+          .run(supervisor.header.id, 901, supervisor.header.id);
+        legacy.exec('COMMIT');
+      } catch (error) {
+        legacy.exec('ROLLBACK');
+        throw error;
+      } finally {
+        legacy.close();
+      }
+
+      const reopened = createSqliteSessionMetadataStore(path, { now: () => 902 });
+      try {
+        assert.equal(await reopened.has('graph-child'), true);
+        assert.deepEqual(await reopened.listPendingSessionRetirementCleanupIds(), []);
+        assert.deepEqual(await reopened.reconcileOrphanedAgentGraphRetirements(), ['graph-child']);
+        assert.deepEqual(await reopened.probeRemoval('graph-child'), { kind: 'removed' });
+        assert.deepEqual(
+          await reopened.listPendingSessionRetirementCleanupIds(supervisor.header.id),
+          ['graph-child', supervisor.header.id],
+        );
+        assert.equal((await reopened.listAgentGraphOperatorProvisions('graph-1')).length, 1);
+        assert.deepEqual(await reopened.reconcileOrphanedAgentGraphRetirements(), []);
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('rolls back child and topology together on a provision failure', async () => {
     const store = createSqliteSessionMetadataStore(':memory:', {
       failpoint(point) {
@@ -2112,6 +2350,7 @@ describe('SQLite agent graph client projections', () => {
       now: nextNow(400),
     });
     try {
+      await store.create(graphRootHeader('root-session'));
       await store.commitAgentGraphClientProjection({
         schemaVersion: 1,
         graphId: 'graph-atomic-read',
@@ -2167,6 +2406,7 @@ describe('SQLite agent graph client projections', () => {
       now: nextNow(500),
     });
     try {
+      await store.create(graphRootHeader('root-session'));
       await store.commitAgentGraphClientProjection({
         schemaVersion: 1,
         graphId: 'graph-cas',
@@ -2268,6 +2508,7 @@ describe('SQLite agent graph client projections', () => {
       now: nextNow(1_000),
     });
     try {
+      await store.create(graphRootHeader('root-session'));
       const first = await store.commitAgentGraphClientProjection({
         schemaVersion: 1,
         graphId: 'graph-1',
@@ -2366,6 +2607,37 @@ describe('SQLite agent graph client projections', () => {
       store.close();
     }
   });
+
+  test('rejects a projection commit after its root retirement cleanup completes', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    try {
+      const root = await store.create(graphRootHeader('root-session'));
+      const request = {
+        schemaVersion: 1 as const,
+        graphId: 'graph-retired-root',
+        rootSessionId: root.header.id,
+        expectedSnapshotVersion: null,
+        snapshotVersion: 'snapshot-1',
+        snapshot: { status: 'idle' },
+        replaceOperators: true,
+        operators: [],
+        terminalActivities: [],
+        activityRecords: [],
+      };
+
+      await store.removeVersioned([
+        { sessionId: root.header.id, expectedVersion: root.metadataVersion },
+      ]);
+      await store.purgeAgentGraphControlState(request.graphId);
+      await store.completeSessionRetirementCleanup(root.header.id);
+
+      await assert.rejects(store.commitAgentGraphClientProjection(request), /not found/);
+      assert.equal(await store.readAgentGraphClientProjection(request.graphId), undefined);
+      assert.deepEqual(await store.listPendingSessionRetirementCleanupIds(), []);
+    } finally {
+      store.close();
+    }
+  });
 });
 
 function fullHeader(overrides: Partial<SessionHeader> = {}): SessionHeader {
@@ -2404,6 +2676,21 @@ function fullHeader(overrides: Partial<SessionHeader> = {}): SessionHeader {
     schemaVersion: 1,
     ...overrides,
   };
+}
+
+function graphRootHeader(id: string): SessionHeader {
+  return fullHeader({
+    id,
+    parentSessionId: undefined,
+    branchOfTurnId: undefined,
+    revisionRootSessionId: undefined,
+    revisionParentSessionId: undefined,
+    revisionOfTurnId: undefined,
+    revisionIndex: undefined,
+    revisionState: undefined,
+    status: 'active',
+    blockedReason: undefined,
+  });
 }
 
 function graphProvisionRequest(): AgentGraphOperatorProvisionRequest {

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -373,6 +373,8 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
         run(() => sessionStore.setSessionsLifecycleVersioned(sessions, state)),
       removeSessionsVersioned: (sessions) =>
         run(() => sessionStore.removeSessionsVersioned(sessions)),
+      reconcileOrphanedAgentGraphRetirements: () =>
+        run(() => sessionStore.reconcileOrphanedAgentGraphRetirements()),
       listPendingSessionRetirementCleanupIds: (sessionId) =>
         run(() => sessionStore.listPendingSessionRetirementCleanupIds(sessionId)),
       purgeRemovedSessionTranscript: (sessionId) =>

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -10,6 +10,7 @@ import {
 } from './sqlite-runtime-schema.js';
 import {
   migrateSqliteSessionMetadataDatabase,
+  SQLITE_AGENT_GRAPH_CONTROL_TABLES,
   SQLITE_SESSION_METADATA_SCHEMA_VERSION,
 } from './sqlite-session-metadata-schema.js';
 import {
@@ -40,15 +41,7 @@ const SESSION_METADATA_TABLES = [
   'session_metadata_import_sources',
   'session_metadata_tombstones',
   'subagent_spawns',
-  'agent_graph_intent_claims',
-  'agent_graph_schedule_updates',
-  'agent_graph_operator_provisions',
-  'agent_graph_client_projections',
-  'agent_graph_client_operator_projections',
-  'agent_graph_client_terminal_activity',
-  'agent_graph_client_applied_records',
-  'agent_graph_supervisor_wakes',
-  'agent_graph_supervisor_wake_attempts',
+  ...SQLITE_AGENT_GRAPH_CONTROL_TABLES,
   'sandbox_boundary_log',
 ] as const;
 

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -256,6 +256,7 @@ export interface SessionAuthorityStore extends SessionStore {
     state: 'active' | 'archived',
   ): Promise<SessionHeaderSnapshot[]>;
   removeSessionsVersioned(sessions: readonly VersionedSessionIdentity[]): Promise<string[]>;
+  reconcileOrphanedAgentGraphRetirements(): Promise<string[]>;
   listPendingSessionRetirementCleanupIds(sessionId?: string): Promise<string[]>;
   purgeRemovedSessionTranscript(sessionId: string): Promise<void>;
   completeSessionRetirementCleanup(sessionId: string): Promise<void>;
@@ -728,6 +729,11 @@ class SqliteSessionStore implements SessionAuthorityStore {
   async removeSessionsVersioned(sessions: readonly VersionedSessionIdentity[]): Promise<string[]> {
     await this.ensureReady();
     return this.metadata.removeVersioned(sessions);
+  }
+
+  async reconcileOrphanedAgentGraphRetirements(): Promise<string[]> {
+    await this.ensureReady();
+    return this.metadata.reconcileOrphanedAgentGraphRetirements();
   }
 
   async listPendingSessionRetirementCleanupIds(sessionId?: string): Promise<string[]> {

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -2,6 +2,18 @@ import type { DatabaseSync } from 'node:sqlite';
 
 export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 19;
 
+export const SQLITE_AGENT_GRAPH_CONTROL_TABLES = [
+  'agent_graph_intent_claims',
+  'agent_graph_schedule_updates',
+  'agent_graph_operator_provisions',
+  'agent_graph_client_projections',
+  'agent_graph_client_operator_projections',
+  'agent_graph_client_terminal_activity',
+  'agent_graph_client_applied_records',
+  'agent_graph_supervisor_wakes',
+  'agent_graph_supervisor_wake_attempts',
+] as const;
+
 const MIGRATIONS: ReadonlyMap<number, string> = new Map([
   [
     1,

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -73,6 +73,7 @@ import {
   configureSqliteSessionMetadataDatabase,
   migrateSqliteSessionMetadataDatabase,
   readSqliteSessionMetadataSchemaVersion,
+  SQLITE_AGENT_GRAPH_CONTROL_TABLES,
 } from './sqlite-session-metadata-schema.js';
 import type { OperationalStateDatabaseLease } from './operational-state-store.js';
 import {
@@ -83,6 +84,7 @@ import {
 export { SQLITE_SESSION_METADATA_SCHEMA_VERSION } from './sqlite-session-metadata-schema.js';
 
 const require = createRequire(import.meta.url);
+const AGENT_GRAPH_CONTROL_DELETE_TABLES = [...SQLITE_AGENT_GRAPH_CONTROL_TABLES].reverse();
 
 function loadSqliteModule(): typeof import('node:sqlite') {
   const emitWarning = process.emitWarning;
@@ -1006,6 +1008,100 @@ export class SqliteSessionMetadataStore {
     return (rows as unknown as Array<{ readonly sessionId: string }>).map((row) => row.sessionId);
   }
 
+  async reconcileOrphanedAgentGraphRetirements(): Promise<string[]> {
+    this.assertOpen();
+    return this.transaction(() => {
+      const rows = this.db
+        .prepare(`
+          SELECT
+            child.session_id,
+            child.payload_json,
+            child.metadata_version,
+            child.committed_at,
+            child.subagent_parent_session_id AS parent_session_id,
+            provision.graph_id,
+            provision.work_id,
+            provision.operator_id,
+            parent_tombstone.retirement_unit_id
+          FROM agent_graph_operator_provisions provision
+          JOIN session_metadata child
+            ON child.session_id = provision.target_session_id
+          JOIN session_metadata_tombstones parent_tombstone
+            ON parent_tombstone.session_id = child.subagent_parent_session_id
+          LEFT JOIN session_metadata live_parent
+            ON live_parent.session_id = child.subagent_parent_session_id
+          WHERE live_parent.session_id IS NULL
+          ORDER BY child.session_id
+        `)
+        .all() as unknown as OrphanedAgentGraphOperatorRow[];
+      const deletedAt = this.now();
+      const reconciled: string[] = [];
+      for (const row of rows) {
+        const record = decodeRecord(row);
+        const parent = record.header.subagentParent;
+        if (
+          !parent?.graph ||
+          parent.parentSessionId !== row.parent_session_id ||
+          parent.graph.graphId !== row.graph_id ||
+          parent.graph.workId !== row.work_id ||
+          parent.graph.operatorId !== row.operator_id ||
+          !row.retirement_unit_id
+        ) {
+          throw new SessionMetadataConflictError(
+            `Cannot reconcile invalid graph operator Session ${row.session_id}`,
+          );
+        }
+        const deleted = this.db
+          .prepare('DELETE FROM session_metadata WHERE session_id = ?')
+          .run(row.session_id);
+        if (deleted.changes !== 1) {
+          throw new SessionMetadataConflictError(
+            `Agent Graph retirement reconciliation lost Session ${row.session_id}`,
+          );
+        }
+        this.db
+          .prepare(`
+            INSERT INTO session_metadata_tombstones(
+              session_id,
+              deleted_at,
+              retirement_unit_id,
+              cleanup_pending
+            )
+            VALUES (?, ?, ?, 1)
+          `)
+          .run(row.session_id, deletedAt, row.retirement_unit_id);
+        this.db
+          .prepare(`
+            UPDATE session_metadata_tombstones
+            SET cleanup_pending = 1
+            WHERE session_id = ?
+          `)
+          .run(row.parent_session_id);
+        reconciled.push(row.session_id);
+      }
+      this.db
+        .prepare(`
+          WITH graph_roots(root_session_id) AS (
+            SELECT root_session_id
+            FROM agent_graph_client_projections
+            UNION
+            SELECT source_session_id
+            FROM agent_graph_schedule_updates
+            UNION
+            SELECT root_session_id
+            FROM agent_graph_supervisor_wakes
+          )
+          UPDATE session_metadata_tombstones
+          SET cleanup_pending = 1
+          WHERE cleanup_pending = 0
+            AND session_id IN (SELECT root_session_id FROM graph_roots)
+            AND session_id NOT IN (SELECT session_id FROM session_metadata)
+        `)
+        .run();
+      return reconciled;
+    });
+  }
+
   async listTombstonedSessionIdsAmong(sessionIds: readonly string[]): Promise<string[]> {
     this.assertOpen();
     const unique = [...new Set(sessionIds)].sort();
@@ -1724,6 +1820,19 @@ export class SqliteSessionMetadataStore {
     );
   }
 
+  async purgeAgentGraphControlState(graphId: string): Promise<number> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    return this.transaction(() =>
+      AGENT_GRAPH_CONTROL_DELETE_TABLES.reduce(
+        (removed, table) =>
+          removed +
+          Number(this.db.prepare(`DELETE FROM ${table} WHERE graph_id = ?`).run(graphId).changes),
+        0,
+      ),
+    );
+  }
+
   async readAgentGraphTimelineMetadata(
     graphId: string,
   ): Promise<AgentGraphTimelineMetadataSnapshot> {
@@ -1858,6 +1967,9 @@ export class SqliteSessionMetadataStore {
     this.assertOpen();
     assertAgentGraphClientProjectionRequest(request);
     return this.transaction(() => {
+      if (!this.readRecordSync(request.rootSessionId)) {
+        throw new SessionNotFoundError(request.rootSessionId);
+      }
       const current = this.db
         .prepare(`
           SELECT
@@ -2265,6 +2377,7 @@ export class SqliteSessionMetadataStore {
   async removeVersioned(sessions: readonly VersionedSessionIdentity[]): Promise<string[]> {
     this.assertOpen();
     const identities = uniqueVersionedSessionIdentities(sessions);
+    const retirementSessionIds = new Set(identities.map(({ sessionId }) => sessionId));
     const retirementUnitId = identities[0]!.sessionId;
     return this.transaction(() => {
       const present: VersionedSessionIdentity[] = [];
@@ -2281,7 +2394,7 @@ export class SqliteSessionMetadataStore {
             record.metadataVersion,
           );
         }
-        this.assertSessionCanBeRemoved(identity.sessionId);
+        this.assertSessionCanBeRemoved(identity.sessionId, retirementSessionIds);
         present.push(identity);
       }
       const deletedAt = this.now();
@@ -3420,18 +3533,65 @@ export class SqliteSessionMetadataStore {
     );
   }
 
-  private assertSessionCanBeRemoved(sessionId: string): void {
+  private assertSessionCanBeRemoved(
+    sessionId: string,
+    retirementSessionIds?: ReadonlySet<string>,
+  ): void {
     const graphOwner = this.db
       .prepare(`
-        SELECT graph_id AS graphId, work_id AS workId
+        SELECT graph_id AS graphId, work_id AS workId, operator_id AS operatorId
         FROM agent_graph_operator_provisions
         WHERE target_session_id = ?
       `)
-      .get(sessionId) as { graphId: string; workId: string } | undefined;
+      .get(sessionId) as { graphId: string; workId: string; operatorId: string } | undefined;
     if (graphOwner) {
-      throw new SessionMetadataConflictError(
-        `Cannot remove graph operator Session ${sessionId}; owned by ${graphOwner.graphId}/${graphOwner.workId}`,
-      );
+      const parent = this.readRecordSync(sessionId)?.header.subagentParent;
+      if (
+        !retirementSessionIds?.has(parent?.parentSessionId ?? '') ||
+        parent?.graph?.graphId !== graphOwner.graphId ||
+        parent.graph.workId !== graphOwner.workId ||
+        parent.graph.operatorId !== graphOwner.operatorId
+      ) {
+        throw new SessionMetadataConflictError(
+          `Cannot remove graph operator Session ${sessionId}; owned by ${graphOwner.graphId}/${graphOwner.workId}`,
+        );
+      }
+    }
+    const ownedOperators = this.db
+      .prepare(`
+        SELECT
+          child.session_id,
+          child.payload_json,
+          child.metadata_version,
+          child.committed_at,
+          provision.graph_id,
+          provision.work_id,
+          provision.operator_id
+        FROM agent_graph_operator_provisions provision
+        JOIN session_metadata child
+          ON child.session_id = provision.target_session_id
+        WHERE child.subagent_parent_session_id = ?
+        ORDER BY child.session_id
+      `)
+      .all(sessionId) as unknown as OwnedAgentGraphOperatorRow[];
+    for (const row of ownedOperators) {
+      const parent = decodeRecord(row).header.subagentParent;
+      if (
+        !parent?.graph ||
+        parent.parentSessionId !== sessionId ||
+        parent.graph.graphId !== row.graph_id ||
+        parent.graph.workId !== row.work_id ||
+        parent.graph.operatorId !== row.operator_id
+      ) {
+        throw new SessionMetadataConflictError(
+          `Cannot remove Session ${sessionId}; graph operator ${row.session_id} has invalid ownership`,
+        );
+      }
+      if (!retirementSessionIds?.has(row.session_id)) {
+        throw new SessionMetadataConflictError(
+          `Cannot remove Session ${sessionId}; graph operator ${row.session_id} is outside the retirement unit`,
+        );
+      }
     }
   }
 
@@ -3495,6 +3655,17 @@ interface SessionMetadataRow {
   payload_json: string;
   metadata_version: number;
   committed_at: number;
+}
+
+interface OwnedAgentGraphOperatorRow extends SessionMetadataRow {
+  graph_id: string;
+  work_id: string;
+  operator_id: string;
+}
+
+interface OrphanedAgentGraphOperatorRow extends OwnedAgentGraphOperatorRow {
+  parent_session_id: string;
+  retirement_unit_id: string | null;
 }
 
 interface SessionMetadataCatalogRow extends SessionMetadataRow {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Treat every Session revision root and its canonical Agent Graph operators as one lifecycle and retirement unit.
- Purge all durable Agent Graph control state through retryable Session cleanup, including recovery of legacy root-only retirements with or without operators.
- Fence client projection commits against removed roots and preserve cleanup authority across Runtime Host startup and shutdown.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck -w @maka/storage`
- `npm run typecheck -w @maka/runtime-host`
- `npm test -w @maka/storage`
- `npm test -w @maka/runtime-host`

Related to #1167

</details>

<details>
<summary>中文</summary>

## 概要

- 将每个 Session revision root 与其 canonical Agent Graph operators 作为同一个生命周期和退休单元处理。
- 通过可重试的 Session cleanup 清除全部持久化 Agent Graph 控制状态，并恢复历史版本中有或没有 operator 的 root-only retirement。
- 在 client projection 提交时校验 root 仍然存在，并在 Runtime Host 启动与关闭期间保留完整的 cleanup authority。

## 验证

- `npm run format:check`
- `npm run lint`
- `npm run typecheck -w @maka/storage`
- `npm run typecheck -w @maka/runtime-host`
- `npm test -w @maka/storage`
- `npm test -w @maka/runtime-host`

关联 #1167

</details>