### PR TITLE
fix(storage): converge concurrent fresh WAL initialization

### DIFF
--- a/packages/storage/src/__tests__/fixtures/sqlite-recovery-concurrency-child.ts
+++ b/packages/storage/src/__tests__/fixtures/sqlite-recovery-concurrency-child.ts
@@ -1,4 +1,5 @@
 import { existsSync, writeSync } from 'node:fs';
+import { dirname } from 'node:path';
 import {
   createRuntimeBoundaryCursor,
   runtimePrefixSegment,
@@ -7,6 +8,7 @@ import {
   type WorkspaceBaselineAuthorityInput,
 } from '@maka/core';
 import { createSqliteRuntimeStore } from '../../sqlite-runtime-store.js';
+import { acquireOperationalStateDatabase } from '../../operational-state-store.js';
 import { commitWorkspaceBaselineInternal } from '../../workspace-version-authority-internal.js';
 
 const mode = requiredEnv('MAKA_SQLITE_RECOVERY_CONCURRENCY_MODE');
@@ -20,28 +22,33 @@ while (!existsSync(startPath)) {
 }
 
 let store: ReturnType<typeof createSqliteRuntimeStore> | undefined;
+let operationalLease: ReturnType<typeof acquireOperationalStateDatabase> | undefined;
 try {
-  store = createSqliteRuntimeStore(dbPath);
+  if (mode === 'operational_open_only') {
+    operationalLease = acquireOperationalStateDatabase(dirname(dbPath));
+  } else {
+    store = createSqliteRuntimeStore(dbPath);
+  }
   writeSync(1, 'OPENED\n');
-  if (mode === 'open_only') {
+  if (mode === 'open_only' || mode === 'operational_open_only') {
     if (!stopPath) throw new Error('Missing MAKA_SQLITE_RECOVERY_CONCURRENCY_STOP');
     while (!existsSync(stopPath)) {
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
     }
   } else if (mode === 'completed') {
-    await store.commitToolRecoveryBundle(completedBundle());
+    await store!.commitToolRecoveryBundle(completedBundle());
   } else if (mode === 'parked') {
-    await store.commitToolRecoveryBundle(parkedBundle());
+    await store!.commitToolRecoveryBundle(parkedBundle());
   } else if (mode === 'rebuild') {
-    await store.rebuildToolProjectionsFromRuntimeEvents();
+    await store!.rebuildToolProjectionsFromRuntimeEvents();
   } else if (mode === 'workspace_baseline_a' || mode === 'workspace_baseline_b') {
     const result = await commitWorkspaceBaselineInternal(
-      store,
+      store!,
       workspaceBaselineInput(mode === 'workspace_baseline_b' ? 'b' : 'a'),
     );
     writeSync(1, `BASELINE ${result.created ? 'created' : 'existing'}\n`);
   } else if (mode === 'append_source') {
-    await store.ensureTerminalRuntimeEventDurable('session-1', 'run-1', {
+    await store!.ensureTerminalRuntimeEventDurable('session-1', 'run-1', {
       ...baseEvent('concurrent-source-terminal', 3),
       status: 'failed',
       actions: {
@@ -51,7 +58,7 @@ try {
     });
     writeSync(1, 'APPEND committed\n');
   } else if (mode === 'append_target') {
-    await store.appendRuntimeEvent('session-1', 'fixed-target-run', {
+    await store!.appendRuntimeEvent('session-1', 'fixed-target-run', {
       id: `target-event-${process.pid}`,
       sessionId: 'session-1',
       invocationId: 'fixed-target-invocation',
@@ -66,7 +73,7 @@ try {
     writeSync(1, 'TARGET_APPEND committed\n');
   } else if (mode === 'claim' || mode === 'claim_fixed_target' || mode === 'claim_nonterminal') {
     const sourceRunId = mode === 'claim_nonterminal' ? 'run-1' : 'continuation-source-run';
-    const prefix = await store.readImmutableRuntimePrefix({
+    const prefix = await store!.readImmutableRuntimePrefix({
       sessionId: 'session-1',
       runId: sourceRunId,
       ...(mode === 'claim_nonterminal' ? { upToEventSeq: 2 } : {}),
@@ -87,7 +94,7 @@ try {
             runId: `run-${process.pid}`,
             turnId: `turn-${process.pid}`,
           };
-    const result = await store.claimContinuation({
+    const result = await store!.claimContinuation({
       claim: {
         protocol: 'continuation_claim_v1',
         claimId: `claim-${process.pid}`,
@@ -137,6 +144,7 @@ try {
   process.exitCode = 2;
 } finally {
   store?.close();
+  operationalLease?.close();
 }
 
 function completedBundle() {

--- a/packages/storage/src/__tests__/sqlite-recovery-concurrency.test.ts
+++ b/packages/storage/src/__tests__/sqlite-recovery-concurrency.test.ts
@@ -162,6 +162,40 @@ describe('SQLite recovery authority multi-process races', () => {
     });
   });
 
+  it('allows concurrent operational owners to initialize the same fresh WAL database', async () => {
+    for (let round = 0; round < 12; round += 1) {
+      const root = await mkdtemp(join(tmpdir(), 'maka-operational-fresh-open-race-'));
+      const dbPath = join(root, 'runtime.sqlite');
+      const startPath = join(root, 'start');
+      try {
+        const results = await runOpenWorkers(dbPath, startPath, 'operational_open_only');
+        assert.deepEqual(
+          results.map(({ code }) => code),
+          [0, 0],
+          `fresh concurrent operational open failed in round ${round + 1}: ${JSON.stringify(results)}`,
+        );
+
+        const database = new DatabaseSync(dbPath, { readOnly: true });
+        try {
+          assert.equal(
+            (database.prepare('PRAGMA journal_mode').get() as { journal_mode: string })
+              .journal_mode,
+            'wal',
+          );
+          assert.equal(
+            (database.prepare('PRAGMA user_version').get() as { user_version: number })
+              .user_version,
+            SQLITE_RUNTIME_SCHEMA_VERSION,
+          );
+        } finally {
+          database.close();
+        }
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
   it('makes an exact concurrent workspace baseline open idempotent', async () => {
     await withPreparedDatabase(async ({ dbPath, startPath }) => {
       const results = await runWorkers(dbPath, startPath, [
@@ -323,10 +357,14 @@ async function runWorkers(
   }
 }
 
-async function runOpenWorkers(dbPath: string, startPath: string): Promise<WorkerResult[]> {
+async function runOpenWorkers(
+  dbPath: string,
+  startPath: string,
+  mode = 'open_only',
+): Promise<WorkerResult[]> {
   const stopPath = `${startPath}.stop`;
-  const workers = ['open_only', 'open_only'].map((mode) =>
-    startWorker(dbPath, startPath, mode, stopPath),
+  const workers = [mode, mode].map((workerMode) =>
+    startWorker(dbPath, startPath, workerMode, stopPath),
   );
   try {
     await withTimeout(

--- a/packages/storage/src/sqlite-runtime-schema.ts
+++ b/packages/storage/src/sqlite-runtime-schema.ts
@@ -7,6 +7,9 @@ export const RUNTIME_CONTINUATION_AUTHORITY_CAPABILITY = 'runtime_continuation_a
 export const RUNTIME_CONTINUATION_AUTHORITY_CAPABILITY_VERSION = 1;
 export const RUNTIME_WORKSPACE_VERSION_AUTHORITY_CAPABILITY = 'runtime_workspace_version_authority';
 export const RUNTIME_WORKSPACE_VERSION_AUTHORITY_CAPABILITY_VERSION = 1;
+const SQLITE_INITIALIZATION_BUSY_TIMEOUT_MS = 5_000;
+const SQLITE_INITIALIZATION_RETRY_DELAY_MS = 10;
+const initializationRetryGate = new Int32Array(new SharedArrayBuffer(4));
 
 const MIGRATIONS: ReadonlyMap<number, string> = new Map([
   [
@@ -247,11 +250,8 @@ export function configureSqliteRuntimeDatabase(db: DatabaseSync): void {
   // Bound lock acquisition before touching persistent journal state. WAL mode is
   // database-persistent, so established workspaces only need to verify it rather
   // than making every concurrent opener execute the setting form of the pragma.
-  db.exec('PRAGMA busy_timeout = 5000');
-  const journalMode = readJournalMode(db);
-  if (journalMode !== 'wal') {
-    db.exec('PRAGMA journal_mode = WAL');
-  }
+  db.exec(`PRAGMA busy_timeout = ${SQLITE_INITIALIZATION_BUSY_TIMEOUT_MS}`);
+  ensureWalJournalMode(db);
   db.exec('PRAGMA synchronous = FULL');
   db.exec('PRAGMA foreign_keys = ON');
 }
@@ -305,6 +305,45 @@ function readJournalMode(db: DatabaseSync): string {
     throw new Error('Invalid SQLite runtime journal mode');
   }
   return row.journal_mode.toLowerCase();
+}
+
+function ensureWalJournalMode(db: DatabaseSync): void {
+  const deadline = Date.now() + SQLITE_INITIALIZATION_BUSY_TIMEOUT_MS;
+  while (true) {
+    try {
+      const journalMode = readJournalMode(db);
+      if (journalMode === 'wal' || journalMode === 'memory') return;
+      db.exec('PRAGMA journal_mode = WAL');
+      const configuredMode = readJournalMode(db);
+      if (configuredMode !== 'wal') {
+        throw new Error(`SQLite runtime requires WAL journal mode, received ${configuredMode}`);
+      }
+      return;
+    } catch (error) {
+      if (!isSqliteBusy(error) || Date.now() >= deadline) throw error;
+      Atomics.wait(
+        initializationRetryGate,
+        0,
+        0,
+        Math.min(SQLITE_INITIALIZATION_RETRY_DELAY_MS, Math.max(1, deadline - Date.now())),
+      );
+    }
+  }
+}
+
+function isSqliteBusy(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const sqliteError = error as Error & {
+    code?: unknown;
+    errcode?: unknown;
+    errstr?: unknown;
+  };
+  return (
+    sqliteError.errcode === 5 ||
+    sqliteError.code === 'SQLITE_BUSY' ||
+    sqliteError.errstr === 'database is locked' ||
+    /database (?:is )?(?:locked|busy)/i.test(sqliteError.message)
+  );
 }
 
 function rollback(db: DatabaseSync): void {


### PR DESCRIPTION
## Summary

- make fresh operational-state SQLite initialization converge when multiple processes race to enable WAL
- retry only transient `SQLITE_BUSY` / locked failures within the existing 5-second initialization bound
- add a production-shaped, 12-round, two-process regression through `acquireOperationalStateDatabase()`

## Invariant and boundary

- **Owner:** the operational-state SQLite initializer
- **Atomicity boundary:** SQLite's persistent journal-mode transition; each process re-observes the mode before attempting the transition
- **Failure state:** transient lock contention is retried; an unsupported mode or contention beyond 5 seconds still fails closed
- **Rollback:** revert this commit; there is no schema, protocol, or persisted-data migration

## Compatibility

- rebuilt from current `upstream/main` (`72027d2bb` at implementation time)
- the same patch was applied to PR #1872's head, preserving its schema-8 storage-root binding; the production-shaped fresh-open test passed there as well

## Verification

- RED before the production change: the first fresh-open round failed with `database is locked`
- focused schema / operational-owner / recovery concurrency suite: 21 passed
- fresh operational-owner race: 12/12 rounds passed on current main
- fresh operational-owner race: 12/12 rounds passed with #1872
- `@maka/storage` build and formatting checks passed

The full storage suite was also attempted on local Windows. Unrelated tests hit the repository's existing parallel temp-cleanup `EBUSY` failures while deleting open `runtime.sqlite[-shm]` files; the focused tests above completed cleanly.

Fixes #1544

<details>
<summary>中文说明</summary>

## 变更摘要

- 修复多个进程同时首次打开同一个 operational-state 空数据库时，竞争设置 WAL 导致 `database is locked` 的问题
- 只对 `SQLITE_BUSY` / locked 做有界重试，沿用 5 秒初始化上限
- 新增真实生产入口测试：两个独立进程经 `acquireOperationalStateDatabase()` 同时起跑，共重复 12 轮

## 不变量与边界

- **Owner：** operational-state SQLite initializer
- **原子性边界：** SQLite 持久化的 journal-mode 转换；每个进程在尝试转换前重新读取当前模式
- **失败状态：** 短暂锁竞争会重试；超过 5 秒或得到不支持的模式时仍然 fail-closed
- **回滚方式：** 直接回滚本提交；本 PR 不修改 schema、runtime protocol 或持久化数据格式

## 兼容性验证

- 从最新 `upstream/main` 平铺实现
- 同一补丁临时叠加到 #1872 head，保留其 schema 8 storage-root binding 后，构建和 12 轮双进程 fresh-open 测试同样通过

## 测试

- 修改生产代码前，新增测试第一轮即复现 `database is locked`
- schema / operational owner / recovery concurrency 定向套件：21 项通过
- 最新 main：12/12 轮 fresh-open 通过
- #1872 组合分支：12/12 轮 fresh-open 通过
- storage build 与格式检查通过

本机 Windows 也尝试了完整 storage suite；若干无关测试在并行删除仍被占用的 `runtime.sqlite[-shm]` 临时文件时触发既有 `EBUSY`，不属于本次 WAL 初始化回归。上述定向测试均已通过。

</details>