### PR TITLE
fix(headless): honour the command-timeout floor over the Harbor bridge

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -4850,6 +4850,47 @@ describe('createHarborHttpToolExecutor', () => {
     }
   });
 
+  test('applies the operator command-timeout floor over the bridge too', async () => {
+    // MAKA_CELL_COMMAND_TIMEOUT_MS reached the local executor and was dropped on
+    // the floor here, so the same env var raised the per-command ceiling in
+    // container mode and did nothing in host-cell mode — the mode the benchmark
+    // actually runs. maka_agent.py forwards it either way.
+    const previousFetch = globalThis.fetch;
+    const bodies: Array<Record<string, unknown>> = [];
+    try {
+      globalThis.fetch = async (_input, init) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return new Response(JSON.stringify({ exitCode: 0, stdout: '', stderr: '' }), {
+          status: 200,
+        });
+      };
+      const executor = createMockedHarborHttpToolExecutor({
+        MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
+        MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+        MAKA_CELL_COMMAND_TIMEOUT_MS: '600000',
+      });
+
+      // A command that asks for nothing inherits the operator's floor.
+      await executor.exec({ command: 'make', cwd: '/workspace' });
+      assert.equal(bodies.at(-1)?.timeoutMs, 600_000);
+
+      // A command that asks for its own timeout still owns it, in both directions.
+      await executor.exec({ command: 'ls', cwd: '/workspace', timeoutMs: 5_000 });
+      assert.equal(bodies.at(-1)?.timeoutMs, 5_000);
+
+      // Unset leaves the field off entirely so the bridge's own default stands as
+      // the single fallback rather than being shadowed by a second one here.
+      const bare = createMockedHarborHttpToolExecutor({
+        MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
+        MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+      });
+      await bare.exec({ command: 'make', cwd: '/workspace' });
+      assert.equal(Object.hasOwn(bodies.at(-1) ?? {}, 'timeoutMs'), false);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   test('uses a long-running dispatcher without replacing active-tool cancellation', async () => {
     const previousFetch = globalThis.fetch;
     const controller = new AbortController();
@@ -4890,7 +4931,6 @@ describe('createHarborHttpToolExecutor', () => {
         command: 'sleep until cancelled',
         cwd: '/workspace',
         timeoutMs: 600_000,
-        timeoutSec: 600,
       });
     } finally {
       globalThis.fetch = previousFetch;

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -37,10 +37,20 @@ export function createHarborHttpToolExecutor(
 ): IsolatedToolExecutor {
   const baseUrl = requiredHarborEnv(env, 'MAKA_HARBOR_TOOL_EXECUTOR_URL');
   const token = requiredHarborEnv(env, 'MAKA_HARBOR_TOOL_EXECUTOR_TOKEN');
+  // The same floor the local executor applies, for the same reason: a task that
+  // builds or tests for longer than the default must be able to say so once
+  // instead of losing every command to it. Left unread, this env var worked in
+  // container mode and was silently inert in host-cell mode — the adapter
+  // forwards it either way. Unset stays unset so the bridge's own default
+  // (maka_agent.py _BRIDGE_DEFAULT_TIMEOUT_SEC) remains the single fallback.
+  const operatorDefaultTimeoutMs = numericEnv(env.MAKA_CELL_COMMAND_TIMEOUT_MS);
   return {
     exec: async (input, control) => {
-      const timeoutSec =
-        input.timeoutMs === undefined ? undefined : Math.max(1, Math.ceil(input.timeoutMs / 1000));
+      // timeoutMs is the field the bridge reads (maka_agent.py _ToolExecutorServer
+      // takes payload["timeoutMs"]); the timeoutSec that used to ride alongside it
+      // was never read by anything, and sitting next to the live field is how the
+      // env var above looked handled while doing nothing.
+      const timeoutMs = input.timeoutMs ?? operatorDefaultTimeoutMs;
       const response = await fetchImpl(new URL('/exec', baseUrl), {
         method: 'POST',
         headers: {
@@ -49,7 +59,7 @@ export function createHarborHttpToolExecutor(
         },
         body: JSON.stringify({
           ...input,
-          ...(timeoutSec !== undefined ? { timeoutSec } : {}),
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
         }),
         signal: control?.abortSignal,
         dispatcher: harborHttpDispatcher,

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -18,6 +18,11 @@ import {
 
 const execAsync = promisify(nodeExec);
 
+// Container mode's fallback when no command and no operator asks for a timeout.
+// Its host-cell counterpart is maka_agent.py's _BRIDGE_DEFAULT_TIMEOUT_SEC: two
+// enforcers in two processes, so two constants, but the same cell must not be
+// killed at different times depending on which isolation mode ran it. Change
+// both or neither.
 export const HARBOR_CELL_DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
 // The bridge returns response headers only after the isolated command exits.


### PR DESCRIPTION
## Summary

`MAKA_CELL_COMMAND_TIMEOUT_MS` is honoured by `createHarborCellLocalToolExecutor` ([`harbor-cell-tool-executor.ts:110`](https://github.com/maka-agent/maka-agent/blob/main/packages/headless/src/harbor-cell-tool-executor.ts#L110)) and silently ignored by `createHarborHttpToolExecutor`. Container-mode cells use the first; host-cell mode — the mode `run-host-cell.mjs` and therefore the Terminal-Bench benchmark runs — uses the second. `maka_agent.py:625` forwards the variable on both paths, which is what kept the gap invisible: the knob looked wired end to end while doing nothing on the path that matters.

While fixing it: the bridge reads `payload["timeoutMs"]` (`maka_agent.py` `_ToolExecutorServer`), and the `timeoutSec` the client sent alongside it was never read by anything. A dead field sitting next to the live one is how a timeout could look handled while being dropped, so this resolves one effective timeout into `timeoutMs` and removes `timeoutSec`.

Unset behaviour is deliberately unchanged: no timeout field is sent, so the bridge's own `_BRIDGE_DEFAULT_TIMEOUT_SEC` (120s) stays the single fallback rather than being shadowed by a second default on the client. Both paths already agree on 120s when the variable is unset, so no existing run changes.

## Review focus

**This did not cause the 300-second command timeouts seen in the #1970 run.** Those were the model's own choice: it passes `timeout_ms` explicitly on 11 of 32 Bash calls in `extract-moves-from-video` (`300000`, `240000`, `180000`, `90000`, `40000`), and `apt-get install ffmpeg` outran the 300s the model itself picked. `MAKA_CELL_COMMAND_TIMEOUT_MS` was not set for that run at all. This PR fixes a latent inconsistency found while tracing that, not the observed failure.

## Verification

- `npm run --workspace @maka/headless test` — 1346 pass, 0 fail
- `npm run lint`, `npm run format:check` — clean
- `npm run typecheck --workspace @maka/headless` — clean
- Red-first: without the executor change the new test fails `undefined !== 600000`

The new test pins all three cases the bug spans — operator floor applied when the tool asks for nothing, an explicit per-command timeout still winning in both directions, and the field omitted entirely when unset.

Not run: a live Harbor trial. The bridge contract is asserted against the payload the client sends, and the field name is checked against `maka_agent.py`'s reader rather than assumed.

Refs #1970
