### PR TITLE
feat(storage): implement Session Bundle filesystem codec

### DIFF
--- a/packages/storage/src/__tests__/fixtures/session-bundle-hydration-binding-crash.ts
+++ b/packages/storage/src/__tests__/fixtures/session-bundle-hydration-binding-crash.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+
+const [archivePath, archiveDigest, limitsJson, destinationRoot] = process.argv.slice(2);
+if (
+  archivePath === undefined ||
+  archiveDigest === undefined ||
+  limitsJson === undefined ||
+  destinationRoot === undefined
+) {
+  process.exit(2);
+}
+
+const originalOpen = fs.promises.open.bind(fs.promises);
+let targeted = false;
+fs.promises.open = async (...args) => {
+  const handle = await originalOpen(...args);
+  if (targeted || !args[0].toString().endsWith('.owner.json')) return handle;
+  targeted = true;
+  const originalWrite = handle.write.bind(handle);
+  handle.write = (async (
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+    position: number | null,
+  ) => {
+    if (position === null) return originalWrite(buffer, offset, length, position);
+    await originalWrite(buffer, offset, Math.min(length, 1), position);
+    process.stdout.write('binding-partial\n');
+    return new Promise<never>(() => {});
+  }) as typeof handle.write;
+  return handle;
+};
+syncBuiltinESMExports();
+
+const { createSessionBundleFileService } = await import('../../index.js');
+await createSessionBundleFileService().hydrate({
+  source: {
+    path: archivePath,
+    expectedArchiveDigest: archiveDigest as `sha256:${string}`,
+  },
+  limits: JSON.parse(limitsJson),
+  expectedSessionId: 'cloud-session-1',
+  destinationRoot,
+});

--- a/packages/storage/src/__tests__/fixtures/session-bundle-hydration-owner-write-failure.ts
+++ b/packages/storage/src/__tests__/fixtures/session-bundle-hydration-owner-write-failure.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+
+const [archivePath, archiveDigest, limitsJson, destinationRoot] = process.argv.slice(2);
+if (
+  archivePath === undefined ||
+  archiveDigest === undefined ||
+  limitsJson === undefined ||
+  destinationRoot === undefined
+) {
+  process.exit(2);
+}
+
+const originalOpen = fs.promises.open.bind(fs.promises);
+let targeted = false;
+fs.promises.open = async (...args) => {
+  const handle = await originalOpen(...args);
+  if (targeted || !args[0].toString().endsWith('.owner.json')) return handle;
+  targeted = true;
+  const originalWrite = handle.write.bind(handle);
+  let wroteOneByte = false;
+  handle.write = (async (
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+    position: number | null,
+  ) => {
+    if (wroteOneByte) {
+      throw Object.assign(new Error('injected ownership write failure'), {
+        code: 'EIO',
+      });
+    }
+    wroteOneByte = true;
+    return originalWrite(buffer, offset, Math.min(length, 1), position);
+  }) as typeof handle.write;
+  return handle;
+};
+syncBuiltinESMExports();
+
+const { createSessionBundleFileService, SessionBundleFileError } = await import('../../index.js');
+try {
+  await createSessionBundleFileService().hydrate({
+    source: {
+      path: archivePath,
+      expectedArchiveDigest: archiveDigest as `sha256:${string}`,
+    },
+    limits: JSON.parse(limitsJson),
+    expectedSessionId: 'cloud-session-1',
+    destinationRoot,
+  });
+  process.exit(3);
+} catch (error) {
+  process.stdout.write(
+    JSON.stringify({
+      code: error instanceof SessionBundleFileError ? error.code : 'unexpected',
+    }),
+  );
+  process.exit(error instanceof SessionBundleFileError && error.code === 'io_failure' ? 0 : 4);
+}

--- a/packages/storage/src/__tests__/fixtures/session-bundle-inspect-child.ts
+++ b/packages/storage/src/__tests__/fixtures/session-bundle-inspect-child.ts
@@ -1,0 +1,28 @@
+import { createSessionBundleFileService, type SessionBundleLimits } from '../../index.js';
+
+const [archivePath, archiveDigest, limitsJson, destinationRoot] = process.argv.slice(2);
+if (!archivePath || !archiveDigest || !limitsJson) process.exit(2);
+
+const limits = JSON.parse(limitsJson) as SessionBundleLimits;
+const service = createSessionBundleFileService();
+const source = {
+  path: archivePath,
+  expectedArchiveDigest: archiveDigest as `sha256:${string}`,
+};
+const result = destinationRoot
+  ? await service.hydrate({
+      source,
+      limits,
+      expectedSessionId: 'cloud-session-1',
+      destinationRoot,
+    })
+  : await service.inspect({ source, limits });
+process.stdout.write(
+  JSON.stringify({
+    sessionId: result.manifest.envelope.sessionId,
+    archiveDigest: result.archiveDigest,
+    identityHex: Buffer.from(result.stateIdentity.bytes).toString('hex'),
+    verified: result.verified,
+    ...(destinationRoot ? { destinationRoot } : {}),
+  }),
+);

--- a/packages/storage/src/__tests__/fixtures/session-bundle-inspect-source-mutator.ts
+++ b/packages/storage/src/__tests__/fixtures/session-bundle-inspect-source-mutator.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import { resolve } from 'node:path';
+import { syncBuiltinESMExports } from 'node:module';
+
+const [archivePath, limitsJson] = process.argv.slice(2);
+if (archivePath === undefined || limitsJson === undefined) process.exit(2);
+
+const target = resolve(archivePath);
+const originalOpen = fs.promises.open.bind(fs.promises);
+let mutated = false;
+fs.promises.open = async (...args) => {
+  const handle = await originalOpen(...args);
+  if (resolve(args[0].toString()) !== target) return handle;
+  const originalCreateReadStream = handle.createReadStream.bind(handle);
+  handle.createReadStream = (options) => {
+    if (!mutated) {
+      mutated = true;
+      const changed = new Date(Date.now() + 60_000);
+      fs.utimesSync(target, changed, changed);
+    }
+    return originalCreateReadStream(options);
+  };
+  return handle;
+};
+syncBuiltinESMExports();
+
+const { createSessionBundleFileService, SessionBundleFileError } = await import('../../index.js');
+try {
+  await createSessionBundleFileService().inspect({
+    source: { path: target },
+    limits: JSON.parse(limitsJson),
+  });
+  process.exit(3);
+} catch (error) {
+  process.stdout.write(
+    JSON.stringify({
+      code: error instanceof SessionBundleFileError ? error.code : 'unexpected',
+      operation: error instanceof SessionBundleFileError ? error.details?.operation : undefined,
+    }),
+  );
+  process.exit(error instanceof SessionBundleFileError && error.code === 'source_changed' ? 0 : 4);
+}

--- a/packages/storage/src/__tests__/fixtures/session-bundle-pack-destination-replacer.ts
+++ b/packages/storage/src/__tests__/fixtures/session-bundle-pack-destination-replacer.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+
+const [stateRoot, workspaceRoot, destination, resultPath, limitsJson, identityHex] =
+  process.argv.slice(2);
+if (
+  stateRoot === undefined ||
+  workspaceRoot === undefined ||
+  destination === undefined ||
+  resultPath === undefined ||
+  limitsJson === undefined ||
+  identityHex === undefined
+) {
+  process.exit(2);
+}
+
+const originalLink = fs.promises.link.bind(fs.promises);
+fs.promises.link = async (existingPath, newPath) => {
+  await originalLink(existingPath, newPath);
+  await fs.promises.rm(newPath);
+  await fs.promises.writeFile(newPath, 'UNRELATED');
+};
+syncBuiltinESMExports();
+
+const { createSessionBundleFileService, SessionBundleFileError } = await import('../../index.js');
+try {
+  await createSessionBundleFileService().pack({
+    snapshot: {
+      stateRoot,
+      workspaceRoot,
+      stateIdentity: {
+        mediaType: 'application/vnd.maka.session-state-identity+json;version=1',
+        bytes: Buffer.from(identityHex, 'hex'),
+      },
+    },
+    envelope: {
+      sessionId: 'cloud-session-1',
+      lastCommittedActivationId: 'activation-9',
+    },
+    destination,
+    limits: JSON.parse(limitsJson),
+  });
+  process.exit(3);
+} catch (error) {
+  await fs.promises.writeFile(
+    resultPath,
+    JSON.stringify({
+      code: error instanceof SessionBundleFileError ? error.code : 'unexpected',
+      destinationContents: await fs.promises.readFile(destination, 'utf8'),
+    }),
+  );
+  process.exit(error instanceof SessionBundleFileError && error.code === 'source_changed' ? 0 : 4);
+}

--- a/packages/storage/src/__tests__/fixtures/session-bundle-pack-link-replacer.ts
+++ b/packages/storage/src/__tests__/fixtures/session-bundle-pack-link-replacer.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+
+const [stateRoot, workspaceRoot, destination, resultPath, limitsJson, identityHex] =
+  process.argv.slice(2);
+if (
+  stateRoot === undefined ||
+  workspaceRoot === undefined ||
+  destination === undefined ||
+  resultPath === undefined ||
+  limitsJson === undefined ||
+  identityHex === undefined
+) {
+  process.exit(2);
+}
+
+const originalLink = fs.promises.link.bind(fs.promises);
+let capturedPath: string | undefined;
+let temporaryPath: string | undefined;
+fs.promises.link = async (existingPath, newPath) => {
+  temporaryPath = existingPath.toString();
+  capturedPath = `${temporaryPath}.captured`;
+  await fs.promises.rename(temporaryPath, capturedPath);
+  await fs.promises.writeFile(temporaryPath, 'EVIL');
+  await originalLink(existingPath, newPath);
+};
+syncBuiltinESMExports();
+
+const { createSessionBundleFileService, SessionBundleFileError } = await import('../../index.js');
+try {
+  await createSessionBundleFileService().pack({
+    snapshot: {
+      stateRoot,
+      workspaceRoot,
+      stateIdentity: {
+        mediaType: 'application/vnd.maka.session-state-identity+json;version=1',
+        bytes: Buffer.from(identityHex, 'hex'),
+      },
+    },
+    envelope: {
+      sessionId: 'cloud-session-1',
+      lastCommittedActivationId: 'activation-9',
+    },
+    destination,
+    limits: JSON.parse(limitsJson),
+  });
+  process.exit(3);
+} catch (error) {
+  await fs.promises.writeFile(
+    resultPath,
+    JSON.stringify({
+      code: error instanceof SessionBundleFileError ? error.code : 'unexpected',
+      capturedPath,
+      temporaryPath,
+    }),
+  );
+  process.exit(error instanceof SessionBundleFileError && error.code === 'source_changed' ? 0 : 4);
+}

--- a/packages/storage/src/__tests__/fixtures/session-bundle-pack-linked-temp-remover.ts
+++ b/packages/storage/src/__tests__/fixtures/session-bundle-pack-linked-temp-remover.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+
+const [stateRoot, workspaceRoot, destination, resultPath, limitsJson, identityHex] =
+  process.argv.slice(2);
+if (
+  stateRoot === undefined ||
+  workspaceRoot === undefined ||
+  destination === undefined ||
+  resultPath === undefined ||
+  limitsJson === undefined ||
+  identityHex === undefined
+) {
+  process.exit(2);
+}
+
+const originalLink = fs.promises.link.bind(fs.promises);
+let capturedPath: string | undefined;
+fs.promises.link = async (existingPath, newPath) => {
+  await originalLink(existingPath, newPath);
+  const temporaryPath = existingPath.toString();
+  capturedPath = `${temporaryPath}.captured`;
+  await fs.promises.rename(temporaryPath, capturedPath);
+};
+syncBuiltinESMExports();
+
+const { createSessionBundleFileService, SessionBundleFileError } = await import('../../index.js');
+try {
+  await createSessionBundleFileService().pack({
+    snapshot: {
+      stateRoot,
+      workspaceRoot,
+      stateIdentity: {
+        mediaType: 'application/vnd.maka.session-state-identity+json;version=1',
+        bytes: Buffer.from(identityHex, 'hex'),
+      },
+    },
+    envelope: {
+      sessionId: 'cloud-session-1',
+      lastCommittedActivationId: 'activation-9',
+    },
+    destination,
+    limits: JSON.parse(limitsJson),
+  });
+  process.exit(3);
+} catch (error) {
+  await fs.promises.writeFile(
+    resultPath,
+    JSON.stringify({
+      code: error instanceof SessionBundleFileError ? error.code : 'unexpected',
+      capturedPath,
+    }),
+  );
+  process.exit(error instanceof SessionBundleFileError && error.code === 'io_failure' ? 0 : 4);
+}

--- a/packages/storage/src/__tests__/fixtures/session-bundle-pack-temp-replacer.ts
+++ b/packages/storage/src/__tests__/fixtures/session-bundle-pack-temp-replacer.ts
@@ -1,0 +1,25 @@
+import { readdirSync, renameSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const [root, resultPath] = process.argv.slice(2);
+if (root === undefined || resultPath === undefined) process.exit(2);
+
+process.stdout.write('ready\n');
+const deadline = Date.now() + 10_000;
+while (Date.now() < deadline) {
+  const name = readdirSync(root).find((candidate) =>
+    candidate.includes('.maka-session-bundle-pack-'),
+  );
+  if (name === undefined) continue;
+  const temporaryPath = join(root, name);
+  const capturedPath = `${temporaryPath}.captured`;
+  try {
+    renameSync(temporaryPath, capturedPath);
+    writeFileSync(temporaryPath, 'EVIL');
+    writeFileSync(resultPath, JSON.stringify({ capturedPath, temporaryPath }));
+    process.exit(0);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+process.exit(3);

--- a/packages/storage/src/__tests__/root-authority-dependency.test.ts
+++ b/packages/storage/src/__tests__/root-authority-dependency.test.ts
@@ -24,6 +24,7 @@ const allowedSessionBundleCodecLocalModules = new Set([
   'session-bundle-canonical-tree.ts',
   'session-bundle-ustar.ts',
   'session-bundle-file-service.ts',
+  'stable-storage.ts',
 ]);
 const allowedAuthorityExternalImports = new Set([
   'fs-native-extensions',

--- a/packages/storage/src/__tests__/root-authority-dependency.test.ts
+++ b/packages/storage/src/__tests__/root-authority-dependency.test.ts
@@ -15,11 +15,15 @@ const sessionBundleCodecEntrypoints = [
   join(sourceRoot, 'session-bundle-contract.ts'),
   join(sourceRoot, 'session-bundle-manifest.ts'),
   join(sourceRoot, 'session-bundle-canonical-tree.ts'),
+  join(sourceRoot, 'session-bundle-ustar.ts'),
+  join(sourceRoot, 'session-bundle-file-service.ts'),
 ];
 const allowedSessionBundleCodecLocalModules = new Set([
   'session-bundle-contract.ts',
   'session-bundle-manifest.ts',
   'session-bundle-canonical-tree.ts',
+  'session-bundle-ustar.ts',
+  'session-bundle-file-service.ts',
 ]);
 const allowedAuthorityExternalImports = new Set([
   'fs-native-extensions',
@@ -29,7 +33,16 @@ const allowedAuthorityExternalImports = new Set([
   'node:os',
   'node:path',
 ]);
-const allowedSessionBundleCodecExternalImports = new Set(['node:buffer', 'node:crypto']);
+const allowedSessionBundleCodecExternalImports = new Set([
+  'node:buffer',
+  'node:crypto',
+  'node:fs',
+  'node:fs/promises',
+  'node:path',
+  'node:stream',
+  'node:stream/promises',
+  'node:zlib',
+]);
 
 async function dependencyScannerFixture(target: string): Promise<void> {
   await import(`node:url`);

--- a/packages/storage/src/__tests__/root-authority-dependency.test.ts
+++ b/packages/storage/src/__tests__/root-authority-dependency.test.ts
@@ -34,6 +34,7 @@ const allowedAuthorityExternalImports = new Set([
   'node:path',
 ]);
 const allowedSessionBundleCodecExternalImports = new Set([
+  'fs-native-extensions',
   'node:buffer',
   'node:crypto',
   'node:fs',

--- a/packages/storage/src/__tests__/session-bundle-file-service.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-file-service.test.ts
@@ -8,6 +8,7 @@ import {
   mkdtemp,
   readFile,
   readdir,
+  rename,
   rm,
   stat,
   symlink,
@@ -149,7 +150,7 @@ test('an independent process verifies and hydrates the same archive contract', a
   );
 });
 
-test('a process crash before hydration publication leaves only orphan staging', {
+test('a process crash leaves owned staging that can be reclaimed without touching decoys', {
   timeout: 30_000,
 }, async () => {
   const fixture = await createFixture();
@@ -193,9 +194,58 @@ test('a process crash before hydration publication leaves only orphan staging', 
     const stagingMetadata = await lstat(stagingPath);
     assert.equal(stagingMetadata.isDirectory(), true);
     assert.equal(stagingMetadata.isSymbolicLink(), false);
+    const ownershipName = `${stagingName}.owner.json`;
+    assert.equal((await lstat(join(fixture.root, ownershipName))).isFile(), true);
     assert.deepEqual(
-      (await readdir(fixture.root)).filter((name) => name.startsWith(stagingPrefix)),
-      [stagingName],
+      (await readdir(fixture.root)).filter((name) => name.startsWith(stagingPrefix)).sort(),
+      [ownershipName, stagingName].sort(),
+    );
+
+    const unrelatedRoot = await mkdtemp(join(tmpdir(), 'maka-session-bundle-unrelated-'));
+    roots.push(unrelatedRoot);
+    await writeFile(join(unrelatedRoot, 'sentinel'), 'unrelated');
+    const decoyDirectory = join(fixture.root, `${stagingPrefix}unowned-directory`);
+    const decoyOwnership = `${decoyDirectory}.owner.json`;
+    await mkdir(decoyDirectory);
+    await writeFile(decoyOwnership, '{}\n');
+
+    const capturedStagingPath = `${stagingPath}.captured`;
+    await rename(stagingPath, capturedStagingPath);
+    await symlink(unrelatedRoot, stagingPath);
+    assert.deepEqual(
+      await createSessionBundleFileService().cleanupHydrationStaging({ destinationRoot }),
+      {
+        destinationRoot,
+        removedStagingDirectories: 0,
+        removedOwnershipRecords: 0,
+      },
+    );
+    assert.equal((await lstat(stagingPath)).isSymbolicLink(), true);
+    assert.equal((await lstat(join(fixture.root, ownershipName))).isFile(), true);
+    assert.equal(await readFile(join(unrelatedRoot, 'sentinel'), 'utf8'), 'unrelated');
+    await rm(stagingPath);
+    await rename(capturedStagingPath, stagingPath);
+
+    const cleanup = await createSessionBundleFileService().cleanupHydrationStaging({
+      destinationRoot,
+    });
+    assert.deepEqual(cleanup, {
+      destinationRoot,
+      removedStagingDirectories: 1,
+      removedOwnershipRecords: 1,
+    });
+    await assert.rejects(lstat(stagingPath), { code: 'ENOENT' });
+    await assert.rejects(lstat(join(fixture.root, ownershipName)), { code: 'ENOENT' });
+    assert.equal((await lstat(decoyDirectory)).isDirectory(), true);
+    assert.equal(await readFile(decoyOwnership, 'utf8'), '{}\n');
+    assert.equal(await readFile(join(unrelatedRoot, 'sentinel'), 'utf8'), 'unrelated');
+    assert.deepEqual(
+      await createSessionBundleFileService().cleanupHydrationStaging({ destinationRoot }),
+      {
+        destinationRoot,
+        removedStagingDirectories: 0,
+        removedOwnershipRecords: 0,
+      },
     );
   } finally {
     if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
@@ -277,6 +327,87 @@ test('binds pack publication and cleanup to the hashed temporary inode', async (
   await assert.rejects(lstat(destination), { code: 'ENOENT' });
   assert.equal(await readFile(temporaryPath, 'utf8'), 'EVIL');
   assert.equal((await lstat(capturedPath)).isFile(), true);
+});
+
+test('cleans the inode actually linked when the pack pathname is swapped at link time', async () => {
+  const fixture = await createFixture();
+  const destination = join(fixture.root, 'link-window.tar.zst');
+  const resultPath = join(fixture.root, 'link-window-result.json');
+  const childPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'fixtures',
+    'session-bundle-pack-link-replacer.js',
+  );
+  const child = spawn(
+    process.execPath,
+    [
+      childPath,
+      fixture.stateRoot,
+      fixture.workspaceRoot,
+      destination,
+      resultPath,
+      JSON.stringify(limits),
+      identityBytes.toString('hex'),
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] },
+  );
+  const stderr: Buffer[] = [];
+  child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+  const result = await waitForChildClose(
+    child,
+    CHILD_PROCESS_TIMEOUT_MS,
+    'Session Bundle link replacer',
+  );
+  assert.equal(result.code, 0, Buffer.concat(stderr).toString('utf8'));
+  const replacement = JSON.parse(await readFile(resultPath, 'utf8')) as {
+    code: string;
+    capturedPath: string;
+    temporaryPath: string;
+  };
+  assert.equal(replacement.code, 'source_changed');
+  await assert.rejects(lstat(destination), { code: 'ENOENT' });
+  assert.equal(await readFile(replacement.temporaryPath, 'utf8'), 'EVIL');
+  assert.equal((await lstat(replacement.capturedPath)).isFile(), true);
+});
+
+test('reports read-side source changes and filesystem failures at the operation boundary', async () => {
+  const fixture = await createFixture();
+  const archivePath = join(fixture.root, 'read-errors.tar.zst');
+  await packFixture(archivePath, fixture);
+  const childPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'fixtures',
+    'session-bundle-inspect-source-mutator.js',
+  );
+  const child = spawn(process.execPath, [childPath, archivePath, JSON.stringify(limits)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+  const result = await waitForChildClose(
+    child,
+    CHILD_PROCESS_TIMEOUT_MS,
+    'Session Bundle source mutator',
+  );
+  assert.equal(result.code, 0, Buffer.concat(stderr).toString('utf8'));
+  assert.deepEqual(JSON.parse(Buffer.concat(stdout).toString('utf8')), {
+    code: 'source_changed',
+  });
+
+  await assert.rejects(
+    createSessionBundleFileService().inspect({
+      source: { path: join(fixture.root, 'missing.tar.zst') },
+      limits,
+    }),
+    (error) => {
+      assert.ok(error instanceof SessionBundleFileError);
+      assert.equal(error.code, 'io_failure');
+      assert.equal(error.details?.operation, 'inspect');
+      return true;
+    },
+  );
 });
 
 test('rejects corrupted payloads and transport mismatches without publishing hydration', async () => {
@@ -837,8 +968,11 @@ async function waitForDirectoryEntry(
 ): Promise<string> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const entry = (await readdir(root)).find((name) => name.startsWith(prefix));
-    if (entry !== undefined) return entry;
+    for (const entry of await readdir(root)) {
+      if (!entry.startsWith(prefix)) continue;
+      const metadata = await lstat(join(root, entry));
+      if (metadata.isDirectory() && !metadata.isSymbolicLink()) return entry;
+    }
     await new Promise<void>((resolvePoll) => setTimeout(resolvePoll, 1));
   }
   throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);

--- a/packages/storage/src/__tests__/session-bundle-file-service.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-file-service.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import {
   chmod,
+  link as createHardLink,
   lstat,
   mkdir,
   mkdtemp,
@@ -182,6 +183,39 @@ test('concurrent publications never overwrite an existing destination', async ()
     await readFile(join(destinationRoot, 'workspace', 'run.sh'), 'utf8'),
     '#!/bin/sh\necho ok\n',
   );
+});
+
+test('binds pack publication and cleanup to the hashed temporary inode', async () => {
+  const fixture = await createFixture();
+  await writeFile(join(fixture.workspaceRoot, 'large.bin'), randomBytes(8 * 1024 * 1024));
+  const destination = join(fixture.root, 'inode-bound.tar.zst');
+  const replacementResultPath = join(fixture.root, 'replacement-result.json');
+  const replacerPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'fixtures',
+    'session-bundle-pack-temp-replacer.js',
+  );
+  const replacer = spawn(process.execPath, [replacerPath, fixture.root, replacementResultPath], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  await once(replacer.stdout, 'data');
+  const packing = packFixture(destination, fixture, {
+    ...limits,
+    maxCompressedBytes: 16 * 1024 * 1024,
+    maxDecompressedTarBytes: 16 * 1024 * 1024,
+    maxPayloadBytes: 16 * 1024 * 1024,
+    maxFileBytes: 10 * 1024 * 1024,
+  });
+  const [replacerCode] = (await once(replacer, 'exit')) as [number | null];
+  assert.equal(replacerCode, 0);
+  const { capturedPath, temporaryPath } = JSON.parse(
+    await readFile(replacementResultPath, 'utf8'),
+  ) as { capturedPath: string; temporaryPath: string };
+
+  await assertBundleRejects(packing, 'source_changed');
+  await assert.rejects(lstat(destination), { code: 'ENOENT' });
+  assert.equal(await readFile(temporaryPath, 'utf8'), 'EVIL');
+  assert.equal((await lstat(capturedPath)).isFile(), true);
 });
 
 test('rejects corrupted payloads and transport mismatches without publishing hydration', async () => {
@@ -467,6 +501,14 @@ test('rejects source links, identity mismatch, and existing destinations', async
     'unsupported_entry',
   );
   await rm(join(fixture.stateRoot, 'linked.bin'));
+
+  const hardLinkPath = join(fixture.workspaceRoot, 'hard-linked.bin');
+  await createHardLink(join(fixture.stateRoot, 'session.bin'), hardLinkPath);
+  await assertBundleRejects(
+    packFixture(join(fixture.root, 'hard-linked.tar.zst'), fixture),
+    'unsupported_entry',
+  );
+  await rm(hardLinkPath);
 
   if (process.platform === 'linux') {
     const invalidUtf8Path = Buffer.concat([

--- a/packages/storage/src/__tests__/session-bundle-file-service.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-file-service.test.ts
@@ -1,0 +1,559 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { afterEach, test } from 'node:test';
+import { constants as zlibConstants, zstdCompressSync, zstdDecompressSync } from 'node:zlib';
+import {
+  createSessionBundleFileService,
+  decodeSessionBundleUstarHeaderV1,
+  encodeSessionBundleManifestV1,
+  SessionBundleFileError,
+  type SessionBundleArtifact,
+  type SessionBundleLimits,
+} from '../index.js';
+
+const roots: string[] = [];
+const identityBytes = Buffer.from('{"schemaVersion":1,"makaSessionId":"maka-α"}', 'utf8');
+const limits: SessionBundleLimits = {
+  maxCompressedBytes: 4 * 1024 * 1024,
+  maxDecompressedTarBytes: 8 * 1024 * 1024,
+  maxPayloadBytes: 4 * 1024 * 1024,
+  maxFileBytes: 2 * 1024 * 1024,
+  maxEntryCount: 100,
+  maxManifestBytes: 256 * 1024,
+  maxStateIdentityBytes: 64 * 1024,
+  maxPathBytes: 255,
+  maxPathDepth: 16,
+};
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+test('packs deterministically, inspects completely, and atomically hydrates', async () => {
+  const fixture = await createFixture();
+  const service = createSessionBundleFileService();
+  const firstPath = join(fixture.root, 'first.tar.zst');
+  const secondPath = join(fixture.root, 'second.tar.zst');
+
+  const first = await packFixture(firstPath, fixture);
+  const second = await packFixture(secondPath, fixture);
+  const firstBytes = await readFile(firstPath);
+  const secondBytes = await readFile(secondPath);
+  assert.deepEqual(secondBytes, firstBytes);
+  assert.equal(second.archiveDigest, first.archiveDigest);
+  assert.equal(first.compressedBytes, firstBytes.byteLength);
+  assert.equal(first.entryCount, 8);
+  assert.equal(first.payloadBytes, identityBytes.byteLength + 5 + 18 + Buffer.byteLength('好'));
+
+  const tar = zstdDecompressSync(firstBytes);
+  assert.equal(tar.byteLength, first.decompressedTarBytes);
+  assert.equal(
+    tar.subarray(-1024).every((byte) => byte === 0),
+    true,
+  );
+  assert.equal(
+    createHash('sha256').update(tar).digest('hex'),
+    '5aed5bb2802d79826339fcc89f0c0aaf657c36d898452e22ef972fb6d5306148',
+  );
+  assert.equal(
+    first.archiveDigest,
+    'sha256:5d4d93d96a0906827a6296a1bd9f87f7189be829052796cd0a8a4cb35262fb52',
+  );
+
+  const inspected = await service.inspect({
+    source: { path: firstPath, expectedArchiveDigest: first.archiveDigest },
+    limits,
+  });
+  assert.equal(inspected.verified, true);
+  assert.equal(inspected.manifest.envelope.sessionId, 'cloud-session-1');
+  assert.equal(inspected.manifest.envelope.lastCommittedActivationId, 'activation-9');
+  assert.deepEqual(Buffer.from(inspected.stateIdentity.bytes), identityBytes);
+
+  const destinationRoot = join(fixture.root, 'hydrated');
+  const hydrated = await service.hydrate({
+    source: { path: firstPath, expectedArchiveDigest: first.archiveDigest },
+    limits,
+    expectedSessionId: 'cloud-session-1',
+    destinationRoot,
+  });
+  assert.equal(hydrated.destinationRoot, destinationRoot);
+  assert.equal(hydrated.stateRoot, join(destinationRoot, 'state'));
+  assert.equal(hydrated.workspaceRoot, join(destinationRoot, 'workspace'));
+  assert.deepEqual(await readFile(join(destinationRoot, 'state-identity.json')), identityBytes);
+  assert.equal(await readFile(join(destinationRoot, 'state', 'session.bin'), 'utf8'), 'state');
+  assert.equal(
+    await readFile(join(destinationRoot, 'workspace', 'run.sh'), 'utf8'),
+    '#!/bin/sh\necho ok\n',
+  );
+  assert.equal(await readFile(join(destinationRoot, 'workspace', '深', 'x.txt'), 'utf8'), '好');
+  assert.equal((await stat(join(destinationRoot, 'workspace', 'run.sh'))).mode & 0o777, 0o755);
+  assert.equal((await stat(join(destinationRoot, 'state', 'session.bin'))).mode & 0o777, 0o644);
+  await assert.rejects(lstat(join(destinationRoot, 'manifest.json')), { code: 'ENOENT' });
+});
+
+test('an independent process verifies and hydrates the same archive contract', async () => {
+  const fixture = await createFixture();
+  const archivePath = join(fixture.root, 'bundle.tar.zst');
+  const artifact = await packFixture(archivePath, fixture);
+  const childPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'fixtures',
+    'session-bundle-inspect-child.js',
+  );
+  const destinationRoot = join(fixture.root, 'child-hydrated');
+  const child = spawn(
+    process.execPath,
+    [childPath, archivePath, artifact.archiveDigest, JSON.stringify(limits), destinationRoot],
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+  const [code] = (await once(child, 'exit')) as [number | null];
+  assert.equal(code, 0, Buffer.concat(stderr).toString('utf8'));
+  assert.deepEqual(JSON.parse(Buffer.concat(stdout).toString('utf8')), {
+    sessionId: 'cloud-session-1',
+    archiveDigest: artifact.archiveDigest,
+    identityHex: identityBytes.toString('hex'),
+    verified: true,
+    destinationRoot,
+  });
+  assert.equal(await readFile(join(destinationRoot, 'state', 'session.bin'), 'utf8'), 'state');
+  assert.equal(
+    await readFile(join(destinationRoot, 'workspace', 'run.sh'), 'utf8'),
+    '#!/bin/sh\necho ok\n',
+  );
+});
+
+test('rejects corrupted payloads and transport mismatches without publishing hydration', async () => {
+  const fixture = await createFixture();
+  const archivePath = join(fixture.root, 'bundle.tar.zst');
+  const artifact = await packFixture(archivePath, fixture);
+  const service = createSessionBundleFileService();
+  const corruptedPath = join(fixture.root, 'corrupted.tar.zst');
+  const tar = zstdDecompressSync(await readFile(archivePath));
+  const payload = findTarEntry(tar, 'state/session.bin');
+  tar[payload.contentOffset] ^= 0xff;
+  await writeFile(corruptedPath, compressTar(tar));
+
+  await assertBundleRejects(
+    service.inspect({ source: { path: corruptedPath }, limits }),
+    'integrity_mismatch',
+  );
+  const destinationRoot = join(fixture.root, 'failed-hydration');
+  await assertBundleRejects(
+    service.hydrate({
+      source: { path: archivePath, expectedArchiveDigest: `sha256:${'00'.repeat(32)}` },
+      limits,
+      expectedSessionId: 'cloud-session-1',
+      destinationRoot,
+    }),
+    'integrity_mismatch',
+  );
+  await assert.rejects(lstat(destinationRoot), { code: 'ENOENT' });
+  assert.equal(
+    (await readdir(fixture.root)).some((name) => name.includes('.maka-session-bundle-staging-')),
+    false,
+  );
+  assert.notEqual(artifact.archiveDigest, `sha256:${'00'.repeat(32)}`);
+});
+
+test('rejects corrupted manifest, descriptor, tree digest, and Zstandard stream', async () => {
+  const fixture = await createFixture();
+  const archivePath = join(fixture.root, 'bundle.tar.zst');
+  await packFixture(archivePath, fixture);
+  const archiveBytes = await readFile(archivePath);
+  const originalTar = zstdDecompressSync(archiveBytes);
+  const service = createSessionBundleFileService();
+
+  const manifest = Buffer.from(originalTar);
+  const manifestEntry = findTarEntry(manifest, 'manifest.json');
+  manifest[manifestEntry.contentOffset] = '['.charCodeAt(0);
+  await assertMutatedTarRejected(service, fixture.root, 'manifest', manifest, 'invalid_manifest');
+
+  const descriptor = Buffer.from(originalTar);
+  const descriptorEntry = findTarEntry(descriptor, 'state-identity.json');
+  descriptor[descriptorEntry.contentOffset] ^= 0xff;
+  await assertMutatedTarRejected(
+    service,
+    fixture.root,
+    'descriptor',
+    descriptor,
+    'integrity_mismatch',
+  );
+
+  const treeDigest = Buffer.from(originalTar);
+  const treeManifestEntry = findTarEntry(treeDigest, 'manifest.json');
+  const decodedManifest = JSON.parse(
+    treeDigest
+      .subarray(
+        treeManifestEntry.contentOffset,
+        treeManifestEntry.contentOffset + treeManifestEntry.size,
+      )
+      .toString('utf8'),
+  ) as Parameters<typeof encodeSessionBundleManifestV1>[0];
+  decodedManifest.payload.treeDigest = `sha256:${'00'.repeat(32)}`;
+  const changedManifest = Buffer.from(encodeSessionBundleManifestV1(decodedManifest));
+  assert.equal(changedManifest.byteLength, treeManifestEntry.size);
+  changedManifest.copy(treeDigest, treeManifestEntry.contentOffset);
+  await assertMutatedTarRejected(
+    service,
+    fixture.root,
+    'tree-digest',
+    treeDigest,
+    'integrity_mismatch',
+  );
+
+  const truncatedZstandardPath = join(fixture.root, 'corrupted-zstd.tar.zst');
+  const corruptedZstandard = Buffer.from(archiveBytes);
+  corruptedZstandard[0] ^= 0xff;
+  await writeFile(truncatedZstandardPath, corruptedZstandard);
+  await assertBundleRejects(
+    service.inspect({ source: { path: truncatedZstandardPath }, limits }),
+    'integrity_mismatch',
+  );
+
+  const trailingZstandardPath = join(fixture.root, 'trailing-zstd.tar.zst');
+  await writeFile(trailingZstandardPath, Buffer.concat([archiveBytes, Buffer.from([0])]));
+  await assertBundleRejects(
+    service.inspect({ source: { path: trailingZstandardPath }, limits }),
+    'integrity_mismatch',
+  );
+
+  const noncanonicalZstandardPath = join(fixture.root, 'noncanonical-zstd.tar.zst');
+  await writeFile(noncanonicalZstandardPath, zstdCompressSync(originalTar));
+  await assertBundleRejects(
+    service.inspect({ source: { path: noncanonicalZstandardPath }, limits }),
+    'integrity_mismatch',
+  );
+});
+
+test('enforces every explicit streaming quota with bounded details', async () => {
+  const fixture = await createFixture();
+  const archivePath = join(fixture.root, 'bundle.tar.zst');
+  const artifact = await packFixture(archivePath, fixture);
+  const service = createSessionBundleFileService();
+  const cases: Array<[keyof SessionBundleLimits, number]> = [
+    ['maxCompressedBytes', artifact.compressedBytes - 1],
+    ['maxDecompressedTarBytes', artifact.decompressedTarBytes - 1],
+    ['maxPayloadBytes', artifact.payloadBytes - 1],
+    ['maxFileBytes', 17],
+    ['maxEntryCount', artifact.entryCount - 1],
+    ['maxManifestBytes', 1],
+    ['maxStateIdentityBytes', identityBytes.byteLength - 1],
+    ['maxPathBytes', 18],
+    ['maxPathDepth', 2],
+  ];
+
+  for (const [quota, value] of cases) {
+    await assert.rejects(
+      service.inspect({ source: { path: archivePath }, limits: { ...limits, [quota]: value } }),
+      (error) => {
+        assert.ok(error instanceof SessionBundleFileError);
+        assert.equal(error.code, 'quota_exceeded', quota);
+        assert.equal(error.details?.quota, quota);
+        assert.equal(error.details?.limit, value);
+        return true;
+      },
+    );
+  }
+});
+
+test('rejects unsafe paths, links, bad checksums, truncation, and trailing TAR bytes', async () => {
+  const fixture = await createFixture();
+  const archivePath = join(fixture.root, 'bundle.tar.zst');
+  await packFixture(archivePath, fixture);
+  const originalTar = zstdDecompressSync(await readFile(archivePath));
+  const service = createSessionBundleFileService();
+
+  const unsafe = Buffer.from(originalTar);
+  const unsafeEntry = findTarEntry(unsafe, 'state/session.bin');
+  rewriteHeaderName(
+    unsafe.subarray(unsafeEntry.headerOffset, unsafeEntry.headerOffset + 512),
+    '../outside',
+  );
+  await assertMutatedTarRejected(service, fixture.root, 'unsafe', unsafe, 'unsafe_path');
+
+  const link = Buffer.from(originalTar);
+  const linkEntry = findTarEntry(link, 'workspace/run.sh');
+  const linkHeader = link.subarray(linkEntry.headerOffset, linkEntry.headerOffset + 512);
+  linkHeader[156] = '2'.charCodeAt(0);
+  rewriteChecksum(linkHeader);
+  await assertMutatedTarRejected(service, fixture.root, 'link', link, 'unsupported_entry');
+
+  const checksum = Buffer.from(originalTar);
+  const checksumEntry = findTarEntry(checksum, 'workspace/run.sh');
+  checksum[checksumEntry.headerOffset + 148] ^= 1;
+  await assertMutatedTarRejected(service, fixture.root, 'checksum', checksum, 'integrity_mismatch');
+
+  const truncated = originalTar.subarray(0, originalTar.byteLength - 512);
+  await assertMutatedTarRejected(
+    service,
+    fixture.root,
+    'truncated',
+    truncated,
+    'integrity_mismatch',
+  );
+
+  const trailing = Buffer.concat([originalTar, Buffer.alloc(512)]);
+  await assertMutatedTarRejected(service, fixture.root, 'trailing', trailing, 'integrity_mismatch');
+
+  const duplicate = Buffer.from(originalTar);
+  const duplicateEntry = findTarEntry(duplicate, 'workspace/深/x.txt');
+  rewriteHeaderName(
+    duplicate.subarray(duplicateEntry.headerOffset, duplicateEntry.headerOffset + 512),
+    'workspace/run.sh',
+  );
+  await assertMutatedTarRejected(service, fixture.root, 'duplicate', duplicate, 'unsafe_path');
+});
+
+test('unsafe hydration cannot escape staging or remove unrelated paths', async () => {
+  const fixture = await createFixture();
+  const archivePath = join(fixture.root, 'bundle.tar.zst');
+  await packFixture(archivePath, fixture);
+  const unsafe = zstdDecompressSync(await readFile(archivePath));
+  const unsafeEntry = findTarEntry(unsafe, 'state/session.bin');
+  rewriteHeaderName(
+    unsafe.subarray(unsafeEntry.headerOffset, unsafeEntry.headerOffset + 512),
+    '../outside',
+  );
+  const unsafeArchivePath = join(fixture.root, 'unsafe-hydrate.tar.zst');
+  await writeFile(unsafeArchivePath, compressTar(unsafe));
+
+  const outsidePath = join(fixture.root, 'outside');
+  await writeFile(outsidePath, 'sentinel');
+  const unrelatedRoot = await mkdtemp(join(tmpdir(), 'maka-session-bundle-unrelated-'));
+  roots.push(unrelatedRoot);
+  await writeFile(join(unrelatedRoot, 'sentinel'), 'unrelated');
+  const unrelatedLink = join(
+    fixture.root,
+    '.unsafe-destination.maka-session-bundle-staging-unrelated',
+  );
+  await symlink(unrelatedRoot, unrelatedLink);
+
+  const destinationRoot = join(fixture.root, 'unsafe-destination');
+  await assertBundleRejects(
+    createSessionBundleFileService().hydrate({
+      source: { path: unsafeArchivePath },
+      limits,
+      expectedSessionId: 'cloud-session-1',
+      destinationRoot,
+    }),
+    'unsafe_path',
+  );
+  assert.equal(await readFile(outsidePath, 'utf8'), 'sentinel');
+  assert.equal((await lstat(unrelatedLink)).isSymbolicLink(), true);
+  assert.equal(await readFile(join(unrelatedRoot, 'sentinel'), 'utf8'), 'unrelated');
+  await assert.rejects(lstat(destinationRoot), { code: 'ENOENT' });
+});
+
+test('pack enforces caller quotas and cleans unpublished output', async () => {
+  const fixture = await createFixture();
+  const cases: Array<[keyof SessionBundleLimits, number]> = [
+    ['maxCompressedBytes', 1],
+    ['maxDecompressedTarBytes', 1],
+    ['maxPayloadBytes', identityBytes.byteLength],
+    ['maxFileBytes', 4],
+    ['maxEntryCount', 1],
+    ['maxManifestBytes', 1],
+    ['maxStateIdentityBytes', identityBytes.byteLength - 1],
+    ['maxPathBytes', Buffer.byteLength('state-identity.json') - 1],
+    ['maxPathDepth', 1],
+  ];
+
+  for (const [quota, value] of cases) {
+    const destination = join(fixture.root, `${quota}.tar.zst`);
+    await assert.rejects(
+      packFixture(destination, fixture, { ...limits, [quota]: value }),
+      (error) => {
+        assert.ok(error instanceof SessionBundleFileError);
+        assert.equal(error.code, 'quota_exceeded', quota);
+        assert.equal(error.details?.quota, quota);
+        return true;
+      },
+    );
+    await assert.rejects(lstat(destination), { code: 'ENOENT' });
+  }
+  assert.equal(
+    (await readdir(fixture.root)).some((name) => name.includes('.maka-session-bundle-pack-')),
+    false,
+  );
+});
+
+test('rejects source links, identity mismatch, and existing destinations', async () => {
+  const fixture = await createFixture();
+  const service = createSessionBundleFileService();
+  await symlink(join(fixture.stateRoot, 'session.bin'), join(fixture.stateRoot, 'linked.bin'));
+  await assertBundleRejects(
+    packFixture(join(fixture.root, 'linked.tar.zst'), fixture),
+    'unsupported_entry',
+  );
+  await rm(join(fixture.stateRoot, 'linked.bin'));
+
+  if (process.platform === 'linux') {
+    const invalidUtf8Path = Buffer.concat([
+      Buffer.from(`${fixture.stateRoot}/`, 'utf8'),
+      Buffer.from([0xff]),
+    ]);
+    await writeFile(invalidUtf8Path, 'invalid UTF-8 name');
+    await assertBundleRejects(
+      packFixture(join(fixture.root, 'invalid-utf8.tar.zst'), fixture),
+      'unsafe_path',
+    );
+    await rm(invalidUtf8Path);
+  }
+
+  const archivePath = join(fixture.root, 'bundle.tar.zst');
+  await packFixture(archivePath, fixture);
+  await assertBundleRejects(
+    service.hydrate({
+      source: { path: archivePath },
+      limits,
+      expectedSessionId: 'wrong-session',
+      destinationRoot: join(fixture.root, 'identity-mismatch'),
+    }),
+    'identity_mismatch',
+  );
+
+  const destinationRoot = join(fixture.root, 'existing');
+  await mkdir(destinationRoot);
+  await assertBundleRejects(
+    service.hydrate({
+      source: { path: archivePath },
+      limits,
+      expectedSessionId: 'cloud-session-1',
+      destinationRoot,
+    }),
+    'destination_exists',
+  );
+});
+
+async function createFixture(): Promise<{
+  root: string;
+  stateRoot: string;
+  workspaceRoot: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-session-bundle-codec-'));
+  roots.push(root);
+  const stateRoot = join(root, 'source-state');
+  const workspaceRoot = join(root, 'source-workspace');
+  await mkdir(join(stateRoot, 'empty'), { recursive: true });
+  await mkdir(join(workspaceRoot, '深'), { recursive: true });
+  await writeFile(join(stateRoot, 'session.bin'), 'state');
+  await writeFile(join(workspaceRoot, 'run.sh'), '#!/bin/sh\necho ok\n');
+  await chmod(join(workspaceRoot, 'run.sh'), 0o755);
+  await writeFile(join(workspaceRoot, '深', 'x.txt'), '好');
+  return { root, stateRoot, workspaceRoot };
+}
+
+async function packFixture(
+  destination: string,
+  fixture: { stateRoot: string; workspaceRoot: string },
+  packLimits: SessionBundleLimits = limits,
+): Promise<SessionBundleArtifact> {
+  return createSessionBundleFileService().pack({
+    snapshot: {
+      stateRoot: fixture.stateRoot,
+      workspaceRoot: fixture.workspaceRoot,
+      stateIdentity: {
+        mediaType: 'application/vnd.maka.session-state-identity+json;version=1',
+        bytes: identityBytes,
+      },
+    },
+    envelope: {
+      sessionId: 'cloud-session-1',
+      lastCommittedActivationId: 'activation-9',
+    },
+    destination,
+    limits: packLimits,
+  });
+}
+
+function findTarEntry(
+  tar: Buffer,
+  target: string,
+): { headerOffset: number; contentOffset: number; size: number } {
+  let offset = 0;
+  while (offset + 512 <= tar.byteLength) {
+    const headerBytes = tar.subarray(offset, offset + 512);
+    if (headerBytes.every((byte) => byte === 0)) break;
+    const header = decodeSessionBundleUstarHeaderV1(headerBytes);
+    const contentOffset = offset + 512;
+    if (header.path === target) return { headerOffset: offset, contentOffset, size: header.size };
+    offset = contentOffset + header.size + ((512 - (header.size % 512)) % 512);
+  }
+  throw new Error(`Missing TAR entry ${target}`);
+}
+
+function rewriteHeaderName(header: Buffer, path: string): void {
+  assert.ok(Buffer.byteLength(path) <= 100);
+  header.fill(0, 0, 100);
+  header.write(path, 0, 'utf8');
+  rewriteChecksum(header);
+}
+
+function rewriteChecksum(header: Buffer): void {
+  header.fill(' '.charCodeAt(0), 148, 156);
+  const checksum = header
+    .reduce((sum, byte) => sum + byte, 0)
+    .toString(8)
+    .padStart(6, '0');
+  header.write(checksum, 148, 6, 'ascii');
+  header[154] = 0;
+  header[155] = ' '.charCodeAt(0);
+}
+
+function compressTar(tar: Uint8Array): Buffer {
+  return zstdCompressSync(tar, {
+    params: {
+      [zlibConstants.ZSTD_c_compressionLevel]: 3,
+      [zlibConstants.ZSTD_c_checksumFlag]: 1,
+      [zlibConstants.ZSTD_c_contentSizeFlag]: 0,
+      [zlibConstants.ZSTD_c_dictIDFlag]: 0,
+      [zlibConstants.ZSTD_c_nbWorkers]: 0,
+    },
+  });
+}
+
+async function assertMutatedTarRejected(
+  service: ReturnType<typeof createSessionBundleFileService>,
+  root: string,
+  name: string,
+  tar: Uint8Array,
+  code: SessionBundleFileError['code'],
+): Promise<void> {
+  const path = join(root, `${name}.tar.zst`);
+  await writeFile(path, compressTar(tar));
+  await assertBundleRejects(service.inspect({ source: { path }, limits }), code);
+}
+
+async function assertBundleRejects(
+  action: Promise<unknown>,
+  code: SessionBundleFileError['code'],
+): Promise<void> {
+  await assert.rejects(action, (error) => {
+    assert.ok(error instanceof SessionBundleFileError);
+    assert.equal(error.code, code);
+    return true;
+  });
+}

--- a/packages/storage/src/__tests__/session-bundle-file-service.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-file-service.test.ts
@@ -17,7 +17,6 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
-import { once } from 'node:events';
 import { afterEach, test } from 'node:test';
 import { constants as zlibConstants, zstdCompressSync, zstdDecompressSync } from 'node:zlib';
 import {
@@ -42,6 +41,7 @@ const limits: SessionBundleLimits = {
   maxPathBytes: 255,
   maxPathDepth: 16,
 };
+const CHILD_PROCESS_TIMEOUT_MS = 15_000;
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
@@ -75,6 +75,7 @@ test('packs deterministically, inspects completely, and atomically hydrates', as
   );
   assert.equal(
     first.archiveDigest,
+    // Pinned with Node 24's bundled Zstandard encoder; Node 26 currently matches.
     'sha256:c7c9efbe9fc8a1c84f22ec016985457d82070001c4579d5cecb1304459fed5e1',
   );
   assert.equal(firstBytes.lastIndexOf(Buffer.from('28b52ffd', 'hex')), 0);
@@ -131,8 +132,9 @@ test('an independent process verifies and hydrates the same archive contract', a
   const stderr: Buffer[] = [];
   child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
   child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
-  const [code] = (await once(child, 'exit')) as [number | null];
-  assert.equal(code, 0, Buffer.concat(stderr).toString('utf8'));
+  const closed = waitForChildClose(child, CHILD_PROCESS_TIMEOUT_MS, 'Session Bundle child');
+  const result = await closed;
+  assert.equal(result.code, 0, Buffer.concat(stderr).toString('utf8'));
   assert.deepEqual(JSON.parse(Buffer.concat(stdout).toString('utf8')), {
     sessionId: 'cloud-session-1',
     archiveDigest: artifact.archiveDigest,
@@ -145,6 +147,60 @@ test('an independent process verifies and hydrates the same archive contract', a
     await readFile(join(destinationRoot, 'workspace', 'run.sh'), 'utf8'),
     '#!/bin/sh\necho ok\n',
   );
+});
+
+test('a process crash before hydration publication leaves only orphan staging', {
+  timeout: 30_000,
+}, async () => {
+  const fixture = await createFixture();
+  await writeFile(join(fixture.workspaceRoot, 'large.bin'), randomBytes(16 * 1024 * 1024));
+  const crashLimits: SessionBundleLimits = {
+    ...limits,
+    maxCompressedBytes: 32 * 1024 * 1024,
+    maxDecompressedTarBytes: 32 * 1024 * 1024,
+    maxPayloadBytes: 32 * 1024 * 1024,
+    maxFileBytes: 20 * 1024 * 1024,
+  };
+  const archivePath = join(fixture.root, 'crash-bundle.tar.zst');
+  const artifact = await packFixture(archivePath, fixture, crashLimits);
+  const childPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'fixtures',
+    'session-bundle-inspect-child.js',
+  );
+  const destinationRoot = join(fixture.root, 'crash-hydrated');
+  const stagingPrefix = '.crash-hydrated.maka-session-bundle-staging-';
+  const child = spawn(
+    process.execPath,
+    [childPath, archivePath, artifact.archiveDigest, JSON.stringify(crashLimits), destinationRoot],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  const stderr: Buffer[] = [];
+  child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+  const closed = waitForChildClose(child, CHILD_PROCESS_TIMEOUT_MS, 'hydration crash child');
+  try {
+    const stagingName = await waitForDirectoryEntry(
+      fixture.root,
+      stagingPrefix,
+      10_000,
+      'hydration staging',
+    );
+    assert.equal(child.kill('SIGKILL'), true);
+    const result = await closed;
+    assert.equal(result.signal, 'SIGKILL', Buffer.concat(stderr).toString('utf8'));
+    await assert.rejects(lstat(destinationRoot), { code: 'ENOENT' });
+    const stagingPath = join(fixture.root, stagingName);
+    const stagingMetadata = await lstat(stagingPath);
+    assert.equal(stagingMetadata.isDirectory(), true);
+    assert.equal(stagingMetadata.isSymbolicLink(), false);
+    assert.deepEqual(
+      (await readdir(fixture.root)).filter((name) => name.startsWith(stagingPrefix)),
+      [stagingName],
+    );
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+    await closed.catch(() => {});
+  }
 });
 
 test('concurrent publications never overwrite an existing destination', async () => {
@@ -198,7 +254,12 @@ test('binds pack publication and cleanup to the hashed temporary inode', async (
   const replacer = spawn(process.execPath, [replacerPath, fixture.root, replacementResultPath], {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
-  await once(replacer.stdout, 'data');
+  const replacerClosed = waitForChildClose(
+    replacer,
+    CHILD_PROCESS_TIMEOUT_MS,
+    'Session Bundle temp replacer',
+  );
+  await waitForStreamText(replacer.stdout, 'ready\n', 5_000, 'Session Bundle temp replacer');
   const packing = packFixture(destination, fixture, {
     ...limits,
     maxCompressedBytes: 16 * 1024 * 1024,
@@ -206,8 +267,8 @@ test('binds pack publication and cleanup to the hashed temporary inode', async (
     maxPayloadBytes: 16 * 1024 * 1024,
     maxFileBytes: 10 * 1024 * 1024,
   });
-  const [replacerCode] = (await once(replacer, 'exit')) as [number | null];
-  assert.equal(replacerCode, 0);
+  const replacerResult = await replacerClosed;
+  assert.equal(replacerResult.code, 0);
   const { capturedPath, temporaryPath } = JSON.parse(
     await readFile(replacementResultPath, 'utf8'),
   ) as { capturedPath: string; temporaryPath: string };
@@ -371,6 +432,48 @@ test('enforces every explicit streaming quota with bounded details', async () =>
   }
 });
 
+test('accepts exact file, entry, path-byte, and path-depth quota boundaries', async () => {
+  const fixture = await createFixture();
+  const firstDirectory = 'a'.repeat(70);
+  const secondDirectory = 'b'.repeat(73);
+  const fileName = 'c'.repeat(100);
+  const boundaryDirectory = join(fixture.workspaceRoot, firstDirectory, secondDirectory);
+  await mkdir(boundaryDirectory, { recursive: true });
+  await writeFile(join(boundaryDirectory, fileName), Buffer.alloc(128, 0x5a));
+  const archivePath = join(fixture.root, 'boundary-source.tar.zst');
+  const artifact = await packFixture(archivePath, fixture);
+  const boundaryPath = `workspace/${firstDirectory}/${secondDirectory}/${fileName}`;
+  assert.equal(Buffer.byteLength(boundaryPath), 255);
+  assert.equal(boundaryPath.split('/').length, 4);
+
+  const exactLimits: SessionBundleLimits = {
+    ...limits,
+    maxCompressedBytes: artifact.compressedBytes,
+    maxDecompressedTarBytes: artifact.decompressedTarBytes,
+    maxPayloadBytes: artifact.payloadBytes,
+    maxFileBytes: 128,
+    maxEntryCount: artifact.entryCount,
+    maxPathBytes: 255,
+    maxPathDepth: 4,
+  };
+  const exactPath = join(fixture.root, 'boundary-exact.tar.zst');
+  const exact = await packFixture(exactPath, fixture, exactLimits);
+  assert.equal(exact.archiveDigest, artifact.archiveDigest);
+  assert.equal(exact.entryCount, exactLimits.maxEntryCount);
+  assert.equal(exact.payloadBytes, exactLimits.maxPayloadBytes);
+  assert.equal(exact.compressedBytes, exactLimits.maxCompressedBytes);
+  assert.equal(exact.decompressedTarBytes, exactLimits.maxDecompressedTarBytes);
+  assert.equal(
+    (
+      await createSessionBundleFileService().inspect({
+        source: { path: exactPath, expectedArchiveDigest: exact.archiveDigest },
+        limits: exactLimits,
+      })
+    ).verified,
+    true,
+  );
+});
+
 test('rejects unsafe paths, links, bad checksums, truncation, and trailing TAR bytes', async () => {
   const fixture = await createFixture();
   const archivePath = join(fixture.root, 'bundle.tar.zst');
@@ -419,7 +522,7 @@ test('rejects unsafe paths, links, bad checksums, truncation, and trailing TAR b
   await assertMutatedTarRejected(service, fixture.root, 'duplicate', duplicate, 'unsafe_path');
 });
 
-test('unsafe hydration cannot escape staging or remove unrelated paths', async () => {
+test('unsafe hydration paths cannot escape staging', async () => {
   const fixture = await createFixture();
   const archivePath = join(fixture.root, 'bundle.tar.zst');
   await packFixture(archivePath, fixture);
@@ -434,14 +537,6 @@ test('unsafe hydration cannot escape staging or remove unrelated paths', async (
 
   const outsidePath = join(fixture.root, 'outside');
   await writeFile(outsidePath, 'sentinel');
-  const unrelatedRoot = await mkdtemp(join(tmpdir(), 'maka-session-bundle-unrelated-'));
-  roots.push(unrelatedRoot);
-  await writeFile(join(unrelatedRoot, 'sentinel'), 'unrelated');
-  const unrelatedLink = join(
-    fixture.root,
-    '.unsafe-destination.maka-session-bundle-staging-unrelated',
-  );
-  await symlink(unrelatedRoot, unrelatedLink);
 
   const destinationRoot = join(fixture.root, 'unsafe-destination');
   await assertBundleRejects(
@@ -454,8 +549,6 @@ test('unsafe hydration cannot escape staging or remove unrelated paths', async (
     'unsafe_path',
   );
   assert.equal(await readFile(outsidePath, 'utf8'), 'sentinel');
-  assert.equal((await lstat(unrelatedLink)).isSymbolicLink(), true);
-  assert.equal(await readFile(join(unrelatedRoot, 'sentinel'), 'utf8'), 'unrelated');
   await assert.rejects(lstat(destinationRoot), { code: 'ENOENT' });
 });
 
@@ -665,4 +758,88 @@ async function assertBundleRejects(
 function assertBundleErrorValue(error: unknown, code: SessionBundleFileError['code']): void {
   assert.ok(error instanceof SessionBundleFileError);
   assert.equal(error.code, code);
+}
+
+function waitForChildClose(
+  child: ReturnType<typeof spawn>,
+  timeoutMs: number,
+  label: string,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolveChild, rejectChild) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      rejectChild(new Error(`${label} did not close within ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolveChild({ code, signal });
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      rejectChild(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off('close', onClose);
+      child.off('error', onError);
+    };
+    child.once('close', onClose);
+    child.once('error', onError);
+  });
+}
+
+function waitForStreamText(
+  stream: NonNullable<ReturnType<typeof spawn>['stdout']>,
+  expected: string,
+  timeoutMs: number,
+  label: string,
+): Promise<void> {
+  return new Promise((resolveText, rejectText) => {
+    let observed = '';
+    const timeout = setTimeout(() => {
+      cleanup();
+      rejectText(
+        new Error(`${label} did not emit ${JSON.stringify(expected)} within ${timeoutMs}ms`),
+      );
+    }, timeoutMs);
+    const onData = (chunk: Buffer | string) => {
+      observed += String(chunk);
+      if (!observed.includes(expected)) return;
+      cleanup();
+      resolveText();
+    };
+    const onEnd = () => {
+      cleanup();
+      rejectText(new Error(`${label} ended before emitting ${JSON.stringify(expected)}`));
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      rejectText(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      stream.off('data', onData);
+      stream.off('end', onEnd);
+      stream.off('error', onError);
+    };
+    stream.on('data', onData);
+    stream.once('end', onEnd);
+    stream.once('error', onError);
+  });
+}
+
+async function waitForDirectoryEntry(
+  root: string,
+  prefix: string,
+  timeoutMs: number,
+  label: string,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const entry = (await readdir(root)).find((name) => name.startsWith(prefix));
+    if (entry !== undefined) return entry;
+    await new Promise<void>((resolvePoll) => setTimeout(resolvePoll, 1));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);
 }

--- a/packages/storage/src/__tests__/session-bundle-file-service.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-file-service.test.ts
@@ -186,6 +186,13 @@ test('a process crash leaves owned staging that can be reclaimed without touchin
       10_000,
       'hydration staging',
     );
+    const ownershipName = `${stagingName}.owner.json`;
+    await waitForFileText(
+      join(fixture.root, ownershipName),
+      '"stagingDev"',
+      10_000,
+      'bound hydration ownership',
+    );
     assert.equal(child.kill('SIGKILL'), true);
     const result = await closed;
     assert.equal(result.signal, 'SIGKILL', Buffer.concat(stderr).toString('utf8'));
@@ -194,7 +201,6 @@ test('a process crash leaves owned staging that can be reclaimed without touchin
     const stagingMetadata = await lstat(stagingPath);
     assert.equal(stagingMetadata.isDirectory(), true);
     assert.equal(stagingMetadata.isSymbolicLink(), false);
-    const ownershipName = `${stagingName}.owner.json`;
     assert.equal((await lstat(join(fixture.root, ownershipName))).isFile(), true);
     assert.deepEqual(
       (await readdir(fixture.root)).filter((name) => name.startsWith(stagingPrefix)).sort(),
@@ -213,7 +219,9 @@ test('a process crash leaves owned staging that can be reclaimed without touchin
     await rename(stagingPath, capturedStagingPath);
     await symlink(unrelatedRoot, stagingPath);
     assert.deepEqual(
-      await createSessionBundleFileService().cleanupHydrationStaging({ destinationRoot }),
+      await createSessionBundleFileService().cleanupHydrationStaging({
+        destinationRoot,
+      }),
       {
         destinationRoot,
         removedStagingDirectories: 0,
@@ -226,6 +234,24 @@ test('a process crash leaves owned staging that can be reclaimed without touchin
     await rm(stagingPath);
     await rename(capturedStagingPath, stagingPath);
 
+    await rename(stagingPath, capturedStagingPath);
+    await mkdir(stagingPath);
+    await writeFile(join(stagingPath, 'replacement-sentinel'), 'replacement');
+    assert.deepEqual(
+      await createSessionBundleFileService().cleanupHydrationStaging({
+        destinationRoot,
+      }),
+      {
+        destinationRoot,
+        removedStagingDirectories: 0,
+        removedOwnershipRecords: 0,
+      },
+    );
+    assert.equal(await readFile(join(stagingPath, 'replacement-sentinel'), 'utf8'), 'replacement');
+    assert.equal((await lstat(join(fixture.root, ownershipName))).isFile(), true);
+    await rm(stagingPath, { recursive: true });
+    await rename(capturedStagingPath, stagingPath);
+
     const cleanup = await createSessionBundleFileService().cleanupHydrationStaging({
       destinationRoot,
     });
@@ -235,12 +261,16 @@ test('a process crash leaves owned staging that can be reclaimed without touchin
       removedOwnershipRecords: 1,
     });
     await assert.rejects(lstat(stagingPath), { code: 'ENOENT' });
-    await assert.rejects(lstat(join(fixture.root, ownershipName)), { code: 'ENOENT' });
+    await assert.rejects(lstat(join(fixture.root, ownershipName)), {
+      code: 'ENOENT',
+    });
     assert.equal((await lstat(decoyDirectory)).isDirectory(), true);
     assert.equal(await readFile(decoyOwnership, 'utf8'), '{}\n');
     assert.equal(await readFile(join(unrelatedRoot, 'sentinel'), 'utf8'), 'unrelated');
     assert.deepEqual(
-      await createSessionBundleFileService().cleanupHydrationStaging({ destinationRoot }),
+      await createSessionBundleFileService().cleanupHydrationStaging({
+        destinationRoot,
+      }),
       {
         destinationRoot,
         removedStagingDirectories: 0,
@@ -368,6 +398,82 @@ test('cleans the inode actually linked when the pack pathname is swapped at link
   await assert.rejects(lstat(destination), { code: 'ENOENT' });
   assert.equal(await readFile(replacement.temporaryPath, 'utf8'), 'EVIL');
   assert.equal((await lstat(replacement.capturedPath)).isFile(), true);
+});
+
+test('cleans a published pack when the temporary pathname disappears after link', async () => {
+  const fixture = await createFixture();
+  const destination = join(fixture.root, 'linked-temp-removed.tar.zst');
+  const resultPath = join(fixture.root, 'linked-temp-removed-result.json');
+  const childPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'fixtures',
+    'session-bundle-pack-linked-temp-remover.js',
+  );
+  const child = spawn(
+    process.execPath,
+    [
+      childPath,
+      fixture.stateRoot,
+      fixture.workspaceRoot,
+      destination,
+      resultPath,
+      JSON.stringify(limits),
+      identityBytes.toString('hex'),
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] },
+  );
+  const stderr: Buffer[] = [];
+  child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+  const result = await waitForChildClose(
+    child,
+    CHILD_PROCESS_TIMEOUT_MS,
+    'Session Bundle linked temp remover',
+  );
+  assert.equal(result.code, 0, Buffer.concat(stderr).toString('utf8'));
+  const removal = JSON.parse(await readFile(resultPath, 'utf8')) as {
+    code: string;
+    capturedPath: string;
+  };
+  assert.equal(removal.code, 'io_failure');
+  await assert.rejects(lstat(destination), { code: 'ENOENT' });
+  assert.equal((await lstat(removal.capturedPath)).isFile(), true);
+});
+
+test('removes an ownership record when its initialization write fails', async () => {
+  const fixture = await createFixture();
+  const archivePath = join(fixture.root, 'owner-write-failure.tar.zst');
+  const artifact = await packFixture(archivePath, fixture);
+  const destinationRoot = join(fixture.root, 'owner-write-failure-hydrated');
+  const childPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'fixtures',
+    'session-bundle-hydration-owner-write-failure.js',
+  );
+  const child = spawn(
+    process.execPath,
+    [childPath, archivePath, artifact.archiveDigest, JSON.stringify(limits), destinationRoot],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+  const result = await waitForChildClose(
+    child,
+    CHILD_PROCESS_TIMEOUT_MS,
+    'Session Bundle ownership write failure',
+  );
+  assert.equal(result.code, 0, Buffer.concat(stderr).toString('utf8'));
+  assert.deepEqual(JSON.parse(Buffer.concat(stdout).toString('utf8')), {
+    code: 'io_failure',
+  });
+  await assert.rejects(lstat(destinationRoot), { code: 'ENOENT' });
+  assert.deepEqual(
+    (await readdir(fixture.root)).filter((name) =>
+      name.startsWith('.owner-write-failure-hydrated.maka-session-bundle-staging-'),
+    ),
+    [],
+  );
 });
 
 test('reports read-side source changes and filesystem failures at the operation boundary', async () => {
@@ -973,6 +1079,21 @@ async function waitForDirectoryEntry(
       const metadata = await lstat(join(root, entry));
       if (metadata.isDirectory() && !metadata.isSymbolicLink()) return entry;
     }
+    await new Promise<void>((resolvePoll) => setTimeout(resolvePoll, 1));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);
+}
+
+async function waitForFileText(
+  path: string,
+  expected: string,
+  timeoutMs: number,
+  label: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const contents = await readFile(path, 'utf8').catch(() => undefined);
+    if (contents?.includes(expected)) return;
     await new Promise<void>((resolvePoll) => setTimeout(resolvePoll, 1));
   }
   throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);

--- a/packages/storage/src/__tests__/session-bundle-file-service.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-file-service.test.ts
@@ -74,8 +74,9 @@ test('packs deterministically, inspects completely, and atomically hydrates', as
   );
   assert.equal(
     first.archiveDigest,
-    'sha256:5d4d93d96a0906827a6296a1bd9f87f7189be829052796cd0a8a4cb35262fb52',
+    'sha256:c7c9efbe9fc8a1c84f22ec016985457d82070001c4579d5cecb1304459fed5e1',
   );
+  assert.equal(firstBytes.lastIndexOf(Buffer.from('28b52ffd', 'hex')), 0);
 
   const inspected = await service.inspect({
     source: { path: firstPath, expectedArchiveDigest: first.archiveDigest },
@@ -139,6 +140,44 @@ test('an independent process verifies and hydrates the same archive contract', a
     destinationRoot,
   });
   assert.equal(await readFile(join(destinationRoot, 'state', 'session.bin'), 'utf8'), 'state');
+  assert.equal(
+    await readFile(join(destinationRoot, 'workspace', 'run.sh'), 'utf8'),
+    '#!/bin/sh\necho ok\n',
+  );
+});
+
+test('concurrent publications never overwrite an existing destination', async () => {
+  const fixture = await createFixture();
+  const archivePath = join(fixture.root, 'concurrent.tar.zst');
+  const packResults = await Promise.allSettled(
+    Array.from({ length: 8 }, () => packFixture(archivePath, fixture)),
+  );
+  assert.equal(packResults.filter((result) => result.status === 'fulfilled').length, 1);
+  for (const result of packResults) {
+    if (result.status === 'rejected') assertBundleErrorValue(result.reason, 'destination_exists');
+  }
+
+  const artifact = packResults.find(
+    (result): result is PromiseFulfilledResult<SessionBundleArtifact> =>
+      result.status === 'fulfilled',
+  )?.value;
+  assert.ok(artifact);
+  const destinationRoot = join(fixture.root, 'concurrent-hydration');
+  const service = createSessionBundleFileService();
+  const hydrateInput = {
+    source: { path: archivePath, expectedArchiveDigest: artifact.archiveDigest },
+    limits,
+    expectedSessionId: 'cloud-session-1',
+    destinationRoot,
+  } as const;
+  const hydrateResults = await Promise.allSettled([
+    service.hydrate(hydrateInput),
+    service.hydrate(hydrateInput),
+  ]);
+  assert.equal(hydrateResults.filter((result) => result.status === 'fulfilled').length, 1);
+  for (const result of hydrateResults) {
+    if (result.status === 'rejected') assertBundleErrorValue(result.reason, 'destination_exists');
+  }
   assert.equal(
     await readFile(join(destinationRoot, 'workspace', 'run.sh'), 'utf8'),
     '#!/bin/sh\necho ok\n',
@@ -244,6 +283,25 @@ test('rejects corrupted manifest, descriptor, tree digest, and Zstandard stream'
   await writeFile(noncanonicalZstandardPath, zstdCompressSync(originalTar));
   await assertBundleRejects(
     service.inspect({ source: { path: noncanonicalZstandardPath }, limits }),
+    'integrity_mismatch',
+  );
+
+  const oversizedWindowPath = join(fixture.root, 'oversized-window-zstd.tar.zst');
+  const oversizedWindow = Buffer.from(archiveBytes);
+  assert.equal(oversizedWindow[5], 0x58);
+  oversizedWindow[5] = 0x60;
+  await writeFile(oversizedWindowPath, oversizedWindow);
+  await assertBundleRejects(
+    service.inspect({ source: { path: oversizedWindowPath }, limits }),
+    'integrity_mismatch',
+  );
+
+  const emptyFrame = compressTar(Buffer.alloc(0));
+  assert.equal(zstdDecompressSync(emptyFrame).byteLength, 0);
+  const multipleFramesPath = join(fixture.root, 'multiple-frames-zstd.tar.zst');
+  await writeFile(multipleFramesPath, Buffer.concat([archiveBytes, emptyFrame]));
+  await assertBundleRejects(
+    service.inspect({ source: { path: multipleFramesPath }, limits }),
     'integrity_mismatch',
   );
 });
@@ -524,15 +582,19 @@ function rewriteChecksum(header: Buffer): void {
 }
 
 function compressTar(tar: Uint8Array): Buffer {
-  return zstdCompressSync(tar, {
+  const compressed = zstdCompressSync(tar, {
     params: {
       [zlibConstants.ZSTD_c_compressionLevel]: 3,
       [zlibConstants.ZSTD_c_checksumFlag]: 1,
       [zlibConstants.ZSTD_c_contentSizeFlag]: 0,
       [zlibConstants.ZSTD_c_dictIDFlag]: 0,
       [zlibConstants.ZSTD_c_nbWorkers]: 0,
+      [zlibConstants.ZSTD_c_windowLog]: 21,
     },
   });
+  // One-shot compression shrinks the descriptor to the known input size; V1 pins 2 MiB.
+  compressed[5] = 0x58;
+  return compressed;
 }
 
 async function assertMutatedTarRejected(
@@ -556,4 +618,9 @@ async function assertBundleRejects(
     assert.equal(error.code, code);
     return true;
   });
+}
+
+function assertBundleErrorValue(error: unknown, code: SessionBundleFileError['code']): void {
+  assert.ok(error instanceof SessionBundleFileError);
+  assert.equal(error.code, code);
 }

--- a/packages/storage/src/__tests__/session-bundle-file-service.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-file-service.test.ts
@@ -10,6 +10,7 @@ import {
   readdir,
   rename,
   rm,
+  rmdir,
   stat,
   symlink,
   writeFile,
@@ -154,32 +155,25 @@ test('a process crash leaves owned staging that can be reclaimed without touchin
   timeout: 30_000,
 }, async () => {
   const fixture = await createFixture();
-  await writeFile(join(fixture.workspaceRoot, 'large.bin'), randomBytes(16 * 1024 * 1024));
-  const crashLimits: SessionBundleLimits = {
-    ...limits,
-    maxCompressedBytes: 32 * 1024 * 1024,
-    maxDecompressedTarBytes: 32 * 1024 * 1024,
-    maxPayloadBytes: 32 * 1024 * 1024,
-    maxFileBytes: 20 * 1024 * 1024,
-  };
   const archivePath = join(fixture.root, 'crash-bundle.tar.zst');
-  const artifact = await packFixture(archivePath, fixture, crashLimits);
+  const artifact = await packFixture(archivePath, fixture);
   const childPath = join(
     dirname(fileURLToPath(import.meta.url)),
     'fixtures',
-    'session-bundle-inspect-child.js',
+    'session-bundle-hydration-binding-crash.js',
   );
   const destinationRoot = join(fixture.root, 'crash-hydrated');
   const stagingPrefix = '.crash-hydrated.maka-session-bundle-staging-';
   const child = spawn(
     process.execPath,
-    [childPath, archivePath, artifact.archiveDigest, JSON.stringify(crashLimits), destinationRoot],
+    [childPath, archivePath, artifact.archiveDigest, JSON.stringify(limits), destinationRoot],
     { stdio: ['ignore', 'pipe', 'pipe'] },
   );
   const stderr: Buffer[] = [];
   child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
   const closed = waitForChildClose(child, CHILD_PROCESS_TIMEOUT_MS, 'hydration crash child');
   try {
+    await waitForStreamText(child.stdout, 'binding-partial\n', 10_000, 'partial ownership binding');
     const stagingName = await waitForDirectoryEntry(
       fixture.root,
       stagingPrefix,
@@ -187,12 +181,9 @@ test('a process crash leaves owned staging that can be reclaimed without touchin
       'hydration staging',
     );
     const ownershipName = `${stagingName}.owner.json`;
-    await waitForFileText(
-      join(fixture.root, ownershipName),
-      '"stagingDev"',
-      10_000,
-      'bound hydration ownership',
-    );
+    const ownershipContents = await readFile(join(fixture.root, ownershipName), 'utf8');
+    assert.equal(ownershipContents.includes('"stagingDev"'), false);
+    assert.equal(ownershipContents.endsWith('\n{'), true);
     assert.equal(child.kill('SIGKILL'), true);
     const result = await closed;
     assert.equal(result.signal, 'SIGKILL', Buffer.concat(stderr).toString('utf8'));
@@ -252,6 +243,25 @@ test('a process crash leaves owned staging that can be reclaimed without touchin
     await rm(stagingPath, { recursive: true });
     await rename(capturedStagingPath, stagingPath);
 
+    const unrelatedCleanupRoot = `${stagingPath}.cleanup`;
+    await mkdir(unrelatedCleanupRoot);
+    assert.deepEqual(
+      await createSessionBundleFileService().cleanupHydrationStaging({
+        destinationRoot,
+      }),
+      {
+        destinationRoot,
+        removedStagingDirectories: 0,
+        removedOwnershipRecords: 0,
+      },
+    );
+    assert.equal((await lstat(unrelatedCleanupRoot)).isDirectory(), true);
+    assert.equal((await lstat(stagingPath)).isDirectory(), true);
+    await rmdir(unrelatedCleanupRoot);
+
+    // Simulate a process dying after the owned staging inode was quarantined
+    // but before recursive removal started.
+    await rename(stagingPath, unrelatedCleanupRoot);
     const cleanup = await createSessionBundleFileService().cleanupHydrationStaging({
       destinationRoot,
     });
@@ -261,6 +271,7 @@ test('a process crash leaves owned staging that can be reclaimed without touchin
       removedOwnershipRecords: 1,
     });
     await assert.rejects(lstat(stagingPath), { code: 'ENOENT' });
+    await assert.rejects(lstat(unrelatedCleanupRoot), { code: 'ENOENT' });
     await assert.rejects(lstat(join(fixture.root, ownershipName)), {
       code: 'ENOENT',
     });
@@ -437,6 +448,43 @@ test('cleans a published pack when the temporary pathname disappears after link'
   assert.equal(removal.code, 'io_failure');
   await assert.rejects(lstat(destination), { code: 'ENOENT' });
   assert.equal((await lstat(removal.capturedPath)).isFile(), true);
+});
+
+test('does not clean an unrelated destination replacement after link', async () => {
+  const fixture = await createFixture();
+  const destination = join(fixture.root, 'destination-replaced.tar.zst');
+  const resultPath = join(fixture.root, 'destination-replaced-result.json');
+  const childPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'fixtures',
+    'session-bundle-pack-destination-replacer.js',
+  );
+  const child = spawn(
+    process.execPath,
+    [
+      childPath,
+      fixture.stateRoot,
+      fixture.workspaceRoot,
+      destination,
+      resultPath,
+      JSON.stringify(limits),
+      identityBytes.toString('hex'),
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] },
+  );
+  const stderr: Buffer[] = [];
+  child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+  const result = await waitForChildClose(
+    child,
+    CHILD_PROCESS_TIMEOUT_MS,
+    'Session Bundle destination replacer',
+  );
+  assert.equal(result.code, 0, Buffer.concat(stderr).toString('utf8'));
+  assert.deepEqual(JSON.parse(await readFile(resultPath, 'utf8')), {
+    code: 'source_changed',
+    destinationContents: 'UNRELATED',
+  });
+  assert.equal(await readFile(destination, 'utf8'), 'UNRELATED');
 });
 
 test('removes an ownership record when its initialization write fails', async () => {
@@ -1079,21 +1127,6 @@ async function waitForDirectoryEntry(
       const metadata = await lstat(join(root, entry));
       if (metadata.isDirectory() && !metadata.isSymbolicLink()) return entry;
     }
-    await new Promise<void>((resolvePoll) => setTimeout(resolvePoll, 1));
-  }
-  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);
-}
-
-async function waitForFileText(
-  path: string,
-  expected: string,
-  timeoutMs: number,
-  label: string,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const contents = await readFile(path, 'utf8').catch(() => undefined);
-    if (contents?.includes(expected)) return;
     await new Promise<void>((resolvePoll) => setTimeout(resolvePoll, 1));
   }
   throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);

--- a/packages/storage/src/__tests__/session-bundle-ustar.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-ustar.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { test } from 'node:test';
+import {
+  decodeSessionBundleUstarHeaderV1,
+  encodeSessionBundleUstarHeaderV1,
+  SessionBundleFileError,
+} from '../index.js';
+
+test('pins the exact canonical USTAR V1 header', () => {
+  const header = Buffer.from(
+    encodeSessionBundleUstarHeaderV1({
+      kind: 'file',
+      path: 'workspace/run.sh',
+      mode: 0o755,
+      size: 18,
+    }),
+  );
+
+  assert.equal(header.byteLength, 512);
+  assert.equal(header.subarray(0, 16).toString('utf8'), 'workspace/run.sh');
+  assert.equal(header.subarray(100, 108).toString('ascii'), '0000755\0');
+  assert.equal(header.subarray(124, 136).toString('ascii'), '00000000022\0');
+  assert.equal(header.subarray(257, 265).toString('hex'), '7573746172003030');
+  assert.equal(
+    createHash('sha256').update(header).digest('hex'),
+    '1d69bf3bf7dcb40b103d0d405c1d21ebc49a22c0ae3771b07dfd17eeeb4b6c4d',
+  );
+  assert.deepEqual(decodeSessionBundleUstarHeaderV1(header), {
+    kind: 'file',
+    path: 'workspace/run.sh',
+    mode: 0o755,
+    size: 18,
+  });
+});
+
+test('uses the rightmost representable USTAR prefix split', () => {
+  const path = `workspace/${'a'.repeat(90)}/${'b'.repeat(90)}`;
+  const header = Buffer.from(
+    encodeSessionBundleUstarHeaderV1({ kind: 'file', path, mode: 0o644, size: 0 }),
+  );
+  assert.equal(header.subarray(0, 100).toString('utf8').replaceAll('\0', ''), 'b'.repeat(90));
+  assert.equal(
+    header.subarray(345, 500).toString('utf8').replaceAll('\0', ''),
+    `workspace/${'a'.repeat(90)}`,
+  );
+  assert.equal(decodeSessionBundleUstarHeaderV1(header).path, path);
+});
+
+test('rejects noncanonical metadata and unrepresentable paths', () => {
+  for (const path of ['/absolute', '../outside', 'state//file', 'C:/drive']) {
+    assertBundleError(
+      () => encodeSessionBundleUstarHeaderV1({ kind: 'file', path, mode: 0o644, size: 0 }),
+      'unsafe_path',
+    );
+  }
+  assertBundleError(
+    () =>
+      encodeSessionBundleUstarHeaderV1({
+        kind: 'file',
+        path: `${'a'.repeat(101)}`,
+        mode: 0o644,
+        size: 0,
+      }),
+    'unsafe_path',
+  );
+
+  const header = Buffer.from(
+    encodeSessionBundleUstarHeaderV1({
+      kind: 'directory',
+      path: 'state/',
+      mode: 0o755,
+      size: 0,
+    }),
+  );
+  header[135] = '1'.charCodeAt(0);
+  assertBundleError(() => decodeSessionBundleUstarHeaderV1(header), 'integrity_mismatch');
+});
+
+function assertBundleError(action: () => unknown, code: SessionBundleFileError['code']): void {
+  assert.throws(action, (error) => {
+    assert.ok(error instanceof SessionBundleFileError);
+    assert.equal(error.code, code);
+    return true;
+  });
+}

--- a/packages/storage/src/__tests__/session-bundle-ustar.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-ustar.test.ts
@@ -48,7 +48,19 @@ test('uses the rightmost representable USTAR prefix split', () => {
 });
 
 test('rejects noncanonical metadata and unrepresentable paths', () => {
-  for (const path of ['/absolute', '../outside', 'state//file', 'C:/drive']) {
+  for (const path of [
+    '/absolute',
+    '../outside',
+    'state//file',
+    'C:/drive',
+    'workspace/file:stream',
+    'workspace/CON',
+    'workspace/con.txt',
+    'workspace/LPT9.log',
+    'workspace/trailing.',
+    'workspace/trailing ',
+    'workspace/question?',
+  ]) {
     assertBundleError(
       () => encodeSessionBundleUstarHeaderV1({ kind: 'file', path, mode: 0o644, size: 0 }),
       'unsafe_path',

--- a/packages/storage/src/__tests__/session-bundle-ustar.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-ustar.test.ts
@@ -47,6 +47,55 @@ test('uses the rightmost representable USTAR prefix split', () => {
   assert.equal(decodeSessionBundleUstarHeaderV1(header).path, path);
 });
 
+test('accepts exact USTAR field boundaries and non-BMP paths', () => {
+  const name100 = 'n'.repeat(100);
+  const nameHeader = Buffer.from(
+    encodeSessionBundleUstarHeaderV1({ kind: 'file', path: name100, mode: 0o644, size: 0 }),
+  );
+  assert.equal(nameHeader.subarray(0, 100).toString('utf8'), name100);
+  assert.equal(decodeSessionBundleUstarHeaderV1(nameHeader).path, name100);
+
+  const prefix155 = 'p'.repeat(155);
+  const total256 = `${prefix155}/${name100}`;
+  assert.equal(Buffer.byteLength(total256), 256);
+  const splitHeader = Buffer.from(
+    encodeSessionBundleUstarHeaderV1({
+      kind: 'file',
+      path: total256,
+      mode: 0o644,
+      size: 0o77_777_777_777,
+    }),
+  );
+  assert.equal(splitHeader.subarray(0, 100).toString('utf8'), name100);
+  assert.equal(splitHeader.subarray(345, 500).toString('utf8'), prefix155);
+  assert.deepEqual(decodeSessionBundleUstarHeaderV1(splitHeader), {
+    kind: 'file',
+    path: total256,
+    mode: 0o644,
+    size: 0o77_777_777_777,
+  });
+
+  const nonBmpPath = 'workspace/😀.txt';
+  const nonBmpHeader = encodeSessionBundleUstarHeaderV1({
+    kind: 'file',
+    path: nonBmpPath,
+    mode: 0o644,
+    size: 0,
+  });
+  assert.equal(decodeSessionBundleUstarHeaderV1(nonBmpHeader).path, nonBmpPath);
+
+  assertBundleError(
+    () =>
+      encodeSessionBundleUstarHeaderV1({
+        kind: 'file',
+        path: `${'p'.repeat(156)}/n`,
+        mode: 0o644,
+        size: 0,
+      }),
+    'unsafe_path',
+  );
+});
+
 test('rejects noncanonical metadata and unrepresentable paths', () => {
   for (const path of [
     '/absolute',

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -129,3 +129,5 @@ export * from './session-bundle-policy.js';
 export * from './session-bundle-contract.js';
 export * from './session-bundle-manifest.js';
 export * from './session-bundle-canonical-tree.js';
+export * from './session-bundle-ustar.js';
+export * from './session-bundle-file-service.js';

--- a/packages/storage/src/session-bundle-canonical-tree.ts
+++ b/packages/storage/src/session-bundle-canonical-tree.ts
@@ -38,6 +38,10 @@ export type SessionBundleCanonicalTreeEntry =
   | SessionBundleCanonicalDirectoryEntry
   | SessionBundleCanonicalFileEntry;
 
+export type SessionBundleCanonicalLayoutEntry =
+  | SessionBundleCanonicalDirectoryEntry
+  | Pick<SessionBundleCanonicalFileEntry, 'kind' | 'mode' | 'path'>;
+
 export interface SessionBundleCanonicalTreeDigest {
   treeDigest: Sha256Digest;
   payloadBytes: number;
@@ -89,16 +93,10 @@ export function computeSessionBundleCanonicalTreeDigest(
  * layout, normalized modes, and the final count without retaining file bytes.
  */
 export class SessionBundleCanonicalTreeDigestBuilder {
-  readonly #expectedEntryCount: number;
   readonly #hash: Hash;
-  readonly #logicalPaths = new Set<string>();
-  readonly #directories = new Set<string>();
-  #previousPathBytes?: Buffer;
+  readonly #layout: SessionBundleCanonicalLayoutValidator;
   #entryCount = 0;
   #payloadBytes = 0;
-  #sawStateIdentity = false;
-  #sawStateRoot = false;
-  #sawWorkspaceRoot = false;
   #failed = false;
   #result?: SessionBundleCanonicalTreeDigest;
 
@@ -106,7 +104,7 @@ export class SessionBundleCanonicalTreeDigestBuilder {
     if (!Number.isSafeInteger(expectedEntryCount) || expectedEntryCount < 0) {
       throw new RangeError('Canonical tree entry count must be a non-negative safe integer');
     }
-    this.#expectedEntryCount = expectedEntryCount;
+    this.#layout = new SessionBundleCanonicalLayoutValidator(expectedEntryCount);
     this.#hash = createHash('sha256');
     this.#hash.update(encodeTreeHeader(expectedEntryCount));
   }
@@ -120,11 +118,83 @@ export class SessionBundleCanonicalTreeDigestBuilder {
     }
 
     try {
+      const validated = validateEntry(value);
+      this.#layout.add(validated.entry);
+      const nextPayloadBytes =
+        validated.entry.kind === 'file'
+          ? this.#payloadBytes + validated.entry.size
+          : this.#payloadBytes;
+      if (!Number.isSafeInteger(nextPayloadBytes)) {
+        throw unsupportedEntry('Canonical tree payload byte count exceeds safe integer range');
+      }
+      const record = encodeTreeEntry(validated);
+
+      // Commit only after every validation and encoding step has succeeded.
+      this.#hash.update(record);
+      this.#entryCount += 1;
+      this.#payloadBytes = nextPayloadBytes;
+    } catch (error) {
+      this.#failed = true;
+      throw error;
+    }
+  }
+
+  finish(): SessionBundleCanonicalTreeDigest {
+    if (this.#result !== undefined) return { ...this.#result };
+    if (this.#failed) {
+      throw integrityError('Canonical tree digest builder previously rejected an entry');
+    }
+    try {
+      this.#layout.finish();
+    } catch (error) {
+      this.#failed = true;
+      throw error;
+    }
+    this.#result = Object.freeze({
+      treeDigest: `sha256:${this.#hash.digest('hex')}` as Sha256Digest,
+      payloadBytes: this.#payloadBytes,
+      entryCount: this.#entryCount,
+    });
+    return { ...this.#result };
+  }
+}
+
+/**
+ * Shared state machine for canonical path order, explicit parents, conflicts,
+ * required roots, and entry count. The streaming reader uses it before any
+ * hydration write, while the digest builder applies the same rules after file
+ * content hashes are available.
+ */
+export class SessionBundleCanonicalLayoutValidator {
+  readonly #expectedEntryCount: number;
+  readonly #logicalPaths = new Set<string>();
+  readonly #directories = new Set<string>();
+  #previousPathBytes?: Buffer;
+  #entryCount = 0;
+  #sawStateIdentity = false;
+  #sawStateRoot = false;
+  #sawWorkspaceRoot = false;
+  #failed = false;
+  #finished = false;
+
+  constructor(expectedEntryCount: number) {
+    if (!Number.isSafeInteger(expectedEntryCount) || expectedEntryCount < 0) {
+      throw new RangeError('Canonical layout entry count must be a non-negative safe integer');
+    }
+    this.#expectedEntryCount = expectedEntryCount;
+  }
+
+  add(value: SessionBundleCanonicalLayoutEntry): void {
+    if (this.#finished) throw integrityError('Canonical layout is already finalized');
+    if (this.#failed)
+      throw integrityError('Canonical layout validator previously rejected an entry');
+
+    try {
+      const entry = validateLayoutEntry(value);
       if (this.#entryCount >= this.#expectedEntryCount) {
         throw integrityError('Canonical tree contains more entries than declared');
       }
-
-      const validated = validateEntry(value);
+      const validated = validateCanonicalPath(entry.path, entry.kind);
       if (
         this.#previousPathBytes !== undefined &&
         Buffer.compare(this.#previousPathBytes, validated.pathBytes) >= 0
@@ -141,23 +211,11 @@ export class SessionBundleCanonicalTreeDigestBuilder {
         throw unsafePath('Canonical tree entry is missing its explicit parent directory');
       }
 
-      const layout = classifyPayloadPath(validated.entry);
-      const nextPayloadBytes =
-        validated.entry.kind === 'file'
-          ? this.#payloadBytes + validated.entry.size
-          : this.#payloadBytes;
-      if (!Number.isSafeInteger(nextPayloadBytes)) {
-        throw unsupportedEntry('Canonical tree payload byte count exceeds safe integer range');
-      }
-      const record = encodeTreeEntry(validated);
-
-      // Commit only after every validation and encoding step has succeeded.
-      this.#hash.update(record);
+      const layout = classifyPayloadPath(entry);
       this.#logicalPaths.add(validated.logicalPath);
-      if (validated.entry.kind === 'directory') this.#directories.add(validated.entry.path);
+      if (entry.kind === 'directory') this.#directories.add(entry.path);
       this.#previousPathBytes = validated.pathBytes;
       this.#entryCount += 1;
-      this.#payloadBytes = nextPayloadBytes;
       if (layout === 'state_identity') this.#sawStateIdentity = true;
       if (layout === 'state_root') this.#sawStateRoot = true;
       if (layout === 'workspace_root') this.#sawWorkspaceRoot = true;
@@ -167,23 +225,22 @@ export class SessionBundleCanonicalTreeDigestBuilder {
     }
   }
 
-  finish(): SessionBundleCanonicalTreeDigest {
-    if (this.#result !== undefined) return { ...this.#result };
-    if (this.#failed) {
-      throw integrityError('Canonical tree digest builder previously rejected an entry');
+  finish(): void {
+    if (this.#finished) return;
+    if (this.#failed)
+      throw integrityError('Canonical layout validator previously rejected an entry');
+    try {
+      if (this.#entryCount !== this.#expectedEntryCount) {
+        throw integrityError('Canonical tree entry count does not match the declared count');
+      }
+      if (!this.#sawStateIdentity || !this.#sawStateRoot || !this.#sawWorkspaceRoot) {
+        throw integrityError('Canonical tree is missing a required V1 payload root');
+      }
+      this.#finished = true;
+    } catch (error) {
+      this.#failed = true;
+      throw error;
     }
-    if (this.#entryCount !== this.#expectedEntryCount) {
-      throw integrityError('Canonical tree entry count does not match the declared count');
-    }
-    if (!this.#sawStateIdentity || !this.#sawStateRoot || !this.#sawWorkspaceRoot) {
-      throw integrityError('Canonical tree is missing a required V1 payload root');
-    }
-    this.#result = Object.freeze({
-      treeDigest: `sha256:${this.#hash.digest('hex')}` as Sha256Digest,
-      payloadBytes: this.#payloadBytes,
-      entryCount: this.#entryCount,
-    });
-    return { ...this.#result };
   }
 }
 
@@ -248,6 +305,21 @@ function validateEntry(value: unknown): ValidatedCanonicalTreeEntry {
   };
 }
 
+function validateLayoutEntry(value: unknown): SessionBundleCanonicalLayoutEntry {
+  if (!isRecord(value) || typeof value.path !== 'string') {
+    throw unsupportedEntry('Canonical layout entry has an invalid shape');
+  }
+  if (value.kind === 'directory') return { kind: 'directory', path: value.path };
+  if (
+    value.kind === 'file' &&
+    typeof value.mode === 'number' &&
+    REGULAR_FILE_MODES.has(value.mode)
+  ) {
+    return { kind: 'file', path: value.path, mode: value.mode as 0o644 | 0o755 };
+  }
+  throw unsupportedEntry('Canonical layout entry has unsupported metadata');
+}
+
 function validateCanonicalPath(
   path: string,
   kind: SessionBundleCanonicalTreeEntry['kind'],
@@ -291,7 +363,7 @@ function validateCanonicalPath(
 }
 
 function classifyPayloadPath(
-  entry: SessionBundleCanonicalTreeEntry,
+  entry: SessionBundleCanonicalLayoutEntry,
 ): 'state_identity' | 'state_root' | 'workspace_root' | 'payload' {
   if (entry.path === SESSION_BUNDLE_STATE_IDENTITY_PATH) {
     if (entry.kind !== 'file' || entry.mode !== 0o644) {

--- a/packages/storage/src/session-bundle-contract.ts
+++ b/packages/storage/src/session-bundle-contract.ts
@@ -6,6 +6,11 @@
  * Artifact schemas. State preparation and semantic identity validation happen
  * before this codec is called; state migration and re-keying happen after
  * hydration in the state-owning layer.
+ *
+ * V1 archive paths intentionally use a host-independent portability subset.
+ * Every segment rejects ASCII control characters, `<`, `>`, `:`, `"`, `|`,
+ * `?`, `*`, trailing dots/spaces, and case-insensitive Windows device names
+ * such as `CON`, `NUL`, `COM1`, and `LPT1`, even when encoding on POSIX.
  */
 
 export const SESSION_BUNDLE_SCHEMA_VERSION = 1 as const;
@@ -151,6 +156,11 @@ export interface SessionBundleHydrateInput extends SessionBundleReadInput {
   destinationRoot: string;
 }
 
+export interface SessionBundleHydrationCleanupInput {
+  /** Cleanup is restricted to codec-owned staging for this exact target. */
+  destinationRoot: string;
+}
+
 export interface SessionBundleManifestV1 {
   schemaVersion: 1;
   codec: {
@@ -200,10 +210,19 @@ export interface SessionBundleHydration extends SessionBundleInspection {
   workspaceRoot: string;
 }
 
+export interface SessionBundleHydrationCleanupResult {
+  destinationRoot: string;
+  removedStagingDirectories: number;
+  removedOwnershipRecords: number;
+}
+
 export interface SessionBundleFileService {
   pack(input: SessionBundlePackInput): Promise<SessionBundleArtifact>;
   inspect(input: SessionBundleReadInput): Promise<SessionBundleInspection>;
   hydrate(input: SessionBundleHydrateInput): Promise<SessionBundleHydration>;
+  cleanupHydrationStaging(
+    input: SessionBundleHydrationCleanupInput,
+  ): Promise<SessionBundleHydrationCleanupResult>;
 }
 
 export type SessionBundleFileErrorCode =
@@ -219,7 +238,7 @@ export type SessionBundleFileErrorCode =
   | 'source_changed'
   | 'io_failure';
 
-export type SessionBundleFileOperation = 'pack' | 'inspect' | 'hydrate';
+export type SessionBundleFileOperation = 'pack' | 'inspect' | 'hydrate' | 'cleanup';
 
 /**
  * Bounded diagnostic facts only. Raw attacker-controlled paths and strings do

--- a/packages/storage/src/session-bundle-file-service.ts
+++ b/packages/storage/src/session-bundle-file-service.ts
@@ -69,8 +69,8 @@ import {
   sessionBundleUstarPaddingBytes,
   type SessionBundleUstarHeader,
 } from './session-bundle-ustar.js';
+import { syncDirectory } from './stable-storage.js';
 
-const ZERO_BLOCK = Buffer.alloc(SESSION_BUNDLE_USTAR_BLOCK_BYTES);
 const ARCHIVE_TERMINATOR = Buffer.alloc(SESSION_BUNDLE_USTAR_BLOCK_BYTES * 2);
 const HYDRATION_STAGING_MARKER = '.maka-session-bundle-staging-';
 const PACK_TEMP_MARKER = '.maka-session-bundle-pack-';
@@ -201,9 +201,13 @@ export class NodeSessionBundleFileService implements SessionBundleFileService {
             'Session bundle hydration staging root changed before publication',
           );
         }
+        // Codec participants serialize this check/rename gap with the publication lock.
+        // A non-cooperating writer can still create an empty destination here because
+        // Node does not expose rename-without-replacement for directories.
         await rename(publicationStagingRoot, validated.destinationRoot);
+        published = true;
+        await syncDirectory(parent);
       });
-      published = true;
       return {
         ...inspectionFromReadResult(result),
         destinationRoot: validated.destinationRoot,
@@ -370,6 +374,7 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
       compressedMeter.bytes,
       publicationState,
     );
+    await syncDirectory(parent);
     published = true;
     return {
       path: validated.destination,
@@ -1130,7 +1135,11 @@ class OpenFileHandleWritable extends Writable {
   }
 }
 
-/** Remove the empty frame Node's streaming compressor appends after multi-chunk input. */
+/**
+ * Node 24/26's bundled encoder appends this empty frame after multi-chunk input.
+ * This is undocumented: if Node stops appending it, `_flush` emits the retained
+ * tail unchanged; any other encoder drift fails the golden archive test.
+ */
 class CanonicalZstdOutputTransform extends Transform {
   #tail = Buffer.alloc(0);
 

--- a/packages/storage/src/session-bundle-file-service.ts
+++ b/packages/storage/src/session-bundle-file-service.ts
@@ -10,6 +10,7 @@ import {
   readdir,
   rename,
   rm,
+  rmdir,
   stat,
   type FileHandle,
 } from 'node:fs/promises';
@@ -78,8 +79,10 @@ const HYDRATION_STAGING_MARKER = '.maka-session-bundle-staging-';
 const HYDRATION_OWNERSHIP_SUFFIX = '.owner.json';
 const HYDRATION_OWNERSHIP_KIND = 'maka-session-bundle-hydration-staging' as const;
 const HYDRATION_OWNERSHIP_MAX_BYTES = 2 * 1024;
+const HYDRATION_CLEANUP_SUFFIX = '.cleanup';
 const HYDRATION_TOKEN_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const FILESYSTEM_ID_PATTERN = /^(0|[1-9][0-9]*)$/;
 const PACK_TEMP_MARKER = '.maka-session-bundle-pack-';
 const PUBLICATION_LOCK_MARKER = '.maka-session-bundle-publish-';
 const PACK_FILE_CHUNK_BYTES = 64 * 1024;
@@ -88,9 +91,12 @@ const SESSION_BUNDLE_ZSTD_WINDOW_DESCRIPTOR = 0x58;
 const NODE_ZSTD_TRAILING_EMPTY_FRAME = Buffer.from('28b52ffd040001000099e9d851', 'hex');
 const publicationLockGates = new Map<string, Promise<void>>();
 
-interface FileFingerprint {
+interface FilesystemNodeIdentity {
   dev: bigint;
   ino: bigint;
+}
+
+interface FileFingerprint extends FilesystemNodeIdentity {
   nlink: bigint;
   size: bigint;
   mtimeNs: bigint;
@@ -114,7 +120,14 @@ interface HydrationStagingOwnershipV1 {
   destinationName: string;
   stagingName: string;
   token: string;
+  stagingDev: string;
+  stagingIno: string;
 }
+
+type HydrationStagingOwnershipReservationV1 = Omit<
+  HydrationStagingOwnershipV1,
+  'stagingDev' | 'stagingIno'
+>;
 
 interface PackDirectoryEntry {
   canonical: Extract<SessionBundleCanonicalTreeEntry, { kind: 'directory' }>;
@@ -1543,28 +1556,29 @@ async function publishPackFileNoReplace(
     throw error;
   }
 
+  // Establish cleanup ownership from the path that link() published before any
+  // lookup of the mutable temporary pathname can fail. The final cleanup still
+  // verifies this inode binding before removing the destination.
+  const linkedMetadata = await lstat(destination, { bigint: true });
+  if (linkedMetadata.isFile() && !linkedMetadata.isSymbolicLink()) {
+    state.linkedFingerprint = fingerprint(linkedMetadata);
+  }
   const [beforeHandle, beforeTemporary, beforeDestination] = await Promise.all([
     handle.stat({ bigint: true }),
     lstat(temporaryPath, { bigint: true }),
     lstat(destination, { bigint: true }),
   ]);
   const verificationFingerprint = fingerprint(beforeHandle);
-  const linkedFingerprint = fingerprint(beforeDestination);
-  if (
-    beforeTemporary.isFile() &&
-    beforeDestination.isFile() &&
-    !beforeTemporary.isSymbolicLink() &&
-    !beforeDestination.isSymbolicLink() &&
-    sameFilesystemNode(fingerprint(beforeTemporary), linkedFingerprint)
-  ) {
-    // Cleanup must follow the inode this link() actually published, even when
-    // the mutable temporary pathname was swapped after its binding check.
-    state.linkedFingerprint = linkedFingerprint;
-  }
   if (
     !beforeHandle.isFile() ||
+    !beforeTemporary.isFile() ||
     !beforeDestination.isFile() ||
+    beforeTemporary.isSymbolicLink() ||
+    beforeDestination.isSymbolicLink() ||
     beforeHandle.size !== BigInt(expectedBytes) ||
+    state.linkedFingerprint === undefined ||
+    !sameFilesystemNode(state.linkedFingerprint, fingerprint(beforeDestination)) ||
+    !sameFilesystemNode(fingerprint(beforeTemporary), fingerprint(beforeDestination)) ||
     !sameFilesystemNode(hashedFingerprint, verificationFingerprint) ||
     !sameFingerprint(verificationFingerprint, fingerprint(beforeDestination))
   ) {
@@ -1710,6 +1724,21 @@ async function writeAll(
   }
 }
 
+async function replaceOpenFileContents(
+  handle: FileHandle,
+  contents: Buffer,
+  operation: 'pack' | 'hydrate',
+): Promise<void> {
+  await handle.truncate(0);
+  let offset = 0;
+  while (offset < contents.byteLength) {
+    const result = await handle.write(contents, offset, contents.byteLength - offset, offset);
+    if (result.bytesWritten <= 0) throw ioError(operation);
+    offset += result.bytesWritten;
+  }
+  await handle.sync();
+}
+
 async function createHydrationStaging(
   destinationRoot: string,
   parentMetadata: BigIntStats,
@@ -1721,7 +1750,7 @@ async function createHydrationStaging(
   const stagingName = `${prefix}${token}`;
   const stagingRoot = join(parent, stagingName);
   const ownershipPath = `${stagingRoot}${HYDRATION_OWNERSHIP_SUFFIX}`;
-  const ownership = encodeHydrationStagingOwnership({
+  const reservation = encodeHydrationStagingOwnershipReservation({
     schemaVersion: 1,
     kind: HYDRATION_OWNERSHIP_KIND,
     destinationName,
@@ -1729,15 +1758,24 @@ async function createHydrationStaging(
     token,
   });
   let ownershipHandle: FileHandle | undefined;
+  let createdOwnershipFingerprint: FileFingerprint | undefined;
+  let stagingFingerprint: FileFingerprint | undefined;
+  let initialized = false;
   try {
     ownershipHandle = await open(ownershipPath, 'wx', 0o600);
-    await writeAll(ownershipHandle, ownership, 'hydrate');
+    const createdOwnershipMetadata = await ownershipHandle.stat({
+      bigint: true,
+    });
+    if (
+      !createdOwnershipMetadata.isFile() ||
+      createdOwnershipMetadata.nlink !== 1n ||
+      createdOwnershipMetadata.size !== 0n
+    ) {
+      throw ioError('hydrate');
+    }
+    createdOwnershipFingerprint = fingerprint(createdOwnershipMetadata);
+    await writeAll(ownershipHandle, reservation, 'hydrate');
     await ownershipHandle.sync();
-    const ownershipMetadata = await ownershipHandle.stat({ bigint: true });
-    if (!ownershipMetadata.isFile() || ownershipMetadata.nlink !== 1n) throw ioError('hydrate');
-    const ownershipFingerprint = fingerprint(ownershipMetadata);
-    await ownershipHandle.close();
-    ownershipHandle = undefined;
     await syncDirectory(parent);
 
     await mkdir(stagingRoot, { mode: 0o700 });
@@ -1750,15 +1788,54 @@ async function createHydrationStaging(
     ) {
       throw ioError('hydrate');
     }
+    stagingFingerprint = fingerprint(stagingMetadata);
     await syncDirectory(parent);
+
+    const ownership = encodeHydrationStagingOwnership({
+      schemaVersion: 1,
+      kind: HYDRATION_OWNERSHIP_KIND,
+      destinationName,
+      stagingName,
+      token,
+      stagingDev: stagingMetadata.dev.toString(),
+      stagingIno: stagingMetadata.ino.toString(),
+    });
+    await replaceOpenFileContents(ownershipHandle, ownership, 'hydrate');
+    const [ownershipMetadata, ownershipPathMetadata] = await Promise.all([
+      ownershipHandle.stat({ bigint: true }),
+      lstat(ownershipPath, { bigint: true }),
+    ]);
+    if (
+      !ownershipMetadata.isFile() ||
+      !ownershipPathMetadata.isFile() ||
+      ownershipPathMetadata.isSymbolicLink() ||
+      ownershipMetadata.nlink !== 1n ||
+      !sameFilesystemNode(createdOwnershipFingerprint, fingerprint(ownershipMetadata)) ||
+      !sameFingerprint(fingerprint(ownershipMetadata), fingerprint(ownershipPathMetadata))
+    ) {
+      throw ioError('hydrate');
+    }
+    const ownershipFingerprint = fingerprint(ownershipMetadata);
+    await ownershipHandle.close();
+    ownershipHandle = undefined;
+    initialized = true;
     return {
       stagingRoot,
-      stagingFingerprint: fingerprint(stagingMetadata),
+      stagingFingerprint,
       ownershipPath,
       ownershipFingerprint,
     };
   } finally {
     await ownershipHandle?.close().catch(() => {});
+    if (!initialized) {
+      if (stagingFingerprint !== undefined) {
+        await removeOwnedDirectory(stagingRoot, parent, stagingFingerprint).catch(() => {});
+      }
+      if (createdOwnershipFingerprint !== undefined) {
+        await removeOwnedPackFile(ownershipPath, createdOwnershipFingerprint).catch(() => {});
+      }
+      await syncDirectory(parent).catch(() => {});
+    }
   }
 }
 
@@ -1789,40 +1866,32 @@ async function cleanupHydrationStagingForDestination(
       ownershipName,
     );
     if (owned === undefined) continue;
-    const stagingMetadata = await lstat(owned.stagingRoot, { bigint: true }).catch(
-      (error: unknown) => {
-        if (isErrno(error, 'ENOENT')) return undefined;
-        throw error;
-      },
-    );
-    if (stagingMetadata === undefined) {
+    if (await removeOwnedDirectory(owned.stagingRoot, parent, owned.stagingIdentity)) {
+      removedStagingDirectories += 1;
+      changed = true;
       if (await removeOwnedPackFile(owned.ownershipPath, owned.ownershipFingerprint)) {
         removedOwnershipRecords += 1;
-        changed = true;
       }
       continue;
     }
+
+    const [stagingMetadata, quarantineMetadata] = await Promise.all([
+      lstat(owned.stagingRoot).catch((error: unknown) => {
+        if (isErrno(error, 'ENOENT')) return undefined;
+        throw error;
+      }),
+      lstat(hydrationCleanupRoot(owned.stagingRoot)).catch((error: unknown) => {
+        if (isErrno(error, 'ENOENT')) return undefined;
+        throw error;
+      }),
+    ]);
     if (
-      !stagingMetadata.isDirectory() ||
-      stagingMetadata.isSymbolicLink() ||
-      stagingMetadata.dev !== parentMetadata.dev
+      stagingMetadata === undefined &&
+      quarantineMetadata === undefined &&
+      (await removeOwnedPackFile(owned.ownershipPath, owned.ownershipFingerprint))
     ) {
-      continue;
-    }
-    const expectedStaging = fingerprint(stagingMetadata);
-    const currentStaging = await lstat(owned.stagingRoot, { bigint: true });
-    if (
-      !currentStaging.isDirectory() ||
-      currentStaging.isSymbolicLink() ||
-      !sameFingerprint(expectedStaging, fingerprint(currentStaging))
-    ) {
-      continue;
-    }
-    await rm(owned.stagingRoot, { recursive: true });
-    removedStagingDirectories += 1;
-    changed = true;
-    if (await removeOwnedPackFile(owned.ownershipPath, owned.ownershipFingerprint)) {
       removedOwnershipRecords += 1;
+      changed = true;
     }
   }
   if (changed) await syncDirectory(parent);
@@ -1837,6 +1906,7 @@ async function readHydrationStagingOwnership(
 ): Promise<
   | {
       stagingRoot: string;
+      stagingIdentity: FilesystemNodeIdentity;
       ownershipPath: string;
       ownershipFingerprint: FileFingerprint;
     }
@@ -1882,6 +1952,10 @@ async function readHydrationStagingOwnership(
     }
     return {
       stagingRoot: join(parent, ownership.stagingName),
+      stagingIdentity: {
+        dev: BigInt(ownership.stagingDev),
+        ino: BigInt(ownership.stagingIno),
+      },
       ownershipPath,
       ownershipFingerprint,
     };
@@ -1894,6 +1968,12 @@ function encodeHydrationStagingOwnership(value: HydrationStagingOwnershipV1): Bu
   return Buffer.from(`${JSON.stringify(value)}\n`, 'utf8');
 }
 
+function encodeHydrationStagingOwnershipReservation(
+  value: HydrationStagingOwnershipReservationV1,
+): Buffer {
+  return Buffer.from(`${JSON.stringify(value)}\n`, 'utf8');
+}
+
 function decodeHydrationStagingOwnership(value: Buffer): HydrationStagingOwnershipV1 | undefined {
   let decoded: unknown;
   try {
@@ -1903,13 +1983,17 @@ function decodeHydrationStagingOwnership(value: Buffer): HydrationStagingOwnersh
   }
   if (
     !isRecord(decoded) ||
-    Object.keys(decoded).length !== 5 ||
+    Object.keys(decoded).length !== 7 ||
     decoded.schemaVersion !== 1 ||
     decoded.kind !== HYDRATION_OWNERSHIP_KIND ||
     typeof decoded.destinationName !== 'string' ||
     typeof decoded.stagingName !== 'string' ||
     typeof decoded.token !== 'string' ||
-    !HYDRATION_TOKEN_PATTERN.test(decoded.token)
+    !HYDRATION_TOKEN_PATTERN.test(decoded.token) ||
+    typeof decoded.stagingDev !== 'string' ||
+    !FILESYSTEM_ID_PATTERN.test(decoded.stagingDev) ||
+    typeof decoded.stagingIno !== 'string' ||
+    !FILESYSTEM_ID_PATTERN.test(decoded.stagingIno)
   ) {
     return undefined;
   }
@@ -1919,6 +2003,8 @@ function decodeHydrationStagingOwnership(value: Buffer): HydrationStagingOwnersh
     destinationName: decoded.destinationName,
     stagingName: decoded.stagingName,
     token: decoded.token,
+    stagingDev: decoded.stagingDev,
+    stagingIno: decoded.stagingIno,
   };
   return encodeHydrationStagingOwnership(ownership).equals(value) ? ownership : undefined;
 }
@@ -1937,6 +2023,101 @@ async function readBoundedFileHandle(
   return offset > maxBytes ? undefined : buffer.subarray(0, offset);
 }
 
+async function removeOwnedDirectory(
+  path: string,
+  parent: string,
+  expectedIdentity: FilesystemNodeIdentity,
+): Promise<boolean> {
+  if (dirname(path) !== parent) return false;
+  const quarantineRoot = hydrationCleanupRoot(path);
+  const quarantinedPath = join(quarantineRoot, 'staging');
+  const existingQuarantined = await lstat(quarantinedPath, {
+    bigint: true,
+  }).catch((error: unknown) => {
+    if (isErrno(error, 'ENOENT') || isErrno(error, 'ENOTDIR')) return undefined;
+    throw error;
+  });
+  if (existingQuarantined !== undefined) {
+    if (
+      !existingQuarantined.isDirectory() ||
+      existingQuarantined.isSymbolicLink() ||
+      !sameFilesystemNode(expectedIdentity, fingerprint(existingQuarantined))
+    ) {
+      return false;
+    }
+    await rm(quarantinedPath, { recursive: true });
+    await rmdir(quarantineRoot).catch(() => {});
+    return true;
+  }
+  try {
+    await rmdir(quarantineRoot);
+  } catch (error) {
+    if (!isErrno(error, 'ENOENT')) return false;
+  }
+
+  const initial = await lstat(path, { bigint: true }).catch((error: unknown) => {
+    if (isErrno(error, 'ENOENT')) return undefined;
+    throw error;
+  });
+  if (
+    initial === undefined ||
+    !initial.isDirectory() ||
+    initial.isSymbolicLink() ||
+    !sameFilesystemNode(expectedIdentity, fingerprint(initial))
+  ) {
+    return false;
+  }
+
+  // Recursive removal is path-based in Node. Move the candidate into a fresh,
+  // destination-owned quarantine first, then verify the moved inode. Its name
+  // is derivable from the ownership record so a crash during cleanup can resume.
+  let quarantined = false;
+  try {
+    await mkdir(quarantineRoot, { mode: 0o700 });
+  } catch (error) {
+    if (isErrno(error, 'EEXIST')) return false;
+    throw error;
+  }
+  try {
+    const current = await lstat(path, { bigint: true }).catch((error: unknown) => {
+      if (isErrno(error, 'ENOENT')) return undefined;
+      throw error;
+    });
+    if (
+      current === undefined ||
+      !current.isDirectory() ||
+      current.isSymbolicLink() ||
+      !sameFilesystemNode(expectedIdentity, fingerprint(current))
+    ) {
+      return false;
+    }
+    try {
+      await rename(path, quarantinedPath);
+    } catch (error) {
+      if (isErrno(error, 'ENOENT')) return false;
+      throw error;
+    }
+    quarantined = true;
+    const moved = await lstat(quarantinedPath, { bigint: true });
+    if (
+      !moved.isDirectory() ||
+      moved.isSymbolicLink() ||
+      !sameFilesystemNode(expectedIdentity, fingerprint(moved))
+    ) {
+      return false;
+    }
+    await rm(quarantinedPath, { recursive: true });
+    quarantined = false;
+    return true;
+  } finally {
+    if (!quarantined) await rmdir(quarantineRoot).catch(() => {});
+  }
+}
+
+function hydrationCleanupRoot(stagingRoot: string): string {
+  return `${stagingRoot}${HYDRATION_CLEANUP_SUFFIX}`;
+}
+
 async function removeOwnedHydrationStaging(
   staging: HydrationStagingBinding,
   parent: string,
@@ -1951,18 +2132,7 @@ async function removeOwnedHydrationStaging(
   ) {
     return;
   }
-  const metadata = await lstat(staging.stagingRoot, { bigint: true }).catch((error: unknown) => {
-    if (isErrno(error, 'ENOENT')) return undefined;
-    throw error;
-  });
-  if (
-    metadata !== undefined &&
-    metadata.isDirectory() &&
-    !metadata.isSymbolicLink() &&
-    sameFilesystemNode(staging.stagingFingerprint, fingerprint(metadata))
-  ) {
-    await rm(staging.stagingRoot, { recursive: true });
-  }
+  await removeOwnedDirectory(staging.stagingRoot, parent, staging.stagingFingerprint);
   await removeOwnedPackFile(staging.ownershipPath, staging.ownershipFingerprint);
   await syncDirectory(parent);
 }
@@ -2036,7 +2206,7 @@ function sameFingerprint(left: FileFingerprint, right: FileFingerprint): boolean
   );
 }
 
-function sameFilesystemNode(left: FileFingerprint, right: FileFingerprint): boolean {
+function sameFilesystemNode(left: FilesystemNodeIdentity, right: FilesystemNodeIdentity): boolean {
   return left.dev === right.dev && left.ino === right.ino;
 }
 

--- a/packages/storage/src/session-bundle-file-service.ts
+++ b/packages/storage/src/session-bundle-file-service.ts
@@ -1,0 +1,1567 @@
+import { Buffer } from 'node:buffer';
+import { createHash, randomUUID, type Hash } from 'node:crypto';
+import { constants as fsConstants, type BigIntStats } from 'node:fs';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readdir,
+  rename,
+  rm,
+  stat,
+  type FileHandle,
+} from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+import { PassThrough, Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { constants as zlibConstants, createZstdCompress, createZstdDecompress } from 'node:zlib';
+import {
+  compareSessionBundleCanonicalPaths,
+  computeSessionBundleCanonicalTreeDigest,
+  SessionBundleCanonicalTreeDigestBuilder,
+  type SessionBundleCanonicalTreeEntry,
+} from './session-bundle-canonical-tree.js';
+import {
+  assertSessionBundleLimits,
+  copyOpaqueStateIdentityDescriptor,
+  isNonEmptyUnicodeString,
+  isSha256Digest,
+  isValidUnicodeString,
+  SESSION_BUNDLE_ARCHIVE_FORMAT,
+  SESSION_BUNDLE_CANONICALIZATION_VERSION,
+  SESSION_BUNDLE_CODEC_NAME,
+  SESSION_BUNDLE_CODEC_VERSION,
+  SESSION_BUNDLE_COMPRESSION_FORMAT,
+  SESSION_BUNDLE_COMPRESSION_LEVEL,
+  SESSION_BUNDLE_MANIFEST_PATH,
+  SESSION_BUNDLE_SCHEMA_VERSION,
+  SESSION_BUNDLE_STATE_IDENTITY_PATH,
+  SESSION_BUNDLE_STATE_PATH,
+  SESSION_BUNDLE_WORKSPACE_PATH,
+  SessionBundleFileError,
+  type OpaqueStateIdentityDescriptor,
+  type SessionBundleArtifact,
+  type SessionBundleFileOperation,
+  type SessionBundleFileService,
+  type SessionBundleHydrateInput,
+  type SessionBundleHydration,
+  type SessionBundleInspection,
+  type SessionBundleLimits,
+  type SessionBundleManifestV1,
+  type SessionBundlePackInput,
+  type SessionBundleQuotaName,
+  type SessionBundleReadInput,
+  type Sha256Digest,
+} from './session-bundle-contract.js';
+import {
+  decodeSessionBundleManifestV1,
+  encodeSessionBundleManifestV1,
+} from './session-bundle-manifest.js';
+import {
+  decodeSessionBundleUstarHeaderV1,
+  encodeSessionBundleUstarHeaderV1,
+  isSessionBundleUstarZeroBlock,
+  SESSION_BUNDLE_USTAR_BLOCK_BYTES,
+  sessionBundleUstarPaddingBytes,
+  type SessionBundleUstarHeader,
+} from './session-bundle-ustar.js';
+
+const ZERO_BLOCK = Buffer.alloc(SESSION_BUNDLE_USTAR_BLOCK_BYTES);
+const ARCHIVE_TERMINATOR = Buffer.alloc(SESSION_BUNDLE_USTAR_BLOCK_BYTES * 2);
+const HYDRATION_STAGING_MARKER = '.maka-session-bundle-staging-';
+const PACK_TEMP_MARKER = '.maka-session-bundle-pack-';
+const PACK_FILE_CHUNK_BYTES = 64 * 1024;
+
+interface FileFingerprint {
+  dev: bigint;
+  ino: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+}
+
+interface PackDirectoryEntry {
+  canonical: Extract<SessionBundleCanonicalTreeEntry, { kind: 'directory' }>;
+  fingerprint: FileFingerprint;
+  sourcePath: string;
+}
+
+interface PackDiskFileEntry {
+  canonical: Extract<SessionBundleCanonicalTreeEntry, { kind: 'file' }>;
+  fingerprint: FileFingerprint;
+  sourcePath: string;
+}
+
+interface PackMemoryFileEntry {
+  canonical: Extract<SessionBundleCanonicalTreeEntry, { kind: 'file' }>;
+  bytes: Buffer;
+}
+
+type PackEntry = PackDirectoryEntry | PackDiskFileEntry | PackMemoryFileEntry;
+
+interface PackScanBudget {
+  payloadBytes: number;
+}
+
+interface ReadValidationResult extends SessionBundleInspection {
+  decompressedTarBytes: number;
+}
+
+interface ParsedTarResult {
+  manifest: SessionBundleManifestV1;
+  stateIdentity: OpaqueStateIdentityDescriptor;
+}
+
+interface ArchiveLayoutState {
+  directories: Set<string>;
+  logicalPaths: Set<string>;
+  previousPath?: string;
+}
+
+export function createSessionBundleFileService(): SessionBundleFileService {
+  return new NodeSessionBundleFileService();
+}
+
+export class NodeSessionBundleFileService implements SessionBundleFileService {
+  async pack(input: SessionBundlePackInput): Promise<SessionBundleArtifact> {
+    try {
+      return await packSessionBundle(input);
+    } catch (error) {
+      throw normalizeOperationError(error, 'pack');
+    }
+  }
+
+  async inspect(input: SessionBundleReadInput): Promise<SessionBundleInspection> {
+    const validated = validateReadInput(input);
+    try {
+      const result = await readAndValidateSessionBundle({
+        ...validated,
+        operation: 'inspect',
+      });
+      return inspectionFromReadResult(result);
+    } catch (error) {
+      throw normalizeOperationError(error, 'inspect');
+    }
+  }
+
+  async hydrate(input: SessionBundleHydrateInput): Promise<SessionBundleHydration> {
+    const validated = validateHydrateInput(input);
+    const parent = dirname(validated.destinationRoot);
+    const prefix = `.${basename(validated.destinationRoot)}${HYDRATION_STAGING_MARKER}`;
+    let stagingRoot: string | undefined;
+    let stagingFingerprint: FileFingerprint | undefined;
+    let published = false;
+
+    try {
+      await assertDestinationMissing(validated.destinationRoot, 'hydrate');
+      const parentMetadata = await stat(parent, { bigint: true });
+      if (!parentMetadata.isDirectory()) throw ioError('hydrate');
+      stagingRoot = await mkdtemp(join(parent, prefix));
+      await chmod(stagingRoot, 0o700);
+      const stagingMetadata = await lstat(stagingRoot, { bigint: true });
+      if (!stagingMetadata.isDirectory() || stagingMetadata.dev !== parentMetadata.dev) {
+        throw ioError('hydrate');
+      }
+      stagingFingerprint = fingerprint(stagingMetadata);
+
+      const result = await readAndValidateSessionBundle({
+        sourcePath: validated.sourcePath,
+        expectedArchiveDigest: validated.expectedArchiveDigest,
+        limits: validated.limits,
+        operation: 'hydrate',
+        expectedSessionId: validated.expectedSessionId,
+        stagingRoot,
+      });
+
+      await assertDestinationMissing(validated.destinationRoot, 'hydrate');
+      const currentStaging = await lstat(stagingRoot, { bigint: true });
+      if (
+        !currentStaging.isDirectory() ||
+        !sameFilesystemNode(stagingFingerprint, fingerprint(currentStaging))
+      ) {
+        throw new SessionBundleFileError(
+          'source_changed',
+          'Session bundle hydration staging root changed before publication',
+        );
+      }
+      await rename(stagingRoot, validated.destinationRoot);
+      published = true;
+      return {
+        ...inspectionFromReadResult(result),
+        destinationRoot: validated.destinationRoot,
+        stateRoot: join(validated.destinationRoot, 'state'),
+        workspaceRoot: join(validated.destinationRoot, 'workspace'),
+      };
+    } catch (error) {
+      throw normalizeOperationError(error, 'hydrate');
+    } finally {
+      if (!published && stagingRoot !== undefined) {
+        await removeOwnedHydrationStaging(stagingRoot, parent, prefix, stagingFingerprint).catch(
+          () => {},
+        );
+      }
+    }
+  }
+}
+
+async function packSessionBundle(input: SessionBundlePackInput): Promise<SessionBundleArtifact> {
+  const validated = validatePackInput(input);
+  await assertDestinationMissing(validated.destination, 'pack');
+  assertQuota(
+    'pack',
+    validated.limits,
+    'maxPathBytes',
+    Buffer.byteLength(SESSION_BUNDLE_MANIFEST_PATH),
+  );
+  assertQuota('pack', validated.limits, 'maxPathDepth', 1);
+  assertPathQuota('pack', validated.limits, SESSION_BUNDLE_STATE_IDENTITY_PATH);
+
+  const identityBytes = Buffer.from(validated.stateIdentity.bytes);
+  assertQuota('pack', validated.limits, 'maxStateIdentityBytes', identityBytes.byteLength);
+  assertQuota('pack', validated.limits, 'maxFileBytes', identityBytes.byteLength);
+  const entries: PackEntry[] = [
+    {
+      canonical: {
+        kind: 'file',
+        path: SESSION_BUNDLE_STATE_IDENTITY_PATH,
+        mode: 0o644,
+        size: identityBytes.byteLength,
+        contentDigest: digestBytes(identityBytes),
+      },
+      bytes: identityBytes,
+    },
+  ];
+  const budget: PackScanBudget = { payloadBytes: identityBytes.byteLength };
+  assertQuota('pack', validated.limits, 'maxEntryCount', entries.length);
+  assertQuota('pack', validated.limits, 'maxPayloadBytes', budget.payloadBytes);
+
+  await scanPackRoot(
+    validated.stateRoot,
+    SESSION_BUNDLE_STATE_PATH,
+    entries,
+    budget,
+    validated.limits,
+  );
+  await scanPackRoot(
+    validated.workspaceRoot,
+    SESSION_BUNDLE_WORKSPACE_PATH,
+    entries,
+    budget,
+    validated.limits,
+  );
+  entries.sort((left, right) =>
+    compareSessionBundleCanonicalPaths(left.canonical.path, right.canonical.path),
+  );
+  assertQuota('pack', validated.limits, 'maxEntryCount', entries.length);
+
+  const tree = computeSessionBundleCanonicalTreeDigest(entries.map((entry) => entry.canonical));
+  assertQuota('pack', validated.limits, 'maxPayloadBytes', tree.payloadBytes);
+  const manifest: SessionBundleManifestV1 = {
+    schemaVersion: SESSION_BUNDLE_SCHEMA_VERSION,
+    codec: {
+      name: SESSION_BUNDLE_CODEC_NAME,
+      version: SESSION_BUNDLE_CODEC_VERSION,
+      canonicalizationVersion: SESSION_BUNDLE_CANONICALIZATION_VERSION,
+      archive: SESSION_BUNDLE_ARCHIVE_FORMAT,
+      compression: SESSION_BUNDLE_COMPRESSION_FORMAT,
+      compressionLevel: SESSION_BUNDLE_COMPRESSION_LEVEL,
+    },
+    envelope: validated.envelope,
+    stateIdentity: {
+      path: SESSION_BUNDLE_STATE_IDENTITY_PATH,
+      mediaType: validated.stateIdentity.mediaType,
+    },
+    payload: {
+      statePath: SESSION_BUNDLE_STATE_PATH,
+      workspacePath: SESSION_BUNDLE_WORKSPACE_PATH,
+      treeDigest: tree.treeDigest,
+      payloadBytes: tree.payloadBytes,
+      entryCount: tree.entryCount,
+    },
+  };
+  const manifestBytes = Buffer.from(encodeSessionBundleManifestV1(manifest));
+  assertQuota('pack', validated.limits, 'maxManifestBytes', manifestBytes.byteLength);
+  const decompressedTarBytes = calculateTarBytes(manifestBytes.byteLength, entries);
+  assertQuota('pack', validated.limits, 'maxDecompressedTarBytes', decompressedTarBytes);
+
+  const parent = dirname(validated.destination);
+  const parentMetadata = await stat(parent, { bigint: true });
+  if (!parentMetadata.isDirectory()) throw ioError('pack');
+  const temporaryPath = join(
+    parent,
+    `.${basename(validated.destination)}${PACK_TEMP_MARKER}${randomUUID()}.tmp`,
+  );
+  let handle: FileHandle | undefined;
+  let published = false;
+  const archiveHash = createHash('sha256');
+  const compressedMeter = new HashingQuotaTransform(
+    archiveHash,
+    validated.limits,
+    'maxCompressedBytes',
+    'pack',
+  );
+  let generatedTarBytes = 0;
+  let output: ReturnType<FileHandle['createWriteStream']> | undefined;
+
+  try {
+    handle = await open(temporaryPath, 'wx', 0o600);
+    output = handle.createWriteStream({ autoClose: false, emitClose: false });
+    const tar = Readable.from(
+      meterGeneratedTar(generateSessionBundleTar(manifestBytes, entries), (bytes) => {
+        generatedTarBytes += bytes;
+      }),
+    );
+    await pipeline(tar, createSessionBundleZstdCompressor(), compressedMeter, output);
+    if (generatedTarBytes !== decompressedTarBytes) {
+      throw new SessionBundleFileError(
+        'integrity_mismatch',
+        'Session bundle USTAR byte count changed during pack',
+      );
+    }
+    await assertPackDirectoriesUnchanged(entries);
+    await handle.sync();
+    output.destroy();
+    output = undefined;
+    await handle.close();
+    handle = undefined;
+    await assertDestinationMissing(validated.destination, 'pack');
+    await rename(temporaryPath, validated.destination);
+    published = true;
+    return {
+      path: validated.destination,
+      archiveDigest: `sha256:${archiveHash.digest('hex')}` as Sha256Digest,
+      compressedBytes: compressedMeter.bytes,
+      decompressedTarBytes,
+      payloadBytes: tree.payloadBytes,
+      entryCount: tree.entryCount,
+    };
+  } finally {
+    output?.destroy();
+    await handle?.close().catch(() => {});
+    if (!published) await removeOwnedPackTemporary(temporaryPath, parent).catch(() => {});
+  }
+}
+
+async function scanPackRoot(
+  sourceRoot: string,
+  archiveRoot: 'state/' | 'workspace/',
+  entries: PackEntry[],
+  budget: PackScanBudget,
+  limits: SessionBundleLimits,
+): Promise<void> {
+  const metadata = await lstat(sourceRoot, { bigint: true });
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new SessionBundleFileError(
+      'unsupported_entry',
+      'Session bundle source root must be a real directory',
+    );
+  }
+  const rootFingerprint = fingerprint(metadata);
+  validatePackPath(archiveRoot, limits);
+  entries.push({
+    canonical: { kind: 'directory', path: archiveRoot },
+    sourcePath: sourceRoot,
+    fingerprint: rootFingerprint,
+  });
+  assertQuota('pack', limits, 'maxEntryCount', entries.length);
+  await scanPackDirectory(sourceRoot, archiveRoot, entries, budget, limits);
+  const after = await lstat(sourceRoot, { bigint: true });
+  if (!after.isDirectory() || !sameFingerprint(rootFingerprint, fingerprint(after))) {
+    throw sourceChanged();
+  }
+}
+
+async function scanPackDirectory(
+  sourceDirectory: string,
+  archiveDirectory: string,
+  entries: PackEntry[],
+  budget: PackScanBudget,
+  limits: SessionBundleLimits,
+): Promise<void> {
+  const children = await readdir(sourceDirectory, { encoding: 'buffer', withFileTypes: true });
+  for (const child of children) {
+    const childName = decodeFilesystemName(child.name);
+    const sourcePath = join(sourceDirectory, childName);
+    const metadata = await lstat(sourcePath, { bigint: true });
+    if (metadata.isSymbolicLink()) {
+      throw new SessionBundleFileError(
+        'unsupported_entry',
+        'Session bundle source contains a symbolic link',
+      );
+    }
+    if (metadata.isDirectory()) {
+      const path = `${archiveDirectory}${childName}/`;
+      validatePackPath(path, limits);
+      const directoryFingerprint = fingerprint(metadata);
+      entries.push({
+        canonical: { kind: 'directory', path },
+        sourcePath,
+        fingerprint: directoryFingerprint,
+      });
+      assertQuota('pack', limits, 'maxEntryCount', entries.length);
+      await scanPackDirectory(sourcePath, path, entries, budget, limits);
+      const after = await lstat(sourcePath, { bigint: true });
+      if (!after.isDirectory() || !sameFingerprint(directoryFingerprint, fingerprint(after))) {
+        throw sourceChanged();
+      }
+      continue;
+    }
+    if (!metadata.isFile()) {
+      throw new SessionBundleFileError(
+        'unsupported_entry',
+        'Session bundle source contains an unsupported filesystem entry',
+      );
+    }
+
+    const path = `${archiveDirectory}${childName}`;
+    validatePackPath(path, limits);
+    const size = safeBigIntSize(metadata.size);
+    budget.payloadBytes = safeAdd(budget.payloadBytes, size, 'quota_exceeded');
+    assertQuota('pack', limits, 'maxPayloadBytes', budget.payloadBytes);
+    encodeSessionBundleUstarHeaderV1({
+      kind: 'file',
+      path,
+      mode: hasExecutableBit(metadata.mode) ? 0o755 : 0o644,
+      size,
+    });
+    const file = await inspectPackFile(sourcePath, metadata, limits);
+    entries.push({
+      canonical: {
+        kind: 'file',
+        path,
+        mode: hasExecutableBit(metadata.mode) ? 0o755 : 0o644,
+        size: file.size,
+        contentDigest: file.contentDigest,
+      },
+      sourcePath,
+      fingerprint: file.fingerprint,
+    });
+    assertQuota('pack', limits, 'maxEntryCount', entries.length);
+  }
+}
+
+async function inspectPackFile(
+  sourcePath: string,
+  scannedMetadata: BigIntStats,
+  limits: SessionBundleLimits,
+): Promise<{ contentDigest: Sha256Digest; fingerprint: FileFingerprint; size: number }> {
+  const scannedFingerprint = fingerprint(scannedMetadata);
+  const size = safeBigIntSize(scannedMetadata.size);
+  assertQuota('pack', limits, 'maxFileBytes', size);
+  const handle = await openPackSourceFile(sourcePath);
+  try {
+    const before = await handle.stat({ bigint: true });
+    if (!before.isFile() || !sameFingerprint(scannedFingerprint, fingerprint(before))) {
+      throw sourceChanged();
+    }
+    const hash = createHash('sha256');
+    let observed = 0;
+    for await (const value of handle.createReadStream({
+      autoClose: false,
+      emitClose: false,
+      highWaterMark: PACK_FILE_CHUNK_BYTES,
+    })) {
+      const chunk = Buffer.from(value);
+      observed = safeAdd(observed, chunk.byteLength, 'source_changed');
+      assertQuota('pack', limits, 'maxFileBytes', observed);
+      hash.update(chunk);
+    }
+    const after = await handle.stat({ bigint: true });
+    if (
+      observed !== size ||
+      !after.isFile() ||
+      !sameFingerprint(scannedFingerprint, fingerprint(after))
+    ) {
+      throw sourceChanged();
+    }
+    return {
+      contentDigest: `sha256:${hash.digest('hex')}` as Sha256Digest,
+      fingerprint: scannedFingerprint,
+      size,
+    };
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
+async function* generateSessionBundleTar(
+  manifestBytes: Buffer,
+  entries: readonly PackEntry[],
+): AsyncGenerator<Buffer> {
+  yield Buffer.from(
+    encodeSessionBundleUstarHeaderV1({
+      kind: 'file',
+      path: SESSION_BUNDLE_MANIFEST_PATH,
+      mode: 0o644,
+      size: manifestBytes.byteLength,
+    }),
+  );
+  yield manifestBytes;
+  yield padding(manifestBytes.byteLength);
+
+  for (const entry of entries) {
+    yield Buffer.from(
+      encodeSessionBundleUstarHeaderV1({
+        kind: entry.canonical.kind,
+        path: entry.canonical.path,
+        mode: entry.canonical.kind === 'directory' ? 0o755 : entry.canonical.mode,
+        size: entry.canonical.kind === 'directory' ? 0 : entry.canonical.size,
+      }),
+    );
+    if (entry.canonical.kind === 'file') {
+      if ('bytes' in entry) {
+        yield entry.bytes;
+      } else if (isPackDiskFileEntry(entry)) {
+        yield* readVerifiedPackFile(entry);
+      } else {
+        throw new SessionBundleFileError(
+          'integrity_mismatch',
+          'Session bundle pack entry lost its source binding',
+        );
+      }
+      yield padding(entry.canonical.size);
+    }
+  }
+  yield ARCHIVE_TERMINATOR;
+}
+
+function isPackDiskFileEntry(entry: PackEntry): entry is PackDiskFileEntry {
+  return entry.canonical.kind === 'file' && 'sourcePath' in entry;
+}
+
+async function* readVerifiedPackFile(entry: PackDiskFileEntry): AsyncGenerator<Buffer> {
+  const handle = await openPackSourceFile(entry.sourcePath);
+  try {
+    const before = await handle.stat({ bigint: true });
+    if (!before.isFile() || !sameFingerprint(entry.fingerprint, fingerprint(before))) {
+      throw sourceChanged();
+    }
+    const hash = createHash('sha256');
+    let observed = 0;
+    for await (const value of handle.createReadStream({
+      autoClose: false,
+      emitClose: false,
+      highWaterMark: PACK_FILE_CHUNK_BYTES,
+    })) {
+      const chunk = Buffer.from(value);
+      observed = safeAdd(observed, chunk.byteLength, 'source_changed');
+      hash.update(chunk);
+      yield chunk;
+    }
+    const after = await handle.stat({ bigint: true });
+    const digest = `sha256:${hash.digest('hex')}`;
+    if (
+      observed !== entry.canonical.size ||
+      digest !== entry.canonical.contentDigest ||
+      !after.isFile() ||
+      !sameFingerprint(entry.fingerprint, fingerprint(after))
+    ) {
+      throw sourceChanged();
+    }
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
+async function assertPackDirectoriesUnchanged(entries: readonly PackEntry[]): Promise<void> {
+  for (const entry of entries) {
+    if (entry.canonical.kind !== 'directory' || !('sourcePath' in entry)) continue;
+    const metadata = await lstat(entry.sourcePath, { bigint: true });
+    if (!metadata.isDirectory() || !sameFingerprint(entry.fingerprint, fingerprint(metadata))) {
+      throw sourceChanged();
+    }
+  }
+}
+
+async function readAndValidateSessionBundle(input: {
+  sourcePath: string;
+  expectedArchiveDigest?: Sha256Digest;
+  limits: SessionBundleLimits;
+  operation: 'inspect' | 'hydrate';
+  expectedSessionId?: string;
+  stagingRoot?: string;
+}): Promise<ReadValidationResult> {
+  const handle = await open(input.sourcePath, 'r');
+  const archiveHash = createHash('sha256');
+  const compressedMeter = new HashingQuotaTransform(
+    archiveHash,
+    input.limits,
+    'maxCompressedBytes',
+    input.operation,
+  );
+  const decompressedMeter = new CountingQuotaTransform(
+    input.limits,
+    'maxDecompressedTarBytes',
+    input.operation,
+  );
+  const output = new PassThrough();
+  let pump: Promise<void> | undefined;
+  let source: ReturnType<FileHandle['createReadStream']> | undefined;
+  try {
+    const before = await handle.stat({ bigint: true });
+    if (!before.isFile()) throw ioError(input.operation);
+    const sourceFingerprint = fingerprint(before);
+    const sourceBytes = safeBigIntSize(before.size);
+    assertQuota(input.operation, input.limits, 'maxCompressedBytes', sourceBytes);
+
+    source = handle.createReadStream({ autoClose: false, emitClose: false });
+    const decompressor = createZstdDecompress();
+    pump = pipeline(
+      source,
+      compressedMeter,
+      new CanonicalZstdFrameTransform(),
+      decompressor,
+      decompressedMeter,
+      output,
+    );
+    const parsed = await parseAndValidateTar(output, input);
+    await pump;
+    const after = await handle.stat({ bigint: true });
+    if (!after.isFile() || !sameFingerprint(sourceFingerprint, fingerprint(after))) {
+      throw sourceChanged();
+    }
+    if (compressedMeter.bytes !== sourceBytes) throw sourceChanged();
+
+    const archiveDigest = `sha256:${archiveHash.digest('hex')}` as Sha256Digest;
+    if (
+      input.expectedArchiveDigest !== undefined &&
+      input.expectedArchiveDigest !== archiveDigest
+    ) {
+      throw new SessionBundleFileError(
+        'integrity_mismatch',
+        'Session bundle archive digest does not match the expected digest',
+      );
+    }
+    return {
+      manifest: parsed.manifest,
+      stateIdentity: parsed.stateIdentity,
+      archiveDigest,
+      verified: true,
+      decompressedTarBytes: decompressedMeter.bytes,
+    };
+  } catch (error) {
+    output.destroy();
+    await pump?.catch(() => {});
+    throw normalizeReadError(error, input.operation);
+  } finally {
+    source?.destroy();
+    await handle.close().catch(() => {});
+  }
+}
+
+async function parseAndValidateTar(
+  source: AsyncIterable<Uint8Array>,
+  input: {
+    limits: SessionBundleLimits;
+    operation: 'inspect' | 'hydrate';
+    expectedSessionId?: string;
+    stagingRoot?: string;
+  },
+): Promise<ParsedTarResult> {
+  const reader = new AsyncByteReader(source);
+  const manifestHeaderBytes = await reader.readExactly(SESSION_BUNDLE_USTAR_BLOCK_BYTES);
+  if (isSessionBundleUstarZeroBlock(manifestHeaderBytes)) {
+    throw new SessionBundleFileError('invalid_manifest', 'Session bundle manifest is missing');
+  }
+  const manifestHeader = decodeSessionBundleUstarHeaderV1(manifestHeaderBytes);
+  if (
+    manifestHeader.kind !== 'file' ||
+    manifestHeader.path !== SESSION_BUNDLE_MANIFEST_PATH ||
+    manifestHeader.mode !== 0o644
+  ) {
+    throw new SessionBundleFileError(
+      'invalid_manifest',
+      'Session bundle manifest is not the first canonical USTAR entry',
+    );
+  }
+  assertPathQuota(input.operation, input.limits, manifestHeader.path);
+  assertQuota(input.operation, input.limits, 'maxManifestBytes', manifestHeader.size);
+  const manifestBytes = await reader.readExactly(manifestHeader.size);
+  await reader.readZeroPadding(sessionBundleUstarPaddingBytes(manifestHeader.size));
+  const manifest = decodeSessionBundleManifestV1(manifestBytes);
+  assertQuota(input.operation, input.limits, 'maxEntryCount', manifest.payload.entryCount);
+  assertQuota(input.operation, input.limits, 'maxPayloadBytes', manifest.payload.payloadBytes);
+  if (
+    input.expectedSessionId !== undefined &&
+    manifest.envelope.sessionId !== input.expectedSessionId
+  ) {
+    throw new SessionBundleFileError(
+      'identity_mismatch',
+      'Session bundle Cloud Session identity does not match the expected identity',
+    );
+  }
+
+  const builder = new SessionBundleCanonicalTreeDigestBuilder(manifest.payload.entryCount);
+  const layout: ArchiveLayoutState = {
+    directories: new Set(),
+    logicalPaths: new Set(),
+  };
+  let declaredPayloadBytes = 0;
+  let identityBytes: Buffer | undefined;
+
+  for (let entryIndex = 0; entryIndex < manifest.payload.entryCount; entryIndex += 1) {
+    const headerBytes = await reader.readExactly(SESSION_BUNDLE_USTAR_BLOCK_BYTES);
+    if (isSessionBundleUstarZeroBlock(headerBytes)) {
+      throw new SessionBundleFileError(
+        'integrity_mismatch',
+        'Session bundle ended before every declared payload entry',
+        { details: { operation: input.operation, entryIndex } },
+      );
+    }
+    const header = decodeSessionBundleUstarHeaderV1(headerBytes);
+    validateArchiveEntryBeforeContent(header, layout, input, entryIndex);
+    if (header.kind === 'file') {
+      assertQuota(input.operation, input.limits, 'maxFileBytes', header.size, entryIndex);
+      if (header.path === SESSION_BUNDLE_STATE_IDENTITY_PATH) {
+        assertQuota(
+          input.operation,
+          input.limits,
+          'maxStateIdentityBytes',
+          header.size,
+          entryIndex,
+        );
+      }
+      declaredPayloadBytes = safeAdd(declaredPayloadBytes, header.size, 'integrity_mismatch');
+      assertQuota(
+        input.operation,
+        input.limits,
+        'maxPayloadBytes',
+        declaredPayloadBytes,
+        entryIndex,
+      );
+      if (declaredPayloadBytes > manifest.payload.payloadBytes) {
+        throw new SessionBundleFileError(
+          'integrity_mismatch',
+          'Session bundle payload exceeds its manifest declaration',
+        );
+      }
+    }
+
+    const result = await consumeArchiveEntry(reader, header, input);
+    builder.add(
+      header.kind === 'directory'
+        ? { kind: 'directory', path: header.path }
+        : {
+            kind: 'file',
+            path: header.path,
+            mode: header.mode,
+            size: header.size,
+            contentDigest: result.contentDigest,
+          },
+    );
+    if (result.identityBytes !== undefined) identityBytes = result.identityBytes;
+  }
+
+  const firstTerminator = await reader.readExactly(SESSION_BUNDLE_USTAR_BLOCK_BYTES);
+  const secondTerminator = await reader.readExactly(SESSION_BUNDLE_USTAR_BLOCK_BYTES);
+  if (
+    !isSessionBundleUstarZeroBlock(firstTerminator) ||
+    !isSessionBundleUstarZeroBlock(secondTerminator)
+  ) {
+    throw new SessionBundleFileError(
+      'integrity_mismatch',
+      'Session bundle does not end with exactly two canonical zero blocks',
+    );
+  }
+  await reader.assertEof();
+
+  if (
+    !layout.directories.has(SESSION_BUNDLE_STATE_PATH) ||
+    !layout.directories.has(SESSION_BUNDLE_WORKSPACE_PATH)
+  ) {
+    throw new SessionBundleFileError(
+      'integrity_mismatch',
+      'Session bundle is missing a required payload root',
+    );
+  }
+
+  const tree = builder.finish();
+  if (
+    tree.treeDigest !== manifest.payload.treeDigest ||
+    tree.payloadBytes !== manifest.payload.payloadBytes ||
+    tree.entryCount !== manifest.payload.entryCount
+  ) {
+    throw new SessionBundleFileError(
+      'integrity_mismatch',
+      'Session bundle payload tree does not match its manifest',
+    );
+  }
+  if (identityBytes === undefined) {
+    throw new SessionBundleFileError(
+      'integrity_mismatch',
+      'Session bundle state identity descriptor is missing',
+    );
+  }
+  return {
+    manifest,
+    stateIdentity: {
+      mediaType: manifest.stateIdentity.mediaType,
+      bytes: Uint8Array.from(identityBytes),
+    },
+  };
+}
+
+function validateArchiveEntryBeforeContent(
+  header: SessionBundleUstarHeader,
+  layout: ArchiveLayoutState,
+  input: { limits: SessionBundleLimits; operation: 'inspect' | 'hydrate' },
+  entryIndex: number,
+): void {
+  const { path } = header;
+  if (
+    !isValidUnicodeString(path) ||
+    path.length === 0 ||
+    path.includes('\0') ||
+    path.includes('\\') ||
+    path.startsWith('/') ||
+    /^[A-Za-z]:/.test(path)
+  ) {
+    throw unsafePath(input.operation, entryIndex);
+  }
+  const isDirectory = header.kind === 'directory';
+  if (isDirectory !== path.endsWith('/')) throw unsafePath(input.operation, entryIndex);
+  const logicalPath = isDirectory ? path.slice(0, -1) : path;
+  const segments = logicalPath.split('/');
+  if (
+    logicalPath.length === 0 ||
+    segments.some((segment) => segment.length === 0 || segment === '.' || segment === '..')
+  ) {
+    throw unsafePath(input.operation, entryIndex);
+  }
+  assertPathQuota(input.operation, input.limits, path, entryIndex);
+  if (
+    layout.previousPath !== undefined &&
+    compareSessionBundleCanonicalPaths(layout.previousPath, path) >= 0
+  ) {
+    throw unsafePath(input.operation, entryIndex);
+  }
+  if (layout.logicalPaths.has(logicalPath)) throw unsafePath(input.operation, entryIndex);
+  const parent = segments.length === 1 ? undefined : `${segments.slice(0, -1).join('/')}/`;
+  if (parent !== undefined && !layout.directories.has(parent)) {
+    throw unsafePath(input.operation, entryIndex);
+  }
+  if (path === SESSION_BUNDLE_STATE_IDENTITY_PATH) {
+    if (header.kind !== 'file' || header.mode !== 0o644) {
+      throw unsupportedEntry(input.operation, entryIndex);
+    }
+  } else if (path === SESSION_BUNDLE_STATE_PATH || path === SESSION_BUNDLE_WORKSPACE_PATH) {
+    if (header.kind !== 'directory') throw unsupportedEntry(input.operation, entryIndex);
+  } else if (
+    !path.startsWith(SESSION_BUNDLE_STATE_PATH) &&
+    !path.startsWith(SESSION_BUNDLE_WORKSPACE_PATH)
+  ) {
+    throw unsafePath(input.operation, entryIndex);
+  }
+
+  layout.logicalPaths.add(logicalPath);
+  if (isDirectory) layout.directories.add(path);
+  layout.previousPath = path;
+}
+
+async function consumeArchiveEntry(
+  reader: AsyncByteReader,
+  header: SessionBundleUstarHeader,
+  input: {
+    operation: 'inspect' | 'hydrate';
+    stagingRoot?: string;
+  },
+): Promise<{ contentDigest: Sha256Digest; identityBytes?: Buffer }> {
+  if (header.kind === 'directory') {
+    if (input.stagingRoot !== undefined) {
+      const path = hydrationPath(input.stagingRoot, header.path);
+      await mkdir(path, { mode: 0o755 });
+      await chmod(path, 0o755);
+    }
+    return { contentDigest: digestBytes(Buffer.alloc(0)) };
+  }
+
+  const hash = createHash('sha256');
+  const identityChunks: Buffer[] | undefined =
+    header.path === SESSION_BUNDLE_STATE_IDENTITY_PATH ? [] : undefined;
+  let output: FileHandle | undefined;
+  try {
+    if (input.stagingRoot !== undefined) {
+      output = await open(hydrationPath(input.stagingRoot, header.path), 'wx', header.mode);
+    }
+    await reader.consumeExactly(header.size, async (chunk) => {
+      hash.update(chunk);
+      if (identityChunks !== undefined) identityChunks.push(Buffer.from(chunk));
+      if (output !== undefined) await writeAll(output, chunk);
+    });
+    await reader.readZeroPadding(sessionBundleUstarPaddingBytes(header.size));
+    if (output !== undefined) {
+      await output.sync();
+      await output.chmod(header.mode);
+    }
+  } finally {
+    await output?.close().catch(() => {});
+  }
+  return {
+    contentDigest: `sha256:${hash.digest('hex')}` as Sha256Digest,
+    ...(identityChunks === undefined ? {} : { identityBytes: Buffer.concat(identityChunks) }),
+  };
+}
+
+class AsyncByteReader {
+  readonly #iterator: AsyncIterator<Uint8Array>;
+  #chunk = Buffer.alloc(0);
+  #offset = 0;
+  #ended = false;
+
+  constructor(source: AsyncIterable<Uint8Array>) {
+    this.#iterator = source[Symbol.asyncIterator]();
+  }
+
+  async readExactly(size: number): Promise<Buffer> {
+    if (!Number.isSafeInteger(size) || size < 0) throw integrityError();
+    const output = Buffer.alloc(size);
+    let written = 0;
+    await this.consumeExactly(size, (chunk) => {
+      chunk.copy(output, written);
+      written += chunk.byteLength;
+    });
+    return output;
+  }
+
+  async consumeExactly(
+    size: number,
+    consume: (chunk: Buffer) => void | Promise<void>,
+  ): Promise<void> {
+    let remaining = size;
+    while (remaining > 0) {
+      if (!(await this.#ensureChunk())) throw integrityError();
+      const available = this.#chunk.byteLength - this.#offset;
+      const length = Math.min(remaining, available);
+      const slice = this.#chunk.subarray(this.#offset, this.#offset + length);
+      await consume(slice);
+      this.#offset += length;
+      remaining -= length;
+    }
+  }
+
+  async readZeroPadding(size: number): Promise<void> {
+    await this.consumeExactly(size, (chunk) => {
+      if (chunk.some((byte) => byte !== 0)) {
+        throw new SessionBundleFileError(
+          'integrity_mismatch',
+          'Session bundle USTAR padding is not canonical',
+        );
+      }
+    });
+  }
+
+  async assertEof(): Promise<void> {
+    if (await this.#ensureChunk()) {
+      throw new SessionBundleFileError(
+        'integrity_mismatch',
+        'Session bundle contains bytes after its canonical terminator',
+      );
+    }
+  }
+
+  async #ensureChunk(): Promise<boolean> {
+    while (this.#offset >= this.#chunk.byteLength && !this.#ended) {
+      const next = await this.#iterator.next();
+      if (next.done) {
+        this.#ended = true;
+        this.#chunk = Buffer.alloc(0);
+        this.#offset = 0;
+        break;
+      }
+      this.#chunk = Buffer.from(next.value);
+      this.#offset = 0;
+    }
+    return this.#offset < this.#chunk.byteLength;
+  }
+}
+
+class CountingQuotaTransform extends Transform {
+  bytes = 0;
+
+  constructor(
+    private readonly limits: SessionBundleLimits,
+    private readonly quota: SessionBundleQuotaName,
+    private readonly operation: SessionBundleFileOperation,
+  ) {
+    super();
+  }
+
+  override _transform(
+    value: Buffer | Uint8Array,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null, data?: Buffer) => void,
+  ): void {
+    const chunk = Buffer.from(value);
+    try {
+      this.bytes = safeAdd(this.bytes, chunk.byteLength, 'quota_exceeded');
+      assertQuota(this.operation, this.limits, this.quota, this.bytes);
+      callback(null, chunk);
+    } catch (error) {
+      callback(error as Error);
+    }
+  }
+}
+
+class HashingQuotaTransform extends CountingQuotaTransform {
+  constructor(
+    private readonly hash: Hash,
+    limits: SessionBundleLimits,
+    quota: SessionBundleQuotaName,
+    operation: SessionBundleFileOperation,
+  ) {
+    super(limits, quota, operation);
+  }
+
+  override _transform(
+    value: Buffer | Uint8Array,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null, data?: Buffer) => void,
+  ): void {
+    const chunk = Buffer.from(value);
+    super._transform(chunk, encoding, (error, data) => {
+      if (error !== undefined && error !== null) {
+        callback(error);
+        return;
+      }
+      this.hash.update(chunk);
+      callback(null, data);
+    });
+  }
+}
+
+type ZstdFramePhase = 'block-header' | 'block-payload' | 'checksum' | 'frame-header';
+
+/**
+ * Node's native decoder accepts arbitrary bytes after its last complete frame.
+ * Validate the framing independently while passing the same bytes downstream.
+ */
+class CanonicalZstdFrameTransform extends Transform {
+  #buffer = Buffer.alloc(0);
+  #frameCount = 0;
+  #lastBlock = false;
+  #payloadBytes = 0;
+  #phase: ZstdFramePhase = 'frame-header';
+
+  override _transform(
+    value: Buffer | Uint8Array,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null, data?: Buffer) => void,
+  ): void {
+    const chunk = Buffer.from(value);
+    try {
+      this.#buffer = this.#buffer.byteLength === 0 ? chunk : Buffer.concat([this.#buffer, chunk]);
+      this.#consumeAvailableBytes();
+      callback(null, chunk);
+    } catch (error) {
+      callback(error as Error);
+    }
+  }
+
+  override _flush(callback: (error?: Error | null) => void): void {
+    if (this.#phase !== 'frame-header' || this.#buffer.byteLength !== 0 || this.#frameCount === 0) {
+      callback(
+        new SessionBundleFileError(
+          'integrity_mismatch',
+          'Session bundle Zstandard framing is truncated or contains trailing bytes',
+        ),
+      );
+      return;
+    }
+    callback();
+  }
+
+  #consumeAvailableBytes(): void {
+    while (true) {
+      if (this.#phase === 'frame-header') {
+        if (this.#buffer.byteLength < 6) return;
+        if (this.#buffer.readUInt32LE(0) !== 0xfd2fb528 || this.#buffer[4] !== 0x04) {
+          throw new SessionBundleFileError(
+            'integrity_mismatch',
+            'Session bundle Zstandard frame settings are not canonical',
+          );
+        }
+        this.#discard(6);
+        this.#phase = 'block-header';
+        continue;
+      }
+
+      if (this.#phase === 'block-header') {
+        if (this.#buffer.byteLength < 3) return;
+        const header = this.#buffer[0] | (this.#buffer[1] << 8) | (this.#buffer[2] << 16);
+        this.#lastBlock = (header & 1) === 1;
+        const blockType = (header >>> 1) & 0x03;
+        const blockSize = header >>> 3;
+        if (blockType === 0x03 || blockSize > 128 * 1024) {
+          throw new SessionBundleFileError(
+            'integrity_mismatch',
+            'Session bundle Zstandard block is malformed',
+          );
+        }
+        this.#payloadBytes = blockType === 0x01 ? 1 : blockSize;
+        this.#discard(3);
+        this.#phase = 'block-payload';
+        continue;
+      }
+
+      if (this.#phase === 'block-payload') {
+        if (this.#buffer.byteLength < this.#payloadBytes) {
+          this.#payloadBytes -= this.#buffer.byteLength;
+          this.#buffer = Buffer.alloc(0);
+          return;
+        }
+        this.#discard(this.#payloadBytes);
+        this.#payloadBytes = 0;
+        this.#phase = this.#lastBlock ? 'checksum' : 'block-header';
+        continue;
+      }
+
+      if (this.#buffer.byteLength < 4) return;
+      this.#discard(4);
+      this.#frameCount += 1;
+      this.#phase = 'frame-header';
+    }
+  }
+
+  #discard(bytes: number): void {
+    this.#buffer = this.#buffer.subarray(bytes);
+  }
+}
+
+function createSessionBundleZstdCompressor(): Transform {
+  return createZstdCompress({
+    params: {
+      [zlibConstants.ZSTD_c_compressionLevel]: SESSION_BUNDLE_COMPRESSION_LEVEL,
+      [zlibConstants.ZSTD_c_checksumFlag]: 1,
+      [zlibConstants.ZSTD_c_contentSizeFlag]: 0,
+      [zlibConstants.ZSTD_c_dictIDFlag]: 0,
+      [zlibConstants.ZSTD_c_nbWorkers]: 0,
+    },
+  });
+}
+
+async function* meterGeneratedTar(
+  source: AsyncIterable<Buffer>,
+  observe: (bytes: number) => void,
+): AsyncGenerator<Buffer> {
+  for await (const chunk of source) {
+    observe(chunk.byteLength);
+    if (chunk.byteLength > 0) yield chunk;
+  }
+}
+
+function calculateTarBytes(manifestBytes: number, entries: readonly PackEntry[]): number {
+  let total = tarEntryBytes(manifestBytes);
+  for (const entry of entries) {
+    total = safeAdd(
+      total,
+      tarEntryBytes(entry.canonical.kind === 'directory' ? 0 : entry.canonical.size),
+      'unsupported_entry',
+    );
+  }
+  return safeAdd(total, ARCHIVE_TERMINATOR.byteLength, 'unsupported_entry');
+}
+
+function tarEntryBytes(size: number): number {
+  return safeAdd(
+    SESSION_BUNDLE_USTAR_BLOCK_BYTES,
+    safeAdd(size, sessionBundleUstarPaddingBytes(size), 'unsupported_entry'),
+    'unsupported_entry',
+  );
+}
+
+function padding(size: number): Buffer {
+  const bytes = sessionBundleUstarPaddingBytes(size);
+  return bytes === 0 ? Buffer.alloc(0) : Buffer.alloc(bytes);
+}
+
+function validatePackPath(path: string, limits: SessionBundleLimits): void {
+  assertPathQuota('pack', limits, path);
+  if (
+    !isValidUnicodeString(path) ||
+    path.includes('\0') ||
+    path.includes('\\') ||
+    path.startsWith('/') ||
+    /^[A-Za-z]:/.test(path)
+  ) {
+    throw new SessionBundleFileError('unsafe_path', 'Session bundle source path is unsafe');
+  }
+  const logicalPath = path.endsWith('/') ? path.slice(0, -1) : path;
+  if (
+    logicalPath.length === 0 ||
+    logicalPath
+      .split('/')
+      .some((segment) => segment.length === 0 || segment === '.' || segment === '..')
+  ) {
+    throw new SessionBundleFileError('unsafe_path', 'Session bundle source path is unsafe');
+  }
+  encodeSessionBundleUstarHeaderV1({
+    kind: path.endsWith('/') ? 'directory' : 'file',
+    path,
+    mode: path.endsWith('/') ? 0o755 : 0o644,
+    size: 0,
+  });
+}
+
+function assertPathQuota(
+  operation: SessionBundleFileOperation,
+  limits: SessionBundleLimits,
+  path: string,
+  entryIndex?: number,
+): void {
+  const pathBytes = Buffer.byteLength(path, 'utf8');
+  const logicalPath = path.endsWith('/') ? path.slice(0, -1) : path;
+  const depth = logicalPath.length === 0 ? 0 : logicalPath.split('/').length;
+  assertQuota(operation, limits, 'maxPathBytes', pathBytes, entryIndex);
+  assertQuota(operation, limits, 'maxPathDepth', depth, entryIndex, depth);
+}
+
+function assertQuota(
+  operation: SessionBundleFileOperation,
+  limits: SessionBundleLimits,
+  quota: SessionBundleQuotaName,
+  observed: number,
+  entryIndex?: number,
+  pathDepth?: number,
+): void {
+  const limit = limits[quota];
+  if (observed <= limit) return;
+  throw new SessionBundleFileError('quota_exceeded', 'Session bundle quota was exceeded', {
+    details: {
+      operation,
+      quota,
+      limit,
+      observed,
+      ...(entryIndex === undefined ? {} : { entryIndex }),
+      ...(pathDepth === undefined ? {} : { pathDepth }),
+    },
+  });
+}
+
+function validatePackInput(input: SessionBundlePackInput): {
+  stateRoot: string;
+  workspaceRoot: string;
+  stateIdentity: OpaqueStateIdentityDescriptor;
+  envelope: SessionBundleManifestV1['envelope'];
+  destination: string;
+  limits: SessionBundleLimits;
+} {
+  if (!isRecord(input) || !isRecord(input.snapshot) || !isRecord(input.envelope)) {
+    throw new TypeError('Session bundle pack input must be an object');
+  }
+  assertSessionBundleLimits(input.limits);
+  const stateRoot = requiredFilesystemPath(input.snapshot.stateRoot, 'stateRoot');
+  const workspaceRoot = requiredFilesystemPath(input.snapshot.workspaceRoot, 'workspaceRoot');
+  const destination = requiredFilesystemPath(input.destination, 'destination');
+  const stateIdentity = copyOpaqueStateIdentityDescriptor(input.snapshot.stateIdentity);
+  if (!isNonEmptyUnicodeString(input.envelope.sessionId)) {
+    throw new TypeError('Session bundle sessionId must be a non-empty Unicode string');
+  }
+  let lastCommittedActivationId: string | undefined;
+  if (Object.hasOwn(input.envelope, 'lastCommittedActivationId')) {
+    if (!isNonEmptyUnicodeString(input.envelope.lastCommittedActivationId)) {
+      throw new TypeError(
+        'Session bundle lastCommittedActivationId must be a non-empty Unicode string',
+      );
+    }
+    lastCommittedActivationId = input.envelope.lastCommittedActivationId;
+  }
+  return {
+    stateRoot,
+    workspaceRoot,
+    stateIdentity,
+    envelope: {
+      sessionId: input.envelope.sessionId,
+      ...(lastCommittedActivationId === undefined ? {} : { lastCommittedActivationId }),
+    },
+    destination,
+    limits: input.limits,
+  };
+}
+
+function validateReadInput(input: SessionBundleReadInput): {
+  sourcePath: string;
+  expectedArchiveDigest?: Sha256Digest;
+  limits: SessionBundleLimits;
+} {
+  if (!isRecord(input) || !isRecord(input.source)) {
+    throw new TypeError('Session bundle read input must be an object');
+  }
+  assertSessionBundleLimits(input.limits);
+  const sourcePath = requiredFilesystemPath(input.source.path, 'source.path');
+  let expectedArchiveDigest: Sha256Digest | undefined;
+  if (Object.hasOwn(input.source, 'expectedArchiveDigest')) {
+    if (!isSha256Digest(input.source.expectedArchiveDigest)) {
+      throw new TypeError('Session bundle expected archive digest must be lowercase SHA-256');
+    }
+    expectedArchiveDigest = input.source.expectedArchiveDigest;
+  }
+  return {
+    sourcePath,
+    ...(expectedArchiveDigest === undefined ? {} : { expectedArchiveDigest }),
+    limits: input.limits,
+  };
+}
+
+function validateHydrateInput(input: SessionBundleHydrateInput): {
+  sourcePath: string;
+  expectedArchiveDigest?: Sha256Digest;
+  limits: SessionBundleLimits;
+  expectedSessionId: string;
+  destinationRoot: string;
+} {
+  const read = validateReadInput(input);
+  if (!isNonEmptyUnicodeString(input.expectedSessionId)) {
+    throw new TypeError('Session bundle expectedSessionId must be a non-empty Unicode string');
+  }
+  return {
+    ...read,
+    expectedSessionId: input.expectedSessionId,
+    destinationRoot: requiredFilesystemPath(input.destinationRoot, 'destinationRoot'),
+  };
+}
+
+function requiredFilesystemPath(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\0')) {
+    throw new TypeError(`Session bundle ${label} must be a non-empty filesystem path`);
+  }
+  return resolve(value);
+}
+
+function decodeFilesystemName(value: Buffer): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(value);
+  } catch {
+    throw new SessionBundleFileError(
+      'unsafe_path',
+      'Session bundle source name is not valid UTF-8',
+    );
+  }
+}
+
+async function assertDestinationMissing(
+  path: string,
+  operation: 'pack' | 'hydrate',
+): Promise<void> {
+  try {
+    await lstat(path);
+  } catch (error) {
+    if (isErrno(error, 'ENOENT')) return;
+    throw error;
+  }
+  throw new SessionBundleFileError(
+    'destination_exists',
+    'Session bundle destination already exists',
+    { details: { operation } },
+  );
+}
+
+async function openPackSourceFile(path: string): Promise<FileHandle> {
+  const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+  try {
+    return await open(path, fsConstants.O_RDONLY | noFollow);
+  } catch (error) {
+    if (isErrno(error, 'ELOOP')) {
+      throw new SessionBundleFileError(
+        'unsupported_entry',
+        'Session bundle source changed to a symbolic link',
+      );
+    }
+    throw error;
+  }
+}
+
+function hydrationPath(stagingRoot: string, archivePath: string): string {
+  const logical = archivePath.endsWith('/') ? archivePath.slice(0, -1) : archivePath;
+  return join(stagingRoot, ...logical.split('/'));
+}
+
+async function writeAll(handle: FileHandle, chunk: Buffer): Promise<void> {
+  let offset = 0;
+  while (offset < chunk.byteLength) {
+    const result = await handle.write(chunk, offset, chunk.byteLength - offset, null);
+    if (result.bytesWritten <= 0) throw ioError('hydrate');
+    offset += result.bytesWritten;
+  }
+}
+
+async function removeOwnedHydrationStaging(
+  stagingRoot: string,
+  parent: string,
+  prefix: string,
+  expectedFingerprint: FileFingerprint | undefined,
+): Promise<void> {
+  if (
+    expectedFingerprint === undefined ||
+    dirname(stagingRoot) !== parent ||
+    !basename(stagingRoot).startsWith(prefix)
+  ) {
+    return;
+  }
+  const metadata = await lstat(stagingRoot, { bigint: true }).catch((error: unknown) => {
+    if (isErrno(error, 'ENOENT')) return undefined;
+    throw error;
+  });
+  if (
+    metadata === undefined ||
+    !metadata.isDirectory() ||
+    metadata.isSymbolicLink() ||
+    !sameFilesystemNode(expectedFingerprint, fingerprint(metadata))
+  ) {
+    return;
+  }
+  await rm(stagingRoot, { recursive: true });
+}
+
+async function removeOwnedPackTemporary(path: string, parent: string): Promise<void> {
+  if (dirname(path) !== parent || !basename(path).includes(PACK_TEMP_MARKER)) return;
+  const metadata = await lstat(path).catch((error: unknown) => {
+    if (isErrno(error, 'ENOENT')) return undefined;
+    throw error;
+  });
+  if (metadata === undefined || !metadata.isFile() || metadata.isSymbolicLink()) return;
+  await rm(path);
+}
+
+function inspectionFromReadResult(result: ReadValidationResult): SessionBundleInspection {
+  return {
+    manifest: result.manifest,
+    stateIdentity: copyOpaqueStateIdentityDescriptor(result.stateIdentity),
+    archiveDigest: result.archiveDigest,
+    verified: true,
+  };
+}
+
+function fingerprint(metadata: BigIntStats): FileFingerprint {
+  return {
+    dev: metadata.dev,
+    ino: metadata.ino,
+    size: metadata.size,
+    mtimeNs: metadata.mtimeNs,
+    ctimeNs: metadata.ctimeNs,
+  };
+}
+
+function sameFingerprint(left: FileFingerprint, right: FileFingerprint): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function sameFilesystemNode(left: FileFingerprint, right: FileFingerprint): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function safeBigIntSize(value: bigint): number {
+  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new SessionBundleFileError(
+      'unsupported_entry',
+      'Session bundle filesystem entry size is outside the safe integer range',
+    );
+  }
+  return Number(value);
+}
+
+function safeAdd(
+  left: number,
+  right: number,
+  code: 'integrity_mismatch' | 'quota_exceeded' | 'source_changed' | 'unsupported_entry',
+): number {
+  const value = left + right;
+  if (!Number.isSafeInteger(value)) {
+    throw new SessionBundleFileError(code, 'Session bundle byte count exceeds safe integers');
+  }
+  return value;
+}
+
+function hasExecutableBit(mode: bigint): boolean {
+  return (mode & 0o111n) !== 0n;
+}
+
+function digestBytes(value: Uint8Array): Sha256Digest {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}` as Sha256Digest;
+}
+
+function sourceChanged(): SessionBundleFileError {
+  return new SessionBundleFileError(
+    'source_changed',
+    'Session bundle source changed while it was being consumed',
+  );
+}
+
+function unsafePath(
+  operation: SessionBundleFileOperation,
+  entryIndex: number,
+): SessionBundleFileError {
+  return new SessionBundleFileError('unsafe_path', 'Session bundle contains an unsafe path', {
+    details: { operation, entryIndex },
+  });
+}
+
+function unsupportedEntry(
+  operation: SessionBundleFileOperation,
+  entryIndex: number,
+): SessionBundleFileError {
+  return new SessionBundleFileError(
+    'unsupported_entry',
+    'Session bundle contains unsupported entry metadata',
+    { details: { operation, entryIndex } },
+  );
+}
+
+function integrityError(): SessionBundleFileError {
+  return new SessionBundleFileError(
+    'integrity_mismatch',
+    'Session bundle archive is truncated or malformed',
+  );
+}
+
+function ioError(operation: SessionBundleFileOperation): SessionBundleFileError {
+  return new SessionBundleFileError('io_failure', 'Session bundle filesystem operation failed', {
+    details: { operation },
+  });
+}
+
+function normalizeReadError(
+  error: unknown,
+  operation: 'inspect' | 'hydrate',
+): SessionBundleFileError {
+  if (error instanceof SessionBundleFileError) return error;
+  if (isFilesystemError(error)) return ioError(operation);
+  return new SessionBundleFileError(
+    'integrity_mismatch',
+    'Session bundle compressed stream is invalid or truncated',
+  );
+}
+
+function normalizeOperationError(error: unknown, operation: SessionBundleFileOperation): Error {
+  if (
+    error instanceof SessionBundleFileError ||
+    error instanceof TypeError ||
+    error instanceof RangeError
+  ) {
+    return error;
+  }
+  return ioError(operation);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && typeof (error as NodeJS.ErrnoException).code === 'string';
+}
+
+function isFilesystemError(error: unknown): error is NodeJS.ErrnoException {
+  return isErrnoException(error) && typeof error.syscall === 'string';
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return isErrnoException(error) && error.code === code;
+}

--- a/packages/storage/src/session-bundle-file-service.ts
+++ b/packages/storage/src/session-bundle-file-service.ts
@@ -10,7 +10,6 @@ import {
   readdir,
   rename,
   rm,
-  rmdir,
   stat,
   type FileHandle,
 } from 'node:fs/promises';
@@ -78,6 +77,8 @@ const ARCHIVE_TERMINATOR = Buffer.alloc(SESSION_BUNDLE_USTAR_BLOCK_BYTES * 2);
 const HYDRATION_STAGING_MARKER = '.maka-session-bundle-staging-';
 const HYDRATION_OWNERSHIP_SUFFIX = '.owner.json';
 const HYDRATION_OWNERSHIP_KIND = 'maka-session-bundle-hydration-staging' as const;
+const HYDRATION_OWNERSHIP_BINDING_KIND = 'maka-session-bundle-hydration-staging-binding' as const;
+const HYDRATION_OWNERSHIP_ANCHOR = '.maka-session-bundle-owner';
 const HYDRATION_OWNERSHIP_MAX_BYTES = 2 * 1024;
 const HYDRATION_CLEANUP_SUFFIX = '.cleanup';
 const HYDRATION_TOKEN_PATTERN =
@@ -120,14 +121,19 @@ interface HydrationStagingOwnershipV1 {
   destinationName: string;
   stagingName: string;
   token: string;
+}
+
+interface HydrationStagingOwnershipBindingV1 {
+  schemaVersion: 1;
+  kind: typeof HYDRATION_OWNERSHIP_BINDING_KIND;
   stagingDev: string;
   stagingIno: string;
 }
 
-type HydrationStagingOwnershipReservationV1 = Omit<
-  HydrationStagingOwnershipV1,
-  'stagingDev' | 'stagingIno'
->;
+interface DecodedHydrationStagingOwnership {
+  ownership: HydrationStagingOwnershipV1;
+  binding?: HydrationStagingOwnershipBindingV1;
+}
 
 interface PackDirectoryEntry {
   canonical: Extract<SessionBundleCanonicalTreeEntry, { kind: 'directory' }>;
@@ -1556,19 +1562,39 @@ async function publishPackFileNoReplace(
     throw error;
   }
 
-  // Establish cleanup ownership from the path that link() published before any
-  // lookup of the mutable temporary pathname can fail. The final cleanup still
-  // verifies this inode binding before removing the destination.
-  const linkedMetadata = await lstat(destination, { bigint: true });
-  if (linkedMetadata.isFile() && !linkedMetadata.isSymbolicLink()) {
-    state.linkedFingerprint = fingerprint(linkedMetadata);
-  }
-  const [beforeHandle, beforeTemporary, beforeDestination] = await Promise.all([
+  const [beforeHandle, beforeDestination] = await Promise.all([
     handle.stat({ bigint: true }),
-    lstat(temporaryPath, { bigint: true }),
     lstat(destination, { bigint: true }),
   ]);
   const verificationFingerprint = fingerprint(beforeHandle);
+  const destinationFingerprint = fingerprint(beforeDestination);
+  if (
+    beforeHandle.isFile() &&
+    beforeDestination.isFile() &&
+    !beforeDestination.isSymbolicLink() &&
+    beforeHandle.size === BigInt(expectedBytes) &&
+    sameFilesystemNode(hashedFingerprint, verificationFingerprint) &&
+    sameFilesystemNode(verificationFingerprint, destinationFingerprint)
+  ) {
+    // The open, hashed file proves that this is the inode link() published.
+    // Do not claim an arbitrary destination merely because link() returned.
+    state.linkedFingerprint = destinationFingerprint;
+  }
+
+  const beforeTemporary = await lstat(temporaryPath, { bigint: true });
+  const temporaryFingerprint = fingerprint(beforeTemporary);
+  if (
+    state.linkedFingerprint === undefined &&
+    beforeTemporary.isFile() &&
+    !beforeTemporary.isSymbolicLink() &&
+    beforeDestination.isFile() &&
+    !beforeDestination.isSymbolicLink() &&
+    sameFilesystemNode(temporaryFingerprint, destinationFingerprint)
+  ) {
+    // The pathname may have been swapped before link(). In that case the
+    // current temporary inode still proves which unwanted inode we published.
+    state.linkedFingerprint = destinationFingerprint;
+  }
   if (
     !beforeHandle.isFile() ||
     !beforeTemporary.isFile() ||
@@ -1577,8 +1603,8 @@ async function publishPackFileNoReplace(
     beforeDestination.isSymbolicLink() ||
     beforeHandle.size !== BigInt(expectedBytes) ||
     state.linkedFingerprint === undefined ||
-    !sameFilesystemNode(state.linkedFingerprint, fingerprint(beforeDestination)) ||
-    !sameFilesystemNode(fingerprint(beforeTemporary), fingerprint(beforeDestination)) ||
+    !sameFilesystemNode(state.linkedFingerprint, destinationFingerprint) ||
+    !sameFilesystemNode(temporaryFingerprint, destinationFingerprint) ||
     !sameFilesystemNode(hashedFingerprint, verificationFingerprint) ||
     !sameFingerprint(verificationFingerprint, fingerprint(beforeDestination))
   ) {
@@ -1724,15 +1750,20 @@ async function writeAll(
   }
 }
 
-async function replaceOpenFileContents(
+async function appendOpenFileContents(
   handle: FileHandle,
   contents: Buffer,
+  start: number,
   operation: 'pack' | 'hydrate',
 ): Promise<void> {
-  await handle.truncate(0);
   let offset = 0;
   while (offset < contents.byteLength) {
-    const result = await handle.write(contents, offset, contents.byteLength - offset, offset);
+    const result = await handle.write(
+      contents,
+      offset,
+      contents.byteLength - offset,
+      start + offset,
+    );
     if (result.bytesWritten <= 0) throw ioError(operation);
     offset += result.bytesWritten;
   }
@@ -1750,7 +1781,8 @@ async function createHydrationStaging(
   const stagingName = `${prefix}${token}`;
   const stagingRoot = join(parent, stagingName);
   const ownershipPath = `${stagingRoot}${HYDRATION_OWNERSHIP_SUFFIX}`;
-  const reservation = encodeHydrationStagingOwnershipReservation({
+  const ownershipAnchorPath = join(stagingRoot, HYDRATION_OWNERSHIP_ANCHOR);
+  const ownership = encodeHydrationStagingOwnership({
     schemaVersion: 1,
     kind: HYDRATION_OWNERSHIP_KIND,
     destinationName,
@@ -1774,7 +1806,7 @@ async function createHydrationStaging(
       throw ioError('hydrate');
     }
     createdOwnershipFingerprint = fingerprint(createdOwnershipMetadata);
-    await writeAll(ownershipHandle, reservation, 'hydrate');
+    await writeAll(ownershipHandle, ownership, 'hydrate');
     await ownershipHandle.sync();
     await syncDirectory(parent);
 
@@ -1789,18 +1821,42 @@ async function createHydrationStaging(
       throw ioError('hydrate');
     }
     stagingFingerprint = fingerprint(stagingMetadata);
+
+    // Keep the first canonical record intact and hard-link it into the staging
+    // directory before appending the inode binding. If the process dies during
+    // that append, cleanup can still authenticate the directory through this
+    // exact owner-file inode instead of trusting a partial second JSON line.
+    await link(ownershipPath, ownershipAnchorPath);
+    const [anchoredOwnershipMetadata, ownershipAnchorMetadata] = await Promise.all([
+      ownershipHandle.stat({ bigint: true }),
+      lstat(ownershipAnchorPath, { bigint: true }),
+    ]);
+    if (
+      !anchoredOwnershipMetadata.isFile() ||
+      !ownershipAnchorMetadata.isFile() ||
+      ownershipAnchorMetadata.isSymbolicLink() ||
+      anchoredOwnershipMetadata.nlink !== 2n ||
+      !sameFilesystemNode(
+        fingerprint(anchoredOwnershipMetadata),
+        fingerprint(ownershipAnchorMetadata),
+      )
+    ) {
+      throw ioError('hydrate');
+    }
+    await syncDirectory(stagingRoot);
     await syncDirectory(parent);
 
-    const ownership = encodeHydrationStagingOwnership({
+    const binding = encodeHydrationStagingOwnershipBinding({
       schemaVersion: 1,
-      kind: HYDRATION_OWNERSHIP_KIND,
-      destinationName,
-      stagingName,
-      token,
+      kind: HYDRATION_OWNERSHIP_BINDING_KIND,
       stagingDev: stagingMetadata.dev.toString(),
       stagingIno: stagingMetadata.ino.toString(),
     });
-    await replaceOpenFileContents(ownershipHandle, ownership, 'hydrate');
+    await appendOpenFileContents(ownershipHandle, binding, ownership.byteLength, 'hydrate');
+    if (!(await removeOwnedPackFile(ownershipAnchorPath, createdOwnershipFingerprint))) {
+      throw ioError('hydrate');
+    }
+    await syncDirectory(stagingRoot);
     const [ownershipMetadata, ownershipPathMetadata] = await Promise.all([
       ownershipHandle.stat({ bigint: true }),
       lstat(ownershipPath, { bigint: true }),
@@ -1810,6 +1866,7 @@ async function createHydrationStaging(
       !ownershipPathMetadata.isFile() ||
       ownershipPathMetadata.isSymbolicLink() ||
       ownershipMetadata.nlink !== 1n ||
+      ownershipMetadata.size !== BigInt(ownership.byteLength + binding.byteLength) ||
       !sameFilesystemNode(createdOwnershipFingerprint, fingerprint(ownershipMetadata)) ||
       !sameFingerprint(fingerprint(ownershipMetadata), fingerprint(ownershipPathMetadata))
     ) {
@@ -1866,7 +1923,10 @@ async function cleanupHydrationStagingForDestination(
       ownershipName,
     );
     if (owned === undefined) continue;
-    if (await removeOwnedDirectory(owned.stagingRoot, parent, owned.stagingIdentity)) {
+    if (
+      owned.stagingIdentity !== undefined &&
+      (await removeOwnedDirectory(owned.stagingRoot, parent, owned.stagingIdentity))
+    ) {
       removedStagingDirectories += 1;
       changed = true;
       if (await removeOwnedPackFile(owned.ownershipPath, owned.ownershipFingerprint)) {
@@ -1906,7 +1966,7 @@ async function readHydrationStagingOwnership(
 ): Promise<
   | {
       stagingRoot: string;
-      stagingIdentity: FilesystemNodeIdentity;
+      stagingIdentity?: FilesystemNodeIdentity;
       ownershipPath: string;
       ownershipFingerprint: FileFingerprint;
     }
@@ -1931,7 +1991,8 @@ async function readHydrationStagingOwnership(
       !handleMetadata.isFile() ||
       !pathMetadata.isFile() ||
       pathMetadata.isSymbolicLink() ||
-      handleMetadata.nlink !== 1n ||
+      handleMetadata.nlink < 1n ||
+      handleMetadata.nlink > 2n ||
       handleMetadata.size > BigInt(HYDRATION_OWNERSHIP_MAX_BYTES) ||
       !sameFingerprint(ownershipFingerprint, fingerprint(pathMetadata))
     ) {
@@ -1941,21 +2002,26 @@ async function readHydrationStagingOwnership(
     if (bytes === undefined) return undefined;
     const after = await handle.stat({ bigint: true });
     if (!sameFingerprint(ownershipFingerprint, fingerprint(after))) return undefined;
-    const ownership = decodeHydrationStagingOwnership(bytes);
+    const decoded = decodeHydrationStagingOwnership(bytes);
     if (
-      ownership === undefined ||
-      ownership.destinationName !== destinationName ||
-      ownership.stagingName !== `${prefix}${ownership.token}` ||
-      ownershipName !== `${ownership.stagingName}${HYDRATION_OWNERSHIP_SUFFIX}`
+      decoded === undefined ||
+      decoded.ownership.destinationName !== destinationName ||
+      decoded.ownership.stagingName !== `${prefix}${decoded.ownership.token}` ||
+      ownershipName !== `${decoded.ownership.stagingName}${HYDRATION_OWNERSHIP_SUFFIX}`
     ) {
       return undefined;
     }
+    const stagingRoot = join(parent, decoded.ownership.stagingName);
+    const stagingIdentity =
+      decoded.binding === undefined
+        ? await readAnchoredHydrationStagingIdentity(stagingRoot, ownershipFingerprint)
+        : {
+            dev: BigInt(decoded.binding.stagingDev),
+            ino: BigInt(decoded.binding.stagingIno),
+          };
     return {
-      stagingRoot: join(parent, ownership.stagingName),
-      stagingIdentity: {
-        dev: BigInt(ownership.stagingDev),
-        ino: BigInt(ownership.stagingIno),
-      },
+      stagingRoot,
+      stagingIdentity,
       ownershipPath,
       ownershipFingerprint,
     };
@@ -1968,13 +2034,29 @@ function encodeHydrationStagingOwnership(value: HydrationStagingOwnershipV1): Bu
   return Buffer.from(`${JSON.stringify(value)}\n`, 'utf8');
 }
 
-function encodeHydrationStagingOwnershipReservation(
-  value: HydrationStagingOwnershipReservationV1,
-): Buffer {
+function encodeHydrationStagingOwnershipBinding(value: HydrationStagingOwnershipBindingV1): Buffer {
   return Buffer.from(`${JSON.stringify(value)}\n`, 'utf8');
 }
 
-function decodeHydrationStagingOwnership(value: Buffer): HydrationStagingOwnershipV1 | undefined {
+function decodeHydrationStagingOwnership(
+  value: Buffer,
+): DecodedHydrationStagingOwnership | undefined {
+  const firstLineEnd = value.indexOf(0x0a);
+  if (firstLineEnd < 0) return undefined;
+  const ownership = decodeHydrationStagingOwnershipRecord(value.subarray(0, firstLineEnd + 1));
+  if (ownership === undefined) return undefined;
+  const bindingBytes = value.subarray(firstLineEnd + 1);
+  if (bindingBytes.byteLength === 0) return { ownership };
+  const binding = decodeHydrationStagingOwnershipBinding(bindingBytes);
+  // An incomplete final line is an interrupted append, not a reason to lose
+  // the valid first record. The caller requires the hard-link anchor before it
+  // trusts such a reservation.
+  return binding === undefined ? { ownership } : { ownership, binding };
+}
+
+function decodeHydrationStagingOwnershipRecord(
+  value: Buffer,
+): HydrationStagingOwnershipV1 | undefined {
   let decoded: unknown;
   try {
     decoded = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(value));
@@ -1983,17 +2065,13 @@ function decodeHydrationStagingOwnership(value: Buffer): HydrationStagingOwnersh
   }
   if (
     !isRecord(decoded) ||
-    Object.keys(decoded).length !== 7 ||
+    Object.keys(decoded).length !== 5 ||
     decoded.schemaVersion !== 1 ||
     decoded.kind !== HYDRATION_OWNERSHIP_KIND ||
     typeof decoded.destinationName !== 'string' ||
     typeof decoded.stagingName !== 'string' ||
     typeof decoded.token !== 'string' ||
-    !HYDRATION_TOKEN_PATTERN.test(decoded.token) ||
-    typeof decoded.stagingDev !== 'string' ||
-    !FILESYSTEM_ID_PATTERN.test(decoded.stagingDev) ||
-    typeof decoded.stagingIno !== 'string' ||
-    !FILESYSTEM_ID_PATTERN.test(decoded.stagingIno)
+    !HYDRATION_TOKEN_PATTERN.test(decoded.token)
   ) {
     return undefined;
   }
@@ -2003,10 +2081,91 @@ function decodeHydrationStagingOwnership(value: Buffer): HydrationStagingOwnersh
     destinationName: decoded.destinationName,
     stagingName: decoded.stagingName,
     token: decoded.token,
+  };
+  return encodeHydrationStagingOwnership(ownership).equals(value) ? ownership : undefined;
+}
+
+function decodeHydrationStagingOwnershipBinding(
+  value: Buffer,
+): HydrationStagingOwnershipBindingV1 | undefined {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(value));
+  } catch {
+    return undefined;
+  }
+  if (
+    !isRecord(decoded) ||
+    Object.keys(decoded).length !== 4 ||
+    decoded.schemaVersion !== 1 ||
+    decoded.kind !== HYDRATION_OWNERSHIP_BINDING_KIND ||
+    typeof decoded.stagingDev !== 'string' ||
+    !FILESYSTEM_ID_PATTERN.test(decoded.stagingDev) ||
+    typeof decoded.stagingIno !== 'string' ||
+    !FILESYSTEM_ID_PATTERN.test(decoded.stagingIno)
+  ) {
+    return undefined;
+  }
+  const binding: HydrationStagingOwnershipBindingV1 = {
+    schemaVersion: 1,
+    kind: HYDRATION_OWNERSHIP_BINDING_KIND,
     stagingDev: decoded.stagingDev,
     stagingIno: decoded.stagingIno,
   };
-  return encodeHydrationStagingOwnership(ownership).equals(value) ? ownership : undefined;
+  return encodeHydrationStagingOwnershipBinding(binding).equals(value) ? binding : undefined;
+}
+
+async function readAnchoredHydrationStagingIdentity(
+  stagingRoot: string,
+  ownershipFingerprint: FileFingerprint,
+): Promise<FilesystemNodeIdentity | undefined> {
+  for (const candidate of [stagingRoot, hydrationCleanupRoot(stagingRoot)]) {
+    const identity = await readAnchoredHydrationDirectoryIdentity(candidate, ownershipFingerprint);
+    if (identity !== undefined) return identity;
+  }
+  return undefined;
+}
+
+async function readAnchoredHydrationDirectoryIdentity(
+  directory: string,
+  ownershipFingerprint: FileFingerprint,
+): Promise<FilesystemNodeIdentity | undefined> {
+  const anchorPath = join(directory, HYDRATION_OWNERSHIP_ANCHOR);
+  const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+  let anchorHandle: FileHandle | undefined;
+  try {
+    anchorHandle = await open(anchorPath, fsConstants.O_RDONLY | noFollow);
+  } catch (error) {
+    if (isErrno(error, 'ENOENT') || isErrno(error, 'ELOOP') || isErrno(error, 'ENOTDIR')) {
+      return undefined;
+    }
+    throw error;
+  }
+  try {
+    const [stagingMetadata, anchorMetadata, anchorPathMetadata] = await Promise.all([
+      lstat(directory, { bigint: true }),
+      anchorHandle.stat({ bigint: true }),
+      lstat(anchorPath, { bigint: true }),
+    ]);
+    if (
+      !stagingMetadata.isDirectory() ||
+      stagingMetadata.isSymbolicLink() ||
+      !anchorMetadata.isFile() ||
+      !anchorPathMetadata.isFile() ||
+      anchorPathMetadata.isSymbolicLink() ||
+      ownershipFingerprint.nlink !== 2n ||
+      !sameFingerprint(ownershipFingerprint, fingerprint(anchorMetadata)) ||
+      !sameFingerprint(fingerprint(anchorMetadata), fingerprint(anchorPathMetadata))
+    ) {
+      return undefined;
+    }
+    return fingerprint(stagingMetadata);
+  } catch (error) {
+    if (isErrno(error, 'ENOENT') || isErrno(error, 'ENOTDIR')) return undefined;
+    throw error;
+  } finally {
+    await anchorHandle.close().catch(() => {});
+  }
 }
 
 async function readBoundedFileHandle(
@@ -2030,29 +2189,22 @@ async function removeOwnedDirectory(
 ): Promise<boolean> {
   if (dirname(path) !== parent) return false;
   const quarantineRoot = hydrationCleanupRoot(path);
-  const quarantinedPath = join(quarantineRoot, 'staging');
-  const existingQuarantined = await lstat(quarantinedPath, {
+  const existingQuarantine = await lstat(quarantineRoot, {
     bigint: true,
   }).catch((error: unknown) => {
-    if (isErrno(error, 'ENOENT') || isErrno(error, 'ENOTDIR')) return undefined;
+    if (isErrno(error, 'ENOENT')) return undefined;
     throw error;
   });
-  if (existingQuarantined !== undefined) {
+  if (existingQuarantine !== undefined) {
     if (
-      !existingQuarantined.isDirectory() ||
-      existingQuarantined.isSymbolicLink() ||
-      !sameFilesystemNode(expectedIdentity, fingerprint(existingQuarantined))
+      !existingQuarantine.isDirectory() ||
+      existingQuarantine.isSymbolicLink() ||
+      !sameFilesystemNode(expectedIdentity, fingerprint(existingQuarantine))
     ) {
       return false;
     }
-    await rm(quarantinedPath, { recursive: true });
-    await rmdir(quarantineRoot).catch(() => {});
+    await rm(quarantineRoot, { recursive: true });
     return true;
-  }
-  try {
-    await rmdir(quarantineRoot);
-  } catch (error) {
-    if (!isErrno(error, 'ENOENT')) return false;
   }
 
   const initial = await lstat(path, { bigint: true }).catch((error: unknown) => {
@@ -2068,50 +2220,47 @@ async function removeOwnedDirectory(
     return false;
   }
 
-  // Recursive removal is path-based in Node. Move the candidate into a fresh,
-  // destination-owned quarantine first, then verify the moved inode. Its name
-  // is derivable from the ownership record so a crash during cleanup can resume.
-  let quarantined = false;
+  const current = await lstat(path, { bigint: true }).catch((error: unknown) => {
+    if (isErrno(error, 'ENOENT')) return undefined;
+    throw error;
+  });
+  if (
+    current === undefined ||
+    !current.isDirectory() ||
+    current.isSymbolicLink() ||
+    !sameFilesystemNode(expectedIdentity, fingerprint(current))
+  ) {
+    return false;
+  }
+
+  // The quarantine path itself retains the staging inode, so a crash at any
+  // later point remains recoverable from the persisted ownership binding. The
+  // lifecycle lock excludes cooperating writers; Node does not expose a
+  // rename-without-replacement primitive for non-cooperating directory writers.
   try {
-    await mkdir(quarantineRoot, { mode: 0o700 });
+    await rename(path, quarantineRoot);
   } catch (error) {
-    if (isErrno(error, 'EEXIST')) return false;
+    if (
+      isErrno(error, 'ENOENT') ||
+      isErrno(error, 'EEXIST') ||
+      isErrno(error, 'ENOTEMPTY') ||
+      isErrno(error, 'EISDIR') ||
+      isErrno(error, 'ENOTDIR')
+    ) {
+      return false;
+    }
     throw error;
   }
-  try {
-    const current = await lstat(path, { bigint: true }).catch((error: unknown) => {
-      if (isErrno(error, 'ENOENT')) return undefined;
-      throw error;
-    });
-    if (
-      current === undefined ||
-      !current.isDirectory() ||
-      current.isSymbolicLink() ||
-      !sameFilesystemNode(expectedIdentity, fingerprint(current))
-    ) {
-      return false;
-    }
-    try {
-      await rename(path, quarantinedPath);
-    } catch (error) {
-      if (isErrno(error, 'ENOENT')) return false;
-      throw error;
-    }
-    quarantined = true;
-    const moved = await lstat(quarantinedPath, { bigint: true });
-    if (
-      !moved.isDirectory() ||
-      moved.isSymbolicLink() ||
-      !sameFilesystemNode(expectedIdentity, fingerprint(moved))
-    ) {
-      return false;
-    }
-    await rm(quarantinedPath, { recursive: true });
-    quarantined = false;
-    return true;
-  } finally {
-    if (!quarantined) await rmdir(quarantineRoot).catch(() => {});
+  const moved = await lstat(quarantineRoot, { bigint: true });
+  if (
+    !moved.isDirectory() ||
+    moved.isSymbolicLink() ||
+    !sameFilesystemNode(expectedIdentity, fingerprint(moved))
+  ) {
+    return false;
   }
+  await rm(quarantineRoot, { recursive: true });
+  return true;
 }
 
 function hydrationCleanupRoot(stagingRoot: string): string {
@@ -2132,9 +2281,28 @@ async function removeOwnedHydrationStaging(
   ) {
     return;
   }
-  await removeOwnedDirectory(staging.stagingRoot, parent, staging.stagingFingerprint);
-  await removeOwnedPackFile(staging.ownershipPath, staging.ownershipFingerprint);
+  const removed = await removeOwnedDirectory(
+    staging.stagingRoot,
+    parent,
+    staging.stagingFingerprint,
+  );
+  if (removed || (await hydrationStagingPathsAbsent(staging.stagingRoot))) {
+    await removeOwnedPackFile(staging.ownershipPath, staging.ownershipFingerprint);
+  }
   await syncDirectory(parent);
+}
+
+async function hydrationStagingPathsAbsent(stagingRoot: string): Promise<boolean> {
+  const paths = [stagingRoot, hydrationCleanupRoot(stagingRoot)];
+  const metadata = await Promise.all(
+    paths.map((path) =>
+      lstat(path).catch((error: unknown) => {
+        if (isErrno(error, 'ENOENT')) return undefined;
+        throw error;
+      }),
+    ),
+  );
+  return metadata.every((value) => value === undefined);
 }
 
 async function removeOwnedPackTemporary(

--- a/packages/storage/src/session-bundle-file-service.ts
+++ b/packages/storage/src/session-bundle-file-service.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID, type Hash } from 'node:crypto';
 import { constants as fsConstants, type BigIntStats } from 'node:fs';
 import {
   chmod,
+  link,
   lstat,
   mkdir,
   mkdtemp,
@@ -17,6 +18,7 @@ import { basename, dirname, join, resolve } from 'node:path';
 import { PassThrough, Readable, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { constants as zlibConstants, createZstdCompress, createZstdDecompress } from 'node:zlib';
+import { unlock, waitForLock } from 'fs-native-extensions';
 import {
   compareSessionBundleCanonicalPaths,
   computeSessionBundleCanonicalTreeDigest,
@@ -72,7 +74,12 @@ const ZERO_BLOCK = Buffer.alloc(SESSION_BUNDLE_USTAR_BLOCK_BYTES);
 const ARCHIVE_TERMINATOR = Buffer.alloc(SESSION_BUNDLE_USTAR_BLOCK_BYTES * 2);
 const HYDRATION_STAGING_MARKER = '.maka-session-bundle-staging-';
 const PACK_TEMP_MARKER = '.maka-session-bundle-pack-';
+const PUBLICATION_LOCK_MARKER = '.maka-session-bundle-publish-';
 const PACK_FILE_CHUNK_BYTES = 64 * 1024;
+const SESSION_BUNDLE_ZSTD_WINDOW_LOG = 21;
+const SESSION_BUNDLE_ZSTD_WINDOW_DESCRIPTOR = 0x58;
+const NODE_ZSTD_TRAILING_EMPTY_FRAME = Buffer.from('28b52ffd040001000099e9d851', 'hex');
+const publicationLockGates = new Map<string, Promise<void>>();
 
 interface FileFingerprint {
   dev: bigint;
@@ -175,18 +182,22 @@ export class NodeSessionBundleFileService implements SessionBundleFileService {
         stagingRoot,
       });
 
-      await assertDestinationMissing(validated.destinationRoot, 'hydrate');
-      const currentStaging = await lstat(stagingRoot, { bigint: true });
-      if (
-        !currentStaging.isDirectory() ||
-        !sameFilesystemNode(stagingFingerprint, fingerprint(currentStaging))
-      ) {
-        throw new SessionBundleFileError(
-          'source_changed',
-          'Session bundle hydration staging root changed before publication',
-        );
-      }
-      await rename(stagingRoot, validated.destinationRoot);
+      const publicationStagingRoot = stagingRoot;
+      const publicationStagingFingerprint = stagingFingerprint;
+      await withDestinationPublicationLock(validated.destinationRoot, 'hydrate', async () => {
+        await assertDestinationMissing(validated.destinationRoot, 'hydrate');
+        const currentStaging = await lstat(publicationStagingRoot, { bigint: true });
+        if (
+          !currentStaging.isDirectory() ||
+          !sameFilesystemNode(publicationStagingFingerprint, fingerprint(currentStaging))
+        ) {
+          throw new SessionBundleFileError(
+            'source_changed',
+            'Session bundle hydration staging root changed before publication',
+          );
+        }
+        await rename(publicationStagingRoot, validated.destinationRoot);
+      });
       published = true;
       return {
         ...inspectionFromReadResult(result),
@@ -294,7 +305,6 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
     `.${basename(validated.destination)}${PACK_TEMP_MARKER}${randomUUID()}.tmp`,
   );
   let handle: FileHandle | undefined;
-  let published = false;
   const archiveHash = createHash('sha256');
   const compressedMeter = new HashingQuotaTransform(
     archiveHash,
@@ -313,7 +323,13 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
         generatedTarBytes += bytes;
       }),
     );
-    await pipeline(tar, createSessionBundleZstdCompressor(), compressedMeter, output);
+    await pipeline(
+      tar,
+      createSessionBundleZstdCompressor(),
+      new CanonicalZstdOutputTransform(),
+      compressedMeter,
+      output,
+    );
     if (generatedTarBytes !== decompressedTarBytes) {
       throw new SessionBundleFileError(
         'integrity_mismatch',
@@ -326,9 +342,7 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
     output = undefined;
     await handle.close();
     handle = undefined;
-    await assertDestinationMissing(validated.destination, 'pack');
-    await rename(temporaryPath, validated.destination);
-    published = true;
+    await publishPackFileNoReplace(temporaryPath, validated.destination);
     return {
       path: validated.destination,
       archiveDigest: `sha256:${archiveHash.digest('hex')}` as Sha256Digest,
@@ -340,7 +354,7 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
   } finally {
     output?.destroy();
     await handle?.close().catch(() => {});
-    if (!published) await removeOwnedPackTemporary(temporaryPath, parent).catch(() => {});
+    await removeOwnedPackTemporary(temporaryPath, parent).catch(() => {});
   }
 }
 
@@ -607,7 +621,11 @@ async function readAndValidateSessionBundle(input: {
     assertQuota(input.operation, input.limits, 'maxCompressedBytes', sourceBytes);
 
     source = handle.createReadStream({ autoClose: false, emitClose: false });
-    const decompressor = createZstdDecompress();
+    const decompressor = createZstdDecompress({
+      params: {
+        [zlibConstants.ZSTD_d_windowLogMax]: SESSION_BUNDLE_ZSTD_WINDOW_LOG,
+      },
+    });
     pump = pipeline(
       source,
       compressedMeter,
@@ -1031,6 +1049,34 @@ class HashingQuotaTransform extends CountingQuotaTransform {
   }
 }
 
+/** Remove the empty frame Node's streaming compressor appends after multi-chunk input. */
+class CanonicalZstdOutputTransform extends Transform {
+  #tail = Buffer.alloc(0);
+
+  override _transform(
+    value: Buffer | Uint8Array,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null, data?: Buffer) => void,
+  ): void {
+    const combined = Buffer.concat([this.#tail, Buffer.from(value)]);
+    if (combined.byteLength <= NODE_ZSTD_TRAILING_EMPTY_FRAME.byteLength) {
+      this.#tail = combined;
+      callback();
+      return;
+    }
+    const retainedBytes = NODE_ZSTD_TRAILING_EMPTY_FRAME.byteLength;
+    const emittedBytes = combined.byteLength - retainedBytes;
+    this.#tail = combined.subarray(emittedBytes);
+    callback(null, combined.subarray(0, emittedBytes));
+  }
+
+  override _flush(callback: (error?: Error | null) => void): void {
+    if (!this.#tail.equals(NODE_ZSTD_TRAILING_EMPTY_FRAME)) this.push(this.#tail);
+    this.#tail = Buffer.alloc(0);
+    callback();
+  }
+}
+
 type ZstdFramePhase = 'block-header' | 'block-payload' | 'checksum' | 'frame-header';
 
 /**
@@ -1060,7 +1106,7 @@ class CanonicalZstdFrameTransform extends Transform {
   }
 
   override _flush(callback: (error?: Error | null) => void): void {
-    if (this.#phase !== 'frame-header' || this.#buffer.byteLength !== 0 || this.#frameCount === 0) {
+    if (this.#phase !== 'frame-header' || this.#buffer.byteLength !== 0 || this.#frameCount !== 1) {
       callback(
         new SessionBundleFileError(
           'integrity_mismatch',
@@ -1075,8 +1121,18 @@ class CanonicalZstdFrameTransform extends Transform {
   #consumeAvailableBytes(): void {
     while (true) {
       if (this.#phase === 'frame-header') {
+        if (this.#frameCount !== 0 && this.#buffer.byteLength !== 0) {
+          throw new SessionBundleFileError(
+            'integrity_mismatch',
+            'Session bundle must contain exactly one canonical Zstandard frame',
+          );
+        }
         if (this.#buffer.byteLength < 6) return;
-        if (this.#buffer.readUInt32LE(0) !== 0xfd2fb528 || this.#buffer[4] !== 0x04) {
+        if (
+          this.#buffer.readUInt32LE(0) !== 0xfd2fb528 ||
+          this.#buffer[4] !== 0x04 ||
+          this.#buffer[5] !== SESSION_BUNDLE_ZSTD_WINDOW_DESCRIPTOR
+        ) {
           throw new SessionBundleFileError(
             'integrity_mismatch',
             'Session bundle Zstandard frame settings are not canonical',
@@ -1137,6 +1193,7 @@ function createSessionBundleZstdCompressor(): Transform {
       [zlibConstants.ZSTD_c_contentSizeFlag]: 0,
       [zlibConstants.ZSTD_c_dictIDFlag]: 0,
       [zlibConstants.ZSTD_c_nbWorkers]: 0,
+      [zlibConstants.ZSTD_c_windowLog]: SESSION_BUNDLE_ZSTD_WINDOW_LOG,
     },
   });
 }
@@ -1350,11 +1407,90 @@ async function assertDestinationMissing(
     if (isErrno(error, 'ENOENT')) return;
     throw error;
   }
-  throw new SessionBundleFileError(
-    'destination_exists',
-    'Session bundle destination already exists',
-    { details: { operation } },
+  throw destinationExists(operation);
+}
+
+async function publishPackFileNoReplace(temporaryPath: string, destination: string): Promise<void> {
+  try {
+    // Both paths are siblings, so a hard link is an atomic no-replace publication.
+    await link(temporaryPath, destination);
+  } catch (error) {
+    if (isErrno(error, 'EEXIST')) throw destinationExists('pack');
+    throw error;
+  }
+}
+
+async function withDestinationPublicationLock<T>(
+  destination: string,
+  operation: 'hydrate',
+  action: () => Promise<T>,
+): Promise<T> {
+  const lockPath = join(
+    dirname(destination),
+    `${PUBLICATION_LOCK_MARKER}${createHash('sha256')
+      .update(basename(destination).normalize('NFC').toLocaleLowerCase('en-US'))
+      .digest('hex')}.lock`,
   );
+  return runWithPublicationLockGate(lockPath, async () => {
+    const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+    const handle = await open(lockPath, fsConstants.O_CREAT | fsConstants.O_RDWR | noFollow, 0o600);
+    let acquired = false;
+    try {
+      if (process.platform !== 'win32') await handle.chmod(0o600);
+      await assertStablePublicationLock(handle, lockPath, operation);
+      await waitForLock(handle.fd);
+      acquired = true;
+      await assertStablePublicationLock(handle, lockPath, operation);
+      return await action();
+    } finally {
+      if (acquired) {
+        try {
+          unlock(handle.fd);
+        } catch {
+          // Closing the handle is the final OS-level release path.
+        }
+      }
+      await handle.close().catch(() => {});
+    }
+  });
+}
+
+async function runWithPublicationLockGate<T>(
+  lockPath: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  const previous = publicationLockGates.get(lockPath);
+  let release!: () => void;
+  const current = new Promise<void>((resolveGate) => {
+    release = resolveGate;
+  });
+  publicationLockGates.set(lockPath, current);
+  await previous?.catch(() => {});
+  try {
+    return await action();
+  } finally {
+    release();
+    if (publicationLockGates.get(lockPath) === current) publicationLockGates.delete(lockPath);
+  }
+}
+
+async function assertStablePublicationLock(
+  handle: FileHandle,
+  lockPath: string,
+  operation: 'hydrate',
+): Promise<void> {
+  const [handleMetadata, pathMetadata] = await Promise.all([
+    handle.stat({ bigint: true }),
+    lstat(lockPath, { bigint: true }),
+  ]);
+  if (
+    !handleMetadata.isFile() ||
+    !pathMetadata.isFile() ||
+    handleMetadata.dev !== pathMetadata.dev ||
+    handleMetadata.ino !== pathMetadata.ino
+  ) {
+    throw ioError(operation);
+  }
 }
 
 async function openPackSourceFile(path: string): Promise<FileHandle> {
@@ -1491,6 +1627,14 @@ function sourceChanged(): SessionBundleFileError {
   return new SessionBundleFileError(
     'source_changed',
     'Session bundle source changed while it was being consumed',
+  );
+}
+
+function destinationExists(operation: 'pack' | 'hydrate'): SessionBundleFileError {
+  return new SessionBundleFileError(
+    'destination_exists',
+    'Session bundle destination already exists',
+    { details: { operation } },
   );
 }
 

--- a/packages/storage/src/session-bundle-file-service.ts
+++ b/packages/storage/src/session-bundle-file-service.ts
@@ -6,7 +6,6 @@ import {
   link,
   lstat,
   mkdir,
-  mkdtemp,
   open,
   readdir,
   rename,
@@ -22,6 +21,7 @@ import { unlock, waitForLock } from 'fs-native-extensions';
 import {
   compareSessionBundleCanonicalPaths,
   computeSessionBundleCanonicalTreeDigest,
+  SessionBundleCanonicalLayoutValidator,
   SessionBundleCanonicalTreeDigestBuilder,
   type SessionBundleCanonicalTreeEntry,
 } from './session-bundle-canonical-tree.js';
@@ -47,6 +47,8 @@ import {
   type SessionBundleArtifact,
   type SessionBundleFileOperation,
   type SessionBundleFileService,
+  type SessionBundleHydrationCleanupInput,
+  type SessionBundleHydrationCleanupResult,
   type SessionBundleHydrateInput,
   type SessionBundleHydration,
   type SessionBundleInspection,
@@ -73,6 +75,11 @@ import { syncDirectory } from './stable-storage.js';
 
 const ARCHIVE_TERMINATOR = Buffer.alloc(SESSION_BUNDLE_USTAR_BLOCK_BYTES * 2);
 const HYDRATION_STAGING_MARKER = '.maka-session-bundle-staging-';
+const HYDRATION_OWNERSHIP_SUFFIX = '.owner.json';
+const HYDRATION_OWNERSHIP_KIND = 'maka-session-bundle-hydration-staging' as const;
+const HYDRATION_OWNERSHIP_MAX_BYTES = 2 * 1024;
+const HYDRATION_TOKEN_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const PACK_TEMP_MARKER = '.maka-session-bundle-pack-';
 const PUBLICATION_LOCK_MARKER = '.maka-session-bundle-publish-';
 const PACK_FILE_CHUNK_BYTES = 64 * 1024;
@@ -91,7 +98,22 @@ interface FileFingerprint {
 }
 
 interface PackPublicationState {
-  destinationLinked: boolean;
+  linkedFingerprint?: FileFingerprint;
+}
+
+interface HydrationStagingBinding {
+  stagingRoot: string;
+  stagingFingerprint: FileFingerprint;
+  ownershipPath: string;
+  ownershipFingerprint: FileFingerprint;
+}
+
+interface HydrationStagingOwnershipV1 {
+  schemaVersion: 1;
+  kind: typeof HYDRATION_OWNERSHIP_KIND;
+  destinationName: string;
+  stagingName: string;
+  token: string;
 }
 
 interface PackDirectoryEntry {
@@ -126,12 +148,6 @@ interface ParsedTarResult {
   stateIdentity: OpaqueStateIdentityDescriptor;
 }
 
-interface ArchiveLayoutState {
-  directories: Set<string>;
-  logicalPaths: Set<string>;
-  previousPath?: string;
-}
-
 export function createSessionBundleFileService(): SessionBundleFileService {
   return new NodeSessionBundleFileService();
 }
@@ -160,65 +176,88 @@ export class NodeSessionBundleFileService implements SessionBundleFileService {
 
   async hydrate(input: SessionBundleHydrateInput): Promise<SessionBundleHydration> {
     const validated = validateHydrateInput(input);
-    const parent = dirname(validated.destinationRoot);
-    const prefix = `.${basename(validated.destinationRoot)}${HYDRATION_STAGING_MARKER}`;
-    let stagingRoot: string | undefined;
-    let stagingFingerprint: FileFingerprint | undefined;
-    let published = false;
-
     try {
-      await assertDestinationMissing(validated.destinationRoot, 'hydrate');
-      const parentMetadata = await stat(parent, { bigint: true });
-      if (!parentMetadata.isDirectory()) throw ioError('hydrate');
-      stagingRoot = await mkdtemp(join(parent, prefix));
-      await chmod(stagingRoot, 0o700);
-      const stagingMetadata = await lstat(stagingRoot, { bigint: true });
-      if (!stagingMetadata.isDirectory() || stagingMetadata.dev !== parentMetadata.dev) {
-        throw ioError('hydrate');
-      }
-      stagingFingerprint = fingerprint(stagingMetadata);
-
-      const result = await readAndValidateSessionBundle({
-        sourcePath: validated.sourcePath,
-        expectedArchiveDigest: validated.expectedArchiveDigest,
-        limits: validated.limits,
-        operation: 'hydrate',
-        expectedSessionId: validated.expectedSessionId,
-        stagingRoot,
-      });
-
-      const publicationStagingRoot = stagingRoot;
-      const publicationStagingFingerprint = stagingFingerprint;
-      await withDestinationPublicationLock(validated.destinationRoot, 'hydrate', async () => {
-        await assertDestinationMissing(validated.destinationRoot, 'hydrate');
-        const currentStaging = await lstat(publicationStagingRoot, { bigint: true });
-        if (
-          !currentStaging.isDirectory() ||
-          !sameFilesystemNode(publicationStagingFingerprint, fingerprint(currentStaging))
-        ) {
-          throw new SessionBundleFileError(
-            'source_changed',
-            'Session bundle hydration staging root changed before publication',
-          );
-        }
-        // Codec participants serialize this check/rename gap with the publication lock.
-        // A non-cooperating writer can still create an empty destination here because
-        // Node does not expose rename-without-replacement for directories.
-        await rename(publicationStagingRoot, validated.destinationRoot);
-        published = true;
-        await syncDirectory(parent);
-      });
-      return {
-        ...inspectionFromReadResult(result),
-        destinationRoot: validated.destinationRoot,
-        stateRoot: join(validated.destinationRoot, 'state'),
-        workspaceRoot: join(validated.destinationRoot, 'workspace'),
-      };
+      return await withDestinationPublicationLock(validated.destinationRoot, 'hydrate', () =>
+        hydrateSessionBundle(validated),
+      );
     } catch (error) {
       throw normalizeOperationError(error, 'hydrate');
-    } finally {
-      if (!published && stagingRoot !== undefined) {
-        await removeOwnedHydrationStaging(stagingRoot, parent, prefix, stagingFingerprint).catch(
+    }
+  }
+
+  async cleanupHydrationStaging(
+    input: SessionBundleHydrationCleanupInput,
+  ): Promise<SessionBundleHydrationCleanupResult> {
+    const destinationRoot = validateHydrationCleanupInput(input);
+    try {
+      return await withDestinationPublicationLock(destinationRoot, 'cleanup', async () => ({
+        destinationRoot,
+        ...(await cleanupHydrationStagingForDestination(destinationRoot)),
+      }));
+    } catch (error) {
+      throw normalizeOperationError(error, 'cleanup');
+    }
+  }
+}
+
+async function hydrateSessionBundle(validated: {
+  sourcePath: string;
+  expectedArchiveDigest?: Sha256Digest;
+  limits: SessionBundleLimits;
+  expectedSessionId: string;
+  destinationRoot: string;
+}): Promise<SessionBundleHydration> {
+  const parent = dirname(validated.destinationRoot);
+  const prefix = `.${basename(validated.destinationRoot)}${HYDRATION_STAGING_MARKER}`;
+  let staging: HydrationStagingBinding | undefined;
+  let published = false;
+
+  try {
+    await cleanupHydrationStagingForDestination(validated.destinationRoot, 'hydrate');
+    await assertDestinationMissing(validated.destinationRoot, 'hydrate');
+    const parentMetadata = await stat(parent, { bigint: true });
+    if (!parentMetadata.isDirectory()) throw ioError('hydrate');
+    staging = await createHydrationStaging(validated.destinationRoot, parentMetadata);
+
+    const result = await readAndValidateSessionBundle({
+      sourcePath: validated.sourcePath,
+      expectedArchiveDigest: validated.expectedArchiveDigest,
+      limits: validated.limits,
+      operation: 'hydrate',
+      expectedSessionId: validated.expectedSessionId,
+      stagingRoot: staging.stagingRoot,
+    });
+
+    await assertDestinationMissing(validated.destinationRoot, 'hydrate');
+    const currentStaging = await lstat(staging.stagingRoot, { bigint: true });
+    if (
+      !currentStaging.isDirectory() ||
+      !sameFilesystemNode(staging.stagingFingerprint, fingerprint(currentStaging))
+    ) {
+      throw new SessionBundleFileError(
+        'source_changed',
+        'Session bundle hydration staging root changed before publication',
+      );
+    }
+    // Codec participants hold the destination lifecycle lock from cleanup through
+    // publication. A non-cooperating writer can still create an empty destination
+    // here because Node does not expose rename-without-replacement for directories.
+    await rename(staging.stagingRoot, validated.destinationRoot);
+    published = true;
+    await removeOwnedPackFile(staging.ownershipPath, staging.ownershipFingerprint);
+    await syncDirectory(parent);
+    return {
+      ...inspectionFromReadResult(result),
+      destinationRoot: validated.destinationRoot,
+      stateRoot: join(validated.destinationRoot, 'state'),
+      workspaceRoot: join(validated.destinationRoot, 'workspace'),
+    };
+  } finally {
+    if (!published) {
+      if (staging !== undefined) {
+        await removeOwnedHydrationStaging(staging, parent, prefix).catch(() => {});
+      } else {
+        await cleanupHydrationStagingForDestination(validated.destinationRoot, 'hydrate').catch(
           () => {},
         );
       }
@@ -316,7 +355,7 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
   let handle: FileHandle | undefined;
   let temporaryFingerprint: FileFingerprint | undefined;
   let published = false;
-  const publicationState: PackPublicationState = { destinationLinked: false };
+  const publicationState: PackPublicationState = {};
   const archiveHash = createHash('sha256');
   const compressedMeter = new HashingQuotaTransform(
     archiveHash,
@@ -386,10 +425,12 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
     };
   } finally {
     output?.destroy();
-    if (!published && publicationState.destinationLinked && temporaryFingerprint !== undefined) {
-      await removeOwnedPackPublication(validated.destination, parent, temporaryFingerprint).catch(
-        () => {},
-      );
+    if (!published && publicationState.linkedFingerprint !== undefined) {
+      await removeOwnedPackPublication(
+        validated.destination,
+        parent,
+        publicationState.linkedFingerprint,
+      ).catch(() => {});
     }
     if (temporaryFingerprint !== undefined) {
       await removeOwnedPackTemporary(temporaryPath, parent, temporaryFingerprint).catch(() => {});
@@ -778,10 +819,7 @@ async function parseAndValidateTar(
   }
 
   const builder = new SessionBundleCanonicalTreeDigestBuilder(manifest.payload.entryCount);
-  const layout: ArchiveLayoutState = {
-    directories: new Set(),
-    logicalPaths: new Set(),
-  };
+  const layout = new SessionBundleCanonicalLayoutValidator(manifest.payload.entryCount);
   let declaredPayloadBytes = 0;
   let identityBytes: Buffer | undefined;
 
@@ -851,16 +889,7 @@ async function parseAndValidateTar(
   }
   await reader.assertEof();
 
-  if (
-    !layout.directories.has(SESSION_BUNDLE_STATE_PATH) ||
-    !layout.directories.has(SESSION_BUNDLE_WORKSPACE_PATH)
-  ) {
-    throw new SessionBundleFileError(
-      'integrity_mismatch',
-      'Session bundle is missing a required payload root',
-    );
-  }
-
+  layout.finish();
   const tree = builder.finish();
   if (
     tree.treeDigest !== manifest.payload.treeDigest ||
@@ -889,59 +918,24 @@ async function parseAndValidateTar(
 
 function validateArchiveEntryBeforeContent(
   header: SessionBundleUstarHeader,
-  layout: ArchiveLayoutState,
+  layout: SessionBundleCanonicalLayoutValidator,
   input: { limits: SessionBundleLimits; operation: 'inspect' | 'hydrate' },
   entryIndex: number,
 ): void {
-  const { path } = header;
-  if (
-    !isValidUnicodeString(path) ||
-    path.length === 0 ||
-    path.includes('\0') ||
-    path.includes('\\') ||
-    path.startsWith('/') ||
-    /^[A-Za-z]:/.test(path)
-  ) {
-    throw unsafePath(input.operation, entryIndex);
+  assertPathQuota(input.operation, input.limits, header.path, entryIndex);
+  try {
+    layout.add(
+      header.kind === 'directory'
+        ? { kind: 'directory', path: header.path }
+        : { kind: 'file', path: header.path, mode: header.mode },
+    );
+  } catch (error) {
+    if (!(error instanceof SessionBundleFileError)) throw error;
+    throw new SessionBundleFileError(error.code, error.message, {
+      cause: error,
+      details: { operation: input.operation, entryIndex },
+    });
   }
-  const isDirectory = header.kind === 'directory';
-  if (isDirectory !== path.endsWith('/')) throw unsafePath(input.operation, entryIndex);
-  const logicalPath = isDirectory ? path.slice(0, -1) : path;
-  const segments = logicalPath.split('/');
-  if (
-    logicalPath.length === 0 ||
-    segments.some((segment) => segment.length === 0 || segment === '.' || segment === '..')
-  ) {
-    throw unsafePath(input.operation, entryIndex);
-  }
-  assertPathQuota(input.operation, input.limits, path, entryIndex);
-  if (
-    layout.previousPath !== undefined &&
-    compareSessionBundleCanonicalPaths(layout.previousPath, path) >= 0
-  ) {
-    throw unsafePath(input.operation, entryIndex);
-  }
-  if (layout.logicalPaths.has(logicalPath)) throw unsafePath(input.operation, entryIndex);
-  const parent = segments.length === 1 ? undefined : `${segments.slice(0, -1).join('/')}/`;
-  if (parent !== undefined && !layout.directories.has(parent)) {
-    throw unsafePath(input.operation, entryIndex);
-  }
-  if (path === SESSION_BUNDLE_STATE_IDENTITY_PATH) {
-    if (header.kind !== 'file' || header.mode !== 0o644) {
-      throw unsupportedEntry(input.operation, entryIndex);
-    }
-  } else if (path === SESSION_BUNDLE_STATE_PATH || path === SESSION_BUNDLE_WORKSPACE_PATH) {
-    if (header.kind !== 'directory') throw unsupportedEntry(input.operation, entryIndex);
-  } else if (
-    !path.startsWith(SESSION_BUNDLE_STATE_PATH) &&
-    !path.startsWith(SESSION_BUNDLE_WORKSPACE_PATH)
-  ) {
-    throw unsafePath(input.operation, entryIndex);
-  }
-
-  layout.logicalPaths.add(logicalPath);
-  if (isDirectory) layout.directories.add(path);
-  layout.previousPath = path;
 }
 
 async function consumeArchiveEntry(
@@ -1469,6 +1463,13 @@ function validateHydrateInput(input: SessionBundleHydrateInput): {
   };
 }
 
+function validateHydrationCleanupInput(input: SessionBundleHydrationCleanupInput): string {
+  if (!isRecord(input)) {
+    throw new TypeError('Session bundle hydration cleanup input must be an object');
+  }
+  return requiredFilesystemPath(input.destinationRoot, 'destinationRoot');
+}
+
 function requiredFilesystemPath(value: unknown, label: string): string {
   if (typeof value !== 'string' || value.length === 0 || value.includes('\0')) {
     throw new TypeError(`Session bundle ${label} must be a non-empty filesystem path`);
@@ -1537,17 +1538,29 @@ async function publishPackFileNoReplace(
   try {
     // Both paths are siblings, so a hard link is an atomic no-replace publication.
     await link(temporaryPath, destination);
-    state.destinationLinked = true;
   } catch (error) {
     if (isErrno(error, 'EEXIST')) throw destinationExists('pack');
     throw error;
   }
 
-  const [beforeHandle, beforeDestination] = await Promise.all([
+  const [beforeHandle, beforeTemporary, beforeDestination] = await Promise.all([
     handle.stat({ bigint: true }),
+    lstat(temporaryPath, { bigint: true }),
     lstat(destination, { bigint: true }),
   ]);
   const verificationFingerprint = fingerprint(beforeHandle);
+  const linkedFingerprint = fingerprint(beforeDestination);
+  if (
+    beforeTemporary.isFile() &&
+    beforeDestination.isFile() &&
+    !beforeTemporary.isSymbolicLink() &&
+    !beforeDestination.isSymbolicLink() &&
+    sameFilesystemNode(fingerprint(beforeTemporary), linkedFingerprint)
+  ) {
+    // Cleanup must follow the inode this link() actually published, even when
+    // the mutable temporary pathname was swapped after its binding check.
+    state.linkedFingerprint = linkedFingerprint;
+  }
   if (
     !beforeHandle.isFile() ||
     !beforeDestination.isFile() ||
@@ -1593,7 +1606,7 @@ async function digestOpenPackFile(
 
 async function withDestinationPublicationLock<T>(
   destination: string,
-  operation: 'hydrate',
+  operation: 'hydrate' | 'cleanup',
   action: () => Promise<T>,
 ): Promise<T> {
   const lockPath = join(
@@ -1648,7 +1661,7 @@ async function runWithPublicationLockGate<T>(
 async function assertStablePublicationLock(
   handle: FileHandle,
   lockPath: string,
-  operation: 'hydrate',
+  operation: 'hydrate' | 'cleanup',
 ): Promise<void> {
   const [handleMetadata, pathMetadata] = await Promise.all([
     handle.stat({ bigint: true }),
@@ -1697,32 +1710,261 @@ async function writeAll(
   }
 }
 
+async function createHydrationStaging(
+  destinationRoot: string,
+  parentMetadata: BigIntStats,
+): Promise<HydrationStagingBinding> {
+  const parent = dirname(destinationRoot);
+  const destinationName = basename(destinationRoot);
+  const prefix = `.${destinationName}${HYDRATION_STAGING_MARKER}`;
+  const token = randomUUID();
+  const stagingName = `${prefix}${token}`;
+  const stagingRoot = join(parent, stagingName);
+  const ownershipPath = `${stagingRoot}${HYDRATION_OWNERSHIP_SUFFIX}`;
+  const ownership = encodeHydrationStagingOwnership({
+    schemaVersion: 1,
+    kind: HYDRATION_OWNERSHIP_KIND,
+    destinationName,
+    stagingName,
+    token,
+  });
+  let ownershipHandle: FileHandle | undefined;
+  try {
+    ownershipHandle = await open(ownershipPath, 'wx', 0o600);
+    await writeAll(ownershipHandle, ownership, 'hydrate');
+    await ownershipHandle.sync();
+    const ownershipMetadata = await ownershipHandle.stat({ bigint: true });
+    if (!ownershipMetadata.isFile() || ownershipMetadata.nlink !== 1n) throw ioError('hydrate');
+    const ownershipFingerprint = fingerprint(ownershipMetadata);
+    await ownershipHandle.close();
+    ownershipHandle = undefined;
+    await syncDirectory(parent);
+
+    await mkdir(stagingRoot, { mode: 0o700 });
+    await chmod(stagingRoot, 0o700);
+    const stagingMetadata = await lstat(stagingRoot, { bigint: true });
+    if (
+      !stagingMetadata.isDirectory() ||
+      stagingMetadata.isSymbolicLink() ||
+      stagingMetadata.dev !== parentMetadata.dev
+    ) {
+      throw ioError('hydrate');
+    }
+    await syncDirectory(parent);
+    return {
+      stagingRoot,
+      stagingFingerprint: fingerprint(stagingMetadata),
+      ownershipPath,
+      ownershipFingerprint,
+    };
+  } finally {
+    await ownershipHandle?.close().catch(() => {});
+  }
+}
+
+async function cleanupHydrationStagingForDestination(
+  destinationRoot: string,
+  operation: 'hydrate' | 'cleanup' = 'cleanup',
+): Promise<{
+  removedStagingDirectories: number;
+  removedOwnershipRecords: number;
+}> {
+  const parent = dirname(destinationRoot);
+  const destinationName = basename(destinationRoot);
+  const prefix = `.${destinationName}${HYDRATION_STAGING_MARKER}`;
+  const parentMetadata = await stat(parent, { bigint: true });
+  if (!parentMetadata.isDirectory()) throw ioError(operation);
+  let removedStagingDirectories = 0;
+  let removedOwnershipRecords = 0;
+  let changed = false;
+
+  for (const ownershipName of (await readdir(parent)).sort()) {
+    if (!ownershipName.startsWith(prefix) || !ownershipName.endsWith(HYDRATION_OWNERSHIP_SUFFIX)) {
+      continue;
+    }
+    const owned = await readHydrationStagingOwnership(
+      parent,
+      destinationName,
+      prefix,
+      ownershipName,
+    );
+    if (owned === undefined) continue;
+    const stagingMetadata = await lstat(owned.stagingRoot, { bigint: true }).catch(
+      (error: unknown) => {
+        if (isErrno(error, 'ENOENT')) return undefined;
+        throw error;
+      },
+    );
+    if (stagingMetadata === undefined) {
+      if (await removeOwnedPackFile(owned.ownershipPath, owned.ownershipFingerprint)) {
+        removedOwnershipRecords += 1;
+        changed = true;
+      }
+      continue;
+    }
+    if (
+      !stagingMetadata.isDirectory() ||
+      stagingMetadata.isSymbolicLink() ||
+      stagingMetadata.dev !== parentMetadata.dev
+    ) {
+      continue;
+    }
+    const expectedStaging = fingerprint(stagingMetadata);
+    const currentStaging = await lstat(owned.stagingRoot, { bigint: true });
+    if (
+      !currentStaging.isDirectory() ||
+      currentStaging.isSymbolicLink() ||
+      !sameFingerprint(expectedStaging, fingerprint(currentStaging))
+    ) {
+      continue;
+    }
+    await rm(owned.stagingRoot, { recursive: true });
+    removedStagingDirectories += 1;
+    changed = true;
+    if (await removeOwnedPackFile(owned.ownershipPath, owned.ownershipFingerprint)) {
+      removedOwnershipRecords += 1;
+    }
+  }
+  if (changed) await syncDirectory(parent);
+  return { removedStagingDirectories, removedOwnershipRecords };
+}
+
+async function readHydrationStagingOwnership(
+  parent: string,
+  destinationName: string,
+  prefix: string,
+  ownershipName: string,
+): Promise<
+  | {
+      stagingRoot: string;
+      ownershipPath: string;
+      ownershipFingerprint: FileFingerprint;
+    }
+  | undefined
+> {
+  const ownershipPath = join(parent, ownershipName);
+  const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+  let handle: FileHandle | undefined;
+  try {
+    handle = await open(ownershipPath, fsConstants.O_RDONLY | noFollow);
+  } catch (error) {
+    if (isErrno(error, 'ENOENT') || isErrno(error, 'ELOOP')) return undefined;
+    throw error;
+  }
+  try {
+    const [handleMetadata, pathMetadata] = await Promise.all([
+      handle.stat({ bigint: true }),
+      lstat(ownershipPath, { bigint: true }),
+    ]);
+    const ownershipFingerprint = fingerprint(handleMetadata);
+    if (
+      !handleMetadata.isFile() ||
+      !pathMetadata.isFile() ||
+      pathMetadata.isSymbolicLink() ||
+      handleMetadata.nlink !== 1n ||
+      handleMetadata.size > BigInt(HYDRATION_OWNERSHIP_MAX_BYTES) ||
+      !sameFingerprint(ownershipFingerprint, fingerprint(pathMetadata))
+    ) {
+      return undefined;
+    }
+    const bytes = await readBoundedFileHandle(handle, HYDRATION_OWNERSHIP_MAX_BYTES);
+    if (bytes === undefined) return undefined;
+    const after = await handle.stat({ bigint: true });
+    if (!sameFingerprint(ownershipFingerprint, fingerprint(after))) return undefined;
+    const ownership = decodeHydrationStagingOwnership(bytes);
+    if (
+      ownership === undefined ||
+      ownership.destinationName !== destinationName ||
+      ownership.stagingName !== `${prefix}${ownership.token}` ||
+      ownershipName !== `${ownership.stagingName}${HYDRATION_OWNERSHIP_SUFFIX}`
+    ) {
+      return undefined;
+    }
+    return {
+      stagingRoot: join(parent, ownership.stagingName),
+      ownershipPath,
+      ownershipFingerprint,
+    };
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
+function encodeHydrationStagingOwnership(value: HydrationStagingOwnershipV1): Buffer {
+  return Buffer.from(`${JSON.stringify(value)}\n`, 'utf8');
+}
+
+function decodeHydrationStagingOwnership(value: Buffer): HydrationStagingOwnershipV1 | undefined {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(value));
+  } catch {
+    return undefined;
+  }
+  if (
+    !isRecord(decoded) ||
+    Object.keys(decoded).length !== 5 ||
+    decoded.schemaVersion !== 1 ||
+    decoded.kind !== HYDRATION_OWNERSHIP_KIND ||
+    typeof decoded.destinationName !== 'string' ||
+    typeof decoded.stagingName !== 'string' ||
+    typeof decoded.token !== 'string' ||
+    !HYDRATION_TOKEN_PATTERN.test(decoded.token)
+  ) {
+    return undefined;
+  }
+  const ownership: HydrationStagingOwnershipV1 = {
+    schemaVersion: 1,
+    kind: HYDRATION_OWNERSHIP_KIND,
+    destinationName: decoded.destinationName,
+    stagingName: decoded.stagingName,
+    token: decoded.token,
+  };
+  return encodeHydrationStagingOwnership(ownership).equals(value) ? ownership : undefined;
+}
+
+async function readBoundedFileHandle(
+  handle: FileHandle,
+  maxBytes: number,
+): Promise<Buffer | undefined> {
+  const buffer = Buffer.alloc(maxBytes + 1);
+  let offset = 0;
+  while (offset < buffer.byteLength) {
+    const { bytesRead } = await handle.read(buffer, offset, buffer.byteLength - offset, offset);
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  return offset > maxBytes ? undefined : buffer.subarray(0, offset);
+}
+
 async function removeOwnedHydrationStaging(
-  stagingRoot: string,
+  staging: HydrationStagingBinding,
   parent: string,
   prefix: string,
-  expectedFingerprint: FileFingerprint | undefined,
 ): Promise<void> {
   if (
-    expectedFingerprint === undefined ||
-    dirname(stagingRoot) !== parent ||
-    !basename(stagingRoot).startsWith(prefix)
+    dirname(staging.stagingRoot) !== parent ||
+    !basename(staging.stagingRoot).startsWith(prefix) ||
+    dirname(staging.ownershipPath) !== parent ||
+    basename(staging.ownershipPath) !==
+      `${basename(staging.stagingRoot)}${HYDRATION_OWNERSHIP_SUFFIX}`
   ) {
     return;
   }
-  const metadata = await lstat(stagingRoot, { bigint: true }).catch((error: unknown) => {
+  const metadata = await lstat(staging.stagingRoot, { bigint: true }).catch((error: unknown) => {
     if (isErrno(error, 'ENOENT')) return undefined;
     throw error;
   });
   if (
-    metadata === undefined ||
-    !metadata.isDirectory() ||
-    metadata.isSymbolicLink() ||
-    !sameFilesystemNode(expectedFingerprint, fingerprint(metadata))
+    metadata !== undefined &&
+    metadata.isDirectory() &&
+    !metadata.isSymbolicLink() &&
+    sameFilesystemNode(staging.stagingFingerprint, fingerprint(metadata))
   ) {
-    return;
+    await rm(staging.stagingRoot, { recursive: true });
   }
-  await rm(stagingRoot, { recursive: true });
+  await removeOwnedPackFile(staging.ownershipPath, staging.ownershipFingerprint);
+  await syncDirectory(parent);
 }
 
 async function removeOwnedPackTemporary(
@@ -1746,7 +1988,7 @@ async function removeOwnedPackPublication(
 async function removeOwnedPackFile(
   path: string,
   expectedFingerprint: FileFingerprint,
-): Promise<void> {
+): Promise<boolean> {
   const metadata = await lstat(path, { bigint: true }).catch((error: unknown) => {
     if (isErrno(error, 'ENOENT')) return undefined;
     throw error;
@@ -1757,9 +1999,10 @@ async function removeOwnedPackFile(
     metadata.isSymbolicLink() ||
     !sameFilesystemNode(expectedFingerprint, fingerprint(metadata))
   ) {
-    return;
+    return false;
   }
   await rm(path);
+  return true;
 }
 
 function inspectionFromReadResult(result: ReadValidationResult): SessionBundleInspection {

--- a/packages/storage/src/session-bundle-file-service.ts
+++ b/packages/storage/src/session-bundle-file-service.ts
@@ -15,7 +15,7 @@ import {
   type FileHandle,
 } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
-import { PassThrough, Readable, Transform } from 'node:stream';
+import { PassThrough, Readable, Transform, Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { constants as zlibConstants, createZstdCompress, createZstdDecompress } from 'node:zlib';
 import { unlock, waitForLock } from 'fs-native-extensions';
@@ -84,9 +84,14 @@ const publicationLockGates = new Map<string, Promise<void>>();
 interface FileFingerprint {
   dev: bigint;
   ino: bigint;
+  nlink: bigint;
   size: bigint;
   mtimeNs: bigint;
   ctimeNs: bigint;
+}
+
+interface PackPublicationState {
+  destinationLinked: boolean;
 }
 
 interface PackDirectoryEntry {
@@ -305,6 +310,9 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
     `.${basename(validated.destination)}${PACK_TEMP_MARKER}${randomUUID()}.tmp`,
   );
   let handle: FileHandle | undefined;
+  let temporaryFingerprint: FileFingerprint | undefined;
+  let published = false;
+  const publicationState: PackPublicationState = { destinationLinked: false };
   const archiveHash = createHash('sha256');
   const compressedMeter = new HashingQuotaTransform(
     archiveHash,
@@ -313,15 +321,21 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
     'pack',
   );
   let generatedTarBytes = 0;
-  let output: ReturnType<FileHandle['createWriteStream']> | undefined;
+  let output: OpenFileHandleWritable | undefined;
 
   try {
-    handle = await open(temporaryPath, 'wx', 0o600);
-    output = handle.createWriteStream({ autoClose: false, emitClose: false });
+    handle = await open(temporaryPath, 'wx+', 0o600);
+    const createdMetadata = await handle.stat({ bigint: true });
+    if (!createdMetadata.isFile()) throw ioError('pack');
+    temporaryFingerprint = fingerprint(createdMetadata);
+    output = new OpenFileHandleWritable(handle, 'pack');
     const tar = Readable.from(
-      meterGeneratedTar(generateSessionBundleTar(manifestBytes, entries), (bytes) => {
-        generatedTarBytes += bytes;
-      }),
+      meterGeneratedTar(
+        generateSessionBundleTar(manifestBytes, entries, validated.limits),
+        (bytes) => {
+          generatedTarBytes += bytes;
+        },
+      ),
     );
     await pipeline(
       tar,
@@ -340,12 +354,26 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
     await handle.sync();
     output.destroy();
     output = undefined;
-    await handle.close();
-    handle = undefined;
-    await publishPackFileNoReplace(temporaryPath, validated.destination);
+    const archiveDigest = `sha256:${archiveHash.digest('hex')}` as Sha256Digest;
+    const hashedFingerprint = await assertPackTemporaryBound(
+      handle,
+      temporaryPath,
+      temporaryFingerprint,
+      compressedMeter.bytes,
+    );
+    await publishPackFileNoReplace(
+      handle,
+      temporaryPath,
+      validated.destination,
+      hashedFingerprint,
+      archiveDigest,
+      compressedMeter.bytes,
+      publicationState,
+    );
+    published = true;
     return {
       path: validated.destination,
-      archiveDigest: `sha256:${archiveHash.digest('hex')}` as Sha256Digest,
+      archiveDigest,
       compressedBytes: compressedMeter.bytes,
       decompressedTarBytes,
       payloadBytes: tree.payloadBytes,
@@ -353,8 +381,15 @@ async function packSessionBundle(input: SessionBundlePackInput): Promise<Session
     };
   } finally {
     output?.destroy();
+    if (!published && publicationState.destinationLinked && temporaryFingerprint !== undefined) {
+      await removeOwnedPackPublication(validated.destination, parent, temporaryFingerprint).catch(
+        () => {},
+      );
+    }
+    if (temporaryFingerprint !== undefined) {
+      await removeOwnedPackTemporary(temporaryPath, parent, temporaryFingerprint).catch(() => {});
+    }
     await handle?.close().catch(() => {});
-    await removeOwnedPackTemporary(temporaryPath, parent).catch(() => {});
   }
 }
 
@@ -428,6 +463,12 @@ async function scanPackDirectory(
         'Session bundle source contains an unsupported filesystem entry',
       );
     }
+    if (metadata.nlink !== 1n) {
+      throw new SessionBundleFileError(
+        'unsupported_entry',
+        'Session bundle source contains a hard-linked file',
+      );
+    }
 
     const path = `${archiveDirectory}${childName}`;
     validatePackPath(path, limits);
@@ -467,7 +508,11 @@ async function inspectPackFile(
   const handle = await openPackSourceFile(sourcePath);
   try {
     const before = await handle.stat({ bigint: true });
-    if (!before.isFile() || !sameFingerprint(scannedFingerprint, fingerprint(before))) {
+    if (
+      !before.isFile() ||
+      before.nlink !== 1n ||
+      !sameFingerprint(scannedFingerprint, fingerprint(before))
+    ) {
       throw sourceChanged();
     }
     const hash = createHash('sha256');
@@ -486,6 +531,7 @@ async function inspectPackFile(
     if (
       observed !== size ||
       !after.isFile() ||
+      after.nlink !== 1n ||
       !sameFingerprint(scannedFingerprint, fingerprint(after))
     ) {
       throw sourceChanged();
@@ -503,6 +549,7 @@ async function inspectPackFile(
 async function* generateSessionBundleTar(
   manifestBytes: Buffer,
   entries: readonly PackEntry[],
+  limits: SessionBundleLimits,
 ): AsyncGenerator<Buffer> {
   yield Buffer.from(
     encodeSessionBundleUstarHeaderV1({
@@ -528,7 +575,7 @@ async function* generateSessionBundleTar(
       if ('bytes' in entry) {
         yield entry.bytes;
       } else if (isPackDiskFileEntry(entry)) {
-        yield* readVerifiedPackFile(entry);
+        yield* readVerifiedPackFile(entry, limits);
       } else {
         throw new SessionBundleFileError(
           'integrity_mismatch',
@@ -545,24 +592,37 @@ function isPackDiskFileEntry(entry: PackEntry): entry is PackDiskFileEntry {
   return entry.canonical.kind === 'file' && 'sourcePath' in entry;
 }
 
-async function* readVerifiedPackFile(entry: PackDiskFileEntry): AsyncGenerator<Buffer> {
+async function* readVerifiedPackFile(
+  entry: PackDiskFileEntry,
+  limits: SessionBundleLimits,
+): AsyncGenerator<Buffer> {
   const handle = await openPackSourceFile(entry.sourcePath);
   try {
     const before = await handle.stat({ bigint: true });
-    if (!before.isFile() || !sameFingerprint(entry.fingerprint, fingerprint(before))) {
+    if (
+      !before.isFile() ||
+      before.nlink !== 1n ||
+      !sameFingerprint(entry.fingerprint, fingerprint(before))
+    ) {
       throw sourceChanged();
     }
     const hash = createHash('sha256');
     let observed = 0;
-    for await (const value of handle.createReadStream({
-      autoClose: false,
-      emitClose: false,
-      highWaterMark: PACK_FILE_CHUNK_BYTES,
-    })) {
-      const chunk = Buffer.from(value);
-      observed = safeAdd(observed, chunk.byteLength, 'source_changed');
-      hash.update(chunk);
-      yield chunk;
+    if (entry.canonical.size > 0) {
+      for await (const value of handle.createReadStream({
+        autoClose: false,
+        emitClose: false,
+        start: 0,
+        end: entry.canonical.size - 1,
+        highWaterMark: PACK_FILE_CHUNK_BYTES,
+      })) {
+        const chunk = Buffer.from(value);
+        observed = safeAdd(observed, chunk.byteLength, 'source_changed');
+        if (observed > entry.canonical.size) throw sourceChanged();
+        assertQuota('pack', limits, 'maxFileBytes', observed);
+        hash.update(chunk);
+        yield chunk;
+      }
     }
     const after = await handle.stat({ bigint: true });
     const digest = `sha256:${hash.digest('hex')}`;
@@ -570,6 +630,7 @@ async function* readVerifiedPackFile(entry: PackDiskFileEntry): AsyncGenerator<B
       observed !== entry.canonical.size ||
       digest !== entry.canonical.contentDigest ||
       !after.isFile() ||
+      after.nlink !== 1n ||
       !sameFingerprint(entry.fingerprint, fingerprint(after))
     ) {
       throw sourceChanged();
@@ -1049,6 +1110,26 @@ class HashingQuotaTransform extends CountingQuotaTransform {
   }
 }
 
+class OpenFileHandleWritable extends Writable {
+  constructor(
+    private readonly handle: FileHandle,
+    private readonly operation: 'pack' | 'hydrate',
+  ) {
+    super();
+  }
+
+  override _write(
+    value: Buffer | Uint8Array,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    writeAll(this.handle, Buffer.from(value), this.operation).then(
+      () => callback(),
+      (error: unknown) => callback(error as Error),
+    );
+  }
+}
+
 /** Remove the empty frame Node's streaming compressor appends after multi-chunk input. */
 class CanonicalZstdOutputTransform extends Transform {
   #tail = Buffer.alloc(0);
@@ -1410,14 +1491,95 @@ async function assertDestinationMissing(
   throw destinationExists(operation);
 }
 
-async function publishPackFileNoReplace(temporaryPath: string, destination: string): Promise<void> {
+async function assertPackTemporaryBound(
+  handle: FileHandle,
+  temporaryPath: string,
+  expectedIdentity: FileFingerprint,
+  expectedBytes: number,
+): Promise<FileFingerprint> {
+  const [handleMetadata, pathMetadata] = await Promise.all([
+    handle.stat({ bigint: true }),
+    lstat(temporaryPath, { bigint: true }),
+  ]);
+  const handleFingerprint = fingerprint(handleMetadata);
+  if (
+    !handleMetadata.isFile() ||
+    !pathMetadata.isFile() ||
+    handleMetadata.nlink !== 1n ||
+    pathMetadata.nlink !== 1n ||
+    handleMetadata.size !== BigInt(expectedBytes) ||
+    !sameFilesystemNode(expectedIdentity, handleFingerprint) ||
+    !sameFingerprint(handleFingerprint, fingerprint(pathMetadata))
+  ) {
+    throw packPublicationChanged();
+  }
+  return handleFingerprint;
+}
+
+async function publishPackFileNoReplace(
+  handle: FileHandle,
+  temporaryPath: string,
+  destination: string,
+  hashedFingerprint: FileFingerprint,
+  expectedDigest: Sha256Digest,
+  expectedBytes: number,
+  state: PackPublicationState,
+): Promise<void> {
   try {
     // Both paths are siblings, so a hard link is an atomic no-replace publication.
     await link(temporaryPath, destination);
+    state.destinationLinked = true;
   } catch (error) {
     if (isErrno(error, 'EEXIST')) throw destinationExists('pack');
     throw error;
   }
+
+  const [beforeHandle, beforeDestination] = await Promise.all([
+    handle.stat({ bigint: true }),
+    lstat(destination, { bigint: true }),
+  ]);
+  const verificationFingerprint = fingerprint(beforeHandle);
+  if (
+    !beforeHandle.isFile() ||
+    !beforeDestination.isFile() ||
+    beforeHandle.size !== BigInt(expectedBytes) ||
+    !sameFilesystemNode(hashedFingerprint, verificationFingerprint) ||
+    !sameFingerprint(verificationFingerprint, fingerprint(beforeDestination))
+  ) {
+    throw packPublicationChanged();
+  }
+
+  const actualDigest = await digestOpenPackFile(handle, expectedBytes);
+  const [afterHandle, afterDestination] = await Promise.all([
+    handle.stat({ bigint: true }),
+    lstat(destination, { bigint: true }),
+  ]);
+  if (
+    actualDigest !== expectedDigest ||
+    !afterHandle.isFile() ||
+    !afterDestination.isFile() ||
+    !sameFingerprint(verificationFingerprint, fingerprint(afterHandle)) ||
+    !sameFingerprint(fingerprint(afterHandle), fingerprint(afterDestination))
+  ) {
+    throw packPublicationChanged();
+  }
+}
+
+async function digestOpenPackFile(
+  handle: FileHandle,
+  expectedBytes: number,
+): Promise<Sha256Digest> {
+  const hash = createHash('sha256');
+  const buffer = Buffer.alloc(Math.min(PACK_FILE_CHUNK_BYTES, Math.max(expectedBytes, 1)));
+  let position = 0;
+  while (position < expectedBytes) {
+    const length = Math.min(buffer.byteLength, expectedBytes - position);
+    const { bytesRead } = await handle.read(buffer, 0, length, position);
+    if (bytesRead <= 0) throw packPublicationChanged();
+    hash.update(buffer.subarray(0, bytesRead));
+    position += bytesRead;
+  }
+  return `sha256:${hash.digest('hex')}` as Sha256Digest;
 }
 
 async function withDestinationPublicationLock<T>(
@@ -1513,11 +1675,15 @@ function hydrationPath(stagingRoot: string, archivePath: string): string {
   return join(stagingRoot, ...logical.split('/'));
 }
 
-async function writeAll(handle: FileHandle, chunk: Buffer): Promise<void> {
+async function writeAll(
+  handle: FileHandle,
+  chunk: Buffer,
+  operation: 'pack' | 'hydrate' = 'hydrate',
+): Promise<void> {
   let offset = 0;
   while (offset < chunk.byteLength) {
     const result = await handle.write(chunk, offset, chunk.byteLength - offset, null);
-    if (result.bytesWritten <= 0) throw ioError('hydrate');
+    if (result.bytesWritten <= 0) throw ioError(operation);
     offset += result.bytesWritten;
   }
 }
@@ -1550,13 +1716,40 @@ async function removeOwnedHydrationStaging(
   await rm(stagingRoot, { recursive: true });
 }
 
-async function removeOwnedPackTemporary(path: string, parent: string): Promise<void> {
+async function removeOwnedPackTemporary(
+  path: string,
+  parent: string,
+  expectedFingerprint: FileFingerprint,
+): Promise<void> {
   if (dirname(path) !== parent || !basename(path).includes(PACK_TEMP_MARKER)) return;
-  const metadata = await lstat(path).catch((error: unknown) => {
+  await removeOwnedPackFile(path, expectedFingerprint);
+}
+
+async function removeOwnedPackPublication(
+  path: string,
+  parent: string,
+  expectedFingerprint: FileFingerprint,
+): Promise<void> {
+  if (dirname(path) !== parent) return;
+  await removeOwnedPackFile(path, expectedFingerprint);
+}
+
+async function removeOwnedPackFile(
+  path: string,
+  expectedFingerprint: FileFingerprint,
+): Promise<void> {
+  const metadata = await lstat(path, { bigint: true }).catch((error: unknown) => {
     if (isErrno(error, 'ENOENT')) return undefined;
     throw error;
   });
-  if (metadata === undefined || !metadata.isFile() || metadata.isSymbolicLink()) return;
+  if (
+    metadata === undefined ||
+    !metadata.isFile() ||
+    metadata.isSymbolicLink() ||
+    !sameFilesystemNode(expectedFingerprint, fingerprint(metadata))
+  ) {
+    return;
+  }
   await rm(path);
 }
 
@@ -1573,6 +1766,7 @@ function fingerprint(metadata: BigIntStats): FileFingerprint {
   return {
     dev: metadata.dev,
     ino: metadata.ino,
+    nlink: metadata.nlink,
     size: metadata.size,
     mtimeNs: metadata.mtimeNs,
     ctimeNs: metadata.ctimeNs,
@@ -1583,6 +1777,7 @@ function sameFingerprint(left: FileFingerprint, right: FileFingerprint): boolean
   return (
     left.dev === right.dev &&
     left.ino === right.ino &&
+    left.nlink === right.nlink &&
     left.size === right.size &&
     left.mtimeNs === right.mtimeNs &&
     left.ctimeNs === right.ctimeNs
@@ -1627,6 +1822,13 @@ function sourceChanged(): SessionBundleFileError {
   return new SessionBundleFileError(
     'source_changed',
     'Session bundle source changed while it was being consumed',
+  );
+}
+
+function packPublicationChanged(): SessionBundleFileError {
+  return new SessionBundleFileError(
+    'source_changed',
+    'Session bundle pack output changed before publication completed',
   );
 }
 

--- a/packages/storage/src/session-bundle-ustar.ts
+++ b/packages/storage/src/session-bundle-ustar.ts
@@ -19,7 +19,11 @@ export interface SessionBundleUstarHeader {
   size: number;
 }
 
-/** Encode the exact POSIX USTAR header admitted by Session Bundle codec V1. */
+/**
+ * Encode the exact POSIX USTAR header admitted by Session Bundle codec V1.
+ * Paths use a portable subset on every host: Windows device names, forbidden
+ * characters, and trailing dots/spaces are rejected even when running on POSIX.
+ */
 export function encodeSessionBundleUstarHeaderV1(value: SessionBundleUstarHeader): Uint8Array {
   const path = splitUstarPath(value.path);
   if (value.kind === 'directory') {

--- a/packages/storage/src/session-bundle-ustar.ts
+++ b/packages/storage/src/session-bundle-ustar.ts
@@ -8,6 +8,9 @@ const USTAR_PREFIX_BYTES = 155;
 const USTAR_SIZE_MAX = 0o77_777_777_777;
 const ASCII_ZERO = '0'.charCodeAt(0);
 const ASCII_SPACE = ' '.charCodeAt(0);
+const WINDOWS_FORBIDDEN_PATH_CHARACTERS = /[\u0000-\u001f<>:"|?*]/u;
+const WINDOWS_RESERVED_PATH_SEGMENT =
+  /^(?:con|prn|aux|nul|conin\$|conout\$|com[1-9\u00b9\u00b2\u00b3]|lpt[1-9\u00b9\u00b2\u00b3])(?:\..*)?$/iu;
 
 export interface SessionBundleUstarHeader {
   kind: 'directory' | 'file';
@@ -120,11 +123,19 @@ function splitUstarPath(path: string): { name: string; prefix: string } {
     throw unsafePath('Session bundle path is not valid for USTAR');
   }
   const logicalPath = path.endsWith('/') ? path.slice(0, -1) : path;
+  const segments = logicalPath.split('/');
   if (
     logicalPath.length === 0 ||
-    logicalPath
-      .split('/')
-      .some((segment) => segment.length === 0 || segment === '.' || segment === '..')
+    segments.some(
+      (segment) =>
+        segment.length === 0 ||
+        segment === '.' ||
+        segment === '..' ||
+        WINDOWS_FORBIDDEN_PATH_CHARACTERS.test(segment) ||
+        segment.endsWith('.') ||
+        segment.endsWith(' ') ||
+        WINDOWS_RESERVED_PATH_SEGMENT.test(segment),
+    )
   ) {
     throw unsafePath('Session bundle path is not valid for USTAR');
   }

--- a/packages/storage/src/session-bundle-ustar.ts
+++ b/packages/storage/src/session-bundle-ustar.ts
@@ -1,0 +1,212 @@
+import { Buffer } from 'node:buffer';
+import { isValidUnicodeString, SessionBundleFileError } from './session-bundle-contract.js';
+
+export const SESSION_BUNDLE_USTAR_BLOCK_BYTES = 512;
+
+const USTAR_NAME_BYTES = 100;
+const USTAR_PREFIX_BYTES = 155;
+const USTAR_SIZE_MAX = 0o77_777_777_777;
+const ASCII_ZERO = '0'.charCodeAt(0);
+const ASCII_SPACE = ' '.charCodeAt(0);
+
+export interface SessionBundleUstarHeader {
+  kind: 'directory' | 'file';
+  path: string;
+  mode: 0o644 | 0o755;
+  size: number;
+}
+
+/** Encode the exact POSIX USTAR header admitted by Session Bundle codec V1. */
+export function encodeSessionBundleUstarHeaderV1(value: SessionBundleUstarHeader): Uint8Array {
+  const path = splitUstarPath(value.path);
+  if (value.kind === 'directory') {
+    if (value.mode !== 0o755 || value.size !== 0 || !value.path.endsWith('/')) {
+      throw unsupportedEntry('Session bundle directory metadata is not canonical');
+    }
+  } else if (
+    (value.mode !== 0o644 && value.mode !== 0o755) ||
+    !Number.isSafeInteger(value.size) ||
+    value.size < 0 ||
+    value.size > USTAR_SIZE_MAX ||
+    value.path.endsWith('/')
+  ) {
+    throw unsupportedEntry('Session bundle regular-file metadata is not representable in V1');
+  }
+
+  const header = Buffer.alloc(SESSION_BUNDLE_USTAR_BLOCK_BYTES);
+  Buffer.from(path.name, 'utf8').copy(header, 0);
+  writeOctal(header, 100, 8, value.mode);
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  writeOctal(header, 124, 12, value.size);
+  writeOctal(header, 136, 12, 0);
+  header.fill(ASCII_SPACE, 148, 156);
+  header[156] = value.kind === 'directory' ? '5'.charCodeAt(0) : '0'.charCodeAt(0);
+  Buffer.from('ustar\0', 'ascii').copy(header, 257);
+  Buffer.from('00', 'ascii').copy(header, 263);
+  writeOctal(header, 329, 8, 0);
+  writeOctal(header, 337, 8, 0);
+  Buffer.from(path.prefix, 'utf8').copy(header, 345);
+
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  writeChecksum(header, checksum);
+  return header;
+}
+
+/** Decode a header and reject every representation outside the exact V1 subset. */
+export function decodeSessionBundleUstarHeaderV1(value: Uint8Array): SessionBundleUstarHeader {
+  if (!(value instanceof Uint8Array) || value.byteLength !== SESSION_BUNDLE_USTAR_BLOCK_BYTES) {
+    throw integrityError('Session bundle USTAR header is truncated');
+  }
+  const header = Buffer.from(value);
+  const expectedChecksum = parseOctal(header.subarray(148, 156));
+  const checksumHeader = Buffer.from(header);
+  checksumHeader.fill(ASCII_SPACE, 148, 156);
+  const actualChecksum = checksumHeader.reduce((sum, byte) => sum + byte, 0);
+  if (expectedChecksum !== actualChecksum) {
+    throw integrityError('Session bundle USTAR checksum does not match');
+  }
+
+  const name = decodeNulTerminatedUtf8(header.subarray(0, 100));
+  const prefix = decodeNulTerminatedUtf8(header.subarray(345, 500));
+  const path = prefix.length === 0 ? name : `${prefix}/${name}`;
+  if (path.length === 0) throw unsafePath('Session bundle USTAR path is empty');
+
+  const type = header[156];
+  const kind =
+    type === '0'.charCodeAt(0) ? 'file' : type === '5'.charCodeAt(0) ? 'directory' : undefined;
+  if (kind === undefined) {
+    throw unsupportedEntry('Session bundle USTAR entry type is not supported');
+  }
+
+  const mode = parseOctal(header.subarray(100, 108));
+  const size = parseOctal(header.subarray(124, 136));
+  const decoded: SessionBundleUstarHeader = {
+    kind,
+    path,
+    mode: mode as 0o644 | 0o755,
+    size,
+  };
+  const canonical = encodeSessionBundleUstarHeaderV1(decoded);
+  if (!header.equals(canonical)) {
+    throw unsupportedEntry('Session bundle USTAR metadata is not canonical');
+  }
+  return decoded;
+}
+
+export function sessionBundleUstarPaddingBytes(size: number): number {
+  if (!Number.isSafeInteger(size) || size < 0) {
+    throw unsupportedEntry('Session bundle USTAR entry size is invalid');
+  }
+  return (
+    (SESSION_BUNDLE_USTAR_BLOCK_BYTES - (size % SESSION_BUNDLE_USTAR_BLOCK_BYTES)) %
+    SESSION_BUNDLE_USTAR_BLOCK_BYTES
+  );
+}
+
+export function isSessionBundleUstarZeroBlock(value: Uint8Array): boolean {
+  return value.byteLength === SESSION_BUNDLE_USTAR_BLOCK_BYTES && value.every((byte) => byte === 0);
+}
+
+function splitUstarPath(path: string): { name: string; prefix: string } {
+  if (
+    !isValidUnicodeString(path) ||
+    path.length === 0 ||
+    path.includes('\0') ||
+    path.includes('\\') ||
+    path.startsWith('/') ||
+    /^[A-Za-z]:/.test(path)
+  ) {
+    throw unsafePath('Session bundle path is not valid for USTAR');
+  }
+  const logicalPath = path.endsWith('/') ? path.slice(0, -1) : path;
+  if (
+    logicalPath.length === 0 ||
+    logicalPath
+      .split('/')
+      .some((segment) => segment.length === 0 || segment === '.' || segment === '..')
+  ) {
+    throw unsafePath('Session bundle path is not valid for USTAR');
+  }
+  if (Buffer.byteLength(path, 'utf8') <= USTAR_NAME_BYTES) return { name: path, prefix: '' };
+
+  for (let index = path.length - 1; index > 0; index = path.lastIndexOf('/', index - 1)) {
+    if (index < 0) break;
+    const prefix = path.slice(0, index);
+    const name = path.slice(index + 1);
+    if (
+      name.length > 0 &&
+      Buffer.byteLength(prefix, 'utf8') <= USTAR_PREFIX_BYTES &&
+      Buffer.byteLength(name, 'utf8') <= USTAR_NAME_BYTES
+    ) {
+      return { name, prefix };
+    }
+  }
+  throw unsafePath('Session bundle path is not representable by USTAR V1');
+}
+
+function writeOctal(target: Buffer, offset: number, length: number, value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw unsupportedEntry('Session bundle USTAR numeric field is invalid');
+  }
+  const octal = value.toString(8);
+  if (octal.length > length - 1) {
+    throw unsupportedEntry('Session bundle USTAR numeric field exceeds V1');
+  }
+  target.fill(ASCII_ZERO, offset, offset + length - 1);
+  target.write(octal, offset + length - 1 - octal.length, octal.length, 'ascii');
+  target[offset + length - 1] = 0;
+}
+
+function writeChecksum(target: Buffer, value: number): void {
+  const octal = value.toString(8);
+  if (octal.length > 6) throw integrityError('Session bundle USTAR checksum exceeds its field');
+  target.fill(ASCII_ZERO, 148, 154);
+  target.write(octal, 154 - octal.length, octal.length, 'ascii');
+  target[154] = 0;
+  target[155] = ASCII_SPACE;
+}
+
+function parseOctal(value: Buffer): number {
+  const nul = value.indexOf(0);
+  const body = value
+    .subarray(0, nul < 0 ? value.length : nul)
+    .toString('ascii')
+    .trim();
+  if (body.length === 0 || !/^[0-7]+$/.test(body)) {
+    throw unsupportedEntry('Session bundle USTAR numeric field is malformed');
+  }
+  if (nul >= 0 && value.subarray(nul + 1).some((byte) => byte !== 0 && byte !== ASCII_SPACE)) {
+    throw unsupportedEntry('Session bundle USTAR numeric field has unsupported trailing bytes');
+  }
+  const parsed = Number.parseInt(body, 8);
+  if (!Number.isSafeInteger(parsed)) {
+    throw unsupportedEntry('Session bundle USTAR numeric field exceeds the safe integer range');
+  }
+  return parsed;
+}
+
+function decodeNulTerminatedUtf8(value: Buffer): string {
+  const nul = value.indexOf(0);
+  const bytes = value.subarray(0, nul < 0 ? value.length : nul);
+  if (nul >= 0 && value.subarray(nul + 1).some((byte) => byte !== 0)) {
+    throw unsupportedEntry('Session bundle USTAR string field has unsupported trailing bytes');
+  }
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    throw unsafePath('Session bundle USTAR path is not valid UTF-8');
+  }
+}
+
+function unsafePath(message: string): SessionBundleFileError {
+  return new SessionBundleFileError('unsafe_path', message);
+}
+
+function unsupportedEntry(message: string): SessionBundleFileError {
+  return new SessionBundleFileError('unsupported_entry', message);
+}
+
+function integrityError(message: string): SessionBundleFileError {
+  return new SessionBundleFileError('integrity_mismatch', message);
+}

--- a/packages/storage/src/session-bundle-ustar.ts
+++ b/packages/storage/src/session-bundle-ustar.ts
@@ -142,7 +142,6 @@ function splitUstarPath(path: string): { name: string; prefix: string } {
   if (Buffer.byteLength(path, 'utf8') <= USTAR_NAME_BYTES) return { name: path, prefix: '' };
 
   for (let index = path.length - 1; index > 0; index = path.lastIndexOf('/', index - 1)) {
-    if (index < 0) break;
     const prefix = path.slice(0, index);
     const name = path.slice(index + 1);
     if (
@@ -191,9 +190,6 @@ function parseOctal(value: Buffer): number {
     throw unsupportedEntry('Session bundle USTAR numeric field has unsupported trailing bytes');
   }
   const parsed = Number.parseInt(body, 8);
-  if (!Number.isSafeInteger(parsed)) {
-    throw unsupportedEntry('Session bundle USTAR numeric field exceeds the safe integer range');
-  }
   return parsed;
 }
 


### PR DESCRIPTION
## Summary

- implement deterministic POSIX USTAR V1 writing and strict canonical decoding
- add fixed-parameter Node.js Zstandard framing, archive SHA-256 verification, and a shared streaming validator
- implement pack, inspect, and hydrate with explicit quotas, safe extraction, source-change detection, sibling staging, cleanup, and atomic publication
- add golden, corruption, security, round-trip, and independent-process hydration coverage

## Testing

- npm run format:check
- npm run lint
- npm run build
- npm run typecheck
- 15 targeted Session Bundle storage tests

Closes #1528