### PR TITLE
feat(runtime-host): own Deep Research state

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
@@ -260,10 +260,18 @@ describe('Desktop backend tool surface', () => {
   it('keeps Deep Research on a read-only local tool surface without boundary expansion', async () => {
     const requestBoundary = tool('request_sandbox_boundary', 'custom_tool');
     const bash = tool('Bash', 'shell_unsafe');
+    const exploreAgent = tool('ExploreAgent', 'subagent');
     const webSearch = tool('WebSearch', 'web_read');
     const deepResearchStatus = tool('deep_research_status', 'read');
     const deps = makeDeps({
-      builtinTools: [readTool, writeTool, requestBoundary, bash, webSearch],
+      builtinTools: [
+        readTool,
+        writeTool,
+        requestBoundary,
+        bash,
+        exploreAgent,
+        webSearch,
+      ],
       deepResearchTools: [deepResearchStatus],
     });
     const input = inputFor('claude-sonnet-4-5-20250929');
@@ -273,7 +281,7 @@ describe('Desktop backend tool surface', () => {
 
     assert.deepEqual(
       surface.selectedTools.map((candidate) => candidate.name),
-      ['Read', 'WebSearch', 'deep_research_status'],
+      ['Read', 'ExploreAgent', 'WebSearch', 'deep_research_status'],
     );
   });
 

--- a/apps/desktop/src/main/desktop-backend-tool-surface.ts
+++ b/apps/desktop/src/main/desktop-backend-tool-surface.ts
@@ -14,6 +14,7 @@ import {
 import {
   AGENT_TOOL_GROUP_ID,
   buildCancelPlanTool,
+  isDeepResearchToolAllowed,
   buildMcpTools,
   buildSubmitPlanTool,
   buildToolsForAgentDefinition,
@@ -247,21 +248,6 @@ export async function resolveDesktopBackendToolSurface(
     skillHost: productToolSurface.hostCapabilities,
     admitsAgentChildren: productToolSurface.boundSurfaceIds.includes(AGENT_TOOL_GROUP_ID),
   };
-}
-
-const DEEP_RESEARCH_ALLOWED_TOOL_NAMES = new Set([
-  'AskUserQuestion',
-  'Read',
-  'ArchiveRead',
-  'Glob',
-  'Grep',
-  'WebSearch',
-]);
-
-function isDeepResearchToolAllowed(tool: MakaTool): boolean {
-  return (
-    DEEP_RESEARCH_ALLOWED_TOOL_NAMES.has(tool.name) || tool.name.startsWith('deep_research_')
-  );
 }
 
 function modelSupportsVision(connection: LlmConnection, model: string): boolean {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,6 +66,7 @@
     "./task-ledger": "./dist/task-ledger.js",
     "./foreign-session": "./dist/foreign-session.js",
     "./deep-research-run": "./dist/deep-research-run.js",
+    "./explore-agent": "./dist/explore-agent.js",
     "./memory": "./dist/memory.js",
     "./long-term-memory": "./dist/long-term-memory.js",
     "./local-memory": "./dist/local-memory.js",

--- a/packages/core/src/__tests__/explore-agent.test.ts
+++ b/packages/core/src/__tests__/explore-agent.test.ts
@@ -87,5 +87,10 @@ describe('deep research session profile', () => {
     ]) {
       assert.match(prompt, contract);
     }
+    assert.match(prompt, /ExploreAgent/);
+    assert.doesNotMatch(
+      buildDeepResearchSystemPromptFragment({ exploreAgentAvailable: false }),
+      /ExploreAgent/,
+    );
   });
 });

--- a/packages/core/src/explore-agent.ts
+++ b/packages/core/src/explore-agent.ts
@@ -178,15 +178,24 @@ export function buildDeepResearchImplementationPrompt(run: DeepResearchRun): str
   );
 }
 
-export function buildDeepResearchSystemPromptFragment(): string {
+export function buildDeepResearchSystemPromptFragment(
+  options: { readonly exploreAgentAvailable?: boolean } = {},
+): string {
+  const exploreAgentAvailable = options.exploreAgentAvailable ?? true;
   return [
     'Deep research mode is active for this session.',
     '',
     'Mode contract:',
-    '- Inspect first. Prefer Read, Glob, Grep, ExploreAgent, and safe read-only shell commands.',
-    '- Use ExploreAgent only for a separate, self-contained local investigation that benefits from a bounded read-only worker. Keep synthesis and final judgment in the main thread.',
-    '- Do not use ExploreAgent just because it is available. If the next step is a known file, a specific symbol, package scripts, test setup, config, or 1-3 obvious files, inspect directly in the main thread.',
-    '- When using ExploreAgent, bound the prompt with a goal, relevant paths or keywords, what to ignore, a stopping condition, and exactly what evidence the worker should return.',
+    exploreAgentAvailable
+      ? '- Inspect first. Prefer Read, Glob, Grep, WebSearch, and ExploreAgent.'
+      : '- Inspect first. Prefer Read, Glob, Grep, and WebSearch.',
+    ...(exploreAgentAvailable
+      ? [
+          '- Use ExploreAgent only for a separate, self-contained local investigation that benefits from a bounded read-only worker. Keep synthesis and final judgment in the main thread.',
+          '- Do not use ExploreAgent just because it is available. If the next step is a known file, a specific symbol, package scripts, test setup, config, or 1-3 obvious files, inspect directly in the main thread.',
+          '- When using ExploreAgent, bound the prompt with a goal, relevant paths or keywords, what to ignore, a stopping condition, and exactly what evidence the worker should return.',
+        ]
+      : []),
     '- Do not write, edit, delete, move, or rename user project files; do not install, run migrations, start services, or send network requests unless the user explicitly leaves research mode.',
     '- The deep_research_* tools are the one write exception: they only update Maka-owned research artifacts and an append-only workspace ledger, never the user project.',
     '- If implementation is needed, produce a concrete plan with files, risks, and verification commands instead of modifying files.',

--- a/packages/runtime-host/src/__tests__/deep-research-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/deep-research-protocol.test.ts
@@ -1,0 +1,250 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  DEEP_RESEARCH_DEFAULT_CHECKLIST,
+  DEEP_RESEARCH_REPORT_SECTION_KEYS,
+  projectDeepResearchEvents,
+  type DeepResearchArtifactRef,
+  type DeepResearchEvent,
+} from '@maka/core/deep-research-run';
+import {
+  decodeDeepResearchQueryResult,
+  decodeRequestFrame,
+  decodeResponseFrame,
+  DEEP_RESEARCH_RECENT_REFS_MAX,
+  DEEP_RESEARCH_RESULT_MAX_BYTES,
+  HOST_OPERATION_SPECS,
+} from '../protocol/index.js';
+import { projectDeepResearchRun } from '../server/deep-research-coordinator.js';
+
+const snapshot = {
+  kind: 'snapshot' as const,
+  sessionId: 'session-1',
+  revision: 3,
+  objective: 'Trace the Runtime Host boundary',
+  scopeLevel: 'standard' as const,
+  status: 'active' as const,
+  stage: 'knowledge_base' as const,
+  round: 1,
+  createdAt: 1,
+  updatedAt: 2,
+  artifactsCount: 2,
+  stepsCount: 1,
+  checklist: [
+    {
+      itemId: 'core_flow',
+      title: 'Trace the core implementation and data flow',
+      status: 'in_progress' as const,
+      blockedReason: null,
+    },
+  ],
+  reportSections: [{ key: 'conclusion' as const, status: 'pending' as const }],
+  recentInspectedRefs: [{ kind: 'file' as const, locator: 'src/main.ts', label: null }],
+  workerRunIds: ['worker.run:1'],
+  reportArtifactId: null,
+  implementationPrompt: null,
+};
+
+test('Deep Research protocol exposes one bounded read-only projection', () => {
+  assert.equal(HOST_OPERATION_SPECS['deep-research.query'].mode, 'query');
+  assert.deepEqual(
+    decodeRequestFrame({
+      requestId: 'request-1',
+      operation: 'deep-research.query',
+      input: { sessionId: 'session-1' },
+    }),
+    {
+      requestId: 'request-1',
+      operation: 'deep-research.query',
+      input: { sessionId: 'session-1' },
+    },
+  );
+  assert.deepEqual(
+    decodeResponseFrame({
+      requestId: 'request-1',
+      operation: 'deep-research.query',
+      ok: true,
+      result: snapshot,
+    }),
+    {
+      requestId: 'request-1',
+      operation: 'deep-research.query',
+      ok: true,
+      result: snapshot,
+    },
+  );
+});
+
+test('Deep Research projection rejects open, oversized, and cross-Session shapes', () => {
+  assert.deepEqual(decodeDeepResearchQueryResult(snapshot), snapshot);
+  assert.throws(() => decodeDeepResearchQueryResult({ ...snapshot, extra: true }));
+  assert.throws(() =>
+    decodeDeepResearchQueryResult({
+      ...snapshot,
+      recentInspectedRefs: Array.from({ length: DEEP_RESEARCH_RECENT_REFS_MAX + 1 }, () => ({
+        kind: 'file',
+        locator: 'src/main.ts',
+        label: null,
+      })),
+    }),
+  );
+  assert.throws(() =>
+    HOST_OPERATION_SPECS['deep-research.query'].assertOutputForInput?.(
+      { sessionId: 'session-1' },
+      { ...snapshot, sessionId: 'session-2' },
+    ),
+  );
+  assert.throws(() =>
+    decodeDeepResearchQueryResult({ kind: 'not_started', sessionId: 'session-1', revision: 1 }),
+  );
+});
+
+test('Deep Research producer fits escaping-heavy legal state to its encoded result budget', () => {
+  const projectionResult = projectDeepResearchEvents(escapingHeavyCompletedEvents());
+  assert.deepEqual(projectionResult.diagnostics, []);
+  assert.ok(projectionResult.run);
+  assert.equal(projectionResult.run.status, 'completed');
+
+  const projection = projectDeepResearchRun(projectionResult.run, 7);
+  assert.deepEqual(decodeDeepResearchQueryResult(projection), projection);
+  assert.ok(
+    Buffer.byteLength(JSON.stringify(projection), 'utf8') <= DEEP_RESEARCH_RESULT_MAX_BYTES,
+  );
+});
+
+function escapingHeavyCompletedEvents(): DeepResearchEvent[] {
+  const escaped = '\u0000"\\';
+  const sessionId = 'session-research';
+  let eventIndex = 0;
+  let timestamp = 0;
+  const event = <T extends Omit<DeepResearchEvent, 'eventId' | 'sessionId' | 'ts'>>(
+    value: T,
+  ): T & Pick<DeepResearchEvent, 'eventId' | 'sessionId' | 'ts'> => ({
+    ...value,
+    eventId: `event-${++eventIndex}`,
+    sessionId,
+    ts: ++timestamp,
+  });
+  const artifact = (
+    value: Omit<DeepResearchArtifactRef, 'createdAt' | 'contentHash'>,
+  ): DeepResearchArtifactRef => ({
+    ...value,
+    createdAt: timestamp + 1,
+    contentHash: `sha256:${'a'.repeat(64)}`,
+  });
+  const sourceArtifact = artifact({
+    artifactId: 'source-1',
+    role: 'source',
+    name: 'source.md',
+    locator: 'https://example.com/source',
+    sourceArtifactIds: [],
+  });
+  const evidenceArtifact = artifact({
+    artifactId: 'evidence-1',
+    role: 'evidence_note',
+    name: 'evidence.md',
+    sourceArtifactIds: [sourceArtifact.artifactId],
+  });
+  const reportSectionArtifacts = DEEP_RESEARCH_REPORT_SECTION_KEYS.map((key) =>
+    artifact({
+      artifactId: `section-${key}`,
+      role: 'report_section',
+      name: `${key}.md`,
+      sourceArtifactIds: [sourceArtifact.artifactId],
+      reportSectionKey: key,
+      reportSectionStatus: 'completed',
+    }),
+  );
+  const reportArtifact = artifact({
+    artifactId: 'report-1',
+    role: 'report',
+    name: 'report.md',
+    sourceArtifactIds: [sourceArtifact.artifactId],
+  });
+  const handoffArtifact = artifact({
+    artifactId: 'handoff-1',
+    role: 'handoff',
+    name: 'handoff.md',
+    sourceArtifactIds: [sourceArtifact.artifactId],
+  });
+  const artifacts = [
+    sourceArtifact,
+    evidenceArtifact,
+    ...reportSectionArtifacts,
+    reportArtifact,
+    handoffArtifact,
+  ];
+
+  return [
+    event({
+      type: 'research_started',
+      objective: 'Inspect the Runtime Host boundary',
+      scopeLevel: 'deep',
+    }),
+    ...artifacts.map((entry) => event({ type: 'research_artifact_recorded', artifact: entry })),
+    ...DEEP_RESEARCH_DEFAULT_CHECKLIST.map((item) =>
+      event({
+        type: 'research_checklist_updated',
+        item: {
+          ...item,
+          status: 'completed' as const,
+          evidenceArtifactIds: [evidenceArtifact.artifactId],
+          updatedAt: timestamp + 1,
+        },
+      }),
+    ),
+    event({
+      type: 'research_step_recorded',
+      step: {
+        stepId: 'step-1',
+        kind: 'local_exploration',
+        status: 'completed',
+        objective: 'Inspect the boundary',
+        summary: 'Boundary inspected',
+        roots: ['.'],
+        keywords: [],
+        ignoredPaths: [],
+        stoppingCondition: 'Enough evidence',
+        expectedEvidence: 'Source references',
+        evidenceArtifactIds: [evidenceArtifact.artifactId],
+        inspectedRefs: Array.from({ length: DEEP_RESEARCH_RECENT_REFS_MAX }, (_, index) => ({
+          kind: 'file',
+          locator: escaped.repeat(1_365),
+          label: `${index}-${escaped.repeat(330)}`,
+          sourceArtifactId: sourceArtifact.artifactId,
+        })),
+        workerRunIds: Array.from(
+          { length: DEEP_RESEARCH_RECENT_REFS_MAX },
+          (_, index) => `worker.run:${index}`,
+        ),
+        createdAt: timestamp + 1,
+      },
+    }),
+    event({
+      type: 'research_checkpoint_recorded',
+      checkpoint: {
+        checkpointId: 'checkpoint-1',
+        round: 1,
+        stage: 'report_writing',
+        status: 'active',
+        summary: 'Report sections completed',
+        openQuestions: [],
+        nextSteps: ['Complete the research run'],
+        taskIds: [],
+        artifactIds: [reportArtifact.artifactId, handoffArtifact.artifactId],
+        createdAt: timestamp + 1,
+      },
+    }),
+    event({
+      type: 'research_completed',
+      reportArtifactId: reportArtifact.artifactId,
+      handoff: {
+        artifactId: handoffArtifact.artifactId,
+        implementationTasks: Array.from({ length: 50 }, () => escaped.repeat(333)),
+        recommendedIssues: ['issue-1'],
+        recommendedPullRequests: [],
+        verificationCommands: ['npm test'],
+      },
+    }),
+  ];
+}

--- a/packages/runtime-host/src/__tests__/deep-research-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/deep-research-two-client-uds.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { openInteractiveDeepResearchStoreForWrite } from '@maka/storage/deep-research-authority';
+import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import {
+  connectRuntimeHost,
+  RuntimeHostOperationError,
+  type RuntimeHostConnection,
+} from '../client/index.js';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '../protocol/index.js';
+import { createExecutionRuntimeHostComposition } from '../server/execution-composition.js';
+import { RuntimeHostKernel } from '../server/host-kernel.js';
+
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+
+test('two UDS Clients and a restarted production Host share one Deep Research projection', {
+  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-deep-research-uds-'));
+  const root = join(base, 'interactive');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  let owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  let host: Awaited<ReturnType<typeof RuntimeHostKernel.start>> | undefined;
+  let desktop: RuntimeHostConnection | undefined;
+  let tui: RuntimeHostConnection | undefined;
+  try {
+    const setupStores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const deepResearch = await openInteractiveDeepResearchStoreForWrite(owner.lease);
+    const session = await setupStores.sessionStore.create({
+      cwd: root,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'explore',
+      labels: ['mode:deep_research'],
+    });
+    await deepResearch.start(
+      session.id,
+      'Establish one durable Host-owned research workspace',
+      'standard',
+      { turnId: 'turn-1', toolCallId: 'research-start' },
+    );
+    await deepResearch.updateChecklist(
+      session.id,
+      {
+        itemId: 'project_entrypoints',
+        status: 'in_progress',
+        evidenceArtifactIds: [],
+      },
+      { turnId: 'turn-1', toolCallId: 'research-checklist' },
+    );
+    const sourceRevision = (await setupStores.sessionStore.readHeaderRecordSnapshot(session.id))
+      .revision;
+    deepResearch.close();
+
+    host = await RuntimeHostKernel.start({
+      owner,
+      idleGraceMs: 30_000,
+      compositionFactory: createExecutionRuntimeHostComposition,
+    });
+    owner = undefined;
+    [desktop, tui] = await Promise.all([connect(root, 'desktop'), connect(root, 'tui')]);
+
+    const [desktopProjection, tuiProjection] = await Promise.all([
+      desktop.queryDeepResearch({ sessionId: session.id }),
+      tui.queryDeepResearch({ sessionId: session.id }),
+    ]);
+    assert.deepEqual(tuiProjection, desktopProjection);
+    assert.equal(desktopProjection.kind, 'snapshot');
+    if (desktopProjection.kind !== 'snapshot') return;
+    assert.equal(desktopProjection.revision, 2);
+    assert.equal(desktopProjection.status, 'active');
+    assert.equal(
+      desktopProjection.checklist.find((item) => item.itemId === 'project_entrypoints')?.status,
+      'in_progress',
+    );
+    await assert.rejects(
+      desktop.request('session.branch.create', {
+        sourceSessionId: session.id,
+        targetSessionId: 'deep-research-branch',
+        sourceTurnId: 'turn-1',
+        expectedSourceRevision: sourceRevision,
+      }),
+      (error: unknown) =>
+        error instanceof RuntimeHostOperationError && error.code === 'operation_unavailable',
+    );
+
+    await Promise.all([desktop.close(), tui.close()]);
+    desktop = undefined;
+    tui = undefined;
+    await host.close();
+    host = undefined;
+
+    owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    if (!owner) return;
+    host = await RuntimeHostKernel.start({
+      owner,
+      idleGraceMs: 30_000,
+      compositionFactory: createExecutionRuntimeHostComposition,
+    });
+    owner = undefined;
+    tui = await connect(root, 'tui');
+
+    assert.deepEqual(await tui.queryDeepResearch({ sessionId: session.id }), desktopProjection);
+  } finally {
+    await Promise.allSettled([desktop?.close(), tui?.close()]);
+    await host?.close().catch(() => undefined);
+    await owner?.close().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+async function connect(
+  rootPath: string,
+  surface: 'desktop' | 'tui',
+): Promise<RuntimeHostConnection> {
+  const result = await connectRuntimeHost({ rootPath, surface, protocol: PROTOCOL });
+  assert.equal(result.kind, 'connected');
+  if (result.kind !== 'connected') throw new Error('Unable to connect to Runtime Host');
+  return result.connection;
+}

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -30,6 +30,7 @@ const allowedServerExternalImports = new Set([
   '@maka/core/automation',
   '@maka/core/backend-types',
   '@maka/core/events',
+  '@maka/core/explore-agent',
   '@maka/core/interaction',
   '@maka/core/llm-connections',
   '@maka/core/local-memory',
@@ -40,6 +41,7 @@ const allowedServerExternalImports = new Set([
   '@maka/core/model-thinking',
   '@maka/core/oauth-subscription',
   '@maka/core/plan',
+  '@maka/core/deep-research-run',
   '@maka/core/redaction',
   '@maka/core/runtime-policy',
   '@maka/core/runtime-event',
@@ -56,6 +58,7 @@ const allowedServerExternalImports = new Set([
   '@maka/storage/agent-graph-control-store',
   '@maka/storage/artifact-stores',
   '@maka/storage/automation-authority',
+  '@maka/storage/deep-research-authority',
   '@maka/storage/model-call-ledger',
   '@maka/storage/execution-stores',
   '@maka/storage/git-worktree-child-executor',
@@ -79,6 +82,7 @@ const allowedExternalImports = {
     '@maka/core/automation',
     '@maka/core/collaboration',
     '@maka/core/events',
+    '@maka/core/deep-research-run',
     '@maka/core/execution-inspect',
     '@maka/core/goal',
     '@maka/core/interaction',
@@ -199,6 +203,7 @@ test('the production Candidate dependency graph remains non-serving', () => {
       if (
         specifier === '@maka/runtime' ||
         specifier === '@maka/storage/agent-graph-control-store' ||
+        specifier === '@maka/storage/deep-research-authority' ||
         specifier === '@maka/storage/execution-stores' ||
         specifier === '@maka/storage/long-term-memory-store' ||
         specifier === '@maka/storage/memory-bundle-store' ||

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -1968,6 +1968,76 @@ test('Client Capability tools join the existing load_tools catalog without a par
   );
 });
 
+test('Deep Research composition keeps one read-only research surface and prompt', async () => {
+  const tool = (name: string, categoryHint?: MakaTool['categoryHint']): MakaTool => ({
+    name,
+    description: `${name} fixture`,
+    parameters: {},
+    ...(categoryHint ? { categoryHint } : {}),
+    impl: async () => name,
+  });
+  const read = tool('Read');
+  const webSearch = tool('WebSearch');
+  const shell = tool('Shell');
+  const deepResearchStatus = tool('deep_research_status');
+  const unsafeDeepResearchTool = tool('deep_research_unsafe_fixture');
+  const clientMutation = tool('mcp__opaque__mutate', 'client_capability');
+  const composition = createHostExecutionModelComposition({
+    policy: {
+      getSnapshot: async () => ({ revision: 0, policy: createDefaultRuntimePolicy() }),
+    },
+    skills: {
+      readCanonicalModelInventory: async () => ({ inventory: [] }),
+    } as unknown as HostSkillCatalogCoordinator,
+    memory: {
+      readPromptProjection: async () => ({
+        policy: { revision: 0, policy: createDefaultRuntimePolicy() },
+      }),
+    } as unknown as HostMemoryCoordinator,
+    taskLedger: { list: async () => [] } as unknown as TaskLedgerStore,
+    hostTools: [read, webSearch, shell, unsafeDeepResearchTool],
+    parentAgentTools: buildParentAgentTools(),
+    clientCapabilities: {
+      tools: [clientMutation],
+      groups: [
+        {
+          id: 'client_fixture',
+          label: 'Opaque fixture',
+          toolNames: [clientMutation.name],
+        },
+      ],
+    },
+    deepResearch: { tools: [deepResearchStatus] },
+  });
+
+  assert.deepEqual(composition.tools.map((candidate) => candidate.name).sort(), [
+    'AskUserQuestion',
+    'Read',
+    'WebSearch',
+    'deep_research_status',
+  ]);
+  assert.equal(composition.tools.includes(shell), false);
+  assert.equal(composition.tools.includes(clientMutation), false);
+  assert.equal(composition.tools.includes(unsafeDeepResearchTool), false);
+  assert.equal(
+    composition.tools.some((candidate) => candidate.categoryHint === 'subagent'),
+    false,
+  );
+  assert.equal(
+    composition.toolAvailability.groups?.find((group) => group.id === 'client_fixture'),
+    undefined,
+  );
+  const prompt =
+    (await composition.systemPrompt({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      cwd: process.cwd(),
+      workspaceRoot: process.cwd(),
+    })) ?? '';
+  assert.match(prompt, /Deep research mode is active/);
+  assert.doesNotMatch(prompt, /ExploreAgent/);
+});
+
 test('Plan composition admits only planning tools before approval and execution controls after', async () => {
   const proposal = {
     planId: 'plan-1',

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -69,6 +69,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'credential.vault.delete',
       'credential.vault.query',
       'credential.vault.set',
+      'deep-research.query',
       'execution.inspect.query',
       'execution.inspect.resolve',
       'goal.control',

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -20,6 +20,8 @@ import {
   type ContextCompactResult,
   type ContextDiagnosticsQueryInput,
   type ContextDiagnosticsResult,
+  type DeepResearchQueryInput,
+  type DeepResearchQueryResult,
   type HostOperationErrorCode,
   type HostIncompatible,
   type HostRegistration,
@@ -154,6 +156,10 @@ export interface RuntimeHostConnection {
   ): Promise<SessionRecapGenerateResult>;
   queryPlan(input: PlanQueryInput, timeoutMs?: number): Promise<PlanQueryResult>;
   controlPlan(input: PlanControlInput, timeoutMs?: number): Promise<PlanControlResult>;
+  queryDeepResearch(
+    input: DeepResearchQueryInput,
+    timeoutMs?: number,
+  ): Promise<DeepResearchQueryResult>;
   queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan>;
   startTurnResume(input: TurnResumeStartInput, timeoutMs?: number): Promise<TurnResumeStartResult>;
   openSessionSubscription(
@@ -364,6 +370,13 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
 
   controlPlan(input: PlanControlInput, timeoutMs?: number): Promise<PlanControlResult> {
     return this.request('plan.control', input, timeoutMs);
+  }
+
+  queryDeepResearch(
+    input: DeepResearchQueryInput,
+    timeoutMs?: number,
+  ): Promise<DeepResearchQueryResult> {
+    return this.request('deep-research.query', input, timeoutMs);
   }
 
   queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan> {

--- a/packages/runtime-host/src/protocol/deep-research.ts
+++ b/packages/runtime-host/src/protocol/deep-research.ts
@@ -1,0 +1,329 @@
+import {
+  DEEP_RESEARCH_CHECKLIST_ITEMS_MAX,
+  DEEP_RESEARCH_INSPECTED_REF_KINDS,
+  DEEP_RESEARCH_REPORT_SECTION_KEYS,
+  DEEP_RESEARCH_REPORT_SECTION_STATUSES,
+  DEEP_RESEARCH_RUN_STATUSES,
+  DEEP_RESEARCH_SCOPE_LEVELS,
+  DEEP_RESEARCH_STAGES,
+  DEEP_RESEARCH_CHECKLIST_STATUSES,
+  type DeepResearchChecklistStatus,
+  type DeepResearchInspectedRefKind,
+  type DeepResearchReportSectionKey,
+  type DeepResearchReportSectionStatus,
+  type DeepResearchRunStatus,
+  type DeepResearchScopeLevel,
+  type DeepResearchStage,
+} from '@maka/core/deep-research-run';
+import {
+  requireCount,
+  requireEncodedByteLimit,
+  requireEntityId,
+  requireExactRecord,
+  requireShapedRecord,
+  requireUtf8String,
+} from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const DEEP_RESEARCH_RESULT_MAX_BYTES = 48 * 1024;
+export const DEEP_RESEARCH_RECENT_REFS_MAX = 8;
+export const DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES = 4 * 1024;
+export const DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES = 1024;
+export const DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_BYTES = 16 * 1024;
+const DEEP_RESEARCH_STABLE_ID_MAX_BYTES = 128;
+const DEEP_RESEARCH_STABLE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'not_found',
+  'session_archived',
+  'invalid_request',
+  'internal_failure',
+] as const;
+
+export interface DeepResearchQueryInput {
+  readonly sessionId: string;
+}
+
+export interface DeepResearchChecklistProjection {
+  readonly itemId: string;
+  readonly title: string;
+  readonly status: DeepResearchChecklistStatus;
+  readonly blockedReason: string | null;
+}
+
+export interface DeepResearchReportSectionProjection {
+  readonly key: DeepResearchReportSectionKey;
+  readonly status: DeepResearchReportSectionStatus;
+}
+
+export interface DeepResearchInspectedRefProjection {
+  readonly kind: DeepResearchInspectedRefKind;
+  readonly locator: string;
+  readonly label: string | null;
+}
+
+export type DeepResearchQueryResult =
+  | {
+      readonly kind: 'not_started';
+      readonly sessionId: string;
+      readonly revision: 0;
+    }
+  | {
+      readonly kind: 'snapshot';
+      readonly sessionId: string;
+      readonly revision: number;
+      readonly objective: string;
+      readonly scopeLevel: DeepResearchScopeLevel;
+      readonly status: DeepResearchRunStatus;
+      readonly stage: DeepResearchStage;
+      readonly round: number;
+      readonly createdAt: number;
+      readonly updatedAt: number;
+      readonly artifactsCount: number;
+      readonly stepsCount: number;
+      readonly checklist: readonly DeepResearchChecklistProjection[];
+      readonly reportSections: readonly DeepResearchReportSectionProjection[];
+      readonly recentInspectedRefs: readonly DeepResearchInspectedRefProjection[];
+      readonly workerRunIds: readonly string[];
+      readonly reportArtifactId: string | null;
+      readonly implementationPrompt: string | null;
+    };
+
+export const DEEP_RESEARCH_OPERATION_SPECS = {
+  'deep-research.query': defineOperation<
+    DeepResearchQueryInput,
+    DeepResearchQueryResult,
+    (typeof QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeDeepResearchQueryInput,
+    decodeOutput: decodeDeepResearchQueryResult,
+    assertOutputForInput(input, output) {
+      if (output.sessionId !== input.sessionId) {
+        throw invalidProtocolFrame('Deep Research result belongs to a different Session');
+      }
+    },
+  }),
+} as const;
+
+export function decodeDeepResearchQueryInput(value: unknown): DeepResearchQueryInput {
+  const input = requireExactRecord(value, 'Deep Research query input', ['sessionId']);
+  return { sessionId: requireEntityId(input.sessionId, 'sessionId') };
+}
+
+export function decodeDeepResearchQueryResult(value: unknown): DeepResearchQueryResult {
+  requireEncodedByteLimit(value, 'Deep Research query result', DEEP_RESEARCH_RESULT_MAX_BYTES);
+  const record = requireShapedRecord(
+    value,
+    'Deep Research query result',
+    ['kind', 'sessionId', 'revision'],
+    [
+      'objective',
+      'scopeLevel',
+      'status',
+      'stage',
+      'round',
+      'createdAt',
+      'updatedAt',
+      'artifactsCount',
+      'stepsCount',
+      'checklist',
+      'reportSections',
+      'recentInspectedRefs',
+      'workerRunIds',
+      'reportArtifactId',
+      'implementationPrompt',
+    ],
+  );
+  const sessionId = requireEntityId(record.sessionId, 'sessionId');
+  const revision = requireCount(record.revision, 'Deep Research revision');
+  if (record.kind === 'not_started') {
+    requireExactRecord(record, 'Deep Research not-started result', [
+      'kind',
+      'sessionId',
+      'revision',
+    ]);
+    if (revision !== 0) throw invalidProtocolFrame('Invalid Deep Research not-started revision');
+    return { kind: 'not_started', sessionId, revision: 0 };
+  }
+  if (record.kind !== 'snapshot') {
+    throw invalidProtocolFrame('Invalid Deep Research query result kind');
+  }
+  requireExactRecord(record, 'Deep Research snapshot result', [
+    'kind',
+    'sessionId',
+    'revision',
+    'objective',
+    'scopeLevel',
+    'status',
+    'stage',
+    'round',
+    'createdAt',
+    'updatedAt',
+    'artifactsCount',
+    'stepsCount',
+    'checklist',
+    'reportSections',
+    'recentInspectedRefs',
+    'workerRunIds',
+    'reportArtifactId',
+    'implementationPrompt',
+  ]);
+  if (revision === 0) throw invalidProtocolFrame('Invalid Deep Research snapshot revision');
+  return {
+    kind: 'snapshot',
+    sessionId,
+    revision,
+    objective: requireUtf8String(
+      record.objective,
+      'Deep Research objective',
+      DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES,
+    ),
+    scopeLevel: requireEnum(
+      record.scopeLevel,
+      DEEP_RESEARCH_SCOPE_LEVELS,
+      'Deep Research scope level',
+    ),
+    status: requireEnum(record.status, DEEP_RESEARCH_RUN_STATUSES, 'Deep Research status'),
+    stage: requireEnum(record.stage, DEEP_RESEARCH_STAGES, 'Deep Research stage'),
+    round: requireCount(record.round, 'Deep Research round'),
+    createdAt: requireCount(record.createdAt, 'Deep Research createdAt'),
+    updatedAt: requireCount(record.updatedAt, 'Deep Research updatedAt'),
+    artifactsCount: requireCount(record.artifactsCount, 'Deep Research artifact count'),
+    stepsCount: requireCount(record.stepsCount, 'Deep Research step count'),
+    checklist: decodeChecklist(record.checklist),
+    reportSections: decodeReportSections(record.reportSections),
+    recentInspectedRefs: decodeInspectedRefs(record.recentInspectedRefs),
+    workerRunIds: decodeIds(record.workerRunIds, 'Deep Research worker run ids'),
+    reportArtifactId: nullableId(record.reportArtifactId, 'Deep Research report artifact id'),
+    implementationPrompt: nullableText(
+      record.implementationPrompt,
+      'Deep Research implementation prompt',
+      DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_BYTES,
+    ),
+  };
+}
+
+function decodeChecklist(value: unknown): DeepResearchChecklistProjection[] {
+  if (!Array.isArray(value) || value.length > DEEP_RESEARCH_CHECKLIST_ITEMS_MAX) {
+    throw invalidProtocolFrame('Invalid Deep Research checklist');
+  }
+  return value.map((candidate) => {
+    const item = requireExactRecord(candidate, 'Deep Research checklist item', [
+      'itemId',
+      'title',
+      'status',
+      'blockedReason',
+    ]);
+    return {
+      itemId: requireEntityId(item.itemId, 'Deep Research checklist item id'),
+      title: requireUtf8String(
+        item.title,
+        'Deep Research checklist title',
+        DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES,
+      ),
+      status: requireEnum(
+        item.status,
+        DEEP_RESEARCH_CHECKLIST_STATUSES,
+        'Deep Research checklist status',
+      ),
+      blockedReason: nullableText(
+        item.blockedReason,
+        'Deep Research checklist blocker',
+        DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES,
+      ),
+    };
+  });
+}
+
+function decodeReportSections(value: unknown): DeepResearchReportSectionProjection[] {
+  if (!Array.isArray(value) || value.length > DEEP_RESEARCH_REPORT_SECTION_KEYS.length) {
+    throw invalidProtocolFrame('Invalid Deep Research report sections');
+  }
+  return value.map((candidate) => {
+    const section = requireExactRecord(candidate, 'Deep Research report section', [
+      'key',
+      'status',
+    ]);
+    return {
+      key: requireEnum(
+        section.key,
+        DEEP_RESEARCH_REPORT_SECTION_KEYS,
+        'Deep Research report section key',
+      ),
+      status: requireEnum(
+        section.status,
+        DEEP_RESEARCH_REPORT_SECTION_STATUSES,
+        'Deep Research report section status',
+      ),
+    };
+  });
+}
+
+function decodeInspectedRefs(value: unknown): DeepResearchInspectedRefProjection[] {
+  if (!Array.isArray(value) || value.length > DEEP_RESEARCH_RECENT_REFS_MAX) {
+    throw invalidProtocolFrame('Invalid Deep Research inspected refs');
+  }
+  return value.map((candidate) => {
+    const ref = requireExactRecord(candidate, 'Deep Research inspected ref', [
+      'kind',
+      'locator',
+      'label',
+    ]);
+    return {
+      kind: requireEnum(
+        ref.kind,
+        DEEP_RESEARCH_INSPECTED_REF_KINDS,
+        'Deep Research inspected ref kind',
+      ),
+      locator: requireUtf8String(
+        ref.locator,
+        'Deep Research inspected ref locator',
+        DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES,
+      ),
+      label: nullableText(
+        ref.label,
+        'Deep Research inspected ref label',
+        DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES,
+      ),
+    };
+  });
+}
+
+function decodeIds(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.length > DEEP_RESEARCH_RECENT_REFS_MAX) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value.map((candidate) => requireStableResearchId(candidate, label));
+}
+
+function nullableId(value: unknown, label: string): string | null {
+  return value === null ? null : requireEntityId(value, label);
+}
+
+function nullableText(value: unknown, label: string, maxBytes: number): string | null {
+  return value === null ? null : requireUtf8String(value, label, maxBytes);
+}
+
+function requireStableResearchId(value: unknown, label: string): string {
+  const id = requireUtf8String(value, label, DEEP_RESEARCH_STABLE_ID_MAX_BYTES);
+  if (!DEEP_RESEARCH_STABLE_ID.test(id)) throw invalidProtocolFrame(`Invalid ${label}`);
+  return id;
+}
+
+function requireEnum<const T extends readonly string[]>(
+  value: unknown,
+  values: T,
+  label: string,
+): T[number] {
+  if (typeof value !== 'string' || !(values as readonly string[]).includes(value)) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value as T[number];
+}

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -3,6 +3,7 @@ import { AGENT_GRAPH_OPERATION_SPECS } from './agent-graph.js';
 import { AUTOMATION_OPERATION_SPECS } from './automation.js';
 import { requireExactRecord, requireId, requireRecord, requireString } from './codec.js';
 import { CONNECTION_EFFECT_OPERATION_SPECS } from './connection-effects.js';
+import { DEEP_RESEARCH_OPERATION_SPECS } from './deep-research.js';
 import { CONTEXT_OPERATION_SPECS } from './context.js';
 import { EXECUTION_INSPECT_OPERATION_SPECS } from './execution-inspect.js';
 import { CLIENT_CAPABILITY_OPERATION_SPECS } from './client-capability.js';
@@ -106,6 +107,7 @@ export type {
   TurnStopInput,
 } from './turn.js';
 export * from './connection-effects.js';
+export * from './deep-research.js';
 export * from './context.js';
 export * from './agent-graph.js';
 export * from './execution-inspect.js';
@@ -130,6 +132,7 @@ export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   TURN_OPERATION_SPECS,
   CONTEXT_OPERATION_SPECS,
   CONNECTION_EFFECT_OPERATION_SPECS,
+  DEEP_RESEARCH_OPERATION_SPECS,
   EXECUTION_INSPECT_OPERATION_SPECS,
   RUNTIME_POLICY_OPERATION_SPECS,
   RUNTIME_RESOURCE_OPERATION_SPECS,

--- a/packages/runtime-host/src/server/deep-research-coordinator.ts
+++ b/packages/runtime-host/src/server/deep-research-coordinator.ts
@@ -1,0 +1,286 @@
+import { projectDeepResearchEvents, type DeepResearchRun } from '@maka/core/deep-research-run';
+import {
+  buildDeepResearchImplementationPrompt,
+  isDeepResearchSession,
+} from '@maka/core/explore-agent';
+import { buildDeepResearchTools, type MakaTool } from '@maka/runtime';
+import {
+  authenticateInteractiveArtifactStoreWriter,
+  type InteractiveArtifactStoreWriter,
+} from '@maka/storage/artifact-stores';
+import {
+  authenticateInteractiveDeepResearchStoreWriter,
+  type InteractiveDeepResearchStoreWriter,
+} from '@maka/storage/deep-research-authority';
+import {
+  isSessionNotFoundError,
+  type ExecutionSessionWriter,
+} from '@maka/storage/execution-stores';
+import {
+  DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES,
+  DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES,
+  DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_BYTES,
+  DEEP_RESEARCH_RECENT_REFS_MAX,
+  DEEP_RESEARCH_RESULT_MAX_BYTES,
+  type DeepResearchQueryInput,
+  type DeepResearchQueryResult,
+  type OperationOutcome,
+} from '../protocol/index.js';
+import type { DeepResearchOperationHandlerMap } from './operation-dispatcher.js';
+import { SessionAdmissionGate } from './session-admission-gate.js';
+
+export interface HostDeepResearchCoordinatorInput {
+  readonly store: InteractiveDeepResearchStoreWriter;
+  readonly artifacts: InteractiveArtifactStoreWriter;
+  readonly sessions: Pick<ExecutionSessionWriter, 'readHeaderSnapshot'>;
+  readonly sessionAdmission: SessionAdmissionGate;
+  readonly onProjectionChanged: (sessionId: string) => void;
+}
+
+/** Host-owned Deep Research ledger, model-tool, and Client projection boundary. */
+export class HostDeepResearchCoordinator {
+  readonly handlers: DeepResearchOperationHandlerMap = {
+    'deep-research.query': (input) =>
+      this.#sessionAdmission.run(input.sessionId, () => this.#query(input)),
+  };
+
+  readonly #store: InteractiveDeepResearchStoreWriter;
+  readonly #artifacts: InteractiveArtifactStoreWriter;
+  readonly #sessions: HostDeepResearchCoordinatorInput['sessions'];
+  readonly #sessionAdmission: SessionAdmissionGate;
+  readonly #unsubscribe: () => void;
+
+  constructor(input: HostDeepResearchCoordinatorInput) {
+    this.#store = authenticateInteractiveDeepResearchStoreWriter(input.store);
+    this.#artifacts = authenticateInteractiveArtifactStoreWriter(input.artifacts);
+    this.#sessions = input.sessions;
+    this.#sessionAdmission = input.sessionAdmission;
+    this.#unsubscribe = this.#store.subscribe(({ sessionId }) => {
+      input.onProjectionChanged(sessionId);
+    });
+  }
+
+  toolsForSession(sessionId: string): readonly MakaTool[] {
+    return buildDeepResearchTools({
+      store: this.#store,
+      artifactStore: {
+        create: async (input) => {
+          if (input.sessionId !== sessionId) {
+            throw new Error('Deep Research tool attempted to write another Session');
+          }
+          return this.#artifacts.create(input);
+        },
+        get: async (artifactId) =>
+          (await this.#artifacts.getInSession(sessionId, artifactId)).record ?? null,
+        readText: (artifactId, options) =>
+          this.#artifacts.readTextInSession(sessionId, artifactId, options),
+        delete: (artifactId) =>
+          this.#artifacts.deleteOwnedDeepResearchArtifactInSession(sessionId, artifactId),
+      },
+    });
+  }
+
+  close(): void {
+    this.#unsubscribe();
+  }
+
+  async #query(input: DeepResearchQueryInput): Promise<OperationOutcome<'deep-research.query'>> {
+    const unavailable = await this.#assertSessionAvailable(input.sessionId);
+    if (unavailable) return failure(unavailable.code, unavailable.message);
+    try {
+      const events = await this.#store.readEvents(input.sessionId);
+      if (events.length === 0) {
+        return success({ kind: 'not_started', sessionId: input.sessionId, revision: 0 });
+      }
+      const projection = projectDeepResearchEvents(events);
+      if (projection.diagnostics.length > 0 || !projection.run) {
+        return failure('internal_failure', 'Deep Research projection is unavailable');
+      }
+      return success(projectDeepResearchRun(projection.run, events.length));
+    } catch (error) {
+      if (isSessionNotFoundError(error)) return failure('not_found', 'Session does not exist');
+      return failure('internal_failure', 'Deep Research projection is unavailable');
+    }
+  }
+
+  async #assertSessionAvailable(sessionId: string): Promise<
+    | {
+        code: 'not_found' | 'session_archived' | 'invalid_request' | 'internal_failure';
+        message: string;
+      }
+    | undefined
+  > {
+    try {
+      const header = await this.#sessions.readHeaderSnapshot(sessionId);
+      if (header.isArchived || header.status === 'archived') {
+        return { code: 'session_archived', message: 'Session is archived' };
+      }
+      if (!isDeepResearchSession(header.labels)) {
+        return {
+          code: 'invalid_request',
+          message: 'Session is not a Deep Research Session',
+        };
+      }
+      return undefined;
+    } catch (error) {
+      if (isSessionNotFoundError(error)) {
+        return { code: 'not_found', message: 'Session does not exist' };
+      }
+      return { code: 'internal_failure', message: 'Session authority is unavailable' };
+    }
+  }
+}
+
+type DeepResearchSnapshot = Extract<DeepResearchQueryResult, { kind: 'snapshot' }>;
+
+export function projectDeepResearchRun(
+  run: DeepResearchRun,
+  revision: number,
+): DeepResearchQueryResult {
+  const recentInspectedRefs = run.steps
+    .flatMap((step) => step.inspectedRefs)
+    .slice(-DEEP_RESEARCH_RECENT_REFS_MAX)
+    .map((ref) => ({
+      kind: ref.kind,
+      locator: truncateUtf8(ref.locator, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES),
+      label: ref.label ? truncateUtf8(ref.label, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES) : null,
+    }));
+  const workerRunIds = [...new Set(run.steps.flatMap((step) => step.workerRunIds))].slice(
+    -DEEP_RESEARCH_RECENT_REFS_MAX,
+  );
+  const implementationPrompt =
+    run.status === 'completed' && run.handoff && run.reportArtifactId
+      ? truncateUtf8(
+          buildDeepResearchImplementationPrompt(run),
+          DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_BYTES,
+        )
+      : null;
+  const snapshot: DeepResearchSnapshot = {
+    kind: 'snapshot',
+    sessionId: run.sessionId,
+    revision,
+    objective: truncateUtf8(run.objective, DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES),
+    scopeLevel: run.scopeLevel,
+    status: run.status,
+    stage: run.stage,
+    round: run.round,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    artifactsCount: run.artifacts.length,
+    stepsCount: run.steps.length,
+    checklist: run.checklist.map((item) => ({
+      itemId: item.itemId,
+      title: truncateUtf8(item.title, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES),
+      status: item.status,
+      blockedReason: item.blockedReason
+        ? truncateUtf8(item.blockedReason, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES)
+        : null,
+    })),
+    reportSections: run.reportSections.map((section) => ({
+      key: section.key,
+      status: section.status,
+    })),
+    recentInspectedRefs,
+    workerRunIds,
+    reportArtifactId: run.reportArtifactId ?? null,
+    implementationPrompt: null,
+  };
+  return fitProjectionToEncodedBudget(snapshot, implementationPrompt);
+}
+
+function fitProjectionToEncodedBudget(
+  input: DeepResearchSnapshot,
+  implementationPrompt: string | null,
+): DeepResearchSnapshot {
+  let snapshot = input;
+  if (encodedBytes(snapshot) > DEEP_RESEARCH_RESULT_MAX_BYTES) {
+    snapshot = {
+      ...snapshot,
+      recentInspectedRefs: snapshot.recentInspectedRefs.map((ref) => ({
+        ...ref,
+        label: null,
+      })),
+    };
+  }
+  while (
+    encodedBytes(snapshot) > DEEP_RESEARCH_RESULT_MAX_BYTES &&
+    snapshot.recentInspectedRefs.length > 0
+  ) {
+    snapshot = { ...snapshot, recentInspectedRefs: snapshot.recentInspectedRefs.slice(1) };
+  }
+  while (
+    encodedBytes(snapshot) > DEEP_RESEARCH_RESULT_MAX_BYTES &&
+    snapshot.workerRunIds.length > 0
+  ) {
+    snapshot = { ...snapshot, workerRunIds: snapshot.workerRunIds.slice(1) };
+  }
+  if (encodedBytes(snapshot) > DEEP_RESEARCH_RESULT_MAX_BYTES) {
+    throw new Error('Deep Research projection cannot fit the protocol result budget');
+  }
+  if (!implementationPrompt) return snapshot;
+  return fitOptionalText(snapshot, implementationPrompt, (value) => ({
+    ...snapshot,
+    implementationPrompt: value,
+  }));
+}
+
+function fitOptionalText(
+  snapshot: DeepResearchSnapshot,
+  value: string,
+  update: (value: string | null) => DeepResearchSnapshot,
+): DeepResearchSnapshot {
+  const full = update(value);
+  if (encodedBytes(full) <= DEEP_RESEARCH_RESULT_MAX_BYTES) return full;
+  const characters = Array.from(value);
+  let low = 1;
+  let high = characters.length;
+  let best = snapshot;
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidate = update(truncateCharacters(value, midpoint));
+    if (encodedBytes(candidate) <= DEEP_RESEARCH_RESULT_MAX_BYTES) {
+      best = candidate;
+      low = midpoint + 1;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+  return best;
+}
+
+function truncateCharacters(value: string, maxCharacters: number): string {
+  const characters = Array.from(value);
+  if (characters.length <= maxCharacters) return value;
+  if (maxCharacters === 1) return characters[0] ?? '…';
+  return `${characters.slice(0, maxCharacters - 1).join('')}…`;
+}
+
+function encodedBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value;
+  const marker = '…';
+  const markerBytes = Buffer.byteLength(marker, 'utf8');
+  let bytes = 0;
+  let output = '';
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character, 'utf8');
+    if (bytes + characterBytes + markerBytes > maxBytes) break;
+    output += character;
+    bytes += characterBytes;
+  }
+  return `${output}${marker}`;
+}
+
+function success(result: DeepResearchQueryResult): OperationOutcome<'deep-research.query'> {
+  return { ok: true, result };
+}
+
+function failure(
+  code: Extract<OperationOutcome<'deep-research.query'>, { ok: false }>['error']['code'],
+  message: string,
+): OperationOutcome<'deep-research.query'> {
+  return { ok: false, error: { code, message } };
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { isDeepResearchSession } from '@maka/core/session';
 import { filterModelVisibleTaskLedgerTasks } from '@maka/core/task-ledger';
 import {
   AgentGraphCoordinator,
@@ -26,6 +27,7 @@ import {
   openInteractiveArtifactStoreForWrite,
 } from '@maka/storage/artifact-stores';
 import { openInteractiveAutomationAuthorityForWrite } from '@maka/storage/automation-authority';
+import { openInteractiveDeepResearchStoreForWrite } from '@maka/storage/deep-research-authority';
 import { openInteractivePlanStoreForWrite } from '@maka/storage/plan-authority';
 import {
   isSessionNotFoundError,
@@ -55,6 +57,7 @@ import { HostAutomationCoordinator } from './automation-coordinator.js';
 import { recoverClientCapabilityOutcomes } from './client-capability-recovery.js';
 import { HostConnectionEffectCoordinator } from './connection-effect-coordinator.js';
 import { HostClientCapabilityCoordinator } from './client-capability-coordinator.js';
+import { HostDeepResearchCoordinator } from './deep-research-coordinator.js';
 import {
   createHostAiSdkBackend,
   createHostExecutionModelComposition,
@@ -108,6 +111,9 @@ export async function createExecutionRuntimeHostComposition(
     | Awaited<ReturnType<typeof openInteractiveAutomationAuthorityForWrite>>
     | undefined;
   let planStore: Awaited<ReturnType<typeof openInteractivePlanStoreForWrite>> | undefined;
+  let deepResearchStore:
+    | Awaited<ReturnType<typeof openInteractiveDeepResearchStoreForWrite>>
+    | undefined;
   let graphClient: HostAgentGraphCoordinator | undefined;
   let sessionEffects: HostSessionEffectCoordinator | undefined;
   try {
@@ -121,6 +127,10 @@ export async function createExecutionRuntimeHostComposition(
     automationStore = openedAutomationStore;
     const openedPlanStore = await openInteractivePlanStoreForWrite(context.owner.lease);
     planStore = openedPlanStore;
+    const openedDeepResearchStore = await openInteractiveDeepResearchStoreForWrite(
+      context.owner.lease,
+    );
+    deepResearchStore = openedDeepResearchStore;
     const memoryStore = await openInteractiveMemoryBundleStoreForWrite(context.owner.lease);
     longTermMemoryStore = await openInteractiveLongTermMemoryStoreForWrite(context.owner.lease);
     taskLedgerStore = await openInteractiveTaskLedgerStoreForWrite(context.owner.lease);
@@ -220,6 +230,7 @@ export async function createExecutionRuntimeHostComposition(
     let oauth: HostOAuthCoordinator | undefined;
     let automations: HostAutomationCoordinator | undefined;
     let goal: HostGoalCoordinator | undefined;
+    let deepResearch: HostDeepResearchCoordinator | undefined;
     const rootPort: HostMessageRootPort = {
       readSessionHeader: (sessionId) =>
         requireRootCoordinator(rootCoordinator).readSessionHeader(sessionId),
@@ -265,6 +276,13 @@ export async function createExecutionRuntimeHostComposition(
       context.requestDrain,
     );
     const continuityCoordinator = continuity;
+    deepResearch = new HostDeepResearchCoordinator({
+      store: openedDeepResearchStore,
+      artifacts: openedArtifactStore,
+      sessions: stores.sessionStore,
+      sessionAdmission,
+      onProjectionChanged: (sessionId) => continuityCoordinator.enqueueCanonicalRefresh(sessionId),
+    });
     let poisonFailure: Error | undefined;
     let draining = false;
     let recoveryTask: Promise<void> | undefined;
@@ -335,6 +353,9 @@ export async function createExecutionRuntimeHostComposition(
         clientCapabilities: requireClientCapabilities(clientCapabilities),
         automationTool: requireAutomationCoordinator(automations).modelTool,
         planStore: openedPlanStore,
+        deepResearchTools: requireDeepResearch(deepResearch).toolsForSession(
+          backendContext.sessionId,
+        ),
         goalTools: requireGoal(goal).tools,
         builtinTools,
         hostTools,
@@ -383,6 +404,13 @@ export async function createExecutionRuntimeHostComposition(
             state: planState,
             mode: header.collaborationMode ?? 'agent',
           },
+          ...(isDeepResearchSession(header.labels)
+            ? {
+                deepResearch: {
+                  tools: requireDeepResearch(deepResearch).toolsForSession(sessionId),
+                },
+              }
+            : {}),
         }).tools.map((tool) => tool.name);
       } finally {
         capabilitySnapshot?.release();
@@ -720,6 +748,7 @@ export async function createExecutionRuntimeHostComposition(
       purgeOperationalState: async (sessionId) => {
         await stores.purgeConversationOperationalState(sessionId);
         await openedPlanStore.purgeSessionState(sessionId);
+        await openedDeepResearchStore.purgeSessionState(sessionId);
       },
       purgeAgentGraphState: async (sessionId) => {
         await openedGraphControlStore.purgeAgentGraphControlState(
@@ -753,6 +782,7 @@ export async function createExecutionRuntimeHostComposition(
       ...runtimeResources.handlers,
       ...automations.handlers,
       ...plans.handlers,
+      ...requireDeepResearch(deepResearch).handlers,
     } satisfies DomainOperationHandlerMap;
     const recover = () => {
       recoveryTask ??= (async () => {
@@ -849,6 +879,11 @@ export async function createExecutionRuntimeHostComposition(
         } catch (error) {
           errors.push(error);
         }
+        try {
+          deepResearch?.close();
+        } catch (error) {
+          errors.push(error);
+        }
         if (!backendInvalidationPoisoned) {
           try {
             await manager.refreshIdleBackends();
@@ -937,6 +972,11 @@ export async function createExecutionRuntimeHostComposition(
           errors.push(error);
         }
         try {
+          openedDeepResearchStore.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
           await stores.sessionStore.close?.();
         } catch (error) {
           errors.push(error);
@@ -966,6 +1006,11 @@ export async function createExecutionRuntimeHostComposition(
     const errors: unknown[] = [error];
     try {
       await sessionEffects?.close();
+    } catch (closeError) {
+      errors.push(closeError);
+    }
+    try {
+      deepResearchStore?.close();
     } catch (closeError) {
       errors.push(closeError);
     }
@@ -1070,6 +1115,13 @@ function requireAutomationCoordinator(
   coordinator: HostAutomationCoordinator | undefined,
 ): HostAutomationCoordinator {
   if (!coordinator) throw new Error('Runtime Host Automation coordinator is not composed');
+  return coordinator;
+}
+
+function requireDeepResearch(
+  coordinator: HostDeepResearchCoordinator | undefined,
+): HostDeepResearchCoordinator {
+  if (!coordinator) throw new Error('Runtime Host Deep Research coordinator is not composed');
   return coordinator;
 }
 

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from 'node:crypto';
+import {
+  buildDeepResearchSystemPromptFragment,
+  isDeepResearchSession,
+} from '@maka/core/explore-agent';
 import { resolveModelVisionSupport } from '@maka/core/model-metadata';
 import { activePlanExecution, type PlanSessionState, type PlanStore } from '@maka/core/plan';
 import type { ModelCallAttempt } from '@maka/core/model-call-attempt';
@@ -30,6 +34,7 @@ import {
   createProviderRequestCaptureRecorder,
   createProxiedFetchTransport,
   getAIModel,
+  isDeepResearchToolAllowed,
   projectEffectiveProductToolSurface,
   recordToolInvocation,
   resolveProjectGitInfo,
@@ -119,6 +124,9 @@ export interface HostExecutionModelCompositionInput {
     readonly state: PlanSessionState;
     readonly mode: 'agent' | 'plan';
   };
+  readonly deepResearch?: {
+    readonly tools: readonly MakaTool[];
+  };
 }
 
 /** Composes one Host-owned prompt and pure tool surface from canonical authorities. */
@@ -137,9 +145,13 @@ export function createHostExecutionModelComposition(
         input.goalTools,
         input.parentAgentTools,
         input.plan,
+        input.deepResearch?.tools,
       );
   const clientCapabilityTools = input.boundTools ? [] : (input.clientCapabilities?.tools ?? []);
-  const candidateTools = [...defaultTools, ...clientCapabilityTools];
+  const unscopedCandidateTools = [...defaultTools, ...clientCapabilityTools];
+  const candidateTools = input.deepResearch
+    ? unscopedCandidateTools.filter(isDeepResearchToolAllowed)
+    : unscopedCandidateTools;
   const activeExecution = input.plan ? activePlanExecution(input.plan.state) : undefined;
   const selectedTools = input.plan
     ? selectCollaborationTools({
@@ -208,6 +220,11 @@ export function createHostExecutionModelComposition(
         workspaceInstructions,
         promptState.memory,
         input.plan?.mode === 'plan' ? renderPlanModePrompt() : undefined,
+        input.deepResearch
+          ? buildDeepResearchSystemPromptFragment({
+              exploreAgentAvailable: tools.some(({ name }) => name === 'ExploreAgent'),
+            })
+          : undefined,
       ]);
     },
     turnTailPrompt: async (context: HostModelPromptContext) => {
@@ -257,6 +274,7 @@ export interface HostAiSdkBackendInput {
   readonly parentAgentTools?: readonly MakaTool[];
   readonly childAgents?: HostChildAgentBackendCapabilities;
   readonly planStore?: PlanStore;
+  readonly deepResearchTools?: readonly MakaTool[];
   readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
 }
 
@@ -352,6 +370,9 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
               mode: input.context.header.collaborationMode ?? 'agent',
             },
           }
+        : {}),
+      ...(isDeepResearchSession(input.context.header.labels) && !input.context.tools
+        ? { deepResearch: { tools: requireDeepResearchTools(input.deepResearchTools) } }
         : {}),
       skillBudget: {
         contextWindow: resolveSelectedModelContextWindow(target.connection, target.model),
@@ -630,6 +651,7 @@ function buildDefaultHostTools(
   goalTools: readonly MakaTool[] = [],
   parentAgentTools: readonly MakaTool[] = [],
   plan?: HostExecutionModelCompositionInput['plan'],
+  deepResearchTools: readonly MakaTool[] = [],
 ): MakaTool[] {
   const builtins = builtinOptions ? buildBuiltinTools(builtinOptions) : [];
   const question = buildAskUserQuestionTool();
@@ -659,6 +681,7 @@ function buildDefaultHostTools(
     ...goalTools.map((tool) => tool.name),
     ...parentAgentTools.map((tool) => tool.name),
     ...planTools.map((tool) => tool.name),
+    ...deepResearchTools.map((tool) => tool.name),
   ];
   const skillHost = buildHostCapabilitiesFromBinding(toolNames);
   const shadowTracker = new SkillShadowSelectionTracker();
@@ -677,7 +700,13 @@ function buildDefaultHostTools(
     ...goalTools,
     ...parentAgentTools,
     ...planTools,
+    ...deepResearchTools,
   ];
+}
+
+function requireDeepResearchTools(tools: readonly MakaTool[] | undefined): readonly MakaTool[] {
+  if (!tools) throw new Error('Runtime Host Deep Research tools are not composed');
+  return tools;
 }
 
 function renderPlanTail(state: PlanSessionState, mode: 'agent' | 'plan'): string | undefined {

--- a/packages/runtime-host/src/server/host-session-availability.ts
+++ b/packages/runtime-host/src/server/host-session-availability.ts
@@ -1,53 +1,37 @@
 import type { RootExecutionDescriptor } from '@maka/core/agent-run';
-import { isDeepResearchSession, type SessionHeader } from '@maka/core/session';
+import type { SessionHeader } from '@maka/core/session';
 
 const WORKTREE_CHILD_UNAVAILABLE_REASON =
   'Worktree child Sessions must be continued through their parent agent.';
 const CHILD_CONTINUATION_UNAVAILABLE_REASON =
   'Child Sessions must be continued through their parent agent.';
 
-export function runtimeHostSessionUnavailableReason(
-  header: Pick<SessionHeader, 'collaborationMode' | 'labels'>,
-): string | undefined {
-  if (isDeepResearchSession(header.labels)) {
-    return 'Deep Research sessions are not yet supported by Runtime Host.';
-  }
-  return undefined;
-}
-
 export function runtimeHostAutomationSessionUnavailableReason(
-  header: Pick<SessionHeader, 'collaborationMode' | 'labels'>,
+  header: Pick<SessionHeader, 'collaborationMode'>,
 ): string | undefined {
   if (header.collaborationMode === 'plan') {
     return 'Automations cannot execute while the target Session is in Plan mode.';
   }
-  return runtimeHostSessionUnavailableReason(header);
+  return undefined;
 }
 
 export function runtimeHostExternalTurnUnavailableReason(
-  header: Pick<SessionHeader, 'collaborationMode' | 'labels' | 'subagentWorkspace'>,
+  header: Pick<SessionHeader, 'collaborationMode' | 'subagentWorkspace'>,
 ): string | undefined {
   return runtimeHostExecutionUnavailableReason(header, { kind: 'external_message' });
 }
 
 export function runtimeHostSafeBoundaryContinuationUnavailableReason(
-  header: Pick<
-    SessionHeader,
-    'collaborationMode' | 'labels' | 'subagentParent' | 'subagentWorkspace'
-  >,
+  header: Pick<SessionHeader, 'subagentParent'>,
 ): string | undefined {
-  return (
-    runtimeHostSessionUnavailableReason(header) ??
-    (header.subagentParent ? CHILD_CONTINUATION_UNAVAILABLE_REASON : undefined)
-  );
+  return header.subagentParent ? CHILD_CONTINUATION_UNAVAILABLE_REASON : undefined;
 }
 
 export function runtimeHostExecutionUnavailableReason(
-  header: Pick<SessionHeader, 'collaborationMode' | 'labels' | 'subagentWorkspace'>,
+  header: Pick<SessionHeader, 'collaborationMode' | 'subagentWorkspace'>,
   execution: RootExecutionDescriptor,
 ): string | undefined {
   return (
-    runtimeHostSessionUnavailableReason(header) ??
     (header.collaborationMode === 'plan' &&
     execution.kind !== 'external_message' &&
     execution.kind !== 'regenerate' &&

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -87,6 +87,7 @@ export type RuntimeResourceOperationKey = Extract<OperationKey, `runtime.resourc
 export type ClientCapabilityOperationKey = Extract<OperationKey, `client.capability.${string}`>;
 export type AutomationOperationKey = Extract<OperationKey, `automation.${string}`>;
 export type PlanOperationKey = Extract<OperationKey, `plan.${string}`>;
+export type DeepResearchOperationKey = Extract<OperationKey, `deep-research.${string}`>;
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
 export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
 export type ContextOperationHandlerMap = Pick<OperationHandlerMap, ContextOperationKey>;
@@ -136,6 +137,7 @@ export type ClientCapabilityOperationHandlerMap = Pick<
 >;
 export type AutomationOperationHandlerMap = Pick<OperationHandlerMap, AutomationOperationKey>;
 export type PlanOperationHandlerMap = Pick<OperationHandlerMap, PlanOperationKey>;
+export type DeepResearchOperationHandlerMap = Pick<OperationHandlerMap, DeepResearchOperationKey>;
 
 export function composeOperationHandlers(
   ...handlerMaps: readonly Partial<OperationHandlerMap>[]

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { isDeepResearchSession } from '@maka/core/explore-agent';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
 import {
@@ -218,6 +219,12 @@ export class HostSessionRevisionCoordinator {
       return copyFailure(
         'operation_conflict',
         'Linked child Sessions cannot be copied as ordinary conversations',
+      );
+    }
+    if (isDeepResearchSession(sourceHeader.labels)) {
+      return copyFailure(
+        'operation_unavailable',
+        'Deep Research Sessions cannot be copied without an exact research ledger boundary',
       );
     }
     if (this.options.isSessionActive(input.sourceSessionId)) {

--- a/packages/runtime/src/__tests__/deep-research-tools.test.ts
+++ b/packages/runtime/src/__tests__/deep-research-tools.test.ts
@@ -16,6 +16,7 @@ import {
   DEEP_RESEARCH_STATUS_TOOL_NAME,
   DEEP_RESEARCH_UPDATE_CHECKLIST_TOOL_NAME,
   buildDeepResearchTools,
+  isDeepResearchToolAllowed,
   renderDeepResearchRunStatus,
   type DeepResearchArtifactStore,
 } from '../deep-research-tools.js';
@@ -124,6 +125,21 @@ describe('Deep Research runtime tools', () => {
         DEEP_RESEARCH_COMPLETE_TOOL_NAME,
       ],
     );
+  });
+
+  it('admits only the explicit Deep Research tool surface', () => {
+    const canonicalNames = [
+      DEEP_RESEARCH_START_TOOL_NAME,
+      DEEP_RESEARCH_SAVE_ARTIFACT_TOOL_NAME,
+      DEEP_RESEARCH_READ_ARTIFACT_TOOL_NAME,
+      DEEP_RESEARCH_UPDATE_CHECKLIST_TOOL_NAME,
+      DEEP_RESEARCH_RECORD_STEP_TOOL_NAME,
+      DEEP_RESEARCH_CHECKPOINT_TOOL_NAME,
+      DEEP_RESEARCH_STATUS_TOOL_NAME,
+      DEEP_RESEARCH_COMPLETE_TOOL_NAME,
+    ];
+    assert.ok(canonicalNames.every((name) => isDeepResearchToolAllowed({ name })));
+    assert.equal(isDeepResearchToolAllowed({ name: 'deep_research_unsafe_fixture' }), false);
   });
 
   it('runs the source-checkpoint-report lifecycle and makes artifact retries idempotent', async () => {

--- a/packages/runtime/src/deep-research-tools.ts
+++ b/packages/runtime/src/deep-research-tools.ts
@@ -39,6 +39,24 @@ export const DEEP_RESEARCH_CHECKPOINT_TOOL_NAME = 'deep_research_checkpoint';
 export const DEEP_RESEARCH_STATUS_TOOL_NAME = 'deep_research_status';
 export const DEEP_RESEARCH_COMPLETE_TOOL_NAME = 'deep_research_complete';
 
+const DEEP_RESEARCH_ALLOWED_TOOL_NAMES = new Set([
+  'AskUserQuestion',
+  'Read',
+  'ArchiveRead',
+  'Glob',
+  'Grep',
+  'ExploreAgent',
+  'WebSearch',
+  DEEP_RESEARCH_START_TOOL_NAME,
+  DEEP_RESEARCH_SAVE_ARTIFACT_TOOL_NAME,
+  DEEP_RESEARCH_READ_ARTIFACT_TOOL_NAME,
+  DEEP_RESEARCH_UPDATE_CHECKLIST_TOOL_NAME,
+  DEEP_RESEARCH_RECORD_STEP_TOOL_NAME,
+  DEEP_RESEARCH_CHECKPOINT_TOOL_NAME,
+  DEEP_RESEARCH_STATUS_TOOL_NAME,
+  DEEP_RESEARCH_COMPLETE_TOOL_NAME,
+]);
+
 export const DEEP_RESEARCH_ARTIFACT_CONTENT_MAX_CHARS = 512_000;
 export const DEEP_RESEARCH_ARTIFACT_READ_DEFAULT_CHARS = 32_000;
 export const DEEP_RESEARCH_ARTIFACT_READ_MAX_CHARS = 64_000;
@@ -98,6 +116,10 @@ export function buildDeepResearchTools(deps: BuildDeepResearchToolsDeps): MakaTo
     buildStatusTool(deps),
     buildCompleteTool(deps),
   ];
+}
+
+export function isDeepResearchToolAllowed(tool: Pick<MakaTool, 'name'>): boolean {
+  return DEEP_RESEARCH_ALLOWED_TOOL_NAMES.has(tool.name);
 }
 
 function buildStartTool(deps: BuildDeepResearchToolsDeps): MakaTool<

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -797,6 +797,7 @@ export {
   DEEP_RESEARCH_STATUS_TOOL_NAME,
   DEEP_RESEARCH_UPDATE_CHECKLIST_TOOL_NAME,
   buildDeepResearchTools,
+  isDeepResearchToolAllowed,
   renderDeepResearchRunStatus,
 } from './deep-research-tools.js';
 export type {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -10,6 +10,7 @@
     ".": "./dist/index.js",
     "./artifact-stores": "./dist/artifact-stores.js",
     "./automation-authority": "./dist/automation-authority.js",
+    "./deep-research-authority": "./dist/deep-research-authority.js",
     "./plan-authority": "./dist/plan-authority.js",
     "./execution-stores": "./dist/execution-stores.js",
     "./agent-graph-control-store": "./dist/agent-graph-control-store.js",

--- a/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
@@ -355,6 +355,20 @@ describe('SQLite workflow stores', () => {
     });
   });
 
+  test('purges Deep Research events for retired Sessions', async () => {
+    await withRoot(async (root) => {
+      const store = createSqliteDeepResearchStore(root);
+      try {
+        await store.start(SESSION_ID, 'Remove the retired research workspace', 'standard');
+        await store.purgeSessionState(SESSION_ID);
+        assert.equal(await store.read(SESSION_ID), undefined);
+        assert.deepEqual(await store.readEvents(SESSION_ID), []);
+      } finally {
+        store.close();
+      }
+    });
+  });
+
   test('persists Plan Reminders', async () => {
     await withRoot(async (root) => {
       const store = createSqlitePlanReminderStore(root);

--- a/packages/storage/src/artifact-stores.ts
+++ b/packages/storage/src/artifact-stores.ts
@@ -35,6 +35,7 @@ export interface InteractiveArtifactStoreWriter extends DurableArtifactAttachmen
   readonly [writerBrand]: true;
   recover(): Promise<void>;
   create(input: CreateArtifactInput): Promise<ArtifactRecord>;
+  deleteOwnedDeepResearchArtifactInSession(sessionId: string, artifactId: string): Promise<void>;
   copyConversationArtifacts(
     input: ConversationArtifactCopyInput,
   ): Promise<ConversationArtifactCopyResult>;
@@ -184,6 +185,14 @@ function createWriterFacade(
       const acceptedInput = snapshotCreateInput(input);
       return run(() => store.create(acceptedInput));
     },
+    deleteOwnedDeepResearchArtifactInSession: (sessionId, artifactId) =>
+      run(async () => {
+        const entry = await store.getInSession(sessionId, artifactId);
+        if (!entry.record || entry.record.source !== 'deep_research') {
+          throw new Error('Artifact does not belong to the expected Session authority');
+        }
+        await store.delete(artifactId);
+      }),
     copyConversationArtifacts: (input) => {
       const acceptedInput: ConversationArtifactCopyInput = Object.freeze({
         ...input,

--- a/packages/storage/src/deep-research-authority.ts
+++ b/packages/storage/src/deep-research-authority.ts
@@ -1,0 +1,180 @@
+import type {
+  DeepResearchArtifactRef,
+  DeepResearchChecklistItem,
+  DeepResearchCheckpoint,
+  DeepResearchChangedEvent,
+  DeepResearchEvent,
+  DeepResearchHandoff,
+  DeepResearchMutationContext,
+  DeepResearchRun,
+  DeepResearchScopeLevel,
+  DeepResearchStep,
+  DeepResearchStore,
+} from '@maka/core/deep-research-run';
+import {
+  assertStorageRootLease,
+  runWithStorageRootLease,
+  StorageRootAuthorityError,
+  type StorageRootLease,
+} from './root-authority.js';
+import {
+  createSqliteDeepResearchStore,
+  type SqliteDeepResearchStore,
+} from './deep-research-store.js';
+
+const writerBrand: unique symbol = Symbol('InteractiveDeepResearchStoreWriter');
+const writers = new WeakSet<object>();
+const writerByLease = new WeakMap<object, InteractiveDeepResearchStoreWriter>();
+const writerOpeningByLease = new WeakMap<object, Promise<InteractiveDeepResearchStoreWriter>>();
+
+export interface InteractiveDeepResearchStoreWriter extends DeepResearchStore {
+  readonly kind: 'interactive';
+  readonly access: 'write';
+  readonly [writerBrand]: true;
+  purgeSessionState(sessionId: string): Promise<void>;
+  close(): void;
+}
+
+export function authenticateInteractiveDeepResearchStoreWriter(
+  writer: InteractiveDeepResearchStoreWriter,
+): InteractiveDeepResearchStoreWriter {
+  if (!writers.has(writer)) {
+    throw new StorageRootAuthorityError(
+      'invalid_lease',
+      'Expected an authentic interactive Deep Research Store writer',
+    );
+  }
+  return writer;
+}
+
+export async function openInteractiveDeepResearchStoreForWrite(
+  lease: StorageRootLease<'interactive', 'write'>,
+): Promise<InteractiveDeepResearchStoreWriter> {
+  await assertStorageRootLease(lease, 'interactive', 'write');
+  const existing = writerByLease.get(lease);
+  if (existing) return existing;
+  const opening = writerOpeningByLease.get(lease);
+  if (opening) return opening;
+
+  const pending = Promise.resolve().then(async () => {
+    let store: SqliteDeepResearchStore | undefined;
+    try {
+      store = await runWithStorageRootLease(lease, 'interactive', 'write', async (root) => {
+        const opened = createSqliteDeepResearchStore(root);
+        try {
+          await opened.ready();
+          return opened;
+        } catch (error) {
+          opened.close();
+          throw error;
+        }
+      });
+      await assertStorageRootLease(lease, 'interactive', 'write');
+      const recoveredExisting = writerByLease.get(lease);
+      if (recoveredExisting) {
+        store.close();
+        return recoveredExisting;
+      }
+      const writer = createWriterFacade(lease, store);
+      writers.add(writer);
+      writerByLease.set(lease, writer);
+      return writer;
+    } catch (error) {
+      store?.close();
+      throw error;
+    }
+  });
+  writerOpeningByLease.set(lease, pending);
+  try {
+    return await pending;
+  } finally {
+    if (writerOpeningByLease.get(lease) === pending) writerOpeningByLease.delete(lease);
+  }
+}
+
+function createWriterFacade(
+  lease: StorageRootLease<'interactive', 'write'>,
+  store: SqliteDeepResearchStore,
+): InteractiveDeepResearchStoreWriter {
+  let closed = false;
+  const run = <T>(operation: () => Promise<T>): Promise<T> => {
+    if (closed) {
+      return Promise.reject(
+        new StorageRootAuthorityError('invalid_lease', 'Deep Research Store writer is closed'),
+      );
+    }
+    return runWithStorageRootLease(lease, 'interactive', 'write', operation);
+  };
+  const writer: InteractiveDeepResearchStoreWriter = {
+    kind: 'interactive',
+    access: 'write',
+    [writerBrand]: true,
+    read: (sessionId) => run(() => store.read(sessionId)),
+    readEvents: (sessionId) => run(() => store.readEvents(sessionId)),
+    start: (sessionId, objective, scopeLevel, context) =>
+      run(() => store.start(sessionId, objective, scopeLevel, cloneContext(context))),
+    recordArtifact: (sessionId, artifact, context) =>
+      run(() => store.recordArtifact(sessionId, cloneArtifact(artifact), cloneContext(context))),
+    updateChecklist: (sessionId, item, context) =>
+      run(() => store.updateChecklist(sessionId, cloneChecklist(item), cloneContext(context))),
+    recordStep: (sessionId, step, context) =>
+      run(() => store.recordStep(sessionId, cloneStep(step), cloneContext(context))),
+    recordCheckpoint: (sessionId, checkpoint, context) =>
+      run(() =>
+        store.recordCheckpoint(sessionId, cloneCheckpoint(checkpoint), cloneContext(context)),
+      ),
+    complete: (sessionId, reportArtifactId, handoff, context) =>
+      run(() =>
+        store.complete(sessionId, reportArtifactId, cloneHandoff(handoff), cloneContext(context)),
+      ),
+    subscribe: (listener) => store.subscribe(listener),
+    purgeSessionState: (sessionId) => run(() => store.purgeSessionState(sessionId)),
+    close: () => {
+      if (closed) return;
+      closed = true;
+      if (writerByLease.get(lease) === writer) writerByLease.delete(lease);
+      writers.delete(writer);
+      store.close();
+    },
+  };
+  return Object.freeze(writer);
+}
+
+function cloneContext(
+  context: DeepResearchMutationContext | undefined,
+): DeepResearchMutationContext | undefined {
+  return context ? { ...context } : undefined;
+}
+
+function cloneArtifact(artifact: DeepResearchArtifactRef): DeepResearchArtifactRef {
+  return structuredClone(artifact);
+}
+
+function cloneChecklist(
+  item: Omit<DeepResearchChecklistItem, 'title' | 'updatedAt'>,
+): Omit<DeepResearchChecklistItem, 'title' | 'updatedAt'> {
+  return structuredClone(item);
+}
+
+function cloneStep(
+  step: Omit<DeepResearchStep, 'stepId' | 'createdAt'>,
+): Omit<DeepResearchStep, 'stepId' | 'createdAt'> {
+  return structuredClone(step);
+}
+
+function cloneCheckpoint(
+  checkpoint: Omit<DeepResearchCheckpoint, 'checkpointId' | 'createdAt'>,
+): Omit<DeepResearchCheckpoint, 'checkpointId' | 'createdAt'> {
+  return structuredClone(checkpoint);
+}
+
+function cloneHandoff(handoff: DeepResearchHandoff): DeepResearchHandoff {
+  return structuredClone(handoff);
+}
+
+export type {
+  DeepResearchChangedEvent,
+  DeepResearchEvent,
+  DeepResearchRun,
+  DeepResearchScopeLevel,
+};

--- a/packages/storage/src/deep-research-store.ts
+++ b/packages/storage/src/deep-research-store.ts
@@ -35,6 +35,7 @@ export interface CreateDeepResearchStoreOptions {
 
 export interface SqliteDeepResearchStore extends DeepResearchStore {
   ready(): Promise<void>;
+  purgeSessionState(sessionId: string): Promise<void>;
   close(): void;
 }
 
@@ -80,6 +81,17 @@ class SqliteDeepResearchStoreImpl implements SqliteDeepResearchStore {
   async readEvents(sessionId: string): Promise<DeepResearchEvent[]> {
     assertSafeSessionId(sessionId);
     return readSqliteDeepResearchEvents(this.#lease.database, sessionId);
+  }
+
+  async purgeSessionState(sessionId: string): Promise<void> {
+    assertSafeSessionId(sessionId);
+    await chainWrite(this.writeQueues, sessionId, async () => {
+      this.#lease.transaction('write', () => {
+        this.#lease.database
+          .prepare('DELETE FROM workflow_deep_research_events WHERE session_id = ?')
+          .run(sessionId);
+      });
+    });
   }
 
   subscribe(listener: (event: DeepResearchChangedEvent) => void): () => void {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -111,6 +111,11 @@ export type {
   DeepResearchStore,
   SqliteDeepResearchStore,
 } from './deep-research-store.js';
+export {
+  authenticateInteractiveDeepResearchStoreWriter,
+  openInteractiveDeepResearchStoreForWrite,
+} from './deep-research-authority.js';
+export type { InteractiveDeepResearchStoreWriter } from './deep-research-authority.js';
 export * from './config-transfer.js';
 export * from './automation-store.js';
 export * from './automation-authority.js';


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- move Deep Research ledger ownership into the Runtime Host behind a lease-authenticated writer
- expose one bounded, read-only `deep-research.query` Client operation
- compose the exact Deep Research model tool surface for labelled Sessions
- bind research artifacts, cleanup, and query projection to the owning Session

## Runtime contract

The Runtime Host now opens the canonical Deep Research Store and serves model mutations through a Session-scoped coordinator. The coordinator owns the durable ledger, constrains Artifact access to the same Session and the `deep_research` source, and publishes a bounded Client projection that remains stable across Client reconnects and Host restarts.

Deep Research mode uses an explicit tool allowlist. It does not inherit arbitrary `deep_research_*` tools, and the Host prompt only advertises `ExploreAgent` when that tool is actually present in the projected surface. Branch and revision operations fail closed until an exact research-ledger copy boundary exists.

Session removal purges the research ledger through the same authority lifecycle. The wire result uses its final JSON-encoded size as the budget and deterministically trims only optional projection fields.

## Validation

- full repository build
- full repository typecheck
- Runtime Host suite: 637 passed, 0 failed
- Core and Runtime suites: 0 failed
- Desktop Deep Research tool-surface regression
- two-Client UDS query and Host restart recovery regression
- escaping-heavy canonical ledger and wire-budget regression
- Storage purge regression
- Biome checks
- `git diff --check`

</details>

<details>
<summary>中文</summary>

## 概要

- 将 Deep Research ledger 所有权迁入 Runtime Host，并置于 lease-authenticated writer 之后
- 提供一个有界、只读的 `deep-research.query` Client 操作
- 为带有对应标签的 Session 组合精确的 Deep Research 模型工具面
- 将研究 Artifact、清理流程和查询投影绑定到所属 Session

## 运行时契约

Runtime Host 现在会打开 canonical Deep Research Store，并通过 Session-scoped coordinator 执行模型侧 mutation。该 coordinator 负责 durable ledger，将 Artifact 访问限制在同一 Session 与 `deep_research` source 内，并发布有界的 Client 投影；Client 重连或 Host 重启后，投影仍保持一致。

Deep Research 模式使用显式工具 allowlist，不会自动继承任意 `deep_research_*` 工具。只有最终投影工具面中确实存在 `ExploreAgent` 时，Host prompt 才会声明该能力。在具备精确 research-ledger copy boundary 之前，branch 与 revision 操作会 fail closed。

删除 Session 时会通过同一 authority lifecycle 清理研究 ledger。Wire result 以最终 JSON 编码大小作为预算，并且只会确定性裁剪可选投影字段。

## 验证

- 完整仓库构建
- 完整仓库 typecheck
- Runtime Host 测试：637 passed，0 failed
- Core 与 Runtime 测试：0 failed
- Desktop Deep Research 工具面回归测试
- 双 Client UDS 查询与 Host 重启恢复回归测试
- 转义密集 canonical ledger 与 wire budget 回归测试
- Storage purge 回归测试
- Biome 检查
- `git diff --check`

</details>
