### PR TITLE
fix(runtime): tell a refused Automation pause/resume which cause stopped it

### DIFF
--- a/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
@@ -43,6 +43,17 @@ const CONNECTION_CONTEXT: ConnectionContext = {
 const ASYNC_STATE_TIMEOUT_MS = 5_000;
 const ASYNC_STATE_POLL_MS = 5;
 
+function modelToolContext(sessionId = 'creator-session'): MakaToolContext {
+  return {
+    sessionId,
+    turnId: 'turn-model',
+    cwd: '/workspace',
+    toolCallId: 'tool-model',
+    abortSignal: new AbortController().signal,
+    emitOutput: () => {},
+  };
+}
+
 describe('Host Automation coordinator', () => {
   test('atomically admits one heartbeat fire and settles the same durable Run identity', async () => {
     await withHarness(async (harness) => {
@@ -463,6 +474,75 @@ describe('Host Automation coordinator', () => {
         'durable fire to settle',
         async () => (await harness.store.read()).pendingFires.length === 0,
       );
+    });
+  });
+
+  test('a Session that can no longer mutate is not reported to the model as a wrong status', async () => {
+    await withHarness(async (harness) => {
+      await harness.coordinator.prepareRecovery();
+      await harness.coordinator.recover();
+      harness.coordinator.start();
+      const durables: AutomationDefinition[] = [];
+      for (const name of ['nightly digest', 'weekly digest']) {
+        const created = await harness.coordinator.create({
+          kind: 'cron',
+          name,
+          prompt: 'Summarize the workspace.',
+          sessionId: 'creator-session',
+          schedule: { type: 'interval', seconds: 60 },
+          durable: true,
+        });
+        assert.ok(!('error' in created));
+        if ('error' in created) return;
+        durables.push(created);
+      }
+      const [toPause, toResume] = durables;
+      assert.ok(toPause && toResume);
+      // Its fire budget is untouched, so nothing about it is spent.
+      assert.ok(await harness.coordinator.pause(toResume.id, 'creator-session'));
+
+      // Retirement fences mutations only. Both automations keep the status the
+      // verb they are about to be asked for requires, and both stay visible.
+      const retirement = await harness.coordinator.beginSessionRetirement(['creator-session']);
+      try {
+        assert.equal(
+          (await harness.coordinator.get(toPause.id, 'creator-session'))?.status,
+          'active',
+        );
+        assert.equal(
+          (await harness.coordinator.get(toResume.id, 'creator-session'))?.status,
+          'paused',
+        );
+
+        const refusedPause = (await harness.coordinator.modelTool.impl(
+          { mode: 'pause', id: toPause.id },
+          modelToolContext(),
+        )) as string;
+        assert.match(refusedPause, /it is active/);
+        // The status admits pause, so the status is not what refused.
+        assert.doesNotMatch(refusedPause, /only an active automation can be paused/);
+        assert.match(refusedPause, /mode "list"/);
+
+        const refusedResume = (await harness.coordinator.modelTool.impl(
+          { mode: 'resume', id: toResume.id },
+          modelToolContext(),
+        )) as string;
+        assert.match(refusedResume, /it is paused/);
+        // The old wording called an automation with an intact budget spent, and
+        // sent the model to create — which passes through this same gate.
+        assert.doesNotMatch(refusedResume, /can no longer fire/);
+        assert.doesNotMatch(refusedResume, /Create a new automation instead/);
+        assert.match(refusedResume, /mode "list"/);
+
+        // mode "list" reads state, so it is a next step this gate still allows.
+        const listed = (await harness.coordinator.modelTool.impl(
+          { mode: 'list' },
+          modelToolContext(),
+        )) as string;
+        assert.match(listed, /nightly digest/);
+      } finally {
+        retirement.rollback();
+      }
     });
   });
 

--- a/packages/runtime/src/__tests__/automation-integration.test.ts
+++ b/packages/runtime/src/__tests__/automation-integration.test.ts
@@ -1,8 +1,10 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { AutomationManager } from '../automation-state.js';
+import type { AutomationDefinition } from '../automation-state.js';
 import { AutomationScheduler } from '../automation-scheduler.js';
-import { buildAutomationTool } from '../automation-tools.js';
+import { buildAutomationTool, buildAutomationAuthorityTool } from '../automation-tools.js';
+import type { AutomationToolAuthority } from '../automation-tools.js';
 import type { MakaToolContext } from '../tool-runtime.js';
 
 const SESSION_ID = 'integration-sess-1';
@@ -566,5 +568,58 @@ describe('Automation integration: a refused pause/resume says which cause stoppe
     const paused = (await t.tool.impl({ mode: 'pause', id }, t.ctx())) as string;
     assert.match(paused, /it is paused/);
     assert.match(paused, /only an active automation can be paused/);
+  });
+
+  test('an authority that refuses a status it accepts is not blamed on the status', async () => {
+    // The host coordinator collapses a retiring or archived Session into the
+    // same empty result a wrong status produces, while its get() still reports
+    // an automation whose status admits the verb. Blaming the status there
+    // states a verdict nothing checked, and sending the model to create runs it
+    // into the same Session gate a second time.
+    const definition: AutomationDefinition = {
+      id: 'auto-7',
+      kind: 'cron',
+      name: 'nightly digest',
+      prompt: 'digest',
+      sessionId: SESSION_ID,
+      schedule: { type: 'interval', seconds: 60 },
+      status: 'active',
+      createdAt: 0,
+      updatedAt: 0,
+      nextFireAt: 60_000,
+      lastFireAt: null,
+      lastRunId: null,
+      fireCount: 0,
+      maxFires: null,
+      expiresAt: null,
+      durable: true,
+      consecutiveFailures: 0,
+      lastError: null,
+    };
+    const authority: AutomationToolAuthority = {
+      create: async () => ({ error: 'Session lifecycle is changing' }),
+      delete: async () => false,
+      // Every mutation is refused the way the host refuses one for a Session
+      // that can no longer mutate: an empty result carrying no cause.
+      pause: async () => undefined,
+      resume: async () => undefined,
+      get: async () => definition,
+      listVisibleForSession: async () => [definition],
+    };
+    const tool = buildAutomationAuthorityTool({ authority, cronEnabled: true });
+
+    const paused = (await tool.impl({ mode: 'pause', id: 'auto-7' }, createContext())) as string;
+    assert.match(paused, /it is active/);
+    assert.doesNotMatch(paused, /only an active automation can be paused/);
+    assert.match(paused, /mode "list"/);
+
+    definition.status = 'paused';
+    const resumed = (await tool.impl({ mode: 'resume', id: 'auto-7' }, createContext())) as string;
+    assert.match(resumed, /it is paused/);
+    // Both halves of the old sentence were false here, and the next step it
+    // named goes through the same Session gate that just refused.
+    assert.doesNotMatch(resumed, /can no longer fire/);
+    assert.doesNotMatch(resumed, /Create a new automation instead/);
+    assert.match(resumed, /mode "list"/);
   });
 });

--- a/packages/runtime/src/__tests__/automation-integration.test.ts
+++ b/packages/runtime/src/__tests__/automation-integration.test.ts
@@ -518,3 +518,53 @@ describe('Automation integration: cron gating by host capability', () => {
     assert.equal(schema.safeParse({ ...input, prompt: '提'.repeat(2_001) }).success, false);
   });
 });
+
+describe('Automation integration: a refused pause/resume says which cause stopped it', () => {
+  function createFor(t: ReturnType<typeof createIntegrationSetup>, sessionId: string): string {
+    const created = t.manager.create({
+      kind: 'heartbeat',
+      name: 'poller',
+      prompt: 'poll',
+      sessionId,
+      schedule: { type: 'interval', seconds: 30 },
+    });
+    if ('error' in created) throw new Error(created.error);
+    return created.id;
+  }
+
+  test('an unknown id says so, and points at the mode that lists the real ones', async () => {
+    for (const mode of ['pause', 'resume'] as const) {
+      const t = createIntegrationSetup();
+      const text = (await t.tool.impl({ mode, id: 'auto-404' }, t.ctx())) as string;
+      assert.match(text, /has no automation with that id/);
+      assert.match(text, /mode "list"/);
+      // The old sentence offered three causes and a next step for none of them.
+      assert.doesNotMatch(text, /not found, not owned/);
+    }
+  });
+
+  test("another session's automation reads the same way, because the recovery is the same", async () => {
+    const t = createIntegrationSetup();
+    const id = createFor(t, 'some-other-session');
+    const text = (await t.tool.impl({ mode: 'pause', id }, t.ctx())) as string;
+    assert.match(text, /has no automation with that id/);
+    assert.match(text, /mode "list"/);
+  });
+
+  test('a wrong-status automation reports the status it actually has', async () => {
+    const t = createIntegrationSetup();
+    const id = createFor(t, SESSION_ID);
+
+    // It is active, so resume is the wrong verb for it.
+    const resumed = (await t.tool.impl({ mode: 'resume', id }, t.ctx())) as string;
+    assert.match(resumed, /it is active/);
+    assert.match(resumed, /only a paused automation can be resumed/);
+    assert.doesNotMatch(resumed, /not found, not owned/);
+
+    // Once paused, pause becomes the wrong verb instead.
+    await t.tool.impl({ mode: 'pause', id }, t.ctx());
+    const paused = (await t.tool.impl({ mode: 'pause', id }, t.ctx())) as string;
+    assert.match(paused, /it is paused/);
+    assert.match(paused, /only an active automation can be paused/);
+  });
+});

--- a/packages/runtime/src/automation-tools.ts
+++ b/packages/runtime/src/automation-tools.ts
@@ -17,6 +17,7 @@ import {
   AUTOMATION_PROMPT_MAX_CODE_UNITS,
   isAutomationTextWithinLimit,
 } from '@maka/core/automation';
+import type { AutomationStatus } from '@maka/core/automation';
 import type { MakaTool } from './tool-runtime.js';
 import type { AutomationManager, AutomationDefinition } from './automation-state.js';
 
@@ -262,6 +263,25 @@ async function handleById(
 }
 
 /**
+ * What each status means for pause/resume, in one place.
+ *
+ * The two facts the refusal text needs — which verb the status admits, and
+ * whether the automation is past reviving — used to be hand-rolled literal
+ * comparisons, so a fifth AutomationStatus would have compiled clean and
+ * quietly told the model that a live automation was beyond repair. A total
+ * Record makes the compiler ask for the answer instead.
+ */
+const AUTOMATION_STATUS_FACTS: Record<
+  AutomationStatus,
+  { readonly admits: 'pause' | 'resume' | null; readonly terminal: boolean }
+> = {
+  active: { admits: 'pause', terminal: false },
+  paused: { admits: 'resume', terminal: false },
+  completed: { admits: null, terminal: true },
+  expired: { admits: null, terminal: true },
+};
+
+/**
  * Say what actually blocked pause/resume, and what to do about it.
  *
  * "not found, not owned, or not active" folds three independent causes into one
@@ -272,6 +292,15 @@ async function handleById(
  * The authority only exposes automations this session may manage, so a missing
  * id and another session's id are genuinely indistinguishable here and share
  * one message — but that message points at mode "list", which settles both.
+ *
+ * Status is the only cause this function can actually read. An authority may
+ * refuse for reasons that live outside the automation — the host coordinator
+ * turns a retiring or archived session into the same empty result as a
+ * wrong-status automation — and in that case the status on record still admits
+ * the verb. Saying "it is active, so it cannot be paused" there would be a
+ * verdict on something never checked, so that case says the cause was not
+ * reported rather than inventing one. Every branch lands on mode "list", which
+ * reads state and so survives the session conditions that refuse mutations.
  */
 async function explainManageFailure(
   authority: AutomationToolAuthority,
@@ -284,17 +313,15 @@ async function explainManageFailure(
   if (!existing) {
     return `Cannot ${verb} "${id}": this session has no automation with that id. ${listHint}`;
   }
+  const facts = AUTOMATION_STATUS_FACTS[existing.status];
+  if (facts.admits === verb) {
+    return `Cannot ${verb} "${id}": it is ${existing.status}, which is the status ${verb} needs, so its status is not what refused. The reason was not reported here. Use mode "list" to re-read its current state.`;
+  }
   if (verb === 'pause') {
     return `Cannot pause "${id}": it is ${existing.status}, and only an active automation can be paused.`;
   }
-  if (existing.status === 'paused') {
-    // resume() declined a paused automation whose fire budget the caller above
-    // found intact, so nothing the model can send will revive it.
-    return `Cannot resume "${id}": it is paused but can no longer fire. Create a new automation instead.`;
-  }
-  const terminal = existing.status === 'completed' || existing.status === 'expired';
   return `Cannot resume "${id}": it is ${existing.status}, and only a paused automation can be resumed.${
-    terminal ? ' Create a new automation instead.' : ''
+    facts.terminal ? ' Create a new automation instead.' : ''
   }`;
 }
 

--- a/packages/runtime/src/automation-tools.ts
+++ b/packages/runtime/src/automation-tools.ts
@@ -222,7 +222,7 @@ export function buildAutomationAuthorityTool(
             const r = await deps.authority.pause(id, ctx.sessionId);
             return r
               ? `Automation "${r.name}" paused. Use mode "resume" to reactivate.`
-              : `Cannot pause "${id}": not found, not owned, or not active.`;
+              : await explainManageFailure(deps.authority, id, ctx.sessionId, 'pause');
           });
           break;
         }
@@ -243,7 +243,7 @@ export function buildAutomationAuthorityTool(
                 return `Cannot resume "${id}": its fire budget is exhausted (fired ${existing.fireCount}${existing.maxFires != null ? `/${existing.maxFires}` : ''} time(s)). Create a new automation instead.`;
               }
             }
-            return `Cannot resume "${id}": not found, not owned, or not paused.`;
+            return await explainManageFailure(deps.authority, id, ctx.sessionId, 'resume');
           });
           break;
         }
@@ -259,6 +259,43 @@ async function handleById(
 ): Promise<string> {
   if (!input.id) return 'Error: "id" is required for delete/pause/resume.';
   return await run(input.id);
+}
+
+/**
+ * Say what actually blocked pause/resume, and what to do about it.
+ *
+ * "not found, not owned, or not active" folds three independent causes into one
+ * sentence and names a next action for none of them. Two of the three are
+ * answered by mode "list"; the third is a status the model can neither see nor
+ * change by sending the same call again, so it has to be said out loud.
+ *
+ * The authority only exposes automations this session may manage, so a missing
+ * id and another session's id are genuinely indistinguishable here and share
+ * one message — but that message points at mode "list", which settles both.
+ */
+async function explainManageFailure(
+  authority: AutomationToolAuthority,
+  id: string,
+  sessionId: string,
+  verb: 'pause' | 'resume',
+): Promise<string> {
+  const listHint = 'Use mode "list" to see the automations you can manage and their ids.';
+  const existing = await authority.get(id, sessionId);
+  if (!existing) {
+    return `Cannot ${verb} "${id}": this session has no automation with that id. ${listHint}`;
+  }
+  if (verb === 'pause') {
+    return `Cannot pause "${id}": it is ${existing.status}, and only an active automation can be paused.`;
+  }
+  if (existing.status === 'paused') {
+    // resume() declined a paused automation whose fire budget the caller above
+    // found intact, so nothing the model can send will revive it.
+    return `Cannot resume "${id}": it is paused but can no longer fire. Create a new automation instead.`;
+  }
+  const terminal = existing.status === 'completed' || existing.status === 'expired';
+  return `Cannot resume "${id}": it is ${existing.status}, and only a paused automation can be resumed.${
+    terminal ? ' Create a new automation instead.' : ''
+  }`;
 }
 
 async function handleCreate(


### PR DESCRIPTION
When the Automation tool refuses a pause or a resume, it currently answers with "Cannot pause \"id\": not found, not owned, or not active." That sentence lists three independent causes and gives a next action for none of them. Two of the three (the id does not exist, the id belongs to another session) are settled by looking at mode "list". The third is a status the model cannot see from where it stands and cannot change by sending the same call again, so it retries, and the retry fails identically.

This splits the message along the line the tool can actually draw. The authority only exposes automations this session may manage, so a missing id and another session's id really are indistinguishable at this layer; they share one message, and that message points at mode "list", which settles both. When the automation is there and manageable, the refusal names the status it has and the status the verb needs — "it is active, and only a paused automation can be resumed" — and adds "Create a new automation instead" when the status is terminal.

The exhausted-fire-budget branch above this is unchanged; it already said something specific and stays as it is. The delete path is unchanged too.

How to tell it works: three tests in packages/runtime/src/__tests__/automation-integration.test.ts drive the real tool against a real AutomationManager. One asks to pause and to resume an id that does not exist, one asks to pause an automation created under a different session id, and one asks for the wrong verb twice — resume on an active automation, then pause on the same one after pausing it. Each asserts on what the model can act on (the phrase "mode \"list\"", or the status word) and asserts the old three-way sentence is gone.