### PR TITLE
refactor(desktop): remove dead shell CSS recipes and close check-dead-css blind spots

### DIFF
--- a/apps/desktop/src/renderer/astryx-theme/maka.d.ts
+++ b/apps/desktop/src/renderer/astryx-theme/maka.d.ts
@@ -4,7 +4,6 @@
  * Command: astryx theme build src/renderer/astryx-theme/makaTheme.ts --out src/renderer/astryx-theme/maka.css
  */
 
-/// <reference path="./maka.variants.d.ts" />
 import type { DefinedTheme } from '@astryxdesign/core/theme';
 import type { IconRegistry } from '@astryxdesign/core/Icon';
 export declare const neutralIconRegistry: IconRegistry;

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -657,9 +657,6 @@
   /* A 1px inner top sheen gives lifted cards a physical edge. */
   --card-highlight: inset 0 1px 0 oklch(1 0 0 / 0.04);
 
-  /* sidebar / pane widths (use as max-inline-size on resizable panels) */
-  --w-sidebar: 240px;
-  --w-rail: 240px;
   --h-titlebar: 36px;
 
   /* OS window-resize corridor. A draggable app-region rect flush against a
@@ -1256,81 +1253,6 @@ html[data-os="darwin"].dark {
 
 @layer components {
 
-  /* ---- App shell -------------------------------------------------- */
-
-  .maka-shell {
-    font: var(--maka-text-body);
-    display: grid;
-    grid-template-columns: var(--w-sidebar) 1fr;
-    height: 100dvh;
-    background: var(--background);
-    color: var(--foreground);
-  }
-
-  .maka-shell-rail-right {
-    grid-template-columns: var(--w-sidebar) 1fr var(--w-rail);
-  }
-
-  /* ---- Sidebar ---------------------------------------------------- */
-
-  .maka-sidebar {
-    background: var(--foreground-2);            /* subtle 2% wash */
-    border-right: var(--border-width-hairline) solid var(--border);
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-  }
-  .maka-sidebar-header {
-    font: var(--maka-text-heading-4);
-    height: var(--h-titlebar);
-    padding: 0 var(--space-3);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border-bottom: var(--border-width-hairline) solid var(--border);
-    letter-spacing: var(--tracking-wide);
-    text-transform: uppercase;
-    color: var(--foreground-secondary);
-  }
-  .maka-sidebar-section {
-    padding: var(--space-2) var(--space-1-5);
-  }
-  .maka-sidebar-row {
-    font: var(--maka-text-body);
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding: var(--space-1-5) var(--space-2-5);
-    border-radius: var(--radius-control);
-    color: var(--foreground-secondary);
-    user-select: none;
-    transition: background var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong);
-  }
-  .maka-sidebar-row:hover    { background: var(--state-hover-bg); }
-  .maka-sidebar-row[data-active="true"] {
-    font: var(--maka-text-label);
-    background: var(--state-selected-bg);
-    color: var(--foreground);
-  }
-  .maka-sidebar-row[data-unread="true"]::before {
-    content: "";
-    width: 6px; height: 6px;
-    border-radius: 50%;
-    background: var(--status-running);
-    flex-shrink: 0;
-  }
-
-  .maka-sidebar-button {
-    font: var(--maka-text-body);
-    appearance: none;
-    background: transparent;
-    border: none;
-    padding: var(--space-1) var(--space-2);
-    border-radius: var(--radius-control);
-    color: var(--foreground-secondary);
-  }
-  .maka-sidebar-button:hover { background: var(--state-hover-bg); color: var(--foreground); }
-
   /* ---- Main column ------------------------------------------------ */
 
   .maka-main {
@@ -1344,27 +1266,8 @@ html[data-os="darwin"].dark {
        chat / composer). One panel, one surface. */
     background: transparent;
   }
-  .maka-titlebar {
-    font: var(--maka-text-body);
-    height: var(--h-titlebar);
-    border-bottom: var(--border-width-hairline) solid var(--border);
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    padding: 0 var(--space-4);
-    color: var(--foreground-secondary);
-  }
-  .maka-titlebar strong {
-  font: var(--maka-text-label);
- color: var(--foreground); }
 
   /* ---- Chat surface ----------------------------------------------- */
-
-  .maka-chat {
-    flex: 1;
-    overflow-y: auto;
-    padding: var(--space-6) 0 var(--space-4) 0;
-  }
 
   /* Turn grouping (per kenji UI-04): user msg + tools + assistant answer
    * cluster into one visual unit. The section is a flex container; both the
@@ -1434,14 +1337,6 @@ html[data-os="darwin"].dark {
       0 0 0 4px oklch(from var(--focus-ring) l c h / 0.08),
       0 1px 3px oklch(from var(--foreground) l c h / 0.04);
   }
-  .maka-composer-toolbar {
-    font: var(--maka-text-body);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-2);
-    color: var(--foreground-secondary);
-  }
 
   /* ---- Code blocks (used in args preview inside permission prompt) --- */
 
@@ -1465,11 +1360,6 @@ html[data-os="darwin"].dark {
 /* =============================================================================
    ANIMATIONS
 ============================================================================= */
-
-@keyframes maka-shimmer {
-  0%   { background-position: -200% 0; }
-  100% { background-position:  200% 0; }
-}
 
 /* Governance-level keyframe for the `TextShimmer` primitive (streaming UI
    rework). A named `@keyframes` is a global rule, not an element property, so
@@ -1495,16 +1385,6 @@ html[data-os="darwin"].dark {
    revealed on hover / focus-within of the answer block (see the `footer`
    marker variant in packages/ui/src/primitives/chat.tsx), so there is no live
    mount transition to animate. */
-.maka-shimmer {
-  background-image: linear-gradient(
-    90deg,
-    transparent 0%,
-    var(--foreground-5) 50%,
-    transparent 100%
-  );
-  background-size: 200% 100%;
-  animation: maka-shimmer 1.5s var(--ease-in-out-strong) infinite;
-}
 
 /* =============================================================================
    Icon stroke governance: call sites had

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -403,12 +403,6 @@
     justify-content: flex-start;
   }
 
-  .maka-plan-card,
-  .maka-plan-card {
-    gap: var(--space-2);
-  }
-
-
   .maka-plan-run-row {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -79,7 +79,6 @@ html[data-os="darwin"] .maka-session-panel-footer {
   .maka-session-panel-footer,
   .maka-module-main-header,
   .maka-plan-heading,
-  .maka-skill-tab,
   .maka-titlebar-action {
     -webkit-user-select: none;
     user-select: none;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:dist": "npm run test:scripts:full && node scripts/run-workspace-tests-parallel.mjs --concurrency=3",
     "test:dist:serial": "npm run test:scripts:full && node scripts/run-workspace-tests-parallel.mjs --serial",
     "test:fast": "npm run build:test && npm run test:scripts && node scripts/run-workspace-tests-parallel.mjs --concurrency=3",
-    "test:scripts": "node --test scripts/sync-model-metadata.test.mjs scripts/fixture-env.test.mjs scripts/electron-lifecycle.test.mjs scripts/check-story-annotations.test.mjs scripts/ci-test-plan.test.mjs scripts/run-headless-tests.test.mjs scripts/run-workspace-tests-parallel.test.mjs scripts/cu-e2e-scenarios.test.mjs scripts/cu-report-sanitize.test.mjs scripts/computer-use-provenance.test.mjs scripts/cu-trace-analyse.test.mjs apps/desktop/scripts/dev-app-runtime.test.mjs",
+    "test:scripts": "node --test scripts/sync-model-metadata.test.mjs scripts/fixture-env.test.mjs scripts/electron-lifecycle.test.mjs scripts/check-story-annotations.test.mjs scripts/check-dead-css.test.mjs scripts/build-astryx-theme.test.mjs scripts/ci-test-plan.test.mjs scripts/run-headless-tests.test.mjs scripts/run-workspace-tests-parallel.test.mjs scripts/cu-e2e-scenarios.test.mjs scripts/cu-report-sanitize.test.mjs scripts/computer-use-provenance.test.mjs scripts/cu-trace-analyse.test.mjs apps/desktop/scripts/dev-app-runtime.test.mjs",
     "test:scripts:extended": "node --test scripts/cu-provider-matrix.test.mjs scripts/cu-process-restart-harness.test.mjs scripts/cu-real-model-launcher.test.mjs scripts/macos-arm64-release.test.mjs scripts/measure-session-bundle.test.mjs",
     "test:scripts:full": "npm run test:scripts && npm run test:scripts:extended",
     "dev": "npm --workspace @maka/desktop run dev:hmr --",

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -285,10 +285,6 @@
 .maka-sandbox-blocked-copy[data-pending="true"] { cursor: progress; }
 .maka-sandbox-blocked-copy[data-copy-feedback="copied"] { border-color: oklch(from var(--link) l c h / 0.35); color: var(--link); }
 .maka-sandbox-blocked-copy[data-copy-feedback="failed"] { border-color: oklch(from var(--destructive) l c h / 0.35); color: var(--destructive); }
-.maka-daily-review-copy,
-.maka-daily-review-save { min-width: 64px; }
-.maka-daily-review-append { min-width: 80px; }
-.maka-daily-review-quick-run { min-width: 96px; }
 .maka-agent-preview-failure { color: var(--destructive); }
 .maka-automation-result-icon { display: inline; margin-right: 4px; vertical-align: text-bottom; }
 .maka-turn-status-icon { flex: 0 0 auto; }

--- a/packages/ui/stories/functional-motion.stories.tsx
+++ b/packages/ui/stories/functional-motion.stories.tsx
@@ -17,6 +17,10 @@ type Story = StoryObj<typeof meta>;
 export const RetainedFunctionalMotion: Story = {
   render: () => (
     <div style={{ alignItems: 'end', display: 'grid', gap: 24, gridTemplateColumns: 'repeat(2, minmax(96px, 1fr))' }}>
+      {/* This story is the keyframe's only consumer since the product's
+          `.maka-shimmer` recipe died (#1980), so the keyframe lives here
+          rather than in maka-tokens.css. */}
+      <style>{'@keyframes maka-shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }'}</style>
       <div style={{ alignItems: 'center', display: 'grid', gap: 8, justifyItems: 'center' }}>
         <Spinner style={{ height: 20, width: 20 }} />
         <span style={{ color: 'var(--foreground-secondary)', fontSize: 12, fontWeight: 600 }}>Spinner</span>

--- a/scripts/build-astryx-theme.mjs
+++ b/scripts/build-astryx-theme.mjs
@@ -29,7 +29,10 @@ const themeSource = path.join('src', 'renderer', 'astryx-theme', 'makaTheme.ts')
 const cssOut = path.join('src', 'renderer', 'astryx-theme', 'maka.css');
 // @astryxdesign/cli 0.2.0 stopped emitting maka.variants.d.ts (`astryx theme
 // build` now outputs css/js/d.ts only) — the file was tracked but never
-// imported, so it is gone with the upgrade.
+// imported, so it is gone with the upgrade. The CLI's maka.d.ts still opens
+// with a `/// <reference>` to it, though, so post-processing strips the
+// dangling line (#1980) — without it every `tsc` run that resolves maka.d.ts
+// leans on skipLibCheck to ignore the missing file.
 const generatedFiles = ['maka.css', 'maka.js', 'maka.d.ts'];
 const canonicalCommand =
   ' * Command: astryx theme build src/renderer/astryx-theme/makaTheme.ts --out ' +
@@ -75,9 +78,15 @@ export function stripResetLayer(css, file = cssOut) {
   return stripped.replace('*/\n', `*/\n\n${postProcessNote}`);
 }
 
+export function stripVariantsReference(dts) {
+  return dts.replace(/^\/\/\/\s*<reference\s+path="\.\/maka\.variants\.d\.ts"\s*\/>\s*\n/m, '');
+}
+
 function postProcessGeneratedFile(file, source) {
   const normalized = normalizeGeneratedHeader(source);
-  return file === 'maka.css' ? stripResetLayer(normalized, file) : normalized;
+  if (file === 'maka.css') return stripResetLayer(normalized, file);
+  if (file === 'maka.d.ts') return stripVariantsReference(normalized);
+  return normalized;
 }
 
 function generateTheme(output, stdio) {

--- a/scripts/build-astryx-theme.test.mjs
+++ b/scripts/build-astryx-theme.test.mjs
@@ -6,11 +6,13 @@ import { stripVariantsReference } from './build-astryx-theme.mjs';
 // no longer emits the file (#1980). Post-processing must drop the dangling
 // line so tsc does not depend on skipLibCheck to resolve maka.d.ts.
 test('the dangling variants reference line is stripped', () => {
-  const dts = '/// <reference path="./maka.variants.d.ts" />\nimport type { DefinedTheme } from "x";\n';
+  const dts =
+    '/// <reference path="./maka.variants.d.ts" />\nimport type { DefinedTheme } from "x";\n';
   assert.equal(stripVariantsReference(dts), 'import type { DefinedTheme } from "x";\n');
 });
 
 test('stripping is idempotent and leaves other content alone', () => {
-  const dts = 'import type { DefinedTheme } from "x";\nexport declare const makaTheme: DefinedTheme;\n';
+  const dts =
+    'import type { DefinedTheme } from "x";\nexport declare const makaTheme: DefinedTheme;\n';
   assert.equal(stripVariantsReference(dts), dts);
 });

--- a/scripts/build-astryx-theme.test.mjs
+++ b/scripts/build-astryx-theme.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { stripVariantsReference } from './build-astryx-theme.mjs';
+
+// @astryxdesign/cli 0.2.0 emits a `/// <reference>` to maka.variants.d.ts but
+// no longer emits the file (#1980). Post-processing must drop the dangling
+// line so tsc does not depend on skipLibCheck to resolve maka.d.ts.
+test('the dangling variants reference line is stripped', () => {
+  const dts = '/// <reference path="./maka.variants.d.ts" />\nimport type { DefinedTheme } from "x";\n';
+  assert.equal(stripVariantsReference(dts), 'import type { DefinedTheme } from "x";\n');
+});
+
+test('stripping is idempotent and leaves other content alone', () => {
+  const dts = 'import type { DefinedTheme } from "x";\nexport declare const makaTheme: DefinedTheme;\n';
+  assert.equal(stripVariantsReference(dts), dts);
+});

--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -3,9 +3,10 @@
  * check-dead-css — detect CSS classes and design tokens with zero consumers.
  *
  * Classes: parses all .css files under apps/desktop/src/renderer/styles/
- * (including the settings/ sub-directory) plus maka-tokens.css for class
- * selectors, then searches the renderer and packages/ui/src source for
- * consumers. A consumer is an exact class-name match: `maka-shell` in source
+ * (including the settings/ sub-directory) plus maka-tokens.css and
+ * packages/ui/src/styles.css (the component-library sheet imported into the
+ * product CSS) for class selectors, then searches the renderer and
+ * packages/ui/src source for consumers. A consumer is an exact class-name match: `maka-shell` in source
  * does not keep `.maka-shell-rail` alive, and `maka-shell-rail` does not keep
  * `.maka-shell` alive (#1980).
  *
@@ -56,6 +57,11 @@ const EXTRA_TOKEN_CONSUMER_FILES = [
   resolve(REPO_ROOT, 'node_modules', '@astryxdesign', 'core', 'dist', 'theme', 'tokens.stylex.js'),
 ];
 const TOKEN_FILE = resolve(RENDERER_ROOT, 'maka-tokens.css');
+/** The component-library sheet — imported into the product CSS, so its
+ * classes are product classes and join the dead-class scan. Deliberately not
+ * the whole of packages/ui/src: the only other stylesheets there would be
+ * generated ones, which own no hand-written product classes. */
+const UI_STYLE_FILE = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'styles.css');
 const SOURCE_ROOTS = [
   resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer'),
   resolve(REPO_ROOT, 'packages', 'ui', 'src'),
@@ -133,6 +139,12 @@ const DYNAMIC_STYLE_HOOKS = new Set([
   'settingsPaletteSwatch-dusk',
   'settingsPaletteSwatch-sand',
   'settingsPaletteSwatch-mono',
+  // Markdown code-block density variants — composed at runtime via
+  // `maka-markdown-code-${props.density}` in markdown-body.tsx and
+  // mermaid-diagram.tsx, so the per-density names never appear as string
+  // literals. Keep in sync with the density prop's values.
+  'maka-markdown-code-default',
+  'maka-markdown-code-compact',
 ]);
 
 /**
@@ -158,10 +170,10 @@ const RESERVED_SCALE_TOKENS = new Set([
   // Zero rung of the spacing ruler.
   '--space-0',
   // Easing vocabulary (see the motion governance comment in maka-tokens.css):
-  // --ease-out-strong for feedback, --ease-in-out-strong for on-screen
-  // movement, --ease-linear for shimmer sweeps. The movement curve lost its
-  // last consumer with the dead shell recipes (#1980), but deleting the named
-  // curve is what invites the next bare cubic-bezier.
+  // --ease-out-strong for feedback/state changes, --ease-in-out-strong for
+  // on-screen movement. The movement curve lost its last consumer with the
+  // dead shell recipes (#1980), but deleting the named curve is what invites
+  // the next bare cubic-bezier.
   '--ease-in-out-strong',
 ]);
 
@@ -279,7 +291,11 @@ export function analyzeTokenSheet(css, isClassLive) {
   const derivations = new Map();
   const liveReads = new Set();
   for (const rule of parseLeafRules(css)) {
-    const ruleLive = [...collectClassSelectors(rule.selector)].every(isClassLive);
+    // A comma group applies when ANY branch matches, and a branch matches
+    // only when ALL of its classes exist somewhere.
+    const ruleLive = rule.selector
+      .split(',')
+      .some((branch) => [...collectClassSelectors(branch)].every(isClassLive));
     if (!ruleLive) continue;
     for (const declaration of rule.body.split(';')) {
       const definition = declaration.match(/^\s*(--[a-z0-9-]+)\s*:/);
@@ -321,7 +337,7 @@ async function main() {
   // Collect all CSS class selectors. The token sheet owns product classes
   // too (shell recipes historically hid there — #1980), so it joins the scan.
   const cssFiles = await readCssFiles(STYLES_DIR);
-  for (const file of [...EXTRA_STYLE_FILES, TOKEN_FILE]) {
+  for (const file of [...EXTRA_STYLE_FILES, TOKEN_FILE, UI_STYLE_FILE]) {
     cssFiles.push(file);
   }
   const allClasses = new Set();

--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -3,12 +3,17 @@
  * check-dead-css — detect CSS classes and design tokens with zero consumers.
  *
  * Classes: parses all .css files under apps/desktop/src/renderer/styles/
- * (including the settings/ sub-directory) for class selectors, then greps the
- * renderer and packages/ui/src source for consumers.
+ * (including the settings/ sub-directory) plus maka-tokens.css for class
+ * selectors, then searches the renderer and packages/ui/src source for
+ * consumers. A consumer is an exact class-name match: `maka-shell` in source
+ * does not keep `.maka-shell-rail` alive, and `maka-shell-rail` does not keep
+ * `.maka-shell` alive (#1980).
  *
  * Tokens: parses the custom properties declared in maka-tokens.css and sweeps
- * every renderer stylesheet plus the source tree for var() reads. Tokens
- * derive from one another, so the token sheet counts as its own consumer.
+ * every renderer stylesheet plus the source tree for var() reads. Reads
+ * inside the token sheet itself only count when they can fire: a read in a
+ * class rule counts when that rule's classes have consumers, and a read in
+ * another token's value counts when that token is itself live (#1980).
  *
  * Known limitations:
  *   - Dynamic class names (template-string concatenation) cause false
@@ -152,6 +157,12 @@ const RESERVED_SCALE_TOKENS = new Set([
   '--border-width-accent',
   // Zero rung of the spacing ruler.
   '--space-0',
+  // Easing vocabulary (see the motion governance comment in maka-tokens.css):
+  // --ease-out-strong for feedback, --ease-in-out-strong for on-screen
+  // movement, --ease-linear for shimmer sweeps. The movement curve lost its
+  // last consumer with the dead shell recipes (#1980), but deleting the named
+  // curve is what invites the next bare cubic-bezier.
+  '--ease-in-out-strong',
 ]);
 
 async function readCssFiles(dir) {
@@ -184,7 +195,7 @@ function stripCssComments(css) {
   return css.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
-function collectClassSelectors(css) {
+export function collectClassSelectors(css) {
   const selectors = new Set();
   for (const match of stripCssComments(css).matchAll(/\.(-?[_a-zA-Z][_a-zA-Z0-9-]*)/g)) {
     const cls = match[1];
@@ -199,7 +210,7 @@ function collectClassSelectors(css) {
  * indentation — several tokens share a line in the compact blocks. `--x` inside
  * `var(--x)` is preceded by `(` and never matches.
  */
-function collectTokenDefinitions(css) {
+export function collectTokenDefinitions(css) {
   const tokens = new Set();
   for (const match of stripCssComments(css).matchAll(/(?:^|[{;])\s*(--[a-z0-9-]+)\s*:/gm)) {
     tokens.add(match[1]);
@@ -208,7 +219,7 @@ function collectTokenDefinitions(css) {
 }
 
 /** Custom properties read through var(). */
-function collectTokenReferences(text) {
+export function collectTokenReferences(text) {
   const refs = new Set();
   for (const match of text.matchAll(/var\(\s*(--[a-z0-9-]+)/g)) {
     refs.add(match[1]);
@@ -216,12 +227,101 @@ function collectTokenReferences(text) {
   return refs;
 }
 
+/**
+ * Whether `cls` appears in `blob` as a whole class name. `\b` alone treats a
+ * hyphen as a boundary, so it would let `maka-shell-rail` keep `.maka-shell`
+ * alive; class names extend across hyphens, so both ends must be checked
+ * against the class-name alphabet.
+ */
+export function hasExactConsumer(blob, cls) {
+  return new RegExp(`(?<![\\w-])${cls.replaceAll('-', '\\-')}(?![\\w-])`).test(blob);
+}
+
+/**
+ * Leaf rules (`selector { declarations }`) of a stylesheet, with at-rule
+ * wrappers (@media, @supports, …) flattened away. Good enough for the token
+ * sheet's shapes; not a general CSS parser.
+ */
+export function parseLeafRules(css) {
+  const rules = [];
+  const walk = (text) => {
+    let cursor = 0;
+    while (cursor < text.length) {
+      const open = text.indexOf('{', cursor);
+      if (open === -1) return;
+      const selector = text.slice(cursor, open).trim();
+      let depth = 1;
+      let close = open + 1;
+      while (close < text.length && depth > 0) {
+        if (text[close] === '{') depth += 1;
+        else if (text[close] === '}') depth -= 1;
+        close += 1;
+      }
+      const body = text.slice(open + 1, close - 1);
+      if (body.includes('{')) walk(body);
+      else rules.push({ selector, body });
+      cursor = close;
+    }
+  };
+  walk(stripCssComments(css));
+  return rules;
+}
+
+/**
+ * var() reads inside the token sheet, attributed to the context that can make
+ * them fire. A read in a class rule's declaration only counts when every
+ * class in the rule's selector has a consumer — a rule whose classes are dead
+ * never applies, so it must not keep its tokens alive. A read inside another
+ * token's value is a derivation edge: it counts only once the deriving token
+ * is live (resolved by `resolveLiveTokens`).
+ */
+export function analyzeTokenSheet(css, isClassLive) {
+  const derivations = new Map();
+  const liveReads = new Set();
+  for (const rule of parseLeafRules(css)) {
+    const ruleLive = [...collectClassSelectors(rule.selector)].every(isClassLive);
+    if (!ruleLive) continue;
+    for (const declaration of rule.body.split(';')) {
+      const definition = declaration.match(/^\s*(--[a-z0-9-]+)\s*:/);
+      const reads = collectTokenReferences(declaration);
+      if (definition) {
+        const existing = derivations.get(definition[1]) ?? new Set();
+        for (const read of reads) existing.add(read);
+        derivations.set(definition[1], existing);
+      } else {
+        for (const read of reads) liveReads.add(read);
+      }
+    }
+  }
+  return { derivations, liveReads };
+}
+
+/** Close the externally-seeded live set over the sheet's derivation edges. */
+export function resolveLiveTokens(externalReads, { derivations, liveReads }) {
+  const live = new Set([...externalReads, ...liveReads]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [from, reads] of derivations) {
+      if (!live.has(from)) continue;
+      for (const read of reads) {
+        if (!live.has(read)) {
+          live.add(read);
+          changed = true;
+        }
+      }
+    }
+  }
+  return live;
+}
+
 async function main() {
   const checkMode = process.argv.includes('--check');
 
-  // Collect all CSS class selectors
+  // Collect all CSS class selectors. The token sheet owns product classes
+  // too (shell recipes historically hid there — #1980), so it joins the scan.
   const cssFiles = await readCssFiles(STYLES_DIR);
-  for (const file of EXTRA_STYLE_FILES) {
+  for (const file of [...EXTRA_STYLE_FILES, TOKEN_FILE]) {
     cssFiles.push(file);
   }
   const allClasses = new Set();
@@ -245,28 +345,29 @@ async function main() {
   }
   const storyBlob = stories.join('\n');
 
-  // Find dead classes (zero consumers)
+  // Find dead classes (zero consumers, exact class-name match)
+  const isClassLive = (cls) => DYNAMIC_STYLE_HOOKS.has(cls) || hasExactConsumer(sourceBlob, cls);
   const dead = [];
   for (const cls of [...allClasses].sort()) {
-    if (DYNAMIC_STYLE_HOOKS.has(cls)) continue;
-    // Search for the class name as a string literal in source
-    if (!sourceBlob.includes(cls)) {
+    if (!isClassLive(cls)) {
       dead.push(cls);
     }
   }
 
   // Find dead tokens (declared in the product sheet, read by nobody).
   // A token's consumers are spread across every stylesheet, not just the ones
-  // that own classes, so the reference sweep covers all renderer CSS plus the
-  // token sheet itself (tokens routinely derive from one another).
+  // that own classes. Reads inside the token sheet itself only count when
+  // they can fire (live class rule, or derivation from a live token) — a
+  // token read exclusively by dead rules is dead with them (#1980).
   const tokenCss = await readFile(TOKEN_FILE, 'utf8');
   const definedTokens = collectTokenDefinitions(tokenCss);
-  const referenced = collectTokenReferences(tokenCss);
+  const referenced = new Set();
   const tokenCssFiles = [...EXTRA_STYLE_FILES, ...EXTRA_TOKEN_CONSUMER_FILES];
   for (const root of TOKEN_CONSUMER_ROOTS) {
     tokenCssFiles.push(...(await readCssFiles(root)));
   }
   for (const file of tokenCssFiles) {
+    if (file === TOKEN_FILE) continue;
     for (const ref of collectTokenReferences(await readFile(file, 'utf8'))) {
       referenced.add(ref);
     }
@@ -277,11 +378,12 @@ async function main() {
   for (const ref of collectTokenReferences(storyBlob)) {
     referenced.add(ref);
   }
+  const liveTokens = resolveLiveTokens(referenced, analyzeTokenSheet(tokenCss, isClassLive));
 
   const deadTokens = [];
   for (const token of [...definedTokens].sort()) {
     if (RESERVED_SCALE_TOKENS.has(token)) continue;
-    if (!referenced.has(token)) deadTokens.push(token);
+    if (!liveTokens.has(token)) deadTokens.push(token);
   }
 
   if (dead.length === 0 && deadTokens.length === 0) {
@@ -356,7 +458,10 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error('check-dead-css: ERROR', err.message);
-  process.exit(1);
-});
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error('check-dead-css: ERROR', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/check-dead-css.test.mjs
+++ b/scripts/check-dead-css.test.mjs
@@ -65,6 +65,22 @@ test('the same read counts once the rule class has a consumer', () => {
   assert.equal(resolveLiveTokens(new Set(), analysis).has('--w-rail'), true);
 });
 
+// A comma group applies when any branch matches, so one live branch must
+// keep the whole rule's reads alive — and all-dead branches must not.
+test('a comma group with one live branch keeps its token reads', () => {
+  const sheet = '.maka-dead, .maka-live { width: var(--w-shared); }';
+  const live = (isLive) =>
+    resolveLiveTokens(new Set(), analyzeTokenSheet(sheet, isLive)).has('--w-shared');
+  assert.equal(
+    live((cls) => cls === 'maka-live'),
+    true,
+  );
+  assert.equal(
+    live(() => false),
+    false,
+  );
+});
+
 test('token-to-token derivation keeps a base token alive only via a live head', () => {
   const sheet = ':root { --derived: var(--base); --base: 4px; }';
   const analysis = analyzeTokenSheet(sheet, () => false);
@@ -77,6 +93,34 @@ test('derivation chains resolve transitively', () => {
   const analysis = analyzeTokenSheet(sheet, () => false);
   const live = resolveLiveTokens(new Set(['--a']), analysis);
   assert.equal(live.has('--c'), true);
+});
+
+test('a self-referencing token does not loop and does not revive itself', () => {
+  const sheet = ':root { --a: var(--a, 4px); }';
+  const analysis = analyzeTokenSheet(sheet, () => false);
+  assert.equal(resolveLiveTokens(new Set(), analysis).has('--a'), false);
+  assert.equal(resolveLiveTokens(new Set(['--a']), analysis).has('--a'), true);
+});
+
+test('a derivation cycle terminates and lives or dies as one unit', () => {
+  const sheet = ':root { --a: var(--b); --b: var(--a); }';
+  const analysis = analyzeTokenSheet(sheet, () => false);
+  const dead = resolveLiveTokens(new Set(), analysis);
+  assert.equal(dead.has('--a'), false);
+  assert.equal(dead.has('--b'), false);
+  const live = resolveLiveTokens(new Set(['--a']), analysis);
+  assert.equal(live.has('--a'), true);
+  assert.equal(live.has('--b'), true);
+});
+
+test('a diamond of derivations resolves every path to the shared base', () => {
+  const sheet =
+    ':root { --top: var(--left) var(--right); --left: var(--base); --right: var(--base); --base: 1px; }';
+  const analysis = analyzeTokenSheet(sheet, () => false);
+  const live = resolveLiveTokens(new Set(['--top']), analysis);
+  for (const token of ['--left', '--right', '--base']) {
+    assert.equal(live.has(token), true, `${token} should be live via the diamond`);
+  }
 });
 
 test('reads in rules without class selectors always count', () => {

--- a/scripts/check-dead-css.test.mjs
+++ b/scripts/check-dead-css.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  analyzeTokenSheet,
+  collectClassSelectors,
+  hasExactConsumer,
+  parseLeafRules,
+  resolveLiveTokens,
+} from './check-dead-css.mjs';
+
+// #1980 blind spot 2: `maka-shell` was reported live because the substring
+// check found it inside `maka-shell-astryx`. Class names extend across
+// hyphens, so a prefix hit in either direction is not a consumer.
+test('a longer hyphenated class name is not a consumer of its prefix', () => {
+  assert.equal(hasExactConsumer('className="maka-shell-astryx"', 'maka-shell'), false);
+  assert.equal(hasExactConsumer('className="maka-shell"', 'maka-shell-astryx'), false);
+});
+
+test('exact matches count as consumers regardless of surrounding syntax', () => {
+  assert.equal(hasExactConsumer('className="maka-shell chat"', 'maka-shell'), true);
+  assert.equal(hasExactConsumer("classes.push('maka-shell')", 'maka-shell'), true);
+  assert.equal(hasExactConsumer('<div class="a maka-shell">', 'maka-shell'), true);
+});
+
+test('class selectors are collected from compact and nested rules', () => {
+  const css = `
+    .maka-shell { display: grid; }
+    @media (min-width: 600px) { .maka-sidebar:hover, .maka-titlebar strong { color: red; } }
+    /* .maka-commented { } */
+  `;
+  assert.deepEqual(
+    [...collectClassSelectors(css)].sort(),
+    ['maka-shell', 'maka-sidebar', 'maka-titlebar'],
+  );
+});
+
+test('parseLeafRules flattens at-rule wrappers to selector/body pairs', () => {
+  const rules = parseLeafRules(
+    '@layer components { .a { color: red; } @media (x) { .b { color: blue; } } }',
+  );
+  assert.deepEqual(
+    rules.map((rule) => rule.selector),
+    ['.a', '.b'],
+  );
+});
+
+// #1980 blind spot 3: --w-rail / --w-sidebar were reported live because dead
+// shell rules inside the token sheet itself read them.
+test('a token read only by a dead rule in the token sheet is dead', () => {
+  const sheet = `
+    :root { --w-rail: 240px; }
+    .maka-shell { grid-template-columns: var(--w-rail) 1fr; }
+  `;
+  const analysis = analyzeTokenSheet(sheet, () => false);
+  assert.equal(resolveLiveTokens(new Set(), analysis).has('--w-rail'), false);
+});
+
+test('the same read counts once the rule class has a consumer', () => {
+  const sheet = `
+    :root { --w-rail: 240px; }
+    .maka-shell { grid-template-columns: var(--w-rail) 1fr; }
+  `;
+  const analysis = analyzeTokenSheet(sheet, (cls) => cls === 'maka-shell');
+  assert.equal(resolveLiveTokens(new Set(), analysis).has('--w-rail'), true);
+});
+
+test('token-to-token derivation keeps a base token alive only via a live head', () => {
+  const sheet = ':root { --derived: var(--base); --base: 4px; }';
+  const analysis = analyzeTokenSheet(sheet, () => false);
+  assert.equal(resolveLiveTokens(new Set(['--derived']), analysis).has('--base'), true);
+  assert.equal(resolveLiveTokens(new Set(), analysis).has('--base'), false);
+});
+
+test('derivation chains resolve transitively', () => {
+  const sheet = ':root { --a: var(--b); --b: var(--c); --c: 1px; }';
+  const analysis = analyzeTokenSheet(sheet, () => false);
+  const live = resolveLiveTokens(new Set(['--a']), analysis);
+  assert.equal(live.has('--c'), true);
+});
+
+test('reads in rules without class selectors always count', () => {
+  const sheet = 'body { margin: var(--space-page); }';
+  const analysis = analyzeTokenSheet(sheet, () => false);
+  assert.equal(resolveLiveTokens(new Set(), analysis).has('--space-page'), true);
+});

--- a/scripts/check-dead-css.test.mjs
+++ b/scripts/check-dead-css.test.mjs
@@ -28,10 +28,11 @@ test('class selectors are collected from compact and nested rules', () => {
     @media (min-width: 600px) { .maka-sidebar:hover, .maka-titlebar strong { color: red; } }
     /* .maka-commented { } */
   `;
-  assert.deepEqual(
-    [...collectClassSelectors(css)].sort(),
-    ['maka-shell', 'maka-sidebar', 'maka-titlebar'],
-  );
+  assert.deepEqual([...collectClassSelectors(css)].sort(), [
+    'maka-shell',
+    'maka-sidebar',
+    'maka-titlebar',
+  ]);
 });
 
 test('parseLeafRules flattens at-rule wrappers to selector/body pairs', () => {


### PR DESCRIPTION
## Summary

Implements #1980 end to end: fixes the three `check-dead-css` blind spots, then deletes everything the fixed scanner reveals — the audit's 13 dead rules were still present on `main` (the gate printed "no dead classes or tokens found ✓" over them the whole time).

### Scanner fixes (`scripts/check-dead-css.mjs`)

1. **Class scan now includes `maka-tokens.css`** — previously it was scanned for tokens only, so `.maka-composer-toolbar` and `.maka-shimmer` were invisible outright.
2. **Exact class-name matching** — the substring check let `maka-shell-astryx` keep `.maka-shell` alive, `maka-chat-message-*` keep `.maka-chat` alive, etc. Consumers now match with hyphen-aware boundaries (`\b` alone treats `-` as a boundary, so plain word-boundary matching would not have fixed the collision).
3. **Sheet-internal token reads are attributed, not blanket-seeded** — a `var()` read in a class rule counts only when the rule's classes have consumers; a read inside another token's value counts only once that token is live (fixpoint over derivation edges). This is what let the dead shell rules keep `--w-rail`/`--w-sidebar` alive.

The script also gains an `isMain` guard and exports its pure pieces for the new `scripts/check-dead-css.test.mjs` (fixtures cover both acceptance scenarios: prefix-collision and token-read-only-by-dead-rules). Wired into `test:scripts`.

### Deletions (all zero-consumer under the fixed scanner, re-verified individually)

- `maka-tokens.css`: `.maka-shell`, `.maka-shell-rail-right`, the `.maka-sidebar` header/section/row/button family, `.maka-titlebar` (+`strong`), `.maka-chat`, `.maka-composer-toolbar`, `.maka-shimmer` + its `@keyframes` (folded into `functional-motion.stories.tsx`, its only consumer), and `--w-rail`/`--w-sidebar`. `.maka-main`, `.maka-turn`, `.maka-code` stay — they are live.
- Two prefix-collision finds the original audit missed: `.maka-plan-card` (plan-reminders.css; its "consumer" was `maka-plan-card-menu`) and `.maka-skill-tab` (theme-glass.css; its "consumer" was `maka-skill-tabs-bar`).
- `--ease-in-out-strong` lost its last consumer with `.maka-shimmer`, but it is the named movement curve of the motion governance vocabulary (out-strong = feedback, in-out-strong = movement), so it joins `RESERVED_SCALE_TOKENS` with that rationale instead of being deleted.

### Theme build (`scripts/build-astryx-theme.mjs`)

`@astryxdesign/cli` 0.2.0 stopped emitting `maka.variants.d.ts` but its `maka.d.ts` still opens with a `/// <reference>` to it (masked by `skipLibCheck`). Post-processing now strips the dangling line; `maka.d.ts` regenerated (css/js byte-identical), `astryx:theme --check` current. Covered by `scripts/build-astryx-theme.test.mjs`.

Closes #1980.

## Verification

- `check-dead-css` reports the 13 rules + 3 tokens before the deletions, and is clean at baseline **0/0** after; `--check` passes.
- `npm run astryx:theme -- --check`: artifacts current.
- `npm run typecheck`: clean across all workspaces.
- Script tests 19/19 (including the two new files); `check-story-annotations` clean.
- e2e/main/preload grepped for the deleted class names as locators: none.

Note: `dev-app-runtime.test.mjs › ignores an unreadable or wrong-schema environment file` fails on my machine both with and without this change (it picks up the developer's real local env file — a pre-existing test-isolation issue, unrelated).
