### PR TITLE
refactor(headless): unify held in task set hash(#1409)

### DIFF
--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -3373,6 +3373,46 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('leaves a tampered heldInTaskSetHash untouched on read', async () => {
+    // A committed event whose hash matches neither codepoint nor localeCompare
+    // is corrupt/tampered. The conditional projection must pass it through
+    // unchanged so the downstream self-consistency check can still catch it,
+    // rather than silently normalizing the bad hash away.
+    await withDir(async (dir) => {
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      const heldInTaskIds = ['apple', 'Banana', 'cherry', 'Date'];
+      await appendFile(
+        resultsJsonlPath,
+        `${JSON.stringify({
+          schemaVersion: 1,
+          type: 'prompt_candidate_committed',
+          id: 'tampered-commit',
+          ts: 100,
+          runId: 'run-1',
+          roundId: 'round-1',
+          commitSha: 'tampered-sha',
+          summary: 'tampered candidate',
+          promptHash: 'sha256:prompt',
+          heldInTaskSetHash: 'sha256:definitely-not-a-real-hash',
+          heldInTaskIds: [...new Set(heldInTaskIds)].sort((a, b) => a.localeCompare(b)),
+          candidateRationaleHash: 'sha256:rationale',
+          candidateRationale: {
+            failurePattern: 'held_in_within_noise',
+            summary: 'tampered',
+            evidenceRefs: [],
+            predictedFixes: [],
+            riskTasks: [],
+          },
+        })}\n`,
+        'utf8',
+      );
+
+      const [event] = await readFixedPromptWal(resultsJsonlPath);
+      assert.equal(event?.type, 'prompt_candidate_committed');
+      assert.equal(event.heldInTaskSetHash, 'sha256:definitely-not-a-real-hash');
+    });
+  });
+
   test('projects a stored structured verifier failure without resampling Harbor', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import { appendFile, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { syncBuiltinESMExports } from 'node:module';
@@ -3318,6 +3319,65 @@ describe('fixed prompt controller', () => {
       assert.equal(result.events[0]?.scored, false);
       assert.equal(result.events[0]?.eligible, false);
       assert.equal(result.events[0]?.errorClass, 'network');
+    });
+  });
+
+  test('projects a legacy heldInTaskSetHash into canonical codepoint order on read', async () => {
+    // Legacy WALs written before the codepoint unification sorted heldInTaskIds
+    // with localeCompare. For mixed-case ids the localeCompare and codepoint
+    // orders diverge, so the persisted hash disagrees with the codepoint
+    // re-hash done at replay. readFixedPromptWal must re-derive the hash so a
+    // resume after upgrade does not hard-fail.
+    await withDir(async (dir) => {
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      const heldInTaskIds = ['apple', 'Banana', 'cherry', 'Date'];
+      const localeCompareHash = `sha256:${createHash('sha256')
+        .update(
+          JSON.stringify(
+            [...new Set(heldInTaskIds)].sort((a, b) => a.localeCompare(b)),
+          ),
+        )
+        .digest('hex')}`;
+      const codepointHash = `sha256:${createHash('sha256')
+        .update(
+          JSON.stringify(
+            [...new Set(heldInTaskIds)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+          ),
+        )
+        .digest('hex')}`;
+      assert.notEqual(localeCompareHash, codepointHash);
+
+      await appendFile(
+        resultsJsonlPath,
+        `${JSON.stringify({
+          schemaVersion: 1,
+          type: 'prompt_candidate_committed',
+          id: 'legacy-commit',
+          ts: 100,
+          runId: 'run-1',
+          roundId: 'round-1',
+          commitSha: 'legacy-sha',
+          summary: 'legacy candidate',
+          promptHash: 'sha256:prompt',
+          heldInTaskSetHash: localeCompareHash,
+          heldInTaskIds: [...new Set(heldInTaskIds)].sort((a, b) =>
+            a.localeCompare(b),
+          ),
+          candidateRationaleHash: 'sha256:rationale',
+          candidateRationale: {
+            failurePattern: 'held_in_within_noise',
+            summary: 'legacy',
+            evidenceRefs: [],
+            predictedFixes: [],
+            riskTasks: [],
+          },
+        })}\n`,
+        'utf8',
+      );
+
+      const [event] = await readFixedPromptWal(resultsJsonlPath);
+      assert.equal(event?.type, 'prompt_candidate_committed');
+      assert.equal(event.heldInTaskSetHash, codepointHash);
     });
   });
 

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -3332,17 +3332,11 @@ describe('fixed prompt controller', () => {
       const resultsJsonlPath = join(dir, 'results.jsonl');
       const heldInTaskIds = ['apple', 'Banana', 'cherry', 'Date'];
       const localeCompareHash = `sha256:${createHash('sha256')
-        .update(
-          JSON.stringify(
-            [...new Set(heldInTaskIds)].sort((a, b) => a.localeCompare(b)),
-          ),
-        )
+        .update(JSON.stringify([...new Set(heldInTaskIds)].sort((a, b) => a.localeCompare(b))))
         .digest('hex')}`;
       const codepointHash = `sha256:${createHash('sha256')
         .update(
-          JSON.stringify(
-            [...new Set(heldInTaskIds)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
-          ),
+          JSON.stringify([...new Set(heldInTaskIds)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))),
         )
         .digest('hex')}`;
       assert.notEqual(localeCompareHash, codepointHash);
@@ -3360,9 +3354,7 @@ describe('fixed prompt controller', () => {
           summary: 'legacy candidate',
           promptHash: 'sha256:prompt',
           heldInTaskSetHash: localeCompareHash,
-          heldInTaskIds: [...new Set(heldInTaskIds)].sort((a, b) =>
-            a.localeCompare(b),
-          ),
+          heldInTaskIds: [...new Set(heldInTaskIds)].sort((a, b) => a.localeCompare(b)),
           candidateRationaleHash: 'sha256:rationale',
           candidateRationale: {
             failurePattern: 'held_in_within_noise',

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -2254,7 +2254,7 @@ async function runCandidateRoundHeldInTaskSetHash(
 }
 
 function expectedHeldInTaskSetHash(heldInTaskIds: readonly string[]): string {
-  return sha256Json([...new Set(heldInTaskIds)].sort((a, b) => a.localeCompare(b)));
+  return sha256Json([...new Set(heldInTaskIds)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)));
 }
 
 function expectedCandidateRationaleHash(candidateRationale: Record<string, unknown>): string {

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -18,6 +18,7 @@ import {
   type MetaAgentPromptInput,
   type MetaAgentPromptResult,
 } from '../prompt-candidate-loop.js';
+import { heldInTaskSetHash } from '../rsi-round-analysis.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -126,6 +127,23 @@ describe('prompt candidate loop', () => {
     assert.equal(firstHash, secondHash);
     assert.notEqual(firstHash, differentHash);
     assert.equal(firstHash, expectedHeldInTaskSetHash(['task-a', 'task-b']));
+  });
+
+  test('writer commits a held-in task set hash in canonical codepoint order', async () => {
+    // Writer-contract test: drive the real runPromptCandidateRound writer (not a
+    // hand-constructed event) with ids whose codepoint and localeCompare orders
+    // diverge (mixed case: localeCompare folds case to ['apple','Banana',...],
+    // codepoint orders ['Banana','Date','apple','cherry']). The hash persisted
+    // to the WAL must equal the canonical codepoint heldInTaskSetHash; this
+    // fails if the writer regresses to localeCompare.
+    const heldInTaskIds = ['apple', 'Banana', 'cherry', 'Date'];
+    const writerHash = await runCandidateRoundHeldInTaskSetHash(heldInTaskIds);
+
+    assert.equal(writerHash, heldInTaskSetHash(heldInTaskIds));
+    assert.notEqual(
+      writerHash,
+      sha256Json([...new Set(heldInTaskIds)].sort((a, b) => a.localeCompare(b))),
+    );
   });
 
   test('filters results TSV by held-in tasks independently from trajectory digests', async () => {

--- a/packages/headless/src/__tests__/prompt-optimization-loop-replay-attribution.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop-replay-attribution.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { writeFile } from 'node:fs/promises';
 import { describe, test } from 'node:test';
 import { readFixedPromptWal } from '../fixed-prompt-controller.js';
-import { hashHeldInTaskSet } from '../prompt-candidate-loop.js';
+import { heldInTaskSetHash } from '../rsi-round-analysis.js';
 import {
   execFileAsync,
   fakeMetaAgent,
@@ -400,7 +400,7 @@ describe('runPromptOptimizationLoop replay attribution guards', () => {
         baselineRuns: 1,
       });
       const tamperedHeldInTaskIds = [...heldInTasks.map((task) => task.id), 'hout-0'];
-      const tamperedHeldInTaskSetHash = hashHeldInTaskSet(tamperedHeldInTaskIds);
+      const tamperedHeldInTaskSetHash = heldInTaskSetHash(tamperedHeldInTaskIds);
       const events = await readFixedPromptWal(harness.resultsJsonlPath);
       const tamperedEvents = events.map((event) => {
         if (event.type === 'prompt_candidate_committed' && event.roundId === 'round-0') {

--- a/packages/headless/src/__tests__/prompt-optimization-run.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-run.test.ts
@@ -25,7 +25,8 @@ import {
   runPromptOptimizationRun,
   selectPromptOptimizationPartitions,
 } from '../prompt-optimization-run.js';
-import { hashCandidateRationale, hashHeldInTaskSet } from '../prompt-candidate-loop.js';
+import { hashCandidateRationale } from '../prompt-candidate-loop.js';
+import { heldInTaskSetHash } from '../rsi-round-analysis.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 
 const execFileAsync = promisify(execFile);
@@ -674,7 +675,7 @@ describe('runPromptOptimizationRun', () => {
           commitSha: candidateSha,
           summary: 'candidate',
           promptHash: hashSystemPrompt('candidate prompt\n'),
-          heldInTaskSetHash: hashHeldInTaskSet(['hin-0']),
+          heldInTaskSetHash: heldInTaskSetHash(['hin-0']),
           heldInTaskIds: ['hin-0'],
           candidateRationaleHash: hashCandidateRationale(candidateRationale),
           candidateRationale,

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -6,7 +6,6 @@ import type {
   PromptCandidateRewardHackScan,
 } from '../fixed-prompt-controller.js';
 import { promptStructuralSmokeReport } from '../prompt-structural-smoke.js';
-import { hashHeldInTaskSet } from '../prompt-candidate-loop.js';
 import { heldInTaskSetHash } from '../rsi-round-analysis.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 
@@ -471,12 +470,12 @@ describe('prompt structural smoke report', () => {
     // Ids chosen to diverge between codepoint order and localeCompare.
     // localeCompare folds case (UCA tertiary weight), so it orders these as
     // ['apple','Banana','cherry','Date']; codepoint orders them as
-    // ['Banana','Date','apple','cherry'] (uppercase < lowercase). The committed
-    // event hashes with hashHeldInTaskSet (formerly localeCompare) and the
-    // attribution event hashes with heldInTaskSetHash (codepoint). Under the old
-    // split the two hashes diverged for these ids and the smoke check marked this
-    // legitimate round as malformed. The unified codepoint order must keep both
-    // sides equal so the round stays clean.
+    // ['Banana','Date','apple','cherry'] (uppercase < lowercase). Both the
+    // committed and attribution events now hash with the unified codepoint
+    // heldInTaskSetHash; this end-to-end test guards the cross-WAL-boundary
+    // smoke check against these ids. (The writer-side regression guard — that
+    // the real writer uses codepoint, not localeCompare — lives in the
+    // writer-contract test in prompt-candidate-loop.test.ts.)
     const heldInTaskIds = ['apple', 'Banana', 'cherry', 'Date'];
     const events: FixedPromptWalEvent[] = [
       committedEvent('round-1', 'run-1', promptHashForRound('round-1'), heldInTaskIds),
@@ -485,13 +484,13 @@ describe('prompt structural smoke report', () => {
       attributionEvent('round-1'),
     ];
 
-    // Override the placeholder hashes with the two real implementations, so the
+    // Override the placeholder hashes with the canonical implementation, so the
     // committed/attribution pair mirrors what each side actually writes.
     const committed = events[0] as Extract<
       FixedPromptWalEvent,
       { type: 'prompt_candidate_committed' }
     >;
-    committed.heldInTaskSetHash = hashHeldInTaskSet(heldInTaskIds);
+    committed.heldInTaskSetHash = heldInTaskSetHash(heldInTaskIds);
     const attribution = events[3] as Extract<
       FixedPromptWalEvent,
       { type: 'rsi_controller_attribution' }

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -6,6 +6,8 @@ import type {
   PromptCandidateRewardHackScan,
 } from '../fixed-prompt-controller.js';
 import { promptStructuralSmokeReport } from '../prompt-structural-smoke.js';
+import { hashHeldInTaskSet } from '../prompt-candidate-loop.js';
+import { heldInTaskSetHash } from '../rsi-round-analysis.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 
 describe('prompt structural smoke report', () => {
@@ -463,6 +465,46 @@ describe('prompt structural smoke report', () => {
     assert.equal(report.status, 'fail');
     assert.deepEqual(report.failures, ['rsi_attribution_malformed']);
     assert.deepEqual(report.roundsWithMalformedRsiAttribution, ['round-1']);
+  });
+
+  test('keeps a legitimate round clean when held-in ids trigger sort divergence', () => {
+    // Ids chosen to diverge between codepoint order and localeCompare.
+    // localeCompare folds case (UCA tertiary weight), so it orders these as
+    // ['apple','Banana','cherry','Date']; codepoint orders them as
+    // ['Banana','Date','apple','cherry'] (uppercase < lowercase). The committed
+    // event hashes with hashHeldInTaskSet (formerly localeCompare) and the
+    // attribution event hashes with heldInTaskSetHash (codepoint). Under the old
+    // split the two hashes diverged for these ids and the smoke check marked this
+    // legitimate round as malformed. The unified codepoint order must keep both
+    // sides equal so the round stays clean.
+    const heldInTaskIds = ['apple', 'Banana', 'cherry', 'Date'];
+    const events: FixedPromptWalEvent[] = [
+      committedEvent('round-1', 'run-1', promptHashForRound('round-1'), heldInTaskIds),
+      completedEvent('round-1', 'apple', 0.1),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+      attributionEvent('round-1'),
+    ];
+
+    // Override the placeholder hashes with the two real implementations, so the
+    // committed/attribution pair mirrors what each side actually writes.
+    const committed = events[0] as Extract<
+      FixedPromptWalEvent,
+      { type: 'prompt_candidate_committed' }
+    >;
+    committed.heldInTaskSetHash = hashHeldInTaskSet(heldInTaskIds);
+    const attribution = events[3] as Extract<
+      FixedPromptWalEvent,
+      { type: 'rsi_controller_attribution' }
+    >;
+    attribution.heldInTaskSetHash = heldInTaskSetHash(heldInTaskIds);
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.deepEqual(report.roundsWithMalformedRsiAttribution, []);
   });
 });
 

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, truncate, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import {
@@ -12,6 +12,7 @@ import type { Config } from './contracts.js';
 import {
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
   heldInTaskSetHash,
+  sortedUnique,
   type FixedPromptTaskAttemptStartedEvent,
   type FixedPromptTaskBudgetExhaustedEvent,
   type FixedPromptTaskCompletedEvent,
@@ -1258,27 +1259,43 @@ function projectStructuredVerifierOutcome(event: FixedPromptWalEvent): FixedProm
 }
 
 /**
- * Re-derives `heldInTaskSetHash` on legacy `prompt_candidate_committed` records
- * using the canonical codepoint order. WALs written before the codepoint
+ * Conditionally re-derives `heldInTaskSetHash` on legacy
+ * `prompt_candidate_committed` records. WALs written before the codepoint
  * unification sorted task ids with localeCompare; replay self-consistency
  * checks (prompt-optimization-replay-state.ts) re-hash with codepoint, so
  * without this projection a resume after upgrade hard-fails for id sets where
- * the two orders differ (mixed case, e.g. apple/Banana). Re-computing here is
- * idempotent for records already on codepoint order.
+ * the two orders differ (mixed case, e.g. apple/Banana).
  *
- * Tamper semantics: because the hash is re-derived on every read, a hash-only
- * edit to a committed event is silently normalized away before the
- * self-consistency check runs — only tampering with `heldInTaskIds` (which
- * shifts the re-derived hash out of sync with other events) is still caught.
- * This is the intended trade-off for legacy-WAL resume compatibility.
+ * Only records whose persisted hash matches the legacy localeCompare order are
+ * rewritten (both hash and ids normalized to codepoint). Records already on
+ * codepoint order are left untouched, and records whose hash matches neither
+ * order — i.e. tampered or corrupt — are passed through unchanged so the
+ * downstream self-consistency check still catches them. This preserves the
+ * tamper-detection that an unconditional re-derive would silently weaken.
  */
 function projectLegacyHeldInTaskSetHash(event: FixedPromptWalEvent): FixedPromptWalEvent {
   if (event.type !== 'prompt_candidate_committed') return event;
-  if (!Array.isArray(event.heldInTaskIds)) return event;
+  const ids = event.heldInTaskIds;
+  if (!Array.isArray(ids)) return event;
+  const codepointHash = heldInTaskSetHash(ids);
+  if (event.heldInTaskSetHash === codepointHash) return event;
+  if (event.heldInTaskSetHash !== legacyHeldInTaskSetHash(ids)) return event;
+  const normalizedIds = sortedUnique(ids);
   return {
     ...event,
-    heldInTaskSetHash: heldInTaskSetHash(event.heldInTaskIds),
+    heldInTaskSetHash: heldInTaskSetHash(normalizedIds),
+    heldInTaskIds: normalizedIds,
   };
+}
+
+/**
+ * The pre-unification hash (localeCompare sort order), used only to recognize
+ * legacy WAL records so the projection above can rewrite them selectively.
+ */
+function legacyHeldInTaskSetHash(taskIds: readonly string[]): string {
+  return `sha256:${createHash('sha256')
+    .update(JSON.stringify([...new Set(taskIds)].sort((a, b) => a.localeCompare(b))))
+    .digest('hex')}`;
 }
 
 /**

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, truncate, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import {
@@ -11,6 +11,7 @@ import {
 import type { Config } from './contracts.js';
 import {
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
+  heldInTaskSetHash,
   type FixedPromptTaskAttemptStartedEvent,
   type FixedPromptTaskBudgetExhaustedEvent,
   type FixedPromptTaskCompletedEvent,
@@ -1264,28 +1265,20 @@ function projectStructuredVerifierOutcome(event: FixedPromptWalEvent): FixedProm
  * without this projection a resume after upgrade hard-fails for id sets where
  * the two orders differ (mixed case, e.g. apple/Banana). Re-computing here is
  * idempotent for records already on codepoint order.
+ *
+ * Tamper semantics: because the hash is re-derived on every read, a hash-only
+ * edit to a committed event is silently normalized away before the
+ * self-consistency check runs — only tampering with `heldInTaskIds` (which
+ * shifts the re-derived hash out of sync with other events) is still caught.
+ * This is the intended trade-off for legacy-WAL resume compatibility.
  */
 function projectLegacyHeldInTaskSetHash(event: FixedPromptWalEvent): FixedPromptWalEvent {
   if (event.type !== 'prompt_candidate_committed') return event;
+  if (!Array.isArray(event.heldInTaskIds)) return event;
   return {
     ...event,
-    heldInTaskSetHash: canonicalHeldInTaskSetHash(event.heldInTaskIds),
+    heldInTaskSetHash: heldInTaskSetHash(event.heldInTaskIds),
   };
-}
-
-/**
- * Mirrors the canonical codepoint `heldInTaskSetHash` in rsi-round-analysis.ts.
- * Inlined here (rather than imported) because fixed-prompt-controller sits
- * upstream of rsi-round-analysis in the dependency graph — importing it would
- * create a reverse dependency. The sort comparator must stay byte-identical to
- * rsi-round-analysis `compareStrings`; see the cross-WAL-boundary regression
- * test (prompt-structural-smoke.test.ts) and writer-contract test
- * (prompt-candidate-loop.test.ts) which pin this equivalence.
- */
-function canonicalHeldInTaskSetHash(taskIds: readonly string[]): string {
-  return `sha256:${createHash('sha256')
-    .update(JSON.stringify([...new Set(taskIds)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))))
-    .digest('hex')}`;
 }
 
 /**

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, truncate, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import {
@@ -410,7 +410,10 @@ export async function readFixedPromptWal(path: string): Promise<FixedPromptWalEv
       throw error;
     }
   }
-  return events.map(projectLegacyTimeoutOutcome).map(projectStructuredVerifierOutcome);
+  return events
+    .map(projectLegacyTimeoutOutcome)
+    .map(projectStructuredVerifierOutcome)
+    .map(projectLegacyHeldInTaskSetHash);
 }
 
 export async function readHarborTaskRunOutput(
@@ -1251,6 +1254,38 @@ function projectStructuredVerifierOutcome(event: FixedPromptWalEvent): FixedProm
     ...stable,
     ...scoring,
   };
+}
+
+/**
+ * Re-derives `heldInTaskSetHash` on legacy `prompt_candidate_committed` records
+ * using the canonical codepoint order. WALs written before the codepoint
+ * unification sorted task ids with localeCompare; replay self-consistency
+ * checks (prompt-optimization-replay-state.ts) re-hash with codepoint, so
+ * without this projection a resume after upgrade hard-fails for id sets where
+ * the two orders differ (mixed case, e.g. apple/Banana). Re-computing here is
+ * idempotent for records already on codepoint order.
+ */
+function projectLegacyHeldInTaskSetHash(event: FixedPromptWalEvent): FixedPromptWalEvent {
+  if (event.type !== 'prompt_candidate_committed') return event;
+  return {
+    ...event,
+    heldInTaskSetHash: canonicalHeldInTaskSetHash(event.heldInTaskIds),
+  };
+}
+
+/**
+ * Mirrors the canonical codepoint `heldInTaskSetHash` in rsi-round-analysis.ts.
+ * Inlined here (rather than imported) because fixed-prompt-controller sits
+ * upstream of rsi-round-analysis in the dependency graph — importing it would
+ * create a reverse dependency. The sort comparator must stay byte-identical to
+ * rsi-round-analysis `compareStrings`; see the cross-WAL-boundary regression
+ * test (prompt-structural-smoke.test.ts) and writer-contract test
+ * (prompt-candidate-loop.test.ts) which pin this equivalence.
+ */
+function canonicalHeldInTaskSetHash(taskIds: readonly string[]): string {
+  return `sha256:${createHash('sha256')
+    .update(JSON.stringify([...new Set(taskIds)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))))
+    .digest('hex')}`;
 }
 
 /**

--- a/packages/headless/src/fixed-prompt-wal-types.ts
+++ b/packages/headless/src/fixed-prompt-wal-types.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type {
   HarborCellContextBudgetPolicySnapshot,
   HarborCellContextBudgetSummary,
@@ -302,3 +303,24 @@ export type FixedPromptTaskWalEvent =
   | FixedPromptTaskInfraFailedEvent
   | FixedPromptTaskBudgetExhaustedEvent
   | FixedPromptTaskPlumbingFailedEvent;
+
+/**
+ * Canonical codepoint comparison and dedupe helpers, plus the held-in task set
+ * hash built on them. These live here (rather than in rsi-round-analysis.ts) so
+ * that fixed-prompt-controller.ts — which sits upstream of rsi-round-analysis —
+ * can share the single source of truth for the hash used both when writing WAL
+ * events and when projecting legacy records on read.
+ */
+export function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort(compareStrings);
+}
+
+export function heldInTaskSetHash(taskIds: readonly string[]): string {
+  return `sha256:${createHash('sha256')
+    .update(JSON.stringify(sortedUnique(taskIds)))
+    .digest('hex')}`;
+}

--- a/packages/headless/src/prompt-candidate-digest.ts
+++ b/packages/headless/src/prompt-candidate-digest.ts
@@ -1,0 +1,213 @@
+import { readFile } from 'node:fs/promises';
+
+export interface TrajectoryDigest {
+  taskId: string;
+  errorClass?: string;
+  summary: string;
+  recentToolCalls?: readonly TrajectoryToolCallDigest[];
+  toolFailures?: readonly TrajectoryToolFailureDigest[];
+}
+
+export interface TrajectoryToolCallDigest {
+  name: string;
+  argsPreview: string;
+}
+
+export interface TrajectoryToolFailureDigest {
+  name: string;
+  count: number;
+  errorClass?: string;
+  argsPreview?: string;
+}
+
+export interface ExtractTrajectoryDigestInput {
+  taskId: string;
+  errorClass?: string;
+  runtimeEventsPath: string;
+  traceEventsPath?: string;
+  verifierSummary: string;
+}
+
+export async function extractTrajectoryDigest(
+  input: ExtractTrajectoryDigestInput,
+): Promise<TrajectoryDigest> {
+  const events = await readRuntimeEventsJsonl(input.runtimeEventsPath);
+  const callsById = new Map<string, TrajectoryToolCallDigest>();
+  for (const event of events) {
+    const call = functionCallDigestWithId(event);
+    if (call) callsById.set(call.id, { name: call.name, argsPreview: call.argsPreview });
+  }
+  const recentToolCalls = events
+    .map((event) => functionCallDigest(event))
+    .filter((call): call is TrajectoryToolCallDigest => call !== undefined)
+    .slice(-2);
+  const toolFailures = input.traceEventsPath
+    ? await extractToolFailureDigests(input.traceEventsPath, callsById)
+    : [];
+  return {
+    taskId: input.taskId,
+    ...(input.errorClass ? { errorClass: input.errorClass } : {}),
+    summary: input.verifierSummary,
+    ...(recentToolCalls.length > 0 ? { recentToolCalls } : {}),
+    ...(toolFailures.length > 0 ? { toolFailures } : {}),
+  };
+}
+
+export function renderToolFailureSummary(
+  digests: readonly TrajectoryDigest[],
+  resultsTsv: string,
+): string[] {
+  const passedByTask = passedResultsByTask(resultsTsv);
+  const failures = new Map<string, { digest: TrajectoryToolFailureDigest; taskIds: Set<string> }>();
+  for (const digest of digests) {
+    if (passedByTask?.get(digest.taskId) === true) continue;
+    for (const failure of digest.toolFailures ?? []) {
+      const key = [failure.name, failure.errorClass ?? '', failure.argsPreview ?? ''].join('\0');
+      const current = failures.get(key) ?? {
+        digest: { ...failure, count: 0 },
+        taskIds: new Set<string>(),
+      };
+      current.digest = { ...failure, count: current.digest.count + failure.count };
+      current.taskIds.add(digest.taskId);
+      failures.set(key, current);
+    }
+  }
+  const lines = [...failures.values()]
+    .sort((a, b) => compareToolFailures(a.digest, b.digest))
+    .slice(0, 10)
+    .map(({ digest, taskIds }) =>
+      [
+        `${digest.name} x${digest.count}`,
+        ...(digest.errorClass ? [`error=${digest.errorClass}`] : []),
+        ...(digest.argsPreview ? [`args=${digest.argsPreview}`] : []),
+        `tasks=${[...taskIds].sort((a, b) => a.localeCompare(b)).join(',')}`,
+      ].join(' '),
+    );
+  return lines.length > 0 ? ['# Held-In Tool Failure Summary', ...lines] : [];
+}
+
+export function stripPromptOnlyToolFailures(
+  digests: readonly TrajectoryDigest[],
+): readonly Omit<TrajectoryDigest, 'toolFailures'>[] {
+  return digests.map(({ toolFailures: _toolFailures, ...digest }) => digest);
+}
+
+export async function readRuntimeEventsJsonl(path: string): Promise<unknown[]> {
+  const raw = await readFile(path, 'utf8');
+  return raw
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+async function extractToolFailureDigests(
+  traceEventsPath: string,
+  callsById: ReadonlyMap<string, TrajectoryToolCallDigest>,
+): Promise<TrajectoryToolFailureDigest[]> {
+  let events: unknown[];
+  try {
+    events = await readRuntimeEventsJsonl(traceEventsPath);
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+    return [];
+  }
+  const failures = new Map<string, TrajectoryToolFailureDigest>();
+  for (const event of events) {
+    const failure = toolFailureDigest(event, callsById);
+    if (!failure) continue;
+    const key = [failure.name, failure.errorClass ?? '', failure.argsPreview ?? ''].join('\0');
+    const current = failures.get(key);
+    failures.set(key, {
+      ...failure,
+      count: (current?.count ?? 0) + 1,
+    });
+  }
+  return [...failures.values()].sort(compareToolFailures).slice(0, 5);
+}
+
+function passedResultsByTask(resultsTsv: string): ReadonlyMap<string, boolean> | undefined {
+  const lines = resultsTsv.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  const header = lines[0]?.split('\t');
+  if (!header) return undefined;
+  const taskIdIndex = header.indexOf('task_id');
+  const passedIndex = header.indexOf('passed');
+  if (taskIdIndex === -1 || passedIndex === -1) return undefined;
+  const passedByTask = new Map<string, boolean>();
+  for (const line of lines.slice(1)) {
+    const columns = line.split('\t');
+    const taskId = columns[taskIdIndex];
+    if (!taskId) continue;
+    passedByTask.set(taskId, columns[passedIndex] === 'true');
+  }
+  return passedByTask;
+}
+
+function functionCallDigest(event: unknown): TrajectoryToolCallDigest | undefined {
+  if (!isRecord(event) || !isRecord(event.content)) return undefined;
+  const content = event.content;
+  if (content.kind !== 'function_call' || typeof content.name !== 'string') return undefined;
+  return {
+    name: content.name,
+    argsPreview: argsPreview(content.args),
+  };
+}
+
+function functionCallDigestWithId(
+  event: unknown,
+): (TrajectoryToolCallDigest & { id: string }) | undefined {
+  const call = functionCallDigest(event);
+  if (!call || !isRecord(event) || !isRecord(event.content) || typeof event.content.id !== 'string')
+    return undefined;
+  return { ...call, id: event.content.id };
+}
+
+function toolFailureDigest(
+  event: unknown,
+  callsById: ReadonlyMap<string, TrajectoryToolCallDigest>,
+): TrajectoryToolFailureDigest | undefined {
+  if (!isRecord(event) || event.type !== 'tool_failed' || !isRecord(event.data)) return undefined;
+  const data = event.data;
+  if (typeof data.toolName !== 'string') return undefined;
+  const call = typeof data.toolUseId === 'string' ? callsById.get(data.toolUseId) : undefined;
+  return {
+    name: promptSafeToken(data.toolName, 'unknown_tool'),
+    count: 1,
+    ...(typeof data.errorClass === 'string'
+      ? { errorClass: promptSafeToken(data.errorClass, 'unknown_error') }
+      : {}),
+    ...(call?.argsPreview ? { argsPreview: call.argsPreview } : {}),
+  };
+}
+
+function compareToolFailures(
+  a: TrajectoryToolFailureDigest,
+  b: TrajectoryToolFailureDigest,
+): number {
+  return (
+    b.count - a.count ||
+    a.name.localeCompare(b.name) ||
+    (a.errorClass ?? '').localeCompare(b.errorClass ?? '') ||
+    (a.argsPreview ?? '').localeCompare(b.argsPreview ?? '')
+  );
+}
+
+function argsPreview(args: unknown): string {
+  if (!isRecord(args)) return typeof args;
+  return Object.keys(args)
+    .map((key) => promptSafeToken(key, 'arg'))
+    .sort((a, b) => a.localeCompare(b))
+    .join(',');
+}
+
+function promptSafeToken(value: string, fallback: string): string {
+  if (/^[A-Za-z0-9_.:-]{1,64}$/.test(value)) return value;
+  return fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNotFound(error: unknown): boolean {
+  return isRecord(error) && error.code === 'ENOENT';
+}

--- a/packages/headless/src/prompt-candidate-git.ts
+++ b/packages/headless/src/prompt-candidate-git.ts
@@ -1,0 +1,235 @@
+import { createHash } from 'node:crypto';
+import { execFile, execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { lstat, readFile, realpath } from 'node:fs/promises';
+import { isAbsolute, relative, resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export interface PromptCandidateGit {
+  gitRootPath: string;
+  systemPromptGitPath: string;
+  assertSystemPromptClean(): Promise<void>;
+  changedFiles(): Promise<readonly string[]>;
+  commit(message: string): Promise<string>;
+  rollbackCommit(commitSha: string): Promise<void>;
+  restoreSystemPrompt(): Promise<void>;
+}
+
+export interface CreateCliPromptCandidateGitInput {
+  cwd: string;
+  systemPromptPath: string;
+}
+
+export function assertOnlySystemPromptChanged(
+  changedFiles: readonly string[],
+  systemPromptGitPath: string,
+): void {
+  const allowed = normalizeGitPath(systemPromptGitPath);
+  const unexpected = changedFiles.filter((file) => normalizeGitPath(file) !== allowed);
+  if (unexpected.length > 0) {
+    throw new Error(`only ${allowed} may change; unexpected files: ${unexpected.join(', ')}`);
+  }
+}
+
+export async function assertRegularSystemPromptFile(
+  systemPromptPath: string,
+  gitRootPath: string,
+): Promise<void> {
+  const stat = await lstat(systemPromptPath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error('system_prompt.md must be a regular file');
+  }
+  const [promptRealPath, gitRootRealPath] = await Promise.all([
+    realpath(systemPromptPath),
+    realpath(gitRootPath),
+  ]);
+  if (!isPathInside(gitRootRealPath, promptRealPath)) {
+    throw new Error('system_prompt.md must stay inside the git cwd');
+  }
+}
+
+export function createCliPromptCandidateGit(
+  input: CreateCliPromptCandidateGitInput,
+): PromptCandidateGit {
+  const gitRootPath = realpathSync(findGitRoot(input.cwd));
+  const systemPromptPath = isAbsolute(input.systemPromptPath)
+    ? realpathSync(input.systemPromptPath)
+    : realpathSync(resolve(input.cwd, input.systemPromptPath));
+  const systemPromptGitPath = toGitRelativePath(gitRootPath, systemPromptPath);
+  let statusBaseline: ReadonlyMap<string, string> | undefined;
+  let headBaseline: string | undefined;
+  return {
+    gitRootPath,
+    systemPromptGitPath,
+    async assertSystemPromptClean(): Promise<void> {
+      if (!(await isGitTracked(gitRootPath, systemPromptGitPath))) {
+        throw new Error('system_prompt.md must be tracked before candidate round');
+      }
+      const [worktreeDirty, indexDirty] = await Promise.all([
+        hasGitDiff(gitRootPath, ['diff', '--quiet', '--', systemPromptGitPath]),
+        hasGitDiff(gitRootPath, ['diff', '--cached', '--quiet', '--', systemPromptGitPath]),
+      ]);
+      if (worktreeDirty || indexDirty) {
+        throw new Error('system_prompt.md must be clean before candidate round');
+      }
+      [statusBaseline, headBaseline] = await Promise.all([
+        gitStatusSnapshot(gitRootPath),
+        gitHeadSha(gitRootPath),
+      ]);
+    },
+    async changedFiles(): Promise<readonly string[]> {
+      await assertGitHeadUnchanged(gitRootPath, headBaseline);
+      const baseline = statusBaseline ?? new Map<string, string>();
+      const current = await gitStatusSnapshot(gitRootPath);
+      const paths = new Set([...baseline.keys(), ...current.keys()]);
+      return [...paths].filter((path) => baseline.get(path) !== current.get(path));
+    },
+    async commit(message: string): Promise<string> {
+      await assertGitHeadUnchanged(gitRootPath, headBaseline);
+      await execFileAsync('git', ['add', '--', systemPromptGitPath], { cwd: gitRootPath });
+      await execFileAsync('git', ['commit', '-m', message, '--', systemPromptGitPath], {
+        cwd: gitRootPath,
+      });
+      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: gitRootPath });
+      return stdout.trim();
+    },
+    async rollbackCommit(commitSha: string): Promise<void> {
+      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: gitRootPath });
+      if (stdout.trim() !== commitSha) {
+        throw new Error('candidate prompt commit cannot be rolled back because HEAD moved');
+      }
+      await execFileAsync('git', ['reset', '--soft', `${commitSha}^`], { cwd: gitRootPath });
+      await execFileAsync('git', ['restore', '--staged', '--worktree', '--', systemPromptGitPath], {
+        cwd: gitRootPath,
+      });
+    },
+    async restoreSystemPrompt(): Promise<void> {
+      await execFileAsync('git', ['restore', '--staged', '--worktree', '--', systemPromptGitPath], {
+        cwd: gitRootPath,
+      });
+    },
+  };
+}
+
+async function assertGitHeadUnchanged(cwd: string, baseline: string | undefined): Promise<void> {
+  if (baseline === undefined) return;
+  const current = await gitHeadSha(cwd);
+  if (current !== baseline) {
+    throw new Error('candidate round HEAD moved before prompt commit');
+  }
+}
+
+async function gitHeadSha(cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd });
+  return stdout.trim();
+}
+
+async function isGitTracked(cwd: string, path: string): Promise<boolean> {
+  try {
+    await execFileAsync('git', ['ls-files', '--error-unmatch', '--', path], { cwd });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function hasGitDiff(cwd: string, args: readonly string[]): Promise<boolean> {
+  try {
+    await execFileAsync('git', [...args], { cwd });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+async function gitStatusFiles(cwd: string): Promise<readonly string[]> {
+  const { stdout } = await execFileAsync(
+    'git',
+    ['status', '--porcelain', '--untracked-files=all'],
+    { cwd },
+  );
+  return stdout
+    .split('\n')
+    .map((line) => statusPath(line))
+    .filter((path): path is string => path !== undefined);
+}
+
+async function gitStatusSnapshot(cwd: string): Promise<ReadonlyMap<string, string>> {
+  const snapshot = new Map<string, string>();
+  for (const path of await gitStatusFiles(cwd)) {
+    snapshot.set(path, await gitStatusFingerprint(cwd, path));
+  }
+  return snapshot;
+}
+
+async function gitStatusFingerprint(cwd: string, path: string): Promise<string> {
+  const [fileHash, worktreeDiff, indexDiff] = await Promise.all([
+    fileFingerprint(resolve(cwd, path)),
+    gitDiffFingerprint(cwd, ['diff', '--binary', '--', path]),
+    gitDiffFingerprint(cwd, ['diff', '--cached', '--binary', '--', path]),
+  ]);
+  return [fileHash, worktreeDiff, indexDiff].join('\0');
+}
+
+async function fileFingerprint(path: string): Promise<string> {
+  try {
+    const content = await readFile(path);
+    return createHash('sha256').update(content).digest('hex');
+  } catch (error) {
+    if (isNotFound(error)) return 'missing';
+    throw error;
+  }
+}
+
+async function gitDiffFingerprint(cwd: string, args: readonly string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', [...args], { cwd, encoding: 'buffer' });
+  return createHash('sha256').update(stdout).digest('hex');
+}
+
+function statusPath(line: string): string | undefined {
+  const path = line.slice(3).trim();
+  if (path.length === 0) return undefined;
+  const renameSeparator = ' -> ';
+  const renameIndex = path.indexOf(renameSeparator);
+  return renameIndex === -1 ? path : path.slice(renameIndex + renameSeparator.length);
+}
+
+function findGitRoot(cwd: string): string {
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd, encoding: 'utf8' }).trim();
+}
+
+export function isPathInside(rootPath: string, targetPath: string): boolean {
+  const relativePath = relative(rootPath, targetPath).split('\\').join('/');
+  return (
+    relativePath !== '' &&
+    relativePath !== '..' &&
+    !relativePath.startsWith('../') &&
+    !isAbsolute(relativePath)
+  );
+}
+
+function toGitRelativePath(cwd: string, path: string): string {
+  const absolutePath = isAbsolute(path) ? path : resolve(cwd, path);
+  const relativePath = relative(cwd, absolutePath).split('\\').join('/');
+  if (relativePath === '' || relativePath === '..' || relativePath.startsWith('../')) {
+    throw new Error('system_prompt.md must be inside the git cwd');
+  }
+  return relativePath;
+}
+
+export function normalizeGitPath(path: string): string {
+  let current = path;
+  current = current.split('\\').join('/');
+  while (current.startsWith('./')) current = current.slice(2);
+  return current;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNotFound(error: unknown): boolean {
+  return isRecord(error) && error.code === 'ENOENT';
+}

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -1,10 +1,20 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { execFile, execFileSync } from 'node:child_process';
-import { realpathSync } from 'node:fs';
-import { lstat, readdir, readFile, readlink, realpath, writeFile } from 'node:fs/promises';
-import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
-import { promisify } from 'node:util';
+import { readdir, readFile, readlink, realpath, writeFile } from 'node:fs/promises';
+import { basename, dirname, relative, resolve } from 'node:path';
 import { appendFixedPromptWalEvent, hashSystemPrompt } from './fixed-prompt-controller.js';
+import {
+  assertOnlySystemPromptChanged,
+  assertRegularSystemPromptFile,
+  isPathInside,
+  normalizeGitPath,
+  type PromptCandidateGit,
+} from './prompt-candidate-git.js';
+
+export {
+  createCliPromptCandidateGit,
+  type CreateCliPromptCandidateGitInput,
+  type PromptCandidateGit,
+} from './prompt-candidate-git.js';
 import {
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
   PROMPT_CANDIDATE_FAILURE_PATTERNS,
@@ -20,8 +30,6 @@ import type { RsiRoundAnalysis } from './rsi-round-analysis.js';
 import { heldInTaskSetHash, sortedUnique } from './rsi-round-analysis.js';
 
 export { heldInTaskSetHash as hashHeldInTaskSet } from './rsi-round-analysis.js';
-
-const execFileAsync = promisify(execFile);
 
 const CANDIDATE_RATIONALE_MAX_TASK_IDS = 16;
 const CANDIDATE_RATIONALE_MAX_TEXT_CHARS = 280;
@@ -103,21 +111,6 @@ export type MetaAgentCompletion = (input: MetaAgentCompletionInput) => Promise<s
 
 export interface CreateScriptedMetaAgentInput {
   complete: MetaAgentCompletion;
-}
-
-export interface PromptCandidateGit {
-  gitRootPath: string;
-  systemPromptGitPath: string;
-  assertSystemPromptClean(): Promise<void>;
-  changedFiles(): Promise<readonly string[]>;
-  commit(message: string): Promise<string>;
-  rollbackCommit(commitSha: string): Promise<void>;
-  restoreSystemPrompt(): Promise<void>;
-}
-
-export interface CreateCliPromptCandidateGitInput {
-  cwd: string;
-  systemPromptPath: string;
 }
 
 export interface RunPromptCandidateRoundInput {
@@ -715,210 +708,6 @@ export function hashCandidateRationale(candidateRationale: CandidateRationale): 
 
 function sha256Json(value: unknown): string {
   return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
-}
-
-export function assertOnlySystemPromptChanged(
-  changedFiles: readonly string[],
-  systemPromptGitPath: string,
-): void {
-  const allowed = normalizeGitPath(systemPromptGitPath);
-  const unexpected = changedFiles.filter((file) => normalizeGitPath(file) !== allowed);
-  if (unexpected.length > 0) {
-    throw new Error(`only ${allowed} may change; unexpected files: ${unexpected.join(', ')}`);
-  }
-}
-
-async function assertRegularSystemPromptFile(
-  systemPromptPath: string,
-  gitRootPath: string,
-): Promise<void> {
-  const stat = await lstat(systemPromptPath);
-  if (!stat.isFile() || stat.isSymbolicLink()) {
-    throw new Error('system_prompt.md must be a regular file');
-  }
-  const [promptRealPath, gitRootRealPath] = await Promise.all([
-    realpath(systemPromptPath),
-    realpath(gitRootPath),
-  ]);
-  if (!isPathInside(gitRootRealPath, promptRealPath)) {
-    throw new Error('system_prompt.md must stay inside the git cwd');
-  }
-}
-
-export function createCliPromptCandidateGit(
-  input: CreateCliPromptCandidateGitInput,
-): PromptCandidateGit {
-  const gitRootPath = realpathSync(findGitRoot(input.cwd));
-  const systemPromptPath = isAbsolute(input.systemPromptPath)
-    ? realpathSync(input.systemPromptPath)
-    : realpathSync(resolve(input.cwd, input.systemPromptPath));
-  const systemPromptGitPath = toGitRelativePath(gitRootPath, systemPromptPath);
-  let statusBaseline: ReadonlyMap<string, string> | undefined;
-  let headBaseline: string | undefined;
-  return {
-    gitRootPath,
-    systemPromptGitPath,
-    async assertSystemPromptClean(): Promise<void> {
-      if (!(await isGitTracked(gitRootPath, systemPromptGitPath))) {
-        throw new Error('system_prompt.md must be tracked before candidate round');
-      }
-      const [worktreeDirty, indexDirty] = await Promise.all([
-        hasGitDiff(gitRootPath, ['diff', '--quiet', '--', systemPromptGitPath]),
-        hasGitDiff(gitRootPath, ['diff', '--cached', '--quiet', '--', systemPromptGitPath]),
-      ]);
-      if (worktreeDirty || indexDirty) {
-        throw new Error('system_prompt.md must be clean before candidate round');
-      }
-      [statusBaseline, headBaseline] = await Promise.all([
-        gitStatusSnapshot(gitRootPath),
-        gitHeadSha(gitRootPath),
-      ]);
-    },
-    async changedFiles(): Promise<readonly string[]> {
-      await assertGitHeadUnchanged(gitRootPath, headBaseline);
-      const baseline = statusBaseline ?? new Map<string, string>();
-      const current = await gitStatusSnapshot(gitRootPath);
-      const paths = new Set([...baseline.keys(), ...current.keys()]);
-      return [...paths].filter((path) => baseline.get(path) !== current.get(path));
-    },
-    async commit(message: string): Promise<string> {
-      await assertGitHeadUnchanged(gitRootPath, headBaseline);
-      await execFileAsync('git', ['add', '--', systemPromptGitPath], { cwd: gitRootPath });
-      await execFileAsync('git', ['commit', '-m', message, '--', systemPromptGitPath], {
-        cwd: gitRootPath,
-      });
-      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: gitRootPath });
-      return stdout.trim();
-    },
-    async rollbackCommit(commitSha: string): Promise<void> {
-      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: gitRootPath });
-      if (stdout.trim() !== commitSha) {
-        throw new Error('candidate prompt commit cannot be rolled back because HEAD moved');
-      }
-      await execFileAsync('git', ['reset', '--soft', `${commitSha}^`], { cwd: gitRootPath });
-      await execFileAsync('git', ['restore', '--staged', '--worktree', '--', systemPromptGitPath], {
-        cwd: gitRootPath,
-      });
-    },
-    async restoreSystemPrompt(): Promise<void> {
-      await execFileAsync('git', ['restore', '--staged', '--worktree', '--', systemPromptGitPath], {
-        cwd: gitRootPath,
-      });
-    },
-  };
-}
-
-async function assertGitHeadUnchanged(cwd: string, baseline: string | undefined): Promise<void> {
-  if (baseline === undefined) return;
-  const current = await gitHeadSha(cwd);
-  if (current !== baseline) {
-    throw new Error('candidate round HEAD moved before prompt commit');
-  }
-}
-
-async function gitHeadSha(cwd: string): Promise<string> {
-  const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd });
-  return stdout.trim();
-}
-
-async function isGitTracked(cwd: string, path: string): Promise<boolean> {
-  try {
-    await execFileAsync('git', ['ls-files', '--error-unmatch', '--', path], { cwd });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function hasGitDiff(cwd: string, args: readonly string[]): Promise<boolean> {
-  try {
-    await execFileAsync('git', [...args], { cwd });
-    return false;
-  } catch {
-    return true;
-  }
-}
-
-async function gitStatusFiles(cwd: string): Promise<readonly string[]> {
-  const { stdout } = await execFileAsync(
-    'git',
-    ['status', '--porcelain', '--untracked-files=all'],
-    { cwd },
-  );
-  return stdout
-    .split('\n')
-    .map((line) => statusPath(line))
-    .filter((path): path is string => path !== undefined);
-}
-
-async function gitStatusSnapshot(cwd: string): Promise<ReadonlyMap<string, string>> {
-  const snapshot = new Map<string, string>();
-  for (const path of await gitStatusFiles(cwd)) {
-    snapshot.set(path, await gitStatusFingerprint(cwd, path));
-  }
-  return snapshot;
-}
-
-async function gitStatusFingerprint(cwd: string, path: string): Promise<string> {
-  const [fileHash, worktreeDiff, indexDiff] = await Promise.all([
-    fileFingerprint(resolve(cwd, path)),
-    gitDiffFingerprint(cwd, ['diff', '--binary', '--', path]),
-    gitDiffFingerprint(cwd, ['diff', '--cached', '--binary', '--', path]),
-  ]);
-  return [fileHash, worktreeDiff, indexDiff].join('\0');
-}
-
-async function fileFingerprint(path: string): Promise<string> {
-  try {
-    const content = await readFile(path);
-    return createHash('sha256').update(content).digest('hex');
-  } catch (error) {
-    if (isNotFound(error)) return 'missing';
-    throw error;
-  }
-}
-
-async function gitDiffFingerprint(cwd: string, args: readonly string[]): Promise<string> {
-  const { stdout } = await execFileAsync('git', [...args], { cwd, encoding: 'buffer' });
-  return createHash('sha256').update(stdout).digest('hex');
-}
-
-function statusPath(line: string): string | undefined {
-  const path = line.slice(3).trim();
-  if (path.length === 0) return undefined;
-  const renameSeparator = ' -> ';
-  const renameIndex = path.indexOf(renameSeparator);
-  return renameIndex === -1 ? path : path.slice(renameIndex + renameSeparator.length);
-}
-
-function findGitRoot(cwd: string): string {
-  return execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd, encoding: 'utf8' }).trim();
-}
-
-function isPathInside(rootPath: string, targetPath: string): boolean {
-  const relativePath = relative(rootPath, targetPath).split('\\').join('/');
-  return (
-    relativePath !== '' &&
-    relativePath !== '..' &&
-    !relativePath.startsWith('../') &&
-    !isAbsolute(relativePath)
-  );
-}
-
-function toGitRelativePath(cwd: string, path: string): string {
-  const absolutePath = isAbsolute(path) ? path : resolve(cwd, path);
-  const relativePath = relative(cwd, absolutePath).split('\\').join('/');
-  if (relativePath === '' || relativePath === '..' || relativePath.startsWith('../')) {
-    throw new Error('system_prompt.md must be inside the git cwd');
-  }
-  return relativePath;
-}
-
-function normalizeGitPath(path: string): string {
-  let current = path;
-  current = current.split('\\').join('/');
-  while (current.startsWith('./')) current = current.slice(2);
-  return current;
 }
 
 function randomId(): string {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -17,6 +17,9 @@ import {
   type ProjectRsiPromptAttributionInput,
 } from './rsi-controller-attribution.js';
 import type { RsiRoundAnalysis } from './rsi-round-analysis.js';
+import { heldInTaskSetHash, sortedUnique } from './rsi-round-analysis.js';
+
+export { heldInTaskSetHash as hashHeldInTaskSet } from './rsi-round-analysis.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -229,7 +232,7 @@ export async function runPromptCandidateRound(
     commitSha,
     candidateRationale,
     candidateRationaleHash: hashCandidateRationale(candidateRationale),
-    heldInTaskSetHash: hashHeldInTaskSet(input.heldInTaskIds),
+    heldInTaskSetHash: heldInTaskSetHash(input.heldInTaskIds),
   };
 }
 
@@ -699,15 +702,11 @@ function promptCandidateCommittedEvent(input: {
     commitSha: input.commitSha,
     summary: input.summary,
     promptHash: hashSystemPrompt(input.systemPrompt),
-    heldInTaskSetHash: hashHeldInTaskSet(input.heldInTaskIds),
-    heldInTaskIds: [...new Set(input.heldInTaskIds)].sort((a, b) => a.localeCompare(b)),
+    heldInTaskSetHash: heldInTaskSetHash(input.heldInTaskIds),
+    heldInTaskIds: sortedUnique(input.heldInTaskIds),
     candidateRationaleHash: hashCandidateRationale(input.candidateRationale),
     candidateRationale: input.candidateRationale,
   };
-}
-
-export function hashHeldInTaskSet(heldInTaskIds: readonly string[]): string {
-  return sha256Json([...new Set(heldInTaskIds)].sort((a, b) => a.localeCompare(b)));
 }
 
 export function hashCandidateRationale(candidateRationale: CandidateRationale): string {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -32,6 +32,8 @@ export {
 import {
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
   PROMPT_CANDIDATE_FAILURE_PATTERNS,
+  heldInTaskSetHash,
+  sortedUnique,
   type PromptCandidateCommittedEvent,
   type PromptCandidateFailurePattern,
   type PromptCandidateRationale,
@@ -41,9 +43,6 @@ import {
   type ProjectRsiPromptAttributionInput,
 } from './rsi-controller-attribution.js';
 import type { RsiRoundAnalysis } from './rsi-round-analysis.js';
-import { heldInTaskSetHash, sortedUnique } from './rsi-round-analysis.js';
-
-export { heldInTaskSetHash as hashHeldInTaskSet } from './rsi-round-analysis.js';
 
 const CANDIDATE_RATIONALE_MAX_TASK_IDS = 16;
 const CANDIDATE_RATIONALE_MAX_TEXT_CHARS = 280;

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -16,6 +16,20 @@ export {
   type PromptCandidateGit,
 } from './prompt-candidate-git.js';
 import {
+  readRuntimeEventsJsonl,
+  renderToolFailureSummary,
+  stripPromptOnlyToolFailures,
+  type TrajectoryDigest,
+} from './prompt-candidate-digest.js';
+
+export {
+  extractTrajectoryDigest,
+  type ExtractTrajectoryDigestInput,
+  type TrajectoryDigest,
+  type TrajectoryToolCallDigest,
+  type TrajectoryToolFailureDigest,
+} from './prompt-candidate-digest.js';
+import {
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
   PROMPT_CANDIDATE_FAILURE_PATTERNS,
   type PromptCandidateCommittedEvent,
@@ -38,34 +52,6 @@ const META_AGENT_MAX_ATTEMPTS = 3;
 const META_AGENT_RETRY_ERROR_MAX_CHARS = 240;
 const FORBIDDEN_RATIONALE_TEXT_RE =
   /```|\r|\n|held[-_]out|verifier|expected[- ]output|\/app\/|tests\/|test\.sh|canary|runtime-events|events\.jsonl|raw trace/i;
-
-export interface TrajectoryDigest {
-  taskId: string;
-  errorClass?: string;
-  summary: string;
-  recentToolCalls?: readonly TrajectoryToolCallDigest[];
-  toolFailures?: readonly TrajectoryToolFailureDigest[];
-}
-
-export interface TrajectoryToolCallDigest {
-  name: string;
-  argsPreview: string;
-}
-
-export interface TrajectoryToolFailureDigest {
-  name: string;
-  count: number;
-  errorClass?: string;
-  argsPreview?: string;
-}
-
-export interface ExtractTrajectoryDigestInput {
-  taskId: string;
-  errorClass?: string;
-  runtimeEventsPath: string;
-  traceEventsPath?: string;
-  verifierSummary: string;
-}
 
 export interface RewardHackScanInput {
   runtimeEventsPath: string;
@@ -355,31 +341,6 @@ async function realOrParentResolvedPath(path: string): Promise<string> {
     if (!isNotFound(error)) throw error;
     return resolve(await realpath(dirname(path)), basename(path));
   }
-}
-
-export async function extractTrajectoryDigest(
-  input: ExtractTrajectoryDigestInput,
-): Promise<TrajectoryDigest> {
-  const events = await readRuntimeEventsJsonl(input.runtimeEventsPath);
-  const callsById = new Map<string, TrajectoryToolCallDigest>();
-  for (const event of events) {
-    const call = functionCallDigestWithId(event);
-    if (call) callsById.set(call.id, { name: call.name, argsPreview: call.argsPreview });
-  }
-  const recentToolCalls = events
-    .map((event) => functionCallDigest(event))
-    .filter((call): call is TrajectoryToolCallDigest => call !== undefined)
-    .slice(-2);
-  const toolFailures = input.traceEventsPath
-    ? await extractToolFailureDigests(input.traceEventsPath, callsById)
-    : [];
-  return {
-    taskId: input.taskId,
-    ...(input.errorClass ? { errorClass: input.errorClass } : {}),
-    summary: input.verifierSummary,
-    ...(recentToolCalls.length > 0 ? { recentToolCalls } : {}),
-    ...(toolFailures.length > 0 ? { toolFailures } : {}),
-  };
 }
 
 export async function scanRuntimeEventsForRewardHack(
@@ -714,138 +675,6 @@ function randomId(): string {
   return randomUUID();
 }
 
-async function readRuntimeEventsJsonl(path: string): Promise<unknown[]> {
-  const raw = await readFile(path, 'utf8');
-  return raw
-    .split('\n')
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as unknown);
-}
-
-async function extractToolFailureDigests(
-  traceEventsPath: string,
-  callsById: ReadonlyMap<string, TrajectoryToolCallDigest>,
-): Promise<TrajectoryToolFailureDigest[]> {
-  let events: unknown[];
-  try {
-    events = await readRuntimeEventsJsonl(traceEventsPath);
-  } catch (error) {
-    if (!isNotFound(error)) throw error;
-    return [];
-  }
-  const failures = new Map<string, TrajectoryToolFailureDigest>();
-  for (const event of events) {
-    const failure = toolFailureDigest(event, callsById);
-    if (!failure) continue;
-    const key = [failure.name, failure.errorClass ?? '', failure.argsPreview ?? ''].join('\0');
-    const current = failures.get(key);
-    failures.set(key, {
-      ...failure,
-      count: (current?.count ?? 0) + 1,
-    });
-  }
-  return [...failures.values()].sort(compareToolFailures).slice(0, 5);
-}
-
-function renderToolFailureSummary(
-  digests: readonly TrajectoryDigest[],
-  resultsTsv: string,
-): string[] {
-  const passedByTask = passedResultsByTask(resultsTsv);
-  const failures = new Map<string, { digest: TrajectoryToolFailureDigest; taskIds: Set<string> }>();
-  for (const digest of digests) {
-    if (passedByTask?.get(digest.taskId) === true) continue;
-    for (const failure of digest.toolFailures ?? []) {
-      const key = [failure.name, failure.errorClass ?? '', failure.argsPreview ?? ''].join('\0');
-      const current = failures.get(key) ?? {
-        digest: { ...failure, count: 0 },
-        taskIds: new Set<string>(),
-      };
-      current.digest = { ...failure, count: current.digest.count + failure.count };
-      current.taskIds.add(digest.taskId);
-      failures.set(key, current);
-    }
-  }
-  const lines = [...failures.values()]
-    .sort((a, b) => compareToolFailures(a.digest, b.digest))
-    .slice(0, 10)
-    .map(({ digest, taskIds }) =>
-      [
-        `${digest.name} x${digest.count}`,
-        ...(digest.errorClass ? [`error=${digest.errorClass}`] : []),
-        ...(digest.argsPreview ? [`args=${digest.argsPreview}`] : []),
-        `tasks=${[...taskIds].sort((a, b) => a.localeCompare(b)).join(',')}`,
-      ].join(' '),
-    );
-  return lines.length > 0 ? ['# Held-In Tool Failure Summary', ...lines] : [];
-}
-
-function passedResultsByTask(resultsTsv: string): ReadonlyMap<string, boolean> | undefined {
-  const lines = resultsTsv.split(/\r?\n/).filter((line) => line.trim().length > 0);
-  const header = lines[0]?.split('\t');
-  if (!header) return undefined;
-  const taskIdIndex = header.indexOf('task_id');
-  const passedIndex = header.indexOf('passed');
-  if (taskIdIndex === -1 || passedIndex === -1) return undefined;
-  const passedByTask = new Map<string, boolean>();
-  for (const line of lines.slice(1)) {
-    const columns = line.split('\t');
-    const taskId = columns[taskIdIndex];
-    if (!taskId) continue;
-    passedByTask.set(taskId, columns[passedIndex] === 'true');
-  }
-  return passedByTask;
-}
-
-function functionCallDigest(event: unknown): TrajectoryToolCallDigest | undefined {
-  if (!isRecord(event) || !isRecord(event.content)) return undefined;
-  const content = event.content;
-  if (content.kind !== 'function_call' || typeof content.name !== 'string') return undefined;
-  return {
-    name: content.name,
-    argsPreview: argsPreview(content.args),
-  };
-}
-
-function functionCallDigestWithId(
-  event: unknown,
-): (TrajectoryToolCallDigest & { id: string }) | undefined {
-  const call = functionCallDigest(event);
-  if (!call || !isRecord(event) || !isRecord(event.content) || typeof event.content.id !== 'string')
-    return undefined;
-  return { ...call, id: event.content.id };
-}
-
-function toolFailureDigest(
-  event: unknown,
-  callsById: ReadonlyMap<string, TrajectoryToolCallDigest>,
-): TrajectoryToolFailureDigest | undefined {
-  if (!isRecord(event) || event.type !== 'tool_failed' || !isRecord(event.data)) return undefined;
-  const data = event.data;
-  if (typeof data.toolName !== 'string') return undefined;
-  const call = typeof data.toolUseId === 'string' ? callsById.get(data.toolUseId) : undefined;
-  return {
-    name: promptSafeToken(data.toolName, 'unknown_tool'),
-    count: 1,
-    ...(typeof data.errorClass === 'string'
-      ? { errorClass: promptSafeToken(data.errorClass, 'unknown_error') }
-      : {}),
-    ...(call?.argsPreview ? { argsPreview: call.argsPreview } : {}),
-  };
-}
-
-function compareToolFailures(
-  a: TrajectoryToolFailureDigest,
-  b: TrajectoryToolFailureDigest,
-): number {
-  return (
-    b.count - a.count ||
-    a.name.localeCompare(b.name) ||
-    (a.errorClass ?? '').localeCompare(b.errorClass ?? '') ||
-    (a.argsPreview ?? '').localeCompare(b.argsPreview ?? '')
-  );
-}
-
 function modelVisibleStrings(event: unknown): readonly string[] {
   if (!isRecord(event) || !isRecord(event.content)) return [];
   const content = event.content;
@@ -862,25 +691,6 @@ function stringValues(value: unknown): string[] {
   if (Array.isArray(value)) return value.flatMap((item) => stringValues(item));
   if (isRecord(value)) return Object.values(value).flatMap((item) => stringValues(item));
   return [];
-}
-
-function argsPreview(args: unknown): string {
-  if (!isRecord(args)) return typeof args;
-  return Object.keys(args)
-    .map((key) => promptSafeToken(key, 'arg'))
-    .sort((a, b) => a.localeCompare(b))
-    .join(',');
-}
-
-function stripPromptOnlyToolFailures(
-  digests: readonly TrajectoryDigest[],
-): readonly Omit<TrajectoryDigest, 'toolFailures'>[] {
-  return digests.map(({ toolFailures: _toolFailures, ...digest }) => digest);
-}
-
-function promptSafeToken(value: string, fallback: string): string {
-  if (/^[A-Za-z0-9_.:-]{1,64}$/.test(value)) return value;
-  return fallback;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/headless/src/prompt-optimization-replay-state.ts
+++ b/packages/headless/src/prompt-optimization-replay-state.ts
@@ -3,14 +3,14 @@ import { realpath } from 'node:fs/promises';
 import { isAbsolute, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { hashSystemPrompt } from './fixed-prompt-controller.js';
-import type {
-  FixedPromptTaskWalEvent,
-  FixedPromptWalEvent,
-  PromptCandidateCommittedEvent,
-  PromptCandidateDecisionEvent,
+import {
+  heldInTaskSetHash,
+  type FixedPromptTaskWalEvent,
+  type FixedPromptWalEvent,
+  type PromptCandidateCommittedEvent,
+  type PromptCandidateDecisionEvent,
 } from './fixed-prompt-wal-types.js';
 import { hashCandidateRationale } from './prompt-candidate-loop.js';
-import { heldInTaskSetHash } from './rsi-round-analysis.js';
 
 const execFileAsync = promisify(execFile);
 

--- a/packages/headless/src/prompt-optimization-replay-state.ts
+++ b/packages/headless/src/prompt-optimization-replay-state.ts
@@ -9,7 +9,8 @@ import type {
   PromptCandidateCommittedEvent,
   PromptCandidateDecisionEvent,
 } from './fixed-prompt-wal-types.js';
-import { hashCandidateRationale, hashHeldInTaskSet } from './prompt-candidate-loop.js';
+import { hashCandidateRationale } from './prompt-candidate-loop.js';
+import { heldInTaskSetHash } from './rsi-round-analysis.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -71,8 +72,8 @@ export function assertCandidateMatchesStableTaskSet(
   stableHeldInTaskIds: readonly string[],
 ): void {
   assertCandidateEventSelfConsistent(candidate);
-  const actualHash = hashHeldInTaskSet(candidate.heldInTaskIds);
-  const expectedHash = hashHeldInTaskSet(stableHeldInTaskIds);
+  const actualHash = heldInTaskSetHash(candidate.heldInTaskIds);
+  const expectedHash = heldInTaskSetHash(stableHeldInTaskIds);
   if (candidate.heldInTaskSetHash !== actualHash || candidate.heldInTaskSetHash !== expectedHash) {
     throw new Error(`RSI WAL replay candidate task-set mismatch for ${candidate.roundId}`);
   }
@@ -258,7 +259,7 @@ function assertWalBelongsToRun(events: readonly FixedPromptWalEvent[], runId: st
 }
 
 function assertCandidateEventSelfConsistent(candidate: PromptCandidateCommittedEvent): void {
-  if (candidate.heldInTaskSetHash !== hashHeldInTaskSet(candidate.heldInTaskIds)) {
+  if (candidate.heldInTaskSetHash !== heldInTaskSetHash(candidate.heldInTaskIds)) {
     throw new Error(`RSI WAL replay candidate task-set mismatch for ${candidate.roundId}`);
   }
   if (candidate.candidateRationaleHash !== hashCandidateRationale(candidate.candidateRationale)) {

--- a/packages/headless/src/prompt-optimization-run.ts
+++ b/packages/headless/src/prompt-optimization-run.ts
@@ -10,7 +10,8 @@ import {
   type HarborTaskPricing,
 } from './harbor-task-runner.js';
 import { createAiSdkMetaAgent } from './meta-agent-completion.js';
-import { createCliPromptCandidateGit, type MetaAgent } from './prompt-candidate-loop.js';
+import { type MetaAgent } from './prompt-candidate-loop.js';
+import { createCliPromptCandidateGit } from './prompt-candidate-git.js';
 import {
   runPromptOptimizationLoop,
   type PromptOptimizationLoopResult,

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -333,10 +333,6 @@ function roundPromptHashEvidenceKey(
   return `${roundEvidenceKey(event)}\0${promptHash}`;
 }
 
-function sortedUnique(values: readonly string[]): string[] {
-  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
-}
-
 function isQuarantineDecision(event: { reason: string; rewardHackScan?: unknown }): boolean {
   return (
     event.reason === PROMPT_REWARD_HACK_QUARANTINE_REASON ||

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -8,6 +8,7 @@ import type {
 } from './fixed-prompt-wal-types.js';
 import type { PromptAcceptanceResult } from './prompt-acceptance-policy.js';
 import type { RsiRoundAnalysis, RsiTaskOutcome, RsiTaskTransition } from './rsi-round-analysis.js';
+import { compareStrings, sortedUnique } from './rsi-round-analysis.js';
 
 export type {
   RsiPredictedFixOutcome,
@@ -271,10 +272,6 @@ function isErrorClassBackedFailurePattern(failurePattern: PromptCandidateFailure
   );
 }
 
-function sortedUnique(values: readonly string[]): string[] {
-  return [...new Set(values)].sort(compareStrings);
-}
-
 function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
   const sortedLeft = sortedUnique(left);
   const sortedRight = sortedUnique(right);
@@ -282,8 +279,4 @@ function sameStringSet(left: readonly string[], right: readonly string[]): boole
     sortedLeft.length === sortedRight.length &&
     sortedLeft.every((value, index) => value === sortedRight[index])
   );
-}
-
-function compareStrings(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
 }

--- a/packages/headless/src/rsi-round-analysis.ts
+++ b/packages/headless/src/rsi-round-analysis.ts
@@ -2,7 +2,14 @@ import { createHash } from 'node:crypto';
 import { createReadStream } from 'node:fs';
 import { readFile, stat } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
-import type { FixedPromptTaskWalEvent } from './fixed-prompt-wal-types.js';
+import {
+  compareStrings,
+  sortedUnique,
+  heldInTaskSetHash,
+  type FixedPromptTaskWalEvent,
+} from './fixed-prompt-wal-types.js';
+
+export { compareStrings, sortedUnique, heldInTaskSetHash };
 
 const DEFAULT_MAX_TOOL_FAILURE_CLUSTERS = 10;
 const DEFAULT_MAX_TOOL_FAILURE_JSONL_BYTES = 1_000_000;
@@ -169,12 +176,6 @@ export async function analyzeRsiRound(input: AnalyzeRsiRoundInput): Promise<RsiR
       traceUnavailable: toolFailures.traceUnavailable,
     }),
   };
-}
-
-export function heldInTaskSetHash(taskIds: readonly string[]): string {
-  return `sha256:${createHash('sha256')
-    .update(JSON.stringify(sortedUnique(taskIds)))
-    .digest('hex')}`;
 }
 
 function taskTransitions(
@@ -567,10 +568,6 @@ function nonNegativeInt(value: number | undefined, fallback: number): number {
   return Math.max(0, Math.trunc(value));
 }
 
-export function compareStrings(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
-}
-
 function promptSafeToken(value: string, fallback: string): string {
   if (/^[A-Za-z0-9_.:-]{1,64}$/.test(value)) return value;
   return fallback;
@@ -582,8 +579,4 @@ function isNotFound(error: unknown): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-export function sortedUnique(values: readonly string[]): string[] {
-  return [...new Set(values)].sort(compareStrings);
 }

--- a/packages/headless/src/rsi-round-analysis.ts
+++ b/packages/headless/src/rsi-round-analysis.ts
@@ -567,7 +567,7 @@ function nonNegativeInt(value: number | undefined, fallback: number): number {
   return Math.max(0, Math.trunc(value));
 }
 
-function compareStrings(a: string, b: string): number {
+export function compareStrings(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
@@ -584,6 +584,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function sortedUnique(values: readonly string[]): string[] {
+export function sortedUnique(values: readonly string[]): string[] {
   return [...new Set(values)].sort(compareStrings);
 }


### PR DESCRIPTION
# Summary

- unify the two divergent `heldInTaskSetHash` implementations on a single codepoint order: `hashHeldInTaskSet` in prompt-candidate-loop.ts (localeCompare) wrote `prompt_candidate_committed` events while `heldInTaskSetHash` in rsi-round-analysis.ts (codepoint via `compareStrings`/`sortedUnique`) fed `rsi_controller_attribution` events; since task ids are unconstrained directory names, localeCompare's case folding made the two hashes diverge for mixed-case ids (e.g. `apple`/`Banana`/`cherry`/`Date`), and the strict-`!==` checks at the WAL boundary (`prompt-optimization-replay-state.ts:74`, `prompt-structural-smoke.ts:253`) flagged legitimate rounds as malformed. Keep rsi-round-analysis.ts as the single source (already codepoint, sits upstream with no back-import), export `compareStrings`/`sortedUnique` from it, delete the local `hashHeldInTaskSet`/`sha256Json` copy from prompt-candidate-loop.ts and re-export `heldInTaskSetHash as hashHeldInTaskSet` to preserve the public name, normalize the persisted `heldInTaskIds` array sort to `sortedUnique`, and drop the duplicate private `compareStrings`/`sortedUnique` in rsi-controller-attribution.ts plus the dead `localeCompare`-based `sortedUnique` in prompt-structural-smoke.ts. Point all internal callers and tests at `heldInTaskSetHash` directly.

- extract the self-contained git safety/rollback wrapper (~160 lines: `PromptCandidateGit` interface, `createCliPromptCandidateGit` factory, `assertOnlySystemPromptChanged`, `assertRegularSystemPromptFile`, and the private git/path helpers only it uses — `rollbackCommit`, the worktree/index dirty checks, the `gitStatusSnapshot`/fingerprint hashing, `findGitRoot`, `toGitRelativePath`, etc.) into a new sibling `prompt-candidate-git.ts`; export `isPathInside`/`normalizeGitPath` since the retained controller-artifact checks still use them, keep `isRecord`/`isNotFound` as private copies in each file matching the existing codebase convention (no shared utils module; duplicated across many files), and preserve public imports via re-export while prompt-optimization-run.ts now imports `createCliPromptCandidateGit` directly from the new module.

- extract the trajectory/tool-failure digest pipeline (~200 lines: the four digest types, `extractTrajectoryDigest` entry point, the per-task aggregation `extractToolFailureDigests`, the cross-task aggregation `renderToolFailureSummary`, the per-event parser `toolFailureDigest`, and `stripPromptOnlyToolFailures`) into a new sibling `prompt-candidate-digest.ts`; export `readRuntimeEventsJsonl` since it has real IO/parse semantics and is shared by the retained `scanRuntimeEventsForRewardHack` (prompt-candidate-loop.ts imports it back, single direction, no cycle), keep `modelVisibleStrings`/`stringValues` in prompt-candidate-loop.ts as they are used only by `scanRuntimeEventsForRewardHack`, and preserve public imports via re-export while the trivial pure guards `isRecord`/`isNotFound` stay as private copies in each file.

- add a cross-WAL-boundary regression test in prompt-structural-smoke.test.ts that constructs a committed/attribution event pair with case-diverging ids (`apple`/`Banana`/`cherry`/`Date`) and asserts `roundsWithMalformedRsiAttribution` stays empty — verified bidirectionally: it passes under the unified codepoint order and fails when the committed side is reverted to localeCompare; update the `expectedHeldInTaskSetHash` test helper to codepoint so existing prompt-loop tests stay green.

Refs #1409 .

# Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck` (packages/headless) — passed, 0 errors
- `npm --workspace @maka/headless run build` — passed
- `npm --workspace @maka/headless run test:dist` 1309 passed, 5 skipped
