### PR TITLE
ci: parallelize heavy test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,10 @@ jobs:
       code: ${{ steps.plan.outputs.code }}
       e2e: ${{ steps.plan.outputs.e2e }}
       headless: ${{ steps.plan.outputs.headless }}
+      runtime_host: ${{ steps.plan.outputs.runtime_host }}
       runtime_sandbox: ${{ steps.plan.outputs.runtime_sandbox }}
       script_mode: ${{ steps.plan.outputs.script_mode }}
+      standard_workspaces: ${{ steps.plan.outputs.standard_workspaces }}
       storage_stress: ${{ steps.plan.outputs.storage_stress }}
       storybook: ${{ steps.plan.outputs.storybook }}
       unit: ${{ steps.plan.outputs.unit }}
@@ -81,9 +83,9 @@ jobs:
       - name: Story annotations
         run: node scripts/check-story-annotations.mjs
 
-  test:
+  test_workspaces:
     needs: changes
-    if: needs.changes.outputs.unit == 'true' || needs.changes.outputs.script_mode != 'none'
+    if: needs.changes.outputs.standard_workspaces != '' || needs.changes.outputs.script_mode != 'none'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -91,15 +93,8 @@ jobs:
         with:
           node-version: '24'
           cache: npm
-      - uses: astral-sh/setup-uv@v6
-        if: needs.changes.outputs.headless == 'true'
-      - name: Install pinned Harbor contract runtime
-        if: needs.changes.outputs.headless == 'true'
-        run: |
-          uv tool install "harbor==0.13.2"
-          uv tool dir --bin >> "$GITHUB_PATH"
       - name: Install Linux runtime dependencies
-        if: needs.changes.outputs.headless == 'true' || needs.changes.outputs.runtime_sandbox == 'true'
+        if: needs.changes.outputs.runtime_sandbox == 'true'
         run: sudo apt-get update && sudo apt-get install -y ripgrep bubblewrap
       # Ubuntu 24.04 hosted runners gate unprivileged user namespaces through
       # AppArmor, which otherwise makes bwrap fail while configuring loopback.
@@ -117,7 +112,6 @@ jobs:
       # tsc outputs (dist/main + dist/renderer side-files), never the vite
       # bundle. e2e builds its own renderer in a separate job.
       - run: npm run build:test
-        if: needs.changes.outputs.unit == 'true' || needs.changes.outputs.script_mode != 'none'
       - name: Linux sandbox smoke
         if: needs.changes.outputs.runtime_sandbox == 'true'
         env:
@@ -132,20 +126,98 @@ jobs:
       # Workspaces consume the dist built above. Selection includes reverse
       # dependencies, while bounded concurrency avoids both the old serial
       # critical path and an unbounded process stampede on two-core runners.
-      - name: Run affected workspace tests
-        if: needs.changes.outputs.unit == 'true'
+      - name: Run affected standard workspace tests
+        if: needs.changes.outputs.standard_workspaces != ''
         env:
-          HEADLESS_AFFECTED: ${{ needs.changes.outputs.headless }}
           STORAGE_STRESS: ${{ needs.changes.outputs.storage_stress }}
-          WORKSPACES: ${{ needs.changes.outputs.workspaces }}
+          WORKSPACES: ${{ needs.changes.outputs.standard_workspaces }}
         run: |
-          if [[ "$HEADLESS_AFFECTED" == "true" ]]; then
-            export MAKA_REQUIRE_HARBOR_CONTRACT=1
-          fi
           if [[ "$STORAGE_STRESS" == "true" ]]; then
             export MAKA_STORAGE_STRESS=1
           fi
           node scripts/run-workspace-tests-parallel.mjs --concurrency=3 --workspaces="$WORKSPACES"
+
+  test_runtime_host:
+    needs: changes
+    if: needs.changes.outputs.runtime_host == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npm run build:test
+      - name: Run Runtime Host tests
+        run: npm --workspace @maka/runtime-host run test:dist
+
+  test_headless:
+    needs: changes
+    if: needs.changes.outputs.headless == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+      - uses: astral-sh/setup-uv@v6
+      - name: Install pinned Harbor contract runtime
+        run: |
+          uv tool install "harbor==0.13.2"
+          uv tool dir --bin >> "$GITHUB_PATH"
+      - name: Install Linux runtime dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep bubblewrap
+      - run: npm ci
+      - run: npm run build:test
+      - name: Run Headless tests
+        env:
+          MAKA_REQUIRE_HARBOR_CONTRACT: '1'
+        run: npm --workspace @maka/headless run test:dist
+
+  # Preserve one stable required check while letting independent heavy suites
+  # occupy their own runners. The aggregator waits for every selected lane.
+  test:
+    needs: [changes, test_workspaces, test_runtime_host, test_headless]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require successful test lanes
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          HEADLESS_RESULT: ${{ needs.test_headless.result }}
+          HEADLESS_SELECTED: ${{ needs.changes.outputs.headless }}
+          RUNTIME_HOST_RESULT: ${{ needs.test_runtime_host.result }}
+          RUNTIME_HOST_SELECTED: ${{ needs.changes.outputs.runtime_host }}
+          SCRIPT_MODE: ${{ needs.changes.outputs.script_mode }}
+          STANDARD_WORKSPACES: ${{ needs.changes.outputs.standard_workspaces }}
+          WORKSPACES_RESULT: ${{ needs.test_workspaces.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "changes failed: $CHANGES_RESULT" >&2
+            exit 1
+          fi
+          require_lane() {
+            local name="$1"
+            local selected="$2"
+            local result="$3"
+            local expected="skipped"
+            if [[ "$selected" == "true" ]]; then
+              expected="success"
+            fi
+            if [[ "$result" != "$expected" ]]; then
+              echo "$name expected $expected but was $result" >&2
+              exit 1
+            fi
+          }
+          workspaces_selected="false"
+          if [[ -n "$STANDARD_WORKSPACES" || "$SCRIPT_MODE" != "none" ]]; then
+            workspaces_selected="true"
+          fi
+          require_lane "workspace tests" "$workspaces_selected" "$WORKSPACES_RESULT"
+          require_lane "Runtime Host tests" "$RUNTIME_HOST_SELECTED" "$RUNTIME_HOST_RESULT"
+          require_lane "Headless tests" "$HEADLESS_SELECTED" "$HEADLESS_RESULT"
 
   e2e:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,10 +219,15 @@ jobs:
           require_lane "Runtime Host tests" "$RUNTIME_HOST_SELECTED" "$RUNTIME_HOST_RESULT"
           require_lane "Headless tests" "$HEADLESS_SELECTED" "$HEADLESS_RESULT"
 
-  e2e:
+  e2e_shard:
     needs: changes
     if: needs.changes.outputs.e2e == 'true'
+    name: e2e_shard (${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -230,19 +235,46 @@ jobs:
           node-version: '24'
           cache: npm
       - run: npm ci
-      # Electron is a GUI app; on a headless Linux runner it needs a virtual
-      # display. The suite already runs with show:false, but the process still
-      # requires an X server to start.
+      # Each shard keeps one Playwright worker on its own runner and X display.
+      # This overlaps independent Electron cold starts without reintroducing
+      # the OS-focus races observed with multiple workers on one display.
       - name: Ensure xvfb
         run: command -v xvfb-run >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y xvfb; }
-      - name: E2E
-        run: xvfb-run -a npm --workspace @maka/desktop run e2e
+      - name: E2E shard ${{ matrix.shard }}/2
+        run: xvfb-run -a npm --workspace @maka/desktop run e2e -- --shard=${{ matrix.shard }}/2
       # Design governance: the CDP alignment auditor walks the e2e-fixture
       # fixtures and fails on same-type height mismatches, mixed-type
-      # centerline drift, or radius-family splits. Reuses the renderer the
-      # e2e step just built; same xvfb pattern.
+      # centerline drift, or radius-family splits. One shard reuses its built
+      # renderer so the audit does not pay for a third runner and build.
       - name: Alignment audit
+        if: matrix.shard == 1
         run: xvfb-run -a node scripts/audit-alignment.mjs
+
+  # Preserve the existing required check while every selected shard retains
+  # its own failure and diagnostic output.
+  e2e:
+    needs: [changes, e2e_shard]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require successful E2E shards
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          E2E_SELECTED: ${{ needs.changes.outputs.e2e }}
+          SHARDS_RESULT: ${{ needs.e2e_shard.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "changes failed: $CHANGES_RESULT" >&2
+            exit 1
+          fi
+          expected="skipped"
+          if [[ "$E2E_SELECTED" == "true" ]]; then
+            expected="success"
+          fi
+          if [[ "$SHARDS_RESULT" != "$expected" ]]; then
+            echo "E2E shards expected $expected but were $SHARDS_RESULT" >&2
+            exit 1
+          fi
 
   # Storybook build + render smoke. Independent of Electron e2e: the smoke
   # launches Playwright Chromium, not `_electron.launch`, so it does not

--- a/apps/desktop/e2e/playwright.config.ts
+++ b/apps/desktop/e2e/playwright.config.ts
@@ -14,8 +14,9 @@ import { defineConfig } from '@playwright/test';
  * What parallel windows DO share is OS focus. Specs that assert
  * `toBeFocused()` (e.g. plan-reminders) fail when another window steals
  * activation mid-assertion — Chromium blurs the document when its window
- * deactivates. CI stays at 1 until those are hardened; local runs take the
- * parallel win, and a local focus failure re-runs alone to confirm.
+ * deactivates. Each CI shard therefore keeps one worker on an isolated X
+ * display; local runs take the parallel win, and a local focus failure re-runs
+ * alone to confirm.
  *
  * Run from apps/desktop via `npm run e2e`, which builds the app first.
  */
@@ -23,6 +24,9 @@ export default defineConfig({
   testDir: '.',
   fullyParallel: true,
   workers: process.env.CI ? 1 : 4,
+  // CI publishes no Playwright report that consumes Git metadata. Disable its
+  // best-effort shallow-history fetch, which otherwise waits on a fixed timeout.
+  captureGitInfo: { commit: false, diff: false },
   // No retries: flakes should fail loudly. The fixture waits for the composer
   // to mount (the cold-start convergence point — connection seed, onboarding
   // clear, renderer hydrated), so cold-start variance never reaches the test.

--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -24,6 +24,8 @@ const TYPECHECK_ONLY_FILES = new Set([
   'tsconfig.lib.json',
 ]);
 
+const DEDICATED_WORKSPACE_LANES = new Set(['packages/runtime-host', 'packages/headless']);
+
 // Scripts the Electron e2e job runs. Editing one of these changes what that
 // job verifies, so it has to re-run — a unit test on the runner is not
 // evidence that the run it drives still works.
@@ -127,17 +129,25 @@ export function reverseDependencyClosure(seedDirs, graph) {
   return graph.dirs.filter((dir) => selected.has(dir));
 }
 
+function workspaceLanes(workspaces) {
+  return {
+    headless: workspaces.includes('packages/headless'),
+    runtimeHost: workspaces.includes('packages/runtime-host'),
+    standardWorkspaces: workspaces.filter((dir) => !DEDICATED_WORKSPACE_LANES.has(dir)),
+  };
+}
+
 export function planTests(changedFiles, options = {}) {
   const graph = options.graph ?? loadWorkspaceGraph(options.repoRoot);
   const files = [...new Set(changedFiles.map(normalizePath).filter(Boolean))];
   const forceFull = options.forceFull ?? false;
   const full = forceFull || files.some((path) => FULL_SUITE_FILES.has(path));
   if (full) {
+    const workspaces = [...graph.dirs];
     return {
       code: true,
       e2e: true,
       full: true,
-      headless: graph.dirs.includes('packages/headless'),
       runtimeSandbox: graph.dirs.includes('packages/cli'),
       scriptMode: 'full',
       // A complete functional suite is still the default release/main gate.
@@ -146,7 +156,8 @@ export function planTests(changedFiles, options = {}) {
       // every unrelated merge into a 10K-chunk pressure run.
       storageStress: false,
       storybook: true,
-      workspaces: [...graph.dirs],
+      workspaces,
+      ...workspaceLanes(workspaces),
     };
   }
 
@@ -204,7 +215,6 @@ export function planTests(changedFiles, options = {}) {
       directWorkspaces.has('packages/ui') ||
       files.some((path) => E2E_DRIVING_SCRIPTS.has(path)),
     full: false,
-    headless: workspaces.includes('packages/headless'),
     // packages/cli/src/__tests__/runtime-bootstrap.test.ts executes real sandboxed
     // shell tools, so the bubblewrap + user-namespace setup is required whenever
     // the cli workspace runs in the dependency closure, not only for direct
@@ -217,6 +227,7 @@ export function planTests(changedFiles, options = {}) {
     // isStorybookPath.
     storybook: files.some((path) => isStorybookPath(path)),
     workspaces,
+    ...workspaceLanes(workspaces),
   };
 }
 
@@ -226,11 +237,13 @@ export function formatGitHubOutputs(plan) {
     `e2e=${plan.e2e}`,
     `full=${plan.full}`,
     `headless=${plan.headless}`,
+    `runtime_host=${plan.runtimeHost}`,
     `runtime_sandbox=${plan.runtimeSandbox}`,
     `script_mode=${plan.scriptMode}`,
     `storage_stress=${plan.storageStress}`,
     `storybook=${plan.storybook}`,
     `unit=${plan.workspaces.length > 0}`,
+    `standard_workspaces=${plan.standardWorkspaces.join(',')}`,
     `workspaces=${plan.workspaces.join(',')}`,
   ].join('\n');
 }

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { loadWorkspaceGraph, planTests } from './ci-test-plan.mjs';
+import { formatGitHubOutputs, loadWorkspaceGraph, planTests } from './ci-test-plan.mjs';
 
 const graph = loadWorkspaceGraph();
 
@@ -98,6 +98,36 @@ test('sandbox is flagged whenever the cli workspace runs in the closure', () => 
   ]) {
     assert.equal(planTests([path], { graph }).runtimeSandbox, true, path);
   }
+});
+
+test('heavy workspaces are projected onto dedicated CI lanes', () => {
+  const runtimeHost = planTests(['packages/runtime-host/src/server/index.ts'], { graph });
+  assert.equal(runtimeHost.runtimeHost, true);
+  assert.equal(runtimeHost.headless, false);
+  assert.deepEqual(runtimeHost.standardWorkspaces, ['packages/cli']);
+
+  const runtime = planTests(['packages/runtime/src/index.ts'], { graph });
+  assert.equal(runtime.runtimeHost, true);
+  assert.equal(runtime.headless, true);
+  assert.deepEqual(runtime.standardWorkspaces, [
+    'packages/runtime',
+    'packages/computer-use',
+    'packages/cli',
+    'apps/desktop',
+  ]);
+
+  const full = planTests([], { graph, forceFull: true });
+  assert.equal(full.runtimeHost, true);
+  assert.equal(full.headless, true);
+  assert.deepEqual(
+    full.standardWorkspaces,
+    graph.dirs.filter((dir) => dir !== 'packages/runtime-host' && dir !== 'packages/headless'),
+  );
+
+  const outputs = formatGitHubOutputs(runtimeHost).split('\n');
+  assert.ok(outputs.includes('runtime_host=true'));
+  assert.ok(outputs.includes('headless=false'));
+  assert.ok(outputs.includes('standard_workspaces=packages/cli'));
 });
 
 test('global and unknown production changes fail safe to the complete suite', () => {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- project affected workspaces into standard, Runtime Host, and Headless test lanes
- run Runtime Host and Headless on independent runners instead of one shared workspace critical path
- split the Desktop Electron suite into two 29-test Playwright shards, each with one worker on its own runner and X display
- run the Alignment audit after one shard so it reuses that shard's built renderer without requiring a third build
- retain stable `test` and `e2e` checks that wait for every selected lane and verify exact success/skip outcomes
- disable unused Playwright Git metadata capture and its fixed shallow-history fetch timeout

## Why

The workspace test job previously combined independent heavy suites on one two-core runner and then ran Headless serially. Separately, Desktop E2E launched 58 isolated Electron applications through one CI worker because multiple workers on one X display have real OS-focus races.

The workspace lanes give independent suites their own capacity. The E2E shards preserve one worker per display—and therefore the focus behavior—while overlapping independent Electron cold starts across isolated runners.

## Safety

- the existing impact planner remains the source of truth
- both Playwright shards retain `workers: 1`, `retries: 0`, and the existing timeouts
- local enumeration proves the shards contain 29 tests each and their disjoint union is the original 58-test suite
- Alignment coverage and all test assertions are unchanged
- selected lanes must succeed; unselected lanes must be skipped; failed or cancelled lanes fail the stable aggregate check

This trades bounded runner parallelism for lower feedback latency. Narrow changes still start only the lanes selected by the dependency closure.

## Validation

- `npm run test:scripts`: 24 passed
- CI planner and workspace scheduler tests: 9 passed
- `npm --workspace @maka/desktop run typecheck`
- `npm run lint`
- `npm run format:check`
- full Desktop build through `npm run e2e -- --shard=1/2 --list`
- Playwright shard enumeration: 29 + 29 tests, no omissions or duplicates
- workflow YAML and job dependency structure parsed locally

</details>

<details>
<summary>中文</summary>

## 概要

- 将受影响的 workspace 投影为普通、Runtime Host 和 Headless 三条测试 lane
- 将 Runtime Host 与 Headless 放到独立 runner，不再占用同一条 workspace 关键路径
- 将 Desktop Electron suite 拆为两条各含 29 个测试的 Playwright shard；每条仍在独立 runner 和 X display 上使用一个 worker
- Alignment audit 跟随其中一条 shard，复用其已构建 renderer，避免第三次构建
- 保留稳定的 `test` 与 `e2e` 检查；它们会等待全部已选择 lane，并严格核对成功/跳过状态
- 关闭未被使用的 Playwright Git metadata 捕获及其固定浅历史 fetch 超时

## 原因

原 workspace test job 会在同一个两核 runner 上组合多个相互独立的重型 suite，最后再串行运行 Headless。与此同时，Desktop E2E 会通过一个 CI worker 依次启动 58 个相互隔离的 Electron 应用；这是因为同一 X display 上的多个 worker 已被证实会发生真实 OS focus 竞态。

Workspace lane 为独立 suite 提供独立容量。E2E shard 继续保持每个 display 只有一个 worker，从而保留原有 focus 行为，同时在相互隔离的 runner 之间重叠 Electron 冷启动。

## 安全性

- 继续以现有 impact planner 为唯一选择依据
- 两条 Playwright shard 均保留 `workers: 1`、`retries: 0` 和现有 timeout
- 本地枚举证明两条 shard 各有 29 个测试，其无交集并集等于原有 58 个测试
- Alignment 覆盖与所有测试断言均未改变
- 应运行的 lane 必须成功，未选择的 lane 必须跳过；失败或取消都会使稳定聚合检查失败

本方案以有限的 runner 并行度换取更短反馈时间；范围较窄的改动仍只启动依赖闭包选中的 lane。

## 验证

- `npm run test:scripts`：24 个通过
- CI planner 与 workspace scheduler 测试：9 个通过
- `npm --workspace @maka/desktop run typecheck`
- `npm run lint`
- `npm run format:check`
- 通过 `npm run e2e -- --shard=1/2 --list` 完成 Desktop 全量构建
- Playwright shard 枚举：29 + 29 个测试，无遗漏或重复
- 本地解析 workflow YAML 与 job 依赖结构

</details>
