### PR TITLE
fix(desktop): reset incompatible operational state

### DIFF
--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -74,6 +74,7 @@ import {
   createMcpConfigStore,
   createSqliteModelCallLedger,
   createSqliteTelemetryRepo,
+  resetIncompatibleOperationalStateDatabase,
 } from '@maka/storage';
 import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
@@ -214,6 +215,10 @@ if (e2eFixture) {
     app.exit(0);
     await new Promise<never>(() => {});
   }
+}
+
+if (resetIncompatibleOperationalStateDatabase(workspaceRoot)) {
+  console.warn('[startup] cleared incompatible operational state');
 }
 
 async function confirmDesktopStorageRootRepair(): Promise<boolean> {

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -5,7 +5,11 @@ import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { test } from 'node:test';
 import type { SessionHeader } from '@maka/core';
-import { acquireOperationalStateDatabase } from '../operational-state-store.js';
+import {
+  acquireOperationalStateDatabase,
+  resetIncompatibleOperationalStateDatabase,
+} from '../operational-state-store.js';
+import { SQLITE_RUNTIME_SCHEMA_VERSION } from '../sqlite-runtime-schema.js';
 import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
 
 test('shares one operational database and produces an online backup', async () => {
@@ -40,6 +44,57 @@ test('shares one operational database and produces an online backup', async () =
     }
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves operational state when every schema is current', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-compatible-'));
+  try {
+    const lease = acquireOperationalStateDatabase(root);
+    lease.database.exec('CREATE TABLE compatibility_sentinel (value TEXT NOT NULL)');
+    lease.database.exec("INSERT INTO compatibility_sentinel(value) VALUES ('preserved')");
+    lease.close();
+
+    assert.equal(resetIncompatibleOperationalStateDatabase(root), false);
+    const reopened = acquireOperationalStateDatabase(root);
+    assert.equal(
+      (
+        reopened.database.prepare('SELECT value FROM compatibility_sentinel').get() as {
+          value: string;
+        }
+      ).value,
+      'preserved',
+    );
+    reopened.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('clears operational state instead of migrating an incompatible schema', async (context) => {
+  for (const version of [SQLITE_RUNTIME_SCHEMA_VERSION - 1, SQLITE_RUNTIME_SCHEMA_VERSION + 1]) {
+    await context.test(`schema ${version}`, async () => {
+      const root = await mkdtemp(join(tmpdir(), 'maka-operational-incompatible-'));
+      const databasePath = join(root, 'runtime.sqlite');
+      try {
+        const lease = acquireOperationalStateDatabase(root);
+        lease.close();
+        const database = new DatabaseSync(databasePath);
+        database.exec(`PRAGMA user_version = ${version}`);
+        database.close();
+
+        assert.equal(resetIncompatibleOperationalStateDatabase(root), true);
+        const rebuilt = acquireOperationalStateDatabase(root);
+        assert.equal(
+          (rebuilt.database.prepare('PRAGMA user_version').get() as { user_version: number })
+            .user_version,
+          SQLITE_RUNTIME_SCHEMA_VERSION,
+        );
+        rebuilt.close();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
   }
 });
 

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -1,10 +1,11 @@
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { createRequire } from 'node:module';
 import type { DatabaseSync } from 'node:sqlite';
 import {
   configureSqliteRuntimeDatabase,
   migrateSqliteRuntimeDatabase,
+  readUserVersion,
   SQLITE_RUNTIME_SCHEMA_VERSION,
 } from './sqlite-runtime-schema.js';
 import {
@@ -32,6 +33,17 @@ import {
 export const OPERATIONAL_STATE_DATABASE_NAME = 'runtime.sqlite';
 export const OPERATIONAL_STATE_SCHEMA_VERSION = 1;
 
+const OPERATIONAL_SCHEMA_VERSIONS: ReadonlyMap<string, number> = new Map([
+  ['runtime', SQLITE_RUNTIME_SCHEMA_VERSION],
+  ['session_metadata', SQLITE_SESSION_METADATA_SCHEMA_VERSION],
+  ['core_execution', SQLITE_CORE_EXECUTION_SCHEMA_VERSION],
+  ['workflow', SQLITE_WORKFLOW_SCHEMA_VERSION],
+  ['usage', SQLITE_USAGE_SCHEMA_VERSION],
+  ['artifact', SQLITE_ARTIFACT_SCHEMA_VERSION],
+  ['automation', SQLITE_AUTOMATION_SCHEMA_VERSION],
+  ['operational', OPERATIONAL_STATE_SCHEMA_VERSION],
+] as const);
+
 const require = createRequire(import.meta.url);
 const owners = new Map<string, OperationalStateDatabaseOwner>();
 
@@ -45,6 +57,55 @@ export interface OperationalStateDatabaseLease {
   transaction<T>(mode: 'read' | 'write', operation: () => T): T;
   backup(destinationPath: string): Promise<number>;
   close(): void;
+}
+
+/**
+ * Operational state is disposable across incompatible app versions. Settings
+ * and credentials live in dedicated stores, so rebuild this database instead
+ * of migrating or downgrading its schema.
+ */
+export function resetIncompatibleOperationalStateDatabase(workspaceRoot: string): boolean {
+  const databasePath = resolve(workspaceRoot, OPERATIONAL_STATE_DATABASE_NAME);
+  if (!existsSync(databasePath)) return false;
+  if (owners.has(databasePath)) {
+    throw new Error('Operational state compatibility must be checked before opening the database');
+  }
+
+  const Database = loadDatabaseSync();
+  const database = new Database(databasePath, { readOnly: true });
+  let compatible: boolean;
+  try {
+    compatible = hasCurrentOperationalSchema(database);
+  } finally {
+    database.close();
+  }
+  if (compatible) return false;
+
+  for (const suffix of ['', '-wal', '-shm']) {
+    rmSync(`${databasePath}${suffix}`, { force: true });
+  }
+  return true;
+}
+
+function hasCurrentOperationalSchema(database: DatabaseSync): boolean {
+  if (readUserVersion(database) !== SQLITE_RUNTIME_SCHEMA_VERSION) return false;
+  const table = database
+    .prepare(`
+      SELECT 1 AS present
+      FROM sqlite_master
+      WHERE type = 'table' AND name = 'operational_schema_migrations'
+    `)
+    .get() as { present?: unknown } | undefined;
+  if (table?.present !== 1) return false;
+
+  const rows = database
+    .prepare('SELECT scope, version FROM operational_schema_migrations')
+    .all() as Array<{ scope?: unknown; version?: unknown }>;
+  if (rows.length !== OPERATIONAL_SCHEMA_VERSIONS.size) return false;
+  return rows.every(
+    ({ scope, version }) =>
+      typeof scope === 'string' && OPERATIONAL_SCHEMA_VERSIONS.get(scope) === version,
+  );
 }
 
 /**
@@ -172,14 +233,9 @@ function migrateOperationalStateDatabase(db: DatabaseSync, now: () => number): v
       );
     `);
     const appliedAt = now();
-    registerSchema(db, 'runtime', SQLITE_RUNTIME_SCHEMA_VERSION, appliedAt);
-    registerSchema(db, 'session_metadata', SQLITE_SESSION_METADATA_SCHEMA_VERSION, appliedAt);
-    registerSchema(db, 'core_execution', SQLITE_CORE_EXECUTION_SCHEMA_VERSION, appliedAt);
-    registerSchema(db, 'workflow', SQLITE_WORKFLOW_SCHEMA_VERSION, appliedAt);
-    registerSchema(db, 'usage', SQLITE_USAGE_SCHEMA_VERSION, appliedAt);
-    registerSchema(db, 'artifact', SQLITE_ARTIFACT_SCHEMA_VERSION, appliedAt);
-    registerSchema(db, 'automation', SQLITE_AUTOMATION_SCHEMA_VERSION, appliedAt);
-    registerSchema(db, 'operational', OPERATIONAL_STATE_SCHEMA_VERSION, appliedAt);
+    for (const [scope, version] of OPERATIONAL_SCHEMA_VERSIONS) {
+      registerSchema(db, scope, version, appliedAt);
+    }
     db.exec('COMMIT');
   } catch (error) {
     rollback(db);


### PR DESCRIPTION
## Summary
- check the complete operational SQLite schema before Desktop opens any store
- delete runtime.sqlite and its WAL/SHM sidecars when any schema version differs
- rebuild operational state on both upgrades and downgrades instead of migrating
- preserve settings, credentials, model connections, MCP configuration, and other file-backed configuration

## Data behavior
An incompatible app version intentionally starts with empty conversations and operational history. This is the requested no-migration policy; compatible databases are left untouched.

## Verification
- schema 8 to 9 reset and rebuild
- schema 10 to 9 reset and rebuild
- current schema preservation
- Desktop typecheck
- Biome and diff checks