### PR TITLE
fix(headless): resolve host.docker.internal for Harbor's in-container arms

### DIFF
--- a/packages/headless/harbor/docker-compose-linux-amd64.yaml
+++ b/packages/headless/harbor/docker-compose-linux-amd64.yaml
@@ -1,3 +1,9 @@
 services:
   main:
     platform: linux/amd64
+    # Docker Desktop injects host.docker.internal; native Linux Docker does not.
+    # In-container agents dial that name to reach the host credential proxy, so
+    # without this mapping every Codex and Claude Code cell fails before its
+    # first model step -- Codex as a connect error, Claude Code as ENOTFOUND.
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -3155,3 +3155,18 @@ describe('incompleteTerminalProviderRequest', () => {
     assert.equal(incompleteTerminalProviderRequest([], false), undefined);
   });
 });
+
+test('the linux/amd64 compose override resolves host.docker.internal for in-container agents', async () => {
+  const compose = await readFile(
+    new URL('../../harbor/docker-compose-linux-amd64.yaml', import.meta.url),
+    'utf8',
+  );
+
+  // Docker Desktop injects this name; native Linux Docker does not. Codex and
+  // Claude Code dial it to reach the host credential proxy, so dropping the
+  // mapping fails both competitor arms before their first model step while the
+  // Maka host cell -- which uses loopback -- keeps passing. That asymmetry
+  // looks like a competitor defect rather than a harness one, so pin it here.
+  assert.match(compose, /extra_hosts:/);
+  assert.match(compose, /host\.docker\.internal:host-gateway/);
+});


### PR DESCRIPTION
## Summary

The first real three-arm canary on a bare-metal Linux VM produced a result that reads like a competitor indictment: Maka 3 passed / 2 budget-exhausted, Codex 5/5 `infra_failed`, Claude Code 5/5 `plumbing_failed`. Both competitor arms had in fact died before their first model step, for one reason.

In-container agents dial `host.docker.internal` to reach the host credential proxy (`provider-auth-proxy.ts` defaults `advertisedHost` to that name). Docker Desktop injects it; native Linux Docker does not, and Harbor's linux/amd64 compose override declared only `platform`. So the name did not resolve:

- Codex — `stream disconnected before completion: error sending request for url (http://host.docker.internal:34151/responses)`, five reconnects then `turn.failed`
- Claude Code — `API Error: Unable to connect to API (ENOTFOUND)`, ten retries over 170s

The Maka arm passed throughout, because a Maka host cell reaches the proxy on loopback and never needs the name. That is what makes this worth pinning rather than just patching: a missing container DNS entry presented as *the two competitors are broken*, on exactly the axis the benchmark exists to measure.

`pier-task-runner.ts:180-186` already documents this Linux gap and threads `providerProxyAdvertisedHost` past it, but `MAKA_HARNESS_AB_PROVIDER_PROXY_ADVERTISED_HOST` reaches only the Pier path; the Harbor path has no equivalent knob. Rather than add one, fix it where the platform difference already lives. `harbor-task-runner.ts` attaches the compose override precisely when `dockerPlatform === 'linux/amd64'`, so mapping the name to `host-gateway` there fixes native Linux, is a no-op on Docker Desktop, and keeps the advertised host byte-identical across platforms — manifests, prompt hashes, and fingerprints are untouched, so a Linux run stays comparable with a macOS one.

Refs #1970.

## Verification

- Live containers on the affected VM, same Docker (29.7.1) and image the benchmark uses:
  - base compose only — `getent hosts host.docker.internal` returns nothing
  - base + this override — `172.17.0.1  host.docker.internal`
- `npm run test -w @maka/headless` — 1338 pass / 0 fail / 1 skip, including the added contract test.
- `npm run lint`, `npm run format:check`, `git diff --check` — clean.

## Review focus

The added test asserts the compose file's content rather than a runner behavior. That is deliberate: no unit-level assertion over `buildHarborJobConfig` can observe container DNS, and the failure mode this guards against is the two lines silently going away. The cost of that regression is a wasted multi-hour, real-spend benchmark run whose output looks like data.