### PR TITLE
fix(headless): stop misfiling graded competitor cells as infrastructure failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,10 @@ jobs:
         env:
           MAKA_REQUIRE_HARBOR_CONTRACT: '1'
         run: npm --workspace @maka/headless run test:dist
+      # The Harbor adapters are Python, so their contracts cannot ride the
+      # workspace suite. This one needs only the stdlib.
+      - name: Run Harbor adapter tests
+        run: python3 packages/headless/harbor/tests/test_process_scope.py
 
   # Preserve one stable required check while letting independent heavy suites
   # occupy their own runners. The aggregator waits for every selected lane.

--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -26,9 +26,17 @@ async def cleanup_process_scope(
                 command=scoped_process_cleanup_command(scope, signal),
             )
         except Exception as error:  # noqa: BLE001 - teardown is best effort.
-            agent.logger.warning(
-                "process scope %s %s cleanup failed: %s", scope, signal, error
-            )
+            logger = getattr(agent, "logger", None)
+            if logger is not None:
+                # Reporting the failure must not become one: an exception from
+                # here escapes the same `finally` and rewrites the same agent
+                # failure this function exists to preserve.
+                try:
+                    logger.warning(
+                        "process scope %s %s cleanup failed: %s", scope, signal, error
+                    )
+                except Exception:  # noqa: BLE001 - logging is best effort too.
+                    pass
         if signal == "TERM":
             await asyncio.sleep(0.2)
 

--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -15,25 +15,22 @@ COMMAND_SCOPE_ROOT = "/tmp/maka-harbor-command-scopes"
 async def cleanup_process_scope(
     agent: Any, environment: Any, scope: str
 ) -> None:
-    first_error: BaseException | None = None
-    try:
-        await agent.exec_as_agent(
-            environment,
-            command=scoped_process_cleanup_command(scope, "TERM"),
-        )
-    except BaseException as error:
-        first_error = error
-    await asyncio.sleep(0.2)
-    try:
-        await agent.exec_as_agent(
-            environment,
-            command=scoped_process_cleanup_command(scope, "KILL"),
-        )
-    except BaseException as error:
-        if first_error is None:
-            first_error = error
-    if first_error is not None:
-        raise first_error
+    """Reap the scope's leftovers. Callers run this from a `finally` while the
+    agent's own exception is in flight, so raising here would replace the real
+    failure with the teardown's — which is how agent timeouts were being
+    recorded as infrastructure failures. Cancellation still propagates."""
+    for signal in ("TERM", "KILL"):
+        try:
+            await agent.exec_as_agent(
+                environment,
+                command=scoped_process_cleanup_command(scope, signal),
+            )
+        except Exception as error:  # noqa: BLE001 - teardown is best effort.
+            agent.logger.warning(
+                "process scope %s %s cleanup failed: %s", scope, signal, error
+            )
+        if signal == "TERM":
+            await asyncio.sleep(0.2)
 
 
 def scoped_command(command: str, scope: str, command_id: str) -> str:

--- a/packages/headless/harbor/tests/test_process_scope.py
+++ b/packages/headless/harbor/tests/test_process_scope.py
@@ -68,6 +68,31 @@ def test_kill_still_runs_after_term_fails() -> None:
     assert signals == ["TERM", "KILL"], signals
 
 
+def test_a_broken_logger_never_replaces_the_agent_failure() -> None:
+    class _RaisingLogger(_Logger):
+        def warning(self, message: str, *args: object) -> None:
+            raise RuntimeError("logging handler is down")
+
+    missing = _Agent(fail=True)
+    del missing.logger
+    raising = _Agent(fail=True)
+    raising.logger = _RaisingLogger()
+
+    for agent in (missing, raising):
+
+        async def run(agent: _Agent = agent) -> None:
+            try:
+                raise TimeoutError("agent deadline")
+            finally:
+                await cleanup_process_scope(agent, object(), "scope-4")
+
+        try:
+            asyncio.run(run())
+        except TimeoutError:
+            continue
+        raise AssertionError("reporting the teardown failure became one")
+
+
 def test_cancellation_still_propagates() -> None:
     class _Cancelling(_Agent):
         async def exec_as_agent(self, environment: object, command: str) -> None:

--- a/packages/headless/harbor/tests/test_process_scope.py
+++ b/packages/headless/harbor/tests/test_process_scope.py
@@ -1,0 +1,103 @@
+"""Behavior contract for the shared command-scope teardown.
+
+``cleanup_process_scope`` only ever runs from an adapter's ``finally`` while the
+agent's own exception is in flight (claude_code_agent.py, codex_agent.py,
+kimi_code_agent.py all guard it with ``if abnormal_exit``). An exception raised
+there replaces the exception being propagated, so a teardown that raises rewrites
+the trial's cause: an ``AgentTimeoutError`` reached Harbor as a
+``NonZeroAgentExitCodeError``, which the runner reads as an infrastructure
+failure instead of a graded timeout.
+
+Run directly: ``python3 packages/headless/harbor/tests/test_process_scope.py``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from process_scope import cleanup_process_scope  # noqa: E402
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+
+    def warning(self, message: str, *args: object) -> None:
+        self.warnings.append(message % args)
+
+
+class _Agent:
+    def __init__(self, fail: bool) -> None:
+        self.logger = _Logger()
+        self.commands: list[str] = []
+        self._fail = fail
+
+    async def exec_as_agent(self, environment: object, command: str) -> None:
+        self.commands.append(command)
+        if self._fail:
+            raise RuntimeError("Command failed (exit -9)")
+
+
+def test_a_failing_teardown_never_replaces_the_agent_failure() -> None:
+    agent = _Agent(fail=True)
+
+    async def run() -> None:
+        try:
+            raise TimeoutError("agent deadline")
+        finally:
+            await cleanup_process_scope(agent, object(), "scope-1")
+
+    try:
+        asyncio.run(run())
+    except TimeoutError:
+        pass
+    else:
+        raise AssertionError("the agent's own failure did not survive teardown")
+    assert len(agent.commands) == 2, agent.commands
+    assert len(agent.logger.warnings) == 2, agent.logger.warnings
+
+
+def test_kill_still_runs_after_term_fails() -> None:
+    agent = _Agent(fail=True)
+    asyncio.run(cleanup_process_scope(agent, object(), "scope-2"))
+    signals = ["KILL" if "kill -KILL" in c else "TERM" for c in agent.commands]
+    assert signals == ["TERM", "KILL"], signals
+
+
+def test_cancellation_still_propagates() -> None:
+    class _Cancelling(_Agent):
+        async def exec_as_agent(self, environment: object, command: str) -> None:
+            self.commands.append(command)
+            raise asyncio.CancelledError
+
+    agent = _Cancelling(fail=False)
+    try:
+        asyncio.run(cleanup_process_scope(agent, object(), "scope-3"))
+    except asyncio.CancelledError:
+        pass
+    else:
+        raise AssertionError("teardown swallowed cancellation")
+    assert len(agent.commands) == 1, agent.commands
+
+
+def _main() -> int:
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    failures = 0
+    for test in tests:
+        try:
+            test()
+        except Exception as error:  # noqa: BLE001 - standalone runner reports all
+            failures += 1
+            print(f"FAIL {test.__name__}: {error!r}")
+        else:
+            print(f"PASS {test.__name__}")
+    print(f"\n{len(tests) - failures} passed, {failures} failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -715,6 +715,68 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
+  test('scores a cell whose agent exited cleanly while a provider stream was open', async () => {
+    // Codex and Claude Code end their last turn by tearing down an in-flight
+    // stream, which the proxy records as `aborted`. The trial itself raises
+    // nothing and the verifier grades it, so the cell is evidence: reading that
+    // tail as an outage discarded passing competitor cells as infra failures.
+    await withRun(async ({ jobsDir, repo, keyFile }) => {
+      const upstream = createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'text/event-stream' });
+        response.write('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n');
+      });
+      await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+      const address = upstream.address();
+      assert.ok(address && typeof address !== 'string');
+      try {
+        const runner = createHarborTaskRunner({
+          makaRepoPath: repo,
+          jobsDir,
+          agent: 'codex',
+          codexToolchainPath: '/toolchain',
+          agentVersion: '0.146.0',
+          model: 'deepseek/deepseek-v4-flash',
+          provider: 'deepseek',
+          reasoningEffort: 'max',
+          apiKeyFile: keyFile,
+          agentEnv: { MAKA_BASE_URL: `http://127.0.0.1:${address.port}` },
+          runHarbor: async (request) => {
+            const proxyUrl = request.env?.MAKA_PROVIDER_PROXY_URL?.replace(
+              'host.docker.internal',
+              '127.0.0.1',
+            );
+            const proxyToken = request.env?.MAKA_PROVIDER_PROXY_TOKEN;
+            assert.ok(proxyUrl && proxyToken);
+            const abort = new AbortController();
+            const pending = fetch(`${proxyUrl}/chat/completions`, {
+              method: 'POST',
+              headers: { authorization: `Bearer ${proxyToken}` },
+              body: '{}',
+              signal: abort.signal,
+            });
+            const response = await pending;
+            assert.equal(response.status, 200);
+            abort.abort();
+            await response.body?.cancel().catch(() => {});
+            return fakeRunner({ reward: '1\n' })(request);
+          },
+        });
+
+        const output = await runner(runInput());
+
+        assert.equal(output.harbor.reward, 1);
+        const telemetry = JSON.parse(
+          await readFile(output.cell.providerTelemetryPath!, 'utf8'),
+        ) as { requests: Array<{ outcome: string }> };
+        assert.equal(telemetry.requests.at(-1)?.outcome, 'aborted');
+      } finally {
+        await new Promise<void>((resolve, reject) =>
+          upstream.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+    });
+  });
+
   test('gives Codex an ephemeral OpenAI proxy without exposing the provider key file', async () => {
     await withRun(async ({ jobsDir, repo, keyFile }) => {
       const captured: { config?: Record<string, unknown> } = {};

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -1694,6 +1694,9 @@ test('createPierTaskRunner rejects a Pier cell whose terminal provider stream is
     // A completed terminal request takes the normal reward path.
     const output = await makeRunner('completed')(runInput());
     assert.equal(output.harbor.reward, 0);
+    // So does a tail the agent tore down itself on its way out: the trial
+    // raised nothing and the verifier graded it, so the cell is evidence.
+    assert.equal((await makeRunner('aborted')(runInput())).harbor.reward, 0);
   });
 });
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -513,9 +513,13 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
           tail(result.stderr || result.stdout),
         );
       }
+      // A trial that raised nothing ended its agent phase on its own terms, so it
+      // settles the tail request the same way the two abnormal shapes above do.
+      // Leaving it out read every clean exit that closed a stream mid-flight as
+      // an outage and threw the graded cell away.
       const terminalProviderRequest = incompleteTerminalProviderRequest(
         providerTelemetry,
-        completeTimedOutTrial || verifierSettledTrial,
+        termination === null || completeTimedOutTrial || verifierSettledTrial,
       );
       if (terminalProviderRequest) {
         throw new HarborInfraError(

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -563,7 +563,7 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       // last provider request is infra, never a graded model failure.
       const terminalProviderRequest = incompleteTerminalProviderRequest(
         providerTelemetry,
-        completeTimedOutTrial || verifierSettledTrial,
+        termination === null || completeTimedOutTrial || verifierSettledTrial,
       );
       if (terminalProviderRequest) {
         throw new PierInfraError(


### PR DESCRIPTION
## Summary

Two independent defects in the Harbor cell path recorded graded cells as `infra_failed`, which drops them from the denominator entirely. Both are structurally unreachable on the maka arm, so every cell they cost belonged to a competitor.

Found while tracking the three-arm run for #1970. Of that run's 14 `infra_failed` cells, 13 were these two bugs and 1 was a real infrastructure failure.

**Teardown rewrote the agent's failure.** `cleanup_process_scope` only ever runs from an adapter's `finally` while the agent's own exception is in flight (`claude_code_agent.py`, `codex_agent.py`, `kimi_code_agent.py` all guard it with `if abnormal_exit`). Raising there replaces the exception being propagated, so an `AgentTimeoutError` reached Harbor as `NonZeroAgentExitCodeError` and the runner read it as infrastructure rather than a graded timeout. Teardown after a failure is best effort by nature — no caller can act on its error — so it now logs and continues. Cancellation still propagates. Cost: 10 Claude Code cells, each already carrying `errorClass=budget_exhausted` in its own cell output while the WAL said `infra_failed`. `maka_agent.py` never calls this teardown.

**The `aborted` tail exemption could not fire on a clean exit.** `incompleteTerminalProviderRequest` exempts an `aborted` last request when the agent phase settled, but the caller computed `agentPhaseSettled` only inside the abnormal-termination branch. A trial that raised nothing never reached it — so the exemption missed the most ordinary shape there is: an agent that finishes and exits while a stream is open. Cost: 3 codex cells with `verifier reward 1.0` and no trial exception, discarded as infrastructure failures. maka produced no aborted tail request anywhere in the run.

Refs #1970.

## Verification

- `npm run --workspace @maka/headless test` — 97/97 in `harbor-task-runner.test.ts`, including the new case. One pre-existing failure remains in `cli.test.js` (`components[0].sourceRefs[2].path: source ref "apps/desktop/src/main/workspace-instructions.ts" does not exist under repo root`); it reproduces on unmodified `origin/main` and is unrelated to this change.
- `python3 packages/headless/harbor/tests/test_process_scope.py` — 3 passed. This directory is run by hand, as `test_harness_compat.py` already is; it is not wired into CI.
- `npm run format` / `npm run lint` — clean.

Both tests were confirmed red against the unfixed code, and the TS one fails with the exact production error:

```
✖ scores a cell whose agent exited cleanly while a provider stream was open
  Error [HarborInfraError]: terminal provider request did not complete for task task-1
```

```
FAIL test_a_failing_teardown_never_replaces_the_agent_failure: RuntimeError('Command failed (exit -9)')
```

## Review focus

The fix stops the misfiling going forward; it does not repair WALs already written. The #1970 run's own numbers still need a re-scoring pass from the on-disk artifacts, which will land with that report rather than here.