### PR TITLE
chore(headless): raise the harness A/B pair-concurrency cap to 16

### DIFF
--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -89,7 +89,9 @@ const execFileAsync = promisify(execFile);
 
 export const DEFAULT_HARNESS_AB_RUN_ID = 'k3-maka-vs-kimi-code-tbench-2.1-full-v2';
 const CANARY_TASKS = 5;
-const MAX_PAIR_CONCURRENCY = 4;
+// Bounds host load only: every cell is an independent Harbor run, so pair
+// concurrency never enters scoring or resume identity beyond the manifest.
+const MAX_PAIR_CONCURRENCY = 16;
 const DEFAULT_PAIR_CONCURRENCY = 1;
 const DEFAULT_ARM_EXECUTION = 'sequential';
 const KIMI_CODING_PLAN_PRICING = Object.freeze({

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -98,8 +98,8 @@ test('harness A/B uses one safe execution default and accepts per-run overrides'
     armExecution: 'sequential',
   });
   assert.throws(
-    () => resolveHarnessAbExecutionPolicy('5', undefined, 30),
-    /MAKA_HARNESS_AB_PAIR_CONCURRENCY must be an integer between 1 and 4/,
+    () => resolveHarnessAbExecutionPolicy('17', undefined, 30),
+    /MAKA_HARNESS_AB_PAIR_CONCURRENCY must be an integer between 1 and 16/,
   );
   assert.throws(
     () => resolveHarnessAbExecutionPolicy(undefined, 'together', 30),
@@ -283,10 +283,6 @@ test('harness A/B records its configured execution policy in the manifest', asyn
   assert.equal(selection.limit, 89);
   assert.equal(manifest.maxConcurrency, 2);
   assert.equal(manifest.maxConcurrentAttempts, 4);
-  assert.throws(
-    () => resolveHarnessAbExecutionPolicy('5', undefined, selection.taskIds.length),
-    /MAKA_HARNESS_AB_PAIR_CONCURRENCY must be an integer between 1 and 4/,
-  );
 });
 
 test('harness Oracle environment selects the linux/amd64 image manifest digest', async () => {


### PR DESCRIPTION
## Summary

The harness A/B scheduler capped `MAKA_HARNESS_AB_PAIR_CONCURRENCY` at 4 — a bare constant with no comment and a default of 1, which reads as a guardrail sized for a laptop rather than a correctness invariant. Concurrency does not enter scoring: each cell is an independent `harbor run` with its own provider proxy port, and Pass@1 is adjudicated per cell.

That cap was the binding constraint on a server-class benchmark host. Measured on the 32-core box running the three-arm Terminal-Bench 2.1 comparison, cells spend a **median 97% of their wall clock blocked on provider inference** (per-cell `provider-request-telemetry.json` request duration over cell wall time, n=27). At the old maximum — 4 pairs, i.e. 12 in-flight cells across three arms — `sar` showed the host at **18% CPU, 5 GiB of 61 GiB, run queue 0–1**. The scheduler was idling the machine while waiting on sockets.

This raises the cap to 16. The default stays 1, so any run that does not explicitly opt in is unchanged.

Refs #1970.

## Verification

- `node --test packages/headless/dist/__tests__/harness-ab-cli.test.js` — 40/40 pass
- `npx biome format` / `npx biome lint` on both changed files — clean
- Exercised end to end at `MAKA_HARNESS_AB_PAIR_CONCURRENCY=16` (48 in-flight cells) on the #1970 benchmark host: 41 containers, load 10.3/32 cores, 17 GiB used, first 13 cells all `completed` across all three arms with zero infra failures.

Not run: the full workspace suite.

## Review focus

Raising the cap alone is not sufficient to run at 48 in-flight cells. Docker's default address pool (`172.16.0.0/12` at /16 plus `192.168.0.0/16` at /20) yields roughly 31 user-defined networks, and every `docker compose up` allocates one. Past that, Compose fails with `all predefined address pools have been fully subnetted` and every cell lands as `infra_failed`. Hosts that opt into a high pair concurrency need `default-address-pools` widened in `/etc/docker/daemon.json`.

That is host configuration rather than harness code, so it is deliberately not in this diff — but anyone raising the knob will hit it immediately, and the failure mode is opaque enough to be worth naming here.
