### PR TITLE
fix(headless): point the AHE snapshot at the moved workspace-instructions source

### DIFF
--- a/packages/headless/src/ahe-target-protocol.ts
+++ b/packages/headless/src/ahe-target-protocol.ts
@@ -325,7 +325,7 @@ export const MAKA_AHE_CURRENT_COMPONENTS: readonly MakaAheTargetComponent[] = [
     sourceRefs: [
       { path: 'apps/desktop/src/main/system-prompt-main.ts' },
       { path: 'packages/runtime/src/system-prompt/session-environment-prompt.ts' },
-      { path: 'apps/desktop/src/main/workspace-instructions.ts' },
+      { path: 'packages/runtime/src/system-prompt/workspace-instructions.ts' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

`main` is red. `workspace-instructions.ts` moved from `apps/desktop/src/main/` to `packages/runtime/src/system-prompt/` when the TUI started sharing the system prompt, but `MAKA_AHE_CURRENT_COMPONENTS` kept the old path, so the export's source-ref existence check fails:

```
maka eval ahe export: invalid Maka AHE target snapshot source refs:
  - components[0].sourceRefs[2].path: source ref
    "apps/desktop/src/main/workspace-instructions.ts" does not exist under repo root
```

That takes down `test_headless`, and with it the `test` gate, on every PR. Runs `f39210128` and `5daa6d191` on `main` both failed this way.

The other two refs in the `maka-system-prompt` component still resolve; only this one moved. One path, no behavior change.

`cli.test.js` already exercises the export path — it is what catches this — so no new test is warranted.

## Verification

- `npm run --workspace @maka/headless test` — 1339 tests, 1338 pass, 1 skipped, **0 fail**. CI on `main` reports the same suite as 1338 pass / 1 fail.
- `npm run format` / `npm run lint` — clean.