### PR TITLE
refactor(settings): drop the specs and jargon nobody can act on

### DIFF
--- a/apps/desktop/src/renderer/locales/settings-voice-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-voice-copy.ts
@@ -14,20 +14,11 @@ export type VoiceSettingsCopy = {
   aria: string;
   title: string;
   badge: string;
-  subtitle: string;
   statusAria: string;
+  statusHelp: string;
   microphone: string;
-  captureLimit: string;
-  durationSize(seconds: number, megabytes: number): string;
-  channels: string;
-  channelValue(khz: number): string;
-  privacy: string;
-  privacyValue: string;
   checking: string;
   run: string;
-  boundary: string;
-  boundaryAria: string;
-  boundaries: readonly [string, string, string];
   permissions: Record<VoicePermissionStatus, string>;
   validation: Record<'duration_exceeded' | 'audio_too_large' | 'invalid_audio_shape' | 'permission_not_granted' | 'default', string>;
   duration(seconds: string): string;
@@ -84,24 +75,11 @@ const SETTINGS_VOICE_COPY = {
     aria: '语音模型',
     title: '语音模型',
     badge: '本地自检',
-    subtitle: '这页现在可以验证麦克风权限和本地录音链路。语音转写和语音朗读模型必须遵守这个边界：转写结果必须先回到消息输入框，由用户编辑确认后才能发送；音频样本默认不落盘。',
     statusAria: '语音能力状态',
+    statusHelp: '麦克风只在自检时录一小段，用完即丢弃；配置语音转写模型前不会把音频发往任何服务，转写结果也会先回到输入框、由你确认后再发送。',
     microphone: '麦克风权限',
-    captureLimit: '采集上限',
-    durationSize: (seconds, megabytes) => `${seconds} 秒 · ${megabytes} MB`,
-    channels: '通道',
-    channelValue: (khz) => `单声道 · ≤ ${khz} kHz`,
-    privacy: '隐私',
-    privacyValue: '不保存音频 · 不进遥测',
     checking: '自检中…',
     run: '运行录音自检',
-    boundary: '当前边界',
-    boundaryAria: '语音能力边界说明',
-    boundaries: [
-      '录音样本只在本机内存里用于计算时长和大小；自检结束后立即停止采集并丢弃样本。',
-      '配置语音转写模型之前，不会把音频传给任何云端服务。',
-      '转写文本只进入消息输入框草稿；用户发送前必须能编辑。',
-    ],
     permissions: {
       granted: '已授权',
       denied: '已拒绝',
@@ -169,24 +147,11 @@ const SETTINGS_VOICE_COPY = {
     aria: 'Voice models',
     title: 'Voice models',
     badge: 'Local check',
-    subtitle: 'Verify microphone permission and the local recording pipeline here. Speech-to-text and text-to-speech models must preserve this boundary: transcripts return to the message composer for editing and confirmation before sending, and audio samples are not saved by default.',
     statusAria: 'Voice capability status',
+    statusHelp: 'The microphone records only a short sample during the self-check and discards it immediately. No audio leaves this machine until you configure a speech-to-text model, and transcripts return to the composer for you to confirm before sending.',
     microphone: 'Microphone permission',
-    captureLimit: 'Capture limit',
-    durationSize: (seconds, megabytes) => `${seconds} seconds · ${megabytes} MB`,
-    channels: 'Channels',
-    channelValue: (khz) => `Mono · ≤ ${khz} kHz`,
-    privacy: 'Privacy',
-    privacyValue: 'Audio not saved · excluded from telemetry',
     checking: 'Checking…',
     run: 'Run recording check',
-    boundary: 'Current boundary',
-    boundaryAria: 'Voice capability boundaries',
-    boundaries: [
-      'The recording sample is used only in local memory to calculate duration and size; capture stops and the sample is discarded when the check ends.',
-      'Audio is never sent to a cloud service before a speech-to-text model is configured.',
-      'Transcribed text enters only the message composer draft and remains editable before sending.',
-    ],
     permissions: {
       granted: 'Granted',
       denied: 'Denied',

--- a/apps/desktop/src/renderer/locales/settings-web-search-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-web-search-copy.ts
@@ -6,8 +6,8 @@ export type WebSearchSettingsCopy = {
   statusAria: string; lastTest: string; enabledAria: string; key: string; envKeyHelp: string; savedKeyHelp: string;
   envPlaceholder: string; storedPlaceholder: string; keyPlaceholder: string; keyAria: string; actions: string; actionsHelp: string;
   saving: string; saveKey: string; testing: string; testKey: string; clearing: string; clearKey: string;
-  liveTitle: string; liveHelp: string; query: string; queryHelp: string; queryPlaceholder: string;
-  execute: string; executeHelp: string; searching: string; search: string; queryFailed(error: string): string; noResults: string; resultsAria: string;
+  testSearch: string; testSearchHelp: string; queryPlaceholder: string;
+  searching: string; search: string; queryFailed(error: string): string; noResults: string; resultsAria: string;
   disabledReasons: { noKey: string; disabled: string; noQuery: string };
   statuses: Record<WebSearchCredentialStatus, string> & { validEnabled: string; validDisabled: string; unknownEnabled: string };
   sources: { envWithSaved: string; env: string; saved: string; none: string };
@@ -20,13 +20,12 @@ const SETTINGS_WEB_SEARCH_COPY = {
     credentialsCleared: '已清空 Tavily 凭据', credentialsClearedDetail: '联网搜索已自动关闭。', credentialValid: 'Tavily 凭据可用', resultCount: (count) => `返回 ${count} 条结果。`,
     testFailed: 'Tavily 测试失败', testError: 'Tavily 测试出错', enabled: '启用联网搜索', enabledHelp: '开关启用后，界面里显式触发的查询才会真的请求 Tavily。模型不会自动调用。',
     statusAria: '联网搜索凭据状态', lastTest: '最近测试 ', enabledAria: '启用联网搜索', key: 'Tavily 密钥',
-    envKeyHelp: '当前使用环境变量 TAVILY_API_KEY / MAKA_TAVILY_API_KEY；如需改用保存的密钥，请移除环境变量后重启。', savedKeyHelp: '保存在主进程设置中，渲染器永远看不到明文。申请地址：',
+    envKeyHelp: '当前使用环境变量 TAVILY_API_KEY / MAKA_TAVILY_API_KEY；如需改用保存的密钥，请移除环境变量后重启。', savedKeyHelp: '密钥只保存在本机。申请地址：',
     envPlaceholder: '由环境变量提供', storedPlaceholder: '已保存（输入新密钥可替换）', keyPlaceholder: 'tvly-xxxxxxxx', keyAria: 'Tavily 密钥',
     actions: '凭据操作', actionsHelp: '保存后可以测试一次真实请求；清空凭据会同步关闭联网搜索。', saving: '保存中…', saveKey: '保存密钥', testing: '测试中…', testKey: '测试凭据', clearing: '清空中…', clearKey: '清空密钥',
-    liveTitle: '真实查询验证', liveHelp: '直接发一条真实查询，看到 Tavily 返回的标题 / 摘要 / 来源域名。结果只显示在此页面，不写入会话也不写入遥测。',
-    query: '查询', queryHelp: '输入一条用于验证联网搜索配置的真实请求。', queryPlaceholder: '例如：本周 AI 产品发布动态',
-    execute: '执行查询', executeHelp: '按钮可用时会走主进程 Tavily 请求并刷新下方结果。', searching: '搜索中…', search: '搜索', queryFailed: (error) => `查询失败：${error}`, noResults: '没有结果。', resultsAria: '联网搜索真实查询结果',
-    disabledReasons: { noKey: '先保存 Tavily 密钥，或设置 TAVILY_API_KEY 环境变量', disabled: '先启用联网搜索', noQuery: '输入查询后再搜索' },
+    testSearch: '测试搜索', testSearchHelp: '发一条真实查询，确认联网搜索是否配置可用。结果只显示在这里，不写入会话。', queryPlaceholder: '例如：本周 AI 产品发布动态',
+    searching: '搜索中…', search: '搜索', queryFailed: (error) => `查询失败：${error}`, noResults: '没有结果。', resultsAria: '联网搜索真实查询结果',
+    disabledReasons: { noKey: '先保存 Tavily 密钥', disabled: '先启用联网搜索', noQuery: '输入查询后再搜索' },
     statuses: { valid: '已验证', invalid_credentials: '密钥无效', rate_limited: 'Tavily 限流', timeout: '测试超时', network_error: '网络异常', not_configured: '等待配置', untested: '未测试', validEnabled: '已验证 · 已启用', validDisabled: '已验证 · 未启用', unknownEnabled: '未测试 · 已启用' },
     sources: { envWithSaved: '来源：环境变量（已保存密钥备用）', env: '来源：环境变量', saved: '来源：本机已保存密钥', none: '来源：未配置' },
     errors: { invalid_query: '请输入有效的搜索内容。', incognito_active: '无痕模式下无法使用联网搜索。', not_configured: '请先配置 Tavily 密钥并启用联网搜索。', invalid_credentials: 'Tavily 密钥无效，请更新后重试。', rate_limited: 'Tavily 请求过于频繁，请稍后重试。', network_error: '网络请求失败，请检查网络后重试。', timeout: 'Tavily 请求超时，请重试。', unsupported_provider: '当前配置不支持这个搜索引擎，请选择 Tavily 后重试。', experimental_disabled: '联网搜索实验功能当前已关闭。' },
@@ -36,13 +35,12 @@ const SETTINGS_WEB_SEARCH_COPY = {
     credentialsCleared: 'Tavily credentials cleared', credentialsClearedDetail: 'Web search was disabled automatically.', credentialValid: 'Tavily credentials work', resultCount: (count) => `Returned ${count} ${count === 1 ? 'result' : 'results'}.`,
     testFailed: 'Tavily test failed', testError: 'Tavily test error', enabled: 'Enable web search', enabledHelp: 'When enabled, only queries explicitly started in the interface call Tavily. The model does not invoke it automatically.',
     statusAria: 'Web search credential status', lastTest: 'Last tested ', enabledAria: 'Enable web search', key: 'Tavily key',
-    envKeyHelp: 'Currently using TAVILY_API_KEY / MAKA_TAVILY_API_KEY from the environment. Remove the environment variable and restart to use a saved key.', savedKeyHelp: 'Saved in main-process settings; the renderer never sees the clear text. Apply at:',
+    envKeyHelp: 'Currently using TAVILY_API_KEY / MAKA_TAVILY_API_KEY from the environment. Remove the environment variable and restart to use a saved key.', savedKeyHelp: 'The key is stored only on this machine. Apply at:',
     envPlaceholder: 'Provided by environment variable', storedPlaceholder: 'Saved (enter a new key to replace)', keyPlaceholder: 'tvly-xxxxxxxx', keyAria: 'Tavily key',
     actions: 'Credential actions', actionsHelp: 'After saving, test with a real request. Clearing credentials also disables web search.', saving: 'Saving…', saveKey: 'Save key', testing: 'Testing…', testKey: 'Test credentials', clearing: 'Clearing…', clearKey: 'Clear key',
-    liveTitle: 'Live query verification', liveHelp: 'Send a real query and inspect Tavily titles, snippets, and source domains. Results stay on this page and are not written to sessions or telemetry.',
-    query: 'Query', queryHelp: 'Enter a real query to verify the web search configuration.', queryPlaceholder: 'For example: AI product launches this week',
-    execute: 'Run query', executeHelp: 'When available, the button sends a main-process Tavily request and refreshes the results below.', searching: 'Searching…', search: 'Search', queryFailed: (error) => `Query failed: ${error}`, noResults: 'No results.', resultsAria: 'Web search live query results',
-    disabledReasons: { noKey: 'Save a Tavily key or set the TAVILY_API_KEY environment variable first', disabled: 'Enable web search first', noQuery: 'Enter a query before searching' },
+    testSearch: 'Test search', testSearchHelp: 'Send a real query to confirm web search is configured and working. Results appear here only and are not written to the conversation.', queryPlaceholder: 'For example: AI product launches this week',
+    searching: 'Searching…', search: 'Search', queryFailed: (error) => `Query failed: ${error}`, noResults: 'No results.', resultsAria: 'Web search live query results',
+    disabledReasons: { noKey: 'Save a Tavily key first', disabled: 'Enable web search first', noQuery: 'Enter a query before searching' },
     statuses: { valid: 'Verified', invalid_credentials: 'Invalid key', rate_limited: 'Rate limited by Tavily', timeout: 'Test timed out', network_error: 'Network error', not_configured: 'Needs setup', untested: 'Not tested', validEnabled: 'Verified · enabled', validDisabled: 'Verified · disabled', unknownEnabled: 'Not tested · enabled' },
     sources: { envWithSaved: 'Source: environment variable (saved key available as backup)', env: 'Source: environment variable', saved: 'Source: key saved on this device', none: 'Source: not configured' },
     errors: { invalid_query: 'Enter a valid search query.', incognito_active: 'Web search is unavailable in incognito mode.', not_configured: 'Configure a Tavily key and enable web search first.', invalid_credentials: 'The Tavily key is invalid. Update it and try again.', rate_limited: 'Tavily is receiving too many requests. Try again later.', network_error: 'The network request failed. Check your connection and try again.', timeout: 'The Tavily request timed out. Try again.', unsupported_provider: 'This search provider is not supported by the current configuration. Select Tavily and try again.', experimental_disabled: 'The experimental web search feature is currently disabled.' },

--- a/apps/desktop/src/renderer/settings/voice-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/voice-settings-page.tsx
@@ -568,12 +568,17 @@ export function VoiceModelsSettingsPage(props: {
         </FormLayout>
         </SettingsField>
       </SettingsSection>
-      <SettingsSection title={copy.statusAria}>
+      {/* UX audit (owner msg `30f736ed`): 采集上限 60秒·16MB and 通道
+          单声道·≤48kHz were implementation specs — the user cannot change
+          either, and knowing them changes nothing they do. 隐私 was a promise
+          rather than a status, so it reads as the group's own sentence.
+
+          What is left is the row with an action behind it (permission), the
+          self-check, and its result — which is the entire task this group
+          serves: "can my microphone be used". */}
+      <SettingsSection title={copy.statusAria} description={copy.statusHelp}>
         <div role="group" aria-label={copy.statusAria} className="settingsRowsGroup">
           <SettingRow title={copy.microphone} detail="" value={copy.permissions[permission]} />
-          <SettingRow title={copy.captureLimit} detail="" value={copy.durationSize(Math.round(caps.maxDurationMs / 1000), Math.round(caps.maxAudioBytes / 1024 / 1024))} />
-          <SettingRow title={copy.channels} detail="" value={copy.channelValue(Math.round(caps.maxSampleRate / 1000))} />
-          <SettingRow title={copy.privacy} detail="" value={copy.privacyValue} />
         </div>
         <SettingsActions>
           <Button
@@ -602,11 +607,6 @@ export function VoiceModelsSettingsPage(props: {
             </p>
           )}
         </SettingsField>
-      </SettingsSection>
-      <SettingsSection variant="bare" title={copy.boundary} description={copy.subtitle}>
-        <ul className="settingsFeatureStatusList" aria-label={copy.boundaryAria}>
-          {copy.boundaries.map((boundary) => <li key={boundary}>{boundary}</li>)}
-        </ul>
       </SettingsSection>
     </SettingsPage>
   );

--- a/apps/desktop/src/renderer/settings/web-search-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/web-search-settings-page.tsx
@@ -314,19 +314,20 @@ export function WebSearchSettingsPage(props: {
         title={sharedCopy.groups.searchBehavior}
         description={sharedCopy.groups.searchBehaviorHelp}
       >
-        <SettingsRow
-          label={copy.liveTitle}
-          description={copy.liveHelp}
-        />
-        {/* The query deserves the full row width — it was squeezed into the
-            row's end slot before, an ~360px input for a real search query. */}
+        {/* UX audit (owner msg `30f736ed`): one action wore three labels —
+            真实查询验证 over 查询 over 执行查询, each with its own help line,
+            for what is a single act: type a query, press the button, read the
+            result. One label now, on the field the user actually fills in.
+
+            The query keeps the full row width — it was squeezed into a row's
+            end slot before, an ~360px input for a real search query. */}
         <SettingsField>
           <TextInput
             value={liveQuery}
             onChange={(value) => updateLiveQuery(value)}
             placeholder={copy.queryPlaceholder}
-            label={copy.query}
-            description={copy.queryHelp}
+            label={copy.testSearch}
+            description={copy.testSearchHelp}
             width="100%"
             onKeyDown={(event) => {
               if (event.key === 'Enter' && !liveQueryRunning) {
@@ -336,11 +337,8 @@ export function WebSearchSettingsPage(props: {
             }}
           />
         </SettingsField>
-        <SettingsRow
-          label={copy.execute}
-          description={copy.executeHelp}
-          align="start"
-          end={<div className="settingsWebSearchSearchControls">
+        <SettingsActions>
+          <div className="settingsWebSearchSearchControls">
             <Button
               variant="primary"
               isDisabled={liveQueryRunning || queryDisabledReason !== null}
@@ -352,8 +350,8 @@ export function WebSearchSettingsPage(props: {
                 {queryDisabledReason}
               </small>
             )}
-          </div>}
-        />
+          </div>
+        </SettingsActions>
       </SettingsSection>
 
       {liveQueryError && (

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -7,26 +7,14 @@
 /* Astryx convergence: the orphaned voice hero vocabulary
    (.settingsFeatureStatusPage / Hero / Icon / HeroHeading) is deleted — the
    voice page moved onto the SettingsSection kit and nothing consumed it.
-   .settingsFeatureStatusList below is still used by the voice 边界 list. */
+   .settingsFeatureStatusList went the same way with the voice 边界 list, whose
+   three developer-facing bullets became one sentence on the status group. */
 
 .settingsBackButton {
   justify-content: flex-start;
   -webkit-app-region: no-drag;
 }
 
-
-.settingsFeatureStatusList {
-  font: var(--maka-text-supporting);
-  margin: 0;
-  padding: 0 0 0 var(--space-3);
-  display: grid;
-  gap: var(--space-1);
-  color: var(--foreground-secondary);
-}
-
-.settingsFeatureStatusList li::marker {
-  color: var(--muted-foreground);
-}
 
 
 .settingsLoadingSkeleton {


### PR DESCRIPTION
Task #145 — UX 信息暴露清理 B（owner 拍板 msg `30f736ed`）。

## 语音页

**删「采集上限 60秒 · 16MB」「通道 单声道 · ≤48kHz」** —— 两个都不可调，知道了也不改变用户任何行为。**是实现在自我描述。**

**「隐私：不保存音频 · 不进遥测」行删掉** —— 它是承诺不是状态，改成组自己的一句话描述。

**「当前边界」整段删掉** —— 它开头写「这页现在可以验证…」，然后列三条语音模型「必须遵守」的规则。**那是写给下一个做模型接入的人的变更说明，却摆在打开设置的用户面前。**

内容没丢，压成一句用户语言放进「语音能力状态」组描述：

> 麦克风只在自检时录一小段，用完即丢弃；配置语音转写模型前不会把音频发往任何服务，转写结果也会先回到输入框、由你确认后再发送。

组里剩下的正是这个组服务的全部任务：**有动作的那一行（麦克风权限）+ 自检按钮 + 自检结果**。

## 联网搜索页

**Electron 内部词汇外泄**：
- 「保存在**主进程**设置中，**渲染器**永远看不到明文」→「**密钥只保存在本机**」（同样的承诺，不暴露进程模型）
- 搜索按钮禁用理由里的「或设置 `TAVILY_API_KEY` 环境变量」→ 删（那是写给开着终端的人的）

**一个动作戴了三层标签**：`真实查询验证` 套 `查询` 套 `执行查询`，每层还各带一句 help —— 而它其实是**一个动作**：输入查询、按按钮、看结果。

现在一层：标签落在**用户真正要填的那个输入框**上，下面一个按钮，再下面结果区。

## Copy 清理（中英都删）

`captureLimit` / `durationSize` / `channels` / `channelValue` / `privacy` / `privacyValue` / `boundary` / `boundaryAria` / `boundaries` / `subtitle`；`liveTitle` / `liveHelp` / `query` / `queryHelp` / `execute` / `executeHelp`。

`.settingsFeatureStatusList` 随边界列表一起删了 —— 顺带**修正了它上面那句注释**，原文写「still used by the voice 边界 list」，留着会误导下一个读的人。

## 验证

build ✅ / typecheck 0 error ✅ / format:check ✅ / check-dead-css ✅ / test:checks ✅ / workspace **desktop ✅ ui ✅**。两页真实 app 截图已发任务线程。

已知失败：`storage` / `cli` 是 Node v25 `node:sqlite`（本轮 runtime / runtime-host 都过了）。

@maka-审美专家 请 review。