### PR TITLE
test(desktop): isolate dev bootstrap environment

### DIFF
--- a/apps/desktop/scripts/dev-app-runtime.test.mjs
+++ b/apps/desktop/scripts/dev-app-runtime.test.mjs
@@ -163,6 +163,14 @@ async function runBootstrap({ envFileContent, omitMainEntry } = {}) {
   // shared between these tests; snapshot it so cases stay independent.
   const previousEnv = { ...process.env };
   try {
+    // Each run measures what the bootstrap assigns from its published file.
+    // Do not mistake the developer shell's forwarded values for that output.
+    const publishedEnvironmentKeys = new Set([
+      ...Object.keys(selectDevelopmentEnvironment(process.env)),
+      'VITE_DEV_SERVER_URL',
+    ]);
+    for (const key of publishedEnvironmentKeys) delete process.env[key];
+
     nodeModule(bootstrapFile);
     const cwd = process.cwd();
     // The import settles on the next tick; poll rather than guess a tick count.
@@ -219,14 +227,26 @@ test('adopts a published environment file: env, userData override, switches', as
 
 test('ignores an unreadable or wrong-schema environment file instead of failing to boot', async () => {
   const wrongSchema = JSON.stringify({ schemaVersion: 999, env: { OPENAI_API_KEY: 'leak' } });
-  for (const content of ['not json at all', wrongSchema]) {
-    const { calls, loaded, root } = await runBootstrap({ envFileContent: content });
-    assert.deepEqual(calls.find(([kind]) => kind === 'setPath'), [
-      'setPath',
-      'userData',
-      join(root, 'default-user-data'),
-    ]);
-    assert.equal(loaded.apiKey, null);
+  const previousApiKey = process.env.OPENAI_API_KEY;
+  const previousViteUrl = process.env.VITE_DEV_SERVER_URL;
+  process.env.OPENAI_API_KEY = 'ambient-openai-key';
+  process.env.VITE_DEV_SERVER_URL = 'http://ambient.invalid';
+  try {
+    for (const content of ['not json at all', wrongSchema]) {
+      const { calls, loaded, root } = await runBootstrap({ envFileContent: content });
+      assert.deepEqual(calls.find(([kind]) => kind === 'setPath'), [
+        'setPath',
+        'userData',
+        join(root, 'default-user-data'),
+      ]);
+      assert.equal(loaded.apiKey, null);
+      assert.equal(loaded.viteUrl, null);
+    }
+  } finally {
+    if (previousApiKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousApiKey;
+    if (previousViteUrl === undefined) delete process.env.VITE_DEV_SERVER_URL;
+    else process.env.VITE_DEV_SERVER_URL = previousViteUrl;
   }
 });
 


### PR DESCRIPTION
## Summary

`dev-app-runtime.test.mjs` executes the generated Electron bootstrap in-process. The harness restored `process.env` afterward, but it did not clear values inherited from the developer shell before the bootstrap ran. An ignored env file could therefore appear to supply `OPENAI_API_KEY`, and the failed assertion printed the ambient value.

This change stays entirely in the test harness:

- derive the currently published environment keys from the existing `selectDevelopmentEnvironment` policy;
- clear those keys plus the separately supplied `VITE_DEV_SERVER_URL` before each bootstrap run;
- retain the existing full environment restoration in `finally`;
- seed fixed dummy ambient OpenAI/Vite values outside `runBootstrap`, so the regression fails against the old helper without ever printing a developer's real credential.

Production bootstrap behavior is unchanged.

## Verification

- `node --test apps/desktop/scripts/dev-app-runtime.test.mjs` — 25 passed
- `npm run test:scripts` — 105 passed
- mutation check with the cleanup block removed — 24 passed, the target test failed with the fixed dummy value

Closes #2077

<details>
<summary><strong>简体中文</strong></summary>

`dev-app-runtime.test.mjs` 会在当前测试进程中执行生成的 Electron bootstrap。旧 harness 虽然会在结束后恢复 `process.env`，却没有在执行前清掉开发者 shell 中已经存在的可转发变量。因此 env file 被忽略时，测试仍可能读到真实 `OPENAI_API_KEY`，并在断言失败时把它打印出来。

本修复只改测试 harness：复用现有 `selectDevelopmentEnvironment` 策略清理官方会发布的环境变量，并显式清理单独传入的 Vite URL；结束后仍通过原有 `finally` 完整恢复环境。回归测试在 helper 外部注入固定 dummy 值，所以旧实现必然失败，但失败输出也不会包含开发者的真实凭据。

生产 bootstrap 行为没有变化。

</details>
