### PR TITLE
refactor(settings): give each capability its own disclosure

### DIFF
--- a/apps/desktop/src/renderer/locales/permission-center-copy.ts
+++ b/apps/desktop/src/renderer/locales/permission-center-copy.ts
@@ -43,8 +43,6 @@ export type PermissionCenterCopy = {
   osListAria: string;
   capabilitiesSection: string;
   capabilitiesHelp: string;
-  collapseDetails: string;
-  expandDetails: string;
   capabilityListAria: string;
   footnote: string;
   layers: {
@@ -64,6 +62,7 @@ export type PermissionCenterCopy = {
   requiredPermissionsAria(label: string): string;
   guidance: string;
   guidanceAria(label: string): string;
+  auditSection: string;
   noAudit: string;
   auditAria(label: string): string;
   impact: string;
@@ -111,7 +110,7 @@ const PERMISSION_CENTER_COPY = {
     lastRead: '最近读取：', detectAgain: '重新检测', summaryAria: '权限概览', granted: '已授权', pending: '等待授权', denied: '已拒绝', other: '未知 / 不支持',
     osSection: '系统权限', osSectionHelp: 'Maka 读到的 OS 级权限状态。点击右侧按钮可以直接前往「系统设置 → 隐私与安全性」对应分区。', osListAria: '系统权限列表',
     capabilitiesSection: '功能能力', capabilitiesHelp: '每个能力的就绪状态由「功能开关 · 配置 · 系统权限 · 运行态探测」共同决定。',
-    collapseDetails: '收起详情', expandDetails: '展开详情', capabilityListAria: '功能能力列表',
+    capabilityListAria: '功能能力列表',
     footnote: 'Maka 不会自动授予 Accessibility、Automation 或 Screen Recording。高风险自动化能力必须保持逐项审批、可审计、可撤销。这里只读取系统权限与功能能力的当前快照，授权变更仍需在「系统设置 → 隐私与安全性」完成。',
     layers: {
       aria: (label) => `${label}能力状态明细`, feature: '功能开关', configuration: '配置', approval: '操作审批', memory: '记忆写入', runtime: '运行态探测',
@@ -122,7 +121,7 @@ const PERMISSION_CENTER_COPY = {
       runtimeStates: { not_available: '尚无运行态探测', not_run: '探测未运行', healthy: '探测通过', degraded: '探测降级' },
     },
     requiredPermissions: '所需系统权限', requiredPermissionsAria: (label) => `${label}所需系统权限列表`, guidance: '处理建议', guidanceAria: (label) => `${label}处理建议列表`,
-    noAudit: '暂无审计记录', auditAria: (label) => `${label}审计记录列表`,
+    auditSection: '审计记录', noAudit: '暂无审计记录', auditAria: (label) => `${label}审计记录列表`,
     impact: '影响功能', opening: '打开中…', openSettings: '前往系统设置', requesting: '请求中…', request: '请求授权', dragGrant: '引导授权', dragGranting: '引导中…',
   },
   en: {
@@ -159,7 +158,7 @@ const PERMISSION_CENTER_COPY = {
     lastRead: 'Last read: ', detectAgain: 'Check again', summaryAria: 'Permission overview', granted: 'Granted', pending: 'Waiting', denied: 'Denied', other: 'Unknown / unsupported',
     osSection: 'System permissions', osSectionHelp: 'OS-level permission states reported to Maka. Use the action on the right to open the matching Privacy & Security section in System Settings.', osListAria: 'System permission list',
     capabilitiesSection: 'Feature capabilities', capabilitiesHelp: 'Each readiness state combines the feature toggle, configuration, system permissions, and runtime probe.',
-    collapseDetails: 'Hide details', expandDetails: 'Show details', capabilityListAria: 'Feature capability list',
+    capabilityListAria: 'Feature capability list',
     footnote: 'Maka never grants Accessibility, Automation, or Screen Recording automatically. High-risk automation must remain individually approved, auditable, and revocable. This page only reads the current snapshot; permission changes still happen in System Settings under Privacy & Security.',
     layers: {
       aria: (label) => `${label} capability state details`, feature: 'Feature toggle', configuration: 'Configuration', approval: 'Action approval', memory: 'Memory writes', runtime: 'Runtime probe',
@@ -170,7 +169,7 @@ const PERMISSION_CENTER_COPY = {
       runtimeStates: { not_available: 'No runtime probe available', not_run: 'Probe not run', healthy: 'Probe passed', degraded: 'Probe degraded' },
     },
     requiredPermissions: 'Required system permissions', requiredPermissionsAria: (label) => `${label} required system permissions`, guidance: 'Suggested actions', guidanceAria: (label) => `${label} suggested actions`,
-    noAudit: 'No audit records', auditAria: (label) => `${label} audit records`,
+    auditSection: 'Audit records', noAudit: 'No audit records', auditAria: (label) => `${label} audit records`,
     impact: 'Affects', opening: 'Opening…', openSettings: 'Open System Settings', requesting: 'Requesting…', request: 'Request permission', dragGrant: 'Guide me', dragGranting: 'Opening…',
   },
 } satisfies UiCatalog<PermissionCenterCopy>;

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -246,10 +246,18 @@ export function PermissionCenterPage() {
             settings surface uses everywhere else, except now it is the
             component's, not ours. `density` must be stated: hasDividers
             silently defaults items to `balanced`. */}
+        {/* `role="group"` is load-bearing, not decoration. CollapsibleGroup's
+            wrapper is a bare div with no role of its own, and an aria-label on
+            a role-less element names nothing — ARIA prohibits naming `generic`.
+            The rows used to sit in a `List`, which ships `role="list"` and can
+            carry a name, so without this the section would have quietly lost
+            its accessible name in the move. `group` + aria-label is valid and
+            gives 功能能力列表 back. */}
         <CollapsibleGroup
           type="single"
           hasDividers
           density="compact"
+          role="group"
           className="settingsCapabilityGroup"
           aria-label={copy.capabilityListAria}
         >

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -20,6 +20,8 @@ import { isDragGrantPermissionId, OS_PERMISSION_IDS } from '@maka/core';
 import {
   Banner,
   Button,
+  Collapsible,
+  CollapsibleGroup,
   HStack,
   List,
   ListItem,
@@ -72,7 +74,6 @@ export function PermissionCenterPage() {
   const [error, setError] = useState<string | null>(null);
   const [refreshTick, setRefreshTick] = useState(0);
   const [pendingPermAction, setPendingPermAction] = useState<string | null>(null);
-  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const toast = useToast();
   const mountedRef = useMountedRef();
   const permissionActionGuard = useActionGuard<string>();
@@ -235,27 +236,32 @@ export function PermissionCenterPage() {
         variant="bare"
         title={copy.capabilitiesSection}
         description={copy.capabilitiesHelp}
-        action={(
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => setDiagnosticsOpen((open) => !open)}
-            aria-expanded={diagnosticsOpen}
-            label={diagnosticsOpen ? copy.collapseDetails : copy.expandDetails}
-          />
-        )}
       >
-        <List hasDividers aria-label={copy.capabilityListAria}>
-            {capabilities.capabilities.map((capability) => (
-              <CapabilityRow
-                key={capability.id}
-                capability={capability}
-                copy={copy}
-                locale={locale}
-                diagnosticsOpen={diagnosticsOpen}
-              />
-            ))}
-        </List>
+        {/* Each capability opens on its own, and only one at a time. The page
+            used to carry a single 展开详情 button that unfolded four
+            MetadataLists on EVERY row at once — a wall you had to scroll past
+            to reach the one capability you came to diagnose. `type="single"`
+            makes reading one row the default act; `hasDividers` +
+            `density="compact"` is the same edge-to-edge hairline row this
+            settings surface uses everywhere else, except now it is the
+            component's, not ours. `density` must be stated: hasDividers
+            silently defaults items to `balanced`. */}
+        <CollapsibleGroup
+          type="single"
+          hasDividers
+          density="compact"
+          className="settingsCapabilityGroup"
+          aria-label={copy.capabilityListAria}
+        >
+          {capabilities.capabilities.map((capability) => (
+            <CapabilityRow
+              key={capability.id}
+              capability={capability}
+              copy={copy}
+              locale={locale}
+            />
+          ))}
+        </CollapsibleGroup>
       </SettingsSection>
 
       <Text type="supporting" size="sm" color="secondary">{copy.footnote}</Text>
@@ -314,20 +320,23 @@ function permissionActionFailureCopy(reason: string, message: string | undefined
 }
 
 /**
- * One capability row.
+ * One capability row — a Collapsible whose trigger is the row and whose content
+ * is that capability's diagnostics.
  *
  * The four-layer breakdown, the required-permission list and the guidance list
  * used to be a `<dl>` and two `<ul>`s with ~180 lines of CSS giving them label
  * columns, tone colors and spacing. They are all "label → value" readouts, so
- * they are Astryx `MetadataList` now, and the diagnostics toggle simply chooses
- * whether to render them rather than driving a `data-diagnostics-open`
- * attribute that CSS then translated into a collapse.
+ * they are Astryx `MetadataList` now.
+ *
+ * The disclosure itself is no longer ours either: it was a page-level boolean
+ * that every row read, so opening one capability opened all of them. Collapsible
+ * owns the trigger button, aria-expanded, aria-controls, and the keyboard
+ * semantics; CollapsibleGroup owns "only one at a time".
  */
 function CapabilityRow(props: {
   capability: CapabilitySnapshot;
   copy: PermissionCenterCopy;
   locale: UiLocale;
-  diagnosticsOpen: boolean;
 }) {
   const { capability } = props;
   const { copy, locale } = props;
@@ -359,110 +368,126 @@ function CapabilityRow(props: {
   ];
 
   return (
-    <ListItem
+    <Collapsible
+      /* The group owns which row is open, keyed by this value. */
+      value={capability.id}
       data-readiness={capability.readiness}
-      /* Contract hook for the DiagnosticsExpanded story. It used to assert on
-         `.settingsCapabilityList[data-diagnostics-open]`, but the list is an
-         Astryx `List` now and Astryx does not forward arbitrary data-* to it;
-         ListItem does, and the row is where the disclosure actually lands. */
-      data-diagnostics={props.diagnosticsOpen ? 'open' : 'closed'}
-      /* The readiness Badge rides the LABEL row, not endContent. ListItem
-         centers endContent against the whole row, so with diagnostics expanded
-         the badge floated hundreds of pixels below the title it describes. */
-      label={(
-        <HStack gap={2} align="center">
-          <Text type="label" size="sm">{capabilityLabel}</Text>
-          <span className="settingsStatus">
-            <StatusDot variant={statusDotVariant(readinessCopy.tone)} label={readinessCopy.label} />
-            <span>{readinessCopy.label}</span>
-          </span>
-        </HStack>
-      )}
-      description={(
-        <VStack gap={2}>
-          <VStack gap={0.5}>
+      /* The `data-diagnostics` hook is gone with the page-level flag it
+         mirrored: open state now lives in CollapsibleGroup, and the row's own
+         trigger already publishes it as `aria-expanded`. The story asserts on
+         that instead — the component's real contract rather than an attribute
+         we maintained by hand for the test. */
+      /* The readiness dot rides the title line: the trigger is a row, and a
+         status that describes the capability belongs beside its name, not
+         centered against a block that grows when the row expands. */
+      trigger={(
+        <VStack gap={1} align="start">
+          <HStack gap={2} align="center">
+            <Text type="label" size="sm">{capabilityLabel}</Text>
+            <span className="settingsStatus">
+              <StatusDot variant={statusDotVariant(readinessCopy.tone)} label={readinessCopy.label} />
+              <span>{readinessCopy.label}</span>
+            </span>
+          </HStack>
+          <VStack gap={0.5} align="start">
             <Text type="code" size="xsm" color="secondary">{prettyCapabilityId(capability.id)}</Text>
             <Text type="supporting" size="sm" color="secondary">{readinessCopy.detail}</Text>
           </VStack>
-          {props.diagnosticsOpen ? (
-            <VStack gap={3}>
-              {/* Explicit 2 columns: `columns="multi"` laid every item out
-                  full width, so the five layers became five tall rows and the
-                  row grew ~5x. `label position: start` keeps each readout on
-                  one line (label left, value right) like the <dl> it replaced. */}
-              <MetadataList
-                columns={2}
-                label={{ position: 'start', width: 92 }}
-                aria-label={copy.layers.aria(capabilityLabel)}
-              >
-                {layers.map((layer) => (
-                  <MetadataListItem key={layer.label} label={layer.label}>
-                    {/* Stacked: MetadataListItem flows its children inline, so
-                        an unwrapped reason ran straight into the state value
-                        ("探测降级maka-cu 未响应握手…"). */}
-                    <VStack gap={0.5}>
-                      <Text type="body" size="sm">{layer.value}</Text>
-                      {layer.reason ? (
-                        <Text type="supporting" size="xsm" color="secondary">{layer.reason}</Text>
-                      ) : null}
-                    </VStack>
-                  </MetadataListItem>
-                ))}
-              </MetadataList>
-              {capability.osPermissions.length > 0 && (
-                <MetadataList
-                  columns={2}
-                  label={{ position: 'start', width: 92 }}
-                  aria-label={copy.requiredPermissionsAria(capabilityLabel)}
-                  title={copy.requiredPermissions}
-                >
-                  {capability.osPermissions.map((req) => (
-                    <MetadataListItem key={req.id} label={copy.osPermissions[req.id]?.label ?? req.id}>
-                      <span className="settingsStatus">
-                        <StatusDot variant={statusDotVariant(copy.osStates[req.status].tone)} label={copy.osStates[req.status].label} />
-                        <span>{copy.osStates[req.status].label}</span>
-                      </span>
-                    </MetadataListItem>
-                  ))}
-                </MetadataList>
-              )}
-              {guidance.length > 0 && (
-                <VStack gap={1}>
-                  <Text type="label" size="sm">{copy.guidance}</Text>
-                  <List aria-label={copy.guidanceAria(capabilityLabel)} density="compact">
-                    {guidance.map((item, index) => (
-                      <ListItem
-                        key={`${capability.id}-guidance-${index}`}
-                        label={<Text type="supporting" size="sm" color="secondary">{item}</Text>}
-                      />
-                    ))}
-                  </List>
-                </VStack>
-              )}
-              {/*
-                PR-UX-POLISH-1 commit 2 (yuejing UX audit + xuan
-                ROADMAP-SURFACE-0 + kenji boundary 1): unavailable pause/revoke
-                chips looked like disabled toggles, which violates the
-                capability presentation contract. Keep them hidden until there
-                are real actions.
-              */}
-              {capability.auditEvents.length === 0 ? (
-                <Text type="supporting" size="xsm" color="secondary">{copy.noAudit}</Text>
-              ) : (
-                <List aria-label={copy.auditAria(capabilityLabel)} density="compact">
-                  {capability.auditEvents.slice(-3).map((event, index) => (
-                    <ListItem
-                      key={`${capability.id}-audit-${index}`}
-                      label={<Text type="supporting" size="xsm" color="secondary">{event}</Text>}
-                    />
-                  ))}
-                </List>
-              )}
-            </VStack>
-          ) : null}
         </VStack>
       )}
-    />
+    >
+      {/* One step of indent, no card. These rows carry no icon column, so
+          without it the diagnostics share a left edge with the capability
+          name and read as sibling rows rather than as that row's detail.
+          A tinted or rounded container instead of the indent would be a
+          card inside a row list, which this surface does not do. */}
+      <div className="settingsCapabilityDetail">
+        <VStack gap={3}>
+          {/* Explicit 2 columns: `columns="multi"` laid every item out
+              full width, so the five layers became five tall rows and the
+              row grew ~5x. `label position: start` keeps each readout on
+              one line (label left, value right) like the <dl> it replaced. */}
+          <MetadataList
+            columns={2}
+            label={{ position: 'start', width: 92 }}
+            aria-label={copy.layers.aria(capabilityLabel)}
+          >
+            {layers.map((layer) => (
+              <MetadataListItem key={layer.label} label={layer.label}>
+                {/* Stacked: MetadataListItem flows its children inline, so
+                    an unwrapped reason ran straight into the state value
+                    ("探测降级maka-cu 未响应握手…"). */}
+                <VStack gap={0.5}>
+                  <Text type="body" size="sm">{layer.value}</Text>
+                  {layer.reason ? (
+                    <Text type="supporting" size="xsm" color="secondary">{layer.reason}</Text>
+                  ) : null}
+                </VStack>
+              </MetadataListItem>
+            ))}
+          </MetadataList>
+          {capability.osPermissions.length > 0 && (
+            <MetadataList
+              columns={2}
+              label={{ position: 'start', width: 92 }}
+              aria-label={copy.requiredPermissionsAria(capabilityLabel)}
+              title={copy.requiredPermissions}
+            >
+              {capability.osPermissions.map((req) => (
+                <MetadataListItem key={req.id} label={copy.osPermissions[req.id]?.label ?? req.id}>
+                  <span className="settingsStatus">
+                    <StatusDot variant={statusDotVariant(copy.osStates[req.status].tone)} label={copy.osStates[req.status].label} />
+                    <span>{copy.osStates[req.status].label}</span>
+                  </span>
+                </MetadataListItem>
+              ))}
+            </MetadataList>
+          )}
+          {guidance.length > 0 && (
+            <VStack gap={1}>
+              <Text type="label" size="sm">{copy.guidance}</Text>
+              <List aria-label={copy.guidanceAria(capabilityLabel)} density="compact">
+                {guidance.map((item, index) => (
+                  <ListItem
+                    key={`${capability.id}-guidance-${index}`}
+                    label={<Text type="supporting" size="sm" color="secondary">{item}</Text>}
+                  />
+                ))}
+              </List>
+            </VStack>
+          )}
+          {/*
+            PR-UX-POLISH-1 commit 2 (yuejing UX audit + xuan
+            ROADMAP-SURFACE-0 + kenji boundary 1): unavailable pause/revoke
+            chips looked like disabled toggles, which violates the
+            capability presentation contract. Keep them hidden until there
+            are real actions.
+          */}
+          {/* The audit slot carries its own sub-heading, the same way
+              所需系统权限 does. It used to be a lone 暂无审计记录 line with
+              nothing above it — an orphan, which is why it read as short of
+              breathing room; the gap was a symptom of the missing parent,
+              not of the spacing. With the label, empty and populated states
+              hang off the same heading and the two sub-groups are
+              parallel. */}
+          <VStack gap={1}>
+            <Text type="label" size="sm">{copy.auditSection}</Text>
+            {capability.auditEvents.length === 0 ? (
+              <Text type="supporting" size="xsm" color="secondary">{copy.noAudit}</Text>
+            ) : (
+              <List aria-label={copy.auditAria(capabilityLabel)} density="compact">
+                {capability.auditEvents.slice(-3).map((event, index) => (
+                  <ListItem
+                    key={`${capability.id}-audit-${index}`}
+                    label={<Text type="supporting" size="xsm" color="secondary">{event}</Text>}
+                  />
+                ))}
+              </List>
+            )}
+          </VStack>
+        </VStack>
+      </div>
+    </Collapsible>
   );
 }
 

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -49,3 +49,26 @@
   background: oklch(from var(--destructive) l c h / 0.10);
   color: var(--destructive);
 }
+
+/* The capability rows are Astryx Collapsibles whose trigger stacks three lines
+   (name + status, id, readiness sentence). Astryx centers the trigger's chevron
+   against that whole block, which parks it beside the id line — the chevron
+   ends up pointing at the least important row of the three. Top-align it and
+   give it the title line's height so it centers on the name instead. */
+.settingsCapabilityGroup .astryx-collapsible-trigger {
+  align-items: flex-start;
+}
+
+.settingsCapabilityGroup .astryx-collapsible-trigger > :last-child {
+  /* One line box of the capability name (`Text type="label" size="sm"`), so the
+     chevron's own internal centering resolves onto that first line. */
+  height: calc(var(--font-size-sm) * var(--text-label-leading));
+}
+
+/* One indent step for a row's diagnostics. These rows have no icon column, so
+   without it the layer readouts share a left edge with the capability name and
+   read as sibling rows rather than as that row's detail. Indent only — a tint
+   or a rounded container here would be a card nested inside a row list. */
+.settingsCapabilityDetail {
+  padding-inline-start: var(--space-4);
+}

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -1049,21 +1049,30 @@ export const Data: Story = {
  * and the guidance block are hidden until diagnostics are expanded, so the collapsed story
  * gives those layouts no baseline at all — which is exactly where the remaining overflow
  * was hiding. Everything the collapsed story shows is still on screen here.
+ *
+ * The disclosure is per-row now (a CollapsibleGroup, one open at a time) rather than one
+ * page-level 展开详情 button, so the story opens the first capability instead — and asserts
+ * on the trigger's own `aria-expanded`, which is Collapsible's contract, rather than on a
+ * `data-diagnostics` attribute the page used to maintain by hand for this test.
  */
-// Real path: 设置 → 权限与能力 → 展开详情.
+// Real path: 设置 → 权限与能力 → 展开某个能力行.
 export const PermissionCenterDiagnosticsExpanded: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="permissions" />,
   play: async ({ canvasElement }) => {
-    const toggle = await waitForStoryButton(
+    // Scoped through `data-readiness` — the capability rows' own attribute — so
+    // the story cannot latch onto some other expandable button on the page.
+    const trigger = await waitForStoryButton(
       canvasElement,
-      (candidate) => candidate.textContent?.includes('展开详情') === true,
+      (candidate) =>
+        candidate.getAttribute('aria-expanded') === 'false' &&
+        candidate.closest('[data-readiness]') !== null,
     );
-    toggle.click();
+    trigger.click();
     await waitForStoryCondition(
       () =>
-        canvasElement.querySelector('[data-diagnostics="open"]') !== null,
-      'Permission Center story did not expand the capability diagnostics',
+        canvasElement.querySelector('[data-readiness] button[aria-expanded="true"]') !== null,
+      'Permission Center story did not expand a capability row',
     );
   },
 };


### PR DESCRIPTION
Task #139 —【Astryx 落地 ③】CollapsibleGroup 重做权限与能力页的诊断展开。

## 问题

诊断展开是**一个页面级布尔**，所有能力行共读。按一次「展开详情」，**每一行**都同时铺开四个 MetadataList —— 要看你真正关心的那个能力，得先滚过其他所有能力的五层状态 + 所需权限 + 处理建议 + 审计位。一面墙。

## 做法

`CollapsibleGroup` + 每行一个 `Collapsible`：

- `type="single"` —— 开一行自动收起上一行
- `hasDividers` + `density="compact"` —— 就是这个设置页到处在用的 edge-to-edge hairline 行，只不过现在是组件的，不是我们手写的
- **`density` 必须显式写**：`hasDividers` 会把 items 默认成 `balanced`

trigger button、`aria-expanded`、`aria-controls`、键盘语义全归 Collapsible。所以 `diagnosticsOpen` state、那个 toggle 按钮、以及 `expandDetails`/`collapseDetails` 文案（中英）**全部删除**。

## 设计 review 的三处修正（同一个 PR 内）

| 问题 | 修正 |
|---|---|
| chevron 对着三行 trigger 居中 → 落在 `computer_use` 那行，指着三行里最不重要的一行 | 改 top-align，高度取一个标题行盒，让它自身的居中落到能力名那一行 |
| 诊断内容和能力名共用左边缘 → 「功能开关」读起来像兄弟行而不是从属内容（这些行没有图标列，没有天然 gutter） | 加一档缩进。**只加缩进** —— 底色或圆角容器等于在行列表里套卡，这个界面不做 |
| 审计位是一条光秃秃的「暂无审计记录」，上面什么都没有 | 补「审计记录」子标签（和「所需系统权限」同款）。缺呼吸的根因是**缺上级**不是缺间距；补了标签之后，空态和有数据态挂在同一个标题下，两个子组变成平行结构 |

## 选择器影响面（先查后改，全列出来）

⚠️ **`PermissionCenterDiagnosticsExpanded` story 必须改** —— 它 play 函数**两个锚点都被这个 PR 删掉了**：按 `展开详情` 文本找按钮 → 点击 → 等 `[data-diagnostics="open"]`。

改成：找 `[data-readiness]` 内 `aria-expanded="false"` 的 trigger → 点击 → 等 `[data-readiness] button[aria-expanded="true"]`。

**用 `aria-expanded` 而不是再造一个 `data-diagnostics`**：那是 Collapsible 自己的 ARIA 契约，不需要页面手工维护一个属性专门给测试看。`data-readiness` 用来收窄作用域，避免抓到页面上别的可展开按钮。

✅ **e2e 无影响** —— `permission-mode-surface.spec.ts` 测的是 composer 的权限模式，不是这个页面。全仓搜过没有别的测试引用这页。

## 验证

| 步骤 | 结果 |
|---|---|
| `npm run build` | ✅ |
| `npm run typecheck` | ✅ 0 error |
| `npm run format:check` | ✅ |
| `check-dead-css.mjs --check` | ✅ |
| `test:checks`（console / a11y / copy） | ✅ |
| `check-story-annotations.mjs` | ✅ |
| **`build-storybook`** | ✅ |
| **`smoke:storybook`** | ✅ `permission-center-diagnostics-expanded` 通过 |
| workspace 测试 · **desktop** | ✅ |
| workspace 测试 · **ui** | ✅ |

截图（三态：收起 / 展开 / 单开互斥）跑的是**真实 Electron app** —— e2e fixture 不 stub permissions IPC，所以能力行显示的是这台机器真实的 TCC 状态，已发任务线程经设计侧确认。

**已知失败，与本 PR 无关：**
- `storage` / `cli` —— Node v25 打 `node:sqlite` ExperimentalWarning，那些测试断言 stderr 为空。既有问题。
- `runtime-host` —— 并行跑挂过一次（`elects one owner…` 所有权选举），**单独重跑连过两次**。timing flake。本 PR 只动 renderer，因果上不可能影响它。

@maka-审美专家 请 review diff（三处视觉修正按你的裁定做的，你说不用再发截图）。