### PR TITLE
chore(release): prepare 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,49 @@
 
 ## Unreleased
 
-### Open Gateway removal
+## 0.1.3 - 2026-08-03
 
-Removed the desktop Open Gateway HTTP/SSE server, its Settings and IPC surfaces,
-and its dedicated credential/capability types. Model providers, OpenAI-compatible
-connections, Vercel AI Gateway, and bot event gateways are unchanged. Persisted
-settings from older builds are accepted with the retired section ignored.
+### Highlights
+
+- Expanded Runtime Host ownership across hosted child agents, Agent Graph
+  execution, Web Research, Goals, Automation, OAuth enrollment, session
+  lifecycle, runtime resources, and live execution inspection.
+- Strengthened Graph and Swarm coordination with structured operator handoffs,
+  non-blocking supervisor turns, durable child summaries, and session-bound
+  graph retirement.
+- Migrated the Desktop shell, Settings, Composer, conversation surfaces,
+  typography, navigation, resizing, and common controls to Astryx 0.2.0.
+- Added SQLite-backed local memory, managed Git workspaces, verified operational
+  backups, canonical model-call metering, and confirmed agent
+  self-configuration tools.
+- Added `opencode-free` as a zero-credential default provider and improved
+  Runtime Host OAuth-backed execution.
+
+### Reliability and developer experience
+
+- Fixed Electron development and packaged startup failures, onboarding snapshot
+  handoff, Runtime lifecycle races, PTY backpressure, clipboard writes, and
+  several Graph, Headless, and UI regressions.
+- Reduced low-signal, duplicate, source-shape, and happy-path tests; routed CI
+  suites by affected surface; and kept build, typecheck, Storybook, and E2E
+  gates intact.
+
+### Removed
+
+- Removed the desktop Open Gateway HTTP/SSE server and its Settings and IPC
+  surfaces. Model providers, OpenAI-compatible connections, Vercel AI Gateway,
+  and bot event gateways are unchanged.
+- Removed the superseded Expert Team mode and its Notes-era architecture
+  artifacts now that Graph and Swarm own multi-agent coordination.
+- Retired legacy storage writer exports and Astryx compatibility adapters that
+  no longer had active callers.
+
+### Distribution
+
+- Ships for Apple Silicon macOS as a signed and notarized DMG and ZIP.
+- Computer Use remains excluded from this release.
+
+## 0.1.2 - 2026-07-31
 
 ### Runtime kernel extraction
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@maka/desktop",
   "productName": "Maka",
   "description": "A local-first agent workspace built for real work.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "The Maka Authors",
   "license": "Apache-2.0",
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maka",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maka",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -35,7 +35,7 @@
     },
     "apps/desktop": {
       "name": "@maka/desktop",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@astryxdesign/core": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maka",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Summary

- bump root and Desktop release versions to `0.1.3`
- add the `0.1.3` changelog covering Runtime Host, Graph/Swarm, Astryx 0.2.0, reliability, test/CI simplification, removals, and macOS distribution
- retain an empty `Unreleased` section for subsequent changes

## Local verification

- `npm ci`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:release`
- `npm audit --omit=dev --audit-level=high`
- version consistency check across both manifests and lockfile
- `git diff --check`

## Full-test note

`npm test` completed its build and script-test phases, and all emitted assertions passed, including Desktop (`1382/1382`). The local runner did not terminate because existing `storage/root-authority` and `runtime-host/host-kernel` test processes retained idle UDS handles. No production or test code changes are part of this PR; PR/main CI remains the authoritative release gate before the macOS workflow is dispatched.

## Release boundary

After this PR lands and the exact main commit passes CI, dispatch `Release macOS arm64`. The workflow must create a signed/notarized **draft** `v0.1.3` release. Public publishing remains blocked on the separate Apple Silicon quarantine acceptance checklist.
