### PR TITLE
fix(desktop): honor default permission mode immediately

### DIFF
--- a/apps/desktop/src/renderer/app-shell-overlays.tsx
+++ b/apps/desktop/src/renderer/app-shell-overlays.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react';
 import type {
+  ChatDefaultPermissionMode,
   LlmConnection,
   ProviderType,
   SettingsSection,
@@ -51,6 +52,7 @@ export function AppShellOverlays(props: {
   setUiLocalePreference: (preference: UiLocalePreference) => void;
   uiLocaleUpdateGate: UiLocaleUpdateGate;
   setUserLabel(userLabel: string): void;
+  setDefaultPermissionMode(mode: ChatDefaultPermissionMode): void;
   settingsRequestedSection: SettingsSection | undefined;
   settingsProviderCatalogOpen: boolean;
   settingsConnectionDetailSlug: string | undefined;
@@ -91,6 +93,7 @@ export function AppShellOverlays(props: {
     setUiLocalePreference,
     uiLocaleUpdateGate,
     setUserLabel,
+    setDefaultPermissionMode,
     themePalette,
     themePref,
   } = props;
@@ -114,6 +117,7 @@ export function AppShellOverlays(props: {
             onUiLocalePreferenceChange={setUiLocalePreference}
             uiLocaleUpdateGate={uiLocaleUpdateGate}
             onUserLabelChange={setUserLabel}
+            onDefaultPermissionModeChange={setDefaultPermissionMode}
             requestedSection={settingsRequestedSection}
             openProviderCatalog={settingsProviderCatalogOpen}
             initialConnectionSlug={settingsConnectionDetailSlug}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2582,6 +2582,7 @@ function AppShellContent({
         setUiLocalePreference={setUiLocalePreference}
         uiLocaleUpdateGate={uiLocaleUpdateGate}
         setUserLabel={setUserLabel}
+        setDefaultPermissionMode={setDefaultPermissionMode}
         settingsRequestedSection={settingsRequestedSection}
         settingsProviderCatalogOpen={settingsProviderCatalogOpen}
         settingsConnectionDetailSlug={settingsConnectionDetailSlug}

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { useHotkeys } from '@astryxdesign/core/hooks';
 import type {
+  ChatDefaultPermissionMode,
   LlmConnection,
   ProviderType,
   SettingsSection,
@@ -35,6 +36,7 @@ export function SettingsModal(props: {
   onUiLocalePreferenceChange(preference: UiLocalePreference): void;
   uiLocaleUpdateGate: UiLocaleUpdateGate;
   onUserLabelChange?(label: string): void;
+  onDefaultPermissionModeChange(mode: ChatDefaultPermissionMode): void;
   /**
    * Force the modal to a specific section when it (re-)mounts or when the
    * value changes while already open. Used by the command palette so
@@ -100,6 +102,7 @@ export function SettingsModal(props: {
         onUiLocalePreferenceChange={props.onUiLocalePreferenceChange}
         uiLocaleUpdateGate={props.uiLocaleUpdateGate}
         onUserLabelChange={props.onUserLabelChange}
+        onDefaultPermissionModeChange={props.onDefaultPermissionModeChange}
         requestedSection={props.requestedSection}
         openProviderCatalog={props.openProviderCatalog}
         initialConnectionSlug={props.initialConnectionSlug}

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -16,6 +16,7 @@ import {
 import { ArrowLeft } from '@maka/ui/icons';
 import type {
   AppSettings,
+  ChatDefaultPermissionMode,
   LlmConnection,
   ProviderType,
   SettingsSection,
@@ -66,6 +67,7 @@ export function SettingsSurface(props: {
   onUiLocalePreferenceChange(preference: UiLocalePreference): void;
   uiLocaleUpdateGate: UiLocaleUpdateGate;
   onUserLabelChange?(label: string): void;
+  onDefaultPermissionModeChange(mode: ChatDefaultPermissionMode): void;
   requestedSection?: SettingsSection;
   openProviderCatalog?: boolean;
   initialConnectionSlug?: string;
@@ -201,6 +203,12 @@ export function SettingsSurface(props: {
         next.personalization.uiLocale,
         props.onUiLocalePreferenceChange,
       );
+      if (patch.chatDefaults?.permissionMode !== undefined) {
+        // The empty composer lives outside Settings and mirrors this value.
+        // Update it from the committed result even if Settings closed while
+        // the save was in flight; a close-time re-read can race the write.
+        props.onDefaultPermissionModeChange(next.chatDefaults.permissionMode);
+      }
       if (settingsModalMountedRef.current && ticket === settingsUpdateTicketRef.current) {
         setSettings(next);
         props.onUserLabelChange?.(next.personalization.displayName);

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -813,6 +813,7 @@ function SettingsStory(props: {
           onThemePaletteChange={setThemePalette}
           onUiLocalePreferenceChange={noop}
           uiLocaleUpdateGate={uiLocaleUpdateGate}
+          onDefaultPermissionModeChange={noop}
           requestedSection={props.section}
           initialFocusRef={initialFocusRef}
           onOpenDailyReview={noop}


### PR DESCRIPTION
## Summary
- sync the committed default permission mode from Settings back to AppShell
- eliminate the save/close race that left the new-chat composer showing Ask
- keep Main as the sole authority when a Session is actually created

## Verification
- Desktop typecheck
- 14 focused default-permission session creation tests
- Biome and git diff checks