### PR TITLE
fix(headless): repoint AHE component map at the moved workspace-instructions source

### DIFF
--- a/packages/headless/src/__tests__/ahe-target-protocol.test.ts
+++ b/packages/headless/src/__tests__/ahe-target-protocol.test.ts
@@ -1,5 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 import {
   MAKA_AHE_CURRENT_COMPONENTS,
@@ -19,11 +22,23 @@ import {
   VALID_MAKA_AHE_CHANGE_MANIFEST,
 } from './ahe-target-protocol.fixtures.js';
 
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+
 describe('AHE target protocol', () => {
   it('accepts the current Maka component map', () => {
     const result = validateMakaAheTargetComponents(MAKA_AHE_CURRENT_COMPONENTS);
 
     assert.equal(result.ok, true);
+  });
+
+  it('pins every component source ref to a file that exists in the repo', () => {
+    const missing = MAKA_AHE_CURRENT_COMPONENTS.flatMap((component) =>
+      component.sourceRefs
+        .filter((sourceRef) => !existsSync(join(repoRoot, sourceRef.path)))
+        .map((sourceRef) => `${component.id}: ${sourceRef.path}`),
+    );
+
+    assert.deepEqual(missing, []);
   });
 
   it('validates content-addressed v2 snapshots and detects manifest tampering', () => {

--- a/packages/headless/src/ahe-target-protocol.ts
+++ b/packages/headless/src/ahe-target-protocol.ts
@@ -325,7 +325,7 @@ export const MAKA_AHE_CURRENT_COMPONENTS: readonly MakaAheTargetComponent[] = [
     sourceRefs: [
       { path: 'apps/desktop/src/main/system-prompt-main.ts' },
       { path: 'packages/runtime/src/system-prompt/session-environment-prompt.ts' },
-      { path: 'apps/desktop/src/main/workspace-instructions.ts' },
+      { path: 'packages/runtime/src/system-prompt/workspace-instructions.ts' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

CI has been red across the board since #2082 landed: every `test_headless` lane fails. The single failing assertion chain is `ahe export` (via `maka-headless CLI` → `task run, inspect, and exports tolerate unavailable optional Session evidence`):

```
maka eval ahe export: invalid Maka AHE target snapshot source refs:
- components[0].sourceRefs[2].path: source ref "apps/desktop/src/main/workspace-instructions.ts" does not exist under repo root
```

Root cause: #2081 moved workspace-instructions out of the desktop main process into `packages/runtime/src/system-prompt/workspace-instructions.ts`, and #2082 deleted the old file, but `MAKA_AHE_CURRENT_COMPONENTS` (packages/headless/src/ahe-target-protocol.ts) still pinned the deleted `apps/desktop` path. Snapshot validation rightly fails closed on the dangling ref, so every export-based CLI test dies.

Fix: repoint the component source ref at the moved file, and pin every `sourceRef` in the current component map to a file that exists in the repo in `ahe-target-protocol.test.ts`, so a future move breaks the protocol test instead of all of CI.

## Verification

- Reproduced the failure on `main` locally (`node scripts/run-headless-tests.mjs`): exactly the two failing tests CI reports.
- With the fix: full headless suite passes — 1339 pass, 0 fail.
- Regression test toggle check: restoring the stale path makes `pins every component source ref to a file that exists in the repo` fail; with the fix it passes.
- `npx biome check` clean on both touched files; `tsc` clean.
