### PR TITLE
fix(runtime): force tool-free child summaries

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -7123,6 +7123,7 @@ describe('AiSdkBackend usage telemetry', () => {
 
     assert.equal(streamCalls, 2);
     assert.equal(model.doStreamCalls[1]?.tools?.length ?? 0, 0);
+    assert.deepEqual(model.doStreamCalls[1]?.toolChoice, { type: 'none' });
     assert.match(JSON.stringify(model.doStreamCalls[1]?.prompt), /final budgeted step/i);
     assert.ok(
       events.some(

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -203,6 +203,13 @@ export class ModelAdapter {
       messages: lowerNativeAudioMessages(input.messages),
       tools: schemaOnlyTools,
       activeTools: input.activeTools,
+      // An empty active set is an authoritative tool-free request (not merely
+      // an empty provider schema).  Some OpenAI-compatible models, including
+      // DeepSeek, otherwise keep emitting their native tool-call envelope as
+      // ordinary text when the SDK leaves toolChoice at its `auto` default.
+      // The child-agent finalization step relies on this boundary to spend its
+      // last budgeted request on a summary instead of one more unusable call.
+      ...(input.activeTools.length === 0 ? { toolChoice: 'none' } : {}),
       repairToolCall: input.repairToolCall,
       ...(input.system ? { instructions: input.system } : {}),
       ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),


### PR DESCRIPTION
## Summary

- force `toolChoice: none` whenever the runtime has an authoritative empty active-tool set
- prevent DeepSeek-compatible child finalization steps from emitting native DSML tool-call envelopes as plain summary text
- lock the child finalization contract with a regression assertion

## Real-model verification

Reproduced before the fix with a local DeepSeek chain:

- root: `deepseek-v4-pro`
- configured subagent preset: `deepseek-flash-reader`
- two swarm children: `deepseek-v4-flash`
- `maxSteps=12`

Before the change, both child summaries ended as raw DSML tool-call envelopes and the root had to recover through `agent_output`.

After the change:

- root session: `fd8c6c3e-e944-4296-9d3d-fade5f18e2c1`
- root called only `load_tools`, `agent_list`, and `agent_swarm`
- both child sessions persisted `deepseek-v4-flash`, `deepseek-flash-reader`, and `local_read`
- both children read their assigned runtime source file
- both swarm summaries were complete natural-language results with no DSML envelope
- root synthesized directly from the swarm result without `agent_output`

## Tests

- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime run build`
- targeted child-finalization regression test
- full `ai-sdk-backend` test file: 175 passed
- real DeepSeek Pro to Flash swarm E2E: passed
- full runtime suite: 2740 passed, 5 failed, 9 skipped; all 5 failures are pre-existing macOS `/var` vs `/private/var` path-canonicalization assertions in `builtin-tools.test`, unrelated to this change