### PR TITLE
fix(headless): classify a benchmark trial by who ended it, not by how the exception reads

### DIFF
--- a/packages/headless/harbor/claude_code_agent.py
+++ b/packages/headless/harbor/claude_code_agent.py
@@ -128,6 +128,7 @@ class MakaClaudeCodeAgent(ClaudeCode):
             await super().run(instruction, environment, context)
         except asyncio.CancelledError:
             abnormal_exit = True
+            self._deadline_settled = True
             self._failure_class = "budget_exhausted"
             raise
         except BaseException as error:
@@ -248,6 +249,19 @@ class MakaClaudeCodeAgent(ClaudeCode):
             "schemaVersion": 1,
             "status": "failed" if error_class is not None else "completed",
             **({"errorClass": error_class} if error_class is not None else {}),
+            # Same contract as the Codex arm: the benchmark deadline, not the
+            # agent, ended this run, and the arm that observed it is the only
+            # one that can say so.
+            **(
+                {
+                    "deadlineSettlement": {
+                        "source": "benchmark.deadline",
+                        "mode": "immediate",
+                    }
+                }
+                if getattr(self, "_deadline_settled", False)
+                else {}
+            ),
             "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
             "promptHash": identity["systemPromptHash"],
             "executionIdentity": identity,

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -112,26 +112,6 @@ describe('Harbor adapter contract', () => {
     assert.equal(classifyTrialTermination({ type: 'RuntimeError', message }), 'agent_budget');
   });
 
-  test('every competitor adapter reports a benchmark deadline the same way', async () => {
-    // Settlement must not depend on which adapter happened to record the fact.
-    // An arm whose cell output omits deadlineSettlement has its timeouts read as
-    // ordinary runtime failures, which silently changes what that arm's score
-    // means relative to the others.
-    for (const adapter of ['codex_agent.py', 'claude_code_agent.py']) {
-      const source = await readFile(resolve(repoRoot, 'packages/headless/harbor', adapter), 'utf8');
-      assert.match(
-        source,
-        /except asyncio\.CancelledError:[\s\S]{0,200}?self\._deadline_settled = True/,
-        `${adapter} must record the deadline that ended its agent phase`,
-      );
-      assert.match(
-        source,
-        /"deadlineSettlement": \{[\s\S]{0,160}?"source": "benchmark\.deadline"/,
-        `${adapter} must emit deadlineSettlement in its cell output`,
-      );
-    }
-  });
-
   test('run-host-cell.mjs resolves package-local harbor-cell internals at runtime', (t: TestContext) => {
     const result = spawnSync('node', ['packages/headless/harbor/run-host-cell.mjs'], {
       cwd: repoRoot,
@@ -4106,6 +4086,9 @@ class ClaudeCode:
             "auth_token": self._get_env("ANTHROPIC_AUTH_TOKEN"),
             "oauth_token": self._get_env("CLAUDE_CODE_OAUTH_TOKEN"),
         })
+        if instruction == "cancel":
+            environment.started.set()
+            await asyncio.Event().wait()
         if instruction == "pipeline-fail":
             result = await self.exec_as_agent(
                 environment,
@@ -4252,6 +4235,48 @@ with tempfile.TemporaryDirectory() as tmp:
     assert json.loads(written_payload(managed_command, "permissions")) == {
         "permissions": {"deny": ["WebSearch", "WebFetch"]}
     }, managed_command
+
+    # Arm symmetry with the Codex adapter's cancel_codex() case below: a
+    # benchmark deadline is the harness cancelling the agent phase, and the arm
+    # that observed it is the only one that can report it. An arm whose cell
+    # output omits deadlineSettlement has its timeouts read as ordinary runtime
+    # failures, which silently changes what that arm's score means.
+    class CancelEnvironment(RecordingEnvironment):
+        def __init__(self):
+            super().__init__()
+            self.started = asyncio.Event()
+
+    cancel_environment = CancelEnvironment()
+    cancel_agent = agent(logs)
+
+    async def cancel_claude():
+        task = asyncio.create_task(cancel_agent.run("cancel", cancel_environment, context))
+        await asyncio.wait_for(cancel_environment.started.wait(), timeout=2)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        else:
+            raise AssertionError("expected Claude Code cancellation")
+
+    asyncio.run(cancel_claude())
+    cancel_agent.populate_context_post_run(context)
+    cancel_cell = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+    assert cancel_cell["status"] == "failed", cancel_cell
+    assert cancel_cell["errorClass"] == "budget_exhausted", cancel_cell
+    assert cancel_cell["deadlineSettlement"] == {
+        "source": "benchmark.deadline",
+        "mode": "immediate",
+    }, cancel_cell
+
+    # A normal run must NOT claim the deadline settled it — the assertion above
+    # passes just as well if the field is written unconditionally.
+    settled_free = agent(logs)
+    asyncio.run(settled_free.run("success", Environment(), context))
+    settled_free.populate_context_post_run(context)
+    success_cell = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+    assert "deadlineSettlement" not in success_cell, success_cell
 
 print("claude-code adapter ok")
 `;

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { decodeRuntimeEvent } from '@maka/core';
 import { HARBOR_CELL_CONTEXT_ENV_KEYS } from '../harbor-cell.js';
-import { buildHarborJobConfig, isBudgetExhaustedTrialException } from '../harbor-task-runner.js';
+import { buildHarborJobConfig, classifyTrialTermination } from '../harbor-task-runner.js';
 import { agentPhaseTimeoutSec, MAKA_SETTLEMENT_GRACE_SEC } from '../maka-settlement.js';
 import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '../system-prompts.js';
 
@@ -106,7 +106,30 @@ describe('Harbor adapter contract', () => {
     assert.ok(template, 'host-cell timeout message template');
     const message = template.replace('{self._agent_phase_timeout_sec()}', '1800');
 
-    assert.equal(isBudgetExhaustedTrialException(`RuntimeError: ${message}`), true);
+    // The host cell's deadline arrives as a generic RuntimeError, so this is the
+    // one termination still identified by its message. That is only sound while
+    // the raiser lives in this repo, which is exactly what this test pins.
+    assert.equal(classifyTrialTermination({ type: 'RuntimeError', message }), 'agent_budget');
+  });
+
+  test('every competitor adapter reports a benchmark deadline the same way', async () => {
+    // Settlement must not depend on which adapter happened to record the fact.
+    // An arm whose cell output omits deadlineSettlement has its timeouts read as
+    // ordinary runtime failures, which silently changes what that arm's score
+    // means relative to the others.
+    for (const adapter of ['codex_agent.py', 'claude_code_agent.py']) {
+      const source = await readFile(resolve(repoRoot, 'packages/headless/harbor', adapter), 'utf8');
+      assert.match(
+        source,
+        /except asyncio\.CancelledError:[\s\S]{0,200}?self\._deadline_settled = True/,
+        `${adapter} must record the deadline that ended its agent phase`,
+      );
+      assert.match(
+        source,
+        /"deadlineSettlement": \{[\s\S]{0,160}?"source": "benchmark\.deadline"/,
+        `${adapter} must emit deadlineSettlement in its cell output`,
+      );
+    }
   });
 
   test('run-host-cell.mjs resolves package-local harbor-cell internals at runtime', (t: TestContext) => {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1784,7 +1784,7 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
-  test('keeps an externally ended run infra however complete its artifacts are', async () => {
+  test('keeps an externally ended run that exited non-zero infra despite full artifacts', async () => {
     await withRun(async ({ jobsDir, repo }) => {
       const runner = createHarborTaskRunner({
         makaRepoPath: repo,
@@ -1795,6 +1795,13 @@ describe('createHarborTaskRunner', () => {
           // Every artifact present and the verdict conclusive: the container
           // died after the verifier ran. The agent still never got the run it
           // was given, so this is not a fair sample at any reward.
+          //
+          // Scoped deliberately to the non-zero exit. Both harnesses swallow a
+          // recorded agent-phase exception and exit 0 (trial.py run()), and on
+          // that path an external termination with a full verdict still falls
+          // through and scores. That is defensible — the verifier did grade it,
+          // and the verifier only ever runs for an agent-owned termination in
+          // the first place — but it is not what this test pins.
           reward: '0\n',
           cell: cellOutput({ status: 'failed', errorClass: 'aborted' }),
           trialResult: {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1699,6 +1699,70 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
+  test('scores a graded trial whose exception wording the budget regexes do not match', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          exitCodeAfterArtifacts: 1,
+          reward: '1\n',
+          cell: cellOutput({ status: 'failed', errorClass: 'aborted' }),
+          trialResult: {
+            exception_info: {
+              exception_type: 'AgentTimeoutError',
+              // Upstream wording drift: same fact, phrasing the pinned regexes miss.
+              exception_message: 'Agent execution exceeded its 900s deadline',
+            },
+          },
+        }),
+      });
+
+      const output = await runner(runInput());
+      assert.equal(output.harbor.reward, 1);
+      assert.equal(output.harbor.verifier?.outcome, 'passed');
+      // The exception is not budget-shaped, so nothing may claim the deadline
+      // settled it — the verifier grade is what makes the trial scoreable.
+      assert.equal(output.cell.deadlineSettlement, undefined);
+      assert.equal(output.cell.errorClass, 'aborted');
+    });
+  });
+
+  test('keeps a non-zero exit infra when the verifier reached no verdict', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          exitCodeAfterArtifacts: 1,
+          reward: '0\n',
+          cell: cellOutput({ status: 'failed', errorClass: 'aborted' }),
+          verifierOutcome: {
+            schemaVersion: 1,
+            outcome: 'candidate_timeout',
+            attempts: [{ attempt: 1, classification: 'timeout', durationMs: 1 }],
+          },
+          trialResult: {
+            exception_info: {
+              exception_type: 'DockerExecError',
+              exception_message: 'container exec failed',
+            },
+          },
+        }),
+      });
+
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof HarborInfraError);
+        // The infra message has to name the trial exception: the WAL keeps only
+        // the message, so anything dropped here is unfindable after the run.
+        assert.match(error.message, /trial exception: DockerExecError: container exec failed/);
+        return true;
+      });
+    });
+  });
+
   test('returns the official verifier result after a non-zero Harbor timeout exit', async () => {
     await withRun(async ({ jobsDir, repo }) => {
       const timedCell = cellOutput({

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -13,6 +13,7 @@ import {
   createHarborOracleQualifier,
   createHarborTaskRunner,
   HarborInfraError,
+  incompleteTerminalProviderRequest,
   MAKA_SETTLEMENT_GRACE_SEC,
   type HarborProcessRunner,
   type HarborRunRequest,
@@ -24,6 +25,7 @@ import {
   providerProxyUpstreamAuthMode,
   providerProxyUsageProtocol,
 } from '../harness-agent-registry.js';
+import type { ProviderRequestTelemetry } from '../provider-auth-proxy.js';
 import { HARBOR_ORACLE_EXECUTION_POLICY } from '../harness-oracle-policy.js';
 import {
   CLAUDE_CODE_TOOLCHAIN_FINGERPRINT,
@@ -1699,7 +1701,7 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
-  test('scores a graded trial whose exception wording the budget regexes do not match', async () => {
+  test('settles a timeout by its exception type when the harness rewords the message', async () => {
     await withRun(async ({ jobsDir, repo }) => {
       const runner = createHarborTaskRunner({
         makaRepoPath: repo,
@@ -1711,8 +1713,9 @@ describe('createHarborTaskRunner', () => {
           cell: cellOutput({ status: 'failed', errorClass: 'aborted' }),
           trialResult: {
             exception_info: {
+              // AgentTimeoutError is Harbor's own class, so the type settles it.
+              // The message is upstream prose and may be reworded at any time.
               exception_type: 'AgentTimeoutError',
-              // Upstream wording drift: same fact, phrasing the pinned regexes miss.
               exception_message: 'Agent execution exceeded its 900s deadline',
             },
           },
@@ -1721,15 +1724,40 @@ describe('createHarborTaskRunner', () => {
 
       const output = await runner(runInput());
       assert.equal(output.harbor.reward, 1);
+      assert.equal(output.cell.deadlineSettlement?.source, 'benchmark.deadline');
+    });
+  });
+
+  test('scores a graded trial the agent ended by exiting non-zero', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          exitCodeAfterArtifacts: 1,
+          reward: '1\n',
+          cell: cellOutput({ status: 'failed', errorClass: 'aborted' }),
+          trialResult: {
+            exception_info: {
+              exception_type: 'NonZeroAgentExitCodeError',
+              exception_message: 'agent exited 1',
+            },
+          },
+        }),
+      });
+
+      const output = await runner(runInput());
+      assert.equal(output.harbor.reward, 1);
       assert.equal(output.harbor.verifier?.outcome, 'passed');
-      // The exception is not budget-shaped, so nothing may claim the deadline
-      // settled it — the verifier grade is what makes the trial scoreable.
+      // No deadline ended this run, so nothing may claim one — the structured
+      // verifier grade is what makes the trial scoreable.
       assert.equal(output.cell.deadlineSettlement, undefined);
       assert.equal(output.cell.errorClass, 'aborted');
     });
   });
 
-  test('keeps a non-zero exit infra when the verifier reached no verdict', async () => {
+  test('scores a graded-failed agent exit, not just a graded-passed one', async () => {
     await withRun(async ({ jobsDir, repo }) => {
       const runner = createHarborTaskRunner({
         makaRepoPath: repo,
@@ -1739,11 +1767,36 @@ describe('createHarborTaskRunner', () => {
           exitCodeAfterArtifacts: 1,
           reward: '0\n',
           cell: cellOutput({ status: 'failed', errorClass: 'aborted' }),
-          verifierOutcome: {
-            schemaVersion: 1,
-            outcome: 'candidate_timeout',
-            attempts: [{ attempt: 1, classification: 'timeout', durationMs: 1 }],
+          trialResult: {
+            exception_info: {
+              exception_type: 'NonZeroAgentExitCodeError',
+              exception_message: 'agent exited 1',
+            },
           },
+        }),
+      });
+
+      // A verdict settles the trial whichever way it went; scoring only the
+      // passes would quietly drop every graded failure from the denominator.
+      const output = await runner(runInput());
+      assert.equal(output.harbor.reward, 0);
+      assert.equal(output.harbor.verifier?.outcome, 'failed');
+    });
+  });
+
+  test('keeps an externally ended run infra however complete its artifacts are', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          exitCodeAfterArtifacts: 1,
+          // Every artifact present and the verdict conclusive: the container
+          // died after the verifier ran. The agent still never got the run it
+          // was given, so this is not a fair sample at any reward.
+          reward: '0\n',
+          cell: cellOutput({ status: 'failed', errorClass: 'aborted' }),
           trialResult: {
             exception_info: {
               exception_type: 'DockerExecError',
@@ -1755,6 +1808,7 @@ describe('createHarborTaskRunner', () => {
 
       await assert.rejects(runner(runInput()), (error: unknown) => {
         assert.ok(error instanceof HarborInfraError);
+        assert.match(error.message, /harbor run exited 1/);
         // The infra message has to name the trial exception: the WAL keeps only
         // the message, so anything dropped here is unfindable after the run.
         assert.match(error.message, /trial exception: DockerExecError: container exec failed/);
@@ -3040,5 +3094,57 @@ describe('createHarborTaskRunner timeout', () => {
 
       await assert.rejects(runner(runInput()), HarborInfraError);
     });
+  });
+});
+
+describe('incompleteTerminalProviderRequest', () => {
+  const request = (outcome: ProviderRequestTelemetry['outcome']): ProviderRequestTelemetry => ({
+    requestId: 1,
+    method: 'POST',
+    path: '/v1/messages',
+    outcome,
+    durationMs: 10,
+    bodyChunks: 1,
+    responseBytes: 10,
+    terminalEvent: outcome === 'completed',
+  });
+
+  test('accepts a completed tail request whether or not the trial settled', () => {
+    assert.equal(incompleteTerminalProviderRequest([request('completed')], false), undefined);
+    assert.equal(incompleteTerminalProviderRequest([request('completed')], true), undefined);
+  });
+
+  test('exempts a settled trial whose tail request the client tore down', () => {
+    // `aborted` is set from `signal.aborted` — it is what killing the agent
+    // looks like from the proxy, so a settled trial explains it.
+    assert.equal(incompleteTerminalProviderRequest([request('aborted')], true), undefined);
+  });
+
+  test('keeps a provider-side truncation infra even on a settled trial', () => {
+    // This is the boundary that keeps a provider outage out of the denominator
+    // instead of recording it as the agent's zero. `interrupted` (200 stream
+    // with no terminal event) and `failed` are the upstream's doing, and the
+    // agent phase ending does not explain either.
+    for (const outcome of ['interrupted', 'failed'] as const) {
+      assert.equal(
+        incompleteTerminalProviderRequest([request(outcome)], true)?.outcome,
+        outcome,
+        `${outcome} must stay infra`,
+      );
+    }
+  });
+
+  test('keeps every non-completing tail request infra on an unsettled trial', () => {
+    for (const outcome of ['interrupted', 'failed', 'aborted'] as const) {
+      assert.equal(incompleteTerminalProviderRequest([request(outcome)], false)?.outcome, outcome);
+    }
+  });
+
+  test('reads only the last request', () => {
+    assert.equal(
+      incompleteTerminalProviderRequest([request('failed'), request('completed')], false),
+      undefined,
+    );
+    assert.equal(incompleteTerminalProviderRequest([], false), undefined);
   });
 });

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -1014,6 +1014,53 @@ test('createPierTaskRunner scores a graded trial despite a non-budget exception'
   });
 });
 
+test('createPierTaskRunner scores a graded trial despite a non-zero pier exit', async () => {
+  // The grade is the evidence, the exit code is not: pier can exit non-zero on
+  // an exceptional trial the verifier nonetheless graded. Discarding it as infra
+  // drops a real sample out of the Pass@1 denominator.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({
+          reward: 1,
+          exitCode: 1,
+          exceptionInfo: {
+            exception_type: 'NonZeroAgentExitCodeError',
+            exception_message: 'agent exited 1',
+          },
+        }),
+      }),
+    );
+    const output = await runner(runInput());
+    assert.equal(output.harbor.reward, 1);
+    assert.equal(output.cell.deadlineSettlement, undefined);
+  });
+});
+
+test('createPierTaskRunner keeps a non-zero exit infra when the trial went ungraded', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({
+          exitCode: 1,
+          exceptionInfo: { exception_type: 'DockerExecError', exception_message: 'exec failed' },
+        }),
+      }),
+    );
+    await assert.rejects(runner(runInput()), (error: Error) => {
+      assert.ok(error instanceof PierInfraError);
+      assert.match(error.message, /pier run exited 1/);
+      // The WAL keeps only the message, so the cause has to travel inside it.
+      assert.match(error.message, /trial exception: DockerExecError: exec failed/);
+      return true;
+    });
+  });
+});
+
 test('createPierTaskRunner treats an ungraded non-budget trial exception as infra', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const runner = createPierTaskRunner(

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -1026,6 +1026,10 @@ test('createPierTaskRunner scores a graded trial despite a non-zero pier exit', 
         runPier: fakePier({
           reward: 1,
           exitCode: 1,
+          // status 'failed' keeps the verifier grade load-bearing: with the
+          // default 'completed' the controller would score the trial on status
+          // alone and the settle rule under test would not be exercised.
+          cell: cellOutput({ status: 'failed', errorClass: 'aborted' }),
           exceptionInfo: {
             exception_type: 'NonZeroAgentExitCodeError',
             exception_message: 'agent exited 1',
@@ -1035,18 +1039,46 @@ test('createPierTaskRunner scores a graded trial despite a non-zero pier exit', 
     );
     const output = await runner(runInput());
     assert.equal(output.harbor.reward, 1);
+    assert.equal(output.harbor.verifier?.outcome, 'passed');
     assert.equal(output.cell.deadlineSettlement, undefined);
   });
 });
 
-test('createPierTaskRunner keeps a non-zero exit infra when the trial went ungraded', async () => {
+test('createPierTaskRunner scores a graded-failed agent exit, not just a graded-passed one', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const runner = createPierTaskRunner(
       baseOptions({
         jobsDir,
         makaRepoPath: repo,
         runPier: fakePier({
+          reward: 0,
           exitCode: 1,
+          cell: cellOutput({ status: 'failed', errorClass: 'aborted' }),
+          exceptionInfo: {
+            exception_type: 'NonZeroAgentExitCodeError',
+            exception_message: 'agent exited 1',
+          },
+        }),
+      }),
+    );
+    const output = await runner(runInput());
+    assert.equal(output.harbor.reward, 0);
+    assert.equal(output.harbor.verifier?.outcome, 'failed');
+  });
+});
+
+test('createPierTaskRunner keeps an externally ended run infra despite a full grade', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({
+          // Graded and complete, but pier's container — not the agent — ended
+          // the run, so the artifacts are not evidence of a fair sample.
+          reward: 1,
+          exitCode: 1,
+          cell: cellOutput({ status: 'failed', errorClass: 'aborted' }),
           exceptionInfo: { exception_type: 'DockerExecError', exception_message: 'exec failed' },
         }),
       }),

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -102,15 +102,23 @@ const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
 /** Shared across runners: the last proxied provider request must have
  * completed. A 200 stream without its protocol terminal event means the
  * provider response is incomplete — the trial is an infra failure, never a
- * graded model failure. Complete timed-out trials settle by deadline, so
- * their truncated tail request is expected and exempt. */
+ * graded model failure.
+ *
+ * A settled trial's tail request is expected to be truncated, but only in one
+ * specific way: killing the agent tears the request down from the client side,
+ * which the proxy records as `aborted` (provider-auth-proxy.ts sets it from
+ * `signal.aborted`). `interrupted` and `failed` are the upstream's doing and
+ * are not explained by the agent phase ending, so they stay infra however the
+ * trial settled — that is what keeps a provider outage out of the denominator
+ * instead of scoring it as the agent's zero. */
 export function incompleteTerminalProviderRequest(
   providerTelemetry: readonly ProviderRequestTelemetry[],
-  completeTimedOutTrial: boolean,
+  agentPhaseSettled: boolean,
 ): ProviderRequestTelemetry | undefined {
-  if (completeTimedOutTrial) return undefined;
   const terminal = providerTelemetry.at(-1);
-  return terminal && terminal.outcome !== 'completed' ? terminal : undefined;
+  if (!terminal || terminal.outcome === 'completed') return undefined;
+  if (agentPhaseSettled && terminal.outcome === 'aborted') return undefined;
+  return terminal;
 }
 
 export class HarborInfraError extends Error {
@@ -373,25 +381,24 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
       const resultPath = join(trialDir, TRIAL_RESULT);
       const hostEventsPath = join(trialDir, TRIAL_RUNTIME_EVENTS);
 
-      // Evidence before wording: Harbor's single_step.py runs the verifier after
-      // *any* agent-phase exception, so the trial's grade — not the exception's
-      // phrasing — decides whether a trial was settled. Read the artifacts for
-      // every exception shape, and only fall back to the budget-shaped message
-      // regexes when the evidence is incomplete.
+      // Two facts decide an abnormally ended trial, in this order: who ended the
+      // agent phase (classifyTrialTermination, from the harness's own exception
+      // class) and whether the verifier reached a verdict. Harbor's
+      // single_step.py runs the verifier after any agent-phase exception, so an
+      // agent-owned termination can still carry an authoritative reward. An
+      // externally ended run never can — the agent did not get the run it was
+      // given — so its artifacts are not evidence and it stays infra below.
       const trialException = await readTrialException(resultPath);
+      const termination = classifyTrialTermination(trialException);
       let completeTimedOutTrial = false;
       let verifierSettledTrial = false;
-      if (trialException) {
+      if (termination === 'agent_budget' || termination === 'agent_exit') {
         const [rewardArtifact, verifierArtifact, cellArtifact] = await Promise.all([
           readOptionalText(rewardPath),
           readOptionalText(join(trialDir, TRIAL_VERIFIER_OUTCOME)),
           readOptionalText(cellOutputPath),
         ]);
-        const settledByEvidence =
-          rewardArtifact !== null &&
-          cellArtifact !== null &&
-          hasConclusiveVerifierOutcome(verifierArtifact);
-        if (isBudgetExhaustedTrialException(trialException)) {
+        if (termination === 'agent_budget') {
           if (rewardArtifact === null || verifierArtifact === null || cellArtifact === null) {
             const artifactRefs = await readTimedOutTrialArtifacts(
               trialDir,
@@ -401,7 +408,7 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
             );
             throw new FixedPromptBudgetExhaustedError(
               `agent budget exhausted for task ${input.task.id}`,
-              trialException,
+              formatTrialException(trialException),
               artifactRefs || providerTelemetry.length > 0
                 ? {
                     ...(artifactRefs ?? {}),
@@ -412,10 +419,14 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
           }
           completeTimedOutTrial = true;
         } else {
-          // An unrecognized exception shape that the verifier still graded is a
-          // real result: keep the cell's own status/errorClass (no fabricated
-          // deadline settlement) and let the structured verifier grade score it.
-          verifierSettledTrial = settledByEvidence;
+          // The agent's own process exited non-zero and the verifier graded the
+          // workspace it left: a real result. Keep the cell's own status and
+          // errorClass — nothing here is a deadline, so nothing may claim one —
+          // and let the structured verifier grade score it.
+          verifierSettledTrial =
+            rewardArtifact !== null &&
+            cellArtifact !== null &&
+            hasConclusiveVerifierOutcome(verifierArtifact);
         }
       }
       if (result.exitCode !== 0 && !completeTimedOutTrial && !verifierSettledTrial) {
@@ -429,11 +440,11 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
       }
       const terminalProviderRequest = incompleteTerminalProviderRequest(
         providerTelemetry,
-        completeTimedOutTrial,
+        completeTimedOutTrial || verifierSettledTrial,
       );
       if (terminalProviderRequest) {
         throw new HarborInfraError(
-          `terminal provider request did not complete for task ${input.task.id}`,
+          `terminal provider request did not complete for task ${input.task.id}${trialExceptionSuffix(trialException)}`,
           [
             `outcome=${terminalProviderRequest.outcome}`,
             terminalProviderRequest.status !== undefined
@@ -1540,14 +1551,14 @@ async function readReward(rewardPath: string, resultPath: string, taskId: string
   } catch (error) {
     const trialException = await readTrialException(resultPath);
     if (trialException) {
-      if (isBudgetExhaustedTrialException(trialException)) {
+      if (classifyTrialTermination(trialException) === 'agent_budget') {
         throw new FixedPromptBudgetExhaustedError(
           `host cell budget exhausted for task ${taskId}`,
-          trialException,
+          formatTrialException(trialException),
         );
       }
       throw new HarborInfraError(
-        `Harbor trial failed before verifier reward for task ${taskId}: ${trialException}`,
+        `Harbor trial failed before verifier reward for task ${taskId}: ${formatTrialException(trialException)}`,
         errorText(error),
       );
     }
@@ -1564,12 +1575,22 @@ async function readReward(rewardPath: string, resultPath: string, taskId: string
   return reward;
 }
 
+/** How the agent phase ended, kept structured. Both harnesses record it in the
+ * trial result's `exception_info` in the same shape, and `exception_type` is
+ * Python's `type(e).__name__` — the harness's own exception classes, which are
+ * a stable fact. Flattening this to one string is what forced every downstream
+ * decision to re-derive the type by matching prose. */
+export interface TrialException {
+  type: string;
+  message: string;
+}
+
 /** Shared across runners: both harnesses record how the agent phase ended in
  * the trial result's `exception_info`, in the same shape. */
 export async function readTrialException(
   resultPath: string,
   fallbackType = 'HarborTrialError',
-): Promise<string | null> {
+): Promise<TrialException | null> {
   let raw: string;
   try {
     raw = await readFile(resultPath, 'utf8');
@@ -1589,24 +1610,53 @@ export async function readTrialException(
     typeof exceptionInfo.exception_type === 'string' ? exceptionInfo.exception_type : fallbackType;
   const message =
     typeof exceptionInfo.exception_message === 'string' ? exceptionInfo.exception_message : '';
-  return message ? `${type}: ${message}` : type;
+  return { type, message };
 }
 
-/** Shared across runners: the trial exceptions that mean the agent budget ran out (host cell deadline or harness AgentTimeoutError). */
-export function isBudgetExhaustedTrialException(message: string): boolean {
-  return (
-    /^RuntimeError: Maka host cell exceeded \d+(?:\.\d+)?s$/.test(message) ||
-    /^AgentTimeoutError: Agent execution timed out after \d+(?:\.\d+)? seconds$/.test(message)
-  );
+/** The `Type: message` rendering used in diagnostics. */
+export function formatTrialException(exception: TrialException | null): string | undefined {
+  if (!exception) return undefined;
+  return exception.message ? `${exception.type}: ${exception.message}` : exception.type;
 }
 
-/** Shared across runners: a verifier outcome is authoritative evidence that the
- * trial was graded only when it reached a verdict. `candidate_timeout` and
- * `infra_failed` say the verifier itself did not conclude, so they never settle
- * a trial whose agent phase already ended abnormally. Unreadable or malformed
- * text is treated as no evidence — the caller's own reader raises the precise
- * diagnosis on the paths that require a verdict. */
-export function hasConclusiveVerifierOutcome(raw: string | null): boolean {
+/** Who ended the agent phase — the one fact that decides whether an abnormally
+ * ended trial can be scored at all.
+ *
+ * - `agent_budget`: the agent ran out of its own time. Harbor raises its own
+ *   `AgentTimeoutError` class, so the type alone is unambiguous; the host cell's
+ *   deadline arrives as a generic `RuntimeError`, so that one still needs its
+ *   message — legitimately, because this repo raises it (harbor/maka_agent.py)
+ *   and `harbor-adapter.test.ts` pins the two ends together.
+ * - `agent_exit`: the agent's own process ended non-zero. That is the agent's
+ *   behavior, so a verifier verdict on the workspace it left is a real result.
+ * - `external`: the harness, container, or anything else ended the run. The
+ *   agent never got the run it was given, so no artifact on disk makes it a
+ *   fair sample. Unrecognized types land here on purpose: an unknown terminator
+ *   is not evidence of a fair trial, and the recognized budget shapes are
+ *   matched by type, so nothing regresses when upstream rewords a message. */
+export type TrialTerminationOwner = 'agent_budget' | 'agent_exit' | 'external';
+
+const HOST_CELL_DEADLINE_MESSAGE = /^Maka host cell exceeded \d+(?:\.\d+)?s$/;
+
+/** Shared across runners. */
+export function classifyTrialTermination(
+  exception: TrialException | null,
+): TrialTerminationOwner | null {
+  if (!exception) return null;
+  if (exception.type === 'AgentTimeoutError') return 'agent_budget';
+  if (exception.type === 'RuntimeError' && HOST_CELL_DEADLINE_MESSAGE.test(exception.message))
+    return 'agent_budget';
+  if (exception.type === 'NonZeroAgentExitCodeError') return 'agent_exit';
+  return 'external';
+}
+
+/** A verifier outcome is authoritative evidence that the trial was graded only
+ * when it reached a verdict. `candidate_timeout` and `infra_failed` say the
+ * verifier itself did not conclude, so they never settle a trial whose agent
+ * phase already ended abnormally. Unreadable or malformed text is treated as no
+ * evidence — the caller's own reader raises the precise diagnosis on the paths
+ * that require a verdict. */
+function hasConclusiveVerifierOutcome(raw: string | null): boolean {
   if (raw === null) return false;
   let parsed: unknown;
   try {
@@ -1620,9 +1670,10 @@ export function hasConclusiveVerifierOutcome(raw: string | null): boolean {
 
 /** Names the trial exception inside an infra error message. The WAL keeps only
  * the message, so an exception that never reaches it cannot be found by grep. */
-export function trialExceptionSuffix(trialException: string | null): string {
-  if (!trialException) return '';
-  const collapsed = trialException.replace(/\s+/g, ' ').trim();
+export function trialExceptionSuffix(trialException: TrialException | null): string {
+  const rendered = formatTrialException(trialException);
+  if (!rendered) return '';
+  const collapsed = rendered.replace(/\s+/g, ' ').trim();
   const truncated = collapsed.length > 200 ? `${collapsed.slice(0, 200)}…` : collapsed;
   return ` (trial exception: ${truncated})`;
 }

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -373,37 +373,57 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
       const resultPath = join(trialDir, TRIAL_RESULT);
       const hostEventsPath = join(trialDir, TRIAL_RUNTIME_EVENTS);
 
+      // Evidence before wording: Harbor's single_step.py runs the verifier after
+      // *any* agent-phase exception, so the trial's grade — not the exception's
+      // phrasing — decides whether a trial was settled. Read the artifacts for
+      // every exception shape, and only fall back to the budget-shaped message
+      // regexes when the evidence is incomplete.
       const trialException = await readTrialException(resultPath);
       let completeTimedOutTrial = false;
-      if (trialException && isBudgetExhaustedTrialException(trialException)) {
+      let verifierSettledTrial = false;
+      if (trialException) {
         const [rewardArtifact, verifierArtifact, cellArtifact] = await Promise.all([
           readOptionalText(rewardPath),
           readOptionalText(join(trialDir, TRIAL_VERIFIER_OUTCOME)),
           readOptionalText(cellOutputPath),
         ]);
-        if (rewardArtifact === null || verifierArtifact === null || cellArtifact === null) {
-          const artifactRefs = await readTimedOutTrialArtifacts(
-            trialDir,
-            input.task.id,
-            runnerOptions.agent,
-            harborTraceMode(runnerOptions.agentEnv),
-          );
-          throw new FixedPromptBudgetExhaustedError(
-            `agent budget exhausted for task ${input.task.id}`,
-            trialException,
-            artifactRefs || providerTelemetry.length > 0
-              ? {
-                  ...(artifactRefs ?? {}),
-                  ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
-                }
-              : undefined,
-          );
+        const settledByEvidence =
+          rewardArtifact !== null &&
+          cellArtifact !== null &&
+          hasConclusiveVerifierOutcome(verifierArtifact);
+        if (isBudgetExhaustedTrialException(trialException)) {
+          if (rewardArtifact === null || verifierArtifact === null || cellArtifact === null) {
+            const artifactRefs = await readTimedOutTrialArtifacts(
+              trialDir,
+              input.task.id,
+              runnerOptions.agent,
+              harborTraceMode(runnerOptions.agentEnv),
+            );
+            throw new FixedPromptBudgetExhaustedError(
+              `agent budget exhausted for task ${input.task.id}`,
+              trialException,
+              artifactRefs || providerTelemetry.length > 0
+                ? {
+                    ...(artifactRefs ?? {}),
+                    ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
+                  }
+                : undefined,
+            );
+          }
+          completeTimedOutTrial = true;
+        } else {
+          // An unrecognized exception shape that the verifier still graded is a
+          // real result: keep the cell's own status/errorClass (no fabricated
+          // deadline settlement) and let the structured verifier grade score it.
+          verifierSettledTrial = settledByEvidence;
         }
-        completeTimedOutTrial = true;
       }
-      if (result.exitCode !== 0 && !completeTimedOutTrial) {
+      if (result.exitCode !== 0 && !completeTimedOutTrial && !verifierSettledTrial) {
         throw new HarborInfraError(
-          `harbor run exited ${result.exitCode} for task ${input.task.id}`,
+          // WAL records only the message, so name the trial exception here: an
+          // infra bucket that silently swallows every timeout shape is exactly
+          // how the previous wording regression stayed invisible.
+          `harbor run exited ${result.exitCode} for task ${input.task.id}${trialExceptionSuffix(trialException)}`,
           tail(result.stderr || result.stdout),
         );
       }
@@ -1578,6 +1598,33 @@ export function isBudgetExhaustedTrialException(message: string): boolean {
     /^RuntimeError: Maka host cell exceeded \d+(?:\.\d+)?s$/.test(message) ||
     /^AgentTimeoutError: Agent execution timed out after \d+(?:\.\d+)? seconds$/.test(message)
   );
+}
+
+/** Shared across runners: a verifier outcome is authoritative evidence that the
+ * trial was graded only when it reached a verdict. `candidate_timeout` and
+ * `infra_failed` say the verifier itself did not conclude, so they never settle
+ * a trial whose agent phase already ended abnormally. Unreadable or malformed
+ * text is treated as no evidence — the caller's own reader raises the precise
+ * diagnosis on the paths that require a verdict. */
+export function hasConclusiveVerifierOutcome(raw: string | null): boolean {
+  if (raw === null) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+  if (!isRecord(parsed)) return false;
+  return parsed.outcome === 'passed' || parsed.outcome === 'failed';
+}
+
+/** Names the trial exception inside an infra error message. The WAL keeps only
+ * the message, so an exception that never reaches it cannot be found by grep. */
+export function trialExceptionSuffix(trialException: string | null): string {
+  if (!trialException) return '';
+  const collapsed = trialException.replace(/\s+/g, ' ').trim();
+  const truncated = collapsed.length > 200 ? `${collapsed.slice(0, 200)}…` : collapsed;
+  return ` (trial exception: ${truncated})`;
 }
 
 /** Shared across runners: the same adapters write the same maka-cell-output.json

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -17,7 +17,6 @@ import {
   harborTraceMode,
   hostTraceEventsPath,
   isBudgetExhaustedError,
-  isBudgetExhaustedTrialException,
   mergeAgentEnv,
   modelIdForProvider,
   providerProxyApiProtocol,
@@ -26,6 +25,8 @@ import {
   providerTokenSummary,
   readCellOutput,
   readTimedOutTrialArtifacts,
+  classifyTrialTermination,
+  formatTrialException,
   readTrialException,
   resolveNativeTrialTimeoutMs,
   trialExceptionSuffix,
@@ -492,28 +493,25 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       // then unconditionally runs verification, so an exceptional trial can
       // still carry an authoritative reward. Mirror Harbor's authority order
       // exactly: an ungraded budget exhaustion is a budget_exhausted outcome;
-      // every other exception falls through to the normal reward/cell reads —
-      // a graded trial scores on its actual reward (e.g. a non-zero Kimi CLI
-      // exit the verifier still passed), and missing artifacts become infra
-      // there, with the trial exception attached for diagnosis. Reading the
-      // grade for every exception shape is what makes that fall-through real:
-      // pier's own non-zero exit must not discard a trial the verifier graded.
+      // an agent-owned exit the verifier graded scores on its actual reward
+      // (e.g. a non-zero Kimi CLI exit the verifier still passed), whatever
+      // pier's own exit code was; and an externally ended run is infra however
+      // complete its artifacts look, because the agent never got the run it was
+      // given. The trial exception rides along for diagnosis.
       const trialException = await readTrialException(
         join(trialDir, TRIAL_RESULT),
         'PierTrialError',
       );
+      const termination = classifyTrialTermination(trialException);
       let completeTimedOutTrial = false;
       let verifierSettledTrial = false;
-      if (trialException) {
+      if (termination === 'agent_budget' || termination === 'agent_exit') {
         const [grade, cellArtifact] = await Promise.all([
           readPierGrade(trialDir, input.task.id),
           readOptionalText(join(trialDir, TRIAL_CELL_OUTPUT)),
         ]);
         const settledByEvidence = grade.state === 'graded' && cellArtifact !== null;
-        if (!isBudgetExhaustedTrialException(trialException)) {
-          // An unrecognized exception shape the verifier still graded is a real
-          // result, whatever pier's own exit code was: keep the cell's status and
-          // score on the recorded reward instead of discarding the trial as infra.
+        if (termination === 'agent_exit') {
           verifierSettledTrial = settledByEvidence;
         } else {
           // Budget-gate context, distinct from the graded read path: the agent has
@@ -539,7 +537,9 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
               // Carry the invalid-grade detail alongside the exhaustion cause so a
               // corrupt/crashed verifier is still diagnosable, without letting it
               // count toward the score.
-              grade.state === 'invalid' ? `${trialException}; ${grade.detail}` : trialException,
+              grade.state === 'invalid'
+                ? `${formatTrialException(trialException)}; ${grade.detail}`
+                : formatTrialException(trialException),
               artifactRefs || providerTelemetry.length > 0
                 ? {
                     ...(artifactRefs ?? {}),
@@ -563,11 +563,11 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       // last provider request is infra, never a graded model failure.
       const terminalProviderRequest = incompleteTerminalProviderRequest(
         providerTelemetry,
-        completeTimedOutTrial,
+        completeTimedOutTrial || verifierSettledTrial,
       );
       if (terminalProviderRequest) {
         throw new PierInfraError(
-          `terminal provider request did not complete for task ${input.task.id}`,
+          `terminal provider request did not complete for task ${input.task.id}${trialExceptionSuffix(trialException)}`,
           [
             `outcome=${terminalProviderRequest.outcome}`,
             terminalProviderRequest.status !== undefined
@@ -581,7 +581,11 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
         );
       }
 
-      const reward = await readPierReward(trialDir, input.task.id, trialException);
+      const reward = await readPierReward(
+        trialDir,
+        input.task.id,
+        formatTrialException(trialException),
+      );
       const rawCell = await readCellOutput(
         join(trialDir, TRIAL_CELL_OUTPUT),
         input.task.id,
@@ -1106,7 +1110,7 @@ function classifyPierReward(reward: number, taskId: string): PierGrade {
 async function readPierReward(
   trialDir: string,
   taskId: string,
-  trialException: string | null,
+  trialException: string | undefined,
 ): Promise<number> {
   const grade = await readPierGrade(trialDir, taskId);
   if (grade.state === 'graded') return grade.reward;

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -28,6 +28,7 @@ import {
   readTimedOutTrialArtifacts,
   readTrialException,
   resolveNativeTrialTimeoutMs,
+  trialExceptionSuffix,
   withProviderTelemetryArtifact,
   incompleteTerminalProviderRequest,
   modelForOpenCode,
@@ -494,54 +495,67 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       // every other exception falls through to the normal reward/cell reads —
       // a graded trial scores on its actual reward (e.g. a non-zero Kimi CLI
       // exit the verifier still passed), and missing artifacts become infra
-      // there, with the trial exception attached for diagnosis.
+      // there, with the trial exception attached for diagnosis. Reading the
+      // grade for every exception shape is what makes that fall-through real:
+      // pier's own non-zero exit must not discard a trial the verifier graded.
       const trialException = await readTrialException(
         join(trialDir, TRIAL_RESULT),
         'PierTrialError',
       );
       let completeTimedOutTrial = false;
-      if (trialException && isBudgetExhaustedTrialException(trialException)) {
+      let verifierSettledTrial = false;
+      if (trialException) {
         const [grade, cellArtifact] = await Promise.all([
           readPierGrade(trialDir, input.task.id),
           readOptionalText(join(trialDir, TRIAL_CELL_OUTPUT)),
         ]);
-        // Budget-gate context, distinct from the graded read path: the agent has
-        // already exhausted its budget, which is the authoritative fact. A
-        // verifier that crashed or wrote a corrupt reward here does NOT overturn
-        // it — an `invalid` grade is treated exactly like `ungraded` / a missing
-        // reward file, yielding budget_exhausted (no retry, Pass@1 evidence
-        // preserved) rather than an infra failure the controller would retry. In
-        // the graded read path a corrupt scoring authority IS infra; only when
-        // the budget is already spent does the agent fact take precedence.
-        if (grade.state !== 'graded' || cellArtifact === null) {
-          // Recover attested evidence (identity/usage/cell output) via the shared
-          // Harbor implementation so a budget-exhausted sample keeps its Pass@1
-          // eligibility instead of being excluded as missing_execution_identity.
-          const artifactRefs = await readTimedOutTrialArtifacts(
-            trialDir,
-            input.task.id,
-            agent,
-            harborTraceMode(attemptAgentEnv),
-          );
-          throw new FixedPromptBudgetExhaustedError(
-            `agent budget exhausted for task ${input.task.id}`,
-            // Carry the invalid-grade detail alongside the exhaustion cause so a
-            // corrupt/crashed verifier is still diagnosable, without letting it
-            // count toward the score.
-            grade.state === 'invalid' ? `${trialException}; ${grade.detail}` : trialException,
-            artifactRefs || providerTelemetry.length > 0
-              ? {
-                  ...(artifactRefs ?? {}),
-                  ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
-                }
-              : undefined,
-          );
+        const settledByEvidence = grade.state === 'graded' && cellArtifact !== null;
+        if (!isBudgetExhaustedTrialException(trialException)) {
+          // An unrecognized exception shape the verifier still graded is a real
+          // result, whatever pier's own exit code was: keep the cell's status and
+          // score on the recorded reward instead of discarding the trial as infra.
+          verifierSettledTrial = settledByEvidence;
+        } else {
+          // Budget-gate context, distinct from the graded read path: the agent has
+          // already exhausted its budget, which is the authoritative fact. A
+          // verifier that crashed or wrote a corrupt reward here does NOT overturn
+          // it — an `invalid` grade is treated exactly like `ungraded` / a missing
+          // reward file, yielding budget_exhausted (no retry, Pass@1 evidence
+          // preserved) rather than an infra failure the controller would retry. In
+          // the graded read path a corrupt scoring authority IS infra; only when
+          // the budget is already spent does the agent fact take precedence.
+          if (!settledByEvidence) {
+            // Recover attested evidence (identity/usage/cell output) via the shared
+            // Harbor implementation so a budget-exhausted sample keeps its Pass@1
+            // eligibility instead of being excluded as missing_execution_identity.
+            const artifactRefs = await readTimedOutTrialArtifacts(
+              trialDir,
+              input.task.id,
+              agent,
+              harborTraceMode(attemptAgentEnv),
+            );
+            throw new FixedPromptBudgetExhaustedError(
+              `agent budget exhausted for task ${input.task.id}`,
+              // Carry the invalid-grade detail alongside the exhaustion cause so a
+              // corrupt/crashed verifier is still diagnosable, without letting it
+              // count toward the score.
+              grade.state === 'invalid' ? `${trialException}; ${grade.detail}` : trialException,
+              artifactRefs || providerTelemetry.length > 0
+                ? {
+                    ...(artifactRefs ?? {}),
+                    ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
+                  }
+                : undefined,
+            );
+          }
+          completeTimedOutTrial = true;
         }
-        completeTimedOutTrial = true;
       }
-      if (result.exitCode !== 0 && !completeTimedOutTrial) {
+      if (result.exitCode !== 0 && !completeTimedOutTrial && !verifierSettledTrial) {
         throw new PierInfraError(
-          `pier run exited ${result.exitCode} for task ${input.task.id}`,
+          // The WAL keeps only the message, so the trial exception has to travel
+          // in it or an infra bucket full of timeouts stays invisible to grep.
+          `pier run exited ${result.exitCode} for task ${input.task.id}${trialExceptionSuffix(trialException)}`,
           tail(result.stderr || result.stdout),
         );
       }


### PR DESCRIPTION
## Summary

A benchmark trial whose agent phase ended abnormally was classified by the *wording* of its exception. `isBudgetExhaustedTrialException` matched two pinned messages; only on a match did the runner read the reward / verifier outcome / cell output. Everything else hit the `exitCode !== 0` gate and was thrown as infra — dropped from the Pass@1 denominator — even though both harnesses run the verifier after an agent-phase exception, so the reward was already on disk.

The root defect is narrower than "the regexes are brittle": the termination reason **arrives typed** and was being thrown away. Harbor records `exception_type` as Python's `type(e).__name__` (`harbor/models/trial/result.py:31`), and `readTrialException` flattened it to `"Type: message"` before any caller could use it. Every downstream decision — the regexes, the exit-code gate, the settle predicate — was re-deriving that discarded fact by matching prose.

So keep it structured. Classification now reads two facts, who ended the agent phase and whether the verifier reached a verdict:

| | verdict | no verdict |
|---|---|---|
| **agent-owned** (`AgentTimeoutError`, host-cell deadline, `NonZeroAgentExitCodeError`) | scored | `budget_exhausted` |
| **external** (Docker, harness, unrecognized) | infra (on a non-zero exit) | infra |

- `agent_budget` — Harbor's own `AgentTimeoutError` class is unambiguous by type. The host cell's deadline arrives as a generic `RuntimeError`, so it is the one termination still matched by message; that is sound only because this repo raises it (`harbor/maka_agent.py`) and `harbor-adapter.test.ts` pins both ends together.
- `agent_exit` — `NonZeroAgentExitCodeError` is the agent's own process ending, so a verdict on the workspace it left is a real result whatever the exit code. Nothing fabricates a `deadlineSettlement` for it; `taskCompletedScoringProjection` already scores on `verifierGrade !== undefined`, so the cell keeps its honest `status` / `errorClass`.
- `external` — unrecognized types land here deliberately. The recognized budget shapes are matched by type, so nothing regresses when upstream rewords a message.

**The terminal-provider-request gate had the same defect in miniature.** A boolean "this trial settled" exempted *every* non-completing tail request. Only a client-side teardown (`aborted`, set from `signal.aborted`) is explained by the agent phase ending — `interrupted` and `failed` are the upstream's doing and now stay infra however the trial settled. This tightens the pre-existing budget path in the safe direction: a provider outage is excluded from the denominator rather than recorded as the agent's zero.

**Arm symmetry.** `claude_code_agent.py` never emitted `deadlineSettlement` — not a missing assignment but a missing field in `_write_cell_output` — so the same termination was labelled `budget_exhausted` for Codex and a plain runtime failure for Claude Code. Both arms now report it, pinned by extending the existing `cancel_codex()` behavioral seam rather than by matching adapter source text.

Infra errors now name the trial exception in their **message**. The WAL persists only `error: errorMessage(...)` and drops `detail`, which is why 225 infra events in the current run carried no trace of the timeouts inside them.

Refs #1970. Independent of #2047.

## Verification

- `npm run test -w @maka/headless` — 1337 pass / 1 skip, three consecutive runs (baseline 1326 pass / 1 skip).
- `npm run lint`, `npm run format` — clean.
- Mutation battery, 12 mutations, each caught: every branch of `classifyTrialTermination`; both conjuncts of the settle predicate; the terminal gate exempting everything / exempting nothing; pier settling external types; and the three adapter mutations a source regex could not see (flag moved into `finally`, emission guard inverted, emission deleted).

## Review focus

Six independent reviews (deepseek-v4-flash via `pi`; two rounds × design / correctness / test-quality lenses) returned no P0 or P1. The round-one convergent finding — that the terminal-provider-request gate silently undid the fix — is addressed above. Round two's strongest finding was that the arm-symmetry test was a source-text proxy when an executable seam already existed; that is now fixed, and the two semantic mutations that defeated the regex are pinned.

Known and deliberately not addressed here:

- **`external` is narrower than it looks.** Both harnesses catch only `(AgentTimeoutError, NonZeroAgentExitCodeError)` in `_run_agent` and reach `_run_verifier()` only from there (`harbor/trial/single_step.py:75-86`, `trial/trial.py:286-305`); any other exception routes to `_recover_outputs()`, which does not run the verifier. So a conclusive verdict on disk is *already* evidence of an agent-owned termination, and both harnesses exit 0 on a recorded agent-phase exception. The `external` row therefore fires mainly on the non-zero-exit path. Collapsing it — letting evidence decide scoring, telemetry decide fairness, and type decide only the label — is the smaller structure, but it is a fourth restructure on the eve of a full rerun and is not worth the risk tonight.
- **Pier's `NonZeroAgentExitCodeError` has a subclass hierarchy** (`ApiRateLimitError`, `ContextWindowExceededError`, `AgentSafetyRefusalError`, …) that `type(e).__name__` records as leaf names, so `agent_exit` does not reach them. Not a regression — they behave exactly as on `main` — but the improvement does not reach the Pier arms. The collapse above would fix this for free.
- **The `aborted` discriminator is event-order dependent.** If a connection dies in the same instant as the agent kill, the proxy may record `failed`/`interrupted` before `signal.aborted` is set. The right owner is the proxy (classify teardown by client-connection state, not by which error arrives first), not the runner gate.
- **`harbor/maka_agent.py` still raises a generic `RuntimeError`** for the host-cell deadline, so one message regex survives. A distinct exception class would remove it, but that is a cross-language contract change and a mistake there silently reclassifies timeouts as external.