### PR TITLE
refactor(settings): one expandable row component, not two

### DIFF
--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -10,6 +10,7 @@ import {
   useUiLocale,
 } from '@maka/ui';
 import { PasswordInput } from './password-input';
+import { SettingsExpandableRow } from './settings-expandable-row';
 import { getProviderSettingsCopy } from '../locales/settings-provider-copy';
 import { providerDisplay } from './provider-display';
 import { EnabledModelManager } from './provider-enabled-model-manager';
@@ -215,14 +216,15 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
           <VStack gap={0}>
             <Divider />
             {supportsApiKey && (
-              <ExpandableSettingRow
+              <>
+              <SettingsExpandableRow
                 label={copy.modelKey}
                 value={apiKeyStatusHint}
                 actionLabel={hasSecret === true ? copy.change : copy.set}
                 isEditing={editingRow === 'key'}
                 isDisabled={detailActionBusy}
                 canSave={hasApiKeyChange}
-                saveLabel={busy ? copy.saving : copy.save}
+                saveLabel={copy.save}
                 cancelLabel={copy.cancel}
                 onEdit={() => openRow('key')}
                 onCancel={() => { setApiKey(''); setEditingRow(null); }}
@@ -246,17 +248,20 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
                     {copy.getModelKey}
                   </Link>
                 )}
-              </ExpandableSettingRow>
+              </SettingsExpandableRow>
+              <Divider />
+              </>
             )}
             {showsEndpoint && (
-              <ExpandableSettingRow
+              <>
+              <SettingsExpandableRow
                 label={copy.endpoint}
                 value={savedBaseUrl || copy.endpointDefault}
                 actionLabel={copy.edit}
                 isEditing={editingRow === 'endpoint'}
                 isDisabled={detailActionBusy}
                 canSave={hasBaseUrlChange}
-                saveLabel={busy ? copy.saving : copy.save}
+                saveLabel={copy.save}
                 cancelLabel={copy.cancel}
                 onEdit={() => openRow('endpoint')}
                 onCancel={() => { setBaseUrl(savedBaseUrl); setEditingRow(null); }}
@@ -270,7 +275,9 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
                   placeholder={defaults.baseUrl}
                   isDisabled={detailActionBusy}
                 />
-              </ExpandableSettingRow>
+              </SettingsExpandableRow>
+              <Divider />
+              </>
             )}
           </VStack>
         )}
@@ -325,63 +332,6 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
  * as heading → sentence → controls; it splits into two columns for free if the
  * shell ever widens.
  */
-/**
- * A settled value: its name, what it currently is, and one link to change it.
- * Editing swaps the row in place for the control plus save / cancel — the
- * settings-sidebar template's ExpandableRow, which is the shape Astryx uses for
- * exactly this (a password that is already set, an address already on file).
- *
- * The Divider trails each row, as in the template, so a stack of rows carries
- * its own separators without the caller interleaving them.
- */
-function ExpandableSettingRow(props: {
-  label: string;
-  value: string;
-  actionLabel: string;
-  isEditing: boolean;
-  isDisabled: boolean;
-  canSave: boolean;
-  saveLabel: string;
-  cancelLabel: string;
-  onEdit(): void;
-  onCancel(): void;
-  onSave(): void | Promise<void>;
-  children: ReactNode;
-}) {
-  return (
-    <>
-      {props.isEditing ? (
-        <VStack gap={3} paddingBlock={4}>
-          <Text type="body" weight="semibold">{props.label}</Text>
-          {props.children}
-          <HStack gap={2}>
-            <Button
-              variant="primary"
-              isDisabled={props.isDisabled || !props.canSave}
-              onClick={() => void props.onSave()}
-              label={props.saveLabel}
-            />
-            <Button variant="ghost" isDisabled={props.isDisabled} onClick={props.onCancel} label={props.cancelLabel} />
-          </HStack>
-        </VStack>
-      ) : (
-        <HStack hAlign="between" vAlign="start" gap={4} paddingBlock={4}>
-          <VStack gap={0}>
-            <Text type="body" weight="semibold">{props.label}</Text>
-            <Text type="supporting" color="secondary">{props.value}</Text>
-          </VStack>
-          {/* A button, not a Link: this opens a form, it does not navigate. As
-              a link it announced itself as one, ignored Space, and pointed at
-              "#". Astryx has no link-styled variant, and ghost is the right
-              weight for a row affordance anyway. */}
-          <Button variant="ghost" size="sm" isDisabled={props.isDisabled} onClick={props.onEdit} label={props.actionLabel} />
-        </HStack>
-      )}
-      <Divider />
-    </>
-  );
-}
-
 function DetailSection(props: { title: string; description: string; children: ReactNode }) {
   return (
     /* `columnGap`, not `gap`: the template's 10 is the gutter BETWEEN the two


### PR DESCRIPTION
Task #149 — `ExpandableSettingRow` 去重（#141 合入后按约定开）。

## 改了什么

`provider-connection-detail.tsx` 里的本地 `ExpandableSettingRow` 删掉，两处调用换成 kit 的 `SettingsExpandableRow`。**净 -50 行。**

**顺带白拿到的**：本地那份早就修了模板的「链接当 trigger」，但**从来没有焦点管理**，所以密钥行和服务地址行是这个界面上唯二保存/取消后**不把焦点还给 trigger** 的设置行。现在有了。

## 两个 swap 必须接住的细节

1. **分隔线**：本地组件自己尾随一个 `<Divider />`，kit 把横线交给行组。改到调用点画，**rule-row-rule-row-rule 的序列不变**。
2. **保存按钮不再改名成「保存中…」**：kit 的 Save 走 `clickAction`（自带 spinner）。核过 `save()` 内部**没有 confirm**，所以没有 #137 那个 transition 死锁风险。

## 验证

typecheck 0 / lint / format:check / check-dead-css / test:checks / providers + settings e2e。

**`providers.spec.ts:256`「keeps each settled row to its own field on a provider that has two」原样通过** —— 那正是这两行存在的意义。

前后截图（收起/展开）已发任务线程：**行略微更紧凑、拿到 Item 的标签样式和缩进** —— 这就是采用共享组件的含义，不是回归。

`providers.spec.ts:71` 是离线环境专属失败（网络错误 toast 在 500px 视口遮住删除按钮），与干净 main 上一模一样。

@maka-审美专家 请 review。