### PR TITLE
fix(core): let a Claude the generated table has not heard of still read images

### DIFF
--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -18,12 +18,66 @@ describe('model-metadata vision capability', () => {
     assert.equal(resolveModelVisionSupport('anthropic', undefined, 'claude-fable-1'), true);
   });
 
-  it('does not guess for other providers, and yields to what a connection reports', () => {
+  it('treats a Claude older than the generated snapshot the same way', () => {
+    // Before Claude 4 the version came first and the family sat behind it.
+    // None of these is in the generated table, all of them read images, and
+    // this is the shape a person is most likely to pin by hand.
+    for (const id of [
+      'claude-3-5-sonnet-20241022',
+      'claude-3-7-sonnet-20250219',
+      'claude-3-opus-20240229',
+      'claude-3-5-haiku-20241022',
+    ]) {
+      assert.deepEqual(lookupModelMetadata('anthropic', id), {}, id);
+      assert.equal(resolveModelVisionSupport('anthropic', undefined, id), true, id);
+    }
+  });
+
+  it('still fails closed for the Claude generation that cannot read images', () => {
+    // claude-2.x and claude-instant carry no family segment, so widening the
+    // default to the pre-4 id shape must not reach them.
+    for (const id of ['claude-2.1', 'claude-2.0', 'claude-instant-1.2']) {
+      assert.equal(resolveModelVisionSupport('anthropic', undefined, id), false, id);
+    }
+  });
+
+  it('extends the default to the subscription path, which fetches the same models', () => {
+    // claude-subscription reaches Anthropic's own models over the same
+    // protocol and stores the same bare { id } entries, and it is usually
+    // where a new Claude becomes usable first.
+    assert.deepEqual(lookupModelMetadata('claude-subscription', 'claude-opus-5'), {});
+    assert.equal(
+      resolveModelVisionSupport('claude-subscription', undefined, 'claude-opus-5'),
+      true,
+    );
+    assert.equal(
+      resolveModelVisionSupport('claude-subscription', undefined, 'claude-3-opus-20240229'),
+      true,
+    );
+  });
+
+  it('confines the default to the providers that serve Anthropic their own models', () => {
+    // A claude-prefixed id on somebody else's provider says nothing about what
+    // is actually behind it, so the default must not travel with the id.
+    for (const providerType of [
+      'openrouter',
+      'anthropic-compatible',
+      'kimi-coding-plan',
+    ] satisfies ProviderType[]) {
+      assert.equal(
+        resolveModelVisionSupport(providerType, undefined, 'claude-opus-5'),
+        false,
+        providerType,
+      );
+    }
     assert.equal(resolveModelVisionSupport('openai', undefined, 'some-unlisted-model'), false);
-    // A connection that declares the capability wins over the default, in both
-    // directions.
-    const declared: ModelInfo[] = [{ id: 'claude-opus-5', capabilities: { vision: false } }];
-    assert.equal(resolveModelVisionSupport('anthropic', declared, 'claude-opus-5'), false);
+  });
+
+  it('yields to what a connection reports, in both directions', () => {
+    const denied: ModelInfo[] = [{ id: 'claude-opus-5', capabilities: { vision: false } }];
+    assert.equal(resolveModelVisionSupport('anthropic', denied, 'claude-opus-5'), false);
+    const granted: ModelInfo[] = [{ id: 'some-unlisted-model', capabilities: { vision: true } }];
+    assert.equal(resolveModelVisionSupport('openai', granted, 'some-unlisted-model'), true);
   });
 
   it('publishes the Kimi K3 Coding Plan limits and sole supported effort', () => {

--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -8,6 +8,24 @@ import {
 import { PROVIDER_DEFAULTS, type ModelInfo, type ProviderType } from '../llm-connections.js';
 
 describe('model-metadata vision capability', () => {
+  it('treats a Claude newer than the generated snapshot as able to read images', () => {
+    // The generated table is a snapshot of models.dev, so a Claude released
+    // after it is absent from the table rather than listed as text-only.
+    // Resolving absent to "no vision" silently drops the user's attachment and
+    // turns an image tool result into a sentence about the model.
+    assert.deepEqual(lookupModelMetadata('anthropic', 'claude-opus-5'), {});
+    assert.equal(resolveModelVisionSupport('anthropic', undefined, 'claude-opus-5'), true);
+    assert.equal(resolveModelVisionSupport('anthropic', undefined, 'claude-fable-1'), true);
+  });
+
+  it('does not guess for other providers, and yields to what a connection reports', () => {
+    assert.equal(resolveModelVisionSupport('openai', undefined, 'some-unlisted-model'), false);
+    // A connection that declares the capability wins over the default, in both
+    // directions.
+    const declared: ModelInfo[] = [{ id: 'claude-opus-5', capabilities: { vision: false } }];
+    assert.equal(resolveModelVisionSupport('anthropic', declared, 'claude-opus-5'), false);
+  });
+
   it('publishes the Kimi K3 Coding Plan limits and sole supported effort', () => {
     assert.deepEqual(lookupModelMetadata('kimi-coding-plan', 'k3'), {
       displayName: 'Kimi K3',

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -86,17 +86,6 @@ export function openAiAdapterApiProtocol(
 }
 
 /**
- * Resolve whether a model accepts image input for the send path.
- *
- * Stored `connection.models` win when they declare `vision` explicitly
- * (provider-fetched facts). But `model-fetcher` stores bare `{ id }` entries
- * for many providers, and older connections predate any enrichment — so when
- * `vision` is unknown we fall back to the generated models.dev snapshot and
- * access-path-specific in-repo overrides. Unknown (no stored value, no
- * metadata entry) resolves to false,
- * keeping the send path fail-closed for text-only models.
- */
-/**
  * Anthropic model families whose every member reads images.
  *
  * The generated table is a snapshot of models.dev, so a Claude released after
@@ -112,10 +101,58 @@ export function openAiAdapterApiProtocol(
  * to a sentence, with nothing on screen to explain why, until someone
  * regenerates the table.
  *
+ * Anthropic has used two id shapes, and both have to match. From Claude 4 on
+ * the family comes first (`claude-opus-5`); before that the version came first
+ * and the family sat behind it (`claude-3-5-sonnet-20241022`,
+ * `claude-3-opus-20240229`). The pre-4 ids are the ones most likely to be
+ * pinned by hand, none of them is in the generated table, and all of them read
+ * images — so `(?:[\d.]+-)*` skips any leading version segments before the
+ * family name.
+ *
+ * What must keep missing is the generation that genuinely cannot read images:
+ * `claude-2.1`, `claude-2.0` and `claude-instant-*` have no family segment at
+ * all, so they never reach the alternation.
+ *
  * A connection that reports `vision` still wins over this, in both directions.
  */
-const VISION_BY_DEFAULT = /^claude-(?:opus|sonnet|haiku|fable)\b/;
+const VISION_BY_DEFAULT = /^claude-(?:[\d.]+-)*(?:opus|sonnet|haiku|fable)\b/;
 
+/**
+ * The providers whose bare `claude-*` ids are Anthropic's own models.
+ *
+ * Both fetch over the Anthropic protocol and both store the bare `{ id }`
+ * entries that leave `vision` unknown, and `claude-subscription` is usually
+ * where a new Claude becomes usable first — it is the same table of models
+ * reached through a subscription instead of an API key.
+ *
+ * Deliberately narrower than "speaks the Anthropic protocol". `anthropic`
+ * and `claude-subscription` are the only two whose base URL is Anthropic's own;
+ * `anthropic-compatible`, `kimi-coding-plan` and `minimax-coding-plan` share
+ * the wire format while serving somebody else's models, and a `claude-`
+ * prefixed id there says nothing about what is behind it. The same goes for
+ * aggregators like OpenRouter, which do serve Claude but under ids the
+ * generated table already carries.
+ */
+const VISION_BY_DEFAULT_PROVIDERS: ReadonlySet<ProviderType> = new Set<ProviderType>([
+  'anthropic',
+  'claude-subscription',
+]);
+
+/**
+ * Resolve whether a model accepts image input for the send path.
+ *
+ * Stored `connection.models` win when they declare `vision` explicitly
+ * (provider-fetched facts). But `model-fetcher` stores bare `{ id }` entries
+ * for many providers, and older connections predate any enrichment — so when
+ * `vision` is unknown we fall back to the generated models.dev snapshot and
+ * access-path-specific in-repo overrides.
+ *
+ * Unknown then resolves to false — the send path stays fail-closed for
+ * text-only models — with one exception: an unlisted Claude on one of
+ * Anthropic's own providers resolves to true, because there absent means
+ * "newer than the snapshot" rather than "text-only". See
+ * {@link VISION_BY_DEFAULT}.
+ */
 export function resolveModelVisionSupport(
   providerType: ProviderType,
   models: readonly ModelInfo[] | undefined,
@@ -129,7 +166,7 @@ export function resolveModelVisionSupport(
   if (metadata.capabilities?.vision !== undefined) {
     return metadata.capabilities.vision === true;
   }
-  return providerType === 'anthropic' && VISION_BY_DEFAULT.test(modelId.trim());
+  return VISION_BY_DEFAULT_PROVIDERS.has(providerType) && VISION_BY_DEFAULT.test(modelId.trim());
 }
 
 export function curatedCatalogFallbackModelsForProvider(

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -96,6 +96,26 @@ export function openAiAdapterApiProtocol(
  * metadata entry) resolves to false,
  * keeping the send path fail-closed for text-only models.
  */
+/**
+ * Anthropic model families whose every member reads images.
+ *
+ * The generated table is a snapshot of models.dev, so a Claude released after
+ * that snapshot is simply absent from it — `lookupModelMetadata('anthropic',
+ * 'claude-opus-5')` returns `{}` today. Absent used to resolve to "no vision",
+ * which is the wrong default for this provider: every Claude in these families
+ * accepts image input, and the fail-closed rule was written for text-only
+ * models, not for models nobody has listed yet.
+ *
+ * The two mistakes are not symmetrical. Sending an image to a Claude that
+ * turned out not to read it costs one turn and produces a message. Withholding
+ * it silently drops the user's attachment and downgrades an image tool result
+ * to a sentence, with nothing on screen to explain why, until someone
+ * regenerates the table.
+ *
+ * A connection that reports `vision` still wins over this, in both directions.
+ */
+const VISION_BY_DEFAULT = /^claude-(?:opus|sonnet|haiku|fable)\b/;
+
 export function resolveModelVisionSupport(
   providerType: ProviderType,
   models: readonly ModelInfo[] | undefined,
@@ -105,7 +125,11 @@ export function resolveModelVisionSupport(
   if (stored?.capabilities?.vision !== undefined) {
     return stored.capabilities.vision === true;
   }
-  return lookupModelMetadata(providerType, modelId).capabilities?.vision === true;
+  const metadata = lookupModelMetadata(providerType, modelId);
+  if (metadata.capabilities?.vision !== undefined) {
+    return metadata.capabilities.vision === true;
+  }
+  return providerType === 'anthropic' && VISION_BY_DEFAULT.test(modelId.trim());
 }
 
 export function curatedCatalogFallbackModelsForProvider(


### PR DESCRIPTION
resolveModelVisionSupport asks the connection first, then the generated models.dev table, and answers false when neither knows. That fail-closed rule was written for text-only models, but it also catches a model the table has simply not been regenerated for yet. On main today, lookupModelMetadata("anthropic", "claude-opus-5") returns {} and resolveModelVisionSupport returns false for it.

What the user sees when that happens: an image attached to the message is replaced by the non-vision fallback notice instead of being sent, and an image returned by a tool becomes the text "Image was read, but the selected model does not support image input." (both in packages/runtime/src/ai-sdk-backend.ts). Nothing on screen attributes this to a stale table, so it reads as the model lacking a capability it has, and it comes back every time a new Claude ships ahead of the snapshot.

The change defaults the Anthropic opus, sonnet, haiku and fable families to vision when neither the connection nor the table has an opinion. It is deliberately narrow: it is scoped to providerType "anthropic", it is only consulted after both explicit sources come back undefined, and an explicit value from either still wins in both directions. No other provider gains a default.

The asymmetry is the argument for it. Guessing yes and being wrong costs one turn and produces a provider error. Guessing no and being wrong silently discards the user's attachment.

How to tell it works: two tests in packages/core/src/__tests__/model-metadata.test.ts. The first pins that the generated table really returns {} for claude-opus-5 (so the test is exercising the unknown path, not a listed entry) and that vision now resolves true for it. The second holds the blast radius down: an unlisted OpenAI model still resolves false, and a connection that declares vision: false for claude-opus-5 still wins.