### PR TITLE
feat(headless): add the Reasonix benchmark arm

### DIFF
--- a/packages/headless/harbor/reasonix_agent.py
+++ b/packages/headless/harbor/reasonix_agent.py
@@ -147,13 +147,12 @@ class MakaReasonixAgent(BaseInstalledAgent):
     async def _download_agent_logs(self, environment: BaseEnvironment) -> None:
         # _write_cell_output's only in-container input is the stream-json the
         # CLI writes to /logs/agent/reasonix.jsonl (identity and timestamps are
-        # host-side). Under Harbor the agent log dir is bind-mounted, so the
-        # file is already host-side and is skipped; under Pier a --mounts-json
-        # run replaces the default log mounts while capabilities.mounted stays
-        # true (pier docker.py), so pier's own log download never runs —
-        # without this download, _events() sees nothing and a real
-        # token-burning run is misclassified as infra. Runs in run()'s finally
-        # so the AgentTimeoutError path is hydrated too.
+        # host-side). Whenever the agent log dir is bind-mounted the file is
+        # already host-side and this is a no-op; the download is the fallback
+        # for every executor that does not mount it, because without the stream
+        # _events() sees nothing and a real token-burning run is misclassified
+        # as infra. Runs in run()'s finally so the AgentTimeoutError path is
+        # hydrated too. Same shape as the other installed-agent adapters.
         local = self.logs_dir / _OUTPUT_PATH.name
         if local.exists():
             return
@@ -294,12 +293,16 @@ class MakaReasonixAgent(BaseInstalledAgent):
                 # command line, including the task instruction, whose wording
                 # can match the infrastructure markers by chance — and its
                 # fallthrough is infra_failed, which drops the cell out of the
-                # scored denominator. The stream's own message is the accurate
-                # signal, so it wins whenever the run reported its own failure.
-                error_class = _classify_failure_text(
-                    str(result.get("result") or ""),
-                    default=_self_reported_failure_class(result.get("subtype")),
-                )
+                # scored denominator.
+                #
+                # A run that wrote a terminal result object reached the model
+                # and burned tokens, so it is an agent outcome no matter how the
+                # message reads. Re-scanning that message for markers would
+                # reintroduce the same coincidence it exists to defeat, this
+                # time on prose the model itself wrote. Scoring a provider-side
+                # failure as an agent loss is the honest direction; silently
+                # shrinking the denominator is not.
+                error_class = "runtime_error"
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         runtime_events_path = self.logs_dir / "runtime-events.jsonl"
         source_path = self.logs_dir / _OUTPUT_PATH.name
@@ -372,22 +375,10 @@ def _result_object(events: list[dict[str, Any]]) -> dict[str, Any] | None:
     return None
 
 
-def _self_reported_failure_class(subtype: Any) -> str:
-    # A failure Reasonix reports about itself is an agent-incomplete outcome
-    # (harbor-failure-policy's runtime_error), not an infrastructure fault to be
-    # retried or dropped from scoring. Unknown subtypes fail safe the same way:
-    # a future Reasonix release adding one must not silently shrink the scored
-    # denominator, and over-counting an agent failure is the honest direction.
-    del subtype
-    return "runtime_error"
-
-
 def _classify_failure(error: Exception) -> str:
-    return _classify_failure_text(str(error), default="infra_failed")
-
-
-def _classify_failure_text(message: str, *, default: str) -> str:
-    text = message.lower()
+    # Only reachable when the run left no terminal result object to trust, so
+    # Harbor's exception text is the only signal there is.
+    text = str(error).lower()
     if any(
         marker in text
         for marker in ("401", "403", "unauthorized", "authentication", "invalid api key")
@@ -401,4 +392,4 @@ def _classify_failure_text(message: str, *, default: str) -> str:
         return "network"
     if any(marker in text for marker in ("500", "502", "503", "504", "unavailable")):
         return "provider_unavailable"
-    return default
+    return "infra_failed"

--- a/packages/headless/harbor/reasonix_agent.py
+++ b/packages/headless/harbor/reasonix_agent.py
@@ -34,9 +34,13 @@ _TOOLCHAIN_MANIFEST = _TOOLCHAIN_ROOT / "manifest.json"
 _TOOLCHAIN_CHECKSUMS = _TOOLCHAIN_ROOT / "checksums.sha256"
 _OUTPUT_PATH = Path("/logs/agent/reasonix.jsonl")
 _REASONIX_HOME = Path("/tmp/maka-reasonix")
-# Reasonix resolves a provider's key through api_key_env, so only the variable
-# name lands in config.toml. A Maka-specific name keeps the proxy token clear of
-# any DEEPSEEK_API_KEY a stray environment or global .env might also define.
+# Reasonix resolves api_key_env against its own credential store
+# ($REASONIX_HOME/.env), NOT the process environment — see
+# ProviderEntry.APIKey -> storedCredentialValue in internal/config. So the
+# config file names the key and this file holds it, both inside an isolated
+# home outside the task workspace. A Maka-specific name keeps the cell-scoped
+# proxy token clear of any DEEPSEEK_API_KEY a stray environment might define.
+_REASONIX_CREDENTIALS = _REASONIX_HOME / ".env"
 _PROXY_TOKEN_ENV = "MAKA_REASONIX_PROXY_TOKEN"
 # A reserved provider name: it cannot collide with Reasonix's built-in deepseek
 # entry, so the proxy route is unambiguous regardless of what else resolves.
@@ -118,9 +122,20 @@ class MakaReasonixAgent(BaseInstalledAgent):
         abnormal_exit = False
         try:
             command = (
+                # umask before any write: the credential file must never exist
+                # group- or world-readable, not even momentarily.
+                "umask 077; "
                 f"mkdir -p {shlex.quote(str(_REASONIX_HOME))}; "
                 f"printf %s {shlex.quote(self._config_toml())} > "
                 f"{shlex.quote(str(_REASONIX_HOME / 'config.toml'))}; "
+                # Reasonix resolves api_key_env from its own credential store,
+                # not the process environment, so the token has to reach that
+                # file. It is expanded from the environment here rather than
+                # interpolated, so the value never enters the command line,
+                # the process table, or Harbor's command logs.
+                f"printf '%s=%s\\n' {shlex.quote(_PROXY_TOKEN_ENV)} "
+                f'"${_PROXY_TOKEN_ENV}" > '
+                f"{shlex.quote(str(_REASONIX_CREDENTIALS))}; "
                 f"{shlex.quote(str(_TOOLCHAIN_BINARY))} run --auto "
                 f"--model {shlex.quote(self._model_reference())} "
                 f"--effort {shlex.quote(self._effort())} "
@@ -214,11 +229,14 @@ class MakaReasonixAgent(BaseInstalledAgent):
         if not proxy_token:
             raise ValueError("Reasonix requires the host provider proxy")
         return {
-            # An isolated home keeps Reasonix's config, session state, and .env
-            # off any host or task-workspace config that could redirect the run.
+            # An isolated home keeps Reasonix's config, session state, and
+            # credential file off any host or task-workspace config that could
+            # redirect the run.
             "REASONIX_HOME": str(_REASONIX_HOME),
-            # The only place the cell-scoped proxy token exists: never a config
-            # file, never a command line, never the task workspace.
+            # This carries the cell-scoped proxy token into the container so the
+            # command can expand it into Reasonix's credential file without ever
+            # naming the value itself. The upstream provider key stays host-side
+            # in the proxy and never enters the container in any form.
             _PROXY_TOKEN_ENV: proxy_token,
         }
 

--- a/packages/headless/harbor/reasonix_agent.py
+++ b/packages/headless/harbor/reasonix_agent.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import re
 import secrets
 import shlex
 import time
@@ -19,11 +18,9 @@ from harness_compat import (
     AgentContext,
     BaseEnvironment,
     BaseInstalledAgent,
-    NetworkAllowlist as _NetworkAllowlist,
     with_prompt_template,
 )
 from process_scope import cleanup_process_scope, scoped_command
-from provider_proxy import provider_proxy_endpoint, warn_if_pier_unreachable_proxy_port
 
 _TOOLCHAIN_ROOT = Path("/opt/maka-reasonix-toolchain")
 # Reasonix is a static Go binary; the pinned Node next to it is only the offline
@@ -46,9 +43,6 @@ _PROXY_TOKEN_ENV = "MAKA_REASONIX_PROXY_TOKEN"
 # entry, so the proxy route is unambiguous regardless of what else resolves.
 _PROVIDER_NAME = "maka-proxy"
 _DEFAULT_EFFORT = "max"
-_DEFAULT_CELL_TIMEOUT_SEC = 900
-_MAX_SAFE_INTEGER = 9007199254740991
-_POSITIVE_INT_RE = re.compile(r"[1-9][0-9]*")
 
 
 class MakaReasonixAgent(BaseInstalledAgent):
@@ -64,22 +58,6 @@ class MakaReasonixAgent(BaseInstalledAgent):
         # nothing to install at Pier build time. Pier declares this abstract on
         # BaseInstalledAgent; None keeps the runtime verify path unchanged.
         return None
-
-    def network_allowlist(self) -> _NetworkAllowlist | None:
-        # Called only under Pier; plain Harbor never calls it and harness_compat
-        # exports NetworkAllowlist = None there.
-        if _NetworkAllowlist is None:
-            return None
-        # The container runs the pre-baked Reasonix CLI against the provider
-        # base_url written into config.toml, which _write_config() sets to
-        # MAKA_PROVIDER_PROXY_URL. The toolchain is verified offline (no install
-        # download), so the only outbound host the container needs is that model
-        # endpoint. A missing or malformed proxy URL fails here, at environment
-        # creation — no fallback domain, so a misconfigured trial never gets a
-        # spurious egress grant.
-        hostname, port = provider_proxy_endpoint(self._get_env, "Reasonix")
-        warn_if_pier_unreachable_proxy_port(port, "Reasonix")
-        return _NetworkAllowlist(domains=[hostname])
 
     def get_version_command(self) -> str | None:
         return f"{shlex.quote(str(_TOOLCHAIN_BINARY))} --version"
@@ -222,9 +200,9 @@ class MakaReasonixAgent(BaseInstalledAgent):
         )
 
     def _runtime_env(self) -> dict[str, str]:
-        # The proxy URL is forwarded opaquely (IPv6 included) — endpoint-shape
-        # validation is a Pier allowlist constraint and lives in
-        # network_allowlist(), not in this plain-Harbor code path.
+        # The proxy URL is forwarded opaquely (IPv6 included): endpoint-shape
+        # validation is a Pier egress-allowlist concern, and this arm runs only
+        # under plain Harbor (see PierAgent in pier-task-runner.ts).
         proxy_token = self._get_env("MAKA_PROVIDER_PROXY_TOKEN")
         if not proxy_token:
             raise ValueError("Reasonix requires the host provider proxy")
@@ -239,19 +217,6 @@ class MakaReasonixAgent(BaseInstalledAgent):
             # in the proxy and never enters the container in any form.
             _PROXY_TOKEN_ENV: proxy_token,
         }
-
-    def _cell_timeout_sec(self) -> int:
-        raw = self._get_env("MAKA_CELL_TIMEOUT_SEC")
-        if not raw:
-            return _DEFAULT_CELL_TIMEOUT_SEC
-        stripped = raw.strip()
-        if _POSITIVE_INT_RE.fullmatch(stripped) is None:
-            return _DEFAULT_CELL_TIMEOUT_SEC
-        try:
-            value = int(stripped)
-        except ValueError:
-            return _DEFAULT_CELL_TIMEOUT_SEC
-        return value if value <= _MAX_SAFE_INTEGER else _DEFAULT_CELL_TIMEOUT_SEC
 
     def _events(self, *, require_result: bool = False) -> list[dict[str, Any]]:
         path = self.logs_dir / _OUTPUT_PATH.name
@@ -308,10 +273,20 @@ class MakaReasonixAgent(BaseInstalledAgent):
                 session_id = result["session_id"]
             if isinstance(result.get("num_turns"), int):
                 steps = max(0, result["num_turns"])
-            # A run that reports its own failure stays failed even when the CLI
-            # exits 0, so a token-burning error is never scored as completed.
-            if error_class is None and result.get("is_error") is True:
-                error_class = _classify_failure_subtype(result.get("subtype"))
+            if result.get("is_error") is True:
+                # Reasonix binds its verdict to its exit code: every
+                # error_during_execution also exits 1 (internal/cli/
+                # run_completion.go), so run() has already raised and classified
+                # from Harbor's exception text. That text embeds the whole
+                # command line, including the task instruction, whose wording
+                # can match the infrastructure markers by chance — and its
+                # fallthrough is infra_failed, which drops the cell out of the
+                # scored denominator. The stream's own message is the accurate
+                # signal, so it wins whenever the run reported its own failure.
+                error_class = _classify_failure_text(
+                    str(result.get("result") or ""),
+                    default=_self_reported_failure_class(result.get("subtype")),
+                )
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         runtime_events_path = self.logs_dir / "runtime-events.jsonl"
         source_path = self.logs_dir / _OUTPUT_PATH.name
@@ -384,15 +359,22 @@ def _result_object(events: list[dict[str, Any]]) -> dict[str, Any] | None:
     return None
 
 
-def _classify_failure_subtype(subtype: Any) -> str:
-    # error_during_execution is Reasonix reporting its own run failure, which is
-    # an agent-incomplete outcome (harbor-failure-policy's runtime_error), not
-    # an infrastructure fault that should be retried or excluded from scoring.
-    return "runtime_error" if subtype == "error_during_execution" else "infra_failed"
+def _self_reported_failure_class(subtype: Any) -> str:
+    # A failure Reasonix reports about itself is an agent-incomplete outcome
+    # (harbor-failure-policy's runtime_error), not an infrastructure fault to be
+    # retried or dropped from scoring. Unknown subtypes fail safe the same way:
+    # a future Reasonix release adding one must not silently shrink the scored
+    # denominator, and over-counting an agent failure is the honest direction.
+    del subtype
+    return "runtime_error"
 
 
 def _classify_failure(error: Exception) -> str:
-    text = str(error).lower()
+    return _classify_failure_text(str(error), default="infra_failed")
+
+
+def _classify_failure_text(message: str, *, default: str) -> str:
+    text = message.lower()
     if any(
         marker in text
         for marker in ("401", "403", "unauthorized", "authentication", "invalid api key")
@@ -406,4 +388,4 @@ def _classify_failure(error: Exception) -> str:
         return "network"
     if any(marker in text for marker in ("500", "502", "503", "504", "unavailable")):
         return "provider_unavailable"
-    return "infra_failed"
+    return default

--- a/packages/headless/harbor/reasonix_agent.py
+++ b/packages/headless/harbor/reasonix_agent.py
@@ -197,6 +197,19 @@ class MakaReasonixAgent(BaseInstalledAgent):
             f"models = [{_toml_string(model)}]\n"
             f"api_key_env = {_toml_string(_PROXY_TOKEN_ENV)}\n"
             f"effort = {_toml_string(self._effort())}\n"
+            "\n"
+            # Reasonix defaults to bash = "enforce", which jails each command in
+            # an OS sandbox and REFUSES to run bash at all when none is
+            # available. Terminal-Bench images do not ship bubblewrap, so the
+            # default silently disables the agent's most important tool: the
+            # first live cell spent its whole run writing a setup script it was
+            # never allowed to execute. The Harbor task container is already the
+            # isolation boundary — that is the declared execution policy, and
+            # every other arm runs its commands unconfined inside it. Turning
+            # this off puts Reasonix on the same footing rather than handing it
+            # an advantage.
+            "[sandbox]\n"
+            'bash = "off"\n'
         )
 
     def _runtime_env(self) -> dict[str, str]:

--- a/packages/headless/harbor/reasonix_agent.py
+++ b/packages/headless/harbor/reasonix_agent.py
@@ -1,0 +1,391 @@
+"""Harbor adapter for the pinned official Reasonix CLI."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import shlex
+import time
+from pathlib import Path
+from typing import Any
+
+# harness_compat picks the harbor.* tree under plain Harbor 0.13.2 and the
+# pier.* tree under Pier, whose parallel classes are type-incompatible with
+# harbor's (Pier's TrialResult only accepts Pier's AgentInfo).
+from harness_compat import (
+    AgentContext,
+    BaseEnvironment,
+    BaseInstalledAgent,
+    NetworkAllowlist as _NetworkAllowlist,
+    with_prompt_template,
+)
+from process_scope import cleanup_process_scope, scoped_command
+from provider_proxy import provider_proxy_endpoint, warn_if_pier_unreachable_proxy_port
+
+_TOOLCHAIN_ROOT = Path("/opt/maka-reasonix-toolchain")
+# Reasonix is a static Go binary; the pinned Node next to it is only the offline
+# manifest verifier install() runs, exactly as for the prebuilt OpenCode binary.
+_TOOLCHAIN_NODE = _TOOLCHAIN_ROOT / "bin" / "node"
+_TOOLCHAIN_BINARY = _TOOLCHAIN_ROOT / "bin" / "reasonix"
+_TOOLCHAIN_MANIFEST = _TOOLCHAIN_ROOT / "manifest.json"
+_TOOLCHAIN_CHECKSUMS = _TOOLCHAIN_ROOT / "checksums.sha256"
+_OUTPUT_PATH = Path("/logs/agent/reasonix.jsonl")
+_REASONIX_HOME = Path("/tmp/maka-reasonix")
+# Reasonix resolves a provider's key through api_key_env, so only the variable
+# name lands in config.toml. A Maka-specific name keeps the proxy token clear of
+# any DEEPSEEK_API_KEY a stray environment or global .env might also define.
+_PROXY_TOKEN_ENV = "MAKA_REASONIX_PROXY_TOKEN"
+# A reserved provider name: it cannot collide with Reasonix's built-in deepseek
+# entry, so the proxy route is unambiguous regardless of what else resolves.
+_PROVIDER_NAME = "maka-proxy"
+_DEFAULT_EFFORT = "max"
+_DEFAULT_CELL_TIMEOUT_SEC = 900
+_MAX_SAFE_INTEGER = 9007199254740991
+_POSITIVE_INT_RE = re.compile(r"[1-9][0-9]*")
+
+
+class MakaReasonixAgent(BaseInstalledAgent):
+    """Run Reasonix in deterministic print mode for a single Harbor task."""
+
+    @staticmethod
+    def name() -> str:
+        return "reasonix"
+
+    def install_spec(self) -> None:
+        # The Reasonix toolchain is baked into the task image and only verified
+        # (sha256 checksums + manifest fingerprint) in install(); there is
+        # nothing to install at Pier build time. Pier declares this abstract on
+        # BaseInstalledAgent; None keeps the runtime verify path unchanged.
+        return None
+
+    def network_allowlist(self) -> _NetworkAllowlist | None:
+        # Called only under Pier; plain Harbor never calls it and harness_compat
+        # exports NetworkAllowlist = None there.
+        if _NetworkAllowlist is None:
+            return None
+        # The container runs the pre-baked Reasonix CLI against the provider
+        # base_url written into config.toml, which _write_config() sets to
+        # MAKA_PROVIDER_PROXY_URL. The toolchain is verified offline (no install
+        # download), so the only outbound host the container needs is that model
+        # endpoint. A missing or malformed proxy URL fails here, at environment
+        # creation — no fallback domain, so a misconfigured trial never gets a
+        # spurious egress grant.
+        hostname, port = provider_proxy_endpoint(self._get_env, "Reasonix")
+        warn_if_pier_unreachable_proxy_port(port, "Reasonix")
+        return _NetworkAllowlist(domains=[hostname])
+
+    def get_version_command(self) -> str | None:
+        return f"{shlex.quote(str(_TOOLCHAIN_BINARY))} --version"
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        expected_fingerprint = self._get_env("MAKA_REASONIX_TOOLCHAIN_FINGERPRINT")
+        if not expected_fingerprint:
+            raise ValueError("MAKA_REASONIX_TOOLCHAIN_FINGERPRINT is required")
+        manifest_check = (
+            "const fs = require('node:fs'); "
+            "const manifest = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); "
+            "if (manifest.fingerprint !== process.env.MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT) "
+            "throw new Error('Reasonix toolchain fingerprint mismatch');"
+        )
+        command = (
+            "set -euo pipefail; "
+            'test "$(uname -s)" = Linux; '
+            'test "$(uname -m)" = x86_64; '
+            f"cd {shlex.quote(str(_TOOLCHAIN_ROOT))}; "
+            f"sha256sum --check {shlex.quote(_TOOLCHAIN_CHECKSUMS.name)}; "
+            f"{shlex.quote(str(_TOOLCHAIN_NODE))} -e {shlex.quote(manifest_check)} "
+            f"{shlex.quote(str(_TOOLCHAIN_MANIFEST))}"
+        )
+        await self.exec_as_agent(
+            environment,
+            command=command,
+            env={"MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT": expected_fingerprint},
+        )
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        self._started_at_ms = int(time.time() * 1000)
+        self._write_execution_identity()
+        command_scope = secrets.token_urlsafe(24)
+        abnormal_exit = False
+        try:
+            command = (
+                f"mkdir -p {shlex.quote(str(_REASONIX_HOME))}; "
+                f"printf %s {shlex.quote(self._config_toml())} > "
+                f"{shlex.quote(str(_REASONIX_HOME / 'config.toml'))}; "
+                f"{shlex.quote(str(_TOOLCHAIN_BINARY))} run --auto "
+                f"--model {shlex.quote(self._model_reference())} "
+                f"--effort {shlex.quote(self._effort())} "
+                "--output-format stream-json "
+                f"{shlex.quote(instruction)} "
+                f"> {shlex.quote(str(_OUTPUT_PATH))} "
+                "2> /logs/agent/reasonix.stderr.txt"
+            )
+            await self.exec_as_agent(
+                environment,
+                command=scoped_command(
+                    command,
+                    command_scope,
+                    secrets.token_urlsafe(12),
+                ),
+                env=self._runtime_env(),
+            )
+        except BaseException as error:
+            abnormal_exit = True
+            if isinstance(error, Exception):
+                self._failure_class = _classify_failure(error)
+            raise
+        finally:
+            try:
+                if abnormal_exit:
+                    await cleanup_process_scope(self, environment, command_scope)
+            finally:
+                self._finished_at_ms = int(time.time() * 1000)
+                await self._download_agent_logs(environment)
+
+    async def _download_agent_logs(self, environment: BaseEnvironment) -> None:
+        # _write_cell_output's only in-container input is the stream-json the
+        # CLI writes to /logs/agent/reasonix.jsonl (identity and timestamps are
+        # host-side). Under Harbor the agent log dir is bind-mounted, so the
+        # file is already host-side and is skipped; under Pier a --mounts-json
+        # run replaces the default log mounts while capabilities.mounted stays
+        # true (pier docker.py), so pier's own log download never runs —
+        # without this download, _events() sees nothing and a real
+        # token-burning run is misclassified as infra. Runs in run()'s finally
+        # so the AgentTimeoutError path is hydrated too.
+        local = self.logs_dir / _OUTPUT_PATH.name
+        if local.exists():
+            return
+        try:
+            await environment.download_file(_OUTPUT_PATH.as_posix(), local)
+        except Exception as exc:  # noqa: BLE001 - best-effort log hydration.
+            self.logger.debug("Could not download Reasonix stream %s: %s", _OUTPUT_PATH, exc)
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        self._write_cell_output()
+
+    def _model(self) -> str:
+        model = self._get_env("MAKA_MODEL") or self.model_name
+        if not model:
+            raise ValueError("MAKA_MODEL is required")
+        return model
+
+    def _model_reference(self) -> str:
+        return f"{_PROVIDER_NAME}/{self._model()}"
+
+    def _effort(self) -> str:
+        return self._get_env("MAKA_REASONING_EFFORT") or _DEFAULT_EFFORT
+
+    def _config_toml(self) -> str:
+        proxy_url = self._get_env("MAKA_PROVIDER_PROXY_URL")
+        if not proxy_url:
+            raise ValueError("Reasonix requires the host provider proxy")
+        model = self._model()
+        # Reasonix has no flag or environment override for a provider base_url,
+        # so the proxy route has to come from config. Only non-secret values are
+        # written here: the key itself is resolved from api_key_env at runtime.
+        # Model and effort are also pinned as flags, which outrank config; both
+        # are declared so a dropped flag cannot silently downgrade the arm.
+        return (
+            f"default_model = {_toml_string(f'{_PROVIDER_NAME}/{model}')}\n"
+            "\n"
+            "[[providers]]\n"
+            f"name = {_toml_string(_PROVIDER_NAME)}\n"
+            'kind = "openai"\n'
+            f"base_url = {_toml_string(proxy_url)}\n"
+            f"models = [{_toml_string(model)}]\n"
+            f"api_key_env = {_toml_string(_PROXY_TOKEN_ENV)}\n"
+            f"effort = {_toml_string(self._effort())}\n"
+        )
+
+    def _runtime_env(self) -> dict[str, str]:
+        # The proxy URL is forwarded opaquely (IPv6 included) — endpoint-shape
+        # validation is a Pier allowlist constraint and lives in
+        # network_allowlist(), not in this plain-Harbor code path.
+        proxy_token = self._get_env("MAKA_PROVIDER_PROXY_TOKEN")
+        if not proxy_token:
+            raise ValueError("Reasonix requires the host provider proxy")
+        return {
+            # An isolated home keeps Reasonix's config, session state, and .env
+            # off any host or task-workspace config that could redirect the run.
+            "REASONIX_HOME": str(_REASONIX_HOME),
+            # The only place the cell-scoped proxy token exists: never a config
+            # file, never a command line, never the task workspace.
+            _PROXY_TOKEN_ENV: proxy_token,
+        }
+
+    def _cell_timeout_sec(self) -> int:
+        raw = self._get_env("MAKA_CELL_TIMEOUT_SEC")
+        if not raw:
+            return _DEFAULT_CELL_TIMEOUT_SEC
+        stripped = raw.strip()
+        if _POSITIVE_INT_RE.fullmatch(stripped) is None:
+            return _DEFAULT_CELL_TIMEOUT_SEC
+        try:
+            value = int(stripped)
+        except ValueError:
+            return _DEFAULT_CELL_TIMEOUT_SEC
+        return value if value <= _MAX_SAFE_INTEGER else _DEFAULT_CELL_TIMEOUT_SEC
+
+    def _events(self, *, require_result: bool = False) -> list[dict[str, Any]]:
+        path = self.logs_dir / _OUTPUT_PATH.name
+        if not path.exists():
+            if require_result:
+                raise ValueError("Reasonix stream-json did not contain a result object")
+            return []
+        events = []
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as error:
+                if require_result:
+                    raise ValueError(
+                        f"Reasonix stream-json line {line_number} is not valid JSON"
+                    ) from error
+                continue
+            if not isinstance(value, dict):
+                if require_result:
+                    raise ValueError(
+                        f"Reasonix stream-json line {line_number} must be a JSON object"
+                    )
+                continue
+            events.append(value)
+        if require_result and _result_object(events) is None:
+            raise ValueError("Reasonix stream-json did not contain a result object")
+        return events
+
+    def _write_cell_output(self) -> None:
+        started_at = getattr(self, "_started_at_ms", int(time.time() * 1000))
+        finished_at = getattr(self, "_finished_at_ms", started_at)
+        identity = self._execution_identity()
+        failed = hasattr(self, "_failure_class")
+        events = self._events(require_result=not failed)
+        result = _result_object(events)
+        tool_call_counts: dict[str, int] = {}
+        for event in events:
+            # tool_result and tool_progress repeat a dispatched call; only
+            # tool_dispatch marks a distinct invocation.
+            if event.get("kind") != "tool_dispatch":
+                continue
+            tool = event.get("tool")
+            name = tool.get("name") if isinstance(tool, dict) else None
+            if name:
+                key = str(name)
+                tool_call_counts[key] = tool_call_counts.get(key, 0) + 1
+        session_id = "reasonix"
+        steps = 0
+        error_class: str | None = self._failure_class if failed else None
+        if result is not None:
+            if isinstance(result.get("session_id"), str) and result["session_id"]:
+                session_id = result["session_id"]
+            if isinstance(result.get("num_turns"), int):
+                steps = max(0, result["num_turns"])
+            # A run that reports its own failure stays failed even when the CLI
+            # exits 0, so a token-burning error is never scored as completed.
+            if error_class is None and result.get("is_error") is True:
+                error_class = _classify_failure_subtype(result.get("subtype"))
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        runtime_events_path = self.logs_dir / "runtime-events.jsonl"
+        source_path = self.logs_dir / _OUTPUT_PATH.name
+        runtime_events_path.write_text(
+            source_path.read_text(encoding="utf-8") if source_path.exists() else "",
+            encoding="utf-8",
+        )
+        output = {
+            "schemaVersion": 1,
+            "status": "failed" if error_class else "completed",
+            **({"errorClass": error_class} if error_class else {}),
+            "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+            "promptHash": identity["systemPromptHash"],
+            "executionIdentity": identity,
+            "toolSummary": {
+                "providerVisibleToolCount": 0,
+                "actualToolCalls": sum(tool_call_counts.values()),
+                "actualToolNames": sorted(tool_call_counts),
+                "actualToolCallCounts": tool_call_counts,
+            },
+            "steps": steps,
+            "durationMs": max(0, finished_at - started_at),
+            "startedAt": started_at,
+            "finishedAt": finished_at,
+            "runtimeRefs": {
+                "invocationId": session_id,
+                "sessionId": session_id,
+                "runId": session_id,
+                "turnId": session_id,
+            },
+        }
+        (self.logs_dir / "maka-cell-output.json").write_text(
+            json.dumps(output, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def _execution_identity(self) -> dict[str, Any]:
+        system_prompt = self._get_env("MAKA_SYSTEM_PROMPT") or ""
+        prompt_hash = "sha256:" + hashlib.sha256(
+            json.dumps(system_prompt, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return {
+            "llmConnectionSlug": self._get_env("MAKA_LLM_CONNECTION_SLUG") or "deepseek",
+            "model": self._get_env("MAKA_MODEL") or self.model_name or "deepseek-v4-flash",
+            "reasoningEffort": self._effort(),
+            "systemPromptHash": prompt_hash,
+            "pricingProfile": self._get_env("MAKA_TRIAL_PRICING_SOURCE") or "unconfigured",
+            "agentTools": False,
+        }
+
+    def _write_execution_identity(self) -> None:
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        path = self.logs_dir / "maka-cell-execution-identity.json"
+        with path.open("w", encoding="utf-8") as output:
+            output.write(json.dumps(self._execution_identity(), indent=2) + "\n")
+            output.flush()
+            os.fsync(output.fileno())
+
+
+def _toml_string(value: str) -> str:
+    """Render a TOML basic string; JSON string escaping is a valid subset."""
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _result_object(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    # stream-json emits one eventwire object per line, then the final result
+    # object; the result is the only line keyed by "type" instead of "kind".
+    for event in reversed(events):
+        if event.get("type") == "result":
+            return event
+    return None
+
+
+def _classify_failure_subtype(subtype: Any) -> str:
+    # error_during_execution is Reasonix reporting its own run failure, which is
+    # an agent-incomplete outcome (harbor-failure-policy's runtime_error), not
+    # an infrastructure fault that should be retried or excluded from scoring.
+    return "runtime_error" if subtype == "error_during_execution" else "infra_failed"
+
+
+def _classify_failure(error: Exception) -> str:
+    text = str(error).lower()
+    if any(
+        marker in text
+        for marker in ("401", "403", "unauthorized", "authentication", "invalid api key")
+    ):
+        return "auth"
+    if any(marker in text for marker in ("429", "rate limit", "too many requests")):
+        return "rate_limit"
+    if any(marker in text for marker in ("billing", "insufficient credit", "quota exceeded")):
+        return "provider_billing"
+    if any(marker in text for marker in ("connection", "network", "dns", "socket")):
+        return "network"
+    if any(marker in text for marker in ("500", "502", "503", "504", "unavailable")):
+        return "provider_unavailable"
+    return "infra_failed"

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -46,6 +46,11 @@ import {
   CLAUDE_CODE_TOOLCHAIN_SPEC,
   prepareClaudeCodeToolchain,
 } from '#claude-code-toolchain';
+import {
+  REASONIX_TOOLCHAIN_FINGERPRINT,
+  REASONIX_TOOLCHAIN_SPEC,
+  prepareReasonixToolchain,
+} from '#reasonix-toolchain';
 import { MAKA_NODE_TOOLCHAIN_FINGERPRINT, prepareMakaNodeToolchain } from '#maka-node-toolchain';
 import { createCodexOAuthHarnessCredentialBinding } from '#codex-oauth-harness';
 import {
@@ -322,6 +327,22 @@ export const HARNESS_COMPETITOR_PROFILES = Object.freeze({
       attemptPolicy: 'single',
     }),
   }),
+  reasonix: Object.freeze({
+    id: 'reasonix',
+    version: REASONIX_TOOLCHAIN_SPEC.reasonix.version,
+    toolchainFingerprint: REASONIX_TOOLCHAIN_FINGERPRINT,
+    prepareToolchain: prepareReasonixToolchain,
+    toolchainPathEnvKey: 'MAKA_HARNESS_AB_REASONIX_TOOLCHAIN',
+    runnerToolchainOption: 'reasonixToolchainPath',
+    config: Object.freeze({
+      // stream-json carries real tool names, which the redacted --events-jsonl
+      // surface aliases away; the arms are only comparable on tool behaviour if
+      // both capture their CLI's native stream.
+      outputFormat: 'stream-json',
+      permissions: 'auto',
+      attemptPolicy: 'single',
+    }),
+  }),
 });
 
 export const HARNESS_RUNTIME_PROFILES = Object.freeze({
@@ -393,6 +414,7 @@ const DEFAULT_RUNTIME_BY_COMPETITOR = Object.freeze({
   opencode: 'kimi-coding-plan-k3-max',
   codex: 'openai-codex-gpt-5.6-sol-xhigh',
   'claude-code': 'deepseek-v4-flash-max',
+  reasonix: 'deepseek-v4-flash-max',
 });
 
 const SUPPORTED_HARNESS_COMPOSITIONS = new Set([
@@ -403,6 +425,7 @@ const SUPPORTED_HARNESS_COMPOSITIONS = new Set([
   'terminal-bench-2.1|openai-codex-gpt-5.6-sol-xhigh|codex',
   'terminal-bench-2.1|deepseek-v4-flash-max|codex',
   'terminal-bench-2.1|deepseek-v4-flash-max|claude-code',
+  'terminal-bench-2.1|deepseek-v4-flash-max|reasonix',
   'deep-swe-1.1|kimi-coding-plan-k3-max|kimi-code',
   'deep-swe-1.1|openai-codex-gpt-5.6-sol-xhigh|codex',
   'deep-swe-1.1-full|kimi-coding-plan-k3-max|kimi-code',

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -263,11 +263,20 @@ async function readPierVersion() {
   }
 }
 
+/**
+ * A competitor profile is the single source of truth for one arm's pinned
+ * toolchain: how to prepare it, which env var overrides its cached path, and
+ * which runner option carries it. Downstream code reads these fields instead
+ * of re-dispatching on the competitor id.
+ */
 export const HARNESS_COMPETITOR_PROFILES = Object.freeze({
   'kimi-code': Object.freeze({
     id: 'kimi-code',
     version: KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.version,
     toolchainFingerprint: KIMI_CODE_TOOLCHAIN_FINGERPRINT,
+    prepareToolchain: prepareKimiCodeToolchain,
+    toolchainPathEnvKey: 'MAKA_HARNESS_AB_KIMI_CODE_TOOLCHAIN',
+    runnerToolchainOption: 'kimiCodeToolchainPath',
     config: Object.freeze({
       outputFormat: 'stream-json',
       permissions: 'prompt-auto',
@@ -278,6 +287,9 @@ export const HARNESS_COMPETITOR_PROFILES = Object.freeze({
     id: 'opencode',
     version: OPENCODE_TOOLCHAIN_SPEC.opencode.version,
     toolchainFingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
+    prepareToolchain: prepareOpenCodeToolchain,
+    toolchainPathEnvKey: 'MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN',
+    runnerToolchainOption: 'opencodeToolchainPath',
     config: Object.freeze({
       pure: true,
       permissions: 'auto',
@@ -288,6 +300,9 @@ export const HARNESS_COMPETITOR_PROFILES = Object.freeze({
     id: 'codex',
     version: CODEX_TOOLCHAIN_SPEC.codex.version,
     toolchainFingerprint: CODEX_TOOLCHAIN_FINGERPRINT,
+    prepareToolchain: prepareCodexToolchain,
+    toolchainPathEnvKey: 'MAKA_HARNESS_AB_CODEX_TOOLCHAIN',
+    runnerToolchainOption: 'codexToolchainPath',
     config: Object.freeze({
       transport: 'responses-http',
       permissions: 'container-full-access',
@@ -298,6 +313,9 @@ export const HARNESS_COMPETITOR_PROFILES = Object.freeze({
     id: 'claude-code',
     version: CLAUDE_CODE_TOOLCHAIN_SPEC.claudeCode.version,
     toolchainFingerprint: CLAUDE_CODE_TOOLCHAIN_FINGERPRINT,
+    prepareToolchain: prepareClaudeCodeToolchain,
+    toolchainPathEnvKey: 'MAKA_HARNESS_AB_CLAUDE_CODE_TOOLCHAIN',
+    runnerToolchainOption: 'claudeCodeToolchainPath',
     config: Object.freeze({
       transport: 'anthropic-messages',
       permissions: 'bypassPermissions',
@@ -562,39 +580,16 @@ export function resolveHarnessCompetitorToolchainPath(runRoot, competitorProfile
 }
 
 export function resolveHarnessCompetitorToolchain(runRoot, competitorProfile, env = process.env) {
-  if (competitorProfile.id === 'kimi-code') {
-    return {
-      path: env.MAKA_HARNESS_AB_KIMI_CODE_TOOLCHAIN
-        ? resolve(env.MAKA_HARNESS_AB_KIMI_CODE_TOOLCHAIN)
-        : resolveHarnessCompetitorToolchainPath(runRoot, competitorProfile),
-      prepare: prepareKimiCodeToolchain,
-    };
+  if (!competitorProfile.prepareToolchain) {
+    throw new Error(`unsupported harness competitor: ${competitorProfile.id}`);
   }
-  if (competitorProfile.id === 'opencode') {
-    return {
-      path: env.MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN
-        ? resolve(env.MAKA_HARNESS_AB_OPENCODE_TOOLCHAIN)
-        : resolveHarnessCompetitorToolchainPath(runRoot, competitorProfile),
-      prepare: prepareOpenCodeToolchain,
-    };
-  }
-  if (competitorProfile.id === 'codex') {
-    return {
-      path: env.MAKA_HARNESS_AB_CODEX_TOOLCHAIN
-        ? resolve(env.MAKA_HARNESS_AB_CODEX_TOOLCHAIN)
-        : resolveHarnessCompetitorToolchainPath(runRoot, competitorProfile),
-      prepare: prepareCodexToolchain,
-    };
-  }
-  if (competitorProfile.id === 'claude-code') {
-    return {
-      path: env.MAKA_HARNESS_AB_CLAUDE_CODE_TOOLCHAIN
-        ? resolve(env.MAKA_HARNESS_AB_CLAUDE_CODE_TOOLCHAIN)
-        : resolveHarnessCompetitorToolchainPath(runRoot, competitorProfile),
-      prepare: prepareClaudeCodeToolchain,
-    };
-  }
-  throw new Error(`unsupported harness competitor: ${competitorProfile.id}`);
+  const override = env[competitorProfile.toolchainPathEnvKey];
+  return {
+    path: override
+      ? resolve(override)
+      : resolveHarnessCompetitorToolchainPath(runRoot, competitorProfile),
+    prepare: competitorProfile.prepareToolchain,
+  };
 }
 
 export function resolveHarnessMakaNodeToolchain(runRoot, env = process.env) {
@@ -1178,13 +1173,7 @@ async function runLocked({
               ...runnerOptions,
               agent: profile.id,
               agentVersion: profile.version,
-              ...(profile.id === 'kimi-code'
-                ? { kimiCodeToolchainPath: toolchain.path }
-                : profile.id === 'opencode'
-                  ? { opencodeToolchainPath: toolchain.path }
-                  : profile.id === 'codex'
-                    ? { codexToolchainPath: toolchain.path }
-                    : { claudeCodeToolchainPath: toolchain.path }),
+              [profile.runnerToolchainOption]: toolchain.path,
             }),
           };
         }),

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -47,6 +47,7 @@
     "#kimi-code-toolchain": "./dist/kimi-code-toolchain.js",
     "#codex-toolchain": "./dist/codex-toolchain.js",
     "#claude-code-toolchain": "./dist/claude-code-toolchain.js",
+    "#reasonix-toolchain": "./dist/reasonix-toolchain.js",
     "#maka-node-toolchain": "./dist/maka-node-toolchain.js",
     "#codex-oauth-harness": "./dist/codex-oauth-harness.js",
     "#runtime-policy-ab-profile": "./dist/runtime-policy-ab-profile.js",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -636,6 +636,19 @@ describe('Harbor adapter contract', () => {
     assert.match(result.stdout, /claude-code adapter ok/);
   });
 
+  test('reasonix_agent.py keeps the proxy token out of its config and command line', (t: TestContext) => {
+    const result = spawnSync('python3', ['-c', pythonReasonixAdapterSmokeScript(repoRoot)], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
+      t.skip('python3 is not available');
+      return;
+    }
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /reasonix adapter ok/);
+  });
+
   test('Codex DeepSeek catalog pins the official Flash model contract', async () => {
     const catalog = JSON.parse(
       await readFile(
@@ -4007,6 +4020,249 @@ with tempfile.TemporaryDirectory() as pier_tmp:
     assert pier_cell["steps"] == 1, pier_cell
 
 print("kimi-code adapter ok")
+`;
+}
+
+function pythonReasonixAdapterSmokeScript(root: string): string {
+  return String.raw`
+import asyncio
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+root = Path(${JSON.stringify(root)})
+
+def module(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+module("harbor")
+module("harbor.agents")
+module("harbor.agents.installed")
+base_mod = module("harbor.agents.installed.base")
+
+def with_prompt_template(fn):
+    async def wrapper(self, instruction, *args, **kwargs):
+        return await fn(self, self.render_instruction(instruction), *args, **kwargs)
+    return wrapper
+
+class BaseInstalledAgent:
+    def __init__(self, logs_dir, prompt_template_path=None, version=None, extra_env=None, model_name=None, **kwargs):
+        self.logs_dir = Path(logs_dir)
+        self._prompt_template_path = Path(prompt_template_path) if prompt_template_path else None
+        self._extra_env = extra_env or {}
+        self._version = version
+        self.model_name = model_name
+        self.logger = types.SimpleNamespace(debug=lambda *args, **kwargs: None)
+
+    def _get_env(self, key):
+        return self._extra_env.get(key)
+
+    def render_instruction(self, instruction):
+        if not self._prompt_template_path:
+            return instruction
+        return self._prompt_template_path.read_text(encoding="utf-8").replace("{{ instruction }}", instruction)
+
+    async def exec_as_agent(self, environment, command, env=None, **kwargs):
+        return await environment.exec(command, env=env or {}, **kwargs)
+
+base_mod.BaseInstalledAgent = BaseInstalledAgent
+base_mod.with_prompt_template = with_prompt_template
+
+module("harbor.environments")
+env_mod = module("harbor.environments.base")
+env_mod.BaseEnvironment = object
+module("harbor.models")
+module("harbor.models.agent")
+context_mod = module("harbor.models.agent.context")
+context_mod.AgentContext = object
+
+sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
+from reasonix_agent import MakaReasonixAgent
+
+PROXY_TOKEN = "ephemeral-proxy-token"
+
+def stream(*lines):
+    return "\n".join(json.dumps(line) for line in lines) + "\n"
+
+RESULT = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": False,
+    "duration_ms": 1234,
+    "num_turns": 3,
+    "result": "done",
+    "session_id": "session-1",
+    "total_cost": 0.5,
+    "currency": "CNY",
+    "usage": {"input_tokens": 10, "output_tokens": 20},
+}
+
+STREAM = stream(
+    {"kind": "turn_started"},
+    {"kind": "tool_dispatch", "tool": {"name": "bash", "args": "ls"}},
+    {"kind": "tool_result", "tool": {"name": "bash", "output": "ok"}},
+    {"kind": "tool_dispatch", "tool": {"name": "bash", "args": "pwd"}},
+    {"kind": "tool_dispatch", "tool": {"name": "edit", "args": "main.go"}},
+    {"kind": "turn_done", "outcome": "ok"},
+    RESULT,
+)
+
+with tempfile.TemporaryDirectory() as tmp:
+    logs = Path(tmp)
+    template = logs / "prompt.j2"
+    template.write_text("templated: {{ instruction }}", encoding="utf-8")
+    commands = []
+
+    class Environment:
+        def __init__(self):
+            self.downloads = []
+
+        async def exec(self, command, env=None, **kwargs):
+            commands.append((command, env or {}))
+            if "--output-format stream-json" in command:
+                identity = logs / "maka-cell-execution-identity.json"
+                assert identity.exists(), "execution identity must be durable before sampling"
+                (logs / "reasonix.jsonl").write_text(STREAM, encoding="utf-8")
+            return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+
+        async def download_file(self, remote, local):
+            self.downloads.append(remote)
+
+    agent = MakaReasonixAgent(
+        logs,
+        prompt_template_path=template,
+        version="1.19.4",
+        model_name="deepseek-v4-flash",
+        extra_env={
+            "MAKA_REASONIX_TOOLCHAIN_FINGERPRINT": "sha256:" + "a" * 64,
+            "MAKA_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
+            "MAKA_PROVIDER_PROXY_TOKEN": PROXY_TOKEN,
+            "MAKA_MODEL": "deepseek-v4-flash",
+            "MAKA_LLM_CONNECTION_SLUG": "deepseek",
+            "MAKA_REASONING_EFFORT": "max",
+            "MAKA_SYSTEM_PROMPT": "",
+            "MAKA_TRIAL_PRICING_SOURCE": "deepseek-official",
+        },
+    )
+    environment = Environment()
+    asyncio.run(agent.install(environment))
+    install_command, install_env = commands[0]
+    assert "sha256sum --check" in install_command, install_command
+    assert "/opt/maka-reasonix-toolchain/bin/node" in install_command, install_command
+    assert install_env["MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT"] == "sha256:" + "a" * 64, install_env
+
+    asyncio.run(agent.run("hi", environment, object()))
+    # Harbor mounted path: the stream-json already landed host-side, so the
+    # adapter must not race the mount with a re-download.
+    assert environment.downloads == [], environment.downloads
+    run_command, run_env = commands[-1]
+    assert "/opt/maka-reasonix-toolchain/bin/reasonix run --auto" in run_command, run_command
+    assert "--model maka-proxy/deepseek-v4-flash" in run_command, run_command
+    assert "--effort max" in run_command, run_command
+    assert "--output-format stream-json" in run_command, run_command
+    assert "--events-jsonl" not in run_command, run_command
+    assert "templated: hi" in run_command, run_command
+    # The provider route lives in an isolated Reasonix home, never in the task
+    # workspace where the agent under test could read or rewrite it.
+    assert "/tmp/maka-reasonix/config.toml" in run_command, run_command
+    assert "reasonix.toml" not in run_command, run_command
+    assert 'api_key_env = "MAKA_REASONIX_PROXY_TOKEN"' in run_command, run_command
+    assert 'base_url = "http://host.docker.internal:43210"' in run_command, run_command
+    # Secret boundary: the cell-scoped proxy token exists only in the process
+    # environment — never the command line, never the generated config.
+    assert PROXY_TOKEN not in run_command, run_command
+    assert run_env["MAKA_REASONIX_PROXY_TOKEN"] == PROXY_TOKEN, run_env
+    assert run_env["REASONIX_HOME"] == "/tmp/maka-reasonix", run_env
+    assert PROXY_TOKEN not in agent._config_toml(), agent._config_toml()
+
+    agent.populate_context_post_run(object())
+    cell = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+    assert cell["status"] == "completed", cell
+    assert cell["executionIdentity"]["model"] == "deepseek-v4-flash", cell
+    assert cell["executionIdentity"]["reasoningEffort"] == "max", cell
+    assert cell["executionIdentity"]["agentTools"] is False, cell
+    assert cell["runtimeRefs"]["sessionId"] == "session-1", cell
+    assert cell["steps"] == 3, cell
+    # tool_result and tool_progress echo a dispatched call and must not inflate
+    # the count that the report compares across arms.
+    assert cell["toolSummary"]["actualToolCallCounts"] == {"bash": 2, "edit": 1}, cell
+    assert cell["toolSummary"]["actualToolCalls"] == 3, cell
+    assert "tokenSummary" not in cell, cell
+
+    def assert_invalid_stream(raw, expected):
+        (logs / "reasonix.jsonl").write_text(raw, encoding="utf-8")
+        try:
+            agent.populate_context_post_run(object())
+        except ValueError as error:
+            assert expected in str(error), error
+        else:
+            raise AssertionError(f"invalid stream was accepted: {raw!r}")
+
+    assert_invalid_stream("", "result object")
+    assert_invalid_stream("{not-json}\n", "valid JSON")
+    assert_invalid_stream("[]\n", "JSON object")
+    assert_invalid_stream(stream({"kind": "turn_done"}), "result object")
+
+    # A run that reports its own failure stays failed even on a zero exit code,
+    # and lands in harbor-failure-policy's agent-incomplete class rather than
+    # inflating the infrastructure-failure count.
+    failing = dict(RESULT, is_error=True, subtype="error_during_execution")
+    (logs / "reasonix.jsonl").write_text(stream(failing), encoding="utf-8")
+    agent.populate_context_post_run(object())
+    self_reported = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+    assert self_reported["status"] == "failed", self_reported
+    assert self_reported["errorClass"] == "runtime_error", self_reported
+
+    agent._failure_class = "auth"
+    (logs / "reasonix.jsonl").write_text("", encoding="utf-8")
+    agent.populate_context_post_run(object())
+    failed = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+    assert failed["status"] == "failed", failed
+    assert failed["errorClass"] == "auth", failed
+
+# Pier custom-mounts path: --mounts-json replaces the default log mounts while
+# capabilities.mounted stays true, so pier's own log download never runs and
+# the CLI's stream-json exists only in the container. The adapter must download
+# it itself, or _events(require_result=True) raises and a real token-burning
+# run is misclassified as infra.
+with tempfile.TemporaryDirectory() as pier_tmp:
+    pier_logs = Path(pier_tmp)
+
+    class PierEnvironment:
+        def __init__(self):
+            self.downloads = []
+
+        async def exec(self, command, env=None, **kwargs):
+            return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+
+        async def download_file(self, remote, local):
+            self.downloads.append(remote)
+            Path(local).write_text(stream(RESULT), encoding="utf-8")
+
+    pier_agent = MakaReasonixAgent(
+        pier_logs,
+        version="1.19.4",
+        model_name="deepseek-v4-flash",
+        extra_env={
+            "MAKA_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
+            "MAKA_PROVIDER_PROXY_TOKEN": PROXY_TOKEN,
+            "MAKA_MODEL": "deepseek-v4-flash",
+            "MAKA_SYSTEM_PROMPT": "",
+        },
+    )
+    pier_environment = PierEnvironment()
+    asyncio.run(pier_agent.run("hi", pier_environment, object()))
+    assert "/logs/agent/reasonix.jsonl" in pier_environment.downloads, pier_environment.downloads
+    pier_agent.populate_context_post_run(object())
+    pier_cell = json.loads((pier_logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+    assert pier_cell["status"] == "completed", pier_cell
+    assert pier_cell["steps"] == 3, pier_cell
+
+print("reasonix adapter ok")
 `;
 }
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -4172,12 +4172,23 @@ with tempfile.TemporaryDirectory() as tmp:
     assert "reasonix.toml" not in run_command, run_command
     assert 'api_key_env = "MAKA_REASONIX_PROXY_TOKEN"' in run_command, run_command
     assert 'base_url = "http://host.docker.internal:43210"' in run_command, run_command
-    # Secret boundary: the cell-scoped proxy token exists only in the process
-    # environment — never the command line, never the generated config.
+    # Reasonix resolves api_key_env from its own credential store rather than
+    # the process environment, so the token has to reach $REASONIX_HOME/.env.
+    # It must get there by shell expansion of the env var, never by
+    # interpolating the value into the command.
+    assert "/tmp/maka-reasonix/.env" in run_command, run_command
+    assert '"$MAKA_REASONIX_PROXY_TOKEN"' in run_command, run_command
+    # umask must precede every write so the credential file is never even
+    # momentarily group- or world-readable.
+    assert run_command.index("umask 077") < run_command.index("/tmp/maka-reasonix/.env"), run_command
+    # Secret boundary: the token value never appears in the command line (and so
+    # never in the process table or Harbor's command logs) nor in the config.
     assert PROXY_TOKEN not in run_command, run_command
+    assert PROXY_TOKEN not in agent._config_toml(), agent._config_toml()
     assert run_env["MAKA_REASONIX_PROXY_TOKEN"] == PROXY_TOKEN, run_env
     assert run_env["REASONIX_HOME"] == "/tmp/maka-reasonix", run_env
-    assert PROXY_TOKEN not in agent._config_toml(), agent._config_toml()
+    # The credential file lives in the isolated home, never the task workspace.
+    assert "/tmp/maka-reasonix/" in run_command, run_command
 
     agent.populate_context_post_run(object())
     cell = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -4081,7 +4081,7 @@ context_mod = module("harbor.models.agent.context")
 context_mod.AgentContext = object
 
 sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
-from reasonix_agent import MakaReasonixAgent
+from reasonix_agent import MakaReasonixAgent, _classify_failure as _classify_from_harbor_text
 
 PROXY_TOKEN = "ephemeral-proxy-token"
 
@@ -4218,16 +4218,56 @@ with tempfile.TemporaryDirectory() as tmp:
     assert_invalid_stream("[]\n", "JSON object")
     assert_invalid_stream(stream({"kind": "turn_done"}), "result object")
 
-    # A run that reports its own failure stays failed even on a zero exit code,
-    # and lands in harbor-failure-policy's agent-incomplete class rather than
-    # inflating the infrastructure-failure count.
-    failing = dict(RESULT, is_error=True, subtype="error_during_execution")
+    # Reasonix binds its verdict to its exit code: error_during_execution always
+    # exits 1 (internal/cli/run_completion.go), so the real failure path always
+    # arrives with run() having raised. The stream's verdict must still win, or
+    # every genuine agent failure is classified infra_failed, drops out of the
+    # scored denominator, and silently biases the comparison toward Reasonix.
+    failing = dict(RESULT, is_error=True, subtype="error_during_execution",
+                   result="the model gave up after 40 turns")
     (logs / "reasonix.jsonl").write_text(stream(failing), encoding="utf-8")
+    agent._failure_class = "infra_failed"
     agent.populate_context_post_run(object())
     self_reported = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
     assert self_reported["status"] == "failed", self_reported
     assert self_reported["errorClass"] == "runtime_error", self_reported
 
+    # Harbor's exception text embeds the whole command line, hence the task
+    # instruction; a task about network sockets must not be misread as an
+    # infrastructure fault when Reasonix itself said the agent failed.
+    del agent._failure_class
+    agent._failure_class = _classify_from_harbor_text(
+        "Command failed (exit 1): reasonix run ... 'debug the socket connection timeout'"
+    )
+    assert agent._failure_class == "network", agent._failure_class
+    agent.populate_context_post_run(object())
+    noisy = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+    assert noisy["errorClass"] == "runtime_error", noisy
+
+    # An unknown future subtype must fail safe toward the scored class rather
+    # than silently shrinking the denominator.
+    unknown = dict(RESULT, is_error=True, subtype="some_future_subtype", result="")
+    (logs / "reasonix.jsonl").write_text(stream(unknown), encoding="utf-8")
+    agent.populate_context_post_run(object())
+    assert json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))["errorClass"] == "runtime_error"
+
+    # A real infrastructure fault named by the stream itself still classifies as
+    # infrastructure, so an auth or rate-limit failure is not scored as a loss.
+    for message, expected in [
+        ("provider returned 401 unauthorized", "auth"),
+        ("429 rate limit exceeded", "rate_limit"),
+        ("upstream 503 unavailable", "provider_unavailable"),
+    ]:
+        (logs / "reasonix.jsonl").write_text(
+            stream(dict(RESULT, is_error=True, subtype="error_during_execution", result=message)),
+            encoding="utf-8",
+        )
+        agent.populate_context_post_run(object())
+        cell_out = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+        assert cell_out["errorClass"] == expected, (message, cell_out)
+
+    # With no stream at all there is no verdict to trust, so the exception-derived
+    # class stands.
     agent._failure_class = "auth"
     (logs / "reasonix.jsonl").write_text("", encoding="utf-8")
     agent.populate_context_post_run(object())

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -4257,12 +4257,18 @@ with tempfile.TemporaryDirectory() as tmp:
     agent.populate_context_post_run(object())
     assert json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))["errorClass"] == "runtime_error"
 
-    # A real infrastructure fault named by the stream itself still classifies as
-    # infrastructure, so an auth or rate-limit failure is not scored as a loss.
-    for message, expected in [
-        ("provider returned 401 unauthorized", "auth"),
-        ("429 rate limit exceeded", "rate_limit"),
-        ("upstream 503 unavailable", "provider_unavailable"),
+    # A run that wrote a terminal result reached the model and burned tokens, so
+    # it stays a scored agent outcome however the message reads. Re-scanning that
+    # prose for infrastructure markers would reintroduce the very coincidence the
+    # override exists to defeat: a task about sockets, or a model that narrates
+    # "the connection kept dropping", would drop the cell out of the denominator.
+    # Over-counting an agent loss is the honest direction; shrinking the
+    # denominator is not.
+    for message in [
+        "provider returned 401 unauthorized",
+        "429 rate limit exceeded",
+        "upstream 503 unavailable",
+        "the connection to the test service kept dropping",
     ]:
         (logs / "reasonix.jsonl").write_text(
             stream(dict(RESULT, is_error=True, subtype="error_during_execution", result=message)),
@@ -4270,7 +4276,12 @@ with tempfile.TemporaryDirectory() as tmp:
         )
         agent.populate_context_post_run(object())
         cell_out = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
-        assert cell_out["errorClass"] == expected, (message, cell_out)
+        assert cell_out["errorClass"] == "runtime_error", (message, cell_out)
+
+    # The marker scan survives for the one path that has no verdict to trust:
+    # a run that died before writing a terminal result.
+    assert _classify_from_harbor_text("provider returned 401 unauthorized") == "auth"
+    assert _classify_from_harbor_text("boom") == "infra_failed"
 
     # With no stream at all there is no verdict to trust, so the exception-derived
     # class stands.
@@ -4281,15 +4292,14 @@ with tempfile.TemporaryDirectory() as tmp:
     assert failed["status"] == "failed", failed
     assert failed["errorClass"] == "auth", failed
 
-# Pier custom-mounts path: --mounts-json replaces the default log mounts while
-# capabilities.mounted stays true, so pier's own log download never runs and
-# the CLI's stream-json exists only in the container. The adapter must download
-# it itself, or _events(require_result=True) raises and a real token-burning
-# run is misclassified as infra.
+# Unmounted-log-dir path: when the executor does not bind-mount the agent log
+# dir, the CLI's stream-json exists only in the container. The adapter must
+# download it itself, or _events(require_result=True) raises and a real
+# token-burning run is misclassified as infra.
 with tempfile.TemporaryDirectory() as pier_tmp:
     pier_logs = Path(pier_tmp)
 
-    class PierEnvironment:
+    class UnmountedLogsEnvironment:
         def __init__(self):
             self.downloads = []
 
@@ -4311,7 +4321,7 @@ with tempfile.TemporaryDirectory() as pier_tmp:
             "MAKA_SYSTEM_PROMPT": "",
         },
     )
-    pier_environment = PierEnvironment()
+    pier_environment = UnmountedLogsEnvironment()
     asyncio.run(pier_agent.run("hi", pier_environment, object()))
     assert "/logs/agent/reasonix.jsonl" in pier_environment.downloads, pier_environment.downloads
     pier_agent.populate_context_post_run(object())

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -4172,6 +4172,12 @@ with tempfile.TemporaryDirectory() as tmp:
     assert "reasonix.toml" not in run_command, run_command
     assert 'api_key_env = "MAKA_REASONIX_PROXY_TOKEN"' in run_command, run_command
     assert 'base_url = "http://host.docker.internal:43210"' in run_command, run_command
+    # Reasonix's default bash = "enforce" refuses to run bash at all when no OS
+    # sandbox is present, and Terminal-Bench images have no bubblewrap. Without
+    # this the arm silently loses its shell and can only write scripts it cannot
+    # run, which measures the image rather than the agent.
+    assert "[sandbox]" in run_command, run_command
+    assert 'bash = "off"' in run_command, run_command
     # Reasonix resolves api_key_env from its own credential store rather than
     # the process environment, so the token has to reach $REASONIX_HOME/.env.
     # It must get there by shell expansion of the env var, never by

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -20,6 +20,7 @@ import {
   type HarborRunResult,
 } from '../harbor-task-runner.js';
 import {
+  harnessAgentImportPath,
   providerProxyClientAuthMode,
   providerProxyClientBaseUrl,
   providerProxyUpstreamAuthMode,
@@ -31,6 +32,7 @@ import {
   CLAUDE_CODE_TOOLCHAIN_FINGERPRINT,
   CLAUDE_CODE_TOOLCHAIN_SPEC,
 } from '../claude-code-toolchain.js';
+import { REASONIX_TOOLCHAIN_FINGERPRINT, REASONIX_TOOLCHAIN_SPEC } from '../reasonix-toolchain.js';
 
 function cellOutput(overrides: Partial<HarborCellOutput> = {}): HarborCellOutput {
   return {
@@ -104,6 +106,16 @@ test('DeepSeek routes each CLI through its native wire protocol', () => {
     providerProxyClientBaseUrl('https://proxy.invalid/lease', 'claude-code', 'deepseek'),
     'https://proxy.invalid/lease/anthropic',
   );
+  // Reasonix speaks DeepSeek's OpenAI-compatible wire natively, so it needs no
+  // agent-specific auth, usage, or base-URL branch — only the registry entry.
+  assert.equal(providerProxyUsageProtocol('reasonix', 'deepseek'), 'openai-chat-sse');
+  assert.equal(providerProxyClientAuthMode('reasonix', 'deepseek'), 'bearer');
+  assert.equal(providerProxyUpstreamAuthMode('reasonix', 'deepseek'), 'bearer');
+  assert.equal(
+    providerProxyClientBaseUrl('https://proxy.invalid/lease', 'reasonix', 'deepseek'),
+    'https://proxy.invalid/lease',
+  );
+  assert.equal(harnessAgentImportPath('reasonix'), 'reasonix_agent:MakaReasonixAgent');
 });
 
 interface FakeOptions {
@@ -2434,6 +2446,70 @@ describe('buildHarborJobConfig', () => {
     );
     assert.equal(env.KIMI_API_KEY, undefined);
     assert.equal(env.ANTHROPIC_API_KEY, undefined);
+  });
+
+  test('pins the Reasonix adapter and official toolchain without serializing credentials', () => {
+    const config = buildHarborJobConfig(runInput(), {
+      makaRepoPath: '/repo',
+      jobsDir: '/jobs/x',
+      jobName: 'trial',
+      agent: 'reasonix',
+      model: 'deepseek/deepseek-v4-flash',
+      provider: 'deepseek',
+      reasoningEffort: 'max',
+      agentVersion: REASONIX_TOOLCHAIN_SPEC.reasonix.version,
+      reasonixToolchainPath: '/cache/reasonix-1.19.4-linux-x64',
+      dockerPlatform: 'linux/amd64',
+    });
+    const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
+    const env = agent.env as Record<string, string>;
+    const mounts = (config.environment as { mounts: Array<Record<string, unknown>> }).mounts;
+
+    assert.equal(agent.import_path, 'reasonix_agent:MakaReasonixAgent');
+    assert.equal(agent.model_name, 'deepseek-v4-flash');
+    assert.deepEqual(agent.kwargs, { version: REASONIX_TOOLCHAIN_SPEC.reasonix.version });
+    assert.equal(env.MAKA_REASONIX_TOOLCHAIN_FINGERPRINT, REASONIX_TOOLCHAIN_FINGERPRINT);
+    assert.equal(env.MAKA_REASONING_EFFORT, 'max');
+    assert.ok(
+      mounts.some(
+        (mount) =>
+          mount.source === '/cache/reasonix-1.19.4-linux-x64' &&
+          mount.target === '/opt/maka-reasonix-toolchain' &&
+          mount.read_only === true,
+      ),
+    );
+    assert.equal(env.DEEPSEEK_API_KEY, undefined);
+    assert.equal(env.MAKA_REASONIX_PROXY_TOKEN, undefined);
+  });
+
+  test('refuses a Reasonix arm whose adapter version drifts from the pinned toolchain', () => {
+    assert.throws(
+      () =>
+        buildHarborJobConfig(runInput(), {
+          makaRepoPath: '/repo',
+          jobsDir: '/jobs/x',
+          jobName: 'trial',
+          agent: 'reasonix',
+          model: 'deepseek/deepseek-v4-flash',
+          provider: 'deepseek',
+          agentVersion: '1.19.3',
+          reasonixToolchainPath: '/cache/reasonix-1.19.4-linux-x64',
+        }),
+      /Reasonix adapter version must match toolchain version 1\.19\.4/,
+    );
+    assert.throws(
+      () =>
+        buildHarborJobConfig(runInput(), {
+          makaRepoPath: '/repo',
+          jobsDir: '/jobs/x',
+          jobName: 'trial',
+          agent: 'reasonix',
+          model: 'deepseek/deepseek-v4-flash',
+          provider: 'deepseek',
+          agentVersion: REASONIX_TOOLCHAIN_SPEC.reasonix.version,
+        }),
+      /reasonixToolchainPath is required for the Reasonix adapter/,
+    );
   });
 
   test('pins the Codex adapter and toolchain behind the host provider proxy', () => {

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -780,6 +780,58 @@ test('harness composition preserves historical manifest fingerprints', async () 
   }
 });
 
+test('Reasonix comparison freezes the DeepSeek runtime, toolchain, and run identity', async () => {
+  const {
+    buildHarnessAbManifest,
+    buildHarnessExecutionProfile,
+    resolveHarnessAbRunId,
+    resolveHarnessComposition,
+    resolveHarnessCompetitorToolchain,
+    resolveHarnessCompetitorToolchainPath,
+  } = await import(new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href);
+  const composition = resolveHarnessComposition({ competitor: 'reasonix' });
+  const { competitorProfile, runtimeProfile } = composition;
+  // The competitor axis alone selects the DeepSeek runtime; both arms then
+  // share one model, effort, pricing source, and execution policy.
+  assert.equal(runtimeProfile.id, 'deepseek-v4-flash-max');
+  const manifest = buildHarnessAbManifest({
+    subjectFingerprint: 'subject',
+    taskSourceFingerprint: 'tasks',
+    toolchainFingerprint: 'tools',
+    composition,
+  });
+  assert.deepEqual(manifest.metadata.model, {
+    provider: 'deepseek',
+    id: 'deepseek-v4-flash',
+    reasoningEffort: 'max',
+  });
+  assert.equal(manifest.arms[0].id, 'maka');
+  assert.equal(manifest.arms[1].id, 'reasonix');
+  assert.equal(manifest.arms[1].metadata.config.adapter, 'reasonix_agent:MakaReasonixAgent');
+  assert.equal(manifest.arms[1].metadata.config.billingMode, 'metered');
+  assert.equal(manifest.metadata.pricing.source, runtimeProfile.pricing.source);
+  assert.equal(
+    resolveHarnessAbRunId(composition),
+    'deepseek-v4-flash-maka-vs-reasonix-tbench-2.1-full-v1',
+  );
+  assert.match(
+    resolveHarnessCompetitorToolchainPath('/run', competitorProfile),
+    new RegExp(
+      `reasonix-1\\.19\\.4-${competitorProfile.toolchainFingerprint.slice(7, 19)}-linux-x64$`,
+    ),
+  );
+  const toolchain = resolveHarnessCompetitorToolchain('/run', competitorProfile, {
+    MAKA_HARNESS_AB_REASONIX_TOOLCHAIN: '/prepared/reasonix',
+  });
+  assert.equal(toolchain.path, '/prepared/reasonix');
+  assert.equal(toolchain.prepare.name, 'prepareReasonixToolchain');
+  assert.equal(competitorProfile.runnerToolchainOption, 'reasonixToolchainPath');
+  assert.equal(
+    buildHarnessExecutionProfile(runtimeProfile).modelSpec,
+    'deepseek/deepseek-v4-flash',
+  );
+});
+
 test('Codex comparison freezes the OpenAI model, pricing, and run identity', async () => {
   const {
     buildHarnessAbManifest,

--- a/packages/headless/src/__tests__/reasonix-toolchain.test.ts
+++ b/packages/headless/src/__tests__/reasonix-toolchain.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { REASONIX_TOOLCHAIN_FINGERPRINT, REASONIX_TOOLCHAIN_SPEC } from '../reasonix-toolchain.js';
+
+describe('Reasonix toolchain', () => {
+  test('binds the fingerprint to the extracted binaries and rejects a self-signed cache', async () => {
+    assert.equal(
+      (REASONIX_TOOLCHAIN_SPEC.node as { binarySha256?: string }).binarySha256,
+      '93956de2e59480474a7b46571da1651180b1a050cdf32641ebec4ce6e478e068',
+    );
+    assert.equal(
+      (REASONIX_TOOLCHAIN_SPEC.reasonix as { binarySha256?: string }).binarySha256,
+      'f2840b5e8401d45f809dceaaea9b4540c2a946c79dcd640d2db7a79021c8a474',
+    );
+    const root = await mkdtemp(join(tmpdir(), 'maka-reasonix-toolchain-'));
+    try {
+      const binDir = join(root, 'bin');
+      await mkdir(binDir);
+      await writeFile(join(binDir, 'node'), 'pinned node\n');
+      await writeFile(join(binDir, 'reasonix'), 'pinned reasonix\n');
+      await chmod(join(binDir, 'node'), 0o755);
+      await chmod(join(binDir, 'reasonix'), 0o755);
+      const files = {
+        'bin/node': sha256('pinned node\n'),
+        'bin/reasonix': sha256('pinned reasonix\n'),
+      };
+      await writeFile(
+        join(root, 'manifest.json'),
+        `${JSON.stringify(
+          {
+            schemaVersion: 1,
+            fingerprint: REASONIX_TOOLCHAIN_FINGERPRINT,
+            spec: REASONIX_TOOLCHAIN_SPEC,
+            files,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      await writeFile(
+        join(root, 'checksums.sha256'),
+        Object.entries(files)
+          .map(([path, hash]) => `${hash}  ${path}\n`)
+          .join(''),
+      );
+
+      const { validatePreparedReasonixToolchain } = await import('../reasonix-toolchain.js');
+      await assert.rejects(validatePreparedReasonixToolchain(root), /bin\/node SHA-256 mismatch/);
+      assert.match(await readFile(join(root, 'manifest.json'), 'utf8'), /1\.19\.4/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}

--- a/packages/headless/src/__tests__/reasonix-toolchain.test.ts
+++ b/packages/headless/src/__tests__/reasonix-toolchain.test.ts
@@ -51,6 +51,24 @@ describe('Reasonix toolchain', () => {
       const { validatePreparedReasonixToolchain } = await import('../reasonix-toolchain.js');
       await assert.rejects(validatePreparedReasonixToolchain(root), /bin\/node SHA-256 mismatch/);
       assert.match(await readFile(join(root, 'manifest.json'), 'utf8'), /1\.19\.4/);
+
+      // A cache prepared under a different spec must be refused before its own
+      // checksums are consulted, or a stale toolchain silently passes off as
+      // this one and the arms stop being comparable.
+      await writeFile(
+        join(root, 'manifest.json'),
+        `${JSON.stringify(
+          {
+            schemaVersion: 1,
+            fingerprint: `sha256:${'0'.repeat(64)}`,
+            spec: REASONIX_TOOLCHAIN_SPEC,
+            files,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      await assert.rejects(validatePreparedReasonixToolchain(root), /fingerprint mismatch/);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -83,6 +83,65 @@ export { MAKA_SETTLEMENT_GRACE_SEC } from './maka-settlement.js';
 const execFileAsync = promisify(execFile);
 
 const CONTAINER_MAKA_REPO = '/opt/maka-agent';
+
+/**
+ * Every competitor arm is pinned the same way: a prepared toolchain directory
+ * bind-mounted read-only, a version that must match the pinned spec, and a
+ * fingerprint the in-container adapter re-verifies before it runs. Only Maka
+ * runs from the repo mount, so it has no entry.
+ */
+const COMPETITOR_TOOLCHAINS: Partial<
+  Record<
+    HarnessAgentId,
+    {
+      readonly label: string;
+      readonly optionKey: keyof Pick<
+        HarborTaskRunnerOptions,
+        | 'opencodeToolchainPath'
+        | 'kimiCodeToolchainPath'
+        | 'codexToolchainPath'
+        | 'claudeCodeToolchainPath'
+      >;
+      readonly version: string;
+      readonly containerPath: string;
+      readonly fingerprint: string;
+      readonly fingerprintEnvKey: string;
+    }
+  >
+> = {
+  opencode: {
+    label: 'OpenCode',
+    optionKey: 'opencodeToolchainPath',
+    version: OPENCODE_TOOLCHAIN_SPEC.opencode.version,
+    containerPath: OPENCODE_TOOLCHAIN_CONTAINER_PATH,
+    fingerprint: OPENCODE_TOOLCHAIN_FINGERPRINT,
+    fingerprintEnvKey: 'MAKA_OPENCODE_TOOLCHAIN_FINGERPRINT',
+  },
+  'kimi-code': {
+    label: 'Kimi Code',
+    optionKey: 'kimiCodeToolchainPath',
+    version: KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.version,
+    containerPath: KIMI_CODE_TOOLCHAIN_CONTAINER_PATH,
+    fingerprint: KIMI_CODE_TOOLCHAIN_FINGERPRINT,
+    fingerprintEnvKey: 'MAKA_KIMI_CODE_TOOLCHAIN_FINGERPRINT',
+  },
+  codex: {
+    label: 'Codex',
+    optionKey: 'codexToolchainPath',
+    version: CODEX_TOOLCHAIN_SPEC.codex.version,
+    containerPath: CODEX_TOOLCHAIN_CONTAINER_PATH,
+    fingerprint: CODEX_TOOLCHAIN_FINGERPRINT,
+    fingerprintEnvKey: 'MAKA_CODEX_TOOLCHAIN_FINGERPRINT',
+  },
+  'claude-code': {
+    label: 'Claude Code',
+    optionKey: 'claudeCodeToolchainPath',
+    version: CLAUDE_CODE_TOOLCHAIN_SPEC.claudeCode.version,
+    containerPath: CLAUDE_CODE_TOOLCHAIN_CONTAINER_PATH,
+    fingerprint: CLAUDE_CODE_TOOLCHAIN_FINGERPRINT,
+    fingerprintEnvKey: 'MAKA_CLAUDE_CODE_TOOLCHAIN_FINGERPRINT',
+  },
+};
 const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
 const TRIAL_EXECUTION_IDENTITY = 'agent/maka-cell-execution-identity.json';
 const TRIAL_USAGE_CHECKPOINT = 'agent/maka-cell-usage-checkpoint.json';
@@ -1010,83 +1069,30 @@ export function buildHarborJobConfig(
   const makaModel = modelIdForProvider(options.model, provider);
   const adapter = options.agent ?? 'maka';
   const agentModel = adapter === 'opencode' ? modelForOpenCode(options.model, provider) : makaModel;
-  if (adapter === 'opencode' && !options.opencodeToolchainPath) {
-    throw new Error('opencodeToolchainPath is required for the OpenCode adapter');
-  }
-  if (adapter === 'opencode' && options.agentVersion !== OPENCODE_TOOLCHAIN_SPEC.opencode.version) {
-    throw new Error(
-      `OpenCode adapter version must match toolchain version ${OPENCODE_TOOLCHAIN_SPEC.opencode.version}`,
-    );
-  }
-  if (adapter === 'kimi-code' && !options.kimiCodeToolchainPath) {
-    throw new Error('kimiCodeToolchainPath is required for the Kimi Code adapter');
-  }
-  if (
-    adapter === 'kimi-code' &&
-    options.agentVersion !== KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.version
-  ) {
-    throw new Error(
-      `Kimi Code adapter version must match toolchain version ${KIMI_CODE_TOOLCHAIN_SPEC.kimiCode.version}`,
-    );
-  }
-  if (adapter === 'codex' && !options.codexToolchainPath) {
-    throw new Error('codexToolchainPath is required for the Codex adapter');
-  }
-  if (adapter === 'codex' && options.agentVersion !== CODEX_TOOLCHAIN_SPEC.codex.version) {
-    throw new Error(
-      `Codex adapter version must match toolchain version ${CODEX_TOOLCHAIN_SPEC.codex.version}`,
-    );
-  }
-  if (adapter === 'claude-code' && !options.claudeCodeToolchainPath) {
-    throw new Error('claudeCodeToolchainPath is required for the Claude Code adapter');
-  }
-  if (
-    adapter === 'claude-code' &&
-    options.agentVersion !== CLAUDE_CODE_TOOLCHAIN_SPEC.claudeCode.version
-  ) {
-    throw new Error(
-      `Claude Code adapter version must match toolchain version ${CLAUDE_CODE_TOOLCHAIN_SPEC.claudeCode.version}`,
-    );
+  const toolchain = COMPETITOR_TOOLCHAINS[adapter];
+  if (toolchain) {
+    const toolchainPath = options[toolchain.optionKey];
+    if (!toolchainPath) {
+      throw new Error(`${toolchain.optionKey} is required for the ${toolchain.label} adapter`);
+    }
+    if (options.agentVersion !== toolchain.version) {
+      throw new Error(
+        `${toolchain.label} adapter version must match toolchain version ${toolchain.version}`,
+      );
+    }
   }
   const mounts: Array<Record<string, unknown>> = [
     { type: 'bind', source: options.makaRepoPath, target: CONTAINER_MAKA_REPO, read_only: true },
-    ...(adapter === 'opencode'
+    ...(toolchain
       ? [
           {
             type: 'bind',
-            source: options.opencodeToolchainPath!,
-            target: OPENCODE_TOOLCHAIN_CONTAINER_PATH,
+            source: options[toolchain.optionKey]!,
+            target: toolchain.containerPath,
             read_only: true,
           },
         ]
-      : adapter === 'kimi-code'
-        ? [
-            {
-              type: 'bind',
-              source: options.kimiCodeToolchainPath!,
-              target: KIMI_CODE_TOOLCHAIN_CONTAINER_PATH,
-              read_only: true,
-            },
-          ]
-        : adapter === 'codex'
-          ? [
-              {
-                type: 'bind',
-                source: options.codexToolchainPath!,
-                target: CODEX_TOOLCHAIN_CONTAINER_PATH,
-                read_only: true,
-              },
-            ]
-          : adapter === 'claude-code'
-            ? [
-                {
-                  type: 'bind',
-                  source: options.claudeCodeToolchainPath!,
-                  target: CLAUDE_CODE_TOOLCHAIN_CONTAINER_PATH,
-                  read_only: true,
-                },
-              ]
-            : []),
+      : []),
   ];
 
   const agentEnv: Record<string, string> = {
@@ -1102,17 +1108,8 @@ export function buildHarborJobConfig(
     agentEnv.MAKA_REASONING_EFFORT = options.reasoningEffort;
     if (adapter === 'opencode') agentEnv.MAKA_OPENCODE_VARIANT = options.reasoningEffort;
   }
-  if (adapter === 'opencode') {
-    agentEnv.MAKA_OPENCODE_TOOLCHAIN_FINGERPRINT = OPENCODE_TOOLCHAIN_FINGERPRINT;
-  }
-  if (adapter === 'kimi-code') {
-    agentEnv.MAKA_KIMI_CODE_TOOLCHAIN_FINGERPRINT = KIMI_CODE_TOOLCHAIN_FINGERPRINT;
-  }
-  if (adapter === 'codex') {
-    agentEnv.MAKA_CODEX_TOOLCHAIN_FINGERPRINT = CODEX_TOOLCHAIN_FINGERPRINT;
-  }
-  if (adapter === 'claude-code') {
-    agentEnv.MAKA_CLAUDE_CODE_TOOLCHAIN_FINGERPRINT = CLAUDE_CODE_TOOLCHAIN_FINGERPRINT;
+  if (toolchain) {
+    agentEnv[toolchain.fingerprintEnvKey] = toolchain.fingerprint;
   }
 
   if (options.pricing) {

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -75,6 +75,11 @@ import {
   CLAUDE_CODE_TOOLCHAIN_FINGERPRINT,
   CLAUDE_CODE_TOOLCHAIN_SPEC,
 } from './claude-code-toolchain.js';
+import {
+  REASONIX_TOOLCHAIN_CONTAINER_PATH,
+  REASONIX_TOOLCHAIN_FINGERPRINT,
+  REASONIX_TOOLCHAIN_SPEC,
+} from './reasonix-toolchain.js';
 
 import { agentPhaseTimeoutSec, settlementGraceSec } from './maka-settlement.js';
 
@@ -101,6 +106,7 @@ const COMPETITOR_TOOLCHAINS: Partial<
         | 'kimiCodeToolchainPath'
         | 'codexToolchainPath'
         | 'claudeCodeToolchainPath'
+        | 'reasonixToolchainPath'
       >;
       readonly version: string;
       readonly containerPath: string;
@@ -140,6 +146,14 @@ const COMPETITOR_TOOLCHAINS: Partial<
     containerPath: CLAUDE_CODE_TOOLCHAIN_CONTAINER_PATH,
     fingerprint: CLAUDE_CODE_TOOLCHAIN_FINGERPRINT,
     fingerprintEnvKey: 'MAKA_CLAUDE_CODE_TOOLCHAIN_FINGERPRINT',
+  },
+  reasonix: {
+    label: 'Reasonix',
+    optionKey: 'reasonixToolchainPath',
+    version: REASONIX_TOOLCHAIN_SPEC.reasonix.version,
+    containerPath: REASONIX_TOOLCHAIN_CONTAINER_PATH,
+    fingerprint: REASONIX_TOOLCHAIN_FINGERPRINT,
+    fingerprintEnvKey: 'MAKA_REASONIX_TOOLCHAIN_FINGERPRINT',
   },
 };
 const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
@@ -236,6 +250,8 @@ export interface HarborTaskRunnerOptions {
   codexToolchainPath?: string;
   /** Prepared Claude Code native toolchain mounted read-only into task containers. */
   claudeCodeToolchainPath?: string;
+  /** Prepared Reasonix toolchain mounted read-only into task containers. */
+  reasonixToolchainPath?: string;
   /** Explicit Docker target platform shared by comparison arms. */
   dockerPlatform?: 'linux/amd64';
   /** Base directory under which each task gets an isolated per-task job dir. */

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -95,9 +95,9 @@ const CONTAINER_MAKA_REPO = '/opt/maka-agent';
  * fingerprint the in-container adapter re-verifies before it runs. Only Maka
  * runs from the repo mount, so it has no entry.
  */
-const COMPETITOR_TOOLCHAINS: Partial<
+const COMPETITOR_TOOLCHAINS: Readonly<
   Record<
-    HarnessAgentId,
+    Exclude<HarnessAgentId, 'maka'>,
     {
       readonly label: string;
       readonly optionKey: keyof Pick<
@@ -1085,7 +1085,7 @@ export function buildHarborJobConfig(
   const makaModel = modelIdForProvider(options.model, provider);
   const adapter = options.agent ?? 'maka';
   const agentModel = adapter === 'opencode' ? modelForOpenCode(options.model, provider) : makaModel;
-  const toolchain = COMPETITOR_TOOLCHAINS[adapter];
+  const toolchain = adapter === 'maka' ? undefined : COMPETITOR_TOOLCHAINS[adapter];
   if (toolchain) {
     const toolchainPath = options[toolchain.optionKey];
     if (!toolchainPath) {

--- a/packages/headless/src/harness-agent-registry.ts
+++ b/packages/headless/src/harness-agent-registry.ts
@@ -1,7 +1,13 @@
 import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core/llm-connections';
 import type { ProviderAuthProxyMode, ProviderUsageProtocol } from './provider-auth-proxy.js';
 
-export type HarnessAgentId = 'maka' | 'opencode' | 'kimi-code' | 'codex' | 'claude-code';
+export type HarnessAgentId =
+  | 'maka'
+  | 'opencode'
+  | 'kimi-code'
+  | 'codex'
+  | 'claude-code'
+  | 'reasonix';
 
 const HARNESS_AGENT_IMPORT_PATHS: Readonly<Record<HarnessAgentId, string>> = {
   maka: 'maka_agent:MakaAgent',
@@ -9,6 +15,7 @@ const HARNESS_AGENT_IMPORT_PATHS: Readonly<Record<HarnessAgentId, string>> = {
   'kimi-code': 'kimi_code_agent:MakaKimiCodeAgent',
   codex: 'codex_agent:MakaCodexAgent',
   'claude-code': 'claude_code_agent:MakaClaudeCodeAgent',
+  reasonix: 'reasonix_agent:MakaReasonixAgent',
 };
 
 export function harnessAgentImportPath(agent: HarnessAgentId): string {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -251,7 +251,7 @@ export interface PierRunResult {
 
 export type PierProcessRunner = (request: PierRunRequest) => Promise<PierRunResult>;
 
-export type PierAgent = Exclude<HarnessAgentId, 'claude-code'>;
+export type PierAgent = Exclude<HarnessAgentId, 'claude-code' | 'reasonix'>;
 
 interface PierProviderRuntime {
   /** Proxy-minted secret env delivered via `--env-file` (kept off argv). */

--- a/packages/headless/src/reasonix-toolchain.ts
+++ b/packages/headless/src/reasonix-toolchain.ts
@@ -1,0 +1,73 @@
+import { createHash } from 'node:crypto';
+import {
+  prepareNodeCliToolchain,
+  validatePreparedNodeCliToolchain,
+  type PinnedNodeCliToolchainDefinition,
+} from './node-cli-toolchain.js';
+
+export const REASONIX_TOOLCHAIN_CONTAINER_PATH = '/opt/maka-reasonix-toolchain';
+
+export const REASONIX_TOOLCHAIN_SPEC = {
+  schemaVersion: 1,
+  platform: 'linux',
+  arch: 'x64',
+  // Reasonix ships a static Go binary and never runs on Node. The pinned Node is
+  // the offline manifest verifier the container's install() step executes, the
+  // same role it plays for the prebuilt OpenCode binary.
+  node: {
+    version: '22.23.1',
+    archiveUrl: 'https://nodejs.org/dist/v22.23.1/node-v22.23.1-linux-x64.tar.gz',
+    archiveSha256: '7a8cb04b4a1df4eaf432125324b81b29a088e73570a23259a8de1c65d07fc129',
+    binarySha256: '93956de2e59480474a7b46571da1651180b1a050cdf32641ebec4ce6e478e068',
+  },
+  reasonix: {
+    version: '1.19.4',
+    archiveUrl: 'https://registry.npmjs.org/@reasonix/cli-linux-x64/-/cli-linux-x64-1.19.4.tgz',
+    archiveIntegrity:
+      'sha512-H2iktxh6obnB4iV055PFEf6oBGNN7E4zMBrT9mxA4U1udeGNVb5YOuh//wA2Oo1M8kOfxQszRVWS1ebld3dUBw==',
+    binarySha256: 'f2840b5e8401d45f809dceaaea9b4540c2a946c79dcd640d2db7a79021c8a474',
+  },
+} as const;
+
+export const REASONIX_TOOLCHAIN_FINGERPRINT = `sha256:${createHash('sha256')
+  .update(JSON.stringify(REASONIX_TOOLCHAIN_SPEC))
+  .digest('hex')}`;
+
+export interface PreparedReasonixToolchain {
+  path: string;
+  fingerprint: typeof REASONIX_TOOLCHAIN_FINGERPRINT;
+}
+
+const DEFINITION: PinnedNodeCliToolchainDefinition<typeof REASONIX_TOOLCHAIN_SPEC> = {
+  label: 'Reasonix',
+  fingerprint: REASONIX_TOOLCHAIN_FINGERPRINT,
+  spec: REASONIX_TOOLCHAIN_SPEC,
+  node: REASONIX_TOOLCHAIN_SPEC.node,
+  packageArchive: {
+    url: REASONIX_TOOLCHAIN_SPEC.reasonix.archiveUrl,
+    integrity: REASONIX_TOOLCHAIN_SPEC.reasonix.archiveIntegrity,
+  },
+  packageFiles: [
+    {
+      archivePath: 'package/bin/reasonix',
+      installedPath: 'bin/reasonix',
+      sha256: REASONIX_TOOLCHAIN_SPEC.reasonix.binarySha256,
+      executable: true,
+    },
+  ],
+};
+
+export async function validatePreparedReasonixToolchain(
+  path: string,
+): Promise<PreparedReasonixToolchain> {
+  await validatePreparedNodeCliToolchain(path, DEFINITION);
+  return { path, fingerprint: REASONIX_TOOLCHAIN_FINGERPRINT };
+}
+
+export async function prepareReasonixToolchain(
+  path: string,
+  options: { fetchFn?: typeof fetch } = {},
+): Promise<PreparedReasonixToolchain> {
+  await prepareNodeCliToolchain(path, DEFINITION, options);
+  return { path, fingerprint: REASONIX_TOOLCHAIN_FINGERPRINT };
+}


### PR DESCRIPTION
## Summary

Adds Reasonix ([esengine/DeepSeek-Reasonix](https://github.com/esengine/DeepSeek-Reasonix)) as a competitor arm so Maka can be benchmarked head-to-head on `deepseek-v4-flash`. Refs #2076.

Reasonix is DeepSeek-native, which is what makes it the closest available comparison, but the harness had no way to run it: no pinned toolchain, no Harbor adapter, no registry entry. This lands the infrastructure on the existing two-arm path rather than a new one. Scheduling, resume identity, manifests, pricing, deadline policy, verifier, and report rendering are reused unchanged; the registry needs only an id and an import path, because DeepSeek already resolves to bearer auth and `openai-chat-sse` usage.

The first commit is a no-op refactor: each pinned arm was wired by hand in five places, and the mount ternary was already four levels deep. It collapses those into one table and moves the toolchain preparer, path-override env key, and runner option onto the competitor profile, so the profile is the single source of truth instead of being re-dispatched downstream. Splitting it out keeps the behaviour-preserving change reviewable and revertable on its own.

Three decisions worth flagging:

- **Pinned Node as verifier only.** Reasonix ships a static Go binary in `@reasonix/cli-linux-x64`, whose tarball layout is identical to `opencode-linux-x64`. It reuses the shared `node-cli-toolchain` implementation, and the pinned Node next to it is only the offline manifest verifier `install()` runs — exactly the role it already plays for the prebuilt OpenCode binary. Making `node` optional in the shared implementation would not perturb existing fingerprints (each is `sha256` of its own spec constant), but it would widen the verification surface to save one cached download.
- **`stream-json`, not `--events-jsonl`.** `internal/cli/run_output.go:265-270` passes tool names through `machineOpaqueValue`, so the redacted surface aliases real tool names away. All four existing competitor arms capture their CLI's native stream, and the arms are only comparable on tool behaviour if this one does too. The secrets that need protecting — the upstream key and the proxy token — never appear in the event stream either way.
- **Pier is excluded from `PierAgent`.** Terminal-Bench runs under plain Harbor. Letting the type admit an arm that has no mount would be a half-supported state.

### Secret boundary

Reasonix has no flag or env override for a provider `base_url` (verified by grep over `internal/` and `cmd/`), so the proxy route must come from config. It is written to an isolated `$REASONIX_HOME/config.toml` rather than the task workspace, and the key is referenced indirectly through `api_key_env`.

`api_key_env` does not read the process environment: `ProviderEntry.APIKey()` resolves it through `storedCredentialValue()`, which reads `$REASONIX_HOME/.env` and nothing else (`internal/config/credentials.go:537`, `internal/config/paths.go:406`). The token therefore has to be materialised in that file. It is written under `umask 077` by shell expansion of the already-exported variable, so the value never appears in the command line, in `config.toml`, in the task workspace, or in any log. The credential proxy remains the authoritative source of token, cache, and cost evidence; Reasonix's self-reported `total_cost` is not used for settlement (its `total_cost_usd` alias is not converted when `currency` is `CNY`).

## Verification

- `npm --workspace @maka/headless run test` (clean build + full suite): 1344 tests, 0 failures. The stream-verdict fix was reverse-verified: reverting it fails the suite.
- `npm run format:check`, `npm run lint`: clean.
- The refactor commit was verified on its own before the feature was applied: 1340 tests, 0 failures — the same suite minus the four new Reasonix tests.

New coverage:

- `reasonix-toolchain.test.ts` — pins the tarball integrity and binary SHA-256, and rejects a self-signed cache.
- `harbor-adapter.test.ts` — asserts the proxy token is absent from both the command line and the generated config, that `reasonix.toml` is never written to the workspace, that `tool_result` does not inflate tool-call counts, and that a self-reported `is_error` on a zero exit code still lands as `runtime_error`.
- `harbor-task-runner.test.ts` — mount, fingerprint env, no credential serialization, and version-drift refusal.
- `harness-ab-cli.test.ts` — composition, run identity, toolchain path, and env override.

### Live smoke

One paired cell on `configure-git-webserver` (Terminal-Bench 2.1 @ `d49e28f1`), both arms on `deepseek-v4-flash` at `max`, against the real DeepSeek key through the credential proxy:

| arm | outcome | scored | tokens (cached) | cost |
| --- | --- | --- | --- | --- |
| maka | passed | yes | 136 886 (122 624) | $0.0036 |
| reasonix | passed | yes | 672 080 (653 952) | $0.0064 |

The stream parser recovered the real session id and 35 tool calls with their real names — `{bash: 23, todo_write: 5, complete_step: 5, write_file: 1, wait: 1}` — which is the evidence that `stream-json` was the right surface: `--events-jsonl` would have aliased every one of those names away.

Two live findings no static review surfaced, both fixed in this branch:

- **The proxy token never reached the CLI.** `api_key_env` is not a process-environment lookup (see above); the run died at `provider "maka-proxy/deepseek-v4-flash": missing env MAKA_REASONIX_PROXY_TOKEN`. Fixed by writing `$REASONIX_HOME/.env`.
- **Reasonix had silently disabled its own bash tool.** Its default `[sandbox] bash = "enforce"` requires an OS sandbox and refuses bash outright when none exists; Terminal-Bench images ship no `bubblewrap`. The arm spent an entire trial writing a script it could never run, and lost the cell to `verification_failed` — a defect that would have been invisible in an aggregate score and would have understated Reasonix across the board. Pinning `bash = "off"` restores it to the same tool surface as every other arm, which all run unconfined inside the container that is itself the isolation boundary.

## Remaining work

- [ ] Predeclared canary passes for both arms
- [ ] One full synchronized Terminal-Bench 2.1 run
- [ ] `docs/eval/terminal-bench-2.1-deepseek-v4-flash-maka-vs-reasonix.{md,csv}` report checked in

