### PR TITLE
test: own the temp namespace in the test runners

### DIFF
--- a/scripts/run-headless-tests.mjs
+++ b/scripts/run-headless-tests.mjs
@@ -76,7 +76,12 @@ export function runHeadlessTests(options = {}) {
     if (result.error) throw result.error;
     return result.status ?? 1;
   } finally {
-    rmSync(tempDir, { recursive: true, force: true });
+    // A cleanup failure must not replace the suite's own result.
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      console.warn(`could not remove ${tempDir}: ${error.message}`);
+    }
   }
 }
 

--- a/scripts/run-headless-tests.mjs
+++ b/scripts/run-headless-tests.mjs
@@ -8,7 +8,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -34,8 +34,12 @@ export function runHeadlessTests(options = {}) {
   const tempDir = mkdtempSync(join(tmpdir(), 'maka-headless-test-env-'));
   const credentialsPath = join(tempDir, 'credentials.json');
   const globalConfigPath = join(tempDir, 'gitconfig');
+  // Unlike the XDG directories, which the code under test creates on demand,
+  // this one has to exist before a test calls mkdtemp() against it.
+  const tempTmpDir = join(tempDir, 'tmp');
 
   try {
+    mkdirSync(tempTmpDir, { recursive: true });
     writeFileSync(credentialsPath, '{"version":1,"values":{}}\n', {
       encoding: 'utf8',
       mode: 0o600,
@@ -51,6 +55,13 @@ export function runHeadlessTests(options = {}) {
         ),
         HOME: tempDir,
         USERPROFILE: tempDir,
+        // Keeps `mkdtemp(tmpdir(), …)` inside the tree this script already
+        // removes, so a direct run isolates temp state the same way the
+        // workspace runner does. TMPDIR is read by os.tmpdir() on POSIX,
+        // TMP/TEMP on Windows.
+        TMPDIR: tempTmpDir,
+        TMP: tempTmpDir,
+        TEMP: tempTmpDir,
         XDG_CONFIG_HOME: join(tempDir, 'config'),
         XDG_DATA_HOME: join(tempDir, 'data'),
         XDG_STATE_HOME: join(tempDir, 'state'),

--- a/scripts/run-headless-tests.test.mjs
+++ b/scripts/run-headless-tests.test.mjs
@@ -24,6 +24,9 @@ test('runHeadlessTests isolates user state and removes its temporary files', () 
       XDG_STATE_HOME: '/host/state',
       XDG_CACHE_HOME: '/host/cache',
       APPDATA: '/host/appdata',
+      TMPDIR: '/host/tmp',
+      TMP: '/host/tmp',
+      TEMP: '/host/tmp',
       GIT_CONFIG_GLOBAL: '/host/gitconfig',
       GIT_CONFIG_NOSYSTEM: '0',
       GROQ_API_KEY: 'secret',
@@ -69,9 +72,17 @@ test('runHeadlessTests isolates user state and removes its temporary files', () 
         'APPDATA',
         'MAKA_CREDENTIALS_PATH',
         'GIT_CONFIG_GLOBAL',
+        'TMPDIR',
+        'TMP',
+        'TEMP',
       ]) {
         assert.equal(relative(tempDir, options.env[name]).startsWith('..'), false);
       }
+      // mkdtemp() against os.tmpdir() fails unless the directory already exists,
+      // so this one cannot be left for the code under test to create.
+      assert.equal(statSync(options.env.TMPDIR).isDirectory(), true);
+      assert.equal(options.env.TMP, options.env.TMPDIR);
+      assert.equal(options.env.TEMP, options.env.TMPDIR);
 
       credentialsPath = options.env.MAKA_CREDENTIALS_PATH;
       assert.equal(readFileSync(credentialsPath, 'utf8'), '{"version":1,"values":{}}\n');

--- a/scripts/run-workspace-tests-parallel.mjs
+++ b/scripts/run-workspace-tests-parallel.mjs
@@ -71,76 +71,89 @@ export async function runWorkspace(
   // to book-keep its own removal — a rule nothing enforces, and which years of
   // accumulated `maka-*` directories in the user's tmpdir show is not kept.
   const tempRoot = await mkdtemp(join(tmpdir(), `maka-test-${tempRootSlug(name)}-`));
-  console.log(`\n[${name}] start: ${command}`);
-  const child = spawn(command, {
-    cwd,
-    stdio: 'inherit',
-    shell: true,
-    detached: process.platform !== 'win32',
-    // TMPDIR is what os.tmpdir() reads on POSIX, TMP/TEMP on Windows.
-    env: { ...process.env, TMPDIR: tempRoot, TMP: tempRoot, TEMP: tempRoot },
-  });
-  const completion = new Promise((resolvePromise, reject) => {
-    let settled = false;
-    const settle = (fn) => {
-      if (settled) return;
-      settled = true;
-      fn();
-    };
-    child.on('error', (err) => {
-      settle(() => reject(new Error(`[${name}] spawn failed: ${err.message}`)));
+  // Everything after the tree exists runs under the finally that removes it, so
+  // no path out of this function — including a synchronous throw from spawn —
+  // can leave it behind.
+  let timeout;
+  let onAbort;
+  try {
+    console.log(`\n[${name}] start: ${command}`);
+    const child = spawn(command, {
+      cwd,
+      stdio: 'inherit',
+      shell: true,
+      detached: process.platform !== 'win32',
+      // TMPDIR is what os.tmpdir() reads on POSIX, TMP/TEMP on Windows.
+      env: { ...process.env, TMPDIR: tempRoot, TMP: tempRoot, TEMP: tempRoot },
     });
-    child.on('close', (code) => {
-      settle(() => {
-        if (code === 0) {
-          console.log(`[${name}] passed`);
-          resolvePromise(name);
-        } else {
-          reject(new Error(`[${name}] failed with code ${code}`));
-        }
+    const completion = new Promise((resolvePromise, reject) => {
+      let settled = false;
+      const settle = (fn) => {
+        if (settled) return;
+        settled = true;
+        fn();
+      };
+      child.on('error', (err) => {
+        settle(() => reject(new Error(`[${name}] spawn failed: ${err.message}`)));
+      });
+      child.on('close', (code) => {
+        settle(() => {
+          if (code === 0) {
+            console.log(`[${name}] passed`);
+            resolvePromise(name);
+          } else {
+            reject(new Error(`[${name}] failed with code ${code}`));
+          }
+        });
       });
     });
-  });
 
-  let stopReason;
-  let requestStop;
-  const stopRequested = new Promise((_resolve, reject) => {
-    requestStop = (reason) => {
-      if (stopReason) return;
-      stopReason = reason;
-      reject(reason);
-    };
-  });
-  const onAbort = () => requestStop(workspaceRunCancelledError());
-  signal?.addEventListener('abort', onAbort, { once: true });
-  const timeout = Number.isFinite(timeoutMs)
-    ? setTimeout(
-        () => requestStop(new Error(`[${name}] timed out after ${timeoutMs}ms`)),
-        timeoutMs,
-      )
-    : undefined;
-  if (signal?.aborted) onAbort();
+    let stopReason;
+    let requestStop;
+    const stopRequested = new Promise((_resolve, reject) => {
+      requestStop = (reason) => {
+        if (stopReason) return;
+        stopReason = reason;
+        reject(reason);
+      };
+    });
+    onAbort = () => requestStop(workspaceRunCancelledError());
+    signal?.addEventListener('abort', onAbort, { once: true });
+    timeout = Number.isFinite(timeoutMs)
+      ? setTimeout(
+          () => requestStop(new Error(`[${name}] timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        )
+      : undefined;
+    if (signal?.aborted) onAbort();
 
-  try {
-    return await Promise.race([completion, stopRequested]);
-  } catch (error) {
-    if (error === stopReason) {
-      try {
-        await terminateWorkspace(child);
-      } catch (terminationError) {
-        throw new AggregateError(
-          [error, terminationError],
-          `[${name}] failed to terminate its test process tree`,
-        );
+    try {
+      return await Promise.race([completion, stopRequested]);
+    } catch (error) {
+      if (error === stopReason) {
+        try {
+          await terminateWorkspace(child);
+        } catch (terminationError) {
+          throw new AggregateError(
+            [error, terminationError],
+            `[${name}] failed to terminate its test process tree`,
+          );
+        }
       }
+      throw error;
     }
-    throw error;
   } finally {
     if (timeout) clearTimeout(timeout);
-    signal?.removeEventListener('abort', onAbort);
-    // Runs after terminateWorkspace, so the process tree is already down and
-    // nothing is still writing into the tree being removed.
-    await rm(tempRoot, { recursive: true, force: true });
+    if (onAbort) signal?.removeEventListener('abort', onAbort);
+    // Normally the process tree is already down here: either it closed on its
+    // own or terminateWorkspace reaped it. When termination itself failed the
+    // tree is removed under a process that may still be writing — that run has
+    // already been declared failed and killed, so losing its scratch files is
+    // preferable to leaking the tree. Removal failure must not replace whatever
+    // this function was already reporting.
+    await rm(tempRoot, { recursive: true, force: true }).catch((error) => {
+      console.warn(`[${name}] could not remove ${tempRoot}: ${error.message}`);
+    });
   }
 }
 

--- a/scripts/run-workspace-tests-parallel.mjs
+++ b/scripts/run-workspace-tests-parallel.mjs
@@ -8,11 +8,14 @@
  * `--workspaces a,b`: run only the selected workspace paths.
  *
  * Each workspace owns how its dist tests run via package.json `test:dist`.
- * This script owns scheduling, bounded process residency, and failure reporting.
+ * This script owns scheduling, bounded process residency, failure reporting, and
+ * the temp namespace each workspace's tests run in.
  */
 
 import { spawn as defaultSpawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -62,12 +65,20 @@ export async function runWorkspace(
   // Package-owned contract: each workspace declares how dist tests run.
   const command = 'npm run test:dist';
   const cwd = join(repoRoot, dir);
+  // Suites reach the temp directory through hundreds of `mkdtemp(tmpdir(), …)`
+  // calls across every package. Owning the namespace here means the whole tree
+  // goes away when the workspace process does, instead of each call site having
+  // to book-keep its own removal — a rule nothing enforces, and which years of
+  // accumulated `maka-*` directories in the user's tmpdir show is not kept.
+  const tempRoot = await mkdtemp(join(tmpdir(), `maka-test-${tempRootSlug(name)}-`));
   console.log(`\n[${name}] start: ${command}`);
   const child = spawn(command, {
     cwd,
     stdio: 'inherit',
     shell: true,
     detached: process.platform !== 'win32',
+    // TMPDIR is what os.tmpdir() reads on POSIX, TMP/TEMP on Windows.
+    env: { ...process.env, TMPDIR: tempRoot, TMP: tempRoot, TEMP: tempRoot },
   });
   const completion = new Promise((resolvePromise, reject) => {
     let settled = false;
@@ -127,7 +138,15 @@ export async function runWorkspace(
   } finally {
     if (timeout) clearTimeout(timeout);
     signal?.removeEventListener('abort', onAbort);
+    // Runs after terminateWorkspace, so the process tree is already down and
+    // nothing is still writing into the tree being removed.
+    await rm(tempRoot, { recursive: true, force: true });
   }
+}
+
+/** Workspace name reduced to what is safe in a temp directory prefix. */
+function tempRootSlug(name) {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '-');
 }
 
 async function runSerial(dirs, options) {

--- a/scripts/run-workspace-tests-parallel.test.mjs
+++ b/scripts/run-workspace-tests-parallel.test.mjs
@@ -88,6 +88,21 @@ test('each workspace runs in its own temp namespace, removed however it ends', a
   assert.notEqual(observed[0].tmpdir, process.env.TMPDIR);
 });
 
+test('the temp namespace is removed even when spawn throws synchronously', async () => {
+  let observed;
+  const spawn = (_command, options) => {
+    observed = options.env.TMPDIR;
+    throw new Error('spawn exploded');
+  };
+
+  await assert.rejects(
+    () => runWorkspaceTests({ repoRoot: '/repo', workspaceDirs: ['packages/core'], spawn }),
+    /spawn exploded/,
+  );
+
+  assert.equal(existsSync(observed), false);
+});
+
 test('bounded parallel mode never exceeds its configured concurrency', async () => {
   const repoRoot = '/repo';
   const workspaceDirs = ['packages/core', 'packages/ui', 'apps/desktop'];
@@ -161,7 +176,11 @@ test('workspace timeout waits for process cleanup before reporting failure', asy
   child.pid = 42;
   let terminationStarted = false;
   let terminationFinished = false;
-  const spawn = () => child;
+  let tempRoot;
+  const spawn = (_command, options) => {
+    tempRoot = options.env.TMPDIR;
+    return child;
+  };
   const terminateWorkspace = async (target) => {
     assert.equal(target, child);
     terminationStarted = true;
@@ -182,6 +201,8 @@ test('workspace timeout waits for process cleanup before reporting failure', asy
   );
   assert.equal(terminationStarted, true);
   assert.equal(terminationFinished, true);
+  // The stop path reaps the process tree before the namespace goes away.
+  assert.equal(existsSync(tempRoot), false);
 });
 
 async function waitForPidFile(path) {

--- a/scripts/run-workspace-tests-parallel.test.mjs
+++ b/scripts/run-workspace-tests-parallel.test.mjs
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
+import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { test } from 'node:test';
 import { runWorkspaceTests } from './run-workspace-tests-parallel.mjs';
 
@@ -47,6 +48,44 @@ test('parallel mode aggregates every failed workspace name', async () => {
       return true;
     },
   );
+});
+
+test('each workspace runs in its own temp namespace, removed however it ends', async () => {
+  const observed = [];
+  const spawn = (_command, options) => {
+    const child = new EventEmitter();
+    observed.push({
+      tmpdir: options.env.TMPDIR,
+      tmp: options.env.TMP,
+      temp: options.env.TEMP,
+      presentWhileRunning: existsSync(options.env.TMPDIR),
+    });
+    // First workspace passes, second fails: both paths must still clean up.
+    queueMicrotask(() => child.emit('close', observed.length - 1));
+    return child;
+  };
+
+  await assert.rejects(
+    () =>
+      runWorkspaceTests({
+        repoRoot: '/repo',
+        workspaceDirs: ['packages/core', 'packages/ui'],
+        concurrency: 1,
+        spawn,
+      }),
+    /\[ui\] failed with code 1/,
+  );
+
+  assert.equal(observed.length, 2);
+  assert.notEqual(observed[0].tmpdir, observed[1].tmpdir);
+  for (const entry of observed) {
+    assert.equal(entry.presentWhileRunning, true);
+    assert.equal(entry.tmp, entry.tmpdir);
+    assert.equal(entry.temp, entry.tmpdir);
+    assert.equal(relative(tmpdir(), entry.tmpdir).startsWith('..'), false);
+    assert.equal(existsSync(entry.tmpdir), false);
+  }
+  assert.notEqual(observed[0].tmpdir, process.env.TMPDIR);
 });
 
 test('bounded parallel mode never exceeds its configured concurrency', async () => {


### PR DESCRIPTION
## Summary

Test suites reach the temp directory through 933 `mkdtemp(join(tmpdir(), …))` calls spread over 250 files, and nothing removes what they create. On a developer machine that runs the suite repeatedly this accumulates without bound — the tmpdir this was found on held over 47,000 stale `maka-*` directories. CI containers are discarded after a run, so the cost lands entirely on local development: slower tmpdir traversal, noise for anything that scans it, and enough churn that "did this run leak?" stops being measurable.

The obvious fix is to give each call site a `cleanup` array and an `afterEach`, which is the convention `builtin-tools-file-worker.test.ts` already follows. Applied across the repo that is the same eight lines of book-keeping in 250 files — roughly 2,000 lines whose correctness depends on nobody ever forgetting them again, which the current state shows is not a safe assumption.

So this puts the temp namespace where the process lifetime already is. `runWorkspace` is the single spawn point for every workspace suite: it now hands each test process its own `TMPDIR`/`TMP`/`TEMP` and removes the tree when the workspace finishes, however it finishes. The headless runner gets the same treatment — it already isolates `HOME`, the XDG directories and `APPDATA` into a tree it deletes on exit, and simply left the temp namespace pointing at the host. No call site changes, and nothing new for a future test author to remember.

Ownership is the whole point, so the exit paths matter: the tree is created before the `try` that removes it covers everything after it, including a synchronous throw from `spawn`, and a removal that fails warns rather than replacing whatever result the run was already reporting.

## Verification

`packages/runtime` against the same build, once through the runner and once directly (`npm run test:dist`, which is what the runner invokes and therefore the no-isolation control), counting top-level `maka-*` directories in the host tmpdir before and after:

| | tests | pass | fail | skipped | leaked dirs |
|---|---|---|---|---|---|
| direct, no isolation | 3167 | 3158 | 0 | 9 | 51 |
| through the runner | 3167 | 3158 | 0 | 9 | **0** |

- `node --test scripts/run-workspace-tests-parallel.test.mjs scripts/run-headless-tests.test.mjs` — 7/7 pass.
- Both new behaviours were checked against their own removal rather than assumed: reverting the implementation file turns the spawn-throw test red, and dropping the `rm` turns the three namespace tests red.
- `npm run test:scripts` (the one `npm test` path that does not go through the runner) measured at zero leaked directories already, so both paths are now clean.
- `npm run lint`, `npm run format:check` — pass.

## Known boundaries

- Running a suite outside the runner (`node --test` by hand in a package) still leaks, by design: the isolation belongs to whatever starts the test process, and a bare `node --test` has no such owner.
- `packages/runtime-host` builds its Unix socket endpoint under a hardcoded `/tmp` rather than `os.tmpdir()` (`src/control/endpoint.ts`), so it is unaffected either way; it already prunes its own stale directories.
- The Windows `TMP`/`TEMP` variables are set alongside `TMPDIR` but were not exercised — no Windows host was available.
- Not run: the full `npm test` across every workspace.
