### PR TITLE
redesign(settings): two-column split sections, previewed on General

### DIFF
--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -176,7 +176,7 @@ export function PersonalizationSettingsPage(props: {
       {/* These editable values stay in the same grouped Settings card as the
           neighboring preferences; the full-width tone field uses the vertical
           row variant. */}
-      <SettingsSection title={sections.identity} description={sections.identityHelp}>
+      <SettingsSection layout="split" title={sections.identity} description={sections.identityHelp}>
         <SettingsField>
           <TextInput
             type="text"

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -61,7 +61,7 @@ export function GeneralSettingsPage(props: {
           moved here from the 外观 page — they configure who you are to the
           app, not how the app looks. The component keeps its save flow. */}
       <PersonalizationSettingsPage settings={props.settings} onUpdate={props.onUpdate} />
-      <SettingsSection title={sections.privacy} description={sections.privacyHelp}>
+      <SettingsSection layout="split" title={sections.privacy} description={sections.privacyHelp}>
         <SettingsRow
           label={copy.incognito}
           description={copy.incognitoHelp}
@@ -99,6 +99,7 @@ export function GeneralSettingsPage(props: {
         onUpdate={props.onUpdate}
       />
       <SettingsSection
+        layout="split"
         title={memoryCopy.text.instructions}
         description={memoryCopy.text.instructionsHelp}
       >
@@ -121,7 +122,7 @@ export function GeneralSettingsPage(props: {
           onCreate={workspaceInstructions.createFile}
         />
       </SettingsSection>
-      <SettingsSection title={sections.network} description={sections.networkHelp}>
+      <SettingsSection layout="split" title={sections.network} description={sections.networkHelp}>
         <NetworkProxySection settings={props.settings} onUpdate={props.onUpdate} />
       </SettingsSection>
     </SettingsPage>
@@ -238,7 +239,7 @@ function GeneralDefaultsCard(props: {
   }
 
   return (
-    <SettingsSection title={sections.chatDefaults} description={sections.chatDefaultsHelp}>
+    <SettingsSection layout="split" title={sections.chatDefaults} description={sections.chatDefaultsHelp}>
       <SettingsRow
         label={copy.defaultModel}
         description={copy.defaultModelHelp}

--- a/apps/desktop/src/renderer/settings/settings-section.tsx
+++ b/apps/desktop/src/renderer/settings/settings-section.tsx
@@ -68,6 +68,11 @@ export function SettingsSection(props: {
   /** Group-level action cluster (refresh, add, filter), right-aligned. */
   action?: ReactNode;
   variant?: 'rows' | 'bare';
+  /** 'split' pairs the header (left column) with the body (right column) at
+   *  wide content widths — the Astryx settings template's two-column form.
+   *  Falls back to the stacked layout below the width threshold. The anchor
+   *  Divider is omitted in split mode; the column seam carries the grouping. */
+  layout?: 'stack' | 'split';
   className?: string;
   /** Class for the body element, when a page needs to pin its own grid. */
   bodyClassName?: string;
@@ -75,7 +80,11 @@ export function SettingsSection(props: {
 }) {
   const hasHeader = props.title != null || props.description != null || props.action != null;
   return (
-    <section className={cn('settingsSection', props.className)} aria-labelledby={props.titleId}>
+    <section
+      className={cn('settingsSection', props.className)}
+      data-layout={props.layout === 'split' ? 'split' : undefined}
+      aria-labelledby={props.titleId}
+    >
       {hasHeader ? (
         /* The header is Astryx's own settings idiom — `Heading level={3}` over
            a `Text type="supporting" color="secondary"` lede — as used by the
@@ -98,7 +107,7 @@ export function SettingsSection(props: {
           {props.action != null ? <div>{props.action}</div> : null}
         </HStack>
       ) : null}
-      {hasHeader ? <Divider /> : null}
+      {hasHeader && props.layout !== 'split' ? <Divider /> : null}
       {props.variant === 'bare' ? (
         <div className={cn('settingsSectionBody', props.bodyClassName)}>{props.children}</div>
       ) : (

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -315,7 +315,7 @@ export function SettingsSurface(props: {
             <Layout
               height="fill"
               padding={0}
-              contentWidth={section === 'usage' ? 920 : 640}
+              contentWidth={section === 'usage' ? 920 : section === 'general' ? 1040 : 640}
               header={(
                 <LayoutHeader padding={6}>
                   <div className="settingsPageHeader">

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -124,6 +124,7 @@
    no longer a card — it's just the vertical container with gap, and
    `.settingsRows` is the ONLY card primitive. */
 .settingsPageStack {
+  container: settings-page / inline-size;
   display: grid;
   align-content: start;
   /* #1362: explicit column. The implicit `auto` track sizes to the widest
@@ -159,6 +160,21 @@
      (a long mono path, a scrollable pre) must not widen the section. */
   grid-template-columns: minmax(0, 1fr);
   gap: var(--space-2);
+}
+
+/* The Astryx settings template's two-column form (layout='split'): title +
+   lede in a fixed left column, the rows in the right column, 40px between —
+   template evidence: settings/page.tsx Grid columns={{minWidth: 320}}
+   gap={10}. Below the threshold the section falls back to the stacked grid
+   above. Gated on the page-stack container width, so a section splits only
+   where its page actually grants a wide content column (General at 1040)
+   and stays stacked on narrow pages regardless of window size. */
+@container settings-page (min-width: 880px) {
+  .settingsSection[data-layout='split'] {
+    grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+    column-gap: var(--space-10);
+    row-gap: var(--space-2);
+  }
 }
 
 .settingsSectionBodyHidden {


### PR DESCRIPTION
The premium study called the Astryx settings template's **two-column form** (title + lede left, fields right, `Grid columns={{minWidth: 320}} gap={10}`) the single biggest visual gap between Maka's settings and the template. This PR lands it as an **opt-in kit capability, previewed on the General page only**, for sign-off before sweeping all pages.

- `SettingsSection` gains `layout="split"` — header column + body column, no anchor Divider (the column seam carries the grouping); stacked stays the default.
- Split is gated on a **container query** (`.settingsPageStack` becomes an inline-size container): a section splits only where its page grants a wide content column. General widens to `contentWidth` 1040; the 身份 section General composes from the appearance page splits inside General yet stays stacked on 外观's 640 column — same code, both correct automatically.
- General's five groups adopt the split.

Layout-only: no logic or a11y changes (headings/ids/roles untouched). Verification: build ✅ typecheck ✅ format ✅ dead-css ✅ checks ✅ smoke 74×3 ✅. Screenshot in the work thread — **awaiting the sweep-or-revert verdict there before converting the remaining pages**.