### PR TITLE
fix(settings): give every section the same 920px content column

### DIFF
--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -315,7 +315,13 @@ export function SettingsSurface(props: {
             <Layout
               height="fill"
               padding={0}
-              contentWidth={section === 'usage' ? 920 : 640}
+              /* One column width for EVERY section. Usage used to get 920
+                 while the rest sat in a 640 column, so switching pages
+                 visibly shifted the left edge — the title jumped ~120px
+                 between 使用统计 and any other page. A settings surface is
+                 one place; its margins must not depend on which page is
+                 open. */
+              contentWidth={920}
               header={(
                 <LayoutHeader padding={6}>
                   <div className="settingsPageHeader">

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -43,7 +43,7 @@
    pull the page header into the same centered max-w-3xl column as the
    content. Before this, the header sat in `.settingsMainPane` padding
    (~34px from pane edge), while the row cards lived in the centered
-   640px column — the title
+   content column — the title
    and content were visibly misaligned. Drop the mainpane padding to
    thin top/bottom so the header + content can both share the centered
    column. */

--- a/apps/desktop/stories/settings/provider-settings.stories.tsx
+++ b/apps/desktop/stories/settings/provider-settings.stories.tsx
@@ -311,7 +311,7 @@ function ProviderStoryFrame(props: {
           <Layout
             height="fill"
             padding={0}
-            contentWidth={640}
+            contentWidth={920}
             header={(
               <LayoutHeader padding={6}>
                 <div className="settingsPageHeader">


### PR DESCRIPTION
## 问题
WAWQAQ 反馈（#my-ai 线程 msg 437c59c4，带截图）：大部分设置子页的左边距和「使用统计」不一致。

根因：`settings-surface.tsx` 里 `contentWidth={section === 'usage' ? 920 : 640}` —— 使用统计单独 920 宽列，其余子页 640 窄列居中，窗口一宽左缘就差 ~120px，切页时标题横跳。

## 改动
- 所有 section 统一 `contentWidth={920}`（3 行实改 + 注释）
- provider story frame 同步 920（它镜像 surface 的 Layout）
- nav-sidebar.css 里一处过期的 "640px column" 注释措辞更正

## 验证
- build / typecheck / format:check / check-dead-css / test:checks 全绿
- build-storybook + visual smoke：68 manifest checks, 73 renders 全过
- e2e 电镜实拍（1240×820）：外观 / 通用 / 权限与能力 / 使用统计 四页标题左缘完全对齐