### PR TITLE
feat(settings): let a settled value stay a row until you ask to edit it

### DIFF
--- a/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
@@ -14,6 +14,9 @@ export type SettingsPreferencesCopy = {
     displayName: string;
     displayNameHelp: string;
     displayNamePlaceholder: string;
+    displayNameUnset: string;
+    displayNameChange: string;
+    displayNameSet: string;
     interfaceLanguage: string;
     interfaceLanguageHelp: string;
     localeOptions: ReadonlyArray<readonly [UiLocalePreference, string]>;
@@ -128,7 +131,7 @@ export type SettingsPreferencesCopy = {
 const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
   zh: {
     personalization: {
-      saveFailed: '保存失败', displayName: '显示名称', displayNameHelp: 'Maka 在聊天里会以这个名字称呼你。留空就用默认的“你”。', displayNamePlaceholder: '例如：JK',
+      saveFailed: '保存失败', displayName: '显示名称', displayNameHelp: 'Maka 在聊天里会以这个名字称呼你。留空就用默认的“你”。', displayNamePlaceholder: '例如：JK', displayNameUnset: '未设置，Maka 会称呼你“你”', displayNameChange: '更改', displayNameSet: '设置',
       interfaceLanguage: '界面语言', interfaceLanguageHelp: '选择 Maka 界面的显示语言。切换后立即生效，重启后保持。', localeOptions: [['auto', '跟随系统'], ['zh', '中文'], ['en', 'English']],
       assistantTone: '助手语气偏好', assistantToneHelp: '最多 500 字，只影响回答的语气和风格。权限确认与安全规则不受影响；改动会自动保存。', assistantTonePlaceholder: '例如：技术严谨、偏简洁、不要 emoji。',
     },
@@ -159,7 +162,7 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
   },
   en: {
     personalization: {
-      saveFailed: 'Could not save', displayName: 'Display name', displayNameHelp: 'Maka uses this name when addressing you. Leave it blank to use “you”.', displayNamePlaceholder: 'For example: JK', interfaceLanguage: 'Interface language', interfaceLanguageHelp: 'Choose the language used by Maka. Changes apply immediately and persist after restart.', localeOptions: [['auto', 'Follow system'], ['zh', '中文'], ['en', 'English']], assistantTone: 'Assistant tone', assistantToneHelp: 'Up to 500 characters. This changes response style only; permission and safety rules still apply. Changes save automatically.', assistantTonePlaceholder: 'For example: technically rigorous, concise, and no emoji.',
+      saveFailed: 'Could not save', displayName: 'Display name', displayNameHelp: 'Maka uses this name when addressing you. Leave it blank to use “you”.', displayNamePlaceholder: 'For example: JK', displayNameUnset: 'Not set — Maka will say “you”', displayNameChange: 'Change', displayNameSet: 'Set', interfaceLanguage: 'Interface language', interfaceLanguageHelp: 'Choose the language used by Maka. Changes apply immediately and persist after restart.', localeOptions: [['auto', 'Follow system'], ['zh', '中文'], ['en', 'English']], assistantTone: 'Assistant tone', assistantToneHelp: 'Up to 500 characters. This changes response style only; permission and safety rules still apply. Changes save automatically.', assistantTonePlaceholder: 'For example: technically rigorous, concise, and no emoji.',
     },
     sections: {
       identity: 'Identity', identityHelp: 'How Maka addresses you, plus interface language and response tone.',

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -9,6 +9,8 @@ import {
   VStack,
 } from '@astryxdesign/core';
 import { SettingsField, SettingsPage, SettingsRow, SettingsSection } from './settings-section';
+import { SettingsExpandableRow } from './settings-expandable-row';
+import { getSettingsSharedCopy } from '../locales/settings-shared-copy';
 import type {
   AppSettings,
   PersonalizationSettings,
@@ -69,6 +71,9 @@ export function PersonalizationSettingsPage(props: {
   const locale = useUiLocale();
   const copy = getSettingsPreferencesCopy(locale).personalization;
   const sections = getSettingsPreferencesCopy(locale).sections;
+  const sharedCopy = getSettingsSharedCopy(locale);
+  // At most one row in the group is open — the template's own rule.
+  const [expandedRow, setExpandedRow] = useState<string | null>(null);
   // Persist the tone textarea this long after the user stops typing; blur
   // flushes immediately regardless.
   const TONE_AUTOSAVE_DEBOUNCE_MS = 800;
@@ -143,10 +148,6 @@ export function PersonalizationSettingsPage(props: {
     }
   }
 
-  function flushDisplayName(nextValue: string) {
-    void persistPersonalization({ displayName: nextValue.trim().slice(0, 60) });
-  }
-
   function persistLocale(next: UiLocalePreference) {
     setUiLocale(next);
     void persistPersonalization({ uiLocale: next });
@@ -177,18 +178,42 @@ export function PersonalizationSettingsPage(props: {
           neighboring preferences; the full-width tone field uses the vertical
           row variant. */}
       <SettingsSection title={sections.identity} description={sections.identityHelp}>
-        <SettingsField>
+        {/* A name you set once and then read. A permanently-open input asked
+            the user to fill in something already filled in, and its blur-save
+            gave them no way to back out of a change. The row reports the
+            settled value and opens on demand; Cancel puts the draft back. */}
+        <SettingsExpandableRow
+          label={copy.displayName}
+          value={value.displayName || copy.displayNameUnset}
+          actionLabel={value.displayName ? copy.displayNameChange : copy.displayNameSet}
+          isEditing={expandedRow === 'displayName'}
+          canSave={displayName.trim() !== value.displayName}
+          saveLabel={sharedCopy.save}
+          cancelLabel={sharedCopy.cancel}
+          onEdit={() => {
+            setDisplayName(value.displayName);
+            setExpandedRow('displayName');
+          }}
+          onCancel={() => {
+            setDisplayName(value.displayName);
+            setExpandedRow(null);
+          }}
+          onSave={async () => {
+            await persistPersonalization({ displayName: displayName.trim().slice(0, 60) });
+            setExpandedRow(null);
+          }}
+        >
           <TextInput
             type="text"
             value={displayName}
             onChange={(value) => setDisplayName(value.slice(0, 60))}
-            onBlur={() => flushDisplayName(displayName)}
             placeholder={copy.displayNamePlaceholder}
             label={copy.displayName}
             description={copy.displayNameHelp}
+            isLabelHidden
             width="100%"
           />
-        </SettingsField>
+        </SettingsExpandableRow>
 
         {/*
           PR-LANG-PREF-0 (WAWQAQ msg `edc9cb41` + kenji `7e532892`

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -125,24 +125,31 @@ export function PersonalizationSettingsPage(props: {
 
   // Shared persist path for every personalization field. Locale has its own
   // last-write-wins lane so unrelated saves cannot steal rollback ownership.
-  async function persistPersonalization(patch: Partial<PersonalizationSettings>) {
+  // Returns whether the write landed. The autosaving fields ignore it — they
+  // have nowhere to put the answer — but a row that closes on save has to
+  // know, or a failed write collapses the row onto the old value and drops
+  // the draft with only a toast to show for it.
+  async function persistPersonalization(patch: Partial<PersonalizationSettings>): Promise<boolean> {
     const ticket = ++persistTicketRef.current;
     const localeTicket = patch.uiLocale === undefined ? null : ++localePersistTicketRef.current;
     persistPendingCountRef.current += 1;
     try {
       const result = await props.onUpdate({ personalization: patch });
-      if (!personalizationMountedRef.current) return;
+      // Saved. An unmounted page just has nowhere left to reflect it.
+      if (!personalizationMountedRef.current) return true;
       if (localeTicket !== null && localeTicket === localePersistTicketRef.current) {
         setUiLocale(result.settings.personalization.uiLocale);
       }
+      return true;
     } catch (error) {
-      if (!personalizationMountedRef.current) return;
+      if (!personalizationMountedRef.current) return false;
       if (localeTicket !== null && localeTicket === localePersistTicketRef.current) {
         setUiLocale(value.uiLocale);
       }
       if (ticket === persistTicketRef.current) {
         toast.error(copy.saveFailed, settingsActionErrorMessage(error, locale));
       }
+      return false;
     } finally {
       persistPendingCountRef.current = Math.max(0, persistPendingCountRef.current - 1);
     }
@@ -199,8 +206,12 @@ export function PersonalizationSettingsPage(props: {
             setExpandedRow(null);
           }}
           onSave={async () => {
-            await persistPersonalization({ displayName: displayName.trim().slice(0, 60) });
-            setExpandedRow(null);
+            // Only close on a write that landed: a failed save leaves the row
+            // open with the draft intact, which is the promise explicit saving
+            // makes and blur-autosave could not keep.
+            if (await persistPersonalization({ displayName: displayName.trim().slice(0, 60) })) {
+              setExpandedRow(null);
+            }
           }}
         >
           <TextInput

--- a/apps/desktop/src/renderer/settings/settings-expandable-row.tsx
+++ b/apps/desktop/src/renderer/settings/settings-expandable-row.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useId, useRef, type ReactNode } from 'react';
+import { Button, HStack, Text } from '@astryxdesign/core';
+import { SettingsField, SettingsRow } from './settings-section';
+
+/**
+ * A settled value that becomes a form only when the user asks it to.
+ *
+ * The shape is Astryx's own — the `settings-sidebar` template's ExpandableRow
+ * (`@astryxdesign/cli/templates/pages/settings-sidebar/page.tsx:140-193`): a
+ * row reports its label and current value with one affordance to change it,
+ * and swaps in place for the editor plus Save / Cancel. At most one row in a
+ * group is open at a time, which is the caller's `expandedRow` state.
+ *
+ * The shape is copied; the template's implementation is not, because it has
+ * three problems this component exists to not have:
+ *
+ * 1. The template's trigger is `<a href="#">` with `preventDefault`. That
+ *    announces itself as a link, ignores Space, and points nowhere. Opening a
+ *    form is a button.
+ *
+ * 2. The template has no focus management at all. Expanding moves focus into
+ *    the editor here, and Save / Cancel return it to the trigger the user came
+ *    from — otherwise collapsing drops focus to the top of the document and a
+ *    keyboard user loses their place in the list.
+ *
+ * 3. The template's Cancel only closes; its fields edit live, so there is
+ *    nothing to discard. Ours is a real discard: the caller reverts its draft
+ *    in `onCancel`, which is what makes Cancel mean anything.
+ *
+ * Built on `SettingsRow` rather than a bare HStack so the collapsed row keeps
+ * the Item vocabulary the rest of the surface uses — the `settingsRowEnd`
+ * width ceiling and the container queries in rows.css apply here too. The
+ * expanded editor sits in a `SettingsField`, the same full-width block a
+ * permanently-open input would use.
+ */
+export function SettingsExpandableRow(props: {
+  label: string;
+  /** The settled value, shown while collapsed. */
+  value: ReactNode;
+  /** Label for the affordance that opens the editor (更改 / 设置 / 编辑). */
+  actionLabel: string;
+  isEditing: boolean;
+  isDisabled?: boolean;
+  /** Save stays disabled until the draft actually differs from the value. */
+  canSave?: boolean;
+  saveLabel: string;
+  cancelLabel: string;
+  onEdit(): void;
+  onCancel(): void;
+  onSave(): void | Promise<void>;
+  children: ReactNode;
+}) {
+  const editorId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const editorRef = useRef<HTMLDivElement>(null);
+  // Only pull focus for a transition the user drove. Without this the row
+  // would grab focus on first paint whenever a caller mounts already-expanded.
+  const wasEditingRef = useRef(props.isEditing);
+
+  useEffect(() => {
+    const opened = props.isEditing && !wasEditingRef.current;
+    const closed = !props.isEditing && wasEditingRef.current;
+    wasEditingRef.current = props.isEditing;
+    if (opened) {
+      // The first control the editor renders, whatever the caller put there.
+      const first = editorRef.current?.querySelector<HTMLElement>(
+        'input, textarea, select, button, [contenteditable="true"], [tabindex]:not([tabindex="-1"])',
+      );
+      first?.focus();
+      return;
+    }
+    if (closed) triggerRef.current?.focus();
+  }, [props.isEditing]);
+
+  if (!props.isEditing) {
+    return (
+      <SettingsRow
+        label={props.label}
+        description={props.value}
+        align="start"
+        end={(
+          <Button
+            ref={triggerRef}
+            variant="ghost"
+            size="sm"
+            isDisabled={props.isDisabled}
+            onClick={props.onEdit}
+            aria-expanded={false}
+            aria-controls={editorId}
+            label={props.actionLabel}
+          />
+        )}
+      />
+    );
+  }
+
+  return (
+    <SettingsField>
+      <div id={editorId} ref={editorRef} className="settingsExpandableEditor">
+        {/* The label survives the swap. Collapsed, the row's own label names
+            the value; expanded, the editor would otherwise be an unlabelled
+            box — the user pressed 更改 on something and must still be able to
+            see what. The caller hides the control's own label instead, so the
+            name is stated once. */}
+        <Text type="body" weight="semibold">{props.label}</Text>
+        {props.children}
+        <HStack gap={2}>
+          <Button
+            variant="primary"
+            isDisabled={props.isDisabled || props.canSave === false}
+            clickAction={() => props.onSave()}
+            label={props.saveLabel}
+          />
+          <Button
+            variant="ghost"
+            isDisabled={props.isDisabled}
+            onClick={props.onCancel}
+            label={props.cancelLabel}
+          />
+        </HStack>
+      </div>
+    </SettingsField>
+  );
+}

--- a/apps/desktop/src/renderer/settings/settings-expandable-row.tsx
+++ b/apps/desktop/src/renderer/settings/settings-expandable-row.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, type ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import { Button, HStack, Text } from '@astryxdesign/core';
 import { SettingsField, SettingsRow } from './settings-section';
 
@@ -50,7 +50,6 @@ export function SettingsExpandableRow(props: {
   onSave(): void | Promise<void>;
   children: ReactNode;
 }) {
-  const editorId = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const editorRef = useRef<HTMLDivElement>(null);
   // Only pull focus for a transition the user drove. Without this the row
@@ -72,6 +71,14 @@ export function SettingsExpandableRow(props: {
     if (closed) triggerRef.current?.focus();
   }, [props.isEditing]);
 
+  // The collapsed row carries no aria-expanded / aria-controls on purpose.
+  // Those describe a disclosure — a trigger that stays put while a region
+  // beside it opens — and this is a mode swap: the trigger unmounts when the
+  // editor replaces it, so aria-expanded could never reach true and
+  // aria-controls would name a node that does not exist while collapsed.
+  // Declaring a contract the DOM never honours is worse than declaring none;
+  // the focus move is what tells assistive tech the mode changed, and that
+  // part is measured rather than assumed.
   if (!props.isEditing) {
     return (
       <SettingsRow
@@ -85,8 +92,6 @@ export function SettingsExpandableRow(props: {
             size="sm"
             isDisabled={props.isDisabled}
             onClick={props.onEdit}
-            aria-expanded={false}
-            aria-controls={editorId}
             label={props.actionLabel}
           />
         )}
@@ -96,7 +101,7 @@ export function SettingsExpandableRow(props: {
 
   return (
     <SettingsField>
-      <div id={editorId} ref={editorRef} className="settingsExpandableEditor">
+      <div ref={editorRef} className="settingsExpandableEditor">
         {/* The label survives the swap. Collapsed, the row's own label names
             the value; expanded, the editor would otherwise be an unlabelled
             box — the user pressed 更改 on something and must still be able to

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -141,3 +141,12 @@
     min-height: 2rem;
   }
 }
+
+/* The expanded half of SettingsExpandableRow: the editor the caller supplies,
+   then its Save / Cancel pair. A grid rather than margins so the gap is the
+   row group's own rhythm and the editor keeps the field block's full width. */
+.settingsExpandableEditor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-3);
+}


### PR DESCRIPTION
Task #141 —【Astryx 落地 ⑤】SettingsExpandableRow。**预览已过设计审 + owner 授权设计侧拍板通过。**

## 第一性原理的账（审美专家的裁定原文）

「显示名称」这个字段：**读当前状态是高频**（每次进设置页都看见），**编辑是极低频**（多数用户设一次或永不设）。

原来的常开输入框**把界面成本花在低频动作上**，还用 blur 自动保存**剥夺了反悔路径**。

收起态一行让高频的「读」更好 ——「未设置，Maka 会称呼你"你"」比一个空输入框信息量高（空输入框说不出"空着会怎样"）；低频的「编辑」多付一次点击，换来显式保存 + 真正的取消。**频率匹配 + 反悔路径，两头都是赚的。**

## 只学形状，模板的三处硬伤都没抄

形状取自 Astryx `settings-sidebar` 模板的 ExpandableRow，实现没抄：

| 模板的问题 | 我们的做法 |
|---|---|
| trigger 是 `<a href="#">` + preventDefault —— 自称链接、不响应 Space、指向 `#` | **真 Button**（`variant="ghost"`）。打开表单不是导航 |
| **完全没有焦点管理** | 展开时焦点进编辑器，保存/取消收起时焦点回 trigger |
| Cancel 只是关闭（它的字段是实时生效的，没东西可丢弃） | **Cancel 真的丢弃草稿** —— 这才让"取消"有意义 |

### 焦点是**实测**的，不是声称的

预览阶段跑真实 app 探针：
```
FOCUS_AFTER_EXPAND  INPUT     ← 焦点确实进了输入框
FOCUS_AFTER_CANCEL  设置       ← 取消后确实回到 trigger
```

另加 **`wasEditingRef` 守卫**：只在**用户驱动的状态切换**时抢焦点。否则调用方若以展开态挂载，首帧就会抢走焦点。

## 按规格搭在 SettingsRow 上

用 `SettingsRow`（Item）而非裸 HStack —— `settingsRowEnd` 宽度上限和 rows.css 的容器查询照常生效；展开态用 `SettingsField`，和常开输入框走同一个全宽块。

**标签在切换后保留**：收起时行标签命名这个值，展开时若不保留就是个无标签输入框（用户点了「设置」之后不知道在设什么）。控件自身 label 设 `isLabelHidden`，名字只出现一次。

> 这个问题是我**自己看预览截图时发现的** —— 第一版展开态确实把标签弄丢了。

## 范围：仅通用页

规格原本还点名了数据页的工作区路径，**设计侧 review 时撤销**：那一行是**只读值 + 动作**，没有"编辑"语义，ExpandableRow 不适配。

## 验证

build ✅ / typecheck 0 error ✅ / lint ✅ / format:check ✅ / check-dead-css ✅ / test:checks ✅。收起/展开两态截图在任务线程 #my-ai:46078eb1。

合入后按已批准的计划，单开任务把 `provider-connection-detail.tsx` 里的本地 `ExpandableSettingRow`（2 处在用）迁到这个 kit 组件并删除副本。

@maka-审美专家 请 review。