### PR TITLE
refactor(core): unify cron expression authority

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,7 @@
     "./search": "./dist/search.js",
     "./bot-events": "./dist/bot-events.js",
     "./bot-platform-hints": "./dist/bot-platform-hints.js",
+    "./cron-expression": "./dist/cron-expression.js",
     "./plan-reminders": "./dist/plan-reminders.js",
     "./agent-graph-control": "./dist/agent-graph-control.js",
     "./agent-graph-schedule": "./dist/agent-graph-schedule.js",

--- a/packages/core/src/__tests__/cron-expression.test.ts
+++ b/packages/core/src/__tests__/cron-expression.test.ts
@@ -104,23 +104,59 @@ describe('cron expression authority', () => {
     assert.equal(automation.nextAfter(after), new Date(2026, 0, 5, 0, 15, 0, 0).getTime());
   });
 
-  it('rejects malformed tokens instead of keeping the old validator/matcher split', () => {
-    for (const expression of [
-      '1x * * * *',
-      '1.9 * * * *',
-      '+1 * * * *',
-      '1-2-3 * * * *',
-      '*/2/3 * * * *',
-      '1,,2 * * * *',
-      '*/0 * * * *',
-    ]) {
+  it('preserves legacy Automation token coercion without broadening Plan Reminder', () => {
+    const after = new Date(2026, 0, 5, 0, 0, 0, 0).getTime();
+    const cases = [
+      ['1x * * * *', 1],
+      ['1.9 * * * *', 1],
+      ['+1 * * * *', 1],
+      ['1-2-3 * * * *', 1],
+      ['1/2/3 * * * *', 1],
+      ['1x/2y * * * *', 1],
+      ['*/2/3 * * * *', 2],
+      ['1.5-5.5 * * * *', 2],
+    ] as const;
+
+    for (const [expression, expectedMinute] of cases) {
+      const automation = assertCompiled(expression, 'automation-v1');
+      assert.equal(new Date(automation.nextAfter(after)!).getMinutes(), expectedMinute, expression);
       assert.equal(
-        compileCronExpression(expression, { profile: 'automation-v1' }).ok,
+        compileCronExpression(expression, { profile: 'plan-reminder-v1' }).ok,
         false,
         expression,
       );
+    }
+  });
+
+  it('compiles the legacy validator/matcher split into one effective match set', () => {
+    const after = new Date(2026, 0, 1, 0, 0, 0, 0).getTime();
+    const mixed = assertCompiled('1x-5y,10 * * * *', 'automation-v1');
+    assert.equal(mixed.nextAfter(after), new Date(2026, 0, 1, 0, 10, 0, 0).getTime());
+
+    const emptyMinute = assertCompiled('1x-5y * * * *', 'automation-v1');
+    const startedAt = Date.now();
+    assert.equal(emptyMinute.nextAfter(after), null);
+    assert.ok(Date.now() - startedAt < 100, 'an empty effective set must not scan eight years');
+
+    assert.equal(assertCompiled('* 1x-5y * * *', 'automation-v1').nextAfter(after), null);
+    assert.equal(assertCompiled('* * * 1x-5y *', 'automation-v1').nextAfter(after), null);
+    assert.equal(assertCompiled('* * 1x-5y * *', 'automation-v1').nextAfter(after), null);
+    assert.equal(assertCompiled('* * * * 1x-5y', 'automation-v1').nextAfter(after), null);
+    assert.equal(assertCompiled('* * 1x-5y * 1x-5y', 'automation-v1').nextAfter(after), null);
+
+    // The invalid DOM range contributed no matches in the old matcher, but its
+    // restricted DOW sibling could still fire through Vixie OR semantics.
+    const fridayOnly = assertCompiled('0 0 1x-5y * 5', 'automation-v1');
+    assert.equal(fridayOnly.nextAfter(after), new Date(2026, 0, 2, 0, 0, 0, 0).getTime());
+
+    const secondOfMonthOnly = assertCompiled('0 0 2 * 1x-5y', 'automation-v1');
+    assert.equal(secondOfMonthOnly.nextAfter(after), new Date(2026, 0, 2, 0, 0, 0, 0).getTime());
+  });
+
+  it('still rejects fields that legacy Automation validation rejected', () => {
+    for (const expression of ['1,,2 * * * *', '*/0 * * * *', 'BADTOKEN * * * *', '60 * * * *']) {
       assert.equal(
-        compileCronExpression(expression, { profile: 'plan-reminder-v1' }).ok,
+        compileCronExpression(expression, { profile: 'automation-v1' }).ok,
         false,
         expression,
       );
@@ -185,6 +221,14 @@ describe('cron expression authority', () => {
     assert.equal(impossibleAutomation.ok, false);
     if (!impossibleAutomation.ok) assert.equal(impossibleAutomation.error.code, 'unsatisfiable');
 
+    // Legacy impossible-date validation used its parseInt view (month 2 only),
+    // not the matcher's Number view (2..20). Keep that validation authority.
+    const coercedImpossible = compileCronExpression('0 0 30 2e0-2e1 *', {
+      profile: 'automation-v1',
+    });
+    assert.equal(coercedImpossible.ok, false);
+    if (!coercedImpossible.ok) assert.equal(coercedImpossible.error.code, 'unsatisfiable');
+
     const after = new Date(2026, 0, 1, 0, 0, 0, 0).getTime();
     const impossiblePlan = assertCompiled('0 0 30 2 *', 'plan-reminder-v1');
     assert.equal(
@@ -196,6 +240,10 @@ describe('cron expression authority', () => {
     assert.ok(fridayInFebruary);
     assert.equal(new Date(fridayInFebruary).getMonth(), 1);
     assert.equal(new Date(fridayInFebruary).getDay(), 5);
+
+    const coercedFriday = assertCompiled('0 0 30 2e0-2e1 5', 'automation-v1').nextAfter(after);
+    assert.ok(coercedFriday);
+    assert.equal(new Date(coercedFriday).getDay(), 5);
 
     const leapDay = assertCompiled('0 0 29 2 *', 'automation-v1').nextAfter(after);
     assert.ok(leapDay);
@@ -216,14 +264,25 @@ describe('cron expression authority', () => {
     assert.equal(cron.nextAfter(atNine, { notAfter: atNineOne }), atNineOne);
     assert.equal(cron.nextAfter(Number.NaN), null);
     assert.equal(cron.nextAfter(atNine, { notBefore: Number.POSITIVE_INFINITY }), null);
+
+    assert.equal(cron.nextAfter(-1), 60_000);
+    assert.equal(assertCompiled('* * * * *', 'plan-reminder-v1').nextAfter(-1), 0);
   });
 
-  it('keeps the legacy valid-field matcher export on the shared parser', () => {
+  it('keeps the legacy field matcher export on the shared parser', () => {
     assert.equal(matchesCronField('5-15/3', 5, 0, 59), true);
     assert.equal(matchesCronField('5-15/3', 14, 0, 59), true);
     assert.equal(matchesCronField('5-15/3', 15, 0, 59), false);
     assert.equal(matchesCronField('5-15/3', 18, 0, 59), false);
-    assert.equal(matchesCronField('1x', 1, 0, 59), false);
+    assert.equal(matchesCronField('1x', 1, 0, 59), true);
+    assert.equal(matchesCronField('1x-5y,10', 10, 0, 59), true);
+    assert.equal(matchesCronField('1x-5y,10', 2, 0, 59), false);
+    assert.equal(matchesCronField('bad,10', 10, 0, 59), true);
+    assert.equal(matchesCronField('*/0,10', 10, 0, 59), true);
+    assert.equal(matchesCronField('60,10', 10, 0, 59), true);
+    assert.equal(matchesCronField(',10', 10, 0, 59), true);
+    assert.equal(matchesCronField('1-2', 1.5, 0, 59), true);
+    assert.equal(matchesCronField('1', 1, 10, 0), true);
   });
 
   it('moves forward by epoch minutes across local DST folds and gaps', () => {

--- a/packages/core/src/__tests__/cron-expression.test.ts
+++ b/packages/core/src/__tests__/cron-expression.test.ts
@@ -1,0 +1,242 @@
+import { execFileSync } from 'node:child_process';
+import assert from 'node:assert/strict';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  type CompiledCronExpression,
+  type CompileCronExpressionResult,
+  type CronCompatibilityProfile,
+  compileCronExpression,
+  matchesCronField,
+} from '../cron-expression.js';
+
+const compileContract: (
+  expression: string,
+  options: { readonly profile: CronCompatibilityProfile },
+) => CompileCronExpressionResult = compileCronExpression;
+const nextContract: CompiledCronExpression['nextAfter'] = assertCompiled(
+  '* * * * *',
+  'automation-v1',
+).nextAfter;
+const fieldMatchContract: (field: string, value: number, min: number, max: number) => boolean =
+  matchesCronField;
+void compileContract;
+void nextContract;
+void fieldMatchContract;
+
+describe('cron expression authority', () => {
+  it('compiles lists, ranges, and steps once and finds the next local minute', () => {
+    const cron = assertCompiled('5,20-30/5 9 * * *', 'automation-v1');
+    const after = new Date(2026, 0, 5, 8, 0, 0, 0).getTime();
+
+    assert.equal(cron.nextAfter(after), new Date(2026, 0, 5, 9, 5, 0, 0).getTime());
+  });
+
+  it('preserves each caller profile for bare-value steps', () => {
+    const after = new Date(2026, 0, 5, 0, 5, 0, 0).getTime();
+    const plan = assertCompiled('5/10 * * * *', 'plan-reminder-v1');
+    const automation = assertCompiled('5/10 * * * *', 'automation-v1');
+
+    assert.equal(plan.nextAfter(after), new Date(2026, 0, 5, 1, 5, 0, 0).getTime());
+    assert.equal(automation.nextAfter(after), new Date(2026, 0, 5, 0, 15, 0, 0).getTime());
+  });
+
+  it('keeps named tokens in Automation without broadening Plan Reminder', () => {
+    const plan = compileCronExpression('0 9 * * MON', { profile: 'plan-reminder-v1' });
+    assert.equal(plan.ok, false);
+    if (!plan.ok) assert.equal(plan.error.code, 'unsupported_syntax');
+
+    const after = new Date(2026, 0, 5, 8, 0, 0, 0).getTime();
+    const named = assertCompiled('0 9 * JAN MON', 'automation-v1').nextAfter(after);
+    const numeric = assertCompiled('0 9 * 1 1', 'automation-v1').nextAfter(after);
+    assert.equal(named, numeric);
+  });
+
+  it('keeps Plan schedules strict outside their normalization entrypoint', () => {
+    for (const expression of [' * * * * *', '* * * * * ', '*  * * * *', '*\t* * * *']) {
+      assert.equal(
+        compileCronExpression(expression, { profile: 'plan-reminder-v1' }).ok,
+        false,
+        expression,
+      );
+      assert.equal(
+        compileCronExpression(expression, { profile: 'automation-v1' }).ok,
+        true,
+        expression,
+      );
+    }
+  });
+
+  it('preserves the caller-specific step ceiling', () => {
+    const plan = compileCronExpression('*/100 * * * *', { profile: 'plan-reminder-v1' });
+    assert.equal(plan.ok, false);
+    if (!plan.ok) {
+      assert.equal(plan.error.code, 'out_of_range');
+      assert.equal(plan.error.min, 1);
+      assert.equal(plan.error.max, 60);
+    }
+
+    const after = new Date(2026, 0, 5, 0, 0, 0, 0).getTime();
+    const automation = assertCompiled('*/100 * * * *', 'automation-v1');
+    assert.equal(automation.nextAfter(after), new Date(2026, 0, 5, 1, 0, 0, 0).getTime());
+  });
+
+  it('pins each profile wildcard classification for DOM and DOW', () => {
+    const friday = new Date(2026, 0, 2, 0, 0, 0, 0).getTime();
+    const plan = assertCompiled('0 0 */1 * 5', 'plan-reminder-v1');
+    const automation = assertCompiled('0 0 */1 * 5', 'automation-v1');
+
+    assert.equal(plan.nextAfter(friday), new Date(2026, 0, 9, 0, 0, 0, 0).getTime());
+    assert.equal(automation.nextAfter(friday), new Date(2026, 0, 3, 0, 0, 0, 0).getTime());
+  });
+
+  it('preserves Automation matching for a bare star inside a list', () => {
+    const after = new Date(2026, 0, 5, 0, 0, 0, 0).getTime();
+    const plan = assertCompiled('*,15 * * * *', 'plan-reminder-v1');
+    const automation = assertCompiled('*,15 * * * *', 'automation-v1');
+
+    assert.equal(plan.nextAfter(after), new Date(2026, 0, 5, 0, 1, 0, 0).getTime());
+    assert.equal(automation.nextAfter(after), new Date(2026, 0, 5, 0, 15, 0, 0).getTime());
+  });
+
+  it('rejects malformed tokens instead of keeping the old validator/matcher split', () => {
+    for (const expression of [
+      '1x * * * *',
+      '1.9 * * * *',
+      '+1 * * * *',
+      '1-2-3 * * * *',
+      '*/2/3 * * * *',
+      '1,,2 * * * *',
+      '*/0 * * * *',
+    ]) {
+      assert.equal(
+        compileCronExpression(expression, { profile: 'automation-v1' }).ok,
+        false,
+        expression,
+      );
+      assert.equal(
+        compileCronExpression(expression, { profile: 'plan-reminder-v1' }).ok,
+        false,
+        expression,
+      );
+    }
+  });
+
+  it('normalizes both 0 and 7 to Sunday, including ranges', () => {
+    const monday = new Date(2026, 0, 5, 0, 0, 0, 0).getTime();
+    const sundayZero = assertCompiled('0 0 * * 0', 'automation-v1').nextAfter(monday);
+    const sundaySeven = assertCompiled('0 0 * * 7', 'automation-v1').nextAfter(monday);
+    assert.equal(sundaySeven, sundayZero);
+    assert.equal(new Date(sundaySeven!).getDay(), 0);
+
+    const friday = assertCompiled('0 0 * * 5-7', 'automation-v1').nextAfter(monday);
+    assert.equal(new Date(friday!).getDay(), 5);
+  });
+
+  it('uses Vixie OR semantics when DOM and DOW are both restricted', () => {
+    const after = new Date(2026, 6, 6, 10, 0, 0, 0).getTime();
+    const cron = assertCompiled('0 0 13 * 5', 'automation-v1');
+    const fires: Date[] = [];
+    let cursor = after;
+    for (let index = 0; index < 8; index += 1) {
+      const next = cron.nextAfter(cursor);
+      assert.ok(next);
+      fires.push(new Date(next));
+      cursor = next;
+    }
+
+    assert.ok(fires.every((date) => date.getDate() === 13 || date.getDay() === 5));
+    assert.ok(fires.some((date) => date.getDate() === 13 && date.getDay() !== 5));
+    assert.ok(fires.some((date) => date.getDate() !== 13 && date.getDay() === 5));
+  });
+
+  it('keeps caller policy around impossible and sparse dates', () => {
+    const impossibleAutomation = compileCronExpression('0 0 30 2 *', {
+      profile: 'automation-v1',
+    });
+    assert.equal(impossibleAutomation.ok, false);
+    if (!impossibleAutomation.ok) assert.equal(impossibleAutomation.error.code, 'unsatisfiable');
+
+    const after = new Date(2026, 0, 1, 0, 0, 0, 0).getTime();
+    const impossiblePlan = assertCompiled('0 0 30 2 *', 'plan-reminder-v1');
+    assert.equal(
+      impossiblePlan.nextAfter(after, { notAfter: after + 366 * 24 * 60 * 60 * 1000 }),
+      null,
+    );
+
+    const fridayInFebruary = assertCompiled('0 0 30 2 5', 'automation-v1').nextAfter(after);
+    assert.ok(fridayInFebruary);
+    assert.equal(new Date(fridayInFebruary).getMonth(), 1);
+    assert.equal(new Date(fridayInFebruary).getDay(), 5);
+
+    const leapDay = assertCompiled('0 0 29 2 *', 'automation-v1').nextAfter(after);
+    assert.ok(leapDay);
+    assert.equal(new Date(leapDay).getMonth(), 1);
+    assert.equal(new Date(leapDay).getDate(), 29);
+  });
+
+  it('enforces strictly-after, inclusive lower, and inclusive upper bounds', () => {
+    const cron = assertCompiled('* * * * *', 'automation-v1');
+    const atNine = new Date(2026, 0, 5, 9, 0, 0, 0).getTime();
+    const atNineOne = new Date(2026, 0, 5, 9, 1, 0, 0).getTime();
+    assert.equal(cron.nextAfter(atNine), atNineOne);
+    assert.equal(
+      cron.nextAfter(atNine, { notBefore: new Date(2026, 0, 5, 9, 5, 30, 0).getTime() }),
+      new Date(2026, 0, 5, 9, 6, 0, 0).getTime(),
+    );
+    assert.equal(cron.nextAfter(atNine, { notAfter: atNine }), null);
+    assert.equal(cron.nextAfter(atNine, { notAfter: atNineOne }), atNineOne);
+    assert.equal(cron.nextAfter(Number.NaN), null);
+    assert.equal(cron.nextAfter(atNine, { notBefore: Number.POSITIVE_INFINITY }), null);
+  });
+
+  it('keeps the legacy valid-field matcher export on the shared parser', () => {
+    assert.equal(matchesCronField('5-15/3', 5, 0, 59), true);
+    assert.equal(matchesCronField('5-15/3', 14, 0, 59), true);
+    assert.equal(matchesCronField('5-15/3', 15, 0, 59), false);
+    assert.equal(matchesCronField('5-15/3', 18, 0, 59), false);
+    assert.equal(matchesCronField('1x', 1, 0, 59), false);
+  });
+
+  it('moves forward by epoch minutes across local DST folds and gaps', () => {
+    const moduleUrl = pathToFileURL(
+      join(dirname(fileURLToPath(import.meta.url)), '..', 'cron-expression.js'),
+    ).href;
+    const snippet = `
+      import(${JSON.stringify(moduleUrl)}).then(({ compileCronExpression }) => {
+        const compile = (source) => {
+          const result = compileCronExpression(source, { profile: 'automation-v1' });
+          if (!result.ok) process.exit(2);
+          return result.value;
+        };
+        const foldFrom = Date.parse('2026-11-01T06:30:00Z');
+        const foldNext = compile('30 1 * * *').nextAfter(foldFrom);
+        const gapFrom = Date.parse('2026-03-08T06:59:00Z');
+        const gapNext = compile('30 2 * * *').nextAfter(gapFrom);
+        const gapDate = new Date(gapNext);
+        const valid =
+          typeof foldNext === 'number' && foldNext > foldFrom &&
+          typeof gapNext === 'number' && gapNext > gapFrom &&
+          gapDate.getDate() === 9 && gapDate.getHours() === 2 && gapDate.getMinutes() === 30;
+        process.exit(valid ? 0 : 1);
+      }).catch(() => process.exit(3));
+    `;
+
+    assert.doesNotThrow(() =>
+      execFileSync(process.execPath, ['--input-type=module', '-e', snippet], {
+        env: { ...process.env, TZ: 'America/New_York' },
+        stdio: 'pipe',
+      }),
+    );
+  });
+});
+
+function assertCompiled(
+  expression: string,
+  profile: CronCompatibilityProfile,
+): CompiledCronExpression {
+  const result = compileCronExpression(expression, { profile });
+  if (!result.ok) throw new Error(`${expression} did not compile: ${result.error.code}`);
+  return result.value;
+}

--- a/packages/core/src/__tests__/cron-expression.test.ts
+++ b/packages/core/src/__tests__/cron-expression.test.ts
@@ -51,6 +51,10 @@ describe('cron expression authority', () => {
     const named = assertCompiled('0 9 * JAN MON', 'automation-v1').nextAfter(after);
     const numeric = assertCompiled('0 9 * 1 1', 'automation-v1').nextAfter(after);
     assert.equal(named, numeric);
+
+    const namedRange = assertCompiled('0 9 * jan mon-fri', 'automation-v1').nextAfter(after);
+    const numericRange = assertCompiled('0 9 * 1 1-5', 'automation-v1').nextAfter(after);
+    assert.equal(namedRange, numericRange);
   });
 
   it('keeps Plan schedules strict outside their normalization entrypoint', () => {
@@ -121,6 +125,29 @@ describe('cron expression authority', () => {
         expression,
       );
     }
+  });
+
+  it('validates every field and impossible dates before searching', () => {
+    const cases = [
+      ['0 9 32 * *', 'day-of-month', 'out_of_range'],
+      ['0 25 * * *', 'hour', 'out_of_range'],
+      ['0 9 * 13 *', 'month', 'out_of_range'],
+      ['0 9 * * BADTOKEN', 'day-of-week', 'invalid_integer'],
+      ['0 0 30 2 *', 'day-of-month', 'unsatisfiable'],
+      ['0 0 31 4 *', 'day-of-month', 'unsatisfiable'],
+    ] as const;
+    const startedAt = Date.now();
+
+    for (const [expression, field, code] of cases) {
+      const result = compileCronExpression(expression, { profile: 'automation-v1' });
+      assert.equal(result.ok, false, expression);
+      if (!result.ok) {
+        assert.equal(result.error.field, field, expression);
+        assert.equal(result.error.code, code, expression);
+      }
+    }
+
+    assert.ok(Date.now() - startedAt < 100, 'invalid expressions must fail before search');
   });
 
   it('normalizes both 0 and 7 to Sunday, including ranges', () => {

--- a/packages/core/src/__tests__/plan-reminders.test.ts
+++ b/packages/core/src/__tests__/plan-reminders.test.ts
@@ -114,6 +114,31 @@ describe('plan reminder contract', () => {
       normalizeCreatePlanReminderInput({ title: 'x', runAt: now + 1, recurrence: 'cron' }, now).ok,
       false,
     );
+    assert.deepEqual(normalizePlanReminderCronExpression('MON * * * *'), {
+      ok: false,
+      reason: 'invalid_cron',
+      message: 'Plan reminder cron fields support only numbers, *, ranges, lists, and steps',
+    });
+    assert.deepEqual(normalizePlanReminderCronExpression('*/100 * * * *'), {
+      ok: false,
+      reason: 'invalid_cron',
+      message: 'Plan reminder cron field value must be between 1 and 60',
+    });
+  });
+
+  it('normalizes user whitespace but keeps direct schedule values strict', () => {
+    assert.deepEqual(normalizePlanReminderCronExpression(' \t*/5   * * * *\n'), {
+      ok: true,
+      value: '*/5 * * * *',
+    });
+    const after = new Date(2026, 0, 5, 8, 0, 0, 0).getTime();
+    assert.equal(
+      nextPlanReminderRunAtAfter(
+        { kind: 'cron', startAt: after, expression: ' */5 * * * *' },
+        after,
+      ),
+      undefined,
+    );
   });
 
   it('normalizes bot delivery with a closed platform and sanitized chat id', () => {

--- a/packages/core/src/cron-expression.ts
+++ b/packages/core/src/cron-expression.ts
@@ -1,0 +1,377 @@
+export const CRON_COMPATIBILITY_PROFILES = ['plan-reminder-v1', 'automation-v1'] as const;
+
+export type CronCompatibilityProfile = (typeof CRON_COMPATIBILITY_PROFILES)[number];
+
+export type CronFieldName = 'minute' | 'hour' | 'day-of-month' | 'month' | 'day-of-week';
+
+export type CronCompileErrorCode =
+  | 'invalid_field_count'
+  | 'unsupported_syntax'
+  | 'empty_list_item'
+  | 'invalid_step'
+  | 'invalid_range'
+  | 'reversed_range'
+  | 'invalid_integer'
+  | 'out_of_range'
+  | 'empty_field'
+  | 'unsatisfiable';
+
+export interface CronCompileError {
+  readonly code: CronCompileErrorCode;
+  readonly field?: CronFieldName;
+  readonly min?: number;
+  readonly max?: number;
+}
+
+export interface CronSearchBounds {
+  /** Inclusive lower bound. The result is still strictly after `after`. */
+  readonly notBefore?: number;
+  /** Inclusive absolute upper bound. */
+  readonly notAfter?: number;
+}
+
+/**
+ * An opaque, validated five-field cron expression.
+ *
+ * Field sets and calendar-matching details intentionally stay private so a
+ * caller cannot create another interpretation of the grammar.
+ */
+export interface CompiledCronExpression {
+  /**
+   * Find the next whole-minute occurrence in the host's local timezone.
+   * Returns null when the bounded search contains no matching instant.
+   */
+  nextAfter(after: number, bounds?: CronSearchBounds): number | null;
+}
+
+export type CompileCronExpressionResult =
+  | { readonly ok: true; readonly value: CompiledCronExpression }
+  | { readonly ok: false; readonly error: CronCompileError };
+
+interface CronFieldSpec {
+  readonly name: CronFieldName;
+  readonly min: number;
+  readonly max: number;
+  readonly aliases?: Readonly<Record<string, number>>;
+  readonly normalizeSunday?: boolean;
+}
+
+interface CronCompatibilityPolicy {
+  readonly fieldSeparator: 'single-space' | 'ascii-whitespace';
+  readonly allowAliases: boolean;
+  readonly singleValueStepExtendsToMax: boolean;
+  readonly limitStepToFieldWidth: boolean;
+  readonly wildcardMode: 'any-star-base' | 'literal-star';
+  readonly ignoreBareStarInList: boolean;
+  readonly rejectImpossibleDates: boolean;
+}
+
+interface ParsedCronField {
+  readonly wildcard: boolean;
+  readonly values: ReadonlySet<number>;
+}
+
+interface ParsedCronExpression {
+  readonly minute: ParsedCronField;
+  readonly hour: ParsedCronField;
+  readonly dayOfMonth: ParsedCronField;
+  readonly month: ParsedCronField;
+  readonly dayOfWeek: ParsedCronField;
+}
+
+type CronParseResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: CronCompileError };
+
+const MINUTE_MS = 60_000;
+const MINUTES_PER_DAY = 24 * 60;
+
+/** Covers the maximum gap between consecutive leap days across a non-leap century. */
+const MAX_SEARCH_MINUTES = 8 * 366 * MINUTES_PER_DAY;
+
+const MONTH_ALIASES: Readonly<Record<string, number>> = Object.freeze({
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12,
+});
+
+const DAY_OF_WEEK_ALIASES: Readonly<Record<string, number>> = Object.freeze({
+  sun: 0,
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+});
+
+const FIELD_SPECS = Object.freeze({
+  minute: { name: 'minute', min: 0, max: 59 },
+  hour: { name: 'hour', min: 0, max: 23 },
+  dayOfMonth: { name: 'day-of-month', min: 1, max: 31 },
+  month: { name: 'month', min: 1, max: 12, aliases: MONTH_ALIASES },
+  dayOfWeek: {
+    name: 'day-of-week',
+    min: 0,
+    max: 7,
+    aliases: DAY_OF_WEEK_ALIASES,
+    normalizeSunday: true,
+  },
+} satisfies Record<string, CronFieldSpec>);
+
+const PROFILE_POLICIES: Readonly<Record<CronCompatibilityProfile, CronCompatibilityPolicy>> =
+  Object.freeze({
+    'plan-reminder-v1': {
+      fieldSeparator: 'single-space',
+      allowAliases: false,
+      singleValueStepExtendsToMax: false,
+      limitStepToFieldWidth: true,
+      wildcardMode: 'any-star-base',
+      ignoreBareStarInList: false,
+      rejectImpossibleDates: false,
+    },
+    'automation-v1': {
+      fieldSeparator: 'ascii-whitespace',
+      allowAliases: true,
+      singleValueStepExtendsToMax: true,
+      limitStepToFieldWidth: false,
+      wildcardMode: 'literal-star',
+      // The legacy Automation matcher ignored a bare `*` when it appeared as
+      // one item in a list (`*,15` matched only 15). Keep that persisted-input
+      // behavior while removing the second parser that caused it.
+      ignoreBareStarInList: true,
+      rejectImpossibleDates: true,
+    },
+  });
+
+// Leap-year maxima; used only for the impossible-date fast path.
+const MAX_DAYS_IN_MONTH = Object.freeze([31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]);
+
+export function compileCronExpression(
+  expression: string,
+  options: { readonly profile: CronCompatibilityProfile },
+): CompileCronExpressionResult {
+  const policy = PROFILE_POLICIES[options.profile];
+  const parts =
+    policy.fieldSeparator === 'single-space'
+      ? expression.split(' ')
+      : expression.trim().split(/\s+/);
+  if (parts.length !== 5) return parseError('invalid_field_count');
+
+  const minute = parseCronField(parts[0] ?? '', FIELD_SPECS.minute, policy);
+  if (!minute.ok) return minute;
+  const hour = parseCronField(parts[1] ?? '', FIELD_SPECS.hour, policy);
+  if (!hour.ok) return hour;
+  const dayOfMonth = parseCronField(parts[2] ?? '', FIELD_SPECS.dayOfMonth, policy);
+  if (!dayOfMonth.ok) return dayOfMonth;
+  const month = parseCronField(parts[3] ?? '', FIELD_SPECS.month, policy);
+  if (!month.ok) return month;
+  const dayOfWeek = parseCronField(parts[4] ?? '', FIELD_SPECS.dayOfWeek, policy);
+  if (!dayOfWeek.ok) return dayOfWeek;
+
+  const parsed: ParsedCronExpression = {
+    minute: minute.value,
+    hour: hour.value,
+    dayOfMonth: dayOfMonth.value,
+    month: month.value,
+    dayOfWeek: dayOfWeek.value,
+  };
+  if (policy.rejectImpossibleDates && hasImpossibleCalendarDate(parsed)) {
+    return parseError('unsatisfiable', 'day-of-month');
+  }
+
+  return {
+    ok: true,
+    value: Object.freeze({
+      nextAfter(after: number, bounds?: CronSearchBounds): number | null {
+        return nextCronOccurrence(parsed, after, bounds);
+      },
+    }),
+  };
+}
+
+/**
+ * Compatibility entry for the existing `@maka/runtime` export.
+ *
+ * It uses the Automation field dialect but, unlike the retired matcher, fails
+ * the whole field closed when any token is malformed.
+ */
+export function matchesCronField(field: string, value: number, min: number, max: number): boolean {
+  if (field === '*') return true;
+  if (!Number.isFinite(value) || !Number.isSafeInteger(min) || !Number.isSafeInteger(max)) {
+    return false;
+  }
+  if (min > max) return false;
+  const parsed = parseCronField(
+    field,
+    { name: 'minute', min, max },
+    PROFILE_POLICIES['automation-v1'],
+  );
+  return parsed.ok && parsed.value.values.has(value);
+}
+
+function parseCronField(
+  input: string,
+  spec: CronFieldSpec,
+  policy: CronCompatibilityPolicy,
+): CronParseResult<ParsedCronField> {
+  if (!policy.allowAliases && !/^[\d*,/\-]+$/.test(input)) {
+    return parseError('unsupported_syntax', spec.name);
+  }
+
+  const rawParts = input.split(',');
+  const values = new Set<number>();
+  let hasWildcardBase = false;
+
+  for (const rawPart of rawParts) {
+    if (rawPart.length === 0) return parseError('empty_list_item', spec.name);
+    const stepParts = rawPart.split('/');
+    if (stepParts.length > 2) return parseError('invalid_step', spec.name);
+    const base = stepParts[0] ?? '';
+    const hasStep = stepParts[1] !== undefined;
+    const stepMax = policy.limitStepToFieldWidth
+      ? spec.max - spec.min + 1
+      : Number.MAX_SAFE_INTEGER;
+    const step = hasStep
+      ? parseCronInteger(stepParts[1] ?? '', 1, stepMax, spec)
+      : ({ ok: true, value: 1 } as const);
+    if (!step.ok) return step;
+
+    const bareStar = base === '*' && !hasStep;
+    if (bareStar && rawParts.length > 1 && policy.ignoreBareStarInList) continue;
+
+    let start: number;
+    let end: number;
+    if (base === '*') {
+      hasWildcardBase = true;
+      start = spec.min;
+      end = spec.max;
+    } else if (base.includes('-')) {
+      const range = base.split('-');
+      if (range.length !== 2) return parseError('invalid_range', spec.name);
+      const parsedStart = parseCronInteger(range[0] ?? '', spec.min, spec.max, spec, policy);
+      if (!parsedStart.ok) return parsedStart;
+      const parsedEnd = parseCronInteger(range[1] ?? '', spec.min, spec.max, spec, policy);
+      if (!parsedEnd.ok) return parsedEnd;
+      start = parsedStart.value;
+      end = parsedEnd.value;
+      if (start > end) return parseError('reversed_range', spec.name);
+    } else {
+      const parsed = parseCronInteger(base, spec.min, spec.max, spec, policy);
+      if (!parsed.ok) return parsed;
+      start = parsed.value;
+      end = hasStep && policy.singleValueStepExtendsToMax ? spec.max : start;
+    }
+
+    for (let candidate = start; candidate <= end; candidate += step.value) {
+      values.add(spec.normalizeSunday === true && candidate === 7 ? 0 : candidate);
+    }
+  }
+
+  if (values.size === 0) return parseError('empty_field', spec.name);
+  const wildcard = policy.wildcardMode === 'any-star-base' ? hasWildcardBase : input === '*';
+  return { ok: true, value: { wildcard, values } };
+}
+
+function parseCronInteger(
+  input: string,
+  min: number,
+  max: number,
+  spec: CronFieldSpec,
+  policy?: CronCompatibilityPolicy,
+): CronParseResult<number> {
+  const alias = policy?.allowAliases ? spec.aliases?.[input.toLowerCase()] : undefined;
+  if (alias !== undefined) return { ok: true, value: alias };
+  if (!/^\d+$/.test(input)) return parseError('invalid_integer', spec.name, min, max);
+  const value = Number(input);
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    return parseError('out_of_range', spec.name, min, max);
+  }
+  return { ok: true, value };
+}
+
+function hasImpossibleCalendarDate(expression: ParsedCronExpression): boolean {
+  if (
+    expression.dayOfMonth.wildcard ||
+    expression.month.wildcard ||
+    !expression.dayOfWeek.wildcard
+  ) {
+    return false;
+  }
+  const maxDays = Math.max(
+    ...[...expression.month.values].map((month) => MAX_DAYS_IN_MONTH[month - 1] ?? 0),
+  );
+  return Math.min(...expression.dayOfMonth.values) > maxDays;
+}
+
+function nextCronOccurrence(
+  expression: ParsedCronExpression,
+  after: number,
+  bounds: CronSearchBounds | undefined,
+): number | null {
+  if (!Number.isFinite(after)) return null;
+  if (bounds?.notBefore !== undefined && !Number.isFinite(bounds.notBefore)) return null;
+  if (bounds?.notAfter !== undefined && !Number.isFinite(bounds.notAfter)) return null;
+
+  const firstMinuteAfter = (Math.floor(after / MINUTE_MS) + 1) * MINUTE_MS;
+  const notBefore = bounds?.notBefore;
+  const boundedStart =
+    notBefore === undefined
+      ? firstMinuteAfter
+      : Math.max(firstMinuteAfter, Math.ceil(notBefore / MINUTE_MS) * MINUTE_MS);
+  const defaultEnd = firstMinuteAfter + (MAX_SEARCH_MINUTES - 1) * MINUTE_MS;
+  const searchEnd = Math.min(defaultEnd, bounds?.notAfter ?? defaultEnd);
+  if (
+    !Number.isFinite(boundedStart) ||
+    !Number.isFinite(searchEnd) ||
+    boundedStart > searchEnd ||
+    Number.isNaN(new Date(boundedStart).getTime())
+  ) {
+    return null;
+  }
+
+  for (let candidate = boundedStart; candidate <= searchEnd; candidate += MINUTE_MS) {
+    const date = new Date(candidate);
+    if (cronExpressionMatches(expression, date)) return candidate;
+  }
+  return null;
+}
+
+function cronExpressionMatches(expression: ParsedCronExpression, date: Date): boolean {
+  if (!expression.minute.values.has(date.getMinutes())) return false;
+  if (!expression.hour.values.has(date.getHours())) return false;
+  if (!expression.month.values.has(date.getMonth() + 1)) return false;
+
+  const dayOfMonthMatches = expression.dayOfMonth.values.has(date.getDate());
+  const dayOfWeekMatches = expression.dayOfWeek.values.has(date.getDay());
+  if (!expression.dayOfMonth.wildcard && !expression.dayOfWeek.wildcard) {
+    return dayOfMonthMatches || dayOfWeekMatches;
+  }
+  return dayOfMonthMatches && dayOfWeekMatches;
+}
+
+function parseError<T = never>(
+  code: CronCompileErrorCode,
+  field?: CronFieldName,
+  min?: number,
+  max?: number,
+): CronParseResult<T> {
+  return {
+    ok: false,
+    error: {
+      code,
+      ...(field ? { field } : {}),
+      ...(min !== undefined ? { min } : {}),
+      ...(max !== undefined ? { max } : {}),
+    },
+  };
+}

--- a/packages/core/src/cron-expression.ts
+++ b/packages/core/src/cron-expression.ts
@@ -86,7 +86,11 @@ type CronParseResult<T> =
 const MINUTE_MS = 60_000;
 const MINUTES_PER_DAY = 24 * 60;
 
-/** Covers the maximum gap between consecutive leap days across a non-leap century. */
+/**
+ * A sparse valid expression such as Feb 29 can be eight years away when a
+ * century year is not divisible by 400 (2096 -> 2104). This bound covers that
+ * maximum gap while still making an impossible expression terminate.
+ */
 const MAX_SEARCH_MINUTES = 8 * 366 * MINUTES_PER_DAY;
 
 const MONTH_ALIASES: Readonly<Record<string, number>> = Object.freeze({
@@ -322,6 +326,9 @@ function nextCronOccurrence(
   if (bounds?.notBefore !== undefined && !Number.isFinite(bounds.notBefore)) return null;
   if (bounds?.notAfter !== undefined && !Number.isFinite(bounds.notAfter)) return null;
 
+  // Advance in epoch minutes. Mutating local Date fields during a DST fold can
+  // re-encode the repeated wall-clock time with the earlier offset and produce
+  // a candidate at or before `after`, causing a scheduler re-fire loop.
   const firstMinuteAfter = (Math.floor(after / MINUTE_MS) + 1) * MINUTE_MS;
   const notBefore = bounds?.notBefore;
   const boundedStart =
@@ -353,6 +360,8 @@ function cronExpressionMatches(expression: ParsedCronExpression, date: Date): bo
 
   const dayOfMonthMatches = expression.dayOfMonth.values.has(date.getDate());
   const dayOfWeekMatches = expression.dayOfWeek.values.has(date.getDay());
+  // Vixie cron treats DOM and DOW as OR only when both fields are restricted.
+  // When either field is a wildcard it is a no-op, so matching stays AND.
   if (!expression.dayOfMonth.wildcard && !expression.dayOfWeek.wildcard) {
     return dayOfMonthMatches || dayOfWeekMatches;
   }

--- a/packages/core/src/cron-expression.ts
+++ b/packages/core/src/cron-expression.ts
@@ -59,16 +59,29 @@ interface CronFieldSpec {
 interface CronCompatibilityPolicy {
   readonly fieldSeparator: 'single-space' | 'ascii-whitespace';
   readonly allowAliases: boolean;
+  readonly legacyTokenCoercion: boolean;
   readonly singleValueStepExtendsToMax: boolean;
   readonly limitStepToFieldWidth: boolean;
   readonly wildcardMode: 'any-star-base' | 'literal-star';
   readonly ignoreBareStarInList: boolean;
+  readonly allowEmptyMatchSet: boolean;
   readonly rejectImpossibleDates: boolean;
+  readonly nextMinuteRounding: 'floor' | 'truncate';
 }
 
 interface ParsedCronField {
   readonly wildcard: boolean;
   readonly values: ReadonlySet<number>;
+  /** Values admitted by the legacy validator before matcher coercion. */
+  readonly validationValues: ReadonlySet<number>;
+  readonly validationWildcard: boolean;
+}
+
+interface ParseCronFieldOptions {
+  /** Preserve the retired standalone matcher's skip-invalid, no-validation contract. */
+  readonly matcherOnly?: boolean;
+  /** Candidate values to project instead of the field's normal integer domain. */
+  readonly candidates?: readonly number[];
 }
 
 interface ParsedCronExpression {
@@ -137,15 +150,21 @@ const PROFILE_POLICIES: Readonly<Record<CronCompatibilityProfile, CronCompatibil
     'plan-reminder-v1': {
       fieldSeparator: 'single-space',
       allowAliases: false,
+      legacyTokenCoercion: false,
       singleValueStepExtendsToMax: false,
       limitStepToFieldWidth: true,
       wildcardMode: 'any-star-base',
       ignoreBareStarInList: false,
+      allowEmptyMatchSet: false,
       rejectImpossibleDates: false,
+      nextMinuteRounding: 'floor',
     },
     'automation-v1': {
       fieldSeparator: 'ascii-whitespace',
       allowAliases: true,
+      // Existing persisted Automation schedules inherit parseInt-prefix
+      // coercion and ignored extra slash/range segments from the retired parser.
+      legacyTokenCoercion: true,
       singleValueStepExtendsToMax: true,
       limitStepToFieldWidth: false,
       wildcardMode: 'literal-star',
@@ -153,7 +172,12 @@ const PROFILE_POLICIES: Readonly<Record<CronCompatibilityProfile, CronCompatibil
       // one item in a list (`*,15` matched only 15). Keep that persisted-input
       // behavior while removing the second parser that caused it.
       ignoreBareStarInList: true,
+      // A legacy range could pass validation but contribute no matches because
+      // the old matcher used Number where validation used parseInt. Preserve
+      // that effective empty set, especially for Vixie DOM/DOW OR schedules.
+      allowEmptyMatchSet: true,
       rejectImpossibleDates: true,
+      nextMinuteRounding: 'truncate',
     },
   });
 
@@ -197,7 +221,7 @@ export function compileCronExpression(
     ok: true,
     value: Object.freeze({
       nextAfter(after: number, bounds?: CronSearchBounds): number | null {
-        return nextCronOccurrence(parsed, after, bounds);
+        return nextCronOccurrence(parsed, after, bounds, policy.nextMinuteRounding);
       },
     }),
   };
@@ -206,19 +230,17 @@ export function compileCronExpression(
 /**
  * Compatibility entry for the existing `@maka/runtime` export.
  *
- * It uses the Automation field dialect but, unlike the retired matcher, fails
- * the whole field closed when any token is malformed.
+ * Fields admitted by the full-expression compiler use the same Automation
+ * parser and effective match set. Malformed standalone calls additionally keep
+ * the retired matcher's fail-soft contract by skipping invalid list items.
  */
 export function matchesCronField(field: string, value: number, min: number, max: number): boolean {
   if (field === '*') return true;
-  if (!Number.isFinite(value) || !Number.isSafeInteger(min) || !Number.isSafeInteger(max)) {
-    return false;
-  }
-  if (min > max) return false;
   const parsed = parseCronField(
     field,
     { name: 'minute', min, max },
     PROFILE_POLICIES['automation-v1'],
+    { matcherOnly: true, candidates: [value] },
   );
   return parsed.ok && parsed.value.values.has(value);
 }
@@ -227,63 +249,143 @@ function parseCronField(
   input: string,
   spec: CronFieldSpec,
   policy: CronCompatibilityPolicy,
+  options?: ParseCronFieldOptions,
 ): CronParseResult<ParsedCronField> {
   if (!policy.allowAliases && !/^[\d*,/\-]+$/.test(input)) {
     return parseError('unsupported_syntax', spec.name);
   }
 
-  const rawParts = input.split(',');
+  const matcherOnly = options?.matcherOnly === true;
+  const normalizedInput =
+    policy.allowAliases && spec.aliases ? translateCronAliases(input, spec.aliases) : input;
+  const rawParts = normalizedInput.split(',');
   const values = new Set<number>();
+  const validationValues = new Set<number>();
   let hasWildcardBase = false;
 
   for (const rawPart of rawParts) {
-    if (rawPart.length === 0) return parseError('empty_list_item', spec.name);
+    if (rawPart.length === 0) {
+      if (matcherOnly) continue;
+      return parseError('empty_list_item', spec.name);
+    }
     const stepParts = rawPart.split('/');
-    if (stepParts.length > 2) return parseError('invalid_step', spec.name);
+    if (stepParts.length > 2 && !policy.legacyTokenCoercion) {
+      return parseError('invalid_step', spec.name);
+    }
     const base = stepParts[0] ?? '';
     const hasStep = stepParts[1] !== undefined;
-    const stepMax = policy.limitStepToFieldWidth
-      ? spec.max - spec.min + 1
-      : Number.MAX_SAFE_INTEGER;
-    const step = hasStep
-      ? parseCronInteger(stepParts[1] ?? '', 1, stepMax, spec)
-      : ({ ok: true, value: 1 } as const);
-    if (!step.ok) return step;
+    let step = 1;
+    if (hasStep) {
+      if (matcherOnly) {
+        step = Number.parseInt(stepParts[1] ?? '', 10);
+        if (Number.isNaN(step) || step <= 0) continue;
+      } else {
+        const stepMax = policy.limitStepToFieldWidth
+          ? spec.max - spec.min + 1
+          : Number.POSITIVE_INFINITY;
+        const parsedStep = parseCronInteger(stepParts[1] ?? '', 1, stepMax, spec, policy);
+        if (!parsedStep.ok) return parsedStep;
+        step = parsedStep.value;
+      }
+    }
 
     const bareStar = base === '*' && !hasStep;
-    if (bareStar && rawParts.length > 1 && policy.ignoreBareStarInList) continue;
+    if (matcherOnly && bareStar) continue;
+    const ignoreEffectivePart = bareStar && rawParts.length > 1 && policy.ignoreBareStarInList;
 
-    let start: number;
-    let end: number;
+    let start = 0;
+    let end = -1;
+    let validationStart = 0;
+    let validationEnd = -1;
+    let contributesEffectiveMatches = true;
     if (base === '*') {
       hasWildcardBase = true;
       start = spec.min;
       end = spec.max;
+      validationStart = spec.min;
+      validationEnd = spec.max;
     } else if (base.includes('-')) {
       const range = base.split('-');
-      if (range.length !== 2) return parseError('invalid_range', spec.name);
-      const parsedStart = parseCronInteger(range[0] ?? '', spec.min, spec.max, spec, policy);
-      if (!parsedStart.ok) return parsedStart;
-      const parsedEnd = parseCronInteger(range[1] ?? '', spec.min, spec.max, spec, policy);
-      if (!parsedEnd.ok) return parsedEnd;
-      start = parsedStart.value;
-      end = parsedEnd.value;
-      if (start > end) return parseError('reversed_range', spec.name);
+      if (matcherOnly) {
+        start = Number(range[0] ?? '');
+        end = Number(range[1] ?? '');
+        if (Number.isNaN(start) || Number.isNaN(end)) continue;
+      } else if (range.length !== 2 && !policy.legacyTokenCoercion) {
+        return parseError('invalid_range', spec.name);
+      } else {
+        const parsedStart = parseCronInteger(range[0] ?? '', spec.min, spec.max, spec, policy);
+        if (!parsedStart.ok) return parsedStart;
+        const parsedEnd = parseCronInteger(range[1] ?? '', spec.min, spec.max, spec, policy);
+        if (!parsedEnd.ok) return parsedEnd;
+        if (parsedStart.value > parsedEnd.value) {
+          return parseError('reversed_range', spec.name);
+        }
+        validationStart = parsedStart.value;
+        validationEnd = parsedEnd.value;
+
+        if (policy.legacyTokenCoercion) {
+          // The old Automation validator used parseInt for ranges while its
+          // matcher used Number. Validate once above, then compile the matcher's
+          // effective values so callers never interpret the source again.
+          start = Number(range[0] ?? '');
+          end = Number(range[1] ?? '');
+          contributesEffectiveMatches = !Number.isNaN(start) && !Number.isNaN(end);
+        } else {
+          start = parsedStart.value;
+          end = parsedEnd.value;
+        }
+      }
     } else {
-      const parsed = parseCronInteger(base, spec.min, spec.max, spec, policy);
-      if (!parsed.ok) return parsed;
-      start = parsed.value;
-      end = hasStep && policy.singleValueStepExtendsToMax ? spec.max : start;
+      if (matcherOnly) {
+        start = Number.parseInt(base, 10);
+        if (Number.isNaN(start)) continue;
+      } else {
+        const parsed = parseCronInteger(base, spec.min, spec.max, spec, policy);
+        if (!parsed.ok) return parsed;
+        start = parsed.value;
+        validationStart = parsed.value;
+      }
+      end = hasStep && (matcherOnly || policy.singleValueStepExtendsToMax) ? spec.max : start;
+      validationEnd = end;
     }
 
-    for (let candidate = start; candidate <= end; candidate += step.value) {
+    if (!matcherOnly) {
+      for (let candidate = validationStart; candidate <= validationEnd; candidate += step) {
+        validationValues.add(spec.normalizeSunday === true && candidate === 7 ? 0 : candidate);
+      }
+    }
+    if (ignoreEffectivePart || !contributesEffectiveMatches) continue;
+
+    // Enumerating the field's tiny integer domain also reproduces legacy range
+    // coercions such as `1.5-5.5` without leaking raw-token logic into matching.
+    const addCandidate = (candidate: number): void => {
+      if (!(candidate >= start && candidate <= end)) return;
+      if (hasStep && (candidate - start) % step !== 0) return;
       values.add(spec.normalizeSunday === true && candidate === 7 ? 0 : candidate);
+    };
+    if (options?.candidates) {
+      for (const candidate of options.candidates) addCandidate(candidate);
+    } else {
+      for (let candidate = spec.min; candidate <= spec.max; candidate += 1) {
+        addCandidate(candidate);
+      }
     }
   }
 
-  if (values.size === 0) return parseError('empty_field', spec.name);
-  const wildcard = policy.wildcardMode === 'any-star-base' ? hasWildcardBase : input === '*';
-  return { ok: true, value: { wildcard, values } };
+  if (values.size === 0 && !matcherOnly && !policy.allowEmptyMatchSet) {
+    return parseError('empty_field', spec.name);
+  }
+  const wildcard =
+    policy.wildcardMode === 'any-star-base' ? hasWildcardBase : normalizedInput === '*';
+  return {
+    ok: true,
+    value: {
+      wildcard,
+      values,
+      validationValues,
+      validationWildcard: normalizedInput === '*',
+    },
+  };
 }
 
 function parseCronInteger(
@@ -291,45 +393,63 @@ function parseCronInteger(
   min: number,
   max: number,
   spec: CronFieldSpec,
-  policy?: CronCompatibilityPolicy,
+  policy: CronCompatibilityPolicy,
 ): CronParseResult<number> {
-  const alias = policy?.allowAliases ? spec.aliases?.[input.toLowerCase()] : undefined;
-  if (alias !== undefined) return { ok: true, value: alias };
-  if (!/^\d+$/.test(input)) return parseError('invalid_integer', spec.name, min, max);
-  const value = Number(input);
-  if (!Number.isSafeInteger(value) || value < min || value > max) {
+  const value = policy.legacyTokenCoercion ? Number.parseInt(input, 10) : Number(input);
+  const validSyntax = policy.legacyTokenCoercion || /^\d+$/.test(input);
+  const validInteger = policy.legacyTokenCoercion
+    ? Number.isInteger(value)
+    : Number.isSafeInteger(value);
+  if (!validSyntax || !validInteger) {
+    return parseError('invalid_integer', spec.name, min, max);
+  }
+  if (value < min || value > max) {
     return parseError('out_of_range', spec.name, min, max);
   }
   return { ok: true, value };
 }
 
+function translateCronAliases(input: string, aliases: Readonly<Record<string, number>>): string {
+  return input.replace(/[a-zA-Z]+/g, (token) => {
+    const alias = aliases[token.toLowerCase()];
+    return alias === undefined ? token : String(alias);
+  });
+}
+
 function hasImpossibleCalendarDate(expression: ParsedCronExpression): boolean {
   if (
-    expression.dayOfMonth.wildcard ||
-    expression.month.wildcard ||
-    !expression.dayOfWeek.wildcard
+    expression.dayOfMonth.validationWildcard ||
+    expression.month.validationWildcard ||
+    !expression.dayOfWeek.validationWildcard
   ) {
     return false;
   }
   const maxDays = Math.max(
-    ...[...expression.month.values].map((month) => MAX_DAYS_IN_MONTH[month - 1] ?? 0),
+    ...[...expression.month.validationValues].map((month) => MAX_DAYS_IN_MONTH[month - 1] ?? 0),
   );
-  return Math.min(...expression.dayOfMonth.values) > maxDays;
+  return Math.min(...expression.dayOfMonth.validationValues) > maxDays;
 }
 
 function nextCronOccurrence(
   expression: ParsedCronExpression,
   after: number,
   bounds: CronSearchBounds | undefined,
+  nextMinuteRounding: CronCompatibilityPolicy['nextMinuteRounding'],
 ): number | null {
   if (!Number.isFinite(after)) return null;
   if (bounds?.notBefore !== undefined && !Number.isFinite(bounds.notBefore)) return null;
   if (bounds?.notAfter !== undefined && !Number.isFinite(bounds.notAfter)) return null;
+  if (!hasPotentialEffectiveMatch(expression)) return null;
 
   // Advance in epoch minutes. Mutating local Date fields during a DST fold can
   // re-encode the repeated wall-clock time with the earlier offset and produce
-  // a candidate at or before `after`, causing a scheduler re-fire loop.
-  const firstMinuteAfter = (Math.floor(after / MINUTE_MS) + 1) * MINUTE_MS;
+  // a candidate at or before `after`, causing a scheduler re-fire loop. The
+  // truncation branch retains Automation's pre-epoch behavior; both profiles
+  // are identical for every normal positive timestamp.
+  const firstMinuteAfter =
+    nextMinuteRounding === 'truncate'
+      ? after - (after % MINUTE_MS) + MINUTE_MS
+      : (Math.floor(after / MINUTE_MS) + 1) * MINUTE_MS;
   const notBefore = bounds?.notBefore;
   const boundedStart =
     notBefore === undefined
@@ -351,6 +471,28 @@ function nextCronOccurrence(
     if (cronExpressionMatches(expression, date)) return candidate;
   }
   return null;
+}
+
+/**
+ * Detect effective empty sets before the bounded minute scan. DOM and DOW use
+ * Vixie OR only when both are restricted, so one restricted side may remain
+ * empty when the other can still match.
+ */
+function hasPotentialEffectiveMatch(expression: ParsedCronExpression): boolean {
+  if (
+    expression.minute.values.size === 0 ||
+    expression.hour.values.size === 0 ||
+    expression.month.values.size === 0
+  ) {
+    return false;
+  }
+
+  const hasDayOfMonth = expression.dayOfMonth.values.size > 0;
+  const hasDayOfWeek = expression.dayOfWeek.values.size > 0;
+  if (!expression.dayOfMonth.wildcard && !expression.dayOfWeek.wildcard) {
+    return hasDayOfMonth || hasDayOfWeek;
+  }
+  return hasDayOfMonth && hasDayOfWeek;
 }
 
 function cronExpressionMatches(expression: ParsedCronExpression, date: Date): boolean {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -930,6 +930,22 @@ export {
   validateWorkspacePrivacyContext,
 } from './incognito.js';
 
+// cron-expression.ts — shared five-field cron grammar and occurrence authority.
+export type {
+  CompiledCronExpression,
+  CompileCronExpressionResult,
+  CronCompatibilityProfile,
+  CronCompileError,
+  CronCompileErrorCode,
+  CronFieldName,
+  CronSearchBounds,
+} from './cron-expression.js';
+export {
+  CRON_COMPATIBILITY_PROFILES,
+  compileCronExpression,
+  matchesCronField,
+} from './cron-expression.js';
+
 // plan-reminders.ts (PR-PLAN-REMINDER-MVP-0)
 export type {
   CreatePlanReminderInput,

--- a/packages/core/src/plan-reminders.ts
+++ b/packages/core/src/plan-reminders.ts
@@ -1,4 +1,5 @@
 import { BOT_PROVIDERS, isBotDeliveryProvider, type BotProvider } from './bot-chat-settings.js';
+import { compileCronExpression, type CronCompileError } from './cron-expression.js';
 
 export const PLAN_REMINDER_TITLE_MAX_CHARS = 120;
 export const PLAN_REMINDER_NOTE_MAX_CHARS = 1000;
@@ -316,8 +317,8 @@ export function normalizePlanReminderCronExpression(
       `Plan reminder cron expression must be ${PLAN_REMINDER_CRON_EXPRESSION_MAX_CHARS} characters or fewer`,
     );
   }
-  const parsed = parsePlanReminderCronExpression(expression);
-  if (!parsed.ok) return invalid('invalid_cron', parsed.message);
+  const compiled = compileCronExpression(expression, { profile: 'plan-reminder-v1' });
+  if (!compiled.ok) return invalid('invalid_cron', planReminderCronErrorMessage(compiled.error));
   return { ok: true, value: expression };
 }
 
@@ -512,147 +513,40 @@ function addMonthsClamped(anchor: number, monthOffset: number): number {
   ).getTime();
 }
 
-interface ParsedCronField {
-  wildcard: boolean;
-  values: Set<number>;
-}
-
-interface ParsedCronExpression {
-  minute: ParsedCronField;
-  hour: ParsedCronField;
-  dayOfMonth: ParsedCronField;
-  month: ParsedCronField;
-  dayOfWeek: ParsedCronField;
-}
-
 function nextCronRunAtAfter(schedule: PlanReminderCronSchedule, after: number): number | undefined {
-  const parsed = parsePlanReminderCronExpression(schedule.expression);
-  if (!parsed.ok) return undefined;
-  const searchStart = Math.max(after + 1, schedule.startAt);
-  let candidate = Math.ceil(searchStart / 60_000) * 60_000;
-  const searchEnd = after + PLAN_REMINDER_MAX_DELAY_MS;
-  while (candidate <= searchEnd) {
-    if (cronExpressionMatches(parsed.value, new Date(candidate))) return candidate;
-    candidate += 60_000;
-  }
-  return undefined;
+  const compiled = compileCronExpression(schedule.expression, { profile: 'plan-reminder-v1' });
+  if (!compiled.ok) return undefined;
+  return (
+    compiled.value.nextAfter(after, {
+      notBefore: schedule.startAt,
+      notAfter: after + PLAN_REMINDER_MAX_DELAY_MS,
+    }) ?? undefined
+  );
 }
 
-function parsePlanReminderCronExpression(
-  input: string,
-): PlanReminderNormalizeResult<ParsedCronExpression> {
-  const parts = input.split(' ');
-  if (parts.length !== 5) {
-    return invalid('invalid_cron', 'Plan reminder cron expression must have exactly 5 fields');
+function planReminderCronErrorMessage(error: CronCompileError): string {
+  switch (error.code) {
+    case 'invalid_field_count':
+      return 'Plan reminder cron expression must have exactly 5 fields';
+    case 'unsupported_syntax':
+      return 'Plan reminder cron fields support only numbers, *, ranges, lists, and steps';
+    case 'empty_list_item':
+      return 'Plan reminder cron field contains an empty list item';
+    case 'invalid_step':
+      return 'Plan reminder cron field has an invalid step';
+    case 'invalid_range':
+      return 'Plan reminder cron field has an invalid range';
+    case 'reversed_range':
+      return 'Plan reminder cron range start must be before its end';
+    case 'invalid_integer':
+      return 'Plan reminder cron field values must be integers';
+    case 'out_of_range':
+      return `Plan reminder cron field value must be between ${error.min} and ${error.max}`;
+    case 'empty_field':
+      return 'Plan reminder cron field cannot be empty';
+    case 'unsatisfiable':
+      return 'Plan reminder cron expression has no run within one year';
   }
-  const minute = parseCronField(parts[0] ?? '', 0, 59, false);
-  if (!minute.ok) return minute;
-  const hour = parseCronField(parts[1] ?? '', 0, 23, false);
-  if (!hour.ok) return hour;
-  const dayOfMonth = parseCronField(parts[2] ?? '', 1, 31, false);
-  if (!dayOfMonth.ok) return dayOfMonth;
-  const month = parseCronField(parts[3] ?? '', 1, 12, false);
-  if (!month.ok) return month;
-  const dayOfWeek = parseCronField(parts[4] ?? '', 0, 7, true);
-  if (!dayOfWeek.ok) return dayOfWeek;
-  return {
-    ok: true,
-    value: {
-      minute: minute.value,
-      hour: hour.value,
-      dayOfMonth: dayOfMonth.value,
-      month: month.value,
-      dayOfWeek: dayOfWeek.value,
-    },
-  };
-}
-
-function parseCronField(
-  input: string,
-  min: number,
-  max: number,
-  normalizeSevenToZero: boolean,
-): PlanReminderNormalizeResult<ParsedCronField> {
-  if (!/^[\d*,/\-]+$/.test(input)) {
-    return invalid(
-      'invalid_cron',
-      'Plan reminder cron fields support only numbers, *, ranges, lists, and steps',
-    );
-  }
-  const values = new Set<number>();
-  let wildcard = false;
-  for (const rawPart of input.split(',')) {
-    if (!rawPart)
-      return invalid('invalid_cron', 'Plan reminder cron field contains an empty list item');
-    const stepSplit = rawPart.split('/');
-    if (stepSplit.length > 2)
-      return invalid('invalid_cron', 'Plan reminder cron field has an invalid step');
-    const base = stepSplit[0] ?? '';
-    const step =
-      stepSplit[1] === undefined
-        ? { ok: true as const, value: 1 }
-        : parseCronInteger(stepSplit[1], 1, max - min + 1);
-    if (!step.ok) return step;
-    let start: number;
-    let end: number;
-    if (base === '*') {
-      wildcard = true;
-      start = min;
-      end = max;
-    } else if (base.includes('-')) {
-      const range = base.split('-');
-      if (range.length !== 2)
-        return invalid('invalid_cron', 'Plan reminder cron field has an invalid range');
-      const parsedStart = parseCronInteger(range[0] ?? '', min, max);
-      if (!parsedStart.ok) return parsedStart;
-      const parsedEnd = parseCronInteger(range[1] ?? '', min, max);
-      if (!parsedEnd.ok) return parsedEnd;
-      start = parsedStart.value;
-      end = parsedEnd.value;
-      if (start > end)
-        return invalid('invalid_cron', 'Plan reminder cron range start must be before its end');
-    } else {
-      const parsed = parseCronInteger(base, min, max);
-      if (!parsed.ok) return parsed;
-      start = parsed.value;
-      end = parsed.value;
-    }
-    for (let value = start; value <= end; value += step.value) {
-      values.add(normalizeSevenToZero && value === 7 ? 0 : value);
-    }
-  }
-  if (values.size === 0) return invalid('invalid_cron', 'Plan reminder cron field cannot be empty');
-  return { ok: true, value: { wildcard, values } };
-}
-
-function parseCronInteger(
-  input: string,
-  min: number,
-  max: number,
-): PlanReminderNormalizeResult<number> {
-  if (!/^\d+$/.test(input)) {
-    return invalid('invalid_cron', 'Plan reminder cron field values must be integers');
-  }
-  const value = Number(input);
-  if (!Number.isSafeInteger(value) || value < min || value > max) {
-    return invalid(
-      'invalid_cron',
-      `Plan reminder cron field value must be between ${min} and ${max}`,
-    );
-  }
-  return { ok: true, value };
-}
-
-function cronExpressionMatches(expression: ParsedCronExpression, date: Date): boolean {
-  if (!expression.minute.values.has(date.getMinutes())) return false;
-  if (!expression.hour.values.has(date.getHours())) return false;
-  if (!expression.month.values.has(date.getMonth() + 1)) return false;
-  const dayOfMonthMatches = expression.dayOfMonth.values.has(date.getDate());
-  const dayOfWeekMatches = expression.dayOfWeek.values.has(date.getDay());
-  if (!expression.dayOfMonth.wildcard && !expression.dayOfWeek.wildcard) {
-    return dayOfMonthMatches || dayOfWeekMatches;
-  }
-  return dayOfMonthMatches && dayOfWeekMatches;
 }
 
 function isBotProvider(value: unknown): value is BotProvider {

--- a/packages/runtime/src/__tests__/automation.test.ts
+++ b/packages/runtime/src/__tests__/automation.test.ts
@@ -1,8 +1,5 @@
 import { describe, test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-import { dirname, join } from 'node:path';
 import {
   AutomationManager,
   computeJitter,
@@ -454,154 +451,13 @@ describe('AutomationManager', () => {
 });
 
 describe('computeNextCronFire', () => {
-  describe('validation + named tokens (O(1), no multi-second scan)', () => {
-    test('named weekday, weekday range, and month tokens resolve case-insensitively', () => {
-      const base = new Date('2026-07-06T08:00:00').getTime(); // 2026-07-06 is a Monday
-      const named = computeNextCronFire('0 9 * * MON', base);
-      const numeric = computeNextCronFire('0 9 * * 1', base);
-      assert.ok(named);
-      assert.equal(named, numeric, 'MON must resolve identically to 1');
-      assert.equal(new Date(named!).getDay(), 1);
+  test('keeps Runtime return and compatibility-export contracts', () => {
+    const base = new Date('2026-07-06T08:00:00').getTime();
 
-      const january = new Date(computeNextCronFire('0 0 1 jan *', base)!);
-      assert.equal(january.getMonth(), 0);
-      assert.equal(january.getDate(), 1);
-
-      const dow = new Date(computeNextCronFire('0 9 * * mon-fri', base)!).getDay();
-      assert.ok(dow >= 1 && dow <= 5);
-    });
-
-    test('invalid fields and impossible dates fail fast', () => {
-      const base = Date.now();
-      const start = Date.now();
-      for (const expression of [
-        '0 9 32 * *',
-        '0 25 * * *',
-        '0 9 * 13 *',
-        '0 9 * * BADTOKEN',
-        '0 0 30 2 *',
-        '0 0 31 4 *',
-      ]) {
-        assert.equal(computeNextCronFire(expression, base), null, expression);
-      }
-      assert.ok(Date.now() - start < 100, 'invalid expressions must fail fast');
-    });
-
-    test('impossible dom is NOT rejected when dow is also restricted (Vixie OR)', () => {
-      // `0 0 30 2 5` = Feb 30 (impossible) OR any Friday in Feb (valid) → fires.
-      const base = new Date('2026-01-01T00:00:00').getTime();
-      const next = computeNextCronFire('0 0 30 2 5', base);
-      assert.ok(next, 'must still fire on Fridays in February');
-      const d = new Date(next!);
-      assert.equal(d.getMonth(), 1); // February
-      assert.equal(d.getDay(), 5); // Friday
-    });
-
-    test('DST fall-back: next fire is strictly after fromTime (regression: no re-fire storm)', () => {
-      // Under America/New_York, 2026-11-01T06:30Z is inside the REPEATED (fall-back)
-      // local hour. A local wall-clock round-trip would shift the scan start ~59min
-      // before fromTime, returning a candidate <= fromTime → the scheduler would
-      // re-fire every tick for the whole hour. Run in a child with TZ set; the
-      // snippet exits non-zero (→ execFileSync throws) if strictly-after is violated.
-      const modUrl = pathToFileURL(
-        join(dirname(fileURLToPath(import.meta.url)), '..', 'automation-state.js'),
-      ).href;
-      const snippet =
-        `import(${JSON.stringify(modUrl)}).then(m => {` +
-        `const from = Date.parse('2026-11-01T06:30:00Z');` +
-        `const next = m.computeNextCronFire('30 1 * * *', from);` +
-        `process.exit(typeof next === 'number' && next > from ? 0 : 1);` +
-        `}).catch(() => process.exit(2));`;
-      assert.doesNotThrow(() =>
-        execFileSync(process.execPath, ['--input-type=module', '-e', snippet], {
-          env: { ...process.env, TZ: 'America/New_York' },
-          stdio: 'pipe',
-        }),
-      );
-    });
-  });
-
-  test('range/step 5-15/3 does not match 18,21,24...', () => {
-    // Verify values outside the range don't match
-    assert.equal(matchesCronField('5-15/3', 18, 0, 59), false);
-    assert.equal(matchesCronField('5-15/3', 21, 0, 59), false);
-    assert.equal(matchesCronField('5-15/3', 5, 0, 59), true);
-    assert.equal(matchesCronField('5-15/3', 8, 0, 59), true);
-    assert.equal(matchesCronField('5-15/3', 11, 0, 59), true);
+    assert.equal(computeNextCronFire('0 9 * * MON', base), computeNextCronFire('0 9 * * 1', base));
+    assert.equal(computeNextCronFire('not valid', base), null);
     assert.equal(matchesCronField('5-15/3', 14, 0, 59), true);
-    assert.equal(matchesCronField('5-15/3', 15, 0, 59), false); // 15-5=10, 10%3≠0
-  });
-
-  // --- Bug 1: sparse annual crons must resolve within a bounded window ---
-
-  test('sparse annual cron 0 0 29 2 * resolves to Feb 29 in a leap year (not null)', () => {
-    const base = new Date('2026-07-06T10:00:00').getTime();
-    const next = computeNextCronFire('0 0 29 2 *', base);
-    assert.ok(next, 'Feb 29 cron should resolve within the extended search window');
-    const d = new Date(next!);
-    assert.equal(d.getMonth(), 1, 'month should be February (0-indexed 1)');
-    assert.equal(d.getDate(), 29, 'day should be the 29th');
-    assert.equal(d.getHours(), 0);
-    assert.equal(d.getMinutes(), 0);
-    const y = d.getFullYear();
-    const isLeap = (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
-    assert.ok(isLeap, `${y} should be a leap year`);
-    assert.ok(next! > base);
-  });
-
-  // --- Bug 2: dom + dow are OR (not AND) when BOTH fields are restricted ---
-
-  test('dom+dow OR: 0 0 13 * 5 matches the 13th OR any Friday (not Friday-the-13th)', () => {
-    const base = new Date('2026-07-06T10:00:00').getTime();
-    const fires: Date[] = [];
-    let cursor = base;
-    for (let i = 0; i < 8; i++) {
-      const next = computeNextCronFire('0 0 13 * 5', cursor);
-      assert.ok(next);
-      fires.push(new Date(next!));
-      cursor = next!;
-    }
-    // Every fire is at midnight and is either the 13th OR a Friday (dow 5).
-    for (const d of fires) {
-      assert.equal(d.getHours(), 0);
-      assert.equal(d.getMinutes(), 0);
-      assert.ok(
-        d.getDate() === 13 || d.getDay() === 5,
-        `${d.toISOString()} should be the 13th or a Friday`,
-      );
-    }
-    // Proves OR (not AND): a Friday that is NOT the 13th must appear ...
-    assert.ok(
-      fires.some((d) => d.getDay() === 5 && d.getDate() !== 13),
-      'expected at least one Friday that is not the 13th',
-    );
-    // ... and a 13th that is NOT a Friday must appear.
-    assert.ok(
-      fires.some((d) => d.getDate() === 13 && d.getDay() !== 5),
-      'expected at least one 13th that is not a Friday',
-    );
-    assert.equal(new Date(computeNextCronFire('0 0 13 * *', base)!).getDate(), 13);
-    assert.equal(new Date(computeNextCronFire('0 0 * * 5', base)!).getDay(), 5);
-  });
-
-  test('dow=7 matches Sundays (cron allows 0 OR 7 for Sunday)', () => {
-    const base = new Date('2026-07-06T10:00:00').getTime(); // Monday
-    for (const field of ['0 0 * * 7', '0 0 * * 0', '0 0 * * 5-7', '0 0 * * 0,3']) {
-      const next = computeNextCronFire(field, base);
-      assert.ok(next, `${field} should resolve`);
-    }
-    // "* * * * 7" must actually land on a Sunday.
-    const sun = computeNextCronFire('0 0 * * 7', base);
-    assert.equal(new Date(sun!).getDay(), 0, 'dow=7 lands on Sunday (getDay()===0)');
-    // "5-7" (Fri/Sat/Sun) includes Sunday.
-    let cursor = base;
-    let sawSunday = false;
-    for (let i = 0; i < 6; i++) {
-      const n = computeNextCronFire('0 0 * * 5-7', cursor);
-      if (n && new Date(n).getDay() === 0) sawSunday = true;
-      cursor = n ?? cursor;
-    }
-    assert.ok(sawSunday, '5-7 range includes Sunday');
+    assert.equal(matchesCronField('5-15/3', 18, 0, 59), false);
   });
 });
 

--- a/packages/runtime/src/automation-state.ts
+++ b/packages/runtime/src/automation-state.ts
@@ -13,6 +13,9 @@ import type {
   AutomationSchedule,
 } from '@maka/core/automation';
 import { AUTOMATION_LAST_ERROR_LIMIT, truncateAutomationText } from '@maka/core/automation';
+import { compileCronExpression } from '@maka/core/cron-expression';
+
+export { matchesCronField } from '@maka/core/cron-expression';
 
 export type {
   AutomationDefinition,
@@ -473,134 +476,6 @@ export function settleAutomationAttempt(
   }
 }
 
-const MINUTES_PER_DAY = 24 * 60;
-
-/**
- * Upper bound on the minute-by-minute search window.
- *
- * A valid but sparse cron such as `0 0 29 2 *` (Feb 29, leap years only) can be
- * several years out. The maximum gap between two consecutive Feb 29ths is
- * 8 years: a century year that is not divisible by 400 (e.g. 2100, 2200) is NOT
- * a leap year, so the sequence 2096 -> 2104 skips 2100 entirely. Searching a
- * full ~8-year window guarantees every legally-satisfiable expression resolves,
- * while the bound still lets genuinely-impossible expressions (e.g.
- * `0 0 30 2 *`, Feb 30 never exists) terminate and return null instead of
- * looping forever.
- */
-const MAX_SEARCH_MINUTES = 8 * 366 * MINUTES_PER_DAY; // ~8 years, bounded
-
-const CRON_MONTH_ALIASES: Record<string, number> = {
-  jan: 1,
-  feb: 2,
-  mar: 3,
-  apr: 4,
-  may: 5,
-  jun: 6,
-  jul: 7,
-  aug: 8,
-  sep: 9,
-  oct: 10,
-  nov: 11,
-  dec: 12,
-};
-const CRON_DOW_ALIASES: Record<string, number> = {
-  sun: 0,
-  mon: 1,
-  tue: 2,
-  wed: 3,
-  thu: 4,
-  fri: 5,
-  sat: 6,
-};
-// Leap-year max days per month (Feb=29) — used only for impossible-date detection.
-const CRON_MAX_DAYS_IN_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-
-/** Replace alphabetic cron tokens (e.g. MON, JAN) with their numeric value. */
-function translateCronAliases(field: string, aliases: Record<string, number>): string {
-  return field.replace(/[a-zA-Z]+/g, (tok) => {
-    const n = aliases[tok.toLowerCase()];
-    return n === undefined ? tok : String(n);
-  });
-}
-
-/**
- * Expand a numeric cron field to the set of values it matches within [min,max].
- * Returns 'star' for "*", or null if any token is malformed or out of range.
- */
-function expandCronField(field: string, min: number, max: number): number[] | 'star' | null {
-  if (field === '*') return 'star';
-  const values = new Set<number>();
-  for (const part of field.split(',')) {
-    let range = part;
-    let step = 1;
-    if (part.includes('/')) {
-      const [r, s] = part.split('/');
-      step = parseInt(s, 10);
-      if (!Number.isInteger(step) || step <= 0) return null;
-      range = r;
-    }
-    let lo: number;
-    let hi: number;
-    if (range === '*') {
-      lo = min;
-      hi = max;
-    } else if (range.includes('-')) {
-      const [a, b] = range.split('-');
-      lo = parseInt(a, 10);
-      hi = parseInt(b, 10);
-      if (!Number.isInteger(lo) || !Number.isInteger(hi)) return null;
-    } else {
-      lo = parseInt(range, 10);
-      if (!Number.isInteger(lo)) return null;
-      hi = part.includes('/') ? max : lo; // "5/10" means 5,15,25… up to max
-    }
-    if (lo < min || hi > max || lo > hi) return null;
-    for (let v = lo; v <= hi; v += step) values.add(v);
-  }
-  return [...values];
-}
-
-interface NormalizedCron {
-  minuteField: string;
-  hourField: string;
-  domField: string;
-  monthField: string;
-  dowField: string;
-}
-
-/**
- * Validate + normalize a 5-field cron expression in O(1): translate named
- * day/month tokens to numbers, reject out-of-range values, and fast-fail
- * impossible calendar dates (e.g. Feb 30, Apr 31). Returns null for anything
- * malformed or unsatisfiable so the caller skips the expensive minute scan.
- */
-function normalizeCronExpression(expression: string): NormalizedCron | null {
-  const parts = expression.trim().split(/\s+/);
-  if (parts.length !== 5) return null;
-  const minuteField = parts[0];
-  const hourField = parts[1];
-  const domField = parts[2];
-  const monthField = translateCronAliases(parts[3], CRON_MONTH_ALIASES);
-  const dowField = translateCronAliases(parts[4], CRON_DOW_ALIASES);
-
-  if (expandCronField(minuteField, 0, 59) === null) return null;
-  if (expandCronField(hourField, 0, 23) === null) return null;
-  const domVals = expandCronField(domField, 1, 31);
-  const monthVals = expandCronField(monthField, 1, 12);
-  const dowVals = expandCronField(dowField, 0, 7); // 0 and 7 both = Sunday
-  if (domVals === null || monthVals === null || dowVals === null) return null;
-
-  // Impossible calendar date: only fast-fail when the day is constrained ONLY by
-  // dom+month (dow="*"). If dow is also restricted, Vixie OR-semantics mean a
-  // matching weekday can still fire, so we must NOT reject.
-  if (domVals !== 'star' && monthVals !== 'star' && dowVals === 'star') {
-    const maxDays = Math.max(...monthVals.map((m) => CRON_MAX_DAYS_IN_MONTH[m - 1]));
-    if (Math.min(...domVals) > maxDays) return null; // e.g. Feb 30, Apr 31
-  }
-
-  return { minuteField, hourField, domField, monthField, dowField };
-}
-
 /**
  * Compute the next Unix-ms timestamp at which a 5-field cron expression fires,
  * strictly after `fromTime`. Returns null for a malformed expression or one
@@ -617,91 +492,8 @@ function normalizeCronExpression(expression: string): NormalizedCron | null {
  * intentionally out of scope for this parser.
  */
 export function computeNextCronFire(expression: string, fromTime: number): number | null {
-  // Validate + normalize BEFORE the bounded scan so an unsatisfiable or
-  // unsupported expression fails in O(1) instead of blocking the (main-process)
-  // thread for a multi-second full-window scan. This translates named tokens
-  // (MON-SUN, JAN-DEC), rejects out-of-range values, and fast-fails impossible
-  // calendar dates (e.g. Feb 30).
-  const normalized = normalizeCronExpression(expression);
-  if (!normalized) return null;
-  const { minuteField, hourField, domField, monthField, dowField } = normalized;
-
-  // Vixie-cron day semantics: when BOTH the day-of-month and day-of-week fields
-  // are restricted (neither is "*"), a day matches if it satisfies EITHER field
-  // (OR) — e.g. `0 0 13 * 5` fires on the 13th of any month OR on any Friday,
-  // NOT only on Friday the 13th. When at least one field is "*", that field
-  // matches every value, so the two are combined with AND (the "*" field is a
-  // no-op and only the other constrains).
-  const domIsStar = domField === '*';
-  const dowIsStar = dowField === '*';
-  const bothDayFieldsRestricted = !domIsStar && !dowIsStar;
-
-  // Start the scan at the next whole-minute boundary strictly after fromTime,
-  // computed in EPOCH arithmetic. Using Date.setSeconds() would round-trip the
-  // instant through local wall-clock; during a DST fall-back (a repeated local
-  // hour) V8 re-encodes the ambiguous time to the earlier offset, shifting the
-  // start ~59 min BEFORE fromTime. The scan would then return a candidate
-  // <= fromTime, breaking the strictly-after contract and making the scheduler
-  // re-fire every tick for the whole repeated hour. Epoch math is offset-safe;
-  // candidate wall-clock fields are still read with local getters below.
-  const baseTime = fromTime - (fromTime % 60000) + 60000;
-
-  for (let attempt = 0; attempt < MAX_SEARCH_MINUTES; attempt++) {
-    const candidateTime = baseTime + attempt * 60000;
-    const candidate = new Date(candidateTime);
-
-    // Cheapest, most-selective checks first so most candidates are pruned before
-    // the day-field matching runs.
-    if (!matchesCronField(minuteField, candidate.getMinutes(), 0, 59)) continue;
-    if (!matchesCronField(hourField, candidate.getHours(), 0, 23)) continue;
-    if (!matchesCronField(monthField, candidate.getMonth() + 1, 1, 12)) continue;
-
-    const domMatch = matchesCronField(domField, candidate.getDate(), 1, 31);
-    // Day-of-week: cron allows both 0 and 7 for Sunday, but Date.getDay() only
-    // returns 0-6 (0=Sunday). Match against the raw value, plus the 7-alias when
-    // the day is Sunday, so fields like "7", "5-7", "0,7" all fire on Sundays.
-    const dow = candidate.getDay();
-    const dowMatch =
-      matchesCronField(dowField, dow, 0, 7) || (dow === 0 && matchesCronField(dowField, 7, 0, 7));
-    const dayMatch = bothDayFieldsRestricted
-      ? domMatch || dowMatch // OR when both are constrained
-      : domMatch && dowMatch; // AND when one is "*"
-
-    if (dayMatch) return candidateTime;
-  }
-  return null;
-}
-
-export function matchesCronField(field: string, value: number, min: number, max: number): boolean {
-  if (field === '*') return true;
-
-  for (const part of field.split(',')) {
-    if (part.includes('/')) {
-      const [range, stepStr] = part.split('/');
-      const step = parseInt(stepStr, 10);
-      if (isNaN(step) || step <= 0) continue;
-      let start = min;
-      let end = max;
-      if (range !== '*') {
-        if (range.includes('-')) {
-          const [lo, hi] = range.split('-').map(Number);
-          if (isNaN(lo) || isNaN(hi)) continue;
-          start = lo;
-          end = hi;
-        } else {
-          start = parseInt(range, 10);
-          if (isNaN(start)) continue;
-        }
-      }
-      if (value >= start && value <= end && (value - start) % step === 0) return true;
-    } else if (part.includes('-')) {
-      const [lo, hi] = part.split('-').map(Number);
-      if (!isNaN(lo) && !isNaN(hi) && value >= lo && value <= hi) return true;
-    } else {
-      if (parseInt(part, 10) === value) return true;
-    }
-  }
-  return false;
+  const compiled = compileCronExpression(expression, { profile: 'automation-v1' });
+  return compiled.ok ? compiled.value.nextAfter(fromTime) : null;
 }
 
 export { MAX_AUTOMATIONS_PER_SESSION, MAX_CONSECUTIVE_FAILURES, DEFAULT_EXPIRY_DAYS };


### PR DESCRIPTION
## Summary

`plan-reminders.ts` and `automation-state.ts` each owned a five-field cron implementation, and Automation additionally parsed the same field twice with different validation and matching rules.

This PR moves cron parsing, matching, and bounded next-occurrence search into one compiled `@maka/core/cron-expression` authority. Plan Reminder and Runtime Automation consume the same opaque compiled representation, while their scheduling responsibilities stay where they are: Plan still owns `startAt`, its 366-day horizon, and user-facing validation errors; Runtime still owns Automation scheduling and jitter, and the existing persistence and lifecycle boundaries are unchanged.

The two callers did not previously accept exactly the same dialect, so the shared module uses named compatibility profiles instead of silently normalizing their behavior:

- `plan-reminder-v1` keeps the numeric-only grammar, single-space field boundary, step ceiling, normalization errors, and bounded Plan search contract.
- `automation-v1` keeps ASCII-whitespace input, month/day aliases, Sunday `0`/`7`, Vixie DOM/DOW OR semantics, the eight-year sparse-date search, and persisted legacy coercions such as parseInt-prefixed tokens.
- Automation's retired validator/matcher disagreement is handled by one parser that produces a private validation projection and one effective match set. The validation projection is used only for the existing impossible-date gate; occurrence search consumes only the compiled effective set. This preserves existing schedules such as `*,15` and legacy ranges whose effective set is empty, while allowing empty sets to return before the minute scan.
- The existing Runtime exports `computeNextCronFire` and `matchesCronField` remain available.

Refs #1404

<details>
<summary>中文说明</summary>

`plan-reminders.ts` 与 `automation-state.ts` 原本各自维护一套五字段 Cron 实现；Automation 内部还会用不同规则对同一个字段分别做校验和匹配。

本 PR 将 Cron 解析、匹配以及有界的下一次触发时间搜索统一到 `@maka/core/cron-expression`。Plan Reminder 与 Runtime Automation 现在消费同一个不透明的编译结果，但原有职责边界不变：Plan 继续负责 `startAt`、366 天搜索窗口和面向用户的校验错误；Runtime 继续负责 Automation 调度和 jitter，现有持久化及生命周期边界不变。

由于两个调用方原本接受的 Cron 方言并不完全相同，共享模块使用具名兼容 profile，而不是静默改变既有行为：

- `plan-reminder-v1` 保留仅数字语法、单空格字段边界、step 上限、规范化错误和 Plan 的有界搜索行为。
- `automation-v1` 保留 ASCII 空白、月份/星期别名、Sunday `0`/`7`、Vixie DOM/DOW OR 语义、八年稀疏日期搜索，以及 `parseInt` 前缀等已持久化的历史 coercion。
- 旧 Automation validator/matcher 的差异由同一个 parser 处理：一次解析产生私有 validation projection 和唯一的 effective match set。validation projection 只用于保留既有 impossible-date 判断；下一次触发时间搜索只消费编译后的 effective set。因此，`*,15` 以及 effective set 为空的历史 range 都保持原行为，同时空集合可以在分钟扫描前直接返回。
- Runtime 现有的 `computeNextCronFire` 与 `matchesCronField` 导出路径保持可用。

</details>

## Verification

- `npm --workspace @maka/core test` — 715 passed
- `npm --workspace @maka/runtime test` — 2,695 passed, 3 skipped
- `npm --workspace @maka/storage test` — 1,023 passed, 3 skipped
- `npm run typecheck`
- `npm run lint` — 2,280 files checked
- `npm run format:check` — 1,407 files checked
- `git diff origin/main...HEAD --check`
- loaded `@maka/core`, `@maka/core/cron-expression`, and the compatibility exports from `@maka/runtime` from their built artifacts
- differential audit against the retired Automation field matcher — 216,942 comparisons with no mismatch

## Review focus

- `PROFILE_POLICIES` is the compatibility boundary. Please check that it records the two existing caller contracts without exposing parser internals to consumers.
- Automation's `validationValues` and effective `values` intentionally differ for legacy inputs. Validation retains the old impossible-date authority; matching reproduces the values the retired matcher would actually select.
- The empty-effective-set fast path follows the same Vixie DOM/DOW truth table as normal matching, so an empty DOM can still fire through a restricted DOW and vice versa.
- Next-occurrence search advances in epoch minutes to remain strictly after the input across local DST folds. Runtime scheduling, jitter, persistence, and lifecycle ownership are outside this change.
