### PR TITLE
feat(memory): add durable extraction storage

### DIFF
--- a/packages/core/src/long-term-memory.ts
+++ b/packages/core/src/long-term-memory.ts
@@ -41,7 +41,68 @@ export const MEMORY_MUTATION_TYPES = ['create', 'update', 'archive', 'restore'] 
 export type MemoryMutationType = (typeof MEMORY_MUTATION_TYPES)[number];
 export type MemoryWriteOperationType = MemoryMutationType | 'batch';
 
+export const MEMORY_EXTRACTION_MODES = ['sweep', 'targeted'] as const;
+export type MemoryExtractionMode = (typeof MEMORY_EXTRACTION_MODES)[number];
+
+export const MEMORY_EXTRACTION_TRIGGER_KINDS = [
+  'context_threshold',
+  'compaction',
+  'user_requested',
+  'agent_requested',
+] as const;
+export type MemoryExtractionTriggerKind = (typeof MEMORY_EXTRACTION_TRIGGER_KINDS)[number];
+
+export const MEMORY_EXTRACTION_OPERATION_STATES = [
+  'pending',
+  'running',
+  'succeeded',
+  'failed',
+] as const;
+export type MemoryExtractionOperationState = (typeof MEMORY_EXTRACTION_OPERATION_STATES)[number];
+
+export const MEMORY_EXTRACTION_ATTEMPT_STATES = [
+  'running',
+  'succeeded',
+  'failed',
+  'abandoned',
+] as const;
+export type MemoryExtractionAttemptState = (typeof MEMORY_EXTRACTION_ATTEMPT_STATES)[number];
+
+export const MEMORY_EXTRACTION_SNAPSHOT_KINDS = [
+  'provider_prefix',
+  'runtime_delta',
+  'reconstructed_full',
+] as const;
+export type MemoryExtractionSnapshotKind = (typeof MEMORY_EXTRACTION_SNAPSHOT_KINDS)[number];
+
+export const MEMORY_EXTRACTION_FAILURE_STAGES = [
+  'admission',
+  'provider',
+  'search',
+  'read',
+  'submit',
+  'commit',
+  'recovery',
+  'cleanup',
+] as const;
+export type MemoryExtractionFailureStage = (typeof MEMORY_EXTRACTION_FAILURE_STAGES)[number];
+
+export const MEMORY_EXTRACTION_CLEANUP_STATES = ['pending', 'running', 'completed'] as const;
+export type MemoryExtractionCleanupState = (typeof MEMORY_EXTRACTION_CLEANUP_STATES)[number];
+
+export const MEMORY_EXTRACTION_RESULT_TYPES = [
+  'proposed',
+  'empty',
+  'unresolved',
+  'not_storable',
+] as const;
+export type MemoryExtractionResultType = (typeof MEMORY_EXTRACTION_RESULT_TYPES)[number];
+
+/** Store and scheduler hard cap for one atomic multi-Run Sweep. */
+export const MEMORY_EXTRACTION_MAX_RANGES = 32;
+
 export const LONG_TERM_MEMORY_CONTENT_MAX_CODE_POINTS = 2_000;
+export type MemorySha256Digest = `sha256:${string}`;
 
 const LONG_TERM_MEMORY_CONTROL_CHARS = new RegExp(
   `[${String.fromCharCode(0x00)}-${String.fromCharCode(0x1f)}${String.fromCharCode(0x7f)}-${String.fromCharCode(0x9f)}]`,
@@ -179,11 +240,347 @@ export interface SearchMemoryItemsByKeyRequest {
   readonly limit?: number;
 }
 
+/** A frozen sweep range. Event sequence values are comparable only within its Run. */
+export interface MemoryExtractionOperationRange {
+  readonly operationId: string;
+  readonly rangeOrdinal: number;
+  readonly sessionId: string;
+  readonly invocationId: string;
+  readonly runId: string;
+  readonly turnId: string;
+  readonly fromEventSeqExclusive: number;
+  readonly fromEventId: string | null;
+  readonly fromPrefixDigest: MemorySha256Digest | null;
+  readonly toEventSeqInclusive: number;
+  readonly toEventId: string;
+  readonly toPrefixDigest: MemorySha256Digest;
+}
+
+export type MemoryExtractionOperationRangeInput = Omit<
+  MemoryExtractionOperationRange,
+  'operationId'
+>;
+
+/** Persistent task authority for one frozen memory-extraction input. */
+export interface MemoryExtractionOperation {
+  readonly operationId: string;
+  readonly sessionId: string;
+  readonly mode: MemoryExtractionMode;
+  readonly triggerKind: MemoryExtractionTriggerKind;
+  readonly internalSessionId: string;
+  readonly sessionCreateFingerprint: MemorySha256Digest;
+  readonly requestHash: MemorySha256Digest;
+  readonly requestJson: string;
+  readonly triggerEpoch: string | null;
+  readonly state: MemoryExtractionOperationState;
+  readonly attemptCount: number;
+  readonly activeAttemptId: string | null;
+  readonly leaseExpiresAt: number | null;
+  readonly nextAttemptAt: number | null;
+  readonly lastErrorCode: string | null;
+  readonly lastErrorStage: MemoryExtractionFailureStage | null;
+  readonly lastErrorAt: number | null;
+  readonly lastFailedAttemptId: string | null;
+  readonly startedAt: number | null;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly completedAt: number | null;
+  readonly resultType: MemoryExtractionResultType | null;
+  /** Raw lowercase SHA-256 hex, matching memory_write_operations.request_hash. */
+  readonly commitHash: string | null;
+  readonly receipt: MemoryExtractionCommitReceipt | null;
+  readonly diagnosticRetentionUntil: number | null;
+  readonly cleanupState: MemoryExtractionCleanupState | null;
+  readonly cleanupClaimId: string | null;
+  readonly cleanupLeaseExpiresAt: number | null;
+  readonly cleanupAttemptCount: number;
+  readonly cleanupErrorCode: string | null;
+  readonly cleanedAt: number | null;
+  readonly ranges: readonly MemoryExtractionOperationRange[];
+}
+
+export interface CreateMemoryExtractionOperationRequest {
+  readonly operationId: string;
+  readonly sessionId: string;
+  readonly mode: MemoryExtractionMode;
+  readonly triggerKind: MemoryExtractionTriggerKind;
+  readonly internalSessionId: string;
+  readonly sessionCreateFingerprint: MemorySha256Digest;
+  /** Semantic task hash; cache-only capture hints must not be its sole input. */
+  readonly requestHash: MemorySha256Digest;
+  /** Versioned boundary/search manifest. It must not contain prompts or proposal text. */
+  readonly requestJson: string;
+  readonly triggerEpoch?: string | null;
+  /** Required for sweep and forbidden for targeted operations. */
+  readonly ranges?: readonly MemoryExtractionOperationRangeInput[];
+  /** Atomic admission ceiling for unfinished Targeted Operations in this Session. */
+  readonly maxUnfinishedTargetedPerSession?: number;
+}
+
+export interface CreateMemoryExtractionOperationResult {
+  readonly operation: MemoryExtractionOperation;
+  readonly replayed: boolean;
+}
+
+/** Numeric-only durable diagnostics. Raw provider output and errors are intentionally excluded. */
+export interface MemoryExtractionAttemptMetrics {
+  readonly version: 1;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheWriteTokens?: number;
+  readonly latencyMs?: number;
+  readonly searchCount?: number;
+  readonly readCount?: number;
+}
+
+export interface MemoryExtractionAttempt {
+  readonly attemptId: string;
+  readonly operationId: string;
+  readonly attemptOrdinal: number;
+  readonly state: MemoryExtractionAttemptState;
+  readonly turnId: string;
+  readonly runId: string;
+  readonly snapshotKind: MemoryExtractionSnapshotKind;
+  readonly startedAt: number;
+  readonly completedAt: number | null;
+  readonly failureCode: string | null;
+  readonly failureStage: MemoryExtractionFailureStage | null;
+  readonly metrics: MemoryExtractionAttemptMetrics | null;
+}
+
+export interface ClaimMemoryExtractionOperationRequest {
+  readonly operationId: string;
+  readonly attemptId: string;
+  readonly turnId: string;
+  readonly runId: string;
+  readonly snapshotKind: MemoryExtractionSnapshotKind;
+  readonly leaseExpiresAt: number;
+  /** Optional durable retry ceiling enforced atomically before a new Attempt is created. */
+  readonly maxAttempts?: number;
+  /** Required with maxAttempts so exhaustion can enter retained terminal failure. */
+  readonly diagnosticRetentionUntil?: number;
+}
+
+export interface ClaimMemoryExtractionOperationResult {
+  readonly operation: MemoryExtractionOperation;
+  readonly attempt: MemoryExtractionAttempt;
+  readonly replayed: boolean;
+}
+
+export interface ListRecoverableMemoryExtractionsRequest {
+  /**
+   * Eligibility is evaluated against the Store clock; callers cannot supply `now`.
+   * The Store applies a bounded default and rejects values above its hard cap.
+   */
+  readonly limit?: number;
+}
+
+export interface ListUnassignedMemoryExtractionSweepDebtsRequest {
+  readonly limit?: number;
+}
+
+/** A durable Sweep boundary that was requested but has no active Operation. */
+export type MemoryExtractionSweepDebt = MemoryExtractionCursor & {
+  readonly activeSweepOperationId: null;
+};
+
+export interface CreateMemoryExtractionSweepFollowupRequest {
+  readonly operation: CreateMemoryExtractionOperationRequest;
+  /** CAS guard captured by the reconciler before it builds the follow-up request. */
+  readonly expectedCursorVersion: number;
+}
+
+export interface RenewMemoryExtractionAttemptLeaseRequest {
+  readonly operationId: string;
+  readonly attemptId: string;
+  /** Trusted Child AgentRun identity bound when the Attempt was claimed. */
+  readonly runId: string;
+  readonly leaseExpiresAt: number;
+}
+
+export interface FailMemoryExtractionAttemptRequest {
+  readonly operationId: string;
+  readonly attemptId: string;
+  readonly runId: string;
+  readonly failureCode: string;
+  readonly failureStage: MemoryExtractionFailureStage;
+  readonly metrics?: MemoryExtractionAttemptMetrics | null;
+  /** When set, the Operation returns to pending; otherwise this is its final failure. */
+  readonly nextAttemptAt?: number | null;
+  /** Required for a final failure and ignored for a retryable failure. */
+  readonly diagnosticRetentionUntil?: number | null;
+}
+
+export interface MemoryExtractionCursor {
+  readonly sessionId: string;
+  readonly invocationId: string;
+  readonly runId: string;
+  readonly turnId: string;
+  readonly committedEventSeq: number;
+  readonly committedEventId: string | null;
+  readonly committedPrefixDigest: MemorySha256Digest | null;
+  readonly requestedEventSeq: number;
+  readonly requestedEventId: string | null;
+  readonly requestedPrefixDigest: MemorySha256Digest | null;
+  readonly activeSweepOperationId: string | null;
+  readonly version: number;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
+
+/** Raise, but never lower, a running sweep's requested high-water boundary. */
+export interface RaiseMemoryExtractionRequestedBoundaryRequest {
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly activeSweepOperationId: string;
+  readonly requestedEventSeq: number;
+  readonly requestedEventId: string;
+  readonly requestedPrefixDigest: MemorySha256Digest;
+}
+
+export interface SearchMemoryExtractionCandidatesRequest {
+  readonly content: string;
+  readonly kind: MemoryItemKind;
+  readonly statementType: MemoryStatementType;
+  readonly temporalType: MemoryTemporalType;
+  readonly scopeType: MemoryScopeType;
+  readonly scopeKey?: string | null;
+  readonly eventStartedAt?: number | null;
+  readonly eventEndedAt?: number | null;
+  readonly keys: readonly string[];
+  readonly sourceEventIds?: readonly string[];
+  /** Hard-capped by the Store at 20. */
+  readonly limit?: number;
+}
+
+export interface MemoryExtractionCandidate {
+  readonly record: MemoryItemRecord;
+  readonly contentHashMatch: boolean;
+  readonly sourceOverlapCount: number;
+  readonly exactKeyMatchCount: number;
+  readonly kindMatch: boolean;
+  readonly statementTypeMatch: boolean;
+  readonly temporalMatch: boolean;
+}
+
+export interface SearchMemoryExtractionCandidatesResult {
+  readonly candidates: readonly MemoryExtractionCandidate[];
+  readonly truncated: boolean;
+}
+
+export interface CommitMemoryExtractionRequest {
+  readonly operationId: string;
+  readonly attemptId: string;
+  /** Trusted Child AgentRun identity bound when the Attempt was claimed. */
+  readonly runId: string;
+  readonly resultType: MemoryExtractionResultType;
+  readonly selectionSaturated: boolean;
+  readonly evidenceDigest: MemorySha256Digest;
+  readonly mutations: readonly MemoryItemMutation[];
+  readonly diagnosticRetentionUntil: number;
+}
+
+export interface MemoryExtractionCommitReceipt {
+  readonly schemaVersion: 1;
+  readonly operationId: string;
+  readonly attemptId: string;
+  readonly resultType: MemoryExtractionResultType;
+  readonly selectionSaturated: boolean;
+  readonly evidenceDigest: MemorySha256Digest;
+  readonly mutationDigest: MemorySha256Digest;
+  readonly writeOperationId: string;
+  readonly committedAt: number;
+  readonly mutationResults: readonly MemoryMutationResult[];
+  /** Frozen post-commit snapshots; replay never re-reads later Cursor state. */
+  readonly cursors: readonly MemoryExtractionCursor[];
+}
+
+export interface CommitMemoryExtractionResult {
+  readonly operation: MemoryExtractionOperation;
+  readonly attempt: MemoryExtractionAttempt;
+  readonly writeOperation: MemoryWriteOperationResult;
+  readonly cursors: readonly MemoryExtractionCursor[];
+  readonly receipt: MemoryExtractionCommitReceipt;
+  readonly resultType: MemoryExtractionResultType;
+  readonly replayed: boolean;
+}
+
+export interface ClaimMemoryExtractionCleanupRequest {
+  readonly operationId: string;
+  readonly claimId: string;
+  readonly leaseExpiresAt: number;
+}
+
+export interface FinishMemoryExtractionCleanupRequest {
+  readonly operationId: string;
+  readonly claimId: string;
+  /** Omit on success; a stable code returns the cleanup task to pending. */
+  readonly errorCode?: string;
+}
+
+export interface CancelMemoryExtractionsForSessionsRequest {
+  readonly sessionIds: readonly string[];
+  readonly diagnosticRetentionUntil: number;
+}
+
 export interface MemoryItemStore {
   applyMutations(request: ApplyMemoryMutationsRequest): Promise<MemoryWriteOperationResult>;
   readItem(itemId: string): Promise<MemoryItemRecord | undefined>;
   searchByKeys(request: SearchMemoryItemsByKeyRequest): Promise<readonly MemoryItemRecord[]>;
   readOperation(operationId: string): Promise<MemoryWriteOperationResult | undefined>;
+  createMemoryExtractionOperation(
+    request: CreateMemoryExtractionOperationRequest,
+  ): Promise<CreateMemoryExtractionOperationResult>;
+  claimMemoryExtractionOperation(
+    request: ClaimMemoryExtractionOperationRequest,
+  ): Promise<ClaimMemoryExtractionOperationResult | undefined>;
+  listRecoverableMemoryExtractions(
+    request?: ListRecoverableMemoryExtractionsRequest,
+  ): Promise<readonly MemoryExtractionOperation[]>;
+  /** Terminal Operations whose diagnostic retention elapsed and whose cleanup is claimable. */
+  listRecoverableMemoryExtractionCleanups(
+    request?: ListRecoverableMemoryExtractionsRequest,
+  ): Promise<readonly MemoryExtractionOperation[]>;
+  hasUnfinishedMemoryExtractions(): Promise<boolean>;
+  listUnassignedMemoryExtractionSweepDebts(
+    request?: ListUnassignedMemoryExtractionSweepDebtsRequest,
+  ): Promise<readonly MemoryExtractionSweepDebt[]>;
+  createMemoryExtractionSweepFollowup(
+    request: CreateMemoryExtractionSweepFollowupRequest,
+  ): Promise<CreateMemoryExtractionOperationResult | undefined>;
+  renewMemoryExtractionAttemptLease(
+    request: RenewMemoryExtractionAttemptLeaseRequest,
+  ): Promise<MemoryExtractionOperation>;
+  failMemoryExtractionAttempt(
+    request: FailMemoryExtractionAttemptRequest,
+  ): Promise<MemoryExtractionOperation>;
+  readMemoryExtractionOperation(
+    operationId: string,
+  ): Promise<MemoryExtractionOperation | undefined>;
+  readMemoryExtractionAttempt(attemptId: string): Promise<MemoryExtractionAttempt | undefined>;
+  readMemoryExtractionCursor(
+    sessionId: string,
+    runId: string,
+  ): Promise<MemoryExtractionCursor | undefined>;
+  raiseMemoryExtractionRequestedBoundary(
+    request: RaiseMemoryExtractionRequestedBoundaryRequest,
+  ): Promise<MemoryExtractionCursor>;
+  searchMemoryExtractionCandidates(
+    request: SearchMemoryExtractionCandidatesRequest,
+  ): Promise<SearchMemoryExtractionCandidatesResult>;
+  commitMemoryExtraction(
+    request: CommitMemoryExtractionRequest,
+  ): Promise<CommitMemoryExtractionResult>;
+  claimMemoryExtractionCleanup(
+    request: ClaimMemoryExtractionCleanupRequest,
+  ): Promise<MemoryExtractionOperation | undefined>;
+  finishMemoryExtractionCleanup(
+    request: FinishMemoryExtractionCleanupRequest,
+  ): Promise<MemoryExtractionOperation>;
+  cancelMemoryExtractionsForSessions(
+    request: CancelMemoryExtractionsForSessionsRequest,
+  ): Promise<readonly string[]>;
 }
 
 export type MemoryItemStoreConflictReason =
@@ -192,7 +589,13 @@ export type MemoryItemStoreConflictReason =
   | 'duplicate_active'
   | 'duplicate_within_batch'
   | 'item_not_found'
-  | 'invalid_lifecycle_transition';
+  | 'invalid_lifecycle_transition'
+  | 'extraction_operation_not_found'
+  | 'extraction_operation_not_claimable'
+  | 'extraction_queue_full'
+  | 'extraction_attempt_not_active'
+  | 'extraction_cursor_conflict'
+  | 'extraction_cleanup_conflict';
 
 export class MemoryItemStoreConflictError extends Error {
   readonly name = 'MemoryItemStoreConflictError';
@@ -295,6 +698,50 @@ export function isMemoryKeyType(value: unknown): value is MemoryKeyType {
 
 export function isMemoryKeyOrigin(value: unknown): value is MemoryKeyOrigin {
   return memberOf(MEMORY_KEY_ORIGINS, value);
+}
+
+export function isMemoryExtractionMode(value: unknown): value is MemoryExtractionMode {
+  return memberOf(MEMORY_EXTRACTION_MODES, value);
+}
+
+export function isMemoryExtractionTriggerKind(
+  value: unknown,
+): value is MemoryExtractionTriggerKind {
+  return memberOf(MEMORY_EXTRACTION_TRIGGER_KINDS, value);
+}
+
+export function isMemoryExtractionOperationState(
+  value: unknown,
+): value is MemoryExtractionOperationState {
+  return memberOf(MEMORY_EXTRACTION_OPERATION_STATES, value);
+}
+
+export function isMemoryExtractionAttemptState(
+  value: unknown,
+): value is MemoryExtractionAttemptState {
+  return memberOf(MEMORY_EXTRACTION_ATTEMPT_STATES, value);
+}
+
+export function isMemoryExtractionSnapshotKind(
+  value: unknown,
+): value is MemoryExtractionSnapshotKind {
+  return memberOf(MEMORY_EXTRACTION_SNAPSHOT_KINDS, value);
+}
+
+export function isMemoryExtractionFailureStage(
+  value: unknown,
+): value is MemoryExtractionFailureStage {
+  return memberOf(MEMORY_EXTRACTION_FAILURE_STAGES, value);
+}
+
+export function isMemoryExtractionCleanupState(
+  value: unknown,
+): value is MemoryExtractionCleanupState {
+  return memberOf(MEMORY_EXTRACTION_CLEANUP_STATES, value);
+}
+
+export function isMemoryExtractionResultType(value: unknown): value is MemoryExtractionResultType {
+  return memberOf(MEMORY_EXTRACTION_RESULT_TYPES, value);
 }
 
 function memberOf<const T extends readonly string[]>(

--- a/packages/storage/src/__tests__/sqlite-long-term-memory-extraction.test.ts
+++ b/packages/storage/src/__tests__/sqlite-long-term-memory-extraction.test.ts
@@ -1,0 +1,828 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type {
+  CreateMemoryExtractionOperationRequest,
+  MemoryItemWrite,
+  MemorySha256Digest,
+} from '@maka/core/long-term-memory';
+import { LONG_TERM_MEMORY_DATABASE_NAME } from '../long-term-memory-store.js';
+import {
+  SqliteMemoryItemStore,
+  type SqliteMemoryItemStoreFailpoint,
+} from '../sqlite-long-term-memory-store.js';
+
+const DIGEST_A = digest('a');
+const DIGEST_B = digest('b');
+
+describe('SQLite long-term memory extraction', () => {
+  test('commits an empty sweep atomically and replays its frozen receipt', async () => {
+    await withExtractionStore(async ({ store, setNow }) => {
+      await store.createMemoryExtractionOperation(sweepOperation());
+      await store.claimMemoryExtractionOperation({
+        operationId: 'operation-1',
+        attemptId: 'attempt-1',
+        turnId: 'memory-turn-1',
+        runId: 'memory-run-1',
+        snapshotKind: 'provider_prefix',
+        leaseExpiresAt: 2_000,
+      });
+
+      const committed = await store.commitMemoryExtraction(emptyCommit());
+      assert.equal(committed.replayed, false);
+      assert.equal(committed.resultType, 'empty');
+      assert.equal(committed.cursors[0]?.committedEventSeq, 3);
+      assert.equal(committed.cursors[0]?.activeSweepOperationId, null);
+
+      setNow(1_500);
+      const replayed = await store.commitMemoryExtraction(emptyCommit());
+      assert.equal(replayed.replayed, true);
+      assert.deepEqual(replayed.receipt, committed.receipt);
+      assert.deepEqual(replayed.cursors, committed.cursors);
+    });
+  });
+
+  test('abandons an expired attempt and respects retry scheduling', async () => {
+    await withExtractionStore(async ({ store, setNow }) => {
+      await store.createMemoryExtractionOperation(targetedOperation());
+      await store.claimMemoryExtractionOperation({
+        operationId: 'operation-targeted',
+        attemptId: 'attempt-stale',
+        turnId: 'memory-turn-stale',
+        runId: 'memory-run-stale',
+        snapshotKind: 'runtime_delta',
+        leaseExpiresAt: 1_100,
+      });
+
+      setNow(1_200);
+      const reclaimed = await store.claimMemoryExtractionOperation({
+        operationId: 'operation-targeted',
+        attemptId: 'attempt-reclaimed',
+        turnId: 'memory-turn-reclaimed',
+        runId: 'memory-run-reclaimed',
+        snapshotKind: 'reconstructed_full',
+        leaseExpiresAt: 1_500,
+      });
+      assert.equal(reclaimed?.attempt.attemptOrdinal, 2);
+      assert.equal((await store.readMemoryExtractionAttempt('attempt-stale'))?.state, 'abandoned');
+
+      const pending = await store.failMemoryExtractionAttempt({
+        operationId: 'operation-targeted',
+        attemptId: 'attempt-reclaimed',
+        runId: 'memory-run-reclaimed',
+        failureCode: 'provider_unavailable',
+        failureStage: 'provider',
+        nextAttemptAt: 1_400,
+      });
+      assert.equal(pending.state, 'pending');
+      assert.equal(
+        await store.claimMemoryExtractionOperation({
+          operationId: 'operation-targeted',
+          attemptId: 'attempt-too-early',
+          turnId: 'memory-turn-too-early',
+          runId: 'memory-run-too-early',
+          snapshotKind: 'reconstructed_full',
+          leaseExpiresAt: 1_600,
+        }),
+        undefined,
+      );
+
+      setNow(1_400);
+      const retried = await store.claimMemoryExtractionOperation({
+        operationId: 'operation-targeted',
+        attemptId: 'attempt-retry',
+        turnId: 'memory-turn-retry',
+        runId: 'memory-run-retry',
+        snapshotKind: 'reconstructed_full',
+        leaseExpiresAt: 1_800,
+      });
+      assert.equal(retried?.attempt.attemptOrdinal, 3);
+    });
+  });
+
+  test('atomically stops recovery before claiming beyond the retry ceiling', async () => {
+    await withExtractionStore(async ({ store, setNow }) => {
+      await store.createMemoryExtractionOperation(targetedOperation());
+      await store.claimMemoryExtractionOperation({
+        operationId: 'operation-targeted',
+        attemptId: 'attempt-last',
+        turnId: 'memory-turn-last',
+        runId: 'memory-run-last',
+        snapshotKind: 'runtime_delta',
+        leaseExpiresAt: 1_100,
+      });
+
+      setNow(1_200);
+      assert.equal(
+        await store.claimMemoryExtractionOperation({
+          operationId: 'operation-targeted',
+          attemptId: 'attempt-forbidden',
+          turnId: 'memory-turn-forbidden',
+          runId: 'memory-run-forbidden',
+          snapshotKind: 'reconstructed_full',
+          leaseExpiresAt: 1_500,
+          maxAttempts: 1,
+          diagnosticRetentionUntil: 2_000,
+        }),
+        undefined,
+      );
+      assert.equal(
+        (await store.readMemoryExtractionOperation('operation-targeted'))?.state,
+        'failed',
+      );
+      assert.equal((await store.readMemoryExtractionAttempt('attempt-last'))?.state, 'abandoned');
+      assert.equal(await store.readMemoryExtractionAttempt('attempt-forbidden'), undefined);
+    });
+  });
+
+  test('lists only recoverable operations with targeted-first stable ordering', async () => {
+    await withExtractionStore(async ({ store, setNow }) => {
+      setNow(1_000);
+      await store.createMemoryExtractionOperation(recoveryOperation('sweep-pending', 'sweep', '1'));
+
+      setNow(1_050);
+      await store.createMemoryExtractionOperation(
+        recoveryOperation('targeted-expired', 'targeted', '2'),
+      );
+      await store.claimMemoryExtractionOperation({
+        operationId: 'targeted-expired',
+        attemptId: 'attempt-targeted-expired',
+        turnId: 'turn-targeted-expired',
+        runId: 'run-targeted-expired',
+        snapshotKind: 'runtime_delta',
+        leaseExpiresAt: 1_100,
+      });
+
+      setNow(1_060);
+      await store.createMemoryExtractionOperation(
+        recoveryOperation('targeted-pending', 'targeted', '3'),
+      );
+
+      setNow(1_070);
+      await store.createMemoryExtractionOperation(
+        recoveryOperation('targeted-delayed', 'targeted', '4'),
+      );
+      await store.claimMemoryExtractionOperation({
+        operationId: 'targeted-delayed',
+        attemptId: 'attempt-targeted-delayed',
+        turnId: 'turn-targeted-delayed',
+        runId: 'run-targeted-delayed',
+        snapshotKind: 'runtime_delta',
+        leaseExpiresAt: 1_200,
+      });
+      await store.failMemoryExtractionAttempt({
+        operationId: 'targeted-delayed',
+        attemptId: 'attempt-targeted-delayed',
+        runId: 'run-targeted-delayed',
+        failureCode: 'provider_unavailable',
+        failureStage: 'provider',
+        nextAttemptAt: 1_300,
+      });
+
+      setNow(1_080);
+      await store.createMemoryExtractionOperation(
+        recoveryOperation('sweep-unexpired', 'sweep', '5'),
+      );
+      await store.claimMemoryExtractionOperation({
+        operationId: 'sweep-unexpired',
+        attemptId: 'attempt-sweep-unexpired',
+        turnId: 'turn-sweep-unexpired',
+        runId: 'run-sweep-unexpired',
+        snapshotKind: 'provider_prefix',
+        leaseExpiresAt: 1_400,
+      });
+
+      setNow(1_200);
+      const recoverable = await store.listRecoverableMemoryExtractions();
+      assert.deepEqual(
+        recoverable.map((operation) => operation.operationId),
+        ['targeted-expired', 'targeted-pending', 'sweep-pending'],
+      );
+      assert.deepEqual(
+        (await store.listRecoverableMemoryExtractions({ limit: 2 })).map(
+          (operation) => operation.operationId,
+        ),
+        ['targeted-expired', 'targeted-pending'],
+      );
+      await assert.rejects(
+        store.listRecoverableMemoryExtractions({ limit: 101 }),
+        /limit must be between 1 and 100/,
+      );
+      await assert.rejects(
+        store.listRecoverableMemoryExtractions({ limit: 10, now: 0 } as never),
+        /only accepts limit/,
+      );
+    });
+  });
+
+  test('renews only the active unexpired attempt lease and never shortens it', async () => {
+    await withExtractionStore(async ({ store, setNow }) => {
+      await store.createMemoryExtractionOperation(
+        recoveryOperation('targeted-renew', 'targeted', '6'),
+      );
+      await store.claimMemoryExtractionOperation({
+        operationId: 'targeted-renew',
+        attemptId: 'attempt-renew',
+        turnId: 'turn-renew',
+        runId: 'run-renew',
+        snapshotKind: 'runtime_delta',
+        leaseExpiresAt: 1_200,
+      });
+
+      setNow(1_100);
+      const renewed = await store.renewMemoryExtractionAttemptLease({
+        operationId: 'targeted-renew',
+        attemptId: 'attempt-renew',
+        runId: 'run-renew',
+        leaseExpiresAt: 1_500,
+      });
+      assert.equal(renewed.leaseExpiresAt, 1_500);
+      assert.equal(
+        (
+          await store.renewMemoryExtractionAttemptLease({
+            operationId: 'targeted-renew',
+            attemptId: 'attempt-renew',
+            runId: 'run-renew',
+            leaseExpiresAt: 1_500,
+          })
+        ).leaseExpiresAt,
+        1_500,
+      );
+      await assert.rejects(
+        store.renewMemoryExtractionAttemptLease({
+          operationId: 'targeted-renew',
+          attemptId: 'attempt-renew',
+          runId: 'run-renew',
+          leaseExpiresAt: 1_400,
+        }),
+        /cannot shorten/,
+      );
+      await assert.rejects(
+        store.renewMemoryExtractionAttemptLease({
+          operationId: 'targeted-renew',
+          attemptId: 'attempt-renew',
+          runId: 'wrong-run',
+          leaseExpiresAt: 1_600,
+        }),
+        /not the active running Attempt/,
+      );
+      assert.equal(
+        (await store.readMemoryExtractionOperation('targeted-renew'))?.leaseExpiresAt,
+        1_500,
+      );
+
+      setNow(1_500);
+      await assert.rejects(
+        store.renewMemoryExtractionAttemptLease({
+          operationId: 'targeted-renew',
+          attemptId: 'attempt-renew',
+          runId: 'run-renew',
+          leaseExpiresAt: 1_800,
+        }),
+        /not the active running Attempt/,
+      );
+      assert.deepEqual(
+        (await store.listRecoverableMemoryExtractions()).map((operation) => operation.operationId),
+        ['targeted-renew'],
+      );
+    });
+  });
+
+  test('finds active candidates only inside the exact scope', async () => {
+    await withExtractionStore(async ({ store }) => {
+      await store.applyMutations({
+        operationId: 'seed-candidates',
+        mutations: [
+          { type: 'create', item: memoryWrite('workspace-a', 'event-a') },
+          { type: 'create', item: memoryWrite('workspace-b', 'event-b') },
+        ],
+      });
+
+      const result = await store.searchMemoryExtractionCandidates({
+        content: 'The project uses SQLite for durable memory.',
+        kind: 'knowledge',
+        statementType: 'fact',
+        temporalType: 'undated',
+        scopeType: 'workspace',
+        scopeKey: 'workspace-a',
+        keys: ['sqlite'],
+        sourceEventIds: ['event-a'],
+      });
+
+      assert.equal(result.truncated, false);
+      assert.equal(result.candidates.length, 1);
+      assert.equal(result.candidates[0]?.record.item.scopeKey, 'workspace-a');
+      assert.equal(result.candidates[0]?.sourceOverlapCount, 1);
+      assert.equal(result.candidates[0]?.exactKeyMatchCount, 1);
+    });
+  });
+
+  test('commits a Targeted proposed Item without a Cursor range', async () => {
+    await withExtractionStore(async ({ store }) => {
+      await store.createMemoryExtractionOperation(targetedOperation());
+      await store.claimMemoryExtractionOperation({
+        operationId: 'operation-targeted',
+        attemptId: 'attempt-targeted',
+        turnId: 'memory-turn-targeted',
+        runId: 'memory-run-targeted',
+        snapshotKind: 'provider_prefix',
+        leaseExpiresAt: 2_000,
+      });
+
+      const committed = await store.commitMemoryExtraction({
+        operationId: 'operation-targeted',
+        attemptId: 'attempt-targeted',
+        runId: 'memory-run-targeted',
+        resultType: 'proposed',
+        selectionSaturated: false,
+        evidenceDigest: DIGEST_A,
+        mutations: [{ type: 'create', item: memoryWrite('workspace-a', 'event-a') }],
+        diagnosticRetentionUntil: 2_000,
+      });
+
+      assert.equal(committed.operation.state, 'succeeded');
+      assert.deepEqual(committed.cursors, []);
+      const itemId = committed.writeOperation.results[0]?.itemId;
+      assert.ok(itemId);
+      assert.equal((await store.readItem(itemId))?.sources[0]?.eventId, 'event-a');
+    });
+  });
+
+  test('rolls back a proposed Item with extraction state at every transaction boundary', async () => {
+    for (const point of [
+      'after_item_write',
+      'after_keys_write',
+      'after_sources_write',
+      'after_cursor_write',
+      'after_extraction_state_write',
+    ] as const) {
+      await withExtractionStore(async ({ store, setFailpoint }) => {
+        await store.createMemoryExtractionOperation(sweepOperation());
+        await store.claimMemoryExtractionOperation({
+          operationId: 'operation-1',
+          attemptId: 'attempt-1',
+          turnId: 'memory-turn-1',
+          runId: 'memory-run-1',
+          snapshotKind: 'provider_prefix',
+          leaseExpiresAt: 2_000,
+        });
+        const request = proposedCommit();
+
+        setFailpoint(point);
+        await assert.rejects(store.commitMemoryExtraction(request), new RegExp(point));
+        setFailpoint(undefined);
+
+        assert.equal(await store.readItem('memory-item-1'), undefined, point);
+        assert.equal(await store.readOperation('operation-1'), undefined, point);
+        assert.deepEqual(
+          {
+            state: (await store.readMemoryExtractionOperation('operation-1'))?.state,
+            activeAttemptId: (await store.readMemoryExtractionOperation('operation-1'))
+              ?.activeAttemptId,
+            attemptState: (await store.readMemoryExtractionAttempt('attempt-1'))?.state,
+            committedEventSeq: (await store.readMemoryExtractionCursor('session-1', 'run-1'))
+              ?.committedEventSeq,
+          },
+          {
+            state: 'running',
+            activeAttemptId: 'attempt-1',
+            attemptState: 'running',
+            committedEventSeq: 0,
+          },
+          point,
+        );
+
+        const committed = await store.commitMemoryExtraction(request);
+        assert.equal(committed.replayed, false, point);
+        assert.equal(committed.writeOperation.results.length, 1, point);
+        const itemId = committed.writeOperation.results[0]?.itemId;
+        assert.ok(itemId, point);
+        assert.deepEqual((await store.readItem(itemId))?.sources, [
+          { sessionId: 'session-1', runId: 'run-1', turnId: 'turn-1', eventId: 'event-a' },
+        ]);
+        assert.equal(committed.cursors[0]?.committedEventSeq, 3, point);
+
+        const replayed = await store.commitMemoryExtraction(request);
+        assert.equal(replayed.replayed, true, point);
+        assert.deepEqual(replayed.receipt, committed.receipt, point);
+        assert.deepEqual(
+          (
+            await store.searchByKeys({
+              terms: ['SQLite'],
+              match: 'exact',
+              workspaceKey: 'workspace-a',
+            })
+          ).map((record) => record.item.itemId),
+          [itemId],
+          point,
+        );
+      });
+    }
+  });
+
+  test('keeps a raised requested boundary after committing the frozen sweep range', async () => {
+    await withExtractionStore(async ({ store }) => {
+      await store.createMemoryExtractionOperation(sweepOperation());
+      const raised = await store.raiseMemoryExtractionRequestedBoundary({
+        sessionId: 'session-1',
+        runId: 'run-1',
+        activeSweepOperationId: 'operation-1',
+        requestedEventSeq: 5,
+        requestedEventId: 'event-5',
+        requestedPrefixDigest: DIGEST_B,
+      });
+      assert.equal(raised.requestedEventSeq, 5);
+
+      await store.claimMemoryExtractionOperation({
+        operationId: 'operation-1',
+        attemptId: 'attempt-1',
+        turnId: 'memory-turn-1',
+        runId: 'memory-run-1',
+        snapshotKind: 'provider_prefix',
+        leaseExpiresAt: 2_000,
+      });
+      const committed = await store.commitMemoryExtraction(emptyCommit());
+      assert.equal(committed.cursors[0]?.committedEventSeq, 3);
+      assert.equal(committed.cursors[0]?.requestedEventSeq, 5);
+      assert.equal(committed.cursors[0]?.requestedEventId, 'event-5');
+
+      const debts = await store.listUnassignedMemoryExtractionSweepDebts();
+      assert.equal(debts.length, 1);
+      const debt = debts[0]!;
+      const followup = await store.createMemoryExtractionSweepFollowup({
+        expectedCursorVersion: debt.version,
+        operation: {
+          operationId: 'operation-followup',
+          sessionId: debt.sessionId,
+          mode: 'sweep',
+          triggerKind: 'context_threshold',
+          internalSessionId: 'memory-session-followup',
+          sessionCreateFingerprint: digest('d'),
+          requestHash: digest('e'),
+          requestJson: JSON.stringify({ version: 1, kind: 'cursor_debt_followup' }),
+          triggerEpoch: `cursor-debt-${debt.version}`,
+          ranges: [
+            {
+              rangeOrdinal: 0,
+              sessionId: debt.sessionId,
+              invocationId: debt.invocationId,
+              runId: debt.runId,
+              turnId: debt.turnId,
+              fromEventSeqExclusive: debt.committedEventSeq,
+              fromEventId: debt.committedEventId,
+              fromPrefixDigest: debt.committedPrefixDigest,
+              toEventSeqInclusive: debt.requestedEventSeq,
+              toEventId: debt.requestedEventId!,
+              toPrefixDigest: debt.requestedPrefixDigest!,
+            },
+          ],
+        },
+      });
+      assert.equal(followup?.replayed, false);
+      assert.equal(
+        (await store.readMemoryExtractionCursor('session-1', 'run-1'))?.activeSweepOperationId,
+        'operation-followup',
+      );
+      assert.deepEqual(await store.listUnassignedMemoryExtractionSweepDebts(), []);
+    });
+  });
+
+  test('releases a Sweep cursor after its final failed Attempt', async () => {
+    await withExtractionStore(async ({ store }) => {
+      await store.createMemoryExtractionOperation(sweepOperation());
+      await store.claimMemoryExtractionOperation({
+        operationId: 'operation-1',
+        attemptId: 'attempt-1',
+        turnId: 'memory-turn-1',
+        runId: 'memory-run-1',
+        snapshotKind: 'provider_prefix',
+        leaseExpiresAt: 2_000,
+      });
+
+      await store.failMemoryExtractionAttempt({
+        operationId: 'operation-1',
+        attemptId: 'attempt-1',
+        runId: 'memory-run-1',
+        failureCode: 'provider_unavailable',
+        failureStage: 'provider',
+        diagnosticRetentionUntil: 2_000,
+      });
+
+      assert.equal(
+        (await store.readMemoryExtractionCursor('session-1', 'run-1'))?.activeSweepOperationId,
+        null,
+      );
+      assert.equal(
+        (await store.readMemoryExtractionCursor('session-1', 'run-1'))?.requestedEventSeq,
+        3,
+      );
+      assert.deepEqual(await store.listUnassignedMemoryExtractionSweepDebts(), []);
+    });
+  });
+
+  test('retires unassigned Sweep cursor debt after its parent Session is removed', async () => {
+    await withExtractionStore(async ({ store }) => {
+      await store.createMemoryExtractionOperation(sweepOperation());
+      await store.raiseMemoryExtractionRequestedBoundary({
+        sessionId: 'session-1',
+        runId: 'run-1',
+        activeSweepOperationId: 'operation-1',
+        requestedEventSeq: 5,
+        requestedEventId: 'event-5',
+        requestedPrefixDigest: DIGEST_B,
+      });
+      await store.claimMemoryExtractionOperation({
+        operationId: 'operation-1',
+        attemptId: 'attempt-1',
+        turnId: 'memory-turn-1',
+        runId: 'memory-run-1',
+        snapshotKind: 'provider_prefix',
+        leaseExpiresAt: 2_000,
+      });
+      await store.commitMemoryExtraction(emptyCommit());
+
+      assert.equal((await store.listUnassignedMemoryExtractionSweepDebts()).length, 1);
+
+      assert.deepEqual(
+        await store.cancelMemoryExtractionsForSessions({
+          sessionIds: ['session-1'],
+          diagnosticRetentionUntil: 2_000,
+        }),
+        [],
+      );
+      assert.deepEqual(await store.listUnassignedMemoryExtractionSweepDebts(), []);
+    });
+  });
+
+  test('claims cleanup only after retention and settles the durable claim', async () => {
+    await withExtractionStore(async ({ store, setNow }) => {
+      await store.createMemoryExtractionOperation(sweepOperation());
+      await store.claimMemoryExtractionOperation({
+        operationId: 'operation-1',
+        attemptId: 'attempt-1',
+        turnId: 'memory-turn-1',
+        runId: 'memory-run-1',
+        snapshotKind: 'provider_prefix',
+        leaseExpiresAt: 2_000,
+      });
+      await store.commitMemoryExtraction(emptyCommit());
+
+      assert.deepEqual(await store.listRecoverableMemoryExtractionCleanups(), []);
+
+      assert.equal(
+        await store.claimMemoryExtractionCleanup({
+          operationId: 'operation-1',
+          claimId: 'cleanup-too-early',
+          leaseExpiresAt: 2_500,
+        }),
+        undefined,
+      );
+      setNow(2_000);
+      assert.deepEqual(
+        (await store.listRecoverableMemoryExtractionCleanups()).map(
+          (operation) => operation.operationId,
+        ),
+        ['operation-1'],
+      );
+      const claimed = await store.claimMemoryExtractionCleanup({
+        operationId: 'operation-1',
+        claimId: 'cleanup-1',
+        leaseExpiresAt: 2_500,
+      });
+      assert.equal(claimed?.cleanupState, 'running');
+
+      const completed = await store.finishMemoryExtractionCleanup({
+        operationId: 'operation-1',
+        claimId: 'cleanup-1',
+      });
+      assert.equal(completed.cleanupState, 'completed');
+      assert.equal(completed.cleanedAt, 2_000);
+      assert.deepEqual(await store.listRecoverableMemoryExtractionCleanups(), []);
+    });
+  });
+
+  test('terminally cancels pending and running Operations when their parent Session is removed', async () => {
+    await withExtractionStore(async ({ store }) => {
+      await store.createMemoryExtractionOperation(sweepOperation());
+      await store.claimMemoryExtractionOperation({
+        operationId: 'operation-1',
+        attemptId: 'attempt-1',
+        turnId: 'memory-turn-1',
+        runId: 'memory-run-1',
+        snapshotKind: 'provider_prefix',
+        leaseExpiresAt: 2_000,
+      });
+      await store.createMemoryExtractionOperation(targetedOperation());
+
+      assert.deepEqual(
+        await store.cancelMemoryExtractionsForSessions({
+          sessionIds: ['session-1'],
+          diagnosticRetentionUntil: 2_000,
+        }),
+        ['operation-1', 'operation-targeted'],
+      );
+      assert.equal((await store.readMemoryExtractionOperation('operation-1'))?.state, 'failed');
+      assert.equal(
+        (await store.readMemoryExtractionAttempt('attempt-1'))?.failureCode,
+        'source_evidence_deleted',
+      );
+      assert.equal((await store.readMemoryExtractionAttempt('attempt-1'))?.state, 'abandoned');
+      assert.equal(
+        (await store.readMemoryExtractionCursor('session-1', 'run-1'))?.activeSweepOperationId,
+        null,
+      );
+      assert.deepEqual(await store.listUnassignedMemoryExtractionSweepDebts(), []);
+    });
+  });
+
+  test('atomically enforces the unfinished Targeted queue ceiling', async () => {
+    await withExtractionStore(async ({ store }) => {
+      for (const [index, character] of ['d', 'e'].entries()) {
+        await store.createMemoryExtractionOperation({
+          ...targetedOperation(),
+          operationId: `operation-targeted-${index}`,
+          internalSessionId: `memory-session-targeted-${index}`,
+          requestHash: digest(character),
+          requestJson: JSON.stringify({ version: 1, index }),
+          maxUnfinishedTargetedPerSession: 2,
+        });
+      }
+
+      await assert.rejects(
+        store.createMemoryExtractionOperation({
+          ...targetedOperation(),
+          operationId: 'operation-targeted-overflow',
+          internalSessionId: 'memory-session-targeted-overflow',
+          requestHash: digest('f'),
+          requestJson: JSON.stringify({ version: 1, index: 2 }),
+          maxUnfinishedTargetedPerSession: 2,
+        }),
+        (error: unknown) =>
+          error instanceof Error && 'reason' in error && error.reason === 'extraction_queue_full',
+      );
+    });
+  });
+});
+
+function sweepOperation(): CreateMemoryExtractionOperationRequest {
+  return {
+    operationId: 'operation-1',
+    sessionId: 'session-1',
+    mode: 'sweep',
+    triggerKind: 'context_threshold',
+    internalSessionId: 'memory-session-1',
+    sessionCreateFingerprint: DIGEST_A,
+    requestHash: DIGEST_B,
+    requestJson: JSON.stringify({ version: 1, kind: 'sweep' }),
+    triggerEpoch: 'threshold-1',
+    ranges: [
+      {
+        rangeOrdinal: 0,
+        sessionId: 'session-1',
+        invocationId: 'invocation-1',
+        runId: 'run-1',
+        turnId: 'turn-1',
+        fromEventSeqExclusive: 0,
+        fromEventId: null,
+        fromPrefixDigest: null,
+        toEventSeqInclusive: 3,
+        toEventId: 'event-3',
+        toPrefixDigest: DIGEST_A,
+      },
+    ],
+  };
+}
+
+function targetedOperation(): CreateMemoryExtractionOperationRequest {
+  return {
+    operationId: 'operation-targeted',
+    sessionId: 'session-1',
+    mode: 'targeted',
+    triggerKind: 'user_requested',
+    internalSessionId: 'memory-session-targeted',
+    sessionCreateFingerprint: DIGEST_A,
+    requestHash: digest('c'),
+    requestJson: JSON.stringify({ version: 1, kind: 'targeted' }),
+    triggerEpoch: 'tool-call-1',
+  };
+}
+
+function recoveryOperation(
+  operationId: string,
+  mode: 'sweep' | 'targeted',
+  digestCharacter: string,
+): CreateMemoryExtractionOperationRequest {
+  const sessionId = `session-${operationId}`;
+  return {
+    operationId,
+    sessionId,
+    mode,
+    triggerKind: mode === 'targeted' ? 'user_requested' : 'compaction',
+    internalSessionId: `memory-session-${operationId}`,
+    sessionCreateFingerprint: DIGEST_A,
+    requestHash: digest(digestCharacter),
+    requestJson: JSON.stringify({ version: 1, operationId }),
+    triggerEpoch: `trigger-${operationId}`,
+    ...(mode === 'sweep'
+      ? {
+          ranges: [
+            {
+              rangeOrdinal: 0,
+              sessionId,
+              invocationId: `invocation-${operationId}`,
+              runId: `source-run-${operationId}`,
+              turnId: `source-turn-${operationId}`,
+              fromEventSeqExclusive: 0,
+              fromEventId: null,
+              fromPrefixDigest: null,
+              toEventSeqInclusive: 1,
+              toEventId: `source-event-${operationId}`,
+              toPrefixDigest: DIGEST_A,
+            },
+          ],
+        }
+      : {}),
+  };
+}
+
+function emptyCommit() {
+  return {
+    operationId: 'operation-1',
+    attemptId: 'attempt-1',
+    runId: 'memory-run-1',
+    resultType: 'empty' as const,
+    selectionSaturated: false,
+    evidenceDigest: DIGEST_A,
+    mutations: [],
+    diagnosticRetentionUntil: 2_000,
+  };
+}
+
+function proposedCommit() {
+  return {
+    operationId: 'operation-1',
+    attemptId: 'attempt-1',
+    runId: 'memory-run-1',
+    resultType: 'proposed' as const,
+    selectionSaturated: false,
+    evidenceDigest: DIGEST_A,
+    mutations: [{ type: 'create' as const, item: memoryWrite('workspace-a', 'event-a') }],
+    diagnosticRetentionUntil: 2_000,
+  };
+}
+
+function memoryWrite(workspaceKey: string, eventId: string): MemoryItemWrite {
+  return {
+    content: 'The project uses SQLite for durable memory.',
+    kind: 'knowledge',
+    statementType: 'fact',
+    temporalType: 'undated',
+    scopeType: 'workspace',
+    scopeKey: workspaceKey,
+    observedAt: 900,
+    origin: 'agent_extracted',
+    keys: [{ key: 'SQLite', keyType: 'exact', keyOrigin: 'deterministic' }],
+    sources: [{ sessionId: 'session-1', runId: 'run-1', turnId: 'turn-1', eventId }],
+  };
+}
+
+async function withExtractionStore(
+  run: (context: {
+    store: SqliteMemoryItemStore;
+    setNow: (value: number) => void;
+    setFailpoint: (value: SqliteMemoryItemStoreFailpoint | undefined) => void;
+  }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-memory-extraction-'));
+  await chmod(root, 0o700);
+  let now = 1_000;
+  let failpoint: SqliteMemoryItemStoreFailpoint | undefined;
+  let item = 0;
+  const store = new SqliteMemoryItemStore(join(root, LONG_TERM_MEMORY_DATABASE_NAME), {
+    now: () => now,
+    idFactory: () => `memory-item-${++item}`,
+    failpoint: (point) => {
+      if (point === failpoint) throw new Error(`failpoint:${point}`);
+    },
+  });
+  try {
+    await run({
+      store,
+      setNow: (value) => {
+        now = value;
+      },
+      setFailpoint: (value) => {
+        failpoint = value;
+      },
+    });
+  } finally {
+    store.close();
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function digest(character: string): MemorySha256Digest {
+  return `sha256:${character.repeat(64)}`;
+}

--- a/packages/storage/src/long-term-memory-store.ts
+++ b/packages/storage/src/long-term-memory-store.ts
@@ -1,8 +1,21 @@
 import { join } from 'node:path';
 import type {
   ApplyMemoryMutationsRequest,
+  ClaimMemoryExtractionCleanupRequest,
+  CancelMemoryExtractionsForSessionsRequest,
+  ClaimMemoryExtractionOperationRequest,
+  CommitMemoryExtractionRequest,
+  CreateMemoryExtractionOperationRequest,
+  CreateMemoryExtractionSweepFollowupRequest,
+  FailMemoryExtractionAttemptRequest,
+  FinishMemoryExtractionCleanupRequest,
+  ListRecoverableMemoryExtractionsRequest,
+  ListUnassignedMemoryExtractionSweepDebtsRequest,
   MemoryItemStore,
   MemoryItemWrite,
+  RaiseMemoryExtractionRequestedBoundaryRequest,
+  RenewMemoryExtractionAttemptLeaseRequest,
+  SearchMemoryExtractionCandidatesRequest,
   SearchMemoryItemsByKeyRequest,
 } from '@maka/core/long-term-memory';
 import {
@@ -119,6 +132,102 @@ function createWriterFacade(
       return run(() => store.searchByKeys(snapshot));
     },
     readOperation: (operationId) => run(() => store.readOperation(operationId)),
+    createMemoryExtractionOperation: (request) => {
+      const snapshot = snapshotCreateExtractionRequest(request);
+      return run(() => store.createMemoryExtractionOperation(snapshot));
+    },
+    claimMemoryExtractionOperation: (request) => {
+      const snapshot = Object.freeze({ ...request }) as ClaimMemoryExtractionOperationRequest;
+      return run(() => store.claimMemoryExtractionOperation(snapshot));
+    },
+    listRecoverableMemoryExtractions: (request) => {
+      const snapshot = Object.freeze(
+        request?.limit === undefined ? {} : { limit: request.limit },
+      ) as ListRecoverableMemoryExtractionsRequest;
+      return run(() => store.listRecoverableMemoryExtractions(snapshot));
+    },
+    listRecoverableMemoryExtractionCleanups: (request) => {
+      const snapshot = Object.freeze(
+        request?.limit === undefined ? {} : { limit: request.limit },
+      ) as ListRecoverableMemoryExtractionsRequest;
+      return run(() => store.listRecoverableMemoryExtractionCleanups(snapshot));
+    },
+    hasUnfinishedMemoryExtractions: () => run(() => store.hasUnfinishedMemoryExtractions()),
+    listUnassignedMemoryExtractionSweepDebts: (request) => {
+      const snapshot = Object.freeze(
+        request?.limit === undefined ? {} : { limit: request.limit },
+      ) as ListUnassignedMemoryExtractionSweepDebtsRequest;
+      return run(() => store.listUnassignedMemoryExtractionSweepDebts(snapshot));
+    },
+    createMemoryExtractionSweepFollowup: (request) => {
+      const snapshot = Object.freeze({
+        operation: snapshotCreateExtractionRequest(request.operation),
+        expectedCursorVersion: request.expectedCursorVersion,
+      }) as CreateMemoryExtractionSweepFollowupRequest;
+      return run(() => store.createMemoryExtractionSweepFollowup(snapshot));
+    },
+    renewMemoryExtractionAttemptLease: (request) => {
+      const snapshot = Object.freeze({
+        operationId: request.operationId,
+        attemptId: request.attemptId,
+        runId: request.runId,
+        leaseExpiresAt: request.leaseExpiresAt,
+      }) as RenewMemoryExtractionAttemptLeaseRequest;
+      return run(() => store.renewMemoryExtractionAttemptLease(snapshot));
+    },
+    failMemoryExtractionAttempt: (request) => {
+      const snapshot = Object.freeze({
+        ...request,
+        ...(request.metrics === undefined || request.metrics === null
+          ? {}
+          : { metrics: Object.freeze({ ...request.metrics }) }),
+      }) as FailMemoryExtractionAttemptRequest;
+      return run(() => store.failMemoryExtractionAttempt(snapshot));
+    },
+    readMemoryExtractionOperation: (operationId) =>
+      run(() => store.readMemoryExtractionOperation(operationId)),
+    readMemoryExtractionAttempt: (attemptId) =>
+      run(() => store.readMemoryExtractionAttempt(attemptId)),
+    readMemoryExtractionCursor: (sessionId, runId) =>
+      run(() => store.readMemoryExtractionCursor(sessionId, runId)),
+    raiseMemoryExtractionRequestedBoundary: (request) => {
+      const snapshot = Object.freeze({
+        ...request,
+      }) as RaiseMemoryExtractionRequestedBoundaryRequest;
+      return run(() => store.raiseMemoryExtractionRequestedBoundary(snapshot));
+    },
+    searchMemoryExtractionCandidates: (request) => {
+      const snapshot = Object.freeze({
+        ...request,
+        keys: Object.freeze([...request.keys]),
+        ...(request.sourceEventIds === undefined
+          ? {}
+          : { sourceEventIds: Object.freeze([...request.sourceEventIds]) }),
+      }) as SearchMemoryExtractionCandidatesRequest;
+      return run(() => store.searchMemoryExtractionCandidates(snapshot));
+    },
+    commitMemoryExtraction: (request) => {
+      const snapshot = Object.freeze({
+        ...request,
+        mutations: snapshotMutations(request.mutations),
+      }) as CommitMemoryExtractionRequest;
+      return run(() => store.commitMemoryExtraction(snapshot));
+    },
+    claimMemoryExtractionCleanup: (request) => {
+      const snapshot = Object.freeze({ ...request }) as ClaimMemoryExtractionCleanupRequest;
+      return run(() => store.claimMemoryExtractionCleanup(snapshot));
+    },
+    finishMemoryExtractionCleanup: (request) => {
+      const snapshot = Object.freeze({ ...request }) as FinishMemoryExtractionCleanupRequest;
+      return run(() => store.finishMemoryExtractionCleanup(snapshot));
+    },
+    cancelMemoryExtractionsForSessions: (request) => {
+      const snapshot = Object.freeze({
+        sessionIds: Object.freeze([...request.sessionIds]),
+        diagnosticRetentionUntil: request.diagnosticRetentionUntil,
+      }) as CancelMemoryExtractionsForSessionsRequest;
+      return run(() => store.cancelMemoryExtractionsForSessions(snapshot));
+    },
     close: () => {
       if (closed) return;
       closed = true;
@@ -133,26 +242,43 @@ function createWriterFacade(
 function snapshotApplyRequest(request: ApplyMemoryMutationsRequest): ApplyMemoryMutationsRequest {
   return Object.freeze({
     operationId: request.operationId,
-    mutations: Object.freeze(
-      request.mutations.map((mutation) => {
-        if (mutation.type === 'create') {
-          return Object.freeze({ type: mutation.type, item: snapshotItemWrite(mutation.item) });
-        }
-        if (mutation.type === 'update') {
-          return Object.freeze({
-            type: mutation.type,
-            itemId: mutation.itemId,
-            expectedVersion: mutation.expectedVersion,
-            item: snapshotItemWrite(mutation.item),
-          });
-        }
+    mutations: snapshotMutations(request.mutations),
+  });
+}
+
+function snapshotMutations(
+  mutations: ApplyMemoryMutationsRequest['mutations'],
+): ApplyMemoryMutationsRequest['mutations'] {
+  return Object.freeze(
+    mutations.map((mutation) => {
+      if (mutation.type === 'create') {
+        return Object.freeze({ type: mutation.type, item: snapshotItemWrite(mutation.item) });
+      }
+      if (mutation.type === 'update') {
         return Object.freeze({
           type: mutation.type,
           itemId: mutation.itemId,
           expectedVersion: mutation.expectedVersion,
+          item: snapshotItemWrite(mutation.item),
         });
-      }),
-    ),
+      }
+      return Object.freeze({
+        type: mutation.type,
+        itemId: mutation.itemId,
+        expectedVersion: mutation.expectedVersion,
+      });
+    }),
+  );
+}
+
+function snapshotCreateExtractionRequest(
+  request: CreateMemoryExtractionOperationRequest,
+): CreateMemoryExtractionOperationRequest {
+  return Object.freeze({
+    ...request,
+    ...(request.ranges === undefined
+      ? {}
+      : { ranges: Object.freeze(request.ranges.map((range) => Object.freeze({ ...range }))) }),
   });
 }
 

--- a/packages/storage/src/sqlite-long-term-memory-schema.ts
+++ b/packages/storage/src/sqlite-long-term-memory-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_LONG_TERM_MEMORY_SCHEMA_VERSION = 1;
+export const SQLITE_LONG_TERM_MEMORY_SCHEMA_VERSION = 2;
 
 const SQLITE_INITIALIZATION_BUSY_TIMEOUT_MS = 5_000;
 const SQLITE_INITIALIZATION_RETRY_DELAY_MS = 10;
@@ -111,7 +111,270 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
       result_json TEXT NOT NULL,
       committed_at INTEGER NOT NULL CHECK (committed_at >= 0)
     );
-  `,
+    `,
+  ],
+  [
+    2,
+    `
+    CREATE TABLE memory_extraction_operations (
+      operation_id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL CHECK (length(session_id) > 0),
+      mode TEXT NOT NULL CHECK (mode IN ('sweep', 'targeted')),
+      trigger_kind TEXT NOT NULL CHECK (
+        trigger_kind IN ('context_threshold', 'compaction', 'user_requested', 'agent_requested')
+      ),
+      internal_session_id TEXT NOT NULL UNIQUE CHECK (length(internal_session_id) > 0),
+      session_create_fingerprint TEXT NOT NULL CHECK (
+        length(session_create_fingerprint) = 71
+        AND substr(session_create_fingerprint, 1, 7) = 'sha256:'
+      ),
+      request_hash TEXT NOT NULL CHECK (
+        length(request_hash) = 71 AND substr(request_hash, 1, 7) = 'sha256:'
+      ),
+      request_json TEXT NOT NULL CHECK (
+        json_valid(request_json) AND json_type(request_json) = 'object'
+      ),
+      trigger_epoch TEXT,
+
+      state TEXT NOT NULL CHECK (state IN ('pending', 'running', 'succeeded', 'failed')),
+      attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+      active_attempt_id TEXT,
+      lease_expires_at INTEGER CHECK (lease_expires_at IS NULL OR lease_expires_at >= 0),
+      next_attempt_at INTEGER CHECK (next_attempt_at IS NULL OR next_attempt_at >= 0),
+      last_error_code TEXT,
+      last_error_stage TEXT CHECK (
+        last_error_stage IS NULL OR last_error_stage IN (
+          'admission', 'provider', 'search', 'read', 'submit', 'commit', 'recovery', 'cleanup'
+        )
+      ),
+      last_error_at INTEGER CHECK (last_error_at IS NULL OR last_error_at >= 0),
+      last_failed_attempt_id TEXT,
+      started_at INTEGER CHECK (started_at IS NULL OR started_at >= 0),
+      created_at INTEGER NOT NULL CHECK (created_at >= 0),
+      updated_at INTEGER NOT NULL CHECK (updated_at >= 0),
+      completed_at INTEGER CHECK (completed_at IS NULL OR completed_at >= 0),
+      result_type TEXT CHECK (
+        result_type IS NULL OR result_type IN ('proposed', 'empty', 'unresolved', 'not_storable')
+      ),
+      commit_hash TEXT CHECK (commit_hash IS NULL OR length(commit_hash) = 64),
+      result_json TEXT CHECK (
+        result_json IS NULL OR (json_valid(result_json) AND json_type(result_json) = 'object')
+      ),
+      diagnostic_retention_until INTEGER CHECK (
+        diagnostic_retention_until IS NULL OR diagnostic_retention_until >= 0
+      ),
+      cleanup_state TEXT CHECK (
+        cleanup_state IS NULL OR cleanup_state IN ('pending', 'running', 'completed')
+      ),
+      cleanup_claim_id TEXT,
+      cleanup_lease_expires_at INTEGER CHECK (
+        cleanup_lease_expires_at IS NULL OR cleanup_lease_expires_at >= 0
+      ),
+      cleanup_attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (cleanup_attempt_count >= 0),
+      cleanup_error_code TEXT,
+      cleaned_at INTEGER CHECK (cleaned_at IS NULL OR cleaned_at >= 0),
+
+      UNIQUE(session_id, request_hash),
+      CHECK (created_at <= updated_at),
+      CHECK (started_at IS NULL OR created_at <= started_at),
+      CHECK (completed_at IS NULL OR started_at IS NOT NULL),
+      CHECK (
+        (state = 'running' AND active_attempt_id IS NOT NULL AND lease_expires_at IS NOT NULL)
+        OR
+        (state <> 'running' AND active_attempt_id IS NULL AND lease_expires_at IS NULL)
+      ),
+      CHECK (state = 'pending' OR next_attempt_at IS NULL),
+      CHECK (
+        (state = 'succeeded'
+          AND completed_at IS NOT NULL
+          AND result_type IS NOT NULL
+          AND commit_hash IS NOT NULL
+          AND result_json IS NOT NULL)
+        OR
+        (state = 'failed'
+          AND completed_at IS NOT NULL
+          AND result_type IS NULL
+          AND commit_hash IS NULL
+          AND result_json IS NULL)
+        OR
+        (state IN ('pending', 'running')
+          AND completed_at IS NULL
+          AND result_type IS NULL
+          AND commit_hash IS NULL
+          AND result_json IS NULL)
+      ),
+      CHECK (
+        (state IN ('succeeded', 'failed')
+          AND diagnostic_retention_until IS NOT NULL
+          AND cleanup_state IS NOT NULL)
+        OR
+        (state IN ('pending', 'running')
+          AND diagnostic_retention_until IS NULL
+          AND cleanup_state IS NULL)
+      ),
+      CHECK (
+        (cleanup_state = 'running'
+          AND cleanup_claim_id IS NOT NULL
+          AND cleanup_lease_expires_at IS NOT NULL
+          AND cleaned_at IS NULL)
+        OR
+        (cleanup_state = 'completed'
+          AND cleanup_claim_id IS NULL
+          AND cleanup_lease_expires_at IS NULL
+          AND cleaned_at IS NOT NULL)
+        OR
+        ((cleanup_state = 'pending' OR cleanup_state IS NULL)
+          AND cleanup_claim_id IS NULL
+          AND cleanup_lease_expires_at IS NULL
+          AND cleaned_at IS NULL)
+      )
+    );
+
+    CREATE INDEX memory_extraction_operations_by_claim
+      ON memory_extraction_operations(state, next_attempt_at, created_at, operation_id);
+
+    CREATE INDEX memory_extraction_operations_by_lease
+      ON memory_extraction_operations(state, lease_expires_at, operation_id);
+
+    CREATE INDEX memory_extraction_operations_by_session
+      ON memory_extraction_operations(session_id, mode, state, created_at, operation_id);
+
+    CREATE INDEX memory_extraction_operations_by_cleanup
+      ON memory_extraction_operations(
+        cleanup_state, diagnostic_retention_until, cleanup_lease_expires_at, operation_id
+      );
+
+    CREATE TABLE memory_extraction_attempts (
+      attempt_id TEXT PRIMARY KEY,
+      operation_id TEXT NOT NULL,
+      attempt_ordinal INTEGER NOT NULL CHECK (attempt_ordinal >= 1),
+      state TEXT NOT NULL CHECK (state IN ('running', 'succeeded', 'failed', 'abandoned')),
+      turn_id TEXT NOT NULL CHECK (length(turn_id) > 0),
+      run_id TEXT NOT NULL UNIQUE CHECK (length(run_id) > 0),
+      snapshot_kind TEXT NOT NULL CHECK (
+        snapshot_kind IN ('provider_prefix', 'runtime_delta', 'reconstructed_full')
+      ),
+      started_at INTEGER NOT NULL CHECK (started_at >= 0),
+      completed_at INTEGER CHECK (completed_at IS NULL OR completed_at >= 0),
+      failure_code TEXT,
+      failure_stage TEXT CHECK (
+        failure_stage IS NULL OR failure_stage IN (
+          'admission', 'provider', 'search', 'read', 'submit', 'commit', 'recovery', 'cleanup'
+        )
+      ),
+      metrics_json TEXT CHECK (
+        metrics_json IS NULL OR (json_valid(metrics_json) AND json_type(metrics_json) = 'object')
+      ),
+      UNIQUE(operation_id, attempt_ordinal),
+      UNIQUE(operation_id, attempt_id),
+      FOREIGN KEY(operation_id) REFERENCES memory_extraction_operations(operation_id) ON DELETE CASCADE,
+      CHECK (
+        (state = 'running'
+          AND completed_at IS NULL
+          AND failure_code IS NULL
+          AND failure_stage IS NULL)
+        OR
+        (state = 'succeeded'
+          AND completed_at IS NOT NULL
+          AND failure_code IS NULL
+          AND failure_stage IS NULL)
+        OR
+        (state IN ('failed', 'abandoned')
+          AND completed_at IS NOT NULL
+          AND failure_code IS NOT NULL
+          AND failure_stage IS NOT NULL)
+      )
+    );
+
+    CREATE INDEX memory_extraction_attempts_by_operation
+      ON memory_extraction_attempts(operation_id, attempt_ordinal, attempt_id);
+
+    CREATE TABLE memory_extraction_operation_ranges (
+      operation_id TEXT NOT NULL,
+      range_ordinal INTEGER NOT NULL CHECK (range_ordinal >= 0),
+      session_id TEXT NOT NULL CHECK (length(session_id) > 0),
+      invocation_id TEXT NOT NULL CHECK (length(invocation_id) > 0),
+      run_id TEXT NOT NULL CHECK (length(run_id) > 0),
+      turn_id TEXT NOT NULL CHECK (length(turn_id) > 0),
+      from_event_seq_exclusive INTEGER NOT NULL CHECK (from_event_seq_exclusive >= 0),
+      from_event_id TEXT,
+      from_prefix_digest TEXT,
+      to_event_seq_inclusive INTEGER NOT NULL CHECK (to_event_seq_inclusive > 0),
+      to_event_id TEXT NOT NULL CHECK (length(to_event_id) > 0),
+      to_prefix_digest TEXT NOT NULL CHECK (
+        length(to_prefix_digest) = 71 AND substr(to_prefix_digest, 1, 7) = 'sha256:'
+      ),
+      PRIMARY KEY(operation_id, range_ordinal),
+      UNIQUE(operation_id, run_id),
+      FOREIGN KEY(operation_id) REFERENCES memory_extraction_operations(operation_id) ON DELETE CASCADE,
+      CHECK (to_event_seq_inclusive > from_event_seq_exclusive),
+      CHECK (
+        (from_event_seq_exclusive = 0
+          AND from_event_id IS NULL
+          AND from_prefix_digest IS NULL)
+        OR
+        (from_event_seq_exclusive > 0
+          AND from_event_id IS NOT NULL
+          AND length(from_event_id) > 0
+          AND from_prefix_digest IS NOT NULL
+          AND length(from_prefix_digest) = 71
+          AND substr(from_prefix_digest, 1, 7) = 'sha256:')
+      )
+    ) WITHOUT ROWID;
+
+    CREATE INDEX memory_extraction_operation_ranges_by_run
+      ON memory_extraction_operation_ranges(session_id, run_id, operation_id);
+
+    CREATE TABLE memory_extraction_cursors (
+      session_id TEXT NOT NULL CHECK (length(session_id) > 0),
+      invocation_id TEXT NOT NULL CHECK (length(invocation_id) > 0),
+      run_id TEXT NOT NULL CHECK (length(run_id) > 0),
+      turn_id TEXT NOT NULL CHECK (length(turn_id) > 0),
+      committed_event_seq INTEGER NOT NULL CHECK (committed_event_seq >= 0),
+      committed_event_id TEXT,
+      committed_prefix_digest TEXT,
+      requested_event_seq INTEGER NOT NULL CHECK (requested_event_seq >= 0),
+      requested_event_id TEXT,
+      requested_prefix_digest TEXT,
+      active_sweep_operation_id TEXT,
+      followup_eligible INTEGER NOT NULL DEFAULT 0 CHECK (followup_eligible IN (0, 1)),
+      version INTEGER NOT NULL CHECK (version >= 1),
+      created_at INTEGER NOT NULL CHECK (created_at >= 0),
+      updated_at INTEGER NOT NULL CHECK (updated_at >= 0),
+      PRIMARY KEY(session_id, run_id),
+      FOREIGN KEY(active_sweep_operation_id)
+        REFERENCES memory_extraction_operations(operation_id) ON DELETE SET NULL,
+      CHECK (committed_event_seq <= requested_event_seq),
+      CHECK (created_at <= updated_at),
+      CHECK (
+        (committed_event_seq = 0
+          AND committed_event_id IS NULL
+          AND committed_prefix_digest IS NULL)
+        OR
+        (committed_event_seq > 0
+          AND committed_event_id IS NOT NULL
+          AND length(committed_event_id) > 0
+          AND committed_prefix_digest IS NOT NULL
+          AND length(committed_prefix_digest) = 71
+          AND substr(committed_prefix_digest, 1, 7) = 'sha256:')
+      ),
+      CHECK (
+        (requested_event_seq = 0
+          AND requested_event_id IS NULL
+          AND requested_prefix_digest IS NULL)
+        OR
+        (requested_event_seq > 0
+          AND requested_event_id IS NOT NULL
+          AND length(requested_event_id) > 0
+          AND requested_prefix_digest IS NOT NULL
+          AND length(requested_prefix_digest) = 71
+          AND substr(requested_prefix_digest, 1, 7) = 'sha256:')
+      )
+    ) WITHOUT ROWID;
+
+    CREATE INDEX memory_extraction_cursors_by_active_sweep
+      ON memory_extraction_cursors(active_sweep_operation_id, session_id, run_id);
+    `,
   ],
 ]);
 
@@ -183,6 +446,180 @@ const MINIMUM_SCHEMA_SHAPES: ReadonlyMap<number, MinimumSchemaShape> = new Map([
           name: 'memory_item_keys_by_normalized_key',
           tableName: 'memory_item_keys',
           requiredColumnPrefix: ['normalized_key', 'item_id'],
+        },
+      ],
+    },
+  ],
+  [
+    2,
+    {
+      tables: [
+        {
+          name: 'memory_items',
+          requiredColumns: [
+            'item_id',
+            'version',
+            'content',
+            'kind',
+            'statement_type',
+            'temporal_type',
+            'scope_type',
+            'scope_key',
+            'event_started_at',
+            'event_ended_at',
+            'observed_at',
+            'lifecycle_state',
+            'origin',
+            'content_hash',
+            'created_at',
+            'updated_at',
+          ],
+        },
+        {
+          name: 'memory_item_keys',
+          requiredColumns: ['item_id', 'key_text', 'normalized_key', 'key_type', 'key_origin'],
+        },
+        {
+          name: 'memory_item_sources',
+          requiredColumns: ['item_id', 'session_id', 'run_id', 'turn_id', 'event_id'],
+        },
+        {
+          name: 'memory_write_operations',
+          requiredColumns: [
+            'operation_id',
+            'operation_type',
+            'request_hash',
+            'result_json',
+            'committed_at',
+          ],
+        },
+        {
+          name: 'memory_extraction_operations',
+          requiredColumns: [
+            'operation_id',
+            'session_id',
+            'mode',
+            'trigger_kind',
+            'internal_session_id',
+            'session_create_fingerprint',
+            'request_hash',
+            'request_json',
+            'trigger_epoch',
+            'state',
+            'attempt_count',
+            'active_attempt_id',
+            'lease_expires_at',
+            'next_attempt_at',
+            'last_error_code',
+            'last_error_stage',
+            'last_error_at',
+            'last_failed_attempt_id',
+            'started_at',
+            'created_at',
+            'updated_at',
+            'completed_at',
+            'result_type',
+            'commit_hash',
+            'result_json',
+            'diagnostic_retention_until',
+            'cleanup_state',
+            'cleanup_claim_id',
+            'cleanup_lease_expires_at',
+            'cleanup_attempt_count',
+            'cleanup_error_code',
+            'cleaned_at',
+          ],
+        },
+        {
+          name: 'memory_extraction_attempts',
+          requiredColumns: [
+            'attempt_id',
+            'operation_id',
+            'attempt_ordinal',
+            'state',
+            'turn_id',
+            'run_id',
+            'snapshot_kind',
+            'started_at',
+            'completed_at',
+            'failure_code',
+            'failure_stage',
+            'metrics_json',
+          ],
+        },
+        {
+          name: 'memory_extraction_operation_ranges',
+          requiredColumns: [
+            'operation_id',
+            'range_ordinal',
+            'session_id',
+            'invocation_id',
+            'run_id',
+            'turn_id',
+            'from_event_seq_exclusive',
+            'from_event_id',
+            'from_prefix_digest',
+            'to_event_seq_inclusive',
+            'to_event_id',
+            'to_prefix_digest',
+          ],
+        },
+        {
+          name: 'memory_extraction_cursors',
+          requiredColumns: [
+            'session_id',
+            'invocation_id',
+            'run_id',
+            'turn_id',
+            'committed_event_seq',
+            'committed_event_id',
+            'committed_prefix_digest',
+            'requested_event_seq',
+            'requested_event_id',
+            'requested_prefix_digest',
+            'active_sweep_operation_id',
+            'followup_eligible',
+            'version',
+            'created_at',
+            'updated_at',
+          ],
+        },
+      ],
+      indexes: [
+        {
+          name: 'memory_item_keys_by_normalized_key',
+          tableName: 'memory_item_keys',
+          requiredColumnPrefix: ['normalized_key', 'item_id'],
+        },
+        {
+          name: 'memory_extraction_operations_by_claim',
+          tableName: 'memory_extraction_operations',
+          requiredColumnPrefix: ['state', 'next_attempt_at', 'created_at', 'operation_id'],
+        },
+        {
+          name: 'memory_extraction_operations_by_cleanup',
+          tableName: 'memory_extraction_operations',
+          requiredColumnPrefix: [
+            'cleanup_state',
+            'diagnostic_retention_until',
+            'cleanup_lease_expires_at',
+            'operation_id',
+          ],
+        },
+        {
+          name: 'memory_extraction_attempts_by_operation',
+          tableName: 'memory_extraction_attempts',
+          requiredColumnPrefix: ['operation_id', 'attempt_ordinal', 'attempt_id'],
+        },
+        {
+          name: 'memory_extraction_operation_ranges_by_run',
+          tableName: 'memory_extraction_operation_ranges',
+          requiredColumnPrefix: ['session_id', 'run_id', 'operation_id'],
+        },
+        {
+          name: 'memory_extraction_cursors_by_active_sweep',
+          tableName: 'memory_extraction_cursors',
+          requiredColumnPrefix: ['active_sweep_operation_id', 'session_id', 'run_id'],
         },
       ],
     },

--- a/packages/storage/src/sqlite-long-term-memory-store.ts
+++ b/packages/storage/src/sqlite-long-term-memory-store.ts
@@ -10,7 +10,16 @@ import {
 import { createRequire } from 'node:module';
 import type { DatabaseSync } from 'node:sqlite';
 import {
+  MEMORY_EXTRACTION_MAX_RANGES,
   MemoryItemStoreConflictError,
+  isMemoryExtractionAttemptState,
+  isMemoryExtractionCleanupState,
+  isMemoryExtractionFailureStage,
+  isMemoryExtractionMode,
+  isMemoryExtractionOperationState,
+  isMemoryExtractionResultType,
+  isMemoryExtractionSnapshotKind,
+  isMemoryExtractionTriggerKind,
   isMemoryItemKind,
   isMemoryItemOrigin,
   isMemoryKeyOrigin,
@@ -22,6 +31,19 @@ import {
   normalizeLongTermMemoryContent,
   validateMemoryTemporalBounds,
   type ApplyMemoryMutationsRequest,
+  type ClaimMemoryExtractionCleanupRequest,
+  type CancelMemoryExtractionsForSessionsRequest,
+  type ClaimMemoryExtractionOperationRequest,
+  type ClaimMemoryExtractionOperationResult,
+  type CommitMemoryExtractionRequest,
+  type CommitMemoryExtractionResult,
+  type CreateMemoryExtractionOperationRequest,
+  type CreateMemoryExtractionOperationResult,
+  type CreateMemoryExtractionSweepFollowupRequest,
+  type FailMemoryExtractionAttemptRequest,
+  type FinishMemoryExtractionCleanupRequest,
+  type ListRecoverableMemoryExtractionsRequest,
+  type ListUnassignedMemoryExtractionSweepDebtsRequest,
   type MemoryItem,
   type MemoryItemKey,
   type MemoryItemKeyInput,
@@ -31,7 +53,21 @@ import {
   type MemoryItemStore,
   type MemoryItemWrite,
   type MemoryMutationResult,
+  type MemorySha256Digest,
+  type MemoryExtractionAttempt,
+  type MemoryExtractionAttemptMetrics,
+  type MemoryExtractionCandidate,
+  type MemoryExtractionCommitReceipt,
+  type MemoryExtractionCursor,
+  type MemoryExtractionOperation,
+  type MemoryExtractionOperationRange,
+  type MemoryExtractionOperationRangeInput,
+  type MemoryExtractionSweepDebt,
   type MemoryWriteOperationResult,
+  type RaiseMemoryExtractionRequestedBoundaryRequest,
+  type RenewMemoryExtractionAttemptLeaseRequest,
+  type SearchMemoryExtractionCandidatesRequest,
+  type SearchMemoryExtractionCandidatesResult,
   type SearchMemoryItemsByKeyRequest,
 } from '@maka/core/long-term-memory';
 import {
@@ -47,9 +83,16 @@ const MAX_KEYS_PER_ITEM = 32;
 const MAX_SOURCES_PER_ITEM = 256;
 const MAX_SEARCH_TERMS = 32;
 const MAX_SEARCH_RESULTS = 100;
+const MAX_EXTRACTION_CANDIDATES = 20;
+const MAX_EXTRACTION_CANDIDATE_KEYS = 32;
+const MAX_EXTRACTION_CANDIDATE_SOURCES = 256;
+const DEFAULT_RECOVERABLE_EXTRACTION_LIMIT = 20;
+const MAX_RECOVERABLE_EXTRACTION_LIMIT = 100;
 const MAX_IDENTIFIER_CODE_POINTS = 512;
 const MAX_KEY_CODE_POINTS = 256;
 const MAX_OPERATION_RESULT_JSON_CODE_UNITS = 128 * 1_024;
+const MAX_EXTRACTION_REQUEST_JSON_CODE_UNITS = 128 * 1_024;
+const MAX_EXTRACTION_METRICS_JSON_CODE_UNITS = 8 * 1_024;
 
 const require = createRequire(import.meta.url);
 
@@ -57,6 +100,8 @@ export type SqliteMemoryItemStoreFailpoint =
   | 'after_item_write'
   | 'after_keys_write'
   | 'after_sources_write'
+  | 'after_cursor_write'
+  | 'after_extraction_state_write'
   | 'before_operation_write'
   | 'after_commit';
 
@@ -135,6 +180,127 @@ interface MemoryOperationRow {
   committed_at: unknown;
 }
 
+interface MemoryExtractionOperationRow {
+  operation_id: unknown;
+  session_id: unknown;
+  mode: unknown;
+  trigger_kind: unknown;
+  internal_session_id: unknown;
+  session_create_fingerprint: unknown;
+  request_hash: unknown;
+  request_json: unknown;
+  trigger_epoch: unknown;
+  state: unknown;
+  attempt_count: unknown;
+  active_attempt_id: unknown;
+  lease_expires_at: unknown;
+  next_attempt_at: unknown;
+  last_error_code: unknown;
+  last_error_stage: unknown;
+  last_error_at: unknown;
+  last_failed_attempt_id: unknown;
+  started_at: unknown;
+  created_at: unknown;
+  updated_at: unknown;
+  completed_at: unknown;
+  result_type: unknown;
+  commit_hash: unknown;
+  result_json: unknown;
+  diagnostic_retention_until: unknown;
+  cleanup_state: unknown;
+  cleanup_claim_id: unknown;
+  cleanup_lease_expires_at: unknown;
+  cleanup_attempt_count: unknown;
+  cleanup_error_code: unknown;
+  cleaned_at: unknown;
+}
+
+interface MemoryExtractionAttemptRow {
+  attempt_id: unknown;
+  operation_id: unknown;
+  attempt_ordinal: unknown;
+  state: unknown;
+  turn_id: unknown;
+  run_id: unknown;
+  snapshot_kind: unknown;
+  started_at: unknown;
+  completed_at: unknown;
+  failure_code: unknown;
+  failure_stage: unknown;
+  metrics_json: unknown;
+}
+
+interface MemoryExtractionOperationRangeRow {
+  operation_id: unknown;
+  range_ordinal: unknown;
+  session_id: unknown;
+  invocation_id: unknown;
+  run_id: unknown;
+  turn_id: unknown;
+  from_event_seq_exclusive: unknown;
+  from_event_id: unknown;
+  from_prefix_digest: unknown;
+  to_event_seq_inclusive: unknown;
+  to_event_id: unknown;
+  to_prefix_digest: unknown;
+}
+
+interface MemoryExtractionCursorRow {
+  session_id: unknown;
+  invocation_id: unknown;
+  run_id: unknown;
+  turn_id: unknown;
+  committed_event_seq: unknown;
+  committed_event_id: unknown;
+  committed_prefix_digest: unknown;
+  requested_event_seq: unknown;
+  requested_event_id: unknown;
+  requested_prefix_digest: unknown;
+  active_sweep_operation_id: unknown;
+  followup_eligible: unknown;
+  version: unknown;
+  created_at: unknown;
+  updated_at: unknown;
+}
+
+interface MemoryExtractionCandidateRow {
+  item_id: unknown;
+  content_hash_match: unknown;
+  source_overlap_count: unknown;
+  exact_key_match_count: unknown;
+  kind_match: unknown;
+  statement_type_match: unknown;
+  temporal_match: unknown;
+}
+
+interface NormalizedCreateMemoryExtractionOperation {
+  readonly operationId: string;
+  readonly sessionId: string;
+  readonly mode: 'sweep' | 'targeted';
+  readonly triggerKind: 'context_threshold' | 'compaction' | 'user_requested' | 'agent_requested';
+  readonly internalSessionId: string;
+  readonly sessionCreateFingerprint: string;
+  readonly requestHash: string;
+  readonly requestJson: string;
+  readonly triggerEpoch: string | null;
+  readonly ranges: readonly MemoryExtractionOperationRangeInput[];
+  readonly maxUnfinishedTargetedPerSession: number | null;
+}
+
+interface NormalizedExtractionCandidateQuery {
+  readonly contentHash: string;
+  readonly kind: MemoryItem['kind'];
+  readonly statementType: MemoryItem['statementType'];
+  readonly temporalType: MemoryItem['temporalType'];
+  readonly scopeType: MemoryItem['scopeType'];
+  readonly scopeKey: string | null;
+  readonly eventStartedAt: number | null;
+  readonly eventEndedAt: number | null;
+  readonly keys: readonly string[];
+  readonly sourceEventIds: readonly string[];
+  readonly limit: number;
+}
+
 interface SqliteMemoryKeySearchQuery {
   readonly sql: string;
   readonly parameters: readonly (string | number)[];
@@ -197,6 +363,12 @@ export class SqliteMemoryItemStore implements MemoryItemStore {
 
     this.#database.exec('BEGIN IMMEDIATE');
     try {
+      if (this.#readExtractionOperationRow(operationId)) {
+        throw new MemoryItemStoreConflictError(
+          'operation_reused',
+          `Memory operation ${operationId} is reserved by a Memory Extraction Operation`,
+        );
+      }
       const existing = this.#readOperationRow(operationId);
       if (existing) {
         if (requiredHash(existing.request_hash, 'request_hash') !== requestHash) {
@@ -211,13 +383,7 @@ export class SqliteMemoryItemStore implements MemoryItemStore {
 
       validateObservedAtForCommit(mutations, committedAt);
 
-      const results: MemoryMutationResult[] = [];
-      const transientItemIds = new Set<string>();
-      for (let index = 0; index < mutations.length; index += 1) {
-        const result = this.#applyMutation(mutations[index]!, index, committedAt, transientItemIds);
-        results.push(result);
-        if (result.outcome !== 'noop') transientItemIds.add(result.itemId);
-      }
+      const results = this.#applyNormalizedMutations(mutations, committedAt);
 
       this.#options.failpoint?.('before_operation_write');
       this.#database
@@ -292,10 +458,1058 @@ export class SqliteMemoryItemStore implements MemoryItemStore {
     return row ? decodeOperation(row) : undefined;
   }
 
+  async createMemoryExtractionOperation(
+    request: CreateMemoryExtractionOperationRequest,
+  ): Promise<CreateMemoryExtractionOperationResult> {
+    this.#assertOpen();
+    const createdAt = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const normalized = normalizeCreateMemoryExtractionOperation(request);
+
+    this.#database.exec('BEGIN IMMEDIATE');
+    try {
+      if (this.#readOperationRow(normalized.operationId)) {
+        throw new MemoryItemStoreConflictError(
+          'operation_reused',
+          `Memory operation ${normalized.operationId} is already a write receipt`,
+        );
+      }
+      const existing = this.#readExtractionOperationRow(normalized.operationId);
+      if (existing) {
+        if (!extractionOperationDefinitionMatches(existing, normalized)) {
+          throw new MemoryItemStoreConflictError(
+            'operation_reused',
+            `Memory Extraction Operation ${normalized.operationId} was already used for a different request`,
+          );
+        }
+        const operation = this.#decodeExtractionOperation(existing);
+        this.#database.exec('COMMIT');
+        return { operation, replayed: true };
+      }
+
+      const equivalent = this.#readExtractionOperationRowByRequestHash(
+        normalized.sessionId,
+        normalized.requestHash,
+      );
+      if (equivalent) {
+        const operation = this.#decodeExtractionOperation(equivalent);
+        this.#database.exec('COMMIT');
+        return { operation, replayed: true };
+      }
+
+      if (normalized.maxUnfinishedTargetedPerSession !== null) {
+        const row = this.#database
+          .prepare(
+            `SELECT COUNT(*) AS count
+             FROM memory_extraction_operations
+             WHERE session_id = ? AND mode = 'targeted' AND state IN ('pending', 'running')`,
+          )
+          .get(normalized.sessionId) as { count?: unknown } | undefined;
+        const count = requiredNonNegativeInteger(row?.count, 'count');
+        if (count >= normalized.maxUnfinishedTargetedPerSession) {
+          throw new MemoryItemStoreConflictError(
+            'extraction_queue_full',
+            `Memory Extraction Targeted queue is full for Session ${normalized.sessionId}`,
+          );
+        }
+      }
+
+      this.#insertExtractionOperation(normalized, createdAt);
+
+      const operation = this.#requireExtractionOperation(normalized.operationId);
+      this.#database.exec('COMMIT');
+      return { operation, replayed: false };
+    } catch (error) {
+      rollback(this.#database);
+      throw error;
+    }
+  }
+
+  async listRecoverableMemoryExtractions(
+    request: ListRecoverableMemoryExtractionsRequest = {},
+  ): Promise<readonly MemoryExtractionOperation[]> {
+    this.#assertOpen();
+    const now = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const limit = normalizeRecoverableExtractionLimit(request);
+    return this.#readSnapshot(() => {
+      const rows = this.#database
+        .prepare(
+          `SELECT * FROM memory_extraction_operations
+           WHERE (state = 'pending' AND (next_attempt_at IS NULL OR next_attempt_at <= ?))
+              OR (state = 'running' AND lease_expires_at IS NOT NULL AND lease_expires_at <= ?)
+           ORDER BY
+             CASE mode WHEN 'targeted' THEN 0 ELSE 1 END ASC,
+             created_at ASC,
+             operation_id ASC
+           LIMIT ?`,
+        )
+        .all(now, now, limit) as unknown as MemoryExtractionOperationRow[];
+      return rows.map((row) => this.#decodeExtractionOperation(row));
+    });
+  }
+
+  async listRecoverableMemoryExtractionCleanups(
+    request: ListRecoverableMemoryExtractionsRequest = {},
+  ): Promise<readonly MemoryExtractionOperation[]> {
+    this.#assertOpen();
+    const now = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const limit = normalizeRecoverableExtractionLimit(request);
+    return this.#readSnapshot(() => {
+      const rows = this.#database
+        .prepare(
+          `SELECT * FROM memory_extraction_operations
+           WHERE state IN ('succeeded', 'failed')
+             AND diagnostic_retention_until <= ?
+             AND (cleanup_state = 'pending'
+               OR (cleanup_state = 'running' AND cleanup_lease_expires_at <= ?))
+           ORDER BY diagnostic_retention_until ASC, operation_id ASC
+           LIMIT ?`,
+        )
+        .all(now, now, limit) as unknown as MemoryExtractionOperationRow[];
+      return rows.map((row) => this.#decodeExtractionOperation(row));
+    });
+  }
+
+  async hasUnfinishedMemoryExtractions(): Promise<boolean> {
+    this.#assertOpen();
+    return this.#readSnapshot(() =>
+      Boolean(
+        this.#database
+          .prepare(
+            `SELECT 1
+             FROM memory_extraction_operations
+             WHERE state IN ('pending', 'running')
+             LIMIT 1`,
+          )
+          .get(),
+      ),
+    );
+  }
+
+  async listUnassignedMemoryExtractionSweepDebts(
+    request: ListUnassignedMemoryExtractionSweepDebtsRequest = {},
+  ): Promise<readonly MemoryExtractionSweepDebt[]> {
+    this.#assertOpen();
+    const limit = normalizeSweepDebtLimit(request);
+    return this.#readSnapshot(() => {
+      const rows = this.#database
+        .prepare(
+          `SELECT * FROM memory_extraction_cursors
+           WHERE active_sweep_operation_id IS NULL
+             AND requested_event_seq > committed_event_seq
+             AND followup_eligible = 1
+           ORDER BY updated_at ASC, session_id ASC, run_id ASC
+           LIMIT ?`,
+        )
+        .all(limit) as unknown as MemoryExtractionCursorRow[];
+      return rows.map((row) => {
+        const cursor = decodeExtractionCursor(row);
+        if (cursor.activeSweepOperationId !== null)
+          throw invalidColumn('active_sweep_operation_id');
+        return cursor as MemoryExtractionSweepDebt;
+      });
+    });
+  }
+
+  async createMemoryExtractionSweepFollowup(
+    request: CreateMemoryExtractionSweepFollowupRequest,
+  ): Promise<CreateMemoryExtractionOperationResult | undefined> {
+    this.#assertOpen();
+    if (!Number.isSafeInteger(request.expectedCursorVersion) || request.expectedCursorVersion < 1) {
+      throw new Error('Memory Extraction follow-up expectedCursorVersion must be positive');
+    }
+    const createdAt = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const normalized = normalizeCreateMemoryExtractionOperation(request.operation);
+    if (normalized.mode !== 'sweep' || normalized.ranges.length !== 1) {
+      throw new Error('Memory Extraction follow-up requires exactly one Sweep Range');
+    }
+    const range = normalized.ranges[0]!;
+
+    this.#database.exec('BEGIN IMMEDIATE');
+    try {
+      const existing = this.#readExtractionOperationRow(normalized.operationId);
+      if (existing) {
+        if (!extractionOperationDefinitionMatches(existing, normalized)) {
+          throw new MemoryItemStoreConflictError(
+            'operation_reused',
+            `Memory Extraction Operation ${normalized.operationId} was already used for a different request`,
+          );
+        }
+        const operation = this.#decodeExtractionOperation(existing);
+        this.#database.exec('COMMIT');
+        return { operation, replayed: true };
+      }
+
+      const cursorRow = this.#readExtractionCursorRow(range.sessionId, range.runId);
+      if (!cursorRow)
+        throw extractionCursorConflict(range.sessionId, range.runId, 'does not exist');
+      const cursor = decodeExtractionCursor(cursorRow);
+      if (
+        cursor.version !== request.expectedCursorVersion ||
+        cursor.activeSweepOperationId !== null ||
+        cursor.requestedEventSeq <= cursor.committedEventSeq ||
+        requiredBooleanInteger(cursorRow.followup_eligible, 'followup_eligible') !== true
+      ) {
+        this.#database.exec('COMMIT');
+        return undefined;
+      }
+      if (
+        cursor.invocationId !== range.invocationId ||
+        cursor.turnId !== range.turnId ||
+        !cursorMatchesFrozenStart(cursor, range) ||
+        cursor.requestedEventSeq !== range.toEventSeqInclusive ||
+        cursor.requestedEventId !== range.toEventId ||
+        cursor.requestedPrefixDigest !== range.toPrefixDigest
+      ) {
+        throw extractionCursorConflict(range.sessionId, range.runId, 'follow-up debt changed');
+      }
+
+      this.#insertExtractionOperation(normalized, createdAt);
+      const operation = this.#requireExtractionOperation(normalized.operationId);
+      this.#database.exec('COMMIT');
+      return { operation, replayed: false };
+    } catch (error) {
+      rollback(this.#database);
+      throw error;
+    }
+  }
+
+  async claimMemoryExtractionOperation(
+    request: ClaimMemoryExtractionOperationRequest,
+  ): Promise<ClaimMemoryExtractionOperationResult | undefined> {
+    this.#assertOpen();
+    const now = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const operationId = normalizeIdentifier(request.operationId, 'operationId');
+    const attemptId = normalizeIdentifier(request.attemptId, 'attemptId');
+    const turnId = normalizeIdentifier(request.turnId, 'attempt turnId');
+    const runId = normalizeIdentifier(request.runId, 'attempt runId');
+    if (!isMemoryExtractionSnapshotKind(request.snapshotKind)) {
+      throw new Error('Invalid Memory Extraction snapshot kind');
+    }
+    const leaseExpiresAt = normalizeTimestamp(request.leaseExpiresAt, 'leaseExpiresAt');
+    if (leaseExpiresAt <= now) throw new Error('Memory Extraction lease must expire in the future');
+    const maxAttempts =
+      request.maxAttempts === undefined
+        ? null
+        : normalizePositiveInteger(request.maxAttempts, 'maxAttempts');
+    const exhaustionRetentionUntil =
+      request.diagnosticRetentionUntil === undefined
+        ? null
+        : normalizeTimestamp(request.diagnosticRetentionUntil, 'diagnosticRetentionUntil');
+    if ((maxAttempts === null) !== (exhaustionRetentionUntil === null)) {
+      throw new Error('Memory Extraction retry ceiling requires diagnostic retention');
+    }
+    if (exhaustionRetentionUntil !== null && exhaustionRetentionUntil < now) {
+      throw new Error('diagnosticRetentionUntil cannot be earlier than claim time');
+    }
+
+    this.#database.exec('BEGIN IMMEDIATE');
+    try {
+      const existingAttemptRow = this.#readExtractionAttemptRow(attemptId);
+      if (existingAttemptRow) {
+        const existingAttempt = decodeExtractionAttempt(existingAttemptRow);
+        const operation = this.#requireExtractionOperation(operationId);
+        if (
+          existingAttempt.operationId !== operationId ||
+          existingAttempt.turnId !== turnId ||
+          existingAttempt.runId !== runId ||
+          existingAttempt.snapshotKind !== request.snapshotKind
+        ) {
+          throw new MemoryItemStoreConflictError(
+            'operation_reused',
+            `Memory Extraction Attempt ${attemptId} was already used for a different claim`,
+          );
+        }
+        if (
+          existingAttempt.state !== 'running' ||
+          operation.state !== 'running' ||
+          operation.activeAttemptId !== attemptId
+        ) {
+          this.#database.exec('COMMIT');
+          return undefined;
+        }
+        this.#database.exec('COMMIT');
+        return { operation, attempt: existingAttempt, replayed: true };
+      }
+
+      const operationRow = this.#readExtractionOperationRow(operationId);
+      if (!operationRow) throw extractionOperationNotFound(operationId);
+      const operation = this.#decodeExtractionOperation(operationRow);
+      if (operation.state === 'succeeded' || operation.state === 'failed') {
+        this.#database.exec('COMMIT');
+        return undefined;
+      }
+      if (
+        operation.state === 'pending' &&
+        operation.nextAttemptAt !== null &&
+        operation.nextAttemptAt > now
+      ) {
+        this.#database.exec('COMMIT');
+        return undefined;
+      }
+      if (
+        operation.state === 'running' &&
+        operation.leaseExpiresAt !== null &&
+        operation.leaseExpiresAt > now
+      ) {
+        this.#database.exec('COMMIT');
+        return undefined;
+      }
+
+      if (maxAttempts !== null && operation.attemptCount >= maxAttempts) {
+        if (operation.state === 'running') {
+          const staleAttemptId = operation.activeAttemptId;
+          if (!staleAttemptId) throw invalidColumn('active_attempt_id');
+          this.#database
+            .prepare(
+              `UPDATE memory_extraction_attempts
+               SET state = 'abandoned', completed_at = ?,
+                   failure_code = 'attempt_limit_exhausted', failure_stage = 'recovery'
+               WHERE attempt_id = ? AND operation_id = ? AND state = 'running'`,
+            )
+            .run(now, staleAttemptId, operationId);
+        }
+        this.#database
+          .prepare(
+            `UPDATE memory_extraction_operations
+             SET state = 'failed', active_attempt_id = NULL, lease_expires_at = NULL,
+                 next_attempt_at = NULL, last_error_code = 'attempt_limit_exhausted',
+                 last_error_stage = 'recovery', last_error_at = ?,
+                 last_failed_attempt_id = COALESCE(active_attempt_id, last_failed_attempt_id),
+                 updated_at = MAX(updated_at, ?), completed_at = ?, result_type = NULL,
+                 diagnostic_retention_until = ?, cleanup_state = 'pending',
+                 cleanup_claim_id = NULL, cleanup_lease_expires_at = NULL,
+                 cleanup_error_code = NULL, cleaned_at = NULL
+             WHERE operation_id = ? AND state IN ('pending', 'running')`,
+          )
+          .run(now, now, now, exhaustionRetentionUntil, operationId);
+        this.#database
+          .prepare(
+            `UPDATE memory_extraction_cursors
+             SET active_sweep_operation_id = NULL, followup_eligible = 0,
+                 version = version + 1,
+                 updated_at = MAX(updated_at, ?)
+             WHERE active_sweep_operation_id = ?`,
+          )
+          .run(now, operationId);
+        this.#database.exec('COMMIT');
+        return undefined;
+      }
+
+      if (operation.state === 'running') {
+        const staleAttemptId = operation.activeAttemptId;
+        if (!staleAttemptId) throw invalidColumn('active_attempt_id');
+        const stale = this.#database
+          .prepare(
+            `UPDATE memory_extraction_attempts
+             SET state = 'abandoned', completed_at = ?,
+                 failure_code = 'lease_expired', failure_stage = 'recovery'
+             WHERE attempt_id = ? AND operation_id = ? AND state = 'running'`,
+          )
+          .run(now, staleAttemptId, operationId);
+        if (Number(stale.changes) !== 1) {
+          throw new MemoryItemStoreConflictError(
+            'extraction_attempt_not_active',
+            `Memory Extraction Attempt ${staleAttemptId} is no longer active`,
+          );
+        }
+      }
+
+      const ordinal = operation.attemptCount + 1;
+      this.#database
+        .prepare(
+          `INSERT INTO memory_extraction_attempts(
+             attempt_id, operation_id, attempt_ordinal, state, turn_id, run_id,
+             snapshot_kind, started_at, completed_at, failure_code, failure_stage, metrics_json
+           ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, NULL, NULL, NULL, NULL)`,
+        )
+        .run(attemptId, operationId, ordinal, turnId, runId, request.snapshotKind, now);
+      const updated = this.#database
+        .prepare(
+          `UPDATE memory_extraction_operations
+           SET state = 'running', attempt_count = ?, active_attempt_id = ?,
+               lease_expires_at = ?, next_attempt_at = NULL,
+               last_error_code = CASE WHEN state = 'running' THEN 'lease_expired' ELSE last_error_code END,
+               last_error_stage = CASE WHEN state = 'running' THEN 'recovery' ELSE last_error_stage END,
+               last_error_at = CASE WHEN state = 'running' THEN ? ELSE last_error_at END,
+               last_failed_attempt_id = CASE WHEN state = 'running' THEN active_attempt_id ELSE last_failed_attempt_id END,
+               started_at = COALESCE(started_at, ?), updated_at = MAX(updated_at, ?)
+           WHERE operation_id = ? AND state IN ('pending', 'running')`,
+        )
+        .run(ordinal, attemptId, leaseExpiresAt, now, now, now, operationId);
+      if (Number(updated.changes) !== 1) {
+        throw new MemoryItemStoreConflictError(
+          'extraction_operation_not_claimable',
+          `Memory Extraction Operation ${operationId} is not claimable`,
+        );
+      }
+
+      const claimedOperation = this.#requireExtractionOperation(operationId);
+      const attempt = this.#requireExtractionAttempt(attemptId);
+      this.#database.exec('COMMIT');
+      return { operation: claimedOperation, attempt, replayed: false };
+    } catch (error) {
+      rollback(this.#database);
+      throw error;
+    }
+  }
+
+  async renewMemoryExtractionAttemptLease(
+    request: RenewMemoryExtractionAttemptLeaseRequest,
+  ): Promise<MemoryExtractionOperation> {
+    this.#assertOpen();
+    const now = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const operationId = normalizeIdentifier(request.operationId, 'operationId');
+    const attemptId = normalizeIdentifier(request.attemptId, 'attemptId');
+    const runId = normalizeIdentifier(request.runId, 'attempt runId');
+    const leaseExpiresAt = normalizeTimestamp(request.leaseExpiresAt, 'leaseExpiresAt');
+    if (leaseExpiresAt <= now) throw new Error('Memory Extraction lease must expire in the future');
+
+    this.#database.exec('BEGIN IMMEDIATE');
+    try {
+      this.#requireActiveExtractionAttempt(operationId, attemptId, runId);
+      const operation = this.#requireExtractionOperation(operationId);
+      if (operation.leaseExpiresAt === null || operation.leaseExpiresAt <= now) {
+        throw extractionAttemptNotActive(attemptId);
+      }
+      if (leaseExpiresAt < operation.leaseExpiresAt) {
+        throw new Error('Memory Extraction lease renewal cannot shorten the active lease');
+      }
+      if (leaseExpiresAt === operation.leaseExpiresAt) {
+        this.#database.exec('COMMIT');
+        return operation;
+      }
+
+      const updated = this.#database
+        .prepare(
+          `UPDATE memory_extraction_operations
+           SET lease_expires_at = ?, updated_at = MAX(updated_at, ?)
+           WHERE operation_id = ? AND state = 'running' AND active_attempt_id = ?
+             AND lease_expires_at = ? AND lease_expires_at > ?`,
+        )
+        .run(leaseExpiresAt, now, operationId, attemptId, operation.leaseExpiresAt, now);
+      if (Number(updated.changes) !== 1) throw extractionAttemptNotActive(attemptId);
+      const renewed = this.#requireExtractionOperation(operationId);
+      this.#database.exec('COMMIT');
+      return renewed;
+    } catch (error) {
+      rollback(this.#database);
+      throw error;
+    }
+  }
+
+  async failMemoryExtractionAttempt(
+    request: FailMemoryExtractionAttemptRequest,
+  ): Promise<MemoryExtractionOperation> {
+    this.#assertOpen();
+    const now = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const operationId = normalizeIdentifier(request.operationId, 'operationId');
+    const attemptId = normalizeIdentifier(request.attemptId, 'attemptId');
+    const runId = normalizeIdentifier(request.runId, 'attempt runId');
+    const failureCode = normalizeStableErrorCode(request.failureCode, 'failureCode');
+    if (!isMemoryExtractionFailureStage(request.failureStage)) {
+      throw new Error('Invalid Memory Extraction failure stage');
+    }
+    const metricsJson = encodeExtractionMetrics(request.metrics ?? null);
+    const nextAttemptAt = normalizeOptionalTimestamp(request.nextAttemptAt, 'nextAttemptAt');
+    const diagnosticRetentionUntil = normalizeOptionalTimestamp(
+      request.diagnosticRetentionUntil,
+      'diagnosticRetentionUntil',
+    );
+    if (nextAttemptAt !== null && nextAttemptAt < now) {
+      throw new Error('nextAttemptAt cannot be earlier than failure time');
+    }
+    if (
+      nextAttemptAt === null &&
+      (diagnosticRetentionUntil === null || diagnosticRetentionUntil < now)
+    ) {
+      throw new Error(
+        'Final Memory Extraction failure requires a future diagnostic retention boundary',
+      );
+    }
+
+    this.#database.exec('BEGIN IMMEDIATE');
+    try {
+      this.#requireActiveExtractionAttempt(operationId, attemptId, runId);
+      const attemptUpdate = this.#database
+        .prepare(
+          `UPDATE memory_extraction_attempts
+           SET state = 'failed', completed_at = ?, failure_code = ?, failure_stage = ?, metrics_json = ?
+           WHERE attempt_id = ? AND operation_id = ? AND run_id = ? AND state = 'running'`,
+        )
+        .run(now, failureCode, request.failureStage, metricsJson, attemptId, operationId, runId);
+      if (Number(attemptUpdate.changes) !== 1) throw extractionAttemptNotActive(attemptId);
+
+      const operationUpdate =
+        nextAttemptAt === null
+          ? this.#database
+              .prepare(
+                `UPDATE memory_extraction_operations
+               SET state = 'failed', active_attempt_id = NULL, lease_expires_at = NULL,
+                   next_attempt_at = NULL, last_error_code = ?, last_error_stage = ?,
+                   last_error_at = ?, last_failed_attempt_id = ?, updated_at = MAX(updated_at, ?),
+                   completed_at = ?, result_type = NULL, diagnostic_retention_until = ?,
+                   cleanup_state = 'pending', cleanup_claim_id = NULL,
+                   cleanup_lease_expires_at = NULL, cleanup_error_code = NULL, cleaned_at = NULL
+               WHERE operation_id = ? AND state = 'running' AND active_attempt_id = ?`,
+              )
+              .run(
+                failureCode,
+                request.failureStage,
+                now,
+                attemptId,
+                now,
+                now,
+                diagnosticRetentionUntil,
+                operationId,
+                attemptId,
+              )
+          : this.#database
+              .prepare(
+                `UPDATE memory_extraction_operations
+               SET state = 'pending', active_attempt_id = NULL, lease_expires_at = NULL,
+                   next_attempt_at = ?, last_error_code = ?, last_error_stage = ?,
+                   last_error_at = ?, last_failed_attempt_id = ?, updated_at = MAX(updated_at, ?)
+               WHERE operation_id = ? AND state = 'running' AND active_attempt_id = ?`,
+              )
+              .run(
+                nextAttemptAt,
+                failureCode,
+                request.failureStage,
+                now,
+                attemptId,
+                now,
+                operationId,
+                attemptId,
+              );
+      if (Number(operationUpdate.changes) !== 1) throw extractionAttemptNotActive(attemptId);
+      if (nextAttemptAt === null) {
+        this.#database
+          .prepare(
+            `UPDATE memory_extraction_cursors
+             SET active_sweep_operation_id = NULL, followup_eligible = 0,
+                 version = version + 1,
+                 updated_at = MAX(updated_at, ?)
+             WHERE active_sweep_operation_id = ?`,
+          )
+          .run(now, operationId);
+      }
+      const operation = this.#requireExtractionOperation(operationId);
+      this.#database.exec('COMMIT');
+      return operation;
+    } catch (error) {
+      rollback(this.#database);
+      throw error;
+    }
+  }
+
+  async readMemoryExtractionOperation(
+    operationId: string,
+  ): Promise<MemoryExtractionOperation | undefined> {
+    this.#assertOpen();
+    const normalized = normalizeIdentifier(operationId, 'operationId');
+    return this.#readSnapshot(() => {
+      const row = this.#readExtractionOperationRow(normalized);
+      return row ? this.#decodeExtractionOperation(row) : undefined;
+    });
+  }
+
+  async readMemoryExtractionAttempt(
+    attemptId: string,
+  ): Promise<MemoryExtractionAttempt | undefined> {
+    this.#assertOpen();
+    const normalized = normalizeIdentifier(attemptId, 'attemptId');
+    const row = this.#readExtractionAttemptRow(normalized);
+    return row ? decodeExtractionAttempt(row) : undefined;
+  }
+
+  async readMemoryExtractionCursor(
+    sessionId: string,
+    runId: string,
+  ): Promise<MemoryExtractionCursor | undefined> {
+    this.#assertOpen();
+    const row = this.#readExtractionCursorRow(
+      normalizeIdentifier(sessionId, 'sessionId'),
+      normalizeIdentifier(runId, 'runId'),
+    );
+    return row ? decodeExtractionCursor(row) : undefined;
+  }
+
+  async raiseMemoryExtractionRequestedBoundary(
+    request: RaiseMemoryExtractionRequestedBoundaryRequest,
+  ): Promise<MemoryExtractionCursor> {
+    this.#assertOpen();
+    const now = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const sessionId = normalizeIdentifier(request.sessionId, 'sessionId');
+    const runId = normalizeIdentifier(request.runId, 'runId');
+    const operationId = normalizeIdentifier(
+      request.activeSweepOperationId,
+      'activeSweepOperationId',
+    );
+    const requestedEventSeq = normalizePositiveInteger(
+      request.requestedEventSeq,
+      'requestedEventSeq',
+    );
+    const requestedEventId = normalizeIdentifier(request.requestedEventId, 'requestedEventId');
+    const requestedPrefixDigest = normalizeSha256Digest(
+      request.requestedPrefixDigest,
+      'requestedPrefixDigest',
+    );
+
+    this.#database.exec('BEGIN IMMEDIATE');
+    try {
+      const operation = this.#requireExtractionOperation(operationId);
+      if (operation.mode !== 'sweep' || !['pending', 'running'].includes(operation.state)) {
+        throw new MemoryItemStoreConflictError(
+          'extraction_cursor_conflict',
+          `Memory Extraction Operation ${operationId} cannot own an active Sweep Cursor`,
+        );
+      }
+      const row = this.#readExtractionCursorRow(sessionId, runId);
+      if (!row) throw extractionCursorConflict(sessionId, runId, 'does not exist');
+      const cursor = decodeExtractionCursor(row);
+      if (cursor.activeSweepOperationId !== operationId) {
+        throw extractionCursorConflict(sessionId, runId, 'is owned by another Sweep Operation');
+      }
+      if (requestedEventSeq < cursor.requestedEventSeq) {
+        throw extractionCursorConflict(
+          sessionId,
+          runId,
+          'requested boundary cannot move backwards',
+        );
+      }
+      if (requestedEventSeq === cursor.requestedEventSeq) {
+        if (
+          cursor.requestedEventId !== requestedEventId ||
+          cursor.requestedPrefixDigest !== requestedPrefixDigest
+        ) {
+          throw extractionCursorConflict(sessionId, runId, 'requested boundary identity changed');
+        }
+        this.#database.exec('COMMIT');
+        return cursor;
+      }
+      this.#database
+        .prepare(
+          `UPDATE memory_extraction_cursors
+           SET requested_event_seq = ?, requested_event_id = ?, requested_prefix_digest = ?,
+               version = version + 1, updated_at = MAX(updated_at, ?)
+           WHERE session_id = ? AND run_id = ? AND active_sweep_operation_id = ?`,
+        )
+        .run(
+          requestedEventSeq,
+          requestedEventId,
+          requestedPrefixDigest,
+          now,
+          sessionId,
+          runId,
+          operationId,
+        );
+      const updated = this.#readExtractionCursorRow(sessionId, runId);
+      if (!updated) throw invalidColumn('memory_extraction_cursors');
+      this.#database.exec('COMMIT');
+      return decodeExtractionCursor(updated);
+    } catch (error) {
+      rollback(this.#database);
+      throw error;
+    }
+  }
+
+  async searchMemoryExtractionCandidates(
+    request: SearchMemoryExtractionCandidatesRequest,
+  ): Promise<SearchMemoryExtractionCandidatesResult> {
+    this.#assertOpen();
+    const query = normalizeExtractionCandidateQuery(request);
+    return this.#readSnapshot(() => {
+      const built = buildExtractionCandidateQuery(query);
+      const rows = this.#database
+        .prepare(built.sql)
+        .all(...built.parameters) as unknown as MemoryExtractionCandidateRow[];
+      const truncated = rows.length > query.limit;
+      const candidates = rows.slice(0, query.limit).map((row): MemoryExtractionCandidate => {
+        const itemId = requiredIdentifierString(row.item_id, 'item_id');
+        return {
+          record: this.#requireItemRecord(itemId),
+          contentHashMatch: requiredBooleanInteger(row.content_hash_match, 'content_hash_match'),
+          sourceOverlapCount: requiredNonNegativeInteger(
+            row.source_overlap_count,
+            'source_overlap_count',
+          ),
+          exactKeyMatchCount: requiredNonNegativeInteger(
+            row.exact_key_match_count,
+            'exact_key_match_count',
+          ),
+          kindMatch: requiredBooleanInteger(row.kind_match, 'kind_match'),
+          statementTypeMatch: requiredBooleanInteger(
+            row.statement_type_match,
+            'statement_type_match',
+          ),
+          temporalMatch: requiredBooleanInteger(row.temporal_match, 'temporal_match'),
+        };
+      });
+      return { candidates, truncated };
+    });
+  }
+
+  async commitMemoryExtraction(
+    request: CommitMemoryExtractionRequest,
+  ): Promise<CommitMemoryExtractionResult> {
+    this.#assertOpen();
+    const committedAt = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const operationId = normalizeIdentifier(request.operationId, 'operationId');
+    const attemptId = normalizeIdentifier(request.attemptId, 'attemptId');
+    const runId = normalizeIdentifier(request.runId, 'attempt runId');
+    if (!isMemoryExtractionResultType(request.resultType)) {
+      throw new Error('Invalid Memory Extraction result type');
+    }
+    if (typeof request.selectionSaturated !== 'boolean') {
+      throw new Error('Memory Extraction selectionSaturated must be a boolean');
+    }
+    const evidenceDigest = normalizeSha256Digest(request.evidenceDigest, 'evidenceDigest');
+    const diagnosticRetentionUntil = normalizeTimestamp(
+      request.diagnosticRetentionUntil,
+      'diagnosticRetentionUntil',
+    );
+    const mutations = normalizeMutations(request.mutations, true);
+    validateObservedAtForCommit(mutations, committedAt);
+
+    this.#database.exec('BEGIN IMMEDIATE');
+    try {
+      const operationRow = this.#readExtractionOperationRow(operationId);
+      if (!operationRow) throw extractionOperationNotFound(operationId);
+      const operation = this.#decodeExtractionOperation(operationRow);
+      const ranges = operation.ranges;
+      validateExtractionCommitShape(operation, request.resultType, mutations);
+      const mutationDigest = `sha256:${hashCanonical(mutations)}` as MemorySha256Digest;
+      const commitHash = hashCanonical({
+        version: 1,
+        operationId,
+        operationRequestHash: operation.requestHash,
+        attemptId,
+        runId,
+        resultType: request.resultType,
+        selectionSaturated: request.selectionSaturated,
+        evidenceDigest,
+        mutationDigest,
+        mutations,
+        ranges,
+      });
+
+      const existingReceipt = this.#readOperationRow(operationId);
+      if (existingReceipt) {
+        if (requiredHash(existingReceipt.request_hash, 'request_hash') !== commitHash) {
+          throw new MemoryItemStoreConflictError(
+            'operation_reused',
+            `Memory Extraction Operation ${operationId} was already committed with a different result`,
+          );
+        }
+        const successfulAttempt = this.#readExtractionAttemptRow(attemptId);
+        if (!successfulAttempt) throw extractionAttemptNotActive(attemptId);
+        const attempt = decodeExtractionAttempt(successfulAttempt);
+        if (
+          operation.state !== 'succeeded' ||
+          operation.resultType !== request.resultType ||
+          attempt.operationId !== operationId ||
+          attempt.runId !== runId ||
+          attempt.state !== 'succeeded'
+        ) {
+          throw new Error(`Invalid committed Memory Extraction Operation ${operationId}`);
+        }
+        if (operation.commitHash !== commitHash || operation.receipt === null) {
+          throw new Error(`Invalid committed Memory Extraction receipt ${operationId}`);
+        }
+        const writeOperation = { ...decodeOperation(existingReceipt), replayed: true };
+        const receipt = operation.receipt;
+        const cursors = receipt.cursors;
+        this.#database.exec('COMMIT');
+        return {
+          operation,
+          attempt,
+          writeOperation,
+          cursors,
+          receipt,
+          resultType: request.resultType,
+          replayed: true,
+        };
+      }
+
+      if (diagnosticRetentionUntil < committedAt) {
+        throw new Error('diagnosticRetentionUntil cannot be earlier than commit time');
+      }
+      this.#requireActiveExtractionAttempt(operationId, attemptId, runId);
+      if (operation.state !== 'running' || operation.activeAttemptId !== attemptId) {
+        throw extractionAttemptNotActive(attemptId);
+      }
+      for (const range of ranges) this.#validateCursorAtFrozenRange(operationId, range);
+
+      const results = this.#applyNormalizedMutations(mutations, committedAt);
+      for (const range of ranges) this.#advanceExtractionCursor(operationId, range, committedAt);
+      this.#options.failpoint?.('after_cursor_write');
+
+      const cursors = ranges.map((range) =>
+        this.#requireExtractionCursor(range.sessionId, range.runId),
+      );
+      const receipt: MemoryExtractionCommitReceipt = {
+        schemaVersion: 1,
+        operationId,
+        attemptId,
+        resultType: request.resultType,
+        selectionSaturated: request.selectionSaturated,
+        evidenceDigest,
+        mutationDigest,
+        writeOperationId: operationId,
+        committedAt,
+        mutationResults: results,
+        cursors,
+      };
+      const resultJson = JSON.stringify(receipt);
+
+      const operationType = mutations.length === 1 ? mutations[0]!.type : 'batch';
+      this.#options.failpoint?.('before_operation_write');
+      this.#database
+        .prepare(
+          `INSERT INTO memory_write_operations(
+             operation_id, operation_type, request_hash, result_json, committed_at
+           ) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(operationId, operationType, commitHash, JSON.stringify(results), committedAt);
+
+      const attemptUpdate = this.#database
+        .prepare(
+          `UPDATE memory_extraction_attempts
+           SET state = 'succeeded', completed_at = ?, failure_code = NULL, failure_stage = NULL
+           WHERE attempt_id = ? AND operation_id = ? AND run_id = ? AND state = 'running'`,
+        )
+        .run(committedAt, attemptId, operationId, runId);
+      if (Number(attemptUpdate.changes) !== 1) throw extractionAttemptNotActive(attemptId);
+      const operationUpdate = this.#database
+        .prepare(
+          `UPDATE memory_extraction_operations
+           SET state = 'succeeded', active_attempt_id = NULL, lease_expires_at = NULL,
+               next_attempt_at = NULL, last_error_code = NULL, last_error_stage = NULL,
+               last_error_at = NULL, last_failed_attempt_id = NULL,
+               updated_at = MAX(updated_at, ?), completed_at = ?, result_type = ?,
+               commit_hash = ?, result_json = ?,
+               diagnostic_retention_until = ?, cleanup_state = 'pending',
+               cleanup_claim_id = NULL, cleanup_lease_expires_at = NULL,
+               cleanup_error_code = NULL, cleaned_at = NULL
+           WHERE operation_id = ? AND state = 'running' AND active_attempt_id = ?`,
+        )
+        .run(
+          committedAt,
+          committedAt,
+          request.resultType,
+          commitHash,
+          resultJson,
+          diagnosticRetentionUntil,
+          operationId,
+          attemptId,
+        );
+      if (Number(operationUpdate.changes) !== 1) throw extractionAttemptNotActive(attemptId);
+      this.#options.failpoint?.('after_extraction_state_write');
+
+      const committedOperation = this.#requireExtractionOperation(operationId);
+      const attempt = this.#requireExtractionAttempt(attemptId);
+      const writeOperation: MemoryWriteOperationResult = {
+        operationId,
+        operationType,
+        replayed: false,
+        committedAt,
+        results,
+      };
+      this.#database.exec('COMMIT');
+      this.#options.failpoint?.('after_commit');
+      return {
+        operation: committedOperation,
+        attempt,
+        writeOperation,
+        cursors,
+        receipt,
+        resultType: request.resultType,
+        replayed: false,
+      };
+    } catch (error) {
+      rollback(this.#database);
+      throw error;
+    }
+  }
+
+  async claimMemoryExtractionCleanup(
+    request: ClaimMemoryExtractionCleanupRequest,
+  ): Promise<MemoryExtractionOperation | undefined> {
+    this.#assertOpen();
+    const now = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const operationId = normalizeIdentifier(request.operationId, 'operationId');
+    const claimId = normalizeIdentifier(request.claimId, 'cleanup claimId');
+    const leaseExpiresAt = normalizeTimestamp(request.leaseExpiresAt, 'cleanup leaseExpiresAt');
+    if (leaseExpiresAt <= now) throw new Error('Cleanup lease must expire in the future');
+
+    this.#database.exec('BEGIN IMMEDIATE');
+    try {
+      this.#requireExtractionOperation(operationId);
+      const update = this.#database
+        .prepare(
+          `UPDATE memory_extraction_operations
+           SET cleanup_state = 'running', cleanup_claim_id = ?, cleanup_lease_expires_at = ?,
+               cleanup_attempt_count = cleanup_attempt_count + 1,
+               cleanup_error_code = NULL, updated_at = MAX(updated_at, ?)
+           WHERE operation_id = ? AND state IN ('succeeded', 'failed')
+             AND active_attempt_id IS NULL AND diagnostic_retention_until <= ?
+             AND (cleanup_state = 'pending'
+               OR (cleanup_state = 'running' AND cleanup_lease_expires_at <= ?))`,
+        )
+        .run(claimId, leaseExpiresAt, now, operationId, now, now);
+      if (Number(update.changes) !== 1) {
+        this.#database.exec('COMMIT');
+        return undefined;
+      }
+      const claimed = this.#requireExtractionOperation(operationId);
+      this.#database.exec('COMMIT');
+      return claimed;
+    } catch (error) {
+      rollback(this.#database);
+      throw error;
+    }
+  }
+
+  async finishMemoryExtractionCleanup(
+    request: FinishMemoryExtractionCleanupRequest,
+  ): Promise<MemoryExtractionOperation> {
+    this.#assertOpen();
+    const now = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    const operationId = normalizeIdentifier(request.operationId, 'operationId');
+    const claimId = normalizeIdentifier(request.claimId, 'cleanup claimId');
+    const errorCode =
+      request.errorCode === undefined
+        ? undefined
+        : normalizeStableErrorCode(request.errorCode, 'cleanup errorCode');
+
+    this.#database.exec('BEGIN IMMEDIATE');
+    try {
+      const update =
+        errorCode === undefined
+          ? this.#database
+              .prepare(
+                `UPDATE memory_extraction_operations
+               SET cleanup_state = 'completed', cleanup_claim_id = NULL,
+                   cleanup_lease_expires_at = NULL, cleanup_error_code = NULL,
+                   cleaned_at = ?, updated_at = MAX(updated_at, ?)
+               WHERE operation_id = ? AND cleanup_state = 'running' AND cleanup_claim_id = ?`,
+              )
+              .run(now, now, operationId, claimId)
+          : this.#database
+              .prepare(
+                `UPDATE memory_extraction_operations
+               SET cleanup_state = 'pending', cleanup_claim_id = NULL,
+                   cleanup_lease_expires_at = NULL, cleanup_error_code = ?,
+                   updated_at = MAX(updated_at, ?)
+               WHERE operation_id = ? AND cleanup_state = 'running' AND cleanup_claim_id = ?`,
+              )
+              .run(errorCode, now, operationId, claimId);
+      if (Number(update.changes) !== 1) {
+        throw new MemoryItemStoreConflictError(
+          'extraction_cleanup_conflict',
+          `Memory Extraction cleanup claim ${claimId} is no longer active`,
+        );
+      }
+      const operation = this.#requireExtractionOperation(operationId);
+      this.#database.exec('COMMIT');
+      return operation;
+    } catch (error) {
+      rollback(this.#database);
+      throw error;
+    }
+  }
+
+  async cancelMemoryExtractionsForSessions(
+    request: CancelMemoryExtractionsForSessionsRequest,
+  ): Promise<readonly string[]> {
+    this.#assertOpen();
+    const now = normalizeTimestamp((this.#options.now ?? Date.now)(), 'current time');
+    if (!Array.isArray(request.sessionIds) || request.sessionIds.length === 0) return [];
+    const sessionIds = [
+      ...new Set(request.sessionIds.map((id) => normalizeIdentifier(id, 'sessionId'))),
+    ];
+    const retention = normalizeTimestamp(
+      request.diagnosticRetentionUntil,
+      'diagnosticRetentionUntil',
+    );
+    if (retention < now)
+      throw new Error('diagnosticRetentionUntil cannot be earlier than cancel time');
+    const placeholders = sessionIds.map(() => '?').join(', ');
+
+    this.#database.exec('BEGIN IMMEDIATE');
+    try {
+      const rows = this.#database
+        .prepare(
+          `SELECT operation_id FROM memory_extraction_operations
+           WHERE session_id IN (${placeholders}) AND state IN ('pending', 'running')
+           ORDER BY operation_id ASC`,
+        )
+        .all(...sessionIds) as Array<{ operation_id?: unknown }>;
+      const operationIds = rows.map((row) =>
+        requiredIdentifierString(row.operation_id, 'operation_id'),
+      );
+      this.#database
+        .prepare(
+          `UPDATE memory_extraction_cursors
+           SET active_sweep_operation_id = NULL, followup_eligible = 0,
+               version = version + 1, updated_at = MAX(updated_at, ?)
+           WHERE session_id IN (${placeholders})
+             AND (active_sweep_operation_id IS NOT NULL OR followup_eligible != 0)`,
+        )
+        .run(now, ...sessionIds);
+      if (operationIds.length === 0) {
+        this.#database.exec('COMMIT');
+        return [];
+      }
+      const operationPlaceholders = operationIds.map(() => '?').join(', ');
+      this.#database
+        .prepare(
+          `UPDATE memory_extraction_attempts
+           SET state = 'abandoned', completed_at = ?, failure_code = 'source_evidence_deleted',
+               failure_stage = 'admission'
+           WHERE operation_id IN (${operationPlaceholders}) AND state = 'running'`,
+        )
+        .run(now, ...operationIds);
+      this.#database
+        .prepare(
+          `UPDATE memory_extraction_operations
+           SET state = 'failed', active_attempt_id = NULL, lease_expires_at = NULL,
+               next_attempt_at = NULL, last_error_code = 'source_evidence_deleted',
+               last_error_stage = 'admission', last_error_at = ?,
+               last_failed_attempt_id = COALESCE(active_attempt_id, last_failed_attempt_id),
+               started_at = COALESCE(started_at, ?), updated_at = MAX(updated_at, ?),
+               completed_at = ?, result_type = NULL, diagnostic_retention_until = ?,
+               cleanup_state = 'pending', cleanup_claim_id = NULL,
+               cleanup_lease_expires_at = NULL, cleanup_error_code = NULL, cleaned_at = NULL
+           WHERE operation_id IN (${operationPlaceholders}) AND state IN ('pending', 'running')`,
+        )
+        .run(now, now, now, now, retention, ...operationIds);
+      this.#database.exec('COMMIT');
+      return operationIds;
+    } catch (error) {
+      rollback(this.#database);
+      throw error;
+    }
+  }
+
   close(): void {
     if (this.#closed) return;
     this.#database.close();
     this.#closed = true;
+  }
+
+  #applyNormalizedMutations(
+    mutations: readonly NormalizedMutation[],
+    committedAt: number,
+  ): readonly MemoryMutationResult[] {
+    const results: MemoryMutationResult[] = [];
+    const transientItemIds = new Set<string>();
+    for (let index = 0; index < mutations.length; index += 1) {
+      const result = this.#applyMutation(mutations[index]!, index, committedAt, transientItemIds);
+      results.push(result);
+      if (result.outcome !== 'noop') transientItemIds.add(result.itemId);
+    }
+    return results;
   }
 
   #applyMutation(
@@ -624,6 +1838,345 @@ export class SqliteMemoryItemStore implements MemoryItemStore {
       .get(operationId) as MemoryOperationRow | undefined;
   }
 
+  #readExtractionOperationRow(operationId: string): MemoryExtractionOperationRow | undefined {
+    return this.#database
+      .prepare('SELECT * FROM memory_extraction_operations WHERE operation_id = ?')
+      .get(operationId) as MemoryExtractionOperationRow | undefined;
+  }
+
+  #readExtractionOperationRowByRequestHash(
+    sessionId: string,
+    requestHash: string,
+  ): MemoryExtractionOperationRow | undefined {
+    return this.#database
+      .prepare(
+        `SELECT * FROM memory_extraction_operations
+         WHERE session_id = ? AND request_hash = ?`,
+      )
+      .get(sessionId, requestHash) as MemoryExtractionOperationRow | undefined;
+  }
+
+  #readExtractionAttemptRow(attemptId: string): MemoryExtractionAttemptRow | undefined {
+    return this.#database
+      .prepare('SELECT * FROM memory_extraction_attempts WHERE attempt_id = ?')
+      .get(attemptId) as MemoryExtractionAttemptRow | undefined;
+  }
+
+  #readExtractionCursorRow(
+    sessionId: string,
+    runId: string,
+  ): MemoryExtractionCursorRow | undefined {
+    return this.#database
+      .prepare(
+        `SELECT * FROM memory_extraction_cursors
+         WHERE session_id = ? AND run_id = ?`,
+      )
+      .get(sessionId, runId) as MemoryExtractionCursorRow | undefined;
+  }
+
+  #readExtractionRanges(operationId: string): readonly MemoryExtractionOperationRange[] {
+    const rows = this.#database
+      .prepare(
+        `SELECT * FROM memory_extraction_operation_ranges
+         WHERE operation_id = ? ORDER BY range_ordinal ASC`,
+      )
+      .all(operationId) as unknown as MemoryExtractionOperationRangeRow[];
+    const ranges = rows.map(decodeExtractionRange);
+    for (let index = 0; index < ranges.length; index += 1) {
+      if (ranges[index]!.rangeOrdinal !== index) {
+        throw new Error(`Memory Extraction Operation ${operationId} has non-contiguous Ranges`);
+      }
+    }
+    return ranges;
+  }
+
+  #decodeExtractionOperation(row: MemoryExtractionOperationRow): MemoryExtractionOperation {
+    const operation = decodeExtractionOperation(
+      row,
+      this.#readExtractionRanges(requiredIdentifierString(row.operation_id, 'operation_id')),
+    );
+    if (operation.mode === 'sweep' && operation.ranges.length === 0) {
+      throw new Error(`Sweep Memory Extraction Operation ${operation.operationId} has no Ranges`);
+    }
+    if (operation.mode === 'targeted' && operation.ranges.length !== 0) {
+      throw new Error(`Targeted Memory Extraction Operation ${operation.operationId} has Ranges`);
+    }
+    return operation;
+  }
+
+  #requireExtractionOperation(operationId: string): MemoryExtractionOperation {
+    const row = this.#readExtractionOperationRow(operationId);
+    if (!row) throw extractionOperationNotFound(operationId);
+    return this.#decodeExtractionOperation(row);
+  }
+
+  #requireExtractionAttempt(attemptId: string): MemoryExtractionAttempt {
+    const row = this.#readExtractionAttemptRow(attemptId);
+    if (!row) throw extractionAttemptNotActive(attemptId);
+    return decodeExtractionAttempt(row);
+  }
+
+  #requireExtractionCursor(sessionId: string, runId: string): MemoryExtractionCursor {
+    const row = this.#readExtractionCursorRow(sessionId, runId);
+    if (!row) throw extractionCursorConflict(sessionId, runId, 'does not exist');
+    return decodeExtractionCursor(row);
+  }
+
+  #requireActiveExtractionAttempt(
+    operationId: string,
+    attemptId: string,
+    runId: string,
+  ): MemoryExtractionAttempt {
+    const operation = this.#requireExtractionOperation(operationId);
+    const attempt = this.#requireExtractionAttempt(attemptId);
+    if (
+      operation.state !== 'running' ||
+      operation.activeAttemptId !== attemptId ||
+      attempt.operationId !== operationId ||
+      attempt.runId !== runId ||
+      attempt.state !== 'running'
+    ) {
+      throw extractionAttemptNotActive(attemptId);
+    }
+    return attempt;
+  }
+
+  #insertExtractionOperation(
+    normalized: NormalizedCreateMemoryExtractionOperation,
+    createdAt: number,
+  ): void {
+    const reusedInternalSession = this.#database
+      .prepare(
+        `SELECT operation_id FROM memory_extraction_operations
+         WHERE internal_session_id = ?`,
+      )
+      .get(normalized.internalSessionId) as { operation_id?: unknown } | undefined;
+    if (reusedInternalSession) {
+      throw new MemoryItemStoreConflictError(
+        'operation_reused',
+        `Internal Session ${normalized.internalSessionId} is already bound to another Memory Extraction Operation`,
+      );
+    }
+
+    this.#database
+      .prepare(
+        `INSERT INTO memory_extraction_operations(
+           operation_id, session_id, mode, trigger_kind, internal_session_id,
+           session_create_fingerprint, request_hash, request_json, trigger_epoch,
+           state, attempt_count, active_attempt_id, lease_expires_at, next_attempt_at,
+           last_error_code, last_error_stage, last_error_at, last_failed_attempt_id,
+           started_at, created_at, updated_at, completed_at, result_type,
+           diagnostic_retention_until, cleanup_state, cleanup_claim_id,
+           cleanup_lease_expires_at, cleanup_attempt_count, cleanup_error_code, cleaned_at
+         ) VALUES (
+           ?, ?, ?, ?, ?, ?, ?, ?, ?,
+           'pending', 0, NULL, NULL, NULL,
+           NULL, NULL, NULL, NULL,
+           NULL, ?, ?, NULL, NULL,
+           NULL, NULL, NULL, NULL, 0, NULL, NULL
+         )`,
+      )
+      .run(
+        normalized.operationId,
+        normalized.sessionId,
+        normalized.mode,
+        normalized.triggerKind,
+        normalized.internalSessionId,
+        normalized.sessionCreateFingerprint,
+        normalized.requestHash,
+        normalized.requestJson,
+        normalized.triggerEpoch,
+        createdAt,
+        createdAt,
+      );
+
+    const insertRange = this.#database.prepare(
+      `INSERT INTO memory_extraction_operation_ranges(
+         operation_id, range_ordinal, session_id, invocation_id, run_id, turn_id,
+         from_event_seq_exclusive, from_event_id, from_prefix_digest,
+         to_event_seq_inclusive, to_event_id, to_prefix_digest
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const range of normalized.ranges) {
+      insertRange.run(
+        normalized.operationId,
+        range.rangeOrdinal,
+        range.sessionId,
+        range.invocationId,
+        range.runId,
+        range.turnId,
+        range.fromEventSeqExclusive,
+        range.fromEventId,
+        range.fromPrefixDigest,
+        range.toEventSeqInclusive,
+        range.toEventId,
+        range.toPrefixDigest,
+      );
+      this.#attachSweepCursor(normalized.operationId, range, createdAt);
+    }
+  }
+
+  #attachSweepCursor(
+    operationId: string,
+    range: MemoryExtractionOperationRangeInput,
+    now: number,
+  ): void {
+    const existingRow = this.#readExtractionCursorRow(range.sessionId, range.runId);
+    if (!existingRow) {
+      if (
+        range.fromEventSeqExclusive !== 0 ||
+        range.fromEventId !== null ||
+        range.fromPrefixDigest !== null
+      ) {
+        throw extractionCursorConflict(
+          range.sessionId,
+          range.runId,
+          'cannot start a non-zero Range without an existing Cursor',
+        );
+      }
+      this.#database
+        .prepare(
+          `INSERT INTO memory_extraction_cursors(
+             session_id, invocation_id, run_id, turn_id,
+             committed_event_seq, committed_event_id, committed_prefix_digest,
+             requested_event_seq, requested_event_id, requested_prefix_digest,
+             active_sweep_operation_id, followup_eligible, version, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, 0, NULL, NULL, ?, ?, ?, ?, 0, 1, ?, ?)`,
+        )
+        .run(
+          range.sessionId,
+          range.invocationId,
+          range.runId,
+          range.turnId,
+          range.toEventSeqInclusive,
+          range.toEventId,
+          range.toPrefixDigest,
+          operationId,
+          now,
+          now,
+        );
+      return;
+    }
+
+    const cursor = decodeExtractionCursor(existingRow);
+    if (cursor.invocationId !== range.invocationId || cursor.turnId !== range.turnId) {
+      throw extractionCursorConflict(range.sessionId, range.runId, 'Run identity changed');
+    }
+    if (!cursorMatchesFrozenStart(cursor, range)) {
+      throw extractionCursorConflict(range.sessionId, range.runId, 'committed boundary changed');
+    }
+    if (cursor.activeSweepOperationId !== null && cursor.activeSweepOperationId !== operationId) {
+      throw extractionCursorConflict(range.sessionId, range.runId, 'already has an active Sweep');
+    }
+
+    let requestedEventSeq = cursor.requestedEventSeq;
+    let requestedEventId = cursor.requestedEventId;
+    let requestedPrefixDigest = cursor.requestedPrefixDigest;
+    if (range.toEventSeqInclusive > cursor.requestedEventSeq) {
+      requestedEventSeq = range.toEventSeqInclusive;
+      requestedEventId = range.toEventId;
+      requestedPrefixDigest = range.toPrefixDigest;
+    } else if (
+      range.toEventSeqInclusive === cursor.requestedEventSeq &&
+      (cursor.requestedEventId !== range.toEventId ||
+        cursor.requestedPrefixDigest !== range.toPrefixDigest)
+    ) {
+      throw extractionCursorConflict(
+        range.sessionId,
+        range.runId,
+        'requested boundary identity changed',
+      );
+    }
+    this.#database
+      .prepare(
+        `UPDATE memory_extraction_cursors
+         SET requested_event_seq = ?, requested_event_id = ?, requested_prefix_digest = ?,
+             active_sweep_operation_id = ?, followup_eligible = 0, version = version + 1,
+             updated_at = MAX(updated_at, ?)
+         WHERE session_id = ? AND run_id = ?
+           AND (active_sweep_operation_id IS NULL OR active_sweep_operation_id = ?)`,
+      )
+      .run(
+        requestedEventSeq,
+        requestedEventId,
+        requestedPrefixDigest,
+        operationId,
+        now,
+        range.sessionId,
+        range.runId,
+        operationId,
+      );
+  }
+
+  #validateCursorAtFrozenRange(operationId: string, range: MemoryExtractionOperationRange): void {
+    const cursor = this.#requireExtractionCursor(range.sessionId, range.runId);
+    if (cursor.activeSweepOperationId !== operationId) {
+      throw extractionCursorConflict(range.sessionId, range.runId, 'active Sweep changed');
+    }
+    if (!cursorMatchesFrozenStart(cursor, range)) {
+      throw extractionCursorConflict(range.sessionId, range.runId, 'committed boundary changed');
+    }
+    if (cursor.requestedEventSeq < range.toEventSeqInclusive) {
+      throw extractionCursorConflict(
+        range.sessionId,
+        range.runId,
+        'requested boundary is behind the frozen Range',
+      );
+    }
+    if (
+      cursor.requestedEventSeq === range.toEventSeqInclusive &&
+      (cursor.requestedEventId !== range.toEventId ||
+        cursor.requestedPrefixDigest !== range.toPrefixDigest)
+    ) {
+      throw extractionCursorConflict(
+        range.sessionId,
+        range.runId,
+        'requested boundary identity changed',
+      );
+    }
+  }
+
+  #advanceExtractionCursor(
+    operationId: string,
+    range: MemoryExtractionOperationRange,
+    committedAt: number,
+  ): void {
+    const result = this.#database
+      .prepare(
+        `UPDATE memory_extraction_cursors
+         SET committed_event_seq = ?, committed_event_id = ?, committed_prefix_digest = ?,
+             active_sweep_operation_id = NULL,
+             followup_eligible = CASE WHEN requested_event_seq > ? THEN 1 ELSE 0 END,
+             version = version + 1,
+             updated_at = MAX(updated_at, ?)
+         WHERE session_id = ? AND run_id = ?
+           AND invocation_id = ? AND turn_id = ?
+           AND committed_event_seq = ?
+           AND committed_event_id IS ? AND committed_prefix_digest IS ?
+           AND requested_event_seq >= ?
+           AND active_sweep_operation_id = ?`,
+      )
+      .run(
+        range.toEventSeqInclusive,
+        range.toEventId,
+        range.toPrefixDigest,
+        range.toEventSeqInclusive,
+        committedAt,
+        range.sessionId,
+        range.runId,
+        range.invocationId,
+        range.turnId,
+        range.fromEventSeqExclusive,
+        range.fromEventId,
+        range.fromPrefixDigest,
+        range.toEventSeqInclusive,
+        operationId,
+      );
+    if (Number(result.changes) !== 1) {
+      throw extractionCursorConflict(range.sessionId, range.runId, 'changed during commit');
+    }
+  }
+
   #assertOpen(): void {
     if (this.#closed) throw new Error('SQLite Memory Item Store is closed');
   }
@@ -701,10 +2254,782 @@ export function buildSqliteMemoryKeySearchQuery(input: {
   };
 }
 
+function normalizeCreateMemoryExtractionOperation(
+  request: CreateMemoryExtractionOperationRequest,
+): NormalizedCreateMemoryExtractionOperation {
+  if (!request || typeof request !== 'object') {
+    throw new Error('Memory Extraction Operation request must be an object');
+  }
+  if (!isMemoryExtractionMode(request.mode)) throw new Error('Invalid Memory Extraction mode');
+  if (!isMemoryExtractionTriggerKind(request.triggerKind)) {
+    throw new Error('Invalid Memory Extraction trigger kind');
+  }
+  const operationId = normalizeIdentifier(request.operationId, 'operationId');
+  const sessionId = normalizeIdentifier(request.sessionId, 'sessionId');
+  const internalSessionId = normalizeIdentifier(request.internalSessionId, 'internalSessionId');
+  const sessionCreateFingerprint = normalizeSha256Digest(
+    request.sessionCreateFingerprint,
+    'sessionCreateFingerprint',
+  );
+  const requestHash = normalizeSha256Digest(request.requestHash, 'requestHash');
+  const requestJson = normalizeJsonObject(
+    request.requestJson,
+    'Memory Extraction requestJson',
+    MAX_EXTRACTION_REQUEST_JSON_CODE_UNITS,
+  );
+  const triggerEpoch =
+    request.triggerEpoch === undefined || request.triggerEpoch === null
+      ? null
+      : normalizeIdentifier(request.triggerEpoch, 'triggerEpoch');
+  const maxUnfinishedTargetedPerSession =
+    request.maxUnfinishedTargetedPerSession === undefined
+      ? null
+      : normalizePositiveInteger(
+          request.maxUnfinishedTargetedPerSession,
+          'maxUnfinishedTargetedPerSession',
+        );
+  if (request.mode === 'sweep' && maxUnfinishedTargetedPerSession !== null) {
+    throw new Error('Sweep Memory Extraction cannot set a Targeted queue ceiling');
+  }
+  const sourceRanges = request.ranges ?? [];
+  if (!Array.isArray(sourceRanges) || sourceRanges.length > MEMORY_EXTRACTION_MAX_RANGES) {
+    throw new Error(`Memory Extraction accepts at most ${MEMORY_EXTRACTION_MAX_RANGES} Ranges`);
+  }
+  if (request.mode === 'sweep' && sourceRanges.length === 0) {
+    throw new Error('Sweep Memory Extraction Operation requires at least one Range');
+  }
+  if (request.mode === 'targeted' && sourceRanges.length !== 0) {
+    throw new Error('Targeted Memory Extraction Operation cannot carry Sweep Ranges');
+  }
+  if (request.mode === 'targeted' && request.triggerKind !== 'user_requested') {
+    throw new Error('Targeted Memory Extraction Operation must be user_requested');
+  }
+  if (request.mode === 'sweep' && request.triggerKind === 'user_requested') {
+    throw new Error('Sweep Memory Extraction Operation cannot be user_requested');
+  }
+
+  const ranges = sourceRanges
+    .map((range) => normalizeExtractionRangeInput(range, sessionId))
+    .sort((left, right) => left.rangeOrdinal - right.rangeOrdinal);
+  for (let index = 0; index < ranges.length; index += 1) {
+    if (ranges[index]!.rangeOrdinal !== index) {
+      throw new Error('Memory Extraction Range ordinals must be contiguous from zero');
+    }
+    if (index > 0 && ranges[index - 1]!.runId === ranges[index]!.runId) {
+      throw new Error(`Memory Extraction Run ${ranges[index]!.runId} appears more than once`);
+    }
+  }
+  if (new Set(ranges.map((range) => range.runId)).size !== ranges.length) {
+    throw new Error('Memory Extraction Operation cannot contain duplicate Run Ranges');
+  }
+  return {
+    operationId,
+    sessionId,
+    mode: request.mode,
+    triggerKind: request.triggerKind,
+    internalSessionId,
+    sessionCreateFingerprint,
+    requestHash,
+    requestJson,
+    triggerEpoch,
+    ranges,
+    maxUnfinishedTargetedPerSession,
+  };
+}
+
+function normalizeRecoverableExtractionLimit(
+  request: ListRecoverableMemoryExtractionsRequest,
+): number {
+  if (!request || typeof request !== 'object' || Array.isArray(request)) {
+    throw new Error('Recoverable Memory Extraction request must be an object');
+  }
+  if (Object.keys(request).some((key) => key !== 'limit')) {
+    throw new Error('Recoverable Memory Extraction request only accepts limit');
+  }
+  const limit = request.limit ?? DEFAULT_RECOVERABLE_EXTRACTION_LIMIT;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_RECOVERABLE_EXTRACTION_LIMIT) {
+    throw new Error(
+      `Recoverable Memory Extraction limit must be between 1 and ${MAX_RECOVERABLE_EXTRACTION_LIMIT}`,
+    );
+  }
+  return limit;
+}
+
+function normalizeSweepDebtLimit(request: ListUnassignedMemoryExtractionSweepDebtsRequest): number {
+  if (!request || typeof request !== 'object' || Array.isArray(request)) {
+    throw new Error('Memory Extraction Sweep debt request must be an object');
+  }
+  if (Object.keys(request).some((key) => key !== 'limit')) {
+    throw new Error('Memory Extraction Sweep debt request only accepts limit');
+  }
+  const limit = request.limit ?? DEFAULT_RECOVERABLE_EXTRACTION_LIMIT;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_RECOVERABLE_EXTRACTION_LIMIT) {
+    throw new Error(
+      `Memory Extraction Sweep debt limit must be between 1 and ${MAX_RECOVERABLE_EXTRACTION_LIMIT}`,
+    );
+  }
+  return limit;
+}
+
+function normalizeExtractionRangeInput(
+  range: MemoryExtractionOperationRangeInput,
+  operationSessionId: string,
+): MemoryExtractionOperationRangeInput {
+  if (!range || typeof range !== 'object') throw new Error('Invalid Memory Extraction Range');
+  const rangeOrdinal = normalizeNonNegativeInteger(range.rangeOrdinal, 'rangeOrdinal');
+  const sessionId = normalizeIdentifier(range.sessionId, 'Range sessionId');
+  if (sessionId !== operationSessionId) {
+    throw new Error('Memory Extraction Range must belong to its Operation Session');
+  }
+  const invocationId = normalizeIdentifier(range.invocationId, 'Range invocationId');
+  const runId = normalizeIdentifier(range.runId, 'Range runId');
+  const turnId = normalizeIdentifier(range.turnId, 'Range turnId');
+  const fromEventSeqExclusive = normalizeNonNegativeInteger(
+    range.fromEventSeqExclusive,
+    'fromEventSeqExclusive',
+  );
+  const fromEventId =
+    range.fromEventId === null ? null : normalizeIdentifier(range.fromEventId, 'fromEventId');
+  const fromPrefixDigest =
+    range.fromPrefixDigest === null
+      ? null
+      : normalizeSha256Digest(range.fromPrefixDigest, 'fromPrefixDigest');
+  if (
+    (fromEventSeqExclusive === 0 && (fromEventId !== null || fromPrefixDigest !== null)) ||
+    (fromEventSeqExclusive > 0 && (fromEventId === null || fromPrefixDigest === null))
+  ) {
+    throw new Error('Memory Extraction Range start boundary is inconsistent');
+  }
+  const toEventSeqInclusive = normalizePositiveInteger(
+    range.toEventSeqInclusive,
+    'toEventSeqInclusive',
+  );
+  if (toEventSeqInclusive <= fromEventSeqExclusive) {
+    throw new Error('Memory Extraction Range end must be after its start');
+  }
+  return {
+    rangeOrdinal,
+    sessionId,
+    invocationId,
+    runId,
+    turnId,
+    fromEventSeqExclusive,
+    fromEventId,
+    fromPrefixDigest,
+    toEventSeqInclusive,
+    toEventId: normalizeIdentifier(range.toEventId, 'toEventId'),
+    toPrefixDigest: normalizeSha256Digest(range.toPrefixDigest, 'toPrefixDigest'),
+  };
+}
+
+function extractionOperationDefinitionMatches(
+  row: MemoryExtractionOperationRow,
+  input: NormalizedCreateMemoryExtractionOperation,
+): boolean {
+  return (
+    row.operation_id === input.operationId &&
+    row.session_id === input.sessionId &&
+    row.mode === input.mode &&
+    row.trigger_kind === input.triggerKind &&
+    row.internal_session_id === input.internalSessionId &&
+    row.session_create_fingerprint === input.sessionCreateFingerprint &&
+    row.request_hash === input.requestHash &&
+    row.request_json === input.requestJson &&
+    row.trigger_epoch === input.triggerEpoch
+  );
+}
+
+function decodeExtractionOperation(
+  row: MemoryExtractionOperationRow,
+  ranges: readonly MemoryExtractionOperationRange[],
+): MemoryExtractionOperation {
+  const operationId = requiredIdentifierString(row.operation_id, 'operation_id');
+  const sessionId = requiredIdentifierString(row.session_id, 'session_id');
+  const mode = requiredString(row.mode, 'mode');
+  const triggerKind = requiredString(row.trigger_kind, 'trigger_kind');
+  const state = requiredString(row.state, 'state');
+  const lastErrorStage = nullableString(row.last_error_stage, 'last_error_stage');
+  const cleanupState = nullableString(row.cleanup_state, 'cleanup_state');
+  const resultType = nullableString(row.result_type, 'result_type');
+  if (!isMemoryExtractionMode(mode)) throw invalidColumn('mode');
+  if (!isMemoryExtractionTriggerKind(triggerKind)) throw invalidColumn('trigger_kind');
+  if (!isMemoryExtractionOperationState(state)) throw invalidColumn('state');
+  if (lastErrorStage !== null && !isMemoryExtractionFailureStage(lastErrorStage)) {
+    throw invalidColumn('last_error_stage');
+  }
+  if (cleanupState !== null && !isMemoryExtractionCleanupState(cleanupState)) {
+    throw invalidColumn('cleanup_state');
+  }
+  if (resultType !== null && !isMemoryExtractionResultType(resultType)) {
+    throw invalidColumn('result_type');
+  }
+  const requestJson = requiredString(row.request_json, 'request_json');
+  normalizeJsonObject(
+    requestJson,
+    'Memory Extraction request_json',
+    MAX_EXTRACTION_REQUEST_JSON_CODE_UNITS,
+  );
+  for (const range of ranges) {
+    if (range.operationId !== operationId || range.sessionId !== sessionId) {
+      throw invalidColumn('memory_extraction_operation_ranges');
+    }
+  }
+  const operation: MemoryExtractionOperation = {
+    operationId,
+    sessionId,
+    mode,
+    triggerKind,
+    internalSessionId: requiredIdentifierString(row.internal_session_id, 'internal_session_id'),
+    sessionCreateFingerprint: requiredSha256Digest(
+      row.session_create_fingerprint,
+      'session_create_fingerprint',
+    ),
+    requestHash: requiredSha256Digest(row.request_hash, 'request_hash'),
+    requestJson,
+    triggerEpoch: nullableIdentifierString(row.trigger_epoch, 'trigger_epoch'),
+    state,
+    attemptCount: requiredNonNegativeInteger(row.attempt_count, 'attempt_count'),
+    activeAttemptId: nullableIdentifierString(row.active_attempt_id, 'active_attempt_id'),
+    leaseExpiresAt: nullableNonNegativeInteger(row.lease_expires_at, 'lease_expires_at'),
+    nextAttemptAt: nullableNonNegativeInteger(row.next_attempt_at, 'next_attempt_at'),
+    lastErrorCode: nullableStableErrorCode(row.last_error_code, 'last_error_code'),
+    lastErrorStage,
+    lastErrorAt: nullableNonNegativeInteger(row.last_error_at, 'last_error_at'),
+    lastFailedAttemptId: nullableIdentifierString(
+      row.last_failed_attempt_id,
+      'last_failed_attempt_id',
+    ),
+    startedAt: nullableNonNegativeInteger(row.started_at, 'started_at'),
+    createdAt: requiredNonNegativeInteger(row.created_at, 'created_at'),
+    updatedAt: requiredNonNegativeInteger(row.updated_at, 'updated_at'),
+    completedAt: nullableNonNegativeInteger(row.completed_at, 'completed_at'),
+    resultType,
+    commitHash: nullableHash(row.commit_hash, 'commit_hash'),
+    receipt: decodeExtractionCommitReceipt(row.result_json),
+    diagnosticRetentionUntil: nullableNonNegativeInteger(
+      row.diagnostic_retention_until,
+      'diagnostic_retention_until',
+    ),
+    cleanupState,
+    cleanupClaimId: nullableIdentifierString(row.cleanup_claim_id, 'cleanup_claim_id'),
+    cleanupLeaseExpiresAt: nullableNonNegativeInteger(
+      row.cleanup_lease_expires_at,
+      'cleanup_lease_expires_at',
+    ),
+    cleanupAttemptCount: requiredNonNegativeInteger(
+      row.cleanup_attempt_count,
+      'cleanup_attempt_count',
+    ),
+    cleanupErrorCode: nullableStableErrorCode(row.cleanup_error_code, 'cleanup_error_code'),
+    cleanedAt: nullableNonNegativeInteger(row.cleaned_at, 'cleaned_at'),
+    ranges,
+  };
+  validateDecodedExtractionOperation(operation);
+  return operation;
+}
+
+function validateDecodedExtractionOperation(operation: MemoryExtractionOperation): void {
+  if (operation.createdAt > operation.updatedAt) throw invalidColumn('updated_at');
+  if (
+    operation.state === 'running' &&
+    (operation.activeAttemptId === null || operation.leaseExpiresAt === null)
+  ) {
+    throw invalidColumn('active_attempt_id');
+  }
+  if (
+    operation.state !== 'running' &&
+    (operation.activeAttemptId !== null || operation.leaseExpiresAt !== null)
+  ) {
+    throw invalidColumn('active_attempt_id');
+  }
+  const terminal = operation.state === 'succeeded' || operation.state === 'failed';
+  if (
+    terminal !==
+    (operation.completedAt !== null &&
+      operation.diagnosticRetentionUntil !== null &&
+      operation.cleanupState !== null)
+  ) {
+    throw invalidColumn('completed_at');
+  }
+  if (
+    (operation.state === 'succeeded' &&
+      (operation.resultType === null ||
+        operation.commitHash === null ||
+        operation.receipt === null)) ||
+    (operation.state !== 'succeeded' &&
+      (operation.resultType !== null ||
+        operation.commitHash !== null ||
+        operation.receipt !== null))
+  ) {
+    throw invalidColumn('result_type');
+  }
+  if (
+    operation.receipt !== null &&
+    (operation.receipt.operationId !== operation.operationId ||
+      operation.receipt.writeOperationId !== operation.operationId ||
+      operation.receipt.resultType !== operation.resultType ||
+      operation.receipt.committedAt !== operation.completedAt)
+  ) {
+    throw invalidColumn('result_json');
+  }
+}
+
+function decodeExtractionRange(
+  row: MemoryExtractionOperationRangeRow,
+): MemoryExtractionOperationRange {
+  const fromEventSeqExclusive = requiredNonNegativeInteger(
+    row.from_event_seq_exclusive,
+    'from_event_seq_exclusive',
+  );
+  const fromEventId = nullableIdentifierString(row.from_event_id, 'from_event_id');
+  const fromPrefixDigest = nullableSha256Digest(row.from_prefix_digest, 'from_prefix_digest');
+  const toEventSeqInclusive = requiredPositiveInteger(
+    row.to_event_seq_inclusive,
+    'to_event_seq_inclusive',
+  );
+  if (
+    toEventSeqInclusive <= fromEventSeqExclusive ||
+    (fromEventSeqExclusive === 0 && (fromEventId !== null || fromPrefixDigest !== null)) ||
+    (fromEventSeqExclusive > 0 && (fromEventId === null || fromPrefixDigest === null))
+  ) {
+    throw invalidColumn('memory_extraction_operation_ranges');
+  }
+  return {
+    operationId: requiredIdentifierString(row.operation_id, 'operation_id'),
+    rangeOrdinal: requiredNonNegativeInteger(row.range_ordinal, 'range_ordinal'),
+    sessionId: requiredIdentifierString(row.session_id, 'session_id'),
+    invocationId: requiredIdentifierString(row.invocation_id, 'invocation_id'),
+    runId: requiredIdentifierString(row.run_id, 'run_id'),
+    turnId: requiredIdentifierString(row.turn_id, 'turn_id'),
+    fromEventSeqExclusive,
+    fromEventId,
+    fromPrefixDigest,
+    toEventSeqInclusive,
+    toEventId: requiredIdentifierString(row.to_event_id, 'to_event_id'),
+    toPrefixDigest: requiredSha256Digest(row.to_prefix_digest, 'to_prefix_digest'),
+  };
+}
+
+function decodeExtractionAttempt(row: MemoryExtractionAttemptRow): MemoryExtractionAttempt {
+  const state = requiredString(row.state, 'state');
+  const snapshotKind = requiredString(row.snapshot_kind, 'snapshot_kind');
+  const failureStage = nullableString(row.failure_stage, 'failure_stage');
+  if (!isMemoryExtractionAttemptState(state)) throw invalidColumn('state');
+  if (!isMemoryExtractionSnapshotKind(snapshotKind)) throw invalidColumn('snapshot_kind');
+  if (failureStage !== null && !isMemoryExtractionFailureStage(failureStage)) {
+    throw invalidColumn('failure_stage');
+  }
+  const metrics = decodeExtractionMetrics(row.metrics_json);
+  const attempt: MemoryExtractionAttempt = {
+    attemptId: requiredIdentifierString(row.attempt_id, 'attempt_id'),
+    operationId: requiredIdentifierString(row.operation_id, 'operation_id'),
+    attemptOrdinal: requiredPositiveInteger(row.attempt_ordinal, 'attempt_ordinal'),
+    state,
+    turnId: requiredIdentifierString(row.turn_id, 'turn_id'),
+    runId: requiredIdentifierString(row.run_id, 'run_id'),
+    snapshotKind,
+    startedAt: requiredNonNegativeInteger(row.started_at, 'started_at'),
+    completedAt: nullableNonNegativeInteger(row.completed_at, 'completed_at'),
+    failureCode: nullableStableErrorCode(row.failure_code, 'failure_code'),
+    failureStage,
+    metrics,
+  };
+  if (
+    (state === 'running' &&
+      (attempt.completedAt !== null ||
+        attempt.failureCode !== null ||
+        attempt.failureStage !== null)) ||
+    (state === 'succeeded' &&
+      (attempt.completedAt === null ||
+        attempt.failureCode !== null ||
+        attempt.failureStage !== null)) ||
+    ((state === 'failed' || state === 'abandoned') &&
+      (attempt.completedAt === null ||
+        attempt.failureCode === null ||
+        attempt.failureStage === null))
+  ) {
+    throw invalidColumn('memory_extraction_attempts');
+  }
+  return attempt;
+}
+
+function decodeExtractionCursor(row: MemoryExtractionCursorRow): MemoryExtractionCursor {
+  const committedEventSeq = requiredNonNegativeInteger(
+    row.committed_event_seq,
+    'committed_event_seq',
+  );
+  const committedEventId = nullableIdentifierString(row.committed_event_id, 'committed_event_id');
+  const committedPrefixDigest = nullableSha256Digest(
+    row.committed_prefix_digest,
+    'committed_prefix_digest',
+  );
+  const requestedEventSeq = requiredNonNegativeInteger(
+    row.requested_event_seq,
+    'requested_event_seq',
+  );
+  const requestedEventId = nullableIdentifierString(row.requested_event_id, 'requested_event_id');
+  const requestedPrefixDigest = nullableSha256Digest(
+    row.requested_prefix_digest,
+    'requested_prefix_digest',
+  );
+  if (
+    committedEventSeq > requestedEventSeq ||
+    (committedEventSeq === 0 && (committedEventId !== null || committedPrefixDigest !== null)) ||
+    (committedEventSeq > 0 && (committedEventId === null || committedPrefixDigest === null)) ||
+    (requestedEventSeq === 0 && (requestedEventId !== null || requestedPrefixDigest !== null)) ||
+    (requestedEventSeq > 0 && (requestedEventId === null || requestedPrefixDigest === null))
+  ) {
+    throw invalidColumn('memory_extraction_cursors');
+  }
+  const createdAt = requiredNonNegativeInteger(row.created_at, 'created_at');
+  const updatedAt = requiredNonNegativeInteger(row.updated_at, 'updated_at');
+  if (createdAt > updatedAt) throw invalidColumn('updated_at');
+  return {
+    sessionId: requiredIdentifierString(row.session_id, 'session_id'),
+    invocationId: requiredIdentifierString(row.invocation_id, 'invocation_id'),
+    runId: requiredIdentifierString(row.run_id, 'run_id'),
+    turnId: requiredIdentifierString(row.turn_id, 'turn_id'),
+    committedEventSeq,
+    committedEventId,
+    committedPrefixDigest,
+    requestedEventSeq,
+    requestedEventId,
+    requestedPrefixDigest,
+    activeSweepOperationId: nullableIdentifierString(
+      row.active_sweep_operation_id,
+      'active_sweep_operation_id',
+    ),
+    version: requiredPositiveInteger(row.version, 'version'),
+    createdAt,
+    updatedAt,
+  };
+}
+
+function cursorMatchesFrozenStart(
+  cursor: MemoryExtractionCursor,
+  range: MemoryExtractionOperationRangeInput | MemoryExtractionOperationRange,
+): boolean {
+  return (
+    cursor.committedEventSeq === range.fromEventSeqExclusive &&
+    cursor.committedEventId === range.fromEventId &&
+    cursor.committedPrefixDigest === range.fromPrefixDigest
+  );
+}
+
+function normalizeExtractionCandidateQuery(
+  request: SearchMemoryExtractionCandidatesRequest,
+): NormalizedExtractionCandidateQuery {
+  if (!request || typeof request !== 'object') {
+    throw new Error('Memory Extraction candidate query must be an object');
+  }
+  const content = normalizeLongTermMemoryContent(request.content);
+  if (!content.ok) throw new Error(content.message);
+  if (!isMemoryItemKind(request.kind)) throw new Error('Invalid Memory Item kind');
+  if (!isMemoryStatementType(request.statementType))
+    throw new Error('Invalid Memory statement type');
+  if (!isMemoryTemporalType(request.temporalType)) throw new Error('Invalid Memory temporal type');
+  if (!isMemoryScopeType(request.scopeType)) throw new Error('Invalid Memory scope type');
+  const scopeKey = normalizeScopeKey(request.scopeType, request.scopeKey);
+  const eventStartedAt = normalizeOptionalTimestamp(request.eventStartedAt, 'eventStartedAt');
+  const eventEndedAt = normalizeOptionalTimestamp(request.eventEndedAt, 'eventEndedAt');
+  validateMemoryTemporalBounds({
+    temporalType: request.temporalType,
+    eventStartedAt,
+    eventEndedAt,
+  });
+  if (!Array.isArray(request.keys) || request.keys.length === 0) {
+    throw new Error('Memory Extraction candidate query requires at least one key');
+  }
+  if (request.keys.length > MAX_EXTRACTION_CANDIDATE_KEYS) {
+    throw new Error(
+      `Memory Extraction candidate query accepts at most ${MAX_EXTRACTION_CANDIDATE_KEYS} keys`,
+    );
+  }
+  const keys = [...new Set(request.keys.map(normalizeSearchTerm))].sort(compareText);
+  const sourceEventIdsInput = request.sourceEventIds ?? [];
+  if (
+    !Array.isArray(sourceEventIdsInput) ||
+    sourceEventIdsInput.length > MAX_EXTRACTION_CANDIDATE_SOURCES
+  ) {
+    throw new Error(
+      `Memory Extraction candidate query accepts at most ${MAX_EXTRACTION_CANDIDATE_SOURCES} sources`,
+    );
+  }
+  const sourceEventIds = [
+    ...new Set(
+      sourceEventIdsInput.map((eventId) => normalizeIdentifier(eventId, 'source eventId')),
+    ),
+  ].sort(compareText);
+  const limit = request.limit ?? MAX_EXTRACTION_CANDIDATES;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_EXTRACTION_CANDIDATES) {
+    throw new Error(
+      `Memory Extraction candidate limit must be between 1 and ${MAX_EXTRACTION_CANDIDATES}`,
+    );
+  }
+  return {
+    contentHash: hashText(content.value),
+    kind: request.kind,
+    statementType: request.statementType,
+    temporalType: request.temporalType,
+    scopeType: request.scopeType,
+    scopeKey,
+    eventStartedAt,
+    eventEndedAt,
+    keys,
+    sourceEventIds,
+    limit,
+  };
+}
+
+function buildExtractionCandidateQuery(input: NormalizedExtractionCandidateQuery): {
+  readonly sql: string;
+  readonly parameters: readonly (string | number | null)[];
+} {
+  const parameters: Array<string | number | null> = [input.contentHash];
+  const sourceOverlap =
+    input.sourceEventIds.length === 0
+      ? '0'
+      : `(SELECT COUNT(*) FROM memory_item_sources s
+         WHERE s.item_id = i.item_id AND s.event_id IN (${placeholders(input.sourceEventIds.length)}))`;
+  parameters.push(...input.sourceEventIds);
+  const keyOverlap = `(SELECT COUNT(*) FROM memory_item_keys k
+    WHERE k.item_id = i.item_id AND k.normalized_key IN (${placeholders(input.keys.length)}))`;
+  parameters.push(...input.keys);
+  parameters.push(
+    input.kind,
+    input.statementType,
+    input.temporalType,
+    input.eventStartedAt,
+    input.eventEndedAt,
+  );
+  const scopeClause =
+    input.scopeType === 'global'
+      ? `i.scope_type = 'global' AND i.scope_key IS NULL`
+      : `i.scope_type = 'workspace' AND i.scope_key = ?`;
+  if (input.scopeType === 'workspace') parameters.push(input.scopeKey);
+  parameters.push(input.limit + 1);
+  return {
+    sql: `
+      WITH ranked AS MATERIALIZED (
+        SELECT
+          i.item_id,
+          CASE WHEN i.content_hash = ? THEN 1 ELSE 0 END AS content_hash_match,
+          ${sourceOverlap} AS source_overlap_count,
+          ${keyOverlap} AS exact_key_match_count,
+          CASE WHEN i.kind = ? THEN 1 ELSE 0 END AS kind_match,
+          CASE WHEN i.statement_type = ? THEN 1 ELSE 0 END AS statement_type_match,
+          CASE WHEN i.temporal_type = ?
+                     AND i.event_started_at IS ?
+                     AND i.event_ended_at IS ? THEN 1 ELSE 0 END AS temporal_match
+        FROM memory_items i
+        WHERE i.lifecycle_state = 'active' AND ${scopeClause}
+      )
+      SELECT * FROM ranked
+      WHERE content_hash_match = 1 OR source_overlap_count > 0 OR exact_key_match_count > 0
+      ORDER BY
+        CASE WHEN content_hash_match = 1 OR source_overlap_count > 0 THEN 1 ELSE 0 END DESC,
+        content_hash_match DESC,
+        source_overlap_count DESC,
+        exact_key_match_count DESC,
+        kind_match DESC,
+        statement_type_match DESC,
+        temporal_match DESC,
+        item_id ASC
+      LIMIT ?`,
+    parameters,
+  };
+}
+
+function validateExtractionCommitShape(
+  operation: MemoryExtractionOperation,
+  resultType: CommitMemoryExtractionRequest['resultType'],
+  mutations: readonly NormalizedMutation[],
+): void {
+  if (operation.mode === 'sweep') {
+    if (resultType !== 'proposed' && resultType !== 'empty') {
+      throw new Error('Sweep Memory Extraction result must be proposed or empty');
+    }
+  } else if (
+    resultType !== 'proposed' &&
+    resultType !== 'unresolved' &&
+    resultType !== 'not_storable'
+  ) {
+    throw new Error('Targeted Memory Extraction result has an invalid type');
+  }
+  if (resultType !== 'proposed' && mutations.length !== 0) {
+    throw new Error(`${resultType} Memory Extraction result cannot carry mutations`);
+  }
+}
+
+function encodeExtractionMetrics(input: MemoryExtractionAttemptMetrics | null): string | null {
+  if (input === null) return null;
+  return JSON.stringify(normalizeExtractionMetrics(input));
+}
+
+function decodeExtractionMetrics(value: unknown): MemoryExtractionAttemptMetrics | null {
+  if (value === null) return null;
+  const json = requiredString(value, 'metrics_json');
+  if (json.length > MAX_EXTRACTION_METRICS_JSON_CODE_UNITS) throw invalidColumn('metrics_json');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw invalidColumn('metrics_json');
+  }
+  return normalizeExtractionMetrics(parsed);
+}
+
+function normalizeExtractionMetrics(input: unknown): MemoryExtractionAttemptMetrics {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Memory Extraction metrics must be an object');
+  }
+  const record = input as Record<string, unknown>;
+  const allowed = new Set([
+    'version',
+    'inputTokens',
+    'outputTokens',
+    'cacheReadTokens',
+    'cacheWriteTokens',
+    'latencyMs',
+    'searchCount',
+    'readCount',
+  ]);
+  if (Object.keys(record).some((key) => !allowed.has(key)) || record.version !== 1) {
+    throw new Error('Invalid Memory Extraction metrics schema');
+  }
+  const optionalMetric = (name: string): number | undefined => {
+    const value = record[name];
+    if (value === undefined) return undefined;
+    return normalizeNonNegativeInteger(value, `metrics.${name}`);
+  };
+  const inputTokens = optionalMetric('inputTokens');
+  const outputTokens = optionalMetric('outputTokens');
+  const cacheReadTokens = optionalMetric('cacheReadTokens');
+  const cacheWriteTokens = optionalMetric('cacheWriteTokens');
+  const latencyMs = optionalMetric('latencyMs');
+  const searchCount = optionalMetric('searchCount');
+  const readCount = optionalMetric('readCount');
+  return {
+    version: 1,
+    ...(inputTokens === undefined ? {} : { inputTokens }),
+    ...(outputTokens === undefined ? {} : { outputTokens }),
+    ...(cacheReadTokens === undefined ? {} : { cacheReadTokens }),
+    ...(cacheWriteTokens === undefined ? {} : { cacheWriteTokens }),
+    ...(latencyMs === undefined ? {} : { latencyMs }),
+    ...(searchCount === undefined ? {} : { searchCount }),
+    ...(readCount === undefined ? {} : { readCount }),
+  };
+}
+
+function decodeExtractionCommitReceipt(value: unknown): MemoryExtractionCommitReceipt | null {
+  if (value === null) return null;
+  const json = requiredString(value, 'result_json');
+  if (json.length > MAX_OPERATION_RESULT_JSON_CODE_UNITS) throw invalidColumn('result_json');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw invalidColumn('result_json');
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw invalidColumn('result_json');
+  }
+  const record = parsed as Record<string, unknown>;
+  const allowed = new Set([
+    'schemaVersion',
+    'operationId',
+    'attemptId',
+    'resultType',
+    'selectionSaturated',
+    'evidenceDigest',
+    'mutationDigest',
+    'writeOperationId',
+    'committedAt',
+    'mutationResults',
+    'cursors',
+  ]);
+  if (Object.keys(record).some((key) => !allowed.has(key)) || record.schemaVersion !== 1) {
+    throw invalidColumn('result_json');
+  }
+  const resultType = requiredString(record.resultType, 'resultType');
+  if (!isMemoryExtractionResultType(resultType)) throw invalidColumn('resultType');
+  if (typeof record.selectionSaturated !== 'boolean') throw invalidColumn('selectionSaturated');
+  if (
+    !Array.isArray(record.mutationResults) ||
+    record.mutationResults.length > MAX_MUTATIONS_PER_OPERATION
+  ) {
+    throw invalidColumn('mutationResults');
+  }
+  if (!Array.isArray(record.cursors) || record.cursors.length > MEMORY_EXTRACTION_MAX_RANGES) {
+    throw invalidColumn('cursors');
+  }
+  const mutationResults = record.mutationResults.map((result, index) => {
+    const decoded = decodeMutationResult(result, index);
+    validateMutationResultOutcome(decoded);
+    return decoded;
+  });
+  const cursors = record.cursors.map(decodeExtractionCursorValue);
+  return {
+    schemaVersion: 1,
+    operationId: requiredIdentifierString(record.operationId, 'operationId'),
+    attemptId: requiredIdentifierString(record.attemptId, 'attemptId'),
+    resultType,
+    selectionSaturated: record.selectionSaturated,
+    evidenceDigest: requiredSha256Digest(record.evidenceDigest, 'evidenceDigest'),
+    mutationDigest: requiredSha256Digest(record.mutationDigest, 'mutationDigest'),
+    writeOperationId: requiredIdentifierString(record.writeOperationId, 'writeOperationId'),
+    committedAt: requiredNonNegativeInteger(record.committedAt, 'committedAt'),
+    mutationResults,
+    cursors,
+  };
+}
+
+function decodeExtractionCursorValue(value: unknown): MemoryExtractionCursor {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw invalidColumn('receipt.cursor');
+  }
+  const record = value as Record<string, unknown>;
+  const allowed = new Set([
+    'sessionId',
+    'invocationId',
+    'runId',
+    'turnId',
+    'committedEventSeq',
+    'committedEventId',
+    'committedPrefixDigest',
+    'requestedEventSeq',
+    'requestedEventId',
+    'requestedPrefixDigest',
+    'activeSweepOperationId',
+    'version',
+    'createdAt',
+    'updatedAt',
+  ]);
+  if (Object.keys(record).some((key) => !allowed.has(key))) throw invalidColumn('receipt.cursor');
+  return decodeExtractionCursor({
+    session_id: record.sessionId,
+    invocation_id: record.invocationId,
+    run_id: record.runId,
+    turn_id: record.turnId,
+    committed_event_seq: record.committedEventSeq,
+    committed_event_id: record.committedEventId,
+    committed_prefix_digest: record.committedPrefixDigest,
+    requested_event_seq: record.requestedEventSeq,
+    requested_event_id: record.requestedEventId,
+    requested_prefix_digest: record.requestedPrefixDigest,
+    active_sweep_operation_id: record.activeSweepOperationId,
+    followup_eligible: 0,
+    version: record.version,
+    created_at: record.createdAt,
+    updated_at: record.updatedAt,
+  });
+}
+
 function normalizeMutations(
   mutations: readonly MemoryItemMutation[],
+  allowEmpty = false,
 ): readonly NormalizedMutation[] {
-  if (!Array.isArray(mutations) || mutations.length === 0) {
+  if (!Array.isArray(mutations) || (!allowEmpty && mutations.length === 0)) {
     throw new Error('Memory operation requires at least one mutation');
   }
   if (mutations.length > MAX_MUTATIONS_PER_OPERATION) {
@@ -909,6 +3234,19 @@ function normalizeVersion(value: unknown): number {
   return value as number;
 }
 
+function normalizeNonNegativeInteger(value: unknown, name: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new Error(`${name} must be a non-negative safe integer`);
+  }
+  return value as number;
+}
+
+function normalizePositiveInteger(value: unknown, name: string): number {
+  const normalized = normalizeNonNegativeInteger(value, name);
+  if (normalized < 1) throw new Error(`${name} must be a positive safe integer`);
+  return normalized;
+}
+
 function normalizeTimestamp(value: unknown, name: string): number {
   if (!Number.isSafeInteger(value) || (value as number) < 0) {
     throw new Error(`${name} must be a non-negative integer UTC millisecond timestamp`);
@@ -919,6 +3257,37 @@ function normalizeTimestamp(value: unknown, name: string): number {
 function normalizeOptionalTimestamp(value: unknown, name: string): number | null {
   if (value === undefined || value === null) return null;
   return normalizeTimestamp(value, name);
+}
+
+function normalizeSha256Digest(value: unknown, name: string): MemorySha256Digest {
+  if (typeof value !== 'string' || !/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw new Error(`${name} must be a lowercase sha256:<64 hex> digest`);
+  }
+  return value as MemorySha256Digest;
+}
+
+function normalizeJsonObject(value: unknown, name: string, maximumCodeUnits: number): string {
+  if (typeof value !== 'string') throw new Error(`${name} must be a JSON string`);
+  if (value.length > maximumCodeUnits) {
+    throw new Error(`${name} must be ${maximumCodeUnits} code units or fewer`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new Error(`${name} must contain valid JSON`, { cause: error });
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${name} must contain a JSON object`);
+  }
+  return value;
+}
+
+function normalizeStableErrorCode(value: unknown, name: string): string {
+  if (typeof value !== 'string' || !/^[a-z][a-z0-9_]{0,127}$/u.test(value)) {
+    throw new Error(`${name} must be a stable lowercase error code`);
+  }
+  return value;
 }
 
 function keyPriority(key: MemoryItemKey): number {
@@ -1083,7 +3452,7 @@ function decodeOperation(row: MemoryOperationRow): MemoryWriteOperationResult {
   }
   const decodedResults = results.map((result, index) => decodeMutationResult(result, index));
   if (
-    (operationType === 'batch' && decodedResults.length < 2) ||
+    (operationType === 'batch' && decodedResults.length === 1) ||
     (operationType !== 'batch' &&
       (decodedResults.length !== 1 || decodedResults[0]?.mutationType !== operationType))
   ) {
@@ -1147,6 +3516,10 @@ function requiredString(value: unknown, column: string): string {
   return value;
 }
 
+function nullableString(value: unknown, column: string): string | null {
+  return value === null ? null : requiredString(value, column);
+}
+
 function requiredNonEmptyString(value: unknown, column: string): string {
   const result = requiredString(value, column);
   if (result.length === 0) throw invalidColumn(column);
@@ -1166,6 +3539,15 @@ function nullableIdentifierString(value: unknown, column: string): string | null
   return value === null ? null : requiredIdentifierString(value, column);
 }
 
+function nullableStableErrorCode(value: unknown, column: string): string | null {
+  if (value === null) return null;
+  try {
+    return normalizeStableErrorCode(value, column);
+  } catch {
+    throw invalidColumn(column);
+  }
+}
+
 function requiredInteger(value: unknown, column: string): number {
   if (typeof value !== 'number' || !Number.isSafeInteger(value)) throw invalidColumn(column);
   return value;
@@ -1175,6 +3557,12 @@ function requiredNonNegativeInteger(value: unknown, column: string): number {
   const result = requiredInteger(value, column);
   if (result < 0) throw invalidColumn(column);
   return result;
+}
+
+function requiredBooleanInteger(value: unknown, column: string): boolean {
+  const result = requiredInteger(value, column);
+  if (result !== 0 && result !== 1) throw invalidColumn(column);
+  return result === 1;
 }
 
 function requiredPositiveInteger(value: unknown, column: string): number {
@@ -1193,8 +3581,47 @@ function requiredHash(value: unknown, column: string): string {
   return result;
 }
 
+function nullableHash(value: unknown, column: string): string | null {
+  return value === null ? null : requiredHash(value, column);
+}
+
+function requiredSha256Digest(value: unknown, column: string): MemorySha256Digest {
+  const result = requiredString(value, column);
+  if (!/^sha256:[0-9a-f]{64}$/u.test(result)) throw invalidColumn(column);
+  return result as MemorySha256Digest;
+}
+
+function nullableSha256Digest(value: unknown, column: string): MemorySha256Digest | null {
+  return value === null ? null : requiredSha256Digest(value, column);
+}
+
 function invalidColumn(column: string): Error {
   return new Error(`Invalid long-term memory SQLite column ${column}`);
+}
+
+function extractionOperationNotFound(operationId: string): MemoryItemStoreConflictError {
+  return new MemoryItemStoreConflictError(
+    'extraction_operation_not_found',
+    `Memory Extraction Operation ${operationId} does not exist`,
+  );
+}
+
+function extractionAttemptNotActive(attemptId: string): MemoryItemStoreConflictError {
+  return new MemoryItemStoreConflictError(
+    'extraction_attempt_not_active',
+    `Memory Extraction Attempt ${attemptId} is not the active running Attempt`,
+  );
+}
+
+function extractionCursorConflict(
+  sessionId: string,
+  runId: string,
+  detail: string,
+): MemoryItemStoreConflictError {
+  return new MemoryItemStoreConflictError(
+    'extraction_cursor_conflict',
+    `Memory Extraction Cursor ${sessionId}/${runId} ${detail}`,
+  );
 }
 
 function assertChanged(changes: number | bigint, itemId: string): void {


### PR DESCRIPTION
## Summary

- Split the durable storage foundation out of #2020 as slice 1 of 4 for incremental long-term-memory extraction.
- Extend the Core memory contract and `memory.sqlite` with extraction Operations, Attempts, immutable Ranges, per-Run Cursors, cleanup state, and frozen commit receipts.
- Commit memory item mutations, sources, keys, Cursor progress, and extraction state in one SQLite transaction with idempotency, lease, retry, recovery, and cancellation safeguards.

## Scope

This PR intentionally contains storage contracts and SQLite authority only. It does not add a Memory Agent, extraction Prompt, Worker, Runtime trigger, recall, feedback, or forgetting behavior.

Refs #1615

Design scope: https://github.com/maka-agent/maka-agent/issues/1615#issuecomment-5139323816

## Verification

- `npm run build --workspace @maka/core`
- `npm run build --workspace @maka/storage`
- SQLite extraction lifecycle suite: 14 passed
- Existing SQLite memory store and Storage Root authority suites: 32 passed
- Biome checks for all 5 changed files

<details>
<summary>中文翻译</summary>

## 摘要

- 将 #2020 中的持久化存储基础拆分为增量长期记忆提取的第 1/4 个 Slice。
- 扩展 Core 记忆契约和 `memory.sqlite`，加入 Extraction Operation、Attempt、不可变 Range、每个 Run 的 Cursor、清理状态和冻结的提交回执。
- 在同一个 SQLite 事务中提交 memory item 修改、来源、关键词、Cursor 进度和提取状态，并处理幂等、lease、重试、恢复和取消。

## 范围

本 PR 仅包含存储契约和 SQLite authority，不包含 Memory Agent、提取 Prompt、Worker、Runtime 触发、召回、反馈或遗忘行为。

关联 #1615

设计范围：https://github.com/maka-agent/maka-agent/issues/1615#issuecomment-5139323816

## 验证

- `npm run build --workspace @maka/core`
- `npm run build --workspace @maka/storage`
- SQLite 提取生命周期测试：14 个通过
- 现有 SQLite memory store 与 Storage Root authority 测试：32 个通过
- 5 个修改文件的 Biome 检查通过

</details>
