### PR TITLE
refactor(desktop): finish Astryx convergence for Claude card + WeChat QR panes

### DIFF
--- a/apps/desktop/src/renderer/settings/bot-wechat-login.tsx
+++ b/apps/desktop/src/renderer/settings/bot-wechat-login.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import type { BotChannelSettings } from '@maka/core';
 import type { WechatBridgeQrCodeResult } from '@maka/runtime';
-import { Button, FormLayout, TextInput, useUiLocale, Banner } from '@maka/ui';
+import { Button, EmptyState, FormLayout, Spinner, TextInput, useUiLocale, Banner } from '@maka/ui';
+import { CircleCheckBig } from '@maka/ui/icons';
 import { Collapsible } from '@astryxdesign/core/Collapsible';
 import {
   Dialog,
@@ -165,20 +166,27 @@ export function WechatQrLoginModal(props: {
         }
         content={
           <LayoutContent padding={0}>
+            {/* Astryx convergence (task #136): the four hand-tinted
+                `data-tone` placeholder panes are EmptyState / Spinner now —
+                the QR frame keeps its bespoke white plate (a QR code needs a
+                light background regardless of theme). */}
             <div className="settingsWechatQrBody">
           {loading ? (
-            <div className="settingsWechatQrState" data-tone="loading">
-              {copy.generating}
-            </div>
+            <EmptyState isCompact headingLevel={4} icon={<Spinner size="lg" />} title={copy.generating} />
           ) : loggedIn ? (
-            <div className="settingsWechatQrState" data-tone="success">
-              {copy.loggedIn}
-            </div>
+            <EmptyState
+              isCompact
+              headingLevel={4}
+              icon={<CircleCheckBig size={24} aria-hidden="true" />}
+              title={copy.loggedIn}
+            />
           ) : expired ? (
-            <div className="settingsWechatQrState" data-tone="warning">
-              {copy.expired}
-              <Button variant="secondary" size="sm" isDisabled={loading} onClick={reloadQrCode} label={loading ? copy.refreshing : copy.refresh} />
-            </div>
+            <EmptyState
+              isCompact
+              headingLevel={4}
+              title={copy.expired}
+              actions={<Button variant="secondary" size="sm" isDisabled={loading} onClick={reloadQrCode} label={loading ? copy.refreshing : copy.refresh} />}
+            />
           ) : qrDataUrl ? (
             <>
               <div className="settingsWechatQrFrame">
@@ -187,16 +195,22 @@ export function WechatQrLoginModal(props: {
               <p className="settingsWechatQrCaption">{copy.waiting}</p>
             </>
           ) : error ? (
-            <div className="settingsWechatQrState" data-tone="error" role="alert">
-              <strong>{error.error}</strong>
-              <span>{error.hint}</span>
-              <Button variant="secondary" size="sm" isDisabled={loading} onClick={reloadQrCode} label={loading ? copy.retrying : copy.retry} />
+            <div role="alert">
+              <EmptyState
+                isCompact
+                headingLevel={4}
+                title={error.error}
+                description={error.hint}
+                actions={<Button variant="secondary" size="sm" isDisabled={loading} onClick={reloadQrCode} label={loading ? copy.retrying : copy.retry} />}
+              />
             </div>
           ) : (
-            <div className="settingsWechatQrState" data-tone="loading">
-              {copy.bridgeGenerating}
-              <Button variant="secondary" size="sm" isDisabled={loading} onClick={reloadQrCode} label={loading ? copy.fetching : copy.fetchAgain} />
-            </div>
+            <EmptyState
+              isCompact
+              headingLevel={4}
+              title={copy.bridgeGenerating}
+              actions={<Button variant="secondary" size="sm" isDisabled={loading} onClick={reloadQrCode} label={loading ? copy.fetching : copy.fetchAgain} />}
+            />
           )}
             </div>
           </LayoutContent>

--- a/apps/desktop/src/renderer/settings/claude-subscription-card.tsx
+++ b/apps/desktop/src/renderer/settings/claude-subscription-card.tsx
@@ -1,10 +1,19 @@
 import { useEffect, useRef, useState } from 'react';
 import { type SubscriptionAccountState, type UiLocale } from '@maka/core';
+import { FieldStatus, ProgressBar } from '@astryxdesign/core';
 import {
   Badge,
+  Banner,
   Button,
+  Card,
+  Divider,
+  HStack,
   RelativeTime,
+  SectionHeader,
+  StackItem,
+  Text,
   TextArea,
+  VStack,
   useMountedRef,
   useToast,
   useUiLocale,
@@ -112,28 +121,23 @@ export function ClaudeSubscriptionCard() {
   }, []);
 
   if (experimentalGateError) {
+    // Astryx convergence (task #136): the gate-read failure was a hand-tinted
+    // `.settingsConnectionRow[data-status=error]` card; Banner is the one
+    // error surface Settings uses now.
     return (
-      <div className="settingsConnectionRow" data-status="error">
-        <div className="settingsConnectionRowHead">
-          <div className="settingsConnectionRowText">
-            <div className="settingsConnectionRowName">
-              <strong>{copy.title}</strong>
-            </div>
-            <small>{copy.gateUnknown}</small>
-          </div>
-          <Badge variant="error" label={copy.readFailed} />
-        </div>
-        <small className="settingsErrorText" role="alert">
-          {copy.gateError}{experimentalGateError}
-        </small>
-        <div className="settingsConnectionActions">
+      <Banner
+        status="error"
+        role="alert"
+        title={copy.title}
+        description={`${copy.gateUnknown} ${copy.gateError}${experimentalGateError}`}
+        endContent={
           <Button
             variant="primary"
             onClick={() => void refreshExperimentalGate()}
             label={copy.retry}
           />
-        </div>
-      </div>
+        }
+      />
     );
   }
 
@@ -308,48 +312,62 @@ export function ClaudeSubscriptionCard() {
   const claudeLoginPending = authRequestId !== null || state?.runtimeState === 'authorizing';
   const actionBusy = pendingAction !== null;
 
+  // Astryx convergence (task #136): the hand-rolled
+  // `.settingsConnectionRow[data-status]` card (9 tinted variants) sat inside
+  // the otherwise fully Astryx Providers surface. Default Card chrome now;
+  // status is carried by the Badge + detail line only (status-color
+  // restraint), and the quota numbers gained a real ProgressBar gauge.
   return (
-    <>
-    <h3 className="settingsSubheading">{copy.section}</h3>
-    <div className="settingsConnectionRow" data-status={state?.runtimeState ?? 'loading'}>
-      <div className="settingsConnectionRowHead">
-        <div className="settingsConnectionRowText">
-          <div className="settingsConnectionRowName">
-            <strong>{copy.title}</strong>
-          </div>
-          <small>
-            {copy.subtitle}
-            {state?.profile?.email ? ` · ${state.profile.email}` : ''}
-          </small>
-        </div>
+    <VStack gap={2}>
+    <SectionHeader as="h3" title={copy.section} />
+    <Card padding={4}>
+      <VStack gap={2}>
+      <HStack gap={3} vAlign="start">
+        <StackItem size="fill">
+          <VStack gap={0.5}>
+            <Text weight="semibold">{copy.title}</Text>
+            <Text type="supporting" color="secondary">
+              {copy.subtitle}
+              {state?.profile?.email ? ` · ${state.profile.email}` : ''}
+            </Text>
+          </VStack>
+        </StackItem>
         <Badge variant={statusBadgeVariant(presentation.tone)} label={presentation.label} />
-      </div>
-      <p className="settingsConnectionDetail">{presentation.detail}</p>
+      </HStack>
+      <Text as="p" type="supporting" color="secondary">{presentation.detail}</Text>
       {pasteError && !authRequestId && (
-        <small className="settingsErrorText" role="alert">{pasteError}</small>
+        <div role="alert">
+          <FieldStatus type="error" message={pasteError} variant="detached" />
+        </div>
       )}
 
       {state?.quota && (state.quota.fiveHour || state.quota.sevenDay) && (
-        <div className="settingsQuotaSection">
+        <VStack gap={2}>
           {state.quota.fiveHour && (
-            <div className="settingsQuotaRow">
-              <span>{copy.fiveHour}</span>
-              <span>{state.quota.fiveHour.utilization}%</span>
-            </div>
+            <ProgressBar
+              label={copy.fiveHour}
+              value={state.quota.fiveHour.utilization}
+              hasValueLabel
+              formatValueLabel={(value) => `${value}%`}
+              variant={quotaVariant(state.quota.fiveHour.utilization)}
+            />
           )}
           {state.quota.sevenDay && (
-            <div className="settingsQuotaRow">
-              <span>{copy.sevenDay}</span>
-              <span>{state.quota.sevenDay.utilization}%</span>
-            </div>
+            <ProgressBar
+              label={copy.sevenDay}
+              value={state.quota.sevenDay.utilization}
+              hasValueLabel
+              formatValueLabel={(value) => `${value}%`}
+              variant={quotaVariant(state.quota.sevenDay.utilization)}
+            />
           )}
-          <small className="settingsHelpText">
+          <Text type="supporting" color="secondary">
             {copy.updated}<RelativeTime ts={state.quota.fetchedAt} className="settingsHelpInlineTime" />
-          </small>
-        </div>
+          </Text>
+        </VStack>
       )}
 
-      <div className="settingsConnectionActions">
+      <HStack gap={2} hAlign="end" wrap="wrap">
         {canStartClaudeLogin || claudeLoginPending ? (
           <Button
             variant="primary"
@@ -379,15 +397,17 @@ export function ClaudeSubscriptionCard() {
             />
           </>
         )}
-      </div>
+      </HStack>
 
       {authRequestId && (
-        <div className="settingsOauthPastePanel" role="region" aria-label={copy.pasteAria}>
-          <p>
+        <>
+        <Divider />
+        <VStack gap={2} role="region" aria-label={copy.pasteAria}>
+          <Text as="p">
             {copy.pasteHelpBefore} <code>#</code> {copy.pasteHelpAfter}
-          </p>
+          </Text>
           {stateHint && (
-            <small>{copy.stateHint} <code>{stateHint}</code> {copy.startsWith}</small>
+            <Text type="supporting" color="secondary">{copy.stateHint} <code>{stateHint}</code> {copy.startsWith}</Text>
           )}
           <TextArea
             value={pasteValue}
@@ -398,7 +418,7 @@ export function ClaudeSubscriptionCard() {
             hasSpellCheck={false}
             status={pasteError ? { type: 'error', message: pasteError } : undefined}
           />
-          <div className="settingsConnectionActions">
+          <HStack gap={2} hAlign="end" wrap="wrap">
             <Button
               variant="primary"
               onClick={() => void submitPaste()}
@@ -411,12 +431,20 @@ export function ClaudeSubscriptionCard() {
               isDisabled={actionBusy}
               label={pendingAction === 'cancel' ? copy.cancelling : copy.cancel}
             />
-          </div>
-        </div>
+          </HStack>
+        </VStack>
+        </>
       )}
-    </div>
-    </>
+      </VStack>
+    </Card>
+    </VStack>
   );
+}
+
+function quotaVariant(utilization: number): 'accent' | 'warning' | 'error' {
+  if (utilization >= 90) return 'error';
+  if (utilization >= 75) return 'warning';
+  return 'accent';
 }
 
 type ClaudeSubscriptionPendingAction = 'login' | 'submit' | 'cancel' | 'logout' | 'quota';

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -1,119 +1,14 @@
+/* Astryx convergence (task #136): the Claude subscription card was the last
+   user of the hand-rolled `.settingsConnectionRow[data-status]` recipe (9
+   tinted variants), the quota rows, and the paste panel — it now composes
+   Card / Banner / HStack / VStack / ProgressBar / FieldStatus, so those rules
+   are retired. What remains is the inline-meta helper the Web Search page
+   still uses. */
 
-  .settingsConnectionRow {
-    display: grid;
-    gap: var(--space-1-5);
-    padding: var(--space-3) var(--space-3);
-    border-radius: var(--radius-surface);
-    border: var(--border-width-hairline) solid var(--border);
-    background: var(--foreground-2);
-    box-shadow: 0 1px 3px oklch(from var(--foreground) l c h / 0.03);
-  }
-/* Status-color restraint: verified is the expected state — default
-   card chrome; color is reserved for exception states below. */
-.settingsConnectionRow[data-status="needs_reauth"] {
-    border-color: oklch(from var(--info) l c h / 0.30);
-    background: oklch(from var(--info) l c h / 0.06);
-  }
-.settingsConnectionRow[data-status="error"] {
-    border-color: oklch(from var(--destructive) l c h / 0.30);
-    background: oklch(from var(--destructive) l c h / 0.05);
-  }
-.settingsConnectionRow[data-status="not_configured"] {
-    border-color: oklch(from var(--info) l c h / 0.20);
-    background: oklch(from var(--info) l c h / 0.03);
-  }
-/* PR-OAUTH-SUBSCRIPTION-0: Claude subscription card states. */
-.settingsConnectionRow[data-status="not_logged_in"] {
-    border-color: var(--border);
-    background: var(--foreground-2);
-  }
-.settingsConnectionRow[data-status="authorizing"],
-  .settingsConnectionRow[data-status="refreshing"] {
-    border-color: oklch(from var(--info) l c h / 0.30);
-    background: oklch(from var(--info) l c h / 0.04);
-  }
-/* authenticated: expected state, default card chrome (see above). */
-.settingsConnectionRow[data-status="refresh_failed"],
-  .settingsConnectionRow[data-status="quota_unavailable"] {
-    border-color: oklch(from var(--warning, var(--info)) l c h / 0.30);
-    background: oklch(from var(--warning, var(--info)) l c h / 0.05);
-  }
-.settingsConnectionRow[data-status="provider_rejected"] {
-    border-color: oklch(from var(--destructive) l c h / 0.30);
-    background: oklch(from var(--destructive) l c h / 0.05);
-  }
-.settingsQuotaSection {
-    display: grid;
-    gap: var(--space-1);
-    padding: var(--space-2) var(--space-2-5);
-    border-radius: var(--radius-surface);
-    background: oklch(from var(--foreground) l c h / 0.03);
-  }
-.settingsQuotaRow {
-    font: var(--maka-text-body);
-    display: flex;
-    justify-content: space-between;
-    font-variant-numeric: tabular-nums;
-  }
-.settingsOauthPastePanel {
-    display: grid;
-    gap: var(--space-2);
-    margin-top: var(--space-1);
-    padding: var(--space-3) var(--space-3);
-    border-radius: var(--radius-surface);
-    background: oklch(from var(--foreground) l c h / 0.04);
-  }
-.settingsErrorText {
-    color: var(--destructive-text, var(--destructive, red));
-  }
-.settingsConnectionRow[data-status="disabled"] {
-    opacity: var(--opacity-disabled);
-  }
-.settingsConnectionRow[data-default="true"] {
-    box-shadow: 0 0 0 2px oklch(from var(--control) l c h / 0.12);
-  }
-.settingsConnectionRowName {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    min-width: 0;
-  }
-.settingsConnectionRowHead {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-3);
-  }
-.settingsConnectionRowText {
-    display: grid;
-    gap: var(--space-0-5);
-    min-width: 0;
-  }
-.settingsConnectionRowText strong {
-    font: var(--maka-text-heading-4);
-    color: var(--foreground);
-  }
-.settingsConnectionRowText small {
-    font: var(--maka-text-supporting);
-    color: var(--muted-foreground);
-  }
-.settingsConnectionDetail {
-    font: var(--maka-text-supporting);
-    margin: 0;
-    color: var(--foreground-secondary);
-  }
 .settingsConnectionMeta {
     font: var(--maka-text-supporting);
     margin: 0;
     display: flex;
     gap: var(--space-3);
     color: var(--muted-foreground);
-  }
-.settingsConnectionActions {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    align-items: center;
-    gap: var(--space-2);
-    margin-top: var(--space-1);
   }

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -63,13 +63,8 @@
 
 .settingsActionWidthXs { min-width: 46px; }
 
-.settingsSubheading {
-  font: var(--maka-text-heading-4);
-  margin: 0;
-  color: var(--foreground-secondary);
-  letter-spacing: var(--tracking-wider);
-  text-transform: uppercase;
-}
+/* Astryx convergence (task #136): `.settingsSubheading` (uppercase eyebrow)
+   retired with the Claude subscription card's move onto SectionHeader. */
 
 /* Quiet informational voice — replaces the info Banner where content is
    guidance, not an alert (Signal-Not-Texture: blue never becomes ambient

--- a/apps/desktop/src/renderer/styles/settings/wechat.css
+++ b/apps/desktop/src/renderer/styles/settings/wechat.css
@@ -31,40 +31,6 @@
   image-rendering: pixelated;
 }
 
-.settingsWechatQrState {
-  font: var(--maka-text-body);
-  width: 100%;
-  min-height: 180px;
-  display: grid;
-  place-items: center;
-  align-content: center;
-  gap: var(--space-2-5);
-  border: var(--border-width-hairline) dashed var(--border);
-  border-radius: var(--radius-surface);
-  background: var(--foreground-3);
-  color: var(--foreground-secondary);
-  padding: var(--space-4);
-}
-
-.settingsWechatQrState strong {
-  font: var(--maka-text-heading-4);
-  color: inherit;
-}
-
-.settingsWechatQrState[data-tone="success"] {
-  border-color: oklch(from var(--success) l c h / 0.24);
-  background: oklch(from var(--success) l c h / 0.08);
-  color: var(--success-text);
-}
-
-.settingsWechatQrState[data-tone="warning"] {
-  border-color: oklch(from var(--info) l c h / 0.26);
-  background: oklch(from var(--info) l c h / 0.09);
-  color: var(--info-text);
-}
-
-.settingsWechatQrState[data-tone="error"] {
-  border-color: oklch(from var(--destructive) l c h / 0.24);
-  background: oklch(from var(--destructive) l c h / 0.08);
-  color: var(--destructive-text);
-}
+/* Astryx convergence (task #136): the `.settingsWechatQrState` placeholder
+   pane and its four hand-tinted `data-tone` variants are EmptyState / Spinner
+   now; only the QR frame plate and caption remain bespoke. */


### PR DESCRIPTION
Follow-up to #1972, covering the two Settings surfaces it left on the old hand-rolled card dialect.

## Claude subscription card (`claude-subscription-card.tsx`)

- The hand-rolled `.settingsConnectionRow` with **9 `data-status` tinted variants** was the last card of its kind, sitting inside the otherwise fully-Astryx Providers surface. It now composes `Card` / `HStack` / `VStack`; status is carried by the Badge + detail line only (status-color restraint — color reserved for exceptions).
- Gate-read failure state → `Banner status="error"` with retry in `endContent`, matching every other Settings error surface.
- Quota went from text-only `5小时 | 87%` rows to real `ProgressBar` gauges (`warning` ≥ 75%, `error` ≥ 90% utilization) with a relative "updated" timestamp.
- Paste-code panel → `Divider` + `VStack`; the inline paste error routes through `FieldStatus` (kept inside a `role="alert"` wrapper to preserve the announcement).
- Section eyebrow `h3.settingsSubheading` → shared `SectionHeader`.

## WeChat QR login modal (`bot-wechat-login.tsx`)

- The four hand-tinted `data-tone` placeholder panes (loading / logged-in / expired / error) become `EmptyState` — `Spinner` icon while generating, check icon on success, retry buttons in the `actions` slot, error pane wrapped in `role="alert"`.
- The white QR frame plate stays bespoke on purpose: a QR code needs a light background in every theme.

## CSS

- `connection.css`: 119 → 15 lines; only `.settingsConnectionMeta` (still used by Web Search) survives.
- `form.css`: `.settingsSubheading` retired (this card was its last user; `check-dead-css` confirms).

## Verification

- `npm --workspace @maka/desktop run typecheck` ✅
- `check-dead-css` ✅ (no dead classes)
- `check-a11y` / `check-copy` / `check-console` ✅
- Product Storybook visual smoke: 70 catalog renders × 3 viewports ✅

Net: 5 files, +139/−249.