### PR TITLE
fix(runtime): branch copied tool authority facts

### DIFF
--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -377,9 +377,14 @@ immutable immediate-source replay，但不产生 claim/start，也不能承接
 SQLite authority owner 后删除。
 
 B3 之前，branch/revision preflight 必须在创建目标 Session 之前拒绝任何 V1/V2
-`continuationSource`、continuation-start、tool dispatch/recovery 与 operation reference，稳定
-返回 `branch_runtime_fact_rewrite_unsupported`。B3 的正确实现要先建立旧 id 到新 id 的 typed
-映射，再逐类重写内部 evidence/claim/operation 引用；不允许恢复 shallow copy。
+`continuationSource` 与 continuation-start，稳定返回
+`branch_runtime_fact_rewrite_unsupported`。continuation claim 与 boundary evidence 不属于普通
+Run/Event 复制边界，不能在没有 typed authority copy 协议时浅拷贝。
+
+tool dispatch/recovery 与 operation reference 则已由 conversation runtime ledger copy 建立旧 id
+到新 id 的 typed 映射：新 invocation 决定新 operation id，dispatch、recovery、RuntimeEvent
+refs 和 recovery evidence RuntimeEvent ids 必须原子重写后才能导入目标 Session。该路径
+应保持可用，不得因 continuation authority 的 fail-closed 闸门被误拦截。
 
 #### 后续执行语义绑定：ContinuationExecutionProfileV1
 

--- a/packages/core/src/__tests__/redaction.test.ts
+++ b/packages/core/src/__tests__/redaction.test.ts
@@ -259,6 +259,16 @@ describe('generalizedErrorMessage', () => {
       assert.doesNotMatch(message, /sk-live-secret-token-value|token=secret/);
     }
   });
+
+  test('does not mistake runtime authority errors for authentication failures', () => {
+    assert.equal(
+      generalizedErrorMessage(
+        new Error('Conversation copy contains durable runtime authority facts'),
+        'Conversation copy failed',
+      ),
+      'Conversation copy failed',
+    );
+  });
 });
 
 describe('generalizedErrorMessageChinese', () => {
@@ -296,6 +306,16 @@ describe('generalizedErrorMessageChinese', () => {
         '会话已创建但发送失败，请重试。',
       ),
       '会话已创建但发送失败，请重试。',
+    );
+  });
+
+  test('does not mistake runtime authority errors for authentication failures', () => {
+    assert.equal(
+      generalizedErrorMessageChinese(
+        new Error('Conversation copy contains durable runtime authority facts'),
+        '无法基于该上下文创建新会话。',
+      ),
+      '无法基于该上下文创建新会话。',
     );
   });
 });

--- a/packages/core/src/__tests__/redaction.test.ts
+++ b/packages/core/src/__tests__/redaction.test.ts
@@ -269,6 +269,18 @@ describe('generalizedErrorMessage', () => {
       'Conversation copy failed',
     );
   });
+
+  test('recognizes provider authentication error spellings', () => {
+    for (const message of [
+      'AuthenticationError',
+      'OAuth2 token expired',
+      'User is not authorized',
+      'Please authenticate',
+      'authToken is missing',
+    ]) {
+      assert.equal(generalizedErrorMessage(new Error(message)), 'Authentication failed');
+    }
+  });
 });
 
 describe('generalizedErrorMessageChinese', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1688,6 +1688,7 @@ export {
 export {
   generalizedErrorMessage,
   generalizedErrorMessageChinese,
+  isAuthenticationErrorText,
   redactSecrets,
 } from './redaction.js';
 

--- a/packages/core/src/redaction.ts
+++ b/packages/core/src/redaction.ts
@@ -188,7 +188,7 @@ export function generalizedErrorMessage(error: unknown, fallback = 'Operation fa
   const lower = redacted.toLowerCase();
   if (lower.includes('timeout')) return 'Request timed out';
   if (lower.includes('429') || lower.includes('rate')) return 'Rate limit exceeded';
-  if (lower.includes('401') || lower.includes('403') || containsAuthenticationTerm(lower))
+  if (lower.includes('401') || lower.includes('403') || isAuthenticationErrorText(lower))
     return 'Authentication failed';
   if (lower.includes('5') && /\b5\d\d\b/.test(lower)) return 'Provider returned an error';
   if (
@@ -220,7 +220,7 @@ export function generalizedErrorMessageChinese(error: unknown, fallback = '操�
   const lower = redacted.toLowerCase();
   if (lower.includes('timeout')) return '请求超时';
   if (lower.includes('429') || lower.includes('rate')) return '触发模型速率限制';
-  if (lower.includes('401') || lower.includes('403') || containsAuthenticationTerm(lower))
+  if (lower.includes('401') || lower.includes('403') || isAuthenticationErrorText(lower))
     return '鉴权失败';
   if (lower.includes('5') && /\b5\d\d\b/.test(lower)) return '模型服务返回错误';
   if (
@@ -233,8 +233,6 @@ export function generalizedErrorMessageChinese(error: unknown, fallback = '操�
   return fallback;
 }
 
-function containsAuthenticationTerm(message: string): boolean {
-  return /\b(?:auth|authentication|authorization|oauth|unauthenticated|unauthorized)\b/.test(
-    message,
-  );
+export function isAuthenticationErrorText(message: string): boolean {
+  return message.replace(/\bauthorit\w*/g, '').includes('auth');
 }

--- a/packages/core/src/redaction.ts
+++ b/packages/core/src/redaction.ts
@@ -188,7 +188,7 @@ export function generalizedErrorMessage(error: unknown, fallback = 'Operation fa
   const lower = redacted.toLowerCase();
   if (lower.includes('timeout')) return 'Request timed out';
   if (lower.includes('429') || lower.includes('rate')) return 'Rate limit exceeded';
-  if (lower.includes('401') || lower.includes('403') || lower.includes('auth'))
+  if (lower.includes('401') || lower.includes('403') || containsAuthenticationTerm(lower))
     return 'Authentication failed';
   if (lower.includes('5') && /\b5\d\d\b/.test(lower)) return 'Provider returned an error';
   if (
@@ -220,7 +220,8 @@ export function generalizedErrorMessageChinese(error: unknown, fallback = '操�
   const lower = redacted.toLowerCase();
   if (lower.includes('timeout')) return '请求超时';
   if (lower.includes('429') || lower.includes('rate')) return '触发模型速率限制';
-  if (lower.includes('401') || lower.includes('403') || lower.includes('auth')) return '鉴权失败';
+  if (lower.includes('401') || lower.includes('403') || containsAuthenticationTerm(lower))
+    return '鉴权失败';
   if (lower.includes('5') && /\b5\d\d\b/.test(lower)) return '模型服务返回错误';
   if (
     lower.includes('network') ||
@@ -230,4 +231,10 @@ export function generalizedErrorMessageChinese(error: unknown, fallback = '操�
   )
     return '网络错误';
   return fallback;
+}
+
+function containsAuthenticationTerm(message: string): boolean {
+  return /\b(?:auth|authentication|authorization|oauth|unauthenticated|unauthorized)\b/.test(
+    message,
+  );
 }

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -544,6 +544,9 @@ async function seedSource(
       ),
       parentRunId: continuationParent.runId,
       agentId: 'child-agent',
+      agentName: 'Child Agent',
+      retriedFromRunId: continuationParent.runId,
+      retriedFromTurnId: continuationParent.turnId,
       continuationSource: {
         sourceInvocationId: continuationParent.invocationId!,
         sourceRunId: continuationParent.runId,
@@ -553,6 +556,18 @@ async function seedSource(
     };
     for (const run of [continuationParent, continuationChild]) {
       await execution.agentRunStore.createRun(run);
+      if (run.runId === continuationParent.runId) {
+        await execution.runtimeEventStore.appendRuntimeEvent(
+          run.sessionId,
+          run.runId,
+          runtimeEvent(run.sessionId, run.runId, run.invocationId!, run.turnId, {
+            id: 'continuation-parent-user',
+            role: 'user',
+            author: 'user',
+            content: { kind: 'text', text: 'retain the child continuation closure' },
+          }),
+        );
+      }
       await execution.runtimeEventStore.appendRuntimeEvent(
         run.sessionId,
         run.runId,
@@ -562,6 +577,17 @@ async function seedSource(
         }),
       );
     }
+    const persistedContinuationRuns = await execution.agentRunStore.listSessionRuns(
+      continuationSource.id,
+    );
+    const persistedContinuationChild = persistedContinuationRuns.find(
+      (run) => run.runId === continuationChild.runId,
+    );
+    assert.equal(persistedContinuationChild?.agentId, continuationChild.agentId);
+    assert.deepEqual(
+      persistedContinuationChild?.continuationSource,
+      continuationChild.continuationSource,
+    );
     const artifact = await artifacts.create({
       id: 'source-artifact',
       sessionId: source.id,

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -58,6 +58,7 @@ test('two UDS Clients share exact retryable Session branch and revision authorit
     metadataLinkedSourceSessionId,
     archivedOwnedSourceSessionId,
     graphChildSessionId,
+    continuationSourceSessionId,
   } = await seedSource(root, capability);
   let host: ExecutionHostHandle | undefined;
   try {
@@ -70,6 +71,7 @@ test('two UDS Clients share exact retryable Session branch and revision authorit
       metadataLinkedSourceSessionId,
       archivedOwnedSourceSessionId,
       graphChildSessionId,
+      continuationSourceSessionId,
     );
     await stopHost(host);
     host = undefined;
@@ -113,11 +115,29 @@ async function verifyConcurrentRevisionAuthority(
   metadataLinkedSourceSessionId: string,
   archivedOwnedSourceSessionId: string,
   graphChildSessionId: string,
+  continuationSourceSessionId: string,
 ): Promise<void> {
   const desktop = await connectClient(root, 'desktop');
   const tui = await connectClient(root, 'tui');
   try {
     const source = await querySession(desktop, sourceSessionId);
+    const continuationSource = await querySession(desktop, continuationSourceSessionId);
+    await assert.rejects(
+      desktop.request('session.branch.create', {
+        sourceSessionId: continuationSourceSessionId,
+        targetSessionId: 'continuation-copy-target',
+        sourceTurnId: 'continuation-parent-turn',
+        expectedSourceRevision: continuationSource.revision,
+      }),
+      operationError('operation_unavailable'),
+    );
+    assert.deepEqual(
+      await tui.request('session.catalog.query', {
+        kind: 'get',
+        sessionId: 'continuation-copy-target',
+      }),
+      { kind: 'session', session: null },
+    );
     const linkedChildSource = await querySession(desktop, linkedChildSourceSessionId);
     await assert.rejects(
       desktop.request('session.branch.create', {
@@ -441,6 +461,7 @@ async function seedSource(
   metadataLinkedSourceSessionId: string;
   archivedOwnedSourceSessionId: string;
   graphChildSessionId: string;
+  continuationSourceSessionId: string;
 }> {
   const owner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(owner);
@@ -491,6 +512,56 @@ async function seedSource(
       model: 'fake-model',
       permissionMode: 'ask',
     });
+    const continuationSource = await execution.sessionStore.create({
+      cwd: root,
+      name: 'Continuation Source Session',
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    await execution.sessionStore.appendMessage(continuationSource.id, {
+      type: 'user',
+      id: 'continuation-parent-user',
+      turnId: 'continuation-parent-turn',
+      ts: 1,
+      text: 'retain the child continuation closure',
+    });
+    const continuationParent = agentRunHeader(
+      root,
+      continuationSource.id,
+      'continuation-parent-run',
+      'continuation-parent-invocation',
+      'continuation-parent-turn',
+    );
+    const continuationChild: AgentRunHeader = {
+      ...agentRunHeader(
+        root,
+        continuationSource.id,
+        'continuation-child-run',
+        'continuation-child-invocation',
+        'continuation-child-turn',
+      ),
+      parentRunId: continuationParent.runId,
+      agentId: 'child-agent',
+      continuationSource: {
+        sourceInvocationId: continuationParent.invocationId!,
+        sourceRunId: continuationParent.runId,
+        sourceTurnId: continuationParent.turnId,
+        sourceRuntimeEventHighWater: 1,
+      },
+    };
+    for (const run of [continuationParent, continuationChild]) {
+      await execution.agentRunStore.createRun(run);
+      await execution.runtimeEventStore.appendRuntimeEvent(
+        run.sessionId,
+        run.runId,
+        runtimeEvent(run.sessionId, run.runId, run.invocationId!, run.turnId, {
+          id: `${run.runId}-terminal`,
+          status: 'completed',
+        }),
+      );
+    }
     const artifact = await artifacts.create({
       id: 'source-artifact',
       sessionId: source.id,
@@ -1123,6 +1194,7 @@ async function seedSource(
       metadataLinkedSourceSessionId: metadataLinkedSource.id,
       archivedOwnedSourceSessionId: archivedOwnedSource.id,
       graphChildSessionId: graphChild.header.id,
+      continuationSourceSessionId: continuationSource.id,
     };
   } finally {
     graph.close();

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -258,7 +258,13 @@ export class HostSessionRevisionCoordinator {
         }),
         this.#stores.sessionStore.listHeaders(),
       ]);
-    } catch {
+    } catch (error) {
+      if (isConversationRuntimeFactRewriteUnsupported(error)) {
+        return copyFailure(
+          'operation_unavailable',
+          'Session conversation copy does not yet support continuation authority facts',
+        );
+      }
       return copyFailure('persistence_failed', 'Source conversation lineage is unavailable');
     }
     if (
@@ -681,6 +687,14 @@ export class HostSessionRevisionCoordinator {
     }
     return boundary >= 0 && messages.slice(boundary + 1).some((message) => message.type === 'user');
   }
+}
+
+function isConversationRuntimeFactRewriteUnsupported(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    error.code === 'branch_runtime_fact_rewrite_unsupported'
+  );
 }
 
 function conversationCopyFingerprint(

--- a/packages/runtime/src/__tests__/conversation-copy.test.ts
+++ b/packages/runtime/src/__tests__/conversation-copy.test.ts
@@ -519,6 +519,95 @@ test('conversation copy turn closure includes legacy children but excludes later
   assert.deepEqual(plan.copyTurnIds, ['turn-parent', 'turn-child', 'turn-grandchild']);
 });
 
+test('conversation copy rejects continuation authority selected through the child-run closure', async () => {
+  const parent = agentRunHeader({ runId: 'run-parent', turnId: 'turn-parent' });
+  const child = agentRunHeader({
+    runId: 'run-child-retry',
+    turnId: 'turn-child-retry',
+    parentRunId: 'run-parent',
+    agentId: 'agent-child',
+    continuationSource: {
+      sourceInvocationId: parent.invocationId!,
+      sourceRunId: parent.runId,
+      sourceTurnId: parent.turnId,
+      sourceRuntimeEventHighWater: 1,
+    },
+  });
+  const runs = [parent, child];
+
+  await assert.rejects(
+    prepareConversationRuntimeLedgerCopy({
+      sourceSessionId: 'session-source',
+      sourceEvents: [],
+      copiedMessages: [
+        {
+          type: 'user',
+          id: 'message-parent',
+          turnId: parent.turnId,
+          ts: 1,
+          text: 'retain the parent and its child closure',
+        },
+      ],
+      runStore: {
+        listSessionRuns: async () => runs,
+        readEvents: async () => [],
+      },
+      runtimeEventStore: {
+        readRuntimeEvents: async (_sessionId, runId) => {
+          const run = runs.find((candidate) => candidate.runId === runId);
+          assert.ok(run);
+          return [
+            runtimeEvent({
+              id: `terminal-${runId}`,
+              runId,
+              invocationId: run.invocationId,
+              turnId: run.turnId,
+              status: 'completed',
+            }),
+          ];
+        },
+      },
+    }),
+    /typed identity rewriting/i,
+  );
+});
+
+test('conversation copy rejects legacy v1 continuation-start events', async () => {
+  const run = agentRunHeader({ runId: 'run-v1', turnId: 'turn-v1' });
+  await assert.rejects(
+    prepareConversationRuntimeLedgerCopy({
+      sourceSessionId: 'session-source',
+      sourceEvents: [],
+      copiedMessages: [
+        { type: 'user', id: 'message-v1', turnId: run.turnId, ts: 1, text: 'retain' },
+      ],
+      runStore: {
+        listSessionRuns: async () => [run],
+        readEvents: async () => [],
+      },
+      runtimeEventStore: {
+        readRuntimeEvents: async () => [
+          runtimeEvent({
+            id: 'v1-start',
+            runId: run.runId,
+            invocationId: run.invocationId,
+            turnId: run.turnId,
+            actions: { stateDelta: { continuationStart: true } },
+          }),
+          runtimeEvent({
+            id: 'v1-terminal',
+            runId: run.runId,
+            invocationId: run.invocationId,
+            turnId: run.turnId,
+            status: 'completed',
+          }),
+        ],
+      },
+    }),
+    /typed identity rewriting/i,
+  );
+});
+
 test('conversation copy rejects a retained AgentRun without RuntimeEvent facts', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-conversation-missing-runtime-copy-'));
   try {

--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -518,3 +518,18 @@ describe('Provider error classification', () => {
     assert.deepEqual(errorPresentationFromClass('Other'), {});
   });
 });
+test('auth classification preserves broad provider spellings without matching authority', () => {
+  for (const message of [
+    'AuthenticationError',
+    'OAuth2 token expired',
+    'User is not authorized',
+    'Please authenticate',
+    'authToken is missing',
+  ]) {
+    assert.equal(classifyError(new Error(message)), 'Auth');
+  }
+  assert.equal(
+    classifyError(new Error('Conversation copy contains durable runtime authority facts')),
+    'Error',
+  );
+});

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -17947,7 +17947,7 @@ describe('SessionManager permission mode updates', () => {
     expect((await store.readHeader(child.id)).projectId).toBe(null);
   });
 
-  test('fails before creating branch or revision sessions that need typed authority-fact rewriting', async () => {
+  test('branch and revision sessions rewrite tool operation authority facts', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -18055,25 +18055,29 @@ describe('SessionManager permission mode updates', () => {
       ],
     );
 
-    const attempts = [
-      () =>
-        manager.branchFromTurn(session.id, {
-          sourceTurnId: 'authority-source-turn',
-          name: 'Blocked branch',
-        }),
-      () =>
-        manager.branchBeforeTurn(session.id, {
-          sourceTurnId: 'authority-later-turn',
-          name: 'Blocked before branch',
-        }),
-      () =>
-        manager.reviseBeforeTurn(session.id, {
-          sourceTurnId: 'authority-later-turn',
-        }),
+    const copies = [
+      await manager.branchFromTurn(session.id, {
+        sourceTurnId: 'authority-source-turn',
+        name: 'Tool branch',
+      }),
+      await manager.branchBeforeTurn(session.id, {
+        sourceTurnId: 'authority-later-turn',
+        name: 'Tool branch before later turn',
+      }),
+      await manager.reviseBeforeTurn(session.id, {
+        sourceTurnId: 'authority-later-turn',
+      }),
     ];
-    for (const attempt of attempts) {
-      await expectRejects(attempt(), /typed identity rewriting/i);
-      expect((await store.list()).map((candidate) => candidate.id)).toEqual([session.id]);
+    for (const copy of copies) {
+      const [targetRun] = await runStore.listSessionRuns(copy.id);
+      assert.ok(targetRun);
+      const targetEvents = await runStore.readRuntimeEvents(copy.id, targetRun.runId);
+      const dispatch = targetEvents.find((event) => event.actions?.toolDispatch);
+      const targetOperationId = dispatch?.actions?.toolDispatch?.operationId;
+      assert.ok(targetOperationId);
+      assert.notEqual(targetOperationId, 'authority-operation');
+      assert.equal(dispatch?.refs?.operationId, targetOperationId);
+      assert.equal(targetRun.sessionId, copy.id);
     }
   });
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -18081,7 +18081,7 @@ describe('SessionManager permission mode updates', () => {
     }
   });
 
-  test('fails before cloning a legacy v1 continuation source until typed rewriting exists', async () => {
+  test('fails before creating branch or revision sessions for child continuation authority', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const manager = new SessionManager({
@@ -18098,8 +18098,46 @@ describe('SessionManager permission mode updates', () => {
       runStore,
       makeRunHeader({
         sessionId: session.id,
+        runId: 'continuation-parent-run',
+        turnId: 'continuation-parent-turn',
+        status: 'completed',
+        cwd: header.cwd,
+        createdAt: 1,
+        updatedAt: 2,
+        completedAt: 2,
+      }),
+      [
+        runtimeEvent({
+          id: 'continuation-parent-user',
+          sessionId: session.id,
+          invocationId: 'continuation-parent-invocation',
+          runId: 'continuation-parent-run',
+          turnId: 'continuation-parent-turn',
+          ts: 1,
+          role: 'user',
+          author: 'user',
+          content: { kind: 'text', text: 'retain parent and child closure' },
+        }),
+        runtimeEvent({
+          id: 'continuation-parent-terminal',
+          sessionId: session.id,
+          invocationId: 'continuation-parent-invocation',
+          runId: 'continuation-parent-run',
+          turnId: 'continuation-parent-turn',
+          ts: 2,
+          status: 'completed',
+          actions: { endInvocation: true },
+        }),
+      ],
+    );
+    await seedRuntimeRun(
+      runStore,
+      makeRunHeader({
+        sessionId: session.id,
         runId: 'legacy-continuation-run',
-        turnId: 'legacy-continuation-turn',
+        turnId: 'legacy-child-turn',
+        parentRunId: 'continuation-parent-run',
+        agentId: 'child-agent',
         status: 'completed',
         cwd: header.cwd,
         continuationSource: {
@@ -18108,9 +18146,9 @@ describe('SessionManager permission mode updates', () => {
           sourceTurnId: 'legacy-source-turn',
           sourceRuntimeEventHighWater: 1,
         },
-        createdAt: 1,
-        updatedAt: 2,
-        completedAt: 2,
+        createdAt: 3,
+        updatedAt: 4,
+        completedAt: 4,
       }),
       [
         runtimeEvent({
@@ -18118,8 +18156,8 @@ describe('SessionManager permission mode updates', () => {
           sessionId: session.id,
           invocationId: 'legacy-continuation-run',
           runId: 'legacy-continuation-run',
-          turnId: 'legacy-continuation-turn',
-          ts: 1,
+          turnId: 'legacy-child-turn',
+          ts: 3,
           role: 'user',
           author: 'user',
           content: { kind: 'text', text: 'legacy continuation history' },
@@ -18129,21 +18167,69 @@ describe('SessionManager permission mode updates', () => {
           sessionId: session.id,
           invocationId: 'legacy-continuation-run',
           runId: 'legacy-continuation-run',
-          turnId: 'legacy-continuation-turn',
-          ts: 2,
+          turnId: 'legacy-child-turn',
+          ts: 4,
+          status: 'completed',
+          actions: { endInvocation: true },
+        }),
+      ],
+    );
+    await seedRuntimeRun(
+      runStore,
+      makeRunHeader({
+        sessionId: session.id,
+        runId: 'continuation-later-run',
+        turnId: 'continuation-later-turn',
+        status: 'completed',
+        cwd: header.cwd,
+        createdAt: 5,
+        updatedAt: 6,
+        completedAt: 6,
+      }),
+      [
+        runtimeEvent({
+          id: 'continuation-later-user',
+          sessionId: session.id,
+          invocationId: 'continuation-later-invocation',
+          runId: 'continuation-later-run',
+          turnId: 'continuation-later-turn',
+          ts: 5,
+          role: 'user',
+          author: 'user',
+          content: { kind: 'text', text: 'later boundary' },
+        }),
+        runtimeEvent({
+          id: 'continuation-later-terminal',
+          sessionId: session.id,
+          invocationId: 'continuation-later-invocation',
+          runId: 'continuation-later-run',
+          turnId: 'continuation-later-turn',
+          ts: 6,
           status: 'completed',
           actions: { endInvocation: true },
         }),
       ],
     );
 
-    await expectRejects(
-      manager.branchFromTurn(session.id, {
-        sourceTurnId: 'legacy-continuation-turn',
-        name: 'Blocked legacy branch',
-      }),
-      /typed identity rewriting/i,
-    );
+    const attempts = [
+      () =>
+        manager.branchFromTurn(session.id, {
+          sourceTurnId: 'continuation-parent-turn',
+          name: 'Blocked child continuation branch',
+        }),
+      () =>
+        manager.branchBeforeTurn(session.id, {
+          sourceTurnId: 'continuation-later-turn',
+          name: 'Blocked child continuation branch before',
+        }),
+      () =>
+        manager.reviseBeforeTurn(session.id, {
+          sourceTurnId: 'continuation-later-turn',
+        }),
+    ];
+    for (const attempt of attempts) {
+      await expectRejects(attempt(), /typed identity rewriting/i);
+    }
     expect((await store.list()).map((candidate) => candidate.id)).toEqual([session.id]);
   });
 

--- a/packages/runtime/src/conversation-copy.ts
+++ b/packages/runtime/src/conversation-copy.ts
@@ -26,6 +26,7 @@ import {
   commitTerminalRunWithRuntimeFact,
 } from './terminal-run-commit.js';
 import { buildToolOperationId } from './runtime-commit-sink.js';
+import { isContinuationStartRuntimeEvent } from './runtime-event-read-model.js';
 import {
   buildToolResultArchiveResourceRef,
   parseToolResultArchiveResourceRef,
@@ -231,12 +232,30 @@ export async function prepareConversationRuntimeLedgerCopy(input: {
       return { run, runtimeEvents: events, operationalEvents };
     }),
   );
-  return {
+  const plan = {
     sourceSessionId: input.sourceSessionId,
     copyTurnIds,
     inlineRuntimeEvents: [...input.sourceEvents],
     runs,
   };
+  assertConversationRuntimeLedgerCopySupported(plan);
+  return plan;
+}
+
+function assertConversationRuntimeLedgerCopySupported(
+  plan: ConversationRuntimeLedgerCopyPlan,
+): void {
+  const unsupported = plan.runs.some(
+    ({ run, runtimeEvents }) =>
+      run.continuationSource !== undefined || runtimeEvents.some(isContinuationStartRuntimeEvent),
+  );
+  if (!unsupported) return;
+
+  const error = new Error(
+    'Conversation copy contains durable runtime authority facts that require typed identity rewriting',
+  ) as Error & { code: string };
+  error.code = 'branch_runtime_fact_rewrite_unsupported';
+  throw error;
 }
 
 export async function cloneConversationRuntimeLedger(

--- a/packages/runtime/src/provider-error-classification.ts
+++ b/packages/runtime/src/provider-error-classification.ts
@@ -1,4 +1,5 @@
 import { RetryError } from 'ai';
+import { isAuthenticationErrorText } from '@maka/core/redaction';
 
 /**
  * Structured provider error identifiers that mean the INPUT exceeded the
@@ -309,7 +310,7 @@ export function classifyError(error: unknown): string {
   // ("generate"/"separate" are not rate limits) while still matching the
   // rate_limit/RateLimitError identifier spellings.
   if (/\brate\b|rate[_-]?limit/.test(text)) return 'RateLimit';
-  if (text.includes('auth')) return 'Auth';
+  if (isAuthenticationErrorText(text)) return 'Auth';
   if (text.includes('timeout')) return 'Timeout';
   if (
     text.includes('network') ||

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -73,6 +73,13 @@ export function isHardRuntimeEventReadModelDiagnostic(diagnostic: {
   return RUNTIME_EVENT_READ_MODEL_DIAGNOSTIC_SEVERITY[diagnostic.code] === 'hard';
 }
 
+export function isContinuationStartRuntimeEvent(event: RuntimeEvent): boolean {
+  return (
+    event.actions?.stateDelta?.continuationStart === true ||
+    event.actions?.continuationStart !== undefined
+  );
+}
+
 /**
  * Codes that mean the projection did not claim an event, at either severity.
  *
@@ -299,10 +306,7 @@ export function projectRuntimeEventsToStoredMessages(
       projected = true;
     }
 
-    if (
-      event.actions?.stateDelta?.continuationStart === true ||
-      event.actions?.continuationStart !== undefined
-    ) {
+    if (isContinuationStartRuntimeEvent(event)) {
       // Continuation start is a canonical lineage/recovery fact with no
       // legacy chat row. Its following model events own the visible output.
       projected = true;

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -125,6 +125,7 @@ import {
   cloneConversationRuntimeLedger as cloneConversationLedger,
   createConversationCopySlice,
   prepareConversationRuntimeLedgerCopy,
+  type ConversationRuntimeLedgerCopyPlan,
 } from './conversation-copy.js';
 import { firstRuntimeRepairRunId, RuntimeLedgerRepair } from './runtime-ledger-repair.js';
 import {
@@ -4897,7 +4898,7 @@ export class SessionManager {
     copied: StoredMessage[],
     input: ReviseBeforeTurnInput,
   ): Promise<SessionSummary> {
-    this.assertConversationRuntimeLedgerCloneSupported(sourceView, copied);
+    const plan = await this.prepareConversationRuntimeLedgerClone(sessionId, sourceView, copied);
     const [header, boundary] = await Promise.all([
       this.deps.store.readHeader(sessionId),
       this.deps.store.readExecutionBoundary(sessionId),
@@ -4937,12 +4938,7 @@ export class SessionManager {
       boundary,
     );
     try {
-      const rewritten = await this.cloneConversationRuntimeLedger(
-        sessionId,
-        next.id,
-        sourceView,
-        copied,
-      );
+      const rewritten = await this.cloneConversationRuntimeLedger(next.id, copied, plan);
       if (rewritten.length > 0) await this.deps.store.appendMessages(next.id, [...rewritten]);
       await this.deps.store.appendMessage(next.id, {
         type: 'system_note',
@@ -4973,7 +4969,7 @@ export class SessionManager {
     copied: StoredMessage[],
     input: BranchFromTurnInput,
   ): Promise<SessionSummary> {
-    this.assertConversationRuntimeLedgerCloneSupported(sourceView, copied);
+    const plan = await this.prepareConversationRuntimeLedgerClone(sessionId, sourceView, copied);
     const [header, boundary] = await Promise.all([
       this.deps.store.readHeader(sessionId),
       this.deps.store.readExecutionBoundary(sessionId),
@@ -4998,12 +4994,7 @@ export class SessionManager {
       boundary,
     );
     try {
-      const rewritten = await this.cloneConversationRuntimeLedger(
-        sessionId,
-        next.id,
-        sourceView,
-        copied,
-      );
+      const rewritten = await this.cloneConversationRuntimeLedger(next.id, copied, plan);
       if (rewritten.length > 0) await this.deps.store.appendMessages(next.id, [...rewritten]);
       await this.deps.store.appendMessage(next.id, {
         type: 'system_note',
@@ -5412,26 +5403,33 @@ export class SessionManager {
     );
   }
 
-  private async cloneConversationRuntimeLedger(
+  private async prepareConversationRuntimeLedgerClone(
     sourceSessionId: string,
-    childSessionId: string,
     sourceView: RuntimeReadModelSessionView,
     copiedMessages: readonly StoredMessage[],
-  ): Promise<readonly StoredMessage[]> {
-    if (!this.deps.runStore || !this.deps.runtimeEventStore) return copiedMessages;
-    const plan = await prepareConversationRuntimeLedgerCopy({
+  ): Promise<ConversationRuntimeLedgerCopyPlan | undefined> {
+    if (!this.deps.runStore || !this.deps.runtimeEventStore) return undefined;
+    return prepareConversationRuntimeLedgerCopy({
       sourceSessionId,
       sourceEvents: sourceView.events,
       copiedMessages,
       runStore: this.deps.runStore,
       runtimeEventStore: this.deps.runtimeEventStore,
     });
+  }
+
+  private async cloneConversationRuntimeLedger(
+    childSessionId: string,
+    copiedMessages: readonly StoredMessage[],
+    plan: ConversationRuntimeLedgerCopyPlan | undefined,
+  ): Promise<readonly StoredMessage[]> {
+    if (!plan || !this.deps.runStore || !this.deps.runtimeEventStore) return copiedMessages;
     const copied = await cloneConversationLedger({
       plan,
       copiedMessages,
       referenceMap: {
         mode: 'preserve_external',
-        sourceSessionId,
+        sourceSessionId: plan.sourceSessionId,
         targetSessionId: childSessionId,
       },
       runStore: this.deps.runStore,
@@ -5450,46 +5448,6 @@ export class SessionManager {
         `Conversation copy ${sessionId} failed and could not be removed`,
       );
     }
-    throw error;
-  }
-
-  /**
-   * Tool operation identities are rewritten by cloneConversationRuntimeLedger.
-   * Continuation authority is different: its claim and boundary evidence live
-   * outside the copied Run/Event ledger. Until that authority has a typed copy
-   * protocol, fail before creating a target Session rather than carrying source
-   * continuation identities into a readable-looking clone.
-   */
-  private assertConversationRuntimeLedgerCloneSupported(
-    sourceView: RuntimeReadModelSessionView,
-    copiedMessages: readonly StoredMessage[],
-  ): void {
-    const copiedTurnIds = new Set<string>();
-    for (const message of copiedMessages) {
-      if ('turnId' in message && typeof message.turnId === 'string') {
-        copiedTurnIds.add(message.turnId);
-      }
-    }
-    if (copiedTurnIds.size === 0) return;
-
-    const selectedRuns = new Set(
-      sourceView.runs.filter((run) => copiedTurnIds.has(run.turnId)).map((run) => run.runId),
-    );
-    const unsupportedRun = sourceView.runs.find(
-      (run) => selectedRuns.has(run.runId) && run.continuationSource !== undefined,
-    );
-    const unsupportedContinuationEvent = sourceView.events.find(
-      (event) =>
-        selectedRuns.has(event.runId) &&
-        copiedTurnIds.has(event.turnId) &&
-        event.actions?.continuationStart !== undefined,
-    );
-    if (!unsupportedRun && !unsupportedContinuationEvent) return;
-
-    const error = new Error(
-      'Conversation copy contains durable runtime authority facts that require typed identity rewriting',
-    ) as Error & { code: string };
-    error.code = 'branch_runtime_fact_rewrite_unsupported';
     throw error;
   }
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -5454,10 +5454,11 @@ export class SessionManager {
   }
 
   /**
-   * PR B3 will provide typed identity rewriting for authority-bearing facts.
-   * Until then, fail before creating the target session: shallow-copying any
-   * of these facts would produce a readable-looking conversation whose durable
-   * operation/continuation identities still point at the source session.
+   * Tool operation identities are rewritten by cloneConversationRuntimeLedger.
+   * Continuation authority is different: its claim and boundary evidence live
+   * outside the copied Run/Event ledger. Until that authority has a typed copy
+   * protocol, fail before creating a target Session rather than carrying source
+   * continuation identities into a readable-looking clone.
    */
   private assertConversationRuntimeLedgerCloneSupported(
     sourceView: RuntimeReadModelSessionView,
@@ -5477,16 +5478,13 @@ export class SessionManager {
     const unsupportedRun = sourceView.runs.find(
       (run) => selectedRuns.has(run.runId) && run.continuationSource !== undefined,
     );
-    const unsupportedEvent = sourceView.events.find(
+    const unsupportedContinuationEvent = sourceView.events.find(
       (event) =>
         selectedRuns.has(event.runId) &&
         copiedTurnIds.has(event.turnId) &&
-        (event.actions?.continuationStart !== undefined ||
-          event.actions?.toolDispatch !== undefined ||
-          event.actions?.toolRecovery !== undefined ||
-          event.refs?.operationId !== undefined),
+        event.actions?.continuationStart !== undefined,
     );
-    if (!unsupportedRun && !unsupportedEvent) return;
+    if (!unsupportedRun && !unsupportedContinuationEvent) return;
 
     const error = new Error(
       'Conversation copy contains durable runtime authority facts that require typed identity rewriting',


### PR DESCRIPTION
## Summary

- allow branch, branch-before, and revision copies containing tool dispatch/recovery facts to reach the existing typed Runtime ledger copy path
- keep V1/V2 continuation source/start authority fail-closed because claim and boundary evidence are outside the copied Run/Event ledger
- stop classifying `authority` as authentication failure by matching explicit authentication terms
- align the runtime-resume architecture note with the capabilities already shipped in conversation ledger copy

## Root cause

The conversation copy implementation already creates new Run, invocation, RuntimeEvent, provider trace, and tool operation identities, then rewrites dispatch/recovery and operation references before importing the target ledger. The later continuation preflight rejected those supported tool facts together with unsupported continuation claims, so the typed copy path was unreachable for ordinary tool-bearing conversations.

The Desktop error was also misleading: the shared classifier used `includes('auth')`, so the word `authority` became “Authentication failed”.

## Safety boundary

This does not copy or bypass continuation authority. A retained Run with `continuationSource`, or a retained RuntimeEvent with `continuationStart`, is still rejected before the target Session is created. Tool operation facts are only admitted through the existing typed rewrite and atomic RuntimeEvent import path.

## Verification

- `npm --workspace @maka/core test` — 771 passed
- `TMPDIR=/private/tmp npm --workspace @maka/runtime run test:dist` — 3,080 passed, 9 skipped, 0 failed
- focused SessionManager tests — branch, branch-before, revision rewrite pass; legacy continuation rejection pass
- `node --test packages/runtime/dist/__tests__/conversation-copy.test.js` — 10 passed
- `npm run test:scripts` — 86 passed
- `npm run typecheck` — all workspaces clean
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Real Desktop acceptance

Using the current macOS Desktop build and the exact persisted conversation/turn that reproduced the failure:

- invoked `window.maka.sessions.branchFromTurn()` through the real preload/IPC boundary
- child Session was created with the expected `parentSessionId` and `branchOfTurnId`
- all 3 retained turns and 44 messages were readable from the child
- no Runtime/IPC error was logged
- removed the acceptance child Session afterward

Fixes #2060
