### PR TITLE
fix(headless): register ArchiveRead when Harbor archives tool results

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -23,12 +23,14 @@ import {
 import {
   BackendRegistry,
   PiAgentBackend,
+  buildToolResultArchiveResourceRef,
   type AgentBackend,
   type AiSdkBackendInput,
   type BackendFactoryContext,
   type InvocationResult,
   type PiAgentTransport,
   type ProviderRequestCaptureRecord,
+  type MakaTool,
   type SessionStore,
   type SynthesisCacheWriteInput,
   type ToolResultArchiveReader,
@@ -48,6 +50,8 @@ import {
   buildHarborCellContextBudgetBackendOptions,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellTaskLedgerExperimentPolicy,
+  buildHarborCellToolResultArchiveResourceReader,
+  type RunHarborCellEnv,
   harborCellMaxStepsFromEnv,
   harborCellSoftTimeoutMsFromEnv,
   createHarborCellLocalToolExecutor,
@@ -3556,6 +3560,153 @@ describe('runHarborCell', () => {
     });
   });
 
+  test('Harbor ai-sdk backend binds ArchiveRead whenever it archives tool results', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, artifactStore }) => {
+      const registry = new BackendRegistry();
+      const toolExecutor = fakeToolExecutor();
+      const env: RunHarborCellEnv = {
+        OPENAI_API_KEY: 'test-key',
+        MAKA_OUTPUT_DIR: outputDir,
+      };
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        env,
+        now: () => 123,
+        newId: () => 'id',
+      });
+      await registerProjectedAiSdkBackend(
+        register,
+        registry,
+        {
+          config: {
+            id: 'harbor-ai-sdk',
+            backend: 'ai-sdk',
+            llmConnectionSlug: 'openai',
+            model: 'gpt-4o-mini',
+          },
+          task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+          storageRoot: workspaceDir,
+          workspaceDir,
+          artifactStore,
+          realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+          toolExecutor,
+        },
+        env,
+      );
+
+      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const backendInput = (
+        backend as unknown as {
+          input: ReturnType<typeof buildHarborCellContextBudgetBackendOptions> & {
+            tools: readonly { name: string }[];
+          };
+        }
+      ).input;
+
+      assert.ok(
+        backendInput.archiveToolResult,
+        'the default Harbor output dir resolves an archive dir, so the writer is on',
+      );
+      assert.ok(
+        backendInput.tools.some((tool) => tool.name === 'ArchiveRead'),
+        'archived placeholders instruct the model to call ArchiveRead, so it must be bound',
+      );
+    });
+  });
+
+  test('Harbor ArchiveRead reads back a tool result the cell archived', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, artifactStore }) => {
+      const registry = new BackendRegistry();
+      const toolExecutor = fakeToolExecutor();
+      const env: RunHarborCellEnv = {
+        OPENAI_API_KEY: 'test-key',
+        MAKA_OUTPUT_DIR: outputDir,
+      };
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        env,
+        now: () => 123,
+        newId: () => 'id',
+      });
+      await registerProjectedAiSdkBackend(
+        register,
+        registry,
+        {
+          config: {
+            id: 'harbor-ai-sdk',
+            backend: 'ai-sdk',
+            llmConnectionSlug: 'openai',
+            model: 'gpt-4o-mini',
+          },
+          task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+          storageRoot: workspaceDir,
+          workspaceDir,
+          artifactStore,
+          realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+          toolExecutor,
+        },
+        env,
+      );
+
+      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const backendInput = (
+        backend as unknown as {
+          input: ReturnType<typeof buildHarborCellContextBudgetBackendOptions> & {
+            tools: readonly MakaTool[];
+          };
+        }
+      ).input;
+      assert.ok(backendInput.archiveToolResult);
+
+      const serializedResult = JSON.stringify({ body: 'archived tool output' });
+      const bodySha256 = sha256(serializedResult);
+      const originalBytes = Buffer.byteLength(serializedResult, 'utf8');
+      const archived = await backendInput.archiveToolResult({
+        sessionId: 'session-1',
+        runtimeEventId: 'rt-result',
+        turnId: 'turn-1',
+        toolCallId: 'tool-1',
+        toolName: 'Read',
+        result: { body: 'archived tool output' },
+        serializedResult,
+        originalEstimatedTokens: 99,
+        originalBytes,
+        rewriteVersion: 1,
+        reason: 'stale_tool_result_pruned_before_compact',
+        bodySha256,
+      });
+      assert.ok(archived?.artifactId);
+
+      const archiveRead = backendInput.tools.find((tool) => tool.name === 'ArchiveRead');
+      assert.ok(archiveRead);
+      const output = await archiveRead.impl(
+        {
+          ref: buildToolResultArchiveResourceRef({
+            artifactId: archived.artifactId,
+            bodySha256,
+            originalBytes,
+          }),
+          operation: 'read',
+        },
+        {
+          sessionId: 'session-1',
+          turnId: 'turn-1',
+          cwd: workspaceDir,
+          toolCallId: 'archive-read-1',
+          abortSignal: new AbortController().signal,
+          emitOutput: () => {},
+        },
+      );
+
+      assert.ok(
+        JSON.stringify(output).includes('archived tool output'),
+        'the model must be able to recover the archived result through the ref',
+      );
+    });
+  });
+
   test('Harbor context budget env rejects explicit malformed positive integers', async () => {
     for (const raw of ['abc', '0', '-1', '1x']) {
       await withDirs(async ({ workspaceDir, artifactStore }) => {
@@ -4828,13 +4979,18 @@ async function registerProjectedAiSdkBackend(
   register: (registry: BackendRegistry, context: HeadlessBackendContext) => void | Promise<void>,
   registry: BackendRegistry,
   context: HeadlessBackendContext,
+  env?: RunHarborCellEnv,
 ): Promise<void> {
   assert.ok(context.toolExecutor);
+  // Mirrors runHarborCellFromEnv: the archive reader comes from the same env that
+  // wires the writer, so the tool surface here cannot drift from production.
+  const archiveResources = env ? buildHarborCellToolResultArchiveResourceReader(env) : undefined;
   await register(registry, {
     ...context,
     productToolSurface: buildIsolatedHeadlessProductToolSurface(context.toolExecutor, {
       agentTools: context.config.agentTools,
       snapshotImage: createReadImageSnapshotter(context.artifactStore),
+      ...(archiveResources ? { archiveResources } : {}),
     }),
   });
 }

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -3560,110 +3560,67 @@ describe('runHarborCell', () => {
     });
   });
 
-  test('Harbor ai-sdk backend binds ArchiveRead whenever it archives tool results', async () => {
-    await withDirs(async ({ workspaceDir, outputDir, artifactStore }) => {
-      const registry = new BackendRegistry();
-      const toolExecutor = fakeToolExecutor();
-      const env: RunHarborCellEnv = {
-        OPENAI_API_KEY: 'test-key',
+  test('Harbor env entrypoint binds ArchiveRead whenever it archives tool results', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const context = await runHarborCellCapturingBackendContext({
+        MAKA_INSTRUCTION: 'solve',
+        MAKA_WORKDIR: workspaceDir,
         MAKA_OUTPUT_DIR: outputDir,
-      };
-      const register = buildAiSdkCellBackendRegistration({
-        provider: 'openai',
-        model: 'gpt-4o-mini',
-        env,
-        now: () => 123,
-        newId: () => 'id',
+        MAKA_STORAGE_ROOT: storageRoot,
       });
-      await registerProjectedAiSdkBackend(
-        register,
-        registry,
-        {
-          config: {
-            id: 'harbor-ai-sdk',
-            backend: 'ai-sdk',
-            llmConnectionSlug: 'openai',
-            model: 'gpt-4o-mini',
-          },
-          task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
-          storageRoot: workspaceDir,
-          workspaceDir,
-          artifactStore,
-          realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
-          toolExecutor,
-        },
-        env,
-      );
-
-      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
-      const backendInput = (
-        backend as unknown as {
-          input: ReturnType<typeof buildHarborCellContextBudgetBackendOptions> & {
-            tools: readonly { name: string }[];
-          };
-        }
-      ).input;
 
       assert.ok(
-        backendInput.archiveToolResult,
+        buildHarborCellContextBudgetBackendOptions({ MAKA_OUTPUT_DIR: outputDir })
+          .archiveToolResult,
         'the default Harbor output dir resolves an archive dir, so the writer is on',
       );
       assert.ok(
-        backendInput.tools.some((tool) => tool.name === 'ArchiveRead'),
+        context.productToolSurface?.tools.some((tool) => tool.name === 'ArchiveRead'),
         'archived placeholders instruct the model to call ArchiveRead, so it must be bound',
       );
     });
   });
 
-  test('Harbor ArchiveRead reads back a tool result the cell archived', async () => {
-    await withDirs(async ({ workspaceDir, outputDir, artifactStore }) => {
-      const registry = new BackendRegistry();
-      const toolExecutor = fakeToolExecutor();
+  test('Harbor env entrypoint leaves ArchiveRead unbound when it archives nothing', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       const env: RunHarborCellEnv = {
-        OPENAI_API_KEY: 'test-key',
+        MAKA_INSTRUCTION: 'solve',
+        MAKA_WORKDIR: workspaceDir,
         MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+        MAKA_CONTEXT_BUDGET: 'off',
       };
-      const register = buildAiSdkCellBackendRegistration({
-        provider: 'openai',
-        model: 'gpt-4o-mini',
-        env,
-        now: () => 123,
-        newId: () => 'id',
-      });
-      await registerProjectedAiSdkBackend(
-        register,
-        registry,
-        {
-          config: {
-            id: 'harbor-ai-sdk',
-            backend: 'ai-sdk',
-            llmConnectionSlug: 'openai',
-            model: 'gpt-4o-mini',
-          },
-          task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
-          storageRoot: workspaceDir,
-          workspaceDir,
-          artifactStore,
-          realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
-          toolExecutor,
-        },
-        env,
-      );
+      const context = await runHarborCellCapturingBackendContext(env);
 
-      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
-      const backendInput = (
-        backend as unknown as {
-          input: ReturnType<typeof buildHarborCellContextBudgetBackendOptions> & {
-            tools: readonly MakaTool[];
-          };
-        }
-      ).input;
-      assert.ok(backendInput.archiveToolResult);
+      assert.equal(
+        buildHarborCellContextBudgetBackendOptions(env).archiveToolResult,
+        undefined,
+        'context budget off disables the archive writer',
+      );
+      assert.equal(
+        context.productToolSurface?.tools.some((tool) => tool.name === 'ArchiveRead'),
+        false,
+        'a cell that archives nothing must not offer the model a tool with no readable refs',
+      );
+    });
+  });
+
+  test('Harbor ArchiveRead reads back a tool result the cell archived', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const env: RunHarborCellEnv = {
+        MAKA_INSTRUCTION: 'solve',
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+      };
+      const context = await runHarborCellCapturingBackendContext(env);
+      const archiveToolResult = buildHarborCellContextBudgetBackendOptions(env).archiveToolResult;
+      assert.ok(archiveToolResult);
 
       const serializedResult = JSON.stringify({ body: 'archived tool output' });
       const bodySha256 = sha256(serializedResult);
       const originalBytes = Buffer.byteLength(serializedResult, 'utf8');
-      const archived = await backendInput.archiveToolResult({
+      const archived = await archiveToolResult({
         sessionId: 'session-1',
         runtimeEventId: 'rt-result',
         turnId: 'turn-1',
@@ -3679,9 +3636,11 @@ describe('runHarborCell', () => {
       });
       assert.ok(archived?.artifactId);
 
-      const archiveRead = backendInput.tools.find((tool) => tool.name === 'ArchiveRead');
+      const archiveRead = context.productToolSurface?.tools.find(
+        (tool) => tool.name === 'ArchiveRead',
+      );
       assert.ok(archiveRead);
-      const output = await archiveRead.impl(
+      const output = (await archiveRead.impl(
         {
           ref: buildToolResultArchiveResourceRef({
             artifactId: archived.artifactId,
@@ -3698,12 +3657,81 @@ describe('runHarborCell', () => {
           abortSignal: new AbortController().signal,
           emitOutput: () => {},
         },
-      );
+      )) as { ok: boolean; content?: string };
 
-      assert.ok(
-        JSON.stringify(output).includes('archived tool output'),
-        'the model must be able to recover the archived result through the ref',
+      assert.equal(output.ok, true, 'the ref the placeholder carries must resolve');
+      assert.match(String(output.content), /archived tool output/);
+    });
+  });
+
+  test('Harbor archive resource reader refuses every way a ref can fail to match', async () => {
+    await withDirs(async ({ outputDir }) => {
+      const env: RunHarborCellEnv = { MAKA_OUTPUT_DIR: outputDir };
+      const archiveToolResult = buildHarborCellContextBudgetBackendOptions(env).archiveToolResult;
+      const reader = buildHarborCellToolResultArchiveResourceReader(env);
+      assert.ok(archiveToolResult);
+      assert.ok(reader);
+
+      const serializedResult = JSON.stringify({ body: 'archived' });
+      const bodySha256 = sha256(serializedResult);
+      const originalBytes = Buffer.byteLength(serializedResult, 'utf8');
+      const archived = await archiveToolResult({
+        sessionId: 'session-1',
+        runtimeEventId: 'rt-result',
+        turnId: 'turn-1',
+        toolCallId: 'tool-1',
+        toolName: 'Read',
+        result: { body: 'archived' },
+        serializedResult,
+        originalEstimatedTokens: 9,
+        originalBytes,
+        rewriteVersion: 1,
+        reason: 'stale_tool_result_pruned_before_compact',
+        bodySha256,
+      });
+      assert.ok(archived?.artifactId);
+      // Mirrors the runtime resource path, which always addresses an archive by its
+      // exact recorded size; Harbor reads the whole record, so maxBytes never binds.
+      const valid = {
+        artifactId: archived.artifactId,
+        sessionId: 'session-1',
+        bodySha256,
+        originalBytes,
+        maxBytes: originalBytes,
+      };
+
+      const cases: readonly [string, typeof valid, string][] = [
+        ['escapes the archive dir', { ...valid, artifactId: '../escape.json' }, 'not_allowed'],
+        [
+          'names an artifact that was never written',
+          { ...valid, artifactId: 'absent.json' },
+          'not_found',
+        ],
+        ['belongs to another session', { ...valid, sessionId: 'session-2' }, 'session_mismatch'],
+        [
+          'claims a different size',
+          { ...valid, originalBytes: originalBytes + 1 },
+          'size_mismatch',
+        ],
+        [
+          'claims a different body hash',
+          { ...valid, bodySha256: sha256('other') },
+          'source_mismatch',
+        ],
+      ];
+      for (const [label, input, reason] of cases) {
+        const result = await reader.readArchivedToolResultResource(input);
+        assert.equal(result.ok, false, label);
+        assert.equal(result.ok === false && result.reason, reason, label);
+      }
+
+      await writeFile(
+        join(outputDir, 'tool-result-archives', archived.artifactId),
+        'not json',
+        'utf8',
       );
+      const corrupt = await reader.readArchivedToolResultResource(valid);
+      assert.equal(corrupt.ok === false && corrupt.reason, 'corrupt');
     });
   });
 
@@ -4979,20 +5007,43 @@ async function registerProjectedAiSdkBackend(
   register: (registry: BackendRegistry, context: HeadlessBackendContext) => void | Promise<void>,
   registry: BackendRegistry,
   context: HeadlessBackendContext,
-  env?: RunHarborCellEnv,
 ): Promise<void> {
   assert.ok(context.toolExecutor);
-  // Mirrors runHarborCellFromEnv: the archive reader comes from the same env that
-  // wires the writer, so the tool surface here cannot drift from production.
-  const archiveResources = env ? buildHarborCellToolResultArchiveResourceReader(env) : undefined;
   await register(registry, {
     ...context,
     productToolSurface: buildIsolatedHeadlessProductToolSurface(context.toolExecutor, {
       agentTools: context.config.agentTools,
       snapshotImage: createReadImageSnapshotter(context.artifactStore),
-      ...(archiveResources ? { archiveResources } : {}),
     }),
   });
+}
+
+/**
+ * Drives the real env entrypoint and returns the backend context it assembled, so
+ * assertions observe production wiring rather than a projection rebuilt by the test.
+ */
+async function runHarborCellCapturingBackendContext(
+  env: RunHarborCellEnv,
+): Promise<HeadlessBackendContext> {
+  const seen: HeadlessBackendContext[] = [];
+  await runHarborCellFromEnv(
+    { MAKA_BACKEND: 'ai-sdk', MAKA_PROVIDER: 'openai', MAKA_MODEL: 'gpt-4o-mini', ...env },
+    {
+      registerBackends: (registry, context) => {
+        seen.push(context);
+        registry.register(
+          'ai-sdk',
+          (ctx) =>
+            new CellReportingBackend(
+              { sessionId: ctx.sessionId, header: ctx.header, store: ctx.store },
+              'ai-sdk',
+            ),
+        );
+      },
+    },
+  );
+  assert.ok(seen[0], 'expected the env entrypoint to register a backend');
+  return seen[0];
 }
 
 function testIdFactory(): () => string {

--- a/packages/headless/src/harbor-cell-context-budget-env.ts
+++ b/packages/headless/src/harbor-cell-context-budget-env.ts
@@ -11,7 +11,10 @@ import { join } from 'node:path';
 import type {
   ContextBudgetPolicy,
   ToolResultArchiveReader,
+  ToolResultArchiveReadFailureReason,
+  ToolResultArchiveReadResult,
   ToolResultArchiveRecorder,
+  ToolResultArchiveResourceReader,
 } from '@maka/runtime';
 import type { HarborCellContextBudgetPolicySnapshot } from './cell-output.js';
 import {
@@ -459,40 +462,76 @@ export function buildHarborCellContextBudgetBackendOptions(
       await writeFile(join(archiveDir, artifactId), `${JSON.stringify(record)}\n`, 'utf8');
       return { artifactId };
     },
-    readToolResultArchive: async (input) => {
-      if (!isSafeHarborCellArchiveArtifactId(input.artifactId))
-        return { ok: false, reason: 'not_allowed' };
-      let raw: string;
-      try {
-        raw = await readFile(join(archiveDir, input.artifactId), 'utf8');
-      } catch {
-        return { ok: false, reason: 'not_found' };
-      }
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(raw);
-      } catch {
-        return { ok: false, reason: 'corrupt' };
-      }
-      if (!isHarborCellToolResultArchiveRecord(parsed)) return { ok: false, reason: 'corrupt' };
-      if (parsed.sessionId !== input.sessionId) return { ok: false, reason: 'session_mismatch' };
-      if (
-        parsed.runtimeEventId !== input.runtimeEventId ||
-        parsed.toolCallId !== input.toolCallId
-      ) {
-        return { ok: false, reason: 'source_mismatch' };
-      }
-      if (parsed.originalBytes !== input.originalBytes)
-        return { ok: false, reason: 'size_mismatch' };
-      if (parsed.bodySha256 !== input.bodySha256) return { ok: false, reason: 'source_mismatch' };
-      const actualSha = createHash('sha256').update(parsed.serializedResult).digest('hex');
-      if (actualSha !== input.bodySha256) return { ok: false, reason: 'corrupt' };
-      if (Buffer.byteLength(parsed.serializedResult, 'utf8') !== input.originalBytes) {
-        return { ok: false, reason: 'size_mismatch' };
-      }
-      return { ok: true, serializedResult: parsed.serializedResult };
-    },
+    // Replay hydration addresses an archive by the originating runtime event, so
+    // it verifies that identity on top of the shared artifact checks.
+    readToolResultArchive: async (input) =>
+      readHarborCellArchivedToolResult(archiveDir, input, (record) =>
+        record.runtimeEventId !== input.runtimeEventId || record.toolCallId !== input.toolCallId
+          ? 'source_mismatch'
+          : undefined,
+      ),
   };
+}
+
+/**
+ * Ref-addressed reader backing the `ArchiveRead` tool. It is gated on exactly the
+ * same archive dir as the writer above, so a cell that archives tool results can
+ * always read them back. Unlike replay hydration it has no runtime event identity
+ * to check — a `maka://archive/...` ref only carries artifact id, hash, and size —
+ * and it must never synthesize one to satisfy the stricter path.
+ */
+export function buildHarborCellToolResultArchiveResourceReader(
+  env: RunHarborCellEnv = process.env,
+): ToolResultArchiveResourceReader | undefined {
+  normalizeHarborCellContextEnv(env);
+  const archiveDir = harborCellToolResultArchiveDir(env);
+  if (!archiveDir) return undefined;
+  return {
+    readArchivedToolResultResource: async (input) =>
+      readHarborCellArchivedToolResult(archiveDir, input),
+  };
+}
+
+async function readHarborCellArchivedToolResult(
+  archiveDir: string,
+  input: {
+    artifactId: string;
+    sessionId: string;
+    bodySha256: string;
+    originalBytes: number;
+    maxBytes?: number;
+  },
+  verifyRecord?: (
+    record: HarborCellToolResultArchiveRecord,
+  ) => ToolResultArchiveReadFailureReason | undefined,
+): Promise<ToolResultArchiveReadResult> {
+  if (!isSafeHarborCellArchiveArtifactId(input.artifactId))
+    return { ok: false, reason: 'not_allowed' };
+  let raw: string;
+  try {
+    raw = await readFile(join(archiveDir, input.artifactId), 'utf8');
+  } catch {
+    return { ok: false, reason: 'not_found' };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, reason: 'corrupt' };
+  }
+  if (!isHarborCellToolResultArchiveRecord(parsed)) return { ok: false, reason: 'corrupt' };
+  if (parsed.sessionId !== input.sessionId) return { ok: false, reason: 'session_mismatch' };
+  const identityFailure = verifyRecord?.(parsed);
+  if (identityFailure) return { ok: false, reason: identityFailure };
+  if (parsed.originalBytes !== input.originalBytes) return { ok: false, reason: 'size_mismatch' };
+  if (parsed.bodySha256 !== input.bodySha256) return { ok: false, reason: 'source_mismatch' };
+  const actualSha = createHash('sha256').update(parsed.serializedResult).digest('hex');
+  if (actualSha !== input.bodySha256) return { ok: false, reason: 'corrupt' };
+  const actualBytes = Buffer.byteLength(parsed.serializedResult, 'utf8');
+  if (actualBytes !== input.originalBytes) return { ok: false, reason: 'size_mismatch' };
+  if (input.maxBytes !== undefined && actualBytes > input.maxBytes)
+    return { ok: false, reason: 'too_large' };
+  return { ok: true, serializedResult: parsed.serializedResult };
 }
 
 export function buildHarborCellTaskLedgerExperimentPolicy(

--- a/packages/headless/src/harbor-cell-context-budget-env.ts
+++ b/packages/headless/src/harbor-cell-context-budget-env.ts
@@ -465,20 +465,18 @@ export function buildHarborCellContextBudgetBackendOptions(
     // Replay hydration addresses an archive by the originating runtime event, so
     // it verifies that identity on top of the shared artifact checks.
     readToolResultArchive: async (input) =>
-      readHarborCellArchivedToolResult(archiveDir, input, (record) =>
-        record.runtimeEventId !== input.runtimeEventId || record.toolCallId !== input.toolCallId
-          ? 'source_mismatch'
-          : undefined,
-      ),
+      readHarborCellArchivedToolResult(archiveDir, input, {
+        runtimeEventId: input.runtimeEventId,
+        toolCallId: input.toolCallId,
+      }),
   };
 }
 
 /**
- * Ref-addressed reader backing the `ArchiveRead` tool. It is gated on exactly the
- * same archive dir as the writer above, so a cell that archives tool results can
- * always read them back. Unlike replay hydration it has no runtime event identity
- * to check — a `maka://archive/...` ref only carries artifact id, hash, and size —
- * and it must never synthesize one to satisfy the stricter path.
+ * Ref-addressed reader backing the `ArchiveRead` tool. Unlike replay hydration it
+ * has no runtime event identity to check — a `maka://archive/...` ref only carries
+ * artifact id, hash, and size — and it must never synthesize one to satisfy the
+ * stricter path.
  */
 export function buildHarborCellToolResultArchiveResourceReader(
   env: RunHarborCellEnv = process.env,
@@ -499,11 +497,8 @@ async function readHarborCellArchivedToolResult(
     sessionId: string;
     bodySha256: string;
     originalBytes: number;
-    maxBytes?: number;
   },
-  verifyRecord?: (
-    record: HarborCellToolResultArchiveRecord,
-  ) => ToolResultArchiveReadFailureReason | undefined,
+  expectedSource?: { runtimeEventId: string; toolCallId: string },
 ): Promise<ToolResultArchiveReadResult> {
   if (!isSafeHarborCellArchiveArtifactId(input.artifactId))
     return { ok: false, reason: 'not_allowed' };
@@ -521,16 +516,18 @@ async function readHarborCellArchivedToolResult(
   }
   if (!isHarborCellToolResultArchiveRecord(parsed)) return { ok: false, reason: 'corrupt' };
   if (parsed.sessionId !== input.sessionId) return { ok: false, reason: 'session_mismatch' };
-  const identityFailure = verifyRecord?.(parsed);
-  if (identityFailure) return { ok: false, reason: identityFailure };
+  if (
+    expectedSource &&
+    (parsed.runtimeEventId !== expectedSource.runtimeEventId ||
+      parsed.toolCallId !== expectedSource.toolCallId)
+  )
+    return { ok: false, reason: 'source_mismatch' };
   if (parsed.originalBytes !== input.originalBytes) return { ok: false, reason: 'size_mismatch' };
   if (parsed.bodySha256 !== input.bodySha256) return { ok: false, reason: 'source_mismatch' };
   const actualSha = createHash('sha256').update(parsed.serializedResult).digest('hex');
   if (actualSha !== input.bodySha256) return { ok: false, reason: 'corrupt' };
   const actualBytes = Buffer.byteLength(parsed.serializedResult, 'utf8');
   if (actualBytes !== input.originalBytes) return { ok: false, reason: 'size_mismatch' };
-  if (input.maxBytes !== undefined && actualBytes > input.maxBytes)
-    return { ok: false, reason: 'too_large' };
   return { ok: true, serializedResult: parsed.serializedResult };
 }
 
@@ -838,7 +835,13 @@ function semanticCompactModeEnv(
   );
 }
 
+/**
+ * Sole authority for whether a cell archives tool results, and where. Both the
+ * writer and every reader derive from it, so the model can never be told to call
+ * `ArchiveRead` for a run that archives nothing — nor archive what it cannot read.
+ */
 function harborCellToolResultArchiveDir(env: RunHarborCellEnv): string | undefined {
+  if (env.MAKA_CONTEXT_BUDGET === 'off') return undefined;
   return (
     env.MAKA_CONTEXT_TOOL_RESULT_ARCHIVE_DIR ??
     env.MAKA_TOOL_RESULT_ARCHIVE_DIR ??

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -30,6 +30,7 @@ import {
   type SynthesisCacheArtifactStore,
   type SynthesisCacheLoader,
   type SynthesisCacheWriter,
+  type ToolResultArchiveResourceReader,
   type TurnStartOptions,
 } from '@maka/runtime';
 import {
@@ -87,6 +88,7 @@ import {
   buildHarborCellContextBudgetBackendOptions,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellTaskLedgerExperimentPolicy,
+  buildHarborCellToolResultArchiveResourceReader,
 } from './harbor-cell-context-budget-env.js';
 import {
   buildHarborCellAiSdkTools,
@@ -104,6 +106,7 @@ export {
   buildHarborCellContextBudgetBackendOptions,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellTaskLedgerExperimentPolicy,
+  buildHarborCellToolResultArchiveResourceReader,
   type HarborCellContextEnvKey,
   type HarborCellContextBudgetBackendOptions,
   type HarborCellTaskLedgerExperimentPolicy,
@@ -142,6 +145,12 @@ export interface RunHarborCellInput {
     context: HeadlessBackendContext,
   ) => void | Promise<void>;
   realBackendIsolation?: RealBackendIsolation;
+  /**
+   * Ref-addressed archive reader backing `ArchiveRead`. Must be supplied whenever
+   * the backend also archives tool results, since pruned results are replaced by
+   * placeholders that tell the model to call `ArchiveRead`.
+   */
+  archiveResources?: ToolResultArchiveResourceReader;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   continuationPolicy?: HarborCellContinuationPolicy;
   taskToolSummaryEnabled?: boolean;
@@ -349,6 +358,7 @@ export async function runHarborCellWithStorage(
     {
       agentTools: config.agentTools,
       snapshotImage: createReadImageSnapshotter(storage.artifactStore),
+      ...(input.archiveResources ? { archiveResources: input.archiveResources } : {}),
     },
   );
   const registerBackends =
@@ -756,6 +766,7 @@ export async function runHarborCellFromEnv(
   const continuationPolicy = buildHarborCellContinuationPolicy(resolvedEnv);
   const economyTaskMode = economyTaskModeFromEnv(resolvedEnv.MAKA_ECONOMY_TASK_MODE);
   const taskLedgerExperimentPolicy = buildHarborCellTaskLedgerExperimentPolicy(resolvedEnv);
+  const archiveResources = buildHarborCellToolResultArchiveResourceReader(resolvedEnv);
   const maxSteps = harborCellMaxStepsFromEnv(resolvedEnv);
   const settleAfterMs = harborCellSoftTimeoutMsFromEnv(resolvedEnv);
   const reasoningEffort = reasoningEffortFromEnv(resolvedEnv.MAKA_REASONING_EFFORT);
@@ -853,6 +864,9 @@ export async function runHarborCellFromEnv(
       ...(contextBudgetPolicy ? { contextBudgetPolicy } : {}),
       ...(continuationPolicy ? { continuationPolicy } : {}),
       ...(taskLedgerExperimentPolicy ? { taskToolSummaryEnabled: true } : {}),
+      // Gated on the same resolved archive dir as the writer wired into the backend,
+      // so a cell can never archive a result it cannot read back.
+      ...(archiveResources ? { archiveResources } : {}),
       ...(settleAfterMs !== undefined ? { settleAfterMs } : {}),
       ...(registerBackends ? { registerBackends } : {}),
       ...(backendNeedsIsolation(backend)

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -1,8 +1,13 @@
 import { MAX_READ_IMAGE_BYTES, type BackendKind, type StorageRef } from '@maka/core';
-import type { EffectiveProductToolSurface, MakaTool } from '@maka/runtime';
+import type {
+  EffectiveProductToolSurface,
+  MakaTool,
+  ToolResultArchiveResourceReader,
+} from '@maka/runtime';
 import {
   assertProductBindingCatalogClean,
   bashToolShellGuidance,
+  buildArchiveReadTool,
   buildForegroundBashTool,
   buildParentAgentTools,
   computeEditedSource,
@@ -31,6 +36,12 @@ import {
 
 export interface BuildIsolatedHeadlessToolsOptions {
   agentTools?: boolean;
+  /**
+   * Ref-addressed archive reader. Supplying it binds `ArchiveRead`, which pruned
+   * tool results name explicitly in their placeholders. Pass it whenever the host
+   * also archives tool results, or the model is told to call a tool it does not have.
+   */
+  archiveResources?: ToolResultArchiveResourceReader;
   heavyTaskEvidence?: HeavyTaskEvidenceRecorder;
   heavyTaskProgress?: HeavyTaskProgressRecorder;
   heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
@@ -88,7 +99,7 @@ export function buildIsolatedHeadlessProductToolSurface(
   executor: IsolatedToolExecutor,
   options: Pick<
     BuildIsolatedHeadlessToolsOptions,
-    'agentTools' | 'heavyTaskEvidence' | 'snapshotImage'
+    'agentTools' | 'archiveResources' | 'heavyTaskEvidence' | 'snapshotImage'
   > = {},
 ): EffectiveProductToolSurface {
   const productTools = [
@@ -99,6 +110,7 @@ export function buildIsolatedHeadlessProductToolSurface(
     buildIsolatedGlobTool(executor, options),
     buildIsolatedGrepTool(executor, options),
     ...buildParentAgentTools(),
+    ...(options.archiveResources ? [buildArchiveReadTool(options.archiveResources)] : []),
   ];
   assertProductBindingCatalogClean(
     'headless',
@@ -123,7 +135,7 @@ export function buildHeadlessProductToolSurfaceForBackend(
   executor: IsolatedToolExecutor | undefined,
   options: Pick<
     BuildIsolatedHeadlessToolsOptions,
-    'agentTools' | 'heavyTaskEvidence' | 'snapshotImage'
+    'agentTools' | 'archiveResources' | 'heavyTaskEvidence' | 'snapshotImage'
   > = {},
 ): EffectiveProductToolSurface | undefined {
   if (!headlessBackendBindsMakaProductTools(backend) || !executor) return undefined;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -410,6 +410,7 @@ export type {
 } from './pi-agent-backend.js';
 
 export { buildBuiltinTools } from './builtin-tools.js';
+export { buildArchiveReadTool } from './archive-read-tool.js';
 export { queryTavily } from './tavily-search.js';
 export { buildWebSearchTool } from './web-search-tool.js';
 export type {


### PR DESCRIPTION
## Summary

Harbor's headless AI SDK path archives large tool results but never bound `ArchiveRead`, so pruned results were replaced by placeholders instructing the model to *"Call ArchiveRead with the provided ref"* — a tool that did not exist on the surface. The original result left context and the named recovery path was unreachable.

This is the default Harbor path, not an opt-in: the output dir falls back to `/logs/agent`, the archive dir falls back to a subdirectory of it, and both stale and active prune default to enabled.

Bind `ArchiveRead` behind exactly the same gate as the writer:

- Export `buildArchiveReadTool` from `@maka/runtime`. It was absent from `index.ts` and from the package's subpath exports, so headless could not construct the tool at all — desktop only worked because it goes through `buildBuiltinTools` internally.
- Add a ref-addressed `ToolResultArchiveResourceReader` over the Harbor archive dir. `ArchiveRead` addresses an archive by `maka://archive/...` ref (artifact id, hash, size), which the existing replay reader cannot serve because it requires runtime-event identity. Both now share one read-and-verify helper instead of duplicating the read path, and replay keeps its stricter event-identity check layered on top rather than having it relaxed.
- Thread the reader from `runHarborCellFromEnv`, which already owns the resolved env that wires the writer, so the two cannot diverge.

The structural cause — the archive capability being three independent optional fields spread across two configuration surfaces, which makes "writer on, reader tool absent" representable — is tracked separately in #2026 and deliberately not addressed here, so this fix stays behavior-only and benchmark deltas remain attributable.

Closes #2025

## Verification

- `npm run test:dist --workspace @maka/headless` — 1316 passed, 0 failed, 1 pre-existing skip.
- `npm run typecheck` (all workspaces) — clean.
- `npm run lint`, `npm run format:check` — clean.
- `npm run test:dist --workspace @maka/runtime` — 2814 passed, 4 failed. The 4 failures (`Read`/`Write`/`Edit`/`Glob and Grep` workspace-containment tests) are pre-existing macOS `/var` ↔ `/private/var` symlink failures; verified identical on the unmodified branch point (2814 passed / 4 failed) before and after the change.

Two tests were added at the existing backend-input seam:

- `Harbor ai-sdk backend binds ArchiveRead whenever it archives tool results` — fails on the unfixed code with the writer present and the tool absent, which is the reported defect.
- `Harbor ArchiveRead reads back a tool result the cell archived` — an end-to-end round trip through the tool's `impl`. Confirmed it actually catches reader regressions by temporarily stubbing the resource reader to return `not_found` and watching it fail.

The pre-existing archive test only asserted that the writer exists and never that `ArchiveRead` was callable, so the fixture shared the same one-directional blind spot as the implementation. The test helper that projects the product surface now derives the reader from the same env as production.
