### PR TITLE
refactor(desktop): remove consumer-less IPC bridge surface

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -243,3 +243,10 @@ test('remote access prioritizes a configured channel that needs attention', asyn
   const recentFailure = settings.getByRole('alert').filter({ hasText: '最近一次失败' });
   await expect(recentFailure).toContainText(runtimeError);
 });
+
+test('the platform settings shortcut opens settings', async ({ window: page }) => {
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+,' : 'Control+,');
+  await expect(page.getByLabel('设置内容')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.getByLabel('设置内容')).toBeHidden();
+});

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -53,9 +53,6 @@ type RendererMakaStub = {
       projectGit: { isGitRepo: boolean };
     }>;
   };
-  appWindow: {
-    subscribeOpenSettings(callback: () => void): () => void;
-  };
   connections: {
     subscribeEvents(callback: (event: ConnectionEvent) => void): () => void;
   };
@@ -919,9 +916,6 @@ function installFakeMaka(captured: CapturedSubscriptions): void {
         projectPath: '/workspace/relocated',
         projectGit: { isGitRepo: false },
       }),
-    },
-    appWindow: {
-      subscribeOpenSettings: () => noop,
     },
     connections: {
       subscribeEvents(callback: (event: ConnectionEvent) => void) {

--- a/apps/desktop/src/main/daily-review-ipc-main.ts
+++ b/apps/desktop/src/main/daily-review-ipc-main.ts
@@ -83,9 +83,6 @@ export function registerDailyReviewIpc(deps: DailyReviewIpcDeps): void {
   ipcMain.handle('daily-review:get', (_event, archiveId: string) =>
     deps.dailyReviewArchiveStore.getArchive(archiveId),
   );
-  ipcMain.handle('daily-review:delete', async (_event, archiveId: string) => {
-    await deps.dailyReviewArchiveStore.deleteArchive(archiveId);
-  });
   ipcMain.handle(
     'daily-review:saveMarkdownToFile',
     (_event, input: { markdown?: unknown; defaultName?: unknown } | undefined) =>

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -609,12 +609,8 @@ export interface MakaBridge {
     getConfig?(): Promise<DailyReviewConfig>;
     setConfig?(patch: Partial<DailyReviewConfig>): Promise<DailyReviewConfig>;
     runOnce?(input: { range: DailyReviewRange; offsetDays?: number; modelKey?: string }): Promise<{ archiveId: string }>;
-    list?(): Promise<DailyReviewArchiveSummary[]>;
-    get?(archiveId: string): Promise<DailyReviewArchive | null>;
-    delete?(archiveId: string): Promise<void>;
     listArchives?(): Promise<DailyReviewArchiveSummary[]>;
     getArchive?(archiveId: string): Promise<DailyReviewArchive | null>;
-    deleteArchive?(archiveId: string): Promise<void>;
     saveMarkdownToFile(input: {
       markdown: string;
       defaultName: string;
@@ -630,7 +626,6 @@ export interface MakaBridge {
      */
   };
   appWindow: {
-    subscribeOpenSettings(handler: () => void): () => void;
     setTitlebarControlsVisible(visible: boolean): Promise<void>;
     setThemeSource(themePref: ThemePreference): Promise<void>;
     // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -942,23 +942,11 @@ const makaBridge = {
     runOnce(input: { range: DailyReviewRange; offsetDays?: number; modelKey?: string }): Promise<{ archiveId: string }> {
       return ipcRenderer.invoke('daily-review:runOnce', input);
     },
-    list(): Promise<DailyReviewArchiveSummary[]> {
-      return ipcRenderer.invoke('daily-review:list');
-    },
     listArchives(): Promise<DailyReviewArchiveSummary[]> {
       return ipcRenderer.invoke('daily-review:list');
     },
-    get(archiveId: string): Promise<DailyReviewArchive | null> {
-      return ipcRenderer.invoke('daily-review:get', archiveId);
-    },
     getArchive(archiveId: string): Promise<DailyReviewArchive | null> {
       return ipcRenderer.invoke('daily-review:get', archiveId);
-    },
-    delete(archiveId: string): Promise<void> {
-      return ipcRenderer.invoke('daily-review:delete', archiveId);
-    },
-    deleteArchive(archiveId: string): Promise<void> {
-      return ipcRenderer.invoke('daily-review:delete', archiveId);
     },
     /**
      * PR-DAILY-REVIEW-EXPORT-FILE-0: render the markdown in the renderer
@@ -989,11 +977,6 @@ const makaBridge = {
     },
   },
   appWindow: {
-    subscribeOpenSettings(handler: () => void): () => void {
-      const listener = () => handler();
-      ipcRenderer.on('window:openSettings', listener);
-      return () => ipcRenderer.off('window:openSettings', listener);
-    },
     setTitlebarControlsVisible(visible: boolean): Promise<void> {
       return ipcRenderer.invoke('window:setTitlebarControlsVisible', visible);
     },

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -269,9 +269,6 @@ export function useAppShellBootstrapSubscriptions(options: {
     }
     },
   );
-  const handleOpenSettings = useEffectEvent(() => {
-    options.openSettings();
-  });
   const handlePlanChange = useEffectEvent(() => {
     void options.refreshPlanReminders();
   });
@@ -337,7 +334,6 @@ export function useAppShellBootstrapSubscriptions(options: {
       void options.refreshConnections();
     });
     const unsubscribeSessionChanges = window.maka.sessions.subscribeChanges(handleSessionChange);
-    const unsubscribeOpenSettings = window.maka.appWindow.subscribeOpenSettings(handleOpenSettings);
     const unsubscribePlanChanges = window.maka.plans.subscribeChanges(handlePlanChange);
     const unsubscribePlanDue = window.maka.plans.subscribeDue(handlePlanDue);
     markRendererMounted();
@@ -347,7 +343,6 @@ export function useAppShellBootstrapSubscriptions(options: {
       unsubscribeConnections();
       unsubscribeSettingsExternal();
       unsubscribeSessionChanges();
-      unsubscribeOpenSettings();
       unsubscribePlanChanges();
       unsubscribePlanDue();
       window.removeEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
## Summary

Closes #1978. Removes IPC bridge surface with zero consumers in the renderer/overlay/e2e, verified against current `main` (`ceb23ec3d`).

## Changes

1. **`window:openSettings` push** — no sender since #390. Removed `appWindow.subscribeOpenSettings` from preload + contract, and the `handleOpenSettings` subscription/cleanup in `app-shell-effects.ts`. The `⌘/Ctrl+,` keydown handler (renderer) is untouched, so the shortcut still works — covered by a new e2e test.
2. **Daily Review aliases** — removed duplicate `dailyReview.list/get/delete` and `deleteArchive` from preload + `bridge-contract.d.ts`, and the renderer-dead `daily-review:delete` `ipcMain` handler. The archive store's internal `deleteArchive` stays (used by retention cleanup).
3. **`cursor-subscription:logout`** — already handled upstream: #2037 retired the entire Cursor subscription surface (commit `61a0ca1f5`), so this finding no longer applies.

## Tests

- `npm run typecheck` ✅
- Desktop unit suite: **1565 passed, 0 failed** (incl. IPC surface contract parity check) ✅
- `biome lint` / `biome format` / `git diff --check` ✅
- New e2e: `settings.spec.ts` → `the platform settings shortcut opens settings`