### PR TITLE
fix(settings): stop the row hairline bending on Astryx Item's corners

### DIFF
--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -22,6 +22,23 @@
   border-block-start: var(--border-width-hairline) solid var(--border);
 }
 
+/* …and the row must be square for that hairline to read as one line.
+   Astryx's Item ships `border-radius: 10px` for its standalone use — a
+   rounded chip that highlights on hover. Our divider is a border on the Item
+   itself, and a border follows its element's corners, so the line curved
+   down at both ends: a straight middle with two hooks, which reads as two
+   different divider systems meeting. (Reported by owner; measured at
+   runtime as radius 10px + border-block-start 1px on `.astryx-item`.)
+
+   In an edge-to-edge row group the row is not a chip — it spans the column,
+   so its hover highlight should span it too. Zeroing the radius is therefore
+   the whole fix: do NOT wrap the row to preserve rounded hover, which would
+   reintroduce the chip the open idiom removed. */
+.settingsRows > .astryx-item,
+.settingsRowsGroup > .astryx-item {
+  border-radius: 0;
+}
+
 /* Form blocks inside a row group (SettingsField / SettingsActions): block
    padding only — the open idiom has no inline inset, so fields stay flush
    with the section heading and the Item rows around them. */

--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -120,6 +120,11 @@ const DYNAMIC_STYLE_HOOKS = new Set([
   // Rendered by Astryx's own Collapsible; chat-message.css targets it to give
   // reasoning/tool disclosures one trigger dialect inside the turn body (#1768).
   'astryx-collapsible-trigger',
+  // Astryx's Item (themeProps class on every settings row). rows.css squares
+  // its corners inside an open row group: Item ships a 10px radius for its
+  // standalone chip use, and our hairline is a border on the Item itself, so
+  // the radius bent the divider at both ends.
+  'astryx-item',
   // Rendered by `useTriggerMenu` for the composer's `@` / `/` menus.
   // composer-mention.css caps its width: upstream sets a 180px floor and no
   // ceiling, and our rows carry a non-wrapping second line.


### PR DESCRIPTION
Task #143 — owner 报障的「弯曲分隔线 / 两套隔离线」。

## 根因（运行时实测，不是推断）

探针取计算样式：开放行组里**每一个 `.astryx-item` 都同时是 `border-radius: 10px` + `border-block-start: 1px`**。

Astryx 给 Item 这个圆角是服务它的独立用法 —— 一个 hover 时高亮的圆角芯片。而我们的 hairline 是画在 **Item 元素自己身上**的 border，**border 会跟着自己元素的圆角走**，于是分隔线两端向下弯。一条线，两种形状 —— owner 看到的「两套隔离线」就是这个。

## 修法

在 `.settingsRows` / `.settingsRowsGroup` 内把 Item 圆角归零，**这就是全部**。

edge-to-edge 行组里的行**不是芯片**：它横贯内容列，所以它的 hover 高亮本来就该横贯。为了保住圆角 hover 去包一层 wrapper，等于把开放行组刚去掉的芯片又装回来 —— 按规格没有这么做。

## 全仓同族扫描（用通用检测，不是 grep CSS）

写了个探针走 9 个设置页，报告**所有同时带横向 border 和圆角的元素**。这比搜 CSS 规则可靠 —— 圆角来自 Astryx 主题，源码里根本搜不到。

结果两类宿主：

| 宿主 | 判定 |
|---|---|
| `.astryx-item` | ✅ **就是这个 bug**，命中 关于 / 通用 / 数据 / 记忆 / 语音 / 健康 **6 个页面**，一条规则全覆盖 |
| `kbd` | ❌ **不是**。radius 6px + borderBottom 2px，但四角全圆、底部粗边是 Astryx 的**键帽效果**，故意画的。不动 |

修完重跑扫描：`.astryx-item` 条目**全部消失**，只剩 kbd。

**两个虚惊，都核过了**：
- `.maka-plan-rows` 圆角在**容器**上且 `overflow: hidden` —— 这正是正确形状
- `.maka-skill-library-item` 附近那个圆角属于旁边的状态图标方块，不是带 border 的行

## 顺带

`astryx-item` 加进 check-dead-css 的运行时类白名单，紧挨着 `astryx-collapsible-trigger` —— 同样的理由：Astryx 通过 themeProps 运行时产出，源码里不存在这个 className 字面量。

## 验证

| 步骤 | 结果 |
|---|---|
| `npm run build` | ✅ |
| `npm run typecheck` | ✅ |
| `npm run format:check` | ✅ |
| `check-dead-css --check` | ✅ |
| `test:checks` | ✅ |
| workspace · **desktop** | ✅ |
| workspace · **ui** | ✅ |
| 真实 app 前后截图（关于 / 数据） | ✅ 分隔线两端笔直到边 |

已知失败：`storage` / `cli` 是 Node v25 `node:sqlite`；`runtime-host` 是并行 runner 下的 ownership 测试 flake（单独跑必过）。均与本 PR 无关，本 PR 只改一条 CSS 规则 + 一个白名单条目。

@maka-审美专家 请 review。