### PR TITLE
fix(headless): make the smoke harness reach Maka's settlement window

### DIFF
--- a/packages/headless/src/__tests__/harbor-smoke-config.test.ts
+++ b/packages/headless/src/__tests__/harbor-smoke-config.test.ts
@@ -66,14 +66,46 @@ describe('harbor smoke config generation', () => {
     assert.equal(env.MAKA_MAX_STEPS, '100');
     assert.equal(env.MAKA_CELL_TIMEOUT_SEC, '7200');
     assert.equal(env.MAKA_HARBOR_AGENT_TIMEOUT_SEC, undefined);
-    assert.equal(config.agent_timeout_multiplier, 8);
   });
 
+  // Harbor resolves the agent phase as
+  // `min(override_timeout_sec ?? task_declared, max_timeout_sec ?? inf) * multiplier`
+  // (harbor/trial/trial.py, _resolve_timeout_sec). Every deadline assertion below
+  // goes through this rather than reading one field: a settlement tail published
+  // on max_timeout_sec satisfies a field-shaped assertion while folding straight
+  // back to the task's own timeout, which is how the window stayed unreachable
+  // through the smoke path while these tests were green.
+  type SmokeAgentEntry = {
+    env: Record<string, string>;
+    override_timeout_sec?: number | null;
+    max_timeout_sec?: number | null;
+  };
+  const harborAgentPhaseSec = (
+    config: Record<string, unknown>,
+    taskDeclaredSec: number,
+  ): number => {
+    const agent = (config.agents as SmokeAgentEntry[])[0]!;
+    const multiplier =
+      (config.agent_timeout_multiplier as number | null) ?? (config.timeout_multiplier as number);
+    return (
+      Math.min(
+        agent.override_timeout_sec ?? taskDeclaredSec,
+        agent.max_timeout_sec ?? Number.POSITIVE_INFINITY,
+      ) * multiplier
+    );
+  };
+
+  // The declared agent timeouts actually present in the smoke dataset. The
+  // profile multipliers were tuned against 900 alone, so anything else is where
+  // a multiplier-derived phase silently stops tracking the cell budget.
+  const DECLARED_AGENT_TIMEOUTS_SEC = [600, 900, 1800, 3600];
+
   test('the smoke agent phase outlasts the cell budget by the settlement window', async () => {
-    // The maka profiles tune agent_timeout_multiplier so the task-native budget
-    // times the multiplier equals the cell budget. Leaving max_timeout_sec null
-    // therefore makes Harbor kill the cell at the exact moment it stops calling
-    // the model and starts writing, turning a scored result into an infra failure.
+    // The regression this pins: publishing budget + grace on max_timeout_sec.
+    // For maka-basic on the default 900s task Harbor folded that to
+    // min(900, 3630) * 4 = 3600 — the cell budget exactly, so the cell was
+    // SIGKILLed at the instant it stopped calling the model and began writing
+    // maka-cell-output.json, and a scored trial read as an infra failure.
     const manifest = await loadManifest();
     for (const profileName of ['maka-basic', 'maka-heavy']) {
       const { config } = buildSmokeJobConfig({
@@ -81,25 +113,89 @@ describe('harbor smoke config generation', () => {
         profileName,
         overrides: { jobName: 'job' },
       });
-      const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
-      const env = agent.env as Record<string, string>;
-      assert.equal(
-        agent.max_timeout_sec,
-        Number(env.MAKA_CELL_TIMEOUT_SEC) + MAKA_SETTLEMENT_GRACE_SEC,
-        profileName,
-      );
+      const agent = (config.agents as SmokeAgentEntry[])[0]!;
+      const budget = Number(agent.env.MAKA_CELL_TIMEOUT_SEC);
+      // The budget is the cell's, so the phase is the same on every task the
+      // dataset declares — not only the 900s one the multiplier was tuned for.
+      for (const declared of DECLARED_AGENT_TIMEOUTS_SEC) {
+        assert.equal(
+          harborAgentPhaseSec(config, declared),
+          budget + MAKA_SETTLEMENT_GRACE_SEC,
+          `${profileName} @ declared=${declared}`,
+        );
+      }
+      // A ceiling cannot raise a base, so leaving one behind can only re-clamp it.
+      assert.equal(agent.max_timeout_sec, null, profileName);
     }
   });
 
-  test('a non-maka smoke profile gets no settlement window', async () => {
+  test('a non-maka smoke profile keeps its multiplier and gets no settlement window', async () => {
     const manifest = await loadManifest();
+    // opencode has no cell budget to publish, so the multiplier stays its only
+    // control — and on the default 900s task it still buys the same 3600s of
+    // model time the maka arms get, which is what makes --compare comparable.
+    const { config: opencode } = buildSmokeJobConfig({
+      manifest,
+      profileName: 'opencode',
+      overrides: { jobName: 'job' },
+    });
+    assert.equal(opencode.agent_timeout_multiplier, 4);
+    assert.equal(harborAgentPhaseSec(opencode, 900), 3600);
+    assert.equal((opencode.agents as SmokeAgentEntry[])[0]!.override_timeout_sec, null);
+
     const { config } = buildSmokeJobConfig({
       manifest,
       profileName: 'oracle',
       overrides: { jobName: 'job' },
     });
-    const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
+    const agent = (config.agents as SmokeAgentEntry[])[0]!;
     assert.equal(agent.max_timeout_sec, null);
+    assert.equal(agent.override_timeout_sec, null);
+    // No multiplier of its own: the phase is the task's own declared timeout.
+    assert.equal(config.agent_timeout_multiplier, null);
+    assert.equal(harborAgentPhaseSec(config, 900), 900);
+  });
+
+  test('--agent-timeout-sec moves the whole phase, not just the cell budget', async () => {
+    const manifest = await loadManifest();
+    const { config } = buildSmokeJobConfig({
+      manifest,
+      profileName: 'maka-heavy',
+      overrides: { jobName: 'job', agentTimeoutSec: '180' },
+    });
+    const agent = (config.agents as SmokeAgentEntry[])[0]!;
+    assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, '180');
+    // Pre-fix this resolved to min(900, 210) * 8 = 1680 — an operator asking for
+    // a 3-minute smoke run got a 28-minute one, and never saw the kill at all.
+    assert.equal(harborAgentPhaseSec(config, 900), 180 + MAKA_SETTLEMENT_GRACE_SEC);
+  });
+
+  test('a maka profile with an unparseable cell budget falls back to the multiplier', async () => {
+    // Nothing absolute to publish, so Harbor's own base has to stand — clamping
+    // it to a phase we could not derive would be worse than leaving it alone.
+    const manifest = await loadManifest();
+    const profile = manifest.profiles!['maka-basic']!;
+    const patched: SmokeManifest = {
+      ...manifest,
+      profiles: {
+        ...manifest.profiles,
+        'maka-basic': {
+          ...profile,
+          agent: {
+            ...profile.agent,
+            env: { ...profile.agent!.env, MAKA_CELL_TIMEOUT_SEC: 'nope' },
+          },
+        },
+      },
+    };
+    const { config } = buildSmokeJobConfig({
+      manifest: patched,
+      profileName: 'maka-basic',
+      overrides: { jobName: 'job' },
+    });
+    assert.equal((config.agents as SmokeAgentEntry[])[0]!.override_timeout_sec, null);
+    assert.equal(config.agent_timeout_multiplier, 4);
+    assert.equal(harborAgentPhaseSec(config, 900), 3600);
   });
 
   test('--model override targets MAKA_MODEL for maka and model_name for non-maka', async () => {

--- a/packages/headless/src/__tests__/harbor-smoke-config.test.ts
+++ b/packages/headless/src/__tests__/harbor-smoke-config.test.ts
@@ -9,6 +9,7 @@ import {
   type SmokeManifest,
 } from '../harbor-smoke-config.js';
 import { MAKA_SETTLEMENT_GRACE_SEC } from '../maka-settlement.js';
+import { type HarborAgentEntry, harborAgentPhaseSec } from './helpers/harbor-agent-phase.js';
 
 const repoRoot = resolve(fileURLToPath(new URL('../../../..', import.meta.url)));
 
@@ -68,37 +69,24 @@ describe('harbor smoke config generation', () => {
     assert.equal(env.MAKA_HARBOR_AGENT_TIMEOUT_SEC, undefined);
   });
 
-  // Harbor resolves the agent phase as
-  // `min(override_timeout_sec ?? task_declared, max_timeout_sec ?? inf) * multiplier`
-  // (harbor/trial/trial.py, _resolve_timeout_sec). Every deadline assertion below
-  // goes through this rather than reading one field: a settlement tail published
-  // on max_timeout_sec satisfies a field-shaped assertion while folding straight
-  // back to the task's own timeout, which is how the window stayed unreachable
-  // through the smoke path while these tests were green.
-  type SmokeAgentEntry = {
-    env: Record<string, string>;
-    override_timeout_sec?: number | null;
-    max_timeout_sec?: number | null;
-  };
-  const harborAgentPhaseSec = (
-    config: Record<string, unknown>,
-    taskDeclaredSec: number,
-  ): number => {
-    const agent = (config.agents as SmokeAgentEntry[])[0]!;
-    const multiplier =
-      (config.agent_timeout_multiplier as number | null) ?? (config.timeout_multiplier as number);
-    return (
-      Math.min(
-        agent.override_timeout_sec ?? taskDeclaredSec,
-        agent.max_timeout_sec ?? Number.POSITIVE_INFINITY,
-      ) * multiplier
-    );
-  };
+  // Every deadline assertion below goes through harborAgentPhaseSec — Harbor's
+  // own resolution rule, modelled once in ./helpers/harbor-agent-phase.js and
+  // shared with the fixed-prompt producer's suite.
+  const MAKA_PROFILES = [
+    'maka-basic',
+    'maka-heavy',
+    'maka-heavy-prune',
+    'maka-prune-default',
+    'maka-stale-off',
+    'maka-retrieval-on',
+  ];
 
-  // The declared agent timeouts actually present in the smoke dataset. The
-  // profile multipliers were tuned against 900 alone, so anything else is where
-  // a multiplier-derived phase silently stops tracking the cell budget.
-  const DECLARED_AGENT_TIMEOUTS_SEC = [600, 900, 1800, 3600];
+  // Two declared timeouts that bracket every shipped cell budget from both
+  // sides. Naming a pair rather than one is the point: with the phase published
+  // absolutely it cannot depend on the declared timeout at all, and one value
+  // cannot express independence.
+  const DECLARED_BELOW_SEC = 600;
+  const DECLARED_ABOVE_SEC = 12_000;
 
   test('the smoke agent phase outlasts the cell budget by the settlement window', async () => {
     // The regression this pins: publishing budget + grace on max_timeout_sec.
@@ -107,17 +95,15 @@ describe('harbor smoke config generation', () => {
     // SIGKILLed at the instant it stopped calling the model and began writing
     // maka-cell-output.json, and a scored trial read as an infra failure.
     const manifest = await loadManifest();
-    for (const profileName of ['maka-basic', 'maka-heavy']) {
+    for (const profileName of MAKA_PROFILES) {
       const { config } = buildSmokeJobConfig({
         manifest,
         profileName,
         overrides: { jobName: 'job' },
       });
-      const agent = (config.agents as SmokeAgentEntry[])[0]!;
+      const agent = (config.agents as HarborAgentEntry[])[0]!;
       const budget = Number(agent.env.MAKA_CELL_TIMEOUT_SEC);
-      // The budget is the cell's, so the phase is the same on every task the
-      // dataset declares — not only the 900s one the multiplier was tuned for.
-      for (const declared of DECLARED_AGENT_TIMEOUTS_SEC) {
+      for (const declared of [DECLARED_BELOW_SEC, DECLARED_ABOVE_SEC]) {
         assert.equal(
           harborAgentPhaseSec(config, declared),
           budget + MAKA_SETTLEMENT_GRACE_SEC,
@@ -126,33 +112,101 @@ describe('harbor smoke config generation', () => {
       }
       // A ceiling cannot raise a base, so leaving one behind can only re-clamp it.
       assert.equal(agent.max_timeout_sec, null, profileName);
+      // 1.0, not null: null makes Harbor fall back to the job-level
+      // timeout_multiplier, which would rescale the absolute phase we just
+      // published. The manifest test below proves the difference is real.
+      assert.equal(config.agent_timeout_multiplier, 1.0, profileName);
     }
   });
 
-  test('a non-maka smoke profile keeps its multiplier and gets no settlement window', async () => {
+  test('a job-level timeout multiplier cannot rescale the published smoke phase', async () => {
+    // timeoutMultiplier is a supported manifest knob, and Harbor reaches for it
+    // whenever agent_timeout_multiplier is null. Pinning agent_timeout_multiplier
+    // at 1.0 is what keeps the number we publish the number Harbor kills at;
+    // leaving it null here would resolve 3630 * 0.5 = 1815 — under the cell's own
+    // 3600s budget, which is the very kill this fix exists to prevent.
     const manifest = await loadManifest();
-    // opencode has no cell budget to publish, so the multiplier stays its only
-    // control — and on the default 900s task it still buys the same 3600s of
-    // model time the maka arms get, which is what makes --compare comparable.
-    const { config: opencode } = buildSmokeJobConfig({
-      manifest,
-      profileName: 'opencode',
+    const scaled: SmokeManifest = {
+      ...manifest,
+      defaults: { ...manifest.defaults, timeoutMultiplier: 0.5 },
+    };
+    const { config } = buildSmokeJobConfig({
+      manifest: scaled,
+      profileName: 'maka-basic',
       overrides: { jobName: 'job' },
     });
-    assert.equal(opencode.agent_timeout_multiplier, 4);
-    assert.equal(harborAgentPhaseSec(opencode, 900), 3600);
-    assert.equal((opencode.agents as SmokeAgentEntry[])[0]!.override_timeout_sec, null);
+    assert.equal(config.timeout_multiplier, 0.5);
+    assert.equal(harborAgentPhaseSec(config, 900), 3600 + MAKA_SETTLEMENT_GRACE_SEC);
+  });
 
+  test('an operator-widened settlement window widens the smoke phase', async () => {
+    const manifest = await loadManifest();
+    const widened = MAKA_SETTLEMENT_GRACE_SEC * 3;
+    const profile = manifest.profiles!['maka-basic']!;
+    const patched: SmokeManifest = {
+      ...manifest,
+      profiles: {
+        ...manifest.profiles,
+        'maka-basic': {
+          ...profile,
+          agent: {
+            ...profile.agent,
+            env: {
+              ...profile.agent!.env,
+              MAKA_CELL_SETTLEMENT_GRACE_SEC: String(widened),
+            },
+          },
+        },
+      },
+    };
+    const { config } = buildSmokeJobConfig({
+      manifest: patched,
+      profileName: 'maka-basic',
+      overrides: { jobName: 'job' },
+    });
+    const agent = (config.agents as HarborAgentEntry[])[0]!;
+    // The cell reads the same env, so both sides of the window move together.
+    assert.equal(agent.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, String(widened));
+    assert.equal(harborAgentPhaseSec(config, 900), 3600 + widened);
+  });
+
+  test('every smoke arm gets the same model budget and only Maka a settlement tail', async () => {
+    // The one number that has to be identical across arms for --compare to mean
+    // anything is the model budget. opencode has no cell budget of its own, so
+    // its multiplier stays the only control that can buy it the same 3600s — and
+    // nothing else in the suite ties the two arms together.
+    const manifest = await loadManifest();
+    const configFor = (profileName: string) =>
+      buildSmokeJobConfig({ manifest, profileName, overrides: { jobName: 'job' } }).config;
+
+    const maka = configFor('maka-basic');
+    const opencode = configFor('opencode');
+    const budget = Number((maka.agents as HarborAgentEntry[])[0]!.env.MAKA_CELL_TIMEOUT_SEC);
+
+    // On the dataset's default task both arms call the model for the same budget.
+    assert.equal(harborAgentPhaseSec(opencode, 900), budget);
+    assert.equal(opencode.agent_timeout_multiplier, 4);
+    assert.equal((opencode.agents as HarborAgentEntry[])[0]!.override_timeout_sec, null);
+
+    // The whole asymmetry: only the Maka cell has artifacts to settle.
+    assert.ok(MAKA_SETTLEMENT_GRACE_SEC > 0, 'the settlement window must be a real window');
+    assert.equal(
+      harborAgentPhaseSec(maka, 900) - harborAgentPhaseSec(opencode, 900),
+      MAKA_SETTLEMENT_GRACE_SEC,
+    );
+  });
+
+  test('the oracle profile gets neither a settlement window nor a multiplier', async () => {
+    const manifest = await loadManifest();
     const { config } = buildSmokeJobConfig({
       manifest,
       profileName: 'oracle',
       overrides: { jobName: 'job' },
     });
-    const agent = (config.agents as SmokeAgentEntry[])[0]!;
+    const agent = (config.agents as HarborAgentEntry[])[0]!;
     assert.equal(agent.max_timeout_sec, null);
     assert.equal(agent.override_timeout_sec, null);
-    // No multiplier of its own: the phase is the task's own declared timeout.
-    assert.equal(config.agent_timeout_multiplier, null);
+    // The phase is the task's own declared timeout, untouched.
     assert.equal(harborAgentPhaseSec(config, 900), 900);
   });
 
@@ -163,7 +217,7 @@ describe('harbor smoke config generation', () => {
       profileName: 'maka-heavy',
       overrides: { jobName: 'job', agentTimeoutSec: '180' },
     });
-    const agent = (config.agents as SmokeAgentEntry[])[0]!;
+    const agent = (config.agents as HarborAgentEntry[])[0]!;
     assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, '180');
     // Pre-fix this resolved to min(900, 210) * 8 = 1680 — an operator asking for
     // a 3-minute smoke run got a 28-minute one, and never saw the kill at all.
@@ -193,7 +247,7 @@ describe('harbor smoke config generation', () => {
       profileName: 'maka-basic',
       overrides: { jobName: 'job' },
     });
-    assert.equal((config.agents as SmokeAgentEntry[])[0]!.override_timeout_sec, null);
+    assert.equal((config.agents as HarborAgentEntry[])[0]!.override_timeout_sec, null);
     assert.equal(config.agent_timeout_multiplier, 4);
     assert.equal(harborAgentPhaseSec(config, 900), 3600);
   });

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
+import { type HarborAgentEntry, harborAgentPhaseSec } from './helpers/harbor-agent-phase.js';
 import type { HarborCellExecutionIdentity, HarborCellOutput } from '../cell-output.js';
 import { FixedPromptBudgetExhaustedError, type TaskRunInput } from '../fixed-prompt-controller.js';
 import { CODEX_TOOLCHAIN_SPEC } from '../codex-toolchain.js';
@@ -2802,26 +2803,10 @@ describe('buildHarborJobConfig', () => {
     assert.equal(env.MAKA_BACKEND, 'ai-sdk');
   });
 
-  // Harbor resolves the agent phase as `min(override ?? task_declared, max ?? inf)`
-  // (harbor/trial/trial.py, _resolve_timeout_sec). Every deadline assertion below
-  // goes through this rather than reading a field directly: a settlement tail
-  // published on max_timeout_sec satisfies a field-shaped assertion while
-  // resolving straight back to the task's own timeout, which is exactly how the
-  // window stayed unreachable while these tests were green.
-  // Harbor then scales that by agent_timeout_multiplier ?? timeout_multiplier,
-  // omitted here because this runner never sets the former and every call site
-  // passes 1.0 for the latter. Assert a scaled phase through Harbor's own
-  // multiplier rather than widening this helper if that ever stops being true.
-  type HarborAgentEntry = {
-    env: Record<string, string>;
-    override_timeout_sec?: number;
-    max_timeout_sec?: number;
-  };
-  const harborAgentPhaseSec = (agent: HarborAgentEntry, taskDeclaredSec: number): number =>
-    Math.min(
-      agent.override_timeout_sec ?? taskDeclaredSec,
-      agent.max_timeout_sec ?? Number.POSITIVE_INFINITY,
-    );
+  // Deadline assertions below go through harborAgentPhaseSec — Harbor's own
+  // resolution rule, modelled once in ./helpers/harbor-agent-phase.js and shared with
+  // the smoke producer's suite. See that file for why a field-shaped assertion
+  // is not enough.
 
   test('resolves Maka a settlement tail past the task-declared agent timeout', () => {
     // The regression this pins: publishing budget + grace on max_timeout_sec.
@@ -2838,7 +2823,7 @@ describe('buildHarborJobConfig', () => {
     });
     const agent = (config.agents as HarborAgentEntry[])[0]!;
     assert.equal(
-      harborAgentPhaseSec(agent, declared),
+      harborAgentPhaseSec(config, declared),
       declared + MAKA_SETTLEMENT_GRACE_SEC,
       'Harbor must kill one settlement window after the model budget, not at it',
     );
@@ -2850,8 +2835,8 @@ describe('buildHarborJobConfig', () => {
     // Maka's cell stops calling the model one grace window before its own budget
     // runs out; native CLIs run until Harbor cancels. Taking the grace out of the
     // budget would hand Maka less model time than its competitors for the same task.
-    const agentFor = (adapter: 'maka' | 'codex') => {
-      const config = buildHarborJobConfig(runInput(), {
+    const configFor = (adapter: 'maka' | 'codex') =>
+      buildHarborJobConfig(runInput(), {
         makaRepoPath: '/repo',
         jobsDir: '/jobs/x',
         jobName: 'trial',
@@ -2865,15 +2850,14 @@ describe('buildHarborJobConfig', () => {
             }
           : {}),
       });
-      return (config.agents as HarborAgentEntry[])[0]!;
-    };
 
     // Pin the window as a real quantity: with a zero grace every assertion below
     // would hold for an implementation that gives no arm any settlement tail.
     assert.ok(MAKA_SETTLEMENT_GRACE_SEC > 0, 'the settlement window must be a real window');
 
-    const maka = agentFor('maka');
-    const makaPhase = harborAgentPhaseSec(maka, 1800);
+    const makaConfig = configFor('maka');
+    const maka = (makaConfig.agents as HarborAgentEntry[])[0]!;
+    const makaPhase = harborAgentPhaseSec(makaConfig, 1800);
     assert.equal(makaPhase, 1800 + MAKA_SETTLEMENT_GRACE_SEC);
     // The budget the cell is handed is the model budget itself, on every path.
     assert.equal(maka.env.MAKA_CELL_TIMEOUT_SEC, '1800');
@@ -2881,8 +2865,9 @@ describe('buildHarborJobConfig', () => {
     // Harbor kills at the agent phase, which is that budget plus the window.
     assert.equal(makaPhase - Number(maka.env.MAKA_CELL_TIMEOUT_SEC), MAKA_SETTLEMENT_GRACE_SEC);
 
-    const codex = agentFor('codex');
-    const codexPhase = harborAgentPhaseSec(codex, 1800);
+    const codexConfig = configFor('codex');
+    const codex = (codexConfig.agents as HarborAgentEntry[])[0]!;
+    const codexPhase = harborAgentPhaseSec(codexConfig, 1800);
     assert.equal(codexPhase, 1800);
     assert.equal(codex.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, undefined);
     // The whole asymmetry: Maka's phase is longer by exactly the window it
@@ -2907,7 +2892,7 @@ describe('buildHarborJobConfig', () => {
     const agent = (config.agents as HarborAgentEntry[])[0]!;
     assert.equal(agent.env.MAKA_CELL_SETTLEMENT_GRACE_SEC, String(widened));
     assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, '1800');
-    assert.equal(harborAgentPhaseSec(agent, 1800), 1800 + widened);
+    assert.equal(harborAgentPhaseSec(config, 1800), 1800 + widened);
   });
 
   test('a malformed cell timeout falls back instead of failing the run', () => {
@@ -2970,7 +2955,7 @@ describe('buildHarborJobConfig', () => {
         label,
       );
       assert.equal(
-        harborAgentPhaseSec(metadataAgent, 1234),
+        harborAgentPhaseSec(withMetadata, 1234),
         (parsed ?? 1234) + MAKA_SETTLEMENT_GRACE_SEC,
         label,
       );
@@ -2993,7 +2978,7 @@ describe('buildHarborJobConfig', () => {
       // the task's declared timeout, stood in for here by a sentinel.
       const declaredSentinel = 4321;
       assert.equal(
-        harborAgentPhaseSec(agent, declaredSentinel),
+        harborAgentPhaseSec(withoutMetadata, declaredSentinel),
         parsed === undefined ? declaredSentinel : parsed + MAKA_SETTLEMENT_GRACE_SEC,
         label,
       );
@@ -3021,7 +3006,7 @@ describe('buildHarborJobConfig', () => {
     assert.equal(agent.env.MAKA_CELL_TIMEOUT_SEC, '1234');
     assert.equal(agent.env.MAKA_STREAM_CONNECT_TIMEOUT_MS, '1234000');
     assert.equal(agent.env.MAKA_STREAM_IDLE_TIMEOUT_MS, '1234000');
-    assert.equal(harborAgentPhaseSec(agent, 1234), 1234 + MAKA_SETTLEMENT_GRACE_SEC);
+    assert.equal(harborAgentPhaseSec(config, 1234), 1234 + MAKA_SETTLEMENT_GRACE_SEC);
   });
 
   test('merges per-attempt agent env into the Harbor agent config', () => {

--- a/packages/headless/src/__tests__/helpers/harbor-agent-phase.ts
+++ b/packages/headless/src/__tests__/helpers/harbor-agent-phase.ts
@@ -1,0 +1,48 @@
+/**
+ * Harbor's own agent-phase resolution rule, modelled once for the tests.
+ *
+ * Every producer of a Harbor job config publishes the agent phase across three
+ * fields, and Harbor folds them together in `_resolve_timeout_sec` /
+ * `_compute_agent_timeout_sec` (harbor/trial/trial.py):
+ *
+ *   base  = agent.override_timeout_sec or task.config.agent.timeout_sec
+ *   phase = min(base, agent.max_timeout_sec or inf)
+ *           * (agent_timeout_multiplier if not None else timeout_multiplier)
+ *
+ * Deadline assertions go through this rather than reading a field directly. A
+ * settlement tail published on max_timeout_sec satisfies a field-shaped
+ * assertion while folding straight back to the task's own declared timeout,
+ * which is exactly how the window stayed unreachable while the tests were
+ * green — on both producers, twice.
+ *
+ * It takes the whole config because the multiplier lives at job level and the
+ * min() at agent level: a producer that gets one right and the other wrong
+ * publishes the wrong phase, and only reading both catches it.
+ */
+
+export type HarborAgentEntry = {
+  env: Record<string, string>;
+  override_timeout_sec?: number | null;
+  max_timeout_sec?: number | null;
+};
+
+/** The phase Harbor resolves for `config`'s single agent on a task declaring
+ * `taskDeclaredSec`. Takes the producers' own untyped job-config shape so no
+ * call site has to cast. Mirror any change to Harbor's rule here, not at a call
+ * site — one drifting copy is how this class of bug survives a green suite. */
+export function harborAgentPhaseSec(
+  config: Record<string, unknown>,
+  taskDeclaredSec: number,
+): number {
+  const agent = (config.agents as HarborAgentEntry[])[0]!;
+  const multiplier =
+    (config.agent_timeout_multiplier as number | null | undefined) ??
+    (config.timeout_multiplier as number | undefined) ??
+    1;
+  return (
+    Math.min(
+      agent.override_timeout_sec ?? taskDeclaredSec,
+      agent.max_timeout_sec ?? Number.POSITIVE_INFINITY,
+    ) * multiplier
+  );
+}

--- a/packages/headless/src/harbor-smoke-config.ts
+++ b/packages/headless/src/harbor-smoke-config.ts
@@ -177,11 +177,13 @@ export function buildSmokeJobConfig(input: {
 
   if (overrides.maxSteps) agentEnv.MAKA_MAX_STEPS = overrides.maxSteps;
   if (overrides.agentTimeoutSec) agentEnv.MAKA_CELL_TIMEOUT_SEC = overrides.agentTimeoutSec;
-  // Without this, Harbor bounds the agent phase at the task-native budget times
-  // the profile multiplier, which the maka profiles tune to equal the cell
-  // budget exactly — so the cell would be killed at the instant it stops calling
-  // the model and starts writing, and the trial would read as an infra failure
-  // instead of a scored result. Same rule the fixed-prompt runner applies.
+  // Harbor resolves the agent phase as
+  // `min(override_timeout_sec ?? task_declared, max_timeout_sec ?? inf) * multiplier`
+  // (harbor/trial/trial.py, _resolve_timeout_sec). Once a maka profile declares a
+  // cell budget, that budget plus its settlement window is the phase — on every
+  // task, not just the ones whose declared timeout the profile multiplier happens
+  // to line up with. So it goes on override_timeout_sec, which replaces the
+  // declared base; max_timeout_sec is only a ceiling and could never raise it.
   const smokeModelBudgetSec = profileName.startsWith('maka-')
     ? lenientPositiveIntEnv(agentEnv.MAKA_CELL_TIMEOUT_SEC)
     : undefined;
@@ -205,10 +207,13 @@ export function buildSmokeJobConfig(input: {
     jobs_dir: defaults.jobsDir || 'packages/headless/harbor/smoke-jobs',
     n_attempts: Number(defaults.nAttempts || 1),
     timeout_multiplier: Number(defaults.timeoutMultiplier || 1.0),
+    // Harbor applies this multiplier after the min(), so it would scale an
+    // absolute phase too. Where we publish one, the multiplier's whole job —
+    // stretching a task-declared timeout into the budget this profile wants —
+    // is already done, and 1.0 is what keeps the published number the phase.
+    // Profiles with no cell budget of their own still lean on the multiplier.
     agent_timeout_multiplier:
-      profile.agentTimeoutMultiplier === undefined || profile.agentTimeoutMultiplier === null
-        ? null
-        : profile.agentTimeoutMultiplier,
+      smokeAgentPhaseSec !== null ? 1.0 : (profile.agentTimeoutMultiplier ?? null),
     verifier_timeout_multiplier: null,
     agent_setup_timeout_multiplier: null,
     environment_build_timeout_multiplier: null,
@@ -247,9 +252,9 @@ export function buildSmokeJobConfig(input: {
         import_path: agent.importPath ?? null,
         model_name: agentModelName,
         skills: [],
-        override_timeout_sec: null,
+        override_timeout_sec: smokeAgentPhaseSec,
         override_setup_timeout_sec: null,
-        max_timeout_sec: smokeAgentPhaseSec,
+        max_timeout_sec: null,
         extra_allowed_hosts: [],
         kwargs: agent.kwargs ?? {},
         env: agentEnv,


### PR DESCRIPTION
## Summary

The smoke harness published the Maka cell budget plus its settlement grace on `max_timeout_sec`. Harbor resolves the agent phase as `min(override_timeout_sec ?? task_declared, max_timeout_sec ?? inf) * multiplier` (`harbor/trial/trial.py`, `_resolve_timeout_sec`), so `max_timeout_sec` is a **ceiling** — it can only lower the task's declared timeout, never raise it. For `maka-basic` on the default 900s task that folded to `min(900, 3630) * 4 = 3600`, the cell budget exactly, and the cell was SIGKILLed at the instant it stopped calling the model and began writing `maka-cell-output.json`. The symptom `packages/headless/src/maka-settlement.ts` describes.

#2107 fixed the same bug on the fixed-prompt batch path and deliberately left this one out, because the two paths do not resolve the phase the same way: `harbor-task-runner.ts` sets no `agent_timeout_multiplier`, while the smoke profiles do (`maka-heavy` is 8). Harbor applies that multiplier **after** the `min()`, so moving an absolute value onto `override_timeout_sec` alone would have it multiplied again — 7230 × 8 = 57840.

So this publishes the phase on `override_timeout_sec` **and** normalises `agent_timeout_multiplier` to 1.0 wherever an absolute phase is published. The multiplier's only job is stretching a task-declared timeout into the budget the profile wants, and an absolute value has already absorbed it. 1.0 rather than null: null makes Harbor fall back to the job-level `timeout_multiplier`, which would rescale the number we just published. Profiles with no cell budget of their own (`opencode`, `oracle`) keep their multiplier untouched.

That also drops a premise the old comment took for granted. It claimed the profiles tune the multiplier so that `declared * multiplier == cell budget`. The multipliers were tuned against a 900s declared timeout alone, but the dataset declares 600/900/1800/3600 (52/92 tasks at 900), so the identity was never true in general — on a 3600s task `maka-heavy` was resolving a 28800s phase against a 7200s budget. The phase now tracks `MAKA_CELL_TIMEOUT_SEC` on every task, which is what `maka-settlement.ts` says the one rule is.

Refs #2107.

### Second commit: one model of Harbor's rule, not two

#2107 landed a `harborAgentPhaseSec` helper in `harbor-task-runner.test.ts`; this PR had grown its own. Two hand-written copies of one external system's rule is how this bug class survives — if Harbor changes `_resolve_timeout_sec`, both suites stay green and both are wrong. It now lives once in `packages/headless/src/__tests__/helpers/harbor-agent-phase.ts`. The shared version models the multiplier, which the fixed-prompt copy deliberately did not, so that suite gets strictly more faithful assertions.

## Verification

`npm test --workspace=packages/headless` (1353 tests, 0 fail), `npm run lint`, `npm run format:check`.

Assertions go through the phase Harbor actually **resolves**, not a field value — a tail on `max_timeout_sec` satisfies a field-shaped assertion while folding straight back to the task's own timeout, which is how this stayed green while the window was unreachable. Reverting only `harbor-smoke-config.ts` fails the regression tests and leaves the rest green. Regressing `agent_timeout_multiplier` from `1.0` to `null` — invisible to every test before the second commit — now fails two.

### Live smoke run

Unit tests cannot show a SIGKILL, so both geometries were run through the real harness (Harbor + Docker + DeepSeek, `*sqlite-with-gcov`). The shipped `maka-basic` geometry is budget 3600 / declared 900 / ×4 → phase 3600 = budget. Reproduced at 1/20 the wall clock as budget 180 / declared 900 / ×6⁄7 → phase 180 = budget; the "after" arm is the generated config unmodified.

| | before (phase = budget = 180s) | after (phase = budget + grace = 210s) |
| --- | --- | --- |
| config | `max_timeout_sec: 210`, `override: null`, mult 6⁄7 | `override_timeout_sec: 210`, `max: null`, mult 1.0 |
| cell wall clock | killed at 180s | 182.0s, exited `budget_exhausted` (rc 124) |
| `maka-harbor.status.json` | frozen at `"status": "running"` | `budget_exhausted` |
| `maka-harbor.stdout.json` | **0 bytes** — no envelope | 55972 bytes, `settledByDeadline: true`, `taxonomy: budget_exhausted`, `benchmarkFailureShouldThrow: false` |
| Harbor trial | `AgentTimeoutError`, `n_errored_trials: 1` | no exception, `n_errors: 0` |
| reward | 1.0 — a verifier-passing run filed as an infra failure | 0.0 |

The differing rewards are model nondeterminism on a 3-minute cap, not a property of the change. The before arm is the sharper illustration of the bug: the verifier scored it 1.0 and Harbor still filed it as `AgentTimeoutError`.

### Not run

Full-budget (3600s) runs of the shipped profiles, and the `--compare` opencode arm, which this change does not touch.

## Deferred

`agentTimeoutMultiplier` on the six `maka-*` profiles in `terminal-bench-smoke-profiles.json` is now reachable only through the malformed-budget fallback, so it reads as a live control that no longer controls anything. Deleting it is a manifest semantics change that also moves that fallback's phase from `declared × 4` to `declared × 1`, which deserves its own decision rather than riding along with a timeout fix.

`opencode` still derives its phase from a multiplier, so `--compare` gives both arms the same model budget only on a 900s-declared task. Pre-existing, untouched here, and fixable by giving that profile an absolute budget of its own.