### PR TITLE
fix(headless): put every benchmark arm under the same tool surface and model budget

### DIFF
--- a/packages/headless/harbor/claude_code_agent.py
+++ b/packages/headless/harbor/claude_code_agent.py
@@ -77,13 +77,11 @@ class MakaClaudeCodeAgent(ClaudeCode):
         await self._write_managed_settings(environment)
 
     async def _write_managed_settings(self, environment: BaseEnvironment) -> None:
-        # Claude Code enables WebSearch and WebFetch by default. Terminal-Bench task
-        # instructions, tests, and reference solutions are public, so a search tool
-        # turns benchmark scoring into retrieval of the answer, and WebSearch runs
-        # server-side behind the provider proxy where the task container's network
-        # allowlist cannot stop it. Managed settings are the only scope the agent
-        # session cannot override (settings precedence: managed > CLI args > local
-        # > project > user).
+        # Claude Code enables WebSearch and WebFetch by default, and WebSearch runs
+        # server-side behind the provider proxy, where the task container's network
+        # policy cannot stop it. Managed settings bind nested `claude` invocations
+        # too; --disallowedTools would only bind the one process the harness starts.
+        # bypassPermissions still honors explicit deny rules.
         settings = json.dumps(_MANAGED_SETTINGS, sort_keys=True)
         await self.exec_as_root(
             environment,

--- a/packages/headless/harbor/claude_code_agent.py
+++ b/packages/headless/harbor/claude_code_agent.py
@@ -31,6 +31,8 @@ _TOOLCHAIN_CHECKSUMS = _TOOLCHAIN_ROOT / "checksums.sha256"
 _OUTPUT_FILENAME = "claude-code.txt"
 _REMOTE_OUTPUT_PATH = Path("/logs/agent") / _OUTPUT_FILENAME
 _REMOTE_SESSIONS_DIR = Path("/logs/agent/sessions")
+_MANAGED_SETTINGS_PATH = Path("/etc/claude-code/managed-settings.json")
+_MANAGED_SETTINGS = {"permissions": {"deny": ["WebSearch", "WebFetch"]}}
 
 
 class MakaClaudeCodeAgent(ClaudeCode):
@@ -71,6 +73,25 @@ class MakaClaudeCodeAgent(ClaudeCode):
         await self.exec_as_root(
             environment,
             command=f"ln -sf -- {shlex.quote(str(_TOOLCHAIN_CLAUDE))} /usr/local/bin/claude",
+        )
+        await self._write_managed_settings(environment)
+
+    async def _write_managed_settings(self, environment: BaseEnvironment) -> None:
+        # Claude Code enables WebSearch and WebFetch by default. Terminal-Bench task
+        # instructions, tests, and reference solutions are public, so a search tool
+        # turns benchmark scoring into retrieval of the answer, and WebSearch runs
+        # server-side behind the provider proxy where the task container's network
+        # allowlist cannot stop it. Managed settings are the only scope the agent
+        # session cannot override (settings precedence: managed > CLI args > local
+        # > project > user).
+        settings = json.dumps(_MANAGED_SETTINGS, sort_keys=True)
+        await self.exec_as_root(
+            environment,
+            command=(
+                f"mkdir -p {shlex.quote(str(_MANAGED_SETTINGS_PATH.parent))}; "
+                f"printf '%s\\n' {shlex.quote(settings)} > "
+                f"{shlex.quote(str(_MANAGED_SETTINGS_PATH))}"
+            ),
         )
 
     def _get_env(self, key: str) -> str | None:

--- a/packages/headless/harbor/claude_code_agent.py
+++ b/packages/headless/harbor/claude_code_agent.py
@@ -82,6 +82,12 @@ class MakaClaudeCodeAgent(ClaudeCode):
         # policy cannot stop it. Managed settings bind nested `claude` invocations
         # too; --disallowedTools would only bind the one process the harness starts.
         # bypassPermissions still honors explicit deny rules.
+        #
+        # This removes the tools from what the model is offered; it is not an
+        # adversarial control. CLAUDE_CODE_MANAGED_SETTINGS_PATH redirects this
+        # file, and many task images run the agent as root, so a model that set
+        # out to defeat it could. The benchmark claim is that no arm reaches the
+        # web by accident, not that the sandbox is escape-proof.
         settings = json.dumps(_MANAGED_SETTINGS, sort_keys=True)
         await self.exec_as_root(
             environment,

--- a/packages/headless/harbor/codex_agent.py
+++ b/packages/headless/harbor/codex_agent.py
@@ -35,6 +35,8 @@ _TOOLCHAIN_NODE = _TOOLCHAIN_BIN / "node"
 _TOOLCHAIN_MANIFEST = _TOOLCHAIN_ROOT / "manifest.json"
 _TOOLCHAIN_CHECKSUMS = _TOOLCHAIN_ROOT / "checksums.sha256"
 _DEFAULT_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+_REQUIREMENTS_PATH = Path("/etc/codex/requirements.toml")
+_WEB_SEARCH_REQUIREMENTS = 'allowed_web_search_modes = ["disabled"]'
 _OUTPUT_FILENAME = "codex.txt"
 _REMOTE_OUTPUT_PATH = Path("/logs/agent") / _OUTPUT_FILENAME
 _REMOTE_SESSIONS_DIR = Path("/logs/agent/sessions")
@@ -108,6 +110,22 @@ class MakaCodexAgent(Codex):
         await self.exec_as_root(
             environment,
             command=f"ln -sf -- {shlex.quote(str(_TOOLCHAIN_CODEX))} /usr/local/bin/codex",
+        )
+        await self._write_web_search_requirements(environment)
+
+    async def _write_web_search_requirements(self, environment: BaseEnvironment) -> None:
+        # config.toml only pins the user layer, which a task-directory config, a
+        # profile, or a `-c web_search=live` override still outranks (config/src/
+        # loader/mod.rs layer order). The system requirements layer constrains which
+        # modes are settable at all, so every higher layer resolves back to disabled
+        # (config/src/config_requirements.rs allowed_web_search_modes).
+        await self.exec_as_root(
+            environment,
+            command=(
+                f"mkdir -p {shlex.quote(str(_REQUIREMENTS_PATH.parent))}; "
+                f"printf '%s\\n' {shlex.quote(_WEB_SEARCH_REQUIREMENTS)} > "
+                f"{shlex.quote(str(_REQUIREMENTS_PATH))}"
+            ),
         )
 
     def _get_env(self, key: str) -> str | None:
@@ -204,14 +222,15 @@ class MakaCodexAgent(Codex):
         config = "\n".join(
             (
                 'model_provider = "maka-http"',
-                # Codex 0.144's WebSearchMode defaults to "cached", so the hosted
-                # web_search tool ships unless the mode is pinned off. Terminal-Bench
-                # task instructions, tests, and reference solutions are public, so a
-                # search tool turns benchmark scoring into retrieval of the answer.
-                # The top-level key wins over the deprecated [tools].web_search
-                # toggle and over feature flags (core/src/config/mod.rs
-                # resolve_web_search_mode), and "disabled" drops the tool from the
-                # spec entirely (core/src/tools/hosted_spec.rs).
+                # Terminal-Bench instructions, tests, and reference solutions are
+                # public, so a search tool turns scoring into retrieval of the answer.
+                # Codex 0.144's WebSearchMode defaults to "cached", and a full-access
+                # sandbox upgrades that to "live" (core/src/config/mod.rs
+                # resolve_web_search_mode_for_turn), so the mode has to be pinned off.
+                # The top-level key wins over the deprecated [tools].web_search toggle
+                # and over feature flags (resolve_web_search_mode), and "disabled"
+                # drops the tool from the spec (core/src/tools/hosted_spec.rs). Keep
+                # this key above the first table header or TOML nests it in that table.
                 'web_search = "disabled"',
                 *(
                     (f'model_catalog_json = "{_DEEPSEEK_MODELS_PATH.as_posix()}"',)

--- a/packages/headless/harbor/codex_agent.py
+++ b/packages/headless/harbor/codex_agent.py
@@ -204,6 +204,15 @@ class MakaCodexAgent(Codex):
         config = "\n".join(
             (
                 'model_provider = "maka-http"',
+                # Codex 0.144's WebSearchMode defaults to "cached", so the hosted
+                # web_search tool ships unless the mode is pinned off. Terminal-Bench
+                # task instructions, tests, and reference solutions are public, so a
+                # search tool turns benchmark scoring into retrieval of the answer.
+                # The top-level key wins over the deprecated [tools].web_search
+                # toggle and over feature flags (core/src/config/mod.rs
+                # resolve_web_search_mode), and "disabled" drops the tool from the
+                # spec entirely (core/src/tools/hosted_spec.rs).
+                'web_search = "disabled"',
                 *(
                     (f'model_catalog_json = "{_DEEPSEEK_MODELS_PATH.as_posix()}"',)
                     if deepseek_catalog

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -485,13 +485,10 @@ class MakaAgent(BaseInstalledAgent):
             if env is not None
             else self._get_env("MAKA_CELL_SETTLEMENT_GRACE_SEC")
         )
-        if not raw:
-            return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
-        try:
-            value = int(raw)
-        except (TypeError, ValueError):
-            return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
-        return value if value > 0 else self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
+        # Same accepted syntax as MAKA_CELL_TIMEOUT_SEC so both sides of the
+        # boundary reject exactly the same strings; bare int() would take
+        # "+60"/"060"/" 60 ", which the TypeScript producer never emits.
+        return _positive_int_literal(raw) or self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
 
     def _model_budget_ms(self, env: dict[str, str] | None = None) -> int:
         """Wall-clock the cell may spend calling the model, in milliseconds.
@@ -504,7 +501,7 @@ class MakaAgent(BaseInstalledAgent):
         budget_ms = self._cell_timeout_sec(env) * 1000
         if budget_ms > _MAX_NODE_TIMER_MS:
             raise RuntimeError(
-                "MAKA_CELL_SOFT_TIMEOUT_MS exceeds the Node timer limit "
+                "MAKA_CELL_TIMEOUT_SEC exceeds the Node timer limit "
                 f"of {_MAX_NODE_TIMER_MS}ms"
             )
         return budget_ms
@@ -1885,6 +1882,8 @@ def _runner_env_summary(env: dict[str, str]) -> dict[str, str]:
         "MAKA_CELL_TIMEOUT_SEC",
         "MAKA_CELL_SOFT_TIMEOUT_MS",
         "MAKA_CELL_SETTLEMENT_GRACE_SEC",
+        "MAKA_AGENT_PHASE_TIMEOUT_SEC",
+        "MAKA_CELL_DEADLINE_AT_MS",
     ]
     return {key: env[key] for key in allowed_keys if key in env}
 

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -430,6 +430,9 @@ class MakaAgent(BaseInstalledAgent):
                 f"2>&1 | tee {shlex.quote(run_log_path.as_posix())}"
             )
             command = f"bash -lc {shlex.quote(shell_script)}"
+            # _cell_env sets no MAKA_CELL_SOFT_TIMEOUT_MS, so this cell never
+            # stops early to settle: it calls the model until it is killed. The
+            # model budget is therefore the whole deadline, with no window to add.
             await self.exec_as_agent(environment, command=command, env=env, timeout_sec=self._cell_timeout_sec())
             await self._download_cell_output(environment)
         output = self._read_cell_output(required=True)
@@ -490,20 +493,28 @@ class MakaAgent(BaseInstalledAgent):
             return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
         return value if value > 0 else self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
 
-    def _cell_soft_timeout_ms(self, env: dict[str, str] | None = None) -> int:
-        timeout_sec = self._cell_timeout_sec(env)
-        grace_sec = self._cell_settlement_grace_sec(env)
-        if grace_sec >= timeout_sec:
-            raise RuntimeError(
-                "MAKA_CELL_SETTLEMENT_GRACE_SEC must be smaller than MAKA_CELL_TIMEOUT_SEC"
-            )
-        soft_timeout_ms = (timeout_sec - grace_sec) * 1000
-        if soft_timeout_ms > _MAX_NODE_TIMER_MS:
+    def _model_budget_ms(self, env: dict[str, str] | None = None) -> int:
+        """Wall-clock the cell may spend calling the model, in milliseconds.
+
+        This is MAKA_CELL_TIMEOUT_SEC verbatim: the budget is the model budget on
+        every path, and the settlement window is added around it rather than
+        carved out of it. Benchmark arms are only comparable when this number is
+        the task-native budget for every harness.
+        """
+        budget_ms = self._cell_timeout_sec(env) * 1000
+        if budget_ms > _MAX_NODE_TIMER_MS:
             raise RuntimeError(
                 "MAKA_CELL_SOFT_TIMEOUT_MS exceeds the Node timer limit "
                 f"of {_MAX_NODE_TIMER_MS}ms"
             )
-        return soft_timeout_ms
+        return budget_ms
+
+    def _agent_phase_timeout_sec(self, env: dict[str, str] | None = None) -> int:
+        """Wall-clock the whole agent phase may take: the model budget plus the
+        window the cell needs to settle its artifacts after it stops calling the
+        model. Every hard process deadline uses this, never the model budget, or
+        the cell would be killed exactly when it starts writing."""
+        return self._cell_timeout_sec(env) + self._cell_settlement_grace_sec(env)
 
     def _host_side_llm_enabled(self) -> bool:
         return bool(
@@ -532,14 +543,14 @@ class MakaAgent(BaseInstalledAgent):
                 stderr=asyncio.subprocess.PIPE,
             )
             try:
-                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self._cell_timeout_sec())
+                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self._agent_phase_timeout_sec())
             except BaseException as error:
                 if process.returncode is None:
                     process.kill()
                 stdout, stderr = await process.communicate()
                 run_log_path.write_bytes(stdout + stderr)
                 if isinstance(error, asyncio.TimeoutError):
-                    raise RuntimeError(f"Maka host cell exceeded {self._cell_timeout_sec()}s") from error
+                    raise RuntimeError(f"Maka host cell exceeded {self._agent_phase_timeout_sec()}s") from error
                 raise
             run_log_path.write_bytes(stdout + stderr)
             if process.returncode == 124:
@@ -566,7 +577,7 @@ class MakaAgent(BaseInstalledAgent):
         env["MAKA_WORKDIR"] = container_cwd
         env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] = executor.url
         env["MAKA_HARBOR_TOOL_EXECUTOR_TOKEN"] = executor.token
-        env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms())
+        env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._model_budget_ms())
         for key in _HOST_PROVIDER_AUTHORITY_ENV_KEYS:
             value = self._get_env(key)
             if value:
@@ -917,7 +928,7 @@ class MakaAgent(BaseInstalledAgent):
         env["MAKA_STORAGE_ROOT"] = str(out_dir / "runs")
         env["MAKA_CELL_ARTIFACT_DIR"] = EnvironmentPaths.agent_dir.as_posix()
         if model_deadline_at_ms is None:
-            env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms(env))
+            env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._model_budget_ms(env))
         else:
             env.pop("MAKA_CELL_SOFT_TIMEOUT_MS", None)
             env["MAKA_CELL_DEADLINE_AT_MS"] = str(model_deadline_at_ms)
@@ -941,7 +952,7 @@ class MakaAgent(BaseInstalledAgent):
     ) -> float:
         phase_timeout_sec = _positive_int_literal(env.get("MAKA_AGENT_PHASE_TIMEOUT_SEC"))
         if phase_timeout_sec is None:
-            return float(self._cell_timeout_sec(env))
+            return float(self._agent_phase_timeout_sec(env))
         remaining = phase_timeout_sec - max(0.0, time.monotonic() - phase_started_monotonic)
         if remaining <= 0:
             raise asyncio.TimeoutError("Maka agent phase exhausted before task-run start")
@@ -1013,7 +1024,7 @@ class MakaAgent(BaseInstalledAgent):
         env["MAKA_OUTPUT_DIR"] = str(output_dir)
         env["MAKA_STORAGE_ROOT"] = str(storage_root)
         self._trajectory_storage_root = output_dir / "trajectory-state"
-        env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms(env))
+        env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._model_budget_ms(env))
 
         task_workdir, workdir_probe = await self._resolve_task_workdir(environment)
 
@@ -1040,7 +1051,7 @@ class MakaAgent(BaseInstalledAgent):
             },
         )
 
-        timeout_sec = self._cell_timeout_sec(env)
+        timeout_sec = self._agent_phase_timeout_sec(env)
         proc: asyncio.subprocess.Process | None = None
         async with _ToolExecutorServer(self, environment) as executor:
             env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] = executor.url

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -14,12 +14,8 @@ import {
   resolveFixedPromptRunRoot,
   selectTasksByIds,
 } from '#fixed-prompt-task-source';
-import { createHarborTaskRunner } from '#harbor-task-runner';
-import {
-  createPierProviderProxyHub,
-  createPierTaskRunner,
-  PIER_MAKA_SETTLEMENT_GRACE_SEC,
-} from '#pier-task-runner';
+import { createHarborTaskRunner, MAKA_SETTLEMENT_GRACE_SEC } from '#harbor-task-runner';
+import { createPierProviderProxyHub, createPierTaskRunner } from '#pier-task-runner';
 import {
   buildHarnessOracleExecutionPolicyFingerprint,
   HARBOR_ORACLE_DOCKER_PLATFORM,
@@ -800,9 +796,9 @@ export function buildHarnessAbManifest({
       ...(pierVersion === null ? {} : { executor: { id: 'pier', version: pierVersion } }),
       timeoutPolicy: 'task-native',
       timeoutMultiplier: 1,
-      ...(benchmarkProfile.executor === 'pier'
-        ? { agentSettlementGraceSec: PIER_MAKA_SETTLEMENT_GRACE_SEC }
-        : {}),
+      // Both executors give the Maka arm this settlement window on top of the
+      // task-native model budget, so every arm gets the same model time.
+      agentSettlementGraceSec: MAKA_SETTLEMENT_GRACE_SEC,
       outerTimeoutGraceSec: HARBOR_SETUP_TEARDOWN_GRACE_SEC,
     },
     taskIds: resolvedTaskIds,
@@ -824,7 +820,10 @@ export function buildHarnessAbManifest({
           ...(competitorProfiles.length > 1
             ? { transport: harnessMeasuredTransport('maka', execution.provider) }
             : {}),
-          externalSystemPrompt: 'empty',
+          // The runner hands every arm MAKA_SYSTEM_PROMPT, but only the Maka
+          // cell applies it; the native CLIs hash it into their execution
+          // identity and drop it. Record what each arm actually runs with.
+          externalSystemPrompt: 'default-headless',
           reasoningEffort: execution.reasoningEffort,
           continuation: false,
           attemptPolicy: 'single',
@@ -855,7 +854,7 @@ export function buildHarnessAbManifest({
             : {}),
           ...(profile.id === 'opencode' ? { variant: runtimeProfile.reasoningEffort } : {}),
           billingMode: runtimeProfile.billingMode,
-          externalSystemPrompt: 'empty',
+          externalSystemPrompt: 'none',
           profile: profile.id,
           ...(benchmarkProfile.executor === 'pier'
             ? { execution: { placement: 'task-container' } }

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -3767,6 +3767,7 @@ function pythonClaudeCodeAdapterSmokeScript(root: string): string {
 import asyncio
 import json
 import os
+import shlex
 import sys
 import tempfile
 import types
@@ -3778,6 +3779,25 @@ def module(name):
     mod = types.ModuleType(name)
     sys.modules[name] = mod
     return mod
+
+def written_payload(command, marker):
+    """Return the file payload a write command sends, keyed by content.
+
+    A process-scope wrapper re-quotes the whole script for bash -lc, so
+    unquote layer by layer until nothing but the written payload is left.
+    """
+    payload = command
+    while "printf" in payload:
+        payload = min((token for token in shlex.split(payload) if marker in token), key=len)
+    return payload
+
+class RecordingEnvironment:
+    def __init__(self):
+        self.calls = []
+
+    async def exec(self, command, env=None, as_root=False, **kwargs):
+        self.calls.append((command, env or {}, as_root))
+        return types.SimpleNamespace(return_code=0, stdout="", stderr="")
 
 module("harbor")
 module("harbor.agents")
@@ -3934,23 +3954,21 @@ with tempfile.TemporaryDirectory() as tmp:
     assert pipeline_cell["status"] == "failed", pipeline_cell
     assert pipeline_cell["errorClass"] == "infra_failed", pipeline_cell
 
-    class RecordingEnvironment:
-        def __init__(self):
-            self.root_commands = []
-            self.agent_commands = []
-
-        async def exec(self, command, env=None, as_root=False, **kwargs):
-            (self.root_commands if as_root else self.agent_commands).append(command)
-            return types.SimpleNamespace(return_code=0, stdout="", stderr="")
-
     install_environment = RecordingEnvironment()
     install_agent = agent(logs)
     install_agent._extra_env["MAKA_CLAUDE_CODE_TOOLCHAIN_FINGERPRINT"] = "fingerprint"
     asyncio.run(install_agent.install(install_environment))
-    managed_command = install_environment.root_commands[-1]
-    assert "/etc/claude-code/managed-settings.json" in managed_command, managed_command
-    assert '"WebSearch"' in managed_command, managed_command
-    assert '"WebFetch"' in managed_command, managed_command
+    managed_calls = [
+        call for call in install_environment.calls if "/etc/claude-code/managed-settings.json" in call[0]
+    ]
+    # Exactly one writer: a second command could append settings that re-enable the tools.
+    assert len(managed_calls) == 1, install_environment.calls
+    managed_command, _, managed_as_root = managed_calls[0]
+    # Only the root-owned managed scope binds a session that cannot be overridden.
+    assert managed_as_root is True, managed_calls
+    assert json.loads(written_payload(managed_command, "permissions")) == {
+        "permissions": {"deny": ["WebSearch", "WebFetch"]}
+    }, managed_command
 
 print("claude-code adapter ok")
 `;
@@ -3961,10 +3979,12 @@ function pythonCodexAdapterSmokeScript(root: string): string {
 import asyncio
 import json
 import os
+import shlex
 import signal
 import sys
 import tempfile
 import time
+import tomllib
 import types
 from pathlib import Path
 
@@ -3974,6 +3994,17 @@ def module(name):
     mod = types.ModuleType(name)
     sys.modules[name] = mod
     return mod
+
+def written_payload(command, marker):
+    """Return the file payload a write command sends, keyed by content.
+
+    A process-scope wrapper re-quotes the whole script for bash -lc, so
+    unquote layer by layer until nothing but the written payload is left.
+    """
+    payload = command
+    while "printf" in payload:
+        payload = min((token for token in shlex.split(payload) if marker in token), key=len)
+    return payload
 
 module("harbor")
 module("harbor.agents")
@@ -4177,8 +4208,19 @@ with tempfile.TemporaryDirectory() as tmp:
     assert 'model_provider = "maka-http"' in http_provider_command, http_provider_command
     assert 'base_url = "http://host.docker.internal:43210"' in http_provider_command, http_provider_command
     assert 'wire_api = "responses"' in http_provider_command, http_provider_command
-    assert 'web_search = "disabled"' in http_provider_command, http_provider_command
     assert "ephemeral-token" not in http_provider_command, http_provider_command
+    # Parse rather than substring-match: the same line under a table header would
+    # become model_providers.maka-http.web_search, which Codex never reads.
+    written_config = tomllib.loads(written_payload(http_provider_command, "model_provider"))
+    assert written_config["web_search"] == "disabled", written_config
+    assert "web_search" not in written_config["model_providers"]["maka-http"], written_config
+    requirements_commands = [
+        command for command, _env in commands if "/etc/codex/requirements.toml" in command
+    ]
+    assert len(requirements_commands) == 1, commands
+    assert tomllib.loads(written_payload(requirements_commands[0], "allowed_web_search_modes")) == {
+        "allowed_web_search_modes": ["disabled"]
+    }, requirements_commands
     deepseek_agent = MakaCodexAgent(
         logs,
         version="0.144.6",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -9,7 +9,8 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { decodeRuntimeEvent } from '@maka/core';
 import { HARBOR_CELL_CONTEXT_ENV_KEYS } from '../harbor-cell.js';
-import { isBudgetExhaustedTrialException } from '../harbor-task-runner.js';
+import { buildHarborJobConfig, isBudgetExhaustedTrialException } from '../harbor-task-runner.js';
+import { agentPhaseTimeoutSec, MAKA_SETTLEMENT_GRACE_SEC } from '../maka-settlement.js';
 import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '../system-prompts.js';
 
 const repoRoot = resolve(fileURLToPath(new URL('../../../..', import.meta.url)));
@@ -433,6 +434,69 @@ describe('Harbor adapter contract', () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  test('the runners and the Python adapter agree on one model budget', (t: TestContext) => {
+    // The bug this pins: MAKA_CELL_TIMEOUT_SEC used to mean the model budget on
+    // one path and budget-plus-window on another, so TypeScript had to predict
+    // which Python branch would run. Nothing caught a wrong prediction because
+    // each side only ever asserted its own arithmetic. Feed what the runners
+    // actually emit into the adapter that actually consumes it.
+    const budgetSec = 1800;
+    const harborConfig = buildHarborJobConfig(
+      {
+        runId: 'run-1',
+        roundId: 'round-1',
+        task: { id: 'task-1', path: '/tasks/task-1', metadata: { agentTimeoutSec: budgetSec } },
+        config: {
+          id: 'cfg',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'deepseek',
+          model: 'deepseek-v4-flash',
+        },
+        systemPrompt: 'PROMPT\n',
+      },
+      {
+        makaRepoPath: '/repo',
+        jobsDir: '/jobs/x',
+        jobName: 'trial',
+        model: 'deepseek/deepseek-v4-flash',
+      },
+    );
+    const harborAgent = (
+      harborConfig.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
+    )[0]!;
+    assert.equal(harborAgent.env.MAKA_CELL_TIMEOUT_SEC, String(budgetSec));
+
+    // Pier reaches the same two numbers through its own deadline model.
+    const pierEnv = {
+      MAKA_HARBOR_MODE: 'task-run',
+      MAKA_CELL_TIMEOUT_SEC: String(budgetSec),
+      MAKA_CELL_SETTLEMENT_GRACE_SEC: String(MAKA_SETTLEMENT_GRACE_SEC),
+    };
+    const pierPhaseSec = agentPhaseTimeoutSec('maka', pierEnv, budgetSec);
+
+    const result = spawnSync(
+      'python3',
+      [
+        '-c',
+        pythonBudgetContractScript(repoRoot, [
+          {
+            label: 'harbor',
+            env: harborAgent.env,
+            agentPhaseSec: harborAgent.max_timeout_sec!,
+          },
+          { label: 'pier', env: pierEnv, agentPhaseSec: pierPhaseSec },
+        ]),
+      ],
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+    if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
+      t.skip('python3 is not available');
+      return;
+    }
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /budget contract ok/);
   });
 
   test('maka_agent.py hydrates a valid cell output without Harbor installed', (t: TestContext) => {
@@ -1243,6 +1307,147 @@ finally:
     if process.poll() is None:
         process.kill()
         process.wait()
+`;
+}
+
+/** Harbor is not installed in this repo, so every Python contract script
+ * stubs the parts of its package tree the adapters import. Shared so a stub
+ * that drifts cannot make one script pass while another fails to import. */
+function pythonHarborStubPrelude(root: string): string {
+  return String.raw`
+import json
+import os
+import sys
+import tempfile
+import time
+import types
+from pathlib import Path
+
+root = Path(${JSON.stringify(root)})
+
+def module(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+module("harbor")
+module("harbor.agents")
+module("harbor.agents.installed")
+base_mod = module("harbor.agents.installed.base")
+
+class BaseInstalledAgent:
+    def __init__(self, logs_dir, *args, **kwargs):
+        self.logs_dir = Path(logs_dir)
+        self._extra_env = kwargs.get("extra_env") or {}
+        self._resolved_flags = {}
+        self.model_name = None
+        self.logger = types.SimpleNamespace(debug=lambda *args, **kwargs: None)
+
+    def _get_env(self, key):
+        if key in self._extra_env:
+            return self._extra_env[key]
+        return os.environ.get(key)
+
+    def version(self):
+        return "test"
+
+    async def exec_as_root(self, environment, command, **kwargs):
+        environment.root_commands.append(command)
+        return types.SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+    async def exec_as_agent(self, environment, command, **kwargs):
+        environment.agent_commands.append(command)
+        return types.SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+class CliFlag:
+    def __init__(self, *args, **kwargs):
+        pass
+
+def with_prompt_template(fn):
+    return fn
+
+base_mod.BaseInstalledAgent = BaseInstalledAgent
+base_mod.CliFlag = CliFlag
+base_mod.with_prompt_template = with_prompt_template
+
+module("harbor.environments")
+env_mod = module("harbor.environments.base")
+class BaseEnvironment:
+    pass
+env_mod.BaseEnvironment = BaseEnvironment
+
+module("harbor.models")
+module("harbor.models.agent")
+context_mod = module("harbor.models.agent.context")
+class AgentContext:
+    def __init__(self):
+        self.metadata = {}
+context_mod.AgentContext = AgentContext
+
+traj_mod = module("harbor.models.trajectories")
+class Agent:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+class FinalMetrics:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+class Step:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+class Trajectory:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+    def to_json_dict(self):
+        return {"ok": True}
+traj_mod.Agent = Agent
+traj_mod.FinalMetrics = FinalMetrics
+traj_mod.Step = Step
+traj_mod.Trajectory = Trajectory
+
+module("harbor.models.trial")
+paths_mod = module("harbor.models.trial.paths")
+class EnvironmentPaths:
+    agent_dir = Path("/logs/agent")
+paths_mod.EnvironmentPaths = EnvironmentPaths
+
+module("harbor.utils")
+utils_mod = module("harbor.utils.trajectory_utils")
+utils_mod.format_trajectory_json = lambda value: json.dumps(value)
+
+`;
+}
+
+function pythonBudgetContractScript(
+  root: string,
+  cases: Array<{ label: string; env: Record<string, string>; agentPhaseSec: number }>,
+): string {
+  return `${pythonHarborStubPrelude(root)}
+sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
+from maka_agent import MakaAgent
+
+cases = json.loads(${JSON.stringify(JSON.stringify(cases))})
+with tempfile.TemporaryDirectory() as tmp:
+    for case in cases:
+        env = case["env"]
+        agent = MakaAgent(Path(tmp), extra_env=env)
+        budget_sec = int(env["MAKA_CELL_TIMEOUT_SEC"])
+        # The number that has to be identical across arms: the runner hands the
+        # adapter a model budget, and the adapter must read back exactly that.
+        assert agent._model_budget_ms() == budget_sec * 1000, (case["label"], agent._model_budget_ms())
+        # The deadline the executor was told to kill at must be the same deadline
+        # the adapter derives for itself. If these two drift, the cell is either
+        # killed while settling or given time the other arms never got.
+        assert agent._agent_phase_timeout_sec() == case["agentPhaseSec"], (
+            case["label"],
+            agent._agent_phase_timeout_sec(),
+            case["agentPhaseSec"],
+        )
+        phase_env = dict(env)
+        phase_env.setdefault("MAKA_AGENT_PHASE_TIMEOUT_SEC", str(case["agentPhaseSec"]))
+        remaining = agent._task_run_hard_timeout_sec(phase_env, time.monotonic())
+        assert abs(remaining - float(case["agentPhaseSec"])) < 1.0, (case["label"], remaining)
+
+print("budget contract ok")
 `;
 }
 
@@ -2162,8 +2367,29 @@ with tempfile.TemporaryDirectory() as tmp:
             "MAKA_ECONOMY_TASK_MODE": "true",
         })
         host_process_environment = types.SimpleNamespace(root_commands=[], agent_commands=[])
-        asyncio.run(host_process_agent._run_host_cell(host_process_environment, Path(tmp) / "instruction.txt"))
+        host_cell_walls = []
+        original_wait_for = asyncio.wait_for
+
+        async def recording_wait_for(awaitable, timeout=None, **wait_kwargs):
+            host_cell_walls.append(timeout)
+            return await original_wait_for(awaitable, timeout=timeout, **wait_kwargs)
+
+        asyncio.wait_for = recording_wait_for
+        try:
+            asyncio.run(host_process_agent._run_host_cell(host_process_environment, Path(tmp) / "instruction.txt"))
+        finally:
+            asyncio.wait_for = original_wait_for
         host_cell_process = dict(captured_host_process)
+        # This is the path Terminal-Bench actually takes. The cell stops calling
+        # the model at MAKA_CELL_SOFT_TIMEOUT_MS and then writes its artifacts,
+        # so the wall that kills it has to be a settlement window later — killing
+        # at the model budget would compress that window to nothing.
+        assert host_cell_walls == [930], host_cell_walls
+        assert (
+            host_cell_walls[0] * 1000
+            - int(host_cell_process["kwargs"]["env"]["MAKA_CELL_SOFT_TIMEOUT_MS"])
+            == 30_000
+        ), (host_cell_walls, host_cell_process["kwargs"]["env"]["MAKA_CELL_SOFT_TIMEOUT_MS"])
 
         task_run_agent = MakaAgent(Path(tmp), extra_env={
             "MAKA_BACKEND": "fake",
@@ -3994,7 +4220,7 @@ with tempfile.TemporaryDirectory() as tmp:
     # Exactly one writer: a second command could append settings that re-enable the tools.
     assert len(managed_calls) == 1, install_environment.calls
     managed_command, _, managed_as_root = managed_calls[0]
-    # Only the root-owned managed scope binds a session that cannot be overridden.
+    # Only the managed scope binds nested invocations rather than one process.
     assert managed_as_root is True, managed_calls
     assert redirect_target(managed_command) == "/etc/claude-code/managed-settings.json", managed_command
     # A swallowed failure would leave the tools enabled while install reports

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -3791,6 +3791,17 @@ def written_payload(command, marker):
         payload = min((token for token in shlex.split(payload) if marker in token), key=len)
     return payload
 
+def redirect_target(command):
+    """Return the path a write command redirects into, peeling bash -lc wrappers."""
+    while True:
+        tokens = shlex.split(command)
+        if ">" in tokens:
+            return tokens[tokens.index(">") + 1]
+        nested = [token for token in tokens if ">" in token]
+        if not nested:
+            return None
+        command = max(nested, key=len)
+
 class RecordingEnvironment:
     def __init__(self):
         self.calls = []
@@ -3966,6 +3977,10 @@ with tempfile.TemporaryDirectory() as tmp:
     managed_command, _, managed_as_root = managed_calls[0]
     # Only the root-owned managed scope binds a session that cannot be overridden.
     assert managed_as_root is True, managed_calls
+    assert redirect_target(managed_command) == "/etc/claude-code/managed-settings.json", managed_command
+    # A swallowed failure would leave the tools enabled while install reports
+    # success; Harbor's exec raises on a non-zero exit, so keep that reachable.
+    assert "|| true" not in managed_command, managed_command
     assert json.loads(written_payload(managed_command, "permissions")) == {
         "permissions": {"deny": ["WebSearch", "WebFetch"]}
     }, managed_command
@@ -4005,6 +4020,17 @@ def written_payload(command, marker):
     while "printf" in payload:
         payload = min((token for token in shlex.split(payload) if marker in token), key=len)
     return payload
+
+def redirect_target(command):
+    """Return the path a write command redirects into, peeling bash -lc wrappers."""
+    while True:
+        tokens = shlex.split(command)
+        if ">" in tokens:
+            return tokens[tokens.index(">") + 1]
+        nested = [token for token in tokens if ">" in token]
+        if not nested:
+            return None
+        command = max(nested, key=len)
 
 module("harbor")
 module("harbor.agents")
@@ -4154,8 +4180,8 @@ with tempfile.TemporaryDirectory() as tmp:
     commands = []
 
     class Environment:
-        async def exec(self, command, env=None, **kwargs):
-            commands.append((command, env or {}))
+        async def exec(self, command, env=None, as_root=False, **kwargs):
+            commands.append((command, env or {}, as_root))
             return types.SimpleNamespace(return_code=0, stdout="", stderr="")
 
     context = types.SimpleNamespace(
@@ -4187,14 +4213,14 @@ with tempfile.TemporaryDirectory() as tmp:
     )
     environment = Environment()
     asyncio.run(agent.install(environment))
-    install_command, install_env = commands[0]
+    install_command, install_env, _install_root = commands[0]
     assert "sha256sum --check" in install_command, install_command
     assert "/opt/maka-codex-toolchain/bin/codex" in install_command, install_command
     assert install_env["MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT"] == "sha256:" + "a" * 64, install_env
     assert "ca-certificates" not in install_command, install_command
     assert "npm" not in install_command, install_command
     assert "curl" not in install_command, install_command
-    alias_commands = [command for command, _env in commands if "ln -sf" in command]
+    alias_commands = [command for command, _env, _root in commands if "ln -sf" in command]
     assert len(alias_commands) == 1, commands
     assert "/opt/maka-codex-toolchain/bin/node" not in alias_commands[0], alias_commands[0]
     assert "/usr/local/bin/node" not in alias_commands[0], alias_commands[0]
@@ -4203,7 +4229,7 @@ with tempfile.TemporaryDirectory() as tmp:
 
     asyncio.run(agent.run("hi", environment, context))
     http_provider_command = next(
-        command for command, _env in commands if "supports_websockets = false" in command
+        command for command, _env, _root in commands if "supports_websockets = false" in command
     )
     assert 'model_provider = "maka-http"' in http_provider_command, http_provider_command
     assert 'base_url = "http://host.docker.internal:43210"' in http_provider_command, http_provider_command
@@ -4214,13 +4240,19 @@ with tempfile.TemporaryDirectory() as tmp:
     written_config = tomllib.loads(written_payload(http_provider_command, "model_provider"))
     assert written_config["web_search"] == "disabled", written_config
     assert "web_search" not in written_config["model_providers"]["maka-http"], written_config
-    requirements_commands = [
-        command for command, _env in commands if "/etc/codex/requirements.toml" in command
+    requirements_calls = [
+        call for call in commands if "/etc/codex/requirements.toml" in call[0]
     ]
-    assert len(requirements_commands) == 1, commands
-    assert tomllib.loads(written_payload(requirements_commands[0], "allowed_web_search_modes")) == {
+    assert len(requirements_calls) == 1, commands
+    requirements_command, _requirements_env, requirements_as_root = requirements_calls[0]
+    # /etc is root-owned: writing this as the agent user fails silently enough to
+    # leave web search enabled, so the privilege is part of the contract.
+    assert requirements_as_root is True, requirements_calls
+    assert redirect_target(requirements_command) == "/etc/codex/requirements.toml", requirements_command
+    assert "|| true" not in requirements_command, requirements_command
+    assert tomllib.loads(written_payload(requirements_command, "allowed_web_search_modes")) == {
         "allowed_web_search_modes": ["disabled"]
-    }, requirements_commands
+    }, requirements_command
     deepseek_agent = MakaCodexAgent(
         logs,
         version="0.144.6",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -103,7 +103,7 @@ describe('Harbor adapter contract', () => {
     );
     const template = source.match(/f"(Maka host cell exceeded [^"]+)"/)?.[1];
     assert.ok(template, 'host-cell timeout message template');
-    const message = template.replace('{self._cell_timeout_sec()}', '1800');
+    const message = template.replace('{self._agent_phase_timeout_sec()}', '1800');
 
     assert.equal(isBudgetExhaustedTrialException(`RuntimeError: ${message}`), true);
   });
@@ -1629,7 +1629,10 @@ with tempfile.TemporaryDirectory() as tmp:
     assert container_env["MAKA_OUTPUT_DIR"] == "/logs/agent/maka-task-run", container_env
     assert container_env["MAKA_CELL_ARTIFACT_DIR"] == "/logs/agent", container_env
     assert container_env["MAKA_STORAGE_ROOT"] == "/logs/agent/maka-task-run/runs", container_env
-    assert container_kwargs["timeout_sec"] == 7200, container_kwargs
+    # No MAKA_AGENT_PHASE_TIMEOUT_SEC here, so the hard process deadline falls
+    # back to the model budget plus the settlement window rather than the budget
+    # itself — killing at the budget would cut the cell off as it starts writing.
+    assert container_kwargs["timeout_sec"] == 7230, container_kwargs
     assert "/logs/agent/maka-task-run" in container_environment.download_dirs
     assert "/logs/agent/maka-cell-output.json" in container_environment.downloads
     assert json.loads(
@@ -1958,15 +1961,29 @@ with tempfile.TemporaryDirectory() as tmp:
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "01800"})._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "1٢"})._cell_timeout_sec() == 900
     assert MakaAgent(Path(tmp), extra_env={"MAKA_CELL_TIMEOUT_SEC": "9" * 5000})._cell_timeout_sec() == 900
-    assert MakaAgent(Path(tmp))._cell_soft_timeout_ms() == 870000
-    assert MakaAgent(Path(tmp), extra_env={
+    # MAKA_CELL_TIMEOUT_SEC is the model budget verbatim on every path, and the
+    # settlement window is added around it. Benchmark arms are only comparable
+    # while the model budget stays exactly the task-native budget.
+    assert MakaAgent(Path(tmp))._model_budget_ms() == 900000
+    assert MakaAgent(Path(tmp))._agent_phase_timeout_sec() == 930
+    graced = MakaAgent(Path(tmp), extra_env={
         "MAKA_CELL_TIMEOUT_SEC": "1800",
         "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
-    })._cell_soft_timeout_ms() == 1740000
+    })
+    assert graced._model_budget_ms() == 1800000
+    assert graced._agent_phase_timeout_sec() == 1860
+    # A window wider than the budget is not a contradiction any more: it just
+    # buys more settlement time, and the model budget is untouched.
+    wide = MakaAgent(Path(tmp), extra_env={
+        "MAKA_CELL_TIMEOUT_SEC": "60",
+        "MAKA_CELL_SETTLEMENT_GRACE_SEC": "600",
+    })
+    assert wide._model_budget_ms() == 60000
+    assert wide._agent_phase_timeout_sec() == 660
     try:
         MakaAgent(Path(tmp), extra_env={
             "MAKA_CELL_TIMEOUT_SEC": "2147514",
-        })._cell_soft_timeout_ms()
+        })._model_budget_ms()
     except RuntimeError as exc:
         assert "Node timer limit" in str(exc), str(exc)
     else:
@@ -1979,7 +1996,7 @@ with tempfile.TemporaryDirectory() as tmp:
         url="http://127.0.0.1:1",
         token="test-token",
     ))
-    assert host_deadline_env["MAKA_CELL_SOFT_TIMEOUT_MS"] == "870000", host_deadline_env
+    assert host_deadline_env["MAKA_CELL_SOFT_TIMEOUT_MS"] == "900000", host_deadline_env
 
     copilot_host_env = MakaAgent(Path(tmp), extra_env={
         "MAKA_HOST_API_KEY": "copilot-token",
@@ -2174,7 +2191,9 @@ with tempfile.TemporaryDirectory() as tmp:
         )
         task_run_env = captured_host_process["kwargs"]["env"]
         assert "MAKA_MAX_STEPS" not in task_run_env, task_run_env.get("MAKA_MAX_STEPS")
-        assert task_run_timeouts[-1] == 7200, task_run_timeouts
+            # The hard process deadline is the model budget plus the settlement
+        # window, never the budget itself: the cell is still writing at 7200.
+        assert task_run_timeouts[-1] == 7230, task_run_timeouts
 
         host_repo_root = Path(tmp) / "different-host-repo"
         relative_task_run_agent = MakaAgent(Path(tmp), extra_env={
@@ -2222,7 +2241,7 @@ with tempfile.TemporaryDirectory() as tmp:
             )
         finally:
             maka_agent_mod._DEFAULT_RUNNER_ENV = original_runner_env
-        assert task_run_timeouts[-1] == 4321, task_run_timeouts
+        assert task_run_timeouts[-1] == 4351, task_run_timeouts
 
         capped_task_run_agent = MakaAgent(Path(tmp), extra_env={
             "MAKA_BACKEND": "fake",
@@ -2271,7 +2290,7 @@ with tempfile.TemporaryDirectory() as tmp:
                 AgentContext(),
             )
         )
-        assert captured_host_process["kwargs"]["env"]["MAKA_CELL_SOFT_TIMEOUT_MS"] == "50000"
+        assert captured_host_process["kwargs"]["env"]["MAKA_CELL_SOFT_TIMEOUT_MS"] == "60000"
         assert FakeToolExecutor.instances[-1].reclaim_active_commands
         assert not FakeToolExecutor.instances[-1].reclaim_scoped_processes
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -3934,6 +3934,24 @@ with tempfile.TemporaryDirectory() as tmp:
     assert pipeline_cell["status"] == "failed", pipeline_cell
     assert pipeline_cell["errorClass"] == "infra_failed", pipeline_cell
 
+    class RecordingEnvironment:
+        def __init__(self):
+            self.root_commands = []
+            self.agent_commands = []
+
+        async def exec(self, command, env=None, as_root=False, **kwargs):
+            (self.root_commands if as_root else self.agent_commands).append(command)
+            return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+
+    install_environment = RecordingEnvironment()
+    install_agent = agent(logs)
+    install_agent._extra_env["MAKA_CLAUDE_CODE_TOOLCHAIN_FINGERPRINT"] = "fingerprint"
+    asyncio.run(install_agent.install(install_environment))
+    managed_command = install_environment.root_commands[-1]
+    assert "/etc/claude-code/managed-settings.json" in managed_command, managed_command
+    assert '"WebSearch"' in managed_command, managed_command
+    assert '"WebFetch"' in managed_command, managed_command
+
 print("claude-code adapter ok")
 `;
 }
@@ -4159,6 +4177,7 @@ with tempfile.TemporaryDirectory() as tmp:
     assert 'model_provider = "maka-http"' in http_provider_command, http_provider_command
     assert 'base_url = "http://host.docker.internal:43210"' in http_provider_command, http_provider_command
     assert 'wire_api = "responses"' in http_provider_command, http_provider_command
+    assert 'web_search = "disabled"' in http_provider_command, http_provider_command
     assert "ephemeral-token" not in http_provider_command, http_provider_command
     deepseek_agent = MakaCodexAgent(
         logs,

--- a/packages/headless/src/__tests__/harbor-smoke-config.test.ts
+++ b/packages/headless/src/__tests__/harbor-smoke-config.test.ts
@@ -8,6 +8,7 @@ import {
   resolveSmokeRunTargets,
   type SmokeManifest,
 } from '../harbor-smoke-config.js';
+import { MAKA_SETTLEMENT_GRACE_SEC } from '../maka-settlement.js';
 
 const repoRoot = resolve(fileURLToPath(new URL('../../../..', import.meta.url)));
 
@@ -66,6 +67,39 @@ describe('harbor smoke config generation', () => {
     assert.equal(env.MAKA_CELL_TIMEOUT_SEC, '7200');
     assert.equal(env.MAKA_HARBOR_AGENT_TIMEOUT_SEC, undefined);
     assert.equal(config.agent_timeout_multiplier, 8);
+  });
+
+  test('the smoke agent phase outlasts the cell budget by the settlement window', async () => {
+    // The maka profiles tune agent_timeout_multiplier so the task-native budget
+    // times the multiplier equals the cell budget. Leaving max_timeout_sec null
+    // therefore makes Harbor kill the cell at the exact moment it stops calling
+    // the model and starts writing, turning a scored result into an infra failure.
+    const manifest = await loadManifest();
+    for (const profileName of ['maka-basic', 'maka-heavy']) {
+      const { config } = buildSmokeJobConfig({
+        manifest,
+        profileName,
+        overrides: { jobName: 'job' },
+      });
+      const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
+      const env = agent.env as Record<string, string>;
+      assert.equal(
+        agent.max_timeout_sec,
+        Number(env.MAKA_CELL_TIMEOUT_SEC) + MAKA_SETTLEMENT_GRACE_SEC,
+        profileName,
+      );
+    }
+  });
+
+  test('a non-maka smoke profile gets no settlement window', async () => {
+    const manifest = await loadManifest();
+    const { config } = buildSmokeJobConfig({
+      manifest,
+      profileName: 'oracle',
+      overrides: { jobName: 'job' },
+    });
+    const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
+    assert.equal(agent.max_timeout_sec, null);
   });
 
   test('--model override targets MAKA_MODEL for maka and model_name for non-maka', async () => {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -7,11 +7,13 @@ import { describe, test } from 'node:test';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 import type { HarborCellExecutionIdentity, HarborCellOutput } from '../cell-output.js';
 import { FixedPromptBudgetExhaustedError, type TaskRunInput } from '../fixed-prompt-controller.js';
+import { CODEX_TOOLCHAIN_SPEC } from '../codex-toolchain.js';
 import {
   buildHarborJobConfig,
   createHarborOracleQualifier,
   createHarborTaskRunner,
   HarborInfraError,
+  MAKA_SETTLEMENT_GRACE_SEC,
   type HarborProcessRunner,
   type HarborRunRequest,
   type HarborRunResult,
@@ -2537,16 +2539,72 @@ describe('buildHarborJobConfig', () => {
     assert.equal(env.MAKA_BACKEND, 'ai-sdk');
   });
 
-  test('mirrors the cell timeout into Harbor agent timeout', () => {
+  test('every arm gets the same model budget and only Maka a settlement tail', () => {
+    // Maka's cell stops calling the model one grace window before its own budget
+    // runs out; native CLIs run until Harbor cancels. Taking the grace out of the
+    // budget would hand Maka less model time than its competitors for the same task.
+    const agentFor = (adapter: 'maka' | 'codex') => {
+      const config = buildHarborJobConfig(runInput(), {
+        makaRepoPath: '/repo',
+        jobsDir: '/jobs/x',
+        jobName: 'trial',
+        model: 'deepseek/deepseek-v4-flash',
+        agentEnv: { MAKA_CELL_TIMEOUT_SEC: '1800' },
+        ...(adapter === 'codex'
+          ? {
+              agent: adapter,
+              agentVersion: CODEX_TOOLCHAIN_SPEC.codex.version,
+              codexToolchainPath: '/toolchains/codex',
+            }
+          : {}),
+      });
+      return (
+        config.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
+      )[0]!;
+    };
+
+    // Pin the window as a real quantity: with a zero grace every assertion below
+    // would hold for an implementation that gives no arm any settlement tail.
+    assert.ok(MAKA_SETTLEMENT_GRACE_SEC > 0, 'the settlement window must be a real window');
+
+    const maka = agentFor('maka');
+    assert.equal(maka.max_timeout_sec, 1800 + MAKA_SETTLEMENT_GRACE_SEC);
+    assert.equal(maka.env.MAKA_CELL_TIMEOUT_SEC, String(1800 + MAKA_SETTLEMENT_GRACE_SEC));
+    assert.equal(maka.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, String(MAKA_SETTLEMENT_GRACE_SEC));
+    // Model time = cell budget - grace, which is the task-native budget itself.
+    assert.equal(
+      Number(maka.env.MAKA_CELL_TIMEOUT_SEC) - Number(maka.env.MAKA_CELL_SETTLEMENT_GRACE_SEC),
+      1800,
+    );
+
+    const codex = agentFor('codex');
+    assert.equal(codex.max_timeout_sec, 1800);
+    assert.equal(codex.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, undefined);
+    // The whole asymmetry: Maka's phase is longer by exactly the window it
+    // spends settling, and both arms still call the model for the same 1800s.
+    assert.equal(maka.max_timeout_sec! - codex.max_timeout_sec!, MAKA_SETTLEMENT_GRACE_SEC);
+  });
+
+  test('an operator-widened settlement window is honoured, not overwritten', () => {
+    // The grace is a default, not a constant: a run that needs a longer tail
+    // must keep it, and the budget must widen with it so model time is unchanged.
+    const widened = MAKA_SETTLEMENT_GRACE_SEC + 45;
     const config = buildHarborJobConfig(runInput(), {
       makaRepoPath: '/repo',
       jobsDir: '/jobs/x',
       jobName: 'trial',
       model: 'deepseek/deepseek-v4-flash',
-      agentEnv: { MAKA_CELL_TIMEOUT_SEC: '1800' },
+      agentEnv: {
+        MAKA_CELL_TIMEOUT_SEC: '1800',
+        MAKA_CELL_SETTLEMENT_GRACE_SEC: String(widened),
+      },
     });
-    const agent = (config.agents as Array<{ max_timeout_sec?: number }>)[0]!;
-    assert.equal(agent.max_timeout_sec, 1800);
+    const agent = (
+      config.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
+    )[0]!;
+    assert.equal(agent.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, String(widened));
+    assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, String(1800 + widened));
+    assert.equal(agent.max_timeout_sec, 1800 + widened);
   });
 
   test('a malformed cell timeout falls back instead of failing the run', () => {
@@ -2597,7 +2655,11 @@ describe('buildHarborJobConfig', () => {
       const metadataAgent = (
         withMetadata.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
       )[0]!;
-      assert.equal(metadataAgent.env.MAKA_CELL_TIMEOUT_SEC, String(parsed ?? 1234), label);
+      assert.equal(
+        metadataAgent.env.MAKA_CELL_TIMEOUT_SEC,
+        String((parsed ?? 1234) + MAKA_SETTLEMENT_GRACE_SEC),
+        label,
+      );
       assert.equal(
         metadataAgent.env.MAKA_STREAM_CONNECT_TIMEOUT_MS,
         String((parsed ?? 1234) * 1_000),
@@ -2608,7 +2670,11 @@ describe('buildHarborJobConfig', () => {
         String((parsed ?? 1234) * 1_000),
         label,
       );
-      assert.equal(metadataAgent.max_timeout_sec, parsed ?? 1234, label);
+      assert.equal(
+        metadataAgent.max_timeout_sec,
+        (parsed ?? 1234) + MAKA_SETTLEMENT_GRACE_SEC,
+        label,
+      );
 
       // Without metadata, a parsed value is rewritten into the env; a parse
       // miss passes the raw string through for the adapter's default.
@@ -2623,10 +2689,14 @@ describe('buildHarborJobConfig', () => {
       )[0]!;
       assert.equal(
         agent.env.MAKA_CELL_TIMEOUT_SEC,
-        parsed !== undefined ? String(parsed) : raw,
+        parsed !== undefined ? String(parsed + MAKA_SETTLEMENT_GRACE_SEC) : raw,
         label,
       );
-      assert.equal(agent.max_timeout_sec, parsed, label);
+      assert.equal(
+        agent.max_timeout_sec,
+        parsed === undefined ? undefined : parsed + MAKA_SETTLEMENT_GRACE_SEC,
+        label,
+      );
     }
   });
 
@@ -2650,10 +2720,10 @@ describe('buildHarborJobConfig', () => {
     const agent = (
       config.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
     )[0]!;
-    assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, '1234');
+    assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, String(1234 + MAKA_SETTLEMENT_GRACE_SEC));
     assert.equal(agent.env.MAKA_STREAM_CONNECT_TIMEOUT_MS, '1234000');
     assert.equal(agent.env.MAKA_STREAM_IDLE_TIMEOUT_MS, '1234000');
-    assert.equal(agent.max_timeout_sec, 1234);
+    assert.equal(agent.max_timeout_sec, 1234 + MAKA_SETTLEMENT_GRACE_SEC);
   });
 
   test('merges per-attempt agent env into the Harbor agent config', () => {
@@ -2673,7 +2743,7 @@ describe('buildHarborJobConfig', () => {
       },
     );
     const env = (config.agents as Array<{ env: Record<string, string> }>)[0]!.env;
-    assert.equal(env.MAKA_CELL_TIMEOUT_SEC, '1800');
+    assert.equal(env.MAKA_CELL_TIMEOUT_SEC, String(1800 + MAKA_SETTLEMENT_GRACE_SEC));
     assert.equal(env.MAKA_CONTEXT_BUDGET, 'off');
     assert.equal(env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE, 'on');
   });
@@ -2732,6 +2802,39 @@ describe('createHarborTaskRunner timeout', () => {
           },
         }),
       );
+      // The agent phase Harbor is handed is the model budget plus Maka's
+      // settlement window, so the watchdog has to outlast that sum — otherwise
+      // it can kill a trial that is still legitimately settling.
+      assert.equal(seenTimeout, (7_200 + MAKA_SETTLEMENT_GRACE_SEC + 1_320 + 15 * 60) * 1_000);
+    });
+  });
+
+  test('gives a native CLI arm no settlement window in the outer watchdog', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      let seenTimeout: number | undefined;
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        agent: 'codex',
+        agentVersion: CODEX_TOOLCHAIN_SPEC.codex.version,
+        codexToolchainPath: '/toolchains/codex',
+        runHarbor: async (request) => {
+          seenTimeout = request.timeoutMs;
+          return fakeRunner({ reward: '1\n' })(request);
+        },
+      });
+      await runner(
+        runInput({
+          task: {
+            id: 'task-1',
+            path: '/tasks/task-1',
+            metadata: { agentTimeoutSec: 7_200, verifierTimeoutSec: 600 },
+          },
+        }),
+      );
+      // Codex is cancelled at its own deadline with nothing to settle, so its
+      // watchdog must not carry Maka's window either.
       assert.equal(seenTimeout, (7_200 + 1_320 + 15 * 60) * 1_000);
     });
   });
@@ -2759,7 +2862,7 @@ describe('createHarborTaskRunner timeout', () => {
           },
         }),
       );
-      assert.equal(seenTimeout, (7_200 + 1_320 + 15 * 60) * 1_000);
+      assert.equal(seenTimeout, (7_200 + MAKA_SETTLEMENT_GRACE_SEC + 1_320 + 15 * 60) * 1_000);
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -2569,12 +2569,13 @@ describe('buildHarborJobConfig', () => {
 
     const maka = agentFor('maka');
     assert.equal(maka.max_timeout_sec, 1800 + MAKA_SETTLEMENT_GRACE_SEC);
-    assert.equal(maka.env.MAKA_CELL_TIMEOUT_SEC, String(1800 + MAKA_SETTLEMENT_GRACE_SEC));
+    // The budget the cell is handed is the model budget itself, on every path.
+    assert.equal(maka.env.MAKA_CELL_TIMEOUT_SEC, '1800');
     assert.equal(maka.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, String(MAKA_SETTLEMENT_GRACE_SEC));
-    // Model time = cell budget - grace, which is the task-native budget itself.
+    // Harbor kills at the agent phase, which is that budget plus the window.
     assert.equal(
-      Number(maka.env.MAKA_CELL_TIMEOUT_SEC) - Number(maka.env.MAKA_CELL_SETTLEMENT_GRACE_SEC),
-      1800,
+      maka.max_timeout_sec! - Number(maka.env.MAKA_CELL_TIMEOUT_SEC),
+      MAKA_SETTLEMENT_GRACE_SEC,
     );
 
     const codex = agentFor('codex');
@@ -2603,7 +2604,7 @@ describe('buildHarborJobConfig', () => {
       config.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
     )[0]!;
     assert.equal(agent.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, String(widened));
-    assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, String(1800 + widened));
+    assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, '1800');
     assert.equal(agent.max_timeout_sec, 1800 + widened);
   });
 
@@ -2655,11 +2656,7 @@ describe('buildHarborJobConfig', () => {
       const metadataAgent = (
         withMetadata.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
       )[0]!;
-      assert.equal(
-        metadataAgent.env.MAKA_CELL_TIMEOUT_SEC,
-        String((parsed ?? 1234) + MAKA_SETTLEMENT_GRACE_SEC),
-        label,
-      );
+      assert.equal(metadataAgent.env.MAKA_CELL_TIMEOUT_SEC, String(parsed ?? 1234), label);
       assert.equal(
         metadataAgent.env.MAKA_STREAM_CONNECT_TIMEOUT_MS,
         String((parsed ?? 1234) * 1_000),
@@ -2689,7 +2686,7 @@ describe('buildHarborJobConfig', () => {
       )[0]!;
       assert.equal(
         agent.env.MAKA_CELL_TIMEOUT_SEC,
-        parsed !== undefined ? String(parsed + MAKA_SETTLEMENT_GRACE_SEC) : raw,
+        parsed !== undefined ? String(parsed) : raw,
         label,
       );
       assert.equal(
@@ -2720,7 +2717,7 @@ describe('buildHarborJobConfig', () => {
     const agent = (
       config.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
     )[0]!;
-    assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, String(1234 + MAKA_SETTLEMENT_GRACE_SEC));
+    assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, '1234');
     assert.equal(agent.env.MAKA_STREAM_CONNECT_TIMEOUT_MS, '1234000');
     assert.equal(agent.env.MAKA_STREAM_IDLE_TIMEOUT_MS, '1234000');
     assert.equal(agent.max_timeout_sec, 1234 + MAKA_SETTLEMENT_GRACE_SEC);
@@ -2743,7 +2740,7 @@ describe('buildHarborJobConfig', () => {
       },
     );
     const env = (config.agents as Array<{ env: Record<string, string> }>)[0]!.env;
-    assert.equal(env.MAKA_CELL_TIMEOUT_SEC, String(1800 + MAKA_SETTLEMENT_GRACE_SEC));
+    assert.equal(env.MAKA_CELL_TIMEOUT_SEC, '1800');
     assert.equal(env.MAKA_CONTEXT_BUDGET, 'off');
     assert.equal(env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE, 'on');
   });

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { test } from 'node:test';
 import { TERMINAL_BENCH_2_1_TASK_IDS } from '../harness-ab-manifest.js';
+import { buildHarborJobConfig } from '../harbor-task-runner.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -1455,6 +1456,34 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
   // the same window on top of the task-native model budget, so both manifests
   // must record it.
   assert.equal(tbenchManifest.metadata.benchmark.agentSettlementGraceSec, 30);
+  // Anchor the declared window to what the runner actually hands out. Recording
+  // the constant alone would stay green even if every arm got no window at all.
+  const anchorBudgetSec = 1800;
+  const anchorAgent = (
+    buildHarborJobConfig(
+      {
+        runId: 'run-1',
+        roundId: 'round-1',
+        task: {
+          id: 'task-1',
+          path: '/tasks/task-1',
+          metadata: { agentTimeoutSec: anchorBudgetSec },
+        },
+        config: {
+          id: 'cfg',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'deepseek',
+          model: 'deepseek-v4-flash',
+        },
+        systemPrompt: 'PROMPT\n',
+      },
+      { makaRepoPath: '/repo', jobsDir: '/jobs/x', jobName: 'trial', model: 'deepseek/v4' },
+    ).agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
+  )[0]!;
+  assert.equal(
+    anchorAgent.max_timeout_sec! - Number(anchorAgent.env.MAKA_CELL_TIMEOUT_SEC),
+    tbenchManifest.metadata.benchmark.agentSettlementGraceSec,
+  );
   // Every arm is handed MAKA_SYSTEM_PROMPT but only the Maka cell applies it, so
   // the arm identity has to say so in a readable field rather than only inside a
   // hash. Asserting both arms keeps the asymmetry itself under test.

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -731,6 +731,9 @@ test('harness CLI freezes the synchronized DeepSeek three-way composition', asyn
   );
 });
 
+// Baselines move only when arm identity genuinely changes; the current values
+// cover the settlement-grace and externalSystemPrompt corrections, which both
+// alter what an arm actually runs with.
 test('harness composition preserves historical manifest fingerprints', async () => {
   const { buildHarnessAbManifest, resolveHarnessComposition } = await import(
     new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
@@ -740,31 +743,31 @@ test('harness composition preserves historical manifest fingerprints', async () 
       name: 'Terminal-Bench Kimi Code',
       composition: { competitor: 'kimi-code' },
       pierVersion: null,
-      fingerprint: 'sha256:c1f1f4ef3c1de99a4f20ba71f5deddc144f942d5cdb1d9b1223b2ac65e551f9b',
+      fingerprint: 'sha256:6469fb00ceeec168799d67bb84d73a288cd7b68e118f36398185a298278fe2ab',
     },
     {
       name: 'Terminal-Bench OpenCode',
       composition: { competitor: 'opencode' },
       pierVersion: null,
-      fingerprint: 'sha256:700267bbe62f37892d72c2b6ee327dd37632b3f0563a755e693681730a07bb68',
+      fingerprint: 'sha256:375894a49ddfe2a2ce2c195c2b0f14075be4416135bb63e2382b400efc9f460b',
     },
     {
       name: 'Terminal-Bench Codex',
       composition: { competitor: 'codex' },
       pierVersion: null,
-      fingerprint: 'sha256:176c2b12f36b6a78e7558d79a43bc7f12a0073afb8b1e893d0178bccf6d23de4',
+      fingerprint: 'sha256:08d30757e28717184889a9d71ecb2aabac2f223997b9b164d4969ab7a3adcbef',
     },
     {
       name: 'DeepSWE Kimi Code',
       composition: { benchmark: 'deep-swe-1.1', competitor: 'kimi-code' },
       pierVersion: '0.3.0',
-      fingerprint: 'sha256:4a3979f0ccf085063e9cd812444d3739d9f792bac58397eac25ba76120785779',
+      fingerprint: 'sha256:4e4b8fb414b9f3ba9ebe0697592cdc4f9cf20c2bad46d73a6f11c35670e9266a',
     },
     {
       name: 'DeepSWE Codex',
       composition: { benchmark: 'deep-swe-1.1', competitor: 'codex' },
       pierVersion: '0.3.0',
-      fingerprint: 'sha256:e61cf1e48747d6fafc696f334ea609e62d00e98e8b79db2352964aafca128c25',
+      fingerprint: 'sha256:732cdafa5a804485ec6af4f3268e73bf6bd639bdb55926fc6da843e5ad5fdbb8',
     },
   ] as const;
 
@@ -1448,7 +1451,22 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
   // No executor key for Harbor benchmarks: the manifest payload (and with it
   // the resume fingerprint) must stay byte-identical to historical runs.
   assert.equal('executor' in tbenchManifest.metadata.benchmark, false);
-  assert.equal('agentSettlementGraceSec' in tbenchManifest.metadata.benchmark, false);
+  // The settlement grace is executor-independent: both runners give the Maka arm
+  // the same window on top of the task-native model budget, so both manifests
+  // must record it.
+  assert.equal(tbenchManifest.metadata.benchmark.agentSettlementGraceSec, 30);
+  // Every arm is handed MAKA_SYSTEM_PROMPT but only the Maka cell applies it, so
+  // the arm identity has to say so in a readable field rather than only inside a
+  // hash. Asserting both arms keeps the asymmetry itself under test.
+  for (const manifestUnderTest of [manifest, pierManifest, tbenchManifest]) {
+    assert.equal(
+      manifestUnderTest.arms[0].metadata.config.externalSystemPrompt,
+      'default-headless',
+    );
+    for (const competitor of manifestUnderTest.arms.slice(1)) {
+      assert.equal(competitor.metadata.config.externalSystemPrompt, 'none');
+    }
+  }
 });
 
 test('harness A/B benchmark profiles bind their executor and resolve from env', async () => {

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -302,7 +302,6 @@ test('createPierTaskRunner gives Maka a controller-owned settlement tail', async
         agentEnv: {
           MAKA_HARBOR_MODE: 'task-run',
           MAKA_CELL_TIMEOUT_SEC: '1',
-          MAKA_CELL_SETTLEMENT_GRACE_SEC: '1',
           MAKA_AGENT_PHASE_TIMEOUT_SEC: '1',
         },
         runPier: fakePier({ reward: 0, captured }),
@@ -333,7 +332,46 @@ test('createPierTaskRunner gives Maka a controller-owned settlement tail', async
     assert.ok(request.args.includes('MAKA_CELL_TIMEOUT_SEC=5400'));
     assert.ok(request.args.includes('MAKA_CELL_SETTLEMENT_GRACE_SEC=30'));
     assert.ok(request.args.includes('MAKA_AGENT_PHASE_TIMEOUT_SEC=5430'));
+
     assert.equal(request.timeoutMs, 13_890_000);
+  });
+});
+
+test('createPierTaskRunner honours an operator-widened settlement window', async () => {
+  // Same contract as the Harbor runner. Pier used to overwrite the operator's
+  // value with the constant, so widening the window worked on one executor and
+  // silently did nothing on the other.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'maka',
+        makaNodeToolchainPath: '/toolchains/maka-node',
+        agentEnv: {
+          MAKA_HARBOR_MODE: 'task-run',
+          MAKA_CELL_SETTLEMENT_GRACE_SEC: '90',
+        },
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+
+    await runner(
+      runInput({
+        task: {
+          id: 'dasel',
+          path: '/tasks/dasel-html-document-format',
+          metadata: { agentTimeoutSec: 5_400, buildTimeoutSec: 1_800, verifierTimeoutSec: 1_800 },
+        },
+      }),
+    );
+
+    const request = captured.request;
+    assert.ok(request);
+    assert.ok(request.args.includes('MAKA_CELL_TIMEOUT_SEC=5400'));
+    assert.ok(request.args.includes('MAKA_CELL_SETTLEMENT_GRACE_SEC=90'));
+    assert.ok(request.args.includes('MAKA_AGENT_PHASE_TIMEOUT_SEC=5490'));
   });
 });
 

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../fixed-prompt-controller.js';
 import { CODEX_TOOLCHAIN_FINGERPRINT, CODEX_TOOLCHAIN_SPEC } from '../codex-toolchain.js';
 import { OPENCODE_TOOLCHAIN_FINGERPRINT, OPENCODE_TOOLCHAIN_SPEC } from '../opencode-toolchain.js';
-import { findTrialDir } from '../harbor-task-runner.js';
+import { findTrialDir, MAKA_SETTLEMENT_GRACE_SEC } from '../harbor-task-runner.js';
 import { MAKA_NODE_TOOLCHAIN_FINGERPRINT } from '../maka-node-toolchain.js';
 import type { ProviderRequestTelemetry } from '../provider-auth-proxy.js';
 import {
@@ -327,10 +327,59 @@ test('createPierTaskRunner gives Maka a controller-owned settlement tail', async
     assert.ok(request);
     const agentTimeoutFlag = request.args.indexOf('--agent-timeout-multiplier');
     assert.equal(request.args[agentTimeoutFlag + 1], '1.0055555555555555');
+    // Container task-run reads the cell budget as the model budget itself and
+    // takes its settlement window out of the agent phase, so the model already
+    // gets the full 5400s here without adding the grace to the budget.
     assert.ok(request.args.includes('MAKA_CELL_TIMEOUT_SEC=5400'));
     assert.ok(request.args.includes('MAKA_CELL_SETTLEMENT_GRACE_SEC=30'));
     assert.ok(request.args.includes('MAKA_AGENT_PHASE_TIMEOUT_SEC=5430'));
     assert.equal(request.timeoutMs, 13_890_000);
+  });
+});
+
+test('createPierTaskRunner gives a native CLI arm no settlement tail', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'codex',
+        agentVersion: CODEX_TOOLCHAIN_SPEC.codex.version,
+        codexToolchainPath: repo,
+        backend: 'ai-sdk',
+        provider: 'openai-codex',
+        model: 'gpt-5.6-sol',
+        resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
+        providerProxyPort: 0,
+        agentEnv: { MAKA_HARBOR_MODE: 'task-run' },
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+
+    await runner(
+      runInput({
+        task: {
+          id: 'dasel',
+          path: '/tasks/dasel-html-document-format',
+          metadata: {
+            agentTimeoutSec: 5_400,
+            buildTimeoutSec: 1_800,
+            verifierTimeoutSec: 1_800,
+          },
+        },
+      }),
+    );
+
+    const request = captured.request;
+    assert.ok(request);
+    // Codex has nothing to settle: it runs until Pier cancels it at the
+    // task-native deadline, so it gets neither the phase stretch nor the
+    // wall-clock window Maka needs on top of it.
+    assert.ok(!request.args.includes('--agent-timeout-multiplier'));
+    assert.ok(!request.args.some((arg) => arg.startsWith('MAKA_CELL_SETTLEMENT_GRACE_SEC=')));
+    assert.ok(!request.args.some((arg) => arg.startsWith('MAKA_AGENT_PHASE_TIMEOUT_SEC=')));
+    assert.equal(request.timeoutMs, 13_890_000 - MAKA_SETTLEMENT_GRACE_SEC * 1_000);
   });
 });
 

--- a/packages/headless/src/harbor-smoke-config.ts
+++ b/packages/headless/src/harbor-smoke-config.ts
@@ -13,6 +13,9 @@
  * profiles keep producing byte-equivalent configs.
  */
 
+import { lenientPositiveIntEnv } from './headless-run-env.js';
+import { agentPhaseTimeoutSec } from './maka-settlement.js';
+
 export interface SmokeManifestDataset {
   name?: string;
   version?: string;
@@ -174,6 +177,18 @@ export function buildSmokeJobConfig(input: {
 
   if (overrides.maxSteps) agentEnv.MAKA_MAX_STEPS = overrides.maxSteps;
   if (overrides.agentTimeoutSec) agentEnv.MAKA_CELL_TIMEOUT_SEC = overrides.agentTimeoutSec;
+  // Without this, Harbor bounds the agent phase at the task-native budget times
+  // the profile multiplier, which the maka profiles tune to equal the cell
+  // budget exactly — so the cell would be killed at the instant it stops calling
+  // the model and starts writing, and the trial would read as an infra failure
+  // instead of a scored result. Same rule the fixed-prompt runner applies.
+  const smokeModelBudgetSec = profileName.startsWith('maka-')
+    ? lenientPositiveIntEnv(agentEnv.MAKA_CELL_TIMEOUT_SEC)
+    : undefined;
+  const smokeAgentPhaseSec =
+    smokeModelBudgetSec === undefined
+      ? null
+      : agentPhaseTimeoutSec('maka', agentEnv, smokeModelBudgetSec);
   if (profileName.startsWith('maka-') && !agentEnv.MAKA_BENCHMARK_DATASET) {
     agentEnv.MAKA_BENCHMARK_DATASET = overrides.benchmarkDataset || datasetName;
   }
@@ -234,7 +249,7 @@ export function buildSmokeJobConfig(input: {
         skills: [],
         override_timeout_sec: null,
         override_setup_timeout_sec: null,
-        max_timeout_sec: null,
+        max_timeout_sec: smokeAgentPhaseSec,
         extra_allowed_hosts: [],
         kwargs: agent.kwargs ?? {},
         env: agentEnv,

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -76,24 +76,13 @@ import {
   CLAUDE_CODE_TOOLCHAIN_SPEC,
 } from './claude-code-toolchain.js';
 
+import { agentPhaseTimeoutSec, settlementGraceSec } from './maka-settlement.js';
+
+export { MAKA_SETTLEMENT_GRACE_SEC } from './maka-settlement.js';
+
 const execFileAsync = promisify(execFile);
 
 const CONTAINER_MAKA_REPO = '/opt/maka-agent';
-/** Wall-clock Maka's cell reserves to settle artifacts after it stops calling
- * the model. Shared with the Pier runner so both executors bound model time the
- * same way. */
-export const MAKA_SETTLEMENT_GRACE_SEC = 30;
-
-/** Seconds this arm spends settling after its model budget runs out. Only the
- * Maka cell has such a window; native CLIs run until Harbor cancels them. Both
- * the job config and the wall-clock watchdog resolve it here so the watchdog can
- * never bound a shorter lifecycle than the one the job config hands out. */
-function settlementGraceSec(adapter: string, agentEnv: Record<string, string> | undefined): number {
-  if (adapter !== 'maka') return 0;
-  return (
-    lenientPositiveIntEnv(agentEnv?.MAKA_CELL_SETTLEMENT_GRACE_SEC) ?? MAKA_SETTLEMENT_GRACE_SEC
-  );
-}
 const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
 const TRIAL_EXECUTION_IDENTITY = 'agent/maka-cell-execution-identity.json';
 const TRIAL_USAGE_CHECKPOINT = 'agent/maka-cell-usage-checkpoint.json';
@@ -672,7 +661,11 @@ function resolveNativeHarborTimeoutMs(
   );
   return resolveNativeTrialTimeoutMs({
     // The agent phase Harbor is given is the model budget plus Maka's
-    // settlement window, so the watchdog has to bound that same sum.
+    // settlement window, so the watchdog bounds that same sum. It reads the
+    // runner-level env only, while the job config also sees per-attempt env —
+    // the shared setup/teardown grace is far wider than any window an operator
+    // would set, so the watchdog still outlasts the phase either way.
+    // Resolved through the shared rule so the two cannot drift in kind.
     nativePhasesSec:
       agentTimeoutSec +
       settlementGraceSec(options.agent ?? 'maka', options.agentEnv) +
@@ -1116,9 +1109,9 @@ export function buildHarborJobConfig(
   // at — is one window longer. Native CLIs have nothing to settle and get the
   // budget itself, which is how every arm ends up with the same model time.
   const graceSec = settlementGraceSec(adapter, agentEnv);
-  let agentPhaseTimeoutSec: number | undefined;
+  let agentPhaseSec: number | undefined;
   if (modelBudgetSec !== undefined) {
-    agentPhaseTimeoutSec = modelBudgetSec + graceSec;
+    agentPhaseSec = agentPhaseTimeoutSec(adapter, agentEnv, modelBudgetSec);
     agentEnv.MAKA_CELL_TIMEOUT_SEC = String(modelBudgetSec);
     if (adapter === 'maka') {
       agentEnv.MAKA_CELL_SETTLEMENT_GRACE_SEC = String(graceSec);
@@ -1176,7 +1169,7 @@ export function buildHarborJobConfig(
                 }
               : {},
         env: agentEnv,
-        ...(agentPhaseTimeoutSec !== undefined ? { max_timeout_sec: agentPhaseTimeoutSec } : {}),
+        ...(agentPhaseSec !== undefined ? { max_timeout_sec: agentPhaseSec } : {}),
       },
     ],
     datasets: [],

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -79,6 +79,21 @@ import {
 const execFileAsync = promisify(execFile);
 
 const CONTAINER_MAKA_REPO = '/opt/maka-agent';
+/** Wall-clock Maka's cell reserves to settle artifacts after it stops calling
+ * the model. Shared with the Pier runner so both executors bound model time the
+ * same way. */
+export const MAKA_SETTLEMENT_GRACE_SEC = 30;
+
+/** Seconds this arm spends settling after its model budget runs out. Only the
+ * Maka cell has such a window; native CLIs run until Harbor cancels them. Both
+ * the job config and the wall-clock watchdog resolve it here so the watchdog can
+ * never bound a shorter lifecycle than the one the job config hands out. */
+function settlementGraceSec(adapter: string, agentEnv: Record<string, string> | undefined): number {
+  if (adapter !== 'maka') return 0;
+  return (
+    lenientPositiveIntEnv(agentEnv?.MAKA_CELL_SETTLEMENT_GRACE_SEC) ?? MAKA_SETTLEMENT_GRACE_SEC
+  );
+}
 const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
 const TRIAL_EXECUTION_IDENTITY = 'agent/maka-cell-execution-identity.json';
 const TRIAL_USAGE_CHECKPOINT = 'agent/maka-cell-usage-checkpoint.json';
@@ -647,7 +662,7 @@ function resolveHarborTimeoutMs(options: HarborTaskRunnerOptions, input: TaskRun
 }
 
 function resolveNativeHarborTimeoutMs(
-  options: Pick<HarborTaskRunnerOptions, 'timeoutMultiplier' | 'agentEnv'>,
+  options: Pick<HarborTaskRunnerOptions, 'timeoutMultiplier' | 'agentEnv' | 'agent'>,
   task: TaskRunInput['task'],
 ): number {
   const configuredCellTimeoutSec = lenientPositiveIntEnv(options.agentEnv?.MAKA_CELL_TIMEOUT_SEC);
@@ -656,7 +671,12 @@ function resolveNativeHarborTimeoutMs(
     configuredCellTimeoutSec ?? 0,
   );
   return resolveNativeTrialTimeoutMs({
-    nativePhasesSec: agentTimeoutSec + verifierPolicy(task).outerTimeoutSec,
+    // The agent phase Harbor is given is the model budget plus Maka's
+    // settlement window, so the watchdog has to bound that same sum.
+    nativePhasesSec:
+      agentTimeoutSec +
+      settlementGraceSec(options.agent ?? 'maka', options.agentEnv) +
+      verifierPolicy(task).outerTimeoutSec,
     timeoutMultiplier: options.timeoutMultiplier ?? 1,
   });
 }
@@ -1088,11 +1108,23 @@ export function buildHarborJobConfig(
   Object.assign(agentEnv, attemptAgentEnv ?? {});
   // Lenient by shared contract with the Python adapter: a malformed value must
   // fall back (metadata, then the adapter's default) rather than fail the run.
-  const cellTimeoutSec =
+  const modelBudgetSec =
     lenientPositiveIntEnv(agentEnv.MAKA_CELL_TIMEOUT_SEC) ?? input.task.metadata?.agentTimeoutSec;
-  if (cellTimeoutSec !== undefined) {
-    agentEnv.MAKA_CELL_TIMEOUT_SEC = String(cellTimeoutSec);
-    const streamTimeoutMs = cellTimeoutSec * 1_000;
+  // Maka's cell stops calling the model one grace window before its cell budget
+  // runs out (maka_agent.py _cell_soft_timeout_ms). Native CLIs have no such
+  // window: they run until Harbor cancels at the task-native deadline. Give the
+  // grace on top of the budget, not out of it, so every arm gets the same model
+  // time and only Maka's extra settlement lands outside it. An operator that
+  // widens the window keeps it — the budget then carries the wider window too.
+  const graceSec = settlementGraceSec(adapter, agentEnv);
+  let agentPhaseTimeoutSec: number | undefined;
+  if (modelBudgetSec !== undefined) {
+    agentPhaseTimeoutSec = modelBudgetSec + graceSec;
+    agentEnv.MAKA_CELL_TIMEOUT_SEC = String(agentPhaseTimeoutSec);
+    if (adapter === 'maka') {
+      agentEnv.MAKA_CELL_SETTLEMENT_GRACE_SEC = String(graceSec);
+    }
+    const streamTimeoutMs = modelBudgetSec * 1_000;
     if (adapter === 'maka' && Number.isSafeInteger(streamTimeoutMs)) {
       // Harbor already owns the task-native hard deadline. Keep the runtime's
       // first-event and between-event watchdogs from imposing a shorter,
@@ -1145,7 +1177,7 @@ export function buildHarborJobConfig(
                 }
               : {},
         env: agentEnv,
-        ...(cellTimeoutSec !== undefined ? { max_timeout_sec: cellTimeoutSec } : {}),
+        ...(agentPhaseTimeoutSec !== undefined ? { max_timeout_sec: agentPhaseTimeoutSec } : {}),
       },
     ],
     datasets: [],

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -1110,17 +1110,16 @@ export function buildHarborJobConfig(
   // fall back (metadata, then the adapter's default) rather than fail the run.
   const modelBudgetSec =
     lenientPositiveIntEnv(agentEnv.MAKA_CELL_TIMEOUT_SEC) ?? input.task.metadata?.agentTimeoutSec;
-  // Maka's cell stops calling the model one grace window before its cell budget
-  // runs out (maka_agent.py _cell_soft_timeout_ms). Native CLIs have no such
-  // window: they run until Harbor cancels at the task-native deadline. Give the
-  // grace on top of the budget, not out of it, so every arm gets the same model
-  // time and only Maka's extra settlement lands outside it. An operator that
-  // widens the window keeps it — the budget then carries the wider window too.
+  // MAKA_CELL_TIMEOUT_SEC is the model budget on every path, so it is passed
+  // through untouched. Maka's cell stops calling the model when it runs out and
+  // then settles its artifacts, so its agent phase — the deadline Harbor kills
+  // at — is one window longer. Native CLIs have nothing to settle and get the
+  // budget itself, which is how every arm ends up with the same model time.
   const graceSec = settlementGraceSec(adapter, agentEnv);
   let agentPhaseTimeoutSec: number | undefined;
   if (modelBudgetSec !== undefined) {
     agentPhaseTimeoutSec = modelBudgetSec + graceSec;
-    agentEnv.MAKA_CELL_TIMEOUT_SEC = String(agentPhaseTimeoutSec);
+    agentEnv.MAKA_CELL_TIMEOUT_SEC = String(modelBudgetSec);
     if (adapter === 'maka') {
       agentEnv.MAKA_CELL_SETTLEMENT_GRACE_SEC = String(graceSec);
     }

--- a/packages/headless/src/maka-settlement.ts
+++ b/packages/headless/src/maka-settlement.ts
@@ -1,0 +1,45 @@
+/**
+ * The one rule for how long a benchmark arm runs.
+ *
+ * MAKA_CELL_TIMEOUT_SEC is the model budget on every path — the seconds an arm
+ * may spend calling the model, and the only number that has to be identical
+ * across arms for the comparison to mean anything. The Maka cell alone then
+ * stops calling the model and settles its artifacts, so its agent phase is one
+ * settlement window longer. Native CLIs have nothing to settle and are killed at
+ * the budget itself.
+ *
+ * Every producer of a Harbor or Pier agent phase resolves it here. Producing it
+ * anywhere else is how the smoke harness ended up killing the cell at the exact
+ * moment it began writing.
+ */
+
+import { lenientPositiveIntEnv } from './headless-run-env.js';
+
+/** Wall-clock the Maka cell reserves to settle artifacts after it stops calling
+ * the model. Executor-independent: both runners bound model time the same way. */
+export const MAKA_SETTLEMENT_GRACE_SEC = 30;
+
+/** Seconds this arm spends settling after its model budget runs out. Only the
+ * Maka cell has such a window; native CLIs run until the executor cancels them.
+ * An operator may widen it; the agent phase widens with it. */
+export function settlementGraceSec(
+  adapter: string,
+  agentEnv: Record<string, string> | undefined,
+): number {
+  if (adapter !== 'maka') return 0;
+  return (
+    lenientPositiveIntEnv(agentEnv?.MAKA_CELL_SETTLEMENT_GRACE_SEC) ?? MAKA_SETTLEMENT_GRACE_SEC
+  );
+}
+
+/** The deadline the executor must kill at: the model budget plus whatever this
+ * arm needs to settle. Killing at the model budget instead cuts the cell off at
+ * the instant it starts writing, which reads as an infra failure rather than a
+ * scored result. */
+export function agentPhaseTimeoutSec(
+  adapter: string,
+  agentEnv: Record<string, string> | undefined,
+  modelBudgetSec: number,
+): number {
+  return modelBudgetSec + settlementGraceSec(adapter, agentEnv);
+}

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -783,11 +783,8 @@ function buildPierAgentEnv(
   Object.assign(env, providerAgentEnv);
   Object.assign(env, mergeAgentEnv(options.agentEnv, input.agentEnv) ?? {});
   if (makaDeadline) {
-    // Container task-run drops MAKA_CELL_SOFT_TIMEOUT_MS and derives the model
-    // deadline straight from the cell budget (maka_agent.py
-    // _container_task_run_env), so this budget already is the model budget and
-    // the settlement window lives in the agent phase. Harbor's cell mode instead
-    // subtracts the grace from the budget, which is why only that runner adds it.
+    // The budget is the model budget and the settlement window is added around
+    // it, so the agent phase Pier is given is one window longer.
     env.MAKA_CELL_TIMEOUT_SEC = String(makaDeadline.modelBudgetSec);
     env.MAKA_CELL_SETTLEMENT_GRACE_SEC = String(makaDeadline.settlementGraceSec);
     env.MAKA_AGENT_PHASE_TIMEOUT_SEC = String(makaDeadline.phaseTimeoutSec);

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -30,10 +30,10 @@ import {
   resolveNativeTrialTimeoutMs,
   withProviderTelemetryArtifact,
   incompleteTerminalProviderRequest,
-  MAKA_SETTLEMENT_GRACE_SEC,
   modelForOpenCode,
   type HarborTaskPricing,
 } from './harbor-task-runner.js';
+import { agentPhaseTimeoutSec, settlementGraceSec } from './maka-settlement.js';
 import {
   harnessAgentImportPath,
   providerProxyClientAuthMode,
@@ -296,8 +296,8 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       taskAgentTimeoutSec !== undefined
         ? {
             modelBudgetSec: taskAgentTimeoutSec,
-            settlementGraceSec: MAKA_SETTLEMENT_GRACE_SEC,
-            phaseTimeoutSec: taskAgentTimeoutSec + MAKA_SETTLEMENT_GRACE_SEC,
+            settlementGraceSec: settlementGraceSec(agent, attemptAgentEnv),
+            phaseTimeoutSec: agentPhaseTimeoutSec(agent, attemptAgentEnv, taskAgentTimeoutSec),
           }
         : undefined;
     const jobsDir = join(

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -30,6 +30,7 @@ import {
   resolveNativeTrialTimeoutMs,
   withProviderTelemetryArtifact,
   incompleteTerminalProviderRequest,
+  MAKA_SETTLEMENT_GRACE_SEC,
   modelForOpenCode,
   type HarborTaskPricing,
 } from './harbor-task-runner.js';
@@ -84,7 +85,6 @@ const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
  * container reaching the host proxy through Squid must present one of those.
  * 443 keeps the model endpoint on the conventional TLS port. */
 export const PIER_PROVIDER_PROXY_DEFAULT_PORT = 443;
-export const PIER_MAKA_SETTLEMENT_GRACE_SEC = 30;
 
 /** Compatibility fallback for callers that do not provide a run-scoped proxy
  * hub. Such callers still bind one fixed port per attempt, so concurrent binds
@@ -296,8 +296,8 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       taskAgentTimeoutSec !== undefined
         ? {
             modelBudgetSec: taskAgentTimeoutSec,
-            settlementGraceSec: PIER_MAKA_SETTLEMENT_GRACE_SEC,
-            phaseTimeoutSec: taskAgentTimeoutSec + PIER_MAKA_SETTLEMENT_GRACE_SEC,
+            settlementGraceSec: MAKA_SETTLEMENT_GRACE_SEC,
+            phaseTimeoutSec: taskAgentTimeoutSec + MAKA_SETTLEMENT_GRACE_SEC,
           }
         : undefined;
     const jobsDir = join(
@@ -783,6 +783,11 @@ function buildPierAgentEnv(
   Object.assign(env, providerAgentEnv);
   Object.assign(env, mergeAgentEnv(options.agentEnv, input.agentEnv) ?? {});
   if (makaDeadline) {
+    // Container task-run drops MAKA_CELL_SOFT_TIMEOUT_MS and derives the model
+    // deadline straight from the cell budget (maka_agent.py
+    // _container_task_run_env), so this budget already is the model budget and
+    // the settlement window lives in the agent phase. Harbor's cell mode instead
+    // subtracts the grace from the budget, which is why only that runner adds it.
     env.MAKA_CELL_TIMEOUT_SEC = String(makaDeadline.modelBudgetSec);
     env.MAKA_CELL_SETTLEMENT_GRACE_SEC = String(makaDeadline.settlementGraceSec);
     env.MAKA_AGENT_PHASE_TIMEOUT_SEC = String(makaDeadline.phaseTimeoutSec);


### PR DESCRIPTION
## Summary

The three-arm harness comparison was not running the same exam for each arm. Two independent asymmetries, both fixed here. Refs #1970.

**Web tools.** Maka's headless product tool surface is an explicit allowlist with no web tools, but the Codex and Claude Code adapters shipped their CLIs with web search and fetch left at their defaults. That let a competitor arm search for a task's `benchmark/tests/solution` directly, which is where the 13/13 Codex result came from.

- Claude Code: `/etc/claude-code/managed-settings.json` denying `WebSearch` and `WebFetch`. Managed settings is the only process-independent scope — `--disallowedTools` would bind only the process the harness starts, not nested `claude` invocations — and `bypassPermissions` still honors explicit deny rules. This has to be a config-layer fix because `WebSearch` executes server-side behind the provider proxy, where the container network policy cannot reach it.
- Codex: top-level `web_search = "disabled"` in the generated config **plus** `allowed_web_search_modes = ["disabled"]` in `/etc/codex/requirements.toml`. `config.toml` alone only pins the user layer, which a task-directory config, a profile, or a runtime `-c web_search=live` still outranks; the requirements layer constrains which modes are settable at all, so every higher layer resolves back to disabled. The default is `Cached`, and a full-access sandbox upgrades it to `Live`.

This removes the tools from what each model is offered. It is not an adversarial control: `CLAUDE_CODE_MANAGED_SETTINGS_PATH` redirects the managed file and many task images run the agent as root. The claim is that no arm reaches the web by accident.

**Model budget.** `MAKA_CELL_TIMEOUT_SEC` meant two different quantities. On the container task-run path it was the model budget; everywhere else the adapter subtracted the settlement window from it, making it budget-plus-window. So the TypeScript side had to predict which Python branch would run — a branch selected by whether `MAKA_AGENT_PHASE_TIMEOUT_SEC` is present, not by which runner started the trial — just to decide whether to add the window back. Nothing tested that prediction, and a wrong guess silently costs the Maka arm a window of model time.

Every other producer already treated it as the model budget. Dropping the subtraction makes it mean one thing everywhere: the seconds an arm may spend calling the model. The settlement window is added around it, never carved out of it, and the hard process deadlines derive from `_agent_phase_timeout_sec` so the cell is never killed at the moment it starts writing.

That rule now lives in one place (`maka-settlement.ts`) and every producer resolves it there — both runners and the smoke config, which writes its own Harbor job config and had been left behind. It is executor-independent, so it no longer lives in or is imported from the Harbor runner.

**Arm identity.** The runner hands every arm `MAKA_SYSTEM_PROMPT` but only the Maka cell applies it; the native CLIs hash it into their execution identity and drop it. The manifest now records `externalSystemPrompt` per arm and the settlement window, so arm identity is readable rather than only hashed. **The manifest fingerprint baselines move with those two fields, so in-flight runs will fork rather than resume.**

## Verification

- `npm run test -w @maka/headless` — 1326 pass, 0 fail, 1 skip.
- `npm run lint` and `npm run format:check` — clean.
- Mutation checks; every one of these correctly turns the suite red:
  - downgrading the Codex requirements write from `exec_as_root` to `exec_as_agent` (`/etc` is root-owned; the silent failure would leave web search enabled),
  - moving `web_search` below the first table header, where it becomes `model_providers.maka-http.web_search` and Codex never reads it,
  - writing the managed settings to `~/.claude/settings.json` instead of the managed path,
  - reverting the host cell wall to the model budget, which compresses the settlement window to zero,
  - having the runner emit budget-plus-window again, which the cross-language contract now catches,
  - dropping the settlement window from the outer watchdog, or handing it to a native CLI arm.
- Policy assertions parse the written TOML/JSON rather than substring-matching, and assert the redirect target and the root privilege.
- `WebSearchModeRequirement` accepts `disabled` — confirmed against the pinned Codex binary's variant list, so the requirements file cannot hard-fail Codex at startup.

Not verified here: these tests prove the correct policy files are written and that both languages agree on the budget, not that the CLIs end up with no web tools in a live container. `codex debug-config` prints the requirements layer and is worth running once in the task image before the re-run.

## Out of scope

- OpenCode and Kimi Code still have their web tools at defaults. Those arms are not being run right now; they need the same treatment before they are.
- `MAKA_CELL_SOFT_TIMEOUT_MS` and `MAKA_CELL_DEADLINE_AT_MS` now express the same quantity relative and absolute. Collapsing them to a single absolute deadline would remove the last of this coupling, but it reaches `run-cell.mjs` and `run-host-cell.mjs` and does not belong here.