### PR TITLE
fix(runtime): preserve stream liveness across filtered parts

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10482,7 +10482,7 @@ describe('AiSdkBackend tool execution', () => {
     assert.equal(resumeCount, 1);
   });
 
-  test('keeps the stream alive while a large tool input is still arriving', async () => {
+  test('keeps the stream alive while filtered tool input parts keep arriving', async () => {
     let providerCalls = 0;
     const model = new MockLanguageModelV4({
       doStream: async () => {
@@ -10525,7 +10525,7 @@ describe('AiSdkBackend tool execution', () => {
       modelId: 'claude-sonnet-4-5-20250929',
       modelFactory: () => model,
       tools: [],
-      streamConnectTimeoutMs: 100,
+      streamConnectTimeoutMs: 1_000,
       streamIdleTimeoutMs: 100,
       newId: idGenerator(),
       now: Date.now,

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10482,6 +10482,71 @@ describe('AiSdkBackend tool execution', () => {
     assert.equal(resumeCount, 1);
   });
 
+  test('keeps the stream alive while a large tool input is still arriving', async () => {
+    let providerCalls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        providerCalls += 1;
+        const chunks: LanguageModelV4StreamPart[] = [
+          { type: 'stream-start', warnings: [] },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Preparing the report.' },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'tool-input-start', id: 'tool-1', toolName: 'Write' },
+          { type: 'tool-input-delta', id: 'tool-1', delta: '{"path":' },
+          { type: 'tool-input-delta', id: 'tool-1', delta: '"report.md",' },
+          { type: 'tool-input-delta', id: 'tool-1', delta: '"content":' },
+          { type: 'tool-input-delta', id: 'tool-1', delta: '"complete"}' },
+          { type: 'tool-input-end', id: 'tool-1' },
+          { type: 'text-start', id: 'text-2' },
+          { type: 'text-delta', id: 'text-2', delta: 'Done.' },
+          { type: 'text-end', id: 'text-2' },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: emptyUsage(),
+          },
+        ];
+        return {
+          stream: simulateReadableStream({
+            chunks,
+            initialDelayInMs: null,
+            chunkDelayInMs: 25,
+          }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header('bypass'),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'claude-sonnet-4-5-20250929',
+      modelFactory: () => model,
+      tools: [],
+      streamConnectTimeoutMs: 100,
+      streamIdleTimeoutMs: 100,
+      newId: idGenerator(),
+      now: Date.now,
+    });
+
+    const events: SessionEvent[] = [];
+    await collectEvents(
+      backend.send({ turnId: 'turn-1', text: 'write the report', context: [] }),
+      events,
+    );
+
+    assert.equal(
+      events.some((event) => event.type === 'error'),
+      false,
+      JSON.stringify(events.filter((event) => event.type === 'error')),
+    );
+    assert.equal(providerCalls, 1);
+    const completion = events.find((event) => event.type === 'complete');
+    assert.equal(completion?.type === 'complete' ? completion.stopReason : undefined, 'end_turn');
+  });
+
   test('caps concurrent read-only subagent tools in one turn', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/deferred-tools-wire.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-wire.test.ts
@@ -71,6 +71,7 @@ async function toolNamesSeenByProvider(activeNames: ReadonlySet<string>): Promis
     messages: [{ role: 'user', content: 'hi' }],
     tools: modelTools,
     activeTools: canonical.activeTools,
+    onStreamActivity: () => {},
     system: 'sys',
     abortSignal: new AbortController().signal,
     repairToolCall: async () => null,
@@ -142,6 +143,7 @@ describe('ModelAdapter provider-step boundary', () => {
         },
       },
       activeTools: ['Read'],
+      onStreamActivity: () => {},
       abortSignal: new AbortController().signal,
       repairToolCall: async () => null,
     });
@@ -187,6 +189,7 @@ describe('ModelAdapter provider-step boundary', () => {
       messages: [{ role: 'user', content: 'read it' }],
       tools: toolsWithExecutableBehavior,
       activeTools: ['Read'],
+      onStreamActivity: () => {},
       abortSignal: new AbortController().signal,
       repairToolCall: async () => null,
     });

--- a/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
@@ -34,6 +34,7 @@ describe('ModelAdapter.startStream onError', () => {
       messages: [{ role: 'user', content: 'hi' }],
       tools: {},
       activeTools: [],
+      onStreamActivity: () => {},
       abortSignal: new AbortController().signal,
       repairToolCall: async () => null,
     });
@@ -73,6 +74,7 @@ describe('ModelAdapter.startStream onError', () => {
       messages: [{ role: 'user', content: 'hi' }],
       tools: {},
       activeTools: [],
+      onStreamActivity: () => {},
       abortSignal: new AbortController().signal,
       repairToolCall: async () => null,
     });
@@ -106,6 +108,7 @@ describe('ModelAdapter.startStream onError', () => {
       messages: [{ role: 'user', content: 'hi' }],
       tools: {},
       activeTools: [],
+      onStreamActivity: () => {},
       system: 'sys',
       abortSignal: new AbortController().signal,
       repairToolCall: async () => null,
@@ -143,6 +146,7 @@ describe('ModelAdapter.startStream onError', () => {
         messages: [{ role: 'user', content: 'hi' }],
         tools: {},
         activeTools: [],
+        onStreamActivity: () => {},
         system: 'sys',
         abortSignal: new AbortController().signal,
         repairToolCall: async () => null,

--- a/packages/runtime/src/__tests__/model-adapter-stream-activity.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter-stream-activity.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { LanguageModelV4StreamPart, LanguageModelV4Usage } from '@ai-sdk/provider';
+import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
+
+import { ModelAdapter } from '../model-adapter.js';
+
+const ZERO_USAGE: LanguageModelV4Usage = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+};
+
+test('reports activity for every pulled SDK stream part before semantic translation', async () => {
+  const parts: LanguageModelV4StreamPart[] = [
+    { type: 'stream-start', warnings: [] },
+    { type: 'tool-input-start', id: 'tool-1', toolName: 'Write' },
+    { type: 'tool-input-delta', id: 'tool-1', delta: '{"path":' },
+    { type: 'tool-input-delta', id: 'tool-1', delta: '"report.md"}' },
+    { type: 'tool-input-end', id: 'tool-1' },
+    {
+      type: 'finish',
+      finishReason: { unified: 'stop', raw: 'stop' },
+      usage: ZERO_USAGE,
+    },
+  ];
+  const model = new MockLanguageModelV4({
+    doStream: {
+      stream: convertArrayToReadableStream(parts),
+    },
+  });
+  const adapter = new ModelAdapter({
+    connection: { providerType: 'openai' } as never,
+    apiKey: 'test',
+    modelId: 'mock',
+    modelFactory: () => model,
+    newId: () => 'id',
+    now: () => 0,
+  });
+  let activityCount = 0;
+
+  const result = await adapter.startStream({
+    model,
+    messages: [{ role: 'user', content: 'write it' }],
+    tools: {},
+    activeTools: [],
+    abortSignal: new AbortController().signal,
+    repairToolCall: async () => null,
+    onStreamActivity: () => {
+      activityCount += 1;
+    },
+  });
+  const semanticKinds: string[] = [];
+  for await (const event of result.events) semanticKinds.push(event.kind);
+
+  // streamText adds start-step and finish-step around the six provider parts.
+  // The tool-input parts are intentionally absent from the semantic stream,
+  // but each successfully pulled SDK part still reports liveness.
+  assert.equal(activityCount, parts.length + 2);
+  assert.ok(activityCount > semanticKinds.length);
+});

--- a/packages/runtime/src/__tests__/model-adapter-stream-activity.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter-stream-activity.test.ts
@@ -52,9 +52,9 @@ test('reports activity for every pulled SDK stream part before semantic translat
   const semanticKinds: string[] = [];
   for await (const event of result.events) semanticKinds.push(event.kind);
 
-  // streamText adds start-step and finish-step around the six provider parts.
-  // The tool-input parts are intentionally absent from the semantic stream,
-  // but each successfully pulled SDK part still reports liveness.
+  // streamText consumes the provider stream-start/finish parts and emits
+  // start/start-step plus finish-step/finish, so this fixture becomes eight
+  // pulled SDK parts. Tool-input parts stay absent from the semantic stream.
   assert.equal(activityCount, parts.length + 2);
   assert.ok(activityCount > semanticKinds.length);
 });

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -990,7 +990,7 @@ export class AiSdkBackend implements AgentBackend {
       let watchdog: StreamWatchdog | null = null;
       let watchdogTimeoutError: Error | null = null;
       try {
-        watchdog = new StreamWatchdog({
+        const streamWatchdog = new StreamWatchdog({
           now: this.now,
           connectTimeoutMs: this.input.streamConnectTimeoutMs,
           idleTimeoutMs: this.input.streamIdleTimeoutMs,
@@ -1006,6 +1006,7 @@ export class AiSdkBackend implements AgentBackend {
             turnAbortController.abort(watchdogTimeoutError);
           },
         });
+        watchdog = streamWatchdog;
         scope.watchdog = watchdog;
         watchdog.start();
         const activeTools = plan.activeTools;
@@ -1375,6 +1376,7 @@ export class AiSdkBackend implements AgentBackend {
               messages: attemptMessages,
               tools: modelTools,
               activeTools: activeToolsForRequest,
+              onStreamActivity: () => streamWatchdog.markActivity(),
               repairToolCall: async ({
                 toolCall,
                 error,
@@ -1402,7 +1404,6 @@ export class AiSdkBackend implements AgentBackend {
             try {
               for await (const event of result.events) {
                 if (scope.aborted) break;
-                watchdog.markActivity();
                 if (event.kind === 'error') {
                   // A request-level error ends this stream; capture it and stop
                   // consuming (the synthesized trailer carries no real step) so

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -109,6 +109,8 @@ export interface ModelAdapterStreamInput {
   messages: ModelMessage[];
   tools: ModelToolSet;
   activeTools: string[];
+  /** Observe each successfully pulled SDK stream part before semantic translation. */
+  onStreamActivity: () => void;
   system?: string;
   abortSignal: AbortSignal;
   repairToolCall: (input: {
@@ -228,7 +230,7 @@ export class ModelAdapter {
       // `error` event → ErrorEvent path, so silence the default.
       onError: () => {},
     }) as unknown as SdkStreamResult;
-    return this.toModelStreamResult(sdkResult);
+    return this.toModelStreamResult(sdkResult, input.onStreamActivity);
   }
 
   /**
@@ -237,7 +239,10 @@ export class ModelAdapter {
    * streaming stays live; failures, usage, finish reason, and request messages
    * are normalized to Maka-owned contracts. No AI SDK type escapes this method.
    */
-  private toModelStreamResult(sdk: SdkStreamResult): ModelStreamResult {
+  private toModelStreamResult(
+    sdk: SdkStreamResult,
+    onStreamActivity: () => void,
+  ): ModelStreamResult {
     const kimiOpenAiTransportState = usesKimiOpenAiChat(this.input.connection, this.input.modelId)
       ? this.kimiOpenAiTransportState
       : undefined;
@@ -245,6 +250,7 @@ export class ModelAdapter {
       async *[Symbol.asyncIterator]() {
         try {
           for await (const chunk of sdk.stream as AsyncIterable<AiSdkStreamChunk>) {
+            onStreamActivity();
             for (const event of translateChunk(chunk, kimiOpenAiTransportState)) yield event;
           }
         } catch (error) {


### PR DESCRIPTION
## Summary

- restore the stream watchdog invariant at the `ModelAdapter` boundary by reporting every successfully pulled AI SDK stream part before semantic translation
- wire that activity directly to the backend watchdog and remove semantic-event-based liveness tracking
- add adapter contract and backend regressions for long streamed tool inputs that emit no intermediate `ModelStreamEvent`s

Closes #2119

## Verification

- `npm --workspace @maka/runtime test` — 3124 passed, 0 failed, 9 skipped
- targeted adapter and backend regression tests — passed; the backend regression fails with `reason: timeout` when the old semantic-event activity mark is restored
- Biome lint and format for all changed files — passed
- `npm --workspace @maka/runtime run typecheck` — passed
- `npm run typecheck` — blocked by unrelated errors reproducible on clean `main`, including the existing `@maka/storage` `parseDailyReviewArchiveId` export mismatch

## Root cause

The watchdog observed the lossy Maka semantic event stream. AI SDK `tool-input-start`, `tool-input-delta`, and `tool-input-end` parts are intentionally filtered by `ModelAdapter`, so a healthy provider stream could appear idle for longer than 120 seconds while a large tool argument was still arriving. The adapter is the narrowest boundary that sees every successfully pulled SDK stream part, so it now exposes a required synchronous activity observer without adding liveness events to `ModelStreamEvent`.