### PR TITLE
redesign(ui): plan-reminder list rows meet the Astryx premium checklist

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -403,7 +403,7 @@ export const test = base.extend<{
     await withE2eWindow(
       {
         seed: false,
-        readinessSelector: '.maka-plan-card',
+        readinessSelector: '.maka-plan-list-row',
         e2eFixtureScenario: 'plan-reminders',
         locale: 'zh',
       },

--- a/apps/desktop/e2e/plan-reminders.spec.ts
+++ b/apps/desktop/e2e/plan-reminders.spec.ts
@@ -68,7 +68,9 @@ test('keeps Plan row actions keyboard ordered and destructive confirmation rever
   await expect(clearDialog.getByRole('button', { name: '取消' })).toBeFocused();
   await page.keyboard.press('Enter');
   await expect(clearDialog).toBeHidden();
-  await expect(reviewRow).toContainText('已生成本周竞品动态摘要');
+  // Premium-row redesign: run MESSAGES live in the 执行记录 tab; the task row
+  // keeps its schedule line. Cancelling the clear must leave the row intact.
+  await expect(reviewRow).toContainText('每周竞品动态追踪');
   await expect(reviewMenu).toBeFocused();
 });
 

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -21,10 +21,9 @@
   width: min(100%, 900px);
   margin-inline: auto;
   display: grid;
-  /* Atlas §14.6 quick-win: section gap tightens 14 -> 8 (reference uses
-     `--agents-content-area-gap: 4px`; 8 keeps long-page readability while
-     pulling toward the dense reference cadence). */
-  gap: var(--space-2);
+  /* Premium checklist rule 10: two-tier rhythm — 24px between page tiers
+     (hero / tabs / panel), small steps only inside a unit. */
+  gap: var(--space-6);
   padding: 0;
 }
 
@@ -40,7 +39,6 @@
   gap: var(--space-1);
   max-width: 560px;
 }
-
 
 .maka-plan-heading h2 {
   font: var(--maka-text-display-2);
@@ -82,57 +80,96 @@
   row-gap: var(--space-2-5);
 }
 
-.maka-plan-toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: end;
-  justify-content: flex-end;
-  gap: var(--space-2);
-}
-
-.maka-plan-toolbar-compact {
-  display: flex;
-}
-
 .maka-plan-tab-panel {
   display: grid;
-  gap: var(--space-2-5);
+  gap: var(--space-3);
 }
 
+/* Premium checklist rules 6/11: edge-to-edge rows, zero gap, hairline
+   dividers owned by the list. */
 .maka-plan-list {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
+}
+
+.maka-plan-list > * + * {
+  border-block-start: var(--border-width-hairline) solid var(--border);
+}
+
+.maka-plan-list-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: 52px;
+  padding: var(--space-2) 0;
+}
+
+.maka-plan-list-row[data-status="completed"] {
+  opacity: var(--opacity-muted);
+}
+
+/* Completed rows drop their dead switch; hold its track so titles align. */
+.maka-plan-list-row-switch-ghost {
+  flex: 0 0 40px;
+}
+
+.maka-plan-list-row-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: grid;
+  gap: var(--space-0-5);
+}
+
+.maka-plan-list-row-title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.maka-plan-list-row-title h3 {
+  font: var(--maka-text-body);
+  font-weight: 600;
+  margin: 0;
+  min-width: 0;
+  color: var(--foreground);
+  overflow-wrap: anywhere;
+}
+
+.maka-plan-list-row-meta {
+  font: var(--maka-text-supporting);
+  margin: 0;
+  color: var(--foreground-secondary);
+  overflow-wrap: anywhere;
+}
+
+/* StatusDot + text — the shared quiet status idiom (settings surface). */
+.maka-plan-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  font: var(--maka-text-supporting);
+  color: var(--foreground-secondary);
+  white-space: nowrap;
+}
+
+.maka-plan-list-row-countdown {
+  font: var(--maka-text-supporting);
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .maka-plan-form,
 .maka-plan-run-row {
   display: grid;
   gap: var(--space-2-5);
-  border: var(--border-width-hairline) solid var(--border);
-  border-radius: var(--radius-control);
   background: var(--background);
+}
+
+.maka-plan-form {
   padding: var(--space-4);
-}
-
-.maka-plan-card {
-  display: grid;
-  /* Switch (32px) + row menu (28px) + gap (4px). Keep the track stable
-     when a completed reminder intentionally omits its dead switch. */
-  grid-template-columns: minmax(0, 1.35fr) minmax(240px, 1fr) 64px;
-  align-items: center;
-  gap: var(--space-4);
-  position: relative;
-  border-bottom: var(--border-width-hairline) solid var(--border);
-  background: var(--background);
-  padding: var(--space-3) 0;
-}
-
-.maka-plan-card:first-child {
-  border-top: var(--border-width-hairline) solid var(--border);
-}
-
-.maka-plan-card[data-status="completed"] {
-  opacity: var(--opacity-muted);
 }
 
 .maka-plan-form-header,
@@ -141,26 +178,6 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-2-5);
-}
-
-.maka-plan-card-title-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  min-width: 0;
-}
-
-.maka-plan-card-context {
-  display: grid;
-  gap: var(--space-1-5);
-  min-width: 0;
-}
-
-.maka-plan-card-controls {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--space-1);
 }
 
 .maka-plan-form {
@@ -282,7 +299,6 @@
   color: var(--foreground-secondary);
 }
 
-
 .maka-plan-rows > * + * {
   border-block-start: var(--border-width-hairline) solid var(--border);
 }
@@ -322,27 +338,6 @@
   color: var(--foreground-secondary);
 }
 
-.maka-plan-search,
-.maka-plan-compact-select {
-  font: var(--maka-text-heading-5);
-  display: grid;
-  gap: var(--space-1);
-  color: var(--foreground-secondary);
-}
-
-.maka-plan-search {
-  width: min(200px, 28vw);
-}
-
-.maka-plan-compact-select {
-  width: 124px;
-  gap: 0;
-}
-
-.maka-plan-sort-select {
-  width: 168px;
-}
-
 .maka-plan-search-summary {
   font: var(--maka-text-heading-5);
   font-variant-numeric: tabular-nums;
@@ -354,116 +349,22 @@
   color: var(--muted-foreground);
 }
 
-.maka-plan-empty {
-  position: static;
-  width: auto;
-  transform: none;
-  padding: var(--space-4) var(--space-2-5);
-}
-
-.maka-plan-card-main {
-  display: grid;
-  gap: var(--space-1-5);
-  min-width: 0;
-}
-
-.maka-plan-card-title {
-  font: var(--maka-text-heading-3);
-  margin: 0;
-  min-width: 0;
-  color: var(--foreground);
-  overflow-wrap: anywhere;
-}
-
-/* #1879 measured this row and deliberately leaves its height unpinned, which
-   is the opposite of what that issue assumed (it read the row as already
-   pinned and offered it as the shape the other chips should take; it declares
-   no height at all — the 20px it measures at comes from the Badge beside the
-   message). It must stay unpinned: the message wraps by design
-   (`overflow-wrap: anywhere` below), and measured, replacing it with a long
-   string grows this row well past its one-line 20px. A pinned height would
-   clip all of that to one line. Multi-line capability is what disqualifies a
-   row from the single-line chip family — same call as
-   `.maka-plan-card-schedule` and `.settingsMemoryBackupCandidate`. */
-.maka-plan-card-run {
-  font: var(--maka-text-supporting);
-  display: flex;
-  min-width: 0;
-  gap: var(--space-1);
-  align-items: flex-start;
-  color: var(--foreground-secondary);
-}
-
-.maka-plan-card-run > :first-child {
-  flex: 0 0 auto;
-}
-
-.maka-plan-card-run > span {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-/* #1879: unpinned on purpose. `flex-wrap: wrap` is not decorative here —
-   measured, this row wraps to a second row at the 480px window floor. (The
-   pixel height is not recorded: a wrap threshold is a font metric, and CI
-   Linux reported a different one than macOS did, which is exactly why the e2e
-   for this asserts the relation and not a figure.) It is a wrapping meta row,
-   not a single-line chip; its height tracking its content is correct
-   behaviour, so there is nothing here for a box-height pin to fix. The chip
-   inside it (`.maka-plan-card-countdown`) is an Astryx Badge instead. */
-.maka-plan-card-schedule {
-  font: var(--maka-text-supporting);
-  display: flex;
-  min-width: 0;
-  flex-wrap: wrap;
-  align-items: baseline;
-  column-gap: var(--space-1);
-  row-gap: var(--space-0-5);
-  color: var(--foreground-secondary);
-}
-
-.maka-plan-card-schedule > span {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-.maka-plan-card-schedule-separator {
-  color: var(--foreground-tertiary);
-}
-
-/* PR-PLAN-NEXT-RUN-COUNTDOWN-0: small pill next to the absolute next-run
-   time so user sees both wall-clock and distance-from-now in one glance.
-   #651 exception-only status color: a scheduled countdown is the expected
-   steady state, so the pill is neutral (foreground wash) rather than
-   accent-tinted — colour is reserved for genuinely exceptional states
-   (e.g. an overdue run), which would opt in via a data-attribute. */
-/* #1879: it had pill chrome and no height, so its own leading at 40px doubled
-   the box to 40px, measured. It is an Astryx `Badge` now — neutral is the
-   variant that keeps the exception-only rule above — so the box (20px off
-   `--spacing-5`), radius, padding, caption type and `nowrap` all come from the
-   component. Only the gap to the preceding text is product layout. */
-.maka-plan-card-countdown {
-  margin-left: var(--space-1);
-}
-
-.maka-plan-card-note {
-  font: var(--maka-text-body);
-  color: var(--foreground-secondary);
-  margin: 0;
-  padding: 0;
-  overflow-wrap: anywhere;
-}
-
 .maka-plan-run-list {
   display: grid;
   gap: var(--space-1);
 }
 
+/* Runs are the same edge-to-edge row idiom as the task list. */
 .maka-plan-run-row {
   grid-template-columns: max-content minmax(0, 1fr) max-content;
   align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-1-5) var(--space-2-5);
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+}
+
+.maka-plan-run-row time {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .maka-plan-run-main {
@@ -492,12 +393,6 @@
   white-space: nowrap;
 }
 
-.maka-plan-runs-empty {
-  border-style: dashed;
-  background: transparent;
-  box-shadow: none;
-}
-
 @media (max-width: 1100px) {
   .maka-plan-hero,
   .maka-plan-tabs-bar {
@@ -513,20 +408,6 @@
     gap: var(--space-2);
   }
 
-  .maka-plan-card-controls {
-    justify-content: flex-end;
-  }
-
-  .maka-plan-toolbar,
-  .maka-plan-toolbar-compact {
-    justify-content: flex-start;
-  }
-
-  .maka-plan-search,
-  .maka-plan-compact-select,
-  .maka-plan-sort-select {
-    width: min(100%, 260px);
-  }
 
   .maka-plan-run-row {
     grid-template-columns: minmax(0, 1fr);

--- a/packages/ui/src/__tests__/plan-reminder-panel.test.tsx
+++ b/packages/ui/src/__tests__/plan-reminder-panel.test.tsx
@@ -56,7 +56,7 @@ describe('Plan Reminder scanning hierarchy', () => {
     assert.match(markup, /重复：每周/);
     assert.match(markup, /下次触发：/);
     const schedule = markup.match(
-      /<div class="maka-plan-card-schedule">([\s\S]*?)<\/div>/,
+      /<p class="maka-plan-list-row-meta">([\s\S]*?)<\/p>/,
     )?.[1];
     assert.ok(schedule);
     assert.doesNotMatch(schedule, /<svg|lucide-repeat|lucide-clock/);
@@ -142,7 +142,10 @@ describe('Plan Reminder scanning hierarchy', () => {
 
     assert.equal(markup.match(/>已完成</g)?.length, 1);
     assert.equal(markup.match(/>失败</g)?.length, 1);
-    assert.match(markup, /投递目标不可用。/);
+    // Premium-checklist redesign: the task row carries only the exceptional
+    // state (StatusDot + text, once). The run MESSAGE lives in the 执行记录
+    // tab — it must not repeat inside every task row.
+    assert.doesNotMatch(markup, /投递目标不可用。/);
     assert.doesNotMatch(markup, /maka-capability-audit-strip/);
   });
 });

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -21,7 +21,6 @@ import {
   comparePlanReminderBySort,
   createPlanReminderFormSeed,
   formatPlanRecurrence,
-  formatPlanReminderDeliveryTargetLabel,
   formatReminderCountdown,
   formatReminderTime,
   normalizePlanReminderSearchQuery,
@@ -34,13 +33,14 @@ import {
 } from './plan-reminder-helpers.js';
 import { PlanReminderFormDialog } from './plan-reminder-form-dialog.js';
 import {
-  Badge,
   Button as UiButton,
   EmptyState,
   Selector,
+  StatusDot,
   Switch,
   Tab,
   TabList,
+  Toolbar,
 } from '@astryxdesign/core';
 import {
   DropdownMenu,
@@ -48,7 +48,6 @@ import {
   DropdownMenuItem,
 } from '@astryxdesign/core/DropdownMenu';
 import { Divider } from '@astryxdesign/core/Divider';
-import type { BadgeProps } from '@astryxdesign/core/Badge';
 import { PageHeader } from './primitives/page-header.js';
 import { TextInput } from '@astryxdesign/core';
 import type { ModuleHubHeader } from './module-hub-selector.js';
@@ -59,16 +58,16 @@ import type {
 import { getPlanReminderCopy } from './plan-reminder-copy.js';
 import { useUiLocale } from './locale-context.js';
 
-// Run-history status Badge tone. triggered = it fired (info, informational,
-// not a health signal), blocked = intentionally skipped (warning), failed =
-// delivery error (destructive). Exception-only: no success green for a plain
-// "it ran" record.
-function planRunStatusBadgeVariant(
+// Run-history status tone. triggered = it fired (informational accent, not a
+// health signal), blocked = intentionally skipped (warning), failed =
+// delivery error. Exception-only: no success green for a plain "it ran"
+// record — and rows only surface the exceptional states at all.
+function planRunStatusDotVariant(
   status: NonNullable<PlanReminder['lastRun']>['status'],
-): BadgeProps['variant'] {
+): 'accent' | 'warning' | 'error' {
   if (status === 'blocked') return 'warning';
   if (status === 'failed') return 'error';
-  return 'info';
+  return 'accent';
 }
 
 export function PlanReminderPanel(props: {
@@ -343,33 +342,39 @@ export function PlanReminderPanel(props: {
             </TabList>
             {planView === 'tasks' ? (
               showListControls ? (
-                <div className="maka-plan-toolbar" aria-label={copy.page.filtersAriaLabel}>
-                  <div className="maka-plan-compact-select maka-plan-sort-select">
-                    <Selector
-                      value={listSort}
-                      onChange={(value) => setListSort(value as typeof listSort)}
-                      label={copy.page.sort}
-                      width="100%"
-                      options={copy.page.sortOptions.map(([value, label]) => ({ value, label }))}
-                    />
-                  </div>
-                  <div className="maka-plan-search">
-                    <TextInput
-                      label={copy.page.searchLabel}
-                      isLabelHidden
-                      width="100%"
-                      value={listQuery}
-                      onChange={(value) => setListQuery(value.slice(0, 120))}
-                      placeholder={copy.page.searchPlaceholder}
-                    />
-                  </div>
-                  <div className="maka-plan-compact-select">
-                    <Selector
-                      value={listFilter}
-                      onChange={(value) => setListFilter(value as PlanReminderListFilter)}
-                      label={copy.page.state}
-                      width="100%"
-                      options={[
+                <Toolbar
+                  size="sm"
+                  label={copy.page.filtersAriaLabel}
+                  className="maka-plan-toolbar"
+                  startContent={(
+                    <>
+                      <TextInput
+                        label={copy.page.searchLabel}
+                        isLabelHidden
+                        width={260}
+                        value={listQuery}
+                        onChange={(value) => setListQuery(value.slice(0, 120))}
+                        placeholder={copy.page.searchPlaceholder}
+                      />
+                    </>
+                  )}
+                  endContent={(
+                    <>
+                      <Selector
+                        value={listSort}
+                        onChange={(value) => setListSort(value as typeof listSort)}
+                        label={copy.page.sort}
+                        isLabelHidden
+                        width={172}
+                        options={copy.page.sortOptions.map(([value, label]) => ({ value, label }))}
+                      />
+                      <Selector
+                        value={listFilter}
+                        onChange={(value) => setListFilter(value as PlanReminderListFilter)}
+                        label={copy.page.state}
+                        isLabelHidden
+                        width={148}
+                        options={[
                         { value: 'active', label: copy.page.filterOption(copy.page.active, filterCounts.active) },
                         { value: 'all', label: copy.page.filterOption(copy.page.all, filterCounts.all) },
                         {
@@ -381,23 +386,28 @@ export function PlanReminderPanel(props: {
                           value: 'completed',
                           label: copy.page.filterOption(copy.status.completed, filterCounts.completed),
                         },
-                      ]}
-                    />
-                  </div>
-                </div>
+                        ]}
+                      />
+                    </>
+                  )}
+                />
               ) : null
             ) : (
-              <div className="maka-plan-toolbar maka-plan-toolbar-compact" aria-label={copy.page.runsFilterAriaLabel}>
-                <div className="maka-plan-compact-select">
+              <Toolbar
+                size="sm"
+                label={copy.page.runsFilterAriaLabel}
+                className="maka-plan-toolbar"
+                endContent={(
                   <Selector
                     value={runRange}
                     onChange={(value) => setRunRange(value as typeof runRange)}
                     label={copy.page.range}
-                    width="100%"
+                    isLabelHidden
+                    width={148}
                     options={copy.page.rangeOptions.map(([value, label]) => ({ value, label }))}
                   />
-                </div>
-              </div>
+                )}
+              />
             )}
           </div>
 
@@ -414,7 +424,7 @@ export function PlanReminderPanel(props: {
                 icon={<Clock />}
                 title={copy.page.emptyTitle}
                 description={copy.page.emptyBody}
-                className="maka-plan-empty"
+                actions={<UiButton variant="primary" onClick={openCreateReminderDialog} label={copy.page.create} />}
               />
             ) : sortedReminders.length === 0 ? (
               <EmptyState
@@ -422,7 +432,6 @@ export function PlanReminderPanel(props: {
                 title={normalizedListQuery ? copy.page.noSearchTitle : copy.page.noFilterTitle}
                 description={normalizedListQuery ? copy.page.noSearchBody : copy.page.noFilterBody}
                 actions={<UiButton variant="ghost" label={copy.page.clearSearch} onClick={() => setListQuery('')} isDisabled={!normalizedListQuery} />}
-                className="maka-plan-empty"
               />
             ) : (
               <div className="maka-plan-list" aria-label={copy.page.listAriaLabel}>
@@ -430,64 +439,69 @@ export function PlanReminderPanel(props: {
                   const reminderActionPrefix = `${reminder.id}:`;
                   const reminderActionPending = Array.from(pendingActionKeys).some((key) => key.startsWith(reminderActionPrefix));
                   return (
+                    /* Premium-checklist row (rules 6/11/16): a two-line
+                       edge-to-edge row — leading switch, title + exception-only
+                       status dots, one supporting schedule line, a live
+                       relative Timestamp trailing. The per-row Badges
+                       (countdown pill, run status) and the note preview are
+                       gone: durations are supporting text, run details live in
+                       the 执行记录 tab. */
                     <article
                       key={reminder.id}
-                      className="maka-plan-card"
+                      className="maka-plan-list-row"
                       data-status={reminder.status}
                     >
-                      <div className="maka-plan-card-main">
-                        <div className="maka-plan-card-title-row">
-                          <h3 className="maka-plan-card-title">{reminder.title}</h3>
+                      {reminder.status !== 'completed' ? (
+                        <Switch
+                          value={reminder.enabled}
+                          isDisabled={reminderActionPending}
+                          label={`${reminder.enabled ? copy.page.pause : copy.page.enable}: ${reminder.title}`}
+                          isLabelHidden
+                          onChange={() => void runPlanReminderAction(`${reminder.id}:toggle`, () => props.onToggle?.(reminder.id, !reminder.enabled))}
+                        />
+                      ) : (
+                        <span className="maka-plan-list-row-switch-ghost" aria-hidden="true" />
+                      )}
+                      <div className="maka-plan-list-row-main">
+                        <div className="maka-plan-list-row-title">
+                          <h3>{reminder.title}</h3>
                           {reminder.status !== 'scheduled' && (
-                            <Badge
-                              variant={reminder.status === 'paused' ? 'warning' : 'neutral'}
-                              label={planReminderStatusLabel(reminder.status, locale)}
-                            />
+                            <span className="maka-plan-status">
+                              <StatusDot
+                                variant={reminder.status === 'paused' ? 'warning' : 'neutral'}
+                                label={planReminderStatusLabel(reminder.status, locale)}
+                              />
+                              <span>{planReminderStatusLabel(reminder.status, locale)}</span>
+                            </span>
+                          )}
+                          {reminder.lastRun && reminder.lastRun.status !== 'triggered' && (
+                            <span className="maka-plan-status">
+                              <StatusDot
+                                variant={planRunStatusDotVariant(reminder.lastRun.status)}
+                                label={runStatusLabel(reminder.lastRun.status, locale)}
+                              />
+                              <span>{runStatusLabel(reminder.lastRun.status, locale)}</span>
+                            </span>
                           )}
                         </div>
-                        <p className="maka-plan-card-note">
-                          {reminder.note || copy.delivery.fallback(formatPlanReminderDeliveryTargetLabel(reminder.delivery, locale))}
+                        <p className="maka-plan-list-row-meta">
+                          {formatPlanRecurrence(reminder, locale)}
+                          <span aria-hidden="true"> · </span>
+                          {reminder.nextRunAt
+                            ? copy.page.nextRun(formatReminderTime(reminder.nextRunAt, locale))
+                            : reminder.lastRun
+                              ? copy.page.recentRun(formatReminderTime(reminder.lastRun.at, locale))
+                              : copy.page.unscheduled}
                         </p>
                       </div>
-                      <div className="maka-plan-card-context">
-                        <div className="maka-plan-card-schedule">
-                          <span>{formatPlanRecurrence(reminder, locale)}</span>
-                          <span className="maka-plan-card-schedule-separator" aria-hidden="true">
-                            ·
-                          </span>
-                          <span>
-                            {reminder.nextRunAt ? (
-                              <>
-                                {copy.page.nextRun(formatReminderTime(reminder.nextRunAt, locale))}
-                                <Badge className="maka-plan-card-countdown" label={formatReminderCountdown(reminder.nextRunAt, locale)} />
-                              </>
-                            ) : reminder.lastRun ? (
-                              copy.page.recentRun(formatReminderTime(reminder.lastRun.at, locale))
-                            ) : (
-                              copy.page.unscheduled
-                            )}
-                          </span>
-                        </div>
-                        {reminder.lastRun && (
-                          <div className="maka-plan-card-run">
-                            <Badge
-                              variant={planRunStatusBadgeVariant(reminder.lastRun.status)}
-                              label={runStatusLabel(reminder.lastRun.status, locale)}
-                            />
-                            <span>{reminder.lastRun.message}</span>
-                          </div>
-                        )}
-                      </div>
-                      <div className="maka-plan-card-controls">
-                        {reminder.status !== 'completed' && (
-                          <Switch
-                            value={reminder.enabled}
-                            isDisabled={reminderActionPending}
-                            label={`${reminder.enabled ? copy.page.pause : copy.page.enable}: ${reminder.title}`}
-                            isLabelHidden
-                            onChange={() => void runPlanReminderAction(`${reminder.id}:toggle`, () => props.onToggle?.(reminder.id, !reminder.enabled))}
-                          />
-                        )}
+                      {typeof reminder.nextRunAt === 'number' && (
+                        /* Duration as quiet supporting text (checklist rule 16)
+                           — the locale-aware formatter, not Astryx Timestamp,
+                           which renders Intl relative time in English only. */
+                        <span className="maka-plan-list-row-countdown">
+                          {formatReminderCountdown(reminder.nextRunAt, locale)}
+                        </span>
+                      )}
                         <DropdownMenu
                           isMenuOpen={openReminderMenuId === reminder.id}
                           onOpenChange={(open) =>
@@ -562,7 +576,6 @@ export function PlanReminderPanel(props: {
                               style={{ color: 'var(--destructive-text)' }}
                             />
                         </DropdownMenu>
-                      </div>
                     </article>
                   );
                 })}
@@ -578,18 +591,15 @@ export function PlanReminderPanel(props: {
                 icon={<Clock />}
                 title={copy.page.noRunsTitle}
                 description={copy.page.noRunsBody}
-                className="maka-plan-empty maka-plan-runs-empty"
               />
             ) : (
               <div className="maka-plan-run-list" aria-label={copy.page.runsAriaLabel}>
                 {visibleRunEntries.map(({ reminder, run }) => (
                   <article key={`${reminder.id}:${run.id}`} className="maka-plan-run-row">
-                    <Badge
-                      variant={planRunStatusBadgeVariant(run.status)}
-                      className="maka-plan-run-status"
-                      data-status={run.status}
-                      label={runStatusLabel(run.status, locale)}
-                    />
+                    <span className="maka-plan-status" data-status={run.status}>
+                      <StatusDot variant={planRunStatusDotVariant(run.status)} label={runStatusLabel(run.status, locale)} />
+                      <span>{runStatusLabel(run.status, locale)}</span>
+                    </span>
                     <div className="maka-plan-run-main">
                       <strong>{reminder.title}</strong>
                       <span>{run.message}</span>

--- a/scripts/storybook-visual-smoke.mjs
+++ b/scripts/storybook-visual-smoke.mjs
@@ -407,16 +407,10 @@ async function smokeStory(page, baseUrl, job, options = {}) {
             ) {
               failures.push('completed plan reminder row is missing its lifecycle state');
             }
-            for (const selector of [
-              '.maka-plan-list-row-title',
-              '.maka-plan-list-row-meta',
-            ]) {
+            for (const selector of ['.maka-plan-list-row-title', '.maka-plan-list-row-meta']) {
               checkElement(row.querySelector(selector), selector);
             }
-            for (const selector of [
-              '.maka-plan-status',
-              '.maka-plan-list-row-countdown',
-            ]) {
+            for (const selector of ['.maka-plan-status', '.maka-plan-list-row-countdown']) {
               const element = row.querySelector(selector);
               if (element) checkElement(element, selector);
             }
@@ -424,7 +418,9 @@ async function smokeStory(page, baseUrl, job, options = {}) {
           // The margin loop above runs zero times if countdowns stop rendering,
           // which would make the spacing contract pass by vacancy. Rows with a
           // scheduled next run are exactly the ones that must show one.
-          const scheduledRows = rows.filter((row) => row.getAttribute('data-status') === 'scheduled');
+          const scheduledRows = rows.filter(
+            (row) => row.getAttribute('data-status') === 'scheduled',
+          );
           if (
             scheduledRows.length > 0 &&
             !rows.some((row) => row.querySelector('.maka-plan-list-row-countdown'))
@@ -441,8 +437,9 @@ async function smokeStory(page, baseUrl, job, options = {}) {
               failures.push('plan reminder wide row must lay out as a flex row');
             }
             const countdownRights = rows
-              .map((row) =>
-                row.querySelector('.maka-plan-list-row-countdown')?.getBoundingClientRect().right,
+              .map(
+                (row) =>
+                  row.querySelector('.maka-plan-list-row-countdown')?.getBoundingClientRect().right,
               )
               .filter((right) => typeof right === 'number')
               .map((right) => Math.round(right));

--- a/scripts/storybook-visual-smoke.mjs
+++ b/scripts/storybook-visual-smoke.mjs
@@ -226,7 +226,7 @@ async function smokeStory(page, baseUrl, job, options = {}) {
 
     if (job.checks?.includes('plan-reminder-row')) {
       try {
-        await page.waitForSelector('.maka-plan-card', { state: 'visible', timeout: 5_000 });
+        await page.waitForSelector('.maka-plan-list-row', { state: 'visible', timeout: 5_000 });
       } catch {
         browserFailures.push('plan reminder rows did not finish rendering');
       }
@@ -378,7 +378,7 @@ async function smokeStory(page, baseUrl, job, options = {}) {
           if (document.documentElement.scrollWidth > document.documentElement.clientWidth) {
             failures.push('document has horizontal overflow');
           }
-          const rows = [...document.querySelectorAll('.maka-plan-card')];
+          const rows = [...document.querySelectorAll('.maka-plan-list-row')];
           if (rows.length === 0) failures.push('plan reminder rows are missing');
           const checkElement = (element, label) => {
             const rect = element?.getBoundingClientRect();
@@ -399,65 +399,59 @@ async function smokeStory(page, baseUrl, job, options = {}) {
           for (const row of rows) {
             if (row.scrollWidth > row.clientWidth)
               failures.push('plan reminder row has horizontal overflow');
+            /* Premium-row redesign: completed rows show their lifecycle as a
+               StatusDot cluster; run messages live in the runs tab. */
             if (
               row.getAttribute('data-status') === 'completed' &&
-              !row.querySelector('.maka-plan-card-run')
+              !row.querySelector('.maka-plan-status')
             ) {
-              failures.push('completed plan reminder row is missing its last-run context');
+              failures.push('completed plan reminder row is missing its lifecycle state');
             }
             for (const selector of [
-              '.maka-plan-card-title-row',
-              '.maka-plan-card-schedule',
-              '.maka-plan-card-controls',
+              '.maka-plan-list-row-title',
+              '.maka-plan-list-row-meta',
             ]) {
               checkElement(row.querySelector(selector), selector);
             }
             for (const selector of [
-              '.maka-plan-card-title-row [data-slot="badge"]',
-              '.maka-plan-card-run',
-              '.maka-plan-card-run [data-slot="chip"]',
+              '.maka-plan-status',
+              '.maka-plan-list-row-countdown',
             ]) {
               const element = row.querySelector(selector);
               if (element) checkElement(element, selector);
-            }
-            for (const countdown of row.querySelectorAll('.maka-plan-card-countdown')) {
-              const marginLeft = Number.parseFloat(getComputedStyle(countdown).marginLeft);
-              if (!Number.isFinite(marginLeft) || marginLeft < 4) {
-                failures.push(
-                  `plan reminder countdown must keep at least 4px from its wall-clock time, got ${marginLeft || 0}px`,
-                );
-              }
             }
           }
           // The margin loop above runs zero times if countdowns stop rendering,
           // which would make the spacing contract pass by vacancy. Rows with a
           // scheduled next run are exactly the ones that must show one.
-          const scheduledRows = rows.filter((row) => row.querySelector('.maka-plan-card-schedule'));
+          const scheduledRows = rows.filter((row) => row.getAttribute('data-status') === 'scheduled');
           if (
             scheduledRows.length > 0 &&
-            !rows.some((row) => row.querySelector('.maka-plan-card-countdown'))
+            !rows.some((row) => row.querySelector('.maka-plan-list-row-countdown'))
           ) {
             failures.push(
               'no plan reminder row rendered a countdown, so its spacing went unchecked',
             );
           }
           if (document.documentElement.clientWidth >= 1100 && rows[0]) {
-            const columns = getComputedStyle(rows[0])
-              .gridTemplateColumns.split(' ')
-              .filter(Boolean);
-            if (columns.length !== 3) {
-              failures.push(
-                `plan reminder wide row must have 3 hierarchy columns, got ${columns.length}`,
-              );
+            /* Premium-row contract: a single flex row — leading switch, main
+               column, trailing countdown/menu. Countdown right edges must
+               align across rows so the trailing column reads as a column. */
+            if (getComputedStyle(rows[0]).display !== 'flex') {
+              failures.push('plan reminder wide row must lay out as a flex row');
             }
-            const contextLefts = rows.map((row) =>
-              Math.round(
-                row.querySelector('.maka-plan-card-context')?.getBoundingClientRect().left ?? -1,
-              ),
-            );
-            if (contextLefts.some((left) => Math.abs(left - contextLefts[0]) > 1)) {
+            const countdownRights = rows
+              .map((row) =>
+                row.querySelector('.maka-plan-list-row-countdown')?.getBoundingClientRect().right,
+              )
+              .filter((right) => typeof right === 'number')
+              .map((right) => Math.round(right));
+            if (
+              countdownRights.length > 1 &&
+              countdownRights.some((right) => Math.abs(right - countdownRights[0]) > 1)
+            ) {
               failures.push(
-                `plan reminder wide context columns must align, got ${contextLefts.join(', ')}`,
+                `plan reminder countdowns must right-align, got ${countdownRights.join(', ')}`,
               );
             }
           }


### PR DESCRIPTION
First execution wave of the premium-quality goal. Method: distilled an 18-rule "premium checklist" from Astryx's own CLI page templates + component design docs (`incident-console` is the model template for this surface), then rebuilt the 定时任务 list against it.

## What changed

- **Rows**: the hand-rolled 3-column `.maka-plan-card` grid (~68px tall) → a single flex row: leading switch (ghost slot keeps completed rows aligned), title + exception-only StatusDot clusters, **one** supporting schedule line, right-aligned localized countdown, trailing menu. Edge-to-edge, list-owned hairline dividers.
- **Badge misuse eliminated** (the docs' most explicit DON'T — "repeat the same badge in every row"): the per-row countdown pill and run-status Badge are gone. Durations render as quiet supporting text via the locale-aware formatter (deliberately **not** Astryx `Timestamp`, which outputs Intl relative time in English inside a zh UI); run state appears once as StatusDot + text; run **messages** live in the 执行记录 tab, not in every task row.
- **Rhythm**: flat 8px shell gap → the checklist's two-tier rhythm (24px between page tiers).
- **Toolbar**: filters/sort/search move into an Astryx `Toolbar` (size set once) instead of three pinned-width divs.
- **Empty states**: first-run gains its create CTA (the docs require a next-step action); the dashed runs empty-state decoration is gone.
- Runs-tab rows join the same idiom (StatusDot + text, no card chrome).

## Contracts updated to pin the new design

Two unit tests that asserted the old markup, the e2e fixture readiness selector, and the storybook smoke product checks (flex-row + countdown right-alignment replace the 3-column-grid assertions).

## Verification

build ✅ typecheck ✅ dead-css ✅ a11y/copy/console ✅ unit 9/9 ✅ plan-reminders e2e 2/2 locally ✅ Storybook smoke 74 renders × 3 viewports ✅ — rendered screenshot in the work thread.

Next waves: extensions/skills page (its own checklist deltas: hover-lift shadows, heading-as-caption ×9, hand-rolled list), then the settings polish round (Layout frames, two-column settings grid, ExpandableRow).