### PR TITLE
feat(inspector): filter the trace by what a reader actually asks

### DIFF
--- a/apps/desktop/src/main/__tests__/session-inspector-filter.test.ts
+++ b/apps/desktop/src/main/__tests__/session-inspector-filter.test.ts
@@ -1,0 +1,148 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { emptyTraceTotals, type TraceTotals } from '@maka/core/session-trace';
+import {
+  applyInspectorFilter,
+  isEmptyInspectorFilter,
+} from '../../renderer/session-inspector-filter.js';
+import type {
+  InspectorPanelModel,
+  InspectorStepRow,
+  InspectorTurnRow,
+} from '../../renderer/session-inspector-panel-model.js';
+
+function step(overrides: Partial<InspectorStepRow> = {}): InspectorStepRow {
+  return {
+    id: 'step-1',
+    kind: 'model_call',
+    label: 'claude-test',
+    failed: false,
+    ...overrides,
+  };
+}
+
+function turn(overrides: Partial<InspectorTurnRow> = {}): InspectorTurnRow {
+  return {
+    turnId: 'turn-1',
+    startedAt: 1_000,
+    durationMs: 500,
+    totals: emptyTraceTotals(),
+    failed: false,
+    steps: [step()],
+    ...overrides,
+  };
+}
+
+function model(turns: InspectorTurnRow[], totals: TraceTotals = emptyTraceTotals()): InspectorPanelModel {
+  return { turns, totals, empty: turns.length === 0 };
+}
+
+describe('inspector filter', () => {
+  it('treats an absent or blank filter as no filter at all', () => {
+    assert.equal(isEmptyInspectorFilter(undefined), true);
+    assert.equal(isEmptyInspectorFilter({ query: '   ' }), true);
+    assert.equal(isEmptyInspectorFilter({ kinds: [] }), true);
+    assert.equal(isEmptyInspectorFilter({ query: 'bash' }), false);
+    assert.equal(isEmptyInspectorFilter({ failedOnly: true }), false);
+    assert.equal(isEmptyInspectorFilter({ minCostUsd: 0 }), false, 'zero is a real threshold');
+
+    const source = model([turn()]);
+    const result = applyInspectorFilter(source, undefined);
+    assert.equal(result.filtered, false);
+    assert.deepEqual(result.turns, source.turns);
+  });
+
+  it('matches free text across the fields the panel renders', () => {
+    const source = model([
+      turn({
+        turnId: 'turn-a',
+        steps: [step({ id: 'a', kind: 'tool', label: 'Bash' }), step({ id: 'b', label: 'gpt-x' })],
+      }),
+    ]);
+
+    const byTool = applyInspectorFilter(source, { query: 'bash' });
+    assert.deepEqual(
+      byTool.turns[0]?.steps.map((entry) => entry.id),
+      ['a'],
+      'case-insensitive on the tool name',
+    );
+    assert.equal(byTool.hiddenSteps, 1);
+
+    const byModel = applyInspectorFilter(source, { query: 'GPT' });
+    assert.deepEqual(byModel.turns[0]?.steps.map((entry) => entry.id), ['b']);
+  });
+
+  it('keeps a turn whose id matches even when no step does', () => {
+    // Answering "where is turn-a" with silence would be the wrong answer.
+    const source = model([turn({ turnId: 'turn-a', steps: [step({ label: 'claude' })] })]);
+    const result = applyInspectorFilter(source, { query: 'turn-a' });
+
+    assert.equal(result.turns.length, 1);
+    assert.equal(result.hiddenTurns, 0);
+  });
+
+  it('excludes unpriced steps from a cost threshold rather than treating them as cheap', () => {
+    // Absent is not zero — the same rule the canonical record keeps.
+    const source = model([
+      turn({
+        steps: [
+          step({ id: 'priced', costUsd: 0.05 }),
+          step({ id: 'cheap', costUsd: 0.001 }),
+          step({ id: 'unpriced' }),
+        ],
+      }),
+    ]);
+
+    const result = applyInspectorFilter(source, { minCostUsd: 0.01 });
+    assert.deepEqual(result.turns[0]?.steps.map((entry) => entry.id), ['priced']);
+    assert.equal(result.hiddenSteps, 2);
+  });
+
+  it('restricts to the selected kinds', () => {
+    const source = model([
+      turn({
+        steps: [
+          step({ id: 'call', kind: 'model_call' }),
+          step({ id: 'tool', kind: 'tool' }),
+          step({ id: 'compaction', kind: 'compaction' }),
+        ],
+      }),
+    ]);
+
+    const result = applyInspectorFilter(source, { kinds: ['tool', 'compaction'] });
+    assert.deepEqual(result.turns[0]?.steps.map((entry) => entry.id), ['tool', 'compaction']);
+  });
+
+  it('failed-only drops whole turns that succeeded', () => {
+    const source = model([
+      turn({ turnId: 'ok' }),
+      turn({ turnId: 'bad', failed: true, failureCode: 'tool_failed' }),
+    ]);
+
+    const result = applyInspectorFilter(source, { failedOnly: true });
+    assert.deepEqual(result.turns.map((entry) => entry.turnId), ['bad']);
+    assert.equal(result.hiddenTurns, 1);
+  });
+
+  it('a filter that matches nothing is not an empty session', () => {
+    // "Nothing matches your filter" and "this session did nothing" are
+    // different claims, and only the panel can tell the reader which it is.
+    const source = model([turn()]);
+    const result = applyInspectorFilter(source, { query: 'no-such-thing' });
+
+    assert.equal(result.turns.length, 0);
+    assert.equal(result.filtered, true);
+    assert.equal(result.hiddenTurns, 1);
+    assert.equal(result.empty, false, 'the session still happened');
+  });
+
+  it('leaves session totals alone so a filtered view cannot restate the bill', () => {
+    // Totals answer "what did this session cost". Recomputing them per filter
+    // would produce a number that is true of nothing.
+    const totals: TraceTotals = { ...emptyTraceTotals(), modelAttempts: 4, costUsd: 0.2 };
+    const source = model([turn({ steps: [step({ costUsd: 0.05 })] })], totals);
+
+    const result = applyInspectorFilter(source, { query: 'no-such-thing' });
+    assert.deepEqual(result.totals, totals);
+  });
+});

--- a/apps/desktop/src/main/__tests__/session-inspector-filter.test.ts
+++ b/apps/desktop/src/main/__tests__/session-inspector-filter.test.ts
@@ -41,10 +41,8 @@ describe('inspector filter', () => {
   it('treats an absent or blank filter as no filter at all', () => {
     assert.equal(isEmptyInspectorFilter(undefined), true);
     assert.equal(isEmptyInspectorFilter({ query: '   ' }), true);
-    assert.equal(isEmptyInspectorFilter({ kinds: [] }), true);
     assert.equal(isEmptyInspectorFilter({ query: 'bash' }), false);
     assert.equal(isEmptyInspectorFilter({ failedOnly: true }), false);
-    assert.equal(isEmptyInspectorFilter({ minCostUsd: 0 }), false, 'zero is a real threshold');
 
     const source = model([turn()]);
     const result = applyInspectorFilter(source, undefined);
@@ -72,45 +70,46 @@ describe('inspector filter', () => {
     assert.deepEqual(byModel.turns[0]?.steps.map((entry) => entry.id), ['b']);
   });
 
-  it('keeps a turn whose id matches even when no step does', () => {
-    // Answering "where is turn-a" with silence would be the wrong answer.
-    const source = model([turn({ turnId: 'turn-a', steps: [step({ label: 'claude' })] })]);
+  it('keeps a turn whose id matches even when it has no steps at all', () => {
+    // The zero-step path is the one worth pinning: with steps present, the step
+    // haystack could carry the match instead and the branch would never run.
+    const source = model([turn({ turnId: 'turn-a', steps: [] })]);
     const result = applyInspectorFilter(source, { query: 'turn-a' });
 
-    assert.equal(result.turns.length, 1);
+    assert.equal(result.turns.length, 1, 'answering "where is turn-a" with silence is wrong');
     assert.equal(result.hiddenTurns, 0);
+    assert.equal(result.turns[0]?.steps.length, 0);
   });
 
-  it('excludes unpriced steps from a cost threshold rather than treating them as cheap', () => {
-    // Absent is not zero — the same rule the canonical record keeps.
+  it('keeps a failed turn with no steps when the filter asks only about outcome', () => {
+    // A turn that failed before recording a step is exactly what "failed only"
+    // is asked to surface; a text-free filter must not drop it for being empty.
+    const source = model([
+      turn({ turnId: 'ok' }),
+      turn({ turnId: 'bad', failed: true, steps: [] }),
+    ]);
+    const result = applyInspectorFilter(source, { failedOnly: true });
+
+    assert.deepEqual(
+      result.turns.map((entry) => entry.turnId),
+      ['bad'],
+    );
+  });
+
+  it('does not let one turn-level failure message retain every step', () => {
+    // Turn text belongs to the turn. Folding it into each step's haystack made
+    // a single match keep steps that explain nothing about it.
     const source = model([
       turn({
-        steps: [
-          step({ id: 'priced', costUsd: 0.05 }),
-          step({ id: 'cheap', costUsd: 0.001 }),
-          step({ id: 'unpriced' }),
-        ],
+        turnId: 'turn-a',
+        failed: true,
+        failureMessage: 'disk full',
+        steps: [step({ id: 'a', label: 'Bash' }), step({ id: 'b', label: 'claude' })],
       }),
     ]);
 
-    const result = applyInspectorFilter(source, { minCostUsd: 0.01 });
-    assert.deepEqual(result.turns[0]?.steps.map((entry) => entry.id), ['priced']);
-    assert.equal(result.hiddenSteps, 2);
-  });
-
-  it('restricts to the selected kinds', () => {
-    const source = model([
-      turn({
-        steps: [
-          step({ id: 'call', kind: 'model_call' }),
-          step({ id: 'tool', kind: 'tool' }),
-          step({ id: 'compaction', kind: 'compaction' }),
-        ],
-      }),
-    ]);
-
-    const result = applyInspectorFilter(source, { kinds: ['tool', 'compaction'] });
-    assert.deepEqual(result.turns[0]?.steps.map((entry) => entry.id), ['tool', 'compaction']);
+    const result = applyInspectorFilter(source, { query: 'disk full' });
+    assert.equal(result.turns.length, 0, 'no rendered row explains that phrase');
   });
 
   it('failed-only drops whole turns that succeeded', () => {

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -77,6 +77,12 @@ export interface DesktopConversationCopy {
     turnsShort: string;
     recovered: string;
     turnFailed: string;
+    filterLabel: string;
+    filterPlaceholder: string;
+    filterFailedOnly: string;
+    filterClear: string;
+    noMatches: string;
+    hiddenByFilter: string;
   };
   quoteCompanion: {
     /** Read-only exploration hint shown in the empty companion panel. */
@@ -172,6 +178,12 @@ const COPY = {
       turnsShort: '轮记录数少于步数',
       recovered: '已恢复',
       turnFailed: '本轮失败',
+      filterLabel: '筛选追踪',
+      filterPlaceholder: '按工具、模型或轮次筛选',
+      filterFailedOnly: '仅失败',
+      filterClear: '清除筛选',
+      noMatches: '没有匹配的步骤——这个会话本身是有内容的',
+      hiddenByFilter: '项被筛选隐藏',
     },
     quoteCompanion: {
       hint: '这里的追问会带上主对话的完整上下文：只做解释和只读探索，不会改动文件，也不写回主对话。在主对话里继续选中文本追问，会加进这个侧栏。',
@@ -252,6 +264,12 @@ const COPY = {
       turnsShort: 'turns short of their step count',
       recovered: 'recovered',
       turnFailed: 'Turn failed',
+      filterLabel: 'Filter the trace',
+      filterPlaceholder: 'Filter by tool, model or turn',
+      filterFailedOnly: 'Failed only',
+      filterClear: 'Clear filter',
+      noMatches: 'Nothing matches this filter — the session itself is not empty',
+      hiddenByFilter: 'hidden by the filter',
     },
     quoteCompanion: {
       hint: 'Questions here carry the full context of the main conversation: read-only exploration and explanation, no file changes, and nothing is written back to the main conversation. Select more text in the main transcript to add it to this side panel.',

--- a/apps/desktop/src/renderer/session-inspector-filter.ts
+++ b/apps/desktop/src/renderer/session-inspector-filter.ts
@@ -1,32 +1,31 @@
-import type { TraceStep } from '@maka/core/session-trace';
 import type { InspectorPanelModel, InspectorStepRow, InspectorTurnRow } from './session-inspector-panel-model.js';
 
 /**
  * Filtering the Inspector timeline (#1625).
  *
  * Pure predicates over the projected trace, deliberately not a query API on the
- * contract: the questions a reader actually asks — "which tool failed", "what
- * cost more than a cent", "where did it compact" — are `Array.filter` over
+ * contract: the questions a reader brings to a trace are `Array.filter` over
  * `TraceStep[]`, and inventing a query language for them would be surface
  * nobody needs.
  *
- * Free text matches what the panel renders — tool names, model ids, turn ids,
- * error messages, recovery dispositions. It deliberately does **not** reach
- * into event bodies: that is `searchRuntimeEventHistory`'s job, and shipping
- * every tool result into the renderer to fake it here would multiply a payload
- * this panel is already asked to bound, with silent truncation as the only way
- * out. A filter that quietly stops matching is worse than one with a stated
- * reach.
+ * Two predicates, because they are the two the panel can produce. Kind and cost
+ * filters are easy to write here and were, but a predicate no control emits is
+ * dead surface with tests that guard nothing; they come back when the controls
+ * that drive them are designed.
+ *
+ * Free text matches what each row renders — the step kind, its label, its
+ * detail, its recovery disposition — plus the turn's own id, matched against
+ * the turn. It deliberately does **not** reach into event bodies: that is
+ * `searchRuntimeEventHistory`'s job, and shipping every tool result into the
+ * renderer to imitate it would multiply a payload this panel is already asked
+ * to bound, with silent truncation as the only way out. A filter that quietly
+ * stops matching is worse than one with a stated reach.
  */
 export interface InspectorFilter {
-  /** Case-insensitive substring over the rendered fields. */
+  /** Case-insensitive substring over the fields each row renders. */
   query?: string;
-  /** Restrict to these step kinds; empty or absent means every kind. */
-  kinds?: readonly TraceStep['kind'][];
-  /** Only turns that failed, and within them every step. */
+  /** Only turns that failed. */
   failedOnly?: boolean;
-  /** Only priced steps at or above this amount. Unpriced steps never match. */
-  minCostUsd?: number;
 }
 
 export interface FilteredInspectorModel extends InspectorPanelModel {
@@ -45,12 +44,7 @@ export interface FilteredInspectorModel extends InspectorPanelModel {
 
 export function isEmptyInspectorFilter(filter: InspectorFilter | undefined): boolean {
   if (!filter) return true;
-  return (
-    !filter.query?.trim() &&
-    (filter.kinds === undefined || filter.kinds.length === 0) &&
-    !filter.failedOnly &&
-    filter.minCostUsd === undefined
-  );
+  return !filter.query?.trim() && !filter.failedOnly;
 }
 
 export function applyInspectorFilter(
@@ -67,10 +61,13 @@ export function applyInspectorFilter(
   const turns: InspectorTurnRow[] = [];
   for (const turn of model.turns) {
     if (active.failedOnly && !turn.failed) continue;
-    const steps = turn.steps.filter((step) => matchesStep(step, turn, active, query));
-    // A turn whose own identity matches keeps its place even with no matching
-    // step: hiding it would answer "where is turn-7" with silence.
-    const turnMatches = query !== undefined && turn.turnId.toLowerCase().includes(query);
+    const steps = turn.steps.filter((step) => matchesStep(step, query));
+    // A turn with no matching step is still kept when the filter is about the
+    // turn itself: its id matched, or there is no text query at all and it
+    // already passed the outcome gate above. Dropping it would answer "where is
+    // turn-7" — or "show me what failed", for a turn that failed before it
+    // recorded a step — with silence.
+    const turnMatches = query === undefined ? true : turn.turnId.toLowerCase().includes(query);
     if (steps.length === 0 && !turnMatches) continue;
     hiddenSteps += turn.steps.length - steps.length;
     turns.push({ ...turn, steps });
@@ -89,35 +86,22 @@ export function applyInspectorFilter(
   };
 }
 
-function matchesStep(
-  step: InspectorStepRow,
-  turn: InspectorTurnRow,
-  filter: InspectorFilter,
-  query: string | undefined,
-): boolean {
-  if (filter.kinds && filter.kinds.length > 0 && !filter.kinds.includes(step.kind)) return false;
-  if (filter.minCostUsd !== undefined) {
-    // An unpriced step is not a cheap step. Excluding it from a cost threshold
-    // is the same rule the ledger keeps: absent is not zero.
-    if (step.costUsd === undefined || step.costUsd < filter.minCostUsd) return false;
-  }
-  if (filter.failedOnly && !turn.failed) return false;
+function matchesStep(step: InspectorStepRow, query: string | undefined): boolean {
+  // The turn-level gate is applied by the caller; repeating it here would be a
+  // second place to keep in step with it.
   if (query === undefined || query === '') return true;
-  return stepSearchText(step, turn).includes(query);
+  return stepSearchText(step).includes(query);
 }
 
-/** Exactly the fields the panel renders — the filter's reach is what you see. */
-function stepSearchText(step: InspectorStepRow, turn: InspectorTurnRow): string {
-  return [
-    step.kind,
-    step.label,
-    step.detail,
-    step.status,
-    step.recovered,
-    turn.turnId,
-    turn.failureCode,
-    turn.failureMessage,
-  ]
+/**
+ * Exactly the fields this row renders — the filter's reach is what you see.
+ *
+ * Turn-level text is deliberately absent: folding a turn's failure message into
+ * every step's haystack would make one match retain steps that explain nothing
+ * about it. The turn's own id is matched against the turn, where it belongs.
+ */
+function stepSearchText(step: InspectorStepRow): string {
+  return [step.kind, step.label, step.detail, step.recovered]
     .filter((part): part is string => typeof part === 'string')
     .join(' ')
     .toLowerCase();

--- a/apps/desktop/src/renderer/session-inspector-filter.ts
+++ b/apps/desktop/src/renderer/session-inspector-filter.ts
@@ -1,0 +1,124 @@
+import type { TraceStep } from '@maka/core/session-trace';
+import type { InspectorPanelModel, InspectorStepRow, InspectorTurnRow } from './session-inspector-panel-model.js';
+
+/**
+ * Filtering the Inspector timeline (#1625).
+ *
+ * Pure predicates over the projected trace, deliberately not a query API on the
+ * contract: the questions a reader actually asks — "which tool failed", "what
+ * cost more than a cent", "where did it compact" — are `Array.filter` over
+ * `TraceStep[]`, and inventing a query language for them would be surface
+ * nobody needs.
+ *
+ * Free text matches what the panel renders — tool names, model ids, turn ids,
+ * error messages, recovery dispositions. It deliberately does **not** reach
+ * into event bodies: that is `searchRuntimeEventHistory`'s job, and shipping
+ * every tool result into the renderer to fake it here would multiply a payload
+ * this panel is already asked to bound, with silent truncation as the only way
+ * out. A filter that quietly stops matching is worse than one with a stated
+ * reach.
+ */
+export interface InspectorFilter {
+  /** Case-insensitive substring over the rendered fields. */
+  query?: string;
+  /** Restrict to these step kinds; empty or absent means every kind. */
+  kinds?: readonly TraceStep['kind'][];
+  /** Only turns that failed, and within them every step. */
+  failedOnly?: boolean;
+  /** Only priced steps at or above this amount. Unpriced steps never match. */
+  minCostUsd?: number;
+}
+
+export interface FilteredInspectorModel extends InspectorPanelModel {
+  /**
+   * Whether a filter is narrowing the view. Kept separate from `empty` so the
+   * panel can say "nothing matches" instead of "nothing happened" — a filtered
+   * timeline that reads as an idle session is the same lie as an unreported
+   * coverage gap, one layer up.
+   */
+  filtered: boolean;
+  /** Turns present in the trace but hidden by the filter. */
+  hiddenTurns: number;
+  /** Steps hidden inside the turns that still render. */
+  hiddenSteps: number;
+}
+
+export function isEmptyInspectorFilter(filter: InspectorFilter | undefined): boolean {
+  if (!filter) return true;
+  return (
+    !filter.query?.trim() &&
+    (filter.kinds === undefined || filter.kinds.length === 0) &&
+    !filter.failedOnly &&
+    filter.minCostUsd === undefined
+  );
+}
+
+export function applyInspectorFilter(
+  model: InspectorPanelModel,
+  filter: InspectorFilter | undefined,
+): FilteredInspectorModel {
+  if (isEmptyInspectorFilter(filter)) {
+    return { ...model, filtered: false, hiddenTurns: 0, hiddenSteps: 0 };
+  }
+  const active = filter!;
+  const query = active.query?.trim().toLowerCase();
+
+  let hiddenSteps = 0;
+  const turns: InspectorTurnRow[] = [];
+  for (const turn of model.turns) {
+    if (active.failedOnly && !turn.failed) continue;
+    const steps = turn.steps.filter((step) => matchesStep(step, turn, active, query));
+    // A turn whose own identity matches keeps its place even with no matching
+    // step: hiding it would answer "where is turn-7" with silence.
+    const turnMatches = query !== undefined && turn.turnId.toLowerCase().includes(query);
+    if (steps.length === 0 && !turnMatches) continue;
+    hiddenSteps += turn.steps.length - steps.length;
+    turns.push({ ...turn, steps });
+  }
+
+  return {
+    ...model,
+    turns,
+    filtered: true,
+    hiddenTurns: model.turns.length - turns.length,
+    hiddenSteps,
+    // `empty` stays a statement about the session, not about the filter. The
+    // panel distinguishes the two; collapsing them here would make a narrow
+    // filter indistinguishable from an empty session.
+    empty: model.empty,
+  };
+}
+
+function matchesStep(
+  step: InspectorStepRow,
+  turn: InspectorTurnRow,
+  filter: InspectorFilter,
+  query: string | undefined,
+): boolean {
+  if (filter.kinds && filter.kinds.length > 0 && !filter.kinds.includes(step.kind)) return false;
+  if (filter.minCostUsd !== undefined) {
+    // An unpriced step is not a cheap step. Excluding it from a cost threshold
+    // is the same rule the ledger keeps: absent is not zero.
+    if (step.costUsd === undefined || step.costUsd < filter.minCostUsd) return false;
+  }
+  if (filter.failedOnly && !turn.failed) return false;
+  if (query === undefined || query === '') return true;
+  return stepSearchText(step, turn).includes(query);
+}
+
+/** Exactly the fields the panel renders — the filter's reach is what you see. */
+function stepSearchText(step: InspectorStepRow, turn: InspectorTurnRow): string {
+  return [
+    step.kind,
+    step.label,
+    step.detail,
+    step.status,
+    step.recovered,
+    turn.turnId,
+    turn.failureCode,
+    turn.failureMessage,
+  ]
+    .filter((part): part is string => typeof part === 'string')
+    .join(' ')
+    .toLowerCase();
+}

--- a/apps/desktop/src/renderer/session-inspector-panel.tsx
+++ b/apps/desktop/src/renderer/session-inspector-panel.tsx
@@ -1,5 +1,10 @@
+import { useMemo, useState } from 'react';
 import { useUiLocale } from '@maka/ui';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
+import {
+  applyInspectorFilter,
+  type InspectorFilter,
+} from './session-inspector-filter.js';
 import {
   deriveInspectorPanelModel,
   type InspectorStepRow,
@@ -21,7 +26,12 @@ export function SessionInspectorPanel(props: { sessionId: string; active: boolea
     loadFailed: copy.loadFailed,
     locale,
   });
-  const model = deriveInspectorPanelModel(snapshot.trace);
+  const [filter, setFilter] = useState<InspectorFilter>({});
+  const model = useMemo(
+    () => applyInspectorFilter(deriveInspectorPanelModel(snapshot.trace), filter),
+    [snapshot.trace, filter],
+  );
+  const hidden = model.hiddenTurns + model.hiddenSteps;
 
   return (
     <section
@@ -72,10 +82,50 @@ export function SessionInspectorPanel(props: { sessionId: string; active: boolea
         </header>
       )}
 
-      {/* "Nothing to trace" is a claim about the session; a failed read cannot
-          make it, so the error stands alone. */}
+      {!model.empty && (
+        <div className="maka-inspector-filter">
+          <label className="maka-inspector-filter-query">
+            <span className="maka-inspector-filter-label">{copy.filterLabel}</span>
+            <input
+              type="search"
+              value={filter.query ?? ''}
+              placeholder={copy.filterPlaceholder}
+              onChange={(changed) => setFilter({ ...filter, query: changed.target.value })}
+            />
+          </label>
+          <label className="maka-inspector-filter-toggle">
+            <input
+              type="checkbox"
+              checked={filter.failedOnly ?? false}
+              onChange={(changed) => setFilter({ ...filter, failedOnly: changed.target.checked })}
+            />
+            <span>{copy.filterFailedOnly}</span>
+          </label>
+          {model.filtered && (
+            <button type="button" onClick={() => setFilter({})}>
+              {copy.filterClear}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Three different silences, kept apart: a read that failed, a filter
+          that matches nothing, and a session that did nothing. Only the last
+          one is "nothing to trace". */}
       {model.empty && !snapshot.loading && !snapshot.error && (
         <p className="maka-inspector-empty">{copy.empty}</p>
+      )}
+
+      {!model.empty && model.turns.length === 0 && model.filtered && (
+        <p className="maka-inspector-empty" data-maka-contract="session-inspector-no-matches">
+          {copy.noMatches}
+        </p>
+      )}
+
+      {model.filtered && hidden > 0 && model.turns.length > 0 && (
+        <p className="maka-inspector-hidden" data-maka-contract="session-inspector-hidden">
+          {hidden} {copy.hiddenByFilter}
+        </p>
       )}
 
       <ol className="maka-inspector-turns">

--- a/apps/desktop/src/renderer/session-inspector-panel.tsx
+++ b/apps/desktop/src/renderer/session-inspector-panel.tsx
@@ -1,4 +1,7 @@
 import { useMemo, useState } from 'react';
+import { Button } from '@astryxdesign/core/Button';
+import { Switch } from '@astryxdesign/core/Switch';
+import { TextInput } from '@astryxdesign/core/TextInput';
 import { useUiLocale } from '@maka/ui';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
 import {
@@ -84,49 +87,52 @@ export function SessionInspectorPanel(props: { sessionId: string; active: boolea
 
       {!model.empty && (
         <div className="maka-inspector-filter">
-          <label className="maka-inspector-filter-query">
-            <span className="maka-inspector-filter-label">{copy.filterLabel}</span>
-            <input
-              type="search"
-              value={filter.query ?? ''}
-              placeholder={copy.filterPlaceholder}
-              onChange={(changed) => setFilter({ ...filter, query: changed.target.value })}
-            />
-          </label>
-          <label className="maka-inspector-filter-toggle">
-            <input
-              type="checkbox"
-              checked={filter.failedOnly ?? false}
-              onChange={(changed) => setFilter({ ...filter, failedOnly: changed.target.checked })}
-            />
-            <span>{copy.filterFailedOnly}</span>
-          </label>
+          <TextInput
+            size="sm"
+            label={copy.filterLabel}
+            isLabelHidden
+            hasClear
+            value={filter.query ?? ''}
+            placeholder={copy.filterPlaceholder}
+            onChange={(value) => setFilter({ ...filter, query: value })}
+          />
+          <Switch
+            label={copy.filterFailedOnly}
+            value={filter.failedOnly ?? false}
+            onChange={(checked) => setFilter({ ...filter, failedOnly: checked })}
+          />
           {model.filtered && (
-            <button type="button" onClick={() => setFilter({})}>
-              {copy.filterClear}
-            </button>
+            <Button
+              variant="ghost"
+              size="sm"
+              label={copy.filterClear}
+              onClick={() => setFilter({})}
+            />
           )}
         </div>
       )}
 
       {/* Three different silences, kept apart: a read that failed, a filter
           that matches nothing, and a session that did nothing. Only the last
-          one is "nothing to trace". */}
-      {model.empty && !snapshot.loading && !snapshot.error && (
-        <p className="maka-inspector-empty">{copy.empty}</p>
-      )}
-
-      {!model.empty && model.turns.length === 0 && model.filtered && (
-        <p className="maka-inspector-empty" data-maka-contract="session-inspector-no-matches">
-          {copy.noMatches}
-        </p>
-      )}
-
-      {model.filtered && hidden > 0 && model.turns.length > 0 && (
-        <p className="maka-inspector-hidden" data-maka-contract="session-inspector-hidden">
-          {hidden} {copy.hiddenByFilter}
-        </p>
-      )}
+          one is "nothing to trace".
+          One persistent live region rather than three conditional ones: a
+          container that mounts and unmounts is not announced, and these
+          messages change as the reader types. */}
+      <div role="status" aria-live="polite" className="maka-inspector-status">
+        {model.empty && !snapshot.loading && !snapshot.error && (
+          <p className="maka-inspector-empty">{copy.empty}</p>
+        )}
+        {!model.empty && model.turns.length === 0 && model.filtered && (
+          <p className="maka-inspector-empty" data-maka-contract="session-inspector-no-matches">
+            {copy.noMatches}
+          </p>
+        )}
+        {model.filtered && hidden > 0 && model.turns.length > 0 && (
+          <p className="maka-inspector-hidden" data-maka-contract="session-inspector-hidden">
+            {hidden} {copy.hiddenByFilter}
+          </p>
+        )}
+      </div>
 
       <ol className="maka-inspector-turns">
         {model.turns.map((turn) => (

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -109,6 +109,48 @@
   color: var(--maka-color-text-warning, inherit);
 }
 
+.maka-inspector-filter {
+  display: flex;
+  align-items: center;
+  gap: var(--maka-space-2, 8px);
+  flex-wrap: wrap;
+}
+
+.maka-inspector-filter-query {
+  display: flex;
+  align-items: center;
+  gap: var(--maka-space-1, 4px);
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.maka-inspector-filter-query input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.maka-inspector-filter-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.maka-inspector-filter-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--maka-space-1, 4px);
+  white-space: nowrap;
+}
+
+.maka-inspector-hidden {
+  margin: 0;
+  color: var(--maka-color-text-secondary, inherit);
+  font-variant-numeric: tabular-nums;
+}
+
 .maka-inspector-error {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -116,33 +116,9 @@
   flex-wrap: wrap;
 }
 
-.maka-inspector-filter-query {
-  display: flex;
-  align-items: center;
-  gap: var(--maka-space-1, 4px);
-  flex: 1 1 12rem;
-  min-width: 0;
-}
-
-.maka-inspector-filter-query input {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.maka-inspector-filter-label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
-}
-
-.maka-inspector-filter-toggle {
-  display: flex;
-  align-items: center;
-  gap: var(--maka-space-1, 4px);
-  white-space: nowrap;
+/* The live region is a wrapper only; its children carry their own spacing. */
+.maka-inspector-status:empty {
+  display: none;
 }
 
 .maka-inspector-hidden {


### PR DESCRIPTION
## Summary

Third layer of the Session Inspector: filtering the timeline. Refs #1625.

The RFC framed this as trace search. The shape settled on the issue was narrower and better — structured predicates are `Array.filter` over `TraceStep[]` — so there is no query API on the contract, nothing new on the wire, and no main-process work at all. Two predicates, because they are the two the panel can produce: free text and failed-only. Kind and cost filters were written and then removed in review — a predicate no control emits is dead surface with tests that guard nothing, and they come back when the controls do.

## Two properties worth pinning

**A filter that matches nothing is not an empty session.** The panel now distinguishes three silences that used to be one: a read that failed, a filter that matches nothing, and a session that genuinely did nothing. Only the last says "nothing to trace".

**Filtering never restates the bill.** Session totals are left alone. A total recomputed per filter would be a number that is true of nothing — and this surface has already been careful not to become a second cost authority.

## Where free text reaches, and why it stops there

Exactly as far as each row renders: the step kind, its label, its detail, its recovery disposition — plus the turn's own id, matched against the turn rather than folded into every step.

It deliberately does not reach into event bodies. That is `searchRuntimeEventHistory`'s job, and imitating it here would mean shipping every tool result into the renderer — multiplying a payload this panel is already asked to bound, with silent truncation as the only way out. A filter that quietly stops matching is worse than one with a stated reach, so the reach is stated rather than approximated.

One asymmetry on purpose: a turn whose own id matches keeps its place even when no step does, because answering "where is turn-7" with silence is the wrong answer.

## Not here: replay step-through

The RFC's other PR 3 bullet is missing on purpose. "Scrub the timeline to inspect reconstructed state at each boundary" needs a decision about what *reconstructed state* means against the ledger as it stands now, and what a read-only surface may claim about it. I would rather ask than guess — the last time this issue guessed at a substrate, the finding was that the substrate did not exist, and the answer was the accounting refactor in #1679. Happy to take it as its own change once the shape is settled.

## Verification

8 filter tests (pure, no DOM), 33 desktop inspector tests overall. The filter bar uses Astryx `TextInput` / `Switch` / `Button` per the design review. `check-a11y`, `check-dead-css`, `check-copy` and `format:check` clean; renderer and main typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

