### PR TITLE
Gate managed workspace execution behind owner-bound authority

### DIFF
--- a/docs/architecture/runtime-managed-workspace-baseline-open-v1.zh-CN.md
+++ b/docs/architecture/runtime-managed-workspace-baseline-open-v1.zh-CN.md
@@ -1,8 +1,7 @@
 # Managed Workspace Baseline Open v1：M0 最终接受门
 
-- 状态：M0 实现与审查收口中；前置 Git Workspace Service、Workspace Version Authority 与
-  Managed Workspace Owner 合并后仍需从最新 `main` 平铺重建
-- 更新日期：2026-08-02
+- 状态：已合并；M1 execution admission 在其返回值上增加 owner-bound handle，不改变 M0 durable authority
+- 更新日期：2026-08-04
 - 主要不变量：只有经 Git artifact owner 持久化并重新验证的 exact baseline receipt，才能由同一
   storage-root lifecycle owner 提交给 SQLite workspace authority；Git artifact 单独成功不构成
   canonical workspace version
@@ -104,8 +103,10 @@ v1 receipt 严格包含：
 `ManagedWorkspaceOwner` 只暴露 `openManagedWorkspaceBaseline(...)` 与 lifecycle close。对应 receipt capability
 位于未被 package root 导出的 internal module，并通过实例绑定的 `WeakMap` 只交给该 owner。普通 package
 consumer 既不能预占一个 epoch 的 admission identity，也不能在 canonical acceptance 前取得 executable
-worktree path。未来 ToolRuntime 接入时只允许消费由该入口成功返回的 accepted handle；在真实 consumer 出现前，
-M0 不预设一个无消费者的 opaque-handle 抽象。
+worktree path。M1 execution admission 只允许消费由该入口成功返回的 owner-bound handle；handle 的 consumer
+是同一 `ManagedWorkspaceOwner.withManagedWorkspaceExecution(...)` 准入门，仍未把 cwd 暴露给 Desktop、CLI
+或 ToolRuntime。详细合同见
+[Managed Workspace Execution Admission v1](./runtime-managed-workspace-execution-admission-v1.zh-CN.md)。
 
 receipt 不保存 wall-clock `committedAt`：artifact owner 无法从 Git evidence 重新证明该时间，允许它进入 receipt
 会让 orphan receipt 篡改污染 canonical event 时间。M0 的 baseline authority 使用协议固定逻辑时间 `0`；

--- a/docs/architecture/runtime-managed-workspace-execution-admission-v1.zh-CN.md
+++ b/docs/architecture/runtime-managed-workspace-execution-admission-v1.zh-CN.md
@@ -1,10 +1,11 @@
 # Managed Workspace Execution Admission v1：M1.1 可撤销 scope 门
 
-- 状态：实现中
+- 状态：M1.1 已实现；尚无 runtime-host / Desktop / CLI 生产消费者
 - 更新日期：2026-08-04
-- 主要不变量：同一个 `ManagedWorkspaceOwner` 只能用其亲自签发的进程内 execution handle 创建一次 active
-  execution scope；每次创建 scope 前重新证明 exact SQLite workspace head 与 exact Git artifact，公共 API
-  永不发布 raw cwd，callback 退出后 scope 立即失效
+- 主要不变量：同一个 `ManagedWorkspaceOwner` 只能用其亲自签发的进程内 execution handle 创建 active
+  execution scope；一次 admission 只签发一个 scope，但同一 handle 允许多个只读 admission 并发。每次创建
+  scope 前重新证明 exact SQLite workspace head 与 exact Git artifact，公共 API 永不发布 raw cwd，callback
+  退出后 scope 立即失效
 - lifecycle / admission owner：`ManagedWorkspaceOwner`
 - durable truth：SQLite immutable workspace RuntimeEvents
 - artifact evidence：Maka-owned Git binding、baseline receipt、HEAD/tree 与 ownership lock
@@ -27,7 +28,9 @@ await owner.withManagedWorkspaceExecution(accepted.executionHandle, async (scope
 `openManagedWorkspaceBaseline(...)` 不再公开 raw binding、receipt 或 `worktreePath`。handle 的内部证据保存在
 未从 package root 导出的模块中，并使用 `WeakMap` 与 owner token 绑定；复制相同字段或使用另一个 owner 的
 handle 都不能获得执行权限。scope 同样由 `WeakMap` 保存真实状态，callback 退出后即使被闭包保留也只能得到
-`managed_workspace_execution_scope_expired`。
+typed `ManagedWorkspaceExecutionAuthorityError`，其稳定 code 为
+`managed_workspace_execution_scope_expired`；伪造 scope 的 code 为
+`managed_workspace_execution_scope_invalid`。
 
 本切片没有接入 Desktop、CLI 或 ToolRuntime。它只建立 host 后续接线必须消费的唯一准入 API，不同时跨越
 runtime protocol、host lifecycle 与工具 I/O 三个边界。
@@ -39,7 +42,7 @@ runtime protocol、host lifecycle 与工具 I/O 三个边界。
 | execution admission owner | 只有签发 handle 的同一个 `ManagedWorkspaceOwner` 可以消费它 |
 | durable authority | handle/scope 都不是 durable fact；canonical head 通过注册时捕获的 storage-internal reader 读取，不调用可被 caller shadow 的 public method |
 | 原子性边界 | 不虚构 Git 与 SQLite 之外的新事务；在 owner/root lease residency 内完成 final root/DB/head proof，再以 exact receipt/binding/Git verification 作为 scope 签发前最后一个 await |
-| 执行期间 | callback 计入 owner active operation；`close()` 等它 drain，新 admission 在 closing 后被拒绝 |
+| 执行期间 | 每个 callback 分别计入 owner active operation；同一 handle 可并发多个 `workspaceEffect: none` scope；`close()` 等全部 scope drain，新 admission 在 closing 后被拒绝 |
 | invalid handle | `managed_workspace_execution_handle_invalid`；不签发 scope |
 | canonical head 漂移/缺失 | fail closed；旧 handle 不能自行选择新 head |
 | artifact drift | 不签发 scope；所有 Git verification 阶段的 `managed_workspace_drifted` 统一 quarantine |
@@ -71,7 +74,9 @@ sequenceDiagram
 ```
 
 这不是跨 SQLite/Git/filesystem 的共同事务。它关闭 cooperating Maka writer 的 proof-to-scope seam；任意外部
-进程仍可能在最后一次 filesystem observation 后制造 drift，后续 admission 会 fail closed。M1.2 的 worker/
+进程仍可能在最后一次 filesystem observation 后制造 drift，后续 admission 会 fail closed。普通生产路径只执行
+图中的一次 final Git verification；只有配置 production-shaped crash failpoint 的测试路径才先执行一次 preliminary
+verification，以便在真实 proof 完成后 `SIGKILL`，随后仍必须再次执行 final verification 才能签发 scope。M1.2 的 worker/
 sandbox 建立实际 I/O 隔离，M2 才负责 mutating tool 产生 successor candidate 并接受新 workspace version。
 
 ## 4. Provisioning 与实际可用性边界
@@ -95,8 +100,9 @@ ignored dependency、secret 与 scratch overlay 必须作为独立 M1 provisioni
 |---|---|
 | baseline 已接受，签发 handle 前崩溃 | 重启后从 canonical head 与 receipt 重新签发新 handle |
 | execution verification 中崩溃 | 没有 durable “half admission”；旧 handle 随进程消失 |
-| preliminary verification 后 drift | final exact receipt/Git verification 检测并 quarantine；scope 不签发 |
-| callback 运行时 owner close | close 等 callback drain；不取消已 admission operation |
+| crash-test preliminary verification 后 drift | final exact receipt/Git verification 检测并 quarantine；scope 不签发 |
+| 同一 handle 的两个只读 callback 并发 | 两个 scope 可同时 active，彼此独立 revoke |
+| 多个 callback 运行时 owner close | close 等全部 callback drain；不取消已 admission operation |
 | closing 后新 execution 请求 | `managed_workspace_owner_closing` |
 | forged / cross-owner handle | `managed_workspace_execution_handle_invalid` |
 | callback 保存 scope 后再次使用 | scope 已 expired，internal consumer 必须拒绝 |
@@ -105,7 +111,8 @@ ignored dependency、secret 与 scratch overlay 必须作为独立 M1 provisioni
 | 重启后恢复 | 新 root owner、新 managed owner、新 handle；不可恢复旧进程内 capability |
 
 production-shaped 测试使用真实 pinned Git、真实 SQLite、真实子进程和 `SIGKILL`，证明 execution artifact
-verification 中断后，重启只能经完整 reopen/revalidate 获得新 scope authority。
+verification 中断后，重启只能经完整 reopen/revalidate 获得新 scope authority；真实 Git 并发测试证明两个
+只读 scope 可以并行，且 `close()` 必须等待二者全部退出。
 
 ## 6. 平台能力矩阵
 

--- a/docs/architecture/runtime-managed-workspace-execution-admission-v1.zh-CN.md
+++ b/docs/architecture/runtime-managed-workspace-execution-admission-v1.zh-CN.md
@@ -1,10 +1,10 @@
-# Managed Workspace Execution Admission v1：M1.1 cwd 发布门
+# Managed Workspace Execution Admission v1：M1.1 可撤销 scope 门
 
 - 状态：实现中
 - 更新日期：2026-08-04
-- 主要不变量：工具只能由同一个 `ManagedWorkspaceOwner` 消费其亲自签发的进程内 execution handle，并在
-  每次执行前重新证明 exact SQLite workspace head 与 exact Git artifact 后，才能在受 drain 管理的 callback
-  内短暂取得 managed cwd
+- 主要不变量：同一个 `ManagedWorkspaceOwner` 只能用其亲自签发的进程内 execution handle 创建一次 active
+  execution scope；每次创建 scope 前重新证明 exact SQLite workspace head 与 exact Git artifact，公共 API
+  永不发布 raw cwd，callback 退出后 scope 立即失效
 - lifecycle / admission owner：`ManagedWorkspaceOwner`
 - durable truth：SQLite immutable workspace RuntimeEvents
 - artifact evidence：Maka-owned Git binding、baseline receipt、HEAD/tree 与 ownership lock
@@ -12,21 +12,22 @@
 ## 1. 本切片交付什么
 
 M0 已经能创建或 exact-adopt 一个 managed baseline，并把 Git receipt 与 SQLite canonical head 组合接受。
-但如果 M0 直接返回 `worktreePath`，调用者可以永久缓存 cwd，绕过 owner close、后续 revalidation 和未来
-workspace version 变化。因此 M1.1 把 executable path 改成不可伪造、不可持久化、绑定具体 owner 实例的
-execution handle。
+但 raw `worktreePath` 是不可撤销字符串，调用者可以永久缓存并绕过 owner close、后续 revalidation 和未来
+workspace version 变化。因此 M1.1 使用两级进程内 capability：baseline 返回 owner-bound execution handle；
+每次 admission callback 只得到 active execution scope，不得到 path。
 
 ```ts
 const accepted = await owner.openManagedWorkspaceBaseline(store, identity);
 
-await owner.withManagedWorkspaceExecution(accepted.executionHandle, async (context) => {
-  // 只有这个 callback 内可以把 context.cwd 交给受控工具执行层。
+await owner.withManagedWorkspaceExecution(accepted.executionHandle, async (scope) => {
+  // M1.2 的 storage-internal worker bridge 才能消费 active scope。
 });
 ```
 
 `openManagedWorkspaceBaseline(...)` 不再公开 raw binding、receipt 或 `worktreePath`。handle 的内部证据保存在
 未从 package root 导出的模块中，并使用 `WeakMap` 与 owner token 绑定；复制相同字段或使用另一个 owner 的
-handle 都不能获得 cwd。
+handle 都不能获得执行权限。scope 同样由 `WeakMap` 保存真实状态，callback 退出后即使被闭包保留也只能得到
+`managed_workspace_execution_scope_expired`。
 
 本切片没有接入 Desktop、CLI 或 ToolRuntime。它只建立 host 后续接线必须消费的唯一准入 API，不同时跨越
 runtime protocol、host lifecycle 与工具 I/O 三个边界。
@@ -36,13 +37,13 @@ runtime protocol、host lifecycle 与工具 I/O 三个边界。
 | 项目 | 决策 |
 |---|---|
 | execution admission owner | 只有签发 handle 的同一个 `ManagedWorkspaceOwner` 可以消费它 |
-| durable authority | handle 不是 durable fact；每次调用都重新读取 SQLite canonical head，并验证 durable Git receipt |
-| 原子性边界 | 不虚构 Git 与 SQLite 之外的新事务；在 owner/root lease residency 内完成“读 head → 验 Git → 最终 reopen/revalidate → 发布 cwd callback” |
+| durable authority | handle/scope 都不是 durable fact；canonical head 通过注册时捕获的 storage-internal reader 读取，不调用可被 caller shadow 的 public method |
+| 原子性边界 | 不虚构 Git 与 SQLite 之外的新事务；在 owner/root lease residency 内完成 final root/DB/head proof，再以 exact receipt/binding/Git verification 作为 scope 签发前最后一个 await |
 | 执行期间 | callback 计入 owner active operation；`close()` 等它 drain，新 admission 在 closing 后被拒绝 |
-| invalid handle | `managed_workspace_execution_handle_invalid`；不读取或发布 cwd |
+| invalid handle | `managed_workspace_execution_handle_invalid`；不签发 scope |
 | canonical head 漂移/缺失 | fail closed；旧 handle 不能自行选择新 head |
-| artifact drift | 不发布 cwd；可证明的外部 drift 按 Git owner 协议 quarantine |
-| verification 后竞态 | cwd 发布前再次 exact-open；该窗口出现 drift 时 quarantine，而不是使用旧验证结果 |
+| artifact drift | 不签发 scope；所有 Git verification 阶段的 `managed_workspace_drifted` 统一 quarantine |
+| mutation permission | scope 固定 `workspaceEffect: none`；M2 前没有 raw cwd consumer，Write/Edit/Bash/未知工具不得接入 |
 | 回滚 | 无新增 schema 或 durable admission row；停止调用 API 即回滚能力，已接受的 baseline history 与 artifact 不变 |
 
 ## 3. 每次执行的时序
@@ -53,28 +54,30 @@ sequenceDiagram
   participant O as "ManagedWorkspaceOwner"
   participant S as "SQLite workspace authority"
   participant G as "Git artifact owner"
-  participant T as "Tool callback"
+  participant T as "Scope callback"
 
   H->>O: withManagedWorkspaceExecution(handle, callback)
   O->>O: 验证 handle 属于本 owner，进入 drain residency
-  O->>S: 读取 exact workspace/epoch canonical head
+  O->>S: internal reader 读取 exact workspace/epoch canonical head
   S-->>O: accepted WorkspaceHead
-  O->>G: exact open binding + verify receipt/HEAD/tree/lock
+  O->>O: exact compare frozen expected head + full cross-plane identity
+  O->>O: final root marker / runtime.sqlite pathname+inode guard
+  O->>S: final internal head reread
+  O->>G: one-shot exact receipt/binding/HEAD/tree/lock verification
   G-->>O: verified artifact
-  O->>G: 发布前再次 exact open（关闭 verify→cwd 竞态）
-  G-->>O: same ready artifact
-  O->>O: 最终 root marker / DB identity guard
-  O->>T: callback({ cwd, exact identity, canonical_tree_only_v1 })
+  O->>T: callback(active opaque scope)
   T-->>O: result / error
-  O->>O: 释放 active residency；允许 close 收敛
+  O->>O: revoke scope；释放 active residency；允许 close 收敛
 ```
 
-这不是 filesystem transaction。M1.1 保证的是“未经重新证明的 cwd 永不发布”；M2 才负责 mutating tool
-产生 successor candidate 并由 SQLite 接受新 workspace version。
+这不是跨 SQLite/Git/filesystem 的共同事务。它关闭 cooperating Maka writer 的 proof-to-scope seam；任意外部
+进程仍可能在最后一次 filesystem observation 后制造 drift，后续 admission 会 fail closed。M1.2 的 worker/
+sandbox 建立实际 I/O 隔离，M2 才负责 mutating tool 产生 successor candidate 并接受新 workspace version。
 
 ## 4. Provisioning 与实际可用性边界
 
-本切片唯一合法 provisioning 值是 `canonical_tree_only_v1`。它明确表示 cwd 只包含 accepted Git tree：
+本切片 scope 的 provisioning 固定为 `canonical_tree_only_v1`，且 `workspaceEffect` 固定为 `none`。底层
+artifact 只包含 accepted Git tree：
 
 - 不复制 source checkout 的 ignored/untracked 文件；
 - 不复制 `.env`、credential、`node_modules` 或 build cache；
@@ -92,15 +95,17 @@ ignored dependency、secret 与 scratch overlay 必须作为独立 M1 provisioni
 |---|---|
 | baseline 已接受，签发 handle 前崩溃 | 重启后从 canonical head 与 receipt 重新签发新 handle |
 | execution verification 中崩溃 | 没有 durable “half admission”；旧 handle 随进程消失 |
-| verification 后、cwd callback 前 drift | 最终 exact-open 检测并 quarantine；callback 不执行 |
+| preliminary verification 后 drift | final exact receipt/Git verification 检测并 quarantine；scope 不签发 |
 | callback 运行时 owner close | close 等 callback drain；不取消已 admission operation |
 | closing 后新 execution 请求 | `managed_workspace_owner_closing` |
 | forged / cross-owner handle | `managed_workspace_execution_handle_invalid` |
+| callback 保存 scope 后再次使用 | scope 已 expired，internal consumer 必须拒绝 |
+| callback 抛错 | scope 仍在 finally 中 revoke，owner residency 正常释放 |
 | 用户直接编辑 Maka-owned worktree | 系统不能物理阻止；下一次 admission 检测 drift 并 fail closed/quarantine |
 | 重启后恢复 | 新 root owner、新 managed owner、新 handle；不可恢复旧进程内 capability |
 
 production-shaped 测试使用真实 pinned Git、真实 SQLite、真实子进程和 `SIGKILL`，证明 execution artifact
-verification 中断后，重启只能经完整 reopen/revalidate 获得新 cwd authority。
+verification 中断后，重启只能经完整 reopen/revalidate 获得新 scope authority。
 
 ## 6. 平台能力矩阵
 
@@ -115,8 +120,11 @@ verification 中断后，重启只能经完整 reopen/revalidate 获得新 cwd a
 
 ## 7. 后续切片
 
-1. M1.2：runtime-host lifecycle 组合与 managed/attached typed profile；只允许 host 在 callback 内向 worker
-   传递 cwd，关闭顺序为 tool operations → managed owner → root owner。
+1. M1.2：runtime-host lifecycle 组合与 managed/attached typed profile；storage-internal worker bridge 消费
+   active scope 并在内部解析 cwd，公共 host 仍不获得 path。managed profile 在 M2 前只允许
+   `workspaceEffect: none` 的 Read/Glob/Grep 类工具；Write/Edit/Bash/未知工具 fail closed。关闭顺序为
+   tool operations → managed owner → root owner；同时用 execution-context guard 拒绝 callback 内 reentrant
+   `owner.close()`，避免 callback 与自身 drain 互等。
 2. M1.3：显式 dependency/secret/scratch provisioning；首版若无法安全提供则保持
    `canonical_tree_only_v1`，不能 silent fallback。
 3. M2：mutation candidate capture/accept；T1 前冻结 profile/base version，SQLite 原子接受 tool outcome

--- a/docs/architecture/runtime-managed-workspace-execution-admission-v1.zh-CN.md
+++ b/docs/architecture/runtime-managed-workspace-execution-admission-v1.zh-CN.md
@@ -1,0 +1,125 @@
+# Managed Workspace Execution Admission v1：M1.1 cwd 发布门
+
+- 状态：实现中
+- 更新日期：2026-08-04
+- 主要不变量：工具只能由同一个 `ManagedWorkspaceOwner` 消费其亲自签发的进程内 execution handle，并在
+  每次执行前重新证明 exact SQLite workspace head 与 exact Git artifact 后，才能在受 drain 管理的 callback
+  内短暂取得 managed cwd
+- lifecycle / admission owner：`ManagedWorkspaceOwner`
+- durable truth：SQLite immutable workspace RuntimeEvents
+- artifact evidence：Maka-owned Git binding、baseline receipt、HEAD/tree 与 ownership lock
+
+## 1. 本切片交付什么
+
+M0 已经能创建或 exact-adopt 一个 managed baseline，并把 Git receipt 与 SQLite canonical head 组合接受。
+但如果 M0 直接返回 `worktreePath`，调用者可以永久缓存 cwd，绕过 owner close、后续 revalidation 和未来
+workspace version 变化。因此 M1.1 把 executable path 改成不可伪造、不可持久化、绑定具体 owner 实例的
+execution handle。
+
+```ts
+const accepted = await owner.openManagedWorkspaceBaseline(store, identity);
+
+await owner.withManagedWorkspaceExecution(accepted.executionHandle, async (context) => {
+  // 只有这个 callback 内可以把 context.cwd 交给受控工具执行层。
+});
+```
+
+`openManagedWorkspaceBaseline(...)` 不再公开 raw binding、receipt 或 `worktreePath`。handle 的内部证据保存在
+未从 package root 导出的模块中，并使用 `WeakMap` 与 owner token 绑定；复制相同字段或使用另一个 owner 的
+handle 都不能获得 cwd。
+
+本切片没有接入 Desktop、CLI 或 ToolRuntime。它只建立 host 后续接线必须消费的唯一准入 API，不同时跨越
+runtime protocol、host lifecycle 与工具 I/O 三个边界。
+
+## 2. Owner、原子性边界、失败状态与回滚
+
+| 项目 | 决策 |
+|---|---|
+| execution admission owner | 只有签发 handle 的同一个 `ManagedWorkspaceOwner` 可以消费它 |
+| durable authority | handle 不是 durable fact；每次调用都重新读取 SQLite canonical head，并验证 durable Git receipt |
+| 原子性边界 | 不虚构 Git 与 SQLite 之外的新事务；在 owner/root lease residency 内完成“读 head → 验 Git → 最终 reopen/revalidate → 发布 cwd callback” |
+| 执行期间 | callback 计入 owner active operation；`close()` 等它 drain，新 admission 在 closing 后被拒绝 |
+| invalid handle | `managed_workspace_execution_handle_invalid`；不读取或发布 cwd |
+| canonical head 漂移/缺失 | fail closed；旧 handle 不能自行选择新 head |
+| artifact drift | 不发布 cwd；可证明的外部 drift 按 Git owner 协议 quarantine |
+| verification 后竞态 | cwd 发布前再次 exact-open；该窗口出现 drift 时 quarantine，而不是使用旧验证结果 |
+| 回滚 | 无新增 schema 或 durable admission row；停止调用 API 即回滚能力，已接受的 baseline history 与 artifact 不变 |
+
+## 3. 每次执行的时序
+
+```mermaid
+sequenceDiagram
+  participant H as "Runtime host（后续消费者）"
+  participant O as "ManagedWorkspaceOwner"
+  participant S as "SQLite workspace authority"
+  participant G as "Git artifact owner"
+  participant T as "Tool callback"
+
+  H->>O: withManagedWorkspaceExecution(handle, callback)
+  O->>O: 验证 handle 属于本 owner，进入 drain residency
+  O->>S: 读取 exact workspace/epoch canonical head
+  S-->>O: accepted WorkspaceHead
+  O->>G: exact open binding + verify receipt/HEAD/tree/lock
+  G-->>O: verified artifact
+  O->>G: 发布前再次 exact open（关闭 verify→cwd 竞态）
+  G-->>O: same ready artifact
+  O->>O: 最终 root marker / DB identity guard
+  O->>T: callback({ cwd, exact identity, canonical_tree_only_v1 })
+  T-->>O: result / error
+  O->>O: 释放 active residency；允许 close 收敛
+```
+
+这不是 filesystem transaction。M1.1 保证的是“未经重新证明的 cwd 永不发布”；M2 才负责 mutating tool
+产生 successor candidate 并由 SQLite 接受新 workspace version。
+
+## 4. Provisioning 与实际可用性边界
+
+本切片唯一合法 provisioning 值是 `canonical_tree_only_v1`。它明确表示 cwd 只包含 accepted Git tree：
+
+- 不复制 source checkout 的 ignored/untracked 文件；
+- 不复制 `.env`、credential、`node_modules` 或 build cache；
+- 不自动运行安装命令；
+- 不把 scratch/build output 偷偷写入 canonical baseline；
+- 不从 managed profile 静默 fallback 到 attached checkout。
+
+因此 M1.1 可用于验证纯 tracked-tree 读取和后续受控工具接线，但还不宣称一般开发任务已经可用。
+ignored dependency、secret 与 scratch overlay 必须作为独立 M1 provisioning 切片，写明数据来源、生命周期、
+泄露边界和清理方式后才能接入。
+
+## 5. Crash、并发与外部 drift 矩阵
+
+| 场景 | 必须结果 |
+|---|---|
+| baseline 已接受，签发 handle 前崩溃 | 重启后从 canonical head 与 receipt 重新签发新 handle |
+| execution verification 中崩溃 | 没有 durable “half admission”；旧 handle 随进程消失 |
+| verification 后、cwd callback 前 drift | 最终 exact-open 检测并 quarantine；callback 不执行 |
+| callback 运行时 owner close | close 等 callback drain；不取消已 admission operation |
+| closing 后新 execution 请求 | `managed_workspace_owner_closing` |
+| forged / cross-owner handle | `managed_workspace_execution_handle_invalid` |
+| 用户直接编辑 Maka-owned worktree | 系统不能物理阻止；下一次 admission 检测 drift 并 fail closed/quarantine |
+| 重启后恢复 | 新 root owner、新 managed owner、新 handle；不可恢复旧进程内 capability |
+
+production-shaped 测试使用真实 pinned Git、真实 SQLite、真实子进程和 `SIGKILL`，证明 execution artifact
+verification 中断后，重启只能经完整 reopen/revalidate 获得新 cwd authority。
+
+## 6. 平台能力矩阵
+
+| 能力 | Linux | macOS | Windows |
+|---|---|---|---|
+| owner-bound opaque handle | 支持 | 支持 | 支持 |
+| exact SQLite/Git/head/tree revalidation | 支持 | 支持 | 支持 |
+| callback drain | 支持 | 支持 | 支持 |
+| process crash 后重新准入 | 支持 | 支持 | 支持（进程级；不宣称断电 durability） |
+| external drift quarantine | 支持 | 支持 | 有限支持，沿用 Git artifact owner 的 Windows 保证 |
+| power-loss durability | 不承诺 | 不承诺 | 不承诺 |
+
+## 7. 后续切片
+
+1. M1.2：runtime-host lifecycle 组合与 managed/attached typed profile；只允许 host 在 callback 内向 worker
+   传递 cwd，关闭顺序为 tool operations → managed owner → root owner。
+2. M1.3：显式 dependency/secret/scratch provisioning；首版若无法安全提供则保持
+   `canonical_tree_only_v1`，不能 silent fallback。
+3. M2：mutation candidate capture/accept；T1 前冻结 profile/base version，SQLite 原子接受 tool outcome
+   与 successor workspace version。
+
+在 M1.2 出现真实生产消费者前，本切片不默认开启 managed execution，也不改变 attached mode。

--- a/docs/architecture/runtime-managed-workspace-owner-v1.zh-CN.md
+++ b/docs/architecture/runtime-managed-workspace-owner-v1.zh-CN.md
@@ -1,7 +1,7 @@
 # Managed Workspace Owner v1：M0 生命周期门
 
-- 状态：实现完成；Git Workspace Service 与 Workspace Version Authority 合并后平铺重建
-- 更新日期：2026-08-02
+- 状态：已合并；M1 execution admission 继续复用本 owner 的 lifecycle/drain 门
+- 更新日期：2026-08-04
 - 主要不变量：一个 authenticated interactive storage-root owner 在其生命周期内至多发布一个
   managed workspace owner；已经 admission 的 workspace 操作必须在关闭前 drain
 - artifact owner：`GitWorkspaceService`
@@ -56,10 +56,12 @@ stateDiagram-v2
 
 ## 4. Workspace gate
 
-owner 的 public surface 只开放一个 workspace admission 操作：
+owner 的 public surface 开放两个连续、不可绕过的 workspace admission 操作：
 
 1. `openManagedWorkspaceBaseline(store, identity)` 从 eligible clean source 创建/exact-adopt artifact，
-   持久化并复验 receipt，再由 storage-internal writer 接受 canonical baseline。
+   持久化并复验 receipt，再由 storage-internal writer 接受 canonical baseline，返回 owner-bound execution handle；
+2. `withManagedWorkspaceExecution(handle, callback)` 在每次执行前重新证明 canonical head、receipt、HEAD/tree、
+   ownership 与 root identity，只在 drain-managed callback 中发布 cwd。
 
 artifact-only create/open 和 `GitWorkspaceService` factory 不从 package root 导出。调用者不能在 SQLite
 acceptance 前取得 `worktreePath` 或裸 `ManagedWorkspaceBinding`。入口返回前必须验证 worktree、index、
@@ -69,6 +71,9 @@ HEAD、tree、ownership lock、canonical `runtime.sqlite` pathname/inode、durab
 
 本切片不扫描目录来猜测 workspace identity。Baseline Open Bundle 通过 Git artifact owner 的 durable
 receipt 与 canonical workspace authority 绑定 exact identity；未接受 Git artifact 属于 orphan GC 范畴。
+
+M1 execution admission 的详细合同见
+[Managed Workspace Execution Admission v1](./runtime-managed-workspace-execution-admission-v1.zh-CN.md)。
 
 ## 5. Crash 与并发证明
 
@@ -98,7 +103,7 @@ reopen/repair，最后才允许 baseline authority read”的组合顺序。
 
 ## 7. 明确延期
 
-- Desktop、CLI、runtime-host 接线与 managed-mode 设置；
+- Desktop、CLI、runtime-host 接线与 managed-mode 设置；execution admission API 已建立，但尚无生产 host consumer；
 - filesystem worker、mutation coordinator 与工具 cwd 切换；
 - candidate refs、mutation repair、GC、replication outbox；
 - ignored dependencies、build/test environment provisioning；
@@ -108,4 +113,4 @@ reopen/repair，最后才允许 baseline authority read”的组合顺序。
 
 这些能力不能借 owner lifecycle PR 顺手接入。Baseline Open Bundle 已作为本 owner 的第一个
 canonical-fact consumer 完成组合，证明 Git baseline 与 RuntimeEvent baseline 不会只成功一半；后续
-M1 execution admission 仍必须从该 bundle 成功返回的结果进入，不能重新开放 artifact-only 旁路。
+M1 execution admission 已从该 bundle 返回的 owner-bound handle 进入，未重新开放 artifact-only 旁路。

--- a/docs/architecture/runtime-managed-workspace-owner-v1.zh-CN.md
+++ b/docs/architecture/runtime-managed-workspace-owner-v1.zh-CN.md
@@ -61,7 +61,8 @@ owner 的 public surface 开放两个连续、不可绕过的 workspace admissio
 1. `openManagedWorkspaceBaseline(store, identity)` 从 eligible clean source 创建/exact-adopt artifact，
    持久化并复验 receipt，再由 storage-internal writer 接受 canonical baseline，返回 owner-bound execution handle；
 2. `withManagedWorkspaceExecution(handle, callback)` 在每次执行前重新证明 canonical head、receipt、HEAD/tree、
-   ownership 与 root identity，只在 drain-managed callback 中发布 cwd。
+   ownership 与 root identity，只在 drain-managed callback 中签发可撤销 opaque scope；raw cwd 不进入
+   public API。
 
 artifact-only create/open 和 `GitWorkspaceService` factory 不从 package root 导出。调用者不能在 SQLite
 acceptance 前取得 `worktreePath` 或裸 `ManagedWorkspaceBinding`。入口返回前必须验证 worktree、index、

--- a/docs/architecture/runtime-resume-architecture.md
+++ b/docs/architecture/runtime-resume-architecture.md
@@ -736,6 +736,18 @@ Layer responsibilities:
 
 The Runtime host uses strict recovery stores. It does not silently turn an unreadable ledger into best-effort fallback before admitting new writes.
 
+### Managed workspace execution admission (M1.1)
+
+The workspace plane now has a storage-owned execution-admission foundation, but it is not yet wired into the Runtime host:
+
+- baseline open returns an opaque handle bound to its `ManagedWorkspaceOwner`, never a raw cwd;
+- every admission reproves storage-root identity, the exact SQLite canonical head, and the exact Git receipt/binding/HEAD/tree/ownership; the ordinary production path performs one final Git verification immediately before scope issuance;
+- one admission issues one callback-scoped opaque scope with `workspaceEffect: none`; the same handle may have multiple concurrent read-only scopes;
+- `close()` rejects new admissions and drains every active scope; a scope expires when its callback exits, with typed `managed_workspace_execution_scope_invalid` and `managed_workspace_execution_scope_expired` codes for forged and retained scopes;
+- the crash harness may enable a preliminary-verification failpoint, but that test path must still pass the final verification before any scope is issued.
+
+This proves only the proof-to-scope seam for cooperating Maka writers; it does not make workspace-bound resume available. M1.2 still needs a real storage-internal worker consumer, typed managed/attached profiles, a read-only tool allowlist, a reentrant `close()` guard inside execution callbacks, and shutdown ordering of tool operations → managed owner → root owner. Until those gates exist, Desktop, CLI, and Runtime host must not receive a raw managed cwd; Write/Edit/Bash/unknown tools must fail closed; and managed mode must never silently fall back to the attached checkout. See [Managed Workspace Execution Admission v1](./runtime-managed-workspace-execution-admission-v1.zh-CN.md) for the detailed contract.
+
 ### Headless / Harbor
 
 Runtime provides immutable history high-water and replay gates, but Attempt resume additionally needs:

--- a/docs/architecture/runtime-resume-architecture.zh-CN.md
+++ b/docs/architecture/runtime-resume-architecture.zh-CN.md
@@ -767,6 +767,18 @@ flowchart LR
 
 Runtime host 使用 strict recovery stores 执行 startup repair。严格模式不会把 unreadable ledger 吞成 best-effort fallback，适合服务端 composition 在接收新写入前建立清楚的恢复边界。
 
+### Managed workspace execution admission（M1.1）
+
+Resume 的 workspace plane 已经有一层 storage-owned 的执行准入地基，但它还没有接入 Runtime host：
+
+- baseline open 只返回绑定 `ManagedWorkspaceOwner` 的 opaque handle，不公开 raw cwd；
+- 每次 admission 都重新证明 storage-root identity、exact SQLite canonical head 和 exact Git receipt/binding/HEAD/tree/ownership；普通生产路径只在签发 scope 前做一次最终 Git verification；
+- 一次 admission 签发一个 callback-scoped、`workspaceEffect: none` 的 opaque scope；同一 handle 可以并发多个只读 scope；
+- `close()` 拒绝新 admission，并等待所有 active scope drain；callback 退出后 scope 立即失效，伪造与过期分别返回 typed `managed_workspace_execution_scope_invalid` / `managed_workspace_execution_scope_expired`；
+- crash harness 可配置 preliminary-verification failpoint，但该测试路径仍须再次通过 final verification 才能签发 scope。
+
+这只证明 cooperating Maka writer 下的 proof-to-scope seam，不等于 workspace-bound resume 已可用。M1.2 仍须提供真实的 storage-internal worker consumer、managed/attached typed profile、只读工具 allowlist、callback 内 reentrant `close()` guard，以及 tool operations → managed owner → root owner 的关闭顺序。在这些门完成前，Desktop、CLI、Runtime host 都不得获得 raw managed cwd，Write/Edit/Bash/未知工具必须 fail closed，也不得从 managed mode 静默 fallback 到 attached checkout。详细合同见 [Managed Workspace Execution Admission v1](./runtime-managed-workspace-execution-admission-v1.zh-CN.md)。
+
 ### Headless / Harbor
 
 当前 Runtime resume 可以提供 immutable history high-water 和 replay gate，但 timeout Attempt 的真正恢复还必须绑定：

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -561,7 +561,10 @@ M1 拆成独立不变量，避免一次 PR 同时跨越 host lifecycle、runtime
 1. **M1.1 execution scope admission（当前切片）**：M0 只返回 owner-bound opaque handle；同一 owner 每次
    execution 都在 drain residency 内重新证明 canonical head、Git receipt、HEAD/tree/ownership 与 root
    identity，最后只签发 callback 生命周期内有效的 opaque scope，不公开 raw cwd。provisioning 固定为
-   `canonical_tree_only_v1`，`workspaceEffect` 固定为 `none`；
+   `canonical_tree_only_v1`，`workspaceEffect` 固定为 `none`。同一 handle 可以并发多个只读 admission，
+   `close()` 必须等待全部 active scope drain；普通生产 admission 只做一次最终 Git verification，preliminary
+   verification 仅存在于配置 crash failpoint 的 production-shaped 测试路径；过期或伪造 scope 通过 typed
+   `ManagedWorkspaceExecutionAuthorityError` 的稳定 code fail closed；
 2. **M1.2 runtime-host composition**：建立 managed/attached typed profile、startup/drain/shutdown 顺序，并让
    storage-internal worker bridge 只能用 active scope 解析 cwd；
 3. **M1.3 environment provisioning**：单独设计 ignored dependency、secret 与 scratch overlay。M1.1 不复制

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -528,7 +528,7 @@ RuntimeEvents 决定 Maka 是否接受某个文件版本；Git commit、ref、re
 
 ## 4. Git-native managed workspace 演进
 
-### M0 — Baseline admission（当前切片）
+### M0 — Baseline admission（已合并）
 
 M0 只证明一条接受链：
 
@@ -555,6 +555,19 @@ baseline open 中。
 - ignored dependencies、`.env` 与 build scratch 使用明确 provisioning/overlay policy，不污染 canonical tree；
 - 外部修改 Maka-owned worktree 时检测 drift、fail closed 并 quarantine；
 - attached 与 managed execution profile 在类型和配置上不可静默互相 fallback。
+
+M1 拆成独立不变量，避免一次 PR 同时跨越 host lifecycle、runtime protocol 与 platform I/O：
+
+1. **M1.1 execution cwd admission（当前切片）**：M0 只返回 owner-bound opaque handle；同一 owner 每次
+   execution 都在 drain residency 内重新证明 canonical head、Git receipt、HEAD/tree/ownership 与 root
+   identity，最后才在 callback 中发布 cwd。provisioning 固定为 `canonical_tree_only_v1`；
+2. **M1.2 runtime-host composition**：建立 managed/attached typed profile、startup/drain/shutdown 顺序，并让
+   worker 只能在 callback 内取得 cwd；
+3. **M1.3 environment provisioning**：单独设计 ignored dependency、secret 与 scratch overlay。M1.1 不复制
+   `.env`、`node_modules` 或 build output，也不以 attached checkout silent fallback 掩盖能力缺失。
+
+M1.1 合同见
+[Managed Workspace Execution Admission v1](./runtime-managed-workspace-execution-admission-v1.zh-CN.md)。
 
 ### M2 — Mutation version acceptance
 
@@ -601,11 +614,13 @@ Git-native workspace:
 M0.1 Git artifact owner (merged)
   + M0.2 workspace version authority (merged)
   + M0.3 managed owner lifecycle (merged)
-  └─> M0.4 baseline open bundle (current)
-       └─> M1 execution admission / provisioning
-            └─> M2 mutation version acceptance
-                 └─> M3 workspace-bound continuation
-                      └─> M4 restore / rebaseline / publish / replication
+  └─> M0.4 baseline open bundle (merged)
+       └─> M1.1 execution cwd admission (current)
+            └─> M1.2 runtime-host composition
+                 └─> M1.3 explicit environment provisioning
+                      └─> M2 mutation version acceptance
+                           └─> M3 workspace-bound continuation
+                                └─> M4 restore / rebaseline / publish / replication
 
 Independent maintenance gates before broad production enablement:
   - legacy non-empty DB root-binding adoption

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -558,11 +558,12 @@ baseline open 中。
 
 M1 拆成独立不变量，避免一次 PR 同时跨越 host lifecycle、runtime protocol 与 platform I/O：
 
-1. **M1.1 execution cwd admission（当前切片）**：M0 只返回 owner-bound opaque handle；同一 owner 每次
+1. **M1.1 execution scope admission（当前切片）**：M0 只返回 owner-bound opaque handle；同一 owner 每次
    execution 都在 drain residency 内重新证明 canonical head、Git receipt、HEAD/tree/ownership 与 root
-   identity，最后才在 callback 中发布 cwd。provisioning 固定为 `canonical_tree_only_v1`；
+   identity，最后只签发 callback 生命周期内有效的 opaque scope，不公开 raw cwd。provisioning 固定为
+   `canonical_tree_only_v1`，`workspaceEffect` 固定为 `none`；
 2. **M1.2 runtime-host composition**：建立 managed/attached typed profile、startup/drain/shutdown 顺序，并让
-   worker 只能在 callback 内取得 cwd；
+   storage-internal worker bridge 只能用 active scope 解析 cwd；
 3. **M1.3 environment provisioning**：单独设计 ignored dependency、secret 与 scratch overlay。M1.1 不复制
    `.env`、`node_modules` 或 build output，也不以 attached checkout silent fallback 掩盖能力缺失。
 
@@ -615,7 +616,7 @@ M0.1 Git artifact owner (merged)
   + M0.2 workspace version authority (merged)
   + M0.3 managed owner lifecycle (merged)
   └─> M0.4 baseline open bundle (merged)
-       └─> M1.1 execution cwd admission (current)
+       └─> M1.1 execution scope admission (current)
             └─> M1.2 runtime-host composition
                  └─> M1.3 explicit environment provisioning
                       └─> M2 mutation version acceptance

--- a/packages/core/src/workspace-version-authority.ts
+++ b/packages/core/src/workspace-version-authority.ts
@@ -112,14 +112,14 @@ export interface WorkspaceVersionRecordV1 extends WorkspaceBaselineAcceptedV1 {
 }
 
 export interface WorkspaceHeadRecordV1 {
-  repositoryId: string;
-  workspaceId: string;
-  workspaceEpochId: string;
-  workspaceVersionId: string;
-  acceptedEventId: string;
-  commitOid: string;
-  treeOid: string;
-  revision: number;
+  readonly repositoryId: string;
+  readonly workspaceId: string;
+  readonly workspaceEpochId: string;
+  readonly workspaceVersionId: string;
+  readonly acceptedEventId: string;
+  readonly commitOid: string;
+  readonly treeOid: string;
+  readonly revision: number;
 }
 
 export interface WorkspaceBaselineCommitResult {

--- a/packages/storage/src/__tests__/fixtures/git-workspace-service-crash-child.ts
+++ b/packages/storage/src/__tests__/fixtures/git-workspace-service-crash-child.ts
@@ -34,6 +34,17 @@ if (process.env.MAKA_GIT_WORKSPACE_ACTION === 'baseline-receipt') {
   throw new Error('Managed baseline crash child missed its failpoint');
 }
 
+if (process.env.MAKA_GIT_WORKSPACE_ACTION === 'execution-admission') {
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const rootOwner = await tryAcquireInteractiveRootOwner(capability);
+  if (!rootOwner) throw new Error('Unable to acquire crash-child root owner');
+  const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
+  const owner = await openManagedWorkspaceOwner({ rootOwner, gitRuntime, failpoint });
+  const accepted = await owner.openManagedWorkspaceBaseline(runtimeStore, request);
+  await owner.withManagedWorkspaceExecution(accepted.executionHandle, async () => undefined);
+  throw new Error('Managed execution admission crash child missed its failpoint');
+}
+
 const service = createGitWorkspaceService({
   storageRoot,
   gitRuntime,

--- a/packages/storage/src/__tests__/managed-workspace-baseline.test.ts
+++ b/packages/storage/src/__tests__/managed-workspace-baseline.test.ts
@@ -21,6 +21,7 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { afterEach, before, test } from 'node:test';
 import { openManagedWorkspaceOwner } from '../managed-workspace-owner.js';
+import { inspectManagedWorkspaceExecutionHandleInternal } from '../managed-workspace-execution-authority-internal.js';
 import { createGitWorkspaceService } from '../git-workspace-service.js';
 import * as publicStorage from '../index.js';
 import { acquireOperationalStateDatabase } from '../operational-state-store.js';
@@ -57,6 +58,8 @@ test('does not expose baseline receipt issuance on the public Git workspace serv
 
 test('does not expose artifact-only workspace creation through the public storage API', async () => {
   assert.equal('createGitWorkspaceService' in publicStorage, false);
+  assert.equal('issueManagedWorkspaceExecutionHandleInternal' in publicStorage, false);
+  assert.equal('inspectManagedWorkspaceExecutionHandleInternal' in publicStorage, false);
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
@@ -102,23 +105,25 @@ test('opens one canonical baseline from a durable verified Git receipt', async (
 
     const first = await owner.openManagedWorkspaceBaseline(runtimeStore, input);
     const retry = await owner.openManagedWorkspaceBaseline(runtimeStore, input);
+    const firstEvidence = inspectManagedWorkspaceExecutionHandleInternal(first.executionHandle);
+    const retryEvidence = inspectManagedWorkspaceExecutionHandleInternal(retry.executionHandle);
 
     assert.equal(first.created, true);
     assert.equal(retry.created, false);
-    assert.equal('committedAt' in first.receipt, false);
-    assert.deepEqual(retry.receipt, first.receipt);
-    assert.equal(first.head.commitOid, first.binding.baselineCommitOid);
-    assert.equal(first.head.treeOid, first.binding.baselineTreeOid);
-    assert.equal(first.receipt.changedFileCount, 2);
-    assert.equal(first.receipt.deletedFileCount, 0);
-    assert.equal(first.receipt.policyVersion, 1);
+    assert.equal('committedAt' in firstEvidence.receipt, false);
+    assert.deepEqual(retryEvidence.receipt, firstEvidence.receipt);
+    assert.equal(first.head.commitOid, firstEvidence.binding.baselineCommitOid);
+    assert.equal(first.head.treeOid, firstEvidence.binding.baselineTreeOid);
+    assert.equal(firstEvidence.receipt.changedFileCount, 2);
+    assert.equal(firstEvidence.receipt.deletedFileCount, 0);
+    assert.equal(firstEvidence.receipt.policyVersion, 1);
     assert.equal(
-      first.receipt.policyHash,
+      firstEvidence.receipt.policyHash,
       'sha256:48eb80c9c8dd6c4d1e7a635dcc187488e0e0b20e2296b81bbaae0be7c5467341',
     );
-    assert.match(first.receipt.treeDeltaDigest, /^sha256:[a-f0-9]{64}$/u);
+    assert.match(firstEvidence.receipt.treeDeltaDigest, /^sha256:[a-f0-9]{64}$/u);
     assert.equal(
-      first.receipt.treeDeltaDigest,
+      firstEvidence.receipt.treeDeltaDigest,
       'sha256:84a37411a467c40c9fd763ab128a6b23e56ec74ab3da2bd54de8d61e375244e8',
     );
     assert.deepEqual(
@@ -135,11 +140,11 @@ test('opens one canonical baseline from a durable verified Git receipt', async (
       unrelatedStore.close();
     }
 
-    const receiptPath = join(dirname(first.binding.worktreePath), 'baseline-receipt.json');
+    const receiptPath = join(dirname(firstEvidence.binding.worktreePath), 'baseline-receipt.json');
     await writeFile(
       receiptPath,
       `${JSON.stringify({
-        ...first.receipt,
+        ...firstEvidence.receipt,
         treeDeltaDigest: `sha256:${'f'.repeat(64)}`,
       })}\n`,
       'utf8',
@@ -148,12 +153,12 @@ test('opens one canonical baseline from a durable verified Git receipt', async (
       owner.openManagedWorkspaceBaseline(runtimeStore, input),
       /does not match its verified Git boundary/u,
     );
-    await writeFile(receiptPath, `${JSON.stringify(first.receipt)}\n`, 'utf8');
+    await writeFile(receiptPath, `${JSON.stringify(firstEvidence.receipt)}\n`, 'utf8');
 
     await writeFile(
       receiptPath,
       `${JSON.stringify({
-        ...first.receipt,
+        ...firstEvidence.receipt,
         workspaceVersionId: `version_${'a'.repeat(32)}`,
         epochOpenedEventId: `workspace_epoch_opened_${'b'.repeat(64)}`,
         baselineAcceptedEventId: `workspace_baseline_accepted_${'c'.repeat(64)}`,
@@ -165,20 +170,20 @@ test('opens one canonical baseline from a durable verified Git receipt', async (
       owner.openManagedWorkspaceBaseline(runtimeStore, input),
       /does not match its verified Git boundary/u,
     );
-    await writeFile(receiptPath, `${JSON.stringify(first.receipt)}\n`, 'utf8');
+    await writeFile(receiptPath, `${JSON.stringify(firstEvidence.receipt)}\n`, 'utf8');
 
     await writeFile(
       receiptPath,
-      `${JSON.stringify({ ...first.receipt, committedAt: Date.now() })}\n`,
+      `${JSON.stringify({ ...firstEvidence.receipt, committedAt: Date.now() })}\n`,
       'utf8',
     );
     await assert.rejects(
       owner.openManagedWorkspaceBaseline(runtimeStore, input),
       /Invalid managed workspace baseline receipt/u,
     );
-    await writeFile(receiptPath, `${JSON.stringify(first.receipt)}\n`, 'utf8');
+    await writeFile(receiptPath, `${JSON.stringify(firstEvidence.receipt)}\n`, 'utf8');
 
-    const bindingPath = join(dirname(first.binding.worktreePath), 'binding.json');
+    const bindingPath = join(dirname(firstEvidence.binding.worktreePath), 'binding.json');
     await rm(receiptPath);
     await rm(bindingPath);
     await assert.rejects(
@@ -232,8 +237,11 @@ test('reuses an orphan receipt after interruption before SQLite acceptance', asy
     );
 
     const recovered = await owner.openManagedWorkspaceBaseline(runtimeStore, input);
+    const recoveredEvidence = inspectManagedWorkspaceExecutionHandleInternal(
+      recovered.executionHandle,
+    );
     assert.equal(recovered.created, true);
-    assert.equal(recovered.receipt.baselineAcceptedEventId, recovered.head.acceptedEventId);
+    assert.equal(recoveredEvidence.receipt.baselineAcceptedEventId, recovered.head.acceptedEventId);
     await owner.close();
   } finally {
     runtimeStore.close();
@@ -261,7 +269,10 @@ test('rejects a receipt read through a replaced instance-root symlink before par
       runtimeStore,
       openRequest(sourceRoot),
     );
-    const instanceRoot = dirname(accepted.binding.worktreePath);
+    const acceptedEvidence = inspectManagedWorkspaceExecutionHandleInternal(
+      accepted.executionHandle,
+    );
+    const instanceRoot = dirname(acceptedEvidence.binding.worktreePath);
     const externalRoot = join(root, 'external-instance');
     await mkdir(externalRoot, { recursive: true });
     const movedInstance = join(externalRoot, 'instance');
@@ -301,7 +312,10 @@ test('serializes concurrent baseline opens under the same managed workspace owne
       owner.openManagedWorkspaceBaseline(runtimeStore, openRequest(sourceRoot)),
     ]);
     assert.deepEqual([left.created, right.created].sort(), [false, true]);
-    assert.deepEqual(left.receipt, right.receipt);
+    assert.deepEqual(
+      inspectManagedWorkspaceExecutionHandleInternal(left.executionHandle).receipt,
+      inspectManagedWorkspaceExecutionHandleInternal(right.executionHandle).receipt,
+    );
     assert.deepEqual(left.head, right.head);
     await owner.close();
   } finally {
@@ -799,8 +813,11 @@ test('keeps an orphan receipt across SQLite rollback and accepts it on retry', a
     );
 
     const recovered = await owner.openManagedWorkspaceBaseline(runtimeStore, input);
+    const recoveredEvidence = inspectManagedWorkspaceExecutionHandleInternal(
+      recovered.executionHandle,
+    );
     assert.equal(recovered.created, true);
-    assert.equal(recovered.receipt.workspaceVersionId, recovered.head.workspaceVersionId);
+    assert.equal(recoveredEvidence.receipt.workspaceVersionId, recovered.head.workspaceVersionId);
     await owner.close();
   } finally {
     runtimeStore.close();
@@ -853,9 +870,12 @@ test('accepts the same durable receipt after a real process crash before SQLite 
       const accepted = await owner.openManagedWorkspaceBaseline(runtimeStore, {
         ...openRequest(sourceRoot),
       });
+      const acceptedEvidence = inspectManagedWorkspaceExecutionHandleInternal(
+        accepted.executionHandle,
+      );
       assert.equal(accepted.created, true);
-      assert.equal(accepted.receipt.baselineAcceptedEventId, accepted.head.acceptedEventId);
-      assert.deepEqual(accepted.receipt, durableBeforeCrash);
+      assert.equal(acceptedEvidence.receipt.baselineAcceptedEventId, accepted.head.acceptedEventId);
+      assert.deepEqual(acceptedEvidence.receipt, durableBeforeCrash);
       await owner.close();
     } finally {
       runtimeStore.close();
@@ -912,9 +932,75 @@ test('reopens the exact accepted baseline after a real crash before post-commit 
         runtimeStore,
         openRequest(sourceRoot),
       );
+      const reopenedEvidence = inspectManagedWorkspaceExecutionHandleInternal(
+        reopened.executionHandle,
+      );
       assert.equal(reopened.created, false);
-      assert.deepEqual(reopened.receipt, durableBeforeCrash);
-      assert.equal(reopened.head.acceptedEventId, reopened.receipt.baselineAcceptedEventId);
+      assert.deepEqual(reopenedEvidence.receipt, durableBeforeCrash);
+      assert.equal(reopened.head.acceptedEventId, reopenedEvidence.receipt.baselineAcceptedEventId);
+      await owner.close();
+    } finally {
+      runtimeStore.close();
+      await rootOwner.close();
+    }
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+  }
+});
+
+test('reissues execution authority after a real process crash during admission verification', {
+  timeout: 60_000,
+}, async () => {
+  const root = await temporaryRoot();
+  const storageRoot = join(root, 'storage');
+  const sourceRoot = await createEligibleSource(join(root, 'source'));
+  const child = spawn(
+    process.execPath,
+    [fileURLToPath(new URL('./fixtures/git-workspace-service-crash-child.js', import.meta.url))],
+    {
+      env: {
+        ...process.env,
+        MAKA_GIT_WORKSPACE_STORAGE: storageRoot,
+        MAKA_GIT_WORKSPACE_SOURCE: sourceRoot,
+        MAKA_GIT_WORKSPACE_EXECUTABLE: gitExecutablePath,
+        MAKA_GIT_WORKSPACE_SHA256: gitExecutableSha256,
+        MAKA_GIT_WORKSPACE_FAILPOINT: 'after_execution_artifact_verification',
+        MAKA_GIT_WORKSPACE_ACTION: 'execution-admission',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  try {
+    await waitForReady(child, 30_000);
+    child.kill('SIGKILL');
+    await waitForExit(child);
+
+    const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+    const rootOwner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(rootOwner);
+    const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
+    try {
+      const owner = await openManagedWorkspaceOwner({
+        rootOwner,
+        gitRuntime: {
+          executablePath: gitExecutablePath,
+          expectedSha256: gitExecutableSha256,
+        },
+      });
+      const reopened = await owner.openManagedWorkspaceBaseline(
+        runtimeStore,
+        openRequest(sourceRoot),
+      );
+      let observedCwd: string | undefined;
+      await owner.withManagedWorkspaceExecution(reopened.executionHandle, async (context) => {
+        observedCwd = context.cwd;
+        assert.equal(await readFile(join(context.cwd, 'tracked.txt'), 'utf8'), 'tracked\n');
+      });
+      assert.equal(
+        observedCwd,
+        inspectManagedWorkspaceExecutionHandleInternal(reopened.executionHandle).binding
+          .worktreePath,
+      );
       await owner.close();
     } finally {
       runtimeStore.close();

--- a/packages/storage/src/__tests__/managed-workspace-baseline.test.ts
+++ b/packages/storage/src/__tests__/managed-workspace-baseline.test.ts
@@ -21,7 +21,10 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { afterEach, before, test } from 'node:test';
 import { openManagedWorkspaceOwner } from '../managed-workspace-owner.js';
-import { inspectManagedWorkspaceExecutionHandleInternal } from '../managed-workspace-execution-authority-internal.js';
+import {
+  inspectManagedWorkspaceExecutionHandleInternal,
+  inspectManagedWorkspaceExecutionScopeInternal,
+} from '../managed-workspace-execution-authority-internal.js';
 import { createGitWorkspaceService } from '../git-workspace-service.js';
 import * as publicStorage from '../index.js';
 import { acquireOperationalStateDatabase } from '../operational-state-store.js';
@@ -60,6 +63,8 @@ test('does not expose artifact-only workspace creation through the public storag
   assert.equal('createGitWorkspaceService' in publicStorage, false);
   assert.equal('issueManagedWorkspaceExecutionHandleInternal' in publicStorage, false);
   assert.equal('inspectManagedWorkspaceExecutionHandleInternal' in publicStorage, false);
+  assert.equal('issueManagedWorkspaceExecutionScopeInternal' in publicStorage, false);
+  assert.equal('inspectManagedWorkspaceExecutionScopeInternal' in publicStorage, false);
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
@@ -992,7 +997,8 @@ test('reissues execution authority after a real process crash during admission v
         openRequest(sourceRoot),
       );
       let observedCwd: string | undefined;
-      await owner.withManagedWorkspaceExecution(reopened.executionHandle, async (context) => {
+      await owner.withManagedWorkspaceExecution(reopened.executionHandle, async (scope) => {
+        const context = inspectManagedWorkspaceExecutionScopeInternal(scope);
         observedCwd = context.cwd;
         assert.equal(await readFile(join(context.cwd, 'tracked.txt'), 'utf8'), 'tracked\n');
       });

--- a/packages/storage/src/__tests__/managed-workspace-owner.test.ts
+++ b/packages/storage/src/__tests__/managed-workspace-owner.test.ts
@@ -338,7 +338,7 @@ test('rejects execution when runtime.sqlite detaches from its canonical path aft
       owner.withManagedWorkspaceExecution(accepted.executionHandle, async () => {
         callbackCalled = true;
       }),
-      /workspace baseline authority database file identity changed|belongs to a different storage root/u,
+      /database file identity changed|belongs to a different storage root/u,
     );
     assert.equal(callbackCalled, false);
     await owner.close();

--- a/packages/storage/src/__tests__/managed-workspace-owner.test.ts
+++ b/packages/storage/src/__tests__/managed-workspace-owner.test.ts
@@ -11,7 +11,9 @@ import { afterEach, before, test } from 'node:test';
 import {
   ManagedWorkspaceOwnerError,
   openManagedWorkspaceOwner,
+  type ManagedWorkspaceExecutionHandle,
 } from '../managed-workspace-owner.js';
+import { inspectManagedWorkspaceExecutionHandleInternal } from '../managed-workspace-execution-authority-internal.js';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '../root-authority.js';
 import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
 
@@ -108,15 +110,262 @@ test('creates an accepted managed baseline only through the active owner', async
       },
     });
 
-    const { binding } = await owner.openManagedWorkspaceBaseline(
+    const accepted = await owner.openManagedWorkspaceBaseline(
       runtimeStore,
       openRequest(sourceRoot),
     );
+    const { binding } = inspectManagedWorkspaceExecutionHandleInternal(accepted.executionHandle);
 
     assert.equal(binding.sourceTreeOid, binding.baselineTreeOid);
     assert.equal(existsSync(join(binding.worktreePath, '.maka-workspace.json')), false);
     await owner.close();
   } finally {
+    runtimeStore.close();
+    await rootOwner.close();
+  }
+});
+
+test('publishes a managed tool cwd only through its accepted execution handle', async () => {
+  const root = await temporaryRoot();
+  const storageRoot = join(root, 'storage');
+  const sourceRoot = await createEligibleSource(join(root, 'source'));
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const rootOwner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(rootOwner);
+  const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
+  try {
+    const owner = await openManagedWorkspaceOwner({
+      rootOwner,
+      gitRuntime: {
+        executablePath: gitExecutablePath,
+        expectedSha256: gitExecutableSha256,
+      },
+    });
+    const accepted = await owner.openManagedWorkspaceBaseline(
+      runtimeStore,
+      openRequest(sourceRoot),
+    );
+
+    assert.equal('binding' in accepted, false);
+    assert.equal('receipt' in accepted, false);
+    const execution = await owner.withManagedWorkspaceExecution(
+      accepted.executionHandle,
+      async (context) => ({
+        ...context,
+        tracked: existsSync(join(context.cwd, 'tracked.txt')),
+      }),
+    );
+
+    assert.equal(execution.kind, 'managed_worktree');
+    assert.equal(execution.provisioning, 'canonical_tree_only_v1');
+    assert.equal(execution.workspaceVersionId, accepted.head.workspaceVersionId);
+    assert.equal(execution.commitOid, accepted.head.commitOid);
+    assert.equal(execution.treeOid, accepted.head.treeOid);
+    assert.equal(execution.tracked, true);
+    assert.equal(execution.cwd.startsWith(storageRoot), true);
+    await owner.close();
+  } finally {
+    runtimeStore.close();
+    await rootOwner.close();
+  }
+});
+
+test('quarantines drift introduced after execution artifact verification before publishing cwd', async () => {
+  const root = await temporaryRoot();
+  const storageRoot = join(root, 'storage');
+  const sourceRoot = await createEligibleSource(join(root, 'source'));
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const rootOwner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(rootOwner);
+  const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
+  let executionFailpointArmed = false;
+  let callbackCalled = false;
+  try {
+    const owner = await openManagedWorkspaceOwner({
+      rootOwner,
+      gitRuntime: {
+        executablePath: gitExecutablePath,
+        expectedSha256: gitExecutableSha256,
+      },
+      async failpoint(point) {
+        if (
+          executionFailpointArmed &&
+          (point as string) === 'after_execution_artifact_verification'
+        ) {
+          executionFailpointArmed = false;
+          const acceptedEvidence = inspectManagedWorkspaceExecutionHandleInternal(
+            accepted.executionHandle,
+          );
+          await writeFile(
+            join(acceptedEvidence.binding.worktreePath, 'tracked.txt'),
+            'external drift after verification\n',
+            'utf8',
+          );
+        }
+      },
+    });
+    const accepted = await owner.openManagedWorkspaceBaseline(
+      runtimeStore,
+      openRequest(sourceRoot),
+    );
+    executionFailpointArmed = true;
+
+    await assert.rejects(
+      owner.withManagedWorkspaceExecution(accepted.executionHandle, async () => {
+        callbackCalled = true;
+      }),
+      isOwnerError('managed_workspace_quarantined'),
+    );
+
+    assert.equal(callbackCalled, false);
+    await owner.close();
+  } finally {
+    runtimeStore.close();
+    await rootOwner.close();
+  }
+});
+
+test('rejects a forged execution handle before invoking the tool callback', async () => {
+  const storageRoot = await temporaryRoot();
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const rootOwner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(rootOwner);
+  let callbackCalled = false;
+  try {
+    const owner = await openManagedWorkspaceOwner({
+      rootOwner,
+      gitRuntime: {
+        executablePath: gitExecutablePath,
+        expectedSha256: gitExecutableSha256,
+      },
+    });
+
+    await assert.rejects(
+      owner.withManagedWorkspaceExecution(
+        Object.freeze({
+          kind: 'managed_workspace_execution_handle_v1',
+        }) as ManagedWorkspaceExecutionHandle,
+        async () => {
+          callbackCalled = true;
+        },
+      ),
+      isOwnerError('managed_workspace_execution_handle_invalid'),
+    );
+
+    assert.equal(callbackCalled, false);
+    await owner.close();
+  } finally {
+    await rootOwner.close();
+  }
+});
+
+test('rejects an execution handle issued by another managed workspace owner', async () => {
+  const root = await temporaryRoot();
+  const sourceRoot = await createEligibleSource(join(root, 'source'));
+  const leftCapability = await resolveStorageRoot({
+    path: join(root, 'left-storage'),
+    kind: 'interactive',
+  });
+  const rightCapability = await resolveStorageRoot({
+    path: join(root, 'right-storage'),
+    kind: 'interactive',
+  });
+  const leftRootOwner = await tryAcquireInteractiveRootOwner(leftCapability);
+  const rightRootOwner = await tryAcquireInteractiveRootOwner(rightCapability);
+  assert.ok(leftRootOwner);
+  assert.ok(rightRootOwner);
+  const leftStore = createSqliteRuntimeStore(join(leftCapability.canonicalPath, 'runtime.sqlite'));
+  try {
+    const leftOwner = await openManagedWorkspaceOwner({
+      rootOwner: leftRootOwner,
+      gitRuntime: {
+        executablePath: gitExecutablePath,
+        expectedSha256: gitExecutableSha256,
+      },
+    });
+    const rightOwner = await openManagedWorkspaceOwner({
+      rootOwner: rightRootOwner,
+      gitRuntime: {
+        executablePath: gitExecutablePath,
+        expectedSha256: gitExecutableSha256,
+      },
+    });
+    const accepted = await leftOwner.openManagedWorkspaceBaseline(
+      leftStore,
+      openRequest(sourceRoot),
+    );
+
+    await assert.rejects(
+      rightOwner.withManagedWorkspaceExecution(accepted.executionHandle, async () => {}),
+      isOwnerError('managed_workspace_execution_handle_invalid'),
+    );
+
+    await leftOwner.close();
+    await rightOwner.close();
+  } finally {
+    leftStore.close();
+    await leftRootOwner.close();
+    await rightRootOwner.close();
+  }
+});
+
+test('drains an admitted managed execution before owner close completes', async () => {
+  const root = await temporaryRoot();
+  const storageRoot = join(root, 'storage');
+  const sourceRoot = await createEligibleSource(join(root, 'source'));
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const rootOwner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(rootOwner);
+  const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
+  let releaseExecution!: () => void;
+  const executionMayFinish = new Promise<void>((resolve) => {
+    releaseExecution = resolve;
+  });
+  let executionAdmitted!: () => void;
+  const executionStarted = new Promise<void>((resolve) => {
+    executionAdmitted = resolve;
+  });
+  let executing: Promise<void> | undefined;
+  let closing: Promise<void> | undefined;
+  try {
+    const owner = await openManagedWorkspaceOwner({
+      rootOwner,
+      gitRuntime: {
+        executablePath: gitExecutablePath,
+        expectedSha256: gitExecutableSha256,
+      },
+    });
+    const accepted = await owner.openManagedWorkspaceBaseline(
+      runtimeStore,
+      openRequest(sourceRoot),
+    );
+    executing = owner.withManagedWorkspaceExecution(accepted.executionHandle, async () => {
+      executionAdmitted();
+      await executionMayFinish;
+    });
+    await executionStarted;
+
+    let closeSettled = false;
+    closing = owner.close().then(() => {
+      closeSettled = true;
+    });
+    assert.equal(
+      await Promise.race([closing.then(() => 'closed'), delay(250, 'pending')]),
+      'pending',
+    );
+    assert.equal(closeSettled, false);
+    await assert.rejects(
+      owner.withManagedWorkspaceExecution(accepted.executionHandle, async () => {}),
+      isOwnerError('managed_workspace_owner_closing'),
+    );
+
+    releaseExecution();
+    await executing;
+    await closing;
+    assert.equal(owner.state, 'closed');
+  } finally {
+    releaseExecution();
+    await Promise.allSettled([executing, closing].filter((value) => value !== undefined));
     runtimeStore.close();
     await rootOwner.close();
   }
@@ -214,10 +463,11 @@ test('rejects external drift instead of reopening a non-ready workspace', async 
         expectedSha256: gitExecutableSha256,
       },
     });
-    const { binding } = await owner.openManagedWorkspaceBaseline(
+    const accepted = await owner.openManagedWorkspaceBaseline(
       runtimeStore,
       openRequest(sourceRoot),
     );
+    const { binding } = inspectManagedWorkspaceExecutionHandleInternal(accepted.executionHandle);
     await writeFile(join(binding.worktreePath, 'tracked.txt'), 'external drift\n', 'utf8');
 
     await assert.rejects(

--- a/packages/storage/src/__tests__/managed-workspace-owner.test.ts
+++ b/packages/storage/src/__tests__/managed-workspace-owner.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   inspectManagedWorkspaceExecutionHandleInternal,
   inspectManagedWorkspaceExecutionScopeInternal,
+  ManagedWorkspaceExecutionAuthorityError,
 } from '../managed-workspace-execution-authority-internal.js';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '../root-authority.js';
 import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
@@ -167,10 +168,21 @@ test('publishes only a revocable execution scope through its accepted handle', a
     assert.deepEqual(retainedScope, { kind: 'managed_workspace_execution_scope_v1' });
     assert.throws(
       () =>
+        inspectManagedWorkspaceExecutionScopeInternal({
+          kind: 'managed_workspace_execution_scope_v1',
+        }),
+      (error) =>
+        error instanceof ManagedWorkspaceExecutionAuthorityError &&
+        error.code === 'managed_workspace_execution_scope_invalid',
+    );
+    assert.throws(
+      () =>
         inspectManagedWorkspaceExecutionScopeInternal(
           retainedScope as ManagedWorkspaceExecutionScope,
         ),
-      /execution scope has expired/u,
+      (error) =>
+        error instanceof ManagedWorkspaceExecutionAuthorityError &&
+        error.code === 'managed_workspace_execution_scope_expired',
     );
     await owner.close();
   } finally {
@@ -477,6 +489,80 @@ test('drains an admitted managed execution before owner close completes', async 
   } finally {
     releaseExecution();
     await Promise.allSettled([executing, closing].filter((value) => value !== undefined));
+    runtimeStore.close();
+    await rootOwner.close();
+  }
+});
+
+test('allows concurrent read-only scopes for one handle and close drains both', async () => {
+  const root = await temporaryRoot();
+  const storageRoot = join(root, 'storage');
+  const sourceRoot = await createEligibleSource(join(root, 'source'));
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const rootOwner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(rootOwner);
+  const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
+  let releaseFirst!: () => void;
+  const firstReleased = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  let releaseSecond!: () => void;
+  const secondReleased = new Promise<void>((resolve) => {
+    releaseSecond = resolve;
+  });
+  let bothAdmitted!: () => void;
+  const bothScopesActive = new Promise<void>((resolve) => {
+    bothAdmitted = resolve;
+  });
+  let activeScopes = 0;
+  let executions: Promise<void>[] = [];
+  let closing: Promise<void> | undefined;
+  try {
+    const owner = await openManagedWorkspaceOwner({
+      rootOwner,
+      gitRuntime: {
+        executablePath: gitExecutablePath,
+        expectedSha256: gitExecutableSha256,
+      },
+    });
+    const accepted = await owner.openManagedWorkspaceBaseline(
+      runtimeStore,
+      openRequest(sourceRoot),
+    );
+    const execute = (released: Promise<void>) =>
+      owner.withManagedWorkspaceExecution(accepted.executionHandle, async (scope) => {
+        assert.equal(inspectManagedWorkspaceExecutionScopeInternal(scope).workspaceEffect, 'none');
+        activeScopes += 1;
+        if (activeScopes === 2) bothAdmitted();
+        await released;
+        activeScopes -= 1;
+      });
+
+    executions = [execute(firstReleased), execute(secondReleased)];
+    assert.equal(
+      await Promise.race([bothScopesActive.then(() => 'active'), delay(20_000, 'timeout')]),
+      'active',
+    );
+    assert.equal(activeScopes, 2);
+
+    closing = owner.close();
+    assert.equal(
+      await Promise.race([closing.then(() => 'closed'), delay(250, 'pending')]),
+      'pending',
+    );
+    releaseFirst();
+    assert.equal(
+      await Promise.race([closing.then(() => 'closed'), delay(250, 'pending')]),
+      'pending',
+    );
+    releaseSecond();
+    await Promise.all(executions);
+    await closing;
+    assert.equal(owner.state, 'closed');
+  } finally {
+    releaseFirst();
+    releaseSecond();
+    await Promise.allSettled([...executions, closing].filter((value) => value !== undefined));
     runtimeStore.close();
     await rootOwner.close();
   }

--- a/packages/storage/src/__tests__/managed-workspace-owner.test.ts
+++ b/packages/storage/src/__tests__/managed-workspace-owner.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { createReadStream, existsSync } from 'node:fs';
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
@@ -12,8 +12,12 @@ import {
   ManagedWorkspaceOwnerError,
   openManagedWorkspaceOwner,
   type ManagedWorkspaceExecutionHandle,
+  type ManagedWorkspaceExecutionScope,
 } from '../managed-workspace-owner.js';
-import { inspectManagedWorkspaceExecutionHandleInternal } from '../managed-workspace-execution-authority-internal.js';
+import {
+  inspectManagedWorkspaceExecutionHandleInternal,
+  inspectManagedWorkspaceExecutionScopeInternal,
+} from '../managed-workspace-execution-authority-internal.js';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '../root-authority.js';
 import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
 
@@ -125,7 +129,7 @@ test('creates an accepted managed baseline only through the active owner', async
   }
 });
 
-test('publishes a managed tool cwd only through its accepted execution handle', async () => {
+test('publishes only a revocable execution scope through its accepted handle', async () => {
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
@@ -148,21 +152,75 @@ test('publishes a managed tool cwd only through its accepted execution handle', 
 
     assert.equal('binding' in accepted, false);
     assert.equal('receipt' in accepted, false);
+    let retainedScope: unknown;
     const execution = await owner.withManagedWorkspaceExecution(
       accepted.executionHandle,
-      async (context) => ({
-        ...context,
-        tracked: existsSync(join(context.cwd, 'tracked.txt')),
-      }),
+      async (scope) => {
+        retainedScope = scope;
+        assert.equal('cwd' in scope, false);
+        assert.equal(scope.kind, 'managed_workspace_execution_scope_v1');
+        return 'admitted';
+      },
     );
 
-    assert.equal(execution.kind, 'managed_worktree');
-    assert.equal(execution.provisioning, 'canonical_tree_only_v1');
-    assert.equal(execution.workspaceVersionId, accepted.head.workspaceVersionId);
-    assert.equal(execution.commitOid, accepted.head.commitOid);
-    assert.equal(execution.treeOid, accepted.head.treeOid);
-    assert.equal(execution.tracked, true);
-    assert.equal(execution.cwd.startsWith(storageRoot), true);
+    assert.equal(execution, 'admitted');
+    assert.deepEqual(retainedScope, { kind: 'managed_workspace_execution_scope_v1' });
+    assert.throws(
+      () =>
+        inspectManagedWorkspaceExecutionScopeInternal(
+          retainedScope as ManagedWorkspaceExecutionScope,
+        ),
+      /execution scope has expired/u,
+    );
+    await owner.close();
+  } finally {
+    runtimeStore.close();
+    await rootOwner.close();
+  }
+});
+
+test('does not let caller-mutated head state or a shadowed public reader forge execution authority', async () => {
+  const root = await temporaryRoot();
+  const storageRoot = join(root, 'storage');
+  const sourceRoot = await createEligibleSource(join(root, 'source'));
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const rootOwner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(rootOwner);
+  const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
+  let callbackCalled = false;
+  try {
+    const owner = await openManagedWorkspaceOwner({
+      rootOwner,
+      gitRuntime: {
+        executablePath: gitExecutablePath,
+        expectedSha256: gitExecutableSha256,
+      },
+    });
+    const accepted = await owner.openManagedWorkspaceBaseline(
+      runtimeStore,
+      openRequest(sourceRoot),
+    );
+    const forgedHead = {
+      ...accepted.head,
+      workspaceVersionId: `version_${'a'.repeat(32)}`,
+      commitOid: 'a'.repeat(40),
+      treeOid: 'b'.repeat(40),
+      revision: accepted.head.revision + 1,
+    };
+    assert.throws(() => Object.assign(accepted.head, forgedHead), TypeError);
+    Object.defineProperty(runtimeStore, 'readWorkspaceHead', {
+      configurable: true,
+      value: async () => forgedHead,
+    });
+
+    await owner.withManagedWorkspaceExecution(accepted.executionHandle, async (scope) => {
+      callbackCalled = true;
+      const context = inspectManagedWorkspaceExecutionScopeInternal(scope);
+      assert.equal(context.head.workspaceVersionId, accepted.head.workspaceVersionId);
+      assert.equal(context.head.commitOid, accepted.head.commitOid);
+      assert.equal(context.head.treeOid, accepted.head.treeOid);
+    });
+    assert.equal(callbackCalled, true);
     await owner.close();
   } finally {
     runtimeStore.close();
@@ -217,6 +275,59 @@ test('quarantines drift introduced after execution artifact verification before 
       isOwnerError('managed_workspace_quarantined'),
     );
 
+    assert.equal(callbackCalled, false);
+    await owner.close();
+  } finally {
+    runtimeStore.close();
+    await rootOwner.close();
+  }
+});
+
+test('rejects execution when runtime.sqlite detaches from its canonical path after verification', {
+  skip:
+    process.platform === 'win32'
+      ? 'Open SQLite files cannot be renamed reliably on Windows'
+      : false,
+}, async () => {
+  const root = await temporaryRoot();
+  const storageRoot = join(root, 'storage');
+  const databasePath = join(storageRoot, 'runtime.sqlite');
+  const sourceRoot = await createEligibleSource(join(root, 'source'));
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const rootOwner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(rootOwner);
+  const runtimeStore = createSqliteRuntimeStore(databasePath);
+  let executionFailpointArmed = false;
+  let callbackCalled = false;
+  try {
+    const owner = await openManagedWorkspaceOwner({
+      rootOwner,
+      gitRuntime: {
+        executablePath: gitExecutablePath,
+        expectedSha256: gitExecutableSha256,
+      },
+      async failpoint(point) {
+        if (
+          executionFailpointArmed &&
+          (point as string) === 'after_execution_artifact_verification'
+        ) {
+          executionFailpointArmed = false;
+          await rename(databasePath, `${databasePath}.detached`);
+        }
+      },
+    });
+    const accepted = await owner.openManagedWorkspaceBaseline(
+      runtimeStore,
+      openRequest(sourceRoot),
+    );
+    executionFailpointArmed = true;
+
+    await assert.rejects(
+      owner.withManagedWorkspaceExecution(accepted.executionHandle, async () => {
+        callbackCalled = true;
+      }),
+      /workspace baseline authority database file identity changed|belongs to a different storage root/u,
+    );
     assert.equal(callbackCalled, false);
     await owner.close();
   } finally {
@@ -366,6 +477,49 @@ test('drains an admitted managed execution before owner close completes', async 
   } finally {
     releaseExecution();
     await Promise.allSettled([executing, closing].filter((value) => value !== undefined));
+    runtimeStore.close();
+    await rootOwner.close();
+  }
+});
+
+test('expires the execution scope and releases owner residency when its callback rejects', async () => {
+  const root = await temporaryRoot();
+  const storageRoot = join(root, 'storage');
+  const sourceRoot = await createEligibleSource(join(root, 'source'));
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const rootOwner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(rootOwner);
+  const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
+  let retainedScope: ManagedWorkspaceExecutionScope | undefined;
+  try {
+    const owner = await openManagedWorkspaceOwner({
+      rootOwner,
+      gitRuntime: {
+        executablePath: gitExecutablePath,
+        expectedSha256: gitExecutableSha256,
+      },
+    });
+    const accepted = await owner.openManagedWorkspaceBaseline(
+      runtimeStore,
+      openRequest(sourceRoot),
+    );
+
+    await assert.rejects(
+      owner.withManagedWorkspaceExecution(accepted.executionHandle, async (scope) => {
+        retainedScope = scope;
+        throw new Error('simulated managed tool failure');
+      }),
+      /simulated managed tool failure/u,
+    );
+    if (!retainedScope) throw new Error('Execution callback did not expose its scope');
+    const expiredScope = retainedScope;
+    assert.throws(
+      () => inspectManagedWorkspaceExecutionScopeInternal(expiredScope),
+      /execution scope has expired/u,
+    );
+    await owner.close();
+    assert.equal(owner.state, 'closed');
+  } finally {
     runtimeStore.close();
     await rootOwner.close();
   }

--- a/packages/storage/src/managed-workspace-execution-authority-internal.ts
+++ b/packages/storage/src/managed-workspace-execution-authority-internal.ts
@@ -8,17 +8,37 @@ export interface ManagedWorkspaceExecutionHandle {
   readonly kind: 'managed_workspace_execution_handle_v1';
 }
 
+export interface ManagedWorkspaceExecutionScope {
+  readonly kind: 'managed_workspace_execution_scope_v1';
+}
+
 export interface ManagedWorkspaceExecutionAuthorityStateInternal {
   readonly store: RuntimeWorkspaceVersionAuthorityStore;
-  readonly binding: ManagedWorkspaceBinding;
-  readonly receipt: ManagedWorkspaceBaselineReceiptV1;
-  readonly head: WorkspaceHeadRecordV1;
+  readonly binding: Readonly<ManagedWorkspaceBinding>;
+  readonly receipt: Readonly<ManagedWorkspaceBaselineReceiptV1>;
+  readonly head: Readonly<WorkspaceHeadRecordV1>;
 }
 
 const states = new WeakMap<
   object,
   ManagedWorkspaceExecutionAuthorityStateInternal & {
     readonly ownerToken: object;
+  }
+>();
+
+export interface ManagedWorkspaceExecutionScopeStateInternal {
+  readonly provisioning: 'canonical_tree_only_v1';
+  readonly workspaceEffect: 'none';
+  readonly cwd: string;
+  readonly binding: Readonly<ManagedWorkspaceBinding>;
+  readonly head: Readonly<WorkspaceHeadRecordV1>;
+}
+
+const scopes = new WeakMap<
+  object,
+  ManagedWorkspaceExecutionScopeStateInternal & {
+    readonly ownerToken: object;
+    active: boolean;
   }
 >();
 
@@ -48,5 +68,35 @@ export function inspectManagedWorkspaceExecutionHandleInternal(
 ): ManagedWorkspaceExecutionAuthorityStateInternal {
   const state = states.get(handle);
   if (!state) throw new Error('Managed workspace execution handle is invalid');
+  return state;
+}
+
+export function issueManagedWorkspaceExecutionScopeInternal(
+  ownerToken: object,
+  state: ManagedWorkspaceExecutionScopeStateInternal,
+): ManagedWorkspaceExecutionScope {
+  const scope = Object.freeze({ kind: 'managed_workspace_execution_scope_v1' as const });
+  scopes.set(scope, { ...state, ownerToken, active: true });
+  return scope;
+}
+
+export function revokeManagedWorkspaceExecutionScopeInternal(
+  ownerToken: object,
+  scope: ManagedWorkspaceExecutionScope,
+): void {
+  const state = scopes.get(scope);
+  if (!state || state.ownerToken !== ownerToken) {
+    throw new Error('Managed workspace execution scope is invalid for this owner');
+  }
+  state.active = false;
+}
+
+/** Package-internal active-scope evidence access for storage contract tests. */
+export function inspectManagedWorkspaceExecutionScopeInternal(
+  scope: ManagedWorkspaceExecutionScope,
+): ManagedWorkspaceExecutionScopeStateInternal {
+  const state = scopes.get(scope);
+  if (!state) throw new Error('Managed workspace execution scope is invalid');
+  if (!state.active) throw new Error('Managed workspace execution scope has expired');
   return state;
 }

--- a/packages/storage/src/managed-workspace-execution-authority-internal.ts
+++ b/packages/storage/src/managed-workspace-execution-authority-internal.ts
@@ -1,0 +1,52 @@
+import type { RuntimeWorkspaceVersionAuthorityStore, WorkspaceHeadRecordV1 } from '@maka/core';
+import type {
+  ManagedWorkspaceBaselineReceiptV1,
+  ManagedWorkspaceBinding,
+} from './git-workspace-service.js';
+
+export interface ManagedWorkspaceExecutionHandle {
+  readonly kind: 'managed_workspace_execution_handle_v1';
+}
+
+export interface ManagedWorkspaceExecutionAuthorityStateInternal {
+  readonly store: RuntimeWorkspaceVersionAuthorityStore;
+  readonly binding: ManagedWorkspaceBinding;
+  readonly receipt: ManagedWorkspaceBaselineReceiptV1;
+  readonly head: WorkspaceHeadRecordV1;
+}
+
+const states = new WeakMap<
+  object,
+  ManagedWorkspaceExecutionAuthorityStateInternal & {
+    readonly ownerToken: object;
+  }
+>();
+
+export function issueManagedWorkspaceExecutionHandleInternal(
+  ownerToken: object,
+  state: ManagedWorkspaceExecutionAuthorityStateInternal,
+): ManagedWorkspaceExecutionHandle {
+  const handle = Object.freeze({ kind: 'managed_workspace_execution_handle_v1' as const });
+  states.set(handle, { ...state, ownerToken });
+  return handle;
+}
+
+export function requireManagedWorkspaceExecutionHandleInternal(
+  ownerToken: object,
+  handle: ManagedWorkspaceExecutionHandle,
+): ManagedWorkspaceExecutionAuthorityStateInternal {
+  const state = states.get(handle);
+  if (!state || state.ownerToken !== ownerToken) {
+    throw new Error('Managed workspace execution handle is invalid for this owner');
+  }
+  return state;
+}
+
+/** Package-internal evidence access for storage contract and crash tests. */
+export function inspectManagedWorkspaceExecutionHandleInternal(
+  handle: ManagedWorkspaceExecutionHandle,
+): ManagedWorkspaceExecutionAuthorityStateInternal {
+  const state = states.get(handle);
+  if (!state) throw new Error('Managed workspace execution handle is invalid');
+  return state;
+}

--- a/packages/storage/src/managed-workspace-execution-authority-internal.ts
+++ b/packages/storage/src/managed-workspace-execution-authority-internal.ts
@@ -12,6 +12,20 @@ export interface ManagedWorkspaceExecutionScope {
   readonly kind: 'managed_workspace_execution_scope_v1';
 }
 
+export type ManagedWorkspaceExecutionAuthorityErrorCode =
+  | 'managed_workspace_execution_scope_invalid'
+  | 'managed_workspace_execution_scope_expired';
+
+export class ManagedWorkspaceExecutionAuthorityError extends Error {
+  constructor(
+    readonly code: ManagedWorkspaceExecutionAuthorityErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ManagedWorkspaceExecutionAuthorityError';
+  }
+}
+
 export interface ManagedWorkspaceExecutionAuthorityStateInternal {
   readonly store: RuntimeWorkspaceVersionAuthorityStore;
   readonly binding: Readonly<ManagedWorkspaceBinding>;
@@ -86,7 +100,10 @@ export function revokeManagedWorkspaceExecutionScopeInternal(
 ): void {
   const state = scopes.get(scope);
   if (!state || state.ownerToken !== ownerToken) {
-    throw new Error('Managed workspace execution scope is invalid for this owner');
+    throw new ManagedWorkspaceExecutionAuthorityError(
+      'managed_workspace_execution_scope_invalid',
+      'Managed workspace execution scope is invalid for this owner',
+    );
   }
   state.active = false;
 }
@@ -96,7 +113,17 @@ export function inspectManagedWorkspaceExecutionScopeInternal(
   scope: ManagedWorkspaceExecutionScope,
 ): ManagedWorkspaceExecutionScopeStateInternal {
   const state = scopes.get(scope);
-  if (!state) throw new Error('Managed workspace execution scope is invalid');
-  if (!state.active) throw new Error('Managed workspace execution scope has expired');
+  if (!state) {
+    throw new ManagedWorkspaceExecutionAuthorityError(
+      'managed_workspace_execution_scope_invalid',
+      'Managed workspace execution scope is invalid',
+    );
+  }
+  if (!state.active) {
+    throw new ManagedWorkspaceExecutionAuthorityError(
+      'managed_workspace_execution_scope_expired',
+      'Managed workspace execution scope has expired',
+    );
+  }
   return state;
 }

--- a/packages/storage/src/managed-workspace-owner.ts
+++ b/packages/storage/src/managed-workspace-owner.ts
@@ -282,10 +282,13 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
         );
       }
       assertExecutionCrossPlaneIdentity(accepted.binding, accepted.receipt, accepted.head);
-      // This preliminary proof exists so crash tests can stop at a real,
-      // completed artifact verification. No authority is published from it.
-      await this.#verifyExecutionArtifactOrQuarantine(accepted.binding, accepted.receipt);
-      await this.failpoint?.('after_execution_artifact_verification');
+      // Test builds with a failpoint retain a preliminary proof so crash tests
+      // can stop after a real, completed artifact verification. The ordinary
+      // production path performs only the final proof below.
+      if (this.failpoint) {
+        await this.#verifyExecutionArtifactOrQuarantine(accepted.binding, accepted.receipt);
+        await this.failpoint('after_execution_artifact_verification');
+      }
 
       // The final proof bundle is intentionally ordered so the exact Git
       // receipt/binding/worktree verification is the last awaited operation

--- a/packages/storage/src/managed-workspace-owner.ts
+++ b/packages/storage/src/managed-workspace-owner.ts
@@ -14,8 +14,11 @@ import {
 } from './managed-baseline-receipt-authority-internal.js';
 import {
   issueManagedWorkspaceExecutionHandleInternal,
+  issueManagedWorkspaceExecutionScopeInternal,
   requireManagedWorkspaceExecutionHandleInternal,
+  revokeManagedWorkspaceExecutionScopeInternal,
   type ManagedWorkspaceExecutionHandle,
+  type ManagedWorkspaceExecutionScope,
 } from './managed-workspace-execution-authority-internal.js';
 import type { RuntimeWorkspaceVersionAuthorityStore, WorkspaceHeadRecordV1 } from '@maka/core';
 import {
@@ -29,6 +32,7 @@ import {
   assertWorkspaceBaselineAuthorityStoreRootInternal,
   bindWorkspaceBaselineAuthorityStoreRootInternal,
   commitWorkspaceBaselineInternal,
+  readWorkspaceHeadInternal,
 } from './workspace-version-authority-internal.js';
 
 // RuntimeEvent order is assigned by the SQLite authority spine. M0 therefore
@@ -75,19 +79,6 @@ export interface OpenManagedWorkspaceBaselineResult {
   readonly executionHandle: ManagedWorkspaceExecutionHandle;
 }
 
-export interface ManagedWorkspaceExecutionContext {
-  readonly kind: 'managed_worktree';
-  readonly provisioning: 'canonical_tree_only_v1';
-  readonly cwd: string;
-  readonly repositoryId: string;
-  readonly workspaceId: string;
-  readonly workspaceEpochId: string;
-  readonly workspaceInstanceId: string;
-  readonly workspaceVersionId: string;
-  readonly commitOid: string;
-  readonly treeOid: string;
-}
-
 export interface ManagedWorkspaceOwner {
   readonly state: 'ready' | 'closing' | 'closed';
   openManagedWorkspaceBaseline(
@@ -96,12 +87,12 @@ export interface ManagedWorkspaceOwner {
   ): Promise<OpenManagedWorkspaceBaselineResult>;
   withManagedWorkspaceExecution<T>(
     handle: ManagedWorkspaceExecutionHandle,
-    operation: (context: ManagedWorkspaceExecutionContext) => Promise<T>,
+    operation: (scope: ManagedWorkspaceExecutionScope) => Promise<T>,
   ): Promise<T>;
   close(): Promise<void>;
 }
 
-export type { ManagedWorkspaceExecutionHandle };
+export type { ManagedWorkspaceExecutionHandle, ManagedWorkspaceExecutionScope };
 
 const owners = new WeakMap<InteractiveRootOwner, object>();
 
@@ -190,7 +181,11 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
       );
       bindWorkspaceBaselineAuthorityStoreRootInternal(store, this.rootOwner.capability.rootId);
       await this.failpoint?.('after_initial_store_root_validation');
-      const existingHead = await store.readWorkspaceHead(input.workspaceId, input.workspaceEpochId);
+      const existingHead = await readWorkspaceHeadInternal(
+        store,
+        input.workspaceId,
+        input.workspaceEpochId,
+      );
       const receipt = existingHead ? await this.receiptAuthority.require(input) : undefined;
       const binding = receipt
         ? await this.#openReadyBinding(receipt.binding)
@@ -252,13 +247,17 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
       // verification. Revalidate its identity at the final return gate without
       // rejecting an operation that owner.close() is legitimately draining.
       await this.#assertCurrentRootIdentity();
+      const internalHead = freezeWorkspaceHead(committed.head);
+      const internalBinding = freezeManagedWorkspaceBinding(binding);
+      const internalReceipt = freezeManagedWorkspaceReceipt(durableReceipt, internalBinding);
       return {
-        ...committed,
+        created: committed.created,
+        head: freezeWorkspaceHead(committed.head),
         executionHandle: issueManagedWorkspaceExecutionHandleInternal(this.#executionOwnerToken, {
           store,
-          binding,
-          receipt: durableReceipt,
-          head: committed.head,
+          binding: internalBinding,
+          receipt: internalReceipt,
+          head: internalHead,
         }),
       };
     });
@@ -266,7 +265,7 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
 
   async withManagedWorkspaceExecution<T>(
     handle: ManagedWorkspaceExecutionHandle,
-    operation: (context: ManagedWorkspaceExecutionContext) => Promise<T>,
+    operation: (scope: ManagedWorkspaceExecutionScope) => Promise<T>,
   ): Promise<T> {
     return this.#run(async () => {
       let accepted;
@@ -282,6 +281,17 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
           { cause: error },
         );
       }
+      assertExecutionCrossPlaneIdentity(accepted.binding, accepted.receipt, accepted.head);
+      // This preliminary proof exists so crash tests can stop at a real,
+      // completed artifact verification. No authority is published from it.
+      await this.#verifyExecutionArtifactOrQuarantine(accepted.binding, accepted.receipt);
+      await this.failpoint?.('after_execution_artifact_verification');
+
+      // The final proof bundle is intentionally ordered so the exact Git
+      // receipt/binding/worktree verification is the last awaited operation
+      // before the in-memory scope is issued. The root write lease excludes
+      // cooperating Maka writers across the whole sequence.
+      await this.#assertCurrentRootIdentity();
       await assertWorkspaceBaselineAuthorityStoreRootInternal(
         accepted.store,
         this.rootOwner.capability.canonicalPath,
@@ -290,7 +300,8 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
         accepted.store,
         this.rootOwner.capability.rootId,
       );
-      const currentHead = await accepted.store.readWorkspaceHead(
+      const currentHead = await readWorkspaceHeadInternal(
+        accepted.store,
         accepted.binding.workspaceId,
         accepted.binding.workspaceEpochId,
       );
@@ -300,28 +311,21 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
           'Managed workspace execution handle no longer matches the canonical workspace head',
         );
       }
-      await this.#openReadyBinding(accepted.binding);
-      await this.receiptAuthority.verify(accepted.receipt);
-      await this.failpoint?.('after_execution_artifact_verification');
-      // Receipt verification and cwd publication are separate await points.
-      // Re-open the exact binding once more so drift introduced in that seam
-      // is quarantined before the callback can observe an executable path.
-      const binding = await this.#openReadyBinding(accepted.binding);
-      await this.#assertCurrentRootIdentity();
-      return operation(
-        Object.freeze({
-          kind: 'managed_worktree' as const,
-          provisioning: 'canonical_tree_only_v1' as const,
-          cwd: binding.worktreePath,
-          repositoryId: binding.repositoryId,
-          workspaceId: binding.workspaceId,
-          workspaceEpochId: binding.workspaceEpochId,
-          workspaceInstanceId: binding.workspaceInstanceId,
-          workspaceVersionId: currentHead.workspaceVersionId,
-          commitOid: currentHead.commitOid,
-          treeOid: currentHead.treeOid,
-        }),
-      );
+      assertExecutionCrossPlaneIdentity(accepted.binding, accepted.receipt, currentHead);
+      await this.#verifyExecutionArtifactOrQuarantine(accepted.binding, accepted.receipt);
+      const binding = accepted.binding;
+      const scope = issueManagedWorkspaceExecutionScopeInternal(this.#executionOwnerToken, {
+        provisioning: 'canonical_tree_only_v1',
+        workspaceEffect: 'none',
+        cwd: binding.worktreePath,
+        binding: Object.freeze({ ...binding }),
+        head: freezeWorkspaceHead(currentHead),
+      });
+      try {
+        return await operation(scope);
+      } finally {
+        revokeManagedWorkspaceExecutionScopeInternal(this.#executionOwnerToken, scope);
+      }
     });
   }
 
@@ -396,15 +400,81 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
       );
     }
   }
+
+  async #verifyExecutionArtifactOrQuarantine(
+    binding: ManagedWorkspaceBinding,
+    receipt: ManagedWorkspaceBaselineReceiptV1,
+  ): Promise<void> {
+    try {
+      await this.receiptAuthority.verify(receipt);
+    } catch (error) {
+      if (
+        !(error instanceof GitWorkspaceServiceError) ||
+        error.code !== 'managed_workspace_drifted'
+      ) {
+        throw error;
+      }
+      const quarantine = await this.service.quarantineManagedWorkspace(
+        binding,
+        'external_workspace_drift',
+      );
+      throw new ManagedWorkspaceOwnerError(
+        'managed_workspace_quarantined',
+        `Managed workspace drift was quarantined at ${quarantine.quarantinePath}`,
+        { cause: error },
+      );
+    }
+  }
 }
 
 function sameWorkspaceHead(left: WorkspaceHeadRecordV1, right: WorkspaceHeadRecordV1): boolean {
   return (
     left.workspaceId === right.workspaceId &&
+    left.repositoryId === right.repositoryId &&
     left.workspaceEpochId === right.workspaceEpochId &&
     left.workspaceVersionId === right.workspaceVersionId &&
     left.acceptedEventId === right.acceptedEventId &&
     left.commitOid === right.commitOid &&
-    left.treeOid === right.treeOid
+    left.treeOid === right.treeOid &&
+    left.revision === right.revision
   );
+}
+
+function freezeWorkspaceHead(head: WorkspaceHeadRecordV1): Readonly<WorkspaceHeadRecordV1> {
+  return Object.freeze({ ...head });
+}
+
+function freezeManagedWorkspaceBinding(
+  binding: ManagedWorkspaceBinding,
+): Readonly<ManagedWorkspaceBinding> {
+  return Object.freeze({ ...binding });
+}
+
+function freezeManagedWorkspaceReceipt(
+  receipt: ManagedWorkspaceBaselineReceiptV1,
+  binding: Readonly<ManagedWorkspaceBinding>,
+): Readonly<ManagedWorkspaceBaselineReceiptV1> {
+  return Object.freeze({ ...receipt, binding });
+}
+
+function assertExecutionCrossPlaneIdentity(
+  binding: ManagedWorkspaceBinding,
+  receipt: ManagedWorkspaceBaselineReceiptV1,
+  head: Readonly<WorkspaceHeadRecordV1>,
+): void {
+  if (
+    JSON.stringify(binding) !== JSON.stringify(receipt.binding) ||
+    head.repositoryId !== binding.repositoryId ||
+    head.workspaceId !== binding.workspaceId ||
+    head.workspaceEpochId !== binding.workspaceEpochId ||
+    head.workspaceVersionId !== receipt.workspaceVersionId ||
+    head.acceptedEventId !== receipt.baselineAcceptedEventId ||
+    head.commitOid !== binding.baselineCommitOid ||
+    head.treeOid !== binding.baselineTreeOid
+  ) {
+    throw new ManagedWorkspaceOwnerError(
+      'managed_workspace_owner_unavailable',
+      'Managed workspace execution evidence does not identify one exact accepted boundary',
+    );
+  }
 }

--- a/packages/storage/src/managed-workspace-owner.ts
+++ b/packages/storage/src/managed-workspace-owner.ts
@@ -12,6 +12,11 @@ import {
   requireManagedBaselineReceiptAuthorityInternal,
   type ManagedBaselineReceiptAuthorityInternal,
 } from './managed-baseline-receipt-authority-internal.js';
+import {
+  issueManagedWorkspaceExecutionHandleInternal,
+  requireManagedWorkspaceExecutionHandleInternal,
+  type ManagedWorkspaceExecutionHandle,
+} from './managed-workspace-execution-authority-internal.js';
 import type { RuntimeWorkspaceVersionAuthorityStore, WorkspaceHeadRecordV1 } from '@maka/core';
 import {
   assertInteractiveRootOwner,
@@ -35,7 +40,8 @@ export type ManagedWorkspaceOwnerErrorCode =
   | 'managed_workspace_owner_conflict'
   | 'managed_workspace_owner_unavailable'
   | 'managed_workspace_owner_closing'
-  | 'managed_workspace_quarantined';
+  | 'managed_workspace_quarantined'
+  | 'managed_workspace_execution_handle_invalid';
 
 export class ManagedWorkspaceOwnerError extends Error {
   constructor(
@@ -58,15 +64,28 @@ export type ManagedWorkspaceOwnerFailpoint =
   | GitWorkspaceServiceFailpoint
   | 'after_initial_store_root_validation'
   | 'after_baseline_authority_commit'
-  | 'after_post_commit_artifact_verification';
+  | 'after_post_commit_artifact_verification'
+  | 'after_execution_artifact_verification';
 
 export type OpenManagedWorkspaceBaselineInput = CreateManagedWorkspaceFromSourceInput;
 
 export interface OpenManagedWorkspaceBaselineResult {
   readonly created: boolean;
-  readonly binding: ManagedWorkspaceBinding;
-  readonly receipt: ManagedWorkspaceBaselineReceiptV1;
   readonly head: WorkspaceHeadRecordV1;
+  readonly executionHandle: ManagedWorkspaceExecutionHandle;
+}
+
+export interface ManagedWorkspaceExecutionContext {
+  readonly kind: 'managed_worktree';
+  readonly provisioning: 'canonical_tree_only_v1';
+  readonly cwd: string;
+  readonly repositoryId: string;
+  readonly workspaceId: string;
+  readonly workspaceEpochId: string;
+  readonly workspaceInstanceId: string;
+  readonly workspaceVersionId: string;
+  readonly commitOid: string;
+  readonly treeOid: string;
 }
 
 export interface ManagedWorkspaceOwner {
@@ -75,8 +94,14 @@ export interface ManagedWorkspaceOwner {
     store: RuntimeWorkspaceVersionAuthorityStore,
     input: OpenManagedWorkspaceBaselineInput,
   ): Promise<OpenManagedWorkspaceBaselineResult>;
+  withManagedWorkspaceExecution<T>(
+    handle: ManagedWorkspaceExecutionHandle,
+    operation: (context: ManagedWorkspaceExecutionContext) => Promise<T>,
+  ): Promise<T>;
   close(): Promise<void>;
 }
+
+export type { ManagedWorkspaceExecutionHandle };
 
 const owners = new WeakMap<InteractiveRootOwner, object>();
 
@@ -132,6 +157,7 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
   readonly #drainWaiters = new Set<() => void>();
   readonly #assertCurrentRootIdentity: () => Promise<void>;
   #closeTask: Promise<void> | undefined;
+  readonly #executionOwnerToken = {};
 
   constructor(
     private readonly rootOwner: InteractiveRootOwner,
@@ -226,7 +252,76 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
       // verification. Revalidate its identity at the final return gate without
       // rejecting an operation that owner.close() is legitimately draining.
       await this.#assertCurrentRootIdentity();
-      return { ...committed, binding, receipt: durableReceipt };
+      return {
+        ...committed,
+        executionHandle: issueManagedWorkspaceExecutionHandleInternal(this.#executionOwnerToken, {
+          store,
+          binding,
+          receipt: durableReceipt,
+          head: committed.head,
+        }),
+      };
+    });
+  }
+
+  async withManagedWorkspaceExecution<T>(
+    handle: ManagedWorkspaceExecutionHandle,
+    operation: (context: ManagedWorkspaceExecutionContext) => Promise<T>,
+  ): Promise<T> {
+    return this.#run(async () => {
+      let accepted;
+      try {
+        accepted = requireManagedWorkspaceExecutionHandleInternal(
+          this.#executionOwnerToken,
+          handle,
+        );
+      } catch (error) {
+        throw new ManagedWorkspaceOwnerError(
+          'managed_workspace_execution_handle_invalid',
+          'Managed workspace execution handle is invalid for this owner',
+          { cause: error },
+        );
+      }
+      await assertWorkspaceBaselineAuthorityStoreRootInternal(
+        accepted.store,
+        this.rootOwner.capability.canonicalPath,
+      );
+      bindWorkspaceBaselineAuthorityStoreRootInternal(
+        accepted.store,
+        this.rootOwner.capability.rootId,
+      );
+      const currentHead = await accepted.store.readWorkspaceHead(
+        accepted.binding.workspaceId,
+        accepted.binding.workspaceEpochId,
+      );
+      if (!currentHead || !sameWorkspaceHead(currentHead, accepted.head)) {
+        throw new ManagedWorkspaceOwnerError(
+          'managed_workspace_owner_unavailable',
+          'Managed workspace execution handle no longer matches the canonical workspace head',
+        );
+      }
+      await this.#openReadyBinding(accepted.binding);
+      await this.receiptAuthority.verify(accepted.receipt);
+      await this.failpoint?.('after_execution_artifact_verification');
+      // Receipt verification and cwd publication are separate await points.
+      // Re-open the exact binding once more so drift introduced in that seam
+      // is quarantined before the callback can observe an executable path.
+      const binding = await this.#openReadyBinding(accepted.binding);
+      await this.#assertCurrentRootIdentity();
+      return operation(
+        Object.freeze({
+          kind: 'managed_worktree' as const,
+          provisioning: 'canonical_tree_only_v1' as const,
+          cwd: binding.worktreePath,
+          repositoryId: binding.repositoryId,
+          workspaceId: binding.workspaceId,
+          workspaceEpochId: binding.workspaceEpochId,
+          workspaceInstanceId: binding.workspaceInstanceId,
+          workspaceVersionId: currentHead.workspaceVersionId,
+          commitOid: currentHead.commitOid,
+          treeOid: currentHead.treeOid,
+        }),
+      );
     });
   }
 
@@ -301,4 +396,15 @@ class ManagedWorkspaceOwnerImpl implements ManagedWorkspaceOwner {
       );
     }
   }
+}
+
+function sameWorkspaceHead(left: WorkspaceHeadRecordV1, right: WorkspaceHeadRecordV1): boolean {
+  return (
+    left.workspaceId === right.workspaceId &&
+    left.workspaceEpochId === right.workspaceEpochId &&
+    left.workspaceVersionId === right.workspaceVersionId &&
+    left.acceptedEventId === right.acceptedEventId &&
+    left.commitOid === right.commitOid &&
+    left.treeOid === right.treeOid
+  );
 }

--- a/packages/storage/src/sqlite-runtime-store.ts
+++ b/packages/storage/src/sqlite-runtime-store.ts
@@ -939,11 +939,13 @@ export class SqliteRuntimeStore
   }
 
   private registerWorkspaceBaselineAuthorityWriter(databasePath: string): void {
+    const readWorkspaceHead = this.readWorkspaceHead.bind(this);
     registerWorkspaceBaselineAuthorityWriterInternal(
       this,
       databasePath,
       (input, rootId) => this.#commitWorkspaceBaseline(input, rootId),
       (rootId) => this.#bindWorkspaceStorageRoot(rootId),
+      readWorkspaceHead,
     );
   }
 

--- a/packages/storage/src/workspace-version-authority-internal.ts
+++ b/packages/storage/src/workspace-version-authority-internal.ts
@@ -1,4 +1,8 @@
-import type { WorkspaceBaselineAuthorityInput, WorkspaceBaselineCommitResult } from '@maka/core';
+import type {
+  WorkspaceBaselineAuthorityInput,
+  WorkspaceBaselineCommitResult,
+  WorkspaceHeadRecordV1,
+} from '@maka/core';
 import { lstatSync } from 'node:fs';
 import { realpath } from 'node:fs/promises';
 import { basename, dirname, join, normalize, resolve } from 'node:path';
@@ -9,9 +13,14 @@ type WorkspaceBaselineAuthorityWriter = (
   rootId: string,
 ) => Promise<WorkspaceBaselineCommitResult>;
 type WorkspaceStorageRootBinder = (rootId: string) => void;
+type WorkspaceHeadReader = (
+  workspaceId: string,
+  workspaceEpochId: string,
+) => Promise<WorkspaceHeadRecordV1 | undefined>;
 
 interface WorkspaceBaselineAuthorityRegistration {
   readonly writer: WorkspaceBaselineAuthorityWriter;
+  readonly readHead: WorkspaceHeadReader;
   readonly bindStorageRoot: WorkspaceStorageRootBinder;
   readonly databasePath: string;
   readonly databaseFileIdentity?: string;
@@ -28,6 +37,7 @@ export function registerWorkspaceBaselineAuthorityWriterInternal(
   databasePath: string,
   writer: WorkspaceBaselineAuthorityWriter,
   bindStorageRoot: WorkspaceStorageRootBinder,
+  readHead: WorkspaceHeadReader,
 ): void {
   if (workspaceBaselineAuthorityWriters.has(store)) {
     throw new Error('Workspace baseline authority writer is already registered');
@@ -35,10 +45,21 @@ export function registerWorkspaceBaselineAuthorityWriterInternal(
   const resolvedDatabasePath = resolve(databasePath);
   workspaceBaselineAuthorityWriters.set(store, {
     writer,
+    readHead,
     bindStorageRoot,
     databasePath: resolvedDatabasePath,
     databaseFileIdentity: captureRegularFileIdentity(resolvedDatabasePath),
   });
+}
+
+export function readWorkspaceHeadInternal(
+  store: object,
+  workspaceId: string,
+  workspaceEpochId: string,
+): Promise<WorkspaceHeadRecordV1 | undefined> {
+  const registration = workspaceBaselineAuthorityWriters.get(store);
+  if (!registration) throw new Error('Workspace baseline authority reader is unavailable');
+  return registration.readHead(workspaceId, workspaceEpochId);
 }
 
 /**


### PR DESCRIPTION
## Summary

This change gates managed-workspace execution behind an owner-bound, short-lived authority scope. Runtime consumers no longer receive a reusable raw worktree path or a transferable receipt; they can only operate through an opaque scope issued after the storage owner revalidates the complete managed-workspace boundary.

The primary invariant is:

> A managed workspace execution capability is issued only while the durable storage root, workspace binding, baseline receipt, repository state, worktree lock, and canonical workspace head all describe the same exact Git state; the capability becomes unusable as soon as its callback settles or the owner closes.

## What changed

- Add an internal managed-workspace execution authority owned by `ManagedWorkspaceOwner`.
- Replace public raw `cwd`/binding/receipt exposure with an opaque, revocable execution scope.
- Re-read and compare the canonical workspace head immediately before scope issuance.
- Verify the storage-root identity, runtime database identity, binding, receipt, Git HEAD/tree, and worktree ownership lock as one admission proof.
- Quarantine managed worktrees when final verification detects drift.
- Support explicitly concurrent read-only (`workspaceEffect: none`) scopes on the same handle and drain all of them during owner shutdown.
- Return stable error codes for invalid and expired scopes.
- Add production-shaped real-Git, crash/reopen, SIGKILL, expiry, drift, shadowing, concurrent-scope, and runtime-database-detach tests.
- Document the authority owner, admission sequence, failure states, rollback boundary, platform guarantees, and the follow-up worker integration.

## Why

The earlier baseline and owner APIs could prove that a managed worktree existed, but they did not provide a narrow execution boundary. A consumer that obtained the raw worktree path could retain or reuse it after the proof became stale. This PR makes execution admission an explicit storage-owned capability and closes that authority leak before managed workspaces are connected to runtime tools.

## Ownership and atomicity boundary

- **Owner:** `ManagedWorkspaceOwner` and its storage-internal execution authority.
- **Admission boundary:** final canonical-head reread plus exact storage/Git identity verification immediately before scope issuance.
- **Revocation boundary:** callback settlement or owner shutdown.
- **Failure state:** no scope is issued; drift is fail-closed and, where applicable, the managed worktree is quarantined.
- **Rollback:** this slice can be reverted without changing the RuntimeEvent schema or existing Desktop/CLI execution behavior because it has no production runtime-host consumer yet.

This is a detection-and-revocation boundary, not a claim that arbitrary external filesystem writers can be atomically excluded. Stronger process isolation belongs to the subsequent worker/sandbox integration.

## Deliberately out of scope

- Passing the scope into Desktop/CLI/runtime tool execution.
- A managed-workspace worker protocol or read-only tool allowlist.
- Mutation admission, checkpoint creation, redo, or workspace publication.
- Reentrant `owner.close()` protection from inside an active callback; the worker integration will add an execution-context guard.

## Validation

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- Focused storage suites: **45 passed, 0 failed, 6 skipped**.
- The skips are explicit Windows capability gaps for POSIX inode/detach and signal behavior; Windows path and identity behavior remains covered by the applicable tests.

<details>
<summary>中文说明</summary>

## 概要

本次修改把 managed workspace 的执行入口收敛为由 `ManagedWorkspaceOwner` 持有的短生命周期授权作用域。调用方不再获得可长期保存的原始 worktree 路径、binding 或 receipt；只有在 storage owner 重新验证完整 managed-workspace 边界后，才能在回调期间拿到一个不透明、可撤销的 scope。

核心不变量是：

> 只有当 durable storage root、workspace binding、baseline receipt、repository state、worktree ownership lock 与 canonical workspace head 全部指向同一个精确 Git 状态时，系统才签发 managed workspace execution capability；回调结束或 owner 关闭后，该 capability 立即失效。

## 主要修改

- 新增由 `ManagedWorkspaceOwner` 独占的内部 execution authority。
- 删除公共 API 中原始 `cwd`、binding、receipt 的直接暴露，改为 opaque execution scope。
- scope 签发前重新读取并完整比较 canonical workspace head。
- 在同一个 admission proof 中验证 storage-root identity、runtime database identity、binding、receipt、Git HEAD/tree 与 worktree ownership lock。
- 最终验证发现漂移时，对 managed worktree 执行 quarantine。
- 明确定义同一 handle 可以并发持有多个只读（`workspaceEffect: none`）scope；owner shutdown 会等待所有 scope 收敛。
- 为 scope invalid/expired 提供稳定错误码。
- 增加真实 Git、crash/reopen、SIGKILL、scope expiry、drift、method shadowing、并发 scope 和 runtime database detach 等 production-shaped 测试。
- 更新架构文档，明确 owner、原子性边界、失败状态、回滚方式、平台能力与后续 worker 集成边界。

## 为什么要做

之前的 baseline/owner API 能证明 managed worktree 存在，但无法形成狭窄的执行授权边界。调用方拿到原始路径后，可以在证明过期后继续保存或复用它。本 PR 在 managed workspace 接入 runtime tools 之前，把执行许可收敛为 storage-owned capability，从 API 权限上关闭这条泄漏路径。

## Owner 与原子性边界

- **Owner：** `ManagedWorkspaceOwner` 及其 storage-internal execution authority。
- **Admission boundary：** scope 签发前最后一次 canonical head 重读，以及 storage/Git 身份的精确联合验证。
- **Revocation boundary：** callback settle 或 owner shutdown。
- **Failure state：** 不签发 scope；drift fail-closed，并在适用场景 quarantine worktree。
- **Rollback：** 本切片不修改 RuntimeEvent schema，也尚未接入 Desktop/CLI 的生产工具执行，因此可以独立回滚。

这是一条“检测 + 撤销”边界，并不声称能够原子排除任意外部文件系统写入者。更强的进程隔离属于下一阶段 worker/sandbox 集成。

## 明确不在本 PR 范围内

- 将 scope 接入 Desktop/CLI/runtime tools。
- managed-workspace worker protocol 或只读工具 allowlist。
- mutation admission、checkpoint、redo 或 workspace publication。
- active callback 内重入调用 `owner.close()` 的保护；后续 worker 集成将加入 execution-context guard。

## 验证

- Core build 通过。
- Storage build 通过。
- 聚焦测试：**45 passed、0 failed、6 skipped**。
- skips 是明确记录的 Windows capability gap，涉及 POSIX inode/detach 与 signal 语义；适用于 Windows 的路径和身份逻辑仍有覆盖。

</details>