### PR TITLE
test(storybook): prove the autoplay contract the smoke harness stands on

### DIFF
--- a/apps/desktop/stories/FIDELITY.md
+++ b/apps/desktop/stories/FIDELITY.md
@@ -44,7 +44,7 @@ If the runtime computes a field, ask the runtime for it. A story that hardcodes 
 
 ## A `play` function is a step, not a test report
 
-A `play` that throws — including from an assertion — fails the smoke run and CI: `scripts/storybook-visual-smoke.mjs` subscribes to `playFunctionThrewException` and `unhandledErrorsWhilePlaying`, and the throw also surfaces as a console error it collects. What `play` cannot do is *report*: there is no test addon, so a run tells you the story broke, not which assertion, in what state, or against what expectation. It is also the slowest place to put a check, because reaching it means building and serving Storybook.
+A `play` that throws — including from an assertion — fails the smoke run and CI: `scripts/storybook-visual-smoke.mjs` subscribes to `playFunctionThrewException` and `unhandledErrorsWhilePlaying`, and the throw also surfaces as a console error it collects. That failure path only exists while plays actually run, so the harness carries its own proof: `harness-play-contract.stories.tsx` flips a DOM marker from `play`, and the manifest's `play-executed` check fails the run if autoplay ever stops (#1981). What `play` cannot do is *report*: there is no test addon, so a run tells you the story broke, not which assertion, in what state, or against what expectation. It is also the slowest place to put a check, because reaching it means building and serving Storybook.
 
 So put behavioural and computed-style contracts where they can name what they check — a `packages/ui` test, an e2e journey, or the smoke script's `checks` — and use `play` for what it is good at: driving a story into the state it claims to render.
 

--- a/apps/desktop/stories/harness-play-contract.stories.tsx
+++ b/apps/desktop/stories/harness-play-contract.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+// The autoplay contract the smoke harness depends on (#1981): Storybook's
+// preview runtime executes `play` by default, and FIDELITY.md documents that
+// a throwing play fails the smoke run. Both claims silently stop being true
+// if a Storybook upgrade turns autoplay off — nothing else in CI would
+// notice, because plays that no longer run can no longer fail.
+//
+// This story is the positive proof: its play flips a DOM marker, and the
+// smoke manifest's `play-executed` check fails the run when the marker never
+// flips. The surface is listed in REQUIRED_PRODUCT_SURFACES, so it cannot be
+// switched off by deleting its manifest entry either.
+const meta = {
+  title: 'Design System/Harness Contracts',
+  parameters: { layout: 'centered' },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const PlayExecutes: Story = {
+  render: () => (
+    <p data-play-proof="pending" style={{ font: 'var(--maka-text-body)' }}>
+      play 未执行 — smoke 的 play-executed 检查应当失败
+    </p>
+  ),
+  play: async ({ canvasElement }) => {
+    const proof = canvasElement.querySelector('[data-play-proof]');
+    if (!(proof instanceof HTMLElement)) {
+      throw new Error('play contract story rendered without its proof node');
+    }
+    proof.dataset.playProof = 'executed';
+    proof.textContent = 'play 已执行 — autoplay 契约成立';
+  },
+};

--- a/apps/desktop/stories/product-smoke-manifest.json
+++ b/apps/desktop/stories/product-smoke-manifest.json
@@ -6,6 +6,18 @@
     "floor": { "width": 480, "height": 900 }
   },
   "surfaces": {
+    "playContract": {
+      "storyId": "design-system-harness-contracts--play-executes",
+      "productionHost": "storybook-visual-smoke harness (autoplay contract, #1981)",
+      "state": "play function executed and flipped its DOM proof marker",
+      "viewports": ["wide"],
+      "viewportOptOuts": {
+        "compact": "harness contract, not a product surface — autoplay either runs or it does not, one viewport proves it",
+        "floor": "harness contract, not a product surface — autoplay either runs or it does not, one viewport proves it"
+      },
+      "colorSchemes": ["light"],
+      "checks": ["play-executed"]
+    },
     "onboarding": {
       "storyId": "product-onboarding--needs-connection",
       "productionHost": "ChatView > OnboardingHero",

--- a/scripts/storybook-visual-smoke.mjs
+++ b/scripts/storybook-visual-smoke.mjs
@@ -21,12 +21,16 @@ const REQUIRED_PRODUCT_SURFACES = Object.freeze([
   'dailyReview',
   'sessionContext',
   'composer',
+  // The autoplay contract (#1981): if plays stop running, they also stop
+  // failing, so the harness carries a story that positively proves execution.
+  'playContract',
 ]);
 
 const PRODUCT_CHECKS = new Set([
   'composer-focus-ownership',
   'plan-reminder-row',
   'session-context-layer',
+  'play-executed',
 ]);
 
 function fail(message) {
@@ -296,6 +300,20 @@ async function smokeStory(page, baseUrl, job, options = {}) {
                 `session context layer overflows horizontally (${layer.scrollWidth} > ${layer.clientWidth})`,
               );
             }
+          }
+        }
+        // #1981: the play-contract story's play flips this marker. If it is
+        // still pending, Storybook stopped autoplaying play functions — which
+        // also means throwing plays no longer fail this harness, so the
+        // regression must surface here, positively.
+        if (checks.includes('play-executed')) {
+          const proof = root?.querySelector('[data-play-proof]');
+          if (!(proof instanceof HTMLElement)) {
+            failures.push('play contract story rendered without its proof node');
+          } else if (proof.dataset.playProof !== 'executed') {
+            failures.push(
+              'play function did not execute — the Storybook autoplay contract (FIDELITY.md) is broken',
+            );
           }
         }
         if (checks.includes('composer-focus-ownership')) {


### PR DESCRIPTION
## Summary

The remaining item from #1981. The doc half was already fixed on `main` — FIDELITY.md's play section now correctly states that plays execute and a throwing play fails the smoke run. What was still missing is the guard the issue asked for: that failure path only exists **while plays actually run**. If a Storybook upgrade turned autoplay off, throwing plays would stop failing, silently.

A literally-throwing story can't ship (it would keep CI permanently red), so the contract is proven positively instead:

- `harness-play-contract.stories.tsx` (`Design System/Harness Contracts`, exempt namespace): renders a `data-play-proof="pending"` node; its `play` flips it to `executed`.
- A new `play-executed` product check in `storybook-visual-smoke.mjs` fails the run when the marker never flips, with a message that names the broken contract.
- The surface joins `REQUIRED_PRODUCT_SURFACES`, so it cannot be switched off by deleting its manifest entry — the same durability rule the other required surfaces get.
- FIDELITY.md's play section points at the contract.

Closes #1981.

## Verification

Both directions, locally against a real `build-storybook` output:

- **Positive**: `smoke:storybook` passes — `Product Storybook smoke passed (68 manifest check(s), 73 catalog render(s))`.
- **Negative** (the actual acceptance): with the play sabotaged into a no-op (marker never flips, simulating an autoplay regression), the run exits 1 with `[design-system-harness-contracts--play-executes @ wide] play function did not execute — the Storybook autoplay contract (FIDELITY.md) is broken`. Restored and re-verified green after.
- `tsc -p tsconfig.storybook.json`, biome format/lint, `check-story-annotations` all clean.
