### PR TITLE
fix(headless): let an authoritative reward survive a missing agent self-report

### DIFF
--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -85,12 +85,21 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.taskLevel.losses, 1);
   });
 
-  test('counts a graded budget exhaustion as a pass', () => {
+  // A graded budget exhaustion now decides A/B outcomes, so pin what it does to
+  // the paired layer, not just the arm-level rate: this is the consumer the
+  // rescued cells actually reach.
+  test('counts a graded budget exhaustion as a pass and lets it decide a pair', () => {
     const gradedTimeout = {
       ...budgetExhausted('long-task'),
       passed: true,
       scored: true,
-      harbor: { reward: 1 },
+      harbor: {
+        reward: 1,
+        verifier: {
+          outcome: 'passed' as const,
+          attempts: [{ attempt: 1, classification: 'passed' as const, durationMs: 5, reward: 1 }],
+        },
+      },
     };
     const result = summarizeAbComparison({
       runId: 'ab-run',
@@ -106,6 +115,16 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.baseline.budgetExhausted, 1);
     assert.equal(result.baseline.passed, 1);
     assert.equal(result.baseline.passRate, 1);
+    // The pair is evaluated and lost by the candidate — a graded timeout is not
+    // excluded from the denominator, and it is not a free tie.
+    assert.equal(result.pairedAttempts.evaluatedPairs, 1);
+    assert.equal(result.pairedAttempts.baselinePassed, 1);
+    assert.equal(result.pairedAttempts.candidatePassed, 0);
+    assert.equal(result.pairedAttempts.losses, 1);
+    assert.equal(result.pairedAttempts.wins, 0);
+    // It is still budget-shaped, so the non-budget conditional view excludes it.
+    assert.deepEqual(result.pairedAttempts.budgetExcludedPairIds, ['long-task#r0']);
+    assert.equal(result.pairedAttempts.nonBudgetEvaluatedPairs, 0);
   });
 
   test('classifies a scored completed benchmark deadline as budget exhausted', () => {

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -85,6 +85,29 @@ describe('summarizeAbComparison', () => {
     assert.equal(result.taskLevel.losses, 1);
   });
 
+  test('counts a graded budget exhaustion as a pass', () => {
+    const gradedTimeout = {
+      ...budgetExhausted('long-task'),
+      passed: true,
+      scored: true,
+      harbor: { reward: 1 },
+    };
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka-baseline',
+      candidateArmId: 'candidate',
+      evaluationTaskIds: ['long-task'],
+      baselineRuns: [[gradedTimeout]],
+      candidateRuns: [[completed('long-task', false)]],
+    });
+
+    assert.equal(result.baseline.valid, 1);
+    assert.equal(result.baseline.budgetExhausted, 1);
+    assert.equal(result.baseline.passed, 1);
+    assert.equal(result.baseline.passRate, 1);
+  });
+
   test('classifies a scored completed benchmark deadline as budget exhausted', () => {
     const deadlineFailure = {
       ...completed('long-task', false),

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -1008,6 +1008,120 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('scores a budget exhaustion the verifier already graded', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        taskRunner: async () => {
+          throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
+            harbor: {
+              reward: 1,
+              verifier: {
+                outcome: 'passed',
+                attempts: [{ attempt: 1, classification: 'passed', durationMs: 5, reward: 1 }],
+              },
+            },
+          });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      const event = result.events[0];
+      assert.equal(event?.type, 'task_budget_exhausted');
+      if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+      assert.equal(event.passed, true);
+      assert.equal(event.scored, true);
+      assert.equal(event.eligible, true);
+      assert.equal(event.harbor?.reward, 1);
+    });
+  });
+
+  test('records a graded-zero budget exhaustion as scored but not passed', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        taskRunner: async () => {
+          throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
+            harbor: {
+              reward: 0,
+              verifier: {
+                outcome: 'failed',
+                attempts: [{ attempt: 1, classification: 'failed', durationMs: 5, reward: 0 }],
+              },
+            },
+          });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      const event = result.events[0];
+      assert.equal(event?.type, 'task_budget_exhausted');
+      if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+      assert.equal(event.passed, false);
+      assert.equal(event.scored, true);
+    });
+  });
+
+  test('leaves a graded budget exhaustion unscored when its evidence does not attest the arm', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        taskRunner: async () => {
+          throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
+            harbor: {
+              reward: 1,
+              verifier: {
+                outcome: 'passed',
+                attempts: [{ attempt: 1, classification: 'passed', durationMs: 5, reward: 1 }],
+              },
+            },
+          });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      const event = result.events[0];
+      assert.equal(event?.type, 'task_budget_exhausted');
+      if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+      assert.equal(event.passed, false);
+      assert.equal(event.scored, false);
+      assert.equal(event.eligible, false);
+      assert.equal(event.evidenceErrorClass, 'missing_execution_identity');
+    });
+  });
+
   test('keeps an unattested timeout ineligible for A/B attribution', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -997,6 +997,9 @@ describe('fixed prompt controller', () => {
       assert.equal(result.events[0]?.type, 'task_budget_exhausted');
       assert.equal(result.events[0]?.eligible, true);
       assert.equal(result.events[0]?.passed, false);
+      // An exhaustion the verifier never graded carries no score, however clean
+      // its evidence: eligibility is about attribution, not about a verdict.
+      assert.equal(result.events[0]?.scored, false);
       assert.equal(result.events[0]?.expectedPromptHash, hashSystemPrompt('fixed prompt\n'));
       if (result.events[0]?.type !== 'task_budget_exhausted')
         assert.fail('expected budget exhaustion event');

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -6,7 +6,12 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 import type { HarborCellExecutionIdentity, HarborCellOutput } from '../cell-output.js';
-import { FixedPromptBudgetExhaustedError, type TaskRunInput } from '../fixed-prompt-controller.js';
+import {
+  FixedPromptBudgetExhaustedError,
+  runFixedPromptController,
+  type FixedPromptTaskBudgetExhaustedEvent,
+  type TaskRunInput,
+} from '../fixed-prompt-controller.js';
 import { CODEX_TOOLCHAIN_SPEC } from '../codex-toolchain.js';
 import {
   buildHarborJobConfig,
@@ -276,6 +281,51 @@ async function withRun<T>(
   } finally {
     await rm(base, { recursive: true, force: true });
   }
+}
+
+/** Drives the real Harbor runner through the controller so a trial directory on
+ * disk is projected into the WAL row the benchmark actually counts. */
+async function budgetExhaustedWalEvent(input: {
+  jobsDir: string;
+  repo: string;
+  opts: FakeOptions;
+}): Promise<FixedPromptTaskBudgetExhaustedEvent> {
+  const systemPromptPath = join(input.repo, 'system_prompt.md');
+  await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+  let id = 0;
+  const result = await runFixedPromptController({
+    runId: 'run-1',
+    roundId: 'round-1',
+    config: {
+      id: 'cfg',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'deepseek',
+      model: 'deepseek-v4-flash',
+    },
+    systemPromptPath,
+    resultsJsonlPath: join(input.jobsDir, 'results.jsonl'),
+    tasks: [{ id: 'task-1', path: '/tasks/cobol-modernization' }],
+    taskRunner: createHarborTaskRunner({
+      makaRepoPath: input.repo,
+      jobsDir: input.jobsDir,
+      model: 'deepseek/deepseek-v4-flash',
+      runHarbor: fakeRunner({
+        trialResult: {
+          exception_info: {
+            exception_type: 'AgentTimeoutError',
+            exception_message: 'Agent execution timed out after 60.0 seconds',
+          },
+        },
+        ...input.opts,
+      }),
+    }),
+    now: () => 100,
+    newId: () => `id-${(id += 1)}`,
+  });
+  const event = result.events[0];
+  assert.equal(event?.type, 'task_budget_exhausted');
+  if (event?.type !== 'task_budget_exhausted') assert.fail('expected budget exhaustion event');
+  return event;
 }
 
 describe('createHarborTaskRunner', () => {
@@ -1983,40 +2033,105 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
-  test('carries the authoritative verifier grade of a timed-out trial that never wrote its cell output', async () => {
-    await withRun(async ({ jobsDir, repo }) => {
-      const runner = createHarborTaskRunner({
-        makaRepoPath: repo,
-        jobsDir,
-        model: 'deepseek/deepseek-v4-flash',
-        runHarbor: fakeRunner({
-          reward: '1.0\n',
-          cell: null,
-          trialResult: {
-            exception_info: {
-              exception_type: 'AgentTimeoutError',
-              exception_message: 'Agent execution timed out after 60.0 seconds',
+  // The runner transports the verifier's artifacts verbatim; the controller
+  // decides what counts as a grade. So the contract under test here is only
+  // "readable artifacts travel, unreadable ones do not" — including reward 0,
+  // which is a real graded failure and must not be silently dropped.
+  for (const trial of [
+    {
+      name: 'a passing reward',
+      opts: { reward: '1.0\n' },
+      expected: { reward: 1, outcome: 'passed' },
+    },
+    { name: 'a zero reward', opts: { reward: '0\n' }, expected: { reward: 0, outcome: 'failed' } },
+    { name: 'no reward file', opts: {}, expected: undefined },
+    { name: 'an empty reward file', opts: { reward: '' }, expected: undefined },
+    { name: 'a non-numeric reward', opts: { reward: 'crashed\n' }, expected: undefined },
+    {
+      name: 'no verifier outcome file',
+      opts: { reward: '1.0\n', verifierOutcome: null },
+      expected: undefined,
+    },
+    {
+      name: 'a malformed verifier outcome',
+      opts: { reward: '1.0\n', verifierOutcome: { schemaVersion: 1, outcome: 'passed' } },
+      expected: undefined,
+    },
+  ] as const) {
+    test(`carries the verifier artifacts of a timed-out trial without cell output: ${trial.name}`, async () => {
+      await withRun(async ({ jobsDir, repo }) => {
+        const runner = createHarborTaskRunner({
+          makaRepoPath: repo,
+          jobsDir,
+          model: 'deepseek/deepseek-v4-flash',
+          runHarbor: fakeRunner({
+            ...trial.opts,
+            cell: null,
+            trialResult: {
+              exception_info: {
+                exception_type: 'AgentTimeoutError',
+                exception_message: 'Agent execution timed out after 60.0 seconds',
+              },
             },
-          },
-        }),
-      });
+          }),
+        });
 
-      await assert.rejects(runner(runInput()), (error: unknown) => {
-        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
-        assert.equal(error.artifactRefs?.harbor?.reward, 1);
-        assert.equal(error.artifactRefs?.harbor?.verifier?.outcome, 'passed');
-        return true;
+        await assert.rejects(runner(runInput()), (error: unknown) => {
+          assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+          assert.equal(error.artifactRefs?.harbor?.reward, trial.expected?.reward);
+          assert.equal(error.artifactRefs?.harbor?.verifier?.outcome, trial.expected?.outcome);
+          return true;
+        });
       });
+    });
+  }
+
+  // The reported defect end to end: the six dropped cells were exactly these
+  // artifacts on disk. Nothing else joins the runner's read of the trial dir to
+  // the WAL row the benchmark counts.
+  test('scores a timed-out trial the verifier graded, from trial dir to WAL', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const event = await budgetExhaustedWalEvent({
+        jobsDir,
+        repo,
+        opts: { reward: '1.0\n', cell: null },
+      });
+      assert.equal(event.passed, true);
+      assert.equal(event.scored, true);
+      assert.equal(event.eligible, true);
+      assert.equal(event.harbor?.reward, 1);
     });
   });
 
-  test('carries no verifier grade when a timed-out trial has no conclusive verifier outcome', async () => {
+  test('refuses to score a timed-out trial whose reward disagrees with its verifier outcome', async () => {
     await withRun(async ({ jobsDir, repo }) => {
-      const runner = createHarborTaskRunner({
-        makaRepoPath: repo,
+      const event = await budgetExhaustedWalEvent({
         jobsDir,
-        model: 'deepseek/deepseek-v4-flash',
-        runHarbor: fakeRunner({
+        repo,
+        opts: {
+          reward: '1.0\n',
+          verifierOutcome: {
+            schemaVersion: 1,
+            outcome: 'failed',
+            attempts: [{ attempt: 1, classification: 'failed', durationMs: 1, reward: 0 }],
+          },
+          cell: null,
+        },
+      });
+      // The completed path rejects these same artifacts as infra
+      // (assertVerifierRewardAgreement); a missing self-report must not turn a
+      // corrupt scoring authority into a pass.
+      assert.equal(event.passed, false);
+      assert.equal(event.scored, false);
+    });
+  });
+
+  test('refuses to score a timed-out trial whose verifier never concluded', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const event = await budgetExhaustedWalEvent({
+        jobsDir,
+        repo,
+        opts: {
           reward: '1.0\n',
           verifierOutcome: {
             schemaVersion: 1,
@@ -2024,20 +2139,10 @@ describe('createHarborTaskRunner', () => {
             attempts: [{ attempt: 1, classification: 'timeout', durationMs: 1 }],
           },
           cell: null,
-          trialResult: {
-            exception_info: {
-              exception_type: 'AgentTimeoutError',
-              exception_message: 'Agent execution timed out after 60.0 seconds',
-            },
-          },
-        }),
+        },
       });
-
-      await assert.rejects(runner(runInput()), (error: unknown) => {
-        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
-        assert.equal(error.artifactRefs?.harbor, undefined);
-        return true;
-      });
+      assert.equal(event.passed, false);
+      assert.equal(event.scored, false);
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -19,6 +19,7 @@ import {
   createHarborTaskRunner,
   HarborInfraError,
   incompleteTerminalProviderRequest,
+  trialGradeSurvivingProviderOutage,
   MAKA_SETTLEMENT_GRACE_SEC,
   type HarborProcessRunner,
   type HarborRunRequest,
@@ -3440,6 +3441,25 @@ describe('incompleteTerminalProviderRequest', () => {
         `${outcome} must stay infra`,
       );
     }
+  });
+
+  test('withholds a budget-exhausted grade when the provider cut the tail request short', () => {
+    // The grade is evidence only if the agent got the run it was given. A
+    // provider-side truncation says it did not, so the verdict does not travel
+    // — the same boundary that makes the settled path infra, applied where the
+    // trial ends as a budget exhaustion instead.
+    const grade = { reward: 1 };
+    assert.equal(trialGradeSurvivingProviderOutage(grade, [request('completed')]), grade);
+    assert.equal(trialGradeSurvivingProviderOutage(grade, [request('aborted')]), grade);
+    assert.equal(trialGradeSurvivingProviderOutage(grade, []), grade);
+    for (const outcome of ['interrupted', 'failed'] as const) {
+      assert.equal(
+        trialGradeSurvivingProviderOutage(grade, [request(outcome)]),
+        undefined,
+        `${outcome} must withhold the grade`,
+      );
+    }
+    assert.equal(trialGradeSurvivingProviderOutage(undefined, [request('completed')]), undefined);
   });
 
   test('keeps every non-completing tail request infra on an unsettled trial', () => {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1983,6 +1983,64 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
+  test('carries the authoritative verifier grade of a timed-out trial that never wrote its cell output', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          reward: '1.0\n',
+          cell: null,
+          trialResult: {
+            exception_info: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 60.0 seconds',
+            },
+          },
+        }),
+      });
+
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+        assert.equal(error.artifactRefs?.harbor?.reward, 1);
+        assert.equal(error.artifactRefs?.harbor?.verifier?.outcome, 'passed');
+        return true;
+      });
+    });
+  });
+
+  test('carries no verifier grade when a timed-out trial has no conclusive verifier outcome', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          reward: '1.0\n',
+          verifierOutcome: {
+            schemaVersion: 1,
+            outcome: 'candidate_timeout',
+            attempts: [{ attempt: 1, classification: 'timeout', durationMs: 1 }],
+          },
+          cell: null,
+          trialResult: {
+            exception_info: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 60.0 seconds',
+            },
+          },
+        }),
+      });
+
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+        assert.equal(error.artifactRefs?.harbor, undefined);
+        return true;
+      });
+    });
+  });
+
   test('recovers checkpoint usage when a timed-out deadline cell has no summary', async () => {
     await withRun(async ({ jobsDir, repo }) => {
       const usageCheckpoint = tokenSummary({

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -990,6 +990,31 @@ test('createPierTaskRunner recovers execution identity from a budget-exhausted t
   });
 });
 
+test('createPierTaskRunner carries the verifier grade of a budget-exhausted trial without cell output', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({
+          cell: null,
+          reward: 1,
+          exceptionInfo: {
+            exception_type: 'AgentTimeoutError',
+            exception_message: 'Agent execution timed out after 600 seconds',
+          },
+        }),
+      }),
+    );
+    await assert.rejects(runner(runInput()), (error: Error) => {
+      assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+      assert.equal(error.artifactRefs?.harbor?.reward, 1);
+      assert.equal(error.artifactRefs?.harbor?.verifier?.outcome, 'passed');
+      return true;
+    });
+  });
+});
+
 test('createPierTaskRunner scores a graded trial despite a non-budget exception', async () => {
   // Harbor-authority parity: exception_info records how the agent phase ended,
   // not whether the trial was graded. A Kimi CLI non-zero exit the verifier

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -1015,6 +1015,105 @@ test('createPierTaskRunner carries the verifier grade of a budget-exhausted tria
   });
 });
 
+// The grade travels only from a graded state. `invalid` (corrupt or crashed
+// verifier) and `ungraded` (no reward at all) are not verdicts, so a budget
+// exhaustion carries no score — the same negative side the Harbor table pins.
+for (const trial of [
+  { name: 'a crash-sentinel reward', opts: { reward: -1 } },
+  { name: 'a corrupt reward.json', opts: { rewardJsonRaw: 'not-json{' } },
+  { name: 'no reward at all', opts: {} },
+] as const) {
+  test(`createPierTaskRunner carries no verdict from a budget-exhausted trial with ${trial.name}`, async () => {
+    await withDirs(async ({ jobsDir, repo }) => {
+      const runner = createPierTaskRunner(
+        baseOptions({
+          jobsDir,
+          makaRepoPath: repo,
+          runPier: fakePier({
+            ...trial.opts,
+            cell: null,
+            exceptionInfo: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 600 seconds',
+            },
+          }),
+        }),
+      );
+      await assert.rejects(runner(runInput()), (error: Error) => {
+        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+        assert.equal(error.artifactRefs?.harbor, undefined);
+        return true;
+      });
+    });
+  });
+}
+
+test('createPierTaskRunner withholds a budget-exhausted grade when the provider cut the tail short', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const makeRunner = (outcome: ProviderRequestTelemetry['outcome']) =>
+      createPierTaskRunner(
+        baseOptions({
+          jobsDir,
+          makaRepoPath: repo,
+          agent: 'opencode',
+          agentVersion: OPENCODE_TOOLCHAIN_SPEC.opencode.version,
+          backend: 'ai-sdk',
+          provider: 'deepseek',
+          model: 'deepseek-v4-flash',
+          reasoningEffort: 'max',
+          opencodeToolchainPath: repo,
+          apiKeyFile: '/secrets/deepseek.key',
+          providerProxyHub: {
+            baseUrl: 'http://host.docker.internal:443',
+            issue: () => ({
+              baseUrl: 'http://host.docker.internal:443',
+              token: 'ephemeral-token',
+              usage: () => null,
+              telemetry: () => [
+                {
+                  requestId: 1,
+                  method: 'POST',
+                  path: '/chat/completions',
+                  status: 200,
+                  outcome,
+                  durationMs: 5,
+                  bodyChunks: 1,
+                  responseBytes: 64,
+                  terminalEvent: outcome === 'completed',
+                },
+              ],
+              close: async () => {},
+            }),
+            close: async () => {},
+          },
+          runPier: fakePier({
+            reward: 1,
+            cell: null,
+            exceptionInfo: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 600 seconds',
+            },
+          }),
+        }),
+      );
+
+    // The agent tearing its own request down on the way out is what a deadline
+    // looks like from the proxy, so the verdict still travels.
+    await assert.rejects(makeRunner('aborted')(runInput()), (error: Error) => {
+      assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+      assert.equal(error.artifactRefs?.harbor?.reward, 1);
+      return true;
+    });
+    // An upstream truncation is a provider outage: the agent never got the run
+    // it was given, so its verdict is not this arm's evidence.
+    await assert.rejects(makeRunner('interrupted')(runInput()), (error: Error) => {
+      assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+      assert.equal(error.artifactRefs?.harbor, undefined);
+      return true;
+    });
+  });
+});
+
 test('createPierTaskRunner scores a graded trial despite a non-budget exception', async () => {
   // Harbor-authority parity: exception_info records how the agent phase ended,
   // not whether the trial was graded. A Kimi CLI non-zero exit the verifier

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -473,6 +473,27 @@ describe('prompt acceptance policy', () => {
     });
   });
 
+  test('counts a graded budget exhaustion as evidence and an ungraded one as lost coverage', () => {
+    // A timeout the verifier graded is a score, so it belongs in both rates. An
+    // ungraded one is the case the partition already handled: eligible, but
+    // nothing to score, so it drags coverage down and blocks calibration.
+    const summary = summarizePromptAcceptancePartition(
+      [
+        budgetExhausted('task-a', { passed: true, scored: true }),
+        budgetExhausted('task-b', { passed: false, scored: true }),
+        budgetExhausted('task-c'),
+      ],
+      ['task-a', 'task-b', 'task-c'],
+    );
+
+    assert.equal(summary.eligible, 3);
+    assert.equal(summary.scored, 2);
+    assert.equal(summary.passed, 1);
+    assert.equal(summary.passEligibleRate, 1 / 3);
+    assert.equal(summary.coverageRate, 2 / 3);
+    assert.deepEqual(summary.unscoredTaskIds, ['task-c']);
+  });
+
   test('discards flat held-in changes without requiring a positive noise margin', () => {
     const decision = decidePromptAcceptance({
       ...baseDecisionInput(),
@@ -778,6 +799,30 @@ function infraFailed(taskId: string): FixedPromptTaskWalEvent {
     eligible: false,
     errorClass: 'infra_error',
     error: 'container crashed',
+  };
+}
+
+function budgetExhausted(
+  taskId: string,
+  outcome: { passed?: boolean; scored?: boolean } = {},
+): FixedPromptTaskWalEvent {
+  const scored = outcome.scored ?? false;
+  return {
+    schemaVersion: 1,
+    type: 'task_budget_exhausted',
+    id: `event-${taskId}`,
+    ts: 1,
+    runId: 'run-1',
+    roundId: 'round-1',
+    taskId,
+    status: 'budget_exhausted',
+    passed: outcome.passed ?? false,
+    scored,
+    eligible: true,
+    errorClass: 'budget_exhausted',
+    error: 'agent budget exhausted',
+    expectedPromptHash: 'sha256:prompt',
+    ...(scored ? { harbor: { reward: outcome.passed ? 1 : 0 } } : {}),
   };
 }
 

--- a/packages/headless/src/__tests__/rsi-round-analysis.test.ts
+++ b/packages/headless/src/__tests__/rsi-round-analysis.test.ts
@@ -51,6 +51,32 @@ describe('RSI round analysis', () => {
     ]);
   });
 
+  test('reads a graded budget exhaustion as the score it carries, not as lost coverage', async () => {
+    // A verifier-graded timeout has a score. Reporting it as a coverage
+    // regression and a pass→budget flip would blame the candidate prompt for
+    // evidence that exists and says the task passed.
+    const analysis = await analyzeRsiRound({
+      heldInTaskIds: ['task-a', 'task-b', 'task-c'],
+      lastKeptEvents: [
+        completed({ taskId: 'task-a', passed: true }),
+        completed({ taskId: 'task-b', passed: true }),
+        completed({ taskId: 'task-c', passed: true }),
+      ],
+      candidateEvents: [
+        budgetExhausted({ taskId: 'task-a', passed: true, scored: true }),
+        budgetExhausted({ taskId: 'task-b', passed: false, scored: true }),
+        budgetExhausted({ taskId: 'task-c' }),
+      ],
+    });
+
+    assert.deepEqual(analysis.transitionVsLastKept, [
+      { taskId: 'task-b', from: 'pass', to: 'fail' },
+      { taskId: 'task-c', from: 'pass', to: 'budget' },
+    ]);
+    // Only the ungraded one actually lost coverage.
+    assert.deepEqual(analysis.coverageRegressionTaskIds, ['task-c']);
+  });
+
   test('only reports coverage regression when last kept was covered', async () => {
     const analysis = await analyzeRsiRound({
       heldInTaskIds: ['task-a', 'task-b', 'task-c'],
@@ -723,6 +749,31 @@ function plumbingFailed(input: {
     runtimeEventsPath: input.runtimeEventsPath ?? '/tmp/runtime-events.jsonl',
     ...(input.traceEventsPath ? { traceEventsPath: input.traceEventsPath } : {}),
     harbor: { reward: 0 },
+  };
+}
+
+function budgetExhausted(input: {
+  taskId: string;
+  passed?: boolean;
+  scored?: boolean;
+}): FixedPromptTaskWalEvent {
+  const scored = input.scored ?? false;
+  return {
+    schemaVersion: 1,
+    type: 'task_budget_exhausted',
+    id: `${input.taskId}-budget`,
+    ts: 1,
+    runId: 'run-1',
+    roundId: 'round-1',
+    taskId: input.taskId,
+    status: 'budget_exhausted',
+    passed: input.passed ?? false,
+    scored,
+    eligible: true,
+    errorClass: 'budget_exhausted',
+    error: 'agent budget exhausted',
+    expectedPromptHash: 'sha256:prompt',
+    ...(scored ? { harbor: { reward: input.passed ? 1 : 0 } } : {}),
   };
 }
 

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -114,6 +114,13 @@ export interface FixedPromptBudgetExhaustedArtifactRefs {
   tokenSummary?: HarborCellTokenSummary;
   cellOutput?: HarborTaskRunCellOutput;
   executionIdentity?: HarborCellExecutionIdentity;
+  /** The verifier's own verdict on the workspace the exhausted agent left. It is
+   * the harness's authoritative artifact, so it survives a missing cell output —
+   * the agent's self-report is not what grades a trial. */
+  harbor?: {
+    reward: number;
+    verifier?: HarborVerifierOutcome;
+  };
 }
 
 export class FixedPromptBudgetExhaustedError extends Error {
@@ -1097,6 +1104,13 @@ function taskBudgetExhaustedEvent(input: {
   const traceEventsPath = artifactRefs.traceEventsPath ?? cellOutput?.traceEventsPath;
   const providerTelemetryPath =
     artifactRefs.providerTelemetryPath ?? cellOutput?.providerTelemetryPath;
+  // A budget exhaustion is a settled deadline, which taskCompletedScoringProjection
+  // already counts as verifierGraded. So the same rule applies here: when the
+  // harness handed back an authoritative reward, the trial has a score, and
+  // reward > 0 is a pass. Evidence that fails to attest this arm keeps it
+  // unscored — a grade nobody can attribute is not this arm's grade.
+  const harbor = evidenceFailure === undefined ? artifactRefs.harbor : undefined;
+  const passed = harbor !== undefined && harbor.reward > 0;
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_budget_exhausted',
@@ -1107,11 +1121,12 @@ function taskBudgetExhaustedEvent(input: {
     ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
     taskId: input.taskId,
     status: 'budget_exhausted',
-    passed: false,
-    scored: false,
+    passed,
+    scored: harbor !== undefined,
     eligible: evidenceFailure === undefined,
     errorClass: 'budget_exhausted',
     error: errorMessage(input.error),
+    ...(harbor ? { harbor } : {}),
     ...(evidenceFailure
       ? {
           evidenceErrorClass: evidenceFailure.errorClass,
@@ -1292,7 +1307,8 @@ function budgetExhaustedArtifactRefs(error: unknown): FixedPromptBudgetExhausted
         refs.runtimeEventsUnavailableReason ||
         refs.tokenSummary ||
         refs.cellOutput ||
-        refs.executionIdentity)
+        refs.executionIdentity ||
+        refs.harbor)
     )
       return refs;
   }

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -17,6 +17,7 @@ import {
   type FixedPromptTaskPlumbingFailedEvent,
   type FixedPromptTaskWalEvent,
   type FixedPromptWalEvent,
+  type HarborTrialGrade,
   type HarborVerifierOutcome,
   type UnscoredCellFailureClass,
 } from './fixed-prompt-wal-types.js';
@@ -37,6 +38,7 @@ export type {
   FixedPromptTaskPlumbingFailedEvent,
   FixedPromptTaskWalEvent,
   FixedPromptWalEvent,
+  HarborTrialGrade,
   HarborVerifierAttempt,
   HarborVerifierOutcome,
   PromptCandidateCommittedEvent,
@@ -117,10 +119,7 @@ export interface FixedPromptBudgetExhaustedArtifactRefs {
   /** The verifier's own verdict on the workspace the exhausted agent left. It is
    * the harness's authoritative artifact, so it survives a missing cell output —
    * the agent's self-report is not what grades a trial. */
-  harbor?: {
-    reward: number;
-    verifier?: HarborVerifierOutcome;
-  };
+  harbor?: HarborTrialGrade;
 }
 
 export class FixedPromptBudgetExhaustedError extends Error {
@@ -1104,13 +1103,21 @@ function taskBudgetExhaustedEvent(input: {
   const traceEventsPath = artifactRefs.traceEventsPath ?? cellOutput?.traceEventsPath;
   const providerTelemetryPath =
     artifactRefs.providerTelemetryPath ?? cellOutput?.providerTelemetryPath;
-  // A budget exhaustion is a settled deadline, which taskCompletedScoringProjection
-  // already counts as verifierGraded. So the same rule applies here: when the
-  // harness handed back an authoritative reward, the trial has a score, and
-  // reward > 0 is a pass. Evidence that fails to attest this arm keeps it
-  // unscored — a grade nobody can attribute is not this arm's grade.
+  // The runner transports the verifier's artifacts; scoring authority is decided
+  // here, by the same two functions the completed path uses. structuredVerifierGrade
+  // is what rejects a reward that disagrees with its own verifier outcome, so a
+  // missing self-report cannot turn a corrupt scoring authority into a pass. No
+  // deadline is claimed: without a cell there is no attested settlement, and the
+  // verdict alone is what grades the trial. Evidence that fails to attest this
+  // arm keeps it unscored — a grade nobody can attribute is not this arm's grade.
   const harbor = evidenceFailure === undefined ? artifactRefs.harbor : undefined;
-  const passed = harbor !== undefined && harbor.reward > 0;
+  const { passed, scored } = taskCompletedScoringProjection({
+    status: 'failed',
+    reward: harbor?.reward ?? 0,
+    errorClass: 'budget_exhausted',
+    deadlineSettled: false,
+    verifierGrade: structuredVerifierGrade(harbor),
+  });
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_budget_exhausted',
@@ -1122,7 +1129,7 @@ function taskBudgetExhaustedEvent(input: {
     taskId: input.taskId,
     status: 'budget_exhausted',
     passed,
-    scored: harbor !== undefined,
+    scored,
     eligible: evidenceFailure === undefined,
     errorClass: 'budget_exhausted',
     error: errorMessage(input.error),

--- a/packages/headless/src/fixed-prompt-wal-types.ts
+++ b/packages/headless/src/fixed-prompt-wal-types.ts
@@ -27,6 +27,15 @@ export interface HarborVerifierOutcome {
   attempts: HarborVerifierAttempt[];
 }
 
+/** What the harness's verifier wrote about a trial. One shape from the runner's
+ * read of the trial directory through to the WAL, so the grade contract cannot
+ * drift along the way. Whether it amounts to a score is decided in one place,
+ * by structuredVerifierGrade. */
+export interface HarborTrialGrade {
+  reward: number;
+  verifier?: HarborVerifierOutcome;
+}
+
 export interface FixedPromptTaskCompletedEvent {
   schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
   type: 'task_completed';
@@ -137,10 +146,7 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   taskToolSummary?: HarborCellTaskToolSummary;
   steps?: number;
   durationMs?: number;
-  harbor?: {
-    reward: number;
-    verifier?: HarborVerifierOutcome;
-  };
+  harbor?: HarborTrialGrade;
 }
 
 export interface FixedPromptTaskPlumbingFailedEvent {

--- a/packages/headless/src/fixed-prompt-wal-types.ts
+++ b/packages/headless/src/fixed-prompt-wal-types.ts
@@ -108,8 +108,12 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   resumeFingerprint?: string;
   taskId: string;
   status: 'budget_exhausted';
-  passed: false;
-  scored: false;
+  /** A trial can exhaust its budget and still be graded: the harness runs the
+   * verifier after the agent-phase exception, so an authoritative reward exists
+   * whenever `harbor` is present. Only then may these be true — without a
+   * verifier verdict the outcome carries no score. */
+  passed: boolean;
+  scored: boolean;
   eligible: boolean;
   errorClass: 'budget_exhausted';
   error: string;
@@ -133,6 +137,10 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   taskToolSummary?: HarborCellTaskToolSummary;
   steps?: number;
   durationMs?: number;
+  harbor?: {
+    reward: number;
+    verifier?: HarborVerifierOutcome;
+  };
 }
 
 export interface FixedPromptTaskPlumbingFailedEvent {

--- a/packages/headless/src/fixed-prompt-wal-types.ts
+++ b/packages/headless/src/fixed-prompt-wal-types.ts
@@ -118,9 +118,10 @@ export interface FixedPromptTaskBudgetExhaustedEvent {
   taskId: string;
   status: 'budget_exhausted';
   /** A trial can exhaust its budget and still be graded: the harness runs the
-   * verifier after the agent-phase exception, so an authoritative reward exists
-   * whenever `harbor` is present. Only then may these be true — without a
-   * verifier verdict the outcome carries no score. */
+   * verifier after the agent-phase exception. `scored` is the authority — it is
+   * true only when the verifier's artifacts agreed on a verdict. `harbor` also
+   * travels with a verdict that was rejected, so its presence alone says
+   * nothing; read `scored` before trusting the reward. */
   passed: boolean;
   scored: boolean;
   eligible: boolean;

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -481,12 +481,18 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
               runnerOptions.agent,
               harborTraceMode(runnerOptions.agentEnv),
             );
+            // The exhaustion is the agent's fact; the verifier's verdict is the
+            // harness's. Both are true at once, so both travel — dropping the
+            // grade because the agent never filed its self-report threw away a
+            // pass Harbor had already awarded.
+            const harbor = authoritativeTrialGrade(rewardArtifact, verifierArtifact, input.task.id);
             throw new FixedPromptBudgetExhaustedError(
               `agent budget exhausted for task ${input.task.id}`,
               formatTrialException(trialException),
-              artifactRefs || providerTelemetry.length > 0
+              artifactRefs || harbor || providerTelemetry.length > 0
                 ? {
                     ...(artifactRefs ?? {}),
+                    ...(harbor ? { harbor } : {}),
                     ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
                   }
                 : undefined,
@@ -946,6 +952,10 @@ async function readVerifierOutcome(
       errorText(error),
     );
   }
+  return parseVerifierOutcome(value, taskId);
+}
+
+function parseVerifierOutcome(value: unknown, taskId: string): HarborVerifierOutcome {
   if (!isRecord(value) || value.schemaVersion !== 1) {
     throw new HarborInfraError(`verifier outcome is malformed for task ${taskId}`);
   }
@@ -1673,6 +1683,28 @@ export function classifyTrialTermination(
  * phase already ended abnormally. Unreadable or malformed text is treated as no
  * evidence — the caller's own reader raises the precise diagnosis on the paths
  * that require a verdict. */
+/** The trial's authoritative grade, read straight from the verifier's own
+ * artifacts. It exists independently of `maka-cell-output.json`: that file is
+ * the agent's self-report, and an agent that ran out of budget mid-write never
+ * gets to file one. Returning the grade lets a budget exhaustion carry the
+ * verdict Harbor actually reached instead of discarding it. A verifier that did
+ * not conclude, or artifacts that do not parse, yield no grade — the caller
+ * then records the exhaustion with no score, as before. */
+function authoritativeTrialGrade(
+  rewardArtifact: string | null,
+  verifierArtifact: string | null,
+  taskId: string,
+): { reward: number; verifier: HarborVerifierOutcome } | undefined {
+  if (rewardArtifact === null || !hasConclusiveVerifierOutcome(verifierArtifact)) return undefined;
+  const reward = Number(rewardArtifact.trim());
+  if (rewardArtifact.trim().length === 0 || !Number.isFinite(reward)) return undefined;
+  try {
+    return { reward, verifier: parseVerifierOutcome(JSON.parse(verifierArtifact!), taskId) };
+  } catch {
+    return undefined;
+  }
+}
+
 function hasConclusiveVerifierOutcome(raw: string | null): boolean {
   if (raw === null) return false;
   let parsed: unknown;

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -198,6 +198,20 @@ export function incompleteTerminalProviderRequest(
   return terminal;
 }
 
+/** Shared across runners: a verdict is this arm's evidence only if the agent got
+ * the run it was given. A tail request the upstream cut short says it did not,
+ * so the grade does not travel — the same boundary that makes a settled trial
+ * infra, applied where the trial ends as a budget exhaustion instead. Without
+ * it, a provider outage that a verifier happened to pass would be recorded as a
+ * pass on the one path that skips the infra check. `aborted` stays exempt: the
+ * agent phase ended, and tearing the request down is what that looks like. */
+export function trialGradeSurvivingProviderOutage<T>(
+  grade: T | undefined,
+  providerTelemetry: readonly ProviderRequestTelemetry[],
+): T | undefined {
+  return incompleteTerminalProviderRequest(providerTelemetry, true) ? undefined : grade;
+}
+
 export class HarborInfraError extends Error {
   constructor(
     message: string,
@@ -489,7 +503,10 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
             // harness's. Both are true at once, so both travel — dropping the
             // verdict because the agent never filed its self-report threw away a
             // pass Harbor had already awarded.
-            const harbor = trialVerifierArtifacts(rewardArtifact, verifierArtifact, input.task.id);
+            const harbor = trialGradeSurvivingProviderOutage(
+              trialVerifierArtifacts(rewardArtifact, verifierArtifact, input.task.id),
+              providerTelemetry,
+            );
             throw new FixedPromptBudgetExhaustedError(
               `agent budget exhausted for task ${input.task.id}`,
               formatTrialException(trialException),

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -26,7 +26,11 @@ import {
   type TaskRunOutput,
   type TaskRunner,
 } from './fixed-prompt-controller.js';
-import type { HarborVerifierAttempt, HarborVerifierOutcome } from './fixed-prompt-wal-types.js';
+import type {
+  HarborTrialGrade,
+  HarborVerifierAttempt,
+  HarborVerifierOutcome,
+} from './fixed-prompt-wal-types.js';
 import {
   HARBOR_ORACLE_EXECUTION_POLICY,
   HARBOR_ORACLE_MAX_ATTEMPTS,
@@ -483,19 +487,17 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
             );
             // The exhaustion is the agent's fact; the verifier's verdict is the
             // harness's. Both are true at once, so both travel — dropping the
-            // grade because the agent never filed its self-report threw away a
+            // verdict because the agent never filed its self-report threw away a
             // pass Harbor had already awarded.
-            const harbor = authoritativeTrialGrade(rewardArtifact, verifierArtifact, input.task.id);
+            const harbor = trialVerifierArtifacts(rewardArtifact, verifierArtifact, input.task.id);
             throw new FixedPromptBudgetExhaustedError(
               `agent budget exhausted for task ${input.task.id}`,
               formatTrialException(trialException),
-              artifactRefs || harbor || providerTelemetry.length > 0
-                ? {
-                    ...(artifactRefs ?? {}),
-                    ...(harbor ? { harbor } : {}),
-                    ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
-                  }
-                : undefined,
+              {
+                ...(artifactRefs ?? {}),
+                ...(harbor ? { harbor } : {}),
+                ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
+              },
             );
           }
           completeTimedOutTrial = true;
@@ -504,6 +506,13 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
           // workspace it left: a real result. Keep the cell's own status and
           // errorClass — nothing here is a deadline, so nothing may claim one —
           // and let the structured verifier grade score it.
+          //
+          // The cell requirement is a known exclusion, not the veto fixed above:
+          // a graded agent-exit trial with no self-report has no truthful event
+          // to land in. It claims no deadline, so task_budget_exhausted would
+          // lie, and task_completed needs the runtimeRefs/steps only the cell
+          // attests. Until such a shape exists it stays infra. Widening it is a
+          // WAL taxonomy decision, tracked separately.
           verifierSettledTrial =
             rewardArtifact !== null &&
             cellArtifact !== null &&
@@ -1677,34 +1686,35 @@ export function classifyTrialTermination(
   return 'external';
 }
 
+/** What the verifier wrote about the trial, read straight from its own
+ * artifacts. It exists independently of `maka-cell-output.json`: that file is
+ * the agent's self-report, and an agent that ran out of budget mid-write never
+ * gets to file one, so a budget exhaustion can still carry the verdict Harbor
+ * reached. This only transports what is on disk — whether the two artifacts
+ * agree, and so whether they amount to a grade, is decided once by the
+ * controller's structuredVerifierGrade, the same judge the completed path uses.
+ * Artifacts that do not parse are not evidence and travel as nothing. */
+function trialVerifierArtifacts(
+  rewardArtifact: string | null,
+  verifierArtifact: string | null,
+  taskId: string,
+): HarborTrialGrade | undefined {
+  if (rewardArtifact === null || verifierArtifact === null) return undefined;
+  const reward = Number(rewardArtifact.trim());
+  if (rewardArtifact.trim().length === 0 || !Number.isFinite(reward)) return undefined;
+  try {
+    return { reward, verifier: parseVerifierOutcome(JSON.parse(verifierArtifact), taskId) };
+  } catch {
+    return undefined;
+  }
+}
+
 /** A verifier outcome is authoritative evidence that the trial was graded only
  * when it reached a verdict. `candidate_timeout` and `infra_failed` say the
  * verifier itself did not conclude, so they never settle a trial whose agent
  * phase already ended abnormally. Unreadable or malformed text is treated as no
  * evidence — the caller's own reader raises the precise diagnosis on the paths
  * that require a verdict. */
-/** The trial's authoritative grade, read straight from the verifier's own
- * artifacts. It exists independently of `maka-cell-output.json`: that file is
- * the agent's self-report, and an agent that ran out of budget mid-write never
- * gets to file one. Returning the grade lets a budget exhaustion carry the
- * verdict Harbor actually reached instead of discarding it. A verifier that did
- * not conclude, or artifacts that do not parse, yield no grade — the caller
- * then records the exhaustion with no score, as before. */
-function authoritativeTrialGrade(
-  rewardArtifact: string | null,
-  verifierArtifact: string | null,
-  taskId: string,
-): { reward: number; verifier: HarborVerifierOutcome } | undefined {
-  if (rewardArtifact === null || !hasConclusiveVerifierOutcome(verifierArtifact)) return undefined;
-  const reward = Number(rewardArtifact.trim());
-  if (rewardArtifact.trim().length === 0 || !Number.isFinite(reward)) return undefined;
-  try {
-    return { reward, verifier: parseVerifierOutcome(JSON.parse(verifierArtifact!), taskId) };
-  } catch {
-    return undefined;
-  }
-}
-
 function hasConclusiveVerifierOutcome(raw: string | null): boolean {
   if (raw === null) return false;
   let parsed: unknown;

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -32,6 +32,7 @@ import {
   trialExceptionSuffix,
   withProviderTelemetryArtifact,
   incompleteTerminalProviderRequest,
+  trialGradeSurvivingProviderOutage,
   modelForOpenCode,
   type HarborTaskPricing,
 } from './harbor-task-runner.js';
@@ -535,7 +536,7 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
             // Same cross-runner contract as Harbor: a graded trial that never
             // filed its cell output still carries the verifier's own verdict,
             // because the self-report is not what scores a trial.
-            const harbor =
+            const harbor = trialGradeSurvivingProviderOutage(
               grade.state === 'graded'
                 ? {
                     reward: grade.reward,
@@ -544,7 +545,9 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
                       await readVerifierDurationMs(join(trialDir, TRIAL_RESULT)),
                     ),
                   }
-                : undefined;
+                : undefined,
+              providerTelemetry,
+            );
             throw new FixedPromptBudgetExhaustedError(
               `agent budget exhausted for task ${input.task.id}`,
               // Carry the invalid-grade detail alongside the exhaustion cause so a

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -532,6 +532,19 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
               agent,
               harborTraceMode(attemptAgentEnv),
             );
+            // Same cross-runner contract as Harbor: a graded trial that never
+            // filed its cell output still carries the verifier's own verdict,
+            // because the self-report is not what scores a trial.
+            const harbor =
+              grade.state === 'graded'
+                ? {
+                    reward: grade.reward,
+                    verifier: pierVerifierOutcome(
+                      grade.reward,
+                      await readVerifierDurationMs(join(trialDir, TRIAL_RESULT)),
+                    ),
+                  }
+                : undefined;
             throw new FixedPromptBudgetExhaustedError(
               `agent budget exhausted for task ${input.task.id}`,
               // Carry the invalid-grade detail alongside the exhaustion cause so a
@@ -540,9 +553,10 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
               grade.state === 'invalid'
                 ? `${formatTrialException(trialException)}; ${grade.detail}`
                 : formatTrialException(trialException),
-              artifactRefs || providerTelemetry.length > 0
+              artifactRefs || harbor || providerTelemetry.length > 0
                 ? {
                     ...(artifactRefs ?? {}),
+                    ...(harbor ? { harbor } : {}),
                     ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
                   }
                 : undefined,

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -553,13 +553,11 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
               grade.state === 'invalid'
                 ? `${formatTrialException(trialException)}; ${grade.detail}`
                 : formatTrialException(trialException),
-              artifactRefs || harbor || providerTelemetry.length > 0
-                ? {
-                    ...(artifactRefs ?? {}),
-                    ...(harbor ? { harbor } : {}),
-                    ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
-                  }
-                : undefined,
+              {
+                ...(artifactRefs ?? {}),
+                ...(harbor ? { harbor } : {}),
+                ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
+              },
             );
           }
           completeTimedOutTrial = true;

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -222,8 +222,12 @@ function riskTaskOutcome(from: RsiTaskOutcome, to: RsiTaskOutcome): RsiRiskTaskO
 function taskOutcome(event: FixedPromptTaskWalEvent | undefined): RsiTaskOutcome {
   if (!event) return 'missing';
   if (event.type === 'task_infra_failed') return 'infra';
-  if (event.type === 'task_budget_exhausted') return 'budget';
   if (event.type === 'task_plumbing_failed') return 'plumbing';
+  // A budget exhaustion the verifier graded carries a real score, so it reads
+  // as that score. `budget` is for the ones that ran out with no verdict —
+  // otherwise a graded pass would be attributed to the prompt as a flip away
+  // from passing.
+  if (event.type === 'task_budget_exhausted' && !(event.eligible && event.scored)) return 'budget';
   if (!event.eligible || !event.scored) return 'unscored';
   return event.passed ? 'pass' : 'fail';
 }

--- a/packages/headless/src/rsi-round-analysis.ts
+++ b/packages/headless/src/rsi-round-analysis.ts
@@ -192,14 +192,22 @@ function taskTransitions(
 function taskOutcome(event: FixedPromptTaskWalEvent | undefined): RsiTaskOutcome {
   if (!event) return 'missing';
   if (event.type === 'task_infra_failed') return 'infra';
-  if (event.type === 'task_budget_exhausted') return 'budget';
   if (event.type === 'task_plumbing_failed') return 'plumbing';
+  // A budget exhaustion the verifier graded carries a real score, so it reads
+  // as that score. `budget` is for the ones that ran out with no verdict —
+  // otherwise a graded pass would be attributed to the prompt as a flip away
+  // from passing.
+  if (event.type === 'task_budget_exhausted' && !(event.eligible && event.scored)) return 'budget';
   if (!event.eligible || !event.scored) return 'unscored';
   return event.passed ? 'pass' : 'fail';
 }
 
+/** Coverage is whether the round produced a score for the task, so it asks the
+ * event's own fields rather than its type. A verifier-graded budget exhaustion
+ * is covered: the score exists, and calling it a coverage regression would
+ * charge the candidate prompt for evidence that is on disk. */
 function isCovered(event: FixedPromptTaskWalEvent | undefined): boolean {
-  return event?.type === 'task_completed' && event.eligible && event.scored;
+  return event !== undefined && event.eligible && event.scored;
 }
 
 function safeErrorClassGroups(


### PR DESCRIPTION
## Summary

Harbor's `single_step.py` and Pier both run the verifier after any agent-phase exception, so a trial that ended on `AgentTimeoutError` can still carry an authoritative reward. Both runners nonetheless required `maka-cell-output.json` — the agent's own self-report — before a budget exhaustion could keep its grade:

```ts
if (rewardArtifact === null || verifierArtifact === null || cellArtifact === null) {
  throw new FixedPromptBudgetExhaustedError(...)
}
```

An agent that ran out of time before filing that report therefore had a verifier-confirmed `reward = 1.0` recorded as `passed = false, scored = false`. Six Maka cells in `deepseek-v4-flash-3arm-tbench-2.1-full-v7` (`adaptive-rejection-sampler`, `caffe-cifar-10`, `largest-eigenval`, `mcmc-sampling-stan`, `path-tracing`, `schemelike-metacircular-eval`) were dropped this way; the Codex arm's identically-shaped `adaptive-rejection-sampler` cell scored correctly only because its self-report is written by an adapter wrapper that always runs.

The root cause of the missing self-report is fixed in #2107 (Harbor's `max_timeout_sec` is a ceiling, not an override, so Maka's 30s settlement window did not mathematically exist). This PR fixes the grading defect that #2107 records as a Known gap: an authoritative verdict must not be vetoed by a non-authoritative artifact.

**Approach.** No synthetic `HarborCellOutput` — its required fields (`runtimeRefs`, `steps`, `startedAt`, `finishedAt`, `toolSummary`) would have to be invented, which is worse than the defect. Instead the authoritative grade travels along the budget-exhausted path:

- `FixedPromptBudgetExhaustedError.artifactRefs` gains `harbor: { reward, verifier }`, read from the verifier's own artifacts (`verifier/reward.txt` + `maka-verifier-outcome.json`).
- `taskBudgetExhaustedEvent` projects `passed` / `scored` from it, under the rule `taskCompletedScoringProjection` already uses for a settled deadline: a settled deadline counts as `verifierGraded`, and `reward > 0` is a pass. `FixedPromptTaskBudgetExhaustedEvent.passed/scored` widen from `false` to `boolean` and the event carries `harbor`.
- Evidence that fails to attest the arm (identity mismatch, `requireExecutionIdentity` with no identity) keeps the outcome unscored — a grade nobody can attribute is not this arm's grade.
- A verifier that did not conclude (`candidate_timeout`, `infra_failed`) or artifacts that do not parse yield no grade, so those exhaustions stay exactly as they are today.

Only facts that exist are recorded: the agent did exhaust its budget, and the verifier did reach a verdict.

Pier carried the identical defect (`settledByEvidence = grade.state === 'graded' && cellArtifact !== null`) and is fixed the same way; its recovery contract is already declared as non-forking with Harbor's.

Refs #2107

## Verification

- `npm run --workspace @maka/headless test` — 1367 pass, 0 fail, 1 skipped
- `npm run lint`, `npm run format:check` — clean
- `npm run typecheck` (all workspaces) — clean

The decisive test drives the **real** `createHarborTaskRunner` through `runFixedPromptController`, so a trial directory on disk is projected into the WAL row the benchmark counts — the seam where the six cells were actually lost:

- `scores a timed-out trial the verifier graded, from trial dir to WAL` → `passed/scored/eligible = true`, `harbor.reward = 1`
- `refuses to score a timed-out trial whose reward disagrees with its verifier outcome` → `passed/scored = false`
- `refuses to score a timed-out trial whose verifier never concluded` → `passed/scored = false`

Plus a table covering the runner's own transport contract (reward `0`, empty, non-numeric; missing or malformed verifier outcome), controller-level projection cases, and an A/B assertion on the **paired** outcome a graded timeout now decides — not just the arm-level rate.

## Review round: the first cut had a real defect

External review (three independent passes) caught that the first commit re-derived "what counts as a grade" at the new seam instead of reusing the existing judge. It read the artifacts and scored on `reward > 0` alone, skipping `assertVerifierRewardAgreement` — the check the completed path enforces. Reproduced end to end: a `reward.txt` of `1.0` alongside a verifier outcome of `failed` — artifacts the completed path rejects as `HarborInfraError` — was recorded as `passed: true, scored: true`. A corrupt scoring authority became a fabricated pass, worse than the drop this PR fixes.

Fixed at the owner in 459ae43: the runner now only transports what the verifier wrote, and the controller derives `passed`/`scored` through `structuredVerifierGrade` + `taskCompletedScoringProjection` — the same pair the completed path uses. Disagreeing artifacts and a non-conclusive verifier both fall out as ungraded, so the runner's duplicated conclusiveness guard and its second parse of the same string were deleted with them. One `HarborTrialGrade` type now spans trial dir → error → WAL.

## Blast radius

`ab-summary` needed no change: `abOutcomeCategory` already classifies a `task_budget_exhausted` event with no `evidenceErrorClass` as `budget`, `isEvaluatedOutcome` already admits it to the pass@1 denominator, and `summarizeArm`/`summarizePairedAttempts` already sum `event.passed`. A `task_completed` cell with `errorClass = 'budget_exhausted'` (the path taken when the self-report *does* exist) has always been able to be `passed: true` there, so this only restores symmetry between the two shapes. The new test pins the paired consequence explicitly.

`prompt-acceptance-policy.ts` gates on `task_completed` and is unaffected.

## Second review round: propagation

A fresh-eyes round (three independent passes, no prior context) could not refute the derivation itself — no input produces a fabricated pass. It found that carrying the verdict was only half the change: the verdict also had to survive the checks every other scored path runs, and mean the same thing to every consumer.

**Provider outage bypass.** The budget-exhausted throw happens before `incompleteTerminalProviderRequest`, whose own contract says an upstream-truncated tail request stays infra *however the trial settled* — "that is what keeps a provider outage out of the denominator instead of scoring it as the agent's zero". Pre-branch that bypass was harmless because the event was always a non-pass; this branch made it consequential. The grade is now withheld on that path through one shared predicate used by both runners: the agent did not get the run it was given, so its verdict is not this arm's evidence. Mutation-verified (removing the guard fails both new tests).

**RSI round analysis.** `taskOutcome` read every `task_budget_exhausted` as `budget`, and `isCovered` required `task_completed`. A graded timeout pass was therefore reported as a `pass → budget` flip *and* a coverage regression — charging the candidate prompt for evidence that exists and says the task passed, while the acceptance gate counted the same row as a pass. Coverage now asks the event's own `eligible`/`scored` instead of its type; ungraded exhaustions still read as `budget`.

**Acceptance partition.** `summarizePromptAcceptancePartition` has no type guard, so graded timeouts already counted correctly into `passEligibleRate`/`coverageRate` — the intended consequence of this fix, but untested. Now pinned, alongside the ungraded case it must keep excluding. (An earlier note in this PR said the acceptance policy was unaffected; that was true of `isStableBaselineEvent` and `selectAddressablePromptTasks`, not of the partition summary.)

**Doc.** The WAL comment claimed an authoritative reward exists whenever `harbor` is present. It does not — a rejected verdict travels too. `scored` is the authority.

## Deferred, with reasons

- **`agent_exit` without a self-report** stays `task_infra_failed`. It claims no deadline, so `task_budget_exhausted` would lie, and `task_completed` needs the `runtimeRefs`/`steps` only the cell attests. Widening it is a WAL taxonomy decision, not this fix. Now documented at the branch rather than left silent.
- **RSI attribution** (`rsi-round-analysis.ts`, `rsi-controller-attribution.ts`) buckets every `task_budget_exhausted` as `budget` before reading `passed`. That bucket is a deliberate category — prompt attribution should not credit a prompt for a timeout — and the new events land in the category matching their name. Changing it is a methodology decision about prompt optimization, not part of this defect.
- **Torn/partial `maka-cell-output.json`** on the budget path still falls to infra: a non-empty but unparseable file is not `null`, so it takes the settled path and `readCellOutput` throws. Pre-existing behavior, unchanged here; distinguishing "absent" from "unreadable" at the gate is a separate change.
