### PR TITLE
perf(desktop): stop idle-session event-health polling from re-rendering the whole shell

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -86,9 +86,10 @@ type RendererMakaStub = {
 type FakeClock = {
   documentListeners: Map<string, Set<() => void>>;
   intervals: Map<number, { callback: () => void; delayMs: number }>;
-  intervalsRegistered: number;
   now: number;
 };
+
+const FAKE_CLOCK_START = 1_000;
 
 let fakeClock: FakeClock = createFakeClock();
 
@@ -96,8 +97,7 @@ function createFakeClock(): FakeClock {
   return {
     documentListeners: new Map(),
     intervals: new Map(),
-    intervalsRegistered: 0,
-    now: 1_000,
+    now: FAKE_CLOCK_START,
   };
 }
 
@@ -107,6 +107,10 @@ function advanceFakeClock(byMs: number): void {
 
 function runFakeIntervals(): void {
   for (const { callback } of [...fakeClock.intervals.values()]) callback();
+}
+
+function dispatchFakeDocumentEvent(type: string): void {
+  for (const listener of [...(fakeClock.documentListeners.get(type) ?? [])]) listener();
 }
 
 const cleanupTasks: Array<() => void> = [];
@@ -325,21 +329,51 @@ describe('AppShell effect stability contract', () => {
       }),
     );
 
-    assert.equal(fakeClock.intervalsRegistered, 0, 'an idle session must not arm a polling interval');
+    assert.equal(fakeClock.intervals.size, 0, 'an idle session must not arm a polling interval');
     assert.equal(
       fakeClock.documentListeners.get('visibilitychange')?.size ?? 0,
       0,
       'an idle session must not listen for visibility changes',
     );
-    assert.equal(writes, 1, 'the one-off transition to a closed stream is still recorded');
-    assert.equal(healthRef.current['session-1']?.status, 'closed');
+    assert.equal(writes, 0, 'an idle session has nothing to observe, so it must not probe at all');
 
     advanceFakeClock(60_000);
     await act(async () => {
       runFakeIntervals();
     });
 
-    assert.equal(writes, 1, 'a settled idle session must not keep writing health snapshots');
+    assert.equal(writes, 0, 'an idle session must stay silent as time passes');
+  });
+
+  it('re-arms when an idle session starts running and disarms once it settles', async () => {
+    const effects = await appShellEffects;
+    const root = installReactRenderer(createCapturedSubscriptions());
+    const healthRef = createSessionHealthRef();
+    const renderWithStatus = (sessionStatus: SessionStatus) =>
+      render(
+        root,
+        createElement(SessionEventHealthPollingProbe, {
+          activeId: 'session-1',
+          effects,
+          healthRef,
+          sessionStatus,
+        }),
+      );
+
+    await renderWithStatus('active');
+    assert.equal(fakeClock.intervals.size, 0);
+
+    await renderWithStatus('running');
+    assert.equal(fakeClock.intervals.size, 1, 'a session that starts running must re-arm on its own');
+    assert.equal(fakeClock.documentListeners.get('visibilitychange')?.size, 1);
+
+    await renderWithStatus('active');
+    assert.equal(fakeClock.intervals.size, 0, 'settling back to idle must disarm the interval');
+    assert.equal(
+      fakeClock.documentListeners.get('visibilitychange')?.size ?? 0,
+      0,
+      'settling back to idle must drop the visibility listener',
+    );
   });
 
   it('keeps polling a running session and refreshes once its stream goes stale', async () => {
@@ -365,8 +399,7 @@ describe('AppShell effect stability contract', () => {
       }),
     );
 
-    assert.equal(fakeClock.intervalsRegistered, 1, 'a running session must poll its event stream');
-    assert.equal(fakeClock.documentListeners.get('visibilitychange')?.size, 1);
+    assert.equal(fakeClock.intervals.size, 1, 'a running session must poll its event stream');
     assert.equal(healthRef.current['session-1']?.status, 'connected');
 
     advanceFakeClock(16_000);
@@ -377,6 +410,20 @@ describe('AppShell effect stability contract', () => {
     assert.equal(healthRef.current['session-1']?.status, 'stale');
     assert.equal(refreshedSessions, 1);
     assert.equal(refreshedMessages, 1);
+
+    // Returning to a backgrounded window must probe too, not merely register a
+    // listener — assert the probe ran rather than that the handler exists.
+    const checkedAtBeforeReturn = healthRef.current['session-1']?.checkedAt;
+    advanceFakeClock(1_000);
+    await act(async () => {
+      dispatchFakeDocumentEvent('visibilitychange');
+    });
+
+    assert.notEqual(
+      healthRef.current['session-1']?.checkedAt,
+      checkedAtBeforeReturn,
+      'becoming visible again must re-check the stream',
+    );
   });
 
   it('preserves a known keep-awake snapshot when a later refresh fails', async () => {
@@ -752,14 +799,16 @@ function createBootstrapRefs() {
   };
 }
 
-function createSessionHealthRef(): RefBox<Record<string, SessionEventStreamSnapshot>> {
+function createSessionHealthRef(
+  subscribedAt = FAKE_CLOCK_START,
+): RefBox<Record<string, SessionEventStreamSnapshot>> {
   return {
     current: {
       'session-1': {
         sessionId: 'session-1',
         status: 'connected',
-        subscribedAt: fakeClock.now,
-        checkedAt: fakeClock.now,
+        subscribedAt,
+        checkedAt: subscribedAt,
       },
     },
   };
@@ -890,7 +939,6 @@ function installFakeDom(): void {
     setInterval: (callback: () => void, delayMs: number) => {
       const id = nextIntervalId++;
       fakeClock.intervals.set(id, { callback, delayMs });
-      fakeClock.intervalsRegistered += 1;
       return id;
     },
     clearInterval: (id: number) => {

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -8,6 +8,9 @@ import type {
   PlanReminder,
   ProjectRecord,
   SessionEvent,
+  SessionEventStreamSnapshot,
+  SessionStatus,
+  SessionSummary,
   StoredMessage,
 } from '@maka/core';
 import { build } from 'esbuild';
@@ -23,7 +26,7 @@ type RefBox<T> = { current: T };
 type RendererWindow = Window & typeof globalThis & { maka: RendererMakaStub };
 type AppShellEffectsModule = Pick<
   typeof AppShellEffects,
-  'useActiveSessionEvents' | 'useAppShellBootstrapSubscriptions'
+  'useActiveSessionEvents' | 'useAppShellBootstrapSubscriptions' | 'useSessionEventHealthPolling'
 >;
 type KeepSystemAwakeModule = Pick<typeof KeepSystemAwake, 'useKeepSystemAwake'>;
 type ProjectContextModule = Pick<typeof ProjectContext, 'useAppShellProjectContext'>;
@@ -76,6 +79,35 @@ type RendererMakaStub = {
     }): Promise<{ settings: { system: { keepSystemAwake: boolean } } }>;
   };
 };
+
+// The fake DOM drives the polling contract below: `useSessionEventHealthPolling`
+// arms `window.setInterval` and a `visibilitychange` listener, so both have to be
+// observable rather than silently swallowed by a no-op stub.
+type FakeClock = {
+  documentListeners: Map<string, Set<() => void>>;
+  intervals: Map<number, { callback: () => void; delayMs: number }>;
+  intervalsRegistered: number;
+  now: number;
+};
+
+let fakeClock: FakeClock = createFakeClock();
+
+function createFakeClock(): FakeClock {
+  return {
+    documentListeners: new Map(),
+    intervals: new Map(),
+    intervalsRegistered: 0,
+    now: 1_000,
+  };
+}
+
+function advanceFakeClock(byMs: number): void {
+  fakeClock.now += byMs;
+}
+
+function runFakeIntervals(): void {
+  for (const { callback } of [...fakeClock.intervals.values()]) callback();
+}
 
 const cleanupTasks: Array<() => void> = [];
 
@@ -272,6 +304,79 @@ describe('AppShell effect stability contract', () => {
     });
 
     assert.deepEqual(navSections, ['automations']);
+  });
+
+  it('does not arm event-health polling for an idle active session', async () => {
+    const effects = await appShellEffects;
+    const root = installReactRenderer(createCapturedSubscriptions());
+    const healthRef = createSessionHealthRef();
+    let writes = 0;
+
+    await render(
+      root,
+      createElement(SessionEventHealthPollingProbe, {
+        activeId: 'session-1',
+        effects,
+        healthRef,
+        onHealthWrite: () => {
+          writes += 1;
+        },
+        sessionStatus: 'active',
+      }),
+    );
+
+    assert.equal(fakeClock.intervalsRegistered, 0, 'an idle session must not arm a polling interval');
+    assert.equal(
+      fakeClock.documentListeners.get('visibilitychange')?.size ?? 0,
+      0,
+      'an idle session must not listen for visibility changes',
+    );
+    assert.equal(writes, 1, 'the one-off transition to a closed stream is still recorded');
+    assert.equal(healthRef.current['session-1']?.status, 'closed');
+
+    advanceFakeClock(60_000);
+    await act(async () => {
+      runFakeIntervals();
+    });
+
+    assert.equal(writes, 1, 'a settled idle session must not keep writing health snapshots');
+  });
+
+  it('keeps polling a running session and refreshes once its stream goes stale', async () => {
+    const effects = await appShellEffects;
+    const root = installReactRenderer(createCapturedSubscriptions());
+    const healthRef = createSessionHealthRef();
+    let refreshedMessages = 0;
+    let refreshedSessions = 0;
+
+    await render(
+      root,
+      createElement(SessionEventHealthPollingProbe, {
+        activeId: 'session-1',
+        effects,
+        healthRef,
+        onRefreshMessages: () => {
+          refreshedMessages += 1;
+        },
+        onRefreshSessions: () => {
+          refreshedSessions += 1;
+        },
+        sessionStatus: 'running',
+      }),
+    );
+
+    assert.equal(fakeClock.intervalsRegistered, 1, 'a running session must poll its event stream');
+    assert.equal(fakeClock.documentListeners.get('visibilitychange')?.size, 1);
+    assert.equal(healthRef.current['session-1']?.status, 'connected');
+
+    advanceFakeClock(16_000);
+    await act(async () => {
+      runFakeIntervals();
+    });
+
+    assert.equal(healthRef.current['session-1']?.status, 'stale');
+    assert.equal(refreshedSessions, 1);
+    assert.equal(refreshedMessages, 1);
   });
 
   it('preserves a known keep-awake snapshot when a later refresh fails', async () => {
@@ -492,6 +597,41 @@ function ActiveSessionEventProbe(props: {
   return null;
 }
 
+function SessionEventHealthPollingProbe(props: {
+  activeId?: string;
+  effects: AppShellEffectsModule;
+  healthRef: RefBox<Record<string, SessionEventStreamSnapshot>>;
+  onHealthWrite?(): void;
+  onRefreshMessages?(): void;
+  onRefreshSessions?(): void;
+  sessionStatus?: SessionStatus;
+}) {
+  props.effects.useSessionEventHealthPolling({
+    activeId: props.activeId,
+    activeInteraction: undefined,
+    activeSession: props.sessionStatus
+      ? ({ id: props.activeId, status: props.sessionStatus } as SessionSummary)
+      : undefined,
+    activeStreamingLive: false,
+    hasInFlightLiveTools: false,
+    refreshMessages: async () => {
+      props.onRefreshMessages?.();
+      return true;
+    },
+    refreshSessions: async () => {
+      props.onRefreshSessions?.();
+      return [];
+    },
+    sessionEventHealthBySessionRef: props.healthRef,
+    // Mirrors the real controller, which syncs the ref inside `replaceState`.
+    setSessionEventHealthBySession: (updater) => {
+      props.onHealthWrite?.();
+      props.healthRef.current = updater(props.healthRef.current);
+    },
+  });
+  return null;
+}
+
 function KeepSystemAwakeProbe(props: {
   controller: KeepSystemAwakeModule;
   onSnapshot(snapshot: boolean | undefined): void;
@@ -612,6 +752,19 @@ function createBootstrapRefs() {
   };
 }
 
+function createSessionHealthRef(): RefBox<Record<string, SessionEventStreamSnapshot>> {
+  return {
+    current: {
+      'session-1': {
+        sessionId: 'session-1',
+        status: 'connected',
+        subscribedAt: fakeClock.now,
+        checkedAt: fakeClock.now,
+      },
+    },
+  };
+}
+
 function createPlanReminder(): PlanReminder {
   return {
     id: 'reminder-1',
@@ -726,14 +879,30 @@ function installFakeDom(): void {
     IS_REACT_ACT_ENVIRONMENT?: boolean;
     }
   ).IS_REACT_ACT_ENVIRONMENT;
+  const previousDateNow = Date.now;
+  fakeClock = createFakeClock();
+  let nextIntervalId = 1;
   const fakeDocument = createFakeDocument();
   const fakeWindow = {
     document: fakeDocument,
     addEventListener: () => {},
     removeEventListener: () => {},
+    setInterval: (callback: () => void, delayMs: number) => {
+      const id = nextIntervalId++;
+      fakeClock.intervals.set(id, { callback, delayMs });
+      fakeClock.intervalsRegistered += 1;
+      return id;
+    },
+    clearInterval: (id: number) => {
+      fakeClock.intervals.delete(id);
+    },
     HTMLElement: class HTMLElement {},
     HTMLIFrameElement: class HTMLIFrameElement {},
   } as unknown as RendererWindow;
+  Date.now = () => fakeClock.now;
+  cleanupTasks.push(() => {
+    Date.now = previousDateNow;
+  });
   Object.defineProperty(fakeDocument, 'defaultView', { value: fakeWindow });
   globalThis.document = fakeDocument;
   globalThis.window = fakeWindow;
@@ -754,8 +923,15 @@ function installFakeDom(): void {
 function createFakeDocument(): Document {
   const fakeDocument = {
     nodeType: 9,
-    addEventListener: () => {},
-    removeEventListener: () => {},
+    visibilityState: 'visible',
+    addEventListener(type: string, listener: () => void) {
+      const listeners = fakeClock.documentListeners.get(type) ?? new Set<() => void>();
+      listeners.add(listener);
+      fakeClock.documentListeners.set(type, listeners);
+    },
+    removeEventListener(type: string, listener: () => void) {
+      fakeClock.documentListeners.get(type)?.delete(listener);
+    },
     createElement(tagName: string) {
       return new FakeElement(tagName, fakeDocument as unknown as Document);
     },

--- a/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import type { SandboxBoundaryRequestEvent, SessionSummary } from '@maka/core';
+import type { SandboxBoundaryRequestEvent, SessionEventStreamSnapshot, SessionSummary } from '@maka/core';
 import { armLiveTurn } from '@maka/ui';
 import { settledSessionTransientIds } from '../../renderer/settled-session-transients.js';
 import {
@@ -27,6 +27,10 @@ function boundaryRequest(requestId: string): SandboxBoundaryRequestEvent {
   };
 }
 
+function healthSnapshot(sessionId: string): SessionEventStreamSnapshot {
+  return { sessionId, status: 'connected', subscribedAt: 1, checkedAt: 1 };
+}
+
 function seededState(): AppShellSessionUiState {
   return {
     ...createInitialAppShellSessionUiState(),
@@ -37,10 +41,6 @@ function seededState(): AppShellSessionUiState {
     interactionBySession: {
       drop: [boundaryRequest('drop')],
       keep: [boundaryRequest('keep')],
-    },
-    sessionEventHealthBySession: {
-      drop: { sessionId: 'drop', status: 'connected', subscribedAt: 1, checkedAt: 1 },
-      keep: { sessionId: 'keep', status: 'stale', subscribedAt: 1, checkedAt: 2, staleSince: 2 },
     },
     pendingPermissionModeBySession: { drop: true, keep: true },
     pendingSessionModelBySession: { drop: true, keep: true },
@@ -72,7 +72,6 @@ describe('app shell session UI state controller', () => {
     assert.deepEqual(Object.keys(next.stopPendingBySession), ['keep']);
     assert.deepEqual(Object.keys(next.liveTurnBySession), ['keep']);
     assert.deepEqual(Object.keys(next.interactionBySession), ['keep']);
-    assert.deepEqual(Object.keys(next.sessionEventHealthBySession), ['keep']);
     assert.deepEqual(Object.keys(next.pendingPermissionModeBySession), ['keep']);
     assert.deepEqual(Object.keys(next.pendingSessionModelBySession), ['keep']);
   });
@@ -90,6 +89,35 @@ describe('app shell session UI state controller', () => {
     assert.deepEqual(next.messageLoadErrorBySession, { session: 'failed' });
     assert.equal(next.stopPendingBySession, state.stopPendingBySession);
     assert.equal(next.liveTurnBySession, state.liveTurnBySession);
+  });
+
+  it('records event-stream health without notifying render subscribers', () => {
+    let notifications = 0;
+    const controller = createAppShellSessionUiStateController(undefined, () => {
+      notifications += 1;
+    });
+    const snapshot = healthSnapshot('session');
+
+    controller.setSessionEventHealthBySession((current) => ({ ...current, session: snapshot }));
+
+    assert.equal(controller.sessionEventHealthBySessionRef.current.session, snapshot);
+    assert.equal(notifications, 0, 'stream health has no render consumer, so it must not force one');
+
+    controller.setMessageLoadErrorBySession((current) => ({ ...current, session: 'failed' }));
+
+    assert.equal(notifications, 1, 'maps that are rendered still notify');
+  });
+
+  it('drops event-stream health along with the rest of a cleared session', () => {
+    const controller = createAppShellSessionUiStateController();
+    controller.setSessionEventHealthBySession(() => ({
+      drop: healthSnapshot('drop'),
+      keep: healthSnapshot('keep'),
+    }));
+
+    controller.clearSessionUiState('drop');
+
+    assert.deepEqual(Object.keys(controller.sessionEventHealthBySessionRef.current), ['keep']);
   });
 
   it('keeps the synchronous live-turn ref aligned with reducer updates', () => {

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -561,14 +561,14 @@ export function useSessionEventHealthPolling(options: {
         void refreshMessages(activeId);
       }
     };
-    // One evaluate on every dep change records the transition itself — notably the
-    // one that lands `closed` when a session stops expecting a stream.
-    evaluate();
-    // #1979: past that transition an unexpected stream has nothing left to observe
-    // (`deriveSessionEventStreamStatus` returns `closed` and never asks for a
-    // refresh), so polling it is a pure idle wakeup. Both inputs to `expected` are
-    // deps of this effect, so a session that starts running re-arms on its own.
+    // #1979: a stream nobody expects has nothing to observe — `evaluate` can only
+    // derive `closed` and can never ask for a refresh, and no one renders either
+    // field. So an idle session gets no probe at all, not merely a cheaper one.
+    // Both inputs to `expected` are deps of this effect, so a session that starts
+    // running re-arms on its own; `markSessionEventStreamClosed` still records the
+    // closed stream when the subscription itself goes away.
     if (!sessionExpectsEventStream(activeSession?.status, hasLiveActivity)) return;
+    evaluate();
     const interval = window.setInterval(evaluate, 5_000);
     const onVisibilityChange = () => {
       if (document.visibilityState === 'visible') evaluate();

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -10,7 +10,12 @@ import type {
   ThemePreference,
   UiLocale,
 } from '@maka/core';
-import { ShellRunUpdateBuffer, generalizedErrorMessageChinese, type ShellRunUpdate } from '@maka/core';
+import {
+  ShellRunUpdateBuffer,
+  generalizedErrorMessageChinese,
+  sessionExpectsEventStream,
+  type ShellRunUpdate,
+} from '@maka/core';
 import type { LiveTurnProjection, NavSelection } from '@maka/ui';
 import { messageReadErrorMessage } from './app-shell-copy';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
@@ -556,7 +561,14 @@ export function useSessionEventHealthPolling(options: {
         void refreshMessages(activeId);
       }
     };
+    // One evaluate on every dep change records the transition itself — notably the
+    // one that lands `closed` when a session stops expecting a stream.
     evaluate();
+    // #1979: past that transition an unexpected stream has nothing left to observe
+    // (`deriveSessionEventStreamStatus` returns `closed` and never asks for a
+    // refresh), so polling it is a pure idle wakeup. Both inputs to `expected` are
+    // deps of this effect, so a session that starts running re-arms on its own.
+    if (!sessionExpectsEventStream(activeSession?.status, hasLiveActivity)) return;
     const interval = window.setInterval(evaluate, 5_000);
     const onVisibilityChange = () => {
       if (document.visibilityState === 'visible') evaluate();

--- a/apps/desktop/src/renderer/app-shell-session-ui-state.ts
+++ b/apps/desktop/src/renderer/app-shell-session-ui-state.ts
@@ -5,11 +5,6 @@ import type { ShellRunUpdatesBySession } from './shell-run-update-state.js';
 
 type StateUpdater<T> = (updater: (current: T) => T) => void;
 
-// Event-stream health is deliberately absent: it is observation-only bookkeeping
-// (`checkedAt` advances on every probe) that nothing renders, so the controller
-// keeps it in a ref instead — see `sessionEventHealthBySessionRef` below. Putting
-// it here would make each probe force a full AppShell render for no visible
-// change (#1979).
 export interface AppShellSessionUiState {
   messageLoadErrorBySession: Record<string, string>;
   messageRetryPendingBySession: Record<string, boolean>;
@@ -41,10 +36,11 @@ void allSessionUiMapsAreListed;
 // `useSettledSessionTransientReconcile` heals a session whose turn ended while
 // its SessionEvent stream wasn't being followed, and must drop only the live
 // projection. The independently-scoped maps (message load error / retry, pending
-// permission-mode / model toggles, the permission queue, event-stream health,
-// stop-pending) each have their own lifecycle and must survive a mere turn
-// settle — a full `clearAppShellSessionUiStateForSession` (session deletion)
-// would wipe them too.
+// permission-mode / model toggles, the permission queue, stop-pending) each have
+// their own lifecycle and must survive a mere turn settle — a full
+// `clearAppShellSessionUiStateForSession` (session deletion) would wipe them too.
+// Event-stream health is scoped the same way but lives outside this state; see
+// `sessionEventHealthBySessionRef`.
 const TURN_TRANSIENT_MAP_KEYS = [
   'liveTurnBySession',
 ] as const satisfies readonly AppShellSessionUiStateMapKey[];
@@ -53,7 +49,7 @@ export function createInitialAppShellSessionUiState(): AppShellSessionUiState {
   return Object.fromEntries(SESSION_UI_MAP_KEYS.map((key) => [key, {}])) as unknown as AppShellSessionUiState;
 }
 
-function omitSessionKey<T extends object>(current: T, sessionId: string): T {
+function omitSessionKey<T extends Record<string, unknown>>(current: T, sessionId: string): T {
   if (!(sessionId in current)) return current;
   const next = { ...current };
   delete (next as Record<string, unknown>)[sessionId];

--- a/apps/desktop/src/renderer/app-shell-session-ui-state.ts
+++ b/apps/desktop/src/renderer/app-shell-session-ui-state.ts
@@ -5,6 +5,11 @@ import type { ShellRunUpdatesBySession } from './shell-run-update-state.js';
 
 type StateUpdater<T> = (updater: (current: T) => T) => void;
 
+// Event-stream health is deliberately absent: it is observation-only bookkeeping
+// (`checkedAt` advances on every probe) that nothing renders, so the controller
+// keeps it in a ref instead — see `sessionEventHealthBySessionRef` below. Putting
+// it here would make each probe force a full AppShell render for no visible
+// change (#1979).
 export interface AppShellSessionUiState {
   messageLoadErrorBySession: Record<string, string>;
   messageRetryPendingBySession: Record<string, boolean>;
@@ -12,7 +17,6 @@ export interface AppShellSessionUiState {
   liveTurnBySession: Record<string, LiveTurnProjection>;
   shellRunUpdatesBySession: ShellRunUpdatesBySession;
   interactionBySession: InteractionQueues;
-  sessionEventHealthBySession: Record<string, SessionEventStreamSnapshot>;
   pendingPermissionModeBySession: Record<string, boolean>;
   pendingSessionModelBySession: Record<string, boolean>;
 }
@@ -26,7 +30,6 @@ const SESSION_UI_MAP_KEYS = [
   'liveTurnBySession',
   'shellRunUpdatesBySession',
   'interactionBySession',
-  'sessionEventHealthBySession',
   'pendingPermissionModeBySession',
   'pendingSessionModelBySession',
 ] as const satisfies readonly AppShellSessionUiStateMapKey[];
@@ -50,14 +53,11 @@ export function createInitialAppShellSessionUiState(): AppShellSessionUiState {
   return Object.fromEntries(SESSION_UI_MAP_KEYS.map((key) => [key, {}])) as unknown as AppShellSessionUiState;
 }
 
-function omitSessionKey<K extends AppShellSessionUiStateMapKey>(
-  current: AppShellSessionUiState[K],
-  sessionId: string,
-): AppShellSessionUiState[K] {
+function omitSessionKey<T extends object>(current: T, sessionId: string): T {
   if (!(sessionId in current)) return current;
   const next = { ...current };
   delete (next as Record<string, unknown>)[sessionId];
-  return next as AppShellSessionUiState[K];
+  return next;
 }
 
 function updateAppShellSessionUiStateMap<K extends AppShellSessionUiStateMapKey>(
@@ -107,13 +107,16 @@ export function createAppShellSessionUiStateController(
 ) {
   let currentState = initialState;
   const liveTurnBySessionRef = { current: currentState.liveTurnBySession };
-  const sessionEventHealthBySessionRef = { current: currentState.sessionEventHealthBySession };
+  // Written by the event-health probes and read back by them alone. Kept off
+  // `currentState` so a probe never notifies `onChange`.
+  const sessionEventHealthBySessionRef: { current: Record<string, SessionEventStreamSnapshot> } = {
+    current: {},
+  };
 
   function replaceState(next: AppShellSessionUiState): void {
     if (next === currentState) return;
     currentState = next;
     liveTurnBySessionRef.current = next.liveTurnBySession;
-    sessionEventHealthBySessionRef.current = next.sessionEventHealthBySession;
     onChange(next);
   }
 
@@ -141,10 +144,16 @@ export function createAppShellSessionUiStateController(
     setLiveTurnBySession: createMapSetter('liveTurnBySession'),
     setShellRunUpdatesBySession: createMapSetter('shellRunUpdatesBySession'),
     setInteractionBySession: createMapSetter('interactionBySession'),
-    setSessionEventHealthBySession: createMapSetter('sessionEventHealthBySession'),
+    setSessionEventHealthBySession: ((updater) => {
+      sessionEventHealthBySessionRef.current = updater(sessionEventHealthBySessionRef.current);
+    }) satisfies StateUpdater<Record<string, SessionEventStreamSnapshot>>,
     setPendingPermissionModeBySession: createMapSetter('pendingPermissionModeBySession'),
     setPendingSessionModelBySession: createMapSetter('pendingSessionModelBySession'),
     clearSessionUiState: (sessionId: string) => {
+      sessionEventHealthBySessionRef.current = omitSessionKey(
+        sessionEventHealthBySessionRef.current,
+        sessionId,
+      );
       replaceState(clearAppShellSessionUiStateForSession(currentState, sessionId));
     },
     clearTurnTransientState: (sessionId: string) => {


### PR DESCRIPTION
## Summary

`useSessionEventHealthPolling` re-rendered the whole AppShell every 5s for the entire lifetime of any open session, idle or not — the only periodic work the app did while idle, and it changed nothing visible.

Four commits, one root cause:

1. **Gate the polling.** Once a session no longer expects an event stream there is nothing to observe: `deriveSessionEventStreamStatus` short-circuits to `closed` and `shouldRefreshStaleSessionEventStream` never fires. The interval and the `visibilitychange` listener are now gated on `sessionExpectsEventStream`.
2. **Take health out of rendered state.** `sessionEventHealthBySession` lived in `AppShellSessionUiState`, whose only purpose is to force a render. Nothing renders it — the sole reader is the polling effect via `sessionEventHealthBySessionRef`. It now lives in a controller-owned ref, so neither the probes nor the per-SessionEvent writes (`app-shell-effects.ts:380`, one extra full render per streamed event) notify React. `setSessionEventHealthBySession` keeps its updater signature, so all four call sites are untouched; `clearSessionUiState` drops the session from the ref alongside the rendered maps.
3. **Drop the probe the gate left behind.** The gate initially sat after a one-off `evaluate()`, so settling into idle still wrote one snapshot. That write cannot do anything — `expected` is false on this path, and neither `status` nor `staleSince` has a renderer consumer (the sidebar's `staleSessionIds` comes from `stale-sessions.ts`, an unrelated backend/slug classifier). `markSessionEventStreamClosed` already records the closed stream when the subscription goes away, so an idle session now costs nothing at all.
4. **Comment and type cleanup** left over from step 2.

Gating alone would have fixed the idle symptom, but only step 2 removes the per-event renders during a stream. Note that "skip unchanged writes" is *not* a valid alternative to either: the ref is only synced on write, so skipping writes would strand `refreshRequestedAt` and turn the 10s refresh cooldown into a refresh every tick.

Closes #1979

## Verification

- `npm --workspace apps/desktop run test:dist` — 1348 pass, 0 fail.
- `npm --workspace apps/desktop run typecheck` — clean (preload, main, renderer, storybook).
- `npm run format` / `npm run lint` — clean.
- `npm --workspace apps/desktop run e2e` — 58 passed, including `session-health-notice.spec.ts`.

New coverage in `app-shell-effect-stability-contract.test.ts`, driven by a fake clock added to the existing fake DOM (observable `window.setInterval` / `document.addEventListener`, controllable `Date.now`):

- an idle `active` session arms no interval, registers no `visibilitychange` listener, and writes nothing at all — before or after the clock advances;
- a session going `active → running → active` re-arms and then disarms both the interval and the listener;
- a `running` session goes `stale` past the threshold, refreshes sessions and messages exactly once, and re-probes when the window becomes visible again.

Each was verified by mutation, not just by passing: removing the gate, moving the gate back after `evaluate`, making health writes notify again, dropping the ref cleanup in `clearSessionUiState`, and no-oping the interval callback each turn the corresponding test red. The round-trip case specifically covers the one failure mode this gate introduces — a session that starts running but never re-arms; shrinking the dep array to `[activeId]` leaves every other case green and fails only that one.

Not run: no screenshot or Storybook evidence — this PR removes renders and changes no pixels.

## Review focus

`clearSessionUiState` now mutates the health ref in addition to `replaceState`. That is the one place where the ref's lifecycle could drift from the rendered maps, and it is covered by `drops event-stream health along with the rest of a cleared session`.

## Known pre-existing behavior, not addressed here

If a session sits idle past the 15s threshold and then starts running before a fresh SessionEvent or `sessions:changed` observation reaches the renderer, the first `evaluate` reads stale observation timestamps, derives `stale`, and fires one extra refresh. The inputs to that first evaluate are bit-identical before and after this PR — `evaluateSessionEventStreamSnapshot` never advances `subscribedAt` / `lastEventAt` / `lastChangedAt`, so the idle ticks this PR removes never affected it. The refresh is idempotent and self-healing. Out of scope; worth a separate issue if it ever shows up in practice.

## Related

- #1985 — the other half of the same root cause: AppShell subscribes to all session UI state at a single granularity, so any write to a rendered map still re-renders the whole shell. Deliberately out of scope here.
