### PR TITLE
fix(runtime): land the terminal fact a stop claims, and stop dropping non-terminal prior runs

### DIFF
--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -36,6 +36,7 @@ import {
 } from '../terminal-run-commit.js';
 import { RuntimeReadModel } from '../runtime-read-model.js';
 import { RuntimeKernel } from '../runtime-kernel.js';
+import type { RuntimeInteractionAuthority } from '../interaction-authority.js';
 
 describe('SessionManager terminal ledger invariants', () => {
   test('error streams persist a failed terminal fact without non-terminal error ledger rows', async () => {
@@ -187,6 +188,38 @@ describe('SessionManager terminal ledger invariants', () => {
       isTerminalRuntimeEvent,
     );
     expect(terminalEvents).toHaveLength(1);
+  });
+
+  test('a hosted stop leaves the terminal fact to the Host', async () => {
+    const store = new TinySessionStore();
+    const runStore = new TinyAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new NeverEndingBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(21_700),
+      runtimeSource: 'test',
+      interactionAuthority: hostedInteractionAuthority(),
+      canonicalPermissionOutcomes: { readPermissionOutcome: async () => undefined },
+    });
+    const session = await manager.createSession(makeInput());
+
+    const iterator = manager
+      .sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })
+      [Symbol.asyncIterator]();
+    expect((await iterator.next()).value?.type).toBe('text_delta');
+    await manager.stopSession(session.id, { source: 'stop_button' });
+
+    const [run] = await runStore.listSessionRuns(session.id);
+    if (!run) throw new Error('run was not recorded');
+    const terminalEvents = (await runStore.readRuntimeEvents(session.id, run.runId)).filter(
+      isTerminalRuntimeEvent,
+    );
+    expect(terminalEvents).toHaveLength(0);
   });
 
   test('terminal acceptance wins over a later stop during terminal persistence', async () => {
@@ -952,6 +985,69 @@ describe('SessionManager terminal ledger invariants', () => {
       isTerminalRuntimeEvent,
     );
     expect(terminalEvents).toHaveLength(1);
+  });
+
+  test('a stop settlement leaves an already sealed ledger untouched', async () => {
+    const store = new TinySessionStore();
+    const runStore = new TinyAgentRunStore();
+    const session = await store.create(makeInput());
+    const backend = new ScriptBackend({ sessionId: session.id } as BackendFactoryContext, []);
+    const activeRuns = new Map<string, AgentRun>();
+    const turnToRunId = new Map<string, string>();
+    const run = new AgentRun({
+      sessionId: session.id,
+      header: session,
+      userInput: { turnId: 'turn-1', text: 'hello' },
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      newId: nextId(),
+      now: nextNow(41_700),
+      hooks: {
+        reserveRun: async (_sessionId, _header, activeRun) => {
+          activeRuns.set(activeRun.runId, activeRun);
+          turnToRunId.set(activeRun.turnId, activeRun.runId);
+          return {
+            sessionId: session.id,
+            backend,
+            cachedHeader: session,
+            activeRuns,
+            turnToRunId,
+          };
+        },
+        unregisterRun: (_active, activeRun) => {
+          activeRuns.delete(activeRun.runId);
+          turnToRunId.delete(activeRun.turnId);
+        },
+        updateHeader: (sessionId, patch) => store.updateHeader(sessionId, patch),
+        updateStatus: async () => {},
+        appendTurnState: async () => {},
+      },
+    });
+    await run.begin();
+    run.stop('stop_button');
+    // Another owner — a Host recovery, a resumed continuation — sealed the run
+    // before this stop got to settle it.
+    await runStore.appendRuntimeEvent(
+      session.id,
+      run.runId,
+      runtimeEvent({
+        id: 'rt-foreign-terminal',
+        sessionId: session.id,
+        runId: run.runId,
+        turnId: run.turnId,
+        status: 'aborted',
+        actions: { endInvocation: true },
+      }),
+    );
+
+    await run.settleStopTerminal();
+
+    const terminalEvents = (await runStore.readRuntimeEvents(session.id, run.runId)).filter(
+      isTerminalRuntimeEvent,
+    );
+    expect(terminalEvents).toHaveLength(1);
+    expect(terminalEvents[0]?.id).toBe('rt-foreign-terminal');
   });
 
   test('direct AgentRun error events still commit failed terminal facts when failed turn projection fails', async () => {
@@ -1894,6 +1990,18 @@ function nextId(): () => string {
 function nextNow(start: number): () => number {
   let ts = start;
   return () => ++ts;
+}
+
+function hostedInteractionAuthority(): RuntimeInteractionAuthority {
+  return {
+    bindRun: (identity) => ({
+      ...identity,
+      acceptSandboxBoundaryRequest: async () => {},
+      acceptUserQuestionRequest: async () => {},
+      close: async () => {},
+      release: () => {},
+    }),
+  };
 }
 
 function inertAgentRunHooks(store: TinySessionStore) {

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -1,5 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
+import { setTimeout as timerDelay } from 'node:timers/promises';
 import { deriveTurnRecords, DurableStoreWriteError, isTerminalRuntimeEvent } from '@maka/core';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
 import type {
@@ -844,6 +845,73 @@ describe('SessionManager terminal ledger invariants', () => {
     await new RuntimeReadModel({ runStore, runtimeEventStore: runStore }).getSessionView(
       session.id,
     );
+  });
+
+  test('a stop settlement racing finalize commits exactly one terminal run event', async () => {
+    const store = new TinySessionStore();
+    const settleReachedAppend = deferred<void>();
+    const releaseTerminalAppend = deferred<void>();
+    const runStore = new TinyAgentRunStore({
+      beforeTerminalRuntimeEventAppend: async () => {
+        settleReachedAppend.resolve();
+        await releaseTerminalAppend.promise;
+      },
+    });
+    const session = await store.create(makeInput());
+    const backend = new ScriptBackend({ sessionId: session.id } as BackendFactoryContext, []);
+    const activeRuns = new Map<string, AgentRun>();
+    const turnToRunId = new Map<string, string>();
+    const run = new AgentRun({
+      sessionId: session.id,
+      header: session,
+      userInput: { turnId: 'turn-1', text: 'hello' },
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      newId: nextId(),
+      now: nextNow(41_500),
+      hooks: {
+        reserveRun: async (_sessionId, _header, activeRun) => {
+          activeRuns.set(activeRun.runId, activeRun);
+          turnToRunId.set(activeRun.turnId, activeRun.runId);
+          return {
+            sessionId: session.id,
+            backend,
+            cachedHeader: session,
+            activeRuns,
+            turnToRunId,
+          };
+        },
+        unregisterRun: (_active, activeRun) => {
+          activeRuns.delete(activeRun.runId);
+          turnToRunId.delete(activeRun.turnId);
+        },
+        updateHeader: (sessionId, patch) => store.updateHeader(sessionId, patch),
+        updateStatus: async () => {},
+        appendTurnState: async () => {},
+      },
+    });
+
+    await run.begin();
+    run.stop('stop_button');
+    // The stop settles the claim while the backend stream is still unwinding,
+    // so both settlement paths queue behind the same in-flight terminal write.
+    const settled = run.settleStopTerminal();
+    await settleReachedAppend.promise;
+    await timerDelay(0);
+    const finalized = run.finalize();
+    await timerDelay(0);
+    releaseTerminalAppend.resolve();
+    await Promise.all([settled, finalized]);
+
+    const runEvents = (await runStore.readEvents(session.id, run.runId)).filter(
+      (event) => event.type === 'run_cancelled',
+    );
+    expect(runEvents).toHaveLength(1);
+    const terminalEvents = (await runStore.readRuntimeEvents(session.id, run.runId)).filter(
+      isTerminalRuntimeEvent,
+    );
+    expect(terminalEvents).toHaveLength(1);
   });
 
   test('direct AgentRun error events still commit failed terminal facts when failed turn projection fails', async () => {

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -114,6 +114,40 @@ describe('SessionManager terminal ledger invariants', () => {
     expect(terminalEvents[0]?.actions?.stateDelta?.abortSource).toBe('renderer.stop_button');
   });
 
+  test('stopSession commits a terminal fact when the backend stream never ends', async () => {
+    const store = new TinySessionStore();
+    const runStore = new TinyAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new NeverEndingBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(21_000),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+
+    const iterator = manager
+      .sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })
+      [Symbol.asyncIterator]();
+    expect((await iterator.next()).value?.type).toBe('text_delta');
+    await manager.stopSession(session.id, { source: 'stop_button' });
+
+    const [run] = await runStore.listSessionRuns(session.id);
+    if (!run) throw new Error('run was not recorded');
+    expect(run.status).toBe('cancelled');
+    expect(run.abortSource).toBe('renderer.stop_button');
+    const terminalEvents = (await runStore.readRuntimeEvents(session.id, run.runId)).filter(
+      isTerminalRuntimeEvent,
+    );
+    expect(terminalEvents).toHaveLength(1);
+    expect(terminalEvents[0]?.status).toBe('aborted');
+    expect(terminalEvents[0]?.actions?.stateDelta?.abortSource).toBe('renderer.stop_button');
+  });
+
   test('terminal acceptance wins over a later stop during terminal persistence', async () => {
     const terminalAppendStarted = deferred<void>();
     const releaseTerminalAppend = deferred<void>();
@@ -1435,6 +1469,36 @@ class StopDuringSendBackend implements AgentBackend {
     this.stopReturned.resolve();
   }
 
+  async respondToSandboxBoundary(_decision: SandboxBoundaryResponse): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+/**
+ * A turn parked on an unanswered interaction: `stop()` returns, but the event
+ * stream never produces another event and never ends, so nothing downstream
+ * can finalize the run.
+ */
+class NeverEndingBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(ctx: BackendFactoryContext) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'text_delta',
+      id: `${input.turnId}-text`,
+      turnId: input.turnId,
+      ts: 1,
+      messageId: 'message-1',
+      text: 'before the question',
+    };
+    await new Promise<never>(() => {});
+  }
+
+  async stop(_reason: 'user_stop' | 'redirect'): Promise<void> {}
   async respondToSandboxBoundary(_decision: SandboxBoundaryResponse): Promise<void> {}
   async dispose(): Promise<void> {}
 }

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -149,6 +149,46 @@ describe('SessionManager terminal ledger invariants', () => {
     expect(terminalEvents[0]?.actions?.stateDelta?.abortSource).toBe('renderer.stop_button');
   });
 
+  test('a stop whose terminal settlement fails stays retryable', async () => {
+    let failNextTerminalAppend = true;
+    const store = new TinySessionStore();
+    const runStore = new TinyAgentRunStore({
+      beforeTerminalRuntimeEventAppend: async () => {
+        if (!failNextTerminalAppend) return;
+        failNextTerminalAppend = false;
+        throw new Error('terminal runtime event append failed');
+      },
+    });
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new NeverEndingBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(21_500),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+
+    const iterator = manager
+      .sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })
+      [Symbol.asyncIterator]();
+    expect((await iterator.next()).value?.type).toBe('text_delta');
+
+    await assert.rejects(() => manager.stopSession(session.id, { source: 'stop_button' }));
+    await manager.stopSession(session.id, { source: 'stop_button' });
+
+    const [run] = await runStore.listSessionRuns(session.id);
+    if (!run) throw new Error('run was not recorded');
+    expect(run.status).toBe('cancelled');
+    const terminalEvents = (await runStore.readRuntimeEvents(session.id, run.runId)).filter(
+      isTerminalRuntimeEvent,
+    );
+    expect(terminalEvents).toHaveLength(1);
+  });
+
   test('terminal acceptance wins over a later stop during terminal persistence', async () => {
     const terminalAppendStarted = deferred<void>();
     const releaseTerminalAppend = deferred<void>();

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -8255,6 +8255,70 @@ describe('SessionManager permission mode updates', () => {
     );
   });
 
+  test('sendMessage replays a prior run left non-terminal by an unanswered interaction', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    let backend: TestBackend | undefined;
+    backends.register('fake', (ctx) => {
+      backend = new TestBackend(ctx);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(7_075),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    // A run parked on AskUserQuestion and then stopped: the header never left
+    // `waiting_for_user` and the ledger never received a terminal fact. Its
+    // turn is still conversation the model must see.
+    await seedRuntimeRun(
+      runStore,
+      makeRunHeader({
+        sessionId: session.id,
+        runId: 'run-1',
+        turnId: 'turn-1',
+        status: 'waiting_for_user',
+        createdAt: 100,
+        updatedAt: 102,
+      }),
+      [
+        runtimeEvent({
+          id: 'rt-user',
+          sessionId: session.id,
+          runId: 'run-1',
+          turnId: 'turn-1',
+          ts: 101,
+          role: 'user',
+          author: 'user',
+          content: { kind: 'text', text: 'prior question' },
+        }),
+        runtimeEvent({
+          id: 'rt-assistant',
+          sessionId: session.id,
+          runId: 'run-1',
+          turnId: 'turn-1',
+          ts: 102,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text: 'prior answer' },
+        }),
+      ],
+    );
+
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-2', text: 'follow up' }));
+
+    expect(backend?.sendInputs[0]?.runtimeContext?.map((event) => event.id)).toEqual([
+      'rt-user',
+      'rt-assistant',
+    ]);
+  });
+
   test('sendMessage resumes incomplete legacy backfill for prior context', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore({ failRuntimeEventAppendAfter: 1 });

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -312,7 +312,8 @@ export class AgentRun {
     // own reserved event is not foreign — that is a settlement being retried.
     const claimedEventId = this.terminalClaim.event?.id;
     const events = await this.loadTurnRuntimeEvents();
-    if (events.some((event) => isTerminalRuntimeEvent(event) && event.id !== claimedEventId)) return;
+    if (events.some((event) => isTerminalRuntimeEvent(event) && event.id !== claimedEventId))
+      return;
     const ts = this.lastTs || this.input.now();
     const finalStatus = { status: 'aborted' as const };
     this.finalStatus ??= finalStatus;

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -1410,6 +1410,12 @@ export class AgentRun {
       const terminalEvent = terminalClaim?.event;
       if (!terminalEvent) throw new Error('terminal RuntimeEvent claim is missing');
       await terminalClaim.write;
+      // Re-check after the await, not only at entry. Two callers — a stop
+      // settling the claim and the stream's own finalize — can both pass the
+      // entry guard and then queue behind the same write. The claim slot
+      // dedupes the RuntimeEvent, but the run-store projection would append a
+      // second terminal AgentRunEvent for the one run.
+      if (this.terminalRunHeaderCommitted) return;
       if (this.continuationActive) {
         await this.input.continuationFailpoint?.('after_terminal_event_committed');
       }

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -299,21 +299,37 @@ export class AgentRun {
    * produces its own terminal event finds the claim taken and writes nothing.
    */
   async settleStopTerminal(): Promise<void> {
-    if (this.terminalClaim?.owner !== 'stop' || this.terminalClaim.event) return;
-    if (!this.input.runtimeEventStore || !this.runtimeEventStoreAvailable) return;
+    if (this.terminalClaim?.owner !== 'stop' || this.terminalRunHeaderCommitted) return;
+    // Nothing durable is configured, so there is no fact to land. Every other
+    // failure below is real and must reach the stop's caller: a stop that
+    // reports success while the run stays non-terminal is the silent loss this
+    // method exists to prevent.
+    if (!this.input.runtimeEventStore || !this.input.runStore) return;
     // The claim only fences writers inside this Run. Another owner — a Host
     // recovery, a resumed continuation — may have sealed the ledger already,
     // and a sealed run rejects further appends. Nothing to land in that case:
-    // the fact this method exists to guarantee is already there.
-    const sealed = await this.loadTurnRuntimeEvents()
-      .then((events) => events.some(isTerminalRuntimeEvent))
-      .catch(() => true);
-    if (sealed) return;
+    // the fact this method exists to guarantee is already there. This claim's
+    // own reserved event is not foreign — that is a settlement being retried.
+    const claimedEventId = this.terminalClaim.event?.id;
+    const events = await this.loadTurnRuntimeEvents();
+    if (events.some((event) => isTerminalRuntimeEvent(event) && event.id !== claimedEventId)) return;
     const ts = this.lastTs || this.input.now();
     const finalStatus = { status: 'aborted' as const };
     this.finalStatus ??= finalStatus;
     this.reserveFinalizationTerminal(finalStatus, ts);
-    await this.commitTerminalRun(finalStatus, ts);
+    const runStoreAvailable = this.runStoreAvailable;
+    try {
+      await this.commitTerminalRun(finalStatus, ts);
+    } catch (error) {
+      // This commit runs ahead of the stream's own finalize, so one failure is
+      // not evidence the store is gone for the rest of the run. Undo the marks
+      // that would turn a single failed attempt into a permanently unwritable
+      // run, and let the caller decide whether to retry. The reserved event
+      // stays, so a retry lands the same terminal fact rather than a new one.
+      this.runStoreAvailable = runStoreAvailable;
+      if (this.terminalClaim) this.terminalClaim.write = undefined;
+      throw error;
+    }
   }
 
   recordRunTrace(event: RunTraceEvent): void {

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -287,6 +287,26 @@ export class AgentRun {
     if (this.terminalClaim?.owner === 'stop') this.terminalClaim.stopCompleted = true;
   }
 
+  /**
+   * Cash the terminal claim a stop already took.
+   *
+   * `stop()` claims the terminal outcome, but only `finalize()` — reached when
+   * the backend's event stream ends — has ever cashed it. A turn parked on an
+   * unanswered interaction never ends that stream, so the Session projection
+   * read as aborted while the run stayed non-terminal in the ledger forever,
+   * and every later turn dropped it from model context. Cash the claim at the
+   * stop instead. The claim keeps this idempotent: a stream that later
+   * produces its own terminal event finds the claim taken and writes nothing.
+   */
+  async settleStopTerminal(): Promise<void> {
+    if (this.terminalClaim?.owner !== 'stop' || this.terminalClaim.event) return;
+    const ts = this.lastTs || this.input.now();
+    const finalStatus = { status: 'aborted' as const };
+    this.finalStatus ??= finalStatus;
+    this.reserveFinalizationTerminal(finalStatus, ts);
+    await this.commitTerminalRun(finalStatus, ts);
+  }
+
   recordRunTrace(event: RunTraceEvent): void {
     if (!this.input.runStore || !this.runStoreAvailable) return;
     this.enqueueRunStore('append trace event', async () => {

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -300,6 +300,15 @@ export class AgentRun {
    */
   async settleStopTerminal(): Promise<void> {
     if (this.terminalClaim?.owner !== 'stop' || this.terminalClaim.event) return;
+    if (!this.input.runtimeEventStore || !this.runtimeEventStoreAvailable) return;
+    // The claim only fences writers inside this Run. Another owner — a Host
+    // recovery, a resumed continuation — may have sealed the ledger already,
+    // and a sealed run rejects further appends. Nothing to land in that case:
+    // the fact this method exists to guarantee is already there.
+    const sealed = await this.loadTurnRuntimeEvents()
+      .then((events) => events.some(isTerminalRuntimeEvent))
+      .catch(() => true);
+    if (sealed) return;
     const ts = this.lastTs || this.input.now();
     const finalStatus = { status: 'aborted' as const };
     this.finalStatus ??= finalStatus;

--- a/packages/runtime/src/prior-run-context.ts
+++ b/packages/runtime/src/prior-run-context.ts
@@ -206,14 +206,13 @@ async function readNonTerminalPriorRun(
   run: AgentRunHeader,
 ): Promise<{ events: RuntimeEvent[]; run?: AgentRunHeader }> {
   if (!input.runtimeEventStore) return { events: [] };
-  const read = async (): Promise<RuntimeEvent[]> =>
-    await input.runtimeEventStore!.readRuntimeEvents(input.sessionId, run.runId).catch(() => []);
-  let events = await read();
-  let terminalFact = classifyRuntimeEventTerminalFact(run, events).fact;
-  if (!terminalFact && (await input.repairRunRuntimeLedger?.(input.sessionId, run.runId))) {
-    events = await read();
-    terminalFact = classifyRuntimeEventTerminalFact(run, events).fact;
-  }
+  // No repair attempt here, unlike the terminal branch: `repairRunTerminalFact`
+  // returns false for a non-terminal header before reading anything, so calling
+  // it would be a promise that only ever answers "no".
+  const events = await input.runtimeEventStore
+    .readRuntimeEvents(input.sessionId, run.runId)
+    .catch(() => []);
+  const terminalFact = classifyRuntimeEventTerminalFact(run, events).fact;
   return terminalFact
     ? { events, run: effectiveRunHeaderFromTerminalFact(run, terminalFact) }
     : { events };

--- a/packages/runtime/src/prior-run-context.ts
+++ b/packages/runtime/src/prior-run-context.ts
@@ -60,10 +60,9 @@ export async function buildPriorRuntimeContext(
   for (let runIndex = 0; runIndex < priorRuns.length; runIndex += 1) {
     const run = priorRuns[runIndex]!;
     if (!isTerminalRunStatus(run.status)) {
-      const terminalFactContext = await readNonTerminalPriorRunWithTerminalFact(input, run);
-      if (!terminalFactContext) continue;
-      priorRuns[runIndex] = terminalFactContext.run;
-      appendEvents(ordered, terminalFactContext.events, runIndex, input);
+      const nonTerminal = await readNonTerminalPriorRun(input, run);
+      if (nonTerminal.run) priorRuns[runIndex] = nonTerminal.run;
+      appendEvents(ordered, nonTerminal.events, runIndex, input);
       continue;
     }
     let events = await input.runtimeEventStore.readRuntimeEvents(input.sessionId, run.runId);
@@ -194,18 +193,30 @@ async function loadRequiredChildResumeContext(
   return { events, run: effectiveRunHeaderFromTerminalFact(run, terminalFact) };
 }
 
-async function readNonTerminalPriorRunWithTerminalFact(
+/**
+ * A prior run whose header never reached a terminal status: it was stopped
+ * while parked on an interaction, or the process died mid-turn. Its turn is
+ * still conversation the model must see, so the ledger it does have is
+ * replayed either way. Dropping the run instead would delete a whole turn —
+ * the user message included — from every later turn's context, silently and
+ * for good, because the header never becomes terminal on its own.
+ */
+async function readNonTerminalPriorRun(
   input: BuildPriorRuntimeContextInput,
   run: AgentRunHeader,
-): Promise<PriorRunTerminalFactContext | undefined> {
-  if (!input.runtimeEventStore) return undefined;
-  const events = await input.runtimeEventStore
-    .readRuntimeEvents(input.sessionId, run.runId)
-    .catch(() => []);
-  const terminalFact = classifyRuntimeEventTerminalFact(run, events).fact;
+): Promise<{ events: RuntimeEvent[]; run?: AgentRunHeader }> {
+  if (!input.runtimeEventStore) return { events: [] };
+  const read = async (): Promise<RuntimeEvent[]> =>
+    await input.runtimeEventStore!.readRuntimeEvents(input.sessionId, run.runId).catch(() => []);
+  let events = await read();
+  let terminalFact = classifyRuntimeEventTerminalFact(run, events).fact;
+  if (!terminalFact && (await input.repairRunRuntimeLedger?.(input.sessionId, run.runId))) {
+    events = await read();
+    terminalFact = classifyRuntimeEventTerminalFact(run, events).fact;
+  }
   return terminalFact
     ? { events, run: effectiveRunHeaderFromTerminalFact(run, terminalFact) }
-    : undefined;
+    : { events };
 }
 
 async function backfillMissingPriorRuntimeEvents(

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -2296,7 +2296,11 @@ export class RuntimeKernel implements RuntimeKernelLike {
         try {
           await target.run?.settleStopTerminal();
         } catch (error) {
+          // Leave the target unfinished so the operation stays pending and a
+          // retried stop settles it again, the same way a failed projection
+          // write is retried above.
           failures.add(error);
+          continue;
         }
       }
       target.run?.completeStop();

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -2287,11 +2287,17 @@ export class RuntimeKernel implements RuntimeKernelLike {
     // the same thing before this stop reports success: a Run left non-terminal
     // here stays that way, because the stream that would have finalized it is
     // exactly the one the stop could not wake.
+    //
+    // Embedded owners only. A Hosted Run's terminal fact belongs to the Host's
+    // own terminal authority (#1359, #1996), which also parks provider-
+    // indeterminate Runs a stop must not resolve on its behalf.
     for (const target of stoppedRuns.values()) {
-      try {
-        await target.run?.settleStopTerminal();
-      } catch (error) {
-        failures.add(error);
+      if (!this.deps.interactionAuthority) {
+        try {
+          await target.run?.settleStopTerminal();
+        } catch (error) {
+          failures.add(error);
+        }
       }
       target.run?.completeStop();
       target.stopCompleted = true;

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -2283,7 +2283,16 @@ export class RuntimeKernel implements RuntimeKernelLike {
       await this.appendStopProjection(sessionId, operation.abortNote);
       operation.abortNoteProjected = true;
     }
+    // The Session projection above now reads as aborted. The ledger has to say
+    // the same thing before this stop reports success: a Run left non-terminal
+    // here stays that way, because the stream that would have finalized it is
+    // exactly the one the stop could not wake.
     for (const target of stoppedRuns.values()) {
+      try {
+        await target.run?.settleStopTerminal();
+      } catch (error) {
+        failures.add(error);
+      }
       target.run?.completeStop();
       target.stopCompleted = true;
     }


### PR DESCRIPTION
## Summary

A run stopped while parked on `AskUserQuestion` left the Session projection saying "aborted" and the RuntimeEvent ledger saying nothing at all. Its header stayed `waiting_for_user` forever, and every later turn then dropped that whole turn — user message, assistant text, all tool activity — from the model's context. The agent read as amnesiac, permanently, because the header never becomes terminal on its own.

Two changes, one at the source and one at the amplifier:

- **`stop` lands the terminal fact it already claimed.** `stop()` takes the Run's terminal claim, but only `finalize()` — reached when the backend's event stream ends — ever cashed it, and a turn parked on an unanswered interaction never ends that stream. The claim is now cashed where the stop completes, and the stop is fail-closed: a settlement that cannot land makes the stop fail rather than report a success it did not establish, and leaves the operation pending so a retry settles it again. The claim keeps the write idempotent — a stream that later produces its own terminal event finds it taken and writes nothing.
- **Prior-run context stops silently deleting a run.** `buildPriorRuntimeContext` treated a non-terminal prior run as skippable. It now replays whatever ledger that run does have; only the effective run header still depends on a terminal fact. No repair is attempted on this branch — `repairRunTerminalFact` returns `false` for a non-terminal header before reading anything, so the call could only ever answer "no".

Either change alone leaves the defect reachable: the first does not help runs already stranded (a crash, an older build), and the second leaves `stop` reporting a success it did not establish.

Scope: embedded owners. A Hosted Run's terminal fact belongs to the Host's terminal authority (#1359, #1996), which also parks provider-indeterminate Runs that a stop must not resolve on their behalf.

Refs #2074

## Verification

- `@maka/runtime` — 3096 pass, 0 fail (9 skipped), including six new behavior tests: a stop whose backend stream never ends commits a terminal fact; a prior run left non-terminal by an unanswered interaction is replayed into model context; a settlement racing `finalize` commits exactly one terminal run event; a stop whose settlement fails stays retryable; a hosted stop leaves the terminal fact to the Host; a settlement finds an already sealed ledger and leaves it untouched. Each was confirmed red against the code without its guard first.
- `@maka/runtime-host` — 619 pass, 0 fail. This suite caught two real regressions from an earlier, wider version of the fix (a sealed-ledger append and a parked continuation being resolved by shutdown); both shaped the final scope.
- `@maka/headless` — 1338 pass (1 skipped). `maka-agent` (CLI/TUI) — 468 pass.
- `npm run build` (full workspace tsc), `npm run lint`, `npm run format:check` — clean.
- Not run: Desktop E2E and Storybook. No renderer, IPC, or UI surface changes.

## Root cause

Confirmed against a real Desktop store, not inferred. Across 157 runs, exactly 5 were non-terminal, and all 5 held an `AskUserQuestion` `function_call` with no matching `function_response`. For one of them the session-message layer was complete — `turn_state{status:aborted, abortSource:renderer.stop_button}` and an error `tool_result` — while the ledger held `text×4, function_call×8, tool_dispatch×8, function_response×7` and no terminal event. The next run started 22s later and was built without any of it. Full evidence in #2074.
