### PR TITLE
refactor(runtime): make the execution boundary the sole file-path authority

### DIFF
--- a/packages/headless/src/__tests__/workspace-executor-adapter.test.ts
+++ b/packages/headless/src/__tests__/workspace-executor-adapter.test.ts
@@ -148,16 +148,18 @@ describe('isolatedToolExecutorToWorkspaceExecutor', () => {
     };
     const executor = isolatedToolExecutorToWorkspaceExecutor(isolated);
 
-    await assert.rejects(
-      () =>
-        executor.resolveWritablePath({
-          cwd: '/workspace',
-          path: '/tmp/out.txt',
-          label: 'Write',
-          scope: 'host',
-        }),
-      /cannot use host path scope/,
-    );
+    for (const resolve of [executor.resolveWritablePath, executor.resolveExistingPath]) {
+      await assert.rejects(
+        () =>
+          resolve({
+            cwd: '/workspace',
+            path: '/tmp/out.txt',
+            label: 'Write',
+            scope: 'host',
+          }),
+        /cannot use host path scope/,
+      );
+    }
     assert.deepEqual(
       await executor.resolveWritablePath({
         cwd: '/workspace',

--- a/packages/headless/src/__tests__/workspace-executor-adapter.test.ts
+++ b/packages/headless/src/__tests__/workspace-executor-adapter.test.ts
@@ -140,6 +140,35 @@ describe('isolatedToolExecutorToWorkspaceExecutor', () => {
     );
   });
 
+  test('refuses host path scope instead of degrading the isolated workspace', async () => {
+    const isolated: IsolatedToolExecutor = {
+      async exec() {
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+    const executor = isolatedToolExecutorToWorkspaceExecutor(isolated);
+
+    await assert.rejects(
+      () =>
+        executor.resolveWritablePath({
+          cwd: '/workspace',
+          path: '/tmp/out.txt',
+          label: 'Write',
+          scope: 'host',
+        }),
+      /cannot use host path scope/,
+    );
+    assert.deepEqual(
+      await executor.resolveWritablePath({
+        cwd: '/workspace',
+        path: 'out.txt',
+        label: 'Write',
+        scope: 'workspace',
+      }),
+      { path: '/workspace/out.txt' },
+    );
+  });
+
   test('exposes only supported workspace capabilities at the type boundary', () => {
     const isolated: IsolatedToolExecutor = {
       async exec() {

--- a/packages/headless/src/workspace-executor-adapter.ts
+++ b/packages/headless/src/workspace-executor-adapter.ts
@@ -84,6 +84,15 @@ async function isolatedWriteFile(
 async function isolatedResolvePath(
   input: WorkspaceResolvePathInput,
 ): Promise<WorkspaceResolvePathResult> {
+  // Host scope is not a policy this adapter may relax: the isolated workspace is
+  // the whole filesystem its backend can address, so a host path has no meaning
+  // here. Rejecting it loudly keeps a bypass boundary from silently degrading
+  // into host access through an isolated executor.
+  if (input.scope === 'host') {
+    throw new Error(
+      `${input.label} cannot use host path scope: the isolated workspace executor only addresses paths inside its workspace.`,
+    );
+  }
   return { path: resolveIsolatedWorkspacePath(input.cwd, input.path, input.label) };
 }
 

--- a/packages/runtime/src/__tests__/filesystem-authority.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-authority.test.ts
@@ -1,0 +1,266 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ExecutionBoundary } from '@maka/core';
+import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
+import { expect } from '../test-helpers.js';
+import { buildBuiltinTools } from '../builtin-tools.js';
+import { SandboxCommandError } from '../sandbox/errors.js';
+import { createLocalWorkspaceExecutor } from '../workspace-executor.js';
+import type { MakaTool } from '../tool-runtime.js';
+
+/**
+ * The execution boundary is the only authority over where the file tools may
+ * reach. These tests pin that from the outside — through the tools themselves,
+ * against a real filesystem — because the defect they cover (#2083) was
+ * invisible to every unit that knew only one of the two backends: "full access"
+ * was the one mode where an undeclared cwd containment became the arbiter, and
+ * it was stricter than the profile every other mode enforces.
+ */
+
+const BYPASS: ExecutionBoundary = { kind: 'bypass', revision: 0 };
+const EXTERNAL: ExecutionBoundary = { kind: 'external', revision: 0 };
+const MANAGED: ExecutionBoundary = {
+  kind: 'managed',
+  revision: 0,
+  profile: createWorkspaceWritePermissionProfile(),
+};
+
+async function makeDirs(): Promise<{ cwd: string; outside: string; cleanup: () => Promise<void> }> {
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'maka-fs-authority-')));
+  const cwd = join(root, 'session');
+  const outside = join(root, 'outside');
+  await mkdir(cwd);
+  await mkdir(outside);
+  return { cwd, outside, cleanup: () => rm(root, { recursive: true, force: true }) };
+}
+
+function toolsFor(overrides: Parameters<typeof buildBuiltinTools>[0] = {}): MakaTool[] {
+  return buildBuiltinTools({ executor: createLocalWorkspaceExecutor(), ...overrides });
+}
+
+function toolNamed(tools: MakaTool[], name: string): MakaTool {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`${name} tool missing`);
+  return tool;
+}
+
+function runTool(
+  tool: MakaTool,
+  args: unknown,
+  cwd: string,
+  executionBoundary?: ExecutionBoundary,
+): Promise<unknown> {
+  return Promise.resolve(
+    tool.impl(args as never, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      cwd,
+      toolCallId: 'tool-1',
+      abortSignal: new AbortController().signal,
+      emitOutput: () => {},
+      ...(executionBoundary ? { executionBoundary } : {}),
+    }),
+  );
+}
+
+describe('file tools follow the execution boundary', () => {
+  test('a bypass boundary reaches outside the session cwd, as Bash already does', async () => {
+    const { cwd, outside, cleanup } = await makeDirs();
+    try {
+      const tools = toolsFor();
+      const target = join(outside, 'note.md');
+
+      const written = await runTool(
+        toolNamed(tools, 'Write'),
+        { path: target, content: 'hello' },
+        cwd,
+        BYPASS,
+      );
+      expect(written).toMatchObject({ ok: true, path: target });
+      expect(await readFile(target, 'utf8')).toBe('hello');
+
+      const read = await runTool(toolNamed(tools, 'Read'), { path: target }, cwd, BYPASS);
+      expect(read).toEqual({ content: 'hello' });
+
+      const edited = await runTool(
+        toolNamed(tools, 'Edit'),
+        { path: target, old_string: 'hello', new_string: 'bye' },
+        cwd,
+        BYPASS,
+      );
+      expect(edited).toMatchObject({ ok: true, replacements: 1 });
+      expect(await readFile(target, 'utf8')).toBe('bye');
+
+      await writeFile(join(outside, 'data.json'), '{"b":1,"a":2}', 'utf8');
+      const formatted = await runTool(
+        toolNamed(tools, 'FormatJson'),
+        { path: join(outside, 'data.json'), sort_keys: true },
+        cwd,
+        BYPASS,
+      );
+      expect(formatted).toMatchObject({ ok: true, valid: true, changed: true });
+
+      const globbed = (await runTool(
+        toolNamed(tools, 'Glob'),
+        { pattern: '*.md', cwd: outside },
+        cwd,
+        BYPASS,
+      )) as { files: string[] };
+      expect(globbed.files).toEqual(['note.md']);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('every other boundary keeps the same paths inside the session cwd', async () => {
+    const { cwd, outside, cleanup } = await makeDirs();
+    try {
+      const tools = toolsFor();
+      const target = join(outside, 'note.md');
+      await writeFile(target, 'hello', 'utf8');
+
+      for (const boundary of [undefined, EXTERNAL]) {
+        await assert.rejects(
+          runTool(toolNamed(tools, 'Write'), { path: target, content: 'x' }, cwd, boundary),
+          /Write path must stay inside session cwd/,
+        );
+        await assert.rejects(
+          runTool(toolNamed(tools, 'Read'), { path: target }, cwd, boundary),
+          /Read path must stay inside session cwd/,
+        );
+        await assert.rejects(
+          runTool(
+            toolNamed(tools, 'Edit'),
+            { path: target, old_string: 'hello', new_string: 'bye' },
+            cwd,
+            boundary,
+          ),
+          /Edit path must stay inside session cwd/,
+        );
+        await assert.rejects(
+          runTool(toolNamed(tools, 'Grep'), { pattern: 'hello', path: outside }, cwd, boundary),
+          /Grep path must stay inside session cwd/,
+        );
+      }
+      // The write never landed under any of them.
+      expect(await readFile(target, 'utf8')).toBe('hello');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('a symlink out of the cwd stays an escape under a workspace boundary', async () => {
+    const { cwd, outside, cleanup } = await makeDirs();
+    try {
+      const tools = toolsFor();
+      await writeFile(join(outside, 'secret.txt'), 'secret', 'utf8');
+      await symlink(join(outside, 'secret.txt'), join(cwd, 'link.txt'));
+
+      await assert.rejects(
+        runTool(toolNamed(tools, 'Read'), { path: 'link.txt' }, cwd),
+        /Read path must stay inside session cwd/,
+      );
+      // Under bypass the same link resolves, because nothing is being escaped.
+      expect(await runTool(toolNamed(tools, 'Read'), { path: 'link.txt' }, cwd, BYPASS)).toEqual({
+        content: 'secret',
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('a glob pattern may only leave the search root under a bypass boundary', async () => {
+    const { cwd, outside, cleanup } = await makeDirs();
+    try {
+      const tools = toolsFor();
+      await writeFile(join(outside, 'note.md'), '', 'utf8');
+      const absolute = join(outside, '*.md');
+
+      await assert.rejects(
+        runTool(toolNamed(tools, 'Glob'), { pattern: absolute }, cwd),
+        /Glob pattern must stay inside session cwd/,
+      );
+      const globbed = (await runTool(
+        toolNamed(tools, 'Glob'),
+        { pattern: absolute },
+        cwd,
+        BYPASS,
+      )) as { files: string[] };
+      expect(globbed.files).toHaveLength(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('a managed boundary goes to the worker and never to the host backend', async () => {
+    const { cwd, outside, cleanup } = await makeDirs();
+    try {
+      const calls: unknown[] = [];
+      const target = join(outside, 'note.md');
+      const tools = toolsFor({
+        filesystemWorker: {
+          execute: async (input) => {
+            calls.push(input);
+            return { kind: 'write', ok: true, path: target, bytes: 1 };
+          },
+        },
+      });
+
+      const result = await runTool(
+        toolNamed(tools, 'Write'),
+        { path: target, content: 'x' },
+        cwd,
+        MANAGED,
+      );
+      expect(result).toMatchObject({ ok: true, path: target });
+      expect(calls).toHaveLength(1);
+      // The worker decided; nothing was written by the host backend.
+      await assert.rejects(readFile(target, 'utf8'));
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('a managed boundary without a worker refuses instead of falling back to the host', async () => {
+    const { cwd, cleanup } = await makeDirs();
+    try {
+      const tools = toolsFor();
+      await assert.rejects(
+        runTool(toolNamed(tools, 'Write'), { path: 'note.md', content: 'x' }, cwd, MANAGED),
+        (error: unknown) =>
+          error instanceof SandboxCommandError && error.reason === 'requires_bypass',
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('one file takes one write lock however its path is spelled', async () => {
+    const { cwd, outside, cleanup } = await makeDirs();
+    try {
+      const tools = toolsFor();
+      const target = join(outside, 'note.md');
+      const order: string[] = [];
+      const write = toolNamed(tools, 'Write');
+
+      await Promise.all([
+        runTool(write, { path: target, content: 'a'.repeat(4096) }, cwd, BYPASS).then(() =>
+          order.push('absolute'),
+        ),
+        runTool(write, { path: join('..', 'outside', 'note.md'), content: 'b' }, cwd, BYPASS).then(
+          () => order.push('relative'),
+        ),
+      ]);
+
+      // Both spellings resolve to one file, so the lock serialised them and the
+      // survivor is whole rather than interleaved.
+      expect(['a'.repeat(4096), 'b']).toContain(await readFile(target, 'utf8'));
+      expect(order).toHaveLength(2);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/packages/runtime/src/__tests__/filesystem-authority.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-authority.test.ts
@@ -1,5 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
+import { Buffer } from 'node:buffer';
 import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -241,24 +242,135 @@ describe('file tools follow the execution boundary', () => {
   test('one file takes one write lock however its path is spelled', async () => {
     const { cwd, outside, cleanup } = await makeDirs();
     try {
-      const tools = toolsFor();
       const target = join(outside, 'note.md');
-      const order: string[] = [];
-      const write = toolNamed(tools, 'Write');
+      await writeFile(target, 'a', 'utf8');
+
+      // Instrumented so the assertion is about serialisation itself. A plain
+      // concurrent-write race proves nothing: one write(2) per file is already
+      // atomic, so the survivor is whole even with no lock at all. Only an
+      // overlap counter distinguishes a held lock from the kernel's own
+      // serialisation, and only two spellings of one path prove the key
+      // canonicalises.
+      const host = createLocalWorkspaceExecutor();
+      let active = 0;
+      let overlapped = false;
+      const tools = toolsFor({
+        executor: Object.assign(Object.create(host) as typeof host, {
+          readFile: async (input: Parameters<typeof host.readFile>[0]) => {
+            active += 1;
+            overlapped ||= active > 1;
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            try {
+              return await host.readFile(input);
+            } finally {
+              active -= 1;
+            }
+          },
+        }),
+      });
+      const edit = toolNamed(tools, 'Edit');
 
       await Promise.all([
-        runTool(write, { path: target, content: 'a'.repeat(4096) }, cwd, BYPASS).then(() =>
-          order.push('absolute'),
-        ),
-        runTool(write, { path: join('..', 'outside', 'note.md'), content: 'b' }, cwd, BYPASS).then(
-          () => order.push('relative'),
+        runTool(edit, { path: target, old_string: 'a', new_string: 'b' }, cwd, BYPASS),
+        runTool(
+          edit,
+          { path: join('..', 'outside', 'note.md'), old_string: 'b', new_string: 'c' },
+          cwd,
+          BYPASS,
         ),
       ]);
 
-      // Both spellings resolve to one file, so the lock serialised them and the
-      // survivor is whole rather than interleaved.
-      expect(['a'.repeat(4096), 'b']).toContain(await readFile(target, 'utf8'));
-      expect(order).toHaveLength(2);
+      expect(overlapped).toBe(false);
+      // The second edit saw the first one's output, so they ran in sequence
+      // against one file rather than racing two reads of the same start state.
+      expect(await readFile(target, 'utf8')).toBe('c');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('the lock key is the same for every spelling of one file', async () => {
+    const { cwd, outside, cleanup } = await makeDirs();
+    try {
+      const executor = createLocalWorkspaceExecutor();
+      const target = join(outside, 'note.md');
+
+      const absolute = await executor.writeLockKey({ cwd, path: target });
+      const relative = await executor.writeLockKey({
+        cwd,
+        path: join('..', 'outside', 'note.md'),
+      });
+      expect(absolute.key).toBe(relative.key);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('a bypass boundary searches outside the session cwd', async () => {
+    const { cwd, outside, cleanup } = await makeDirs();
+    try {
+      const tools = toolsFor();
+      await writeFile(join(outside, 'note.md'), 'needle here\n', 'utf8');
+
+      const found = (await runTool(
+        toolNamed(tools, 'Grep'),
+        { pattern: 'needle', path: outside },
+        cwd,
+        BYPASS,
+      )) as { matches: string[] };
+      expect(found.matches).toHaveLength(1);
+      expect(found.matches[0]).toContain('needle here');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('a bypass boundary bypasses a wired worker too', async () => {
+    const { cwd, outside, cleanup } = await makeDirs();
+    try {
+      const calls: unknown[] = [];
+      const tools = toolsFor({
+        filesystemWorker: {
+          execute: async (input) => {
+            calls.push(input);
+            return { kind: 'write', ok: true, path: 'unused', bytes: 0 };
+          },
+        },
+      });
+      const target = join(outside, 'note.md');
+
+      await runTool(toolNamed(tools, 'Write'), { path: target, content: 'host' }, cwd, BYPASS);
+
+      expect(calls).toHaveLength(0);
+      expect(await readFile(target, 'utf8')).toBe('host');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('worker image bytes reach the tool decoded', async () => {
+    const { cwd, cleanup } = await makeDirs();
+    try {
+      const snapshots: Uint8Array[] = [];
+      const tools = toolsFor({
+        filesystemWorker: {
+          execute: async () => ({
+            kind: 'read_image',
+            base64: Buffer.from([137, 80, 78, 71]).toString('base64'),
+            mimeType: 'image/png',
+          }),
+        },
+        snapshotImage: async (input) => {
+          snapshots.push(input.bytes);
+          return { kind: 'session_file', sessionId: input.sessionId, relativePath: 'artifact-1' };
+        },
+      });
+
+      const result = await runTool(toolNamed(tools, 'Read'), { path: 'image.png' }, cwd, MANAGED);
+
+      expect(result).toMatchObject({ kind: 'image', mimeType: 'image/png' });
+      expect(snapshots).toHaveLength(1);
+      expect(Buffer.from(snapshots[0] ?? new Uint8Array()).toString('hex')).toBe('89504e47');
     } finally {
       await cleanup();
     }

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -23,7 +23,6 @@ import {
   type StorageRef,
   type PermissionProfile,
 } from '@maka/core';
-import { computeEditedSource } from './edit-replace.js';
 import { bashToolResultToModelOutput } from './bash-model-output.js';
 import {
   buildManagedBashTool,
@@ -44,6 +43,12 @@ import {
   type WorkspaceExecResult,
   type WorkspaceExecutor,
 } from './workspace-executor.js';
+import {
+  createBoundaryFilesystemExecutor,
+  type FilesystemExecuteInput,
+  type FilesystemExecutor,
+  type FilesystemWriteLockKeyInput,
+} from './filesystem-executor.js';
 
 // tool-runtime.ts is the single source of truth for the tool shape; this
 // re-export only keeps back-compat for callers that imported from
@@ -143,6 +148,12 @@ export interface BuildBuiltinToolsOptions {
   sandboxManager?: SandboxManager;
   /** Sandboxed worker used for all local filesystem tools. */
   filesystemWorker?: Pick<FilesystemWorkerClient, 'execute'>;
+  /**
+   * Boundary-driven filesystem authority for the file tools. Composed from
+   * `executor` and `filesystemWorker` when omitted, which is what every
+   * production caller wants; inject only to replace both backends at once.
+   */
+  filesystem?: FilesystemExecutor;
   /** Host-surface gate for Edit. Defaults to enabled. */
   includeEdit?: boolean;
   /** Test/embedding override. Production callers use the current process platform. */
@@ -158,6 +169,13 @@ export interface BuildBuiltinToolsOptions {
 
 export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaTool[] {
   const executor = options.executor ?? createLocalWorkspaceExecutor();
+  const filesystem =
+    options.filesystem ??
+    createBoundaryFilesystemExecutor({
+      workspace: executor,
+      ...(options.filesystemWorker ? { worker: options.filesystemWorker } : {}),
+      ...(options.permissionProfile ? { permissionProfile: options.permissionProfile } : {}),
+    });
   const executionFacts = executor.facts;
   const readDescription = `Read a text file${options.snapshotImage ? ' or supported image' : ''} from disk${options.runtimeResources ? ', or read a whole runtime resource using ref' : ''}.`;
   const pathField = z
@@ -305,54 +323,16 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
         if (runtimeRef === 'runtime') {
           throw new Error('Runtime resources must be read with the ref parameter, not path');
         }
-        const filesystemWorker = filesystemWorkerForExecution(options.filesystemWorker, ctx);
-        if (filesystemWorker) {
-          const canonicalCwd = canonicalExistingPath(cwd);
-          const result = await filesystemWorker.execute({
-            operation: {
-              kind: 'read',
-              path,
-              ...(offset !== undefined ? { offset } : {}),
-              ...(limit !== undefined ? { limit } : {}),
-            },
-            cwd: canonicalCwd,
-            ...(ctx.executionBoundary ? { executionBoundary: ctx.executionBoundary } : {}),
-            mode: ctx.permissionMode ?? 'ask',
-            ...(options.permissionProfile ? { permissionProfile: options.permissionProfile } : {}),
-            ...(abortSignal ? { abortSignal } : {}),
-          });
-          if (result.kind === 'read_image') {
-            if (!options.snapshotImage)
-              throw new Error('Read image snapshots are not available in this toolset.');
-            const ref = await options.snapshotImage({
-              sessionId,
-              turnId: ctx.turnId,
-              name: basename(path),
-              bytes: Buffer.from(result.base64, 'base64'),
-              mimeType: result.mimeType,
-            });
-            return { kind: 'image' as const, mimeType: result.mimeType, ref };
-          }
-          if (result.kind !== 'read')
-            throw internalFilesystemReadFailure(
-              'Read',
-              'no file content came back',
-              'the file is empty or missing',
-            );
-          return { content: result.content };
-        }
-        const { path: resolvedPath } = await executor.resolveExistingPath({
-          cwd,
-          path,
-          label: 'Read',
+        const result = await filesystem.execute({
+          operation: {
+            kind: 'read',
+            path,
+            ...(offset !== undefined ? { offset } : {}),
+            ...(limit !== undefined ? { limit } : {}),
+          },
+          ...filesystemCall(ctx),
         });
-        const result = await executor.readFile({
-          cwd,
-          path: resolvedPath,
-          ...(offset !== undefined ? { offset } : {}),
-          ...(limit !== undefined ? { limit } : {}),
-        });
-        if ('bytes' in result) {
+        if (result.kind === 'read_image') {
           if (!options.snapshotImage)
             throw new Error('Read image snapshots are not available in this toolset.');
           const ref = await options.snapshotImage({
@@ -364,53 +344,36 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
           });
           return { kind: 'image' as const, mimeType: result.mimeType, ref };
         }
-        return result;
+        if (result.kind !== 'read')
+          throw internalFilesystemReadFailure(
+            'Read',
+            'no file content came back',
+            'the file is empty or missing',
+          );
+        return { content: result.content };
       },
     },
     {
       name: 'Write',
       activityKind: 'edit',
       description:
-        'Write content to a file using a path relative to the session cwd. ' +
-        'Absolute paths and parent traversal are rejected. Subject to permission policy.',
+        'Write content to a file. Relative paths resolve from the session cwd; ' +
+        'how far outside it a path may reach is decided by the session permissions.',
       parameters: z.object({
-        path: z
-          .string()
-          .describe(
-            'Path relative to the session cwd. Absolute paths and parent traversal are rejected.',
-          ),
+        path: z.string().describe('A file path; relative paths are resolved from the session cwd'),
         content: z.string(),
       }),
       executionFacts,
       impl: async ({ path, content }, ctx) => {
-        const { cwd } = ctx;
-        const filesystemWorker = filesystemWorkerForExecution(options.filesystemWorker, ctx);
-        const canonicalCwd = filesystemWorker ? canonicalExistingPath(cwd) : cwd;
-        const key = filesystemWorker
-          ? await fileToolWriteLockKey(canonicalCwd, path)
-          : (await executor.writeLockKey({ cwd, path })).key;
+        const key = await filesystem.writeLockKey(filesystemLockTarget(ctx, path));
         return await withFileWriteLock(key, async () => {
-          if (filesystemWorker) {
-            const result = await filesystemWorker.execute({
-              operation: { kind: 'write', path, content },
-              cwd: canonicalCwd,
-              ...(ctx.executionBoundary ? { executionBoundary: ctx.executionBoundary } : {}),
-              mode: ctx.permissionMode ?? 'ask',
-              ...(options.permissionProfile
-                ? { permissionProfile: options.permissionProfile }
-                : {}),
-              ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
-            });
-            if (result.kind !== 'write')
-              throw internalFilesystemWriteFailure('Write', 'the file was written');
-            return { ok: result.ok, path: result.path, bytes: result.bytes };
-          }
-          const { path: resolvedPath } = await executor.resolveWritablePath({
-            cwd,
-            path,
-            label: 'Write',
+          const result = await filesystem.execute({
+            operation: { kind: 'write', path, content },
+            ...filesystemCall(ctx),
           });
-          return await executor.writeFile({ cwd, path: resolvedPath, content });
+          if (result.kind !== 'write')
+            throw internalFilesystemWriteFailure('Write', 'the file was written');
+          return { ok: result.ok, path: result.path, bytes: result.bytes };
         });
       },
     },
@@ -430,58 +393,22 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
       }),
       executionFacts,
       impl: async ({ path, old_string, new_string }, ctx) => {
-        const { cwd } = ctx;
-        const filesystemWorker = filesystemWorkerForExecution(options.filesystemWorker, ctx);
-        const canonicalCwd = filesystemWorker ? canonicalExistingPath(cwd) : cwd;
-        const key = filesystemWorker
-          ? await fileToolWriteLockKey(canonicalCwd, path)
-          : (await executor.writeLockKey({ cwd, path })).key;
+        const key = await filesystem.writeLockKey(filesystemLockTarget(ctx, path));
         return await withFileWriteLock(key, async () => {
-          if (filesystemWorker) {
-            const result = await filesystemWorker.execute({
-              operation: {
-                kind: 'edit',
-                path,
-                oldString: old_string,
-                newString: new_string,
-              },
-              cwd: canonicalCwd,
-              ...(ctx.executionBoundary ? { executionBoundary: ctx.executionBoundary } : {}),
-              mode: ctx.permissionMode ?? 'ask',
-              ...(options.permissionProfile
-                ? { permissionProfile: options.permissionProfile }
-                : {}),
-              ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
-            });
-            if (result.kind !== 'edit')
-              throw internalFilesystemWriteFailure(
-                'Edit',
-                'the edit was applied',
-                'a different old_string will not help',
-              );
-            return {
-              ok: result.ok,
-              path: result.path,
-              replacements: result.replacements,
-              matchedVia: result.matchedVia,
-              startLine: result.startLine,
-              endLine: result.endLine,
-            };
-          }
-          const { path: resolvedPath } = await executor.resolveExistingPath({
-            cwd,
-            path,
-            label: 'Edit',
+          const result = await filesystem.execute({
+            operation: { kind: 'edit', path, oldString: old_string, newString: new_string },
+            ...filesystemCall(ctx),
           });
-          const read = await executor.readFile({ cwd, path: resolvedPath });
-          if ('bytes' in read) throw new Error('Edit does not support image files.');
-          const current = read.content;
-          const result = computeEditedSource(current, old_string, new_string, path);
-          await executor.writeFile({ cwd, path: resolvedPath, content: result.content });
+          if (result.kind !== 'edit')
+            throw internalFilesystemWriteFailure(
+              'Edit',
+              'the edit was applied',
+              'a different old_string will not help',
+            );
           return {
-            ok: true,
-            path: resolvedPath,
-            replacements: 1,
+            ok: result.ok,
+            path: result.path,
+            replacements: result.replacements,
             matchedVia: result.matchedVia,
             startLine: result.startLine,
             endLine: result.endLine,
@@ -512,68 +439,16 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
       }),
       executionFacts,
       impl: async ({ path, sort_keys }, ctx) => {
-        const { cwd } = ctx;
-        const filesystemWorker = filesystemWorkerForExecution(options.filesystemWorker, ctx);
-        const canonicalCwd = filesystemWorker ? canonicalExistingPath(cwd) : cwd;
-        const key = filesystemWorker
-          ? await fileToolWriteLockKey(canonicalCwd, path)
-          : (await executor.writeLockKey({ cwd, path })).key;
+        const key = await filesystem.writeLockKey(filesystemLockTarget(ctx, path));
         return await withFileWriteLock(key, async () => {
-          if (filesystemWorker) {
-            const result = await filesystemWorker.execute({
-              operation: { kind: 'format_json', path, sortKeys: sort_keys ?? false },
-              cwd: canonicalCwd,
-              ...(ctx.executionBoundary ? { executionBoundary: ctx.executionBoundary } : {}),
-              mode: ctx.permissionMode ?? 'ask',
-              ...(options.permissionProfile
-                ? { permissionProfile: options.permissionProfile }
-                : {}),
-              ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
-            });
-            if (result.kind !== 'format_json') {
-              throw internalFilesystemWriteFailure('FormatJson', 'the file was rewritten');
-            }
-            return result;
-          }
-          const { path: resolvedPath } = await executor.resolveExistingPath({
-            cwd,
-            path,
-            label: 'FormatJson',
+          const result = await filesystem.execute({
+            operation: { kind: 'format_json', path, sortKeys: sort_keys ?? false },
+            ...filesystemCall(ctx),
           });
-          const read = await executor.readFile({ cwd, path: resolvedPath });
-          if ('bytes' in read) throw new Error('FormatJson does not support image files.');
-          const original = read.content;
-          const bytesBefore = Buffer.byteLength(original, 'utf8');
-          let parsed: unknown;
-          try {
-            parsed = JSON.parse(original);
-          } catch (e) {
-            return {
-              ok: false,
-              valid: false,
-              error: `FormatJson: invalid JSON: ${(e as Error).message}`,
-              path: resolvedPath,
-              bytesBefore,
-              byteDelta: 0,
-              changed: false,
-            };
+          if (result.kind !== 'format_json') {
+            throw internalFilesystemWriteFailure('FormatJson', 'the file was rewritten');
           }
-          const value = sort_keys ? sortKeysDeep(parsed) : parsed;
-          const formatted = JSON.stringify(value, null, 2);
-          const { bytes: bytesAfter } = await executor.writeFile({
-            cwd,
-            path: resolvedPath,
-            content: formatted,
-          });
-          return {
-            ok: true,
-            path: resolvedPath,
-            valid: true,
-            bytesBefore,
-            bytesAfter,
-            byteDelta: bytesAfter - bytesBefore,
-            changed: formatted !== original,
-          };
+          return result;
         });
       },
     },
@@ -597,33 +472,17 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
       }),
       executionFacts,
       impl: async ({ pattern, cwd: relCwd }, ctx) => {
-        const { cwd } = ctx;
-        assertRelativeGlobPattern(pattern);
-        const filesystemWorker = filesystemWorkerForExecution(options.filesystemWorker, ctx);
-        if (filesystemWorker) {
-          const canonicalCwd = canonicalExistingPath(cwd);
-          const result = await filesystemWorker.execute({
-            operation: { kind: 'glob', path: relCwd ?? '.', pattern, limit: 200 },
-            cwd: canonicalCwd,
-            ...(ctx.executionBoundary ? { executionBoundary: ctx.executionBoundary } : {}),
-            mode: ctx.permissionMode ?? 'ask',
-            ...(options.permissionProfile ? { permissionProfile: options.permissionProfile } : {}),
-            ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
-          });
-          if (result.kind !== 'glob')
-            throw internalFilesystemReadFailure(
-              'Glob',
-              'no file list came back',
-              'no files match the pattern',
-            );
-          return { files: result.files };
-        }
-        const { path: base } = await executor.resolveExistingPath({
-          cwd,
-          path: relCwd ?? '.',
-          label: 'Glob cwd',
+        const result = await filesystem.execute({
+          operation: { kind: 'glob', path: relCwd ?? '.', pattern, limit: 200 },
+          ...filesystemCall(ctx),
         });
-        return await executor.globFiles({ cwd: base, pattern, limit: 200 });
+        if (result.kind !== 'glob')
+          throw internalFilesystemReadFailure(
+            'Glob',
+            'no file list came back',
+            'no files match the pattern',
+          );
+        return { files: result.files };
       },
     },
     {
@@ -637,77 +496,53 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
       }),
       executionFacts,
       impl: async ({ pattern, path, glob }, ctx) => {
-        const { cwd, abortSignal } = ctx;
-        const filesystemWorker = filesystemWorkerForExecution(options.filesystemWorker, ctx);
-        if (filesystemWorker) {
-          const canonicalCwd = canonicalExistingPath(cwd);
-          const result = await filesystemWorker.execute({
-            operation: {
-              kind: 'grep',
-              path: path ?? '.',
-              pattern,
-              ...(glob ? { glob } : {}),
-              maxCountPerFile: 50,
-              limit: 200,
-              timeoutMs: GREP_TIMEOUT_MS,
-            },
-            cwd: canonicalCwd,
-            ...(ctx.executionBoundary ? { executionBoundary: ctx.executionBoundary } : {}),
-            mode: ctx.permissionMode ?? 'ask',
-            ...(options.permissionProfile ? { permissionProfile: options.permissionProfile } : {}),
-            ...(abortSignal ? { abortSignal } : {}),
-          });
-          if (result.kind !== 'grep')
-            throw internalFilesystemReadFailure(
-              'Grep',
-              'no search result came back',
-              'the pattern is absent',
-            );
-          return { matches: result.matches };
-        }
-        const { path: searchPath } = await executor.resolveExistingPath({
-          cwd,
-          path: path ?? '.',
-          label: 'Grep',
-        });
         // Self-bound: ripgrep finishes in well under a second normally, but a
         // pathological tree (network mount, /proc, a FIFO) could hang it. The
         // stream watchdog no longer caps tool execution, so each spawning tool
         // must carry its own wall-clock timeout and honour the turn's abort.
-        return await executor.grepFiles({
-          cwd,
-          pattern,
-          path: searchPath,
-          ...(glob ? { glob } : {}),
-          maxCountPerFile: 50,
-          limit: 200,
-          timeoutMs: GREP_TIMEOUT_MS,
-          ...(abortSignal ? { abortSignal } : {}),
+        const result = await filesystem.execute({
+          operation: {
+            kind: 'grep',
+            path: path ?? '.',
+            pattern,
+            ...(glob ? { glob } : {}),
+            maxCountPerFile: 50,
+            limit: 200,
+            timeoutMs: GREP_TIMEOUT_MS,
+          },
+          ...filesystemCall(ctx),
         });
+        if (result.kind !== 'grep')
+          throw internalFilesystemReadFailure(
+            'Grep',
+            'no search result came back',
+            'the pattern is absent',
+          );
+        return { matches: result.matches };
       },
     },
   ];
   return tools.filter((tool) => options.includeEdit !== false || tool.name !== 'Edit');
 }
 
-function filesystemWorkerForExecution(
-  worker: Pick<FilesystemWorkerClient, 'execute'> | undefined,
+/** The per-call context every file tool hands to the filesystem authority. */
+function filesystemCall(
   ctx: MakaToolContext,
-): Pick<FilesystemWorkerClient, 'execute'> | undefined {
-  if (ctx.executionBoundary?.kind === 'bypass' || ctx.executionBoundary?.kind === 'external') {
-    return undefined;
-  }
-  if (worker) return worker;
-  if (ctx.executionBoundary?.kind !== 'managed') return undefined;
-  throw new SandboxCommandError({
-    domain: 'filesystem',
-    stage: 'capability',
-    reason: 'requires_bypass',
-    recoverable: false,
-    profileName: ctx.executionBoundary.profile.name ?? ctx.executionBoundary.profile.type,
-    message:
-      'Managed filesystem execution is unavailable because the sandboxed worker cannot be enforced.',
-  });
+): Pick<FilesystemExecuteInput, 'cwd' | 'executionBoundary' | 'permissionMode' | 'abortSignal'> {
+  return {
+    cwd: ctx.cwd,
+    ...(ctx.executionBoundary ? { executionBoundary: ctx.executionBoundary } : {}),
+    ...(ctx.permissionMode ? { permissionMode: ctx.permissionMode } : {}),
+    ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
+  };
+}
+
+function filesystemLockTarget(ctx: MakaToolContext, path: string): FilesystemWriteLockKeyInput {
+  return {
+    cwd: ctx.cwd,
+    path,
+    ...(ctx.executionBoundary ? { executionBoundary: ctx.executionBoundary } : {}),
+  };
 }
 
 interface ExecutorBashSandboxOptions {
@@ -1175,16 +1010,6 @@ function effectivePermissionProfile(
   return { profile: compiled.profile, workspaceRoots: compiled.workspaceRoots };
 }
 
-async function fileToolWriteLockKey(cwd: string, path: string): Promise<string> {
-  const target = await normalizeSandboxBoundaryPath({
-    path,
-    access: 'write',
-    scope: 'exact',
-    cwd,
-  });
-  return target.enforcementPath;
-}
-
 function terminalError(
   message: string,
   result: Pick<WorkspaceExecResult, 'stdout' | 'stderr' | 'stdoutTruncated' | 'stderrTruncated'> & {
@@ -1223,12 +1048,6 @@ function terminalError(
   return error;
 }
 
-function assertRelativeGlobPattern(pattern: string): void {
-  if (isAbsolute(pattern) || pattern.split(/[\\/]+/).includes('..')) {
-    throw new Error('Glob pattern must stay inside session cwd');
-  }
-}
-
 export function classifyRuntimeResourceRef(path: string): 'runtime' | 'file' | 'unsupported' {
   let url: URL;
   try {
@@ -1248,18 +1067,4 @@ export function classifyRuntimeResourceRef(path: string): 'runtime' | 'file' | '
     return 'unsupported';
   }
   return 'runtime';
-}
-
-// Object.fromEntries creates own data properties, so special keys like
-// "__proto__" are preserved instead of triggering the inherited setter.
-function sortKeysDeep(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(sortKeysDeep);
-  if (value !== null && typeof value === 'object' && !(value instanceof Date)) {
-    return Object.fromEntries(
-      Object.keys(value)
-        .sort()
-        .map((key) => [key, sortKeysDeep((value as Record<string, unknown>)[key])]),
-    );
-  }
-  return value;
 }

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -46,8 +46,6 @@ import {
 import {
   createBoundaryFilesystemExecutor,
   type FilesystemExecuteInput,
-  type FilesystemExecutor,
-  type FilesystemWriteLockKeyInput,
 } from './filesystem-executor.js';
 
 // tool-runtime.ts is the single source of truth for the tool shape; this
@@ -55,7 +53,6 @@ import {
 // builtin-tools directly.
 import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 export type { MakaTool, MakaToolContext };
-import { withFileWriteLock } from './file-write-lock.js';
 import { profileRequiresSandbox, type SandboxManager } from './sandbox/sandbox-manager.js';
 import { SandboxCommandError } from './sandbox/errors.js';
 import { isLikelySandboxDenial } from './sandbox/detect.js';
@@ -148,12 +145,6 @@ export interface BuildBuiltinToolsOptions {
   sandboxManager?: SandboxManager;
   /** Sandboxed worker used for all local filesystem tools. */
   filesystemWorker?: Pick<FilesystemWorkerClient, 'execute'>;
-  /**
-   * Boundary-driven filesystem authority for the file tools. Composed from
-   * `executor` and `filesystemWorker` when omitted, which is what every
-   * production caller wants; inject only to replace both backends at once.
-   */
-  filesystem?: FilesystemExecutor;
   /** Host-surface gate for Edit. Defaults to enabled. */
   includeEdit?: boolean;
   /** Test/embedding override. Production callers use the current process platform. */
@@ -169,13 +160,11 @@ export interface BuildBuiltinToolsOptions {
 
 export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaTool[] {
   const executor = options.executor ?? createLocalWorkspaceExecutor();
-  const filesystem =
-    options.filesystem ??
-    createBoundaryFilesystemExecutor({
-      workspace: executor,
-      ...(options.filesystemWorker ? { worker: options.filesystemWorker } : {}),
-      ...(options.permissionProfile ? { permissionProfile: options.permissionProfile } : {}),
-    });
+  const filesystem = createBoundaryFilesystemExecutor({
+    workspace: executor,
+    ...(options.filesystemWorker ? { worker: options.filesystemWorker } : {}),
+    ...(options.permissionProfile ? { permissionProfile: options.permissionProfile } : {}),
+  });
   const executionFacts = executor.facts;
   const readDescription = `Read a text file${options.snapshotImage ? ' or supported image' : ''} from disk${options.runtimeResources ? ', or read a whole runtime resource using ref' : ''}.`;
   const pathField = z
@@ -365,16 +354,13 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
       }),
       executionFacts,
       impl: async ({ path, content }, ctx) => {
-        const key = await filesystem.writeLockKey(filesystemLockTarget(ctx, path));
-        return await withFileWriteLock(key, async () => {
-          const result = await filesystem.execute({
-            operation: { kind: 'write', path, content },
-            ...filesystemCall(ctx),
-          });
-          if (result.kind !== 'write')
-            throw internalFilesystemWriteFailure('Write', 'the file was written');
-          return { ok: result.ok, path: result.path, bytes: result.bytes };
+        const result = await filesystem.execute({
+          operation: { kind: 'write', path, content },
+          ...filesystemCall(ctx),
         });
+        if (result.kind !== 'write')
+          throw internalFilesystemWriteFailure('Write', 'the file was written');
+        return { ok: result.ok, path: result.path, bytes: result.bytes };
       },
     },
     {
@@ -393,27 +379,24 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
       }),
       executionFacts,
       impl: async ({ path, old_string, new_string }, ctx) => {
-        const key = await filesystem.writeLockKey(filesystemLockTarget(ctx, path));
-        return await withFileWriteLock(key, async () => {
-          const result = await filesystem.execute({
-            operation: { kind: 'edit', path, oldString: old_string, newString: new_string },
-            ...filesystemCall(ctx),
-          });
-          if (result.kind !== 'edit')
-            throw internalFilesystemWriteFailure(
-              'Edit',
-              'the edit was applied',
-              'a different old_string will not help',
-            );
-          return {
-            ok: result.ok,
-            path: result.path,
-            replacements: result.replacements,
-            matchedVia: result.matchedVia,
-            startLine: result.startLine,
-            endLine: result.endLine,
-          };
+        const result = await filesystem.execute({
+          operation: { kind: 'edit', path, oldString: old_string, newString: new_string },
+          ...filesystemCall(ctx),
         });
+        if (result.kind !== 'edit')
+          throw internalFilesystemWriteFailure(
+            'Edit',
+            'the edit was applied',
+            'a different old_string will not help',
+          );
+        return {
+          ok: result.ok,
+          path: result.path,
+          replacements: result.replacements,
+          matchedVia: result.matchedVia,
+          startLine: result.startLine,
+          endLine: result.endLine,
+        };
       },
     },
     {
@@ -430,7 +413,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
         path: z
           .string()
           .describe(
-            'Path to the JSON file to validate and normalize, relative to the session cwd.',
+            'Path to the JSON file to validate and normalize; relative paths are resolved from the session cwd.',
           ),
         sort_keys: z
           .boolean()
@@ -439,17 +422,17 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
       }),
       executionFacts,
       impl: async ({ path, sort_keys }, ctx) => {
-        const key = await filesystem.writeLockKey(filesystemLockTarget(ctx, path));
-        return await withFileWriteLock(key, async () => {
-          const result = await filesystem.execute({
-            operation: { kind: 'format_json', path, sortKeys: sort_keys ?? false },
-            ...filesystemCall(ctx),
-          });
-          if (result.kind !== 'format_json') {
-            throw internalFilesystemWriteFailure('FormatJson', 'the file was rewritten');
-          }
-          return result;
+        const result = await filesystem.execute({
+          operation: { kind: 'format_json', path, sortKeys: sort_keys ?? false },
+          ...filesystemCall(ctx),
         });
+        if (result.kind !== 'format_json') {
+          throw internalFilesystemWriteFailure('FormatJson', 'the file was rewritten');
+        }
+        // The discriminator is how the backends name their results to each
+        // other; the model is owed the payload, as with every other file tool.
+        const { kind: _kind, ...diagnostic } = result;
+        return diagnostic;
       },
     },
     {
@@ -461,13 +444,13 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
         pattern: z
           .string()
           .describe(
-            'Relative glob pattern without an absolute path or "..", for example "**/*.txt".',
+            'Glob pattern, for example "**/*.txt". Whether it may leave the search root is decided by the session permissions.',
           ),
         cwd: z
           .string()
           .optional()
           .describe(
-            'Optional search directory inside the session cwd. Absolute or relative directory paths are accepted.',
+            'Optional search directory. Absolute or relative directory paths are accepted; how far outside the session cwd it may reach is decided by the session permissions.',
           ),
       }),
       executionFacts,
@@ -534,14 +517,6 @@ function filesystemCall(
     ...(ctx.executionBoundary ? { executionBoundary: ctx.executionBoundary } : {}),
     ...(ctx.permissionMode ? { permissionMode: ctx.permissionMode } : {}),
     ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
-  };
-}
-
-function filesystemLockTarget(ctx: MakaToolContext, path: string): FilesystemWriteLockKeyInput {
-  return {
-    cwd: ctx.cwd,
-    path,
-    ...(ctx.executionBoundary ? { executionBoundary: ctx.executionBoundary } : {}),
   };
 }
 

--- a/packages/runtime/src/filesystem-executor.ts
+++ b/packages/runtime/src/filesystem-executor.ts
@@ -1,0 +1,349 @@
+// packages/runtime/src/filesystem-executor.ts
+// The single authority for where the built-in file tools may reach.
+//
+// One decision — the active ExecutionBoundary — picks the backend and the path
+// scope; the tools carry no policy branch and no executor carries a containment
+// rule of its own. Before this seam existed each file tool repeated the same
+// worker-versus-executor branch, and the fallback executor hard-coded a session-cwd
+// containment that no permission profile actually declares. A bypass boundary
+// skipped the worker, so that undeclared rule became the only arbiter and made
+// "full access" stricter than ask mode, which grants :slash_tmp outright (#2083).
+
+import { Buffer } from 'node:buffer';
+import { realpath } from 'node:fs/promises';
+import { isAbsolute } from 'node:path';
+import type { ExecutionBoundary, PermissionMode, PermissionProfile } from '@maka/core';
+import { computeEditedSource } from './edit-replace.js';
+import type {
+  FilesystemWorkerClient,
+  FilesystemWorkerClientOperation,
+} from './filesystem-worker/client.js';
+import type { ImageMimeType } from './image-file.js';
+import type { FilesystemWorkerResult } from './filesystem-worker/protocol.js';
+import { normalizeSandboxBoundaryPath } from './sandbox-boundary-path.js';
+import { SandboxCommandError } from './sandbox/errors.js';
+import type {
+  WorkspaceEditExecutor,
+  WorkspacePathScope,
+  WorkspaceSearchExecutor,
+  WorkspaceWriteExecutor,
+} from './workspace-executor.js';
+
+/** A file operation, named the same way on every backend. `cwd` is supplied per call. */
+export type FilesystemOperation = FilesystemWorkerClientOperation;
+
+/**
+ * The result shape every backend answers with.
+ *
+ * It is the worker protocol's union with one substitution: image bytes stay
+ * bytes. Base64 is how the worker's JSON transport carries them, not part of
+ * this contract, so the worker-backed backend decodes once at its own edge and
+ * the host-local backend hands its buffer straight through.
+ */
+export type FilesystemResult =
+  | Exclude<FilesystemWorkerResult, { kind: 'read_image' }>
+  | { kind: 'read_image'; bytes: Uint8Array; mimeType: ImageMimeType };
+
+export interface FilesystemExecuteInput {
+  operation: FilesystemOperation;
+  cwd: string;
+  executionBoundary?: ExecutionBoundary;
+  /** Only consulted when no boundary is present; the boundary always wins. */
+  permissionMode?: PermissionMode;
+  abortSignal?: AbortSignal;
+}
+
+export interface FilesystemWriteLockKeyInput {
+  cwd: string;
+  path: string;
+  executionBoundary?: ExecutionBoundary;
+}
+
+export interface FilesystemExecutor {
+  execute(input: FilesystemExecuteInput): Promise<FilesystemResult>;
+  /** Canonical identity of a write target, so every spelling takes one lock. */
+  writeLockKey(input: FilesystemWriteLockKeyInput): Promise<string>;
+}
+
+/** The workspace primitives the host-local backend drives. */
+export type FilesystemWorkspaceExecutor = WorkspaceWriteExecutor &
+  WorkspaceEditExecutor &
+  WorkspaceSearchExecutor;
+
+export interface BoundaryFilesystemExecutorInput {
+  workspace: FilesystemWorkspaceExecutor;
+  worker?: Pick<FilesystemWorkerClient, 'execute'>;
+  /** Explicit embedding policy handed to the worker instead of a mode default. */
+  permissionProfile?: PermissionProfile;
+}
+
+/**
+ * The path scope a boundary authorises.
+ *
+ * `bypass` is the user asking for no restrictions, and it already means exactly
+ * that for Bash, which runs untransformed on the host under the same boundary.
+ * Every other boundary — including a missing one, which is an embedder that
+ * never opted in — stays workspace-scoped.
+ */
+export function pathScopeForBoundary(boundary: ExecutionBoundary | undefined): WorkspacePathScope {
+  return boundary?.kind === 'bypass' ? 'host' : 'workspace';
+}
+
+/**
+ * Compose the backends behind one boundary-driven decision.
+ *
+ * - `managed` → the sandboxed worker, which enforces the boundary's profile.
+ * - `bypass` → host-local execution with host path scope.
+ * - `external` → the injected workspace executor, whose own workspace is the
+ *   whole filesystem it can address; it never falls back to host access.
+ * - absent → the worker when one is wired, otherwise workspace-scoped local
+ *   execution. This is the embedding default and deliberately the narrow one.
+ */
+export function createBoundaryFilesystemExecutor(
+  input: BoundaryFilesystemExecutorInput,
+): FilesystemExecutor {
+  const local = createWorkspaceFilesystemExecutor(input.workspace);
+  const usesWorker = (boundary: ExecutionBoundary | undefined): boolean => {
+    if (boundary?.kind === 'bypass' || boundary?.kind === 'external') return false;
+    if (input.worker) return true;
+    if (boundary?.kind !== 'managed') return false;
+    throw new SandboxCommandError({
+      domain: 'filesystem',
+      stage: 'capability',
+      reason: 'requires_bypass',
+      recoverable: false,
+      profileName: boundary.profile.name ?? boundary.profile.type,
+      message:
+        'Managed filesystem execution is unavailable because the sandboxed worker cannot be enforced.',
+    });
+  };
+  return {
+    async execute(call) {
+      if (!usesWorker(call.executionBoundary)) {
+        return await local.execute(call, pathScopeForBoundary(call.executionBoundary));
+      }
+      const worker = input.worker;
+      if (!worker) throw new Error('Filesystem worker is unavailable.');
+      const result = await worker.execute({
+        operation: call.operation,
+        // The worker is host-local by definition, so a session opened through a
+        // symlinked cwd must reach it under the real path — otherwise the same
+        // file arrives under two identities. The workspace backend is left the
+        // cwd it was given: an isolated or remote workspace path is not the
+        // host's to rewrite, and its own resolvers canonicalise what they need.
+        cwd: await canonicalExistingPath(call.cwd),
+        ...(call.executionBoundary ? { executionBoundary: call.executionBoundary } : {}),
+        mode: call.permissionMode ?? 'ask',
+        ...(input.permissionProfile ? { permissionProfile: input.permissionProfile } : {}),
+        ...(call.abortSignal ? { abortSignal: call.abortSignal } : {}),
+      });
+      if (result.kind === 'read_image') {
+        return {
+          kind: 'read_image',
+          bytes: Buffer.from(result.base64, 'base64'),
+          mimeType: result.mimeType,
+        };
+      }
+      return result;
+    },
+    async writeLockKey(call) {
+      // Canonicalisation without any containment check, so a path the policy
+      // later rejects still takes the same lock as its other spellings. The
+      // worker-backed and local backends must agree here or the lock-key space
+      // and the resolved-path space drift apart.
+      if (!usesWorker(call.executionBoundary)) {
+        return (await input.workspace.writeLockKey({ cwd: call.cwd, path: call.path })).key;
+      }
+      const target = await normalizeSandboxBoundaryPath({
+        path: call.path,
+        access: 'write',
+        scope: 'exact',
+        cwd: await canonicalExistingPath(call.cwd),
+      });
+      return target.enforcementPath;
+    },
+  };
+}
+
+interface WorkspaceFilesystemBackend {
+  execute(input: FilesystemExecuteInput, scope: WorkspacePathScope): Promise<FilesystemResult>;
+}
+
+/**
+ * Run an operation directly against the host (or an isolated workspace), with the
+ * path scope the caller derived from the boundary. This backend enforces the
+ * scope it is given and decides nothing else.
+ */
+function createWorkspaceFilesystemExecutor(
+  workspace: FilesystemWorkspaceExecutor,
+): WorkspaceFilesystemBackend {
+  return {
+    async execute({ operation, cwd, abortSignal }, scope) {
+      switch (operation.kind) {
+        case 'read': {
+          const { path } = await workspace.resolveExistingPath({
+            cwd,
+            path: operation.path,
+            label: 'Read',
+            scope,
+          });
+          const result = await workspace.readFile({
+            cwd,
+            path,
+            ...(operation.offset !== undefined ? { offset: operation.offset } : {}),
+            ...(operation.limit !== undefined ? { limit: operation.limit } : {}),
+          });
+          if ('bytes' in result) {
+            return { kind: 'read_image', bytes: result.bytes, mimeType: result.mimeType };
+          }
+          return { kind: 'read', content: result.content };
+        }
+        case 'write': {
+          const { path } = await workspace.resolveWritablePath({
+            cwd,
+            path: operation.path,
+            label: 'Write',
+            scope,
+          });
+          const written = await workspace.writeFile({ cwd, path, content: operation.content });
+          return { kind: 'write', ok: true, path: written.path, bytes: written.bytes };
+        }
+        case 'edit': {
+          const { path } = await workspace.resolveExistingPath({
+            cwd,
+            path: operation.path,
+            label: 'Edit',
+            scope,
+          });
+          const read = await workspace.readFile({ cwd, path });
+          if ('bytes' in read) throw new Error('Edit does not support image files.');
+          const edited = computeEditedSource(
+            read.content,
+            operation.oldString,
+            operation.newString,
+            operation.path,
+          );
+          await workspace.writeFile({ cwd, path, content: edited.content });
+          return {
+            kind: 'edit',
+            ok: true,
+            path,
+            replacements: 1,
+            matchedVia: edited.matchedVia,
+            startLine: edited.startLine,
+            endLine: edited.endLine,
+          };
+        }
+        case 'format_json': {
+          const { path } = await workspace.resolveExistingPath({
+            cwd,
+            path: operation.path,
+            label: 'FormatJson',
+            scope,
+          });
+          const read = await workspace.readFile({ cwd, path });
+          if ('bytes' in read) throw new Error('FormatJson does not support image files.');
+          const original = read.content;
+          const bytesBefore = Buffer.byteLength(original, 'utf8');
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(original);
+          } catch (error) {
+            return {
+              kind: 'format_json',
+              ok: false,
+              valid: false,
+              error: `FormatJson: invalid JSON: ${(error as Error).message}`,
+              path,
+              bytesBefore,
+              byteDelta: 0,
+              changed: false,
+            };
+          }
+          const value = operation.sortKeys ? sortKeysDeep(parsed) : parsed;
+          const formatted = JSON.stringify(value, null, 2);
+          const { bytes: bytesAfter } = await workspace.writeFile({
+            cwd,
+            path,
+            content: formatted,
+          });
+          return {
+            kind: 'format_json',
+            ok: true,
+            valid: true,
+            path,
+            bytesBefore,
+            bytesAfter,
+            byteDelta: bytesAfter - bytesBefore,
+            changed: formatted !== original,
+          };
+        }
+        case 'glob': {
+          assertGlobPatternInScope(operation.pattern, scope);
+          const { path: base } = await workspace.resolveExistingPath({
+            cwd,
+            path: operation.path,
+            label: 'Glob cwd',
+            scope,
+          });
+          const { files } = await workspace.globFiles({
+            cwd: base,
+            pattern: operation.pattern,
+            ...(operation.limit !== undefined ? { limit: operation.limit } : {}),
+          });
+          return { kind: 'glob', files };
+        }
+        case 'grep': {
+          const { path } = await workspace.resolveExistingPath({
+            cwd,
+            path: operation.path,
+            label: 'Grep',
+            scope,
+          });
+          const { matches } = await workspace.grepFiles({
+            cwd,
+            pattern: operation.pattern,
+            path,
+            ...(operation.glob ? { glob: operation.glob } : {}),
+            maxCountPerFile: operation.maxCountPerFile,
+            limit: operation.limit,
+            timeoutMs: operation.timeoutMs,
+            ...(abortSignal ? { abortSignal } : {}),
+          });
+          return { kind: 'grep', matches };
+        }
+      }
+    },
+  };
+}
+
+/**
+ * A glob pattern is expanded by the walker rather than resolved as a path, so
+ * its escapes have to be caught lexically. Under host scope there is nothing to
+ * escape from and the pattern is left alone.
+ */
+function assertGlobPatternInScope(pattern: string, scope: WorkspacePathScope): void {
+  if (scope === 'host') return;
+  if (isAbsolute(pattern) || pattern.split(/[\\/]+/).includes('..')) {
+    throw new Error('Glob pattern must stay inside session cwd');
+  }
+}
+
+/** The canonical spelling of an existing directory, or the input when it is not resolvable here. */
+async function canonicalExistingPath(path: string): Promise<string> {
+  return await realpath(path).catch(() => path);
+}
+
+// Object.fromEntries creates own data properties, so special keys like
+// "__proto__" are preserved instead of triggering the inherited setter.
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value !== null && typeof value === 'object' && !(value instanceof Date)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, sortKeysDeep((value as Record<string, unknown>)[key])]),
+    );
+  }
+  return value;
+}

--- a/packages/runtime/src/filesystem-executor.ts
+++ b/packages/runtime/src/filesystem-executor.ts
@@ -14,6 +14,7 @@ import { realpath } from 'node:fs/promises';
 import { isAbsolute } from 'node:path';
 import type { ExecutionBoundary, PermissionMode, PermissionProfile } from '@maka/core';
 import { computeEditedSource } from './edit-replace.js';
+import { withFileWriteLock } from './file-write-lock.js';
 import type {
   FilesystemWorkerClient,
   FilesystemWorkerClientOperation,
@@ -53,16 +54,13 @@ export interface FilesystemExecuteInput {
   abortSignal?: AbortSignal;
 }
 
-export interface FilesystemWriteLockKeyInput {
-  cwd: string;
-  path: string;
-  executionBoundary?: ExecutionBoundary;
-}
-
 export interface FilesystemExecutor {
+  /**
+   * Run one operation under the authority of the boundary it carries. A mutating
+   * operation holds the target's write lock for its whole read-modify-write, so
+   * no caller has to know that a lock exists or how its key is spelled.
+   */
   execute(input: FilesystemExecuteInput): Promise<FilesystemResult>;
-  /** Canonical identity of a write target, so every spelling takes one lock. */
-  writeLockKey(input: FilesystemWriteLockKeyInput): Promise<string>;
 }
 
 /** The workspace primitives the host-local backend drives. */
@@ -85,8 +83,15 @@ export interface BoundaryFilesystemExecutorInput {
  * Every other boundary — including a missing one, which is an embedder that
  * never opted in — stays workspace-scoped.
  */
-export function pathScopeForBoundary(boundary: ExecutionBoundary | undefined): WorkspacePathScope {
+function pathScopeForBoundary(boundary: ExecutionBoundary | undefined): WorkspacePathScope {
   return boundary?.kind === 'bypass' ? 'host' : 'workspace';
+}
+
+/** Operations that read, modify and write back, and so must hold the target's lock. */
+function mutates(operation: FilesystemOperation): boolean {
+  return (
+    operation.kind === 'write' || operation.kind === 'edit' || operation.kind === 'format_json'
+  );
 }
 
 /**
@@ -103,10 +108,13 @@ export function createBoundaryFilesystemExecutor(
   input: BoundaryFilesystemExecutorInput,
 ): FilesystemExecutor {
   const local = createWorkspaceFilesystemExecutor(input.workspace);
-  const usesWorker = (boundary: ExecutionBoundary | undefined): boolean => {
-    if (boundary?.kind === 'bypass' || boundary?.kind === 'external') return false;
-    if (input.worker) return true;
-    if (boundary?.kind !== 'managed') return false;
+  /** The worker that owns this boundary, or undefined when the workspace backend does. */
+  const workerFor = (
+    boundary: ExecutionBoundary | undefined,
+  ): Pick<FilesystemWorkerClient, 'execute'> | undefined => {
+    if (boundary?.kind === 'bypass' || boundary?.kind === 'external') return undefined;
+    if (input.worker) return input.worker;
+    if (boundary?.kind !== 'managed') return undefined;
     throw new SandboxCommandError({
       domain: 'filesystem',
       stage: 'capability',
@@ -117,50 +125,50 @@ export function createBoundaryFilesystemExecutor(
         'Managed filesystem execution is unavailable because the sandboxed worker cannot be enforced.',
     });
   };
+  async function run(call: FilesystemExecuteInput): Promise<FilesystemResult> {
+    const worker = workerFor(call.executionBoundary);
+    if (!worker) return await local.execute(call, pathScopeForBoundary(call.executionBoundary));
+    const result = await worker.execute({
+      operation: call.operation,
+      // The worker is host-local by definition, so a session opened through a
+      // symlinked cwd must reach it under the real path — otherwise the same
+      // file arrives under two identities. The workspace backend is left the cwd
+      // it was given: an isolated or remote workspace path is not the host's to
+      // rewrite, and its own resolvers canonicalise what they need.
+      cwd: await canonicalExistingPath(call.cwd),
+      ...(call.executionBoundary ? { executionBoundary: call.executionBoundary } : {}),
+      mode: call.permissionMode ?? 'ask',
+      ...(input.permissionProfile ? { permissionProfile: input.permissionProfile } : {}),
+      ...(call.abortSignal ? { abortSignal: call.abortSignal } : {}),
+    });
+    if (result.kind === 'read_image') {
+      return {
+        kind: 'read_image',
+        bytes: Buffer.from(result.base64, 'base64'),
+        mimeType: result.mimeType,
+      };
+    }
+    return result;
+  }
   return {
     async execute(call) {
-      if (!usesWorker(call.executionBoundary)) {
-        return await local.execute(call, pathScopeForBoundary(call.executionBoundary));
-      }
-      const worker = input.worker;
-      if (!worker) throw new Error('Filesystem worker is unavailable.');
-      const result = await worker.execute({
-        operation: call.operation,
-        // The worker is host-local by definition, so a session opened through a
-        // symlinked cwd must reach it under the real path — otherwise the same
-        // file arrives under two identities. The workspace backend is left the
-        // cwd it was given: an isolated or remote workspace path is not the
-        // host's to rewrite, and its own resolvers canonicalise what they need.
-        cwd: await canonicalExistingPath(call.cwd),
-        ...(call.executionBoundary ? { executionBoundary: call.executionBoundary } : {}),
-        mode: call.permissionMode ?? 'ask',
-        ...(input.permissionProfile ? { permissionProfile: input.permissionProfile } : {}),
-        ...(call.abortSignal ? { abortSignal: call.abortSignal } : {}),
-      });
-      if (result.kind === 'read_image') {
-        return {
-          kind: 'read_image',
-          bytes: Buffer.from(result.base64, 'base64'),
-          mimeType: result.mimeType,
-        };
-      }
-      return result;
-    },
-    async writeLockKey(call) {
-      // Canonicalisation without any containment check, so a path the policy
-      // later rejects still takes the same lock as its other spellings. The
-      // worker-backed and local backends must agree here or the lock-key space
-      // and the resolved-path space drift apart.
-      if (!usesWorker(call.executionBoundary)) {
-        return (await input.workspace.writeLockKey({ cwd: call.cwd, path: call.path })).key;
-      }
-      const target = await normalizeSandboxBoundaryPath({
-        path: call.path,
-        access: 'write',
-        scope: 'exact',
-        cwd: await canonicalExistingPath(call.cwd),
-      });
-      return target.enforcementPath;
+      if (!mutates(call.operation)) return await run(call);
+      // Canonicalisation without any containment check, so a target the policy
+      // goes on to reject still takes the same lock as its other spellings. The
+      // key is derived from the same canonicalisation the backend will resolve
+      // with, or the lock-key space and the resolved-path space drift apart.
+      const worker = workerFor(call.executionBoundary);
+      const key = worker
+        ? (
+            await normalizeSandboxBoundaryPath({
+              path: call.operation.path,
+              access: 'write',
+              scope: 'exact',
+              cwd: await canonicalExistingPath(call.cwd),
+            })
+          ).enforcementPath
+        : (await input.workspace.writeLockKey({ cwd: call.cwd, path: call.operation.path })).key;
+      return await withFileWriteLock(key, () => run(call));
     },
   };
 }

--- a/packages/runtime/src/workspace-executor.ts
+++ b/packages/runtime/src/workspace-executor.ts
@@ -81,10 +81,22 @@ export interface WorkspaceWriteFileResult {
   bytes: number;
 }
 
+/**
+ * Which path space a resolution may land in.
+ *
+ * `workspace` keeps the resolved path inside the session cwd; `host` accepts
+ * any canonical path on the host. This is a *mechanism* parameter: the caller
+ * decides it from the active ExecutionBoundary, so no executor has to carry a
+ * containment policy of its own. Executors whose transport cannot express host
+ * paths (a remote or isolated workspace) reject `host` explicitly.
+ */
+export type WorkspacePathScope = 'workspace' | 'host';
+
 export interface WorkspaceResolvePathInput {
   cwd: string;
   path: string;
   label: string;
+  scope: WorkspacePathScope;
 }
 
 export interface WorkspaceResolvePathResult {
@@ -245,11 +257,15 @@ export class LocalWorkspaceExecutor implements WorkspaceExecutor {
   }
 
   async resolveExistingPath(input: WorkspaceResolvePathInput): Promise<WorkspaceResolvePathResult> {
-    return { path: await resolveExistingInsideCwd(input.cwd, input.path, input.label) };
+    return {
+      path: await resolveExistingPathInScope(input.cwd, input.path, input.label, input.scope),
+    };
   }
 
   async resolveWritablePath(input: WorkspaceResolvePathInput): Promise<WorkspaceResolvePathResult> {
-    return { path: (await canonicalPathInsideCwd(input.cwd, input.path, input.label)).path };
+    return {
+      path: (await canonicalPathInScope(input.cwd, input.path, input.label, input.scope)).path,
+    };
   }
 
   async writeLockKey(input: WorkspaceWriteLockKeyInput): Promise<WorkspaceWriteLockKeyResult> {
@@ -318,25 +334,34 @@ async function canonicalPathUnderCwd(
 }
 
 /**
- * The same canonical path, rejected unless it stays inside the session cwd.
- * Following the symlinks does not weaken containment: a link inside the cwd that
- * points out of it resolves to its outside target and is rejected.
+ * The same canonical path, rejected unless it stays inside the session cwd when
+ * the caller asked for `workspace` scope. Following the symlinks does not weaken
+ * containment: a link inside the cwd that points out of it resolves to its
+ * outside target and is rejected.
+ *
+ * Under `host` scope the canonicalisation is identical and only the containment
+ * assertion is skipped, so both scopes work in one path space and a scope change
+ * cannot move a path.
  */
-async function canonicalPathInsideCwd(
+async function canonicalPathInScope(
   cwd: string,
   inputPath: string,
   label: string,
+  scope: WorkspacePathScope,
 ): Promise<{ root: string; path: string }> {
   const { root, path } = await canonicalPathUnderCwd(cwd, inputPath);
+  if (scope === 'host') return { root, path };
   return { root, path: assertInsideCwd(root, path, inputPath, label) };
 }
 
-async function resolveExistingInsideCwd(
+async function resolveExistingPathInScope(
   cwd: string,
   inputPath: string,
   label: string,
+  scope: WorkspacePathScope,
 ): Promise<string> {
-  const { root, path: candidate } = await canonicalPathInsideCwd(cwd, inputPath, label);
+  const { root, path: candidate } = await canonicalPathInScope(cwd, inputPath, label, scope);
+  if (scope === 'host') return await fs.realpath(candidate);
   // The read/search callers depend on the target existing; surface that here
   // rather than as a downstream open/spawn failure.
   //


### PR DESCRIPTION
## Summary

The built-in file tools each carried the same worker-versus-executor branch, and the fallback executor hard-coded a session-cwd containment that no permission profile declares. Managed sessions never met that rule because they route through the sandboxed worker; a bypass boundary skips the worker, so the undeclared rule became the only arbiter — and it is stricter than every declared profile. "Full access" therefore rejected `Write` to `/tmp`, which `ask` mode allows outright via `:slash_tmp`, while `Bash` under that same bypass boundary wrote anywhere on the host.

This makes the `ExecutionBoundary` the only authority over where the file tools may reach:

- One `FilesystemExecutor` (`packages/runtime/src/filesystem-executor.ts`) composes the backends behind a single decision — `managed` → the sandboxed worker, `bypass` → host-local execution with host path scope, `external` and a missing boundary → workspace-scoped local execution, never a silent host fallback.
- Path containment becomes a `scope` parameter the caller derives from the boundary instead of a policy each executor invents. The isolated headless adapter keeps its own containment as a transport invariant and now rejects host scope explicitly rather than degrading.
- The write lock lives with the authority that resolves the path: `execute()` holds it for mutating operations, so the cwd is canonicalised once per call and no tool knows a lock exists.
- `filesystemWorkerForExecution` and the duplicated branch in all six file tools are gone; each tool holds one call. The glob pattern check moved next to the scope it enforces, and the `Write`, `Glob` and `FormatJson` descriptions no longer promise a containment the boundary now decides.
- Image bytes stay bytes across the contract; base64 remains the worker transport's business. FormatJson no longer leaks the backend discriminator into its result.

Closes #2083

## Verification

- New conformance suite `packages/runtime/src/__tests__/filesystem-authority.test.ts` (11 cases) drives the tools against a real filesystem across boundaries: bypass reaches outside the cwd (Write/Read/Edit/FormatJson/Glob/Grep) and bypasses a wired worker, every other boundary does not, symlink escapes stay rejected under workspace scope, absolute glob patterns are refused unless bypass, managed routes to the worker and never to the host backend, managed without a worker fails `requires_bypass`, worker image bytes arrive decoded, and one file takes one write lock however its path is spelled.
- Checked against the pre-change tree: 4 of the original 7 cases fail on `d3b0bc8` (including the reported symptom), and the 3 that encode unchanged behavior pass — so the suite tracks the defect rather than the implementation.
- Mutation-checked the lock case: with `withFileWriteLock` removed it fails. Its first version did not — a plain concurrent-write race passes without any lock, because one `write(2)` per file is already atomic — so it now instruments the backend for overlap and asserts a sequenced outcome, with the key equality pinned separately.
- `@maka/runtime` 3108 passed / 0 failed, `@maka/headless` 1339/0, `@maka/runtime-host` 628/0, `maka-agent` 468/0, `@maka/core` 772/0.
- `npm run typecheck`, `npm run lint`, `npm run format:check` all clean.
- Not run: desktop E2E and the UI suites — this change is below the renderer and has no user-visible surface beyond the tool descriptions.

## Review focus

The behavior change is deliberate and user-facing in one direction: under "full access" the file tools now reach the whole host, matching what `Bash` already does in that mode and what `danger-full-access` declares. A missing boundary stays workspace-scoped, so embedders that never opted into a boundary are unaffected.

One accepted drift: under a managed boundary an absolute or `..` Glob pattern is now refused by the worker's own check ("must stay inside its search root") instead of the deleted tool-level message ("must stay inside session cwd"). The rejection is unchanged; only the wording is, and the worker's is the more accurate of the two.
