### PR TITLE
fix(deps): upgrade ip-address past the new SSRF advisories

### DIFF
--- a/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
+++ b/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
@@ -8475,10 +8475,10 @@ SOFTWARE.
 
 ================================================================================
 
-Package: ip-address@10.2.0
+Package: ip-address@10.4.0
 Declared license: MIT
 Selected license: MIT
-Repository: git://github.com/beaugunderson/ip-address.git
+Repository: https://github.com/beaugunderson/ip-address.git
 
 --- LICENSE ---
 Copyright (C) 2011 by Beau Gunderson

--- a/package-lock.json
+++ b/package-lock.json
@@ -8451,9 +8451,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Summary

`Release macOS arm64` run [30850257192](https://github.com/maka-agent/maka-agent/actions/runs/30850257192) failed at `npm audit --omit=dev --audit-level=high` on three advisories against `ip-address` `<=10.3.0`, all high:

- [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) — `Address4` decodes leading-zero octets as decimal while resolvers decode them as octal
- [GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh) — a CIDR suffix suppresses special-use classification
- [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) — IPv4-mapped/NAT64 IPv6 addresses are misclassified

All three bypass SSRF and trust-boundary checks. They were published after #2055 merged, where the same audit reported zero vulnerabilities — this is new advisory data against an unchanged tree, not a regression from that upgrade.

`ip-address` 10.2.0 → 10.4.0. It is a transitive dependency reached through `express-rate-limit` (`^10.2.0`) and `socks` (`^10.1.1`); 10.4.0 satisfies both, so this is a lockfile change with no `package.json` edits.

`THIRD_PARTY_NOTICES.txt` is regenerated in the same commit, because the release packaging step fails on a stale inventory — that is what broke run [30849279454](https://github.com/maka-agent/maka-agent/actions/runs/30849279454) after #2055. The notice entry moves to 10.4.0 and its repository URL normalizes from `git://` to `https://`; the license stays MIT.

## Verification

- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities (was 3 high).
- `npm run check:release`: all three gates pass — dist fresh, notices current, no dead CSS.
- `npm ci` then `npm run build`: clean.
- `npm run format:check`: clean.

## Rollout

Re-dispatch `Release macOS arm64` once this is on `main` and CI is green. No `v0.1.4` tag or release exists yet — every failed run stopped before `Create draft GitHub Release` — so the version does not need another bump.