### PR TITLE
refactor(desktop): move the bot-chat cluster onto the Astryx settings kit

### DIFF
--- a/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
@@ -10,11 +10,10 @@ import {
 } from '@maka/core';
 import type { BotStatus } from '@maka/runtime';
 import { MAX_ALLOWED_USER_IDS, parseAllowedUserIdsFromText } from '@maka/core/settings';
-import { SegmentedControl, SegmentedControlItem } from '@astryxdesign/core';
+import { Card, MetadataList, MetadataListItem, SegmentedControl, SegmentedControlItem, StatusDot, Text, VStack } from '@astryxdesign/core';
 import {
   BOT_BRAND,
   Button,
-  Badge,
   FormLayout,
   TextInput,
   RelativeTime,
@@ -38,7 +37,8 @@ import {
   type BotPendingActionName,
 } from './bot-chat-shared';
 import { getBotSettingsCopy, type BotSettingsCopy } from '../locales/settings-bot-copy';
-import { statusBadgeVariant } from './settings-status-badge';
+import { SettingsSection } from './settings-section';
+import { statusDotVariant } from './settings-status-badge';
 
 function canEnableBotChannel(readiness: BotReadinessState): boolean {
   return readiness === 'credentials_valid' || readiness === 'operational' || readiness === 'degraded';
@@ -178,7 +178,12 @@ export function BotChatChannelDetail(props: {
           <div className="settingsBotDetailHeaderBody">
             <h3>
               {providerPresentation.label}
-              <Badge variant={statusBadgeVariant(readinessCopy.tone)} label={readinessCopy.label} />
+              {/* Astryx convergence: readiness reads as the shared StatusDot +
+                  text idiom — "no decorative Badge" (astryx docs principles). */}
+              <span className="settingsStatus">
+                <StatusDot variant={statusDotVariant(readinessCopy.tone)} label={readinessCopy.label} />
+                <span>{readinessCopy.label}</span>
+              </span>
             </h3>
             <p>{providerPresentation.help}</p>
             {enableSwitchHint && (
@@ -211,12 +216,14 @@ export function BotChatChannelDetail(props: {
           )}
         </header>
 
-        <section className="settingsBotRuntime" aria-labelledby="settings-bot-runtime-heading">
-          <div className="settingsBotRuntimeHeader">
-            <div>
-              <h4 id="settings-bot-runtime-heading">{viewState.liveOperational ? detailCopy.listening : readinessCopy.label}</h4>
-              <p>{viewState.liveOperational ? detailCopy.healthy : readinessCopy.detail}</p>
-            </div>
+        {/* Astryx convergence: the runtime block was a full-width tinted card
+            used as page structure (the named cards-in-page anti-pattern). It
+            is an open kit section now — header + anchor divider + rows. */}
+        <SettingsSection
+          titleId="settings-bot-runtime-heading"
+          title={viewState.liveOperational ? detailCopy.listening : readinessCopy.label}
+          description={viewState.liveOperational ? detailCopy.healthy : readinessCopy.detail}
+          action={(
             <div className="settingsBotActionStack" role="group" aria-label={detailCopy.actionsAria(providerPresentation.label)}>
               {inQuickOnboarding ? (
                 <>
@@ -238,15 +245,18 @@ export function BotChatChannelDetail(props: {
                 <Button variant="secondary" isDisabled={props.actionBusy} onClick={() => void props.onRestart()} label={props.restarting ? detailCopy.restarting : detailCopy.restart} />
               )}
             </div>
-          </div>
-
-          <dl className="settingsBotStatusGrid" aria-label={detailCopy.runtimeAria(providerPresentation.label)}>
-            <div><dt>{detailCopy.identity}</dt><dd>{status?.identity?.username ?? status?.identity?.displayName ?? detailCopy.unknownIdentity}</dd></div>
-            <div><dt>{detailCopy.connectionType}</dt><dd>{botConnectionLabel(status?.connection ?? 'none', locale)}</dd></div>
-            <div><dt>{detailCopy.lastEvent}</dt><dd>{status?.lastEventAt ? <RelativeTime ts={status.lastEventAt} /> : detailCopy.noneYet}</dd></div>
-            <div><dt>{detailCopy.lastTest}</dt><dd>{channel.lastTestAt ? <RelativeTime ts={channel.lastTestAt} /> : detailCopy.neverTested}</dd></div>
-          </dl>
-        </section>
+          )}
+        >
+          {/* Astryx convergence: the hand-rolled <dl> grid (4→2→1 columns via
+              two media queries) is MetadataList, whose multi-column layout
+              handles the collapse itself. */}
+          <MetadataList columns="multi" aria-label={detailCopy.runtimeAria(providerPresentation.label)}>
+            <MetadataListItem label={detailCopy.identity}>{status?.identity?.username ?? status?.identity?.displayName ?? detailCopy.unknownIdentity}</MetadataListItem>
+            <MetadataListItem label={detailCopy.connectionType}>{botConnectionLabel(status?.connection ?? 'none', locale)}</MetadataListItem>
+            <MetadataListItem label={detailCopy.lastEvent}>{status?.lastEventAt ? <RelativeTime ts={status.lastEventAt} /> : detailCopy.noneYet}</MetadataListItem>
+            <MetadataListItem label={detailCopy.lastTest}>{channel.lastTestAt ? <RelativeTime ts={channel.lastTestAt} /> : detailCopy.neverTested}</MetadataListItem>
+          </MetadataList>
+        </SettingsSection>
 
         {props.statusLoadError && (
           <Banner
@@ -271,11 +281,14 @@ export function BotChatChannelDetail(props: {
             )} />
         )}
 
-        <div className="settingsBotConfigurationHeader">
-          <h4>{quickOnboarding && !qrOnlyOnboarding ? detailCopy.setupMethod : detailCopy.connectionSettings}</h4>
-          <span>{quickOnboarding ? detailCopy.localCredentials : detailCopy.autosave}</span>
-        </div>
-
+        {/* Astryx convergence: the bespoke configuration header dialect
+            becomes a kit section wrapping the mode toggle, quick-setup
+            callout, and credential form. */}
+        <SettingsSection
+          variant="bare"
+          title={quickOnboarding && !qrOnlyOnboarding ? detailCopy.setupMethod : detailCopy.connectionSettings}
+          description={quickOnboarding ? detailCopy.localCredentials : detailCopy.autosave}
+        >
         {quickOnboarding && !qrOnlyOnboarding && (
           <SegmentedControl
             className="settingsBotSetupModes"
@@ -289,36 +302,41 @@ export function BotChatChannelDetail(props: {
         )}
 
         {quickOnboarding && provider !== 'wechat' && setupMode === 'quick' && (
-          <section className="settingsBotQuickSetup" aria-label={detailCopy.quickAria(providerPresentation.label)}>
-            <div>
-              <strong>
-                {provider === 'wecom'
-                  ? detailCopy.quickWecomTitle
-                  : provider === 'qq'
-                    ? detailCopy.quickQqTitle
-                    : detailCopy.quickTitle}
-              </strong>
-              <p>
-                {provider === 'wecom'
-                  ? detailCopy.quickWecomDetail
-                  : provider === 'qq'
-                    ? detailCopy.quickQqDetail
-                    : detailCopy.quickDetail}
-              </p>
-            </div>
-            {provider === 'feishu' ? (
-              <SegmentedControl
-                className="settingsBotBrandChoice"
-                value={feishuBrand}
-                label={detailCopy.feishuRegionAria}
-                onChange={(value) => setFeishuBrand(value as BotOnboardingBrand)}
-              >
-                <SegmentedControlItem value="feishu" label={detailCopy.feishu} />
-                <SegmentedControlItem value="lark" label="Lark" />
-              </SegmentedControl>
-            ) : null}
-            <Button variant="primary" onClick={() => setScanLoginPhase('mounting')} label={provider === 'wecom' ? detailCopy.beginQuickBind : detailCopy.scanWith(provider === 'feishu' && feishuBrand === 'lark' ? 'Lark' : providerPresentation.label)} />
-          </section>
+          /* Astryx convergence: the hand-tinted quick-setup plate is an
+             Astryx Card — a genuine callout, the one legitimate Card use
+             inside a settings page. */
+          <Card padding={4} role="region" aria-label={detailCopy.quickAria(providerPresentation.label)}>
+            <VStack gap={2} align="start">
+              <VStack gap={0.5}>
+                <Text weight="semibold">
+                  {provider === 'wecom'
+                    ? detailCopy.quickWecomTitle
+                    : provider === 'qq'
+                      ? detailCopy.quickQqTitle
+                      : detailCopy.quickTitle}
+                </Text>
+                <Text type="supporting" color="secondary">
+                  {provider === 'wecom'
+                    ? detailCopy.quickWecomDetail
+                    : provider === 'qq'
+                      ? detailCopy.quickQqDetail
+                      : detailCopy.quickDetail}
+                </Text>
+              </VStack>
+              {provider === 'feishu' ? (
+                <SegmentedControl
+                  className="settingsBotBrandChoice"
+                  value={feishuBrand}
+                  label={detailCopy.feishuRegionAria}
+                  onChange={(value) => setFeishuBrand(value as BotOnboardingBrand)}
+                >
+                  <SegmentedControlItem value="feishu" label={detailCopy.feishu} />
+                  <SegmentedControlItem value="lark" label="Lark" />
+                </SegmentedControl>
+              ) : null}
+              <Button variant="primary" onClick={() => setScanLoginPhase('mounting')} label={provider === 'wecom' ? detailCopy.beginQuickBind : detailCopy.scanWith(provider === 'feishu' && feishuBrand === 'lark' ? 'Lark' : providerPresentation.label)} />
+            </VStack>
+          </Card>
         )}
 
         {/* PR-BOT-WECHAT-SCAN-LOGIN-0 (WAWQAQ msg `2fa6ada6` screenshots):
@@ -348,6 +366,7 @@ export function BotChatChannelDetail(props: {
         {support === 'planned' && (
           <Banner status="info" title={detailCopy.planned} />
         )}
+        </SettingsSection>
 
         {/* WeChat keeps scan login as a first-class action, separate from
             connection testing, because QR generation and listener readiness

--- a/apps/desktop/src/renderer/settings/bot-chat-overview.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-overview.tsx
@@ -3,12 +3,13 @@ import { ChevronRight, MessageSquare } from '@maka/ui/icons';
 import type { BotChannelSettings, BotProvider } from '@maka/core';
 import type { BotStatus } from '@maka/runtime';
 import { BOT_PROVIDERS } from '@maka/core/settings';
-import { EmptyState, Item } from '@astryxdesign/core';
-import { Button, Badge, RelativeTime, useUiLocale, Banner } from '@maka/ui';
+import { EmptyState, Item, StatusDot } from '@astryxdesign/core';
+import { Button, RelativeTime, useUiLocale, Banner } from '@maka/ui';
 import { deriveBotChannelViewState } from './bot-settings-view-model';
 import { BOT_LABELS, BotBrandLogo, botReadinessCopyForSupport, botStatusDetail } from './bot-chat-shared';
 import { getBotSettingsCopy } from '../locales/settings-bot-copy';
-import { statusBadgeVariant } from './settings-status-badge';
+import { SettingsPage, SettingsSection } from './settings-section';
+import { statusDotVariant } from './settings-status-badge';
 
 /**
  * Remote-access overview: the "正在使用" list of configured channels plus
@@ -56,8 +57,14 @@ export function BotChatOverview(props: {
     });
   const availableChannels = overviewChannels.filter((entry) => !entry.configured);
 
+  // Astryx convergence: the overview was the last page speaking the
+  // pre-#1972 dialect — bespoke page container, section-header dialect,
+  // hand-rolled list grids, a decorative readiness Badge. It is a kit page
+  // now: SettingsPage → SettingsSection (whose headings keep the ids the
+  // remote-access e2e names sections by) → hairline rows; readiness reads
+  // as the shared StatusDot + text idiom.
   return (
-    <div className="settingsRemoteAccessOverview">
+    <SettingsPage>
       {props.statusLoadError && (
         <Banner
           status="error"
@@ -65,18 +72,13 @@ export function BotChatOverview(props: {
           description={props.statusLoadError}
           endContent={<Button variant="secondary" onClick={() => void props.onRefreshStatuses()} label={copy.reload} />} />
       )}
-      <section className="settingsRemoteAccessSection" aria-labelledby="remote-access-active-heading">
-        <div className="settingsRemoteAccessSectionHeader">
-          <h3 id="remote-access-active-heading">{copy.active}</h3>
-          <span>{copy.sortHint}</span>
-        </div>
-        <div className="settingsRemoteAccessActiveList">
+      <SettingsSection titleId="remote-access-active-heading" title={copy.active} description={copy.sortHint}>
           {activeChannels.length === 0 ? (
             <EmptyState
+              isCompact
               icon={<MessageSquare />}
               title={copy.empty}
               description={copy.emptyHelp}
-              className="settingsRemoteAccessEmpty"
             />
           ) : activeChannels.map((entry) => (
             <Item
@@ -87,7 +89,10 @@ export function BotChatOverview(props: {
               label={(
                 <span className="settingsRemoteAccessItemTitle" aria-label={copy.manageAria(botCopy.providers[entry.provider].label, entry.copy.label)}>
                   {botCopy.providers[entry.provider].label}
-                  <Badge variant={statusBadgeVariant(entry.copy.tone)} label={entry.copy.label} />
+                  <span className="settingsStatus">
+                    <StatusDot variant={statusDotVariant(entry.copy.tone)} label={entry.copy.label} />
+                    <span>{entry.copy.label}</span>
+                  </span>
                 </span>
               )}
               description={(
@@ -99,14 +104,8 @@ export function BotChatOverview(props: {
               onClick={() => props.onOpenChannel(entry.provider)}
             />
           ))}
-        </div>
-      </section>
-      <section className="settingsRemoteAccessSection" aria-labelledby="remote-access-available-heading">
-        <div className="settingsRemoteAccessSectionHeader">
-          <h3 id="remote-access-available-heading">{copy.more}</h3>
-          <span>{copy.choose}</span>
-        </div>
-        <div className="settingsRemoteAccessCatalog">
+      </SettingsSection>
+      <SettingsSection titleId="remote-access-available-heading" title={copy.more} description={copy.choose}>
           {availableChannels.map((entry) => (
             <Item
               key={entry.provider}
@@ -119,9 +118,8 @@ export function BotChatOverview(props: {
               onClick={() => props.onOpenChannel(entry.provider)}
             />
           ))}
-        </div>
-      </section>
-    </div>
+      </SettingsSection>
+    </SettingsPage>
   );
 }
 

--- a/apps/desktop/src/renderer/settings/settings-section.tsx
+++ b/apps/desktop/src/renderer/settings/settings-section.tsx
@@ -60,6 +60,9 @@ export function SettingsPage(props: {
 export function SettingsSection(props: {
   /** Group label. Omit only for a page's single unlabeled lead group. */
   title?: ReactNode;
+  /** id for the title Heading; the section wires `aria-labelledby` to it so
+   *  the landmark is named (remote-access e2e relies on these headings). */
+  titleId?: string;
   /** One quiet line under the title explaining what the group governs. */
   description?: ReactNode;
   /** Group-level action cluster (refresh, add, filter), right-aligned. */
@@ -72,7 +75,7 @@ export function SettingsSection(props: {
 }) {
   const hasHeader = props.title != null || props.description != null || props.action != null;
   return (
-    <section className={cn('settingsSection', props.className)}>
+    <section className={cn('settingsSection', props.className)} aria-labelledby={props.titleId}>
       {hasHeader ? (
         /* The header is Astryx's own settings idiom — `Heading level={3}` over
            a `Text type="supporting" color="secondary"` lede — as used by the
@@ -84,7 +87,7 @@ export function SettingsSection(props: {
            of the theme's values. */
         <HStack gap={3} align="start" justify="between">
           <VStack gap={0.5}>
-            {props.title != null ? <Heading level={3}>{props.title}</Heading> : null}
+            {props.title != null ? <Heading level={3} id={props.titleId}>{props.title}</Heading> : null}
             {props.description != null ? (
               <Text type="supporting" size="sm" color="secondary">{props.description}</Text>
             ) : null}

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -1,3 +1,10 @@
+/* Astryx convergence: the pre-#1972 remote-access dialect is retired — page
+   containers → SettingsPage, section headers → SettingsSection, the runtime
+   tinted card + <dl> status grid → SettingsSection + MetadataList, the
+   quick-setup plate → Astryx Card, list grids → the kit's rows body. What
+   stays below is genuine art (brand plate, QR frames, onboarding glyphs) and
+   the row-level behaviors (attention wash, planned opacity). */
+
 .settingsBotLogo {
   width: 32px;
   height: 32px;
@@ -13,49 +20,6 @@
 .settingsBotLogo[data-large="true"] {
   width: 44px;
   height: 44px;
-}
-
-.settingsRemoteAccessOverview,
-.settingsRemoteAccessDetail,
-.settingsBotDetail {
-  display: grid;
-  align-content: start;
-}
-
-.settingsRemoteAccessOverview {
-  gap: var(--space-8);
-}
-
-.settingsRemoteAccessSection {
-  display: grid;
-  gap: var(--space-2-5);
-}
-
-.settingsRemoteAccessSectionHeader,
-.settingsBotConfigurationHeader {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--space-3);
-  padding-inline: var(--space-1);
-}
-
-.settingsRemoteAccessSectionHeader h3,
-.settingsBotConfigurationHeader h4 {
-  font: var(--maka-text-heading-4);
-  margin: 0;
-  color: var(--foreground);
-}
-
-.settingsRemoteAccessSectionHeader span,
-.settingsBotConfigurationHeader span {
-  font: var(--maka-text-supporting);
-  color: var(--muted-foreground);
-}
-
-.settingsRemoteAccessActiveList {
-  display: grid;
-  gap: var(--space-1);
 }
 
 .settingsRemoteAccessChannelRow,
@@ -88,19 +52,6 @@
   color: var(--muted-foreground);
 }
 
-/* The active-list empty slot rides the shared EmptyState card primitive;
-   trim its default page-scale padding so it sits compactly inside the
-   settings list instead of the full-height module-page treatment. */
-.settingsRemoteAccessEmpty {
-  padding: var(--space-5);
-}
-
-.settingsRemoteAccessCatalog {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--space-1);
-}
-
 .settingsRemoteAccessCatalogRow[data-support="planned"] {
   opacity: var(--opacity-muted);
 }
@@ -128,7 +79,14 @@
   min-width: 0;
 }
 
-.settingsBotDetailHeader > .settingsBotLogo {
+.settingsBotDetailHeader > /* Astryx convergence: the pre-#1972 remote-access dialect is retired — page
+   containers → SettingsPage, section headers → SettingsSection, the runtime
+   tinted card + <dl> status grid → SettingsSection + MetadataList, the
+   quick-setup plate → Astryx Card, list grids → the kit's rows body. What
+   stays below is genuine art (brand plate, QR frames, onboarding glyphs) and
+   the row-level behaviors (attention wash, planned opacity). */
+
+.settingsBotLogo {
   grid-column: 1;
   grid-row: 1;
 }
@@ -175,84 +133,10 @@
   text-decoration: underline;
 }
 
-.settingsBotRuntime {
-  display: grid;
-  gap: var(--space-4);
-  border-radius: var(--radius-surface);
-  background: var(--foreground-3);
-  padding: var(--space-4);
-}
-
-.settingsBotRuntimeHeader {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-4);
-}
-
-.settingsBotRuntimeHeader h4 {
-  font: var(--maka-text-heading-4);
-  margin: 0 0 var(--space-1);
-  color: var(--foreground);
-}
-
-.settingsBotRuntimeHeader p {
-  font: var(--maka-text-supporting);
-  margin: 0;
-  color: var(--foreground-secondary);
-}
-
-.settingsBotStatusGrid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--space-4);
-  margin: 0;
-}
-.settingsBotStatusGrid div {
-  min-width: 0;
-}
-.settingsBotStatusGrid dt {
-  font: var(--maka-text-supporting);
-  margin-bottom: var(--space-1);
-  color: var(--muted-foreground);
-}
-.settingsBotStatusGrid dd {
-  font: var(--maka-text-body);
-  min-width: 0;
-  margin: 0;
-  color: var(--foreground);
-  overflow-wrap: anywhere;
-}
-
-.settingsBotConfigurationHeader {
-  margin-top: var(--space-2);
-}
-
-@media (max-width: 900px) {
-  .settingsRemoteAccessCatalog {
-    grid-template-columns: 1fr;
-  }
-
-  .settingsBotRuntimeHeader {
-    flex-direction: column;
-  }
-
-  .settingsBotStatusGrid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
 /* At the restored/sanitized 480px window floor, the fixed Settings navigation
    leaves a narrow content column. Keep provider summaries readable instead of
    squeezing the logo, title, status chip, and switch into one row. */
 @media (max-width: 620px) {
-  .settingsRemoteAccessSectionHeader,
-  .settingsBotConfigurationHeader {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: var(--space-1);
-  }
-
   .settingsBotDetailHeader {
     grid-template-columns: auto minmax(0, 1fr) auto;
   }
@@ -265,10 +149,6 @@
   .settingsBotConfigDocLink {
     grid-column: 1 / -1;
     grid-row: 3;
-  }
-
-  .settingsBotStatusGrid {
-    grid-template-columns: 1fr;
   }
 
   .settingsRemoteAccessChannelRow,
@@ -296,40 +176,6 @@
 .settingsBotSetupModes,
 .settingsBotBrandChoice {
   justify-self: start;
-}
-
-.settingsBotQuickSetup {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--space-4);
-  padding: var(--space-4);
-  border: var(--border-width-hairline) solid var(--border);
-  border-radius: var(--radius-surface);
-  background: var(--foreground-3);
-}
-
-.settingsBotQuickSetup strong {
-  font: var(--maka-text-heading-4);
-  display: block;
-  margin-bottom: var(--space-1);
-  color: var(--foreground);
-}
-
-.settingsBotQuickSetup p {
-  font: var(--maka-text-supporting);
-  max-width: 58ch;
-  margin: 0;
-  color: var(--foreground-secondary);
-}
-
-.settingsBotQuickSetup .settingsBotBrandChoice {
-  grid-column: 1;
-}
-
-.settingsBotQuickSetup > button:last-child {
-  grid-column: 2;
-  grid-row: 1 / span 2;
 }
 
 .settingsBotOnboardingBody {
@@ -416,15 +262,6 @@
 }
 
 @media (max-width: 620px) {
-  .settingsBotQuickSetup {
-    grid-template-columns: 1fr;
-  }
-
-  .settingsBotQuickSetup > button:last-child {
-    grid-column: 1;
-    grid-row: auto;
-  }
-
   .settingsBotOnboardingBody {
     padding-inline: var(--space-4);
   }


### PR DESCRIPTION
Closes out the settings convergence: 远程接入 (overview + detail) was the last page group on the pre-#1972 dialect — #1972 didn't list it in its rewrite scope, so opening it felt like a different product from every other settings page.

## Overview (`bot-chat-overview.tsx`)

- Bespoke page container / section-header dialect / hand-rolled list grids → `SettingsPage` → `SettingsSection` → the kit's hairline rows.
- `SettingsSection` gains a **`titleId`** prop (Heading id + section `aria-labelledby`) so both sections keep the ids the a11y wiring names them by.
- Readiness `Badge` → the shared **StatusDot + text** idiom; the title span's `aria-label` keeps each row's accessible name byte-identical for `settings.spec.ts`.
- `EmptyState` drops its padding-override class for `isCompact`.

## Detail (`bot-chat-detail.tsx`)

- The runtime block was a full-width tinted card used as page structure (the named cards-in-page anti-pattern) → open `SettingsSection` with the test/connect/restart cluster in its `action` slot.
- The 4→2→1-column `<dl>` status grid → **`MetadataList`**, which owns the responsive collapse the two hand-rolled media queries used to carry.
- The configuration-header dialect → bare-variant `SettingsSection` wrapping the mode toggle + credential form (e2e's `heading '接入方式'` stays a heading).
- The hand-tinted quick-setup plate → Astryx **`Card`** (a genuine callout — the one legitimate Card use in a settings page).
- Header readiness Badge → StatusDot + text.

## Deliberately untouched

`.settingsBotDetailHeader`'s pinned grid (`settings.spec.ts` asserts its back → switch → doc link → connect **focus order**), the brand plate, both QR frames, and the onboarding glyphs — documented art, not layout debt.

## Verification

typecheck ✅ · check-dead-css ✅ · check-a11y/copy/console ✅ · product Storybook smoke 71 renders × 3 viewports ✅ · e2e heading-name/focus-order/accessible-name contracts re-checked against the new DOM (roles and names unchanged).

Net: 4 files, +114/−257 — bot.css sheds ~200 lines of retired dialect while keeping the attention wash, planned-opacity, and narrow-viewport row behaviors.