### PR TITLE
fix(scripts): the serial workspace batch was never running after a parallel failure

### DIFF
--- a/scripts/run-workspace-tests-parallel.mjs
+++ b/scripts/run-workspace-tests-parallel.mjs
@@ -27,7 +27,27 @@ const defaultRepoRoot = dirname(dirname(scriptPath));
 // handled inside scripts/run-headless-tests.mjs; serial scheduling is extra
 // conservatism for root orchestration, not a claim that its suite shares FS
 // state with other packages.
-export const SERIAL_WORKSPACE_DIRS = ['packages/headless'];
+//
+// runtime and runtime-host join it as a TEMPORARY mitigation for #2132, and
+// the reason is worth stating precisely so this list does not become a
+// dumping ground: they do NOT contend over a shared resource. Measured, at
+// --concurrency 3 some run fails 3 times out of 3; at --concurrency 1 across
+// every workspace, 0 out of 2; and each package alone passes repeatedly. Two
+// tempting explanations were tested and are false — /tmp does not fill up
+// (331 -> 339 entries under load, readdir in 1ms) and leftover child
+// processes are not the cause (running them back to back passes 3 of 3).
+// What is left is saturation: three tests with fixed waits miss their window
+// when the machine is busy.
+//
+// So this buys a quiet review pipeline at the cost of wall clock, and it is
+// the wrong permanent answer — the fix is in those tests' timing assumptions
+// (#2132). Remove these two entries when that lands. The unrelated /tmp
+// isolation gap found during the same investigation is #2133.
+export const SERIAL_WORKSPACE_DIRS = [
+  'packages/headless',
+  'packages/runtime',
+  'packages/runtime-host',
+];
 export const DEFAULT_WORKSPACE_TIMEOUT_MS = 15 * 60_000;
 
 const PROCESS_TERMINATION_GRACE_MS = 1_000;

--- a/scripts/run-workspace-tests-parallel.mjs
+++ b/scripts/run-workspace-tests-parallel.mjs
@@ -216,8 +216,34 @@ export async function runWorkspaceTests(options = {}) {
     await runSerial(workspaceDirs, runOptions);
   } else {
     const { parallel, serial } = partitionWorkspaces(workspaceDirs, serialDirs);
-    await runParallel(parallel, runOptions, concurrency);
-    await runSerial(serial, runOptions);
+    // The serial batch runs even when the parallel batch failed, and both
+    // results are reported together.
+    //
+    // It used to be a plain `await` pair, so one failing parallel workspace
+    // threw before the serial batch started and those suites silently did not
+    // run — the summary looked shorter and finished sooner, which reads as
+    // "faster and greener" rather than "three packages were skipped". That is
+    // the wrong direction for a runner whose entire job is to say what passed.
+    //
+    // Cancellation still stops everything at once: an aborted signal skips the
+    // serial batch, because there the caller has asked for no further work.
+    let parallelError;
+    try {
+      await runParallel(parallel, runOptions, concurrency);
+    } catch (error) {
+      parallelError = error;
+    }
+    if (runOptions.signal?.aborted) throw parallelError ?? workspaceRunCancelledError();
+    let serialError;
+    try {
+      await runSerial(serial, runOptions);
+    } catch (error) {
+      serialError = error;
+    }
+    const errors = [parallelError, serialError].filter(Boolean);
+    if (errors.length > 0) {
+      throw new Error(errors.map((error) => error?.message ?? String(error)).join('\n'));
+    }
   }
 }
 

--- a/scripts/run-workspace-tests-parallel.test.mjs
+++ b/scripts/run-workspace-tests-parallel.test.mjs
@@ -7,14 +7,23 @@ import { join, relative } from 'node:path';
 import { test } from 'node:test';
 import { runWorkspaceTests } from './run-workspace-tests-parallel.mjs';
 
+/**
+ * `plan` is keyed by workspace directory, not by spawn order.
+ *
+ * Keying on order made the outcome depend on which worker's `mkdtemp`
+ * resolved first — something the runner does not promise and a test cannot
+ * control — so `[core] failed with code 1` was a coin flip that landed wrong
+ * about one run in three. Keying on the workspace makes "core exits 1" a fact
+ * of the fixture, which lets the assertions get stricter rather than looser.
+ */
 function makeSpawn(plan) {
   const calls = [];
   const spawn = (command, options) => {
     const child = new EventEmitter();
-    const index = calls.length;
+    const dir = String(options.cwd).split('/').slice(-2).join('/');
     calls.push({ command, cwd: options.cwd, shell: options.shell });
     queueMicrotask(() => {
-      const step = plan[index] ?? { close: 0 };
+      const step = plan[dir] ?? { close: 0 };
       if (step.error) {
         child.emit(
           'error',
@@ -32,7 +41,11 @@ function makeSpawn(plan) {
 test('parallel mode aggregates every failed workspace name', async () => {
   const repoRoot = '/repo';
   const workspaceDirs = ['packages/core', 'packages/ui', 'packages/headless'];
-  const { spawn } = makeSpawn([{ close: 1 }, { close: 2 }, { close: 0 }]);
+  const { spawn, calls } = makeSpawn({
+    'packages/core': { close: 1 },
+    'packages/ui': { close: 2 },
+    'packages/headless': { close: 0 },
+  });
 
   await assert.rejects(
     () =>
@@ -48,6 +61,11 @@ test('parallel mode aggregates every failed workspace name', async () => {
       return true;
     },
   );
+
+  // The serial workspace runs even though the parallel batch failed — the
+  // regression that had headless silently not running whenever anything else
+  // did.
+  assert.ok(calls.some((call) => call.cwd.endsWith('packages/headless')));
 });
 
 test('each workspace runs in its own temp namespace, removed however it ends', async () => {
@@ -108,9 +126,11 @@ test('bounded parallel mode never exceeds its configured concurrency', async () 
   const workspaceDirs = ['packages/core', 'packages/ui', 'apps/desktop'];
   let active = 0;
   let maxActive = 0;
+  let started = 0;
   const spawn = () => {
     const child = new EventEmitter();
     active += 1;
+    started += 1;
     maxActive = Math.max(maxActive, active);
     setImmediate(() => {
       active -= 1;
@@ -121,7 +141,14 @@ test('bounded parallel mode never exceeds its configured concurrency', async () 
 
   await runWorkspaceTests({ repoRoot, workspaceDirs, concurrency: 2, spawn });
 
-  assert.equal(maxActive, 2);
+  // The contract is the one in this test's name: never MORE than the
+  // configured concurrency. Asserting exactly 2 additionally demanded that the
+  // scheduler be saturated at the moment of measurement, which depends on
+  // which worker's mkdtemp resolved first — so it failed about one run in
+  // three on main, before this file was touched.
+  assert.ok(maxActive <= 2, `expected at most 2 concurrent workspaces, saw ${maxActive}`);
+  // …and the cap must not be met by doing less work: every workspace ran.
+  assert.equal(started, workspaceDirs.length);
 });
 
 test('cancellation terminates active workspace process trees and starts no queued work', async () => {


### PR DESCRIPTION
Task #147 收尾。两个 commit，**顺序重要**。

## 🚨 主线：`headless` 此前在任何并行失败时都没有在跑

`runParallel` 只要有一个 workspace 失败就 throw，而串行批次是紧接着的下一条语句 —— **于是串行 workspace 一次都没执行**。

这不是理论问题。`SERIAL_WORKSPACE_DIRS` 里目前只有 `packages/headless`，而本地 `storage` / `cli` **每次**都挂（Node v25 打 `node:sqlite` ExperimentalWarning，那些用例断言 stderr 为空）。所以：

> **`headless` 在本地一直没有运行，而且没有任何提示。** 汇总输出只是提前结束了 —— 看起来像"跑得比较短"，不像"跳过了一个包"。

实测每种状态下**实际产出结果的 workspace 数**：

| 状态 | 实际跑了 |
|---|---|
| 当前 main | **9 / 10**（headless 缺席） |
| 只加串行化（不修这条） | **7 / 10**（headless + runtime + runtime-host 全缺席） |
| **本 PR 两个 commit** | **10 / 10** ✅ |

**我差点被自己的假绿骗过去**：只加串行化那版跑出 **46s（原 92s）、目标包零失败**，又快又绿 —— 实际是三个包没运行。核对"哪些 workspace 产出了结果行"才发现。

现在两个批次都跑，失败合并上报。取消语义不变：signal aborted 时跳过串行批次，因为那是调用方明确要求停。

## commit 2：串行化 runtime / runtime-host（临时缓解 #2132）

**它们不是在抢共享资源** —— 实测逐个证伪：

| 配置 | 结果 |
|---|---|
| `--concurrency 3` | 3/3 次至少挂一个 |
| `--concurrency 1`（全 workspace） | 0/2 次挂 |
| 各包单独跑 | 全过 |
| ❌ 「/tmp 被塞满」 | 331 → **339** 条目，readdir **1ms** |
| ❌ 「上个包进程没收干净」 | 背靠背连跑 3 轮全过 |

**真因是机器饱和下三条固定等待的测试错过窗口。** 所以这是**临时缓解**，用整体耗时换 review 流程不被假红打断；根因修复在 **#2132**，落地后请删掉这两条。同次调查发现的 `/tmp` 硬编码隔离缺口是 **#2133**。

⚠️ **顺序**：commit 2 单独存在是**有害的**（会让这两个包彻底不跑），必须建立在 commit 1 之上。

## runner 自测：两条断言修正，**没有放宽**

两条自测把结果钉在 **spawn 顺序**上，而那是 runner 从不承诺的东西（取决于哪个 worker 的 `mkdtemp` 先返回）。**两条在 main 上本来就 flaky**（实测 baseline 3 次挂 1 次），我这次多一次 spawn 把其中一条变成稳定挂。

- **聚合测试**：mock 改成**按 workspace 目录**派退出码，而不是调用序号 —— 「core 退出码 1」变成 fixture 的事实而非掷硬币，断言保持精确。**并新增断言：串行 workspace 确实跑了**（就是上面那条回归）。
- **并发上限测试**：改成断言它自己名字里的契约 —— *never MORE than* 配置的并发度 —— 外加**每个 workspace 都启动了**，这样"少跑"不能用来满足上限。原来断言 `=== 2` 额外要求"测量瞬间调度器恰好饱和"。

自测现在 **5/5 稳定**，main 上大约 1/3 会挂。

## 验证

`format:check` ✅ / `lint` ✅ / runner 自测 5/5 ✅ / **`npm run test:scripts` ✅** / 全量 workspace 跑 **10/10 产出结果**（storage + cli 仍是 Node v25 既有失败）。

@maka-审美专家 请 review。合入后我按裁定去 #2132 补评论说明全貌。