### PR TITLE
feat: add configurable subagent model routing

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -17,12 +17,11 @@ test('changing the theme in settings applies to the UI', async ({ window: page }
   await expect(page.getByLabel('设置内容')).toBeVisible();
 
   await settingsNavigation(page).getByRole('button', { name: '外观', exact: true }).click();
-  const themeGroup = page.getByRole('radiogroup', { name: '主题' });
-  const lightTheme = themeGroup.getByRole('radio', { name: '浅色' });
-  const darkTheme = themeGroup.getByRole('radio', { name: '深色' });
-  await lightTheme.focus();
-  await lightTheme.press('ArrowDown');
+  const lightTheme = page.getByRole('checkbox', { name: '浅色' });
+  const darkTheme = page.getByRole('checkbox', { name: '深色' });
+  await darkTheme.locator('..').click();
   await expect(darkTheme).toBeChecked();
+  await expect(lightTheme).not.toBeChecked();
 
   await expect.poll(
     async () => page.evaluate(() => document.documentElement.classList.contains('dark')),

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -39,6 +39,7 @@ import {
   FakeBackend,
   SessionManager,
   createLocalContinuationSafetyInspector,
+  createConfiguredSubagentCatalog,
   buildDeepResearchTools,
   getAIModel,
   generateSessionTitle as generateRuntimeSessionTitle,
@@ -253,6 +254,10 @@ const runtimePersistence = await openRuntimeEventPersistence({
 const runtimeEventStore = runtimePersistence.runtimeEventStore;
 const connectionStore = createConnectionStore(workspaceRoot);
 const settingsStore = createSettingsStore(workspaceRoot);
+const subagentCatalog = createConfiguredSubagentCatalog({
+  getSettings: () => settingsStore.get(),
+  getConnection: (slug) => connectionStore.get(slug),
+});
 const mcpConfigStore = createMcpConfigStore(workspaceRoot);
 const mcpManager = new McpClientManager({ clientName: 'maka-desktop', clientVersion: app.getVersion() });
 let mcpStartup: Promise<void> | undefined;
@@ -844,6 +849,7 @@ const runtime = new SessionManager({
   shellRuns,
   backends,
   childTools: childAgentTools,
+  subagentCatalog,
   worktreeChildExecutor,
   safeBoundaryResumeEnabled: process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME === '1',
   onContinuationLifecycleEvent: (event) => {

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -199,6 +199,7 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
                   toolCallId: input.toolCallId,
                 },
                 agentProfile: input.agentProfile,
+                ...(input.subagentId ? { subagentId: input.subagentId } : {}),
                 prompt: input.prompt,
                 ...(input.swarm ? { swarm: input.swarm } : {}),
                 abortSignal: input.abortSignal,

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -29,6 +29,7 @@ import type {
 import { createDefaultSettings } from '@maka/core/settings';
 import { useMountedRef, useToast, useUiLocale } from '@maka/ui';
 import { ProvidersPanel } from './ProvidersPanel';
+import { SubagentPresetsPanel } from './subagent-presets-panel';
 import { safeLocalStorageSet } from '../browser-storage';
 import { AboutSettingsPage } from './about-settings-page';
 import { AppearanceSettingsPage } from './appearance-settings-page';
@@ -402,6 +403,11 @@ function SettingsPage(props: {
             initialConnectionSlug={props.initialConnectionSlug}
             initialCreateProviderType={props.initialCreateProviderType}
             onInitialCreateProviderConsumed={props.onInitialCreateProviderConsumed}
+          />
+          <SubagentPresetsPanel
+            settings={props.settings}
+            connections={props.connections}
+            onUpdate={props.onUpdateSettings}
           />
         </div>
       );

--- a/apps/desktop/src/renderer/settings/subagent-presets-panel.tsx
+++ b/apps/desktop/src/renderer/settings/subagent-presets-panel.tsx
@@ -1,0 +1,207 @@
+import { useMemo, useState } from 'react';
+import { Card, Item } from '@astryxdesign/core';
+import {
+  connectionEnabledModelIds,
+  isSafeSubagentPresetId,
+  type AppSettings,
+  type LlmConnection,
+  type SubagentPreset,
+  type SubagentProfile,
+  type UpdateAppSettingsResult,
+} from '@maka/core';
+import { Button, FormLayout, Selector, Switch, TextInput, useToast, useUiLocale } from '@maka/ui';
+import { settingsActionErrorMessage } from './settings-error-copy';
+
+const PROFILE_OPTIONS: Array<{ value: SubagentProfile; label: string }> = [
+  { value: 'local_read', label: 'Local Read' },
+  { value: 'web_research', label: 'Web Research' },
+  { value: 'implementation', label: 'Implementation' },
+];
+
+export function SubagentPresetsPanel(props: {
+  settings: AppSettings;
+  connections: readonly LlmConnection[];
+  onUpdate(
+    patch: Parameters<typeof window.maka.settings.update>[0],
+  ): Promise<UpdateAppSettingsResult>;
+}) {
+  const locale = useUiLocale();
+  const zh = locale === 'zh';
+  const toast = useToast();
+  const usableConnections = useMemo(
+    () => props.connections.filter((connection) => connection.enabled),
+    [props.connections],
+  );
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [id, setId] = useState('');
+  const [profile, setProfile] = useState<SubagentProfile>('local_read');
+  const [connectionSlug, setConnectionSlug] = useState(usableConnections[0]?.slug ?? '');
+  const selectedConnection =
+    usableConnections.find((connection) => connection.slug === connectionSlug) ??
+    usableConnections[0];
+  const modelIds = selectedConnection ? connectionEnabledModelIds(selectedConnection) : [];
+  const [model, setModel] = useState(modelIds[0] ?? '');
+  const selectedModel = modelIds.includes(model) ? model : (modelIds[0] ?? '');
+  const [saving, setSaving] = useState(false);
+
+  async function persist(presets: SubagentPreset[]): Promise<boolean> {
+    setSaving(true);
+    try {
+      await props.onUpdate({ subagents: { presets } });
+      return true;
+    } catch (error) {
+      toast.error(
+        zh ? '保存子 Agent 配置失败' : 'Failed to save subagent presets',
+        settingsActionErrorMessage(error, locale),
+      );
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function addPreset() {
+    const presetId = id.trim();
+    if (
+      !isSafeSubagentPresetId(presetId) ||
+      !name.trim() ||
+      !selectedConnection ||
+      !selectedModel ||
+      props.settings.subagents.presets.some((preset) => preset.id === presetId)
+    ) {
+      toast.error(
+        zh
+          ? '请填写唯一且有效的 ID、名称、连接和模型'
+          : 'Enter a unique valid id, name, connection, and model',
+      );
+      return;
+    }
+    const saved = await persist([
+      ...props.settings.subagents.presets,
+      {
+        id: presetId,
+        name: name.trim(),
+        description: description.trim(),
+        profile,
+        connectionSlug: selectedConnection.slug,
+        model: selectedModel,
+        enabled: true,
+      },
+    ]);
+    if (!saved) return;
+    setName('');
+    setDescription('');
+    setId('');
+  }
+
+  return (
+    <Card padding={0} className="settingsRows subagentPresetPanel">
+      <Item
+        label={zh ? '子 Agent 模型路由' : 'Subagent model routing'}
+        description={
+          zh
+            ? '主 Agent 从这里批准的配置中选择 subagent_id；能力边界由 Profile 决定，Provider 与模型在子会话创建时冻结。'
+            : 'The main agent selects an approved subagent_id. The profile owns capabilities; provider and model are frozen when the child session is created.'
+        }
+      />
+      {props.settings.subagents.presets.map((preset) => (
+        <Item
+          key={preset.id}
+          label={`${preset.name} · ${preset.id}`}
+          description={`${preset.description ? `${preset.description} · ` : ''}${preset.profile} · ${preset.connectionSlug} / ${preset.model}`}
+          endContent={
+            <div className="subagentPresetActions">
+              <Switch
+                label={zh ? '启用' : 'Enabled'}
+                isLabelHidden
+                value={preset.enabled}
+                isDisabled={saving}
+                onChange={(enabled) =>
+                  void persist(
+                    props.settings.subagents.presets.map((candidate) =>
+                      candidate.id === preset.id ? { ...candidate, enabled } : candidate,
+                    ),
+                  )
+                }
+              />
+              <Button
+                variant="secondary"
+                label={zh ? '删除' : 'Remove'}
+                isDisabled={saving}
+                onClick={() =>
+                  void persist(
+                    props.settings.subagents.presets.filter(
+                      (candidate) => candidate.id !== preset.id,
+                    ),
+                  )
+                }
+              />
+            </div>
+          }
+        />
+      ))}
+      <div className="subagentPresetForm">
+        <FormLayout className="settingsFormLayout" direction="horizontal">
+          <TextInput
+            label={zh ? '显示名称' : 'Display name'}
+            value={name}
+            onChange={setName}
+            placeholder={zh ? '快速代码阅读' : 'Fast code reader'}
+          />
+          <TextInput label="subagent_id" value={id} onChange={setId} placeholder="fast-reader" />
+          <Selector
+            label="Profile"
+            value={profile}
+            options={PROFILE_OPTIONS}
+            width="100%"
+            onChange={(value) => setProfile(value as SubagentProfile)}
+          />
+        </FormLayout>
+        <TextInput
+          label={zh ? '适用场景' : 'When to use'}
+          value={description}
+          onChange={setDescription}
+          placeholder={
+            zh ? '适合快速、低成本地阅读大型仓库' : 'Fast, low-cost exploration of large repositories'
+          }
+          width="100%"
+        />
+        <FormLayout className="settingsFormLayout" direction="horizontal">
+          <Selector
+            label={zh ? '模型连接' : 'Model connection'}
+            value={selectedConnection?.slug ?? ''}
+            options={usableConnections.map((connection) => ({
+              value: connection.slug,
+              label: connection.name,
+            }))}
+            width="100%"
+            onChange={(value) => {
+              setConnectionSlug(value);
+              const connection = usableConnections.find((candidate) => candidate.slug === value);
+              setModel(connection ? (connectionEnabledModelIds(connection)[0] ?? '') : '');
+            }}
+          />
+          <Selector
+            label={zh ? '模型' : 'Model'}
+            value={selectedModel}
+            options={modelIds.map((modelId) => ({
+              value: modelId,
+              label: modelId,
+            }))}
+            width="100%"
+            onChange={setModel}
+          />
+        </FormLayout>
+        <div className="settingsActionRow">
+          <Button
+            variant="primary"
+            label={zh ? '添加子 Agent 配置' : 'Add subagent preset'}
+            isDisabled={saving || usableConnections.length === 0}
+            onClick={() => void addPreset()}
+          />
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -90,3 +90,15 @@
   mask-repeat: no-repeat;
   mask-size: contain;
 }
+.subagentPresetActions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.subagentPresetForm {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-top: var(--border-width-hairline) solid var(--border);
+}

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -814,8 +814,11 @@ function assertDailyReviewSettingsBounds(
 ): void {
   const time = canvasElement.querySelector<HTMLInputElement>('input[type="text"]');
   const page = canvasElement.querySelector<HTMLElement>('.settingsFormPage');
-  const timeForm = time?.closest<HTMLElement>('.settingsFormLayout');
-  const selectorForm = selector.closest<HTMLElement>('.settingsFormLayout');
+  // The rows kit (#1972) retired `.settingsFormLayout`. A control now lives in
+  // its row's capped end slot, so `.settingsRowEnd` is the container this
+  // contract has always meant: the bound the control must not overflow.
+  const timeForm = time?.closest<HTMLElement>('.settingsRowEnd');
+  const selectorForm = selector.closest<HTMLElement>('.settingsRowEnd');
   const listbox = document.querySelector<HTMLElement>('[role="listbox"]');
   const popover = listbox?.closest<HTMLElement>('[popover]');
   if (!time || !page || !timeForm || !selectorForm || !popover) {

--- a/docs/agent-swarm.md
+++ b/docs/agent-swarm.md
@@ -37,11 +37,37 @@ input order even when children finish out of order.
 
 New work has two mutually exclusive forms. Callers may provide the explicit
 structured items shown below, or use a homogeneous template batch with one
-shared `profile`, a `prompt_template` containing `{{item}}`, and string
+shared selector, a `prompt_template` containing `{{item}}`, and string
 `items`. Template batches replace every placeholder occurrence, reject
 duplicate expanded tasks, generate stable ordered IDs (`item-1`, `item-2`,
 ...), and then enter the same preflight and execution path as explicit items.
 They are input shorthand, not a separate scheduler.
+
+### Configurable subagent model routes
+
+Settings → Models can define multiple user-approved subagent presets. Each
+preset has a stable `subagent_id`, a capability `profile`, and its own model
+connection/model pair. The main Agent discovers these routes with `agent_list`
+and selects one by `subagent_id`; it cannot supply an arbitrary provider or
+model in a tool call.
+
+The runtime resolves the id against the host-owned catalog and freezes the
+resolved connection, model, thinking level, and profile into the new child
+Session. Editing or deleting a preset therefore affects future spawns only;
+resume and retry continue to use the child Session's durable target. The
+legacy `profile` selector remains supported and inherits the parent target.
+
+For a configured route, replace `profile` with `subagent_id` in either an
+explicit item or a template batch:
+
+```ts
+agent_swarm({
+  prompt_template: "Review {{item}} and return concrete evidence.",
+  subagent_id: "fast-reader",
+  items: ["runtime", "desktop", "tests"],
+  max_concurrency: 3
+})
+```
 
 Either form may also include `resume_run_ids`, a map from an existing child
 `runId` to the new prompt that should continue it. A call may contain only

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -25,6 +25,7 @@ import {
   createProviderRequestCaptureRecorder,
   createFilesystemWorkerLaunchSpecProvider,
   createLocalContinuationSafetyInspector,
+  createConfiguredSubagentCatalog,
   drainGoalTurn,
   FilesystemWorkerClient,
   buildDefaultContextBudgetPolicy,
@@ -255,6 +256,10 @@ export async function createMakaCliRuntimeContext(
   const connectionStore = createConnectionStore(configRoot);
   const credentialStore = createFileCredentialStore(configRoot);
   const settingsStore = createSettingsStore(configRoot);
+  const subagentCatalog = createConfiguredSubagentCatalog({
+    getSettings: () => settingsStore.get(),
+    getConnection: (slug) => connectionStore.get(slug),
+  });
   // Read-only scanner over other agents' local session stores (~/.claude,
   // ~/.codex). Independent of the Maka workspace — takes no workspaceRoot.
   const foreignSessions = createForeignSessionStore();
@@ -703,6 +708,7 @@ export async function createMakaCliRuntimeContext(
                   toolCallId: childInput.toolCallId,
                 },
                 agentProfile: childInput.agentProfile,
+                ...(childInput.subagentId ? { subagentId: childInput.subagentId } : {}),
                 prompt: childInput.prompt,
                 ...(childInput.swarm ? { swarm: childInput.swarm } : {}),
                 abortSignal: childInput.abortSignal,
@@ -814,6 +820,7 @@ export async function createMakaCliRuntimeContext(
       : {}),
     shellRuns,
     backends,
+    subagentCatalog,
     runtimeSource: input.runtimeSource ?? (input.surface === 'activation' ? 'gateway' : undefined),
     safeBoundaryResumeEnabled:
       input.safeBoundaryResumeEnabled ??

--- a/packages/core/src/__tests__/settings.test.ts
+++ b/packages/core/src/__tests__/settings.test.ts
@@ -8,6 +8,76 @@ import {
   normalizeSettings,
 } from '../settings.js';
 
+test('normalizes user-approved subagent presets without widening the catalog', () => {
+  const normalized = normalizeSettings({
+    subagents: {
+      presets: [
+        {
+          id: 'fast-reader',
+          name: ' Fast reader ',
+          description: ' Cheap repository scans ',
+          profile: 'local_read',
+          connectionSlug: 'openai-main',
+          model: 'gpt-5-mini',
+          thinkingLevel: 'low',
+          enabled: true,
+        },
+        {
+          id: 'fast-reader',
+          name: 'duplicate',
+          description: '',
+          profile: 'implementation',
+          connectionSlug: 'other',
+          model: 'other',
+          enabled: true,
+        },
+        {
+          id: 'unsafe id',
+          name: 'unsafe',
+          profile: 'root',
+          connectionSlug: 'other',
+          model: 'other',
+          enabled: true,
+        },
+      ],
+    },
+  });
+
+  expect(normalized.subagents.presets).toEqual([
+    {
+      id: 'fast-reader',
+      name: 'Fast reader',
+      description: 'Cheap repository scans',
+      profile: 'local_read',
+      connectionSlug: 'openai-main',
+      model: 'gpt-5-mini',
+      thinkingLevel: 'low',
+      enabled: true,
+    },
+  ]);
+});
+
+test('replaces subagent presets atomically through the settings patch', () => {
+  const current = normalizeSettings({
+    subagents: {
+      presets: [
+        {
+          id: 'reader',
+          name: 'Reader',
+          description: '',
+          profile: 'local_read',
+          connectionSlug: 'a',
+          model: 'model-a',
+          enabled: true,
+        },
+      ],
+    },
+  });
+  const next = mergeSettings(current, { subagents: { presets: [] } });
+
+  expect(next.subagents.presets).toEqual([]);
+});
+
 test('delegates bot patches and persisted normalization to the bot settings owner', () => {
   const current = createDefaultSettings();
   Object.assign(current.botChat.channels.telegram, {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1533,6 +1533,16 @@ export type {
   UsageSummary,
   UsageTab,
 } from './settings.js';
+
+export type { SubagentPreset, SubagentProfile, SubagentSettings } from './subagent-settings.js';
+export {
+  MAX_SUBAGENT_PRESETS,
+  SUBAGENT_PRESET_ID_MAX_CHARS,
+  SUBAGENT_PROFILES,
+  isSafeSubagentPresetId,
+  isSubagentProfile,
+  normalizeSubagentSettings,
+} from './subagent-settings.js';
 export {
   CHAT_DEFAULT_PERMISSION_MODES,
   DEFAULT_PROXY_BYPASS_DOMAINS,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -120,6 +120,8 @@ export interface SubagentSessionRuntime {
   agentId: string;
   agentName: string;
   profile: string;
+  /** User-approved model route selected at spawn time. Absent for legacy profile spawns. */
+  presetId?: string;
   systemPrompt: string;
   toolNames: string[];
   categoryPolicy: Partial<Record<ToolCategory, PolicyDecision>>;
@@ -349,7 +351,7 @@ const SUBAGENT_SESSION_RUNTIME_SHAPE = defineObjectShape<SubagentSessionRuntime>
     'toolNames',
     'categoryPolicy',
   ],
-  ['permissionCeiling'],
+  ['permissionCeiling', 'presetId'],
 );
 const SUBAGENT_SESSION_SPAWN_IDENTITY_SHAPE = defineObjectShape<SubagentSessionSpawn>()(
   ['schemaVersion', 'requestFingerprint', 'initialTurnId', 'initialRunId'],
@@ -408,6 +410,7 @@ export function isSubagentSessionRuntime(value: unknown): value is SubagentSessi
     (value.definitionVersion as number) < 1 ||
     !isSessionLineageId(value.agentId) ||
     !isSessionLineageId(value.profile) ||
+    (value.presetId !== undefined && !isSessionLineageId(value.presetId)) ||
     typeof value.agentName !== 'string' ||
     value.agentName.length === 0 ||
     value.agentName.length > SUBAGENT_RUNTIME_NAME_MAX_CHARS ||

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -21,6 +21,7 @@ import {
   type UiLocalePreference,
 } from './ui-locale.js';
 import { defaultVoiceSettings, normalizeVoiceSettings, type VoiceSettings } from './voice.js';
+import { normalizeSubagentSettings, type SubagentSettings } from './subagent-settings.js';
 
 export { UI_LOCALE_PREFERENCES, isUiLocalePreference } from './ui-locale.js';
 export type { UiLocalePreference } from './ui-locale.js';
@@ -279,6 +280,7 @@ export interface AppSettings {
   notifications: NotificationSettings;
   system: SystemSettings;
   voice: VoiceSettings;
+  subagents: SubagentSettings;
 }
 
 export interface UsageRequestLog {
@@ -360,6 +362,7 @@ export type UpdateAppSettingsInput = Partial<{
     realtime: Partial<VoiceSettings['realtime']>;
   }>;
   webSearch: WebSearchSettingsPatch;
+  subagents: SubagentSettings;
 }>;
 
 export type PersonalizationSettingsWarning =
@@ -437,6 +440,7 @@ export function createDefaultSettings(): AppSettings {
       keepSystemAwake: false,
     },
     voice: defaultVoiceSettings(),
+    subagents: { presets: [] },
   };
 }
 
@@ -504,6 +508,10 @@ export function mergeSettings(current: AppSettings, patch: UpdateAppSettingsInpu
       },
     }),
     webSearch: mergeWebSearchSettings(current.webSearch, patch.webSearch),
+    subagents:
+      patch.subagents === undefined
+        ? current.subagents
+        : normalizeSubagentSettings(patch.subagents),
   };
 }
 
@@ -525,6 +533,7 @@ export function normalizeSettings(input: unknown): AppSettings {
     notifications: value.notifications,
     system: value.system,
     voice: value.voice,
+    subagents: value.subagents,
   });
   // PR110b: milestones bypass the generic patch surface so we can
   // sanitize them with the closed-enum + at-most-one validator on
@@ -601,6 +610,7 @@ export function normalizeSettings(input: unknown): AppSettings {
         typeof base.system.keepSystemAwake === 'boolean' ? base.system.keepSystemAwake : false,
     },
     voice: normalizeVoiceSettings(base.voice),
+    subagents: normalizeSubagentSettings(base.subagents),
   };
 }
 

--- a/packages/core/src/subagent-settings.ts
+++ b/packages/core/src/subagent-settings.ts
@@ -1,0 +1,86 @@
+import { isThinkingLevel, type ThinkingLevel } from './model-thinking.js';
+
+export const SUBAGENT_PROFILES = ['local_read', 'web_research', 'implementation'] as const;
+export type SubagentProfile = (typeof SUBAGENT_PROFILES)[number];
+
+export const MAX_SUBAGENT_PRESETS = 64;
+export const SUBAGENT_PRESET_ID_MAX_CHARS = 128;
+const SAFE_SUBAGENT_PRESET_ID = /^[A-Za-z0-9._:-]+$/;
+
+/** User-approved model route for one catalog subagent capability. */
+export interface SubagentPreset {
+  id: string;
+  name: string;
+  description: string;
+  profile: SubagentProfile;
+  connectionSlug: string;
+  model: string;
+  thinkingLevel?: ThinkingLevel;
+  enabled: boolean;
+}
+
+export interface SubagentSettings {
+  presets: SubagentPreset[];
+}
+
+export function isSubagentProfile(value: unknown): value is SubagentProfile {
+  return typeof value === 'string' && (SUBAGENT_PROFILES as readonly string[]).includes(value);
+}
+
+export function isSafeSubagentPresetId(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= SUBAGENT_PRESET_ID_MAX_CHARS &&
+    SAFE_SUBAGENT_PRESET_ID.test(value)
+  );
+}
+
+export function normalizeSubagentSettings(input: unknown): SubagentSettings {
+  if (
+    !input ||
+    typeof input !== 'object' ||
+    !Array.isArray((input as { presets?: unknown }).presets)
+  ) {
+    return { presets: [] };
+  }
+  const presets: SubagentPreset[] = [];
+  const seen = new Set<string>();
+  for (const candidate of (input as { presets: unknown[] }).presets) {
+    if (presets.length >= MAX_SUBAGENT_PRESETS) break;
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) continue;
+    const value = candidate as Record<string, unknown>;
+    if (
+      !isSafeSubagentPresetId(value.id) ||
+      seen.has(value.id) ||
+      !isSubagentProfile(value.profile) ||
+      typeof value.name !== 'string' ||
+      value.name.trim().length < 1 ||
+      value.name.trim().length > 128 ||
+      typeof value.connectionSlug !== 'string' ||
+      value.connectionSlug.trim().length < 1 ||
+      value.connectionSlug.trim().length > 128 ||
+      typeof value.model !== 'string' ||
+      value.model.trim().length < 1 ||
+      value.model.trim().length > 512 ||
+      (value.enabled !== true && value.enabled !== false) ||
+      (value.thinkingLevel !== undefined && !isThinkingLevel(value.thinkingLevel))
+    ) {
+      continue;
+    }
+    const id = value.id;
+    seen.add(id);
+    presets.push({
+      id,
+      name: value.name.trim(),
+      description:
+        typeof value.description === 'string' ? value.description.trim().slice(0, 1_000) : '',
+      profile: value.profile,
+      connectionSlug: value.connectionSlug.trim(),
+      model: value.model.trim(),
+      ...(value.thinkingLevel !== undefined ? { thinkingLevel: value.thinkingLevel } : {}),
+      enabled: value.enabled,
+    });
+  }
+  return { presets };
+}

--- a/packages/runtime-host/src/server/child-agent-composition.ts
+++ b/packages/runtime-host/src/server/child-agent-composition.ts
@@ -73,6 +73,7 @@ export function bindHostChildAgentBackend(
           toolCallId: input.toolCallId,
         },
         agentProfile: input.agentProfile,
+        ...(input.subagentId ? { subagentId: input.subagentId } : {}),
         prompt: input.prompt,
         ...(input.swarm ? { swarm: input.swarm } : {}),
         abortSignal: input.abortSignal,

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -270,6 +270,41 @@ describe('AgentSwarm adapter', () => {
     );
   });
 
+  test('routes every configured template item through the selected subagent_id', async () => {
+    const selectors: Array<{ profile: string; subagentId?: string }> = [];
+    const tool = buildAgentSwarmTool();
+    const result = await tool.impl(
+      {
+        prompt_template: `Review ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER}.`,
+        subagent_id: 'fast-reader',
+        items: ['runtime', 'desktop'],
+        max_concurrency: 2,
+      },
+      context({
+        listChildAgents: async () => ({
+          presets: [
+            {
+              id: 'fast-reader',
+              profile: LOCAL_READ_AGENT_PROFILE,
+              availability: { status: 'available' },
+            },
+          ],
+        }),
+        spawnChildSession: async (input) => {
+          selectors.push({ profile: input.agentProfile, subagentId: input.subagentId });
+          const index = selectors.length - 1;
+          return { ...childResult(index), childSessionId: `child-session-${index}` };
+        },
+      }),
+    );
+
+    assert.deepEqual(selectors, [
+      { profile: LOCAL_READ_AGENT_PROFILE, subagentId: 'fast-reader' },
+      { profile: LOCAL_READ_AGENT_PROFILE, subagentId: 'fast-reader' },
+    ]);
+    assert.equal(result.status, 'completed');
+  });
+
   test('projects item-scoped child tool and provider retry progress for spawned and resumed items', async () => {
     const output: Array<{ stream: string; chunk: string }> = [];
     const result = await buildAgentSwarmTool().impl(

--- a/packages/runtime/src/__tests__/configured-subagent-catalog.test.ts
+++ b/packages/runtime/src/__tests__/configured-subagent-catalog.test.ts
@@ -1,0 +1,62 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { expect } from '../test-helpers.js';
+import { createDefaultSettings, type LlmConnection } from '@maka/core';
+import { createConfiguredSubagentCatalog } from '../configured-subagent-catalog.js';
+
+const connection: LlmConnection = {
+  slug: 'worker-provider',
+  name: 'Worker provider',
+  providerType: 'openai',
+  defaultModel: 'gpt-5-mini',
+  enabledModelIds: ['gpt-5-mini'],
+  enabled: true,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+describe('configured subagent catalog', () => {
+  test('lists availability and resolves only enabled user-approved targets', async () => {
+    const settings = createDefaultSettings();
+    settings.subagents.presets = [
+      {
+        id: 'fast-reader',
+        name: 'Fast reader',
+        description: 'Cheap scans',
+        profile: 'local_read',
+        connectionSlug: connection.slug,
+        model: 'gpt-5-mini',
+        enabled: true,
+      },
+      {
+        id: 'missing-model',
+        name: 'Missing model',
+        description: '',
+        profile: 'local_read',
+        connectionSlug: connection.slug,
+        model: 'gpt-5-nano',
+        enabled: true,
+      },
+    ];
+    const catalog = createConfiguredSubagentCatalog({
+      getSettings: async () => settings,
+      getConnection: async (slug) => (slug === connection.slug ? connection : null),
+    });
+
+    expect(
+      (await catalog.list()).map(({ id, availability }) => ({
+        id,
+        availability,
+      })),
+    ).toEqual([
+      { id: 'fast-reader', availability: { status: 'available' } },
+      {
+        id: 'missing-model',
+        availability: { status: 'unavailable', reason: 'model_disabled' },
+      },
+    ]);
+    expect(await catalog.resolve('fast-reader')).toEqual(settings.subagents.presets[0]);
+    await assert.rejects(catalog.resolve('missing-model'), /model_disabled/);
+    await assert.rejects(catalog.resolve('invented'), /Call agent_list/);
+  });
+});

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -2122,6 +2122,91 @@ describe('SessionManager child-session runtime primitive', () => {
     while (!(await parentTurn.next()).done) {}
   });
 
+  test('freezes a configured subagent model target independently from the parent', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const parentGate = makeGate();
+    backends.register(
+      'fake',
+      (ctx) => new TestBackend(ctx, ctx.header.subagentRuntime ? undefined : parentGate),
+    );
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      subagentCatalog: {
+        list: async () => [
+          {
+            id: 'fast-reader',
+            name: 'Fast reader',
+            description: 'Cheap scans',
+            profile: 'local_read',
+            connectionSlug: 'worker-connection',
+            model: 'worker-model',
+            thinkingLevel: 'low',
+            enabled: true,
+            availability: { status: 'available' },
+          },
+        ],
+        resolve: async (id) => {
+          if (id !== 'fast-reader') throw new Error('unknown preset');
+          return {
+            id,
+            name: 'Fast reader',
+            description: 'Cheap scans',
+            profile: 'local_read',
+            connectionSlug: 'worker-connection',
+            model: 'worker-model',
+            thinkingLevel: 'low',
+            enabled: true,
+          };
+        },
+      },
+      newId: nextId(),
+      now: nextNow(150),
+      runtimeSource: 'test',
+    });
+    const parent = await manager.createSession(
+      makeInput({
+        llmConnectionSlug: 'parent-connection',
+        model: 'parent-model',
+        thinkingLevel: 'high',
+      }),
+    );
+    const parentTurn = manager
+      .sendMessage(parent.id, { turnId: 'parent-turn-preset', text: 'delegate' })
+      [Symbol.asyncIterator]();
+    await parentTurn.next();
+    const [parentRun] = await runStore.listSessionRuns(parent.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+
+    const result = await manager.spawnChildSession(parent.id, {
+      spawnedBy: {
+        parentRunId: parentRun.runId,
+        parentTurnId: parentRun.turnId,
+        toolCallId: 'tool-call-preset',
+      },
+      agentProfile: LOCAL_READ_AGENT_PROFILE,
+      subagentId: 'fast-reader',
+      prompt: 'inspect cheaply',
+    });
+    const child = await store.readHeader(result.childSessionId);
+
+    expect(child.llmConnectionSlug).toBe('worker-connection');
+    expect(child.model).toBe('worker-model');
+    expect(child.thinkingLevel).toBe('low');
+    expect(child.subagentRuntime?.presetId).toBe('fast-reader');
+    expect(child.subagentRuntime?.agentName).toBe('Fast reader');
+    expect(child.connectionLocked).toBe(true);
+    expect((await manager.listChildAgents(parent.id)).presets[0]?.id).toBe('fast-reader');
+
+    parentGate.release();
+    while (!(await parentTurn.next()).done) {}
+  });
+
   test('child sessions preserve an explicit no-project association', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -115,6 +115,7 @@ describe('subagent tools', () => {
 
     expect(Object.keys(await advertisedProperties(buildSubagentSpawnTool()))).toEqual([
       'profile',
+      'subagent_id',
       'task',
       'write_back',
       'isolation',
@@ -125,7 +126,7 @@ describe('subagent tools', () => {
           buildSubagentSpawnTool({ taskLedger: taskLedgerStub(undefined, []) }),
         ),
       ),
-    ).toEqual(['profile', 'task', 'write_back', 'isolation', 'task_id']);
+    ).toEqual(['profile', 'subagent_id', 'task', 'write_back', 'isolation', 'task_id']);
   });
 
   test('agent_spawn rejects task_id when task binding is unavailable', () => {
@@ -574,6 +575,51 @@ describe('subagent tools', () => {
       summary: 'done',
       artifactIds: [],
     });
+  });
+
+  test('agent_spawn resolves a configured subagent_id and never accepts a raw model target', async () => {
+    const tool = buildSubagentSpawnTool();
+    const calls: Array<{ agentProfile: string; subagentId?: string; prompt?: string }> = [];
+    await tool.impl(
+      { subagent_id: 'fast-reader', task: 'Inspect the runtime tests.' },
+      {
+        sessionId: 'session-1',
+        turnId: 'parent-turn',
+        cwd: '/tmp/cwd',
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+        listChildAgents: async () => ({
+          presets: [
+            {
+              id: 'fast-reader',
+              profile: LOCAL_READ_AGENT_PROFILE,
+              availability: { status: 'available' },
+            },
+          ],
+        }),
+        spawnChildSession: async (input) => {
+          calls.push(input);
+          return {
+            profile: input.agentProfile,
+            childSessionId: 'child-session',
+            agentId: LOCAL_READ_AGENT_ID,
+            agentName: 'Local Read',
+            turnId: 'child-turn',
+            runId: 'child-run',
+            status: 'completed',
+            permissionMode: 'explore',
+            summary: 'done',
+            artifactIds: [],
+          };
+        },
+      },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.agentProfile).toBe(LOCAL_READ_AGENT_PROFILE);
+    expect(calls[0]?.subagentId).toBe('fast-reader');
+    expect(calls[0]?.prompt).toBe('Inspect the runtime tests.');
   });
 
   test('agent_spawn bounds projected child tool activity', async () => {

--- a/packages/runtime/src/agent-catalog.ts
+++ b/packages/runtime/src/agent-catalog.ts
@@ -4,6 +4,7 @@ import {
   type PolicyDecision,
   type ToolCategory,
 } from '@maka/core/permission';
+import { SUBAGENT_PROFILES, type SubagentPreset, type SubagentProfile } from '@maka/core';
 import type { MakaTool } from './tool-runtime.js';
 
 export const LOCAL_READ_AGENT_ID = 'local-read';
@@ -12,11 +13,7 @@ export const WEB_RESEARCH_AGENT_ID = 'web-research';
 export const WEB_RESEARCH_AGENT_PROFILE = 'web_research';
 export const IMPLEMENTATION_AGENT_ID = 'implementation';
 export const IMPLEMENTATION_AGENT_PROFILE = 'implementation';
-export const BUILTIN_AGENT_PROFILES = [
-  LOCAL_READ_AGENT_PROFILE,
-  WEB_RESEARCH_AGENT_PROFILE,
-  IMPLEMENTATION_AGENT_PROFILE,
-] as const;
+export const BUILTIN_AGENT_PROFILES = SUBAGENT_PROFILES;
 export const AGENT_INVOCATION_FOREGROUND = 'foreground';
 export const AGENT_CONTEXT_ISOLATED = 'isolated';
 export const AGENT_WORKSPACE_SAME_WORKSPACE = 'same_workspace';
@@ -24,7 +21,7 @@ export const AGENT_WORKSPACE_WORKTREE = 'worktree';
 export const AGENT_WRITE_BACK_SUMMARY = 'summary';
 export const AGENT_WRITE_BACK_PATCH = 'patch';
 
-export type AgentProfile = (typeof BUILTIN_AGENT_PROFILES)[number];
+export type AgentProfile = SubagentProfile;
 export type AgentCapability = AgentProfile;
 export type AgentInvocationMode = typeof AGENT_INVOCATION_FOREGROUND;
 export type AgentContextMode = typeof AGENT_CONTEXT_ISOLATED;
@@ -82,6 +79,17 @@ export interface AgentDefinitionListItem {
   availability: AgentDefinitionAvailability;
   permissionMode: PermissionMode;
   tools: string[];
+}
+
+export type SubagentPresetAvailability =
+  | { status: 'available' }
+  | {
+      status: 'unavailable';
+      reason: 'disabled' | 'missing_connection' | 'connection_disabled' | 'model_disabled';
+    };
+
+export interface SubagentPresetListItem extends SubagentPreset {
+  availability: SubagentPresetAvailability;
 }
 
 export interface AgentDefinitionListOptions {

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -2,6 +2,7 @@ import { redactSecrets } from '@maka/core/redaction';
 import {
   TASK_ID_MAX_CHARS,
   isSafeTaskId,
+  isSafeSubagentPresetId,
   projectAgentSwarmResult,
   type ToolResultContent,
 } from '@maka/core';
@@ -48,7 +49,8 @@ const AGENT_SWARM_ERROR_MAX_CHARS = 1_000;
 
 export interface AgentSwarmExplicitItemInput {
   item_id: string;
-  profile: string;
+  profile?: string;
+  subagent_id?: string;
   task: string;
   write_back?: string;
   isolation?: string;
@@ -62,7 +64,8 @@ export interface AgentSwarmExplicitToolInput {
 
 export interface AgentSwarmTemplateToolInput {
   prompt_template: string;
-  profile: string;
+  profile?: string;
+  subagent_id?: string;
   items: string[];
   resume_run_ids?: Record<string, string>;
   max_concurrency?: number;
@@ -84,6 +87,7 @@ interface PreparedAgentSwarmItem {
   readonly index: number;
   readonly itemId: string;
   readonly profile: string;
+  readonly subagentId?: string;
   readonly task: string;
   readonly definition: AgentDefinition;
   readonly mode: 'spawn' | 'resume';
@@ -129,7 +133,7 @@ export function buildAgentSwarmTool(
     displayName: 'Agent Swarm',
     description: [
       'Run the same kind of bounded foreground child work over several independent items.',
-      `Provide either explicit structured items, or prompt_template with one shared profile and string items; every ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER} occurrence is replaced with the item value.`,
+      `Prefer a user-approved subagent_id from agent_list; legacy profile remains supported. Provide either explicit structured items, or prompt_template with one shared selector and string items; every ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER} occurrence is replaced with the item value.`,
       'Use resume_run_ids to continue terminal child AgentRuns by runId; resumed children are ordered before new items.',
       'Use this only when every item can run independently. Results return in input order; you remain responsible for semantic synthesis.',
     ].join(' '),
@@ -248,6 +252,7 @@ export function buildAgentSwarmTool(
                   })) as SpawnChildAgentResult)
                 : ((await ctx.spawnChildSession!({
                     agentProfile: item.definition.profile,
+                    ...(item.subagentId ? { subagentId: item.subagentId } : {}),
                     prompt: item.task,
                     swarm: {
                       swarmId: ctx.toolCallId,
@@ -423,7 +428,14 @@ function agentSwarmInputSchema(
         .max(TASK_ID_MAX_CHARS)
         .refine(isSafeTaskId)
         .describe('Stable item id (letters, digits, dot, underscore, colon, or dash).'),
-      profile: z.enum(profiles).describe('Child agent profile.'),
+      profile: z.enum(profiles).optional().describe('Legacy child capability profile.'),
+      subagent_id: z
+        .string()
+        .min(1)
+        .max(128)
+        .refine(isSafeSubagentPresetId)
+        .optional()
+        .describe('User-approved subagent preset id from agent_list.'),
       task: z
         .string()
         .min(1)
@@ -439,6 +451,14 @@ function agentSwarmInputSchema(
         .describe('Requested child workspace isolation.'),
     })
     .superRefine((input, ctx) => {
+      if (Boolean(input.profile) === Boolean(input.subagent_id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Provide exactly one of subagent_id or legacy profile.',
+        });
+        return;
+      }
+      if (!input.profile) return;
       addAgentContractIssues(input, ctx, definitions);
     });
 
@@ -478,6 +498,13 @@ function agentSwarmInputSchema(
         .enum(profiles)
         .optional()
         .describe('Shared child profile for prompt_template string items.'),
+      subagent_id: z
+        .string()
+        .min(1)
+        .max(128)
+        .refine(isSafeSubagentPresetId)
+        .optional()
+        .describe('Shared user-approved subagent preset id for string items.'),
       resume_run_ids: z
         .record(z.string().trim().min(1), z.string().trim().min(1).max(AGENT_SWARM_TASK_MAX_CHARS))
         .optional()
@@ -521,6 +548,13 @@ function agentSwarmInputSchema(
             message: 'profile requires string items.',
           });
         }
+        if (input.subagent_id !== undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['subagent_id'],
+            message: 'subagent_id requires string items.',
+          });
+        }
         return;
       }
 
@@ -540,6 +574,13 @@ function agentSwarmInputSchema(
             message: 'profile is specified per item when items are structured.',
           });
         }
+        if (input.subagent_id !== undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['subagent_id'],
+            message: 'subagent_id is specified per item when items are structured.',
+          });
+        }
         return;
       }
 
@@ -551,11 +592,10 @@ function agentSwarmInputSchema(
         });
         return;
       }
-      if (input.profile === undefined) {
+      if (Boolean(input.profile) === Boolean(input.subagent_id)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          path: ['profile'],
-          message: 'profile is required when items are strings.',
+          message: 'String items require exactly one of subagent_id or legacy profile.',
         });
       }
       if (!input.prompt_template.includes(AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER)) {
@@ -596,6 +636,7 @@ function addAgentContractIssues(
   ctx: z.RefinementCtx,
   definitions: readonly AgentDefinition[],
 ): void {
+  if (!input.profile) return;
   const definition = requireAgentDefinitionByProfile(definitions, input.profile);
   const writeBack = input.write_back ?? definition.contract.defaultWriteBack;
   if (!definition.contract.supportedWriteBack.some((mode) => mode === writeBack)) {
@@ -623,7 +664,8 @@ async function prepareAgentSwarmInput(
   readonly items: readonly PreparedAgentSwarmItem[];
   readonly maxConcurrency: number;
 }> {
-  const preflight = preflightAgentSwarmInput(input, definitions);
+  const presetProfiles = await readAvailablePresetProfiles(input, ctx);
+  const preflight = preflightAgentSwarmInput(input, definitions, presetProfiles);
   if (preflight.items.length > 0 && !ctx.spawnChildSession) {
     throw new Error('spawnChildSession capability is unavailable in this runtime context');
   }
@@ -671,6 +713,7 @@ async function prepareAgentSwarmInput(
 function preflightAgentSwarmInput(
   input: AgentSwarmToolInput,
   definitions: readonly AgentDefinition[],
+  presetProfiles: ReadonlyMap<string, string>,
 ): {
   readonly items: readonly PreparedAgentSwarmItem[];
   readonly resumes: readonly PendingAgentSwarmResume[];
@@ -731,7 +774,13 @@ function preflightAgentSwarmInput(
       throw new Error(`Agent swarm item "${item.item_id}" has an invalid task.`);
     }
 
-    const definition = requireAgentDefinitionByProfile(definitions, item.profile);
+    const profile = item.profile ?? presetProfiles.get(item.subagent_id!);
+    if (!profile) {
+      throw new Error(
+        `Unknown or unavailable subagent_id "${item.subagent_id}". Call agent_list first.`,
+      );
+    }
+    const definition = requireAgentDefinitionByProfile(definitions, profile);
     const writeBack = item.write_back ?? definition.contract.defaultWriteBack;
     if (!definition.contract.supportedWriteBack.some((mode) => mode === writeBack)) {
       throw new Error(
@@ -748,6 +797,7 @@ function preflightAgentSwarmInput(
       index: resumes.length + index,
       itemId: item.item_id,
       profile: definition.profile,
+      ...(item.subagent_id ? { subagentId: item.subagent_id } : {}),
       task: item.task,
       definition,
       mode: 'spawn',
@@ -758,15 +808,15 @@ function preflightAgentSwarmInput(
 
 function normalizeAgentSwarmItems(input: AgentSwarmToolInput): AgentSwarmExplicitItemInput[] {
   if (!('items' in input) || !input.items) {
-    if ('prompt_template' in input || 'profile' in input) {
-      throw new Error('prompt_template and shared profile require string items.');
+    if ('prompt_template' in input || 'profile' in input || 'subagent_id' in input) {
+      throw new Error('prompt_template and shared selector require string items.');
     }
     return [];
   }
   const stringItemCount = input.items.filter((item) => typeof item === 'string').length;
   if (stringItemCount === 0) {
-    if ('prompt_template' in input || 'profile' in input) {
-      throw new Error('prompt_template and shared profile are only valid when items are strings.');
+    if ('prompt_template' in input || 'profile' in input || 'subagent_id' in input) {
+      throw new Error('prompt_template and shared selector are only valid when items are strings.');
     }
     return input.items;
   }
@@ -776,8 +826,8 @@ function normalizeAgentSwarmItems(input: AgentSwarmToolInput): AgentSwarmExplici
   if (!('prompt_template' in input) || typeof input.prompt_template !== 'string') {
     throw new Error('prompt_template is required when agent swarm items are strings.');
   }
-  if (!('profile' in input) || typeof input.profile !== 'string') {
-    throw new Error('profile is required when agent swarm items are strings.');
+  if (Boolean(input.profile) === Boolean(input.subagent_id)) {
+    throw new Error('String items require exactly one of subagent_id or legacy profile.');
   }
 
   const promptTemplate = input.prompt_template.trim();
@@ -802,10 +852,50 @@ function normalizeAgentSwarmItems(input: AgentSwarmToolInput): AgentSwarmExplici
     seenTasks.add(task);
     return {
       item_id: `item-${index + 1}`,
-      profile: input.profile,
+      ...(input.subagent_id ? { subagent_id: input.subagent_id } : { profile: input.profile! }),
       task,
     };
   });
+}
+
+async function readAvailablePresetProfiles(
+  input: AgentSwarmToolInput,
+  ctx: MakaToolContext,
+): Promise<ReadonlyMap<string, string>> {
+  const ids = new Set<string>();
+  if ('subagent_id' in input && input.subagent_id) ids.add(input.subagent_id);
+  if ('items' in input && Array.isArray(input.items)) {
+    for (const item of input.items) {
+      if (typeof item !== 'string' && item.subagent_id) ids.add(item.subagent_id);
+    }
+  }
+  if (ids.size === 0) return new Map();
+  if (!ctx.listChildAgents) {
+    throw new Error('listChildAgents capability is unavailable in this runtime context');
+  }
+  const catalog = await ctx.listChildAgents();
+  const presets =
+    catalog && typeof catalog === 'object' && !Array.isArray(catalog)
+      ? (catalog as { presets?: unknown }).presets
+      : undefined;
+  if (!Array.isArray(presets)) throw new Error('Configured subagent catalog is unavailable');
+  const profiles = new Map<string, string>();
+  for (const candidate of presets) {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) continue;
+    const preset = candidate as {
+      id?: unknown;
+      profile?: unknown;
+      availability?: { status?: unknown };
+    };
+    if (
+      typeof preset.id === 'string' &&
+      typeof preset.profile === 'string' &&
+      preset.availability?.status === 'available'
+    ) {
+      profiles.set(preset.id, preset.profile);
+    }
+  }
+  return profiles;
 }
 
 function expandAgentSwarmPromptTemplate(promptTemplate: string, item: string): string {

--- a/packages/runtime/src/configured-subagent-catalog.ts
+++ b/packages/runtime/src/configured-subagent-catalog.ts
@@ -1,0 +1,65 @@
+import {
+  connectionEnabledModelIds,
+  type AppSettings,
+  type LlmConnection,
+  type SubagentPreset,
+} from '@maka/core';
+import type { SubagentPresetListItem } from './agent-catalog.js';
+
+export interface ConfiguredSubagentCatalog {
+  list(): Promise<SubagentPresetListItem[]>;
+  resolve(id: string): Promise<SubagentPreset>;
+}
+
+export function createConfiguredSubagentCatalog(deps: {
+  getSettings(): Promise<AppSettings>;
+  getConnection(slug: string): Promise<LlmConnection | null>;
+}): ConfiguredSubagentCatalog {
+  const inspect = async (preset: SubagentPreset): Promise<SubagentPresetListItem> => {
+    if (!preset.enabled)
+      return {
+        ...preset,
+        availability: { status: 'unavailable', reason: 'disabled' },
+      };
+    const connection = await deps.getConnection(preset.connectionSlug);
+    if (!connection) {
+      return {
+        ...preset,
+        availability: { status: 'unavailable', reason: 'missing_connection' },
+      };
+    }
+    if (!connection.enabled) {
+      return {
+        ...preset,
+        availability: { status: 'unavailable', reason: 'connection_disabled' },
+      };
+    }
+    if (!connectionEnabledModelIds(connection).includes(preset.model)) {
+      return {
+        ...preset,
+        availability: { status: 'unavailable', reason: 'model_disabled' },
+      };
+    }
+    return { ...preset, availability: { status: 'available' } };
+  };
+
+  return {
+    async list() {
+      const settings = await deps.getSettings();
+      return await Promise.all(settings.subagents.presets.map(inspect));
+    },
+    async resolve(id) {
+      const settings = await deps.getSettings();
+      const preset = settings.subagents.presets.find((candidate) => candidate.id === id);
+      if (!preset) throw new Error(`Unknown subagent_id "${id}". Call agent_list before spawning.`);
+      const inspected = await inspect(preset);
+      if (inspected.availability.status !== 'available') {
+        throw new Error(
+          `Subagent preset "${id}" is unavailable: ${inspected.availability.reason}.`,
+        );
+      }
+      const { availability: _availability, ...resolved } = inspected;
+      return resolved;
+    },
+  };
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -722,9 +722,13 @@ export type {
   AgentInvocationMode,
   AgentProfile,
   AgentProfileContract,
+  SubagentPresetAvailability,
+  SubagentPresetListItem,
   AgentWorkspaceMode,
   AgentWriteBackMode,
 } from './agent-catalog.js';
+export { createConfiguredSubagentCatalog } from './configured-subagent-catalog.js';
+export type { ConfiguredSubagentCatalog } from './configured-subagent-catalog.js';
 export {
   AGENT_SWARM_DEFAULT_CONCURRENCY,
   AGENT_SWARM_MAX_CONCURRENCY,

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -102,6 +102,7 @@ import type {
   ToolBoundaryProtocol,
   SubagentWorkspaceBinding,
   SubagentWorktreeExecutor,
+  SubagentPreset,
 } from '@maka/core';
 import { AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION } from '@maka/core';
 import {
@@ -191,6 +192,7 @@ import {
   type AgentProfile,
   type AgentDefinition,
   type AgentDefinitionListItem,
+  type SubagentPresetListItem,
 } from './agent-catalog.js';
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { stableHash } from './request-shape.js';
@@ -257,6 +259,8 @@ export interface SpawnChildAgentInput {
 export interface SpawnChildSessionInput {
   spawnedBy: SubagentSessionParent['spawnedBy'];
   agentProfile: AgentProfile;
+  /** User-approved catalog selector. The runtime resolves its frozen model target. */
+  subagentId?: string;
   prompt: string;
   name?: string;
   turnId?: string;
@@ -273,6 +277,10 @@ export interface SpawnChildSessionInput {
   /** Presentation-only observer for projecting child activity into a parent surface. */
   onEvent?: (event: SessionEvent) => void;
 }
+
+type ResolvedSpawnChildSessionInput = SpawnChildSessionInput & {
+  resolvedPreset?: SubagentPreset;
+};
 
 export interface SpawnChildSessionResult extends SpawnChildAgentResult {
   childSessionId: string;
@@ -438,6 +446,8 @@ export interface SubagentExecutionListItem {
 
 export interface AgentListResult {
   definitions: AgentDefinitionListItem[];
+  /** User-configured, host-validated routes the main agent may select by id. */
+  presets: SubagentPresetListItem[];
   /** Canonical mixed projection for new child Sessions and legacy same-session child AgentRuns. */
   executions: SubagentExecutionListItem[];
   /** Legacy projection retained while callers migrate to executions. */
@@ -733,6 +743,11 @@ interface SessionManagerBaseDeps {
   newId: () => string;
   now: () => number;
   childTools?: readonly MakaTool[];
+  /** Host-owned user catalog. Runtime receives ids from models, never raw model targets. */
+  subagentCatalog?: {
+    list(): Promise<SubagentPresetListItem[]>;
+    resolve(id: string): Promise<SubagentPreset>;
+  };
   /** Host-owned filesystem isolation for worktree-backed child Sessions. */
   worktreeChildExecutor?: SubagentWorktreeExecutor;
   listArtifactsForTurn?: (sessionId: string, turnId: string) => Promise<ArtifactRecord[]>;
@@ -2114,8 +2129,9 @@ export class SessionManager {
     parentSessionId: string,
     input: SpawnChildSessionInput,
   ): Promise<SpawnChildSessionResult> {
-    const spawnKey = childSessionSpawnKey(parentSessionId, input);
-    const requestFingerprint = childSessionRequestFingerprint(parentSessionId, input);
+    const resolvedInput = await this.resolveChildSessionSelector(input);
+    const spawnKey = childSessionSpawnKey(parentSessionId, resolvedInput);
+    const requestFingerprint = childSessionRequestFingerprint(parentSessionId, resolvedInput);
     const inFlight = this.childSessionSpawns.get(spawnKey);
     if (inFlight) {
       if (inFlight.requestFingerprint !== requestFingerprint) {
@@ -2128,7 +2144,7 @@ export class SessionManager {
     };
     const promise = this.spawnChildSessionOnce(
       parentSessionId,
-      input,
+      resolvedInput,
       requestFingerprint,
       runtimeOwner,
     ).finally(() => runtimeOwner.execution.release());
@@ -2140,6 +2156,20 @@ export class SessionManager {
         this.childSessionSpawns.delete(spawnKey);
       }
     }
+  }
+
+  private async resolveChildSessionSelector(
+    input: SpawnChildSessionInput,
+  ): Promise<ResolvedSpawnChildSessionInput> {
+    if (!input.subagentId) return { ...input };
+    if (!this.deps.subagentCatalog) {
+      throw new Error('Configured subagent catalog is unavailable in this runtime');
+    }
+    const resolvedPreset = await this.deps.subagentCatalog.resolve(input.subagentId);
+    if (resolvedPreset.profile !== input.agentProfile) {
+      throw new Error(`Subagent preset "${input.subagentId}" profile changed during spawn`);
+    }
+    return { ...input, resolvedPreset };
   }
 
   /**
@@ -2737,7 +2767,7 @@ export class SessionManager {
 
   private async spawnChildSessionOnce(
     parentSessionId: string,
-    input: SpawnChildSessionInput,
+    input: ResolvedSpawnChildSessionInput,
     requestFingerprint: string,
     runtimeOwner: { execution: RuntimeExecutionClaim },
   ): Promise<SpawnChildSessionResult> {
@@ -2773,13 +2803,17 @@ export class SessionManager {
       {
         cwd: workspace?.worktreePath ?? parentHeader.cwd,
         ...(parentHeader.projectId !== undefined ? { projectId: parentHeader.projectId } : {}),
-        name: input.name ?? definition.name,
+        name: input.name ?? input.resolvedPreset?.name ?? definition.name,
         backend: parentHeader.backend,
-        llmConnectionSlug: parentHeader.llmConnectionSlug,
-        model: parentHeader.model,
-        ...(parentHeader.thinkingLevel !== undefined
-          ? { thinkingLevel: parentHeader.thinkingLevel }
-          : {}),
+        llmConnectionSlug: input.resolvedPreset?.connectionSlug ?? parentHeader.llmConnectionSlug,
+        model: input.resolvedPreset?.model ?? parentHeader.model,
+        ...(input.resolvedPreset
+          ? input.resolvedPreset.thinkingLevel !== undefined
+            ? { thinkingLevel: input.resolvedPreset.thinkingLevel }
+            : {}
+          : parentHeader.thinkingLevel !== undefined
+            ? { thinkingLevel: parentHeader.thinkingLevel }
+            : {}),
         permissionMode: definition.permissionMode,
         collaborationMode: 'agent',
         orchestrationMode: 'default',
@@ -2794,8 +2828,9 @@ export class SessionManager {
           schemaVersion: SUBAGENT_SESSION_RUNTIME_SCHEMA_VERSION,
           definitionVersion: definition.definitionVersion,
           agentId: definition.id,
-          agentName: definition.name,
+          agentName: input.resolvedPreset?.name ?? definition.name,
           profile: definition.profile,
+          ...(input.resolvedPreset ? { presetId: input.resolvedPreset.id } : {}),
           systemPrompt: definition.systemPrompt,
           toolNames: [...definition.tools],
           categoryPolicy: {},
@@ -4068,7 +4103,8 @@ export class SessionManager {
       tools: this.deps.childTools ?? [],
       worktreeChildExecutorAvailable: this.hasWorktreeChildExecutor(),
     });
-    if (!this.deps.runStore) return { definitions, executions: [], runs: [] };
+    const presets = this.deps.subagentCatalog ? await this.deps.subagentCatalog.list() : [];
+    if (!this.deps.runStore) return { definitions, presets, executions: [], runs: [] };
     const runs = await this.deps.runStore.listSessionRuns(sessionId);
     const childRuns = await Promise.all(
       runs
@@ -4143,6 +4179,7 @@ export class SessionManager {
     );
     return {
       definitions,
+      presets,
       executions: [
         ...childSessionExecutions,
         ...childRuns.map(
@@ -5851,11 +5888,25 @@ function childSessionSpawnKey(
 
 function childSessionRequestFingerprint(
   parentSessionId: string,
-  input: Pick<SpawnChildSessionInput, 'spawnedBy' | 'agentProfile' | 'prompt' | 'swarm'>,
+  input: Pick<
+    ResolvedSpawnChildSessionInput,
+    'spawnedBy' | 'agentProfile' | 'prompt' | 'swarm' | 'resolvedPreset'
+  >,
 ): string {
-  return createHash('sha256')
-    .update(
-      JSON.stringify([
+  const payload = input.resolvedPreset
+    ? [
+        2,
+        parentSessionId,
+        input.spawnedBy.parentRunId,
+        input.spawnedBy.parentTurnId,
+        input.spawnedBy.toolCallId,
+        input.agentProfile,
+        input.resolvedPreset,
+        input.prompt,
+        input.swarm?.swarmId ?? null,
+        input.swarm?.itemId ?? null,
+      ]
+    : [
         1,
         parentSessionId,
         input.spawnedBy.parentRunId,
@@ -5865,9 +5916,8 @@ function childSessionRequestFingerprint(
         input.prompt,
         input.swarm?.swarmId ?? null,
         input.swarm?.itemId ?? null,
-      ]),
-    )
-    .digest('hex');
+      ];
+  return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
 }
 
 function claimedAgentGraphIntentRequestFingerprint(

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -3,6 +3,7 @@ import {
   TASK_ID_MAX_CHARS,
   decodeCanonicalToolResultContent,
   isSafeTaskId,
+  isSafeSubagentPresetId,
   type TaskLedgerStore,
   type ToolResultContent,
 } from '@maka/core';
@@ -70,7 +71,8 @@ export function buildSubagentSpawnTool(
   deps: { taskLedger?: TaskLedgerStore; definitions?: readonly AgentDefinition[] } = {},
 ): MakaTool<
   {
-    profile: string;
+    profile?: string;
+    subagent_id?: string;
     task: string;
     write_back?: string;
     isolation?: string;
@@ -84,10 +86,17 @@ export function buildSubagentSpawnTool(
     name: AGENT_SPAWN_TOOL_NAME,
     displayName: 'Agent',
     description:
-      'Run a foreground catalog child agent for a bounded task and return its explicit result.',
+      'Run one bounded foreground child task. Prefer agent_list, then select the user-approved subagent_id whose description fits the task; profile is retained for legacy callers.',
     parameters: z
       .object({
-        profile: z.enum(profiles).describe('Child agent profile.'),
+        profile: z.enum(profiles).optional().describe('Legacy child capability profile.'),
+        subagent_id: z
+          .string()
+          .min(1)
+          .max(128)
+          .refine(isSafeSubagentPresetId)
+          .optional()
+          .describe('User-approved subagent preset id from agent_list.'),
         task: z.string().min(1).max(60_000).describe('Bounded task for the selected child agent.'),
         write_back: z
           .enum(AGENT_SPAWN_WRITE_BACK_MODES)
@@ -115,6 +124,14 @@ export function buildSubagentSpawnTool(
       })
       .strict()
       .superRefine((input, ctx) => {
+        if (Boolean(input.profile) === Boolean(input.subagent_id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Provide exactly one of subagent_id or legacy profile.',
+          });
+          return;
+        }
+        if (!input.profile) return;
         const definition = requireAgentDefinitionByProfile(definitions, input.profile);
         const requestedWriteBack = input.write_back ?? definition.contract.defaultWriteBack;
         if (!definition.contract.supportedWriteBack.some((mode) => mode === requestedWriteBack)) {
@@ -135,7 +152,9 @@ export function buildSubagentSpawnTool(
       }),
     categoryHint: 'subagent',
     impl: async (input, ctx) => {
-      const definition = requireAgentDefinitionByProfile(definitions, input.profile);
+      const definition = input.profile
+        ? requireAgentDefinitionByProfile(definitions, input.profile)
+        : await resolvePresetDefinition(input.subagent_id!, ctx, definitions);
       const requestedWriteBack = input.write_back ?? definition.contract.defaultWriteBack;
       if (!definition.contract.supportedWriteBack.some((mode) => mode === requestedWriteBack)) {
         throw new Error(
@@ -173,6 +192,7 @@ export function buildSubagentSpawnTool(
         result = projectSubagentToolResult(
           await ctx.spawnChildSession({
             agentProfile: definition.profile,
+            ...(input.subagent_id ? { subagentId: input.subagent_id } : {}),
             prompt: input.task,
             ...(boundTask
               ? {
@@ -257,6 +277,35 @@ export function buildSubagentSpawnTool(
   };
 }
 
+async function resolvePresetDefinition(
+  subagentId: string,
+  ctx: MakaToolContext,
+  definitions: readonly AgentDefinition[],
+): Promise<AgentDefinition> {
+  if (!ctx.listChildAgents) {
+    throw new Error('listChildAgents capability is unavailable in this runtime context');
+  }
+  const catalog = await ctx.listChildAgents();
+  if (!catalog || typeof catalog !== 'object' || Array.isArray(catalog)) {
+    throw new Error('agent_list returned an invalid catalog');
+  }
+  const presets = (catalog as { presets?: unknown }).presets;
+  if (!Array.isArray(presets)) throw new Error('Configured subagent catalog is unavailable');
+  const preset = presets.find(
+    (candidate): candidate is { id: string; profile: string; availability?: { status?: string } } =>
+      Boolean(candidate) &&
+      typeof candidate === 'object' &&
+      !Array.isArray(candidate) &&
+      (candidate as { id?: unknown }).id === subagentId &&
+      typeof (candidate as { profile?: unknown }).profile === 'string',
+  );
+  if (!preset) throw new Error(`Unknown subagent_id "${subagentId}". Call agent_list first.`);
+  if (preset.availability?.status !== 'available') {
+    throw new Error(`Subagent preset "${subagentId}" is unavailable.`);
+  }
+  return requireAgentDefinitionByProfile(definitions, preset.profile);
+}
+
 function projectSubagentToolResult(value: unknown): Omit<SubagentToolResult, 'kind'> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error('Child agent returned an invalid result');
@@ -296,7 +345,7 @@ export function buildSubagentListTool(): MakaTool<Record<string, never>, unknown
     name: AGENT_LIST_TOOL_NAME,
     displayName: 'Agent List',
     description:
-      'List available agent catalog definitions and child agent runs for the current session.',
+      'List user-approved subagent presets (including task descriptions, model routes, and availability), capability definitions, and child runs for this session.',
     parameters: z.object({}),
     categoryHint: 'read',
     impl: async (_input, ctx) => {

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -168,6 +168,7 @@ export interface MakaToolContext {
   }) => Promise<unknown>;
   spawnChildSession?: (input: {
     agentProfile: AgentProfile;
+    subagentId?: string;
     prompt: string;
     /** Optional swarm identity, scoped to the owning tool call. */
     swarm?: {
@@ -322,6 +323,7 @@ export interface ToolRuntimeInput {
     parentTurnId: string;
     toolCallId: string;
     agentProfile: AgentProfile;
+    subagentId?: string;
     prompt: string;
     swarm?: {
       swarmId: string;
@@ -1703,6 +1705,7 @@ export class ToolRuntime {
                     parentTurnId: input.turnId,
                     toolCallId: input.toolUseId,
                     agentProfile: spawnInput.agentProfile,
+                    ...(spawnInput.subagentId ? { subagentId: spawnInput.subagentId } : {}),
                     prompt: spawnInput.prompt,
                     ...(spawnInput.swarm ? { swarm: spawnInput.swarm } : {}),
                     abortSignal,


### PR DESCRIPTION
## Summary

- add a user-approved subagent preset catalog with profile, provider connection, model, and optional thinking level
- let agent_list expose available presets and let agent_spawn / agent_swarm select them by subagent_id
- resolve model targets in the host, freeze them into child sessions, and preserve legacy profile-based spawning
- add Desktop Settings UI, documentation, and coverage for normalization, availability, model decoupling, swarm routing, and idempotent retries

## Safety and compatibility

- models cannot submit raw connection or model targets through spawn tools
- profile remains the capability and permission boundary
- disabled, missing-connection, and disabled-model presets fail closed
- configured child sessions retain their selected preset/model across resume and retry

## Verification

- npm run build
- npm run typecheck
- npm run lint -- --diagnostic-level=error
- npm run format:check -- --diagnostic-level=error
- npm run test -w @maka/core (722 passed)
- targeted runtime routing, swarm, catalog, and idempotency tests (7 passed)