### PR TITLE
fix(runtime): close lifecycle races exposed by CI

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -480,19 +480,25 @@ test('two Clients share one execution after the starting Client disconnects', as
     const secondProbe = new SubscriptionProbe(secondSubscription);
     const turnId = randomUUID();
 
-    const started = await first.startTurn({
-      sessionId: fixture.sessionId,
-      turnId,
-      content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
-    });
+    const started = await first.startTurn(
+      {
+        sessionId: fixture.sessionId,
+        turnId,
+        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+      },
+      PROCESS_TIMEOUT_MS,
+    );
     assert.equal(started.turnId, turnId);
     await assert.rejects(
       () =>
-        second.startTurn({
-          sessionId: fixture.sessionId,
-          turnId: randomUUID(),
-          content: { text: 'must stay busy' },
-        }),
+        second.startTurn(
+          {
+            sessionId: fixture.sessionId,
+            turnId: randomUUID(),
+            content: { text: 'must stay busy' },
+          },
+          PROCESS_TIMEOUT_MS,
+        ),
       operationError('session_busy'),
     );
 
@@ -548,17 +554,23 @@ test('two Clients share one execution after the starting Client disconnects', as
     );
 
     const nextTurnId = randomUUID();
-    const next = await second.startTurn({
-      sessionId: fixture.sessionId,
-      turnId: nextTurnId,
-      content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
-    });
-    assert.deepEqual(
-      await second.startTurn({
+    const next = await second.startTurn(
+      {
         sessionId: fixture.sessionId,
-        turnId,
+        turnId: nextTurnId,
         content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
-      }),
+      },
+      PROCESS_TIMEOUT_MS,
+    );
+    assert.deepEqual(
+      await second.startTurn(
+        {
+          sessionId: fixture.sessionId,
+          turnId,
+          content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+        },
+        PROCESS_TIMEOUT_MS,
+      ),
       stopped,
     );
     assert.deepEqual(

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -227,7 +227,7 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
-  test('composition process-exit retention requires termination without releasing ownership', async () => {
+  test('process-exit retention closes admission before requiring termination without releasing ownership', async () => {
     await withHostPaths(async (paths) => {
       const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
       const owner = await tryAcquireInteractiveRootOwner(capability);
@@ -250,6 +250,14 @@ describe('non-serving Runtime Host kernel', () => {
           (error: unknown) =>
             error instanceof RuntimeHostProcessTerminationRequiredError &&
             error.code === 'process_termination_required',
+        );
+        await assert.rejects(
+          () => openSocket(host.endpoint),
+          (error: unknown) =>
+            error instanceof Error &&
+            'code' in error &&
+            ((error as NodeJS.ErrnoException).code === 'ENOENT' ||
+              (error as NodeJS.ErrnoException).code === 'ECONNREFUSED'),
         );
         assert.equal(await tryAcquireInteractiveRootOwner(capability), undefined);
       } finally {

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -558,9 +558,13 @@ export class RuntimeHostKernel {
 
   async #closeResources(): Promise<void> {
     const errors: unknown[] = [];
+    // Stop new admissions before any asynchronous shutdown bookkeeping. The
+    // shutdown deadline may expire while publishing the draining registration;
+    // leaving the listener open in that case strands an unreachable, ref'ed
+    // server until the process is forcibly terminated.
+    const serverClosed = closeServer(this.#server).catch((error: unknown) => errors.push(error));
     await this.#publishRegistration().catch((error: unknown) => errors.push(error));
     this.#assertShutdownCanContinue();
-    const serverClosed = closeServer(this.#server).catch((error: unknown) => errors.push(error));
     const accepted = [...this.#acceptedTransports];
     const handshaking = [...this.#handshakingTransports];
     const operationDrain = this.#waitForOperations();

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -527,27 +527,45 @@ describe('ShellRunProcessManager', () => {
   }, async (context) => {
     const processDiscovery = delayPosixProcessDiscovery(context);
     const abort = new AbortController();
-    const manager = await createTestManager();
+    const backingStore = createLegacyShellRunStoreForTest(await workspace());
+    const runningCommitted = deferred<void>();
+    const releaseRunning = deferred<void>();
+    const store: ShellRunStore = {
+      createShellRun: (...args) => backingStore.createShellRun(...args),
+      async updateShellRun(sessionId, shellRunId, patch) {
+        const updated = await backingStore.updateShellRun(sessionId, shellRunId, patch);
+        if (patch.status === 'running') {
+          runningCommitted.resolve(undefined);
+          await releaseRunning.promise;
+        }
+        return updated;
+      },
+      readShellRun: (...args) => backingStore.readShellRun(...args),
+      listSessionShellRuns: (...args) => backingStore.listSessionShellRuns(...args),
+    };
+    const manager = createManager(store);
     const run = manager.runForegroundBash(
       shellInput({
         cwd: await workspace(),
         command: waitForeverCommand('ready'),
         timeoutMs: 50,
         abortSignal: abort.signal,
-        emitOutput: () => abort.abort(),
       }),
     );
 
     try {
+      await runningCommitted.promise;
       await processDiscovery.started;
-      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+      abort.abort();
       processDiscovery.release();
+      releaseRunning.resolve(undefined);
 
       const result = await run;
       assert.equal(result.status, 'cancelled');
       assert.equal(result.exitCode, 130);
     } finally {
       processDiscovery.release();
+      releaseRunning.resolve(undefined);
       await run.catch(() => undefined);
       await manager.terminateAll().catch(() => undefined);
     }

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -251,6 +251,11 @@ export class ShellRunProcessManager
   async runForegroundBash(input: ShellRunBashInput): Promise<TerminalToolResult> {
     const onCompletion = onceShellRunCompletion(input.onCompletion);
     const ownedInput = onCompletion ? { ...input, onCompletion } : input;
+    let live: LiveShellRun | undefined;
+    const cancel = () => {
+      if (live) this.requestForcedTermination(live, 'cancel');
+    };
+    input.abortSignal?.addEventListener('abort', cancel, { once: true });
     try {
       validateSourceToolCallId(input.sourceToolCallId);
       return await this.withPendingStartup(input.sessionId, async () => {
@@ -259,15 +264,17 @@ export class ShellRunProcessManager
         if (input.abortSignal?.aborted)
           throw abortError('Command aborted before shell process started');
         const timeoutMs = normalizeForegroundTimeoutMs(input.timeoutMs ?? DEFAULT_BASH_TIMEOUT_MS);
-        const live = await this.start(ownedInput, 'pipes', timeoutMs, true);
-        if ((await live.finished.waitFor(input.abortSignal)) === 'abort') {
-          this.requestForcedTermination(live, 'cancel');
-        }
+        live = await this.start(ownedInput, 'pipes', timeoutMs, true, (admitted) => {
+          live = admitted;
+          if (input.abortSignal?.aborted) cancel();
+        });
         return this.markObservedAndReturnTerminal(await live.finished.join());
       });
     } catch (error) {
       notifyFailedStartup(onCompletion);
       throw error;
+    } finally {
+      input.abortSignal?.removeEventListener('abort', cancel);
     }
   }
 
@@ -570,6 +577,7 @@ export class ShellRunProcessManager
     mode: ShellMode,
     timeoutMs: number | undefined,
     forwardLive: boolean,
+    onLiveAdmission?: (live: LiveShellRun) => void,
   ): Promise<LiveShellRun> {
     const sessionEpoch = this.sessionTerminationEpoch(input.sessionId);
     this.assertStartAllowed(input.sessionId, sessionEpoch);
@@ -589,6 +597,7 @@ export class ShellRunProcessManager
             forwardLive,
             slotReservation,
             sessionEpoch,
+            onLiveAdmission,
           );
         }
 
@@ -620,6 +629,7 @@ export class ShellRunProcessManager
     forwardLive: boolean,
     slotReservation: ShellRunSlotReservation,
     sessionEpoch: number,
+    onLiveAdmission: ((live: LiveShellRun) => void) | undefined,
   ): Promise<LivePipeShellRun> {
     const collector = new PipeTailCollector(this.maxRetainedChars);
     const pending: Array<(live: LivePipeShellRun) => void> = [];
@@ -673,6 +683,7 @@ export class ShellRunProcessManager
       for (const callback of pending) callback(live);
       driver.writeInputs();
       await racePromiseWithAbort(driver.ready, input.abortSignal);
+      onLiveAdmission?.(live);
       this.armTimeout(live);
       this.assertLiveStartupAllowed(live, sessionEpoch, input.abortSignal);
       await this.markRunning(live);


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- observe foreground Bash cancellation from native process readiness through the durable startup commit, removing the window where a timeout could win only because storage was slow
- make the cancellation/timeout regression test establish the race with explicit process-discovery and durable-commit gates
- give the real-process multi-Client execution test its existing process-level deadline while leaving production request defaults unchanged
- stop new Runtime Host admissions before asynchronous draining-state publication, so an expiring shutdown deadline cannot strand an unreachable, referenced UDS listener

## Why

The full workspace CI run after #1928 exposed two independent existing timing assumptions under parallel load. A high-load reproduction also exposed a shutdown ordering bug that could leave the Host test process alive after its socket path had already been removed.

These changes make the lifecycle boundaries causal instead of relying on child-output timing, fixed sleeps, or a fast filesystem.

## Verification

- ShellRun cancellation/timeout regression: 100 consecutive Storage-stress passes
- multi-Client execution regression: 20 consecutive Storage-stress passes
- Host kernel lifecycle suite: 8 concurrent suites, 240/240 tests passed with no listener residue
- complete affected-workspace CI test matrix with Storage stress on the latest `main`
- build, format, lint, typecheck, and diff checks

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- foreground Bash 从原生进程 ready 到 durable startup 提交期间持续监听取消，消除存储变慢时 timeout 意外抢先的空窗
- cancellation/timeout 回归测试通过显式的进程发现门控和 durable commit 门控构造竞态
- 真实进程的多 Client execution 测试使用已有的进程级 deadline，生产默认 request deadline 保持不变
- Runtime Host 在异步发布 draining 状态之前停止新连接，避免 shutdown deadline 到期后遗留不可达但仍被引用的 UDS listener

## 原因

#1928 合并后的完整 workspace CI 在并行负载下暴露了两个彼此独立的既有时序假设。高负载复现还发现了一处 shutdown 顺序问题：socket 路径已经移除后，Host 测试进程仍可能因 listener 未关闭而存活。

这些修改让生命周期边界由明确事件决定，不再依赖子进程输出时机、固定 sleep 或快速文件系统。

## 验证

- ShellRun cancellation/timeout 回归测试在 Storage stress 下连续通过 100 次
- 多 Client execution 回归测试在 Storage stress 下连续通过 20 次
- Host kernel 生命周期套件并发运行 8 份，240/240 通过且无 listener 残留
- 在最新 `main` 上通过带 Storage stress 的完整 affected-workspace CI 测试矩阵
- build、format、lint、typecheck 与 diff 检查

</details>
