### PR TITLE
fix(release): regenerate third-party notices for the upgraded production tree

### DIFF
--- a/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
+++ b/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
@@ -792,10 +792,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-Package: @hono/node-server@1.19.15
+Package: @hono/node-server@2.0.12
 Declared license: MIT
 Selected license: MIT
-Repository: https://github.com/honojs/node-server.git
+Repository: git+https://github.com/honojs/node-server.git
 
 --- LICENSE ---
 MIT License
@@ -1163,7 +1163,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-Package: @modelcontextprotocol/sdk@1.29.0
+Package: @modelcontextprotocol/sdk@1.30.0
 Declared license: MIT
 Selected license: MIT
 Repository: git+https://github.com/modelcontextprotocol/typescript-sdk.git
@@ -7368,7 +7368,7 @@ SOFTWARE.
 
 ================================================================================
 
-Package: fast-uri@3.1.4
+Package: fast-uri@3.1.5
 Declared license: BSD-3-Clause
 Selected license: BSD-3-Clause
 Repository: git+https://github.com/fastify/fast-uri.git
@@ -12447,7 +12447,7 @@ SOFTWARE.
 
 ================================================================================
 
-Package: undici@8.7.0
+Package: undici@8.10.0
 Declared license: MIT
 Selected license: MIT
 Repository: git+https://github.com/nodejs/undici.git


### PR DESCRIPTION
## Summary

#2055 upgraded four production dependencies to clear the release audit, but did not regenerate the bundled license inventory. `Release macOS arm64` run [30849279454](https://github.com/maka-agent/maka-agent/actions/runs/30849279454) then failed inside `npm run package:macos-arm64`:

```
Error: Production dependency notices are stale. Run npm run generate:third-party-notices.
```

This is the output of `npm run generate:third-party-notices`. Four version lines change, one per upgraded package:

| Package | Before | After |
| --- | --- | --- |
| `@hono/node-server` | 1.19.15 | 2.0.12 |
| `@modelcontextprotocol/sdk` | 1.29.0 | 1.30.0 |
| `fast-uri` | 3.1.4 | 3.1.5 |
| `undici` | 8.7.0 | 8.10.0 |

No package is added or removed and no declared license changes (MIT and BSD-3-Clause throughout). The `@hono/node-server` entry also normalizes its repository URL to the `git+https://` form the package now publishes.

## Verification

- `npm run check:release` — the exact command the release packaging step runs, and the one that caught this. All three gates pass: `check:stale` reports dist fresh, `check:third-party-notices` reports the inventory current, `check-dead-css` finds nothing dead.
- `npm ci` then `npm run build`: clean.
- `npm run format:check`: clean.

## Review focus

`check:release` only runs inside `npm run package:macos-arm64`, so no ordinary CI lane exercises it — #2055 was fully green and still left this stale. Any future change to the production dependency tree needs `npm run generate:third-party-notices` in the same commit, or the release fails at packaging.

## Rollout

Re-dispatch `Release macOS arm64` once this is on `main` and CI is green. The failed run stopped before `Create draft GitHub Release`, so no `v0.1.4` tag or release exists yet and the version does not need another bump.