### PR TITLE
fix(settings): use Astryx Link for the last bare anchors, and refresh the memory seed

### DIFF
--- a/apps/desktop/src/renderer/settings/web-search-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/web-search-settings-page.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { Link } from '@astryxdesign/core';
 import type { AppSettings, UpdateAppSettingsResult, WebSearchCredentialStatus } from '@maka/core';
 import { normalizeSearchUrl, webSearchCredentialStatusFromResponse } from '@maka/core';
 import { Button, StatusDot, TextInput, RelativeTime, Switch, redactSecrets, useMountedRef, useToast, useUiLocale } from '@maka/ui';
@@ -281,7 +282,7 @@ export function WebSearchSettingsPage(props: {
           />
           {!usingEnvKey && (
             <small className="settingsQuietStatus">
-              <a href="https://tavily.com" target="_blank" rel="noreferrer noopener">tavily.com</a>
+              <Link href="https://tavily.com" target="_blank" rel="noreferrer noopener">tavily.com</Link>
             </small>
           )}
         </SettingsField>
@@ -394,7 +395,7 @@ export function WebSearchSettingsPage(props: {
             <ul className="settingsWebSearchResults" aria-label={copy.resultsAria}>
               {safeRows.map((row, idx) => (
                 <li key={`${row.url}-${idx}`} className="settingsWebSearchResult">
-                  <a href={row.url} target="_blank" rel="noreferrer noopener">{row.title}</a>
+                  <Link href={row.url} target="_blank" rel="noreferrer noopener">{row.title}</Link>
                   <small>{row.source}</small>
                   <p>{row.snippet}</p>
                 </li>

--- a/packages/core/src/__tests__/local-memory.test.ts
+++ b/packages/core/src/__tests__/local-memory.test.ts
@@ -620,7 +620,10 @@ describe('local MEMORY.md contract', () => {
     const parsed = parseLocalMemoryMarkdown(defaultLocalMemoryMarkdown(1700000000000));
     assert.equal(parsed.safeMode, false);
     assert.equal(parsed.entries.length, 1);
-    assert.equal(parsed.entries[0]?.id, 'mem-5de3e38c014ca2d7');
+    // Content-addressed: the id is a hash of the template body, so it moves
+    // whenever the seed copy does. Recomputed from the source, not copied out
+    // of a failure message.
+    assert.equal(parsed.entries[0]?.id, 'mem-e060c48e23fe4573');
     assert.equal(parsed.entries[0]?.origin, 'manual');
   });
 });

--- a/packages/core/src/local-memory.ts
+++ b/packages/core/src/local-memory.ts
@@ -256,7 +256,7 @@ export function normalizeLocalMemorySettings(input: unknown): LocalMemorySetting
 
 export function defaultLocalMemoryMarkdown(now = Date.now()): string {
   const exampleContent =
-    '这里写你希望 Maka 记住的长期偏好。默认不会注入给 agent；需要在设置里单独开启“agent 可读取本地记忆”。';
+    '这里写你希望 Maka 记住的长期偏好。默认不会提供给模型；需要在设置里单独开启“模型上下文可读取”。';
   const exampleId = stableLocalMemoryEntryId(exampleContent, now);
   return [
     '# Maka Memory',


### PR DESCRIPTION
两条 review 标为非阻塞的小尾巴，趁文件打开一并清掉。

## 1. 最后两处裸 `<a href>`

`web-search-settings-page.tsx` 里剩的两处：**tavily.com 注册链接**（review 点名的那处）+ **实时查询结果行**（同一个页面往下一屏，同样的写法）。两处都换成 Astryx `Link` —— 现在这一页的外链**全部**走正典组件。

> review 只点名了第一处，第二处是同族，一起清干净比留一半好。

## 2. MEMORY.md 默认种子文案已经过期

原文：
> 默认不会**注入**给 agent；需要在设置里单独开启「**agent 可读取本地记忆**」

**两处都不再成立**：开关现在叫「模型上下文可读取」，而记忆页的文案在 #2120 已经不再用「注入」的说法。

**一个指向用户找不到的设置名的种子文案，比什么都不写更糟。**

改成：
> 默认不会**提供给模型**；需要在设置里单独开启「**模型上下文可读取**」

### ⚠️ 连带影响：条目 id 是内容哈希

这条目的 id 由模板正文哈希而来，改文案就会变：`mem-5de3e38c014ca2d7` → `mem-e060c48e23fe4573`。

**新值是从源码重新计算出来的、并确认跑两次稳定**，不是从失败信息里抄的：
```
node -e "…defaultLocalMemoryMarkdown(1700000000000) → parse → entries[0].id"
→ mem-e060c48e23fe4573（两次一致）
```
测试里也加了注释说明这个 id 是内容寻址的，改种子文案就会移动。

**只影响新建的 MEMORY.md**；已存在的文件保留自己的内容和 id。

## 验证

build ✅ / typecheck 0 error ✅ / format:check ✅ / check-dead-css ✅ / test:checks ✅ / workspace 套件（core / computer-use / ui / desktop / mcp / runtime / headless 全过）。

已知失败：`storage` / `cli` 是 Node v25 `node:sqlite`。另外 **`runtime-host` 这次又偶发挂了一回、单跑通过** —— 这正是缓解措施该有的表现：**它降低发生率，不是根治**，根因修复仍在 #2132。

@maka-审美专家 请 review。