### PR TITLE
feat(inspector): project a per-session causal trace over both ledgers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
     "./model-call-attempt": "./dist/model-call-attempt.js",
     "./model-call-usage-projection": "./dist/model-call-usage-projection.js",
     "./usage-ledger-merge": "./dist/usage-ledger-merge.js",
+    "./session-trace": "./dist/session-trace.js",
     "./shell-run": "./dist/shell-run.js",
     "./shell-run-result": "./dist/shell-run-result.js",
     "./browser": "./dist/browser.js",

--- a/packages/core/src/session-trace.ts
+++ b/packages/core/src/session-trace.ts
@@ -83,6 +83,18 @@ export interface TraceModelCallStep {
   costUsd?: number;
 }
 
+/**
+ * A durable recovery decision, correlated to a dispatch by `operationId`.
+ *
+ * Separate from the policy below because they answer different questions. Every
+ * dispatch declares a `recoveryPolicy`, including ordinary first executions;
+ * only a recovery that actually happened writes one of these.
+ */
+export interface TraceToolRecovery {
+  disposition: 'completed' | 'parked';
+  reasonCode: string;
+}
+
 export interface TraceToolStep {
   kind: 'tool';
   id: string;
@@ -93,9 +105,16 @@ export interface TraceToolStep {
   durationMs?: number;
   toolName: string;
   toolCallId?: string;
+  operationId?: string;
   status: 'completed' | 'failed' | 'in_flight';
-  /** Present when the dispatch was recovered rather than executed fresh. */
-  recoveryMode?: string;
+  /**
+   * What the dispatch declared it would be safe to do on resume. Present on
+   * normal executions too — it is a policy, not evidence that anything was
+   * recovered.
+   */
+  recoveryPolicy?: string;
+  /** Present only when a recovery decision was durably recorded. */
+  recovered?: TraceToolRecovery;
 }
 
 export interface TracePermissionStep {
@@ -108,14 +127,22 @@ export interface TracePermissionStep {
   decision: string;
 }
 
+/**
+ * A compaction boundary that was durably written — the checkpoint the next
+ * request replays from.
+ *
+ * Distinct from a `history_compact` model call, which is the summarizer request
+ * that produced the text. One is the spend, the other is the boundary; a turn
+ * can show either without the other.
+ */
 export interface TraceCompactionStep {
   kind: 'compaction';
   id: string;
   turnId: string;
   runId: string;
   startedAt: number;
-  /** Which compaction wrote here, when the trace can tell them apart. */
-  compactionKind?: Extract<ModelCallKind, 'history_compact' | 'semantic_compact'>;
+  /** Checkpoint identity, when the boundary carries one. */
+  checkpointId?: string;
 }
 
 export interface TraceErrorStep {
@@ -188,15 +215,24 @@ export interface TurnTrace {
  */
 export interface SessionTraceCoverage {
   /**
-   * `complete` — every turn with model activity has canonical records.
-   * `partial` — some turns have them and some do not.
-   * `absent` — the session has model activity but no canonical records at all,
-   * which is what a backend outside canonical accounting looks like.
+   * `no_known_gap` — nothing detectable is missing. Deliberately not
+   * "complete": present settlements cannot prove that every call settled, so
+   * this states the absence of evidence of a gap, not the presence of proof.
+   * `partial` — a shortfall is detectable, either a turn with aggregate usage
+   * and no records, or fewer main calls than the aggregate says it stood for.
+   * `absent` — model activity with no canonical records anywhere, which is what
+   * a backend outside canonical accounting looks like.
    * `none` — no model activity to cover.
    */
-  modelCalls: 'complete' | 'partial' | 'absent' | 'none';
+  modelCalls: 'no_known_gap' | 'partial' | 'absent' | 'none';
   /** Turn ids with aggregate usage but no canonical record behind it. */
   turnsMissingModelCalls: string[];
+  /**
+   * Turn ids where the aggregate usage stands for more runtime steps than there
+   * are main model calls on record. A shortfall this narrow is still only what
+   * the ledgers disagree about — it is a floor on what is missing, not a count.
+   */
+  turnsWithFewerModelCallsThanSteps: string[];
 }
 
 export interface SessionTrace {

--- a/packages/core/src/session-trace.ts
+++ b/packages/core/src/session-trace.ts
@@ -1,0 +1,244 @@
+import type { ModelCallAttemptStatus, ModelCallKind } from './model-call-attempt.js';
+
+/**
+ * Per-session causal trace: what happened inside a session's runs, in order,
+ * with the cost and latency of the model calls that drove it (#1625).
+ *
+ * This is a **projection, not a record**. Two authorities feed it and neither is
+ * restated here:
+ *
+ * - `RuntimeEvent` supplies causal structure — tool dispatch, permission
+ *   decisions, errors, the shape of a turn.
+ * - `ModelCallAttempt` supplies metering — one record per physical provider
+ *   request, with the cost frozen at call time (#1679).
+ *
+ * The projection joins them and reports what it could not see. It never derives
+ * a number the ledgers do not carry: an unpriced call has no cost here either,
+ * and a backend that emits no canonical records produces a trace that says so
+ * rather than one that looks idle.
+ */
+export const SESSION_TRACE_SCHEMA_VERSION = 1 as const;
+
+/**
+ * Why a step exists. Deliberately not the RuntimeEvent content kind: this is the
+ * causal vocabulary a reader thinks in ("the model called a tool, the tool
+ * failed, the context compacted"), which is a projection of several event
+ * shapes rather than a rename of one.
+ */
+export type TraceStepKind = 'model_call' | 'tool' | 'permission' | 'compaction' | 'error';
+
+/** One physical provider request, as metered. */
+export interface TraceModelAttempt {
+  attemptId: string;
+  /** Retry ordinal within the logical call; 0 is the first dispatch. */
+  attempt: number;
+  status: ModelCallAttemptStatus;
+  startedAt: number;
+  completedAt: number;
+  latencyMs: number;
+  timeToFirstTokenMs?: number;
+  finishReason?: string;
+  errorClass?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadInputTokens?: number;
+  reasoningTokens?: number;
+  /**
+   * Absent when the record carries no price. Never rendered as zero: a call
+   * nobody could price and a call that was free are different facts, and the
+   * canonical record keeps them apart (#1679).
+   */
+  costUsd?: number;
+  /** Whether the amount above is real, and if not, why there isn't one. */
+  costBasis: 'priced' | 'unpriced';
+  /** Whether the tokens above were reported by the provider or are partial. */
+  usageBasis: 'reported' | 'partial' | 'missing';
+}
+
+/**
+ * One logical model call and every attempt of it.
+ *
+ * Retries are nested rather than flattened because "this call was retried three
+ * times" is the fact a reader is looking for; a flat list of four steps that
+ * happen to share an id makes them reconstruct it.
+ */
+export interface TraceModelCallStep {
+  kind: 'model_call';
+  id: string;
+  turnId: string;
+  runId: string;
+  startedAt: number;
+  endedAt: number;
+  durationMs: number;
+  callKind: ModelCallKind;
+  providerId: string;
+  modelId: string;
+  connectionSlug?: string;
+  /** Runtime tool-loop step index within the turn. */
+  step: number;
+  attempts: TraceModelAttempt[];
+  /** Terminal status of the last attempt. */
+  status: ModelCallAttemptStatus;
+  /** Sum over attempts that carry a price; absent when none do. */
+  costUsd?: number;
+}
+
+export interface TraceToolStep {
+  kind: 'tool';
+  id: string;
+  turnId: string;
+  runId: string;
+  startedAt: number;
+  endedAt?: number;
+  durationMs?: number;
+  toolName: string;
+  toolCallId?: string;
+  status: 'completed' | 'failed' | 'in_flight';
+  /** Present when the dispatch was recovered rather than executed fresh. */
+  recoveryMode?: string;
+}
+
+export interface TracePermissionStep {
+  kind: 'permission';
+  id: string;
+  turnId: string;
+  runId: string;
+  startedAt: number;
+  toolName?: string;
+  decision: string;
+}
+
+export interface TraceCompactionStep {
+  kind: 'compaction';
+  id: string;
+  turnId: string;
+  runId: string;
+  startedAt: number;
+  /** Which compaction wrote here, when the trace can tell them apart. */
+  compactionKind?: Extract<ModelCallKind, 'history_compact' | 'semantic_compact'>;
+}
+
+export interface TraceErrorStep {
+  kind: 'error';
+  id: string;
+  turnId: string;
+  runId: string;
+  startedAt: number;
+  message: string;
+}
+
+export type TraceStep =
+  | TraceModelCallStep
+  | TraceToolStep
+  | TracePermissionStep
+  | TraceCompactionStep
+  | TraceErrorStep;
+
+/**
+ * What ended a turn badly, and what the trace believes caused it.
+ *
+ * `attributedToStepId` is a claim about *sequence*, not about intent: the step
+ * that failed first. The projection does not diagnose; it points at evidence.
+ */
+export interface TraceFailureAttribution {
+  code: string;
+  message?: string;
+  attributedToStepId?: string;
+}
+
+export interface TraceTotals {
+  durationMs: number;
+  /** Physical provider requests, retries included. */
+  modelAttempts: number;
+  /** Attempts beyond the first of their logical call. */
+  retries: number;
+  compactions: number;
+  inputTokens: number;
+  outputTokens: number;
+  /**
+   * Summed over priced records only, and absent when none were priced.
+   *
+   * Same authority as Settings → Usage, read at a different scope: both sum
+   * `ModelCallAttempt`. A total here that disagreed with that surface would be
+   * a bug in one of them, not two defensible numbers (#1679).
+   */
+  costUsd?: number;
+  /** Records that carried no price, and are therefore absent from `costUsd`. */
+  unpricedAttempts: number;
+}
+
+export interface TurnTrace {
+  turnId: string;
+  runId: string;
+  startedAt: number;
+  endedAt: number;
+  durationMs: number;
+  steps: TraceStep[];
+  totals: TraceTotals;
+  failure?: TraceFailureAttribution;
+}
+
+/**
+ * What the trace could not see.
+ *
+ * Stated per session rather than inferred per view, because incompleteness that
+ * only shows as an empty timeline is indistinguishable from an idle session —
+ * and the pi backend produces exactly that: `token_usage` events with no
+ * canonical records behind them.
+ */
+export interface SessionTraceCoverage {
+  /**
+   * `complete` — every turn with model activity has canonical records.
+   * `partial` — some turns have them and some do not.
+   * `absent` — the session has model activity but no canonical records at all,
+   * which is what a backend outside canonical accounting looks like.
+   * `none` — no model activity to cover.
+   */
+  modelCalls: 'complete' | 'partial' | 'absent' | 'none';
+  /** Turn ids with aggregate usage but no canonical record behind it. */
+  turnsMissingModelCalls: string[];
+}
+
+export interface SessionTrace {
+  schemaVersion: typeof SESSION_TRACE_SCHEMA_VERSION;
+  sessionId: string;
+  turns: TurnTrace[];
+  totals: TraceTotals;
+  coverage: SessionTraceCoverage;
+}
+
+/** Empty totals, so callers fold rather than special-case the first element. */
+export function emptyTraceTotals(): TraceTotals {
+  return {
+    durationMs: 0,
+    modelAttempts: 0,
+    retries: 0,
+    compactions: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    unpricedAttempts: 0,
+  };
+}
+
+/**
+ * Folds one set of totals into another.
+ *
+ * `costUsd` stays absent until something priced arrives, so a session of
+ * entirely unpriced calls totals to "no price", not to zero.
+ */
+export function mergeTraceTotals(base: TraceTotals, next: TraceTotals): TraceTotals {
+  const costUsd =
+    base.costUsd === undefined && next.costUsd === undefined
+      ? undefined
+      : (base.costUsd ?? 0) + (next.costUsd ?? 0);
+  return {
+    durationMs: base.durationMs + next.durationMs,
+    modelAttempts: base.modelAttempts + next.modelAttempts,
+    retries: base.retries + next.retries,
+    compactions: base.compactions + next.compactions,
+    inputTokens: base.inputTokens + next.inputTokens,
+    outputTokens: base.outputTokens + next.outputTokens,
+    unpricedAttempts: base.unpricedAttempts + next.unpricedAttempts,
+    ...(costUsd !== undefined ? { costUsd } : {}),
+  };
+}

--- a/packages/runtime/src/__tests__/session-trace-projection.test.ts
+++ b/packages/runtime/src/__tests__/session-trace-projection.test.ts
@@ -288,4 +288,223 @@ describe('session trace projection', () => {
     assert.equal(steps[0]?.kind, 'model_call');
     assert.equal(trace.turns[0]?.failure, undefined);
   });
+  test('collapses a re-appended settlement instead of inventing a retry', () => {
+    // A provisional abort and its later settlement are appended under one
+    // `attemptId`. The ledger dedupes on write; a stream read does not, so
+    // without collapsing them the trace shows a retry that never happened and
+    // bills the priced settlement twice.
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [],
+      modelCallAttempts: [
+        attempt({ attemptId: 'a-0', status: 'aborted', costUsd: undefined, costBasis: 'unpriced' }),
+        attempt({ attemptId: 'a-0', status: 'completed', costUsd: 0.002 }),
+      ],
+    });
+
+    const call = trace.turns[0]!.steps[0]!;
+    assert.equal(call.kind, 'model_call');
+    if (call.kind !== 'model_call') return;
+    assert.equal(call.attempts.length, 1, 'one attempt id is one attempt');
+    assert.equal(call.status, 'completed', 'the later settlement wins');
+    assert.equal(trace.totals.retries, 0);
+    assert.equal(trace.totals.costUsd, 0.002, 'not double-counted against Settings → Usage');
+    assert.equal(trace.totals.unpricedAttempts, 0);
+  });
+
+  test('reports a shortfall when usage stands for more steps than there are calls', () => {
+    // `runtimeSteps` says how many tool-loop steps one aggregate usage event
+    // represents, and each is a main call. Fewer on record is a gap the two
+    // ledgers disagree about — a floor on what is missing, not a count.
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'usage-1',
+          ts: 2_000,
+          actions: { tokenUsage: { input: 100, output: 20, total: 120, runtimeSteps: 2 } },
+        }),
+      ],
+      modelCallAttempts: [attempt()],
+    });
+
+    assert.equal(trace.coverage.modelCalls, 'partial');
+    assert.deepEqual(trace.coverage.turnsWithFewerModelCallsThanSteps, ['turn-1']);
+    assert.deepEqual(trace.coverage.turnsMissingModelCalls, []);
+  });
+
+  test('a matching turn is reported as no known gap rather than as proven complete', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'usage-1',
+          ts: 2_000,
+          actions: { tokenUsage: { input: 100, output: 20, total: 120, runtimeSteps: 1 } },
+        }),
+      ],
+      modelCallAttempts: [attempt()],
+    });
+
+    assert.equal(trace.coverage.modelCalls, 'no_known_gap');
+    assert.deepEqual(trace.coverage.turnsWithFewerModelCallsThanSteps, []);
+  });
+
+  test('a turn with no projected steps still has finite bounds', () => {
+    // Usage-only and text-only turns project nothing. Folding an empty list
+    // gives ±Infinity, which JSON serializes to null — a turn that renders as
+    // having no time at all.
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({ id: 'text-1', ts: 1_000, content: { kind: 'text', text: 'hello' } }),
+        event({
+          id: 'usage-1',
+          ts: 2_500,
+          actions: { tokenUsage: { input: 10, output: 2, total: 12 } },
+        }),
+      ],
+      modelCallAttempts: [],
+    });
+
+    const turn = trace.turns[0]!;
+    assert.equal(turn.steps.length, 0);
+    assert.equal(Number.isFinite(turn.startedAt), true);
+    assert.equal(Number.isFinite(turn.endedAt), true);
+    assert.equal(turn.startedAt, 1_000);
+    assert.equal(turn.endedAt, 2_500);
+    assert.equal(turn.durationMs, 1_500);
+    assert.equal(JSON.parse(JSON.stringify(turn)).startedAt, 1_000);
+  });
+
+  test('a tool failure the turn recovered from does not fail the turn', () => {
+    // The ledger's terminal verdict decides whether the turn failed; the failed
+    // step only locates a cause once that is established.
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'dispatch-1',
+          ts: 1_000,
+          actions: {
+            toolDispatch: {
+              protocol: 't1_after_preflight_v1',
+              operationId: 'op-1',
+              providerToolCallId: 'tool-call-1',
+              toolName: 'Bash',
+              canonicalArgsHash: 'hash',
+              recoveryMode: 'replay_safe',
+            },
+          },
+        }),
+        event({
+          id: 'response-1',
+          ts: 1_200,
+          role: 'tool',
+          author: 'tool',
+          content: {
+            kind: 'function_response',
+            id: 'tool-call-1',
+            name: 'Bash',
+            result: 'boom',
+            isError: true,
+          },
+        }),
+        event({
+          id: 'final-1',
+          ts: 2_000,
+          status: 'completed',
+          content: { kind: 'text', text: 'recovered and finished' },
+        }),
+      ],
+      modelCallAttempts: [],
+    });
+
+    assert.equal(trace.turns[0]?.failure, undefined, 'a handled failure is not a failed turn');
+    const tool = trace.turns[0]!.steps.find((step) => step.kind === 'tool');
+    assert.equal(
+      tool?.kind === 'tool' ? tool.status : undefined,
+      'failed',
+      'the step still failed',
+    );
+  });
+
+  test('emits the written compaction boundary, which is not the summarizer call', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'history-compact:checkpoint-7',
+          turnId: 'history-compact:12',
+          runId: 'history-compact:checkpoint-7',
+          ts: 900,
+          role: 'user',
+          author: 'system',
+          content: { kind: 'text', text: '<maka_history_compact_checkpoint>' },
+        }),
+      ],
+      modelCallAttempts: [attempt({ callKind: 'history_compact', logicalCallId: 'call-compact' })],
+    });
+
+    const boundary = trace.turns
+      .flatMap((turn) => turn.steps)
+      .find((step) => step.kind === 'compaction');
+    assert.ok(boundary, 'the checkpoint is a step in its own right');
+    assert.equal(
+      boundary.kind === 'compaction' ? boundary.checkpointId : undefined,
+      'checkpoint-7',
+    );
+    // The summarizer request is still its own model call, counted as spend.
+    assert.equal(trace.totals.compactions, 1);
+    assert.equal(trace.totals.modelAttempts, 1);
+  });
+
+  test('separates the declared recovery policy from a recovery that happened', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'dispatch-1',
+          ts: 1_000,
+          actions: {
+            toolDispatch: {
+              protocol: 't1_after_preflight_v1',
+              operationId: 'op-1',
+              providerToolCallId: 'tool-call-1',
+              toolName: 'Bash',
+              canonicalArgsHash: 'hash',
+              recoveryMode: 'reconcile',
+            },
+          },
+        }),
+        event({
+          id: 'recovery-1',
+          ts: 1_400,
+          actions: {
+            toolRecovery: {
+              kind: 'maka.tool.recovery_decision',
+              version: 1,
+              payload: {
+                protocol: 'tool_recovery_v1',
+                operationId: 'op-1',
+                disposition: 'parked',
+                reasonCode: 'reconcile_diverged',
+                evidenceEventIds: ['dispatch-1'],
+              },
+            },
+          },
+        }),
+      ],
+      modelCallAttempts: [],
+    });
+
+    const tool = trace.turns[0]!.steps.find((step) => step.kind === 'tool');
+    assert.ok(tool && tool.kind === 'tool');
+    assert.equal(tool.recoveryPolicy, 'reconcile', 'the policy every dispatch declares');
+    assert.deepEqual(
+      tool.recovered,
+      { disposition: 'parked', reasonCode: 'reconcile_diverged' },
+      'and the decision that was actually recorded',
+    );
+  });
 });

--- a/packages/runtime/src/__tests__/session-trace-projection.test.ts
+++ b/packages/runtime/src/__tests__/session-trace-projection.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Session Inspector trace projection (#1625).
+ *
+ * Run: `npm --workspace @maka/runtime run test`
+ */
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MODEL_CALL_ATTEMPT_SCHEMA_VERSION,
+  type ModelCallAttempt,
+} from '@maka/core/model-call-attempt';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { projectSessionTrace } from '../session-trace-projection.js';
+
+function attempt(overrides: Partial<ModelCallAttempt> = {}): ModelCallAttempt {
+  return {
+    schemaVersion: MODEL_CALL_ATTEMPT_SCHEMA_VERSION,
+    logicalCallId: 'call-1',
+    attemptId: 'attempt-1',
+    traceId: 'trace-1',
+    sessionId: 'session-1',
+    runId: 'run-1',
+    turnId: 'turn-1',
+    step: 0,
+    attempt: 0,
+    callKind: 'main',
+    providerId: 'anthropic',
+    modelId: 'claude-test',
+    startedAt: 1_000,
+    completedAt: 1_500,
+    latencyMs: 500,
+    status: 'completed',
+    usageBasis: 'reported',
+    inputTokens: 10,
+    outputTokens: 5,
+    costBasis: 'priced',
+    costUsd: 0.002,
+    ...overrides,
+  };
+}
+
+function event(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
+  return {
+    id: 'event-1',
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1_000,
+    partial: false,
+    role: 'model',
+    author: 'agent',
+    ...overrides,
+  };
+}
+
+describe('session trace projection', () => {
+  test('groups retries of one logical call into a single step', () => {
+    // Retries share a `logicalCallId` by contract, so "this call was retried"
+    // is a grouping rather than something the reader has to reconstruct.
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [],
+      modelCallAttempts: [
+        attempt({
+          attemptId: 'a-0',
+          attempt: 0,
+          status: 'failed',
+          costUsd: undefined,
+          costBasis: 'unpriced',
+        }),
+        attempt({ attemptId: 'a-1', attempt: 1, startedAt: 1_600, completedAt: 2_000 }),
+      ],
+    });
+
+    assert.equal(trace.turns.length, 1);
+    const steps = trace.turns[0]!.steps;
+    assert.equal(steps.length, 1, 'one logical call is one step');
+    const call = steps[0]!;
+    assert.equal(call.kind, 'model_call');
+    if (call.kind !== 'model_call') return;
+    assert.equal(call.attempts.length, 2);
+    assert.equal(call.status, 'completed', 'the step carries the last attempt outcome');
+    assert.equal(trace.totals.modelAttempts, 2);
+    assert.equal(trace.totals.retries, 1, 'attempts beyond the first are retries');
+    // Only the second attempt was priced, so the step's cost is that one.
+    assert.equal(call.costUsd, 0.002);
+    assert.equal(trace.totals.unpricedAttempts, 1);
+  });
+
+  test('a session of entirely unpriced calls totals to no price, not to zero', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [],
+      modelCallAttempts: [attempt({ costUsd: undefined, costBasis: 'unpriced' })],
+    });
+
+    assert.equal(trace.totals.costUsd, undefined, 'absent price is not a zero price');
+    assert.equal(trace.totals.unpricedAttempts, 1);
+    assert.equal(trace.turns[0]?.steps[0]?.kind, 'model_call');
+  });
+
+  test('counts compaction calls made inside a turn', () => {
+    // The compaction kinds settle through the same seam as the send they
+    // interrupt (#1877), so a compacted turn shows what compacting cost.
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [],
+      modelCallAttempts: [
+        attempt({ logicalCallId: 'call-main', attemptId: 'a-main' }),
+        attempt({
+          logicalCallId: 'call-compact',
+          attemptId: 'a-compact',
+          callKind: 'history_compact',
+          startedAt: 1_600,
+          completedAt: 1_900,
+          costUsd: 0.001,
+        }),
+      ],
+    });
+
+    const totals = trace.turns[0]!.totals;
+    assert.equal(totals.compactions, 1);
+    assert.equal(totals.modelAttempts, 2);
+    assert.equal(totals.costUsd, 0.003, 'compaction cost belongs to the turn it interrupted');
+  });
+
+  test('pairs a tool dispatch with the result that answers it', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'dispatch-1',
+          ts: 1_000,
+          actions: {
+            toolDispatch: {
+              protocol: 't1_after_preflight_v1',
+              operationId: 'op-1',
+              providerToolCallId: 'tool-call-1',
+              toolName: 'Bash',
+              canonicalArgsHash: 'hash',
+              recoveryMode: 'replay_safe',
+            },
+          },
+        }),
+        event({
+          id: 'response-1',
+          ts: 1_800,
+          role: 'tool',
+          author: 'tool',
+          content: {
+            kind: 'function_response',
+            id: 'tool-call-1',
+            name: 'Bash',
+            result: 'boom',
+            isError: true,
+          },
+        }),
+      ],
+      modelCallAttempts: [],
+    });
+
+    const steps = trace.turns[0]!.steps;
+    assert.equal(steps.length, 1, 'a call and its result are one step to a reader');
+    const tool = steps[0]!;
+    assert.equal(tool.kind, 'tool');
+    if (tool.kind !== 'tool') return;
+    assert.equal(tool.toolName, 'Bash');
+    assert.equal(tool.status, 'failed');
+    assert.equal(tool.durationMs, 800);
+  });
+
+  test('attributes a turn failure to what failed first, not to the terminal error', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'dispatch-1',
+          ts: 1_000,
+          actions: {
+            toolDispatch: {
+              protocol: 't1_after_preflight_v1',
+              operationId: 'op-1',
+              providerToolCallId: 'tool-call-1',
+              toolName: 'Bash',
+              canonicalArgsHash: 'hash',
+              recoveryMode: 'replay_safe',
+            },
+          },
+        }),
+        event({
+          id: 'response-1',
+          ts: 1_200,
+          role: 'tool',
+          author: 'tool',
+          content: {
+            kind: 'function_response',
+            id: 'tool-call-1',
+            name: 'Bash',
+            result: 'boom',
+            isError: true,
+          },
+        }),
+        event({
+          id: 'error-1',
+          ts: 2_000,
+          content: { kind: 'error', message: 'turn ended after tool failure' },
+        }),
+      ],
+      modelCallAttempts: [],
+    });
+
+    const failure = trace.turns[0]!.failure;
+    assert.ok(failure);
+    assert.equal(failure.code, 'tool_failed');
+    assert.equal(failure.attributedToStepId, 'dispatch-1', 'the symptom is not the cause');
+    assert.equal(failure.message, 'turn ended after tool failure');
+  });
+
+  test('reports a backend that emits no canonical records instead of rendering an idle session', () => {
+    // The pi backend emits `token_usage` and no `ModelCallAttempt` at all. An
+    // empty timeline would be indistinguishable from a session that did nothing.
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'usage-1',
+          ts: 1_000,
+          actions: { tokenUsage: { input: 100, output: 20, total: 120 } },
+        }),
+      ],
+      modelCallAttempts: [],
+    });
+
+    assert.equal(trace.coverage.modelCalls, 'absent');
+    assert.deepEqual(trace.coverage.turnsMissingModelCalls, ['turn-1']);
+    assert.equal(trace.totals.modelAttempts, 0);
+    assert.equal(trace.totals.costUsd, undefined);
+  });
+
+  test('distinguishes a partially covered session from a wholly uncovered one', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({
+          id: 'usage-1',
+          turnId: 'turn-1',
+          ts: 1_000,
+          actions: { tokenUsage: { input: 100, output: 20, total: 120 } },
+        }),
+        event({
+          id: 'usage-2',
+          turnId: 'turn-2',
+          ts: 3_000,
+          actions: { tokenUsage: { input: 50, output: 10, total: 60 } },
+        }),
+      ],
+      modelCallAttempts: [attempt({ turnId: 'turn-2', startedAt: 3_000, completedAt: 3_200 })],
+    });
+
+    assert.equal(trace.coverage.modelCalls, 'partial');
+    assert.deepEqual(trace.coverage.turnsMissingModelCalls, ['turn-1']);
+    assert.equal(trace.turns.map((turn) => turn.turnId).join(','), 'turn-1,turn-2');
+  });
+
+  test('a session with no model activity is uncovered rather than incomplete', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [event({ content: { kind: 'text', text: 'hi' } })],
+      modelCallAttempts: [],
+    });
+
+    assert.equal(trace.coverage.modelCalls, 'none');
+    assert.deepEqual(trace.coverage.turnsMissingModelCalls, []);
+  });
+
+  test('ignores partial streaming events', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [
+        event({ id: 'partial-1', partial: true, content: { kind: 'error', message: 'transient' } }),
+      ],
+      modelCallAttempts: [attempt()],
+    });
+
+    const steps = trace.turns[0]!.steps;
+    assert.equal(steps.length, 1);
+    assert.equal(steps[0]?.kind, 'model_call');
+    assert.equal(trace.turns[0]?.failure, undefined);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1228,6 +1228,10 @@ export type {
   RuntimeEventToDraftOptions,
 } from './runtime-event-adapters.js';
 
+// session-trace-projection.ts — per-session causal trace for the Inspector (#1625).
+export { projectSessionTrace, attributeTurnFailure } from './session-trace-projection.js';
+export type { SessionTraceInput } from './session-trace-projection.js';
+
 // runtime-event-read-model.ts — side-by-side RuntimeEvent read projection.
 export {
   projectRuntimeEventsToStoredMessages,

--- a/packages/runtime/src/session-trace-projection.ts
+++ b/packages/runtime/src/session-trace-projection.ts
@@ -1,5 +1,9 @@
-import type { ModelCallAttempt } from '@maka/core/model-call-attempt';
-import type { RuntimeEvent } from '@maka/core/runtime-event';
+import {
+  dedupeModelCallAttempts,
+  groupModelCallAttempts,
+  type ModelCallAttempt,
+} from '@maka/core/model-call-attempt';
+import { TERMINAL_RUNTIME_EVENT_STATUSES, type RuntimeEvent } from '@maka/core/runtime-event';
 import {
   emptyTraceTotals,
   mergeTraceTotals,
@@ -37,12 +41,18 @@ export interface SessionTraceInput {
 
 export function projectSessionTrace(input: SessionTraceInput): SessionTrace {
   const events = input.runtimeEvents.filter((event) => !event.partial);
-  const turnIds = orderedTurnIds(events, input.modelCallAttempts);
+  // An aborted attempt and its later settlement are appended under one
+  // `attemptId`; the ledger dedupes on write, a stream read does not. Without
+  // this the trace invents a retry and can double-count a priced settlement,
+  // which would put it out of step with Settings → Usage over the same records.
+  const attempts = dedupeModelCallAttempts(input.modelCallAttempts);
+  const turnIds = orderedTurnIds(events, attempts);
   const eventsByTurn = groupBy(events, (event) => event.turnId);
-  const attemptsByTurn = groupBy(input.modelCallAttempts, (attempt) => attempt.turnId);
+  const attemptsByTurn = groupBy(attempts, (attempt) => attempt.turnId);
 
   const turns: TurnTrace[] = [];
   const turnsMissingModelCalls: string[] = [];
+  const turnsWithFewerModelCallsThanSteps: string[] = [];
   let turnsWithModelActivity = 0;
 
   for (const turnId of turnIds) {
@@ -56,7 +66,11 @@ export function projectSessionTrace(input: SessionTraceInput): SessionTrace {
     // the metering ledger holds. That disagreement is the coverage signal.
     const hasAggregateUsage = turnEvents.some((event) => event.actions?.tokenUsage !== undefined);
     if (hasAggregateUsage || turnAttempts.length > 0) turnsWithModelActivity += 1;
-    if (hasAggregateUsage && turnAttempts.length === 0) turnsMissingModelCalls.push(turnId);
+    if (hasAggregateUsage && turnAttempts.length === 0) {
+      turnsMissingModelCalls.push(turnId);
+    } else if (hasAggregateUsage && missesRuntimeSteps(turnEvents, turn)) {
+      turnsWithFewerModelCallsThanSteps.push(turnId);
+    }
   }
 
   const totals = turns.reduce<TraceTotals>(
@@ -69,7 +83,11 @@ export function projectSessionTrace(input: SessionTraceInput): SessionTrace {
     sessionId: input.sessionId,
     turns,
     totals,
-    coverage: resolveCoverage(turnsWithModelActivity, turnsMissingModelCalls),
+    coverage: resolveCoverage(
+      turnsWithModelActivity,
+      turnsMissingModelCalls,
+      turnsWithFewerModelCallsThanSteps,
+    ),
   };
 }
 
@@ -81,17 +99,49 @@ export function projectSessionTrace(input: SessionTraceInput): SessionTrace {
 function resolveCoverage(
   turnsWithModelActivity: number,
   turnsMissingModelCalls: string[],
+  turnsWithFewerModelCallsThanSteps: string[],
 ): SessionTraceCoverage {
   if (turnsWithModelActivity === 0) {
-    return { modelCalls: 'none', turnsMissingModelCalls: [] };
+    return {
+      modelCalls: 'none',
+      turnsMissingModelCalls: [],
+      turnsWithFewerModelCallsThanSteps: [],
+    };
   }
-  if (turnsMissingModelCalls.length === 0) {
-    return { modelCalls: 'complete', turnsMissingModelCalls: [] };
+  if (turnsMissingModelCalls.length === turnsWithModelActivity) {
+    return { modelCalls: 'absent', turnsMissingModelCalls, turnsWithFewerModelCallsThanSteps };
   }
+  const gaps = turnsMissingModelCalls.length + turnsWithFewerModelCallsThanSteps.length;
   return {
-    modelCalls: turnsMissingModelCalls.length === turnsWithModelActivity ? 'absent' : 'partial',
+    // "No known gap" rather than "complete": records that are present cannot
+    // prove that every call settled, so this is the absence of evidence of a
+    // gap, not evidence of its absence.
+    modelCalls: gaps === 0 ? 'no_known_gap' : 'partial',
     turnsMissingModelCalls,
+    turnsWithFewerModelCallsThanSteps,
   };
+}
+
+/**
+ * Whether the aggregate usage stands for more runtime steps than the turn has
+ * main model calls on record.
+ *
+ * `runtimeSteps` counts the provider tool-loop steps one aggregate usage event
+ * represents, and each of those steps is one main call. Fewer main calls than
+ * that is a shortfall the ledgers themselves disagree about — a floor on what
+ * is missing, never a count of it. Compaction kinds are excluded because they
+ * are not part of that count.
+ */
+function missesRuntimeSteps(events: readonly RuntimeEvent[], turn: TurnTrace): boolean {
+  const declaredSteps = events.reduce(
+    (carry, event) => carry + (event.actions?.tokenUsage?.runtimeSteps ?? 0),
+    0,
+  );
+  if (declaredSteps === 0) return false;
+  const mainCalls = turn.steps.filter(
+    (step) => step.kind === 'model_call' && step.callKind === 'main',
+  ).length;
+  return mainCalls < declaredSteps;
 }
 
 function projectTurn(
@@ -105,10 +155,20 @@ function projectTurn(
     (left, right) => left.startedAt - right.startedAt,
   );
 
-  const startedAt = Math.min(...steps.map((step) => step.startedAt));
-  const endedAt = Math.max(...steps.map((step) => stepEndedAt(step)));
+  // Bounds come from the ledger facts, not from the steps that happen to be
+  // visible: a usage-only or text-only turn projects no steps at all, and
+  // folding an empty list gives ±Infinity, which JSON renders as `null`.
+  const instants = [
+    ...events.map((event) => event.ts),
+    ...attempts.map((attempt) => attempt.startedAt),
+    ...attempts.map((attempt) => attempt.completedAt),
+    ...steps.map((step) => step.startedAt),
+    ...steps.map(stepEndedAt),
+  ];
+  const startedAt = Math.min(...instants);
+  const endedAt = Math.max(...instants);
   const totals = turnTotals(steps, endedAt - startedAt);
-  const failure = attributeTurnFailure(steps);
+  const failure = attributeTurnFailure(steps, events);
 
   return {
     turnId,
@@ -130,10 +190,9 @@ function projectTurn(
  * reconstructed from `(traceId, step)` by every consumer.
  */
 function projectModelCallSteps(attempts: readonly ModelCallAttempt[]): TraceModelCallStep[] {
-  const byLogicalCall = groupBy(attempts, (attempt) => attempt.logicalCallId);
   const steps: TraceModelCallStep[] = [];
 
-  for (const [logicalCallId, group] of byLogicalCall) {
+  for (const { logicalCallId, attempts: group } of groupModelCallAttempts(attempts)) {
     const ordered = [...group].sort((left, right) => left.attempt - right.attempt);
     const last = ordered[ordered.length - 1]!;
     const first = ordered[0]!;
@@ -192,16 +251,49 @@ function toTraceAttempt(attempt: ModelCallAttempt): TraceModelAttempt {
   };
 }
 
+/** Prefix the runtime gives a written history-compaction boundary. */
+const HISTORY_COMPACT_EVENT_PREFIX = 'history-compact:';
+
 /** Causal steps the metering ledger knows nothing about. */
 function projectEventSteps(events: readonly RuntimeEvent[]): TraceStep[] {
   const steps: TraceStep[] = [];
   const toolStarts = new Map<string, { id: string; startedAt: number }>();
+  const toolStepsByOperation = new Map<string, TraceStep & { kind: 'tool' }>();
 
   for (const event of events) {
+    // A written compaction boundary, which is not the same fact as the
+    // summarizer call that produced its text: one is the checkpoint the next
+    // request replays from, the other is the spend.
+    if (event.id.startsWith(HISTORY_COMPACT_EVENT_PREFIX)) {
+      steps.push({
+        kind: 'compaction',
+        id: event.id,
+        turnId: event.turnId,
+        runId: event.runId,
+        startedAt: event.ts,
+        checkpointId: event.id.slice(HISTORY_COMPACT_EVENT_PREFIX.length),
+      });
+      continue;
+    }
+
+    const recovery = event.actions?.toolRecovery;
+    if (recovery?.kind === 'maka.tool.recovery_decision') {
+      // Correlated by `operationId` rather than by position: the decision is
+      // appended by the recovery writer, not by the dispatch it settles.
+      const settled = toolStepsByOperation.get(recovery.payload.operationId);
+      if (settled) {
+        settled.recovered = {
+          disposition: recovery.payload.disposition,
+          reasonCode: recovery.payload.reasonCode,
+        };
+      }
+      continue;
+    }
+
     const dispatch = event.actions?.toolDispatch;
     if (dispatch) {
       toolStarts.set(dispatch.providerToolCallId, { id: event.id, startedAt: event.ts });
-      steps.push({
+      const step: TraceStep & { kind: 'tool' } = {
         kind: 'tool',
         id: event.id,
         turnId: event.turnId,
@@ -209,9 +301,14 @@ function projectEventSteps(events: readonly RuntimeEvent[]): TraceStep[] {
         startedAt: event.ts,
         toolName: dispatch.toolName,
         toolCallId: dispatch.providerToolCallId,
+        operationId: dispatch.operationId,
         status: 'in_flight',
-        ...(dispatch.recoveryMode ? { recoveryMode: dispatch.recoveryMode } : {}),
-      });
+        // The declared policy, present on ordinary first executions too. What
+        // actually recovered, if anything, arrives as a decision fact above.
+        ...(dispatch.recoveryMode ? { recoveryPolicy: dispatch.recoveryMode } : {}),
+      };
+      toolStepsByOperation.set(dispatch.operationId, step);
+      steps.push(step);
       continue;
     }
 
@@ -270,7 +367,21 @@ function projectEventSteps(events: readonly RuntimeEvent[]): TraceStep[] {
  */
 export function attributeTurnFailure(
   steps: readonly TraceStep[],
+  events: readonly RuntimeEvent[] = [],
 ): TraceFailureAttribution | undefined {
+  // Whether the turn failed is the ledger's call, not the projection's. A tool
+  // that errored and was recovered from is a step that failed inside a turn
+  // that succeeded, and marking that turn failed would be wrong in the
+  // direction that matters — it is the reading a user acts on.
+  const terminalStatus = [...events]
+    .reverse()
+    .find(
+      (event) =>
+        event.status !== undefined &&
+        (TERMINAL_RUNTIME_EVENT_STATUSES as readonly string[]).includes(event.status),
+    )?.status;
+  if (terminalStatus === 'completed') return undefined;
+
   const terminalError = [...steps].reverse().find((step) => step.kind === 'error');
   const firstFailure = steps.find(
     (step) =>
@@ -278,14 +389,18 @@ export function attributeTurnFailure(
       (step.kind === 'model_call' && step.status === 'failed') ||
       step.kind === 'error',
   );
-  if (!terminalError && !firstFailure) return undefined;
+  // With no terminal verdict and nothing that failed there is nothing to
+  // report; a non-completed verdict on its own is still a failed turn.
+  if (!terminalError && !firstFailure && terminalStatus === undefined) return undefined;
 
   const code =
     firstFailure?.kind === 'tool'
       ? 'tool_failed'
       : firstFailure?.kind === 'model_call'
         ? 'model_call_failed'
-        : 'error';
+        : terminalStatus !== undefined
+          ? `turn_${terminalStatus}`
+          : 'error';
   return {
     code,
     ...(terminalError?.kind === 'error' ? { message: terminalError.message } : {}),

--- a/packages/runtime/src/session-trace-projection.ts
+++ b/packages/runtime/src/session-trace-projection.ts
@@ -1,0 +1,351 @@
+import type { ModelCallAttempt } from '@maka/core/model-call-attempt';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import {
+  emptyTraceTotals,
+  mergeTraceTotals,
+  SESSION_TRACE_SCHEMA_VERSION,
+  type SessionTrace,
+  type SessionTraceCoverage,
+  type TraceFailureAttribution,
+  type TraceModelAttempt,
+  type TraceModelCallStep,
+  type TraceStep,
+  type TraceTotals,
+  type TurnTrace,
+} from '@maka/core/session-trace';
+
+/**
+ * Builds the per-session causal trace the Inspector renders (#1625).
+ *
+ * Pure and synchronous by construction: both ledgers are handed in already
+ * read. The caller owns the I/O — `readSessionRuntimeEvents` for structure and
+ * the AgentRun stream for canonical records — which keeps this file testable
+ * against fixtures and keeps `@maka/storage` out of `@maka/runtime`.
+ *
+ * The two inputs are joined on `(runId, turnId)`, the identity both ledgers
+ * carry. Nothing is inferred across that boundary: a turn with events and no
+ * records renders its structure and reports the gap, rather than borrowing
+ * numbers from a neighbouring turn.
+ */
+export interface SessionTraceInput {
+  sessionId: string;
+  /** Causal structure, from `RuntimeEventStore.readSessionRuntimeEvents`. */
+  runtimeEvents: readonly RuntimeEvent[];
+  /** Canonical metering, from the AgentRun stream's `model_call_attempt_recorded`. */
+  modelCallAttempts: readonly ModelCallAttempt[];
+}
+
+export function projectSessionTrace(input: SessionTraceInput): SessionTrace {
+  const events = input.runtimeEvents.filter((event) => !event.partial);
+  const turnIds = orderedTurnIds(events, input.modelCallAttempts);
+  const eventsByTurn = groupBy(events, (event) => event.turnId);
+  const attemptsByTurn = groupBy(input.modelCallAttempts, (attempt) => attempt.turnId);
+
+  const turns: TurnTrace[] = [];
+  const turnsMissingModelCalls: string[] = [];
+  let turnsWithModelActivity = 0;
+
+  for (const turnId of turnIds) {
+    const turnEvents = eventsByTurn.get(turnId) ?? [];
+    const turnAttempts = attemptsByTurn.get(turnId) ?? [];
+    const turn = projectTurn(turnId, turnEvents, turnAttempts);
+    if (!turn) continue;
+    turns.push(turn);
+
+    // Aggregate usage on the ledger means the turn made model calls, whatever
+    // the metering ledger holds. That disagreement is the coverage signal.
+    const hasAggregateUsage = turnEvents.some((event) => event.actions?.tokenUsage !== undefined);
+    if (hasAggregateUsage || turnAttempts.length > 0) turnsWithModelActivity += 1;
+    if (hasAggregateUsage && turnAttempts.length === 0) turnsMissingModelCalls.push(turnId);
+  }
+
+  const totals = turns.reduce<TraceTotals>(
+    (carry, turn) => mergeTraceTotals(carry, turn.totals),
+    emptyTraceTotals(),
+  );
+
+  return {
+    schemaVersion: SESSION_TRACE_SCHEMA_VERSION,
+    sessionId: input.sessionId,
+    turns,
+    totals,
+    coverage: resolveCoverage(turnsWithModelActivity, turnsMissingModelCalls),
+  };
+}
+
+/**
+ * Coverage is a session-level fact, because that is the scale at which the
+ * dangerous case is legible: a backend outside canonical accounting produces a
+ * trace that looks like an idle session unless something says otherwise.
+ */
+function resolveCoverage(
+  turnsWithModelActivity: number,
+  turnsMissingModelCalls: string[],
+): SessionTraceCoverage {
+  if (turnsWithModelActivity === 0) {
+    return { modelCalls: 'none', turnsMissingModelCalls: [] };
+  }
+  if (turnsMissingModelCalls.length === 0) {
+    return { modelCalls: 'complete', turnsMissingModelCalls: [] };
+  }
+  return {
+    modelCalls: turnsMissingModelCalls.length === turnsWithModelActivity ? 'absent' : 'partial',
+    turnsMissingModelCalls,
+  };
+}
+
+function projectTurn(
+  turnId: string,
+  events: readonly RuntimeEvent[],
+  attempts: readonly ModelCallAttempt[],
+): TurnTrace | undefined {
+  if (events.length === 0 && attempts.length === 0) return undefined;
+  const runId = events[0]?.runId ?? attempts[0]?.runId ?? '';
+  const steps = [...projectModelCallSteps(attempts), ...projectEventSteps(events)].sort(
+    (left, right) => left.startedAt - right.startedAt,
+  );
+
+  const startedAt = Math.min(...steps.map((step) => step.startedAt));
+  const endedAt = Math.max(...steps.map((step) => stepEndedAt(step)));
+  const totals = turnTotals(steps, endedAt - startedAt);
+  const failure = attributeTurnFailure(steps);
+
+  return {
+    turnId,
+    runId,
+    startedAt,
+    endedAt,
+    durationMs: Math.max(0, endedAt - startedAt),
+    steps,
+    totals,
+    ...(failure ? { failure } : {}),
+  };
+}
+
+/**
+ * One step per logical call, attempts nested under it.
+ *
+ * Retries share a `logicalCallId` by contract, so this is a grouping rather
+ * than a heuristic — the reason that field is explicit on the record instead of
+ * reconstructed from `(traceId, step)` by every consumer.
+ */
+function projectModelCallSteps(attempts: readonly ModelCallAttempt[]): TraceModelCallStep[] {
+  const byLogicalCall = groupBy(attempts, (attempt) => attempt.logicalCallId);
+  const steps: TraceModelCallStep[] = [];
+
+  for (const [logicalCallId, group] of byLogicalCall) {
+    const ordered = [...group].sort((left, right) => left.attempt - right.attempt);
+    const last = ordered[ordered.length - 1]!;
+    const first = ordered[0]!;
+    const startedAt = Math.min(...ordered.map((attempt) => attempt.startedAt));
+    const endedAt = Math.max(...ordered.map((attempt) => attempt.completedAt));
+    const priced = ordered.filter((attempt) => attempt.costUsd !== undefined);
+
+    steps.push({
+      kind: 'model_call',
+      id: logicalCallId,
+      turnId: first.turnId,
+      runId: first.runId,
+      startedAt,
+      endedAt,
+      durationMs: Math.max(0, endedAt - startedAt),
+      callKind: first.callKind,
+      providerId: first.providerId,
+      modelId: first.modelId,
+      ...(first.connectionSlug !== undefined ? { connectionSlug: first.connectionSlug } : {}),
+      step: first.step,
+      attempts: ordered.map(toTraceAttempt),
+      status: last.status,
+      // Absent rather than zero when nothing in the group was priced: the sum of
+      // no prices is not a price (#1679).
+      ...(priced.length > 0
+        ? { costUsd: priced.reduce((carry, attempt) => carry + (attempt.costUsd ?? 0), 0) }
+        : {}),
+    });
+  }
+
+  return steps;
+}
+
+function toTraceAttempt(attempt: ModelCallAttempt): TraceModelAttempt {
+  return {
+    attemptId: attempt.attemptId,
+    attempt: attempt.attempt,
+    status: attempt.status,
+    startedAt: attempt.startedAt,
+    completedAt: attempt.completedAt,
+    latencyMs: attempt.latencyMs,
+    ...(attempt.timeToFirstTokenMs !== undefined
+      ? { timeToFirstTokenMs: attempt.timeToFirstTokenMs }
+      : {}),
+    ...(attempt.finishReason !== undefined ? { finishReason: attempt.finishReason } : {}),
+    ...(attempt.errorClass !== undefined ? { errorClass: attempt.errorClass } : {}),
+    ...(attempt.inputTokens !== undefined ? { inputTokens: attempt.inputTokens } : {}),
+    ...(attempt.outputTokens !== undefined ? { outputTokens: attempt.outputTokens } : {}),
+    ...(attempt.cacheReadInputTokens !== undefined
+      ? { cacheReadInputTokens: attempt.cacheReadInputTokens }
+      : {}),
+    ...(attempt.reasoningTokens !== undefined ? { reasoningTokens: attempt.reasoningTokens } : {}),
+    ...(attempt.costUsd !== undefined ? { costUsd: attempt.costUsd } : {}),
+    costBasis: attempt.costBasis,
+    usageBasis: attempt.usageBasis,
+  };
+}
+
+/** Causal steps the metering ledger knows nothing about. */
+function projectEventSteps(events: readonly RuntimeEvent[]): TraceStep[] {
+  const steps: TraceStep[] = [];
+  const toolStarts = new Map<string, { id: string; startedAt: number }>();
+
+  for (const event of events) {
+    const dispatch = event.actions?.toolDispatch;
+    if (dispatch) {
+      toolStarts.set(dispatch.providerToolCallId, { id: event.id, startedAt: event.ts });
+      steps.push({
+        kind: 'tool',
+        id: event.id,
+        turnId: event.turnId,
+        runId: event.runId,
+        startedAt: event.ts,
+        toolName: dispatch.toolName,
+        toolCallId: dispatch.providerToolCallId,
+        status: 'in_flight',
+        ...(dispatch.recoveryMode ? { recoveryMode: dispatch.recoveryMode } : {}),
+      });
+      continue;
+    }
+
+    if (event.content?.kind === 'function_response') {
+      // Settle the dispatch this result answers rather than emitting a second
+      // step: a call and its result are one thing to a reader.
+      const response = event.content;
+      const started = toolStarts.get(response.id);
+      const settled = steps.find(
+        (step): step is Extract<TraceStep, { kind: 'tool' }> =>
+          step.kind === 'tool' && step.id === started?.id,
+      );
+      if (settled) {
+        settled.endedAt = event.ts;
+        settled.durationMs = Math.max(0, event.ts - settled.startedAt);
+        settled.status = response.isError === true ? 'failed' : 'completed';
+      }
+      continue;
+    }
+
+    const decision = event.actions?.permissionDecision;
+    if (decision) {
+      steps.push({
+        kind: 'permission',
+        id: event.id,
+        turnId: event.turnId,
+        runId: event.runId,
+        startedAt: event.ts,
+        ...(decision.toolName !== undefined ? { toolName: decision.toolName } : {}),
+        decision: decision.decision,
+      });
+      continue;
+    }
+
+    if (event.content?.kind === 'error') {
+      steps.push({
+        kind: 'error',
+        id: event.id,
+        turnId: event.turnId,
+        runId: event.runId,
+        startedAt: event.ts,
+        message: event.content.message,
+      });
+    }
+  }
+
+  return steps;
+}
+
+/**
+ * The first thing that failed, not the last thing that happened.
+ *
+ * A turn that ends in an error usually ends there *because* of something
+ * earlier — a tool that failed, a call that exhausted its retries. Pointing at
+ * the terminal event would name the symptom.
+ */
+export function attributeTurnFailure(
+  steps: readonly TraceStep[],
+): TraceFailureAttribution | undefined {
+  const terminalError = [...steps].reverse().find((step) => step.kind === 'error');
+  const firstFailure = steps.find(
+    (step) =>
+      (step.kind === 'tool' && step.status === 'failed') ||
+      (step.kind === 'model_call' && step.status === 'failed') ||
+      step.kind === 'error',
+  );
+  if (!terminalError && !firstFailure) return undefined;
+
+  const code =
+    firstFailure?.kind === 'tool'
+      ? 'tool_failed'
+      : firstFailure?.kind === 'model_call'
+        ? 'model_call_failed'
+        : 'error';
+  return {
+    code,
+    ...(terminalError?.kind === 'error' ? { message: terminalError.message } : {}),
+    ...(firstFailure ? { attributedToStepId: firstFailure.id } : {}),
+  };
+}
+
+function turnTotals(steps: readonly TraceStep[], durationMs: number): TraceTotals {
+  const totals = emptyTraceTotals();
+  totals.durationMs = Math.max(0, durationMs);
+
+  for (const step of steps) {
+    if (step.kind === 'model_call') {
+      totals.modelAttempts += step.attempts.length;
+      totals.retries += Math.max(0, step.attempts.length - 1);
+      if (step.callKind === 'history_compact' || step.callKind === 'semantic_compact') {
+        totals.compactions += 1;
+      }
+      for (const attempt of step.attempts) {
+        totals.inputTokens += attempt.inputTokens ?? 0;
+        totals.outputTokens += attempt.outputTokens ?? 0;
+        if (attempt.costUsd === undefined) totals.unpricedAttempts += 1;
+      }
+      if (step.costUsd !== undefined) totals.costUsd = (totals.costUsd ?? 0) + step.costUsd;
+    }
+  }
+
+  return totals;
+}
+
+function stepEndedAt(step: TraceStep): number {
+  if (step.kind === 'model_call') return step.endedAt;
+  if (step.kind === 'tool') return step.endedAt ?? step.startedAt;
+  return step.startedAt;
+}
+
+/** Turn order follows first appearance, so a trace reads in the order it ran. */
+function orderedTurnIds(
+  events: readonly RuntimeEvent[],
+  attempts: readonly ModelCallAttempt[],
+): string[] {
+  const seen = new Map<string, number>();
+  for (const event of events) {
+    const at = seen.get(event.turnId);
+    if (at === undefined || event.ts < at) seen.set(event.turnId, event.ts);
+  }
+  for (const attempt of attempts) {
+    const at = seen.get(attempt.turnId);
+    if (at === undefined || attempt.startedAt < at) seen.set(attempt.turnId, attempt.startedAt);
+  }
+  return [...seen.entries()].sort((left, right) => left[1] - right[1]).map(([turnId]) => turnId);
+}
+
+function groupBy<T>(items: readonly T[], key: (item: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const item of items) {
+    const id = key(item);
+    const group = groups.get(id);
+    if (group) group.push(item);
+    else groups.set(id, [item]);
+  }
+  return groups;
+}


### PR DESCRIPTION
## Summary

First layer of the Session Inspector: a pure per-session causal trace over the two ledgers that already record it. No UI, no I/O, no new store.

This is the PR that #1625 paused for. The RFC's headline — per-step latency and cost — was **not derivable from `RuntimeEvent`**: one aggregate usage event per send, carrying a `runtimeSteps` count of how many steps it stood for. Rather than ship a view that was knowingly incomplete on exactly the turns worth inspecting, the metering source was fixed first (#1687, #1755, #1877). `ModelCallAttempt` now records one canonical record per physical provider request — `step`, `attempt`, `latencyMs`, `timeToFirstTokenMs`, usage with a `usageBasis`, and a cost frozen at call time with the rates it used — so the projection can finally be written honestly.

`projectSessionTrace` joins:

- **`RuntimeEvent`** for causal structure — tool dispatch paired with the result that answers it, permission decisions, errors.
- **`ModelCallAttempt`** for metering — what each call cost and how long it took.

Contract in `packages/core`, builder in `packages/runtime`, pure and synchronous with both ledgers handed in already read. The caller owns the I/O, which keeps `@maka/storage` out of `@maka/runtime` and the projection testable against fixtures.

Refs #1625. Builds on #1679.

## Three properties that are deliberate

**Retries are nested, not flattened.** Attempts of one logical call share a `logicalCallId` by contract, so "this call was retried twice" is a grouping. A flat list of three steps that happen to share an id makes the reader reconstruct it.

**An absent price stays absent.** A step whose attempts were never priced carries no `costUsd`, and a session of only such calls totals to no price rather than to zero. That distinction is the one the canonical record exists to keep: unpriced and free are different facts.

**Coverage is stated, not implied.** A backend outside canonical accounting produces a trace that says so. The pi backend is exactly this case — `recordModelCallAttempt` has zero references in `pi-agent-backend.ts`, it emits `token_usage` only — and an empty timeline is indistinguishable from a session that did nothing. Aggregate usage with no canonical record behind it is the signal, reported per session as `absent` or `partial` with the turns named.

Failure attribution points at what failed **first**, not at the terminal error. A turn that ends in an error usually ends there because of an earlier tool failure; naming the last event names the symptom.

## One thing I'd like confirmed before it stays

`TraceTotals.costUsd` sums a session's attempts. @Astro-Han warned in the issue thread that a per-session cost would make the Inspector a second cost authority, and at the time that was right — Settings → Usage aggregated the telemetry index while the Inspector would have projected the RuntimeEvent ledger, two record paths over one pricing table.

That inverted with #1755: Settings → Usage now aggregates **these same `ModelCallAttempt` records**. Summing a session's attempts is reading one authority at a different scope, not creating a second — a disagreement between the two would be a bug in one of them rather than two defensible numbers. I've written it that way, but it's the claim I'm least willing to assert unilaterally. If you'd rather it wait, dropping `costUsd` from `TraceTotals` touches one field and one test; everything else stands.

## Deliberately not here

No `searchTrace` API — structured predicates are caller-side `Array.filter` over `TraceStep[]`, per the issue discussion. No UI; the fifth `SessionWorkbar` tab is PR 2. No pricing parameter; cost is read off the record as stored rather than recomputed from a current snapshot. Nothing touches Runtime Host ownership or the Desktop writer path.

Two coverage gaps are reported rather than closed: the pi backend above, and `goal_evaluation`, which still writes only the frozen table because it has no run or turn identity at the Host layer.

## Verification

- 9 node tests covering retry grouping, unpriced totals, compaction attribution inside a turn, tool dispatch/result pairing, failure attribution across failed-tool → terminal error, the pi-shaped session, partial coverage, no-model-activity sessions, and partial streaming events.
- `@maka/core` 703/703, `@maka/runtime` 2721/2733 — the 3 failing suites are this machine's `rg`-as-a-shell-function sandbox noise, identical on the parent commit.
- `npm run format:check` and `node scripts/check-console.mjs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
