### PR TITLE
test(storage): build invalid UTF-8 path with Git plumbing

### DIFF
--- a/packages/storage/src/__tests__/managed-workspace-baseline.test.ts
+++ b/packages/storage/src/__tests__/managed-workspace-baseline.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFile, spawn } from 'node:child_process';
+import { execFile, execFileSync, spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { createReadStream } from 'node:fs';
 import {
@@ -931,20 +931,7 @@ test('rejects a source tree containing a non-UTF-8 Git path', {
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const invalidPath = Buffer.concat([Buffer.from(`${sourceRoot}/`, 'utf8'), Buffer.from([0xff])]);
-  await writeFile(invalidPath, 'invalid path bytes\n');
-  await git(sourceRoot, 'add', '-A');
-  await git(
-    sourceRoot,
-    '-c',
-    'user.name=Maka Test',
-    '-c',
-    'user.email=test@maka.invalid',
-    'commit',
-    '--quiet',
-    '-m',
-    'add invalid path',
-  );
+  await commitInvalidUtf8Path(sourceRoot);
   const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
@@ -1012,6 +999,52 @@ async function createEligibleSource(sourceRoot: string): Promise<string> {
   return realpath(sourceRoot);
 }
 
+async function commitInvalidUtf8Path(sourceRoot: string): Promise<void> {
+  const invalidPath = Buffer.from([0xff]);
+  const blobOid = gitWithInput(sourceRoot, ['hash-object', '-w', '--stdin'], 'invalid\n')
+    .toString('ascii')
+    .trim();
+  const existingEntries = gitWithInput(sourceRoot, ['ls-tree', '-z', 'HEAD']);
+  const invalidEntry = Buffer.concat([
+    Buffer.from(`100644 blob ${blobOid}\t`, 'ascii'),
+    invalidPath,
+    Buffer.from([0]),
+  ]);
+  const treeOid = gitWithInput(
+    sourceRoot,
+    ['mktree', '-z'],
+    Buffer.concat([existingEntries, invalidEntry]),
+  )
+    .toString('ascii')
+    .trim();
+  const parentOid = await git(sourceRoot, 'rev-parse', 'HEAD');
+  const commitOid = gitWithInput(
+    sourceRoot,
+    [
+      '-c',
+      'user.name=Maka Test',
+      '-c',
+      'user.email=test@maka.invalid',
+      'commit-tree',
+      treeOid,
+      '-p',
+      parentOid,
+    ],
+    'add invalid path\n',
+  )
+    .toString('ascii')
+    .trim();
+
+  await git(sourceRoot, 'update-ref', 'HEAD', commitOid, parentOid);
+  await git(sourceRoot, 'read-tree', treeOid);
+  // Keep Git status clean without asking the filesystem to materialize the invalid path.
+  gitWithInput(
+    sourceRoot,
+    ['update-index', '--skip-worktree', '-z', '--stdin'],
+    Buffer.concat([invalidPath, Buffer.from([0])]),
+  );
+}
+
 function openRequest(sourceRoot: string) {
   return {
     repositoryId: 'repository_11111111111111111111111111111111',
@@ -1047,6 +1080,18 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
     maxBuffer: 8 * 1024 * 1024,
   });
   return stdout.trim();
+}
+
+function gitWithInput(
+  cwd: string,
+  args: readonly string[],
+  input: string | Buffer = Buffer.alloc(0),
+): Buffer {
+  return execFileSync('git', args, {
+    cwd,
+    input,
+    maxBuffer: 8 * 1024 * 1024,
+  });
 }
 
 function waitForReady(child: ReturnType<typeof spawn>, timeoutMs: number): Promise<void> {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- construct the invalid UTF-8 Git path fixture with Git plumbing instead of the host filesystem
- preserve the original `0xff` path byte through the repository tree
- keep the public managed-workspace validation path unchanged

## Why

The previous fixture asked macOS to create a filename containing an invalid UTF-8 byte. APFS rejects that setup with `EILSEQ` before the managed-workspace code runs, making the test platform-dependent and preventing it from exercising the intended boundary.

The new fixture writes the blob, tree, and commit directly through Git plumbing, then marks the path `skip-worktree` so Git does not materialize it. The product code still reads the raw `ls-tree -z` bytes and rejects the non-UTF-8 source tree.

Closes #2095.

## Validation

- focused regression test
- full `@maka/storage` test suite: 634 passed, 12 skipped, 0 failed
- `npm run typecheck -w @maka/storage`
- `npm run build -w @maka/storage`
- `npm run lint`
- Biome format check
- `git diff --check`

</details>

<details>
<summary>中文</summary>

## 概要

- 使用 Git plumbing 构造非法 UTF-8 路径测试夹具，不再依赖宿主文件系统创建该路径
- 在 Git tree 中原样保留 `0xff` 路径字节
- 保持公开的 managed-workspace 校验路径不变

## 原因

旧测试要求 macOS 文件系统创建包含非法 UTF-8 字节的文件名。APFS 会在 managed-workspace 代码运行前以 `EILSEQ` 拒绝该操作，导致测试依赖平台，也无法覆盖原本要验证的产品边界。

新测试通过 Git plumbing 直接写入 blob、tree 和 commit，再将该路径标记为 `skip-worktree`，避免 Git 将其物化到文件系统。产品代码仍通过 `ls-tree -z` 读取原始路径字节，并拒绝非 UTF-8 source tree。

Closes #2095.

## 验证

- 定向回归测试
- 完整 `@maka/storage` 测试：634 passed，12 skipped，0 failed
- `npm run typecheck -w @maka/storage`
- `npm run build -w @maka/storage`
- `npm run lint`
- Biome format check
- `git diff --check`

</details>
