### PR TITLE
fix(desktop): restore Astryx composer focus ownership

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-focus-ownership-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-focus-ownership-contract.test.ts
@@ -1,0 +1,18 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { parseCssBlocks, readAllRendererCss } from './css-test-helpers.js';
+
+describe('composer focus ownership CSS contract', () => {
+  it('keeps Astryx composer internals outside product CSS', async () => {
+    const blocks = parseCssBlocks(await readAllRendererCss());
+    const internalRules = blocks
+      .map((block) => block.rule)
+      .filter((selector) => /\.maka-composer-editor(?:\s*[>+~]|\s+)/.test(selector));
+
+    assert.deepEqual(
+      internalRules,
+      [],
+      'Maka CSS may position the ChatComposerInput root but must not style its Astryx-owned descendants',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -202,7 +202,6 @@
   --muted:         oklch(from var(--foreground) l c h / 0.05);
   --muted-foreground: color-mix(in oklch, var(--foreground) 50%, var(--background));
   --foreground-secondary: color-mix(in oklch, var(--foreground) 80%, var(--background));
-  --ring:          oklch(from var(--foreground) l c h / 0.25);
   --state-hover-bg:    oklch(from var(--foreground) l c h / 0.04);
   --state-selected-bg: oklch(from var(--foreground) l c h / 0.065);
   /* PR5 FOREGROUND-ALPHA-TOKEN-0: raw foreground-alpha tiers for component
@@ -615,10 +614,9 @@
    --opacity-overlay: 0.04;   /* body::after subtle overlay (light) */
 
    /* === focus-ring recipe ===
-      --focus-ring is the strong accent color (existing); --ring is the
-      subtle foreground-derived color (existing, for compact/secondary
-      focus). These two geometry tokens converge outline width and offset so
-      every focus ring shares one recipe instead of hand-written 2px. The
+      --focus-ring is the strong accent color. These two geometry tokens
+      converge outline width and offset so every focus ring shares one recipe
+      instead of hand-written 2px. The
       recipe once carried a third, the outer glow halo width, but nothing
       drew that halo.
       PR-FOCUS-RING-RECIPE-0 (issue #520 PR2). */
@@ -651,7 +649,6 @@
   --w-sidebar: 240px;
   --w-rail: 240px;
   --h-titlebar: 36px;
-  --h-composer-min: 44px;
 
   /* OS window-resize corridor. A draggable app-region rect flush against a
      window edge takes the native resize hit area with it — that is the P0 WAWQAQ
@@ -693,8 +690,8 @@
      The historic sidebar/会话/设置 height drift came from off-ruler bare px
      (22/26/30/34/38); this scale converges them. Square icon controls use
      the same token for width and height (their footprint = control size).
-     App-chrome bars (--h-titlebar/--h-composer-min) stay as their own
-     semantic tokens — they are structure, not controls.
+     The app-chrome bar (--h-titlebar) stays as its own semantic token — it is
+     structure, not a control.
      xs/sm/2xl (20/24/40) stay on the --space-* ruler: Astryx has no element
      token at those sizes, and 20px is what its own Badge and Kbd take from
      --spacing-5, so that tier already agrees by construction. */
@@ -1175,11 +1172,6 @@ html[data-os="darwin"].dark {
   ::-webkit-scrollbar-corner { background: transparent; }
 
   ::selection { background: var(--selection); }
-
-  *:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 var(--focus-ring-width) var(--ring);
-  }
 
   /* Subtle film-grain overlay. Per the taste-skill and frontend-design
      skill, fixed pointer-events-none noise breaks the digital flatness

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -206,45 +206,6 @@
   padding-top: 0;
 }
 
-/* The input owns no chrome (the card does). ChatComposerInput sizes itself from
-   `maxRows`, so only the resting minimum is ours. Type is the `body` role, one
-   token for the whole shorthand — not a local 14/22 magic pair, and not a
-   fallback chain, since the role is the only vocabulary left.
-
-   Kill the global `*:focus-visible` ring (maka-tokens) — Astryx ChatComposer
-   elevates the outer shell on focus-within; a second rectangle on the field
-   is the bug users describe as “输入后出现长方形边框”. */
-.composer .maka-composer-editor > [contenteditable] {
-  font: var(--maka-text-body);
-  width: 100%;
-  border: none;
-  outline: none;
-  box-shadow: none;
-  background: transparent;
-  color: var(--foreground);
-  min-height: var(--h-composer-min);
-}
-
-.composer .maka-composer-editor > [contenteditable]:focus,
-.composer .maka-composer-editor > [contenteditable]:focus-visible {
-  border: none;
-  outline: none;
-  box-shadow: none;
-}
-
-.composer .maka-composer-editor > [aria-hidden="true"] {
-  /* Astryx renders the placeholder as a sibling of the editable, not inside
-     it, so `font: inherit` would resolve against the card. Name the same role
-     the editable names. */
-  font: var(--maka-text-body);
-  color: var(--muted-foreground);
-  transition: opacity var(--duration-emphasized) var(--ease-out-strong);
-}
-
-.composer .maka-composer-editor:focus-within > [aria-hidden="true"] {
-  opacity: var(--opacity-disabled);
-}
-
 /* Composer send button — flat solid action fill. #546: dropped the gradient
    + inner sheen + drop shadow (the "machined hardware" look read heavy next
    to the calm parchment container). Flat --action with darken on hover/press

--- a/apps/desktop/stories/product-smoke-manifest.json
+++ b/apps/desktop/stories/product-smoke-manifest.json
@@ -106,6 +106,18 @@
       "colorSchemes": ["light", "dark"],
       "checks": ["session-context-layer"]
     },
+    "composer": {
+      "storyId": "product-shell-official-appshell--new-chat-composer",
+      "productionHost": "ChatView > Composer > Astryx ChatComposer",
+      "state": "Focused empty editor before the first message is sent",
+      "viewports": ["wide"],
+      "colorSchemes": ["light", "dark"],
+      "checks": ["composer-focus-ownership"],
+      "viewportOptOuts": {
+        "compact": "Focus ownership is independent of viewport geometry.",
+        "floor": "Focus ownership is independent of viewport geometry."
+      }
+    },
     "askUserQuestion": {
       "storyId": "product-ask-user-question--pending-decisions",
       "productionHost": "UserQuestionPrompt (the ChatComposerRegion takeover is out of scope)",

--- a/scripts/storybook-visual-smoke.mjs
+++ b/scripts/storybook-visual-smoke.mjs
@@ -20,9 +20,14 @@ const REQUIRED_PRODUCT_SURFACES = Object.freeze([
   'planReminders',
   'dailyReview',
   'sessionContext',
+  'composer',
 ]);
 
-const PRODUCT_CHECKS = new Set(['plan-reminder-row', 'session-context-layer']);
+const PRODUCT_CHECKS = new Set([
+  'composer-focus-ownership',
+  'plan-reminder-row',
+  'session-context-layer',
+]);
 
 function fail(message) {
   throw new Error(`Product Storybook manifest: ${message}`);
@@ -290,6 +295,43 @@ async function smokeStory(page, baseUrl, job, options = {}) {
               failures.push(
                 `session context layer overflows horizontally (${layer.scrollWidth} > ${layer.clientWidth})`,
               );
+            }
+          }
+        }
+        if (checks.includes('composer-focus-ownership')) {
+          const editor = document.querySelector('.maka-composer-editor > [contenteditable="true"]');
+          const composer = editor?.closest('[data-maka-contract="composer-inner"]');
+          if (!(editor instanceof HTMLElement) || !(composer instanceof HTMLElement)) {
+            failures.push('composer editor or Astryx focus surface is missing');
+          } else {
+            editor.focus();
+            const style = getComputedStyle(editor);
+            const actual = {
+              backgroundColor: style.backgroundColor,
+              borderWidth: style.borderWidth,
+              boxShadow: style.boxShadow,
+              minHeight: style.minHeight,
+              outlineStyle: style.outlineStyle,
+            };
+            const expected = {
+              backgroundColor: 'rgba(0, 0, 0, 0)',
+              borderWidth: '0px',
+              boxShadow: 'none',
+              minHeight: 'auto',
+              outlineStyle: 'none',
+            };
+            for (const [property, expectedValue] of Object.entries(expected)) {
+              if (actual[property] !== expectedValue) {
+                failures.push(
+                  `composer editor ${property} must be ${expectedValue}, got ${actual[property]}`,
+                );
+              }
+            }
+            if (document.activeElement !== editor) {
+              failures.push('composer editor did not retain focus');
+            }
+            if (!composer.matches(':focus-within')) {
+              failures.push('Astryx composer surface did not receive the focus-within state');
             }
           }
         }

--- a/scripts/storybook-visual-smoke.mjs
+++ b/scripts/storybook-visual-smoke.mjs
@@ -304,20 +304,51 @@ async function smokeStory(page, baseUrl, job, options = {}) {
           if (!(editor instanceof HTMLElement) || !(composer instanceof HTMLElement)) {
             failures.push('composer editor or Astryx focus surface is missing');
           } else {
+            const focusAncestors = [];
+            for (let element = editor.parentElement; element; element = element.parentElement) {
+              focusAncestors.push(element);
+              if (element === composer) break;
+            }
+            const visibleFocusChrome = (element) => {
+              const style = getComputedStyle(element);
+              const border = ['Top', 'Right', 'Bottom', 'Left'].flatMap((side) => {
+                const width = Number.parseFloat(style[`border${side}Width`]);
+                return width > 0
+                  ? [
+                      `${side}:${style[`border${side}Style`]} ${width}px ${style[`border${side}Color`]}`,
+                    ]
+                  : [];
+              });
+              return {
+                border,
+                boxShadow: style.boxShadow === 'none' ? null : style.boxShadow,
+                outline:
+                  style.outlineStyle === 'none' || Number.parseFloat(style.outlineWidth) === 0
+                    ? null
+                    : `${style.outlineStyle} ${style.outlineWidth} ${style.outlineColor}`,
+              };
+            };
+            const restingChrome = focusAncestors.map(visibleFocusChrome);
             editor.focus();
+            // Resolve Astryx's focus transition to its final state before
+            // comparing computed presentation. The contract is the visible
+            // owner, not an intermediate animation frame.
+            for (const element of focusAncestors) {
+              void getComputedStyle(element).boxShadow;
+              for (const animation of element.getAnimations()) animation.finish();
+            }
+            const focusedChrome = focusAncestors.map(visibleFocusChrome);
             const style = getComputedStyle(editor);
             const actual = {
               backgroundColor: style.backgroundColor,
               borderWidth: style.borderWidth,
               boxShadow: style.boxShadow,
-              minHeight: style.minHeight,
               outlineStyle: style.outlineStyle,
             };
             const expected = {
               backgroundColor: 'rgba(0, 0, 0, 0)',
               borderWidth: '0px',
               boxShadow: 'none',
-              minHeight: 'auto',
               outlineStyle: 'none',
             };
             for (const [property, expectedValue] of Object.entries(expected)) {
@@ -330,8 +361,16 @@ async function smokeStory(page, baseUrl, job, options = {}) {
             if (document.activeElement !== editor) {
               failures.push('composer editor did not retain focus');
             }
-            if (!composer.matches(':focus-within')) {
-              failures.push('Astryx composer surface did not receive the focus-within state');
+            const visibleOwner = focusedChrome.some((focused, index) => {
+              const changed = JSON.stringify(focused) !== JSON.stringify(restingChrome[index]);
+              const visible =
+                focused.border.length > 0 || focused.boxShadow !== null || focused.outline !== null;
+              return changed && visible;
+            });
+            if (!visibleOwner) {
+              failures.push(
+                'no Astryx composer ancestor produced visible border, shadow, or outline focus feedback',
+              );
             }
           }
         }


### PR DESCRIPTION
## Summary

- Remove Maka's global `*:focus-visible` rewrite and product CSS that reached into Astryx `ChatComposerInput` internals.
- Let Astryx remain the single owner of editor geometry, typography, placeholder, and focus-within presentation; remove the now-dead `--h-composer-min` and `--ring` tokens.
- Add a required Storybook smoke contract that focuses the real composer in light and dark themes, verifies the editor has no independent chrome, and proves an Astryx-owned ancestor produces visible focus feedback.
- Add a source-level CSS ownership contract so Maka may position the `ChatComposerInput` root but cannot style its Astryx-owned descendants.

## Root cause

Maka had two competing focus owners: a global renderer rule added a ring to every focused element, while composer-specific CSS cancelled that ring and independently restyled Astryx's contenteditable and placeholder. The same override also forced the editor to `min-height: 44px`, producing a second rectangular input area inside the composer shell. Removing both overrides restores the component boundary instead of maintaining a compensating exception.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `node scripts/check-dead-css.mjs --check`
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run smoke:storybook` — 67 manifest checks and 70 catalog renders passed
- `npm --workspace @maka/desktop run build:main && node --test apps/desktop/dist/main/__tests__/composer-focus-ownership-contract.test.js`
- `npm --workspace @maka/desktop run build`
- `npx playwright test --config e2e/playwright.config.ts e2e/plan-reminders.spec.ts --workers=1` — 2 passed after rebuilding the renderer
- Live Electron check: typed into the focused composer and verified `document.activeElement` is the contenteditable, with transparent background, zero border width, no inner box shadow/outline, and Astryx-owned natural geometry.

### Visual evidence

Live Electron before/after captured from the same deterministic fake-backend fixture. Left: Maka's fixed 44px editor. Right: Astryx-owned natural editor geometry.

<img width="3108" height="680" alt="Maka composer focus before and after" src="https://github.com/user-attachments/assets/7b2cd8ce-4116-47f8-9b73-af79614b2b96" />
