### PR TITLE
refactor(ui): simplify the Skills page on Astryx

### DIFF
--- a/apps/desktop/e2e/skill-delete-scope.spec.ts
+++ b/apps/desktop/e2e/skill-delete-scope.spec.ts
@@ -2,9 +2,9 @@
 //
 // The delete path is the one place the Skills panel removes files from the
 // user's HOME rather than from app-managed workspace data, so the journey that
-// matters is the whole round trip: the button is offered for the scopes the
-// backend can actually delete, two clicks remove the directory from disk, and
-// the row is gone on the refresh that follows.
+// matters is the whole round trip: the contextual action is offered for the
+// scopes the backend can actually delete, the confirmation protects the file
+// operation, and the row is gone on the refresh that follows.
 //
 // This spec only exists because `buildE2eEnv` now sandboxes HOME. Before that,
 // running it would have deleted a real skill out of the developer's
@@ -38,13 +38,14 @@ test('deletes a user-scope skill from disk and drops it from the list', async ({
   const row = page.locator('.maka-skill-library-list li').filter({ hasText: 'User Only' });
   await expect(row).toHaveCount(1);
 
-  // Two-step confirm: the first click only arms the button, so the skill must
-  // still be on disk at this point — a single stray click cannot delete.
-  const deleteButton = row.getByRole('button', { name: /删除/ });
-  await deleteButton.click();
+  await row.getByRole('button', { name: 'User Only 的更多操作' }).click();
+  await page.getByRole('menuitem', { name: '删除', exact: true }).click();
+
+  // Opening the confirmation alone must not touch disk.
   await access(skillDir);
 
-  await deleteButton.click();
+  const confirm = page.getByRole('alertdialog', { name: '确认删除 User Only' });
+  await confirm.getByRole('button', { name: '删除', exact: true }).click();
 
   await expect(row).toHaveCount(0);
   await expect.poll(() => access(skillDir).then(() => 'present', () => 'gone')).toBe('gone');
@@ -63,5 +64,7 @@ test('offers no delete for a project-scope skill', async ({ invocableSkillsWindo
 
   const projectRow = page.locator('.maka-skill-library-list li').filter({ hasText: 'Project Only' });
   await expect(projectRow).toHaveCount(1);
-  await expect(projectRow.getByRole('button', { name: /删除/ })).toHaveCount(0);
+  await projectRow.getByRole('button', { name: 'Project Only 的更多操作' }).click();
+  const menu = page.getByRole('menu', { name: 'Project Only 的更多操作' });
+  await expect(menu.getByRole('menuitem', { name: '删除', exact: true })).toHaveCount(0);
 });

--- a/apps/desktop/e2e/skills.spec.ts
+++ b/apps/desktop/e2e/skills.spec.ts
@@ -1,0 +1,35 @@
+// Skills page interaction hierarchy (#1901).
+//
+// These checks use the real Desktop bridge and seeded Skill inventory. They
+// protect the visible contract rather than the component implementation: one
+// direct invocation, one state control, and one menu for secondary actions.
+
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures.js';
+
+async function openInstalledSkills(page: Page) {
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  const sidebar = page.getByRole('navigation', { name: '对话列表' });
+  await sidebar.getByRole('button', { name: '扩展', exact: true }).click();
+  await page.getByRole('main', { name: '扩展' }).waitFor();
+  await page.getByRole('button', { name: '已安装' }).click();
+}
+
+test('keeps rare installed Skill actions in one contextual menu', async ({
+  invocableSkillsWindow: page,
+}) => {
+  await openInstalledSkills(page);
+
+  const row = page.locator('.maka-skill-library-list li').filter({ hasText: 'Workspace Only' });
+  await expect(row).toHaveCount(1);
+  await expect(row.getByRole('button', { name: '在对话中使用 Workspace Only' })).toBeVisible();
+  await expect(row.getByRole('switch')).toHaveCount(1);
+  await expect(row.getByRole('button', { name: '打开 SKILL.md' })).toHaveCount(0);
+  await expect(row.getByRole('button', { name: /删除/ })).toHaveCount(0);
+
+  await row.getByRole('button', { name: 'Workspace Only 的更多操作' }).click();
+  const menu = page.getByRole('menu', { name: 'Workspace Only 的更多操作' });
+  await expect(menu.getByRole('menuitem', { name: '打开 SKILL.md' })).toBeVisible();
+  await expect(menu.getByRole('menuitem', { name: '固定到技能上下文' })).toBeVisible();
+  await expect(menu.getByRole('menuitem', { name: '删除', exact: true })).toBeVisible();
+});

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -247,24 +247,8 @@
      --background); it carries its darwin overrides in "DARWIN GLASS" below. */
   --color-bg-container: var(--background);
 
-  /* === shadow opacity (subtle in light, stronger in dark) === */
-  --shadow-blur-opacity:   0.06;
-
   /* === shadow recipes ===
-     Always include the 1px border ring as the FIRST inset-like layer.
-     Subsequent layers are very low-opacity blurs that stack into a soft glow. */
-  /* Blur layers were
-     pure-black rgba — on a light warm-gray shell a pure black shadow
-     reads as a dirty smudge (taste-skill ban). Every layer now derives
-     from the warm foreground so shadow, border ring, and ink share one
-     light source. Dark mode collapses these to border rings below. */
-  --shadow-minimal:
-    rgba(0,0,0,0) 0 0 0 0,
-    rgba(0,0,0,0) 0 0 0 0,
-    oklch(from var(--foreground) l c h / 0.06) 0 0 0 1px,
-    oklch(from var(--foreground) l c h / var(--shadow-blur-opacity)) 0 1px 1px -0.5px,
-    oklch(from var(--foreground) l c h / var(--shadow-blur-opacity)) 0 3px 3px -1.5px;
-
+     Flat elevation uses a foreground-derived 1px ring in both themes. */
   --shadow-minimal-flat:
     rgba(0,0,0,0) 0 0 0 0,
     rgba(0,0,0,0) 0 0 0 0,
@@ -636,8 +620,8 @@
    /* === transform amplitude (motion) ===
       Tokenize the geometric magnitude of press/hover feedback so the
       motion scale covers amplitude, not just duration/easing. Press
-      scale (active 缩小) and hover lift (上浮); no hover scale — nothing in
-      the app grows on hover. Reset
+      scale (active 缩小); no hover scale — nothing in the app grows on hover.
+      Reset
       transform: translate(0)/scale(1) uses literal 0/1. Decorative
       scale(1.1), strong lift -3px, sidebar slide translateX, and rotate
       are NOT tokenized (diverse, low coverage). Keyframe transform
@@ -787,7 +771,6 @@
   --success: oklch(0.60 0.17 145);
   --destructive: oklch(0.70 0.19 22);
 
-  --shadow-blur-opacity:   0.12;
   --opacity-overlay: 0.06;
 
   /* Dark-mode shadow collapse: blur shadows are nearly
@@ -797,8 +780,6 @@
      (interface-design: "dark mode shadows collapse to a single ring");
      modal keeps one deep drop so overlays still separate from the
      backdrop. */
-  --shadow-minimal:
-    0 0 0 1px oklch(1 0 0 / 0.08);
   --shadow-minimal-flat:
     0 0 0 1px oklch(1 0 0 / 0.08);
   /* Slate user bubble for dark mode — distinct from --accent and readable

--- a/apps/desktop/src/renderer/styles/module-pages/module-shell.css
+++ b/apps/desktop/src/renderer/styles/module-pages/module-shell.css
@@ -79,11 +79,6 @@
   flex-wrap: wrap;
 }
 
-/* Secondary header utilities stay hidden in the compact skills module shell. */
-.maka-panel-detail[data-agents-view="skills"] .maka-module-main-actions > .maka-skill-header-utility {
-  display: none;
-}
-
 @media (max-width: 820px) {
   .maka-module-main {
     padding: var(--space-4);

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -4,9 +4,8 @@
   min-width: 0;
 }
 
-/* Skills page
-   card mirrors the Plan shell: 1px hairline border + 6px radius + 4% lift +
-   1px inner top highlight, with tight 4-6px internal gaps. */
+/* Astryx owns control and row geometry. This stylesheet only arranges the
+   Skills product surfaces and the update-diff content Astryx does not model. */
 .maka-skill-library {
   width: min(100%, 900px);
   margin-inline: auto;
@@ -14,125 +13,11 @@
   overflow: auto;
   display: grid;
   align-content: start;
-  /* Premium checklist rule 10: 24px between page tiers (banner / tabs /
-     market / installed); small steps only inside a unit. */
-  gap: var(--space-6);
-  /* Unboxed (maintainer 2026-07-18): the outer card chrome wrapped the
-     whole module (banner + tabs + list) in a second frame the MCP page
-     never had — the inner surfaces (featured banner, skill rows, market
-     cards) already carry their own borders, so the wrapper reads as a
-     box-in-box. Plain layout container now; content aligns flush with
-     the module header like the MCP page. */
-  padding: 0;
+  gap: var(--space-3);
 }
 
 .maka-skill-tool-summary-hidden {
   display: none;
-}
-
-.maka-skill-featured-banner {
-  position: relative;
-  min-height: 128px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-6);
-  overflow: hidden;
-  border: var(--border-width-hairline) solid var(--border);
-  border-radius: var(--radius-surface);
-  background: var(--background-elevated);
-  box-shadow: var(--shadow-minimal);
-  padding: var(--space-6) var(--space-8);
-}
-
-.maka-skill-featured-banner h3 {
-  font: var(--maka-text-heading-3);
-  margin: 0;
-  color: var(--foreground);
-}
-
-.maka-skill-featured-banner p {
-  font: var(--maka-text-body);
-  max-width: 540px;
-  margin: var(--space-2-5) 0 0;
-  color: var(--foreground-secondary);
-}
-
-.maka-skill-featured-art {
-  position: relative;
-  align-self: stretch;
-  width: min(38%, 310px);
-  min-width: 220px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: calc(var(--space-4) * -1) var(--space-0-5) calc(var(--space-5) * -1) 0;
-}
-
-.maka-skill-featured-art span {
-  position: absolute;
-  /* Cards sized + offset so the banner's overflow:hidden never crops
-     their copy: previous 94-122px heights with 28px+ top offsets cut
-     「总结沉淀」mid-glyph at the banner edge. Corners may still bleed
-     off (intentional sticker collage), text must not. */
-  width: 84px;
-  height: 96px;
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-1);
-  /* Fixed inks: these floating cards stay white in both themes (they
-     sit on the theme-independent banner), so their border/copy must
-     not follow --foreground or they wash out in dark mode. */
-  border: var(--border-width-hairline) solid oklch(from var(--brand-deep) 0.2 min(c, 0.01) h / 0.09);
-  border-radius: var(--radius-control);
-  background: linear-gradient(180deg, oklch(100% 0 0), oklch(98.2% 0.006 96));
-  color: oklch(from var(--brand-deep) 0.44 min(c, 0.015) h);
-  box-shadow:
-    0 12px 24px -20px oklch(from var(--brand-deep) 0.2 min(c, 0.02) h / 0.4),
-    0 1px 2px oklch(from var(--brand-deep) 0.2 min(c, 0.02) h / 0.08);
-}
-
-.maka-skill-featured-art strong {
-  font: var(--maka-text-heading-5);
-color: oklch(from var(--brand-deep) 0.34 min(c, 0.02) h);
-}
-
-.maka-skill-featured-art small {
-  font: var(--maka-text-heading-5);
-color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
-}
-
-.maka-skill-featured-art span:first-child {
-  left: 14px;
-  top: 12px;
-  transform: rotate(-14deg);
-  color: oklch(from var(--brand-deep) 0.64 min(c, 0.15) h);
-}
-
-.maka-skill-featured-art span:nth-child(2) {
-  left: 92px;
-  top: 4px;
-  /* PR-FE-BUG-HUNT-9 z-index allowlist: decorative sticker stack
-     local stacking (3 spans within `.maka-skill-featured-art`).
-     Bare 2 is intentional — these never escape the parent container,
-     so they don't need a global token. The contract test
-     `z-index-contract.test.ts` whitelists this exact site. */
-  z-index: 2;
-  width: 92px;
-  height: 106px;
-  transform: rotate(10deg);
-  color: oklch(54% 0.10 236);
-}
-
-.maka-skill-featured-art span:nth-child(3) {
-  right: 4px;
-  top: 18px;
-  width: 78px;
-  height: 92px;
-  transform: rotate(7deg);
-  color: oklch(58% 0.18 32);
 }
 
 .maka-skill-tabs-bar {
@@ -142,56 +27,98 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   gap: var(--space-4);
 }
 
-/* Category and sort selectors ride the market tab row's right edge. Astryx
-   owns their chrome; this product class only constrains toolbar geometry. */
-.maka-skill-market-controls {
+.maka-skill-market-controls,
+.maka-skill-filter-actions,
+.maka-skill-library-controls,
+.maka-skill-library-exceptions {
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: var(--space-2);
+}
+
+.maka-skill-market-controls,
+.maka-skill-library-controls {
   flex: 0 0 auto;
+}
+
+.maka-skill-filter-actions,
+.maka-skill-library-exceptions {
+  flex-wrap: wrap;
 }
 
 .maka-skill-market-select {
   min-width: 0;
-  width: auto;
 }
 
-.maka-skill-filter-actions {
+.maka-skill-market,
+.maka-skill-installed {
   min-width: 0;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--space-1);
-}
-
-.maka-skill-market {
   display: grid;
-  gap: var(--space-3);
+  gap: var(--space-2);
 }
 
 .maka-skill-section-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2-5);
+  min-width: 0;
 }
 
-.maka-skill-context-inspector {
-  font: var(--maka-text-supporting);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  border: var(--border-width-hairline) solid var(--border);
-  border-radius: var(--radius-control);
-  background: var(--background-elevated);
+.maka-skill-section-label {
+  font: var(--maka-text-heading-5);
   color: var(--foreground-secondary);
-  padding: var(--space-2) var(--space-3);
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
 }
 
-.maka-skill-context-inspector strong {
-  font: var(--maka-text-label);
-  color: var(--foreground);
+.maka-skill-catalog-list,
+.maka-skill-library-list {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.maka-skill-catalog-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr));
+  gap: var(--space-2);
+}
+
+.maka-skill-catalog-item,
+.maka-skill-library-item {
+  min-width: 0;
+}
+
+.maka-skill-catalog-details,
+.maka-skill-library-details {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-0-5);
+}
+
+.maka-skill-catalog-details > span,
+.maka-skill-library-details > span,
+.maka-skill-library-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.maka-skill-catalog-details > span,
+.maka-skill-library-details > span {
+  white-space: nowrap;
+}
+
+.maka-skill-library-list {
+  overflow: hidden;
+  display: grid;
+  align-content: start;
+  border: var(--border-width-hairline) solid var(--foreground-8);
+  border-radius: var(--radius-control);
+  background: var(--background);
+}
+
+.maka-skill-library-item + .maka-skill-library-item {
+  border-top: var(--border-width-hairline) solid var(--foreground-8);
 }
 
 .maka-skill-library-item[data-context-status='shadowed'],
@@ -199,283 +126,24 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   opacity: var(--opacity-pending);
 }
 
-.maka-skill-section-row small {
-  font: var(--maka-text-supporting);
-  font-variant-numeric: tabular-nums;
-  color: var(--muted-foreground);
-}
-
-.maka-skill-market-grid {
-  display: grid;
-  /* Marketplace grid: 3 columns on wide, collapsing to 2/1 via auto-fit as
-     the panel narrows (panel max-width 900px → ~2 cols; narrow → 1). */
-  grid-template-columns: repeat(auto-fill, minmax(min(100%, 260px), 1fr));
-  gap: var(--space-3);
-}
-
-.maka-skill-market-card {
-  min-width: 0;
-  min-height: 150px;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  border: var(--border-width-hairline) solid var(--foreground-8);
-  border-radius: var(--radius-control);
-  background: var(--background);
-  padding: var(--space-4);
-  transition: border-color var(--duration-base) var(--ease-out-strong);
-}
-
-/* Premium checklist rule 17: flat is the default — no hover lift, no
-   hand-written shadow. The border deepening is the whole hover story. */
-.maka-skill-market-card:hover {
-  border-color: oklch(from var(--foreground) l c h / 0.14);
-}
-
-.maka-skill-market-card-head {
-  min-width: 0;
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-2-5);
-}
-
-.maka-skill-market-card-title {
-  min-width: 0;
-  flex: 1 1 auto;
-  display: grid;
-  gap: var(--space-0-5);
-}
-
-.maka-skill-market-card h3 {
-  font: var(--maka-text-heading-3);
-  min-width: 0;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--foreground);
-}
-
-/* Slug caption: soft monospace, matching the library row's id treatment. */
-.maka-skill-market-card-title code {
-  font: var(--maka-text-supporting);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  letter-spacing: var(--tracking-normal);
-}
-
-.maka-skill-market-card small,
-.maka-skill-market-card code,
-.maka-skill-market-card-foot span {
-  font: var(--maka-text-supporting);
-  color: var(--muted-foreground);
-}
-
-.maka-skill-market-category {
-  justify-self: start;
-}
-
-.maka-skill-market-card p {
-  font: var(--maka-text-body);
-  min-height: 40px;
-  margin: 0;
-  color: var(--foreground-secondary);
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.maka-skill-market-icon {
-  width: 38px;
-  height: 38px;
+.maka-skill-library-label {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  border: var(--border-width-hairline) solid var(--border);
-  border-radius: var(--radius-surface);
-  background: var(--background);
-  color: var(--foreground-secondary);
+  align-items: baseline;
+  max-width: 100%;
+  white-space: nowrap;
 }
 
-.maka-skill-market-card-foot {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  margin-top: auto;
-}
-
-.maka-skill-installed {
-  display: grid;
-  gap: var(--space-2);
-  min-width: 0;
-}
-
-.maka-skill-section-label {
-  font: var(--maka-text-label);
-  color: var(--foreground-secondary);
-  letter-spacing: var(--tracking-widest);
-  text-transform: uppercase;
-}
-
-.maka-skill-library-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  min-height: 0;
-  overflow: hidden;
-  display: grid;
-  align-content: start;
-  gap: 0;
-  border: var(--border-width-hairline) solid var(--foreground-8);
-  border-radius: var(--radius-control);
-  background: var(--background);
-}
-
-.maka-skill-library-item {
-  --maka-skill-library-action-size: var(--h-control-sm);
-  min-width: 0;
-  display: grid;
-  /* Info column takes the slack; every trailing action (use / open / switch /
-     review / delete) flows into its own max-content implicit column, so the
-     row never wraps regardless of how many actions a skill surfaces. */
-  grid-template-columns: minmax(0, 1fr);
-  grid-auto-flow: column;
-  grid-auto-columns: max-content;
-  align-items: center;
-  gap: var(--space-2);
-  padding-right: var(--space-3);
-  transition: background-color var(--duration-base) var(--ease-out-strong);
-}
-
-.maka-skill-library-item + .maka-skill-library-item {
-  border-top: var(--border-width-hairline) solid var(--foreground-8);
-}
-
-.maka-skill-library-row {
-  --maka-skill-library-icon-size: calc(var(--space-8) + var(--space-0-5));
-  --maka-skill-library-copy-min-inline: calc((var(--space-16) * 3) - var(--space-3));
-  --maka-skill-library-status-min-inline: calc(var(--space-16) + var(--space-2));
-  width: 100%;
-  min-height: calc(var(--maka-skill-library-icon-size) + (var(--space-3) * 2));
-  display: grid;
-  grid-template-columns:
-    var(--maka-skill-library-icon-size)
-    minmax(var(--maka-skill-library-copy-min-inline), 1fr)
-    minmax(var(--maka-skill-library-status-min-inline), max-content);
-  align-items: center;
-  justify-content: stretch;
-  gap: var(--space-2-5);
-  padding: var(--space-2-5) var(--space-3);
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  color: var(--foreground);
-  white-space: normal;
-  text-align: left;
-  transition: background-color var(--duration-base) var(--ease-out-strong);
-}
-
-/* PR-UI-PIXEL-0 (2026-06-21): reference rule #2 — hover/selected states are
-   NEUTRAL gray (#efefef ≈ foreground/0.06), never tinted with the brand color.
-   The purple-tinted row hover read as "themed"; neutral reads calmer/native.
-   This is a deliberate local alignment exception. */
-.maka-skill-library-item:hover,
-.maka-skill-library-item:focus-within {
-  background: var(--state-hover-bg);
-}
-
-/* PR-UI-PIXEL-1: skill rows are anchored by a reference-style icon tile —
-   a 38px rounded white square with a hairline + ultra-soft shadow holding the
-   glyph (study §3.2), instead of the previous flat 20px chip. */
-.maka-skill-library-status {
-  width: var(--maka-skill-library-icon-size);
-  height: var(--maka-skill-library-icon-size);
-  display: inline-grid;
-  place-items: center;
-  border-radius: var(--radius-surface);
-  border: var(--border-width-hairline) solid var(--foreground-8);
-  background: var(--background);
+.maka-skill-library-slug {
+  margin-inline-start: var(--space-1-5);
   color: var(--muted-foreground);
-  transition: background-color var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong);
-}
-
-/* PR-UI-PIXEL-1: tile stays white on hover (reference keeps icon tiles
-   neutral); only the glyph deepens. */
-.maka-skill-library-item:hover .maka-skill-library-status,
-.maka-skill-library-item:focus-within .maka-skill-library-status {
-  background: var(--background);
-  color: var(--foreground);
-}
-
-.maka-skill-library-copy {
-  min-width: 0;
-  display: grid;
-  gap: var(--space-0-5);
-}
-
-/* PR-UI-PIXEL-4 (2026-06-21): reference's built-in skill rows use a 14px/600
-   name + 12px description (study §3.2). maka's 12/11 read cramped — bump to the
-   reference scale so the skills list feels as comfortable as 参考实现's. */
-.maka-skill-library-name {
-  font: var(--maka-text-heading-4);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.maka-skill-library-description {
-  font: var(--maka-text-supporting);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--foreground-secondary);
-}
-
-.maka-skill-library-meta {
-  font: var(--maka-text-supporting);
-  display: inline-flex;
-  justify-self: end;
-  align-items: center;
-  gap: var(--space-1-5);
-  color: var(--muted-foreground);
-  white-space: nowrap;
-  min-width: 0;
-  overflow: hidden;
 }
 
 .maka-skill-library-supporting {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100%;
   color: var(--muted-foreground);
 }
 
-.maka-skill-library-open-button {
-  justify-self: end;
-}
-
-.maka-skill-library-runtime-switch {
-  justify-self: end;
-}
-
-/* Per-row delete: neutral until armed. The two-step confirm state
-   (data-confirming) deepens to the destructive tone so 确认删除 reads as the
-   hot action, matching exception-only status color governance. */
-.maka-skill-library-delete-button {
-  justify-self: end;
-}
-
-.maka-skill-library-delete-button[data-confirming='true'] {
-  border-color: oklch(from var(--destructive) l c h / 0.4);
-  color: var(--destructive);
+.maka-skill-library-exceptions:empty {
+  display: none;
 }
 
 .maka-skill-installed-empty {
@@ -500,12 +168,8 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   gap: var(--space-1);
 }
 
-/* #1879: `--h-control-sm` (24px), not `xs`. The floor is arithmetic under
-   `border-box`: a 20px line box plus 2 x var(--space-0-5) needs 24px, and at
-   `xs` the declared padding would have been squeezed out of the box entirely.
-   This one stays product CSS rather than becoming an Astryx `Badge` because it
-   truncates — `max-width` + ellipsis on a long skill name is behaviour Badge
-   does not have. */
+/* Update-preview facts truncate as a unit; Astryx Badge does not provide a
+   max-width/ellipsis contract for user-authored Skill names. */
 .maka-skill-governance-summary span {
   font: var(--maka-text-heading-5);
   height: var(--h-control-sm);
@@ -577,35 +241,18 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
     width: min(100%, 280px);
   }
 
-  .maka-skill-library {
-    grid-template-columns: minmax(0, 1fr);
+  .maka-skill-tabs-bar {
+    align-items: stretch;
+    flex-direction: column;
+    gap: var(--space-2);
   }
 
-  .maka-skill-library-item {
-    grid-template-columns: minmax(0, 1fr) max-content max-content;
-  }
-
-  .maka-skill-library-row {
-    --maka-skill-library-icon-size: calc(var(--space-8) + var(--space-1-5));
-    grid-template-columns: var(--maka-skill-library-icon-size) minmax(0, 1fr);
-    gap: var(--space-1-5);
-  }
-
-  .maka-skill-library-meta {
-    grid-column: 2;
+  .maka-skill-market-controls {
     flex-wrap: wrap;
-    white-space: normal;
   }
 
+  .maka-skill-catalog-list,
   .maka-skill-diff-grid {
     grid-template-columns: minmax(0, 1fr);
   }
-}
-
-/* Collision-only slug: revealed inline beside the name ONLY when two visible
-   skills share a display name (normal rows keep the slug in the tooltip). */
-.maka-skill-library-slug {
-  font: var(--maka-text-supporting);
-  margin-left: var(--space-1-5);
-  color: var(--muted-foreground);
 }

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -10,6 +10,7 @@ import {
   getSharedUiCopy,
   ModuleHubSelector,
   SkillsPage,
+  type ManagedSkillUpdatePreview,
   type SkillEntry,
   ToastProvider,
   useUiLocale,
@@ -49,31 +50,130 @@ const CONFIGURED_COMPLETED_LAST_RUN = {
 
 const INSTALLED_SKILLS: SkillEntry[] = [
   {
+    ref: 'workspace:maka:skill-git-flow',
     id: 'skill-git-flow',
     name: 'git-flow',
     description: '封装分支创建、合并与发布打 tag 的常用 git 操作。',
     path: '~/.maka/skills/git-flow',
     declaredTools: ['Bash', 'Write'],
+    sourceType: 'workspace',
+    scope: 'workspace',
+    contextStatus: 'advertised',
+    manageable: true,
     enabled: true,
     runtimeStatus: 'enabled',
   },
   {
+    ref: 'user:agents:skill-docs-screenshot',
     id: 'skill-docs-screenshot',
     name: 'docs-screenshot',
     description: '把组件截图同步进设计文档，按 token 分类命名。',
     path: '~/.maka/skills/docs-screenshot',
     declaredTools: ['Bash', 'Read'],
+    sourceType: 'workspace',
+    scope: 'user',
+    contextStatus: 'disabled',
+    manageable: true,
     enabled: false,
     runtimeStatus: 'disabled',
   },
   {
+    ref: 'project:maka:skill-release-notes',
     id: 'skill-release-notes',
     name: 'release-notes',
     description: '从最近的 commit 历史生成发布说明草稿。',
     path: '~/.maka/skills/release-notes',
     declaredTools: ['Bash'],
+    sourceType: 'bundled',
+    scope: 'project',
+    contextStatus: 'advertised',
+    manageable: false,
     enabled: true,
     runtimeStatus: 'enabled',
+  },
+];
+
+const UPDATE_AVAILABLE_SKILLS: SkillEntry[] = [
+  {
+    ref: 'workspace:maka:release-checklist',
+    id: 'release-checklist',
+    name: 'release-checklist',
+    description: '发布前检查版本、测试证据和变更说明。',
+    path: '~/.maka/skills/release-checklist',
+    declaredTools: ['Bash', 'Read'],
+    sourceType: 'managed',
+    managedUpdateStatus: 'update_available',
+    scope: 'workspace',
+    contextStatus: 'advertised',
+    manageable: true,
+    enabled: true,
+    runtimeStatus: 'enabled',
+  },
+];
+
+const UPDATE_AVAILABLE_PREVIEW: ManagedSkillUpdatePreview = {
+  skill: {
+    id: 'release-checklist',
+    name: 'release-checklist',
+    description: '发布前检查版本、测试证据和变更说明。',
+    path: '~/.maka/skills/release-checklist/SKILL.md',
+    declaredTools: ['Bash', 'Read'],
+    sourceType: 'managed',
+    userModified: false,
+    validationStatus: 'ok',
+    enabled: true,
+    runtimeStatus: 'enabled',
+    validationCodes: [],
+    validationMessages: [],
+    managedSourceId: 'release-checklist-source',
+    managedUpdateStatus: 'update_available',
+    hasManagedBaseline: true,
+  },
+  currentContent: '# Release checklist\n\nRun the release tests.',
+  sourceContent: '# Release checklist\n\nRun tests and attach the release evidence.',
+  baselineContent: '# Release checklist\n\nRun the release tests.',
+  expectedCurrentSha256: 'current-story-sha256',
+  expectedSourceSha256: 'source-story-sha256',
+  summary: {
+    currentLineCount: 3,
+    sourceLineCount: 3,
+    changedLineCount: 1,
+  },
+};
+
+const DISABLED_SKILLS: SkillEntry[] = [
+  {
+    ref: 'workspace:maka:spreadsheet-audit',
+    id: 'spreadsheet-audit',
+    name: 'spreadsheet-audit',
+    description: '检查工作簿中的公式、格式和异常值。',
+    path: '~/.maka/skills/spreadsheet-audit',
+    declaredTools: ['Read'],
+    sourceType: 'bundled',
+    scope: 'workspace',
+    contextStatus: 'disabled',
+    manageable: true,
+    enabled: false,
+    runtimeStatus: 'disabled',
+  },
+];
+
+const BUNDLED_SKILLS: NonNullable<ComponentProps<typeof SkillsPage>['bundledSkillCatalog']> = [
+  {
+    id: 'document-review',
+    name: 'Document review',
+    description: 'Review and refine documents before sharing.',
+    category: '文档与写作',
+    declaredTools: ['Read', 'Write'],
+    installed: false,
+  },
+  {
+    id: 'image-workbench',
+    name: 'Image workbench',
+    description: 'Generate and edit visual assets.',
+    category: '设计与UI',
+    declaredTools: ['Read', 'Write'],
+    installed: true,
   },
 ];
 
@@ -348,7 +448,10 @@ function ModuleSurface(props: {
   );
 }
 
-function ExtensionsSkillsSurface(props: { skills?: SkillEntry[] }) {
+function ExtensionsSkillsSurface(props: {
+  skills?: SkillEntry[];
+  bundledSkillCatalog?: NonNullable<ComponentProps<typeof SkillsPage>['bundledSkillCatalog']>;
+}) {
   const copy = getSharedUiCopy(useUiLocale()).moduleHubs.extensions;
   return (
     <ModuleSurface agentsView="skills">
@@ -360,10 +463,21 @@ function ExtensionsSkillsSurface(props: { skills?: SkillEntry[] }) {
         }}
         skills={props.skills ?? []}
         managedSkillSources={[]}
-        bundledSkillCatalog={[]}
+        bundledSkillCatalog={props.bundledSkillCatalog ?? []}
         onRefreshSkills={noop}
+        onRefreshManagedSkillSources={noop}
+        onRefreshBundledSkillCatalog={noop}
         onOpenSkill={noop}
+        onUseSkill={noop}
         onOpenSkillsFolder={noop}
+        onInstallBundledSkill={noop}
+        onPreviewManagedSkillUpdate={async (skillId) => (
+          skillId === UPDATE_AVAILABLE_PREVIEW.skill.id ? UPDATE_AVAILABLE_PREVIEW : null
+        )}
+        onUpdateManagedSkill={async () => true}
+        onSetSkillEnabled={noop}
+        onSetSkillPinned={noop}
+        onDeleteSkill={noop}
       />
     </ModuleSurface>
   );
@@ -466,9 +580,35 @@ async function waitForStoryText(canvasElement: HTMLElement, text: string): Promi
   throw new Error(`Story text did not render: ${text}`);
 }
 
-// Real path: sidebar → 扩展 → 技能, with several installed skills.
+// Real path: sidebar → 扩展 → 技能, before any Skill or bundled catalog entry exists.
+export const ExtensionsSkillsEmpty: Story = {
+  render: () => <ExtensionsSkillsSurface />,
+};
+
+// Real path: sidebar → 扩展 → 技能, with several installed Skills.
 export const ExtensionsSkillsInstalled: Story = {
   render: () => <ExtensionsSkillsSurface skills={INSTALLED_SKILLS} />,
+};
+
+// Real path: sidebar → 扩展 → 技能, with bundled Skills available to install.
+export const ExtensionsSkillsBundled: Story = {
+  render: () => <ExtensionsSkillsSurface bundledSkillCatalog={BUNDLED_SKILLS} />,
+};
+
+// Real path: sidebar → 扩展 → 技能, after a managed source reports an update.
+export const ExtensionsSkillsUpdateAvailable: Story = {
+  render: () => <ExtensionsSkillsSurface skills={UPDATE_AVAILABLE_SKILLS} />,
+};
+
+// Real path: sidebar → 扩展 → 技能, with an installed Skill disabled.
+export const ExtensionsSkillsDisabled: Story = {
+  render: () => <ExtensionsSkillsSurface skills={DISABLED_SKILLS} />,
+};
+
+// Real path: sidebar → 扩展 → 技能, at a narrow desktop window.
+export const ExtensionsSkillsNarrow: Story = {
+  render: () => <ExtensionsSkillsSurface skills={INSTALLED_SKILLS} />,
+  parameters: { viewport: { defaultViewport: 'mobile2' } },
 };
 
 // Real path: sidebar → 扩展 → MCP, with one healthy server and one actionable failure.

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -451,6 +451,7 @@ function ModuleSurface(props: {
 function ExtensionsSkillsSurface(props: {
   skills?: SkillEntry[];
   bundledSkillCatalog?: NonNullable<ComponentProps<typeof SkillsPage>['bundledSkillCatalog']>;
+  onUpdateManagedSkill?: ComponentProps<typeof SkillsPage>['onUpdateManagedSkill'];
 }) {
   const copy = getSharedUiCopy(useUiLocale()).moduleHubs.extensions;
   return (
@@ -474,7 +475,7 @@ function ExtensionsSkillsSurface(props: {
         onPreviewManagedSkillUpdate={async (skillId) => (
           skillId === UPDATE_AVAILABLE_PREVIEW.skill.id ? UPDATE_AVAILABLE_PREVIEW : null
         )}
-        onUpdateManagedSkill={async () => true}
+        onUpdateManagedSkill={props.onUpdateManagedSkill ?? (async () => true)}
         onSetSkillEnabled={noop}
         onSetSkillPinned={noop}
         onDeleteSkill={noop}
@@ -560,6 +561,20 @@ async function waitForStoryButton(
   throw new Error('Story action button did not render');
 }
 
+async function waitForStoryMenuItem(
+  canvasElement: HTMLElement,
+  predicate: (menuItem: HTMLElement) => boolean,
+): Promise<HTMLElement> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const menuItem = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find(predicate);
+    if (menuItem) return menuItem;
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
+  }
+  throw new Error('Story menu item did not render');
+}
+
 async function waitForStorySelector<T extends Element>(
   canvasElement: HTMLElement,
   selector: string,
@@ -597,7 +612,64 @@ export const ExtensionsSkillsBundled: Story = {
 
 // Real path: sidebar → 扩展 → 技能, after a managed source reports an update.
 export const ExtensionsSkillsUpdateAvailable: Story = {
-  render: () => <ExtensionsSkillsSurface skills={UPDATE_AVAILABLE_SKILLS} />,
+  render: function Render() {
+    const [updateInput, setUpdateInput] = useState<unknown>(null);
+    return (
+      <>
+        <ExtensionsSkillsSurface
+          skills={UPDATE_AVAILABLE_SKILLS}
+          onUpdateManagedSkill={async (skillId, options) => {
+            setUpdateInput({ skillId, options });
+            return true;
+          }}
+        />
+        <output data-testid="skills-update-input" hidden>
+          {updateInput ? JSON.stringify(updateInput) : ''}
+        </output>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const moreActions = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.getAttribute('aria-label') === 'release-checklist 的更多操作',
+    );
+    moreActions.click();
+
+    const storyDocument = canvasElement.ownerDocument.documentElement;
+    const viewUpdate = await waitForStoryMenuItem(
+      storyDocument,
+      (candidate) => candidate.textContent?.includes('查看更新') === true,
+    );
+    viewUpdate.click();
+
+    const review = await waitForStorySelector<HTMLElement>(
+      canvasElement,
+      '[aria-label="Skill 更新审查"]',
+    );
+    await expect(review.textContent).toContain(UPDATE_AVAILABLE_PREVIEW.currentContent);
+    await expect(review.textContent).toContain(UPDATE_AVAILABLE_PREVIEW.sourceContent);
+
+    const applyUpdate = await waitForStoryButton(
+      review,
+      (candidate) => candidate.textContent?.trim() === '更新到来源版本',
+    );
+    applyUpdate.click();
+
+    const output = await waitForStorySelector<HTMLOutputElement>(
+      canvasElement,
+      '[data-testid="skills-update-input"]',
+    );
+    await waitForStoryText(output, UPDATE_AVAILABLE_PREVIEW.expectedSourceSha256);
+    const input = JSON.parse(output.textContent ?? '') as Record<string, unknown>;
+    await expect(input).toEqual({
+      skillId: UPDATE_AVAILABLE_PREVIEW.skill.id,
+      options: {
+        expectedCurrentSha256: UPDATE_AVAILABLE_PREVIEW.expectedCurrentSha256,
+        expectedSourceSha256: UPDATE_AVAILABLE_PREVIEW.expectedSourceSha256,
+      },
+    });
+  },
 };
 
 // Real path: sidebar → 扩展 → 技能, with an installed Skill disabled.

--- a/packages/ui/src/__tests__/skills-panel.test.tsx
+++ b/packages/ui/src/__tests__/skills-panel.test.tsx
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import type { ComponentProps } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { LocaleProvider } from '../locale-context.js';
 import type { SkillEntry } from '../module-panel-types.js';
@@ -21,7 +22,10 @@ const INSTALLED_SKILL: SkillEntry = {
   runtimeStatus: 'enabled',
 };
 
-function render(skills: SkillEntry[] = [INSTALLED_SKILL]): string {
+function render(
+  skills: SkillEntry[] = [INSTALLED_SKILL],
+  overrides: Partial<ComponentProps<typeof SkillsModuleMain>> = {},
+): string {
   return renderToStaticMarkup(
     <LocaleProvider locale="en">
       <ToastProvider>
@@ -32,6 +36,7 @@ function render(skills: SkillEntry[] = [INSTALLED_SKILL]): string {
           onSetSkillEnabled={() => {}}
           onSetSkillPinned={() => {}}
           onDeleteSkill={() => {}}
+          {...overrides}
         />
       </ToastProvider>
     </LocaleProvider>,
@@ -47,9 +52,23 @@ describe('Skills page interaction hierarchy', () => {
     assert.match(markup, /aria-label="More actions for Test Skill"/);
     assert.match(markup, /role="menu" aria-label="More actions for Test Skill"/);
     assert.match(markup, /role="menuitem"[\s\S]*?>Open SKILL.md</);
+    assert.match(markup, /role="menuitem"[\s\S]*?>Pin to the skill context</);
     assert.match(markup, /role="menuitem"[\s\S]*?>Delete</);
     assert.doesNotMatch(markup, /aria-label="Open SKILL.md"/);
     assert.doesNotMatch(markup, /aria-label="Delete Test Skill"/);
+  });
+
+  it('keeps managed update review in the contextual menu', () => {
+    const markup = render([{
+      ...INSTALLED_SKILL,
+      sourceType: 'managed',
+      managedUpdateStatus: 'update_available',
+    }], {
+      onPreviewManagedSkillUpdate: async () => null,
+    });
+
+    assert.match(markup, /role="menuitem"[\s\S]*?>View update</);
+    assert.doesNotMatch(markup, /<button[^>]*>View update<\/button>/);
   });
 
   it('renders scope and source as supporting text rather than status chips', () => {

--- a/packages/ui/src/__tests__/skills-panel.test.tsx
+++ b/packages/ui/src/__tests__/skills-panel.test.tsx
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { LocaleProvider } from '../locale-context.js';
+import type { SkillEntry } from '../module-panel-types.js';
+import { SkillsModuleMain } from '../skills-panel.js';
+import { ToastProvider } from '../toast.js';
+
+const INSTALLED_SKILL: SkillEntry = {
+  ref: 'workspace:maka:test-skill',
+  id: 'test-skill',
+  name: 'Test Skill',
+  description: 'Review a workspace before release.',
+  path: '/workspace/skills/test-skill',
+  declaredTools: ['Read'],
+  sourceType: 'workspace',
+  scope: 'workspace',
+  contextStatus: 'advertised',
+  manageable: true,
+  enabled: true,
+  runtimeStatus: 'enabled',
+};
+
+function render(skills: SkillEntry[] = [INSTALLED_SKILL]): string {
+  return renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <ToastProvider>
+        <SkillsModuleMain
+          skills={skills}
+          onOpenSkill={() => {}}
+          onUseSkill={() => {}}
+          onSetSkillEnabled={() => {}}
+          onSetSkillPinned={() => {}}
+          onDeleteSkill={() => {}}
+        />
+      </ToastProvider>
+    </LocaleProvider>,
+  );
+}
+
+describe('Skills page interaction hierarchy', () => {
+  it('keeps one direct action, one state control, and one contextual menu per installed row', () => {
+    const markup = render();
+
+    assert.match(markup, /aria-label="Use Test Skill in chat"/);
+    assert.match(markup, /role="switch"/);
+    assert.match(markup, /aria-label="More actions for Test Skill"/);
+    assert.match(markup, /role="menu" aria-label="More actions for Test Skill"/);
+    assert.match(markup, /role="menuitem"[\s\S]*?>Open SKILL.md</);
+    assert.match(markup, /role="menuitem"[\s\S]*?>Delete</);
+    assert.doesNotMatch(markup, /aria-label="Open SKILL.md"/);
+    assert.doesNotMatch(markup, /aria-label="Delete Test Skill"/);
+  });
+
+  it('renders scope and source as supporting text rather than status chips', () => {
+    const markup = render();
+
+    assert.match(markup, /Workspace · In context · Local/);
+    assert.doesNotMatch(markup, /aria-label="Workspace"/);
+    assert.doesNotMatch(markup, /aria-label="Local"/);
+  });
+
+  it('does not offer invocation for a disabled Skill', () => {
+    const markup = render([{
+      ...INSTALLED_SKILL,
+      contextStatus: 'disabled',
+      enabled: false,
+      runtimeStatus: 'disabled',
+    }]);
+
+    assert.doesNotMatch(markup, /Use Test Skill in chat/);
+    assert.match(markup, />Enable Test Skill<\/label>/);
+    assert.match(markup, /More actions for Test Skill/);
+  });
+});

--- a/packages/ui/src/skills-copy.ts
+++ b/packages/ui/src/skills-copy.ts
@@ -26,17 +26,6 @@ export interface SkillsCopy {
     sourceFallback: string;
   };
   tabs: { ariaLabel: string; market: string; builtin: string; installed: string };
-  banner: {
-    ariaLabel: string;
-    title: string;
-    body: string;
-    review: string;
-    reviewDetail: string;
-    documents: string;
-    documentsDetail: string;
-    publish: string;
-    publishDetail: string;
-  };
   install: {
     action: (name: string) => string;
     installedTitle: string;
@@ -85,22 +74,20 @@ export interface SkillsCopy {
     updating: string;
     toggling: string;
     reviewing: string;
+    actionsAriaLabel: (name: string) => string;
     useAriaLabel: (name: string) => string;
     use: string;
-    openAriaLabel: (name: string) => string;
     openTitle: string;
     disableAriaLabel: (name: string) => string;
     enableAriaLabel: (name: string) => string;
     stateErrorTitle: string;
-    pinAriaLabel: (name: string) => string;
-    unpinAriaLabel: (name: string) => string;
     pinTitle: string;
     unpinTitle: string;
     viewDiff: string;
     viewUpdate: string;
     confirmDeleteAriaLabel: (name: string) => string;
-    deleteAriaLabel: (name: string) => string;
-    confirmDelete: string;
+    deleteDescription: string;
+    cancel: string;
     delete: string;
   };
   review: {
@@ -144,6 +131,8 @@ export interface SkillsCopy {
     actions: string;
     search: string;
     openFolder: string;
+    moreActions: string;
+    refreshing: string;
     refresh: string;
   };
 }
@@ -153,31 +142,29 @@ const SKILLS_COPY = {
     categories: { '内容创作': '内容创作', '数据与AI': '数据与 AI', '设计与UI': '设计与 UI', 'DevOps与部署': 'DevOps 与部署', '文档与写作': '文档与写作', '效率工具': '效率工具', '研究与分析': '研究与分析' },
     market: { categoryAll: '全部分类', sortName: '排序：名称', sortRecent: '排序：最近', controls: '市场筛选与排序', categoryFilter: '按分类筛选市场技能', sortAriaLabel: '市场技能排序方式', ariaLabel: '技能市场', official: '官方精选', sourceActions: '来源库操作', importLocal: '导入本地 Skill', emptySearchTitle: '没有匹配的市场技能', emptyTitle: '来源库还是空的', emptySearchBody: '换一个关键词，或清空搜索查看全部来源。', emptyBody: '导入一个含 SKILL.md 的本地文件，它会作为可安装的来源出现在这里。', emptyFilterBody: '换一个分类或关键词，或清空筛选查看全部来源。', clearSearch: '清空搜索', clearFilters: '清空筛选', sourceFallback: '本地来源库 Skill。' },
     tabs: { ariaLabel: '技能视图', market: '市场', builtin: '内置', installed: '已安装' },
-    banner: { ariaLabel: '精选技能', title: '为你精选的职场技能', body: '涵盖写作、效率、设计、数据分析等场景，将陆续上线，敬请期待。', review: '复盘', reviewDetail: '总结沉淀', documents: '文档', documentsDetail: '审阅润色', publish: '发布', publishDetail: '检查清单' },
     install: { action: (name) => `安装 ${name}`, installedTitle: '已安装到当前工作区', installed: '已安装', notInstalled: '未安装' },
     builtin: { ariaLabel: '内置技能', title: '应用自带', emptyTitle: '暂无内置技能', emptyBody: '应用自带的技能会出现在这里。', noMatchTitle: '没有匹配的内置技能', noMatchBody: '换一个关键词，或清空搜索查看全部内置技能。', fallback: '应用自带 Skill。' },
     installed: { emptySearchTitle: '没有匹配的 Skill', emptyTitle: '等待添加 Skill', emptySearchBody: '换一个关键词，或清空搜索查看全部本地技能。', emptyBodyBeforeCode: '把一个含', emptyBodyAfterCode: '的文件夹放到工作区的 skills/ 目录下，刷新后会出现在这里。', refreshPending: '刷新中…', refresh: '刷新技能', count: (count) => `${count} 个`, listAriaLabel: '技能列表', sectionLabel: '已安装技能', summary: (skills, tools) => `${skills} 个 Skill · ${tools} 类工具` },
     context: { title: '上下文检查', summary: (discovered, advertised, omitted, shadowed) => `发现 ${discovered} · 已展示 ${advertised} · 预算省略 ${omitted} · 被覆盖 ${shadowed}`, scope: { project: '项目', workspace: '工作区', user: '用户', custom: '自定义' }, decision: { advertised: '已进入上下文', disabled: '已停用', invalid: '元数据无效', host_incompatible: '主机不兼容', shadowed: '被高优先级覆盖', budget: '因预算省略' }, needsReview: '待确认', needsReviewTitle: '旧版偏好同时匹配多个范围。请分别切换或固定每个范围的副本；Maka 不会自动猜测。', discoverySource: (scope, source) => `${scope}/${source} 发现源`, discoveryDiagnostic: { blocked_path: '路径被安全策略阻止', read_failed: '来源不可读取' } },
-    row: { hoverWithTools: (id, runtime, status, tools) => `技能：${id}\n\n运行状态：${runtime}\n来源状态：${status}\n声明工具：${tools}\n权限仍按当前会话策略判断；这里不是授权。`, hover: (id, runtime, status) => `技能：${id}\n\n运行状态：${runtime}\n来源状态：${status}`, opening: '打开中…', updating: '更新中…', toggling: '切换中…', reviewing: '审查中…', useAriaLabel: (name) => `在对话中使用 ${name}`, use: '使用', openAriaLabel: (name) => `打开 ${name} 的 SKILL.md`, openTitle: '打开 SKILL.md', disableAriaLabel: (name) => `停用 ${name}`, enableAriaLabel: (name) => `启用 ${name}`, stateErrorTitle: '当前项目的 Skill 状态文件异常', pinAriaLabel: (name) => `固定 ${name} 到技能上下文`, unpinAriaLabel: (name) => `取消固定 ${name}`, pinTitle: '优先放入模型可见的技能目录', unpinTitle: '取消上下文优先级', viewDiff: '查看差异', viewUpdate: '查看更新', confirmDeleteAriaLabel: (name) => `确认删除 ${name}`, deleteAriaLabel: (name) => `删除 ${name}`, confirmDelete: '确认删除', delete: '删除' },
+    row: { hoverWithTools: (id, runtime, status, tools) => `技能：${id}\n\n运行状态：${runtime}\n来源状态：${status}\n声明工具：${tools}\n权限仍按当前会话策略判断；这里不是授权。`, hover: (id, runtime, status) => `技能：${id}\n\n运行状态：${runtime}\n来源状态：${status}`, opening: '打开中…', updating: '更新中…', toggling: '切换中…', reviewing: '审查中…', actionsAriaLabel: (name) => `${name} 的更多操作`, useAriaLabel: (name) => `在对话中使用 ${name}`, use: '使用', openTitle: '打开 SKILL.md', disableAriaLabel: (name) => `停用 ${name}`, enableAriaLabel: (name) => `启用 ${name}`, stateErrorTitle: '当前项目的 Skill 状态文件异常', pinTitle: '固定到技能上下文', unpinTitle: '取消固定', viewDiff: '查看差异', viewUpdate: '查看更新', confirmDeleteAriaLabel: (name) => `确认删除 ${name}`, deleteDescription: '此操作会删除这个 Skill 的文件，且无法撤销。', cancel: '取消', delete: '删除' },
     review: { ariaLabel: 'Skill 更新审查', title: '更新审查', source: (id) => `来源 ${id}`, managedSource: '受管理来源', hasBaseline: '已有基线', missingBaseline: '缺少基线', lineTransition: (current, source) => `${current} → ${source} 行`, changedLines: (count) => `${count} 行不同`, warning: '工作区副本已有本地修改。继续更新会用来源库版本覆盖当前 SKILL.md。', workspace: '当前工作区', sourceVersion: '来源库版本', cancel: '取消', overwrite: '覆盖本地修改', update: '更新到来源版本' },
     description: { document: '创建、编辑、检查文档内容。', presentation: '创建、编辑、检查演示文稿。', spreadsheet: '创建、编辑、分析表格数据。', image: '生成或编辑图片素材。', browser: '打开、检查、操作网页界面。', macos: '辅助构建和调试 macOS 应用。', fallback: '打开技能文件查看适用场景。' },
     status: { metadataError: '元数据异常', managed: { source_missing: '来源缺失', update_available: '可更新', local_modified: '本地已修改', metadata_error: '元数据异常', up_to_date: '受管理', not_managed: '受管理' }, modified: '已修改', bundled: '内置', local: '本地', stateError: '状态异常', enabled: '已启用', disabled: '已停用' },
-    page: { title: '技能', subtitle: '安装与管理技能，在对话中扩展 Maka 的能力。', actions: '技能操作', search: '搜索技能', openFolder: '打开目录', refresh: '刷新' },
+    page: { title: '技能', subtitle: '安装与管理技能，在对话中扩展 Maka 的能力。', actions: '技能操作', search: '搜索技能', openFolder: '打开目录', moreActions: '更多技能操作', refreshing: '刷新中…', refresh: '刷新' },
   },
   en: {
     categories: { '内容创作': 'Content creation', '数据与AI': 'Data & AI', '设计与UI': 'Design & UI', 'DevOps与部署': 'DevOps & deployment', '文档与写作': 'Documents & writing', '效率工具': 'Productivity', '研究与分析': 'Research & analysis' },
     market: { categoryAll: 'All categories', sortName: 'Sort: Name', sortRecent: 'Sort: Recent', controls: 'Marketplace filters and sorting', categoryFilter: 'Filter marketplace skills by category', sortAriaLabel: 'Marketplace skill sort order', ariaLabel: 'Skill marketplace', official: 'Official picks', sourceActions: 'Source library actions', importLocal: 'Import local Skill', emptySearchTitle: 'No matching marketplace skills', emptyTitle: 'The source library is empty', emptySearchBody: 'Try another keyword or clear search to see all sources.', emptyBody: 'Import a local file containing SKILL.md to make it available as an installable source.', emptyFilterBody: 'Try another category or keyword, or clear the filters.', clearSearch: 'Clear search', clearFilters: 'Clear filters', sourceFallback: 'Local source-library Skill.' },
     tabs: { ariaLabel: 'Skill views', market: 'Marketplace', builtin: 'Built in', installed: 'Installed' },
-    banner: { ariaLabel: 'Featured skills', title: 'Featured workplace skills', body: 'Writing, productivity, design, and data-analysis skills are coming soon.', review: 'Review', reviewDetail: 'Capture insights', documents: 'Documents', documentsDetail: 'Review and refine', publish: 'Publish', publishDetail: 'Checklists' },
     install: { action: (name) => `Install ${name}`, installedTitle: 'Installed in this workspace', installed: 'Installed', notInstalled: 'Not installed' },
     builtin: { ariaLabel: 'Built-in skills', title: 'Included with the app', emptyTitle: 'No built-in skills', emptyBody: 'Skills included with the app appear here.', noMatchTitle: 'No matching built-in skills', noMatchBody: 'Try another keyword or clear search to see all built-in skills.', fallback: 'Skill included with the app.' },
     installed: { emptySearchTitle: 'No matching Skills', emptyTitle: 'Waiting for a Skill', emptySearchBody: 'Try another keyword or clear search to see all local skills.', emptyBodyBeforeCode: 'Place a folder containing', emptyBodyAfterCode: 'in the workspace skills/ directory, then refresh to show it here.', refreshPending: 'Refreshing…', refresh: 'Refresh skills', count: (count) => `${count}`, listAriaLabel: 'Skill list', sectionLabel: 'Installed skills', summary: (skills, tools) => `${skills} ${skills === 1 ? 'Skill' : 'Skills'} · ${tools} tool ${tools === 1 ? 'type' : 'types'}` },
     context: { title: 'Context inspector', summary: (discovered, advertised, omitted, shadowed) => `Discovered ${discovered} · advertised ${advertised} · budget omitted ${omitted} · shadowed ${shadowed}`, scope: { project: 'Project', workspace: 'Workspace', user: 'User', custom: 'Custom' }, decision: { advertised: 'In context', disabled: 'Disabled', invalid: 'Invalid metadata', host_incompatible: 'Host incompatible', shadowed: 'Shadowed', budget: 'Budget omitted' }, needsReview: 'Needs review', needsReviewTitle: 'A legacy preference matches multiple scopes. Toggle or pin each scoped copy explicitly; Maka will not guess.', discoverySource: (scope, source) => `${scope}/${source} discovery source`, discoveryDiagnostic: { blocked_path: 'Path blocked by the safety policy', read_failed: 'Source could not be read' } },
-    row: { hoverWithTools: (id, runtime, status, tools) => `Skill: ${id}\n\nRuntime status: ${runtime}\nSource status: ${status}\nDeclared tools: ${tools}\nPermissions still follow the current session policy; this is not authorization.`, hover: (id, runtime, status) => `Skill: ${id}\n\nRuntime status: ${runtime}\nSource status: ${status}`, opening: 'Opening…', updating: 'Updating…', toggling: 'Switching…', reviewing: 'Reviewing…', useAriaLabel: (name) => `Use ${name} in chat`, use: 'Use', openAriaLabel: (name) => `Open SKILL.md for ${name}`, openTitle: 'Open SKILL.md', disableAriaLabel: (name) => `Disable ${name}`, enableAriaLabel: (name) => `Enable ${name}`, stateErrorTitle: 'The Skill state file for this project is invalid', pinAriaLabel: (name) => `Pin ${name} to the skill context`, unpinAriaLabel: (name) => `Unpin ${name}`, pinTitle: 'Prioritize this skill in the model-visible catalog', unpinTitle: 'Remove the context priority', viewDiff: 'View diff', viewUpdate: 'View update', confirmDeleteAriaLabel: (name) => `Confirm deletion of ${name}`, deleteAriaLabel: (name) => `Delete ${name}`, confirmDelete: 'Confirm delete', delete: 'Delete' },
+    row: { hoverWithTools: (id, runtime, status, tools) => `Skill: ${id}\n\nRuntime status: ${runtime}\nSource status: ${status}\nDeclared tools: ${tools}\nPermissions still follow the current session policy; this is not authorization.`, hover: (id, runtime, status) => `Skill: ${id}\n\nRuntime status: ${runtime}\nSource status: ${status}`, opening: 'Opening…', updating: 'Updating…', toggling: 'Switching…', reviewing: 'Reviewing…', actionsAriaLabel: (name) => `More actions for ${name}`, useAriaLabel: (name) => `Use ${name} in chat`, use: 'Use', openTitle: 'Open SKILL.md', disableAriaLabel: (name) => `Disable ${name}`, enableAriaLabel: (name) => `Enable ${name}`, stateErrorTitle: 'The Skill state file for this project is invalid', pinTitle: 'Pin to the skill context', unpinTitle: 'Unpin', viewDiff: 'View diff', viewUpdate: 'View update', confirmDeleteAriaLabel: (name) => `Delete ${name}?`, deleteDescription: 'This removes the Skill files and cannot be undone.', cancel: 'Cancel', delete: 'Delete' },
     review: { ariaLabel: 'Skill update review', title: 'Update review', source: (id) => `Source ${id}`, managedSource: 'Managed source', hasBaseline: 'Baseline available', missingBaseline: 'No baseline', lineTransition: (current, source) => `${current} → ${source} lines`, changedLines: (count) => `${count} ${count === 1 ? 'line differs' : 'lines differ'}`, warning: 'The workspace copy has local changes. Continuing will replace the current SKILL.md with the source version.', workspace: 'Current workspace', sourceVersion: 'Source version', cancel: 'Cancel', overwrite: 'Overwrite local changes', update: 'Update to source version' },
     description: { document: 'Create, edit, and inspect documents.', presentation: 'Create, edit, and inspect presentations.', spreadsheet: 'Create, edit, and analyze spreadsheet data.', image: 'Generate or edit images.', browser: 'Open, inspect, and operate web interfaces.', macos: 'Build and debug macOS apps.', fallback: 'Open the skill file to see when to use it.' },
     status: { metadataError: 'Metadata error', managed: { source_missing: 'Source missing', update_available: 'Update available', local_modified: 'Locally modified', metadata_error: 'Metadata error', up_to_date: 'Managed', not_managed: 'Managed' }, modified: 'Modified', bundled: 'Built in', local: 'Local', stateError: 'State error', enabled: 'Enabled', disabled: 'Disabled' },
-    page: { title: 'Skills', subtitle: 'Install and manage skills to extend Maka in conversations.', actions: 'Skill actions', search: 'Search skills', openFolder: 'Open folder', refresh: 'Refresh' },
+    page: { title: 'Skills', subtitle: 'Install and manage skills to extend Maka in conversations.', actions: 'Skill actions', search: 'Search skills', openFolder: 'Open folder', moreActions: 'More Skill actions', refreshing: 'Refreshing…', refresh: 'Refresh' },
   },
 } satisfies UiCatalog<SkillsCopy>;
 

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -5,9 +5,12 @@ import {
   BookOpen,
   Download,
   FileEdit,
+  FolderOpen,
   Loader2,
+  MoreHorizontal,
   Pin,
   PinOff,
+  RefreshCcw,
   Search,
   Trash2,
 } from './icons.js';
@@ -18,11 +21,15 @@ import {
   Button as UiButton,
   EmptyState,
   IconButton,
+  Item,
   Switch,
   Tab,
   TabList,
-  Token,
 } from '@astryxdesign/core';
+import {
+  DropdownMenu,
+  DropdownMenuItem,
+} from '@astryxdesign/core/DropdownMenu';
 import { PageHeader } from './primitives/page-header.js';
 import { TextInput } from '@astryxdesign/core';
 import {
@@ -35,6 +42,7 @@ import type { ModuleHubHeader } from './module-hub-selector.js';
 import type { BundledSkillCatalogEntry, ManagedSkillCategory, ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry } from './module-panel-types.js';
 import { getSkillsCopy, type SkillsCopy } from './skills-copy.js';
 import { useUiLocale } from './locale-context.js';
+import { useToast } from './toast.js';
 
 // 市场 tab client-side filter/sort controls. Both are pure renderer
 // state — the managed-source list itself is fetched once over IPC.
@@ -42,7 +50,6 @@ const MARKET_CATEGORY_ALL = '__all__';
 type MarketSort = 'name' | 'recent';
 
 const SKILL_UPDATE_PREVIEW_MAX_LINES = 80;
-const DELETE_CONFIRM_TIMEOUT_MS = 4_000;
 
 function SkillLibraryPanel(props: {
   skills?: SkillEntry[];
@@ -62,7 +69,6 @@ function SkillLibraryPanel(props: {
   installingSourceId?: string | null;
   updatingSkillId?: string | null;
   togglingSkillId?: string | null;
-  deletingSkillId?: string | null;
   searchQuery?: string;
   /** Clears the module-header search box (owned by the outer panel). */
   onClearSearch?: () => void;
@@ -72,6 +78,8 @@ function SkillLibraryPanel(props: {
   installingBundledId?: string | null;
 }) {
   const copy = getSkillsCopy(useUiLocale());
+  const toast = useToast();
+  const skillLibraryMountedRef = useMountedRef();
   const marketCategories = Object.keys(copy.categories) as ManagedSkillCategory[];
   const skillCount = props.skills?.length ?? 0;
   // Designer audit P1-5: land on skills the user can actually run, not the
@@ -86,35 +94,27 @@ function SkillLibraryPanel(props: {
   });
   const [updatePreview, setUpdatePreview] = useState<ManagedSkillUpdatePreview | null>(null);
   const [reviewingSkillId, setReviewingSkillId] = useState<string | null>(null);
-  // Two-step in-place delete confirm (no dialog precedent in this panel): the
-  // first click arms 确认删除 on that row; a second click within the window
-  // deletes. The timeout reverts the armed state so a stray first click can't
-  // linger as a hot destructive control.
-  const [confirmingDeleteSkillId, setConfirmingDeleteSkillId] = useState<string | null>(null);
-  const deleteConfirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => () => {
-    if (deleteConfirmTimerRef.current) clearTimeout(deleteConfirmTimerRef.current);
-  }, []);
-  function clearDeleteConfirmTimer() {
-    if (deleteConfirmTimerRef.current) {
-      clearTimeout(deleteConfirmTimerRef.current);
-      deleteConfirmTimerRef.current = null;
-    }
-  }
-  // Keyed by ref, not id: the same skill id can be discovered in more than one
-  // scope, and an id-keyed confirm would arm the delete on every copy at once.
-  function requestDeleteSkill(skill: SkillEntry) {
+  async function requestDeleteSkill(skill: SkillEntry) {
     if (!props.onDeleteSkill) return;
     const ref = skill.ref ?? skill.id;
-    if (confirmingDeleteSkillId !== ref) {
-      clearDeleteConfirmTimer();
-      setConfirmingDeleteSkillId(ref);
-      deleteConfirmTimerRef.current = setTimeout(() => setConfirmingDeleteSkillId(null), DELETE_CONFIRM_TIMEOUT_MS);
-      return;
-    }
-    clearDeleteConfirmTimer();
-    setConfirmingDeleteSkillId(null);
-    void props.onDeleteSkill(ref);
+    const confirmed = await toast.confirm({
+      title: copy.row.confirmDeleteAriaLabel(skill.name),
+      description: copy.row.deleteDescription,
+      confirmLabel: copy.row.delete,
+      cancelLabel: copy.row.cancel,
+      destructive: true,
+    });
+    if (!confirmed || !skillLibraryMountedRef.current) return;
+    await props.onDeleteSkill(ref);
+  }
+
+  // Menu items close their Astryx layer synchronously. Defer actions that open
+  // another layer (the update review or destructive confirmation) by one frame
+  // so focus returns to the menu trigger before the next surface takes it.
+  function runAfterMenuClose(action: () => void) {
+    window.requestAnimationFrame(() => {
+      if (skillLibraryMountedRef.current) action();
+    });
   }
   const [marketCategory, setMarketCategory] = useState<ManagedSkillCategory | typeof MARKET_CATEGORY_ALL>(MARKET_CATEGORY_ALL);
   const [marketSort, setMarketSort] = useState<MarketSort>('name');
@@ -261,32 +261,6 @@ function SkillLibraryPanel(props: {
     </div>
   );
 
-  const banner = (
-    <section className="maka-skill-featured-banner" data-skills-banner aria-label={copy.banner.ariaLabel}>
-      <div>
-        <h3>{copy.banner.title}</h3>
-        <p>{copy.banner.body}</p>
-      </div>
-      <div className="maka-skill-featured-art" aria-hidden="true">
-        <span>
-          <FileEdit size={22} />
-          <strong>{copy.banner.review}</strong>
-          <small>{copy.banner.reviewDetail}</small>
-        </span>
-        <span>
-          <BookOpen size={22} />
-          <strong>{copy.banner.documents}</strong>
-          <small>{copy.banner.documentsDetail}</small>
-        </span>
-        <span>
-          <Blocks size={22} />
-          <strong>{copy.banner.publish}</strong>
-          <small>{copy.banner.publishDetail}</small>
-        </span>
-      </div>
-    </section>
-  );
-
   const market = (
     <section className="maka-skill-market" aria-label={copy.market.ariaLabel}>
       <SectionHeader
@@ -335,27 +309,26 @@ function SkillLibraryPanel(props: {
           className="maka-skill-installed-empty"
         />
       ) : (
-        <div className="maka-skill-market-grid">
+        <ul className="maka-skill-catalog-list">
           {marketSources.map((source) => {
             const installed = (props.skills ?? []).some((skill) => skill.id === source.id);
             const installing = props.installingSourceId === source.id;
             const description = source.description || copy.market.sourceFallback;
             return (
-              <article key={source.id} className="maka-skill-market-card">
-                <div className="maka-skill-market-card-head">
-                  <span className="maka-skill-market-icon" aria-hidden="true">
-                    <Blocks size={18} />
+              <Item
+                key={source.id}
+                as="li"
+                align="start"
+                className="maka-skill-catalog-item"
+                startContent={<Blocks size={18} aria-hidden="true" />}
+                label={source.name}
+                description={(
+                  <span className="maka-skill-catalog-details">
+                    <span>{description}</span>
+                    <span><code>{source.id}</code> · {copy.categories[source.category]} · {installed ? copy.install.installed : copy.install.notInstalled}</span>
                   </span>
-                  <div className="maka-skill-market-card-title">
-                    <h3>{source.name}</h3>
-                    {/* The source id is an identifier, not an aside — and it
-                        is the markup, not a call-site font-family, that puts
-                        it in the code family now. */}
-                    <code>{source.id}</code>
-                  </div>
-                  {/* + install acts; the card itself is inert (honest
-                      affordance). Disabled once the source is in the
-                      workspace, so it reads as a real state, not a toggle. */}
+                )}
+                endContent={(
                   <IconButton
                     variant="secondary"
                     size="sm"
@@ -365,16 +338,11 @@ function SkillLibraryPanel(props: {
                     tooltip={installed ? copy.install.installedTitle : copy.install.action(source.name)}
                     icon={installing ? <Loader2 size={16} aria-hidden="true" /> : <Download size={16} aria-hidden="true" />}
                   />
-                </div>
-                <p>{description}</p>
-                <div className="maka-skill-market-card-foot">
-                  <Token size="sm" className="maka-skill-market-category" label={copy.categories[source.category]} />
-                  <span>{installed ? copy.install.installed : copy.install.notInstalled}</span>
-                </div>
-              </article>
+                )}
+              />
             );
           })}
-        </div>
+        </ul>
       )}
     </section>
   );
@@ -403,22 +371,25 @@ function SkillLibraryPanel(props: {
           className="maka-skill-installed-empty"
         />
       ) : (
-        <div className="maka-skill-market-grid">
+        <ul className="maka-skill-catalog-list">
           {bundledCatalogFiltered.map((entry) => {
             const installing = props.installingBundledId === entry.id;
             const description = entry.description || copy.builtin.fallback;
             return (
-              <article key={entry.id} className="maka-skill-market-card">
-                <div className="maka-skill-market-card-head">
-                  <span className="maka-skill-market-icon" aria-hidden="true">
-                    <Blocks size={18} />
+              <Item
+                key={entry.id}
+                as="li"
+                align="start"
+                className="maka-skill-catalog-item"
+                startContent={<Blocks size={18} aria-hidden="true" />}
+                label={entry.name}
+                description={(
+                  <span className="maka-skill-catalog-details">
+                    <span>{description}</span>
+                    <span><code>{entry.id}</code> · {copy.categories[entry.category]} · {entry.installed ? copy.install.installed : copy.install.notInstalled}</span>
                   </span>
-                  <div className="maka-skill-market-card-title">
-                    <h3>{entry.name}</h3>
-                    <code>{entry.id}</code>
-                  </div>
-                  {/* Install copies the shipped body into the workspace. Disabled
-                      once installed, so the button reads as a state, not a toggle. */}
+                )}
+                endContent={(
                   <IconButton
                     variant="secondary"
                     size="sm"
@@ -428,16 +399,11 @@ function SkillLibraryPanel(props: {
                     tooltip={entry.installed ? copy.install.installedTitle : copy.install.action(entry.name)}
                     icon={installing ? <Loader2 size={16} aria-hidden="true" /> : <Download size={16} aria-hidden="true" />}
                   />
-                </div>
-                <p>{description}</p>
-                <div className="maka-skill-market-card-foot">
-                  <Token size="sm" className="maka-skill-market-category" label={copy.categories[entry.category]} />
-                  <span>{entry.installed ? copy.install.installed : copy.install.notInstalled}</span>
-                </div>
-              </article>
+                )}
+              />
             );
           })}
-        </div>
+        </ul>
       )}
     </section>
   );
@@ -458,19 +424,16 @@ function SkillLibraryPanel(props: {
         />
       ) : (
         <>
-          <aside className="maka-skill-context-inspector" aria-label={copy.context.title}>
-            <strong>{copy.context.title}</strong>
-            <span>{copy.context.summary(
-              contextCounts.discovered,
-              contextCounts.advertised,
-              contextCounts.omitted,
-              contextCounts.shadowed,
-            )}</span>
-          </aside>
           <SectionHeader
             className="maka-skill-section-row"
             title={<span className="maka-skill-section-label">{label}</span>}
             count={copy.installed.count(list.length)}
+            subtitle={`${copy.context.title}: ${copy.context.summary(
+              contextCounts.discovered,
+              contextCounts.advertised,
+              contextCounts.omitted,
+              contextCounts.shadowed,
+            )}`}
           />
           <ul className="maka-skill-library-list" aria-label={copy.installed.listAriaLabel}>
             {list.map((skill) => {
@@ -502,8 +465,6 @@ function SkillLibraryPanel(props: {
               const updating = props.updatingSkillId === skill.id;
               const toggling = props.togglingSkillId === skillRef;
               const reviewing = reviewingSkillId === skill.id;
-              const deleting = props.deletingSkillId === skillRef;
-              const confirmingDelete = confirmingDeleteSkillId === skillRef;
               const reviewableManagedUpdate = skill.managedUpdateStatus === 'update_available' || skill.managedUpdateStatus === 'local_modified';
               const canToggleSkill =
                 !isDiscoveryDiagnostic &&
@@ -515,40 +476,38 @@ function SkillLibraryPanel(props: {
                 : tools.length > 0
                   ? copy.row.hoverWithTools(skill.id, runtimeLabel, statusLabel, toolsLabel)
                   : copy.row.hover(skill.id, runtimeLabel, statusLabel);
+              const hasContextualActions = !isDiscoveryDiagnostic && Boolean(
+                props.onOpenSkill
+                || props.onSetSkillPinned
+                || (reviewableManagedUpdate && props.onPreviewManagedSkillUpdate)
+                || (props.onDeleteSkill && skill.manageable !== false),
+              );
               return (
-                <li key={skillRef} className="maka-skill-library-item" data-runtime-status={skill.runtimeStatus} data-context-status={contextStatus}>
-                  <div
-                    className="maka-skill-library-row"
-                    title={hoverText}
-                  >
-                    <span className="maka-skill-library-status" aria-hidden="true">
-                      <Blocks size={16} />
-                    </span>
-                    <span className="maka-skill-library-copy">
-                      <span className="maka-skill-library-name">
-                        {displayName}
-                        {!isDiscoveryDiagnostic && (skillNameCounts.get(skill.name) ?? 0) > 1 && (
-                          <code className="maka-skill-library-slug">{skill.id}</code>
-                        )}
-                      </span>
-                      {description && (
-                        <span className="maka-skill-library-description">{description}</span>
+                <Item
+                  key={skillRef}
+                  as="li"
+                  align="start"
+                  className="maka-skill-library-item"
+                  data-runtime-status={skill.runtimeStatus}
+                  data-context-status={contextStatus}
+                  startContent={<Blocks size={18} aria-hidden="true" />}
+                  label={(
+                    <span className="maka-skill-library-label" title={hoverText}>
+                      {displayName}
+                      {!isDiscoveryDiagnostic && (skillNameCounts.get(skill.name) ?? 0) > 1 && (
+                        <code className="maka-skill-library-slug">{skill.id}</code>
                       )}
                     </span>
-                    <span className="maka-skill-library-meta">
-                      {/* Marketplace redesign: the slug moved into the row's
-                          title tooltip (技能：${skill.id}) — the reference row
-                          shows only name + description. The status chips below
-                          stay (exception-only tone). */}
-                      {/* Detail round 6, exception-only: the adjacent Switch
-                          already says enabled/disabled — the visible chip only
-                          appears for states the switch can't express
-                          (state_error). 已启用/已停用 stay in the hover text. */}
+                  )}
+                  description={(
+                    <span className="maka-skill-library-details">
+                      {description ? <span>{description}</span> : null}
+                      {supportingMeta.length > 0 ? (
+                        <span className="maka-skill-library-supporting">{supportingMeta.join(' · ')}</span>
+                      ) : null}
+                      <span className="maka-skill-library-exceptions">
                       {skill.runtimeStatus === 'state_error' && (
                         <Badge variant="warning" className="maka-skill-library-runtime-label" data-status={skill.runtimeStatus} label={runtimeLabel} />
-                      )}
-                      {supportingMeta.length > 0 && (
-                        <span className="maka-skill-library-supporting">{supportingMeta.join(' · ')}</span>
                       )}
                       {skill.needsReview && (
                         <Badge
@@ -572,33 +531,22 @@ function SkillLibraryPanel(props: {
                       {updating && <span>{copy.row.updating}</span>}
                       {toggling && <span>{copy.row.toggling}</span>}
                       {reviewing && <span>{copy.row.reviewing}</span>}
+                      </span>
                     </span>
-                  </div>
-                  {!isDiscoveryDiagnostic && props.onUseSkill && skill.enabled && contextStatus !== 'shadowed' && (
-                    <UiButton
-                      variant="secondary"
-                      size="sm"
-                      className="maka-skill-library-use-button"
-                      onClick={() => props.onUseSkill?.(skill.id, skill.name)}
-                      isDisabled={props.actionBusy}
-                      aria-label={copy.row.useAriaLabel(skill.name)}
-                      label={copy.row.use}
-                    />
                   )}
-                  {!isDiscoveryDiagnostic && (
-                    <>
-                      <IconButton
-                        variant="secondary"
-                        size="sm"
-                        className="maka-skill-library-open-button"
-                        onClick={() => props.onOpenSkill?.(skillRef)}
-                        isDisabled={props.actionBusy || !props.onOpenSkill}
-                        label={copy.row.openAriaLabel(skill.name)}
-                        tooltip={copy.row.openTitle}
-                        icon={opening ? <Loader2 size={15} aria-hidden="true" /> : <FileEdit size={15} aria-hidden="true" />}
-                      />
+                  endContent={!isDiscoveryDiagnostic ? (
+                    <div className="maka-skill-library-controls">
+                      {props.onUseSkill && skill.enabled && contextStatus !== 'shadowed' ? (
+                        <UiButton
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => props.onUseSkill?.(skill.id, skill.name)}
+                          isDisabled={props.actionBusy}
+                          aria-label={copy.row.useAriaLabel(skill.name)}
+                          label={copy.row.use}
+                        />
+                      ) : null}
                       <Switch
-                        className="maka-skill-library-runtime-switch"
                         value={skill.enabled}
                         isDisabled={props.actionBusy || !canToggleSkill}
                         label={skill.enabled ? copy.row.disableAriaLabel(skill.name) : copy.row.enableAriaLabel(skill.name)}
@@ -608,47 +556,54 @@ function SkillLibraryPanel(props: {
                           : undefined}
                         onChange={(next) => props.onSetSkillEnabled?.(skillRef, next)}
                       />
-                    </>
-                  )}
-                  {!isDiscoveryDiagnostic && props.onSetSkillPinned && (
-                    <IconButton
-                      variant="secondary"
-                      size="sm"
-                      className="maka-skill-library-pin-button"
-                      onClick={() => props.onSetSkillPinned?.(skillRef, !skill.pinned)}
-                      isDisabled={
-                        props.actionBusy ||
-                        skill.runtimeStatus === 'state_error' ||
-                        contextStatus === 'invalid'
-                      }
-                      label={skill.pinned ? copy.row.unpinAriaLabel(skill.name) : copy.row.pinAriaLabel(skill.name)}
-                      tooltip={skill.pinned ? copy.row.unpinTitle : copy.row.pinTitle}
-                      icon={skill.pinned ? <PinOff size={15} aria-hidden="true" /> : <Pin size={15} aria-hidden="true" />}
-                    />
-                  )}
-                  {!isDiscoveryDiagnostic && reviewableManagedUpdate && props.onPreviewManagedSkillUpdate && (
-                    <UiButton
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => void reviewManagedSkillUpdate(skill)}
-                      isDisabled={props.actionBusy || reviewingSkillId !== null}
-                      label={reviewing ? copy.row.reviewing : skill.managedUpdateStatus === 'local_modified' ? copy.row.viewDiff : copy.row.viewUpdate}
-                    />
-                  )}
-                  {!isDiscoveryDiagnostic && props.onDeleteSkill && skill.manageable !== false && (
-                    <UiButton
-                      variant="secondary"
-                      size="sm"
-                      className="maka-skill-library-delete-button"
-                      data-confirming={confirmingDelete ? 'true' : undefined}
-                      onClick={() => requestDeleteSkill(skill)}
-                      isDisabled={props.actionBusy && !deleting}
-                      aria-label={confirmingDelete ? copy.row.confirmDeleteAriaLabel(skill.name) : copy.row.deleteAriaLabel(skill.name)}
-                      icon={deleting ? <Loader2 size={15} aria-hidden="true" /> : <Trash2 size={15} aria-hidden="true" />}
-                      label={confirmingDelete ? copy.row.confirmDelete : copy.row.delete}
-                    />
-                  )}
-                </li>
+                      {hasContextualActions ? (
+                        <DropdownMenu
+                          placement="below"
+                          button={{
+                            label: copy.row.actionsAriaLabel(skill.name),
+                            icon: <MoreHorizontal size={16} aria-hidden="true" />,
+                            isIconOnly: true,
+                            variant: 'ghost',
+                            size: 'sm',
+                            isDisabled: props.actionBusy,
+                          }}
+                        >
+                          {props.onOpenSkill ? (
+                            <DropdownMenuItem
+                              icon={opening ? <Loader2 size={14} aria-hidden="true" /> : <FileEdit size={14} aria-hidden="true" />}
+                              label={opening ? copy.row.opening : copy.row.openTitle}
+                              onClick={() => runAfterMenuClose(() => void props.onOpenSkill?.(skillRef))}
+                            />
+                          ) : null}
+                          {props.onSetSkillPinned ? (
+                            <DropdownMenuItem
+                              icon={skill.pinned ? <PinOff size={14} aria-hidden="true" /> : <Pin size={14} aria-hidden="true" />}
+                              label={skill.pinned ? copy.row.unpinTitle : copy.row.pinTitle}
+                              isDisabled={skill.runtimeStatus === 'state_error' || contextStatus === 'invalid'}
+                              onClick={() => runAfterMenuClose(() => void props.onSetSkillPinned?.(skillRef, !skill.pinned))}
+                            />
+                          ) : null}
+                          {reviewableManagedUpdate && props.onPreviewManagedSkillUpdate ? (
+                            <DropdownMenuItem
+                              icon={<Download size={14} aria-hidden="true" />}
+                              label={reviewing ? copy.row.reviewing : skill.managedUpdateStatus === 'local_modified' ? copy.row.viewDiff : copy.row.viewUpdate}
+                              isDisabled={reviewingSkillId !== null}
+                              onClick={() => runAfterMenuClose(() => void reviewManagedSkillUpdate(skill))}
+                            />
+                          ) : null}
+                          {props.onDeleteSkill && skill.manageable !== false ? (
+                            <DropdownMenuItem
+                              icon={<Trash2 size={14} aria-hidden="true" />}
+                              label={copy.row.delete}
+                              onClick={() => runAfterMenuClose(() => void requestDeleteSkill(skill))}
+                              style={{ color: 'var(--destructive-text)' }}
+                            />
+                          ) : null}
+                        </DropdownMenu>
+                      ) : null}
+                    </div>
+                  ) : undefined}
+                />
               );
             })}
           </ul>
@@ -707,7 +662,6 @@ function SkillLibraryPanel(props: {
 
   return (
     <div className="maka-skill-library" aria-busy={props.actionBusy ? 'true' : undefined}>
-      {banner}
       {tabs}
       {activeSkillTab === 'market' ? market : null}
       {activeSkillTab === 'builtin' ? builtinCatalog : null}
@@ -835,7 +789,29 @@ export function SkillsModuleMain(props: {
     }
   }
 
+  async function refreshSkillData() {
+    await Promise.all([
+      props.onRefreshSkills?.(),
+      props.onRefreshManagedSkillSources?.(),
+      props.onRefreshBundledSkillCatalog?.(),
+    ]);
+  }
+
+  function runPageActionAfterMenuClose(
+    actionKey: string,
+    action: (() => void | Promise<void>) | undefined,
+  ) {
+    window.requestAnimationFrame(() => {
+      if (skillActionMountedRef.current) void runSkillAction(actionKey, action);
+    });
+  }
+
   const skillActionBusy = pendingSkillAction !== null;
+  const canRefreshSkillData = Boolean(
+    props.onRefreshSkills
+    || props.onRefreshManagedSkillSources
+    || props.onRefreshBundledSkillCatalog,
+  );
   const auditReport = props.auditReport ?? deriveCapabilityAuditReport({ skills: props.skills ?? [] });
   return (
     <main className="maka-main detailPane maka-module-main agents-chat-panel" aria-label={props.hubHeader?.title ?? copy.page.title}>
@@ -859,24 +835,32 @@ export function SkillsModuleMain(props: {
               placeholder={copy.page.search}
             />
           </div>
-          {/* clickAction draws the in-flight state on the button itself, so
-              刷新 stops renaming itself to 刷新中… . `pendingSkillAction` stays:
-              it is what tells the library below which row is busy, which is a
-              pane-wide fact no single button holds. */}
-          <UiButton
-            className="maka-skill-header-utility"
-            variant="secondary"
-            clickAction={() => runSkillAction('folder', props.onOpenSkillsFolder)}
-            isDisabled={!props.onOpenSkillsFolder || skillActionBusy}
-            label={copy.page.openFolder}
-          />
-          <UiButton
-            className="maka-skill-header-utility"
-            variant="secondary"
-            clickAction={() => runSkillAction('refresh', props.onRefreshSkills)}
-            isDisabled={!props.onRefreshSkills || skillActionBusy}
-            label={copy.page.refresh}
-          />
+          {props.onOpenSkillsFolder || canRefreshSkillData ? (
+            <DropdownMenu
+              button={{
+                label: copy.page.moreActions,
+                icon: <MoreHorizontal size={16} aria-hidden="true" />,
+                isIconOnly: true,
+                variant: 'ghost',
+                isDisabled: skillActionBusy,
+              }}
+            >
+              {props.onOpenSkillsFolder ? (
+                <DropdownMenuItem
+                  icon={<FolderOpen size={14} aria-hidden="true" />}
+                  label={copy.page.openFolder}
+                  onClick={() => runPageActionAfterMenuClose('folder', props.onOpenSkillsFolder)}
+                />
+              ) : null}
+              {canRefreshSkillData ? (
+                <DropdownMenuItem
+                  icon={<RefreshCcw size={14} aria-hidden="true" />}
+                  label={pendingSkillAction === 'refresh' ? copy.page.refreshing : copy.page.refresh}
+                  onClick={() => runPageActionAfterMenuClose('refresh', refreshSkillData)}
+                />
+              ) : null}
+            </DropdownMenu>
+          ) : null}
         </div>
         }
       />
@@ -885,7 +869,7 @@ export function SkillsModuleMain(props: {
         skills={props.skills}
         managedSkillSources={props.managedSkillSources}
         bundledSkillCatalog={props.bundledSkillCatalog}
-        onRefreshSkills={props.onRefreshSkills ? () => runSkillAction('refresh', props.onRefreshSkills) : undefined}
+        onRefreshSkills={canRefreshSkillData ? () => runSkillAction('refresh', refreshSkillData) : undefined}
         onOpenSkill={props.onOpenSkill ? (skillId) => runSkillAction(`open:${skillId}`, () => props.onOpenSkill?.(skillId)) : undefined}
         onImportManagedSkillSource={props.onImportManagedSkillSource ? () => runSkillAction('source:import', props.onImportManagedSkillSource) : undefined}
         onInstallManagedSkill={props.onInstallManagedSkill ? (sourceId) => runSkillAction(`source:install:${sourceId}`, () => props.onInstallManagedSkill?.(sourceId)) : undefined}
@@ -904,7 +888,6 @@ export function SkillsModuleMain(props: {
         installingBundledId={pendingSkillAction?.startsWith('bundled:install:') ? pendingSkillAction.slice('bundled:install:'.length) : null}
         updatingSkillId={pendingSkillAction?.startsWith('managed:update:') ? pendingSkillAction.slice('managed:update:'.length) : null}
         togglingSkillId={pendingSkillAction?.startsWith('runtime:set:') ? pendingSkillAction.slice('runtime:set:'.length) : null}
-        deletingSkillId={pendingSkillAction?.startsWith('delete:') ? pendingSkillAction.slice('delete:'.length) : null}
         searchQuery={skillSearchQuery}
         onClearSearch={() => setSkillSearchQuery('')}
       />


### PR DESCRIPTION
## Summary

- replace the promotional/card stack and hand-built Skill rows with Astryx `Item` surfaces
- keep one direct `Use` action and one state switch per installed Skill, with open, pin, update, and delete in a single contextual menu
- keep source and scope as inline supporting metadata, reduce `skills.css` from 618 to 258 lines, and add the requested Storybook states plus UI/Desktop coverage

## Rationale

The page gave promotional content, discovery, context diagnostics, and every row action similar visual weight. This makes discovery and installed management easier to scan while preserving source import, installation, update review, enablement, pinning, deletion, file opening, and explicit invocation.

This is rebased onto current `main` and does not restore the removed sample-Skill action. The remaining page-level open-folder and refresh actions move into one secondary menu.

## Verification

- `npm --workspace @maka/ui test` — 321 passed
- `npm --workspace @maka/desktop run typecheck:stories`
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run smoke:storybook` — 68 manifest checks and 78 catalog renders passed
- `npm --workspace @maka/desktop run test:checks`
- workspace dependency build across core, storage, MCP, runtime, runtime host, computer use, and UI
- Storybook annotation and visual-smoke harness tests — 9 passed
- targeted Playwright collection — 3 tests across the Skills hierarchy and scope-aware deletion journeys
- committed update-review Storybook journey opens the row menu and diff panel, applies the source update, and asserts the exact current/source SHA arguments

The committed Playwright specs use normal pointer interactions. The update-review journey also runs through the real Astryx menu layer in the Storybook browser smoke rather than asserting static menu text only.

Closes #1901

<details>
<summary>中文说明</summary>

- 使用 Astryx `Item` 重组市场、内置和已安装 Skill 列表，移除促销区与重复的卡片框架。
- 每个已安装 Skill 只保留一个直接“使用”动作和一个启停开关；打开、固定、更新、删除收进同一个更多菜单。
- 来源与作用域改为行内辅助信息，`skills.css` 从 618 行缩减到 258 行，并补齐空列表、已安装、内置、可更新、已停用和窄窗口 Storybook 场景及相关测试。
- 新增可更新场景的真实交互测试：打开行菜单与差异面板、应用来源版本，并校验传入更新回调的 current/source SHA。
- 本分支已重放到最新主线，不会重新引入已删除的“创建示例 Skill”入口。

</details>
