### PR TITLE
fix(headless): make Maka's settlement window reachable at the Harbor boundary

### DIFF
--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -467,7 +467,7 @@ describe('Harbor adapter contract', () => {
       },
     );
     const harborAgent = (
-      harborConfig.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
+      harborConfig.agents as Array<{ env: Record<string, string>; override_timeout_sec?: number }>
     )[0]!;
     assert.equal(harborAgent.env.MAKA_CELL_TIMEOUT_SEC, String(budgetSec));
 
@@ -487,7 +487,10 @@ describe('Harbor adapter contract', () => {
           {
             label: 'harbor',
             env: harborAgent.env,
-            agentPhaseSec: harborAgent.max_timeout_sec!,
+            // The phase Harbor will actually resolve: override_timeout_sec
+            // replaces the task's declared timeout, where max_timeout_sec could
+            // only have capped it.
+            agentPhaseSec: harborAgent.override_timeout_sec!,
           },
           { label: 'pier', env: pierEnv, agentPhaseSec: pierPhaseSec },
         ]),

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -2808,6 +2808,10 @@ describe('buildHarborJobConfig', () => {
   // published on max_timeout_sec satisfies a field-shaped assertion while
   // resolving straight back to the task's own timeout, which is exactly how the
   // window stayed unreachable while these tests were green.
+  // Harbor then scales that by agent_timeout_multiplier ?? timeout_multiplier,
+  // omitted here because this runner never sets the former and every call site
+  // passes 1.0 for the latter. Assert a scaled phase through Harbor's own
+  // multiplier rather than widening this helper if that ever stops being true.
   type HarborAgentEntry = {
     env: Record<string, string>;
     override_timeout_sec?: number;

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -2802,6 +2802,46 @@ describe('buildHarborJobConfig', () => {
     assert.equal(env.MAKA_BACKEND, 'ai-sdk');
   });
 
+  // Harbor resolves the agent phase as `min(override ?? task_declared, max ?? inf)`
+  // (harbor/trial/trial.py, _resolve_timeout_sec). Every deadline assertion below
+  // goes through this rather than reading a field directly: a settlement tail
+  // published on max_timeout_sec satisfies a field-shaped assertion while
+  // resolving straight back to the task's own timeout, which is exactly how the
+  // window stayed unreachable while these tests were green.
+  type HarborAgentEntry = {
+    env: Record<string, string>;
+    override_timeout_sec?: number;
+    max_timeout_sec?: number;
+  };
+  const harborAgentPhaseSec = (agent: HarborAgentEntry, taskDeclaredSec: number): number =>
+    Math.min(
+      agent.override_timeout_sec ?? taskDeclaredSec,
+      agent.max_timeout_sec ?? Number.POSITIVE_INFINITY,
+    );
+
+  test('resolves Maka a settlement tail past the task-declared agent timeout', () => {
+    // The regression this pins: publishing budget + grace on max_timeout_sec.
+    // Harbor folds that to min(1800, 1830) = 1800, so the cell was SIGKILLed at
+    // the instant it was supposed to begin writing maka-cell-output.json — and
+    // every timed-out Maka cell lost its already-authoritative verifier reward.
+    const declared = 1800;
+    const config = buildHarborJobConfig(runInput(), {
+      makaRepoPath: '/repo',
+      jobsDir: '/jobs/x',
+      jobName: 'trial',
+      model: 'deepseek/deepseek-v4-flash',
+      agentEnv: { MAKA_CELL_TIMEOUT_SEC: String(declared) },
+    });
+    const agent = (config.agents as HarborAgentEntry[])[0]!;
+    assert.equal(
+      harborAgentPhaseSec(agent, declared),
+      declared + MAKA_SETTLEMENT_GRACE_SEC,
+      'Harbor must kill one settlement window after the model budget, not at it',
+    );
+    // A ceiling cannot raise a base, so leaving one behind can only re-clamp it.
+    assert.equal(agent.max_timeout_sec, undefined);
+  });
+
   test('every arm gets the same model budget and only Maka a settlement tail', () => {
     // Maka's cell stops calling the model one grace window before its own budget
     // runs out; native CLIs run until Harbor cancels. Taking the grace out of the
@@ -2821,9 +2861,7 @@ describe('buildHarborJobConfig', () => {
             }
           : {}),
       });
-      return (
-        config.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
-      )[0]!;
+      return (config.agents as HarborAgentEntry[])[0]!;
     };
 
     // Pin the window as a real quantity: with a zero grace every assertion below
@@ -2831,22 +2869,21 @@ describe('buildHarborJobConfig', () => {
     assert.ok(MAKA_SETTLEMENT_GRACE_SEC > 0, 'the settlement window must be a real window');
 
     const maka = agentFor('maka');
-    assert.equal(maka.max_timeout_sec, 1800 + MAKA_SETTLEMENT_GRACE_SEC);
+    const makaPhase = harborAgentPhaseSec(maka, 1800);
+    assert.equal(makaPhase, 1800 + MAKA_SETTLEMENT_GRACE_SEC);
     // The budget the cell is handed is the model budget itself, on every path.
     assert.equal(maka.env.MAKA_CELL_TIMEOUT_SEC, '1800');
     assert.equal(maka.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, String(MAKA_SETTLEMENT_GRACE_SEC));
     // Harbor kills at the agent phase, which is that budget plus the window.
-    assert.equal(
-      maka.max_timeout_sec! - Number(maka.env.MAKA_CELL_TIMEOUT_SEC),
-      MAKA_SETTLEMENT_GRACE_SEC,
-    );
+    assert.equal(makaPhase - Number(maka.env.MAKA_CELL_TIMEOUT_SEC), MAKA_SETTLEMENT_GRACE_SEC);
 
     const codex = agentFor('codex');
-    assert.equal(codex.max_timeout_sec, 1800);
+    const codexPhase = harborAgentPhaseSec(codex, 1800);
+    assert.equal(codexPhase, 1800);
     assert.equal(codex.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, undefined);
     // The whole asymmetry: Maka's phase is longer by exactly the window it
     // spends settling, and both arms still call the model for the same 1800s.
-    assert.equal(maka.max_timeout_sec! - codex.max_timeout_sec!, MAKA_SETTLEMENT_GRACE_SEC);
+    assert.equal(makaPhase - codexPhase, MAKA_SETTLEMENT_GRACE_SEC);
   });
 
   test('an operator-widened settlement window is honoured, not overwritten', () => {
@@ -2863,12 +2900,10 @@ describe('buildHarborJobConfig', () => {
         MAKA_CELL_SETTLEMENT_GRACE_SEC: String(widened),
       },
     });
-    const agent = (
-      config.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
-    )[0]!;
+    const agent = (config.agents as HarborAgentEntry[])[0]!;
     assert.equal(agent.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, String(widened));
     assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, '1800');
-    assert.equal(agent.max_timeout_sec, 1800 + widened);
+    assert.equal(harborAgentPhaseSec(agent, 1800), 1800 + widened);
   });
 
   test('a malformed cell timeout falls back instead of failing the run', () => {
@@ -2897,7 +2932,9 @@ describe('buildHarborJobConfig', () => {
     for (const { raw, parsed } of cases) {
       const agentEnv: Record<string, string> =
         raw === undefined ? {} : { MAKA_CELL_TIMEOUT_SEC: raw };
-      const label = JSON.stringify(raw);
+      // String(): JSON.stringify(undefined) is undefined, and an undefined assert
+      // message throws ERR_INVALID_ARG_TYPE over the top of the real diff.
+      const label = String(JSON.stringify(raw));
 
       // A parse miss falls back to the task metadata timeout.
       const withMetadata = buildHarborJobConfig(
@@ -2916,9 +2953,7 @@ describe('buildHarborJobConfig', () => {
           model: 'deepseek/deepseek-v4-flash',
         },
       );
-      const metadataAgent = (
-        withMetadata.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
-      )[0]!;
+      const metadataAgent = (withMetadata.agents as HarborAgentEntry[])[0]!;
       assert.equal(metadataAgent.env.MAKA_CELL_TIMEOUT_SEC, String(parsed ?? 1234), label);
       assert.equal(
         metadataAgent.env.MAKA_STREAM_CONNECT_TIMEOUT_MS,
@@ -2931,7 +2966,7 @@ describe('buildHarborJobConfig', () => {
         label,
       );
       assert.equal(
-        metadataAgent.max_timeout_sec,
+        harborAgentPhaseSec(metadataAgent, 1234),
         (parsed ?? 1234) + MAKA_SETTLEMENT_GRACE_SEC,
         label,
       );
@@ -2944,17 +2979,18 @@ describe('buildHarborJobConfig', () => {
         jobName: 'trial',
         model: 'deepseek/deepseek-v4-flash',
       });
-      const agent = (
-        withoutMetadata.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
-      )[0]!;
+      const agent = (withoutMetadata.agents as HarborAgentEntry[])[0]!;
       assert.equal(
         agent.env.MAKA_CELL_TIMEOUT_SEC,
         parsed !== undefined ? String(parsed) : raw,
         label,
       );
+      // With nothing to derive a budget from, the phase must stay Harbor's own —
+      // the task's declared timeout, stood in for here by a sentinel.
+      const declaredSentinel = 4321;
       assert.equal(
-        agent.max_timeout_sec,
-        parsed === undefined ? undefined : parsed + MAKA_SETTLEMENT_GRACE_SEC,
+        harborAgentPhaseSec(agent, declaredSentinel),
+        parsed === undefined ? declaredSentinel : parsed + MAKA_SETTLEMENT_GRACE_SEC,
         label,
       );
     }
@@ -2977,13 +3013,11 @@ describe('buildHarborJobConfig', () => {
         provider: 'zai-coding-plan',
       },
     );
-    const agent = (
-      config.agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
-    )[0]!;
+    const agent = (config.agents as HarborAgentEntry[])[0]!;
     assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, '1234');
     assert.equal(agent.env.MAKA_STREAM_CONNECT_TIMEOUT_MS, '1234000');
     assert.equal(agent.env.MAKA_STREAM_IDLE_TIMEOUT_MS, '1234000');
-    assert.equal(agent.max_timeout_sec, 1234 + MAKA_SETTLEMENT_GRACE_SEC);
+    assert.equal(harborAgentPhaseSec(agent, 1234), 1234 + MAKA_SETTLEMENT_GRACE_SEC);
   });
 
   test('merges per-attempt agent env into the Harbor agent config', () => {

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -1526,10 +1526,13 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
         systemPrompt: 'PROMPT\n',
       },
       { makaRepoPath: '/repo', jobsDir: '/jobs/x', jobName: 'trial', model: 'deepseek/v4' },
-    ).agents as Array<{ env: Record<string, string>; max_timeout_sec?: number }>
+    ).agents as Array<{ env: Record<string, string>; override_timeout_sec?: number }>
   )[0]!;
+  // override_timeout_sec, not max_timeout_sec: Harbor folds the latter in as
+  // `min(base, max)`, so a tail published there resolves back to the task's own
+  // declared timeout and the settlement window never exists.
   assert.equal(
-    anchorAgent.max_timeout_sec! - Number(anchorAgent.env.MAKA_CELL_TIMEOUT_SEC),
+    anchorAgent.override_timeout_sec! - Number(anchorAgent.env.MAKA_CELL_TIMEOUT_SEC),
     tbenchManifest.metadata.benchmark.agentSettlementGraceSec,
   );
   // Every arm is handed MAKA_SYSTEM_PROMPT but only the Maka cell applies it, so

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -1217,7 +1217,13 @@ export function buildHarborJobConfig(
                 }
               : {},
         env: agentEnv,
-        ...(agentPhaseSec !== undefined ? { max_timeout_sec: agentPhaseSec } : {}),
+        // override_timeout_sec, not max_timeout_sec: Harbor resolves the agent
+        // phase as `min(override ?? task_declared, max ?? inf)`, so max_ can only
+        // ever lower the task's own timeout. Asking for budget + settlement
+        // through max_ resolved to the task timeout unchanged, which left Maka's
+        // settlement window mathematically unreachable — the cell was SIGKILLed
+        // at the instant it was supposed to start writing.
+        ...(agentPhaseSec !== undefined ? { override_timeout_sec: agentPhaseSec } : {}),
       },
     ],
     datasets: [],


### PR DESCRIPTION
## Summary

Harbor resolves an agent phase as `min(override_timeout_sec ?? task_declared, max_timeout_sec ?? inf) * multiplier` ([`harbor/trial/trial.py`](https://github.com/laude-institute/harbor/blob/main/harbor/trial/trial.py) `_resolve_timeout_sec`). We published the model budget plus Maka's settlement tail on `max_timeout_sec`, which is a **ceiling**: it can only lower the task's own declared timeout, never raise it. For every Terminal-Bench task the tail resolved straight back to the declared timeout, so the Maka cell was SIGKILLed at the exact instant it was supposed to stop calling the model and begin writing `maka-cell-output.json`.

Only Maka has a settlement window — native CLIs have nothing to settle — so only Maka paid.

Observed on run `deepseek-v4-flash-3arm-tbench-2.1-full-v7` (#1970, 89 tasks × 3 arms). Six Maka cells that Harbor's own verifier had already scored `reward = 1.0` were recorded as `passed = false, scored = false`:

| task | Harbor `verifier_result.rewards.reward` | WAL |
| --- | --- | --- |
| `adaptive-rejection-sampler` | 1.0 | `task_budget_exhausted`, `passed=false` |
| `caffe-cifar-10` | 1.0 | same |
| `largest-eigenval` | 1.0 | same |
| `mcmc-sampling-stan` | 1.0 | same |
| `path-tracing` | 1.0 | same |
| `schemelike-metacircular-eval` | 1.0 | same |

`adaptive-rejection-sampler` is the controlled pair: both arms hit `AgentTimeoutError`, both scored `reward = 1.0`, and the Codex cell was recorded `task_completed / passed=true / scored=true` while the Maka cell was discarded.

## Root cause

The settlement never ran at all — it did not run and overrun the grace. All six cells' `core_agent_runs` rows read `status = running, abortSource = null`, and the last `runtime_events` row lands on the SIGKILL instant, so the agent was still working normally through what should have been its quiet window. That is the signature of a window that never opened, and it follows directly from `min(3600, 3630) = 3600`.

## Review focus

The tests asserted the field we set rather than the deadline Harbor resolves, which is why they stayed green across the entire failure. They now go through a helper that models Harbor's own resolution rule, so republishing the tail on a ceiling fails them.

Two sites are deliberately untouched:

- `harbor-task-runner.ts:689` (oracle job) makes the same field substitution, but its value *is* the task's declared timeout, so `min()` is inert. Changing it would widen the diff without fixing anything.
- `harbor-smoke-config.ts:252` has the real form of this bug. Its profiles carry an `agent_timeout_multiplier` that Harbor applies *after* the `min()`, so an absolute override would be scaled by it (8× on `maka-heavy`). Fixing it needs its own analysis and a smoke run to verify, so it is tracked separately rather than guessed at here. It bites when `declared < (budget + grace) / multiplier` — the multiplier is what keeps today's profiles clear of it, which is a mask rather than a fix. The benchmark path is unaffected: `harbor-task-runner.ts` sets no `agent_timeout_multiplier`, and the v7 trial configs confirm `timeout_multiplier: 1.0, agent_timeout_multiplier: null`.

## Verification

- `npm run --workspace @maka/headless test` — 1346 pass, 0 fail
- `npm run lint`, `npm run format:check` — clean
- `npm run typecheck --workspace @maka/headless` — clean
- Red-first: with the tail republished on `max_timeout_sec`, the new deadline assertions fail (`1234 !== 1264`, `1830 !== 1875`), and both cross-boundary contracts fail

Not run: the smoke harness (`harbor-smoke-config.ts` is unchanged here) and any live Harbor trial — this run's cells are re-scored from their on-disk authoritative artifacts rather than re-executed.

## Known gap

Fixing the window means the cell writes its own output, so the scoring path below it is no longer reached in practice. It is still wrong on its own terms: `harbor-task-runner.ts:477` discards an authoritative Harbor reward when the agent's *self-report* is missing, even though the reward and the verifier outcome are both present. Repairing that changes WAL scoring semantics (`task_budget_exhausted` would begin carrying `passed = true`) and touches the A/B denominator, so it is a separate PR rather than a rider here.

Refs #1970

