### PR TITLE
polish(ui): skill empty states gain their next-step actions

### DIFF
--- a/packages/ui/src/skills-copy.ts
+++ b/packages/ui/src/skills-copy.ts
@@ -21,6 +21,8 @@ export interface SkillsCopy {
     emptySearchBody: string;
     emptyBody: string;
     emptyFilterBody: string;
+    clearSearch: string;
+    clearFilters: string;
     sourceFallback: string;
   };
   tabs: { ariaLabel: string; market: string; builtin: string; installed: string };
@@ -150,7 +152,7 @@ export interface SkillsCopy {
 const SKILLS_COPY = {
   zh: {
     categories: { '内容创作': '内容创作', '数据与AI': '数据与 AI', '设计与UI': '设计与 UI', 'DevOps与部署': 'DevOps 与部署', '文档与写作': '文档与写作', '效率工具': '效率工具', '研究与分析': '研究与分析' },
-    market: { categoryAll: '全部分类', sortName: '排序：名称', sortRecent: '排序：最近', controls: '市场筛选与排序', categoryFilter: '按分类筛选市场技能', sortAriaLabel: '市场技能排序方式', ariaLabel: '技能市场', official: '官方精选', sourceActions: '来源库操作', importLocal: '导入本地 Skill', emptySearchTitle: '没有匹配的市场技能', emptyTitle: '来源库还是空的', emptySearchBody: '换一个关键词，或清空搜索查看全部来源。', emptyBody: '导入一个含 SKILL.md 的本地文件，它会作为可安装的来源出现在这里。', emptyFilterBody: '换一个分类或关键词，或清空筛选查看全部来源。', sourceFallback: '本地来源库 Skill。' },
+    market: { categoryAll: '全部分类', sortName: '排序：名称', sortRecent: '排序：最近', controls: '市场筛选与排序', categoryFilter: '按分类筛选市场技能', sortAriaLabel: '市场技能排序方式', ariaLabel: '技能市场', official: '官方精选', sourceActions: '来源库操作', importLocal: '导入本地 Skill', emptySearchTitle: '没有匹配的市场技能', emptyTitle: '来源库还是空的', emptySearchBody: '换一个关键词，或清空搜索查看全部来源。', emptyBody: '导入一个含 SKILL.md 的本地文件，它会作为可安装的来源出现在这里。', emptyFilterBody: '换一个分类或关键词，或清空筛选查看全部来源。', clearSearch: '清空搜索', clearFilters: '清空筛选', sourceFallback: '本地来源库 Skill。' },
     tabs: { ariaLabel: '技能视图', market: '市场', builtin: '内置', installed: '已安装' },
     banner: { ariaLabel: '精选技能', title: '为你精选的职场技能', body: '涵盖写作、效率、设计、数据分析等场景，将陆续上线，敬请期待。', review: '复盘', reviewDetail: '总结沉淀', documents: '文档', documentsDetail: '审阅润色', publish: '发布', publishDetail: '检查清单' },
     install: { action: (name) => `安装 ${name}`, installedTitle: '已安装到当前工作区', installed: '已安装', notInstalled: '未安装' },
@@ -165,7 +167,7 @@ const SKILLS_COPY = {
   },
   en: {
     categories: { '内容创作': 'Content creation', '数据与AI': 'Data & AI', '设计与UI': 'Design & UI', 'DevOps与部署': 'DevOps & deployment', '文档与写作': 'Documents & writing', '效率工具': 'Productivity', '研究与分析': 'Research & analysis' },
-    market: { categoryAll: 'All categories', sortName: 'Sort: Name', sortRecent: 'Sort: Recent', controls: 'Marketplace filters and sorting', categoryFilter: 'Filter marketplace skills by category', sortAriaLabel: 'Marketplace skill sort order', ariaLabel: 'Skill marketplace', official: 'Official picks', sourceActions: 'Source library actions', importLocal: 'Import local Skill', emptySearchTitle: 'No matching marketplace skills', emptyTitle: 'The source library is empty', emptySearchBody: 'Try another keyword or clear search to see all sources.', emptyBody: 'Import a local file containing SKILL.md to make it available as an installable source.', emptyFilterBody: 'Try another category or keyword, or clear the filters.', sourceFallback: 'Local source-library Skill.' },
+    market: { categoryAll: 'All categories', sortName: 'Sort: Name', sortRecent: 'Sort: Recent', controls: 'Marketplace filters and sorting', categoryFilter: 'Filter marketplace skills by category', sortAriaLabel: 'Marketplace skill sort order', ariaLabel: 'Skill marketplace', official: 'Official picks', sourceActions: 'Source library actions', importLocal: 'Import local Skill', emptySearchTitle: 'No matching marketplace skills', emptyTitle: 'The source library is empty', emptySearchBody: 'Try another keyword or clear search to see all sources.', emptyBody: 'Import a local file containing SKILL.md to make it available as an installable source.', emptyFilterBody: 'Try another category or keyword, or clear the filters.', clearSearch: 'Clear search', clearFilters: 'Clear filters', sourceFallback: 'Local source-library Skill.' },
     tabs: { ariaLabel: 'Skill views', market: 'Marketplace', builtin: 'Built in', installed: 'Installed' },
     banner: { ariaLabel: 'Featured skills', title: 'Featured workplace skills', body: 'Writing, productivity, design, and data-analysis skills are coming soon.', review: 'Review', reviewDetail: 'Capture insights', documents: 'Documents', documentsDetail: 'Review and refine', publish: 'Publish', publishDetail: 'Checklists' },
     install: { action: (name) => `Install ${name}`, installedTitle: 'Installed in this workspace', installed: 'Installed', notInstalled: 'Not installed' },

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -64,6 +64,8 @@ function SkillLibraryPanel(props: {
   togglingSkillId?: string | null;
   deletingSkillId?: string | null;
   searchQuery?: string;
+  /** Clears the module-header search box (owned by the outer panel). */
+  onClearSearch?: () => void;
   managedSkillSources?: ManagedSkillSourceEntry[];
   bundledSkillCatalog?: BundledSkillCatalogEntry[];
   onInstallBundledSkill?(id: string): void | Promise<void>;
@@ -309,6 +311,9 @@ function SkillLibraryPanel(props: {
           description={normalizedSkillQuery
             ? copy.market.emptySearchBody
             : copy.market.emptyBody}
+          actions={normalizedSkillQuery && props.onClearSearch
+            ? <UiButton variant="ghost" size="sm" label={copy.market.clearSearch} onClick={props.onClearSearch} />
+            : undefined}
           className="maka-skill-installed-empty"
         />
       ) : marketSources.length === 0 ? (
@@ -316,6 +321,17 @@ function SkillLibraryPanel(props: {
           icon={<Search />}
           title={copy.market.emptySearchTitle}
           description={copy.market.emptyFilterBody}
+          actions={(
+            <UiButton
+              variant="ghost"
+              size="sm"
+              label={copy.market.clearFilters}
+              onClick={() => {
+                setMarketCategory(MARKET_CATEGORY_ALL);
+                props.onClearSearch?.();
+              }}
+            />
+          )}
           className="maka-skill-installed-empty"
         />
       ) : (
@@ -381,6 +397,9 @@ function SkillLibraryPanel(props: {
           icon={<Search />}
           title={copy.builtin.noMatchTitle}
           description={copy.builtin.noMatchBody}
+          actions={props.onClearSearch
+            ? <UiButton variant="ghost" size="sm" label={copy.market.clearSearch} onClick={props.onClearSearch} />
+            : undefined}
           className="maka-skill-installed-empty"
         />
       ) : (
@@ -883,6 +902,7 @@ export function SkillsModuleMain(props: {
         togglingSkillId={pendingSkillAction?.startsWith('runtime:set:') ? pendingSkillAction.slice('runtime:set:'.length) : null}
         deletingSkillId={pendingSkillAction?.startsWith('delete:') ? pendingSkillAction.slice('delete:'.length) : null}
         searchQuery={skillSearchQuery}
+        onClearSearch={() => setSkillSearchQuery('')}
       />
     </main>
   );


### PR DESCRIPTION
Selective-adoption follow-up (no layout changes): checklist rule 18 says every empty region needs a specific description and a next-step action. Marketplace search-empty → 清空搜索; filtered-to-zero → 清空筛选 (resets category + search); built-in no-match → 清空搜索. The library panel gains an optional `onClearSearch` (the search box lives in the outer header). Skeleton first-paint was considered and dropped honestly — these panels have no async seam, and a fake loading phase would be fake motion. Self-reviewed; full local verification green.