### PR TITLE
fix(release): notarize final macOS DMG

### DIFF
--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -73,7 +73,7 @@ jobs:
             echo "update_yml=${update_yml}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Package signed and notarized DMG
+      - name: Package notarized app and signed DMG
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -82,8 +82,28 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: npm run package:macos-arm64
 
-      - name: Remove the temporary notarization key
-        run: rm -f "${{ runner.temp }}/AuthKey_Maka.p8"
+      - name: Notarize and staple the signed final DMG
+        env:
+          APPLE_API_KEY: ${{ runner.temp }}/AuthKey_Maka.p8
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          DMG_PATH: ${{ steps.release.outputs.dmg }}
+        run: |
+          codesign --verify --verbose=4 "$DMG_PATH"
+          xcrun notarytool submit "$DMG_PATH" \
+            --key "$APPLE_API_KEY" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait
+          xcrun stapler staple "$DMG_PATH"
+
+          codesign --verify --verbose=4 "$DMG_PATH"
+          xcrun stapler validate "$DMG_PATH"
+          spctl --assess \
+            --type open \
+            --context context:primary-signature \
+            --verbose=4 \
+            "$DMG_PATH"
 
       - name: Verify the final DMG
         run: npm run verify:macos-arm64 -- "${{ steps.release.outputs.dmg }}"
@@ -113,6 +133,6 @@ jobs:
 
           echo "Draft release ${RELEASE_TAG} created from ${GITHUB_SHA}." >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Ensure the temporary notarization key is removed
+      - name: Remove temporary release credentials
         if: always()
         run: rm -f "${{ runner.temp }}/AuthKey_Maka.p8"

--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -93,7 +93,11 @@ export default {
     },
   },
   dmg: {
-    writeUpdateInfo: true,
+    sign: true,
+    // Stapling the notarization ticket after electron-builder exits changes the
+    // DMG bytes. macOS updates use the ZIP, so do not publish a stale DMG hash
+    // in latest-mac.yml.
+    writeUpdateInfo: false,
   },
   publish: [
     {


### PR DESCRIPTION
## Summary

- enable electron-builder Developer ID signing for the final DMG
- submit the signed DMG to Apple notarytool and wait for acceptance
- staple the notarization ticket before verification and Release upload
- keep latest-mac.yml tied to the ZIP because stapling changes the DMG bytes

## Root cause

The existing mac.notarize setting notarized Maka.app before electron-builder created the DMG. The workflow then uploaded the outer DMG without notarizing or stapling it.

## Validation

- electron-builder config imported successfully with dmg.sign enabled
- release workflow YAML parsed successfully
- git diff --check passed

No test suite or new test infrastructure was added.