### PR TITLE
feat(runtime-host): add Desktop client foundation

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -47,6 +47,7 @@
     "@maka/core": "0.1.0",
     "@maka/mcp": "0.1.0",
     "@maka/runtime": "0.1.0",
+    "@maka/runtime-host": "0.1.0",
     "@maka/storage": "0.1.0",
     "@maka/ui": "0.1.0",
     "ai": "^7.0.31",

--- a/apps/desktop/src/main/__tests__/runtime-host-client.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type {
+  RuntimeHostConnection,
+  RuntimeHostSessionSubscription,
+} from '@maka/runtime-host/client';
+import {
+  SESSION_CONTINUITY_SCHEMA_VERSION,
+  type SubscriptionFrame,
+} from '@maka/runtime-host/protocol';
+import { DesktopRuntimeHostClient } from '../runtime-host-client.js';
+
+test('starts transcript loading at attach and closes every Session before the connection', async () => {
+  const lifecycle: string[] = [];
+  const first = subscription('session-1', lifecycle);
+  const second = subscription('session-2', lifecycle);
+  const subscriptions = [first, second];
+  const connection = {
+    openSessionSubscription: async () => {
+      const next = subscriptions.shift();
+      if (!next) throw new Error('Unexpected Session open');
+      return next;
+    },
+    close: async () => {
+      lifecycle.push('connection:close');
+    },
+  } as unknown as RuntimeHostConnection;
+  const client = new DesktopRuntimeHostClient(connection);
+
+  const sessionOne = await client.openSession('session-1');
+  const sessionTwo = await client.openSession('session-2');
+  assert.deepEqual(lifecycle, ['session-1:transcript', 'session-2:transcript']);
+  assert.deepEqual(await sessionOne.transcript, []);
+  assert.deepEqual(await sessionTwo.transcript, []);
+
+  await client.close();
+  assert.deepEqual(lifecycle, [
+    'session-1:transcript',
+    'session-2:transcript',
+    'session-1:close',
+    'session-2:close',
+    'connection:close',
+  ]);
+  await assert.rejects(() => client.openSession('session-3'), /Client is closed/);
+});
+
+function subscription(
+  sessionId: string,
+  lifecycle: string[],
+): RuntimeHostSessionSubscription {
+  return {
+    hostEpoch: 'host-1',
+    subscriptionId: `subscription-${sessionId}`,
+    snapshot: {
+      schemaVersion: SESSION_CONTINUITY_SCHEMA_VERSION,
+      session: {
+        sessionId,
+        metadataRevision: 1,
+        status: 'active',
+        createdAt: 1,
+        lastUsedAt: 1,
+        isArchived: false,
+      },
+      projectionRevision: 1,
+      rootTurn: null,
+      goal: null,
+      queue: { hostEpoch: 'host-1', queueRevision: 0, steering: [], followup: [] },
+      interactions: { pending: [] },
+    },
+    loadTranscript: async <T>(decodeMessage: (value: unknown) => T) => {
+      lifecycle.push(`${sessionId}:transcript`);
+      return [] as T[];
+    },
+    close: async () => {
+      lifecycle.push(`${sessionId}:close`);
+    },
+    [Symbol.asyncIterator]: async function* (): AsyncIterator<SubscriptionFrame> {},
+  };
+}

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -1,41 +1,18 @@
 import { decodeStoredMessageForRead, type StoredMessage } from '@maka/core/session';
 import {
-  connectOrSpawnRuntimeHost,
-  type ConnectOrSpawnRuntimeHostResult,
   type RuntimeHostConnection,
   type RuntimeHostSessionSubscription,
 } from '@maka/runtime-host/client';
 import {
-  RUNTIME_HOST_PROTOCOL_VERSION,
   type SessionContinuitySnapshot,
   type SubscriptionFrame,
 } from '@maka/runtime-host/protocol';
-
-export type DesktopRuntimeHostConnectResult =
-  | { kind: 'connected'; client: DesktopRuntimeHostClient }
-  | Exclude<ConnectOrSpawnRuntimeHostResult, { kind: 'connected' }>;
 
 export interface DesktopRuntimeHostSession {
   readonly snapshot: SessionContinuitySnapshot;
   readonly transcript: Promise<StoredMessage[]>;
   readonly events: AsyncIterable<SubscriptionFrame>;
   close(): Promise<void>;
-}
-
-export async function connectDesktopRuntimeHost(
-  rootPath: string,
-): Promise<DesktopRuntimeHostConnectResult> {
-  const result = await connectOrSpawnRuntimeHost({
-    rootPath,
-    surface: 'desktop',
-    protocol: {
-      min: RUNTIME_HOST_PROTOCOL_VERSION,
-      max: RUNTIME_HOST_PROTOCOL_VERSION,
-    },
-  });
-  return result.kind === 'connected'
-    ? { kind: 'connected', client: new DesktopRuntimeHostClient(result.connection) }
-    : result;
 }
 
 export class DesktopRuntimeHostClient {

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -1,0 +1,93 @@
+import { decodeStoredMessageForRead, type StoredMessage } from '@maka/core/session';
+import {
+  connectOrSpawnRuntimeHost,
+  type ConnectOrSpawnRuntimeHostResult,
+  type RuntimeHostConnection,
+  type RuntimeHostSessionSubscription,
+} from '@maka/runtime-host/client';
+import {
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  type SessionContinuitySnapshot,
+  type SubscriptionFrame,
+} from '@maka/runtime-host/protocol';
+
+export type DesktopRuntimeHostConnectResult =
+  | { kind: 'connected'; client: DesktopRuntimeHostClient }
+  | Exclude<ConnectOrSpawnRuntimeHostResult, { kind: 'connected' }>;
+
+export interface DesktopRuntimeHostSession {
+  readonly snapshot: SessionContinuitySnapshot;
+  readonly transcript: Promise<StoredMessage[]>;
+  readonly events: AsyncIterable<SubscriptionFrame>;
+  close(): Promise<void>;
+}
+
+export async function connectDesktopRuntimeHost(
+  rootPath: string,
+): Promise<DesktopRuntimeHostConnectResult> {
+  const result = await connectOrSpawnRuntimeHost({
+    rootPath,
+    surface: 'desktop',
+    protocol: {
+      min: RUNTIME_HOST_PROTOCOL_VERSION,
+      max: RUNTIME_HOST_PROTOCOL_VERSION,
+    },
+  });
+  return result.kind === 'connected'
+    ? { kind: 'connected', client: new DesktopRuntimeHostClient(result.connection) }
+    : result;
+}
+
+export class DesktopRuntimeHostClient {
+  readonly #sessions = new Set<DesktopSessionHandle>();
+  #closeTask: Promise<void> | undefined;
+
+  constructor(private readonly connection: RuntimeHostConnection) {}
+
+  async openSession(sessionId: string): Promise<DesktopRuntimeHostSession> {
+    if (this.#closeTask) throw new Error('Desktop Runtime Host Client is closed');
+    const subscription = await this.connection.openSessionSubscription({ sessionId });
+    if (this.#closeTask) {
+      await subscription.close().catch(() => undefined);
+      throw new Error('Desktop Runtime Host Client is closed');
+    }
+    const session = new DesktopSessionHandle(subscription, () => this.#sessions.delete(session));
+    this.#sessions.add(session);
+    return session;
+  }
+
+  close(): Promise<void> {
+    this.#closeTask ??= this.#close();
+    return this.#closeTask;
+  }
+
+  async #close(): Promise<void> {
+    try {
+      await Promise.all([...this.#sessions].map((session) => session.close()));
+    } finally {
+      await this.connection.close();
+    }
+  }
+}
+
+class DesktopSessionHandle implements DesktopRuntimeHostSession {
+  readonly snapshot: SessionContinuitySnapshot;
+  readonly transcript: Promise<StoredMessage[]>;
+  readonly events: AsyncIterable<SubscriptionFrame>;
+  #closeTask: Promise<void> | undefined;
+
+  constructor(
+    private readonly subscription: RuntimeHostSessionSubscription,
+    private readonly onClose: () => void,
+  ) {
+    this.snapshot = subscription.snapshot;
+    this.events = subscription;
+    this.transcript = subscription.loadTranscript(decodeStoredMessageForRead);
+    void this.transcript.catch(() => undefined);
+  }
+
+  close(): Promise<void> {
+    this.#closeTask ??= this.subscription.close().finally(this.onClose);
+    return this.#closeTask;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@maka/core": "0.1.0",
         "@maka/mcp": "0.1.0",
         "@maka/runtime": "0.1.0",
+        "@maka/runtime-host": "0.1.0",
         "@maka/storage": "0.1.0",
         "@maka/ui": "0.1.0",
         "ai": "^7.0.31",

--- a/packages/cli/src/__tests__/inspect-command.test.ts
+++ b/packages/cli/src/__tests__/inspect-command.test.ts
@@ -7,6 +7,7 @@ import type { AgentRunHeader } from '@maka/core';
 import { createInMemoryTaskRunStore, runTaskOnce } from '@maka/headless';
 import type { SessionInspectDocument } from '@maka/runtime';
 import type { RuntimeHostConnection } from '@maka/runtime-host/client';
+import { RUNTIME_HOST_COMPATIBILITY_EPOCH } from '@maka/runtime-host/protocol';
 import { createSessionStore } from '@maka/storage';
 import { createSqliteAgentRunStore, createWorkspaceRuntimeStore } from '@maka/storage';
 import {
@@ -279,6 +280,7 @@ describe('inspect CLI storage authority boundary', () => {
             endpoint: '/tmp/runtime-host.sock',
             protocolMin: 0,
             protocolMax: 0,
+            compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
             state: 'ready',
             pid: 1,
             createdAt: new Date(0).toISOString(),

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -697,6 +697,7 @@ async function openAcceptedTransport(
     surface: 'tui',
     protocolMin: CURRENT_PROTOCOL.min,
     protocolMax: CURRENT_PROTOCOL.max,
+    compatibilityEpoch: 1,
   });
   const handshake = decodeHostFrame(await transport.read(1_000));
   assert.ok('kind' in handshake);

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -20,7 +20,7 @@ import { canonicalToolArgsHash, TOOL_BOUNDARY_PROTOCOL_V1 } from '@maka/core';
 import type { AgentRunHeader } from '@maka/core/agent-run';
 import type { MessageContent } from '@maka/core/events';
 import type { ConnectionCatalogEntry } from '@maka/core/runtime-policy';
-import type { StoredMessage } from '@maka/core/session';
+import { decodeStoredMessageForRead, type StoredMessage } from '@maka/core/session';
 import type { Task } from '@maka/core/task-ledger';
 import { isTerminalRuntimeEvent } from '@maka/core/runtime-event';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
@@ -487,10 +487,6 @@ test('two Clients share one execution after the starting Client disconnects', as
     const host = await fixture.startHost();
     const first = await connectClient(fixture.root, 'desktop');
     const second = await connectClient(fixture.root, 'tui');
-    const secondSubscription = await second.openSessionSubscription({
-      sessionId: fixture.sessionId,
-    });
-    const secondProbe = new SubscriptionProbe(secondSubscription);
     const turnId = randomUUID();
 
     const started = await first.startTurn(
@@ -502,6 +498,19 @@ test('two Clients share one execution after the starting Client disconnects', as
       PROCESS_TIMEOUT_MS,
     );
     assert.equal(started.turnId, turnId);
+    const secondSubscription = await second.openSessionSubscription({
+      sessionId: fixture.sessionId,
+    });
+    const transcript = await secondSubscription.loadTranscript(decodeStoredMessageForRead);
+    assert.ok(
+      transcript.some(
+        (message) =>
+          message.type === 'user' &&
+          message.turnId === turnId &&
+          message.text === FAKE_ASK_USER_QUESTION_PROMPT,
+      ),
+    );
+    const secondProbe = new SubscriptionProbe(secondSubscription);
     await assert.rejects(
       () =>
         second.startTurn(

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
@@ -1097,6 +1097,7 @@ export async function sendStartWithoutReadingResponse(
     surface: 'desktop',
     protocolMin: CURRENT_PROTOCOL.min,
     protocolMax: CURRENT_PROTOCOL.max,
+    compatibilityEpoch: 1,
   });
   const handshake = decodeHostFrame(await transport.read(2_000));
   assert.ok('kind' in handshake);

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -169,6 +169,7 @@ describe('non-serving Runtime Host kernel', () => {
           surface: 'inspect',
           protocolMin: CURRENT_PROTOCOL.min,
           protocolMax: CURRENT_PROTOCOL.max,
+          compatibilityEpoch: 1,
         });
         const handshake = decodeHostFrame(await transport.read(1_000));
         assert.ok('kind' in handshake && handshake.kind === 'accepted');
@@ -390,6 +391,28 @@ describe('non-serving Runtime Host kernel', () => {
       assert.equal(resident.kind, 'connected');
       if (resident.kind !== 'connected') return;
 
+      const staleWhileResident = new FramedTransport(await openSocket(candidate.host.endpoint));
+      await staleWhileResident.writeEncoded(
+        encodeLegacyProtocolFrame({
+          kind: 'hello',
+          clientInstanceId: 'stale-schema-resident',
+          surface: 'tui',
+          protocolMin: CURRENT_PROTOCOL.min,
+          protocolMax: CURRENT_PROTOCOL.max,
+        }),
+      );
+      assert.deepEqual(decodeHostFrame(await staleWhileResident.read(1_000)), {
+        kind: 'incompatible',
+        hostEpoch: candidate.host.hostEpoch,
+        protocolMin: CURRENT_PROTOCOL.min,
+        protocolMax: CURRENT_PROTOCOL.max,
+        compatibilityEpoch: 1,
+        state: 'ready',
+        replacement: 'blocked_by_residency',
+      });
+      staleWhileResident.destroy();
+      await staleWhileResident.closed;
+
       const blocked = await connectOrSpawnRuntimeHost({
         ...paths,
         rootPath: paths.root,
@@ -401,6 +424,24 @@ describe('non-serving Runtime Host kernel', () => {
       if (blocked.kind === 'incompatible')
         assert.equal(blocked.handshake.replacement, 'blocked_by_residency');
       await resident.connection.close();
+
+      const staleAtIdle = new FramedTransport(await openSocket(candidate.host.endpoint));
+      await staleAtIdle.writeEncoded(
+        encodeLegacyProtocolFrame({
+          kind: 'hello',
+          clientInstanceId: 'stale-schema-idle',
+          surface: 'tui',
+          protocolMin: CURRENT_PROTOCOL.min,
+          protocolMax: CURRENT_PROTOCOL.max,
+        }),
+      );
+      const staleIdleResponse = decodeHostFrame(await staleAtIdle.read(1_000));
+      assert.ok('kind' in staleIdleResponse && staleIdleResponse.kind === 'incompatible');
+      if ('kind' in staleIdleResponse && staleIdleResponse.kind === 'incompatible') {
+        assert.equal(staleIdleResponse.replacement, 'wait_for_idle_exit');
+      }
+      staleAtIdle.destroy();
+      await staleAtIdle.closed;
 
       const replaceable = await Promise.all([
         connectRuntimeHost({
@@ -890,6 +931,7 @@ describe('non-serving Runtime Host kernel', () => {
         surface: 'tui',
         protocolMin: CURRENT_PROTOCOL.min,
         protocolMax: CURRENT_PROTOCOL.max,
+        compatibilityEpoch: 1,
       });
       const response = decodeHostFrame(await transport.read(2_000));
       assert.deepEqual(response, { kind: 'draining', hostEpoch: candidate.host.hostEpoch });
@@ -951,6 +993,7 @@ describe('non-serving Runtime Host kernel', () => {
           surface: 'tui',
           protocolMin: CURRENT_PROTOCOL.min,
           protocolMax: CURRENT_PROTOCOL.max,
+          compatibilityEpoch: 1,
         });
         const handshake = decodeHostFrame(await transport.read(2_000));
         assert.ok('kind' in handshake && handshake.kind === 'accepted');
@@ -1002,6 +1045,7 @@ describe('non-serving Runtime Host kernel', () => {
           surface: 'tui',
           protocolMin: CURRENT_PROTOCOL.min,
           protocolMax: CURRENT_PROTOCOL.max,
+          compatibilityEpoch: 1,
         });
         const handshake = decodeHostFrame(await transport.read(2_000));
         assert.ok('kind' in handshake);
@@ -1131,6 +1175,7 @@ describe('non-serving Runtime Host kernel', () => {
           surface: 'tui',
           protocolMin: CURRENT_PROTOCOL.min,
           protocolMax: CURRENT_PROTOCOL.max,
+          compatibilityEpoch: 1,
         });
         const handshake = decodeHostFrame(await transport.read(2_000));
         assert.ok('kind' in handshake);
@@ -1173,6 +1218,7 @@ describe('non-serving Runtime Host kernel', () => {
             surface: 'inspect',
             protocolMin: CURRENT_PROTOCOL.min,
             protocolMax: CURRENT_PROTOCOL.max,
+            compatibilityEpoch: 1,
           });
           assert.deepEqual(decodeHostFrame(await rejectedHandshakeTransport.read(1_000)), {
             kind: 'draining',
@@ -1966,6 +2012,7 @@ async function openNonReadingStatusSocket(path: string): Promise<Socket> {
         surface: 'tui',
         protocolMin: CURRENT_PROTOCOL.min,
         protocolMax: CURRENT_PROTOCOL.max,
+        compatibilityEpoch: 1,
       })}\n`,
     );
   });
@@ -1981,6 +2028,10 @@ async function sendInvalidBootstrap(path: string, payload: Buffer): Promise<void
   const closed = new Promise<void>((resolve) => socket.once('close', () => resolve()));
   socket.write(payload);
   await withTimeout(closed, 1_000, 'Runtime Host did not close an invalid bootstrap connection');
+}
+
+function encodeLegacyProtocolFrame(frame: unknown): Buffer {
+  return Buffer.from(`${JSON.stringify(frame)}\n`, 'utf8');
 }
 
 async function removeControlDirectoriesForRootsUnder(base: string): Promise<void> {

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -15,6 +15,7 @@ import {
   negotiateProtocol,
   ProtocolFrameDecoder,
   RUNTIME_HOST_MAX_FRAME_BYTES,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   SESSION_CONTINUITY_SCHEMA_VERSION,
   SESSION_CONTINUITY_SNAPSHOT_MAX_BYTES,
@@ -107,6 +108,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'session.recap.generate',
       'session.remove',
       'session.revision.create',
+      'session.transcript.query',
       'skill.catalog.mutate',
       'skill.catalog.preview-update',
       'skill.catalog.query',
@@ -618,7 +620,7 @@ describe('Runtime Host bootstrap protocol', () => {
   test('decodes split UTF-8 and multiple newline-delimited frames without an unbounded tail', () => {
     const decoder = new ProtocolFrameDecoder();
     const wire = Buffer.from(
-      `${JSON.stringify({ kind: 'hello', clientInstanceId: '客户端', surface: 'tui', protocolMin: RUNTIME_HOST_PROTOCOL_VERSION, protocolMax: RUNTIME_HOST_PROTOCOL_VERSION })}\n` +
+      `${JSON.stringify({ kind: 'hello', clientInstanceId: '客户端', surface: 'tui', protocolMin: RUNTIME_HOST_PROTOCOL_VERSION, protocolMax: RUNTIME_HOST_PROTOCOL_VERSION, compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH })}\n` +
         `${JSON.stringify({ requestId: 'status-1', operation: 'host.status', input: {} })}\n`,
     );
     const split = wire.indexOf(Buffer.from('端')) + 1;
@@ -631,6 +633,7 @@ describe('Runtime Host bootstrap protocol', () => {
       surface: 'tui',
       protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
       protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
     });
     assert.deepEqual(decodeClientFrame(frames[1]), {
       requestId: 'status-1',
@@ -646,6 +649,7 @@ describe('Runtime Host bootstrap protocol', () => {
       hostEpoch: 'epoch-1',
       connectionId: 'connection-1',
       selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
+      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
       state: 'ready' as const,
     };
     assert.deepEqual(decodeHostFrame(accepted), accepted);
@@ -658,6 +662,7 @@ describe('Runtime Host bootstrap protocol', () => {
       endpoint: '/tmp/maka-runtime-host.sock',
       protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
       protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
       state: 'ready' as const,
       pid: 42,
       createdAt: '2026-07-23T00:00:00.000Z',

--- a/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
@@ -1033,6 +1033,7 @@ async function sendCreateWithoutReadingResponse(
     surface: 'desktop',
     protocolMin: CURRENT_PROTOCOL.min,
     protocolMax: CURRENT_PROTOCOL.max,
+    compatibilityEpoch: 1,
   });
   const handshake = decodeHostFrame(await transport.read(2_000));
   assert.ok('kind' in handshake);

--- a/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { setImmediate as delayImmediate } from 'node:timers/promises';
 import test from 'node:test';
-import type { SessionEvent, SessionHeader } from '@maka/core';
+import type { SessionEvent, SessionHeader, StoredMessage } from '@maka/core';
 import { TOOL_OUTPUT_DELTA_MAX_CHARS } from '@maka/core/events';
 import { PiAgentBackend, type PiAgentTransport } from '@maka/runtime';
 import {
@@ -9,6 +9,7 @@ import {
   encodeProtocolFrame,
   ProtocolFrameDecoder,
   RUNTIME_HOST_MAX_FRAME_BYTES,
+  type SessionTranscriptCursor,
   type SubscriptionFrame,
 } from '../protocol/index.js';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
@@ -407,6 +408,160 @@ test('removal closes every Session subscriber at the admitted sequence boundary'
   coordinator.close();
 });
 
+test('a joining Client receives an immutable transcript and absolute overlapping live offsets', async () => {
+  const transcript: StoredMessage[] = [assistantMessage('chunk-1')];
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+    undefined,
+    async () => transcript,
+  );
+
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(1));
+  const sink = new RecordingSink();
+  const connection = coordinator.attachConnection('connection-1', sink);
+  const opened = await open(coordinator, 'connection-1');
+  connection.activate(opened.subscriptionId);
+
+  const snapshot = await coordinator.handlers['session.transcript.query'](
+    { kind: 'start', subscriptionId: opened.subscriptionId },
+    connectionContext('connection-1'),
+  );
+  assert.equal(snapshot.ok, true);
+  if (!snapshot.ok) assert.fail('expected the transcript snapshot');
+  assert.equal(snapshot.result.kind, 'chunk');
+  if (snapshot.result.kind !== 'chunk') assert.fail('expected a transcript chunk');
+  assert.deepEqual(
+    JSON.parse(Buffer.from(snapshot.result.data, 'base64').toString('utf8')),
+    transcript[0],
+  );
+
+  transcript[0] = assistantMessage('mutated after snapshot');
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(2));
+  await waitFor(() => sink.frames.length === 1);
+  const live = sink.frames[0];
+  assert.equal(live?.kind, 'subscription.session_delta');
+  if (live?.kind === 'subscription.session_delta') {
+    assert.equal(live.delta.startOffset, 'chunk-1'.length);
+    assert.equal(live.delta.text, 'chunk-2');
+  }
+  coordinator.close();
+});
+
+test('transcript snapshots chunk one large message and remain subscription-owned', async () => {
+  const message = assistantMessage('界'.repeat(20_000));
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+    undefined,
+    async () => [message],
+  );
+  const owner = coordinator.attachConnection('connection-owner', new RecordingSink());
+  const sibling = coordinator.attachConnection('connection-sibling', new RecordingSink());
+  const opened = await open(coordinator, 'connection-owner');
+
+  const first = await coordinator.handlers['session.transcript.query'](
+    { kind: 'start', subscriptionId: opened.subscriptionId },
+    connectionContext('connection-owner'),
+  );
+  assert.equal(first.ok, true);
+  if (!first.ok) assert.fail('expected the first transcript chunk');
+  assert.equal(first.result.kind, 'chunk');
+  if (first.result.kind !== 'chunk') assert.fail('expected a transcript chunk');
+  assert.ok(first.result.next, 'expected the large message to require continuation');
+  if (!first.result.next) assert.fail('expected a continuation cursor');
+  const chunks = [Buffer.from(first.result.data, 'base64')];
+  let cursor: SessionTranscriptCursor | null = first.result.next;
+  while (cursor) {
+    const next = await coordinator.handlers['session.transcript.query'](
+      {
+        kind: 'continue',
+        subscriptionId: opened.subscriptionId,
+        snapshotId: first.result.snapshotId,
+        ...cursor,
+      },
+      connectionContext('connection-owner'),
+    );
+    assert.equal(next.ok, true);
+    if (!next.ok) assert.fail('expected a continuation transcript chunk');
+    assert.equal(next.result.kind, 'chunk');
+    if (next.result.kind !== 'chunk') assert.fail('expected a transcript chunk');
+    chunks.push(Buffer.from(next.result.data, 'base64'));
+    cursor = next.result.next;
+  }
+  assert.ok(chunks.length > 1);
+  assert.deepEqual(JSON.parse(Buffer.concat(chunks).toString('utf8')), message);
+
+  const foreign = await coordinator.handlers['session.transcript.query'](
+    { kind: 'start', subscriptionId: opened.subscriptionId },
+    connectionContext('connection-sibling'),
+  );
+  assert.deepEqual(foreign, {
+    ok: false,
+    error: { code: 'not_found', message: 'Session subscription was not found' },
+  });
+  owner.close();
+  sibling.close();
+  coordinator.close();
+});
+
+test('absolute live offsets survive a gap with no connected subscribers', async () => {
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+  );
+  const firstConnection = coordinator.attachConnection('connection-first', new RecordingSink());
+  const first = await open(coordinator, 'connection-first');
+  firstConnection.activate(first.subscriptionId);
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(1));
+  firstConnection.close();
+  await delayImmediate();
+
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(2));
+  const sink = new RecordingSink();
+  const secondConnection = coordinator.attachConnection('connection-second', sink);
+  const second = await open(coordinator, 'connection-second');
+  secondConnection.activate(second.subscriptionId);
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(3));
+  await waitFor(() => sink.frames.length === 1);
+
+  const frame = sink.frames[0];
+  assert.equal(frame?.kind, 'subscription.session_delta');
+  if (frame?.kind === 'subscription.session_delta') {
+    assert.equal(frame.delta.startOffset, 'chunk-1'.length + 'chunk-2'.length);
+  }
+  coordinator.close();
+});
+
+test('an in-flight transcript read cannot outlive its owning connection', async () => {
+  const transcript = deferred<readonly StoredMessage[]>();
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+    undefined,
+    () => transcript.promise,
+  );
+  const connection = coordinator.attachConnection('connection-1', new RecordingSink());
+  const opened = await open(coordinator, 'connection-1');
+  const reading = coordinator.handlers['session.transcript.query'](
+    { kind: 'start', subscriptionId: opened.subscriptionId },
+    connectionContext('connection-1'),
+  );
+  await delayImmediate();
+  connection.close();
+  transcript.resolve([assistantMessage('late snapshot')]);
+
+  assert.deepEqual(await reading, {
+    ok: false,
+    error: { code: 'not_found', message: 'Session subscription was not found' },
+  });
+  coordinator.close();
+});
+
 class RecordingSink implements SessionContinuityFrameSink {
   readonly frames: SubscriptionFrame[] = [];
 
@@ -523,6 +678,17 @@ function textEvent(index: number) {
     ts: index,
     messageId: 'message-1',
     text: `chunk-${index}`,
+  };
+}
+
+function assistantMessage(text: string): Extract<StoredMessage, { type: 'assistant' }> {
+  return {
+    type: 'assistant',
+    id: 'message-1',
+    turnId: 'turn-1',
+    ts: 1,
+    text,
+    modelId: 'test-model',
   };
 }
 

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -9,6 +9,7 @@ import {
   prepareStorageRootControlDirectory,
   resolveStorageRoot,
 } from '@maka/storage/root-authority';
+import { decodeStoredMessageForRead } from '@maka/core/session';
 import {
   connectRuntimeHost,
   RuntimeHostSubscriptionError,
@@ -203,6 +204,228 @@ test('ends every active subscription with connection_closed on EOF', async () =>
   );
 });
 
+test('loads a canonical transcript while live frames continue on the same connection', async () => {
+  const message = {
+    type: 'assistant' as const,
+    id: 'message-1',
+    turnId: 'turn-1',
+    ts: 1,
+    text: 'snapshot text',
+    modelId: 'test-model',
+  };
+  await withProtocolPeer(
+    async (transport, hostEpoch) => {
+      const openRequest = await acceptConnectionAndReadOpen(transport, hostEpoch);
+      const opened = openResult(hostEpoch, 'subscription-transcript');
+      await transport.write({
+        requestId: openRequest.requestId,
+        operation: 'subscription.open',
+        ok: true,
+        result: opened,
+      });
+      const transcriptRequest = decodeClientFrame(await transport.read(1_000));
+      assert.ok(!('kind' in transcriptRequest));
+      assert.equal(transcriptRequest.operation, 'session.transcript.query');
+      assert.deepEqual(transcriptRequest.input, {
+        kind: 'start',
+        subscriptionId: opened.subscriptionId,
+      });
+      await transport.writeEncoded(
+        Buffer.concat([
+          encodeProtocolFrame(deltaFrame(hostEpoch, opened.subscriptionId, 1)),
+          encodeProtocolFrame({
+            requestId: transcriptRequest.requestId,
+            operation: 'session.transcript.query',
+            ok: true,
+            result: {
+              kind: 'chunk',
+              snapshotId: 'snapshot-1',
+              sessionId: 'session-1',
+              messageCount: 1,
+              messageIndex: 0,
+              byteOffset: 0,
+              data: Buffer.from(JSON.stringify(message), 'utf8').toString('base64'),
+              next: null,
+            },
+          }),
+        ]),
+      );
+      await answerClose(transport, opened.subscriptionId);
+    },
+    async (connection) => {
+      const subscription = await connection.openSessionSubscription({ sessionId: 'session-1' });
+      assert.deepEqual(await subscription.loadTranscript(decodeStoredMessageForRead), [message]);
+      assert.deepEqual(await subscription[Symbol.asyncIterator]().next(), {
+        done: false,
+        value: deltaFrame(connection.hostEpoch, subscription.subscriptionId, 1),
+      });
+      await subscription.close();
+    },
+  );
+});
+
+test('restarts transcript loading after an expired snapshot', async () => {
+  const message = {
+    type: 'user' as const,
+    id: 'user-1',
+    turnId: 'turn-1',
+    ts: 1,
+    text: 'hello',
+  };
+  const encoded = Buffer.from(JSON.stringify(message), 'utf8');
+  const splitAt = Math.floor(encoded.byteLength / 2);
+  await withProtocolPeer(
+    async (transport, hostEpoch) => {
+      const openRequest = await acceptConnectionAndReadOpen(transport, hostEpoch);
+      const opened = openResult(hostEpoch, 'subscription-retry');
+      await transport.write({
+        requestId: openRequest.requestId,
+        operation: 'subscription.open',
+        ok: true,
+        result: opened,
+      });
+      const startRequest = decodeClientFrame(await transport.read(1_000));
+      assert.ok(!('kind' in startRequest));
+      assert.deepEqual(startRequest.input, {
+        kind: 'start',
+        subscriptionId: opened.subscriptionId,
+      });
+      await transport.write({
+        requestId: startRequest.requestId,
+        operation: 'session.transcript.query',
+        ok: true,
+        result: {
+          kind: 'chunk',
+          snapshotId: 'expired-snapshot',
+          sessionId: 'session-1',
+          messageCount: 1,
+          messageIndex: 0,
+          byteOffset: 0,
+          data: encoded.subarray(0, splitAt).toString('base64'),
+          next: { messageIndex: 0, byteOffset: splitAt },
+        },
+      });
+      const continuationRequest = decodeClientFrame(await transport.read(1_000));
+      assert.ok(!('kind' in continuationRequest));
+      assert.deepEqual(continuationRequest.input, {
+        kind: 'continue',
+        subscriptionId: opened.subscriptionId,
+        snapshotId: 'expired-snapshot',
+        messageIndex: 0,
+        byteOffset: splitAt,
+      });
+      await transport.write({
+        requestId: continuationRequest.requestId,
+        operation: 'session.transcript.query',
+        ok: true,
+        result: { kind: 'snapshot_expired', snapshotId: 'expired-snapshot' },
+      });
+      const retryStartRequest = decodeClientFrame(await transport.read(1_000));
+      assert.ok(!('kind' in retryStartRequest));
+      assert.deepEqual(retryStartRequest.input, {
+        kind: 'start',
+        subscriptionId: opened.subscriptionId,
+      });
+      await transport.write({
+        requestId: retryStartRequest.requestId,
+        operation: 'session.transcript.query',
+        ok: true,
+        result: {
+          kind: 'chunk',
+          snapshotId: 'snapshot-retry',
+          sessionId: 'session-1',
+          messageCount: 1,
+          messageIndex: 0,
+          byteOffset: 0,
+          data: encoded.toString('base64'),
+          next: null,
+        },
+      });
+      await answerClose(transport, opened.subscriptionId);
+    },
+    async (connection) => {
+      const subscription = await connection.openSessionSubscription({ sessionId: 'session-1' });
+      await assert.rejects(
+        () => subscription.loadTranscript(decodeStoredMessageForRead),
+        hasSubscriptionReason('transcript_expired'),
+      );
+      assert.deepEqual(await subscription.loadTranscript(decodeStoredMessageForRead), [message]);
+      await subscription.close();
+    },
+  );
+});
+
+test('forces a same-v0 pre-epoch Host through its incompatible replacement path', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-legacy-epoch-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'root'),
+    kind: 'interactive',
+  });
+  const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
+  const hostEpoch = randomUUID();
+  const endpoint = await prepareRuntimeHostEndpoint({ rootId: capability.rootId, hostEpoch });
+  const serverTask = deferred<void>();
+  const server = createServer((socket) => {
+    void (async () => {
+      const transport = new FramedTransport(socket);
+      const hello = decodeClientFrame(await transport.read(1_000));
+      assert.ok('kind' in hello && hello.kind === 'hello');
+      if (!('kind' in hello) || hello.kind !== 'hello') return;
+      assert.deepEqual(
+        { min: hello.protocolMin, max: hello.protocolMax },
+        { min: RUNTIME_HOST_PROTOCOL_VERSION + 1, max: RUNTIME_HOST_PROTOCOL_VERSION + 1 },
+      );
+      await transport.writeEncoded(
+        encodeLegacyProtocolFrame({
+          kind: 'incompatible',
+          hostEpoch,
+          protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
+          protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+          state: 'ready',
+          replacement: 'wait_for_idle_exit',
+        }),
+      );
+      transport.destroyAfterFlush();
+      await transport.closed;
+    })().then(serverTask.resolve, serverTask.reject);
+  });
+  try {
+    await listen(server, endpoint.path);
+    await endpoint.prepareAfterListen();
+    await writeHostRegistration(controlDirectory, {
+      kind: 'maka-runtime-host',
+      schemaVersion: RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
+      rootId: capability.rootId,
+      hostEpoch,
+      endpoint: endpoint.path,
+      protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
+      protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+      compatibilityEpoch: 0,
+      state: 'ready',
+      pid: process.pid,
+      createdAt: new Date().toISOString(),
+    });
+
+    const result = await connectRuntimeHost({
+      rootPath: join(base, 'root'),
+      surface: 'desktop',
+      protocol: PROTOCOL,
+    });
+    assert.equal(result.kind, 'incompatible');
+    if (result.kind === 'incompatible') {
+      assert.equal(result.registration.compatibilityEpoch, 0);
+      assert.equal(result.handshake.compatibilityEpoch, 0);
+      assert.equal(result.handshake.replacement, 'wait_for_idle_exit');
+    }
+    await serverTask.promise;
+  } finally {
+    await closeServer(server);
+    await removeHostRegistration(controlDirectory, hostEpoch).catch(() => undefined);
+    await endpoint.cleanup().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 async function withProtocolPeer(
   serve: (transport: FramedTransport, hostEpoch: string) => Promise<void>,
   run: (connection: RuntimeHostConnection) => Promise<void>,
@@ -233,6 +456,7 @@ async function withProtocolPeer(
       endpoint: endpoint.path,
       protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
       protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+      compatibilityEpoch: 1,
       state: 'ready',
       pid: process.pid,
       createdAt: new Date().toISOString(),
@@ -269,6 +493,7 @@ async function acceptConnectionAndReadOpen(
     hostEpoch,
     connectionId: 'connection-1',
     selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
+    compatibilityEpoch: 1,
     state: 'ready',
   });
   const request = decodeClientFrame(await transport.read(1_000));
@@ -358,6 +583,7 @@ function deltaFrame(
       turnId: 'turn-1',
       runId: 'run-1',
       messageId: 'message-1',
+      startOffset: 0,
       text: `chunk-${sequence}`,
     },
   };
@@ -366,6 +592,10 @@ function deltaFrame(
 function hasSubscriptionReason(reason: RuntimeHostSubscriptionError['reason']) {
   return (error: unknown) =>
     error instanceof RuntimeHostSubscriptionError && error.reason === reason;
+}
+
+function encodeLegacyProtocolFrame(frame: unknown): Buffer {
+  return Buffer.from(`${JSON.stringify(frame)}\n`, 'utf8');
 }
 
 function listen(server: Server, path: string): Promise<void> {

--- a/packages/runtime-host/src/__tests__/session-transcript-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-transcript-protocol.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  decodeSessionTranscriptQueryInput,
+  decodeSessionTranscriptQueryResult,
+  HOST_OPERATION_SPECS,
+  RuntimeHostProtocolError,
+  SESSION_TRANSCRIPT_CHUNK_MAX_BYTES,
+} from '../protocol/index.js';
+
+test('Session transcript protocol keeps exact bounded chunk cursors', () => {
+  assert.deepEqual(
+    decodeSessionTranscriptQueryInput({ kind: 'start', subscriptionId: 'subscription-1' }),
+    { kind: 'start', subscriptionId: 'subscription-1' },
+  );
+  const input = {
+    kind: 'continue' as const,
+    subscriptionId: 'subscription-1',
+    snapshotId: 'snapshot-1',
+    messageIndex: 2,
+    byteOffset: 3,
+  };
+  assert.deepEqual(decodeSessionTranscriptQueryInput(input), input);
+  const output = {
+    kind: 'chunk' as const,
+    snapshotId: 'snapshot-1',
+    sessionId: 'session-1',
+    messageCount: 4,
+    messageIndex: 2,
+    byteOffset: 3,
+    data: Buffer.alloc(SESSION_TRANSCRIPT_CHUNK_MAX_BYTES).toString('base64'),
+    next: { messageIndex: 3, byteOffset: 0 },
+  };
+  assert.deepEqual(decodeSessionTranscriptQueryResult(output), output);
+  assert.doesNotThrow(() =>
+    HOST_OPERATION_SPECS['session.transcript.query'].assertOutputForInput?.(input, output),
+  );
+});
+
+test('Session transcript protocol rejects open, malformed, and uncorrelated values', () => {
+  assert.throws(
+    () =>
+      decodeSessionTranscriptQueryInput({
+        kind: 'start',
+        subscriptionId: 'subscription-1',
+        sessionId: 'session-1',
+      }),
+    isProtocolError,
+  );
+  assert.throws(
+    () =>
+      decodeSessionTranscriptQueryResult({
+        kind: 'chunk',
+        snapshotId: 'snapshot-1',
+        sessionId: 'session-1',
+        messageCount: 1,
+        messageIndex: 0,
+        byteOffset: 0,
+        data: 'not base64',
+        next: null,
+      }),
+    isProtocolError,
+  );
+  assert.throws(
+    () =>
+      HOST_OPERATION_SPECS['session.transcript.query'].assertOutputForInput?.(
+        {
+          kind: 'continue',
+          subscriptionId: 'subscription-1',
+          snapshotId: 'snapshot-1',
+          messageIndex: 0,
+          byteOffset: 4,
+        },
+        {
+          kind: 'snapshot_expired',
+          snapshotId: 'different-snapshot',
+        },
+      ),
+    isProtocolError,
+  );
+});
+
+function isProtocolError(error: unknown): boolean {
+  return error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame';
+}

--- a/packages/runtime-host/src/__tests__/session-transcript-reader.test.ts
+++ b/packages/runtime-host/src/__tests__/session-transcript-reader.test.ts
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import type { AgentRunHeader, RuntimeEvent } from '@maka/core';
+import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import { createSessionTranscriptReader } from '../server/session-transcript-reader.js';
+
+test('projects canonical active text and thinking snapshots over Session history', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-session-transcript-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'root'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) assert.fail('expected the interactive root owner');
+  try {
+    const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const session = await stores.sessionStore.create({
+      cwd: capability.canonicalPath,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    await stores.sessionStore.appendMessage(session.id, {
+      type: 'system_note',
+      id: 'history-1',
+      ts: 1,
+      kind: 'session_start',
+    });
+    await stores.agentRunStore.createRun(runHeader(session.id));
+    await stores.runtimeEventStore.appendRuntimeEvent(
+      session.id,
+      'run-1',
+      runtimeEvent(session.id, {
+        id: 'user-event-1',
+        ts: 2,
+        role: 'user',
+        author: 'user',
+        content: { kind: 'text', text: 'hello' },
+        refs: { storedMessageId: 'user-1' },
+      }),
+    );
+    await stores.runtimeEventStore.appendRuntimeEvent(
+      session.id,
+      'run-1',
+      runtimeEvent(session.id, {
+        id: 'thinking-partial-1',
+        ts: 3,
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'thinking', text: 'deep ' },
+        refs: { providerEventId: 'assistant-1' },
+      }),
+    );
+    await stores.runtimeEventStore.appendRuntimeEvent(
+      session.id,
+      'run-1',
+      runtimeEvent(session.id, {
+        id: 'thinking-partial-2',
+        ts: 4,
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'thinking', text: 'thought' },
+        refs: { providerEventId: 'assistant-1' },
+      }),
+    );
+    await stores.runtimeEventStore.appendRuntimeEvent(
+      session.id,
+      'run-1',
+      runtimeEvent(session.id, {
+        id: 'text-partial-1',
+        ts: 5,
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'still ' },
+        refs: { providerEventId: 'assistant-1' },
+      }),
+    );
+    await stores.runtimeEventStore.appendRuntimeEvent(
+      session.id,
+      'run-1',
+      runtimeEvent(session.id, {
+        id: 'text-partial-2',
+        ts: 6,
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'streaming' },
+        refs: { providerEventId: 'assistant-1' },
+      }),
+    );
+    await stores.runtimeEventStore.appendRuntimeEvent(
+      session.id,
+      'run-1',
+      runtimeEvent(session.id, {
+        id: 'thinking-only-1',
+        ts: 7,
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'thinking', text: 'still ' },
+        refs: { providerEventId: 'assistant-2' },
+      }),
+    );
+    await stores.runtimeEventStore.appendRuntimeEvent(
+      session.id,
+      'run-1',
+      runtimeEvent(session.id, {
+        id: 'superseded-text-partial',
+        ts: 9,
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'not final' },
+        refs: { providerEventId: 'assistant-3' },
+      }),
+    );
+    await stores.runtimeEventStore.appendRuntimeEvent(
+      session.id,
+      'run-1',
+      runtimeEvent(session.id, {
+        id: 'complete-text',
+        ts: 10,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'final text' },
+        refs: { providerEventId: 'assistant-3' },
+      }),
+    );
+    await stores.runtimeEventStore.appendRuntimeEvent(
+      session.id,
+      'run-1',
+      runtimeEvent(session.id, {
+        id: 'thinking-only-2',
+        ts: 8,
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'thinking', text: 'reasoning' },
+        refs: { providerEventId: 'assistant-2' },
+      }),
+    );
+
+    const read = createSessionTranscriptReader({
+      stores,
+      canonicalPermissionOutcomes: { readPermissionOutcome: async () => undefined },
+    });
+    const messages = await read(session.id, {
+      sessionId: session.id,
+      turnId: 'turn-1',
+      runId: 'run-1',
+      status: 'running',
+    });
+
+    assert.deepEqual(
+      messages.map((message) => ({ type: message.type, id: message.id })),
+      [
+        { type: 'system_note', id: 'history-1' },
+        { type: 'user', id: 'user-1' },
+        { type: 'assistant', id: 'assistant-1' },
+        { type: 'assistant', id: 'assistant-2' },
+        { type: 'assistant', id: 'assistant-3' },
+      ],
+    );
+    const firstAssistant = messages.at(-3);
+    assert.equal(firstAssistant?.type, 'assistant');
+    if (firstAssistant?.type === 'assistant') {
+      assert.equal(firstAssistant.text, 'still streaming');
+      assert.equal(firstAssistant.thinking?.text, 'deep thought');
+    }
+    const thinkingOnly = messages.at(-2);
+    assert.equal(thinkingOnly?.type, 'assistant');
+    if (thinkingOnly?.type === 'assistant') {
+      assert.equal(thinkingOnly.text, '');
+      assert.equal(thinkingOnly.thinking?.text, 'still reasoning');
+    }
+    const completed = messages.at(-1);
+    assert.equal(completed?.type, 'assistant');
+    if (completed?.type === 'assistant') assert.equal(completed.text, 'final text');
+  } finally {
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+function runHeader(sessionId: string): AgentRunHeader {
+  return {
+    runId: 'run-1',
+    invocationId: 'run-1',
+    sessionId,
+    turnId: 'turn-1',
+    status: 'running',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/tmp',
+    permissionMode: 'ask',
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function runtimeEvent(sessionId: string, overrides: Partial<RuntimeEvent>): RuntimeEvent {
+  return {
+    id: 'event-1',
+    invocationId: 'run-1',
+    sessionId,
+    turnId: 'turn-1',
+    runId: 'run-1',
+    ts: 1,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}

--- a/packages/runtime-host/src/__tests__/transcript-snapshot-store.test.ts
+++ b/packages/runtime-host/src/__tests__/transcript-snapshot-store.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { StoredMessage } from '@maka/core/session';
+import { TranscriptSnapshotStore } from '../server/transcript-snapshot-store.js';
+
+test('expires idle snapshots against an injected clock', () => {
+  let now = 1;
+  const store = new TranscriptSnapshotStore(() => now);
+  const first = store.start(snapshotInput('connection-1', 'subscription-1'));
+  assert.equal(first.ok, true);
+  if (!first.ok) assert.fail('expected the first transcript chunk');
+  assert.equal(first.result.kind, 'chunk');
+  if (first.result.kind !== 'chunk') assert.fail('expected a transcript chunk');
+  assert.ok(first.result.next, 'expected a continuation cursor');
+  if (!first.result.next) assert.fail('expected a continuation cursor');
+
+  now += 60_000;
+  const expired = store.continue({
+    connectionId: 'connection-1',
+    subscriptionId: 'subscription-1',
+    snapshotId: first.result.snapshotId,
+    cursor: first.result.next,
+  });
+  assert.deepEqual(expired, {
+    ok: true,
+    result: { kind: 'snapshot_expired', snapshotId: first.result.snapshotId },
+  });
+  store.close();
+});
+
+test('bounds retained snapshots per connection and releases them with the connection', () => {
+  const store = new TranscriptSnapshotStore();
+  for (let index = 0; index < 4; index += 1) {
+    const started = store.start(snapshotInput('connection-1', `subscription-${index}`));
+    assert.equal(started.ok, true);
+  }
+  const bounded = store.start(snapshotInput('connection-1', 'subscription-5'));
+  assert.deepEqual(bounded, {
+    ok: false,
+    error: {
+      code: 'operation_conflict',
+      message: 'Runtime Host connection transcript snapshot limit reached',
+    },
+  });
+
+  store.deleteConnection('connection-1');
+  assert.equal(store.start(snapshotInput('connection-1', 'subscription-new')).ok, true);
+  store.close();
+});
+
+function snapshotInput(connectionId: string, subscriptionId: string) {
+  return {
+    connectionId,
+    subscriptionId,
+    sessionId: 'session-1',
+    messages: [assistantMessage('x'.repeat(30_000))],
+  };
+}
+
+function assistantMessage(text: string): Extract<StoredMessage, { type: 'assistant' }> {
+  return {
+    type: 'assistant',
+    id: 'assistant-1',
+    turnId: 'turn-1',
+    ts: 1,
+    text,
+    modelId: 'test-model',
+  };
+}

--- a/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
@@ -280,6 +280,7 @@ async function withProtocolPeer(
       endpoint: endpoint.path,
       protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
       protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+      compatibilityEpoch: 1,
       state: 'ready',
       pid: process.pid,
       createdAt: new Date().toISOString(),
@@ -316,6 +317,7 @@ async function acceptConnectionAndReadRequest(
     hostEpoch,
     connectionId: 'usage-pricing-correlation',
     selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
+    compatibilityEpoch: 1,
     state: 'ready',
   });
   const request = decodeClientFrame(await transport.read(REQUEST_TIMEOUT_MS));

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -31,6 +31,7 @@ import {
   type HostRegistration,
   type HostStatusResult,
   HOST_OPERATION_SPECS,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   type OperationInput,
   type OperationKey,
   type OperationOutput,
@@ -437,8 +438,10 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
           'Runtime Host returned a duplicate subscription identity',
         );
       }
-      const subscription = new ClientSessionSubscription(result, () =>
-        this.#closeSessionSubscription(result.subscriptionId),
+      const subscription = new ClientSessionSubscription(
+        result,
+        () => this.#closeSessionSubscription(result.subscriptionId),
+        (query) => this.request('session.transcript.query', query, timeoutMs),
       );
       this.#subscriptions.set(result.subscriptionId, subscription);
       return subscription;
@@ -740,12 +743,20 @@ export async function connectResolvedRuntimeHost(
     transport.destroy(handshakeTimeoutError);
   }, handshakeBudget);
   try {
+    const staleCompatibility = registration.compatibilityEpoch !== RUNTIME_HOST_COMPATIBILITY_EPOCH;
+    const helloProtocol = staleCompatibility
+      ? {
+          min: Math.min(Number.MAX_SAFE_INTEGER, registration.protocolMax + 1),
+          max: Math.min(Number.MAX_SAFE_INTEGER, registration.protocolMax + 1),
+        }
+      : input.protocol;
     await transport.write({
       kind: 'hello',
       clientInstanceId: input.clientInstanceId,
       surface: input.surface,
-      protocolMin: input.protocol.min,
-      protocolMax: input.protocol.max,
+      protocolMin: helloProtocol.min,
+      protocolMax: helloProtocol.max,
+      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
     });
     if (remainingTimeout(handshakeDeadline.at) === undefined) {
       throw handshakeDeadline.exhaustsElection
@@ -768,6 +779,9 @@ export async function connectResolvedRuntimeHost(
       return { kind: 'unavailable', reason: 'epoch_mismatch', registration };
     }
     if (handshake.kind === 'accepted') {
+      if (staleCompatibility || handshake.compatibilityEpoch !== RUNTIME_HOST_COMPATIBILITY_EPOCH) {
+        throw new Error('Runtime Host accepted an incompatible schema epoch');
+      }
       if (
         handshake.selectedProtocol < input.protocol.min ||
         handshake.selectedProtocol > input.protocol.max ||

--- a/packages/runtime-host/src/client/session-subscription.ts
+++ b/packages/runtime-host/src/client/session-subscription.ts
@@ -3,6 +3,8 @@ import {
   type SessionContinuitySnapshot,
   type SubscriptionFrame,
   type SubscriptionOpenResult,
+  type SessionTranscriptQueryInput,
+  type SessionTranscriptQueryResult,
 } from '../protocol/index.js';
 
 const MAX_CLIENT_QUEUED_FRAMES = 32;
@@ -14,7 +16,8 @@ export type RuntimeHostSubscriptionFailureReason =
   | 'correlation_changed'
   | 'projection_revision_invalid'
   | 'slow_consumer'
-  | 'connection_closed';
+  | 'connection_closed'
+  | 'transcript_expired';
 
 export class RuntimeHostSubscriptionError extends Error {
   constructor(
@@ -26,10 +29,19 @@ export class RuntimeHostSubscriptionError extends Error {
   }
 }
 
+function bufferLength(chunks: readonly Buffer[]): number {
+  return chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export interface RuntimeHostSessionSubscription extends AsyncIterable<SubscriptionFrame> {
   readonly hostEpoch: string;
   readonly subscriptionId: string;
   readonly snapshot: SessionContinuitySnapshot;
+  loadTranscript<T>(decodeMessage: (value: unknown) => T): Promise<T[]>;
   close(): Promise<void>;
 }
 
@@ -45,6 +57,9 @@ export class ClientSessionSubscription
   readonly subscriptionId: string;
   readonly snapshot: SessionContinuitySnapshot;
   readonly #requestClose: () => Promise<void>;
+  readonly #queryTranscript: (
+    input: SessionTranscriptQueryInput,
+  ) => Promise<SessionTranscriptQueryResult>;
   readonly #expectedSessionId: string;
   readonly #queue: QueuedFrame[] = [];
   #queuedBytes = 0;
@@ -60,8 +75,13 @@ export class ClientSessionSubscription
   #done = false;
   #doneAfterQueue = false;
   #closeTask: Promise<void> | undefined;
+  #transcriptTask: Promise<unknown[]> | undefined;
 
-  constructor(result: SubscriptionOpenResult, requestClose: () => Promise<void>) {
+  constructor(
+    result: SubscriptionOpenResult,
+    requestClose: () => Promise<void>,
+    queryTranscript: (input: SessionTranscriptQueryInput) => Promise<SessionTranscriptQueryResult>,
+  ) {
     this.hostEpoch = result.hostEpoch;
     this.subscriptionId = result.subscriptionId;
     this.snapshot = result.snapshot;
@@ -69,6 +89,7 @@ export class ClientSessionSubscription
     this.#expectedSequence = result.nextSequence;
     this.#latestProjectionRevision = result.snapshot.projectionRevision;
     this.#requestClose = requestClose;
+    this.#queryTranscript = queryTranscript;
   }
 
   [Symbol.asyncIterator](): AsyncIterator<SubscriptionFrame> {
@@ -104,6 +125,84 @@ export class ClientSessionSubscription
     if (this.#done || this.#terminalError) return Promise.resolve();
     if (!this.#closeTask) this.#closeTask = this.#requestClose();
     return this.#closeTask;
+  }
+
+  loadTranscript<T>(decodeMessage: (value: unknown) => T): Promise<T[]> {
+    this.#transcriptTask ??= this.#loadTranscript().catch((error: unknown) => {
+      this.#transcriptTask = undefined;
+      throw error;
+    });
+    return this.#transcriptTask.then((messages) => messages.map(decodeMessage));
+  }
+
+  async #loadTranscript(): Promise<unknown[]> {
+    let result = await this.#queryTranscript({
+      kind: 'start',
+      subscriptionId: this.subscriptionId,
+    });
+    let snapshotId: string | undefined;
+    let messageCount: number | undefined;
+    let chunks: Buffer[] = [];
+    const messages: unknown[] = [];
+    while (true) {
+      if (result.kind === 'snapshot_expired') {
+        throw new RuntimeHostSubscriptionError(
+          'transcript_expired',
+          'Session transcript snapshot expired before it was consumed',
+        );
+      }
+      if (result.sessionId !== this.#expectedSessionId) {
+        throw new RuntimeHostSubscriptionError(
+          'correlation_changed',
+          'Session transcript belongs to a different Session',
+        );
+      }
+      snapshotId ??= result.snapshotId;
+      messageCount ??= result.messageCount;
+      if (result.snapshotId !== snapshotId || result.messageCount !== messageCount) {
+        throw new RuntimeHostSubscriptionError(
+          'correlation_changed',
+          'Session transcript snapshot identity changed',
+        );
+      }
+      if (result.messageCount === 0) return [];
+      if (result.messageIndex !== messages.length || result.byteOffset !== bufferLength(chunks)) {
+        throw new RuntimeHostSubscriptionError(
+          'correlation_changed',
+          'Session transcript chunk position changed',
+        );
+      }
+      chunks.push(Buffer.from(result.data, 'base64'));
+      if (result.next?.messageIndex !== result.messageIndex) {
+        const bytes = Buffer.concat(chunks);
+        let decoded: unknown;
+        try {
+          decoded = JSON.parse(bytes.toString('utf8')) as unknown;
+        } catch (cause) {
+          throw new RuntimeHostSubscriptionError(
+            'correlation_changed',
+            `Session transcript message is invalid JSON: ${errorMessage(cause)}`,
+          );
+        }
+        messages.push(decoded);
+        chunks = [];
+      }
+      if (!result.next) {
+        if (messages.length !== messageCount) {
+          throw new RuntimeHostSubscriptionError(
+            'correlation_changed',
+            'Session transcript ended before every message was received',
+          );
+        }
+        return messages;
+      }
+      result = await this.#queryTranscript({
+        kind: 'continue',
+        subscriptionId: this.subscriptionId,
+        snapshotId,
+        ...result.next,
+      });
+    }
   }
 
   accept(frame: SubscriptionFrame): void {

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -37,10 +37,15 @@ export * from './operations.js';
 export * from './runtime-resource.js';
 export * from './session-continuity.js';
 export * from './session-retirement.js';
+export * from './session-transcript.js';
 export * from './task-ledger.js';
 
 export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
+// The wire version remains v0 before the first release. This independent epoch
+// lets a new Client retire a stale same-version Host whose closed schema is no
+// longer safe to use.
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 1 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such
@@ -60,6 +65,8 @@ export interface ClientHello {
   surface: ClientSurface;
   protocolMin: number;
   protocolMax: number;
+  /** A missing pre-epoch v0 wire field is decoded as epoch 0. */
+  compatibilityEpoch: number;
 }
 
 export interface HostAccepted {
@@ -67,6 +74,8 @@ export interface HostAccepted {
   hostEpoch: string;
   connectionId: string;
   selectedProtocol: number;
+  /** A missing pre-epoch v0 wire field is decoded as epoch 0. */
+  compatibilityEpoch: number;
   state: Exclude<HostLifecycleState, 'draining'>;
 }
 
@@ -75,6 +84,8 @@ export interface HostIncompatible {
   hostEpoch: string;
   protocolMin: number;
   protocolMax: number;
+  /** A missing pre-epoch v0 wire field is decoded as epoch 0. */
+  compatibilityEpoch: number;
   state: HostLifecycleState;
   replacement: 'blocked_by_residency' | 'wait_for_idle_exit';
 }
@@ -101,6 +112,8 @@ export interface HostRegistration {
   endpoint: string;
   protocolMin: number;
   protocolMax: number;
+  /** A missing pre-epoch v0 registration field is decoded as epoch 0. */
+  compatibilityEpoch: number;
   state: HostLifecycleState;
   pid: number;
   createdAt: string;
@@ -140,6 +153,7 @@ export function decodeClientFrame(value: unknown): ClientFrame {
       surface: requireSurface(frame.surface),
       protocolMin,
       protocolMax,
+      compatibilityEpoch: decodeCompatibilityEpoch(frame.compatibilityEpoch),
     } satisfies ClientHello;
   }
   if (isClientCapabilityClientFrameKind(frame.kind)) {
@@ -156,6 +170,7 @@ export function decodeHostFrame(value: unknown): HostFrame {
       hostEpoch: requireId(frame.hostEpoch, 'hostEpoch'),
       connectionId: requireId(frame.connectionId, 'connectionId'),
       selectedProtocol: requireProtocolVersion(frame.selectedProtocol, 'selectedProtocol'),
+      compatibilityEpoch: decodeCompatibilityEpoch(frame.compatibilityEpoch),
       state: requireAcceptedState(frame.state),
     } satisfies HostAccepted;
   }
@@ -168,6 +183,7 @@ export function decodeHostFrame(value: unknown): HostFrame {
       hostEpoch: requireId(frame.hostEpoch, 'hostEpoch'),
       protocolMin,
       protocolMax,
+      compatibilityEpoch: decodeCompatibilityEpoch(frame.compatibilityEpoch),
       state: requireHostLifecycleState(frame.state),
       replacement: requireReplacement(frame.replacement),
     } satisfies HostIncompatible;
@@ -208,6 +224,10 @@ export function decodeHostRegistration(value: unknown): HostRegistration {
     endpoint: requireString(registration.endpoint, 'endpoint', 512),
     protocolMin,
     protocolMax,
+    compatibilityEpoch:
+      registration.compatibilityEpoch === undefined
+        ? 0
+        : requireCompatibilityEpoch(registration.compatibilityEpoch),
     state: requireHostLifecycleState(registration.state),
     pid,
     createdAt: requireString(registration.createdAt, 'createdAt', 64),
@@ -288,6 +308,16 @@ function requireProtocolVersion(value: unknown, label: string): number {
     throw invalidProtocolFrame(`Invalid ${label}`);
   }
   return value as number;
+}
+
+function requireCompatibilityEpoch(value: unknown): number {
+  const epoch = requireProtocolVersion(value, 'compatibilityEpoch');
+  if (epoch > 1_000_000) throw invalidProtocolFrame('Invalid compatibilityEpoch');
+  return epoch;
+}
+
+function decodeCompatibilityEpoch(value: unknown): number {
+  return value === undefined ? 0 : requireCompatibilityEpoch(value);
 }
 
 function requireSurface(value: unknown): ClientSurface {

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -26,6 +26,7 @@ import { RUNTIME_POLICY_OPERATION_SPECS } from './runtime-policy.js';
 import { RUNTIME_RESOURCE_OPERATION_SPECS } from './runtime-resource.js';
 import { SESSION_CATALOG_OPERATION_SPECS } from './session-catalog.js';
 import { SESSION_CONTINUITY_OPERATION_SPECS } from './session-continuity.js';
+import { SESSION_TRANSCRIPT_OPERATION_SPECS } from './session-transcript.js';
 import { SESSION_REVISION_OPERATION_SPECS } from './session-revision.js';
 import { SESSION_RETIREMENT_OPERATION_SPECS } from './session-retirement.js';
 import { SESSION_EFFECT_OPERATION_SPECS } from './session-effects.js';
@@ -123,6 +124,7 @@ export * from './runtime-resource.js';
 export * from './session-catalog.js';
 export * from './session-revision.js';
 export * from './session-retirement.js';
+export * from './session-transcript.js';
 export * from './session-effects.js';
 export * from './skill-catalog.js';
 export * from './usage-pricing.js';
@@ -145,6 +147,7 @@ export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   TASK_LEDGER_OPERATION_SPECS,
   INTERACTION_OPERATION_SPECS,
   SESSION_CONTINUITY_OPERATION_SPECS,
+  SESSION_TRANSCRIPT_OPERATION_SPECS,
   SESSION_CATALOG_OPERATION_SPECS,
   SESSION_EFFECT_OPERATION_SPECS,
   SESSION_REVISION_OPERATION_SPECS,

--- a/packages/runtime-host/src/protocol/session-continuity.ts
+++ b/packages/runtime-host/src/protocol/session-continuity.ts
@@ -95,6 +95,7 @@ export interface SessionAssistantDelta {
   turnId: string;
   runId: string;
   messageId: string;
+  startOffset: number;
   text: string;
 }
 
@@ -383,6 +384,7 @@ function decodeAssistantDelta(value: unknown): SessionAssistantDelta {
     'turnId',
     'runId',
     'messageId',
+    'startOffset',
     'text',
   ]);
   if (record.kind !== 'text' && record.kind !== 'thinking') {
@@ -393,6 +395,7 @@ function decodeAssistantDelta(value: unknown): SessionAssistantDelta {
     turnId: requireEntityId(record.turnId, 'turnId'),
     runId: requireEntityId(record.runId, 'runId'),
     messageId: requireEntityId(record.messageId, 'messageId'),
+    startOffset: requireCount(record.startOffset, 'Session assistant delta start offset'),
     text: requireUtf8BoundedString(
       record.text,
       'Session assistant delta text',

--- a/packages/runtime-host/src/protocol/session-transcript.ts
+++ b/packages/runtime-host/src/protocol/session-transcript.ts
@@ -1,0 +1,185 @@
+import { requireCount, requireEntityId, requireExactRecord, requireRecord } from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const SESSION_TRANSCRIPT_CHUNK_MAX_BYTES = 24 * 1024;
+export const SESSION_TRANSCRIPT_RESULT_MAX_BYTES = 48 * 1024;
+
+export interface SessionTranscriptCursor {
+  messageIndex: number;
+  byteOffset: number;
+}
+
+export type SessionTranscriptQueryInput =
+  | { kind: 'start'; subscriptionId: string }
+  | {
+      kind: 'continue';
+      subscriptionId: string;
+      snapshotId: string;
+      messageIndex: number;
+      byteOffset: number;
+    };
+
+export type SessionTranscriptQueryResult =
+  | {
+      kind: 'chunk';
+      snapshotId: string;
+      sessionId: string;
+      messageCount: number;
+      messageIndex: number;
+      byteOffset: number;
+      data: string;
+      next: SessionTranscriptCursor | null;
+    }
+  | { kind: 'snapshot_expired'; snapshotId: string };
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'invalid_request',
+  'not_found',
+  'operation_conflict',
+  'persistence_failed',
+  'internal_failure',
+] as const;
+
+export const SESSION_TRANSCRIPT_OPERATION_SPECS = {
+  'session.transcript.query': defineOperation({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeSessionTranscriptQueryInput,
+    decodeOutput: decodeSessionTranscriptQueryResult,
+    assertOutputForInput: assertSessionTranscriptOutput,
+  }),
+} as const;
+
+export function decodeSessionTranscriptQueryInput(value: unknown): SessionTranscriptQueryInput {
+  const input = requireRecord(value, 'Session transcript query input');
+  if (input.kind === 'start') {
+    const exact = requireExactRecord(input, 'Session transcript start input', [
+      'kind',
+      'subscriptionId',
+    ]);
+    return {
+      kind: 'start',
+      subscriptionId: requireEntityId(exact.subscriptionId, 'subscriptionId'),
+    };
+  }
+  if (input.kind === 'continue') {
+    const exact = requireExactRecord(input, 'Session transcript continuation input', [
+      'kind',
+      'subscriptionId',
+      'snapshotId',
+      'messageIndex',
+      'byteOffset',
+    ]);
+    return {
+      kind: 'continue',
+      subscriptionId: requireEntityId(exact.subscriptionId, 'subscriptionId'),
+      snapshotId: requireEntityId(exact.snapshotId, 'Session transcript snapshotId'),
+      messageIndex: requireCount(exact.messageIndex, 'Session transcript message index'),
+      byteOffset: requireCount(exact.byteOffset, 'Session transcript byte offset'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid Session transcript query kind');
+}
+
+export function decodeSessionTranscriptQueryResult(value: unknown): SessionTranscriptQueryResult {
+  const result = requireRecord(value, 'Session transcript query result');
+  if (result.kind === 'snapshot_expired') {
+    const exact = requireExactRecord(result, 'expired Session transcript snapshot', [
+      'kind',
+      'snapshotId',
+    ]);
+    return {
+      kind: 'snapshot_expired',
+      snapshotId: requireEntityId(exact.snapshotId, 'Session transcript snapshotId'),
+    };
+  }
+  if (result.kind !== 'chunk') {
+    throw invalidProtocolFrame('Invalid Session transcript query result kind');
+  }
+  const exact = requireExactRecord(result, 'Session transcript chunk', [
+    'kind',
+    'snapshotId',
+    'sessionId',
+    'messageCount',
+    'messageIndex',
+    'byteOffset',
+    'data',
+    'next',
+  ]);
+  const messageCount = requireCount(exact.messageCount, 'Session transcript message count');
+  const messageIndex = requireCount(exact.messageIndex, 'Session transcript message index');
+  const byteOffset = requireCount(exact.byteOffset, 'Session transcript byte offset');
+  const data = requireBase64Chunk(exact.data);
+  const next = exact.next === null ? null : decodeSessionTranscriptCursor(exact.next);
+  if (messageCount === 0) {
+    if (messageIndex !== 0 || byteOffset !== 0 || data.length !== 0 || next !== null) {
+      throw invalidProtocolFrame('Invalid empty Session transcript chunk');
+    }
+  } else if (messageIndex >= messageCount || data.length === 0) {
+    throw invalidProtocolFrame('Invalid Session transcript chunk position');
+  }
+  const decoded: SessionTranscriptQueryResult = {
+    kind: 'chunk',
+    snapshotId: requireEntityId(exact.snapshotId, 'Session transcript snapshotId'),
+    sessionId: requireEntityId(exact.sessionId, 'sessionId'),
+    messageCount,
+    messageIndex,
+    byteOffset,
+    data,
+    next,
+  };
+  if (Buffer.byteLength(JSON.stringify(decoded), 'utf8') > SESSION_TRANSCRIPT_RESULT_MAX_BYTES) {
+    throw invalidProtocolFrame('Session transcript result exceeds byte limit');
+  }
+  return decoded;
+}
+
+function decodeSessionTranscriptCursor(value: unknown): SessionTranscriptCursor {
+  const cursor = requireExactRecord(value, 'Session transcript cursor', [
+    'messageIndex',
+    'byteOffset',
+  ]);
+  return {
+    messageIndex: requireCount(cursor.messageIndex, 'Session transcript cursor message index'),
+    byteOffset: requireCount(cursor.byteOffset, 'Session transcript cursor byte offset'),
+  };
+}
+
+function requireBase64Chunk(value: unknown): string {
+  if (typeof value !== 'string')
+    throw invalidProtocolFrame('Invalid Session transcript chunk data');
+  if (value.length === 0) return value;
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+    throw invalidProtocolFrame('Invalid Session transcript chunk encoding');
+  }
+  const bytes = Buffer.from(value, 'base64');
+  if (bytes.byteLength > SESSION_TRANSCRIPT_CHUNK_MAX_BYTES || bytes.toString('base64') !== value) {
+    throw invalidProtocolFrame('Invalid Session transcript chunk data');
+  }
+  return value;
+}
+
+function assertSessionTranscriptOutput(
+  input: SessionTranscriptQueryInput,
+  output: SessionTranscriptQueryResult,
+): void {
+  if (input.kind !== 'continue') return;
+  if (output.kind === 'snapshot_expired') {
+    if (output.snapshotId !== input.snapshotId) {
+      throw invalidProtocolFrame('Expired Session transcript snapshot does not match request');
+    }
+    return;
+  }
+  if (
+    output.snapshotId !== input.snapshotId ||
+    output.messageIndex !== input.messageIndex ||
+    output.byteOffset !== input.byteOffset
+  ) {
+    throw invalidProtocolFrame('Session transcript chunk does not match request');
+  }
+}

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -144,7 +144,9 @@ export class RuntimeHostConnectionSession {
     try {
       if (this.#closed) return;
       const continuity =
-        frame.operation === 'subscription.open' || frame.operation === 'subscription.close'
+        frame.operation === 'subscription.open' ||
+        frame.operation === 'subscription.close' ||
+        frame.operation === 'session.transcript.query'
           ? this.#ensureContinuity()
           : undefined;
       if (

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -91,6 +91,7 @@ import { HostSessionRetirementCoordinator } from './session-retirement-coordinat
 import { HostSessionRevisionCoordinator } from './session-revision-coordinator.js';
 import { HostSessionEffectCoordinator } from './session-effect-coordinator.js';
 import { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
+import { createSessionTranscriptReader } from './session-transcript-reader.js';
 import { HostSkillCatalogCoordinator } from './skill-catalog-coordinator.js';
 import { SkillCatalogRepository } from './skill-catalog-repository.js';
 import { HostTaskLedgerCoordinator } from './task-ledger-coordinator.js';
@@ -280,11 +281,15 @@ export async function createExecutionRuntimeHostComposition(
       readGoal: (sessionId) => requireGoal(goal).readProjection(sessionId),
     });
     canonicalProjection = canonicalProjectionReader;
+    const canonicalPermissionOutcomes = new HostCanonicalPermissionOutcomeReader({
+      store: stores.interactionStore,
+    });
     continuity = new SessionContinuityCoordinator(
       context.hostEpoch,
       (sessionId) => canonicalProjectionReader.read(sessionId),
       sessionAdmission,
       context.requestDrain,
+      createSessionTranscriptReader({ stores, canonicalPermissionOutcomes }),
     );
     const continuityCoordinator = continuity;
     deepResearch = new HostDeepResearchCoordinator({
@@ -355,9 +360,6 @@ export async function createExecutionRuntimeHostComposition(
         notifySandboxBoundaryGraphWake(sessionId, stores.sessionStore, (rootSessionId) =>
           requireGraphSupervisorWake(graphSupervisorWake).notifyPermissionResponse(rootSessionId),
         ),
-    });
-    const canonicalPermissionOutcomes = new HostCanonicalPermissionOutcomeReader({
-      store: stores.interactionStore,
     });
     memory = new HostMemoryCoordinator({
       store: memoryStore,

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -11,6 +11,7 @@ import {
   decodeClientFrame,
   HOST_OPERATION_SPECS,
   negotiateProtocol,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
   type ClientHello,
@@ -310,12 +311,16 @@ export class RuntimeHostKernel {
       { min: hello.protocolMin, max: hello.protocolMax },
       HOST_PROTOCOL,
     );
-    if (selectedProtocol === undefined) {
+    if (
+      selectedProtocol === undefined ||
+      hello.compatibilityEpoch !== RUNTIME_HOST_COMPATIBILITY_EPOCH
+    ) {
       return {
         kind: 'incompatible',
         hostEpoch: this.hostEpoch,
         protocolMin: HOST_PROTOCOL.min,
         protocolMax: HOST_PROTOCOL.max,
+        compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
         state: admittedState,
         replacement: this.#isTrueIdle() ? 'wait_for_idle_exit' : 'blocked_by_residency',
       };
@@ -328,6 +333,7 @@ export class RuntimeHostKernel {
       hostEpoch: this.hostEpoch,
       connectionId: randomUUID(),
       selectedProtocol,
+      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
       state: admittedState,
     };
   }
@@ -626,6 +632,7 @@ export class RuntimeHostKernel {
       endpoint: this.endpoint,
       protocolMin: HOST_PROTOCOL.min,
       protocolMax: HOST_PROTOCOL.max,
+      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
       state: this.#state,
       pid: process.pid,
       createdAt: this.#createdAt,

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -62,7 +62,7 @@ export type ExecutionInspectOperationKey = Extract<OperationKey, `execution.insp
 export type AgentGraphOperationKey = Extract<OperationKey, `agent.graph.${string}`>;
 export type SessionContinuityOperationKey = Extract<
   OperationKey,
-  'subscription.open' | 'subscription.close'
+  'subscription.open' | 'subscription.close' | 'session.transcript.query'
 >;
 export type SessionRevisionOperationKey = Extract<
   OperationKey,
@@ -75,7 +75,10 @@ export type SessionRetirementOperationKey = Extract<
 export type SessionEffectOperationKey = Extract<OperationKey, 'session.recap.generate'>;
 export type SessionCatalogOperationKey = Exclude<
   Extract<OperationKey, `session.${string}`>,
-  SessionRevisionOperationKey | SessionRetirementOperationKey | SessionEffectOperationKey
+  | SessionContinuityOperationKey
+  | SessionRevisionOperationKey
+  | SessionRetirementOperationKey
+  | SessionEffectOperationKey
 >;
 export type TaskLedgerOperationKey = Extract<OperationKey, 'task.ledger.query'>;
 export type ArtifactOperationKey = Extract<OperationKey, `artifact.${string}`>;

--- a/packages/runtime-host/src/server/session-continuity-coordinator.ts
+++ b/packages/runtime-host/src/server/session-continuity-coordinator.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { isDeepStrictEqual } from 'node:util';
 import type { SessionEvent } from '@maka/core/events';
+import type { StoredMessage } from '@maka/core/session';
 import {
   encodeProtocolFrame,
   RUNTIME_HOST_MAX_FRAME_BYTES,
@@ -13,6 +14,8 @@ import {
   type SessionDeltaFrame,
   type SessionEventFrame,
   type SessionToolEvent,
+  type SessionTranscriptQueryInput,
+  type OperationOutcome,
   type SubscriptionFrame,
   type SubscriptionOpenResult,
   type TurnSnapshot,
@@ -28,6 +31,7 @@ import type {
   SessionContinuityFrameSink,
   SessionContinuityService,
 } from './session-continuity-service.js';
+import { TranscriptSnapshotStore } from './transcript-snapshot-store.js';
 
 const MAX_CONNECTION_SUBSCRIPTIONS = 16;
 const MAX_SUBSCRIBER_QUEUED_FRAMES = 32;
@@ -52,10 +56,16 @@ export type ReadCanonicalSessionProjection = (
   sessionId: string,
 ) => Promise<CanonicalSessionProjection | null>;
 
+export type ReadSessionTranscript = (
+  sessionId: string,
+  rootTurn: TurnSnapshot | null,
+) => Promise<readonly StoredMessage[]>;
+
 interface SessionProjectionState {
   canonical: CanonicalSessionProjection;
   revision: number;
   subscribers: Map<string, Subscriber>;
+  assistantOffsets: Map<string, number>;
   terminalPublicationFence?: TerminalPublicationFence;
 }
 
@@ -120,15 +130,19 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
             error: { code: 'not_found', message: 'Session subscription was not found' },
           };
     },
+    'session.transcript.query': (input, context) =>
+      this.#queryTranscript(context.connectionId, input),
   };
 
   readonly #connections = new Map<string, ConnectionState>();
   readonly #sessions = new Map<string, SessionProjectionState>();
   readonly #subscriptions = new Map<string, Subscriber>();
+  readonly #transcriptSnapshots = new TranscriptSnapshotStore();
   readonly #pendingRefreshes = new Map<string, PendingRefresh>();
   readonly #pendingAgentGraphChanges = new Map<string, PendingAgentGraphChange>();
   readonly #hostEpoch: string;
   readonly #readCanonical: ReadCanonicalSessionProjection;
+  readonly #readTranscript: ReadSessionTranscript | undefined;
   #closed = false;
 
   constructor(
@@ -136,9 +150,11 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     readCanonical: ReadCanonicalSessionProjection,
     private readonly sessionAdmission: SessionAdmissionGate,
     private readonly onPublicationFailure: (error: unknown) => void = () => undefined,
+    readTranscript?: ReadSessionTranscript,
   ) {
     this.#hostEpoch = hostEpoch;
     this.#readCanonical = readCanonical;
+    this.#readTranscript = readTranscript;
   }
 
   attachConnection(
@@ -323,6 +339,9 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
         state.canonical = canonical;
         state.revision = nextRevision;
         delete state.terminalPublicationFence;
+        for (const key of state.assistantOffsets.keys()) {
+          if (key.startsWith(`${runId}\0`)) state.assistantOffsets.delete(key);
+        }
         this.#broadcastProjection(state, snapshot);
         if (state.subscribers.size === 0) this.#sessions.delete(sessionId);
       },
@@ -348,9 +367,13 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     ) {
       return;
     }
-    await this.sessionAdmission.run(sessionId, () => {
-      const state = this.#sessions.get(sessionId);
-      if (!state || state.subscribers.size === 0) return;
+    await this.sessionAdmission.run(sessionId, async () => {
+      let state = this.#sessions.get(sessionId);
+      if (!state) {
+        const canonical = await this.#readCanonicalProjection(sessionId);
+        if (!canonical) throw new Error('Runtime event belongs to a missing Session');
+        state = this.#commitCanonical(sessionId, canonical).state;
+      }
       const rootTurn = state.canonical.rootTurn;
       if (
         !rootTurn ||
@@ -365,8 +388,11 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
       if (event.type === 'text_delta' || event.type === 'thinking_delta') {
         const kind: SessionAssistantDelta['kind'] =
           event.type === 'text_delta' ? 'text' : 'thinking';
+        const offsetKey = assistantOffsetKey(runId, kind, event.messageId);
+        const startOffset = state.assistantOffsets.get(offsetKey) ?? 0;
+        state.assistantOffsets.set(offsetKey, startOffset + event.text.length);
         for (const subscriber of state.subscribers.values()) {
-          this.#enqueueAssistantDelta(subscriber, sessionId, runId, event, kind);
+          this.#enqueueAssistantDelta(subscriber, sessionId, runId, event, kind, startOffset);
         }
         return;
       }
@@ -399,6 +425,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
           for (const subscriber of state.subscribers.values()) {
             this.#enqueueSessionRemoved(subscriber);
           }
+          this.#transcriptSnapshots.deleteSession(sessionId);
           this.#sessions.delete(sessionId);
         },
         admission,
@@ -412,6 +439,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     for (const connectionId of [...this.#connections.keys()]) this.#closeConnection(connectionId);
     this.#sessions.clear();
     this.#subscriptions.clear();
+    this.#transcriptSnapshots.close();
     this.#pendingRefreshes.clear();
     this.#pendingAgentGraphChanges.clear();
   }
@@ -492,6 +520,59 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     }
   }
 
+  async #queryTranscript(
+    connectionId: string,
+    input: SessionTranscriptQueryInput,
+  ): Promise<OperationOutcome<'session.transcript.query'>> {
+    const subscriber = this.#ownedSubscriber(connectionId, input.subscriptionId);
+    if (!subscriber) {
+      return {
+        ok: false,
+        error: { code: 'not_found', message: 'Session subscription was not found' },
+      };
+    }
+    if (!this.#readTranscript) {
+      return {
+        ok: false,
+        error: { code: 'operation_unavailable', message: 'Session transcript is unavailable' },
+      };
+    }
+    if (input.kind === 'continue') {
+      return this.#transcriptSnapshots.continue({
+        connectionId,
+        subscriptionId: input.subscriptionId,
+        snapshotId: input.snapshotId,
+        cursor: { messageIndex: input.messageIndex, byteOffset: input.byteOffset },
+      });
+    }
+    const readTranscript = this.#readTranscript;
+    return this.sessionAdmission.run(subscriber.sessionId, async () => {
+      if (this.#ownedSubscriber(connectionId, input.subscriptionId) !== subscriber) {
+        return transcriptSubscriptionNotFound();
+      }
+      try {
+        const messages = await readTranscript(
+          subscriber.sessionId,
+          this.#sessions.get(subscriber.sessionId)?.canonical.rootTurn ?? null,
+        );
+        if (this.#ownedSubscriber(connectionId, input.subscriptionId) !== subscriber) {
+          return transcriptSubscriptionNotFound();
+        }
+        return this.#transcriptSnapshots.start({
+          connectionId,
+          subscriptionId: subscriber.subscriptionId,
+          sessionId: subscriber.sessionId,
+          messages,
+        });
+      } catch {
+        return {
+          ok: false,
+          error: { code: 'persistence_failed', message: 'Session transcript is unavailable' },
+        };
+      }
+    });
+  }
+
   #activate(connectionId: string, subscriptionId: string): void {
     const subscriber = this.#ownedSubscriber(connectionId, subscriptionId);
     if (!subscriber || subscriber.activated || subscriber.phase === 'closed') return;
@@ -527,6 +608,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
       if (subscriber) this.#removeSubscriber(subscriber);
     }
     this.#connections.delete(connectionId);
+    this.#transcriptSnapshots.deleteConnection(connectionId);
   }
 
   #enqueue(subscriber: Subscriber, frame: SubscriptionFrame): void {
@@ -584,17 +666,26 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     runId: string,
     event: Extract<RuntimeSessionTransientEvent, { type: 'text_delta' | 'thinking_delta' }>,
     kind: SessionAssistantDelta['kind'],
+    startOffset: number,
   ): void {
     let chunk = '';
     let rawBytes = 0;
     let wireBytes = 0;
+    let emittedCharacters = 0;
     const frame = (text: string): SessionDeltaFrame => ({
       kind: 'subscription.session_delta',
       hostEpoch: this.#hostEpoch,
       subscriptionId: subscriber.subscriptionId,
       sequence: subscriber.nextSequence,
       sessionId,
-      delta: { kind, turnId: event.turnId, runId, messageId: event.messageId, text },
+      delta: {
+        kind,
+        turnId: event.turnId,
+        runId,
+        messageId: event.messageId,
+        startOffset: startOffset + emittedCharacters,
+        text,
+      },
     });
     let wireLimit = wireTextByteLimit(frame(''));
     for (const character of event.text) {
@@ -606,6 +697,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
           wireBytes + wireCharacterBytes > wireLimit)
       ) {
         this.#enqueue(subscriber, frame(chunk));
+        emittedCharacters += chunk.length;
         if (subscriber.phase !== 'open') return;
         chunk = '';
         rawBytes = 0;
@@ -684,6 +776,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     const state = this.#sessions.get(subscriber.sessionId);
     const removed = state?.subscribers.delete(subscriber.subscriptionId);
     this.#subscriptions.delete(subscriber.subscriptionId);
+    this.#transcriptSnapshots.deleteSubscription(subscriber.subscriptionId);
     this.#connections
       .get(subscriber.connectionId)
       ?.subscriptionIds.delete(subscriber.subscriptionId);
@@ -705,7 +798,8 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
       if (
         this.#sessions.get(sessionId) === state &&
         state.subscribers.size === 0 &&
-        !state.terminalPublicationFence
+        !state.terminalPublicationFence &&
+        (!state.canonical.rootTurn || isTerminalTurn(state.canonical.rootTurn))
       ) {
         this.#sessions.delete(sessionId);
       }
@@ -738,7 +832,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     }
     if (!state) {
       const value = createSessionContinuitySnapshot(canonical, 1);
-      state = { canonical, revision: 1, subscribers: new Map() };
+      state = { canonical, revision: 1, subscribers: new Map(), assistantOffsets: new Map() };
       this.#sessions.set(sessionId, state);
       return { changed: true, state, value };
     }
@@ -788,6 +882,21 @@ function slowConsumerFrameBytes(subscriber: Subscriber, hostEpoch: string): numb
     sequence: subscriber.nextSequence + 1,
     reason: 'slow_consumer',
   }).byteLength;
+}
+
+function assistantOffsetKey(
+  runId: string,
+  kind: SessionAssistantDelta['kind'],
+  messageId: string,
+): string {
+  return `${runId}\0${kind}\0${messageId}`;
+}
+
+function transcriptSubscriptionNotFound(): OperationOutcome<'session.transcript.query'> {
+  return {
+    ok: false,
+    error: { code: 'not_found', message: 'Session subscription was not found' },
+  };
 }
 
 function terminalFrameByteBudget(subscriber: Subscriber, hostEpoch: string): number {

--- a/packages/runtime-host/src/server/session-transcript-reader.ts
+++ b/packages/runtime-host/src/server/session-transcript-reader.ts
@@ -1,0 +1,142 @@
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { StoredMessage } from '@maka/core/session';
+import {
+  isHardRuntimeEventReadModelDiagnostic,
+  projectRuntimeEventsToStoredMessages,
+  type CanonicalPermissionOutcomeReader,
+  type CanonicalPermissionOutcomeRecord,
+} from '@maka/runtime';
+import type { ExecutionStoresWriter } from '@maka/storage/execution-stores';
+import type { TurnSnapshot } from '../protocol/index.js';
+import type { ReadSessionTranscript } from './session-continuity-coordinator.js';
+
+const PERMISSION_OUTCOME_READ_CONCURRENCY = 8;
+
+export function createSessionTranscriptReader(input: {
+  stores: ExecutionStoresWriter<'interactive'>;
+  canonicalPermissionOutcomes: CanonicalPermissionOutcomeReader;
+}): ReadSessionTranscript {
+  return async (sessionId, rootTurn) => {
+    const stored = await input.stores.sessionStore.readMessagesSnapshot(sessionId);
+    if (!rootTurn || isTerminalTurn(rootTurn)) return stored;
+
+    const [run, events] = await Promise.all([
+      input.stores.agentRunStore.readRun(sessionId, rootTurn.runId),
+      input.stores.runtimeEventStore.readRuntimeEvents(sessionId, rootTurn.runId),
+    ]);
+    const canonicalPermissionOutcomes = await readCanonicalPermissionOutcomes(
+      events,
+      input.canonicalPermissionOutcomes,
+    );
+    const projected = projectRuntimeEventsToStoredMessages(activePresentationEvents(events), {
+      runHeaders: [run],
+      canonicalPermissionOutcomes,
+    });
+    if (projected.diagnostics.some(isHardRuntimeEventReadModelDiagnostic)) {
+      throw new Error('Active RuntimeEvent transcript projection is incomplete');
+    }
+    return mergeMessageUpserts(stored, projected.messages);
+  };
+}
+
+async function readCanonicalPermissionOutcomes(
+  events: readonly RuntimeEvent[],
+  reader: CanonicalPermissionOutcomeReader,
+): Promise<ReadonlyMap<string, CanonicalPermissionOutcomeRecord>> {
+  const requestIds = new Set(
+    events.flatMap((event) => {
+      const requestId = event.actions?.permissionAnswerAccepted?.requestId;
+      return requestId ? [requestId] : [];
+    }),
+  );
+  const outcomes = new Map<string, CanonicalPermissionOutcomeRecord>();
+  const ids = [...requestIds];
+  for (let index = 0; index < ids.length; index += PERMISSION_OUTCOME_READ_CONCURRENCY) {
+    const batch = await Promise.all(
+      ids.slice(index, index + PERMISSION_OUTCOME_READ_CONCURRENCY).map(async (requestId) => ({
+        requestId,
+        outcome: await reader.readPermissionOutcome(requestId),
+      })),
+    );
+    for (const item of batch) {
+      if (item.outcome) outcomes.set(item.requestId, item.outcome);
+    }
+  }
+  return outcomes;
+}
+
+function activePresentationEvents(events: readonly RuntimeEvent[]): RuntimeEvent[] {
+  const textMessages = new Set<string>();
+  const lastThinkingByMessage = new Map<string, RuntimeEvent>();
+
+  for (const event of events) {
+    const content = event.content;
+    if (event.role !== 'model' || (content?.kind !== 'text' && content?.kind !== 'thinking')) {
+      continue;
+    }
+    const messageKey = activeMessageKey(event);
+    if (content.kind === 'text') textMessages.add(messageKey);
+    else lastThinkingByMessage.set(messageKey, event);
+  }
+
+  const syntheticAfter = new Map<RuntimeEvent, RuntimeEvent[]>();
+  for (const [messageKey, thinking] of lastThinkingByMessage) {
+    if (textMessages.has(messageKey)) continue;
+    const existing = syntheticAfter.get(thinking) ?? [];
+    existing.push(emptyAssistantText(thinking));
+    syntheticAfter.set(thinking, existing);
+  }
+
+  const presented: RuntimeEvent[] = [];
+  for (const event of events) {
+    presented.push(presentationEvent(event));
+    const synthetic = syntheticAfter.get(event);
+    if (synthetic) presented.push(...synthetic);
+  }
+  return presented;
+}
+
+function activeMessageKey(event: RuntimeEvent): string {
+  const messageId = event.refs?.providerEventId ?? event.refs?.storedMessageId ?? event.id;
+  return `${event.runId}\0${messageId}`;
+}
+
+function presentationEvent(event: RuntimeEvent): RuntimeEvent {
+  const content = event.content;
+  return event.partial &&
+    event.role === 'model' &&
+    (content?.kind === 'text' || content?.kind === 'thinking')
+    ? { ...event, partial: false }
+    : event;
+}
+
+function emptyAssistantText(thinking: RuntimeEvent): RuntimeEvent {
+  return {
+    ...thinking,
+    id: `${thinking.id}:active-transcript-empty-text`,
+    partial: false,
+    content: { kind: 'text', text: '' },
+  };
+}
+
+function mergeMessageUpserts(
+  stored: readonly StoredMessage[],
+  active: readonly StoredMessage[],
+): StoredMessage[] {
+  const merged = stored.map((message) => structuredClone(message));
+  const indices = new Map(merged.map((message, index) => [message.id, index]));
+  for (const message of active) {
+    const index = indices.get(message.id);
+    if (index === undefined) {
+      indices.set(message.id, merged.length);
+      merged.push(structuredClone(message));
+    } else {
+      merged[index] = structuredClone(message);
+    }
+  }
+  return merged;
+}
+
+function isTerminalTurn(turn: TurnSnapshot): boolean {
+  return turn.status === 'completed' || turn.status === 'failed' || turn.status === 'cancelled';
+}

--- a/packages/runtime-host/src/server/transcript-snapshot-store.ts
+++ b/packages/runtime-host/src/server/transcript-snapshot-store.ts
@@ -1,0 +1,240 @@
+import { randomUUID } from 'node:crypto';
+import type { StoredMessage } from '@maka/core/session';
+import {
+  SESSION_TRANSCRIPT_CHUNK_MAX_BYTES,
+  type SessionTranscriptCursor,
+  type SessionTranscriptQueryResult,
+} from '../protocol/index.js';
+
+const MAX_CONNECTION_SNAPSHOTS = 4;
+const MAX_SNAPSHOT_BYTES = 16 * 1024 * 1024;
+const MAX_RETAINED_BYTES = 64 * 1024 * 1024;
+const SNAPSHOT_IDLE_MS = 60_000;
+
+interface TranscriptSnapshot {
+  id: string;
+  connectionId: string;
+  subscriptionId: string;
+  sessionId: string;
+  messages: readonly Buffer[];
+  encodedBytes: number;
+  lastAccessAt: number;
+}
+
+export type TranscriptSnapshotQueryOutcome =
+  | { ok: true; result: SessionTranscriptQueryResult }
+  | {
+      ok: false;
+      error: {
+        code: 'invalid_request' | 'operation_conflict' | 'operation_unavailable';
+        message: string;
+      };
+    };
+
+export class TranscriptSnapshotStore {
+  readonly #snapshots = new Map<string, TranscriptSnapshot>();
+  readonly #now: () => number;
+  #cleanupTimer: NodeJS.Timeout | undefined;
+  #closed = false;
+
+  constructor(now: () => number = Date.now) {
+    this.#now = now;
+  }
+
+  start(input: {
+    connectionId: string;
+    subscriptionId: string;
+    sessionId: string;
+    messages: readonly StoredMessage[];
+  }): TranscriptSnapshotQueryOutcome {
+    this.#pruneExpired();
+    let connectionSnapshots = 0;
+    for (const snapshot of this.#snapshots.values()) {
+      if (snapshot.connectionId === input.connectionId) connectionSnapshots += 1;
+    }
+    if (connectionSnapshots >= MAX_CONNECTION_SNAPSHOTS) {
+      return failure(
+        'operation_conflict',
+        'Runtime Host connection transcript snapshot limit reached',
+      );
+    }
+
+    const encoded: Buffer[] = [];
+    let encodedBytes = 0;
+    for (const message of input.messages) {
+      const bytes = Buffer.from(JSON.stringify(message), 'utf8');
+      encodedBytes += bytes.byteLength;
+      if (encodedBytes > MAX_SNAPSHOT_BYTES) {
+        return failure(
+          'operation_unavailable',
+          'Session transcript exceeds the live snapshot byte limit',
+        );
+      }
+      encoded.push(bytes);
+    }
+    if (this.#retainedBytes() + encodedBytes > MAX_RETAINED_BYTES) {
+      return failure('operation_conflict', 'Runtime Host transcript snapshot memory limit reached');
+    }
+
+    const snapshot: TranscriptSnapshot = {
+      id: randomUUID(),
+      connectionId: input.connectionId,
+      subscriptionId: input.subscriptionId,
+      sessionId: input.sessionId,
+      messages: encoded,
+      encodedBytes,
+      lastAccessAt: this.#now(),
+    };
+    this.#snapshots.set(snapshot.id, snapshot);
+    this.#scheduleCleanup();
+    return this.#read(snapshot, { messageIndex: 0, byteOffset: 0 });
+  }
+
+  continue(input: {
+    connectionId: string;
+    subscriptionId: string;
+    snapshotId: string;
+    cursor: SessionTranscriptCursor;
+  }): TranscriptSnapshotQueryOutcome {
+    this.#pruneExpired();
+    const snapshot = this.#snapshots.get(input.snapshotId);
+    if (
+      !snapshot ||
+      snapshot.connectionId !== input.connectionId ||
+      snapshot.subscriptionId !== input.subscriptionId
+    ) {
+      return { ok: true, result: { kind: 'snapshot_expired', snapshotId: input.snapshotId } };
+    }
+    snapshot.lastAccessAt = this.#now();
+    this.#scheduleCleanup();
+    return this.#read(snapshot, input.cursor);
+  }
+
+  deleteConnection(connectionId: string): void {
+    this.#deleteWhere((snapshot) => snapshot.connectionId === connectionId);
+  }
+
+  deleteSubscription(subscriptionId: string): void {
+    this.#deleteWhere((snapshot) => snapshot.subscriptionId === subscriptionId);
+  }
+
+  deleteSession(sessionId: string): void {
+    this.#deleteWhere((snapshot) => snapshot.sessionId === sessionId);
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#snapshots.clear();
+    if (this.#cleanupTimer) clearTimeout(this.#cleanupTimer);
+    this.#cleanupTimer = undefined;
+  }
+
+  #read(
+    snapshot: TranscriptSnapshot,
+    cursor: SessionTranscriptCursor,
+  ): TranscriptSnapshotQueryOutcome {
+    if (snapshot.messages.length === 0) {
+      if (cursor.messageIndex !== 0 || cursor.byteOffset !== 0) {
+        return invalidCursor();
+      }
+      this.#delete(snapshot.id);
+      return {
+        ok: true,
+        result: {
+          kind: 'chunk',
+          snapshotId: snapshot.id,
+          sessionId: snapshot.sessionId,
+          messageCount: 0,
+          messageIndex: 0,
+          byteOffset: 0,
+          data: '',
+          next: null,
+        },
+      };
+    }
+
+    const message = snapshot.messages[cursor.messageIndex];
+    if (!message || cursor.byteOffset >= message.byteLength) return invalidCursor();
+    const end = Math.min(
+      message.byteLength,
+      cursor.byteOffset + SESSION_TRANSCRIPT_CHUNK_MAX_BYTES,
+    );
+    const next =
+      end < message.byteLength
+        ? { messageIndex: cursor.messageIndex, byteOffset: end }
+        : cursor.messageIndex + 1 < snapshot.messages.length
+          ? { messageIndex: cursor.messageIndex + 1, byteOffset: 0 }
+          : null;
+    if (next === null) this.#delete(snapshot.id);
+    return {
+      ok: true,
+      result: {
+        kind: 'chunk',
+        snapshotId: snapshot.id,
+        sessionId: snapshot.sessionId,
+        messageCount: snapshot.messages.length,
+        messageIndex: cursor.messageIndex,
+        byteOffset: cursor.byteOffset,
+        data: message.subarray(cursor.byteOffset, end).toString('base64'),
+        next,
+      },
+    };
+  }
+
+  #retainedBytes(): number {
+    let total = 0;
+    for (const snapshot of this.#snapshots.values()) total += snapshot.encodedBytes;
+    return total;
+  }
+
+  #deleteWhere(predicate: (snapshot: TranscriptSnapshot) => boolean): void {
+    for (const [id, snapshot] of this.#snapshots) {
+      if (predicate(snapshot)) this.#snapshots.delete(id);
+    }
+    this.#scheduleCleanup();
+  }
+
+  #delete(snapshotId: string): void {
+    this.#snapshots.delete(snapshotId);
+    this.#scheduleCleanup();
+  }
+
+  #pruneExpired(): void {
+    const now = this.#now();
+    this.#deleteWhere((snapshot) => now - snapshot.lastAccessAt >= SNAPSHOT_IDLE_MS);
+  }
+
+  #scheduleCleanup(): void {
+    if (this.#cleanupTimer) clearTimeout(this.#cleanupTimer);
+    this.#cleanupTimer = undefined;
+    if (this.#closed) return;
+    let expiresAt = Number.POSITIVE_INFINITY;
+    for (const snapshot of this.#snapshots.values()) {
+      expiresAt = Math.min(expiresAt, snapshot.lastAccessAt + SNAPSHOT_IDLE_MS);
+    }
+    if (!Number.isFinite(expiresAt)) return;
+    this.#cleanupTimer = setTimeout(
+      () => {
+        this.#cleanupTimer = undefined;
+        this.#pruneExpired();
+      },
+      Math.max(1, expiresAt - this.#now()),
+    );
+    this.#cleanupTimer.unref();
+  }
+}
+
+function failure(
+  code: 'operation_conflict' | 'operation_unavailable',
+  message: string,
+): TranscriptSnapshotQueryOutcome {
+  return { ok: false, error: { code, message } };
+}
+
+function invalidCursor(): TranscriptSnapshotQueryOutcome {
+  return {
+    ok: false,
+    error: { code: 'invalid_request', message: 'Session transcript cursor is invalid' },
+  };
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1273,6 +1273,7 @@ export {
   applyArchivedToolResultReadModelStatuses,
   compareRuntimeReadModelMessages,
   classifyRuntimeEventTerminalFact,
+  isHardRuntimeEventReadModelDiagnostic,
 } from './runtime-event-read-model.js';
 export type {
   ArchivedToolResultReadModelStatus,

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -104,7 +104,7 @@ test('heavy workspaces are projected onto dedicated CI lanes', () => {
   const runtimeHost = planTests(['packages/runtime-host/src/server/index.ts'], { graph });
   assert.equal(runtimeHost.runtimeHost, true);
   assert.equal(runtimeHost.headless, false);
-  assert.deepEqual(runtimeHost.standardWorkspaces, ['packages/cli']);
+  assert.deepEqual(runtimeHost.standardWorkspaces, ['packages/cli', 'apps/desktop']);
 
   const runtime = planTests(['packages/runtime/src/index.ts'], { graph });
   assert.equal(runtime.runtimeHost, true);
@@ -127,7 +127,7 @@ test('heavy workspaces are projected onto dedicated CI lanes', () => {
   const outputs = formatGitHubOutputs(runtimeHost).split('\n');
   assert.ok(outputs.includes('runtime_host=true'));
   assert.ok(outputs.includes('headless=false'));
-  assert.ok(outputs.includes('standard_workspaces=packages/cli'));
+  assert.ok(outputs.includes('standard_workspaces=packages/cli,apps/desktop'));
 });
 
 test('global and unknown production changes fail safe to the complete suite', () => {


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Add a compatibility epoch while keeping the Runtime Host wire protocol at `v0`, so a Client can reject and retire a stale same-version Host before using incompatible semantics.
- Add bounded canonical transcript snapshots and absolute live-stream offsets, allowing late or reconnecting Clients to reconstruct a Session and continue following an active Turn without gaps or duplicate ownership.
- Expose transcript loading through the Runtime Host Client API and add the first Desktop main-process lifecycle/session adapter seam.

## Why

Desktop is the first M4 Client adapter. It needs a reliable initial-state/live boundary before its existing renderer-facing flows can move from the embedded Runtime to the Host. Wire version `v0` alone cannot distinguish a pre-foundation Host from one that supports this boundary.

## Design

- `session.transcript.query` creates immutable, subscription-owned snapshots with bounded chunks, memory limits, idle expiry, and connection/session cleanup.
- Active transcripts are projected from the canonical Session and Runtime Event stores. The reader preserves the Store's existing stream fold instead of creating a second transcript journal.
- Live assistant deltas carry absolute UTF-16 offsets, including across periods with no subscribers, so Clients can detect overlap or a gap.
- The Desktop adapter owns only Host connection and subscription lifecycles. It does not open writer Stores or construct an embedded Runtime owner.
- Desktop production bootstrap is intentionally unchanged. The Host-backed path will replace the embedded owner atomically in M5 rather than introducing dual ownership or fallback.

## Validation

- `npm test --workspace @maka/runtime-host`
- `npm test --workspace @maka/desktop` (1,618 tests)
- `npm test --workspace maka-agent`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build --workspace @maka/desktop`
- Existing embedded Desktop regression smoke covering renderer mount, new Session creation, streaming completion, SQLite persistence, the preload/IPC bridge, and error-surface absence.

Part of #2010.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 在 Runtime Host wire protocol 继续保持 `v0` 的同时加入 compatibility epoch，使 Client 能在使用不兼容语义前识别并淘汰同版本的陈旧 Host。
- 加入有界 canonical transcript snapshot 与 live stream 绝对 offset，使中途加入或重连的 Client 能重建 Session，并在不产生缺口或重复 ownership 的情况下继续跟随正在执行的 Turn。
- 通过 Runtime Host Client API 暴露 transcript 加载能力，并提供首个 Desktop main-process lifecycle/session adapter 接入边界。

## 原因

Desktop 是第一个 M4 Client adapter。在现有 renderer-facing flow 从 embedded Runtime 迁移到 Host 前，需要先具备可靠的 initial-state/live 边界。仅靠 wire version `v0` 无法区分不具备该边界的旧 Host 与当前 Host。

## 设计

- `session.transcript.query` 创建由 subscription 持有的 immutable snapshot，并限制 chunk、内存占用和空闲时间，同时在 connection/session 结束时完成清理。
- active transcript 从 canonical Session Store 与 Runtime Event Store 投影。reader 复用 Store 已有的 stream fold，不创建第二份 transcript journal。
- live assistant delta 携带 UTF-16 绝对 offset；即使一段时间没有 subscriber，offset 也连续，使 Client 能识别 overlap 或 gap。
- Desktop adapter 只拥有 Host connection 与 subscription lifecycle，不打开 writer Store，也不构造 embedded Runtime owner。
- Desktop production bootstrap 有意保持不变。Host-backed path 将在 M5 原子替换 embedded owner，不在 M4 引入 dual ownership 或 fallback。

## 验证

- `npm test --workspace @maka/runtime-host`
- `npm test --workspace @maka/desktop`（1,618 tests）
- `npm test --workspace maka-agent`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build --workspace @maka/desktop`
- 对现有 embedded Desktop 执行 regression smoke test，覆盖 renderer mount、新建 Session、streaming completion、SQLite persistence、preload/IPC bridge，并确认未出现 error surface。

#2010 的一部分。

</details>