### PR TITLE
fix(headless): keep Harbor archive ids within ref grammar

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell-archive-artifact-id.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell-archive-artifact-id.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  buildToolResultArchiveResourceRef,
+  parseToolResultArchiveResourceRef,
+} from '@maka/runtime';
+import { buildHarborCellContextBudgetBackendOptions } from '../harbor-cell-context-budget-env.js';
+
+describe('Harbor archive artifact ids', () => {
+  test('grammar-hostile and over-length inputs round-trip through runtime refs', async () => {
+    await withArchiveDir(async (archiveDir) => {
+      const identities = [
+        { sessionId: 'session=1', runtimeEventId: 'event=1' },
+        { sessionId: 's'.repeat(96), runtimeEventId: 'e'.repeat(96) },
+      ];
+
+      for (const identity of identities) {
+        const archived = await archiveToolResult(archiveDir, identity);
+        assert.deepEqual(
+          parseToolResultArchiveResourceRef(
+            buildToolResultArchiveResourceRef({
+              artifactId: archived.artifactId,
+              bodySha256: archived.bodySha256,
+              originalBytes: archived.originalBytes,
+            }),
+          ),
+          archived,
+        );
+      }
+    });
+  });
+
+  test('ids that differ only beyond their readable prefix do not collide', async () => {
+    await withArchiveDir(async (archiveDir) => {
+      const sharedPrefix = 's'.repeat(120);
+      const first = await archiveToolResult(archiveDir, {
+        sessionId: `${sharedPrefix}-first`,
+        runtimeEventId: 'event-1',
+      });
+      const second = await archiveToolResult(archiveDir, {
+        sessionId: `${sharedPrefix}-second`,
+        runtimeEventId: 'event-1',
+      });
+
+      assert.notEqual(first.artifactId, second.artifactId);
+    });
+  });
+});
+
+async function withArchiveDir(run: (archiveDir: string) => Promise<void>): Promise<void> {
+  const archiveDir = await mkdtemp(join(tmpdir(), 'maka-harbor-archive-id-'));
+  try {
+    await run(archiveDir);
+  } finally {
+    await rm(archiveDir, { recursive: true, force: true });
+  }
+}
+
+async function archiveToolResult(
+  archiveDir: string,
+  identity: { sessionId: string; runtimeEventId: string },
+): Promise<{ artifactId: string; bodySha256: string; originalBytes: number }> {
+  const serializedResult = JSON.stringify({ body: 'archived tool output' });
+  const bodySha256 = createHash('sha256').update(serializedResult).digest('hex');
+  const originalBytes = Buffer.byteLength(serializedResult, 'utf8');
+  const recorder = buildHarborCellContextBudgetBackendOptions({
+    MAKA_CONTEXT_TOOL_RESULT_ARCHIVE_DIR: archiveDir,
+  }).archiveToolResult;
+  assert.ok(recorder);
+
+  const archived = await recorder({
+    ...identity,
+    turnId: 'turn-1',
+    toolCallId: 'tool-1',
+    toolName: 'Read',
+    result: { body: 'archived tool output' },
+    serializedResult,
+    originalEstimatedTokens: 9,
+    originalBytes,
+    rewriteVersion: 1,
+    reason: 'stale_tool_result_pruned_before_compact',
+    bodySha256,
+  });
+  assert.ok(archived);
+  return { ...archived, bodySha256, originalBytes };
+}

--- a/packages/headless/src/harbor-cell-context-budget-env.ts
+++ b/packages/headless/src/harbor-cell-context-budget-env.ts
@@ -850,22 +850,31 @@ function harborCellToolResultArchiveDir(env: RunHarborCellEnv): string | undefin
   );
 }
 
+// Two prefixes, separators, a full SHA-256, and `.json` total at most 153
+// characters, within the runtime ref grammar's 160-character cap.
+const HARBOR_CELL_ARCHIVE_ID_PREFIX_MAX_CHARS = 40;
+
 function harborCellToolResultArchiveArtifactId(input: {
   sessionId: string;
   runtimeEventId: string;
   bodySha256: string;
 }): string {
+  const identityHash = createHash('sha256')
+    .update(JSON.stringify([input.sessionId, input.runtimeEventId, input.bodySha256]))
+    .digest('hex');
   return (
     [
-      safeArtifactIdPart(input.sessionId),
-      safeArtifactIdPart(input.runtimeEventId),
-      safeArtifactIdPart(input.bodySha256.slice(0, 16)),
+      safeArtifactIdPrefix(input.sessionId),
+      safeArtifactIdPrefix(input.runtimeEventId),
+      identityHash,
     ].join('--') + '.json'
   );
 }
 
-function safeArtifactIdPart(value: string): string {
-  const safe = value.replace(/[^A-Za-z0-9_.=-]/g, '_').slice(0, 96);
+function safeArtifactIdPrefix(value: string): string {
+  const safe = value
+    .replace(/[^A-Za-z0-9._-]/g, '_')
+    .slice(0, HARBOR_CELL_ARCHIVE_ID_PREFIX_MAX_CHARS);
   return safe || 'unknown';
 }
 


### PR DESCRIPTION
## Summary

Harbor's archive writer could produce an artifact id that the Runtime resource parser rejects: `=` was allowed by the writer but not the parser, and three independently truncated segments could exceed the parser's 160-character limit.

This keeps the Runtime parser as the protocol authority and changes only Harbor's writer:

- retain readable 40-character session and runtime-event prefixes;
- sanitize prefixes to the Runtime grammar;
- append a full SHA-256 over the untruncated `sessionId`, `runtimeEventId`, and `bodySha256`;
- keep the existing reader validation unchanged for legacy replay compatibility.

The maximum generated id is 153 characters. Distinct opaque ids that differ only after the readable prefix also remain distinct on disk.

## Verification

- `biome lint` on both changed files
- `npm --workspace @maka/headless run typecheck`
- focused writer-to-parser regression: 2 passed
- existing Harbor archive/ArchiveRead coverage: 8 passed
- complete Headless suite: 1387 passed, 5 skipped, 0 failed

Closes #2036

<details>
<summary><strong>简体中文</strong></summary>

Harbor 旧 writer 允许 `=`，并分别截断三个 segment；生成的 artifact id 可能含有 Runtime parser 不接受的字符，也可能达到 217 字符，导致文件已经写入、resource ref 却无法解析。

本修复不放宽 Runtime 协议，只收紧 Harbor writer：保留 session/runtime event 的 40 字符可读前缀，并在其后附加基于完整未截断 identity 的 SHA-256。最终长度最多 153 字符；两个只在前缀之后不同的 opaque id 也不会因截断写到同一路径。旧 reader 的兼容校验保持不变。

新增测试通过真实 Harbor writer 归档，再调用真实 Runtime ref builder/parser，分别覆盖 `=`、超长输入和截断碰撞。

</details>
