### PR TITLE
fix(desktop): make the macOS dev TCC grant durable, behind an opt-in

### DIFF
--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -2,4 +2,3 @@
 test-results/
 resources/workers/
 .maka-dev/
-.maka-dev-session/

--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -2,3 +2,7 @@
 test-results/
 resources/workers/
 .maka-dev/
+.maka-dev.staging/
+# Written by the pre-opt-in dev launcher, which ran unconditionally on macOS.
+# Its session.json holds forwarded API keys, so keep ignoring any leftover copy.
+.maka-dev-session/

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -22,29 +22,43 @@ generated app is ignored by Git and rebuilt when the installed Electron version
 or this repository's path changes; run
 `npm --workspace @maka/desktop run prepare:dev-app` to prepare it explicitly.
 
-This workflow is opt-in because LaunchServices detaches the app from the
-terminal: main-process logs go to Console.app instead of your shell. It also
-costs a codesign rebuild. Developers who are not touching OS permissions should
-not pay either.
+This workflow is opt-in because it costs a codesign rebuild and puts an extra
+app in your Dock and in System Settings. Developers who are not touching OS
+permissions should not pay for it. Main-process logs are still streamed to the
+terminal — `open` redirects them to `.maka-dev/app.log`, which the launcher
+follows.
 
 Everything the bundle needs is fixed when it is built, so a launch with no
 arguments and no environment — the Dock, Spotlight, or Screen Recording's
 “Quit & Reopen” — produces a correct app. There is no session protocol or
 supervising process: the app instance and the dev session are separate
 lifecycles. Application-control variables (API keys, `MAKA_*`, the Vite URL)
-are published to an ignored `0600` file at `.maka-dev/dev-env.json`, never on a
-command line. `PATH` is deliberately not forwarded — `shell-env.ts` resolves the
-login-shell `PATH` in the main process, which is exactly the case a
-GUI-launched app needs.
+are published to an ignored `0600` file at `.maka-dev/dev-env.json` rather than
+a command line. That file, not the shell, is what makes a Dock or “Quit &
+Reopen” launch work, since those have no parent shell at all. `PATH` is not
+recorded in it: a stored `PATH` goes stale, and `shell-env.ts` resolves the
+login-shell `PATH` in the main process for exactly this case.
 
-Because the bootstrap is built from constants, the bundle's cdhash is stable
-across rebuilds, so rebuilding does not invalidate a grant you already gave.
+The bundle is signed with an explicit designated requirement of
+`identifier "com.maka.dev"`. An ad-hoc signature otherwise designates a bare
+`cdhash`, which no grant survives — every rebuild, Electron bump, or repository
+move would invalidate it, and each worktree would silently overwrite the
+others' TCC row. Anchoring on the identifier is not a weaker boundary in any
+way that matters: the bundle loads `dist/main/main.js` from outside the
+signature seal, so anyone able to write this repository already inherits the
+grant without forging anything.
 
 The default profile is `~/Library/Application Support/Maka Dev-<worktree-id>`,
-which keeps development isolated from the packaged Maka profile and lets
-separate worktrees run concurrently; an explicit `--user-data-dir` takes
-precedence. Shutdown matches this worktree's own bundle path, so a concurrent
-worktree's app is unaffected.
+which keeps development isolated from the packaged Maka profile; an explicit
+`--user-data-dir` takes precedence. Shutdown matches this worktree's own bundle
+path, so a concurrent worktree's app is unaffected. Because that lock is keyed
+on the profile, a launch first reclaims any app left over from a hard-killed
+session — otherwise the stale app would absorb the new launch and keep showing
+its old, dead Vite URL.
+
+Known limitation: `dev-env.json` outlives the session, so launching from the
+Dock long after `npm run dev` has stopped points the app at a Vite URL that is
+no longer served, and the window stays blank. Start a dev session first.
 
 Grant permissions to **Maka Dev**, not a generic Electron entry. Screen
 Recording changes require restarting the development app. Without

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -4,41 +4,52 @@ The Electron desktop app: `main` (Node/Electron main process) + `preload` (conte
 
 ## macOS development permissions
 
-`npm run dev` and `npm start` launch macOS development builds through a generated, ad-hoc-signed
-`apps/desktop/.maka-dev/Maka Dev.app`. The stable bundle identity lets macOS TCC
-retain Accessibility and Screen Recording grants while renderer and main-process
-code change. The generated app is ignored by Git and is rebuilt automatically
-when the installed Electron version changes. Run
+`npm run dev` and `npm start` use the plain Electron executable on every
+platform. Working on Accessibility or Screen Recording is the exception: macOS
+TCC will not keep a grant for an unsigned executable launched from a terminal.
+Set `MAKA_DEV_TCC=1` to launch through a generated, ad-hoc-signed
+`apps/desktop/.maka-dev/Maka Dev.app` instead.
+
+```sh
+MAKA_DEV_TCC=1 npm run dev
+```
+
+The bundle gives TCC a stable identity (`com.maka.dev`), a verifiable
+signature, and a responsible process that is the app rather than the terminal.
+It is launched through LaunchServices for the same reason — running its inner
+binary directly puts the terminal back in the responsibility chain. The
+generated app is ignored by Git and rebuilt when the installed Electron version
+or this repository's path changes; run
 `npm --workspace @maka/desktop run prepare:dev-app` to prepare it explicitly.
 
-The scripts launch the bundle through macOS LaunchServices rather than executing
-its internal binary from a terminal. This is required for TCC to attribute the
-running process to `Maka Dev` and recognize the stored grants.
-The launcher remains alive as the development-session supervisor until the
-terminal receives Ctrl-C or SIGTERM. The generated bundle contains a small local
-bootstrap that reads a PID-validated, per-worktree session file, restoring the
-Vite URL and a curated environment-variable allowlist before importing the main
-process. macOS's Screen Recording “Quit & Reopen” action can therefore reconnect
-to the same HMR session without relying on command-line arguments that the
-system restart discards. Session files live in the ignored
-`apps/desktop/.maka-dev-session/` directory, outside the rebuildable app bundle,
-and are written atomically with mode `0600`. Startup is acknowledged only after
-the single-instance lock and main-process boot succeed; failures and timeouts are
-reported in the terminal instead of leaving a windowless supervisor running.
+This workflow is opt-in because LaunchServices detaches the app from the
+terminal: main-process logs go to Console.app instead of your shell. It also
+costs a codesign rebuild. Developers who are not touching OS permissions should
+not pay either.
 
-The default profile is `~/Library/Application Support/Maka Dev-<worktree-id>`.
-This keeps development isolated from the packaged Maka profile and lets separate
-worktrees run concurrently. An explicit `--user-data-dir` still takes precedence.
+Everything the bundle needs is fixed when it is built, so a launch with no
+arguments and no environment — the Dock, Spotlight, or Screen Recording's
+“Quit & Reopen” — produces a correct app. There is no session protocol or
+supervising process: the app instance and the dev session are separate
+lifecycles. Application-control variables (API keys, `MAKA_*`, the Vite URL)
+are published to an ignored `0600` file at `.maka-dev/dev-env.json`, never on a
+command line. `PATH` is deliberately not forwarded — `shell-env.ts` resolves the
+login-shell `PATH` in the main process, which is exactly the case a
+GUI-launched app needs.
 
-Only one supervised Maka Dev session can use a worktree at a time. Runtime
-preparation is protected by a PID lock, and shutdown targets the app PID recorded
-by that supervisor rather than every process sharing the development bundle ID.
-Runtime rebuilds refuse to proceed while that worktree has a live supervisor.
+Because the bootstrap is built from constants, the bundle's cdhash is stable
+across rebuilds, so rebuilding does not invalidate a grant you already gave.
 
-Grant permissions to **Maka Dev**, not a generic Electron entry. Screen Recording
-changes require restarting the development app. Recreating the app or changing
-its Electron version may require granting permissions again. Other platforms
-continue to use their normal Electron development executable.
+The default profile is `~/Library/Application Support/Maka Dev-<worktree-id>`,
+which keeps development isolated from the packaged Maka profile and lets
+separate worktrees run concurrently; an explicit `--user-data-dir` takes
+precedence. Shutdown matches this worktree's own bundle path, so a concurrent
+worktree's app is unaffected.
+
+Grant permissions to **Maka Dev**, not a generic Electron entry. Screen
+Recording changes require restarting the development app. Without
+`MAKA_DEV_TCC`, the permission overlay still runs, but its drag target is the
+npm Electron bundle, which macOS will not accept as a durable grant.
 
 ## Three layers
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -14,8 +14,8 @@ Set `MAKA_DEV_TCC=1` to launch through a generated, ad-hoc-signed
 MAKA_DEV_TCC=1 npm run dev
 ```
 
-The bundle gives TCC a stable identity (`com.maka.dev`), a verifiable
-signature, and a responsible process that is the app rather than the terminal.
+The bundle gives TCC a stable identity (`com.maka.dev.<worktree-id>`), a
+verifiable signature, and a responsible process that is the app, not the terminal.
 It is launched through LaunchServices for the same reason — running its inner
 binary directly puts the terminal back in the responsibility chain. The
 generated app is ignored by Git and rebuilt when the installed Electron version
@@ -39,14 +39,26 @@ Reopen” launch work, since those have no parent shell at all. `PATH` is not
 recorded in it: a stored `PATH` goes stale, and `shell-env.ts` resolves the
 login-shell `PATH` in the main process for exactly this case.
 
-The bundle is signed with an explicit designated requirement of
-`identifier "com.maka.dev"`. An ad-hoc signature otherwise designates a bare
-`cdhash`, which no grant survives — every rebuild, Electron bump, or repository
-move would invalidate it, and each worktree would silently overwrite the
-others' TCC row. Anchoring on the identifier is not a weaker boundary in any
-way that matters: the bundle loads `dist/main/main.js` from outside the
-signature seal, so anyone able to write this repository already inherits the
-grant without forging anything.
+The bundle identifier is scoped to the worktree because TCC keys its rows on
+that identifier: a shared one would make each worktree overwrite the previous
+one's stored requirement and silently break it. Scoping it gives every worktree
+its own durable, independently revocable grant.
+
+The ad-hoc signature keeps its default designated requirement, a bare `cdhash`.
+That means a rebuild costs a re-grant — but a rebuild happens only on an
+Electron bump or a repository move, not on an ordinary `npm run dev`. Pinning
+the identifier instead would survive rebuilds, and it is tempting for exactly
+that reason, but `codesign --sign -` is available to every unprivileged process:
+any binary anywhere on the disk could claim the identifier and satisfy the
+requirement. Since TCC rows outlive the code they were granted to, that would
+leave a permanently redeemable Accessibility and Screen Recording token behind
+even after this repository is deleted. Re-granting after an Electron bump is the
+cheaper side of that trade.
+
+Note that the payload at `dist/main/main.js` is loaded from outside the
+signature seal. Write access to this repository is therefore a deliberate trust
+assumption of the development workflow — a separate matter from who may claim
+the bundle's identity.
 
 The default profile is `~/Library/Application Support/Maka Dev-<worktree-id>`,
 which keeps development isolated from the packaged Maka profile; an explicit
@@ -58,7 +70,9 @@ its old, dead Vite URL.
 
 Known limitation: `dev-env.json` outlives the session, so launching from the
 Dock long after `npm run dev` has stopped points the app at a Vite URL that is
-no longer served, and the window stays blank. Start a dev session first.
+no longer served, and the window stays blank. Start a dev session first. If
+another worktree has since taken that port, the window loads *its* renderer
+instead, which looks like it worked.
 
 Grant permissions to **Maka Dev**, not a generic Electron entry. Screen
 Recording changes require restarting the development app. Without

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -59,7 +59,6 @@
   },
   "devDependencies": {
     "@ant-design/icons-svg": "4.5.0",
-    "@electron/asar": "3.4.1",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@playwright/test": "^1.61.1",

--- a/apps/desktop/scripts/dev-app-runtime.mjs
+++ b/apps/desktop/scripts/dev-app-runtime.mjs
@@ -16,11 +16,15 @@
  * lifecycles, and nothing about the app's correctness depends on who started
  * it.
  *
- * The injected payload replaces `default_app.asar` rather than the standard
- * `Resources/app` location. Electron derives `app.isPackaged` from
- * `!process.defaultApp`, so using the packaged-app location would flip
- * `isPackaged` to true and silently disable every dev-mode gate. For the same
- * reason the inner executable keeps the name `Electron`.
+ * `app.isPackaged` is native and computed as
+ * `basename(process.execPath) !== 'electron'`, so the invariant that keeps
+ * every dev-mode gate alive is simply that the inner executable stays named
+ * `Electron` — NOT the payload's location. (It is not derived from
+ * `process.defaultApp`; that flag is set by the stock default_app this module
+ * replaces, and is therefore undefined here.)
+ *
+ * The payload occupies `default_app.asar` rather than `Resources/app` so it
+ * cannot shadow a real packaged app laid down at the standard location.
  */
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
@@ -32,7 +36,9 @@ import { fileURLToPath } from 'node:url';
 const DESKTOP_DIR = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const REPO_ROOT = resolve(DESKTOP_DIR, '..', '..');
 const DEV_RUNTIME_DIR = join(DESKTOP_DIR, '.maka-dev');
+const STAGING_DIR = join(DESKTOP_DIR, '.maka-dev.staging');
 const DEV_APP = join(DEV_RUNTIME_DIR, 'Maka Dev.app');
+const STAGING_APP = join(STAGING_DIR, 'Maka Dev.app');
 const DEV_EXECUTABLE = join(DEV_APP, 'Contents', 'MacOS', 'Electron');
 const DEV_ENV_FILE = join(DEV_RUNTIME_DIR, 'dev-env.json');
 const MARKER = join(DEV_RUNTIME_DIR, 'runtime.json');
@@ -47,7 +53,7 @@ const DEV_USER_DATA_DIR = join(
 );
 
 const DEV_BUNDLE_ID = 'com.maka.dev';
-const RUNTIME_SCHEMA_VERSION = 5;
+const RUNTIME_SCHEMA_VERSION = 6;
 const DEV_ENV_SCHEMA_VERSION = 1;
 
 export const developmentAppPath = DEV_APP;
@@ -55,7 +61,9 @@ export const developmentAppPath = DEV_APP;
 export async function resolveMacosDevelopmentLaunch(env = process.env) {
   if (!shouldUseMacosDevelopmentApp(process.platform, env)) return null;
   const appPath = await prepareDevelopmentApp();
-  return createMacosDevelopmentLaunch(appPath);
+  // A leftover app would absorb this launch through the single-instance lock.
+  await ensureNoRunningDevelopmentApp();
+  return createMacosDevelopmentLaunch(appPath, developmentLogFile);
 }
 
 /**
@@ -71,10 +79,26 @@ export function shouldUseMacosDevelopmentApp(platform, env = process.env) {
   return optIn === '1' || optIn === 'true';
 }
 
-export function createMacosDevelopmentLaunch(appPath) {
+export function createMacosDevelopmentLaunch(appPath, logFile) {
   // LaunchServices must own the launch so macOS TCC attributes the running
   // executable to Maka Dev rather than to its parent terminal.
-  return { command: 'open', args: ['-n', '-a', appPath] };
+  const args = ['-n', '-a', appPath];
+  // Without this the detached app's output only reaches Console.app, which is
+  // also where a bootstrap or boot failure would go silent.
+  if (logFile) args.push('--stdout', logFile, '--stderr', logFile);
+  return { command: 'open', args };
+}
+
+export const developmentLogFile = join(DEV_RUNTIME_DIR, 'app.log');
+
+/**
+ * `pkill -f` / `pgrep -f` match an EXTENDED REGEX against the whole command
+ * line, so a path is not a literal. A repository under `~/Dropbox (Personal)`
+ * would otherwise match nothing — leaving the app un-killable — and an
+ * unbalanced `[` makes the pattern fail to compile entirely.
+ */
+export function toProcessMatchPattern(executable) {
+  return executable.replace(/[.[\]{}()*+?^$|\\]/g, '\\$&');
 }
 
 /**
@@ -97,25 +121,65 @@ export async function quitMacosDevelopmentApp(options = {}) {
 }
 
 function sendSignalToExecutable(name, executable) {
-  return spawnSync('pkill', [`-${name}`, '-f', executable]).status === 0;
+  const status = spawnSync('pkill', [`-${name}`, '-f', toProcessMatchPattern(executable)]).status;
+  // 0 = signalled, 1 = no match. Anything else is a usage or pattern error and
+  // must not be read as "nothing was running".
+  if (status !== 0 && status !== 1) {
+    throw new Error(`pkill -${name} failed for ${executable} (exit ${status})`);
+  }
+  return status === 0;
 }
 
 export function isDevelopmentAppRunning(options = {}) {
   const executable = options.executable ?? DEV_EXECUTABLE;
-  const probe = options.probe ?? ((path) => spawnSync('pgrep', ['-f', path]).status === 0);
+  const probe = options.probe ?? defaultLivenessProbe;
   return probe(executable);
 }
 
+function defaultLivenessProbe(executable) {
+  const status = spawnSync('pgrep', ['-f', toProcessMatchPattern(executable)]).status;
+  if (status !== 0 && status !== 1) {
+    throw new Error(`pgrep failed for ${executable} (exit ${status})`);
+  }
+  return status === 0;
+}
+
 /**
- * Application-control variables for the launched app. LaunchServices does not
- * inherit the shell environment, and these must not travel on a command line.
+ * Takes ownership of this worktree's app instance before launching or
+ * rebuilding. Electron's single-instance lock is keyed on userData, so an app
+ * left over from a hard-killed session would absorb the new launch: the new
+ * process exits 0, the OLD window is raised, and it stays pointed at a dead
+ * Vite URL while a liveness probe still reports success.
+ */
+export async function ensureNoRunningDevelopmentApp(options = {}) {
+  const running = options.isRunning ?? isDevelopmentAppRunning;
+  const quit = options.quit ?? quitMacosDevelopmentApp;
+  const delay = options.delay ?? ((ms) => new Promise((done) => setTimeout(done, ms)));
+  const attempts = options.attempts ?? 10;
+  const pollMs = options.pollMs ?? 200;
+  if (!running(options)) return false;
+  await quit(options);
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (!running(options)) return true;
+    await delay(pollMs);
+  }
+  throw new Error(
+    'A previous Maka Dev.app is still running and could not be stopped; quit it manually (Cmd-Q) and retry',
+  );
+}
+
+/**
+ * Application-control variables to persist for the app.
  *
- * PATH is deliberately absent: `shell-env.ts` already resolves the login-shell
- * PATH in the main process precisely because GUI-launched apps lack it. Passing
- * PATH here would also mean passing TERM/COLORTERM, which that module reads as
- * "this process was started from a terminal and already has a full
- * environment" — making it skip resolution and leave the app with a worse PATH
- * than it derives on its own.
+ * `open` itself does forward the parent environment, so this file is not what
+ * makes `npm run dev` work. It exists for the launches that have no parent
+ * shell at all — Dock, Spotlight, and Screen Recording's "Quit & Reopen" —
+ * which is exactly the path the whole design has to survive.
+ *
+ * That is also why the list is curated rather than a copy of `process.env`:
+ * this content is written to disk and outlives the session. PATH is excluded
+ * because a recorded PATH goes stale, and `shell-env.ts` resolves the
+ * login-shell PATH in the main process for precisely the GUI-launch case.
  */
 export function selectDevelopmentEnvironment(env, viteUrl) {
   const selected = {};
@@ -151,12 +215,26 @@ function isForwardedEnvironmentKey(key) {
   );
 }
 
+/**
+ * `--user-data-dir` cannot ride along in `electronArgs`: the bootstrap calls
+ * `app.setPath('userData', …)`, which overrides the switch. It has to be
+ * separated so the bootstrap can honour it as a value.
+ */
+export function splitDevelopmentCliArgs(argv = []) {
+  const flag = '--user-data-dir=';
+  return {
+    userDataDir: argv.find((argument) => argument.startsWith(flag))?.slice(flag.length),
+    electronArgs: argv.filter((argument) => !argument.startsWith(flag)),
+  };
+}
+
 export function createDevelopmentEnvironmentFile(input) {
+  const { userDataDir, electronArgs } = splitDevelopmentCliArgs(input.argv);
   return {
     schemaVersion: DEV_ENV_SCHEMA_VERSION,
     env: selectDevelopmentEnvironment(input.env, input.viteUrl),
-    userDataDir: input.userDataDir,
-    electronArgs: input.electronArgs ?? [],
+    userDataDir,
+    electronArgs,
   };
 }
 
@@ -184,24 +262,58 @@ export async function prepareDevelopmentApp() {
   const electronVersion = JSON.parse(readFileSync(ELECTRON_PACKAGE, 'utf8')).version;
   if (isCurrentRuntime(electronVersion)) return DEV_APP;
 
+  // Rebuilding unlinks the bundle an already-running app was launched from,
+  // and deletes the environment file it would read on relaunch.
+  await ensureNoRunningDevelopmentApp();
+
   await rebuildDevelopmentRuntime({
     reset: () => {
-      rmSync(DEV_RUNTIME_DIR, { recursive: true, force: true });
-      mkdirSync(DEV_RUNTIME_DIR, { recursive: true });
+      rmSync(STAGING_DIR, { recursive: true, force: true });
+      mkdirSync(STAGING_DIR, { recursive: true });
     },
     build: () => {
-      run('ditto', [SOURCE_APP, DEV_APP]);
-      const plist = join(DEV_APP, 'Contents', 'Info.plist');
+      run('ditto', [SOURCE_APP, STAGING_APP]);
+      const plist = join(STAGING_APP, 'Contents', 'Info.plist');
       setPlistString(plist, 'CFBundleIdentifier', DEV_BUNDLE_ID);
       setPlistString(plist, 'CFBundleName', 'Maka Dev');
       setPlistString(plist, 'CFBundleDisplayName', 'Maka Dev');
-      installBootstrap();
-      // `ditto` does not copy quarantine metadata by default. Clear any
-      // root-level attribute without the newer recursive `xattr -r` flag,
-      // which is unavailable on older supported macOS releases.
-      run('xattr', ['-c', DEV_APP]);
-      run('codesign', ['--force', '--deep', '--sign', '-', '--identifier', DEV_BUNDLE_ID, DEV_APP]);
-      run('codesign', ['--verify', '--deep', '--strict', DEV_APP]);
+      // Stock Electron seals a SHA256 of its own default_app.asar here. We
+      // replace that payload, so the record would describe a file that no
+      // longer exists — inert today only because the integrity fuse is off.
+      spawnSync('plutil', ['-remove', 'ElectronAsarIntegrity', plist]);
+      installBootstrap(STAGING_APP);
+      // `ditto` preserves quarantine by default (`--qtn`), so clear it from the
+      // whole tree rather than the bundle root alone.
+      run('xattr', ['-cr', STAGING_APP]);
+      // No --identifier: `plutil` already set CFBundleIdentifier, and codesign
+      // derives it per bundle. Passing it with --deep stamps the outer app's
+      // identifier onto all four nested helper bundles.
+      //
+      // The explicit designated requirement is the point of the exercise. An
+      // ad-hoc signature otherwise yields a bare `cdhash` DR, which no TCC
+      // grant survives — every rebuild, Electron bump, or repository move
+      // invalidates it. An identifier-based DR is not weaker in any way that
+      // matters here: the bundle loads dist/main/main.js from OUTSIDE the
+      // seal, so anyone who can write the repository already inherits the
+      // grant without forging anything.
+      // Sign inside-out. A single `--deep` pass carrying the requirement would
+      // stamp it onto the nested helpers too, whose own identifier is
+      // com.github.Electron.helper — codesign then rejects them as
+      // "nested code is modified or invalid".
+      run('codesign', ['--force', '--deep', '--sign', '-', STAGING_APP]);
+      run('codesign', [
+        '--force',
+        '--sign',
+        '-',
+        // `-r=<text>`: a separate argument would be read as a file path.
+        `-r=designated => identifier "${DEV_BUNDLE_ID}"`,
+        STAGING_APP,
+      ]);
+      run('codesign', ['--verify', '--deep', '--strict', STAGING_APP]);
+      // Publish atomically so a concurrent launcher never observes a partial
+      // bundle, and a losing racer simply overwrites with identical bytes.
+      rmSync(DEV_RUNTIME_DIR, { recursive: true, force: true });
+      renameSync(STAGING_DIR, DEV_RUNTIME_DIR);
     },
     writeMarker: () => {
       writeFileSync(
@@ -227,8 +339,8 @@ export async function prepareDevelopmentApp() {
  * resolves it as an ordinary directory, so no archive step or asar dependency
  * is needed to occupy the path Electron looks for.
  */
-function installBootstrap() {
-  const payload = join(DEV_APP, 'Contents', 'Resources', 'default_app.asar');
+export function installBootstrap(appPath = DEV_APP) {
+  const payload = join(appPath, 'Contents', 'Resources', 'default_app.asar');
   rmSync(payload, { recursive: true, force: true });
   mkdirSync(payload, { recursive: true });
   writeFileSync(

--- a/apps/desktop/scripts/dev-app-runtime.mjs
+++ b/apps/desktop/scripts/dev-app-runtime.mjs
@@ -1,27 +1,43 @@
+/**
+ * macOS development app for OS-permission work.
+ *
+ * macOS TCC will not keep an Accessibility or Screen Recording grant for an
+ * unsigned executable launched from a terminal. It needs a stable bundle
+ * identity, a verifiable signature, and a responsible process that is the app
+ * bundle itself. That is what this module builds: an ad-hoc-signed
+ * `Maka Dev.app` launched through LaunchServices.
+ *
+ * The bundle is a copy of the npm Electron app with its identity rewritten and
+ * a small bootstrap injected. Everything the bootstrap needs is a build-time
+ * constant, so a launch with no arguments and no environment — the Dock,
+ * Spotlight, or the system's Screen Recording "Quit & Reopen" — reproduces a
+ * correct app. That is why there is no session protocol, pid file, or
+ * supervisor here: the app instance and the dev session are separate
+ * lifecycles, and nothing about the app's correctness depends on who started
+ * it.
+ *
+ * The injected payload replaces `default_app.asar` rather than the standard
+ * `Resources/app` location. Electron derives `app.isPackaged` from
+ * `!process.defaultApp`, so using the packaged-app location would flip
+ * `isPackaged` to true and silently disable every dev-mode gate. For the same
+ * reason the inner executable keeps the name `Electron`.
+ */
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import {
-  closeSync,
-  existsSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  unlinkSync,
-  writeFileSync,
-} from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createPackage } from '@electron/asar';
 
 const DESKTOP_DIR = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const REPO_ROOT = resolve(DESKTOP_DIR, '..', '..');
 const DEV_RUNTIME_DIR = join(DESKTOP_DIR, '.maka-dev');
-const DEV_SESSION_DIR = join(DESKTOP_DIR, '.maka-dev-session');
 const DEV_APP = join(DEV_RUNTIME_DIR, 'Maka Dev.app');
 const DEV_EXECUTABLE = join(DEV_APP, 'Contents', 'MacOS', 'Electron');
+const DEV_ENV_FILE = join(DEV_RUNTIME_DIR, 'dev-env.json');
+const MARKER = join(DEV_RUNTIME_DIR, 'runtime.json');
+const ELECTRON_PACKAGE = join(REPO_ROOT, 'node_modules', 'electron', 'package.json');
+const SOURCE_APP = join(REPO_ROOT, 'node_modules', 'electron', 'dist', 'Electron.app');
 const WORKTREE_ID = createHash('sha256').update(REPO_ROOT).digest('hex').slice(0, 12);
 const DEV_USER_DATA_DIR = join(
   homedir(),
@@ -29,302 +45,89 @@ const DEV_USER_DATA_DIR = join(
   'Application Support',
   `Maka Dev-${WORKTREE_ID}`,
 );
-const MARKER = join(DEV_RUNTIME_DIR, 'runtime.json');
-const SESSION_FILE = join(DEV_SESSION_DIR, 'session.json');
-const APP_PID_FILE = join(DEV_SESSION_DIR, 'app.pid');
-const LAUNCH_STATUS_FILE = join(DEV_SESSION_DIR, 'launch-status.json');
-const RUNTIME_LOCK = join(DEV_SESSION_DIR, 'runtime.lock');
-const ELECTRON_PACKAGE = join(REPO_ROOT, 'node_modules', 'electron', 'package.json');
-const SOURCE_APP = join(REPO_ROOT, 'node_modules', 'electron', 'dist', 'Electron.app');
 
 const DEV_BUNDLE_ID = 'com.maka.dev';
-const RUNTIME_SCHEMA_VERSION = 4;
-const SESSION_SCHEMA_VERSION = 1;
+const RUNTIME_SCHEMA_VERSION = 5;
+const DEV_ENV_SCHEMA_VERSION = 1;
 
-export async function resolveMacosDevelopmentLaunch() {
-  if (!shouldUseMacosDevelopmentApp(process.platform)) return null;
+export const developmentAppPath = DEV_APP;
+
+export async function resolveMacosDevelopmentLaunch(env = process.env) {
+  if (!shouldUseMacosDevelopmentApp(process.platform, env)) return null;
   const appPath = await prepareDevelopmentApp();
   return createMacosDevelopmentLaunch(appPath);
 }
 
-export function shouldUseMacosDevelopmentApp(platform) {
-  return platform === 'darwin';
+/**
+ * The signed-bundle workflow exists only so TCC grants survive development.
+ * It costs a codesign rebuild and a LaunchServices handoff that detaches the
+ * app from the terminal's stdio, so `npm run dev` no longer prints main-process
+ * logs. Developers who are not working on OS permissions should not pay that,
+ * so it stays opt-in.
+ */
+export function shouldUseMacosDevelopmentApp(platform, env = process.env) {
+  if (platform !== 'darwin') return false;
+  const optIn = env.MAKA_DEV_TCC?.trim().toLowerCase();
+  return optIn === '1' || optIn === 'true';
 }
 
 export function createMacosDevelopmentLaunch(appPath) {
-  return {
-    command: 'open',
-    // LaunchServices must own process launch so macOS TCC attributes the
-    // running executable to Maka Dev rather than to its parent terminal.
-    args: [
-      '-n',
-      '-a',
-      appPath,
-    ],
-  };
+  // LaunchServices must own the launch so macOS TCC attributes the running
+  // executable to Maka Dev rather than to its parent terminal.
+  return { command: 'open', args: ['-n', '-a', appPath] };
 }
 
+/**
+ * Terminates this worktree's development app. The bundle path is unique per
+ * worktree, so matching on it is precise without tracking a pid: concurrent
+ * worktrees own different bundles and are unaffected.
+ */
 export async function quitMacosDevelopmentApp(options = {}) {
   const platform = options.platform ?? process.platform;
-  const appPidFile = options.appPidFile ?? APP_PID_FILE;
-  const supervisorPid = options.supervisorPid ?? process.pid;
-  const processAlive = options.processAlive ?? isProcessAlive;
-  const kill = options.kill ?? process.kill.bind(process);
+  const executable = options.executable ?? DEV_EXECUTABLE;
   const graceMs = options.graceMs ?? 3_000;
-  const delay = options.delay ?? ((ms) => new Promise((resolve_) => setTimeout(resolve_, ms)));
-  if (platform !== 'darwin' || !existsSync(appPidFile)) return false;
-  let appProcess;
-  try {
-    appProcess = JSON.parse(readFileSync(appPidFile, 'utf8'));
-  } catch {
-    return false;
-  }
-  if (appProcess.supervisorPid !== supervisorPid) return false;
-  const pid = appProcess.pid;
-  if (!Number.isSafeInteger(pid) || pid <= 0 || !processAlive(pid)) return false;
-  try {
-    kill(pid, 'SIGTERM');
-  } catch {
-    return false;
-  }
+  const signal = options.signal ?? sendSignalToExecutable;
+  const delay = options.delay ?? ((ms) => new Promise((done) => setTimeout(done, ms)));
+  if (platform !== 'darwin') return false;
+  if (!signal('TERM', executable)) return false;
+  // Main-process cleanup runs on before-quit and can outlive a plain SIGTERM.
   await delay(graceMs);
-  if (processAlive(pid)) {
-    try {
-      kill(pid, 'SIGKILL');
-    } catch {
-      // Exited between the liveness check and fallback signal.
-    }
-  }
+  signal('KILL', executable);
   return true;
 }
 
-export async function prepareDevelopmentApp() {
-  if (process.platform !== 'darwin') {
-    throw new Error('Maka Dev.app is only available on macOS');
-  }
-  if (!existsSync(SOURCE_APP)) {
-    throw new Error(`Electron.app is missing at ${SOURCE_APP}; run npm install first`);
-  }
-
-  const electronVersion = JSON.parse(readFileSync(ELECTRON_PACKAGE, 'utf8')).version;
-  if (isCurrentRuntime(electronVersion)) return DEV_APP;
-  assertNoActiveDevelopmentSession();
-  const releaseLock = acquirePidLock(RUNTIME_LOCK);
-
-  try {
-    // Another process may have completed preparation before this lock landed.
-    if (isCurrentRuntime(electronVersion)) return DEV_APP;
-    await rebuildDevelopmentRuntime({
-      reset: () => {
-        rmSync(DEV_RUNTIME_DIR, { recursive: true, force: true });
-        run('mkdir', ['-p', DEV_RUNTIME_DIR]);
-      },
-      build: async () => {
-        run('ditto', [SOURCE_APP, DEV_APP]);
-        const plist = join(DEV_APP, 'Contents', 'Info.plist');
-        replacePlistValue(plist, 'CFBundleIdentifier', DEV_BUNDLE_ID);
-        replacePlistValue(plist, 'CFBundleName', 'Maka Dev');
-        replacePlistValue(plist, 'CFBundleDisplayName', 'Maka Dev');
-        await installRelaunchBootstrap();
-        // `ditto` does not copy quarantine metadata by default. Clear any root-level
-        // attribute without relying on the newer recursive `xattr -r` flag, which
-        // is unavailable on older supported macOS releases.
-        run('xattr', ['-c', DEV_APP]);
-        run('codesign', [
-          '--force',
-          '--deep',
-          '--sign',
-          '-',
-          '--identifier',
-          DEV_BUNDLE_ID,
-          DEV_APP,
-        ]);
-        run('codesign', ['--verify', '--deep', '--strict', DEV_APP]);
-      },
-      writeMarker: () => {
-        writeFileSync(
-          MARKER,
-          `${JSON.stringify({ schemaVersion: RUNTIME_SCHEMA_VERSION, electronVersion, bundleId: DEV_BUNDLE_ID, desktopDir: DESKTOP_DIR }, null, 2)}\n`,
-        );
-      },
-    });
-  } finally {
-    releaseLock();
-  }
-  return DEV_APP;
+function sendSignalToExecutable(name, executable) {
+  return spawnSync('pkill', [`-${name}`, '-f', executable]).status === 0;
 }
 
-async function installRelaunchBootstrap() {
-  const bootstrapDir = join(DEV_RUNTIME_DIR, 'relaunch-bootstrap');
-  mkdirSync(bootstrapDir, { recursive: true });
-  writeFileSync(
-    join(bootstrapDir, 'package.json'),
-    `${JSON.stringify({ name: 'maka-dev-relaunch', main: 'main.cjs', private: true })}\n`,
-  );
-  writeFileSync(
-    join(bootstrapDir, 'main.cjs'),
-    createRelaunchBootstrapSource(
-      DESKTOP_DIR,
-      DEV_USER_DATA_DIR,
-      SESSION_FILE,
-      APP_PID_FILE,
-      LAUNCH_STATUS_FILE,
-    ),
-  );
-  await createPackage(
-    bootstrapDir,
-    join(DEV_APP, 'Contents', 'Resources', 'default_app.asar'),
-  );
-  rmSync(bootstrapDir, { recursive: true, force: true });
+export function isDevelopmentAppRunning(options = {}) {
+  const executable = options.executable ?? DEV_EXECUTABLE;
+  const probe = options.probe ?? ((path) => spawnSync('pgrep', ['-f', path]).status === 0);
+  return probe(executable);
 }
 
-export function createRelaunchBootstrapSource(
-  desktopDir,
-  defaultUserDataDir,
-  sessionFile = SESSION_FILE,
-  appPidFile = APP_PID_FILE,
-  launchStatusFile = LAUNCH_STATUS_FILE,
-) {
-  return [
-    "const { app } = require('electron');",
-    "const { join } = require('node:path');",
-    "const { pathToFileURL } = require('node:url');",
-    `const desktopDir = ${JSON.stringify(desktopDir)};`,
-    `const defaultUserDataDir = ${JSON.stringify(defaultUserDataDir)};`,
-    `const sessionFile = ${JSON.stringify(sessionFile)};`,
-    `const appPidFile = ${JSON.stringify(appPidFile)};`,
-    `const launchStatusFile = ${JSON.stringify(launchStatusFile)};`,
-    "let session = null;",
-    "try {",
-    "  const candidate = JSON.parse(require('node:fs').readFileSync(sessionFile, 'utf8'));",
-    "  process.kill(candidate.supervisorPid, 0);",
-    `  if (candidate.schemaVersion === ${SESSION_SCHEMA_VERSION}) session = candidate;`,
-    "} catch {}",
-    "if (session?.env) Object.assign(process.env, session.env);",
-    "for (const argument of session?.electronArgs || []) {",
-    "  const match = /^--([^=]+)(?:=(.*))?$/.exec(argument);",
-    "  if (match) app.commandLine.appendSwitch(match[1], match[2]);",
-    "}",
-    "const userDataDir = session?.userDataDir || defaultUserDataDir;",
-    'app.setAppPath(desktopDir);',
-    "app.setPath('userData', userDataDir);",
-    "if (session) {",
-    "  process.env.MAKA_DEV_APP_PID_FILE = appPidFile;",
-    "  process.env.MAKA_DEV_LAUNCH_STATUS_FILE = launchStatusFile;",
-    "  process.env.MAKA_DEV_SUPERVISOR_PID = String(session.supervisorPid);",
-    "}",
-    'process.chdir(desktopDir);',
-    "import(pathToFileURL(join(desktopDir, 'dist/main/main.js')).href).catch((error) => {",
-    "  console.error('[maka-dev] relaunch bootstrap failed', error);",
-    '  app.exit(1);',
-    '});',
-    '',
-  ].join('\n');
-}
-
-export function createDevelopmentSession(input) {
-  return {
-    schemaVersion: SESSION_SCHEMA_VERSION,
-    supervisorPid: input.supervisorPid,
-    userDataDir: input.userDataDir ?? DEV_USER_DATA_DIR,
-    env: selectDevelopmentEnvironment(input.env, input.viteUrl),
-    electronArgs: input.electronArgs ?? [],
-  };
-}
-
+/**
+ * Application-control variables for the launched app. LaunchServices does not
+ * inherit the shell environment, and these must not travel on a command line.
+ *
+ * PATH is deliberately absent: `shell-env.ts` already resolves the login-shell
+ * PATH in the main process precisely because GUI-launched apps lack it. Passing
+ * PATH here would also mean passing TERM/COLORTERM, which that module reads as
+ * "this process was started from a terminal and already has a full
+ * environment" — making it skip resolution and leave the app with a worse PATH
+ * than it derives on its own.
+ */
 export function selectDevelopmentEnvironment(env, viteUrl) {
   const selected = {};
   for (const [key, value] of Object.entries(env)) {
     if (typeof value !== 'string') continue;
-    if (isAllowedDevelopmentEnvironmentKey(key)) selected[key] = value;
+    if (isForwardedEnvironmentKey(key)) selected[key] = value;
   }
   if (viteUrl) selected.VITE_DEV_SERVER_URL = viteUrl;
   return selected;
 }
 
-export function writeDevelopmentSession(session, options = {}) {
-  const sessionFile = options.sessionFile ?? SESSION_FILE;
-  const appPidFile = options.appPidFile ?? APP_PID_FILE;
-  const launchStatusFile = options.launchStatusFile ?? LAUNCH_STATUS_FILE;
-  const processAlive = options.processAlive ?? isProcessAlive;
-  mkdirSync(dirname(sessionFile), { recursive: true });
-  if (existsSync(sessionFile)) {
-    try {
-      const current = JSON.parse(readFileSync(sessionFile, 'utf8'));
-      if (current.supervisorPid !== session.supervisorPid && processAlive(current.supervisorPid)) {
-        throw new Error(`Maka Dev session is already supervised by PID ${current.supervisorPid}`);
-      }
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('already supervised')) throw error;
-      // Corrupt or stale sessions are replaced atomically below.
-    }
-  }
-  const temporary = `${sessionFile}.tmp-${process.pid}`;
-  rmSync(appPidFile, { force: true });
-  rmSync(launchStatusFile, { force: true });
-  writeFileSync(temporary, `${JSON.stringify(session, null, 2)}\n`, { mode: 0o600 });
-  renameSync(temporary, sessionFile);
-}
-
-export async function recoverStaleDevelopmentSession(options = {}) {
-  const sessionFile = options.sessionFile ?? SESSION_FILE;
-  const appPidFile = options.appPidFile ?? APP_PID_FILE;
-  const launchStatusFile = options.launchStatusFile ?? LAUNCH_STATUS_FILE;
-  const processAlive = options.processAlive ?? isProcessAlive;
-  let staleSupervisorPid;
-  try {
-    const current = JSON.parse(readFileSync(sessionFile, 'utf8'));
-    staleSupervisorPid = current.supervisorPid;
-  } catch {
-    try {
-      staleSupervisorPid = JSON.parse(readFileSync(appPidFile, 'utf8')).supervisorPid;
-    } catch {
-      return false;
-    }
-  }
-  if (!Number.isSafeInteger(staleSupervisorPid) || processAlive(staleSupervisorPid)) return false;
-  await quitMacosDevelopmentApp({
-    ...options,
-    appPidFile,
-    supervisorPid: staleSupervisorPid,
-    processAlive,
-  });
-  clearDevelopmentSession(staleSupervisorPid, { sessionFile, appPidFile, launchStatusFile });
-  return true;
-}
-
-export function assertNoActiveDevelopmentSession(options = {}) {
-  const sessionFile = options.sessionFile ?? SESSION_FILE;
-  const processAlive = options.processAlive ?? isProcessAlive;
-  if (!existsSync(sessionFile)) return;
-  try {
-    const current = JSON.parse(readFileSync(sessionFile, 'utf8'));
-    if (Number.isSafeInteger(current.supervisorPid) && processAlive(current.supervisorPid)) {
-      throw new Error(
-        `Maka Dev session is already supervised by PID ${current.supervisorPid}; stop it before rebuilding the development app`,
-      );
-    }
-  } catch (error) {
-    if (error instanceof Error && error.message.includes('already supervised')) throw error;
-    // Corrupt or stale ownership state cannot protect a live session.
-  }
-}
-
-export function clearDevelopmentSession(supervisorPid = process.pid, options = {}) {
-  const sessionFile = options.sessionFile ?? SESSION_FILE;
-  const appPidFile = options.appPidFile ?? APP_PID_FILE;
-  const launchStatusFile = options.launchStatusFile ?? LAUNCH_STATUS_FILE;
-  try {
-    const current = JSON.parse(readFileSync(sessionFile, 'utf8'));
-    if (current.supervisorPid === supervisorPid) {
-      unlinkSync(sessionFile);
-      rmSync(appPidFile, { force: true });
-      rmSync(launchStatusFile, { force: true });
-    }
-  } catch {}
-}
-
-function isAllowedDevelopmentEnvironmentKey(key) {
+function isForwardedEnvironmentKey(key) {
   return (
     key.startsWith('MAKA_') ||
     key.startsWith('CUA_') ||
@@ -341,23 +144,141 @@ function isAllowedDevelopmentEnvironmentKey(key) {
       'HTTPS_PROXY',
       'ALL_PROXY',
       'NO_PROXY',
-      'PATH',
       'PYTHONPATH',
-      'SHELL',
       'NODE_ENV',
       'NO_COLOR',
-      'COLORTERM',
-      'TERM',
     ].includes(key)
   );
+}
+
+export function createDevelopmentEnvironmentFile(input) {
+  return {
+    schemaVersion: DEV_ENV_SCHEMA_VERSION,
+    env: selectDevelopmentEnvironment(input.env, input.viteUrl),
+    userDataDir: input.userDataDir,
+    electronArgs: input.electronArgs ?? [],
+  };
+}
+
+/**
+ * Publishes the environment the app should adopt. This is plain data with no
+ * owning process: a relaunch minutes later reads the same file and is just as
+ * correct, which is what removes the need for session supervision.
+ */
+export function writeDevelopmentEnvironment(content, options = {}) {
+  const file = options.file ?? DEV_ENV_FILE;
+  mkdirSync(join(file, '..'), { recursive: true });
+  const temporary = `${file}.tmp-${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify(content, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, file);
+}
+
+export async function prepareDevelopmentApp() {
+  if (process.platform !== 'darwin') {
+    throw new Error('Maka Dev.app is only available on macOS');
+  }
+  if (!existsSync(SOURCE_APP)) {
+    throw new Error(`Electron.app is missing at ${SOURCE_APP}; run npm install first`);
+  }
+
+  const electronVersion = JSON.parse(readFileSync(ELECTRON_PACKAGE, 'utf8')).version;
+  if (isCurrentRuntime(electronVersion)) return DEV_APP;
+
+  await rebuildDevelopmentRuntime({
+    reset: () => {
+      rmSync(DEV_RUNTIME_DIR, { recursive: true, force: true });
+      mkdirSync(DEV_RUNTIME_DIR, { recursive: true });
+    },
+    build: () => {
+      run('ditto', [SOURCE_APP, DEV_APP]);
+      const plist = join(DEV_APP, 'Contents', 'Info.plist');
+      setPlistString(plist, 'CFBundleIdentifier', DEV_BUNDLE_ID);
+      setPlistString(plist, 'CFBundleName', 'Maka Dev');
+      setPlistString(plist, 'CFBundleDisplayName', 'Maka Dev');
+      installBootstrap();
+      // `ditto` does not copy quarantine metadata by default. Clear any
+      // root-level attribute without the newer recursive `xattr -r` flag,
+      // which is unavailable on older supported macOS releases.
+      run('xattr', ['-c', DEV_APP]);
+      run('codesign', ['--force', '--deep', '--sign', '-', '--identifier', DEV_BUNDLE_ID, DEV_APP]);
+      run('codesign', ['--verify', '--deep', '--strict', DEV_APP]);
+    },
+    writeMarker: () => {
+      writeFileSync(
+        MARKER,
+        `${JSON.stringify(
+          {
+            schemaVersion: RUNTIME_SCHEMA_VERSION,
+            electronVersion,
+            bundleId: DEV_BUNDLE_ID,
+            desktopDir: DESKTOP_DIR,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    },
+  });
+  return DEV_APP;
+}
+
+/**
+ * Writes the payload as a plain directory named `default_app.asar`. Node
+ * resolves it as an ordinary directory, so no archive step or asar dependency
+ * is needed to occupy the path Electron looks for.
+ */
+function installBootstrap() {
+  const payload = join(DEV_APP, 'Contents', 'Resources', 'default_app.asar');
+  rmSync(payload, { recursive: true, force: true });
+  mkdirSync(payload, { recursive: true });
+  writeFileSync(
+    join(payload, 'package.json'),
+    `${JSON.stringify({ name: 'maka-dev', main: 'main.cjs', private: true }, null, 2)}\n`,
+  );
+  writeFileSync(
+    join(payload, 'main.cjs'),
+    createBootstrapSource(DESKTOP_DIR, DEV_USER_DATA_DIR, DEV_ENV_FILE),
+  );
+}
+
+/**
+ * Every value here is fixed at build time, which keeps the bundle's cdhash
+ * stable across rebuilds — a rebuild does not invalidate an existing TCC grant.
+ * The environment file is read opportunistically: if it is missing or stale the
+ * app still starts, just without a dev server URL.
+ */
+export function createBootstrapSource(desktopDir, defaultUserDataDir, envFile) {
+  return [
+    "const { app } = require('electron');",
+    "const { join } = require('node:path');",
+    "const { pathToFileURL } = require('node:url');",
+    `const desktopDir = ${JSON.stringify(desktopDir)};`,
+    'let devEnv = null;',
+    'try {',
+    `  const candidate = JSON.parse(require('node:fs').readFileSync(${JSON.stringify(envFile)}, 'utf8'));`,
+    `  if (candidate.schemaVersion === ${DEV_ENV_SCHEMA_VERSION}) devEnv = candidate;`,
+    '} catch {}',
+    'if (devEnv?.env) Object.assign(process.env, devEnv.env);',
+    'for (const argument of devEnv?.electronArgs || []) {',
+    '  const match = /^--([^=]+)(?:=(.*))?$/.exec(argument);',
+    '  if (match) app.commandLine.appendSwitch(match[1], match[2]);',
+    '}',
+    'app.setAppPath(desktopDir);',
+    `app.setPath('userData', devEnv?.userDataDir || ${JSON.stringify(defaultUserDataDir)});`,
+    'process.chdir(desktopDir);',
+    "import(pathToFileURL(join(desktopDir, 'dist/main/main.js')).href).catch((error) => {",
+    "  console.error('[maka-dev] bootstrap failed', error);",
+    '  app.exit(1);',
+    '});',
+    '',
+  ].join('\n');
 }
 
 function isCurrentRuntime(electronVersion) {
   if (!existsSync(DEV_EXECUTABLE) || !existsSync(MARKER)) return false;
   try {
-    const marker = JSON.parse(readFileSync(MARKER, 'utf8'));
     return isDevelopmentRuntimeCurrent({
-      marker,
+      marker: JSON.parse(readFileSync(MARKER, 'utf8')),
       schemaVersion: RUNTIME_SCHEMA_VERSION,
       electronVersion,
       bundleId: DEV_BUNDLE_ID,
@@ -387,46 +308,12 @@ export async function rebuildDevelopmentRuntime(deps) {
   await deps.reset();
   await deps.build();
   // The marker is the cache commit point. Never write it until copying,
-  // bootstrap generation, signing, and strict signature verification succeed.
+  // bootstrap generation, signing, and strict verification all succeed.
   await deps.writeMarker();
 }
 
-export function acquirePidLock(path, options = {}) {
-  const processAlive = options.processAlive ?? isProcessAlive;
-  mkdirSync(dirname(path), { recursive: true });
-  try {
-    const fd = openSync(path, 'wx', 0o600);
-    writeFileSync(fd, `${process.pid}\n`);
-    closeSync(fd);
-  } catch (error) {
-    if (error?.code !== 'EEXIST') throw error;
-    let owner = 0;
-    try {
-      owner = Number(readFileSync(path, 'utf8').trim());
-    } catch {}
-    if (Number.isSafeInteger(owner) && owner > 0 && processAlive(owner)) {
-      throw new Error(`Maka Dev runtime preparation is already running in PID ${owner}`);
-    }
-    rmSync(path, { force: true });
-    return acquirePidLock(path, options);
-  }
-  return () => rmSync(path, { force: true });
-}
-
-function isProcessAlive(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function replacePlistValue(plist, key, value) {
-  const result = spawnSync('plutil', ['-replace', key, '-string', value, plist], {
-    encoding: 'utf8',
-  });
-  if (result.status === 0) return;
+function setPlistString(plist, key, value) {
+  if (spawnSync('plutil', ['-replace', key, '-string', value, plist]).status === 0) return;
   run('plutil', ['-insert', key, '-string', value, plist]);
 }
 
@@ -435,35 +322,4 @@ function run(command, args) {
   if (result.status === 0) return;
   const detail = result.stderr?.trim() || result.stdout?.trim() || `exit ${result.status}`;
   throw new Error(`${command} failed: ${detail}`);
-}
-
-export const developmentAppPath = DEV_APP;
-
-export async function waitForMacosDevelopmentApp(options = {}) {
-  const supervisorPid = options.supervisorPid ?? process.pid;
-  const timeoutMs = options.timeoutMs ?? 30_000;
-  const pollMs = options.pollMs ?? 100;
-  const statusFile = options.statusFile ?? LAUNCH_STATUS_FILE;
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const status = JSON.parse(readFileSync(statusFile, 'utf8'));
-      if (status.supervisorPid !== supervisorPid) throw new Error('stale launch status');
-      if (status.status === 'ready' && isProcessAlive(status.pid)) return status;
-      if (status.status === 'failed') {
-        throw new Error(status.message || 'Maka Dev failed during startup');
-      }
-    } catch (error) {
-      if (
-        error?.code !== 'ENOENT' &&
-        !(error instanceof Error && error.message === 'stale launch status')
-      ) {
-        throw error;
-      }
-    }
-    await new Promise((resolve_) => setTimeout(resolve_, pollMs));
-  }
-  throw new Error(
-    `Maka Dev did not finish starting within ${timeoutMs}ms; another worktree instance or an app boot failure may be blocking it`,
-  );
 }

--- a/apps/desktop/scripts/dev-app-runtime.mjs
+++ b/apps/desktop/scripts/dev-app-runtime.mjs
@@ -26,11 +26,11 @@
  * The payload occupies `default_app.asar` rather than `Resources/app` so it
  * cannot shadow a real packaged app laid down at the standard location.
  */
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const DESKTOP_DIR = resolve(fileURLToPath(new URL('..', import.meta.url)));
@@ -52,11 +52,29 @@ const DEV_USER_DATA_DIR = join(
   `Maka Dev-${WORKTREE_ID}`,
 );
 
-const DEV_BUNDLE_ID = 'com.maka.dev';
-const RUNTIME_SCHEMA_VERSION = 6;
+/**
+ * Per-worktree, and deliberately so. An ad-hoc signature designates a bare
+ * `cdhash`, and TCC keys its rows on the bundle identifier — so a shared
+ * identifier would make every worktree overwrite the previous one's stored
+ * requirement and silently break it. Scoping the identifier gives each worktree
+ * its own durable, independently revocable grant.
+ *
+ * There is no explicit `designated => identifier` requirement here. It would
+ * survive rebuilds, but it is forgeable by construction: `codesign --sign -` is
+ * available to every unprivileged process, so any binary anywhere on the disk
+ * can claim this identifier and satisfy the requirement. TCC rows outlive the
+ * code they were granted to, so that would leave a permanently redeemable
+ * Accessibility and Screen Recording token behind even after this repository is
+ * deleted. The cdhash requirement costs a re-grant when the bundle is rebuilt —
+ * which happens only on an Electron bump or a repository move, not on an
+ * ordinary `npm run dev` — and that is the cheaper side of the trade.
+ */
+const DEV_BUNDLE_ID = `com.maka.dev.${WORKTREE_ID}`;
+const RUNTIME_SCHEMA_VERSION = 7;
 const DEV_ENV_SCHEMA_VERSION = 1;
 
 export const developmentAppPath = DEV_APP;
+export const developmentExecutablePath = DEV_EXECUTABLE;
 
 export async function resolveMacosDevelopmentLaunch(env = process.env) {
   if (!shouldUseMacosDevelopmentApp(process.platform, env)) return null;
@@ -157,10 +175,20 @@ export async function ensureNoRunningDevelopmentApp(options = {}) {
   const delay = options.delay ?? ((ms) => new Promise((done) => setTimeout(done, ms)));
   const attempts = options.attempts ?? 10;
   const pollMs = options.pollMs ?? 200;
-  if (!running(options)) return false;
-  await quit(options);
+  // Forward each callee only what it accepts. Passing this whole object through
+  // would make `delay` double as the SIGTERM grace period, and would let a
+  // caller that stubs `probe` still fall through to a real `pkill`.
+  const liveness = { executable: options.executable, probe: options.probe };
+  const shutdown = {
+    platform: options.platform,
+    executable: options.executable,
+    graceMs: options.graceMs,
+    signal: options.signal,
+  };
+  if (!running(liveness)) return false;
+  await quit(shutdown);
   for (let attempt = 0; attempt < attempts; attempt += 1) {
-    if (!running(options)) return true;
+    if (!running(liveness)) return true;
     await delay(pollMs);
   }
   throw new Error(
@@ -251,6 +279,130 @@ export function writeDevelopmentEnvironment(content, options = {}) {
   renameSync(temporary, file);
 }
 
+/**
+ * The Vite URL a previous launcher published, if any.
+ *
+ * `npm start` does not run a dev server, but it may be reclaiming an app from a
+ * live `npm run dev`. Republishing without the URL would drop the app to the
+ * prebuilt renderer on disk — stale, or absent entirely on a fresh checkout.
+ */
+export function readPublishedViteUrl(file = DEV_ENV_FILE) {
+  try {
+    const published = JSON.parse(readFileSync(file, 'utf8'));
+    if (published.schemaVersion !== DEV_ENV_SCHEMA_VERSION) return undefined;
+    return published.env?.VITE_DEV_SERVER_URL;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveElectronBinary() {
+  for (let dir = DESKTOP_DIR; ; dir = dirname(dir)) {
+    const executable =
+      process.platform === 'win32'
+        ? join(dir, 'node_modules', 'electron', 'dist', 'electron.exe')
+        : join(dir, 'node_modules', '.bin', 'electron');
+    if (existsSync(executable)) return executable;
+    if (dirname(dir) === dir) return 'electron';
+  }
+}
+
+/**
+ * The single way to start the app, on every platform and both entry points.
+ *
+ * `npm run dev` and `npm start` previously each carried their own copy of
+ * this — publish the environment, launch, follow the log, shut down — and the
+ * copies drifted into different bugs rather than different behaviour.
+ *
+ * Returns a handle rather than a child process because the two paths are not
+ * comparable: on the macOS bundle path `open` exits at the LaunchServices
+ * handoff, so its exit code says nothing about the app.
+ */
+export async function startDevelopmentApp(options = {}) {
+  const argv = options.argv ?? [];
+  // Read before preparing: a rebuild republishes the runtime directory and
+  // takes the previous environment file with it.
+  const viteUrl = options.viteUrl ?? readPublishedViteUrl();
+  const launch = await resolveMacosDevelopmentLaunch();
+  if (!launch) {
+    const child = spawn(resolveElectronBinary(), [DESKTOP_DIR, ...argv], {
+      cwd: DESKTOP_DIR,
+      stdio: 'inherit',
+      env: viteUrl ? { ...process.env, VITE_DEV_SERVER_URL: viteUrl } : process.env,
+    });
+    return { child, isMacosBundle: false, stop: () => terminateProcessTree(child) };
+  }
+
+  writeDevelopmentEnvironment(
+    createDevelopmentEnvironmentFile({ argv, env: process.env, viteUrl }),
+  );
+  // LaunchServices detaches the app from this terminal's stdio, so `open`
+  // redirects its output here and we follow it. The log carries whatever the
+  // app prints, so it gets the same mode as the environment file beside it.
+  writeFileSync(developmentLogFile, '', { mode: 0o600 });
+  const logStream = spawn('tail', ['-n', '+1', '-F', developmentLogFile], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  const child = spawn(launch.command, launch.args, {
+    cwd: DESKTOP_DIR,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  return {
+    child,
+    isMacosBundle: true,
+    stop: async () => {
+      logStream.kill();
+      await quitMacosDevelopmentApp();
+    },
+  };
+}
+
+function terminateProcessTree(child) {
+  if (child.exitCode !== null || child.killed) return Promise.resolve();
+  if (process.platform === 'win32' && child.pid) {
+    return new Promise((done) => {
+      const killer = spawn('taskkill', ['/PID', String(child.pid), '/T', '/F'], {
+        stdio: ['ignore', 'ignore', 'ignore'],
+      });
+      killer.on('exit', () => done());
+      killer.on('error', () => done());
+    });
+  }
+  child.kill('SIGTERM');
+  return Promise.resolve();
+}
+
+/**
+ * Watches the detached bundle for the whole session, because `open` exits 0 at
+ * the handoff and reports nothing afterwards.
+ *
+ * Waiting a fixed interval and checking once cannot work in either direction: a
+ * first launch of the freshly signed bundle can still be starting, and quitting
+ * the app is a normal thing to do at any moment. So this waits for the app to
+ * appear, then reports the eventual disappearance as an ordinary session end.
+ */
+export async function monitorDevelopmentApp(options = {}) {
+  const isRunning = options.isRunning ?? isDevelopmentAppRunning;
+  const delay = options.delay ?? ((ms) => new Promise((done) => setTimeout(done, ms)));
+  const stopped = options.stopped ?? (() => false);
+  const pollMs = options.pollMs ?? 250;
+  const startupAttempts = options.startupAttempts ?? 120;
+  let appeared = false;
+  for (let attempt = 0; attempt < startupAttempts && !appeared; attempt += 1) {
+    if (stopped()) return 'stopped';
+    if (isRunning()) appeared = true;
+    else await delay(pollMs);
+  }
+  if (!appeared) return 'never-started';
+  while (!stopped()) {
+    await delay(pollMs);
+    if (stopped()) break;
+    if (!isRunning()) return 'exited';
+  }
+  return 'stopped';
+}
+
 export async function prepareDevelopmentApp() {
   if (process.platform !== 'darwin') {
     throw new Error('Maka Dev.app is only available on macOS');
@@ -266,72 +418,73 @@ export async function prepareDevelopmentApp() {
   // and deletes the environment file it would read on relaunch.
   await ensureNoRunningDevelopmentApp();
 
-  await rebuildDevelopmentRuntime({
-    reset: () => {
-      rmSync(STAGING_DIR, { recursive: true, force: true });
-      mkdirSync(STAGING_DIR, { recursive: true });
-    },
-    build: () => {
-      run('ditto', [SOURCE_APP, STAGING_APP]);
-      const plist = join(STAGING_APP, 'Contents', 'Info.plist');
-      setPlistString(plist, 'CFBundleIdentifier', DEV_BUNDLE_ID);
-      setPlistString(plist, 'CFBundleName', 'Maka Dev');
-      setPlistString(plist, 'CFBundleDisplayName', 'Maka Dev');
-      // Stock Electron seals a SHA256 of its own default_app.asar here. We
-      // replace that payload, so the record would describe a file that no
-      // longer exists — inert today only because the integrity fuse is off.
-      spawnSync('plutil', ['-remove', 'ElectronAsarIntegrity', plist]);
-      installBootstrap(STAGING_APP);
-      // `ditto` preserves quarantine by default (`--qtn`), so clear it from the
-      // whole tree rather than the bundle root alone.
-      run('xattr', ['-cr', STAGING_APP]);
-      // No --identifier: `plutil` already set CFBundleIdentifier, and codesign
-      // derives it per bundle. Passing it with --deep stamps the outer app's
-      // identifier onto all four nested helper bundles.
-      //
-      // The explicit designated requirement is the point of the exercise. An
-      // ad-hoc signature otherwise yields a bare `cdhash` DR, which no TCC
-      // grant survives — every rebuild, Electron bump, or repository move
-      // invalidates it. An identifier-based DR is not weaker in any way that
-      // matters here: the bundle loads dist/main/main.js from OUTSIDE the
-      // seal, so anyone who can write the repository already inherits the
-      // grant without forging anything.
-      // Sign inside-out. A single `--deep` pass carrying the requirement would
-      // stamp it onto the nested helpers too, whose own identifier is
-      // com.github.Electron.helper — codesign then rejects them as
-      // "nested code is modified or invalid".
-      run('codesign', ['--force', '--deep', '--sign', '-', STAGING_APP]);
-      run('codesign', [
-        '--force',
-        '--sign',
-        '-',
-        // `-r=<text>`: a separate argument would be read as a file path.
-        `-r=designated => identifier "${DEV_BUNDLE_ID}"`,
-        STAGING_APP,
-      ]);
-      run('codesign', ['--verify', '--deep', '--strict', STAGING_APP]);
-      // Publish atomically so a concurrent launcher never observes a partial
-      // bundle, and a losing racer simply overwrites with identical bytes.
-      rmSync(DEV_RUNTIME_DIR, { recursive: true, force: true });
-      renameSync(STAGING_DIR, DEV_RUNTIME_DIR);
-    },
-    writeMarker: () => {
-      writeFileSync(
-        MARKER,
-        `${JSON.stringify(
-          {
-            schemaVersion: RUNTIME_SCHEMA_VERSION,
-            electronVersion,
-            bundleId: DEV_BUNDLE_ID,
-            desktopDir: DESKTOP_DIR,
-          },
-          null,
-          2,
-        )}\n`,
-      );
-    },
-  });
+  try {
+    await rebuildDevelopmentRuntime({
+      reset: () => {
+        rmSync(STAGING_DIR, { recursive: true, force: true });
+        mkdirSync(STAGING_DIR, { recursive: true });
+      },
+      build: () => {
+        run('ditto', [SOURCE_APP, STAGING_APP]);
+        const plist = join(STAGING_APP, 'Contents', 'Info.plist');
+        setPlistString(plist, 'CFBundleIdentifier', DEV_BUNDLE_ID);
+        setPlistString(plist, 'CFBundleName', 'Maka Dev');
+        setPlistString(plist, 'CFBundleDisplayName', 'Maka Dev');
+        // Stock Electron seals a SHA256 of its own default_app.asar here. We
+        // replace that payload, so the record would describe a file that no
+        // longer exists — inert today only because the integrity fuse is off.
+        spawnSync('plutil', ['-remove', 'ElectronAsarIntegrity', plist]);
+        installBootstrap(STAGING_APP);
+        // `ditto` preserves quarantine by default (`--qtn`), so clear it from
+        // the whole tree rather than the bundle root alone.
+        run('xattr', ['-cr', STAGING_APP]);
+        // No --identifier: `plutil` already set CFBundleIdentifier, and
+        // codesign derives it per bundle. Passing it with --deep would stamp
+        // the outer app's identifier onto all four nested helper bundles,
+        // whose own identifier is com.github.Electron.helper.
+        //
+        // `--deep` is load-bearing rather than gratuitous here: the npm source
+        // is linker-signed with no bundle seal, so without it the result does
+        // not verify at all. Apple's deprecation concerns distribution
+        // signing, where --deep discards per-target entitlements; this build
+        // has none.
+        run('codesign', ['--force', '--deep', '--sign', '-', STAGING_APP]);
+        run('codesign', ['--verify', '--deep', '--strict', STAGING_APP]);
+        // Publish by rename so a launcher never observes a partial bundle.
+        // This does not make concurrent *builders* safe — they share one
+        // staging path — but two rebuilds in one worktree is not a case worth
+        // locking for.
+        rmSync(DEV_RUNTIME_DIR, { recursive: true, force: true });
+        renameSync(STAGING_DIR, DEV_RUNTIME_DIR);
+      },
+      writeMarker: () => {
+        writeFileSync(
+          MARKER,
+          `${JSON.stringify(createRuntimeMarker(electronVersion), null, 2)}\n`,
+        );
+      },
+    });
+  } finally {
+    // A failed build otherwise leaves a ~250 MB copy of Electron.app behind
+    // with no message. Publishing already moved the directory away.
+    rmSync(STAGING_DIR, { recursive: true, force: true });
+  }
   return DEV_APP;
+}
+
+/**
+ * The cache key this build commits, and the one `isDevelopmentRuntimeCurrent`
+ * validates. Both sides must read from here: a field renamed on one side alone
+ * would silently force a rebuild on every launch, churning the very bundle the
+ * TCC grant is anchored to.
+ */
+export function createRuntimeMarker(electronVersion) {
+  return {
+    schemaVersion: RUNTIME_SCHEMA_VERSION,
+    electronVersion,
+    bundleId: DEV_BUNDLE_ID,
+    desktopDir: DESKTOP_DIR,
+  };
 }
 
 /**
@@ -389,31 +542,23 @@ export function createBootstrapSource(desktopDir, defaultUserDataDir, envFile) {
 function isCurrentRuntime(electronVersion) {
   if (!existsSync(DEV_EXECUTABLE) || !existsSync(MARKER)) return false;
   try {
-    return isDevelopmentRuntimeCurrent({
-      marker: JSON.parse(readFileSync(MARKER, 'utf8')),
-      schemaVersion: RUNTIME_SCHEMA_VERSION,
-      electronVersion,
-      bundleId: DEV_BUNDLE_ID,
-      desktopDir: DESKTOP_DIR,
-      signatureValid:
-        spawnSync('codesign', ['--verify', '--deep', '--strict', DEV_APP]).status === 0,
-    });
+    const marker = JSON.parse(readFileSync(MARKER, 'utf8'));
+    // Compare the cheap marker before paying for a full bundle verification.
+    if (!isDevelopmentRuntimeCurrent(marker, createRuntimeMarker(electronVersion))) return false;
+    return spawnSync('codesign', ['--verify', '--deep', '--strict', DEV_APP]).status === 0;
   } catch {
     return false;
   }
 }
 
-export function isDevelopmentRuntimeCurrent(input) {
-  const marker = input.marker;
-  return (
-    marker !== null &&
-    typeof marker === 'object' &&
-    marker.schemaVersion === input.schemaVersion &&
-    marker.electronVersion === input.electronVersion &&
-    marker.bundleId === input.bundleId &&
-    marker.desktopDir === input.desktopDir &&
-    input.signatureValid
-  );
+/**
+ * Every field the build committed must still hold. Comparing against a marker
+ * built by `createRuntimeMarker` rather than against a hand-listed set means a
+ * new cache input is covered the moment it is added there.
+ */
+export function isDevelopmentRuntimeCurrent(marker, expected) {
+  if (marker === null || typeof marker !== 'object') return false;
+  return Object.entries(expected).every(([key, value]) => marker[key] === value);
 }
 
 export async function rebuildDevelopmentRuntime(deps) {

--- a/apps/desktop/scripts/dev-app-runtime.test.mjs
+++ b/apps/desktop/scripts/dev-app-runtime.test.mjs
@@ -1,11 +1,16 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, statSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import {
+  ensureNoRunningDevelopmentApp,
   createBootstrapSource,
   createDevelopmentEnvironmentFile,
+  developmentAppPath,
+  splitDevelopmentCliArgs,
+  toProcessMatchPattern,
   createMacosDevelopmentLaunch,
   isDevelopmentAppRunning,
   isDevelopmentRuntimeCurrent,
@@ -59,34 +64,124 @@ test('forwards application secrets but leaves PATH to the main process', () => {
   assert.equal(env.MAKA_MODEL, 'test-model');
   assert.equal(env.CUA_ENDPOINT, 'http://cua');
   assert.equal('API_SECRET' in env, false);
-  // shell-env.ts resolves the login-shell PATH itself, and treats TERM /
-  // COLORTERM as proof it need not bother. Forwarding either would make it
-  // skip resolution and leave the app with a worse PATH than it derives.
+  // This content is persisted, so a recorded PATH would go stale; shell-env.ts
+  // resolves the login-shell PATH in the main process for the GUI-launch case.
   assert.equal('PATH' in env, false);
   assert.equal('TERM' in env, false);
   assert.equal('COLORTERM' in env, false);
-  // Secrets travel in a 0600 file, never on a command line.
-  assert.equal(createMacosDevelopmentLaunch('/repo/Maka Dev.app').args.includes('openai-secret'), false);
 });
 
-test('boots the repository app from constants alone', () => {
-  const source = createBootstrapSource(
-    '/repo/apps/desktop',
-    '/user-data/Maka Dev',
-    '/repo/apps/desktop/.maka-dev/dev-env.json',
+/**
+ * Runs the generated bootstrap for real against a stub `electron` module and a
+ * stub main entry. Asserting on the source text only proves it mentions the
+ * right identifiers; `new Function` accepts a typo'd `setPathTYPO` or a
+ * nonexistent module. Executing it is what pins the behaviour.
+ */
+async function runBootstrap({ envFileContent } = {}) {
+  // realpath: macOS resolves /var to /private/var, which process.cwd() reports.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'maka-boot-')));
+  const desktopDir = join(root, 'desktop');
+  const envFile = join(root, 'dev-env.json');
+  const calls = [];
+  mkdirSync(join(desktopDir, 'dist', 'main'), { recursive: true });
+  mkdirSync(join(root, 'node_modules', 'electron'), { recursive: true });
+  writeFileSync(
+    join(root, 'node_modules', 'electron', 'package.json'),
+    JSON.stringify({ name: 'electron', main: 'index.js' }),
   );
-  assert.match(source, /app\.setAppPath\(desktopDir\)/);
-  assert.match(source, /process\.chdir\(desktopDir\)/);
-  assert.match(source, /dist\/main\/main\.js/);
-  assert.match(source, /\/repo\/apps\/desktop/);
-  assert.match(source, /\/user-data\/Maka Dev/);
-  assert.match(source, /app\.commandLine\.appendSwitch/);
-  // The whole point: a relaunch carries no arguments and no live supervisor,
-  // so the bootstrap must not depend on either.
-  assert.doesNotMatch(source, /process\.argv/);
-  assert.doesNotMatch(source, /supervisorPid/);
-  assert.doesNotMatch(source, /process\.kill/);
-  assert.doesNotThrow(() => new Function(source));
+  writeFileSync(
+    join(root, 'node_modules', 'electron', 'index.js'),
+    `const calls = globalThis.__makaCalls;
+     module.exports = { app: {
+       setAppPath: (p) => calls.push(['setAppPath', p]),
+       setPath: (k, v) => calls.push(['setPath', k, v]),
+       exit: (c) => calls.push(['exit', c]),
+       commandLine: { appendSwitch: (k, v) => calls.push(['switch', k, v ?? null]) },
+     } };`,
+  );
+  writeFileSync(
+    join(desktopDir, 'dist', 'main', 'main.js'),
+    `import { writeFileSync } from 'node:fs';
+     writeFileSync(${JSON.stringify(join(root, 'loaded.json'))}, JSON.stringify({
+       cwd: process.cwd(), viteUrl: process.env.VITE_DEV_SERVER_URL ?? null,
+       apiKey: process.env.OPENAI_API_KEY ?? null,
+     }));`,
+  );
+  if (envFileContent !== undefined) writeFileSync(envFile, envFileContent);
+  const bootstrapFile = join(root, 'bootstrap.cjs');
+  writeFileSync(
+    bootstrapFile,
+    createBootstrapSource(desktopDir, join(root, 'default-user-data'), envFile),
+  );
+  const nodeModule = createRequire(join(root, 'x.cjs'));
+  globalThis.__makaCalls = calls;
+  // The bootstrap chdirs by design, and its dynamic import of the main entry
+  // resolves on a later tick — so the cwd must stay in place until that entry
+  // has run. Restore it only afterwards, so later tests are unaffected.
+  const previousCwd = process.cwd();
+  // The bootstrap assigns into process.env, which is per-app in production but
+  // shared between these tests; snapshot it so cases stay independent.
+  const previousEnv = { ...process.env };
+  try {
+    nodeModule(bootstrapFile);
+    const cwd = process.cwd();
+    for (let i = 0; i < 20; i += 1) await new Promise((done) => setImmediate(done));
+    return { root, desktopDir, calls, cwd, loadedFile: join(root, 'loaded.json') };
+  } finally {
+    process.chdir(previousCwd);
+    for (const key of Object.keys(process.env)) {
+      if (!(key in previousEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, previousEnv);
+  }
+}
+
+test('boots the repository app from constants alone, with no env file present', async () => {
+  const { desktopDir, calls, loadedFile, root, cwd } = await runBootstrap();
+  // The central claim of the design: nothing but build-time constants.
+  assert.deepEqual(calls, [
+    ['setAppPath', desktopDir],
+    ['setPath', 'userData', join(root, 'default-user-data')],
+  ]);
+  assert.equal(cwd, desktopDir);
+  const loaded = JSON.parse(readFileSync(loadedFile, 'utf8'));
+  assert.equal(loaded.cwd, desktopDir);
+  assert.equal(loaded.viteUrl, null);
+});
+
+test('adopts a published environment file: env, userData override, switches', async () => {
+  const { calls, loadedFile } = await runBootstrap({
+    envFileContent: JSON.stringify(
+      createDevelopmentEnvironmentFile({
+        argv: ['--enable-logging', '--user-data-dir=/tmp/override-profile'],
+        env: { OPENAI_API_KEY: 'secret' },
+        viteUrl: 'http://localhost:5173',
+      }),
+    ),
+  });
+  assert.deepEqual(calls.filter(([kind]) => kind === 'switch'), [
+    ['switch', 'enable-logging', null],
+  ]);
+  assert.deepEqual(calls.find(([kind]) => kind === 'setPath'), [
+    'setPath',
+    'userData',
+    '/tmp/override-profile',
+  ]);
+  const loaded = JSON.parse(readFileSync(loadedFile, 'utf8'));
+  assert.equal(loaded.viteUrl, 'http://localhost:5173');
+  assert.equal(loaded.apiKey, 'secret');
+});
+
+test('ignores an unreadable or wrong-schema environment file instead of failing to boot', async () => {
+  for (const content of ['not json at all', JSON.stringify({ schemaVersion: 999, env: { OPENAI_API_KEY: 'leak' } })]) {
+    const { calls, loadedFile, root } = await runBootstrap({ envFileContent: content });
+    assert.deepEqual(calls.find(([kind]) => kind === 'setPath'), [
+      'setPath',
+      'userData',
+      join(root, 'default-user-data'),
+    ]);
+    assert.equal(JSON.parse(readFileSync(loadedFile, 'utf8')).apiKey, null);
+  }
 });
 
 test('publishes the environment file atomically and privately', () => {
@@ -95,12 +190,10 @@ test('publishes the environment file atomically and privately', () => {
   const content = createDevelopmentEnvironmentFile({
     env: { OPENAI_API_KEY: 'secret' },
     viteUrl: 'http://localhost:5173',
-    userDataDir: '/tmp/custom-profile',
-    electronArgs: ['--enable-logging', '--remote-debugging-port=9222'],
+    argv: ['--user-data-dir=/tmp/custom-profile', '--enable-logging', '--remote-debugging-port=9222'],
   });
   writeDevelopmentEnvironment(content, { file });
   const written = JSON.parse(readFileSync(file, 'utf8'));
-  assert.equal(written.schemaVersion, 1);
   assert.equal(written.env.OPENAI_API_KEY, 'secret');
   assert.equal(written.env.VITE_DEV_SERVER_URL, 'http://localhost:5173');
   assert.equal(written.userDataDir, '/tmp/custom-profile');
@@ -216,4 +309,86 @@ test('liveness probe checks the worktree bundle path', () => {
   );
   assert.deepEqual(probed, ['/repo-a/Maka Dev.app/Contents/MacOS/Electron']);
   assert.equal(isDevelopmentAppRunning({ probe: () => false }), false);
+});
+
+test('escapes regex metacharacters so a path is matched literally', () => {
+  // pkill/pgrep -f take an extended regex. A repo under "~/Dropbox (Personal)"
+  // would otherwise match nothing, leaving the app impossible to stop.
+  assert.equal(
+    toProcessMatchPattern('/Users/x/Dropbox (Personal)/Maka Dev.app/Contents/MacOS/Electron'),
+    '/Users/x/Dropbox \\(Personal\\)/Maka Dev\\.app/Contents/MacOS/Electron',
+  );
+  assert.equal(toProcessMatchPattern('/a[b]/c+d'), '/a\\[b\\]/c\\+d');
+});
+
+test('defaults target this worktree bundle executable', () => {
+  // Every other quit/liveness test injects around the real wiring; this one
+  // pins that the un-injected default is the bundle path we mean to match.
+  const expected = join(developmentAppPath, 'Contents', 'MacOS', 'Electron');
+  let seen;
+  isDevelopmentAppRunning({
+    probe: (path) => {
+      seen = path;
+      return false;
+    },
+  });
+  assert.equal(seen, expected);
+  let signalled;
+  void quitMacosDevelopmentApp({
+    platform: 'darwin',
+    delay: () => Promise.resolve(),
+    signal: (_name, path) => {
+      signalled = path;
+      return false;
+    },
+  });
+  assert.equal(signalled, expected);
+});
+
+test('separates --user-data-dir from switches forwarded to Electron', () => {
+  assert.deepEqual(splitDevelopmentCliArgs(['--user-data-dir=/x', '--enable-logging']), {
+    userDataDir: '/x',
+    electronArgs: ['--enable-logging'],
+  });
+  assert.deepEqual(splitDevelopmentCliArgs([]), { userDataDir: undefined, electronArgs: [] });
+  // Empty value falls back to the bootstrap default rather than setting ''.
+  assert.equal(splitDevelopmentCliArgs(['--user-data-dir=']).userDataDir, '');
+});
+
+test('claims the app instance before launching or rebuilding', async () => {
+  // A leftover app would absorb the new launch via the single-instance lock,
+  // leaving the OLD window in front while liveness still reports success.
+  let alive = true;
+  const quits = [];
+  assert.equal(
+    await ensureNoRunningDevelopmentApp({
+      isRunning: () => alive,
+      quit: () => {
+        quits.push('quit');
+        alive = false;
+        return Promise.resolve(true);
+      },
+      delay: () => Promise.resolve(),
+    }),
+    true,
+  );
+  assert.deepEqual(quits, ['quit']);
+  // Nothing running: no quit attempt at all.
+  assert.equal(
+    await ensureNoRunningDevelopmentApp({
+      isRunning: () => false,
+      quit: () => assert.fail('must not quit when nothing is running'),
+    }),
+    false,
+  );
+  // Refuses to proceed rather than launching into a doomed single-instance lock.
+  await assert.rejects(
+    ensureNoRunningDevelopmentApp({
+      isRunning: () => true,
+      quit: () => Promise.resolve(true),
+      delay: () => Promise.resolve(),
+      attempts: 2,
+    }),
+    /still running and could not be stopped/,
+  );
 });

--- a/apps/desktop/scripts/dev-app-runtime.test.mjs
+++ b/apps/desktop/scripts/dev-app-runtime.test.mjs
@@ -1,23 +1,19 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import {
-  acquirePidLock,
-  assertNoActiveDevelopmentSession,
-  clearDevelopmentSession,
+  createBootstrapSource,
+  createDevelopmentEnvironmentFile,
   createMacosDevelopmentLaunch,
-  createDevelopmentSession,
-  createRelaunchBootstrapSource,
+  isDevelopmentAppRunning,
   isDevelopmentRuntimeCurrent,
+  quitMacosDevelopmentApp,
   rebuildDevelopmentRuntime,
   selectDevelopmentEnvironment,
   shouldUseMacosDevelopmentApp,
-  quitMacosDevelopmentApp,
-  recoverStaleDevelopmentSession,
-  waitForMacosDevelopmentApp,
-  writeDevelopmentSession,
+  writeDevelopmentEnvironment,
 } from './dev-app-runtime.mjs';
 
 test('launches the signed development bundle through LaunchServices', () => {
@@ -25,245 +21,199 @@ test('launches the signed development bundle through LaunchServices', () => {
     command: 'open',
     args: ['-n', '-a', '/repo/Maka Dev.app'],
   });
-  assert.equal(shouldUseMacosDevelopmentApp('darwin'), true);
-  assert.equal(shouldUseMacosDevelopmentApp('linux'), false);
 });
 
-test('stores the Vite URL and curated environment without command-line secrets', () => {
-  const env = selectDevelopmentEnvironment({
-    VITE_DEV_SERVER_URL: 'http://localhost:5173',
-    OPENAI_API_KEY: 'openai-secret',
-    GH_TOKEN: 'github-secret',
-    GITHUB_TOKEN: 'github-fallback',
-    RIVE_BIN: '/tools/rive',
-    MAKA_MODEL: 'test-model',
-    API_SECRET: 'do-not-forward',
-  }, 'http://localhost:4173');
+test('keeps the signed bundle workflow opt-in', () => {
+  assert.equal(shouldUseMacosDevelopmentApp('darwin', { MAKA_DEV_TCC: '1' }), true);
+  assert.equal(shouldUseMacosDevelopmentApp('darwin', { MAKA_DEV_TCC: 'true' }), true);
+  assert.equal(shouldUseMacosDevelopmentApp('darwin', { MAKA_DEV_TCC: ' TRUE ' }), true);
+  assert.equal(shouldUseMacosDevelopmentApp('darwin', {}), false);
+  assert.equal(shouldUseMacosDevelopmentApp('darwin', { MAKA_DEV_TCC: '0' }), false);
+  assert.equal(shouldUseMacosDevelopmentApp('darwin', { MAKA_DEV_TCC: '' }), false);
+  // Opting in elsewhere must never reach codesign or LaunchServices.
+  assert.equal(shouldUseMacosDevelopmentApp('linux', { MAKA_DEV_TCC: '1' }), false);
+  assert.equal(shouldUseMacosDevelopmentApp('win32', { MAKA_DEV_TCC: 'true' }), false);
+});
+
+test('forwards application secrets but leaves PATH to the main process', () => {
+  const env = selectDevelopmentEnvironment(
+    {
+      OPENAI_API_KEY: 'openai-secret',
+      GH_TOKEN: 'github-secret',
+      GITHUB_TOKEN: 'github-fallback',
+      RIVE_BIN: '/tools/rive',
+      MAKA_MODEL: 'test-model',
+      CUA_ENDPOINT: 'http://cua',
+      API_SECRET: 'do-not-forward',
+      PATH: '/should/not/travel',
+      TERM: 'xterm-256color',
+      COLORTERM: 'truecolor',
+    },
+    'http://localhost:4173',
+  );
   assert.equal(env.VITE_DEV_SERVER_URL, 'http://localhost:4173');
   assert.equal(env.OPENAI_API_KEY, 'openai-secret');
-  assert.equal(env.MAKA_MODEL, 'test-model');
   assert.equal(env.GH_TOKEN, 'github-secret');
   assert.equal(env.GITHUB_TOKEN, 'github-fallback');
   assert.equal(env.RIVE_BIN, '/tools/rive');
+  assert.equal(env.MAKA_MODEL, 'test-model');
+  assert.equal(env.CUA_ENDPOINT, 'http://cua');
   assert.equal('API_SECRET' in env, false);
+  // shell-env.ts resolves the login-shell PATH itself, and treats TERM /
+  // COLORTERM as proof it need not bother. Forwarding either would make it
+  // skip resolution and leave the app with a worse PATH than it derives.
+  assert.equal('PATH' in env, false);
+  assert.equal('TERM' in env, false);
+  assert.equal('COLORTERM' in env, false);
+  // Secrets travel in a 0600 file, never on a command line.
   assert.equal(createMacosDevelopmentLaunch('/repo/Maka Dev.app').args.includes('openai-secret'), false);
 });
 
-test('boots the repository app and recovers a live supervisor session on reopen', () => {
-  const source = createRelaunchBootstrapSource(
+test('boots the repository app from constants alone', () => {
+  const source = createBootstrapSource(
     '/repo/apps/desktop',
     '/user-data/Maka Dev',
-    '/repo/.maka-dev/session.json',
-    '/repo/.maka-dev/app.pid',
-    '/repo/.maka-dev/launch-status.json',
+    '/repo/apps/desktop/.maka-dev/dev-env.json',
   );
   assert.match(source, /app\.setAppPath\(desktopDir\)/);
-  assert.match(source, /app\.setPath\('userData', userDataDir\)/);
   assert.match(source, /process\.chdir\(desktopDir\)/);
   assert.match(source, /dist\/main\/main\.js/);
   assert.match(source, /\/repo\/apps\/desktop/);
   assert.match(source, /\/user-data\/Maka Dev/);
-  assert.match(source, /candidate\.supervisorPid/);
-  assert.match(source, /Object\.assign\(process\.env, session\.env\)/);
-  assert.match(source, /appPidFile/);
-  assert.doesNotMatch(source, /writeFileSync\(appPidFile/);
-  assert.match(source, /MAKA_DEV_APP_PID_FILE/);
   assert.match(source, /app\.commandLine\.appendSwitch/);
+  // The whole point: a relaunch carries no arguments and no live supervisor,
+  // so the bootstrap must not depend on either.
+  assert.doesNotMatch(source, /process\.argv/);
+  assert.doesNotMatch(source, /supervisorPid/);
+  assert.doesNotMatch(source, /process\.kill/);
   assert.doesNotThrow(() => new Function(source));
 });
 
-test('honors an explicit development user-data directory in the session', () => {
-  const session = createDevelopmentSession({
-    supervisorPid: 42,
-    env: {},
+test('publishes the environment file atomically and privately', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'maka-dev-env-'));
+  const file = join(dir, 'dev-env.json');
+  const content = createDevelopmentEnvironmentFile({
+    env: { OPENAI_API_KEY: 'secret' },
+    viteUrl: 'http://localhost:5173',
     userDataDir: '/tmp/custom-profile',
     electronArgs: ['--enable-logging', '--remote-debugging-port=9222'],
   });
-  assert.equal(session.userDataDir, '/tmp/custom-profile');
-  assert.deepEqual(session.electronArgs, ['--enable-logging', '--remote-debugging-port=9222']);
+  writeDevelopmentEnvironment(content, { file });
+  const written = JSON.parse(readFileSync(file, 'utf8'));
+  assert.equal(written.schemaVersion, 1);
+  assert.equal(written.env.OPENAI_API_KEY, 'secret');
+  assert.equal(written.env.VITE_DEV_SERVER_URL, 'http://localhost:5173');
+  assert.equal(written.userDataDir, '/tmp/custom-profile');
+  assert.deepEqual(written.electronArgs, ['--enable-logging', '--remote-debugging-port=9222']);
+  assert.equal(statSync(file).mode & 0o777, 0o600);
+  // Rewriting must not require any prior ownership handshake.
+  writeDevelopmentEnvironment({ ...content, env: {} }, { file });
+  assert.deepEqual(JSON.parse(readFileSync(file, 'utf8')).env, {});
 });
 
 test('reuses only an exact, valid development runtime cache', () => {
   const current = {
     marker: {
-      schemaVersion: 3,
+      schemaVersion: 5,
       electronVersion: '43.1.1',
       bundleId: 'com.maka.dev',
       desktopDir: '/repo/apps/desktop',
     },
-    schemaVersion: 3,
+    schemaVersion: 5,
     electronVersion: '43.1.1',
     bundleId: 'com.maka.dev',
     desktopDir: '/repo/apps/desktop',
     signatureValid: true,
   };
-  assert.equal(isDevelopmentRuntimeCurrent(current), true, 'exact cache hit');
-  assert.equal(
-    isDevelopmentRuntimeCurrent({ ...current, desktopDir: '/moved/apps/desktop' }),
-    false,
-    'repository path change',
-  );
-  assert.equal(
-    isDevelopmentRuntimeCurrent({ ...current, electronVersion: '44.0.0' }),
-    false,
-    'Electron change',
-  );
-  assert.equal(
-    isDevelopmentRuntimeCurrent({ ...current, schemaVersion: 4 }),
-    false,
-    'schema change',
-  );
-  assert.equal(
-    isDevelopmentRuntimeCurrent({ ...current, bundleId: 'com.maka.other' }),
-    false,
-    'bundle ID change',
-  );
-  assert.equal(
-    isDevelopmentRuntimeCurrent({ ...current, signatureValid: false }),
-    false,
-    'failed signature verification',
-  );
-  assert.equal(
-    isDevelopmentRuntimeCurrent({ ...current, marker: { ...current.marker, schemaVersion: undefined } }),
-    false,
-    'missing schema is never accepted as a legacy default',
-  );
-  assert.equal(
-    isDevelopmentRuntimeCurrent({ ...current, marker: 'corrupt' }),
-    false,
-    'corrupt marker shape',
-  );
-});
-
-test('session protocol atomically owns, rejects, and clears its state', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'maka-dev-session-'));
-  const paths = {
-    sessionFile: join(dir, 'session.json'),
-    appPidFile: join(dir, 'app.pid'),
-    launchStatusFile: join(dir, 'launch-status.json'),
-    processAlive: (pid) => pid === 42,
-  };
-  writeFileSync(paths.appPidFile, 'stale');
-  writeFileSync(paths.launchStatusFile, 'stale');
-  const session = createDevelopmentSession({ supervisorPid: 42, env: {} });
-  writeDevelopmentSession(session, paths);
-  assert.equal(statSync(paths.sessionFile).mode & 0o777, 0o600);
-  assert.equal(JSON.parse(readFileSync(paths.sessionFile)).supervisorPid, 42);
-  assert.throws(
-    () => writeDevelopmentSession({ ...session, supervisorPid: 99 }, paths),
-    /already supervised by PID 42/,
-  );
-  clearDevelopmentSession(99, paths);
-  assert.equal(JSON.parse(readFileSync(paths.sessionFile)).supervisorPid, 42);
-  clearDevelopmentSession(42, paths);
-  assert.throws(() => readFileSync(paths.sessionFile), /ENOENT/);
-});
-
-test('launch handshake reports ready, failed, and timeout states', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'maka-dev-launch-'));
-  const statusFile = join(dir, 'status.json');
-  writeFileSync(statusFile, JSON.stringify({ status: 'ready', pid: process.pid, supervisorPid: 42 }));
-  assert.equal(
-    (await waitForMacosDevelopmentApp({ statusFile, supervisorPid: 42, timeoutMs: 20 })).pid,
-    process.pid,
-  );
-  writeFileSync(statusFile, JSON.stringify({ status: 'failed', supervisorPid: 42, message: 'boom' }));
-  await assert.rejects(
-    waitForMacosDevelopmentApp({ statusFile, supervisorPid: 42, timeoutMs: 20 }),
-    /boom/,
-  );
-  await assert.rejects(
-    waitForMacosDevelopmentApp({ statusFile: join(dir, 'missing'), timeoutMs: 5, pollMs: 1 }),
-    /did not finish starting/,
-  );
-});
-
-test('PID-scoped quit waits for cleanup and uses a final fallback signal', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'maka-dev-quit-'));
-  const appPidFile = join(dir, 'app.pid');
-  writeFileSync(appPidFile, JSON.stringify({ pid: 77, supervisorPid: 42 }));
-  const signals = [];
-  let checks = 0;
-  assert.equal(
-    await quitMacosDevelopmentApp({
-      platform: 'darwin',
-      appPidFile,
-      supervisorPid: 42,
-      processAlive: () => checks++ < 2,
-      kill: (pid, signal) => signals.push([pid, signal]),
-      delay: async () => undefined,
-    }),
-    true,
-  );
-  assert.deepEqual(signals, [[77, 'SIGTERM'], [77, 'SIGKILL']]);
-});
-
-test('a new supervisor recovers an orphan app before replacing stale state', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'maka-dev-recover-'));
-  const paths = {
-    sessionFile: join(dir, 'session.json'),
-    appPidFile: join(dir, 'app.pid'),
-    launchStatusFile: join(dir, 'launch-status.json'),
-  };
-  writeFileSync(paths.sessionFile, JSON.stringify({ supervisorPid: 42 }));
-  writeFileSync(paths.appPidFile, JSON.stringify({ pid: 77, supervisorPid: 42 }));
-  writeFileSync(paths.launchStatusFile, 'stale');
-  const signals = [];
-  const alive = new Set([77]);
-  assert.equal(
-    await recoverStaleDevelopmentSession({
-      ...paths,
-      platform: 'darwin',
-      processAlive: (pid) => alive.has(pid),
-      kill: (pid, signal) => {
-        signals.push([pid, signal]);
-        alive.delete(pid);
-      },
-      delay: async () => undefined,
-    }),
-    true,
-  );
-  assert.deepEqual(signals, [[77, 'SIGTERM']]);
-  assert.throws(() => readFileSync(paths.sessionFile), /ENOENT/);
-  assert.throws(() => readFileSync(paths.appPidFile), /ENOENT/);
-});
-
-test('runtime lock rejects a live owner and recovers a stale owner', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'maka-dev-lock-'));
-  const lock = join(dir, 'runtime.lock');
-  writeFileSync(lock, '42\n');
-  assert.throws(() => acquirePidLock(lock, { processAlive: () => true }), /PID 42/);
-  const release = acquirePidLock(lock, { processAlive: () => false });
-  assert.equal(Number(readFileSync(lock, 'utf8').trim()), process.pid);
-  release();
-  assert.throws(() => readFileSync(lock), /ENOENT/);
-});
-
-test('runtime rebuild is blocked while a supervised session is live', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'maka-dev-owner-'));
-  const sessionFile = join(dir, 'session.json');
-  writeFileSync(sessionFile, JSON.stringify({ supervisorPid: 42 }));
-  assert.throws(
-    () => assertNoActiveDevelopmentSession({ sessionFile, processAlive: () => true }),
-    /stop it before rebuilding/,
-  );
-  assert.doesNotThrow(() =>
-    assertNoActiveDevelopmentSession({ sessionFile, processAlive: () => false }),
-  );
+  assert.equal(isDevelopmentRuntimeCurrent(current), true);
+  assert.equal(isDevelopmentRuntimeCurrent({ ...current, signatureValid: false }), false);
+  assert.equal(isDevelopmentRuntimeCurrent({ ...current, electronVersion: '44.0.0' }), false);
+  assert.equal(isDevelopmentRuntimeCurrent({ ...current, schemaVersion: 6 }), false);
+  assert.equal(isDevelopmentRuntimeCurrent({ ...current, bundleId: 'com.other' }), false);
+  // A moved repo must rebuild: the bootstrap embeds the old absolute path.
+  assert.equal(isDevelopmentRuntimeCurrent({ ...current, desktopDir: '/moved' }), false);
+  // A marker with no schema version is not implicitly v1.
+  const { schemaVersion: _omitted, ...markerWithoutSchema } = current.marker;
+  assert.equal(isDevelopmentRuntimeCurrent({ ...current, marker: markerWithoutSchema }), false);
+  assert.equal(isDevelopmentRuntimeCurrent({ ...current, marker: null }), false);
 });
 
 test('does not commit a cache marker when runtime preparation fails', async () => {
-  let markerWritten = false;
-  await assert.rejects(() =>
+  const steps = [];
+  await assert.rejects(
     rebuildDevelopmentRuntime({
-      reset: () => undefined,
+      reset: () => steps.push('reset'),
       build: () => {
+        steps.push('build');
         throw new Error('codesign failed');
       },
-      writeMarker: () => {
-        markerWritten = true;
+      writeMarker: () => steps.push('marker'),
+    }),
+    /codesign failed/,
+  );
+  assert.deepEqual(steps, ['reset', 'build']);
+});
+
+test('shutdown targets this worktree bundle and escalates after a grace period', async () => {
+  const signals = [];
+  const delays = [];
+  const stopped = await quitMacosDevelopmentApp({
+    platform: 'darwin',
+    executable: '/repo-a/.maka-dev/Maka Dev.app/Contents/MacOS/Electron',
+    graceMs: 3_000,
+    delay: (ms) => {
+      delays.push(ms);
+      return Promise.resolve();
+    },
+    signal: (name, executable) => {
+      signals.push([name, executable]);
+      return true;
+    },
+  });
+  assert.equal(stopped, true);
+  // Matching the worktree's own bundle path is what keeps a concurrent
+  // worktree's app untouched without tracking pids.
+  assert.deepEqual(signals, [
+    ['TERM', '/repo-a/.maka-dev/Maka Dev.app/Contents/MacOS/Electron'],
+    ['KILL', '/repo-a/.maka-dev/Maka Dev.app/Contents/MacOS/Electron'],
+  ]);
+  assert.deepEqual(delays, [3_000]);
+});
+
+test('shutdown is inert when nothing matches or the platform differs', async () => {
+  const attempted = [];
+  assert.equal(
+    await quitMacosDevelopmentApp({
+      platform: 'darwin',
+      signal: (name) => {
+        attempted.push(name);
+        return false;
       },
     }),
+    false,
   );
-  assert.equal(markerWritten, false);
+  assert.deepEqual(attempted, ['TERM'], 'a missed TERM must not escalate to KILL');
+  assert.equal(
+    await quitMacosDevelopmentApp({
+      platform: 'linux',
+      signal: () => assert.fail('must not signal off darwin'),
+    }),
+    false,
+  );
+});
+
+test('liveness probe checks the worktree bundle path', () => {
+  const probed = [];
+  assert.equal(
+    isDevelopmentAppRunning({
+      executable: '/repo-a/Maka Dev.app/Contents/MacOS/Electron',
+      probe: (path) => {
+        probed.push(path);
+        return true;
+      },
+    }),
+    true,
+  );
+  assert.deepEqual(probed, ['/repo-a/Maka Dev.app/Contents/MacOS/Electron']);
+  assert.equal(isDevelopmentAppRunning({ probe: () => false }), false);
 });

--- a/apps/desktop/scripts/dev-app-runtime.test.mjs
+++ b/apps/desktop/scripts/dev-app-runtime.test.mjs
@@ -1,23 +1,39 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import test from 'node:test';
 import {
-  ensureNoRunningDevelopmentApp,
   createBootstrapSource,
   createDevelopmentEnvironmentFile,
-  developmentAppPath,
-  splitDevelopmentCliArgs,
-  toProcessMatchPattern,
   createMacosDevelopmentLaunch,
+  createRuntimeMarker,
+  developmentAppPath,
+  developmentExecutablePath,
+  ensureNoRunningDevelopmentApp,
+  installBootstrap,
   isDevelopmentAppRunning,
   isDevelopmentRuntimeCurrent,
+  monitorDevelopmentApp,
   quitMacosDevelopmentApp,
+  readPublishedViteUrl,
   rebuildDevelopmentRuntime,
+  resolveMacosDevelopmentLaunch,
   selectDevelopmentEnvironment,
   shouldUseMacosDevelopmentApp,
+  splitDevelopmentCliArgs,
+  toProcessMatchPattern,
   writeDevelopmentEnvironment,
 } from './dev-app-runtime.mjs';
 
@@ -26,6 +42,18 @@ test('launches the signed development bundle through LaunchServices', () => {
     command: 'open',
     args: ['-n', '-a', '/repo/Maka Dev.app'],
   });
+  // The branch production always takes: LaunchServices detaches the app from
+  // this terminal's stdio, so without the redirect the log has nothing to
+  // follow and startup failures go only to Console.app.
+  assert.deepEqual(createMacosDevelopmentLaunch('/repo/Maka Dev.app', '/repo/app.log').args, [
+    '-n',
+    '-a',
+    '/repo/Maka Dev.app',
+    '--stdout',
+    '/repo/app.log',
+    '--stderr',
+    '/repo/app.log',
+  ]);
 });
 
 test('keeps the signed bundle workflow opt-in', () => {
@@ -38,6 +66,14 @@ test('keeps the signed bundle workflow opt-in', () => {
   // Opting in elsewhere must never reach codesign or LaunchServices.
   assert.equal(shouldUseMacosDevelopmentApp('linux', { MAKA_DEV_TCC: '1' }), false);
   assert.equal(shouldUseMacosDevelopmentApp('win32', { MAKA_DEV_TCC: 'true' }), false);
+});
+
+test('the opt-out path returns before preparing anything', async () => {
+  // The gate is only worth testing where it is actually consulted: this is the
+  // sole entry point, and inverting the check must not leave the suite green.
+  for (const env of [{}, { MAKA_DEV_TCC: '0' }, { MAKA_DEV_TCC: 'false' }, { MAKA_DEV_TCC: '' }]) {
+    assert.equal(await resolveMacosDevelopmentLaunch(env), null);
+  }
 });
 
 test('forwards application secrets but leaves PATH to the main process', () => {
@@ -64,8 +100,9 @@ test('forwards application secrets but leaves PATH to the main process', () => {
   assert.equal(env.MAKA_MODEL, 'test-model');
   assert.equal(env.CUA_ENDPOINT, 'http://cua');
   assert.equal('API_SECRET' in env, false);
-  // This content is persisted, so a recorded PATH would go stale; shell-env.ts
-  // resolves the login-shell PATH in the main process for the GUI-launch case.
+  // This content is persisted, so a recorded PATH would go stale. Worse, a
+  // recorded TERM would make shell-env.ts short-circuit on a Dock launch and
+  // leave launchd's minimal PATH in place — the exact case it exists for.
   assert.equal('PATH' in env, false);
   assert.equal('TERM' in env, false);
   assert.equal('COLORTERM' in env, false);
@@ -77,11 +114,12 @@ test('forwards application secrets but leaves PATH to the main process', () => {
  * right identifiers; `new Function` accepts a typo'd `setPathTYPO` or a
  * nonexistent module. Executing it is what pins the behaviour.
  */
-async function runBootstrap({ envFileContent } = {}) {
+async function runBootstrap({ envFileContent, omitMainEntry } = {}) {
   // realpath: macOS resolves /var to /private/var, which process.cwd() reports.
   const root = realpathSync(mkdtempSync(join(tmpdir(), 'maka-boot-')));
   const desktopDir = join(root, 'desktop');
   const envFile = join(root, 'dev-env.json');
+  const loadedFile = join(root, 'loaded.json');
   const calls = [];
   mkdirSync(join(desktopDir, 'dist', 'main'), { recursive: true });
   mkdirSync(join(root, 'node_modules', 'electron'), { recursive: true });
@@ -99,14 +137,16 @@ async function runBootstrap({ envFileContent } = {}) {
        commandLine: { appendSwitch: (k, v) => calls.push(['switch', k, v ?? null]) },
      } };`,
   );
-  writeFileSync(
-    join(desktopDir, 'dist', 'main', 'main.js'),
-    `import { writeFileSync } from 'node:fs';
-     writeFileSync(${JSON.stringify(join(root, 'loaded.json'))}, JSON.stringify({
-       cwd: process.cwd(), viteUrl: process.env.VITE_DEV_SERVER_URL ?? null,
-       apiKey: process.env.OPENAI_API_KEY ?? null,
-     }));`,
-  );
+  if (!omitMainEntry) {
+    writeFileSync(
+      join(desktopDir, 'dist', 'main', 'main.js'),
+      `import { writeFileSync } from 'node:fs';
+       writeFileSync(${JSON.stringify(loadedFile)}, JSON.stringify({
+         cwd: process.cwd(), viteUrl: process.env.VITE_DEV_SERVER_URL ?? null,
+         apiKey: process.env.OPENAI_API_KEY ?? null,
+       }));`,
+    );
+  }
   if (envFileContent !== undefined) writeFileSync(envFile, envFileContent);
   const bootstrapFile = join(root, 'bootstrap.cjs');
   writeFileSync(
@@ -125,32 +165,37 @@ async function runBootstrap({ envFileContent } = {}) {
   try {
     nodeModule(bootstrapFile);
     const cwd = process.cwd();
-    for (let i = 0; i < 20; i += 1) await new Promise((done) => setImmediate(done));
-    return { root, desktopDir, calls, cwd, loadedFile: join(root, 'loaded.json') };
+    // The import settles on the next tick; poll rather than guess a tick count.
+    for (let i = 0; i < 200 && !existsSync(loadedFile) && !calls.some(([k]) => k === 'exit'); i += 1) {
+      await new Promise((done) => setImmediate(done));
+    }
+    const loaded = existsSync(loadedFile) ? JSON.parse(readFileSync(loadedFile, 'utf8')) : null;
+    return { root, desktopDir, calls, cwd, loaded };
   } finally {
     process.chdir(previousCwd);
     for (const key of Object.keys(process.env)) {
       if (!(key in previousEnv)) delete process.env[key];
     }
     Object.assign(process.env, previousEnv);
+    delete globalThis.__makaCalls;
+    rmSync(root, { recursive: true, force: true });
   }
 }
 
 test('boots the repository app from constants alone, with no env file present', async () => {
-  const { desktopDir, calls, loadedFile, root, cwd } = await runBootstrap();
+  const { desktopDir, calls, loaded, root, cwd } = await runBootstrap();
   // The central claim of the design: nothing but build-time constants.
   assert.deepEqual(calls, [
     ['setAppPath', desktopDir],
     ['setPath', 'userData', join(root, 'default-user-data')],
   ]);
   assert.equal(cwd, desktopDir);
-  const loaded = JSON.parse(readFileSync(loadedFile, 'utf8'));
   assert.equal(loaded.cwd, desktopDir);
   assert.equal(loaded.viteUrl, null);
 });
 
 test('adopts a published environment file: env, userData override, switches', async () => {
-  const { calls, loadedFile } = await runBootstrap({
+  const { calls, loaded } = await runBootstrap({
     envFileContent: JSON.stringify(
       createDevelopmentEnvironmentFile({
         argv: ['--enable-logging', '--user-data-dir=/tmp/override-profile'],
@@ -159,29 +204,80 @@ test('adopts a published environment file: env, userData override, switches', as
       }),
     ),
   });
-  assert.deepEqual(calls.filter(([kind]) => kind === 'switch'), [
-    ['switch', 'enable-logging', null],
-  ]);
+  assert.deepEqual(
+    calls.filter(([kind]) => kind === 'switch'),
+    [['switch', 'enable-logging', null]],
+  );
   assert.deepEqual(calls.find(([kind]) => kind === 'setPath'), [
     'setPath',
     'userData',
     '/tmp/override-profile',
   ]);
-  const loaded = JSON.parse(readFileSync(loadedFile, 'utf8'));
   assert.equal(loaded.viteUrl, 'http://localhost:5173');
   assert.equal(loaded.apiKey, 'secret');
 });
 
 test('ignores an unreadable or wrong-schema environment file instead of failing to boot', async () => {
-  for (const content of ['not json at all', JSON.stringify({ schemaVersion: 999, env: { OPENAI_API_KEY: 'leak' } })]) {
-    const { calls, loadedFile, root } = await runBootstrap({ envFileContent: content });
+  const wrongSchema = JSON.stringify({ schemaVersion: 999, env: { OPENAI_API_KEY: 'leak' } });
+  for (const content of ['not json at all', wrongSchema]) {
+    const { calls, loaded, root } = await runBootstrap({ envFileContent: content });
     assert.deepEqual(calls.find(([kind]) => kind === 'setPath'), [
       'setPath',
       'userData',
       join(root, 'default-user-data'),
     ]);
-    assert.equal(JSON.parse(readFileSync(loadedFile, 'utf8')).apiKey, null);
+    assert.equal(loaded.apiKey, null);
   }
+});
+
+test('an empty --user-data-dir falls back to the per-worktree default', async () => {
+  const { calls, root } = await runBootstrap({
+    envFileContent: JSON.stringify(
+      createDevelopmentEnvironmentFile({ argv: ['--user-data-dir='], env: {} }),
+    ),
+  });
+  assert.deepEqual(calls.find(([kind]) => kind === 'setPath'), [
+    'setPath',
+    'userData',
+    join(root, 'default-user-data'),
+  ]);
+});
+
+test('exits instead of hanging a windowless app when the main entry is missing', async () => {
+  // The most common developer state: dist/main/main.js not built yet.
+  const { calls } = await runBootstrap({ omitMainEntry: true });
+  assert.deepEqual(
+    calls.filter(([kind]) => kind === 'exit'),
+    [['exit', 1]],
+  );
+});
+
+test('installs the payload where Electron will actually load it', () => {
+  const bundle = mkdtempSync(join(tmpdir(), 'maka-bundle-'));
+  const payload = join(bundle, 'Contents', 'Resources', 'default_app.asar');
+  mkdirSync(payload, { recursive: true });
+  writeFileSync(join(payload, 'stale-from-an-older-build.js'), 'x');
+  try {
+    installBootstrap(bundle);
+    // A plain directory, not an archive: that is what lets the payload occupy
+    // the path Electron searches without any asar tooling.
+    assert.equal(statSync(payload).isDirectory(), true);
+    const manifest = JSON.parse(readFileSync(join(payload, 'package.json'), 'utf8'));
+    assert.equal(existsSync(join(payload, manifest.main)), true);
+    assert.equal(existsSync(join(payload, 'stale-from-an-older-build.js')), false);
+    // Production constants, not test doubles, are what reach the bootstrap.
+    const source = readFileSync(join(payload, manifest.main), 'utf8');
+    assert.match(source, /apps[/\\]desktop/);
+    assert.match(source, /Maka Dev-[0-9a-f]{12}/);
+  } finally {
+    rmSync(bundle, { recursive: true, force: true });
+  }
+});
+
+test('keeps the inner executable named Electron so app.isPackaged stays false', () => {
+  // isPackaged is native and computed as basename(execPath) !== 'electron'.
+  // Every dev-mode gate in the product hangs off it.
+  assert.equal(basename(developmentExecutablePath), 'Electron');
 });
 
 test('publishes the environment file atomically and privately', () => {
@@ -192,43 +288,77 @@ test('publishes the environment file atomically and privately', () => {
     viteUrl: 'http://localhost:5173',
     argv: ['--user-data-dir=/tmp/custom-profile', '--enable-logging', '--remote-debugging-port=9222'],
   });
-  writeDevelopmentEnvironment(content, { file });
-  const written = JSON.parse(readFileSync(file, 'utf8'));
-  assert.equal(written.env.OPENAI_API_KEY, 'secret');
-  assert.equal(written.env.VITE_DEV_SERVER_URL, 'http://localhost:5173');
-  assert.equal(written.userDataDir, '/tmp/custom-profile');
-  assert.deepEqual(written.electronArgs, ['--enable-logging', '--remote-debugging-port=9222']);
-  assert.equal(statSync(file).mode & 0o777, 0o600);
-  // Rewriting must not require any prior ownership handshake.
-  writeDevelopmentEnvironment({ ...content, env: {} }, { file });
-  assert.deepEqual(JSON.parse(readFileSync(file, 'utf8')).env, {});
+  try {
+    writeDevelopmentEnvironment(content, { file });
+    const written = JSON.parse(readFileSync(file, 'utf8'));
+    assert.equal(written.env.OPENAI_API_KEY, 'secret');
+    assert.equal(written.env.VITE_DEV_SERVER_URL, 'http://localhost:5173');
+    assert.equal(written.userDataDir, '/tmp/custom-profile');
+    assert.deepEqual(written.electronArgs, ['--enable-logging', '--remote-debugging-port=9222']);
+    assert.equal(statSync(file).mode & 0o777, 0o600);
+    // Rewriting must not require any prior ownership handshake, must leave no
+    // temporary behind, and must not widen the mode.
+    writeDevelopmentEnvironment({ ...content, env: {} }, { file });
+    assert.deepEqual(JSON.parse(readFileSync(file, 'utf8')).env, {});
+    assert.deepEqual(readdirSync(dir), ['dev-env.json']);
+    assert.equal(statSync(file).mode & 0o777, 0o600);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
-test('reuses only an exact, valid development runtime cache', () => {
-  const current = {
-    marker: {
-      schemaVersion: 5,
-      electronVersion: '43.1.1',
-      bundleId: 'com.maka.dev',
-      desktopDir: '/repo/apps/desktop',
-    },
-    schemaVersion: 5,
-    electronVersion: '43.1.1',
-    bundleId: 'com.maka.dev',
-    desktopDir: '/repo/apps/desktop',
-    signatureValid: true,
-  };
-  assert.equal(isDevelopmentRuntimeCurrent(current), true);
-  assert.equal(isDevelopmentRuntimeCurrent({ ...current, signatureValid: false }), false);
-  assert.equal(isDevelopmentRuntimeCurrent({ ...current, electronVersion: '44.0.0' }), false);
-  assert.equal(isDevelopmentRuntimeCurrent({ ...current, schemaVersion: 6 }), false);
-  assert.equal(isDevelopmentRuntimeCurrent({ ...current, bundleId: 'com.other' }), false);
-  // A moved repo must rebuild: the bootstrap embeds the old absolute path.
-  assert.equal(isDevelopmentRuntimeCurrent({ ...current, desktopDir: '/moved' }), false);
-  // A marker with no schema version is not implicitly v1.
-  const { schemaVersion: _omitted, ...markerWithoutSchema } = current.marker;
-  assert.equal(isDevelopmentRuntimeCurrent({ ...current, marker: markerWithoutSchema }), false);
-  assert.equal(isDevelopmentRuntimeCurrent({ ...current, marker: null }), false);
+test('carries a live dev server URL across a reclaiming launch', () => {
+  // `npm start` publishes no URL of its own. Without this, reclaiming an app
+  // from a running `npm run dev` would drop it to the prebuilt renderer.
+  const dir = mkdtempSync(join(tmpdir(), 'maka-dev-env-'));
+  const file = join(dir, 'dev-env.json');
+  try {
+    assert.equal(readPublishedViteUrl(file), undefined);
+    writeDevelopmentEnvironment(
+      createDevelopmentEnvironmentFile({ argv: [], env: {}, viteUrl: 'http://localhost:5173' }),
+      { file },
+    );
+    assert.equal(readPublishedViteUrl(file), 'http://localhost:5173');
+    writeFileSync(file, JSON.stringify({ schemaVersion: 999, env: { VITE_DEV_SERVER_URL: 'x' } }));
+    assert.equal(readPublishedViteUrl(file), undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('reuses only a marker that matches every committed cache input', () => {
+  const expected = createRuntimeMarker('43.1.1');
+  assert.equal(isDevelopmentRuntimeCurrent({ ...expected }, expected), true);
+  for (const [key, value] of Object.entries({
+    schemaVersion: 999,
+    electronVersion: '44.0.0',
+    bundleId: 'com.other',
+    // A moved repo must rebuild: the bootstrap embeds the old absolute path.
+    desktopDir: '/moved',
+  })) {
+    assert.equal(isDevelopmentRuntimeCurrent({ ...expected, [key]: value }, expected), false, key);
+  }
+  const { schemaVersion: _omitted, ...markerWithoutSchema } = expected;
+  assert.equal(isDevelopmentRuntimeCurrent(markerWithoutSchema, expected), false);
+  assert.equal(isDevelopmentRuntimeCurrent(null, expected), false);
+});
+
+test('the marker this build writes is the marker the cache check accepts', () => {
+  // Writer and checker are separate code paths. A field renamed on one side
+  // alone would silently rebuild — and re-sign — on every single launch,
+  // churning the bundle the TCC grant is anchored to.
+  assert.equal(
+    isDevelopmentRuntimeCurrent(createRuntimeMarker('43.1.1'), createRuntimeMarker('43.1.1')),
+    true,
+  );
+  assert.equal(
+    isDevelopmentRuntimeCurrent(createRuntimeMarker('43.1.1'), createRuntimeMarker('44.0.0')),
+    false,
+  );
+  // Ad-hoc signatures designate a bare cdhash and TCC keys its rows on the
+  // identifier, so a shared identifier would make worktrees overwrite each
+  // other's grant.
+  assert.match(createRuntimeMarker('43.1.1').bundleId, /^com\.maka\.dev\.[0-9a-f]{12}$/);
 });
 
 test('does not commit a cache marker when runtime preparation fails', async () => {
@@ -295,22 +425,6 @@ test('shutdown is inert when nothing matches or the platform differs', async () 
   );
 });
 
-test('liveness probe checks the worktree bundle path', () => {
-  const probed = [];
-  assert.equal(
-    isDevelopmentAppRunning({
-      executable: '/repo-a/Maka Dev.app/Contents/MacOS/Electron',
-      probe: (path) => {
-        probed.push(path);
-        return true;
-      },
-    }),
-    true,
-  );
-  assert.deepEqual(probed, ['/repo-a/Maka Dev.app/Contents/MacOS/Electron']);
-  assert.equal(isDevelopmentAppRunning({ probe: () => false }), false);
-});
-
 test('escapes regex metacharacters so a path is matched literally', () => {
   // pkill/pgrep -f take an extended regex. A repo under "~/Dropbox (Personal)"
   // would otherwise match nothing, leaving the app impossible to stop.
@@ -319,6 +433,19 @@ test('escapes regex metacharacters so a path is matched literally', () => {
     '/Users/x/Dropbox \\(Personal\\)/Maka Dev\\.app/Contents/MacOS/Electron',
   );
   assert.equal(toProcessMatchPattern('/a[b]/c+d'), '/a\\[b\\]/c\\+d');
+});
+
+test('the real probe survives a hostile bundle path', () => {
+  // Against the actual matcher, not a copy of the escaping regex: unescaped,
+  // the unbalanced '[' makes pgrep exit 2, which the probe turns into a throw.
+  assert.equal(
+    isDevelopmentAppRunning({
+      executable: '/Users/x/Dropbox (Personal)/a[b/Maka Dev.app/Contents/MacOS/Electron',
+    }),
+    false,
+  );
+  // Real pgrep against the real default executable path.
+  assert.equal(typeof isDevelopmentAppRunning({}), 'boolean');
 });
 
 test('defaults target this worktree bundle executable', () => {
@@ -334,15 +461,16 @@ test('defaults target this worktree bundle executable', () => {
   });
   assert.equal(seen, expected);
   let signalled;
-  void quitMacosDevelopmentApp({
+  return quitMacosDevelopmentApp({
     platform: 'darwin',
     delay: () => Promise.resolve(),
     signal: (_name, path) => {
       signalled = path;
       return false;
     },
+  }).then(() => {
+    assert.equal(signalled, expected);
   });
-  assert.equal(signalled, expected);
 });
 
 test('separates --user-data-dir from switches forwarded to Electron', () => {
@@ -351,7 +479,6 @@ test('separates --user-data-dir from switches forwarded to Electron', () => {
     electronArgs: ['--enable-logging'],
   });
   assert.deepEqual(splitDevelopmentCliArgs([]), { userDataDir: undefined, electronArgs: [] });
-  // Empty value falls back to the bootstrap default rather than setting ''.
   assert.equal(splitDevelopmentCliArgs(['--user-data-dir=']).userDataDir, '');
 });
 
@@ -390,5 +517,94 @@ test('claims the app instance before launching or rebuilding', async () => {
       attempts: 2,
     }),
     /still running and could not be stopped/,
+  );
+});
+
+test('liveness and shutdown compose through their own option shapes', async () => {
+  // One options object reaches two callees that accept different keys. Stubbing
+  // only the probe must not leave a real pkill wired up underneath, and the
+  // poll delay must not double as the SIGTERM grace period.
+  const executable = '/repo-a/.maka-dev/Maka Dev.app/Contents/MacOS/Electron';
+  const probed = [];
+  const signals = [];
+  let alive = true;
+  assert.equal(
+    await ensureNoRunningDevelopmentApp({
+      platform: 'darwin',
+      executable,
+      graceMs: 0,
+      probe: (path) => {
+        probed.push(path);
+        return alive;
+      },
+      signal: (name, path) => {
+        signals.push([name, path]);
+        alive = false;
+        return true;
+      },
+      delay: () => Promise.resolve(),
+    }),
+    true,
+  );
+  assert.deepEqual([...new Set(probed)], [executable]);
+  assert.deepEqual(signals, [
+    ['TERM', executable],
+    ['KILL', executable],
+  ]);
+
+  // Pin what each callee is handed, not just the resulting behaviour: passing
+  // the whole object through happens to produce the same signals here, so only
+  // the forwarded shape itself can catch the regression.
+  let forwardedToQuit;
+  let running = true;
+  await ensureNoRunningDevelopmentApp({
+    platform: 'darwin',
+    executable,
+    graceMs: 7,
+    isRunning: () => running,
+    delay: () => Promise.resolve(),
+    quit: (received) => {
+      forwardedToQuit = received;
+      running = false;
+      return Promise.resolve(true);
+    },
+  });
+  assert.deepEqual(Object.keys(forwardedToQuit).sort(), [
+    'executable',
+    'graceMs',
+    'platform',
+    'signal',
+  ]);
+  assert.equal(forwardedToQuit.graceMs, 7);
+});
+
+test('distinguishes a failed launch, a slow launch, and an ordinary quit', async () => {
+  const delay = () => Promise.resolve();
+  // `open` exits 0 at the handoff, so never appearing is the only real failure.
+  assert.equal(
+    await monitorDevelopmentApp({ isRunning: () => false, delay, startupAttempts: 3 }),
+    'never-started',
+  );
+  // A first launch of the freshly signed bundle is slow; it must be waited for
+  // rather than reported as a failure and killed by the shutdown that follows.
+  let attempts = 0;
+  assert.equal(
+    await monitorDevelopmentApp({
+      isRunning: () => (attempts += 1) > 5,
+      delay,
+      startupAttempts: 20,
+      stopped: () => attempts > 6,
+    }),
+    'stopped',
+  );
+  // Appeared, then quit: an ordinary session end at any moment, not a failure.
+  let remaining = 3;
+  assert.equal(
+    await monitorDevelopmentApp({ isRunning: () => (remaining -= 1) > 0, delay }),
+    'exited',
+  );
+  assert.equal(
+    await monitorDevelopmentApp({ isRunning: () => true, delay, stopped: () => true }),
+    'stopped',
   );
 });

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -18,24 +18,15 @@
  *   Vite dev server + Electron            ─── fork
  */
 import { spawn } from 'node:child_process';
-import { existsSync, writeFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createServer } from 'vite';
 import { build as esbuildBuild } from 'esbuild';
 import { buildCursorOverlay } from '../../../scripts/build-cursor-overlay.mjs';
-import {
-  createDevelopmentEnvironmentFile,
-  developmentLogFile,
-  isDevelopmentAppRunning,
-  quitMacosDevelopmentApp,
-  resolveMacosDevelopmentLaunch,
-  writeDevelopmentEnvironment,
-} from './dev-app-runtime.mjs';
+import { monitorDevelopmentApp, startDevelopmentApp } from './dev-app-runtime.mjs';
 
 const DESKTOP_DIR = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const REPO_ROOT    = resolve(DESKTOP_DIR, '..', '..');
-const ON_WINDOWS   = process.platform === 'win32';
 const TSC_CLI      = join(REPO_ROOT, 'node_modules', 'typescript', 'bin', 'tsc');
 const RUNTIME_WORKER_BUILD = join(REPO_ROOT, 'packages', 'runtime', 'scripts', 'build-filesystem-worker.mjs');
 
@@ -58,16 +49,6 @@ function runNodeTool(dir, script, args) {
     });
     child.on('error', reject_);
   });
-}
-
-function resolveElectronBin() {
-  for (let dir = DESKTOP_DIR; ; dir = dirname(dir)) {
-    const exe = ON_WINDOWS
-      ? join(dir, 'node_modules', 'electron', 'dist', 'electron.exe')
-      : join(dir, 'node_modules', '.bin', 'electron');
-    if (existsSync(exe)) return exe;
-    if (dirname(dir) === dir) return 'electron';
-  }
 }
 
 // ── build phases ─────────────────────────────────────────────────────────────
@@ -150,75 +131,48 @@ if (!devUrl) {
 }
 
 log('electron', `launching against ${devUrl} (renderer HMR live)`);
-const cliArgs = process.argv.slice(2);
-const appArgs = [DESKTOP_DIR, ...cliArgs];
-const macosLaunch = await resolveMacosDevelopmentLaunch();
-let logStream = null;
-if (macosLaunch) {
-  writeDevelopmentEnvironment(
-    createDevelopmentEnvironmentFile({ argv: cliArgs, env: process.env, viteUrl: devUrl }),
-  );
-  // `open` redirects the detached app's output here; follow it so the terminal
-  // keeps showing main-process logs and startup failures.
-  writeFileSync(developmentLogFile, '');
-  logStream = spawn('tail', ['-n', '+1', '-F', developmentLogFile], {
-    stdio: ['ignore', 'inherit', 'inherit'],
-  });
-  log('electron', 'launching Maka Dev.app through LaunchServices');
-}
-const electron = spawn(macosLaunch?.command ?? resolveElectronBin(), macosLaunch?.args ?? appArgs, {
-  cwd: DESKTOP_DIR,
-  stdio: 'inherit',
-  env: { ...process.env, VITE_DEV_SERVER_URL: devUrl },
-});
 
+let app = null;
 let shuttingDown = false;
-async function shutdown(code, options = {}) {
+async function shutdown(code) {
   if (shuttingDown) return;
   shuttingDown = true;
-  logStream?.kill();
-  if (macosLaunch) await quitMacosDevelopmentApp();
-  if (options.killElectron !== false) {
-    await terminateProcessTree(electron);
-  }
+  await app?.stop();
   await server.close().catch(() => {});
   process.exit(code);
 }
 
-function terminateProcessTree(child) {
-  if (child.exitCode !== null || child.killed) return Promise.resolve();
-  if (ON_WINDOWS && child.pid) {
-    return new Promise((resolve_) => {
-      const killer = spawn('taskkill', ['/PID', String(child.pid), '/T', '/F'], {
-        stdio: ['ignore', 'ignore', 'ignore'],
-      });
-      killer.on('exit', () => resolve_());
-      killer.on('error', () => resolve_());
-    });
-  }
-  child.kill('SIGTERM');
-  return Promise.resolve();
-}
+// Registered before the launch await: preparing the bundle can take a codesign
+// rebuild, and a signal arriving with no handler installed takes the default
+// action, leaving the dev server and any app behind.
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));
+// Closing the terminal window sends SIGHUP; without this the detached bundle
+// survives as an orphan holding the single-instance lock.
+process.on('SIGHUP', () => shutdown(0));
 
-if (!macosLaunch) {
-  electron.on('exit', (code) => shutdown(code ?? 0, { killElectron: false }));
-} else {
-  electron.on('exit', (code) => {
-    if (code && code !== 0) shutdown(code, { killElectron: false });
-  });
-}
-electron.on('error', (err) => {
+app = await startDevelopmentApp({ argv: process.argv.slice(2), viteUrl: devUrl });
+if (app.isMacosBundle) log('electron', 'launched Maka Dev.app through LaunchServices');
+
+app.child.on('error', (err) => {
   console.error(`[dev] failed to start Electron: ${err.message}`);
   shutdown(1);
 });
-if (macosLaunch) {
-  // `open` exits 0 at the LaunchServices handoff, so its exit code says nothing
-  // about whether the app came up. Check once that a process actually exists.
-  setTimeout(() => {
-    if (shuttingDown || isDevelopmentAppRunning()) return;
-    console.error('[dev] Maka Dev.app did not stay running (see the output above)');
-    shutdown(1);
-  }, 5_000).unref();
+if (app.isMacosBundle) {
+  // `open` exits 0 at the handoff, so only a failure to hand off is news here;
+  // the app's own lifetime is what the monitor reports.
+  app.child.on('exit', (code) => {
+    if (code) shutdown(code);
+  });
+  monitorDevelopmentApp({ stopped: () => shuttingDown }).then((outcome) => {
+    if (outcome === 'never-started') {
+      console.error('[dev] Maka Dev.app did not start (see the output above)');
+      shutdown(1);
+    } else if (outcome === 'exited') {
+      log('electron', 'Maka Dev.app quit');
+      shutdown(0);
+    }
+  });
+} else {
+  app.child.on('exit', (code) => shutdown(code ?? 0));
 }
-process.on('SIGINT', () => shutdown(0));
-process.on('SIGTERM', () => shutdown(0));

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -25,13 +25,11 @@ import { createServer } from 'vite';
 import { build as esbuildBuild } from 'esbuild';
 import { buildCursorOverlay } from '../../../scripts/build-cursor-overlay.mjs';
 import {
-  clearDevelopmentSession,
-  createDevelopmentSession,
+  createDevelopmentEnvironmentFile,
+  isDevelopmentAppRunning,
   quitMacosDevelopmentApp,
-  recoverStaleDevelopmentSession,
   resolveMacosDevelopmentLaunch,
-  waitForMacosDevelopmentApp,
-  writeDevelopmentSession,
+  writeDevelopmentEnvironment,
 } from './dev-app-runtime.mjs';
 
 const DESKTOP_DIR = resolve(fileURLToPath(new URL('..', import.meta.url)));
@@ -152,17 +150,17 @@ if (!devUrl) {
 
 log('electron', `launching against ${devUrl} (renderer HMR live)`);
 const appArgs = [DESKTOP_DIR, ...process.argv.slice(2)];
+const cliArgs = process.argv.slice(2);
 const macosLaunch = await resolveMacosDevelopmentLaunch();
 if (macosLaunch) {
-  await recoverStaleDevelopmentSession();
-  const userDataArg = process.argv.slice(2).find((arg) => arg.startsWith('--user-data-dir='));
-  writeDevelopmentSession(createDevelopmentSession({
-    supervisorPid: process.pid,
+  const userDataArg = cliArgs.find((arg) => arg.startsWith('--user-data-dir='));
+  writeDevelopmentEnvironment(createDevelopmentEnvironmentFile({
     viteUrl: devUrl,
     env: process.env,
     userDataDir: userDataArg?.slice('--user-data-dir='.length),
-    electronArgs: process.argv.slice(2).filter((arg) => !arg.startsWith('--user-data-dir=')),
+    electronArgs: cliArgs.filter((arg) => !arg.startsWith('--user-data-dir=')),
   }));
+  log('electron', 'launching Maka Dev.app through LaunchServices (main-process logs go to Console.app)');
 }
 const electron = spawn(macosLaunch?.command ?? resolveElectronBin(), macosLaunch?.args ?? appArgs, {
   cwd: DESKTOP_DIR,
@@ -174,10 +172,7 @@ let shuttingDown = false;
 async function shutdown(code, options = {}) {
   if (shuttingDown) return;
   shuttingDown = true;
-  if (macosLaunch) {
-    await quitMacosDevelopmentApp();
-    clearDevelopmentSession();
-  }
+  if (macosLaunch) await quitMacosDevelopmentApp();
   if (options.killElectron !== false) {
     await terminateProcessTree(electron);
   }
@@ -212,13 +207,13 @@ electron.on('error', (err) => {
   shutdown(1);
 });
 if (macosLaunch) {
-  void waitForMacosDevelopmentApp().then(
-    () => log('electron', 'Maka Dev startup handshake complete'),
-    (error) => {
-      console.error(`[dev] ${error.message}`);
-      shutdown(1);
-    },
-  );
+  // `open` exits 0 at the LaunchServices handoff, so its exit code says nothing
+  // about whether the app came up. Check once that a process actually exists.
+  setTimeout(() => {
+    if (shuttingDown || isDevelopmentAppRunning()) return;
+    console.error('[dev] Maka Dev.app did not stay running; see Console.app for its output');
+    shutdown(1);
+  }, 5_000).unref();
 }
 process.on('SIGINT', () => shutdown(0));
 process.on('SIGTERM', () => shutdown(0));

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -18,7 +18,7 @@
  *   Vite dev server + Electron            ─── fork
  */
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createServer } from 'vite';
@@ -26,6 +26,7 @@ import { build as esbuildBuild } from 'esbuild';
 import { buildCursorOverlay } from '../../../scripts/build-cursor-overlay.mjs';
 import {
   createDevelopmentEnvironmentFile,
+  developmentLogFile,
   isDevelopmentAppRunning,
   quitMacosDevelopmentApp,
   resolveMacosDevelopmentLaunch,
@@ -149,18 +150,21 @@ if (!devUrl) {
 }
 
 log('electron', `launching against ${devUrl} (renderer HMR live)`);
-const appArgs = [DESKTOP_DIR, ...process.argv.slice(2)];
 const cliArgs = process.argv.slice(2);
+const appArgs = [DESKTOP_DIR, ...cliArgs];
 const macosLaunch = await resolveMacosDevelopmentLaunch();
+let logStream = null;
 if (macosLaunch) {
-  const userDataArg = cliArgs.find((arg) => arg.startsWith('--user-data-dir='));
-  writeDevelopmentEnvironment(createDevelopmentEnvironmentFile({
-    viteUrl: devUrl,
-    env: process.env,
-    userDataDir: userDataArg?.slice('--user-data-dir='.length),
-    electronArgs: cliArgs.filter((arg) => !arg.startsWith('--user-data-dir=')),
-  }));
-  log('electron', 'launching Maka Dev.app through LaunchServices (main-process logs go to Console.app)');
+  writeDevelopmentEnvironment(
+    createDevelopmentEnvironmentFile({ argv: cliArgs, env: process.env, viteUrl: devUrl }),
+  );
+  // `open` redirects the detached app's output here; follow it so the terminal
+  // keeps showing main-process logs and startup failures.
+  writeFileSync(developmentLogFile, '');
+  logStream = spawn('tail', ['-n', '+1', '-F', developmentLogFile], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  log('electron', 'launching Maka Dev.app through LaunchServices');
 }
 const electron = spawn(macosLaunch?.command ?? resolveElectronBin(), macosLaunch?.args ?? appArgs, {
   cwd: DESKTOP_DIR,
@@ -172,6 +176,7 @@ let shuttingDown = false;
 async function shutdown(code, options = {}) {
   if (shuttingDown) return;
   shuttingDown = true;
+  logStream?.kill();
   if (macosLaunch) await quitMacosDevelopmentApp();
   if (options.killElectron !== false) {
     await terminateProcessTree(electron);
@@ -211,7 +216,7 @@ if (macosLaunch) {
   // about whether the app came up. Check once that a process actually exists.
   setTimeout(() => {
     if (shuttingDown || isDevelopmentAppRunning()) return;
-    console.error('[dev] Maka Dev.app did not stay running; see Console.app for its output');
+    console.error('[dev] Maka Dev.app did not stay running (see the output above)');
     shutdown(1);
   }, 5_000).unref();
 }

--- a/apps/desktop/scripts/start-dev-app.mjs
+++ b/apps/desktop/scripts/start-dev-app.mjs
@@ -3,81 +3,55 @@ import { spawn } from 'node:child_process';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  clearDevelopmentSession,
-  createDevelopmentSession,
+  createDevelopmentEnvironmentFile,
   quitMacosDevelopmentApp,
-  recoverStaleDevelopmentSession,
   resolveMacosDevelopmentLaunch,
-  waitForMacosDevelopmentApp,
-  writeDevelopmentSession,
+  writeDevelopmentEnvironment,
 } from './dev-app-runtime.mjs';
 
 const desktopDir = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const repoRoot = resolve(desktopDir, '..', '..');
 const cliArgs = process.argv.slice(2);
-const forwardedArgs = [desktopDir, ...cliArgs];
 const macosLaunch = await resolveMacosDevelopmentLaunch();
 if (macosLaunch) {
-  await recoverStaleDevelopmentSession();
   const userDataArg = cliArgs.find((arg) => arg.startsWith('--user-data-dir='));
-  writeDevelopmentSession(createDevelopmentSession({
-    supervisorPid: process.pid,
-    env: process.env,
-    userDataDir: userDataArg?.slice('--user-data-dir='.length),
-    electronArgs: cliArgs.filter((arg) => !arg.startsWith('--user-data-dir=')),
-  }));
+  writeDevelopmentEnvironment(
+    createDevelopmentEnvironmentFile({
+      env: process.env,
+      userDataDir: userDataArg?.slice('--user-data-dir='.length),
+      electronArgs: cliArgs.filter((arg) => !arg.startsWith('--user-data-dir=')),
+    }),
+  );
 }
 const electronBin =
   process.platform === 'win32'
     ? join(repoRoot, 'node_modules', 'electron', 'dist', 'electron.exe')
     : join(repoRoot, 'node_modules', '.bin', 'electron');
-const command = macosLaunch?.command ?? electronBin;
-const args = macosLaunch?.args ?? ['.', ...process.argv.slice(2)];
 
-const child = spawn(command, args, {
+const child = spawn(macosLaunch?.command ?? electronBin, macosLaunch?.args ?? ['.', ...cliArgs], {
   cwd: desktopDir,
   stdio: 'inherit',
   env: process.env,
 });
+// `open` returns at the LaunchServices handoff, so this process would exit
+// immediately and leave nothing to stop the app on Ctrl-C.
 const keepAlive = macosLaunch ? setInterval(() => undefined, 60_000) : null;
 let stopping = false;
-async function stop() {
+async function stop(code = 0) {
   if (stopping) return;
   stopping = true;
-  if (macosLaunch) {
-    await quitMacosDevelopmentApp();
-    clearDevelopmentSession();
-  } else child.kill('SIGTERM');
+  if (macosLaunch) await quitMacosDevelopmentApp();
+  else child.kill('SIGTERM');
   if (keepAlive) clearInterval(keepAlive);
-  process.exitCode = 0;
+  process.exitCode = code;
 }
 child.on('error', (error) => {
   console.error(`[dev-app] failed to start: ${error.message}`);
-  void stop().then(() => {
-    process.exitCode = 1;
-  });
+  void stop(1);
 });
 child.on('exit', (code, signal) => {
-  if (!macosLaunch && !stopping) {
-    process.exitCode = signal ? 1 : (code ?? 0);
-  } else if (macosLaunch && code && code !== 0) {
-    void stop().then(() => {
-      process.exitCode = code;
-    });
-  }
+  if (!macosLaunch && !stopping) process.exitCode = signal ? 1 : (code ?? 0);
+  else if (macosLaunch && code) void stop(code);
 });
 process.on('SIGINT', () => void stop());
 process.on('SIGTERM', () => void stop());
-if (macosLaunch) {
-  void waitForMacosDevelopmentApp().then(
-    () => console.log('[dev-app] Maka Dev startup handshake complete'),
-    (error) => {
-      console.error(`[dev-app] ${error.message}`);
-      void stop().then(() => {
-        process.exitCode = 1;
-      });
-    },
-  );
-}
-// `open` exits immediately after handing the launch to LaunchServices. The
-// timer above keeps the supervisor alive so app restarts can recover its session.

--- a/apps/desktop/scripts/start-dev-app.mjs
+++ b/apps/desktop/scripts/start-dev-app.mjs
@@ -14,13 +14,8 @@ const repoRoot = resolve(desktopDir, '..', '..');
 const cliArgs = process.argv.slice(2);
 const macosLaunch = await resolveMacosDevelopmentLaunch();
 if (macosLaunch) {
-  const userDataArg = cliArgs.find((arg) => arg.startsWith('--user-data-dir='));
   writeDevelopmentEnvironment(
-    createDevelopmentEnvironmentFile({
-      env: process.env,
-      userDataDir: userDataArg?.slice('--user-data-dir='.length),
-      electronArgs: cliArgs.filter((arg) => !arg.startsWith('--user-data-dir=')),
-    }),
+    createDevelopmentEnvironmentFile({ argv: cliArgs, env: process.env }),
   );
 }
 const electronBin =

--- a/apps/desktop/scripts/start-dev-app.mjs
+++ b/apps/desktop/scripts/start-dev-app.mjs
@@ -1,52 +1,45 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
-import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import {
-  createDevelopmentEnvironmentFile,
-  quitMacosDevelopmentApp,
-  resolveMacosDevelopmentLaunch,
-  writeDevelopmentEnvironment,
-} from './dev-app-runtime.mjs';
+import { monitorDevelopmentApp, startDevelopmentApp } from './dev-app-runtime.mjs';
 
-const desktopDir = resolve(fileURLToPath(new URL('..', import.meta.url)));
-const repoRoot = resolve(desktopDir, '..', '..');
-const cliArgs = process.argv.slice(2);
-const macosLaunch = await resolveMacosDevelopmentLaunch();
-if (macosLaunch) {
-  writeDevelopmentEnvironment(
-    createDevelopmentEnvironmentFile({ argv: cliArgs, env: process.env }),
-  );
-}
-const electronBin =
-  process.platform === 'win32'
-    ? join(repoRoot, 'node_modules', 'electron', 'dist', 'electron.exe')
-    : join(repoRoot, 'node_modules', '.bin', 'electron');
-
-const child = spawn(macosLaunch?.command ?? electronBin, macosLaunch?.args ?? ['.', ...cliArgs], {
-  cwd: desktopDir,
-  stdio: 'inherit',
-  env: process.env,
-});
-// `open` returns at the LaunchServices handoff, so this process would exit
-// immediately and leave nothing to stop the app on Ctrl-C.
-const keepAlive = macosLaunch ? setInterval(() => undefined, 60_000) : null;
+let app = null;
 let stopping = false;
 async function stop(code = 0) {
   if (stopping) return;
   stopping = true;
-  if (macosLaunch) await quitMacosDevelopmentApp();
-  else child.kill('SIGTERM');
-  if (keepAlive) clearInterval(keepAlive);
+  await app?.stop();
   process.exitCode = code;
 }
-child.on('error', (error) => {
+
+// Registered before any await. Preparing the bundle and monitoring the app both
+// suspend this module for a long time, and a signal arriving while no handler
+// is installed takes the default action — killing this process mid-teardown and
+// orphaning the app it was supposed to stop.
+process.on('SIGINT', () => void stop());
+process.on('SIGTERM', () => void stop());
+process.on('SIGHUP', () => void stop());
+
+app = await startDevelopmentApp({ argv: process.argv.slice(2) });
+
+app.child.on('error', (error) => {
   console.error(`[dev-app] failed to start: ${error.message}`);
   void stop(1);
 });
-child.on('exit', (code, signal) => {
-  if (!macosLaunch && !stopping) process.exitCode = signal ? 1 : (code ?? 0);
-  else if (macosLaunch && code) void stop(code);
-});
-process.on('SIGINT', () => void stop());
-process.on('SIGTERM', () => void stop());
+if (app.isMacosBundle) {
+  // `open` exits 0 at the LaunchServices handoff, so this process would end
+  // immediately and leave nothing to stop the app on Ctrl-C. Monitoring the
+  // detached app is both what keeps it alive and what reports the app quitting.
+  app.child.on('exit', (code) => {
+    if (code) void stop(code);
+  });
+  const outcome = await monitorDevelopmentApp({ stopped: () => stopping });
+  if (outcome === 'never-started') {
+    console.error('[dev-app] Maka Dev.app did not start (see the output above)');
+    void stop(1);
+  } else if (outcome === 'exited') {
+    void stop(0);
+  }
+} else {
+  app.child.on('exit', (code, signal) => {
+    if (!stopping) process.exitCode = signal ? 1 : (code ?? 0);
+  });
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,26 +1,5 @@
 import { app, dialog } from 'electron';
-import { renameSync, writeFileSync } from 'node:fs';
 import { isIsolatedE2e } from './startup-context.js';
-
-function writeDevelopmentLaunchRecord(
-  path: string | undefined,
-  record: Record<string, unknown>,
-): void {
-  if (app.isPackaged || !path) return;
-  try {
-    const temporary = `${path}.tmp-${process.pid}`;
-    writeFileSync(temporary, `${JSON.stringify(record)}\n`, { mode: 0o600 });
-    renameSync(temporary, path);
-  } catch (error) {
-    console.error('[maka-dev] failed to report launch state:', error);
-  }
-}
-
-function developmentLaunchIdentity(): { pid: number; supervisorPid: number } | undefined {
-  const supervisorPid = Number(process.env.MAKA_DEV_SUPERVISOR_PID);
-  if (!Number.isSafeInteger(supervisorPid) || supervisorPid <= 0) return undefined;
-  return { pid: process.pid, supervisorPid };
-}
 
 // The macOS app menu title and app.getName() consumers read this name. Set it
 // before ready, unchanged from its historical pre-ready position.
@@ -42,10 +21,6 @@ if (isIsolatedE2e && process.env.MAKA_E2E_USER_DATA_DIR) {
 if (!app.requestSingleInstanceLock()) {
   app.exit(0);
 } else {
-  const developmentIdentity = developmentLaunchIdentity();
-  if (developmentIdentity) {
-    writeDevelopmentLaunchRecord(process.env.MAKA_DEV_APP_PID_FILE, developmentIdentity);
-  }
   // The full boot must not run in the top-level module-evaluation chain:
   // Electron ESM emits `ready` only after the entry module finishes
   // evaluating, so a top-level `await app.whenReady()` (which the
@@ -59,23 +34,8 @@ if (!app.requestSingleInstanceLock()) {
       console.log('[startup] app ready');
       return import('./boot.js');
     })
-    .then(() => {
-      if (developmentIdentity) {
-        writeDevelopmentLaunchRecord(process.env.MAKA_DEV_LAUNCH_STATUS_FILE, {
-          ...developmentIdentity,
-          status: 'ready',
-        });
-      }
-    })
     .catch((error: unknown) => {
       console.error('[startup] fatal:', error);
-      if (developmentIdentity) {
-        writeDevelopmentLaunchRecord(process.env.MAKA_DEV_LAUNCH_STATUS_FILE, {
-          ...developmentIdentity,
-          status: 'failed',
-          message: error instanceof Error ? error.message : String(error),
-        });
-      }
       // E2E runs must not hang on a modal error box (same reasoning as the
       // fixture-fatal path in boot.ts: print a parseable line and exit fast).
       if (!isIsolatedE2e) {

--- a/apps/desktop/src/main/permission-overlay/app-bundle.ts
+++ b/apps/desktop/src/main/permission-overlay/app-bundle.ts
@@ -11,10 +11,11 @@
  *   /Applications/Maka.app/Contents
  *   /Applications/Maka.app                       <- what we drag
  *
- * In the supported macOS development workflow the same walk lands on the
- * generated, signed `Maka Dev.app`, which is also the TCC identity the user
- * grants. The only genuinely
- * unresolvable case is a layout where the walk doesn't end in `.app`
+ * Under `MAKA_DEV_TCC=1` the same walk lands on the generated, signed
+ * `Maka Dev.app`, which is also the TCC identity the user grants. Under a plain
+ * `electron .` it lands on the npm `Electron.app`, which is the honest answer
+ * for that setup even though macOS will not keep a grant for it. The only
+ * genuinely unresolvable case is a layout where the walk doesn't end in `.app`
  * (e.g. an unpacked CI tree), and the caller degrades explicitly there
  * instead of starting a drag that can never be accepted.
  *

--- a/knip.json
+++ b/knip.json
@@ -23,7 +23,7 @@
       ],
       "project": ["src/**/*.{ts,tsx}", "e2e/**/*.ts", "stories/**/*.{ts,tsx}", "scripts/**/*.mjs"],
       "ignoreDependencies": ["@fontsource-variable/geist", "@fontsource-variable/geist-mono"],
-      "ignoreBinaries": ["taskkill", "plutil"]
+      "ignoreBinaries": ["taskkill", "plutil", "pkill", "pgrep"]
     },
     "packages/ui": {
       "entry": ["src/**/*.test.ts", "src/**/*.test.tsx", "stories/**/*.@(ts|tsx)"],

--- a/knip.json
+++ b/knip.json
@@ -23,7 +23,7 @@
       ],
       "project": ["src/**/*.{ts,tsx}", "e2e/**/*.ts", "stories/**/*.{ts,tsx}", "scripts/**/*.mjs"],
       "ignoreDependencies": ["@fontsource-variable/geist", "@fontsource-variable/geist-mono"],
-      "ignoreBinaries": ["taskkill", "plutil", "pkill", "pgrep"]
+      "ignoreBinaries": ["taskkill", "plutil", "pkill", "pgrep", "tail"]
     },
     "packages/ui": {
       "entry": ["src/**/*.test.ts", "src/**/*.test.tsx", "stories/**/*.@(ts|tsx)"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
       },
       "devDependencies": {
         "@ant-design/icons-svg": "4.5.0",
-        "@electron/asar": "3.4.1",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@playwright/test": "^1.61.1",


### PR DESCRIPTION
## Summary

#1920 established the mechanism macOS TCC requires: an ad-hoc-signed `Maka Dev.app` launched through LaunchServices. That stays. This PR removes the session protocol built around it, scopes the grant per worktree, and puts the whole workflow behind `MAKA_DEV_TCC`.

**The session protocol was unnecessary.** `open` returns at the LaunchServices handoff and the system can relaunch the app at any time, so launch-time context was pushed through `session.json`, `app.pid`, `launch-status.json`, a runtime lock, stale-session recovery, a startup handshake, and a launch-record probe injected into `main.ts`. All of it existed to let a detached app pretend it was still a child process. Make the bootstrap depend on build-time constants instead, and publish the environment as ownerless `0600` data, and a relaunch with no arguments and no environment reproduces a correct app by itself. `main.ts` returns to its pre-#1920 state.

**The grant is scoped per worktree, not pinned to a forgeable identity.** TCC keys its rows on the bundle identifier, so the shared `com.maka.dev` meant each worktree silently overwrote the others' row. The identifier is now `com.maka.dev.<worktree-id>`.

An earlier revision of this PR also pinned `designated => identifier "com.maka.dev"` so the grant would survive rebuilds, arguing that this was not weaker because the bundle loads `dist/main/main.js` from outside the signature seal. **That argument was wrong and the change is reverted.** It only shows that repository write access implies use of the grant; it does not show the converse. `codesign --sign -` is available to every unprivileged process, so any binary anywhere on the disk can claim the identifier and satisfy the requirement — demonstrated with a 15-line C program in `/tmp` that satisfies the identifier requirement and fails a cdhash one. And because TCC rows outlive the code they were granted to, the token stays redeemable after this repository is deleted, at which point "anyone who can write the repo" describes nothing at all. The ad-hoc default cdhash requirement stands instead. A rebuild now costs a re-grant, but a rebuild only happens on an Electron bump or a repository move — not on an ordinary `npm run dev`, which is a marker cache hit.

**`npm run dev` and `npm start` were the same logic twice**, and the copies had drifted into different bugs rather than different behaviour. `npm start` never followed the log, so under `MAKA_DEV_TCC` it was completely silent — including bootstrap failures — while the README promised streamed logs. It also republished the environment with no Vite URL, so running it beside a live `npm run dev` silently killed that app and brought up a replacement on the stale prebuilt renderer. Both now go through one `startDevelopmentApp`.

**Launch and rebuild reclaim a leftover app.** Electron's single-instance lock is keyed on userData, so an app surviving a hard-killed session absorbed the new launch: the new process exited 0, the OLD window came forward against a dead Vite URL, and the liveness probe still reported success.

### Claims from earlier revisions that were wrong

Independent review plus direct experiment refuted several things earlier revisions asserted in comments:

| Claim | Reality |
|---|---|
| An identifier requirement is not weaker here | Refuted by experiment; see above. Reverted to the cdhash default. |
| LaunchServices does not inherit the shell environment | `open` forwards the whole parent environment. The env file earns its place for Dock/Spotlight/"Quit & Reopen", which have no parent shell. |
| `Resources/app` would flip `app.isPackaged` to true | `isPackaged` is `basename(execPath) !== 'electron'`. Only the executable's *name* keeps the dev gates on. |
| `ditto` drops quarantine; `xattr -r` is too new | `man ditto`: `--qtn` is the default. `man xattr`: `-r` is in the first synopsis line. |

Excluding `TERM` from the recorded environment turned out to matter more than "it goes stale": `shell-env.ts` short-circuits when `TERM` is present, so a recorded one would leave a Dock launch on launchd's minimal `PATH`.

Also fixed: `pkill -f`/`pgrep -f` take an **extended regex**, so an unescaped path under e.g. `~/Dropbox (Personal)` matched nothing and left the app unkillable, while a pattern error was read as "not running"; the single 5s liveness check reported a false failure when the app was quit early, never noticed a quit after 5s (hanging the terminal), and could kill a slow first launch — it is now a monitor that waits for the app to appear and treats a later disappearance as an ordinary session end; signal handlers are registered *before* the launch await, since a signal arriving during the codesign rebuild took the default action and orphaned the app (observed: exit 130 with the app and its log tail leaked); `app.log` is created `0600`; a failed rebuild no longer leaves ~250 MB of staging behind; the stale `ElectronAsarIntegrity` record is removed; and `.maka-dev-session/` stays gitignored because the pre-opt-in launcher ran unconditionally and its leftover `session.json` holds forwarded API keys.

Refs #1920

## Verification

On-device, macOS 25.5.0 / Electron 43.1.1:

- **Identity and requirement** — `Identifier=com.maka.dev.5b9c7a5a7a17`, `designated => cdhash H"12ce55…"`, helpers keep `com.github.Electron.helper`, `--verify --deep --strict` passes. An ad-hoc-signed impostor claiming the same identifier is **rejected** (exit 3); against the previous revision's identifier requirement it was accepted (exit 0).
- **Cache** — a second `prepare:dev-app` leaves the cdhash unchanged, so ordinary development does not churn the bundle the grant is anchored to.
- **Lifecycle** — Ctrl-C on both `npm run dev` and `npm start`: exit 0, no leftover app, no leftover `tail`, Vite port released. Quitting the app mid-session ends the dev session cleanly (`Maka Dev.app quit`) instead of hanging.
- **`npm start` fixes** — terminal now shows `[startup] app ready`; the published Vite URL survives a reclaiming launch instead of being dropped.
- **Modes** — `app.log` and `dev-env.json` both `0600`.
- **Default path** — without `MAKA_DEV_TCC` it runs `node .bin/electron <desktopDir>` and never touches the bundle.
- `npm run test:scripts` 78/78 · typecheck · format:check · lint — all clean.

Tests **execute** the generated bootstrap against a stub Electron module rather than regex-matching its source. Six mutations were used to check the suite can actually go red: inverting the opt-in gate, renaming a marker field, dropping the log redirection, moving the payload to `Resources/app`, collapsing the forwarded option shapes, and misreporting a failed launch as a normal exit — all six are caught.

## On not testing the grant by hand

The TCC grant itself was not exercised, and does not need to be for this PR. In TCC terms this branch differs from `main` by one string: `main` (i.e. #1920) already signs ad hoc and already takes codesign's **default cdhash** designated requirement. An earlier revision of this PR deviated by pinning `-r=identifier`; that is now reverted, so the requirement matches `main` and the only remaining change is the per-worktree suffix on the identifier — strictly more isolation.

Whether an ad-hoc-signed bundle can hold a grant at all is therefore a premise of #1920, already on `main`, neither introduced nor worsened by this PR. The parts this PR does change were verified by experiment rather than by argument: an impostor claiming the identifier is rejected, a rebuild leaves the cdhash unchanged, strict verification passes, and the helper bundles keep `com.github.Electron.helper` — which `main`'s `--deep --identifier` had been overwriting.

## Known limitation

`dev-env.json` outlives the session, so a Dock launch long after `npm run dev` stopped points at a Vite URL that is no longer served and the window stays blank; if another worktree has since taken that port, it loads *that* renderer instead, which looks like it worked. Deleting the file on exit would break "Quit & Reopen", the capability this design exists to keep; a proper fix belongs in `main-window.ts`'s load-failure path and is out of scope. Documented in the README.

