### PR TITLE
refactor(shell): register global shortcuts through Astryx useHotkeys

### DIFF
--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -1,4 +1,5 @@
 import { useEffect, useEffectEvent, useLayoutEffect } from 'react';
+import { useHotkeys } from '@astryxdesign/core/hooks';
 import type {
   ConnectionEvent,
   PlanReminder,
@@ -286,23 +287,31 @@ export function useAppShellBootstrapSubscriptions(options: {
       },
     });
   });
-  const handleKeyDown = useEffectEvent((event: globalThis.KeyboardEvent) => {
-    if ((event.metaKey || event.ctrlKey) && event.key === ',') {
-      event.preventDefault();
-      options.openSettings();
-    }
-    // ⌘/Ctrl+N — new task, mirroring the sidebar 新任务 row (whose kbd hint
-    // advertises this). Plain N only: shift/alt combos stay free.
-    if (
-      (event.metaKey || event.ctrlKey) &&
-      !event.shiftKey &&
-      !event.altKey &&
-      (event.key === 'n' || event.key === 'N')
-    ) {
-      event.preventDefault();
-      void options.createSession();
-    }
-  });
+  // Both shortcuts fire while the composer has focus — they always did, and
+  // that is the point of a global new-task / settings key — so both opt out of
+  // the hook's default "stay silent while typing" rule.
+  //
+  // The shiftKey bail keeps the original "plain N only" contract: useHotkeys
+  // ignores shift state unless the combo names it, and there is no way to spell
+  // "must NOT be shifted", so the entry matches ⇧⌘N and the handler declines
+  // it. Net app behavior is unchanged (⇧⌘N did nothing before and does nothing
+  // now); the only residual difference is that the hook has already called
+  // preventDefault() by the time we decline.
+  useHotkeys([
+    {
+      keys: 'mod+,',
+      allowInInputs: true,
+      onPress: () => options.openSettings(),
+    },
+    {
+      keys: 'mod+n',
+      allowInInputs: true,
+      onPress: (event) => {
+        if (event.shiftKey) return;
+        void options.createSession();
+      },
+    },
+  ]);
   const markRendererMounted = useEffectEvent(() => {
     options.rendererMountedRef.current = true;
   });
@@ -337,7 +346,6 @@ export function useAppShellBootstrapSubscriptions(options: {
     const unsubscribePlanChanges = window.maka.plans.subscribeChanges(handlePlanChange);
     const unsubscribePlanDue = window.maka.plans.subscribeDue(handlePlanDue);
     markRendererMounted();
-    window.addEventListener('keydown', handleKeyDown);
     return () => {
       cleanupPendingRefs();
       unsubscribeConnections();
@@ -345,7 +353,6 @@ export function useAppShellBootstrapSubscriptions(options: {
       unsubscribeSessionChanges();
       unsubscribePlanChanges();
       unsubscribePlanDue();
-      window.removeEventListener('keydown', handleKeyDown);
     };
   }, []);
 }

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -1,6 +1,6 @@
 // apps/desktop/src/renderer/command-palette.tsx
 //
-// ⌘K / Ctrl+K command palette. Combines static actions (new chat, theme
+// ⌘K (Ctrl+K off macOS) command palette. Combines static actions (new chat, theme
 // switch, open settings, open keyboard help) with the live session list so
 // the user can fuzzy-search across both. Astryx owns the dialog, input,
 // listbox, keyboard navigation, focus, and dismissal.
@@ -20,6 +20,7 @@ import {
   useUiLocale,
 } from '@maka/ui';
 import { Kbd } from '@astryxdesign/core/Kbd';
+import { useHotkeys } from '@astryxdesign/core/hooks';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
 import type { Command, CommandKind } from './command-palette-types';
 import { getShellCopy } from './locales/shell-copy';
@@ -33,16 +34,16 @@ export { buildCommandList, buildSessionCommands } from './command-palette-comman
 export function useCommandPalette(): [boolean, () => void, () => void] {
   const [open, setOpen] = useState(false);
 
-  useEffect(() => {
-    function onKeyDown(event: globalThis.KeyboardEvent) {
-      if (!(event.metaKey || event.ctrlKey)) return;
-      if (event.key !== 'k' && event.key !== 'K') return;
-      event.preventDefault();
-      setOpen((prev) => !prev);
-    }
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
+  // `allowInInputs` because the palette's whole point is being reachable
+  // mid-sentence in the composer — the hook skips typing surfaces by default,
+  // which would have made ⌘K dead exactly where it is used most.
+  useHotkeys([
+    {
+      keys: 'mod+k',
+      allowInInputs: true,
+      onPress: () => setOpen((prev) => !prev),
+    },
+  ]);
 
   // Stable open/close identities: callers feed these into memoized callback
   // chains (the palette's command pipeline), so fresh closures per render

--- a/apps/desktop/src/renderer/keyboard-help.tsx
+++ b/apps/desktop/src/renderer/keyboard-help.tsx
@@ -1,14 +1,15 @@
 // apps/desktop/src/renderer/keyboard-help.tsx
 //
 // Discoverable keyboard cheat sheet. Modal triggered by `?` (when no input is
-// focused) or `⌘/` / `Ctrl+/`. Lists every shortcut the renderer reacts to so
+// focused) or `⌘/` (`Ctrl+/` off macOS). Lists every shortcut the renderer reacts to so
 // users don't need to scrape the README. Astryx Dialog owns focus trapping,
 // Esc, and focus restoration.
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Keyboard } from '@maka/ui/icons';
 import { useUiLocale } from '@maka/ui';
 import { Kbd } from '@astryxdesign/core/Kbd';
+import { useHotkeys } from '@astryxdesign/core/hooks';
 import {
   Dialog,
   DialogHeader,
@@ -48,27 +49,16 @@ function toAstryxKeyToken(key: string): string {
 export function useKeyboardHelp(): [boolean, () => void, () => void] {
   const [open, setOpen] = useState(false);
 
-  useEffect(() => {
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.metaKey || event.ctrlKey) {
-        if (event.key === '/' || event.key === '?') {
-          event.preventDefault();
-          setOpen((prev) => !prev);
-        }
-        return;
-      }
-      if (event.key !== '?') return;
-      // Skip if the user is typing in a text field so `?` still types.
-      const target = event.target as HTMLElement | null;
-      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
-        return;
-      }
-      event.preventDefault();
-      setOpen(true);
-    }
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
+  // The hand-written "is the user typing?" guard is gone: skipping
+  // input/textarea/select/contenteditable is what useHotkeys does by default,
+  // and it is the only reason the bare `?` entry needs no guard of its own —
+  // `?` must still type itself into the composer. The two modified combos opt
+  // back in, matching the old code, which reached them before its guard.
+  useHotkeys([
+    { keys: 'mod+/', allowInInputs: true, onPress: () => setOpen((prev) => !prev) },
+    { keys: 'mod+?', allowInInputs: true, onPress: () => setOpen((prev) => !prev) },
+    { keys: '?', onPress: () => setOpen(true) },
+  ]);
 
   return [open, () => setOpen(false), () => setOpen(true)];
 }

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import { useHotkeys } from '@astryxdesign/core/hooks';
 import type {
   LlmConnection,
   ProviderType,
@@ -65,17 +66,19 @@ export function SettingsModal(props: {
   // focus away from anything open inside Settings while a session streams.
   const activeNavRef = useRef<HTMLButtonElement>(null);
 
-  // The Escape listener is safe to resubscribe on every onClose identity
-  // change (it only adds/removes a DOM listener, not a focus-stealing side
-  // effect), and keeping it keyed on `onClose` guarantees Escape always
-  // calls the current closure rather than a stale one.
-  useEffect(() => {
-    function onKey(event: globalThis.KeyboardEvent) {
-      if (event.key === 'Escape' && !event.defaultPrevented) props.onClose();
-    }
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [props.onClose]);
+  // useHotkeys keeps its entries in a ref it refreshes every render, so Escape
+  // always calls the current `onClose` without the listener churning on that
+  // prop's identity (it is recreated on every AppShell render, i.e. per
+  // streamed token). It also skips defaultPrevented events, which is what the
+  // old `!event.defaultPrevented` check bought: a nested dialog that already
+  // consumed Escape closes itself, not the whole Settings surface.
+  //
+  // `allowInInputs` because Escape must close Settings from inside its own
+  // fields — the hook's default would have made Escape dead in every text box
+  // on the page.
+  useHotkeys([
+    { keys: 'escape', allowInInputs: true, onPress: () => props.onClose() },
+  ]);
 
   return (
     <div


### PR DESCRIPTION
Task #138 —【Astryx 落地 ②】useHotkeys 替换 4 处手写 window keydown.

## 问题

4 处各自手搓同一套原语：平台修饰键判断（`metaKey || ctrlKey`）、大小写处理（`'k' || 'K'`）、输入框守卫、以及各自的订阅/退订生命周期。

`useHotkeys` 全包了：每个 hook 实例一个 listener、定义存 ref（重渲染不重订阅）、`mod` 按平台解析（和 Kbd 用的是同一套检测）、跳过 defaultPrevented、命中自动 preventDefault。maka 此前 **0 处**使用。

## 三处需要 review 时留意

### 1. 五个快捷键必须 `allowInInputs: true`

⌘K、⌘/、⌘,、⌘N、Escape —— **这几个原本都没有输入框守卫，而且不能有**：命令面板在 composer 打字打到一半打不开就没意义了；Escape 必须能从 Settings 自己的输入框里关掉 Settings。

`useHotkeys` 默认**跳过**输入框，所以这里不显式开就会静默弄死这 5 个快捷键。规格里写的「含在输入框内不触发的语义」只适用于 `?` —— 只有它需要保持默认，因为 `?` 得能打进输入框，这也正是它原来要手写那段 INPUT/TEXTAREA/contenteditable 守卫的原因（现在冗余了，已删）。

### 2. `mod` 比 `metaKey || ctrlKey` 更严格 —— macOS 上是行为变化

macOS 上 **Ctrl+K / Ctrl+/ 不再**打开命令面板和快捷键面板。

我认为这是修 bug 不是引入 bug：「⌘K」本来就该只认 ⌘，而 **Ctrl+K 在 macOS 文本框里是「删到行尾」**（Cocoa/readline 的标准绑定），旧的 `metaKey || ctrlKey` 把它劫持了。非 macOS 上 `mod` 就是 Ctrl，没有任何变化。

顺手把两个文件头注释里「⌘K / Ctrl+K」这种全平台承诺改准确了。

### 3. ⌘N 的「plain N only」靠 handler 里 bail 保住

`useHotkeys` 在 combo 没写 `shift` 时**忽略** shift 状态，而且**没有办法表达「必须不带 shift」**。所以 ⇧⌘N 会命中这个 entry，我在 handler 里 `if (event.shiftKey) return;` 挡掉。

净行为不变（⇧⌘N 以前不干事、现在也不干事），**唯一不是逐字节等价的地方**：到我 bail 的时候 hook 已经调过 `preventDefault()` 了。Electron 的菜单加速键走主进程，实际影响应该为零，但我不想藏这个差异。

## 顺带

`SettingsModal` 的 Escape 去掉了 `[props.onClose]` 依赖 —— hook 每次渲染刷新 ref，handler 永远不会 stale，也就不用为一个「每个流式 token 都重建」的 prop 反复重订阅 listener。

## 优先级/precedence 确认过没被破坏

- `use-voice-input.ts` 用的是**捕获阶段**且录音中会 preventDefault → useHotkeys（window，冒泡）看到 defaultPrevented 会跳过 ✅
- 组件级 Escape handler 冒泡在前，仍然能先截胡 ✅
- `artifact-pane` 的 `handlePaneKeyDown` 带 stopPropagation，根本到不了 window ✅

## 验证

| 步骤 | 结果 |
|---|---|
| `npm run build` | ✅ |
| `npm run typecheck` | ✅ 0 error |
| `npm run format:check` | ✅ |
| `check-dead-css.mjs --check` | ✅ |
| `test:checks`（console / a11y / copy） | ✅ |
| workspace 测试 · **desktop** | ✅ passed |
| workspace 测试 · **ui** | ✅ passed |

`storage` / `cli` 失败与本 PR 无关，在 parent commit 上 stash 重跑失败完全一致（Node v25 的 `node:sqlite` ExperimentalWarning 打进 stderr，那些测试断言 stderr 为空）。本 PR 只动 renderer。

@maka-审美专家 请 review。