### PR TITLE
fix(deps): clear the high-severity advisories blocking the release audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2080,12 +2080,12 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.15",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
-      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2336,12 +2336,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -7568,9 +7568,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -13035,9 +13035,9 @@
       }
     },
     "packages/headless/node_modules/undici": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.8.0.tgz",
-      "integrity": "sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -13097,9 +13097,9 @@
       }
     },
     "packages/runtime/node_modules/undici": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
-      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"


### PR DESCRIPTION
## Summary

The `Release macOS arm64` run for 0.1.4 failed at its first real gate, `npm audit --omit=dev --audit-level=high`, before it reached packaging or reserved a release identity (run [30848094969](https://github.com/maka-agent/maka-agent/actions/runs/30848094969)). Four production advisories were outstanding, two of them high:

| Package | Before | After | Severity | Advisory |
| --- | --- | --- | --- | --- |
| `undici` | 8.7.0, 8.8.0 | 8.10.0 | high ×2 | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524), [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) |
| `fast-uri` | 3.1.4 | 3.1.5 | high | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) |
| `@hono/node-server` | 1.19.15 | 2.0.12 | moderate | [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) |
| `@modelcontextprotocol/sdk` | 1.29.0 | 1.30.0 | moderate | depends on the above |

Lockfile only. Every fixed version already satisfies the existing declared ranges — `undici` `^8.7.0` in runtime and headless, `@modelcontextprotocol/sdk` `^1.24.3` in mcp, and `fast-uri` through `ajv`'s `^3.0.1` — so no `package.json` changes are needed. SDK 1.30.0 widens its own range to `^1.19.9 || ^2.0.5`, which is what lets `@hono/node-server` move off the vulnerable line. `@hono/node-server` 2.x requires Node >=20; the repository already requires >=22.19.0.

## Verification

- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities (was 4).
- `npm ci` then `npm run build`: clean.
- `@maka/mcp` 11/11 pass, `@maka/headless` 1337/1337 pass.
- `@maka/runtime` 3076/3089 pass. The 4 failures are `builtin-tools` workspace-containment cases that fail identically on unmodified `main` on macOS, where the temp dir resolves through the `/var` → `/private/var` symlink; they are environment-specific and unrelated to this change. CI runs on Linux and does not hit them.
- `npm run format:check` and `npm run lint`: clean.

## Review focus

`undici` moves three minors. Its use is confined to bot bridges (`WebSocket`) and the network layer (`Agent`, `ProxyAgent`, `EnvHttpProxyAgent`, `fetch`). Worth noting: `packages/headless/src/provider-auth-proxy.ts` documents the 8.7-vs-8.8 h2 multiplexing gate and deliberately forces h1 pools so it does not depend on which undici build serves the fetch — that comment stays accurate at 8.10.

## Rollout

Once this is on `main` and CI is green, re-dispatch `Release macOS arm64`. The failed run stopped before `Resolve and reserve release identity`, so the `v0.1.4` tag and release name are still unused and the version does not need to be bumped again.