### PR TITLE
test(desktop): stabilize Skill draft restoration

### DIFF
--- a/apps/desktop/e2e/composer-skill-invocation.spec.ts
+++ b/apps/desktop/e2e/composer-skill-invocation.spec.ts
@@ -188,10 +188,12 @@ test('staged Skills come back as chips after leaving and returning', async ({
   const pick = async (query: string, name: RegExp) => {
     await composer.click();
     await composer.pressSequentially(` /${query}`);
-    await expect(
-      page.getByRole('listbox', { name: '技能' }).getByRole('option', { name }),
-    ).toBeVisible();
-    await composer.press('Enter');
+    const option = page.getByRole('listbox', { name: '技能' }).getByRole('option', { name });
+    await expect(option).toBeVisible();
+    // This journey owns draft restoration, while keyboard selection is covered
+    // separately. Select the exact option without coupling setup to the
+    // popover's transient highlighted-item state under concurrent workers.
+    await option.click();
   };
 
   await composer.fill('alpha-marker');


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Select the exact visible Skill option directly when preparing the draft-restoration E2E scenario.
- Keep this test focused on restoring multiple staged Skill chips across session navigation.
- Leave keyboard selection coverage to the dedicated composer Skill tests in the same suite.

## Validation

- `staged Skills come back as chips after leaving and returning`: 100/100 repeated runs with 4 workers
- Full `composer-skill-invocation.spec.ts`: 7/7 passed
- Desktop typecheck
- Repository format check
- Repository lint

</details>

<details>
<summary>中文</summary>

## 概要

- 在准备草稿恢复 E2E 场景时，直接选择准确且可见的 Skill 选项。
- 让该测试聚焦于跨会话导航恢复多个暂存 Skill chip 的行为。
- 键盘选择行为继续由同一测试套件中的专门用例覆盖。

## 验证

- `staged Skills come back as chips after leaving and returning`：4 workers 下重复运行 100/100 通过
- 完整 `composer-skill-invocation.spec.ts`：7/7 通过
- Desktop typecheck
- 仓库格式检查
- 仓库 lint

</details>
