### PR TITLE
test(runtime-host): stabilize asynchronous lifecycle fixtures

### DIFF
--- a/packages/runtime-host/src/__tests__/fixtures/electron-connect-parent.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/electron-connect-parent.ts
@@ -2,24 +2,40 @@ import {
   prepareStorageRootControlDirectory,
   resolveStorageRoot,
 } from '@maka/storage/root-authority';
-import { connectOrSpawnRuntimeHost } from '../../client/index.js';
+import { connectOrSpawnRuntimeHostWithDependencies } from '../../client/connect-or-spawn.js';
+import { launchDetachedRuntimeHostCandidate } from '../../client/launcher.js';
 import { readHostRegistration } from '../../control/registration.js';
 import { RUNTIME_HOST_PROTOCOL_VERSION } from '../../protocol/index.js';
 
-const [rootPath] = process.argv.slice(2);
+const [rootPath, mode] = process.argv.slice(2);
 if (!rootPath) throw new Error('usage: electron-connect-parent <root>');
 if (!process.versions.electron)
   throw new Error('electron-connect-parent requires Electron Node mode');
 
-const result = await connectOrSpawnRuntimeHost({
-  rootPath,
-  surface: 'desktop',
-  protocol: {
-    min: RUNTIME_HOST_PROTOCOL_VERSION,
-    max: RUNTIME_HOST_PROTOCOL_VERSION,
+const result = await connectOrSpawnRuntimeHostWithDependencies(
+  {
+    rootPath,
+    surface: 'desktop',
+    protocol: {
+      min: RUNTIME_HOST_PROTOCOL_VERSION,
+      max: RUNTIME_HOST_PROTOCOL_VERSION,
+    },
+    electionDeadlineMs: 5_000,
   },
-  electionDeadlineMs: 5_000,
-});
+  {
+    random: Math.random,
+    launchCandidate: (input) => {
+      const launch = launchDetachedRuntimeHostCandidate(input);
+      return {
+        spawned: launch.spawned.then(async (attempt) => {
+          await sendToParent({ type: 'electron-candidate-launched', pid: attempt.pid });
+          if (mode === 'exit-after-candidate-launch') process.exit(23);
+          return attempt;
+        }),
+      };
+    },
+  },
+);
 if (result.kind !== 'connected') {
   throw new Error(`Electron Client failed to connect: ${result.kind}`);
 }

--- a/packages/runtime-host/src/__tests__/goal-root-authority.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-root-authority.test.ts
@@ -343,7 +343,7 @@ test('Automation turns can use Goal tools and contribute evaluation evidence', a
       },
     });
 
-    const goal = await waitForGoalStatus(fixture, 'achieved');
+    const goal = await fixture.waitForGoalStatus('achieved');
     assert.equal(goal.condition, 'Automation Goal completes');
     assert.equal(goal.lastReason, 'verified');
     assert.equal(fixture.drainRequested(), false);
@@ -498,8 +498,12 @@ interface Fixture {
   readonly messages: HostMessageCoordinator;
   readonly sessionAdmission: SessionAdmissionGate;
   readonly drainRequested: () => boolean;
+  waitForGoalStatus(status: GoalStatus): Promise<GoalState>;
   close(): Promise<void>;
 }
+
+type GoalState = NonNullable<ReturnType<HostGoalCoordinator['manager']['get']>>;
+type GoalStatus = GoalState['status'];
 
 async function createFixture(options: { recoverAdmissions?: boolean } = {}): Promise<Fixture> {
   const base = await mkdtemp(join(tmpdir(), 'maka-goal-root-'));
@@ -524,6 +528,7 @@ async function createFixture(options: { recoverAdmissions?: boolean } = {}): Pro
   let projection: CanonicalSessionProjectionReader | undefined;
   let goal: HostGoalCoordinator | undefined;
   let requestedDrain = false;
+  const goalChangeListeners = new Set<() => void>();
   const rootPort: HostMessageRootPort = {
     readSessionHeader: (sessionId) => requireCoordinator(coordinator).readSessionHeader(sessionId),
     readRootState: (sessionId) => requireCoordinator(coordinator).readRootState(sessionId),
@@ -633,8 +638,10 @@ async function createFixture(options: { recoverAdmissions?: boolean } = {}): Pro
       rootCoordinator.admitGoalTurn(sessionId, checkpoint, controlLease, text),
     listActionableTaskKeys: async () => [],
     acquireResidency,
-    onProjectionChanged: (sessionId) =>
-      requireContinuity(continuity).enqueueCanonicalRefresh(sessionId),
+    onProjectionChanged: (sessionId) => {
+      requireContinuity(continuity).enqueueCanonicalRefresh(sessionId);
+      for (const listener of goalChangeListeners) listener();
+    },
   });
   const goalCoordinator = goal;
 
@@ -650,6 +657,23 @@ async function createFixture(options: { recoverAdmissions?: boolean } = {}): Pro
     messages,
     sessionAdmission: admission,
     drainRequested: () => requestedDrain,
+    waitForGoalStatus: (status) =>
+      new Promise<GoalState>((resolve, reject) => {
+        let timeout: NodeJS.Timeout | undefined;
+        const check = () => {
+          const current = goalCoordinator.manager.get(session.id);
+          if (current?.status !== status) return;
+          if (timeout) clearTimeout(timeout);
+          goalChangeListeners.delete(check);
+          resolve(current);
+        };
+        goalChangeListeners.add(check);
+        timeout = setTimeout(() => {
+          goalChangeListeners.delete(check);
+          reject(new Error(`Goal did not reach ${status}`));
+        }, 10_000);
+        check();
+      }),
     async close() {
       goalCoordinator.beginDrain();
       rootCoordinator.beginDrain();
@@ -685,18 +709,6 @@ async function waitForGoalRun(
     await new Promise<void>((resolve) => setImmediate(resolve));
   }
   throw new Error('Goal continuation did not reach the root authority');
-}
-
-async function waitForGoalStatus(
-  fixture: Fixture,
-  status: NonNullable<ReturnType<Fixture['goal']['manager']['get']>>['status'],
-) {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    const goal = fixture.goal.manager.get(fixture.sessionId);
-    if (goal?.status === status) return goal;
-    await new Promise<void>((resolve) => setImmediate(resolve));
-  }
-  throw new Error(`Goal did not reach ${status}`);
 }
 
 function runHeader(overrides: Partial<AgentRunHeader>): AgentRunHeader {

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -621,7 +621,7 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
-  test('a Host launched by the public Electron Client survives its parent process', async () => {
+  test('an Electron Client using the real Candidate launcher survives its parent process', async () => {
     const electronPath = require('electron') as string;
     await withHostPaths(async (paths) => {
       const parent = paths.resources.trackChild(
@@ -632,9 +632,16 @@ describe('non-serving Runtime Host kernel', () => {
           env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
         }),
       );
-      const launched = await waitForElectronParentLaunch(parent);
-      paths.resources.trackPid(launched.pid);
+      const launched = await waitForElectronParentLaunch(parent, (pid) =>
+        paths.resources.trackPid(pid),
+      );
       await waitForSuccessfulExit(parent, 'Electron connect parent');
+      assert.ok(launched.candidatePids.includes(launched.pid));
+      for (const pid of launched.candidatePids) {
+        if (pid === launched.pid) continue;
+        await waitForProcessExit(pid);
+        paths.resources.forgetPid(pid);
+      }
 
       const connected = await retryConnect(paths, CURRENT_PROTOCOL);
       assert.equal(connected.kind, 'connected');
@@ -647,6 +654,34 @@ describe('non-serving Runtime Host kernel', () => {
       await waitForProcessExit(launched.pid);
       paths.resources.forgetPid(launched.pid);
     });
+  });
+
+  test('Electron Candidate cleanup owns a launch reported before its parent fails', async () => {
+    const electronPath = require('electron') as string;
+    let candidatePid: number | undefined;
+    await withHostPaths(async (paths) => {
+      const parent = paths.resources.trackChild(
+        fork(
+          new URL('./fixtures/electron-connect-parent.js', import.meta.url),
+          [paths.root, 'exit-after-candidate-launch'],
+          {
+            execPath: electronPath,
+            execArgv: [],
+            stdio: ['ignore', 'ignore', 'inherit', 'ipc'],
+            env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+          },
+        ),
+      );
+      await assert.rejects(
+        waitForElectronParentLaunch(parent, (pid) => {
+          candidatePid = paths.resources.trackPid(pid);
+        }),
+        /Electron connect parent exited before reporting its Host: 23/,
+      );
+      assert.ok(candidatePid);
+    });
+    assert.ok(candidatePid);
+    assert.equal(isProcessAlive(candidatePid), false);
   });
 
   test('a response timeout is connection-fatal and Client close stays local', {
@@ -1646,8 +1681,10 @@ function waitForLaunch(child: ChildProcess): Promise<number> {
 
 function waitForElectronParentLaunch(
   child: ChildProcess,
-): Promise<{ hostEpoch: string; pid: number }> {
+  onCandidateLaunched: (pid: number) => void,
+): Promise<{ hostEpoch: string; pid: number; candidatePids: number[] }> {
   return new Promise((resolve, reject) => {
+    const candidatePids: number[] = [];
     const timer = setTimeout(() => {
       cleanup();
       reject(new Error('Electron connect parent did not report its Host'));
@@ -1669,9 +1706,18 @@ function waitForElectronParentLaunch(
       );
     };
     const onMessage = (message: unknown) => {
+      if (isElectronCandidateLaunch(message)) {
+        candidatePids.push(message.pid);
+        onCandidateLaunched(message.pid);
+        return;
+      }
       if (!isElectronParentLaunch(message)) return;
       cleanup();
-      resolve({ hostEpoch: message.hostEpoch, pid: message.pid });
+      resolve({
+        hostEpoch: message.hostEpoch,
+        pid: message.pid,
+        candidatePids,
+      });
     };
     child.once('error', onError);
     child.once('exit', onExit);
@@ -1679,9 +1725,23 @@ function waitForElectronParentLaunch(
   });
 }
 
-function isElectronParentLaunch(
+function isElectronCandidateLaunch(
   value: unknown,
-): value is { type: 'electron-parent-launched'; hostEpoch: string; pid: number } {
+): value is { type: 'electron-candidate-launched'; pid: number } {
+  if (!value || typeof value !== 'object') return false;
+  const message = value as Record<string, unknown>;
+  return (
+    message.type === 'electron-candidate-launched' &&
+    Number.isSafeInteger(message.pid) &&
+    (message.pid as number) > 0
+  );
+}
+
+function isElectronParentLaunch(value: unknown): value is {
+  type: 'electron-parent-launched';
+  hostEpoch: string;
+  pid: number;
+} {
   if (!value || typeof value !== 'object') return false;
   const message = value as Record<string, unknown>;
   return (


### PR DESCRIPTION
## Summary

- wait for the authoritative Goal projection change instead of counting event-loop turns
- report every detached Electron Candidate PID immediately and join losing Candidates before removing control directories
- cover parent failure after Candidate launch but before the final Host report
- keep the change test-only; production lifecycle behavior is unchanged

## Verification

- npm run build:test
- Goal automation regression: 30/30 focused passes before review, plus 10/10 after review
- Electron success and pre-report failure cleanup regressions: 20/20 combined focused passes
- npm --workspace @maka/runtime-host run test:dist: 571/571 on the final local run
- npm run lint
- npm run format:check
- independent delegated review: GO, no remaining P0-P3

An earlier full Runtime Host run hit the existing load-sensitive session.create request timeout; its focused rerun passed, and both subsequent full runs were green.