### PR TITLE
feat(runtime-host): own derived Session effects

### DIFF
--- a/apps/desktop/src/main/__tests__/artifact-visibility.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-visibility.test.ts
@@ -25,6 +25,7 @@ describe('generated artifact visibility', () => {
       'history_compact_block',
       'history_compact_source',
       'provider_request_capture',
+      'session_effect',
       'user_upload',
     ];
 

--- a/apps/desktop/src/renderer/artifact-visibility.ts
+++ b/apps/desktop/src/renderer/artifact-visibility.ts
@@ -7,6 +7,7 @@ const USER_VISIBLE_ARTIFACT_SOURCES = {
   history_compact_block: false,
   history_compact_source: false,
   provider_request_capture: false,
+  session_effect: false,
   subagent_writeback: true,
   deep_research: true,
   user_upload: false,

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -12,12 +12,11 @@ import {
   RuntimeReadModel,
   SessionManager,
   ShellRunProcessManager,
-  applyRuntimeEventContextBudget,
   buildAutomationTool,
   buildAskUserQuestionTool,
   buildRequestSandboxBoundaryTool,
   buildBuiltinTools,
-  buildRuntimeEventModelReplayPlan,
+  buildSessionRecapMessages,
   buildChildAgentTools,
   createBuiltinSandboxManager,
   isBuiltinFilesystemWorkerSandboxAvailable,
@@ -44,7 +43,6 @@ import {
   getAIModel,
   generateSessionTitle as generateRuntimeSessionTitle,
   loadHistoryCompactBlocksFromArtifacts,
-  replayPlanItemsToModelMessages,
   recoverAgentGraphSupervisorContextOverflow,
   resolveSkillDiscoveryPaths,
   resolveSelectedModelContextWindow,
@@ -93,7 +91,7 @@ import {
 } from './connection-target.js';
 import { buildCliSystemPrompt, buildCliTurnTailPrompt } from './cli-system-prompt.js';
 import { CliGoalContinuation } from './cli-goal-continuation.js';
-import { RECAP_INSTRUCTION, cleanRecapText } from './session-recap.js';
+import { cleanRecapText } from './session-recap.js';
 
 export interface MakaCliRuntimeContext {
   /** Legacy shared-root input retained for callers that do not split roots. */
@@ -505,26 +503,11 @@ export async function createMakaCliRuntimeContext(
               }
             : {}),
         });
-        const contextWindow = resolveSelectedModelContextWindow(ready.connection, ready.model);
-        // Same budget-policy construction the backend uses (buildDefaultContextBudgetPolicy
-        // + applyRuntimeEventContextBudget), with the cap overridden to the
-        // recap-specific 85%-of-window-minus-4096 semantics. An unknown context
-        // window skips trimming entirely rather than guessing a cap.
-        let trimmedEvents = view.events;
-        if (contextWindow !== undefined) {
-          const budgetPolicy = buildDefaultContextBudgetPolicy(ready.connection, {
-            name: 'session-recap-history-budget',
-            modelId: ready.model,
-          });
-          if (budgetPolicy?.maxHistoryEstimatedTokens !== undefined) {
-            budgetPolicy.maxHistoryEstimatedTokens = Math.floor(contextWindow * 0.85) - 4096;
-          }
-          trimmedEvents =
-            applyRuntimeEventContextBudget(view.events, budgetPolicy)?.events ?? view.events;
-        }
-        const plan = buildRuntimeEventModelReplayPlan(trimmedEvents);
-        requestMessages = replayPlanItemsToModelMessages(plan.items);
-        requestMessages.push({ role: 'user', content: RECAP_INSTRUCTION });
+        requestMessages = buildSessionRecapMessages({
+          events: view.events,
+          connection: ready.connection,
+          modelId: ready.model,
+        });
         const ai = (await import('ai')) as unknown as {
           generateText(opts: Record<string, unknown>): Promise<{ text: string }>;
         };

--- a/packages/cli/src/session-recap.ts
+++ b/packages/cli/src/session-recap.ts
@@ -1,10 +1,7 @@
-/**
- * Final instruction appended as the last user message when asking the model
- * to recap a session. No tools are offered on this call and the exchange is
- * never persisted to the session's own history.
- */
-export const RECAP_INSTRUCTION =
-  '<system-reminder>The user is returning to this session after being away. Write ONE sentence (roughly 25-40 words) recapping where things stand so they can resume instantly. Write the sentence in the language of the user\'s most recent substantive message; for mixed-language sessions use the dominant language of the user\'s messages. Lead with agency, phrased naturally in that language: if the session was mainly questions or review with no landed change, open by referencing what the user asked (the equivalent of "You asked ..."); if the agent landed changes, reference what was done (the equivalent of "We fixed/added/wired ..."); if almost nothing happened, say in that language that the session had just begun. Output only the sentence - no labels, no quotes, no preamble.</system-reminder>';
+import { cleanSessionRecapText, SESSION_RECAP_INSTRUCTION } from '@maka/runtime';
+
+export const RECAP_INSTRUCTION = SESSION_RECAP_INSTRUCTION;
+export const cleanRecapText = cleanSessionRecapText;
 
 /** Idle gap (ms) after which the first normal prompt on return triggers an automatic recap. */
 export const AUTO_RECAP_IDLE_MS = 180_000;
@@ -18,28 +15,6 @@ export const AUTO_RECAP_DISPLAY_LIMIT_BYTES = 500;
  * `Recap:` / `Summary:` / `回顾：`-style label, strips one layer of wrapping
  * quotes, and truncates to 1200 characters (with an ellipsis) if needed.
  */
-export function cleanRecapText(raw: string): string {
-  let text = raw.replace(/\s+/g, ' ').trim();
-  text = text.replace(/^(recap|summary|回顾)\s*[:：]\s*/i, '').trim();
-
-  const quotePairs: ReadonlyArray<readonly [string, string]> = [
-    ['"', '"'],
-    ["'", "'"],
-    ['“', '”'],
-  ];
-  for (const [open, close] of quotePairs) {
-    if (text.length >= 2 && text.startsWith(open) && text.endsWith(close)) {
-      text = text.slice(open.length, text.length - close.length).trim();
-      break;
-    }
-  }
-
-  if (text.length > 1200) {
-    text = `${text.slice(0, 1200)}…`;
-  }
-  return text;
-}
-
 export interface ShouldAutoRecapInput {
   /** Milliseconds since the last recorded user activity. */
   idleMs: number;

--- a/packages/core/src/__tests__/artifacts.test.ts
+++ b/packages/core/src/__tests__/artifacts.test.ts
@@ -66,6 +66,7 @@ describe('Artifact user-delete policy', () => {
       'deep_research',
       'subagent_writeback',
       'tool_result_archive',
+      'session_effect',
     ]);
     for (const source of ARTIFACT_SOURCES) {
       assert.equal(canUserDeleteArtifact({ source }), !protectedSources.has(source), source);

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -14,6 +14,7 @@ export const ARTIFACT_SOURCES = [
   'user_upload',
   'export',
   'snapshot',
+  'session_effect',
   'fixture',
 ] as const;
 
@@ -76,6 +77,7 @@ const ARTIFACT_USER_DELETE_ALLOWED_BY_SOURCE = {
   user_upload: true,
   export: true,
   snapshot: true,
+  session_effect: false,
   fixture: true,
 } as const satisfies Record<ArtifactSource, boolean>;
 

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -3,6 +3,8 @@ export const MODEL_CALL_KINDS = [
   'semantic_compact',
   'history_compact',
   'goal_evaluation',
+  'session_title',
+  'session_recap',
 ] as const;
 export type ModelCallKind = (typeof MODEL_CALL_KINDS)[number];
 

--- a/packages/runtime-host/src/__tests__/execution-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-composition.test.ts
@@ -119,6 +119,42 @@ test('composition drain preserves usage admission until active Runtime work sett
   });
 });
 
+test('production composition commits automatic titles through Host-owned Session effects', async () => {
+  await withCompositionRoot(async ({ root, owner }) => {
+    const { composition, manager } = await createCapturedExecutionComposition(owner);
+    try {
+      const session = await manager.createSession({
+        cwd: root,
+        backend: 'fake',
+        llmConnectionSlug: 'fake',
+        model: 'fake-model',
+        permissionMode: 'ask',
+      });
+      const started = await composition.handlers['turn.start'](
+        {
+          sessionId: session.id,
+          turnId: 'turn-title',
+          content: { text: 'Host owns this automatic title' },
+        },
+        {
+          hostEpoch: 'execution-composition-test',
+          connectionId: 'title-client',
+          surface: 'tui',
+          principal: 'local_os_user',
+          acquireResidency: () => ({ release() {} }),
+        },
+      );
+      assert.equal(started.ok, true);
+      await waitFor(async () => {
+        const summary = (await manager.listSessions()).find((item) => item.id === session.id);
+        return summary?.name === 'Host owns this automatic title';
+      });
+    } finally {
+      await composition.close();
+    }
+  });
+});
+
 test('production composition orphans ownerless ShellRuns before serving Resource queries', async () => {
   await withCompositionRoot(async ({ root, owner }) => {
     const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
@@ -537,5 +573,13 @@ async function withCompositionRoot(
   } finally {
     await owner.close();
     await rm(base, { recursive: true, force: true });
+  }
+}
+
+async function waitFor(predicate: () => Promise<boolean>, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await predicate())) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for condition');
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
   }
 }

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -27,7 +27,6 @@ import {
   type ProxiedFetchProxy,
   type ProxiedFetchTransport,
   type RunTraceEvent,
-  type RuntimeReadModelSessionView,
   type ScannedSkill,
   agentGraphIdForRootSession,
   buildParentAgentTools,
@@ -67,8 +66,6 @@ import {
   HostOAuthExecutionAuthority,
   OAuthExecutionCredentialError,
 } from '../server/oauth-execution-authority.js';
-import { SessionAdmissionGate } from '../server/session-admission-gate.js';
-import { HostSessionEffectCoordinator } from '../server/session-effect-coordinator.js';
 import type { HostSkillCatalogCoordinator } from '../server/skill-catalog-coordinator.js';
 import { AgentGraphProviderScenario } from './fixtures/agent-graph-provider-scenario.js';
 
@@ -1601,12 +1598,6 @@ test('Host Goal evaluator meters provider usage and aborts its physical request'
 
     let preflightDrainRequests = 0;
     let preflightTransportCreations = 0;
-    let preflightDraining = false;
-    const requestPreflightDrain = () => {
-      if (preflightDraining) return;
-      preflightDraining = true;
-      preflightDrainRequests += 1;
-    };
     const failingPreflightEffects = createHostSessionEffectModel({
       runtimePolicy: policy,
       oauthCredentials: new HostOAuthExecutionAuthority(policy),
@@ -1622,82 +1613,29 @@ test('Host Goal evaluator meters provider usage and aborts its physical request'
             assert.fail('preflight failure must not record provider usage'),
         },
       } as unknown as InteractiveUsageStoresWriter,
-      requestDrain: requestPreflightDrain,
+      requestDrain: () => {
+        preflightDrainRequests += 1;
+      },
       createFetchTransport: () => {
         preflightTransportCreations += 1;
         throw new Error('preflight failure must not create a provider transport');
       },
     });
-    const preflightArtifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
-    await preflightArtifacts.recover();
-    const preflightCoordinator = new HostSessionEffectCoordinator({
-      model: failingPreflightEffects,
-      readModel: {
-        getSessionView: async () => ({ events: [] }) as unknown as RuntimeReadModelSessionView,
-      },
-      artifacts: preflightArtifacts,
-      sessions: { probeSessionRemoval: async () => ({ kind: 'present' }) },
-      readSessionHeader: async () => session,
-      sessionAdmission: new SessionAdmissionGate(),
-      acquireResidency: () => ({ release() {} }),
-      requestDrain: requestPreflightDrain,
-    });
-    const preflightInput = {
+    const preflightResult = await failingPreflightEffects.generateRecap({
       sessionId: session.id,
       effectId: 'recap-preflight-failure',
-      reason: 'manual' as const,
-    };
-    const preflightContext: ConnectionContext = {
-      hostEpoch: 'preflight-failure',
-      connectionId: 'preflight-failure',
-      surface: 'tui',
-      principal: 'local_os_user',
-      acquireResidency: () => ({ release() {} }),
-    };
-    assert.deepEqual(
-      await preflightCoordinator.handlers['session.recap.generate'](
-        preflightInput,
-        preflightContext,
-      ),
-      {
-        ok: false,
-        error: {
-          code: 'outcome_unknown',
-          message: 'Recap accounting outcome is unknown',
-        },
-      },
-    );
-    assert.deepEqual(
-      await preflightCoordinator.handlers['session.recap.generate'](
-        preflightInput,
-        preflightContext,
-      ),
-      {
-        ok: false,
-        error: {
-          code: 'outcome_unknown',
-          message: 'Recap provider outcome is unknown; use a new effect identity to retry',
-        },
-      },
-    );
+      header: session,
+      events: [],
+      abortSignal: new AbortController().signal,
+    });
+    assert.equal(preflightResult.ok, false);
+    if (!preflightResult.ok) assert.equal(preflightResult.errorClass, 'persistence');
     assert.equal(preflightTransportCreations, 0);
     assert.equal(preflightDrainRequests, 1);
-    assert.equal(
-      (await preflightArtifacts.listPage(session.id, { offset: 0, limit: 10 })).records.length,
-      1,
-    );
-    await preflightCoordinator.close();
-    preflightArtifacts.close();
 
     let oauthDrainRequests = 0;
     let oauthProviderDispatches = 0;
     let oauthTransportCloses = 0;
-    let oauthDraining = false;
-    const requestOAuthDrain = () => {
-      if (oauthDraining) return;
-      oauthDraining = true;
-      oauthDrainRequests += 1;
-    };
     const oauthPersistenceEffects = createHostSessionEffectModel({
       runtimePolicy: {
         operations: {
@@ -1739,7 +1677,9 @@ test('Host Goal evaluator meters provider usage and aborts its physical request'
       } as unknown as HostOAuthExecutionAuthority,
       claudeDeviceId: capability.rootId,
       usage,
-      requestDrain: requestOAuthDrain,
+      requestDrain: () => {
+        oauthDrainRequests += 1;
+      },
       createFetchTransport: () => ({
         fetch: async () => {
           oauthProviderDispatches += 1;
@@ -1750,55 +1690,18 @@ test('Host Goal evaluator meters provider usage and aborts its physical request'
         },
       }),
     });
-    const oauthArtifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
-    await oauthArtifacts.recover();
-    const oauthCoordinator = new HostSessionEffectCoordinator({
-      model: oauthPersistenceEffects,
-      readModel: {
-        getSessionView: async () => ({ events: [] }) as unknown as RuntimeReadModelSessionView,
-      },
-      artifacts: oauthArtifacts,
-      sessions: { probeSessionRemoval: async () => ({ kind: 'present' }) },
-      readSessionHeader: async () => session,
-      sessionAdmission: new SessionAdmissionGate(),
-      acquireResidency: () => ({ release() {} }),
-      requestDrain: requestOAuthDrain,
-    });
-    const oauthInput = {
+    const oauthResult = await oauthPersistenceEffects.generateRecap({
       sessionId: session.id,
       effectId: 'recap-oauth-persistence-failure',
-      reason: 'manual' as const,
-    };
-    assert.deepEqual(
-      await oauthCoordinator.handlers['session.recap.generate'](oauthInput, preflightContext),
-      {
-        ok: false,
-        error: {
-          code: 'outcome_unknown',
-          message: 'Recap accounting outcome is unknown',
-        },
-      },
-    );
-    assert.deepEqual(
-      await oauthCoordinator.handlers['session.recap.generate'](oauthInput, preflightContext),
-      {
-        ok: false,
-        error: {
-          code: 'outcome_unknown',
-          message: 'Recap provider outcome is unknown; use a new effect identity to retry',
-        },
-      },
-    );
+      header: session,
+      events: [],
+      abortSignal: new AbortController().signal,
+    });
+    assert.equal(oauthResult.ok, false);
+    if (!oauthResult.ok) assert.equal(oauthResult.errorClass, 'persistence');
     assert.equal(oauthProviderDispatches, 1);
     assert.equal(oauthTransportCloses, 1);
     assert.equal(oauthDrainRequests, 1);
-    const oauthRecords = (
-      await oauthArtifacts.listPage(session.id, { offset: 0, limit: 10 })
-    ).records.filter((record) => record.turnId === oauthInput.effectId);
-    assert.equal(oauthRecords.length, 1);
-    assert.equal(oauthRecords[0]?.name, 'session-recap-intent.json');
-    await oauthCoordinator.close();
-    oauthArtifacts.close();
 
     let accountingDrains = 0;
     const accountingAbort = new AbortController();

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -27,9 +27,11 @@ import {
   type ProxiedFetchProxy,
   type ProxiedFetchTransport,
   type RunTraceEvent,
+  type RuntimeReadModelSessionView,
   type ScannedSkill,
   agentGraphIdForRootSession,
   buildParentAgentTools,
+  SESSION_RECAP_INSTRUCTION,
 } from '@maka/runtime';
 import { createSqliteRuntimeStore } from '@maka/storage';
 import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
@@ -41,21 +43,32 @@ import {
 } from '@maka/storage/runtime-policy-stores';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-authority';
-import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
+import {
+  openInteractiveUsageStoresForWrite,
+  type InteractiveUsageStoresWriter,
+} from '@maka/storage/usage-stores';
 import type { TurnSnapshot, UsageQueryResult } from '../protocol/index.js';
 import type { ClientCapabilityHostFrame } from '../protocol/index.js';
 import { createExecutionRuntimeHostComposition } from '../server/execution-composition.js';
 import {
+  createHostGoalEvaluator,
+  createHostSessionEffectModel,
+} from '../server/execution-model-authority.js';
+import {
   createHostAiSdkBackend,
   createHostExecutionModelComposition,
-  createHostGoalEvaluator,
   type HostAiSdkBackendInput,
 } from '../server/execution-model-composition.js';
 import { HostClientCapabilityCoordinator } from '../server/client-capability-coordinator.js';
 import type { HostMemoryCoordinator } from '../server/memory-coordinator.js';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
 import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
-import { HostOAuthExecutionAuthority } from '../server/oauth-execution-authority.js';
+import {
+  HostOAuthExecutionAuthority,
+  OAuthExecutionCredentialError,
+} from '../server/oauth-execution-authority.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+import { HostSessionEffectCoordinator } from '../server/session-effect-coordinator.js';
 import type { HostSkillCatalogCoordinator } from '../server/skill-catalog-coordinator.js';
 import { AgentGraphProviderScenario } from './fixtures/agent-graph-provider-scenario.js';
 
@@ -651,7 +664,11 @@ test('production Host executes a canonical ai-sdk Session against a real provide
     }
 
     const mainRequests = provider.requests.filter((request) => request.body.stream === true);
-    const compactRequests = provider.requests.filter((request) => request.body.stream !== true);
+    const compactRequests = provider.requests.filter(
+      (request) =>
+        request.body.stream !== true &&
+        /context summarization assistant/.test(JSON.stringify(request.body)),
+    );
     assert.equal(mainRequests.length, 5);
     assert.ok(compactRequests.length >= 1);
     const request = mainRequests[0];
@@ -738,16 +755,17 @@ test('production Host executes a canonical ai-sdk Session against a real provide
     );
     assert.equal(compactUsage.inputTokens, 7);
     assert.equal(compactUsage.outputTokens, 3);
-    const evidence = await waitForProviderEvidence(execution, session.id, provider.requests.length);
-    assert.equal(evidence.captures.length, provider.requests.length);
-    assert.equal(evidence.attempts.length, provider.requests.length);
+    const capturedRequestCount = mainRequests.length + compactRequests.length;
+    const evidence = await waitForProviderEvidence(execution, session.id, capturedRequestCount);
+    assert.equal(evidence.captures.length, capturedRequestCount);
+    assert.equal(evidence.attempts.length, capturedRequestCount);
 
     const artifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
     const artifactPage = await artifacts.listPage(session.id, { offset: 0, limit: 100 });
     const captureArtifacts = artifactPage.records.filter(
       (artifact) => artifact.source === 'provider_request_capture',
     );
-    assert.equal(captureArtifacts.length, provider.requests.length);
+    assert.equal(captureArtifacts.length, capturedRequestCount);
     let summaryCaptureFound = false;
     for (const artifact of captureArtifacts) {
       const read = await artifacts.readTextInSession(session.id, artifact.id);
@@ -1522,6 +1540,337 @@ test('Host Goal evaluator meters provider usage and aborts its physical request'
     assert.equal(recorded.status, 'success');
     await evaluator.close();
 
+    const sessionEffects = createHostSessionEffectModel({
+      runtimePolicy: policy,
+      oauthCredentials: new HostOAuthExecutionAuthority(policy),
+      claudeDeviceId: capability.rootId,
+      usage,
+      requestDrain: () => assert.fail('Session effect telemetry must not drain the Host'),
+      newId: () => 'effect-call-1',
+    });
+    assert.equal(
+      await sessionEffects.generateTitle({
+        sessionId: session.id,
+        header: session,
+        sourceText: 'Explain the Runtime Host ownership change',
+        abortSignal: new AbortController().signal,
+      }),
+      '## Goal',
+    );
+    const recap = await sessionEffects.generateRecap({
+      sessionId: session.id,
+      effectId: 'recap-effect-1',
+      header: session,
+      events: [],
+      abortSignal: new AbortController().signal,
+    });
+    assert.equal(recap.ok, true);
+    if (!recap.ok) return;
+    assert.equal(recap.modelId, MODEL_ID);
+    assert.deepEqual(recap.messages, [{ role: 'user', content: SESSION_RECAP_INSTRUCTION }]);
+    assert.equal(recap.raw, SUMMARY_TEXT);
+    const effectLogs = await usage.telemetry.logs({ range: 'all' });
+    assert.ok(
+      effectLogs.rows.some(
+        (row) =>
+          row.callKind === 'session_title' &&
+          row.callId === `session_title_${session.id}_effect-call-1`,
+      ),
+    );
+    assert.ok(
+      effectLogs.rows.some(
+        (row) =>
+          row.callKind === 'session_recap' &&
+          row.callId === `session_recap_${session.id}_recap-effect-1`,
+      ),
+    );
+
+    assert.deepEqual(
+      await sessionEffects.generateRecap({
+        sessionId: session.id,
+        effectId: 'recap-disabled-model',
+        header: { ...session, model: 'disabled-model' },
+        events: [],
+        abortSignal: new AbortController().signal,
+      }),
+      {
+        ok: false,
+        errorClass: 'configuration',
+      },
+    );
+
+    let preflightDrainRequests = 0;
+    let preflightTransportCreations = 0;
+    let preflightDraining = false;
+    const requestPreflightDrain = () => {
+      if (preflightDraining) return;
+      preflightDraining = true;
+      preflightDrainRequests += 1;
+    };
+    const failingPreflightEffects = createHostSessionEffectModel({
+      runtimePolicy: policy,
+      oauthCredentials: new HostOAuthExecutionAuthority(policy),
+      claudeDeviceId: capability.rootId,
+      usage: {
+        pricing: {
+          snapshot: async () => {
+            throw new Error('injected pricing snapshot failure');
+          },
+        },
+        telemetry: {
+          recordLlmCall: async () =>
+            assert.fail('preflight failure must not record provider usage'),
+        },
+      } as unknown as InteractiveUsageStoresWriter,
+      requestDrain: requestPreflightDrain,
+      createFetchTransport: () => {
+        preflightTransportCreations += 1;
+        throw new Error('preflight failure must not create a provider transport');
+      },
+    });
+    const preflightArtifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
+    await preflightArtifacts.recover();
+    const preflightCoordinator = new HostSessionEffectCoordinator({
+      model: failingPreflightEffects,
+      readModel: {
+        getSessionView: async () => ({ events: [] }) as unknown as RuntimeReadModelSessionView,
+      },
+      artifacts: preflightArtifacts,
+      sessions: { probeSessionRemoval: async () => ({ kind: 'present' }) },
+      readSessionHeader: async () => session,
+      sessionAdmission: new SessionAdmissionGate(),
+      acquireResidency: () => ({ release() {} }),
+      requestDrain: requestPreflightDrain,
+    });
+    const preflightInput = {
+      sessionId: session.id,
+      effectId: 'recap-preflight-failure',
+      reason: 'manual' as const,
+    };
+    const preflightContext: ConnectionContext = {
+      hostEpoch: 'preflight-failure',
+      connectionId: 'preflight-failure',
+      surface: 'tui',
+      principal: 'local_os_user',
+      acquireResidency: () => ({ release() {} }),
+    };
+    assert.deepEqual(
+      await preflightCoordinator.handlers['session.recap.generate'](
+        preflightInput,
+        preflightContext,
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'outcome_unknown',
+          message: 'Recap accounting outcome is unknown',
+        },
+      },
+    );
+    assert.deepEqual(
+      await preflightCoordinator.handlers['session.recap.generate'](
+        preflightInput,
+        preflightContext,
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'outcome_unknown',
+          message: 'Recap provider outcome is unknown; use a new effect identity to retry',
+        },
+      },
+    );
+    assert.equal(preflightTransportCreations, 0);
+    assert.equal(preflightDrainRequests, 1);
+    assert.equal(
+      (await preflightArtifacts.listPage(session.id, { offset: 0, limit: 10 })).records.length,
+      1,
+    );
+    await preflightCoordinator.close();
+    preflightArtifacts.close();
+
+    let oauthDrainRequests = 0;
+    let oauthProviderDispatches = 0;
+    let oauthTransportCloses = 0;
+    let oauthDraining = false;
+    const requestOAuthDrain = () => {
+      if (oauthDraining) return;
+      oauthDraining = true;
+      oauthDrainRequests += 1;
+    };
+    const oauthPersistenceEffects = createHostSessionEffectModel({
+      runtimePolicy: {
+        operations: {
+          resolveExecutionConnection: async () => ({
+            kind: 'ready',
+            connection: {
+              slug: 'oauth-persistence',
+              providerType: 'openai-codex',
+              enabledModelIds: [MODEL_ID],
+              models: [
+                {
+                  id: MODEL_ID,
+                  capabilities: { chat: true, functionCalling: true },
+                  contextWindow: 8_192,
+                  maxOutputTokens: 1_024,
+                },
+              ],
+            },
+            networkProxy: { enabled: false },
+            secretMaterial: { connection: { secret: 'oauth-material' } },
+          }),
+        },
+      } as unknown as RuntimePolicyStoresWriter,
+      oauthCredentials: {
+        bind: () => ({
+          providerType: 'openai-codex',
+          connectionSlug: 'oauth-persistence',
+          resolve: async () => ({
+            access_token: codexAccessToken('oauth-persistence-account'),
+            refresh_token: 'oauth-persistence-refresh',
+          }),
+          forceRefresh: async () => {
+            throw new OAuthExecutionCredentialError(
+              'persistence_failed',
+              'injected OAuth persistence failure',
+            );
+          },
+        }),
+      } as unknown as HostOAuthExecutionAuthority,
+      claudeDeviceId: capability.rootId,
+      usage,
+      requestDrain: requestOAuthDrain,
+      createFetchTransport: () => ({
+        fetch: async () => {
+          oauthProviderDispatches += 1;
+          return Response.json({ error: { message: 'expired credential' } }, { status: 401 });
+        },
+        close: async () => {
+          oauthTransportCloses += 1;
+        },
+      }),
+    });
+    const oauthArtifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
+    await oauthArtifacts.recover();
+    const oauthCoordinator = new HostSessionEffectCoordinator({
+      model: oauthPersistenceEffects,
+      readModel: {
+        getSessionView: async () => ({ events: [] }) as unknown as RuntimeReadModelSessionView,
+      },
+      artifacts: oauthArtifacts,
+      sessions: { probeSessionRemoval: async () => ({ kind: 'present' }) },
+      readSessionHeader: async () => session,
+      sessionAdmission: new SessionAdmissionGate(),
+      acquireResidency: () => ({ release() {} }),
+      requestDrain: requestOAuthDrain,
+    });
+    const oauthInput = {
+      sessionId: session.id,
+      effectId: 'recap-oauth-persistence-failure',
+      reason: 'manual' as const,
+    };
+    assert.deepEqual(
+      await oauthCoordinator.handlers['session.recap.generate'](oauthInput, preflightContext),
+      {
+        ok: false,
+        error: {
+          code: 'outcome_unknown',
+          message: 'Recap accounting outcome is unknown',
+        },
+      },
+    );
+    assert.deepEqual(
+      await oauthCoordinator.handlers['session.recap.generate'](oauthInput, preflightContext),
+      {
+        ok: false,
+        error: {
+          code: 'outcome_unknown',
+          message: 'Recap provider outcome is unknown; use a new effect identity to retry',
+        },
+      },
+    );
+    assert.equal(oauthProviderDispatches, 1);
+    assert.equal(oauthTransportCloses, 1);
+    assert.equal(oauthDrainRequests, 1);
+    const oauthRecords = (
+      await oauthArtifacts.listPage(session.id, { offset: 0, limit: 10 })
+    ).records.filter((record) => record.turnId === oauthInput.effectId);
+    assert.equal(oauthRecords.length, 1);
+    assert.equal(oauthRecords[0]?.name, 'session-recap-intent.json');
+    await oauthCoordinator.close();
+    oauthArtifacts.close();
+
+    let accountingDrains = 0;
+    const accountingAbort = new AbortController();
+    const accountingFailure = createHostSessionEffectModel({
+      runtimePolicy: policy,
+      oauthCredentials: new HostOAuthExecutionAuthority(policy),
+      claudeDeviceId: capability.rootId,
+      usage: {
+        pricing: usage.pricing,
+        telemetry: {
+          recordLlmCall: async () => {
+            accountingAbort.abort(new DOMException('Host drain raced accounting', 'AbortError'));
+            throw new Error('injected accounting failure');
+          },
+        },
+      } as unknown as InteractiveUsageStoresWriter,
+      requestDrain: () => {
+        accountingDrains += 1;
+      },
+    });
+    assert.deepEqual(
+      await accountingFailure.generateRecap({
+        sessionId: session.id,
+        effectId: 'recap-accounting-failure',
+        header: session,
+        events: [],
+        abortSignal: accountingAbort.signal,
+      }),
+      {
+        ok: false,
+        modelId: MODEL_ID,
+        messages: [{ role: 'user', content: SESSION_RECAP_INSTRUCTION }],
+        errorClass: 'persistence',
+      },
+    );
+    assert.equal(accountingDrains, 1);
+
+    let effectProviderSignal: AbortSignal | undefined;
+    let effectTransportCloses = 0;
+    const effectProviderDispatched = deferred<void>();
+    const stalledEffect = createHostSessionEffectModel({
+      runtimePolicy: policy,
+      oauthCredentials: new HostOAuthExecutionAuthority(policy),
+      claudeDeviceId: capability.rootId,
+      usage,
+      requestDrain: () => assert.fail('A provider timeout must not drain the Host'),
+      createFetchTransport: () => ({
+        fetch: async (_request, init) => {
+          effectProviderSignal = init?.signal ?? undefined;
+          effectProviderDispatched.resolve();
+          return new Promise<Response>(() => {});
+        },
+        close: async () => {
+          effectTransportCloses += 1;
+        },
+      }),
+    });
+    const timedEffect = stalledEffect.generateRecap({
+      sessionId: session.id,
+      effectId: 'recap-timeout',
+      header: session,
+      events: [],
+      abortSignal: AbortSignal.timeout(10),
+    });
+    await settleWithin(effectProviderDispatched.promise);
+    const timedResult = await settleWithin(timedEffect);
+    assert.equal(timedResult.ok, false);
+    if (timedResult.ok) return;
+    assert.equal(timedResult.errorClass, 'timeout');
+    assert.equal(effectProviderSignal?.aborted, true);
+    assert.equal(effectTransportCloses, 1);
+
     let providerSignal: AbortSignal | undefined;
     let transportCloses = 0;
     const providerDispatched = deferred<void>();
@@ -2092,6 +2441,13 @@ function readyExecutionConnection(baseUrl?: string) {
       connection: { secret: API_KEY },
     },
   };
+}
+
+function codexAccessToken(accountId: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ 'https://api.openai.com/auth': { chatgpt_account_id: accountId } }),
+  ).toString('base64url');
+  return `header.${payload}.signature`;
 }
 
 async function settleWithin<T>(pending: Promise<T>): Promise<T> {

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -99,6 +99,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'session.lifecycle.set',
       'session.metadata.update',
       'session.read_marker.set',
+      'session.recap.generate',
       'session.remove',
       'session.revision.create',
       'skill.catalog.mutate',

--- a/packages/runtime-host/src/__tests__/session-effect-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-effect-coordinator.test.ts
@@ -1,0 +1,340 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { SessionHeader } from '@maka/core/session';
+import type { RuntimeReadModelSessionView } from '@maka/runtime';
+import { openInteractiveArtifactStoreForWrite } from '@maka/storage/artifact-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import type { ConnectionContext } from '../server/operation-dispatcher.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+import { HostSessionEffectCoordinator } from '../server/session-effect-coordinator.js';
+import type { HostSessionEffectModel } from '../server/execution-model-authority.js';
+
+const connectionContext: ConnectionContext = {
+  hostEpoch: 'host-epoch-1',
+  connectionId: 'connection-1',
+  surface: 'tui',
+  principal: 'local_os_user',
+  acquireResidency: () => ({ release: () => undefined }),
+};
+
+test('Session recap publishes one protected result and exact retries never repeat provider work', async () => {
+  await withHarness(async ({ store, coordinator, modelCalls }) => {
+    const input = { sessionId: 'session-1', effectId: 'effect-1', reason: 'manual' as const };
+    const generated = {
+      ok: true as const,
+      result: {
+        kind: 'generated' as const,
+        effectId: 'effect-1',
+        reason: 'manual' as const,
+        text: 'We shipped the Host-owned recap.',
+        raw: 'Recap: "We shipped the Host-owned recap."',
+      },
+    };
+
+    assert.deepEqual(
+      await coordinator.handlers['session.recap.generate'](input, connectionContext),
+      generated,
+    );
+    assert.deepEqual(
+      await coordinator.handlers['session.recap.generate'](input, {
+        ...connectionContext,
+        connectionId: 'connection-2',
+      }),
+      generated,
+    );
+    assert.equal(modelCalls.count, 1);
+
+    const successor = createCoordinator(
+      store,
+      {
+        generateTitle: async () => undefined,
+        generateRecap: async () => assert.fail('a durable exact retry must not call the model'),
+      },
+      {
+        readSessionHeader: async () =>
+          ({ isArchived: true, status: 'archived' }) as unknown as SessionHeader,
+      },
+    );
+    assert.deepEqual(
+      await successor.handlers['session.recap.generate'](input, connectionContext),
+      generated,
+    );
+    assert.equal(modelCalls.count, 1);
+    assert.deepEqual(
+      await successor.handlers['session.recap.generate'](
+        { ...input, reason: 'idle' },
+        connectionContext,
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'operation_conflict',
+          message: 'Recap effect identity is already in use',
+        },
+      },
+    );
+    assert.deepEqual(
+      await successor.handlers['session.recap.generate'](
+        { sessionId: 'session-1', effectId: 'effect-new', reason: 'manual' },
+        connectionContext,
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'session_archived',
+          message: 'Archived Session cannot generate a recap',
+        },
+      },
+    );
+
+    const records = await store.listPage('session-1', { offset: 0, limit: 10 });
+    assert.equal(records.records.length, 2);
+    for (const record of records.records) {
+      assert.equal(record.source, 'session_effect');
+      assert.equal(
+        (await store.deleteUserArtifactInSession('session-1', record.id)).kind,
+        'protected',
+      );
+    }
+    await successor.close();
+  });
+});
+
+test('Session effect leaves Turn admission free and drain aborts accepted recap work', async () => {
+  const started = gate();
+  await withHarness(
+    async ({ store, coordinator, admission }) => {
+      const pending = coordinator.handlers['session.recap.generate'](
+        { sessionId: 'session-1', effectId: 'effect-running', reason: 'idle' },
+        connectionContext,
+      );
+      await started.promise;
+      assert.equal(coordinator.hasLiveSessionState('session-1'), true);
+      assert.equal(await admission.run('session-1', () => 'turn admitted'), 'turn admitted');
+      const successor = createCoordinator(
+        store,
+        {
+          generateTitle: async () => undefined,
+          generateRecap: async () => assert.fail('an intent without a result must not be retried'),
+        },
+        {
+          readSessionHeader: async () =>
+            ({ isArchived: true, status: 'archived' }) as unknown as SessionHeader,
+        },
+      );
+      assert.deepEqual(
+        await successor.handlers['session.recap.generate'](
+          { sessionId: 'session-1', effectId: 'effect-running', reason: 'idle' },
+          { ...connectionContext, connectionId: 'successor-client' },
+        ),
+        {
+          ok: false,
+          error: {
+            code: 'outcome_unknown',
+            message: 'Recap provider outcome is unknown; use a new effect identity to retry',
+          },
+        },
+      );
+      await successor.close();
+      coordinator.beginDrain();
+      assert.deepEqual(
+        await coordinator.handlers['session.recap.generate'](
+          { sessionId: 'session-1', effectId: 'effect-rejected', reason: 'manual' },
+          connectionContext,
+        ),
+        {
+          ok: false,
+          error: { code: 'host_draining', message: 'Runtime Host is draining' },
+        },
+      );
+      let closed = false;
+      const close = coordinator.close().then(() => {
+        closed = true;
+      });
+      const result = await pending;
+      assert.deepEqual(result, {
+        ok: true,
+        result: {
+          kind: 'failed',
+          effectId: 'effect-running',
+          reason: 'idle',
+          errorClass: 'aborted',
+        },
+      });
+      await close;
+      assert.equal(closed, true);
+      assert.equal(coordinator.hasLiveSessionState('session-1'), false);
+    },
+    {
+      generateTitle: async () => undefined,
+      generateRecap: async ({ abortSignal }) => {
+        started.release();
+        await new Promise<void>((resolve) =>
+          abortSignal.addEventListener('abort', () => resolve(), { once: true }),
+        );
+        return {
+          ok: false,
+          errorClass: 'aborted',
+        };
+      },
+    },
+  );
+});
+
+test('Automatic title generation fences retirement until the effect settles', async () => {
+  const started = gate();
+  await withHarness(
+    async ({ coordinator }) => {
+      const pending = coordinator.generateTitle({
+        sessionId: 'session-1',
+        header: { id: 'session-1' } as SessionHeader,
+        sourceText: 'A first user message',
+      });
+      await started.promise;
+      assert.equal(coordinator.hasLiveSessionState('session-1'), true);
+      assert.equal(coordinator.hasLiveSessionState('session-2'), false);
+
+      coordinator.beginDrain();
+      assert.equal(await pending, undefined);
+      assert.equal(coordinator.hasLiveSessionState('session-1'), false);
+    },
+    {
+      generateTitle: async ({ abortSignal }) => {
+        started.release();
+        await new Promise<void>((resolve) =>
+          abortSignal.addEventListener('abort', () => resolve(), { once: true }),
+        );
+        return undefined;
+      },
+      generateRecap: async () => assert.fail('title generation must not call recap'),
+    },
+  );
+});
+
+test('Session recap keeps accounting failures non-terminal and unsafe to retry', async () => {
+  let modelCalls = 0;
+  let drains = 0;
+  await withHarness(
+    async ({ store, coordinator }) => {
+      const input = {
+        sessionId: 'session-1',
+        effectId: 'effect-accounting',
+        reason: 'manual' as const,
+      };
+      const unknown = {
+        ok: false as const,
+        error: {
+          code: 'outcome_unknown' as const,
+          message: 'Recap accounting outcome is unknown',
+        },
+      };
+      assert.deepEqual(
+        await coordinator.handlers['session.recap.generate'](input, connectionContext),
+        unknown,
+      );
+      assert.deepEqual(
+        await coordinator.handlers['session.recap.generate'](input, connectionContext),
+        {
+          ok: false,
+          error: {
+            code: 'outcome_unknown',
+            message: 'Recap provider outcome is unknown; use a new effect identity to retry',
+          },
+        },
+      );
+      assert.equal(modelCalls, 1);
+      assert.equal(drains, 1);
+      assert.equal((await store.listPage('session-1', { offset: 0, limit: 10 })).records.length, 1);
+    },
+    {
+      generateTitle: async () => undefined,
+      generateRecap: async () => {
+        modelCalls += 1;
+        return { ok: false, errorClass: 'persistence' };
+      },
+    },
+    { requestDrain: () => (drains += 1) },
+  );
+});
+
+async function withHarness(
+  run: (input: {
+    store: Awaited<ReturnType<typeof openInteractiveArtifactStoreForWrite>>;
+    coordinator: HostSessionEffectCoordinator;
+    modelCalls: { count: number };
+    admission: SessionAdmissionGate;
+  }) => Promise<void>,
+  overrideModel?: HostSessionEffectModel,
+  options?: CoordinatorOptions,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-session-effect-'));
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  try {
+    const store = await openInteractiveArtifactStoreForWrite(owner.lease);
+    await store.recover();
+    const modelCalls = { count: 0 };
+    const model: HostSessionEffectModel =
+      overrideModel ??
+      ({
+        generateTitle: async () => undefined,
+        generateRecap: async () => {
+          modelCalls.count += 1;
+          return {
+            ok: true,
+            modelId: 'openrouter/free',
+            messages: [{ role: 'user', content: 'history' }],
+            raw: 'Recap: "We shipped the Host-owned recap."',
+          };
+        },
+      } satisfies HostSessionEffectModel);
+    const admission = options?.admission ?? new SessionAdmissionGate();
+    const coordinator = createCoordinator(store, model, { ...options, admission });
+    await run({ store, coordinator, modelCalls, admission });
+    await coordinator.close();
+  } finally {
+    await owner.close();
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function createCoordinator(
+  artifacts: Awaited<ReturnType<typeof openInteractiveArtifactStoreForWrite>>,
+  model: HostSessionEffectModel,
+  options: CoordinatorOptions = {},
+): HostSessionEffectCoordinator {
+  return new HostSessionEffectCoordinator({
+    model,
+    readModel: {
+      getSessionView: async () => ({ events: [] }) as unknown as RuntimeReadModelSessionView,
+    },
+    artifacts,
+    sessions: { probeSessionRemoval: async () => ({ kind: 'present' }) },
+    readSessionHeader:
+      options.readSessionHeader ??
+      (async () => ({ isArchived: false, status: 'active' }) as unknown as SessionHeader),
+    sessionAdmission: options.admission ?? new SessionAdmissionGate(),
+    acquireResidency: () => ({ release: () => undefined }),
+    requestDrain:
+      options.requestDrain ??
+      (() => assert.fail('healthy Session effects must not request Host drain')),
+  });
+}
+
+interface CoordinatorOptions {
+  readonly admission?: SessionAdmissionGate;
+  readonly readSessionHeader?: (sessionId: string) => Promise<SessionHeader>;
+  readonly requestDrain?: () => void;
+}
+
+function gate(): { promise: Promise<void>; release(): void } {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}

--- a/packages/runtime-host/src/__tests__/session-effect-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-effect-two-client-uds.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { SessionHeader } from '@maka/core/session';
+import type { RuntimeReadModelSessionView } from '@maka/runtime';
+import { openInteractiveArtifactStoreForWrite } from '@maka/storage/artifact-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.js';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '../protocol/index.js';
+import { RuntimeHostKernel } from '../server/host-kernel.js';
+import { createUnavailableDomainOperationHandlers } from '../server/operation-dispatcher.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+import { HostSessionEffectCoordinator } from '../server/session-effect-coordinator.js';
+
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+
+test('two UDS Clients share one durable Session recap effect', {
+  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-session-effect-uds-'));
+  const root = join(base, 'interactive');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  let modelCalls = 0;
+  const modelStarted = gate();
+  const modelRelease = gate();
+  const host = await RuntimeHostKernel.start({
+    owner,
+    idleGraceMs: 10_000,
+    compositionFactory: async (context) => {
+      const artifacts = await openInteractiveArtifactStoreForWrite(context.owner.lease);
+      const coordinator = new HostSessionEffectCoordinator({
+        model: {
+          generateTitle: async () => undefined,
+          generateRecap: async () => {
+            modelCalls += 1;
+            modelStarted.release();
+            await modelRelease.promise;
+            return {
+              ok: true,
+              modelId: 'openrouter/free',
+              messages: [{ role: 'user', content: 'canonical history' }],
+              raw: 'We connected two Clients to one recap effect.',
+            };
+          },
+        },
+        readModel: {
+          getSessionView: async () => ({ events: [] }) as unknown as RuntimeReadModelSessionView,
+        },
+        artifacts,
+        sessions: { probeSessionRemoval: async () => ({ kind: 'present' }) },
+        readSessionHeader: async () =>
+          ({ isArchived: false, status: 'active' }) as unknown as SessionHeader,
+        sessionAdmission: new SessionAdmissionGate(),
+        acquireResidency: context.acquireResidency,
+        requestDrain: context.requestDrain,
+      });
+      return {
+        handlers: {
+          ...createUnavailableDomainOperationHandlers(),
+          ...coordinator.handlers,
+        },
+        beginDrain: () => coordinator.beginDrain(),
+        recover: () => artifacts.recover(),
+        close: async () => {
+          await coordinator.close();
+          artifacts.close();
+        },
+      };
+    },
+  });
+  let desktop: RuntimeHostConnection | undefined;
+  let tui: RuntimeHostConnection | undefined;
+  try {
+    desktop = await connect(root, 'desktop');
+    tui = await connect(root, 'tui');
+    const input = { sessionId: 'session-1', effectId: 'effect-1', reason: 'manual' as const };
+    const desktopResult = desktop.generateSessionRecap(input);
+    await modelStarted.promise;
+    const tuiResult = tui.generateSessionRecap(input);
+    modelRelease.release();
+    const [first, second] = await Promise.all([desktopResult, tuiResult]);
+    assert.deepEqual(first, {
+      kind: 'generated',
+      effectId: 'effect-1',
+      reason: 'manual',
+      text: 'We connected two Clients to one recap effect.',
+      raw: 'We connected two Clients to one recap effect.',
+    });
+    assert.deepEqual(second, first);
+    assert.equal(modelCalls, 1);
+  } finally {
+    await Promise.allSettled([desktop?.close(), tui?.close()]);
+    await host.close().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+function gate(): { promise: Promise<void>; release(): void } {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+async function connect(
+  rootPath: string,
+  surface: 'desktop' | 'tui',
+): Promise<RuntimeHostConnection> {
+  const result = await connectRuntimeHost({ rootPath, surface, protocol: PROTOCOL });
+  assert.equal(result.kind, 'connected');
+  if (result.kind !== 'connected') throw new Error('Unable to connect to Runtime Host');
+  return result.connection;
+}

--- a/packages/runtime-host/src/__tests__/session-effects-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-effects-protocol.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  decodeClientFrame,
+  decodeHostFrame,
+  RuntimeHostProtocolError,
+  SESSION_EFFECT_OPERATION_SPECS,
+  SESSION_RECAP_RAW_MAX_BYTES,
+} from '../protocol/index.js';
+
+test('Session recap is one ready command with stable effect identity', () => {
+  assert.deepEqual(Object.keys(SESSION_EFFECT_OPERATION_SPECS), ['session.recap.generate']);
+  assert.deepEqual(
+    {
+      mode: SESSION_EFFECT_OPERATION_SPECS['session.recap.generate'].mode,
+      availability: SESSION_EFFECT_OPERATION_SPECS['session.recap.generate'].availability,
+      errors: SESSION_EFFECT_OPERATION_SPECS['session.recap.generate'].errors,
+    },
+    {
+      mode: 'command',
+      availability: 'ready',
+      errors: [
+        'host_not_ready',
+        'host_draining',
+        'operation_unavailable',
+        'not_found',
+        'session_archived',
+        'operation_conflict',
+        'persistence_failed',
+        'outcome_unknown',
+        'internal_failure',
+      ],
+    },
+  );
+
+  const request = {
+    requestId: 'request-1',
+    operation: 'session.recap.generate',
+    input: { sessionId: 'session-1', effectId: 'effect-1', reason: 'manual' },
+  };
+  assert.deepEqual(decodeClientFrame(request), request);
+});
+
+test('Session recap exposes only bounded generated text or a closed failure class', () => {
+  for (const result of [
+    {
+      kind: 'generated',
+      effectId: 'effect-1',
+      reason: 'manual',
+      text: 'We wired Host-owned Session effects.',
+      raw: 'We wired Host-owned Session effects.',
+    },
+    {
+      kind: 'failed',
+      effectId: 'effect-2',
+      reason: 'idle',
+      errorClass: 'timeout',
+    },
+  ]) {
+    const response = {
+      requestId: 'request-1',
+      operation: 'session.recap.generate',
+      ok: true,
+      result,
+    };
+    assert.deepEqual(decodeHostFrame(response), response);
+  }
+
+  assert.throws(
+    () =>
+      decodeHostFrame({
+        requestId: 'request-1',
+        operation: 'session.recap.generate',
+        ok: true,
+        result: {
+          kind: 'generated',
+          effectId: 'effect-1',
+          reason: 'manual',
+          text: 'bounded',
+          raw: 'x'.repeat(SESSION_RECAP_RAW_MAX_BYTES + 1),
+        },
+      }),
+    isProtocolError,
+  );
+  assert.throws(
+    () =>
+      decodeHostFrame({
+        requestId: 'request-1',
+        operation: 'session.recap.generate',
+        ok: true,
+        result: {
+          kind: 'failed',
+          effectId: 'effect-1',
+          reason: 'manual',
+          errorClass: 'raw_provider_error',
+        },
+      }),
+    isProtocolError,
+  );
+});
+
+test('Session recap rejects open or uncorrelated wire values', () => {
+  assert.throws(
+    () =>
+      decodeClientFrame({
+        requestId: 'request-1',
+        operation: 'session.recap.generate',
+        input: {
+          sessionId: 'session-1',
+          effectId: 'effect-1',
+          reason: 'manual',
+          model: 'client-selected-model',
+        },
+      }),
+    isProtocolError,
+  );
+  assert.throws(
+    () =>
+      SESSION_EFFECT_OPERATION_SPECS['session.recap.generate'].assertOutputForInput?.(
+        { sessionId: 'session-1', effectId: 'effect-1', reason: 'manual' },
+        {
+          kind: 'failed',
+          effectId: 'effect-other',
+          reason: 'manual',
+          errorClass: 'provider',
+        },
+      ),
+    isProtocolError,
+  );
+});
+
+function isProtocolError(error: unknown): boolean {
+  return error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame';
+}

--- a/packages/runtime-host/src/__tests__/session-retirement-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-retirement-coordinator.test.ts
@@ -294,6 +294,7 @@ describe('Host Session retirement coordinator', () => {
         harness.blockers.interaction,
         harness.blockers.goal,
         harness.blockers.resource,
+        harness.blockers.effect,
         harness.blockers.graph,
         harness.blockers.graphWake,
         harness.blockers.automation,
@@ -697,6 +698,7 @@ async function withHarness(
       interaction: new Set<string>(),
       goal: new Set<string>(),
       resource: new Set<string>(),
+      effect: new Set<string>(),
       graph: new Set<string>(),
       graphWake: new Set<string>(),
       automation: new Set<string>(),
@@ -779,6 +781,9 @@ async function withHarness(
       },
       resources: {
         hasLiveSessionResources: async (sessionId) => blockers.resource.has(sessionId),
+      },
+      sessionEffects: {
+        hasLiveSessionState: (sessionId) => blockers.effect.has(sessionId),
       },
       graph: {
         hasLiveSessionState: async (sessionId) => blockers.graph.has(sessionId),
@@ -873,6 +878,7 @@ interface RetirementHarness {
     readonly interaction: Set<string>;
     readonly goal: Set<string>;
     readonly resource: Set<string>;
+    readonly effect: Set<string>;
     readonly graph: Set<string>;
     readonly graphWake: Set<string>;
     readonly automation: Set<string>;

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -34,6 +34,8 @@ import {
   type SubscriptionFrame,
   type SubscriptionOpenInput,
   type SessionCwdRelocateInput,
+  type SessionRecapGenerateInput,
+  type SessionRecapGenerateResult,
   type SessionUpdateResult,
   type TurnQueryInput,
   type TurnRegenerateInput,
@@ -142,6 +144,10 @@ export interface RuntimeHostConnection {
     input: SessionCwdRelocateInput,
     timeoutMs?: number,
   ): Promise<SessionUpdateResult>;
+  generateSessionRecap(
+    input: SessionRecapGenerateInput,
+    timeoutMs?: number,
+  ): Promise<SessionRecapGenerateResult>;
   queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan>;
   startTurnResume(input: TurnResumeStartInput, timeoutMs?: number): Promise<TurnResumeStartResult>;
   openSessionSubscription(
@@ -337,6 +343,13 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     timeoutMs?: number,
   ): Promise<SessionUpdateResult> {
     return this.request('session.cwd.relocate', input, timeoutMs);
+  }
+
+  generateSessionRecap(
+    input: SessionRecapGenerateInput,
+    timeoutMs?: number,
+  ): Promise<SessionRecapGenerateResult> {
+    return this.request('session.recap.generate', input, timeoutMs);
   }
 
   queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan> {
@@ -779,6 +792,7 @@ function defaultRequestTimeoutMs(operation: DirectRequestOperationKey): number |
     case 'agent.graph.stop':
     case 'connection.models.fetch':
     case 'connection.test.run':
+    case 'session.recap.generate':
       // Completion effects own their deadlines and may wait for admitted work to settle.
       return undefined;
     default:

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -25,6 +25,7 @@ import { SESSION_CATALOG_OPERATION_SPECS } from './session-catalog.js';
 import { SESSION_CONTINUITY_OPERATION_SPECS } from './session-continuity.js';
 import { SESSION_REVISION_OPERATION_SPECS } from './session-revision.js';
 import { SESSION_RETIREMENT_OPERATION_SPECS } from './session-retirement.js';
+import { SESSION_EFFECT_OPERATION_SPECS } from './session-effects.js';
 import { SKILL_CATALOG_OPERATION_SPECS } from './skill-catalog.js';
 import { TASK_LEDGER_OPERATION_SPECS } from './task-ledger.js';
 import { TURN_OPERATION_SPECS } from './turn.js';
@@ -116,6 +117,7 @@ export * from './runtime-resource.js';
 export * from './session-catalog.js';
 export * from './session-revision.js';
 export * from './session-retirement.js';
+export * from './session-effects.js';
 export * from './skill-catalog.js';
 export * from './usage-pricing.js';
 
@@ -135,6 +137,7 @@ export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   INTERACTION_OPERATION_SPECS,
   SESSION_CONTINUITY_OPERATION_SPECS,
   SESSION_CATALOG_OPERATION_SPECS,
+  SESSION_EFFECT_OPERATION_SPECS,
   SESSION_REVISION_OPERATION_SPECS,
   SESSION_RETIREMENT_OPERATION_SPECS,
   ARTIFACT_OPERATION_SPECS,

--- a/packages/runtime-host/src/protocol/session-effects.ts
+++ b/packages/runtime-host/src/protocol/session-effects.ts
@@ -1,0 +1,133 @@
+import { requireEntityId, requireExactRecord, requireRecord, requireUtf8String } from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const SESSION_RECAP_RAW_MAX_BYTES = 16 * 1024;
+export const SESSION_RECAP_TEXT_MAX_BYTES = 4 * 1024;
+
+export type SessionRecapReason = 'manual' | 'idle';
+export type SessionRecapFailureClass =
+  | 'aborted'
+  | 'timeout'
+  | 'configuration'
+  | 'provider'
+  | 'invalid_response'
+  | 'empty_response'
+  | 'unknown';
+
+export interface SessionRecapGenerateInput {
+  readonly sessionId: string;
+  /** Stable logical identity reused when a Client retries the same model effect. */
+  readonly effectId: string;
+  readonly reason: SessionRecapReason;
+}
+
+export type SessionRecapGenerateResult =
+  | {
+      readonly kind: 'generated';
+      readonly effectId: string;
+      readonly reason: SessionRecapReason;
+      readonly text: string;
+      readonly raw: string;
+    }
+  | {
+      readonly kind: 'failed';
+      readonly effectId: string;
+      readonly reason: SessionRecapReason;
+      readonly errorClass: SessionRecapFailureClass;
+    };
+
+const SESSION_EFFECT_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'not_found',
+  'session_archived',
+  'operation_conflict',
+  'persistence_failed',
+  'outcome_unknown',
+  'internal_failure',
+] as const;
+
+export const SESSION_EFFECT_OPERATION_SPECS = {
+  'session.recap.generate': defineOperation({
+    mode: 'command',
+    availability: 'ready',
+    errors: SESSION_EFFECT_ERRORS,
+    decodeInput: decodeSessionRecapGenerateInput,
+    decodeOutput: decodeSessionRecapGenerateResult,
+    assertOutputForInput: (input, output) => {
+      if (input.effectId !== output.effectId || input.reason !== output.reason) {
+        throw invalidProtocolFrame('Session recap changed effect identity');
+      }
+    },
+  }),
+} as const;
+
+export function decodeSessionRecapGenerateInput(value: unknown): SessionRecapGenerateInput {
+  const input = requireExactRecord(value, 'Session recap input', [
+    'sessionId',
+    'effectId',
+    'reason',
+  ]);
+  return {
+    sessionId: requireEntityId(input.sessionId, 'sessionId'),
+    effectId: requireEntityId(input.effectId, 'effectId'),
+    reason: decodeSessionRecapReason(input.reason),
+  };
+}
+
+export function decodeSessionRecapGenerateResult(value: unknown): SessionRecapGenerateResult {
+  const result = requireRecord(value, 'Session recap result');
+  if (result.kind === 'generated') {
+    const generated = requireExactRecord(result, 'Generated Session recap result', [
+      'kind',
+      'effectId',
+      'reason',
+      'text',
+      'raw',
+    ]);
+    return {
+      kind: 'generated',
+      effectId: requireEntityId(generated.effectId, 'effectId'),
+      reason: decodeSessionRecapReason(generated.reason),
+      text: requireUtf8String(generated.text, 'Session recap text', SESSION_RECAP_TEXT_MAX_BYTES),
+      raw: requireUtf8String(generated.raw, 'raw Session recap', SESSION_RECAP_RAW_MAX_BYTES),
+    };
+  }
+  const failed = requireExactRecord(result, 'Failed Session recap result', [
+    'kind',
+    'effectId',
+    'reason',
+    'errorClass',
+  ]);
+  if (failed.kind !== 'failed') throw invalidProtocolFrame('Invalid Session recap result kind');
+  return {
+    kind: 'failed',
+    effectId: requireEntityId(failed.effectId, 'effectId'),
+    reason: decodeSessionRecapReason(failed.reason),
+    errorClass: decodeSessionRecapFailureClass(failed.errorClass),
+  };
+}
+
+function decodeSessionRecapReason(value: unknown): SessionRecapReason {
+  if (value !== 'manual' && value !== 'idle') {
+    throw invalidProtocolFrame('Invalid Session recap reason');
+  }
+  return value;
+}
+
+function decodeSessionRecapFailureClass(value: unknown): SessionRecapFailureClass {
+  if (
+    value !== 'aborted' &&
+    value !== 'timeout' &&
+    value !== 'configuration' &&
+    value !== 'provider' &&
+    value !== 'invalid_response' &&
+    value !== 'empty_response' &&
+    value !== 'unknown'
+  ) {
+    throw invalidProtocolFrame('Invalid Session recap failure class');
+  }
+  return value;
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -14,6 +14,7 @@ import {
   isOAuthEnrollmentProviderEnabled,
   isBuiltinFilesystemWorkerSandboxAvailable,
   prepareSkillInvocationMessageFromInventory,
+  RuntimeReadModel,
   SessionManager,
   SessionActivityRegistry,
   ShellRunProcessManager,
@@ -56,8 +57,11 @@ import { HostClientCapabilityCoordinator } from './client-capability-coordinator
 import {
   createHostAiSdkBackend,
   createHostExecutionModelComposition,
-  createHostGoalEvaluator,
 } from './execution-model-composition.js';
+import {
+  createHostGoalEvaluator,
+  createHostSessionEffectModel,
+} from './execution-model-authority.js';
 import { HostExecutionInspectCoordinator } from './execution-inspect-coordinator.js';
 import { HostGoalCoordinator } from './goal-coordinator.js';
 import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './host-kernel.js';
@@ -77,6 +81,7 @@ import { SessionAdmissionGate } from './session-admission-gate.js';
 import { HostSessionCatalogCoordinator } from './session-catalog-coordinator.js';
 import { HostSessionRetirementCoordinator } from './session-retirement-coordinator.js';
 import { HostSessionRevisionCoordinator } from './session-revision-coordinator.js';
+import { HostSessionEffectCoordinator } from './session-effect-coordinator.js';
 import { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
 import { HostSkillCatalogCoordinator } from './skill-catalog-coordinator.js';
 import { SkillCatalogRepository } from './skill-catalog-repository.js';
@@ -101,6 +106,7 @@ export async function createExecutionRuntimeHostComposition(
     | Awaited<ReturnType<typeof openInteractiveAutomationAuthorityForWrite>>
     | undefined;
   let graphClient: HostAgentGraphCoordinator | undefined;
+  let sessionEffects: HostSessionEffectCoordinator | undefined;
   try {
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,
@@ -271,6 +277,7 @@ export async function createExecutionRuntimeHostComposition(
       messages.beginDrain();
       interactions.beginDrain();
       connectionEffects.beginDrain();
+      sessionEffects?.beginDrain();
       skills.beginDrain();
       memory?.beginDrain();
       oauth?.beginDrain();
@@ -366,6 +373,28 @@ export async function createExecutionRuntimeHostComposition(
         capabilitySnapshot?.release();
       }
     };
+    const sessionEffectCoordinator = new HostSessionEffectCoordinator({
+      model: createHostSessionEffectModel({
+        runtimePolicy: runtimePolicyStores,
+        oauthCredentials,
+        claudeDeviceId: context.owner.capability.rootId,
+        usage: openedUsageStores,
+        requestDrain: context.requestDrain,
+      }),
+      readModel: new RuntimeReadModel({
+        runStore: stores.agentRunStore,
+        runtimeEventStore: stores.runtimeEventStore,
+        projectionCache: stores.sessionStore,
+        canonicalPermissionOutcomes,
+      }),
+      artifacts: openedArtifactStore,
+      sessions: stores.sessionStore,
+      readSessionHeader: (sessionId) => stores.sessionStore.readHeaderSnapshot(sessionId),
+      sessionAdmission,
+      acquireResidency: context.acquireResidency,
+      requestDrain: context.requestDrain,
+    });
+    sessionEffects = sessionEffectCoordinator;
     manager = new SessionManager({
       store: stores.sessionStore,
       runStore: stores.agentRunStore,
@@ -375,6 +404,9 @@ export async function createExecutionRuntimeHostComposition(
       newId: randomUUID,
       now: Date.now,
       safeBoundaryResumeEnabled: process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME === '1',
+      generateSessionTitle: (input) => sessionEffectCoordinator.generateTitle(input),
+      onSessionTitleChanged: (sessionId) =>
+        continuityCoordinator.enqueueCanonicalRefresh(sessionId),
       inspectContinuationSafety: createLocalContinuationSafetyInspector({
         readSessionCwd: async (sessionId) =>
           (await stores.sessionStore.readHeaderSnapshot(sessionId)).cwd,
@@ -651,6 +683,7 @@ export async function createExecutionRuntimeHostComposition(
       goals: requireGoal(goal),
       automation: automations,
       resources: runtimeResources,
+      sessionEffects: sessionEffectCoordinator,
       graph: requireGraphCoordinator(graphCoordinator),
       graphWake: requireGraphSupervisorWake(graphSupervisorWake),
       manager,
@@ -679,6 +712,7 @@ export async function createExecutionRuntimeHostComposition(
       ...interactions.handlers,
       ...runtimePolicy.handlers,
       ...connectionEffects.handlers,
+      ...sessionEffectCoordinator.handlers,
       ...continuityCoordinator.handlers,
       ...taskLedger.handlers,
       ...artifacts.handlers,
@@ -777,6 +811,11 @@ export async function createExecutionRuntimeHostComposition(
         }
         try {
           await runtimeResources?.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
+          await sessionEffects?.close();
         } catch (error) {
           errors.push(error);
         }
@@ -890,6 +929,11 @@ export async function createExecutionRuntimeHostComposition(
     };
   } catch (error) {
     const errors: unknown[] = [error];
+    try {
+      await sessionEffects?.close();
+    } catch (closeError) {
+      errors.push(closeError);
+    }
     try {
       graphClient?.close();
     } catch (closeError) {

--- a/packages/runtime-host/src/server/execution-model-authority.ts
+++ b/packages/runtime-host/src/server/execution-model-authority.ts
@@ -1,0 +1,658 @@
+import { randomUUID } from 'node:crypto';
+import { PROVIDER_DEFAULTS, type RuntimeExecutionConnection } from '@maka/core/llm-connections';
+import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
+import type { RuntimePolicy } from '@maka/core/runtime-policy';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { SessionHeader } from '@maka/core/session';
+import type { ModelCallKind } from '@maka/core/usage-stats/types';
+import {
+  buildPricingLookup,
+  buildProviderOptions,
+  buildSessionRecapMessages,
+  buildSessionTitlePrompt,
+  cleanGeneratedSessionTitle,
+  createProxiedFetchTransport,
+  generateToolFreeModelCall,
+  getAIModel,
+  llmCallUsageFields,
+  recordLlmCallStrict,
+  SESSION_TITLE_GENERATION_TIMEOUT_MS,
+  type BackendFactoryContext,
+  type GoalEvaluatorResource,
+  type ModelMessage,
+  type ProxiedFetchProxy,
+  type ProxiedFetchTransport,
+  type ToolFreeModelCallContent,
+} from '@maka/runtime';
+import type { RuntimePolicyStoresWriter } from '@maka/storage/runtime-policy-stores';
+import type { InteractiveUsageStoresWriter } from '@maka/storage/usage-stores';
+import {
+  createHostOAuthModelFetch,
+  OAuthExecutionCredentialError,
+  type HostOAuthExecutionAuthority,
+  type HostOAuthExecutionBinding,
+} from './oauth-execution-authority.js';
+import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
+
+export interface HostGoalEvaluatorInput {
+  readonly runtimePolicy: RuntimePolicyStoresWriter;
+  readonly oauthCredentials: HostOAuthExecutionAuthority;
+  readonly claudeDeviceId: string;
+  readonly usage: InteractiveUsageStoresWriter;
+  readonly requestDrain: () => void;
+  readonly readSessionHeader: (sessionId: string) => Promise<SessionHeader>;
+  readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
+  readonly now?: () => number;
+  readonly newId?: () => string;
+}
+
+export type HostSessionEffectModelFailureClass =
+  | 'aborted'
+  | 'timeout'
+  | 'configuration'
+  | 'provider'
+  | 'persistence'
+  | 'unknown';
+
+export type HostSessionRecapModelResult =
+  | {
+      readonly ok: true;
+      readonly modelId: string;
+      readonly messages: readonly ModelMessage[];
+      readonly raw: string;
+    }
+  | {
+      readonly ok: false;
+      readonly modelId?: string;
+      readonly messages?: readonly ModelMessage[];
+      readonly errorClass: Exclude<HostSessionEffectModelFailureClass, 'persistence'>;
+    }
+  | {
+      readonly ok: false;
+      readonly modelId?: string;
+      readonly messages?: readonly ModelMessage[];
+      readonly errorClass: 'persistence';
+    };
+
+export interface HostSessionEffectModel {
+  generateTitle(input: {
+    readonly sessionId: string;
+    readonly header: SessionHeader;
+    readonly sourceText: string;
+    readonly abortSignal: AbortSignal;
+  }): Promise<string | undefined>;
+  generateRecap(input: {
+    readonly sessionId: string;
+    readonly effectId: string;
+    readonly header: SessionHeader;
+    readonly events: readonly RuntimeEvent[];
+    readonly abortSignal: AbortSignal;
+  }): Promise<HostSessionRecapModelResult>;
+}
+
+export type HostSessionEffectModelInput = Omit<HostGoalEvaluatorInput, 'readSessionHeader'>;
+
+/** Creates tool-free Session title and recap calls on canonical Host model authority. */
+export function createHostSessionEffectModel(
+  input: HostSessionEffectModelInput,
+): HostSessionEffectModel {
+  const authority = createAuxiliaryModelCallAuthority(input);
+  return Object.freeze({
+    generateTitle: async ({
+      sessionId,
+      header,
+      sourceText,
+      abortSignal: callerAbortSignal,
+    }: Parameters<HostSessionEffectModel['generateTitle']>[0]) => {
+      if (!sourceText.trim()) return undefined;
+      const abortSignal = AbortSignal.any([
+        callerAbortSignal,
+        AbortSignal.timeout(SESSION_TITLE_GENERATION_TIMEOUT_MS),
+      ]);
+      try {
+        const result = await runHostAuxiliaryModelCall(authority, {
+          sessionId,
+          header,
+          callKind: 'session_title',
+          callId: `session_title_${sessionId}_${authority.newId()}`,
+          abortSignal,
+          buildRequest: () => ({
+            prompt: buildSessionTitlePrompt(sourceText),
+            maxOutputTokens: 1_024,
+          }),
+        });
+        return result.finishReason === 'length'
+          ? undefined
+          : cleanGeneratedSessionTitle(result.text);
+      } catch {
+        return undefined;
+      }
+    },
+    generateRecap: async ({
+      sessionId,
+      effectId,
+      header,
+      events,
+      abortSignal: callerAbortSignal,
+    }: Parameters<HostSessionEffectModel['generateRecap']>[0]) => {
+      const abortSignal = AbortSignal.any([callerAbortSignal, AbortSignal.timeout(30_000)]);
+      let modelId: string | undefined;
+      let messages: readonly ModelMessage[] | undefined;
+      try {
+        const result = await runHostAuxiliaryModelCall(authority, {
+          sessionId,
+          header,
+          callKind: 'session_recap',
+          callId: `session_recap_${sessionId}_${effectId}`,
+          abortSignal,
+          buildRequest: (target) => {
+            modelId = target.model;
+            messages = buildSessionRecapMessages({
+              events,
+              connection: target.connection,
+              modelId: target.model,
+            });
+            return { messages, maxOutputTokens: 1_024 };
+          },
+        });
+        return {
+          ok: true as const,
+          modelId: result.modelId,
+          messages: messages ?? [],
+          raw: result.text,
+        };
+      } catch (error) {
+        return {
+          ok: false as const,
+          ...(modelId ? { modelId } : {}),
+          ...(messages ? { messages } : {}),
+          errorClass: sessionEffectModelErrorClass(error, abortSignal),
+        };
+      }
+    },
+  });
+}
+
+/** Creates a tool-free Goal judge on the Session's canonical connection and model. */
+export function createHostGoalEvaluator(input: HostGoalEvaluatorInput): GoalEvaluatorResource {
+  const authority = createAuxiliaryModelCallAuthority(input);
+  return createOwnedGoalEvaluator({
+    evaluate: async (prompt, sessionId, signal) => {
+      const header = await readDuringBackendCreation(
+        () => input.readSessionHeader(sessionId),
+        signal,
+      );
+      return (
+        await runHostAuxiliaryModelCall(authority, {
+          sessionId,
+          header,
+          callKind: 'goal_evaluation',
+          callId: `goal_evaluation_${sessionId}_${authority.newId()}`,
+          abortSignal: signal,
+          buildRequest: () => ({ prompt, maxOutputTokens: 1_024 }),
+        })
+      ).text;
+    },
+  });
+}
+
+type AuxiliaryModelCallAuthorityInput = Pick<
+  HostGoalEvaluatorInput,
+  | 'runtimePolicy'
+  | 'oauthCredentials'
+  | 'claudeDeviceId'
+  | 'usage'
+  | 'requestDrain'
+  | 'createFetchTransport'
+  | 'now'
+  | 'newId'
+>;
+
+interface AuxiliaryModelCallAuthority {
+  readonly runtimePolicy: RuntimePolicyStoresWriter;
+  readonly oauthCredentials: HostOAuthExecutionAuthority;
+  readonly claudeDeviceId: string;
+  readonly usage: InteractiveUsageStoresWriter;
+  readonly createFetchTransport: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
+  readonly telemetry: {
+    insertLlmCall(
+      record: Parameters<InteractiveUsageStoresWriter['telemetry']['recordLlmCall']>[0],
+    ): Promise<void>;
+  };
+  readonly requestDrain: () => void;
+  readonly now: () => number;
+  readonly newId: () => string;
+}
+
+type AuxiliaryModelRequest = ToolFreeModelCallContent & {
+  readonly maxOutputTokens: number;
+};
+
+interface HostAuxiliaryModelCallInput {
+  readonly sessionId: string;
+  readonly header: SessionHeader;
+  readonly callKind: Exclude<ModelCallKind, 'main'>;
+  readonly callId: string;
+  readonly abortSignal: AbortSignal;
+  readonly buildRequest: (target: ResolvedExecutionTarget) => AuxiliaryModelRequest;
+}
+
+function createAuxiliaryModelCallAuthority(
+  input: AuxiliaryModelCallAuthorityInput,
+): AuxiliaryModelCallAuthority {
+  let drainRequested = false;
+  const requestDrain = () => {
+    if (drainRequested) return;
+    drainRequested = true;
+    input.requestDrain();
+  };
+  return {
+    runtimePolicy: input.runtimePolicy,
+    oauthCredentials: input.oauthCredentials,
+    claudeDeviceId: input.claudeDeviceId,
+    usage: input.usage,
+    createFetchTransport: input.createFetchTransport ?? createProxiedFetchTransport,
+    telemetry: {
+      insertLlmCall: async (record) => {
+        try {
+          await input.usage.telemetry.recordLlmCall(record);
+        } catch (error) {
+          requestDrain();
+          throw error;
+        }
+      },
+    },
+    requestDrain,
+    now: input.now ?? Date.now,
+    newId: input.newId ?? randomUUID,
+  };
+}
+
+async function runHostAuxiliaryModelCall(
+  authority: AuxiliaryModelCallAuthority,
+  input: HostAuxiliaryModelCallInput,
+): Promise<{
+  readonly text: string;
+  readonly finishReason?: string;
+  readonly modelId: string;
+}> {
+  const target = await readAuxiliaryPreflight(authority, input.abortSignal, () =>
+    readDuringBackendCreation(
+      () =>
+        resolveExecutionTarget(
+          input.header,
+          authority.runtimePolicy,
+          authority.oauthCredentials,
+          authority.createFetchTransport,
+        ),
+      input.abortSignal,
+    ),
+  );
+  const pricingSnapshot = await readAuxiliaryPreflight(authority, input.abortSignal, () =>
+    readDuringBackendCreation(() => authority.usage.pricing.snapshot(), input.abortSignal),
+  );
+  const request = input.buildRequest(target);
+  const pricing = buildPricingLookup(pricingSnapshot.overrides);
+  const transport = authority.createFetchTransport(
+    toRuntimePolicyProxy(target.networkProxy, target.proxySecret),
+  );
+  let apiKey = target.apiKey;
+  let modelFetch: typeof fetch = transport.fetch;
+  let readDeferredOAuthFailure: (() => unknown | undefined) | undefined;
+  try {
+    if (target.oauthBinding) {
+      const oauth = normalizeAuxiliaryOAuthBinding(authority, target.oauthBinding);
+      readDeferredOAuthFailure = oauth.readDeferredFailure;
+      const initialOAuthTokens = await readDuringBackendCreation(
+        () => oauth.binding.resolve(),
+        input.abortSignal,
+      );
+      apiKey = initialOAuthTokens.access_token;
+      modelFetch = createHostOAuthModelFetch({
+        binding: oauth.binding,
+        initialTokens: initialOAuthTokens,
+        connection: target.connection,
+        sessionId: input.sessionId,
+        modelId: target.model,
+        claudeDeviceId: authority.claudeDeviceId,
+        fetchFn: transport.fetch,
+      });
+    }
+    const startedAt = authority.now();
+    const baseRecord = {
+      sessionId: input.sessionId,
+      callKind: input.callKind,
+      callId: input.callId,
+      connectionSlug: target.connection.slug,
+      providerId: target.connection.providerType,
+      modelId: target.model,
+      startedAt,
+    };
+    let result: Awaited<ReturnType<typeof generateToolFreeModelCall>>;
+    try {
+      result = await readDuringBackendCreation(
+        () =>
+          generateToolFreeModelCall({
+            model: getAIModel({
+              connection: target.connection,
+              apiKey,
+              modelId: target.model,
+              fetch: modelFetch,
+            }),
+            ...request,
+            abortSignal: input.abortSignal,
+            providerOptions: buildProviderOptions(
+              target.connection,
+              target.model,
+              input.header.thinkingLevel,
+            ),
+          }),
+        input.abortSignal,
+      );
+      const oauthFailure = readDeferredOAuthFailure?.();
+      if (oauthFailure) throw oauthFailure;
+    } catch (error) {
+      const effectiveError = readDeferredOAuthFailure?.() ?? error;
+      try {
+        await recordLlmCallStrict(
+          { repo: authority.telemetry, lookupPricing: pricing },
+          {
+            ...baseRecord,
+            inputTokens: 0,
+            outputTokens: 0,
+            latencyMs: Math.max(0, authority.now() - startedAt),
+            status: input.abortSignal.aborted ? 'aborted' : 'error',
+            errorClass: evaluatorErrorClass(effectiveError),
+          },
+        );
+      } catch (accountingError) {
+        throw new AuxiliaryModelCallLocalError('accounting', accountingError);
+      }
+      throw effectiveError;
+    }
+    try {
+      await recordLlmCallStrict(
+        { repo: authority.telemetry, lookupPricing: pricing },
+        {
+          ...baseRecord,
+          ...(result.usage
+            ? llmCallUsageFields(result.usage)
+            : { inputTokens: 0, outputTokens: 0 }),
+          ...(result.finishReason && !result.usage ? { rawFinishReason: result.finishReason } : {}),
+          latencyMs: Math.max(0, authority.now() - startedAt),
+          status: 'success',
+        },
+      );
+    } catch (accountingError) {
+      throw new AuxiliaryModelCallLocalError('accounting', accountingError);
+    }
+    return {
+      text: result.text,
+      modelId: target.model,
+      ...(result.finishReason ? { finishReason: result.finishReason } : {}),
+    };
+  } finally {
+    try {
+      await transport.close();
+    } catch (cleanupError) {
+      authority.requestDrain();
+      throw new AuxiliaryModelCallLocalError('cleanup', cleanupError);
+    }
+  }
+}
+
+class AuxiliaryModelCallLocalError extends Error {
+  constructor(
+    readonly phase: 'preflight' | 'accounting' | 'cleanup',
+    cause: unknown,
+  ) {
+    super(`Auxiliary model call ${phase} failed`, { cause });
+    this.name = 'AuxiliaryModelCallLocalError';
+  }
+}
+
+async function readAuxiliaryPreflight<T>(
+  authority: AuxiliaryModelCallAuthority,
+  abortSignal: AbortSignal,
+  read: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await read();
+  } catch (error) {
+    if (
+      abortSignal.aborted &&
+      !(
+        error instanceof AuxiliaryModelCallLocalError ||
+        (error instanceof OAuthExecutionCredentialError && error.code === 'persistence_failed')
+      )
+    ) {
+      throw error;
+    }
+    throw normalizeAuxiliaryAuthorityError(authority, error);
+  }
+}
+
+function normalizeAuxiliaryOAuthBinding(
+  authority: AuxiliaryModelCallAuthority,
+  binding: HostOAuthExecutionBinding,
+): {
+  readonly binding: HostOAuthExecutionBinding;
+  readonly readDeferredFailure: () => unknown | undefined;
+} {
+  let deferredFailure: unknown;
+  const read = async <T>(operation: () => Promise<T>): Promise<T> => {
+    try {
+      return await operation();
+    } catch (error) {
+      const normalized = normalizeAuxiliaryAuthorityError(authority, error);
+      if (
+        deferredFailure === undefined &&
+        (normalized instanceof AuxiliaryModelCallLocalError ||
+          normalized instanceof AuxiliaryModelCallConfigurationError)
+      ) {
+        deferredFailure = normalized;
+      }
+      throw normalized;
+    }
+  };
+  return Object.freeze({
+    binding: Object.freeze({
+      providerType: binding.providerType,
+      connectionSlug: binding.connectionSlug,
+      resolve: () => read(() => binding.resolve()),
+      ...(binding.forceRefresh ? { forceRefresh: () => read(() => binding.forceRefresh!()) } : {}),
+    }),
+    readDeferredFailure: () => deferredFailure,
+  });
+}
+
+function normalizeAuxiliaryAuthorityError(
+  authority: AuxiliaryModelCallAuthority,
+  error: unknown,
+): unknown {
+  if (
+    error instanceof AuxiliaryModelCallConfigurationError ||
+    error instanceof AuxiliaryModelCallLocalError
+  ) {
+    return error;
+  }
+  if (error instanceof OAuthExecutionCredentialError) {
+    switch (error.code) {
+      case 'credential_unavailable':
+      case 'credential_superseded':
+        return new AuxiliaryModelCallConfigurationError(error.message, { cause: error });
+      case 'refresh_failed':
+        return error;
+      case 'persistence_failed':
+        authority.requestDrain();
+        return new AuxiliaryModelCallLocalError('preflight', error);
+    }
+  }
+  authority.requestDrain();
+  return new AuxiliaryModelCallLocalError('preflight', error);
+}
+
+function createOwnedGoalEvaluator(
+  evaluator: Pick<GoalEvaluatorResource, 'evaluate'>,
+): GoalEvaluatorResource {
+  const active = new Set<Promise<void>>();
+  let closing = false;
+  let closeTask: Promise<void> | undefined;
+  return {
+    evaluate: (prompt, sessionId, signal) => {
+      if (closing) return Promise.reject(new Error('Goal evaluator is closing'));
+      const task = evaluator.evaluate(prompt, sessionId, signal);
+      const settled = task.then(
+        () => undefined,
+        () => undefined,
+      );
+      active.add(settled);
+      void settled.finally(() => active.delete(settled));
+      return task;
+    },
+    close: () => {
+      closing = true;
+      closeTask ??= Promise.all([...active]).then(() => undefined);
+      return closeTask;
+    },
+  };
+}
+
+function evaluatorErrorClass(error: unknown): string {
+  return error instanceof Error ? error.name : 'UnknownError';
+}
+
+function sessionEffectModelErrorClass(
+  error: unknown,
+  abortSignal: AbortSignal,
+): HostSessionEffectModelFailureClass {
+  if (error instanceof AuxiliaryModelCallLocalError) return 'persistence';
+  if (abortSignal.aborted) {
+    const reason = abortSignal.reason;
+    return reason instanceof Error && reason.name === 'TimeoutError' ? 'timeout' : 'aborted';
+  }
+  if (!(error instanceof Error)) return 'unknown';
+  if (error instanceof AuxiliaryModelCallConfigurationError) return 'configuration';
+  return 'provider';
+}
+
+class AuxiliaryModelCallConfigurationError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'AuxiliaryModelCallConfigurationError';
+  }
+}
+
+interface ResolvedExecutionTarget {
+  readonly connection: RuntimeExecutionConnection;
+  readonly model: string;
+  readonly apiKey: string;
+  readonly oauthBinding?: HostOAuthExecutionBinding;
+  readonly networkProxy: RuntimePolicy['networkProxy'];
+  readonly proxySecret?: string;
+}
+
+export async function resolveExecutionTarget(
+  header: BackendFactoryContext['header'],
+  runtimePolicy: RuntimePolicyStoresWriter,
+  oauthCredentials: HostOAuthExecutionAuthority,
+  createFetchTransport: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport,
+): Promise<ResolvedExecutionTarget> {
+  const resolved = await runtimePolicy.operations.resolveExecutionConnection(
+    header.llmConnectionSlug,
+  );
+  if (resolved.kind !== 'ready') {
+    throw new AuxiliaryModelCallConfigurationError(
+      `Runtime Host model connection is not ready: ${resolved.kind}`,
+    );
+  }
+  const provider = PROVIDER_DEFAULTS[resolved.connection.providerType];
+  if (!provider || provider.runtimeAdapter.kind === 'unavailable') {
+    throw new AuxiliaryModelCallConfigurationError('Runtime Host model provider is not executable');
+  }
+  const model = header.model.trim();
+  const modelInfo = resolved.connection.models.find((candidate) => candidate.id === model);
+  if (!model || !resolved.connection.enabledModelIds.includes(model) || !modelInfo) {
+    throw new AuxiliaryModelCallConfigurationError(
+      'Runtime Host Session model is not enabled by its canonical connection',
+    );
+  }
+  if (isModelExplicitlyUnsupportedForChat(modelInfo)) {
+    throw new AuxiliaryModelCallConfigurationError(
+      'Runtime Host Session model is not chat-capable',
+    );
+  }
+
+  const connection: RuntimeExecutionConnection = {
+    slug: resolved.connection.slug,
+    providerType: resolved.connection.providerType,
+    ...(resolved.connection.baseUrl ? { baseUrl: resolved.connection.baseUrl } : {}),
+    defaultModel: model,
+    models: [...resolved.connection.models],
+  };
+  if (provider.authKind === 'oauth_token') {
+    const material = resolved.secretMaterial.connection;
+    if (!material) {
+      throw new AuxiliaryModelCallConfigurationError(
+        'Runtime Host OAuth credential is not configured',
+      );
+    }
+    const refreshProxy = toRuntimePolicyProxy(
+      resolved.networkProxy,
+      resolved.secretMaterial.networkProxy?.secret,
+    );
+    return {
+      connection,
+      model,
+      apiKey: '',
+      oauthBinding: oauthCredentials.bind({
+        providerType: resolved.connection.providerType,
+        connectionSlug: resolved.connection.slug,
+        material,
+        createRefreshTransport: () => createFetchTransport(refreshProxy),
+      }),
+      networkProxy: resolved.networkProxy,
+      ...(resolved.secretMaterial.networkProxy
+        ? { proxySecret: resolved.secretMaterial.networkProxy.secret }
+        : {}),
+    };
+  }
+
+  return {
+    connection,
+    model,
+    apiKey: resolved.secretMaterial.connection?.secret ?? '',
+    networkProxy: resolved.networkProxy,
+    ...(resolved.secretMaterial.networkProxy
+      ? { proxySecret: resolved.secretMaterial.networkProxy.secret }
+      : {}),
+  };
+}
+
+export function readDuringBackendCreation<T>(
+  read: () => Promise<T>,
+  abortSignal?: AbortSignal,
+): Promise<T> {
+  if (!abortSignal) return read();
+  if (abortSignal.aborted) return Promise.reject(backendCreationAbortReason(abortSignal));
+
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(backendCreationAbortReason(abortSignal));
+    abortSignal.addEventListener('abort', onAbort, { once: true });
+  });
+  const pending = Promise.resolve().then(() => {
+    if (abortSignal.aborted) throw backendCreationAbortReason(abortSignal);
+    return read();
+  });
+  return Promise.race([pending, aborted]).finally(() => {
+    if (onAbort) abortSignal.removeEventListener('abort', onAbort);
+  });
+}
+
+function backendCreationAbortReason(abortSignal: AbortSignal): unknown {
+  return (
+    abortSignal.reason ??
+    new DOMException('Runtime Host backend creation was aborted', 'AbortError')
+  );
+}

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from 'node:crypto';
-import { PROVIDER_DEFAULTS, type RuntimeExecutionConnection } from '@maka/core/llm-connections';
-import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
 import { resolveModelVisionSupport } from '@maka/core/model-metadata';
 import type { ModelCallAttempt } from '@maka/core/model-call-attempt';
 import type { RuntimePolicy } from '@maka/core/runtime-policy';
-import type { SessionHeader } from '@maka/core/session';
 import {
   filterModelVisibleTaskLedgerTasks,
   renderTaskLedgerPromptText,
@@ -29,17 +26,13 @@ import {
   createProviderRequestCaptureRecorder,
   createProxiedFetchTransport,
   getAIModel,
-  generateGoalEvaluationModelCall,
-  llmCallUsageFields,
   projectEffectiveProductToolSurface,
-  recordLlmCall,
   recordToolInvocation,
   resolveProjectGitInfo,
   resolveSelectedModelContextWindow,
   SkillShadowSelectionTracker,
   type BackendFactoryContext,
   type BuildBuiltinToolsOptions,
-  type GoalEvaluatorResource,
   type MakaTool,
   type ProxiedFetchProxy,
   type ProxiedFetchTransport,
@@ -69,10 +62,10 @@ import type {
 import {
   createHostOAuthModelFetch,
   type HostOAuthExecutionAuthority,
-  type HostOAuthExecutionBinding,
 } from './oauth-execution-authority.js';
 import type { HostChildAgentBackendCapabilities } from './child-agent-composition.js';
 import type { HostExecutionArtifactServices } from './execution-artifacts.js';
+import { readDuringBackendCreation, resolveExecutionTarget } from './execution-model-authority.js';
 import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
 
 const CHILD_INSTRUCTION_BOUNDARY = [
@@ -229,174 +222,6 @@ export interface HostAiSdkBackendInput {
   readonly parentAgentTools?: readonly MakaTool[];
   readonly childAgents?: HostChildAgentBackendCapabilities;
   readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
-}
-
-export interface HostGoalEvaluatorInput {
-  readonly runtimePolicy: RuntimePolicyStoresWriter;
-  readonly oauthCredentials: HostOAuthExecutionAuthority;
-  readonly claudeDeviceId: string;
-  readonly usage: InteractiveUsageStoresWriter;
-  readonly requestDrain: () => void;
-  readonly readSessionHeader: (sessionId: string) => Promise<SessionHeader>;
-  readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
-  readonly now?: () => number;
-  readonly newId?: () => string;
-}
-
-/** Creates a tool-free Goal judge on the Session's canonical connection and model. */
-export function createHostGoalEvaluator(input: HostGoalEvaluatorInput): GoalEvaluatorResource {
-  const createFetchTransport = input.createFetchTransport ?? createProxiedFetchTransport;
-  const now = input.now ?? Date.now;
-  const newId = input.newId ?? randomUUID;
-  let telemetryDrainRequested = false;
-  const telemetry = {
-    insertLlmCall: async (
-      record: Parameters<typeof input.usage.telemetry.recordLlmCall>[0],
-    ): Promise<void> => {
-      try {
-        await input.usage.telemetry.recordLlmCall(record);
-      } catch (error) {
-        if (!telemetryDrainRequested) {
-          telemetryDrainRequested = true;
-          input.requestDrain();
-        }
-        throw error;
-      }
-    },
-  };
-  return createOwnedGoalEvaluator({
-    evaluate: async (prompt, sessionId, signal) => {
-      const header = await readDuringBackendCreation(
-        () => input.readSessionHeader(sessionId),
-        signal,
-      );
-      const [target, pricingSnapshot] = await Promise.all([
-        readDuringBackendCreation(
-          () =>
-            resolveExecutionTarget(
-              header,
-              input.runtimePolicy,
-              input.oauthCredentials,
-              createFetchTransport,
-            ),
-          signal,
-        ),
-        readDuringBackendCreation(() => input.usage.pricing.snapshot(), signal),
-      ]);
-      const pricing = buildPricingLookup(pricingSnapshot.overrides);
-      const transport = createFetchTransport(
-        toRuntimePolicyProxy(target.networkProxy, target.proxySecret),
-      );
-      let apiKey = target.apiKey;
-      let modelFetch: typeof fetch = transport.fetch;
-      try {
-        if (target.oauthBinding) {
-          const initialOAuthTokens = await readDuringBackendCreation(
-            () => target.oauthBinding!.resolve(),
-            signal,
-          );
-          apiKey = initialOAuthTokens.access_token;
-          modelFetch = createHostOAuthModelFetch({
-            binding: target.oauthBinding,
-            initialTokens: initialOAuthTokens,
-            connection: target.connection,
-            sessionId,
-            modelId: target.model,
-            claudeDeviceId: input.claudeDeviceId,
-            fetchFn: transport.fetch,
-          });
-        }
-        const startedAt = now();
-        const callId = `goal_evaluation_${sessionId}_${newId()}`;
-        const baseRecord = {
-          sessionId,
-          callKind: 'goal_evaluation' as const,
-          callId,
-          connectionSlug: target.connection.slug,
-          providerId: target.connection.providerType,
-          modelId: target.model,
-          startedAt,
-        };
-        try {
-          const result = await generateGoalEvaluationModelCall({
-            model: getAIModel({
-              connection: target.connection,
-              apiKey,
-              modelId: target.model,
-              fetch: modelFetch,
-            }),
-            prompt,
-            abortSignal: signal,
-            providerOptions: buildProviderOptions(
-              target.connection,
-              target.model,
-              header.thinkingLevel,
-            ),
-          });
-          await recordLlmCall(
-            { repo: telemetry, lookupPricing: pricing },
-            {
-              ...baseRecord,
-              ...(result.usage
-                ? llmCallUsageFields(result.usage)
-                : { inputTokens: 0, outputTokens: 0 }),
-              ...(result.finishReason && !result.usage
-                ? { rawFinishReason: result.finishReason }
-                : {}),
-              latencyMs: Math.max(0, now() - startedAt),
-              status: 'success',
-            },
-          );
-          return result.text;
-        } catch (error) {
-          await recordLlmCall(
-            { repo: telemetry, lookupPricing: pricing },
-            {
-              ...baseRecord,
-              inputTokens: 0,
-              outputTokens: 0,
-              latencyMs: Math.max(0, now() - startedAt),
-              status: signal.aborted ? 'aborted' : 'error',
-              errorClass: evaluatorErrorClass(error),
-            },
-          );
-          throw error;
-        }
-      } finally {
-        await transport.close();
-      }
-    },
-  });
-}
-
-function createOwnedGoalEvaluator(
-  evaluator: Pick<GoalEvaluatorResource, 'evaluate'>,
-): GoalEvaluatorResource {
-  const active = new Set<Promise<void>>();
-  let closing = false;
-  let closeTask: Promise<void> | undefined;
-  return {
-    evaluate: (prompt, sessionId, signal) => {
-      if (closing) return Promise.reject(new Error('Goal evaluator is closing'));
-      const task = evaluator.evaluate(prompt, sessionId, signal);
-      const settled = task.then(
-        () => undefined,
-        () => undefined,
-      );
-      active.add(settled);
-      void settled.finally(() => active.delete(settled));
-      return task;
-    },
-    close: () => {
-      closing = true;
-      closeTask ??= Promise.all([...active]).then(() => undefined);
-      return closeTask;
-    },
-  };
-}
-
-function evaluatorErrorClass(error: unknown): string {
-  return error instanceof Error ? error.name : 'UnknownError';
 }
 
 /** Builds one real provider backend from canonical Host state. */
@@ -678,34 +503,6 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
   }
 }
 
-function readDuringBackendCreation<T>(
-  read: () => Promise<T>,
-  abortSignal?: AbortSignal,
-): Promise<T> {
-  if (!abortSignal) return read();
-  if (abortSignal.aborted) return Promise.reject(backendCreationAbortReason(abortSignal));
-
-  let onAbort: (() => void) | undefined;
-  const aborted = new Promise<never>((_resolve, reject) => {
-    onAbort = () => reject(backendCreationAbortReason(abortSignal));
-    abortSignal.addEventListener('abort', onAbort, { once: true });
-  });
-  const pending = Promise.resolve().then(() => {
-    if (abortSignal.aborted) throw backendCreationAbortReason(abortSignal);
-    return read();
-  });
-  return Promise.race([pending, aborted]).finally(() => {
-    if (onAbort) abortSignal.removeEventListener('abort', onAbort);
-  });
-}
-
-function backendCreationAbortReason(abortSignal: AbortSignal): unknown {
-  return (
-    abortSignal.reason ??
-    new DOMException('Runtime Host backend creation was aborted', 'AbortError')
-  );
-}
-
 class HostAiSdkBackend extends AiSdkBackend {
   constructor(
     input: ConstructorParameters<typeof AiSdkBackend>[0],
@@ -754,82 +551,6 @@ function assertUniqueToolNames(tools: readonly MakaTool[]): void {
     }
     names.add(tool.name);
   }
-}
-
-interface ResolvedExecutionTarget {
-  readonly connection: RuntimeExecutionConnection;
-  readonly model: string;
-  readonly apiKey: string;
-  readonly oauthBinding?: HostOAuthExecutionBinding;
-  readonly networkProxy: RuntimePolicy['networkProxy'];
-  readonly proxySecret?: string;
-}
-
-async function resolveExecutionTarget(
-  header: BackendFactoryContext['header'],
-  runtimePolicy: RuntimePolicyStoresWriter,
-  oauthCredentials: HostOAuthExecutionAuthority,
-  createFetchTransport: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport,
-): Promise<ResolvedExecutionTarget> {
-  const resolved = await runtimePolicy.operations.resolveExecutionConnection(
-    header.llmConnectionSlug,
-  );
-  if (resolved.kind !== 'ready') {
-    throw new Error(`Runtime Host model connection is not ready: ${resolved.kind}`);
-  }
-  const provider = PROVIDER_DEFAULTS[resolved.connection.providerType];
-  if (!provider || provider.runtimeAdapter.kind === 'unavailable') {
-    throw new Error('Runtime Host model provider is not executable');
-  }
-  const model = header.model.trim();
-  const modelInfo = resolved.connection.models.find((candidate) => candidate.id === model);
-  if (!model || !resolved.connection.enabledModelIds.includes(model) || !modelInfo) {
-    throw new Error('Runtime Host Session model is not enabled by its canonical connection');
-  }
-  if (isModelExplicitlyUnsupportedForChat(modelInfo)) {
-    throw new Error('Runtime Host Session model is not chat-capable');
-  }
-
-  const connection: RuntimeExecutionConnection = {
-    slug: resolved.connection.slug,
-    providerType: resolved.connection.providerType,
-    ...(resolved.connection.baseUrl ? { baseUrl: resolved.connection.baseUrl } : {}),
-    defaultModel: model,
-    models: [...resolved.connection.models],
-  };
-  if (provider.authKind === 'oauth_token') {
-    const material = resolved.secretMaterial.connection;
-    if (!material) throw new Error('Runtime Host OAuth credential is not configured');
-    const refreshProxy = toRuntimePolicyProxy(
-      resolved.networkProxy,
-      resolved.secretMaterial.networkProxy?.secret,
-    );
-    return {
-      connection,
-      model,
-      apiKey: '',
-      oauthBinding: oauthCredentials.bind({
-        providerType: resolved.connection.providerType,
-        connectionSlug: resolved.connection.slug,
-        material,
-        createRefreshTransport: () => createFetchTransport(refreshProxy),
-      }),
-      networkProxy: resolved.networkProxy,
-      ...(resolved.secretMaterial.networkProxy
-        ? { proxySecret: resolved.secretMaterial.networkProxy.secret }
-        : {}),
-    };
-  }
-
-  return {
-    connection,
-    model,
-    apiKey: resolved.secretMaterial.connection?.secret ?? '',
-    networkProxy: resolved.networkProxy,
-    ...(resolved.secretMaterial.networkProxy
-      ? { proxySecret: resolved.secretMaterial.networkProxy.secret }
-      : {}),
-  };
 }
 
 function buildDefaultHostTools(

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -72,9 +72,10 @@ export type SessionRetirementOperationKey = Extract<
   OperationKey,
   'session.lifecycle.set' | 'session.remove'
 >;
+export type SessionEffectOperationKey = Extract<OperationKey, 'session.recap.generate'>;
 export type SessionCatalogOperationKey = Exclude<
   Extract<OperationKey, `session.${string}`>,
-  SessionRevisionOperationKey | SessionRetirementOperationKey
+  SessionRevisionOperationKey | SessionRetirementOperationKey | SessionEffectOperationKey
 >;
 export type TaskLedgerOperationKey = Extract<OperationKey, 'task.ledger.query'>;
 export type ArtifactOperationKey = Extract<OperationKey, `artifact.${string}`>;
@@ -117,6 +118,7 @@ export type SessionRetirementOperationHandlerMap = Pick<
   OperationHandlerMap,
   SessionRetirementOperationKey
 >;
+export type SessionEffectOperationHandlerMap = Pick<OperationHandlerMap, SessionEffectOperationKey>;
 export type TaskLedgerOperationHandlerMap = Pick<OperationHandlerMap, TaskLedgerOperationKey>;
 export type ArtifactOperationHandlerMap = Pick<OperationHandlerMap, ArtifactOperationKey>;
 export type SkillCatalogOperationHandlerMap = Pick<OperationHandlerMap, SkillCatalogOperationKey>;

--- a/packages/runtime-host/src/server/session-effect-coordinator.ts
+++ b/packages/runtime-host/src/server/session-effect-coordinator.ts
@@ -1,0 +1,448 @@
+import { createHash } from 'node:crypto';
+import type { SessionHeader } from '@maka/core/session';
+import { cleanSessionRecapText, type RuntimeReadModelSessionView } from '@maka/runtime';
+import {
+  authenticateInteractiveArtifactStoreWriter,
+  type InteractiveArtifactStoreWriter,
+} from '@maka/storage/artifact-stores';
+import {
+  decodeSessionRecapGenerateResult,
+  SESSION_RECAP_RAW_MAX_BYTES,
+  SESSION_RECAP_TEXT_MAX_BYTES,
+  type OperationOutcome,
+  type SessionRecapFailureClass,
+  type SessionRecapGenerateInput,
+  type SessionRecapGenerateResult,
+} from '../protocol/index.js';
+import type {
+  OperationResidency,
+  SessionEffectOperationHandlerMap,
+} from './operation-dispatcher.js';
+import { SessionAdmissionGate } from './session-admission-gate.js';
+import type { SessionPresenceReader } from './session-presence.js';
+import type { HostSessionEffectModel } from './execution-model-authority.js';
+
+const SESSION_EFFECT_ARTIFACT_MAX_BYTES = 16 * 1024 * 1024;
+const SESSION_EFFECT_SCHEMA_VERSION = 1;
+
+export interface HostSessionEffectCoordinatorInput {
+  readonly model: HostSessionEffectModel;
+  readonly readModel: Pick<RuntimeReadModel, 'getSessionView'>;
+  readonly artifacts: InteractiveArtifactStoreWriter;
+  readonly sessions: SessionPresenceReader;
+  readonly readSessionHeader: (sessionId: string) => Promise<SessionHeader>;
+  readonly sessionAdmission: SessionAdmissionGate;
+  readonly acquireResidency: () => OperationResidency;
+  readonly requestDrain: () => void;
+}
+
+interface RuntimeReadModel {
+  getSessionView(sessionId: string): Promise<RuntimeReadModelSessionView>;
+}
+
+interface ActiveRecapEffect {
+  readonly sessionId: string;
+  readonly effectId: string;
+  readonly reason: SessionRecapGenerateInput['reason'];
+  readonly task: Promise<OperationOutcome<'session.recap.generate'>>;
+}
+
+type RecapAdmission =
+  | {
+      readonly kind: 'settled';
+      readonly outcome: OperationOutcome<'session.recap.generate'>;
+    }
+  | { readonly kind: 'active'; readonly task: ActiveRecapEffect['task'] };
+
+/** Owns tool-free Session-derived model effects and their retry boundary. */
+export class HostSessionEffectCoordinator {
+  readonly handlers: SessionEffectOperationHandlerMap = {
+    'session.recap.generate': (input, context) => this.#generateRecap(input, context),
+  };
+
+  readonly #model: HostSessionEffectModel;
+  readonly #readModel: Pick<RuntimeReadModel, 'getSessionView'>;
+  readonly #artifacts: InteractiveArtifactStoreWriter;
+  readonly #sessions: SessionPresenceReader;
+  readonly #readSessionHeader: (sessionId: string) => Promise<SessionHeader>;
+  readonly #sessionAdmission: SessionAdmissionGate;
+  readonly #acquireResidency: () => OperationResidency;
+  readonly #requestDrain: () => void;
+  readonly #active = new Set<Promise<void>>();
+  readonly #titleAborts = new Map<AbortController, string>();
+  readonly #recapAborts = new Set<AbortController>();
+  readonly #recaps = new Map<string, ActiveRecapEffect>();
+  #accepting = true;
+  #closeTask: Promise<void> | undefined;
+
+  constructor(input: HostSessionEffectCoordinatorInput) {
+    this.#model = input.model;
+    this.#readModel = input.readModel;
+    this.#artifacts = authenticateInteractiveArtifactStoreWriter(input.artifacts);
+    this.#sessions = input.sessions;
+    this.#readSessionHeader = input.readSessionHeader;
+    this.#sessionAdmission = input.sessionAdmission;
+    this.#acquireResidency = input.acquireResidency;
+    this.#requestDrain = input.requestDrain;
+  }
+
+  generateTitle(input: {
+    readonly sessionId: string;
+    readonly header: SessionHeader;
+    readonly sourceText: string;
+  }): Promise<string | undefined> {
+    if (!this.#accepting) return Promise.resolve(undefined);
+    const residency = this.#acquireResidency();
+    const abort = new AbortController();
+    this.#titleAborts.set(abort, input.sessionId);
+    return this.#track(
+      this.#model.generateTitle({ ...input, abortSignal: abort.signal }).finally(() => {
+        this.#titleAborts.delete(abort);
+        residency.release();
+      }),
+    );
+  }
+
+  hasLiveSessionState(sessionId: string): boolean {
+    for (const titleSessionId of this.#titleAborts.values()) {
+      if (titleSessionId === sessionId) return true;
+    }
+    for (const effect of this.#recaps.values()) {
+      if (effect.sessionId === sessionId) return true;
+    }
+    return false;
+  }
+
+  beginDrain(): void {
+    if (!this.#accepting) return;
+    this.#accepting = false;
+    const reason = new DOMException('Runtime Host is draining', 'AbortError');
+    for (const abort of this.#titleAborts.keys()) abort.abort(reason);
+    for (const abort of this.#recapAborts) abort.abort(reason);
+  }
+
+  close(): Promise<void> {
+    if (this.#closeTask) return this.#closeTask;
+    this.beginDrain();
+    this.#closeTask = Promise.all([...this.#active]).then(() => undefined);
+    return this.#closeTask;
+  }
+
+  #generateRecap(
+    input: SessionRecapGenerateInput,
+    context: { acquireResidency(): OperationResidency },
+  ): Promise<OperationOutcome<'session.recap.generate'>> {
+    if (!this.#accepting)
+      return Promise.resolve(recapFailure('host_draining', 'Runtime Host is draining'));
+    const residency = context.acquireResidency();
+    const abort = new AbortController();
+    this.#recapAborts.add(abort);
+    const operation = this.#sessionAdmission
+      .run(input.sessionId, () => this.#admitRecap(input, abort))
+      .then((admission) => (admission.kind === 'settled' ? admission.outcome : admission.task))
+      .finally(() => {
+        this.#recapAborts.delete(abort);
+        residency.release();
+      });
+    return this.#track(operation);
+  }
+
+  async #admitRecap(
+    input: SessionRecapGenerateInput,
+    abort: AbortController,
+  ): Promise<RecapAdmission> {
+    const ids = recapArtifactIds(input.sessionId, input.effectId);
+    try {
+      if ((await this.#sessions.probeSessionRemoval(input.sessionId)).kind !== 'present') {
+        return settledRecap(recapFailure('not_found', 'Session was not found'));
+      }
+
+      const terminal = await this.#readTerminal(input, ids.result);
+      if (terminal.kind === 'conflict') {
+        return settledRecap(
+          recapFailure('operation_conflict', 'Recap effect identity is already in use'),
+        );
+      }
+      if (terminal.kind === 'found') return settledRecap(recapSuccess(terminal.result));
+
+      const intent = await this.#readIntent(input, ids.intent);
+      if (intent === 'conflict') {
+        return settledRecap(
+          recapFailure('operation_conflict', 'Recap effect identity is already in use'),
+        );
+      }
+      if (intent === 'found') {
+        const active = this.#recaps.get(ids.result);
+        return active &&
+          active.sessionId === input.sessionId &&
+          active.effectId === input.effectId &&
+          active.reason === input.reason
+          ? { kind: 'active', task: active.task }
+          : settledRecap(
+              recapFailure(
+                'outcome_unknown',
+                'Recap provider outcome is unknown; use a new effect identity to retry',
+              ),
+            );
+      }
+
+      if (abort.signal.aborted) {
+        return settledRecap(recapFailure('host_draining', 'Runtime Host is draining'));
+      }
+
+      const header = await this.#readSessionHeader(input.sessionId);
+      if (header.isArchived || header.status === 'archived') {
+        return settledRecap(
+          recapFailure('session_archived', 'Archived Session cannot generate a recap'),
+        );
+      }
+
+      const view = await this.#readModel.getSessionView(input.sessionId);
+      if (abort.signal.aborted) {
+        return settledRecap(recapFailure('host_draining', 'Runtime Host is draining'));
+      }
+      await this.#artifacts.create({
+        id: ids.intent,
+        sessionId: input.sessionId,
+        turnId: input.effectId,
+        name: 'session-recap-intent.json',
+        kind: 'file',
+        content: encodeJson({
+          schemaVersion: SESSION_EFFECT_SCHEMA_VERSION,
+          kind: 'session_recap_intent',
+          sessionId: input.sessionId,
+          effectId: input.effectId,
+          reason: input.reason,
+        }),
+        mimeType: 'application/json; charset=utf-8',
+        source: 'session_effect',
+        summary: `Session recap ${input.reason} intent`,
+      });
+
+      let active!: ActiveRecapEffect;
+      const task = this.#runRecapEffect(
+        input,
+        header,
+        view.events,
+        ids.result,
+        abort.signal,
+      ).finally(() => {
+        if (this.#recaps.get(ids.result) === active) this.#recaps.delete(ids.result);
+      });
+      active = {
+        sessionId: input.sessionId,
+        effectId: input.effectId,
+        reason: input.reason,
+        task,
+      };
+      this.#recaps.set(ids.result, active);
+      return { kind: 'active', task };
+    } catch {
+      this.#requestDrain();
+      return settledRecap(recapFailure('persistence_failed', 'Session recap persistence failed'));
+    }
+  }
+
+  async #runRecapEffect(
+    input: SessionRecapGenerateInput,
+    header: SessionHeader,
+    events: RuntimeReadModelSessionView['events'],
+    resultArtifactId: string,
+    abortSignal: AbortSignal,
+  ): Promise<OperationOutcome<'session.recap.generate'>> {
+    let model: Awaited<ReturnType<HostSessionEffectModel['generateRecap']>>;
+    try {
+      model = await this.#model.generateRecap({
+        sessionId: input.sessionId,
+        effectId: input.effectId,
+        header,
+        events,
+        abortSignal,
+      });
+    } catch {
+      this.#requestDrain();
+      return recapFailure('outcome_unknown', 'Recap provider outcome is unknown');
+    }
+    const result = projectModelResult(input, model);
+    if (!result) {
+      this.#requestDrain();
+      return recapFailure('outcome_unknown', 'Recap accounting outcome is unknown');
+    }
+    const document = encodeJson({
+      schemaVersion: SESSION_EFFECT_SCHEMA_VERSION,
+      kind: 'session_recap_result',
+      sessionId: input.sessionId,
+      effectId: input.effectId,
+      reason: input.reason,
+      ...(model.modelId ? { model: model.modelId } : {}),
+      ...(model.messages ? { messageCount: model.messages.length, messages: model.messages } : {}),
+      result,
+    });
+    try {
+      await this.#artifacts.create({
+        id: resultArtifactId,
+        sessionId: input.sessionId,
+        turnId: input.effectId,
+        name: 'session-recap-result.json',
+        kind: 'file',
+        content: document,
+        mimeType: 'application/json; charset=utf-8',
+        source: 'session_effect',
+        summary: result.kind === 'generated' ? result.text.slice(0, 100) : result.errorClass,
+      });
+    } catch {
+      const recovered = await this.#readTerminal(input, resultArtifactId).catch(() => ({
+        kind: 'missing' as const,
+      }));
+      if (recovered.kind === 'found') return recapSuccess(recovered.result);
+      this.#requestDrain();
+      return recapFailure('outcome_unknown', 'Recap result publication outcome is unknown');
+    }
+    return recapSuccess(result);
+  }
+
+  async #readIntent(
+    input: SessionRecapGenerateInput,
+    artifactId: string,
+  ): Promise<'missing' | 'found' | 'conflict'> {
+    const document = await this.#readArtifactDocument(input.sessionId, artifactId);
+    if (!document) return 'missing';
+    return document.schemaVersion === SESSION_EFFECT_SCHEMA_VERSION &&
+      document.kind === 'session_recap_intent' &&
+      document.sessionId === input.sessionId &&
+      document.effectId === input.effectId &&
+      document.reason === input.reason
+      ? 'found'
+      : 'conflict';
+  }
+
+  async #readTerminal(
+    input: SessionRecapGenerateInput,
+    artifactId: string,
+  ): Promise<
+    | { readonly kind: 'missing' }
+    | { readonly kind: 'conflict' }
+    | { readonly kind: 'found'; readonly result: SessionRecapGenerateResult }
+  > {
+    const document = await this.#readArtifactDocument(input.sessionId, artifactId);
+    if (!document) return { kind: 'missing' };
+    if (
+      document.schemaVersion !== SESSION_EFFECT_SCHEMA_VERSION ||
+      document.kind !== 'session_recap_result' ||
+      document.sessionId !== input.sessionId ||
+      document.effectId !== input.effectId ||
+      document.reason !== input.reason
+    ) {
+      return { kind: 'conflict' };
+    }
+    try {
+      const result = decodeSessionRecapGenerateResult(document.result);
+      return result.effectId === input.effectId && result.reason === input.reason
+        ? { kind: 'found', result }
+        : { kind: 'conflict' };
+    } catch {
+      return { kind: 'conflict' };
+    }
+  }
+
+  async #readArtifactDocument(
+    sessionId: string,
+    artifactId: string,
+  ): Promise<Record<string, unknown> | undefined> {
+    const entry = await this.#artifacts.getInSession(sessionId, artifactId);
+    if (!entry.record || entry.record.status !== 'live') return undefined;
+    const read = await this.#artifacts.readTextInSession(sessionId, artifactId, {
+      maxBytes: SESSION_EFFECT_ARTIFACT_MAX_BYTES,
+    });
+    if (!read.ok) throw new Error('Session effect Artifact could not be read');
+    const value: unknown = JSON.parse(read.text);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('Session effect Artifact is malformed');
+    }
+    return value as Record<string, unknown>;
+  }
+
+  #track<T>(task: Promise<T>): Promise<T> {
+    const settled = task.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.#active.add(settled);
+    void settled.finally(() => this.#active.delete(settled));
+    return task;
+  }
+}
+
+function projectModelResult(
+  input: SessionRecapGenerateInput,
+  model: Awaited<ReturnType<HostSessionEffectModel['generateRecap']>>,
+): SessionRecapGenerateResult | undefined {
+  if (!model.ok) {
+    return model.errorClass === 'persistence' ? undefined : failedRecap(input, model.errorClass);
+  }
+  const rawBytes = Buffer.byteLength(model.raw, 'utf8');
+  if (rawBytes === 0) return failedRecap(input, 'empty_response');
+  if (rawBytes > SESSION_RECAP_RAW_MAX_BYTES) return failedRecap(input, 'invalid_response');
+  const text = cleanSessionRecapText(model.raw);
+  if (!text) return failedRecap(input, 'empty_response');
+  if (Buffer.byteLength(text, 'utf8') > SESSION_RECAP_TEXT_MAX_BYTES) {
+    return failedRecap(input, 'invalid_response');
+  }
+  return {
+    kind: 'generated',
+    effectId: input.effectId,
+    reason: input.reason,
+    text,
+    raw: model.raw,
+  };
+}
+
+function failedRecap(
+  input: SessionRecapGenerateInput,
+  errorClass: SessionRecapFailureClass,
+): SessionRecapGenerateResult {
+  return { kind: 'failed', effectId: input.effectId, reason: input.reason, errorClass };
+}
+
+function recapArtifactIds(
+  sessionId: string,
+  effectId: string,
+): {
+  readonly intent: string;
+  readonly result: string;
+} {
+  const digest = createHash('sha256')
+    .update('maka-session-recap-v1\0')
+    .update(sessionId)
+    .update('\0')
+    .update(effectId)
+    .digest('hex');
+  return {
+    intent: `session_recap_intent_${digest}`,
+    result: `session_recap_result_${digest}`,
+  };
+}
+
+function encodeJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function recapSuccess(
+  result: SessionRecapGenerateResult,
+): OperationOutcome<'session.recap.generate'> {
+  return { ok: true, result };
+}
+
+function settledRecap(outcome: OperationOutcome<'session.recap.generate'>): RecapAdmission {
+  return { kind: 'settled', outcome };
+}
+
+function recapFailure(
+  code: Extract<
+    OperationOutcome<'session.recap.generate'>,
+    { readonly ok: false }
+  >['error']['code'],
+  message: string,
+): OperationOutcome<'session.recap.generate'> {
+  return { ok: false, error: { code, message } };
+}

--- a/packages/runtime-host/src/server/session-retirement-coordinator.ts
+++ b/packages/runtime-host/src/server/session-retirement-coordinator.ts
@@ -59,6 +59,9 @@ type RetirementGoals = Pick<
   'beginSessionRetirement' | 'hasLiveGoal' | 'unarchiveSessions'
 >;
 type RetirementResources = Pick<HostRuntimeResourceCoordinator, 'hasLiveSessionResources'>;
+type RetirementSessionEffects = {
+  hasLiveSessionState(sessionId: string): boolean;
+};
 type RetirementGraph = {
   hasLiveSessionState(sessionId: string): Promise<boolean>;
 };
@@ -87,6 +90,7 @@ export interface HostSessionRetirementCoordinatorOptions {
     beginSessionRetirement(sessionIds: readonly string[]): Promise<HostAutomationSessionRetirement>;
   };
   readonly resources: RetirementResources;
+  readonly sessionEffects: RetirementSessionEffects;
   readonly graph: RetirementGraph;
   readonly graphWake: RetirementGraphWake;
   readonly manager: RetirementManager;
@@ -138,6 +142,7 @@ export class HostSessionRetirementCoordinator {
   readonly #goals: RetirementGoals;
   readonly #automation: HostSessionRetirementCoordinatorOptions['automation'];
   readonly #resources: RetirementResources;
+  readonly #sessionEffects: RetirementSessionEffects;
   readonly #graph: RetirementGraph;
   readonly #graphWake: RetirementGraphWake;
   readonly #manager: RetirementManager;
@@ -163,6 +168,7 @@ export class HostSessionRetirementCoordinator {
     this.#goals = options.goals;
     this.#automation = options.automation;
     this.#resources = options.resources;
+    this.#sessionEffects = options.sessionEffects;
     this.#graph = options.graph;
     this.#graphWake = options.graphWake;
     this.#manager = options.manager;
@@ -399,6 +405,9 @@ export class HostSessionRetirementCoordinator {
       }
       if (await this.#resources.hasLiveSessionResources(sessionId)) {
         throw new SessionRetirementBusyError('Session has a live Runtime Resource');
+      }
+      if (this.#sessionEffects.hasLiveSessionState(sessionId)) {
+        throw new SessionRetirementBusyError('Session has a live derived effect');
       }
       const header = requireFamilyRecord(family, sessionId).header;
       if (!header.subagentParent && (await this.#graph.hasLiveSessionState(sessionId))) {

--- a/packages/runtime/src/goal-evaluator.ts
+++ b/packages/runtime/src/goal-evaluator.ts
@@ -12,8 +12,8 @@
  */
 
 import { truncateGoalText, type GoalTextLimit } from './goal-state.js';
-import { normalizeAiSdkUsage, type AiSdkUsageLike } from './model-adapter.js';
-import { rawFinishReasonString, type NormalizedUsage } from './model-protocol.js';
+import type { NormalizedUsage } from './model-protocol.js';
+import { generateToolFreeModelCall } from './tool-free-model-call.js';
 
 export interface GoalEvaluation {
   /** Condition is satisfied — stop, success. */
@@ -71,27 +71,13 @@ export interface GoalEvaluationModelResult {
 export async function generateGoalEvaluationModelCall(
   input: GoalEvaluationModelInput,
 ): Promise<GoalEvaluationModelResult> {
-  const ai = (await import('ai')) as unknown as {
-    generateText(options: Record<string, unknown>): Promise<{
-      text: string;
-      usage?: AiSdkUsageLike;
-      finishReason?: unknown;
-    }>;
-  };
-  const result = await ai.generateText({
+  return generateToolFreeModelCall({
     model: input.model,
     prompt: input.prompt,
     ...(input.abortSignal === undefined ? {} : { abortSignal: input.abortSignal }),
     ...(input.providerOptions === undefined ? {} : { providerOptions: input.providerOptions }),
     maxOutputTokens: 1_024,
   });
-  const usage = normalizeAiSdkUsage(result.usage, { rawFinishReason: result.finishReason });
-  const finishReason = rawFinishReasonString(result.finishReason);
-  return {
-    text: result.text,
-    ...(usage ? { usage } : {}),
-    ...(finishReason ? { finishReason } : {}),
-  };
 }
 
 const DEFAULT_EVALUATOR_TIMEOUT_MS = 30_000;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -829,7 +829,14 @@ export type {
 } from './stream-watchdog.js';
 
 export { getAIModel, buildProviderOptions } from './model-factory.js';
-export { fallbackSessionTitle, generateSessionTitle, sessionTitleSource } from './session-title.js';
+export {
+  buildSessionTitlePrompt,
+  cleanGeneratedSessionTitle,
+  fallbackSessionTitle,
+  generateSessionTitle,
+  sessionTitleSource,
+  SESSION_TITLE_GENERATION_TIMEOUT_MS,
+} from './session-title.js';
 export type { ModelFactoryInput as GetAIModelInput } from './model-factory.js';
 export {
   extractOAuthSubscriptionAccessToken,
@@ -1169,6 +1176,7 @@ export {
   getBuiltinPricing,
   llmCallUsageFields,
   recordLlmCall,
+  recordLlmCallStrict,
   recordToolInvocation,
 } from './telemetry/index.js';
 export type {
@@ -1565,6 +1573,17 @@ export type {
   GoalEvaluatorDeps,
   GoalEvaluatorResource,
 } from './goal-evaluator.js';
+export { generateToolFreeModelCall } from './tool-free-model-call.js';
+export type {
+  ToolFreeModelCallContent,
+  ToolFreeModelCallInput,
+  ToolFreeModelCallResult,
+} from './tool-free-model-call.js';
+export {
+  buildSessionRecapMessages,
+  cleanSessionRecapText,
+  SESSION_RECAP_INSTRUCTION,
+} from './session-recap.js';
 export {
   buildGoalTools,
   GOAL_SET_TOOL_NAME,

--- a/packages/runtime/src/session-recap.ts
+++ b/packages/runtime/src/session-recap.ts
@@ -1,0 +1,54 @@
+import type { RuntimeEvent } from '@maka/core';
+import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
+import { applyRuntimeEventContextBudget } from './context-budget.js';
+import {
+  buildDefaultContextBudgetPolicy,
+  resolveSelectedModelContextWindow,
+} from './context-budget-policy.js';
+import { replayPlanItemsToModelMessages } from './history-compact-summarizer.js';
+import { buildRuntimeEventModelReplayPlan } from './model-history.js';
+import type { ModelMessage } from './model-protocol.js';
+
+export const SESSION_RECAP_INSTRUCTION =
+  '<system-reminder>The user is returning to this session after being away. Write ONE sentence (roughly 25-40 words) recapping where things stand so they can resume instantly. Write the sentence in the language of the user\'s most recent substantive message; for mixed-language sessions use the dominant language of the user\'s messages. Lead with agency, phrased naturally in that language: if the session was mainly questions or review with no landed change, open by referencing what the user asked (the equivalent of "You asked ..."); if the agent landed changes, reference what was done (the equivalent of "We fixed/added/wired ..."); if almost nothing happened, say in that language that the session had just begun. Output only the sentence - no labels, no quotes, no preamble.</system-reminder>';
+
+export function buildSessionRecapMessages(input: {
+  readonly events: readonly RuntimeEvent[];
+  readonly connection: RuntimeExecutionConnection;
+  readonly modelId: string;
+}): ModelMessage[] {
+  const contextWindow = resolveSelectedModelContextWindow(input.connection, input.modelId);
+  let events = input.events;
+  if (contextWindow !== undefined) {
+    const budget = buildDefaultContextBudgetPolicy(input.connection, {
+      name: 'session-recap-history-budget',
+      modelId: input.modelId,
+    });
+    if (budget?.maxHistoryEstimatedTokens !== undefined) {
+      budget.maxHistoryEstimatedTokens = Math.max(0, Math.floor(contextWindow * 0.85) - 4_096);
+    }
+    events = applyRuntimeEventContextBudget(events, budget)?.events ?? events;
+  }
+  const messages = replayPlanItemsToModelMessages(buildRuntimeEventModelReplayPlan(events).items);
+  messages.push({ role: 'user', content: SESSION_RECAP_INSTRUCTION });
+  return messages;
+}
+
+export function cleanSessionRecapText(raw: string): string {
+  let text = raw.replace(/\s+/g, ' ').trim();
+  text = text.replace(/^(recap|summary|回顾)\s*[:：]\s*/i, '').trim();
+
+  const quotePairs: ReadonlyArray<readonly [string, string]> = [
+    ['"', '"'],
+    ["'", "'"],
+    ['“', '”'],
+  ];
+  for (const [open, close] of quotePairs) {
+    if (text.length >= 2 && text.startsWith(open) && text.endsWith(close)) {
+      text = text.slice(open.length, text.length - close.length).trim();
+      break;
+    }
+  }
+
+  return text.length > 1_200 ? `${text.slice(0, 1_200)}…` : text;
+}

--- a/packages/runtime/src/session-title.ts
+++ b/packages/runtime/src/session-title.ts
@@ -3,7 +3,7 @@ import { normalizeUserSessionName } from '@maka/core';
 
 const MAX_SOURCE_BYTES = 8 * 1024;
 const MAX_FALLBACK_CODE_POINTS = 42;
-const TITLE_GENERATION_TIMEOUT_MS = 15_000;
+export const SESSION_TITLE_GENERATION_TIMEOUT_MS = 15_000;
 
 export function sessionTitleSource(input: { text: string; displayText?: string }): string {
   const raw = input.displayText ?? input.text;
@@ -49,7 +49,7 @@ export async function generateSessionTitle(input: {
     const generateText: GenerateText =
       input.generateText ??
       (async (options) => aiGenerateText(options as Parameters<typeof aiGenerateText>[0]));
-    const abortSignal = AbortSignal.timeout(input.timeoutMs ?? TITLE_GENERATION_TIMEOUT_MS);
+    const abortSignal = AbortSignal.timeout(input.timeoutMs ?? SESSION_TITLE_GENERATION_TIMEOUT_MS);
     let onAbort!: () => void;
     const timeout = new Promise<never>((_resolve, reject) => {
       onAbort = () => reject(abortSignal.reason);
@@ -58,7 +58,7 @@ export async function generateSessionTitle(input: {
     const result = await Promise.race([
       generateText({
         model: input.model,
-        prompt: `Create a descriptive 5–10 word title for the user message below. Use the user's language; for Chinese and similar languages, use an equivalently brief natural title. Output only the title.\n\n${input.sourceText}`,
+        prompt: buildSessionTitlePrompt(input.sourceText),
         ...(input.providerOptions === undefined ? {} : { providerOptions: input.providerOptions }),
         maxOutputTokens: 1024,
         abortSignal,
@@ -72,7 +72,11 @@ export async function generateSessionTitle(input: {
   }
 }
 
-function cleanGeneratedSessionTitle(text: string): string | undefined {
+export function buildSessionTitlePrompt(sourceText: string): string {
+  return `Create a descriptive 5–10 word title for the user message below. Use the user's language; for Chinese and similar languages, use an equivalently brief natural title. Output only the title.\n\n${sourceText}`;
+}
+
+export function cleanGeneratedSessionTitle(text: string): string | undefined {
   const firstLine = text
     .replace(/<think>[\s\S]*?(?:<\/think>|$)/gi, '')
     .split(/\r?\n/)

--- a/packages/runtime/src/telemetry/index.ts
+++ b/packages/runtime/src/telemetry/index.ts
@@ -1,7 +1,7 @@
 export { BUILTIN_PRICING, getBuiltinPricing } from './builtin-pricing.js';
 export { computeCost } from './cost.js';
 export { buildPricingLookup } from './pricing.js';
-export { recordLlmCall } from './record-llm-call.js';
+export { recordLlmCall, recordLlmCallStrict } from './record-llm-call.js';
 export { llmCallUsageFields } from './llm-call-usage.js';
 export { recordToolInvocation } from './record-tool-invocation.js';
 export type { LlmRecorderDeps } from './record-llm-call.js';

--- a/packages/runtime/src/telemetry/record-llm-call.ts
+++ b/packages/runtime/src/telemetry/record-llm-call.ts
@@ -11,49 +11,57 @@ export interface LlmRecorderDeps {
 
 export async function recordLlmCall(deps: LlmRecorderDeps, record: LlmCallRecord): Promise<void> {
   try {
-    const cacheHitInputTokens = record.cacheHitInputTokens ?? record.cachedInputTokens ?? 0;
-    const cacheWriteInputTokens = record.cacheWriteInputTokens ?? 0;
-    const derivedCacheMissInputTokens = record.cacheMissInputTokens === undefined;
-    const cacheMissInputTokens =
-      record.cacheMissInputTokens ??
-      Math.max(0, record.inputTokens - cacheHitInputTokens - cacheWriteInputTokens);
-    const cacheMissInputSource =
-      record.cacheMissInputSource ?? (derivedCacheMissInputTokens ? 'derived' : undefined);
-    const cachedInputTokens = cacheHitInputTokens;
-    const reasoningTokens = record.reasoningTokens ?? 0;
-    const totalTokens =
-      record.totalTokens ?? record.inputTokens + record.outputTokens + reasoningTokens;
-    const costUsd =
-      record.costUsd ??
-      computeCost(
-        {
-          inputTokens: record.inputTokens,
-          outputTokens: record.outputTokens,
-          cacheHitInputTokens,
-          cacheMissInputTokens,
-          cacheWriteInputTokens,
-        },
-        deps.lookupPricing(`${record.providerId}:${record.modelId}`),
-      ).totalCost;
-    const ts = record.startedAt + record.latencyMs;
-    const recordId = record.callId
-      ? `usage_${record.callId}`
-      : `usage_${record.turnId ?? randomUUID()}`;
-    await deps.repo.insertLlmCall({
-      ...record,
-      id: recordId,
-      cacheHitInputTokens,
-      cacheMissInputTokens,
-      ...(cacheMissInputSource !== undefined ? { cacheMissInputSource } : {}),
-      cachedInputTokens,
-      cacheWriteInputTokens,
-      reasoningTokens,
-      totalTokens,
-      costUsd,
-      date: new Date(ts).toISOString().slice(0, 10),
-      ts,
-    });
+    await recordLlmCallStrict(deps, record);
   } catch (error) {
     console.error(`[telemetry] recordLlmCall failed: ${generalizedErrorMessage(error)}`);
   }
+}
+
+/** Records one LLM call and preserves persistence failure for authority owners. */
+export async function recordLlmCallStrict(
+  deps: LlmRecorderDeps,
+  record: LlmCallRecord,
+): Promise<void> {
+  const cacheHitInputTokens = record.cacheHitInputTokens ?? record.cachedInputTokens ?? 0;
+  const cacheWriteInputTokens = record.cacheWriteInputTokens ?? 0;
+  const derivedCacheMissInputTokens = record.cacheMissInputTokens === undefined;
+  const cacheMissInputTokens =
+    record.cacheMissInputTokens ??
+    Math.max(0, record.inputTokens - cacheHitInputTokens - cacheWriteInputTokens);
+  const cacheMissInputSource =
+    record.cacheMissInputSource ?? (derivedCacheMissInputTokens ? 'derived' : undefined);
+  const cachedInputTokens = cacheHitInputTokens;
+  const reasoningTokens = record.reasoningTokens ?? 0;
+  const totalTokens =
+    record.totalTokens ?? record.inputTokens + record.outputTokens + reasoningTokens;
+  const costUsd =
+    record.costUsd ??
+    computeCost(
+      {
+        inputTokens: record.inputTokens,
+        outputTokens: record.outputTokens,
+        cacheHitInputTokens,
+        cacheMissInputTokens,
+        cacheWriteInputTokens,
+      },
+      deps.lookupPricing(`${record.providerId}:${record.modelId}`),
+    ).totalCost;
+  const ts = record.startedAt + record.latencyMs;
+  const recordId = record.callId
+    ? `usage_${record.callId}`
+    : `usage_${record.turnId ?? randomUUID()}`;
+  await deps.repo.insertLlmCall({
+    ...record,
+    id: recordId,
+    cacheHitInputTokens,
+    cacheMissInputTokens,
+    ...(cacheMissInputSource !== undefined ? { cacheMissInputSource } : {}),
+    cachedInputTokens,
+    cacheWriteInputTokens,
+    reasoningTokens,
+    totalTokens,
+    costUsd,
+    date: new Date(ts).toISOString().slice(0, 10),
+    ts,
+  });
 }

--- a/packages/runtime/src/tool-free-model-call.ts
+++ b/packages/runtime/src/tool-free-model-call.ts
@@ -1,0 +1,47 @@
+import type { ModelMessage } from './model-protocol.js';
+import { normalizeAiSdkUsage, type AiSdkUsageLike } from './model-adapter.js';
+import { rawFinishReasonString, type NormalizedUsage } from './model-protocol.js';
+
+export type ToolFreeModelCallContent =
+  | { readonly prompt: string; readonly messages?: never }
+  | { readonly prompt?: never; readonly messages: readonly ModelMessage[] };
+
+export type ToolFreeModelCallInput = ToolFreeModelCallContent & {
+  readonly model: unknown;
+  readonly providerOptions?: unknown;
+  readonly abortSignal?: AbortSignal;
+  readonly maxOutputTokens: number;
+};
+
+export interface ToolFreeModelCallResult {
+  readonly text: string;
+  readonly usage?: NormalizedUsage;
+  readonly finishReason?: string;
+}
+
+/** Runs one model call without exposing tools and returns its accounting facts. */
+export async function generateToolFreeModelCall(
+  input: ToolFreeModelCallInput,
+): Promise<ToolFreeModelCallResult> {
+  const ai = (await import('ai')) as unknown as {
+    generateText(options: Record<string, unknown>): Promise<{
+      text: string;
+      usage?: AiSdkUsageLike;
+      finishReason?: unknown;
+    }>;
+  };
+  const result = await ai.generateText({
+    model: input.model,
+    ...(input.prompt === undefined ? { messages: input.messages } : { prompt: input.prompt }),
+    ...(input.abortSignal === undefined ? {} : { abortSignal: input.abortSignal }),
+    ...(input.providerOptions === undefined ? {} : { providerOptions: input.providerOptions }),
+    maxOutputTokens: input.maxOutputTokens,
+  });
+  const usage = normalizeAiSdkUsage(result.usage, { rawFinishReason: result.finishReason });
+  const finishReason = rawFinishReasonString(result.finishReason);
+  return {
+    text: result.text,
+    ...(usage ? { usage } : {}),
+    ...(finishReason ? { finishReason } : {}),
+  };
+}


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Move tool-free Session title and recap generation behind Runtime Host ownership, using the Session's canonical model connection, credentials, proxy policy, and Usage authority.
- Add a typed, bounded `session.recap.generate` Client operation with durable intent/result evidence so concurrent Clients and exact retries share one outcome without repeating provider work.
- Integrate derived effects with Host drain, deadlines, transport cleanup, Session retirement fencing, and strict Usage persistence.
- Share the title/recap prompt and cleanup helpers with the existing embedded Runtime path without wiring a production Desktop or TUI adapter in this slice.

## Contract

- The Host admits only a short Session snapshot-and-intent phase; provider I/O does not hold the Session lane.
- Exact retries replay terminal evidence, join same-process work, or return `outcome_unknown` when provider/accounting completion cannot be proven.
- Active title and recap work blocks Session archive/removal and is aborted during Host drain.
- Configuration, provider, cancellation, timeout, and local persistence failures remain distinct; local authority or accounting uncertainty never becomes a false terminal result.
- The Runtime Host wire protocol remains v0.

## Validation

- Runtime and Runtime Host full test suites
- Core and CLI full test suites
- Repository format and lint checks
- Core, Runtime, Runtime Host, and CLI type checks

Part of #1167.

</details>

<details>
<summary><strong>中文</strong></summary>

## 概要

- 将无工具 Session 标题与 recap 生成收归 Runtime Host，并统一使用 Session 的规范模型连接、凭据、代理策略和 Usage authority。
- 新增类型化、受边界约束的 `session.recap.generate` Client 操作，以持久化 intent/result 证据保证并发 Client 与精确重试共享同一结果，避免重复调用 provider。
- 将派生效果纳入 Host drain、截止时间、传输清理、Session retirement fence 和严格 Usage 持久化。
- 标题与 recap 的 prompt/清理逻辑由现有 embedded Runtime 路径复用；本 slice 不接入生产 Desktop 或 TUI adapter。

## 契约

- Host 只在短暂的 Session 快照与 intent 阶段持有 admission；provider I/O 不占用 Session lane。
- 精确重试会重放 terminal 证据、加入同进程工作，或在无法证明 provider/accounting 完成状态时返回 `outcome_unknown`。
- 活跃的标题或 recap 工作会阻止 Session 归档/删除，并在 Host drain 时终止。
- 配置、provider、取消、超时与本地持久化失败保持可区分；本地 authority 或 accounting 不确定性不会被写成虚假的 terminal 结果。
- Runtime Host wire protocol 继续保持 v0。

## 验证

- Runtime 与 Runtime Host 全量测试
- Core 与 CLI 全量测试
- 仓库格式与 lint 检查
- Core、Runtime、Runtime Host 与 CLI 类型检查

属于 #1167 的一部分。

</details>
