### PR TITLE
fix(cu): redact an observation id on the same terms as the fields beside it

### DIFF
--- a/packages/core/src/__tests__/computer-use.test.ts
+++ b/packages/core/src/__tests__/computer-use.test.ts
@@ -187,6 +187,38 @@ describe('Computer Use foundation contract', () => {
     );
   });
 
+  /**
+   * `observation_id` was the one identifier on this projection that skipped
+   * `redactSecrets`, so a secret-shaped value under that key reached the
+   * persisted call, the `tool_start` event and the model's own replayed history
+   * verbatim, while the same string under `app` or `element_id` did not.
+   *
+   * The reason it looked unsafe to redact is that the model quotes this id back
+   * on its next call, so rewriting it could break the observe-then-act loop.
+   * It cannot: the executor mints these with `randomUUID`, and a UUID carries no
+   * run of 40-plus hex characters, so `redactSecrets` leaves it alone. Anything
+   * it does rewrite was never an id this host handed out.
+   */
+  test('a secret-shaped observation id is redacted, and a real one is not', () => {
+    const secret = 'sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIjKlMnOpQrStUvWxYz01';
+    const asObservation = computerUseModelCallArgs({
+      action: 'click_element',
+      observation_id: secret,
+      element_id: 'e12',
+    });
+    const asApp = computerUseModelCallArgs({ action: 'click_element', app: secret });
+    assert.equal(asObservation.observation_id?.includes(secret), false);
+    assert.equal(asObservation.observation_id, asApp.app);
+
+    // The shape the executor actually mints survives, or the model cannot name
+    // the observation it just read and every bound action stops working.
+    const minted = '3f2b1c9e-4a5d-6e7f-8091-a2b3c4d5e6f7';
+    assert.equal(
+      computerUseModelCallArgs({ action: 'click_element', observation_id: minted }).observation_id,
+      minted,
+    );
+  });
+
   test('approval scope separates read, screenshot, and mutation classes', () => {
     const metadata = computerUseApprovalScopeKey({
       action: 'observe',

--- a/packages/core/src/computer-use.ts
+++ b/packages/core/src/computer-use.ts
@@ -546,8 +546,16 @@ export function computerUseModelCallArgs(args: unknown): ComputerUseModelCallArg
       ? { app: boundedDisplay(redactSecrets(app), 256) }
       : {}),
     ...(typeof windowId === 'number' && Number.isInteger(windowId) ? { window_id: windowId } : {}),
+    // Redacted like every field beside it. This one is the model's way back to
+    // an observation it already read, so the temptation is to pass it through
+    // untouched — but the model is what wrote it, and nothing validates the
+    // arguments before this projection runs, so a secret-shaped value under
+    // this key reached the transcript verbatim while the same string under
+    // `app` or `element_id` was redacted. An id the executor actually minted is
+    // a UUID, which `redactSecrets` leaves alone, so the observe-then-act loop
+    // is unaffected: what gets rewritten here was never one of ours.
     ...(typeof observationId === 'string' && stableIdentifier(observationId)
-      ? { observation_id: stableIdentifier(observationId) }
+      ? { observation_id: boundedDisplay(redactSecrets(stableIdentifier(observationId)!), 256) }
       : {}),
     ...(typeof elementId === 'string' && elementId.length > 0
       ? { element_id: boundedDisplay(redactSecrets(elementId), 256) }


### PR DESCRIPTION
`computerUseModelCallArgs` put `observation_id` through `stableIdentifier` and
stopped there. Every identifier beside it goes on through `redactSecrets`, and
so does `observation_id` in the sibling projection `computerUseApprovalSummary`
— the two disagreed, and the model-facing one was the permissive side.

The consequence, measured through the real `ToolRuntime` seam before the fix:

| argument | value sent | persisted |
|---|---|---|
| `element_id` | `sk-ant-api03-…` | `[redacted]` |
| `app` | `sk-ant-api03-…` | `[redacted]` |
| `observation_id` | `sk-ant-api03-…` | `sk-ant-api03-AbCdEfGh…` |

That value lands in the persisted `tool_call`, on the `tool_start` event, and in
the model's own replayed history. Arguments are not validated before this
projection runs, so a model can put anything under that key.

Why this was left alone when it was found: the model quotes the observation id
back on its next call, so rewriting it could break the observe-then-act loop,
and `redactSecrets` matches runs of 40-plus hex among other shapes. That turns
out not to apply. The executor mints these with `randomUUID`, and a UUID has no
such run, so it passes through untouched:

```
原样  3f2b1c9e-4a5d-6e7f-8091-a2b3c4d5e6f7
脱敏  sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456
脱敏  ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
```

Anything this rewrites was never an id the host handed out, so nothing the model
needs is lost.

The test pins both directions, and I checked it can fail: reverting the one-line
change reddens it alone.

```
✖ a secret-shaped observation id is redacted, and a real one is not
```

Restored: `@maka/core` 754 pass / 0 fail.

Closes #2042.
