### PR TITLE
fix(release): derive packaged app test version

### DIFF
--- a/scripts/macos-arm64-release.test.mjs
+++ b/scripts/macos-arm64-release.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 const signingEnvironment = {
@@ -10,6 +11,9 @@ const signingEnvironment = {
 };
 
 test('release tooling fails closed on unsupported hosts, signing, and architecture', async () => {
+  const desktopManifest = JSON.parse(
+    await readFile(new URL('../apps/desktop/package.json', import.meta.url), 'utf8'),
+  );
   const { packageMacosArm64 } = await import(new URL('package-macos-arm64.mjs', import.meta.url));
   const { verifyPackagedMacApp } = await import(
     new URL('verify-macos-arm64-dmg.mjs', import.meta.url)
@@ -29,7 +33,9 @@ test('release tooling fails closed on unsupported hosts, signing, and architectu
       run: async (command, args) => {
         if (command === 'plutil') {
           if (args[1] === 'CFBundleIdentifier') return { stdout: 'com.maka.desktop\n' };
-          if (args[1] === 'CFBundleShortVersionString') return { stdout: '0.1.2\n' };
+          if (args[1] === 'CFBundleShortVersionString') {
+            return { stdout: `${desktopManifest.version}\n` };
+          }
           return { stdout: 'Maka\n' };
         }
         if (command === 'lipo') return { stdout: 'x86_64\n', stderr: '' };


### PR DESCRIPTION
## Summary

- make the macOS packaging test derive its simulated `CFBundleShortVersionString` from the Desktop manifest
- preserve the test's fail-closed ordering so it reaches and verifies the intended arm64 rejection after a version bump

## Why

The `0.1.3` main CI failed because this fixture still returned hard-coded `0.1.2`. The production verifier correctly rejected that mismatch before reaching the architecture assertion.

## Verification

- `npm run test:scripts:extended` (15/15 pass)
- `npm run format:check`
- `git diff --check`
