### PR TITLE
test(ci): keep heavy storage probes off default runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,14 @@ jobs:
       - id: plan
         name: Select affected test surfaces
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
         run: |
-          if [[ "$EVENT_NAME" == "push" ]]; then
+          # A merged PR has already been tested by impact. Re-run the same
+          # affected surfaces for the exact main-branch delta instead of
+          # turning every push (including docs-only pushes) into a full suite.
+          # New branches and unavailable history still fail safe to full.
+          if [[ "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "${BASE_SHA}^{commit}"; then
             node scripts/ci-test-plan.mjs --full >> "$GITHUB_OUTPUT"
           else
             node scripts/ci-test-plan.mjs --base "$BASE_SHA" --head "$HEAD_SHA" >> "$GITHUB_OUTPUT"

--- a/packages/storage/src/__tests__/git-workspace-service.test.ts
+++ b/packages/storage/src/__tests__/git-workspace-service.test.ts
@@ -31,6 +31,12 @@ const cleanup: string[] = [];
 let gitExecutablePath: string;
 let gitExecutableSha256: `sha256:${string}`;
 
+// These probes fork a second Node process, stop it at a durable failpoint, and
+// kill it to verify restart convergence. Keep the full crash matrix on this
+// service's owning stress route; the default suite still covers recovery,
+// quarantine, corruption, ownership, and symlink boundaries in-process.
+const RUN_REAL_PROCESS_CRASH_TESTS = process.env.MAKA_STORAGE_STRESS === '1';
+
 before(async () => {
   gitExecutablePath = await findGitExecutable();
   gitExecutableSha256 = await sha256File(gitExecutablePath);
@@ -246,6 +252,7 @@ describe('Git workspace service', () => {
   });
 
   test('repairs a crash after baseline ref publication even when the source later advances', {
+    skip: !RUN_REAL_PROCESS_CRASH_TESTS,
     timeout: 60_000,
   }, async () => {
     const root = await temporaryRoot();
@@ -302,6 +309,7 @@ describe('Git workspace service', () => {
     'after_head_ref_updated',
   ] as const) {
     test(`repairs a real-process crash at ${failpoint} without accepting residue`, {
+      skip: !RUN_REAL_PROCESS_CRASH_TESTS,
       timeout: 60_000,
     }, async () => {
       const root = await temporaryRoot();
@@ -354,6 +362,7 @@ describe('Git workspace service', () => {
     'after_quarantine_pruned',
   ] as const) {
     test(`converges quarantine after a real-process crash at ${failpoint}`, {
+      skip: !RUN_REAL_PROCESS_CRASH_TESTS,
       timeout: 60_000,
     }, async () => {
       const root = await temporaryRoot();

--- a/packages/storage/src/__tests__/root-authority.test.ts
+++ b/packages/storage/src/__tests__/root-authority.test.ts
@@ -42,6 +42,11 @@ import {
   type StorageRootLease,
 } from '../root-authority.js';
 
+// These probes launch native-lock holders and deliberately exercise abnormal
+// process exits. Keep them on the owning storage seam's stress route; the
+// default suite covers the same-process lease and lock boundaries below.
+const RUN_PROCESS_LOCK_TESTS = process.env.MAKA_STORAGE_STRESS === '1';
+
 describe('storage root authority', () => {
   test('discovers only marked roots without creating or changing filesystem state', async () => {
     await withRoots(async ({ base, root }) => {
@@ -624,7 +629,9 @@ describe('storage root authority', () => {
     });
   });
 
-  test('enforces exclusive/shared lock arbitration across processes', async () => {
+  test('enforces exclusive/shared lock arbitration across processes', {
+    skip: !RUN_PROCESS_LOCK_TESTS,
+  }, async () => {
     await withRoots(async ({ root }) => {
       const writer = spawnHolder(root, 'write');
       try {
@@ -724,7 +731,9 @@ describe('storage root authority', () => {
     });
   });
 
-  test('kernel releases a process lock after normal, uncaught, abort, and forced exits', async () => {
+  test('kernel releases a process lock after normal, uncaught, abort, and forced exits', {
+    skip: !RUN_PROCESS_LOCK_TESTS,
+  }, async () => {
     await withRoots(async ({ root }) => {
       const modes = ['close', 'throw', 'abort', 'SIGKILL'] as const;
       for (const mode of modes) {
@@ -745,7 +754,9 @@ describe('storage root authority', () => {
     });
   });
 
-  test('does not inherit the owner lock into a surviving descendant', async () => {
+  test('does not inherit the owner lock into a surviving descendant', {
+    skip: !RUN_PROCESS_LOCK_TESTS,
+  }, async () => {
     await withRoots(async ({ root }) => {
       const holder = spawnHolder(root, 'write');
       let descendantPid: number | undefined;

--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -66,6 +66,19 @@ const EXTENDED_SCRIPT_FILES = new Set([
   'scripts/verify-macos-arm64-dmg.mjs',
 ]);
 
+const STORAGE_STRESS_FILES = new Set([
+  'packages/storage/src/agent-run-store.ts',
+  'packages/storage/src/git-workspace-service.ts',
+  'packages/storage/src/runtime-event-invariants.ts',
+  'packages/storage/src/root-authority.ts',
+  'packages/storage/src/__tests__/agent-run-store.test.ts',
+  'packages/storage/src/__tests__/git-workspace-service.test.ts',
+  'packages/storage/src/__tests__/root-authority.test.ts',
+  'packages/storage/src/__tests__/fixtures/git-workspace-service-crash-child.ts',
+  'packages/storage/src/__tests__/fixtures/root-lock-holder.ts',
+  'packages/storage/src/__tests__/fixtures/root-resolver.ts',
+]);
+
 function normalizePath(path) {
   return path.split(sep).join('/').replace(/^\.\//, '');
 }
@@ -127,7 +140,11 @@ export function planTests(changedFiles, options = {}) {
       headless: graph.dirs.includes('packages/headless'),
       runtimeSandbox: graph.dirs.includes('packages/cli'),
       scriptMode: 'full',
-      storageStress: graph.dirs.includes('packages/storage'),
+      // A complete functional suite is still the default release/main gate.
+      // Stress multipliers and native child-process lock probes run only when
+      // their owning storage seam changes; making --full imply stress turned
+      // every unrelated merge into a 10K-chunk pressure run.
+      storageStress: false,
       storybook: true,
       workspaces: [...graph.dirs],
     };
@@ -172,12 +189,7 @@ export function planTests(changedFiles, options = {}) {
   }
 
   const workspaces = reverseDependencyClosure(directWorkspaces, graph);
-  const storageStress = files.some(
-    (path) =>
-      path === 'packages/storage/src/agent-run-store.ts' ||
-      path === 'packages/storage/src/runtime-event-invariants.ts' ||
-      path === 'packages/storage/src/__tests__/agent-run-store.test.ts',
-  );
+  const storageStress = files.some((path) => STORAGE_STRESS_FILES.has(path));
 
   return {
     code,

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -57,10 +57,21 @@ test('impact planning distinguishes docs, UI, and backend changes', () => {
 });
 
 test('stress and specialized script checks run only for their owning surfaces', () => {
+  for (const path of [
+    'packages/storage/src/agent-run-store.ts',
+    'packages/storage/src/git-workspace-service.ts',
+    'packages/storage/src/__tests__/fixtures/git-workspace-service-crash-child.ts',
+    'packages/storage/src/root-authority.ts',
+    'packages/storage/src/__tests__/root-authority.test.ts',
+    'packages/storage/src/__tests__/fixtures/root-lock-holder.ts',
+  ]) {
+    assert.equal(planTests([path], { graph }).storageStress, true, path);
+  }
   assert.equal(
-    planTests(['packages/storage/src/agent-run-store.ts'], { graph }).storageStress,
-    true,
+    planTests(['packages/storage/src/session-store.ts'], { graph }).storageStress,
+    false,
   );
+  assert.equal(planTests([], { graph, forceFull: true }).storageStress, false);
   for (const path of [
     'scripts/fixture-env.mjs',
     'scripts/ci-test-plan.test.mjs',
@@ -95,6 +106,7 @@ test('global and unknown production changes fail safe to the complete suite', ()
     assert.equal(plan.full, true);
     assert.equal(plan.e2e, true);
     assert.equal(plan.storybook, true);
+    assert.equal(plan.storageStress, false);
     assert.deepEqual(plan.workspaces, graph.dirs);
   }
 });


### PR DESCRIPTION
## Summary
- stop rerunning the full workspace suite after every main merge; route the exact push delta through the existing impact planner
- remove 9 real-process Git crash probes and 3 native root-lock probes from default runs
- retain those recovery matrices when their owning storage surfaces change

## Review
- preserves security, corruption, ownership, symlink, protocol, and failure-path coverage
- falls back to the full suite when push history is unavailable or test-planning infrastructure changes

## Verification
- lint, format, build:test, typecheck, script tests passed
- storage default suite passed; gated Git stress matrix passed
- all workspace suites passed; runtime-host process suite passed in isolated rerun after high-load timeout