### PR TITLE
feat(runtime-host): add interactive session actions

### DIFF
--- a/packages/core/src/__tests__/agent-run-hosted-root.test.ts
+++ b/packages/core/src/__tests__/agent-run-hosted-root.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { agentRunMatchesHostedRootExecution, type AgentRunHeader } from '../agent-run.js';
+
+test('regenerate hosted root identity requires both source lineage fields', () => {
+  const run: AgentRunHeader = {
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-2',
+    status: 'completed',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/workspace',
+    permissionMode: 'ask',
+    createdAt: 1,
+    updatedAt: 2,
+    completedAt: 2,
+    parentTurnId: 'turn-1',
+    regeneratedFromTurnId: 'turn-1',
+  };
+
+  assert.equal(
+    agentRunMatchesHostedRootExecution(run, {
+      kind: 'regenerate',
+      sourceTurnId: 'turn-1',
+    }),
+    true,
+  );
+  assert.equal(
+    agentRunMatchesHostedRootExecution(
+      { ...run, regeneratedFromTurnId: 'turn-other' },
+      { kind: 'regenerate', sourceTurnId: 'turn-1' },
+    ),
+    false,
+  );
+  assert.equal(
+    agentRunMatchesHostedRootExecution(
+      { ...run, automationId: 'automation-1' },
+      { kind: 'regenerate', sourceTurnId: 'turn-1' },
+    ),
+    false,
+  );
+});
+
+test('context compact hosted root identity rejects message lineage', () => {
+  const run: AgentRunHeader = {
+    runId: 'run-compact',
+    sessionId: 'session-1',
+    turnId: 'turn-compact',
+    status: 'completed',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/workspace',
+    permissionMode: 'ask',
+    createdAt: 1,
+    updatedAt: 2,
+    completedAt: 2,
+    rootExecutionKind: 'context_compact',
+  };
+
+  assert.equal(agentRunMatchesHostedRootExecution(run, { kind: 'context_compact' }), true);
+  const { rootExecutionKind: _, ...ordinaryRun } = run;
+  assert.equal(agentRunMatchesHostedRootExecution(ordinaryRun, { kind: 'context_compact' }), false);
+  assert.equal(
+    agentRunMatchesHostedRootExecution(
+      { ...run, parentTurnId: 'turn-1' },
+      { kind: 'context_compact' },
+    ),
+    false,
+  );
+});

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -50,6 +50,8 @@ export type AgentRunContinuationSource =
 
 export type RootExecutionDescriptor =
   | { kind: 'external_message' }
+  | { kind: 'regenerate'; sourceTurnId: string }
+  | { kind: 'context_compact' }
   | { kind: 'automation'; automationId: string }
   | { kind: 'goal'; goalId: string }
   | {
@@ -160,6 +162,8 @@ export interface AgentRunHeader {
   agentGraphWakeId?: string;
   /** Durable delivery attempt for this host-authored supervisor turn. */
   agentGraphWakeAttemptId?: string;
+  /** Positive identity for a host-authored root that has no message lineage. */
+  rootExecutionKind?: 'context_compact';
   failureClass?: string;
   failureMessage?: string;
   abortSource?: string;
@@ -169,7 +173,13 @@ export interface AgentRunHeader {
 type HostedRootExecutionDescriptor = Extract<
   RootExecutionDescriptor,
   {
-    kind: 'automation' | 'goal' | 'agent_graph_supervisor_wake' | 'safe_boundary_continuation';
+    kind:
+      | 'regenerate'
+      | 'context_compact'
+      | 'automation'
+      | 'goal'
+      | 'agent_graph_supervisor_wake'
+      | 'safe_boundary_continuation';
   }
 >;
 
@@ -177,6 +187,46 @@ export function agentRunMatchesHostedRootExecution(
   run: AgentRunHeader,
   execution: HostedRootExecutionDescriptor,
 ): boolean {
+  if (execution.kind !== 'context_compact' && run.rootExecutionKind !== undefined) return false;
+  if (execution.kind === 'regenerate') {
+    return (
+      run.parentTurnId === execution.sourceTurnId &&
+      run.regeneratedFromTurnId === execution.sourceTurnId &&
+      run.parentRunId === undefined &&
+      run.resumedFromRunId === undefined &&
+      run.retriedFromRunId === undefined &&
+      run.agentId === undefined &&
+      run.agentName === undefined &&
+      run.retriedFromTurnId === undefined &&
+      run.branchOfTurnId === undefined &&
+      run.parentSessionId === undefined &&
+      run.continuationSource === undefined &&
+      run.automationId === undefined &&
+      run.goalId === undefined &&
+      run.agentGraphWakeId === undefined &&
+      run.agentGraphWakeAttemptId === undefined
+    );
+  }
+  if (execution.kind === 'context_compact') {
+    return (
+      run.rootExecutionKind === 'context_compact' &&
+      run.parentTurnId === undefined &&
+      run.regeneratedFromTurnId === undefined &&
+      run.parentRunId === undefined &&
+      run.resumedFromRunId === undefined &&
+      run.retriedFromRunId === undefined &&
+      run.agentId === undefined &&
+      run.agentName === undefined &&
+      run.retriedFromTurnId === undefined &&
+      run.branchOfTurnId === undefined &&
+      run.parentSessionId === undefined &&
+      run.continuationSource === undefined &&
+      run.automationId === undefined &&
+      run.goalId === undefined &&
+      run.agentGraphWakeId === undefined &&
+      run.agentGraphWakeAttemptId === undefined
+    );
+  }
   if (execution.kind === 'safe_boundary_continuation') {
     const source = run.continuationSource;
     return (
@@ -226,7 +276,10 @@ export function agentRunMatchesHostedRootExecution(
 
 function hostedRootAuthorityMatches(
   run: AgentRunHeader,
-  execution: Exclude<HostedRootExecutionDescriptor, { kind: 'safe_boundary_continuation' }>,
+  execution: Exclude<
+    HostedRootExecutionDescriptor,
+    { kind: 'regenerate' | 'context_compact' | 'safe_boundary_continuation' }
+  >,
 ): boolean {
   switch (execution.kind) {
     case 'automation':
@@ -367,6 +420,7 @@ const AGENT_RUN_HEADER_SHAPE = defineObjectShape<AgentRunHeader>()(
     'goalId',
     'agentGraphWakeId',
     'agentGraphWakeAttemptId',
+    'rootExecutionKind',
     'failureClass',
     'failureMessage',
     'abortSource',
@@ -405,6 +459,7 @@ export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
       isEffectiveOrchestrationSource(value.orchestrationSource)) &&
     (value.agentSwarmAuthorization === undefined ||
       isAgentSwarmAuthorizationSource(value.agentSwarmAuthorization)) &&
+    (value.rootExecutionKind === undefined || value.rootExecutionKind === 'context_compact') &&
     !(value.automationId !== undefined && value.goalId !== undefined) &&
     isFiniteNumber(value.createdAt) &&
     isFiniteNumber(value.updatedAt) &&

--- a/packages/runtime-host/src/__tests__/context-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/context-protocol.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { decodeClientFrame, decodeHostFrame, RuntimeHostProtocolError } from '../protocol/index.js';
+
+test('context operations preserve bounded exact wire values', () => {
+  assert.deepEqual(
+    decodeClientFrame({
+      requestId: 'request-query',
+      operation: 'context.diagnostics.query',
+      input: { sessionId: 'session-1' },
+    }),
+    {
+      requestId: 'request-query',
+      operation: 'context.diagnostics.query',
+      input: { sessionId: 'session-1' },
+    },
+  );
+  assert.deepEqual(
+    decodeClientFrame({
+      requestId: 'request-compact',
+      operation: 'context.compact',
+      input: { sessionId: 'session-1', turnId: 'compact-1' },
+    }),
+    {
+      requestId: 'request-compact',
+      operation: 'context.compact',
+      input: { sessionId: 'session-1', turnId: 'compact-1' },
+    },
+  );
+  assert.deepEqual(
+    decodeHostFrame({
+      requestId: 'request-query',
+      operation: 'context.diagnostics.query',
+      ok: true,
+      result: {
+        status: 'available',
+        providerId: 'openrouter',
+        modelId: 'openrouter/free',
+        completedAt: 10,
+        inputTokens: 20,
+        contextWindow: 128_000,
+        segments: [{ kind: 'messages', bytes: 80, estimatedTokens: 20 }],
+        compaction: {
+          kind: 'history',
+          phase: 'pre_turn',
+          eventCount: 4,
+          turnCount: 2,
+          estimatedTokens: 12,
+        },
+      },
+    }),
+    {
+      requestId: 'request-query',
+      operation: 'context.diagnostics.query',
+      ok: true,
+      result: {
+        status: 'available',
+        providerId: 'openrouter',
+        modelId: 'openrouter/free',
+        completedAt: 10,
+        inputTokens: 20,
+        contextWindow: 128_000,
+        segments: [{ kind: 'messages', bytes: 80, estimatedTokens: 20 }],
+        compaction: {
+          kind: 'history',
+          phase: 'pre_turn',
+          eventCount: 4,
+          turnCount: 2,
+          estimatedTokens: 12,
+        },
+      },
+    },
+  );
+  assert.deepEqual(
+    decodeHostFrame({
+      requestId: 'request-compact',
+      operation: 'context.compact',
+      ok: true,
+      result: {
+        sessionId: 'session-1',
+        turnId: 'compact-1',
+        runId: 'run-compact-1',
+        status: 'running',
+      },
+    }),
+    {
+      requestId: 'request-compact',
+      operation: 'context.compact',
+      ok: true,
+      result: {
+        sessionId: 'session-1',
+        turnId: 'compact-1',
+        runId: 'run-compact-1',
+        status: 'running',
+      },
+    },
+  );
+});
+
+test('context operations reject open shapes and invalid diagnostics', () => {
+  assert.throws(
+    () =>
+      decodeClientFrame({
+        requestId: 'request-query',
+        operation: 'context.diagnostics.query',
+        input: { sessionId: 'session-1', includeTrace: true },
+      }),
+    isProtocolError,
+  );
+  assert.throws(
+    () =>
+      decodeHostFrame({
+        requestId: 'request-query',
+        operation: 'context.diagnostics.query',
+        ok: true,
+        result: {
+          status: 'available',
+          providerId: 'openrouter',
+          modelId: 'openrouter/free',
+          completedAt: 10,
+          contextWindow: 0,
+          segments: [],
+        },
+      }),
+    isProtocolError,
+  );
+});
+
+function isProtocolError(error: unknown): boolean {
+  return error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame';
+}

--- a/packages/runtime-host/src/__tests__/execution-host-recovery.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host-recovery.test.ts
@@ -157,6 +157,40 @@ test('retry after a discarded turn.start response reuses the durable semantic ad
   });
 });
 
+test('startup recovery replays an admitted regenerate with its source lineage', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const firstHost = await fixture.startHost();
+    const first = await connectClient(fixture.root, 'desktop');
+    const sourceTurnId = randomUUID();
+    const regeneratedTurnId = randomUUID();
+    await first.startTurn({
+      sessionId: fixture.sessionId,
+      turnId: sourceTurnId,
+      content: quotedContent('recover this regeneration'),
+    });
+    await waitForTerminalTurn(first, fixture.sessionId, sourceTurnId);
+    await first.close();
+    await fixture.stopHost(firstHost);
+
+    const admitted = await fixture.seedRegenerateAdmissionWithoutRun(
+      sourceTurnId,
+      regeneratedTurnId,
+    );
+    const successorHost = await fixture.startHost();
+    const successor = await connectClient(fixture.root, 'tui');
+    const terminal = await waitForTerminalTurn(successor, fixture.sessionId, regeneratedTurnId);
+    assert.equal(terminal.runId, admitted.runId);
+    await successor.close();
+    await fixture.stopHost(successorHost);
+
+    const ledger = await fixture.readTurn(regeneratedTurnId);
+    assert.equal(ledger.runs.length, 1);
+    assert.equal(ledger.userMessages.length, 1);
+    assert.equal(ledger.runs[0]?.parentTurnId, sourceTurnId);
+    assert.equal(ledger.runs[0]?.regeneratedFromTurnId, sourceTurnId);
+  });
+});
+
 test('a fresh quoted Turn preserves durable and Runtime handoff content', async () => {
   await withExecutionRoot(async (fixture) => {
     const host = await fixture.startHost();

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -626,6 +626,170 @@ test('two Clients share one execution after the starting Client disconnects', as
   });
 });
 
+test('regenerate replays the durable source content with one recoverable root identity', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const client = await connectClient(fixture.root, 'tui');
+    const sourceTurnId = randomUUID();
+    const regeneratedTurnId = randomUUID();
+    try {
+      await client.startTurn(
+        {
+          sessionId: fixture.sessionId,
+          turnId: sourceTurnId,
+          content: quotedContent('repeat this request'),
+        },
+        PROCESS_TIMEOUT_MS,
+      );
+      await waitForTerminalTurn(client, fixture.sessionId, sourceTurnId);
+
+      const started = await client.regenerateTurn(
+        {
+          sessionId: fixture.sessionId,
+          sourceTurnId,
+          turnId: regeneratedTurnId,
+        },
+        PROCESS_TIMEOUT_MS,
+      );
+      const terminal = await waitForTerminalTurn(client, fixture.sessionId, regeneratedTurnId);
+      assert.equal(terminal.runId, started.runId);
+      assert.deepEqual(
+        await client.regenerateTurn({
+          sessionId: fixture.sessionId,
+          sourceTurnId,
+          turnId: regeneratedTurnId,
+        }),
+        terminal,
+      );
+    } finally {
+      await client.close();
+      await fixture.stopHost(host);
+    }
+
+    const ledger = await fixture.readTurn(regeneratedTurnId);
+    assert.equal(ledger.runs.length, 1);
+    assert.equal(ledger.userMessages.length, 1);
+    assert.equal(ledger.runs[0]?.parentTurnId, sourceTurnId);
+    assert.equal(ledger.runs[0]?.regeneratedFromTurnId, sourceTurnId);
+    assert.deepEqual(
+      {
+        text: ledger.userMessages[0]?.text,
+        quotes: ledger.userMessages[0]?.quotes,
+      },
+      quotedContent('repeat this request'),
+    );
+  });
+});
+
+test('regenerate rejects self-source and legacy target collisions without draining Host', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const firstHost = await fixture.startHost();
+    const first = await connectClient(fixture.root, 'tui');
+    const sourceTurnId = randomUUID();
+    await first.startTurn({
+      sessionId: fixture.sessionId,
+      turnId: sourceTurnId,
+      content: { text: 'source request' },
+    });
+    await waitForTerminalTurn(first, fixture.sessionId, sourceTurnId);
+    await assert.rejects(
+      first.regenerateTurn({
+        sessionId: fixture.sessionId,
+        sourceTurnId,
+        turnId: sourceTurnId,
+      }),
+      operationError('operation_conflict'),
+    );
+    await first.close();
+    await fixture.stopHost(firstHost);
+
+    const legacy = await fixture.seedSafeBoundaryContinuationSource();
+    const secondHost = await fixture.startHost();
+    const second = await connectClient(fixture.root, 'desktop');
+    try {
+      await assert.rejects(
+        second.regenerateTurn({
+          sessionId: fixture.sessionId,
+          sourceTurnId,
+          turnId: legacy.sourceTurnId,
+        }),
+        operationError('operation_conflict'),
+      );
+      const followingTurnId = randomUUID();
+      await second.startTurn({
+        sessionId: fixture.sessionId,
+        turnId: followingTurnId,
+        content: { text: 'Host remains available' },
+      });
+      assert.equal(
+        (await waitForTerminalTurn(second, fixture.sessionId, followingTurnId)).status,
+        'completed',
+      );
+    } finally {
+      await second.close();
+      await fixture.stopHost(secondHost);
+    }
+    assert.deepEqual(await fixture.readTurnFootprint(legacy.sourceTurnId), {
+      admitted: false,
+      runCount: 1,
+      userMessageCount: 0,
+    });
+  });
+});
+
+test('context actions share root admission and expose backend capability honestly', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const first = await connectClient(fixture.root, 'desktop');
+    const second = await connectClient(fixture.root, 'tui');
+    const turnId = randomUUID();
+    const unavailableTurnId = randomUUID();
+    try {
+      assert.deepEqual(await first.queryContextDiagnostics({ sessionId: fixture.sessionId }), {
+        status: 'unavailable',
+        reason: 'no_completed_request',
+      });
+      const started = await first.startTurn({
+        sessionId: fixture.sessionId,
+        turnId,
+        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+      });
+      await waitForRunningTurn(second, fixture.sessionId, turnId);
+      await assert.rejects(
+        second.compactContext({
+          sessionId: fixture.sessionId,
+          turnId: randomUUID(),
+        }),
+        operationError('session_busy'),
+      );
+      await second.stopTurn({
+        sessionId: fixture.sessionId,
+        turnId,
+        runId: started.runId,
+      });
+      await assert.rejects(
+        second.compactContext({
+          sessionId: fixture.sessionId,
+          turnId: unavailableTurnId,
+        }),
+        operationError('operation_unavailable'),
+      );
+      await assert.rejects(
+        second.queryContextDiagnostics({ sessionId: 'missing-session' }),
+        operationError('not_found'),
+      );
+    } finally {
+      await Promise.allSettled([first.close(), second.close()]);
+      await fixture.stopHost(host);
+    }
+    assert.deepEqual(await fixture.readTurnFootprint(unavailableTurnId), {
+      admitted: false,
+      runCount: 0,
+      userMessageCount: 0,
+    });
+  });
+});
+
 test('a disconnected Client leaves a durable Interaction that another Client can answer', async () => {
   await withExecutionRoot(async (fixture) => {
     const firstHost = await fixture.startHost();

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
@@ -18,7 +18,7 @@ import { dirname, join } from 'node:path';
 import { test } from 'node:test';
 import { canonicalToolArgsHash, TOOL_BOUNDARY_PROTOCOL_V1 } from '@maka/core';
 import type { AgentRunHeader } from '@maka/core/agent-run';
-import type { MessageContent } from '@maka/core/events';
+import { normalizeMessageContent, type MessageContent } from '@maka/core/events';
 import type { ConnectionCatalogEntry } from '@maka/core/runtime-policy';
 import type { StoredMessage } from '@maka/core/session';
 import type { Task } from '@maka/core/task-ledger';
@@ -707,6 +707,45 @@ export class ExecutionFixture {
     content: MessageContent,
   ): Promise<{ runId: string; userMessageId: string }> {
     return this.seedTurnState(turnId, content, true, true);
+  }
+
+  async seedRegenerateAdmissionWithoutRun(
+    sourceTurnId: string,
+    turnId: string,
+  ): Promise<{ runId: string; userMessageId: string }> {
+    const owner = await tryAcquireInteractiveRootOwner(this.capability);
+    assert.ok(owner);
+    if (!owner) throw new Error('Unable to acquire execution root for regenerate admission setup');
+    try {
+      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      const messages = await stores.sessionStore.readMessages(this.sessionId);
+      const source = messages.find(
+        (message): message is Extract<StoredMessage, { type: 'user' }> =>
+          message.type === 'user' && message.turnId === sourceTurnId,
+      );
+      assert.ok(source);
+      if (!source) throw new Error('Regenerate source UserMessage is unavailable');
+      const chain = await stores.agentRunStore.listRootTurnAdmissionsForRecovery(this.sessionId);
+      const result = await stores.agentRunStore.admitRootTurn({
+        sessionId: this.sessionId,
+        turnId,
+        proposedRunId: randomUUID(),
+        proposedUserMessageId: randomUUID(),
+        execution: { kind: 'regenerate', sourceTurnId },
+        previousRootTurnId: chain.at(-1)?.turnId ?? null,
+        normalizedInput: normalizeMessageContent(source),
+        sourceMessages: [],
+        admittedAt: Date.now(),
+      });
+      assert.equal(result.kind, 'admitted');
+      assert.ok(result.admission.userMessageId);
+      return {
+        runId: result.admission.runId,
+        userMessageId: result.admission.userMessageId,
+      };
+    } finally {
+      await owner.close();
+    }
   }
 
   private async seedTurnState(

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -61,6 +61,8 @@ describe('Runtime Host bootstrap protocol', () => {
       'connection.catalog.update',
       'connection.models.fetch',
       'connection.test.run',
+      'context.compact',
+      'context.diagnostics.query',
       'credential.vault.delete',
       'credential.vault.query',
       'credential.vault.set',
@@ -90,6 +92,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'session.catalog.query',
       'session.configuration.update',
       'session.create',
+      'session.cwd.relocate',
       'session.lifecycle.set',
       'session.metadata.update',
       'session.read_marker.set',
@@ -104,6 +107,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'turn.interrupt',
       'turn.message.submit',
       'turn.query',
+      'turn.regenerate',
       'turn.resume.query',
       'turn.resume.start',
       'turn.start',
@@ -938,6 +942,43 @@ describe('Runtime Host bootstrap protocol', () => {
         ...submitWire,
         input: { ...submitWire.input, content: { text: 'valid' } },
       },
+    );
+  });
+
+  test('decodes a closed regenerate identity without accepting replacement content', () => {
+    assert.deepEqual(
+      decodeClientFrame({
+        requestId: 'request-regenerate',
+        operation: 'turn.regenerate',
+        input: {
+          sessionId: 'session-1',
+          sourceTurnId: 'turn-source',
+          turnId: 'turn-regenerated',
+        },
+      }),
+      {
+        requestId: 'request-regenerate',
+        operation: 'turn.regenerate',
+        input: {
+          sessionId: 'session-1',
+          sourceTurnId: 'turn-source',
+          turnId: 'turn-regenerated',
+        },
+      },
+    );
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          requestId: 'request-regenerate',
+          operation: 'turn.regenerate',
+          input: {
+            sessionId: 'session-1',
+            sourceTurnId: 'turn-source',
+            turnId: 'turn-regenerated',
+            content: { text: 'replacement' },
+          },
+        }),
+      isInvalidFrame,
     );
   });
 

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -1009,6 +1009,137 @@ test('Agent Graph context recovery fences competing root turns while compaction 
   }
 });
 
+test('manual context compact uses durable root query, stop, and exact retry authority', async () => {
+  let backend: BlockingContextRecoveryBackend | undefined;
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) =>
+      backends.register('fake', (context) => {
+        backend = new BlockingContextRecoveryBackend(context.sessionId);
+        return backend;
+      }),
+  });
+  const turnId = 'turn-manual-context-compact';
+  const context = operationContext(fixture.hostEpoch, fixture.acquireResidency);
+  try {
+    const started = await fixture.coordinator.handlers['context.compact'](
+      { sessionId: fixture.sessionId, turnId },
+      context,
+    );
+    assert.equal(started.ok, true);
+    if (!started.ok) return;
+    assert.equal(started.result.sessionId, fixture.sessionId);
+    assert.equal(started.result.turnId, turnId);
+    await backend?.compactStarted.promise;
+    assert.deepEqual(fixture.coordinator.readRootState(fixture.sessionId), {
+      kind: 'active',
+      sessionId: fixture.sessionId,
+      turnId,
+      runId: started.result.runId,
+    });
+
+    const queried = await fixture.coordinator.handlers['turn.query'](
+      { sessionId: fixture.sessionId, turnId },
+      context,
+    );
+    assert.equal(queried.ok, true);
+    if (queried.ok) assert.equal(queried.result.runId, started.result.runId);
+
+    const stopped = await fixture.coordinator.handlers['turn.stop'](
+      {
+        sessionId: fixture.sessionId,
+        turnId,
+        runId: started.result.runId,
+      },
+      context,
+    );
+    assert.equal(stopped.ok, true);
+    if (!stopped.ok) return;
+    assert.equal(stopped.result.status, 'cancelled');
+
+    const retried = await fixture.coordinator.handlers['context.compact'](
+      { sessionId: fixture.sessionId, turnId },
+      context,
+    );
+    assert.deepEqual(retried, stopped);
+    const admission = await fixture.stores.agentRunStore.readRootTurnAdmission(
+      fixture.sessionId,
+      turnId,
+    );
+    assert.deepEqual(admission?.execution, { kind: 'context_compact' });
+    assert.equal(admission?.userMessageId, null);
+    assert.equal(
+      (await fixture.stores.sessionStore.readMessages(fixture.sessionId)).some(
+        (message) => message.type === 'user' && message.turnId === turnId,
+      ),
+      false,
+    );
+    assert.equal(fixture.drainRequested(), false);
+  } finally {
+    backend?.releaseCompact();
+    await fixture.coordinator.close();
+    await fixture.messages.close();
+    await fixture.dispose();
+  }
+});
+
+test('startup recovery replays an admitted context compact with its exact Run identity', async () => {
+  let backend: BlockingContextRecoveryBackend | undefined;
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) =>
+      backends.register('fake', (context) => {
+        backend = new BlockingContextRecoveryBackend(context.sessionId);
+        return backend;
+      }),
+  });
+  const turnId = 'turn-recovered-context-compact';
+  const runId = 'run-recovered-context-compact';
+  let recovery: RootTurnCoordinator | undefined;
+  try {
+    await fixture.coordinator.close();
+    await fixture.stores.agentRunStore.admitRootTurn({
+      sessionId: fixture.sessionId,
+      turnId,
+      proposedRunId: runId,
+      proposedUserMessageId: null,
+      execution: { kind: 'context_compact' },
+      previousRootTurnId: null,
+      normalizedInput: null,
+      sourceMessages: [],
+      admittedAt: Date.now(),
+    });
+
+    recovery = fixture.createRecoveryCoordinator();
+    await recovery.prepareRecovery();
+    await recovery.recover();
+    await backend?.compactStarted.promise;
+    assert.deepEqual(recovery.readRootState(fixture.sessionId), {
+      kind: 'active',
+      sessionId: fixture.sessionId,
+      turnId,
+      runId,
+    });
+
+    const stopped = await recovery.handlers['turn.stop'](
+      { sessionId: fixture.sessionId, turnId, runId },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(stopped.ok, true);
+    if (stopped.ok) assert.equal(stopped.result.status, 'cancelled');
+    assert.equal(
+      (await fixture.stores.agentRunStore.listSessionRuns(fixture.sessionId)).filter(
+        (run) => run.turnId === turnId,
+      ).length,
+      1,
+    );
+    assert.equal(fixture.drainRequested(), false);
+  } finally {
+    backend?.releaseCompact();
+    await recovery?.close();
+    await fixture.messages.close();
+    await fixture.dispose();
+  }
+});
+
 test('Agent Graph context recovery abort stops compaction and releases Host close', async () => {
   let backend: BlockingContextRecoveryBackend | undefined;
   const fixture = await createFailureFixture({

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -299,6 +299,104 @@ test('creation fingerprints and persists the canonical cwd behind a symlink', as
   }
 });
 
+test('cwd relocation canonicalizes once and commits through Runtime authority', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-session-relocate-cwd-'));
+  const target = join(root, 'target');
+  const link = join(root, 'link');
+  await mkdir(target);
+  await symlink(target, link, 'dir');
+  try {
+    const fixture = createFixture();
+    const expectedRevision = fixture.revision();
+    const outcome = await fixture.coordinator.handlers['session.cwd.relocate'](
+      {
+        sessionId: fixture.sessionId,
+        expectedRevision,
+        cwd: link,
+      },
+      context,
+    );
+
+    assert.equal(outcome.ok, true);
+    if (!outcome.ok || outcome.result.kind !== 'committed') return;
+    if ('kind' in outcome.result.session) {
+      assert.fail('Relocated Session must remain wire-representable');
+    }
+    assert.equal(outcome.result.session.cwd, await realpath(target));
+    assert.equal(fixture.header().cwd, await realpath(target));
+    assert.equal(fixture.revision(), expectedRevision + 1);
+    assert.equal(fixture.drainRequests(), 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('cwd relocation reports a stale Session revision without mutating Runtime state', async () => {
+  let relocationAttempts = 0;
+  const fixture = createFixture({
+    manager: {
+      relocateSessionWorkspace: async () => {
+        relocationAttempts += 1;
+        assert.fail('Stale relocation must not enter Runtime authority');
+      },
+    },
+  });
+  const outcome = await fixture.coordinator.handlers['session.cwd.relocate'](
+    {
+      sessionId: fixture.sessionId,
+      expectedRevision: fixture.revision() - 1,
+      cwd: process.cwd(),
+    },
+    context,
+  );
+
+  assert.deepEqual(outcome, {
+    ok: true,
+    result: {
+      kind: 'revision_conflict',
+      expectedRevision: fixture.revision() - 1,
+      actualRevision: fixture.revision(),
+    },
+  });
+  assert.equal(relocationAttempts, 0);
+  assert.equal(fixture.drainRequests(), 0);
+});
+
+test('same-cwd relocation still enters Runtime eligibility authority', async () => {
+  let relocationAttempts = 0;
+  const cwd = await realpath(process.cwd());
+  const fixture = createFixture({
+    cwd,
+    manager: {
+      relocateSessionWorkspace: async () => {
+        relocationAttempts += 1;
+        throw new SessionConfigurationTransitionError(
+          'session_busy',
+          'Session workspace cannot change while a Turn is active',
+        );
+      },
+    },
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.cwd.relocate'](
+    {
+      sessionId: fixture.sessionId,
+      expectedRevision: fixture.revision(),
+      cwd,
+    },
+    context,
+  );
+
+  assert.equal(relocationAttempts, 1);
+  assert.deepEqual(outcome, {
+    ok: false,
+    error: {
+      code: 'session_busy',
+      message: 'Session workspace cannot change while a Turn is active',
+    },
+  });
+});
+
 test('catalog paging stops before the encoded 48 KiB result boundary', async () => {
   const records = Array.from({ length: 32 }, (_, index) => {
     const header = {
@@ -341,6 +439,7 @@ test('catalog paging stops before the encoded 48 KiB result boundary', async () 
 function createFixture(
   options: {
     readonly labels?: readonly string[];
+    readonly cwd?: string;
     readonly stores?: Partial<CatalogStores>;
     readonly manager?: Partial<ConfigurationAuthority>;
     readonly continuity?: Partial<SessionContinuity>;
@@ -349,6 +448,7 @@ function createFixture(
   const sessionId = 'session-1';
   let revision = 3;
   let header = sessionHeader(sessionId, options.labels ?? ['user-label']);
+  if (options.cwd) header = { ...header, cwd: options.cwd };
   let drains = 0;
 
   const stores: CatalogStores = {
@@ -386,6 +486,11 @@ function createFixture(
       revision += 1;
       return headerSnapshot(header, revision);
     },
+    relocateSessionWorkspace: async (_sessionId, input) => {
+      header = { ...header, cwd: input.cwd };
+      revision += 1;
+      return headerSnapshot(header, revision);
+    },
     ...options.manager,
   };
   const continuity: SessionContinuity = {
@@ -406,6 +511,7 @@ function createFixture(
     coordinator,
     sessionId,
     revision: () => revision,
+    header: () => header,
     drainRequests: () => drains,
   };
 }

--- a/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
@@ -21,6 +21,7 @@ describe('Session catalog protocol', () => {
             'session.create',
             'session.metadata.update',
             'session.configuration.update',
+            'session.cwd.relocate',
             'session.read_marker.set',
           ] as const
         ).map((operation) => [
@@ -36,6 +37,7 @@ describe('Session catalog protocol', () => {
         'session.create': { mode: 'command', availability: 'ready' },
         'session.metadata.update': { mode: 'command', availability: 'ready' },
         'session.configuration.update': { mode: 'command', availability: 'ready' },
+        'session.cwd.relocate': { mode: 'command', availability: 'ready' },
         'session.read_marker.set': { mode: 'command', availability: 'ready' },
       },
     );
@@ -81,6 +83,27 @@ describe('Session catalog protocol', () => {
           permissionMode: 'ask',
           collaborationMode: 'agent',
           orchestrationMode: 'default',
+        },
+      },
+    );
+
+    assert.deepEqual(
+      decodeClientFrame({
+        requestId: 'request-3',
+        operation: 'session.cwd.relocate',
+        input: {
+          sessionId: 'session-1',
+          expectedRevision: 2,
+          cwd: '/workspace/next',
+        },
+      }),
+      {
+        requestId: 'request-3',
+        operation: 'session.cwd.relocate',
+        input: {
+          sessionId: 'session-1',
+          expectedRevision: 2,
+          cwd: '/workspace/next',
         },
       },
     );

--- a/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { fork, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { readdir, mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, readdir, realpath, mkdtemp, rm } from 'node:fs/promises';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -299,6 +299,35 @@ test('two UDS Clients share stable Session creation, CAS configuration, and cata
       const narrowedSession = requireSessionProjection(narrowedConfiguration.session);
       assert.equal(narrowedSession.permissionMode, 'explore');
 
+      const firstCwd = join(base, 'workspace-first');
+      const secondCwd = join(base, 'workspace-second');
+      await Promise.all([mkdir(firstCwd), mkdir(secondCwd)]);
+      const relocationOutcomes = await Promise.all([
+        desktop.relocateSessionCwd({
+          sessionId: narrowedSession.id,
+          expectedRevision: narrowedSession.revision,
+          cwd: firstCwd,
+        }),
+        tui.relocateSessionCwd({
+          sessionId: narrowedSession.id,
+          expectedRevision: narrowedSession.revision,
+          cwd: secondCwd,
+        }),
+      ]);
+      assert.deepEqual(relocationOutcomes.map((outcome) => outcome.kind).sort(), [
+        'committed',
+        'revision_conflict',
+      ]);
+      const relocated = relocationOutcomes.find((outcome) => outcome.kind === 'committed');
+      assert.ok(relocated);
+      if (relocated?.kind !== 'committed') assert.fail('One Session relocation must commit');
+      const relocatedSession = requireSessionProjection(relocated.session);
+      assert.ok(
+        relocatedSession.cwd === (await realpath(firstCwd)) ||
+          relocatedSession.cwd === (await realpath(secondCwd)),
+      );
+      assert.deepEqual(await querySession(tui, narrowedSession.id), relocatedSession);
+
       await setDefaultModel(desktop, connectionId, WIRE_OVERSIZED_MODEL_ID);
       const rejectedSessionId = 'wire-oversized-default-model';
       await assert.rejects(
@@ -318,19 +347,19 @@ test('two UDS Clients share stable Session creation, CAS configuration, and cata
       );
       await assert.rejects(
         desktop.request('session.configuration.update', {
-          sessionId: narrowedSession.id,
-          expectedRevision: narrowedSession.revision,
+          sessionId: relocatedSession.id,
+          expectedRevision: relocatedSession.revision,
           configuration: {
             modelTarget: { kind: 'default' },
             thinkingLevel: null,
-            permissionMode: narrowedSession.permissionMode,
-            collaborationMode: narrowedSession.collaborationMode,
-            orchestrationMode: narrowedSession.orchestrationMode,
+            permissionMode: relocatedSession.permissionMode,
+            collaborationMode: relocatedSession.collaborationMode,
+            orchestrationMode: relocatedSession.orchestrationMode,
           },
         }),
         operationError('invalid_request'),
       );
-      assert.deepEqual(await querySession(desktop, narrowedSession.id), narrowedSession);
+      assert.deepEqual(await querySession(desktop, relocatedSession.id), relocatedSession);
       await setDefaultModel(tui, connectionId, 'gpt-5');
 
       const read = requireSessionProjection(

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -16,6 +16,10 @@ import {
   type ClientCapabilityReplaceResult,
   type ClientCapabilityUnregisterResult,
   type ClientSurface,
+  type ContextCompactInput,
+  type ContextCompactResult,
+  type ContextDiagnosticsQueryInput,
+  type ContextDiagnosticsResult,
   type HostOperationErrorCode,
   type HostIncompatible,
   type HostRegistration,
@@ -29,7 +33,10 @@ import {
   type ResponseFrame,
   type SubscriptionFrame,
   type SubscriptionOpenInput,
+  type SessionCwdRelocateInput,
+  type SessionUpdateResult,
   type TurnQueryInput,
+  type TurnRegenerateInput,
   type TurnResumePlan,
   type TurnResumeQueryInput,
   type TurnResumeStartInput,
@@ -125,6 +132,16 @@ export interface RuntimeHostConnection {
   startTurn(input: TurnStartInput, timeoutMs?: number): Promise<TurnSnapshot>;
   queryTurn(input: TurnQueryInput, timeoutMs?: number): Promise<TurnSnapshot>;
   stopTurn(input: TurnStopInput, timeoutMs?: number): Promise<TurnSnapshot>;
+  regenerateTurn(input: TurnRegenerateInput, timeoutMs?: number): Promise<TurnSnapshot>;
+  queryContextDiagnostics(
+    input: ContextDiagnosticsQueryInput,
+    timeoutMs?: number,
+  ): Promise<ContextDiagnosticsResult>;
+  compactContext(input: ContextCompactInput, timeoutMs?: number): Promise<ContextCompactResult>;
+  relocateSessionCwd(
+    input: SessionCwdRelocateInput,
+    timeoutMs?: number,
+  ): Promise<SessionUpdateResult>;
   queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan>;
   startTurnResume(input: TurnResumeStartInput, timeoutMs?: number): Promise<TurnResumeStartResult>;
   openSessionSubscription(
@@ -298,6 +315,28 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
 
   stopTurn(input: TurnStopInput, timeoutMs?: number): Promise<TurnSnapshot> {
     return this.request('turn.stop', input, timeoutMs);
+  }
+
+  regenerateTurn(input: TurnRegenerateInput, timeoutMs?: number): Promise<TurnSnapshot> {
+    return this.request('turn.regenerate', input, timeoutMs);
+  }
+
+  queryContextDiagnostics(
+    input: ContextDiagnosticsQueryInput,
+    timeoutMs?: number,
+  ): Promise<ContextDiagnosticsResult> {
+    return this.request('context.diagnostics.query', input, timeoutMs);
+  }
+
+  compactContext(input: ContextCompactInput, timeoutMs?: number): Promise<ContextCompactResult> {
+    return this.request('context.compact', input, timeoutMs);
+  }
+
+  relocateSessionCwd(
+    input: SessionCwdRelocateInput,
+    timeoutMs?: number,
+  ): Promise<SessionUpdateResult> {
+    return this.request('session.cwd.relocate', input, timeoutMs);
   }
 
   queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan> {

--- a/packages/runtime-host/src/protocol/context.ts
+++ b/packages/runtime-host/src/protocol/context.ts
@@ -1,0 +1,203 @@
+import {
+  requireCount,
+  requireEntityId,
+  requireExactRecord,
+  requireShapedRecord,
+  requireString,
+} from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+import { decodeTurnSnapshot, type TurnSnapshot } from './turn.js';
+
+export interface ContextDiagnosticsQueryInput {
+  readonly sessionId: string;
+}
+
+export interface ContextCompactInput {
+  readonly sessionId: string;
+  readonly turnId: string;
+}
+
+export type ContextCompactResult = TurnSnapshot;
+
+export interface ContextDiagnosticsSegment {
+  readonly kind: 'system_instructions' | 'tool_definitions' | 'messages' | 'other';
+  readonly bytes: number;
+  readonly estimatedTokens: number;
+}
+
+export type ContextDiagnosticsResult =
+  | {
+      readonly status: 'unavailable';
+      readonly reason: 'no_completed_request' | 'trace_unavailable';
+    }
+  | {
+      readonly status: 'available';
+      readonly providerId: string;
+      readonly modelId: string;
+      readonly completedAt: number;
+      readonly inputTokens?: number;
+      readonly contextWindow?: number;
+      readonly segments: readonly ContextDiagnosticsSegment[];
+      readonly compaction?: {
+        readonly kind: 'history';
+        readonly phase: 'pre_turn' | 'mid_turn';
+        readonly eventCount: number;
+        readonly turnCount: number;
+        readonly estimatedTokens: number;
+      };
+    };
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'not_found',
+  'internal_failure',
+] as const;
+
+export const CONTEXT_OPERATION_SPECS = {
+  'context.diagnostics.query': defineOperation({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeContextDiagnosticsQueryInput,
+    decodeOutput: decodeContextDiagnosticsResult,
+  }),
+  'context.compact': defineOperation({
+    mode: 'command',
+    availability: 'ready',
+    errors: [...QUERY_ERRORS, 'session_archived', 'session_busy', 'operation_conflict'] as const,
+    decodeInput: decodeContextCompactInput,
+    decodeOutput: decodeTurnSnapshot,
+    assertOutputForInput: (input, output) => {
+      if (input.sessionId !== output.sessionId || input.turnId !== output.turnId) {
+        throw invalidProtocolFrame('Context compact changed operation identity');
+      }
+    },
+  }),
+} as const;
+
+function decodeContextDiagnosticsQueryInput(value: unknown): ContextDiagnosticsQueryInput {
+  const input = requireExactRecord(value, 'Context diagnostics query input', ['sessionId']);
+  return { sessionId: requireEntityId(input.sessionId, 'sessionId') };
+}
+
+function decodeContextCompactInput(value: unknown): ContextCompactInput {
+  const input = requireExactRecord(value, 'Context compact input', ['sessionId', 'turnId']);
+  return {
+    sessionId: requireEntityId(input.sessionId, 'sessionId'),
+    turnId: requireEntityId(input.turnId, 'turnId'),
+  };
+}
+
+function decodeContextDiagnosticsResult(value: unknown): ContextDiagnosticsResult {
+  const record = requireShapedRecord(
+    value,
+    'Context diagnostics result',
+    ['status'],
+    [
+      'reason',
+      'providerId',
+      'modelId',
+      'completedAt',
+      'inputTokens',
+      'contextWindow',
+      'segments',
+      'compaction',
+    ],
+  );
+  if (record.status === 'unavailable') {
+    const unavailable = requireExactRecord(record, 'Unavailable context diagnostics', [
+      'status',
+      'reason',
+    ]);
+    if (
+      unavailable.reason !== 'no_completed_request' &&
+      unavailable.reason !== 'trace_unavailable'
+    ) {
+      throw invalidProtocolFrame('Invalid context diagnostics unavailable reason');
+    }
+    return { status: 'unavailable', reason: unavailable.reason };
+  }
+  if (record.status !== 'available') {
+    throw invalidProtocolFrame('Invalid context diagnostics status');
+  }
+  const available = requireShapedRecord(
+    record,
+    'Available context diagnostics',
+    ['status', 'providerId', 'modelId', 'completedAt', 'segments'],
+    ['inputTokens', 'contextWindow', 'compaction'],
+  );
+  if (!Array.isArray(available.segments) || available.segments.length > 4) {
+    throw invalidProtocolFrame('Invalid context diagnostics segments');
+  }
+  return {
+    status: 'available',
+    providerId: requireString(available.providerId, 'providerId', 512),
+    modelId: requireString(available.modelId, 'modelId', 512),
+    completedAt: requireCount(available.completedAt, 'completedAt'),
+    ...(available.inputTokens === undefined
+      ? {}
+      : { inputTokens: requireCount(available.inputTokens, 'inputTokens') }),
+    ...(available.contextWindow === undefined
+      ? {}
+      : { contextWindow: requirePositiveCount(available.contextWindow, 'contextWindow') }),
+    segments: available.segments.map(decodeContextDiagnosticsSegment),
+    ...(available.compaction === undefined
+      ? {}
+      : { compaction: decodeContextDiagnosticsCompaction(available.compaction) }),
+  };
+}
+
+function decodeContextDiagnosticsSegment(value: unknown): ContextDiagnosticsSegment {
+  const segment = requireExactRecord(value, 'Context diagnostics segment', [
+    'kind',
+    'bytes',
+    'estimatedTokens',
+  ]);
+  if (
+    segment.kind !== 'system_instructions' &&
+    segment.kind !== 'tool_definitions' &&
+    segment.kind !== 'messages' &&
+    segment.kind !== 'other'
+  ) {
+    throw invalidProtocolFrame('Invalid context diagnostics segment kind');
+  }
+  return {
+    kind: segment.kind,
+    bytes: requireCount(segment.bytes, 'bytes'),
+    estimatedTokens: requireCount(segment.estimatedTokens, 'estimatedTokens'),
+  };
+}
+
+function decodeContextDiagnosticsCompaction(
+  value: unknown,
+): NonNullable<Extract<ContextDiagnosticsResult, { status: 'available' }>['compaction']> {
+  const compaction = requireExactRecord(value, 'Context diagnostics compaction', [
+    'kind',
+    'phase',
+    'eventCount',
+    'turnCount',
+    'estimatedTokens',
+  ]);
+  if (
+    compaction.kind !== 'history' ||
+    (compaction.phase !== 'pre_turn' && compaction.phase !== 'mid_turn')
+  ) {
+    throw invalidProtocolFrame('Invalid context diagnostics compaction');
+  }
+  return {
+    kind: 'history',
+    phase: compaction.phase,
+    eventCount: requireCount(compaction.eventCount, 'eventCount'),
+    turnCount: requireCount(compaction.turnCount, 'turnCount'),
+    estimatedTokens: requireCount(compaction.estimatedTokens, 'estimatedTokens'),
+  };
+}
+
+function requirePositiveCount(value: unknown, name: string): number {
+  const count = requireCount(value, name);
+  if (count === 0) throw invalidProtocolFrame(`Invalid ${name}`);
+  return count;
+}

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -3,6 +3,7 @@ import { AGENT_GRAPH_OPERATION_SPECS } from './agent-graph.js';
 import { AUTOMATION_OPERATION_SPECS } from './automation.js';
 import { requireExactRecord, requireId, requireRecord, requireString } from './codec.js';
 import { CONNECTION_EFFECT_OPERATION_SPECS } from './connection-effects.js';
+import { CONTEXT_OPERATION_SPECS } from './context.js';
 import { EXECUTION_INSPECT_OPERATION_SPECS } from './execution-inspect.js';
 import { CLIENT_CAPABILITY_OPERATION_SPECS } from './client-capability.js';
 import { invalidProtocolFrame } from './errors.js';
@@ -85,6 +86,7 @@ export type {
 } from './message.js';
 export type {
   TurnQueryInput,
+  TurnRegenerateInput,
   TurnResumeParkReason,
   TurnResumePlan,
   TurnResumeQueryInput,
@@ -96,6 +98,7 @@ export type {
   TurnStopInput,
 } from './turn.js';
 export * from './connection-effects.js';
+export * from './context.js';
 export * from './agent-graph.js';
 export * from './execution-inspect.js';
 export * from './client-capability.js';
@@ -115,6 +118,7 @@ export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   AGENT_GRAPH_OPERATION_SPECS,
   GOAL_OPERATION_SPECS,
   TURN_OPERATION_SPECS,
+  CONTEXT_OPERATION_SPECS,
   CONNECTION_EFFECT_OPERATION_SPECS,
   EXECUTION_INSPECT_OPERATION_SPECS,
   RUNTIME_POLICY_OPERATION_SPECS,

--- a/packages/runtime-host/src/protocol/session-catalog.ts
+++ b/packages/runtime-host/src/protocol/session-catalog.ts
@@ -155,6 +155,12 @@ export interface SessionConfigurationUpdateInput {
   readonly configuration: SessionConfiguration;
 }
 
+export interface SessionCwdRelocateInput {
+  readonly sessionId: string;
+  readonly expectedRevision: number;
+  readonly cwd: string;
+}
+
 export interface SessionReadMarkerSetInput {
   readonly sessionId: string;
   readonly readThroughMessageId: string;
@@ -283,6 +289,18 @@ export const SESSION_CATALOG_OPERATION_SPECS = {
     availability: 'ready',
     errors: CONFIGURATION_UPDATE_ERRORS,
     decodeInput: decodeSessionConfigurationUpdateInput,
+    decodeOutput: decodeSessionUpdateResult,
+    assertOutputForInput: assertUpdateOutputIdentity,
+  }),
+  'session.cwd.relocate': defineOperation<
+    SessionCwdRelocateInput,
+    SessionUpdateResult,
+    (typeof CONFIGURATION_UPDATE_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: CONFIGURATION_UPDATE_ERRORS,
+    decodeInput: decodeSessionCwdRelocateInput,
     decodeOutput: decodeSessionUpdateResult,
     assertOutputForInput: assertUpdateOutputIdentity,
   }),
@@ -441,6 +459,19 @@ export function decodeSessionConfigurationUpdateInput(
       collaborationMode: collaborationMode(configuration.collaborationMode),
       orchestrationMode: orchestrationMode(configuration.orchestrationMode),
     },
+  };
+}
+
+export function decodeSessionCwdRelocateInput(value: unknown): SessionCwdRelocateInput {
+  const input = requireExactRecord(value, 'Session cwd relocate input', [
+    'sessionId',
+    'expectedRevision',
+    'cwd',
+  ]);
+  return {
+    sessionId: requireEntityId(input.sessionId, 'sessionId'),
+    expectedRevision: positiveRevision(input.expectedRevision, 'expected Session revision'),
+    cwd: requireUtf8String(input.cwd, 'Session cwd', SESSION_CATALOG_CWD_MAX_BYTES),
   };
 }
 
@@ -856,7 +887,7 @@ function boolean(value: unknown, label: string): boolean {
 }
 
 function assertUpdateOutputIdentity(
-  input: SessionMetadataUpdateInput | SessionConfigurationUpdateInput,
+  input: SessionMetadataUpdateInput | SessionConfigurationUpdateInput | SessionCwdRelocateInput,
   output: SessionUpdateResult,
 ): void {
   if (output.kind === 'committed') assertSessionIdentity(input.sessionId, output.session);

--- a/packages/runtime-host/src/protocol/turn.ts
+++ b/packages/runtime-host/src/protocol/turn.ts
@@ -51,6 +51,12 @@ export interface TurnStopInput {
   runId: string;
 }
 
+export interface TurnRegenerateInput {
+  sessionId: string;
+  sourceTurnId: string;
+  turnId: string;
+}
+
 export interface TurnResumeQueryInput {
   sessionId: string;
   sourceRunId?: string;
@@ -172,6 +178,27 @@ export const TURN_OPERATION_SPECS = {
     ] as const,
     decodeInput: decodeTurnStopInput,
     decodeOutput: decodeTurnSnapshot,
+  }),
+  'turn.regenerate': defineOperation({
+    mode: 'command',
+    availability: 'ready',
+    errors: [
+      'host_not_ready',
+      'host_draining',
+      'operation_unavailable',
+      'not_found',
+      'session_archived',
+      'session_busy',
+      'operation_conflict',
+      'internal_failure',
+    ] as const,
+    decodeInput: decodeTurnRegenerateInput,
+    decodeOutput: decodeTurnSnapshot,
+    assertOutputForInput: (input, output) => {
+      if (input.sessionId !== output.sessionId || input.turnId !== output.turnId) {
+        throw invalidProtocolFrame('Turn regenerate changed operation identity');
+      }
+    },
   }),
   'turn.resume.query': defineOperation({
     mode: 'query',
@@ -358,6 +385,19 @@ function decodeTurnStopInput(value: unknown): TurnStopInput {
     sessionId: requireEntityId(record.sessionId, 'sessionId'),
     turnId: requireEntityId(record.turnId, 'turnId'),
     runId: requireEntityId(record.runId, 'runId'),
+  };
+}
+
+function decodeTurnRegenerateInput(value: unknown): TurnRegenerateInput {
+  const record = requireExactRecord(value, 'turn.regenerate input', [
+    'sessionId',
+    'sourceTurnId',
+    'turnId',
+  ]);
+  return {
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    sourceTurnId: requireEntityId(record.sourceTurnId, 'sourceTurnId'),
+    turnId: requireEntityId(record.turnId, 'turnId'),
   };
 }
 

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -36,8 +36,14 @@ export type OperationHandlerMap = {
 export type DomainOperationKey = Exclude<OperationKey, 'host.status'>;
 export type TurnOperationKey = Extract<
   OperationKey,
-  'turn.start' | 'turn.query' | 'turn.stop' | 'turn.resume.query' | 'turn.resume.start'
+  | 'turn.start'
+  | 'turn.query'
+  | 'turn.stop'
+  | 'turn.regenerate'
+  | 'turn.resume.query'
+  | 'turn.resume.start'
 >;
+export type ContextOperationKey = Extract<OperationKey, `context.${string}`>;
 export type RuntimePolicyOperationKey = Extract<
   OperationKey,
   `runtime.policy.${string}` | `connection.catalog.${string}` | `credential.vault.${string}`
@@ -81,6 +87,7 @@ export type ClientCapabilityOperationKey = Extract<OperationKey, `client.capabil
 export type AutomationOperationKey = Extract<OperationKey, `automation.${string}`>;
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
 export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
+export type ContextOperationHandlerMap = Pick<OperationHandlerMap, ContextOperationKey>;
 export type RuntimePolicyOperationHandlerMap = Pick<OperationHandlerMap, RuntimePolicyOperationKey>;
 export type ConnectionEffectOperationHandlerMap = Pick<
   OperationHandlerMap,

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -19,10 +19,12 @@ import {
   classifyTerminalRuntimeLedger,
   RuntimeHostedRootConflictError,
   RuntimeHostedRootUnavailableError,
+  RuntimeContextCompactError,
   RuntimeInteractionAdmissionRejectedError,
   RuntimeInteractionFailStopError,
   RuntimeInteractionInvariantError,
   RuntimeMessageAuthorityInvariantError,
+  RuntimeRegenerateTurnError,
   RuntimeOwnerCleanupError,
   recoverAgentGraphSupervisorContextOverflow,
   type RuntimeContinuation,
@@ -47,7 +49,10 @@ import {
 } from '@maka/storage/execution-stores';
 import type {
   OperationOutcome,
+  ContextCompactInput,
+  ContextDiagnosticsQueryInput,
   TurnQueryInput,
+  TurnRegenerateInput,
   TurnResumePlan,
   TurnResumeQueryInput,
   TurnResumeStartInput,
@@ -67,7 +72,11 @@ import {
   type QueueFenceResult,
   type RootFollowupBatch,
 } from './message-coordinator.js';
-import type { ConnectionContext, TurnOperationHandlerMap } from './operation-dispatcher.js';
+import type {
+  ConnectionContext,
+  ContextOperationHandlerMap,
+  TurnOperationHandlerMap,
+} from './operation-dispatcher.js';
 import { RootAdmissionOwner } from './root-admission-owner.js';
 import { type SessionAdmissionLease, SessionAdmissionGate } from './session-admission-gate.js';
 import {
@@ -107,6 +116,33 @@ interface ActiveRootTurn {
 }
 
 type TurnStartOutcome = OperationOutcome<'turn.start'>;
+
+type RootMessageExecution = Extract<
+  RootExecutionDescriptor,
+  { kind: 'external_message' | 'regenerate' }
+>;
+
+interface RootMessageStartRequestBase {
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly archivedMessage: string;
+}
+
+type RootMessageStartRequest =
+  | (RootMessageStartRequestBase & {
+      readonly execution: Extract<RootMessageExecution, { kind: 'external_message' }>;
+      readonly content: MessageContent;
+      readonly turnOrchestration?: TurnStartInput['turnOrchestration'];
+    })
+  | (RootMessageStartRequestBase & {
+      readonly execution: Extract<RootMessageExecution, { kind: 'regenerate' }>;
+      readonly turnOrchestration?: undefined;
+      prepareContent(): Promise<MessageContent>;
+    });
+
+type RootMessageContentPreparation =
+  | { readonly kind: 'ready'; readonly content: MessageContent }
+  | { readonly kind: 'rejected'; readonly outcome: TurnStartOutcome };
 
 type RootTurnActivationInput =
   | TurnStartInput
@@ -227,12 +263,15 @@ interface RecoverySessionPlan {
 }
 
 export class RootTurnCoordinator {
-  readonly handlers: TurnOperationHandlerMap = {
+  readonly handlers: TurnOperationHandlerMap & ContextOperationHandlerMap = {
     'turn.start': (input, context) => this.startTurn(input, context),
     'turn.query': (input) => this.queryTurn(input),
     'turn.stop': (input) => this.stopTurn(input),
+    'turn.regenerate': (input, context) => this.regenerateTurn(input, context),
     'turn.resume.query': (input, context) => this.queryTurnResume(input, context),
     'turn.resume.start': (input, context) => this.startTurnResume(input, context),
+    'context.diagnostics.query': (input) => this.queryContextDiagnostics(input),
+    'context.compact': (input, context) => this.compactContext(input, context),
   };
 
   readonly #activeBySession = new Map<string, ActiveRootTurn>();
@@ -411,6 +450,8 @@ export class RootTurnCoordinator {
       for (const admission of plan.pendingRecoveryClosures) {
         if (
           admission.execution.kind === 'external_message' ||
+          admission.execution.kind === 'regenerate' ||
+          admission.execution.kind === 'context_compact' ||
           admission.execution.kind === 'automation' ||
           admission.execution.kind === 'safe_boundary_continuation'
         ) {
@@ -829,6 +870,126 @@ export class RootTurnCoordinator {
     } finally {
       this.releaseRootReservation(reservation);
     }
+  }
+
+  private async queryContextDiagnostics(
+    input: ContextDiagnosticsQueryInput,
+  ): Promise<OperationOutcome<'context.diagnostics.query'>> {
+    try {
+      await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
+      return { ok: true, result: await this.manager.getContextDiagnostics(input.sessionId) };
+    } catch (error) {
+      if (isSessionNotFoundError(error)) return notFound('Session does not exist');
+      throw error;
+    }
+  }
+
+  private compactContext(
+    input: ContextCompactInput,
+    context: ConnectionContext,
+  ): Promise<OperationOutcome<'context.compact'>> {
+    return this.runCommand(async () => {
+      await this.awaitTerminalRootCleanup(input.sessionId);
+      const activeAtEntry = this.#activeBySession.has(input.sessionId);
+      let reservation = activeAtEntry ? undefined : this.reserveRootTurn(input.sessionId);
+      if (!activeAtEntry && !reservation) {
+        return sessionBusy('Session already has a pending root Turn');
+      }
+      const admissionTask = this.sessionAdmission.run(input.sessionId, async (lease) => {
+        const existing = await this.stores.agentRunStore.readRootTurnAdmission(
+          input.sessionId,
+          input.turnId,
+        );
+        if (existing) {
+          this.rootAdmissionOwner.assertKnownAdmission(existing);
+          if (existing.execution.kind !== 'context_compact') {
+            return completedStart(
+              operationConflict('Turn identity belongs to a different execution kind'),
+            );
+          }
+          return this.prepareAdmittedTurn(
+            activationInputForAdmission(existing),
+            existing,
+            context.acquireResidency,
+            lease,
+            undefined,
+            undefined,
+            reservation,
+          );
+        }
+
+        reservation ??= this.reserveRootTurn(input.sessionId);
+        if (!reservation) {
+          return completedStart(sessionBusy('Session already has an active or pending root Turn'));
+        }
+        try {
+          let header: SessionHeader;
+          try {
+            header = await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
+          } catch (error) {
+            if (isSessionNotFoundError(error)) {
+              return completedStart(notFound('Session does not exist'));
+            }
+            throw error;
+          }
+          if (header.status === 'archived' || header.isArchived) {
+            return completedStart(sessionArchived('Cannot compact an archived Session'));
+          }
+          const unavailableReason = runtimeHostExternalTurnUnavailableReason(header);
+          if (unavailableReason) {
+            return completedStart(operationUnavailable(unavailableReason));
+          }
+          if (
+            (await this.manager.listTurns(input.sessionId)).some(
+              (turn) => turn.turnId === input.turnId,
+            )
+          ) {
+            return completedStart(operationConflict('Turn identity already exists'));
+          }
+          await this.manager.preflightContextCompaction(input.sessionId);
+        } catch (error) {
+          if (error instanceof RuntimeContextCompactError) {
+            return completedStart(
+              error.code === 'session_busy'
+                ? sessionBusy(error.message)
+                : operationUnavailable(error.message),
+            );
+          }
+          throw error;
+        }
+        if (!this.beginRootAdmission(reservation)) {
+          return completedStart(sessionBusy('Context compact reservation is no longer current'));
+        }
+        const admitted = await this.rootAdmissionOwner.admitRootTurn({
+          sessionId: input.sessionId,
+          turnId: input.turnId,
+          proposedRunId: randomUUID(),
+          proposedUserMessageId: null,
+          execution: { kind: 'context_compact' },
+          normalizedInput: null,
+          sourceMessages: [],
+          admittedAt: Date.now(),
+        });
+        if (admitted.admission.execution.kind !== 'context_compact') {
+          return completedStart(
+            operationConflict('Turn identity belongs to a different execution kind'),
+          );
+        }
+        return this.prepareAdmittedTurn(
+          activationInputForAdmission(admitted.admission),
+          admitted.admission,
+          context.acquireResidency,
+          lease,
+          undefined,
+          undefined,
+          reservation,
+        );
+      });
+      const disposition = await admissionTask.finally(() => {
+        if (reservation) this.releaseRootReservation(reservation);
+      });
+      return this.resolveStartDisposition(input, disposition);
+    });
   }
 
   async #runHostedRootReservation(
@@ -1375,46 +1536,77 @@ export class RootTurnCoordinator {
   }
 
   private startTurn(input: TurnStartInput, context: ConnectionContext): Promise<TurnStartOutcome> {
-    return this.runCommand(async () => {
-      const canonicalInput: TurnStartInput = {
-        ...input,
-        content: normalizeMessageContent(input.content),
+    const content = normalizeMessageContent(input.content);
+    return this.startRootMessage(
+      {
+        sessionId: input.sessionId,
+        turnId: input.turnId,
+        execution: { kind: 'external_message' },
         ...(input.turnOrchestration ? { turnOrchestration: { ...input.turnOrchestration } } : {}),
-      };
-      const activeAtEntry = this.#activeBySession.has(input.sessionId);
-      let reservation = activeAtEntry ? undefined : this.reserveRootTurn(input.sessionId);
+        archivedMessage: 'Cannot start a new Turn in an archived Session',
+        content,
+      },
+      context,
+    );
+  }
+
+  private regenerateTurn(
+    input: TurnRegenerateInput,
+    context: ConnectionContext,
+  ): Promise<OperationOutcome<'turn.regenerate'>> {
+    if (input.sourceTurnId === input.turnId) {
+      return Promise.resolve(
+        operationConflict('Regenerate source and target Turn identities must differ'),
+      );
+    }
+    return this.startRootMessage(
+      {
+        sessionId: input.sessionId,
+        turnId: input.turnId,
+        execution: { kind: 'regenerate', sourceTurnId: input.sourceTurnId },
+        archivedMessage: 'Cannot regenerate a Turn in an archived Session',
+        prepareContent: async () =>
+          (await this.manager.prepareRegenerateTurn(input.sessionId, input.sourceTurnId)).content,
+      },
+      context,
+    );
+  }
+
+  private startRootMessage(
+    request: RootMessageStartRequest,
+    context: ConnectionContext,
+  ): Promise<TurnStartOutcome> {
+    return this.runCommand(async () => {
+      await this.awaitTerminalRootCleanup(request.sessionId);
+      const activeAtEntry = this.#activeBySession.has(request.sessionId);
+      let reservation = activeAtEntry ? undefined : this.reserveRootTurn(request.sessionId);
       if (!activeAtEntry && !reservation) {
         return sessionBusy('Session already has a pending root Turn');
       }
-      const admissionTask = this.sessionAdmission.run(input.sessionId, async (lease) => {
+      const admissionTask = this.sessionAdmission.run(request.sessionId, async (lease) => {
         const existing = await this.stores.agentRunStore.readRootTurnAdmission(
-          input.sessionId,
-          input.turnId,
+          request.sessionId,
+          request.turnId,
         );
         if (existing) {
           this.rootAdmissionOwner.assertKnownAdmission(existing);
-          if (existing.execution.kind !== 'external_message') {
+          if (existing.execution.kind !== request.execution.kind) {
             return completedStart(
               operationConflict('Turn identity belongs to a different execution kind'),
             );
           }
-          if (
-            !messageContentsEqual(
-              requireAdmissionMessageContent(existing),
-              canonicalInput.content,
-            ) ||
-            !isDeepStrictEqual(existing.turnOrchestration, canonicalInput.turnOrchestration) ||
-            existing.sourceMessages.length !== 0
-          ) {
+          const content =
+            'content' in request ? request.content : requireAdmissionMessageContent(existing);
+          if (!rootMessageAdmissionMatches(existing, request, content)) {
             return completedStart(
               operationConflict('Turn identity was already admitted with a different payload'),
             );
           }
-          const existingRun = await this.readRunIfPresent(input.sessionId, existing.runId);
+          const existingRun = await this.readRunIfPresent(request.sessionId, existing.runId);
           if (existingRun) {
             const snapshot = await this.readCanonicalSnapshot(
-              input.sessionId,
-              input.turnId,
+              request.sessionId,
+              request.turnId,
               existing.runId,
               existingRun,
             );
@@ -1423,7 +1615,7 @@ export class RootTurnCoordinator {
             }
           }
           return this.prepareAdmittedTurn(
-            canonicalInput,
+            activationInputForAdmission(existing),
             existing,
             context.acquireResidency,
             lease,
@@ -1433,14 +1625,13 @@ export class RootTurnCoordinator {
           );
         }
 
-        reservation ??= this.reserveRootTurn(input.sessionId);
+        reservation ??= this.reserveRootTurn(request.sessionId);
         if (!reservation) {
           return completedStart(sessionBusy('Session already has an active or pending root Turn'));
         }
-
         let header: SessionHeader;
         try {
-          header = await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
+          header = await this.stores.sessionStore.readHeaderSnapshot(request.sessionId);
         } catch (error) {
           if (isSessionNotFoundError(error)) {
             return completedStart(notFound('Session does not exist'));
@@ -1448,66 +1639,62 @@ export class RootTurnCoordinator {
           throw error;
         }
         if (header.status === 'archived' || header.isArchived) {
-          return completedStart(sessionArchived('Cannot start a new Turn in an archived Session'));
+          return completedStart(sessionArchived(request.archivedMessage));
         }
         const unavailableReason = runtimeHostExternalTurnUnavailableReason(header);
-        if (unavailableReason) {
-          return completedStart(operationUnavailable(unavailableReason));
-        }
-
-        if (this.#activeBySession.has(input.sessionId)) {
+        if (unavailableReason) return completedStart(operationUnavailable(unavailableReason));
+        if (this.#activeBySession.has(request.sessionId)) {
           return completedStart(sessionBusy('Session already has an active root Turn'));
         }
-        if (reservation && this.#reservationsBySession.get(input.sessionId) !== reservation) {
+        if (this.#reservationsBySession.get(request.sessionId) !== reservation) {
           return completedStart(sessionBusy('Root Turn reservation is no longer current'));
         }
 
+        if (
+          request.execution.kind === 'regenerate' &&
+          (await this.manager.listTurns(request.sessionId)).some(
+            (turn) => turn.turnId === request.turnId,
+          )
+        ) {
+          return completedStart(operationConflict('Turn identity already exists'));
+        }
+
+        const prepared = await this.prepareRootMessageContent(request);
+        if (prepared.kind === 'rejected') return completedStart(prepared.outcome);
         const binding = await this.clientCapabilities?.bindSession(
-          input.sessionId,
+          request.sessionId,
           context.connectionId,
         );
         if (binding && !binding.ok) {
           return completedStart(operationConflict(binding.message));
         }
-        if (!reservation || !this.beginRootAdmission(reservation)) {
+        if (!this.beginRootAdmission(reservation)) {
           return completedStart(sessionBusy('Root Turn reservation is no longer current'));
         }
-        const admission = await this.rootAdmissionOwner.admitRootTurn({
-          sessionId: input.sessionId,
-          turnId: input.turnId,
+        const admitted = await this.rootAdmissionOwner.admitRootTurn({
+          sessionId: request.sessionId,
+          turnId: request.turnId,
           proposedRunId: randomUUID(),
           proposedUserMessageId: randomUUID(),
-          execution: { kind: 'external_message' },
-          normalizedInput: canonicalInput.content,
-          ...(canonicalInput.turnOrchestration
-            ? { turnOrchestration: canonicalInput.turnOrchestration }
-            : {}),
+          execution: request.execution,
+          normalizedInput: prepared.content,
+          ...(request.turnOrchestration ? { turnOrchestration: request.turnOrchestration } : {}),
           sourceMessages: [],
           admittedAt: Date.now(),
         });
-        if (admission.admission.execution.kind !== 'external_message') {
+        if (admitted.admission.execution.kind !== request.execution.kind) {
           return completedStart(
             operationConflict('Turn identity belongs to a different execution kind'),
           );
         }
-        if (
-          !messageContentsEqual(
-            requireAdmissionMessageContent(admission.admission),
-            canonicalInput.content,
-          ) ||
-          !isDeepStrictEqual(
-            admission.admission.turnOrchestration,
-            canonicalInput.turnOrchestration,
-          ) ||
-          admission.admission.sourceMessages.length !== 0
-        ) {
+        if (!rootMessageAdmissionMatches(admitted.admission, request, prepared.content)) {
           return completedStart(
             operationConflict('Turn identity was already admitted with a different payload'),
           );
         }
         return this.prepareAdmittedTurn(
-          canonicalInput,
-          admission.admission,
+          activationInputForAdmission(admitted.admission),
+          admitted.admission,
           context.acquireResidency,
           lease,
           undefined,
@@ -1518,8 +1705,38 @@ export class RootTurnCoordinator {
       const disposition = await admissionTask.finally(() => {
         if (reservation) this.releaseRootReservation(reservation);
       });
-      return this.resolveStartDisposition(canonicalInput, disposition);
+      return this.resolveStartDisposition(request, disposition);
     });
+  }
+
+  private async awaitTerminalRootCleanup(sessionId: string): Promise<void> {
+    const active = this.#activeBySession.get(sessionId);
+    if (!active) return;
+    let snapshot: TurnSnapshot;
+    try {
+      snapshot = await this.readCanonicalSnapshot(sessionId, active.turnId, active.runId);
+    } catch {
+      return;
+    }
+    if (isTerminalSnapshot(snapshot)) await active.done;
+  }
+
+  private async prepareRootMessageContent(
+    request: RootMessageStartRequest,
+  ): Promise<RootMessageContentPreparation> {
+    if ('content' in request) return { kind: 'ready', content: request.content };
+    try {
+      return { kind: 'ready', content: normalizeMessageContent(await request.prepareContent()) };
+    } catch (error) {
+      if (error instanceof RuntimeRegenerateTurnError) {
+        return {
+          kind: 'rejected',
+          outcome:
+            error.code === 'not_found' ? notFound(error.message) : operationConflict(error.message),
+        };
+      }
+      throw error;
+    }
   }
 
   private async queryTurnResume(
@@ -2104,7 +2321,7 @@ export class RootTurnCoordinator {
     const startSettled = deferred();
     const goalOutcome = valueDeferred<GoalTurnOutcome>();
     const goalRegistration =
-      admission.execution.kind !== 'goal'
+      admission.execution.kind !== 'goal' && admission.execution.kind !== 'context_compact'
         ? this.resolveGoal().beginObservedTurn(input.sessionId, input.turnId)
         : undefined;
     const entry: ActiveRootTurn = {
@@ -2189,39 +2406,58 @@ export class RootTurnCoordinator {
         await this.continuity.refreshCanonical(input.sessionId);
         startSettled.resolve();
       };
-      const stream = active.continuation
-        ? this.manager.resumeSafeBoundaryContinuation(active.continuation, {
-            onRunStarted,
-          })
-        : active.execution
-          ? active.execution.start({
-              runId: active.runId,
-              userMessageId: active.userMessageId,
-              onRunStarted: async () => {
-                await onRunStarted();
-                await active.execution?.onReady?.();
+      const stream =
+        active.descriptor.kind === 'context_compact'
+          ? this.manager.compactSession(input.sessionId, {
+              turnId: input.turnId,
+              hostedRoot: {
+                runId: active.runId,
+                onRunStarted,
               },
             })
-          : this.manager.sendMessage(
-              input.sessionId,
-              {
-                turnId: input.turnId,
-                ...normalizeMessageContent(requireRootMessageContent(input)),
-                ...(input.turnOrchestration ? { turnOrchestration: input.turnOrchestration } : {}),
-                ...(messageOrigin ? { origin: messageOrigin } : {}),
-              },
-              {
-                runId: active.runId,
-                userMessageId: active.userMessageId ?? undefined,
-                durability: 'required',
-                onRunStarted: async (startedRunId) => {
-                  if (startedRunId !== active.runId) {
-                    throw new Error('Runtime started a different Run than the admitted identity');
-                  }
-                  await onRunStarted();
-                },
-              },
-            );
+          : active.continuation
+            ? this.manager.resumeSafeBoundaryContinuation(active.continuation, {
+                onRunStarted,
+              })
+            : active.execution
+              ? active.execution.start({
+                  runId: active.runId,
+                  userMessageId: active.userMessageId,
+                  onRunStarted: async () => {
+                    await onRunStarted();
+                    await active.execution?.onReady?.();
+                  },
+                })
+              : this.manager.sendMessage(
+                  input.sessionId,
+                  {
+                    turnId: input.turnId,
+                    ...normalizeMessageContent(requireRootMessageContent(input)),
+                    ...(active.descriptor.kind === 'regenerate'
+                      ? {
+                          parentTurnId: active.descriptor.sourceTurnId,
+                          regeneratedFromTurnId: active.descriptor.sourceTurnId,
+                        }
+                      : {}),
+                    ...(input.turnOrchestration
+                      ? { turnOrchestration: input.turnOrchestration }
+                      : {}),
+                    ...(messageOrigin ? { origin: messageOrigin } : {}),
+                  },
+                  {
+                    runId: active.runId,
+                    userMessageId: active.userMessageId ?? undefined,
+                    durability: 'required',
+                    onRunStarted: async (startedRunId) => {
+                      if (startedRunId !== active.runId) {
+                        throw new Error(
+                          'Runtime started a different Run than the admitted identity',
+                        );
+                      }
+                      await onRunStarted();
+                    },
+                  },
+                );
       for await (const event of stream) {
         if (active.execution?.onEvent) {
           try {
@@ -2604,6 +2840,19 @@ function requireAdmissionMessageContent(admission: RootTurnAdmission): MessageCo
   return admission.normalizedInput;
 }
 
+function rootMessageAdmissionMatches(
+  admission: RootTurnAdmission,
+  request: RootMessageStartRequest,
+  content: MessageContent,
+): boolean {
+  return (
+    isDeepStrictEqual(admission.execution, request.execution) &&
+    messageContentsEqual(requireAdmissionMessageContent(admission), content) &&
+    isDeepStrictEqual(admission.turnOrchestration, request.turnOrchestration) &&
+    admission.sourceMessages.length === 0
+  );
+}
+
 function recoveryUserMessage(admission: RootTurnAdmission): RecoveryUserMessage {
   if (!admission.userMessageId || !admission.normalizedInput) {
     throw new Error(`Admitted Turn ${admission.turnId} does not own a UserMessage`);
@@ -2632,6 +2881,8 @@ function assertRunMatchesExecution(
   switch (execution.kind) {
     case 'external_message':
       return;
+    case 'regenerate':
+    case 'context_compact':
     case 'automation':
     case 'goal':
     case 'agent_graph_supervisor_wake':
@@ -2671,6 +2922,8 @@ function assertTrustedAgentIdentity(
     {
       kind:
         | 'external_message'
+        | 'regenerate'
+        | 'context_compact'
         | 'automation'
         | 'goal'
         | 'agent_graph_supervisor_wake'
@@ -2699,6 +2952,18 @@ function recoveryExecutionContract(
       return {
         allowsQueueSources: true,
         requiresUserMessage: true,
+        pendingWithoutRun: 'root_replay',
+      };
+    case 'regenerate':
+      return {
+        allowsQueueSources: false,
+        requiresUserMessage: true,
+        pendingWithoutRun: 'root_replay',
+      };
+    case 'context_compact':
+      return {
+        allowsQueueSources: false,
+        requiresUserMessage: false,
         pendingWithoutRun: 'root_replay',
       };
     case 'automation':

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -39,6 +39,7 @@ import {
   type SessionCatalogRevision,
   type SessionConfigurationUpdateInput,
   type SessionCreateInput,
+  type SessionCwdRelocateInput,
   type SessionMetadataUpdateInput,
   type SessionModelTarget,
   type SessionReadMarkerSetInput,
@@ -65,7 +66,10 @@ type SessionRuntimePolicyStores = {
   readonly operations: Pick<RuntimePolicyStoresWriter['operations'], 'resolveExecutionConnection'>;
 };
 
-type SessionConfigurationAuthority = Pick<SessionManager, 'transitionSessionConfiguration'>;
+type SessionConfigurationAuthority = Pick<
+  SessionManager,
+  'transitionSessionConfiguration' | 'relocateSessionWorkspace'
+>;
 type SessionContinuity = Pick<SessionContinuityCoordinator, 'refreshCanonical'>;
 
 type SessionOperationFailureCode =
@@ -105,6 +109,7 @@ export class HostSessionCatalogCoordinator {
     'session.create': (input) => this.#create(input),
     'session.metadata.update': (input) => this.#updateMetadata(input),
     'session.configuration.update': (input) => this.#updateConfiguration(input),
+    'session.cwd.relocate': (input) => this.#relocateCwd(input),
     'session.read_marker.set': (input) => this.#setReadMarker(input),
   };
 
@@ -356,6 +361,55 @@ export class HostSessionCatalogCoordinator {
           input,
           error,
           'Session configuration update outcome is unknown',
+        );
+      }
+    });
+  }
+
+  async #relocateCwd(
+    input: SessionCwdRelocateInput,
+  ): Promise<OperationOutcome<'session.cwd.relocate'>> {
+    let cwd: string;
+    try {
+      if (!isAbsolute(input.cwd)) {
+        throw new SessionOperationFailure('invalid_request', 'Session cwd must be absolute');
+      }
+      cwd = await canonicalSessionDirectory(input.cwd);
+    } catch (error) {
+      return cwdFailure(
+        error instanceof SessionOperationFailure ? error.code : 'invalid_request',
+        error instanceof Error ? error.message : 'Session cwd is invalid',
+      );
+    }
+    return this.#admission.run(input.sessionId, async (lease) => {
+      let commitAttempted = false;
+      try {
+        const current = await this.#stores.readHeaderRecordSnapshot(input.sessionId);
+        if (current.revision !== input.expectedRevision) {
+          return cwdSuccess(revisionConflict(input.expectedRevision, current.revision));
+        }
+        commitAttempted = true;
+        await this.#manager.relocateSessionWorkspace(input.sessionId, {
+          expectedRevision: input.expectedRevision,
+          cwd,
+        });
+        return cwdSuccess(await this.#committedUpdate(input.sessionId, lease));
+      } catch (error) {
+        if (isNotFound(error)) return cwdFailure('not_found', 'Session does not exist');
+        if (error instanceof SessionConfigurationRevisionConflictError) {
+          return cwdSuccess(revisionConflict(input.expectedRevision, error.actualRevision));
+        }
+        if (error instanceof SessionConfigurationTransitionError) {
+          return cwdFailure(error.code, error.message);
+        }
+        if (!commitAttempted) {
+          this.#requestDrain();
+          return cwdFailure('persistence_failed', 'Session workspace authority is unavailable');
+        }
+        this.#requestDrain();
+        return cwdFailure(
+          'commit_outcome_unknown',
+          'Session workspace relocation outcome is unknown',
         );
       }
     });
@@ -943,6 +997,10 @@ function configurationSuccess(
   return { ok: true, result };
 }
 
+function cwdSuccess(result: SessionUpdateResult): OperationOutcome<'session.cwd.relocate'> {
+  return { ok: true, result };
+}
+
 function createFailure(
   code: OperationError<'session.create'>['code'],
   message: string,
@@ -968,6 +1026,13 @@ function configurationFailure(
   code: OperationError<'session.configuration.update'>['code'],
   message: string,
 ): Extract<OperationOutcome<'session.configuration.update'>, { readonly ok: false }> {
+  return { ok: false, error: { code, message } };
+}
+
+function cwdFailure(
+  code: OperationError<'session.cwd.relocate'>['code'],
+  message: string,
+): Extract<OperationOutcome<'session.cwd.relocate'>, { readonly ok: false }> {
   return { ok: false, error: { code, message } };
 }
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -57,6 +57,7 @@ import { z } from 'zod';
 import { AiSdkBackend } from '../ai-sdk-backend.js';
 import {
   BackendRegistry,
+  SessionConfigurationRevisionConflictError,
   SessionConfigurationTransitionError,
   SessionManager,
   headerToSummary,
@@ -65,7 +66,11 @@ import {
   type SessionStore,
   type VersionedSessionHeader,
 } from '../session-manager.js';
-import { RuntimeKernel, type RuntimeKernelLike } from '../runtime-kernel.js';
+import {
+  RuntimeContextCompactError,
+  RuntimeKernel,
+  type RuntimeKernelLike,
+} from '../runtime-kernel.js';
 import { FAKE_ASK_USER_QUESTION_PROMPT, FakeBackend } from '../fake-backend.js';
 import { RuntimeReadModel, RuntimeReadModelError } from '../runtime-read-model.js';
 import type { AgentBackend } from '@maka/core/backend-types';
@@ -3843,7 +3848,7 @@ describe('SessionManager automatic titles', () => {
   });
 });
 
-describe('SessionManager manual compaction', () => {
+describe('SessionManager manual compaction and quiescent session changes', () => {
   test('runs backend history compaction as a runtime turn and persists diagnostics', async () => {
     const store = new MemorySessionStore();
     const runStore = new OrderingAgentRunStore();
@@ -4337,8 +4342,8 @@ describe('SessionManager manual compaction', () => {
     const compactError = await collectSessionEvents(
       manager.compactSession(session.id, { turnId: 'turn-compact' }),
     ).catch((error: unknown) => error);
-    expect(compactError instanceof Error).toBe(true);
-    expect(String((compactError as Error).message)).toMatch(/turn is running|wait for the turn/);
+    expect(compactError instanceof RuntimeContextCompactError).toBe(true);
+    expect((compactError as RuntimeContextCompactError).code).toBe('session_busy');
 
     expect(compactCalls).toEqual([]);
     const messages = await store.readMessages(session.id);
@@ -4447,6 +4452,71 @@ describe('SessionManager manual compaction', () => {
       },
     );
     assert.deepEqual(kernel.disposed, [session.id]);
+  });
+
+  test('workspace relocation uses the same quiescent revision fence as execution configuration', async () => {
+    const store = new VersionedConfigurationMemorySessionStore();
+    const kernel = new DelegatingRuntimeKernel();
+    const resourceCalls: string[] = [];
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      newId: nextId(),
+      now: nextNow(26_425),
+      runtimeKernel: kernel,
+      shellRuns: {
+        async terminateSession(sessionId: string) {
+          resourceCalls.push(`terminate:${sessionId}`);
+          return { sessionId, token: Symbol('relocate') };
+        },
+        async commitSessionClose() {
+          resourceCalls.push('commit');
+        },
+        rollbackSessionClose() {
+          resourceCalls.push('rollback');
+        },
+        resumeSession(sessionId: string) {
+          resourceCalls.push(`resume:${sessionId}`);
+        },
+      } as never,
+    });
+    const session = await manager.createSession(makeInput({ cwd: '/workspace/old' }));
+
+    kernel.activeRuns = true;
+    await assert.rejects(
+      manager.relocateSessionWorkspace(session.id, {
+        expectedRevision: 1,
+        cwd: '/workspace/new',
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof SessionConfigurationTransitionError);
+        assert.equal(error.code, 'session_busy');
+        return true;
+      },
+    );
+
+    kernel.activeRuns = false;
+    const committed = await manager.relocateSessionWorkspace(session.id, {
+      expectedRevision: 1,
+      cwd: '/workspace/new',
+    });
+    assert.equal(committed.revision, 2);
+    assert.equal(committed.header.cwd, '/workspace/new');
+    assert.deepEqual(kernel.disposed, [session.id]);
+    assert.deepEqual(resourceCalls, [`terminate:${session.id}`, 'commit', `resume:${session.id}`]);
+
+    await assert.rejects(
+      manager.relocateSessionWorkspace(session.id, {
+        expectedRevision: 1,
+        cwd: '/workspace/stale',
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof SessionConfigurationRevisionConflictError);
+        assert.equal(error.actualRevision, 2);
+        return true;
+      },
+    );
+    assert.equal((await store.readHeader(session.id)).cwd, '/workspace/new');
   });
 
   test('configuration transitions reject a claimed turn without waiting for it to settle', async () => {
@@ -19414,6 +19484,8 @@ class DelegatingRuntimeKernel implements RuntimeKernelLike {
     }
   }
 
+  async preflightContextCompaction(): Promise<void> {}
+
   async stopSession(sessionId: string): Promise<void> {
     this.stopped.push(sessionId);
   }
@@ -21370,6 +21442,20 @@ class VersionedConfigurationMemorySessionStore extends MemorySessionStore {
           }
         : {}),
     });
+    this.revisions.set(sessionId, revision + 1);
+    return { header, revision: revision + 1, committedAt: revision + 1 };
+  }
+
+  async updateHeaderVersioned(
+    sessionId: string,
+    patch: Partial<SessionHeader>,
+    expectedRevision: number,
+  ): Promise<VersionedSessionHeader> {
+    const revision = this.revisions.get(sessionId) ?? 1;
+    if (revision !== expectedRevision) {
+      throw new SessionConfigurationRevisionConflictError(expectedRevision, revision);
+    }
+    const header = await super.updateHeader(sessionId, patch);
     this.revisions.set(sessionId, revision + 1);
     return { header, revision: revision + 1, committedAt: revision + 1 };
   }

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -114,6 +114,7 @@ export interface AgentRunInput {
   sessionId: string;
   header: SessionHeader;
   userInput: UserMessageInput;
+  rootExecutionKind?: AgentRunHeader['rootExecutionKind'];
   runId?: string;
   userMessageId?: string;
   durability?: AgentRunDurability;
@@ -1085,6 +1086,7 @@ export class AgentRun {
             agentGraphWakeAttemptId: this.input.userInput.origin.attemptId,
           }
         : {}),
+      ...(this.input.rootExecutionKind ? { rootExecutionKind: this.input.rootExecutionKind } : {}),
     };
     const header =
       continuation && this.input.claimedRunHeader ? this.input.claimedRunHeader : computedHeader;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,9 +10,11 @@ export {
   BackendRegistry,
   SessionConfigurationRevisionConflictError,
   SessionConfigurationTransitionError,
+  RuntimeRegenerateTurnError,
   headerToSummary,
   changesBackendConfig,
 } from './session-manager.js';
+export { RuntimeContextCompactError } from './runtime-kernel.js';
 export type { ModelMessage, JSONValue } from './model-protocol.js';
 export type {
   CompactSessionInput,
@@ -22,6 +24,7 @@ export type {
   SessionConfigurationStoreUpdate,
   SessionConfigurationTransitionRequest,
   SessionConfigurationTransitionErrorCode,
+  RegenerateTurnSource,
   SessionStore,
   StrictRecoveryAgentRunStore,
   StrictRecoverySessionStore,

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -133,6 +133,7 @@ export interface RuntimeKernelLike {
     options?: ResumeContinuationOptions,
   ): AsyncIterable<SessionEvent>;
   compactSession(sessionId: string, input?: CompactSessionInput): AsyncIterable<SessionEvent>;
+  preflightContextCompaction(sessionId: string): Promise<void>;
   startChildTurn(
     sessionId: string,
     input: ChildAgentTurnInput,
@@ -180,6 +181,17 @@ export class SessionQuiescentMutationBusyError extends Error {
 
   constructor(readonly sessionIds: readonly string[]) {
     super('Session mutation cannot start while an execution claim is active');
+  }
+}
+
+export class RuntimeContextCompactError extends Error {
+  readonly name = 'RuntimeContextCompactError';
+
+  constructor(
+    readonly code: 'operation_unavailable' | 'session_busy',
+    message: string,
+  ) {
+    super(message);
   }
 }
 
@@ -933,6 +945,23 @@ export class RuntimeKernel implements RuntimeKernelLike {
     }
   }
 
+  async preflightContextCompaction(sessionId: string): Promise<void> {
+    const execution = this.takeExecutionClaim(sessionId);
+    try {
+      await this.enterExecutionClaim(execution);
+      if (this.hasActiveRuns(sessionId)) {
+        throw new RuntimeContextCompactError(
+          'session_busy',
+          'Cannot compact while a Turn is running',
+        );
+      }
+      const header = await this.deps.store.readHeader(sessionId);
+      await this.requireContextCompactionBackend(sessionId, header, execution);
+    } finally {
+      this.releaseExecutionClaim(execution);
+    }
+  }
+
   private async *compactSessionClaimed(
     sessionId: string,
     input: CompactSessionInput,
@@ -946,10 +975,16 @@ export class RuntimeKernel implements RuntimeKernelLike {
       throw new Error('Runtime compaction minRecentTurns must be a non-negative safe integer');
     }
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {
-      throw new Error('Runtime compaction requires AgentRunStore and RuntimeEventStore');
+      throw new RuntimeContextCompactError(
+        'operation_unavailable',
+        'Runtime compaction requires execution stores',
+      );
     }
     if (this.hasActiveRuns(sessionId)) {
-      throw new Error('Cannot compact while a turn is running; wait for the turn to finish.');
+      throw new RuntimeContextCompactError(
+        'session_busy',
+        'Cannot compact while a Turn is running',
+      );
     }
 
     const header = await this.deps.store.readHeader(sessionId);
@@ -958,6 +993,8 @@ export class RuntimeKernel implements RuntimeKernelLike {
       sessionId,
       header,
       userInput: { turnId, text: '' },
+      rootExecutionKind: 'context_compact',
+      ...(input.hostedRoot ? { runId: input.hostedRoot.runId } : {}),
       store: this.deps.store,
       runStore: this.deps.runStore,
       runtimeEventStore: this.deps.runtimeEventStore,
@@ -989,22 +1026,29 @@ export class RuntimeKernel implements RuntimeKernelLike {
     });
 
     this.attachExecutionClaim(execution, run);
+    const owners = this.createRunOwnerScope(run, execution);
     let begin: Awaited<ReturnType<typeof run.beginOperation>>;
     try {
+      if (input.hostedRoot) {
+        owners.bindMessage(this.deps.messageAuthority, {
+          sessionId,
+          turnId,
+          runId: run.runId,
+        });
+      }
       begin = await this.runBackendActivation(() => run.beginOperation());
+      await input.hostedRoot?.onRunStarted?.();
       this.settleReservedExecutionClaim(execution, run, { ok: true });
     } catch (error) {
-      this.settleReservedExecutionClaim(execution, run, { ok: false, error });
-      await run.recordFailure(error);
-      await this.finalizeExecutionClaimRun(execution, run, () => run.finalize());
-      if (run.isStopped() && isExecutionCancellation(error, execution.cancellation)) return;
-      throw error;
+      await this.finalizeFailedRunStart(owners, run, execution, error);
+      return;
     }
 
     try {
       if (run.isStopped()) return;
-      if (!begin.backend.compactHistory)
-        throw new Error(`Backend ${header.backend} does not support runtime compaction`);
+      if (!begin.backend.compactHistory) {
+        throw new Error(`Backend ${header.backend} changed runtime compaction capability`);
+      }
       this.assertRunCanDispatch(run, begin.backend);
       const result = await begin.backend.compactHistory({
         turnId: run.turnId,
@@ -1066,8 +1110,28 @@ export class RuntimeKernel implements RuntimeKernelLike {
       await run.recordFailure(error);
       throw error;
     } finally {
-      await this.finalizeExecutionClaimRun(execution, run, () => run.finalize());
+      const failures = new FailureCollector();
+      await failures.capture(() => owners.finalize());
+      await failures.capture(() => owners.releaseMessage());
+      failures.throwIfAny(`Runtime compaction cleanup failed for ${run.runId}`);
     }
+  }
+
+  private async requireContextCompactionBackend(
+    sessionId: string,
+    header: SessionHeader,
+    execution: PendingExecutionClaim,
+  ): Promise<BackendGeneration> {
+    const active = await this.runBackendActivation(() =>
+      this.ensureActive(sessionId, header, execution),
+    );
+    if (!active.backend.compactHistory) {
+      throw new RuntimeContextCompactError(
+        'operation_unavailable',
+        `Backend ${header.backend} does not support runtime compaction`,
+      );
+    }
+    return active;
   }
 
   async *startChildTurn(

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -23,8 +23,9 @@ import type {
   PermissionRequestEvent,
   QueueEnqueueOutcome,
   ShellRunUpdate,
+  MessageContent,
 } from '@maka/core/events';
-import { messageContentsEqual } from '@maka/core/events';
+import { messageContentsEqual, normalizeMessageContent } from '@maka/core/events';
 import type {
   SessionHeader,
   SessionBlockedReason,
@@ -229,8 +230,7 @@ export interface StopSessionInput {
   mode?: BackendStopMode;
 }
 
-export interface CompactSessionInput {
-  turnId?: string;
+interface CompactSessionOptions {
   /**
    * Override the configured recent-turn tail. Supervisor overflow recovery
    * uses zero because the failed wake turn itself can contain the oversized
@@ -238,6 +238,19 @@ export interface CompactSessionInput {
    */
   minRecentTurns?: number;
 }
+
+export type CompactSessionInput =
+  | (CompactSessionOptions & {
+      turnId?: string;
+      hostedRoot?: never;
+    })
+  | (CompactSessionOptions & {
+      turnId: string;
+      hostedRoot: {
+        runId: string;
+        onRunStarted?: () => void | Promise<void>;
+      };
+    });
 
 export type PlanSafeBoundaryContinuationInput = Omit<RuntimeContinuationPlannerInput, 'sessionId'>;
 
@@ -573,6 +586,22 @@ export class SessionConfigurationRevisionConflictError extends Error {
   }
 }
 
+export class RuntimeRegenerateTurnError extends Error {
+  readonly name = 'RuntimeRegenerateTurnError';
+
+  constructor(
+    readonly code: 'not_found' | 'operation_conflict',
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export interface RegenerateTurnSource {
+  readonly sourceTurnId: string;
+  readonly content: MessageContent;
+}
+
 export interface SessionStore {
   create(input: CreateSessionInput, initialBoundary?: ExecutionBoundary): Promise<SessionHeader>;
   createSubagent(
@@ -610,6 +639,11 @@ export interface SessionStore {
   appendMessage(sessionId: string, m: StoredMessage): Promise<void>;
   appendMessages(sessionId: string, ms: StoredMessage[]): Promise<void>;
   updateHeader(sessionId: string, patch: Partial<SessionHeader>): Promise<SessionHeader>;
+  updateHeaderVersioned?(
+    sessionId: string,
+    patch: Partial<SessionHeader>,
+    expectedRevision: number,
+  ): Promise<VersionedSessionHeader>;
   readHeaderRecordSnapshot?(sessionId: string): Promise<VersionedSessionHeader>;
   updateSessionConfiguration?(
     sessionId: string,
@@ -1095,6 +1129,75 @@ export class SessionManager {
           });
       },
     );
+    this.runtimeKernel.updateCachedHeader(sessionId, next.header);
+    return next;
+  }
+
+  async relocateSessionWorkspace(
+    sessionId: string,
+    input: { readonly expectedRevision: number; readonly cwd: string },
+  ): Promise<VersionedSessionHeader> {
+    const updateHeaderVersioned = this.deps.store.updateHeaderVersioned?.bind(this.deps.store);
+    const readHeaderRecordSnapshot = this.deps.store.readHeaderRecordSnapshot?.bind(
+      this.deps.store,
+    );
+    if (!updateHeaderVersioned || !readHeaderRecordSnapshot) {
+      throw new SessionConfigurationTransitionError(
+        'operation_unavailable',
+        'Session workspace relocation authority is unavailable',
+      );
+    }
+    const next = await this.runSessionQuiescentMutation([sessionId], async () => {
+      if (this.runtimeKernel.hasActiveRuns(sessionId)) {
+        throw new SessionConfigurationTransitionError(
+          'session_busy',
+          'Session workspace cannot change while a Turn is active',
+        );
+      }
+      const current = await readHeaderRecordSnapshot(sessionId);
+      if (current.revision !== input.expectedRevision) {
+        throw new SessionConfigurationRevisionConflictError(
+          input.expectedRevision,
+          current.revision,
+        );
+      }
+      if (current.header.isArchived || current.header.status === 'archived') {
+        throw new SessionConfigurationTransitionError(
+          'operation_conflict',
+          'Archived Session workspace cannot be relocated',
+        );
+      }
+      if (current.header.subagentWorkspace || current.header.subagentParent) {
+        throw new SessionConfigurationTransitionError(
+          'operation_unavailable',
+          'Managed child Session workspaces cannot be relocated',
+        );
+      }
+      if (current.header.status === 'waiting_for_user') {
+        throw new SessionConfigurationTransitionError(
+          'session_busy',
+          'Session has a pending Interaction',
+        );
+      }
+      if (current.header.cwd === input.cwd) return current;
+
+      const shellRunClose = await this.deps.shellRuns?.terminateSession(sessionId);
+      let committed: VersionedSessionHeader;
+      try {
+        await this.runtimeKernel.disposeBackend(sessionId);
+        committed = await updateHeaderVersioned(
+          sessionId,
+          { cwd: input.cwd },
+          input.expectedRevision,
+        );
+      } catch (error) {
+        if (shellRunClose) this.deps.shellRuns?.rollbackSessionClose(shellRunClose);
+        throw error;
+      }
+      if (shellRunClose) await this.deps.shellRuns?.commitSessionClose(shellRunClose);
+      this.deps.shellRuns?.resumeSession(sessionId);
+      return committed;
+    });
     this.runtimeKernel.updateCachedHeader(sessionId, next.header);
     return next;
   }
@@ -2128,6 +2231,10 @@ export class SessionManager {
     input: CompactSessionInput = {},
   ): AsyncIterable<SessionEvent> {
     yield* this.runtimeKernel.compactSession(sessionId, input);
+  }
+
+  async preflightContextCompaction(sessionId: string): Promise<void> {
+    await this.runtimeKernel.preflightContextCompaction(sessionId);
   }
 
   async *startChildTurn(
@@ -4414,7 +4521,11 @@ export class SessionManager {
     admittedAt: number;
     execution: Exclude<
       RootExecutionDescriptor,
-      { kind: 'external_message' } | { kind: 'automation' } | { kind: 'safe_boundary_continuation' }
+      | { kind: 'external_message' }
+      | { kind: 'regenerate' }
+      | { kind: 'context_compact' }
+      | { kind: 'automation' }
+      | { kind: 'safe_boundary_continuation' }
     >;
   }): Promise<void> {
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {
@@ -4646,33 +4757,58 @@ export class SessionManager {
   ): AsyncIterable<SessionEvent> {
     const execution = this.runtimeKernel.claimExecution(sessionId);
     try {
-      // retry semantics merged into regenerate (#546): regenerate now accepts
-      // failed/aborted turns too, not just completed — one action re-runs the
-      // turn regardless of how the previous attempt ended.
-      const source = await this.requireTurnForAction(
-        sessionId,
-        input.sourceTurnId,
-        ['failed', 'aborted', 'completed'],
-        'regenerate',
-      );
-      const user = await this.requireUserMessageForTurn(sessionId, source.turnId);
+      const source = await this.prepareRegenerateTurn(sessionId, input.sourceTurnId);
       yield* this.sendMessage(
         sessionId,
         {
           turnId: input.turnId ?? this.deps.newId(),
-          text: user.text,
-          ...(user.displayText !== undefined ? { displayText: user.displayText } : {}),
-          ...(user.attachments ? { attachments: user.attachments } : {}),
-          ...(user.quotes ? { quotes: user.quotes } : {}),
-          ...(user.inlineReferences ? { inlineReferences: user.inlineReferences } : {}),
-          parentTurnId: source.turnId,
-          regeneratedFromTurnId: source.turnId,
+          ...source.content,
+          parentTurnId: source.sourceTurnId,
+          regeneratedFromTurnId: source.sourceTurnId,
         },
         { execution },
       );
     } finally {
       execution.release();
     }
+  }
+
+  async prepareRegenerateTurn(
+    sessionId: string,
+    sourceTurnId: string,
+  ): Promise<RegenerateTurnSource> {
+    const view = await this.getSessionView(sessionId);
+    const source = view.turns.find((candidate) => candidate.turnId === sourceTurnId);
+    if (!source) {
+      throw new RuntimeRegenerateTurnError(
+        'not_found',
+        `Cannot regenerate unknown Turn ${sourceTurnId}`,
+      );
+    }
+    if (
+      source.status !== 'failed' &&
+      source.status !== 'aborted' &&
+      source.status !== 'completed'
+    ) {
+      throw new RuntimeRegenerateTurnError(
+        'operation_conflict',
+        `Cannot regenerate Turn ${sourceTurnId} while it is ${source.status}`,
+      );
+    }
+    const user = view.messages.find(
+      (message): message is UserMessage =>
+        message.type === 'user' && message.turnId === sourceTurnId,
+    );
+    if (!user) {
+      throw new RuntimeRegenerateTurnError(
+        'operation_conflict',
+        `Turn ${sourceTurnId} has no UserMessage`,
+      );
+    }
+    return {
+      sourceTurnId,
+      content: normalizeMessageContent(user),
+    };
   }
 
   async branchFromTurn(sessionId: string, input: BranchFromTurnInput): Promise<SessionSummary> {
@@ -5123,14 +5259,6 @@ export class SessionManager {
       throw new Error(`Cannot ${action}: turn ${turnId} is ${turn.status}`);
     }
     return turn;
-  }
-
-  private async requireUserMessageForTurn(sessionId: string, turnId: string): Promise<UserMessage> {
-    const user = (await this.getSessionView(sessionId)).messages.find(
-      (message): message is UserMessage => message.type === 'user' && message.turnId === turnId,
-    );
-    if (!user) throw new Error(`Turn ${turnId} has no user message`);
-    return user;
   }
 
   private async getSessionView(

--- a/packages/storage/src/__tests__/claimed-agent-graph-root-admission.test.ts
+++ b/packages/storage/src/__tests__/claimed-agent-graph-root-admission.test.ts
@@ -144,7 +144,7 @@ describe('claimed agent graph root admission', () => {
               proposedUserMessageId: null,
             }),
           ),
-        /only linked child provider retry omits UserMessage/,
+        /execution has an invalid UserMessage requirement/,
       );
       await assert.rejects(
         access(join(root, 'sessions', 'session-child', 'turn-admissions', 'turn-next.json')),

--- a/packages/storage/src/__tests__/regenerate-root-admission.test.ts
+++ b/packages/storage/src/__tests__/regenerate-root-admission.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { RootExecutionDescriptor } from '@maka/core/agent-run';
+import { createSqliteAgentRunStore, type AdmitRootTurnInput } from '../agent-run-store.js';
+
+test('regenerate admission durably binds the immutable source Turn', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-regenerate-admission-'));
+  try {
+    const store = createSqliteAgentRunStore(root);
+    const input = admissionInput();
+    const admitted = await store.admitRootTurn(input);
+    assert.equal(admitted.kind, 'admitted');
+    assert.deepEqual(admitted.admission.execution, {
+      kind: 'regenerate',
+      sourceTurnId: 'source-turn',
+    });
+    store.close?.();
+
+    const reopened = createSqliteAgentRunStore(root);
+    assert.deepEqual(
+      await reopened.readRootTurnAdmission(input.sessionId, input.turnId),
+      admitted.admission,
+    );
+    await assert.rejects(
+      () =>
+        reopened.admitRootTurn(
+          admissionInput({
+            execution: {
+              kind: 'regenerate',
+              sourceTurnId: ' source-turn ',
+            } as RootExecutionDescriptor,
+          }),
+        ),
+      /Invalid root execution descriptor/,
+    );
+    await assert.rejects(
+      () =>
+        reopened.admitRootTurn(
+          admissionInput({
+            execution: { kind: 'regenerate', sourceTurnId: 'regenerated-turn' },
+          }),
+        ),
+      /regenerate source Turn cannot be the admitted Turn/,
+    );
+
+    const compact = await reopened.admitRootTurn({
+      sessionId: input.sessionId,
+      turnId: 'compact-turn',
+      proposedRunId: 'compact-run',
+      proposedUserMessageId: null,
+      execution: { kind: 'context_compact' },
+      previousRootTurnId: input.turnId,
+      normalizedInput: null,
+      sourceMessages: [],
+      admittedAt: 60,
+    });
+    assert.equal(compact.kind, 'admitted');
+    assert.deepEqual(compact.admission.execution, { kind: 'context_compact' });
+    reopened.close?.();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function admissionInput(overrides: Partial<AdmitRootTurnInput> = {}): AdmitRootTurnInput {
+  return {
+    sessionId: 'root-session',
+    turnId: 'regenerated-turn',
+    proposedRunId: 'regenerated-run',
+    proposedUserMessageId: 'regenerated-message',
+    execution: { kind: 'regenerate', sourceTurnId: 'source-turn' },
+    previousRootTurnId: null,
+    normalizedInput: { text: 'Original request' },
+    sourceMessages: [],
+    admittedAt: 50,
+    ...overrides,
+  };
+}

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1233,7 +1233,9 @@ function assertRootTurnAdmissionSerializedSize(serialized: string): void {
 function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
   const execution = admission.execution;
   const providerRetry = execution.kind === 'linked_child_provider_retry';
-  const safeBoundaryContinuation = execution.kind === 'safe_boundary_continuation';
+  const inputlessExecution =
+    execution.kind === 'safe_boundary_continuation' || execution.kind === 'context_compact';
+  const messageLessExecution = inputlessExecution || providerRetry;
   if (execution.kind === 'agent_graph_supervisor_wake') {
     if (
       admission.turnOrchestration?.mode !== 'graph' ||
@@ -1248,17 +1250,12 @@ function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
       'Invalid root turn admission contract: orchestration override is not authorized for this execution',
     );
   }
-  if (safeBoundaryContinuation && admission.userMessageId !== null) {
+  if ((admission.userMessageId === null) !== messageLessExecution) {
     throw new Error(
-      'Invalid root turn admission contract: safe-boundary continuation omits UserMessage',
+      'Invalid root turn admission contract: execution has an invalid UserMessage requirement',
     );
   }
-  if (!safeBoundaryContinuation && (admission.userMessageId === null) !== providerRetry) {
-    throw new Error(
-      'Invalid root turn admission contract: only linked child provider retry omits UserMessage',
-    );
-  }
-  if ((admission.normalizedInput === null) !== safeBoundaryContinuation) {
+  if ((admission.normalizedInput === null) !== inputlessExecution) {
     throw new Error(
       'Invalid root turn admission contract: execution has an invalid input requirement',
     );
@@ -1302,6 +1299,11 @@ function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
   ) {
     throw new Error(
       'Invalid root turn admission contract: safe-boundary continuation identity is invalid',
+    );
+  }
+  if (execution.kind === 'regenerate' && execution.sourceTurnId === admission.turnId) {
+    throw new Error(
+      'Invalid root turn admission contract: regenerate source Turn cannot be the admitted Turn',
     );
   }
   if (
@@ -1368,6 +1370,20 @@ function normalizeRootExecutionDescriptor(value: unknown): RootExecutionDescript
   if (value.kind === 'external_message') {
     if (!hasExactKeys(value, ['kind'])) throw new Error('Invalid root execution descriptor');
     return Object.freeze({ kind: 'external_message' });
+  }
+  if (value.kind === 'regenerate') {
+    if (
+      !hasExactKeys(value, ['kind', 'sourceTurnId']) ||
+      typeof value.sourceTurnId !== 'string' ||
+      !isSafeId(value.sourceTurnId)
+    ) {
+      throw new Error('Invalid root execution descriptor');
+    }
+    return Object.freeze({ kind: 'regenerate', sourceTurnId: value.sourceTurnId });
+  }
+  if (value.kind === 'context_compact') {
+    if (!hasExactKeys(value, ['kind'])) throw new Error('Invalid root execution descriptor');
+    return Object.freeze({ kind: 'context_compact' });
   }
   if (value.kind === 'automation') {
     if (


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Add the v0 `turn.regenerate`, `context.diagnostics.query`, `context.compact`, and `session.cwd.relocate` Runtime Host operations with matching Client wrappers.
- Make regeneration replay the immutable source content and lineage through one durable Root Turn identity, including exact retry and startup recovery.
- Run manual context compaction as an explicit Host-owned root with durable admission, positive Run identity, query/stop/retry/recovery support, and honest backend capability preflight.
- Route workspace relocation through Runtime's revision and quiescence authority, including same-path requests, so active runs, archived Sessions, and managed child resources remain fenced.

## Why

Interactive Clients need authoritative Session actions without bypassing Runtime lifecycle, recovery, or multi-Client coordination. These operations reuse the existing Root Turn and Session mutation boundaries instead of introducing a parallel execution path.

## Validation

- `npm run build`
- `npm --workspace @maka/runtime-host run test:dist` — 604 passed
- Runtime and AiSdk compaction tests — 53 passed
- `npm --workspace @maka/core run test:dist` — 752 passed
- Focused Storage admission tests
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

Part of #1167. Runtime Host roadmap context: #853.

</details>

<details>
<summary>中文</summary>

## 概要

- 新增 v0 `turn.regenerate`、`context.diagnostics.query`、`context.compact` 与 `session.cwd.relocate` Runtime Host 操作，并提供对应的 Client 封装。
- 让重新生成通过单一持久 Root Turn 身份重放不可变的源内容与 lineage，并支持精确重试和启动恢复。
- 将手动上下文压缩作为显式的 Host-owned root 执行，具备持久 admission、正向 Run 身份、查询、停止、重试、恢复与真实的 backend 能力预检。
- 让工作目录迁移统一经过 Runtime 的 revision 与 quiescence authority；即使路径未变化，也会正确约束 active run、已归档 Session 与受管 child resource。

## 原因

交互式 Client 需要权威的 Session 操作，同时不能绕过 Runtime 生命周期、恢复机制或多 Client 协调。这些操作复用现有 Root Turn 与 Session mutation 边界，不引入平行执行路径。

## 验证

- `npm run build`
- `npm --workspace @maka/runtime-host run test:dist` — 604 项通过
- Runtime 与 AiSdk compaction 测试 — 53 项通过
- `npm --workspace @maka/core run test:dist` — 752 项通过
- Storage admission 聚焦测试
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

属于 #1167 的一部分；Runtime Host 路线图背景见 #853。

</details>
