### PR TITLE
fix: clear the CI reds on main (Mermaid E2E sampling, plan-reminder autofocus, harbor-cell deadline race)

### DIFF
--- a/apps/desktop/e2e/send-message.spec.ts
+++ b/apps/desktop/e2e/send-message.spec.ts
@@ -83,22 +83,33 @@ test('renders a settled Mermaid fence as a diagram', async ({ window: page }) =>
   await expect(diagram.locator('.maka-mermaid-source')).toContainText('flowchart TB');
   await viewSource.click();
 
-  const toolbar = diagram.locator('.maka-mermaid-toolbar');
-  const toolbarBeforeZoom = await toolbar.boundingBox();
-  const diagramBeforeZoom = await diagram.boundingBox();
-  const viewportHeightBeforeZoom = await viewport.evaluate((element) => element.getBoundingClientRect().height);
+  // Zoom moves the diagram's content, never its chrome. Read the toolbar
+  // offset and the viewport height inside one evaluate: the transcript is a
+  // bottom-pinned scroller that re-pins on every ResizeObserver update, so two
+  // separate boundingBox() round-trips sample the same element at two scroll
+  // positions and turn that drift into a phantom offset change (#2000).
+  const readChrome = () => diagram.evaluate((element) => {
+    const diagramTop = element.getBoundingClientRect().top;
+    const toolbarTop = element.querySelector('.maka-mermaid-toolbar')?.getBoundingClientRect().top;
+    const viewportHeight = element.querySelector('.maka-mermaid-viewport')?.getBoundingClientRect().height;
+    return { toolbarOffset: (toolbarTop ?? 0) - diagramTop, viewportHeight: viewportHeight ?? 0 };
+  });
+  const chromeBeforeZoom = await readChrome();
   const zoomIn = diagram.getByRole('button', { name: '放大图表' });
   await zoomIn.click();
   await expect(diagram).toHaveAttribute('data-maka-mermaid-zoom', '1.25');
   await zoomIn.click();
   await expect(diagram).toHaveAttribute('data-maka-mermaid-zoom', '1.50');
-  const toolbarAfterZoom = await toolbar.boundingBox();
-  const diagramAfterZoom = await diagram.boundingBox();
-  const viewportHeightAfterZoom = await viewport.evaluate((element) => element.getBoundingClientRect().height);
-  const toolbarOffsetBeforeZoom = (toolbarBeforeZoom?.y ?? 0) - (diagramBeforeZoom?.y ?? 0);
-  const toolbarOffsetAfterZoom = (toolbarAfterZoom?.y ?? 0) - (diagramAfterZoom?.y ?? 0);
-  expect(Math.abs(toolbarOffsetAfterZoom - toolbarOffsetBeforeZoom)).toBeLessThanOrEqual(1);
-  expect(Math.abs(viewportHeightAfterZoom - viewportHeightBeforeZoom)).toBeLessThanOrEqual(1);
+  // Poll for the steady state: the zoomed layout settles over a rAF, a
+  // ResizeObserver pass, and the scroller's re-pin, so a single instantaneous
+  // read asserts a frame the user never sees.
+  await expect.poll(async () => {
+    const chrome = await readChrome();
+    return Math.max(
+      Math.abs(chrome.toolbarOffset - chromeBeforeZoom.toolbarOffset),
+      Math.abs(chrome.viewportHeight - chromeBeforeZoom.viewportHeight),
+    );
+  }).toBeLessThanOrEqual(1);
   await expect.poll(() => viewport.evaluate((element) =>
     element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight)).toBe(true);
   const zoomedBounds = await diagram.evaluate((element) => {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1216,9 +1216,19 @@ describe('runHarborCell', () => {
       const fallback = new Promise<IsolatedCommandResult>((resolve) => {
         releaseFallback = () => resolve({ exitCode: 0, stdout: '', stderr: '' });
       });
-      const fallbackTimer = setTimeout(releaseFallback, 5_000);
+      // The deadline is a wall-clock timer started when the cell is set up, so
+      // it races the cell's own storage/session/first-send cost before the turn
+      // ever reaches the tool. Lose that race and the run is still cancelled by
+      // `benchmark.deadline` while the backend is never stopped — the empty
+      // `stopModes` seen in CI. Budget the setup generously and name the race,
+      // so a future loss reports itself instead of a bare deepEqual mismatch.
+      const settleAfterMs = 3_000;
+      const startedAt = Date.now();
+      let toolActiveAfterMs: number | undefined;
+      const fallbackTimer = setTimeout(releaseFallback, settleAfterMs + 5_000);
       const executor: IsolatedToolExecutor = {
         exec: async (_input, control) => {
+          toolActiveAfterMs ??= Date.now() - startedAt;
           const signal = control?.abortSignal;
           if (!signal) return await fallback;
           return await new Promise<IsolatedCommandResult>((_resolve, reject) => {
@@ -1233,7 +1243,7 @@ describe('runHarborCell', () => {
           cwd: workspaceDir,
           outputDir,
           storageRoot,
-          settleAfterMs: 1_000,
+          settleAfterMs,
           realBackendIsolation: {
             kind: 'external',
             label: 'cancellable test executor',
@@ -1247,11 +1257,17 @@ describe('runHarborCell', () => {
             });
           },
         }),
-        3_000,
+        settleAfterMs + 10_000,
         'Harbor cell did not cancel its active isolated tool',
       );
       clearTimeout(fallbackTimer);
 
+      assert.ok(
+        toolActiveAfterMs !== undefined && toolActiveAfterMs < settleAfterMs,
+        toolActiveAfterMs === undefined
+          ? `the isolated tool must be active when the deadline fires, but it never started within the ${settleAfterMs}ms budget`
+          : `the isolated tool must be active when the deadline fires, but it started ${toolActiveAfterMs}ms in, past the ${settleAfterMs}ms budget`,
+      );
       assert.equal(result.settledByDeadline, true);
       assert.deepEqual(backend?.stopModes, ['immediate']);
       assert.equal(result.output.tokenSummary?.total, 18);

--- a/packages/ui/src/plan-reminder-form-dialog.tsx
+++ b/packages/ui/src/plan-reminder-form-dialog.tsx
@@ -252,7 +252,12 @@ export function PlanReminderFormDialog(props: {
               id="maka-plan-title"
               className="maka-plan-title-input"
               value={title}
-              autoFocus
+              // Not React's `autoFocus`: it runs during commit, before the
+              // dialog's showModal() makes the field visible, so the focus
+              // silently fails. Astryx's Dialog focuses `[data-autofocus]`
+              // after opening — the same seam TextInput's `hasAutoFocus`
+              // emits, which this bare input replaced.
+              data-autofocus
               onChange={(event) => {
                 setTitleTouched(true);
                 setTitle(event.target.value.slice(0, 120));


### PR DESCRIPTION
## Summary

Three independent failures were keeping `main`'s CI red. Each is fixed at its cause, not by widening a tolerance or adding a retry.

**1. Mermaid toolbar offset E2E (`e2e_shard 2/2`) — the assertion measured the wrong thing.** Failing on six consecutive runs across unrelated branches plus two on `main`, reading 2px or 3px against a `<= 1` bound. The offset it measures cannot move: `Toolbar` is the first flex child of `figure.maka-mermaid-diagram`, and the figure carries a 1px border, so `toolbar.top - figure.top` is structurally that border regardless of zoom. The change came from the sampling — the offset was derived from two independent `boundingBox()` round-trips, and the transcript is a bottom-pinned scroller that re-pins on every ResizeObserver update (`use-chat-scroll.ts`). Zooming widens the canvas, the viewport gains a scrollbar, `mermaid-diagram.tsx` recomputes `viewportHeight` on the next frame, the figure changes height, and the scroller re-pins — landing between the two samples and turning scroll drift into a phantom offset. Both the toolbar offset and the viewport height are now read inside one `evaluate`, and the comparison polls for the steady state instead of the frame right after the click. The 1px tolerance is unchanged.

**2. Plan-reminder edit dialog (`e2e_shard 1/2`) — a real product regression.** #2002 rebuilt the dialog's title row as a bare `<input autoFocus>` inside a `Field`, replacing a `TextInput` with `hasAutoFocus`. Astryx's `Dialog` picks its initial focus target by querying `[data-autofocus]` after `showModal()`, and its own source documents why React's `autoFocus` cannot work there: it calls `.focus()` during commit, while the dialog is still invisible, so the focus silently fails. `TextInput` emits `data-autofocus`; the bare input did not, so opening 编辑提醒 left the caret on the close button instead of the title field. Moved onto the same seam. The E2E was reporting a genuine bug.

**3. Harbor-cell force-stop test (`test_headless`) — a race, not a flake.** The test asserts the deadline stops an *active* isolated tool, but established that precondition by giving the cell 1000ms of wall clock to finish setup, create the session, and drive the first send before the timer fired. Lose that race and the run is still cancelled by `benchmark.deadline` — `settledByDeadline` stays true — while the backend is never stopped, so `stopModes` is empty. Setup costs ~100ms locally; on a loaded runner it can exceed the budget. The setup budget is now 3000ms and the precondition is asserted directly, so losing the race reports "the isolated tool never started within the budget" instead of a bare deepEqual mismatch.

Closes #2000

## Root cause evidence

- **#1** is a structural argument: `toolbar.top - figure.top` is a constant by construction, which makes any non-zero delta a sampling artifact. Not reproduced live — see Verification.
- **#2** is confirmed by Astryx `Dialog.tsx:443-452`, which both implements the `[data-autofocus]` seam and documents the React `autoFocus` failure mode, plus the `git show` of #2002 replacing `hasAutoFocus` with `autoFocus`.
- **#3** is reproduced: forcing the ordering with a 1ms deadline yields the exact CI signature, `actual: []` vs `expected: [ 'immediate' ]`. Restoring the ordering makes it pass.

## Verification

- Full CI green on this branch (run 30811370682): both E2E shards, `test_headless`, `test_workspaces`, `typecheck`, `alignment_audit`.
- Full headless suite locally: 1305 tests, 0 fail.
- The new headless guard was exercised in both directions — passes normally, and fails with its intended message when the race is forced.
- `@maka/ui` typecheck and Biome clean on the touched files.
- E2E could not be run locally: this environment has no window server, so Electron launches but `firstWindow()` times out. CI is the verification for #1 and #2.