### PR TITLE
fix(desktop): keep realtime session creation single-flight

### DIFF
--- a/apps/desktop/src/main/__tests__/voice-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-ipc-main.test.ts
@@ -39,6 +39,7 @@ function service(input: {
   settings: AppSettings;
   connection: LlmConnection;
   fetch?: typeof fetch;
+  now?: () => number;
 }) {
   return createVoiceIpcService({
     settingsStore: { get: async () => input.settings } as never,
@@ -47,7 +48,16 @@ function service(input: {
     } as never,
     resolveConnectionSecret: async () => 'server-secret',
     ...(input.fetch ? { fetch: input.fetch } : {}),
+    ...(input.now ? { now: input.now } : {}),
   });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 const audio = {
@@ -249,5 +259,81 @@ describe('voice IPC service', () => {
       }).createRealtimeSession('not-sdp'),
       /voice_realtime_offer_invalid/,
     );
+  });
+
+  it('keeps realtime creation single-flight past its old deadline and releases admission on settle', async () => {
+    let currentTime = 0;
+    let requestCount = 0;
+    let failNextToken = false;
+    const tokenRequested = deferred<void>();
+    const callRequested = deferred<void>();
+    const tokenResponse = deferred<Response>();
+    const callResponse = deferred<Response>();
+    const fetchMock: typeof fetch = async (url) => {
+      const requestIndex = requestCount;
+      requestCount += 1;
+      if (requestIndex === 0) {
+        tokenRequested.resolve(undefined);
+        return tokenResponse.promise;
+      }
+      if (requestIndex === 1) {
+        callRequested.resolve(undefined);
+        return callResponse.promise;
+      }
+      if (String(url).endsWith('/realtime/client_secrets')) {
+        if (failNextToken) {
+          failNextToken = false;
+          return new Response('{}', { status: 200 });
+        }
+        return new Response(JSON.stringify({ value: 'next-client-secret', expires_at: 123 }), {
+          status: 200,
+        });
+      }
+      return new Response('v=0\r\no=next-answer', { status: 200 });
+    };
+    const voice = service({
+      settings: settings({
+        realtime: {
+          connectionSlug: 'openai',
+          model: 'gpt-realtime',
+          voice: 'marin',
+        },
+      }),
+      connection: connection(['gpt-realtime']),
+      fetch: fetchMock,
+      now: () => currentTime,
+    });
+    const offerSdp = 'v=0\r\no=offer';
+
+    const firstPending = voice.createRealtimeSession(offerSdp);
+    await tokenRequested.promise;
+    currentTime = 18_000;
+    tokenResponse.resolve(
+      new Response(JSON.stringify({ value: 'first-client-secret', expires_at: 123 }), {
+        status: 200,
+      }),
+    );
+    await callRequested.promise;
+
+    currentTime = 31_000;
+    await assert.rejects(
+      () => voice.createRealtimeSession(offerSdp),
+      /voice_realtime_session_already_active/,
+    );
+    assert.equal(requestCount, 2, 'the rejected request must not reach the provider');
+
+    currentTime = 40_000;
+    callResponse.resolve(new Response('v=0\r\no=first-answer', { status: 200 }));
+    const first = await firstPending;
+    voice.closeRealtimeSession(first.sessionId);
+
+    failNextToken = true;
+    await assert.rejects(
+      () => voice.createRealtimeSession(offerSdp),
+      /voice_realtime_secret_missing/,
+    );
+    const next = await voice.createRealtimeSession(offerSdp);
+    assert.equal(next.answerSdp, 'v=0\r\no=next-answer');
+    assert.notEqual(next.sessionId, first.sessionId);
   });
 });

--- a/apps/desktop/src/main/voice-ipc-main.ts
+++ b/apps/desktop/src/main/voice-ipc-main.ts
@@ -77,7 +77,8 @@ export function createVoiceIpcService(deps: {
   const operations = new Map<string, VoiceOperation>();
   const fetchImpl = deps.fetch ?? fetch;
   const now = deps.now ?? Date.now;
-  let realtimeLease: { sessionId: string; expiresAt: number } | undefined;
+  let realtimeSessionPending = false;
+  let activeRealtimeLease: { sessionId: string; expiresAt: number } | undefined;
 
   async function begin(input: VoiceBeginRequest): Promise<VoiceBeginResult> {
     sweepExpired();
@@ -176,13 +177,13 @@ export function createVoiceIpcService(deps: {
   }
 
   async function createRealtimeSession(offerSdpInput: unknown): Promise<VoiceRealtimeClientSession> {
-    if (realtimeLease && realtimeLease.expiresAt > now()) {
+    if (realtimeSessionPending || (activeRealtimeLease && activeRealtimeLease.expiresAt > now())) {
       throw new Error('voice_realtime_session_already_active');
     }
-    realtimeLease = undefined;
+    activeRealtimeLease = undefined;
     const offerSdp = normalizeRealtimeOfferSdp(offerSdpInput);
     const sessionId = randomUUID();
-    realtimeLease = { sessionId, expiresAt: now() + REALTIME_CONNECT_TIMEOUT_MS };
+    realtimeSessionPending = true;
     try {
       const { plan } = await resolveConfiguredRoute({ intent: 'voice_chat' });
       if (plan.kind === 'blocked') throw new Error(`voice_route_blocked:${plan.reason}`);
@@ -248,7 +249,7 @@ export function createVoiceIpcService(deps: {
         throw providerHttpError('realtime_connect', callResponse.status);
       }
       if (!answerSdp.trim()) throw new Error('voice_realtime_answer_invalid');
-      realtimeLease = { sessionId, expiresAt: now() + 24 * 60 * 60_000 };
+      activeRealtimeLease = { sessionId, expiresAt: now() + 24 * 60 * 60_000 };
       return {
         sessionId,
         answerSdp,
@@ -256,15 +257,14 @@ export function createVoiceIpcService(deps: {
         providerLabel: plan.target.providerLabel ?? plan.target.connectionSlug,
         expiresAt,
       };
-    } catch (error) {
-      if (realtimeLease?.sessionId === sessionId) realtimeLease = undefined;
-      throw error;
+    } finally {
+      realtimeSessionPending = false;
     }
   }
 
   function closeRealtimeSession(sessionIdInput: unknown): void {
     const sessionId = normalizeOperationId(sessionIdInput);
-    if (realtimeLease?.sessionId === sessionId) realtimeLease = undefined;
+    if (activeRealtimeLease?.sessionId === sessionId) activeRealtimeLease = undefined;
   }
 
   async function resolveConfiguredRoute(input: VoiceBeginRequest): Promise<{


### PR DESCRIPTION
## Summary

- keep Realtime Voice creation ownership until the token and SDP handshake settles
- install the expiring active-session lease only after a successful handshake
- add a deterministic deferred-fetch regression for the old 30-second admission window and failed-handshake retry

## Why

The previous 30-second provisional lease could expire while a valid create was still inside the sequential 20-second token and 30-second SDP windows. That admitted a second provider session and let the older completion overwrite the newer active lease.

Pending creation is now an exclusive Boolean fact rather than a clock estimate. Because a second creator cannot enter until the first settles, stale completions are unreachable and no generation token is needed. The existing 24-hour active lease behavior is unchanged.

## Validation

- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run build:test`
- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run test:dist` — 1618 passed, 0 failed
- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run typecheck`
- focused Voice IPC suite — 7 passed, 0 failed
- Biome and `git diff --check`

Closes #2125
