### PR TITLE
feat(inspector): surface the session trace as a workbar tab

### DIFF
--- a/apps/desktop/src/main/__tests__/inspector-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/inspector-ipc-main.test.ts
@@ -6,7 +6,7 @@ import {
   type ModelCallAttempt,
 } from '@maka/core/model-call-attempt';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
-import { readSessionTrace } from '../inspector-ipc-main.js';
+import { readSessionTrace, registerInspectorIpc } from '../inspector-ipc-main.js';
 
 function attempt(overrides: Partial<ModelCallAttempt> = {}): ModelCallAttempt {
   return {
@@ -121,5 +121,32 @@ describe('inspector trace read', () => {
 
     assert.equal(trace.turns.length, 0);
     assert.equal(trace.coverage.modelCalls, 'none');
+  });
+
+  it('answers a failed read as a typed error rather than a rejected invoke', async () => {
+    // The renderer treats the channel as `Result`; an unwrapped rejection would
+    // surface as an unhandled invoke failure instead of a retryable panel state.
+    const handlers = new Map<string, (event: unknown, ...args: never[]) => unknown>();
+    registerInspectorIpc({
+      ipcMain: {
+        handle: (channel: string, handler: (event: unknown, ...args: never[]) => unknown) => {
+          handlers.set(channel, handler);
+        },
+      } as never,
+      readSessionRuntimeEvents: async () => {
+        throw new Error('ledger unavailable');
+      },
+      listSessionRuns: async () => [],
+      readRunEvents: async () => [],
+    });
+
+    const handler = handlers.get('inspector:trace');
+    assert.ok(handler, 'the channel is registered');
+    const result = (await handler(undefined, 'session-1' as never)) as {
+      ok: boolean;
+      error?: { code: string };
+    };
+    assert.equal(result.ok, false);
+    assert.equal(result.error?.code, 'INSPECTOR_TRACE_FAILED');
   });
 });

--- a/apps/desktop/src/main/__tests__/inspector-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/inspector-ipc-main.test.ts
@@ -1,0 +1,125 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  MODEL_CALL_ATTEMPT_EVENT_TYPE,
+  MODEL_CALL_ATTEMPT_SCHEMA_VERSION,
+  type ModelCallAttempt,
+} from '@maka/core/model-call-attempt';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { readSessionTrace } from '../inspector-ipc-main.js';
+
+function attempt(overrides: Partial<ModelCallAttempt> = {}): ModelCallAttempt {
+  return {
+    schemaVersion: MODEL_CALL_ATTEMPT_SCHEMA_VERSION,
+    logicalCallId: 'call-1',
+    attemptId: 'attempt-1',
+    traceId: 'trace-1',
+    sessionId: 'session-1',
+    runId: 'run-1',
+    turnId: 'turn-1',
+    step: 0,
+    attempt: 0,
+    callKind: 'main',
+    providerId: 'anthropic',
+    modelId: 'claude-test',
+    startedAt: 1_000,
+    completedAt: 1_500,
+    latencyMs: 500,
+    status: 'completed',
+    usageBasis: 'reported',
+    inputTokens: 10,
+    outputTokens: 5,
+    costBasis: 'priced',
+    costUsd: 0.002,
+    ...overrides,
+  };
+}
+
+function runtimeEvent(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
+  return {
+    id: 'event-1',
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1_000,
+    partial: false,
+    role: 'model',
+    author: 'agent',
+    ...overrides,
+  };
+}
+
+describe('inspector trace read', () => {
+  it('joins the AgentRun stream with the session runtime events', async () => {
+    // The canonical metering authority is the run stream, not the Usage read
+    // model — that one is range-queried and carries no session predicate.
+    const readRuns: string[] = [];
+    const trace = await readSessionTrace(
+      {
+        readSessionRuntimeEvents: async () => [
+          runtimeEvent({
+            id: 'usage-1',
+            ts: 2_000,
+            actions: { tokenUsage: { input: 10, output: 5, total: 15, runtimeSteps: 1 } },
+          }),
+        ],
+        listSessionRuns: async () => [{ runId: 'run-1' }, { runId: 'run-2' }],
+        readRunEvents: async (_sessionId, runId) => {
+          readRuns.push(runId);
+          return runId === 'run-1'
+            ? [
+                { type: 'run_started' },
+                { type: MODEL_CALL_ATTEMPT_EVENT_TYPE, data: attempt() },
+              ]
+            : [];
+        },
+      },
+      'session-1',
+    );
+
+    assert.deepEqual(readRuns, ['run-1', 'run-2'], 'every run of the session is read');
+    assert.equal(trace.sessionId, 'session-1');
+    assert.equal(trace.totals.modelAttempts, 1);
+    assert.equal(trace.totals.costUsd, 0.002);
+    assert.equal(trace.coverage.modelCalls, 'no_known_gap');
+    assert.equal(trace.coverage.unreadableRecords, 0);
+  });
+
+  it('counts a record it cannot decode instead of dropping it', async () => {
+    // An undecodable record is spend the trace cannot show. Silently skipping
+    // it would make an incomplete trace look complete.
+    const trace = await readSessionTrace(
+      {
+        readSessionRuntimeEvents: async () => [],
+        listSessionRuns: async () => [{ runId: 'run-1' }],
+        readRunEvents: async () => [
+          { type: MODEL_CALL_ATTEMPT_EVENT_TYPE, data: attempt() },
+          { type: MODEL_CALL_ATTEMPT_EVENT_TYPE, data: { schemaVersion: 1, broken: true } },
+        ],
+      },
+      'session-1',
+    );
+
+    assert.equal(trace.totals.modelAttempts, 1, 'the readable record still projects');
+    assert.equal(trace.coverage.unreadableRecords, 1);
+    assert.equal(trace.coverage.modelCalls, 'partial', 'an unreadable record is a known gap');
+  });
+
+  it('ignores AgentRun events that are not canonical model calls', async () => {
+    const trace = await readSessionTrace(
+      {
+        readSessionRuntimeEvents: async () => [],
+        listSessionRuns: async () => [{ runId: 'run-1' }],
+        readRunEvents: async () => [
+          { type: 'provider_request_attempt_recorded', data: { step: 0 } },
+          { type: 'run_completed' },
+        ],
+      },
+      'session-1',
+    );
+
+    assert.equal(trace.turns.length, 0);
+    assert.equal(trace.coverage.modelCalls, 'none');
+  });
+});

--- a/apps/desktop/src/main/__tests__/session-inspector-panel-model.test.ts
+++ b/apps/desktop/src/main/__tests__/session-inspector-panel-model.test.ts
@@ -4,6 +4,7 @@ import {
   SESSION_TRACE_SCHEMA_VERSION,
   emptyTraceTotals,
   type SessionTrace,
+  type TraceStep,
 } from '@maka/core/session-trace';
 import { deriveInspectorPanelModel } from '../../renderer/session-inspector-panel-model.js';
 
@@ -133,8 +134,7 @@ describe('inspector panel model', () => {
                 durationMs: 200,
                 toolName: 'Bash',
                 status: 'failed',
-                failed: true,
-              } as never,
+              } satisfies TraceStep,
               {
                 kind: 'permission',
                 id: 'permission-1',
@@ -142,7 +142,7 @@ describe('inspector panel model', () => {
                 runId: 'run-1',
                 startedAt: 2_000,
                 decision: 'allow',
-              } as never,
+              } satisfies TraceStep,
             ],
           },
         ],

--- a/apps/desktop/src/main/__tests__/session-inspector-panel-model.test.ts
+++ b/apps/desktop/src/main/__tests__/session-inspector-panel-model.test.ts
@@ -1,0 +1,162 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  SESSION_TRACE_SCHEMA_VERSION,
+  emptyTraceTotals,
+  type SessionTrace,
+} from '@maka/core/session-trace';
+import { deriveInspectorPanelModel } from '../../renderer/session-inspector-panel-model.js';
+
+function trace(overrides: Partial<SessionTrace> = {}): SessionTrace {
+  return {
+    schemaVersion: SESSION_TRACE_SCHEMA_VERSION,
+    sessionId: 'session-1',
+    turns: [],
+    totals: emptyTraceTotals(),
+    coverage: {
+      modelCalls: 'none',
+      turnsMissingModelCalls: [],
+      turnsWithFewerModelCallsThanSteps: [],
+      unreadableRecords: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe('inspector panel model', () => {
+  it('shows no coverage notice when the trace reports no known gap', () => {
+    // A notice that always shows is a notice nobody reads.
+    const model = deriveInspectorPanelModel(
+      trace({
+        coverage: {
+          modelCalls: 'no_known_gap',
+          turnsMissingModelCalls: [],
+          turnsWithFewerModelCallsThanSteps: [],
+          unreadableRecords: 0,
+        },
+      }),
+    );
+
+    assert.equal(model.coverage, undefined);
+  });
+
+  it('surfaces a partial coverage notice with what is missing', () => {
+    const model = deriveInspectorPanelModel(
+      trace({
+        coverage: {
+          modelCalls: 'partial',
+          turnsMissingModelCalls: ['turn-1'],
+          turnsWithFewerModelCallsThanSteps: ['turn-2', 'turn-3'],
+          unreadableRecords: 2,
+        },
+      }),
+    );
+
+    assert.deepEqual(model.coverage, {
+      kind: 'partial',
+      turnsMissing: 1,
+      turnsShort: 2,
+      unreadableRecords: 2,
+    });
+  });
+
+  it('leaves an unpriced model call without a cost rather than showing zero', () => {
+    const model = deriveInspectorPanelModel(
+      trace({
+        turns: [
+          {
+            turnId: 'turn-1',
+            runId: 'run-1',
+            startedAt: 1_000,
+            endedAt: 1_500,
+            durationMs: 500,
+            totals: emptyTraceTotals(),
+            steps: [
+              {
+                kind: 'model_call',
+                id: 'call-1',
+                turnId: 'turn-1',
+                runId: 'run-1',
+                startedAt: 1_000,
+                endedAt: 1_500,
+                durationMs: 500,
+                callKind: 'main',
+                providerId: 'anthropic',
+                modelId: 'claude-test',
+                step: 0,
+                attempts: [
+                  {
+                    attemptId: 'a-0',
+                    attempt: 0,
+                    status: 'completed',
+                    startedAt: 1_000,
+                    completedAt: 1_500,
+                    latencyMs: 500,
+                    costBasis: 'unpriced',
+                    usageBasis: 'reported',
+                  },
+                ],
+                status: 'completed',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const step = model.turns[0]?.steps[0];
+    assert.equal(step?.label, 'claude-test');
+    assert.equal(step?.costUsd, undefined, 'no price is not a zero price');
+    assert.equal(step?.retries, undefined, 'a single attempt is not a retry');
+  });
+
+  it('marks the attributed step as the failure, not every later step', () => {
+    const model = deriveInspectorPanelModel(
+      trace({
+        turns: [
+          {
+            turnId: 'turn-1',
+            runId: 'run-1',
+            startedAt: 1_000,
+            endedAt: 3_000,
+            durationMs: 2_000,
+            totals: emptyTraceTotals(),
+            failure: { code: 'tool_failed', attributedToStepId: 'dispatch-1' },
+            steps: [
+              {
+                kind: 'tool',
+                id: 'dispatch-1',
+                turnId: 'turn-1',
+                runId: 'run-1',
+                startedAt: 1_000,
+                endedAt: 1_200,
+                durationMs: 200,
+                toolName: 'Bash',
+                status: 'failed',
+                failed: true,
+              } as never,
+              {
+                kind: 'permission',
+                id: 'permission-1',
+                turnId: 'turn-1',
+                runId: 'run-1',
+                startedAt: 2_000,
+                decision: 'allow',
+              } as never,
+            ],
+          },
+        ],
+      }),
+    );
+
+    const [tool, permission] = model.turns[0]!.steps;
+    assert.equal(tool?.failed, true);
+    assert.equal(permission?.failed, false, 'a later step is not implicated by sequence');
+    assert.equal(model.turns[0]?.failureCode, 'tool_failed');
+  });
+
+  it('reports an empty model for a session with no turns', () => {
+    assert.equal(deriveInspectorPanelModel(trace()).empty, true);
+    assert.equal(deriveInspectorPanelModel(undefined).empty, true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/session-trace-refresh.test.ts
+++ b/apps/desktop/src/main/__tests__/session-trace-refresh.test.ts
@@ -1,0 +1,109 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { SessionEvent } from '@maka/core/events';
+import {
+  createTraceRefreshCoalescer,
+  isTraceRelevantEvent,
+} from '../../renderer/session-trace-refresh.js';
+
+function event(type: SessionEvent['type'], extra: Record<string, unknown> = {}): SessionEvent {
+  return { type, id: `${type}-1`, turnId: 'turn-1', ts: 1, ...extra } as SessionEvent;
+}
+
+/** A controllable stand-in for `setTimeout`, so the policy is testable. */
+function fakeTimer() {
+  const pending = new Map<number, () => void>();
+  let nextHandle = 1;
+  return {
+    schedule: (callback: () => void) => {
+      const handle = nextHandle++;
+      pending.set(handle, callback);
+      return handle;
+    },
+    cancel: (handle: unknown) => {
+      pending.delete(handle as number);
+    },
+    fire: () => {
+      const callbacks = [...pending.values()];
+      pending.clear();
+      for (const callback of callbacks) callback();
+    },
+    get scheduled() {
+      return pending.size;
+    },
+  };
+}
+
+describe('session trace refresh policy', () => {
+  it('ignores streaming deltas and reacts to ledger-changing events', () => {
+    // A streaming turn emits deltas continuously. Re-projecting a whole session
+    // per delta would spend the session's own latency budget watching it.
+    assert.equal(isTraceRelevantEvent(event('text_delta', { messageId: 'm', text: 'a' })), false);
+    assert.equal(isTraceRelevantEvent(event('thinking_delta', { messageId: 'm', text: 'a' })), false);
+    assert.equal(isTraceRelevantEvent(event('tool_output_delta')), false);
+
+    for (const type of ['tool_start', 'tool_result', 'token_usage', 'complete', 'error'] as const) {
+      assert.equal(isTraceRelevantEvent(event(type)), true, `${type} changes the trace`);
+    }
+  });
+
+  it('refreshes once for a burst of relevant events', () => {
+    // A finishing turn emits tool_result, token_usage and complete within
+    // milliseconds. Each alone justifies a re-read; three do not.
+    const timer = fakeTimer();
+    let refreshes = 0;
+    const coalescer = createTraceRefreshCoalescer({
+      refresh: () => {
+        refreshes += 1;
+      },
+      delayMs: 400,
+      schedule: timer.schedule,
+      cancel: timer.cancel,
+    });
+
+    coalescer.observe(event('tool_result'));
+    coalescer.observe(event('token_usage'));
+    coalescer.observe(event('complete'));
+    assert.equal(refreshes, 0, 'nothing reads before the burst settles');
+    assert.equal(timer.scheduled, 1, 'the burst holds exactly one pending read');
+
+    timer.fire();
+    assert.equal(refreshes, 1);
+  });
+
+  it('schedules nothing for events that cannot change the trace', () => {
+    const timer = fakeTimer();
+    let refreshes = 0;
+    const coalescer = createTraceRefreshCoalescer({
+      refresh: () => {
+        refreshes += 1;
+      },
+      delayMs: 400,
+      schedule: timer.schedule,
+      cancel: timer.cancel,
+    });
+
+    coalescer.observe(event('text_delta', { messageId: 'm', text: 'hello' }));
+    assert.equal(timer.scheduled, 0);
+    timer.fire();
+    assert.equal(refreshes, 0);
+  });
+
+  it('cancel drops a scheduled read so a closed panel never fires one', () => {
+    const timer = fakeTimer();
+    let refreshes = 0;
+    const coalescer = createTraceRefreshCoalescer({
+      refresh: () => {
+        refreshes += 1;
+      },
+      delayMs: 400,
+      schedule: timer.schedule,
+      cancel: timer.cancel,
+    });
+
+    coalescer.observe(event('complete'));
+    coalescer.cancel();
+    timer.fire();
+    assert.equal(refreshes, 0, 'a hidden panel must not keep re-projecting');
+  });
+});

--- a/apps/desktop/src/main/__tests__/session-workbar-layout.test.ts
+++ b/apps/desktop/src/main/__tests__/session-workbar-layout.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 import {
+  readSessionWorkbarTab,
   readSessionWorkbarWidth,
   SESSION_WORKBAR_DEFAULT_WIDTH,
 } from '../../renderer/session-workbar-layout.js';
@@ -34,6 +35,38 @@ describe('readSessionWorkbarWidth', () => {
     for (const value of [null, '', 'wide', '0', '-10']) {
       storedWidth(value);
       assert.equal(readSessionWorkbarWidth(), SESSION_WORKBAR_DEFAULT_WIDTH, `stored: ${value}`);
+    }
+  });
+});
+
+/**
+ * The persistence whitelist decides which tab survives a restart. A tab that
+ * renders but is not listed here silently reverts to Tasks, which looks like
+ * the panel forgetting rather than like a missing case.
+ */
+function storedTab(value: string | null): void {
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (key: string) => (key === 'maka-session-workbar-tab-v1' ? value : null),
+  };
+}
+
+describe('readSessionWorkbarTab', () => {
+  afterEach(() => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  it('restores every persistable tab, including the Inspector', () => {
+    for (const tab of ['browser', 'files', 'inspector'] as const) {
+      storedTab(tab);
+      assert.equal(readSessionWorkbarTab(), tab);
+    }
+  });
+
+  it('falls back to tasks for the transient quote tab and for junk', () => {
+    // 'quote' only exists while an excerpt is staged, so it is never restored.
+    for (const stored of ['quote', 'nonsense', null]) {
+      storedTab(stored);
+      assert.equal(readSessionWorkbarTab(), 'tasks');
     }
   });
 });

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -115,6 +115,7 @@ import { registerPlanReminderIpc } from './plan-reminders-ipc-main.js';
 import { registerWorkspaceResourcesIpc } from './workspace-resources-ipc-main.js';
 import type { NewSessionSkillContext } from './workspace-resources-ipc-main.js';
 import { registerDailyReviewIpc } from './daily-review-ipc-main.js';
+import { registerInspectorIpc } from './inspector-ipc-main.js';
 import { registerUsageIpc } from './usage-ipc-main.js';
 import { registerWebSearchIpc } from './web-search-ipc-main.js';
 import { registerNotificationsIpc } from './notifications-ipc-main.js';
@@ -1206,6 +1207,12 @@ function registerIpc(): void {
       : {}),
   });
   registerDailyReviewIpc({ dailyReview, dailyReviewArchiveStore, mainWindowController });
+  registerInspectorIpc({
+    ipcMain,
+    readSessionRuntimeEvents: (sessionId) => runtimeEventStore.readSessionRuntimeEvents(sessionId),
+    listSessionRuns: (sessionId) => runStore.listSessionRuns(sessionId),
+    readRunEvents: (sessionId, runId) => runStore.readEvents(sessionId, runId),
+  });
   registerUsageIpc({
     ipcMain,
     settingsStore,

--- a/apps/desktop/src/main/inspector-ipc-main.ts
+++ b/apps/desktop/src/main/inspector-ipc-main.ts
@@ -1,0 +1,69 @@
+import type { IpcMain } from 'electron';
+import { decodeModelCallAttempt, type ModelCallAttempt } from '@maka/core/model-call-attempt';
+import { MODEL_CALL_ATTEMPT_EVENT_TYPE } from '@maka/core/model-call-attempt';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { SessionTrace } from '@maka/core/session-trace';
+import { tryResult } from '@maka/core/result';
+import { projectSessionTrace } from '@maka/runtime';
+
+/**
+ * Read-only projection of one session's causal trace for the Inspector (#1625).
+ *
+ * Reads two ledgers and writes nothing. The AgentRun stream is the authority
+ * for canonical metering — not the Usage read model, which is range-queried and
+ * carries no session predicate — and `readSessionRuntimeEvents` supplies the
+ * causal structure the metering ledger knows nothing about.
+ */
+export interface InspectorIpcDeps {
+  ipcMain: Pick<IpcMain, 'handle'>;
+  readSessionRuntimeEvents: (sessionId: string) => Promise<readonly RuntimeEvent[]>;
+  listSessionRuns: (sessionId: string) => Promise<readonly { readonly runId: string }[]>;
+  readRunEvents: (
+    sessionId: string,
+    runId: string,
+  ) => Promise<readonly { readonly type: string; readonly data?: unknown }[]>;
+}
+
+export function registerInspectorIpc(deps: InspectorIpcDeps): void {
+  deps.ipcMain.handle('inspector:trace', (_event, sessionId: string) =>
+    tryResult(async () => await readSessionTrace(deps, sessionId), 'INSPECTOR_TRACE_FAILED'),
+  );
+}
+
+export async function readSessionTrace(
+  deps: Omit<InspectorIpcDeps, 'ipcMain'>,
+  sessionId: string,
+): Promise<SessionTrace> {
+  const [runtimeEvents, runs] = await Promise.all([
+    deps.readSessionRuntimeEvents(sessionId),
+    deps.listSessionRuns(sessionId),
+  ]);
+
+  const modelCallAttempts: ModelCallAttempt[] = [];
+  let unreadableRecords = 0;
+  // Per run rather than per session: the authority stream is keyed that way, so
+  // reading it run by run is reading it as it is stored, not reshaping it.
+  const runEvents = await Promise.all(
+    runs.map((run) => deps.readRunEvents(sessionId, run.runId)),
+  );
+  for (const events of runEvents) {
+    for (const event of events) {
+      if (event.type !== MODEL_CALL_ATTEMPT_EVENT_TYPE) continue;
+      try {
+        modelCallAttempts.push(decodeModelCallAttempt(event.data));
+      } catch {
+        // A record that will not decode is spend this trace cannot show.
+        // Counted so the gap is visible; dropping it silently is the failure
+        // this projection exists to avoid.
+        unreadableRecords += 1;
+      }
+    }
+  }
+
+  return projectSessionTrace({
+    sessionId,
+    runtimeEvents,
+    modelCallAttempts,
+    ...(unreadableRecords > 0 ? { unreadableRecords } : {}),
+  });
+}

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -87,6 +87,7 @@ import type {
   UsageQuery,
   UsageSummaryV2,
 } from '@maka/core/usage-stats/types';
+import type { SessionTrace } from '@maka/core/session-trace';
 import type { TestProxyInput } from '@maka/core/settings/network-settings';
 import type { Result } from '@maka/core/result';
 import type { CreateSessionRequestInput } from '@maka/core';
@@ -600,6 +601,10 @@ export interface MakaBridge {
       handler: (event: { type: 'plans_changed'; reason: string; reminderId?: string; ts: number }) => void,
     ): () => void;
     subscribeDue(handler: (reminder: PlanReminder) => void): () => void;
+  };
+  inspector: {
+    /** Read-only per-session causal trace (#1625). */
+    trace(sessionId: string): Promise<Result<SessionTrace>>;
   };
   usage: {
     summary(query: UsageQuery): Promise<Result<UsageSummaryV2>>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -98,6 +98,7 @@ import type {
   UsageQuery,
   UsageSummaryV2,
 } from '@maka/core/usage-stats/types';
+import type { SessionTrace } from '@maka/core/session-trace';
 import type {
   AgentGraphClientChangedEvent,
   AgentGraphClientSnapshot,
@@ -930,6 +931,12 @@ const makaBridge = {
       body?: string;
     }): Promise<void> {
       return ipcRenderer.invoke('notifications:runEnded', payload);
+    },
+  },
+  inspector: {
+    /** Read-only per-session causal trace (#1625). Never writes runtime state. */
+    trace(sessionId: string): Promise<Result<SessionTrace>> {
+      return ipcRenderer.invoke('inspector:trace', sessionId);
     },
   },
   usage: {

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -60,7 +60,21 @@ export interface DesktopConversationCopy {
     regeneratedTo: string;
     regeneratedToTooltip: string;
   };
-  workbar: { ariaLabel: string; sectionsAriaLabel: string; tasks: string; browser: string; files: string; quoteTab: string };
+  workbar: { ariaLabel: string; sectionsAriaLabel: string; tasks: string; browser: string; files: string; inspector: string; quoteTab: string };
+  inspector: {
+    ariaLabel: string;
+    loadFailed: string;
+    retry: string;
+    empty: string;
+    costUnavailable: string;
+    attempts: string;
+    retries: string;
+    compactions: string;
+    coveragePartial: string;
+    coverageAbsent: string;
+    unreadable: string;
+    turnFailed: string;
+  };
   quoteCompanion: {
     /** Read-only exploration hint shown in the empty companion panel. */
     hint: string;
@@ -138,7 +152,21 @@ const COPY = {
     },
     footer: { labels: { regenerate: '重新生成', branch: '分支', copy: '复制', info: '详情' }, pending: '正在处理…', regenerateRunning: '当前回答仍在进行中，结束后再重新生成', regenerateAgain: '已重新生成过，再次点击将创建新的并行回答', regenerate: '让模型重新生成本轮回答', branchRunning: '当前回答仍在进行中，结束后再分支', branchAborted: '从中断前的上下文分支出新对话', branch: '基于此回答的上下文分支出新对话', copy: '复制回答到剪贴板', copyEmpty: '此回答尚无可复制的内容' },
     lineage: { regeneratedFrom: '重新生成自旧回答', regeneratedFromTooltip: '这是重新生成的并行回答，点击查看被保留的旧回答', regeneratedTo: '已重新生成 → 新回答', regeneratedToTooltip: '点击跳转到重新生成的新回答' },
-    workbar: { ariaLabel: '会话工作栏', sectionsAriaLabel: '会话工作栏栏目', tasks: '任务', browser: '浏览器', files: '文件', quoteTab: '追问引用' },
+    workbar: { ariaLabel: '会话工作栏', sectionsAriaLabel: '会话工作栏栏目', tasks: '任务', browser: '浏览器', files: '文件', inspector: '追踪', quoteTab: '追问引用' },
+    inspector: {
+      ariaLabel: '会话追踪',
+      loadFailed: '追踪读取失败',
+      retry: '重试',
+      empty: '这个会话还没有可追踪的活动',
+      costUnavailable: '费用不可得',
+      attempts: '次调用',
+      retries: '次重试',
+      compactions: '次压缩',
+      coveragePartial: '部分调用没有记录，下面的数字是下界',
+      coverageAbsent: '该后端不上报逐次调用明细',
+      unreadable: '条记录无法解析',
+      turnFailed: '本轮失败',
+    },
     quoteCompanion: {
       hint: '这里的追问会带上主对话的完整上下文：只做解释和只读探索，不会改动文件，也不写回主对话。在主对话里继续选中文本追问，会加进这个侧栏。',
       exit: '退出',
@@ -201,7 +229,21 @@ const COPY = {
     },
     footer: { labels: { regenerate: 'Regenerate', branch: 'Branch', copy: 'Copy', info: 'Details' }, pending: 'Working…', regenerateRunning: 'Wait for the current response to finish before regenerating', regenerateAgain: 'A regenerated response already exists; click again to create another parallel response', regenerate: 'Generate another response to this turn', branchRunning: 'Wait for the current response to finish before branching', branchAborted: 'Branch from the context before the interruption', branch: 'Branch a new conversation from this response', copy: 'Copy response to clipboard', copyEmpty: 'This response has no content to copy' },
     lineage: { regeneratedFrom: 'Regenerated from previous response', regeneratedFromTooltip: 'This is a parallel regenerated response; click to view the retained previous response', regeneratedTo: 'Regenerated → New response', regeneratedToTooltip: 'Jump to the regenerated response' },
-    workbar: { ariaLabel: 'Conversation workbar', sectionsAriaLabel: 'Conversation workbar sections', tasks: 'Tasks', browser: 'Browser', files: 'Files', quoteTab: 'Quoted' },
+    workbar: { ariaLabel: 'Conversation workbar', sectionsAriaLabel: 'Conversation workbar sections', tasks: 'Tasks', browser: 'Browser', files: 'Files', inspector: 'Trace', quoteTab: 'Quoted' },
+    inspector: {
+      ariaLabel: 'Session trace',
+      loadFailed: 'Could not read the trace',
+      retry: 'Retry',
+      empty: 'Nothing to trace in this session yet',
+      costUnavailable: 'cost unavailable',
+      attempts: 'calls',
+      retries: 'retries',
+      compactions: 'compactions',
+      coveragePartial: 'Some calls have no record; the numbers below are a floor',
+      coverageAbsent: 'This backend does not report per-call detail',
+      unreadable: 'unreadable records',
+      turnFailed: 'Turn failed',
+    },
     quoteCompanion: {
       hint: 'Questions here carry the full context of the main conversation: read-only exploration and explanation, no file changes, and nothing is written back to the main conversation. Select more text in the main transcript to add it to this side panel.',
       exit: 'Exit',

--- a/apps/desktop/src/renderer/session-inspector-panel-model.ts
+++ b/apps/desktop/src/renderer/session-inspector-panel-model.ts
@@ -1,0 +1,160 @@
+import type { SessionTrace, TraceStep, TraceTotals } from '@maka/core/session-trace';
+
+/**
+ * View model for the Inspector panel (#1625).
+ *
+ * Pure, so the panel's judgements — what counts as a gap worth showing, when a
+ * cost may be rendered at all — are testable without a DOM. The panel itself
+ * only lays these out.
+ */
+export interface InspectorStepRow {
+  id: string;
+  kind: TraceStep['kind'];
+  /** Primary label: tool name, model id, or the kind for structural steps. */
+  label: string;
+  detail?: string;
+  durationMs?: number;
+  /**
+   * Absent when nothing priced this step. The panel renders "cost unavailable"
+   * rather than `$0`, because a call nobody could price and a free call are
+   * different facts.
+   */
+  costUsd?: number;
+  status?: string;
+  /** Retries beyond the first attempt of one logical call. */
+  retries?: number;
+  failed: boolean;
+}
+
+export interface InspectorTurnRow {
+  turnId: string;
+  startedAt: number;
+  durationMs: number;
+  totals: TraceTotals;
+  failed: boolean;
+  failureCode?: string;
+  failureMessage?: string;
+  /** The step the failure is attributed to, when the trace named one. */
+  attributedToStepId?: string;
+  steps: InspectorStepRow[];
+}
+
+export interface InspectorCoverageNotice {
+  kind: 'partial' | 'absent';
+  turnsMissing: number;
+  turnsShort: number;
+  unreadableRecords: number;
+}
+
+export interface InspectorPanelModel {
+  turns: InspectorTurnRow[];
+  totals: TraceTotals;
+  /**
+   * Present only when the trace itself reports a gap. A notice that always
+   * shows is a notice nobody reads.
+   */
+  coverage?: InspectorCoverageNotice;
+  /** True when there is nothing to draw — distinct from a trace with gaps. */
+  empty: boolean;
+}
+
+export function deriveInspectorPanelModel(trace: SessionTrace | undefined): InspectorPanelModel {
+  if (!trace) return { turns: [], totals: emptyTotals(), empty: true };
+
+  const turns = trace.turns.map<InspectorTurnRow>((turn) => ({
+    turnId: turn.turnId,
+    startedAt: turn.startedAt,
+    durationMs: turn.durationMs,
+    totals: turn.totals,
+    failed: turn.failure !== undefined,
+    ...(turn.failure?.code !== undefined ? { failureCode: turn.failure.code } : {}),
+    ...(turn.failure?.message !== undefined ? { failureMessage: turn.failure.message } : {}),
+    ...(turn.failure?.attributedToStepId !== undefined
+      ? { attributedToStepId: turn.failure.attributedToStepId }
+      : {}),
+    steps: turn.steps.map((step) => toStepRow(step, turn.failure?.attributedToStepId)),
+  }));
+
+  return {
+    turns,
+    totals: trace.totals,
+    ...(coverageNotice(trace) ? { coverage: coverageNotice(trace)! } : {}),
+    empty: turns.length === 0,
+  };
+}
+
+function toStepRow(step: TraceStep, attributedToStepId: string | undefined): InspectorStepRow {
+  const failed =
+    step.id === attributedToStepId ||
+    (step.kind === 'tool' && step.status === 'failed') ||
+    (step.kind === 'model_call' && step.status === 'failed') ||
+    step.kind === 'error';
+
+  if (step.kind === 'model_call') {
+    return {
+      id: step.id,
+      kind: step.kind,
+      label: step.modelId,
+      detail: step.callKind,
+      durationMs: step.durationMs,
+      ...(step.costUsd !== undefined ? { costUsd: step.costUsd } : {}),
+      status: step.status,
+      ...(step.attempts.length > 1 ? { retries: step.attempts.length - 1 } : {}),
+      failed,
+    };
+  }
+  if (step.kind === 'tool') {
+    return {
+      id: step.id,
+      kind: step.kind,
+      label: step.toolName,
+      // The recovery that happened, never the policy every dispatch declares.
+      ...(step.recovered ? { detail: `recovered: ${step.recovered.disposition}` } : {}),
+      ...(step.durationMs !== undefined ? { durationMs: step.durationMs } : {}),
+      status: step.status,
+      failed,
+    };
+  }
+  if (step.kind === 'permission') {
+    return {
+      id: step.id,
+      kind: step.kind,
+      label: step.toolName ?? 'permission',
+      detail: step.decision,
+      failed: false,
+    };
+  }
+  if (step.kind === 'compaction') {
+    return {
+      id: step.id,
+      kind: step.kind,
+      label: 'compaction',
+      ...(step.checkpointId !== undefined ? { detail: step.checkpointId } : {}),
+      failed: false,
+    };
+  }
+  return { id: step.id, kind: step.kind, label: 'error', detail: step.message, failed: true };
+}
+
+function coverageNotice(trace: SessionTrace): InspectorCoverageNotice | undefined {
+  const { coverage } = trace;
+  if (coverage.modelCalls === 'none' || coverage.modelCalls === 'no_known_gap') return undefined;
+  return {
+    kind: coverage.modelCalls,
+    turnsMissing: coverage.turnsMissingModelCalls.length,
+    turnsShort: coverage.turnsWithFewerModelCallsThanSteps.length,
+    unreadableRecords: coverage.unreadableRecords,
+  };
+}
+
+function emptyTotals(): TraceTotals {
+  return {
+    durationMs: 0,
+    modelAttempts: 0,
+    retries: 0,
+    compactions: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    unpricedAttempts: 0,
+  };
+}

--- a/apps/desktop/src/renderer/session-inspector-panel-model.ts
+++ b/apps/desktop/src/renderer/session-inspector-panel-model.ts
@@ -1,4 +1,4 @@
-import type { SessionTrace, TraceStep, TraceTotals } from '@maka/core/session-trace';
+import { emptyTraceTotals, type SessionTrace, type TraceStep, type TraceTotals } from '@maka/core/session-trace';
 
 /**
  * View model for the Inspector panel (#1625).
@@ -59,7 +59,7 @@ export interface InspectorPanelModel {
 }
 
 export function deriveInspectorPanelModel(trace: SessionTrace | undefined): InspectorPanelModel {
-  if (!trace) return { turns: [], totals: emptyTotals(), empty: true };
+  if (!trace) return { turns: [], totals: emptyTraceTotals(), empty: true };
 
   const turns = trace.turns.map<InspectorTurnRow>((turn) => ({
     turnId: turn.turnId,
@@ -147,14 +147,3 @@ function coverageNotice(trace: SessionTrace): InspectorCoverageNotice | undefine
   };
 }
 
-function emptyTotals(): TraceTotals {
-  return {
-    durationMs: 0,
-    modelAttempts: 0,
-    retries: 0,
-    compactions: 0,
-    inputTokens: 0,
-    outputTokens: 0,
-    unpricedAttempts: 0,
-  };
-}

--- a/apps/desktop/src/renderer/session-inspector-panel.tsx
+++ b/apps/desktop/src/renderer/session-inspector-panel.tsx
@@ -1,0 +1,144 @@
+import { useUiLocale } from '@maka/ui';
+import { getDesktopConversationCopy } from './locales/conversation-copy.js';
+import {
+  deriveInspectorPanelModel,
+  type InspectorStepRow,
+  type InspectorTurnRow,
+} from './session-inspector-panel-model.js';
+import { useSessionTrace } from './use-session-trace.js';
+
+/**
+ * Per-session causal timeline (#1625): what the session did, in order, with
+ * what each model call cost and how long it took.
+ *
+ * Read-only. Every judgement it makes lives in `deriveInspectorPanelModel`;
+ * this file lays the result out.
+ */
+export function SessionInspectorPanel(props: { sessionId: string; active: boolean }) {
+  const locale = useUiLocale();
+  const copy = getDesktopConversationCopy(locale).inspector;
+  const snapshot = useSessionTrace(props.sessionId, props.active);
+  const model = deriveInspectorPanelModel(snapshot.trace);
+
+  return (
+    <section
+      className="maka-inspector-panel"
+      data-maka-contract="session-inspector"
+      aria-label={copy.ariaLabel}
+      aria-busy={snapshot.loading || undefined}
+    >
+      {snapshot.error && (
+        <div className="maka-inspector-error" role="alert">
+          <span>{snapshot.error}</span>
+          <button type="button" aria-label={copy.retry} onClick={snapshot.retry}>
+            {copy.retry}
+          </button>
+        </div>
+      )}
+
+      {model.coverage && (
+        <p className="maka-inspector-coverage" data-maka-contract="session-inspector-coverage">
+          {model.coverage.kind === 'absent' ? copy.coverageAbsent : copy.coveragePartial}
+          {model.coverage.unreadableRecords > 0 &&
+            ` · ${model.coverage.unreadableRecords} ${copy.unreadable}`}
+        </p>
+      )}
+
+      {!model.empty && (
+        <header className="maka-inspector-totals">
+          <span>{formatDuration(model.totals.durationMs)}</span>
+          <span>
+            {model.totals.modelAttempts} {copy.attempts}
+          </span>
+          {model.totals.retries > 0 && (
+            <span>
+              {model.totals.retries} {copy.retries}
+            </span>
+          )}
+          {model.totals.compactions > 0 && (
+            <span>
+              {model.totals.compactions} {copy.compactions}
+            </span>
+          )}
+          <span className="maka-inspector-cost">
+            {formatCost(model.totals.costUsd, copy.costUnavailable)}
+          </span>
+        </header>
+      )}
+
+      {model.empty && !snapshot.loading && <p className="maka-inspector-empty">{copy.empty}</p>}
+
+      <ol className="maka-inspector-turns">
+        {model.turns.map((turn) => (
+          <TurnRow key={turn.turnId} turn={turn} costUnavailable={copy.costUnavailable} failedLabel={copy.turnFailed} />
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function TurnRow(props: { turn: InspectorTurnRow; costUnavailable: string; failedLabel: string }) {
+  const { turn } = props;
+  return (
+    <li className="maka-inspector-turn" data-maka-contract="session-inspector-turn">
+      <div className="maka-inspector-turn-head">
+        <span className="maka-inspector-turn-id">{turn.turnId}</span>
+        <span>{formatDuration(turn.durationMs)}</span>
+        <span className="maka-inspector-cost">
+          {formatCost(turn.totals.costUsd, props.costUnavailable)}
+        </span>
+        {turn.failed && (
+          <span className="maka-inspector-failed" data-maka-contract="session-inspector-turn-failed">
+            {props.failedLabel}
+            {turn.failureCode ? ` · ${turn.failureCode}` : ''}
+          </span>
+        )}
+      </div>
+      <ol className="maka-inspector-steps">
+        {turn.steps.map((step) => (
+          <StepRow key={step.id} step={step} costUnavailable={props.costUnavailable} />
+        ))}
+      </ol>
+    </li>
+  );
+}
+
+function StepRow(props: { step: InspectorStepRow; costUnavailable: string }) {
+  const { step } = props;
+  return (
+    <li
+      className="maka-inspector-step"
+      data-maka-contract="session-inspector-step"
+      data-kind={step.kind}
+      data-failed={step.failed || undefined}
+    >
+      <span className="maka-inspector-step-kind">{step.kind}</span>
+      <span className="maka-inspector-step-label">{step.label}</span>
+      {step.detail && <span className="maka-inspector-step-detail">{step.detail}</span>}
+      {step.retries !== undefined && (
+        <span className="maka-inspector-step-retries">×{step.retries + 1}</span>
+      )}
+      {step.durationMs !== undefined && <span>{formatDuration(step.durationMs)}</span>}
+      {step.kind === 'model_call' && (
+        <span className="maka-inspector-cost">
+          {formatCost(step.costUsd, props.costUnavailable)}
+        </span>
+      )}
+    </li>
+  );
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1_000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1_000).toFixed(1)}s`;
+  return `${Math.floor(ms / 60_000)}m${Math.round((ms % 60_000) / 1_000)}s`;
+}
+
+/**
+ * Absent cost renders as words, never as `$0.00`: the canonical record keeps
+ * "nobody could price this" and "this was free" apart, and so does the panel.
+ */
+function formatCost(costUsd: number | undefined, unavailable: string): string {
+  if (costUsd === undefined) return unavailable;
+  return costUsd < 0.01 ? `$${costUsd.toFixed(4)}` : `$${costUsd.toFixed(2)}`;
+}

--- a/apps/desktop/src/renderer/session-inspector-panel.tsx
+++ b/apps/desktop/src/renderer/session-inspector-panel.tsx
@@ -66,7 +66,11 @@ export function SessionInspectorPanel(props: { sessionId: string; active: boolea
         </header>
       )}
 
-      {model.empty && !snapshot.loading && <p className="maka-inspector-empty">{copy.empty}</p>}
+      {/* "Nothing to trace" is a claim about the session; a failed read cannot
+          make it, so the error stands alone. */}
+      {model.empty && !snapshot.loading && !snapshot.error && (
+        <p className="maka-inspector-empty">{copy.empty}</p>
+      )}
 
       <ol className="maka-inspector-turns">
         {model.turns.map((turn) => (

--- a/apps/desktop/src/renderer/session-trace-refresh.ts
+++ b/apps/desktop/src/renderer/session-trace-refresh.ts
@@ -1,0 +1,66 @@
+import type { SessionEvent } from '@maka/core/events';
+
+/**
+ * When a live session's trace is worth re-reading (#1625).
+ *
+ * The trace is a projection of two durable ledgers, so the only events that can
+ * change it are the ones that mean something was appended to one of them. That
+ * is deliberately not "every event": a streaming turn emits text and tool-output
+ * deltas continuously, and re-projecting a whole session per delta would spend
+ * the session's own latency budget on watching it.
+ */
+const TRACE_RELEVANT_EVENT_TYPES: ReadonlySet<SessionEvent['type']> = new Set([
+  'tool_start',
+  'tool_result',
+  'token_usage',
+  'provider_retry',
+  'error',
+  'complete',
+  'abort',
+]);
+
+export function isTraceRelevantEvent(event: SessionEvent): boolean {
+  return TRACE_RELEVANT_EVENT_TYPES.has(event.type);
+}
+
+export interface TraceRefreshCoalescer {
+  /** Records an event; schedules a refresh when the event can change the trace. */
+  observe(event: SessionEvent): void;
+  /** Drops any scheduled refresh. */
+  cancel(): void;
+}
+
+/**
+ * Coalesces a burst of relevant events into one re-read.
+ *
+ * A finishing turn emits several relevant events within milliseconds
+ * (`tool_result`, `token_usage`, `complete`). Each one alone justifies a
+ * re-read; three re-reads of the same session do not. The timer is injected so
+ * the policy is testable without a clock or a DOM.
+ */
+export function createTraceRefreshCoalescer(input: {
+  refresh: () => void;
+  delayMs: number;
+  schedule: (callback: () => void, delayMs: number) => unknown;
+  cancel: (handle: unknown) => void;
+}): TraceRefreshCoalescer {
+  let handle: unknown;
+  const cancel = (): void => {
+    if (handle === undefined) return;
+    input.cancel(handle);
+    handle = undefined;
+  };
+  return {
+    observe(event) {
+      if (!isTraceRelevantEvent(event)) return;
+      // Restart rather than stack: the last event of a burst is the one whose
+      // state the reader wants, and an earlier timer would read before it.
+      cancel();
+      handle = input.schedule(() => {
+        handle = undefined;
+        input.refresh();
+      }, input.delayMs);
+    },
+    cancel,
+  };
+}

--- a/apps/desktop/src/renderer/session-workbar-layout.ts
+++ b/apps/desktop/src/renderer/session-workbar-layout.ts
@@ -5,7 +5,7 @@ export const SESSION_WORKBAR_MIN_WIDTH = 320;
 export const SESSION_WORKBAR_MAX_WIDTH = 600;
 // 'quote' is a transient tab that only exists while a quote side-panel excerpt
 // is active; it is never persisted as a default (see readSessionWorkbarTab).
-export type SessionWorkbarTab = 'tasks' | 'browser' | 'files' | 'quote';
+export type SessionWorkbarTab = 'tasks' | 'browser' | 'files' | 'inspector' | 'quote';
 
 /**
  * Seeds `useResizable`'s `defaultSize`. Deliberately unclamped: the hook clamps
@@ -32,5 +32,5 @@ export function readSessionWorkbarCollapsed(): boolean {
 
 export function readSessionWorkbarTab(): SessionWorkbarTab {
   const stored = safeLocalStorageGet('maka-session-workbar-tab-v1');
-  return stored === 'browser' || stored === 'files' ? stored : 'tasks';
+  return stored === 'browser' || stored === 'files' || stored === 'inspector' ? stored : 'tasks';
 }

--- a/apps/desktop/src/renderer/session-workbar.tsx
+++ b/apps/desktop/src/renderer/session-workbar.tsx
@@ -11,6 +11,7 @@ import type { SessionSummary } from '@maka/core';
 import { ArtifactPane } from './artifact-pane';
 import { BrowserPanel } from './browser-panel';
 import { QuoteCompanionPanel } from './quote-companion-panel';
+import { SessionInspectorPanel } from './session-inspector-panel';
 import type { SessionWorkbarTab } from './session-workbar-layout';
 import { useSessionTasks } from './use-session-tasks';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
@@ -89,6 +90,7 @@ export function SessionWorkbar(props: {
                 label={copy.files}
                 endContent={<span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">{artifactCount}</span>}
               />
+              <Tab value="inspector" label={copy.inspector} />
               {props.quote && <Tab value="quote" label={copy.quoteTab} />}
             </TabList>
           }
@@ -106,6 +108,12 @@ export function SessionWorkbar(props: {
         </div>
         <div hidden={props.activeTab !== 'files'} className="maka-session-workbar-panel">
           <ArtifactPane sessionId={props.sessionId} onCountChange={setArtifactCount} onDismiss={props.onDismiss} />
+        </div>
+        <div hidden={props.activeTab !== 'inspector'} className="maka-session-workbar-panel">
+          <SessionInspectorPanel
+            sessionId={props.sessionId}
+            active={!props.hidden && props.activeTab === 'inspector'}
+          />
         </div>
         {props.quote && (
           <div

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -75,6 +75,93 @@
 
 .maka-session-workbar-panel[hidden] { display: none; }
 
+/* Session Inspector (#1625): a read-only causal timeline in the workbar. */
+.maka-inspector-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--maka-space-2, 8px);
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--maka-space-3, 12px);
+  font-size: var(--maka-font-size-sm, 12px);
+}
+
+.maka-inspector-totals,
+.maka-inspector-turn-head,
+.maka-inspector-step {
+  display: flex;
+  align-items: baseline;
+  gap: var(--maka-space-2, 8px);
+  flex-wrap: wrap;
+}
+
+.maka-inspector-totals {
+  font-variant-numeric: tabular-nums;
+  color: var(--maka-color-text-secondary, inherit);
+}
+
+.maka-inspector-coverage {
+  margin: 0;
+  padding: var(--maka-space-2, 8px);
+  border-radius: var(--maka-radius-sm, 6px);
+  background: var(--maka-color-surface-warning, rgba(255, 200, 0, 0.12));
+  color: var(--maka-color-text-warning, inherit);
+}
+
+.maka-inspector-error {
+  display: flex;
+  align-items: center;
+  gap: var(--maka-space-2, 8px);
+  color: var(--maka-color-text-danger, inherit);
+}
+
+.maka-inspector-empty {
+  margin: 0;
+  color: var(--maka-color-text-secondary, inherit);
+}
+
+.maka-inspector-turns,
+.maka-inspector-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--maka-space-1, 4px);
+}
+
+.maka-inspector-turn {
+  border-top: 1px solid var(--maka-color-border-subtle, rgba(128, 128, 128, 0.2));
+  padding-top: var(--maka-space-2, 8px);
+}
+
+.maka-inspector-turn-id {
+  font-weight: 600;
+}
+
+.maka-inspector-steps {
+  padding-left: var(--maka-space-3, 12px);
+}
+
+.maka-inspector-step-kind {
+  color: var(--maka-color-text-secondary, inherit);
+  text-transform: lowercase;
+}
+
+.maka-inspector-step[data-failed='true'] {
+  color: var(--maka-color-text-danger, inherit);
+}
+
+.maka-inspector-cost,
+.maka-inspector-step-retries {
+  font-variant-numeric: tabular-nums;
+}
+
+.maka-inspector-failed {
+  color: var(--maka-color-text-danger, inherit);
+}
+
 .maka-session-workbar .maka-browser-panel,
 .maka-session-workbar .maka-artifact-pane {
   width: 100%;

--- a/apps/desktop/src/renderer/use-session-trace.ts
+++ b/apps/desktop/src/renderer/use-session-trace.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { generalizedErrorMessage, generalizedErrorMessageChinese } from '@maka/core';
+import type { SessionTrace } from '@maka/core/session-trace';
+import { useUiLocale } from '@maka/ui';
+import { getDesktopConversationCopy } from './locales/conversation-copy.js';
+
+interface SessionTraceSnapshot {
+  sessionId?: string;
+  trace?: SessionTrace;
+  loading: boolean;
+  error?: string;
+}
+
+const EMPTY_SNAPSHOT: SessionTraceSnapshot = { loading: false };
+
+/**
+ * Reads the per-session causal trace (#1625).
+ *
+ * Reloads on the session's own event stream rather than on a timer: the trace
+ * is a projection of the two ledgers, so the moment worth re-reading is when
+ * one of them gained an event. Only refreshes while the panel is visible —
+ * a hidden panel that keeps re-projecting a long session is a cost with no
+ * reader.
+ */
+export function useSessionTrace(
+  sessionId: string | undefined,
+  active: boolean,
+): SessionTraceSnapshot & { retry: () => void } {
+  const locale = useUiLocale();
+  const copy = getDesktopConversationCopy(locale).inspector;
+  const revisionRef = useRef(0);
+  const [snapshot, setSnapshot] = useState<SessionTraceSnapshot>(EMPTY_SNAPSHOT);
+
+  const load = useCallback(
+    (targetSessionId: string, preserveTrace: boolean) => {
+      const revision = ++revisionRef.current;
+      setSnapshot((current) => ({
+        sessionId: targetSessionId,
+        // Keep the last trace on screen through a refresh: a live turn would
+        // otherwise blank the timeline on every event.
+        ...(preserveTrace && current.sessionId === targetSessionId
+          ? { trace: current.trace }
+          : {}),
+        loading: true,
+      }));
+      void window.maka.inspector.trace(targetSessionId).then(
+        (result) => {
+          if (revision !== revisionRef.current) return;
+          if (!result.ok) {
+            setSnapshot((current) => ({
+              sessionId: targetSessionId,
+              ...(current.sessionId === targetSessionId ? { trace: current.trace } : {}),
+              loading: false,
+              error: result.error.message ?? copy.loadFailed,
+            }));
+            return;
+          }
+          setSnapshot({ sessionId: targetSessionId, trace: result.value, loading: false });
+        },
+        (error: unknown) => {
+          if (revision !== revisionRef.current) return;
+          setSnapshot((current) => ({
+            sessionId: targetSessionId,
+            ...(current.sessionId === targetSessionId ? { trace: current.trace } : {}),
+            loading: false,
+            error:
+              locale === 'zh'
+                ? generalizedErrorMessageChinese(error, copy.loadFailed)
+                : generalizedErrorMessage(error, copy.loadFailed),
+          }));
+        },
+      );
+    },
+    [copy.loadFailed, locale],
+  );
+
+  useEffect(() => {
+    revisionRef.current += 1;
+    if (!sessionId || !active) {
+      if (!sessionId) setSnapshot(EMPTY_SNAPSHOT);
+      return;
+    }
+    load(sessionId, false);
+    return () => {
+      revisionRef.current += 1;
+    };
+  }, [active, load, sessionId]);
+
+  const retry = useCallback(() => {
+    if (sessionId) load(sessionId, true);
+  }, [load, sessionId]);
+
+  if (snapshot.sessionId !== sessionId) {
+    return { ...EMPTY_SNAPSHOT, loading: Boolean(sessionId) && active, retry };
+  }
+  return { ...snapshot, retry };
+}

--- a/apps/desktop/src/renderer/use-session-trace.ts
+++ b/apps/desktop/src/renderer/use-session-trace.ts
@@ -3,6 +3,7 @@ import { generalizedErrorMessage, generalizedErrorMessageChinese } from '@maka/c
 import type { SessionTrace } from '@maka/core/session-trace';
 import { useUiLocale } from '@maka/ui';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
+import { createTraceRefreshCoalescer } from './session-trace-refresh.js';
 
 interface SessionTraceSnapshot {
   sessionId?: string;
@@ -13,13 +14,19 @@ interface SessionTraceSnapshot {
 
 const EMPTY_SNAPSHOT: SessionTraceSnapshot = { loading: false };
 
+/** Long enough to absorb a turn's closing burst, short enough to feel live. */
+const TRACE_REFRESH_DEBOUNCE_MS = 400;
+
 /**
  * Reads the per-session causal trace (#1625).
  *
  * Reloads on the session's own event stream rather than on a timer: the trace
  * is a projection of the two ledgers, so the moment worth re-reading is when
- * one of them gained an event. Only refreshes while the panel is visible —
- * a hidden panel that keeps re-projecting a long session is a cost with no
+ * one of them gained an event. Which events those are, and how a burst is
+ * coalesced into one read, is `session-trace-refresh.ts`.
+ *
+ * Subscribes only while the panel is visible, and unsubscribes with it: a
+ * hidden panel that keeps re-projecting a long session is a cost with no
  * reader.
  */
 export function useSessionTrace(
@@ -80,9 +87,20 @@ export function useSessionTrace(
       if (!sessionId) setSnapshot(EMPTY_SNAPSHOT);
       return;
     }
+    const coalescer = createTraceRefreshCoalescer({
+      refresh: () => load(sessionId, true),
+      delayMs: TRACE_REFRESH_DEBOUNCE_MS,
+      schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+      cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+    });
+    const unsubscribe = window.maka.sessions.subscribeEvents(sessionId, (event) => {
+      coalescer.observe(event);
+    });
     load(sessionId, false);
     return () => {
       revisionRef.current += 1;
+      coalescer.cancel();
+      unsubscribe();
     };
   }, [active, load, sessionId]);
 

--- a/apps/desktop/src/renderer/use-session-trace.ts
+++ b/apps/desktop/src/renderer/use-session-trace.ts
@@ -51,11 +51,11 @@ export function useSessionTrace(
               sessionId: targetSessionId,
               ...(current.sessionId === targetSessionId ? { trace: current.trace } : {}),
               loading: false,
-              error: result.error.message ?? copy.loadFailed,
+              error: result.error.message || copy.loadFailed,
             }));
             return;
           }
-          setSnapshot({ sessionId: targetSessionId, trace: result.value, loading: false });
+          setSnapshot({ sessionId: targetSessionId, trace: result.data, loading: false });
         },
         (error: unknown) => {
           if (revision !== revisionRef.current) return;

--- a/packages/core/src/session-trace.ts
+++ b/packages/core/src/session-trace.ts
@@ -228,6 +228,14 @@ export interface SessionTraceCoverage {
   /** Turn ids with aggregate usage but no canonical record behind it. */
   turnsMissingModelCalls: string[];
   /**
+   * Canonical records the reader could not decode.
+   *
+   * Counted rather than dropped: a record that fails to decode is spend the
+   * trace cannot show, and silently omitting it is the difference between a
+   * gap that is visible and one that is not.
+   */
+  unreadableRecords: number;
+  /**
    * Turn ids where the aggregate usage stands for more runtime steps than there
    * are main model calls on record. A shortfall this narrow is still only what
    * the ledgers disagree about — it is a floor on what is missing, not a count.

--- a/packages/runtime/src/session-trace-projection.ts
+++ b/packages/runtime/src/session-trace-projection.ts
@@ -37,6 +37,11 @@ export interface SessionTraceInput {
   runtimeEvents: readonly RuntimeEvent[];
   /** Canonical metering, from the AgentRun stream's `model_call_attempt_recorded`. */
   modelCallAttempts: readonly ModelCallAttempt[];
+  /**
+   * Records the caller read but could not decode. Carried through to coverage
+   * so unreadable spend is visible instead of silently absent.
+   */
+  unreadableRecords?: number;
 }
 
 export function projectSessionTrace(input: SessionTraceInput): SessionTrace {
@@ -87,6 +92,7 @@ export function projectSessionTrace(input: SessionTraceInput): SessionTrace {
       turnsWithModelActivity,
       turnsMissingModelCalls,
       turnsWithFewerModelCallsThanSteps,
+      input.unreadableRecords ?? 0,
     ),
   };
 }
@@ -100,18 +106,26 @@ function resolveCoverage(
   turnsWithModelActivity: number,
   turnsMissingModelCalls: string[],
   turnsWithFewerModelCallsThanSteps: string[],
+  unreadableRecords: number,
 ): SessionTraceCoverage {
-  if (turnsWithModelActivity === 0) {
+  if (turnsWithModelActivity === 0 && unreadableRecords === 0) {
     return {
       modelCalls: 'none',
       turnsMissingModelCalls: [],
       turnsWithFewerModelCallsThanSteps: [],
+      unreadableRecords: 0,
     };
   }
-  if (turnsMissingModelCalls.length === turnsWithModelActivity) {
-    return { modelCalls: 'absent', turnsMissingModelCalls, turnsWithFewerModelCallsThanSteps };
+  if (turnsWithModelActivity > 0 && turnsMissingModelCalls.length === turnsWithModelActivity) {
+    return {
+      modelCalls: 'absent',
+      turnsMissingModelCalls,
+      turnsWithFewerModelCallsThanSteps,
+      unreadableRecords,
+    };
   }
-  const gaps = turnsMissingModelCalls.length + turnsWithFewerModelCallsThanSteps.length;
+  const gaps =
+    turnsMissingModelCalls.length + turnsWithFewerModelCallsThanSteps.length + unreadableRecords;
   return {
     // "No known gap" rather than "complete": records that are present cannot
     // prove that every call settled, so this is the absence of evidence of a
@@ -119,6 +133,7 @@ function resolveCoverage(
     modelCalls: gaps === 0 ? 'no_known_gap' : 'partial',
     turnsMissingModelCalls,
     turnsWithFewerModelCallsThanSteps,
+    unreadableRecords,
   };
 }
 


### PR DESCRIPTION
## Summary

Second layer of the Session Inspector: a read-only IPC that projects one session's trace, and a fifth `SessionWorkbar` tab that renders it. Consumes the projection merged in #1956.

Refs #1625.

**The read boundary is the AgentRun stream, not the Usage read model.** Usage is range-queried and carries no session predicate; the stream is the authority and is already keyed by session and run, which is how `context-diagnostics.ts` reads it too. `inspector:trace` reads both ledgers and writes nothing — no new store, no new permission path, no execution.

**A record that will not decode is counted, not dropped.** `SessionTraceCoverage` gains `unreadableRecords`. Spend the trace cannot show is exactly the kind of gap that otherwise renders as an absence of activity — the same failure the pi-backend case already forced into the open, one layer up.

**The panel's judgements are pure and tested without a DOM.** `deriveInspectorPanelModel` decides what counts as a gap worth showing, whether a cost may be rendered at all, and which step a failure is attributed to; `SessionInspectorPanel` only lays the result out. Two rules carried through from the ledger: an unpriced call renders "cost unavailable" and never `$0`, and failure highlighting follows the attributed step rather than every step after it.

**Tab placement.** `SessionWorkbar`, not `AgentGraphPanel` — the latter is gated on `orchestrationMode === 'graph'` and would have hidden the Inspector from ordinary sessions, which was the failure mode called out early in #1625. The panel refreshes only while visible: a hidden panel re-projecting a long session is a cost with no reader.

## Tests

- 3 for the IPC read: the two-ledger join across runs, an undecodable record counted rather than skipped, and non-canonical AgentRun events ignored.
- 5 for the panel model: no notice when there is no known gap, a partial notice carrying what is missing, unpriced calls left without a cost, failure attribution not bleeding onto later steps, and the empty case.
- The workbar persistence whitelist, which had **no coverage at all** — a tab that renders but is missing from `readSessionWorkbarTab` silently reverts to Tasks after a restart, which reads as the panel forgetting rather than as a missing case.

## Verification

`@maka/core` 703/703; session-trace projection, inspector IPC, panel model and workbar layout suites green (29 targeted tests). `check-a11y`, `check-console`, `check-copy`, `check-dead-css` and `format:check` clean.

## Not here

No search or replay step-through — that is PR 3. No changes to the ledger, the pricing authority, the permission path, or the execution runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
