### PR TITLE
refactor(desktop): remove consumer-less IPC bridge surface

### DIFF
--- a/apps/desktop/e2e/composer-skill-invocation.spec.ts
+++ b/apps/desktop/e2e/composer-skill-invocation.spec.ts
@@ -210,6 +210,9 @@ test('staged Skills come back as chips after leaving and returning', async ({
   await composer.pressSequentially('run it');
   await pick('workspace', /Workspace Only/);
   await expect(projectChip).toContainText('Project Only');
+  // Both chips must land before navigating away: leaving while the second
+  // token is still committing races the draft snapshot and loses the chip.
+  await expect(workspaceChip).toContainText('Workspace Only');
 
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   const sidebar = page.getByRole('navigation', { name: '对话列表' });

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -53,9 +53,6 @@ type RendererMakaStub = {
       projectGit: { isGitRepo: boolean };
     }>;
   };
-  appWindow: {
-    subscribeOpenSettings(callback: () => void): () => void;
-  };
   connections: {
     subscribeEvents(callback: (event: ConnectionEvent) => void): () => void;
   };
@@ -919,9 +916,6 @@ function installFakeMaka(captured: CapturedSubscriptions): void {
         projectPath: '/workspace/relocated',
         projectGit: { isGitRepo: false },
       }),
-    },
-    appWindow: {
-      subscribeOpenSettings: () => noop,
     },
     connections: {
       subscribeEvents(callback: (event: ConnectionEvent) => void) {

--- a/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
@@ -26,6 +26,19 @@ function extractChannels(source: string, pattern: RegExp): Set<string> {
   return new Set([...source.matchAll(pattern)].map((match) => match[1]));
 }
 
+// Channels deliberately registered in main with no preload consumer.
+// usage:* is the #1596 Usage/Pricing authority surface: per the #1982
+// decision it stays main-side until the #2010 M4 client adapter exposes a
+// narrow renderer interface (pricing.query / pricing.mutate).
+const MAIN_ONLY_CHANNELS = [
+  'usage:summary',
+  'usage:buckets',
+  'usage:logs',
+  'usage:pricing:list',
+  'usage:pricing:put',
+  'usage:pricing:reset',
+];
+
 describe('IPC surface contract', () => {
   it('keeps main handlers and preload invocations in parity', async () => {
     const mainFiles = await findTypeScriptFiles(join(desktopRoot, 'src', 'main'));
@@ -41,6 +54,18 @@ describe('IPC surface contract', () => {
       preloadSource,
       /ipcRenderer\.invoke\(\s*['"]([^'"]+)['"]/g,
     );
+
+    for (const channel of MAIN_ONLY_CHANNELS) {
+      assert.ok(
+        mainChannels.has(channel),
+        `main-only channel ${channel} is no longer registered — remove it from MAIN_ONLY_CHANNELS`,
+      );
+      assert.ok(
+        !preloadChannels.has(channel),
+        `channel ${channel} gained a preload consumer — remove it from MAIN_ONLY_CHANNELS`,
+      );
+      mainChannels.delete(channel);
+    }
 
     assert.deepEqual([...mainChannels].sort(), [...preloadChannels].sort());
   });

--- a/apps/desktop/src/main/daily-review-ipc-main.ts
+++ b/apps/desktop/src/main/daily-review-ipc-main.ts
@@ -83,9 +83,6 @@ export function registerDailyReviewIpc(deps: DailyReviewIpcDeps): void {
   ipcMain.handle('daily-review:get', (_event, archiveId: string) =>
     deps.dailyReviewArchiveStore.getArchive(archiveId),
   );
-  ipcMain.handle('daily-review:delete', async (_event, archiveId: string) => {
-    await deps.dailyReviewArchiveStore.deleteArchive(archiveId);
-  });
   ipcMain.handle(
     'daily-review:saveMarkdownToFile',
     (_event, input: { markdown?: unknown; defaultName?: unknown } | undefined) =>

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -79,14 +79,6 @@ import type {
   DeepResearchRun,
   LocalMemoryEntryPreview,
 } from '@maka/core';
-import type {
-  PricingConfig,
-  UsageBucket,
-  UsageGroupBy,
-  UsageLogRow,
-  UsageQuery,
-  UsageSummaryV2,
-} from '@maka/core/usage-stats/types';
 import type { SessionTrace } from '@maka/core/session-trace';
 import type { TestProxyInput } from '@maka/core/settings/network-settings';
 import type { Result } from '@maka/core/result';
@@ -587,14 +579,6 @@ export interface MakaBridge {
     /** Read-only per-session causal trace (#1625). */
     trace(sessionId: string): Promise<Result<SessionTrace>>;
   };
-  usage: {
-    summary(query: UsageQuery): Promise<Result<UsageSummaryV2>>;
-    buckets(query: UsageQuery & { groupBy: UsageGroupBy }): Promise<Result<UsageBucket[]>>;
-    logs(query: UsageQuery & { offset?: number; limit?: number }): Promise<Result<{ rows: UsageLogRow[]; total: number }>>;
-    listPricing(): Promise<Result<PricingConfig[]>>;
-    putPricing(pricing: PricingConfig): Promise<Result<PricingConfig>>;
-    resetPricing(modelKey: string): Promise<Result<void>>;
-  };
   webSearch: {
     query(input: {
       query: string;
@@ -609,12 +593,8 @@ export interface MakaBridge {
     getConfig?(): Promise<DailyReviewConfig>;
     setConfig?(patch: Partial<DailyReviewConfig>): Promise<DailyReviewConfig>;
     runOnce?(input: { range: DailyReviewRange; offsetDays?: number; modelKey?: string }): Promise<{ archiveId: string }>;
-    list?(): Promise<DailyReviewArchiveSummary[]>;
-    get?(archiveId: string): Promise<DailyReviewArchive | null>;
-    delete?(archiveId: string): Promise<void>;
     listArchives?(): Promise<DailyReviewArchiveSummary[]>;
     getArchive?(archiveId: string): Promise<DailyReviewArchive | null>;
-    deleteArchive?(archiveId: string): Promise<void>;
     saveMarkdownToFile(input: {
       markdown: string;
       defaultName: string;
@@ -630,7 +610,6 @@ export interface MakaBridge {
      */
   };
   appWindow: {
-    subscribeOpenSettings(handler: () => void): () => void;
     setTitlebarControlsVisible(visible: boolean): Promise<void>;
     setThemeSource(themePref: ThemePreference): Promise<void>;
     // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -90,14 +90,6 @@ import type {
   DeepResearchChangedEvent,
   DeepResearchRun,
 } from '@maka/core';
-import type {
-  PricingConfig,
-  UsageBucket,
-  UsageGroupBy,
-  UsageLogRow,
-  UsageQuery,
-  UsageSummaryV2,
-} from '@maka/core/usage-stats/types';
 import type { SessionTrace } from '@maka/core/session-trace';
 import type {
   AgentGraphClientChangedEvent,
@@ -909,26 +901,6 @@ const makaBridge = {
       return ipcRenderer.invoke('inspector:trace', sessionId);
     },
   },
-  usage: {
-    summary(query: UsageQuery): Promise<Result<UsageSummaryV2>> {
-      return ipcRenderer.invoke('usage:summary', query);
-    },
-    buckets(query: UsageQuery & { groupBy: UsageGroupBy }): Promise<Result<UsageBucket[]>> {
-      return ipcRenderer.invoke('usage:buckets', query);
-    },
-    logs(query: UsageQuery & { offset?: number; limit?: number }): Promise<Result<{ rows: UsageLogRow[]; total: number }>> {
-      return ipcRenderer.invoke('usage:logs', query);
-    },
-    listPricing(): Promise<Result<PricingConfig[]>> {
-      return ipcRenderer.invoke('usage:pricing:list');
-    },
-    putPricing(pricing: PricingConfig): Promise<Result<PricingConfig>> {
-      return ipcRenderer.invoke('usage:pricing:put', pricing);
-    },
-    resetPricing(modelKey: string): Promise<Result<void>> {
-      return ipcRenderer.invoke('usage:pricing:reset', modelKey);
-    },
-  },
   dailyReview: {
     day(offsetDays: number, daySpan?: number): Promise<Result<DailyReviewSummary>> {
       return ipcRenderer.invoke('daily-review:day', { offsetDays, daySpan });
@@ -942,23 +914,11 @@ const makaBridge = {
     runOnce(input: { range: DailyReviewRange; offsetDays?: number; modelKey?: string }): Promise<{ archiveId: string }> {
       return ipcRenderer.invoke('daily-review:runOnce', input);
     },
-    list(): Promise<DailyReviewArchiveSummary[]> {
-      return ipcRenderer.invoke('daily-review:list');
-    },
     listArchives(): Promise<DailyReviewArchiveSummary[]> {
       return ipcRenderer.invoke('daily-review:list');
     },
-    get(archiveId: string): Promise<DailyReviewArchive | null> {
-      return ipcRenderer.invoke('daily-review:get', archiveId);
-    },
     getArchive(archiveId: string): Promise<DailyReviewArchive | null> {
       return ipcRenderer.invoke('daily-review:get', archiveId);
-    },
-    delete(archiveId: string): Promise<void> {
-      return ipcRenderer.invoke('daily-review:delete', archiveId);
-    },
-    deleteArchive(archiveId: string): Promise<void> {
-      return ipcRenderer.invoke('daily-review:delete', archiveId);
     },
     /**
      * PR-DAILY-REVIEW-EXPORT-FILE-0: render the markdown in the renderer
@@ -989,11 +949,6 @@ const makaBridge = {
     },
   },
   appWindow: {
-    subscribeOpenSettings(handler: () => void): () => void {
-      const listener = () => handler();
-      ipcRenderer.on('window:openSettings', listener);
-      return () => ipcRenderer.off('window:openSettings', listener);
-    },
     setTitlebarControlsVisible(visible: boolean): Promise<void> {
       return ipcRenderer.invoke('window:setTitlebarControlsVisible', visible);
     },

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -269,9 +269,6 @@ export function useAppShellBootstrapSubscriptions(options: {
     }
     },
   );
-  const handleOpenSettings = useEffectEvent(() => {
-    options.openSettings();
-  });
   const handlePlanChange = useEffectEvent(() => {
     void options.refreshPlanReminders();
   });
@@ -337,7 +334,6 @@ export function useAppShellBootstrapSubscriptions(options: {
       void options.refreshConnections();
     });
     const unsubscribeSessionChanges = window.maka.sessions.subscribeChanges(handleSessionChange);
-    const unsubscribeOpenSettings = window.maka.appWindow.subscribeOpenSettings(handleOpenSettings);
     const unsubscribePlanChanges = window.maka.plans.subscribeChanges(handlePlanChange);
     const unsubscribePlanDue = window.maka.plans.subscribeDue(handlePlanDue);
     markRendererMounted();
@@ -347,7 +343,6 @@ export function useAppShellBootstrapSubscriptions(options: {
       unsubscribeConnections();
       unsubscribeSettingsExternal();
       unsubscribeSessionChanges();
-      unsubscribeOpenSettings();
       unsubscribePlanChanges();
       unsubscribePlanDue();
       window.removeEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
## Summary

Removes the three renderer-dead IPC bridge surfaces from #1978 plus the `maka.usage` preload namespace per the decision recorded on #1982. Pure deletion apart from the contract-test allowlist; all items re-verified zero-consumer on current `main` before removal.

- **`appWindow.subscribeOpenSettings`** (preload + `bridge-contract.d.ts` + `app-shell-effects.ts` wiring + stability-contract stub): the only `window:openSettings` sender was deleted in #390; ⌘/Ctrl+, continues to work through the renderer keydown handler (kept).
- **`dailyReview.list/get/delete` aliases**: duplicates of the live `listArchives`/`getArchive` variants over the same channels. `delete` had no consumer in either spelling, so the `daily-review:delete` channel is removed end-to-end — retention cleanup calls `store.deleteArchive` directly and is unaffected.
- **`maka.usage` preload namespace** (#1982 decision 2): removed with the now-unused `usage-stats` type imports. The main-side `usage:*` authority handlers and their tests stay untouched (they are the #1596 Host authority wiring, awaiting the #2010 M4 adapter). The IPC surface parity test gains a `MAIN_ONLY_CHANNELS` allowlist that documents this and self-checks in both directions: an allowlisted channel that disappears from main, or that gains a preload consumer, fails the test.

The third #1978 finding (`cursor-subscription:logout` not gated) became moot when #2037 retired the entire Cursor subscription surface.

Closes #1978. Ref #1982 (decision 2 of the recorded plan; Pricing Settings spec remains a separate follow-up).

## Verification

- `npm run typecheck` (all four desktop tsconfigs) clean.
- Desktop main suite: **1585/1585** pass, including `ipc-surface-contract` and `app-shell-effect-stability-contract`.
- ⌘/Ctrl+, settings shortcut: keydown path untouched (`app-shell-effects.ts` `handleKeyDown`).
- Daily Review archive journey unaffected: `listArchives`/`getArchive`/`saveMarkdownToFile` and all main-side store methods unchanged.
