### PR TITLE
perf(desktop): subscribe to session UI state at the granularity each surface reads

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { SandboxBoundaryRequestEvent, SessionEventStreamSnapshot, SessionSummary } from '@maka/core';
-import { armLiveTurn, confirmLiveTurn } from '@maka/ui';
+import { applyLiveTurnEvent, armLiveTurn, confirmLiveTurn } from '@maka/ui';
+import { deriveLiveTurnSnapshot } from '../../renderer/live-turn-snapshot.js';
 import { settledSessionTransientIds } from '../../renderer/settled-session-transients.js';
 import {
   clearAppShellSessionUiStateForSession,
@@ -200,5 +201,45 @@ describe('app shell session UI state controller', () => {
     const projection = armLiveTurn('turn-1');
     controller.setLiveTurnBySession((current) => ({ ...current, session: projection }));
     assert.equal(controller.liveTurnBySessionRef.current.session, projection);
+  });
+});
+
+describe('live-turn snapshot', () => {
+  it('drops the phase of a settled turn but keeps its id', () => {
+    // `deriveTurnActive` reads both: no phase means this renderer's arm is
+    // spent, while the id is what tells a still-running sibling turn apart
+    // from this one. Losing the id on terminal would light Stop back up.
+    const settled = { ...armLiveTurn('turn-1'), terminal: true as const };
+
+    const snapshot = deriveLiveTurnSnapshot(settled);
+
+    assert.equal(snapshot.phase, undefined);
+    assert.equal(snapshot.turnId, 'turn-1');
+  });
+
+  it('withholds the handoff message id until the text step closes', () => {
+    const streaming = applyLiveTurnEvent(armLiveTurn('turn-1'), {
+      type: 'text_delta',
+      id: 'event-1',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'message-1',
+      text: 'partial',
+    });
+
+    const midStream = deriveLiveTurnSnapshot(streaming);
+    assert.equal(midStream.hasStreamingText, true);
+    assert.equal(midStream.streamingMessageId, undefined, 'an open text step has nothing to hand off');
+
+    const closed = applyLiveTurnEvent(streaming, {
+      type: 'text_complete',
+      id: 'event-2',
+      turnId: 'turn-1',
+      ts: 2,
+      messageId: 'message-1',
+      text: 'partial answer',
+    });
+
+    assert.equal(deriveLiveTurnSnapshot(closed).streamingMessageId, 'message-1');
   });
 });

--- a/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
@@ -167,7 +167,8 @@ describe('app shell session UI state controller', () => {
 
   it('records event-stream health without notifying render subscribers', () => {
     let notifications = 0;
-    const controller = createAppShellSessionUiStateController(undefined, () => {
+    const controller = createAppShellSessionUiStateController();
+    controller.subscribe(() => {
       notifications += 1;
     });
     const snapshot = healthSnapshot('session');

--- a/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-ui-state.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { SandboxBoundaryRequestEvent, SessionEventStreamSnapshot, SessionSummary } from '@maka/core';
-import { applyLiveTurnEvent, armLiveTurn, confirmLiveTurn } from '@maka/ui';
-import { deriveLiveTurnSnapshot } from '../../renderer/live-turn-snapshot.js';
+import { armLiveTurn, confirmLiveTurn } from '@maka/ui';
 import { settledSessionTransientIds } from '../../renderer/settled-session-transients.js';
 import {
   clearAppShellSessionUiStateForSession,
@@ -201,45 +200,5 @@ describe('app shell session UI state controller', () => {
     const projection = armLiveTurn('turn-1');
     controller.setLiveTurnBySession((current) => ({ ...current, session: projection }));
     assert.equal(controller.liveTurnBySessionRef.current.session, projection);
-  });
-});
-
-describe('live-turn snapshot', () => {
-  it('drops the phase of a settled turn but keeps its id', () => {
-    // `deriveTurnActive` reads both: no phase means this renderer's arm is
-    // spent, while the id is what tells a still-running sibling turn apart
-    // from this one. Losing the id on terminal would light Stop back up.
-    const settled = { ...armLiveTurn('turn-1'), terminal: true as const };
-
-    const snapshot = deriveLiveTurnSnapshot(settled);
-
-    assert.equal(snapshot.phase, undefined);
-    assert.equal(snapshot.turnId, 'turn-1');
-  });
-
-  it('withholds the handoff message id until the text step closes', () => {
-    const streaming = applyLiveTurnEvent(armLiveTurn('turn-1'), {
-      type: 'text_delta',
-      id: 'event-1',
-      turnId: 'turn-1',
-      ts: 1,
-      messageId: 'message-1',
-      text: 'partial',
-    });
-
-    const midStream = deriveLiveTurnSnapshot(streaming);
-    assert.equal(midStream.hasStreamingText, true);
-    assert.equal(midStream.streamingMessageId, undefined, 'an open text step has nothing to hand off');
-
-    const closed = applyLiveTurnEvent(streaming, {
-      type: 'text_complete',
-      id: 'event-2',
-      turnId: 'turn-1',
-      ts: 2,
-      messageId: 'message-1',
-      text: 'partial answer',
-    });
-
-    assert.equal(deriveLiveTurnSnapshot(closed).streamingMessageId, 'message-1');
   });
 });

--- a/apps/desktop/src/main/__tests__/model-wait-state.test.ts
+++ b/apps/desktop/src/main/__tests__/model-wait-state.test.ts
@@ -102,8 +102,8 @@ describe('is a turn running', () => {
 
 const HEAD = {
   turnPhase: 'waiting',
-  streamingText: '',
-  thinkingText: '',
+  hasStreamingText: false,
+  hasThinkingText: false,
   hasInFlightTools: false,
 } as const;
 
@@ -140,8 +140,8 @@ describe('model wait state', () => {
     for (const [input, expected] of [
       [HEAD, 'processing'],
       [{ ...HEAD, turnPhase: undefined }, 'none'],
-      [{ ...HEAD, streamingText: 'answer' }, 'none'],
-      [{ ...HEAD, thinkingText: 'reasoning' }, 'none'],
+      [{ ...HEAD, hasStreamingText: true }, 'none'],
+      [{ ...HEAD, hasThinkingText: true }, 'none'],
       [{ ...HEAD, hasInFlightTools: true }, 'none'],
       [{ ...HEAD, turnPhase: 'streamed', hasInFlightTools: true }, 'none'],
       [{ ...HEAD, turnPhase: 'streamed' }, 'continuing'],

--- a/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, it } from 'node:test';
 import type { SessionEvent, SessionSummary } from '@maka/core';
-import type { TurnViewModel } from '@maka/ui';
+import type { LiveTurnProjection, TurnViewModel } from '@maka/ui';
 import { applyLiveTurnEvent, armLiveTurn } from '@maka/ui';
 import { build } from 'esbuild';
 import { act, createElement, type ReactElement } from 'react';
@@ -12,13 +12,10 @@ import {
   createAppShellSessionUiStateController,
   type AppShellSessionUiState,
 } from '../../renderer/app-shell-session-ui-state.js';
-import {
-  deriveLiveTurnSnapshot,
-  liveTurnSnapshotsEqual,
-  type LiveTurnSnapshot,
-} from '../../renderer/live-turn-snapshot.js';
+import { deriveLiveTurnSnapshot } from '../../renderer/live-turn-snapshot.js';
 import { useAppShellSessionUiReads } from '../../renderer/use-app-shell-session-ui-reads.js';
 import { useAppShellSessionUiSelector } from '../../renderer/use-app-shell-session-ui-selector.js';
+import { useShellLiveTurn } from '../../renderer/use-shell-live-turn.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 const LUCIDE_REACT_PACKAGE = ['lucide', 'react'].join('-');
@@ -153,21 +150,20 @@ describe('UI render memo boundary contract', () => {
 // split at the subscription, which is what keeps the sidebar and composer still
 // while an answer streams.
 describe('AppShell session UI subscription boundary', () => {
-  it('holds a semantic live-turn subscriber steady while a streamed delta re-renders the projection subscriber', async () => {
+  // Drives `useAppShellSessionUiReads` — the shell's real read of the store,
+  // not a copy of its selector list — against a projection subscriber standing
+  // in for the chat surface. Both directions are pinned here: the shell must
+  // still follow the two changes that mean something, and must not follow the
+  // deltas that do not. Adding a token-rate selection to that hook fails this.
+  it('re-renders the shell for the arm and the first token, then for no delta after', async () => {
     const controller = createAppShellSessionUiStateController();
     const { root } = installReactRenderer();
-    let snapshotRenders = 0;
+    let shellRenders = 0;
     let projectionRenders = 0;
-    let lastSnapshot: LiveTurnSnapshot | undefined;
 
-    function SnapshotConsumer(): null {
-      lastSnapshot = useAppShellSessionUiSelector(
-        controller,
-        selectTestSnapshot,
-        LIVE_SESSION_ID,
-        liveTurnSnapshotsEqual,
-      );
-      snapshotRenders += 1;
+    function ShellReader(): null {
+      useAppShellSessionUiReads(controller, LIVE_SESSION_ID);
+      shellRenders += 1;
       return null;
     }
 
@@ -179,79 +175,68 @@ describe('AppShell session UI subscription boundary', () => {
 
     await render(
       root,
-      createElement('div', null, createElement(SnapshotConsumer), createElement(ProjectionConsumer)),
+      createElement('div', null, createElement(ShellReader), createElement(ProjectionConsumer)),
     );
-    const snapshotBaseline = snapshotRenders;
+    const shellBaseline = shellRenders;
     const projectionBaseline = projectionRenders;
 
     // Arming a turn is a semantic change: no turn in flight → waiting.
     await act(async () => {
       controller.setLiveTurnBySession((current) => ({ ...current, [LIVE_SESSION_ID]: armLiveTurn('turn-1') }));
     });
-    assert.equal(snapshotRenders, snapshotBaseline + 1);
-    assert.equal(projectionRenders, projectionBaseline + 1);
+    assert.equal(shellRenders, shellBaseline + 1, 'the shell must follow the arm');
 
-    // First delta is also semantic: waiting → streamed, and text appears.
+    // The first delta is also semantic: waiting → streamed, and text appears.
     await act(async () => {
       streamLiveText(controller, 'Hel', 2);
     });
-    assert.equal(snapshotRenders, snapshotBaseline + 2);
-    assert.equal(projectionRenders, projectionBaseline + 2);
-    assert.equal(lastSnapshot?.hasStreamingText, true);
+    assert.equal(shellRenders, shellBaseline + 2, 'the shell must follow the first token');
 
     // Every further delta only grows text the chat surface owns.
-    await act(async () => {
-      streamLiveText(controller, 'lo', 3);
-    });
-    await act(async () => {
-      streamLiveText(controller, ' there', 4);
-    });
-    assert.equal(
-      projectionRenders,
-      projectionBaseline + 4,
-      'the chat surface must follow every delta',
-    );
-    assert.equal(
-      snapshotRenders,
-      snapshotBaseline + 2,
-      'a text delta must not disturb subscribers that read only semantic turn state',
-    );
-  });
-
-  // Drives `useAppShellSessionUiReads` — the shell's real read of the store, not
-  // a copy of its selector list. Adding a token-rate selection to that hook
-  // fails this test, which is the regression it exists to catch.
-  it('re-renders the shell for no delta after the first token', async () => {
-    const controller = createAppShellSessionUiStateController();
-    const { root } = installReactRenderer();
-    let shellRenders = 0;
-
-    function ShellReader(): null {
-      useAppShellSessionUiReads(controller, LIVE_SESSION_ID);
-      shellRenders += 1;
-      return null;
-    }
-
-    await render(root, createElement(ShellReader));
-    await act(async () => {
-      controller.setLiveTurnBySession((current) => ({ ...current, [LIVE_SESSION_ID]: armLiveTurn('turn-1') }));
-    });
-    await act(async () => {
-      streamLiveText(controller, 'Hel', 2);
-    });
-    const afterFirstToken = shellRenders;
-
-    for (const [index, chunk] of ['lo', ' there', ', here is', ' the answer'].entries()) {
+    const chunks = ['lo', ' there', ', here is', ' the answer'];
+    for (const [index, chunk] of chunks.entries()) {
       await act(async () => {
         streamLiveText(controller, chunk, 3 + index);
       });
     }
 
     assert.equal(
+      projectionRenders,
+      projectionBaseline + 2 + chunks.length,
+      'the chat surface must follow every delta',
+    );
+    assert.equal(
       shellRenders,
-      afterFirstToken,
+      shellBaseline + 2,
       'no delta after the first may re-render the shell',
     );
+  });
+
+  // `useSyncExternalStore` calls `getSnapshot` several times for ONE store
+  // state — in the subscription callback, during render, and again in a passive
+  // effect. A selector that derives a fresh value therefore has to be memoized
+  // per store state, or every call hands React a new identity and it re-renders
+  // forever. That idempotence belongs to this hook; a caller-supplied `isEqual`
+  // is an optimization, not the thing standing between the app and a freeze.
+  it('holds a comparator-less derived selector to one render per store change', async () => {
+    const controller = createAppShellSessionUiStateController();
+    const { root } = installReactRenderer();
+    let renders = 0;
+
+    function Reader(): null {
+      useAppShellSessionUiSelector(controller, selectTestStopPendingIds);
+      renders += 1;
+      return null;
+    }
+
+    await render(root, createElement(Reader));
+    const baseline = renders;
+
+    await act(async () => {
+      controller.setStopPendingBySession((current) => ({ ...current, [LIVE_SESSION_ID]: true }));
+    });
+
+    assert.equal(renders, baseline + 1, 'one store change must cost exactly one render');
   });
 
   // The one branch where the snapshot cache must yield without the store moving.
@@ -277,12 +262,95 @@ describe('AppShell session UI subscription boundary', () => {
   });
 });
 
+// The snapshot is where the shell's turn state is decided, and `useShellLiveTurn`
+// is the only place its two Stop witnesses meet (#1987): the local arm and the
+// runtime's `runningTurnIds`. Drive both through the real adapter, from a
+// projection the reducer can actually produce.
+describe('live-turn snapshot', () => {
+  function renderTurnActive(
+    projection: LiveTurnProjection | undefined,
+    runningTurnIds: readonly string[] | undefined,
+  ): Promise<boolean> {
+    const { root } = installReactRenderer();
+    let turnActive = false;
+
+    function Reader(): null {
+      turnActive = useShellLiveTurn({
+        liveTurn: deriveLiveTurnSnapshot(projection),
+        activeSession: { id: LIVE_SESSION_ID, runningTurnIds } as SessionSummary,
+      }).turnActive;
+      return null;
+    }
+
+    return render(root, createElement(Reader)).then(() => turnActive);
+  }
+
+  /** What a finished turn actually leaves behind: a `complete` over real steps. */
+  function settledTurn(): LiveTurnProjection {
+    const streamed = applyLiveTurnEvent(armLiveTurn('turn-1'), {
+      type: 'text_delta',
+      id: 'event-1',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'message-1',
+      text: 'answer',
+    });
+    return applyLiveTurnEvent(streamed, {
+      type: 'complete',
+      id: 'event-2',
+      turnId: 'turn-1',
+      ts: 2,
+    } as SessionEvent) as LiveTurnProjection;
+  }
+
+  it('releases the turn once its own turn ends, even while the runtime still lists it', async () => {
+    // The projection sees the terminal event first, so a session summary
+    // fetched before that write must not light Stop back up.
+    assert.equal(await renderTurnActive(settledTurn(), ['turn-1']), false);
+  });
+
+  it('holds the turn while a sibling turn is still running', async () => {
+    // Dropping `turnId` from the snapshot would let the arm's own id mask this.
+    assert.equal(await renderTurnActive(settledTurn(), ['turn-1', 'turn-2']), true);
+  });
+
+  it('holds the turn from the local arm alone, before the runtime knows of it', async () => {
+    assert.equal(await renderTurnActive(armLiveTurn('turn-1'), []), true);
+  });
+
+  it('withholds the handoff message id until the text step closes', () => {
+    const streaming = applyLiveTurnEvent(armLiveTurn('turn-1'), {
+      type: 'text_delta',
+      id: 'event-1',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'message-1',
+      text: 'partial',
+    });
+
+    const midStream = deriveLiveTurnSnapshot(streaming);
+    assert.equal(midStream.hasStreamingText, true);
+    assert.equal(midStream.streamingMessageId, undefined, 'an open text step has nothing to hand off');
+
+    const closed = applyLiveTurnEvent(streaming, {
+      type: 'text_complete',
+      id: 'event-2',
+      turnId: 'turn-1',
+      ts: 2,
+      messageId: 'message-1',
+      text: 'partial answer',
+    });
+
+    assert.equal(deriveLiveTurnSnapshot(closed).streamingMessageId, 'message-1');
+  });
+});
+
 const LIVE_SESSION_ID = 'session-live';
 
-const selectTestSnapshot = (state: AppShellSessionUiState, sessionId: string) =>
-  deriveLiveTurnSnapshot(state.liveTurnBySession[sessionId]);
 const selectTestProjection = (state: AppShellSessionUiState, sessionId: string) =>
   state.liveTurnBySession[sessionId];
+/** Derives a fresh array on every call, and deliberately ships no comparator. */
+const selectTestStopPendingIds = (state: AppShellSessionUiState) => Object.keys(state.stopPendingBySession);
 
 function streamLiveText(
   controller: ReturnType<typeof createAppShellSessionUiStateController>,
@@ -462,6 +530,11 @@ function installFakeDom(): void {
     }),
     HTMLElement: FakeElement,
     HTMLIFrameElement: class HTMLIFrameElement {},
+    // `useDelayedFlag` schedules the turn-wait cues through the window. Timers
+    // are real here; the tests below assert only on the undelayed values, and
+    // the timers are unref'd so a pending reveal cannot hold the process open.
+    setTimeout: (handler: () => void, ms: number) => setTimeout(handler, ms).unref(),
+    clearTimeout: (handle: NodeJS.Timeout) => clearTimeout(handle),
   } as unknown as RendererWindow;
   Object.defineProperty(fakeDocument, 'defaultView', { value: fakeWindow });
   globalThis.document = fakeDocument;

--- a/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
@@ -12,6 +12,8 @@ import { createAppShellSessionUiStateController } from '../../renderer/app-shell
 import {
   deriveLiveTurnSnapshot,
   liveTurnSnapshotsEqual,
+  selectStreamingSessionIds,
+  sessionIdSetsEqual,
   type LiveTurnSnapshot,
 } from '../../renderer/live-turn-snapshot.js';
 import { useAppShellSessionUiSelector } from '../../renderer/use-app-shell-session-ui-selector.js';
@@ -210,6 +212,58 @@ describe('AppShell session UI subscription boundary', () => {
       snapshotRenders,
       snapshotBaseline + 2,
       'a text delta must not disturb subscribers that read only semantic turn state',
+    );
+  });
+
+  it('leaves a subscriber shaped like AppShell untouched through a whole stream', async () => {
+    const controller = createAppShellSessionUiStateController();
+    const { root } = installReactRenderer();
+    let shellRenders = 0;
+
+    // The shell's complete read of session UI state: the low-frequency maps by
+    // raw reference, the live turn as a semantic snapshot, and the sidebar's
+    // pulse set by value. Anything added here that follows a delta puts the
+    // sidebar and composer back on the token path.
+    function ShellReader(): null {
+      useAppShellSessionUiSelector(controller, (state) => state.messageLoadErrorBySession);
+      useAppShellSessionUiSelector(controller, (state) => state.messageRetryPendingBySession);
+      useAppShellSessionUiSelector(controller, (state) => state.stopPendingBySession);
+      useAppShellSessionUiSelector(controller, (state) => state.interactionBySession);
+      useAppShellSessionUiSelector(controller, (state) => state.pendingPermissionModeBySession);
+      useAppShellSessionUiSelector(controller, (state) => state.pendingSessionModelBySession);
+      useAppShellSessionUiSelector(
+        controller,
+        (state) => deriveLiveTurnSnapshot(state.liveTurnBySession[LIVE_SESSION_ID]),
+        liveTurnSnapshotsEqual,
+      );
+      useAppShellSessionUiSelector(
+        controller,
+        (state) => selectStreamingSessionIds(state.liveTurnBySession),
+        sessionIdSetsEqual,
+      );
+      shellRenders += 1;
+      return null;
+    }
+
+    await render(root, createElement(ShellReader));
+    await act(async () => {
+      controller.setLiveTurnBySession((current) => ({ ...current, [LIVE_SESSION_ID]: armLiveTurn('turn-1') }));
+    });
+    await act(async () => {
+      streamLiveText(controller, 'Hel', 2);
+    });
+    const afterFirstToken = shellRenders;
+
+    for (const [index, chunk] of ['lo', ' there', ', here is', ' the answer'].entries()) {
+      await act(async () => {
+        streamLiveText(controller, chunk, 3 + index);
+      });
+    }
+
+    assert.equal(
+      shellRenders,
+      afterFirstToken,
+      'no delta after the first may re-render the shell',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
@@ -2,11 +2,19 @@ import { strict as assert } from 'node:assert';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, it } from 'node:test';
-import type { SessionSummary } from '@maka/core';
+import type { SessionEvent, SessionSummary } from '@maka/core';
 import type { TurnViewModel } from '@maka/ui';
+import { applyLiveTurnEvent, armLiveTurn } from '@maka/ui';
 import { build } from 'esbuild';
 import { act, createElement, type ReactElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { createAppShellSessionUiStateController } from '../../renderer/app-shell-session-ui-state.js';
+import {
+  deriveLiveTurnSnapshot,
+  liveTurnSnapshotsEqual,
+  type LiveTurnSnapshot,
+} from '../../renderer/live-turn-snapshot.js';
+import { useAppShellSessionUiSelector } from '../../renderer/use-app-shell-session-ui-selector.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 const LUCIDE_REACT_PACKAGE = ['lucide', 'react'].join('-');
@@ -133,6 +141,99 @@ describe('UI render memo boundary contract', () => {
     assert.equal(settled.length, 1);
   });
 });
+
+// #1985: the shell subscribes to session UI state at one granularity, so a
+// per-token write to `liveTurnBySession` re-rendered every subtree. The chat
+// transcript is the only surface that needs the full projection; everything
+// else reads low-entropy values that a text delta cannot change. This pins that
+// split at the subscription, which is what keeps the sidebar and composer still
+// while an answer streams.
+describe('AppShell session UI subscription boundary', () => {
+  it('holds a semantic live-turn subscriber steady while a streamed delta re-renders the projection subscriber', async () => {
+    const controller = createAppShellSessionUiStateController();
+    const { root } = installReactRenderer();
+    let snapshotRenders = 0;
+    let projectionRenders = 0;
+    let lastSnapshot: LiveTurnSnapshot | undefined;
+
+    function SnapshotConsumer(): null {
+      lastSnapshot = useAppShellSessionUiSelector(
+        controller,
+        (state) => deriveLiveTurnSnapshot(state.liveTurnBySession[LIVE_SESSION_ID]),
+        liveTurnSnapshotsEqual,
+      );
+      snapshotRenders += 1;
+      return null;
+    }
+
+    function ProjectionConsumer(): null {
+      useAppShellSessionUiSelector(controller, (state) => state.liveTurnBySession[LIVE_SESSION_ID]);
+      projectionRenders += 1;
+      return null;
+    }
+
+    await render(
+      root,
+      createElement('div', null, createElement(SnapshotConsumer), createElement(ProjectionConsumer)),
+    );
+    const snapshotBaseline = snapshotRenders;
+    const projectionBaseline = projectionRenders;
+
+    // Arming a turn is a semantic change: no turn in flight → waiting.
+    await act(async () => {
+      controller.setLiveTurnBySession((current) => ({ ...current, [LIVE_SESSION_ID]: armLiveTurn('turn-1') }));
+    });
+    assert.equal(snapshotRenders, snapshotBaseline + 1);
+    assert.equal(projectionRenders, projectionBaseline + 1);
+
+    // First delta is also semantic: waiting → streamed, and text appears.
+    await act(async () => {
+      streamLiveText(controller, 'Hel', 2);
+    });
+    assert.equal(snapshotRenders, snapshotBaseline + 2);
+    assert.equal(projectionRenders, projectionBaseline + 2);
+    assert.equal(lastSnapshot?.hasStreamingText, true);
+
+    // Every further delta only grows text the chat surface owns.
+    await act(async () => {
+      streamLiveText(controller, 'lo', 3);
+    });
+    await act(async () => {
+      streamLiveText(controller, ' there', 4);
+    });
+    assert.equal(
+      projectionRenders,
+      projectionBaseline + 4,
+      'the chat surface must follow every delta',
+    );
+    assert.equal(
+      snapshotRenders,
+      snapshotBaseline + 2,
+      'a text delta must not disturb subscribers that read only semantic turn state',
+    );
+  });
+});
+
+const LIVE_SESSION_ID = 'session-live';
+
+function streamLiveText(
+  controller: ReturnType<typeof createAppShellSessionUiStateController>,
+  text: string,
+  ts: number,
+): void {
+  const event: SessionEvent = {
+    type: 'text_delta',
+    id: `event-${ts}`,
+    turnId: 'turn-1',
+    ts,
+    messageId: 'message-1',
+    text,
+  };
+  controller.setLiveTurnBySession((current) => {
+    const next = applyLiveTurnEvent(current[LIVE_SESSION_ID], event);
+    return next ? { ...current, [LIVE_SESSION_ID]: next } : current;
+  });
+}
 
 function streamingTurn(text: string, complete: boolean): TurnViewModel {
   return {

--- a/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
@@ -8,14 +8,16 @@ import { applyLiveTurnEvent, armLiveTurn } from '@maka/ui';
 import { build } from 'esbuild';
 import { act, createElement, type ReactElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { createAppShellSessionUiStateController } from '../../renderer/app-shell-session-ui-state.js';
+import {
+  createAppShellSessionUiStateController,
+  type AppShellSessionUiState,
+} from '../../renderer/app-shell-session-ui-state.js';
 import {
   deriveLiveTurnSnapshot,
   liveTurnSnapshotsEqual,
-  selectStreamingSessionIds,
-  sessionIdSetsEqual,
   type LiveTurnSnapshot,
 } from '../../renderer/live-turn-snapshot.js';
+import { useAppShellSessionUiReads } from '../../renderer/use-app-shell-session-ui-reads.js';
 import { useAppShellSessionUiSelector } from '../../renderer/use-app-shell-session-ui-selector.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
@@ -161,7 +163,8 @@ describe('AppShell session UI subscription boundary', () => {
     function SnapshotConsumer(): null {
       lastSnapshot = useAppShellSessionUiSelector(
         controller,
-        (state) => deriveLiveTurnSnapshot(state.liveTurnBySession[LIVE_SESSION_ID]),
+        selectTestSnapshot,
+        LIVE_SESSION_ID,
         liveTurnSnapshotsEqual,
       );
       snapshotRenders += 1;
@@ -169,7 +172,7 @@ describe('AppShell session UI subscription boundary', () => {
     }
 
     function ProjectionConsumer(): null {
-      useAppShellSessionUiSelector(controller, (state) => state.liveTurnBySession[LIVE_SESSION_ID]);
+      useAppShellSessionUiSelector(controller, selectTestProjection, LIVE_SESSION_ID);
       projectionRenders += 1;
       return null;
     }
@@ -215,32 +218,16 @@ describe('AppShell session UI subscription boundary', () => {
     );
   });
 
-  it('leaves a subscriber shaped like AppShell untouched through a whole stream', async () => {
+  // Drives `useAppShellSessionUiReads` — the shell's real read of the store, not
+  // a copy of its selector list. Adding a token-rate selection to that hook
+  // fails this test, which is the regression it exists to catch.
+  it('re-renders the shell for no delta after the first token', async () => {
     const controller = createAppShellSessionUiStateController();
     const { root } = installReactRenderer();
     let shellRenders = 0;
 
-    // The shell's complete read of session UI state: the low-frequency maps by
-    // raw reference, the live turn as a semantic snapshot, and the sidebar's
-    // pulse set by value. Anything added here that follows a delta puts the
-    // sidebar and composer back on the token path.
     function ShellReader(): null {
-      useAppShellSessionUiSelector(controller, (state) => state.messageLoadErrorBySession);
-      useAppShellSessionUiSelector(controller, (state) => state.messageRetryPendingBySession);
-      useAppShellSessionUiSelector(controller, (state) => state.stopPendingBySession);
-      useAppShellSessionUiSelector(controller, (state) => state.interactionBySession);
-      useAppShellSessionUiSelector(controller, (state) => state.pendingPermissionModeBySession);
-      useAppShellSessionUiSelector(controller, (state) => state.pendingSessionModelBySession);
-      useAppShellSessionUiSelector(
-        controller,
-        (state) => deriveLiveTurnSnapshot(state.liveTurnBySession[LIVE_SESSION_ID]),
-        liveTurnSnapshotsEqual,
-      );
-      useAppShellSessionUiSelector(
-        controller,
-        (state) => selectStreamingSessionIds(state.liveTurnBySession),
-        sessionIdSetsEqual,
-      );
+      useAppShellSessionUiReads(controller, LIVE_SESSION_ID);
       shellRenders += 1;
       return null;
     }
@@ -266,9 +253,36 @@ describe('AppShell session UI subscription boundary', () => {
       'no delta after the first may re-render the shell',
     );
   });
+
+  // The one branch where the snapshot cache must yield without the store moving.
+  it('follows the newly selected session when activeId changes under a still store', async () => {
+    const controller = createAppShellSessionUiStateController();
+    const { root } = installReactRenderer();
+    controller.setLiveTurnBySession(() => ({
+      [LIVE_SESSION_ID]: armLiveTurn('turn-a'),
+      other: { ...armLiveTurn('turn-b'), phase: 'streamed' as const },
+    }));
+    const seen: Array<string | undefined> = [];
+
+    function Reader(props: { activeId: string }): null {
+      seen.push(useAppShellSessionUiReads(controller, props.activeId).activeLiveTurnSnapshot.turnId);
+      return null;
+    }
+
+    await render(root, createElement(Reader, { activeId: LIVE_SESSION_ID }));
+    assert.equal(seen.at(-1), 'turn-a');
+
+    await render(root, createElement(Reader, { activeId: 'other' }));
+    assert.equal(seen.at(-1), 'turn-b', 'the first render after a switch must read the new session');
+  });
 });
 
 const LIVE_SESSION_ID = 'session-live';
+
+const selectTestSnapshot = (state: AppShellSessionUiState, sessionId: string) =>
+  deriveLiveTurnSnapshot(state.liveTurnBySession[sessionId]);
+const selectTestProjection = (state: AppShellSessionUiState, sessionId: string) =>
+  state.liveTurnBySession[sessionId];
 
 function streamLiveText(
   controller: ReturnType<typeof createAppShellSessionUiStateController>,

--- a/apps/desktop/src/renderer/app-shell-session-ui-state.ts
+++ b/apps/desktop/src/renderer/app-shell-session-ui-state.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef } from 'react';
+import { useRef } from 'react';
 import type { SessionEventStreamSnapshot } from '@maka/core';
 import { confirmLiveTurn, type InteractionQueues, type LiveTurnProjection } from '@maka/ui';
 import type { ShellRunUpdatesBySession } from './shell-run-update-state.js';
@@ -185,8 +185,13 @@ export function createAppShellSessionUiStateController(
 
 export type AppShellSessionUiStateController = ReturnType<typeof createAppShellSessionUiStateController>;
 
+/**
+ * Owns the controller for the component's lifetime. Deliberately does NOT
+ * subscribe: readers select what they need through
+ * `useAppShellSessionUiSelector`, so no single component re-renders for every
+ * write to the store (#1985).
+ */
 export function useAppShellSessionUiState() {
-  const [, forceRender] = useReducer((version: number) => version + 1, 0);
   const controllerRef = useRef<AppShellSessionUiStateController | null>(null);
 
   if (!controllerRef.current) {
@@ -194,13 +199,9 @@ export function useAppShellSessionUiState() {
   }
 
   const controller = controllerRef.current;
-  // TODO(#1985): the aggregate subscription goes away once every reader selects
-  // the slice it needs; kept here so the seam lands in its own commit.
-  useEffect(() => controller.subscribe(() => forceRender()), [controller]);
 
   return {
     controller,
-    state: controller.getState(),
     liveTurnBySessionRef: controller.liveTurnBySessionRef,
     sessionEventHealthBySessionRef: controller.sessionEventHealthBySessionRef,
     setMessageLoadErrorBySession: controller.setMessageLoadErrorBySession,

--- a/apps/desktop/src/renderer/app-shell-session-ui-state.ts
+++ b/apps/desktop/src/renderer/app-shell-session-ui-state.ts
@@ -1,4 +1,4 @@
-import { useReducer, useRef } from 'react';
+import { useEffect, useReducer, useRef } from 'react';
 import type { SessionEventStreamSnapshot } from '@maka/core';
 import { confirmLiveTurn, type InteractionQueues, type LiveTurnProjection } from '@maka/ui';
 import type { ShellRunUpdatesBySession } from './shell-run-update-state.js';
@@ -99,21 +99,31 @@ export function clearAppShellTurnTransientForSession(
 
 export function createAppShellSessionUiStateController(
   initialState: AppShellSessionUiState = createInitialAppShellSessionUiState(),
-  onChange: (state: AppShellSessionUiState) => void = () => {},
 ) {
   let currentState = initialState;
   const liveTurnBySessionRef = { current: currentState.liveTurnBySession };
   // Written by the event-health probes and read back by them alone. Kept off
-  // `currentState` so a probe never notifies `onChange`.
+  // `currentState` so a probe never notifies a subscriber.
   const sessionEventHealthBySessionRef: { current: Record<string, SessionEventStreamSnapshot> } = {
     current: {},
   };
+  const listeners = new Set<() => void>();
 
   function replaceState(next: AppShellSessionUiState): void {
     if (next === currentState) return;
     currentState = next;
     liveTurnBySessionRef.current = next.liveTurnBySession;
-    onChange(next);
+    // Synchronous, immediately after the swap. Never schedule this: the
+    // terminal-turn handoff reads the state it announces (#1985).
+    for (const listener of [...listeners]) listener();
+  }
+
+  /** Subscribe to state replacements. Stable identity, for `useSyncExternalStore`. */
+  function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
   }
 
   function updateMap<K extends AppShellSessionUiStateMapKey>(
@@ -132,6 +142,7 @@ export function createAppShellSessionUiStateController(
 
   return {
     getState: () => currentState,
+    subscribe,
     liveTurnBySessionRef,
     sessionEventHealthBySessionRef,
     setMessageLoadErrorBySession: createMapSetter('messageLoadErrorBySession'),
@@ -172,20 +183,23 @@ export function createAppShellSessionUiStateController(
   };
 }
 
+export type AppShellSessionUiStateController = ReturnType<typeof createAppShellSessionUiStateController>;
+
 export function useAppShellSessionUiState() {
   const [, forceRender] = useReducer((version: number) => version + 1, 0);
-  const controllerRef = useRef<ReturnType<typeof createAppShellSessionUiStateController> | null>(null);
+  const controllerRef = useRef<AppShellSessionUiStateController | null>(null);
 
   if (!controllerRef.current) {
-    controllerRef.current = createAppShellSessionUiStateController(
-      createInitialAppShellSessionUiState(),
-      () => forceRender(),
-    );
+    controllerRef.current = createAppShellSessionUiStateController();
   }
 
   const controller = controllerRef.current;
+  // TODO(#1985): the aggregate subscription goes away once every reader selects
+  // the slice it needs; kept here so the seam lands in its own commit.
+  useEffect(() => controller.subscribe(() => forceRender()), [controller]);
 
   return {
+    controller,
     state: controller.getState(),
     liveTurnBySessionRef: controller.liveTurnBySessionRef,
     sessionEventHealthBySessionRef: controller.sessionEventHealthBySessionRef,

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1,7 +1,6 @@
 import {
   useCallback,
   useEffect,
-  useEffectEvent,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -1775,9 +1774,6 @@ function AppShellContent({
     },
   });
 
-  // Runs per delta inside <LiveTurnReconciler/>, which owns no subtree (#1985).
-  const reconcilePersistedMessagesEffect = useEffectEvent(reconcilePersistedMessages);
-
   // Streaming-settle handoff, FALLBACK path only. The bubble's primary
   // `onStreamingSettled` signal runs after Astryx commits the terminal text.
   // Keep a delayed fallback because a stuck slot would otherwise hide the
@@ -2079,7 +2075,7 @@ function AppShellContent({
         controller={sessionUiController}
         activeId={activeId}
         messages={messages}
-        reconcile={reconcilePersistedMessagesEffect}
+        reconcile={reconcilePersistedMessages}
       />
       {/* Window chrome is frame-level hit-test only (not AppShell topNav): a
           transparent drag overlay so column surfaces paint to the window top.

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -53,6 +53,14 @@ import {
 import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
 import { ChatMessageSurface } from './chat-message-surface';
+import { LiveTurnReconciler } from './live-turn-reconciler';
+import {
+  deriveLiveTurnSnapshot,
+  liveTurnSnapshotsEqual,
+  selectStreamingSessionIds,
+  sessionIdSetsEqual,
+} from './live-turn-snapshot';
+import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
 import { AgentGraphPanel } from './agent-graph-panel';
 import { ChatComposerRegion } from './chat-composer-region';
 import { ChatWorkbar } from './chat-workbar';
@@ -260,7 +268,7 @@ function AppShellContent({
     setMessageLoadPending,
     messageRetryPendingRef,
     stopPendingRef,
-    sessionUiState,
+    sessionUiController,
     liveTurnBySessionRef,
     sessionEventHealthBySessionRef,
     setMessageLoadErrorBySession,
@@ -309,16 +317,47 @@ function AppShellContent({
     ));
   }, []);
   const navSelectionRef = useRef<NavSelection>(navSelection);
-  const {
-    messageLoadErrorBySession,
-    messageRetryPendingBySession,
-    stopPendingBySession,
-    liveTurnBySession,
-    shellRunUpdatesBySession,
-    interactionBySession,
-    pendingPermissionModeBySession,
-    pendingSessionModelBySession,
-  } = sessionUiState;
+  // #1985: one selection per map, each returning the store's own reference, so
+  // the shell re-renders only for the maps it actually reads. `liveTurnBySession`
+  // and `shellRunUpdatesBySession` are deliberately absent — they change per
+  // streamed token and belong to ChatMessageSurface, which subscribes to them
+  // itself. Adding either back here puts the whole shell on the token path.
+  const messageLoadErrorBySession = useAppShellSessionUiSelector(
+    sessionUiController,
+    (state) => state.messageLoadErrorBySession,
+  );
+  const messageRetryPendingBySession = useAppShellSessionUiSelector(
+    sessionUiController,
+    (state) => state.messageRetryPendingBySession,
+  );
+  const stopPendingBySession = useAppShellSessionUiSelector(
+    sessionUiController,
+    (state) => state.stopPendingBySession,
+  );
+  const interactionBySession = useAppShellSessionUiSelector(
+    sessionUiController,
+    (state) => state.interactionBySession,
+  );
+  const pendingPermissionModeBySession = useAppShellSessionUiSelector(
+    sessionUiController,
+    (state) => state.pendingPermissionModeBySession,
+  );
+  const pendingSessionModelBySession = useAppShellSessionUiSelector(
+    sessionUiController,
+    (state) => state.pendingSessionModelBySession,
+  );
+  const streamingSessionIds = useAppShellSessionUiSelector(
+    sessionUiController,
+    (state) => selectStreamingSessionIds(state.liveTurnBySession),
+    sessionIdSetsEqual,
+  );
+  // The active turn as the shell reads it: phase and a few booleans, never the
+  // streamed buffers. Invariant across the deltas of one step.
+  const activeLiveTurnSnapshot = useAppShellSessionUiSelector(
+    sessionUiController,
+    (state) => deriveLiveTurnSnapshot(activeId ? state.liveTurnBySession[activeId] : undefined),
+    liveTurnSnapshotsEqual,
+  );
   // PR-MEMORY-VISIBILITY-INDICATOR-0: session-context memory state (MEMORY.md
   // injected into the system prompt). State and the fire-and-forget refresh
   // live in `useShellMemoryPill`; recompute is triggered on mount (bootstrap
@@ -547,7 +586,6 @@ function AppShellContent({
   // Active autonomous goal for the current session drives the header
   // kill-switch pill (visible indicator + one-click clear).
   const activeGoal = useSessionGoal(activeId);
-  const activeLiveTurn = activeId ? liveTurnBySession[activeId] : undefined;
   // Set of session ids whose backend / connection is no longer usable —
   // drives the sidebar "已过期" pill (PR108g, paired with the PR108e chat
   // header banner). Derivation is pure (see `stale-sessions.ts`) so the
@@ -599,30 +637,20 @@ function AppShellContent({
     activeInteraction?.type === 'sandbox_boundary_request' ? activeInteraction : undefined;
   const activeQuestion = activeInteraction?.type === 'user_question_request' ? activeInteraction : undefined;
   const activeSession = sessions.find((session) => session.id === activeId);
-  // Live-turn projection of the active session: streaming/thinking slices, the
-  // sidebar pulse set, the in-flight tool signal, and the #646 turn-wait cues
-  // all live in useShellLiveTurn (pure derivation of the live projection).
-  // `activeLiveTurn` itself stays here — a source-slice contract pins its
-  // declaration to app-shell.tsx — and is passed in.
+  // The shell's reading of the active live turn: streaming/settled flags, the
+  // in-flight tool signal, and the #646 turn-wait cues, all derived from the
+  // semantic snapshot rather than the projection (#1985).
   const {
-    activeShellRunUpdates,
-    activeStreaming,
-    activeStreamingComplete,
     activeStreamingLive,
     activeStreamingMessageId,
-    activeThinking,
-    streamingSessionIds,
-    liveTools,
     hasInFlightLiveTools,
+    hasLiveTurnContent,
     turnActive,
     showProcessingIndicator,
     showContinuingIndicator,
   } = useShellLiveTurn({
-    activeId,
+    liveTurn: activeLiveTurnSnapshot,
     activeSession,
-    activeLiveTurn,
-    liveTurnBySession,
-    shellRunUpdatesBySession,
   });
   // Surface a credential-lifecycle alert directly in the chat header when
   // the active session's connection is in `needs_reauth` / `error` or has
@@ -1747,22 +1775,15 @@ function AppShellContent({
     },
   });
 
-  // Tool/thinking evidence may survive its event-triggered refresh, including
-  // between steps of one running turn. Reconcile from durable evidence whenever
-  // either side changes, so old output stays on its original tool instead of
-  // joining the next batch, without deleting text that the live renderer still owns.
+  // Runs per delta inside <LiveTurnReconciler/>, which owns no subtree (#1985).
   const reconcilePersistedMessagesEffect = useEffectEvent(reconcilePersistedMessages);
-  useEffect(() => {
-    if (!activeId) return;
-    reconcilePersistedMessagesEffect(activeId, messages);
-  }, [activeId, activeLiveTurn, messages]);
 
   // Streaming-settle handoff, FALLBACK path only. The bubble's primary
   // `onStreamingSettled` signal runs after Astryx commits the terminal text.
   // Keep a delayed fallback because a stuck slot would otherwise hide the
   // committed answer forever (`streamingMessageId` suppresses it while live).
   useEffect(() => {
-    if (!activeId || !activeStreamingComplete || !activeStreamingMessageId) return;
+    if (!activeId || !activeStreamingMessageId) return;
     const committedAssistantArrived = messages.some(
       (message) => message.type === 'assistant' && message.id === activeStreamingMessageId,
     );
@@ -1771,7 +1792,7 @@ function AppShellContent({
       void settleAssistantStreaming(activeId, activeStreamingMessageId);
     }, SETTLE_FALLBACK_GRACE_MS);
     return () => window.clearTimeout(timer);
-  }, [activeId, activeStreamingComplete, activeStreamingMessageId, messages, settleAssistantStreaming]);
+  }, [activeId, activeStreamingMessageId, messages, settleAssistantStreaming]);
 
   const hasModalOpen = helpOpen || paletteOpen || searchModalOpen;
 
@@ -1998,9 +2019,7 @@ function AppShellContent({
   const homeSurfaceActive =
     navSelection.section === 'sessions' &&
     messages.length === 0 &&
-    activeStreaming.length === 0 &&
-    activeThinking.length === 0 &&
-    liveTools.length === 0 &&
+    !hasLiveTurnContent &&
     !activeMessageLoadError;
   const commandOptions: AppShellCommandListOptions = {
     uiLocale,
@@ -2056,6 +2075,12 @@ function AppShellContent({
          for them to disagree. */
       data-sidebar-state={sessionListCollapsed ? 'collapsed' : 'expanded'}
     >
+      <LiveTurnReconciler
+        controller={sessionUiController}
+        activeId={activeId}
+        messages={messages}
+        reconcile={reconcilePersistedMessagesEffect}
+      />
       {/* Window chrome is frame-level hit-test only (not AppShell topNav): a
           transparent drag overlay so column surfaces paint to the window top.
           It precedes the shell so Chromium applies app-region subtraction from
@@ -2430,9 +2455,9 @@ function AppShellContent({
               >
                 {navSelection.section === 'sessions' ? (
                   <ChatMessageSurface
+                sessionUiController={sessionUiController}
+                activeSessionId={activeId}
                 messages={messages}
-                liveTurn={activeLiveTurn}
-                shellRunUpdates={activeShellRunUpdates}
                 messageLoading={activeMessageLoading}
                 processingIndicator={showProcessingIndicator}
                 continuingIndicator={showContinuingIndicator}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -53,13 +53,7 @@ import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
 import { ChatMessageSurface } from './chat-message-surface';
 import { LiveTurnReconciler } from './live-turn-reconciler';
-import {
-  deriveLiveTurnSnapshot,
-  liveTurnSnapshotsEqual,
-  selectStreamingSessionIds,
-  sessionIdSetsEqual,
-} from './live-turn-snapshot';
-import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
+import { useAppShellSessionUiReads } from './use-app-shell-session-ui-reads';
 import { AgentGraphPanel } from './agent-graph-panel';
 import { ChatComposerRegion } from './chat-composer-region';
 import { ChatWorkbar } from './chat-workbar';
@@ -316,47 +310,18 @@ function AppShellContent({
     ));
   }, []);
   const navSelectionRef = useRef<NavSelection>(navSelection);
-  // #1985: one selection per map, each returning the store's own reference, so
-  // the shell re-renders only for the maps it actually reads. `liveTurnBySession`
-  // and `shellRunUpdatesBySession` are deliberately absent — they change per
-  // streamed token and belong to ChatMessageSurface, which subscribes to them
-  // itself. Adding either back here puts the whole shell on the token path.
-  const messageLoadErrorBySession = useAppShellSessionUiSelector(
-    sessionUiController,
-    (state) => state.messageLoadErrorBySession,
-  );
-  const messageRetryPendingBySession = useAppShellSessionUiSelector(
-    sessionUiController,
-    (state) => state.messageRetryPendingBySession,
-  );
-  const stopPendingBySession = useAppShellSessionUiSelector(
-    sessionUiController,
-    (state) => state.stopPendingBySession,
-  );
-  const interactionBySession = useAppShellSessionUiSelector(
-    sessionUiController,
-    (state) => state.interactionBySession,
-  );
-  const pendingPermissionModeBySession = useAppShellSessionUiSelector(
-    sessionUiController,
-    (state) => state.pendingPermissionModeBySession,
-  );
-  const pendingSessionModelBySession = useAppShellSessionUiSelector(
-    sessionUiController,
-    (state) => state.pendingSessionModelBySession,
-  );
-  const streamingSessionIds = useAppShellSessionUiSelector(
-    sessionUiController,
-    (state) => selectStreamingSessionIds(state.liveTurnBySession),
-    sessionIdSetsEqual,
-  );
-  // The active turn as the shell reads it: phase and a few booleans, never the
-  // streamed buffers. Invariant across the deltas of one step.
-  const activeLiveTurnSnapshot = useAppShellSessionUiSelector(
-    sessionUiController,
-    (state) => deriveLiveTurnSnapshot(activeId ? state.liveTurnBySession[activeId] : undefined),
-    liveTurnSnapshotsEqual,
-  );
+  // #1985: the shell's complete read of session UI state. See the hook for why
+  // the two token-rate maps are absent.
+  const {
+    messageLoadErrorBySession,
+    messageRetryPendingBySession,
+    stopPendingBySession,
+    interactionBySession,
+    pendingPermissionModeBySession,
+    pendingSessionModelBySession,
+    streamingSessionIds,
+    activeLiveTurnSnapshot,
+  } = useAppShellSessionUiReads(sessionUiController, activeId);
   // PR-MEMORY-VISIBILITY-INDICATOR-0: session-context memory state (MEMORY.md
   // injected into the system prompt). State and the fire-and-forget refresh
   // live in `useShellMemoryPill`; recompute is triggered on mount (bootstrap

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, ReactNode } from 'react';
+import { useMemo, type ComponentProps, type ReactNode } from 'react';
 import {
   isDeepResearchSession,
   type LlmConnection,
@@ -8,6 +8,8 @@ import {
 } from '@maka/core';
 import { Banner, Button, ChatView, useUiLocale } from '@maka/ui';
 import { OnboardingHero } from './OnboardingHero';
+import type { AppShellSessionUiStateController } from './app-shell-session-ui-state';
+import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
 import type { SessionHealthNoticeView } from './use-shell-chat-model';
 import { getShellCopy } from './locales/shell-copy';
 import { useDeepResearchRun } from './use-deep-research-run';
@@ -24,8 +26,17 @@ import { useDeepResearchRun } from './use-deep-research-run';
  */
 interface ChatMessageSurfaceProps extends Omit<
   ComponentProps<typeof ChatView>,
-  'deepResearchRun' | 'emptyOverride'
+  'deepResearchRun' | 'emptyOverride' | 'liveTurn' | 'shellRunUpdates'
 > {
+  /**
+   * #1985: the live projection and the shell-run records are the only session
+   * UI state that changes per streamed token, and this surface is their only
+   * renderer. It subscribes to them here rather than taking them as props, so
+   * a delta never reaches AppShell and re-renders the sidebar and composer.
+   */
+  sessionUiController: AppShellSessionUiStateController;
+  /** The shell's selected session. Not derived from `activeSession`, which the shell substitutes for an unsaved chat. */
+  activeSessionId: string | undefined;
   sessionHealthNotice?: SessionHealthNoticeView;
   showOnboardingHero: boolean;
   onboardingState: OnboardingState | undefined;
@@ -40,6 +51,8 @@ interface ChatMessageSurfaceProps extends Omit<
 }
 
 export function ChatMessageSurface({
+  sessionUiController,
+  activeSessionId,
   sessionHealthNotice,
   showOnboardingHero,
   onboardingState,
@@ -61,6 +74,20 @@ export function ChatMessageSurface({
   const deepResearchRun = useDeepResearchRun(
     activeSession?.id,
     isDeepResearchSession(activeSession?.labels),
+  );
+  const liveTurn = useAppShellSessionUiSelector(
+    sessionUiController,
+    (state) => (activeSessionId ? state.liveTurnBySession[activeSessionId] : undefined),
+  );
+  // Select the raw per-session record — building the array inside `getSnapshot`
+  // would hand `useSyncExternalStore` a new identity on every read.
+  const shellRunUpdateRecord = useAppShellSessionUiSelector(
+    sessionUiController,
+    (state) => (activeSessionId ? state.shellRunUpdatesBySession[activeSessionId] : undefined),
+  );
+  const shellRunUpdates = useMemo(
+    () => Object.values(shellRunUpdateRecord ?? {}),
+    [shellRunUpdateRecord],
   );
   const emptyOverride: ReactNode =
     showOnboardingHero && onboardingState ? (
@@ -93,6 +120,8 @@ export function ChatMessageSurface({
     <>
       <ChatView
         {...chatViewRest}
+        liveTurn={liveTurn}
+        shellRunUpdates={shellRunUpdates}
         deepResearchRun={deepResearchRun}
         emptyOverride={emptyOverride}
       />

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -8,8 +8,13 @@ import {
 } from '@maka/core';
 import { Banner, Button, ChatView, useUiLocale } from '@maka/ui';
 import { OnboardingHero } from './OnboardingHero';
-import type { AppShellSessionUiStateController } from './app-shell-session-ui-state';
+import type { AppShellSessionUiState, AppShellSessionUiStateController } from './app-shell-session-ui-state';
 import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
+
+const selectLiveTurn = (state: AppShellSessionUiState, sessionId: string | undefined) =>
+  sessionId ? state.liveTurnBySession[sessionId] : undefined;
+const selectShellRunRecord = (state: AppShellSessionUiState, sessionId: string | undefined) =>
+  sessionId ? state.shellRunUpdatesBySession[sessionId] : undefined;
 import type { SessionHealthNoticeView } from './use-shell-chat-model';
 import { getShellCopy } from './locales/shell-copy';
 import { useDeepResearchRun } from './use-deep-research-run';
@@ -75,15 +80,13 @@ export function ChatMessageSurface({
     activeSession?.id,
     isDeepResearchSession(activeSession?.labels),
   );
-  const liveTurn = useAppShellSessionUiSelector(
-    sessionUiController,
-    (state) => (activeSessionId ? state.liveTurnBySession[activeSessionId] : undefined),
-  );
+  const liveTurn = useAppShellSessionUiSelector(sessionUiController, selectLiveTurn, activeSessionId);
   // Select the raw per-session record — building the array inside `getSnapshot`
   // would hand `useSyncExternalStore` a new identity on every read.
   const shellRunUpdateRecord = useAppShellSessionUiSelector(
     sessionUiController,
-    (state) => (activeSessionId ? state.shellRunUpdatesBySession[activeSessionId] : undefined),
+    selectShellRunRecord,
+    activeSessionId,
   );
   const shellRunUpdates = useMemo(
     () => Object.values(shellRunUpdateRecord ?? {}),

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -9,15 +9,14 @@ import {
 import { Banner, Button, ChatView, useUiLocale } from '@maka/ui';
 import { OnboardingHero } from './OnboardingHero';
 import type { AppShellSessionUiState, AppShellSessionUiStateController } from './app-shell-session-ui-state';
-import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
-
-const selectLiveTurn = (state: AppShellSessionUiState, sessionId: string | undefined) =>
-  sessionId ? state.liveTurnBySession[sessionId] : undefined;
-const selectShellRunRecord = (state: AppShellSessionUiState, sessionId: string | undefined) =>
-  sessionId ? state.shellRunUpdatesBySession[sessionId] : undefined;
 import type { SessionHealthNoticeView } from './use-shell-chat-model';
 import { getShellCopy } from './locales/shell-copy';
+import { selectLiveTurn } from './use-app-shell-session-ui-reads';
+import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
 import { useDeepResearchRun } from './use-deep-research-run';
+
+const selectShellRunRecord = (state: AppShellSessionUiState, sessionId: string | undefined) =>
+  sessionId ? state.shellRunUpdatesBySession[sessionId] : undefined;
 
 /**
  * The sessions-section message surface (issue #1043): ChatView plus the
@@ -81,8 +80,10 @@ export function ChatMessageSurface({
     isDeepResearchSession(activeSession?.labels),
   );
   const liveTurn = useAppShellSessionUiSelector(sessionUiController, selectLiveTurn, activeSessionId);
-  // Select the raw per-session record — building the array inside `getSnapshot`
-  // would hand `useSyncExternalStore` a new identity on every read.
+  // Select the raw per-session record: its identity is the store's own, so a
+  // change to any OTHER map cannot rebuild the array. Deriving it in the
+  // selector would need a comparator to say the same thing, and would still
+  // recompute once per store change.
   const shellRunUpdateRecord = useAppShellSessionUiSelector(
     sessionUiController,
     selectShellRunRecord,

--- a/apps/desktop/src/renderer/live-turn-reconciler.tsx
+++ b/apps/desktop/src/renderer/live-turn-reconciler.tsx
@@ -30,7 +30,10 @@ export function LiveTurnReconciler(props: {
   useEffect(() => {
     if (!activeId) return;
     reconcile(activeId, messages);
-    // `reconcile` is an effect event; `liveTurn` is a trigger, not a read.
+    // `liveTurn` is a trigger, not a read. `reconcile` must come from
+    // `useStableActions` — its identity is fixed for the component's lifetime,
+    // so it belongs in the deps honestly rather than being hidden behind a
+    // wrapper whose identity changes every render.
   }, [activeId, liveTurn, messages, reconcile]);
 
   return null;

--- a/apps/desktop/src/renderer/live-turn-reconciler.tsx
+++ b/apps/desktop/src/renderer/live-turn-reconciler.tsx
@@ -1,7 +1,10 @@
 import { useEffect } from 'react';
 import type { StoredMessage } from '@maka/core';
-import type { AppShellSessionUiStateController } from './app-shell-session-ui-state';
+import type { AppShellSessionUiState, AppShellSessionUiStateController } from './app-shell-session-ui-state';
 import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
+
+const selectLiveTurn = (state: AppShellSessionUiState, sessionId: string | undefined) =>
+  sessionId ? state.liveTurnBySession[sessionId] : undefined;
 
 /**
  * Reconciles the live projection against durable messages, and renders nothing.
@@ -22,10 +25,7 @@ export function LiveTurnReconciler(props: {
   reconcile: (sessionId: string, messages: readonly StoredMessage[]) => void;
 }): null {
   const { controller, activeId, messages, reconcile } = props;
-  const liveTurn = useAppShellSessionUiSelector(
-    controller,
-    (state) => (activeId ? state.liveTurnBySession[activeId] : undefined),
-  );
+  const liveTurn = useAppShellSessionUiSelector(controller, selectLiveTurn, activeId);
 
   useEffect(() => {
     if (!activeId) return;

--- a/apps/desktop/src/renderer/live-turn-reconciler.tsx
+++ b/apps/desktop/src/renderer/live-turn-reconciler.tsx
@@ -1,10 +1,8 @@
 import { useEffect } from 'react';
 import type { StoredMessage } from '@maka/core';
-import type { AppShellSessionUiState, AppShellSessionUiStateController } from './app-shell-session-ui-state';
+import type { AppShellSessionUiStateController } from './app-shell-session-ui-state';
+import { selectLiveTurn } from './use-app-shell-session-ui-reads';
 import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
-
-const selectLiveTurn = (state: AppShellSessionUiState, sessionId: string | undefined) =>
-  sessionId ? state.liveTurnBySession[sessionId] : undefined;
 
 /**
  * Reconciles the live projection against durable messages, and renders nothing.

--- a/apps/desktop/src/renderer/live-turn-reconciler.tsx
+++ b/apps/desktop/src/renderer/live-turn-reconciler.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import type { StoredMessage } from '@maka/core';
+import type { AppShellSessionUiStateController } from './app-shell-session-ui-state';
+import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
+
+/**
+ * Reconciles the live projection against durable messages, and renders nothing.
+ *
+ * Tool/thinking evidence may survive its event-triggered refresh, including
+ * between steps of one running turn, so this has to run whenever either side
+ * changes — old output stays on its original tool instead of joining the next
+ * batch, without deleting text that the live renderer still owns.
+ *
+ * #1985: that means following the projection per delta. Keeping it in AppShell
+ * forced the whole shell to subscribe at token rate; as a childless component
+ * it can follow every delta while owning no subtree to rebuild.
+ */
+export function LiveTurnReconciler(props: {
+  controller: AppShellSessionUiStateController;
+  activeId: string | undefined;
+  messages: readonly StoredMessage[];
+  reconcile: (sessionId: string, messages: readonly StoredMessage[]) => void;
+}): null {
+  const { controller, activeId, messages, reconcile } = props;
+  const liveTurn = useAppShellSessionUiSelector(
+    controller,
+    (state) => (activeId ? state.liveTurnBySession[activeId] : undefined),
+  );
+
+  useEffect(() => {
+    if (!activeId) return;
+    reconcile(activeId, messages);
+    // `reconcile` is an effect event; `liveTurn` is a trigger, not a read.
+  }, [activeId, liveTurn, messages, reconcile]);
+
+  return null;
+}

--- a/apps/desktop/src/renderer/live-turn-snapshot.ts
+++ b/apps/desktop/src/renderer/live-turn-snapshot.ts
@@ -1,0 +1,81 @@
+import type { LiveTurnProjection } from '@maka/ui';
+import type { TurnPhase } from './model-wait-state.js';
+import { hasInFlightToolActivity } from './session-event-health.js';
+
+/**
+ * The low-entropy reading of a live turn: everything the shell derives from the
+ * active projection EXCEPT the streamed content itself.
+ *
+ * #1985: a text delta changes the projection on every token, but it changes
+ * none of these values once a turn is under way. The shell (and through it the
+ * sidebar, the composer, and every non-chat surface) subscribes to this
+ * snapshot, so a stream only re-renders the chat transcript — the one surface
+ * that genuinely reads the growing text.
+ *
+ * Keep this free of buffers, arrays, and maps. Anything whose identity changes
+ * per delta belongs to the chat surface, not here.
+ */
+export interface LiveTurnSnapshot {
+  /** Turn phase, or undefined when no turn is in flight (incl. a settled one). */
+  phase: TurnPhase | undefined;
+  /** Whether the active text step has emitted anything yet. */
+  hasStreamingText: boolean;
+  /** Whether that text step is closed. */
+  streamingTextComplete: boolean;
+  /** Step id of the settled answer, once complete — the handoff key. */
+  streamingMessageId: string | undefined;
+  /** Whether the active reasoning step has emitted anything yet. */
+  hasThinkingText: boolean;
+  /** Whether the turn has any tool activity at all. */
+  hasLiveTools: boolean;
+  /** Whether any tool is still pending / running / awaiting permission. */
+  hasInFlightTools: boolean;
+}
+
+const NO_LIVE_TURN: LiveTurnSnapshot = {
+  phase: undefined,
+  hasStreamingText: false,
+  streamingTextComplete: false,
+  streamingMessageId: undefined,
+  hasThinkingText: false,
+  hasLiveTools: false,
+  hasInFlightTools: false,
+};
+
+export function deriveLiveTurnSnapshot(projection: LiveTurnProjection | undefined): LiveTurnSnapshot {
+  if (!projection) return NO_LIVE_TURN;
+  const steps = projection.steps;
+  const textStep = findLast(steps, (step) => Boolean(step.text));
+  const thinkingStep = findLast(steps, (step) => Boolean(step.thinking));
+  const tools = steps.flatMap((step) => step.tools);
+  const streamingTextComplete = textStep?.text?.complete === true;
+  return {
+    phase: projection.terminal ? undefined : projection.phase,
+    hasStreamingText: (textStep?.text?.text.length ?? 0) > 0,
+    streamingTextComplete,
+    streamingMessageId: streamingTextComplete ? textStep?.stepId : undefined,
+    hasThinkingText: (thinkingStep?.thinking?.text.length ?? 0) > 0,
+    hasLiveTools: tools.length > 0,
+    hasInFlightTools: hasInFlightToolActivity(tools),
+  };
+}
+
+export function liveTurnSnapshotsEqual(a: LiveTurnSnapshot, b: LiveTurnSnapshot): boolean {
+  return (
+    a.phase === b.phase &&
+    a.hasStreamingText === b.hasStreamingText &&
+    a.streamingTextComplete === b.streamingTextComplete &&
+    a.streamingMessageId === b.streamingMessageId &&
+    a.hasThinkingText === b.hasThinkingText &&
+    a.hasLiveTools === b.hasLiveTools &&
+    a.hasInFlightTools === b.hasInFlightTools
+  );
+}
+
+function findLast<T>(items: readonly T[], predicate: (item: T) => boolean): T | undefined {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item !== undefined && predicate(item)) return item;
+  }
+  return undefined;
+}

--- a/apps/desktop/src/renderer/live-turn-snapshot.ts
+++ b/apps/desktop/src/renderer/live-turn-snapshot.ts
@@ -48,7 +48,6 @@ export function deriveLiveTurnSnapshot(projection: LiveTurnProjection | undefine
   const steps = projection.steps;
   const textStep = findLast(steps, (step) => Boolean(step.text));
   const thinkingStep = findLast(steps, (step) => Boolean(step.thinking));
-  const tools = steps.flatMap((step) => step.tools);
   const streamingTextComplete = textStep?.text?.complete === true;
   return {
     turnId: projection.turnId,
@@ -56,8 +55,8 @@ export function deriveLiveTurnSnapshot(projection: LiveTurnProjection | undefine
     hasStreamingText: (textStep?.text?.text.length ?? 0) > 0,
     streamingMessageId: streamingTextComplete ? textStep?.stepId : undefined,
     hasThinkingText: (thinkingStep?.thinking?.text.length ?? 0) > 0,
-    hasLiveTools: tools.length > 0,
-    hasInFlightTools: hasInFlightToolActivity(tools),
+    hasLiveTools: steps.some((step) => step.tools.length > 0),
+    hasInFlightTools: steps.some((step) => hasInFlightToolActivity(step.tools)),
   };
 }
 

--- a/apps/desktop/src/renderer/live-turn-snapshot.ts
+++ b/apps/desktop/src/renderer/live-turn-snapshot.ts
@@ -16,13 +16,14 @@ import { hasInFlightToolActivity } from './session-event-health.js';
  * per delta belongs to the chat surface, not here.
  */
 export interface LiveTurnSnapshot {
+  /** The projected turn's id, kept even once terminal — `deriveTurnActive`'s arm. */
+  turnId: string | undefined;
   /** Turn phase, or undefined when no turn is in flight (incl. a settled one). */
   phase: TurnPhase | undefined;
   /** Whether the active text step has emitted anything yet. */
   hasStreamingText: boolean;
-  /** Whether that text step is closed. */
-  streamingTextComplete: boolean;
-  /** Step id of the settled answer, once complete — the handoff key. */
+  /** Step id of the settled answer, once complete — the handoff key. Its
+   *  presence is also what says the text step is closed. */
   streamingMessageId: string | undefined;
   /** Whether the active reasoning step has emitted anything yet. */
   hasThinkingText: boolean;
@@ -33,9 +34,9 @@ export interface LiveTurnSnapshot {
 }
 
 const NO_LIVE_TURN: LiveTurnSnapshot = {
+  turnId: undefined,
   phase: undefined,
   hasStreamingText: false,
-  streamingTextComplete: false,
   streamingMessageId: undefined,
   hasThinkingText: false,
   hasLiveTools: false,
@@ -50,9 +51,9 @@ export function deriveLiveTurnSnapshot(projection: LiveTurnProjection | undefine
   const tools = steps.flatMap((step) => step.tools);
   const streamingTextComplete = textStep?.text?.complete === true;
   return {
+    turnId: projection.turnId,
     phase: projection.terminal ? undefined : projection.phase,
     hasStreamingText: (textStep?.text?.text.length ?? 0) > 0,
-    streamingTextComplete,
     streamingMessageId: streamingTextComplete ? textStep?.stepId : undefined,
     hasThinkingText: (thinkingStep?.thinking?.text.length ?? 0) > 0,
     hasLiveTools: tools.length > 0,
@@ -62,14 +63,40 @@ export function deriveLiveTurnSnapshot(projection: LiveTurnProjection | undefine
 
 export function liveTurnSnapshotsEqual(a: LiveTurnSnapshot, b: LiveTurnSnapshot): boolean {
   return (
+    a.turnId === b.turnId &&
     a.phase === b.phase &&
     a.hasStreamingText === b.hasStreamingText &&
-    a.streamingTextComplete === b.streamingTextComplete &&
     a.streamingMessageId === b.streamingMessageId &&
     a.hasThinkingText === b.hasThinkingText &&
     a.hasLiveTools === b.hasLiveTools &&
     a.hasInFlightTools === b.hasInFlightTools
   );
+}
+
+/**
+ * Session ids with a live streaming delta — the sidebar pulse set.
+ *
+ * Membership is NOT turn-invariant (a session leaves between a settled step and
+ * the next one), but it is delta-invariant, which is what the sidebar needs.
+ * Pair it with `sessionIdSetsEqual`: the set is rebuilt on every projection
+ * change, so only value equality keeps the sidebar off the token path.
+ */
+export function selectStreamingSessionIds(
+  liveTurnBySession: Record<string, LiveTurnProjection>,
+): Set<string> {
+  const streaming = new Set<string>();
+  for (const [sessionId, projection] of Object.entries(liveTurnBySession)) {
+    if (projection.steps.some((step) => step.text?.text && !step.text.complete)) streaming.add(sessionId);
+  }
+  return streaming;
+}
+
+export function sessionIdSetsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const id of a) {
+    if (!b.has(id)) return false;
+  }
+  return true;
 }
 
 function findLast<T>(items: readonly T[], predicate: (item: T) => boolean): T | undefined {

--- a/apps/desktop/src/renderer/model-wait-state.ts
+++ b/apps/desktop/src/renderer/model-wait-state.ts
@@ -67,10 +67,10 @@ export function deriveTurnActive(input: {
 export interface ModelWaitInputs {
   /** Turn phase, or undefined when no turn is in flight. */
   turnPhase: TurnPhase | undefined;
-  /** Active session's live assistant answer buffer. */
-  streamingText: string;
-  /** Active session's live reasoning buffer. */
-  thinkingText: string;
+  /** Whether the active assistant answer buffer has any content. */
+  hasStreamingText: boolean;
+  /** Whether the active reasoning buffer has any content. */
+  hasThinkingText: boolean;
   /** Whether any live tool is still pending / running / awaiting permission. */
   hasInFlightTools: boolean;
 }
@@ -86,10 +86,7 @@ export type ModelWaitKind = 'none' | 'processing' | 'continuing';
  * `'continuing'`.
  */
 export function deriveModelWait(input: ModelWaitInputs): ModelWaitKind {
-  const idle =
-    input.streamingText.length === 0 &&
-    input.thinkingText.length === 0 &&
-    !input.hasInFlightTools;
+  const idle = !input.hasStreamingText && !input.hasThinkingText && !input.hasInFlightTools;
   if (!idle || input.turnPhase === undefined) return 'none';
   return input.turnPhase === 'waiting' ? 'processing' : 'continuing';
 }

--- a/apps/desktop/src/renderer/use-app-shell-session-ui-reads.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-ui-reads.ts
@@ -1,0 +1,66 @@
+import type { InteractionQueues } from '@maka/ui';
+import type { AppShellSessionUiState, AppShellSessionUiStateController } from './app-shell-session-ui-state.js';
+import {
+  deriveLiveTurnSnapshot,
+  liveTurnSnapshotsEqual,
+  selectStreamingSessionIds,
+  sessionIdSetsEqual,
+  type LiveTurnSnapshot,
+} from './live-turn-snapshot.js';
+import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector.js';
+
+const selectMessageLoadError = (state: AppShellSessionUiState) => state.messageLoadErrorBySession;
+const selectMessageRetryPending = (state: AppShellSessionUiState) => state.messageRetryPendingBySession;
+const selectStopPending = (state: AppShellSessionUiState) => state.stopPendingBySession;
+const selectInteraction = (state: AppShellSessionUiState) => state.interactionBySession;
+const selectPendingPermissionMode = (state: AppShellSessionUiState) => state.pendingPermissionModeBySession;
+const selectPendingSessionModel = (state: AppShellSessionUiState) => state.pendingSessionModelBySession;
+const selectPulseSet = (state: AppShellSessionUiState) => selectStreamingSessionIds(state.liveTurnBySession);
+const selectActiveSnapshot = (state: AppShellSessionUiState, sessionId: string | undefined) =>
+  deriveLiveTurnSnapshot(sessionId ? state.liveTurnBySession[sessionId] : undefined);
+
+/**
+ * Everything AppShell reads from session UI state — the complete list, in one
+ * place (#1985).
+ *
+ * Each low-frequency map is selected by the store's own reference, so it needs
+ * no comparator; the active turn arrives as a `LiveTurnSnapshot` and the
+ * sidebar's pulse set by value. A streamed token changes none of them, which is
+ * what keeps the sidebar, the composer, and every non-chat surface off the
+ * token path.
+ *
+ * `liveTurnBySession` and `shellRunUpdatesBySession` are deliberately absent in
+ * raw form: they change per delta, and `ChatMessageSurface` — their only
+ * renderer — subscribes to them itself. Adding either here puts the whole shell
+ * back on the token path, and the render-boundary contract test drives this
+ * hook directly so that it says so.
+ */
+export function useAppShellSessionUiReads(
+  controller: AppShellSessionUiStateController,
+  activeId: string | undefined,
+): {
+  messageLoadErrorBySession: Record<string, string>;
+  messageRetryPendingBySession: Record<string, boolean>;
+  stopPendingBySession: Record<string, boolean>;
+  interactionBySession: InteractionQueues;
+  pendingPermissionModeBySession: Record<string, boolean>;
+  pendingSessionModelBySession: Record<string, boolean>;
+  streamingSessionIds: Set<string>;
+  activeLiveTurnSnapshot: LiveTurnSnapshot;
+} {
+  return {
+    messageLoadErrorBySession: useAppShellSessionUiSelector(controller, selectMessageLoadError),
+    messageRetryPendingBySession: useAppShellSessionUiSelector(controller, selectMessageRetryPending),
+    stopPendingBySession: useAppShellSessionUiSelector(controller, selectStopPending),
+    interactionBySession: useAppShellSessionUiSelector(controller, selectInteraction),
+    pendingPermissionModeBySession: useAppShellSessionUiSelector(controller, selectPendingPermissionMode),
+    pendingSessionModelBySession: useAppShellSessionUiSelector(controller, selectPendingSessionModel),
+    streamingSessionIds: useAppShellSessionUiSelector(controller, selectPulseSet, undefined, sessionIdSetsEqual),
+    activeLiveTurnSnapshot: useAppShellSessionUiSelector(
+      controller,
+      selectActiveSnapshot,
+      activeId,
+      liveTurnSnapshotsEqual,
+    ),
+  };
+}

--- a/apps/desktop/src/renderer/use-app-shell-session-ui-reads.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-ui-reads.ts
@@ -16,8 +16,17 @@ const selectInteraction = (state: AppShellSessionUiState) => state.interactionBy
 const selectPendingPermissionMode = (state: AppShellSessionUiState) => state.pendingPermissionModeBySession;
 const selectPendingSessionModel = (state: AppShellSessionUiState) => state.pendingSessionModelBySession;
 const selectPulseSet = (state: AppShellSessionUiState) => selectStreamingSessionIds(state.liveTurnBySession);
+
+/**
+ * The active session's raw projection — the one selection that moves per token.
+ * Lives here with the rest so its two subscribers (the chat surface and the
+ * reconciler) share one definition instead of each keeping a copy.
+ */
+export const selectLiveTurn = (state: AppShellSessionUiState, sessionId: string | undefined) =>
+  sessionId ? state.liveTurnBySession[sessionId] : undefined;
+
 const selectActiveSnapshot = (state: AppShellSessionUiState, sessionId: string | undefined) =>
-  deriveLiveTurnSnapshot(sessionId ? state.liveTurnBySession[sessionId] : undefined);
+  deriveLiveTurnSnapshot(selectLiveTurn(state, sessionId));
 
 /**
  * Everything AppShell reads from session UI state — the complete list, in one

--- a/apps/desktop/src/renderer/use-app-shell-session-ui-selector.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-ui-selector.ts
@@ -17,10 +17,12 @@ import type { AppShellSessionUiState, AppShellSessionUiStateController } from '.
  * subscription. Changing `arg` rebuilds the cache, so the first render after
  * switching sessions already reads the new one.
  *
- * `isEqual` is required for any selector that derives a fresh object.
- * `useSyncExternalStore` demands a snapshot that keeps its identity while
- * nothing it selects changed; without it such a selector does not merely
- * over-render, it loops.
+ * The cache is keyed by the STATE the value was derived from, because
+ * `useSyncExternalStore` reads a snapshot several times per store state and
+ * demands the same value each time. A selector that derives a fresh object
+ * would otherwise loop, so keying it here is what makes `isEqual` a plain
+ * fewer-renders optimization: it carries a value's identity ACROSS a state the
+ * selection did not actually change.
  */
 export function useAppShellSessionUiSelector<T, A = undefined>(
   controller: AppShellSessionUiStateController,
@@ -29,14 +31,16 @@ export function useAppShellSessionUiSelector<T, A = undefined>(
   isEqual?: (a: T, b: T) => boolean,
 ): T {
   const getSnapshot = useMemo(() => {
-    let cache: { value: T } | null = null;
+    let cache: { state: AppShellSessionUiState; value: T } | null = null;
     return (): T => {
-      const next = select(controller.getState(), arg as A);
-      if (cache && (Object.is(cache.value, next) || isEqual?.(cache.value, next) === true)) {
-        return cache.value;
-      }
-      cache = { value: next };
-      return next;
+      const state = controller.getState();
+      if (cache && cache.state === state) return cache.value;
+      const next = select(state, arg as A);
+      const value = cache && (Object.is(cache.value, next) || isEqual?.(cache.value, next) === true)
+        ? cache.value
+        : next;
+      cache = { state, value };
+      return value;
     };
   }, [controller, select, arg, isEqual]);
 

--- a/apps/desktop/src/renderer/use-app-shell-session-ui-selector.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-ui-selector.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useSyncExternalStore } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
 import type { AppShellSessionUiState, AppShellSessionUiStateController } from './app-shell-session-ui-state.js';
 
 /**
@@ -9,35 +9,36 @@ import type { AppShellSessionUiState, AppShellSessionUiStateController } from '.
  * speed. A component re-renders only when the value IT selects changes, so the
  * chat transcript can follow every delta while the shell around it stays still.
  *
- * `select` may be an inline arrow: it is read through a ref, so `getSnapshot`
- * keeps a stable identity and React never re-subscribes because of it.
+ * `select` must be a stable (module-level) function, and whatever it varies by
+ * — a session id, say — is passed as `arg` rather than captured. That is what
+ * lets the snapshot be memoized instead of published through a render-phase ref
+ * write, which React permits only for lazy initialization: a discarded
+ * concurrent render would otherwise hand its selector to the committed
+ * subscription. Changing `arg` rebuilds the cache, so the first render after
+ * switching sessions already reads the new one.
+ *
+ * `isEqual` is required for any selector that derives a fresh object.
+ * `useSyncExternalStore` demands a snapshot that keeps its identity while
+ * nothing it selects changed; without it such a selector does not merely
+ * over-render, it loops.
  */
-export function useAppShellSessionUiSelector<T>(
+export function useAppShellSessionUiSelector<T, A = undefined>(
   controller: AppShellSessionUiStateController,
-  select: (state: AppShellSessionUiState) => T,
+  select: (state: AppShellSessionUiState, arg: A) => T,
+  arg?: A,
   isEqual?: (a: T, b: T) => boolean,
 ): T {
-  const selectRef = useRef(select);
-  selectRef.current = select;
-  const isEqualRef = useRef(isEqual);
-  isEqualRef.current = isEqual;
-  const cacheRef = useRef<{ value: T } | null>(null);
-
-  // `useSyncExternalStore` requires a snapshot that keeps its identity while
-  // nothing it selects changed, or it loops. A selector that derives a fresh
-  // object therefore has to say what "unchanged" means for that object.
-  const getSnapshot = useCallback(() => {
-    const next = selectRef.current(controller.getState());
-    const cached = cacheRef.current;
-    if (cached && isSameSnapshot(cached.value, next, isEqualRef.current)) return cached.value;
-    cacheRef.current = { value: next };
-    return next;
-  }, [controller]);
+  const getSnapshot = useMemo(() => {
+    let cache: { value: T } | null = null;
+    return (): T => {
+      const next = select(controller.getState(), arg as A);
+      if (cache && (Object.is(cache.value, next) || isEqual?.(cache.value, next) === true)) {
+        return cache.value;
+      }
+      cache = { value: next };
+      return next;
+    };
+  }, [controller, select, arg, isEqual]);
 
   return useSyncExternalStore(controller.subscribe, getSnapshot, getSnapshot);
-}
-
-function isSameSnapshot<T>(previous: T, next: T, isEqual: ((a: T, b: T) => boolean) | undefined): boolean {
-  if (Object.is(previous, next)) return true;
-  return isEqual ? isEqual(previous, next) : false;
 }

--- a/apps/desktop/src/renderer/use-app-shell-session-ui-selector.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-ui-selector.ts
@@ -1,0 +1,43 @@
+import { useCallback, useRef, useSyncExternalStore } from 'react';
+import type { AppShellSessionUiState, AppShellSessionUiStateController } from './app-shell-session-ui-state.js';
+
+/**
+ * Subscribe to one derived reading of session UI state (#1985).
+ *
+ * The controller is a single external store whose maps change at very different
+ * rates — `liveTurnBySession` moves once per streamed token, the rest at human
+ * speed. A component re-renders only when the value IT selects changes, so the
+ * chat transcript can follow every delta while the shell around it stays still.
+ *
+ * `select` may be an inline arrow: it is read through a ref, so `getSnapshot`
+ * keeps a stable identity and React never re-subscribes because of it.
+ */
+export function useAppShellSessionUiSelector<T>(
+  controller: AppShellSessionUiStateController,
+  select: (state: AppShellSessionUiState) => T,
+  isEqual?: (a: T, b: T) => boolean,
+): T {
+  const selectRef = useRef(select);
+  selectRef.current = select;
+  const isEqualRef = useRef(isEqual);
+  isEqualRef.current = isEqual;
+  const cacheRef = useRef<{ value: T } | null>(null);
+
+  // `useSyncExternalStore` requires a snapshot that keeps its identity while
+  // nothing it selects changed, or it loops. A selector that derives a fresh
+  // object therefore has to say what "unchanged" means for that object.
+  const getSnapshot = useCallback(() => {
+    const next = selectRef.current(controller.getState());
+    const cached = cacheRef.current;
+    if (cached && isSameSnapshot(cached.value, next, isEqualRef.current)) return cached.value;
+    cacheRef.current = { value: next };
+    return next;
+  }, [controller]);
+
+  return useSyncExternalStore(controller.subscribe, getSnapshot, getSnapshot);
+}
+
+function isSameSnapshot<T>(previous: T, next: T, isEqual: ((a: T, b: T) => boolean) | undefined): boolean {
+  if (Object.is(previous, next)) return true;
+  return isEqual ? isEqual(previous, next) : false;
+}

--- a/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
@@ -67,7 +67,7 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
     setMessageLoadPending,
     messageRetryPendingRef,
     stopPendingRef,
-    sessionUiState: sessionUi.state,
+    sessionUiController: sessionUi.controller,
     liveTurnBySessionRef: sessionUi.liveTurnBySessionRef,
     sessionEventHealthBySessionRef: sessionUi.sessionEventHealthBySessionRef,
     setMessageLoadErrorBySession: sessionUi.setMessageLoadErrorBySession,

--- a/apps/desktop/src/renderer/use-shell-live-turn.ts
+++ b/apps/desktop/src/renderer/use-shell-live-turn.ts
@@ -1,88 +1,55 @@
-import { useMemo } from 'react';
-import type { SessionSummary, ShellRunUpdate } from '@maka/core';
-import type { LiveTurnProjection, ToolActivityItem } from '@maka/ui';
-import type { ShellRunUpdatesBySession } from './shell-run-update-state';
-import { hasInFlightToolActivity } from './session-event-health';
+import type { SessionSummary } from '@maka/core';
+import type { LiveTurnSnapshot } from './live-turn-snapshot';
 import { MODEL_CONTINUING_DELAY_MS, MODEL_PROCESSING_DELAY_MS, deriveModelWait, deriveTurnActive, type ModelWaitKind } from './model-wait-state';
 import { useDelayedFlag } from './use-delayed-flag';
 
 /**
- * Owns everything the chat surface derives from the live-turn projection of the
- * active session: the streaming/thinking text slices, the per-session streaming
- * pulse set, the in-flight tool signal, and the two #646 turn-wait indicators.
+ * Owns everything the SHELL derives from the active session's live turn: the
+ * streaming/settled flags, the in-flight tool signal, and the two #646
+ * turn-wait cues.
  *
- * Pure move out of AppShell — `activeLiveTurn` itself stays in AppShell (a
- * source-slice contract pins its declaration there) and is passed in, while the
- * memos keep their exact dependency arrays so `activeShellRunUpdates`,
- * `streamingSessionIds`, `liveTools`, and `hasInFlightLiveTools` retain their
- * referential-stability behavior. The rising-edge delays (`useDelayedFlag`)
- * suppress a flash on fast turns / quick step hops exactly as before.
+ * #1985: this takes the low-entropy `LiveTurnSnapshot`, never the projection.
+ * The streamed buffers themselves belong to the chat surface, which subscribes
+ * to them directly — so a text delta changes nothing here and the shell, the
+ * sidebar, and the composer all stay put while an answer streams.
  */
 export function useShellLiveTurn(options: {
-  activeId: string | undefined;
+  liveTurn: LiveTurnSnapshot;
   /** Carries `runningTurnIds` — the authority on turns this renderer did not send. */
   activeSession: SessionSummary | undefined;
-  activeLiveTurn: LiveTurnProjection | undefined;
-  liveTurnBySession: Record<string, LiveTurnProjection>;
-  shellRunUpdatesBySession: ShellRunUpdatesBySession;
 }): {
-  activeShellRunUpdates: ShellRunUpdate[];
-  activeStreaming: string;
-  activeStreamingComplete: boolean;
   activeStreamingLive: boolean;
   activeStreamingMessageId: string | undefined;
-  activeThinking: string;
-  streamingSessionIds: Set<string>;
-  liveTools: ToolActivityItem[];
   hasInFlightLiveTools: boolean;
+  hasLiveTurnContent: boolean;
   turnActive: boolean;
   showProcessingIndicator: boolean;
   showContinuingIndicator: boolean;
 } {
-  const { activeId, activeSession, activeLiveTurn, liveTurnBySession, shellRunUpdatesBySession } = options;
-  const activeShellRunUpdates = useMemo(
-    () => activeId ? Object.values(shellRunUpdatesBySession[activeId] ?? {}) : [],
-    [activeId, shellRunUpdatesBySession],
-  );
-  const activeTextStep = [...(activeLiveTurn?.steps ?? [])].reverse().find((step) => step.text);
-  const activeThinkingStep = [...(activeLiveTurn?.steps ?? [])].reverse().find((step) => step.thinking);
-  const activeStreaming = activeTextStep?.text?.text ?? '';
-  const activeStreamingComplete = activeTextStep?.text?.complete === true;
-  const activeStreamingLive = activeStreaming.length > 0 && !activeStreamingComplete;
-  const activeStreamingMessageId = activeStreamingComplete ? activeTextStep?.stepId : undefined;
-  const activeThinking = activeThinkingStep?.thinking?.text ?? '';
-  // Set of session ids with a live streaming delta — drives the sidebar
-  // pulse indicator. Recomputed on every live projection change; cheap
-  // since the underlying map only has at most a handful of entries.
-  const streamingSessionIds = useMemo(
-    () => new Set(Object.entries(liveTurnBySession).flatMap(([id, projection]) => (
-      projection.steps.some((step) => step.text?.text && !step.text.complete) ? [id] : []
-    ))),
-    [liveTurnBySession],
-  );
-  const liveTools = useMemo(() => activeLiveTurn?.steps.flatMap((step) => step.tools) ?? [], [activeLiveTurn]);
-  const hasInFlightLiveTools = useMemo(() => hasInFlightToolActivity(liveTools), [liveTools]);
+  const { liveTurn, activeSession } = options;
+  // `streamingMessageId` is present only once the last text step completed, so
+  // its absence is exactly what "still streaming" means.
+  const activeStreamingLive = liveTurn.hasStreamingText && liveTurn.streamingMessageId === undefined;
 
   // #646: the turn's phase drives both the Stop affordance and the two wait
-  // cues. `turnPhase` is armed at send with no lag and promoted to 'streamed'
-  // on the first content event, which is what separates the
-  // connect-to-first-token wait from the later step-to-step lulls; the
-  // rising-edge delays (useDelayedFlag) suppress a flash on fast turns.
+  // cues. `phase` is armed at send with no lag and promoted to 'streamed' on
+  // the first content event, which is what separates the connect-to-first-token
+  // wait from the later step-to-step lulls; the rising-edge delays
+  // (useDelayedFlag) suppress a flash on fast turns.
   //
   // Stop / composer lock: see `deriveTurnActive` for why its two witnesses are
   // ORed and never ANDed. Retiring a stale arm is `settledSessionTransientIds`'
   // job, which covers backgrounded sessions too.
-  const activeTurnPhase = activeLiveTurn?.terminal ? undefined : activeLiveTurn?.phase;
   const turnActive = deriveTurnActive({
-    turnPhase: activeTurnPhase,
-    armedTurnId: activeLiveTurn?.turnId,
+    turnPhase: liveTurn.phase,
+    armedTurnId: liveTurn.turnId,
     runningTurnIds: activeSession?.runningTurnIds,
   });
   const modelWaitKind: ModelWaitKind = deriveModelWait({
-    turnPhase: activeTurnPhase,
-    streamingText: activeStreaming,
-    thinkingText: activeThinking,
-    hasInFlightTools: hasInFlightLiveTools,
+    turnPhase: liveTurn.phase,
+    hasStreamingText: liveTurn.hasStreamingText,
+    hasThinkingText: liveTurn.hasThinkingText,
+    hasInFlightTools: liveTurn.hasInFlightTools,
   });
   // The prominent "正在处理…" first-token indicator (turn head only).
   const showProcessingIndicator = useDelayedFlag(
@@ -96,15 +63,10 @@ export function useShellLiveTurn(options: {
   );
 
   return {
-    activeShellRunUpdates,
-    activeStreaming,
-    activeStreamingComplete,
     activeStreamingLive,
-    activeStreamingMessageId,
-    activeThinking,
-    streamingSessionIds,
-    liveTools,
-    hasInFlightLiveTools,
+    activeStreamingMessageId: liveTurn.streamingMessageId,
+    hasInFlightLiveTools: liveTurn.hasInFlightTools,
+    hasLiveTurnContent: liveTurn.hasStreamingText || liveTurn.hasThinkingText || liveTurn.hasLiveTools,
     turnActive,
     showProcessingIndicator,
     showContinuingIndicator,

--- a/apps/desktop/src/renderer/use-shell-live-turn.ts
+++ b/apps/desktop/src/renderer/use-shell-live-turn.ts
@@ -1,7 +1,7 @@
 import type { SessionSummary } from '@maka/core';
-import type { LiveTurnSnapshot } from './live-turn-snapshot';
-import { MODEL_CONTINUING_DELAY_MS, MODEL_PROCESSING_DELAY_MS, deriveModelWait, deriveTurnActive, type ModelWaitKind } from './model-wait-state';
-import { useDelayedFlag } from './use-delayed-flag';
+import type { LiveTurnSnapshot } from './live-turn-snapshot.js';
+import { MODEL_CONTINUING_DELAY_MS, MODEL_PROCESSING_DELAY_MS, deriveModelWait, deriveTurnActive, type ModelWaitKind } from './model-wait-state.js';
+import { useDelayedFlag } from './use-delayed-flag.js';
 
 /**
  * Owns everything the SHELL derives from the active session's live turn: the


### PR DESCRIPTION
## Summary

`AppShellContent` destructured the whole session UI store, so every write to any slice re-rendered the entire shell — including one write per streamed token. The session list, the composer, and any open non-chat surface all re-rendered at token rate, though none of them read `liveTurnBySession`.

The controller was already an external store; it only lacked per-subscriber notification. This adds `subscribe` and a selector hook, then moves each read to the boundary that owns it:

- **`useAppShellSessionUiReads`** is the shell's complete read, in one named place: six low-frequency maps by raw reference, plus a `LiveTurnSnapshot` and the sidebar's pulse set by value. A delta changes none of them.
- **`ChatMessageSurface`** subscribes to the projection and the shell-run record itself. It is their only renderer, so they never reach the shell.
- **`<LiveTurnReconciler/>`** carries the per-delta reconcile that used to sit in AppShell's effect list. It follows every delta and owns no subtree.

Two findings shaped this beyond the issue's original framing:

**`subscribe` + selector alone saves nothing.** The component holding the selector *is* `AppShellContent`. Selecting the full projection there re-renders the whole subtree exactly as before. What makes it work is that the shell's reads turn out to be low-entropy already — even `homeSurfaceActive` only wanted three `.length === 0` booleans. Only `ChatMessageSurface`'s two props genuinely need token-rate data, so only that read had to sink.

**The chat surface needs no `memo`.** The sidebar and composer stop re-rendering because their parent does, not because a comparison blocks them. That is why this avoids stabilizing ~25 props per panel.

`useShellLiveTurn` now takes the snapshot rather than the projection, and `deriveModelWait` takes booleans — it only ever asked whether the buffers were empty.

Rebased onto #1987. `LiveTurnSnapshot` carries `turnId` so `deriveTurnActive` keeps both its witnesses; the snapshot's `phase` is already absent once terminal, which is the other one. `streamingTextComplete` was dropped from the snapshot in the same pass — `streamingMessageId` is set only when the text step closed, so its presence already carried that fact.

Closes #1985

## Verification

- `npm --workspace apps/desktop run test:dist` — 1384 pass, 0 fail (includes #1987's `deriveTurnActive` matrix).
- `npm --workspace apps/desktop run typecheck` — clean (preload, main, renderer, storybook).
- `npm run format:check` / `npm run lint` — clean.
- `npm --workspace apps/desktop run e2e` — 60 passed, 1 failed: `plan-reminders.spec.ts:75 › closes a reminder menu before opening its edit dialog` (an autofocus assertion in the reminder form). **Pre-existing**: it fails identically on unmodified `origin/main` at `1530ac4d5`, verified by checking that commit out in the same worktree and running the same spec. Not addressed here.

Contract coverage in `ui-render-memo-boundary-contract.test.ts`, on the existing `createRoot` + `act` + fake-DOM harness — no new test framework:

- a text delta re-renders a subscriber that selects the full projection, and leaves a subscriber selecting the semantic snapshot untouched;
- **driving `useAppShellSessionUiReads` itself**, no delta after the first re-renders the shell;
- switching `activeId` under a still store reads the new session on the first render.

Plus two snapshot facts in `app-shell-session-ui-state.test.ts`: a settled turn drops its phase but keeps its id, and the handoff message id stays absent while the text step is open.

Verified by mutation, not just by passing. Adding a `state.liveTurnBySession` selection to the **production** hook turns the render-count test red. Dropping the value-equality step does not merely over-render — `useSyncExternalStore` rejects the fresh snapshot outright with *"The result of getSnapshot should be cached"* and loops.

Not run: no screenshot or Storybook evidence — this PR removes renders and changes no pixels.

## Review focus

`useSyncExternalStore` requires a snapshot that keeps its identity while nothing it selects changed, so a selector deriving a fresh object must supply an equality. Three places depend on that discipline:

- `getSnapshot` must never build a `Set`/array/object without a matching comparator. `ChatMessageSurface` selects the raw per-session shell-run record and does `Object.values` in a `useMemo` for this reason.
- Selectors are module-level and take what they vary by as `arg`, so the snapshot is memoized rather than published through a render-phase ref write — React permits that write only for lazy initialization, and a discarded concurrent render would otherwise hand its selector to the committed subscription.
- `LiveTurnSnapshot` must stay free of buffers. Anything added to it whose identity changes per delta silently puts the whole shell back on the token path; the render-count contract is the guard.

Notification is synchronous, immediately after the state swap. A scheduler there (rAF or otherwise) would delay the terminal-turn handoff, which reads the state it announces.

`activeSessionId` is passed to `ChatMessageSurface` explicitly rather than derived from `activeSession.id`. They are equal today, but only because the shell substitutes a placeholder carrying the same id for an unsaved chat.

## Known gap

`ChatMessageSurface`'s own subscription is not pinned by a unit contract — removing it would leave these tests green and be caught only by the E2E streaming journey. Doing better means rendering the real surface with its full `ChatView` dependency tree, which the fake DOM does not currently support. Tracked as a follow-up rather than fixed here.

`useAppShellSessionUiState` still re-exports the controller's eleven setters alongside the controller itself. Collapsing that mirror touches every setter call site across the session-event and effect wiring, so it is deliberately out of scope.
