### PR TITLE
fix(e2e): seed a real project so the sidebar rename spec stops racing

### DIFF
--- a/apps/desktop/e2e/sidebar-navigation.spec.ts
+++ b/apps/desktop/e2e/sidebar-navigation.spec.ts
@@ -75,8 +75,16 @@ test('project rename owns Enter without toggling the project disclosure', async 
   const sidebar = await expandedSidebar(page);
   await sidebar.getByRole('radio', { name: '按项目' }).click();
 
-  const project = sidebar.locator('[data-project-id]').first();
+  // Anchor on the SEEDED project (see LONG_SIDEBAR_PROJECT_* in
+  // seed-helpers): `.first()` used to race the app's async workspace
+  // self-registration — when only the 未归属项目 pseudo-group existed, its
+  // row has no 项目操作 trigger and the click below waited out its timeout.
+  const project = sidebar
+    .locator('[data-project-id]')
+    .filter({ hasText: '示例项目' })
+    .first();
   const projectToggle = project.locator('button[aria-expanded]').first();
+  await expect(project).toBeVisible();
   await expect(projectToggle).toHaveAttribute('aria-expanded', 'true');
   // Capture the disclosure state while the disclosure control is mounted:
   // starting a rename swaps the whole project row for the rename input, so
@@ -95,10 +103,21 @@ test('project rename owns Enter without toggling the project disclosure', async 
   const projectActions = project
     .locator('.maka-project-item-end')
     .getByRole('button', { name: /项目操作$/ });
-  await projectActions.click();
-  await page.getByRole('menuitem', { name: '重命名', exact: true }).click();
+  // focus + Enter, the suite's menu-trigger idiom (plan-reminders.spec's
+  // openFocusedMenu): the trigger nests inside the row's composite
+  // SideNavItem button, and pointer hit-testing on that nesting is
+  // CI-timing sensitive; keyboard activation exercises the same menu.
+  await projectActions.focus();
+  await expect(projectActions).toBeFocused();
+  await page.keyboard.press('Enter');
+  const renameItem = page.getByRole('menuitem', { name: '重命名', exact: true });
+  await expect(renameItem).toBeVisible();
+  await renameItem.click();
 
-  const rename = project.getByRole('textbox', { name: '重命名' });
+  // Sidebar-scoped: starting a rename swaps the row's content for the input,
+  // so the name-filtered `project` locator cannot match while editing (the
+  // name lives in the input's value, which hasText does not read).
+  const rename = sidebar.getByRole('textbox', { name: '重命名' });
   await expect(rename).toBeFocused();
   const originalName = await rename.inputValue();
   await rename.press('A');

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -1,10 +1,13 @@
 import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { UiLocale, E2eFixtureScenario, E2eFixtureState } from '@maka/core';
 import { resolveStorageRoot } from '@maka/storage/root-authority';
 import type { CredentialStore } from './credential-store.js';
 import {
   ARTIFACT_SESSION_ID,
   ERROR_SESSION_ID,
+  LONG_SIDEBAR_PROJECT_ID,
+  LONG_SIDEBAR_PROJECT_NAME,
   LONG_SIDEBAR_SCENARIOS,
   LONG_SIDEBAR_SESSION_PREFIX,
   LONG_TRANSCRIPT_SESSION_ID,
@@ -19,6 +22,7 @@ import {
   TURN_SESSION_ID,
   E2E_FIXTURE_NOW,
   WORKSTATION_RUNNING_SESSION_ID,
+  writeJson,
   writeSession,
 } from './e2e-fixture/seed-helpers.js';
 import {
@@ -737,6 +741,24 @@ export async function seedE2eFixture(input: {
     for (const seed of longSidebarSessions(now)) {
       await writeSession(input.workspaceRoot, seed.header, seed.messages);
     }
+    // Deterministic project record (see LONG_SIDEBAR_PROJECT_ID in
+    // seed-helpers): the 按项目 grouping must not depend on the app's async
+    // workspace self-registration. The location points at the live
+    // workspace root so the catalog presents it as available.
+    await writeJson(join(input.workspaceRoot, 'projects.json'), {
+      schemaVersion: 1,
+      projects: [
+        {
+          id: LONG_SIDEBAR_PROJECT_ID,
+          name: LONG_SIDEBAR_PROJECT_NAME,
+          identity: `folder:${input.workspaceRoot}`,
+          locations: [
+            { path: input.workspaceRoot, isWorktree: false, lastUsedAt: now },
+          ],
+          lastUsedAt: now,
+        },
+      ],
+    });
   }
   if (input.fixture.scenario === 'plan-reminders') {
     await writePlanReminders(input.workspaceRoot, now);

--- a/apps/desktop/src/main/e2e-fixture/scenarios-sessions.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-sessions.ts
@@ -2,6 +2,8 @@ import type { SessionHeader, StoredMessage } from '@maka/core';
 import {
   header,
   HEALTHY_SESSION_ID,
+  LONG_SIDEBAR_PROJECT_ID,
+  LONG_SIDEBAR_PROJECT_SESSION_COUNT,
   LONG_SIDEBAR_SESSION_COUNT,
   LONG_SIDEBAR_SESSION_PREFIX,
   LONG_TRANSCRIPT_SESSION_ID,
@@ -540,6 +542,9 @@ export function longSidebarSessions(now: number): Array<{ header: SessionHeader;
       now,
       lastMessageAt,
       status: 'active',
+      ...(i < LONG_SIDEBAR_PROJECT_SESSION_COUNT
+        ? { projectId: LONG_SIDEBAR_PROJECT_ID }
+        : {}),
     });
     const userTs = lastMessageAt - 30_000;
     const assistantTs = lastMessageAt;

--- a/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
+++ b/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
@@ -54,6 +54,18 @@ export const LONG_SIDEBAR_SESSION_PREFIX = 'e2e-fixture-sidebar-long-';
 export const LONG_SIDEBAR_SESSION_COUNT = 60;
 
 /**
+ * Deterministic project seed for the long-sidebar scenarios. The sidebar's
+ * 按项目 grouping used to depend on the app's ASYNC self-registration of the
+ * workspace as a project — an interaction race the rename e2e sometimes lost
+ * (only the 未归属项目 pseudo-group existed, so its 项目操作 trigger never
+ * mounted and the click waited 30s). Seeding the catalog + linking the three
+ * newest sessions makes the project row exist by construction.
+ */
+export const LONG_SIDEBAR_PROJECT_ID = 'e2e-fixture-project';
+export const LONG_SIDEBAR_PROJECT_NAME = '示例项目';
+export const LONG_SIDEBAR_PROJECT_SESSION_COUNT = 3;
+
+/**
  * Scenarios that share the long-sidebar (60-session) on-disk seed.
  * Kept as a Set so future scenarios reusing the same seed can be
  * registered in one place. Mirrors `TURN_CONTROL_SCENARIOS`.
@@ -100,6 +112,8 @@ export function header(input: {
   isArchived?: boolean;
   isFlagged?: boolean;
   orchestrationMode?: SessionHeader['orchestrationMode'];
+  /** Links the session to a seeded project record (sidebar 按项目 grouping). */
+  projectId?: string;
 }): SessionHeader {
   return {
     id: input.id,
@@ -117,6 +131,7 @@ export function header(input: {
     ...(input.blockedReason ? { blockedReason: input.blockedReason } : {}),
     statusUpdatedAt: input.lastMessageAt,
     hasUnread: input.hasUnread ?? false,
+    ...(input.projectId ? { projectId: input.projectId } : {}),
     ...(input.orchestrationMode ? { orchestrationMode: input.orchestrationMode } : {}),
     backend: input.backend ?? 'ai-sdk',
     llmConnectionSlug: input.connection,


### PR DESCRIPTION
The `project rename owns Enter` spec blocked four PRs tonight with an intermittent 30s click timeout. **Root cause**: the long-sidebar fixture never seeds a project — real project rows only appear after the app *asynchronously* self-registers the workspace, a race the test sometimes lost. On a loss only the 未归属项目 pseudo-group exists, whose row legitimately has no 项目操作 trigger.

**Deterministic fix (fixture)**: seed `projects.json` (one record, location = live workspace root so the catalog presents it available) alongside the 60-session seed, and link the three newest sessions via a new `projectId` passthrough in `header()`. The seed is shared by seven scenarios; default grouping is by-time, so none of their surfaces change.

**Spec hardening**: anchor on the seeded 示例项目 row (not `.first()`); open the menu via focus+Enter (the suite's own `openFocusedMenu` idiom — the trigger nests inside SideNavItem's composite button, where pointer hit-testing is timing-sensitive); sidebar-scope the rename textbox (entering rename swaps row content for the input, so a name-filtered row locator can't match mid-edit).

**Verification**: sidebar spec 7/7 × 5 consecutive runs (~2× faster — no timeout retries) · full local e2e green modulo two known parallel-load flakes that pass 8/8 standalone with and without this change · fixture unit tests 73/73 · typecheck/format/checks ✅

Self-reviewed per the standing instruction.