### PR TITLE
fix(desktop): deep-review round over the settings convergence + shell seam

### DIFF
--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -10,6 +10,7 @@ import {
   List,
   ListItem,
   Skeleton,
+  StatusDot,
   Text,
   Toolbar,
   VStack,
@@ -21,7 +22,7 @@ import {
 } from '@maka/core';
 import { useMountedRef, useUiLocale, useToast } from '@maka/ui';
 import { connectionChipStatus } from './provider-connection-status';
-import { statusBadgeVariant } from './settings-status-badge';
+import { statusDotVariant } from './settings-status-badge';
 import {
   CATALOG_INITIAL_FILTER,
   ProviderCatalogPage,
@@ -407,7 +408,12 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
                     description={connectionSubtitle(connection, locale)}
                     endContent={(
                       <HStack gap={2} vAlign="center">
-                        {status && <Badge variant={statusBadgeVariant(status.tone)} label={status.label} />}
+                        {status && (
+                          <span className="settingsStatus">
+                            <StatusDot variant={statusDotVariant(status.tone)} label={status.label} />
+                            <span>{status.label}</span>
+                          </span>
+                        )}
                         <ChevronRight size={16} aria-hidden="true" />
                       </HStack>
                     )}

--- a/apps/desktop/src/renderer/settings/about-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/about-settings-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useState } from 'react';
-import { List, ListItem } from '@astryxdesign/core';
+import { Badge, List, ListItem } from '@astryxdesign/core';
 import { Sparkles } from '@maka/ui/icons';
 import {
   Banner,
@@ -136,14 +136,15 @@ export function AboutSettingsPage() {
         title="Maka"
         badge={
           <>
-            <span className="settingsAboutVersion">v{info.appVersion}</span>
-            <span className="settingsAboutChannel">
-              {info.buildMode === 'dev'
+            <Badge variant="neutral" label={`v${info.appVersion}`} />
+            <Badge
+              variant="blue"
+              label={info.buildMode === 'dev'
                 ? info.buildCommit
                   ? `${copy.devBuild} · ${info.buildCommit}`
                   : copy.devBuild
                 : copy.packagedBuild}
-            </span>
+            />
           </>
         }
         subtitle={copy.subtitle}

--- a/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
@@ -37,7 +37,7 @@ import {
   type BotPendingActionName,
 } from './bot-chat-shared';
 import { getBotSettingsCopy, type BotSettingsCopy } from '../locales/settings-bot-copy';
-import { SettingsSection } from './settings-section';
+import { SettingsPage, SettingsSection } from './settings-section';
 import { statusDotVariant } from './settings-status-badge';
 
 function canEnableBotChannel(readiness: BotReadinessState): boolean {
@@ -161,8 +161,12 @@ export function BotChatChannelDetail(props: {
     }
   }, [provider, channel.domain]);
 
+  // Deep-review fix: the old wrapper pair (.settingsRemoteAccessDetail had no
+  // CSS rule at all; .settingsBotDetail set `gap` on a display:block section,
+  // which discards it) left this page with zero inter-section rhythm. The kit
+  // page container owns the rhythm now, same as the overview next door.
   return (
-    <div className="settingsRemoteAccessDetail">
+    <SettingsPage>
       <Button
         variant="ghost"
         className="settingsRemoteAccessBack"
@@ -172,8 +176,7 @@ export function BotChatChannelDetail(props: {
         icon={<ArrowLeft size={16} aria-hidden="true" />}
         label={detailCopy.back}
       />
-      <section className="settingsBotDetail">
-        <header className="settingsBotDetailHeader" data-support={support}>
+      <header className="settingsBotDetailHeader" data-support={support}>
           <BotBrandLogo provider={provider} size="large" />
           <div className="settingsBotDetailHeaderBody">
             <h3>
@@ -220,6 +223,7 @@ export function BotChatChannelDetail(props: {
             used as page structure (the named cards-in-page anti-pattern). It
             is an open kit section now — header + anchor divider + rows. */}
         <SettingsSection
+          variant="bare"
           titleId="settings-bot-runtime-heading"
           title={viewState.liveOperational ? detailCopy.listening : readinessCopy.label}
           description={viewState.liveOperational ? detailCopy.healthy : readinessCopy.detail}
@@ -250,12 +254,16 @@ export function BotChatChannelDetail(props: {
           {/* Astryx convergence: the hand-rolled <dl> grid (4→2→1 columns via
               two media queries) is MetadataList, whose multi-column layout
               handles the collapse itself. */}
-          <MetadataList columns="multi" aria-label={detailCopy.runtimeAria(providerPresentation.label)}>
+          {/* Deep-review fix: MetadataList destructures a closed prop list and
+              silently drops aria-label — the group name rides a real wrapper. */}
+          <div role="group" aria-label={detailCopy.runtimeAria(providerPresentation.label)}>
+          <MetadataList columns="multi">
             <MetadataListItem label={detailCopy.identity}>{status?.identity?.username ?? status?.identity?.displayName ?? detailCopy.unknownIdentity}</MetadataListItem>
             <MetadataListItem label={detailCopy.connectionType}>{botConnectionLabel(status?.connection ?? 'none', locale)}</MetadataListItem>
             <MetadataListItem label={detailCopy.lastEvent}>{status?.lastEventAt ? <RelativeTime ts={status.lastEventAt} /> : detailCopy.noneYet}</MetadataListItem>
             <MetadataListItem label={detailCopy.lastTest}>{channel.lastTestAt ? <RelativeTime ts={channel.lastTestAt} /> : detailCopy.neverTested}</MetadataListItem>
           </MetadataList>
+          </div>
         </SettingsSection>
 
         {props.statusLoadError && (
@@ -406,8 +414,7 @@ export function BotChatChannelDetail(props: {
             onRefreshStatuses={props.onRefreshStatuses}
           />
         )}
-      </section>
-    </div>
+    </SettingsPage>
   );
 }
 

--- a/apps/desktop/src/renderer/settings/claude-subscription-card.tsx
+++ b/apps/desktop/src/renderer/settings/claude-subscription-card.tsx
@@ -1,16 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { type SubscriptionAccountState, type UiLocale } from '@maka/core';
-import { FieldStatus, ProgressBar } from '@astryxdesign/core';
+import { FieldStatus, ProgressBar, StatusDot } from '@astryxdesign/core';
 import {
-  Badge,
   Banner,
   Button,
-  Card,
   Divider,
   HStack,
   RelativeTime,
-  SectionHeader,
-  StackItem,
   Text,
   TextArea,
   VStack,
@@ -19,7 +15,7 @@ import {
   useUiLocale,
 } from '@maka/ui';
 import { getProviderSettingsCopy } from '../locales/settings-provider-copy';
-import { statusBadgeVariant, type StatusTone } from './settings-status-badge';
+import { statusDotVariant, type StatusTone } from './settings-status-badge';
 import {
   subscriptionActionErrorMessage,
   subscriptionResultMessage,
@@ -312,27 +308,21 @@ export function ClaudeSubscriptionCard() {
   const claudeLoginPending = authRequestId !== null || state?.runtimeState === 'authorizing';
   const actionBusy = pendingAction !== null;
 
-  // Astryx convergence (task #136): the hand-rolled
-  // `.settingsConnectionRow[data-status]` card (9 tinted variants) sat inside
-  // the otherwise fully Astryx Providers surface. Default Card chrome now;
-  // status is carried by the Badge + detail line only (status-color
-  // restraint), and the quota numbers gained a real ProgressBar gauge.
+  // Deep-review fix: this panel renders under ProvidersPanel's RouteHeader,
+  // which already says 连接 Claude + subtitle — the SectionHeader + full-width
+  // Card + repeated title made it the one OAuth panel with its own chrome.
+  // It is a bare VStack now, the same shape as its sibling login panels, and
+  // runtime state reads as the shared StatusDot + text idiom.
   return (
-    <VStack gap={2}>
-    <SectionHeader as="h3" title={copy.section} />
-    <Card padding={4}>
-      <VStack gap={2}>
-      <HStack gap={3} vAlign="start">
-        <StackItem size="fill">
-          <VStack gap={0.5}>
-            <Text weight="semibold">{copy.title}</Text>
-            <Text type="supporting" color="secondary">
-              {copy.subtitle}
-              {state?.profile?.email ? ` · ${state.profile.email}` : ''}
-            </Text>
-          </VStack>
-        </StackItem>
-        <Badge variant={statusBadgeVariant(presentation.tone)} label={presentation.label} />
+    <VStack gap={3}>
+      <HStack gap={3} vAlign="center" hAlign="between" wrap="wrap">
+        <span className="settingsStatus">
+          <StatusDot variant={statusDotVariant(presentation.tone)} label={presentation.label} />
+          <span>{presentation.label}</span>
+        </span>
+        {state?.profile?.email ? (
+          <Text type="supporting" color="secondary">{state.profile.email}</Text>
+        ) : null}
       </HStack>
       <Text as="p" type="supporting" color="secondary">{presentation.detail}</Text>
       {pasteError && !authRequestId && (
@@ -348,7 +338,7 @@ export function ClaudeSubscriptionCard() {
               label={copy.fiveHour}
               value={state.quota.fiveHour.utilization}
               hasValueLabel
-              formatValueLabel={(value) => `${value}%`}
+              formatValueLabel={(value) => `${Math.round(value)}%`}
               variant={quotaVariant(state.quota.fiveHour.utilization)}
             />
           )}
@@ -357,7 +347,7 @@ export function ClaudeSubscriptionCard() {
               label={copy.sevenDay}
               value={state.quota.sevenDay.utilization}
               hasValueLabel
-              formatValueLabel={(value) => `${value}%`}
+              formatValueLabel={(value) => `${Math.round(value)}%`}
               variant={quotaVariant(state.quota.sevenDay.utilization)}
             />
           )}
@@ -435,8 +425,6 @@ export function ClaudeSubscriptionCard() {
         </VStack>
         </>
       )}
-      </VStack>
-    </Card>
     </VStack>
   );
 }

--- a/apps/desktop/src/renderer/settings/health-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/health-center-page.tsx
@@ -11,7 +11,7 @@ import { getHealthCenterCopy, type HealthCenterCopy } from '../locales/settings-
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsPage, SettingsRow, SettingsSection } from './settings-section';
 import { SettingsSkeletonStack } from './settings-skeleton';
-import { statusBadgeVariant } from './settings-status-badge';
+import { statusDotVariant } from './settings-status-badge';
 
 /**
  * PR-UI-9 — Health Center read-only page. Consumes `window.maka.health.getSnapshot()`
@@ -160,7 +160,6 @@ function HealthSignalRow(props: { signal: HealthSignal; copy: HealthCenterCopy }
   const { signal, copy } = props;
   const statusCopy = copy.statuses[signal.status];
   const detail = copy.signalDetail(signal);
-  const badgeVariant = statusBadgeVariant(statusCopy.tone);
   return (
     <SettingsRow
       align="start"
@@ -184,10 +183,7 @@ function HealthSignalRow(props: { signal: HealthSignal; copy: HealthCenterCopy }
       )}
       end={(
         <span className="settingsStatus">
-          <StatusDot
-            variant={badgeVariant === 'info' ? 'accent' : badgeVariant === 'success' ? 'success' : badgeVariant === 'warning' ? 'warning' : badgeVariant === 'error' ? 'error' : 'neutral'}
-            label={statusCopy.label}
-          />
+          <StatusDot variant={statusDotVariant(statusCopy.tone)} label={statusCopy.label} />
           <span>{statusCopy.label}</span>
         </span>
       )}

--- a/apps/desktop/src/renderer/settings/settings-section.tsx
+++ b/apps/desktop/src/renderer/settings/settings-section.tsx
@@ -85,7 +85,10 @@ export function SettingsSection(props: {
            font-semibold`, a caption-sized subtitle). Deferring to Astryx means
            section typography now moves with the theme instead of with a copy
            of the theme's values. */
-        <HStack gap={3} align="start" justify="between">
+        /* wrap: at the 480px window floor a multi-button action cluster
+           must drop under the title instead of crushing it (the old
+           bot-runtime header carried a media query for this). */
+        <HStack gap={3} align="start" justify="between" wrap="wrap">
           <VStack gap={0.5}>
             {props.title != null ? <Heading level={3} id={props.titleId}>{props.title}</Heading> : null}
             {props.description != null ? (

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -490,9 +490,9 @@ function SettingsPageBody(props: {
       );
     default:
       return (
-        <Card padding={0} className="settingsRows">
+        <div className="settingsRows">
           <SettingRow title={navLabel(props.section, locale)} detail={copy.unavailablePage} value={copy.ready} />
-        </Card>
+        </div>
       );
   }
 }

--- a/apps/desktop/src/renderer/settings/subagent-presets-panel.tsx
+++ b/apps/desktop/src/renderer/settings/subagent-presets-panel.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
-import { Card, Item } from '@astryxdesign/core';
+import { Item } from '@astryxdesign/core';
+import { SettingsSection } from './settings-section';
 import {
   connectionEnabledModelIds,
   isSafeSubagentPresetId,
@@ -95,16 +96,17 @@ export function SubagentPresetsPanel(props: {
     setId('');
   }
 
+  // Deep-review fix: was a Card-wrapped `.settingsRows` (the retired card
+  // dialect) with a leading Item doing a section header's job.
   return (
-    <Card padding={0} className="settingsRows subagentPresetPanel">
-      <Item
-        label={zh ? '子 Agent 模型路由' : 'Subagent model routing'}
-        description={
-          zh
-            ? '主 Agent 从这里批准的配置中选择 subagent_id；能力边界由 Profile 决定，Provider 与模型在子会话创建时冻结。'
-            : 'The main agent selects an approved subagent_id. The profile owns capabilities; provider and model are frozen when the child session is created.'
-        }
-      />
+    <SettingsSection
+      title={zh ? '子 Agent 模型路由' : 'Subagent model routing'}
+      description={
+        zh
+          ? '主 Agent 从这里批准的配置中选择 subagent_id；能力边界由 Profile 决定，Provider 与模型在子会话创建时冻结。'
+          : 'The main agent selects an approved subagent_id. The profile owns capabilities; provider and model are frozen when the child session is created.'
+      }
+    >
       {props.settings.subagents.presets.map((preset) => (
         <Item
           key={preset.id}
@@ -202,6 +204,6 @@ export function SubagentPresetsPanel(props: {
           />
         </div>
       </div>
-    </Card>
+    </SettingsSection>
   );
 }

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -27,7 +27,9 @@
   min-height: 64px;
   min-width: 0;
   gap: var(--space-3);
-  padding: var(--space-2) var(--space-2-5);
+  /* Deep-review fix: flush inline — kit rows edge-align with the section
+     heading; the 10px inset was a leftover from the old card grid. */
+  padding: var(--space-2) 0;
 }
 
 .settingsRemoteAccessItemTitle {
@@ -57,13 +59,12 @@
 }
 
 .settingsRemoteAccessBack {
+  /* Deep-review fix: the page gap owns vertical rhythm now; only the optical
+     inline outdent stays so the ghost button's label aligns with content. */
   justify-self: start;
-  margin: 0 0 var(--space-4) calc(var(--space-2) * -1);
+  margin-inline-start: calc(var(--space-2) * -1);
 }
 
-.settingsBotDetail {
-  gap: var(--space-4);
-}
 
 .settingsBotDetailHeader {
   display: grid;
@@ -79,14 +80,7 @@
   min-width: 0;
 }
 
-.settingsBotDetailHeader > /* Astryx convergence: the pre-#1972 remote-access dialect is retired — page
-   containers → SettingsPage, section headers → SettingsSection, the runtime
-   tinted card + <dl> status grid → SettingsSection + MetadataList, the
-   quick-setup plate → Astryx Card, list grids → the kit's rows body. What
-   stays below is genuine art (brand plate, QR frames, onboarding glyphs) and
-   the row-level behaviors (attention wash, planned opacity). */
-
-.settingsBotLogo {
+.settingsBotDetailHeader > .settingsBotLogo {
   grid-column: 1;
   grid-row: 1;
 }
@@ -154,7 +148,6 @@
   .settingsRemoteAccessChannelRow,
   .settingsRemoteAccessCatalogRow {
     gap: var(--space-2);
-    padding-inline: var(--space-2);
   }
 
   /* The whole row remains the named button. In the narrow layout, dropping

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -145,7 +145,7 @@
 /* Nested `.settingsPageStack` (merged pages like 外观 stack two
    sub-pages, each wrapping in their own SettingsPage):
    the inner one just passes through. */
-.settingsPage .settingsPageStack {
+.settingsPageStack .settingsPageStack {
   gap: var(--space-8);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/wechat.css
+++ b/apps/desktop/src/renderer/styles/settings/wechat.css
@@ -9,8 +9,13 @@
 .settingsWechatQrBody {
   display: grid;
   place-items: center;
+  align-content: center;
   gap: var(--space-3);
   text-align: center;
+  /* Deep-review fix: the retired `.settingsWechatQrState` pane carried a
+     180px floor; without one the dialog collapses in the generating/expired/
+     error states and snaps taller when the QR (224px frame) arrives. */
+  min-height: 224px;
 }
 
 .settingsWechatQrFrame {

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -68,6 +68,19 @@
   border-inline-end-color: transparent;
 }
 
+/* WAWQAQ msg `9f313715` (2026-08-03): the content column is a rounded floating
+   plate flush to the sidebar — its edge is the ONE boundary on that seam. The
+   theme's full-height sidenav hairline (`.astryx-app-shell-sidenav.elevated`
+   in the built maka.css) ran on the same seam, so beside the plate's top-left
+   corner radius both lines showed and read as a doubled border. The collapsed
+   rail already dropped this edge (rule above); drop it expanded too — column
+   separation is tonal (the plate's fill against the canvas), per DESIGN.md's
+   One Working Plane rule. Override lives here because maka.css is a generated
+   artifact (`npm run astryx:theme`), not a hand-edited file. */
+.maka-shell-astryx .astryx-app-shell-sidenav {
+  border-inline-end-color: transparent;
+}
+
 
 /* The column resize handle is the one control positioned against the column BOX
    rather than flowing inside it (Astryx gives it `position:absolute; top:0;


### PR DESCRIPTION
Deep adversarial review of #1984 / #1991 / #1993 (two independent review lenses; every finding verified against the tree before fixing), plus the user-reported doubled-border shell defect.

## Shell seam (user report)

The content column is a rounded floating plate flush to the sidebar — its edge is the one boundary on that seam. The theme's full-height sidenav hairline (`.astryx-app-shell-sidenav.elevated` in the built maka.css) ran on the same seam, reading as a **doubled border** beside the plate's top-left corner radius. The collapsed rail already dropped this edge; it's dropped expanded too. Override lives in product CSS (maka.css is a generated artifact).

## Confirmed regressions from #1993, fixed

- **bot-chat-detail had zero inter-section rhythm**: its wrapper pair kept `gap` on a `display:block` section (inert) and a class with no CSS rule at all. Now a `SettingsPage` like the overview next door.
- **bot.css selector corruption**: the file-header comment got replace-all'd into the middle of `.settingsBotDetailHeader > .settingsBotLogo`. Parsed by luck; removed.
- **MetadataList silently drops `aria-label`** (closed prop destructuring, no `...rest`): the runtime grid's group name now rides a real `role="group"` wrapper.
- **Kit section header now wraps** — at the 480px window floor a multi-button action cluster drops under the title instead of crushing it (replaces the deleted bot-runtime media query, benefits every section).
- **Overview rows flush-inline** (10px inset was old card-grid residue); **WeChat QR dialog height floor restored** (224px) so state swaps stop resizing the modal.
- `.settingsPage .settingsPageStack` rename slip → `.settingsPageStack .settingsPageStack`; quota `formatValueLabel` rounds.

## Convergence completions the review surfaced

- **claude-subscription-card**: dropped its `SectionHeader` + full-width `Card` + repeated title — it renders under ProvidersPanel's RouteHeader exactly like its sibling OAuth panels (bare `VStack`), with the shared StatusDot + text status idiom. Removes the last old `SectionHeader` in settings.
- **ProvidersPanel** connection status Badge → StatusDot + text; **health** deletes its hand-rolled five-arm dot mapping for the shared `statusDotVariant`.
- **subagent-presets** panel: Card-wrapped `.settingsRows` + a lead `Item` posing as a header → `SettingsSection`; the settings-surface fallback drops its Card wrap.
- **About hero pills** referenced two classNames with no CSS rule anywhere — they're now the `Badge`s about.css's comment always described.

## Known items deliberately deferred (copy/product decisions)

usage page kit conversion (L), bot-detail header dialect (guarded by the e2e focus-order contract), voice `statusAria` reused as a visible title, memory quiet-warning boxes vs Banner (depends on the #1972 "un-blue" direction), icon-plate unification.

## Verification

typecheck ✅ · check-dead-css ✅ · check-a11y/copy/console ✅ · format:check ✅ · product Storybook smoke 71 renders × 3 viewports ✅