### PR TITLE
fix(core): accept usage_recorded in AgentRun event schema (desktop fails to start)

### DIFF
--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -262,12 +262,7 @@ export const AGENT_RUN_EVENT_TYPES = [
   'sandbox_denial_detected',
   'provider_request_captured',
   'provider_request_attempt_recorded',
-  // Token-usage checkpoints are written by the agent runtime after each
-  // provider request completes. They were missing from this enum, which made
-  // strict AgentRun ledger reads fail at app startup with
-  // "Invalid AgentRun event schema" (desktop would not launch).
-  // https://github.com/maka-agent/maka-agent/issues/1942
-  // Signed: pi + deepseek-v4-flash
+  // No current writer; shipped ledgers still carry it and strict reads must not reject them (#1942).
   'usage_recorded',
   'model_call_attempt_recorded',
   'history_compact_checkpoint_recorded',

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -262,6 +262,13 @@ export const AGENT_RUN_EVENT_TYPES = [
   'sandbox_denial_detected',
   'provider_request_captured',
   'provider_request_attempt_recorded',
+  // Token-usage checkpoints are written by the agent runtime after each
+  // provider request completes. They were missing from this enum, which made
+  // strict AgentRun ledger reads fail at app startup with
+  // "Invalid AgentRun event schema" (desktop would not launch).
+  // https://github.com/maka-agent/maka-agent/issues/1942
+  // Signed: pi + deepseek-v4-flash
+  'usage_recorded',
   'model_call_attempt_recorded',
   'history_compact_checkpoint_recorded',
   'active_full_compact_block_recorded',


### PR DESCRIPTION
## Problem

Desktop app fails to start after any normal run:

```
AgentRun 99272103-6b74-4dd2-b367-b231bbe0b6c7 has a corrupt JSONL record at line 11: Invalid AgentRun event schema
```

The run event ledger (`workspaces/<ws>/sessions/<session>/runs/<run>/events.jsonl`) contains `type: "usage_recorded"` events, but `usage_recorded` is **not** in `AGENT_RUN_EVENT_TYPES` in `packages/core/src/agent-run.ts`. The strict read path in `@maka/storage` (`readEvents` with `strict=true`) throws on any event whose type is not in the enum, which blocks app startup.

Verified: all 4 runs on a real machine contained a `usage_recorded` event, i.e. every run that completes a turn with token usage writes one — so this is a guaranteed recurrence, not one-off corruption. The event JSON itself is valid; the failure is purely schema-level.

## Fix

Add `usage_recorded` to `AGENT_RUN_EVENT_TYPES`. `AgentRunEvent.data` is `Record<string, unknown>` and projection handling is generic, so no other changes are required.

## Verification

- `packages/core` typecheck + build pass (tsc).
- `node --test dist/__tests__/agent-run-*.test.js` → 9/9 pass.
- Re-ran `decodeAgentRunEvent` against the **original** on-disk ledger from the failing machine (backup of 4 runs, 62 events including 4 `usage_recorded`): all 62 decode successfully, 0 failures.

Fixes #1942