### PR TITLE
test(desktop): await invocable Skill projection

### DIFF
--- a/apps/desktop/e2e/composer-skill-invocation.spec.ts
+++ b/apps/desktop/e2e/composer-skill-invocation.spec.ts
@@ -1,21 +1,12 @@
 import type { Page } from '@playwright/test';
-import { expect, test, COMPOSER_INPUT } from './fixtures';
+import { expect, test, COMPOSER_INPUT, waitForInvocableSkills } from './fixtures';
 
 async function createStarterSkillAndReload(page: Page): Promise<void> {
   const result = await page.evaluate(() => window.maka.skills.createStarter());
   expect(result.ok).toBe(true);
   await page.reload();
   await expect(page.locator(COMPOSER_INPUT)).toBeVisible();
-  // The `/` menu lists what the renderer has projected, and that projection is
-  // refreshed asynchronously after load. Wait for the Skill to be invocable so
-  // an empty first search is never mistaken for a missing suggestion.
-  await expect
-    .poll(async () =>
-      (await page.evaluate(() => window.maka.skills.listInvocable(undefined))).map(
-        (skill) => skill.id,
-      ),
-    )
-    .toContain('starter-skill');
+  await waitForInvocableSkills(page, ['starter-skill']);
 }
 
 /** The staged Skill's inline chip, addressed by the token it serializes to. */

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -22,6 +22,25 @@ const DESKTOP_ROOT = process.cwd();
 export const COMPOSER_INPUT = '.maka-composer-editor [contenteditable="true"]';
 
 /**
+ * Wait for Runtime's authoritative Skill projection, not merely for the
+ * composer DOM to mount. The renderer requests this projection after its first
+ * render, so a visible editor can still have an empty `/` source during cold
+ * start.
+ */
+export async function waitForInvocableSkills(
+  page: Page,
+  expectedIds: readonly string[],
+): Promise<void> {
+  await expect
+    .poll(async () =>
+      page.evaluate(async () =>
+        (await window.maka.skills.listInvocable(undefined)).map((skill) => skill.id),
+      ),
+    )
+    .toEqual(expect.arrayContaining(expectedIds));
+}
+
+/**
  * Pre-seed a real-looking connection into the throwaway workspace so onboarding
  * clears and the composer is enabled. Actual sessions still run on the fake
  * backend (BackendRegistry override in main); this only satisfies the UI
@@ -210,6 +229,9 @@ async function withE2eWindow(
     // Centralize the cold-start wait so test bodies are flake-free under retries:0.
     try {
       await page.waitForSelector(readinessSelector, { timeout: 20_000 });
+      if (invocableSkills) {
+        await waitForInvocableSkills(page, ['project-only', 'workspace-only']);
+      }
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       const mainDetail = mainLogs.length > 0 ? `\nElectron main console:\n${mainLogs.join('\n')}` : '';


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- make `invocableSkillsWindow` wait for its seeded Runtime invocable-Skill projection before handing the window to a test
- centralize that readiness check in `waitForInvocableSkills`
- reuse the same boundary for reload journeys that create Skills after startup

## Root cause

The fixture treated a visible composer as cold-start completion, while the `/` menu receives its authoritative Skill projection asynchronously after the renderer mounts. A test could therefore open the menu while its source was still the initial empty list and mistake `暂无技能` for the final discovery result.

Closes #2103.

## Validation

- Desktop production build completed successfully
- target E2E passed 15 consecutive single-worker runs across validation runs
- all invocable-Skill journeys passed in the full 64-test Desktop E2E run
- `git diff --check`

The full local E2E run also exposed unrelated existing failures in the MCP hover assertion and provider toast interception; neither fixture path executes the new invocable-Skill readiness branch.

</details>

<details>
<summary>中文</summary>

## 概要

- `invocableSkillsWindow` 现在会先等待预置的 Runtime 可调用 Skill 投影，再把窗口交给测试
- 将该就绪检查统一收敛到 `waitForInvocableSkills`
- reload 后新增 Skill 的测试路径复用同一个就绪边界

## 根因

fixture 原先把 composer 可见当作冷启动完成，但 `/` 菜单所依赖的权威 Skill 投影是在 renderer 挂载后异步到达的。因此测试可能在投影仍是初始空列表时打开菜单，并把 `暂无技能` 误判为最终发现结果。

Closes #2103。

## 验证

- Desktop production build 成功
- 目标 E2E 在多轮验证中以单 worker 连续通过 15 次
- 完整 64 项 Desktop E2E 中，所有 invocable-Skill 场景均通过
- `git diff --check`

完整本地 E2E 还暴露了 MCP hover 断言和 provider toast 遮挡的两个无关既有失败；这两个 fixture 路径均不会执行本次新增的 invocable-Skill 就绪分支。

</details>
