### PR TITLE
feat(runtime-host): expose effective pricing projection

### DIFF
--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -51,6 +51,7 @@ const allowedServerExternalImports = new Set([
   '@maka/core/subagent-workspace',
   '@maka/core/task-ledger',
   '@maka/core/usage-ledger-merge',
+  '@maka/core/usage-stats/pricing',
   '@maka/core/usage-stats/types',
   '@maka/runtime',
   '@maka/storage/agent-graph-control-store',

--- a/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
@@ -92,7 +92,7 @@ const mismatchCases = [
       kind: 'page',
       revision: 8,
       offset: 50,
-      overrides: [],
+      entries: [],
       nextOffset: null,
     },
   },

--- a/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
@@ -447,6 +447,17 @@ describe('Usage/Pricing protocol', () => {
     );
     assert.throws(
       () =>
+        pricingResponse('pricing.query', {
+          kind: 'page',
+          revision: 0,
+          offset: 0,
+          overrides: [pricing('m')],
+          nextOffset: null,
+        }),
+      invalidFrame,
+    );
+    assert.throws(
+      () =>
         encodePricingQueryResult({
           kind: 'page',
           revision: 0,

--- a/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
@@ -7,7 +7,7 @@ import {
   comparePricingModelKeys,
   PRICING_MODEL_KEY_MAX_CHARS,
 } from '@maka/core/usage-stats/pricing';
-import type { UsageBucket } from '@maka/core/usage-stats/types';
+import type { PricingConfig, UsageBucket } from '@maka/core/usage-stats/types';
 import {
   resolveRootControlNamespace,
   resolveStorageRoot,
@@ -28,6 +28,7 @@ import {
   USAGE_PAGE_MAX_BYTES,
   USAGE_PAGE_MAX_ITEMS,
   USAGE_PROJECTION_TEXT_MAX_BYTES,
+  type EffectivePricingEntry,
   type LlmUsageLogProjection,
   type ToolUsageLogProjection,
 } from '../protocol/index.js';
@@ -425,14 +426,14 @@ describe('Usage/Pricing protocol', () => {
         kind: 'page',
         revision: 3,
         offset: 0,
-        overrides: [pricing('m')],
+        entries: [customPricingEntry('m')],
         nextOffset: 1,
       }),
       {
         kind: 'page',
         revision: 3,
         offset: 0,
-        overrides: [pricing('m')],
+        entries: [customPricingEntry('m')],
         nextOffset: 1,
       },
     );
@@ -450,8 +451,8 @@ describe('Usage/Pricing protocol', () => {
           kind: 'page',
           revision: 0,
           offset: 0,
-          overrides: Array.from({ length: PRICING_PAGE_MAX_ITEMS + 1 }, (_, index) =>
-            pricing(`model-${index}`),
+          entries: Array.from({ length: PRICING_PAGE_MAX_ITEMS + 1 }, (_, index) =>
+            customPricingEntry(`model-${index}`),
           ),
           nextOffset: null,
         }),
@@ -462,21 +463,21 @@ describe('Usage/Pricing protocol', () => {
         kind: 'page',
         revision: 1,
         offset: 2,
-        overrides: [],
+        entries: [],
         nextOffset: 2,
       },
       {
         kind: 'page',
         revision: 1,
         offset: 2,
-        overrides: [pricing('m')],
+        entries: [customPricingEntry('m')],
         nextOffset: 4,
       },
       {
         kind: 'page',
         revision: 1,
         offset: 0,
-        overrides: [pricing('z'), pricing('a')],
+        entries: [customPricingEntry('z'), customPricingEntry('a')],
         nextOffset: null,
       },
       {
@@ -486,6 +487,24 @@ describe('Usage/Pricing protocol', () => {
       },
     ]) {
       assert.throws(() => pricingResponse('pricing.query', result), invalidFrame);
+    }
+    for (const entry of [
+      { pricing: pricing('m'), source: 'builtin', resetEffect: 'restore_builtin' },
+      { pricing: pricing('m'), source: 'custom' },
+      { pricing: pricing('m'), source: 'custom', resetEffect: 'invalid' },
+      { pricing: pricing('m'), source: 'unknown' },
+    ]) {
+      assert.throws(
+        () =>
+          pricingResponse('pricing.query', {
+            kind: 'page',
+            revision: 1,
+            offset: 0,
+            entries: [entry],
+            nextOffset: null,
+          }),
+        invalidFrame,
+      );
     }
     for (const result of [
       { kind: 'committed', revision: 1 },
@@ -512,23 +531,23 @@ describe('Usage/Pricing protocol', () => {
       kind: 'page',
       revision: 2,
       offset: 0,
-      overrides: [pricing(decomposed), pricing(composed)],
+      entries: [customPricingEntry(decomposed), customPricingEntry(composed)],
       nextOffset: null,
     });
     assert.equal(page.kind, 'page');
     if (page.kind !== 'page') throw new Error('Expected a pricing page');
     assert.deepEqual(
-      page.overrides.map((item) => item.modelKey),
+      page.entries.map((item) => item.pricing.modelKey),
       [decomposed, composed],
     );
-    assert.notEqual(page.overrides[0]?.modelKey, page.overrides[1]?.modelKey);
+    assert.notEqual(page.entries[0]?.pricing.modelKey, page.entries[1]?.pricing.modelKey);
     assert.throws(
       () =>
         encodePricingQueryResult({
           kind: 'page',
           revision: 2,
           offset: 0,
-          overrides: [pricing(composed), pricing(decomposed)],
+          entries: [customPricingEntry(composed), customPricingEntry(decomposed)],
           nextOffset: null,
         }),
       invalidFrame,
@@ -536,20 +555,20 @@ describe('Usage/Pricing protocol', () => {
   });
 
   test('bounds a page of maximum-length CJK pricing items below the frame limit', () => {
-    const cjkOverrides = Array.from({ length: PRICING_PAGE_MAX_ITEMS }, (_, index) =>
-      maximumCjkPricing(index),
-    ).sort((left, right) => comparePricingModelKeys(left.modelKey, right.modelKey));
+    const cjkEntries = Array.from({ length: PRICING_PAGE_MAX_ITEMS }, (_, index) =>
+      customPricingConfigEntry(maximumCjkPricing(index)),
+    ).sort((left, right) => comparePricingModelKeys(left.pricing.modelKey, right.pricing.modelKey));
     const maximumPage = encodePricingQueryResult({
       kind: 'page',
       revision: Number.MAX_SAFE_INTEGER,
       offset: 0,
-      overrides: cjkOverrides.slice(0, 86),
-      nextOffset: 86,
+      entries: cjkEntries.slice(0, 77),
+      nextOffset: 77,
     });
     assert.equal(maximumPage.kind, 'page');
     if (maximumPage.kind !== 'page') throw new Error('Expected a pricing page');
-    assert.equal(maximumPage.overrides[0]?.modelKey.length, PRICING_MODEL_KEY_MAX_CHARS);
-    assert.ok(Buffer.byteLength(maximumPage.overrides[0]!.modelKey, 'utf8') > 128);
+    assert.equal(maximumPage.entries[0]?.pricing.modelKey.length, PRICING_MODEL_KEY_MAX_CHARS);
+    assert.ok(Buffer.byteLength(maximumPage.entries[0]!.pricing.modelKey, 'utf8') > 128);
     const pageBytes = Buffer.byteLength(JSON.stringify(maximumPage), 'utf8');
     assert.ok(pageBytes <= PRICING_PAGE_MAX_BYTES);
     assert.ok(
@@ -566,8 +585,8 @@ describe('Usage/Pricing protocol', () => {
           kind: 'page',
           revision: Number.MAX_SAFE_INTEGER,
           offset: 0,
-          overrides: cjkOverrides.slice(0, 87),
-          nextOffset: 87,
+          entries: cjkEntries.slice(0, 78),
+          nextOffset: 78,
         }),
       invalidFrame,
     );
@@ -792,6 +811,24 @@ function assertDistinctBoundedIdentities(values: readonly (string | undefined)[]
 
 function pricing(modelKey: string) {
   return { modelKey, inputUsdPer1M: 1, outputUsdPer1M: 2 };
+}
+
+function customPricingEntry(
+  modelKey: string,
+  resetEffect: 'restore_builtin' | 'become_unpriced' = 'become_unpriced',
+): EffectivePricingEntry {
+  return customPricingConfigEntry(pricing(modelKey), resetEffect);
+}
+
+function customPricingConfigEntry(
+  config: PricingConfig,
+  resetEffect: 'restore_builtin' | 'become_unpriced' = 'become_unpriced',
+): EffectivePricingEntry {
+  return {
+    pricing: config,
+    source: 'custom',
+    resetEffect,
+  };
 }
 
 function maximumCjkPricing(index: number) {

--- a/packages/runtime-host/src/__tests__/usage-pricing-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-two-client-uds.test.ts
@@ -290,6 +290,62 @@ test('pricing root identity failure requests drain while expected failures do no
   });
 });
 
+test('pricing query rejects continue offsets at and past the effective catalog end', async () => {
+  await withUsageAuthority('pricing-offset', async ({ stores }) => {
+    const coordinator = new HostUsagePricingCoordinator(
+      stores,
+      () => {},
+      new RuntimePolicyActivationGate(),
+    );
+    const entryCount = builtinPricingEntries().length;
+    assert.ok(entryCount > 0, 'the Runtime must expose at least one built-in price');
+
+    for (const offset of [entryCount, entryCount + 1]) {
+      assert.deepEqual(
+        await coordinator.handlers['pricing.query'](
+          { kind: 'continue', revision: 0, offset },
+          CONNECTION_CONTEXT,
+        ),
+        {
+          ok: false,
+          error: { code: 'invalid_request', message: 'Pricing offset is invalid' },
+        },
+      );
+    }
+  });
+});
+
+test('deleting absent pricing overrides is unchanged and preserves revision', async () => {
+  await withUsageAuthority('pricing-delete-absent', async ({ stores }) => {
+    let invalidations = 0;
+    const coordinator = new HostUsagePricingCoordinator(
+      stores,
+      () => {
+        invalidations += 1;
+      },
+      new RuntimePolicyActivationGate(),
+    );
+    const builtin = BUILTIN_PRICING[0];
+    assert.ok(builtin, 'the Runtime must expose at least one built-in price');
+
+    for (const modelKey of ['provider:missing', builtin.modelKey]) {
+      assert.deepEqual(
+        await coordinator.handlers['pricing.mutate'](
+          {
+            expectedRevision: 0,
+            mutation: { kind: 'delete', modelKey },
+          },
+          CONNECTION_CONTEXT,
+        ),
+        { ok: true, result: { kind: 'unchanged', revision: 0 } },
+      );
+    }
+
+    assert.deepEqual(await stores.pricing.snapshot(), { revision: 0, overrides: [] });
+    assert.equal(invalidations, 0);
+  });
+});
+
 test('pricing query projects built-in and custom authority with reset effects', async () => {
   await withUsageAuthority('effective-pricing', async ({ stores }) => {
     const coordinator = new HostUsagePricingCoordinator(
@@ -618,6 +674,7 @@ describe('production Usage/Pricing UDS', () => {
       ]);
       assert.deepEqual(pricingFromSecondClient, pricingAfterRestart);
       assert.equal(pricingAfterRestart.revision, 129);
+      assert.deepEqual(pricingAfterRestart.entries, fullDesktopPricing.entries);
       assert.equal(pricingAfterRestart.entries.length, builtinPricingEntries().length + 128);
       assert.ok(pricingAfterRestart.pageCount > 1);
       assert.equal(usageAfterRestart.summary.kind, 'summary');

--- a/packages/runtime-host/src/__tests__/usage-pricing-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-two-client-uds.test.ts
@@ -3,8 +3,12 @@ import { lstat, mkdtemp, rename, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { PRICING_MODEL_KEY_MAX_CHARS } from '@maka/core/usage-stats/pricing';
+import {
+  comparePricingModelKeys,
+  PRICING_MODEL_KEY_MAX_CHARS,
+} from '@maka/core/usage-stats/pricing';
 import type { PricingConfig } from '@maka/core/usage-stats/types';
+import { BUILTIN_PRICING } from '@maka/runtime';
 import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
 import {
   createHeadlessRootLease,
@@ -19,6 +23,7 @@ import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.
 import {
   RUNTIME_HOST_PROTOCOL_VERSION,
   type ClientSurface,
+  type EffectivePricingEntry,
   type PricingQueryResult,
 } from '../protocol/index.js';
 import { createExecutionRuntimeHostComposition } from '../server/execution-composition.js';
@@ -285,6 +290,85 @@ test('pricing root identity failure requests drain while expected failures do no
   });
 });
 
+test('pricing query projects built-in and custom authority with reset effects', async () => {
+  await withUsageAuthority('effective-pricing', async ({ stores }) => {
+    const coordinator = new HostUsagePricingCoordinator(
+      stores,
+      () => {},
+      new RuntimePolicyActivationGate(),
+    );
+    const builtin = BUILTIN_PRICING[0];
+    assert.ok(builtin, 'the Runtime must expose at least one built-in price');
+
+    const initial = await readCoordinatorPricing(coordinator);
+    assert.deepEqual(initial.entries, builtinPricingEntries());
+
+    assert.deepEqual(
+      await coordinator.handlers['pricing.mutate'](
+        {
+          expectedRevision: 0,
+          mutation: { kind: 'upsert', pricing: builtin },
+        },
+        CONNECTION_CONTEXT,
+      ),
+      { ok: true, result: { kind: 'committed', revision: 1 } },
+    );
+    const customOnly = pricing('acme:custom-only', 0.8);
+    assert.deepEqual(
+      await coordinator.handlers['pricing.mutate'](
+        {
+          expectedRevision: 1,
+          mutation: { kind: 'upsert', pricing: customOnly },
+        },
+        CONNECTION_CONTEXT,
+      ),
+      { ok: true, result: { kind: 'committed', revision: 2 } },
+    );
+
+    const customized = await readCoordinatorPricing(coordinator);
+    assert.deepEqual(
+      customized.entries.find((entry) => entry.pricing.modelKey === builtin.modelKey),
+      { pricing: builtin, source: 'custom', resetEffect: 'restore_builtin' },
+    );
+    assert.deepEqual(
+      customized.entries.find((entry) => entry.pricing.modelKey === customOnly.modelKey),
+      { pricing: customOnly, source: 'custom', resetEffect: 'become_unpriced' },
+    );
+
+    assert.deepEqual(
+      await coordinator.handlers['pricing.mutate'](
+        {
+          expectedRevision: 2,
+          mutation: { kind: 'delete', modelKey: builtin.modelKey },
+        },
+        CONNECTION_CONTEXT,
+      ),
+      { ok: true, result: { kind: 'committed', revision: 3 } },
+    );
+    const reset = await readCoordinatorPricing(coordinator);
+    assert.deepEqual(
+      reset.entries.find((entry) => entry.pricing.modelKey === builtin.modelKey),
+      { pricing: builtin, source: 'builtin' },
+    );
+
+    assert.deepEqual(
+      await coordinator.handlers['pricing.mutate'](
+        {
+          expectedRevision: 3,
+          mutation: { kind: 'delete', modelKey: customOnly.modelKey },
+        },
+        CONNECTION_CONTEXT,
+      ),
+      { ok: true, result: { kind: 'committed', revision: 4 } },
+    );
+    const deleted = await readCoordinatorPricing(coordinator);
+    assert.equal(
+      deleted.entries.some((entry) => entry.pricing.modelKey === customOnly.modelKey),
+      false,
+    );
+  });
+});
+
 describe('production Usage/Pricing UDS', () => {
   test('two clients share usage projection and one revision-CAS pricing authority', {
     skip: process.platform === 'win32',
@@ -369,7 +453,7 @@ describe('production Usage/Pricing UDS', () => {
         kind: 'page',
         revision: 0,
         offset: 0,
-        overrides: [],
+        entries: builtinPricingEntries(),
         nextOffset: null,
       });
       const decomposedModelKey = 'e\u0301';
@@ -431,11 +515,16 @@ describe('production Usage/Pricing UDS', () => {
       ]);
       assert.deepEqual(tuiPricing, desktopPricing);
       assert.equal(desktopPricing.revision, 2);
+      const customEntries = desktopPricing.entries.filter(
+        (entry): entry is Extract<EffectivePricingEntry, { source: 'custom' }> =>
+          entry.source === 'custom',
+      );
       assert.deepEqual(
-        desktopPricing.overrides.map((item) => item.modelKey),
+        customEntries.map((entry) => entry.pricing.modelKey),
         [decomposedModelKey, composedModelKey],
       );
-      assert.notEqual(desktopPricing.overrides[0]?.modelKey, desktopPricing.overrides[1]?.modelKey);
+      assert.ok(customEntries.every((entry) => entry.resetEffect === 'become_unpriced'));
+      assert.notEqual(customEntries[0]?.pricing.modelKey, customEntries[1]?.pricing.modelKey);
 
       let revision = desktopPricing.revision;
       for (let index = 0; index < 126; index += 1) {
@@ -494,11 +583,11 @@ describe('production Usage/Pricing UDS', () => {
       ]);
       assert.deepEqual(fullTuiPricing, fullDesktopPricing);
       assert.equal(fullDesktopPricing.revision, 129);
-      assert.equal(fullDesktopPricing.overrides.length, 128);
+      assert.equal(fullDesktopPricing.entries.length, builtinPricingEntries().length + 128);
       assert.ok(fullDesktopPricing.pageCount > 1);
       assert.equal(
-        fullDesktopPricing.overrides.filter(
-          (item) => item.modelKey.length === PRICING_MODEL_KEY_MAX_CHARS,
+        fullDesktopPricing.entries.filter(
+          (entry) => entry.pricing.modelKey.length === PRICING_MODEL_KEY_MAX_CHARS,
         ).length,
         126,
       );
@@ -529,7 +618,7 @@ describe('production Usage/Pricing UDS', () => {
       ]);
       assert.deepEqual(pricingFromSecondClient, pricingAfterRestart);
       assert.equal(pricingAfterRestart.revision, 129);
-      assert.equal(pricingAfterRestart.overrides.length, 128);
+      assert.equal(pricingAfterRestart.entries.length, builtinPricingEntries().length + 128);
       assert.ok(pricingAfterRestart.pageCount > 1);
       assert.equal(usageAfterRestart.summary.kind, 'summary');
       if (usageAfterRestart.summary.kind === 'summary') {
@@ -609,13 +698,13 @@ async function readUsage(client: RuntimeHostConnection) {
 
 async function readPricing(client: RuntimeHostConnection): Promise<{
   revision: number;
-  overrides: readonly Readonly<PricingConfig>[];
+  entries: readonly EffectivePricingEntry[];
   pageCount: number;
 }> {
   const first = requirePricingPage(
     await client.request('pricing.query', { kind: 'start' }, REQUEST_TIMEOUT_MS),
   );
-  const overrides = [...first.overrides];
+  const entries = [...first.entries];
   let nextOffset = first.nextOffset;
   let pageCount = 1;
   while (nextOffset !== null) {
@@ -628,11 +717,29 @@ async function readPricing(client: RuntimeHostConnection): Promise<{
     );
     assert.equal(page.revision, first.revision);
     assert.equal(page.offset, nextOffset);
-    overrides.push(...page.overrides);
+    entries.push(...page.entries);
     nextOffset = page.nextOffset;
     pageCount += 1;
   }
-  return { revision: first.revision, overrides, pageCount };
+  return { revision: first.revision, entries, pageCount };
+}
+
+async function readCoordinatorPricing(
+  coordinator: HostUsagePricingCoordinator,
+): Promise<Extract<PricingQueryResult, { kind: 'page' }>> {
+  const outcome = await coordinator.handlers['pricing.query'](
+    { kind: 'start' },
+    CONNECTION_CONTEXT,
+  );
+  assert.equal(outcome.ok, true);
+  if (!outcome.ok) throw new Error('Expected an effective pricing page');
+  return requirePricingPage(outcome.result);
+}
+
+function builtinPricingEntries(): readonly EffectivePricingEntry[] {
+  return [...BUILTIN_PRICING]
+    .sort((left, right) => comparePricingModelKeys(left.modelKey, right.modelKey))
+    .map((pricing) => ({ pricing, source: 'builtin' }));
 }
 
 function requirePricingPage(

--- a/packages/runtime-host/src/protocol/usage-pricing.ts
+++ b/packages/runtime-host/src/protocol/usage-pricing.ts
@@ -239,12 +239,27 @@ export type PricingQueryInput =
   | { readonly kind: 'start' }
   | { readonly kind: 'continue'; readonly revision: number; readonly offset: number };
 
+/**
+ * Effective for one Host epoch: `revision` pins persisted overrides, while the
+ * bundled table is fixed by the running Host build.
+ */
+export type EffectivePricingEntry =
+  | {
+      readonly pricing: Readonly<PricingConfig>;
+      readonly source: 'builtin';
+    }
+  | {
+      readonly pricing: Readonly<PricingConfig>;
+      readonly source: 'custom';
+      readonly resetEffect: 'restore_builtin' | 'become_unpriced';
+    };
+
 export type PricingQueryResult =
   | {
       readonly kind: 'page';
       readonly revision: number;
       readonly offset: number;
-      readonly overrides: readonly Readonly<PricingConfig>[];
+      readonly entries: readonly EffectivePricingEntry[];
       readonly nextOffset: number | null;
     }
   | {
@@ -459,33 +474,34 @@ export function decodePricingQueryResult(value: unknown): PricingQueryResult {
     'kind',
     'revision',
     'offset',
-    'overrides',
+    'entries',
     'nextOffset',
   ]);
-  if (!Array.isArray(exact.overrides) || exact.overrides.length > PRICING_PAGE_MAX_ITEMS) {
-    throw invalidProtocolFrame('Pricing overrides exceed item limit');
+  if (!Array.isArray(exact.entries) || exact.entries.length > PRICING_PAGE_MAX_ITEMS) {
+    throw invalidProtocolFrame('Pricing entries exceed item limit');
   }
-  const overrides = exact.overrides.map(decodePricingConfig);
+  const entries = exact.entries.map(decodeEffectivePricingEntry);
   if (
-    overrides.some(
+    entries.some(
       (item, index) =>
-        index > 0 && comparePricingModelKeys(overrides[index - 1]!.modelKey, item.modelKey) >= 0,
+        index > 0 &&
+        comparePricingModelKeys(entries[index - 1]!.pricing.modelKey, item.pricing.modelKey) >= 0,
     )
   ) {
-    throw invalidProtocolFrame('Pricing overrides are not canonically ordered');
+    throw invalidProtocolFrame('Pricing entries are not canonically ordered');
   }
   const offset = requireCount(exact.offset, 'pricing offset');
   const nextOffset =
     exact.nextOffset === null ? null : requireCount(exact.nextOffset, 'pricing next offset');
-  const advancedOffset = offset + overrides.length;
-  if (nextOffset !== null && (overrides.length === 0 || nextOffset !== advancedOffset)) {
+  const advancedOffset = offset + entries.length;
+  if (nextOffset !== null && (entries.length === 0 || nextOffset !== advancedOffset)) {
     throw invalidProtocolFrame('Pricing page does not make canonical progress');
   }
   const decoded: PricingQueryResult = {
     kind: 'page',
     revision: requireCount(exact.revision, 'pricing revision'),
     offset,
-    overrides,
+    entries,
     nextOffset,
   };
   assertJsonBytes(decoded, PRICING_PAGE_MAX_BYTES, 'Pricing page');
@@ -493,6 +509,30 @@ export function decodePricingQueryResult(value: unknown): PricingQueryResult {
 }
 
 export const encodePricingQueryResult = decodePricingQueryResult;
+
+function decodeEffectivePricingEntry(value: unknown): EffectivePricingEntry {
+  const entry = requireRecord(value, 'effective pricing entry');
+  if (entry.source === 'builtin') {
+    const exact = requireExactRecord(entry, 'built-in pricing entry', ['pricing', 'source']);
+    return { pricing: decodePricingConfig(exact.pricing), source: 'builtin' };
+  }
+  if (entry.source === 'custom') {
+    const exact = requireExactRecord(entry, 'custom pricing entry', [
+      'pricing',
+      'source',
+      'resetEffect',
+    ]);
+    if (exact.resetEffect !== 'restore_builtin' && exact.resetEffect !== 'become_unpriced') {
+      throw invalidProtocolFrame('Invalid custom pricing reset effect');
+    }
+    return {
+      pricing: decodePricingConfig(exact.pricing),
+      source: 'custom',
+      resetEffect: exact.resetEffect,
+    };
+  }
+  throw invalidProtocolFrame('Invalid effective pricing source');
+}
 
 export function decodePricingMutateInput(value: unknown): PricingMutateInput {
   const input = requireExactRecord(value, 'pricing mutation input', [

--- a/packages/runtime-host/src/server/usage-pricing-coordinator.ts
+++ b/packages/runtime-host/src/server/usage-pricing-coordinator.ts
@@ -6,6 +6,7 @@ import type {
   UsageLogRow,
   UsageQuery,
 } from '@maka/core/usage-stats/types';
+import { comparePricingModelKeys } from '@maka/core/usage-stats/pricing';
 import { resolveUsageRange } from '@maka/core/model-call-usage-projection';
 import {
   mergeUsageBuckets,
@@ -15,6 +16,7 @@ import {
   type UsageProvenance,
 } from '@maka/core/usage-ledger-merge';
 import { repairPendingModelCallProjections } from '@maka/storage/model-call-ledger';
+import { BUILTIN_PRICING } from '@maka/runtime';
 import {
   authenticateInteractiveUsageStoresWriter,
   classifyInteractiveUsageStoresFailure,
@@ -30,6 +32,7 @@ import {
   USAGE_PAGE_MAX_ITEMS,
   USAGE_PROJECTION_TEXT_MAX_BYTES,
   type OperationOutcome,
+  type EffectivePricingEntry,
   type PricingMutateInput,
   type PricingQueryInput,
   type PricingQueryResult,
@@ -209,11 +212,9 @@ export class HostUsagePricingCoordinator {
           }),
         };
       }
+      const entries = projectEffectivePricingEntries(snapshot.overrides);
       const offset = input.kind === 'start' ? 0 : input.offset;
-      if (
-        offset > snapshot.overrides.length ||
-        (input.kind === 'continue' && offset === snapshot.overrides.length)
-      ) {
+      if (offset > entries.length || (input.kind === 'continue' && offset === entries.length)) {
         return {
           ok: false,
           error: { code: 'invalid_request', message: 'Pricing offset is invalid' },
@@ -221,7 +222,7 @@ export class HostUsagePricingCoordinator {
       }
       return {
         ok: true,
-        result: createPricingPage(snapshot.revision, snapshot.overrides, offset),
+        result: createPricingPage(snapshot.revision, entries, offset),
       };
     } catch (error) {
       return this.#mapReadFailure<'pricing.query'>(error, 'Pricing authority');
@@ -383,13 +384,13 @@ function invalidUsageOffset(): OperationOutcome<'usage.query'> {
 
 function createPricingPage(
   revision: number,
-  overrides: readonly Readonly<PricingConfig>[],
+  entries: readonly EffectivePricingEntry[],
   offset: number,
 ): PricingQueryResult {
-  const items: Readonly<PricingConfig>[] = [];
-  for (let index = offset; index < overrides.length; index += 1) {
+  const items: EffectivePricingEntry[] = [];
+  for (let index = offset; index < entries.length; index += 1) {
     if (items.length >= PRICING_PAGE_MAX_ITEMS) break;
-    const item = overrides[index];
+    const item = entries[index];
     if (!item) break;
     const candidate = [...items, item];
     const nextOffset = offset + candidate.length;
@@ -397,12 +398,12 @@ function createPricingPage(
       kind: 'page',
       revision,
       offset,
-      overrides: candidate,
-      nextOffset: nextOffset < overrides.length ? nextOffset : null,
+      entries: candidate,
+      nextOffset: nextOffset < entries.length ? nextOffset : null,
     };
     if (jsonBytes(page) > PRICING_PAGE_MAX_BYTES) {
       if (items.length === 0) {
-        throw new Error('Canonical pricing override exceeds the wire page limit');
+        throw new Error('Canonical pricing entry exceeds the wire page limit');
       }
       break;
     }
@@ -413,8 +414,28 @@ function createPricingPage(
     kind: 'page',
     revision,
     offset,
-    overrides: items,
-    nextOffset: nextOffset < overrides.length ? nextOffset : null,
+    entries: items,
+    nextOffset: nextOffset < entries.length ? nextOffset : null,
+  });
+}
+
+function projectEffectivePricingEntries(
+  overrides: readonly Readonly<PricingConfig>[],
+): readonly EffectivePricingEntry[] {
+  const builtinsByKey = new Map(BUILTIN_PRICING.map((pricing) => [pricing.modelKey, pricing]));
+  const overridesByKey = new Map(overrides.map((pricing) => [pricing.modelKey, pricing]));
+  const modelKeys = new Set([...builtinsByKey.keys(), ...overridesByKey.keys()]);
+
+  return [...modelKeys].sort(comparePricingModelKeys).map((modelKey) => {
+    const override = overridesByKey.get(modelKey);
+    if (override) {
+      return {
+        pricing: override,
+        source: 'custom',
+        resetEffect: builtinsByKey.has(modelKey) ? 'restore_builtin' : 'become_unpriced',
+      };
+    }
+    return { pricing: builtinsByKey.get(modelKey)!, source: 'builtin' };
   });
 }
 


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Evolve `pricing.query` from override-only pages into a revision-consistent effective pricing projection.
- Combine the Runtime's bundled table with persisted overrides in the Host, preserving canonical model-key ordering and existing page bounds.
- Mark each row as Built-in or Custom, and make a Custom row's reset result explicit as `restore_builtin` or `become_unpriced`.
- Cover exact wire decoding, equal-value override provenance, reset/delete behavior, multi-page revision changes, two-client CAS, and Host restart.

## Why

The existing query exposed only persisted overrides. A future Desktop adapter would otherwise need to copy the bundled pricing table and infer what deleting an override means, creating a second pricing read model outside the Host.

This keeps effective-value composition and provenance behind the existing Host interface, so clients only assemble and present authoritative pages.

## Contract

- `revision` continues to pin the persisted override snapshot; the bundled table is fixed for the running Host build and Host epoch.
- An override remains Custom even when its values equal the bundled row.
- Pagination remains exact-string ordered, item- and byte-bounded, and rejects mixed revisions.
- The v0 `pricing.query` page replaces `overrides` with `entries`; there is no production consumer of the old response.
- This slice does not add the #2010 Desktop adapter, activate a production Host path, or perform the #853 M5 cutover.

## Validation

- `npm run build:test`
- `npm --workspace @maka/runtime-host run test:dist` — 629 passed
- `npm run lint`
- `npm run format:check`
- `git diff --check origin/main...HEAD`

Part of #2015.

</details>

<details>
<summary><strong>中文</strong></summary>

## 概要

- 将 `pricing.query` 从只返回 override 的分页，演进为 revision 一致的生效价格 projection。
- 在 Host 内合并 Runtime 内置价格表与持久化 override，并保持规范 model-key 顺序和现有分页边界。
- 将每一行标记为 Built-in 或 Custom，并明确 Custom 行删除后的结果是 `restore_builtin` 或 `become_unpriced`。
- 覆盖严格 wire 解码、同值 override 的来源语义、reset/delete、多页 revision 变化、双 Client CAS 与 Host 重启。

## 背景

现有 query 只暴露持久化 overrides。未来 Desktop adapter 若直接消费它，就必须复制内置价格表并自行推断删除 override 的后果，从而在 Host 外形成第二套 Pricing read model。

本次将生效价格合成与来源判断保留在现有 Host interface 后面，Client 只负责组装并展示权威分页。

## 契约

- `revision` 继续固定持久化 override snapshot；内置表由当前 Host build 与 Host epoch 固定。
- 即使 override 数值与内置行相同，它仍然属于 Custom。
- 分页继续使用精确字符串顺序，受 item/byte 边界限制，并拒绝混合 revision。
- v0 `pricing.query` 分页以 `entries` 替换 `overrides`；旧响应当前没有生产消费者。
- 本 slice 不增加 #2010 Desktop adapter，不激活生产 Host 路径，也不执行 #853 M5 cutover。

## 验证

- `npm run build:test`
- `npm --workspace @maka/runtime-host run test:dist` — 629 项通过
- `npm run lint`
- `npm run format:check`
- `git diff --check origin/main...HEAD`

属于 #2015 的一部分。

</details>
