### PR TITLE
feat(runtime-host): own Plan runtime state

### DIFF
--- a/packages/core/src/plan.ts
+++ b/packages/core/src/plan.ts
@@ -7,12 +7,41 @@ export type PlanExecutionStatus = (typeof PLAN_EXECUTION_STATUSES)[number];
 export const PLAN_STEP_STATUSES = ['pending', 'in_progress', 'completed', 'skipped'] as const;
 export type PlanStepStatus = (typeof PLAN_STEP_STATUSES)[number];
 
+export const PLAN_ENTITY_ID_MAX_CHARS = 128;
+export const PLAN_TEXT_MAX_BYTES = 16 * 1024;
+export const PLAN_LIFECYCLE_REASON_MAX_BYTES = 1024;
+export const PLAN_PROJECTION_ITEM_MAX_BYTES = 60 * 1024;
+export const PLAN_MAX_STEPS = 50;
+export const PLAN_MAX_FILES_PER_STEP = 50;
+export const PLAN_MAX_RISKS = 20;
+export const PLAN_STEP_TITLE_MAX_CHARS = 30;
+
+const PLAN_ENTITY_ID_PATTERN = new RegExp(`^[A-Za-z0-9_-]{1,${PLAN_ENTITY_ID_MAX_CHARS}}$`);
+const PLAN_TEXT_ENCODER = new TextEncoder();
+
+export function isCanonicalPlanEntityId(value: string): boolean {
+  return PLAN_ENTITY_ID_PATTERN.test(value);
+}
+
+export function planEncodedByteLength(value: unknown): number {
+  return PLAN_TEXT_ENCODER.encode(JSON.stringify(value) ?? 'null').byteLength;
+}
+
+export function isPlanTextWithinLimit(value: string, maxBytes = PLAN_TEXT_MAX_BYTES): boolean {
+  return PLAN_TEXT_ENCODER.encode(value).byteLength <= maxBytes;
+}
+
 export interface PlanStepDefinition {
   id: string;
   title: string;
   description: string;
   files?: string[];
   complexity?: 'low' | 'medium' | 'high';
+}
+
+export interface LegacyPlanProjection {
+  /** The pre-Host ledger required bounded content or identity projection. */
+  truncated: true;
 }
 
 export interface PlanProposal {
@@ -30,6 +59,7 @@ export interface PlanProposal {
   risks?: string[];
   status: PlanProposalStatus;
   submittedAt: number;
+  legacyProjection?: LegacyPlanProjection;
 }
 
 export interface PlanExecutionStep extends PlanStepDefinition {
@@ -52,6 +82,7 @@ export interface PlanExecution {
   interruptedAt?: number;
   cancelReason?: string;
   interruptionReason?: string;
+  legacyProjection?: LegacyPlanProjection;
 }
 
 export interface PlanSessionState {
@@ -66,9 +97,13 @@ export interface PlanSessionState {
 
 interface PlanEventBase {
   id: string;
+  /** Fingerprint of the mutation input used to reconcile an exact retry. */
+  operationFingerprint?: string;
   sessionId: string;
   ts: number;
   storeVersion: number;
+  /** Read-time compatibility marker; new canonical events never persist it. */
+  legacyProjection?: LegacyPlanProjection;
 }
 
 export type PlanEvent =
@@ -117,6 +152,7 @@ export type PlanEvent =
     });
 
 export interface SubmitPlanProposalInput {
+  operationId?: string;
   sessionId: string;
   turnId: string;
   title: string;
@@ -126,7 +162,61 @@ export interface SubmitPlanProposalInput {
   sourceExecutionId?: string;
 }
 
+export function isPlanProposalLifecycleAdmissible(
+  input: Pick<SubmitPlanProposalInput, 'title' | 'overview' | 'steps' | 'risks'>,
+): boolean {
+  const id = 'x'.repeat(PLAN_ENTITY_ID_MAX_CHARS);
+  const timestamp = Number.MAX_SAFE_INTEGER;
+  const proposal: PlanProposal = {
+    planId: id,
+    proposalId: id,
+    sessionId: id,
+    turnId: id,
+    revision: Number.MAX_SAFE_INTEGER,
+    supersedesProposalId: id,
+    sourceExecutionId: id,
+    title: input.title,
+    ...(input.overview ? { overview: input.overview } : {}),
+    steps: structuredClone(input.steps),
+    ...(input.risks ? { risks: structuredClone(input.risks) } : {}),
+    status: 'pending_approval',
+    submittedAt: timestamp,
+  };
+  const execution = worstCasePlanExecution(proposal, id, timestamp);
+  return (
+    planEncodedByteLength({ kind: 'proposal', proposal }) <= PLAN_PROJECTION_ITEM_MAX_BYTES &&
+    planEncodedByteLength({ kind: 'execution', execution }) <= PLAN_PROJECTION_ITEM_MAX_BYTES
+  );
+}
+
+export function worstCasePlanExecution(
+  proposal: Pick<PlanProposal, 'planId' | 'proposalId' | 'sessionId' | 'steps'>,
+  executionId: string,
+  timestamp = Number.MAX_SAFE_INTEGER,
+): PlanExecution {
+  const reason = 'x'.repeat(PLAN_LIFECYCLE_REASON_MAX_BYTES);
+  return {
+    executionId,
+    planId: proposal.planId,
+    proposalId: proposal.proposalId,
+    sessionId: proposal.sessionId,
+    status: 'cancelled',
+    steps: proposal.steps.map((step) => ({
+      ...structuredClone(step),
+      status: 'pending',
+      updatedAt: timestamp,
+    })),
+    startedAt: timestamp,
+    updatedAt: timestamp,
+    interruptedAt: timestamp,
+    interruptionReason: reason,
+    cancelledAt: timestamp,
+    cancelReason: reason,
+  };
+}
+
 export interface ApprovePlanProposalInput {
+  operationId?: string;
   sessionId: string;
   proposalId: string;
   expectedRevision: number;
@@ -134,17 +224,20 @@ export interface ApprovePlanProposalInput {
 }
 
 export interface RequestPlanRevisionInput {
+  operationId?: string;
   sessionId: string;
   proposalId: string;
 }
 
 export interface AbandonPlanProposalInput {
+  operationId?: string;
   sessionId: string;
   proposalId: string;
   reason: string;
 }
 
 export interface UpdatePlanExecutionInput {
+  operationId?: string;
   sessionId: string;
   executionId: string;
   steps: Array<{
@@ -156,6 +249,7 @@ export interface UpdatePlanExecutionInput {
 }
 
 export interface CancelPlanExecutionInput {
+  operationId?: string;
   sessionId: string;
   executionId: string;
   reason: string;
@@ -166,16 +260,100 @@ export interface PlanMutationResult {
   state: PlanSessionState;
 }
 
+export const PLAN_USER_ABANDON_REASON = 'User exited Plan Mode before approval.';
+export const PLAN_USER_CANCEL_REASON = 'User abandoned the interrupted plan.';
+
+export type PlanUserControlInput =
+  | {
+      readonly kind: 'request_revision' | 'abandon_proposal';
+      readonly sessionId: string;
+      readonly proposalId: string;
+      readonly operationId: string;
+    }
+  | {
+      readonly kind: 'approve_proposal';
+      readonly sessionId: string;
+      readonly proposalId: string;
+      readonly expectedRevision: number;
+      readonly expectedStoreVersion: number;
+      readonly operationId: string;
+    }
+  | {
+      readonly kind: 'resume_execution' | 'cancel_execution';
+      readonly sessionId: string;
+      readonly executionId: string;
+      readonly operationId: string;
+    };
+
+export function planUserControlMutationInput(
+  input: PlanUserControlInput,
+):
+  | RequestPlanRevisionInput
+  | AbandonPlanProposalInput
+  | ApprovePlanProposalInput
+  | CancelPlanExecutionInput
+  | { operationId: string; sessionId: string; executionId: string } {
+  switch (input.kind) {
+    case 'request_revision':
+      return {
+        operationId: input.operationId,
+        sessionId: input.sessionId,
+        proposalId: input.proposalId,
+      };
+    case 'abandon_proposal':
+      return {
+        operationId: input.operationId,
+        sessionId: input.sessionId,
+        proposalId: input.proposalId,
+        reason: PLAN_USER_ABANDON_REASON,
+      };
+    case 'approve_proposal':
+      return {
+        operationId: input.operationId,
+        sessionId: input.sessionId,
+        proposalId: input.proposalId,
+        expectedRevision: input.expectedRevision,
+        expectedStoreVersion: input.expectedStoreVersion,
+      };
+    case 'resume_execution':
+      return {
+        operationId: input.operationId,
+        sessionId: input.sessionId,
+        executionId: input.executionId,
+      };
+    case 'cancel_execution':
+      return {
+        operationId: input.operationId,
+        sessionId: input.sessionId,
+        executionId: input.executionId,
+        reason: PLAN_USER_CANCEL_REASON,
+      };
+  }
+}
+
 export interface PlanStore {
   readState(sessionId: string): Promise<PlanSessionState>;
+  readOperationReceipt(
+    sessionId: string,
+    operationId: string,
+    operationInput: unknown,
+  ): Promise<PlanEvent | undefined>;
   submitProposal(input: SubmitPlanProposalInput): Promise<PlanMutationResult>;
   requestRevision(input: RequestPlanRevisionInput): Promise<PlanMutationResult>;
   abandonProposal(input: AbandonPlanProposalInput): Promise<PlanMutationResult>;
   approveProposal(input: ApprovePlanProposalInput): Promise<PlanMutationResult>;
   updateExecution(input: UpdatePlanExecutionInput): Promise<PlanMutationResult>;
   cancelExecution(input: CancelPlanExecutionInput): Promise<PlanMutationResult>;
-  interruptActiveExecution(sessionId: string, reason: string): Promise<PlanMutationResult | null>;
-  resumeExecution(sessionId: string, executionId: string): Promise<PlanMutationResult>;
+  interruptActiveExecution(
+    sessionId: string,
+    reason: string,
+    operationId?: string,
+  ): Promise<PlanMutationResult | null>;
+  resumeExecution(
+    sessionId: string,
+    executionId: string,
+    operationId?: string,
+  ): Promise<PlanMutationResult>;
 }
 
 export class PlanConflictError extends Error {

--- a/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
@@ -363,7 +363,7 @@ describe('Host Automation coordinator', () => {
           ok: false,
           error: {
             code: 'operation_unavailable',
-            message: 'Plan sessions are not yet supported by Runtime Host.',
+            message: 'Automations cannot execute while the target Session is in Plan mode.',
           },
         });
         assert.deepEqual(await harness.store.read(), {

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -39,6 +39,7 @@ const allowedServerExternalImports = new Set([
   '@maka/core/model-metadata',
   '@maka/core/model-thinking',
   '@maka/core/oauth-subscription',
+  '@maka/core/plan',
   '@maka/core/redaction',
   '@maka/core/runtime-policy',
   '@maka/core/runtime-event',
@@ -61,6 +62,7 @@ const allowedServerExternalImports = new Set([
   '@maka/storage/interaction-store',
   '@maka/storage/long-term-memory-store',
   '@maka/storage/memory-bundle-store',
+  '@maka/storage/plan-authority',
   '@maka/storage/runtime-policy-stores',
   '@maka/storage/shell-run-authority',
   '@maka/storage/task-ledger-authority',
@@ -83,6 +85,7 @@ const allowedExternalImports = {
     '@maka/core/local-memory',
     '@maka/core/model-thinking',
     '@maka/core/orchestration',
+    '@maka/core/plan',
     '@maka/core/permission',
     '@maka/core/runtime-policy',
     '@maka/core/session',
@@ -199,6 +202,7 @@ test('the production Candidate dependency graph remains non-serving', () => {
         specifier === '@maka/storage/execution-stores' ||
         specifier === '@maka/storage/long-term-memory-store' ||
         specifier === '@maka/storage/memory-bundle-store' ||
+        specifier === '@maka/storage/plan-authority' ||
         specifier === '@maka/storage/runtime-policy-stores' ||
         specifier === '@maka/storage/task-ledger-authority'
       ) {

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -16,6 +16,7 @@ import {
   type RuntimeEvent,
 } from '@maka/core';
 import { createDefaultRuntimePolicy } from '@maka/core/runtime-policy';
+import type { PlanSessionState, PlanStore } from '@maka/core/plan';
 import type { TaskLedgerStore } from '@maka/core/task-ledger';
 import {
   serializeOAuthSubscriptionTokens,
@@ -1964,6 +1965,102 @@ test('Client Capability tools join the existing load_tools catalog without a par
       description: 'Loaded through the canonical tool connector.',
       toolNames: [capabilityTool.name],
     },
+  );
+});
+
+test('Plan composition admits only planning tools before approval and execution controls after', async () => {
+  const proposal = {
+    planId: 'plan-1',
+    proposalId: 'proposal-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    revision: 1,
+    title: 'Host Plan',
+    steps: [{ id: 'step-1', title: 'Implement', description: 'Implement the approved work' }],
+    status: 'pending_approval' as const,
+    submittedAt: 1,
+  };
+  const pending: PlanSessionState = {
+    schemaVersion: 1,
+    sessionId: 'session-1',
+    storeVersion: 1,
+    proposals: [proposal],
+    executions: [],
+    latestProposalId: proposal.proposalId,
+  };
+  const store = { readState: async () => pending } as unknown as PlanStore;
+  const base = {
+    policy: {
+      getSnapshot: async () => ({ revision: 0, policy: createDefaultRuntimePolicy() }),
+    },
+    skills: {
+      readCanonicalModelInventory: async () => ({ inventory: [] }),
+    } as unknown as HostSkillCatalogCoordinator,
+    memory: {
+      readPromptProjection: async () => ({
+        policy: { revision: 0, policy: createDefaultRuntimePolicy() },
+      }),
+    } as unknown as HostMemoryCoordinator,
+    taskLedger: { list: async () => [] } as unknown as TaskLedgerStore,
+  };
+  const planning = createHostExecutionModelComposition({
+    ...base,
+    plan: { store, state: pending, mode: 'plan' },
+  });
+  assert.deepEqual(planning.tools.map((tool) => tool.name).sort(), [
+    'AskUserQuestion',
+    'SubmitPlan',
+  ]);
+  assert.match(
+    (await planning.systemPrompt({
+      sessionId: 'session-1',
+      turnId: 'turn-2',
+      cwd: process.cwd(),
+      workspaceRoot: process.cwd(),
+    })) ?? '',
+    /Collaboration Mode: Plan/,
+  );
+
+  const execution = {
+    executionId: 'execution-1',
+    planId: proposal.planId,
+    proposalId: proposal.proposalId,
+    sessionId: proposal.sessionId,
+    status: 'active' as const,
+    steps: proposal.steps.map((step) => ({
+      ...step,
+      status: 'pending' as const,
+      updatedAt: 2,
+    })),
+    startedAt: 2,
+    updatedAt: 2,
+  };
+  const active: PlanSessionState = {
+    ...pending,
+    storeVersion: 2,
+    proposals: [{ ...proposal, status: 'approved' }],
+    executions: [execution],
+    activeExecutionId: execution.executionId,
+  };
+  const executing = createHostExecutionModelComposition({
+    ...base,
+    parentAgentTools: buildParentAgentTools(),
+    plan: { store, state: active, mode: 'agent' },
+  });
+  assert.ok(executing.tools.some((tool) => tool.name === 'update_plan'));
+  assert.ok(executing.tools.some((tool) => tool.name === 'cancel_plan'));
+  assert.equal(
+    executing.tools.some((tool) => tool.categoryHint === 'subagent'),
+    false,
+  );
+  assert.match(
+    await executing.turnTailPrompt({
+      sessionId: 'session-1',
+      turnId: 'turn-3',
+      cwd: process.cwd(),
+      workspaceRoot: process.cwd(),
+    }),
+    /plan_execution_context/,
   );
 });
 

--- a/packages/runtime-host/src/__tests__/plan-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/plan-protocol.test.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  decodePlanQueryResult,
+  decodeRequestFrame,
+  decodeResponseFrame,
+  HOST_OPERATION_SPECS,
+  PLAN_PAGE_MAX_ITEMS,
+} from '../protocol/index.js';
+
+const proposal = {
+  planId: 'plan-1',
+  proposalId: 'proposal-1',
+  sessionId: 'session-1',
+  turnId: 'turn-1',
+  revision: 1,
+  title: 'Host-owned Plan',
+  steps: [{ id: 'step-1', title: 'Own state', description: 'Persist the Plan in the Host' }],
+  status: 'pending_approval' as const,
+  submittedAt: 1,
+};
+
+test('Plan protocol declares bounded snapshot queries and stable controls', () => {
+  assert.equal(HOST_OPERATION_SPECS['plan.query'].mode, 'query');
+  assert.equal(HOST_OPERATION_SPECS['plan.control'].mode, 'control');
+  assert.deepEqual(
+    decodeRequestFrame({
+      requestId: 'request-1',
+      operation: 'plan.control',
+      input: {
+        kind: 'approve_proposal',
+        sessionId: 'session-1',
+        proposalId: 'proposal-1',
+        expectedRevision: 1,
+        expectedStoreVersion: 1,
+        operationId: 'approve-1',
+      },
+    }),
+    {
+      requestId: 'request-1',
+      operation: 'plan.control',
+      input: {
+        kind: 'approve_proposal',
+        sessionId: 'session-1',
+        proposalId: 'proposal-1',
+        expectedRevision: 1,
+        expectedStoreVersion: 1,
+        operationId: 'approve-1',
+      },
+    },
+  );
+  assert.deepEqual(
+    decodeResponseFrame({
+      requestId: 'request-1',
+      operation: 'plan.control',
+      ok: true,
+      result: {
+        sessionId: 'session-1',
+        storeVersion: 2,
+        eventType: 'plan_approved',
+        proposalId: 'proposal-1',
+        executionId: 'execution-1',
+      },
+    }),
+    {
+      requestId: 'request-1',
+      operation: 'plan.control',
+      ok: true,
+      result: {
+        sessionId: 'session-1',
+        storeVersion: 2,
+        eventType: 'plan_approved',
+        proposalId: 'proposal-1',
+        executionId: 'execution-1',
+      },
+    },
+  );
+  assert.throws(() =>
+    HOST_OPERATION_SPECS['plan.control'].assertOutputForInput?.(
+      {
+        kind: 'approve_proposal',
+        sessionId: 'session-1',
+        proposalId: 'proposal-1',
+        expectedRevision: 1,
+        expectedStoreVersion: 1,
+        operationId: 'approve-1',
+      },
+      {
+        sessionId: 'session-1',
+        storeVersion: 2,
+        eventType: 'plan_approved',
+        proposalId: 'proposal-1',
+        executionId: null,
+      },
+    ),
+  );
+});
+
+test('Plan pages reject open shapes, oversized pages, and malformed nested state', () => {
+  const page = {
+    kind: 'page',
+    sessionId: 'session-1',
+    storeVersion: 1,
+    latestProposalId: 'proposal-1',
+    activeExecutionId: null,
+    items: [{ kind: 'proposal', proposal }],
+    nextCursor: null,
+  };
+  assert.deepEqual(decodePlanQueryResult(page), page);
+  const legacyPage = {
+    ...page,
+    items: [
+      {
+        kind: 'proposal' as const,
+        proposal: { ...proposal, legacyProjection: { truncated: true as const } },
+      },
+    ],
+  };
+  assert.deepEqual(decodePlanQueryResult(legacyPage), legacyPage);
+  assert.throws(() => decodePlanQueryResult({ ...page, extra: true }));
+  assert.throws(() =>
+    decodePlanQueryResult({
+      ...page,
+      items: Array.from({ length: PLAN_PAGE_MAX_ITEMS + 1 }, () => ({
+        kind: 'proposal',
+        proposal,
+      })),
+    }),
+  );
+  assert.throws(() =>
+    decodePlanQueryResult({
+      ...page,
+      items: [{ kind: 'proposal', proposal: { ...proposal, unknown: true } }],
+    }),
+  );
+  assert.throws(() =>
+    decodePlanQueryResult({
+      ...page,
+      items: [
+        {
+          kind: 'proposal',
+          proposal: { ...proposal, legacyProjection: { truncated: false } },
+        },
+      ],
+    }),
+  );
+  assert.throws(() =>
+    decodePlanQueryResult({
+      ...page,
+      items: [
+        {
+          kind: 'proposal',
+          proposal: {
+            ...proposal,
+            steps: [{ ...proposal.steps[0], id: 'step one' }],
+          },
+        },
+      ],
+    }),
+  );
+  assert.throws(() =>
+    decodeRequestFrame({
+      requestId: 'request-2',
+      operation: 'plan.control',
+      input: {
+        kind: 'resume_execution',
+        sessionId: 'session-1',
+        executionId: 'execution-1',
+      },
+    }),
+  );
+});

--- a/packages/runtime-host/src/__tests__/plan-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/plan-two-client-uds.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
+import { openInteractivePlanStoreForWrite } from '@maka/storage/plan-authority';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.js';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '../protocol/index.js';
+import { createExecutionRuntimeHostComposition } from '../server/execution-composition.js';
+import { RuntimeHostKernel } from '../server/host-kernel.js';
+
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+
+test('two UDS Clients and a restarted production Host share one retry-safe Plan authority', {
+  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-plan-uds-'));
+  const root = join(base, 'interactive');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  let owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  let host: Awaited<ReturnType<typeof RuntimeHostKernel.start>> | undefined;
+  let desktop: RuntimeHostConnection | undefined;
+  let tui: RuntimeHostConnection | undefined;
+  try {
+    const setupStores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const planStore = await openInteractivePlanStoreForWrite(owner.lease);
+    const session = await setupStores.sessionStore.create({
+      cwd: root,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'explore',
+      collaborationMode: 'plan',
+    });
+    const submitted = await planStore.submitProposal({
+      operationId: 'submit-operation',
+      sessionId: session.id,
+      turnId: 'turn-1',
+      title: 'Shared Plan',
+      steps: [
+        {
+          id: 'step-1',
+          title: 'Commit once',
+          description: 'Approve one durable Plan execution',
+        },
+      ],
+    });
+    assert.equal(submitted.event.type, 'plan_submitted');
+    if (submitted.event.type !== 'plan_submitted') return;
+    planStore.close();
+
+    host = await RuntimeHostKernel.start({
+      owner,
+      idleGraceMs: 30_000,
+      compositionFactory: createExecutionRuntimeHostComposition,
+    });
+    owner = undefined;
+    [desktop, tui] = await Promise.all([connect(root, 'desktop'), connect(root, 'tui')]);
+
+    const first = await desktop.queryPlan({ kind: 'list_start', sessionId: session.id });
+    assert.equal(first.kind, 'page');
+    if (first.kind !== 'page') return;
+    const approval = {
+      kind: 'approve_proposal' as const,
+      sessionId: session.id,
+      proposalId: submitted.event.proposal.proposalId,
+      expectedRevision: submitted.event.proposal.revision,
+      expectedStoreVersion: first.storeVersion,
+      operationId: 'approve-operation',
+    };
+    const approved = await desktop.controlPlan(approval);
+    assert.equal(approved.eventType, 'plan_approved');
+    assert.ok(approved.executionId);
+
+    const shared = await tui.queryPlan({ kind: 'list_start', sessionId: session.id });
+    assert.equal(shared.kind, 'page');
+    if (shared.kind === 'page') {
+      assert.equal(shared.activeExecutionId, approved.executionId);
+      assert.equal(shared.items.filter((item) => item.kind === 'execution').length, 1);
+    }
+
+    await Promise.all([desktop.close(), tui.close()]);
+    desktop = undefined;
+    tui = undefined;
+    await host.close();
+    host = undefined;
+
+    owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    if (!owner) return;
+    host = await RuntimeHostKernel.start({
+      owner,
+      idleGraceMs: 30_000,
+      compositionFactory: createExecutionRuntimeHostComposition,
+    });
+    owner = undefined;
+    tui = await connect(root, 'tui');
+
+    const replayed = await tui.controlPlan(approval);
+    assert.equal(replayed.executionId, approved.executionId);
+    assert.equal(replayed.storeVersion, approved.storeVersion);
+    const recovered = await tui.queryPlan({ kind: 'list_start', sessionId: session.id });
+    assert.equal(recovered.kind, 'page');
+    if (recovered.kind !== 'page') return;
+    assert.equal(recovered.activeExecutionId, null);
+    const execution = recovered.items.find((item) => item.kind === 'execution');
+    assert.ok(execution && execution.kind === 'execution');
+    if (!execution || execution.kind !== 'execution') return;
+    assert.equal(execution.execution.status, 'interrupted');
+
+    const cancelled = await tui.controlPlan({
+      kind: 'cancel_execution',
+      sessionId: session.id,
+      executionId: execution.execution.executionId,
+      operationId: 'cancel-operation',
+    });
+    assert.equal(cancelled.eventType, 'plan_execution_cancelled');
+    assert.equal(cancelled.storeVersion, approved.storeVersion + 2);
+  } finally {
+    await Promise.allSettled([desktop?.close(), tui?.close()]);
+    await host?.close().catch(() => undefined);
+    await owner?.close().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+async function connect(
+  rootPath: string,
+  surface: 'desktop' | 'tui',
+): Promise<RuntimeHostConnection> {
+  const result = await connectRuntimeHost({ rootPath, surface, protocol: PROTOCOL });
+  assert.equal(result.kind, 'connected');
+  if (result.kind !== 'connected') throw new Error('Unable to connect to Runtime Host');
+  return result.connection;
+}

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -81,6 +81,8 @@ describe('Runtime Host bootstrap protocol', () => {
       'oauth.login.cancel',
       'oauth.login.query',
       'oauth.login.start',
+      'plan.control',
+      'plan.query',
       'pricing.mutate',
       'pricing.query',
       'queue.retract',

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -219,16 +219,8 @@ test('creation rejects reserved execution labels before claiming a Session ident
   assert.equal(fixture.drainRequests(), 0);
 });
 
-test('configuration update rejects Plan mode before invoking Runtime authority', async () => {
-  let transitionAttempts = 0;
-  const fixture = createFixture({
-    manager: {
-      transitionSessionConfiguration: async () => {
-        transitionAttempts += 1;
-        assert.fail('Plan mode must be rejected before Runtime transition');
-      },
-    },
-  });
+test('configuration update admits Plan mode through Runtime authority', async () => {
+  const fixture = createFixture();
   const input = configurationInput(fixture.sessionId, fixture.revision());
 
   const outcome = await fixture.coordinator.handlers['session.configuration.update'](
@@ -242,14 +234,14 @@ test('configuration update rejects Plan mode before invoking Runtime authority',
     context,
   );
 
-  assert.deepEqual(outcome, {
-    ok: false,
-    error: {
-      code: 'operation_unavailable',
-      message: 'Plan sessions are not yet supported by Runtime Host',
-    },
-  });
-  assert.equal(transitionAttempts, 0);
+  if (!outcome.ok || outcome.result.kind !== 'committed') {
+    assert.fail('Plan mode configuration did not commit');
+  }
+  if ('kind' in outcome.result.session) {
+    assert.fail('Plan mode configuration returned an unsupported Session projection');
+  }
+  assert.equal(outcome.result.session.collaborationMode, 'plan');
+  assert.equal(fixture.header().collaborationMode, 'plan');
   assert.equal(fixture.drainRequests(), 0);
 });
 

--- a/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
@@ -165,22 +165,14 @@ test('two UDS Clients share stable Session creation, CAS configuration, and cata
         }),
         operationError('invalid_request'),
       );
-      await assert.rejects(
-        desktop.request('session.create', {
-          sessionId: 'unsupported-plan-session',
-          cwd: root,
-          modelTarget: { kind: 'default' },
-          collaborationMode: 'plan',
-        }),
-        operationError('operation_unavailable'),
-      );
-      assert.deepEqual(
-        await desktop.request('session.catalog.query', {
-          kind: 'get',
-          sessionId: 'unsupported-plan-session',
-        }),
-        { kind: 'session', session: null },
-      );
+      const planSession = await desktop.request('session.create', {
+        sessionId: 'plan-session',
+        cwd: root,
+        modelTarget: { kind: 'default' },
+        collaborationMode: 'plan',
+      });
+      if ('kind' in planSession) assert.fail('Plan Session must be wire-representable');
+      assert.equal(planSession.collaborationMode, 'plan');
 
       const policy = await tui.request('runtime.policy.query', {});
       const changedPolicy = await tui.request('runtime.policy.mutate', {
@@ -402,7 +394,7 @@ test('two UDS Clients share stable Session creation, CAS configuration, and cata
       if (continuation.kind !== 'page') {
         assert.fail('Stable Session catalog continuation must return a page');
       }
-      assert.equal(firstPage.sessions.length + continuation.sessions.length, bulk.length + 5);
+      assert.equal(firstPage.sessions.length + continuation.sessions.length, bulk.length + 6);
 
       const filteredStart = await desktop.request('session.catalog.query', {
         kind: 'list_start',

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -28,6 +28,10 @@ import {
   type OperationInput,
   type OperationKey,
   type OperationOutput,
+  type PlanControlInput,
+  type PlanControlResult,
+  type PlanQueryInput,
+  type PlanQueryResult,
   type ProtocolRange,
   type RequestFrame,
   type ResponseFrame,
@@ -148,6 +152,8 @@ export interface RuntimeHostConnection {
     input: SessionRecapGenerateInput,
     timeoutMs?: number,
   ): Promise<SessionRecapGenerateResult>;
+  queryPlan(input: PlanQueryInput, timeoutMs?: number): Promise<PlanQueryResult>;
+  controlPlan(input: PlanControlInput, timeoutMs?: number): Promise<PlanControlResult>;
   queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan>;
   startTurnResume(input: TurnResumeStartInput, timeoutMs?: number): Promise<TurnResumeStartResult>;
   openSessionSubscription(
@@ -350,6 +356,14 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     timeoutMs?: number,
   ): Promise<SessionRecapGenerateResult> {
     return this.request('session.recap.generate', input, timeoutMs);
+  }
+
+  queryPlan(input: PlanQueryInput, timeoutMs?: number): Promise<PlanQueryResult> {
+    return this.request('plan.query', input, timeoutMs);
+  }
+
+  controlPlan(input: PlanControlInput, timeoutMs?: number): Promise<PlanControlResult> {
+    return this.request('plan.control', input, timeoutMs);
   }
 
   queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan> {

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -29,6 +29,7 @@ export * from './interaction.js';
 export * from './automation.js';
 export * from './client-capability.js';
 export * from './goal.js';
+export * from './plan.js';
 export * from './execution-inspect.js';
 export * from './message.js';
 export * from './operations.js';

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -13,6 +13,7 @@ import { INTERACTION_OPERATION_SPECS } from './interaction.js';
 import { MESSAGE_OPERATION_SPECS } from './message.js';
 import { MEMORY_OPERATION_SPECS } from './memory.js';
 import { OAUTH_OPERATION_SPECS } from './oauth.js';
+import { PLAN_OPERATION_SPECS } from './plan.js';
 import {
   composeOperationSpecMaps,
   type HostOperationError,
@@ -112,6 +113,7 @@ export * from './client-capability.js';
 export * from './goal.js';
 export * from './memory.js';
 export * from './oauth.js';
+export * from './plan.js';
 export * from './runtime-policy.js';
 export * from './runtime-resource.js';
 export * from './session-catalog.js';
@@ -132,6 +134,7 @@ export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   RUNTIME_POLICY_OPERATION_SPECS,
   RUNTIME_RESOURCE_OPERATION_SPECS,
   AUTOMATION_OPERATION_SPECS,
+  PLAN_OPERATION_SPECS,
   MESSAGE_OPERATION_SPECS,
   TASK_LEDGER_OPERATION_SPECS,
   INTERACTION_OPERATION_SPECS,

--- a/packages/runtime-host/src/protocol/plan.ts
+++ b/packages/runtime-host/src/protocol/plan.ts
@@ -1,0 +1,546 @@
+import {
+  PLAN_EXECUTION_STATUSES,
+  PLAN_LIFECYCLE_REASON_MAX_BYTES,
+  PLAN_MAX_FILES_PER_STEP,
+  PLAN_MAX_RISKS,
+  PLAN_MAX_STEPS,
+  PLAN_PROPOSAL_STATUSES,
+  PLAN_STEP_TITLE_MAX_CHARS,
+  PLAN_STEP_STATUSES,
+  PLAN_TEXT_MAX_BYTES,
+  type PlanEvent,
+  type PlanExecution,
+  type PlanExecutionStatus,
+  type LegacyPlanProjection,
+  type PlanProposal,
+  type PlanProposalStatus,
+  type PlanStepDefinition,
+  type PlanStepStatus,
+  type PlanUserControlInput,
+} from '@maka/core/plan';
+import {
+  requireCount,
+  requireEncodedByteLimit,
+  requireEntityId,
+  requireExactRecord,
+  requireRecord,
+  requireShapedRecord,
+  requireUtf8String,
+} from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const PLAN_PAGE_MAX_ITEMS = 16;
+export const PLAN_RESULT_MAX_BYTES = 64 * 1024;
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'not_found',
+  'session_archived',
+  'invalid_request',
+  'internal_failure',
+] as const;
+const CONTROL_ERRORS = [
+  ...QUERY_ERRORS,
+  'session_busy',
+  'operation_conflict',
+  'persistence_failed',
+] as const;
+
+export type PlanQueryInput =
+  | { readonly kind: 'list_start'; readonly sessionId: string }
+  | {
+      readonly kind: 'list_continue';
+      readonly sessionId: string;
+      readonly storeVersion: number;
+      readonly cursor: string;
+    };
+
+export type PlanProjectionItem =
+  | { readonly kind: 'proposal'; readonly proposal: PlanProposal }
+  | { readonly kind: 'execution'; readonly execution: PlanExecution };
+
+export type PlanQueryResult =
+  | {
+      readonly kind: 'page';
+      readonly sessionId: string;
+      readonly storeVersion: number;
+      readonly latestProposalId: string | null;
+      readonly activeExecutionId: string | null;
+      readonly items: readonly PlanProjectionItem[];
+      readonly nextCursor: string | null;
+    }
+  | {
+      readonly kind: 'revision_changed';
+      readonly expected: number;
+      readonly actual: number;
+    };
+
+export type PlanControlInput = PlanUserControlInput;
+
+export interface PlanControlResult {
+  readonly sessionId: string;
+  readonly storeVersion: number;
+  readonly eventType: PlanEvent['type'];
+  readonly proposalId: string | null;
+  readonly executionId: string | null;
+}
+
+export const PLAN_OPERATION_SPECS = {
+  'plan.query': defineOperation<PlanQueryInput, PlanQueryResult, (typeof QUERY_ERRORS)[number]>({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodePlanQueryInput,
+    decodeOutput: decodePlanQueryResult,
+    assertOutputForInput(input, output) {
+      if (output.kind === 'page' && output.sessionId !== input.sessionId) {
+        throw invalidProtocolFrame('Plan query result belongs to a different Session');
+      }
+    },
+  }),
+  'plan.control': defineOperation<
+    PlanControlInput,
+    PlanControlResult,
+    (typeof CONTROL_ERRORS)[number]
+  >({
+    mode: 'control',
+    availability: 'ready',
+    errors: CONTROL_ERRORS,
+    decodeInput: decodePlanControlInput,
+    decodeOutput: decodePlanControlResult,
+    assertOutputForInput: assertPlanControlResult,
+  }),
+} as const;
+
+export function decodePlanQueryInput(value: unknown): PlanQueryInput {
+  const record = requireRecord(value, 'Plan query input');
+  if (record.kind === 'list_start') {
+    const input = requireExactRecord(record, 'Plan list start input', ['kind', 'sessionId']);
+    return { kind: 'list_start', sessionId: requireEntityId(input.sessionId, 'sessionId') };
+  }
+  if (record.kind === 'list_continue') {
+    const input = requireExactRecord(record, 'Plan list continuation input', [
+      'kind',
+      'sessionId',
+      'storeVersion',
+      'cursor',
+    ]);
+    return {
+      kind: 'list_continue',
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      storeVersion: requireCount(input.storeVersion, 'Plan storeVersion'),
+      cursor: requireEntityId(input.cursor, 'Plan cursor'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid Plan query kind');
+}
+
+export function decodePlanQueryResult(value: unknown): PlanQueryResult {
+  requireEncodedByteLimit(value, 'Plan query result', PLAN_RESULT_MAX_BYTES);
+  const record = requireRecord(value, 'Plan query result');
+  if (record.kind === 'revision_changed') {
+    const result = requireExactRecord(record, 'Plan revision changed result', [
+      'kind',
+      'expected',
+      'actual',
+    ]);
+    return {
+      kind: 'revision_changed',
+      expected: requireCount(result.expected, 'expected Plan storeVersion'),
+      actual: requireCount(result.actual, 'actual Plan storeVersion'),
+    };
+  }
+  const result = requireExactRecord(record, 'Plan page result', [
+    'kind',
+    'sessionId',
+    'storeVersion',
+    'latestProposalId',
+    'activeExecutionId',
+    'items',
+    'nextCursor',
+  ]);
+  if (result.kind !== 'page') throw invalidProtocolFrame('Invalid Plan query result kind');
+  if (!Array.isArray(result.items) || result.items.length > PLAN_PAGE_MAX_ITEMS) {
+    throw invalidProtocolFrame('Invalid Plan page items');
+  }
+  const decoded: PlanQueryResult = {
+    kind: 'page',
+    sessionId: requireEntityId(result.sessionId, 'sessionId'),
+    storeVersion: requireCount(result.storeVersion, 'Plan storeVersion'),
+    latestProposalId: nullableId(result.latestProposalId, 'latestProposalId'),
+    activeExecutionId: nullableId(result.activeExecutionId, 'activeExecutionId'),
+    items: result.items.map(decodePlanProjectionItem),
+    nextCursor: nullableId(result.nextCursor, 'nextCursor'),
+  };
+  if (
+    decoded.items.some((item) =>
+      item.kind === 'proposal'
+        ? item.proposal.sessionId !== decoded.sessionId
+        : item.execution.sessionId !== decoded.sessionId,
+    )
+  ) {
+    throw invalidProtocolFrame('Plan page contains state from another Session');
+  }
+  return decoded;
+}
+
+export function decodePlanControlInput(value: unknown): PlanControlInput {
+  const record = requireRecord(value, 'Plan control input');
+  if (record.kind === 'request_revision' || record.kind === 'abandon_proposal') {
+    const input = requireExactRecord(record, 'Plan proposal control input', [
+      'kind',
+      'sessionId',
+      'proposalId',
+      'operationId',
+    ]);
+    return {
+      kind: record.kind,
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      proposalId: requireEntityId(input.proposalId, 'proposalId'),
+      operationId: requireEntityId(input.operationId, 'operationId'),
+    };
+  }
+  if (record.kind === 'approve_proposal') {
+    const input = requireExactRecord(record, 'Plan approval input', [
+      'kind',
+      'sessionId',
+      'proposalId',
+      'expectedRevision',
+      'expectedStoreVersion',
+      'operationId',
+    ]);
+    return {
+      kind: 'approve_proposal',
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      proposalId: requireEntityId(input.proposalId, 'proposalId'),
+      expectedRevision: requireCount(input.expectedRevision, 'expectedRevision'),
+      expectedStoreVersion: requireCount(input.expectedStoreVersion, 'expectedStoreVersion'),
+      operationId: requireEntityId(input.operationId, 'operationId'),
+    };
+  }
+  if (record.kind === 'resume_execution' || record.kind === 'cancel_execution') {
+    const input = requireExactRecord(record, 'Plan execution control input', [
+      'kind',
+      'sessionId',
+      'executionId',
+      'operationId',
+    ]);
+    return {
+      kind: record.kind,
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      executionId: requireEntityId(input.executionId, 'executionId'),
+      operationId: requireEntityId(input.operationId, 'operationId'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid Plan control kind');
+}
+
+export function decodePlanControlResult(value: unknown): PlanControlResult {
+  requireEncodedByteLimit(value, 'Plan control result', PLAN_RESULT_MAX_BYTES);
+  const result = requireExactRecord(value, 'Plan control result', [
+    'sessionId',
+    'storeVersion',
+    'eventType',
+    'proposalId',
+    'executionId',
+  ]);
+  return {
+    sessionId: requireEntityId(result.sessionId, 'sessionId'),
+    storeVersion: requireCount(result.storeVersion, 'Plan storeVersion'),
+    eventType: requirePlanEventType(result.eventType),
+    proposalId: nullableId(result.proposalId, 'proposalId'),
+    executionId: nullableId(result.executionId, 'executionId'),
+  };
+}
+
+function decodePlanProjectionItem(value: unknown): PlanProjectionItem {
+  const record = requireRecord(value, 'Plan projection item');
+  if (record.kind === 'proposal') {
+    const item = requireExactRecord(record, 'Plan proposal item', ['kind', 'proposal']);
+    return { kind: 'proposal', proposal: decodeProposal(item.proposal) };
+  }
+  if (record.kind === 'execution') {
+    const item = requireExactRecord(record, 'Plan execution item', ['kind', 'execution']);
+    return { kind: 'execution', execution: decodeExecution(item.execution) };
+  }
+  throw invalidProtocolFrame('Invalid Plan projection item kind');
+}
+
+function decodeProposal(value: unknown): PlanProposal {
+  const record = requireShapedRecord(
+    value,
+    'Plan proposal',
+    [
+      'planId',
+      'proposalId',
+      'sessionId',
+      'turnId',
+      'revision',
+      'title',
+      'steps',
+      'status',
+      'submittedAt',
+    ],
+    ['supersedesProposalId', 'sourceExecutionId', 'overview', 'risks', 'legacyProjection'],
+  );
+  return {
+    planId: requireEntityId(record.planId, 'planId'),
+    proposalId: requireEntityId(record.proposalId, 'proposalId'),
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    turnId: requireEntityId(record.turnId, 'turnId'),
+    revision: requireCount(record.revision, 'Plan proposal revision'),
+    ...(record.supersedesProposalId === undefined
+      ? {}
+      : {
+          supersedesProposalId: requireEntityId(
+            record.supersedesProposalId,
+            'supersedesProposalId',
+          ),
+        }),
+    ...(record.sourceExecutionId === undefined
+      ? {}
+      : { sourceExecutionId: requireEntityId(record.sourceExecutionId, 'sourceExecutionId') }),
+    title: planText(record.title, 'Plan title'),
+    ...(record.overview === undefined
+      ? {}
+      : { overview: planText(record.overview, 'Plan overview') }),
+    steps: decodeArray(record.steps, 'Plan steps', PLAN_MAX_STEPS, decodeStepDefinition),
+    ...(record.risks === undefined
+      ? {}
+      : {
+          risks: decodeArray(record.risks, 'Plan risks', PLAN_MAX_RISKS, (item) =>
+            planText(item, 'Plan risk'),
+          ),
+        }),
+    status: requireProposalStatus(record.status),
+    submittedAt: requireCount(record.submittedAt, 'Plan submittedAt'),
+    ...(record.legacyProjection === undefined
+      ? {}
+      : { legacyProjection: decodeLegacyProjection(record.legacyProjection) }),
+  };
+}
+
+function decodeExecution(value: unknown): PlanExecution {
+  const record = requireShapedRecord(
+    value,
+    'Plan execution',
+    [
+      'executionId',
+      'planId',
+      'proposalId',
+      'sessionId',
+      'status',
+      'steps',
+      'startedAt',
+      'updatedAt',
+    ],
+    [
+      'completedAt',
+      'cancelledAt',
+      'interruptedAt',
+      'cancelReason',
+      'interruptionReason',
+      'legacyProjection',
+    ],
+  );
+  return {
+    executionId: requireEntityId(record.executionId, 'executionId'),
+    planId: requireEntityId(record.planId, 'planId'),
+    proposalId: requireEntityId(record.proposalId, 'proposalId'),
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    status: requireExecutionStatus(record.status),
+    steps: decodeArray(record.steps, 'Plan execution steps', PLAN_MAX_STEPS, (item) => {
+      const step = decodeStepDefinition(item);
+      const source = requireShapedRecord(
+        item,
+        'Plan execution step',
+        ['id', 'title', 'description', 'status', 'updatedAt'],
+        ['files', 'complexity', 'note'],
+      );
+      return {
+        ...step,
+        status: requireStepStatus(source.status),
+        ...(source.note === undefined ? {} : { note: planText(source.note, 'Plan step note') }),
+        updatedAt: requireCount(source.updatedAt, 'Plan step updatedAt'),
+      };
+    }),
+    startedAt: requireCount(record.startedAt, 'Plan startedAt'),
+    updatedAt: requireCount(record.updatedAt, 'Plan updatedAt'),
+    ...optionalCount(record, 'completedAt'),
+    ...optionalCount(record, 'cancelledAt'),
+    ...optionalCount(record, 'interruptedAt'),
+    ...(record.cancelReason === undefined
+      ? {}
+      : {
+          cancelReason: lifecycleReason(record.cancelReason, 'Plan cancelReason'),
+        }),
+    ...(record.interruptionReason === undefined
+      ? {}
+      : {
+          interruptionReason: lifecycleReason(record.interruptionReason, 'Plan interruptionReason'),
+        }),
+    ...(record.legacyProjection === undefined
+      ? {}
+      : { legacyProjection: decodeLegacyProjection(record.legacyProjection) }),
+  };
+}
+
+function decodeLegacyProjection(value: unknown): LegacyPlanProjection {
+  const record = requireExactRecord(value, 'Legacy Plan projection', ['truncated']);
+  if (record.truncated !== true) {
+    throw invalidProtocolFrame('Invalid legacy Plan projection');
+  }
+  return { truncated: true };
+}
+
+function decodeStepDefinition(value: unknown): PlanStepDefinition {
+  const record = requireShapedRecord(
+    value,
+    'Plan step',
+    ['id', 'title', 'description'],
+    ['files', 'complexity', 'status', 'note', 'updatedAt'],
+  );
+  const complexity = record.complexity;
+  if (complexity !== undefined && !['low', 'medium', 'high'].includes(String(complexity))) {
+    throw invalidProtocolFrame('Invalid Plan step complexity');
+  }
+  const title = planText(record.title, 'Plan step title');
+  if (title.length > PLAN_STEP_TITLE_MAX_CHARS) {
+    throw invalidProtocolFrame('Invalid Plan step title');
+  }
+  return {
+    id: requireEntityId(record.id, 'Plan step id'),
+    title,
+    description: planText(record.description, 'Plan step description'),
+    ...(record.files === undefined
+      ? {}
+      : {
+          files: decodeArray(record.files, 'Plan step files', PLAN_MAX_FILES_PER_STEP, (item) =>
+            planText(item, 'Plan file'),
+          ),
+        }),
+    ...(complexity === undefined
+      ? {}
+      : { complexity: complexity as PlanStepDefinition['complexity'] }),
+  };
+}
+
+function decodeArray<T>(
+  value: unknown,
+  label: string,
+  maxItems: number,
+  decode: (item: unknown) => T,
+): T[] {
+  if (!Array.isArray(value) || value.length > maxItems) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value.map(decode);
+}
+
+function planText(value: unknown, label: string): string {
+  return requireUtf8String(value, label, PLAN_TEXT_MAX_BYTES);
+}
+
+function lifecycleReason(value: unknown, label: string): string {
+  return requireUtf8String(value, label, PLAN_LIFECYCLE_REASON_MAX_BYTES);
+}
+
+function nullableId(value: unknown, label: string): string | null {
+  return value === null ? null : requireEntityId(value, label);
+}
+
+function optionalCount(record: Record<string, unknown>, key: string): Record<string, number> {
+  return record[key] === undefined ? {} : { [key]: requireCount(record[key], `Plan ${key}`) };
+}
+
+function requireProposalStatus(value: unknown): PlanProposalStatus {
+  if (!PLAN_PROPOSAL_STATUSES.includes(value as PlanProposalStatus)) {
+    throw invalidProtocolFrame('Invalid Plan proposal status');
+  }
+  return value as PlanProposalStatus;
+}
+
+function requireExecutionStatus(value: unknown): PlanExecutionStatus {
+  if (!PLAN_EXECUTION_STATUSES.includes(value as PlanExecutionStatus)) {
+    throw invalidProtocolFrame('Invalid Plan execution status');
+  }
+  return value as PlanExecutionStatus;
+}
+
+function requireStepStatus(value: unknown): PlanStepStatus {
+  if (!PLAN_STEP_STATUSES.includes(value as PlanStepStatus)) {
+    throw invalidProtocolFrame('Invalid Plan step status');
+  }
+  return value as PlanStepStatus;
+}
+
+function requirePlanEventType(value: unknown): PlanEvent['type'] {
+  const types: readonly PlanEvent['type'][] = [
+    'plan_submitted',
+    'plan_revision_requested',
+    'plan_abandoned',
+    'plan_approved',
+    'plan_progress_updated',
+    'plan_execution_completed',
+    'plan_execution_cancelled',
+    'plan_execution_interrupted',
+    'plan_execution_resumed',
+  ];
+  if (!types.includes(value as PlanEvent['type'])) {
+    throw invalidProtocolFrame('Invalid Plan eventType');
+  }
+  return value as PlanEvent['type'];
+}
+
+function assertPlanControlResult(input: PlanControlInput, output: PlanControlResult): void {
+  if (input.sessionId !== output.sessionId) {
+    throw invalidProtocolFrame('Plan control result belongs to a different Session');
+  }
+  if (input.kind === 'request_revision') {
+    assertProposalControl(output, input.proposalId, 'plan_revision_requested');
+    return;
+  }
+  if (input.kind === 'abandon_proposal') {
+    assertProposalControl(output, input.proposalId, 'plan_abandoned');
+    return;
+  }
+  if (input.kind === 'approve_proposal') {
+    if (
+      output.eventType !== 'plan_approved' ||
+      output.proposalId !== input.proposalId ||
+      output.executionId === null
+    ) {
+      throw invalidProtocolFrame('Plan approval result does not match its request');
+    }
+    return;
+  }
+  const expectedType =
+    input.kind === 'resume_execution' ? 'plan_execution_resumed' : 'plan_execution_cancelled';
+  if (!('executionId' in input)) {
+    throw invalidProtocolFrame('Invalid Plan execution control correlation');
+  }
+  if (
+    output.eventType !== expectedType ||
+    output.executionId !== input.executionId ||
+    output.proposalId !== null
+  ) {
+    throw invalidProtocolFrame('Plan execution control result does not match its request');
+  }
+}
+
+function assertProposalControl(
+  output: PlanControlResult,
+  proposalId: string,
+  eventType: 'plan_revision_requested' | 'plan_abandoned',
+): void {
+  if (
+    output.eventType !== eventType ||
+    output.proposalId !== proposalId ||
+    output.executionId !== null
+  ) {
+    throw invalidProtocolFrame('Plan proposal control result does not match its request');
+  }
+}

--- a/packages/runtime-host/src/server/automation-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-coordinator.ts
@@ -46,7 +46,7 @@ import {
   fireContent,
   HostAutomationFireCoordinator,
 } from './automation-fire-coordinator.js';
-import { runtimeHostSessionUnavailableReason } from './host-session-availability.js';
+import { runtimeHostAutomationSessionUnavailableReason } from './host-session-availability.js';
 import { SessionAdmissionGate } from './session-admission-gate.js';
 
 type AutomationSessions = Pick<
@@ -464,7 +464,7 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
     return this.#exclusive(async () => {
       this.#assertWritable();
       const header = await this.#readMutableSession(input.sessionId);
-      const unavailableReason = runtimeHostSessionUnavailableReason(header);
+      const unavailableReason = runtimeHostAutomationSessionUnavailableReason(header);
       if (unavailableReason) {
         throw new AutomationMutationFailure('session_unavailable', unavailableReason);
       }
@@ -681,7 +681,7 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
       if (automation.kind === 'cron' && !automation.execution) {
         try {
           const creator = await this.#sessions.readHeaderSnapshot(automation.sessionId);
-          const unavailableReason = runtimeHostSessionUnavailableReason(creator);
+          const unavailableReason = runtimeHostAutomationSessionUnavailableReason(creator);
           if (unavailableReason) {
             automation.status = 'paused';
             automation.nextFireAt = null;

--- a/packages/runtime-host/src/server/automation-fire-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-fire-coordinator.ts
@@ -21,7 +21,7 @@ import {
 import type { RuntimePolicyStoresWriter } from '@maka/storage/runtime-policy-stores';
 import { AutomationAuthorityInvariantError } from './automation-errors.js';
 import type { RuntimeHostResidency } from './host-kernel.js';
-import { runtimeHostSessionUnavailableReason } from './host-session-availability.js';
+import { runtimeHostAutomationSessionUnavailableReason } from './host-session-availability.js';
 
 type AutomationSessions = Pick<
   ExecutionSessionWriter,
@@ -237,7 +237,7 @@ export class HostAutomationFireCoordinator {
           const header = await this.#sessions.readHeaderSnapshot(sessionId);
           return header.isArchived ||
             header.status === 'archived' ||
-            runtimeHostSessionUnavailableReason(header)
+            runtimeHostAutomationSessionUnavailableReason(header)
             ? null
             : header;
         } catch (error) {
@@ -438,7 +438,7 @@ export class HostAutomationFireCoordinator {
     if (header.isArchived || header.status === 'archived') {
       throw new AutomationFireDeferredError('Automation target Session is archived');
     }
-    if (runtimeHostSessionUnavailableReason(header)) {
+    if (runtimeHostAutomationSessionUnavailableReason(header)) {
       throw new AutomationFireDeferredError('Automation target Session is unavailable');
     }
     if (fire.automationKind === 'heartbeat' && !HEARTBEAT_IDLE_STATUSES.has(header.status)) {

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -26,6 +26,7 @@ import {
   openInteractiveArtifactStoreForWrite,
 } from '@maka/storage/artifact-stores';
 import { openInteractiveAutomationAuthorityForWrite } from '@maka/storage/automation-authority';
+import { openInteractivePlanStoreForWrite } from '@maka/storage/plan-authority';
 import {
   isSessionNotFoundError,
   openInteractiveExecutionStoresForWrite,
@@ -70,6 +71,7 @@ import { HostMemoryCoordinator } from './memory-coordinator.js';
 import { type HostMessageRootPort, HostMessageCoordinator } from './message-coordinator.js';
 import { HostOAuthExecutionAuthority } from './oauth-execution-authority.js';
 import { HostOAuthCoordinator } from './oauth-coordinator.js';
+import { HostPlanCoordinator } from './plan-coordinator.js';
 import type { DomainOperationHandlerMap } from './operation-dispatcher.js';
 import { RootAdmissionOwner } from './root-admission-owner.js';
 import { RootTurnCoordinator } from './root-turn-coordinator.js';
@@ -105,6 +107,7 @@ export async function createExecutionRuntimeHostComposition(
   let automationStore:
     | Awaited<ReturnType<typeof openInteractiveAutomationAuthorityForWrite>>
     | undefined;
+  let planStore: Awaited<ReturnType<typeof openInteractivePlanStoreForWrite>> | undefined;
   let graphClient: HostAgentGraphCoordinator | undefined;
   let sessionEffects: HostSessionEffectCoordinator | undefined;
   try {
@@ -116,6 +119,8 @@ export async function createExecutionRuntimeHostComposition(
       context.owner.lease,
     );
     automationStore = openedAutomationStore;
+    const openedPlanStore = await openInteractivePlanStoreForWrite(context.owner.lease);
+    planStore = openedPlanStore;
     const memoryStore = await openInteractiveMemoryBundleStoreForWrite(context.owner.lease);
     longTermMemoryStore = await openInteractiveLongTermMemoryStoreForWrite(context.owner.lease);
     taskLedgerStore = await openInteractiveTaskLedgerStoreForWrite(context.owner.lease);
@@ -329,6 +334,7 @@ export async function createExecutionRuntimeHostComposition(
         usage: openedUsageStores,
         clientCapabilities: requireClientCapabilities(clientCapabilities),
         automationTool: requireAutomationCoordinator(automations).modelTool,
+        planStore: openedPlanStore,
         goalTools: requireGoal(goal).tools,
         builtinTools,
         hostTools,
@@ -357,6 +363,10 @@ export async function createExecutionRuntimeHostComposition(
       try {
         const graphTools =
           await requireGraphCoordinator(graphCoordinator).toolsForSession(sessionId);
+        const [header, planState] = await Promise.all([
+          stores.sessionStore.readHeaderSnapshot(sessionId),
+          openedPlanStore.readState(sessionId),
+        ]);
         return createHostExecutionModelComposition({
           policy: runtimePolicyStores.runtimePolicy,
           skills,
@@ -368,6 +378,11 @@ export async function createExecutionRuntimeHostComposition(
           automationTool: requireAutomationCoordinator(automations).modelTool,
           goalTools: requireGoal(goal).tools,
           parentAgentTools: childAgentTools.parentTools,
+          plan: {
+            store: openedPlanStore,
+            state: planState,
+            mode: header.collaborationMode ?? 'agent',
+          },
         }).tools.map((tool) => tool.name);
       } finally {
         capabilitySnapshot?.release();
@@ -448,6 +463,7 @@ export async function createExecutionRuntimeHostComposition(
       interactionAuthority: interactions,
       canonicalPermissionOutcomes,
       shellRuns,
+      planStore: openedPlanStore,
       childTools: childAgentTools.childTools,
       worktreeChildExecutor,
       listArtifactsForTurn: (sessionId, turnId) =>
@@ -662,6 +678,16 @@ export async function createExecutionRuntimeHostComposition(
       continuity: continuityCoordinator,
       requestDrain: context.requestDrain,
     });
+    const plans = new HostPlanCoordinator({
+      store: openedPlanStore,
+      sessions: stores.sessionStore,
+      runtime: manager,
+      sessionAdmission,
+      isSessionActive: (sessionId) => coordinator.readRootState(sessionId).kind !== 'idle',
+      refreshContinuity: (sessionId, lease) =>
+        continuityCoordinator.refreshCanonical(sessionId, lease),
+      requestDrain: context.requestDrain,
+    });
     const executionInspect = new HostExecutionInspectCoordinator(stores);
     const sessionRevisions = new HostSessionRevisionCoordinator({
       stores,
@@ -691,7 +717,10 @@ export async function createExecutionRuntimeHostComposition(
       continuity: continuityCoordinator,
       artifacts: openedArtifactStore,
       taskLedger: taskLedgerStore,
-      purgeOperationalState: (sessionId) => stores.purgeConversationOperationalState(sessionId),
+      purgeOperationalState: async (sessionId) => {
+        await stores.purgeConversationOperationalState(sessionId);
+        await openedPlanStore.purgeSessionState(sessionId);
+      },
       purgeAgentGraphState: async (sessionId) => {
         await openedGraphControlStore.purgeAgentGraphControlState(
           agentGraphIdForRootSession(sessionId),
@@ -723,6 +752,7 @@ export async function createExecutionRuntimeHostComposition(
       ...clientCapabilities.handlers,
       ...runtimeResources.handlers,
       ...automations.handlers,
+      ...plans.handlers,
     } satisfies DomainOperationHandlerMap;
     const recover = () => {
       recoveryTask ??= (async () => {
@@ -902,6 +932,11 @@ export async function createExecutionRuntimeHostComposition(
           errors.push(error);
         }
         try {
+          openedPlanStore.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
           await stores.sessionStore.close?.();
         } catch (error) {
           errors.push(error);
@@ -971,6 +1006,11 @@ export async function createExecutionRuntimeHostComposition(
     }
     try {
       automationStore?.close();
+    } catch (closeError) {
+      errors.push(closeError);
+    }
+    try {
+      planStore?.close();
     } catch (closeError) {
       errors.push(closeError);
     }

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { resolveModelVisionSupport } from '@maka/core/model-metadata';
+import { activePlanExecution, type PlanSessionState, type PlanStore } from '@maka/core/plan';
 import type { ModelCallAttempt } from '@maka/core/model-call-attempt';
 import type { RuntimePolicy } from '@maka/core/runtime-policy';
 import {
@@ -15,13 +16,16 @@ import {
   buildHostCapabilitiesFromBinding,
   buildLlmHistorySummarizer,
   buildPersonalizationPromptFragment,
+  buildCancelPlanTool,
   buildPricingLookup,
   buildProviderOptions,
+  buildSubmitPlanTool,
   buildSessionEnvironmentPromptFragment,
   buildSkillAgentToolFromInventory,
   buildSkillSearchAgentToolFromInventory,
   buildSkillsPromptFragmentFromInventoryWithReport,
   buildTaskLedgerTools,
+  buildUpdatePlanTool,
   buildWorkspaceInstructionsPromptFragment,
   createProviderRequestCaptureRecorder,
   createProxiedFetchTransport,
@@ -30,6 +34,10 @@ import {
   recordToolInvocation,
   resolveProjectGitInfo,
   resolveSelectedModelContextWindow,
+  renderInterruptedPlanContext,
+  renderPlanExecutionPrompt,
+  renderPlanModePrompt,
+  selectCollaborationTools,
   SkillShadowSelectionTracker,
   type BackendFactoryContext,
   type BuildBuiltinToolsOptions,
@@ -106,6 +114,11 @@ export interface HostExecutionModelCompositionInput {
   readonly automationTool?: MakaTool;
   readonly goalTools?: readonly MakaTool[];
   readonly parentAgentTools?: readonly MakaTool[];
+  readonly plan?: {
+    readonly store: PlanStore;
+    readonly state: PlanSessionState;
+    readonly mode: 'agent' | 'plan';
+  };
 }
 
 /** Composes one Host-owned prompt and pure tool surface from canonical authorities. */
@@ -123,21 +136,36 @@ export function createHostExecutionModelComposition(
         input.automationTool,
         input.goalTools,
         input.parentAgentTools,
+        input.plan,
       );
+  const clientCapabilityTools = input.boundTools ? [] : (input.clientCapabilities?.tools ?? []);
+  const candidateTools = [...defaultTools, ...clientCapabilityTools];
+  const activeExecution = input.plan ? activePlanExecution(input.plan.state) : undefined;
+  const selectedTools = input.plan
+    ? selectCollaborationTools({
+        mode: input.plan.mode,
+        tools: candidateTools,
+        hasActiveExecution: activeExecution !== undefined,
+      })
+    : candidateTools;
   const productSurface = projectEffectiveProductToolSurface({
     host: 'runtime-host',
-    tools: defaultTools,
+    tools: selectedTools,
     policy: { economy: !process.env.MAKA_DISABLE_DEFERRED_TOOLS },
   });
   // A bound tool list is an exact child/local activation ceiling. Dynamic
   // capabilities must be included by the authority that constructs that list,
   // never appended here.
-  const clientCapabilityTools = input.boundTools ? [] : (input.clientCapabilities?.tools ?? []);
-  const tools = [...productSurface.tools, ...clientCapabilityTools];
+  const tools = [...productSurface.tools];
   assertUniqueToolNames(tools);
   const toolAvailability = mergeToolAvailability(
     productSurface.toolAvailability,
-    input.boundTools ? [] : (input.clientCapabilities?.groups ?? []),
+    input.boundTools
+      ? []
+      : filterToolGroups(
+          input.clientCapabilities?.groups ?? [],
+          new Set(tools.map(({ name }) => name)),
+        ),
   );
   const childInstruction = input.childInstruction?.trim();
 
@@ -179,6 +207,7 @@ export function createHostExecutionModelComposition(
         skills.text,
         workspaceInstructions,
         promptState.memory,
+        input.plan?.mode === 'plan' ? renderPlanModePrompt() : undefined,
       ]);
     },
     turnTailPrompt: async (context: HostModelPromptContext) => {
@@ -195,7 +224,13 @@ export function createHostExecutionModelComposition(
           includeArchived: false,
         }),
       );
-      return joinFragments([environment, renderTaskLedgerTail(tasks)]) ?? environment;
+      return (
+        joinFragments([
+          environment,
+          renderTaskLedgerTail(tasks),
+          input.plan ? renderPlanTail(input.plan.state, input.plan.mode) : undefined,
+        ]) ?? environment
+      );
     },
   });
 }
@@ -221,6 +256,7 @@ export interface HostAiSdkBackendInput {
   readonly goalTools?: readonly MakaTool[];
   readonly parentAgentTools?: readonly MakaTool[];
   readonly childAgents?: HostChildAgentBackendCapabilities;
+  readonly planStore?: PlanStore;
   readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
 }
 
@@ -278,7 +314,15 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
     ? undefined
     : input.clientCapabilities.snapshotForSession(input.context.sessionId);
   let modelComposition: HostExecutionModelComposition;
+  let planState: PlanSessionState | undefined;
   try {
+    planState =
+      input.planStore && !input.context.tools
+        ? await readDuringBackendCreation(
+            () => input.planStore!.readState(input.context.sessionId),
+            input.context.abortSignal,
+          )
+        : undefined;
     const rootTools =
       input.resolveRootTools && !input.context.tools && !input.context.header.subagentParent
         ? await readDuringBackendCreation(
@@ -300,6 +344,15 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
       ...(input.automationTool ? { automationTool: input.automationTool } : {}),
       ...(input.goalTools ? { goalTools: input.goalTools } : {}),
       ...(input.parentAgentTools ? { parentAgentTools: input.parentAgentTools } : {}),
+      ...(planState && input.planStore
+        ? {
+            plan: {
+              store: input.planStore,
+              state: planState,
+              mode: input.context.header.collaborationMode ?? 'agent',
+            },
+          }
+        : {}),
       skillBudget: {
         contextWindow: resolveSelectedModelContextWindow(target.connection, target.model),
       },
@@ -411,7 +464,14 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
     return new HostAiSdkBackend(
       {
         sessionId: input.context.sessionId,
-        header: { ...input.context.header, model: target.model },
+        header: {
+          ...input.context.header,
+          model: target.model,
+          permissionMode:
+            input.context.header.collaborationMode === 'plan'
+              ? 'explore'
+              : input.context.header.permissionMode,
+        },
         appendMessage:
           input.context.appendMessage ??
           ((message) => input.context.store.appendMessage(input.context.sessionId, message)),
@@ -435,6 +495,14 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
         modelFactory,
         tools: [...modelComposition.tools],
         toolAvailability: modelComposition.toolAvailability,
+        ...(planState && !input.context.tools
+          ? {
+              planTraceContext: buildPlanTraceContext(
+                planState,
+                input.context.header.collaborationMode ?? 'agent',
+              ),
+            }
+          : {}),
         ...(!input.context.tools && input.childAgents ? input.childAgents : {}),
         providerOptions,
         contextBudget: buildDefaultContextBudgetPolicy(target.connection, {
@@ -561,10 +629,25 @@ function buildDefaultHostTools(
   automationTool?: MakaTool,
   goalTools: readonly MakaTool[] = [],
   parentAgentTools: readonly MakaTool[] = [],
+  plan?: HostExecutionModelCompositionInput['plan'],
 ): MakaTool[] {
   const builtins = builtinOptions ? buildBuiltinTools(builtinOptions) : [];
   const question = buildAskUserQuestionTool();
   const taskTools = buildTaskLedgerTools({ store: taskLedger });
+  const activeExecution = plan ? activePlanExecution(plan.state) : undefined;
+  const interruptedExecution = plan
+    ? [...plan.state.executions].reverse().find((execution) => execution.status === 'interrupted')
+    : undefined;
+  const planTools = !plan
+    ? []
+    : plan.mode === 'plan'
+      ? [buildSubmitPlanTool(plan.store, interruptedExecution?.executionId)]
+      : activeExecution
+        ? [
+            buildUpdatePlanTool(plan.store, activeExecution.executionId),
+            buildCancelPlanTool(plan.store, activeExecution.executionId),
+          ]
+        : [];
   const toolNames = [
     ...builtins.map((tool) => tool.name),
     ...hostTools.map((tool) => tool.name),
@@ -575,6 +658,7 @@ function buildDefaultHostTools(
     ...(automationTool ? [automationTool.name] : []),
     ...goalTools.map((tool) => tool.name),
     ...parentAgentTools.map((tool) => tool.name),
+    ...planTools.map((tool) => tool.name),
   ];
   const skillHost = buildHostCapabilitiesFromBinding(toolNames);
   const shadowTracker = new SkillShadowSelectionTracker();
@@ -592,7 +676,56 @@ function buildDefaultHostTools(
     ...(automationTool ? [automationTool] : []),
     ...goalTools,
     ...parentAgentTools,
+    ...planTools,
   ];
+}
+
+function renderPlanTail(state: PlanSessionState, mode: 'agent' | 'plan'): string | undefined {
+  const active = activePlanExecution(state);
+  const execution =
+    active ??
+    (mode === 'plan'
+      ? [...state.executions].reverse().find((candidate) => candidate.status === 'interrupted')
+      : undefined);
+  if (!execution) return undefined;
+  const proposal = state.proposals.find(
+    (candidate) => candidate.proposalId === execution.proposalId,
+  );
+  if (!proposal) return undefined;
+  return active
+    ? renderPlanExecutionPrompt({ proposal, execution: active })
+    : renderInterruptedPlanContext({ proposal, execution });
+}
+
+function filterToolGroups(groups: readonly ToolGroup[], names: ReadonlySet<string>): ToolGroup[] {
+  return groups.flatMap((group) => {
+    const toolNames = group.toolNames.filter((name) => names.has(name));
+    return toolNames.length > 0 ? [{ ...group, toolNames }] : [];
+  });
+}
+
+function buildPlanTraceContext(
+  state: PlanSessionState,
+  mode: 'agent' | 'plan',
+): {
+  mode: 'agent' | 'plan';
+  storeVersion: number;
+  planId?: string;
+  proposalId?: string;
+  executionId?: string;
+} {
+  const execution = activePlanExecution(state);
+  return {
+    mode,
+    storeVersion: state.storeVersion,
+    ...(execution
+      ? {
+          planId: execution.planId,
+          proposalId: execution.proposalId,
+          executionId: execution.executionId,
+        }
+      : {}),
+  };
 }
 
 function createTurnSkillInventoryResolver(

--- a/packages/runtime-host/src/server/host-session-availability.ts
+++ b/packages/runtime-host/src/server/host-session-availability.ts
@@ -9,13 +9,19 @@ const CHILD_CONTINUATION_UNAVAILABLE_REASON =
 export function runtimeHostSessionUnavailableReason(
   header: Pick<SessionHeader, 'collaborationMode' | 'labels'>,
 ): string | undefined {
-  if (header.collaborationMode === 'plan') {
-    return 'Plan sessions are not yet supported by Runtime Host.';
-  }
   if (isDeepResearchSession(header.labels)) {
     return 'Deep Research sessions are not yet supported by Runtime Host.';
   }
   return undefined;
+}
+
+export function runtimeHostAutomationSessionUnavailableReason(
+  header: Pick<SessionHeader, 'collaborationMode' | 'labels'>,
+): string | undefined {
+  if (header.collaborationMode === 'plan') {
+    return 'Automations cannot execute while the target Session is in Plan mode.';
+  }
+  return runtimeHostSessionUnavailableReason(header);
 }
 
 export function runtimeHostExternalTurnUnavailableReason(
@@ -42,6 +48,13 @@ export function runtimeHostExecutionUnavailableReason(
 ): string | undefined {
   return (
     runtimeHostSessionUnavailableReason(header) ??
+    (header.collaborationMode === 'plan' &&
+    execution.kind !== 'external_message' &&
+    execution.kind !== 'regenerate' &&
+    execution.kind !== 'context_compact' &&
+    execution.kind !== 'safe_boundary_continuation'
+      ? 'Background and delegated roots cannot execute while the Session is in Plan mode.'
+      : undefined) ??
     (header.subagentWorkspace && !isManagedWorktreeChildExecution(execution)
       ? WORKTREE_CHILD_UNAVAILABLE_REASON
       : undefined)

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -86,6 +86,7 @@ export type OAuthOperationKey = Extract<OperationKey, `oauth.${string}`>;
 export type RuntimeResourceOperationKey = Extract<OperationKey, `runtime.resource.${string}`>;
 export type ClientCapabilityOperationKey = Extract<OperationKey, `client.capability.${string}`>;
 export type AutomationOperationKey = Extract<OperationKey, `automation.${string}`>;
+export type PlanOperationKey = Extract<OperationKey, `plan.${string}`>;
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
 export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
 export type ContextOperationHandlerMap = Pick<OperationHandlerMap, ContextOperationKey>;
@@ -134,6 +135,7 @@ export type ClientCapabilityOperationHandlerMap = Pick<
   ClientCapabilityOperationKey
 >;
 export type AutomationOperationHandlerMap = Pick<OperationHandlerMap, AutomationOperationKey>;
+export type PlanOperationHandlerMap = Pick<OperationHandlerMap, PlanOperationKey>;
 
 export function composeOperationHandlers(
   ...handlerMaps: readonly Partial<OperationHandlerMap>[]

--- a/packages/runtime-host/src/server/plan-coordinator.ts
+++ b/packages/runtime-host/src/server/plan-coordinator.ts
@@ -1,0 +1,313 @@
+import {
+  PlanConflictError,
+  planUserControlMutationInput,
+  type PlanEvent,
+  type PlanMutationResult,
+} from '@maka/core/plan';
+import type { SessionManager } from '@maka/runtime';
+import {
+  isSessionNotFoundError,
+  type ExecutionSessionWriter,
+} from '@maka/storage/execution-stores';
+import {
+  authenticateInteractivePlanStoreWriter,
+  type InteractivePlanStoreWriter,
+} from '@maka/storage/plan-authority';
+import {
+  PLAN_PAGE_MAX_ITEMS,
+  PLAN_RESULT_MAX_BYTES,
+  type OperationOutcome,
+  type PlanControlInput,
+  type PlanControlResult,
+  type PlanProjectionItem,
+  type PlanQueryInput,
+  type PlanQueryResult,
+} from '../protocol/index.js';
+import type { PlanOperationHandlerMap } from './operation-dispatcher.js';
+import { SessionAdmissionGate, type SessionAdmissionLease } from './session-admission-gate.js';
+
+type PlanRuntime = Pick<
+  SessionManager,
+  | 'requestPlanRevision'
+  | 'abandonPlanProposal'
+  | 'approvePlan'
+  | 'resumePlanExecution'
+  | 'cancelPlanExecution'
+>;
+
+export interface HostPlanCoordinatorInput {
+  readonly store: InteractivePlanStoreWriter;
+  readonly sessions: Pick<ExecutionSessionWriter, 'readHeaderSnapshot'>;
+  readonly runtime: PlanRuntime;
+  readonly sessionAdmission: SessionAdmissionGate;
+  readonly isSessionActive: (sessionId: string) => boolean;
+  readonly refreshContinuity: (sessionId: string, lease: SessionAdmissionLease) => Promise<void>;
+  readonly requestDrain: () => void;
+}
+
+/** Host-owned Plan query and user-control boundary. */
+export class HostPlanCoordinator {
+  readonly handlers: PlanOperationHandlerMap = {
+    'plan.query': (input) => this.#sessionAdmission.run(input.sessionId, () => this.#query(input)),
+    'plan.control': (input) =>
+      this.#sessionAdmission.run(input.sessionId, (lease) => this.#control(input, lease)),
+  };
+
+  readonly #store: InteractivePlanStoreWriter;
+  readonly #sessions: HostPlanCoordinatorInput['sessions'];
+  readonly #runtime: PlanRuntime;
+  readonly #sessionAdmission: SessionAdmissionGate;
+  readonly #isSessionActive: (sessionId: string) => boolean;
+  readonly #refreshContinuity: HostPlanCoordinatorInput['refreshContinuity'];
+  readonly #requestDrain: () => void;
+
+  constructor(input: HostPlanCoordinatorInput) {
+    this.#store = authenticateInteractivePlanStoreWriter(input.store);
+    this.#sessions = input.sessions;
+    this.#runtime = input.runtime;
+    this.#sessionAdmission = input.sessionAdmission;
+    this.#isSessionActive = input.isSessionActive;
+    this.#refreshContinuity = input.refreshContinuity;
+    this.#requestDrain = input.requestDrain;
+  }
+
+  async #query(input: PlanQueryInput): Promise<OperationOutcome<'plan.query'>> {
+    const unavailable = await this.#assertSessionAvailable(input.sessionId);
+    if (unavailable) return failure(unavailable.code, unavailable.message);
+    try {
+      const state = await this.#store.readState(input.sessionId);
+      if (input.kind === 'list_continue' && input.storeVersion !== state.storeVersion) {
+        return success({
+          kind: 'revision_changed',
+          expected: input.storeVersion,
+          actual: state.storeVersion,
+        });
+      }
+      let offset = 0;
+      if (input.kind === 'list_continue') {
+        try {
+          offset = decodeCursor(input.cursor);
+        } catch {
+          return failure('invalid_request', 'Plan cursor is invalid');
+        }
+      }
+      const items: PlanProjectionItem[] = [
+        ...state.proposals.map((proposal) => ({ kind: 'proposal' as const, proposal })),
+        ...state.executions.map((execution) => ({ kind: 'execution' as const, execution })),
+      ];
+      if (offset > items.length) {
+        return failure('invalid_request', 'Plan cursor is outside the current projection');
+      }
+      return success(
+        fitPage(
+          {
+            sessionId: input.sessionId,
+            storeVersion: state.storeVersion,
+            latestProposalId: state.latestProposalId ?? null,
+            activeExecutionId: state.activeExecutionId ?? null,
+          },
+          items,
+          offset,
+        ),
+      );
+    } catch (error) {
+      if (isSessionNotFoundError(error)) return failure('not_found', 'Session does not exist');
+      return failure('internal_failure', 'Plan projection is unavailable');
+    }
+  }
+
+  async #control(
+    input: PlanControlInput,
+    lease: SessionAdmissionLease,
+  ): Promise<OperationOutcome<'plan.control'>> {
+    let replay = false;
+    try {
+      replay =
+        (await this.#store.readOperationReceipt(
+          input.sessionId,
+          input.operationId,
+          planUserControlMutationInput(input),
+        )) !== undefined;
+    } catch (error) {
+      return this.#controlFailure(error);
+    }
+    if (!replay) {
+      const unavailable = await this.#assertSessionAvailable(input.sessionId);
+      if (unavailable) return controlAvailabilityFailure(unavailable.code, unavailable.message);
+      if (this.#isSessionActive(input.sessionId)) {
+        return controlFailure('session_busy', 'Session has an active root Turn');
+      }
+    }
+    try {
+      const result = await this.#applyControl(input);
+      await this.#refreshContinuity(input.sessionId, lease);
+      return { ok: true, result: projectControlResult(result) };
+    } catch (error) {
+      return this.#controlFailure(error);
+    }
+  }
+
+  #controlFailure(error: unknown): OperationOutcome<'plan.control'> {
+    if (isSessionNotFoundError(error)) {
+      return controlFailure('not_found', 'Session does not exist');
+    }
+    if (error instanceof PlanConflictError) {
+      return controlFailure('operation_conflict', error.message);
+    }
+    this.#requestDrain();
+    return controlFailure('persistence_failed', 'Plan control outcome is unknown');
+  }
+
+  #applyControl(input: PlanControlInput): Promise<PlanMutationResult> {
+    switch (input.kind) {
+      case 'request_revision':
+        return this.#runtime.requestPlanRevision(
+          input.sessionId,
+          input.proposalId,
+          input.operationId,
+        );
+      case 'abandon_proposal':
+        return this.#runtime.abandonPlanProposal(
+          input.sessionId,
+          input.proposalId,
+          input.operationId,
+        );
+      case 'approve_proposal':
+        return this.#runtime.approvePlan({
+          sessionId: input.sessionId,
+          proposalId: input.proposalId,
+          expectedRevision: input.expectedRevision,
+          expectedStoreVersion: input.expectedStoreVersion,
+          operationId: input.operationId,
+        });
+      case 'resume_execution':
+        return this.#runtime.resumePlanExecution(
+          input.sessionId,
+          input.executionId,
+          input.operationId,
+        );
+      case 'cancel_execution':
+        return this.#runtime.cancelPlanExecution(
+          input.sessionId,
+          input.executionId,
+          input.operationId,
+        );
+    }
+  }
+
+  async #assertSessionAvailable(sessionId: string): Promise<
+    | {
+        code: 'not_found' | 'session_archived' | 'internal_failure';
+        message: string;
+      }
+    | undefined
+  > {
+    try {
+      const header = await this.#sessions.readHeaderSnapshot(sessionId);
+      if (header.isArchived || header.status === 'archived') {
+        return { code: 'session_archived', message: 'Session is archived' };
+      }
+      return undefined;
+    } catch (error) {
+      if (isSessionNotFoundError(error)) {
+        return { code: 'not_found', message: 'Session does not exist' };
+      }
+      return { code: 'internal_failure', message: 'Session authority is unavailable' };
+    }
+  }
+}
+
+function fitPage(
+  header: {
+    readonly sessionId: string;
+    readonly storeVersion: number;
+    readonly latestProposalId: string | null;
+    readonly activeExecutionId: string | null;
+  },
+  allItems: readonly PlanProjectionItem[],
+  offset: number,
+): Extract<PlanQueryResult, { kind: 'page' }> {
+  const items: PlanProjectionItem[] = [];
+  const limit = Math.min(allItems.length, offset + PLAN_PAGE_MAX_ITEMS);
+  for (let index = offset; index < limit; index += 1) {
+    const candidate = [...items, structuredClone(allItems[index]!)];
+    const nextOffset = offset + candidate.length;
+    const page = planPage(header, candidate, nextOffset, allItems.length);
+    if (Buffer.byteLength(JSON.stringify(page), 'utf8') > PLAN_RESULT_MAX_BYTES) {
+      if (items.length === 0) throw new Error('Persisted Plan item exceeds its wire invariant');
+      break;
+    }
+    items.push(candidate.at(-1)!);
+  }
+  return planPage(header, items, offset + items.length, allItems.length);
+}
+
+function planPage(
+  header: Parameters<typeof fitPage>[0],
+  items: readonly PlanProjectionItem[],
+  nextOffset: number,
+  total: number,
+): Extract<PlanQueryResult, { kind: 'page' }> {
+  return {
+    kind: 'page',
+    ...header,
+    items,
+    nextCursor: nextOffset < total ? String(nextOffset) : null,
+  };
+}
+
+function decodeCursor(cursor: string): number {
+  if (!/^\d+$/.test(cursor)) throw new PlanConflictError('Invalid Plan cursor');
+  const offset = Number(cursor);
+  if (!Number.isSafeInteger(offset)) throw new PlanConflictError('Invalid Plan cursor');
+  return offset;
+}
+
+function projectControlResult(result: PlanMutationResult): PlanControlResult {
+  return projectControlEvent(result.event);
+}
+
+function projectControlEvent(event: PlanEvent): PlanControlResult {
+  return {
+    sessionId: event.sessionId,
+    storeVersion: event.storeVersion,
+    eventType: event.type,
+    proposalId: proposalId(event),
+    executionId: executionId(event),
+  };
+}
+
+function proposalId(event: PlanEvent): string | null {
+  if (event.type === 'plan_submitted') return event.proposal.proposalId;
+  return 'proposalId' in event ? event.proposalId : null;
+}
+
+function executionId(event: PlanEvent): string | null {
+  if (event.type === 'plan_approved') return event.execution.executionId;
+  return 'executionId' in event ? event.executionId : null;
+}
+
+function success(result: PlanQueryResult): OperationOutcome<'plan.query'> {
+  return { ok: true, result };
+}
+
+function failure(
+  code: 'not_found' | 'session_archived' | 'invalid_request' | 'internal_failure',
+  message: string,
+): OperationOutcome<'plan.query'> {
+  return { ok: false, error: { code, message } };
+}
+
+function controlFailure(
+  code: 'not_found' | 'session_busy' | 'operation_conflict' | 'persistence_failed',
+  message: string,
+): OperationOutcome<'plan.control'> {
+  return { ok: false, error: { code, message } };
+}
+
+function controlAvailabilityFailure(
+  code: 'not_found' | 'session_archived' | 'internal_failure',
+  message: string,
+): OperationOutcome<'plan.control'> {
+  return { ok: false, error: { code, message } };
+}

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -2596,6 +2596,7 @@ export class RootTurnCoordinator {
         startSettled.resolve();
       }
       this.observeGoalOutcome(active, goalOutcomeFromSnapshot(snapshot));
+      await this.interruptPlanAfterUnsuccessfulTurn(input.sessionId, active, snapshot.status);
       terminalTransitionStarted = true;
       await this.completeTerminalTransition(input.sessionId, active);
     } catch (error) {
@@ -2615,6 +2616,7 @@ export class RootTurnCoordinator {
               executionAuditFailure = auditFailure;
             }
             this.observeGoalOutcome(active, goalOutcomeFromSnapshot(snapshot));
+            await this.interruptPlanAfterUnsuccessfulTurn(input.sessionId, active, snapshot.status);
             terminalTransitionStarted = true;
             await this.completeTerminalTransition(input.sessionId, active);
             containedRunFailure =
@@ -2672,6 +2674,21 @@ export class RootTurnCoordinator {
     if (active.observedGoalOutcome) return;
     active.observedGoalOutcome = outcome;
     if (active.observedGoalSettler) void active.observedGoalSettler(outcome);
+  }
+
+  private async interruptPlanAfterUnsuccessfulTurn(
+    sessionId: string,
+    active: ActiveRootTurn,
+    status: string,
+  ): Promise<void> {
+    if (status === 'completed' || !this.manager.hasPlanAuthority()) return;
+    await this.manager.interruptActivePlanExecution(
+      sessionId,
+      status === 'cancelled'
+        ? 'Plan execution was interrupted because the Runtime root Turn was cancelled.'
+        : 'Plan execution was interrupted because the Runtime root Turn failed.',
+      `plan_interrupt_${active.runId}`,
+    );
   }
 
   private completeTerminalTransition(sessionId: string, active: ActiveRootTurn): Promise<void> {

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -290,12 +290,6 @@ export class HostSessionCatalogCoordinator {
   async #updateConfiguration(
     input: SessionConfigurationUpdateInput,
   ): Promise<OperationOutcome<'session.configuration.update'>> {
-    if (input.configuration.collaborationMode === 'plan') {
-      return configurationFailure(
-        'operation_unavailable',
-        'Plan sessions are not yet supported by Runtime Host',
-      );
-    }
     return this.#admission.run(input.sessionId, async (lease) => {
       let commitAttempted = false;
       try {
@@ -647,12 +641,6 @@ interface PreparedSessionCreate {
 async function prepareCreate(input: SessionCreateInput): Promise<PreparedSessionCreate> {
   if (!isAbsolute(input.cwd)) {
     throw new SessionOperationFailure('invalid_request', 'Session cwd must be absolute');
-  }
-  if (input.collaborationMode === 'plan') {
-    throw new SessionOperationFailure(
-      'operation_unavailable',
-      'Plan sessions are not yet supported by Runtime Host',
-    );
   }
   if (input.labels?.some(isExecutionSemanticLabel)) {
     throw new SessionOperationFailure(

--- a/packages/runtime/src/__tests__/plan-mode.test.ts
+++ b/packages/runtime/src/__tests__/plan-mode.test.ts
@@ -13,6 +13,7 @@ import type { MakaTool } from '../tool-runtime.js';
 describe('Plan Mode tool surface', () => {
   test('requires plain-text step titles and descriptions', () => {
     const submitPlan = buildSubmitPlanTool({} as never);
+    assert.equal(submitPlan.recoveryMode, 'idempotent');
     const schema = submitPlan.parameters as {
       safeParse(input: unknown): { success: boolean };
     };
@@ -41,6 +42,45 @@ describe('Plan Mode tool surface', () => {
       }).success,
       false,
     );
+    assert.equal(
+      schema.safeParse({
+        title: 'Plan',
+        steps: [{ id: 'step one', title: 'Inspect code', description: 'Read files.' }],
+      }).success,
+      false,
+    );
+    assert.equal(
+      schema.safeParse({
+        title: 'Plan',
+        steps: [
+          {
+            id: 'inspect',
+            title: 'Inspect code',
+            description: 'x'.repeat(16 * 1024 + 1),
+          },
+        ],
+      }).success,
+      false,
+    );
+    assert.equal(
+      schema.safeParse({
+        title: 'Plan',
+        steps: Array.from({ length: 16 }, (_, index) => ({
+          id: `step-${index}`,
+          title: `Step ${index}`,
+          description: 'x'.repeat(4_000),
+        })),
+      }).success,
+      false,
+    );
+    const lifecycleSteps = (descriptionBytes: number) =>
+      Array.from({ length: 50 }, (_, index) => ({
+        id: `step-${index}`,
+        title: `Step ${index}`,
+        description: 'x'.repeat(descriptionBytes),
+      }));
+    assert.equal(schema.safeParse({ title: 'Plan', steps: lifecycleSteps(900) }).success, true);
+    assert.equal(schema.safeParse({ title: 'Plan', steps: lifecycleSteps(1_100) }).success, false);
     assert.match(renderPlanModePrompt(), /plain text without Markdown formatting/);
   });
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -50,6 +50,7 @@ import type {
   TurnRecord,
 } from '@maka/core';
 import type { BackendSendInput, BackendStopMode } from '@maka/core/backend-types';
+import { PlanConflictError, emptyPlanSessionState, type PlanStore } from '@maka/core/plan';
 import { expect } from '../test-helpers.js';
 import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
 import { createTestAiSdkBackend } from './execution-boundary-test-helpers.js';
@@ -171,6 +172,239 @@ describe('SessionManager running-turn projection', () => {
 
     expect(listed.map((entry) => entry.id)).toEqual([session.id]);
     expect(listed[0]?.runningTurnIds).toEqual(undefined);
+  });
+});
+
+describe('SessionManager Plan control boundaries', () => {
+  test('an exact approval retry completes Session side effects after a partial failure', async () => {
+    const store = new MemorySessionStore();
+    const runtimeKernel = new DelegatingRuntimeKernel();
+    const sessionId = 'session-1';
+    let receipt: object | undefined;
+    let committedApprovals = 0;
+    const planStore = {
+      readOperationReceipt: async () => receipt,
+      approveProposal: async () => {
+        if (!receipt) {
+          committedApprovals += 1;
+          receipt = { id: 'approve-operation', type: 'plan_approved' };
+        }
+        return {
+          event: receipt,
+          state: { ...emptyPlanSessionState(sessionId), storeVersion: 1 },
+        };
+      },
+    } as unknown as PlanStore;
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      newId: nextId(),
+      now: nextNow(1),
+      planStore,
+      runtimeKernel,
+    });
+    await manager.createSession(makeInput({ collaborationMode: 'plan' }));
+    const input = {
+      sessionId,
+      proposalId: 'proposal-1',
+      expectedRevision: 1,
+      expectedStoreVersion: 1,
+      operationId: 'approve-operation',
+    };
+
+    store.failUpdateHeaderFor.add(sessionId);
+    await assert.rejects(manager.approvePlan(input), /Cannot update header/);
+    store.failUpdateHeaderFor.delete(sessionId);
+    runtimeKernel.activeRuns = true;
+
+    await manager.approvePlan(input);
+
+    expect(committedApprovals).toBe(1);
+    expect((await store.readHeader(sessionId)).collaborationMode).toBe('agent');
+    expect(runtimeKernel.disposed).toEqual([sessionId]);
+  });
+
+  test('does not commit a same-mode Plan revision before backend disposal succeeds', async () => {
+    const store = new MemorySessionStore();
+    const runtimeKernel = new DelegatingRuntimeKernel();
+    const sessionId = 'session-1';
+    let receipt: object | undefined;
+    let committedRevisions = 0;
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      newId: nextId(),
+      now: nextNow(1),
+      runtimeKernel,
+      planStore: {
+        readOperationReceipt: async () => receipt,
+        requestRevision: async () => {
+          committedRevisions += 1;
+          receipt = { id: 'revision-operation', type: 'plan_revision_requested' };
+          return {
+            event: receipt,
+            state: { ...emptyPlanSessionState(sessionId), storeVersion: 1 },
+          };
+        },
+      } as unknown as PlanStore,
+    });
+    await manager.createSession(makeInput({ collaborationMode: 'plan' }));
+
+    runtimeKernel.failNextDispose = true;
+    await assert.rejects(
+      manager.requestPlanRevision(sessionId, 'proposal-1', 'revision-operation'),
+      /backend disposal failed/,
+    );
+    expect(committedRevisions).toBe(0);
+
+    await manager.requestPlanRevision(sessionId, 'proposal-1', 'revision-operation');
+    expect(committedRevisions).toBe(1);
+    expect(runtimeKernel.disposed).toEqual([sessionId]);
+  });
+
+  test('does not commit Plan cancellation before backend disposal succeeds', async () => {
+    const store = new MemorySessionStore();
+    const runtimeKernel = new DelegatingRuntimeKernel();
+    const sessionId = 'session-1';
+    const planState = {
+      ...emptyPlanSessionState(sessionId),
+      storeVersion: 2,
+      executions: [
+        {
+          executionId: 'execution-1',
+          planId: 'plan-1',
+          proposalId: 'proposal-1',
+          sessionId,
+          status: 'interrupted' as const,
+          steps: [],
+          startedAt: 1,
+          updatedAt: 2,
+          interruptedAt: 2,
+          interruptionReason: 'Host restart',
+        },
+      ],
+    };
+    let receipt: object | undefined;
+    let committedCancellations = 0;
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      newId: nextId(),
+      now: nextNow(1),
+      runtimeKernel,
+      planStore: {
+        readState: async () => structuredClone(planState),
+        readOperationReceipt: async () => receipt,
+        cancelExecution: async () => {
+          committedCancellations += 1;
+          receipt = { id: 'cancel-operation', type: 'plan_execution_cancelled' };
+          return { event: receipt, state: { ...planState, storeVersion: 3 } };
+        },
+      } as unknown as PlanStore,
+    });
+    await manager.createSession(makeInput());
+
+    runtimeKernel.failNextDispose = true;
+    await assert.rejects(
+      manager.cancelPlanExecution(sessionId, 'execution-1', 'cancel-operation'),
+      /backend disposal failed/,
+    );
+    expect(committedCancellations).toBe(0);
+
+    await manager.cancelPlanExecution(sessionId, 'execution-1', 'cancel-operation');
+    expect(committedCancellations).toBe(1);
+    expect(runtimeKernel.disposed).toEqual([sessionId]);
+  });
+
+  test('classifies an ineligible execution cancellation as a domain conflict', async () => {
+    const store = new MemorySessionStore();
+    const sessionId = 'session-1';
+    const planState = {
+      ...emptyPlanSessionState(sessionId),
+      storeVersion: 2,
+      activeExecutionId: 'execution-1',
+      executions: [
+        {
+          executionId: 'execution-1',
+          planId: 'plan-1',
+          proposalId: 'proposal-1',
+          sessionId,
+          status: 'active' as const,
+          steps: [],
+          startedAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    };
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      newId: nextId(),
+      now: nextNow(1),
+      planStore: {
+        readState: async () => structuredClone(planState),
+        readOperationReceipt: async () => undefined,
+      } as unknown as PlanStore,
+    });
+    await manager.createSession(makeInput());
+
+    await assert.rejects(
+      manager.cancelPlanExecution(sessionId, 'execution-1', 'cancel-operation'),
+      (error: unknown) => {
+        assert.ok(error instanceof PlanConflictError);
+        assert.match(error.message, /interrupted/);
+        return true;
+      },
+    );
+  });
+
+  test('rejects Plan mode for a linked child Session', async () => {
+    const store = new VersionedConfigurationMemorySessionStore();
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      newId: nextId(),
+      now: nextNow(1),
+      planStore: {
+        readState: async (sessionId: string) => emptyPlanSessionState(sessionId),
+      } as unknown as PlanStore,
+    });
+    const child = await manager.createSession(
+      makeInput({
+        subagentParent: {
+          kind: 'subagent',
+          parentSessionId: 'parent-session',
+          spawnedBy: {
+            parentRunId: 'parent-run',
+            parentTurnId: 'parent-turn',
+            toolCallId: 'tool-call',
+          },
+          lifecycle: 'foreground',
+        },
+      }),
+    );
+
+    await assert.rejects(
+      manager.transitionSessionConfiguration(child.id, {
+        expectedRevision: 1,
+        configuration: {
+          backend: child.backend,
+          llmConnectionSlug: child.llmConnectionSlug,
+          connectionLocked: true,
+          model: child.model,
+          thinkingLevel: child.thinkingLevel,
+          permissionMode: child.permissionMode,
+          collaborationMode: 'plan',
+          orchestrationMode: child.orchestrationMode ?? 'default',
+        },
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof SessionConfigurationTransitionError);
+        assert.equal(error.code, 'operation_unavailable');
+        return true;
+      },
+    );
+    assert.equal((await store.readHeader(child.id)).collaborationMode, 'agent');
   });
 });
 
@@ -19482,6 +19716,7 @@ class DelegatingRuntimeKernel implements RuntimeKernelLike {
   readonly stopped: string[] = [];
   readonly permissionResponses: string[] = [];
   activeRuns = false;
+  failNextDispose = false;
   disposed: string[] = [];
   cachedHeaders: SessionHeader[] = [];
 
@@ -19595,6 +19830,10 @@ class DelegatingRuntimeKernel implements RuntimeKernelLike {
   }
 
   async disposeBackend(sessionId: string): Promise<void> {
+    if (this.failNextDispose) {
+      this.failNextDispose = false;
+      throw new Error('backend disposal failed');
+    }
     this.disposed.push(sessionId);
   }
 }

--- a/packages/runtime/src/plan-tools.ts
+++ b/packages/runtime/src/plan-tools.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { z } from 'zod';
 import type {
   PlanExecution,
@@ -6,33 +7,57 @@ import type {
   PlanStepStatus,
   PlanStore,
 } from '@maka/core/plan';
+import {
+  PLAN_MAX_FILES_PER_STEP,
+  PLAN_MAX_RISKS,
+  PLAN_MAX_STEPS,
+  PLAN_LIFECYCLE_REASON_MAX_BYTES,
+  PLAN_STEP_TITLE_MAX_CHARS,
+  isCanonicalPlanEntityId,
+  isPlanProposalLifecycleAdmissible,
+  isPlanTextWithinLimit,
+} from '@maka/core/plan';
 
 import type { MakaTool } from './tool-runtime.js';
 
 const MARKDOWN_PATTERN =
   /(^|\n)\s{0,3}(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|>\s|```|~~~)|!?(?:\[[^\]\n]+\]\([^)\n]+\))|(?:\*\*|__|`)/;
 
+const boundedTextSchema = (label: string, maxBytes?: number) =>
+  z
+    .string()
+    .trim()
+    .min(1)
+    .refine((value) => isPlanTextWithinLimit(value, maxBytes), {
+      message: `${label} exceeds the Plan text limit`,
+    });
+
 const plainTextSchema = (label: string) =>
   z
     .string()
     .trim()
     .min(1)
+    .refine(isPlanTextWithinLimit, { message: `${label} exceeds the Plan text limit` })
     .refine((value) => !MARKDOWN_PATTERN.test(value), {
       message: `${label} must be plain text without Markdown formatting`,
     });
 
 const stepDefinitionSchema = z.object({
-  id: z.string().trim().min(1),
-  title: plainTextSchema('Plan step title').max(30),
+  id: z.string().trim().refine(isCanonicalPlanEntityId, {
+    message: 'Plan step id must be a canonical entity id',
+  }),
+  title: plainTextSchema('Plan step title').max(PLAN_STEP_TITLE_MAX_CHARS),
   description: plainTextSchema('Plan step description'),
-  files: z.array(z.string().min(1)).optional(),
+  files: z.array(boundedTextSchema('Plan step file')).max(PLAN_MAX_FILES_PER_STEP).optional(),
   complexity: z.enum(['low', 'medium', 'high']).optional(),
 });
 
 const executionStepSchema = z.object({
-  id: z.string().min(1),
+  id: z.string().refine(isCanonicalPlanEntityId, {
+    message: 'Plan step id must be a canonical entity id',
+  }),
   status: z.enum(['pending', 'in_progress', 'completed', 'skipped']),
-  note: z.string().min(1).optional(),
+  note: boundedTextSchema('Plan step note').optional(),
 });
 
 export type PlanToolResult =
@@ -74,14 +99,21 @@ export function buildSubmitPlanTool(
     name: 'SubmitPlan',
     description:
       'Submit the finished implementation plan for user approval. Every step requires a concise plain-text title and a detailed plain-text description; do not use Markdown in either field. This ends the planning turn, so do not call it until the plan is ready to review.',
-    parameters: z.object({
-      title: z.string().min(1),
-      overview: z.string().min(1).optional(),
-      steps: z.array(stepDefinitionSchema).min(1).max(50),
-      risks: z.array(z.string().min(1)).max(20).optional(),
-    }),
+    parameters: z
+      .object({
+        title: boundedTextSchema('Plan title'),
+        overview: boundedTextSchema('Plan overview').optional(),
+        steps: z.array(stepDefinitionSchema).min(1).max(PLAN_MAX_STEPS),
+        risks: z.array(boundedTextSchema('Plan risk')).max(PLAN_MAX_RISKS).optional(),
+      })
+      .refine(
+        isPlanProposalLifecycleAdmissible,
+        'Plan proposal cannot fit its execution lifecycle projection',
+      ),
+    recoveryMode: 'idempotent',
     impl: async (input, context) => {
       const result = await planStore.submitProposal({
+        operationId: planToolOperationId('submit', context),
         sessionId: context.sessionId,
         turnId: context.turnId,
         ...(sourceExecutionId ? { sourceExecutionId } : {}),
@@ -89,9 +121,10 @@ export function buildSubmitPlanTool(
       });
       return {
         kind: 'plan_submitted',
-        proposal: result.state.proposals.find(
-          (proposal) => proposal.proposalId === result.state.latestProposalId,
-        )!,
+        proposal:
+          result.event.type === 'plan_submitted'
+            ? result.event.proposal
+            : missingPlanToolProjection('SubmitPlan'),
         storeVersion: result.state.storeVersion,
       };
     },
@@ -113,11 +146,13 @@ export function buildUpdatePlanTool(
     description:
       'Update execution progress for the approved plan. Include every plan step and keep at most one step in_progress.',
     parameters: z.object({
-      steps: z.array(executionStepSchema).min(1).max(50),
-      explanation: z.string().min(1).optional(),
+      steps: z.array(executionStepSchema).min(1).max(PLAN_MAX_STEPS),
+      explanation: boundedTextSchema('Plan progress explanation').optional(),
     }),
+    recoveryMode: 'idempotent',
     impl: async (input, context) => {
       const result = await planStore.updateExecution({
+        operationId: planToolOperationId('update', context),
         sessionId: context.sessionId,
         executionId,
         ...input,
@@ -135,9 +170,13 @@ export function buildCancelPlanTool(
     name: 'cancel_plan',
     description:
       'Cancel the active plan execution when the user explicitly asks to abandon it. Explain the user request in reason.',
-    parameters: z.object({ reason: z.string().min(1) }),
+    parameters: z.object({
+      reason: boundedTextSchema('Plan cancellation reason', PLAN_LIFECYCLE_REASON_MAX_BYTES),
+    }),
+    recoveryMode: 'idempotent',
     impl: async ({ reason }, context) => {
       const result = await planStore.cancelExecution({
+        operationId: planToolOperationId('cancel', context),
         sessionId: context.sessionId,
         executionId,
         reason,
@@ -145,6 +184,25 @@ export function buildCancelPlanTool(
       return executionResult(result);
     },
   };
+}
+
+function planToolOperationId(
+  kind: 'submit' | 'update' | 'cancel',
+  context: { sessionId: string; turnId: string; toolCallId: string },
+): string {
+  return `plan_${createHash('sha256')
+    .update(kind)
+    .update('\0')
+    .update(context.sessionId)
+    .update('\0')
+    .update(context.turnId)
+    .update('\0')
+    .update(context.toolCallId)
+    .digest('hex')}`;
+}
+
+function missingPlanToolProjection(toolName: string): never {
+  throw new Error(`${toolName} received an incompatible idempotent Plan result`);
 }
 
 function executionResult(result: PlanMutationResult): PlanToolResult {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -61,11 +61,14 @@ import type {
 } from '@maka/core';
 import type { CollaborationMode } from '@maka/core/collaboration';
 import type { OrchestrationMode } from '@maka/core/orchestration';
-import type {
-  ApprovePlanProposalInput,
-  PlanMutationResult,
-  PlanSessionState,
-  PlanStore,
+import {
+  PLAN_USER_ABANDON_REASON,
+  PLAN_USER_CANCEL_REASON,
+  PlanConflictError,
+  type ApprovePlanProposalInput,
+  type PlanMutationResult,
+  type PlanSessionState,
+  type PlanStore,
 } from '@maka/core/plan';
 import {
   DEFAULT_SESSION_NAME,
@@ -1777,10 +1780,17 @@ export class SessionManager {
     return this.requirePlanStore().readState(sessionId);
   }
 
+  hasPlanAuthority(): boolean {
+    return this.deps.planStore !== undefined;
+  }
+
   async setCollaborationMode(sessionId: string, mode: CollaborationMode): Promise<SessionSummary> {
     const previous = await this.deps.store.readHeader(sessionId);
     const from = previous.collaborationMode ?? 'agent';
     if (from === mode) return headerToSummary(previous);
+    if (mode === 'plan' && previous.subagentParent) {
+      throw new PlanConflictError('Linked child Sessions cannot enter Plan mode');
+    }
     if (this.runtimeKernel.hasActiveRuns(sessionId)) {
       throw new Error('当前对话正在运行，等结束后再切换协作模式。');
     }
@@ -1835,94 +1845,121 @@ export class SessionManager {
     return headerToSummary(next);
   }
 
-  async requestPlanRevision(sessionId: string, proposalId: string): Promise<PlanMutationResult> {
-    const result = await this.requirePlanStore().requestRevision({ sessionId, proposalId });
-    const header = await this.deps.store.readHeader(sessionId);
-    if ((header.collaborationMode ?? 'agent') !== 'plan') {
-      const next = await this.deps.store.updateHeader(sessionId, { collaborationMode: 'plan' });
-      this.runtimeKernel.updateCachedHeader(sessionId, next);
-    }
-    await this.runtimeKernel.disposeBackend(sessionId);
+  async requestPlanRevision(
+    sessionId: string,
+    proposalId: string,
+    operationId?: string,
+  ): Promise<PlanMutationResult> {
+    const input = {
+      sessionId,
+      proposalId,
+      ...(operationId ? { operationId } : {}),
+    };
+    const replay = await this.isPlanOperationReplay(sessionId, operationId, input);
+    if (!replay) await this.runtimeKernel.disposeBackend(sessionId);
+    const result = await this.requirePlanStore().requestRevision(input);
+    await this.finalizePlanCollaborationMode(sessionId, 'plan');
     return result;
   }
 
-  async abandonPlanProposal(sessionId: string, proposalId: string): Promise<PlanMutationResult> {
-    const header = await this.deps.store.readHeader(sessionId);
-    if (this.runtimeKernel.hasActiveRuns(sessionId)) {
-      throw new Error('当前对话仍在运行，无法放弃计划。');
-    }
-    if (header.status === 'waiting_for_user') {
-      throw new Error('当前有工具调用正在等待确认，无法放弃计划。');
-    }
-    const result = await this.requirePlanStore().abandonProposal({
+  async abandonPlanProposal(
+    sessionId: string,
+    proposalId: string,
+    operationId?: string,
+  ): Promise<PlanMutationResult> {
+    const input = {
       sessionId,
       proposalId,
-      reason: 'User exited Plan Mode before approval.',
-    });
-    const from = header.collaborationMode ?? 'agent';
-    const next = await this.deps.store.updateHeader(sessionId, { collaborationMode: 'agent' });
-    if (from !== 'agent') {
-      await this.deps.store.appendMessage(sessionId, {
-        type: 'system_note',
-        id: this.deps.newId(),
-        ts: this.deps.now(),
-        kind: 'mode_change',
-        data: { dimension: 'collaboration', from, to: 'agent' },
-      } satisfies SystemNoteMessage);
+      reason: PLAN_USER_ABANDON_REASON,
+      ...(operationId ? { operationId } : {}),
+    };
+    const replay = await this.isPlanOperationReplay(sessionId, operationId, input);
+    const header = await this.deps.store.readHeader(sessionId);
+    if (!replay && this.runtimeKernel.hasActiveRuns(sessionId)) {
+      throw new PlanConflictError('Cannot abandon a Plan while the Session is running');
     }
-    this.runtimeKernel.updateCachedHeader(sessionId, next);
-    await this.runtimeKernel.disposeBackend(sessionId);
+    if (!replay && header.status === 'waiting_for_user') {
+      throw new PlanConflictError('Cannot abandon a Plan while an Interaction is pending');
+    }
+    if (!replay) await this.runtimeKernel.disposeBackend(sessionId);
+    const result = await this.requirePlanStore().abandonProposal(input);
+    await this.finalizePlanAbandonment(sessionId, operationId, replay);
     return result;
   }
 
   async approvePlan(input: ApprovePlanProposalInput): Promise<PlanMutationResult> {
+    const replay = await this.isPlanOperationReplay(input.sessionId, input.operationId, input);
     const header = await this.deps.store.readHeader(input.sessionId);
-    if (this.runtimeKernel.hasActiveRuns(input.sessionId)) {
-      throw new Error('当前对话仍在运行，无法批准计划。');
+    if (!replay && this.runtimeKernel.hasActiveRuns(input.sessionId)) {
+      throw new PlanConflictError('Cannot approve a Plan while the Session is running');
     }
-    if (header.status === 'waiting_for_user') {
-      throw new Error('当前有工具调用正在等待确认，无法批准计划。');
+    if (!replay && header.status === 'waiting_for_user') {
+      throw new PlanConflictError('Cannot approve a Plan while an Interaction is pending');
     }
+    if (!replay) await this.runtimeKernel.disposeBackend(input.sessionId);
     const result = await this.requirePlanStore().approveProposal(input);
-    const next = await this.deps.store.updateHeader(input.sessionId, {
-      collaborationMode: 'agent',
-    });
-    this.runtimeKernel.updateCachedHeader(input.sessionId, next);
-    await this.runtimeKernel.disposeBackend(input.sessionId);
+    await this.finalizePlanCollaborationMode(input.sessionId, 'agent');
     return result;
   }
 
-  async resumePlanExecution(sessionId: string, executionId: string): Promise<PlanMutationResult> {
-    const result = await this.requirePlanStore().resumeExecution(sessionId, executionId);
-    const next = await this.deps.store.updateHeader(sessionId, { collaborationMode: 'agent' });
-    this.runtimeKernel.updateCachedHeader(sessionId, next);
-    await this.runtimeKernel.disposeBackend(sessionId);
-    return result;
-  }
-
-  async cancelPlanExecution(sessionId: string, executionId: string): Promise<PlanMutationResult> {
-    const planStore = this.requirePlanStore();
-    const state = await planStore.readState(sessionId);
-    const execution = state.executions.find((item) => item.executionId === executionId);
-    if (execution?.status !== 'interrupted') {
-      throw new Error('只有已中断的计划可以从这里放弃。');
-    }
-    const result = await planStore.cancelExecution({
+  async resumePlanExecution(
+    sessionId: string,
+    executionId: string,
+    operationId?: string,
+  ): Promise<PlanMutationResult> {
+    const input = { sessionId, executionId };
+    const replay = await this.isPlanOperationReplay(sessionId, operationId, input);
+    if (!replay) await this.runtimeKernel.disposeBackend(sessionId);
+    const result = await this.requirePlanStore().resumeExecution(
       sessionId,
       executionId,
-      reason: 'User abandoned the interrupted plan.',
-    });
-    await this.runtimeKernel.disposeBackend(sessionId);
+      operationId,
+    );
+    await this.finalizePlanCollaborationMode(sessionId, 'agent');
+    return result;
+  }
+
+  async cancelPlanExecution(
+    sessionId: string,
+    executionId: string,
+    operationId?: string,
+  ): Promise<PlanMutationResult> {
+    const planStore = this.requirePlanStore();
+    const input = {
+      sessionId,
+      executionId,
+      reason: PLAN_USER_CANCEL_REASON,
+      ...(operationId ? { operationId } : {}),
+    };
+    const replay = await this.isPlanOperationReplay(sessionId, operationId, input);
+    if (!replay) {
+      const state = await planStore.readState(sessionId);
+      const execution = state.executions.find((item) => item.executionId === executionId);
+      if (execution?.status !== 'interrupted') {
+        throw new PlanConflictError('Only an interrupted Plan execution can be abandoned');
+      }
+      await this.runtimeKernel.disposeBackend(sessionId);
+    }
+    const result = await planStore.cancelExecution(input);
     return result;
   }
 
   async interruptActivePlanExecution(
     sessionId: string,
     reason: string,
+    operationId?: string,
   ): Promise<PlanMutationResult | null> {
-    const result = await this.requirePlanStore().interruptActiveExecution(sessionId, reason);
-    if (result) await this.runtimeKernel.disposeBackend(sessionId);
-    return result;
+    const planStore = this.requirePlanStore();
+    const replay = await this.isPlanOperationReplay(sessionId, operationId, {
+      sessionId,
+      reason,
+    });
+    if (!replay) {
+      const state = await planStore.readState(sessionId);
+      if (!state.activeExecutionId) return null;
+      await this.runtimeKernel.disposeBackend(sessionId);
+    }
+    return planStore.interruptActiveExecution(sessionId, reason, operationId);
   }
 
   async remove(sessionId: string): Promise<void> {
@@ -5170,6 +5207,70 @@ export class SessionManager {
     return next;
   }
 
+  private async isPlanOperationReplay(
+    sessionId: string,
+    operationId: string | undefined,
+    operationInput: unknown,
+  ): Promise<boolean> {
+    if (!operationId) return false;
+    return (
+      (await this.requirePlanStore().readOperationReceipt(
+        sessionId,
+        operationId,
+        operationInput,
+      )) !== undefined
+    );
+  }
+
+  private async finalizePlanCollaborationMode(
+    sessionId: string,
+    mode: CollaborationMode,
+  ): Promise<void> {
+    const header = await this.deps.store.readHeader(sessionId);
+    const changed = (header.collaborationMode ?? 'agent') !== mode;
+    const next = changed
+      ? await this.deps.store.updateHeader(sessionId, { collaborationMode: mode })
+      : header;
+    this.runtimeKernel.updateCachedHeader(sessionId, next);
+  }
+
+  private async finalizePlanAbandonment(
+    sessionId: string,
+    operationId: string | undefined,
+    replay: boolean,
+  ): Promise<void> {
+    const header = await this.deps.store.readHeader(sessionId);
+    const from = header.collaborationMode ?? 'agent';
+    const changed = from !== 'agent';
+    const next = changed
+      ? await this.deps.store.updateHeader(sessionId, { collaborationMode: 'agent' })
+      : header;
+    this.runtimeKernel.updateCachedHeader(sessionId, next);
+
+    if (!changed && !replay) return;
+    if (!operationId) {
+      await this.deps.store.appendMessage(sessionId, {
+        type: 'system_note',
+        id: this.deps.newId(),
+        ts: this.deps.now(),
+        kind: 'mode_change',
+        data: { dimension: 'collaboration', from, to: 'agent' },
+      } satisfies SystemNoteMessage);
+      return;
+    }
+
+    const noteId = planAbandonmentNoteId(operationId);
+    const messages = await this.deps.store.readMessages(sessionId);
+    if (messages.some((message) => message.id === noteId)) return;
+    await this.deps.store.appendMessage(sessionId, {
+      type: 'system_note',
+      id: noteId,
+      ts: this.deps.now(),
+      kind: 'mode_change',
+      data: { dimension: 'collaboration', from: 'plan', to: 'agent' },
+    } satisfies SystemNoteMessage);
+  }
+
   private requirePlanStore(): PlanStore {
     if (!this.deps.planStore) throw new Error('Plan Mode is unavailable on this surface');
     return this.deps.planStore;
@@ -5192,6 +5293,12 @@ export class SessionManager {
     nextMode: CollaborationMode,
   ): Promise<void> {
     if ((current.collaborationMode ?? 'agent') === nextMode) return;
+    if (nextMode === 'plan' && current.subagentParent) {
+      throw new SessionConfigurationTransitionError(
+        'operation_unavailable',
+        'Linked child Sessions cannot enter Plan mode',
+      );
+    }
     const planStore = this.deps.planStore;
     if (!planStore) {
       throw new SessionConfigurationTransitionError(
@@ -5731,6 +5838,10 @@ export class SessionManager {
     if (latest && isTerminalTurnStatus(latest.status) && latest.status === status) return;
     await this.appendTurnState(sessionId, decision.turnId, status, decision.lineage, options);
   }
+}
+
+function planAbandonmentNoteId(operationId: string): string {
+  return `plan-abandonment-${createHash('sha256').update(operationId).digest('hex')}`;
 }
 
 function resumeFeatureDisabledPlan(): SafeBoundaryContinuationPlan {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -10,6 +10,7 @@
     ".": "./dist/index.js",
     "./artifact-stores": "./dist/artifact-stores.js",
     "./automation-authority": "./dist/automation-authority.js",
+    "./plan-authority": "./dist/plan-authority.js",
     "./execution-stores": "./dist/execution-stores.js",
     "./agent-graph-control-store": "./dist/agent-graph-control-store.js",
     "./interaction-store": "./dist/interaction-store-public.js",

--- a/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { createSqliteDeepResearchStore } from '../deep-research-store.js';
+import { acquireOperationalStateDatabase } from '../operational-state-store.js';
 import { createSqlitePlanReminderStore } from '../plan-reminder-store.js';
 import { createSqlitePlanStore } from '../plan-store.js';
 import { createSqliteTaskLedgerStore } from '../task-ledger-store.js';
@@ -56,6 +57,286 @@ describe('SQLite workflow stores', () => {
     });
   });
 
+  test('reconciles exact Plan retries through durable operation identity', async () => {
+    await withRoot(async (root) => {
+      const store = createSqlitePlanStore(root, {
+        newId: (() => {
+          let id = 0;
+          return () => `generated-${++id}`;
+        })(),
+        now: () => 100,
+      });
+      try {
+        const input = {
+          operationId: 'submit-operation',
+          sessionId: SESSION_ID,
+          turnId: 'turn-1',
+          title: 'Stable plan',
+          steps: [{ id: 'one', title: 'Persist once', description: 'Commit one event' }],
+        };
+        const submitted = await store.submitProposal(input);
+        await store.requestRevision({
+          operationId: 'revision-operation',
+          sessionId: SESSION_ID,
+          proposalId:
+            submitted.event.type === 'plan_submitted' ? submitted.event.proposal.proposalId : '',
+        });
+
+        const retried = await store.submitProposal(input);
+        assert.equal(retried.event.id, 'submit-operation');
+        assert.equal(retried.state.storeVersion, 1);
+        assert.equal(
+          (await store.readOperationReceipt(SESSION_ID, input.operationId, input))?.storeVersion,
+          1,
+        );
+        await assert.rejects(
+          store.submitProposal({ ...input, title: 'Reused identity' }),
+          /identity was reused/,
+        );
+        await assert.rejects(
+          store.readOperationReceipt(SESSION_ID, input.operationId, {
+            ...input,
+            title: 'Reused identity',
+          }),
+          /identity was reused/,
+        );
+        assert.equal((await store.readState(SESSION_ID)).storeVersion, 2);
+      } finally {
+        store.close();
+      }
+    });
+  });
+
+  test('rejects Plan data that the Runtime Host projection cannot represent', async () => {
+    await withRoot(async (root) => {
+      const store = createSqlitePlanStore(root);
+      try {
+        await assert.rejects(
+          store.submitProposal({
+            sessionId: SESSION_ID,
+            turnId: 'turn-1',
+            title: 'Invalid identifiers',
+            steps: [{ id: 'step one', title: 'Reject input', description: 'Invalid id' }],
+          }),
+          /canonical entity id/,
+        );
+        await assert.rejects(
+          store.submitProposal({
+            sessionId: SESSION_ID,
+            turnId: 'turn-2',
+            title: 'Oversized text',
+            steps: [
+              {
+                id: 'step-1',
+                title: 'Reject input',
+                description: 'x'.repeat(16 * 1024 + 1),
+              },
+            ],
+          }),
+          /text limit/,
+        );
+        await assert.rejects(
+          store.submitProposal({
+            sessionId: SESSION_ID,
+            turnId: 'turn-3',
+            title: 'Oversized projection',
+            steps: Array.from({ length: 16 }, (_, index) => ({
+              id: `step-${index}`,
+              title: `Step ${index}`,
+              description: 'x'.repeat(4_000),
+            })),
+          }),
+          /projection item limit/,
+        );
+        assert.equal((await store.readState(SESSION_ID)).storeVersion, 0);
+      } finally {
+        store.close();
+      }
+    });
+  });
+
+  test('reserves enough projection space for the complete Plan lifecycle', async () => {
+    await withRoot(async (root) => {
+      const store = createSqlitePlanStore(root);
+      try {
+        const submitted = await store.submitProposal({
+          operationId: 'submit-lifecycle',
+          sessionId: SESSION_ID,
+          turnId: 'turn-lifecycle',
+          title: 'Lifecycle-safe plan',
+          steps: Array.from({ length: 50 }, (_, index) => ({
+            id: `step-${index}`,
+            title: `Step ${index}`,
+            description: 'x'.repeat(900),
+          })),
+        });
+        assert.equal(submitted.event.type, 'plan_submitted');
+        if (submitted.event.type !== 'plan_submitted') return;
+        const approval = {
+          sessionId: SESSION_ID,
+          proposalId: submitted.event.proposal.proposalId,
+          expectedRevision: submitted.event.proposal.revision,
+          expectedStoreVersion: submitted.state.storeVersion,
+        };
+        const approved = await store.approveProposal({
+          ...approval,
+          operationId: 'approve-lifecycle',
+        });
+        await assert.rejects(
+          store.approveProposal({ ...approval, operationId: 'approve-again' }),
+          /already approved by another operation/,
+        );
+        assert.equal(approved.event.type, 'plan_approved');
+        if (approved.event.type !== 'plan_approved') return;
+
+        await store.interruptActiveExecution(SESSION_ID, 'i'.repeat(1024), 'interrupt-lifecycle');
+        const cancelled = await store.cancelExecution({
+          operationId: 'cancel-lifecycle',
+          sessionId: SESSION_ID,
+          executionId: approved.event.execution.executionId,
+          reason: 'c'.repeat(1024),
+        });
+
+        assert.equal(cancelled.state.storeVersion, 4);
+        assert.equal(cancelled.state.executions[0]?.status, 'cancelled');
+      } finally {
+        store.close();
+      }
+    });
+  });
+
+  test('rejects proposals whose later lifecycle projection would overflow', async () => {
+    await withRoot(async (root) => {
+      const store = createSqlitePlanStore(root);
+      try {
+        await assert.rejects(
+          store.submitProposal({
+            sessionId: SESSION_ID,
+            turnId: 'turn-lifecycle-overflow',
+            title: 'Lifecycle overflow',
+            steps: Array.from({ length: 50 }, (_, index) => ({
+              id: `step-${index}`,
+              title: `Step ${index}`,
+              description: 'x'.repeat(1_100),
+            })),
+          }),
+          /projection item limit/,
+        );
+      } finally {
+        store.close();
+      }
+    });
+  });
+
+  test('projects a pre-bound legacy Plan ledger into the bounded Host contract', async () => {
+    await withRoot(async (root) => {
+      seedLegacyPlanLedger(root);
+      const store = createSqlitePlanStore(root);
+      try {
+        const state = await store.readState(SESSION_ID);
+        const proposal = state.proposals[0];
+        const execution = state.executions[0];
+        assert.ok(proposal);
+        assert.ok(execution);
+        assert.match(proposal.steps[0]!.id, /^[A-Za-z0-9_-]+$/);
+        assert.equal(proposal.steps[0]!.files?.length, 50);
+        assert.equal(proposal.risks?.length, 20);
+        assert.ok(Buffer.byteLength(proposal.steps[0]!.description, 'utf8') < 4_000);
+        assert.equal(proposal.legacyProjection?.truncated, true);
+        assert.equal(execution.legacyProjection?.truncated, true);
+        assert.ok(Buffer.byteLength(proposal.title, 'utf8') < 16 * 1024);
+        assert.ok(proposal.steps[0]!.title.length <= 30);
+
+        await assert.rejects(
+          store.updateExecution({
+            operationId: 'update-legacy',
+            sessionId: SESSION_ID,
+            executionId: execution.executionId,
+            steps: execution.steps.map((step) => ({ id: step.id, status: step.status })),
+          }),
+          /projected legacy execution/,
+        );
+        const interrupted = await store.interruptActiveExecution(
+          SESSION_ID,
+          'Upgrade requires a fresh Plan',
+          'interrupt-legacy',
+        );
+        assert.equal(interrupted?.state.executions[0]?.status, 'interrupted');
+        await assert.rejects(
+          store.resumeExecution(SESSION_ID, execution.executionId, 'resume-legacy'),
+          /projected legacy execution/,
+        );
+
+        const cancelled = await store.cancelExecution({
+          operationId: 'cancel-legacy',
+          sessionId: SESSION_ID,
+          executionId: execution.executionId,
+          reason: 'Legacy execution closed after upgrade',
+        });
+        assert.equal(cancelled.state.storeVersion, 5);
+        assert.equal(cancelled.state.executions[0]?.status, 'cancelled');
+      } finally {
+        store.close();
+      }
+    });
+  });
+
+  test('requires a projected legacy proposal to be revised or abandoned', async () => {
+    await withRoot(async (root) => {
+      seedLegacyPlanLedger(root, 1);
+      const store = createSqlitePlanStore(root);
+      try {
+        const state = await store.readState(SESSION_ID);
+        const proposal = state.proposals[0];
+        assert.ok(proposal);
+        assert.equal(proposal.legacyProjection?.truncated, true);
+        await assert.rejects(
+          store.approveProposal({
+            operationId: 'approve-legacy',
+            sessionId: SESSION_ID,
+            proposalId: proposal.proposalId,
+            expectedRevision: proposal.revision,
+            expectedStoreVersion: state.storeVersion,
+          }),
+          /projected legacy plan/,
+        );
+
+        const revised = await store.requestRevision({
+          operationId: 'revise-legacy',
+          sessionId: SESSION_ID,
+          proposalId: proposal.proposalId,
+        });
+        assert.equal(revised.state.proposals[0]?.status, 'stale');
+      } finally {
+        store.close();
+      }
+    });
+  });
+
+  test('purges Plan events and projections for retired Sessions', async () => {
+    await withRoot(async (root) => {
+      const store = createSqlitePlanStore(root);
+      try {
+        await store.submitProposal({
+          sessionId: SESSION_ID,
+          turnId: 'turn-1',
+          title: 'Disposable plan',
+          steps: [{ id: 'one', title: 'Remove state', description: 'Purge the ledger' }],
+        });
+        await store.purgeSessionState(SESSION_ID);
+        assert.deepEqual(await store.readState(SESSION_ID), {
+          schemaVersion: 1,
+          sessionId: SESSION_ID,
+          storeVersion: 0,
+          proposals: [],
+          executions: [],
+        });
+      } finally {
+        store.close();
+      }
+    });
+  });
+
   test('persists Deep Research events', async () => {
     await withRoot(async (root) => {
       const store = createSqliteDeepResearchStore(root, {
@@ -89,6 +370,84 @@ describe('SQLite workflow stores', () => {
     });
   });
 });
+
+function seedLegacyPlanLedger(root: string, eventCount = 3): void {
+  const lease = acquireOperationalStateDatabase(root);
+  try {
+    const steps = Array.from({ length: 50 }, (_, index) => ({
+      id: `legacy step ${index}`,
+      title: '"'.repeat(100),
+      description: '"'.repeat(4_000),
+      files: Array.from({ length: 60 }, () => '"'.repeat(100)),
+    }));
+    const proposal = {
+      planId: 'legacy-plan',
+      proposalId: 'legacy-proposal',
+      sessionId: SESSION_ID,
+      turnId: 'legacy-turn',
+      revision: 1,
+      title: '"'.repeat(16 * 1024),
+      steps,
+      risks: Array.from({ length: 25 }, (_, index) => `Legacy risk ${index}`),
+      status: 'pending_approval',
+      submittedAt: 1,
+    };
+    const execution = {
+      executionId: 'legacy-execution',
+      planId: proposal.planId,
+      proposalId: proposal.proposalId,
+      sessionId: SESSION_ID,
+      status: 'active',
+      steps: steps.map((step) => ({ ...step, status: 'pending', updatedAt: 2 })),
+      startedAt: 2,
+      updatedAt: 2,
+    };
+    const events = [
+      {
+        type: 'plan_submitted',
+        id: 'legacy-submit',
+        sessionId: SESSION_ID,
+        ts: 1,
+        storeVersion: 1,
+        proposal,
+      },
+      {
+        type: 'plan_approved',
+        id: 'legacy-approve',
+        sessionId: SESSION_ID,
+        ts: 2,
+        storeVersion: 2,
+        proposalId: proposal.proposalId,
+        execution,
+      },
+      {
+        type: 'plan_progress_updated',
+        id: 'legacy-progress',
+        sessionId: SESSION_ID,
+        ts: 3,
+        storeVersion: 3,
+        executionId: execution.executionId,
+        steps: execution.steps.map((step, index) => ({
+          ...step,
+          status: index === 0 ? 'in_progress' : 'pending',
+          note: '"'.repeat(4_000),
+          updatedAt: 3,
+        })),
+        explanation: '"'.repeat(16 * 1024),
+      },
+    ];
+    const insert = lease.database.prepare(`
+      INSERT INTO workflow_plan_events(
+        session_id, sequence, event_id, store_version, record_json
+      ) VALUES (?, ?, ?, ?, ?)
+    `);
+    events.slice(0, eventCount).forEach((event, sequence) => {
+      insert.run(SESSION_ID, sequence, event.id, event.storeVersion, JSON.stringify(event));
+    });
+  } finally {
+    lease.close();
+  }
+}
 
 async function withRoot(run: (root: string) => Promise<void>): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'maka-sqlite-workflow-'));

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -95,6 +95,7 @@ export type {
   CreateSqlitePlanStoreOptions,
   SqlitePlanStore,
 } from './plan-store.js';
+export * from './plan-authority.js';
 export { createSqliteTaskLedgerStore } from './task-ledger-store.js';
 export type {
   ConversationTaskLedgerCopyInput,

--- a/packages/storage/src/plan-authority.ts
+++ b/packages/storage/src/plan-authority.ts
@@ -1,0 +1,148 @@
+import type {
+  AbandonPlanProposalInput,
+  ApprovePlanProposalInput,
+  CancelPlanExecutionInput,
+  PlanStore,
+  RequestPlanRevisionInput,
+  SubmitPlanProposalInput,
+  UpdatePlanExecutionInput,
+} from '@maka/core/plan';
+import {
+  assertStorageRootLease,
+  runWithStorageRootLease,
+  StorageRootAuthorityError,
+  type StorageRootLease,
+} from './root-authority.js';
+import { createSqlitePlanStore, type SqlitePlanStore } from './plan-store.js';
+
+const writerBrand: unique symbol = Symbol('InteractivePlanStoreWriter');
+const writers = new WeakSet<object>();
+const writerByLease = new WeakMap<object, InteractivePlanStoreWriter>();
+const writerOpeningByLease = new WeakMap<object, Promise<InteractivePlanStoreWriter>>();
+
+export interface InteractivePlanStoreWriter extends PlanStore {
+  readonly kind: 'interactive';
+  readonly access: 'write';
+  readonly [writerBrand]: true;
+  purgeSessionState(sessionId: string): Promise<void>;
+  close(): void;
+}
+
+export function authenticateInteractivePlanStoreWriter(
+  writer: InteractivePlanStoreWriter,
+): InteractivePlanStoreWriter {
+  if (!writers.has(writer)) {
+    throw new StorageRootAuthorityError(
+      'invalid_lease',
+      'Expected an authentic interactive Plan Store writer',
+    );
+  }
+  return writer;
+}
+
+export async function openInteractivePlanStoreForWrite(
+  lease: StorageRootLease<'interactive', 'write'>,
+): Promise<InteractivePlanStoreWriter> {
+  await assertStorageRootLease(lease, 'interactive', 'write');
+  const existing = writerByLease.get(lease);
+  if (existing) return existing;
+  const opening = writerOpeningByLease.get(lease);
+  if (opening) return opening;
+
+  const pending = Promise.resolve().then(async () => {
+    let store: SqlitePlanStore | undefined;
+    try {
+      store = await runWithStorageRootLease(lease, 'interactive', 'write', async (root) => {
+        const opened = createSqlitePlanStore(root);
+        try {
+          await opened.ready();
+          return opened;
+        } catch (error) {
+          opened.close();
+          throw error;
+        }
+      });
+      await assertStorageRootLease(lease, 'interactive', 'write');
+      const recoveredExisting = writerByLease.get(lease);
+      if (recoveredExisting) {
+        store.close();
+        return recoveredExisting;
+      }
+      const writer = createWriterFacade(lease, store);
+      writers.add(writer);
+      writerByLease.set(lease, writer);
+      return writer;
+    } catch (error) {
+      store?.close();
+      throw error;
+    }
+  });
+  writerOpeningByLease.set(lease, pending);
+  try {
+    return await pending;
+  } finally {
+    if (writerOpeningByLease.get(lease) === pending) writerOpeningByLease.delete(lease);
+  }
+}
+
+function createWriterFacade(
+  lease: StorageRootLease<'interactive', 'write'>,
+  store: SqlitePlanStore,
+): InteractivePlanStoreWriter {
+  let closed = false;
+  const run = <T>(operation: () => Promise<T>): Promise<T> => {
+    if (closed) {
+      return Promise.reject(
+        new StorageRootAuthorityError('invalid_lease', 'Plan Store writer is closed'),
+      );
+    }
+    return runWithStorageRootLease(lease, 'interactive', 'write', operation);
+  };
+  const writer: InteractivePlanStoreWriter = {
+    kind: 'interactive',
+    access: 'write',
+    [writerBrand]: true,
+    readState: (sessionId) => run(() => store.readState(sessionId)),
+    readOperationReceipt: (sessionId, operationId, operationInput) =>
+      run(() =>
+        store.readOperationReceipt(sessionId, operationId, structuredClone(operationInput)),
+      ),
+    submitProposal: (input) => run(() => store.submitProposal(cloneSubmit(input))),
+    requestRevision: (input) => run(() => store.requestRevision(cloneInput(input))),
+    abandonProposal: (input) => run(() => store.abandonProposal(cloneInput(input))),
+    approveProposal: (input) => run(() => store.approveProposal(cloneInput(input))),
+    updateExecution: (input) => run(() => store.updateExecution(cloneUpdate(input))),
+    cancelExecution: (input) => run(() => store.cancelExecution(cloneInput(input))),
+    interruptActiveExecution: (sessionId, reason, operationId) =>
+      run(() => store.interruptActiveExecution(sessionId, reason, operationId)),
+    resumeExecution: (sessionId, executionId, operationId) =>
+      run(() => store.resumeExecution(sessionId, executionId, operationId)),
+    purgeSessionState: (sessionId) => run(() => store.purgeSessionState(sessionId)),
+    close: () => {
+      if (closed) return;
+      closed = true;
+      if (writerByLease.get(lease) === writer) writerByLease.delete(lease);
+      writers.delete(writer);
+      store.close();
+    },
+  };
+  return Object.freeze(writer);
+}
+
+function cloneSubmit(input: SubmitPlanProposalInput): SubmitPlanProposalInput {
+  return structuredClone(input);
+}
+
+function cloneUpdate(input: UpdatePlanExecutionInput): UpdatePlanExecutionInput {
+  return structuredClone(input);
+}
+
+function cloneInput<
+  T extends
+    | RequestPlanRevisionInput
+    | AbandonPlanProposalInput
+    | ApprovePlanProposalInput
+    | CancelPlanExecutionInput,
+>(input: T): T {
+  return structuredClone(input);
+}

--- a/packages/storage/src/plan-legacy-projection.ts
+++ b/packages/storage/src/plan-legacy-projection.ts
@@ -1,0 +1,251 @@
+import { createHash } from 'node:crypto';
+import { isDeepStrictEqual } from 'node:util';
+import {
+  PLAN_MAX_FILES_PER_STEP,
+  PLAN_MAX_RISKS,
+  PLAN_MAX_STEPS,
+  PLAN_LIFECYCLE_REASON_MAX_BYTES,
+  PLAN_PROJECTION_ITEM_MAX_BYTES,
+  PLAN_STEP_TITLE_MAX_CHARS,
+  PLAN_TEXT_MAX_BYTES,
+  type PlanEvent,
+  type PlanExecution,
+  type PlanExecutionStep,
+  type PlanProposal,
+  type PlanSessionState,
+  type PlanStepDefinition,
+  isCanonicalPlanEntityId,
+  isPlanProposalLifecycleAdmissible,
+  planEncodedByteLength,
+  worstCasePlanExecution,
+} from '@maka/core/plan';
+
+/**
+ * Embedded Plan Mode predates the Host wire bounds. Keep its immutable event
+ * history intact while projecting a deterministic, bounded state that the
+ * Host and later strict mutations can consume.
+ */
+export function normalizeLegacyPlanEvent(event: PlanEvent, state: PlanSessionState): PlanEvent {
+  if (event.operationFingerprint) return event;
+  switch (event.type) {
+    case 'plan_submitted':
+      return { ...event, proposal: normalizeLegacyProposal(event.proposal) };
+    case 'plan_approved':
+      return { ...event, execution: normalizeLegacyExecution(event.execution) };
+    case 'plan_progress_updated':
+    case 'plan_execution_completed': {
+      const execution = state.executions.find(
+        (candidate) => candidate.executionId === event.executionId,
+      );
+      if (!execution) return event;
+      const steps = fitLegacyExecutionSteps(event.steps, execution);
+      return isDeepStrictEqual(steps, event.steps)
+        ? event
+        : { ...event, steps, legacyProjection: { truncated: true } };
+    }
+    case 'plan_abandoned': {
+      const reason = legacyText(event.reason, PLAN_TEXT_MAX_BYTES);
+      return reason === event.reason
+        ? event
+        : { ...event, reason, legacyProjection: { truncated: true } };
+    }
+    case 'plan_execution_cancelled':
+    case 'plan_execution_interrupted': {
+      const reason = legacyText(event.reason, PLAN_LIFECYCLE_REASON_MAX_BYTES);
+      return reason === event.reason
+        ? event
+        : { ...event, reason, legacyProjection: { truncated: true } };
+    }
+    case 'plan_revision_requested':
+    case 'plan_execution_resumed':
+      return event;
+  }
+}
+
+function normalizeLegacyProposal(proposal: PlanProposal): PlanProposal {
+  const base = {
+    ...proposal,
+    title: legacyText(proposal.title, PLAN_TEXT_MAX_BYTES),
+    ...(proposal.overview ? { overview: legacyText(proposal.overview, PLAN_TEXT_MAX_BYTES) } : {}),
+    ...(proposal.risks
+      ? {
+          risks: proposal.risks
+            .slice(0, PLAN_MAX_RISKS)
+            .map((risk) => legacyText(risk, PLAN_TEXT_MAX_BYTES)),
+        }
+      : {}),
+    steps: normalizeLegacyDefinitions(proposal.steps, PLAN_TEXT_MAX_BYTES),
+  };
+  const normalized = fitLegacyTextBudget(
+    (textBytes) => ({
+      ...base,
+      title: legacyText(base.title, textBytes),
+      steps: normalizeLegacyDefinitions(base.steps, textBytes),
+      ...(base.overview ? { overview: legacyText(base.overview, textBytes) } : {}),
+      ...(base.risks ? { risks: base.risks.map((risk) => legacyText(risk, textBytes)) } : {}),
+    }),
+    legacyProposalFits,
+  );
+  return isDeepStrictEqual(normalized, proposal)
+    ? proposal
+    : { ...normalized, legacyProjection: { truncated: true } };
+}
+
+function normalizeLegacyExecution(execution: PlanExecution): PlanExecution {
+  const base = {
+    ...execution,
+    steps: normalizeLegacyExecutionSteps(execution.steps, PLAN_TEXT_MAX_BYTES),
+  };
+  const normalized = fitLegacyTextBudget(
+    (textBytes) => ({
+      ...base,
+      steps: normalizeLegacyExecutionSteps(base.steps, textBytes),
+      ...(base.cancelReason
+        ? { cancelReason: legacyText(base.cancelReason, PLAN_LIFECYCLE_REASON_MAX_BYTES) }
+        : {}),
+      ...(base.interruptionReason
+        ? {
+            interruptionReason: legacyText(
+              base.interruptionReason,
+              PLAN_LIFECYCLE_REASON_MAX_BYTES,
+            ),
+          }
+        : {}),
+    }),
+    legacyExecutionFits,
+  );
+  return isDeepStrictEqual(normalized, execution)
+    ? execution
+    : { ...normalized, legacyProjection: { truncated: true } };
+}
+
+function legacyProposalFits(proposal: PlanProposal): boolean {
+  const marked = { ...proposal, legacyProjection: { truncated: true as const } };
+  return (
+    planEncodedByteLength({ kind: 'proposal', proposal: marked }) <=
+      PLAN_PROJECTION_ITEM_MAX_BYTES && isPlanProposalLifecycleAdmissible(proposal)
+  );
+}
+
+function fitLegacyExecutionSteps(
+  steps: PlanExecutionStep[],
+  execution: PlanExecution,
+): PlanExecutionStep[] {
+  const base = normalizeLegacyExecutionSteps(steps, PLAN_TEXT_MAX_BYTES);
+  return fitLegacyTextBudget(
+    (textBytes) => normalizeLegacyExecutionSteps(base, textBytes),
+    (candidate) => legacyExecutionFits({ ...execution, steps: candidate }),
+  );
+}
+
+function legacyExecutionFits(execution: PlanExecution): boolean {
+  const marked = { ...execution, legacyProjection: { truncated: true as const } };
+  const worst = {
+    ...worstCasePlanExecution(execution, execution.executionId, Number.MAX_SAFE_INTEGER),
+    legacyProjection: { truncated: true as const },
+  };
+  return (
+    planEncodedByteLength({ kind: 'execution', execution: marked }) <=
+      PLAN_PROJECTION_ITEM_MAX_BYTES &&
+    planEncodedByteLength({
+      kind: 'execution',
+      execution: worst,
+    }) <= PLAN_PROJECTION_ITEM_MAX_BYTES
+  );
+}
+
+function normalizeLegacyExecutionSteps(
+  steps: PlanExecutionStep[],
+  textBytes: number,
+): PlanExecutionStep[] {
+  const definitions = normalizeLegacyDefinitions(steps, textBytes);
+  return definitions.map((definition, index) => {
+    const source = steps[index]!;
+    return {
+      ...definition,
+      status: source.status,
+      ...(source.note ? { note: legacyText(source.note, textBytes) } : {}),
+      updatedAt: source.updatedAt,
+    };
+  });
+}
+
+function normalizeLegacyDefinitions(
+  steps: PlanStepDefinition[],
+  textBytes: number,
+): PlanStepDefinition[] {
+  const ids = canonicalLegacyStepIds(steps.map((step) => step.id));
+  return steps.slice(0, PLAN_MAX_STEPS).map((step, index) => ({
+    id: ids[index]!,
+    title: legacyStepTitle(step.title, textBytes),
+    description: legacyText(step.description, textBytes),
+    ...(step.files
+      ? {
+          files: step.files
+            .slice(0, PLAN_MAX_FILES_PER_STEP)
+            .map((file) => legacyText(file, textBytes)),
+        }
+      : {}),
+    ...(step.complexity ? { complexity: step.complexity } : {}),
+  }));
+}
+
+function canonicalLegacyStepIds(ids: readonly string[]): string[] {
+  const used = new Set<string>();
+  return ids.slice(0, PLAN_MAX_STEPS).map((id, index) => {
+    const normalized = id.trim();
+    const base = isCanonicalPlanEntityId(normalized)
+      ? normalized
+      : `legacy-${createHash('sha256').update(normalized).digest('hex')}`;
+    let candidate = base;
+    let suffix = 0;
+    while (used.has(candidate)) {
+      suffix += 1;
+      candidate = `${base.slice(0, 120)}-${index}-${suffix}`;
+    }
+    used.add(candidate);
+    return candidate;
+  });
+}
+
+function fitLegacyTextBudget<T>(
+  project: (textBytes: number) => T,
+  accepts: (candidate: T) => boolean,
+): T {
+  let low = 4;
+  let high = PLAN_TEXT_MAX_BYTES;
+  let best = project(low);
+  if (!accepts(best)) throw new Error('Legacy Plan projection cannot be represented safely');
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const candidate = project(middle);
+    if (accepts(candidate)) {
+      best = candidate;
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return best;
+}
+
+function legacyText(value: string, maxBytes: number): string {
+  const normalized = value.trim();
+  if (Buffer.byteLength(normalized, 'utf8') <= maxBytes) return normalized;
+  let result = '';
+  let bytes = 0;
+  for (const character of normalized) {
+    const characterBytes = Buffer.byteLength(character, 'utf8');
+    if (bytes + characterBytes > maxBytes) break;
+    result += character;
+    bytes += characterBytes;
+  }
+  return result;
+}
+
+function legacyStepTitle(value: string, maxBytes: number): string {
+  return legacyText(
+    Array.from(value.trim()).slice(0, PLAN_STEP_TITLE_MAX_CHARS).join(''),
+    maxBytes,
+  );
+}

--- a/packages/storage/src/plan-store.ts
+++ b/packages/storage/src/plan-store.ts
@@ -1,7 +1,13 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import {
+  PLAN_MAX_FILES_PER_STEP,
+  PLAN_MAX_RISKS,
+  PLAN_MAX_STEPS,
+  PLAN_LIFECYCLE_REASON_MAX_BYTES,
+  PLAN_PROJECTION_ITEM_MAX_BYTES,
+  PLAN_STEP_TITLE_MAX_CHARS,
   PlanConflictError,
   activePlanExecution,
   type AbandonPlanProposalInput,
@@ -20,14 +26,18 @@ import {
   type RequestPlanRevisionInput,
   type SubmitPlanProposalInput,
   type UpdatePlanExecutionInput,
+  isCanonicalPlanEntityId,
+  isPlanProposalLifecycleAdmissible,
+  isPlanTextWithinLimit,
+  planEncodedByteLength,
+  worstCasePlanExecution,
 } from '@maka/core/plan';
 import { chainWrite } from './write-queue.js';
 import {
   acquireOperationalStateDatabase,
   type OperationalStateDatabaseLease,
 } from './operational-state-store.js';
-
-const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+import { normalizeLegacyPlanEvent } from './plan-legacy-projection.js';
 
 export interface CreatePlanStoreOptions {
   newId?: () => string;
@@ -36,6 +46,7 @@ export interface CreatePlanStoreOptions {
 
 export interface SqlitePlanStore extends PlanStore {
   ready(): Promise<void>;
+  purgeSessionState(sessionId: string): Promise<void>;
   close(): void;
 }
 
@@ -72,10 +83,46 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
     return (await this.readLedger(sessionId)).state;
   }
 
+  async readOperationReceipt(
+    sessionId: string,
+    operationId: string,
+    operationInput: unknown,
+  ): Promise<PlanEvent | undefined> {
+    assertSafeId(sessionId);
+    assertSafeId(operationId);
+    const fingerprint = operationFingerprint(operationInput);
+    let receipt: PlanEvent | undefined;
+    await chainWrite(this.queues, sessionId, async () => {
+      receipt = reconcileOperationReceipt(
+        (await this.readLedger(sessionId)).events,
+        operationId,
+        fingerprint,
+      );
+    });
+    return receipt;
+  }
+
   async submitProposal(input: SubmitPlanProposalInput): Promise<PlanMutationResult> {
-    return this.mutate(input.sessionId, async (state) => {
+    return this.mutate(input.sessionId, input.operationId, input, async (state) => {
+      requiredId(input.turnId, 'Plan turn id');
+      if (input.sourceExecutionId) {
+        requiredId(input.sourceExecutionId, 'Source Plan execution id');
+      }
       const title = requiredText(input.title, 'Plan title');
       const steps = normalizeDefinitions(input.steps);
+      const overview = optionalText(input.overview, 'Plan overview');
+      if (input.risks && input.risks.length > PLAN_MAX_RISKS) {
+        throw new PlanConflictError(`A plan may contain at most ${PLAN_MAX_RISKS} risks`);
+      }
+      const risks =
+        input.risks && input.risks.length > 0
+          ? input.risks.map((risk) => requiredText(risk, 'Plan risk'))
+          : undefined;
+      if (!isPlanProposalLifecycleAdmissible({ title, overview, steps, risks })) {
+        throw new PlanConflictError(
+          'Plan proposal cannot fit the projection item limit across its execution lifecycle',
+        );
+      }
       const latest = latestPlanProposal(state);
       if (state.activeExecutionId) {
         throw new PlanConflictError('Cannot submit a new proposal while a plan is executing');
@@ -89,8 +136,8 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
       const revisesLatest =
         latest !== undefined &&
         (latest.status !== 'approved' || sourceExecution?.proposalId === latest.proposalId);
-      const planId = revisesLatest ? latest.planId : this.newId();
-      const proposalId = this.newId();
+      const planId = revisesLatest ? latest.planId : requiredId(this.newId(), 'Plan id');
+      const proposalId = requiredId(this.newId(), 'Plan proposal id');
       const submittedAt = this.now();
       const proposal: PlanProposal = {
         planId,
@@ -101,17 +148,15 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
         ...(revisesLatest ? { supersedesProposalId: latest.proposalId } : {}),
         ...(sourceExecution ? { sourceExecutionId: sourceExecution.executionId } : {}),
         title,
-        ...(optionalText(input.overview) ? { overview: optionalText(input.overview) } : {}),
+        ...(overview ? { overview } : {}),
         steps,
-        ...(input.risks && input.risks.length > 0
-          ? { risks: input.risks.map((risk) => requiredText(risk, 'Plan risk')) }
-          : {}),
+        ...(risks ? { risks } : {}),
         status: 'pending_approval',
         submittedAt,
       };
       return {
         type: 'plan_submitted',
-        id: this.newId(),
+        id: input.operationId ?? this.newId(),
         sessionId: input.sessionId,
         ts: submittedAt,
         storeVersion: state.storeVersion + 1,
@@ -121,7 +166,7 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
   }
 
   async requestRevision(input: RequestPlanRevisionInput): Promise<PlanMutationResult> {
-    return this.mutate(input.sessionId, async (state) => {
+    return this.mutate(input.sessionId, input.operationId, input, async (state) => {
       const proposal = proposalById(state, input.proposalId);
       if (proposal.status === 'stale') {
         throw new PlanConflictError('Plan proposal is already stale');
@@ -134,7 +179,7 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
       }
       return {
         type: 'plan_revision_requested',
-        id: this.newId(),
+        id: input.operationId ?? this.newId(),
         sessionId: input.sessionId,
         ts: this.now(),
         storeVersion: state.storeVersion + 1,
@@ -144,7 +189,7 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
   }
 
   async abandonProposal(input: AbandonPlanProposalInput): Promise<PlanMutationResult> {
-    return this.mutate(input.sessionId, async (state) => {
+    return this.mutate(input.sessionId, input.operationId, input, async (state) => {
       const proposal = proposalById(state, input.proposalId);
       if (
         proposal.status !== 'pending_approval' ||
@@ -154,7 +199,7 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
       }
       return {
         type: 'plan_abandoned',
-        id: this.newId(),
+        id: input.operationId ?? this.newId(),
         sessionId: input.sessionId,
         ts: this.now(),
         storeVersion: state.storeVersion + 1,
@@ -166,84 +211,98 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
 
   async approveProposal(input: ApprovePlanProposalInput): Promise<PlanMutationResult> {
     let duplicate: PlanMutationResult | undefined;
-    const result = await this.mutateOptional(input.sessionId, async (state, events) => {
-      const proposal = proposalById(state, input.proposalId);
-      if (proposal.revision !== input.expectedRevision) {
-        throw new PlanConflictError('Plan proposal revision does not match');
-      }
-      if (proposal.status === 'approved') {
-        const prior = [...events]
-          .reverse()
-          .find(
-            (event): event is Extract<PlanEvent, { type: 'plan_approved' }> =>
-              event.type === 'plan_approved' && event.proposalId === proposal.proposalId,
-          );
-        if (!prior) throw new PlanConflictError('Approved plan execution is missing');
-        duplicate = { event: prior, state };
-        return null;
-      }
-      if (
-        input.expectedStoreVersion !== undefined &&
-        state.storeVersion !== input.expectedStoreVersion
-      ) {
-        throw new PlanConflictError('Plan state changed before approval');
-      }
-      if (
-        proposal.status !== 'pending_approval' ||
-        state.latestProposalId !== proposal.proposalId
-      ) {
-        throw new PlanConflictError('Only the latest pending plan proposal can be approved');
-      }
-      if (state.activeExecutionId) {
-        throw new PlanConflictError('This session already has an active plan execution');
-      }
-      if (proposal.sourceExecutionId) {
-        const sourceExecution = executionById(state, proposal.sourceExecutionId);
-        if (sourceExecution.status !== 'interrupted') {
-          throw new PlanConflictError('The execution being replanned is no longer interrupted');
+    const result = await this.mutateOptional(
+      input.sessionId,
+      input.operationId,
+      input,
+      async (state, events) => {
+        const proposal = proposalById(state, input.proposalId);
+        if (proposal.revision !== input.expectedRevision) {
+          throw new PlanConflictError('Plan proposal revision does not match');
         }
-      }
-      const startedAt = this.now();
-      const execution: PlanExecution = {
-        executionId: this.newId(),
-        planId: proposal.planId,
-        proposalId: proposal.proposalId,
-        sessionId: input.sessionId,
-        status: 'active',
-        steps: proposal.steps.map((step) => ({
-          ...structuredClone(step),
-          status: 'pending',
+        if (proposal.status === 'approved') {
+          if (input.operationId) {
+            throw new PlanConflictError('Plan proposal was already approved by another operation');
+          }
+          const prior = [...events]
+            .reverse()
+            .find(
+              (event): event is Extract<PlanEvent, { type: 'plan_approved' }> =>
+                event.type === 'plan_approved' && event.proposalId === proposal.proposalId,
+            );
+          if (!prior) throw new PlanConflictError('Approved plan execution is missing');
+          duplicate = { event: prior, state };
+          return null;
+        }
+        if (
+          input.expectedStoreVersion !== undefined &&
+          state.storeVersion !== input.expectedStoreVersion
+        ) {
+          throw new PlanConflictError('Plan state changed before approval');
+        }
+        if (
+          proposal.status !== 'pending_approval' ||
+          state.latestProposalId !== proposal.proposalId
+        ) {
+          throw new PlanConflictError('Only the latest pending plan proposal can be approved');
+        }
+        if (proposal.legacyProjection?.truncated) {
+          throw new PlanConflictError(
+            'A projected legacy plan must be revised or abandoned before approval',
+          );
+        }
+        if (state.activeExecutionId) {
+          throw new PlanConflictError('This session already has an active plan execution');
+        }
+        if (proposal.sourceExecutionId) {
+          const sourceExecution = executionById(state, proposal.sourceExecutionId);
+          if (sourceExecution.status !== 'interrupted') {
+            throw new PlanConflictError('The execution being replanned is no longer interrupted');
+          }
+        }
+        const startedAt = this.now();
+        const execution: PlanExecution = {
+          executionId: requiredId(this.newId(), 'Plan execution id'),
+          planId: proposal.planId,
+          proposalId: proposal.proposalId,
+          sessionId: input.sessionId,
+          status: 'active',
+          steps: proposal.steps.map((step) => ({
+            ...structuredClone(step),
+            status: 'pending',
+            updatedAt: startedAt,
+          })),
+          startedAt,
           updatedAt: startedAt,
-        })),
-        startedAt,
-        updatedAt: startedAt,
-      };
-      return {
-        type: 'plan_approved',
-        id: this.newId(),
-        sessionId: input.sessionId,
-        ts: startedAt,
-        storeVersion: state.storeVersion + 1,
-        proposalId: proposal.proposalId,
-        execution,
-      };
-    });
+        };
+        return {
+          type: 'plan_approved',
+          id: input.operationId ?? this.newId(),
+          sessionId: input.sessionId,
+          ts: startedAt,
+          storeVersion: state.storeVersion + 1,
+          proposalId: proposal.proposalId,
+          execution,
+        };
+      },
+    );
     if (duplicate) return duplicate;
     if (!result) throw new Error('Plan approval completed without a result');
     return result;
   }
 
   async updateExecution(input: UpdatePlanExecutionInput): Promise<PlanMutationResult> {
-    return this.mutate(input.sessionId, async (state) => {
+    return this.mutate(input.sessionId, input.operationId, input, async (state) => {
       const execution = requireActiveExecution(state, input.executionId);
       const steps = mergeExecutionSteps(execution, input.steps, this.now());
+      const explanation = optionalText(input.explanation, 'Plan progress explanation');
       const completed = steps.every(
         (step) => step.status === 'completed' || step.status === 'skipped',
       );
       return completed
         ? {
             type: 'plan_execution_completed',
-            id: this.newId(),
+            id: input.operationId ?? this.newId(),
             sessionId: input.sessionId,
             ts: this.now(),
             storeVersion: state.storeVersion + 1,
@@ -252,30 +311,32 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
           }
         : {
             type: 'plan_progress_updated',
-            id: this.newId(),
+            id: input.operationId ?? this.newId(),
             sessionId: input.sessionId,
             ts: this.now(),
             storeVersion: state.storeVersion + 1,
             executionId: execution.executionId,
             steps,
-            ...(optionalText(input.explanation)
-              ? { explanation: optionalText(input.explanation) }
-              : {}),
+            ...(explanation ? { explanation } : {}),
           };
     });
   }
 
   async cancelExecution(input: CancelPlanExecutionInput): Promise<PlanMutationResult> {
-    return this.mutate(input.sessionId, async (state) => {
+    return this.mutate(input.sessionId, input.operationId, input, async (state) => {
       const execution = requireCancellableExecution(state, input.executionId);
       return {
         type: 'plan_execution_cancelled',
-        id: this.newId(),
+        id: input.operationId ?? this.newId(),
         sessionId: input.sessionId,
         ts: this.now(),
         storeVersion: state.storeVersion + 1,
         executionId: execution.executionId,
-        reason: requiredText(input.reason, 'Plan cancellation reason'),
+        reason: requiredText(
+          input.reason,
+          'Plan cancellation reason',
+          PLAN_LIFECYCLE_REASON_MAX_BYTES,
+        ),
       };
     });
   }
@@ -283,24 +344,29 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
   async interruptActiveExecution(
     sessionId: string,
     reason: string,
+    operationId?: string,
   ): Promise<PlanMutationResult | null> {
-    return this.mutateOptional(sessionId, async (fresh) => {
+    return this.mutateOptional(sessionId, operationId, { sessionId, reason }, async (fresh) => {
       const execution = activePlanExecution(fresh);
       if (!execution) return null;
       return {
         type: 'plan_execution_interrupted',
-        id: this.newId(),
+        id: operationId ?? this.newId(),
         sessionId,
         ts: this.now(),
         storeVersion: fresh.storeVersion + 1,
         executionId: execution.executionId,
-        reason: requiredText(reason, 'Plan interruption reason'),
+        reason: requiredText(reason, 'Plan interruption reason', PLAN_LIFECYCLE_REASON_MAX_BYTES),
       };
     });
   }
 
-  async resumeExecution(sessionId: string, executionId: string): Promise<PlanMutationResult> {
-    return this.mutate(sessionId, async (state) => {
+  async resumeExecution(
+    sessionId: string,
+    executionId: string,
+    operationId?: string,
+  ): Promise<PlanMutationResult> {
+    return this.mutate(sessionId, operationId, { sessionId, executionId }, async (state) => {
       if (state.activeExecutionId) {
         throw new PlanConflictError('This session already has an active plan execution');
       }
@@ -308,9 +374,14 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
       if (execution.status !== 'interrupted') {
         throw new PlanConflictError('Only an interrupted plan execution can be resumed');
       }
+      if (execution.legacyProjection?.truncated) {
+        throw new PlanConflictError(
+          'A projected legacy execution must be cancelled or replanned instead of resumed',
+        );
+      }
       return {
         type: 'plan_execution_resumed',
-        id: this.newId(),
+        id: operationId ?? this.newId(),
         sessionId,
         ts: this.now(),
         storeVersion: state.storeVersion + 1,
@@ -321,28 +392,60 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
 
   private async mutate(
     sessionId: string,
+    operationId: string | undefined,
+    operationInput: unknown,
     build: (state: PlanSessionState, events: readonly PlanEvent[]) => Promise<PlanEvent | null>,
   ): Promise<PlanMutationResult> {
-    const result = await this.mutateOptional(sessionId, build);
+    const result = await this.mutateOptional(sessionId, operationId, operationInput, build);
     if (!result) throw new Error('Plan mutation completed without a result');
     return result;
   }
 
   private async mutateOptional(
     sessionId: string,
+    operationId: string | undefined,
+    operationInput: unknown,
     build: (state: PlanSessionState, events: readonly PlanEvent[]) => Promise<PlanEvent | null>,
   ): Promise<PlanMutationResult | null> {
     assertSafeId(sessionId);
+    if (operationId !== undefined) assertSafeId(operationId);
+    const fingerprint = operationId ? operationFingerprint(operationInput) : undefined;
     let result: PlanMutationResult | null = null;
     await chainWrite(this.queues, sessionId, async () => {
       const ledger = await this.readLedger(sessionId);
+      if (operationId) {
+        const existing = reconcileOperationReceipt(ledger.events, operationId, fingerprint!);
+        if (existing) {
+          result = {
+            event: existing,
+            state: stateThroughEvent(sessionId, ledger.events, existing.id),
+          };
+          return;
+        }
+      }
       const event = await build(ledger.state, ledger.events);
       if (!event) return;
+      if (fingerprint) event.operationFingerprint = fingerprint;
       const state = applyPlanEvent(ledger.state, event);
+      assertPlanProjectionWithinLimit(state);
       await this.appendCanonicalEvent(sessionId, event, state);
       result = { event, state };
     });
     return result;
+  }
+
+  async purgeSessionState(sessionId: string): Promise<void> {
+    assertSafeId(sessionId);
+    await chainWrite(this.queues, sessionId, async () => {
+      this.#lease.transaction('write', () => {
+        this.#lease.database
+          .prepare('DELETE FROM workflow_plan_events WHERE session_id = ?')
+          .run(sessionId);
+        this.#lease.database
+          .prepare('DELETE FROM workflow_plan_projections WHERE session_id = ?')
+          .run(sessionId);
+      });
+    });
   }
 
   private async readLedger(
@@ -364,6 +467,54 @@ class SqlitePlanStoreImpl implements SqlitePlanStore {
   }
 }
 
+function operationFingerprint(input: unknown): string {
+  const normalized = omitOperationId(structuredClone(input));
+  return `sha256:${createHash('sha256').update(stableJson(normalized)).digest('hex')}`;
+}
+
+function reconcileOperationReceipt(
+  events: readonly PlanEvent[],
+  operationId: string,
+  fingerprint: string,
+): PlanEvent | undefined {
+  const existing = events.find((event) => event.id === operationId);
+  if (!existing) return undefined;
+  if (existing.operationFingerprint !== fingerprint) {
+    throw new PlanConflictError('Plan operation identity was reused with different input');
+  }
+  return existing;
+}
+
+function stateThroughEvent(
+  sessionId: string,
+  events: readonly PlanEvent[],
+  eventId: string,
+): PlanSessionState {
+  let state = emptyPlanSessionState(sessionId);
+  for (const event of events) {
+    state = applyPlanEvent(state, event);
+    if (event.id === eventId) return state;
+  }
+  throw new Error('Plan operation receipt is missing from its ledger');
+}
+
+function omitOperationId(input: unknown): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+  const { operationId: _operationId, ...rest } = input as Record<string, unknown>;
+  return rest;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right));
+    return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`).join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
 function readSqlitePlanLedger(
   database: DatabaseSync,
   sessionId: string,
@@ -377,14 +528,19 @@ function readSqlitePlanLedger(
       ORDER BY sequence
     `)
     .all(sessionId) as Array<{ record_json?: unknown }>;
-  const events = rows.map((row, index) => {
+  const persistedEvents = rows.map((row, index) => {
     if (typeof row.record_json !== 'string') {
       throw new Error(`Invalid SQLite Plan event at sequence ${index}`);
     }
     return decodePlanEvent(JSON.parse(row.record_json), sessionId);
   });
+  const events: PlanEvent[] = [];
   let state = emptyPlanSessionState(sessionId);
-  for (const event of events) state = applyPlanEvent(state, event);
+  for (const persistedEvent of persistedEvents) {
+    const event = normalizeLegacyPlanEvent(persistedEvent, state);
+    events.push(event);
+    state = applyPlanEvent(state, event);
+  }
   return { events, state };
 }
 
@@ -465,6 +621,9 @@ export function applyPlanEvent(state: PlanSessionState, event: PlanEvent): PlanS
       const execution = executionById(next, event.executionId);
       execution.steps = structuredClone(event.steps);
       execution.updatedAt = event.ts;
+      if (event.legacyProjection) {
+        execution.legacyProjection = structuredClone(event.legacyProjection);
+      }
       break;
     }
     case 'plan_execution_completed': {
@@ -473,6 +632,9 @@ export function applyPlanEvent(state: PlanSessionState, event: PlanEvent): PlanS
       execution.status = 'completed';
       execution.updatedAt = event.ts;
       execution.completedAt = event.ts;
+      if (event.legacyProjection) {
+        execution.legacyProjection = structuredClone(event.legacyProjection);
+      }
       if (next.activeExecutionId === execution.executionId) delete next.activeExecutionId;
       break;
     }
@@ -482,6 +644,9 @@ export function applyPlanEvent(state: PlanSessionState, event: PlanEvent): PlanS
       execution.updatedAt = event.ts;
       execution.cancelledAt = event.ts;
       execution.cancelReason = event.reason;
+      if (event.legacyProjection) {
+        execution.legacyProjection = structuredClone(event.legacyProjection);
+      }
       if (next.activeExecutionId === execution.executionId) delete next.activeExecutionId;
       break;
     }
@@ -491,6 +656,9 @@ export function applyPlanEvent(state: PlanSessionState, event: PlanEvent): PlanS
       execution.updatedAt = event.ts;
       execution.interruptedAt = event.ts;
       execution.interruptionReason = event.reason;
+      if (event.legacyProjection) {
+        execution.legacyProjection = structuredClone(event.legacyProjection);
+      }
       if (next.activeExecutionId === execution.executionId) delete next.activeExecutionId;
       break;
     }
@@ -526,10 +694,11 @@ function mergeExecutionSteps(
     ) {
       throw new PlanConflictError(`Terminal plan step ${step.id} cannot be reopened`);
     }
+    const note = optionalText(update.note, 'Plan step note');
     return {
       ...structuredClone(step),
       status: update.status,
-      ...(optionalText(update.note) ? { note: optionalText(update.note) } : {}),
+      ...(note ? { note } : {}),
       updatedAt: now,
     };
   });
@@ -540,18 +709,25 @@ function mergeExecutionSteps(
 }
 
 function normalizeDefinitions(steps: PlanStepDefinition[]): PlanStepDefinition[] {
-  if (!Array.isArray(steps) || steps.length === 0 || steps.length > 50) {
-    throw new PlanConflictError('A plan must contain between 1 and 50 steps');
+  if (!Array.isArray(steps) || steps.length === 0 || steps.length > PLAN_MAX_STEPS) {
+    throw new PlanConflictError(`A plan must contain between 1 and ${PLAN_MAX_STEPS} steps`);
   }
-  const normalized = steps.map((step, index) => ({
-    id: optionalText(step.id) ?? `step-${index + 1}`,
-    title: requiredPlainText(step.title, 'Plan step title', 30),
-    description: requiredPlainText(step.description, 'Plan step description'),
-    ...(step.files && step.files.length > 0
-      ? { files: step.files.map((file) => requiredText(file, 'Plan step file')) }
-      : {}),
-    ...(step.complexity ? { complexity: step.complexity } : {}),
-  }));
+  const normalized = steps.map((step, index) => {
+    if (step.files && step.files.length > PLAN_MAX_FILES_PER_STEP) {
+      throw new PlanConflictError(
+        `A Plan step may reference at most ${PLAN_MAX_FILES_PER_STEP} files`,
+      );
+    }
+    return {
+      id: requiredId(optionalText(step.id, 'Plan step id') ?? `step-${index + 1}`, 'Plan step id'),
+      title: requiredPlainText(step.title, 'Plan step title', PLAN_STEP_TITLE_MAX_CHARS),
+      description: requiredPlainText(step.description, 'Plan step description'),
+      ...(step.files && step.files.length > 0
+        ? { files: step.files.map((file) => requiredText(file, 'Plan step file')) }
+        : {}),
+      ...(step.complexity ? { complexity: step.complexity } : {}),
+    };
+  });
   if (new Set(normalized.map((step) => step.id)).size !== normalized.length) {
     throw new PlanConflictError('Plan step ids must be unique');
   }
@@ -578,6 +754,11 @@ function requireActiveExecution(state: PlanSessionState, executionId: string): P
   if (execution.status !== 'active') {
     throw new PlanConflictError('Plan execution is not active');
   }
+  if (execution.legacyProjection?.truncated) {
+    throw new PlanConflictError(
+      'A projected legacy execution must be cancelled or replanned instead of updated',
+    );
+  }
   return execution;
 }
 
@@ -592,9 +773,12 @@ function requireCancellableExecution(state: PlanSessionState, executionId: strin
   return execution;
 }
 
-function requiredText(value: string, label: string): string {
+function requiredText(value: string, label: string, maxBytes?: number): string {
   const normalized = value.trim();
   if (!normalized) throw new PlanConflictError(`${label} cannot be empty`);
+  if (!isPlanTextWithinLimit(normalized, maxBytes)) {
+    throw new PlanConflictError(`${label} exceeds the Plan text limit`);
+  }
   return normalized;
 }
 
@@ -613,13 +797,48 @@ function requiredPlainText(value: string, label: string, maxLength?: number): st
   return normalized;
 }
 
-function optionalText(value: string | undefined): string | undefined {
+function optionalText(value: string | undefined, label: string): string | undefined {
   const normalized = value?.trim();
-  return normalized ? normalized : undefined;
+  if (!normalized) return undefined;
+  if (!isPlanTextWithinLimit(normalized)) {
+    throw new PlanConflictError(`${label} exceeds the Plan text limit`);
+  }
+  return normalized;
 }
 
 function assertSafeId(value: string): void {
-  if (!SAFE_ID_PATTERN.test(value)) throw new Error('Invalid session id');
+  if (!isCanonicalPlanEntityId(value)) throw new Error('Invalid session id');
+}
+
+function requiredId(value: string, label: string): string {
+  if (!isCanonicalPlanEntityId(value)) {
+    throw new PlanConflictError(`${label} must be a canonical entity id`);
+  }
+  return value;
+}
+
+function assertPlanProjectionWithinLimit(state: PlanSessionState): void {
+  for (const proposal of state.proposals) {
+    if (planEncodedByteLength({ kind: 'proposal', proposal }) > PLAN_PROJECTION_ITEM_MAX_BYTES) {
+      throw new PlanConflictError('Plan proposal exceeds the projection item limit');
+    }
+  }
+  for (const execution of state.executions) {
+    if (planEncodedByteLength({ kind: 'execution', execution }) > PLAN_PROJECTION_ITEM_MAX_BYTES) {
+      throw new PlanConflictError('Plan execution exceeds the projection item limit');
+    }
+    const worst = worstCasePlanExecution(execution, execution.executionId, Number.MAX_SAFE_INTEGER);
+    if (execution.legacyProjection) {
+      worst.legacyProjection = structuredClone(execution.legacyProjection);
+    }
+    if (
+      (execution.status === 'active' || execution.status === 'interrupted') &&
+      planEncodedByteLength({ kind: 'execution', execution: worst }) >
+        PLAN_PROJECTION_ITEM_MAX_BYTES
+    ) {
+      throw new PlanConflictError('Plan execution cannot fit its terminal lifecycle projection');
+    }
+  }
 }
 
 function decodePlanEvent(value: unknown, sessionId: string): PlanEvent {
@@ -627,6 +846,9 @@ function decodePlanEvent(value: unknown, sessionId: string): PlanEvent {
   const event = value as Partial<PlanEvent>;
   if (
     typeof event.id !== 'string' ||
+    (event.operationFingerprint !== undefined &&
+      (typeof event.operationFingerprint !== 'string' ||
+        !/^sha256:[a-f0-9]{64}$/.test(event.operationFingerprint))) ||
     event.sessionId !== sessionId ||
     typeof event.ts !== 'number' ||
     !Number.isFinite(event.ts) ||


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Move durable Plan state behind a lease-authenticated Runtime Host writer, with bounded `v0` query/control operations and typed client helpers.
- Compose planning and execution tools from Host-owned Plan state, and route approval, revision, resume, cancellation, recovery, and collaboration-mode transitions through the Runtime authority.
- Make Plan controls retry-safe across disconnects and Host restarts with durable operation receipts, revision-pinned queries, continuity refresh, and multi-client serialization.
- Preserve pre-Host embedded Plan ledgers through an explicit bounded legacy projection. Lossy projected proposals and executions cannot continue as ordinary work; they can only be revised, abandoned, cancelled, or replanned.
- Cover the production Host composition with two UDS clients, successor recovery, exact replay, and safe cancellation after restart.

## Scope

This is the non-serving M3 authority extraction tracked by #1167. Production Client adapter wiring and the atomic ownership cutover remain tracked by #2010 and M5; existing production entrypoints are unchanged.

## Validation

- Core: 769 passed
- Runtime: 3,095 passed, 9 skipped
- Runtime Host: 632 passed
- Storage Plan workflow and legacy-projection tests
- Workspace typecheck, lint, format, and diff checks

Part of #1167

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 摘要

- 将持久 Plan 状态收归经过 lease 认证的 Runtime Host writer，并提供有界 `v0` query/control operation 与类型化 Client helper。
- 基于 Host-owned Plan state 组合规划与执行工具，并通过 Runtime authority 统一处理审批、修订、恢复执行、取消、恢复流程与 collaboration mode 切换。
- 通过持久 operation receipt、绑定 revision 的查询、continuity refresh 与多 Client 串行化，让 Plan control 在断线和 Host 重启后仍可安全重试。
- 通过显式且有界的 legacy projection 保留 Host 迁移前的 embedded Plan ledger。有损投影后的 proposal/execution 不会被当作普通任务继续执行，只允许修订、放弃、取消或重新规划。
- 使用生产 Host composition 覆盖双 UDS Client、successor recovery、精确重放，以及重启后的安全取消。

## 范围

这是 #1167 追踪的非 serving M3 authority extraction。Production Client adapter wiring 与原子 ownership cutover 仍由 #2010 和 M5 追踪；现有 production entrypoint 保持不变。

## 验证

- Core：769 项通过
- Runtime：3,095 项通过，9 项跳过
- Runtime Host：632 项通过
- Storage Plan workflow 与 legacy projection 测试
- 全仓 typecheck、lint、format 与 diff 检查

#1167 的一部分

</details>
