### PR TITLE
fix(scripts): drop session-bundle imports deleted with the JSONL session tree

### DIFF
--- a/scripts/measure-session-bundle.mjs
+++ b/scripts/measure-session-bundle.mjs
@@ -21,12 +21,7 @@ import { createInterface } from 'node:readline';
 import { Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import {
-  SESSION_BUNDLE_PORTABLE_SESSION_DIRECTORIES,
-  SESSION_BUNDLE_PORTABLE_SESSION_FILES,
-  SESSION_BUNDLE_STATE_ENTRIES,
-  isArtifactPathForSession,
-} from '@maka/storage';
+import { SESSION_BUNDLE_STATE_ENTRIES, isArtifactPathForSession } from '@maka/storage';
 import { STORAGE_ROOT_MARKER_FILE } from '@maka/storage/root-authority';
 import {
   constants as zlibConstants,
@@ -57,8 +52,6 @@ const SUPPORTED_OPTIONS = new Set([
 // must be regenerated when a session export is materialized elsewhere.
 const STORAGE_ROOT_AUTHORITY_MARKER = STORAGE_ROOT_MARKER_FILE;
 const PORTABLE_STATE_TOP_LEVEL = new Set(SESSION_BUNDLE_STATE_ENTRIES);
-const PORTABLE_SESSION_DIRECTORIES = new Set(SESSION_BUNDLE_PORTABLE_SESSION_DIRECTORIES);
-const PORTABLE_SESSION_FILES = new Set(SESSION_BUNDLE_PORTABLE_SESSION_FILES);
 const MAX_JSON_BYTES = 1_048_576;
 const EXCLUDED_WORKSPACE_SEGMENTS = new Set(['.git', 'node_modules']);
 const SENSITIVE_WORKSPACE_FILE_PATTERNS = [
@@ -405,24 +398,6 @@ async function validateStateExportEntries(sourceRoot, entries, sessionId) {
     if (!PORTABLE_STATE_TOP_LEVEL.has(topLevel)) {
       throw new Error(
         `session export contains protected or unclassified state entry: ${entry.path}`,
-      );
-    }
-    if (topLevel === 'sessions') {
-      const sessionPrefix = `sessions/${sessionId}/`;
-      if (entry.path === `sessions/${sessionId}/session.jsonl`) continue;
-      if (!entry.path.startsWith(sessionPrefix)) {
-        throw new Error(`session export contains unfiltered session entry: ${entry.path}`);
-      }
-      const relativePath = entry.path.slice(sessionPrefix.length);
-      const firstSegment = relativePath.split('/')[0];
-      if (
-        (relativePath.includes('/') && PORTABLE_SESSION_DIRECTORIES.has(firstSegment)) ||
-        PORTABLE_SESSION_FILES.has(relativePath)
-      ) {
-        continue;
-      }
-      throw new Error(
-        `session export contains protected or unclassified session entry: ${entry.path}`,
       );
     }
     if (topLevel === 'runtime.sqlite') {


### PR DESCRIPTION
## Summary

`scripts/measure-session-bundle.mjs` fails to load on `main`, taking the whole extended script suite down with it:

```
SyntaxError: The requested module '@maka/storage' does not provide an export
named 'SESSION_BUNDLE_PORTABLE_SESSION_DIRECTORIES'
```

#1994 made SQLite the sole operational authority and removed the JSONL session tree along with the two constants that classified it — `SESSION_BUNDLE_PORTABLE_SESSION_DIRECTORIES` and `SESSION_BUNDLE_PORTABLE_SESSION_FILES` — but the script kept importing them.

Drop the two imports and the `topLevel === 'sessions'` branch they fed. That branch was already unreachable: `sessions` is no longer in `SESSION_BUNDLE_STATE_ENTRIES`, so the top-level portability check rejects such an entry before it can be reached. Net effect is 26 deleted lines and one rewritten import.

### Known remaining gap

This restores module loading, not the harness's runtime correctness. `findSessionId` still requires `sessions/<id>/session.jsonl`, which no export has produced since #1994, so an actual measurement run would fail on its own. Deciding whether to port the harness to the operational database or retire it needs a storage-bundle judgement call, so it is tracked separately rather than guessed at here.

## Verification

- `node --test scripts/measure-session-bundle.test.mjs` — 2 passed, 0 failed (fails to even load on `main`).
- `npm run test:scripts:extended` — 15 passed, 0 failed.
- `npm run lint`, `npm run format:check` — clean.

## Why main is green with this broken

`main`'s CI never reaches the script. In the latest `main` run, `test_workspaces` succeeds with the step itself skipped:

```
skipped  Run fast script tests
skipped  Run extended script tests
success  Run affected standard workspace tests
```

`ci.yml` selects surfaces from a two-dot diff between `pull_request.base.sha` and `pull_request.head.sha`. A push to `main` diffs only that merge, so `scriptMode` stays `none` and the extended step never runs — regardless of the script being broken.

It surfaced on #2028 only because that branch was five commits behind `main`, so the two-dot diff also carried the inverse of those commits, including the root `package.json` change from `a7d17e5bd`. `package.json` is in `FULL_SUITE_FILES` (`scripts/ci-test-plan.mjs:11`), which forces `scriptMode: 'full'` and runs the extended scripts. Rebasing #2028 onto current `main` turns it green again without touching this bug.

Confirmed independently by running the test on a clean detached `origin/main` checkout, where it fails identically. So the breakage is real on `main` and merely invisible to `main`'s own CI path.
