### PR TITLE
test(runtime): drive the shell-run flush timer from the test instead of the wall clock

### DIFF
--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -18,7 +18,10 @@ import {
 import { createSqliteShellRunStore } from '@maka/storage';
 
 import { ShellRunProcessManager } from '../shell-run-manager.js';
-import { ShellRunPtyControlClosedError } from '../shell-run-contract.js';
+import {
+  ShellRunPtyControlClosedError,
+  type ShellRunProcessManagerInput,
+} from '../shell-run-contract.js';
 import { defaultShellPlan, type ShellPlan } from '../shell-detect.js';
 import { PTY_PROTOCOL_REPLY_MAX_BYTES } from '../pty-screen-collector.js';
 
@@ -1605,7 +1608,13 @@ describe('ShellRunProcessManager', () => {
     const cwd = await workspace();
     const dirtyWritten = join(cwd, 'dirty-written');
     const store = createSqliteShellRunStore(await workspace());
-    const manager = createManager(store, undefined, { flushIntervalMs: 1_000 });
+    // The test owns flush timing: no automatic flush fires until it says so, so the
+    // "not yet committed" window cannot be closed by a periodic flush racing the clock.
+    const flushes = manualFlushScheduler();
+    const manager = createManager(store, undefined, {
+      flushIntervalMs: 60_000,
+      scheduleFlush: flushes.schedule,
+    });
     const initial = await manager.runBackgroundBash(
       shellInput({
         cwd,
@@ -1668,6 +1677,10 @@ describe('ShellRunProcessManager', () => {
       abort.abort();
       await assert.rejects(control, /aborted before the control operation was committed/);
 
+      // The contract: the aborted control restores the trailing flush instead of
+      // dropping it, so a flush is pending again and commits the PTY output once it runs.
+      await waitUntil(() => flushes.pending());
+      flushes.runPending();
       await waitUntil(async () => {
         const durable = await store.readShellRun('session-1', 'shell-run-1');
         return (
@@ -2241,6 +2254,7 @@ function createManager(
     killGraceMs?: number;
     flushIntervalMs?: number;
     pipeOutputDrainMs?: number;
+    scheduleFlush?: ShellRunProcessManagerInput['scheduleFlush'];
   } = {},
 ): ShellRunProcessManager {
   let id = 0;
@@ -2255,6 +2269,27 @@ function createManager(
     ...(onShellRunUpdate ? { onShellRunUpdate } : {}),
     ...options,
   });
+}
+
+/** Holds automatic flushes until the test runs them, replacing wall-clock flush timing. */
+function manualFlushScheduler(): {
+  schedule: (run: () => void, delayMs: number) => () => void;
+  pending: () => boolean;
+  runPending: () => void;
+} {
+  const pending = new Set<() => void>();
+  return {
+    schedule: (run) => {
+      pending.add(run);
+      return () => pending.delete(run);
+    },
+    pending: () => pending.size > 0,
+    runPending: () => {
+      const due = [...pending];
+      pending.clear();
+      for (const run of due) run();
+    },
+  };
 }
 
 async function createTestManager(

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -1639,7 +1639,9 @@ describe('ShellRunProcessManager', () => {
         setInterval(() => {}, 1000);
       `),
         pty: true,
-        timeoutMs: 5_000,
+        // Far past the test's own waits: a run timeout would finalize the record and
+        // advance the revision the assertions below pin.
+        timeoutMs: 120_000,
       }),
     );
     assert.equal(initial.kind, 'shell_run');

--- a/packages/runtime/src/shell-run-contract.ts
+++ b/packages/runtime/src/shell-run-contract.ts
@@ -53,6 +53,8 @@ export interface ShellRunProcessManagerInput {
   killGraceMs?: number;
   exitAcknowledgementMs?: number;
   pipeOutputDrainMs?: number;
+  /** Schedules the automatic durable flush and returns its canceler; injected so tests can drive flush timing. */
+  scheduleFlush?: (run: () => void, delayMs: number) => () => void;
 }
 
 export interface ShellRunBashInput {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -154,7 +154,7 @@ interface LiveShellRunBase {
   termination?: TerminationLifecycle;
   pendingStops: Set<PendingStop>;
   timeoutTimer?: NodeJS.Timeout;
-  flushTimer?: NodeJS.Timeout;
+  cancelFlush?: () => void;
   flushInFlight?: Promise<ShellRunRecord>;
   persistChain: Promise<void>;
   persistFailure?: Error;
@@ -228,6 +228,7 @@ export class ShellRunProcessManager
   private readonly killGraceMs: number;
   private readonly exitAcknowledgementMs: number;
   private readonly pipeOutputDrainMs: number;
+  private readonly scheduleFlush: (run: () => void, delayMs: number) => () => void;
   private reservedShellRuns = 0;
   private reservedPtyRuns = 0;
   private shuttingDown = false;
@@ -243,6 +244,12 @@ export class ShellRunProcessManager
     this.exitAcknowledgementMs =
       input.exitAcknowledgementMs ?? DEFAULT_PROCESS_TERMINATION_GRACE_MS;
     this.pipeOutputDrainMs = input.pipeOutputDrainMs ?? DEFAULT_PIPE_OUTPUT_DRAIN_MS;
+    this.scheduleFlush =
+      input.scheduleFlush ??
+      ((run, delayMs) => {
+        const timer = setTimeout(run, delayMs);
+        return () => clearTimeout(timer);
+      });
   }
 
   async runBackgroundBash(input: ShellRunBashInput): Promise<ShellRunToolResult> {
@@ -918,13 +925,13 @@ export class ShellRunProcessManager
   private scheduleAutomaticFlush(live: LiveShellRun): void {
     if (live.finalizeOnce || live.driverExit || live.integrityFailure || live.persistFailure)
       return;
-    if (live.flushInFlight || live.flushTimer) return;
+    if (live.flushInFlight || live.cancelFlush) return;
     if (live.mode === 'pipes') {
       if (live.pendingFlushChars >= this.flushBytes) {
         this.queueAutomaticFlush(live);
       } else {
-        live.flushTimer = setTimeout(() => {
-          live.flushTimer = undefined;
+        live.cancelFlush = this.scheduleFlush(() => {
+          live.cancelFlush = undefined;
           this.queueAutomaticFlush(live);
         }, this.flushIntervalMs);
       }
@@ -934,8 +941,8 @@ export class ShellRunProcessManager
     const delay = Math.max(0, this.flushIntervalMs - elapsed);
     if (delay === 0) this.queueAutomaticFlush(live);
     else {
-      live.flushTimer = setTimeout(() => {
-        live.flushTimer = undefined;
+      live.cancelFlush = this.scheduleFlush(() => {
+        live.cancelFlush = undefined;
         this.queueAutomaticFlush(live);
       }, delay);
     }
@@ -969,9 +976,9 @@ export class ShellRunProcessManager
     snapshotBarrier?: Promise<SnapshotAtCut | undefined>,
   ): Promise<ShellRunRecord> {
     if (live.integrityFailure || live.driverExit) return live.finished.join();
-    if (live.flushTimer) {
-      clearTimeout(live.flushTimer);
-      live.flushTimer = undefined;
+    if (live.cancelFlush) {
+      live.cancelFlush();
+      live.cancelFlush = undefined;
     }
     if (live.mode === 'pipes') live.pendingFlushChars = 0;
     const task = this.queuePersist(live, {}, snapshotBarrier ? { snapshotBarrier } : {});
@@ -1675,9 +1682,9 @@ export class ShellRunProcessManager
 
   private clearLiveTimers(live: LiveShellRun): void {
     if (live.timeoutTimer) clearTimeout(live.timeoutTimer);
-    if (live.flushTimer) clearTimeout(live.flushTimer);
+    live.cancelFlush?.();
     live.timeoutTimer = undefined;
-    live.flushTimer = undefined;
+    live.cancelFlush = undefined;
   }
 
   private sessionTerminationEpoch(sessionId: string): number {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -937,15 +937,16 @@ export class ShellRunProcessManager
       }
       return;
     }
+    // Real elapsed time, not the injected `now()`: this paces flushes against the wall
+    // clock, while `now()` only stamps records and is a plain counter under test.
     const elapsed = Date.now() - live.lastSnapshotWallTime;
-    const delay = Math.max(0, this.flushIntervalMs - elapsed);
-    if (delay === 0) this.queueAutomaticFlush(live);
-    else {
-      live.cancelFlush = this.scheduleFlush(() => {
+    live.cancelFlush = this.scheduleFlush(
+      () => {
         live.cancelFlush = undefined;
         this.queueAutomaticFlush(live);
-      }, delay);
-    }
+      },
+      Math.max(0, this.flushIntervalMs - elapsed),
+    );
   }
 
   private queueAutomaticFlush(live: LiveShellRun): void {


### PR DESCRIPTION
## Summary

`restores the trailing PTY flush after a queued control aborts before commit` flaked on CI (run 30846092608, green on rerun): the manager was built with `flushIntervalMs: 1_000`, and the test waited for the child's dirty-written file before asserting the PTY output had not been committed yet. When that wait crossed the 1s periodic flush, the durable revision advanced on its own and `assert.equal(beforeAbort.revision, beforeDirty.revision)` failed.

The assertion and the periodic flush are semantically in conflict: "not committed at abort time" can only hold if nothing else commits during the window, so as long as flush timing is owned by the wall clock and the test cannot control it, the test is probabilistic. Relaxing the assertion would hide that instead of resolving it.

Root cause is that the manager has two time sources — `now()` is injected, but the automatic flush uses the global `Date.now()` + `setTimeout`. This makes the flush timer injectable so the single test that depends on flush ordering owns it:

- `ShellRunProcessManagerInput.scheduleFlush?: (run, delayMs) => () => void`, defaulting to the previous `setTimeout`/`clearTimeout`. Production behavior is unchanged.
- `LiveShellRunBase.flushTimer: NodeJS.Timeout` becomes `cancelFlush: () => void`, which decouples the pending-flush slot from the platform handle type.
- The test installs a manual scheduler and sets `flushIntervalMs: 60_000` (so the pty branch never takes the `delay === 0` path that flushes synchronously past the scheduler). No automatic flush can fire before the abort, so the revision and "durable output has no DIRTY" assertions are deterministic. After the abort it first asserts a flush was rescheduled, then runs it and checks the output lands.

The restore contract is now checked directly rather than inferred from a timeout: removing `scheduleAutomaticFlush(live)` from the `!snapshot` branch of `queuePersist` fails the test at the pending-flush assertion.

Deeper cleanup deliberately not done here: the manager constructs `PtyProcessDriver`/`PipeProcessDriver` itself, so every test in this file needs a real child process to verify what are internal orchestration rules. Making the driver injectable would remove wall-clock dependence from the timeout and kill-grace paths too, but that is a separate refactor and only this one test has actually flaked.

## Verification

- `node --test dist/__tests__/shell-run-manager.test.js` — 51 pass / 0 fail, 5 consecutive runs on macOS.
- Mutation check: dropping the flush restore in `queuePersist` makes the test fail at `waitUntil(() => flushes.pending())`; restoring it passes.
- Full `node --test "dist/**/*.test.js"` in `packages/runtime`: 3076 pass / 4 fail. The 4 failures are the `/private` symlink workspace-path tests and reproduce identically on unmodified `main`.
- `biome check` clean on the three touched files.
- Not run: the CI Linux job that produced the original flake.