### PR TITLE
fix(headless): stop handing graded competitor arms this repo's tree

### DIFF
--- a/packages/headless/src/__tests__/agent-repo-mount.test.ts
+++ b/packages/headless/src/__tests__/agent-repo-mount.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { existsSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
 import {
@@ -8,7 +8,7 @@ import {
   competitorRepoFiles,
   CONTAINER_MAKA_REPO,
 } from '../agent-repo-mount.js';
-import type { HarnessAgentId } from '../harness-agent-registry.js';
+import { type HarnessAgentId, harnessAgentImportPath } from '../harness-agent-registry.js';
 
 const COMPETITORS: readonly Exclude<HarnessAgentId, 'maka'>[] = [
   'opencode',
@@ -61,6 +61,45 @@ describe('agent repo mounts', () => {
       }
     });
   }
+
+  test('declares every repo file the adapters read at a container path', () => {
+    // Every assertion above derives its expectation from competitorRepoFiles(),
+    // so none of them can tell a wrong list from a right one. The adapters are
+    // the authority for what is read at a container path, so read them instead:
+    // a repo read added there without an entry here mounts nothing, and the arm
+    // fails inside the container partway through a graded run.
+    const harborDir = join(REPO_ROOT, 'packages/headless/harbor');
+    const repoFileByBasename = new Map(
+      readdirSync(harborDir, { recursive: true, withFileTypes: true })
+        .filter((entry) => entry.isFile())
+        .map((entry) => {
+          const absolute = join(entry.parentPath, entry.name);
+          return [entry.name, relative(REPO_ROOT, absolute)] as const;
+        }),
+    );
+
+    for (const agent of COMPETITORS) {
+      const adapterModule = harnessAgentImportPath(agent).split(':')[0];
+      const source = readFileSync(join(harborDir, `${adapterModule}.py`), 'utf8');
+      const read = new Set<string>();
+      for (const [, literal] of source.matchAll(/["']([^"'\n]+)["']/g)) {
+        // Adapters name a file either by its absolute container path or by
+        // joining MAKA_REPO_ROOT with the path segments, so match both.
+        if (literal.startsWith(`${CONTAINER_MAKA_REPO}/`)) {
+          read.add(literal.slice(CONTAINER_MAKA_REPO.length + 1));
+          continue;
+        }
+        const repoFile = repoFileByBasename.get(literal);
+        if (repoFile) read.add(repoFile);
+      }
+      for (const repoFile of read) {
+        assert.ok(
+          competitorRepoFiles(agent).includes(repoFile),
+          `${adapterModule}.py reads ${repoFile}, which ${agent} is not mounted`,
+        );
+      }
+    }
+  });
 
   test('keeps the benchmark identity out of every competitor container', () => {
     // run-harness-ab.mjs carries TERMINAL_BENCH_2_1_REVISION and the upstream

--- a/packages/headless/src/__tests__/agent-repo-mount.test.ts
+++ b/packages/headless/src/__tests__/agent-repo-mount.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, test } from 'node:test';
+import {
+  buildAgentRepoMounts,
+  competitorRepoFiles,
+  CONTAINER_MAKA_REPO,
+} from '../agent-repo-mount.js';
+import type { HarnessAgentId } from '../harness-agent-registry.js';
+
+const COMPETITORS: readonly Exclude<HarnessAgentId, 'maka'>[] = [
+  'opencode',
+  'kimi-code',
+  'codex',
+  'claude-code',
+  'reasonix',
+];
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+describe('agent repo mounts', () => {
+  test('gives Maka the tree it executes out of', () => {
+    assert.deepEqual(buildAgentRepoMounts('maka', '/repo'), [
+      { type: 'bind', source: '/repo', target: CONTAINER_MAKA_REPO, read_only: true },
+    ]);
+  });
+
+  for (const agent of COMPETITORS) {
+    test(`hands ${agent} files, never a directory it can walk`, () => {
+      const mounts = buildAgentRepoMounts(agent, '/repo') as Array<{
+        source: string;
+        target: string;
+        read_only: boolean;
+      }>;
+      // The whole point: no target is the repo root, so there is nothing to
+      // enumerate. A directory mount here is how Codex reached the benchmark's
+      // pinned revision and retrieved a task's reference solution.
+      assert.ok(
+        mounts.every((mount) => mount.target !== CONTAINER_MAKA_REPO),
+        `${agent} must not receive the repo root`,
+      );
+      assert.deepEqual(
+        mounts.map((mount) => mount.target),
+        competitorRepoFiles(agent).map((file) => `${CONTAINER_MAKA_REPO}/${file}`),
+      );
+      assert.ok(
+        mounts.every((mount) => mount.read_only),
+        `${agent} must not receive a writable repo path`,
+      );
+    });
+
+    test(`every file ${agent} declares exists in the repo`, () => {
+      // A declared-but-missing path is worse than a missing mount: Docker
+      // materialises the target as an empty directory, so the adapter reads a
+      // directory where it expected its config and fails inside the container
+      // rather than here.
+      for (const file of competitorRepoFiles(agent)) {
+        assert.ok(existsSync(join(REPO_ROOT, file)), `${agent} declares missing ${file}`);
+      }
+    });
+  }
+
+  test('keeps the benchmark identity out of every competitor container', () => {
+    // run-harness-ab.mjs carries TERMINAL_BENCH_2_1_REVISION and the upstream
+    // repository URL; docs/eval carries earlier per-task results. Neither is a
+    // file any arm needs, and both convert a graded run into retrieval.
+    for (const agent of COMPETITORS) {
+      for (const file of competitorRepoFiles(agent)) {
+        assert.ok(
+          !file.startsWith('docs/'),
+          `${agent} must not be handed evaluation records (${file})`,
+        );
+        assert.notEqual(
+          file,
+          'packages/headless/harbor/run-harness-ab.mjs',
+          `${agent} must not be handed the harness manifest source`,
+        );
+      }
+    }
+  });
+});

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 import { type HarborAgentEntry, harborAgentPhaseSec } from './helpers/harbor-agent-phase.js';
+import { competitorRepoFiles } from '../agent-repo-mount.js';
 import type { HarborCellExecutionIdentity, HarborCellOutput } from '../cell-output.js';
 import {
   FixedPromptBudgetExhaustedError,
@@ -2771,6 +2772,46 @@ describe('buildHarborJobConfig', () => {
     );
     assert.equal(env.OPENAI_API_KEY, undefined);
     assert.equal(env.CODEX_API_KEY, undefined);
+  });
+
+  test('withholds the repo tree from a competitor arm', () => {
+    const forAgent = (agent: 'maka' | 'codex' | 'claude-code') =>
+      (
+        buildHarborJobConfig(runInput(), {
+          makaRepoPath: '/repo',
+          jobsDir: '/jobs/x',
+          jobName: 'trial',
+          agent,
+          model: 'deepseek/deepseek-v4-flash',
+          provider: 'deepseek',
+          agentVersion:
+            agent === 'codex' ? '0.146.0' : CLAUDE_CODE_TOOLCHAIN_SPEC.claudeCode.version,
+          codexToolchainPath: '/cache/codex',
+          claudeCodeToolchainPath: '/cache/claude-code',
+        } as unknown as Parameters<typeof buildHarborJobConfig>[1]).environment as {
+          mounts: Array<Record<string, unknown>>;
+        }
+      ).mounts;
+
+    // Maka executes out of the tree, so it still gets the tree.
+    assert.ok(forAgent('maka').some((mount) => mount.target === '/opt/maka-agent'));
+
+    // A competitor gets the files it named and no directory to walk. Reverting
+    // to the shared tree mount re-opens the path Codex used in the #1970 run:
+    // read the pinned benchmark revision, fetch the task's reference solution.
+    for (const agent of ['codex', 'claude-code'] as const) {
+      const repoMounts = forAgent(agent).filter((mount) =>
+        String(mount.target).startsWith('/opt/maka-agent'),
+      );
+      assert.ok(
+        repoMounts.every((mount) => mount.target !== '/opt/maka-agent'),
+        `${agent} must not receive the repo root`,
+      );
+      assert.deepEqual(
+        repoMounts.map((mount) => mount.target),
+        competitorRepoFiles(agent).map((file) => `/opt/maka-agent/${file}`),
+      );
+    }
   });
 
   test('pins the Claude Code adapter and native toolchain behind the host provider proxy', () => {

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -14,6 +14,7 @@ import {
   type TaskRunInput,
   type TaskRunOutput,
 } from '../fixed-prompt-controller.js';
+import { competitorRepoFiles } from '../agent-repo-mount.js';
 import { CODEX_TOOLCHAIN_FINGERPRINT, CODEX_TOOLCHAIN_SPEC } from '../codex-toolchain.js';
 import { OPENCODE_TOOLCHAIN_FINGERPRINT, OPENCODE_TOOLCHAIN_SPEC } from '../opencode-toolchain.js';
 import { findTrialDir, MAKA_SETTLEMENT_GRACE_SEC } from '../harbor-task-runner.js';
@@ -491,6 +492,50 @@ test('createPierTaskRunner mounts the pinned Maka Node runtime for container tas
       ),
     );
     assert.ok(args.includes(`MAKA_NODE_TOOLCHAIN_FINGERPRINT=${MAKA_NODE_TOOLCHAIN_FINGERPRINT}`));
+  });
+});
+
+test('createPierTaskRunner withholds the repo tree from a competitor arm', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const repoMountsFor = async (agent: 'maka' | 'codex') => {
+      const captured: FakeOptions['captured'] = {};
+      const runner = createPierTaskRunner(
+        baseOptions({
+          jobsDir,
+          makaRepoPath: repo,
+          agent,
+          agentVersion: CODEX_TOOLCHAIN_SPEC.codex.version,
+          codexToolchainPath: '/toolchains/codex',
+          ...(agent === 'codex'
+            ? {
+                backend: 'ai-sdk' as const,
+                provider: 'openai-codex' as const,
+                model: 'gpt-5.6-sol',
+                resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
+                providerProxyPort: 0,
+              }
+            : {}),
+          runPier: fakePier({ reward: 0, captured }),
+        }),
+      );
+      await runner(runInput());
+      const args = captured.request?.args ?? [];
+      const mounts = JSON.parse(args[args.indexOf('--mounts-json') + 1]!) as Array<{
+        target: string;
+      }>;
+      return mounts.filter((mount) => mount.target.startsWith('/opt/maka-agent'));
+    };
+
+    assert.ok((await repoMountsFor('maka')).some((mount) => mount.target === '/opt/maka-agent'));
+
+    // Pier shares agent-repo-mount with the Harbor runner precisely so this
+    // cannot regress in one executor while the other stays fixed.
+    const competitor = await repoMountsFor('codex');
+    assert.ok(competitor.every((mount) => mount.target !== '/opt/maka-agent'));
+    assert.deepEqual(
+      competitor.map((mount) => mount.target),
+      competitorRepoFiles('codex').map((file) => `/opt/maka-agent/${file}`),
+    );
   });
 });
 

--- a/packages/headless/src/agent-repo-mount.ts
+++ b/packages/headless/src/agent-repo-mount.ts
@@ -1,0 +1,65 @@
+/**
+ * What a graded arm may read out of this repo, and the mounts that enforce it.
+ *
+ * Both executors bind this repo into the task container. Maka executes out of
+ * that tree, so it gets the tree. A competitor runs from its own pinned
+ * toolchain and only ever names individual files here, so it gets those files
+ * and no directory to walk.
+ *
+ * The distinction is not tidiness. This repo is not benchmark-neutral cargo:
+ * `packages/headless/harbor/run-harness-ab.mjs` carries
+ * TERMINAL_BENCH_2_1_REVISION and the upstream repository URL, and `docs/eval`
+ * carries per-task results from earlier runs. Handing that to an arm being
+ * scored turns scoring into retrieval. In the #1970 three-arm run Codex read
+ * the pinned revision out of the mount, fetched the task's reference solution
+ * from the public repository at that exact revision, and lifted the expected
+ * output out of its test file — a recorded pass that measured retrieval.
+ *
+ * Both executors resolve their repo mounts here so the two cannot drift: a file
+ * added for one arm in one runner is not silently absent in the other.
+ */
+import { join } from 'node:path';
+import type { HarnessAgentId } from './harness-agent-registry.js';
+
+export const CONTAINER_MAKA_REPO = '/opt/maka-agent';
+
+/**
+ * Repo-relative files each competitor adapter reads at its container path.
+ * An empty list is the default and the goal: the arm needs nothing from here.
+ */
+const COMPETITOR_REPO_FILES: Readonly<Record<Exclude<HarnessAgentId, 'maka'>, readonly string[]>> =
+  {
+    // opencode_agent.py `_stop_runner_path` and `_opencode_config_path`.
+    opencode: [
+      'packages/headless/harbor/opencode-stop-runner.mjs',
+      'packages/headless/harbor/opencode-benchmark.json',
+    ],
+    // codex_agent.py `_DEEPSEEK_MODELS_PATH`.
+    codex: ['packages/headless/harbor/deepseek-codex-models.json'],
+    'kimi-code': [],
+    'claude-code': [],
+    reasonix: [],
+  };
+
+export function competitorRepoFiles(agent: Exclude<HarnessAgentId, 'maka'>): readonly string[] {
+  return COMPETITOR_REPO_FILES[agent];
+}
+
+/**
+ * The repo mounts for one arm. Maka gets the tree it runs from; every other arm
+ * gets exactly the files it declared and nothing it could enumerate.
+ */
+export function buildAgentRepoMounts(
+  agent: HarnessAgentId,
+  makaRepoPath: string,
+): Array<Record<string, unknown>> {
+  if (agent === 'maka') {
+    return [{ type: 'bind', source: makaRepoPath, target: CONTAINER_MAKA_REPO, read_only: true }];
+  }
+  return competitorRepoFiles(agent).map((repoFile) => ({
+    type: 'bind',
+    source: join(makaRepoPath, repoFile),
+    target: `${CONTAINER_MAKA_REPO}/${repoFile}`,
+    read_only: true,
+  }));
+}

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -26,6 +26,7 @@ import {
   type TaskRunOutput,
   type TaskRunner,
 } from './fixed-prompt-controller.js';
+import { buildAgentRepoMounts, CONTAINER_MAKA_REPO } from './agent-repo-mount.js';
 import type {
   HarborTrialGrade,
   HarborVerifierAttempt,
@@ -90,8 +91,6 @@ import { agentPhaseTimeoutSec, settlementGraceSec } from './maka-settlement.js';
 export { MAKA_SETTLEMENT_GRACE_SEC } from './maka-settlement.js';
 
 const execFileAsync = promisify(execFile);
-
-const CONTAINER_MAKA_REPO = '/opt/maka-agent';
 
 /**
  * Every competitor arm is pinned the same way: a prepared toolchain directory
@@ -1138,7 +1137,7 @@ export function buildHarborJobConfig(
     }
   }
   const mounts: Array<Record<string, unknown>> = [
-    { type: 'bind', source: options.makaRepoPath, target: CONTAINER_MAKA_REPO, read_only: true },
+    ...buildAgentRepoMounts(adapter, options.makaRepoPath),
     ...(toolchain
       ? [
           {

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -26,7 +26,7 @@ import {
   type TaskRunOutput,
   type TaskRunner,
 } from './fixed-prompt-controller.js';
-import { buildAgentRepoMounts, CONTAINER_MAKA_REPO } from './agent-repo-mount.js';
+import { buildAgentRepoMounts } from './agent-repo-mount.js';
 import type {
   HarborTrialGrade,
   HarborVerifierAttempt,

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -64,6 +64,7 @@ import {
   MAKA_NODE_TOOLCHAIN_CONTAINER_PATH,
   MAKA_NODE_TOOLCHAIN_FINGERPRINT,
 } from './maka-node-toolchain.js';
+import { buildAgentRepoMounts, CONTAINER_MAKA_REPO } from './agent-repo-mount.js';
 import {
   summarizeProviderTelemetry,
   startProviderAuthProxy,
@@ -75,7 +76,6 @@ import {
   type ProviderUpstreamCredentialResolver,
 } from './provider-auth-proxy.js';
 
-const CONTAINER_MAKA_REPO = '/opt/maka-agent';
 const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
 const TRIAL_RUNTIME_EVENTS = 'agent/runtime-events.jsonl';
 const TRIAL_REWARD_JSON = 'verifier/reward.json';
@@ -716,7 +716,7 @@ function buildPierMounts(
   mode: 'cell' | 'task-run',
 ): Array<Record<string, unknown>> {
   const mounts: Array<Record<string, unknown>> = [
-    { type: 'bind', source: options.makaRepoPath, target: CONTAINER_MAKA_REPO, read_only: true },
+    ...buildAgentRepoMounts(agent, options.makaRepoPath),
   ];
   if (agent === 'maka' && mode === 'task-run') {
     if (!options.makaNodeToolchainPath) {


### PR DESCRIPTION
## Summary

Both executors bind this repo read-only at `/opt/maka-agent` in every arm's task container, competitors included. The repo is not benchmark-neutral cargo: `packages/headless/harbor/run-harness-ab.mjs` carries `TERMINAL_BENCH_2_1_REVISION` and the upstream repository URL, and `docs/eval` carries per-task results from earlier runs.

In the #1970 three-arm run Codex used it. It read the pinned revision out of the mount, resolved the upstream repository, cloned it, `cat`-ed `original-tasks/extract-elf/solution.sh`, and then ran a regex to lift the `REF` expected output straight out of `tests/test_outputs.py`. That cell is recorded as a pass. `codex_agent.py` already pins `web_search = "disabled"` with the comment "a search tool turns scoring into retrieval of the answer" — the tool was closed and the mount was left open.

Maka executes out of that tree, so it keeps it. A competitor runs from its own pinned toolchain and only ever names individual files, so it now gets those files and no directory to walk:

| arm | files |
| --- | --- |
| opencode | `opencode-stop-runner.mjs`, `opencode-benchmark.json` |
| codex | `deepseek-codex-models.json` |
| claude-code, kimi-code, reasonix | none |

The list lives in one module both runners resolve through, rather than in the Harbor toolchain table, because Pier carries the same mount and would otherwise be fixed or broken independently.

## Verification

- `npm run --workspace @maka/headless test` — 1390 pass, 0 fail
- `npm run lint`, `npm run format:check`, `npm run typecheck --workspace @maka/headless` — clean
- Red-first, both halves: restoring the tree mount in `agent-repo-mount.ts` fails 7 tests: the five per-competitor contract tests plus both runners' wiring tests; restoring it in `pier-task-runner.ts` alone fails the Pier wiring test. Neither revert can ship green.

One contract test reads the adapters themselves and asserts every repo path they open is declared here, so the list cannot silently fall behind a new adapter read. The others assert every declared file exists on disk — a declared-but-missing path is worse than a missing mount, since Docker materialises the target as an empty directory and the adapter then fails inside the container instead of here.

Not run: a live Harbor or Pier trial. The mount list is asserted against the adapters' own container paths (`codex_agent.py:48`, `opencode_agent.py:248,264`) rather than assumed.

## Review focus

**Maka still receives the whole tree, so this closes the leak for graded competitor arms only.** It has to: Maka's container task-run mode executes `node /opt/maka-agent/packages/headless/dist/cli.js`. Narrowing it means deciding what the cell needs versus what the harness needs, which is its own change with its own validation, and doing it in the same PR would put Maka's execution at risk immediately before the Maka-vs-Reasonix run. Tracking separately.

The asymmetry that leaves is worth naming: Maka can reach the pinned revision and competitors cannot. In the #1970 run Maka fetched nothing from the benchmark repository — its only same-name fetch across 74 cells was `mteb-leaderboard`, which is the task itself — but that is an observation, not an enforced property.

Refs #1970

