### PR TITLE
chore(headless): bump the pinned Codex CLI to 0.146.0

### DIFF
--- a/packages/headless/src/__tests__/codex-toolchain.test.ts
+++ b/packages/headless/src/__tests__/codex-toolchain.test.ts
@@ -10,18 +10,18 @@ import {
 } from '../codex-toolchain.js';
 
 test('Codex toolchain pins the official linux/x64 CLI package and runtime files', async () => {
-  assert.equal(CODEX_TOOLCHAIN_SPEC.codex.version, '0.144.6');
+  assert.equal(CODEX_TOOLCHAIN_SPEC.codex.version, '0.146.0');
   assert.equal(
     CODEX_TOOLCHAIN_SPEC.codex.archiveIntegrity,
-    'sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==',
+    'sha512-fswvyGprAPCMiOEue/7MKMk7pCjh9kZIJfJX5i9atmfnmGYbYCcUhZsEH9LEP0+0t5xyPqDbfNXY7NSxIVuXxA==',
   );
   assert.deepEqual(CODEX_TOOLCHAIN_SPEC.codex.files, {
-    binary: 'a31ae9450a26216eb1e7c53102fd42123dd675974310b0e2ca3aa4cb622a2c15',
-    codeModeHost: 'b3c1b98e0272ed4bff2bf0459574ff5489dee3087149648e43b1b665a76373e1',
-    ripgrep: 'ebeaf56f8a25e102e9419933423738b3a2a613a444fd749d695e15eba53f71f2',
-    bubblewrap: '7df960565a0dece99240ea4b9d0e011307817f9f3b73176c7b71fda44fe84765',
+    binary: '2e863156ed35ecc5253b1e2f907a9143077b9f7cb51942070c61996471ff6e04',
+    codeModeHost: '520e0f7e2c955a591995c4437d6b10c38595c43c94fba39cef4381a00dadcb98',
+    ripgrep: 'e62198eb19b136b88c330af83647b5a962cb99b6b1f066758568f12de1974849',
+    bubblewrap: '77360cb751ccedc5971391444ac86a8a33c15b04d6b4a6fe45f5d25496e62c4c',
     zsh: '67faaaa89242c4a332e16e508a1977cffc24bf7fca31d4411cdfd101f3831ef3',
-    packageMetadata: '4415fcb6e062b567abf79960dbbd38f046ce3c8fbb1170e35fd8129d476126d8',
+    packageMetadata: '3f9cd79076d1747cba97f610475f3ad99be314a15cbf665b8d8f179c020aa353',
   });
   assert.match(CODEX_TOOLCHAIN_FINGERPRINT, /^sha256:[a-f0-9]{64}$/);
   const catalog = await readFile(

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -4487,7 +4487,7 @@ with tempfile.TemporaryDirectory() as tmp:
     agent = MakaCodexAgent(
         logs,
         prompt_template_path=template,
-        version="0.144.6",
+        version="0.146.0",
         model_name="gpt-5.6-sol",
         reasoning_effort="max",
         extra_env={
@@ -4548,7 +4548,7 @@ with tempfile.TemporaryDirectory() as tmp:
     }, requirements_command
     deepseek_agent = MakaCodexAgent(
         logs,
-        version="0.144.6",
+        version="0.146.0",
         model_name="deepseek-v4-flash",
         extra_env={"MAKA_MODEL": "deepseek-v4-flash"},
     )
@@ -4583,7 +4583,7 @@ with tempfile.TemporaryDirectory() as tmp:
 
     failing = MakaCodexAgent(
         logs,
-        version="0.144.6",
+        version="0.146.0",
         model_name="gpt-5.6-sol",
         reasoning_effort="max",
         extra_env={
@@ -4606,7 +4606,7 @@ with tempfile.TemporaryDirectory() as tmp:
 
     transport = MakaCodexAgent(
         logs,
-        version="0.144.6",
+        version="0.146.0",
         model_name="gpt-5.6-sol",
         reasoning_effort="max",
         extra_env={
@@ -4629,7 +4629,7 @@ with tempfile.TemporaryDirectory() as tmp:
 
     incomplete = MakaCodexAgent(
         logs,
-        version="0.144.6",
+        version="0.146.0",
         model_name="gpt-5.6-sol",
         reasoning_effort="max",
         extra_env={
@@ -4654,7 +4654,7 @@ with tempfile.TemporaryDirectory() as tmp:
 
     transcript = MakaCodexAgent(
         logs,
-        version="0.144.6",
+        version="0.146.0",
         model_name="deepseek-v4-flash",
         reasoning_effort="max",
         extra_env={
@@ -4672,7 +4672,7 @@ with tempfile.TemporaryDirectory() as tmp:
 
     policy = MakaCodexAgent(
         logs,
-        version="0.144.6",
+        version="0.146.0",
         model_name="gpt-5.6-sol",
         reasoning_effort="max",
         extra_env={
@@ -4727,7 +4727,7 @@ with tempfile.TemporaryDirectory() as tmp:
     timeout_environment = TimeoutEnvironment()
     timeout_agent = MakaCodexAgent(
         logs,
-        version="0.144.6",
+        version="0.146.0",
         model_name="gpt-5.6-sol",
         reasoning_effort="max",
         extra_env={

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -712,7 +712,7 @@ describe('createHarborTaskRunner', () => {
         jobsDir,
         agent: 'codex',
         codexToolchainPath: '/toolchain',
-        agentVersion: '0.144.6',
+        agentVersion: '0.146.0',
         model: 'openai/gpt-5.6-sol',
         provider: 'openai',
         reasoningEffort: 'max',
@@ -757,7 +757,7 @@ describe('createHarborTaskRunner', () => {
           jobsDir,
           agent: 'codex',
           codexToolchainPath: '/toolchain',
-          agentVersion: '0.144.6',
+          agentVersion: '0.146.0',
           model: 'openai-codex/gpt-5.6-sol',
           provider: 'openai-codex',
           reasoningEffort: 'max',
@@ -2445,8 +2445,8 @@ describe('buildHarborJobConfig', () => {
       model: 'openai/gpt-5.6-sol',
       provider: 'openai',
       reasoningEffort: 'max',
-      agentVersion: '0.144.6',
-      codexToolchainPath: '/cache/codex-0.144.6-linux-x64',
+      agentVersion: '0.146.0',
+      codexToolchainPath: '/cache/codex-0.146.0-linux-x64',
       dockerPlatform: 'linux/amd64',
     } as unknown as Parameters<typeof buildHarborJobConfig>[1]);
     const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
@@ -2456,12 +2456,12 @@ describe('buildHarborJobConfig', () => {
     assert.equal(agent.name, undefined);
     assert.equal(agent.import_path, 'codex_agent:MakaCodexAgent');
     assert.equal(agent.model_name, 'gpt-5.6-sol');
-    assert.deepEqual(agent.kwargs, { version: '0.144.6', reasoning_effort: 'max' });
+    assert.deepEqual(agent.kwargs, { version: '0.146.0', reasoning_effort: 'max' });
     assert.match(env.MAKA_CODEX_TOOLCHAIN_FINGERPRINT, /^sha256:[a-f0-9]{64}$/);
     assert.ok(
       mounts.some(
         (mount) =>
-          mount.source === '/cache/codex-0.144.6-linux-x64' &&
+          mount.source === '/cache/codex-0.146.0-linux-x64' &&
           mount.target === '/opt/maka-codex-toolchain' &&
           mount.read_only === true,
       ),
@@ -2557,7 +2557,7 @@ describe('buildHarborJobConfig', () => {
           agent: 'codex',
           model: 'openai/gpt-5.6-sol',
           provider: 'openai',
-          agentVersion: '0.144.6',
+          agentVersion: '0.146.0',
         } as unknown as Parameters<typeof buildHarborJobConfig>[1]),
       /codexToolchainPath is required for the Codex adapter/,
     );
@@ -2573,7 +2573,7 @@ describe('buildHarborJobConfig', () => {
           agentVersion: '0.143.0',
           codexToolchainPath: '/toolchain',
         } as unknown as Parameters<typeof buildHarborJobConfig>[1]),
-      /Codex adapter version must match toolchain version 0\.144\.6/,
+      /Codex adapter version must match toolchain version 0\.146\.0/,
     );
   });
 

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -428,7 +428,7 @@ test('harness A/B defaults to pinned Kimi Code and keeps OpenCode selectable', a
   assert.equal(resolveHarnessCompetitorProfile('opencode').version, '1.17.18');
   const codexProfile = resolveHarnessCompetitorProfile('codex');
   const codexComposition = resolveHarnessComposition({ competitor: 'codex' });
-  assert.equal(codexProfile.version, '0.144.6');
+  assert.equal(codexProfile.version, '0.146.0');
   assert.deepEqual(codexComposition.runtimeProfile, {
     id: 'openai-codex-gpt-5.6-sol-xhigh',
     provider: 'openai-codex',
@@ -756,7 +756,7 @@ test('harness composition preserves historical manifest fingerprints', async () 
       name: 'Terminal-Bench Codex',
       composition: { competitor: 'codex' },
       pierVersion: null,
-      fingerprint: 'sha256:08d30757e28717184889a9d71ecb2aabac2f223997b9b164d4969ab7a3adcbef',
+      fingerprint: 'sha256:d8907d44340a1ee4b2f35b015ce78faa527b6b6c4fcefb553556eb9011f54bb6',
     },
     {
       name: 'DeepSWE Kimi Code',
@@ -768,7 +768,7 @@ test('harness composition preserves historical manifest fingerprints', async () 
       name: 'DeepSWE Codex',
       composition: { benchmark: 'deep-swe-1.1', competitor: 'codex' },
       pierVersion: '0.3.0',
-      fingerprint: 'sha256:732cdafa5a804485ec6af4f3268e73bf6bd639bdb55926fc6da843e5ad5fdbb8',
+      fingerprint: 'sha256:afb6a70de939312d998a613a62647842dff85addcd265fdfd4bceadf42ec1688',
     },
   ] as const;
 

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -1498,12 +1498,12 @@ test('buildPierRunArgs targets the Codex adapter and forwards constructor kwargs
     timeoutMultiplier: 1,
     mounts: [],
     agentEnv: {},
-    agentKwargs: { version: '0.144.6', reasoning_effort: 'xhigh' },
+    agentKwargs: { version: '0.146.0', reasoning_effort: 'xhigh' },
   });
   assert.match(args.join(' '), /--agent-import-path codex_agent:MakaCodexAgent/);
   assert.ok(!args.includes('--agent-timeout-multiplier'));
   assert.ok(args.includes('--ak'));
-  assert.ok(args.includes('version=0.144.6'));
+  assert.ok(args.includes('version=0.146.0'));
   assert.ok(args.includes('reasoning_effort=xhigh'));
 });
 

--- a/packages/headless/src/codex-toolchain.ts
+++ b/packages/headless/src/codex-toolchain.ts
@@ -20,17 +20,17 @@ export const CODEX_TOOLCHAIN_SPEC = {
     binarySha256: '93956de2e59480474a7b46571da1651180b1a050cdf32641ebec4ce6e478e068',
   },
   codex: {
-    version: '0.144.6',
-    archiveUrl: 'https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-x64.tgz',
+    version: '0.146.0',
+    archiveUrl: 'https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-x64.tgz',
     archiveIntegrity:
-      'sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==',
+      'sha512-fswvyGprAPCMiOEue/7MKMk7pCjh9kZIJfJX5i9atmfnmGYbYCcUhZsEH9LEP0+0t5xyPqDbfNXY7NSxIVuXxA==',
     files: {
-      binary: 'a31ae9450a26216eb1e7c53102fd42123dd675974310b0e2ca3aa4cb622a2c15',
-      codeModeHost: 'b3c1b98e0272ed4bff2bf0459574ff5489dee3087149648e43b1b665a76373e1',
-      ripgrep: 'ebeaf56f8a25e102e9419933423738b3a2a613a444fd749d695e15eba53f71f2',
-      bubblewrap: '7df960565a0dece99240ea4b9d0e011307817f9f3b73176c7b71fda44fe84765',
+      binary: '2e863156ed35ecc5253b1e2f907a9143077b9f7cb51942070c61996471ff6e04',
+      codeModeHost: '520e0f7e2c955a591995c4437d6b10c38595c43c94fba39cef4381a00dadcb98',
+      ripgrep: 'e62198eb19b136b88c330af83647b5a962cb99b6b1f066758568f12de1974849',
+      bubblewrap: '77360cb751ccedc5971391444ac86a8a33c15b04d6b4a6fe45f5d25496e62c4c',
       zsh: '67faaaa89242c4a332e16e508a1977cffc24bf7fca31d4411cdfd101f3831ef3',
-      packageMetadata: '4415fcb6e062b567abf79960dbbd38f046ce3c8fbb1170e35fd8129d476126d8',
+      packageMetadata: '3f9cd79076d1747cba97f610475f3ad99be314a15cbf665b8d8f179c020aa353',
     },
   },
 } as const;


### PR DESCRIPTION
## Summary

The synchronized three-arm benchmark pins Claude Code at `2.1.220` — the version its vendor ships today — and Codex at `0.144.6`, published 2026-07-18. By the time #1983 merged on 2026-08-03, `0.145.0` (07-21) and `0.146.0` (07-29) had both shipped. The pin was chosen in mid-July and never refreshed before merge.

Pinning is correct; the fingerprint is what makes a published run reproducible. The defect is that the two pins were taken at different times, so the version skew is a property of the *comparison* rather than of either agent. A reader of the report cannot tell whether a Codex result reflects Codex or reflects a 17-day-old build, and the arm that loses the coin flip is the competitor's.

Repin Codex to `0.146.0`. `engines.node` is unchanged at `>=16`, so the pinned Node 22.23.1 runtime and every `archivePath` / `stripComponents` entry stay as they are; only the version, URL, archive integrity, and the six vendored digests move.

The composition fingerprint carries the competitor version string, so the `Terminal-Bench Codex` and `DeepSWE Codex` manifest fingerprints move with the pin while `Terminal-Bench Kimi Code`, `Terminal-Bench OpenCode`, and `DeepSWE Kimi Code` stay byte-identical. That split is the assertion in `harness composition preserves historical manifest fingerprints` — if a non-Codex fingerprint had moved, this bump would have leaked outside its blast radius.

Refs #1970.

## Verification

- `npm run test -w @maka/headless` — 1337 pass / 0 fail / 1 skip.
- `npm run lint`, `npm run format:check`, `git diff --check` — clean.
- `archiveIntegrity` cross-checked against the registry's own `dist.integrity` for `0.146.0-linux-x64`; the same method reproduces the outgoing `0.144.6` value byte-for-byte from the registry, so the procedure is validated against a known-good pin rather than trusted blind.
- End-to-end `prepareCodexToolchain()` against the live registry: downloaded the archive, verified all six vendored digests plus the pinned Node runtime, and materialized a toolchain whose `codex-package.json` reports `0.146.0`.

## Rollout

Any in-flight run whose manifest froze the `0.144.6` composition fingerprint cannot resume across this change — that is the fingerprint doing its job. The full 89-task three-arm run for #1970 has not started; it will be launched on a fresh run id after this merges.