### PR TITLE
feat(runtime-host): add safe-boundary continuation authority

### DIFF
--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -59,6 +59,18 @@ export type RootExecutionDescriptor =
       attemptId: string;
     }
   | {
+      kind: 'safe_boundary_continuation';
+      sourceInvocationId: string;
+      sourceRunId: string;
+      sourceTurnId: string;
+      sourceRuntimeEventHighWater: number;
+      claimId: string;
+      boundaryDigest: `sha256:${string}`;
+      providerReplayDigest: `sha256:${string}`;
+      safetyDigest: `sha256:${string}`;
+      targetInvocationId: string;
+    }
+  | {
       kind: 'linked_child_initial';
       agentId: string;
       agentName: string;
@@ -156,13 +168,45 @@ export interface AgentRunHeader {
 
 type HostedRootExecutionDescriptor = Extract<
   RootExecutionDescriptor,
-  { kind: 'automation' | 'goal' | 'agent_graph_supervisor_wake' }
+  {
+    kind: 'automation' | 'goal' | 'agent_graph_supervisor_wake' | 'safe_boundary_continuation';
+  }
 >;
 
 export function agentRunMatchesHostedRootExecution(
   run: AgentRunHeader,
   execution: HostedRootExecutionDescriptor,
 ): boolean {
+  if (execution.kind === 'safe_boundary_continuation') {
+    const source = run.continuationSource;
+    return (
+      run.invocationId === execution.targetInvocationId &&
+      run.parentRunId === execution.sourceRunId &&
+      run.parentTurnId === execution.sourceTurnId &&
+      source !== undefined &&
+      'protocol' in source &&
+      source.protocol === 'continuation_source_v2' &&
+      source.sourceInvocationId === execution.sourceInvocationId &&
+      source.sourceRunId === execution.sourceRunId &&
+      source.sourceTurnId === execution.sourceTurnId &&
+      source.sourceRuntimeEventHighWater === execution.sourceRuntimeEventHighWater &&
+      source.claimId === execution.claimId &&
+      source.boundaryDigest === execution.boundaryDigest &&
+      source.replayManifestDigest === execution.boundaryDigest &&
+      run.resumedFromRunId === undefined &&
+      run.retriedFromRunId === undefined &&
+      run.agentId === undefined &&
+      run.agentName === undefined &&
+      run.retriedFromTurnId === undefined &&
+      run.regeneratedFromTurnId === undefined &&
+      run.branchOfTurnId === undefined &&
+      run.parentSessionId === undefined &&
+      run.automationId === undefined &&
+      run.goalId === undefined &&
+      run.agentGraphWakeId === undefined &&
+      run.agentGraphWakeAttemptId === undefined
+    );
+  }
   const authorityMatches = hostedRootAuthorityMatches(run, execution);
   return (
     authorityMatches &&
@@ -182,7 +226,7 @@ export function agentRunMatchesHostedRootExecution(
 
 function hostedRootAuthorityMatches(
   run: AgentRunHeader,
-  execution: HostedRootExecutionDescriptor,
+  execution: Exclude<HostedRootExecutionDescriptor, { kind: 'safe_boundary_continuation' }>,
 ): boolean {
   switch (execution.kind) {
     case 'automation':

--- a/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
@@ -70,7 +70,7 @@ describe('Host Client Capability coordinator', () => {
     assert.equal(unregistered.ok, true);
     assert.equal(coordinator.snapshotForSession('session-a'), undefined);
     connection.close();
-    coordinator.close();
+    await coordinator.close();
   });
 
   test('reports capability_lost before acceptance and outcome_unknown after acceptance', async () => {
@@ -101,7 +101,130 @@ describe('Host Client Capability coordinator', () => {
     snapshot?.release();
     first.close();
     second.close();
-    coordinator.close();
+    await coordinator.close();
+  });
+
+  test('previews the initiating provider without persisting a Session binding', async () => {
+    const coordinator = createCoordinator();
+    const connection = coordinator.attachConnection('connection-a', { send: async () => {} });
+    await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
+
+    assert.equal(coordinator.snapshotForSession('session-a'), undefined);
+    const preview = await coordinator.runWithSessionBindingPreview(
+      'session-a',
+      'connection-a',
+      async () => {
+        const snapshot = coordinator.snapshotForSession('session-a');
+        assert.deepEqual(snapshot?.registrationIds, ['registration-a']);
+        snapshot?.release();
+        return 'previewed';
+      },
+    );
+    assert.equal(preview.ok, true);
+    if (preview.ok) {
+      assert.equal(preview.value, 'previewed');
+      assert.equal(typeof preview.commit, 'function');
+    }
+    assert.equal(coordinator.snapshotForSession('session-a'), undefined);
+
+    connection.close();
+    await coordinator.close();
+  });
+
+  test('holds one registry view through preview and rejects a stale commit', async () => {
+    const coordinator = createCoordinator();
+    const connection = coordinator.attachConnection('connection-a', { send: async () => {} });
+    await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
+    let markPreviewStarted!: () => void;
+    const previewStarted = new Promise<void>((resolve) => {
+      markPreviewStarted = resolve;
+    });
+    let releasePreview!: () => void;
+    const previewGate = new Promise<void>((resolve) => {
+      releasePreview = resolve;
+    });
+    const previewTask = coordinator.runWithSessionBindingPreview(
+      'session-a',
+      'connection-a',
+      async () => {
+        const before = coordinator.snapshotForSession('session-a');
+        assert.deepEqual(before?.registrationIds, ['registration-a']);
+        before?.release();
+        markPreviewStarted();
+        await previewGate;
+        const after = coordinator.snapshotForSession('session-a');
+        assert.deepEqual(after?.registrationIds, ['registration-a']);
+        after?.release();
+        return 'stable';
+      },
+    );
+    await previewStarted;
+    let replacementSettled = false;
+    const replacement = replace(
+      coordinator,
+      'connection-a',
+      'registration-b',
+      'inspect_changed',
+    ).finally(() => {
+      replacementSettled = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(replacementSettled, false);
+
+    releasePreview();
+    const preview = await previewTask;
+    assert.equal(preview.ok, true);
+    await replacement;
+    if (preview.ok) {
+      assert.equal(preview.value, 'stable');
+      const committed = await preview.commit();
+      assert.equal(committed.ok, false);
+      if (!committed.ok) assert.match(committed.message, /registry changed/);
+    }
+    assert.equal(coordinator.snapshotForSession('session-a'), undefined);
+
+    connection.close();
+    await coordinator.close();
+  });
+
+  test('serializes connection release behind an active binding preview', async () => {
+    const coordinator = createCoordinator();
+    const connection = coordinator.attachConnection('connection-a', { send: async () => {} });
+    await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
+    let markPreviewStarted!: () => void;
+    const previewStarted = new Promise<void>((resolve) => {
+      markPreviewStarted = resolve;
+    });
+    let releasePreview!: () => void;
+    const previewGate = new Promise<void>((resolve) => {
+      releasePreview = resolve;
+    });
+    const previewTask = coordinator.runWithSessionBindingPreview(
+      'session-a',
+      'connection-a',
+      async () => {
+        markPreviewStarted();
+        await previewGate;
+        const snapshot = coordinator.snapshotForSession('session-a');
+        assert.deepEqual(snapshot?.registrationIds, ['registration-a']);
+        snapshot?.release();
+        return 'stable';
+      },
+    );
+    await previewStarted;
+
+    connection.close();
+    releasePreview();
+    const preview = await previewTask;
+    assert.equal(preview.ok, true);
+    await coordinator.close();
+    if (preview.ok) {
+      assert.equal(preview.value, 'stable');
+      const committed = await preview.commit();
+      assert.equal(committed.ok, false);
+      if (!committed.ok) assert.match(committed.message, /registry changed/);
+    }
+    assert.equal(coordinator.snapshotForSession('session-a'), undefined);
   });
 
   test('composes disjoint contracts from multiple providers', async () => {
@@ -141,7 +264,7 @@ describe('Host Client Capability coordinator', () => {
     snapshot.release();
     first.close();
     second.close();
-    coordinator.close();
+    await coordinator.close();
   });
 
   test('rebinds a lost Session contract to the sole compatible provider', async () => {
@@ -150,7 +273,6 @@ describe('Host Client Capability coordinator', () => {
     await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
     assert.deepEqual(await coordinator.bindSession('session-a', 'connection-a'), { ok: true });
     first.close();
-    assert.equal(coordinator.snapshotForSession('session-a'), undefined);
 
     const replacement = coordinator.attachConnection('connection-b', { send: async () => {} });
     await replace(coordinator, 'connection-b', 'registration-b', 'inspect');
@@ -159,7 +281,7 @@ describe('Host Client Capability coordinator', () => {
     assert.deepEqual(snapshot?.registrationIds, ['registration-b']);
     snapshot?.release();
     replacement.close();
-    coordinator.close();
+    await coordinator.close();
   });
 
   test('forgets initiating Clients when replacement or unregister removes all call-affine offers', async () => {
@@ -224,7 +346,7 @@ describe('Host Client Capability coordinator', () => {
       snapshot.release();
       first.close();
       second.close();
-      coordinator.close();
+      await coordinator.close();
     }
   });
 
@@ -263,7 +385,7 @@ describe('Host Client Capability coordinator', () => {
     snapshot.release();
     first.close();
     second.close();
-    coordinator.close();
+    await coordinator.close();
   });
 
   test('retires Session bindings after explicit replacement and unregister', async () => {
@@ -286,7 +408,7 @@ describe('Host Client Capability coordinator', () => {
     assert.deepEqual(await coordinator.bindSession('session-a', 'observer'), { ok: true });
     assert.equal(coordinator.snapshotForSession('session-a'), undefined);
     connection.close();
-    coordinator.close();
+    await coordinator.close();
   });
 
   test('isolates call-affine ambiguity and freezes the initiating provider in a snapshot', async () => {
@@ -365,7 +487,7 @@ describe('Host Client Capability coordinator', () => {
     assert.deepEqual(await invoke(sole.tools[0]), textResult('second'));
     sole.release();
     second.close();
-    coordinator.close();
+    await coordinator.close();
   });
 
   test('omits ambiguous turn-affine contracts without creating a Session tombstone', async () => {
@@ -404,7 +526,7 @@ describe('Host Client Capability coordinator', () => {
     assert.deepEqual(rebound?.registrationIds, ['registration-a']);
     rebound?.release();
     first.close();
-    coordinator.close();
+    await coordinator.close();
   });
 
   test('keeps load_tools group identity provider-independent and contract-sensitive', async () => {
@@ -435,7 +557,7 @@ describe('Host Client Capability coordinator', () => {
     secondSnapshot.release();
     changedSnapshot.release();
     changed.close();
-    coordinator.close();
+    await coordinator.close();
   });
 
   test('bounds concurrent invocations for one provider connection', async () => {
@@ -486,7 +608,7 @@ describe('Host Client Capability coordinator', () => {
     await Promise.allSettled(active);
     snapshot.release();
     connection.close();
-    coordinator.close();
+    await coordinator.close();
   });
 
   test('cancels accepted work as outcome_unknown and ignores a late provider outcome', async () => {
@@ -553,7 +675,7 @@ describe('Host Client Capability coordinator', () => {
     });
     snapshot.release();
     connection.close();
-    coordinator.close();
+    await coordinator.close();
   });
 
   test('rejects malformed chunk-state transitions without losing invocation ownership', async () => {
@@ -671,7 +793,7 @@ describe('Host Client Capability coordinator', () => {
         connection.close();
         const outcome = await Promise.allSettled([pending]);
         snapshot.release();
-        coordinator.close();
+        await coordinator.close();
         assert.equal(outcome[0]?.status, 'rejected', malformed.name);
       }
     }
@@ -708,7 +830,7 @@ async function assertLossClassification(
         : error instanceof ClientCapabilityInvocationError && error.code === expected,
   );
   snapshot.release();
-  coordinator.close();
+  await coordinator.close();
 }
 
 function createCoordinator(
@@ -818,7 +940,7 @@ test('Host services stay bound to the explicitly initiating Client connection', 
   assert.deepEqual(calls, ['connection-b']);
   first.close();
   second.close();
-  coordinator.close();
+  await coordinator.close();
 });
 
 test('service-only registration lifecycle does not invalidate model backends', async () => {
@@ -861,8 +983,8 @@ test('service-only registration lifecycle does not invalidate model backends', a
   await replace(coordinator, 'connection-a', 'tool-registration', 'inspect');
   assert.equal(modelToolChanges, 1);
   connection.close();
+  await coordinator.close();
   assert.equal(modelToolChanges, 2);
-  coordinator.close();
 });
 
 async function invoke(tool: NonNullable<ReturnType<typeof toolAt>>): Promise<unknown> {

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -64,6 +64,7 @@ const allowedServerExternalImports = new Set([
   '@maka/storage/shell-run-authority',
   '@maka/storage/task-ledger-authority',
   '@maka/storage/usage-stores',
+  '@maka/storage/workspace-identity',
   'node:async_hooks',
   'node:http',
 ]);

--- a/packages/runtime-host/src/__tests__/execution-host-continuation.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host-continuation.test.ts
@@ -1,0 +1,457 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { mcpProxyToolName } from '@maka/runtime';
+import { type ClientCapabilityProvider, RuntimeHostOperationError } from '../client/index.js';
+import {
+  connectClient,
+  waitForTerminalTurn,
+  withExecutionRoot,
+} from './fixtures/execution-host-suite.js';
+
+test('two Clients idempotently start one Host-owned safe-boundary continuation', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const source = await fixture.seedSafeBoundaryContinuationSource();
+    const host = await fixture.startHost();
+    const first = await connectClient(fixture.root, 'desktop');
+    const second = await connectClient(fixture.root, 'tui');
+    const turnId = 'turn-safe-boundary-continuation';
+    let clientsClosed = false;
+    let hostStopped = false;
+    try {
+      const plan = await first.queryTurnResume({ sessionId: fixture.sessionId });
+      assert.deepEqual(plan, {
+        sessionId: fixture.sessionId,
+        disposition: 'ready',
+        sourceRunId: source.sourceRunId,
+        sourceTurnId: source.sourceTurnId,
+        sourceRuntimeEventHighWater: source.sourceRuntimeEventHighWater,
+      });
+
+      const input = {
+        sessionId: fixture.sessionId,
+        turnId,
+        sourceRunId: source.sourceRunId,
+        sourceRuntimeEventHighWater: source.sourceRuntimeEventHighWater,
+      };
+      const [firstStart, secondStart] = await Promise.all([
+        first.startTurnResume(input),
+        second.startTurnResume(input),
+      ]);
+      assert.equal(firstStart.kind, 'started');
+      assert.equal(secondStart.kind, 'started');
+      if (firstStart.kind !== 'started' || secondStart.kind !== 'started') return;
+      assert.equal(firstStart.turn.runId, secondStart.turn.runId);
+
+      const terminal = await waitForTerminalTurn(first, fixture.sessionId, turnId);
+      assert.equal(terminal.status, 'completed');
+      const retry = await second.startTurnResume(input);
+      assert.deepEqual(retry, { kind: 'started', turn: terminal });
+
+      assert.deepEqual(await first.queryTurnResume({ sessionId: fixture.sessionId }), {
+        sessionId: fixture.sessionId,
+        disposition: 'parked',
+        reason: 'continuation_already_exists',
+      });
+
+      await first.close();
+      await second.close();
+      clientsClosed = true;
+      await fixture.stopHost(host);
+      hostStopped = true;
+
+      const footprint = await fixture.readTurnFootprint(turnId);
+      assert.deepEqual(footprint, {
+        admitted: true,
+        runCount: 1,
+        userMessageCount: 0,
+      });
+      const admission = (await fixture.readAdmissionChain()).find(
+        (candidate) => candidate.turnId === turnId,
+      );
+      assert.equal(admission?.userMessageId, null);
+      assert.equal(admission?.execution.kind, 'safe_boundary_continuation');
+      if (admission?.execution.kind !== 'safe_boundary_continuation') return;
+      assert.equal(admission.execution.sourceRunId, source.sourceRunId);
+      assert.equal(admission.execution.sourceInvocationId, source.sourceInvocationId);
+      assert.equal(admission.execution.sourceRuntimeEventHighWater, 2);
+
+      const ledger = await fixture.readTurn(turnId);
+      assert.equal(ledger.runs.length, 1);
+      const run = ledger.runs[0];
+      assert.equal(run?.parentRunId, source.sourceRunId);
+      assert.equal(run?.parentTurnId, source.sourceTurnId);
+      assert.equal(run?.invocationId, admission.execution.targetInvocationId);
+      assert.equal(run?.continuationSource?.sourceRunId, source.sourceRunId);
+      assert.equal(
+        run?.continuationSource && 'protocol' in run.continuationSource
+          ? run.continuationSource.claimId
+          : undefined,
+        admission.execution.claimId,
+      );
+    } finally {
+      if (!clientsClosed) {
+        await first.close();
+        await second.close();
+      }
+      if (!hostStopped) await fixture.stopHost(host);
+    }
+  });
+});
+
+test('startup repairs a continuation Run created before its durable start', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const crash = await fixture.seedSafeBoundaryContinuationCrash('after_run_created');
+    const host = await fixture.startHost();
+    const client = await connectClient(fixture.root, 'desktop');
+    try {
+      const repaired = await client.queryTurn({
+        sessionId: fixture.sessionId,
+        turnId: crash.targetTurnId,
+      });
+      assert.equal(repaired.runId, crash.targetRunId);
+      assert.equal(repaired.status, 'failed');
+      assert.equal(repaired.failureClass, 'continuation_abandoned_before_provider_dispatch');
+      assert.deepEqual(
+        await client.queryTurnResume({
+          sessionId: fixture.sessionId,
+          sourceRunId: crash.sourceRunId,
+          expectedRuntimeEventHighWater: crash.sourceRuntimeEventHighWater,
+        }),
+        {
+          sessionId: fixture.sessionId,
+          disposition: 'parked',
+          reason: 'continuation_already_exists',
+        },
+      );
+    } finally {
+      await client.close();
+      await fixture.stopHost(host);
+    }
+  });
+});
+
+test('startup repairs a continuation claim committed before its target Run', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const crash = await fixture.seedSafeBoundaryContinuationCrash(
+      'after_continuation_claim_committed',
+    );
+    const host = await fixture.startHost();
+    const client = await connectClient(fixture.root, 'desktop');
+    let clientClosed = false;
+    let hostStopped = false;
+    try {
+      const repaired = await client.queryTurn({
+        sessionId: fixture.sessionId,
+        turnId: crash.targetTurnId,
+      });
+      assert.equal(repaired.runId, crash.targetRunId);
+      assert.equal(repaired.status, 'failed');
+      assert.equal(repaired.failureClass, 'continuation_abandoned_before_provider_dispatch');
+
+      await client.close();
+      clientClosed = true;
+      await fixture.stopHost(host);
+      hostStopped = true;
+      const ledger = await fixture.readTurn(crash.targetTurnId);
+      assert.equal(ledger.runs.length, 1);
+      assert.equal(ledger.userMessages.length, 0);
+    } finally {
+      if (!clientClosed) await client.close();
+      if (!hostStopped) await fixture.stopHost(host);
+    }
+  });
+});
+
+test('startup parks a provider-indeterminate continuation without blocking the Host', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const siblingSessionId = await fixture.seedSession();
+    const crash = await fixture.seedSafeBoundaryContinuationCrash(
+      'after_continuation_start_committed',
+    );
+    const host = await fixture.startHost();
+    const client = await connectClient(fixture.root, 'desktop');
+    try {
+      const indeterminate = await client.queryTurn({
+        sessionId: fixture.sessionId,
+        turnId: crash.targetTurnId,
+      });
+      assert.equal(indeterminate.runId, crash.targetRunId);
+      assert.equal(indeterminate.status === 'created' || indeterminate.status === 'running', true);
+      const plan = {
+        sessionId: fixture.sessionId,
+        disposition: 'parked' as const,
+        reason: 'continuation_started_indeterminate' as const,
+      };
+      assert.deepEqual(
+        await client.queryTurnResume({
+          sessionId: fixture.sessionId,
+          sourceRunId: crash.sourceRunId,
+          expectedRuntimeEventHighWater: crash.sourceRuntimeEventHighWater,
+        }),
+        plan,
+      );
+      assert.deepEqual(
+        await client.startTurnResume({
+          sessionId: fixture.sessionId,
+          turnId: crash.targetTurnId,
+          sourceRunId: crash.sourceRunId,
+          sourceRuntimeEventHighWater: crash.sourceRuntimeEventHighWater,
+        }),
+        { kind: 'parked', plan },
+      );
+      await assert.rejects(
+        () =>
+          client.stopTurn({
+            sessionId: fixture.sessionId,
+            turnId: crash.targetTurnId,
+            runId: crash.targetRunId,
+          }),
+        (error) =>
+          error instanceof RuntimeHostOperationError && error.code === 'operation_conflict',
+      );
+      assert.deepEqual(
+        await client.queryTurnResume({
+          sessionId: fixture.sessionId,
+          sourceRunId: 'different-continuation-source',
+          expectedRuntimeEventHighWater: crash.sourceRuntimeEventHighWater,
+        }),
+        {
+          sessionId: fixture.sessionId,
+          disposition: 'parked',
+          reason: 'session_busy',
+        },
+      );
+      await assert.rejects(
+        () =>
+          client.startTurn({
+            sessionId: fixture.sessionId,
+            turnId: 'turn-after-indeterminate-continuation',
+            content: { text: 'Do not overtake the parked continuation.' },
+          }),
+        (error) => error instanceof RuntimeHostOperationError && error.code === 'session_busy',
+      );
+
+      const sibling = await client.startTurn({
+        sessionId: siblingSessionId,
+        turnId: 'turn-unrelated-to-indeterminate-continuation',
+        content: { text: 'Continue normally.' },
+      });
+      assert.equal(sibling.sessionId, siblingSessionId);
+    } finally {
+      await client.close();
+      await fixture.stopHost(host);
+    }
+  });
+});
+
+test('startup parks a provider-indeterminate continuation when resume is disabled', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const siblingSessionId = await fixture.seedSession();
+    const crash = await fixture.seedSafeBoundaryContinuationCrash(
+      'after_continuation_start_committed',
+    );
+    const host = await fixture.startHost(undefined, false);
+    const client = await connectClient(fixture.root, 'desktop');
+    try {
+      const indeterminate = await client.queryTurn({
+        sessionId: fixture.sessionId,
+        turnId: crash.targetTurnId,
+      });
+      assert.equal(indeterminate.runId, crash.targetRunId);
+      assert.equal(indeterminate.status === 'created' || indeterminate.status === 'running', true);
+      assert.deepEqual(
+        await client.queryTurnResume({
+          sessionId: fixture.sessionId,
+          sourceRunId: crash.sourceRunId,
+          expectedRuntimeEventHighWater: crash.sourceRuntimeEventHighWater,
+        }),
+        {
+          sessionId: fixture.sessionId,
+          disposition: 'parked',
+          reason: 'continuation_unavailable',
+        },
+      );
+      const sibling = await client.startTurn({
+        sessionId: siblingSessionId,
+        turnId: 'turn-unrelated-to-disabled-indeterminate-continuation',
+        content: { text: 'Continue normally.' },
+      });
+      assert.equal(sibling.sessionId, siblingSessionId);
+    } finally {
+      await client.close();
+      await fixture.stopHost(host);
+    }
+  });
+});
+
+test('startup parks a pre-claim continuation whose Client Capability is absent', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const requiredToolName = mcpProxyToolName('resume_fixture', 'inspect');
+    const pending = await fixture.seedPendingSafeBoundaryContinuation(requiredToolName);
+    const host = await fixture.startHost();
+    const client = await connectClient(fixture.root, 'desktop');
+    try {
+      assert.deepEqual(
+        await client.queryTurnResume({
+          sessionId: fixture.sessionId,
+          sourceRunId: pending.sourceRunId,
+          expectedRuntimeEventHighWater: pending.sourceRuntimeEventHighWater,
+        }),
+        {
+          sessionId: fixture.sessionId,
+          disposition: 'parked',
+          reason: 'safety_check_failed',
+        },
+      );
+      await assert.rejects(
+        () =>
+          client.startTurn({
+            sessionId: fixture.sessionId,
+            turnId: 'turn-overtaking-client-capability-continuation',
+            content: { text: 'Do not overtake the pending continuation.' },
+          }),
+        (error) => error instanceof RuntimeHostOperationError && error.code === 'session_busy',
+      );
+      assert.deepEqual(
+        await client.queryTurn({
+          sessionId: fixture.sessionId,
+          turnId: pending.targetTurnId,
+        }),
+        {
+          sessionId: fixture.sessionId,
+          turnId: pending.targetTurnId,
+          runId: pending.targetRunId,
+          status: 'admitted',
+        },
+      );
+      await assert.rejects(
+        () =>
+          client.stopTurn({
+            sessionId: fixture.sessionId,
+            turnId: pending.targetTurnId,
+            runId: pending.targetRunId,
+          }),
+        (error) =>
+          error instanceof RuntimeHostOperationError && error.code === 'operation_conflict',
+      );
+      assert.deepEqual(
+        await client.queryTurnResume({
+          sessionId: fixture.sessionId,
+          sourceRunId: pending.sourceRunId,
+          expectedRuntimeEventHighWater: pending.sourceRuntimeEventHighWater,
+        }),
+        {
+          sessionId: fixture.sessionId,
+          disposition: 'parked',
+          reason: 'safety_check_failed',
+        },
+      );
+    } finally {
+      await client.close();
+      await fixture.stopHost(host);
+    }
+  });
+});
+
+test('Runtime Host keeps safe-boundary continuation opt-in', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const source = await fixture.seedSafeBoundaryContinuationSource();
+    const targetTurnId = 'turn-disabled-safe-boundary-continuation';
+    const host = await fixture.startHost(undefined, false);
+    const client = await connectClient(fixture.root, 'desktop');
+    let clientClosed = false;
+    let hostStopped = false;
+    try {
+      const plan = {
+        sessionId: fixture.sessionId,
+        disposition: 'parked' as const,
+        reason: 'continuation_unavailable' as const,
+      };
+      assert.deepEqual(
+        await client.queryTurnResume({
+          sessionId: fixture.sessionId,
+          sourceRunId: source.sourceRunId,
+          expectedRuntimeEventHighWater: source.sourceRuntimeEventHighWater,
+        }),
+        plan,
+      );
+      assert.deepEqual(
+        await client.startTurnResume({
+          sessionId: fixture.sessionId,
+          turnId: targetTurnId,
+          sourceRunId: source.sourceRunId,
+          sourceRuntimeEventHighWater: source.sourceRuntimeEventHighWater,
+        }),
+        { kind: 'parked', plan },
+      );
+
+      await client.close();
+      clientClosed = true;
+      await fixture.stopHost(host);
+      hostStopped = true;
+      assert.deepEqual(await fixture.readTurnFootprint(targetTurnId), {
+        admitted: false,
+        runCount: 0,
+        userMessageCount: 0,
+      });
+    } finally {
+      if (!clientClosed) await client.close();
+      if (!hostStopped) await fixture.stopHost(host);
+    }
+  });
+});
+
+test('resume query previews the initiating Client Capability without binding it', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const serverId = 'resume_fixture';
+    const toolName = 'inspect';
+    const requiredToolName = mcpProxyToolName(serverId, toolName);
+    const source = await fixture.seedSafeBoundaryContinuationSource(requiredToolName);
+    const host = await fixture.startHost();
+    const client = await connectClient(fixture.root, 'desktop');
+    const provider = resumeFixtureProvider(serverId, [toolName]);
+    try {
+      assert.deepEqual(await client.queryTurnResume({ sessionId: fixture.sessionId }), {
+        sessionId: fixture.sessionId,
+        disposition: 'parked',
+        reason: 'safety_check_failed',
+      });
+      await client.replaceClientCapabilities(provider);
+      assert.deepEqual(await client.queryTurnResume({ sessionId: fixture.sessionId }), {
+        sessionId: fixture.sessionId,
+        disposition: 'ready',
+        sourceRunId: source.sourceRunId,
+        sourceTurnId: source.sourceTurnId,
+        sourceRuntimeEventHighWater: source.sourceRuntimeEventHighWater,
+      });
+    } finally {
+      await client.close();
+      await fixture.stopHost(host);
+    }
+  });
+});
+
+function resumeFixtureProvider(
+  serverId: string,
+  toolNames: readonly string[],
+): ClientCapabilityProvider {
+  return {
+    offers: () => [
+      {
+        offerId: 'resume_fixture',
+        version: '0',
+        affinity: 'session',
+        label: 'Resume fixture',
+        tools: toolNames.map((name) => ({
+          serverId,
+          name,
+          inputSchema: { type: 'object', additionalProperties: false },
+        })),
+      },
+    ],
+    call: async (_frame, { accept }) => {
+      await accept();
+      return { content: [{ type: 'text', text: 'ok' }] };
+    },
+  };
+}

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -306,7 +306,7 @@ test('production backend creation continues after a Session Client Capability is
   assert.deepEqual(await coordinator.bindSession('backend-creation-session', 'provider-a'), {
     ok: true,
   });
-  provider.close();
+  await provider.close();
 
   const backend = await createHostAiSdkBackend(
     backendCreationFixture({
@@ -320,7 +320,7 @@ test('production backend creation continues after a Session Client Capability is
     assert.equal(coordinator.snapshotForSession('backend-creation-session'), undefined);
   } finally {
     await backend.dispose();
-    coordinator.close();
+    await coordinator.close();
   }
 });
 
@@ -488,9 +488,9 @@ test('production backend preserves coordinator Client Capability semantics acros
     assert.ok(providerToolSets[1]?.includes(tool.name));
     assert.ok(providerToolSets[2]?.includes(tool.name));
   } finally {
-    connection?.close();
+    await connection?.close();
     await backend?.dispose();
-    coordinator.close();
+    await coordinator.close();
     store.close();
     await provider.close();
   }

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
@@ -25,12 +25,15 @@ import type { Task } from '@maka/core/task-ledger';
 import { isTerminalRuntimeEvent } from '@maka/core/runtime-event';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import {
+  BackendRegistry,
   buildTaskLedgerTools,
   buildRecoveredTerminalRuntimeEvent,
   classifyTerminalRuntimeLedger,
   commitTerminalRunWithRuntimeFact,
   FAKE_ASK_USER_QUESTION_PROMPT,
   FAKE_WAIT_FOR_STEERING_PROMPT,
+  FakeBackend,
+  SessionManager,
   type MakaTool,
   type MakaToolContext,
 } from '@maka/runtime';
@@ -47,6 +50,7 @@ import {
   type StorageRootCapability,
 } from '@maka/storage/root-authority';
 import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-authority';
+import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
 import {
   connectRuntimeHost,
   RuntimeHostOperationError,
@@ -68,6 +72,7 @@ import {
 } from '../../protocol/index.js';
 import { SessionAdmissionGate } from '../../server/session-admission-gate.js';
 import { HostTaskLedgerCoordinator } from '../../server/task-ledger-coordinator.js';
+import { continuationSafetyDigest } from '../../server/root-turn-coordinator.js';
 import { FramedTransport } from '../../transport/framed-transport.js';
 
 export const CURRENT_PROTOCOL = {
@@ -115,6 +120,320 @@ export class ExecutionFixture {
 
   eventsPath(runId: string): string {
     return join(this.root, 'sessions', this.sessionId, 'runs', runId, 'events.jsonl');
+  }
+
+  async seedSession(): Promise<string> {
+    const owner = await tryAcquireInteractiveRootOwner(this.capability);
+    assert.ok(owner);
+    if (!owner) throw new Error('Unable to acquire execution root for Session setup');
+    try {
+      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      const session = await stores.sessionStore.create({
+        cwd: this.root,
+        backend: 'fake',
+        llmConnectionSlug: 'fake',
+        model: 'fake-model',
+        permissionMode: 'ask',
+      });
+      return session.id;
+    } finally {
+      await owner.close();
+    }
+  }
+
+  async seedSafeBoundaryContinuationSource(requiredToolName?: string): Promise<{
+    sourceInvocationId: string;
+    sourceRunId: string;
+    sourceTurnId: string;
+    sourceRuntimeEventHighWater: number;
+  }> {
+    const owner = await tryAcquireInteractiveRootOwner(this.capability);
+    assert.ok(owner);
+    if (!owner) throw new Error('Unable to acquire execution root for continuation setup');
+    try {
+      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      const sourceInvocationId = randomUUID();
+      const sourceRunId = randomUUID();
+      const sourceTurnId = randomUUID();
+      const createdAt = Date.now();
+      const workspace = await resolveWorkspaceIdentity({ path: this.root });
+      const sourceRun: AgentRunHeader = {
+        runId: sourceRunId,
+        invocationId: sourceInvocationId,
+        sessionId: this.sessionId,
+        turnId: sourceTurnId,
+        status: 'created',
+        backendKind: 'fake',
+        llmConnectionSlug: 'fake',
+        modelId: 'fake-model',
+        cwd: this.root,
+        workspaceIdentity: workspace.workspaceIdentity,
+        permissionMode: 'ask',
+        collaborationMode: 'agent',
+        createdAt,
+        updatedAt: createdAt,
+      };
+      await stores.agentRunStore.createRun(sourceRun, { durable: true });
+      await stores.runtimeEventStore.appendRuntimeEvent(this.sessionId, sourceRunId, {
+        id: randomUUID(),
+        sessionId: this.sessionId,
+        invocationId: sourceInvocationId,
+        runId: sourceRunId,
+        turnId: sourceTurnId,
+        ts: createdAt,
+        partial: false,
+        role: 'user',
+        author: 'user',
+        content: { kind: 'text', text: 'Continue this interrupted request.' },
+      });
+      if (requiredToolName) {
+        const toolCallId = randomUUID();
+        await stores.runtimeEventStore.appendRuntimeEvent(this.sessionId, sourceRunId, {
+          id: randomUUID(),
+          sessionId: this.sessionId,
+          invocationId: sourceInvocationId,
+          runId: sourceRunId,
+          turnId: sourceTurnId,
+          ts: createdAt + 1,
+          partial: false,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: toolCallId, name: requiredToolName, args: {} },
+          refs: { toolCallId },
+        });
+        await stores.runtimeEventStore.appendRuntimeEvent(this.sessionId, sourceRunId, {
+          id: randomUUID(),
+          sessionId: this.sessionId,
+          invocationId: sourceInvocationId,
+          runId: sourceRunId,
+          turnId: sourceTurnId,
+          ts: createdAt + 2,
+          partial: false,
+          role: 'tool',
+          author: 'tool',
+          content: {
+            kind: 'function_response',
+            id: toolCallId,
+            name: requiredToolName,
+            result: { ok: true },
+            isError: false,
+          },
+          refs: { toolCallId },
+        });
+      }
+      const terminalAt = createdAt + (requiredToolName ? 3 : 1);
+      const terminal = buildRecoveredTerminalRuntimeEvent({
+        id: randomUUID(),
+        run: sourceRun,
+        status: 'failed',
+        ts: terminalAt,
+        failureClass: 'app_restarted',
+        recoveryReason: 'test_safe_boundary_source',
+      });
+      await commitTerminalRunWithRuntimeFact({
+        runStore: stores.agentRunStore,
+        runtimeEventStore: stores.runtimeEventStore,
+        newId: randomUUID,
+        sessionId: this.sessionId,
+        runId: sourceRunId,
+        turnId: sourceTurnId,
+        status: 'failed',
+        ts: terminalAt,
+        terminalEvent: terminal,
+        failureClass: 'app_restarted',
+      });
+      return {
+        sourceInvocationId,
+        sourceRunId,
+        sourceTurnId,
+        sourceRuntimeEventHighWater: requiredToolName ? 4 : 2,
+      };
+    } finally {
+      await owner.close();
+    }
+  }
+
+  async seedSafeBoundaryContinuationCrash(
+    failpoint:
+      | 'after_continuation_claim_committed'
+      | 'after_run_created'
+      | 'after_continuation_start_committed',
+  ): Promise<{
+    sourceRunId: string;
+    sourceRuntimeEventHighWater: number;
+    targetRunId: string;
+    targetTurnId: string;
+  }> {
+    const source = await this.seedSafeBoundaryContinuationSource();
+    const owner = await tryAcquireInteractiveRootOwner(this.capability);
+    assert.ok(owner);
+    if (!owner) throw new Error('Unable to acquire execution root for continuation crash setup');
+    try {
+      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      const backends = new BackendRegistry();
+      backends.register(
+        'fake',
+        (ctx) =>
+          new FakeBackend({
+            sessionId: ctx.sessionId,
+            header: ctx.header,
+            store: ctx.store,
+            appendMessage: ctx.appendMessage,
+          }),
+      );
+      const workspace = await resolveWorkspaceIdentity({ path: this.root });
+      let markReached!: () => void;
+      const reached = new Promise<void>((resolve) => {
+        markReached = resolve;
+      });
+      const manager = new SessionManager({
+        store: stores.sessionStore,
+        runStore: stores.agentRunStore,
+        runtimeEventStore: stores.runtimeEventStore,
+        backends,
+        safeBoundaryResumeEnabled: true,
+        inspectContinuationSafety: async () => ({
+          workspaceIdentity: workspace.workspaceIdentity,
+          backgroundOperationsSettled: true,
+          availableToolNames: [],
+        }),
+        continuationFailpoint: async (point) => {
+          if (point !== failpoint) return;
+          markReached();
+          await new Promise<never>(() => undefined);
+        },
+        newId: randomUUID,
+        now: Date.now,
+        runtimeSource: 'test',
+      });
+      const plan = await manager.planAuthoritativeSafeBoundaryContinuation(this.sessionId, {
+        sourceRunId: source.sourceRunId,
+      });
+      const planned = plan.continuation;
+      assert.ok(planned?.claimId);
+      assert.ok(planned?.boundary);
+      assert.ok(planned?.providerReplayDigest);
+      if (!planned?.claimId || !planned.boundary || !planned.providerReplayDigest) {
+        throw new Error(`Unable to plan continuation crash setup: ${plan.rejectionReasons}`);
+      }
+      const claimId = planned.claimId;
+      const boundaryDigest = planned.boundary.manifestDigest;
+      const providerReplayDigest = planned.providerReplayDigest;
+      const targetTurnId = `turn-${failpoint}`;
+      const continuation = { ...planned, turnId: targetTurnId };
+      await stores.agentRunStore.admitRootTurn({
+        sessionId: this.sessionId,
+        turnId: targetTurnId,
+        proposedRunId: continuation.runId,
+        proposedUserMessageId: null,
+        execution: {
+          kind: 'safe_boundary_continuation',
+          sourceInvocationId: continuation.sourceInvocationId,
+          sourceRunId: continuation.sourceRunId,
+          sourceTurnId: continuation.sourceTurnId,
+          sourceRuntimeEventHighWater: continuation.sourceRuntimeEventHighWater,
+          claimId,
+          boundaryDigest,
+          providerReplayDigest,
+          safetyDigest: continuationSafetyDigest(continuation),
+          targetInvocationId: continuation.invocationId,
+        },
+        previousRootTurnId: null,
+        normalizedInput: null,
+        sourceMessages: [],
+        admittedAt: Date.now(),
+      });
+      void (async () => {
+        for await (const _event of manager.resumeSafeBoundaryContinuation(continuation)) {
+          // The selected durable failpoint never returns.
+        }
+      })().catch(() => undefined);
+      await withTimeout(reached, PROCESS_TIMEOUT_MS, `continuation did not reach ${failpoint}`);
+      return {
+        sourceRunId: source.sourceRunId,
+        sourceRuntimeEventHighWater: source.sourceRuntimeEventHighWater,
+        targetRunId: continuation.runId,
+        targetTurnId,
+      };
+    } finally {
+      await owner.close();
+    }
+  }
+
+  async seedPendingSafeBoundaryContinuation(requiredToolName: string): Promise<{
+    sourceRunId: string;
+    sourceRuntimeEventHighWater: number;
+    targetRunId: string;
+    targetTurnId: string;
+  }> {
+    const source = await this.seedSafeBoundaryContinuationSource(requiredToolName);
+    const owner = await tryAcquireInteractiveRootOwner(this.capability);
+    assert.ok(owner);
+    if (!owner) throw new Error('Unable to acquire execution root for continuation setup');
+    try {
+      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      const workspace = await resolveWorkspaceIdentity({ path: this.root });
+      const manager = new SessionManager({
+        store: stores.sessionStore,
+        runStore: stores.agentRunStore,
+        runtimeEventStore: stores.runtimeEventStore,
+        backends: new BackendRegistry(),
+        safeBoundaryResumeEnabled: true,
+        inspectContinuationSafety: async () => ({
+          workspaceIdentity: workspace.workspaceIdentity,
+          backgroundOperationsSettled: true,
+          availableToolNames: [requiredToolName],
+        }),
+        newId: randomUUID,
+        now: Date.now,
+        runtimeSource: 'test',
+      });
+      const plan = await manager.planAuthoritativeSafeBoundaryContinuation(this.sessionId, {
+        sourceRunId: source.sourceRunId,
+      });
+      const planned = plan.continuation;
+      assert.ok(planned?.claimId);
+      assert.ok(planned?.boundary);
+      assert.ok(planned?.providerReplayDigest);
+      if (!planned?.claimId || !planned.boundary || !planned.providerReplayDigest) {
+        throw new Error(`Unable to plan pending continuation: ${plan.rejectionReasons}`);
+      }
+      const claimId = planned.claimId;
+      const boundaryDigest = planned.boundary.manifestDigest;
+      const providerReplayDigest = planned.providerReplayDigest;
+      const targetTurnId = 'turn-pending-client-capability-continuation';
+      const continuation = { ...planned, turnId: targetTurnId };
+      await stores.agentRunStore.admitRootTurn({
+        sessionId: this.sessionId,
+        turnId: targetTurnId,
+        proposedRunId: continuation.runId,
+        proposedUserMessageId: null,
+        execution: {
+          kind: 'safe_boundary_continuation',
+          sourceInvocationId: continuation.sourceInvocationId,
+          sourceRunId: continuation.sourceRunId,
+          sourceTurnId: continuation.sourceTurnId,
+          sourceRuntimeEventHighWater: continuation.sourceRuntimeEventHighWater,
+          claimId,
+          boundaryDigest,
+          providerReplayDigest,
+          safetyDigest: continuationSafetyDigest(continuation),
+          targetInvocationId: continuation.invocationId,
+        },
+        previousRootTurnId: null,
+        normalizedInput: null,
+        sourceMessages: [],
+        admittedAt: Date.now(),
+      });
+      return {
+        sourceRunId: source.sourceRunId,
+        sourceRuntimeEventHighWater: source.sourceRuntimeEventHighWater,
+        targetRunId: continuation.runId,
+        targetTurnId,
+      };
+    } finally {
+      await owner.close();
+    }
   }
 
   async seedPendingChildAdmission(
@@ -462,11 +781,14 @@ export class ExecutionFixture {
     }
   }
 
-  async startHost(recoveryProbe?: {
-    sessionId: string;
-    runId: string;
-  }): Promise<ExecutionHostHandle> {
-    const child = this.spawnHost('inherit', recoveryProbe);
+  async startHost(
+    recoveryProbe?: {
+      sessionId: string;
+      runId: string;
+    },
+    safeBoundaryResumeEnabled = true,
+  ): Promise<ExecutionHostHandle> {
+    const child = this.spawnHost('inherit', recoveryProbe, safeBoundaryResumeEnabled);
     const ready = await waitForHostReady(child);
     return { child, ...ready };
   }
@@ -608,7 +930,11 @@ export class ExecutionFixture {
   private spawnHost(
     stderr: 'inherit' | 'ignore',
     recoveryProbe?: { sessionId: string; runId: string },
+    safeBoundaryResumeEnabled = true,
   ): ChildProcess {
+    const env = { ...process.env };
+    if (safeBoundaryResumeEnabled) env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME = '1';
+    else delete env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME;
     const child = fork(
       new URL('./execution-host.js', import.meta.url),
       [
@@ -617,7 +943,7 @@ export class ExecutionFixture {
         '60000',
         ...(recoveryProbe ? [recoveryProbe.sessionId, recoveryProbe.runId] : []),
       ],
-      { stdio: ['ignore', 'ignore', stderr, 'ipc'] },
+      { stdio: ['ignore', 'ignore', stderr, 'ipc'], env },
     );
     this.#children.add(child);
     return child;

--- a/packages/runtime-host/src/__tests__/oauth-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/oauth-coordinator.test.ts
@@ -776,7 +776,7 @@ async function withFixture(
   try {
     await run(fixture);
   } finally {
-    capabilities.close();
+    await capabilities.close();
     if (!owner.closed) await owner.close();
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/runtime-host/src/__tests__/oauth-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/oauth-two-client-uds.test.ts
@@ -91,7 +91,7 @@ test('OAuth enrollment presents only on the initiating Client over real UDS', {
           recover: async () => undefined,
           close: async () => {
             await oauth.close();
-            clientCapabilities.close();
+            await clientCapabilities.close();
           },
         };
       },
@@ -232,7 +232,7 @@ async function assertProviderDisabledOverUds(
           recover: async () => undefined,
           close: async () => {
             await oauth.close();
-            clientCapabilities.close();
+            await clientCapabilities.close();
           },
         };
       },

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -104,6 +104,8 @@ describe('Runtime Host bootstrap protocol', () => {
       'turn.interrupt',
       'turn.message.submit',
       'turn.query',
+      'turn.resume.query',
+      'turn.resume.start',
       'turn.start',
       'turn.stop',
       'usage.query',
@@ -660,6 +662,120 @@ describe('Runtime Host bootstrap protocol', () => {
           ok: false,
           error: { code: 'host_draining', message: 'draining' },
           trace: 'private',
+        }),
+      isInvalidFrame,
+    );
+  });
+
+  test('keeps safe-boundary continuation plans closed and bounded', () => {
+    const query = {
+      requestId: 'resume-query-1',
+      operation: 'turn.resume.query' as const,
+      input: {
+        sessionId: 'session-1',
+        sourceRunId: 'run-source-1',
+        expectedRuntimeEventHighWater: 2,
+      },
+    };
+    assert.deepEqual(decodeClientFrame(query), query);
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          ...query,
+          input: { sessionId: 'session-1', expectedRuntimeEventHighWater: 2 },
+        }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          ...query,
+          input: { ...query.input, expectedRuntimeEventHighWater: 0 },
+        }),
+      isInvalidFrame,
+    );
+
+    const ready = {
+      requestId: query.requestId,
+      operation: query.operation,
+      ok: true as const,
+      result: {
+        sessionId: 'session-1',
+        disposition: 'ready' as const,
+        sourceRunId: 'run-source-1',
+        sourceTurnId: 'turn-source-1',
+        sourceRuntimeEventHighWater: 2,
+      },
+    };
+    assert.deepEqual(decodeHostFrame(ready), ready);
+    assert.throws(
+      () =>
+        HOST_OPERATION_SPECS['turn.resume.query'].assertOutputForInput?.(query.input, {
+          ...ready.result,
+          sourceRuntimeEventHighWater: 3,
+        }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          ...ready,
+          result: { ...ready.result, diagnostics: ['private runtime detail'] },
+        }),
+      isInvalidFrame,
+    );
+
+    const parked = {
+      requestId: query.requestId,
+      operation: query.operation,
+      ok: true as const,
+      result: {
+        sessionId: 'session-1',
+        disposition: 'parked' as const,
+        reason: 'safety_check_failed' as const,
+      },
+    };
+    assert.deepEqual(decodeHostFrame(parked), parked);
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          ...parked,
+          result: { ...parked.result, reason: 'workspace_identity_mismatch' },
+        }),
+      isInvalidFrame,
+    );
+
+    const start = {
+      requestId: 'resume-start-1',
+      operation: 'turn.resume.start' as const,
+      input: {
+        sessionId: 'session-1',
+        turnId: 'turn-resume-1',
+        sourceRunId: 'run-source-1',
+        sourceRuntimeEventHighWater: 2,
+      },
+    };
+    assert.deepEqual(decodeClientFrame(start), start);
+    const started = {
+      requestId: start.requestId,
+      operation: start.operation,
+      ok: true as const,
+      result: {
+        kind: 'started' as const,
+        turn: {
+          sessionId: 'session-1',
+          turnId: 'turn-resume-1',
+          runId: 'run-resume-1',
+          status: 'running' as const,
+        },
+      },
+    };
+    assert.deepEqual(decodeHostFrame(started), started);
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          ...started,
+          result: { kind: 'parked', plan: ready.result },
         }),
       isInvalidFrame,
     );

--- a/packages/runtime-host/src/__tests__/root-admission-owner.test.ts
+++ b/packages/runtime-host/src/__tests__/root-admission-owner.test.ts
@@ -85,6 +85,8 @@ test('fails closed when a known durable admission identity drifts', async () => 
       ...multiSourceAdmitInput('session', 'turn-1', 10),
       previousRootTurnId: null,
     });
+    const firstInput = first.admission.normalizedInput;
+    assert.ok(firstInput);
     const owner = new RootAdmissionOwner(store);
     await owner.recoverSession('session');
     owner.assertKnownAdmission(first.admission);
@@ -96,7 +98,7 @@ test('fails closed when a known durable admission identity drifts', async () => 
       () =>
         owner.assertKnownAdmission({
           ...first.admission,
-          normalizedInput: { ...first.admission.normalizedInput, displayText: 'drifted' },
+          normalizedInput: { ...firstInput, displayText: 'drifted' },
         }),
       /identity changed/,
     );
@@ -118,8 +120,8 @@ test('fails closed when a known durable admission identity drifts', async () => 
         owner.assertKnownAdmission({
           ...first.admission,
           normalizedInput: {
-            ...first.admission.normalizedInput,
-            attachments: first.admission.normalizedInput.attachments?.map((attachment, index) =>
+            ...firstInput,
+            attachments: firstInput.attachments?.map((attachment, index) =>
               index === 0 ? { ...attachment, name: 'drifted.png' } : attachment,
             ),
           },
@@ -180,14 +182,18 @@ test('snapshots recovered admissions without retaining mutable caller references
   const owner = new RootAdmissionOwner(store);
   const [snapshot] = await owner.recoverSession('session');
   assert.ok(snapshot);
+  const snapshotInput = snapshot.normalizedInput;
+  const admissionInput = admission.normalizedInput;
+  assert.ok(snapshotInput);
+  assert.ok(admissionInput);
   const mutableSources = admission.sourceMessages as RootTurnSourceMessage[];
   assert.throws(
     () =>
       owner.assertKnownAdmission({
         ...snapshot,
         normalizedInput: {
-          ...snapshot.normalizedInput,
-          quotes: [...(snapshot.normalizedInput.quotes ?? [])].reverse(),
+          ...snapshotInput,
+          quotes: [...(snapshotInput.quotes ?? [])].reverse(),
         },
       }),
     /identity changed/,
@@ -197,8 +203,8 @@ test('snapshots recovered admissions without retaining mutable caller references
       owner.assertKnownAdmission({
         ...snapshot,
         normalizedInput: {
-          ...snapshot.normalizedInput,
-          quotes: snapshot.normalizedInput.quotes?.map((quote, index) =>
+          ...snapshotInput,
+          quotes: snapshotInput.quotes?.map((quote, index) =>
             index === 0 ? { ...quote, sourceTurnId: 'turn-drifted' } : quote,
           ),
         },
@@ -206,14 +212,14 @@ test('snapshots recovered admissions without retaining mutable caller references
     /identity changed/,
   );
 
-  admission.normalizedInput.displayText = 'mutated display';
-  admission.normalizedInput.attachments![0]!.name = 'mutated.png';
-  admission.normalizedInput.attachments![0]!.ref = {
+  admissionInput.displayText = 'mutated display';
+  admissionInput.attachments![0]!.name = 'mutated.png';
+  admissionInput.attachments![0]!.ref = {
     kind: 'external_file',
     absolutePath: '/mutated.png',
   };
-  admission.normalizedInput.quotes![0]!.text = 'mutated quote';
-  admission.normalizedInput.quotes!.reverse();
+  admissionInput.quotes![0]!.text = 'mutated quote';
+  admissionInput.quotes!.reverse();
   mutableSources[0]!.content.text = 'mutated source';
   mutableSources[0]!.content.attachments![0]!.ref = {
     kind: 'external_file',
@@ -223,13 +229,13 @@ test('snapshots recovered admissions without retaining mutable caller references
   mutableSources[0]!.placement = 'next_turn';
   mutableSources.reverse();
 
-  assert.equal(snapshot.normalizedInput.displayText, 'display text\n\nfollowup text');
-  assert.equal(snapshot.normalizedInput.attachments?.[0]?.name, 'image.png');
-  assert.deepEqual(snapshot.normalizedInput.attachments?.[0]?.ref, {
+  assert.equal(snapshotInput.displayText, 'display text\n\nfollowup text');
+  assert.equal(snapshotInput.attachments?.[0]?.name, 'image.png');
+  assert.deepEqual(snapshotInput.attachments?.[0]?.ref, {
     kind: 'workspace_file',
     relativePath: 'image.png',
   });
-  assert.deepEqual(snapshot.normalizedInput.quotes, [
+  assert.deepEqual(snapshotInput.quotes, [
     { text: 'first excerpt', label: 'Assistant', sourceTurnId: 'turn-source-1' },
     { text: 'second excerpt', sourceTurnId: 'turn-source-2' },
   ]);
@@ -241,12 +247,12 @@ test('snapshots recovered admissions without retaining mutable caller references
     ],
   );
   assert.ok(Object.isFrozen(snapshot));
-  assert.ok(Object.isFrozen(snapshot.normalizedInput));
-  assert.ok(Object.isFrozen(snapshot.normalizedInput.attachments));
-  assert.ok(Object.isFrozen(snapshot.normalizedInput.attachments?.[0]));
-  assert.ok(Object.isFrozen(snapshot.normalizedInput.attachments?.[0]?.ref));
-  assert.ok(Object.isFrozen(snapshot.normalizedInput.quotes));
-  assert.ok(Object.isFrozen(snapshot.normalizedInput.quotes?.[0]));
+  assert.ok(Object.isFrozen(snapshotInput));
+  assert.ok(Object.isFrozen(snapshotInput.attachments));
+  assert.ok(Object.isFrozen(snapshotInput.attachments?.[0]));
+  assert.ok(Object.isFrozen(snapshotInput.attachments?.[0]?.ref));
+  assert.ok(Object.isFrozen(snapshotInput.quotes));
+  assert.ok(Object.isFrozen(snapshotInput.quotes?.[0]));
   assert.ok(Object.isFrozen(snapshot.sourceMessages));
   assert.ok(Object.isFrozen(snapshot.sourceMessages[0]));
   assert.ok(Object.isFrozen(snapshot.sourceMessages[0]?.content));
@@ -256,7 +262,7 @@ test('snapshots recovered admissions without retaining mutable caller references
   assert.ok(Object.isFrozen(snapshot.sourceMessages[0]?.content.quotes));
   assert.ok(Object.isFrozen(snapshot.sourceMessages[0]?.content.quotes?.[0]));
   assert.throws(() => {
-    snapshot.normalizedInput.quotes![0]!.text = 'returned mutation';
+    snapshotInput.quotes![0]!.text = 'returned mutation';
   }, TypeError);
   assert.doesNotThrow(() => owner.assertKnownAdmission(snapshot));
   assert.throws(() => owner.assertKnownAdmission(admission), /identity changed/);
@@ -274,15 +280,19 @@ test('returns an owned frozen admission instead of the mutable store result', as
   await owner.recoverSession('session');
 
   const result = await owner.admitRootTurn(quotedMultiSourceAdmitInput('session', 'turn-1', 10));
+  const resultInput = result.admission.normalizedInput;
+  const durableInput = durableAdmission.normalizedInput;
+  assert.ok(resultInput);
+  assert.ok(durableInput);
   assert.notEqual(result.admission, durableAdmission);
   assert.ok(Object.isFrozen(result));
   assert.ok(Object.isFrozen(result.admission));
-  assert.ok(Object.isFrozen(result.admission.normalizedInput.quotes));
-  assert.ok(Object.isFrozen(result.admission.normalizedInput.quotes?.[0]));
+  assert.ok(Object.isFrozen(resultInput.quotes));
+  assert.ok(Object.isFrozen(resultInput.quotes?.[0]));
 
-  durableAdmission.normalizedInput.quotes![0]!.text = 'store mutation';
+  durableInput.quotes![0]!.text = 'store mutation';
   durableAdmission.sourceMessages[0]!.content.quotes![0]!.label = 'Store mutation';
-  assert.deepEqual(result.admission.normalizedInput.quotes, [
+  assert.deepEqual(resultInput.quotes, [
     { text: 'first excerpt', label: 'Assistant', sourceTurnId: 'turn-source-1' },
     { text: 'second excerpt', sourceTurnId: 'turn-source-2' },
   ]);

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -7,11 +7,14 @@ import { test } from 'node:test';
 import {
   agentGraphIdForRootSession,
   BackendRegistry,
+  buildRecoveredTerminalRuntimeEvent,
   classifyTerminalRuntimeLedger,
+  commitTerminalRunWithRuntimeFact,
   FakeBackend,
   FAKE_ASK_USER_QUESTION_PROMPT,
   IMPLEMENTATION_AGENT_DEFINITION,
   LOCAL_READ_AGENT_PROFILE,
+  mcpProxyToolName,
   RuntimeHostedRootConflictError,
   RuntimeHostedRootUnavailableError,
   RuntimeInteractionAdmissionRejectedError,
@@ -44,6 +47,7 @@ import { HostInteractionCoordinator } from '../server/interaction-coordinator.js
 import { type HostMessageRootPort, HostMessageCoordinator } from '../server/message-coordinator.js';
 import { RootAdmissionOwner } from '../server/root-admission-owner.js';
 import {
+  continuationSafetyDigest,
   type HostGoalRootAuthority,
   RootTurnCoordinator,
 } from '../server/root-turn-coordinator.js';
@@ -64,6 +68,254 @@ const NO_GOAL_ROOT_AUTHORITY: HostGoalRootAuthority = {
   }),
   matchesActive: () => false,
 };
+
+test('startup recovery replays one admitted safe-boundary continuation without a UserMessage', async () => {
+  const workspaceIdentity = 'workspace-safe-boundary-recovery';
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+    continuationSafety: { workspaceIdentity, availableToolNames: [] },
+  });
+  try {
+    await fixture.coordinator.close();
+    const pending = await seedPendingSafeBoundaryContinuation(
+      fixture,
+      workspaceIdentity,
+      'safe-boundary-recovery',
+    );
+
+    const recovery = fixture.createRecoveryCoordinator();
+    await recovery.prepareRecovery();
+    await recovery.recover();
+    let recovered = await recovery.handlers['turn.query'](
+      { sessionId: fixture.sessionId, turnId: pending.targetTurnId },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    await waitUntil(async () => {
+      recovered = await recovery.handlers['turn.query'](
+        { sessionId: fixture.sessionId, turnId: pending.targetTurnId },
+        operationContext(fixture.hostEpoch, fixture.acquireResidency),
+      );
+      return recovered.ok && recovered.result.status !== 'running';
+    });
+    assert.equal(recovered.ok, true);
+    if (recovered.ok) assert.equal(recovered.result.status, 'completed');
+    assert.equal(
+      (await fixture.stores.sessionStore.readMessages(fixture.sessionId)).some(
+        (message) => message.type === 'user' && message.turnId === pending.targetTurnId,
+      ),
+      false,
+    );
+    await recovery.close();
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('a failed exact Capability retry does not poison the parked continuation binding', async () => {
+  const capabilities = new HostClientCapabilityCoordinator({
+    activation: new RuntimePolicyActivationGate(),
+    onModelToolsChanged: () => undefined,
+  });
+  const workspaceIdentity = 'workspace-safe-boundary-capability-retry';
+  const fixture = await createFailureFixture({
+    clientCapabilities: capabilities,
+    continuationSafety: {
+      workspaceIdentity,
+      availableToolNames: (sessionId) => {
+        const snapshot = capabilities.snapshotForSession(sessionId);
+        try {
+          return snapshot?.tools.map((tool) => tool.name) ?? [];
+        } finally {
+          snapshot?.release();
+        }
+      },
+    },
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+  });
+  const seedConnection = capabilities.attachConnection('provider-seed', { send: async () => {} });
+  let wrongConnection: ReturnType<HostClientCapabilityCoordinator['attachConnection']> | undefined;
+  let correctConnection:
+    | ReturnType<HostClientCapabilityCoordinator['attachConnection']>
+    | undefined;
+  let recovery: RootTurnCoordinator | undefined;
+  try {
+    await registerSessionCapability(fixture, capabilities, 'provider-seed', 'registration-seed', [
+      'inspect',
+    ]);
+    assert.deepEqual(await capabilities.bindSession(fixture.sessionId, 'provider-seed'), {
+      ok: true,
+    });
+    await fixture.coordinator.close();
+    const pending = await seedPendingSafeBoundaryContinuation(
+      fixture,
+      workspaceIdentity,
+      'capability-retry',
+    );
+
+    await seedConnection.close();
+    wrongConnection = capabilities.attachConnection('provider-wrong', { send: async () => {} });
+    await registerSessionCapability(fixture, capabilities, 'provider-wrong', 'registration-wrong', [
+      'inspect',
+      'unexpected',
+    ]);
+    capabilities.retireSessions([fixture.sessionId]);
+    recovery = fixture.createRecoveryCoordinator();
+    await recovery.prepareRecovery();
+    await recovery.recover();
+
+    assert.deepEqual(
+      await recovery.handlers['turn.resume.start'](
+        {
+          sessionId: fixture.sessionId,
+          turnId: pending.targetTurnId,
+          sourceRunId: pending.sourceRunId,
+          sourceRuntimeEventHighWater: pending.sourceRuntimeEventHighWater,
+        },
+        operationContext(fixture.hostEpoch, fixture.acquireResidency, 'provider-wrong'),
+      ),
+      {
+        ok: true,
+        result: {
+          kind: 'parked',
+          plan: {
+            sessionId: fixture.sessionId,
+            disposition: 'parked',
+            reason: 'safety_check_failed',
+          },
+        },
+      },
+    );
+
+    await wrongConnection.close();
+    wrongConnection = undefined;
+    correctConnection = capabilities.attachConnection('provider-correct', { send: async () => {} });
+    await registerSessionCapability(
+      fixture,
+      capabilities,
+      'provider-correct',
+      'registration-correct',
+      ['inspect'],
+    );
+    const started = await recovery.handlers['turn.resume.start'](
+      {
+        sessionId: fixture.sessionId,
+        turnId: pending.targetTurnId,
+        sourceRunId: pending.sourceRunId,
+        sourceRuntimeEventHighWater: pending.sourceRuntimeEventHighWater,
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency, 'provider-correct'),
+    );
+    assert.equal(started.ok && started.result.kind === 'started', true, JSON.stringify(started));
+    let terminal = await recovery.handlers['turn.query'](
+      { sessionId: fixture.sessionId, turnId: pending.targetTurnId },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    await waitUntil(async () => {
+      terminal = await recovery!.handlers['turn.query'](
+        { sessionId: fixture.sessionId, turnId: pending.targetTurnId },
+        operationContext(fixture.hostEpoch, fixture.acquireResidency),
+      );
+      return terminal.ok && ['completed', 'failed', 'cancelled'].includes(terminal.result.status);
+    });
+    assert.equal(terminal.ok, true);
+    if (terminal.ok) assert.equal(terminal.result.status, 'completed');
+    assert.equal(
+      (await fixture.stores.agentRunStore.listSessionRuns(fixture.sessionId)).filter(
+        (run) => run.turnId === pending.targetTurnId,
+      ).length,
+      1,
+    );
+    assert.equal(
+      (await fixture.stores.sessionStore.readMessages(fixture.sessionId)).filter(
+        (message) => message.type === 'user' && message.turnId === pending.targetTurnId,
+      ).length,
+      0,
+    );
+  } finally {
+    await Promise.allSettled([
+      seedConnection.close(),
+      wrongConnection?.close(),
+      correctConnection?.close(),
+    ]);
+    await recovery?.close();
+    await capabilities.close();
+    await fixture.dispose();
+  }
+});
+
+test('resume query preserves Session-before-activation lock ordering', async () => {
+  const activation = new RuntimePolicyActivationGate();
+  const capabilities = new HostClientCapabilityCoordinator({
+    activation,
+    onModelToolsChanged: () => undefined,
+  });
+  const fixture = await createFailureFixture({
+    clientCapabilities: capabilities,
+    continuationSafety: {
+      workspaceIdentity: 'workspace-resume-query-lock-order',
+      availableToolNames: (sessionId) => {
+        const snapshot = capabilities.snapshotForSession(sessionId);
+        try {
+          return snapshot?.tools.map((tool) => tool.name) ?? [];
+        } finally {
+          snapshot?.release();
+        }
+      },
+    },
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+  });
+  const connection = capabilities.attachConnection('provider-lock-order', {
+    send: async () => {},
+  });
+  const laneEntered = deferred<void>();
+  const releaseLane = deferred<void>();
+  let blocker: Promise<void> | undefined;
+  let query: Promise<unknown> | undefined;
+  try {
+    await registerSessionCapability(
+      fixture,
+      capabilities,
+      'provider-lock-order',
+      'registration-lock-order',
+      ['inspect'],
+    );
+    blocker = fixture.sessionAdmission.run(fixture.sessionId, async () => {
+      laneEntered.resolve();
+      await releaseLane.promise;
+    });
+    await laneEntered.promise;
+
+    const queryQueued = fixture.sessionAdmission.waitForNextQueuedRun();
+    query = fixture.coordinator.handlers['turn.resume.query'](
+      { sessionId: fixture.sessionId },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency, 'provider-lock-order'),
+    );
+    await queryQueued;
+    await completesWithin(
+      capabilities.bindSession('unrelated-session-before-release', 'provider-lock-order'),
+      2_000,
+      'Capability mutation while resume query waits for its Session lane',
+    );
+
+    releaseLane.resolve();
+    await blocker;
+    const outcome = await completesWithin(query, 2_000, 'queued resume query');
+    assert.equal(
+      typeof outcome === 'object' && outcome !== null && 'ok' in outcome && outcome.ok,
+      true,
+    );
+    assert.deepEqual(
+      await capabilities.bindSession('unrelated-session-after-query', 'provider-lock-order'),
+      { ok: true },
+    );
+  } finally {
+    releaseLane.resolve();
+    await Promise.allSettled([blocker, query]);
+    await connection.close();
+    await capabilities.close();
+    await fixture.dispose();
+  }
+});
 
 test('turn.start durably applies one exact per-Turn orchestration override', async () => {
   const fixture = await createFailureFixture({
@@ -109,6 +361,197 @@ test('turn.start durably applies one exact per-Turn orchestration override', asy
     assert.equal(conflict.ok, false);
     if (!conflict.ok) assert.equal(conflict.error.code, 'operation_conflict');
   } finally {
+    await fixture.dispose();
+  }
+});
+
+test('safe-boundary continuation safety identity uses the exact canonical tool catalog', () => {
+  const safetySnapshot: {
+    workspaceIdentity: string;
+    backgroundOperationsSettled: boolean;
+    availableToolNames: readonly string[];
+    workspaceCheckpoint: { ref: string; runtimeEventHighWater: number };
+  } = {
+    workspaceIdentity: 'workspace-safety-identity',
+    backgroundOperationsSettled: true,
+    availableToolNames: ['tool-beta', 'tool-alpha'],
+    workspaceCheckpoint: {
+      ref: 'checkpoint-ref',
+      runtimeEventHighWater: 7,
+    },
+  };
+  const digest = (snapshot: typeof safetySnapshot) =>
+    continuationSafetyDigest({
+      safetySnapshot: snapshot,
+    } as unknown as Parameters<typeof continuationSafetyDigest>[0]);
+
+  assert.equal(
+    digest(safetySnapshot),
+    digest({
+      ...safetySnapshot,
+      availableToolNames: ['tool-alpha', 'tool-beta', 'tool-alpha'],
+    }),
+  );
+  assert.notEqual(
+    digest(safetySnapshot),
+    digest({
+      ...safetySnapshot,
+      availableToolNames: ['tool-alpha', 'tool-beta', 'tool-privileged'],
+    }),
+  );
+  assert.notEqual(
+    digest(safetySnapshot),
+    digest({ ...safetySnapshot, workspaceIdentity: 'different-workspace' }),
+  );
+  assert.notEqual(
+    digest(safetySnapshot),
+    digest({ ...safetySnapshot, backgroundOperationsSettled: false }),
+  );
+  assert.notEqual(
+    digest(safetySnapshot),
+    digest({
+      ...safetySnapshot,
+      workspaceCheckpoint: { ...safetySnapshot.workspaceCheckpoint, ref: 'different-checkpoint' },
+    }),
+  );
+  assert.notEqual(
+    digest(safetySnapshot),
+    digest({
+      ...safetySnapshot,
+      workspaceCheckpoint: {
+        ...safetySnapshot.workspaceCheckpoint,
+        runtimeEventHighWater: 8,
+      },
+    }),
+  );
+});
+
+test('linked child Sessions reject public safe-boundary continuation', async () => {
+  let recoveryCoordinator: RootTurnCoordinator | undefined;
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+  });
+  try {
+    const parent = await fixture.stores.sessionStore.readHeaderSnapshot(fixture.sessionId);
+    const { header: child } = await fixture.stores.sessionStore.createSubagent({
+      cwd: parent.cwd,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'execute',
+      collaborationMode: 'agent',
+      orchestrationMode: 'default',
+      subagentParent: {
+        kind: 'subagent',
+        parentSessionId: fixture.sessionId,
+        spawnedBy: {
+          parentRunId: 'parent-run',
+          parentTurnId: 'parent-turn',
+          toolCallId: 'implementation-spawn',
+        },
+        lifecycle: 'foreground',
+      },
+      subagentRuntime: {
+        schemaVersion: 1,
+        definitionVersion: IMPLEMENTATION_AGENT_DEFINITION.definitionVersion,
+        agentId: IMPLEMENTATION_AGENT_DEFINITION.id,
+        agentName: IMPLEMENTATION_AGENT_DEFINITION.name,
+        profile: 'implementation',
+        systemPrompt: IMPLEMENTATION_AGENT_DEFINITION.systemPrompt,
+        toolNames: [...IMPLEMENTATION_AGENT_DEFINITION.tools],
+        categoryPolicy: {},
+      },
+      subagentSpawn: {
+        schemaVersion: 1,
+        requestFingerprint: 'c'.repeat(64),
+        initialTurnId: 'managed-child-turn',
+        initialRunId: 'managed-child-run',
+      },
+    });
+    const unavailableMessage = 'Child Sessions must be continued through their parent agent.';
+
+    assert.deepEqual(
+      await fixture.coordinator.handlers['turn.resume.query'](
+        { sessionId: child.id },
+        operationContext(fixture.hostEpoch, fixture.acquireResidency),
+      ),
+      {
+        ok: false,
+        error: { code: 'operation_unavailable', message: unavailableMessage },
+      },
+    );
+    assert.deepEqual(
+      await fixture.coordinator.handlers['turn.resume.start'](
+        {
+          sessionId: child.id,
+          turnId: 'external-child-continuation-turn',
+          sourceRunId: 'external-child-source-run',
+          sourceRuntimeEventHighWater: 1,
+        },
+        operationContext(fixture.hostEpoch, fixture.acquireResidency),
+      ),
+      {
+        ok: false,
+        error: { code: 'operation_unavailable', message: unavailableMessage },
+      },
+    );
+
+    await fixture.coordinator.close();
+    const targetTurnId = 'parked-external-child-continuation-turn';
+    await fixture.stores.agentRunStore.admitRootTurn({
+      sessionId: child.id,
+      turnId: targetTurnId,
+      proposedRunId: 'parked-external-child-continuation-run',
+      proposedUserMessageId: null,
+      execution: {
+        kind: 'safe_boundary_continuation',
+        sourceInvocationId: 'external-child-source-invocation',
+        sourceRunId: 'external-child-source-run',
+        sourceTurnId: 'external-child-source-turn',
+        sourceRuntimeEventHighWater: 1,
+        claimId: 'external-child-continuation-claim',
+        boundaryDigest: `sha256:${'a'.repeat(64)}`,
+        providerReplayDigest: `sha256:${'b'.repeat(64)}`,
+        safetyDigest: `sha256:${'c'.repeat(64)}`,
+        targetInvocationId: 'external-child-target-invocation',
+      },
+      previousRootTurnId: null,
+      normalizedInput: null,
+      sourceMessages: [],
+      admittedAt: Date.now(),
+    });
+    recoveryCoordinator = fixture.createRecoveryCoordinator();
+    await recoveryCoordinator.prepareRecovery();
+    await recoveryCoordinator.recover();
+
+    assert.deepEqual(recoveryCoordinator.readRootState(child.id), { kind: 'reserved' });
+    assert.equal(
+      (await fixture.stores.agentRunStore.listSessionRuns(child.id)).some(
+        (run) => run.turnId === targetTurnId,
+      ),
+      false,
+    );
+    assert.deepEqual(
+      await recoveryCoordinator.handlers['turn.resume.start'](
+        {
+          sessionId: child.id,
+          turnId: targetTurnId,
+          sourceRunId: 'external-child-source-run',
+          sourceRuntimeEventHighWater: 1,
+        },
+        operationContext(fixture.hostEpoch, fixture.acquireResidency),
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'operation_unavailable',
+          message: unavailableMessage,
+        },
+      },
+    );
+    assert.deepEqual(recoveryCoordinator.readRootState(child.id), { kind: 'reserved' });
+  } finally {
+    await recoveryCoordinator?.close();
     await fixture.dispose();
   }
 });
@@ -949,6 +1392,12 @@ test('hosted linked child roots share admission, message, terminal, and stop aut
       childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
       newId: randomUUID,
       now: Date.now,
+      safeBoundaryResumeEnabled: true,
+      inspectContinuationSafety: async () => ({
+        workspaceIdentity: 'workspace-linked-root-authority',
+        backgroundOperationsSettled: true,
+        availableToolNames: ['Read', 'Glob', 'Grep'],
+      }),
       messageAuthority: authority,
       interactionAuthority,
       canonicalPermissionOutcomes: new HostCanonicalPermissionOutcomeReader({
@@ -1193,17 +1642,22 @@ test('hosted linked child roots share admission, message, terminal, and stop aut
       (message) => 'turnId' in message && message.turnId === retried.turnId,
     );
     assert.deepEqual(retryMessages, []);
-    const legacyRetryRun = await stores.agentRunStore.readRun(child.childSessionId, retried.runId!);
-    assert.equal(legacyRetryRun.continuationSource, undefined);
-    assert.equal(
-      (
-        await stores.runtimeEventStore.readImmutableRuntimeEvents(
-          child.childSessionId,
-          retried.runId!,
-        )
-      ).some((event) => event.actions?.continuationStart !== undefined),
-      false,
+    const durableRetryRun = await stores.agentRunStore.readRun(
+      child.childSessionId,
+      retried.runId!,
     );
+    const durableRetrySource = durableRetryRun.continuationSource;
+    assert.ok(durableRetrySource && 'protocol' in durableRetrySource);
+    if (!durableRetrySource || !('protocol' in durableRetrySource)) return;
+    assert.equal(durableRetrySource.sourceRunId, resumed.runId);
+    assert.equal(durableRetrySource.protocol, 'continuation_source_v2');
+    const continuationStart = (
+      await stores.runtimeEventStore.readImmutableRuntimeEvents(
+        child.childSessionId,
+        retried.runId!,
+      )
+    )[0]?.actions?.continuationStart;
+    assert.equal(continuationStart?.claimId, durableRetrySource.claimId);
     assert.deepEqual(coordinator.readRootState(child.childSessionId), {
       kind: 'idle',
     });
@@ -1792,7 +2246,7 @@ test('Client Capability ambiguity fails before durable root admission', async ()
   } finally {
     first.close();
     second.close();
-    clientCapabilities.close();
+    await clientCapabilities.close();
     await fixture.dispose();
   }
 });
@@ -1881,7 +2335,7 @@ test('an exact active retry preserves the Client Capability admission binding', 
     backend?.release();
     first.close();
     second.close();
-    clientCapabilities.close();
+    await clientCapabilities.close();
     await fixture.dispose();
   }
 });
@@ -2014,7 +2468,7 @@ test('mixed-Client queued follow-ups preserve each submitting connection through
   } finally {
     first.close();
     second.close();
-    clientCapabilities.close();
+    await clientCapabilities.close();
     await fixture.dispose();
   }
 });
@@ -2200,7 +2654,7 @@ async function assertFollowupCapabilityRebinding(affinity: 'call' | 'turn'): Pro
     sessionProvider.close();
     previousProvider.close();
     followupProvider.close();
-    clientCapabilities.close();
+    await clientCapabilities.close();
     await fixture.dispose();
   }
 }
@@ -2284,7 +2738,7 @@ test('an exact terminal retry does not require a live Client Capability binding'
     assert.deepEqual(retried, { ok: true, result: terminal });
   } finally {
     provider.close();
-    clientCapabilities.close();
+    await clientCapabilities.close();
     await fixture.dispose();
   }
 });
@@ -3099,6 +3553,141 @@ function executeClaimedGraphRoot(
   return { turnId, runId, execution };
 }
 
+type FailureFixture = Awaited<ReturnType<typeof createFailureFixture>>;
+
+async function seedPendingSafeBoundaryContinuation(
+  fixture: FailureFixture,
+  workspaceIdentity: string,
+  identitySuffix: string,
+): Promise<{
+  sourceRunId: string;
+  sourceRuntimeEventHighWater: number;
+  targetRunId: string;
+  targetTurnId: string;
+}> {
+  const sourceRunId = `source-run-${identitySuffix}`;
+  const sourceTurnId = `source-turn-${identitySuffix}`;
+  const sourceInvocationId = `source-invocation-${identitySuffix}`;
+  const targetTurnId = `target-turn-${identitySuffix}`;
+  const session = await fixture.stores.sessionStore.readHeaderSnapshot(fixture.sessionId);
+  const createdAt = Date.now();
+  const sourceRun = {
+    runId: sourceRunId,
+    invocationId: sourceInvocationId,
+    sessionId: fixture.sessionId,
+    turnId: sourceTurnId,
+    status: 'created' as const,
+    backendKind: 'fake' as const,
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: session.cwd,
+    workspaceIdentity,
+    permissionMode: session.permissionMode,
+    collaborationMode: session.collaborationMode,
+    createdAt,
+    updatedAt: createdAt,
+  };
+  await fixture.stores.agentRunStore.createRun(sourceRun, { durable: true });
+  await fixture.stores.runtimeEventStore.appendRuntimeEvent(fixture.sessionId, sourceRunId, {
+    id: `source-user-${identitySuffix}`,
+    sessionId: fixture.sessionId,
+    invocationId: sourceInvocationId,
+    runId: sourceRunId,
+    turnId: sourceTurnId,
+    ts: createdAt,
+    partial: false,
+    role: 'user',
+    author: 'user',
+    content: { kind: 'text', text: 'Continue after Host restart.' },
+  });
+  const terminalAt = createdAt + 1;
+  await commitTerminalRunWithRuntimeFact({
+    runStore: fixture.stores.agentRunStore,
+    runtimeEventStore: fixture.stores.runtimeEventStore,
+    newId: randomUUID,
+    sessionId: fixture.sessionId,
+    runId: sourceRunId,
+    turnId: sourceTurnId,
+    status: 'failed',
+    ts: terminalAt,
+    terminalEvent: buildRecoveredTerminalRuntimeEvent({
+      id: `source-terminal-${identitySuffix}`,
+      run: sourceRun,
+      status: 'failed',
+      ts: terminalAt,
+      failureClass: 'app_restarted',
+      recoveryReason: 'test_safe_boundary_recovery',
+    }),
+    failureClass: 'app_restarted',
+  });
+  const plan = await fixture.manager.planAuthoritativeSafeBoundaryContinuation(fixture.sessionId, {
+    sourceRunId,
+  });
+  assert.equal(plan.disposition, 'continue', JSON.stringify(plan));
+  const continuation = plan.continuation;
+  if (!continuation?.claimId || !continuation.boundary || !continuation.providerReplayDigest) {
+    throw new Error('Unable to plan the safe-boundary continuation fixture');
+  }
+  const admission = await fixture.stores.agentRunStore.admitRootTurn({
+    sessionId: fixture.sessionId,
+    turnId: targetTurnId,
+    proposedRunId: continuation.runId,
+    proposedUserMessageId: null,
+    execution: {
+      kind: 'safe_boundary_continuation',
+      sourceInvocationId,
+      sourceRunId,
+      sourceTurnId,
+      sourceRuntimeEventHighWater: continuation.sourceRuntimeEventHighWater,
+      claimId: continuation.claimId,
+      boundaryDigest: continuation.boundary.manifestDigest,
+      providerReplayDigest: continuation.providerReplayDigest,
+      safetyDigest: continuationSafetyDigest(continuation),
+      targetInvocationId: continuation.invocationId,
+    },
+    previousRootTurnId: null,
+    normalizedInput: null,
+    sourceMessages: [],
+    admittedAt: Date.now(),
+  });
+  assert.equal(admission.kind, 'admitted');
+  return {
+    sourceRunId,
+    sourceRuntimeEventHighWater: continuation.sourceRuntimeEventHighWater,
+    targetRunId: continuation.runId,
+    targetTurnId,
+  };
+}
+
+async function registerSessionCapability(
+  fixture: FailureFixture,
+  capabilities: HostClientCapabilityCoordinator,
+  connectionId: string,
+  registrationId: string,
+  toolNames: readonly string[],
+): Promise<void> {
+  const replaced = await capabilities.handlers['client.capability.replace'](
+    {
+      registrationId,
+      offers: [
+        {
+          offerId: 'resume_fixture',
+          version: '0',
+          affinity: 'session',
+          label: 'Resume fixture',
+          tools: toolNames.map((name) => ({
+            serverId: 'resume_fixture',
+            name,
+            inputSchema: { type: 'object', additionalProperties: false },
+          })),
+        },
+      ],
+    },
+    operationContext(fixture.hostEpoch, fixture.acquireResidency, connectionId),
+  );
+  assert.equal(replaced.ok, true);
+}
+
 async function createFailureFixture(options: {
   registerBackend(backends: BackendRegistry): void;
   childTools?: MakaTool[];
@@ -3107,6 +3696,10 @@ async function createFailureFixture(options: {
   withInteractions?: boolean;
   beforeInteractionPreflight?(): Promise<void>;
   clientCapabilities?: HostClientCapabilityCoordinator;
+  continuationSafety?: {
+    workspaceIdentity: string;
+    availableToolNames: readonly string[] | ((sessionId: string) => readonly string[]);
+  };
 }) {
   const base = await mkdtemp(join(tmpdir(), 'maka-root-turn-message-failure-'));
   const capability = await resolveStorageRoot({
@@ -3223,6 +3816,19 @@ async function createFailureFixture(options: {
     newId: randomUUID,
     now: Date.now,
     messageAuthority: options.wrapMessageAuthority?.(messages) ?? messages,
+    ...(options.continuationSafety
+      ? {
+          safeBoundaryResumeEnabled: true,
+          inspectContinuationSafety: async (sessionId: string) => ({
+            workspaceIdentity: options.continuationSafety!.workspaceIdentity,
+            backgroundOperationsSettled: true,
+            availableToolNames:
+              typeof options.continuationSafety!.availableToolNames === 'function'
+                ? options.continuationSafety!.availableToolNames(sessionId)
+                : options.continuationSafety!.availableToolNames,
+          }),
+        }
+      : {}),
   };
   const manager = interactions
     ? new SessionManager({
@@ -3247,7 +3853,7 @@ async function createFailureFixture(options: {
         claimRunClosure: async () => undefined,
       },
       messages,
-      continuity,
+      requireContinuity(continuity),
       acquireResidency,
       requestDrain,
       options.clientCapabilities,
@@ -3270,16 +3876,27 @@ async function createFailureFixture(options: {
     createRecoveryCoordinator: (
       assertAutomationRecoveryAdmission?: (admission: RootTurnAdmission) => void,
     ) => {
-      coordinator = createCoordinator(
-        new RootAdmissionOwner(stores.agentRunStore),
-        assertAutomationRecoveryAdmission,
+      const admissionOwner = new RootAdmissionOwner(stores.agentRunStore);
+      const recoveryProjection = new CanonicalSessionProjectionReader({
+        stores,
+        rootAdmissions: admissionOwner,
+        messages,
+      });
+      requireContinuity(continuity).close();
+      canonicalProjection = recoveryProjection;
+      continuity = new SessionContinuityCoordinator(
+        hostEpoch,
+        (sessionId) => recoveryProjection.read(sessionId),
+        sessionAdmission,
+        requestDrain,
       );
+      coordinator = createCoordinator(admissionOwner, assertAutomationRecoveryAdmission);
       return coordinator;
     },
     liveResidencies: () => liveResidencies,
     drainRequested: () => drainRequested,
     dispose: async () => {
-      continuity.close();
+      requireContinuity(continuity).close();
       await owner.close();
       await rm(base, { recursive: true, force: true });
     },
@@ -3351,9 +3968,12 @@ class ObservableSessionAdmissionGate extends SessionAdmissionGate {
   }
 }
 
-async function waitUntil(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 2_000,
+): Promise<void> {
   const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
+  while (!(await predicate())) {
     if (Date.now() >= deadline) throw new Error('Timed out waiting for test condition');
     await new Promise((resolve) => setTimeout(resolve, 5));
   }

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -30,6 +30,10 @@ import {
   type SubscriptionFrame,
   type SubscriptionOpenInput,
   type TurnQueryInput,
+  type TurnResumePlan,
+  type TurnResumeQueryInput,
+  type TurnResumeStartInput,
+  type TurnResumeStartResult,
   type TurnSnapshot,
   type TurnStartInput,
   type TurnStopInput,
@@ -121,6 +125,8 @@ export interface RuntimeHostConnection {
   startTurn(input: TurnStartInput, timeoutMs?: number): Promise<TurnSnapshot>;
   queryTurn(input: TurnQueryInput, timeoutMs?: number): Promise<TurnSnapshot>;
   stopTurn(input: TurnStopInput, timeoutMs?: number): Promise<TurnSnapshot>;
+  queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan>;
+  startTurnResume(input: TurnResumeStartInput, timeoutMs?: number): Promise<TurnResumeStartResult>;
   openSessionSubscription(
     input: SubscriptionOpenInput,
     timeoutMs?: number,
@@ -292,6 +298,14 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
 
   stopTurn(input: TurnStopInput, timeoutMs?: number): Promise<TurnSnapshot> {
     return this.request('turn.stop', input, timeoutMs);
+  }
+
+  queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan> {
+    return this.request('turn.resume.query', input, timeoutMs);
+  }
+
+  startTurnResume(input: TurnResumeStartInput, timeoutMs?: number): Promise<TurnResumeStartResult> {
+    return this.request('turn.resume.start', input, timeoutMs);
   }
 
   openSessionSubscription(

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -66,6 +66,7 @@ export type {
 export {
   TURN_MESSAGE_CONTENT_MAX_BYTES,
   TURN_MESSAGE_TEXT_MAX_BYTES,
+  TURN_RESUME_PARK_REASONS,
 } from './turn.js';
 export type {
   InFlightMessageSnapshot,
@@ -84,6 +85,11 @@ export type {
 } from './message.js';
 export type {
   TurnQueryInput,
+  TurnResumeParkReason,
+  TurnResumePlan,
+  TurnResumeQueryInput,
+  TurnResumeStartInput,
+  TurnResumeStartResult,
   TurnRunStatus,
   TurnSnapshot,
   TurnStartInput,

--- a/packages/runtime-host/src/protocol/turn.ts
+++ b/packages/runtime-host/src/protocol/turn.ts
@@ -12,6 +12,7 @@ import {
 import { invalidProtocolFrame } from './errors.js';
 import {
   assertExactKeys,
+  requireCount,
   requireEntityId,
   requireExactRecord,
   requireShapedRecord,
@@ -49,6 +50,53 @@ export interface TurnStopInput {
   turnId: string;
   runId: string;
 }
+
+export interface TurnResumeQueryInput {
+  sessionId: string;
+  sourceRunId?: string;
+  expectedRuntimeEventHighWater?: number;
+}
+
+export interface TurnResumeStartInput {
+  sessionId: string;
+  turnId: string;
+  sourceRunId: string;
+  sourceRuntimeEventHighWater: number;
+}
+
+export const TURN_RESUME_PARK_REASONS = [
+  'resume_candidate_missing',
+  'source_run_unreadable',
+  'safety_check_failed',
+  'continuation_already_exists',
+  'continuation_repair_required',
+  'continuation_started_indeterminate',
+  'continuation_unavailable',
+  'session_busy',
+] as const;
+
+export type TurnResumeParkReason = (typeof TURN_RESUME_PARK_REASONS)[number];
+
+export type TurnResumePlan =
+  | {
+      sessionId: string;
+      disposition: 'ready';
+      sourceRunId: string;
+      sourceTurnId: string;
+      sourceRuntimeEventHighWater: number;
+    }
+  | {
+      sessionId: string;
+      disposition: 'parked';
+      reason: TurnResumeParkReason;
+    };
+
+export type TurnResumeStartResult =
+  | { kind: 'started'; turn: TurnSnapshot }
+  | {
+      kind: 'parked';
+      plan: Extract<TurnResumePlan, { disposition: 'parked' }>;
+    };
 
 export type TurnRunStatus =
   | 'admitted'
@@ -124,6 +172,64 @@ export const TURN_OPERATION_SPECS = {
     ] as const,
     decodeInput: decodeTurnStopInput,
     decodeOutput: decodeTurnSnapshot,
+  }),
+  'turn.resume.query': defineOperation({
+    mode: 'query',
+    availability: 'ready',
+    errors: [
+      'host_not_ready',
+      'host_draining',
+      'operation_unavailable',
+      'not_found',
+      'session_archived',
+      'internal_failure',
+    ] as const,
+    decodeInput: decodeTurnResumeQueryInput,
+    decodeOutput: decodeTurnResumePlan,
+    assertOutputForInput: (input, output) => {
+      if (input.sessionId !== output.sessionId) {
+        throw invalidProtocolFrame('Turn resume query changed Session identity');
+      }
+      if (
+        output.disposition === 'ready' &&
+        input.sourceRunId !== undefined &&
+        input.sourceRunId !== output.sourceRunId
+      ) {
+        throw invalidProtocolFrame('Turn resume query changed source Run identity');
+      }
+      if (
+        output.disposition === 'ready' &&
+        input.expectedRuntimeEventHighWater !== undefined &&
+        input.expectedRuntimeEventHighWater !== output.sourceRuntimeEventHighWater
+      ) {
+        throw invalidProtocolFrame('Turn resume query changed source RuntimeEvent high-water');
+      }
+    },
+  }),
+  'turn.resume.start': defineOperation({
+    mode: 'command',
+    availability: 'ready',
+    errors: [
+      'host_not_ready',
+      'host_draining',
+      'operation_unavailable',
+      'not_found',
+      'session_archived',
+      'session_busy',
+      'operation_conflict',
+      'internal_failure',
+    ] as const,
+    decodeInput: decodeTurnResumeStartInput,
+    decodeOutput: decodeTurnResumeStartResult,
+    assertOutputForInput: (input, output) => {
+      const sessionId = output.kind === 'started' ? output.turn.sessionId : output.plan.sessionId;
+      if (input.sessionId !== sessionId) {
+        throw invalidProtocolFrame('Turn resume start changed Session identity');
+      }
+      if (output.kind === 'started' && input.turnId !== output.turn.turnId) {
+        throw invalidProtocolFrame('Turn resume start changed Turn identity');
+      }
+    },
   }),
 } as const;
 
@@ -253,6 +359,108 @@ function decodeTurnStopInput(value: unknown): TurnStopInput {
     turnId: requireEntityId(record.turnId, 'turnId'),
     runId: requireEntityId(record.runId, 'runId'),
   };
+}
+
+function decodeTurnResumeQueryInput(value: unknown): TurnResumeQueryInput {
+  const record = requireShapedRecord(
+    value,
+    'turn.resume.query input',
+    ['sessionId'],
+    ['sourceRunId', 'expectedRuntimeEventHighWater'],
+  );
+  if (record.expectedRuntimeEventHighWater !== undefined && record.sourceRunId === undefined) {
+    throw invalidProtocolFrame('Turn resume high-water requires a source Run');
+  }
+  return {
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    ...(record.sourceRunId !== undefined
+      ? { sourceRunId: requireEntityId(record.sourceRunId, 'sourceRunId') }
+      : {}),
+    ...(record.expectedRuntimeEventHighWater !== undefined
+      ? {
+          expectedRuntimeEventHighWater: requirePositiveCount(
+            record.expectedRuntimeEventHighWater,
+            'expectedRuntimeEventHighWater',
+          ),
+        }
+      : {}),
+  };
+}
+
+function decodeTurnResumeStartInput(value: unknown): TurnResumeStartInput {
+  const record = requireExactRecord(value, 'turn.resume.start input', [
+    'sessionId',
+    'turnId',
+    'sourceRunId',
+    'sourceRuntimeEventHighWater',
+  ]);
+  return {
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    turnId: requireEntityId(record.turnId, 'turnId'),
+    sourceRunId: requireEntityId(record.sourceRunId, 'sourceRunId'),
+    sourceRuntimeEventHighWater: requirePositiveCount(
+      record.sourceRuntimeEventHighWater,
+      'sourceRuntimeEventHighWater',
+    ),
+  };
+}
+
+export function decodeTurnResumePlan(value: unknown): TurnResumePlan {
+  const record = requireRecord(value, 'Turn resume plan');
+  if (record.disposition === 'ready') {
+    assertExactKeys(record, 'ready Turn resume plan', [
+      'sessionId',
+      'disposition',
+      'sourceRunId',
+      'sourceTurnId',
+      'sourceRuntimeEventHighWater',
+    ]);
+    return {
+      sessionId: requireEntityId(record.sessionId, 'sessionId'),
+      disposition: 'ready',
+      sourceRunId: requireEntityId(record.sourceRunId, 'sourceRunId'),
+      sourceTurnId: requireEntityId(record.sourceTurnId, 'sourceTurnId'),
+      sourceRuntimeEventHighWater: requirePositiveCount(
+        record.sourceRuntimeEventHighWater,
+        'sourceRuntimeEventHighWater',
+      ),
+    };
+  }
+  if (record.disposition === 'parked') {
+    assertExactKeys(record, 'parked Turn resume plan', ['sessionId', 'disposition', 'reason']);
+    if (!(TURN_RESUME_PARK_REASONS as readonly unknown[]).includes(record.reason)) {
+      throw invalidProtocolFrame('Invalid Turn resume park reason');
+    }
+    return {
+      sessionId: requireEntityId(record.sessionId, 'sessionId'),
+      disposition: 'parked',
+      reason: record.reason as TurnResumeParkReason,
+    };
+  }
+  throw invalidProtocolFrame('Invalid Turn resume disposition');
+}
+
+export function decodeTurnResumeStartResult(value: unknown): TurnResumeStartResult {
+  const record = requireRecord(value, 'Turn resume start result');
+  if (record.kind === 'started') {
+    assertExactKeys(record, 'started Turn resume result', ['kind', 'turn']);
+    return { kind: 'started', turn: decodeTurnSnapshot(record.turn) };
+  }
+  if (record.kind === 'parked') {
+    assertExactKeys(record, 'parked Turn resume result', ['kind', 'plan']);
+    const plan = decodeTurnResumePlan(record.plan);
+    if (plan.disposition !== 'parked') {
+      throw invalidProtocolFrame('Parked Turn resume result requires a parked plan');
+    }
+    return { kind: 'parked', plan };
+  }
+  throw invalidProtocolFrame('Invalid Turn resume start result');
+}
+
+function requirePositiveCount(value: unknown, label: string): number {
+  const count = requireCount(value, label);
+  if (count === 0) throw invalidProtocolFrame(`Invalid ${label}`);
+  return count;
 }
 
 export function decodeTurnSnapshot(value: unknown): TurnSnapshot {

--- a/packages/runtime-host/src/server/automation-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-coordinator.ts
@@ -217,6 +217,7 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
       fire.turnId !== admission.turnId ||
       fire.runId !== admission.runId ||
       fire.userMessageId !== admission.userMessageId ||
+      admission.normalizedInput === null ||
       !messageContentsEqual(fireContent(fire), admission.normalizedInput)
     ) {
       throw new AutomationAuthorityInvariantError(

--- a/packages/runtime-host/src/server/client-capability-coordinator.ts
+++ b/packages/runtime-host/src/server/client-capability-coordinator.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   buildMcpTools,
   mcpProxyToolName,
@@ -81,6 +82,26 @@ interface SessionCapabilityState {
   readonly turnBindings: ReadonlyMap<string, SessionCapabilityBinding>;
 }
 
+type SessionBindingSelection =
+  | {
+      readonly ok: true;
+      readonly state: SessionCapabilityState;
+      readonly modelToolsChanged: boolean;
+    }
+  | { readonly ok: false; readonly message: string };
+
+type SessionBindingResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly message: string };
+
+export type SessionBindingPreview<T> =
+  | {
+      readonly ok: true;
+      readonly value: T;
+      commit(): Promise<SessionBindingResult>;
+    }
+  | { readonly ok: false; readonly message: string };
+
 interface SelectedOfferBinding {
   readonly registration: CapabilityRegistration;
   readonly offer: FrozenOfferBinding;
@@ -120,6 +141,8 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
   readonly #onModelToolsChanged: () => void;
   readonly #providers = new Map<string, ClientProviderState>();
   readonly #sessions = new Map<string, SessionCapabilityState>();
+  readonly #previewSessions = new AsyncLocalStorage<ReadonlyMap<string, SessionCapabilityState>>();
+  readonly #pendingConnectionReleases = new Set<Promise<void>>();
   readonly #invocations: ClientCapabilityInvocationBroker<CapabilityRegistration>;
   #revision = 0;
   #draining = false;
@@ -143,16 +166,15 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       throw new Error('Client Capability connection already has a sender');
     }
     provider.sender = sender;
-    let closed = false;
+    let closeTask: Promise<void> | undefined;
     return {
       accept: (frame) => {
-        if (closed) return;
+        if (closeTask) return;
         this.#invocations.accept(connectionId, frame);
       },
       close: () => {
-        if (closed) return;
-        closed = true;
-        this.releaseConnection(connectionId);
+        closeTask ??= this.releaseConnection(connectionId);
+        return closeTask;
       },
     };
   }
@@ -175,133 +197,196 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     sessionId: string,
     initiatingConnectionId: string,
     mode: SessionBindingMode,
-  ): Promise<{ readonly ok: true } | { readonly ok: false; readonly message: string }> {
+  ): Promise<SessionBindingResult> {
     return this.#activation.runMutation(async () => {
-      const previousState = this.#sessions.get(sessionId);
-      const previous = previousState?.sessionBindings ?? new Map();
-      const eligible = this.#eligibleOffersByContract();
-      const previousInitiatingConnection = previousState?.initiatingConnectionId;
-      const next = new Map<string, SessionCapabilityBinding>();
-      const selected: SelectedOfferBinding[] = [];
-      const sessionContractIds = new Set([
-        ...previous.keys(),
-        ...[...eligible]
-          .filter(([, candidates]) => candidates[0]?.offer.offer.affinity === 'session')
-          .map(([contractId]) => contractId),
-      ]);
-
-      for (const contractId of [...sessionContractIds].sort()) {
-        const previousBinding = previous.get(contractId);
-        const candidates = eligible.get(contractId) ?? [];
-        let candidate: SelectedOfferBinding | undefined;
-        if (previousBinding?.kind === 'bound') {
-          candidate = candidates.find(
-            (entry) => entry.registration.connectionId === previousBinding.connectionId,
-          );
-          if (!candidate) {
-            if (mode === 'degrade') {
-              next.set(contractId, { kind: 'lost' });
-              continue;
-            }
-            return {
-              ok: false,
-              message:
-                'A Session-bound Client Capability provider is no longer available for its frozen contract',
-            };
-          }
-        } else if (previousBinding?.kind === 'lost') {
-          candidate =
-            candidates.find(
-              (entry) => entry.registration.connectionId === initiatingConnectionId,
-            ) ?? (candidates.length === 1 ? candidates[0] : undefined);
-          if (!candidate) {
-            if (mode === 'degrade') {
-              next.set(contractId, previousBinding);
-              continue;
-            }
-            return {
-              ok: false,
-              message:
-                'A lost Client Capability binding requires a compatible initiating Client to rebind',
-            };
-          }
-        } else {
-          candidate =
-            candidates.find(
-              (entry) => entry.registration.connectionId === initiatingConnectionId,
-            ) ?? (candidates.length === 1 ? candidates[0] : undefined);
-          if (!candidate && candidates.length > 1) {
-            if (mode === 'degrade') continue;
-            return {
-              ok: false,
-              message:
-                'Multiple Client Capability providers offer the same contract and no initiating provider can be selected',
-            };
-          }
-        }
-        if (!candidate) continue;
-        next.set(contractId, {
-          kind: 'bound',
-          connectionId: candidate.registration.connectionId,
-        });
-        selected.push(candidate);
-      }
-
-      const proxyNames = new Map<string, string>();
-      for (const candidate of selected) {
-        if (offerConflictsWithProxyNames(candidate.offer, proxyNames)) {
-          if (mode === 'degrade') {
-            if (previous.has(candidate.offer.contractId)) {
-              next.set(candidate.offer.contractId, { kind: 'lost' });
-            } else {
-              next.delete(candidate.offer.contractId);
-            }
-            continue;
-          }
-          return {
-            ok: false,
-            message: 'Client Capability contracts expose conflicting model tool identities',
-          };
-        }
-        rememberOfferProxyNames(candidate.offer, proxyNames);
-      }
-
-      const previousTurn = previousState?.turnBindings ?? new Map();
-      const nextTurn = new Map<string, SessionCapabilityBinding>();
-      for (const [contractId, candidates] of [...eligible].sort(([left], [right]) =>
-        left.localeCompare(right),
-      )) {
-        if (candidates[0]?.offer.offer.affinity !== 'turn') continue;
-        const candidate =
-          candidates.find((entry) => entry.registration.connectionId === initiatingConnectionId) ??
-          (candidates.length === 1 ? candidates[0] : undefined);
-        if (!candidate || offerConflictsWithProxyNames(candidate.offer, proxyNames)) continue;
-        nextTurn.set(contractId, {
-          kind: 'bound',
-          connectionId: candidate.registration.connectionId,
-        });
-        rememberOfferProxyNames(candidate.offer, proxyNames);
-      }
-
-      const bindingsChanged = !bindingMapsEqual(previous, next);
-      const turnBindingsChanged = !bindingMapsEqual(previousTurn, nextTurn);
-      this.#storeSessionState(sessionId, {
-        initiatingConnectionId,
-        sessionBindings: next,
-        turnBindings: nextTurn,
-      });
-      const callSelectionChanged =
-        previousInitiatingConnection !== initiatingConnectionId &&
-        [...eligible.values()].some((candidates) => candidates[0]?.offer.offer.affinity === 'call');
-      if (bindingsChanged || turnBindingsChanged || callSelectionChanged) {
-        this.#onModelToolsChanged();
-      }
+      const selection = this.#selectSessionState(sessionId, initiatingConnectionId, mode);
+      if (!selection.ok) return selection;
+      this.#storeSessionState(sessionId, selection.state);
+      if (selection.modelToolsChanged) this.#onModelToolsChanged();
       return { ok: true };
     });
   }
 
+  async runWithSessionBindingPreview<T>(
+    sessionId: string,
+    initiatingConnectionId: string,
+    operation: () => Promise<T>,
+  ): Promise<SessionBindingPreview<T>> {
+    return this.#activation.runReadActivation(async () => {
+      const registryRevision = this.#revision;
+      const selection = this.#selectSessionState(sessionId, initiatingConnectionId, 'strict');
+      if (!selection.ok) return selection;
+      const inherited = this.#previewSessions.getStore();
+      const preview = new Map(inherited ?? []);
+      preview.set(sessionId, selection.state);
+      return {
+        ok: true,
+        value: await this.#previewSessions.run(preview, operation),
+        commit: () =>
+          this.#commitSessionBindingPreview(
+            sessionId,
+            initiatingConnectionId,
+            registryRevision,
+            selection.state,
+          ),
+      };
+    });
+  }
+
+  #commitSessionBindingPreview(
+    sessionId: string,
+    initiatingConnectionId: string,
+    registryRevision: number,
+    previewState: SessionCapabilityState,
+  ): Promise<SessionBindingResult> {
+    return this.#activation.runMutation(async () => {
+      if (this.#revision !== registryRevision) {
+        return {
+          ok: false,
+          message: 'Client Capability registry changed after continuation safety preview',
+        };
+      }
+      const selection = this.#selectSessionState(sessionId, initiatingConnectionId, 'strict');
+      if (!selection.ok) return selection;
+      if (!sessionCapabilityStatesEqual(selection.state, previewState)) {
+        return {
+          ok: false,
+          message: 'Client Capability Session binding changed after continuation safety preview',
+        };
+      }
+      this.#storeSessionState(sessionId, selection.state);
+      if (selection.modelToolsChanged) this.#onModelToolsChanged();
+      return { ok: true };
+    });
+  }
+
+  #selectSessionState(
+    sessionId: string,
+    initiatingConnectionId: string,
+    mode: SessionBindingMode,
+  ): SessionBindingSelection {
+    const previousState = this.#sessions.get(sessionId);
+    const previous = previousState?.sessionBindings ?? new Map();
+    const eligible = this.#eligibleOffersByContract();
+    const next = new Map<string, SessionCapabilityBinding>();
+    const selected: SelectedOfferBinding[] = [];
+    const sessionContractIds = new Set([
+      ...previous.keys(),
+      ...[...eligible]
+        .filter(([, candidates]) => candidates[0]?.offer.offer.affinity === 'session')
+        .map(([contractId]) => contractId),
+    ]);
+
+    for (const contractId of [...sessionContractIds].sort()) {
+      const previousBinding = previous.get(contractId);
+      const candidates = eligible.get(contractId) ?? [];
+      let candidate: SelectedOfferBinding | undefined;
+      if (previousBinding?.kind === 'bound') {
+        candidate = candidates.find(
+          (entry) => entry.registration.connectionId === previousBinding.connectionId,
+        );
+        if (!candidate) {
+          if (mode === 'degrade') {
+            next.set(contractId, { kind: 'lost' });
+            continue;
+          }
+          return {
+            ok: false,
+            message:
+              'A Session-bound Client Capability provider is no longer available for its frozen contract',
+          };
+        }
+      } else if (previousBinding?.kind === 'lost') {
+        candidate =
+          candidates.find((entry) => entry.registration.connectionId === initiatingConnectionId) ??
+          (candidates.length === 1 ? candidates[0] : undefined);
+        if (!candidate) {
+          if (mode === 'degrade') {
+            next.set(contractId, previousBinding);
+            continue;
+          }
+          return {
+            ok: false,
+            message:
+              'A lost Client Capability binding requires a compatible initiating Client to rebind',
+          };
+        }
+      } else {
+        candidate =
+          candidates.find((entry) => entry.registration.connectionId === initiatingConnectionId) ??
+          (candidates.length === 1 ? candidates[0] : undefined);
+        if (!candidate && candidates.length > 1) {
+          if (mode === 'degrade') continue;
+          return {
+            ok: false,
+            message:
+              'Multiple Client Capability providers offer the same contract and no initiating provider can be selected',
+          };
+        }
+      }
+      if (!candidate) continue;
+      next.set(contractId, {
+        kind: 'bound',
+        connectionId: candidate.registration.connectionId,
+      });
+      selected.push(candidate);
+    }
+
+    const proxyNames = new Map<string, string>();
+    for (const candidate of selected) {
+      if (offerConflictsWithProxyNames(candidate.offer, proxyNames)) {
+        if (mode === 'degrade') {
+          if (previous.has(candidate.offer.contractId)) {
+            next.set(candidate.offer.contractId, { kind: 'lost' });
+          } else {
+            next.delete(candidate.offer.contractId);
+          }
+          continue;
+        }
+        return {
+          ok: false,
+          message: 'Client Capability contracts expose conflicting model tool identities',
+        };
+      }
+      rememberOfferProxyNames(candidate.offer, proxyNames);
+    }
+
+    const previousTurn = previousState?.turnBindings ?? new Map();
+    const nextTurn = new Map<string, SessionCapabilityBinding>();
+    for (const [contractId, candidates] of [...eligible].sort(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      if (candidates[0]?.offer.offer.affinity !== 'turn') continue;
+      const candidate =
+        candidates.find((entry) => entry.registration.connectionId === initiatingConnectionId) ??
+        (candidates.length === 1 ? candidates[0] : undefined);
+      if (!candidate || offerConflictsWithProxyNames(candidate.offer, proxyNames)) continue;
+      nextTurn.set(contractId, {
+        kind: 'bound',
+        connectionId: candidate.registration.connectionId,
+      });
+      rememberOfferProxyNames(candidate.offer, proxyNames);
+    }
+
+    return {
+      ok: true,
+      state: {
+        initiatingConnectionId,
+        sessionBindings: next,
+        turnBindings: nextTurn,
+      },
+      modelToolsChanged:
+        !bindingMapsEqual(previous, next) ||
+        !bindingMapsEqual(previousTurn, nextTurn) ||
+        (previousState?.initiatingConnectionId !== initiatingConnectionId &&
+          [...eligible.values()].some(
+            (candidates) => candidates[0]?.offer.offer.affinity === 'call',
+          )),
+    };
+  }
+
   snapshotForSession(sessionId: string): ClientCapabilitySnapshot | undefined {
-    const state = this.#sessions.get(sessionId);
+    const state = this.#previewSessions.getStore()?.get(sessionId) ?? this.#sessions.get(sessionId);
     const bindings = state?.sessionBindings;
     const turnBindings = state?.turnBindings;
     const selected: SnapshotOfferBinding[] = [];
@@ -442,7 +527,18 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     for (const sessionId of new Set(sessionIds)) this.#sessions.delete(sessionId);
   }
 
-  releaseConnection(connectionId: string): void {
+  releaseConnection(connectionId: string): Promise<void> {
+    this.#invocations.releaseConnection(connectionId);
+    let task!: Promise<void>;
+    task = this.#activation
+      .runMutation(() => this.#releaseConnectionState(connectionId))
+      .finally(() => this.#pendingConnectionReleases.delete(task));
+    this.#pendingConnectionReleases.add(task);
+    void task.catch(() => undefined);
+    return task;
+  }
+
+  #releaseConnectionState(connectionId: string): void {
     const provider = this.#providers.get(connectionId);
     if (!provider) return;
     provider.sender = undefined;
@@ -455,7 +551,6 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       this.#revision += 1;
       if (hasModelToolOffers(registration)) this.#onModelToolsChanged();
     }
-    this.#invocations.releaseConnection(connectionId);
     for (const registration of [...provider.registrations.values()]) {
       this.#releaseRegistrationIfUnused(registration);
     }
@@ -467,11 +562,12 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     this.#draining = true;
   }
 
-  close(): void {
+  async close(): Promise<void> {
     this.beginDrain();
     for (const connectionId of [...this.#providers.keys()]) {
       this.releaseConnection(connectionId);
     }
+    await Promise.allSettled([...this.#pendingConnectionReleases]);
     this.#invocations.close();
     this.#sessions.clear();
   }
@@ -960,6 +1056,17 @@ function bindingMapsEqual(
     }
   }
   return true;
+}
+
+function sessionCapabilityStatesEqual(
+  left: SessionCapabilityState,
+  right: SessionCapabilityState,
+): boolean {
+  return (
+    left.initiatingConnectionId === right.initiatingConnectionId &&
+    bindingMapsEqual(left.sessionBindings, right.sessionBindings) &&
+    bindingMapsEqual(left.turnBindings, right.turnBindings)
+  );
 }
 
 function asError(value: unknown): Error {

--- a/packages/runtime-host/src/server/client-capability-service.ts
+++ b/packages/runtime-host/src/server/client-capability-service.ts
@@ -6,7 +6,7 @@ export interface ClientCapabilityConnectionSender {
 
 export interface ClientCapabilityConnection {
   accept(frame: ClientCapabilityClientFrame): void;
-  close(): void;
+  close(): Promise<void>;
 }
 
 /** Pure full-duplex seam kept outside the Runtime-backed execution composition. */

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -226,7 +226,7 @@ export class RuntimeHostConnectionSession {
   }
 
   #detachClientCapabilities(): void {
-    this.#clientCapabilities?.close();
+    void this.#clientCapabilities?.close();
     this.#clientCapabilities = undefined;
     this.#clientCapabilityService = undefined;
   }

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -5,6 +5,7 @@ import {
   AgentGraphSupervisorWakeCoordinator,
   agentGraphIdForRootSession,
   BackendRegistry,
+  createLocalContinuationSafetyInspector,
   createBuiltinSandboxManager,
   createFilesystemWorkerLaunchSpecProvider,
   FakeBackend,
@@ -37,6 +38,7 @@ import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtim
 import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-authority';
 import { openInteractiveShellRunStoreForWrite } from '@maka/storage/shell-run-authority';
 import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
+import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
 import { CanonicalSessionProjectionReader } from './canonical-session-projection.js';
 import {
   bindHostChildAgentBackend,
@@ -49,7 +51,11 @@ import { HostAutomationCoordinator } from './automation-coordinator.js';
 import { recoverClientCapabilityOutcomes } from './client-capability-recovery.js';
 import { HostConnectionEffectCoordinator } from './connection-effect-coordinator.js';
 import { HostClientCapabilityCoordinator } from './client-capability-coordinator.js';
-import { createHostAiSdkBackend, createHostGoalEvaluator } from './execution-model-composition.js';
+import {
+  createHostAiSdkBackend,
+  createHostExecutionModelComposition,
+  createHostGoalEvaluator,
+} from './execution-model-composition.js';
 import { HostExecutionInspectCoordinator } from './execution-inspect-coordinator.js';
 import { HostGoalCoordinator } from './goal-coordinator.js';
 import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './host-kernel.js';
@@ -337,6 +343,54 @@ export async function createExecutionRuntimeHostComposition(
       backends,
       newId: randomUUID,
       now: Date.now,
+      safeBoundaryResumeEnabled: process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME === '1',
+      inspectContinuationSafety: createLocalContinuationSafetyInspector({
+        readSessionCwd: async (sessionId) =>
+          (await stores.sessionStore.readHeaderSnapshot(sessionId)).cwd,
+        resolveWorkspaceIdentity: async (cwd) => resolveWorkspaceIdentity({ path: cwd }),
+        listAvailableToolNames: async (sessionId) => {
+          const capabilitySnapshot =
+            requireClientCapabilities(clientCapabilities).snapshotForSession(sessionId);
+          try {
+            const graphTools =
+              await requireGraphCoordinator(graphCoordinator).toolsForSession(sessionId);
+            return createHostExecutionModelComposition({
+              policy: runtimePolicyStores.runtimePolicy,
+              skills,
+              memory: requireMemory(memory),
+              taskLedger,
+              ...(capabilitySnapshot ? { clientCapabilities: capabilitySnapshot } : {}),
+              builtinTools,
+              hostTools: [...hostTools, ...graphTools],
+              automationTool: requireAutomationCoordinator(automations).modelTool,
+              goalTools: requireGoal(goal).tools,
+              parentAgentTools: childAgentTools.parentTools,
+            }).tools.map((tool) => tool.name);
+          } finally {
+            capabilitySnapshot?.release();
+          }
+        },
+        hasPendingBackgroundOperations: async (sessionId) => {
+          const graph = requireGraphCoordinator(graphCoordinator);
+          const graphWake = requireGraphSupervisorWake(graphSupervisorWake);
+          const [resourcesLive, graphLive, descendantLive] = await Promise.all([
+            runtimeResources!.hasLiveSessionResources(sessionId),
+            graph.hasLiveSessionState(sessionId),
+            hasLiveLinkedDescendantState(
+              requireSessionManager(manager),
+              stores.agentRunStore,
+              sessionId,
+              async (descendantSessionId) =>
+                (await runtimeResources!.hasLiveSessionResources(descendantSessionId)) ||
+                graph.hasLiveSessionState(descendantSessionId) ||
+                graphWake.hasLiveSessionState(descendantSessionId),
+            ),
+          ]);
+          return (
+            resourcesLive || graphLive || graphWake.hasLiveSessionState(sessionId) || descendantLive
+          );
+        },
+      }),
       runBackendActivation: (operation) => runtimePolicyActivation.runBackendActivation(operation),
       messageAuthority: runtimeAuthority,
       hostedAgentGraphExecution: {
@@ -744,7 +798,7 @@ export async function createExecutionRuntimeHostComposition(
           errors.push(error);
         }
         try {
-          clientCapabilities?.close();
+          await clientCapabilities?.close();
         } catch (error) {
           errors.push(error);
         }
@@ -933,4 +987,41 @@ function requireGraphSupervisorWake(
 function requireGoal(coordinator: HostGoalCoordinator | undefined): HostGoalCoordinator {
   if (!coordinator) throw new Error('Runtime Host Goal coordinator is not composed');
   return coordinator;
+}
+
+async function hasLiveLinkedDescendantState(
+  manager: SessionManager,
+  runStore: {
+    listSessionRuns(sessionId: string): Promise<readonly { status: string }[]>;
+  },
+  rootSessionId: string,
+  hasLiveSessionState: (sessionId: string) => Promise<boolean>,
+): Promise<boolean> {
+  const pending = [rootSessionId];
+  const seen = new Set(pending);
+  while (pending.length > 0) {
+    const parentSessionId = pending.shift()!;
+    const children = await manager.listChildSessions(parentSessionId);
+    for (const child of children) {
+      if (seen.has(child.id)) continue;
+      seen.add(child.id);
+      pending.push(child.id);
+      const [runs, liveState] = await Promise.all([
+        runStore.listSessionRuns(child.id),
+        hasLiveSessionState(child.id),
+      ]);
+      if (liveState) return true;
+      if (
+        runs.some(
+          (run) =>
+            run.status === 'created' ||
+            run.status === 'running' ||
+            run.status === 'waiting_for_user',
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/packages/runtime-host/src/server/host-session-availability.ts
+++ b/packages/runtime-host/src/server/host-session-availability.ts
@@ -3,6 +3,8 @@ import { isDeepResearchSession, type SessionHeader } from '@maka/core/session';
 
 const WORKTREE_CHILD_UNAVAILABLE_REASON =
   'Worktree child Sessions must be continued through their parent agent.';
+const CHILD_CONTINUATION_UNAVAILABLE_REASON =
+  'Child Sessions must be continued through their parent agent.';
 
 export function runtimeHostSessionUnavailableReason(
   header: Pick<SessionHeader, 'collaborationMode' | 'labels'>,
@@ -20,6 +22,18 @@ export function runtimeHostExternalTurnUnavailableReason(
   header: Pick<SessionHeader, 'collaborationMode' | 'labels' | 'subagentWorkspace'>,
 ): string | undefined {
   return runtimeHostExecutionUnavailableReason(header, { kind: 'external_message' });
+}
+
+export function runtimeHostSafeBoundaryContinuationUnavailableReason(
+  header: Pick<
+    SessionHeader,
+    'collaborationMode' | 'labels' | 'subagentParent' | 'subagentWorkspace'
+  >,
+): string | undefined {
+  return (
+    runtimeHostSessionUnavailableReason(header) ??
+    (header.subagentParent ? CHILD_CONTINUATION_UNAVAILABLE_REASON : undefined)
+  );
 }
 
 export function runtimeHostExecutionUnavailableReason(

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -34,7 +34,10 @@ export type OperationHandlerMap = {
 };
 
 export type DomainOperationKey = Exclude<OperationKey, 'host.status'>;
-export type TurnOperationKey = Extract<OperationKey, 'turn.start' | 'turn.query' | 'turn.stop'>;
+export type TurnOperationKey = Extract<
+  OperationKey,
+  'turn.start' | 'turn.query' | 'turn.stop' | 'turn.resume.query' | 'turn.resume.start'
+>;
 export type RuntimePolicyOperationKey = Extract<
   OperationKey,
   `runtime.policy.${string}` | `connection.catalog.${string}` | `credential.vault.${string}`

--- a/packages/runtime-host/src/server/root-admission-owner.ts
+++ b/packages/runtime-host/src/server/root-admission-owner.ts
@@ -101,7 +101,9 @@ function sameRootAdmission(left: RootTurnAdmission, right: RootTurnAdmission): b
     isDeepStrictEqual(left.execution, right.execution) &&
     isDeepStrictEqual(left.turnOrchestration, right.turnOrchestration) &&
     left.previousRootTurnId === right.previousRootTurnId &&
-    messageContentsEqual(left.normalizedInput, right.normalizedInput) &&
+    (left.normalizedInput === null || right.normalizedInput === null
+      ? left.normalizedInput === right.normalizedInput
+      : messageContentsEqual(left.normalizedInput, right.normalizedInput)) &&
     left.sourceMessages.length === right.sourceMessages.length &&
     left.sourceMessages.every((source, index) => {
       const other = right.sourceMessages[index];
@@ -131,7 +133,8 @@ function snapshotAdmission(admission: RootTurnAdmission): RootTurnAdmission {
     ...(admission.turnOrchestration
       ? { turnOrchestration: Object.freeze({ ...admission.turnOrchestration }) }
       : {}),
-    normalizedInput: snapshotMessageContent(admission.normalizedInput),
+    normalizedInput:
+      admission.normalizedInput === null ? null : snapshotMessageContent(admission.normalizedInput),
     sourceMessages: Object.freeze(sourceMessages),
   });
 }

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { isDeepStrictEqual } from 'node:util';
 import type { BackendStopMode } from '@maka/core/backend-types';
 import {
@@ -25,6 +25,8 @@ import {
   RuntimeMessageAuthorityInvariantError,
   RuntimeOwnerCleanupError,
   recoverAgentGraphSupervisorContextOverflow,
+  type RuntimeContinuation,
+  type SafeBoundaryContinuationPlan,
   type RuntimeHostedRootExecutionInput,
   type RuntimeMessageRunIdentity,
   type SessionManager,
@@ -46,6 +48,9 @@ import {
 import type {
   OperationOutcome,
   TurnQueryInput,
+  TurnResumePlan,
+  TurnResumeQueryInput,
+  TurnResumeStartInput,
   TurnSnapshot,
   TurnStartInput,
   TurnStopInput,
@@ -69,10 +74,14 @@ import {
   type RuntimeSessionTransientEvent,
   SessionContinuityCoordinator,
 } from './session-continuity-coordinator.js';
-import type { HostClientCapabilityCoordinator } from './client-capability-coordinator.js';
+import type {
+  HostClientCapabilityCoordinator,
+  SessionBindingPreview,
+} from './client-capability-coordinator.js';
 import {
   runtimeHostExecutionUnavailableReason,
   runtimeHostExternalTurnUnavailableReason,
+  runtimeHostSafeBoundaryContinuationUnavailableReason,
 } from './host-session-availability.js';
 
 type RootTerminalInteractionFence = Pick<
@@ -85,6 +94,7 @@ interface ActiveRootTurn {
   runId: string;
   userMessageId: string | null;
   execution?: RuntimeHostedRootExecutionInput;
+  continuation?: RuntimeContinuation;
   descriptor: RootExecutionDescriptor;
   observedGoalSettler?: GoalObservedTurnSettler;
   goalOutcome: ValueDeferred<GoalTurnOutcome>;
@@ -97,6 +107,31 @@ interface ActiveRootTurn {
 }
 
 type TurnStartOutcome = OperationOutcome<'turn.start'>;
+
+type RootTurnActivationInput =
+  | TurnStartInput
+  | {
+      sessionId: string;
+      turnId: string;
+      content: null;
+      turnOrchestration?: undefined;
+    };
+
+type TurnResumeStartOutcome = OperationOutcome<'turn.resume.start'>;
+
+type TurnResumeStartDisposition =
+  | TurnStartDisposition
+  | {
+      kind: 'parked';
+      plan: Extract<TurnResumePlan, { disposition: 'parked' }>;
+    };
+
+type ReconstructedContinuation =
+  | { disposition: 'ready'; continuation: RuntimeContinuation }
+  | {
+      disposition: 'parked';
+      plan: Extract<TurnResumePlan, { disposition: 'parked' }>;
+    };
 
 type TurnStartDisposition =
   | { kind: 'complete'; outcome: TurnStartOutcome }
@@ -127,11 +162,22 @@ interface ValueDeferred<T> {
 }
 
 interface RootTurnReservation {
+  readonly kind: 'pending';
   readonly sessionId: string;
   readonly whenIdle: Deferred;
   readonly admissionSettled: Deferred;
   admissionPhase: 'prepared' | 'committing';
 }
+
+interface ParkedContinuationReservation {
+  readonly kind: 'parked_continuation';
+  readonly sessionId: string;
+  readonly admission: RootTurnAdmission;
+  readonly whenIdle: Deferred;
+  readonly admissionSettled: Deferred;
+}
+
+type SessionRootReservation = RootTurnReservation | ParkedContinuationReservation;
 
 interface GoalRootReservation extends RootTurnReservation {
   readonly turnId: string;
@@ -185,10 +231,12 @@ export class RootTurnCoordinator {
     'turn.start': (input, context) => this.startTurn(input, context),
     'turn.query': (input) => this.queryTurn(input),
     'turn.stop': (input) => this.stopTurn(input),
+    'turn.resume.query': (input, context) => this.queryTurnResume(input, context),
+    'turn.resume.start': (input, context) => this.startTurnResume(input, context),
   };
 
   readonly #activeBySession = new Map<string, ActiveRootTurn>();
-  readonly #reservationsBySession = new Map<string, RootTurnReservation>();
+  readonly #reservationsBySession = new Map<string, SessionRootReservation>();
   readonly #recoveryAdmissionsBySession = new Map<string, readonly RootTurnAdmission[]>();
   private readonly stores: ExecutionStoresWriter<'interactive'>;
   #draining = false;
@@ -260,10 +308,18 @@ export class RootTurnCoordinator {
             throw new Error(`Admitted Turn ${admission.turnId} must not record a UserMessage`);
           }
           if (!run) {
-            pendingRecoveryClosures.push(admission);
+            if (executionContract.pendingWithoutRun === 'root_replay') {
+              pending.push(admission);
+            } else {
+              pendingRecoveryClosures.push(admission);
+            }
             continue;
           }
-          assertRunMatchesAdmission(run, admission);
+          if (admission.execution.kind === 'safe_boundary_continuation') {
+            assertRunMatchesExecution(run, admission.turnId, admission.execution);
+          } else {
+            await this.assertRunMatchesDurableExecution(run, admission.turnId, admission.execution);
+          }
           continue;
         }
         if (messageIdOwners.length > 1) {
@@ -284,7 +340,7 @@ export class RootTurnCoordinator {
               !recoveryUserMessageOriginMatches(userMessage, admission.execution) ||
               !messageContentsEqual(
                 storedUserMessageContent(userMessage),
-                admission.normalizedInput,
+                requireAdmissionMessageContent(admission),
               )
             ) {
               throw new Error(`Admitted Turn ${admission.turnId} does not match its UserMessage`);
@@ -307,7 +363,7 @@ export class RootTurnCoordinator {
           pending.push(admission);
           continue;
         }
-        assertRunMatchesAdmission(run, admission);
+        await this.assertRunMatchesDurableExecution(run, admission.turnId, admission.execution);
         if (userMessages.length > 1) {
           throw new Error(`Admitted Turn ${admission.turnId} has multiple UserMessages`);
         }
@@ -317,7 +373,10 @@ export class RootTurnCoordinator {
             messageIdOwner !== userMessage ||
             userMessage.id !== admission.userMessageId ||
             !recoveryUserMessageOriginMatches(userMessage, admission.execution) ||
-            !messageContentsEqual(storedUserMessageContent(userMessage), admission.normalizedInput)
+            !messageContentsEqual(
+              storedUserMessageContent(userMessage),
+              requireAdmissionMessageContent(admission),
+            )
           ) {
             throw new Error(`Admitted Turn ${admission.turnId} does not match its UserMessage`);
           }
@@ -352,7 +411,8 @@ export class RootTurnCoordinator {
       for (const admission of plan.pendingRecoveryClosures) {
         if (
           admission.execution.kind === 'external_message' ||
-          admission.execution.kind === 'automation'
+          admission.execution.kind === 'automation' ||
+          admission.execution.kind === 'safe_boundary_continuation'
         ) {
           throw new Error('Root-replay admission cannot use Host recovery closure');
         }
@@ -377,6 +437,7 @@ export class RootTurnCoordinator {
           pending = admission;
           continue;
         }
+        await this.assertRunMatchesDurableExecution(run, admission.turnId, admission.execution);
         const snapshot = await this.readCanonicalSnapshot(
           sessionId,
           admission.turnId,
@@ -384,22 +445,51 @@ export class RootTurnCoordinator {
           run,
         );
         if (!isTerminalSnapshot(snapshot)) {
-          throw new Error(`Startup recovery left Turn ${admission.turnId} non-terminal`);
+          if (admission.execution.kind !== 'safe_boundary_continuation') {
+            throw new Error(`Startup recovery left Turn ${admission.turnId} non-terminal`);
+          }
+          this.parkContinuationAdmission(admission);
         }
       }
       const admission = pending;
       if (!admission) continue;
-      const input = {
-        sessionId,
-        turnId: admission.turnId,
-        content: normalizeMessageContent(admission.normalizedInput),
-        ...(admission.turnOrchestration
-          ? { turnOrchestration: { ...admission.turnOrchestration } }
-          : {}),
-      };
-      const disposition = await this.sessionAdmission.run(sessionId, (lease) =>
-        this.prepareAdmittedTurn(input, admission, this.acquireRecoveryResidency, lease),
-      );
+      const input = activationInputForAdmission(admission);
+      const disposition = await this.sessionAdmission.run(sessionId, async (lease) => {
+        if (admission.execution.kind === 'safe_boundary_continuation') {
+          const header = await this.stores.sessionStore.readHeaderSnapshot(sessionId);
+          if (runtimeHostSafeBoundaryContinuationUnavailableReason(header)) {
+            this.parkContinuationAdmission(admission);
+            return undefined;
+          }
+        }
+        const continuation =
+          admission.execution.kind === 'safe_boundary_continuation'
+            ? await this.reconstructAdmittedContinuation(admission)
+            : undefined;
+        if (continuation?.disposition === 'parked') {
+          if (
+            continuation.plan.reason === 'safety_check_failed' ||
+            continuation.plan.reason === 'continuation_unavailable'
+          ) {
+            this.parkContinuationAdmission(admission);
+            return undefined;
+          }
+          throw new Error(
+            `Unable to recover admitted Turn ${admission.turnId}: ${continuation.plan.reason}`,
+          );
+        }
+        return this.prepareAdmittedTurn(
+          input,
+          admission,
+          this.acquireRecoveryResidency,
+          lease,
+          undefined,
+          undefined,
+          undefined,
+          continuation?.continuation,
+        );
+      });
+      if (!disposition) continue;
       const outcome = await this.resolveStartDisposition(input, disposition);
       if (!outcome.ok) {
         throw new Error(
@@ -476,6 +566,7 @@ export class RootTurnCoordinator {
       return undefined;
     }
     const reservation: RootTurnReservation = {
+      kind: 'pending',
       sessionId,
       whenIdle: deferred(),
       admissionSettled: deferred(),
@@ -483,6 +574,61 @@ export class RootTurnCoordinator {
     };
     this.#reservationsBySession.set(sessionId, reservation);
     return reservation;
+  }
+
+  private parkContinuationAdmission(admission: RootTurnAdmission): void {
+    const existing = this.#reservationsBySession.get(admission.sessionId);
+    if (existing) {
+      if (
+        existing.kind !== 'parked_continuation' ||
+        existing.admission.turnId !== admission.turnId ||
+        existing.admission.runId !== admission.runId
+      ) {
+        throw new RuntimeMessageAuthorityInvariantError(
+          `Session ${admission.sessionId} has conflicting parked continuations`,
+        );
+      }
+      return;
+    }
+    this.#reservationsBySession.set(admission.sessionId, {
+      kind: 'parked_continuation',
+      sessionId: admission.sessionId,
+      admission,
+      whenIdle: deferred(),
+      admissionSettled: deferred(),
+    });
+  }
+
+  private takeParkedContinuationReservation(
+    admission: RootTurnAdmission,
+  ): RootTurnReservation | undefined {
+    const parked = this.#reservationsBySession.get(admission.sessionId);
+    if (parked?.kind !== 'parked_continuation') return;
+    if (
+      parked.admission.turnId !== admission.turnId ||
+      parked.admission.runId !== admission.runId
+    ) {
+      return;
+    }
+    const reservation: RootTurnReservation = {
+      kind: 'pending',
+      sessionId: parked.sessionId,
+      whenIdle: parked.whenIdle,
+      admissionSettled: parked.admissionSettled,
+      admissionPhase: 'prepared',
+    };
+    this.#reservationsBySession.set(admission.sessionId, reservation);
+    return reservation;
+  }
+
+  private clearParkedContinuationAdmission(admission: RootTurnAdmission): void {
+    const reservation = this.takeParkedContinuationReservation(admission);
+    if (reservation) this.releaseRootReservation(reservation);
+  }
+
+  private parkedContinuationAdmission(sessionId: string): RootTurnAdmission | undefined {
+    const reservation = this.#reservationsBySession.get(sessionId);
+    return reservation?.kind === 'parked_continuation' ? reservation.admission : undefined;
   }
 
   private beginRootAdmission(reservation: RootTurnReservation): boolean {
@@ -493,7 +639,7 @@ export class RootTurnCoordinator {
     return true;
   }
 
-  private releaseRootReservation(reservation: RootTurnReservation): void {
+  private releaseRootReservation(reservation: SessionRootReservation): void {
     if (this.#reservationsBySession.get(reservation.sessionId) !== reservation) return;
     this.#reservationsBySession.delete(reservation.sessionId);
     reservation.admissionSettled.resolve();
@@ -504,7 +650,7 @@ export class RootTurnCoordinator {
     if (this.#draining) return;
     this.#draining = true;
     for (const reservation of this.#reservationsBySession.values()) {
-      if (reservation.admissionPhase === 'committing') continue;
+      if (reservation.kind === 'pending' && reservation.admissionPhase === 'committing') continue;
       this.#reservationsBySession.delete(reservation.sessionId);
       reservation.admissionSettled.resolve();
       reservation.whenIdle.resolve();
@@ -529,6 +675,7 @@ export class RootTurnCoordinator {
     if (existing) return { kind: 'busy', whenIdle: existing.whenIdle.promise };
 
     const reservation: GoalRootReservation = {
+      kind: 'pending',
       sessionId,
       turnId: randomUUID(),
       runId: randomUUID(),
@@ -598,6 +745,7 @@ export class RootTurnCoordinator {
         continue;
       }
       reservation = {
+        kind: 'pending',
         sessionId,
         turnId: input.turnId,
         runId: randomUUID(),
@@ -749,7 +897,7 @@ export class RootTurnCoordinator {
             {
               sessionId: reservation.sessionId,
               turnId: reservation.turnId,
-              content: admitted.admission.normalizedInput,
+              content: requireAdmissionMessageContent(admitted.admission),
               ...(options.turnOrchestration
                 ? { turnOrchestration: options.turnOrchestration }
                 : {}),
@@ -885,7 +1033,10 @@ export class RootTurnCoordinator {
             existing.runId !== input.runId ||
             existing.userMessageId !== input.userMessageId ||
             !isDeepStrictEqual(existing.execution, input.execution) ||
-            !messageContentsEqual(existing.normalizedInput, canonicalInput.content) ||
+            !messageContentsEqual(
+              requireAdmissionMessageContent(existing),
+              canonicalInput.content,
+            ) ||
             existing.sourceMessages.length !== 0
           ) {
             throw new RuntimeMessageAuthorityInvariantError(
@@ -979,7 +1130,10 @@ export class RootTurnCoordinator {
           admitted.admission.runId !== input.runId ||
           admitted.admission.userMessageId !== input.userMessageId ||
           !isDeepStrictEqual(admitted.admission.execution, input.execution) ||
-          !messageContentsEqual(admitted.admission.normalizedInput, canonicalInput.content) ||
+          !messageContentsEqual(
+            requireAdmissionMessageContent(admitted.admission),
+            canonicalInput.content,
+          ) ||
           admitted.admission.sourceMessages.length !== 0
         ) {
           throw new RuntimeMessageAuthorityInvariantError(
@@ -1245,7 +1399,10 @@ export class RootTurnCoordinator {
             );
           }
           if (
-            !messageContentsEqual(existing.normalizedInput, canonicalInput.content) ||
+            !messageContentsEqual(
+              requireAdmissionMessageContent(existing),
+              canonicalInput.content,
+            ) ||
             !isDeepStrictEqual(existing.turnOrchestration, canonicalInput.turnOrchestration) ||
             existing.sourceMessages.length !== 0
           ) {
@@ -1334,7 +1491,10 @@ export class RootTurnCoordinator {
           );
         }
         if (
-          !messageContentsEqual(admission.admission.normalizedInput, canonicalInput.content) ||
+          !messageContentsEqual(
+            requireAdmissionMessageContent(admission.admission),
+            canonicalInput.content,
+          ) ||
           !isDeepStrictEqual(
             admission.admission.turnOrchestration,
             canonicalInput.turnOrchestration,
@@ -1360,6 +1520,366 @@ export class RootTurnCoordinator {
       });
       return this.resolveStartDisposition(canonicalInput, disposition);
     });
+  }
+
+  private async queryTurnResume(
+    input: TurnResumeQueryInput,
+    context: ConnectionContext,
+  ): Promise<OperationOutcome<'turn.resume.query'>> {
+    return this.sessionAdmission.run(input.sessionId, async () => {
+      let header: SessionHeader;
+      try {
+        header = await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
+      } catch (error) {
+        if (isSessionNotFoundError(error)) return notFound('Session does not exist');
+        throw error;
+      }
+      if (header.status === 'archived' || header.isArchived) {
+        return sessionArchived('Cannot continue an archived Session');
+      }
+      const unavailableReason = runtimeHostSafeBoundaryContinuationUnavailableReason(header);
+      if (unavailableReason) return operationUnavailable(unavailableReason);
+      const reservation = this.#reservationsBySession.get(input.sessionId);
+      const parkedAdmission = this.parkedContinuationAdmission(input.sessionId);
+      if (
+        this.#activeBySession.has(input.sessionId) ||
+        (reservation &&
+          (!parkedAdmission || !parkedContinuationMatchesQuery(parkedAdmission, input)))
+      ) {
+        return {
+          ok: true,
+          result: parkedTurnResumePlan(input.sessionId, 'session_busy'),
+        };
+      }
+      const preview = await this.previewCapabilityBinding(
+        input.sessionId,
+        context.connectionId,
+        () => this.planTurnResume(input),
+      );
+      return preview.ok
+        ? { ok: true, result: preview.value }
+        : { ok: true, result: parkedTurnResumePlan(input.sessionId, 'safety_check_failed') };
+    });
+  }
+
+  private async previewCapabilityBinding<T>(
+    sessionId: string,
+    initiatingConnectionId: string,
+    operation: () => Promise<T>,
+  ): Promise<SessionBindingPreview<T>> {
+    if (this.clientCapabilities) {
+      return this.clientCapabilities.runWithSessionBindingPreview(
+        sessionId,
+        initiatingConnectionId,
+        operation,
+      );
+    }
+    return {
+      ok: true,
+      value: await operation(),
+      commit: async () => ({ ok: true }),
+    };
+  }
+
+  private startTurnResume(
+    input: TurnResumeStartInput,
+    context: ConnectionContext,
+  ): Promise<TurnResumeStartOutcome> {
+    return this.runCommand(async () => {
+      const turnInput = continuationTurnInput(input.sessionId, input.turnId);
+      const activeAtEntry = this.#activeBySession.has(input.sessionId);
+      let reservation = activeAtEntry ? undefined : this.reserveRootTurn(input.sessionId);
+      const disposition = await this.sessionAdmission
+        .run<TurnResumeStartDisposition>(input.sessionId, async (lease) => {
+          const existing = await this.stores.agentRunStore.readRootTurnAdmission(
+            input.sessionId,
+            input.turnId,
+          );
+          if (existing) {
+            this.rootAdmissionOwner.assertKnownAdmission(existing);
+            if (
+              existing.execution.kind !== 'safe_boundary_continuation' ||
+              existing.execution.sourceRunId !== input.sourceRunId ||
+              existing.execution.sourceRuntimeEventHighWater !== input.sourceRuntimeEventHighWater
+            ) {
+              return {
+                kind: 'complete',
+                outcome: operationConflict(
+                  'Turn identity was already admitted for a different continuation boundary',
+                ),
+              };
+            }
+            const header = await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
+            const unavailableReason = runtimeHostSafeBoundaryContinuationUnavailableReason(header);
+            if (unavailableReason) {
+              return {
+                kind: 'complete',
+                outcome: operationUnavailable(unavailableReason),
+              };
+            }
+            const active = this.#activeBySession.get(input.sessionId);
+            if (active?.turnId === existing.turnId && active.runId === existing.runId) {
+              return { kind: 'await_start', active };
+            }
+            if (active) {
+              return {
+                kind: 'complete',
+                outcome: sessionBusy('Session already has an active root Turn'),
+              };
+            }
+            const existingRun = await this.readRunIfPresent(input.sessionId, existing.runId);
+            if (existingRun) {
+              await this.assertRunMatchesDurableExecution(
+                existingRun,
+                existing.turnId,
+                existing.execution,
+              );
+              const snapshot = await this.readCanonicalSnapshot(
+                input.sessionId,
+                input.turnId,
+                existing.runId,
+                existingRun,
+              );
+              if (isTerminalSnapshot(snapshot)) {
+                this.clearParkedContinuationAdmission(existing);
+                return {
+                  kind: 'complete',
+                  outcome: { ok: true, result: snapshot },
+                };
+              }
+              const reconstructed = await this.reconstructAdmittedContinuation(existing);
+              if (reconstructed.disposition === 'parked') {
+                return { kind: 'parked', plan: reconstructed.plan };
+              }
+              throw new RuntimeMessageAuthorityInvariantError(
+                `Non-terminal continuation Turn ${existing.turnId} became replayable`,
+              );
+            }
+            const preview = await this.previewCapabilityBinding(
+              input.sessionId,
+              context.connectionId,
+              () => this.reconstructAdmittedContinuation(existing),
+            );
+            if (!preview.ok) {
+              return {
+                kind: 'complete',
+                outcome: operationConflict(preview.message),
+              };
+            }
+            const reconstructed = preview.value;
+            if (reconstructed.disposition === 'parked') {
+              return { kind: 'parked', plan: reconstructed.plan };
+            }
+            const binding = await preview.commit();
+            if (!binding.ok) {
+              return {
+                kind: 'complete',
+                outcome: operationConflict(binding.message),
+              };
+            }
+            reservation ??= this.takeParkedContinuationReservation(existing);
+            return this.prepareAdmittedTurn(
+              turnInput,
+              existing,
+              context.acquireResidency,
+              lease,
+              undefined,
+              undefined,
+              reservation,
+              reconstructed.continuation,
+            );
+          }
+
+          reservation ??= this.reserveRootTurn(input.sessionId);
+          if (!reservation) {
+            return {
+              kind: 'complete',
+              outcome: sessionBusy('Session already has an active or pending root Turn'),
+            };
+          }
+
+          let header: SessionHeader;
+          try {
+            header = await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
+          } catch (error) {
+            if (isSessionNotFoundError(error)) {
+              return {
+                kind: 'complete',
+                outcome: notFound('Session does not exist'),
+              };
+            }
+            throw error;
+          }
+          if (header.status === 'archived' || header.isArchived) {
+            return {
+              kind: 'complete',
+              outcome: sessionArchived('Cannot continue an archived Session'),
+            };
+          }
+          const unavailableReason = runtimeHostSafeBoundaryContinuationUnavailableReason(header);
+          if (unavailableReason) {
+            return {
+              kind: 'complete',
+              outcome: operationUnavailable(unavailableReason),
+            };
+          }
+          if (this.#activeBySession.has(input.sessionId)) {
+            return {
+              kind: 'complete',
+              outcome: sessionBusy('Session already has an active root Turn'),
+            };
+          }
+          if (this.#reservationsBySession.get(input.sessionId) !== reservation) {
+            return {
+              kind: 'complete',
+              outcome: sessionBusy('Root Turn reservation is no longer current'),
+            };
+          }
+
+          const preview = await this.previewCapabilityBinding(
+            input.sessionId,
+            context.connectionId,
+            () =>
+              this.manager.planAuthoritativeSafeBoundaryContinuation(input.sessionId, {
+                sourceRunId: input.sourceRunId,
+                expectedRuntimeEventHighWater: input.sourceRuntimeEventHighWater,
+              }),
+          );
+          if (!preview.ok) {
+            return {
+              kind: 'complete',
+              outcome: operationConflict(preview.message),
+            };
+          }
+          const plan = preview.value;
+          const projection = projectTurnResumePlan(input.sessionId, plan);
+          if (projection.disposition === 'parked') {
+            return { kind: 'parked', plan: projection };
+          }
+          const planned = requirePlannedContinuation(plan);
+          if (planned.sourceTurnId === input.turnId) {
+            return {
+              kind: 'complete',
+              outcome: operationConflict(
+                'Continuation Turn identity must differ from its source Turn',
+              ),
+            };
+          }
+          const continuation = { ...planned, turnId: input.turnId };
+          const execution = continuationExecutionDescriptor(continuation);
+          const binding = await preview.commit();
+          if (!binding.ok) {
+            return {
+              kind: 'complete',
+              outcome: operationConflict(binding.message),
+            };
+          }
+          if (!this.beginRootAdmission(reservation)) {
+            return {
+              kind: 'complete',
+              outcome: sessionBusy('Root Turn reservation is no longer current'),
+            };
+          }
+          const admitted = await this.rootAdmissionOwner.admitRootTurn({
+            sessionId: input.sessionId,
+            turnId: input.turnId,
+            proposedRunId: continuation.runId,
+            proposedUserMessageId: null,
+            execution,
+            normalizedInput: null,
+            sourceMessages: [],
+            admittedAt: Date.now(),
+          });
+          if (
+            admitted.admission.runId !== continuation.runId ||
+            !isDeepStrictEqual(admitted.admission.execution, execution)
+          ) {
+            throw new RuntimeMessageAuthorityInvariantError(
+              'Safe-boundary continuation admission changed identity',
+            );
+          }
+          return this.prepareAdmittedTurn(
+            turnInput,
+            admitted.admission,
+            context.acquireResidency,
+            lease,
+            undefined,
+            undefined,
+            reservation,
+            continuation,
+          );
+        })
+        .finally(() => {
+          if (reservation) this.releaseRootReservation(reservation);
+        });
+      if (disposition.kind === 'parked') {
+        return { ok: true, result: { kind: 'parked', plan: disposition.plan } };
+      }
+      const outcome = await this.resolveStartDisposition(turnInput, disposition);
+      return outcome.ok ? { ok: true, result: { kind: 'started', turn: outcome.result } } : outcome;
+    });
+  }
+
+  private async planTurnResume(input: TurnResumeQueryInput): Promise<TurnResumePlan> {
+    const plan = input.sourceRunId
+      ? await this.manager.planAuthoritativeSafeBoundaryContinuation(input.sessionId, {
+          sourceRunId: input.sourceRunId,
+          ...(input.expectedRuntimeEventHighWater !== undefined
+            ? {
+                expectedRuntimeEventHighWater: input.expectedRuntimeEventHighWater,
+              }
+            : {}),
+        })
+      : await this.manager.planLatestAuthoritativeSafeBoundaryContinuation(input.sessionId);
+    return projectTurnResumePlan(input.sessionId, plan);
+  }
+
+  private async reconstructAdmittedContinuation(
+    admission: RootTurnAdmission,
+  ): Promise<ReconstructedContinuation> {
+    const execution = admission.execution;
+    if (execution.kind !== 'safe_boundary_continuation') {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Only safe-boundary continuation admission can reconstruct a continuation',
+      );
+    }
+    const plan = await this.manager.planAuthoritativeSafeBoundaryContinuation(admission.sessionId, {
+      sourceRunId: execution.sourceRunId,
+      expectedRuntimeEventHighWater: execution.sourceRuntimeEventHighWater,
+    });
+    const projection = projectTurnResumePlan(admission.sessionId, plan);
+    if (projection.disposition === 'parked') {
+      return { disposition: 'parked', plan: projection };
+    }
+    const planned = requirePlannedContinuation(plan);
+    if (
+      planned.sourceInvocationId !== execution.sourceInvocationId ||
+      planned.sourceRunId !== execution.sourceRunId ||
+      planned.sourceTurnId !== execution.sourceTurnId ||
+      planned.sourceRuntimeEventHighWater !== execution.sourceRuntimeEventHighWater ||
+      planned.boundary?.manifestDigest !== execution.boundaryDigest ||
+      planned.providerReplayDigest !== execution.providerReplayDigest
+    ) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Safe-boundary continuation source proof changed after admission',
+      );
+    }
+    if (continuationSafetyDigest(planned) !== execution.safetyDigest) {
+      return {
+        disposition: 'parked',
+        plan: parkedTurnResumePlan(admission.sessionId, 'safety_check_failed'),
+      };
+    }
+    return {
+      disposition: 'ready',
+      continuation: {
+        ...planned,
+        invocationId: execution.targetInvocationId,
+        runId: admission.runId,
+        turnId: admission.turnId,
+        claimId: execution.claimId,
+      },
+    };
   }
 
   private queryTurn(input: TurnQueryInput): Promise<OperationOutcome<'turn.query'>> {
@@ -1456,6 +1976,15 @@ export class RootTurnCoordinator {
       }
       return { kind: 'complete', outcome: { ok: true, result: snapshot } };
     }
+    const parked = this.parkedContinuationAdmission(input.sessionId);
+    if (parked?.turnId === input.turnId && parked.runId === input.runId) {
+      return {
+        kind: 'complete',
+        outcome: operationConflict(
+          'Parked continuation cannot be stopped because no active provider execution exists',
+        ),
+      };
+    }
     if (!active) {
       throw new Error('Admitted non-terminal Turn has no active Runtime Host execution');
     }
@@ -1476,27 +2005,32 @@ export class RootTurnCoordinator {
   }
 
   private async prepareAdmittedTurn(
-    input: TurnStartInput,
+    input: RootTurnActivationInput,
     admission: RootTurnAdmission,
     acquireResidency: () => RuntimeHostResidency,
     admissionLease: SessionAdmissionLease,
     replacing?: ActiveRootTurn,
     execution?: RuntimeHostedRootExecutionInput,
     rootReservation?: RootTurnReservation,
+    continuation?: RuntimeContinuation,
   ): Promise<TurnStartDisposition> {
     if (admission.sessionId !== input.sessionId || admission.turnId !== input.turnId) {
       throw new Error('Root Turn admission identity does not match its input');
     }
-    if (
-      !messageContentsEqual(admission.normalizedInput, input.content) ||
-      !isDeepStrictEqual(admission.turnOrchestration, input.turnOrchestration)
-    ) {
+    const inputMatches =
+      admission.normalizedInput === null || input.content === null
+        ? admission.normalizedInput === input.content
+        : messageContentsEqual(admission.normalizedInput, input.content);
+    if (!inputMatches || !isDeepStrictEqual(admission.turnOrchestration, input.turnOrchestration)) {
       throw new RuntimeMessageAuthorityInvariantError(
         'Root Turn admission payload does not match its input',
       );
     }
     const session = await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
-    const unavailableReason = runtimeHostExecutionUnavailableReason(session, admission.execution);
+    const unavailableReason =
+      admission.execution.kind === 'safe_boundary_continuation'
+        ? runtimeHostSafeBoundaryContinuationUnavailableReason(session)
+        : runtimeHostExecutionUnavailableReason(session, admission.execution);
     if (unavailableReason) {
       return completedStart(operationUnavailable(unavailableReason));
     }
@@ -1578,6 +2112,7 @@ export class RootTurnCoordinator {
       runId,
       userMessageId: admission.userMessageId,
       ...(execution ? { execution } : {}),
+      ...(continuation ? { continuation } : {}),
       descriptor: admission.execution,
       ...(goalRegistration?.kind === 'registered'
         ? { observedGoalSettler: goalRegistration.settle }
@@ -1617,7 +2152,7 @@ export class RootTurnCoordinator {
   }
 
   private async resolveStartDisposition(
-    input: TurnStartInput,
+    input: Pick<RootTurnActivationInput, 'sessionId' | 'turnId'>,
     disposition: TurnStartDisposition,
   ): Promise<TurnStartOutcome> {
     if (disposition.kind === 'complete') return disposition.outcome;
@@ -1642,46 +2177,51 @@ export class RootTurnCoordinator {
   }
 
   private async drainTurn(
-    input: TurnStartInput,
+    input: RootTurnActivationInput,
     active: ActiveRootTurn,
     startSettled: Deferred,
   ): Promise<void> {
     let terminalTransitionStarted = false;
     try {
       const messageOrigin = rootExecutionMessageOrigin(active.descriptor);
-      const stream = active.execution
-        ? active.execution.start({
-            runId: active.runId,
-            userMessageId: active.userMessageId,
-            onRunStarted: async () => {
-              await this.manager.commitRevisionVersion(input.sessionId);
-              await this.continuity.refreshCanonical(input.sessionId);
-              startSettled.resolve();
-              await active.execution?.onReady?.();
-            },
+      const onRunStarted = async (): Promise<void> => {
+        await this.manager.commitRevisionVersion(input.sessionId);
+        await this.continuity.refreshCanonical(input.sessionId);
+        startSettled.resolve();
+      };
+      const stream = active.continuation
+        ? this.manager.resumeSafeBoundaryContinuation(active.continuation, {
+            onRunStarted,
           })
-        : this.manager.sendMessage(
-            input.sessionId,
-            {
-              turnId: input.turnId,
-              ...normalizeMessageContent(input.content),
-              ...(input.turnOrchestration ? { turnOrchestration: input.turnOrchestration } : {}),
-              ...(messageOrigin ? { origin: messageOrigin } : {}),
-            },
-            {
+        : active.execution
+          ? active.execution.start({
               runId: active.runId,
-              userMessageId: active.userMessageId ?? undefined,
-              durability: 'required',
-              onRunStarted: async (startedRunId) => {
-                if (startedRunId !== active.runId) {
-                  throw new Error('Runtime started a different Run than the admitted identity');
-                }
-                await this.manager.commitRevisionVersion(input.sessionId);
-                await this.continuity.refreshCanonical(input.sessionId);
-                startSettled.resolve();
+              userMessageId: active.userMessageId,
+              onRunStarted: async () => {
+                await onRunStarted();
+                await active.execution?.onReady?.();
               },
-            },
-          );
+            })
+          : this.manager.sendMessage(
+              input.sessionId,
+              {
+                turnId: input.turnId,
+                ...normalizeMessageContent(requireRootMessageContent(input)),
+                ...(input.turnOrchestration ? { turnOrchestration: input.turnOrchestration } : {}),
+                ...(messageOrigin ? { origin: messageOrigin } : {}),
+              },
+              {
+                runId: active.runId,
+                userMessageId: active.userMessageId ?? undefined,
+                durability: 'required',
+                onRunStarted: async (startedRunId) => {
+                  if (startedRunId !== active.runId) {
+                    throw new Error('Runtime started a different Run than the admitted identity');
+                  }
+                  await onRunStarted();
+                },
+              },
+            );
       for await (const event of stream) {
         if (active.execution?.onEvent) {
           try {
@@ -1978,8 +2518,39 @@ export class RootTurnCoordinator {
     }
   }
 
+  private async assertRunMatchesDurableExecution(
+    run: AgentRunHeader,
+    turnId: string,
+    execution: RootTurnAdmission['execution'],
+  ): Promise<void> {
+    assertRunMatchesExecution(run, turnId, execution);
+    if (execution.kind !== 'safe_boundary_continuation') return;
+    const first = (
+      await this.stores.runtimeEventStore.readImmutableRuntimeEvents(run.sessionId, run.runId)
+    )[0];
+    const start = first?.actions?.continuationStart;
+    if (
+      first?.invocationId !== execution.targetInvocationId ||
+      first.turnId !== turnId ||
+      !start ||
+      start.claimId !== execution.claimId ||
+      start.boundaryDigest !== execution.boundaryDigest ||
+      start.replayManifestDigest !== execution.boundaryDigest ||
+      start.providerReplayDigest !== execution.providerReplayDigest ||
+      start.immediateSource.sessionId !== run.sessionId ||
+      start.immediateSource.invocationId !== execution.sourceInvocationId ||
+      start.immediateSource.runId !== execution.sourceRunId ||
+      start.immediateSource.turnId !== execution.sourceTurnId ||
+      start.immediateSource.highWater !== execution.sourceRuntimeEventHighWater
+    ) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        `Admitted Turn ${turnId} changed its continuation start proof`,
+      );
+    }
+  }
+
   private async assertCompletedExecutionIdentity(
-    input: TurnStartInput,
+    input: Pick<RootTurnActivationInput, 'sessionId' | 'turnId'>,
     active: ActiveRootTurn,
   ): Promise<void> {
     const completedRun = await this.readRunIfPresent(input.sessionId, active.runId);
@@ -1988,7 +2559,7 @@ export class RootTurnCoordinator {
         'Hosted root execution completed without its admitted Run',
       );
     }
-    assertRunMatchesExecution(completedRun, input.turnId, active.descriptor);
+    await this.assertRunMatchesDurableExecution(completedRun, input.turnId, active.descriptor);
   }
 
   private async runCommand<T>(operation: () => Promise<T>): Promise<T> {
@@ -2024,8 +2595,17 @@ interface RecoveryMessageIndex {
   messagesById: Map<string, StoredMessage[]>;
 }
 
+function requireAdmissionMessageContent(admission: RootTurnAdmission): MessageContent {
+  if (admission.normalizedInput === null) {
+    throw new RuntimeMessageAuthorityInvariantError(
+      `Admitted Turn ${admission.turnId} has no message input`,
+    );
+  }
+  return admission.normalizedInput;
+}
+
 function recoveryUserMessage(admission: RootTurnAdmission): RecoveryUserMessage {
-  if (!admission.userMessageId) {
+  if (!admission.userMessageId || !admission.normalizedInput) {
     throw new Error(`Admitted Turn ${admission.turnId} does not own a UserMessage`);
   }
   const origin = rootExecutionMessageOrigin(admission.execution);
@@ -2037,10 +2617,6 @@ function recoveryUserMessage(admission: RootTurnAdmission): RecoveryUserMessage 
     ...normalizeMessageContent(admission.normalizedInput),
     ...(origin ? { origin } : {}),
   };
-}
-
-function assertRunMatchesAdmission(run: AgentRunHeader, admission: RootTurnAdmission): void {
-  assertRunMatchesExecution(run, admission.turnId, admission.execution);
 }
 
 function assertRunMatchesExecution(
@@ -2059,6 +2635,7 @@ function assertRunMatchesExecution(
     case 'automation':
     case 'goal':
     case 'agent_graph_supervisor_wake':
+    case 'safe_boundary_continuation':
       if (agentRunMatchesHostedRootExecution(run, execution)) return;
       break;
     case 'linked_child_initial':
@@ -2092,7 +2669,12 @@ function assertTrustedAgentIdentity(
   execution: Exclude<
     RootTurnAdmission['execution'],
     {
-      kind: 'external_message' | 'automation' | 'goal' | 'agent_graph_supervisor_wake';
+      kind:
+        | 'external_message'
+        | 'automation'
+        | 'goal'
+        | 'agent_graph_supervisor_wake'
+        | 'safe_boundary_continuation';
     }
   >,
 ): void {
@@ -2130,6 +2712,12 @@ function recoveryExecutionContract(
         allowsQueueSources: false,
         requiresUserMessage: true,
         pendingWithoutRun: 'host_recovery_closure',
+      };
+    case 'safe_boundary_continuation':
+      return {
+        allowsQueueSources: false,
+        requiresUserMessage: false,
+        pendingWithoutRun: 'root_replay',
       };
     case 'agent_graph_supervisor_wake':
       return {
@@ -2200,6 +2788,143 @@ function rootExecutionMessageOrigin(execution: RootExecutionDescriptor) {
     default:
       return undefined;
   }
+}
+
+function continuationTurnInput(
+  sessionId: string,
+  turnId: string,
+): Extract<RootTurnActivationInput, { content: null }> {
+  return {
+    sessionId,
+    turnId,
+    content: null,
+  };
+}
+
+function requireRootMessageContent(input: RootTurnActivationInput): MessageContent {
+  if (input.content === null) {
+    throw new RuntimeMessageAuthorityInvariantError(
+      `Continuation Turn ${input.turnId} cannot enter message execution`,
+    );
+  }
+  return input.content;
+}
+
+function activationInputForAdmission(admission: RootTurnAdmission): RootTurnActivationInput {
+  if (admission.normalizedInput === null) {
+    return continuationTurnInput(admission.sessionId, admission.turnId);
+  }
+  return {
+    sessionId: admission.sessionId,
+    turnId: admission.turnId,
+    content: normalizeMessageContent(admission.normalizedInput),
+    ...(admission.turnOrchestration
+      ? { turnOrchestration: { ...admission.turnOrchestration } }
+      : {}),
+  };
+}
+
+function projectTurnResumePlan(
+  sessionId: string,
+  plan: SafeBoundaryContinuationPlan,
+): TurnResumePlan {
+  if (plan.disposition === 'continue') {
+    const continuation = requirePlannedContinuation(plan);
+    return {
+      sessionId,
+      disposition: 'ready',
+      sourceRunId: continuation.sourceRunId,
+      sourceTurnId: continuation.sourceTurnId,
+      sourceRuntimeEventHighWater: continuation.sourceRuntimeEventHighWater,
+    };
+  }
+  const reasons = new Set(plan.rejectionReasons);
+  let reason: Extract<TurnResumePlan, { disposition: 'parked' }>['reason'];
+  if (reasons.has('resume_candidate_missing')) reason = 'resume_candidate_missing';
+  else if (reasons.has('source_run_unreadable') || reasons.has('runtime_ledger_unreadable')) {
+    reason = 'source_run_unreadable';
+  } else if (reasons.has('continuation_already_exists')) {
+    reason = 'continuation_already_exists';
+  } else if (reasons.has('continuation_started_indeterminate')) {
+    reason = 'continuation_started_indeterminate';
+  } else if (reasons.has('continuation_claim_repair_required')) {
+    reason = 'continuation_repair_required';
+  } else if (
+    reasons.has('resume_feature_disabled') ||
+    reasons.has('continuation_authority_unavailable') ||
+    reasons.has('safety_observation_unavailable')
+  ) {
+    reason = 'continuation_unavailable';
+  } else {
+    reason = 'safety_check_failed';
+  }
+  return parkedTurnResumePlan(sessionId, reason);
+}
+
+function parkedTurnResumePlan(
+  sessionId: string,
+  reason: Extract<TurnResumePlan, { disposition: 'parked' }>['reason'],
+): Extract<TurnResumePlan, { disposition: 'parked' }> {
+  return { sessionId, disposition: 'parked', reason };
+}
+
+function parkedContinuationMatchesQuery(
+  admission: RootTurnAdmission,
+  input: TurnResumeQueryInput,
+): boolean {
+  const execution = admission.execution;
+  if (execution.kind !== 'safe_boundary_continuation') return false;
+  return (
+    (input.sourceRunId === undefined || input.sourceRunId === execution.sourceRunId) &&
+    (input.expectedRuntimeEventHighWater === undefined ||
+      input.expectedRuntimeEventHighWater === execution.sourceRuntimeEventHighWater)
+  );
+}
+
+function requirePlannedContinuation(plan: SafeBoundaryContinuationPlan): RuntimeContinuation {
+  if (plan.disposition !== 'continue' || !plan.continuation) {
+    throw new RuntimeMessageAuthorityInvariantError(
+      'Ready continuation plan omitted its Runtime continuation',
+    );
+  }
+  return plan.continuation;
+}
+
+function continuationExecutionDescriptor(
+  continuation: RuntimeContinuation,
+): Extract<RootExecutionDescriptor, { kind: 'safe_boundary_continuation' }> {
+  const boundaryDigest = continuation.boundary?.manifestDigest;
+  if (!continuation.claimId || !boundaryDigest || !continuation.providerReplayDigest) {
+    throw new RuntimeMessageAuthorityInvariantError(
+      'Authoritative continuation plan omitted its durable replay proof',
+    );
+  }
+  return {
+    kind: 'safe_boundary_continuation',
+    sourceInvocationId: continuation.sourceInvocationId,
+    sourceRunId: continuation.sourceRunId,
+    sourceTurnId: continuation.sourceTurnId,
+    sourceRuntimeEventHighWater: continuation.sourceRuntimeEventHighWater,
+    claimId: continuation.claimId,
+    boundaryDigest,
+    providerReplayDigest: continuation.providerReplayDigest,
+    safetyDigest: continuationSafetyDigest(continuation),
+    targetInvocationId: continuation.invocationId,
+  };
+}
+
+export function continuationSafetyDigest(continuation: RuntimeContinuation): `sha256:${string}` {
+  const snapshot = continuation.safetySnapshot;
+  const body = JSON.stringify([
+    'runtime_continuation_safety_v1',
+    snapshot.workspaceIdentity,
+    snapshot.backgroundOperationsSettled,
+    [...new Set(snapshot.availableToolNames)].sort(),
+    snapshot.workspaceCheckpoint
+      ? [snapshot.workspaceCheckpoint.ref, snapshot.workspaceCheckpoint.runtimeEventHighWater]
+      : null,
+  ]);
+  return `sha256:${createHash('sha256').update(body, 'utf8').digest('hex')}`;
 }
 
 function indexRecoveryMessage(index: RecoveryMessageIndex, message: StoredMessage): void {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -5559,6 +5559,45 @@ describe('SessionManager permission mode updates', () => {
     });
   });
 
+  test('parks when authoritative continuation safety inspection fails', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      safeBoundaryResumeEnabled: true,
+      inspectContinuationSafety: async () => {
+        throw new Error('safety authority unavailable');
+      },
+      newId: nextId(),
+      now: nextNow(6_535),
+    });
+    const session = await manager.createSession(makeInput());
+    const header = await store.readHeader(session.id);
+    await runStore.createRun(
+      makeRunHeader({
+        runId: 'source-run-safety-failure',
+        sessionId: session.id,
+        turnId: 'source-turn-safety-failure',
+        status: 'failed',
+        cwd: header.cwd,
+        workspaceIdentity: 'workspace-safety-failure',
+        completedAt: 2,
+        failureClass: 'app_restarted',
+      }),
+    );
+
+    const plan = await manager.planAuthoritativeSafeBoundaryContinuation(session.id, {
+      sourceRunId: 'source-run-safety-failure',
+    });
+
+    expect(plan.disposition).toBe('park');
+    expect(plan.rejectionReasons).toEqual(['safety_observation_unavailable']);
+  });
+
   test('keeps the authoritative continuation entry disabled unless the host enables it', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -7280,6 +7319,115 @@ describe('SessionManager permission mode updates', () => {
       );
       expect(backendCalls).toBe(0);
     }
+  });
+
+  test('revalidates continuation safety inside the backend activation barrier', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    let backendCalls = 0;
+    let availableToolNames: readonly string[] = ['Write'];
+    backends.register(
+      'fake',
+      (ctx) =>
+        new CountingFinalTextBackend(ctx, () => {
+          backendCalls += 1;
+        }),
+    );
+    const newId = nextId();
+    const now = nextNow(6_599);
+    const runtimeKernel = new RuntimeKernel({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      inspectContinuationSafety: async () => ({
+        workspaceIdentity: 'workspace-1',
+        backgroundOperationsSettled: true,
+        availableToolNames,
+      }),
+      runBackendActivation: async (operation) => {
+        availableToolNames = ['Read', 'Write'];
+        return operation();
+      },
+      newId,
+      now,
+      runtimeSource: 'test',
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      runtimeKernel,
+      inspectContinuationSafety: async () => ({
+        workspaceIdentity: 'workspace-1',
+        backgroundOperationsSettled: true,
+        availableToolNames,
+      }),
+      newId,
+      now,
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    const header = await store.readHeader(session.id);
+    const sourceRunId = 'source-run-activation-safety-race';
+    const sourceTurnId = 'source-turn-activation-safety-race';
+    const sourceInvocationId = 'source-invocation-activation-safety-race';
+    await seedRuntimeRun(
+      runStore,
+      makeRunHeader({
+        runId: sourceRunId,
+        sessionId: session.id,
+        turnId: sourceTurnId,
+        status: 'failed',
+        cwd: header.cwd,
+        createdAt: 1,
+        updatedAt: 2,
+        completedAt: 2,
+        failureClass: 'app_restarted',
+      }),
+      [
+        runtimeEvent({
+          id: 'source-user-activation-safety-race',
+          invocationId: sourceInvocationId,
+          runId: sourceRunId,
+          sessionId: session.id,
+          turnId: sourceTurnId,
+          ts: 1,
+          role: 'user',
+          author: 'user',
+          content: { kind: 'text', text: 'continue under one activation snapshot' },
+        }),
+        runtimeEvent({
+          id: 'source-terminal-activation-safety-race',
+          invocationId: sourceInvocationId,
+          runId: sourceRunId,
+          sessionId: session.id,
+          turnId: sourceTurnId,
+          ts: 2,
+          status: 'failed',
+          actions: { endInvocation: true, stateDelta: { failureClass: 'app_restarted' } },
+        }),
+      ],
+    );
+    const plan = await manager.planSafeBoundaryContinuation(session.id, {
+      sourceRunId,
+      currentCwd: header.cwd,
+      sourceWorkspaceIdentity: 'workspace-1',
+      currentWorkspaceIdentity: 'workspace-1',
+      backgroundOperationsSettled: true,
+      availableToolNames,
+    });
+    if (!plan.continuation) throw new Error('expected continuation');
+
+    await expectRejects(
+      collectSessionEvents(manager.resumeSafeBoundaryContinuation(plan.continuation)),
+      /tool catalog changed/i,
+    );
+
+    expect(backendCalls).toBe(0);
+    await expectRejects(runStore.readRun(session.id, plan.continuation.runId), /Unknown run/);
   });
 
   test('fails closed when continuation execution has no authoritative safety inspector', async () => {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -100,6 +100,7 @@ import {
 import {
   RuntimeMessageAuthorityInvariantError,
   type RuntimeMessageAuthority,
+  type RuntimeMessageRunIdentity,
   type RuntimeMessageRunOwner,
 } from './message-authority.js';
 import {
@@ -127,7 +128,10 @@ export interface RuntimeKernelLike {
     input: UserMessageInput,
     options?: TurnStartOptions,
   ): AsyncIterable<SessionEvent>;
-  resumeContinuation?(continuation: RuntimeContinuation): AsyncIterable<SessionEvent>;
+  resumeContinuation?(
+    continuation: RuntimeContinuation,
+    options?: ResumeContinuationOptions,
+  ): AsyncIterable<SessionEvent>;
   compactSession(sessionId: string, input?: CompactSessionInput): AsyncIterable<SessionEvent>;
   startChildTurn(
     sessionId: string,
@@ -180,6 +184,10 @@ export interface TurnStartOptions {
   admitTurn?: () => Promise<'admitted' | 'cancelled'>;
   onRunStarted?: (runId: string, initialHeader: SessionHeader) => void | Promise<void>;
   execution?: RuntimeExecutionClaim;
+}
+
+export interface ResumeContinuationOptions {
+  onRunStarted?: () => void | Promise<void>;
 }
 
 export interface RuntimeExecutionClaim {
@@ -699,7 +707,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
     }
   }
 
-  async *resumeContinuation(continuationInput: RuntimeContinuation): AsyncIterable<SessionEvent> {
+  async *resumeContinuation(
+    continuationInput: RuntimeContinuation,
+    options: ResumeContinuationOptions = {},
+  ): AsyncIterable<SessionEvent> {
     const continuation = snapshotRuntimeContinuation(continuationInput);
     const claimKey = [
       continuation.sessionId,
@@ -716,7 +727,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     this.pendingContinuationClaims.add(claimKey);
     this.pendingContinuationSessions.add(continuation.sessionId);
     try {
-      yield* this.resumeContinuationClaimed(continuation, execution);
+      yield* this.resumeContinuationClaimed(continuation, execution, options);
     } finally {
       this.pendingContinuationClaims.delete(claimKey);
       this.pendingContinuationSessions.delete(continuation.sessionId);
@@ -727,6 +738,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   private async *resumeContinuationClaimed(
     continuation: RuntimeContinuation,
     execution: PendingExecutionClaim,
+    options: ResumeContinuationOptions,
   ): AsyncIterable<SessionEvent> {
     await this.enterExecutionClaim(execution);
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {
@@ -747,11 +759,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     );
     const sourceEvents = await revalidateContinuationBoundary(continuationAuthority, continuation);
     assertContinuationSourceUnchanged(continuation, sourceRun, sourceEvents);
-    if (!this.deps.inspectContinuationSafety) {
-      throw new Error('Runtime continuation requires an authoritative safety inspector');
-    }
-    const observation = await this.deps.inspectContinuationSafety(continuation.sessionId);
-    assertContinuationSafetyUnchanged(continuation, observation);
+    await this.revalidateContinuationSafety(continuation);
 
     const userInput: UserMessageInput = {
       turnId: continuation.turnId,
@@ -888,7 +896,19 @@ export class RuntimeKernel implements RuntimeKernelLike {
     });
 
     this.attachExecutionClaim(execution, run);
-    yield* this.runAgentContinuation(continuation, run, execution, 'durable_continuation');
+    yield* this.runAgentContinuation(
+      continuation,
+      run,
+      execution,
+      'durable_continuation',
+      {
+        sessionId: continuation.sessionId,
+        turnId: continuation.turnId,
+        runId: continuation.runId,
+      },
+      options.onRunStarted,
+      () => this.revalidateContinuationSafety(continuation),
+    );
   }
 
   async *compactSession(
@@ -1211,14 +1231,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
         continuation,
       );
       assertContinuationSourceUnchanged(continuation, sourceRun, sourceEvents);
-      if (!this.deps.inspectContinuationSafety) {
-        throw new Error('Child retry continuation requires an authoritative safety inspector');
-      }
-      const safetyObservation = await this.deps.inspectContinuationSafety(sessionId);
-      assertContinuationSafetyUnchanged(continuation, {
-        ...safetyObservation,
-        availableToolNames: childTools.map((tool) => tool.name),
-      });
+      await this.revalidateContinuationSafety(
+        continuation,
+        childTools.map((tool) => tool.name),
+      );
 
       const claimedAt = this.deps.now();
       const targetRunHeader = continuationTargetRunHeaderForExecution({
@@ -1370,8 +1386,21 @@ export class RuntimeKernel implements RuntimeKernelLike {
       run,
       execution,
       input.admissionMode,
-      input.linkedSession === true,
+      input.linkedSession === true
+        ? {
+            sessionId,
+            turnId: continuation.turnId,
+            runId: continuation.runId,
+          }
+        : undefined,
       input.onRunStarted,
+      input.admissionMode === 'durable_continuation'
+        ? () =>
+            this.revalidateContinuationSafety(
+              continuation,
+              childTools.map((tool) => tool.name),
+            )
+        : undefined,
     );
   }
 
@@ -1622,8 +1651,9 @@ export class RuntimeKernel implements RuntimeKernelLike {
     run: AgentRun,
     execution: PendingExecutionClaim,
     admissionMode: ChildAgentRetryInput['admissionMode'],
-    bindHostedRoot = false,
+    messageOwner?: RuntimeMessageRunIdentity,
     onRunStarted?: () => void | Promise<void>,
+    revalidateSafety?: () => Promise<void>,
   ): AsyncIterable<SessionEvent> {
     const sessionEvents = new DeliveryAckQueue<SessionEvent>();
     const { abortController, release: releaseExecutionAbort } =
@@ -1634,14 +1664,14 @@ export class RuntimeKernel implements RuntimeKernelLike {
       | Awaited<ReturnType<AgentRun['beginContinuation']>>
       | Awaited<ReturnType<AgentRun['beginOperation']>>;
     try {
-      if (bindHostedRoot) {
-        owners.bindMessage(this.deps.messageAuthority, {
-          sessionId: continuation.sessionId,
-          turnId: continuation.turnId,
-          runId: continuation.runId,
-        });
-      }
+      if (messageOwner) owners.bindMessage(this.deps.messageAuthority, messageOwner);
       begin = await this.runBackendActivation(async () => {
+        if (admissionMode === 'durable_continuation') {
+          if (!revalidateSafety) {
+            throw new Error('Durable continuation omitted final safety revalidation');
+          }
+          await revalidateSafety();
+        }
         const started =
           admissionMode === 'durable_continuation'
             ? await run.beginContinuation(continuation)
@@ -1782,6 +1812,20 @@ export class RuntimeKernel implements RuntimeKernelLike {
         releaseExecutionAbort();
       }
     }
+  }
+
+  private async revalidateContinuationSafety(
+    continuation: RuntimeContinuation,
+    availableToolNames?: readonly string[],
+  ): Promise<void> {
+    if (!this.deps.inspectContinuationSafety) {
+      throw new Error('Runtime continuation requires an authoritative safety inspector');
+    }
+    const observation = await this.deps.inspectContinuationSafety(continuation.sessionId);
+    assertContinuationSafetyUnchanged(
+      continuation,
+      availableToolNames ? { ...observation, availableToolNames } : observation,
+    );
   }
 
   private inheritExecutionAbort(execution: PendingExecutionClaim): {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -169,6 +169,7 @@ import {
   type BackendActivationBoundary,
   type RuntimeExecutionClaim,
   type RuntimeKernelLike,
+  type ResumeContinuationOptions,
   type TurnStartOptions,
 } from './runtime-kernel.js';
 import { fallbackSessionTitle, sessionTitleSource } from './session-title.js';
@@ -1954,10 +1955,24 @@ export class SessionManager {
       this.recordContinuationPlan(sessionId, input.sourceRunId, plan);
       return plan;
     }
-    const [header, observation] = await Promise.all([
-      this.deps.store.readHeader(sessionId),
-      this.deps.inspectContinuationSafety(sessionId),
-    ]);
+    const header = await this.deps.store.readHeader(sessionId);
+    let observation: RuntimeContinuationSafetyObservation;
+    try {
+      observation = await this.deps.inspectContinuationSafety(sessionId);
+    } catch {
+      const plan: SafeBoundaryContinuationPlan = {
+        disposition: 'park',
+        rejectionReasons: ['safety_observation_unavailable'],
+        diagnostics: [
+          {
+            code: 'safety_observation_unavailable',
+            message: 'authoritative continuation safety inspection failed',
+          },
+        ],
+      };
+      this.recordContinuationPlan(sessionId, input.sourceRunId, plan);
+      return plan;
+    }
     return this.planSafeBoundaryContinuation(sessionId, {
       sourceRunId: input.sourceRunId,
       currentCwd: header.cwd,
@@ -2024,6 +2039,7 @@ export class SessionManager {
 
   async *resumeSafeBoundaryContinuation(
     continuation: RuntimeContinuation,
+    options: ResumeContinuationOptions = {},
   ): AsyncIterable<SessionEvent> {
     const resume = this.runtimeKernel.resumeContinuation;
     if (!resume) throw new Error('RuntimeKernel does not support safe-boundary continuation');
@@ -2034,7 +2050,7 @@ export class SessionManager {
       targetRunId: continuation.runId,
     });
     try {
-      yield* resume.call(this.runtimeKernel, continuation);
+      yield* resume.call(this.runtimeKernel, continuation, options);
       this.recordContinuationLifecycleEvent({
         type: 'execution_completed',
         sessionId: continuation.sessionId,
@@ -4375,7 +4391,7 @@ export class SessionManager {
     admittedAt: number;
     execution: Exclude<
       RootExecutionDescriptor,
-      { kind: 'external_message' } | { kind: 'automation' }
+      { kind: 'external_message' } | { kind: 'automation' } | { kind: 'safe_boundary_continuation' }
     >;
   }): Promise<void> {
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {

--- a/packages/storage/src/__tests__/execution-stores.test.ts
+++ b/packages/storage/src/__tests__/execution-stores.test.ts
@@ -16,6 +16,7 @@ import {
   canonicalToolArgsHash,
   MAX_ATTACHMENT_BYTES,
   MAX_ATTACHMENT_COUNT,
+  RUNTIME_CONTINUATION_AUTHORITY_V1,
   type AgentRunEvent,
   type AgentRunHeader,
   type AttachmentRef,
@@ -233,6 +234,12 @@ describe('execution stores', () => {
       );
       const rawLocalStore = createSessionStore(root);
 
+      assert.equal(
+        writer.runtimeEventStore.continuationAuthorityCapability,
+        RUNTIME_CONTINUATION_AUTHORITY_V1,
+      );
+      assert.equal(typeof writer.runtimeEventStore.readImmutableRuntimePrefix, 'function');
+
       assert.equal(Reflect.set(reader, 'sessionStore', rawLocalStore), false);
       assert.equal(
         Reflect.set(
@@ -315,14 +322,14 @@ describe('execution stores', () => {
         });
         assert.equal(first.kind, 'admitted');
         mutableAttachment.name = 'mutated.png';
-        assert.equal(first.admission.normalizedInput.attachments?.[0]?.name, 'chart.png');
+        assert.equal(first.admission.normalizedInput!.attachments?.[0]?.name, 'chart.png');
         assert.equal(Object.isFrozen(first.admission), true);
         assert.deepEqual(first.admission.turnOrchestration, {
           mode: 'swarm',
           source: 'host_api',
         });
         assert.equal(Object.isFrozen(first.admission.turnOrchestration), true);
-        assert.equal(Object.isFrozen(first.admission.normalizedInput.attachments?.[0]?.ref), true);
+        assert.equal(Object.isFrozen(first.admission.normalizedInput!.attachments?.[0]?.ref), true);
         assert.deepEqual(await stores.agentRunStore.listSessionRuns(session.id), []);
 
         const retry = await stores.agentRunStore.admitRootTurn({
@@ -356,7 +363,7 @@ describe('execution stores', () => {
         assert.equal(retry.admission.runId, 'run-1');
         assert.equal(retry.admission.userMessageId, 'message-1');
         assert.equal(retry.admission.admittedAt, 10);
-        assert.deepEqual(retry.admission.normalizedInput.attachments, [
+        assert.deepEqual(retry.admission.normalizedInput!.attachments, [
           chartAttachment,
           notesAttachment,
         ]);
@@ -604,14 +611,14 @@ describe('execution stores', () => {
       });
       mutableSecondSourceQuotes.length = 0;
 
-      assert.deepEqual(admitted.admission.normalizedInput.quotes, [
+      assert.deepEqual(admitted.admission.normalizedInput!.quotes, [
         expectedFirstQuote,
         expectedSecondQuote,
       ]);
       assert.deepEqual(admitted.admission.sourceMessages[0]?.content.quotes, [expectedFirstQuote]);
       assert.deepEqual(admitted.admission.sourceMessages[1]?.content.quotes, [expectedSecondQuote]);
-      assert.equal(Object.isFrozen(admitted.admission.normalizedInput.quotes), true);
-      assert.equal(Object.isFrozen(admitted.admission.normalizedInput.quotes?.[0]), true);
+      assert.equal(Object.isFrozen(admitted.admission.normalizedInput!.quotes), true);
+      assert.equal(Object.isFrozen(admitted.admission.normalizedInput!.quotes?.[0]), true);
       assert.equal(
         Object.isFrozen(admitted.admission.sourceMessages[0]?.content.quotes?.[0]),
         true,
@@ -622,10 +629,10 @@ describe('execution stores', () => {
         'turn-1',
       );
       assert.deepEqual(stored, admitted.admission);
-      assert.notEqual(stored?.normalizedInput.quotes, admitted.admission.normalizedInput.quotes);
+      assert.notEqual(stored?.normalizedInput?.quotes, admitted.admission.normalizedInput!.quotes);
       assert.notEqual(
-        stored?.normalizedInput.quotes?.[0],
-        admitted.admission.normalizedInput.quotes?.[0],
+        stored?.normalizedInput?.quotes?.[0],
+        admitted.admission.normalizedInput!.quotes?.[0],
       );
 
       await assert.rejects(
@@ -686,7 +693,7 @@ describe('execution stores', () => {
         'source-first',
       );
       assert.deepEqual(receipt?.sourceMessage.content.quotes, [expectedFirstQuote]);
-      assert.deepEqual(receipt?.admission.normalizedInput.quotes, [
+      assert.deepEqual(receipt?.admission.normalizedInput?.quotes, [
         expectedFirstQuote,
         expectedSecondQuote,
       ]);
@@ -697,6 +704,18 @@ describe('execution stores', () => {
   test('rejects invalid root admission contracts before write and when reading disk', async () => {
     await withRoot(async ({ root }) => {
       const store = createAgentRunStore(root);
+      const continuationExecution = {
+        kind: 'safe_boundary_continuation' as const,
+        sourceInvocationId: 'source-invocation',
+        sourceRunId: 'source-run',
+        sourceTurnId: 'source-turn',
+        sourceRuntimeEventHighWater: 2,
+        claimId: 'continuation-claim',
+        boundaryDigest: `sha256:${'a'.repeat(64)}` as const,
+        providerReplayDigest: `sha256:${'b'.repeat(64)}` as const,
+        safetyDigest: `sha256:${'c'.repeat(64)}` as const,
+        targetInvocationId: 'target-invocation',
+      };
       const turnStartedSource = {
         messageId: 'source-message',
         content: { text: 'source' },
@@ -719,6 +738,18 @@ describe('execution stores', () => {
             agentName: 'Agent',
             sourceRunId: 'source-run',
           },
+          sourceMessages: [],
+        },
+        {
+          name: 'continuation-with-message',
+          userMessageId: 'message-1',
+          execution: continuationExecution,
+          sourceMessages: [],
+        },
+        {
+          name: 'continuation-self-source',
+          userMessageId: null,
+          execution: { ...continuationExecution, sourceRunId: 'run-1' },
           sourceMessages: [],
         },
         {
@@ -776,7 +807,12 @@ describe('execution stores', () => {
         const sessionId = `session-${invalid.name}`;
         const turnId = 'turn-1';
         const normalizedInput =
-          invalid.sourceMessages.length > 0 ? { text: 'source' } : { text: 'input' };
+          invalid.execution.kind === 'safe_boundary_continuation' &&
+          invalid.name !== 'continuation-with-message'
+            ? null
+            : invalid.sourceMessages.length > 0
+              ? { text: 'source' }
+              : { text: 'input' };
         await assert.rejects(
           () =>
             store.admitRootTurn({
@@ -822,6 +858,43 @@ describe('execution stores', () => {
           /Invalid root turn admission contract/,
         );
       }
+    });
+  });
+
+  test('persists one closed safe-boundary continuation root admission', async () => {
+    await withRoot(async ({ root }) => {
+      const store = createAgentRunStore(root);
+      const result = await store.admitRootTurn({
+        sessionId: 'session-continuation',
+        turnId: 'turn-continuation',
+        proposedRunId: 'run-continuation',
+        proposedUserMessageId: null,
+        execution: {
+          kind: 'safe_boundary_continuation',
+          sourceInvocationId: 'source-invocation',
+          sourceRunId: 'source-run',
+          sourceTurnId: 'source-turn',
+          sourceRuntimeEventHighWater: 2,
+          claimId: 'continuation-claim',
+          boundaryDigest: `sha256:${'a'.repeat(64)}`,
+          providerReplayDigest: `sha256:${'b'.repeat(64)}`,
+          safetyDigest: `sha256:${'c'.repeat(64)}`,
+          targetInvocationId: 'target-invocation',
+        },
+        previousRootTurnId: null,
+        normalizedInput: null,
+        sourceMessages: [],
+        admittedAt: 10,
+      });
+      assert.equal(result.kind, 'admitted');
+
+      const recovered = await createAgentRunStore(root).readRootTurnAdmission(
+        'session-continuation',
+        'turn-continuation',
+      );
+      assert.deepEqual(recovered, result.admission);
+      assert.equal(recovered?.userMessageId, null);
+      assert.equal(Object.isFrozen(recovered?.execution), true);
     });
   });
 

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -94,7 +94,7 @@ export interface RootTurnAdmission {
   userMessageId: string | null;
   execution: RootExecutionDescriptor;
   previousRootTurnId: string | null;
-  normalizedInput: MessageContent;
+  normalizedInput: MessageContent | null;
   turnOrchestration?: TurnOrchestration;
   sourceMessages: readonly RootTurnSourceMessage[];
   admittedAt: number;
@@ -107,7 +107,7 @@ export interface AdmitRootTurnInput {
   proposedUserMessageId: string | null;
   execution: RootExecutionDescriptor;
   previousRootTurnId: string | null;
-  normalizedInput: MessageContent;
+  normalizedInput: MessageContent | null;
   turnOrchestration?: TurnOrchestration;
   sourceMessages: readonly RootTurnSourceMessage[];
   admittedAt: number;
@@ -2993,13 +2993,40 @@ function isValidRootTurnAttachment(attachment: AttachmentRef): boolean {
 }
 
 export function normalizeRootTurnAdmissionPayload(
-  normalizedInputValue: unknown,
+  normalizedInputValue: MessageContent,
   sourceMessagesValue: unknown,
 ): {
   normalizedInput: MessageContent;
   sourceMessages: readonly RootTurnSourceMessage[];
+};
+export function normalizeRootTurnAdmissionPayload(
+  normalizedInputValue: null,
+  sourceMessagesValue: unknown,
+): {
+  normalizedInput: null;
+  sourceMessages: readonly RootTurnSourceMessage[];
+};
+export function normalizeRootTurnAdmissionPayload(
+  normalizedInputValue: unknown,
+  sourceMessagesValue: unknown,
+): {
+  normalizedInput: MessageContent | null;
+  sourceMessages: readonly RootTurnSourceMessage[];
+};
+export function normalizeRootTurnAdmissionPayload(
+  normalizedInputValue: unknown,
+  sourceMessagesValue: unknown,
+): {
+  normalizedInput: MessageContent | null;
+  sourceMessages: readonly RootTurnSourceMessage[];
 } {
   const sourceMessages = normalizeRootTurnSourceMessages(sourceMessagesValue);
+  if (normalizedInputValue === null) {
+    if (sourceMessages.length > 0) {
+      throw new Error('Root turn admission without input cannot have source messages');
+    }
+    return { normalizedInput: null, sourceMessages };
+  }
   const normalizedInputMaxAttachments =
     sourceMessages.length > 1
       ? ROOT_TURN_ADMISSION_MAX_AGGREGATED_ATTACHMENTS
@@ -3089,7 +3116,9 @@ function rootTurnAdmissionPayloadsEqual(
   return (
     isDeepStrictEqual(left.execution, right.execution) &&
     isDeepStrictEqual(left.turnOrchestration, right.turnOrchestration) &&
-    messageContentsEqual(left.normalizedInput, right.normalizedInput) &&
+    (left.normalizedInput === null || right.normalizedInput === null
+      ? left.normalizedInput === right.normalizedInput
+      : messageContentsEqual(left.normalizedInput, right.normalizedInput)) &&
     left.sourceMessages.length === right.sourceMessages.length &&
     left.sourceMessages.every((source, index) => {
       const other = right.sourceMessages[index];
@@ -3117,6 +3146,7 @@ function assertRootTurnAdmissionSerializedSize(serialized: string): void {
 function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
   const execution = admission.execution;
   const providerRetry = execution.kind === 'linked_child_provider_retry';
+  const safeBoundaryContinuation = execution.kind === 'safe_boundary_continuation';
   if (execution.kind === 'agent_graph_supervisor_wake') {
     if (
       admission.turnOrchestration?.mode !== 'graph' ||
@@ -3131,9 +3161,19 @@ function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
       'Invalid root turn admission contract: orchestration override is not authorized for this execution',
     );
   }
-  if ((admission.userMessageId === null) !== providerRetry) {
+  if (safeBoundaryContinuation && admission.userMessageId !== null) {
+    throw new Error(
+      'Invalid root turn admission contract: safe-boundary continuation omits UserMessage',
+    );
+  }
+  if (!safeBoundaryContinuation && (admission.userMessageId === null) !== providerRetry) {
     throw new Error(
       'Invalid root turn admission contract: only linked child provider retry omits UserMessage',
+    );
+  }
+  if ((admission.normalizedInput === null) !== safeBoundaryContinuation) {
+    throw new Error(
+      'Invalid root turn admission contract: execution has an invalid input requirement',
     );
   }
   if (execution.kind !== 'external_message' && admission.sourceMessages.length !== 0) {
@@ -3167,6 +3207,17 @@ function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
     );
   }
   if (
+    execution.kind === 'safe_boundary_continuation' &&
+    (execution.sourceRunId === admission.runId ||
+      execution.sourceTurnId === admission.turnId ||
+      execution.sourceInvocationId === execution.targetInvocationId ||
+      admission.normalizedInput !== null)
+  ) {
+    throw new Error(
+      'Invalid root turn admission contract: safe-boundary continuation identity is invalid',
+    );
+  }
+  if (
     execution.kind === 'external_message' &&
     admission.sourceMessages.some(
       (source) =>
@@ -3185,7 +3236,7 @@ function deepFreezeRootTurnAdmission(admission: RootTurnAdmission): RootTurnAdmi
   }
   Object.freeze(admission.execution);
   if (admission.turnOrchestration) Object.freeze(admission.turnOrchestration);
-  deepFreezeRootTurnMessageContent(admission.normalizedInput);
+  if (admission.normalizedInput) deepFreezeRootTurnMessageContent(admission.normalizedInput);
   for (const sourceMessage of admission.sourceMessages) {
     deepFreezeRootTurnMessageContent(sourceMessage.content);
     Object.freeze(sourceMessage);
@@ -3271,6 +3322,52 @@ function normalizeRootExecutionDescriptor(value: unknown): RootExecutionDescript
       attemptId: value.attemptId,
     });
   }
+  if (value.kind === 'safe_boundary_continuation') {
+    const keys = [
+      'kind',
+      'sourceInvocationId',
+      'sourceRunId',
+      'sourceTurnId',
+      'sourceRuntimeEventHighWater',
+      'claimId',
+      'boundaryDigest',
+      'providerReplayDigest',
+      'safetyDigest',
+      'targetInvocationId',
+    ];
+    if (
+      !hasExactKeys(value, keys) ||
+      typeof value.sourceInvocationId !== 'string' ||
+      !isSafeId(value.sourceInvocationId) ||
+      typeof value.sourceRunId !== 'string' ||
+      !isSafeId(value.sourceRunId) ||
+      typeof value.sourceTurnId !== 'string' ||
+      !isSafeId(value.sourceTurnId) ||
+      !Number.isSafeInteger(value.sourceRuntimeEventHighWater) ||
+      (value.sourceRuntimeEventHighWater as number) < 1 ||
+      typeof value.claimId !== 'string' ||
+      !isSafeId(value.claimId) ||
+      !isSha256Digest(value.boundaryDigest) ||
+      !isSha256Digest(value.providerReplayDigest) ||
+      !isSha256Digest(value.safetyDigest) ||
+      typeof value.targetInvocationId !== 'string' ||
+      !isSafeId(value.targetInvocationId)
+    ) {
+      throw new Error('Invalid root execution descriptor');
+    }
+    return Object.freeze({
+      kind: value.kind,
+      sourceInvocationId: value.sourceInvocationId,
+      sourceRunId: value.sourceRunId,
+      sourceTurnId: value.sourceTurnId,
+      sourceRuntimeEventHighWater: value.sourceRuntimeEventHighWater as number,
+      claimId: value.claimId,
+      boundaryDigest: value.boundaryDigest,
+      providerReplayDigest: value.providerReplayDigest,
+      safetyDigest: value.safetyDigest,
+      targetInvocationId: value.targetInvocationId,
+    });
+  }
   if (value.kind === 'claimed_agent_graph_intent') {
     if (
       !hasExactKeys(value, ['kind', 'claim', 'agentId', 'agentName']) ||
@@ -3350,6 +3447,10 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const prototype = Object.getPrototypeOf(value);
   return prototype === Object.prototype || prototype === null;
+}
+
+function isSha256Digest(value: unknown): value is `sha256:${string}` {
+  return typeof value === 'string' && /^sha256:[0-9a-f]{64}$/.test(value);
 }
 
 function turnIdFromAdmissionFile(name: string): string | undefined {

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -3,6 +3,7 @@ import type {
   AgentRunEventType,
   AgentRunHeader,
   RuntimeEvent,
+  RuntimeContinuationAuthorityStore,
   SessionHeader,
   SessionListFilter,
   SessionSummary,
@@ -100,12 +101,13 @@ export type {
 
 export type ExecutionSessionWriter = SessionAuthorityStore;
 export type ExecutionAgentRunWriter = DurableAgentRunStore;
-export interface ExecutionRuntimeEventWriter extends DurableRuntimeEventStore {
-  readonly toolBoundaryProtocol: ToolBoundaryProtocol;
-  commitToolPrepared(input: CommitToolPreparedInput): Promise<ToolCommitResult>;
-  commitToolOutcome(input: CommitToolOutcomeInput): Promise<ToolCommitResult>;
-  listUnsettledToolOperations(sessionId: string): Promise<ToolOperationRecord[]>;
-}
+export type ExecutionRuntimeEventWriter = DurableRuntimeEventStore &
+  RuntimeContinuationAuthorityStore & {
+    readonly toolBoundaryProtocol: ToolBoundaryProtocol;
+    commitToolPrepared(input: CommitToolPreparedInput): Promise<ToolCommitResult>;
+    commitToolOutcome(input: CommitToolOutcomeInput): Promise<ToolCommitResult>;
+    listUnsettledToolOperations(sessionId: string): Promise<ToolOperationRecord[]>;
+  };
 export type ExecutionMessageReceiptWriter = MessageReceiptStore;
 
 interface ExecutionStoresWriterBase<K extends StorageRootKind> {
@@ -426,6 +428,7 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
     },
     runtimeEventStore: {
       durability: runtimeEventStore.durability,
+      continuationAuthorityCapability: runtimeEventStore.continuationAuthorityCapability,
       toolBoundaryProtocol: runtimePersistence.runtimeCommitStore.toolBoundaryProtocol,
       appendRuntimeEvent: (sessionId, runId, event, options) =>
         run(() => runtimeEventStore.appendRuntimeEvent(sessionId, runId, event, options)),
@@ -439,8 +442,21 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
         run(() => runtimeEventStore.readRuntimeEventsBounded(sessionId, runId, budget)),
       readImmutableRuntimeEvents: (sessionId, runId) =>
         run(() => runtimeEventStore.readImmutableRuntimeEvents(sessionId, runId)),
+      readImmutableRuntimePrefix: (input) =>
+        run(() => runtimeEventStore.readImmutableRuntimePrefix(input)),
       readSessionRuntimeEvents: (sessionId) =>
         run(() => runtimeEventStore.readSessionRuntimeEvents(sessionId)),
+      claimContinuation: (input) => run(() => runtimeEventStore.claimContinuation(input)),
+      readContinuationClaimByBoundary: (boundaryDigest) =>
+        run(() => runtimeEventStore.readContinuationClaimByBoundary(boundaryDigest)),
+      readContinuationClaimStateByBoundary: (boundaryDigest) =>
+        run(() => runtimeEventStore.readContinuationClaimStateByBoundary(boundaryDigest)),
+      listContinuationClaimsForRecovery: (sessionId) =>
+        run(() => runtimeEventStore.listContinuationClaimsForRecovery(sessionId)),
+      commitContinuationStart: (input) =>
+        run(() => runtimeEventStore.commitContinuationStart(input)),
+      commitContinuationRepairStart: (input) =>
+        run(() => runtimeEventStore.commitContinuationRepairStart(input)),
       readImmutableSteeringMessageProof: (sessionId, messageId) =>
         run(() => runtimeEventStore.readImmutableSteeringMessageProof(sessionId, messageId)),
       repairImmutableSteeringMessageProofsForRecovery: (sessionId) =>


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Add the v0 `turn.resume.query` and `turn.resume.start` operations for Host-owned safe-boundary continuation.
- Persist a closed continuation admission that binds the exact source boundary, replay identity, safety identity, and target Run without creating another UserMessage.
- Revalidate workspace, checkpoint, background-operation, tool-catalog, and Client Capability state under the backend activation barrier before provider dispatch.
- Make retries, Client rebinding, shutdown, and startup recovery fail closed: repair pre-dispatch crashes, park missing-capability and provider-indeterminate work, and keep unrelated Sessions available.

## Why

Runtime Host needs one authoritative way to continue a recoverable provider boundary without trusting Client-supplied safety claims, duplicating user input, or dispatching the provider twice. The public surface remains opt-in through `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1`.

## Validation

- `npm run build:test`
- `npm --workspace @maka/runtime-host run test:dist` — 597 passed
- Runtime continuation and crash tests — 26 passed
- `npm --workspace @maka/storage run test:dist` — 1016 passed, 13 skipped
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

Part of #1167. Runtime Host roadmap context: #853.

</details>

<details>
<summary>中文</summary>

## 概要

- 新增 v0 `turn.resume.query` 与 `turn.resume.start` 操作，由 Runtime Host 统一管理安全边界续跑。
- 持久化封闭的续跑 admission，绑定精确的源边界、重放身份、安全身份与目标 Run，且不创建新的 UserMessage。
- 在 backend activation barrier 内重新校验 workspace、checkpoint、后台操作、工具目录与 Client Capability 状态，再允许 Provider dispatch。
- 让重试、Client 重新绑定、关闭与启动恢复保持 fail-closed：修复 dispatch 前崩溃，停放 Capability 缺失及 Provider 状态不确定的工作，同时保持无关 Session 可用。

## 原因

Runtime Host 需要一条权威续跑路径，在不信任 Client 安全声明、不重复用户输入、也不重复调用 Provider 的前提下，从可恢复的 Provider 边界继续执行。公开能力仍需通过 `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` 显式启用。

## 验证

- `npm run build:test`
- `npm --workspace @maka/runtime-host run test:dist` — 597 项通过
- Runtime continuation 与 crash 测试 — 26 项通过
- `npm --workspace @maka/storage run test:dist` — 1016 项通过，13 项跳过
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

属于 #1167 的一部分；Runtime Host 路线图背景见 #853。

</details>
