### PR TITLE
fix: keep streamed tool calls alive when a gateway skips index 0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@biomejs/biome": "2.5.4",
         "@types/node": "^25.0.0",
         "knip": "^6.26.0",
+        "patch-package": "8.0.1",
         "typescript": "^7.0.2"
       },
       "engines": {
@@ -4438,6 +4439,13 @@
         "addons/*"
       ]
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
@@ -5024,6 +5032,19 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -5206,6 +5227,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -5726,7 +5766,6 @@
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -6733,6 +6772,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -6780,6 +6832,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
       }
     },
     "node_modules/flow-estree": {
@@ -7185,7 +7247,6 @@
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -7570,6 +7631,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -7616,6 +7687,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -7790,6 +7868,26 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -7823,6 +7921,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7841,6 +7949,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/knip": {
@@ -8772,6 +8890,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -9136,7 +9281,6 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -9368,6 +9512,111 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/path-exists": {
@@ -10463,6 +10712,24 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -10606,6 +10873,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/slice-ansi": {
@@ -11028,6 +11305,19 @@
       "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "apps/desktop"
   ],
   "scripts": {
-    "postinstall": "install-electron",
+    "postinstall": "patch-package --error-on-fail && install-electron",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "format:check": "biome format .",
@@ -77,6 +77,7 @@
     "@biomejs/biome": "2.5.4",
     "@types/node": "^25.0.0",
     "knip": "^6.26.0",
+    "patch-package": "8.0.1",
     "typescript": "^7.0.2"
   },
   "allowScripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "apps/desktop"
   ],
   "scripts": {
-    "postinstall": "patch-package --error-on-fail && install-electron",
+    "postinstall": "node scripts/apply-dependency-patches.mjs && install-electron",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/packages/runtime/src/__tests__/model-factory-tool-call-index.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-tool-call-index.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { LanguageModelV4CallOptions, LanguageModelV4StreamPart } from '@ai-sdk/provider';
+import type { RuntimeExecutionConnection } from '@maka/core';
+import { getAIModel } from '@maka/runtime';
+
+/**
+ * Regression guard for #1967: OpenAI-compatible gateways are free to label streamed
+ * `tool_calls[].index` with any stable number — the field identifies which tool call a
+ * delta belongs to, it is not an array position. Anthropic→OpenAI translators commonly
+ * reuse the Anthropic content-block index, so the first tool call arrives as index 1
+ * once a text block consumed index 0. This must stream through like any other tool call.
+ */
+
+const connection: RuntimeExecutionConnection = {
+  slug: 'relay',
+  providerType: 'openai-compatible',
+  baseUrl: 'https://relay.invalid/v1',
+  defaultModel: 'claude-opus-4-8',
+};
+
+const prompt: LanguageModelV4CallOptions['prompt'] = [
+  { role: 'user', content: [{ type: 'text', text: 'read a.txt' }] },
+];
+
+const tools: LanguageModelV4CallOptions['tools'] = [
+  {
+    type: 'function',
+    name: 'read_file',
+    inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+  },
+];
+
+function chunk(delta: unknown, finishReason: string | null = null): unknown {
+  return {
+    id: 'chatcmpl-1',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: 'claude-opus-4-8',
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+/** A gateway turn that emits one text block, then one tool call at `toolCallIndex`. */
+function streamingRelay(toolCallIndex: number): typeof globalThis.fetch {
+  const payloads = [
+    chunk({ role: 'assistant', content: 'Reading it.' }),
+    chunk({
+      tool_calls: [
+        {
+          index: toolCallIndex,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'read_file', arguments: '' },
+        },
+      ],
+    }),
+    chunk({ tool_calls: [{ index: toolCallIndex, function: { arguments: '{"path":"a.txt"}' } }] }),
+    chunk({}, 'tool_calls'),
+  ];
+  const body = `${payloads.map((payload) => `data: ${JSON.stringify(payload)}\n\n`).join('')}data: [DONE]\n\n`;
+  return async () =>
+    new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+}
+
+async function collectStream(toolCallIndex: number): Promise<LanguageModelV4StreamPart[]> {
+  const model = getAIModel({
+    connection,
+    apiKey: 'test-key',
+    modelId: 'claude-opus-4-8',
+    fetch: streamingRelay(toolCallIndex),
+  });
+  const { stream } = await model.doStream({ prompt, tools });
+  const parts: LanguageModelV4StreamPart[] = [];
+  for await (const part of stream) parts.push(part);
+  return parts;
+}
+
+function toolCallOf(parts: LanguageModelV4StreamPart[]) {
+  return parts.find((part) => part.type === 'tool-call');
+}
+
+describe('getAIModel: OpenAI-compatible streamed tool_calls index', () => {
+  for (const toolCallIndex of [0, 1, 7]) {
+    test(`emits the tool call when the gateway labels it index ${toolCallIndex}`, async () => {
+      const parts = await collectStream(toolCallIndex);
+
+      assert.deepEqual(
+        toolCallOf(parts),
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'read_file',
+          input: '{"path":"a.txt"}',
+        },
+        'the tool call must survive whatever index the gateway assigned',
+      );
+      assert.equal(
+        parts.at(-1)?.type,
+        'finish',
+        'the stream must close cleanly instead of failing the whole turn',
+      );
+      assert.deepEqual(
+        parts.filter((part) => part.type === 'error'),
+        [],
+        'a non-zero tool call index is not a stream error',
+      );
+    });
+  }
+});

--- a/packages/runtime/src/__tests__/model-factory-tool-call-index.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-tool-call-index.test.ts
@@ -41,21 +41,24 @@ function chunk(delta: unknown, finishReason: string | null = null): unknown {
   };
 }
 
-/** A gateway turn that emits one text block, then one tool call at `toolCallIndex`. */
-function streamingRelay(toolCallIndex: number): typeof globalThis.fetch {
+interface StreamedToolCall {
+  index: number;
+  id: string;
+  path: string;
+}
+
+/** A gateway turn that emits one text block, then the given tool calls. */
+function streamingRelay(toolCalls: StreamedToolCall[]): typeof globalThis.fetch {
   const payloads = [
     chunk({ role: 'assistant', content: 'Reading it.' }),
-    chunk({
-      tool_calls: [
-        {
-          index: toolCallIndex,
-          id: 'call_1',
-          type: 'function',
-          function: { name: 'read_file', arguments: '' },
-        },
-      ],
-    }),
-    chunk({ tool_calls: [{ index: toolCallIndex, function: { arguments: '{"path":"a.txt"}' } }] }),
+    ...toolCalls.flatMap(({ index, id, path }) => [
+      chunk({
+        tool_calls: [
+          { index, id, type: 'function', function: { name: 'read_file', arguments: '' } },
+        ],
+      }),
+      chunk({ tool_calls: [{ index, function: { arguments: `{"path":"${path}"}` } }] }),
+    ]),
     chunk({}, 'tool_calls'),
   ];
   const body = `${payloads.map((payload) => `data: ${JSON.stringify(payload)}\n\n`).join('')}data: [DONE]\n\n`;
@@ -63,12 +66,12 @@ function streamingRelay(toolCallIndex: number): typeof globalThis.fetch {
     new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } });
 }
 
-async function collectStream(toolCallIndex: number): Promise<LanguageModelV4StreamPart[]> {
+async function collectStream(toolCalls: StreamedToolCall[]): Promise<LanguageModelV4StreamPart[]> {
   const model = getAIModel({
     connection,
     apiKey: 'test-key',
     modelId: 'claude-opus-4-8',
-    fetch: streamingRelay(toolCallIndex),
+    fetch: streamingRelay(toolCalls),
   });
   const { stream } = await model.doStream({ prompt, tools });
   const parts: LanguageModelV4StreamPart[] = [];
@@ -76,35 +79,49 @@ async function collectStream(toolCallIndex: number): Promise<LanguageModelV4Stre
   return parts;
 }
 
-function toolCallOf(parts: LanguageModelV4StreamPart[]) {
-  return parts.find((part) => part.type === 'tool-call');
+function toolCallsOf(parts: LanguageModelV4StreamPart[]) {
+  return parts
+    .filter((part) => part.type === 'tool-call')
+    .map(({ toolCallId, toolName, input }) => ({ toolCallId, toolName, input }));
+}
+
+function assertStreamSucceeded(parts: LanguageModelV4StreamPart[]): void {
+  assert.equal(
+    parts.at(-1)?.type,
+    'finish',
+    'the stream must close cleanly instead of failing the whole turn',
+  );
+  assert.deepEqual(
+    parts.filter((part) => part.type === 'error'),
+    [],
+    'a non-zero tool call index is not a stream error',
+  );
 }
 
 describe('getAIModel: OpenAI-compatible streamed tool_calls index', () => {
-  for (const toolCallIndex of [0, 1, 7]) {
-    test(`emits the tool call when the gateway labels it index ${toolCallIndex}`, async () => {
-      const parts = await collectStream(toolCallIndex);
+  for (const index of [0, 1, 7]) {
+    test(`emits the tool call when the gateway labels it index ${index}`, async () => {
+      const parts = await collectStream([{ index, id: 'call_1', path: 'a.txt' }]);
 
-      assert.deepEqual(
-        toolCallOf(parts),
-        {
-          type: 'tool-call',
-          toolCallId: 'call_1',
-          toolName: 'read_file',
-          input: '{"path":"a.txt"}',
-        },
-        'the tool call must survive whatever index the gateway assigned',
-      );
-      assert.equal(
-        parts.at(-1)?.type,
-        'finish',
-        'the stream must close cleanly instead of failing the whole turn',
-      );
-      assert.deepEqual(
-        parts.filter((part) => part.type === 'error'),
-        [],
-        'a non-zero tool call index is not a stream error',
-      );
+      assert.deepEqual(toolCallsOf(parts), [
+        { toolCallId: 'call_1', toolName: 'read_file', input: '{"path":"a.txt"}' },
+      ]);
+      assertStreamSucceeded(parts);
     });
   }
+
+  // Holes must not merge, drop, or reorder calls either. A fix that appends every
+  // new index instead of honouring it would still pass the single-call cases above.
+  test('keeps two tool calls distinct and ordered when index 0 is a hole', async () => {
+    const parts = await collectStream([
+      { index: 1, id: 'call_1', path: 'a.txt' },
+      { index: 2, id: 'call_2', path: 'b.txt' },
+    ]);
+
+    assert.deepEqual(toolCallsOf(parts), [
+      { toolCallId: 'call_1', toolName: 'read_file', input: '{"path":"a.txt"}' },
+      { toolCallId: 'call_2', toolName: 'read_file', input: '{"path":"b.txt"}' },
+    ]);
+    assertStreamSucceeded(parts);
+  });
 });

--- a/patches/@ai-sdk+provider-utils+5.0.11.patch
+++ b/patches/@ai-sdk+provider-utils+5.0.11.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@ai-sdk/provider-utils/dist/index.js b/node_modules/@ai-sdk/provider-utils/dist/index.js
+index 851fce4..d16f64c 100644
+--- a/node_modules/@ai-sdk/provider-utils/dist/index.js
++++ b/node_modules/@ai-sdk/provider-utils/dist/index.js
+@@ -3567,6 +3567,9 @@ var StreamingToolCallTracker = class {
+    */
+   flush() {
+     for (const toolCall of this.toolCalls) {
++      if (toolCall == null) {
++        continue;
++      }
+       if (!toolCall.hasFinished) {
+         this.finishToolCall(toolCall);
+       }

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,15 +1,22 @@
 # patches
 
-`patch-package` applies everything here during the root `postinstall`, with `--error-on-fail` so a patch that no longer applies blocks the install instead of silently disappearing.
+`scripts/apply-dependency-patches.mjs` applies everything here during the root `postinstall`, with `--error-on-fail` so a patch that no longer applies blocks the install instead of silently disappearing. It skips when `patch-package` itself is absent, which happens under `npm ci --workspace <name>` and `npm ci --omit=dev`; those trees are not what ships, and an unpatched one fails the regression test below.
+
+After bumping a patched dependency, re-run `npx patch-package <name>` so the patch filename tracks the installed version.
 
 Each patch needs a reason to exist and a condition under which it can be deleted.
 
-## `@ai-sdk/provider-utils` — streamed tool-call index is an identifier, not an array slot
+## `@ai-sdk/provider-utils`: a streamed tool-call index is an identifier, not an array slot
 
-Fixes [#1967](https://github.com/maka-agent/maka-agent/issues/1967): any tool call through an OpenAI-compatible gateway that labels `tool_calls[].index` with a non-zero-starting or non-contiguous number crashes the whole turn.
+Fixes [#1967](https://github.com/maka-agent/maka-agent/issues/1967): a tool call through an OpenAI-compatible gateway that labels `tool_calls[].index` with a non-zero-starting or non-contiguous number crashes the whole turn.
 
-`StreamingToolCallTracker` stores tool calls at `this.toolCalls[index]`, so a gateway reporting `index: 1` leaves an empty slot at 0. `flush()` then walks the array with `for...of`, which — unlike `forEach` — does not skip holes, and dereferences `undefined.hasFinished`. The patch skips empty slots.
+`StreamingToolCallTracker` stores tool calls at `this.toolCalls[index]`, so a gateway reporting `index: 1` leaves an empty slot at 0. `flush()` then walks the array with `for...of`, which does not skip holes the way `forEach` would, and dereferences `undefined.hasFinished`. The patch skips empty slots.
 
-This treats the symptom, not the cause: `index` identifies which tool call a delta belongs to, so the tracker wants a `Map<number, ToolCall>` rather than an array. Upstream has no issue for this and its neighbouring tool-call fixes sit unmerged for months, so the patch is maintained here rather than waited on.
+That is the crash, not the whole defect class. `index` says which tool call a delta belongs to, but identity really lives in `toolCallDelta.id`, and the tracker keys off neither consistently. Two cases remain broken exactly as they are upstream, unchanged by this patch:
 
-Delete it once `@ai-sdk/provider-utils` handles sparse or non-zero-based indices itself. The guard for that is `packages/runtime/src/__tests__/model-factory-tool-call-index.test.ts`, which asserts the behaviour through the real provider stack and stays green either way.
+- **A reused index across two distinct calls** (`id: a` then `id: b`, both at `index: 0`, the Ollama shape in [vercel/ai#14277](https://github.com/vercel/ai/pull/14277)) silently merges them into one call with concatenated, invalid JSON arguments and drops the second `id`.
+- **A call whose deltas omit `index`** and span more than one chunk throws `Expected 'id' to be a string.`, because the `?? this.toolCalls.length` fallback picks a fresh slot each time.
+
+The crash this patch fixes is reported upstream in [vercel/ai#18333](https://github.com/vercel/ai/issues/18333); the reused-index case is [vercel/ai#14277](https://github.com/vercel/ai/pull/14277) and the missing-index case [vercel/ai#15879](https://github.com/vercel/ai/pull/15879). Fixing those means rekeying the tracker on `id`, which is upstream's call to make, not something to widen this patch into.
+
+Delete the patch once `@ai-sdk/provider-utils` stops crashing on sparse indices itself. The guard is `packages/runtime/src/__tests__/model-factory-tool-call-index.test.ts`, which asserts behaviour through the real provider stack and stays green either way.

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,15 @@
+# patches
+
+`patch-package` applies everything here during the root `postinstall`, with `--error-on-fail` so a patch that no longer applies blocks the install instead of silently disappearing.
+
+Each patch needs a reason to exist and a condition under which it can be deleted.
+
+## `@ai-sdk/provider-utils` — streamed tool-call index is an identifier, not an array slot
+
+Fixes [#1967](https://github.com/maka-agent/maka-agent/issues/1967): any tool call through an OpenAI-compatible gateway that labels `tool_calls[].index` with a non-zero-starting or non-contiguous number crashes the whole turn.
+
+`StreamingToolCallTracker` stores tool calls at `this.toolCalls[index]`, so a gateway reporting `index: 1` leaves an empty slot at 0. `flush()` then walks the array with `for...of`, which — unlike `forEach` — does not skip holes, and dereferences `undefined.hasFinished`. The patch skips empty slots.
+
+This treats the symptom, not the cause: `index` identifies which tool call a delta belongs to, so the tracker wants a `Map<number, ToolCall>` rather than an array. Upstream has no issue for this and its neighbouring tool-call fixes sit unmerged for months, so the patch is maintained here rather than waited on.
+
+Delete it once `@ai-sdk/provider-utils` handles sparse or non-zero-based indices itself. The guard for that is `packages/runtime/src/__tests__/model-factory-tool-call-index.test.ts`, which asserts the behaviour through the real provider stack and stays green either way.

--- a/scripts/apply-dependency-patches.mjs
+++ b/scripts/apply-dependency-patches.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Applies patches/ during the root postinstall.
+//
+// patch-package is a root devDependency, so `npm ci --workspace <name>` and
+// `npm ci --omit=dev` install a tree without it while still running the root
+// postinstall. Failing there would break install modes that work on main, so a
+// missing patch-package is reported and skipped; a patch that exists but no
+// longer applies still fails the install via --error-on-fail.
+//
+// Skipping is safe because those trees are not what ships: every release and CI
+// lane runs a plain root `npm ci`, and an unpatched tree turns
+// packages/runtime/src/__tests__/model-factory-tool-call-index.test.ts red.
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const patchesDirectory = join(repoRoot, 'patches');
+
+if (
+  !existsSync(patchesDirectory) ||
+  !readdirSync(patchesDirectory).some((entry) => entry.endsWith('.patch'))
+) {
+  process.exit(0);
+}
+
+let patchPackageEntry;
+try {
+  patchPackageEntry = createRequire(import.meta.url).resolve('patch-package/index.js');
+} catch {
+  console.warn(
+    'patch-package is not installed; skipping patches/. Run a plain `npm ci` from the repo root before building or packaging.',
+  );
+  process.exit(0);
+}
+
+const result = spawnSync(process.execPath, [patchPackageEntry, '--error-on-fail'], {
+  cwd: repoRoot,
+  stdio: 'inherit',
+});
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

Every tool call fails when an OpenAI-compatible gateway labels a streamed `tool_calls[].index` with anything other than a contiguous run from 0. The turn dies mid-stream as "未知错误 / 已保留部分输出". Reported in #1967 against an Anthropic→OpenAI translating gateway, which reuses the Anthropic content-block index, so once a text block consumes index 0, the first tool call arrives as index 1.

`index` identifies which tool call a delta belongs to; it is not an array position. `StreamingToolCallTracker` in `@ai-sdk/provider-utils` treats it as one. It writes to `this.toolCalls[index]`, leaving a hole at 0, and `flush()` then walks the array with `for...of`, which (unlike `forEach`) does not skip holes. It dereferences `undefined.hasFinished`, throws a bare `TypeError` inside the stream's flush handler, and the runtime, with no matching error class, reports it as unknown.

Upstream is not a viable path here. `@ai-sdk/provider-utils@5.0.18` still ships the identical `flush()`, and the neighbouring tool-call fixes sit unmerged: of 877 open PRs on `vercel/ai`, 630 are community-authored with a median age of 79 days, and the closest one (vercel/ai#14277) has been open 116 days. So the fix is a `patch-package` patch applied in `postinstall`. Reported upstream anyway as vercel/ai#18333.

The patch fixes the crash, not the whole defect class: identity really lives in `toolCallDelta.id`, so a reused index and an omitted index stay broken exactly as they are upstream. `patches/README.md` records both, with evidence, so the patch is not later read as covering them.

Closes #1967

## Review focus

`patch-package` is new infrastructure, and it is the reason `@ai-sdk/openai` matters here: it constructs the same `StreamingToolCallTracker` (`node_modules/@ai-sdk/openai/dist/index.js:1211`), so the `openai`, `github-copilot` chat, and custom-baseURL paths carry the identical bug. An SSE-rewriting fetch wrapper at the `openai-compatible` branch in `model-factory.ts` would cover strictly less ground while running a full SSE parse and re-serialize on every chunk of every connection.

## Verification

Regression test `packages/runtime/src/__tests__/model-factory-tool-call-index.test.ts` drives `getAIModel` over a fake gateway, parameterised on index 0 / 1 / 7, plus two tool calls streamed across a hole at index 0. It asserts behaviour through the real provider stack and never references the patch, so it stays meaningful if upstream fixes this differently. Red before the patch, green after:

```
# node_modules restored to stock
ℹ pass 1
ℹ fail 3
    TypeError: Cannot read properties of undefined (reading 'hasFinished')
        at StreamingToolCallTracker.flush (@ai-sdk/provider-utils/dist/index.js:3570)

# node scripts/apply-dependency-patches.mjs
ℹ pass 4
ℹ fail 0
```

The multi-call case exists because the single-call cases all pass under a fix that appends each new index instead of honouring it, which would silently reorder real multi-call turns.

Install modes, each from a clean tree:

| command | result |
|---|---|
| `npm ci` | exit 0, patch applied |
| `npm ci --omit=dev` | exit 0, patch skipped with an explicit message |
| `npm ci --workspace @maka/runtime` | exit 0, same |
| corrupted patch file | exit 1, install blocked |

The two middle rows are why `postinstall` calls a script instead of `patch-package` directly: both skip root devDependencies while still running the root postinstall, so a bare `patch-package --error-on-fail` exited 127 where `main` exits 0. Those trees are never what ships, and an unpatched one fails the regression test.

Also run: `node --test "packages/runtime/dist/__tests__/*.test.js"` (2622/2635; the 4 failures are `builtin-tools` path containment and reproduce identically on `main` on this machine, a macOS `/var` → `/private/var` symlink issue), `npm run lint`, `npm run format:check`, both clean.

Packaged `--dir` and extracted `app.asar` to confirm the patch reaches the shipped app:

```
$ grep -n "toolCall == null" -A2 app.asar-extracted/node_modules/@ai-sdk/provider-utils/dist/index.js
3570:      if (toolCall == null) {
3571-        continue;
3572-      }
```

Not run: full `npm run test`, E2E, and a signed/notarized release build.

## Rollout

`patches/` and the `postinstall` change are new infrastructure. CI and the release workflow both run a plain `npm ci`, so the patch applies everywhere the app is built. Contributors with a warm `node_modules` need one `npm install` to pick it up. `patch-package` adds 294 lines to the lockfile; it is dev-only and does not reach the packaged app.