### PR TITLE
feat(runtime-host): own input and artifact preparation

### DIFF
--- a/apps/desktop/src/main/tool-result-archive-artifacts.ts
+++ b/apps/desktop/src/main/tool-result-archive-artifacts.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import type { ArtifactStore } from '@maka/storage';
 import {
+  stableToolResultArchiveArtifactId,
   type ToolResultArchiveReaderInput,
   type ToolResultArchiveReadResult,
   type ToolResultArchiveRecorderInput,
@@ -70,20 +71,6 @@ async function readArchivedToolResultArtifact(
   if (!read.ok) return read;
   if (sha256(read.text) !== event.bodySha256) return { ok: false, reason: 'corrupt' };
   return { ok: true, serializedResult: read.text };
-}
-
-export function stableToolResultArchiveArtifactId(event: Pick<
-  ToolResultArchiveRecorderInput,
-  'sessionId' | 'runtimeEventId' | 'toolCallId' | 'toolName' | 'bodySha256' | 'rewriteVersion'
->): string {
-  return `tool-result-archive-${sha256(JSON.stringify({
-    sessionId: event.sessionId,
-    runtimeEventId: event.runtimeEventId,
-    toolCallId: event.toolCallId,
-    toolName: event.toolName,
-    bodySha256: event.bodySha256,
-    rewriteVersion: event.rewriteVersion,
-  })).slice(0, 32)}`;
 }
 
 function sha256(text: string): string {

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -49,7 +49,7 @@ export type AgentRunContinuationSource =
   | AgentRunContinuationSourceV2;
 
 export type RootExecutionDescriptor =
-  | { kind: 'external_message' }
+  | { kind: 'external_message'; inputDigest?: `sha256:${string}` }
   | { kind: 'regenerate'; sourceTurnId: string }
   | { kind: 'context_compact' }
   | { kind: 'automation'; automationId: string }

--- a/packages/runtime-host/src/__tests__/artifact-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/artifact-coordinator.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -16,6 +17,233 @@ const connectionContext: ConnectionContext = {
   principal: 'local_os_user',
   acquireResidency: () => ({ release: () => undefined }),
 };
+
+test('Artifact ingest is connection-bound, replay-safe, and commits one durable AttachmentRef', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-artifact-ingest-'));
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  try {
+    const store = await openInteractiveArtifactStoreForWrite(owner.lease);
+    await store.recover();
+    let now = 0;
+    const coordinator = new HostArtifactCoordinator(
+      store,
+      () => assert.fail('successful ingest must not request Host drain'),
+      new SessionAdmissionGate(),
+      { probeSessionRemoval: async () => ({ kind: 'present' }) },
+      () => now,
+    );
+    const bytes = Buffer.from('host-owned attachment bytes');
+    const begin = {
+      kind: 'begin' as const,
+      sessionId: 'session-1',
+      uploadId: 'upload-1',
+      name: 'dir/fixture.txt',
+      mimeType: 'text/plain',
+      totalBytes: bytes.byteLength,
+      contentSha256: digest(bytes),
+    };
+    assert.deepEqual(await coordinator.handlers['artifact.ingest'](begin, connectionContext), {
+      ok: true,
+      result: { kind: 'upload_opened', uploadId: 'upload-1', nextOffset: 0 },
+    });
+    const first = bytes.subarray(0, 8);
+    const firstChunk = {
+      kind: 'chunk' as const,
+      sessionId: 'session-1',
+      uploadId: 'upload-1',
+      offset: 0,
+      chunkBase64: first.toString('base64'),
+    };
+    const firstAccepted = {
+      ok: true as const,
+      result: { kind: 'chunk_accepted' as const, uploadId: 'upload-1', nextOffset: first.length },
+    };
+    assert.deepEqual(
+      await coordinator.handlers['artifact.ingest'](firstChunk, connectionContext),
+      firstAccepted,
+    );
+    assert.deepEqual(
+      await coordinator.handlers['artifact.ingest'](firstChunk, connectionContext),
+      firstAccepted,
+    );
+    assert.deepEqual(
+      await coordinator.handlers['artifact.ingest'](firstChunk, {
+        ...connectionContext,
+        connectionId: 'connection-2',
+      }),
+      {
+        ok: false,
+        error: { code: 'not_found', message: 'Attachment upload was not found' },
+      },
+    );
+    assert.equal(
+      (
+        await coordinator.handlers['artifact.ingest'](
+          {
+            kind: 'chunk',
+            sessionId: 'session-1',
+            uploadId: 'upload-1',
+            offset: first.length,
+            chunkBase64: bytes.subarray(first.length).toString('base64'),
+          },
+          connectionContext,
+        )
+      ).ok,
+      true,
+    );
+    const committed = await coordinator.handlers['artifact.ingest'](
+      { kind: 'commit', sessionId: 'session-1', uploadId: 'upload-1' },
+      connectionContext,
+    );
+    assert.equal(committed.ok, true);
+    if (!committed.ok || committed.result.kind !== 'committed') return;
+    assert.equal(committed.result.attachment.ref.kind, 'session_file');
+    if (committed.result.attachment.ref.kind !== 'session_file') return;
+    const artifactId = committed.result.attachment.ref.relativePath;
+    assert.deepEqual(committed.result.attachment, {
+      kind: 'other',
+      name: 'dir-fixture.txt',
+      mimeType: 'text/plain',
+      bytes: bytes.byteLength,
+      ref: {
+        kind: 'session_file',
+        sessionId: 'session-1',
+        relativePath: artifactId,
+      },
+    });
+    assert.deepEqual(
+      await store.readTextInSession('session-1', artifactId, { maxBytes: bytes.byteLength }),
+      { ok: true, text: bytes.toString('utf8') },
+    );
+    assert.deepEqual(
+      await coordinator.handlers['artifact.ingest'](
+        { kind: 'commit', sessionId: 'session-1', uploadId: 'upload-1' },
+        { ...connectionContext, connectionId: 'connection-after-reconnect' },
+      ),
+      committed,
+    );
+    assert.deepEqual(
+      await coordinator.handlers['artifact.ingest'](begin, {
+        ...connectionContext,
+        connectionId: 'connection-after-reconnect',
+      }),
+      committed,
+    );
+    const mismatchedBegin = {
+      ...begin,
+      uploadId: 'upload-digest-mismatch',
+      contentSha256: `sha256:${'0'.repeat(64)}` as const,
+    };
+    assert.equal(
+      (await coordinator.handlers['artifact.ingest'](mismatchedBegin, connectionContext)).ok,
+      true,
+    );
+    assert.equal(
+      (
+        await coordinator.handlers['artifact.ingest'](
+          {
+            kind: 'chunk',
+            sessionId: 'session-1',
+            uploadId: mismatchedBegin.uploadId,
+            offset: 0,
+            chunkBase64: bytes.toString('base64'),
+          },
+          connectionContext,
+        )
+      ).ok,
+      true,
+    );
+    assert.deepEqual(
+      await coordinator.handlers['artifact.ingest'](
+        { kind: 'commit', sessionId: 'session-1', uploadId: mismatchedBegin.uploadId },
+        connectionContext,
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'operation_conflict',
+          message: 'Attachment content digest does not match',
+        },
+      },
+    );
+    assert.deepEqual(
+      await coordinator.handlers['artifact.ingest'](
+        { kind: 'commit', sessionId: 'session-1', uploadId: mismatchedBegin.uploadId },
+        connectionContext,
+      ),
+      {
+        ok: false,
+        error: { code: 'not_found', message: 'Attachment upload was not found' },
+      },
+    );
+    assert.equal((await store.listPage('session-1', { offset: 0, limit: 10 })).records.length, 1);
+
+    const ttlMs = 5 * 60 * 1000;
+    const ttlBegin = {
+      ...begin,
+      uploadId: 'upload-ttl-conflict',
+      totalBytes: 1,
+      contentSha256: digest(Buffer.from('x')),
+    };
+    const exactReplayBegin = { ...ttlBegin, uploadId: 'upload-ttl-exact' };
+    assert.equal(
+      (await coordinator.handlers['artifact.ingest'](ttlBegin, connectionContext)).ok,
+      true,
+    );
+    assert.equal(
+      (await coordinator.handlers['artifact.ingest'](exactReplayBegin, connectionContext)).ok,
+      true,
+    );
+    now = ttlMs - 1;
+    const conflictingReplay = await coordinator.handlers['artifact.ingest'](
+      { ...ttlBegin, name: 'different.txt' },
+      connectionContext,
+    );
+    assert.equal(conflictingReplay.ok, false);
+    if (!conflictingReplay.ok) assert.equal(conflictingReplay.error.code, 'operation_conflict');
+    assert.equal(
+      (await coordinator.handlers['artifact.ingest'](exactReplayBegin, connectionContext)).ok,
+      true,
+    );
+    now = ttlMs;
+    assert.equal(
+      (
+        await coordinator.handlers['artifact.ingest'](
+          {
+            kind: 'chunk',
+            sessionId: 'session-1',
+            uploadId: ttlBegin.uploadId,
+            offset: 0,
+            chunkBase64: Buffer.from('x').toString('base64'),
+          },
+          connectionContext,
+        )
+      ).ok,
+      false,
+    );
+    assert.equal(
+      (
+        await coordinator.handlers['artifact.ingest'](
+          {
+            kind: 'chunk',
+            sessionId: 'session-1',
+            uploadId: exactReplayBegin.uploadId,
+            offset: 0,
+            chunkBase64: Buffer.from('x').toString('base64'),
+          },
+          connectionContext,
+        )
+      ).ok,
+      true,
+    );
+    await store.close();
+  } finally {
+    await owner.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 test('Artifact mutation failure requests Host drain and fails closed', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-artifact-coordinator-'));
@@ -63,8 +291,34 @@ test('Artifact mutation failure requests Host drain and fails closed', async () 
       },
     );
     assert.equal(drainRequests, 1);
+    assert.deepEqual(
+      await coordinator.handlers['artifact.ingest'](
+        {
+          kind: 'begin',
+          sessionId: 'session-1',
+          uploadId: 'upload-after-close',
+          name: 'fixture.txt',
+          mimeType: 'text/plain',
+          totalBytes: 1,
+          contentSha256: `sha256:${'0'.repeat(64)}`,
+        },
+        connectionContext,
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'persistence_failed',
+          message: 'Attachment publication failed',
+        },
+      },
+    );
+    assert.equal(drainRequests, 2);
   } finally {
     await owner.close();
     await rm(root, { recursive: true, force: true });
   }
 });
+
+function digest(bytes: Uint8Array): `sha256:${string}` {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+}

--- a/packages/runtime-host/src/__tests__/artifact-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/artifact-protocol.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { ArtifactRecord } from '@maka/core/artifacts';
 import {
+  ARTIFACT_INGEST_CHUNK_MAX_BYTES,
   ARTIFACT_MIME_TYPE_MAX_BYTES,
   ARTIFACT_NAME_MAX_BYTES,
   ARTIFACT_PAGE_MAX_ITEMS,
@@ -21,11 +22,15 @@ import { encodeArtifactProjection } from '../protocol/artifact.js';
 const revision = `sha256:${'a'.repeat(64)}` as const;
 
 describe('Artifact protocol', () => {
-  test('registers only the closed ready query and delete operations', () => {
+  test('registers the closed ready ingest, query, and delete operations', () => {
     assert.deepEqual(
       Object.keys(HOST_OPERATION_SPECS).filter((key) => key.startsWith('artifact.')),
-      ['artifact.query', 'artifact.delete'],
+      ['artifact.ingest', 'artifact.query', 'artifact.delete'],
     );
+    assert.deepEqual(metadata('artifact.ingest'), {
+      mode: 'command',
+      availability: 'ready',
+    });
     assert.deepEqual(metadata('artifact.query'), {
       mode: 'query',
       availability: 'ready',
@@ -61,6 +66,134 @@ describe('Artifact protocol', () => {
       () => request('artifact.delete', { sessionId: 'session-1', artifactId: 'a', purge: true }),
       isInvalidFrame,
     );
+  });
+
+  test('bounds chunked attachment publication below the frame limit', () => {
+    const bytes = Buffer.alloc(ARTIFACT_INGEST_CHUNK_MAX_BYTES, 7);
+    const digest = `sha256:${'a'.repeat(64)}`;
+    assert.doesNotThrow(() =>
+      request('artifact.ingest', {
+        kind: 'begin',
+        sessionId: 'session-1',
+        uploadId: 'upload-1',
+        name: 'fixture.bin',
+        mimeType: 'application/octet-stream',
+        totalBytes: bytes.byteLength,
+        contentSha256: digest,
+      }),
+    );
+    assert.doesNotThrow(() =>
+      response('artifact.ingest', {
+        kind: 'committed',
+        uploadId: 'upload-1',
+        attachment: {
+          kind: 'other',
+          name: 'fixture.bin',
+          mimeType: 'application/octet-stream',
+          bytes: bytes.byteLength,
+          ref: {
+            kind: 'session_file',
+            sessionId: 'session-1',
+            relativePath: 'attachment-1',
+          },
+        },
+      }),
+    );
+    assert.throws(
+      () =>
+        response('artifact.ingest', {
+          kind: 'committed',
+          uploadId: 'upload-1',
+          attachment: {
+            kind: 'other',
+            name: 'fixture.bin',
+            mimeType: 'application/octet-stream',
+            bytes: bytes.byteLength,
+            ref: { kind: 'external_file', absolutePath: '/tmp/fixture.bin' },
+          },
+        }),
+      isInvalidFrame,
+    );
+    assert.doesNotThrow(() =>
+      request('artifact.ingest', {
+        kind: 'chunk',
+        sessionId: 'session-1',
+        uploadId: 'upload-1',
+        offset: 0,
+        chunkBase64: bytes.toString('base64'),
+      }),
+    );
+    assert.doesNotThrow(() =>
+      request('artifact.ingest', {
+        kind: 'commit',
+        sessionId: 'session-1',
+        uploadId: 'upload-1',
+      }),
+    );
+    const frame = encodeProtocolFrame({
+      requestId: 'artifact-ingest-chunk',
+      operation: 'artifact.ingest',
+      input: {
+        kind: 'chunk',
+        sessionId: 'session-1',
+        uploadId: 'upload-1',
+        offset: 0,
+        chunkBase64: bytes.toString('base64'),
+      },
+    });
+    assert.ok(frame.byteLength <= RUNTIME_HOST_MAX_FRAME_BYTES);
+
+    for (const chunkBase64 of [
+      Buffer.alloc(ARTIFACT_INGEST_CHUNK_MAX_BYTES + 1).toString('base64'),
+      'not-base64',
+      'YQ',
+      '',
+    ]) {
+      assert.throws(
+        () =>
+          request('artifact.ingest', {
+            kind: 'chunk',
+            sessionId: 'session-1',
+            uploadId: 'upload-1',
+            offset: 0,
+            chunkBase64,
+          }),
+        isInvalidFrame,
+      );
+    }
+    assert.throws(
+      () =>
+        request('artifact.ingest', {
+          kind: 'begin',
+          sessionId: 'session-1',
+          uploadId: 'upload-1',
+          name: 'fixture.bin',
+          mimeType: 'application/octet-stream',
+          totalBytes: 1,
+          contentSha256: `sha256:${'A'.repeat(64)}`,
+        }),
+      isInvalidFrame,
+    );
+    for (const field of [
+      { name: 'bad\nname.bin' },
+      { mimeType: 'application/octet-stream\ninvalid' },
+      { mimeType: 'x'.repeat(257) },
+    ]) {
+      assert.throws(
+        () =>
+          request('artifact.ingest', {
+            kind: 'begin',
+            sessionId: 'session-1',
+            uploadId: 'upload-1',
+            name: 'fixture.bin',
+            mimeType: 'application/octet-stream',
+            totalBytes: 1,
+            contentSha256: digest,
+            ...field,
+          }),
+        isInvalidFrame,
+      );
+    }
   });
 
   test('keeps operation failures closed and typed', () => {
@@ -242,16 +375,19 @@ function validArtifact() {
   };
 }
 
-function metadata(key: 'artifact.query' | 'artifact.delete') {
+function metadata(key: 'artifact.ingest' | 'artifact.query' | 'artifact.delete') {
   const { mode, availability } = HOST_OPERATION_SPECS[key];
   return { mode, availability };
 }
 
-function request(operation: 'artifact.query' | 'artifact.delete', input: unknown): void {
+function request(
+  operation: 'artifact.ingest' | 'artifact.query' | 'artifact.delete',
+  input: unknown,
+): void {
   decodeClientFrame({ requestId: 'request', operation, input });
 }
 
-function response(operation: 'artifact.query', result: unknown): void {
+function response(operation: 'artifact.ingest' | 'artifact.query', result: unknown): void {
   decodeHostFrame({ requestId: 'response', operation, ok: true, result });
 }
 

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -25,6 +25,7 @@ const allowedHostExternalImports = new Set([
 const allowedServerExternalImports = new Set([
   ...allowedHostExternalImports,
   '@maka/core/agent-run',
+  '@maka/core/attachments',
   '@maka/core/artifacts',
   '@maka/core/automation',
   '@maka/core/backend-types',

--- a/packages/runtime-host/src/__tests__/execution-artifacts.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-artifacts.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, rm, truncate, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { MAX_ATTACHMENT_BYTES } from '@maka/core/attachments';
+import { openInteractiveArtifactStoreForWrite } from '@maka/storage/artifact-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import { createHostExecutionArtifactServices } from '../server/execution-artifacts.js';
+
+test('Hosted execution publishes contained Tool Artifacts and durable result archives', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-execution-artifacts-'));
+  const workspace = join(base, 'workspace');
+  const outside = join(base, 'outside.txt');
+  await mkdir(workspace);
+  await writeFile(join(workspace, 'inside.txt'), 'inside artifact');
+  await writeFile(join(workspace, 'oversized.bin'), '');
+  await truncate(join(workspace, 'oversized.bin'), MAX_ATTACHMENT_BYTES + 1);
+  await writeFile(outside, 'outside artifact');
+  const capability = await resolveStorageRoot({ path: join(base, 'root'), kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  try {
+    const store = await openInteractiveArtifactStoreForWrite(owner.lease);
+    await store.recover();
+    const services = createHostExecutionArtifactServices({
+      artifacts: store,
+      requestDrain: () => assert.fail('successful Artifact writes must not request Host drain'),
+    });
+    await services.recordToolArtifacts({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      toolUseId: 'tool-use-1',
+      toolName: 'Write',
+      args: {},
+      result: {},
+      cwd: workspace,
+      candidates: [
+        { kind: 'file', name: 'inside.txt', sourcePath: 'inside.txt' },
+        { kind: 'file', name: 'oversized.bin', sourcePath: 'oversized.bin' },
+        { kind: 'file', name: 'outside.txt', sourcePath: outside },
+      ],
+    });
+    const published = await store.listPage('session-1', { offset: 0, limit: 10 });
+    assert.deepEqual(
+      published.records.map((record) => record.name),
+      ['inside.txt'],
+    );
+
+    const serializedResult = JSON.stringify({ output: 'x'.repeat(2_048) });
+    const bodySha256 = createHash('sha256').update(serializedResult).digest('hex');
+    const archiveInput = {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      runtimeEventId: 'runtime-event-1',
+      toolCallId: 'tool-call-1',
+      toolName: 'Bash',
+      result: { output: 'x'.repeat(2_048) },
+      serializedResult,
+      originalEstimatedTokens: 512,
+      originalBytes: Buffer.byteLength(serializedResult),
+      rewriteVersion: 1 as const,
+      reason: 'stale_tool_result_pruned_before_compact' as const,
+      bodySha256,
+    };
+    const archived = await services.archiveToolResult(archiveInput);
+    assert.deepEqual(await services.archiveToolResult(archiveInput), archived);
+    assert.deepEqual(
+      await services.readToolResultArchive({
+        ...archiveInput,
+        kind: 'maka.archived_tool_result',
+        artifactId: archived.artifactId,
+      }),
+      { ok: true, serializedResult },
+    );
+    await store.close();
+  } finally {
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -635,7 +635,9 @@ test('production Host executes a canonical ai-sdk Session against a real provide
         turnId,
         index === 0
           ? `Reply with the hosted execution result.${' HISTORY_PRESSURE'.repeat(160)}`
-          : `Continue hosted execution turn ${index}.${' HISTORY_PRESSURE'.repeat(160)}`,
+          : index === 1
+            ? `/skill:hosted-skill Continue hosted execution turn ${index}.${' HISTORY_PRESSURE'.repeat(160)}`
+            : `Continue hosted execution turn ${index}.${' HISTORY_PRESSURE'.repeat(160)}`,
         connectionContext,
       );
       const terminal = await waitForTerminal(
@@ -663,7 +665,9 @@ test('production Host executes a canonical ai-sdk Session against a real provide
     assert.match(requestText, /HOSTED_TASK_LEDGER_SENTINEL/);
     assert.match(requestText, /HOSTED_PERSONALIZATION_SENTINEL/);
     assert.match(requestText, /HOSTED_MEMORY_SENTINEL/);
+    assert.match(JSON.stringify(mainRequests[1]?.body), /HOSTED_SKILL_BODY_MUST_STAY_LAZY/);
     assert.deepEqual(toolNames(request?.body), [
+      'ArchiveRead',
       'AskUserQuestion',
       'Automation',
       'Bash',
@@ -697,6 +701,22 @@ test('production Host executes a canonical ai-sdk Session against a real provide
     );
     assert.equal(assistant?.type, 'assistant');
     if (assistant?.type === 'assistant') assert.equal(assistant.text, RESPONSE_TEXT);
+    const skillMessage = messages.find(
+      (message) => message.type === 'user' && message.turnId === turnIds[1],
+    );
+    assert.equal(skillMessage?.type, 'user');
+    if (skillMessage?.type === 'user') {
+      assert.match(skillMessage.text, /HOSTED_SKILL_BODY_MUST_STAY_LAZY/);
+      assert.match(skillMessage.displayText ?? '', /^\/skill:hosted-skill /);
+      assert.deepEqual(skillMessage.inlineReferences, [
+        {
+          kind: 'skill',
+          value: '/skill:hosted-skill',
+          label: 'Hosted Skill Sentinel',
+          start: 0,
+        },
+      ]);
+    }
 
     const usage = await waitForUsage(
       composition,
@@ -1324,10 +1344,15 @@ test('production Host publishes and retires an implementation child patch', asyn
     );
     const artifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
     const childArtifacts = await artifacts.listTurnArtifacts(child.id, childRuns[0]!.turnId);
-    assert.equal(childArtifacts.length, 3);
+    assert.equal(childArtifacts.length, 4);
     assert.equal(
       childArtifacts.filter((artifact) => artifact.source === 'provider_request_capture').length,
       2,
+    );
+    assert.ok(
+      childArtifacts.some(
+        (artifact) => artifact.source === 'tool_result' && artifact.name === 'implementation.txt',
+      ),
     );
     const patchArtifact = childArtifacts.find(
       (artifact) => artifact.source === 'subagent_writeback',
@@ -2021,6 +2046,12 @@ function backendCreationFixture(input: {
       list: async () => [],
     },
     artifacts: {},
+    executionArtifacts: {
+      recordToolArtifacts: async () => undefined,
+      archiveToolResult: async () => ({ artifactId: 'fixture-tool-result-archive' }),
+      readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
+      readArchivedToolResultResource: async () => ({ ok: false, reason: 'not_found' }),
+    },
     usage: {
       pricing: {
         snapshot: input.readPricing,

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -32,6 +32,8 @@ import {
   TURN_MESSAGE_QUOTE_LABEL_MAX_LENGTH,
   TURN_MESSAGE_QUOTE_MAX_COUNT,
   TURN_MESSAGE_QUOTE_TEXT_MAX_LENGTH,
+  TURN_SKILL_ID_MAX_COUNT,
+  TURN_SKILL_ID_MAX_LENGTH,
 } from '../protocol/turn.js';
 
 describe('Runtime Host bootstrap protocol', () => {
@@ -49,6 +51,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'agent.graph.query',
       'agent.graph.stop',
       'artifact.delete',
+      'artifact.ingest',
       'artifact.query',
       'automation.mutate',
       'automation.query',
@@ -943,6 +946,52 @@ describe('Runtime Host bootstrap protocol', () => {
         input: { ...submitWire.input, content: { text: 'valid' } },
       },
     );
+  });
+
+  test('accepts bounded explicit Skill identities only on turn.start', () => {
+    const start = (skillIds: unknown, text = '') =>
+      decodeClientFrame({
+        requestId: 'skill-start',
+        operation: 'turn.start',
+        input: {
+          sessionId: 'session-1',
+          turnId: 'turn-skill-1',
+          content: { text },
+          skillIds,
+        },
+      });
+    assert.deepEqual(start(['writer', 'project:maka:reviewer']), {
+      requestId: 'skill-start',
+      operation: 'turn.start',
+      input: {
+        sessionId: 'session-1',
+        turnId: 'turn-skill-1',
+        content: { text: '' },
+        skillIds: ['writer', 'project:maka:reviewer'],
+      },
+    });
+    assert.doesNotThrow(() =>
+      start(Array.from({ length: TURN_SKILL_ID_MAX_COUNT }, (_, index) => `skill-${index}`)),
+    );
+    for (const skillIds of [
+      Array.from({ length: TURN_SKILL_ID_MAX_COUNT + 1 }, (_, index) => `skill-${index}`),
+      ['bad/id'],
+      ['bad id'],
+      ['x'.repeat(TURN_SKILL_ID_MAX_LENGTH + 1)],
+      [1],
+    ]) {
+      assert.throws(() => start(skillIds), isInvalidFrame);
+    }
+    assert.throws(() => start(undefined), isInvalidFrame);
+    assert.deepEqual(start([], 'plain'), {
+      requestId: 'skill-start',
+      operation: 'turn.start',
+      input: {
+        sessionId: 'session-1',
+        turnId: 'turn-skill-1',
+        content: { text: 'plain' },
+      },
+    });
   });
 
   test('decodes a closed regenerate identity without accepting replacement content', () => {

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -20,6 +20,7 @@ import {
   RuntimeInteractionAdmissionRejectedError,
   RuntimeMessageAuthorityInvariantError,
   SessionManager,
+  type PreparedSkillInvocationMessage,
   type RuntimeHostedRootAuthority,
   type RuntimeInteractionAuthority,
   type RuntimeInteractionRunClosureReason,
@@ -37,8 +38,10 @@ import {
   type RootTurnAdmission,
   type RootTurnAdmissionStore,
 } from '@maka/storage/execution-stores';
+import { openInteractiveArtifactStoreForWrite } from '@maka/storage/artifact-stores';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import type { SubscriptionFrame } from '../protocol/index.js';
+import { HostArtifactCoordinator } from '../server/artifact-coordinator.js';
 import { HostCanonicalPermissionOutcomeReader } from '../server/canonical-permission-outcome-reader.js';
 import { CanonicalSessionProjectionReader } from '../server/canonical-session-projection.js';
 import { HostClientCapabilityCoordinator } from '../server/client-capability-coordinator.js';
@@ -360,6 +363,265 @@ test('turn.start durably applies one exact per-Turn orchestration override', asy
     );
     assert.equal(conflict.ok, false);
     if (!conflict.ok) assert.equal(conflict.error.code, 'operation_conflict');
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('turn.start resolves explicit Skills once before durable admission and replays the result', async () => {
+  let preparationCount = 0;
+  let blocked = false;
+  let observedCapabilityPreview = false;
+  const capabilities = new HostClientCapabilityCoordinator({
+    activation: new RuntimePolicyActivationGate(),
+    onModelToolsChanged: () => undefined,
+  });
+  const connection = capabilities.attachConnection('skill-provider', { send: async () => {} });
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+    clientCapabilities: capabilities,
+    prepareSkillInvocation: async ({ sessionId }): Promise<PreparedSkillInvocationMessage> => {
+      preparationCount += 1;
+      const snapshot = capabilities.snapshotForSession(sessionId);
+      observedCapabilityPreview = (snapshot?.tools.length ?? 0) > 0;
+      snapshot?.release();
+      if (blocked) {
+        return {
+          disposition: 'blocked',
+          skillInvocation: {
+            loaded: [],
+            failed: [{ request: 'writer', reason: 'not_found' }],
+            receipts: [
+              {
+                invocation: 'explicit',
+                request: 'writer',
+                success: false,
+                reason: 'not_found',
+              },
+            ],
+          },
+        };
+      }
+      return {
+        disposition: 'ready',
+        sendText: '<invoked-skill>Write clearly.</invoked-skill>\n\nDraft this.',
+        skillInvocation: {
+          loaded: [{ id: 'writer', name: 'Writer' }],
+          failed: [],
+          receipts: [
+            {
+              invocation: 'explicit',
+              request: 'writer',
+              success: true,
+              ref: 'project:maka:writer',
+              id: 'writer',
+              name: 'Writer',
+              scope: 'project',
+              source: 'maka',
+              truncated: false,
+            },
+          ],
+        },
+      };
+    },
+  });
+  const input = {
+    sessionId: fixture.sessionId,
+    turnId: 'turn-hosted-skill',
+    content: { text: '/skill:writer Draft this.' },
+    skillIds: ['writer'],
+  };
+  try {
+    await registerSessionCapability(fixture, capabilities, 'skill-provider', 'skill-registration', [
+      'inspect',
+    ]);
+    const context = operationContext(fixture.hostEpoch, fixture.acquireResidency, 'skill-provider');
+    const started = await fixture.coordinator.handlers['turn.start'](input, context);
+    assert.equal(started.ok, true);
+    assert.equal(preparationCount, 1);
+    assert.equal(observedCapabilityPreview, true);
+    const admission = await fixture.stores.agentRunStore.readRootTurnAdmission(
+      fixture.sessionId,
+      input.turnId,
+    );
+    assert.equal(admission?.execution.kind, 'external_message');
+    assert.match(
+      admission?.execution.kind === 'external_message'
+        ? (admission.execution.inputDigest ?? '')
+        : '',
+      /^sha256:[a-f0-9]{64}$/,
+    );
+    assert.deepEqual(admission?.normalizedInput, {
+      text: '<invoked-skill>Write clearly.</invoked-skill>\n\nDraft this.',
+      displayText: '/skill:writer Draft this.',
+      inlineReferences: [{ kind: 'skill', value: '/skill:writer', label: 'Writer', start: 0 }],
+    });
+
+    blocked = true;
+    const exactRetry = await fixture.coordinator.handlers['turn.start'](input, context);
+    assert.equal(exactRetry.ok, true);
+    assert.equal(preparationCount, 1, 'durable replay must not resolve a mutable Skill catalog');
+
+    const conflictingRetry = await fixture.coordinator.handlers['turn.start'](
+      { ...input, skillIds: ['writer', 'another'] },
+      context,
+    );
+    assert.equal(conflictingRetry.ok, false);
+    if (!conflictingRetry.ok) assert.equal(conflictingRetry.error.code, 'operation_conflict');
+  } finally {
+    await connection.close();
+    await capabilities.close();
+    await fixture.dispose();
+  }
+});
+
+test('turn.start rejects oversized Skill preparation before admission and preserves not-found semantics', async () => {
+  let preparationCount = 0;
+  let preparation: 'blocked' | 'oversized' = 'blocked';
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+    prepareSkillInvocation: async () => {
+      preparationCount += 1;
+      if (preparation === 'blocked') {
+        return {
+          disposition: 'blocked',
+          skillInvocation: {
+            loaded: [],
+            failed: [{ request: 'writer', reason: 'not_found' }],
+            receipts: [],
+          },
+        };
+      }
+      return {
+        disposition: 'ready',
+        sendText: 'x'.repeat(70 * 1024),
+        skillInvocation: {
+          loaded: [{ id: 'writer', name: 'Writer' }],
+          failed: [],
+          receipts: [],
+        },
+      };
+    },
+  });
+  const context = operationContext(fixture.hostEpoch, fixture.acquireResidency);
+  try {
+    const blocked = await fixture.coordinator.handlers['turn.start'](
+      {
+        sessionId: fixture.sessionId,
+        turnId: 'turn-hosted-skill-blocked',
+        content: { text: '/skill:writer' },
+      },
+      context,
+    );
+    assert.equal(blocked.ok, false);
+    if (!blocked.ok) assert.equal(blocked.error.code, 'operation_conflict');
+    assert.equal(
+      await fixture.stores.agentRunStore.readRootTurnAdmission(
+        fixture.sessionId,
+        'turn-hosted-skill-blocked',
+      ),
+      undefined,
+    );
+
+    preparation = 'oversized';
+    const oversized = await fixture.coordinator.handlers['turn.start'](
+      {
+        sessionId: fixture.sessionId,
+        turnId: 'turn-hosted-skill-oversized',
+        content: { text: '/skill:writer Draft this.' },
+      },
+      context,
+    );
+    assert.equal(oversized.ok, false);
+    if (!oversized.ok) assert.equal(oversized.error.code, 'operation_conflict');
+    assert.equal(fixture.drainRequested(), false);
+    assert.equal(
+      await fixture.stores.agentRunStore.readRootTurnAdmission(
+        fixture.sessionId,
+        'turn-hosted-skill-oversized',
+      ),
+      undefined,
+    );
+
+    const missingSession = await fixture.coordinator.handlers['turn.start'](
+      {
+        sessionId: 'missing-session',
+        turnId: 'turn-hosted-skill-missing-session',
+        content: { text: '/skill:writer Draft this.' },
+      },
+      context,
+    );
+    assert.equal(missingSession.ok, false);
+    if (!missingSession.ok) assert.equal(missingSession.error.code, 'not_found');
+    assert.equal(preparationCount, 2, 'missing Sessions must not resolve Skills');
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('turn.start admits only canonical live Session Artifact attachments', async () => {
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
+    withArtifacts: true,
+  });
+  try {
+    const artifact = await fixture.artifacts!.create({
+      id: 'attachment-fixture',
+      sessionId: fixture.sessionId,
+      turnId: 'upload-1',
+      name: 'fixture.txt',
+      kind: 'file',
+      content: 'fixture bytes',
+      mimeType: 'text/plain',
+      source: 'user_upload',
+    });
+    const attachment = {
+      kind: 'other' as const,
+      name: artifact.name,
+      mimeType: artifact.mimeType!,
+      bytes: artifact.sizeBytes,
+      ref: {
+        kind: 'session_file' as const,
+        sessionId: fixture.sessionId,
+        relativePath: artifact.id,
+      },
+    };
+    for (const [turnId, invalidAttachment] of [
+      ['turn-with-wrong-size', { ...attachment, bytes: attachment.bytes + 1 }],
+      ['turn-with-wrong-kind', { ...attachment, kind: 'image' as const }],
+      [
+        'turn-with-cross-session-ref',
+        { ...attachment, ref: { ...attachment.ref, sessionId: 'another-session' } },
+      ],
+      [
+        'turn-with-missing-artifact',
+        { ...attachment, ref: { ...attachment.ref, relativePath: 'missing-artifact' } },
+      ],
+    ] as const) {
+      const rejected = await fixture.coordinator.handlers['turn.start'](
+        {
+          sessionId: fixture.sessionId,
+          turnId,
+          content: { text: 'Use this attachment.', attachments: [invalidAttachment] },
+        },
+        operationContext(fixture.hostEpoch, fixture.acquireResidency),
+      );
+      assert.equal(rejected.ok, false);
+      if (!rejected.ok) assert.equal(rejected.error.code, 'operation_conflict');
+      assert.equal(
+        await fixture.stores.agentRunStore.readRootTurnAdmission(fixture.sessionId, turnId),
+        undefined,
+      );
+    }
+    const started = await fixture.coordinator.handlers['turn.start'](
+      {
+        sessionId: fixture.sessionId,
+        turnId: 'turn-with-attachment',
+        content: { text: 'Use this attachment.', attachments: [attachment] },
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(started.ok, true);
   } finally {
     await fixture.dispose();
   }
@@ -3825,12 +4087,19 @@ async function createFailureFixture(options: {
   wrapAdmissionStore?(store: RootTurnAdmissionStore): RootTurnAdmissionStore;
   wrapMessageAuthority?(authority: RuntimeMessageAuthority): RuntimeMessageAuthority;
   withInteractions?: boolean;
+  withArtifacts?: boolean;
   beforeInteractionPreflight?(): Promise<void>;
   clientCapabilities?: HostClientCapabilityCoordinator;
   continuationSafety?: {
     workspaceIdentity: string;
     availableToolNames: readonly string[] | ((sessionId: string) => readonly string[]);
   };
+  prepareSkillInvocation?(input: {
+    sessionId: string;
+    turnId: string;
+    text: string;
+    skillIds: readonly string[];
+  }): Promise<PreparedSkillInvocationMessage>;
 }) {
   const base = await mkdtemp(join(tmpdir(), 'maka-root-turn-message-failure-'));
   const capability = await resolveStorageRoot({
@@ -3842,6 +4111,10 @@ async function createFailureFixture(options: {
   if (!owner) throw new Error('Unable to acquire test root');
 
   const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+  const artifacts = options.withArtifacts
+    ? await openInteractiveArtifactStoreForWrite(owner.lease)
+    : undefined;
+  await artifacts?.recover();
   const session = await stores.sessionStore.create({
     cwd: capability.canonicalPath,
     backend: 'fake',
@@ -3970,6 +4243,9 @@ async function createFailureFixture(options: {
         }),
       })
     : new SessionManager(managerDeps);
+  const artifactAuthority = artifacts
+    ? new HostArtifactCoordinator(artifacts, requestDrain, sessionAdmission, stores.sessionStore)
+    : undefined;
   const createCoordinator = (
     admissionOwner: RootAdmissionOwner,
     assertAutomationRecoveryAdmission?: (admission: RootTurnAdmission) => void,
@@ -3990,6 +4266,8 @@ async function createFailureFixture(options: {
       options.clientCapabilities,
       () => NO_GOAL_ROOT_AUTHORITY,
       assertAutomationRecoveryAdmission,
+      artifactAuthority,
+      options.prepareSkillInvocation,
     );
   coordinator = createCoordinator(rootAdmissionOwner);
 
@@ -4002,6 +4280,7 @@ async function createFailureFixture(options: {
     continuity,
     manager,
     interactions,
+    artifacts,
     sessionAdmission,
     acquireResidency,
     createRecoveryCoordinator: (

--- a/packages/runtime-host/src/protocol/artifact.ts
+++ b/packages/runtime-host/src/protocol/artifact.ts
@@ -11,7 +11,9 @@ import {
   isArtifactTurnKey,
   isCanonicalArtifactEntityId,
 } from '@maka/core/artifacts';
-import { requireCount, requireExactRecord, requireRecord } from './codec.js';
+import { MAX_ATTACHMENT_BYTES } from '@maka/core/attachments';
+import { isCanonicalAttachmentRef, type AttachmentRef } from '@maka/core/events';
+import { requireCount, requireEntityId, requireExactRecord, requireRecord } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
 import { defineOperation } from './operation-spec.js';
 
@@ -22,6 +24,8 @@ export const ARTIFACT_CURSOR_MAX_BYTES = 32;
 export const ARTIFACT_NAME_MAX_BYTES = 512;
 export const ARTIFACT_MIME_TYPE_MAX_BYTES = 512;
 export const ARTIFACT_SUMMARY_MAX_BYTES = 8 * 1024;
+export const ARTIFACT_INGEST_CHUNK_MAX_BYTES = 48 * 1024;
+export const ARTIFACT_INGEST_MIME_TYPE_MAX_BYTES = 256;
 
 const QUERY_ERRORS = [
   'host_not_ready',
@@ -122,7 +126,72 @@ export interface ArtifactDeleteResult {
   readonly artifact: ArtifactProjection;
 }
 
+export type ArtifactIngestInput =
+  | {
+      readonly kind: 'begin';
+      readonly sessionId: string;
+      readonly uploadId: string;
+      readonly name: string;
+      readonly mimeType: string;
+      readonly totalBytes: number;
+      readonly contentSha256: `sha256:${string}`;
+    }
+  | {
+      readonly kind: 'chunk';
+      readonly sessionId: string;
+      readonly uploadId: string;
+      readonly offset: number;
+      readonly chunkBase64: string;
+    }
+  | { readonly kind: 'commit'; readonly sessionId: string; readonly uploadId: string }
+  | { readonly kind: 'abort'; readonly sessionId: string; readonly uploadId: string };
+
+export type ArtifactIngestResult =
+  | { readonly kind: 'upload_opened'; readonly uploadId: string; readonly nextOffset: number }
+  | { readonly kind: 'chunk_accepted'; readonly uploadId: string; readonly nextOffset: number }
+  | { readonly kind: 'committed'; readonly uploadId: string; readonly attachment: AttachmentRef }
+  | { readonly kind: 'upload_aborted'; readonly uploadId: string };
+
 export const ARTIFACT_OPERATION_SPECS = {
+  'artifact.ingest': defineOperation<
+    ArtifactIngestInput,
+    ArtifactIngestResult,
+    | 'host_not_ready'
+    | 'host_draining'
+    | 'operation_unavailable'
+    | 'invalid_request'
+    | 'not_found'
+    | 'operation_conflict'
+    | 'persistence_failed'
+    | 'internal_failure'
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: [
+      'host_not_ready',
+      'host_draining',
+      'operation_unavailable',
+      'invalid_request',
+      'not_found',
+      'operation_conflict',
+      'persistence_failed',
+      'internal_failure',
+    ],
+    decodeInput: decodeArtifactIngestInput,
+    decodeOutput: decodeArtifactIngestResult,
+    assertOutputForInput: (input, output) => {
+      if (input.uploadId !== output.uploadId) {
+        throw invalidProtocolFrame('Artifact ingest changed upload identity');
+      }
+      if (
+        output.kind === 'committed' &&
+        (output.attachment.ref.kind !== 'session_file' ||
+          output.attachment.ref.sessionId !== input.sessionId)
+      ) {
+        throw invalidProtocolFrame('Artifact ingest changed Session identity');
+      }
+    },
+  }),
   'artifact.query': defineOperation<
     ArtifactQueryInput,
     ArtifactQueryResult,
@@ -146,6 +215,118 @@ export const ARTIFACT_OPERATION_SPECS = {
     decodeOutput: decodeArtifactDeleteResult,
   }),
 } as const;
+
+export function decodeArtifactIngestInput(value: unknown): ArtifactIngestInput {
+  const input = requireRecord(value, 'artifact ingest input');
+  if (input.kind === 'begin') {
+    const exact = requireExactRecord(input, 'artifact ingest begin input', [
+      'kind',
+      'sessionId',
+      'uploadId',
+      'name',
+      'mimeType',
+      'totalBytes',
+      'contentSha256',
+    ]);
+    return {
+      kind: 'begin',
+      sessionId: requireEntityId(exact.sessionId, 'sessionId'),
+      uploadId: requireEntityId(exact.uploadId, 'uploadId'),
+      name: boundedIngestText(exact.name, 'artifact ingest name', ARTIFACT_NAME_MAX_BYTES),
+      mimeType: boundedIngestText(
+        exact.mimeType,
+        'artifact ingest mime type',
+        ARTIFACT_INGEST_MIME_TYPE_MAX_BYTES,
+      ),
+      totalBytes: boundedAttachmentBytes(exact.totalBytes),
+      contentSha256: contentDigest(exact.contentSha256),
+    };
+  }
+  if (input.kind === 'chunk') {
+    const exact = requireExactRecord(input, 'artifact ingest chunk input', [
+      'kind',
+      'sessionId',
+      'uploadId',
+      'offset',
+      'chunkBase64',
+    ]);
+    const chunkBase64 = boundedText(
+      exact.chunkBase64,
+      'artifact ingest chunk',
+      Math.ceil((ARTIFACT_INGEST_CHUNK_MAX_BYTES * 4) / 3) + 4,
+      true,
+    );
+    if (!isCanonicalBase64(chunkBase64)) {
+      throw invalidProtocolFrame('Invalid artifact ingest chunk');
+    }
+    const chunk = Buffer.from(chunkBase64, 'base64');
+    if (chunk.byteLength === 0 || chunk.byteLength > ARTIFACT_INGEST_CHUNK_MAX_BYTES) {
+      throw invalidProtocolFrame('Invalid artifact ingest chunk');
+    }
+    return {
+      kind: 'chunk',
+      sessionId: requireEntityId(exact.sessionId, 'sessionId'),
+      uploadId: requireEntityId(exact.uploadId, 'uploadId'),
+      offset: requireCount(exact.offset, 'artifact ingest offset'),
+      chunkBase64,
+    };
+  }
+  if (input.kind === 'commit' || input.kind === 'abort') {
+    const exact = requireExactRecord(input, 'artifact ingest terminal input', [
+      'kind',
+      'sessionId',
+      'uploadId',
+    ]);
+    return {
+      kind: input.kind,
+      sessionId: requireEntityId(exact.sessionId, 'sessionId'),
+      uploadId: requireEntityId(exact.uploadId, 'uploadId'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid artifact ingest kind');
+}
+
+export function decodeArtifactIngestResult(value: unknown): ArtifactIngestResult {
+  const result = requireRecord(value, 'artifact ingest result');
+  if (result.kind === 'upload_opened' || result.kind === 'chunk_accepted') {
+    const exact = requireExactRecord(result, 'artifact ingest progress result', [
+      'kind',
+      'uploadId',
+      'nextOffset',
+    ]);
+    return {
+      kind: result.kind,
+      uploadId: requireEntityId(exact.uploadId, 'uploadId'),
+      nextOffset: requireCount(exact.nextOffset, 'artifact ingest next offset'),
+    };
+  }
+  if (result.kind === 'upload_aborted') {
+    const exact = requireExactRecord(result, 'artifact ingest abort result', ['kind', 'uploadId']);
+    return { kind: 'upload_aborted', uploadId: requireEntityId(exact.uploadId, 'uploadId') };
+  }
+  if (result.kind === 'committed') {
+    const exact = requireExactRecord(result, 'artifact ingest committed result', [
+      'kind',
+      'uploadId',
+      'attachment',
+    ]);
+    if (!isCanonicalAttachmentRef(exact.attachment)) {
+      throw invalidProtocolFrame('Invalid artifact ingest AttachmentRef');
+    }
+    if (exact.attachment.ref.kind !== 'session_file') {
+      throw invalidProtocolFrame('Invalid artifact ingest AttachmentRef');
+    }
+    return {
+      kind: 'committed',
+      uploadId: requireEntityId(exact.uploadId, 'uploadId'),
+      attachment: {
+        ...exact.attachment,
+        ref: { ...exact.attachment.ref },
+      },
+    };
+  }
+  throw invalidProtocolFrame('Invalid artifact ingest result kind');
+}
 
 export function decodeArtifactQueryInput(value: unknown): ArtifactQueryInput {
   const input = requireRecord(value, 'artifact query input');
@@ -400,6 +581,13 @@ function boundedText(value: unknown, label: string, maxBytes: number, allowEmpty
   return value;
 }
 
+function boundedIngestText(value: unknown, label: string, maxBytes: number): string {
+  const text = boundedText(value, label, maxBytes);
+  // eslint-disable-next-line no-control-regex
+  if (/[ -]/.test(text)) throw invalidProtocolFrame(`Invalid ${label}`);
+  return text;
+}
+
 function artifactEntityId(value: unknown, label: string): string {
   if (!isCanonicalArtifactEntityId(value)) throw invalidProtocolFrame(`Invalid ${label}`);
   return value;
@@ -415,6 +603,21 @@ function artifactRevision(value: unknown, label: string): ArtifactRevision {
     throw invalidProtocolFrame(`Invalid ${label}`);
   }
   return value as ArtifactRevision;
+}
+
+function boundedAttachmentBytes(value: unknown): number {
+  const bytes = requireCount(value, 'artifact ingest total bytes');
+  if (bytes > MAX_ATTACHMENT_BYTES) {
+    throw invalidProtocolFrame('Artifact ingest exceeds attachment byte limit');
+  }
+  return bytes;
+}
+
+function contentDigest(value: unknown): `sha256:${string}` {
+  if (typeof value !== 'string' || !/^sha256:[a-f0-9]{64}$/.test(value)) {
+    throw invalidProtocolFrame('Invalid artifact ingest content digest');
+  }
+  return value as `sha256:${string}`;
 }
 
 function artifactKind(value: unknown): ArtifactKind {

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -41,6 +41,8 @@ export type {
 } from './operation-spec.js';
 export {
   ARTIFACT_CURSOR_MAX_BYTES,
+  ARTIFACT_INGEST_CHUNK_MAX_BYTES,
+  ARTIFACT_INGEST_MIME_TYPE_MAX_BYTES,
   ARTIFACT_MIME_TYPE_MAX_BYTES,
   ARTIFACT_NAME_MAX_BYTES,
   ARTIFACT_PAGE_MAX_ITEMS,
@@ -49,12 +51,16 @@ export {
   ARTIFACT_SUMMARY_MAX_BYTES,
   decodeArtifactDeleteInput,
   decodeArtifactDeleteResult,
+  decodeArtifactIngestInput,
+  decodeArtifactIngestResult,
   decodeArtifactQueryInput,
   decodeArtifactQueryResult,
   encodeArtifactDeleteResult,
   encodeArtifactQueryResult,
 } from './artifact.js';
 export type {
+  ArtifactIngestInput,
+  ArtifactIngestResult,
   ArtifactBinaryPreview,
   ArtifactDeleteInput,
   ArtifactDeleteResult,

--- a/packages/runtime-host/src/protocol/turn.ts
+++ b/packages/runtime-host/src/protocol/turn.ts
@@ -26,6 +26,7 @@ export interface TurnStartInput {
   sessionId: string;
   turnId: string;
   content: MessageContent;
+  skillIds?: string[];
   turnOrchestration?: TurnOrchestration;
 }
 
@@ -36,6 +37,8 @@ export const TURN_MESSAGE_CONTENT_MAX_BYTES = 52 * 1024;
 export const TURN_MESSAGE_QUOTE_MAX_COUNT = 16;
 export const TURN_MESSAGE_QUOTE_TEXT_MAX_LENGTH = 32_000;
 export const TURN_MESSAGE_QUOTE_LABEL_MAX_LENGTH = 200;
+export const TURN_SKILL_ID_MAX_COUNT = 50;
+export const TURN_SKILL_ID_MAX_LENGTH = 512;
 const ATTACHMENT_NAME_MAX_BYTES = 512;
 const ATTACHMENT_MIME_TYPE_MAX_BYTES = 256;
 const ATTACHMENT_PATH_MAX_BYTES = 4096;
@@ -265,16 +268,36 @@ function decodeTurnStartInput(value: unknown): TurnStartInput {
     value,
     'turn.start input',
     ['sessionId', 'turnId', 'content'],
-    ['turnOrchestration'],
+    ['skillIds', 'turnOrchestration'],
   );
+  const skillIds = decodeSkillIds(record.skillIds);
   return {
     sessionId: requireEntityId(record.sessionId, 'sessionId'),
     turnId: requireEntityId(record.turnId, 'turnId'),
-    content: decodeMessageContent(record.content),
+    content: decodeMessageContent(record.content, skillIds.length > 0),
+    ...(skillIds.length > 0 ? { skillIds } : {}),
     ...(record.turnOrchestration !== undefined
       ? { turnOrchestration: decodeTurnOrchestration(record.turnOrchestration) }
       : {}),
   };
+}
+
+function decodeSkillIds(value: unknown): string[] {
+  if (value === undefined) return [];
+  if (
+    !Array.isArray(value) ||
+    value.length > TURN_SKILL_ID_MAX_COUNT ||
+    value.some(
+      (id) =>
+        typeof id !== 'string' ||
+        id.length === 0 ||
+        id.length > TURN_SKILL_ID_MAX_LENGTH ||
+        !/^[A-Za-z0-9][A-Za-z0-9._-]*(?::[A-Za-z0-9][A-Za-z0-9._-]*)*$/.test(id),
+    )
+  ) {
+    throw invalidProtocolFrame('Invalid Turn skillIds');
+  }
+  return [...value];
 }
 
 function decodeTurnOrchestration(value: unknown): TurnOrchestration {
@@ -285,14 +308,14 @@ function decodeTurnOrchestration(value: unknown): TurnOrchestration {
   return { mode: record.mode, source: record.source };
 }
 
-export function decodeMessageContent(value: unknown): MessageContent {
+export function decodeMessageContent(value: unknown, allowEmptyText = false): MessageContent {
   let content: MessageContent;
   try {
     content = decodeCanonicalMessageContent(value);
   } catch {
     throw invalidProtocolFrame('Invalid Message content');
   }
-  requireUtf8String(content.text, 'Message text', TURN_MESSAGE_TEXT_MAX_BYTES, false);
+  requireUtf8String(content.text, 'Message text', TURN_MESSAGE_TEXT_MAX_BYTES, allowEmptyText);
   if (content.displayText !== undefined) {
     requireUtf8String(
       content.displayText,

--- a/packages/runtime-host/src/server/artifact-coordinator.ts
+++ b/packages/runtime-host/src/server/artifact-coordinator.ts
@@ -1,12 +1,18 @@
+import { createHash } from 'node:crypto';
+import { attachmentKindFromMimeType } from '@maka/core/attachments';
+import type { AttachmentRef } from '@maka/core/events';
 import type { ArtifactRecord } from '@maka/core/artifacts';
 import {
   authenticateInteractiveArtifactStoreWriter,
+  sanitizeArtifactName,
   type InteractiveArtifactStoreWriter,
 } from '@maka/storage/artifact-stores';
 import {
   ARTIFACT_PAGE_MAX_ITEMS,
   ARTIFACT_PREVIEW_MAX_BYTES,
   ARTIFACT_RESULT_MAX_BYTES,
+  type ArtifactIngestInput,
+  type ArtifactIngestResult,
   encodeArtifactDeleteResult,
   encodeArtifactQueryResult,
   type ArtifactProjection,
@@ -19,10 +25,24 @@ import { encodeArtifactProjection } from '../protocol/artifact.js';
 import type { ArtifactOperationHandlerMap } from './operation-dispatcher.js';
 import { SessionAdmissionGate } from './session-admission-gate.js';
 import type { SessionPresenceReader } from './session-presence.js';
+import { ConnectionBoundChunkUploads } from './connection-bound-chunk-uploads.js';
+
+const MAX_ACTIVE_ARTIFACT_UPLOADS = 16;
+const MAX_STAGED_ARTIFACT_UPLOAD_BYTES = 128 * 1024 * 1024;
+const ARTIFACT_UPLOAD_TTL_MS = 5 * 60 * 1000;
+
+interface ArtifactUploadMetadata {
+  readonly attachmentKind: AttachmentRef['kind'];
+  readonly name: string;
+  readonly mimeType: string;
+  readonly contentSha256: `sha256:${string}`;
+}
 
 /** Session-scoped Host projection and deletion authority for Artifacts. */
 export class HostArtifactCoordinator {
   readonly handlers: ArtifactOperationHandlerMap = {
+    'artifact.ingest': (input, context) =>
+      this.#sessionAdmission.run(input.sessionId, () => this.#ingest(input, context)),
     'artifact.query': (input) =>
       this.#sessionAdmission.run(input.sessionId, () => this.#query(input)),
     'artifact.delete': (input) =>
@@ -33,17 +53,241 @@ export class HostArtifactCoordinator {
   readonly #requestDrain: () => void;
   readonly #sessionAdmission: SessionAdmissionGate;
   readonly #sessions: SessionPresenceReader;
+  readonly #uploads: ConnectionBoundChunkUploads<ArtifactUploadMetadata>;
 
   constructor(
     store: InteractiveArtifactStoreWriter,
     requestDrain: () => void,
     sessionAdmission: SessionAdmissionGate,
     sessions: SessionPresenceReader,
+    now: () => number = Date.now,
   ) {
     this.#store = authenticateInteractiveArtifactStoreWriter(store);
     this.#requestDrain = requestDrain;
     this.#sessionAdmission = sessionAdmission;
     this.#sessions = sessions;
+    this.#uploads = new ConnectionBoundChunkUploads(
+      {
+        maxActive: MAX_ACTIVE_ARTIFACT_UPLOADS,
+        maxStagedBytes: MAX_STAGED_ARTIFACT_UPLOAD_BYTES,
+        ttlMs: ARTIFACT_UPLOAD_TTL_MS,
+      },
+      now,
+    );
+  }
+
+  releaseConnection(connectionId: string): void {
+    this.#uploads.releaseConnection(connectionId);
+  }
+
+  async validateTurnAttachments(
+    sessionId: string,
+    attachments: readonly AttachmentRef[],
+  ): Promise<string | undefined> {
+    for (const attachment of attachments) {
+      if (attachment.ref.kind !== 'session_file') {
+        return 'Hosted Turn attachments must use a Session Artifact reference';
+      }
+      if (attachment.ref.sessionId !== sessionId) {
+        return 'Attachment belongs to a different Session';
+      }
+      const entry = await this.#store.getInSession(sessionId, attachment.ref.relativePath);
+      const record = entry.record;
+      if (!record || record.status !== 'live') return 'Attachment Artifact was not found';
+      if (
+        record.name !== attachment.name ||
+        record.mimeType !== attachment.mimeType ||
+        record.sizeBytes !== attachment.bytes
+      ) {
+        return 'Attachment metadata does not match its canonical Artifact';
+      }
+      const canonicalKind = attachmentKindFromMimeType(record.mimeType, record.name);
+      if (
+        attachment.kind !== canonicalKind ||
+        (canonicalKind === 'image' && record.kind !== 'image') ||
+        (canonicalKind === 'pdf' && record.kind !== 'pdf') ||
+        (record.kind === 'image' && canonicalKind !== 'image') ||
+        (record.kind === 'pdf' && canonicalKind !== 'pdf')
+      ) {
+        return 'Attachment kind does not match its canonical Artifact';
+      }
+    }
+    return undefined;
+  }
+
+  async #ingest(
+    input: ArtifactIngestInput,
+    context: { hostEpoch: string; connectionId: string },
+  ): Promise<OperationOutcome<'artifact.ingest'>> {
+    try {
+      if ((await this.#sessions.probeSessionRemoval(input.sessionId)).kind !== 'present') {
+        return ingestFailure('not_found', 'Session was not found');
+      }
+      switch (input.kind) {
+        case 'begin':
+          return await this.#beginIngest(input, context);
+        case 'chunk':
+          return this.#acceptIngestChunk(input, context);
+        case 'abort':
+          return this.#abortIngest(input, context);
+        case 'commit':
+          return await this.#commitIngest(input, context);
+      }
+    } catch {
+      this.#requestDrain();
+      return ingestFailure('persistence_failed', 'Attachment publication failed');
+    }
+  }
+
+  async #beginIngest(
+    input: Extract<ArtifactIngestInput, { kind: 'begin' }>,
+    context: { hostEpoch: string; connectionId: string },
+  ): Promise<OperationOutcome<'artifact.ingest'>> {
+    const name = sanitizeArtifactName(input.name);
+    const attachmentKind = attachmentKindFromMimeType(input.mimeType, name);
+    const committed = await this.#readCommittedUpload(input.sessionId, input.uploadId);
+    if (committed.kind === 'conflict') {
+      return ingestFailure('operation_conflict', 'Upload identity belongs to another Artifact');
+    }
+    if (committed.kind === 'committed') {
+      if (
+        !uploadMatchesRecord(input, committed.record) ||
+        committed.record.summary !== input.contentSha256
+      ) {
+        return ingestFailure('operation_conflict', 'Upload identity was already committed');
+      }
+      return ingestSuccess(committedUploadResult(input.uploadId, committed.record));
+    }
+
+    const opened = this.#uploads.open(
+      uploadKey(input.sessionId, input.uploadId),
+      context,
+      input.totalBytes,
+      {
+        attachmentKind,
+        name,
+        mimeType: input.mimeType,
+        contentSha256: input.contentSha256,
+      },
+    );
+    if (opened.kind === 'identity_conflict') {
+      return ingestFailure('operation_conflict', 'Upload identity is already in use');
+    }
+    if (opened.kind === 'owned_existing') {
+      const existing = opened.upload;
+      if (
+        existing.metadata.attachmentKind !== attachmentKind ||
+        existing.metadata.name !== name ||
+        existing.metadata.mimeType !== input.mimeType ||
+        existing.totalBytes !== input.totalBytes ||
+        existing.metadata.contentSha256 !== input.contentSha256
+      ) {
+        return ingestFailure('operation_conflict', 'Upload identity is already in use');
+      }
+      const refreshed = this.#uploads.refreshOwned(
+        uploadKey(input.sessionId, input.uploadId),
+        context,
+      );
+      if (!refreshed) throw new Error('Owned Artifact upload disappeared during exact replay');
+      return ingestSuccess({
+        kind: 'upload_opened',
+        uploadId: input.uploadId,
+        nextOffset: refreshed.nextOffset,
+      });
+    }
+    if (opened.kind === 'capacity_exhausted') {
+      return ingestFailure('operation_conflict', 'Attachment upload capacity is exhausted');
+    }
+    return ingestSuccess({ kind: 'upload_opened', uploadId: input.uploadId, nextOffset: 0 });
+  }
+
+  #acceptIngestChunk(
+    input: Extract<ArtifactIngestInput, { kind: 'chunk' }>,
+    context: { hostEpoch: string; connectionId: string },
+  ): OperationOutcome<'artifact.ingest'> {
+    const chunk = Buffer.from(input.chunkBase64, 'base64');
+    const accepted = this.#uploads.accept(
+      uploadKey(input.sessionId, input.uploadId),
+      context,
+      input.offset,
+      chunk,
+    );
+    if (accepted.kind === 'not_found') {
+      return ingestFailure('not_found', 'Attachment upload was not found');
+    }
+    if (accepted.kind === 'conflict') {
+      return ingestFailure('operation_conflict', 'Attachment chunk offset or replay is invalid');
+    }
+    return ingestSuccess({
+      kind: 'chunk_accepted',
+      uploadId: input.uploadId,
+      nextOffset: accepted.nextOffset,
+    });
+  }
+
+  #abortIngest(
+    input: Extract<ArtifactIngestInput, { kind: 'abort' }>,
+    context: { hostEpoch: string; connectionId: string },
+  ): OperationOutcome<'artifact.ingest'> {
+    this.#uploads.abort(uploadKey(input.sessionId, input.uploadId), context);
+    return ingestSuccess({ kind: 'upload_aborted', uploadId: input.uploadId });
+  }
+
+  async #commitIngest(
+    input: Extract<ArtifactIngestInput, { kind: 'commit' }>,
+    context: { hostEpoch: string; connectionId: string },
+  ): Promise<OperationOutcome<'artifact.ingest'>> {
+    const committed = await this.#readCommittedUpload(input.sessionId, input.uploadId);
+    if (committed.kind === 'conflict') {
+      return ingestFailure('operation_conflict', 'Upload identity belongs to another Artifact');
+    }
+    if (committed.kind === 'committed') {
+      return ingestSuccess(committedUploadResult(input.uploadId, committed.record));
+    }
+    const consumed = this.#uploads.consumeComplete(
+      uploadKey(input.sessionId, input.uploadId),
+      context,
+    );
+    if (consumed.kind === 'not_found') {
+      return ingestFailure('not_found', 'Attachment upload was not found');
+    }
+    if (consumed.kind === 'incomplete') {
+      return ingestFailure('operation_conflict', 'Attachment upload is incomplete');
+    }
+    const upload = consumed.upload;
+    if (contentDigest(upload.bytes) !== upload.metadata.contentSha256) {
+      return ingestFailure('operation_conflict', 'Attachment content digest does not match');
+    }
+    const record = await this.#store.create({
+      id: artifactIdForUpload(input.sessionId, input.uploadId),
+      sessionId: input.sessionId,
+      turnId: input.uploadId,
+      name: upload.metadata.name,
+      kind: artifactKindForAttachment(upload.metadata.attachmentKind),
+      content: upload.bytes,
+      mimeType: upload.metadata.mimeType,
+      source: 'user_upload',
+      summary: upload.metadata.contentSha256,
+    });
+    return ingestSuccess(committedUploadResult(input.uploadId, record));
+  }
+
+  async #readCommittedUpload(
+    sessionId: string,
+    uploadId: string,
+  ): Promise<
+    { kind: 'missing' } | { kind: 'conflict' } | { kind: 'committed'; record: ArtifactRecord }
+  > {
+    const entry = await this.#store.getInSession(
+      sessionId,
+      artifactIdForUpload(sessionId, uploadId),
+    );
+    const record = entry.record;
+    if (!record) return { kind: 'missing' };
+    if (record.status !== 'live' || record.source !== 'user_upload' || record.turnId !== uploadId) {
+      return { kind: 'conflict' };
+    }
+    return { kind: 'committed', record };
   }
 
   async #query(input: ArtifactQueryInput): Promise<OperationOutcome<'artifact.query'>> {
@@ -244,4 +488,65 @@ function notFound<K extends 'artifact.query' | 'artifact.delete'>(
   message: string,
 ): OperationOutcome<K> {
   return { ok: false, error: { code: 'not_found', message } } as OperationOutcome<K>;
+}
+
+function uploadKey(sessionId: string, uploadId: string): string {
+  return `${sessionId}\0${uploadId}`;
+}
+
+function artifactIdForUpload(sessionId: string, uploadId: string): string {
+  return `attachment-${createHash('sha256')
+    .update(`${sessionId}\0${uploadId}`)
+    .digest('hex')
+    .slice(0, 32)}`;
+}
+
+function contentDigest(bytes: Uint8Array): `sha256:${string}` {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+function artifactKindForAttachment(kind: AttachmentRef['kind']): ArtifactRecord['kind'] {
+  if (kind === 'image') return 'image';
+  if (kind === 'pdf') return 'pdf';
+  return 'file';
+}
+
+function committedUploadResult(uploadId: string, record: ArtifactRecord): ArtifactIngestResult {
+  if (!record.mimeType) throw new Error('Committed Attachment Artifact has no media type');
+  return {
+    kind: 'committed',
+    uploadId,
+    attachment: {
+      kind: attachmentKindFromMimeType(record.mimeType, record.name),
+      name: record.name,
+      mimeType: record.mimeType,
+      bytes: record.sizeBytes,
+      ref: { kind: 'session_file', sessionId: record.sessionId, relativePath: record.id },
+    },
+  };
+}
+
+function uploadMatchesRecord(
+  upload: Extract<ArtifactIngestInput, { kind: 'begin' }>,
+  record: ArtifactRecord,
+): boolean {
+  const name = sanitizeArtifactName(upload.name);
+  const attachmentKind = attachmentKindFromMimeType(upload.mimeType, name);
+  return (
+    record.name === name &&
+    record.mimeType === upload.mimeType &&
+    record.sizeBytes === upload.totalBytes &&
+    record.kind === artifactKindForAttachment(attachmentKind)
+  );
+}
+
+function ingestSuccess(result: ArtifactIngestResult): OperationOutcome<'artifact.ingest'> {
+  return { ok: true, result };
+}
+
+function ingestFailure(
+  code: 'invalid_request' | 'not_found' | 'operation_conflict' | 'persistence_failed',
+  message: string,
+): OperationOutcome<'artifact.ingest'> {
+  return { ok: false, error: { code, message } };
 }

--- a/packages/runtime-host/src/server/connection-bound-chunk-uploads.ts
+++ b/packages/runtime-host/src/server/connection-bound-chunk-uploads.ts
@@ -1,0 +1,172 @@
+export interface ChunkUploadOwner {
+  readonly hostEpoch: string;
+  readonly connectionId: string;
+}
+
+export interface ConnectionBoundChunkUpload<TMetadata> {
+  readonly owner: ChunkUploadOwner;
+  readonly totalBytes: number;
+  readonly metadata: TMetadata;
+  readonly bytes: Buffer;
+  readonly nextOffset: number;
+}
+
+interface MutableChunkUpload<TMetadata> {
+  readonly owner: ChunkUploadOwner;
+  readonly totalBytes: number;
+  readonly metadata: TMetadata;
+  readonly bytes: Buffer;
+  nextOffset: number;
+  touchedAt: number;
+}
+
+type OpenResult<TMetadata> =
+  | { readonly kind: 'opened'; readonly upload: ConnectionBoundChunkUpload<TMetadata> }
+  | { readonly kind: 'owned_existing'; readonly upload: ConnectionBoundChunkUpload<TMetadata> }
+  | { readonly kind: 'identity_conflict' }
+  | { readonly kind: 'capacity_exhausted' };
+
+type AcceptResult =
+  | { readonly kind: 'accepted'; readonly nextOffset: number }
+  | { readonly kind: 'not_found' }
+  | { readonly kind: 'conflict' };
+
+type ConsumeResult<TMetadata> =
+  | { readonly kind: 'taken'; readonly upload: ConnectionBoundChunkUpload<TMetadata> }
+  | { readonly kind: 'not_found' }
+  | { readonly kind: 'incomplete' };
+
+/** Shared bounded staging for connection-affine chunk protocols. */
+export class ConnectionBoundChunkUploads<TMetadata> {
+  readonly #uploads = new Map<string, MutableChunkUpload<TMetadata>>();
+
+  constructor(
+    private readonly limits: {
+      readonly maxActive: number;
+      readonly maxStagedBytes: number;
+      readonly ttlMs: number;
+    },
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  open(
+    key: string,
+    owner: ChunkUploadOwner,
+    totalBytes: number,
+    metadata: TMetadata,
+  ): OpenResult<TMetadata> {
+    this.sweepExpired();
+    const existing = this.#uploads.get(key);
+    if (existing) {
+      if (!ownedBy(existing, owner)) return { kind: 'identity_conflict' };
+      return { kind: 'owned_existing', upload: snapshot(existing) };
+    }
+    if (
+      this.#uploads.size >= this.limits.maxActive ||
+      this.#stagedBytes() + totalBytes > this.limits.maxStagedBytes
+    ) {
+      return { kind: 'capacity_exhausted' };
+    }
+    const upload: MutableChunkUpload<TMetadata> = {
+      owner: { hostEpoch: owner.hostEpoch, connectionId: owner.connectionId },
+      totalBytes,
+      metadata,
+      bytes: Buffer.alloc(totalBytes),
+      nextOffset: 0,
+      touchedAt: this.now(),
+    };
+    this.#uploads.set(key, upload);
+    return { kind: 'opened', upload: snapshot(upload) };
+  }
+
+  accept(key: string, owner: ChunkUploadOwner, offset: number, chunk: Buffer): AcceptResult {
+    this.sweepExpired();
+    const upload = this.#owned(key, owner);
+    if (!upload) return { kind: 'not_found' };
+    const end = offset + chunk.byteLength;
+    if (end > upload.totalBytes || offset > upload.nextOffset) return { kind: 'conflict' };
+    if (offset < upload.nextOffset) {
+      if (end > upload.nextOffset || !upload.bytes.subarray(offset, end).equals(chunk)) {
+        return { kind: 'conflict' };
+      }
+    } else {
+      chunk.copy(upload.bytes, offset);
+      upload.nextOffset = end;
+    }
+    upload.touchedAt = this.now();
+    return { kind: 'accepted', nextOffset: upload.nextOffset };
+  }
+
+  consumeComplete(key: string, owner: ChunkUploadOwner): ConsumeResult<TMetadata> {
+    this.sweepExpired();
+    const upload = this.#owned(key, owner);
+    if (!upload) return { kind: 'not_found' };
+    if (upload.nextOffset !== upload.totalBytes) return { kind: 'incomplete' };
+    this.#uploads.delete(key);
+    return { kind: 'taken', upload: snapshot(upload) };
+  }
+
+  refreshOwned(
+    key: string,
+    owner: ChunkUploadOwner,
+  ): ConnectionBoundChunkUpload<TMetadata> | undefined {
+    this.sweepExpired();
+    const upload = this.#owned(key, owner);
+    if (!upload) return undefined;
+    upload.touchedAt = this.now();
+    return snapshot(upload);
+  }
+
+  abort(key: string, owner: ChunkUploadOwner): void {
+    if (this.#owned(key, owner)) this.#uploads.delete(key);
+  }
+
+  releaseConnection(connectionId: string): void {
+    for (const [key, upload] of this.#uploads) {
+      if (upload.owner.connectionId === connectionId) this.#uploads.delete(key);
+    }
+  }
+
+  clear(): void {
+    this.#uploads.clear();
+  }
+
+  sweepExpired(): void {
+    const cutoff = this.now() - this.limits.ttlMs;
+    for (const [key, upload] of this.#uploads) {
+      if (upload.touchedAt <= cutoff) this.#uploads.delete(key);
+    }
+  }
+
+  #owned(key: string, owner: ChunkUploadOwner): MutableChunkUpload<TMetadata> | undefined {
+    const upload = this.#uploads.get(key);
+    return upload && ownedBy(upload, owner) ? upload : undefined;
+  }
+
+  #stagedBytes(): number {
+    let total = 0;
+    for (const upload of this.#uploads.values()) total += upload.totalBytes;
+    return total;
+  }
+}
+
+function ownedBy<TMetadata>(
+  upload: MutableChunkUpload<TMetadata>,
+  owner: ChunkUploadOwner,
+): boolean {
+  return (
+    upload.owner.hostEpoch === owner.hostEpoch && upload.owner.connectionId === owner.connectionId
+  );
+}
+
+function snapshot<TMetadata>(
+  upload: MutableChunkUpload<TMetadata>,
+): ConnectionBoundChunkUpload<TMetadata> {
+  return {
+    owner: upload.owner,
+    totalBytes: upload.totalBytes,
+    metadata: upload.metadata,
+    bytes: upload.bytes,
+    nextOffset: upload.nextOffset,
+  };
+}

--- a/packages/runtime-host/src/server/execution-artifacts.ts
+++ b/packages/runtime-host/src/server/execution-artifacts.ts
@@ -1,0 +1,159 @@
+import { createHash } from 'node:crypto';
+import { open, realpath, stat } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
+import { MAX_ATTACHMENT_BYTES } from '@maka/core/attachments';
+import {
+  isPathInside,
+  stableToolResultArchiveArtifactId,
+  type ToolArtifactRecorderInput,
+  type ToolResultArchiveReaderInput,
+  type ToolResultArchiveReadResult,
+  type ToolResultArchiveRecorderInput,
+  type ToolResultArchiveResourceReadInput,
+} from '@maka/runtime';
+import type { InteractiveArtifactStoreWriter } from '@maka/storage/artifact-stores';
+
+export interface HostExecutionArtifactServices {
+  recordToolArtifacts(event: ToolArtifactRecorderInput): Promise<void>;
+  archiveToolResult(event: ToolResultArchiveRecorderInput): Promise<{ artifactId: string }>;
+  readToolResultArchive(event: ToolResultArchiveReaderInput): Promise<ToolResultArchiveReadResult>;
+  readArchivedToolResultResource(
+    event: ToolResultArchiveResourceReadInput,
+  ): Promise<ToolResultArchiveReadResult>;
+}
+
+export function createHostExecutionArtifactServices(input: {
+  artifacts: InteractiveArtifactStoreWriter;
+  requestDrain: () => void;
+}): HostExecutionArtifactServices {
+  const runWrite = async <T>(operation: () => Promise<T>): Promise<T> => {
+    try {
+      return await operation();
+    } catch (error) {
+      input.requestDrain();
+      throw error;
+    }
+  };
+
+  const services: HostExecutionArtifactServices = {
+    recordToolArtifacts: async (event: ToolArtifactRecorderInput) => {
+      for (const candidate of event.candidates) {
+        let content = candidate.content;
+        if (content === undefined && candidate.sourcePath) {
+          content = (await readBoundedSourceFile(event.cwd, candidate.sourcePath)) ?? undefined;
+        }
+        if (content === undefined || contentBytes(content) > MAX_ATTACHMENT_BYTES) continue;
+        await runWrite(() =>
+          input.artifacts.create({
+            sessionId: event.sessionId,
+            turnId: event.turnId,
+            name: candidate.name,
+            kind: candidate.kind,
+            content,
+            ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+            source: candidate.source ?? 'tool_result',
+            ...(candidate.summary ? { summary: candidate.summary } : {}),
+          }),
+        );
+      }
+    },
+    archiveToolResult: (event: ToolResultArchiveRecorderInput) =>
+      runWrite(async () => {
+        const artifactId = stableToolResultArchiveArtifactId(event);
+        const existing = await input.artifacts.getInSession(event.sessionId, artifactId);
+        if (existing.record?.status === 'live') {
+          const read = await readArchive(input.artifacts, {
+            artifactId,
+            sessionId: event.sessionId,
+            bodySha256: event.bodySha256,
+            originalBytes: event.originalBytes,
+            maxBytes: event.originalBytes,
+          });
+          if (!read.ok) {
+            throw new Error(`Tool result archive identity conflict: ${read.reason}`);
+          }
+          return { artifactId };
+        }
+        const artifact = await input.artifacts.create({
+          id: artifactId,
+          sessionId: event.sessionId,
+          turnId: event.turnId,
+          name: `archived-${event.toolName}-${event.runtimeEventId}.json`,
+          kind: 'file',
+          content: event.serializedResult,
+          mimeType: 'application/json',
+          source: 'tool_result_archive',
+          summary: `Archived ${event.toolName} tool result for context budget replay`,
+        });
+        return { artifactId: artifact.id };
+      }),
+    readToolResultArchive: (event: ToolResultArchiveReaderInput) =>
+      readArchive(input.artifacts, event),
+    readArchivedToolResultResource: (event: ToolResultArchiveResourceReadInput) =>
+      readArchive(input.artifacts, event),
+  };
+  return Object.freeze(services);
+}
+
+async function readBoundedSourceFile(cwd: string, sourcePath: string): Promise<Buffer | null> {
+  const candidate = isAbsolute(sourcePath) ? sourcePath : resolve(cwd, sourcePath);
+  let root: string;
+  let target: string;
+  try {
+    [root, target] = await Promise.all([realpath(cwd), realpath(candidate)]);
+  } catch {
+    return null;
+  }
+  if (!isPathInside(root, target)) return null;
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(target, 'r');
+    const opened = await handle.stat();
+    if (!opened.isFile() || opened.size > MAX_ATTACHMENT_BYTES) return null;
+    const currentTarget = await realpath(target);
+    if (!isPathInside(root, currentTarget)) return null;
+    const current = await stat(currentTarget);
+    if (current.dev !== opened.dev || current.ino !== opened.ino) return null;
+    const bytes = Buffer.allocUnsafe(opened.size);
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const read = await handle.read(bytes, offset, bytes.byteLength - offset, offset);
+      if (read.bytesRead === 0) break;
+      offset += read.bytesRead;
+    }
+    return offset === bytes.byteLength ? bytes : bytes.subarray(0, offset);
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+function contentBytes(content: string | Uint8Array): number {
+  return typeof content === 'string' ? Buffer.byteLength(content, 'utf8') : content.byteLength;
+}
+
+async function readArchive(
+  artifacts: InteractiveArtifactStoreWriter,
+  event: Pick<
+    ToolResultArchiveReaderInput,
+    'artifactId' | 'sessionId' | 'bodySha256' | 'originalBytes' | 'maxBytes'
+  >,
+): Promise<ToolResultArchiveReadResult> {
+  const entry = await artifacts.getInSession(event.sessionId, event.artifactId);
+  const record = entry.record;
+  if (!record) return { ok: false, reason: 'not_found' };
+  if (record.status === 'deleted') return { ok: false, reason: 'deleted' };
+  if (record.source !== 'tool_result_archive') return { ok: false, reason: 'source_mismatch' };
+  if (record.sizeBytes !== event.originalBytes) return { ok: false, reason: 'size_mismatch' };
+  const read = await artifacts.readTextInSession(event.sessionId, event.artifactId, {
+    maxBytes: event.maxBytes ?? event.originalBytes,
+  });
+  if (!read.ok) return read;
+  if (sha256(read.text) !== event.bodySha256) return { ok: false, reason: 'corrupt' };
+  return { ok: true, serializedResult: read.text };
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -5,6 +5,7 @@ import {
   AgentGraphSupervisorWakeCoordinator,
   agentGraphIdForRootSession,
   BackendRegistry,
+  buildHostCapabilitiesFromBinding,
   createLocalContinuationSafetyInspector,
   createBuiltinSandboxManager,
   createFilesystemWorkerLaunchSpecProvider,
@@ -12,6 +13,7 @@ import {
   FilesystemWorkerClient,
   isOAuthEnrollmentProviderEnabled,
   isBuiltinFilesystemWorkerSandboxAvailable,
+  prepareSkillInvocationMessageFromInventory,
   SessionManager,
   SessionActivityRegistry,
   ShellRunProcessManager,
@@ -81,6 +83,7 @@ import { SkillCatalogRepository } from './skill-catalog-repository.js';
 import { HostTaskLedgerCoordinator } from './task-ledger-coordinator.js';
 import { HostUsagePricingCoordinator } from './usage-pricing-coordinator.js';
 import { createHostWebSearchTool } from './web-search-tool.js';
+import { createHostExecutionArtifactServices } from './execution-artifacts.js';
 
 export async function createExecutionRuntimeHostComposition(
   context: RuntimeHostCompositionContext,
@@ -167,9 +170,14 @@ export async function createExecutionRuntimeHostComposition(
       acquireResidency: context.acquireResidency,
       requestDrain: context.requestDrain,
     });
+    const executionArtifacts = createHostExecutionArtifactServices({
+      artifacts: openedArtifactStore,
+      requestDrain: context.requestDrain,
+    });
     const builtinTools = {
       shellRuns: runtimeResources,
       runtimeResources,
+      archiveResources: executionArtifacts,
       backgroundTasks: runtimeResources,
       ptyControls: runtimeResources,
       snapshotImage: createReadImageSnapshotter(openedArtifactStore),
@@ -310,6 +318,7 @@ export async function createExecutionRuntimeHostComposition(
         memory: requireMemory(memory),
         taskLedger,
         artifacts: openedArtifactStore,
+        executionArtifacts,
         usage: openedUsageStores,
         clientCapabilities: requireClientCapabilities(clientCapabilities),
         automationTool: requireAutomationCoordinator(automations).modelTool,
@@ -335,6 +344,28 @@ export async function createExecutionRuntimeHostComposition(
       stopSession: (sessionId, input) =>
         requireRootCoordinator(rootCoordinator).stopSession(sessionId, input),
     };
+    const resolveAvailableToolNames = async (sessionId: string): Promise<string[]> => {
+      const capabilitySnapshot =
+        requireClientCapabilities(clientCapabilities).snapshotForSession(sessionId);
+      try {
+        const graphTools =
+          await requireGraphCoordinator(graphCoordinator).toolsForSession(sessionId);
+        return createHostExecutionModelComposition({
+          policy: runtimePolicyStores.runtimePolicy,
+          skills,
+          memory: requireMemory(memory),
+          taskLedger,
+          ...(capabilitySnapshot ? { clientCapabilities: capabilitySnapshot } : {}),
+          builtinTools,
+          hostTools: [...hostTools, ...graphTools],
+          automationTool: requireAutomationCoordinator(automations).modelTool,
+          goalTools: requireGoal(goal).tools,
+          parentAgentTools: childAgentTools.parentTools,
+        }).tools.map((tool) => tool.name);
+      } finally {
+        capabilitySnapshot?.release();
+      }
+    };
     manager = new SessionManager({
       store: stores.sessionStore,
       runStore: stores.agentRunStore,
@@ -348,28 +379,7 @@ export async function createExecutionRuntimeHostComposition(
         readSessionCwd: async (sessionId) =>
           (await stores.sessionStore.readHeaderSnapshot(sessionId)).cwd,
         resolveWorkspaceIdentity: async (cwd) => resolveWorkspaceIdentity({ path: cwd }),
-        listAvailableToolNames: async (sessionId) => {
-          const capabilitySnapshot =
-            requireClientCapabilities(clientCapabilities).snapshotForSession(sessionId);
-          try {
-            const graphTools =
-              await requireGraphCoordinator(graphCoordinator).toolsForSession(sessionId);
-            return createHostExecutionModelComposition({
-              policy: runtimePolicyStores.runtimePolicy,
-              skills,
-              memory: requireMemory(memory),
-              taskLedger,
-              ...(capabilitySnapshot ? { clientCapabilities: capabilitySnapshot } : {}),
-              builtinTools,
-              hostTools: [...hostTools, ...graphTools],
-              automationTool: requireAutomationCoordinator(automations).modelTool,
-              goalTools: requireGoal(goal).tools,
-              parentAgentTools: childAgentTools.parentTools,
-            }).tools.map((tool) => tool.name);
-          } finally {
-            capabilitySnapshot?.release();
-          }
-        },
+        listAvailableToolNames: resolveAvailableToolNames,
         hasPendingBackgroundOperations: async (sessionId) => {
           const graph = requireGraphCoordinator(graphCoordinator);
           const graphWake = requireGraphSupervisorWake(graphSupervisorWake);
@@ -484,6 +494,12 @@ export async function createExecutionRuntimeHostComposition(
       // The authority read behind Usage read-model repair (#1679).
       (sessionId, runId) => stores.agentRunStore.readEvents(sessionId, runId),
     );
+    const artifacts = new HostArtifactCoordinator(
+      openedArtifactStore,
+      context.requestDrain,
+      sessionAdmission,
+      stores.sessionStore,
+    );
     rootCoordinator = new RootTurnCoordinator(
       manager,
       stores,
@@ -497,6 +513,20 @@ export async function createExecutionRuntimeHostComposition(
       clientCapabilities,
       () => requireGoal(goal),
       (admission) => requireAutomationCoordinator(automations).assertRecoveryAdmission(admission),
+      artifacts,
+      async ({ sessionId, text, skillIds }) => {
+        const header = await stores.sessionStore.readHeaderSnapshot(sessionId);
+        const [inventory, toolNames] = await Promise.all([
+          skills.readCanonicalModelInventory({ projectRoot: header.cwd }),
+          resolveAvailableToolNames(sessionId),
+        ]);
+        return prepareSkillInvocationMessageFromInventory({
+          text,
+          skillIds,
+          inventory: inventory.inventory,
+          host: buildHostCapabilitiesFromBinding(toolNames),
+        });
+      },
     );
     const coordinator = rootCoordinator;
     graphSupervisorWake = new AgentGraphSupervisorWakeCoordinator({
@@ -636,12 +666,6 @@ export async function createExecutionRuntimeHostComposition(
       worktrees: worktreeChildExecutor,
       requestDrain: context.requestDrain,
     });
-    const artifacts = new HostArtifactCoordinator(
-      openedArtifactStore,
-      context.requestDrain,
-      sessionAdmission,
-      stores.sessionStore,
-    );
     const handlers = {
       ...coordinator.handlers,
       ...requireGoal(goal).handlers,
@@ -854,6 +878,7 @@ export async function createExecutionRuntimeHostComposition(
       continuity: continuityCoordinator,
       clientCapabilities,
       releaseConnection: (connectionId: string) => {
+        artifacts.releaseConnection(connectionId);
         requireMemory(memory).releaseConnection(connectionId);
         clientCapabilities?.releaseConnection(connectionId);
         runtimeResources?.releaseConnection(connectionId);

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -72,6 +72,7 @@ import {
   type HostOAuthExecutionBinding,
 } from './oauth-execution-authority.js';
 import type { HostChildAgentBackendCapabilities } from './child-agent-composition.js';
+import type { HostExecutionArtifactServices } from './execution-artifacts.js';
 import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
 
 const CHILD_INSTRUCTION_BOUNDARY = [
@@ -215,6 +216,7 @@ export interface HostAiSdkBackendInput {
   readonly memory: HostMemoryCoordinator;
   readonly taskLedger: TaskLedgerStore;
   readonly artifacts: InteractiveArtifactStoreWriter;
+  readonly executionArtifacts: HostExecutionArtifactServices;
   readonly usage: InteractiveUsageStoresWriter;
   readonly requestDrain: () => void;
   readonly clientCapabilities: HostClientCapabilityCoordinator;
@@ -623,6 +625,9 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
           artifactStore: input.artifacts,
           sessionId: input.context.sessionId,
         }),
+        recordToolArtifacts: input.executionArtifacts.recordToolArtifacts,
+        archiveToolResult: input.executionArtifacts.archiveToolResult,
+        readToolResultArchive: input.executionArtifacts.readToolResultArchive,
         loadHistoryCompactCheckpoint: input.context.loadHistoryCompactCheckpoint,
         summarizeHistoryCompact: buildLlmHistorySummarizer({
           resolveModel: () =>

--- a/packages/runtime-host/src/server/memory-coordinator.ts
+++ b/packages/runtime-host/src/server/memory-coordinator.ts
@@ -42,6 +42,7 @@ import {
 import { MemoryProjectionError, projectMemoryQuery } from './memory-projection.js';
 import type { ConnectionContext, MemoryOperationHandlerMap } from './operation-dispatcher.js';
 import { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js';
+import { ConnectionBoundChunkUploads } from './connection-bound-chunk-uploads.js';
 
 const PENDING_DOCUMENT_DEFAULT = '# Maka Pending Memory\n';
 const MAX_ACTIVE_UPLOADS = 8;
@@ -64,15 +65,9 @@ export interface HostMemoryCoordinatorDeps {
   readonly newId?: () => string;
 }
 
-interface UploadState {
-  readonly hostEpoch: string;
-  readonly connectionId: string;
+interface MemoryUploadMetadata {
   readonly expectedRevision: MemoryRevision;
-  readonly totalBytes: number;
   readonly contentSha256: MemoryRevision;
-  readonly bytes: Buffer;
-  nextOffset: number;
-  touchedAt: number;
 }
 
 /** Canonical Runtime Host authority for the transparent Memory bundle. */
@@ -88,7 +83,7 @@ export class HostMemoryCoordinator {
   readonly #requestDrain: () => void;
   readonly #now: () => number;
   readonly #newId: () => string;
-  readonly #uploads = new Map<string, UploadState>();
+  readonly #uploads: ConnectionBoundChunkUploads<MemoryUploadMetadata>;
   readonly #acceptedMutations = new Set<Promise<void>>();
   #policyAccess: 'enabled' | 'disabled' | 'incognito_active' | undefined;
   #draining = false;
@@ -101,6 +96,14 @@ export class HostMemoryCoordinator {
     this.#requestDrain = deps.requestDrain ?? (() => {});
     this.#now = deps.now ?? Date.now;
     this.#newId = deps.newId ?? randomUUID;
+    this.#uploads = new ConnectionBoundChunkUploads(
+      {
+        maxActive: MAX_ACTIVE_UPLOADS,
+        maxStagedBytes: MAX_STAGED_UPLOAD_BYTES,
+        ttlMs: UPLOAD_TTL_MS,
+      },
+      this.#now,
+    );
   }
 
   async recover(): Promise<void> {
@@ -129,9 +132,7 @@ export class HostMemoryCoordinator {
   }
 
   releaseConnection(connectionId: string): void {
-    for (const [uploadId, upload] of this.#uploads) {
-      if (upload.connectionId === connectionId) this.#uploads.delete(uploadId);
-    }
+    this.#uploads.releaseConnection(connectionId);
   }
 
   readPromptProjection(sessionId: string): Promise<HostMemoryPromptProjection> {
@@ -198,7 +199,7 @@ export class HostMemoryCoordinator {
     if (this.#draining) return hostDraining();
     const accepted = this.#activation.runMutation(async () => {
       try {
-        this.#sweepExpiredUploads();
+        this.#uploads.sweepExpired();
         const policy = await this.#runtimePolicyStores.runtimePolicy.getSnapshot();
         const blocked = blockedByPolicy(policy.policy);
         if (blocked) {
@@ -245,26 +246,18 @@ export class HostMemoryCoordinator {
     if (snapshot.revision !== input.expectedRevision) {
       return revisionConflict(input.expectedRevision, snapshot.revision);
     }
-    if (
-      this.#uploads.size >= MAX_ACTIVE_UPLOADS ||
-      this.#stagedByteCapacity() + input.totalBytes > MAX_STAGED_UPLOAD_BYTES
-    ) {
-      return rejected('upload_conflict');
-    }
     const uploadId = this.#newId();
-    if (!/^[A-Za-z0-9_-]{1,128}$/.test(uploadId) || this.#uploads.has(uploadId)) {
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(uploadId)) {
       throw new Error('Memory upload id generator returned an invalid or duplicate id');
     }
-    this.#uploads.set(uploadId, {
-      hostEpoch: context.hostEpoch,
-      connectionId: context.connectionId,
+    const opened = this.#uploads.open(uploadId, context, input.totalBytes, {
       expectedRevision: input.expectedRevision,
-      totalBytes: input.totalBytes,
       contentSha256: input.contentSha256,
-      bytes: Buffer.alloc(input.totalBytes),
-      nextOffset: 0,
-      touchedAt: this.#now(),
     });
+    if (opened.kind === 'capacity_exhausted') return rejected('upload_conflict');
+    if (opened.kind === 'owned_existing' || opened.kind === 'identity_conflict') {
+      throw new Error('Memory upload id generator returned an invalid or duplicate id');
+    }
     return { ok: true, result: { kind: 'upload_opened', uploadId, nextOffset: 0 } };
   }
 
@@ -272,39 +265,22 @@ export class HostMemoryCoordinator {
     input: Extract<MemoryMutateInput, { kind: 'replace_chunk' }>,
     context: ConnectionContext,
   ): OperationOutcome<'memory.mutate'> {
-    const upload = this.#ownedUpload(input.uploadId, context);
-    if (!upload) return rejected('upload_not_found');
     const chunk = Buffer.from(input.chunkBase64, 'base64');
-    const end = input.offset + chunk.byteLength;
-    if (end > upload.totalBytes || input.offset > upload.nextOffset) {
-      return rejected('upload_conflict');
-    }
-    if (input.offset < upload.nextOffset) {
-      if (end > upload.nextOffset || !upload.bytes.subarray(input.offset, end).equals(chunk)) {
-        return rejected('upload_conflict');
-      }
-      upload.touchedAt = this.#now();
-      return {
-        ok: true,
-        result: {
-          kind: 'chunk_accepted',
-          uploadId: input.uploadId,
-          nextOffset: upload.nextOffset,
-        },
-      };
-    }
-    chunk.copy(upload.bytes, input.offset);
-    upload.nextOffset = end;
-    upload.touchedAt = this.#now();
+    const accepted = this.#uploads.accept(input.uploadId, context, input.offset, chunk);
+    if (accepted.kind === 'not_found') return rejected('upload_not_found');
+    if (accepted.kind === 'conflict') return rejected('upload_conflict');
     return {
       ok: true,
-      result: { kind: 'chunk_accepted', uploadId: input.uploadId, nextOffset: upload.nextOffset },
+      result: {
+        kind: 'chunk_accepted',
+        uploadId: input.uploadId,
+        nextOffset: accepted.nextOffset,
+      },
     };
   }
 
   #abortReplace(uploadId: string, context: ConnectionContext): OperationOutcome<'memory.mutate'> {
-    const upload = this.#ownedUpload(uploadId, context);
-    if (upload) this.#uploads.delete(uploadId);
+    this.#uploads.abort(uploadId, context);
     return { ok: true, result: { kind: 'upload_aborted', uploadId } };
   }
 
@@ -312,11 +288,12 @@ export class HostMemoryCoordinator {
     uploadId: string,
     context: ConnectionContext,
   ): Promise<OperationOutcome<'memory.mutate'>> {
-    const upload = this.#ownedUpload(uploadId, context);
-    if (!upload) return rejected('upload_not_found');
-    if (upload.nextOffset !== upload.totalBytes) return rejected('upload_incomplete');
-    this.#uploads.delete(uploadId);
-    if (revision(upload.bytes) !== upload.contentSha256) return rejected('invalid_content');
+    const consumed = this.#uploads.consumeComplete(uploadId, context);
+    if (consumed.kind === 'not_found') return rejected('upload_not_found');
+    if (consumed.kind === 'incomplete') return rejected('upload_incomplete');
+    const upload = consumed.upload;
+    if (revision(upload.bytes) !== upload.metadata.contentSha256)
+      return rejected('invalid_content');
 
     let content: string;
     try {
@@ -330,12 +307,12 @@ export class HostMemoryCoordinator {
       return rejected(parsed.reason === 'oversize' ? 'oversize' : 'invalid_content');
 
     const snapshot = await this.#store.read();
-    if (snapshot.revision !== upload.expectedRevision) {
-      return revisionConflict(upload.expectedRevision, snapshot.revision);
+    if (snapshot.revision !== upload.metadata.expectedRevision) {
+      return revisionConflict(upload.metadata.expectedRevision, snapshot.revision);
     }
     if (snapshot.pending.kind === 'safe_mode') return rejected('safe_mode');
     return this.#commitBundle({
-      expectedRevision: upload.expectedRevision,
+      expectedRevision: upload.metadata.expectedRevision,
       memory: encodeText(redacted),
       pending: documentBytesOrNull(snapshot.pending),
       backup: 'save',
@@ -514,13 +491,6 @@ export class HostMemoryCoordinator {
     };
   }
 
-  #ownedUpload(uploadId: string, context: ConnectionContext): UploadState | undefined {
-    const upload = this.#uploads.get(uploadId);
-    return upload?.hostEpoch === context.hostEpoch && upload.connectionId === context.connectionId
-      ? upload
-      : undefined;
-  }
-
   #trackAcceptedMutation(operation: Promise<unknown>): void {
     const completion = operation.then(
       () => undefined,
@@ -530,19 +500,6 @@ export class HostMemoryCoordinator {
     void completion.then(() => {
       this.#acceptedMutations.delete(completion);
     });
-  }
-
-  #sweepExpiredUploads(): void {
-    const cutoff = this.#now() - UPLOAD_TTL_MS;
-    for (const [uploadId, upload] of this.#uploads) {
-      if (upload.touchedAt <= cutoff) this.#uploads.delete(uploadId);
-    }
-  }
-
-  #stagedByteCapacity(): number {
-    let total = 0;
-    for (const upload of this.#uploads.values()) total += upload.totalBytes;
-    return total;
   }
 
   async #refreshForCurrentPolicy(): Promise<void> {

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -7,8 +7,10 @@ import {
   type RootExecutionDescriptor,
 } from '@maka/core/agent-run';
 import {
+  INLINE_REFERENCE_MAX_COUNT,
   messageContentsEqual,
   normalizeMessageContent,
+  type AttachmentRef,
   type MessageContent,
   type SessionEvent,
 } from '@maka/core/events';
@@ -26,7 +28,10 @@ import {
   RuntimeMessageAuthorityInvariantError,
   RuntimeRegenerateTurnError,
   RuntimeOwnerCleanupError,
+  parseSkillInvocationTokens,
+  skillInvocationInlineReferences,
   recoverAgentGraphSupervisorContextOverflow,
+  type PreparedSkillInvocationMessage,
   type RuntimeContinuation,
   type SafeBoundaryContinuationPlan,
   type RuntimeHostedRootExecutionInput,
@@ -44,6 +49,7 @@ import {
 import {
   authenticateExecutionStoresWriter,
   isSessionNotFoundError,
+  normalizeRootTurnAdmissionPayload,
   type ExecutionStoresWriter,
   type RootTurnAdmission,
 } from '@maka/storage/execution-stores';
@@ -135,13 +141,24 @@ type RootMessageStartRequest =
       readonly turnOrchestration?: TurnStartInput['turnOrchestration'];
     })
   | (RootMessageStartRequestBase & {
+      readonly execution: Extract<RootMessageExecution, { kind: 'external_message' }>;
+      readonly turnOrchestration?: TurnStartInput['turnOrchestration'];
+      prepareFreshContent(): Promise<RootMessageContentPreparation>;
+    })
+  | (RootMessageStartRequestBase & {
       readonly execution: Extract<RootMessageExecution, { kind: 'regenerate' }>;
       readonly turnOrchestration?: undefined;
       prepareContent(): Promise<MessageContent>;
     });
 
 type RootMessageContentPreparation =
-  | { readonly kind: 'ready'; readonly content: MessageContent }
+  | {
+      readonly kind: 'ready';
+      readonly content: MessageContent;
+      readonly commitCapabilityBinding?: () => Promise<
+        { readonly ok: true } | { readonly ok: false; readonly message: string }
+      >;
+    }
   | { readonly kind: 'rejected'; readonly outcome: TurnStartOutcome };
 
 type RootTurnActivationInput =
@@ -262,6 +279,22 @@ interface RecoverySessionPlan {
   pendingRecoveryClosures: readonly RootTurnAdmission[];
 }
 
+interface HostSkillInvocationPreparer {
+  (input: {
+    sessionId: string;
+    turnId: string;
+    text: string;
+    skillIds: readonly string[];
+  }): Promise<PreparedSkillInvocationMessage>;
+}
+
+interface HostTurnAttachmentValidator {
+  validateTurnAttachments(
+    sessionId: string,
+    attachments: readonly AttachmentRef[],
+  ): Promise<string | undefined>;
+}
+
 export class RootTurnCoordinator {
   readonly handlers: TurnOperationHandlerMap & ContextOperationHandlerMap = {
     'turn.start': (input, context) => this.startTurn(input, context),
@@ -278,6 +311,8 @@ export class RootTurnCoordinator {
   readonly #reservationsBySession = new Map<string, SessionRootReservation>();
   readonly #recoveryAdmissionsBySession = new Map<string, readonly RootTurnAdmission[]>();
   private readonly stores: ExecutionStoresWriter<'interactive'>;
+  private readonly attachmentValidator: HostTurnAttachmentValidator | undefined;
+  private readonly prepareSkillInvocation: HostSkillInvocationPreparer | undefined;
   #draining = false;
 
   constructor(
@@ -293,8 +328,12 @@ export class RootTurnCoordinator {
     private readonly clientCapabilities: HostClientCapabilityCoordinator | undefined,
     private readonly resolveGoal: () => HostGoalRootAuthority,
     private readonly assertAutomationRecoveryAdmission?: (admission: RootTurnAdmission) => void,
+    attachmentValidator?: HostTurnAttachmentValidator,
+    prepareSkillInvocation?: HostSkillInvocationPreparer,
   ) {
     this.stores = authenticateExecutionStoresWriter(stores, 'interactive');
+    this.attachmentValidator = attachmentValidator;
+    this.prepareSkillInvocation = prepareSkillInvocation;
   }
 
   async prepareRecovery(): Promise<void> {
@@ -1537,6 +1576,33 @@ export class RootTurnCoordinator {
 
   private startTurn(input: TurnStartInput, context: ConnectionContext): Promise<TurnStartOutcome> {
     const content = normalizeMessageContent(input.content);
+    const skillIds = input.skillIds ?? [];
+    const hasSkillInvocation =
+      skillIds.length > 0 || parseSkillInvocationTokens(content.text).length > 0;
+    if (hasSkillInvocation) {
+      const execution = {
+        kind: 'external_message' as const,
+        inputDigest: skillInvocationInputDigest(content, skillIds),
+      };
+      return this.startRootMessage(
+        {
+          sessionId: input.sessionId,
+          turnId: input.turnId,
+          execution,
+          ...(input.turnOrchestration ? { turnOrchestration: { ...input.turnOrchestration } } : {}),
+          archivedMessage: 'Cannot start a new Turn in an archived Session',
+          prepareFreshContent: () =>
+            this.prepareHostedSkillInvocationContent(
+              input.sessionId,
+              input.turnId,
+              content,
+              skillIds,
+              context.connectionId,
+            ),
+        },
+        context,
+      );
+    }
     return this.startRootMessage(
       {
         sessionId: input.sessionId,
@@ -1548,6 +1614,38 @@ export class RootTurnCoordinator {
       },
       context,
     );
+  }
+
+  private async prepareHostedSkillInvocationContent(
+    sessionId: string,
+    turnId: string,
+    content: MessageContent,
+    skillIds: readonly string[],
+    connectionId: string,
+  ): Promise<RootMessageContentPreparation> {
+    if (!this.prepareSkillInvocation) {
+      return {
+        kind: 'rejected',
+        outcome: operationUnavailable('Hosted Skill invocation authority is unavailable'),
+      };
+    }
+    const preview = await this.previewCapabilityBinding(sessionId, connectionId, () =>
+      this.prepareSkillInvocation!({ sessionId, turnId, text: content.text, skillIds }),
+    );
+    if (!preview.ok) {
+      return { kind: 'rejected', outcome: operationConflict(preview.message) };
+    }
+    if (preview.value.disposition === 'blocked') {
+      return {
+        kind: 'rejected',
+        outcome: operationConflict('Explicit Skill invocation could not be resolved'),
+      };
+    }
+    return {
+      kind: 'ready',
+      content: composeHostedSkillInvocationContent(content, preview.value),
+      commitCapabilityBinding: preview.commit,
+    };
   }
 
   private regenerateTurn(
@@ -1661,10 +1759,20 @@ export class RootTurnCoordinator {
 
         const prepared = await this.prepareRootMessageContent(request);
         if (prepared.kind === 'rejected') return completedStart(prepared.outcome);
-        const binding = await this.clientCapabilities?.bindSession(
+        const canonicalContent = preflightRootMessageContent(prepared.content);
+        if (!canonicalContent.ok) return completedStart(canonicalContent.outcome);
+        const attachments = canonicalContent.content.attachments ?? [];
+        if (attachments.length > 0 && !this.attachmentValidator) {
+          return completedStart(operationConflict('Hosted attachment authority is unavailable'));
+        }
+        const attachmentError = await this.attachmentValidator?.validateTurnAttachments(
           request.sessionId,
-          context.connectionId,
+          attachments,
         );
+        if (attachmentError) return completedStart(operationConflict(attachmentError));
+        const binding = prepared.commitCapabilityBinding
+          ? await prepared.commitCapabilityBinding()
+          : await this.clientCapabilities?.bindSession(request.sessionId, context.connectionId);
         if (binding && !binding.ok) {
           return completedStart(operationConflict(binding.message));
         }
@@ -1677,7 +1785,7 @@ export class RootTurnCoordinator {
           proposedRunId: randomUUID(),
           proposedUserMessageId: randomUUID(),
           execution: request.execution,
-          normalizedInput: prepared.content,
+          normalizedInput: canonicalContent.content,
           ...(request.turnOrchestration ? { turnOrchestration: request.turnOrchestration } : {}),
           sourceMessages: [],
           admittedAt: Date.now(),
@@ -1687,7 +1795,7 @@ export class RootTurnCoordinator {
             operationConflict('Turn identity belongs to a different execution kind'),
           );
         }
-        if (!rootMessageAdmissionMatches(admitted.admission, request, prepared.content)) {
+        if (!rootMessageAdmissionMatches(admitted.admission, request, canonicalContent.content)) {
           return completedStart(
             operationConflict('Turn identity was already admitted with a different payload'),
           );
@@ -1725,6 +1833,7 @@ export class RootTurnCoordinator {
     request: RootMessageStartRequest,
   ): Promise<RootMessageContentPreparation> {
     if ('content' in request) return { kind: 'ready', content: request.content };
+    if ('prepareFreshContent' in request) return request.prepareFreshContent();
     try {
       return { kind: 'ready', content: normalizeMessageContent(await request.prepareContent()) };
     } catch (error) {
@@ -2847,10 +2956,73 @@ function rootMessageAdmissionMatches(
 ): boolean {
   return (
     isDeepStrictEqual(admission.execution, request.execution) &&
-    messageContentsEqual(requireAdmissionMessageContent(admission), content) &&
+    (request.execution.kind === 'external_message' && request.execution.inputDigest
+      ? true
+      : messageContentsEqual(requireAdmissionMessageContent(admission), content)) &&
     isDeepStrictEqual(admission.turnOrchestration, request.turnOrchestration) &&
     admission.sourceMessages.length === 0
   );
+}
+
+function skillInvocationInputDigest(
+  content: MessageContent,
+  skillIds: readonly string[],
+): `sha256:${string}` {
+  return `sha256:${createHash('sha256')
+    .update(JSON.stringify({ content, skillIds: [...skillIds] }))
+    .digest('hex')}`;
+}
+
+function composeHostedSkillInvocationContent(
+  content: MessageContent,
+  prepared: Exclude<PreparedSkillInvocationMessage, { disposition: 'blocked' }>,
+): MessageContent {
+  if (prepared.disposition === 'passthrough') return content;
+  const displayText =
+    content.displayText ??
+    (content.text.trim().length > 0
+      ? content.text
+      : prepared.skillInvocation.loaded.map((skill) => `/skill:${skill.id}`).join(' '));
+  const skillReferences = skillInvocationInlineReferences(
+    prepared.skillInvocation.receipts,
+    displayText,
+  );
+  const candidates = [
+    ...(content.inlineReferences ?? []).filter((reference) => reference.kind !== 'skill'),
+    ...skillReferences,
+  ].sort((left, right) => left.start - right.start || right.value.length - left.value.length);
+  const inlineReferences: NonNullable<MessageContent['inlineReferences']> = [];
+  let previousEnd = 0;
+  for (const reference of candidates) {
+    if (inlineReferences.length === INLINE_REFERENCE_MAX_COUNT) break;
+    if (reference.start < previousEnd) continue;
+    inlineReferences.push(reference);
+    previousEnd = reference.start + reference.value.length;
+  }
+  return normalizeMessageContent({
+    ...content,
+    text: prepared.sendText,
+    displayText,
+    inlineReferences,
+  });
+}
+
+function preflightRootMessageContent(
+  content: MessageContent,
+):
+  | { readonly ok: true; readonly content: MessageContent }
+  | { readonly ok: false; readonly outcome: TurnStartOutcome } {
+  try {
+    return {
+      ok: true,
+      content: normalizeRootTurnAdmissionPayload(content, []).normalizedInput,
+    };
+  } catch {
+    return {
+      ok: false,
+      outcome: operationConflict('Turn content exceeds durable admission limits'),
+    };
+  }
 }
 
 function recoveryUserMessage(admission: RootTurnAdmission): RecoveryUserMessage {

--- a/packages/runtime/src/__tests__/skill-invocation.test.ts
+++ b/packages/runtime/src/__tests__/skill-invocation.test.ts
@@ -66,6 +66,27 @@ describe('skill invocation', () => {
     );
   });
 
+  it('bounds successful Skill references to canonical transcript limits', () => {
+    const receipts = Array.from({ length: 40 }, (_, index) => ({
+      invocation: 'explicit' as const,
+      request: `skill-${index}`,
+      success: true as const,
+      ref: `project:agents:skill-${index}`,
+      id: `skill-${index}`,
+      name: `${'x'.repeat(199)}😀tail`,
+      scope: 'project' as const,
+      source: 'agents' as const,
+      truncated: false,
+    }));
+    const references = skillInvocationInlineReferences(
+      receipts,
+      receipts.map((receipt) => `/skill:${receipt.id}`).join(' '),
+    );
+    assert.equal(references.length, 32);
+    assert.equal(references[0]?.label.length, 199);
+    assert.equal(references[0]?.label.endsWith('\ud83d'), false);
+  });
+
   it('lists only enabled, host-eligible skills as slim entries', async () => {
     await withWorkspace(async (workspaceRoot, homeDir) => {
       await writeSkill(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1007,6 +1007,7 @@ export {
   validateHistoryCompactBlockShape,
   validateSynthesisCacheBlockShape,
 } from './context-budget.js';
+export { stableToolResultArchiveArtifactId } from './tool-result-archive.js';
 export type {
   ArchivedToolResultReason,
   BudgetedRuntimeContext,
@@ -1663,6 +1664,7 @@ export {
   composeSkillInvocationMessage,
   parseSkillInvocationTokens,
   prepareSkillInvocationMessage,
+  prepareSkillInvocationMessageFromInventory,
   SKILL_INVOCATION_TOKEN_SOURCE,
   stripSkillInvocationTokens,
 } from './skill-invocation.js';

--- a/packages/runtime/src/skill-invocation-receipt.ts
+++ b/packages/runtime/src/skill-invocation-receipt.ts
@@ -1,4 +1,9 @@
-import { SKILL_INVOCATION_TOKEN_SOURCE, type InlineReference } from '@maka/core';
+import {
+  INLINE_REFERENCE_LABEL_MAX_LENGTH,
+  INLINE_REFERENCE_MAX_COUNT,
+  SKILL_INVOCATION_TOKEN_SOURCE,
+  type InlineReference,
+} from '@maka/core';
 import type { LoadedSkillInstructions, LoadSkillInstructionsResult } from './skills.js';
 
 export type SkillInvocationMode = 'explicit' | 'model_tool';
@@ -74,16 +79,23 @@ export function skillInvocationInlineReferences(
   }
   const references: InlineReference[] = [];
   for (const match of displayText.matchAll(new RegExp(SKILL_INVOCATION_TOKEN_SOURCE, 'g'))) {
+    if (references.length === INLINE_REFERENCE_MAX_COUNT) break;
     const receipt = receiptByTokenName.get(match[1].toLowerCase());
     if (!receipt) continue;
     references.push({
       kind: 'skill',
       value: match[0],
-      label: receipt.name,
+      label: truncateWithoutSplittingSurrogate(receipt.name, INLINE_REFERENCE_LABEL_MAX_LENGTH),
       start: match.index,
     });
   }
   return references;
+}
+
+function truncateWithoutSplittingSurrogate(value: string, maxCodeUnits: number): string {
+  const truncated = value.slice(0, maxCodeUnits);
+  const lastCodeUnit = truncated.charCodeAt(truncated.length - 1);
+  return lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? truncated.slice(0, -1) : truncated;
 }
 
 export function failedSkillInvocationReceipt(

--- a/packages/runtime/src/skill-invocation.ts
+++ b/packages/runtime/src/skill-invocation.ts
@@ -6,7 +6,7 @@ import {
   type LoadedSkillInstructions,
   type LoadSkillInstructionsResult,
 } from './skills-context.js';
-import { scanSkills, type SkillSource } from './skills-discovery.js';
+import { scanSkills, type ScannedSkill, type SkillSource } from './skills-discovery.js';
 import {
   boundSkillInvocationRequest,
   failedSkillInvocationReceipt,
@@ -220,6 +220,39 @@ export async function prepareSkillInvocationMessage(input: {
   source: SkillSource;
   host?: HostCapabilities;
 }): Promise<PreparedSkillInvocationMessage> {
+  return prepareSkillInvocation({
+    text: input.text,
+    ...(input.skillIds ? { skillIds: input.skillIds } : {}),
+    resolve: (requests) => resolveSkillInvocations(input.source, input.host, requests),
+  });
+}
+
+/** Prepare explicit invocation against one Host-owned immutable inventory read. */
+export async function prepareSkillInvocationMessageFromInventory(input: {
+  text: string;
+  skillIds?: readonly string[];
+  inventory: readonly ScannedSkill[];
+  host?: HostCapabilities;
+}): Promise<PreparedSkillInvocationMessage> {
+  const inventory = [...input.inventory];
+  return prepareSkillInvocation({
+    text: input.text,
+    ...(input.skillIds ? { skillIds: input.skillIds } : {}),
+    resolve: (requests) =>
+      Promise.resolve(
+        requests.map((request) => ({
+          request,
+          result: loadSkillInstructionsFromScan(inventory, request, input.host),
+        })),
+      ),
+  });
+}
+
+async function prepareSkillInvocation(input: {
+  text: string;
+  skillIds?: readonly string[];
+  resolve(requests: readonly string[]): Promise<SkillInvocationResolution[]>;
+}): Promise<PreparedSkillInvocationMessage> {
   const passthrough: PreparedSkillInvocationMessage = {
     disposition: 'passthrough',
     sendText: input.text,
@@ -247,7 +280,7 @@ export async function prepareSkillInvocationMessage(input: {
     new Set(tokens.map((token) => token.name.toLowerCase())),
   );
   try {
-    const resolved = await resolveSkillInvocations(input.source, input.host, requests);
+    const resolved = await input.resolve(requests);
     const loaded: LoadedSkillInstructions[] = [];
     const loadedIds = new Set<string>();
     const failures: SkillInvocationFailure[] = [];

--- a/packages/runtime/src/tool-result-archive.ts
+++ b/packages/runtime/src/tool-result-archive.ts
@@ -1,4 +1,5 @@
 import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { createHash } from 'node:crypto';
 import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
 import type {
   ArchivedToolResultSourceRef,
@@ -117,6 +118,29 @@ export type ToolResultArchiveReadResult =
 export type ToolResultArchiveReader = (
   input: ToolResultArchiveReaderInput,
 ) => Promise<ToolResultArchiveReadResult> | ToolResultArchiveReadResult;
+
+export function stableToolResultArchiveArtifactId(event: {
+  sessionId: string;
+  runtimeEventId: string;
+  toolCallId: string;
+  toolName: string;
+  bodySha256: string;
+  rewriteVersion: number;
+}): string {
+  return `tool-result-archive-${createHash('sha256')
+    .update(
+      JSON.stringify({
+        sessionId: event.sessionId,
+        runtimeEventId: event.runtimeEventId,
+        toolCallId: event.toolCallId,
+        toolName: event.toolName,
+        bodySha256: event.bodySha256,
+        rewriteVersion: event.rewriteVersion,
+      }),
+    )
+    .digest('hex')
+    .slice(0, 32)}`;
+}
 
 export interface ArchiveRetrievalResult {
   events: RuntimeEvent[];

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1368,8 +1368,11 @@ function normalizeRootExecutionDescriptor(value: unknown): RootExecutionDescript
     throw new Error('Invalid root execution descriptor');
   }
   if (value.kind === 'external_message') {
-    if (!hasExactKeys(value, ['kind'])) throw new Error('Invalid root execution descriptor');
-    return Object.freeze({ kind: 'external_message' });
+    if (hasExactKeys(value, ['kind'])) return Object.freeze({ kind: 'external_message' });
+    if (!hasExactKeys(value, ['kind', 'inputDigest']) || !isSha256Digest(value.inputDigest)) {
+      throw new Error('Invalid root execution descriptor');
+    }
+    return Object.freeze({ kind: 'external_message', inputDigest: value.inputDigest });
   }
   if (value.kind === 'regenerate') {
     if (

--- a/packages/storage/src/artifact-stores.ts
+++ b/packages/storage/src/artifact-stores.ts
@@ -8,6 +8,8 @@ import {
   type CreateArtifactInput,
   type DurableArtifactAttachmentReader,
 } from './artifact-store.js';
+
+export { sanitizeArtifactName } from './artifact-store.js';
 import {
   assertStorageRootLease,
   createStorageRootLeaseIdentityGuard,


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- resolve explicitly selected Skills in Runtime Host before fresh Turn admission while preserving exact durable retries
- add bounded, connection-scoped Artifact ingest and canonical attachment validation
- integrate hosted Tool Artifacts and oversized tool-result archive/read with the canonical Artifact authority

## Why

Input preparation and the remaining execution Artifact paths were still owned by individual clients or execution surfaces. That made equivalent clients behave differently and left retry, reconnect, and attachment trust semantics outside Runtime Host.

This change makes Runtime Host the single authority for preparing hosted inputs and publishing execution Artifacts without exposing a generic Store RPC.

## Key boundaries

- the wire protocol remains v0 and exposes only bounded domain operations
- upload staging is connection-bound, replay-safe, capacity-limited, and digest-verified
- Turn attachments must match live canonical Artifact records before admission
- fresh Skill expansion happens after Session admission checks; durable retries reuse the exact normalized input
- Tool Artifact reads enforce containment, regular-file identity, and size limits before publication

## Validation

- `npm test -w @maka/runtime-host` — 611 passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check origin/main...HEAD`

Part of #1167 and #853.

</details>

<details>
<summary><strong>中文</strong></summary>

## 概要

- 在全新 Turn admission 前由 Runtime Host 解析显式选择的 Skills，同时保持持久化重试的精确一致性
- 增加有界、绑定连接的 Artifact ingest，以及规范化附件校验
- 将 Tool Artifacts 和超大工具结果的归档/读取接入统一的 Artifact 权威路径

## 背景

输入准备和部分执行期 Artifact 路径此前仍由不同客户端或执行端分别负责，导致等价客户端可能产生不同语义，也使重试、重连和附件可信性没有统一落在 Runtime Host。

本次改动让 Runtime Host 成为托管输入准备和执行期 Artifact 发布的唯一权威，同时不开放通用 Store RPC。

## 关键边界

- wire protocol 继续保持 v0，仅暴露有界的领域操作
- 上传暂存绑定连接，支持安全重放，并限制容量且校验摘要
- Turn admission 前，附件必须与当前有效的规范 Artifact 记录完全匹配
- 全新 Turn 在 Session admission 检查后展开 Skills；持久化重试复用完全相同的规范输入
- Tool Artifact 发布前校验路径包含关系、普通文件身份和大小限制

## 验证

- `npm test -w @maka/runtime-host` — 611 项通过
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check origin/main...HEAD`

属于 #1167 和 #853 的一部分。

</details>
