### PR TITLE
fix(desktop): take the running turn from the run, not from session status

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -37,7 +37,7 @@ type CapturedSubscriptions = {
   connectionSubscribeCount: number;
   planDue?: (reminder: PlanReminder) => void;
   planDueSubscribeCount: number;
-  sessionChange?: (event: { reason: string; sessionId?: string; ts: number }) => void;
+  sessionChange?: (event: { reason: string; sessionId?: string; ts: number; turnId?: string }) => void;
   settingsExternalChanged?: () => void;
   settingsGet?(): Promise<{ system: { keepSystemAwake: boolean } }>;
 };
@@ -68,7 +68,7 @@ type RendererMakaStub = {
   };
   sessions: {
     readMessages(sessionId: string): Promise<StoredMessage[]>;
-    subscribeChanges(callback: (event: { reason: string; sessionId?: string; ts: number }) => void): () => void;
+    subscribeChanges(callback: (event: { reason: string; sessionId?: string; ts: number; turnId?: string }) => void): () => void;
     subscribeEvents(sessionId: string, callback: (event: SessionEvent) => void): () => void;
   };
   settings: {
@@ -178,6 +178,62 @@ describe('AppShell effect stability contract', () => {
     });
 
     assert.equal(projectRefreshes, 1);
+  });
+
+  // The wiring that answers a send: `onRunStarted` broadcasts a `sessions:changed`
+  // naming the turn, and it must reach the arm through the real subscription
+  // handler. Without it the arm stays unconfirmed and a stale session list
+  // retires it, taking the Stop affordance and the first-token wait with it.
+  it('confirms the armed turn a session change names', async () => {
+    const effects = await appShellEffects;
+    const refs = createBootstrapRefs();
+    const captured = createCapturedSubscriptions();
+    const root = installReactRenderer(captured);
+    const confirmed: Array<[string, string]> = [];
+
+    await render(
+      root,
+      createElement(BootstrapSubscriptionProbe, {
+        effects,
+        onConnectionEvent: () => {},
+        onConfirmLiveTurn: (sessionId: string, turnId: string) => confirmed.push([sessionId, turnId]),
+        refs,
+      }),
+    );
+
+    await act(async () => {
+      captured.sessionChange?.({ reason: 'status-change', sessionId: 'session-1', ts: 1, turnId: 'turn-1' });
+      await Promise.resolve();
+    });
+
+    assert.deepEqual(confirmed, [['session-1', 'turn-1']]);
+  });
+
+  // A change with no turn to name is a plain catalog invalidation. Treating it
+  // as an answer would confirm whatever arm happened to be in flight.
+  it('does not confirm anything for a change that names no turn', async () => {
+    const effects = await appShellEffects;
+    const refs = createBootstrapRefs();
+    const captured = createCapturedSubscriptions();
+    const root = installReactRenderer(captured);
+    const confirmed: Array<[string, string]> = [];
+
+    await render(
+      root,
+      createElement(BootstrapSubscriptionProbe, {
+        effects,
+        onConnectionEvent: () => {},
+        onConfirmLiveTurn: (sessionId: string, turnId: string) => confirmed.push([sessionId, turnId]),
+        refs,
+      }),
+    );
+
+    await act(async () => {
+      captured.sessionChange?.({ reason: 'message-appended', sessionId: 'session-1', ts: 1 });
+      await Promise.resolve();
+    });
+
+    assert.deepEqual(confirmed, []);
   });
 
   it('keeps bootstrap subscriptions stable while invoking the latest connection handler', async () => {
@@ -572,6 +628,7 @@ function BootstrapSubscriptionProbe(props: {
   onProjectRefresh?(): void;
   onNavSelection?(selection: { section: string }): void;
   onToastAction?(onClick: (() => void) | undefined): void;
+  onConfirmLiveTurn?(sessionId: string, turnId: string): void;
   refs: ReturnType<typeof createBootstrapRefs>;
 }) {
   props.effects.useAppShellBootstrapSubscriptions({
@@ -580,6 +637,7 @@ function BootstrapSubscriptionProbe(props: {
     applyE2eFixture: async () => {},
     bootstrapSessions: async () => {},
     clearPendingTurnActionsForSession: () => {},
+    confirmLiveTurn: (sessionId: string, turnId: string) => props.onConfirmLiveTurn?.(sessionId, turnId),
     clearSessionRendererState: () => {},
     createSession: () => {},
     handleConnectionEvent: props.onConnectionEvent,
@@ -885,7 +943,7 @@ function installFakeMaka(captured: CapturedSubscriptions): void {
     },
     sessions: {
       readMessages: async () => [],
-      subscribeChanges(callback: (event: { reason: string; sessionId?: string; ts: number }) => void) {
+      subscribeChanges(callback: (event: { reason: string; sessionId?: string; ts: number; turnId?: string }) => void) {
         captured.sessionChange = callback;
         return noop;
       },

--- a/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
@@ -16,7 +16,11 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
+import type { SessionSummary } from '@maka/core';
+import type { LiveTurnProjection } from '@maka/ui';
 import { createAppShellChatActions } from '../../renderer/app-shell-chat-actions.js';
+import { createAppShellSessionUiStateController } from '../../renderer/app-shell-session-ui-state.js';
+import { settledSessionTransientIds } from '../../renderer/settled-session-transients.js';
 
 function installWindow(maka: unknown): () => void {
   const target = globalThis as unknown as { window?: unknown };
@@ -40,6 +44,23 @@ function installWindow(maka: unknown): () => void {
   };
 }
 
+/**
+ * The live-turn arm as a real map rather than a black-hole stub: a send that
+ * never lands must leave nothing behind, and that cannot be asserted against a
+ * no-op setter.
+ */
+function createTurnState() {
+  const liveTurnBySession: Record<string, LiveTurnProjection> = {};
+  return {
+    liveTurnBySession,
+    setLiveTurnBySession(updater: (c: Record<string, LiveTurnProjection>) => Record<string, LiveTurnProjection>) {
+      const next = updater({ ...liveTurnBySession });
+      for (const key of Object.keys(liveTurnBySession)) delete liveTurnBySession[key];
+      Object.assign(liveTurnBySession, next);
+    },
+  };
+}
+
 function createActionsDeps() {
   return {
     uiLocale: 'en' as const,
@@ -53,7 +74,6 @@ function createActionsDeps() {
     isNewChatSendSurfaceActive: () => true,
     isShellSurfaceOwnerActive: () => true,
     markSessionReadLocally: () => undefined,
-    markSessionRunningOptimistic: () => () => undefined,
     messageRetryPendingRef: { current: new Set<string>() },
     refreshSessions: async () => [],
     setActiveId: () => undefined,
@@ -265,6 +285,28 @@ describe('composer send failure feedback', () => {
     assert.deepEqual(setupToasts, [], 'a stale surface must not be navigated to 设置 · 模型');
   });
 
+  // A send that never reaches the runtime must take its arm with it. A leftover
+  // arm still carries its `unconfirmed` claim, which would make
+  // `settledSessionTransientIds` protect a turn that does not exist — leaving a
+  // Stop button nothing can clear.
+  it('leaves no arm behind when the send never lands', async () => {
+    const turnState = createTurnState();
+    const restoreWindow = installWindow(readinessFailure());
+
+    try {
+      const actions = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef: { current: 'session-a' },
+        setLiveTurnBySession: turnState.setLiveTurnBySession,
+      });
+      assert.equal(await actions.send('hello'), false);
+    } finally {
+      restoreWindow();
+    }
+
+    assert.deepEqual(turnState.liveTurnBySession, {}, 'the arm must be disarmed');
+  });
+
   it('still answers the surface that is actually waiting', async () => {
     const setupToasts: string[] = [];
     const restoreWindow = installWindow(readinessFailure());
@@ -282,5 +324,103 @@ describe('composer send failure feedback', () => {
     }
 
     assert.equal(setupToasts.length, 1, 'the user who is still looking must get the answer');
+  });
+});
+
+/**
+ * The bug this guards, as the sequence that actually produced it: send arms the
+ * turn, a session list that was already in flight lands still carrying the
+ * pre-send status, and the settle reconcile runs against it.
+ *
+ * Nothing in that list is wrong — the runtime writes `status: 'running'` only at
+ * the end of `AgentRun.begin` and announces it to nobody until `onRunStarted`.
+ * The list simply predates the answer. Reading it as a settle used to drop the
+ * arm, so the first content event rebuilt the projection as `'streamed'` and the
+ * prominent "正在处理…" silently became the calm "继续中…".
+ *
+ * Asserted through the real `send`, the real state controller, and the real
+ * settle rule, because the defect lived in how those three compose — each one is
+ * individually correct.
+ */
+describe('a send in flight versus a stale session list', () => {
+  const sessionId = 'session-a';
+
+  // Echoes the sent turn back through `readMessages`, which is what `send()`
+  // waits on before it reports success — a window that never shows the user
+  // message would time the send out rather than exercise the race.
+  function sendingWindow() {
+    let sentTurnId: string | undefined;
+    return {
+      sessions: {
+        create: async () => ({ id: sessionId }),
+        send: async (_sessionId: string, command: { turnId: string }) => {
+          sentTurnId = command.turnId;
+          return { ok: true, attachments: [], skillInvocation: { loaded: [], failed: [] } };
+        },
+        readMessages: async () => (
+          sentTurnId
+            ? [{ type: 'user', id: `user-${sentTurnId}`, turnId: sentTurnId, ts: 1, text: 'hello' }]
+            : []
+        ),
+      },
+    };
+  }
+
+  // The list as it reads before the runtime's `running` write — identical to how
+  // it reads after the turn is over, which is exactly why the status alone
+  // cannot settle anything.
+  const preSendList = [{ id: sessionId, status: 'active', statusUpdatedAt: 100 }] as SessionSummary[];
+
+  async function armViaSend(controller: ReturnType<typeof createAppShellSessionUiStateController>) {
+    const restoreWindow = installWindow(sendingWindow());
+    try {
+      const actions = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef: { current: sessionId },
+        setLiveTurnBySession: controller.setLiveTurnBySession,
+      });
+      assert.equal(await actions.send('hello'), true);
+    } finally {
+      restoreWindow();
+    }
+    const armed = controller.getState().liveTurnBySession[sessionId];
+    assert.equal(armed?.unconfirmed, true, 'the send must arm an unconfirmed turn');
+    return armed!.turnId;
+  }
+
+  function settle(controller: ReturnType<typeof createAppShellSessionUiStateController>) {
+    return settledSessionTransientIds({
+      activeId: sessionId,
+      sessions: preSendList,
+      liveTurnBySession: controller.getState().liveTurnBySession,
+    });
+  }
+
+  it('keeps the armed turn, and settles it once the authority names that turn', async () => {
+    const controller = createAppShellSessionUiStateController();
+    const turnId = await armViaSend(controller);
+
+    assert.deepEqual(settle(controller), [], 'a list older than the answer must not settle the turn');
+    assert.equal(
+      controller.getState().liveTurnBySession[sessionId]?.phase,
+      'waiting',
+      'the first-token wait must survive the stale refresh',
+    );
+
+    // `sessions:changed` naming this turn — what `onRunStarted` now emits once
+    // the run has begun. This is the same controller entry point the shell
+    // wires that subscription to.
+    controller.confirmLiveTurn(sessionId, turnId);
+
+    assert.deepEqual(settle(controller), [sessionId], 'an answered turn settles under the plain status rules');
+  });
+
+  it('ignores an answer about a turn other than the one in flight', async () => {
+    const controller = createAppShellSessionUiStateController();
+    await armViaSend(controller);
+
+    controller.confirmLiveTurn(sessionId, 'turn-from-another-client');
+
+    assert.deepEqual(settle(controller), [], 'only this send\'s own turn may release its claim');
   });
 });

--- a/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
@@ -98,6 +98,33 @@ describe('app shell session UI state controller', () => {
     }), ['sending']);
   });
 
+  // The live runs outrank the persisted status in BOTH directions. A status
+  // that has not caught up yet, or one a crash left behind, must not decide
+  // this while the runtime still reports the turn as running.
+  it('keeps transients while the runtime still reports a running turn', () => {
+    const sessions = [
+      { id: 'running', status: 'active', runningTurnIds: ['turn-live'] },
+    ] as SessionSummary[];
+
+    assert.deepEqual(settledSessionTransientIds({
+      activeId: 'running',
+      sessions,
+      liveTurnBySession: { running: answeredArm('turn-live') },
+    }), []);
+  });
+
+  it('settles once the runtime reports no running turn, whatever the status says', () => {
+    const sessions = [
+      { id: 'ended', status: 'active', runningTurnIds: [] as string[] },
+    ] as SessionSummary[];
+
+    assert.deepEqual(settledSessionTransientIds({
+      activeId: 'other',
+      sessions,
+      liveTurnBySession: { ended: answeredArm('turn-over') },
+    }), ['ended']);
+  });
+
   // A backgrounded session's arm is protected by the same bit — the guard must
   // not be an active-session special case, since a send can be backgrounded the
   // instant it is made.

--- a/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { SandboxBoundaryRequestEvent, SessionEventStreamSnapshot, SessionSummary } from '@maka/core';
-import { armLiveTurn } from '@maka/ui';
+import { armLiveTurn, confirmLiveTurn } from '@maka/ui';
 import { settledSessionTransientIds } from '../../renderer/settled-session-transients.js';
 import {
   clearAppShellSessionUiStateForSession,
@@ -31,6 +31,12 @@ function healthSnapshot(sessionId: string): SessionEventStreamSnapshot {
   return { sessionId, status: 'connected', subscribedAt: 1, checkedAt: 1 };
 }
 
+/** An arm the authority has already answered about — what every projection
+ *  looks like once its turn has produced a single event. */
+function answeredArm(turnId: string) {
+  return confirmLiveTurn(armLiveTurn(turnId), turnId)!;
+}
+
 function seededState(): AppShellSessionUiState {
   return {
     ...createInitialAppShellSessionUiState(),
@@ -54,14 +60,55 @@ describe('app shell session UI state controller', () => {
       { id: 'background', status: 'active' },
       { id: 'active', status: 'active' },
     ] as SessionSummary[];
-    const background = { ...armLiveTurn('turn-background'), terminal: true as const };
-    const active = { ...armLiveTurn('turn-active'), terminal: true as const };
+    const background = { ...answeredArm('turn-background'), terminal: true as const };
+    const active = { ...answeredArm('turn-active'), terminal: true as const };
 
     assert.deepEqual(settledSessionTransientIds({
       activeId: 'active',
       sessions,
       liveTurnBySession: { background, active },
     }), ['background']);
+  });
+
+  // The runtime writes `status: 'running'` only at the end of `AgentRun.begin`,
+  // so a list refreshed between the send and that write reports the pre-send
+  // status — which is the same status a FINISHED turn leaves behind. Retiring
+  // the arm on it is what made the first-token wait disappear until the first
+  // content event rebuilt the projection as 'streamed'.
+  it('keeps an armed turn while its send is still awaiting the authority', () => {
+    const sessions = [{ id: 'sending', status: 'active' }] as SessionSummary[];
+
+    assert.deepEqual(settledSessionTransientIds({
+      activeId: 'sending',
+      sessions,
+      liveTurnBySession: { sending: armLiveTurn('turn-1') },
+    }), []);
+  });
+
+  // The same pre-send status also has to stop protecting the arm once the send
+  // has been answered, or a turn that ended while its stream wasn't followed
+  // would leave the Stop affordance up forever.
+  it('settles an armed turn once the authority has answered its send', () => {
+    const sessions = [{ id: 'sending', status: 'active' }] as SessionSummary[];
+
+    assert.deepEqual(settledSessionTransientIds({
+      activeId: 'sending',
+      sessions,
+      liveTurnBySession: { sending: answeredArm('turn-1') },
+    }), ['sending']);
+  });
+
+  // A backgrounded session's arm is protected by the same bit — the guard must
+  // not be an active-session special case, since a send can be backgrounded the
+  // instant it is made.
+  it('protects an unconfirmed arm in a backgrounded session too', () => {
+    const sessions = [{ id: 'background', status: 'active' }] as SessionSummary[];
+
+    assert.deepEqual(settledSessionTransientIds({
+      activeId: 'other',
+      sessions,
+      liveTurnBySession: { background: armLiveTurn('turn-1') },
+    }), []);
   });
 
   it('clears one session from every per-session UI map without touching other sessions', () => {

--- a/apps/desktop/src/main/__tests__/model-wait-state.test.ts
+++ b/apps/desktop/src/main/__tests__/model-wait-state.test.ts
@@ -17,7 +17,7 @@ describe('is a turn running', () => {
     assert.equal(deriveTurnActive({
       turnPhase: 'waiting',
       armedTurnId: 'turn-1',
-      runningTurnId: undefined,
+      runningTurnIds: undefined,
     }), true);
   });
 
@@ -29,7 +29,7 @@ describe('is a turn running', () => {
     assert.equal(deriveTurnActive({
       turnPhase: 'streamed',
       armedTurnId: 'turn-1',
-      runningTurnId: undefined,
+      runningTurnIds: undefined,
     }), true);
   });
 
@@ -37,7 +37,7 @@ describe('is a turn running', () => {
     assert.equal(deriveTurnActive({
       turnPhase: undefined,
       armedTurnId: undefined,
-      runningTurnId: undefined,
+      runningTurnIds: undefined,
     }), false);
   });
 
@@ -47,7 +47,7 @@ describe('is a turn running', () => {
     assert.equal(deriveTurnActive({
       turnPhase: undefined,
       armedTurnId: undefined,
-      runningTurnId: 'turn-elsewhere',
+      runningTurnIds: ['turn-elsewhere'],
     }), true);
   });
 
@@ -58,7 +58,7 @@ describe('is a turn running', () => {
     assert.equal(deriveTurnActive({
       turnPhase: undefined,
       armedTurnId: 'turn-1',
-      runningTurnId: 'turn-1',
+      runningTurnIds: ['turn-1'],
     }), false);
   });
 
@@ -68,8 +68,35 @@ describe('is a turn running', () => {
     assert.equal(deriveTurnActive({
       turnPhase: undefined,
       armedTurnId: 'turn-1',
-      runningTurnId: 'turn-2',
+      runningTurnIds: ['turn-2'],
     }), true);
+  });
+
+  // A session can run concurrent turns. The arm's own turn lingering in the set
+  // — it has ended locally but the run has not been unregistered yet — must not
+  // hide a sibling that is genuinely still running.
+  it('opens for a sibling turn even while the settled arm lingers in the set', () => {
+    assert.equal(deriveTurnActive({
+      turnPhase: undefined,
+      armedTurnId: 'turn-1',
+      runningTurnIds: ['turn-1', 'turn-2'],
+    }), true);
+  });
+
+  it('closes when the only running turn is the arm the renderer already settled', () => {
+    assert.equal(deriveTurnActive({
+      turnPhase: undefined,
+      armedTurnId: 'turn-1',
+      runningTurnIds: ['turn-1'],
+    }), false);
+  });
+
+  it('closes on an empty set', () => {
+    assert.equal(deriveTurnActive({
+      turnPhase: undefined,
+      armedTurnId: undefined,
+      runningTurnIds: [],
+    }), false);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/model-wait-state.test.ts
+++ b/apps/desktop/src/main/__tests__/model-wait-state.test.ts
@@ -5,8 +5,73 @@ import {
   MODEL_PROCESSING_DELAY_MS,
   createDelayedFlag,
   deriveModelWait,
+  deriveTurnActive,
   type DelayedFlagScheduler,
 } from '../../renderer/model-wait-state.js';
+
+// The gate this whole change exists for: a send must show Stop at once and must
+// not lose it mid-turn. Both regressions came from letting a session-level
+// witness speak for the local arm, which is why these read as one suite.
+describe('is a turn running', () => {
+  it('opens on the local arm alone, with no session-level confirmation', () => {
+    assert.equal(deriveTurnActive({
+      turnPhase: 'waiting',
+      armedTurnId: 'turn-1',
+      runningTurnId: undefined,
+    }), true);
+  });
+
+  // The runtime writes `status: 'running'` only at the END of `AgentRun.begin`,
+  // so every list refreshed between the send and that write still describes an
+  // idle session. ANDing such a witness in — the shape this replaced — is what
+  // made Stop appear late and flicker off mid-turn.
+  it('stays open across a session snapshot that predates the run', () => {
+    assert.equal(deriveTurnActive({
+      turnPhase: 'streamed',
+      armedTurnId: 'turn-1',
+      runningTurnId: undefined,
+    }), true);
+  });
+
+  it('closes when neither witness reports a turn', () => {
+    assert.equal(deriveTurnActive({
+      turnPhase: undefined,
+      armedTurnId: undefined,
+      runningTurnId: undefined,
+    }), false);
+  });
+
+  // A turn this renderer did not send: another client, an automation, or one
+  // still running across a reload. There is no local arm to speak for it.
+  it('opens for a running turn this renderer never armed', () => {
+    assert.equal(deriveTurnActive({
+      turnPhase: undefined,
+      armedTurnId: undefined,
+      runningTurnId: 'turn-elsewhere',
+    }), true);
+  });
+
+  // The arm saw its own terminal event; a list fetched just before it did not.
+  // Reading that snapshot as authority would light Stop back up after the turn
+  // visibly ended.
+  it('does not let a stale snapshot revive the arm\'s own finished turn', () => {
+    assert.equal(deriveTurnActive({
+      turnPhase: undefined,
+      armedTurnId: 'turn-1',
+      runningTurnId: 'turn-1',
+    }), false);
+  });
+
+  // A new turn started elsewhere while this renderer still holds the previous
+  // one's terminal projection.
+  it('opens when the authority names a turn other than the settled arm', () => {
+    assert.equal(deriveTurnActive({
+      turnPhase: undefined,
+      armedTurnId: 'turn-1',
+      runningTurnId: 'turn-2',
+    }), true);
+  });
+});
 
 const HEAD = {
   turnPhase: 'waiting',

--- a/apps/desktop/src/main/__tests__/session-stream-unanswered-turn.test.ts
+++ b/apps/desktop/src/main/__tests__/session-stream-unanswered-turn.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Every send the IPC accepts must be answered by a change naming its turn.
+ *
+ * A client arms a live-turn projection the moment it sends, and that arm stays
+ * `unconfirmed` — refusing to let any session snapshot retire it — until the
+ * authority says something about that exact turn. The arm is what puts Stop up
+ * and locks the composer, so a send accepted and then never answered would pin
+ * both for the life of the process; nothing polls, and Stop cannot clear an arm
+ * it never confirms.
+ *
+ * A turn refused registration (session closed underneath it, duplicate turn id)
+ * produces no such answer: it runs none of the streamer's callbacks. What saves
+ * it is that the refusal is thrown SYNCHRONOUSLY, so it escapes the
+ * `void streamEvents(...)` in the send handler, rejects that handler instead of
+ * resolving `{ ok: true }`, and the client disarms in its own catch.
+ *
+ * That synchronicity is the whole safety property, and it is invisible at the
+ * call site — a later `async` on this path would be swallowed by the `void`.
+ * This locks it.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createSessionStreamer } from '../session-stream.js';
+
+function refusingStreamer(reason: string) {
+  const noop = new Proxy({}, { get: () => () => undefined });
+  return createSessionStreamer({
+    sessionActivities: noop as never,
+    goalWiring: {
+      coordinator: {
+        beginObservedTurn: () => ({ kind: 'unavailable' as const, reason }),
+      },
+    } as never,
+    computerUseOverlay: noop as never,
+    computerUseTools: noop as never,
+    safeSendToRenderer: () => undefined,
+    emitSessionsChanged: () => undefined,
+  });
+}
+
+describe('a turn that is refused registration', () => {
+  // `assert.throws`, not `assert.rejects`: a returned rejected promise would be
+  // discarded by the caller's `void`, and the client would sit on `{ ok: true }`
+  // with an arm nothing can ever confirm.
+  it('reaches the caller synchronously rather than as a rejected promise', () => {
+    const streamEvents = refusingStreamer('Goal continuation session is closed.');
+
+    assert.throws(
+      () =>
+        streamEvents('session-a', (async function* () {})(), {
+          turnId: 'turn-1',
+          goalBoundary: 'external',
+        }),
+      /session is closed/,
+    );
+  });
+
+  it('reaches the caller for a duplicate turn id too', () => {
+    const streamEvents = refusingStreamer('Goal turn turn-dup is already registered.');
+
+    assert.throws(() =>
+      streamEvents('session-a', (async function* () {})(), {
+        turnId: 'turn-dup',
+        goalBoundary: 'external',
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/sessions-ipc-send-turn-broadcast.test.ts
+++ b/apps/desktop/src/main/__tests__/sessions-ipc-send-turn-broadcast.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The one seam that tells a client its own send is live.
+ *
+ * No SessionEvent marks a turn's START — only its end — and the runtime writes
+ * `status: 'running'` at the end of `AgentRun.begin`, announcing it to nobody.
+ * Until this broadcast the earliest a client learned its turn had begun was the
+ * `message-appended` riding the FIRST content event, so the entire backend
+ * start-up looked idle.
+ *
+ * The turn id is what makes it an ANSWER rather than a bare invalidation: it
+ * must be the id the renderer sent, or the arm that send placed is never
+ * confirmed and a stale session list can retire it.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createRunStartedHook } from '../session-send-resolve.js';
+
+function hookHarness(turnId: string, options: { commitFails?: boolean } = {}) {
+  const answers: Array<{ sessionId: string; turnId: string }> = [];
+  const commits: string[] = [];
+  return {
+    answers,
+    commits,
+    hook: createRunStartedHook({
+      sessionId: 'session-a',
+      turnId,
+      emitSessionsChanged: (sessionId, turn) => answers.push({ sessionId, turnId: turn }),
+      commitRevisionVersion: async (sessionId) => {
+        commits.push(sessionId);
+        if (options.commitFails) throw new Error('revision commit failed');
+      },
+    }),
+  };
+}
+
+describe('the broadcast that answers a send', () => {
+  it('names the turn the send was made with', async () => {
+    const harness = hookHarness('turn-from-renderer');
+
+    await harness.hook('run-1', {});
+
+    assert.deepEqual(harness.answers, [
+      { sessionId: 'session-a', turnId: 'turn-from-renderer' },
+    ]);
+  });
+
+  // The revision commit shares this callback but nothing in the answer depends
+  // on it, so it must not be able to delay the broadcast.
+  it('answers before committing a prepared revision', async () => {
+    const order: string[] = [];
+    const hook = createRunStartedHook({
+      sessionId: 'session-a',
+      turnId: 'turn-1',
+      emitSessionsChanged: () => order.push('answer'),
+      commitRevisionVersion: async () => {
+        order.push('commit');
+      },
+    });
+
+    await hook('run-1', { revisionState: 'preparing' });
+
+    assert.deepEqual(order, ['answer', 'commit']);
+  });
+
+  // A failing commit rejects the whole callback. If the answer rode behind it,
+  // the client's arm would stay unconfirmed with nothing left to confirm it.
+  it('survives a revision commit that throws', async () => {
+    const harness = hookHarness('turn-1', { commitFails: true });
+
+    await assert.rejects(() => harness.hook('run-1', { revisionState: 'preparing' }));
+
+    assert.deepEqual(harness.answers, [{ sessionId: 'session-a', turnId: 'turn-1' }]);
+    assert.deepEqual(harness.commits, ['session-a']);
+  });
+
+  it('does not commit a revision the session did not prepare', async () => {
+    const harness = hookHarness('turn-1');
+
+    await harness.hook('run-1', {});
+
+    assert.deepEqual(harness.commits, []);
+    assert.equal(harness.answers.length, 1, 'the answer is unconditional');
+  });
+});

--- a/apps/desktop/src/main/__tests__/sessions-ipc-send-turn-broadcast.test.ts
+++ b/apps/desktop/src/main/__tests__/sessions-ipc-send-turn-broadcast.test.ts
@@ -15,7 +15,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { createRunStartedHook } from '../session-send-resolve.js';
+import { createRunStartedHook, stoppedTurnBroadcasts } from '../session-send-resolve.js';
 
 function hookHarness(turnId: string, options: { commitFails?: boolean } = {}) {
   const answers: Array<{ sessionId: string; turnId: string }> = [];
@@ -82,5 +82,39 @@ describe('the broadcast that answers a send', () => {
 
     assert.deepEqual(harness.commits, []);
     assert.equal(harness.answers.length, 1, 'the answer is unconditional');
+  });
+});
+
+// Stop is the one turn ending a client can be waiting on without ever having
+// seen the turn start: pressed inside the send→run-start window, it is the only
+// thing that will ever answer that send. Unnamed, it cannot release the claim —
+// Stop would be the one control unable to undo Stop.
+describe('the broadcasts that announce a stop', () => {
+  it('names the turn it ended, on every reason', () => {
+    assert.deepEqual(stoppedTurnBroadcasts(['turn-1']), [
+      { reason: 'status-change', turnId: 'turn-1' },
+      { reason: 'turn-status-change', turnId: 'turn-1' },
+      { reason: 'message-appended', turnId: 'turn-1' },
+    ]);
+  });
+
+  // A session can carry concurrent runs; stopping ends all of them, and a
+  // client waiting on any one must hear its own turn named.
+  it('names every turn it ended', () => {
+    const named = stoppedTurnBroadcasts(['turn-1', 'turn-2'])
+      .filter((broadcast) => broadcast.reason === 'turn-status-change')
+      .map((broadcast) => broadcast.turnId);
+
+    assert.deepEqual(named, ['turn-1', 'turn-2']);
+  });
+
+  // Nothing was running, so nothing is being answered — an unnamed change is
+  // exactly what "not about any turn" means.
+  it('names nothing when there was no turn to stop', () => {
+    assert.deepEqual(stoppedTurnBroadcasts([]), [
+      { reason: 'status-change' },
+      { reason: 'turn-status-change' },
+      { reason: 'message-appended' },
+    ]);
   });
 });

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -1381,7 +1381,7 @@ function emitConnectionListChanged(): void {
 function emitSessionsChanged(
   reason: SessionChangedReason,
   sessionId?: string,
-  extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId'>,
+  extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId' | 'turnId'>,
 ): void {
   const event: SessionChangedEvent = {
     type: 'sessions_changed',
@@ -1391,6 +1391,7 @@ function emitSessionsChanged(
   if (sessionId) event.sessionId = sessionId;
   if (extra?.connectionSlug) event.connectionSlug = extra.connectionSlug;
   if (extra?.modelId) event.modelId = extra.modelId;
+  if (extra?.turnId) event.turnId = extra.turnId;
   safeSendToRenderer('sessions:changed', event);
 }
 

--- a/apps/desktop/src/main/session-send-resolve.ts
+++ b/apps/desktop/src/main/session-send-resolve.ts
@@ -50,3 +50,33 @@ export async function resolveSessionSend(input: {
   }
   return { turnId: input.command.turnId || randomUUID(), attachments };
 }
+/**
+ * What a send does the moment its run goes live.
+ *
+ * No SessionEvent marks a turn's START — only its end — and the runtime writes
+ * `status: 'running'` at the end of `AgentRun.begin`, announcing it to nobody.
+ * Without this broadcast the earliest a client learns its turn is running is
+ * the `message-appended` riding the FIRST content event, so the whole backend
+ * start-up ahead of it looks idle.
+ *
+ * The broadcast carries the turn id, which is what makes it an ANSWER to a
+ * particular send rather than a bare catalog invalidation: a session's status
+ * reads the same before a turn starts and after it ends, so a client that just
+ * sent cannot otherwise tell "not yet" from "already over".
+ *
+ * It is emitted BEFORE the revision commit. Nothing in the answer depends on
+ * that write, so it must neither be delayed by it nor lost when it throws.
+ */
+export function createRunStartedHook(input: {
+  sessionId: string;
+  turnId: string;
+  emitSessionsChanged: (sessionId: string, turnId: string) => void;
+  commitRevisionVersion: (sessionId: string) => Promise<unknown>;
+}): (runId: string, header: { revisionState?: string }) => Promise<void> {
+  return async (_runId, header) => {
+    input.emitSessionsChanged(input.sessionId, input.turnId);
+    if (header.revisionState === 'preparing') {
+      await input.commitRevisionVersion(input.sessionId);
+    }
+  };
+}

--- a/apps/desktop/src/main/session-send-resolve.ts
+++ b/apps/desktop/src/main/session-send-resolve.ts
@@ -80,3 +80,32 @@ export function createRunStartedHook(input: {
     }
   };
 }
+
+/** One `sessions:changed` to emit, in order. */
+export interface StoppedTurnBroadcast {
+  reason: 'status-change' | 'turn-status-change' | 'message-appended';
+  turnId?: string;
+}
+
+/**
+ * The broadcasts that announce a stop, naming the turns it ended.
+ *
+ * Stopping is the one turn ending a client can be waiting on without ever
+ * having seen the turn start — Stop pressed inside the send→run-start window.
+ * A client holds a local claim on a turn it submitted until it hears back about
+ * that exact turn, so an unnamed stop leaves the claim with nothing to release
+ * it, making Stop the one control unable to undo Stop.
+ *
+ * With no turn running there is nothing to name and the plain invalidations
+ * stand: something not tied to a turn is exactly what an unnamed change means.
+ */
+export function stoppedTurnBroadcasts(
+  stoppedTurnIds: readonly string[],
+): StoppedTurnBroadcast[] {
+  const reasons = ['status-change', 'turn-status-change', 'message-appended'] as const;
+  return reasons.flatMap((reason) =>
+    stoppedTurnIds.length === 0
+      ? [{ reason }]
+      : stoppedTurnIds.map((turnId) => ({ reason, turnId })),
+  );
+}

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -559,6 +559,14 @@ export function createSessionStreamer(deps: SessionStreamerDeps): StreamEvents {
         }
       },
     });
+    // Thrown SYNCHRONOUSLY, and that is load-bearing. A refused turn never runs
+    // `onEvent` / `onStreamError` / `onDrained`, so no change ever names it —
+    // and a client's arm stays unconfirmed until its turn is named, holding Stop
+    // and the composer lock. Throwing synchronously is what carries the failure
+    // out through the `void streamEvents(...)` call in the send handler: it
+    // rejects that handler's promise instead of resolving `{ ok: true }`, so the
+    // client disarms in its own catch. Made async, this line would be swallowed
+    // by the `void` and latch the UI until restart.
     if (started.kind === 'unavailable') throw new Error(started.reason);
     return started.completion.then((outcome) => {
       const failureReason = outcome.kind === 'errored' || outcome.kind === 'suspended'

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -460,7 +460,11 @@ export interface SessionStreamerDeps {
   computerUseOverlay: AssembledTools['computerUseOverlay'];
   computerUseTools: AssembledTools['computerUseTools'];
   safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
-  emitSessionsChanged: (reason: SessionChangedReason, sessionId?: string) => void;
+  emitSessionsChanged: (
+    reason: SessionChangedReason,
+    sessionId?: string,
+    extra?: { turnId?: string },
+  ) => void;
   interruptActivePlanExecution?: (sessionId: string, reason: string) => Promise<unknown>;
 }
 
@@ -511,15 +515,15 @@ export function createSessionStreamer(deps: SessionStreamerDeps): StreamEvents {
         goalWiring.coordinator.beginObservedTurn(externalSessionId, externalTurnId),
       onEvent: (event) => {
         if (!userAppendBroadcasted) {
-          emitSessionsChanged('message-appended', sessionId);
+          emitSessionsChanged('message-appended', sessionId, { turnId });
           userAppendBroadcasted = true;
         }
         safeSendToRenderer(`sessions:event:${sessionId}`, event);
         if (isStatusChangingSessionEvent(event)) {
-          emitSessionsChanged('status-change', sessionId);
+          emitSessionsChanged('status-change', sessionId, { turnId });
         }
         if (isTurnStatusChangingSessionEvent(event)) {
-          emitSessionsChanged('turn-status-change', sessionId);
+          emitSessionsChanged('turn-status-change', sessionId, { turnId });
           computerUseOverlay.clearForSession(sessionId);
           computerUseTools.clearSession(sessionId);
         }
@@ -537,13 +541,13 @@ export function createSessionStreamer(deps: SessionStreamerDeps): StreamEvents {
           message: errorMessage(error),
         } satisfies SessionEvent;
         safeSendToRenderer(`sessions:event:${sessionId}`, event);
-        emitSessionsChanged('status-change', sessionId);
-        emitSessionsChanged('turn-status-change', sessionId);
+        emitSessionsChanged('status-change', sessionId, { turnId });
+        emitSessionsChanged('turn-status-change', sessionId, { turnId });
         computerUseOverlay.clearForSession(sessionId);
         computerUseTools.clearSession(sessionId);
       },
       onDrained: async (outcome) => {
-        emitSessionsChanged('message-appended', sessionId);
+        emitSessionsChanged('message-appended', sessionId, { turnId });
         if (
           interruptActivePlanExecution &&
           (outcome.kind === 'aborted' || outcome.kind === 'errored')

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -28,7 +28,7 @@ import type { PreparedSkillInvocationMessage, SessionManager } from '@maka/runti
 import type { ArtifactStore, createSessionStore } from '@maka/storage';
 import type { ConnectionStore, SettingsStore } from '@maka/storage';
 import { runThreadSearch } from './search/thread-search.js';
-import { resolveSessionSend } from './session-send-resolve.js';
+import { createRunStartedHook, resolveSessionSend } from './session-send-resolve.js';
 import { resizeImageForAttachment } from './attachment-resize-native.js';
 import { releaseBrowserSession } from './browser/session.js';
 import { sessionReadMessagesFailureMessage } from './session-read-error-copy.js';
@@ -89,7 +89,7 @@ export interface SessionsIpcDeps {
   emitSessionsChanged: (
     reason: SessionChangedReason,
     sessionId?: string,
-    extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId'>,
+    extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId' | 'turnId'>,
   ) => void;
   ensureSessionCanSend: (sessionId: string) => Promise<void>;
   prepareSkillInvocation?: (
@@ -479,11 +479,12 @@ export function registerSessionsIpc(
         inlineReferences,
       },
       {
-        onRunStarted: async (_runId, header) => {
-          if (header.revisionState === 'preparing') {
-            await runtime.commitRevisionVersion(sessionId);
-          }
-        },
+        onRunStarted: createRunStartedHook({
+          sessionId,
+          turnId,
+          emitSessionsChanged: (id, turn) => emitSessionsChanged('status-change', id, { turnId: turn }),
+          commitRevisionVersion: (id) => runtime.commitRevisionVersion(id),
+        }),
       },
     );
     void streamEvents(sessionId, iterator, { turnId, goalBoundary: 'external' });

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -28,7 +28,7 @@ import type { PreparedSkillInvocationMessage, SessionManager } from '@maka/runti
 import type { ArtifactStore, createSessionStore } from '@maka/storage';
 import type { ConnectionStore, SettingsStore } from '@maka/storage';
 import { runThreadSearch } from './search/thread-search.js';
-import { createRunStartedHook, resolveSessionSend } from './session-send-resolve.js';
+import { createRunStartedHook, resolveSessionSend, stoppedTurnBroadcasts } from './session-send-resolve.js';
 import { resizeImageForAttachment } from './attachment-resize-native.js';
 import { releaseBrowserSession } from './browser/session.js';
 import { sessionReadMessagesFailureMessage } from './session-read-error-copy.js';
@@ -362,11 +362,21 @@ export function registerSessionsIpc(
     computerUseOverlay.clearForSession(sessionId);
     computerUseTools.clearSession(sessionId);
     await stopAgentGraph?.(sessionId);
+    // Read before stopping, while the runs are still registered: ending a turn
+    // is a change about that turn, and this is the one end a client can be
+    // waiting on without having seen the turn start — Stop pressed during the
+    // send→run-start window. Unnamed, it would leave that client's claim with
+    // nothing to release it, making Stop the one control unable to undo Stop.
+    const stoppedTurnIds = runtime.runningTurnIds(sessionId);
     await runtime.stopSession(sessionId, normalizeStopSessionInput(input));
     await runtime.interruptActivePlanExecution(sessionId, 'user_stopped_execution').catch(() => null);
-    emitSessionsChanged('status-change', sessionId);
-    emitSessionsChanged('turn-status-change', sessionId);
-    emitSessionsChanged('message-appended', sessionId);
+    for (const broadcast of stoppedTurnBroadcasts(stoppedTurnIds)) {
+      emitSessionsChanged(
+        broadcast.reason,
+        sessionId,
+        ...(broadcast.turnId ? [{ turnId: broadcast.turnId }] : []),
+      );
+    }
   });
   ipcMain.handle('sessions:readExecutionBoundary', (_event, sessionId: string) =>
     runtime.readExecutionBoundary(sessionId),

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -133,9 +133,6 @@ export function createAppShellChatActions(deps: {
    *  is why the send path asks it instead of comparing the id itself. */
   isShellSurfaceOwnerActive: (owner: ComposerImportOwner) => boolean;
   markSessionReadLocally: (sessionId: string, readMessages: readonly StoredMessage[]) => void;
-  /** #646: optimistically flip the session's status to 'running' at send() so the
-   * "正在处理…" gate opens before the runtime's status round-trip lands. */
-  markSessionRunningOptimistic: (sessionId: string) => (() => void) | undefined;
   messageRetryPendingRef: RefBox<Set<string>>;
   refreshSessions: () => Promise<SessionSummary[]>;
   setActiveId: (sessionId: string | undefined) => void;
@@ -168,7 +165,6 @@ export function createAppShellChatActions(deps: {
     isNewChatSendSurfaceActive,
     isShellSurfaceOwnerActive,
     markSessionReadLocally,
-    markSessionRunningOptimistic,
     messageRetryPendingRef,
     refreshSessions,
     setActiveId,
@@ -253,6 +249,13 @@ export function createAppShellChatActions(deps: {
   // (re)set to `'waiting'`: a fresh send is a new first-token wait, so it must
   // overwrite any `'streamed'` left by a prior turn whose terminal event was
   // missed — otherwise the new turn's head would never show the indicator.
+  //
+  // The arm carries `unconfirmed` until the authority names this turn back. The
+  // runtime writes `status: 'running'` only at the END of `AgentRun.begin`, so
+  // every session list refreshed in between still reports the pre-send status —
+  // which is the same status a finished turn leaves behind. Without that bit,
+  // the stale value retires the arm the send just created
+  // (settled-session-transients.ts).
   function armTurnActive(sessionId: string, turnId: string): void {
     setLiveTurnBySession((current) => {
       const active = current[sessionId];
@@ -288,7 +291,6 @@ export function createAppShellChatActions(deps: {
     const newChatOwner = initialSessionId ? null : sendOwner;
     let optimisticSessionId: string | undefined;
     let optimisticTurnId: string | undefined;
-    let restoreOptimisticStatus: (() => void) | undefined;
     // #1433: the composer creates the session BEFORE it sends, so a first
     // send that never lands has to take the session with it. Set the moment
     // creation succeeds, cleared the moment the send does — while it holds a
@@ -333,7 +335,6 @@ export function createAppShellChatActions(deps: {
         optimisticSessionId = session.id;
         optimisticTurnId = turnId;
         armTurnActive(session.id, turnId);
-        restoreOptimisticStatus = markSessionRunningOptimistic(session.id);
         const attachmentItems = pending && pending.length > 0 ? toIngestItems(pending) : undefined;
         const sendResult = await window.maka.sessions.send(session.id, {
           type: 'send',
@@ -353,8 +354,6 @@ export function createAppShellChatActions(deps: {
             showSkillInvocationFeedback(uiLocale, toastApi, sendResult.skillInvocation);
           }
           disarmTurnActive(session.id, turnId);
-          restoreOptimisticStatus?.();
-          restoreOptimisticStatus = undefined;
           await discardUnsentSession();
           return false;
         }
@@ -389,7 +388,6 @@ export function createAppShellChatActions(deps: {
       optimisticSessionId = sessionId;
       optimisticTurnId = turnId;
       armTurnActive(sessionId, turnId);
-      restoreOptimisticStatus = markSessionRunningOptimistic(sessionId);
       const attachmentItems = pending && pending.length > 0 ? toIngestItems(pending) : undefined;
       const sendResult = await window.maka.sessions.send(sessionId, {
         type: 'send',
@@ -409,8 +407,6 @@ export function createAppShellChatActions(deps: {
           showSkillInvocationFeedback(uiLocale, toastApi, sendResult.skillInvocation);
         }
         disarmTurnActive(sessionId, turnId);
-        restoreOptimisticStatus?.();
-        restoreOptimisticStatus = undefined;
         return false;
       }
       options.onSessionResolved?.(sessionId);
@@ -436,12 +432,10 @@ export function createAppShellChatActions(deps: {
         removeOptimisticUserMessage(optimisticSessionId, optimisticTurnId);
       }
       // The turn never reached the runtime — close the model-wait window so the
-      // "正在处理…" indicator doesn't hang after a failed send, and revert the
-      // optimistic running status (no subscribeChanges event will reconcile it
-      // for a send that never started) so the session doesn't keep a phantom
-      // running dot / blocked permission-mode toggle.
+      // "正在处理…" indicator doesn't hang after a failed send. Nothing else has
+      // to be undone: the arm was the only claim the send made, and no
+      // subscribeChanges event would reconcile a turn that never started.
       if (optimisticSessionId && optimisticTurnId) disarmTurnActive(optimisticSessionId, optimisticTurnId);
-      restoreOptimisticStatus?.();
       // Which surface is allowed to hear about this failure. The id alone is
       // not it: `selectNavigation` never clears `activeId` (nav-selection.ts),
       // so a user who left for 扩展 → 技能 mid-flight still "is" session A by

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -2,6 +2,7 @@ import { useEffect, useEffectEvent, useLayoutEffect } from 'react';
 import type {
   ConnectionEvent,
   PlanReminder,
+  SessionChangedEvent,
   SessionEvent,
   SessionEventStreamSnapshot,
   SessionSummary,
@@ -182,6 +183,8 @@ export function useAppShellBootstrapSubscriptions(options: {
   applyE2eFixture: () => Promise<void>;
   bootstrapSessions: () => Promise<void>;
   clearPendingTurnActionsForSession: (sessionId: string) => void;
+  /** Releases a send's pending claim once the authority names that turn. */
+  confirmLiveTurn: (sessionId: string, turnId: string) => void;
   clearSessionRendererState: (sessionId: string) => void;
   createSession: () => Promise<void> | void;
   handleConnectionEvent: (event: ConnectionEvent) => void;
@@ -223,7 +226,13 @@ export function useAppShellBootstrapSubscriptions(options: {
     options.handleConnectionEvent(event);
   });
   const handleSessionChange = useEffectEvent(
-    (event: { reason: string; sessionId?: string; ts: number; modelId?: string }) => {
+    (event: SessionChangedEvent) => {
+      // The authority has spoken about a specific turn — whether it started,
+      // failed to start, or ended. That confirms the send's arm, and the
+      // session's status becomes readable as an answer about it again.
+      if (event.sessionId && event.turnId) {
+        options.confirmLiveTurn(event.sessionId, event.turnId);
+      }
       void options.refreshSessions();
       if (event.reason === 'created' || event.reason === 'migrated') {
         void options.refreshProjects();
@@ -592,6 +601,12 @@ export function useSessionEventHealthPolling(options: {
 // settles, drop the turn transient of every session that is no longer running /
 // waiting_for_user. Because it keys off the status landing in `sessions`, it closes
 // the hole regardless of which path or timing delivers that status.
+//
+// Except while a send is still awaiting its answer: an arm carries `unconfirmed`
+// until a `sessions:changed` names its turn back, and the pre-send status is
+// indistinguishable from the post-turn one. Reading a list refreshed in that
+// window as a settle would drop the arm the send just created
+// (settled-session-transients.ts).
 //
 // An active terminal projection is left to its text handoff callback, so this
 // reconcile cannot cut in front of the committed message landing. Background

--- a/apps/desktop/src/renderer/app-shell-session-ui-state.ts
+++ b/apps/desktop/src/renderer/app-shell-session-ui-state.ts
@@ -1,6 +1,6 @@
 import { useReducer, useRef } from 'react';
 import type { SessionEventStreamSnapshot } from '@maka/core';
-import type { InteractionQueues, LiveTurnProjection } from '@maka/ui';
+import { confirmLiveTurn, type InteractionQueues, type LiveTurnProjection } from '@maka/ui';
 import type { ShellRunUpdatesBySession } from './shell-run-update-state.js';
 
 type StateUpdater<T> = (updater: (current: T) => T) => void;
@@ -145,6 +145,20 @@ export function createAppShellSessionUiStateController(
     }) satisfies StateUpdater<Record<string, SessionEventStreamSnapshot>>,
     setPendingPermissionModeBySession: createMapSetter('pendingPermissionModeBySession'),
     setPendingSessionModelBySession: createMapSetter('pendingSessionModelBySession'),
+    /**
+     * The authority said something about `turnId` — it started, failed to
+     * start, or ended. Drop that arm's `unconfirmed` claim so a session list
+     * may settle it again. An answer about a turn this session is not on says
+     * nothing, and leaves the state untouched.
+     */
+    confirmLiveTurn: (sessionId: string, turnId: string) => {
+      updateMap('liveTurnBySession', (current) => {
+        const armed = current[sessionId];
+        if (!armed) return current;
+        const confirmed = confirmLiveTurn(armed, turnId);
+        return confirmed === armed ? current : { ...current, [sessionId]: confirmed! };
+      });
+    },
     clearSessionUiState: (sessionId: string) => {
       sessionEventHealthBySessionRef.current = omitSessionKey(
         sessionEventHealthBySessionRef.current,
@@ -184,6 +198,7 @@ export function useAppShellSessionUiState() {
     setSessionEventHealthBySession: controller.setSessionEventHealthBySession,
     setPendingPermissionModeBySession: controller.setPendingPermissionModeBySession,
     setPendingSessionModelBySession: controller.setPendingSessionModelBySession,
+    confirmLiveTurn: controller.confirmLiveTurn,
     clearSessionUiState: controller.clearSessionUiState,
     clearTurnTransientState: controller.clearTurnTransientState,
   };

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2274,7 +2274,7 @@ function AppShellContent({
                   // user most wants to interrupt is a long wait with nothing on
                   // screen (first token, or a slow provider's step-to-step lull).
                   // `turnActive` unions the send's zero-lag local arm with the
-                  // runtime's live `runningTurnId` (a turn this renderer did not
+                  // runtime's live `runningTurnIds` (turns this renderer did not
                   // send), so neither witness can veto the other — see
                   // `deriveTurnActive`. `activeStreamingLive` is folded in
                   // defensively for the rare replay where the arm was over-cleared.
@@ -2383,12 +2383,18 @@ function AppShellContent({
                   }
                   permissionMode={activePermissionMode}
                   permissionModePending={activeId ? pendingPermissionModeBySession[activeId] === true : false}
+                  // Every "cannot change this mid-turn" gate reads `turnActive`,
+                  // the same witness Stop reads. Reading the persisted status
+                  // here instead left these toggles live through the whole
+                  // send→run-start window — long enough on a cold backend for a
+                  // mode change to land before the run registers and alter the
+                  // execution config of the turn already sent.
                   permissionModeDisabledReason={
                     activeId && pendingPermissionModeBySession[activeId] === true
                         ? shellCopy.permissionModeChanging
                       : activeStreamingLive
                           ? shellCopy.permissionModeStreaming
-                        : activeId && activeSessionForView?.status === 'running'
+                        : activeId && turnActive
                             ? shellCopy.permissionModeRunning
                           : activeId && activeSessionForView?.status === 'waiting_for_user'
                               ? shellCopy.permissionModeWaiting
@@ -2408,7 +2414,7 @@ function AppShellContent({
                       ? shellCopy.planModeChanging
                       : activeStreamingLive
                           ? shellCopy.planModeStreaming
-                        : activeId && activeSessionForView?.status === 'running'
+                        : activeId && turnActive
                             ? shellCopy.planModeRunning
                           : activeId && activeSessionForView?.status === 'waiting_for_user'
                               ? shellCopy.planModeWaiting
@@ -2424,7 +2430,7 @@ function AppShellContent({
                       ? shellCopy.swarmModeChanging
                       : activeStreamingLive
                           ? shellCopy.swarmModeStreaming
-                        : activeId && activeSessionForView?.status === 'running'
+                        : activeId && turnActive
                             ? shellCopy.swarmModeRunning
                           : activeId && activeSessionForView?.status === 'waiting_for_user'
                               ? shellCopy.swarmModeWaiting
@@ -2442,7 +2448,7 @@ function AppShellContent({
                       ? shellCopy.graphModeChanging
                       : activeStreamingLive
                           ? shellCopy.graphModeStreaming
-                        : activeId && activeSessionForView?.status === 'running'
+                        : activeId && turnActive
                             ? shellCopy.graphModeRunning
                           : activeId && activeSessionForView?.status === 'waiting_for_user'
                               ? shellCopy.graphModeWaiting

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -247,7 +247,6 @@ function AppShellContent({
     refreshSessions,
     seedSessions,
     upsertSessionSummary,
-    markSessionRunningOptimistic,
     markSessionReadLocally,
     activeId,
     activeIdRef,
@@ -268,6 +267,7 @@ function AppShellContent({
     setMessageRetryPendingBySession,
     setStopPendingBySession,
     setLiveTurnBySession,
+    confirmLiveTurn,
     setShellRunUpdatesBySession,
     setInteractionBySession,
     setSessionEventHealthBySession,
@@ -613,16 +613,15 @@ function AppShellContent({
     streamingSessionIds,
     liveTools,
     hasInFlightLiveTools,
-    turnInFlight,
-    sessionAwaitingModel,
+    turnActive,
     showProcessingIndicator,
     showContinuingIndicator,
   } = useShellLiveTurn({
     activeId,
+    activeSession,
     activeLiveTurn,
     liveTurnBySession,
     shellRunUpdatesBySession,
-    activeSession,
   });
   // Surface a credential-lifecycle alert directly in the chat header when
   // the active session's connection is in `needs_reauth` / `error` or has
@@ -1373,7 +1372,6 @@ function AppShellContent({
     isNewChatSendSurfaceActive,
     isShellSurfaceOwnerActive,
     markSessionReadLocally,
-    markSessionRunningOptimistic,
     messageRetryPendingRef,
     refreshSessions,
     setActiveId,
@@ -1822,6 +1820,7 @@ function AppShellContent({
     applyE2eFixture,
     bootstrapSessions,
     clearPendingTurnActionsForSession: turnActionRegistry.clearForSession,
+    confirmLiveTurn,
     clearSessionRendererState,
     createSession,
     handleConnectionEvent,
@@ -2274,18 +2273,12 @@ function AppShellContent({
                   // #646: Stop must be available for the WHOLE turn - the moment the
                   // user most wants to interrupt is a long wait with nothing on
                   // screen (first token, or a slow provider's step-to-step lull).
-                  // Drive Stop off `turnInFlight` (armed at send, cleared at the
-                  // terminal event), not the wait indicators, so it never blinks out
-                  // in a mid-turn gap. But `turnInFlight` alone goes STALE: the event
-                  // stream only follows `activeId`, so a session whose turn completes
-                  // while backgrounded never receives its terminal event and keeps its
-                  // arm. Gate on `sessionAwaitingModel` (status === 'running', kept
-                  // truthful for backgrounded sessions by sessions:changed and made
-                  // synchronous at send by markSessionRunningOptimistic) so returning
-                  // to such a session shows Send, not a stuck Stop that hides it.
-                  // `activeStreamingLive` is folded in defensively for the rare replay
-                  // where the arm was over-cleared.
-                  streaming={(sessionAwaitingModel && turnInFlight) || activeStreamingLive}
+                  // `turnActive` unions the send's zero-lag local arm with the
+                  // runtime's live `runningTurnId` (a turn this renderer did not
+                  // send), so neither witness can veto the other — see
+                  // `deriveTurnActive`. `activeStreamingLive` is folded in
+                  // defensively for the rare replay where the arm was over-cleared.
+                  streaming={turnActive || activeStreamingLive}
                   // #646: in the first-token wait (Stop up, nothing streams yet) the
                   // hint reads "Maka 正在处理…"; in a mid-turn lull it reads the calm
                   // "Maka 继续中…". Both are mutually exclusive with activeStreamingLive.

--- a/apps/desktop/src/renderer/model-wait-state.ts
+++ b/apps/desktop/src/renderer/model-wait-state.ts
@@ -45,21 +45,23 @@ export type TurnPhase = 'waiting' | 'streamed';
  * nothing until a status round-trip landed, then had it retracted by any list
  * refresh that resolved before the runtime's `running` write.
  *
- * `runningTurnId` is read only when it names a turn OTHER than the arm's. For
- * the arm's own turn the local projection knows more — it sees the terminal
- * event first — so a snapshot taken before that event must not light Stop back
- * up. For any other turn (another client, an automation, one still running
- * across a reload) it is the only witness there is.
+ * `runningTurnIds` is read only for turns OTHER than the arm's. For the arm's
+ * own turn the local projection knows more — it sees the terminal event first —
+ * so a snapshot taken before that event must not light Stop back up. For any
+ * other turn (another client, an automation, one still running across a reload)
+ * it is the only witness there is. It is a set because a session can run
+ * concurrent turns, and the arm's own turn lingering in it must not hide a
+ * sibling that is genuinely still running.
  */
 export function deriveTurnActive(input: {
   /** The active session's live projection, if this renderer has one. */
   turnPhase: TurnPhase | undefined;
   armedTurnId: string | undefined;
-  /** The turn the authority is running for this session, if any. */
-  runningTurnId: string | undefined;
+  /** The turns the authority is running for this session. */
+  runningTurnIds: readonly string[] | undefined;
 }): boolean {
   if (input.turnPhase !== undefined) return true;
-  return input.runningTurnId !== undefined && input.runningTurnId !== input.armedTurnId;
+  return input.runningTurnIds?.some((turnId) => turnId !== input.armedTurnId) === true;
 }
 
 export interface ModelWaitInputs {

--- a/apps/desktop/src/renderer/model-wait-state.ts
+++ b/apps/desktop/src/renderer/model-wait-state.ts
@@ -36,6 +36,32 @@ export const MODEL_CONTINUING_DELAY_MS = 600;
  */
 export type TurnPhase = 'waiting' | 'streamed';
 
+/**
+ * Whether a turn is running for the active session — the Stop affordance, and
+ * the composer lock that rides with it.
+ *
+ * Two witnesses, ORed. They must never be ANDed: the local arm is the only
+ * instant one, and gating it on a session-level witness meant a send opened
+ * nothing until a status round-trip landed, then had it retracted by any list
+ * refresh that resolved before the runtime's `running` write.
+ *
+ * `runningTurnId` is read only when it names a turn OTHER than the arm's. For
+ * the arm's own turn the local projection knows more — it sees the terminal
+ * event first — so a snapshot taken before that event must not light Stop back
+ * up. For any other turn (another client, an automation, one still running
+ * across a reload) it is the only witness there is.
+ */
+export function deriveTurnActive(input: {
+  /** The active session's live projection, if this renderer has one. */
+  turnPhase: TurnPhase | undefined;
+  armedTurnId: string | undefined;
+  /** The turn the authority is running for this session, if any. */
+  runningTurnId: string | undefined;
+}): boolean {
+  if (input.turnPhase !== undefined) return true;
+  return input.runningTurnId !== undefined && input.runningTurnId !== input.armedTurnId;
+}
+
 export interface ModelWaitInputs {
   /** Turn phase, or undefined when no turn is in flight. */
   turnPhase: TurnPhase | undefined;

--- a/apps/desktop/src/renderer/settled-session-transients.ts
+++ b/apps/desktop/src/renderer/settled-session-transients.ts
@@ -1,6 +1,26 @@
 import type { SessionSummary } from '@maka/core';
 import type { LiveTurnProjection } from '@maka/ui';
 
+/**
+ * Which sessions' turn transients are safe to drop, i.e. whose turn the
+ * authority says is over.
+ *
+ * A session's `status` alone cannot say that. It reads `active` both before the
+ * runtime's `running` write — which lands only at the end of `AgentRun.begin`,
+ * announced by nothing until this renderer's own send is confirmed — and after
+ * the turn ends. A list refreshed inside that window is byte-identical to one
+ * taken after the turn finished, so reading it as a settle drops the arm the
+ * send just created, taking the whole first-token wait with it (the projection
+ * gets rebuilt by the first content event as `'streamed'`, downgrading the
+ * prominent "正在处理…" to the calm "继续中…").
+ *
+ * The arm's own `unconfirmed` bit supplies the missing identity: while it is
+ * set, this renderer has sent a turn the authority has not yet answered about,
+ * and no session-level status may be read as an answer. It is cleared by the
+ * first word about that exact turn — its start, its failure to start, its end,
+ * or any of its events — so a status change caused by some OTHER turn (another
+ * client, an automation) cannot release it early.
+ */
 export function settledSessionTransientIds(options: {
   activeId?: string;
   sessions: readonly SessionSummary[];
@@ -9,6 +29,7 @@ export function settledSessionTransientIds(options: {
   return options.sessions.flatMap((session) => {
     if (session.status === 'running' || session.status === 'waiting_for_user') return [];
     const projection = options.liveTurnBySession[session.id];
+    if (projection?.unconfirmed) return [];
     if (session.id === options.activeId && projection?.terminal) return [];
     return [session.id];
   });

--- a/apps/desktop/src/renderer/settled-session-transients.ts
+++ b/apps/desktop/src/renderer/settled-session-transients.ts
@@ -27,6 +27,11 @@ export function settledSessionTransientIds(options: {
   liveTurnBySession: Readonly<Record<string, LiveTurnProjection>>;
 }): string[] {
   return options.sessions.flatMap((session) => {
+    // The live runs first: a persisted status can disagree with them in both
+    // directions — it is written after the run starts and can be left behind
+    // entirely by a crash — so anything the runtime still reports as running
+    // keeps its transients regardless of what the header says.
+    if (session.runningTurnIds?.length) return [];
     if (session.status === 'running' || session.status === 'waiting_for_user') return [];
     const projection = options.liveTurnBySession[session.id];
     if (projection?.unconfirmed) return [];

--- a/apps/desktop/src/renderer/use-app-shell-session-list.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-list.ts
@@ -79,28 +79,6 @@ export function useAppShellSessionList(toastApi: ToastApi) {
     ]);
   }
 
-  // Sending locally precedes the persisted running status. Open the UI gate
-  // optimistically, then let session refresh reconcile it. The restore only
-  // applies while this exact optimistic status still owns the entry, so a
-  // newer backend update always wins.
-  function markSessionRunningOptimistic(sessionId: string): (() => void) | undefined {
-    const prior = sessionsRef.current.find((entry) => entry.id === sessionId);
-    if (!prior || prior.status === 'running') return undefined;
-    const priorStatus = prior.status;
-    setSessions((current) => current.map((entry) => (
-      entry.id === sessionId && entry.status !== 'running'
-        ? { ...entry, status: 'running' as const }
-        : entry
-    )));
-    return () => {
-      setSessions((current) => current.map((entry) => (
-        entry.id === sessionId && entry.status === 'running'
-          ? { ...entry, status: priorStatus }
-          : entry
-      )));
-    };
-  }
-
   function markSessionReadLocally(sessionId: string, readMessages: readonly StoredMessage[]): void {
     setSessions((current) => applyLocalSessionRead(
       sessionReadBoundariesRef.current,
@@ -118,7 +96,6 @@ export function useAppShellSessionList(toastApi: ToastApi) {
     refreshSessions,
     seedSessions,
     upsertSessionSummary,
-    markSessionRunningOptimistic,
     markSessionReadLocally,
   };
 }

--- a/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
@@ -79,6 +79,7 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
     setSessionEventHealthBySession: sessionUi.setSessionEventHealthBySession,
     setPendingPermissionModeBySession: sessionUi.setPendingPermissionModeBySession,
     setPendingSessionModelBySession: sessionUi.setPendingSessionModelBySession,
+    confirmLiveTurn: sessionUi.confirmLiveTurn,
     clearTurnTransientState: sessionUi.clearTurnTransientState,
   };
 }

--- a/apps/desktop/src/renderer/use-shell-live-turn.ts
+++ b/apps/desktop/src/renderer/use-shell-live-turn.ts
@@ -20,7 +20,7 @@ import { useDelayedFlag } from './use-delayed-flag';
  */
 export function useShellLiveTurn(options: {
   activeId: string | undefined;
-  /** Carries `runningTurnId` — the authority on a turn this renderer did not send. */
+  /** Carries `runningTurnIds` — the authority on turns this renderer did not send. */
   activeSession: SessionSummary | undefined;
   activeLiveTurn: LiveTurnProjection | undefined;
   liveTurnBySession: Record<string, LiveTurnProjection>;
@@ -76,7 +76,7 @@ export function useShellLiveTurn(options: {
   const turnActive = deriveTurnActive({
     turnPhase: activeTurnPhase,
     armedTurnId: activeLiveTurn?.turnId,
-    runningTurnId: activeSession?.runningTurnId,
+    runningTurnIds: activeSession?.runningTurnIds,
   });
   const modelWaitKind: ModelWaitKind = deriveModelWait({
     turnPhase: activeTurnPhase,

--- a/apps/desktop/src/renderer/use-shell-live-turn.ts
+++ b/apps/desktop/src/renderer/use-shell-live-turn.ts
@@ -3,7 +3,7 @@ import type { SessionSummary, ShellRunUpdate } from '@maka/core';
 import type { LiveTurnProjection, ToolActivityItem } from '@maka/ui';
 import type { ShellRunUpdatesBySession } from './shell-run-update-state';
 import { hasInFlightToolActivity } from './session-event-health';
-import { MODEL_CONTINUING_DELAY_MS, MODEL_PROCESSING_DELAY_MS, deriveModelWait, type ModelWaitKind } from './model-wait-state';
+import { MODEL_CONTINUING_DELAY_MS, MODEL_PROCESSING_DELAY_MS, deriveModelWait, deriveTurnActive, type ModelWaitKind } from './model-wait-state';
 import { useDelayedFlag } from './use-delayed-flag';
 
 /**
@@ -20,10 +20,11 @@ import { useDelayedFlag } from './use-delayed-flag';
  */
 export function useShellLiveTurn(options: {
   activeId: string | undefined;
+  /** Carries `runningTurnId` — the authority on a turn this renderer did not send. */
+  activeSession: SessionSummary | undefined;
   activeLiveTurn: LiveTurnProjection | undefined;
   liveTurnBySession: Record<string, LiveTurnProjection>;
   shellRunUpdatesBySession: ShellRunUpdatesBySession;
-  activeSession: SessionSummary | undefined;
 }): {
   activeShellRunUpdates: ShellRunUpdate[];
   activeStreaming: string;
@@ -34,12 +35,11 @@ export function useShellLiveTurn(options: {
   streamingSessionIds: Set<string>;
   liveTools: ToolActivityItem[];
   hasInFlightLiveTools: boolean;
-  turnInFlight: boolean;
-  sessionAwaitingModel: boolean;
+  turnActive: boolean;
   showProcessingIndicator: boolean;
   showContinuingIndicator: boolean;
 } {
-  const { activeId, activeLiveTurn, liveTurnBySession, shellRunUpdatesBySession, activeSession } = options;
+  const { activeId, activeSession, activeLiveTurn, liveTurnBySession, shellRunUpdatesBySession } = options;
   const activeShellRunUpdates = useMemo(
     () => activeId ? Object.values(shellRunUpdatesBySession[activeId] ?? {}) : [],
     [activeId, shellRunUpdatesBySession],
@@ -63,29 +63,35 @@ export function useShellLiveTurn(options: {
   const liveTools = useMemo(() => activeLiveTurn?.steps.flatMap((step) => step.tools) ?? [], [activeLiveTurn]);
   const hasInFlightLiveTools = useMemo(() => hasInFlightToolActivity(liveTools), [liveTools]);
 
-  // #646: the two turn-wait cues. `turnPhase` (armed at send, no lag; promoted to
-  // 'streamed' on the first content event) separates the connect-to-first-token
-  // wait from the later step-to-step lulls; the `status === 'running'` gate
-  // self-heals a backgrounded session whose terminal event was missed while
-  // inactive (its arm can't clear without the event). The rising-edge delays
-  // (useDelayedFlag) suppress a flash on fast turns / quick step hops.
+  // #646: the turn's phase drives both the Stop affordance and the two wait
+  // cues. `turnPhase` is armed at send with no lag and promoted to 'streamed'
+  // on the first content event, which is what separates the
+  // connect-to-first-token wait from the later step-to-step lulls; the
+  // rising-edge delays (useDelayedFlag) suppress a flash on fast turns.
+  //
+  // Stop / composer lock: see `deriveTurnActive` for why its two witnesses are
+  // ORed and never ANDed. Retiring a stale arm is `settledSessionTransientIds`'
+  // job, which covers backgrounded sessions too.
   const activeTurnPhase = activeLiveTurn?.terminal ? undefined : activeLiveTurn?.phase;
-  const turnInFlight = activeTurnPhase !== undefined;
+  const turnActive = deriveTurnActive({
+    turnPhase: activeTurnPhase,
+    armedTurnId: activeLiveTurn?.turnId,
+    runningTurnId: activeSession?.runningTurnId,
+  });
   const modelWaitKind: ModelWaitKind = deriveModelWait({
     turnPhase: activeTurnPhase,
     streamingText: activeStreaming,
     thinkingText: activeThinking,
     hasInFlightTools: hasInFlightLiveTools,
   });
-  const sessionAwaitingModel = activeSession?.status === 'running';
   // The prominent "正在处理…" first-token indicator (turn head only).
   const showProcessingIndicator = useDelayedFlag(
-    sessionAwaitingModel && modelWaitKind === 'processing',
+    modelWaitKind === 'processing',
     MODEL_PROCESSING_DELAY_MS,
   );
   // The calm "继续中…" hint for a mid-turn step-to-step lull (after content).
   const showContinuingIndicator = useDelayedFlag(
-    sessionAwaitingModel && modelWaitKind === 'continuing',
+    modelWaitKind === 'continuing',
     MODEL_CONTINUING_DELAY_MS,
   );
 
@@ -99,8 +105,7 @@ export function useShellLiveTurn(options: {
     streamingSessionIds,
     liveTools,
     hasInFlightLiveTools,
-    turnInFlight,
-    sessionAwaitingModel,
+    turnActive,
     showProcessingIndicator,
     showContinuingIndicator,
   };

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -268,20 +268,25 @@ export interface SessionSummary {
   blockedReason?: SessionBlockedReason;
   statusUpdatedAt?: number;
   /**
-   * The turn the runtime is running for this session right now, if any.
+   * The turns the runtime is running for this session right now. Omitted when
+   * there are none.
    *
-   * Projected from the live run, never persisted: "a run is in flight" is a
+   * Projected from the live runs, never persisted: "a run is in flight" is a
    * fact about the running process, so it must read false again after a crash.
    * `status` cannot serve that purpose — it is written to storage, so a crash
    * between a turn's end and its status write leaves `running` behind forever,
    * and it carries no turn identity, reading the same before a turn starts and
    * after it ends.
    *
+   * A set rather than one turn because a session can carry concurrent runs: a
+   * client asking "is anything OTHER than the turn I sent still running" cannot
+   * answer that from an arbitrary one of them.
+   *
    * Only populated where the runtime is in a position to know: session LISTS
    * come from the authority holding the runs. A summary returned by a mutation
    * (rename, model change) describes the header alone and omits it.
    */
-  runningTurnId?: string;
+  runningTurnIds?: string[];
   parentSessionId?: string;
   branchOfTurnId?: string;
   subagentParent?: SubagentSessionParent;
@@ -635,10 +640,14 @@ export interface SessionChangedEvent {
    * turn identity, and `status` reads the same before a turn starts and after
    * it ends.
    *
-   * Emitter obligation: any change caused by ONE turn — its start, its failure
-   * to start, its end — must name it. Changes with no single turn behind them
-   * (a rename, a catalog migration, a session-wide setting) leave it unset, and
-   * a client must not read them as an answer about any turn.
+   * Emitter obligation, and its exact edge: a change about a turn some CLIENT
+   * may be waiting on — one it submitted, so it holds a local claim until it
+   * hears back — must name that turn. Its start, its refusal to start, and its
+   * end all qualify. Changes with no single turn behind them (a rename, a
+   * catalog migration) leave it unset, as do turns no client submitted and none
+   * is waiting on — a linked child agent's own turns, for instance, which are
+   * reported by `SessionSummary.runningTurnIds` instead. A client must never
+   * read an unset change as an answer about a turn it is waiting on.
    */
   turnId?: string;
   ts: number;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -267,6 +267,21 @@ export interface SessionSummary {
   status: SessionStatus;
   blockedReason?: SessionBlockedReason;
   statusUpdatedAt?: number;
+  /**
+   * The turn the runtime is running for this session right now, if any.
+   *
+   * Projected from the live run, never persisted: "a run is in flight" is a
+   * fact about the running process, so it must read false again after a crash.
+   * `status` cannot serve that purpose — it is written to storage, so a crash
+   * between a turn's end and its status write leaves `running` behind forever,
+   * and it carries no turn identity, reading the same before a turn starts and
+   * after it ends.
+   *
+   * Only populated where the runtime is in a position to know: session LISTS
+   * come from the authority holding the runs. A summary returned by a mutation
+   * (rename, model change) describes the header alone and omits it.
+   */
+  runningTurnId?: string;
   parentSessionId?: string;
   branchOfTurnId?: string;
   subagentParent?: SubagentSessionParent;
@@ -612,6 +627,20 @@ export interface SessionChangedEvent {
   sessionId?: string;
   connectionSlug?: string;
   modelId?: string;
+  /**
+   * The turn this change is ABOUT, when the change has a turn to name.
+   *
+   * Naming the turn is what makes a notification a causal answer to a specific
+   * send rather than a bare invalidation: the session fields alone carry no
+   * turn identity, and `status` reads the same before a turn starts and after
+   * it ends.
+   *
+   * Emitter obligation: any change caused by ONE turn — its start, its failure
+   * to start, its end — must name it. Changes with no single turn behind them
+   * (a rename, a catalog migration, a session-wide setting) leave it unset, and
+   * a client must not read them as an answer about any turn.
+   */
+  turnId?: string;
   ts: number;
 }
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -118,25 +118,25 @@ import type { AgentGraphRunnableIntent } from '../stream-graph-readiness.js';
 describe('SessionManager running-turn projection', () => {
   test('names the turn a session is running, without persisting it', async () => {
     const store = new MemorySessionStore();
-    const runningTurnBySession = new Map<string, string>();
+    const runningTurnBySession = new Map<string, string[]>();
     const manager = new SessionManager({
       store,
       backends: new BackendRegistry(),
       newId: nextId(),
       now: nextNow(1),
       runtimeKernel: {
-        runningTurnId: (sessionId: string) => runningTurnBySession.get(sessionId),
+        runningTurnIds: (sessionId: string) => runningTurnBySession.get(sessionId) ?? [],
       } as never,
     });
     const idle = await manager.createSession(makeInput({ name: 'Idle' }));
     const busy = await manager.createSession(makeInput({ name: 'Busy' }));
-    runningTurnBySession.set(busy.id, 'turn-live');
+    runningTurnBySession.set(busy.id, ['turn-live']);
 
     const listed = await manager.listSessions();
     const byId = new Map(listed.map((session) => [session.id, session]));
 
-    expect(byId.get(busy.id)?.runningTurnId).toEqual('turn-live');
-    expect(byId.get(idle.id)?.runningTurnId).toEqual(undefined);
+    expect(byId.get(busy.id)?.runningTurnIds).toEqual(['turn-live']);
+    expect(byId.get(idle.id)?.runningTurnIds).toEqual(undefined);
 
     // Nothing about it reached storage, which is what makes a restart honest.
     expect(
@@ -147,7 +147,7 @@ describe('SessionManager running-turn projection', () => {
     // and no crash-recovery pass in between.
     runningTurnBySession.delete(busy.id);
     const after = await manager.listSessions();
-    expect(after.find((session) => session.id === busy.id)?.runningTurnId).toEqual(undefined);
+    expect(after.find((session) => session.id === busy.id)?.runningTurnIds).toEqual(undefined);
   });
 
   test('lists sessions unchanged when the kernel cannot report runs', async () => {
@@ -164,7 +164,7 @@ describe('SessionManager running-turn projection', () => {
     const listed = await manager.listSessions();
 
     expect(listed.map((entry) => entry.id)).toEqual([session.id]);
-    expect(listed[0]?.runningTurnId).toEqual(undefined);
+    expect(listed[0]?.runningTurnIds).toEqual(undefined);
   });
 });
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -108,6 +108,66 @@ import {
 } from '../stream-graph-admission.js';
 import type { AgentGraphRunnableIntent } from '../stream-graph-readiness.js';
 
+/**
+ * "A turn is running" is a fact about the live process, so the read model takes
+ * it from the run rather than from the persisted status. The status cannot
+ * serve: it is written only at the END of `AgentRun.begin`, it reads the same
+ * before a turn starts and after it ends, and a crash between a turn's end and
+ * its status write leaves `running` in storage forever.
+ */
+describe('SessionManager running-turn projection', () => {
+  test('names the turn a session is running, without persisting it', async () => {
+    const store = new MemorySessionStore();
+    const runningTurnBySession = new Map<string, string>();
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      newId: nextId(),
+      now: nextNow(1),
+      runtimeKernel: {
+        runningTurnId: (sessionId: string) => runningTurnBySession.get(sessionId),
+      } as never,
+    });
+    const idle = await manager.createSession(makeInput({ name: 'Idle' }));
+    const busy = await manager.createSession(makeInput({ name: 'Busy' }));
+    runningTurnBySession.set(busy.id, 'turn-live');
+
+    const listed = await manager.listSessions();
+    const byId = new Map(listed.map((session) => [session.id, session]));
+
+    expect(byId.get(busy.id)?.runningTurnId).toEqual('turn-live');
+    expect(byId.get(idle.id)?.runningTurnId).toEqual(undefined);
+
+    // Nothing about it reached storage, which is what makes a restart honest.
+    expect(
+      ((await store.readHeader(busy.id)) as unknown as Record<string, unknown>).runningTurnId,
+    ).toEqual(undefined);
+
+    // The run ends; the very next list stops naming it, with no status write
+    // and no crash-recovery pass in between.
+    runningTurnBySession.delete(busy.id);
+    const after = await manager.listSessions();
+    expect(after.find((session) => session.id === busy.id)?.runningTurnId).toEqual(undefined);
+  });
+
+  test('lists sessions unchanged when the kernel cannot report runs', async () => {
+    const store = new MemorySessionStore();
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      newId: nextId(),
+      now: nextNow(1),
+      runtimeKernel: {} as never,
+    });
+    const session = await manager.createSession(makeInput({ name: 'Only' }));
+
+    const listed = await manager.listSessions();
+
+    expect(listed.map((entry) => entry.id)).toEqual([session.id]);
+    expect(listed[0]?.runningTurnId).toEqual(undefined);
+  });
+});
+
 describe('SessionManager child-session read model', () => {
   test('lists typed child sessions without treating branches as children', async () => {
     const store = new MemorySessionStore();

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -154,6 +154,12 @@ export interface RuntimeKernelLike {
   /** Take back every queued message (both queues) as one `\n\n`-joined string. */
   retractQueue(sessionId: string): string;
   hasActiveRuns(sessionId: string): boolean;
+  /**
+   * The turn of a run in flight for this session, if any. The same fact
+   * `hasActiveRuns` reports, named — which is what lets a client tell a turn
+   * that has not started yet from one that already ended.
+   */
+  runningTurnId?(sessionId: string): string | undefined;
   hasActiveRun?(sessionId: string, runId: string, turnId?: string): boolean;
   updateCachedHeader(sessionId: string, header: SessionHeader): void;
   invalidateBackend(sessionId: string): Promise<void>;
@@ -2396,6 +2402,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
 
   hasActiveRuns(sessionId: string): boolean {
     return this.backendGenerationsFor(sessionId).some((active) => active.activeRuns.size > 0);
+  }
+
+  runningTurnId(sessionId: string): string | undefined {
+    for (const active of this.backendGenerationsFor(sessionId)) {
+      for (const run of active.activeRuns.values()) return run.turnId;
+    }
+    return undefined;
   }
 
   hasActiveRun(sessionId: string, runId: string, turnId?: string): boolean {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -155,11 +155,15 @@ export interface RuntimeKernelLike {
   retractQueue(sessionId: string): string;
   hasActiveRuns(sessionId: string): boolean;
   /**
-   * The turn of a run in flight for this session, if any. The same fact
+   * The turns of the runs in flight for this session. The same fact
    * `hasActiveRuns` reports, named — which is what lets a client tell a turn
    * that has not started yet from one that already ended.
+   *
+   * A set, not one turn: a session can carry concurrent runs, and a client
+   * asking "is anything OTHER than my own turn running" cannot answer that
+   * from an arbitrary one of them.
    */
-  runningTurnId?(sessionId: string): string | undefined;
+  runningTurnIds?(sessionId: string): string[];
   hasActiveRun?(sessionId: string, runId: string, turnId?: string): boolean;
   updateCachedHeader(sessionId: string, header: SessionHeader): void;
   invalidateBackend(sessionId: string): Promise<void>;
@@ -2404,11 +2408,14 @@ export class RuntimeKernel implements RuntimeKernelLike {
     return this.backendGenerationsFor(sessionId).some((active) => active.activeRuns.size > 0);
   }
 
-  runningTurnId(sessionId: string): string | undefined {
+  runningTurnIds(sessionId: string): string[] {
+    const turnIds: string[] = [];
     for (const active of this.backendGenerationsFor(sessionId)) {
-      for (const run of active.activeRuns.values()) return run.turnId;
+      for (const run of active.activeRuns.values()) {
+        if (!turnIds.includes(run.turnId)) turnIds.push(run.turnId);
+      }
     }
-    return undefined;
+    return turnIds;
   }
 
   hasActiveRun(sessionId: string, runId: string, turnId?: string): boolean {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -885,13 +885,22 @@ export class SessionManager {
    * live run is the fact, so a client can name what is running and — because
    * nothing survives the process — a restart reports the truth by itself.
    */
+  /**
+   * The turns this session is running right now. Same live fact `listSessions`
+   * projects, for callers that need it about one session — notably to name the
+   * turns a change is about.
+   */
+  runningTurnIds(sessionId: string): string[] {
+    return this.runtimeKernel.runningTurnIds?.(sessionId) ?? [];
+  }
+
   async listSessions(filter?: SessionListFilter): Promise<SessionSummary[]> {
     const sessions = await this.deps.store.list(filter);
-    const runningTurnId = this.runtimeKernel.runningTurnId?.bind(this.runtimeKernel);
-    if (!runningTurnId) return sessions;
+    const runningTurnIds = this.runtimeKernel.runningTurnIds?.bind(this.runtimeKernel);
+    if (!runningTurnIds) return sessions;
     return sessions.map((session) => {
-      const turnId = runningTurnId(session.id);
-      return turnId === undefined ? session : { ...session, runningTurnId: turnId };
+      const turnIds = runningTurnIds(session.id);
+      return turnIds.length === 0 ? session : { ...session, runningTurnIds: turnIds };
     });
   }
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -877,8 +877,22 @@ export class SessionManager {
     return headerToSummary(header);
   }
 
+  /**
+   * Sessions plus the turn each one is running right now. The persisted status
+   * cannot carry that: it is written only at the END of `AgentRun.begin`, it
+   * reads the same before a turn starts and after it ends, and a crash between
+   * a turn's end and its status write leaves `running` behind for good. The
+   * live run is the fact, so a client can name what is running and — because
+   * nothing survives the process — a restart reports the truth by itself.
+   */
   async listSessions(filter?: SessionListFilter): Promise<SessionSummary[]> {
-    return this.deps.store.list(filter);
+    const sessions = await this.deps.store.list(filter);
+    const runningTurnId = this.runtimeKernel.runningTurnId?.bind(this.runtimeKernel);
+    if (!runningTurnId) return sessions;
+    return sessions.map((session) => {
+      const turnId = runningTurnId(session.id);
+      return turnId === undefined ? session : { ...session, runningTurnId: turnId };
+    });
   }
 
   async listChildSessions(parentSessionId: string): Promise<SessionSummary[]> {

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -3,11 +3,87 @@ import { describe, it } from 'node:test';
 import {
   applyLiveTurnEvent,
   armLiveTurn,
+  confirmLiveTurn,
   reconcileTerminalLiveTurn,
   settleLiveTurnStep,
   type LiveTurnProjection,
 } from '../live-turn-projection.js';
 import { overlayLiveTurn, type ToolActivityItem } from '../materialize.js';
+
+// A client that just sent cannot read "has my turn started" off session status:
+// it is the same before the turn starts and after it ends. The arm carries
+// `unconfirmed` until the authority says something about THAT turn, which is
+// what stops a snapshot taken before the send landed from retiring it.
+describe('the unconfirmed claim an arm carries', () => {
+  it('is set at arm and dropped by an answer naming the same turn', () => {
+    const armed = armLiveTurn('turn-1');
+    assert.equal(armed.unconfirmed, true);
+
+    const confirmed = confirmLiveTurn(armed, 'turn-1');
+    assert.equal(confirmed?.unconfirmed, undefined);
+    assert.equal(confirmed?.turnId, 'turn-1');
+    assert.equal(confirmed?.phase, 'waiting', 'confirming is not the same as streaming');
+  });
+
+  // Another client's turn, or an automation's, says nothing about this send.
+  it('survives an answer that names a different turn', () => {
+    const armed = armLiveTurn('turn-mine');
+
+    assert.equal(confirmLiveTurn(armed, 'turn-theirs'), armed);
+  });
+
+  // A late answer about a turn this arm has already replaced must not confirm
+  // the newer send.
+  it('survives a late answer about the turn the arm moved past', () => {
+    const rearmed = armLiveTurn('turn-2');
+
+    assert.equal(confirmLiveTurn(rearmed, 'turn-1'), rearmed);
+  });
+
+  it('is identity-preserving when there is nothing to confirm', () => {
+    const confirmed = confirmLiveTurn(armLiveTurn('turn-1'), 'turn-1')!;
+
+    assert.equal(confirmLiveTurn(confirmed, 'turn-1'), confirmed);
+  });
+
+  // Any event about the turn is itself the authority answering, so the claim
+  // must not outlive the first one — otherwise a turn that ended while its
+  // stream wasn't followed could never be settled.
+  it('is dropped by the turn\'s own events, not just by an explicit answer', () => {
+    const streamed = applyLiveTurnEvent(armLiveTurn('turn-1'), {
+      type: 'text_delta',
+      id: 'event-1',
+      turnId: 'turn-1',
+      messageId: 'step-1',
+      ts: 100,
+      text: '你',
+    });
+
+    assert.equal(streamed.unconfirmed, undefined);
+  });
+
+  it('is dropped when the turn terminates', () => {
+    const streamed = applyLiveTurnEvent(armLiveTurn('turn-1'), {
+      type: 'text_delta',
+      id: 'event-1',
+      turnId: 'turn-1',
+      messageId: 'step-1',
+      ts: 100,
+      text: '你',
+    });
+    const rearmed = { ...streamed, unconfirmed: true as const };
+    const done = applyLiveTurnEvent(rearmed, {
+      type: 'complete',
+      id: 'event-2',
+      turnId: 'turn-1',
+      ts: 200,
+      stopReason: 'end_turn',
+    });
+
+    assert.equal(done?.terminal, true);
+    assert.equal(done?.unconfirmed, undefined);
+  });
+});
 
 describe('applyLiveTurnEvent', () => {
   it('moves an armed turn from waiting to streamed on its first content event', () => {

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -34,6 +34,18 @@ export interface LiveTurnProjection {
   turnId: string;
   phase: 'waiting' | 'streamed';
   terminal?: true;
+  /**
+   * Set by `armLiveTurn` and cleared by the first word the authority says about
+   * this turn (`confirmLiveTurn`, or any event carrying the same turnId).
+   *
+   * A client that just sent cannot tell "the authority has not reached my turn
+   * yet" from "my turn is over" by reading session status: it reads the same
+   * before a turn starts and after it ends. So a snapshot taken before the send
+   * landed would retire the arm the send just placed. This bit says the arm is
+   * still waiting for its answer, which is what keeps such a snapshot from
+   * settling it. Dropped for good once the answer arrives.
+   */
+  unconfirmed?: true;
   providerRetry?: ProviderRetryEvent;
   steps: LiveTurnStepProjection[];
 }
@@ -66,7 +78,27 @@ function appendContentKind(
 }
 
 export function armLiveTurn(turnId: string): LiveTurnProjection {
-  return { turnId, phase: 'waiting', steps: [] };
+  return { turnId, phase: 'waiting', steps: [], unconfirmed: true };
+}
+
+/** Drop the `unconfirmed` claim; identity-preserving when there is none. */
+function confirmed(projection: LiveTurnProjection): LiveTurnProjection {
+  if (!projection.unconfirmed) return projection;
+  const { unconfirmed: _unconfirmed, ...rest } = projection;
+  return rest;
+}
+
+/**
+ * The authority answered about `turnId`: clear the arm's pending claim so a
+ * later snapshot may retire it. A different turn's answer says nothing about
+ * this one, so the projection is returned unchanged (same reference).
+ */
+export function confirmLiveTurn(
+  current: LiveTurnProjection | undefined,
+  turnId: string,
+): LiveTurnProjection | undefined {
+  if (!current || current.turnId !== turnId) return current;
+  return confirmed(current);
 }
 
 export function applyLiveTurnEvent(
@@ -88,19 +120,19 @@ export function applyLiveTurnEvent(
     const prior = current?.turnId === event.turnId
       ? current
       : { turnId: event.turnId, phase: 'waiting' as const, steps: [] };
-    return { ...prior, providerRetry: event };
+    return { ...confirmed(prior), providerRetry: event };
   }
   if (event.type === 'error' || event.type === 'abort') {
     if (!current || current.turnId !== event.turnId) return current;
     const steps = terminalizeLiveSteps(current.steps);
     if (steps.length === 0) return undefined;
-    const { providerRetry: _providerRetry, ...withoutRetry } = current;
+    const { providerRetry: _providerRetry, ...withoutRetry } = confirmed(current);
     return { ...withoutRetry, terminal: true, steps };
   }
   if (event.type === 'complete') {
     if (!current || current.turnId !== event.turnId) return current;
     if (current.steps.length === 0) return undefined;
-    const { providerRetry: _providerRetry, ...withoutRetry } = current;
+    const { providerRetry: _providerRetry, ...withoutRetry } = confirmed(current);
     return {
       ...withoutRetry,
       terminal: true,
@@ -121,7 +153,7 @@ export function applyLiveTurnEvent(
   const prior = current?.turnId === event.turnId
     ? current
     : { turnId: event.turnId, phase: 'streamed' as const, steps: [] };
-  const { providerRetry: _providerRetry, ...priorWithoutRetry } = prior;
+  const { providerRetry: _providerRetry, ...priorWithoutRetry } = confirmed(prior);
   const messageEvent = event.type === 'thinking_delta'
     || event.type === 'thinking_complete'
     || event.type === 'text_delta'


### PR DESCRIPTION
## Summary

Sending a message did not show Stop or "正在处理…" until the reply began, and the state flickered mid-turn.

"Is a turn running" is a fact about the live process, but the UI read it off `SessionHeader.status`, which is three steps removed from that fact:

- it is written only at the END of `AgentRun.begin`, and nothing announced it — no SessionEvent marks a turn's START, only its end;
- it carries no turn identity and reads the same (`active`) before a turn starts and after it ends;
- it is persisted, so a crash between a turn's end and its status write leaves `running` behind for good.

The renderer armed a live-turn projection at send with no lag, then ANDed it with that status, so the send opened nothing until a status round-trip landed. Worse, any session list resolving inside that window looked byte-identical to one taken after the turn ended, so `settledSessionTransientIds` retired the arm outright — the first content event then rebuilt it as `'streamed'`, silently downgrading the prominent "正在处理…" to the calm "继续中…".

This replaces the AND with two witnesses that cannot veto each other:

- **The local arm** answers for the turn this renderer sent. It carries an `unconfirmed` bit until the authority says something about that exact turn, which is what stops a snapshot older than the send from retiring it. `onRunStarted` now broadcasts a `sessions:changed` naming the turn — the earliest seam at which the run is live and anything can say so — and `SessionChangedEvent.turnId` makes it an answer to a specific send rather than a bare invalidation.
- **`SessionSummary.runningTurnId`** answers for a turn this renderer did not send: another client, an automation, or one still running across a reload, none of which could show Stop before. It is projected from the live run and never persisted, so a restart reports the truth by itself rather than inheriting a stuck `running`. It is read only when it names a turn other than the arm's — for the arm's own turn the local projection knows more, having seen the terminal event first.

Also removes `markSessionRunningOptimistic` and its four rollback sites: the optimistic flip lived in the wholesale-replaced session list, so any refresh erased it, and the rollback could revert a genuinely running status.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean.
- `@maka/core` 740 pass, `@maka/ui` 262 pass, `@maka/desktop` 1361 pass — 0 fail.
- `@maka/runtime` 2760 pass / 4 fail. The 4 are pre-existing and unrelated (`builtin-tools` path containment, failing identically on a clean `main` checkout: macOS resolves the temp root as `/private/var/...` while the test passes `/var/...`).
- Playwright E2E: 58/58 pass.
- Not run: no timing measurement against a real slow provider. The fake backend answers faster than the 200ms rising-edge debounce, so the debounce path is covered by unit tests with an injected scheduler rather than end-to-end.

New coverage for the seams this depends on:

- the `unconfirmed` claim's full lifecycle, including that any event about the turn clears it (`@maka/ui`);
- the gate itself — that the local arm alone opens Stop, that a snapshot predating the run does not close it, and that a stale snapshot cannot revive the arm's own finished turn;
- the run-started broadcast naming the turn the send was made with, emitted before the revision commit and surviving a commit that throws;
- the real subscription handler routing a turn-named change to the arm, and ignoring one that names no turn;
- the runtime projection naming a running turn, writing nothing to storage, and dropping it the moment the run ends.

## Review focus

`SessionChangedEvent.turnId` and `SessionSummary.runningTurnId` are contract additions in `packages/core`. Both are optional, and the emitter obligation for each is stated at its declaration. `runningTurnId` is populated on session LISTS only — a summary returned by a mutation describes the header alone.
