### PR TITLE
fix: rehydrate an unanswered user question the surface never received

### DIFF
--- a/apps/desktop/e2e/ask-user-question.spec.ts
+++ b/apps/desktop/e2e/ask-user-question.spec.ts
@@ -1,6 +1,29 @@
 import { FAKE_ASK_USER_QUESTION_PROMPT } from '@maka/runtime';
 import { test, expect, COMPOSER_INPUT } from './fixtures.js';
 
+test('rehydrates a prompt the surface never received live', async ({ window: page }) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill(FAKE_ASK_USER_QUESTION_PROMPT);
+  await composer.press('Enter');
+
+  const prompt = page.locator('.maka-user-question-prompt');
+  await expect(prompt).toBeVisible();
+
+  // Reloading throws away every event this surface ever saw while the runtime
+  // keeps the turn parked on the question. Without a read-back the prompt is
+  // gone for good and the run can never be answered (#2072).
+  await page.reload();
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  await page
+    .getByRole('navigation', { name: '对话列表' })
+    .locator('[data-session-id]')
+    .first()
+    .click();
+
+  await expect(prompt).toBeVisible();
+  await expect(prompt.getByText('1 / 3', { exact: true })).toBeVisible();
+});
+
 test('answers three questions and continues the same fake-backend turn', async ({ window: page }) => {
   const composer = page.locator(COMPOSER_INPUT);
   await composer.fill(FAKE_ASK_USER_QUESTION_PROMPT);

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -432,13 +432,11 @@ export function registerSessionsIpc(
   ipcMain.handle('sessions:readExecutionBoundary', (_event, sessionId: string) =>
     runtime.readExecutionBoundary(sessionId),
   );
-  ipcMain.handle('sessions:listActiveSandboxBoundaryRequests', (_event, sessionId: string) => {
+  ipcMain.handle('sessions:listActiveInteractions', (_event, sessionId: string) => {
     // Already filtered by retirement: `getE2eFixtureState` is the one owner of
     // which fixture requests are still unanswered.
     const fixtureRequest = getE2eFixtureState(e2eFixture)?.sandboxBoundaryBySession?.[sessionId];
-    return fixtureRequest
-      ? [fixtureRequest]
-      : runtime.listActiveSandboxBoundaryRequests(sessionId);
+    return fixtureRequest ? [fixtureRequest] : runtime.listActiveInteractions(sessionId);
   });
   ipcMain.handle('sessions:respondToSandboxBoundary', async (_event, sessionId: string, response) => {
     const normalized = normalizeSandboxBoundaryResponse(response);

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -432,11 +432,17 @@ export function registerSessionsIpc(
   ipcMain.handle('sessions:readExecutionBoundary', (_event, sessionId: string) =>
     runtime.readExecutionBoundary(sessionId),
   );
-  ipcMain.handle('sessions:listActiveInteractions', (_event, sessionId: string) => {
+  ipcMain.handle('sessions:listActiveInteractions', async (_event, sessionId: string) => {
     // Already filtered by retirement: `getE2eFixtureState` is the one owner of
     // which fixture requests are still unanswered.
     const fixtureRequest = getE2eFixtureState(e2eFixture)?.sandboxBoundaryBySession?.[sessionId];
-    return fixtureRequest ? [fixtureRequest] : runtime.listActiveInteractions(sessionId);
+    // Concatenate rather than choose: the read-back is authoritative for the
+    // whole queue now, so shadowing the runtime's list behind a fixture
+    // request would drop a real unanswered one.
+    return [
+      ...(fixtureRequest ? [fixtureRequest] : []),
+      ...(await runtime.listActiveInteractions(sessionId)),
+    ];
   });
   ipcMain.handle('sessions:respondToSandboxBoundary', async (_event, sessionId: string, response) => {
     const normalized = normalizeSandboxBoundaryResponse(response);

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -11,7 +11,7 @@ import type {
   LlmConnection,
   ModelDiscoveryResult,
   ModelInfo,
-  SandboxBoundaryRequestEvent,
+  ActiveInteractionRequestEvent,
   SandboxBoundaryResponse,
   UserQuestionResponse,
   PermissionMode,
@@ -239,9 +239,7 @@ export interface MakaBridge {
     steer(sessionId: string, text: string): Promise<QueueEnqueueOutcome>;
     readMessages(sessionId: string): Promise<StoredMessage[]>;
     readExecutionBoundary(sessionId: string): Promise<ExecutionBoundary>;
-    listActiveSandboxBoundaryRequests(
-      sessionId: string,
-    ): Promise<SandboxBoundaryRequestEvent[]>;
+    listActiveInteractions(sessionId: string): Promise<ActiveInteractionRequestEvent[]>;
     listTurns(sessionId: string): Promise<TurnRecord[]>;
     compact(sessionId: string): Promise<void>;
     resumeLatest(sessionId: string): Promise<

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -21,7 +21,7 @@ import type {
   LlmConnection,
   ModelDiscoveryResult,
   ModelInfo,
-  SandboxBoundaryRequestEvent,
+  ActiveInteractionRequestEvent,
   SandboxBoundaryResponse,
   UserQuestionResponse,
   PermissionMode,
@@ -243,10 +243,8 @@ const makaBridge = {
     readExecutionBoundary(sessionId: string): Promise<ExecutionBoundary> {
       return ipcRenderer.invoke('sessions:readExecutionBoundary', sessionId);
     },
-    listActiveSandboxBoundaryRequests(
-      sessionId: string,
-    ): Promise<SandboxBoundaryRequestEvent[]> {
-      return ipcRenderer.invoke('sessions:listActiveSandboxBoundaryRequests', sessionId);
+    listActiveInteractions(sessionId: string): Promise<ActiveInteractionRequestEvent[]> {
+      return ipcRenderer.invoke('sessions:listActiveInteractions', sessionId);
     },
     listTurns(sessionId: string): Promise<TurnRecord[]> {
       return ipcRenderer.invoke('sessions:listTurns', sessionId);

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -144,7 +144,7 @@ export function createAppShellChatActions(deps: {
    * window opens before any SessionEvent arrives (turn_started is not one). */
   setLiveTurnBySession: LiveTurnRecordUpdater;
   setInteractionBySession: InteractionQueueUpdater;
-  onSandboxBoundaryInteractionChanged?: (sessionId: string) => void;
+  onInteractionChanged?: (sessionId: string) => void;
   /** A boundary decision settled: the session's execution boundary may have moved. */
   onExecutionBoundaryChanged?: (sessionId: string) => void;
   showModelSetupToast: (description: string, reason?: string) => void;
@@ -174,7 +174,7 @@ export function createAppShellChatActions(deps: {
     setNavSelection,
     setLiveTurnBySession,
     setInteractionBySession,
-    onSandboxBoundaryInteractionChanged,
+    onInteractionChanged,
     onExecutionBoundaryChanged,
     showModelSetupToast,
     toastApi,
@@ -471,7 +471,7 @@ export function createAppShellChatActions(deps: {
     if (!sessionId) return;
     try {
       await window.maka.sessions.respondToSandboxBoundary(sessionId, response);
-      onSandboxBoundaryInteractionChanged?.(sessionId);
+      onInteractionChanged?.(sessionId);
       // #1611: the answer has been applied to the authoritative boundary, so
       // the permission label must stop describing the pre-decision one. The
       // ack event covers decisions settled on other surfaces; this covers the
@@ -501,6 +501,7 @@ export function createAppShellChatActions(deps: {
     if (!sessionId) return;
     try {
       await window.maka.sessions.respondToUserQuestion(sessionId, response);
+      onInteractionChanged?.(sessionId);
       setInteractionBySession((current) => dequeueInteractionByRequestId(current, sessionId, response.requestId));
     } catch (error) {
       if (activeIdRef.current !== sessionId) return;

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -123,17 +123,18 @@ export function createAppShellSessionEventHandlers(options: {
         void refreshMessages(sessionId, { requiredAssistantMessageId: event.messageId }).catch(() => false);
         break;
       case 'sandbox_boundary_request':
-        onInteractionChanged?.(sessionId);
-        setInteractionBySession((current) => enqueueInteraction(current, sessionId, event));
-        break;
       case 'user_question_request':
         onInteractionChanged?.(sessionId);
         setInteractionBySession((current) => enqueueInteraction(current, sessionId, event));
         break;
       // The runtime drops its owner on this ack, not on the tool result that
-      // follows it, so this is the point an in-flight hydration goes stale.
+      // follows it, so this is where the request stops being answerable — the
+      // same point its boundary sibling settles on, below.
       case 'user_question_answer_ack':
         onInteractionChanged?.(sessionId);
+        setInteractionBySession((current) =>
+          dequeueInteractionByRequestId(current, sessionId, event.requestId),
+        );
         break;
       case 'sandbox_boundary_decision_ack':
         onInteractionChanged?.(sessionId);

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -40,7 +40,7 @@ export function createAppShellSessionEventHandlers(options: {
   refreshSessions: () => Promise<unknown>;
   setLiveTurnBySession: StateUpdater<Record<string, LiveTurnProjection>>;
   setInteractionBySession: StateUpdater<InteractionQueues>;
-  onSandboxBoundaryInteractionChanged?: (sessionId: string) => void;
+  onInteractionChanged?: (sessionId: string) => void;
   /** A boundary decision settled: the session's execution boundary may have moved. */
   onExecutionBoundaryChanged?: (sessionId: string) => void;
   showModelSetupToast: (description: string, reason?: string) => void;
@@ -55,7 +55,7 @@ export function createAppShellSessionEventHandlers(options: {
     refreshSessions,
     setLiveTurnBySession,
     setInteractionBySession,
-    onSandboxBoundaryInteractionChanged,
+    onInteractionChanged,
     onExecutionBoundaryChanged,
     showModelSetupToast,
     toastApi,
@@ -123,14 +123,20 @@ export function createAppShellSessionEventHandlers(options: {
         void refreshMessages(sessionId, { requiredAssistantMessageId: event.messageId }).catch(() => false);
         break;
       case 'sandbox_boundary_request':
-        onSandboxBoundaryInteractionChanged?.(sessionId);
+        onInteractionChanged?.(sessionId);
         setInteractionBySession((current) => enqueueInteraction(current, sessionId, event));
         break;
       case 'user_question_request':
+        onInteractionChanged?.(sessionId);
         setInteractionBySession((current) => enqueueInteraction(current, sessionId, event));
         break;
+      // The runtime drops its owner on this ack, not on the tool result that
+      // follows it, so this is the point an in-flight hydration goes stale.
+      case 'user_question_answer_ack':
+        onInteractionChanged?.(sessionId);
+        break;
       case 'sandbox_boundary_decision_ack':
-        onSandboxBoundaryInteractionChanged?.(sessionId);
+        onInteractionChanged?.(sessionId);
         // #1611: an approved expansion changes only the boundary's revision —
         // no session field moves — so the boundary read model has to be told,
         // or the permission label keeps describing the permissions the session
@@ -145,7 +151,7 @@ export function createAppShellSessionEventHandlers(options: {
         void refreshMessages(sessionId);
         break;
       case 'error':
-        onSandboxBoundaryInteractionChanged?.(sessionId);
+        onInteractionChanged?.(sessionId);
         setInteractionBySession((current) => clearInteractions(current, sessionId));
         if (activeIdRef.current === sessionId) {
           if (isNoRealConnectionEvent(event)) {
@@ -161,13 +167,13 @@ export function createAppShellSessionEventHandlers(options: {
         void refreshMessages(sessionId, terminalRefreshOptions(before));
         break;
       case 'abort':
-        onSandboxBoundaryInteractionChanged?.(sessionId);
+        onInteractionChanged?.(sessionId);
         setInteractionBySession((current) => clearInteractions(current, sessionId));
         void refreshSessions();
         void refreshMessages(sessionId, terminalRefreshOptions(before));
         break;
       case 'complete': {
-        onSandboxBoundaryInteractionChanged?.(sessionId);
+        onInteractionChanged?.(sessionId);
         setInteractionBySession((current) => clearInteractions(current, sessionId));
         if (event.stopReason === 'end_turn' || event.stopReason === 'max_tokens') {
           const body = [...(before?.steps ?? [])].reverse().find((step) => step.text?.text)?.text?.text;

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -47,7 +47,7 @@ import {
   enqueueInteraction,
   getConversationCopy,
   getSharedUiCopy,
-  reconcileSandboxBoundaryInteractions,
+  reconcileInteractions,
 } from '@maka/ui';
 import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
@@ -276,9 +276,9 @@ function AppShellContent({
     setPendingSessionModelBySession,
     clearTurnTransientState,
   } = useAppShellSessionWorkspace(toastApi);
-  const sandboxBoundaryInteractionEpochRef = useRef(new Map<string, number>());
-  const markSandboxBoundaryInteractionChanged = useCallback((sessionId: string) => {
-    const epochs = sandboxBoundaryInteractionEpochRef.current;
+  const interactionHydrationEpochRef = useRef(new Map<string, number>());
+  const markInteractionChanged = useCallback((sessionId: string) => {
+    const epochs = interactionHydrationEpochRef.current;
     epochs.set(sessionId, (epochs.get(sessionId) ?? 0) + 1);
   }, []);
   const attachmentDraftKey = activeId ?? 'new-session';
@@ -1043,22 +1043,25 @@ function AppShellContent({
     reading: activeExecutionBoundaryReading,
     reload: reloadActiveExecutionBoundary,
   } = useActiveExecutionBoundary(activeId, activeSessionForView?.permissionMode);
+  // The session view only subscribes to the session it shows, so a request
+  // raised while another session was active never reaches this surface as a
+  // live event — and neither does one raised before the window existed. The
+  // runtime holds every unanswered request, so read them back whenever the
+  // active session changes (#2072).
   useEffect(() => {
     if (!activeId) return;
     let cancelled = false;
-    const hydrationEpoch = sandboxBoundaryInteractionEpochRef.current.get(activeId) ?? 0;
+    const hydrationEpoch = interactionHydrationEpochRef.current.get(activeId) ?? 0;
     void window.maka.sessions
-      .listActiveSandboxBoundaryRequests(activeId)
+      .listActiveInteractions(activeId)
       .then((requests) => {
         if (
           cancelled ||
-          (sandboxBoundaryInteractionEpochRef.current.get(activeId) ?? 0) !== hydrationEpoch
+          (interactionHydrationEpochRef.current.get(activeId) ?? 0) !== hydrationEpoch
         ) {
           return;
         }
-        setInteractionBySession((current) =>
-          reconcileSandboxBoundaryInteractions(current, activeId, requests),
-        );
+        setInteractionBySession((current) => reconcileInteractions(current, activeId, requests));
       })
       .catch(() => {});
     return () => {
@@ -1368,7 +1371,7 @@ function AppShellContent({
     setNavSelection,
     setLiveTurnBySession,
     setInteractionBySession,
-    onSandboxBoundaryInteractionChanged: markSandboxBoundaryInteractionChanged,
+    onInteractionChanged: markInteractionChanged,
     onExecutionBoundaryChanged: reloadActiveExecutionBoundary,
     showModelSetupToast,
     toastApi,
@@ -1721,7 +1724,7 @@ function AppShellContent({
     refreshSessions,
     setLiveTurnBySession,
     setInteractionBySession,
-    onSandboxBoundaryInteractionChanged: markSandboxBoundaryInteractionChanged,
+    onInteractionChanged: markInteractionChanged,
     onExecutionBoundaryChanged: reloadActiveExecutionBoundary,
     showModelSetupToast,
     toastApi,

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -835,6 +835,13 @@ export interface SandboxBoundaryRequestEvent extends BaseEvent {
   expansion: SandboxBoundaryExpansion;
 }
 
+/**
+ * The requests a session can park on while it waits for the user. Both are
+ * registered by RuntimeKernel while unanswered, so a surface that missed the
+ * live event can rehydrate the prompt instead of stranding the run.
+ */
+export type ActiveInteractionRequestEvent = SandboxBoundaryRequestEvent | UserQuestionRequestEvent;
+
 export interface SandboxBoundaryDecisionAckEvent extends BaseEvent {
   type: 'sandbox_boundary_decision_ack';
   requestId: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,7 @@ export type {
   ShellRunUpdate,
   SandboxDenialSignal,
   SandboxDenialRecovery,
+  ActiveInteractionRequestEvent,
   SandboxBoundaryRequestEvent,
   SandboxBoundaryDecisionAckEvent,
   AdditionalPermissionRequestEvent,

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -14899,7 +14899,7 @@ describe('SessionManager permission mode updates', () => {
       .sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })
       [Symbol.asyncIterator]();
     expect((await iterator.next()).value?.type).toBe('sandbox_boundary_request');
-    const [activeBoundaryRequest] = await manager.listActiveSandboxBoundaryRequests(session.id);
+    const [activeBoundaryRequest] = await manager.listActiveInteractions(session.id);
     expect(activeBoundaryRequest).toMatchObject({
       type: 'sandbox_boundary_request',
       requestId: 'boundary-1',
@@ -14919,9 +14919,55 @@ describe('SessionManager permission mode updates', () => {
     });
     expect(backend?.responses).toEqual([{ requestId: 'boundary-1', decision: 'deny' }]);
     expect((await iterator.next()).value?.type).toBe('sandbox_boundary_decision_ack');
-    expect(await manager.listActiveSandboxBoundaryRequests(session.id)).toEqual([]);
+    expect(await manager.listActiveInteractions(session.id)).toEqual([]);
     while (!(await iterator.next()).done) {}
     expect((await store.readHeader(session.id)).status).toBe('active');
+  });
+
+  test('lists an unanswered user question until its answer ack lands', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new FakeBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(9_000),
+    });
+    const session = await manager.createSession(makeInput({ backend: 'fake' }));
+
+    const iterator = manager
+      .sendMessage(session.id, { turnId: 'turn-1', text: FAKE_ASK_USER_QUESTION_PROMPT })
+      [Symbol.asyncIterator]();
+    let request: SessionEvent | undefined;
+    while (request?.type !== 'user_question_request') {
+      const next = await iterator.next();
+      if (next.done) break;
+      request = next.value;
+    }
+    expect(request?.type).toBe('user_question_request');
+
+    // The surface that raised this request may never have been mounted, so the
+    // request has to be readable back from the kernel (#2072).
+    const active = await manager.listActiveInteractions(session.id);
+    expect(active).toEqual([request]);
+
+    await manager.respondToUserQuestion(session.id, {
+      requestId: (request as Extract<SessionEvent, { type: 'user_question_request' }>).requestId,
+      answers: ['邀请制', '本周', '是'],
+    });
+    let ack: SessionEvent | undefined;
+    while (ack?.type !== 'user_question_answer_ack') {
+      const next = await iterator.next();
+      if (next.done) break;
+      ack = next.value;
+    }
+    expect(ack?.type).toBe('user_question_answer_ack');
+    expect(await manager.listActiveInteractions(session.id)).toEqual([]);
+    while (!(await iterator.next()).done) {}
   });
 
   test('reads a completed session back after a sandbox boundary allow', async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -14955,8 +14955,18 @@ describe('SessionManager permission mode updates', () => {
     const active = await manager.listActiveInteractions(session.id);
     expect(active).toEqual([request]);
 
+    const requestId = (request as Extract<SessionEvent, { type: 'user_question_request' }>)
+      .requestId;
+    // One registry now holds both request kinds, so answering a question as if
+    // it were a boundary must settle nothing and leave the entry intact.
+    await expectRejects(
+      manager.respondToSandboxBoundary(session.id, { requestId, decision: 'deny' }),
+      /No pending sandbox boundary request/,
+    );
+    expect(await manager.listActiveInteractions(session.id)).toEqual([request]);
+
     await manager.respondToUserQuestion(session.id, {
-      requestId: (request as Extract<SessionEvent, { type: 'user_question_request' }>).requestId,
+      requestId,
       answers: ['邀请制', '本周', '是'],
     });
     let ack: SessionEvent | undefined;
@@ -14968,6 +14978,40 @@ describe('SessionManager permission mode updates', () => {
     expect(ack?.type).toBe('user_question_answer_ack');
     expect(await manager.listActiveInteractions(session.id)).toEqual([]);
     while (!(await iterator.next()).done) {}
+  });
+
+  test('releases a question abandoned by a stopped turn', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new FakeBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(9_000),
+    });
+    const session = await manager.createSession(makeInput({ backend: 'fake' }));
+
+    const iterator = manager
+      .sendMessage(session.id, { turnId: 'turn-1', text: FAKE_ASK_USER_QUESTION_PROMPT })
+      [Symbol.asyncIterator]();
+    let request: SessionEvent | undefined;
+    while (request?.type !== 'user_question_request') {
+      const next = await iterator.next();
+      if (next.done) break;
+      request = next.value;
+    }
+    expect(request?.type).toBe('user_question_request');
+
+    // A stop settles no answer, so this question never gets its ack. Only the
+    // turn-end release keeps it from being read back as a prompt for a dead
+    // run — one nothing could answer, since the backend generation is gone.
+    await manager.stopSession(session.id, { source: 'stop_button' });
+    while (!(await iterator.next()).done) {}
+    expect(await manager.listActiveInteractions(session.id)).toEqual([]);
   });
 
   test('reads a completed session back after a sandbox boundary allow', async () => {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -10,6 +10,7 @@ import type {
 } from '@maka/core';
 import { isSessionInlineRun } from '@maka/core';
 import type {
+  ActiveInteractionRequestEvent,
   CompleteEvent,
   QueueEnqueueOutcome,
   QueueUpdateEvent,
@@ -146,9 +147,7 @@ export interface RuntimeKernelLike {
   ): AsyncIterable<SessionEvent>;
   stopSession(sessionId: string, input?: StopSessionInput): Promise<void>;
   respondToSandboxBoundary(sessionId: string, response: SandboxBoundaryResponse): Promise<void>;
-  listActiveSandboxBoundaryRequests?(
-    sessionId: string,
-  ): Array<Extract<SessionEvent, { type: 'sandbox_boundary_request' }>>;
+  listActiveInteractions?(sessionId: string): ActiveInteractionRequestEvent[];
   respondToUserQuestion?(sessionId: string, response: UserQuestionResponse): Promise<void>;
   /** Queue a user message for mid-turn injection at the next step boundary. */
   steer(sessionId: string, text: string): QueueEnqueueOutcome;
@@ -393,11 +392,11 @@ interface BackendInvalidationState {
   failure?: Error;
 }
 
-interface SandboxBoundaryRequestOwner {
+interface InteractionRequestOwner {
   sessionId: string;
   turnId: string;
   generation: number;
-  request: Extract<SessionEvent, { type: 'sandbox_boundary_request' }>;
+  request: ActiveInteractionRequestEvent;
 }
 
 export class RuntimeKernel implements RuntimeKernelLike {
@@ -419,7 +418,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   private readonly pendingContinuationSessions = new Set<string>();
   private readonly steeringBySession = new Map<string, SessionSteeringState>();
   private readonly backendInvalidations = new Map<string, BackendInvalidationState>();
-  private readonly sandboxBoundaryRequestOwners = new Map<string, SandboxBoundaryRequestOwner>();
+  private readonly interactionRequestOwners = new Map<string, InteractionRequestOwner>();
   private nextBackendGeneration = 0;
   private readonly interactionRuns = new Map<AgentRun, RuntimeInteractionRunBinding>();
 
@@ -1611,7 +1610,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           requireTerminalWrite: Boolean(this.deps.runtimeEventStore),
           allowInteractionResume: await interactionResumeAllowed(interactionRun, sessionEvent),
         });
-        this.observeSandboxBoundaryEvent(sessionId, begin.backend, sessionEvent);
+        this.observeInteractionEvent(sessionId, begin.backend, sessionEvent);
         await sessionEvents.push(sessionEvent);
       },
       onError: async (error) => {
@@ -1714,7 +1713,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           },
         });
       } finally {
-        this.clearSandboxBoundaryRequestOwners(sessionId, run.turnId);
+        this.clearInteractionRequestOwners(sessionId, run.turnId);
         releaseExecutionAbort();
       }
     }
@@ -1785,7 +1784,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           requireTerminalWrite: true,
           allowInteractionResume: await interactionResumeAllowed(interactionRun, sessionEvent),
         });
-        this.observeSandboxBoundaryEvent(continuation.sessionId, begin.backend, sessionEvent);
+        this.observeInteractionEvent(continuation.sessionId, begin.backend, sessionEvent);
         await sessionEvents.push(sessionEvent);
       },
       onError: async (error) => {
@@ -1882,7 +1881,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           releaseOwner: () => owners.releaseMessage(),
         });
       } finally {
-        this.clearSandboxBoundaryRequestOwners(continuation.sessionId, run.turnId);
+        this.clearInteractionRequestOwners(continuation.sessionId, run.turnId);
         releaseExecutionAbort();
       }
     }
@@ -2346,9 +2345,11 @@ export class RuntimeKernel implements RuntimeKernelLike {
     sessionId: string,
     response: SandboxBoundaryResponse,
   ): Promise<void> {
-    const key = sandboxBoundaryOwnerKey(sessionId, response.requestId);
-    const owner = this.sandboxBoundaryRequestOwners.get(key);
-    if (!owner) throw new Error(`No pending sandbox boundary request ${response.requestId}`);
+    const key = interactionOwnerKey(sessionId, response.requestId);
+    const owner = this.interactionRequestOwners.get(key);
+    if (owner?.request.type !== 'sandbox_boundary_request') {
+      throw new Error(`No pending sandbox boundary request ${response.requestId}`);
+    }
     const active = this.backendGenerations.get(owner.generation);
     if (
       !active ||
@@ -2356,16 +2357,14 @@ export class RuntimeKernel implements RuntimeKernelLike {
       active.phase === 'terminated' ||
       active.phase === 'failed'
     ) {
-      this.sandboxBoundaryRequestOwners.delete(key);
+      this.interactionRequestOwners.delete(key);
       throw new Error(`Sandbox boundary request owner is unavailable: ${response.requestId}`);
     }
     await active.backend.respondToSandboxBoundary(response);
   }
 
-  listActiveSandboxBoundaryRequests(
-    sessionId: string,
-  ): Array<Extract<SessionEvent, { type: 'sandbox_boundary_request' }>> {
-    return [...this.sandboxBoundaryRequestOwners.values()]
+  listActiveInteractions(sessionId: string): ActiveInteractionRequestEvent[] {
+    return [...this.interactionRequestOwners.values()]
       .filter((owner) => owner.sessionId === sessionId)
       .sort((left, right) => left.request.ts - right.request.ts)
       .map((owner) => owner.request);
@@ -2609,20 +2608,30 @@ export class RuntimeKernel implements RuntimeKernelLike {
     );
   }
 
-  private observeSandboxBoundaryEvent(
+  /**
+   * Track every request a session can park on until its settlement ack lands,
+   * so a surface that was not mounted when the request streamed by can still
+   * read it back and render the prompt (#2072).
+   */
+  private observeInteractionEvent(
     sessionId: string,
     backend: AgentBackend,
     event: SessionEvent,
   ): void {
     if (
       event.type !== 'sandbox_boundary_request' &&
-      event.type !== 'sandbox_boundary_decision_ack'
+      event.type !== 'user_question_request' &&
+      event.type !== 'sandbox_boundary_decision_ack' &&
+      event.type !== 'user_question_answer_ack'
     ) {
       return;
     }
-    const key = sandboxBoundaryOwnerKey(sessionId, event.requestId);
-    if (event.type === 'sandbox_boundary_decision_ack') {
-      this.sandboxBoundaryRequestOwners.delete(key);
+    const key = interactionOwnerKey(sessionId, event.requestId);
+    if (
+      event.type === 'sandbox_boundary_decision_ack' ||
+      event.type === 'user_question_answer_ack'
+    ) {
+      this.interactionRequestOwners.delete(key);
       return;
     }
     const generation = [...this.backendGenerations.values()].find(
@@ -2633,19 +2642,19 @@ export class RuntimeKernel implements RuntimeKernelLike {
     );
     if (!generation) {
       throw new RuntimeInteractionInvariantError(
-        `Sandbox boundary request ${event.requestId} has no active backend owner`,
+        `Interaction request ${event.requestId} has no active backend owner`,
       );
     }
-    const existing = this.sandboxBoundaryRequestOwners.get(key);
+    const existing = this.interactionRequestOwners.get(key);
     if (
       existing &&
       (existing.generation !== generation.generation || existing.turnId !== event.turnId)
     ) {
       throw new RuntimeInteractionInvariantError(
-        `Sandbox boundary request ${event.requestId} has conflicting owners`,
+        `Interaction request ${event.requestId} has conflicting owners`,
       );
     }
-    this.sandboxBoundaryRequestOwners.set(key, {
+    this.interactionRequestOwners.set(key, {
       sessionId,
       turnId: event.turnId,
       generation: generation.generation,
@@ -2653,10 +2662,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
     });
   }
 
-  private clearSandboxBoundaryRequestOwners(sessionId: string, turnId: string): void {
-    for (const [key, owner] of this.sandboxBoundaryRequestOwners) {
+  private clearInteractionRequestOwners(sessionId: string, turnId: string): void {
+    for (const [key, owner] of this.interactionRequestOwners) {
       if (owner.sessionId === sessionId && owner.turnId === turnId) {
-        this.sandboxBoundaryRequestOwners.delete(key);
+        this.interactionRequestOwners.delete(key);
       }
     }
   }
@@ -3850,7 +3859,7 @@ class FailureCollector {
   }
 }
 
-function sandboxBoundaryOwnerKey(sessionId: string, requestId: string): string {
+function interactionOwnerKey(sessionId: string, requestId: string): string {
   return `${sessionId}\0${requestId}`;
 }
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -14,6 +14,7 @@ import { createHash } from 'node:crypto';
 import { isDeepStrictEqual } from 'node:util';
 import { setTimeout as delay } from 'node:timers/promises';
 import type {
+  ActiveInteractionRequestEvent,
   SessionEvent,
   CompleteEvent,
   TextDeltaEvent,
@@ -1550,11 +1551,9 @@ export class SessionManager {
     return this.deps.store.readExecutionBoundary(sessionId);
   }
 
-  async listActiveSandboxBoundaryRequests(
-    sessionId: string,
-  ): Promise<Array<Extract<SessionEvent, { type: 'sandbox_boundary_request' }>>> {
+  async listActiveInteractions(sessionId: string): Promise<ActiveInteractionRequestEvent[]> {
     await this.deps.store.readHeader(sessionId);
-    return this.runtimeKernel.listActiveSandboxBoundaryRequests?.(sessionId) ?? [];
+    return this.runtimeKernel.listActiveInteractions?.(sessionId) ?? [];
   }
 
   async setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary> {

--- a/packages/ui/src/__tests__/interaction-queue.test.ts
+++ b/packages/ui/src/__tests__/interaction-queue.test.ts
@@ -11,7 +11,7 @@ import {
   dequeueInteractionByRequestId,
   dequeueInteractionByToolUseId,
   enqueueInteraction,
-  reconcileSandboxBoundaryInteractions,
+  reconcileInteractions,
   type InteractionQueues,
 } from '../interaction-queue.js';
 
@@ -78,20 +78,28 @@ describe('composer interaction queue', () => {
     assert.equal(activeInteractionFor(queues, 's'), undefined);
   });
 
-  test('rehydration replaces only boundary prompts and preserves user questions', () => {
+  test('rehydration keeps the shown order and drops what the runtime settled', () => {
     let queues: InteractionQueues = {};
     queues = enqueueInteraction(queues, 's', boundary('stale'));
-    queues = enqueueInteraction(queues, 's', question('question'));
+    queues = enqueueInteraction(queues, 's', question('answered'));
     queues = enqueueInteraction(queues, 's', boundary('live'));
 
-    const reconciled = reconcileSandboxBoundaryInteractions(queues, 's', [
+    const reconciled = reconcileInteractions(queues, 's', [
       boundary('live'),
+      question('unseen'),
       boundary('new'),
     ]);
 
     assert.deepEqual(
       reconciled.s.map((interaction) => interaction.requestId),
-      ['question', 'live', 'new'],
+      ['live', 'unseen', 'new'],
     );
+  });
+
+  test('rehydration adds a question the surface never saw live', () => {
+    const reconciled = reconcileInteractions({}, 's', [question('missed')]);
+
+    assert.equal(activeInteractionFor(reconciled, 's')?.type, 'user_question_request');
+    assert.equal(activeInteractionFor(reconciled, 's')?.requestId, 'missed');
   });
 });

--- a/packages/ui/src/interaction-queue.ts
+++ b/packages/ui/src/interaction-queue.ts
@@ -1,11 +1,6 @@
-import type {
-  SandboxBoundaryRequestEvent,
-  UserQuestionRequestEvent,
-} from '@maka/core';
+import type { ActiveInteractionRequestEvent } from '@maka/core';
 
-export type ComposerInteraction =
-  | SandboxBoundaryRequestEvent
-  | UserQuestionRequestEvent;
+export type ComposerInteraction = ActiveInteractionRequestEvent;
 export type InteractionQueues = Record<string, ComposerInteraction[]>;
 
 export function enqueueInteraction(
@@ -43,19 +38,20 @@ export function clearInteractions(queues: InteractionQueues, sessionId: string):
   return { ...queues, [sessionId]: [] };
 }
 
-export function reconcileSandboxBoundaryInteractions(
+/**
+ * Replace a session's queue with the runtime's live set of unanswered
+ * requests, keeping the order the surface already shows. The runtime owns both
+ * kinds of request, so anything it no longer holds is settled and drops out.
+ */
+export function reconcileInteractions(
   queues: InteractionQueues,
   sessionId: string,
-  liveRequests: readonly SandboxBoundaryRequestEvent[],
+  liveRequests: readonly ComposerInteraction[],
 ): InteractionQueues {
   const liveById = new Map(liveRequests.map((request) => [request.requestId, request]));
   const seen = new Set<string>();
   const reconciled: ComposerInteraction[] = [];
   for (const interaction of queues[sessionId] ?? []) {
-    if (interaction.type !== 'sandbox_boundary_request') {
-      reconciled.push(interaction);
-      continue;
-    }
     const live = liveById.get(interaction.requestId);
     if (!live) continue;
     seen.add(interaction.requestId);


### PR DESCRIPTION
## Summary

A run that parks on `AskUserQuestion` could become permanently unanswerable. The session view subscribes only to the session it shows, so a request raised while another session was active — or before the window existed — never reached the surface, and nothing read it back. The prompt was gone for good; the run stayed parked on a question the UI could not answer.

Sandbox-boundary requests already hold this invariant: RuntimeKernel keeps every unanswered request in a registry, and the shell reads it back whenever the active session changes. `AskUserQuestion` was the one exception. This generalizes that single path to both request kinds rather than adding a parallel mechanism:

- `RuntimeKernel` registers `user_question_request` alongside `sandbox_boundary_request` and drops each on its settlement ack (`user_question_answer_ack` / `sandbox_boundary_decision_ack`); the existing per-turn cleanup already covers both.
- `listActiveSandboxBoundaryRequests` becomes `listActiveInteractions` through `SessionManager`, IPC, and preload, returning the shared `ActiveInteractionRequestEvent` union now exported from `@maka/core`.
- The composer queue's `reconcileInteractions` reconciles against the full live set instead of passing questions through untouched, and the renderer's hydration epoch is now bumped by question events too, so an in-flight read-back cannot resurrect a settled prompt.

Hosted sessions are unaffected: the kernel registry stays an embedded-side in-memory index, and the Question fact remains owned by the Host's `interactionAuthority`.

Closes #2072

## Verification

The new E2E is red before the fix and green after — reload discards every event the surface saw while the runtime keeps the turn parked:

```
# fix stashed, spec kept
  1 failed
    e2e/ask-user-question.spec.ts:4:1 › rehydrates a prompt the surface never received live
  1 passed

# fix restored
  ✓  1 e2e/ask-user-question.spec.ts:4:1 › rehydrates a prompt the surface never received live (1.2s)
  ✓  2 e2e/ask-user-question.spec.ts:27:1 › answers three questions and continues the same fake-backend turn (1.3s)
  2 passed
```

All green locally:

- `npm run build`, `npm run lint`, `npm run format:check`, `@maka/desktop typecheck`
- runtime 3098 pass · runtime-host 628 pass · headless 1338 pass · desktop main 1585 pass · ui 317 pass · core 772 pass
- full Playwright E2E: 64 passed
- `scripts/audit-alignment.mjs`: all fixtures clean
- Storybook build + smoke: 68 manifest checks, 73 catalog renders

New coverage: a runtime test asserting a question is listed until its answer ack lands, and two `reconcileInteractions` unit tests (order preservation + a question the surface never saw live).

## Review follow-ups

Three external review passes (first-principles / correctness / test-quality) returned no P0–P1. Handled in `37ba26cf2`:

- **Ack asymmetry.** The renderer left an answered question queued until its `tool_result`, while the boundary sibling dequeued on the ack. The ack is where the runtime drops its owner, so both kinds settle there now; the two identical request cases fold into one.
- **Read-back shadowing.** `sessions:listActiveInteractions` returned *only* the E2E fixture request when one was present — harmless while questions passed through reconciliation untouched, but now that the live set owns the whole queue it would drop a real unanswered request. Concatenated instead. Probed against the running fixture app: the fixture session's `readHeader` succeeds, so the added runtime call is safe.
- **Untested registry contracts.** Added: a stopped turn releases the question it abandoned (mutation-verified — commenting out the turn-end release turns it red), and a boundary response aimed at a question's `requestId` settles nothing and leaves the entry intact.

Deferred with reason:

- **Stop-window ghost prompt.** Between a stop and the run's turn-end release, a hydration can surface a prompt for a dead run, and answering it is silently dropped (`respondToUserQuestion` fans out to non-terminated generations only). This window predates the change and applies equally to sandbox-boundary requests; closing it means releasing owners on `abort`/`complete`, which is its own intent. Not in scope here.
- **Epoch-guard unit test.** Would require extracting the guard into a helper that exists only to be tested; the read-back path it protects is covered by the E2E and the runtime tests.
- **Multi-question FIFO ordering** at the kernel level needs two concurrently parked turns to construct — cost exceeds the risk for a `ts` sort.

Re-verified after the follow-ups: runtime 3099 pass, desktop main 1585 pass, full E2E 64 passed, `format:check` and `lint` clean.
