### PR TITLE
fix(headless): repoint the system-prompt AHE source ref moved by #2081

### DIFF
--- a/packages/headless/src/ahe-target-protocol.ts
+++ b/packages/headless/src/ahe-target-protocol.ts
@@ -325,7 +325,7 @@ export const MAKA_AHE_CURRENT_COMPONENTS: readonly MakaAheTargetComponent[] = [
     sourceRefs: [
       { path: 'apps/desktop/src/main/system-prompt-main.ts' },
       { path: 'packages/runtime/src/system-prompt/session-environment-prompt.ts' },
-      { path: 'apps/desktop/src/main/workspace-instructions.ts' },
+      { path: 'packages/runtime/src/system-prompt/workspace-instructions.ts' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

`main` is currently red: #2081 moved `workspace-instructions.ts` from `apps/desktop/src/main` into `packages/runtime/src/system-prompt`, but the AHE target snapshot's `sourceRefs` in `packages/headless/src/ahe-target-protocol.ts` kept the old path. `maka eval ahe export` fails snapshot validation (`source ref "apps/desktop/src/main/workspace-instructions.ts" does not exist under repo root`), which fails `cli.test.js › task run, inspect, and exports tolerate unavailable optional Session evidence` and reds `test_headless` on every run since (`f39210128`, `5daa6d191`, and any PR merge-tested against them — e.g. #2070's latest run).

One-line repoint to the file's new home.

## Verification

- Every file-path `sourceRef` in `ahe-target-protocol.ts` now resolves under the repo root (checked mechanically).
- `packages/headless` `cli.test.js`: 11/11 locally, including the previously failing subtest.
