### PR TITLE
feat(runtime): support 32-way agent swarm concurrency

### DIFF
--- a/docs/agent-swarm.md
+++ b/docs/agent-swarm.md
@@ -32,7 +32,7 @@ scheduling, see [Graph Is a Schedule, Not a Second Runtime](./architecture/agent
 ## Contract
 
 One call accepts `1..32` items. Local concurrency defaults to `3` and is capped
-at `5`. The entire input is validated before any child starts. Results retain
+at `32`. The entire input is validated before any child starts. Results retain
 input order even when children finish out of order.
 
 New work has two mutually exclusive forms. Callers may provide the explicit

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -46,6 +46,8 @@ describe('AgentSwarm adapter', () => {
     assert.equal(tool.name, AGENT_SWARM_TOOL_NAME);
     assert.equal(tool.categoryHint, 'subagent');
     assert.equal(AGENT_SWARM_DEFAULT_ITEM_TIMEOUT_MS, 2 * 60 * 60 * 1_000);
+    assert.equal(AGENT_SWARM_MAX_CONCURRENCY, 32);
+    assert.equal(MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN, AGENT_SWARM_MAX_CONCURRENCY);
     assert.equal(([...AGENT_TOOL_NAMES] as string[]).includes(AGENT_SWARM_TOOL_NAME), true);
     assert.deepEqual(
       schema.safeParse({
@@ -1097,11 +1099,20 @@ describe('AgentSwarm adapter', () => {
     const swarm = executeTool(
       runtime,
       {
-        ...buildAgentSwarmTool(),
+        ...buildAgentSwarmTool({
+          adaptiveSwarmPolicy: {
+            initialLaunchLimit: AGENT_SWARM_MAX_CONCURRENCY,
+            initialLaunchIntervalMs: 1,
+            rateLimitRetryBaseMs: 1,
+            rateLimitRetryFactor: 2,
+            capacityShrinkIntervalMs: 1,
+            capacityRecoveryIntervalMs: 100,
+          },
+        }),
       },
       {
-        items: Array.from({ length: 5 }, (_, index) => swarmItem(index)),
-        max_concurrency: 5,
+        items: Array.from({ length: AGENT_SWARM_MAX_CONCURRENCY }, (_, index) => swarmItem(index)),
+        max_concurrency: AGENT_SWARM_MAX_CONCURRENCY,
       },
       new AbortController(),
     );
@@ -1114,7 +1125,7 @@ describe('AgentSwarm adapter', () => {
     );
 
     releases.get('single')?.();
-    await waitFor(() => started.length === 6);
+    await waitFor(() => started.length === MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN + 1);
     assert.equal(maxActive, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
 
     for (const release of releases.values()) release();

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -28,6 +28,7 @@ import type { SpawnChildAgentResult } from '../session-manager.js';
 import type { RunTraceLike } from '../run-trace.js';
 import {
   MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN,
+  MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN,
   ToolRuntime,
   type MakaTool,
   type MakaToolContext,
@@ -1161,11 +1162,11 @@ describe('AgentSwarm adapter', () => {
       { traceEvents },
     );
     const tool = singleChildProbeTool();
-    const pending = Array.from({ length: MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN + 1 }, (_, index) =>
+    const pending = Array.from({ length: MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN + 1 }, (_, index) =>
       executeTool(runtime, tool, {}, new AbortController(), [], `tool-admission-${index}`),
     );
 
-    await waitFor(() => starts === MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
+    await waitFor(() => starts === MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN);
     assert.deepEqual(await pending.at(-1), {
       error: '只读探索并发过多：同一轮最多 5 个子代理。请等待已有探索完成后再继续。',
     });

--- a/packages/runtime/src/__tests__/child-agent-run-limiter.test.ts
+++ b/packages/runtime/src/__tests__/child-agent-run-limiter.test.ts
@@ -157,14 +157,16 @@ describe('ToolRuntime child-agent run permits', () => {
         });
       });
     });
+    const firstCount = Math.floor(MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN / 2);
+    const secondCount = MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN - firstCount + 1;
     const first = executeTool(
       runtime,
-      childBatchProbeTool(3, false, 'first_batch_probe', 'first'),
+      childBatchProbeTool(firstCount, false, 'first_batch_probe', 'first'),
       new AbortController(),
     );
     const second = executeTool(
       runtime,
-      childBatchProbeTool(3, false, 'second_batch_probe', 'second'),
+      childBatchProbeTool(secondCount, false, 'second_batch_probe', 'second'),
       new AbortController(),
     );
 
@@ -173,7 +175,7 @@ describe('ToolRuntime child-agent run permits', () => {
     assert.equal(active.size, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
 
     releases.get(started[0]!)?.();
-    await waitFor(() => started.length === 6);
+    await waitFor(() => started.length === MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN + 1);
     assert.equal(maxActive, MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN);
 
     for (const release of releases.values()) release();

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -33,7 +33,7 @@ import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 
 export const AGENT_SWARM_TOOL_NAME = 'agent_swarm';
 export const AGENT_SWARM_DEFAULT_CONCURRENCY = 3;
-export const AGENT_SWARM_MAX_CONCURRENCY = 5;
+export const AGENT_SWARM_MAX_CONCURRENCY = 32;
 export const AGENT_SWARM_MAX_ITEMS = 32;
 export const AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER = '{{item}}';
 export const AGENT_SWARM_DEFAULT_ITEM_TIMEOUT_MS = 2 * 60 * 60 * 1_000;

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -253,7 +253,7 @@ export interface ToolGating {
 
 export const TOOL_ERROR_RESULT_MAX_CHARS = 4000;
 export const MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN = 5;
-export const MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN = 5;
+export const MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN = 32;
 export const DEFAULT_PERMISSION_TIMEOUT_MS = 300_000;
 
 /**


### PR DESCRIPTION
## Summary

- raise the explicit `agent_swarm` `max_concurrency` ceiling from 5 to 32 while keeping the default at 3
- raise the shared child-run permit pool to 32 so a requested 32-wide swarm can materialize instead of being silently throttled to 5
- lock the schema and real-run boundary together with a regression test that proves the 32nd swarm child starts after a shared permit is released
- update the Agent Swarm contract documentation

## Breaking Changes

None. Existing callers that omit `max_concurrency` continue to use 3.

## Database Migrations

None.

## Merge Order

Standalone; no dependent PRs.

## Related PRs

None.

## Test Plan

- `npm --workspace @maka/runtime test`
- `npm --workspace @maka/runtime run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`