### PR TITLE
refactor(desktop): remove unused Usage preload bridge

### DIFF
--- a/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
@@ -7,6 +7,16 @@ const desktopRoot = process.cwd().endsWith(join('apps', 'desktop'))
   ? process.cwd()
   : join(process.cwd(), 'apps', 'desktop');
 
+// Temporary Main-only Usage/Pricing routes; coordinate Host replacement in #2010 and #2015.
+const RETAINED_MAIN_ONLY_CHANNELS = new Set([
+  'usage:summary',
+  'usage:buckets',
+  'usage:logs',
+  'usage:pricing:list',
+  'usage:pricing:put',
+  'usage:pricing:reset',
+]);
+
 async function findTypeScriptFiles(directory: string): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true });
   const files = await Promise.all(
@@ -27,7 +37,7 @@ function extractChannels(source: string, pattern: RegExp): Set<string> {
 }
 
 describe('IPC surface contract', () => {
-  it('keeps main handlers and preload invocations in parity', async () => {
+  it('keeps preload parity except for the retained Usage authority handlers', async () => {
     const mainFiles = await findTypeScriptFiles(join(desktopRoot, 'src', 'main'));
     const [mainSources, preloadSource] = await Promise.all([
       Promise.all(mainFiles.map((file) => readFile(file, 'utf8'))),
@@ -42,6 +52,22 @@ describe('IPC surface contract', () => {
       /ipcRenderer\.invoke\(\s*['"]([^'"]+)['"]/g,
     );
 
-    assert.deepEqual([...mainChannels].sort(), [...preloadChannels].sort());
+    const retainedMainChannels = new Set(
+      [...mainChannels].filter((channel) => RETAINED_MAIN_ONLY_CHANNELS.has(channel)),
+    );
+    const exposedMainChannels = new Set(
+      [...mainChannels].filter((channel) => !RETAINED_MAIN_ONLY_CHANNELS.has(channel)),
+    );
+
+    assert.deepEqual(
+      [...retainedMainChannels].sort(),
+      [...RETAINED_MAIN_ONLY_CHANNELS].sort(),
+      'every approved Main-only Usage handler must remain registered',
+    );
+    assert.deepEqual(
+      [...exposedMainChannels].sort(),
+      [...preloadChannels].sort(),
+      'all other Main handlers and preload invocations must stay in exact parity',
+    );
   });
 });

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -79,14 +79,6 @@ import type {
   DeepResearchRun,
   LocalMemoryEntryPreview,
 } from '@maka/core';
-import type {
-  PricingConfig,
-  UsageBucket,
-  UsageGroupBy,
-  UsageLogRow,
-  UsageQuery,
-  UsageSummaryV2,
-} from '@maka/core/usage-stats/types';
 import type { SessionTrace } from '@maka/core/session-trace';
 import type { TestProxyInput } from '@maka/core/settings/network-settings';
 import type { Result } from '@maka/core/result';
@@ -586,14 +578,6 @@ export interface MakaBridge {
   inspector: {
     /** Read-only per-session causal trace (#1625). */
     trace(sessionId: string): Promise<Result<SessionTrace>>;
-  };
-  usage: {
-    summary(query: UsageQuery): Promise<Result<UsageSummaryV2>>;
-    buckets(query: UsageQuery & { groupBy: UsageGroupBy }): Promise<Result<UsageBucket[]>>;
-    logs(query: UsageQuery & { offset?: number; limit?: number }): Promise<Result<{ rows: UsageLogRow[]; total: number }>>;
-    listPricing(): Promise<Result<PricingConfig[]>>;
-    putPricing(pricing: PricingConfig): Promise<Result<PricingConfig>>;
-    resetPricing(modelKey: string): Promise<Result<void>>;
   };
   webSearch: {
     query(input: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -90,14 +90,6 @@ import type {
   DeepResearchChangedEvent,
   DeepResearchRun,
 } from '@maka/core';
-import type {
-  PricingConfig,
-  UsageBucket,
-  UsageGroupBy,
-  UsageLogRow,
-  UsageQuery,
-  UsageSummaryV2,
-} from '@maka/core/usage-stats/types';
 import type { SessionTrace } from '@maka/core/session-trace';
 import type {
   AgentGraphClientChangedEvent,
@@ -907,26 +899,6 @@ const makaBridge = {
     /** Read-only per-session causal trace (#1625). Never writes runtime state. */
     trace(sessionId: string): Promise<Result<SessionTrace>> {
       return ipcRenderer.invoke('inspector:trace', sessionId);
-    },
-  },
-  usage: {
-    summary(query: UsageQuery): Promise<Result<UsageSummaryV2>> {
-      return ipcRenderer.invoke('usage:summary', query);
-    },
-    buckets(query: UsageQuery & { groupBy: UsageGroupBy }): Promise<Result<UsageBucket[]>> {
-      return ipcRenderer.invoke('usage:buckets', query);
-    },
-    logs(query: UsageQuery & { offset?: number; limit?: number }): Promise<Result<{ rows: UsageLogRow[]; total: number }>> {
-      return ipcRenderer.invoke('usage:logs', query);
-    },
-    listPricing(): Promise<Result<PricingConfig[]>> {
-      return ipcRenderer.invoke('usage:pricing:list');
-    },
-    putPricing(pricing: PricingConfig): Promise<Result<PricingConfig>> {
-      return ipcRenderer.invoke('usage:pricing:put', pricing);
-    },
-    resetPricing(modelKey: string): Promise<Result<void>> {
-      return ipcRenderer.invoke('usage:pricing:reset', modelKey);
     },
   },
   dailyReview: {


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- remove the unused `window.maka.usage` preload namespace and its renderer type contract
- keep `settings.usageStats`, which still powers the current Usage page
- keep all six Main-process detailed Usage/Pricing handlers for the planned Runtime Host Desktop adapter

## Why

The deleted namespace has no renderer, Storybook, or E2E consumer. Its pricing mutations also predate the Host revision/CAS contract, so keeping it would freeze the wrong renderer interface before #2010 has a real Pricing consumer.

The IPC surface test now names these six handlers as the only approved Main-only channels. It still requires exact Main/preload parity everywhere else and separately proves that every retained handler remains registered.

## Validation

- `npm run build:test`
- `node --test apps/desktop/dist/main/__tests__/ipc-surface-contract.test.js apps/desktop/dist/main/__tests__/usage-ipc-main.test.js`
- `npm --workspace @maka/desktop run test:checks`
- `npm run lint`
- `npm run format:check`
- `git diff --check origin/main...HEAD`

Part of #1982. Pricing Settings is tracked in #2015 and remains coordinated with #2010.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 删除未使用的 `window.maka.usage` preload namespace 及其 renderer 类型契约
- 保留当前 Usage 页面仍在使用的 `settings.usageStats`
- 保留全部六个 Main 侧详细 Usage/Pricing handlers，供计划中的 Runtime Host Desktop adapter 接线

## 原因

被删除的 namespace 在 renderer、Storybook 和 E2E 中都没有消费者。它的 pricing mutation 也早于 Host 的 revision/CAS 契约；在 #2010 出现真实 Pricing consumer 之前继续保留，会提前冻结错误的 renderer interface。

IPC surface test 现在把这六个 handler 明确列为唯一允许的 Main-only channels。除此之外仍保持 Main/preload 严格一一对应，并单独证明六个保留 handler 一项都不能缺失。

## 验证

- `npm run build:test`
- `node --test apps/desktop/dist/main/__tests__/ipc-surface-contract.test.js apps/desktop/dist/main/__tests__/usage-ipc-main.test.js`
- `npm --workspace @maka/desktop run test:checks`
- `npm run lint`
- `npm run format:check`
- `git diff --check origin/main...HEAD`

属于 #1982 的一部分。Pricing Settings 由 #2015 跟踪，并继续与 #2010 协调。

</details>
