### PR TITLE
fix(desktop): restore the native application menu and unify platform command routing

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -19,6 +19,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import type * as AppShellEffects from '../../renderer/app-shell-effects.js';
 import type * as KeepSystemAwake from '../../renderer/use-keep-system-awake.js';
 import type * as ProjectContext from '../../renderer/use-project-context.js';
+import type { WindowCommand } from '../../preload/bridge-contract.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 
@@ -40,6 +41,8 @@ type CapturedSubscriptions = {
   sessionChange?: (event: { reason: string; sessionId?: string; ts: number; turnId?: string }) => void;
   settingsExternalChanged?: () => void;
   settingsGet?(): Promise<{ system: { keepSystemAwake: boolean } }>;
+  windowCommand?: (command: WindowCommand) => void;
+  windowCommandSubscribeCount: number;
 };
 type RendererMakaStub = {
   app: {
@@ -240,6 +243,7 @@ describe('AppShell effect stability contract', () => {
       activeSessionSubscribeCount: 0,
       connectionSubscribeCount: 0,
       planDueSubscribeCount: 0,
+      windowCommandSubscribeCount: 0,
     };
     const root = installReactRenderer(captured);
     const calls: string[] = [];
@@ -278,6 +282,7 @@ describe('AppShell effect stability contract', () => {
       activeSessionSubscribeCount: 0,
       connectionSubscribeCount: 0,
       planDueSubscribeCount: 0,
+      windowCommandSubscribeCount: 0,
     };
     const root = installReactRenderer(captured);
     const refs = { activeIdRef: { current: 'session-1' } };
@@ -311,6 +316,46 @@ describe('AppShell effect stability contract', () => {
     assert.deepEqual(calls, ['second']);
   });
 
+  it('keeps the window-command subscription stable while routing native-menu commands', async () => {
+    const effects = await appShellEffects;
+    const refs = createBootstrapRefs();
+    const captured: CapturedSubscriptions = {
+      activeSessionSubscribeCount: 0,
+      connectionSubscribeCount: 0,
+      planDueSubscribeCount: 0,
+      windowCommandSubscribeCount: 0,
+    };
+    const root = installReactRenderer(captured);
+    const commands: string[] = [];
+    const run = () =>
+      render(
+        root,
+        createElement(BootstrapSubscriptionProbe, {
+          effects,
+          onConnectionEvent: () => {},
+          onCreateSession: () => commands.push('newTask'),
+          onOpenSettings: () => commands.push('openSettings'),
+          onOpenHelp: () => commands.push('openHelp'),
+          refs,
+        }),
+      );
+
+    await run();
+    assert.equal(captured.windowCommandSubscribeCount, 1);
+
+    await run();
+    assert.equal(captured.windowCommandSubscribeCount, 1, 'rerendering with a new handler must not resubscribe');
+
+    await act(async () => {
+      captured.windowCommand?.({ id: 'newTask' });
+      captured.windowCommand?.({ id: 'openSettings' });
+      captured.windowCommand?.({ id: 'openHelp' });
+      await Promise.resolve();
+    });
+
+    assert.deepEqual(commands, ['newTask', 'openSettings', 'openHelp']);
+  });
+
   it('keeps plan reminder toast actions on the latest navigation handler', async () => {
     const effects = await appShellEffects;
     const refs = createBootstrapRefs();
@@ -318,6 +363,7 @@ describe('AppShell effect stability contract', () => {
       activeSessionSubscribeCount: 0,
       connectionSubscribeCount: 0,
       planDueSubscribeCount: 0,
+      windowCommandSubscribeCount: 0,
     };
     const root = installReactRenderer(captured);
     const navSections: string[] = [];
@@ -626,6 +672,9 @@ function BootstrapSubscriptionProbe(props: {
   onNavSelection?(selection: { section: string }): void;
   onToastAction?(onClick: (() => void) | undefined): void;
   onConfirmLiveTurn?(sessionId: string, turnId: string): void;
+  onCreateSession?(): void;
+  onOpenSettings?(): void;
+  onOpenHelp?(): void;
   refs: ReturnType<typeof createBootstrapRefs>;
 }) {
   props.effects.useAppShellBootstrapSubscriptions({
@@ -636,10 +685,10 @@ function BootstrapSubscriptionProbe(props: {
     clearPendingTurnActionsForSession: () => {},
     confirmLiveTurn: (sessionId: string, turnId: string) => props.onConfirmLiveTurn?.(sessionId, turnId),
     clearSessionRendererState: () => {},
-    createSession: () => {},
+    createSession: () => props.onCreateSession?.(),
     handleConnectionEvent: props.onConnectionEvent,
-    openHelp: () => {},
-    openSettings: () => {},
+    openHelp: () => props.onOpenHelp?.(),
+    openSettings: () => props.onOpenSettings?.(),
     pendingPermissionModeChangesRef: props.refs.pendingPermissionModeChangesRef,
     pendingSessionModelChangesRef: props.refs.pendingSessionModelChangesRef,
     pendingTurnActionTimersRef: props.refs.pendingTurnActionTimersRef,
@@ -836,6 +885,7 @@ function createCapturedSubscriptions(
     activeSessionSubscribeCount: 0,
     connectionSubscribeCount: 0,
     planDueSubscribeCount: 0,
+    windowCommandSubscribeCount: 0,
     ...overrides,
   };
 }
@@ -919,7 +969,11 @@ function installFakeMaka(captured: CapturedSubscriptions): void {
       }),
     },
     appWindow: {
-      subscribeCommand: () => noop,
+      subscribeCommand(callback: (command: WindowCommand) => void) {
+        captured.windowCommandSubscribeCount += 1;
+        captured.windowCommand = callback;
+        return noop;
+      },
     },
     connections: {
       subscribeEvents(callback: (event: ConnectionEvent) => void) {

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -638,6 +638,7 @@ function BootstrapSubscriptionProbe(props: {
     clearSessionRendererState: () => {},
     createSession: () => {},
     handleConnectionEvent: props.onConnectionEvent,
+    openHelp: () => {},
     openSettings: () => {},
     pendingPermissionModeChangesRef: props.refs.pendingPermissionModeChangesRef,
     pendingSessionModelChangesRef: props.refs.pendingSessionModelChangesRef,
@@ -916,6 +917,9 @@ function installFakeMaka(captured: CapturedSubscriptions): void {
         projectPath: '/workspace/relocated',
         projectGit: { isGitRepo: false },
       }),
+    },
+    appWindow: {
+      subscribeCommand: () => noop,
     },
     connections: {
       subscribeEvents(callback: (event: ConnectionEvent) => void) {

--- a/apps/desktop/src/main/__tests__/application-menu.test.ts
+++ b/apps/desktop/src/main/__tests__/application-menu.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { MenuItemConstructorOptions } from 'electron';
+import {
+  buildApplicationMenuTemplate,
+  type ApplicationMenuCommand,
+  type ApplicationMenuDeps,
+} from '../application-menu.js';
+
+function deps(overrides: Partial<ApplicationMenuDeps> = {}): ApplicationMenuDeps {
+  return {
+    platform: 'darwin',
+    isPackaged: true,
+    dispatch: () => {},
+    labels: { newTask: 'New Task', openSettings: 'Settings…', openHelp: 'Keyboard Shortcuts' },
+    ...overrides,
+  };
+}
+
+type FlatItem = MenuItemConstructorOptions & { parentLabel?: string };
+
+function flatten(template: ReturnType<typeof buildApplicationMenuTemplate>): FlatItem[] {
+  const items: FlatItem[] = [];
+  for (const item of template ?? []) {
+    items.push(item);
+    for (const sub of (item.submenu as MenuItemConstructorOptions[] | undefined) ?? []) {
+      items.push({ ...sub, parentLabel: item.label });
+    }
+  }
+  return items;
+}
+
+function invoke(item: FlatItem): void {
+  item.click?.(undefined as never, undefined as never, undefined as never);
+}
+
+describe('application menu template', () => {
+  it('returns null off macOS so Windows/Linux shell chrome is untouched', () => {
+    assert.equal(buildApplicationMenuTemplate(deps({ platform: 'win32' })), null);
+    assert.equal(buildApplicationMenuTemplate(deps({ platform: 'linux' })), null);
+  });
+
+  it('exposes New Task and Settings with the standard accelerators in a packaged build', () => {
+    const items = flatten(buildApplicationMenuTemplate(deps()));
+    const newTask = items.find((item) => item.accelerator === 'CmdOrCtrl+N');
+    const settings = items.find((item) => item.accelerator === 'Command+,');
+    assert.equal(newTask?.label, 'New Task');
+    assert.equal(newTask?.parentLabel, 'File');
+    assert.equal(settings?.label, 'Settings…');
+    assert.equal(settings?.parentLabel, 'Maka');
+  });
+
+  it('keeps Reload and DevTools out of production menus', () => {
+    const items = flatten(buildApplicationMenuTemplate(deps()));
+    assert.equal(items.some((item) => item.role === 'reload'), false);
+    assert.equal(items.some((item) => item.role === 'forceReload'), false);
+    assert.equal(items.some((item) => item.role === 'toggleDevTools'), false);
+    assert.equal(items.some((item) => item.role === 'quit'), true);
+  });
+
+  it('adds Reload and DevTools in development', () => {
+    const items = flatten(buildApplicationMenuTemplate(deps({ isPackaged: false })));
+    assert.equal(items.some((item) => item.role === 'reload'), true);
+    assert.equal(items.some((item) => item.role === 'forceReload'), true);
+    assert.equal(items.some((item) => item.role === 'toggleDevTools'), true);
+  });
+
+  it('keeps the standard Edit and Window roles for native behavior', () => {
+    const items = flatten(buildApplicationMenuTemplate(deps()));
+    assert.equal(items.some((item) => item.role === 'editMenu'), true);
+    assert.equal(items.some((item) => item.role === 'windowMenu'), true);
+    assert.equal(items.some((item) => item.role === 'close'), true);
+    assert.equal(items.some((item) => item.role === 'hide'), true);
+    assert.equal(items.some((item) => item.role === 'help'), true);
+  });
+});
+
+describe('menu command dispatch', () => {
+  it('routes each command through dispatch exactly once', () => {
+    const dispatched: ApplicationMenuCommand[] = [];
+    const items = flatten(
+      buildApplicationMenuTemplate(deps({ dispatch: (command) => dispatched.push(command) })),
+    );
+    const newTask = items.find((item) => item.accelerator === 'CmdOrCtrl+N');
+    const settings = items.find((item) => item.accelerator === 'Command+,');
+    const help = items.find((item) => item.label === 'Keyboard Shortcuts');
+    invoke(newTask!);
+    invoke(settings!);
+    invoke(help!);
+    assert.deepEqual(dispatched, ['newTask', 'openSettings', 'openHelp']);
+  });
+});

--- a/apps/desktop/src/main/__tests__/application-menu.test.ts
+++ b/apps/desktop/src/main/__tests__/application-menu.test.ts
@@ -12,7 +12,6 @@ function deps(overrides: Partial<ApplicationMenuDeps> = {}): ApplicationMenuDeps
     platform: 'darwin',
     isPackaged: true,
     dispatch: () => {},
-    labels: { newTask: 'New Task', openSettings: 'Settings…', openHelp: 'Keyboard Shortcuts' },
     ...overrides,
   };
 }

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -38,6 +38,7 @@ import type { assembleDesktopTools } from './tool-assembly.js';
 import type { StreamEvents } from './session-stream.js';
 import type { SettingsIpcHandle } from './settings-ipc-main.js';
 import { createAppQuitCoordinator } from './app-quit-coordinator.js';
+import { installApplicationMenu } from './application-menu.js';
 import { resolveDockPresentation } from './dock-presentation.js';
 import { resumeSafeBoundaryContinuationsOnStartup } from './startup-safe-boundary-resume.js';
 import { retireCursorSubscriptionCredentials } from './oauth/cursor-subscription-retirement.js';
@@ -267,6 +268,25 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     // here after store construction would detach the canonical database.
     const initialWindowSignal = quitCoordinator.getWindowCreationSignal();
     if (!initialWindowSignal) return;
+    // The application menu is app-scoped, not window-scoped: install it once
+    // here (before the first window, surviving window close on macOS) instead
+    // of inside createWindow. A null menu on macOS leaves Cmd+Q and the Edit
+    // roles without any handler; Windows/Linux keep it suppressed so the
+    // renderer's shell chrome and Ctrl+N / Ctrl+, shortcuts stay untouched.
+    // Menu commands route to the renderer through one typed channel when a
+    // window exists, or re-create the window when there is none (quit-phase
+    // no-op via the coordinator).
+    installApplicationMenu({
+      platform: process.platform,
+      isPackaged: app.isPackaged,
+      dispatch: (command) => {
+        if (mainWindowController.hasOpenWindows()) {
+          mainWindowController.send('window:command', { id: command });
+        } else {
+          quitCoordinator.focusOrCreateWindow();
+        }
+      },
+    });
     app.on('second-instance', quitCoordinator.focusOrCreateWindow);
     app.on('activate', quitCoordinator.focusOrCreateWindow);
     backgroundStartup = runBackgroundStartup();

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -283,6 +283,9 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
         if (mainWindowController.hasOpenWindows()) {
           mainWindowController.send('window:command', { id: command });
         } else {
+          // Deliberately drop the command: re-creating the window is what the
+          // user asked for by acting on the menu, and replaying stale commands
+          // after startup would be surprising (accepted trade-off, #2088).
           quitCoordinator.focusOrCreateWindow();
         }
       },

--- a/apps/desktop/src/main/application-menu.ts
+++ b/apps/desktop/src/main/application-menu.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import type { Menu as ElectronMenu, MenuItemConstructorOptions } from 'electron';
+import type { WindowCommand } from '../preload/bridge-contract.js';
 
 // Electron is CommonJS, and named imports from it fail outside a main process.
 // Deferring the require keeps this module loadable under plain `node --test`,
@@ -10,32 +11,23 @@ const electron = (): typeof import('electron') =>
 /**
  * Commands the native menu routes to the renderer. The renderer owns the
  * implementations (`createSession` / `openSettings` / keyboard help in
- * app-shell-effects.ts); the menu is only the macOS entry surface for them —
- * one typed channel (`window:command`), one dispatch.
+ * app-shell-effects.ts); the menu is only the macOS entry surface for them.
+ * Derived from the preload contract so the two sides of the `window:command`
+ * channel cannot drift apart.
  */
-export type ApplicationMenuCommand = 'newTask' | 'openSettings' | 'openHelp';
-
-export interface ApplicationMenuLabels {
-  newTask: string;
-  openSettings: string;
-  openHelp: string;
-}
+export type ApplicationMenuCommand = WindowCommand['id'];
 
 export interface ApplicationMenuDeps {
   platform: NodeJS.Platform;
   isPackaged: boolean;
   dispatch: (command: ApplicationMenuCommand) => void;
-  /** English by default: Electron renders role menus (Edit, Window, …) in
-   * English too, so localizing only the custom items would split the menu
-   * bar's language mid-column. */
-  labels?: ApplicationMenuLabels;
 }
 
-const DEFAULT_LABELS: ApplicationMenuLabels = {
+const MENU_LABELS = {
   newTask: 'New Task',
   openSettings: 'Settings…',
   openHelp: 'Keyboard Shortcuts',
-};
+} as const;
 
 /**
  * Platform-appropriate application menu, or `null` when the platform must
@@ -58,20 +50,23 @@ const DEFAULT_LABELS: ApplicationMenuLabels = {
  * - A menu accelerator is the single active owner of `Cmd+N` / `Cmd+,` on
  *   macOS: AppKit resolves menu key equivalents before the web contents sees
  *   the keydown, so the renderer's `useHotkeys` entry never also fires.
+ *
+ * Labels are English on purpose: Electron renders role menus (Edit, Window,
+ * …) in English too, so localizing only the custom items would split the menu
+ * bar's language mid-column.
  */
 export function buildApplicationMenuTemplate(
   deps: ApplicationMenuDeps,
 ): MenuItemConstructorOptions[] | null {
   const { platform, isPackaged, dispatch } = deps;
   if (platform !== 'darwin') return null;
-  const labels = deps.labels ?? DEFAULT_LABELS;
   return [
     {
       label: 'Maka',
       submenu: [
         { role: 'about' },
         { type: 'separator' },
-        { label: labels.openSettings, accelerator: 'Command+,', click: () => dispatch('openSettings') },
+        { label: MENU_LABELS.openSettings, accelerator: 'Command+,', click: () => dispatch('openSettings') },
         { type: 'separator' },
         { role: 'services' },
         { type: 'separator' },
@@ -85,7 +80,7 @@ export function buildApplicationMenuTemplate(
     {
       label: 'File',
       submenu: [
-        { label: labels.newTask, accelerator: 'CmdOrCtrl+N', click: () => dispatch('newTask') },
+        { label: MENU_LABELS.newTask, accelerator: 'CmdOrCtrl+N', click: () => dispatch('newTask') },
         { type: 'separator' },
         { role: 'close' },
       ],
@@ -112,7 +107,7 @@ export function buildApplicationMenuTemplate(
     { role: 'windowMenu' },
     {
       role: 'help',
-      submenu: [{ label: labels.openHelp, click: () => dispatch('openHelp') }],
+      submenu: [{ label: MENU_LABELS.openHelp, click: () => dispatch('openHelp') }],
     },
   ];
 }

--- a/apps/desktop/src/main/application-menu.ts
+++ b/apps/desktop/src/main/application-menu.ts
@@ -1,0 +1,128 @@
+import { createRequire } from 'node:module';
+import type { Menu as ElectronMenu, MenuItemConstructorOptions } from 'electron';
+
+// Electron is CommonJS, and named imports from it fail outside a main process.
+// Deferring the require keeps this module loadable under plain `node --test`,
+// where every Electron touchpoint is injected instead (status-item.ts pattern).
+const electron = (): typeof import('electron') =>
+  createRequire(import.meta.url)('electron') as typeof import('electron');
+
+/**
+ * Commands the native menu routes to the renderer. The renderer owns the
+ * implementations (`createSession` / `openSettings` / keyboard help in
+ * app-shell-effects.ts); the menu is only the macOS entry surface for them —
+ * one typed channel (`window:command`), one dispatch.
+ */
+export type ApplicationMenuCommand = 'newTask' | 'openSettings' | 'openHelp';
+
+export interface ApplicationMenuLabels {
+  newTask: string;
+  openSettings: string;
+  openHelp: string;
+}
+
+export interface ApplicationMenuDeps {
+  platform: NodeJS.Platform;
+  isPackaged: boolean;
+  dispatch: (command: ApplicationMenuCommand) => void;
+  /** English by default: Electron renders role menus (Edit, Window, …) in
+   * English too, so localizing only the custom items would split the menu
+   * bar's language mid-column. */
+  labels?: ApplicationMenuLabels;
+}
+
+const DEFAULT_LABELS: ApplicationMenuLabels = {
+  newTask: 'New Task',
+  openSettings: 'Settings…',
+  openHelp: 'Keyboard Shortcuts',
+};
+
+/**
+ * Platform-appropriate application menu, or `null` when the platform must
+ * keep the menu suppressed. Windows/Linux keep `setApplicationMenu(null)`:
+ * the renderer owns its shell chrome and the `Ctrl+N` / `Ctrl+,` shortcuts
+ * (`app-shell-effects.ts`), and a visible Electron menu bar would sit above
+ * the custom titlebar.
+ *
+ * macOS details:
+ * - The App submenu is spelled out instead of `role: 'appMenu'` so Settings
+ *   (`Cmd+,`) can sit between About and Services — where macOS users expect
+ *   it — with the standard roles around it. `role: 'quit'` exits through the
+ *   same before-quit cleanup path as any other quit request.
+ * - New Task (`Cmd+N`) lives in File next to `role: 'close'`.
+ * - `role: 'editMenu'` keeps the native editing roles and macOS's
+ *   auto-appended Dictation and Emoji & Symbols entries, so the menu must not
+ *   relabel it.
+ * - View spells out zoom/fullscreen and adds Reload/DevTools only in
+ *   development.
+ * - A menu accelerator is the single active owner of `Cmd+N` / `Cmd+,` on
+ *   macOS: AppKit resolves menu key equivalents before the web contents sees
+ *   the keydown, so the renderer's `useHotkeys` entry never also fires.
+ */
+export function buildApplicationMenuTemplate(
+  deps: ApplicationMenuDeps,
+): MenuItemConstructorOptions[] | null {
+  const { platform, isPackaged, dispatch } = deps;
+  if (platform !== 'darwin') return null;
+  const labels = deps.labels ?? DEFAULT_LABELS;
+  return [
+    {
+      label: 'Maka',
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { label: labels.openSettings, accelerator: 'Command+,', click: () => dispatch('openSettings') },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    },
+    {
+      label: 'File',
+      submenu: [
+        { label: labels.newTask, accelerator: 'CmdOrCtrl+N', click: () => dispatch('newTask') },
+        { type: 'separator' },
+        { role: 'close' },
+      ],
+    },
+    { role: 'editMenu' },
+    {
+      label: 'View',
+      submenu: [
+        ...(isPackaged
+          ? []
+          : ([
+              { role: 'reload' },
+              { role: 'forceReload' },
+              { role: 'toggleDevTools' },
+              { type: 'separator' },
+            ] as MenuItemConstructorOptions[])),
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    { role: 'windowMenu' },
+    {
+      role: 'help',
+      submenu: [{ label: labels.openHelp, click: () => dispatch('openHelp') }],
+    },
+  ];
+}
+
+export function installApplicationMenu(deps: ApplicationMenuDeps): void {
+  const template = buildApplicationMenuTemplate(deps);
+  if (!template) {
+    electron().Menu.setApplicationMenu(null);
+    return;
+  }
+  const menu: ElectronMenu = electron().Menu.buildFromTemplate(template);
+  electron().Menu.setApplicationMenu(menu);
+}

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, Menu, nativeTheme, screen, shell } from 'electron';
+import { app, BrowserWindow, dialog, nativeTheme, screen, shell } from 'electron';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -166,7 +166,6 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
   async function createWindow(signal: AbortSignal): Promise<void> {
     if (signal.aborted) return;
     await mkdir(workspaceRoot, { recursive: true });
-    installApplicationMenu();
     // Restore previously-saved bounds when available; first launch and
     // legacy installs both fall back to the default 1240x820 frame. After
     // load, validate the saved x/y against the current display layout — if
@@ -666,8 +665,4 @@ function emitRealWindowSmokeDiagnostic(stage: string): void {
     .catch((err: unknown) => {
       console.log(`[real-window-smoke] diagnostic ${JSON.stringify({ ...windowState, rendererError: errorMessage(err) })}`);
     });
-}
-
-function installApplicationMenu(): void {
-  Menu.setApplicationMenu(null);
 }

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -175,6 +175,12 @@ export type AppUpdateStatus =
     }
   | { state: 'error'; currentVersion: string; message: string; latestVersion?: string };
 
+/**
+ * Commands dispatched by the native application menu (see
+ * main/application-menu.ts). The renderer owns the implementations.
+ */
+export type WindowCommand = { id: 'newTask' | 'openSettings' | 'openHelp' };
+
 export interface MakaBridge {
 
   tasks: {
@@ -592,6 +598,9 @@ export interface MakaBridge {
     // PR-SHOW-AFTER-FIRST-COMMIT: signal main after the first React commit
     // so the hidden window is revealed (see main-window.ts).
     notifyRendererReady(): Promise<void>;
+    // PR-2088: main-to-renderer route for native-menu commands. Returns an
+    // unsubscribe; a command sent before this subscription exists is dropped.
+    subscribeCommand(handler: (command: WindowCommand) => void): () => void;
   };
   config: {
     export(input: { categories: ConfigCategory[] }): Promise<

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -7,6 +7,7 @@ import type {
   PermissionOverlayStartResult,
   RendererIngestInput,
   AppUpdateStatus,
+  WindowCommand,
 } from './bridge-contract.js';
 import type {
   ConnectionEvent,
@@ -952,6 +953,14 @@ const makaBridge = {
     // React commit so the hidden window can be revealed. Fire-and-forget.
     notifyRendererReady(): Promise<void> {
       return ipcRenderer.invoke('window:notifyRendererReady');
+    },
+    // PR-2088: main-to-renderer route for native-menu commands (New Task /
+    // Settings / Keyboard Shortcuts). The `ipcRenderer.on`/`off` idiom keeps
+    // an HMR or shell remount from stacking duplicate listeners.
+    subscribeCommand(handler: (command: WindowCommand) => void): () => void {
+      const listener = (_event: Electron.IpcRendererEvent, command: WindowCommand) => handler(command);
+      ipcRenderer.on('window:command', listener);
+      return () => ipcRenderer.off('window:command', listener);
     },
   },
   config: {

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -33,6 +33,7 @@ import {
 } from './session-event-health';
 import { settledSessionTransientIds } from './settled-session-transients.js';
 import type { SessionWorkbarTab } from './session-workbar-layout.js';
+import type { WindowCommand } from '../preload/bridge-contract.js';
 import {
   mergeShellRunNotification,
   mergeShellRunUpdates,
@@ -189,6 +190,7 @@ export function useAppShellBootstrapSubscriptions(options: {
   clearSessionRendererState: (sessionId: string) => void;
   createSession: () => Promise<void> | void;
   handleConnectionEvent: (event: ConnectionEvent) => void;
+  openHelp: () => void;
   openSettings: () => void;
   pendingPermissionModeChangesRef: RefBox<Set<string>>;
   pendingSessionModelChangesRef: RefBox<Set<string>>;
@@ -225,6 +227,18 @@ export function useAppShellBootstrapSubscriptions(options: {
   });
   const handleConnectionSubscriptionEvent = useEffectEvent((event: ConnectionEvent) => {
     options.handleConnectionEvent(event);
+  });
+  // PR-2088: the macOS application menu routes New Task / Settings / Keyboard
+  // Shortcuts here through one channel. The renderer already owns these
+  // implementations; the menu is only a second entry surface. The keydown
+  // path (useHotkeys below) stays active on every platform: on macOS AppKit
+  // resolves the menu accelerator before the web contents sees the keydown,
+  // so a real keypress dispatches exactly once, while CDP-injected test keys
+  // still reach this handler for the renderer path.
+  const handleWindowCommand = useEffectEvent((command: WindowCommand) => {
+    if (command.id === 'newTask') void options.createSession();
+    else if (command.id === 'openSettings') options.openSettings();
+    else if (command.id === 'openHelp') options.openHelp();
   });
   const handleSessionChange = useEffectEvent(
     (event: SessionChangedEvent) => {
@@ -345,6 +359,7 @@ export function useAppShellBootstrapSubscriptions(options: {
     const unsubscribeSessionChanges = window.maka.sessions.subscribeChanges(handleSessionChange);
     const unsubscribePlanChanges = window.maka.plans.subscribeChanges(handlePlanChange);
     const unsubscribePlanDue = window.maka.plans.subscribeDue(handlePlanDue);
+    const unsubscribeWindowCommand = window.maka.appWindow.subscribeCommand(handleWindowCommand);
     markRendererMounted();
     return () => {
       cleanupPendingRefs();
@@ -353,6 +368,7 @@ export function useAppShellBootstrapSubscriptions(options: {
       unsubscribeSessionChanges();
       unsubscribePlanChanges();
       unsubscribePlanDue();
+      unsubscribeWindowCommand();
     };
   }, []);
 }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1770,6 +1770,7 @@ function AppShellContent({
     clearSessionRendererState,
     createSession,
     handleConnectionEvent,
+    openHelp,
     openSettings,
     pendingPermissionModeChangesRef: permissionModeChangeRegistry.keysRef,
     pendingSessionModelChangesRef: sessionModelChangeRegistry.keysRef,


### PR DESCRIPTION
## Summary

Closes #2088.

`Menu.setApplicationMenu(null)` (`main-window.ts`, from PR #399) leaves macOS with **no application menu at all** — Cmd+Q has no handler, and after closing the window the process stays alive with the Dock tile lit (`window-all-closed` is a darwin no-op). Windows/Linux keep the menu suppressed and their renderer-owned `Ctrl+N` / `Ctrl+,` shortcuts untouched.

This restores a platform-appropriate native menu from Electron roles and routes its commands through the **existing** renderer actions over one typed channel — no duplicate command implementations:

- **New `application-menu.ts`** — pure `buildApplicationMenuTemplate()` (darwin-only, returns `null` elsewhere) + `installApplicationMenu()`. Menu layout:
  - **App**: About · **Settings… (⌘,)** · Services · Hide/Hide Others/Show All · Quit
  - **File**: **New Task (⌘N)** · Close Window
  - **Edit**: `role: 'editMenu'` — keeps native Undo/Redo/Cut/Copy/Paste/Select All plus macOS's auto-appended Dictation and Emoji & Symbols. Not relabeled on purpose.
  - **View**: explicit zoom/fullscreen; **Reload/DevTools only when `!isPackaged`**
  - **Window**: `role: 'windowMenu'` · **Help**: Keyboard Shortcuts → renderer keyboard help
- **One channel**: `window:command` (`newTask | openSettings | openHelp`) — preload `subscribeCommand` (on/off idiom), renderer subscribes in the existing mount effect, handler is a `useEffectEvent`; menu clicks call `dispatch` once.
- **Single accelerator owner per platform**: on macOS AppKit resolves menu key equivalents before the web contents sees the keydown, so the renderer `useHotkeys` entry never also fires; the renderer path stays active for CDP-injected test keys and on Windows/Linux.
- Menu installs **once at `whenReady`** (app-scoped, survives window close), not inside `createWindow`; dispatch re-creates the window when none exists (`quitCoordinator` makes that a no-op during quit).

Note: menu labels are English — Electron renders role menus (Edit, Window, …) in English anyway, so localizing only the custom items would split the menu bar's language.

## Verification

- `npm run typecheck` (desktop) — clean
- Desktop main suite: **1592 tests pass**, including 6 new ones in `application-menu.test.ts` (template composition + semantic dispatch; no source-regex assertions) and the updated effect-stability contract with the new subscription
- `npm run lint` + `npm run format:check` — clean
- **Live macOS dev run** (isolated `--user-data-dir`): menu bar shows Apple/Electron/File/Edit/View/Window/Help; Settings… sits under About, New Task under File; View shows Reload/Force Reload/Toggle Developer Tools in dev; **menu-click Quit exits through the quit coordinator**
- Not verified: real Cmd+Q keystroke via automation (System Events `keystroke` was refused for the dev Electron process; menu accelerators are the same menu-item path as the verified click), and packaged-build menu behavior (Reload/DevTools absence is locked by the template test). Worth a quick manual check on the packaged app before merge.