### PR TITLE
feat(desktop): add Runtime Host Session adapter core

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
@@ -1,0 +1,340 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { RuntimeHostConnection } from '@maka/runtime-host/client';
+import type {
+  OperationInput,
+  OperationKey,
+  SessionCatalogProjection,
+} from '@maka/runtime-host/protocol';
+import {
+  DesktopRuntimeHostClient,
+  DesktopRuntimeHostClientError,
+} from '../runtime-host-client.js';
+
+test('restarts a paginated catalog read instead of mixing revisions', async () => {
+  const revisionOne = catalogRevision('1');
+  const revisionTwo = catalogRevision('2');
+  const { client, requests } = clientWithResponses([
+    {
+      kind: 'page',
+      revision: revisionOne,
+      sessions: [session('stale', 1)],
+      nextCursor: 'stale-cursor',
+    },
+    {
+      kind: 'revision_changed',
+      expectedRevision: revisionOne,
+      actualRevision: revisionTwo,
+    },
+    {
+      kind: 'page',
+      revision: revisionTwo,
+      sessions: [session('fresh-1', 2)],
+      nextCursor: 'fresh-cursor',
+    },
+    {
+      kind: 'page',
+      revision: revisionTwo,
+      sessions: [session('fresh-2', 1)],
+      nextCursor: null,
+    },
+  ]);
+
+  assert.deepEqual(
+    (await client.listSessions({ isArchived: false })).map(({ id }) => id),
+    ['fresh-1', 'fresh-2'],
+  );
+  assert.deepEqual(requests, [
+    {
+      operation: 'session.catalog.query',
+      input: { kind: 'list_start', filter: { isArchived: false } },
+    },
+    {
+      operation: 'session.catalog.query',
+      input: {
+        kind: 'list_continue',
+        filter: { isArchived: false },
+        revision: revisionOne,
+        cursor: 'stale-cursor',
+      },
+    },
+    {
+      operation: 'session.catalog.query',
+      input: { kind: 'list_start', filter: { isArchived: false } },
+    },
+    {
+      operation: 'session.catalog.query',
+      input: {
+        kind: 'list_continue',
+        filter: { isArchived: false },
+        revision: revisionTwo,
+        cursor: 'fresh-cursor',
+      },
+    },
+  ]);
+});
+
+test('re-reads the Session revision before retrying a product update', async () => {
+  const { client, requests } = clientWithResponses([
+    { kind: 'session', session: session('session-1', 4) },
+    { kind: 'revision_conflict', expectedRevision: 4, actualRevision: 5 },
+    { kind: 'session', session: session('session-1', 5) },
+    { kind: 'committed', session: session('session-1', 6, { name: 'Renamed' }) },
+  ]);
+
+  const updated = await client.updateSessionMetadata('session-1', { name: 'Renamed' });
+
+  assert.equal(updated.revision, 6);
+  assert.equal(updated.name, 'Renamed');
+  assert.deepEqual(requests, [
+    {
+      operation: 'session.catalog.query',
+      input: { kind: 'get', sessionId: 'session-1' },
+    },
+    {
+      operation: 'session.metadata.update',
+      input: {
+        sessionId: 'session-1',
+        expectedRevision: 4,
+        patch: { name: 'Renamed' },
+      },
+    },
+    {
+      operation: 'session.catalog.query',
+      input: { kind: 'get', sessionId: 'session-1' },
+    },
+    {
+      operation: 'session.metadata.update',
+      input: {
+        sessionId: 'session-1',
+        expectedRevision: 5,
+        patch: { name: 'Renamed' },
+      },
+    },
+  ]);
+});
+
+test('merges a configuration patch into each fresh CAS projection', async () => {
+  const { client, requests } = clientWithResponses([
+    { kind: 'session', session: session('session-1', 10) },
+    { kind: 'revision_conflict', expectedRevision: 10, actualRevision: 11 },
+    {
+      kind: 'session',
+      session: session('session-1', 11, { collaborationMode: 'plan' }),
+    },
+    {
+      kind: 'committed',
+      session: session('session-1', 12, {
+        collaborationMode: 'plan',
+        permissionMode: 'execute',
+      }),
+    },
+  ]);
+
+  const updated = await client.updateSessionConfiguration('session-1', {
+    permissionMode: 'execute',
+  });
+
+  assert.equal(updated.permissionMode, 'execute');
+  assert.equal(updated.collaborationMode, 'plan');
+  assert.deepEqual(
+    requests
+      .filter(({ operation }) => operation === 'session.configuration.update')
+      .map(({ input }) => input),
+    [
+      {
+        sessionId: 'session-1',
+        expectedRevision: 10,
+        configuration: {
+          modelTarget: {
+            kind: 'explicit',
+            connectionSlug: 'test-connection',
+            model: 'test-model',
+          },
+          thinkingLevel: null,
+          permissionMode: 'execute',
+          collaborationMode: 'agent',
+          orchestrationMode: 'default',
+        },
+      },
+      {
+        sessionId: 'session-1',
+        expectedRevision: 11,
+        configuration: {
+          modelTarget: {
+            kind: 'explicit',
+            connectionSlug: 'test-connection',
+            model: 'test-model',
+          },
+          thinkingLevel: null,
+          permissionMode: 'execute',
+          collaborationMode: 'plan',
+          orchestrationMode: 'default',
+        },
+      },
+    ],
+  );
+});
+
+test('treats empty configuration patches as read-only lookups', async () => {
+  const unlocked = session('session-1', 10, { connectionLocked: false });
+  const { client, requests } = clientWithResponses([
+    { kind: 'session', session: unlocked },
+    { kind: 'session', session: unlocked },
+  ]);
+
+  assert.deepEqual(await client.updateSessionConfiguration('session-1', {}), unlocked);
+  assert.deepEqual(
+    await client.updateSessionConfiguration('session-1', { thinkingLevel: undefined }),
+    unlocked,
+  );
+  assert.deepEqual(requests, [
+    {
+      operation: 'session.catalog.query',
+      input: { kind: 'get', sessionId: 'session-1' },
+    },
+    {
+      operation: 'session.catalog.query',
+      input: { kind: 'get', sessionId: 'session-1' },
+    },
+  ]);
+});
+
+test('binds message controls to the current Host Epoch', async () => {
+  const { client, requests } = clientWithResponses([
+    { disposition: 'steering', queueRevision: 2 },
+    { queueRevision: 3, retracted: [] },
+    {
+      queueRevision: 4,
+      retracted: [],
+      turn: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        runId: 'run-1',
+        status: 'cancelled',
+        terminalEventId: 'event-1',
+        abortSource: 'user',
+      },
+    },
+  ]);
+
+  await client.submitMessage({
+    sessionId: 'session-1',
+    messageId: 'message-1',
+    content: { text: 'Steer it' },
+    placement: 'current_turn',
+  });
+  await client.retractQueue({ sessionId: 'session-1', retractId: 'retract-1' });
+  await client.interruptTurn({
+    sessionId: 'session-1',
+    interruptId: 'interrupt-1',
+    turnId: 'turn-1',
+    runId: 'run-1',
+  });
+
+  assert.deepEqual(requests, [
+    {
+      operation: 'turn.message.submit',
+      input: {
+        sessionId: 'session-1',
+        messageId: 'message-1',
+        content: { text: 'Steer it' },
+        placement: 'current_turn',
+        originHostEpoch: 'host-current',
+      },
+    },
+    {
+      operation: 'queue.retract',
+      input: {
+        sessionId: 'session-1',
+        retractId: 'retract-1',
+        originHostEpoch: 'host-current',
+      },
+    },
+    {
+      operation: 'turn.interrupt',
+      input: {
+        sessionId: 'session-1',
+        interruptId: 'interrupt-1',
+        turnId: 'turn-1',
+        runId: 'run-1',
+        originHostEpoch: 'host-current',
+      },
+    },
+  ]);
+});
+
+test('fails explicitly when the Host cannot represent a legacy Session', async () => {
+  const { client } = clientWithResponses([
+    {
+      kind: 'session',
+      session: {
+        kind: 'unsupported_legacy_record',
+        id: 'legacy-session',
+        revision: 1,
+        reason: 'not_wire_representable',
+      },
+    },
+  ]);
+
+  await assert.rejects(
+    () => client.getSession('legacy-session'),
+    (error: unknown) =>
+      error instanceof DesktopRuntimeHostClientError && error.code === 'unsupported_session',
+  );
+});
+
+interface RecordedRequest {
+  operation: OperationKey;
+  input: unknown;
+}
+
+function clientWithResponses(responses: unknown[]): {
+  client: DesktopRuntimeHostClient;
+  requests: RecordedRequest[];
+} {
+  const requests: RecordedRequest[] = [];
+  const connection = {
+    hostEpoch: 'host-current',
+    request: async <K extends OperationKey>(operation: K, input: OperationInput<K>) => {
+      requests.push({ operation, input });
+      if (responses.length === 0) throw new Error(`Unexpected operation: ${operation}`);
+      return responses.shift();
+    },
+    close: async () => undefined,
+  } as unknown as RuntimeHostConnection;
+  return { client: new DesktopRuntimeHostClient(connection), requests };
+}
+
+function catalogRevision(seed: string): `sha256:${string}` {
+  return `sha256:${seed.repeat(64)}`;
+}
+
+function session(
+  id: string,
+  revision: number,
+  overrides: Partial<SessionCatalogProjection> = {},
+): SessionCatalogProjection {
+  return {
+    id,
+    revision,
+    cwd: '/workspace',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: id,
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    labelsTruncated: false,
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test-connection',
+    connectionLocked: true,
+    model: 'test-model',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+    ...overrides,
+  };
+}

--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { connectRuntimeHost } from '@maka/runtime-host/client';
+import {
+  HOST_OPERATION_SPECS,
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  type OperationKey,
+} from '@maka/runtime-host/protocol';
+import {
+  RuntimeHostKernel,
+  type RuntimeHostComposition,
+} from '@maka/runtime-host/server';
+import {
+  resolveStorageRoot,
+  tryAcquireInteractiveRootOwner,
+} from '@maka/storage/root-authority';
+import { DesktopRuntimeHostClient } from '../runtime-host-client.js';
+
+test('drives Desktop Session operations through a real Runtime Host connection', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-desktop-host-client-'));
+  let host: RuntimeHostKernel | undefined;
+  try {
+    const capability = await resolveStorageRoot({ path: base, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    const projected = session('session-1');
+    host = await RuntimeHostKernel.start({
+      owner,
+      idleGraceMs: 10_000,
+      compositionFactory: async ({ hostEpoch }) => ({
+        handlers: handlers({
+          'session.catalog.query': async (input) =>
+            input.kind === 'get'
+              ? { ok: true, result: { kind: 'session', session: projected } }
+              : {
+                  ok: true,
+                  result: {
+                    kind: 'page',
+                    revision: catalogRevision('1'),
+                    sessions: [projected],
+                    nextCursor: null,
+                  },
+                },
+          'turn.message.submit': async (input) => {
+            assert.equal(input.originHostEpoch, hostEpoch);
+            return { ok: true, result: { disposition: 'steering', queueRevision: 1 } };
+          },
+        }),
+        beginDrain() {},
+        async recover() {},
+        async close() {},
+      }),
+    });
+    const connected = await connectRuntimeHost({
+      rootPath: base,
+      surface: 'desktop',
+      protocol: {
+        min: RUNTIME_HOST_PROTOCOL_VERSION,
+        max: RUNTIME_HOST_PROTOCOL_VERSION,
+      },
+    });
+    assert.equal(connected.kind, 'connected');
+    if (connected.kind !== 'connected') throw new Error('Desktop did not connect to Runtime Host');
+    const client = new DesktopRuntimeHostClient(connected.connection);
+
+    assert.deepEqual(await client.listSessions(), [projected]);
+    assert.deepEqual(
+      await client.updateSessionConfiguration(projected.id, { thinkingLevel: undefined }),
+      projected,
+    );
+    assert.deepEqual(
+      await client.submitMessage({
+        sessionId: projected.id,
+        messageId: 'message-1',
+        content: { text: 'Continue with the new constraints.' },
+        placement: 'current_turn',
+      }),
+      { disposition: 'steering', queueRevision: 1 },
+    );
+
+    await client.close();
+  } finally {
+    await host?.close().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+type TestHandlers = Partial<RuntimeHostComposition['handlers']>;
+
+function handlers(overrides: TestHandlers): RuntimeHostComposition['handlers'] {
+  const unavailable = Object.fromEntries(
+    (Object.keys(HOST_OPERATION_SPECS) as OperationKey[])
+      .filter((operation) => operation !== 'host.status')
+      .map((operation) => [
+        operation,
+        async () => ({
+          ok: false,
+          error: {
+            code: 'operation_unavailable',
+            message: `${operation} is unavailable in the Desktop adapter fixture`,
+          },
+        }),
+      ]),
+  );
+  return { ...unavailable, ...overrides } as RuntimeHostComposition['handlers'];
+}
+
+function catalogRevision(seed: string): `sha256:${string}` {
+  return `sha256:${seed.repeat(64)}`;
+}
+
+function session(id: string) {
+  return {
+    id,
+    revision: 1,
+    cwd: '/workspace',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Desktop Host Session',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    labelsTruncated: false,
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test-connection',
+    connectionLocked: true,
+    model: 'test-model',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+  } as const;
+}

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -1,12 +1,54 @@
 import { decodeStoredMessageForRead, type StoredMessage } from '@maka/core/session';
 import {
+  type DirectRequestOperationKey,
   type RuntimeHostConnection,
   type RuntimeHostSessionSubscription,
 } from '@maka/runtime-host/client';
 import {
+  type InteractionAnswerInput,
+  type OperationInput,
+  type OperationOutput,
+  type QueueRetractInput,
+  type QueueRetractResult,
+  type SessionCatalogFilter,
+  type SessionCatalogItem,
+  type SessionCatalogProjection,
+  type SessionCatalogQueryResult,
+  type SessionConfiguration,
   type SessionContinuitySnapshot,
+  type SessionConversationCopyInput,
+  type SessionConversationCopyResult,
+  type SessionCreateInput,
+  type SessionLifecycleState,
+  type SessionMetadataPatch,
+  type SessionUpdateResult,
   type SubscriptionFrame,
+  type TurnInterruptInput,
+  type TurnInterruptResult,
+  type TurnMessageSubmitInput,
+  type TurnMessageSubmitResult,
 } from '@maka/runtime-host/protocol';
+
+const MAX_OPTIMISTIC_ATTEMPTS = 3;
+
+export type DesktopSessionConfigurationPatch = Partial<SessionConfiguration>;
+
+export type DesktopRuntimeHostClientErrorCode =
+  | 'catalog_unstable'
+  | 'client_closed'
+  | 'revision_conflict'
+  | 'session_not_found'
+  | 'unsupported_session';
+
+export class DesktopRuntimeHostClientError extends Error {
+  constructor(
+    readonly code: DesktopRuntimeHostClientErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'DesktopRuntimeHostClientError';
+  }
+}
 
 export interface DesktopRuntimeHostSession {
   readonly snapshot: SessionContinuitySnapshot;
@@ -21,12 +63,217 @@ export class DesktopRuntimeHostClient {
 
   constructor(private readonly connection: RuntimeHostConnection) {}
 
+  async listSessions(filter?: SessionCatalogFilter): Promise<SessionCatalogProjection[]> {
+    for (let attempt = 0; attempt < MAX_OPTIMISTIC_ATTEMPTS; attempt += 1) {
+      const sessions = await this.#readCatalog(filter);
+      if (sessions) return sessions;
+    }
+    throw new DesktopRuntimeHostClientError(
+      'catalog_unstable',
+      'Session catalog kept changing while Desktop read it',
+    );
+  }
+
+  async getSession(sessionId: string): Promise<SessionCatalogProjection | null> {
+    const result = await this.#request('session.catalog.query', { kind: 'get', sessionId });
+    if (result.kind !== 'session') {
+      throw new DesktopRuntimeHostClientError(
+        'catalog_unstable',
+        'Runtime Host returned an invalid Session catalog lookup',
+      );
+    }
+    return result.session === null ? null : requireSessionProjection(result.session);
+  }
+
+  async createSession(input: SessionCreateInput): Promise<SessionCatalogProjection> {
+    return requireSessionProjection(await this.#request('session.create', input));
+  }
+
+  updateSessionMetadata(
+    sessionId: string,
+    patch: SessionMetadataPatch,
+  ): Promise<SessionCatalogProjection> {
+    return this.#updateSession(sessionId, (current) =>
+      this.#request('session.metadata.update', {
+        sessionId,
+        expectedRevision: current.revision,
+        patch,
+      }),
+    );
+  }
+
+  async updateSessionConfiguration(
+    sessionId: string,
+    patch: DesktopSessionConfigurationPatch,
+  ): Promise<SessionCatalogProjection> {
+    const definedPatch = Object.fromEntries(
+      Object.entries(patch).filter(([, value]) => value !== undefined),
+    ) as DesktopSessionConfigurationPatch;
+    if (Object.keys(definedPatch).length === 0) return this.#requireSession(sessionId);
+    return this.#updateSession(sessionId, (current) =>
+      this.#request('session.configuration.update', {
+        sessionId,
+        expectedRevision: current.revision,
+        configuration: {
+          // An unlocked Session still follows the Host-owned default route.
+          // Once execution or an explicit model change locks it, the resolved
+          // catalog route is the explicit target that must survive this patch.
+          modelTarget: current.connectionLocked
+            ? {
+                kind: 'explicit',
+                connectionSlug: current.llmConnectionSlug,
+                model: current.model,
+              }
+            : { kind: 'default' },
+          thinkingLevel: current.thinkingLevel ?? null,
+          permissionMode: current.permissionMode,
+          collaborationMode: current.collaborationMode,
+          orchestrationMode: current.orchestrationMode,
+          ...definedPatch,
+        },
+      }),
+    );
+  }
+
+  relocateSessionCwd(sessionId: string, cwd: string): Promise<SessionCatalogProjection> {
+    return this.#updateSession(sessionId, (current) =>
+      this.#request('session.cwd.relocate', {
+        sessionId,
+        expectedRevision: current.revision,
+        cwd,
+      }),
+    );
+  }
+
+  async setSessionReadMarker(
+    sessionId: string,
+    readThroughMessageId: string,
+  ): Promise<SessionCatalogProjection> {
+    return requireSessionProjection(
+      await this.#request('session.read_marker.set', { sessionId, readThroughMessageId }),
+    );
+  }
+
+  async setSessionLifecycle(
+    sessionId: string,
+    state: SessionLifecycleState,
+  ): Promise<SessionCatalogProjection> {
+    return requireSessionProjection(
+      await this.#request('session.lifecycle.set', { sessionId, state }),
+    );
+  }
+
+  async removeSession(sessionId: string): Promise<void> {
+    for (let attempt = 0; attempt < MAX_OPTIMISTIC_ATTEMPTS; attempt += 1) {
+      const current = await this.#requireSession(sessionId);
+      const result = await this.#request('session.remove', {
+        sessionId,
+        expectedRevision: current.revision,
+      });
+      if (result.kind === 'removed') return;
+    }
+    throw revisionConflict('remove', sessionId);
+  }
+
+  async copySession(
+    kind: 'branch' | 'revision',
+    input: Omit<SessionConversationCopyInput, 'expectedSourceRevision'>,
+  ): Promise<SessionCatalogProjection> {
+    for (let attempt = 0; attempt < MAX_OPTIMISTIC_ATTEMPTS; attempt += 1) {
+      const source = await this.#requireSession(input.sourceSessionId);
+      const request = { ...input, expectedSourceRevision: source.revision };
+      const result: SessionConversationCopyResult =
+        kind === 'branch'
+          ? await this.#request('session.branch.create', request)
+          : await this.#request('session.revision.create', request);
+      if (result.kind === 'committed') return requireSessionProjection(result.session);
+    }
+    throw revisionConflict(`${kind} copy`, input.sourceSessionId);
+  }
+
+  submitMessage(
+    input: Omit<TurnMessageSubmitInput, 'originHostEpoch'>,
+  ): Promise<TurnMessageSubmitResult> {
+    return this.#request('turn.message.submit', {
+      ...input,
+      originHostEpoch: this.connection.hostEpoch,
+    });
+  }
+
+  retractQueue(input: Omit<QueueRetractInput, 'originHostEpoch'>): Promise<QueueRetractResult> {
+    return this.#request('queue.retract', {
+      ...input,
+      originHostEpoch: this.connection.hostEpoch,
+    });
+  }
+
+  interruptTurn(
+    input: Omit<TurnInterruptInput, 'originHostEpoch'>,
+  ): Promise<TurnInterruptResult> {
+    return this.#request('turn.interrupt', {
+      ...input,
+      originHostEpoch: this.connection.hostEpoch,
+    });
+  }
+
+  answerInteraction(input: InteractionAnswerInput): Promise<OperationOutput<'interaction.answer'>> {
+    return this.#request('interaction.answer', input);
+  }
+
+  queryInteraction(
+    input: OperationInput<'interaction.query'>,
+  ): Promise<OperationOutput<'interaction.query'>> {
+    return this.#request('interaction.query', input);
+  }
+
+  startTurn(input: OperationInput<'turn.start'>): Promise<OperationOutput<'turn.start'>> {
+    return this.#request('turn.start', input);
+  }
+
+  queryTurn(input: OperationInput<'turn.query'>): Promise<OperationOutput<'turn.query'>> {
+    return this.#request('turn.query', input);
+  }
+
+  stopTurn(input: OperationInput<'turn.stop'>): Promise<OperationOutput<'turn.stop'>> {
+    return this.#request('turn.stop', input);
+  }
+
+  regenerateTurn(
+    input: OperationInput<'turn.regenerate'>,
+  ): Promise<OperationOutput<'turn.regenerate'>> {
+    return this.#request('turn.regenerate', input);
+  }
+
+  queryTurnResume(
+    input: OperationInput<'turn.resume.query'>,
+  ): Promise<OperationOutput<'turn.resume.query'>> {
+    return this.#request('turn.resume.query', input);
+  }
+
+  startTurnResume(
+    input: OperationInput<'turn.resume.start'>,
+  ): Promise<OperationOutput<'turn.resume.start'>> {
+    return this.#request('turn.resume.start', input);
+  }
+
+  queryContextDiagnostics(
+    sessionId: string,
+  ): Promise<OperationOutput<'context.diagnostics.query'>> {
+    return this.#request('context.diagnostics.query', { sessionId });
+  }
+
+  compactContext(
+    input: OperationInput<'context.compact'>,
+  ): Promise<OperationOutput<'context.compact'>> {
+    return this.#request('context.compact', input);
+  }
+
   async openSession(sessionId: string): Promise<DesktopRuntimeHostSession> {
-    if (this.#closeTask) throw new Error('Desktop Runtime Host Client is closed');
+    this.#assertOpen();
     const subscription = await this.connection.openSessionSubscription({ sessionId });
     if (this.#closeTask) {
       await subscription.close().catch(() => undefined);
-      throw new Error('Desktop Runtime Host Client is closed');
+      throw clientClosed();
     }
     const session = new DesktopSessionHandle(subscription, () => this.#sessions.delete(session));
     this.#sessions.add(session);
@@ -44,6 +291,84 @@ export class DesktopRuntimeHostClient {
     } finally {
       await this.connection.close();
     }
+  }
+
+  async #updateSession(
+    sessionId: string,
+    update: (current: SessionCatalogProjection) => Promise<SessionUpdateResult>,
+  ): Promise<SessionCatalogProjection> {
+    for (let attempt = 0; attempt < MAX_OPTIMISTIC_ATTEMPTS; attempt += 1) {
+      const current = await this.#requireSession(sessionId);
+      const result = await update(current);
+      if (result.kind === 'committed') return requireSessionProjection(result.session);
+    }
+    throw revisionConflict('update', sessionId);
+  }
+
+  async #readCatalog(
+    filter: SessionCatalogFilter | undefined,
+  ): Promise<SessionCatalogProjection[] | undefined> {
+    const first = await this.#request('session.catalog.query', {
+      kind: 'list_start',
+      ...(filter ? { filter } : {}),
+    });
+    if (first.kind !== 'page') {
+      throw new DesktopRuntimeHostClientError(
+        'catalog_unstable',
+        'Runtime Host returned an invalid initial Session catalog page',
+      );
+    }
+    const sessions: SessionCatalogProjection[] = [];
+    const cursors = new Set<string>();
+    let page: Extract<SessionCatalogQueryResult, { kind: 'page' }> = first;
+    while (true) {
+      sessions.push(...page.sessions.map(requireSessionProjection));
+      const cursor = page.nextCursor;
+      if (cursor === null) return sessions;
+      if (cursors.has(cursor)) {
+        throw new DesktopRuntimeHostClientError(
+          'catalog_unstable',
+          'Runtime Host repeated a Session catalog cursor',
+        );
+      }
+      cursors.add(cursor);
+      const next = await this.#request('session.catalog.query', {
+        kind: 'list_continue',
+        ...(filter ? { filter } : {}),
+        revision: first.revision,
+        cursor,
+      });
+      if (next.kind === 'revision_changed') return undefined;
+      if (next.kind !== 'page') {
+        throw new DesktopRuntimeHostClientError(
+          'catalog_unstable',
+          'Runtime Host returned an invalid Session catalog continuation',
+        );
+      }
+      if (next.revision !== first.revision) return undefined;
+      page = next;
+    }
+  }
+
+  async #requireSession(sessionId: string): Promise<SessionCatalogProjection> {
+    const session = await this.getSession(sessionId);
+    if (session) return session;
+    throw new DesktopRuntimeHostClientError(
+      'session_not_found',
+      `Runtime Host Session not found: ${sessionId}`,
+    );
+  }
+
+  #request<K extends DirectRequestOperationKey>(
+    operation: K,
+    input: OperationInput<K>,
+  ): Promise<OperationOutput<K>> {
+    this.#assertOpen();
+    return this.connection.request(operation, input);
+  }
+
+  #assertOpen(): void {
+    if (this.#closeTask) throw clientClosed();
   }
 }
 
@@ -67,4 +392,23 @@ class DesktopSessionHandle implements DesktopRuntimeHostSession {
     this.#closeTask ??= this.subscription.close().finally(this.onClose);
     return this.#closeTask;
   }
+}
+
+function requireSessionProjection(item: SessionCatalogItem): SessionCatalogProjection {
+  if (!('kind' in item)) return item;
+  throw new DesktopRuntimeHostClientError(
+    'unsupported_session',
+    `Runtime Host Session is not representable by this Desktop Client: ${item.id}`,
+  );
+}
+
+function clientClosed(): DesktopRuntimeHostClientError {
+  return new DesktopRuntimeHostClientError('client_closed', 'Desktop Runtime Host Client is closed');
+}
+
+function revisionConflict(operation: string, sessionId: string): DesktopRuntimeHostClientError {
+  return new DesktopRuntimeHostClientError(
+    'revision_conflict',
+    `Runtime Host Session kept changing during ${operation}: ${sessionId}`,
+  );
 }


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Add a Desktop main-process adapter for Runtime Host Session catalog, configuration, lifecycle, Turn, Interaction, queue, and context operations.
- Keep paginated catalog reads revision-consistent and make Session updates conflict-safe through bounded CAS retries.
- Bind message control requests to the active Host Epoch inside the adapter, so renderer-facing callers do not handle Host ownership details.
- Treat empty configuration patches as read-only lookups, preserving Host-owned default model routing.

## Scope

This establishes the production-shaped Session/Turn adapter boundary. Existing Desktop IPC remains on the embedded runtime until the later composition cutover, avoiding two concurrent runtime owners during migration.

## Validation

- Desktop main-process typecheck
- Runtime Host client adapter tests, including an isolated real UDS journey
- Full Desktop test suite: 1625 passed
- Repository format and lint checks

</details>

<details>
<summary>中文</summary>

## 摘要

- 为 Desktop main process 增加 Runtime Host Session catalog、配置、生命周期、Turn、Interaction、队列和上下文操作适配层。
- 分页 catalog 读取保持 revision 一致；Session 写操作通过有界 CAS 重试安全处理并发冲突。
- 消息控制请求的 Host Epoch 由适配层绑定，renderer-facing 调用方无需感知 Host ownership 细节。
- 空配置 patch 只执行读取，避免意外锁定由 Host 管理的默认模型路由。

## 范围

本 PR 建立 production-shaped Session/Turn adapter 边界。现有 Desktop IPC 暂时继续使用 embedded runtime，等后续 composition cutover 再统一切换，避免迁移期间出现两个 runtime owner。

## 验证

- Desktop main-process typecheck
- Runtime Host client adapter 测试，包括隔离环境中的真实 UDS 链路
- 完整 Desktop 测试：1625 项通过
- 仓库 format 与 lint 检查

</details>

Part of #2010.
