### PR TITLE
feat(desktop): add Runtime Host Session catalog IPC

### DIFF
--- a/apps/desktop/src/main/__tests__/create-session-input.test.ts
+++ b/apps/desktop/src/main/__tests__/create-session-input.test.ts
@@ -10,7 +10,11 @@ import { describe, it } from 'node:test';
 import type { AppSettings, ChatDefaultPermissionMode } from '@maka/core';
 import { DEEP_RESEARCH_SESSION_LABEL, DEFAULT_SESSION_NAME } from '@maka/core';
 
-import { type CreateSessionRequest, resolveCreateSessionInput } from '../create-session-input.js';
+import {
+  type CreateSessionRequest,
+  resolveCreateSessionInput,
+  resolveCreateSessionRequest,
+} from '../create-session-input.js';
 
 function settings(permissionMode: ChatDefaultPermissionMode) {
   return async () => ({ chatDefaults: { permissionMode } }) as AppSettings;
@@ -23,6 +27,18 @@ function resolve(input: unknown, readSettings = settings('ask')) {
 }
 
 describe('resolveCreateSessionInput', () => {
+  it('leaves an ordinary default permission choice to the owning runtime', () => {
+    assert.equal(resolveCreateSessionRequest(undefined).permissionMode, undefined);
+    assert.equal(resolveCreateSessionRequest({ permissionMode: 'bypass' }).permissionMode, 'bypass');
+    assert.deepEqual(resolveCreateSessionRequest({ mode: 'deep_research' }), {
+      mode: 'deep_research',
+      collaborationMode: 'agent',
+      orchestrationMode: 'default',
+      name: DEFAULT_SESSION_NAME,
+      labels: undefined,
+    });
+  });
+
   it('forces the read-only boundary for Deep Research', async () => {
     const resolved = await resolve({ mode: 'deep_research' });
     assert.equal(resolved.permissionMode, 'explore');

--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -3,11 +3,13 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import type { IpcMain } from 'electron';
 import { connectRuntimeHost } from '@maka/runtime-host/client';
 import {
   HOST_OPERATION_SPECS,
   RUNTIME_HOST_PROTOCOL_VERSION,
   type OperationKey,
+  type SessionCatalogProjection,
 } from '@maka/runtime-host/protocol';
 import {
   RuntimeHostKernel,
@@ -18,6 +20,7 @@ import {
   tryAcquireInteractiveRootOwner,
 } from '@maka/storage/root-authority';
 import { DesktopRuntimeHostClient } from '../runtime-host-client.js';
+import { registerRuntimeHostSessionCatalogIpc } from '../runtime-host-session-catalog-ipc-main.js';
 
 test('drives Desktop Session operations through a real Runtime Host connection', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-desktop-host-client-'));
@@ -88,6 +91,137 @@ test('drives Desktop Session operations through a real Runtime Host connection',
   }
 });
 
+test('drives the renderer Session catalog facade through real UDS framing', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-desktop-host-ipc-'));
+  let host: RuntimeHostKernel | undefined;
+  let projected: SessionCatalogProjection | undefined;
+  try {
+    const capability = await resolveStorageRoot({ path: base, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    host = await RuntimeHostKernel.start({
+      owner,
+      idleGraceMs: 10_000,
+      compositionFactory: async () => ({
+        handlers: handlers({
+          'session.catalog.query': async (input) => {
+            if (input.kind === 'get') {
+              return {
+                ok: true,
+                result: {
+                  kind: 'session',
+                  session: projected?.id === input.sessionId ? projected : null,
+                },
+              };
+            }
+            return {
+              ok: true,
+              result: {
+                kind: 'page',
+                revision: catalogRevision(String(projected?.revision ?? 0)),
+                sessions: projected ? [projected] : [],
+                nextCursor: null,
+              },
+            };
+          },
+          'session.create': async (input) => {
+            assert.deepEqual(input.modelTarget, { kind: 'default' });
+            assert.equal(input.permissionMode, undefined);
+            projected = session(input.sessionId, {
+              cwd: input.cwd,
+              name: input.name,
+              connectionLocked: false,
+            });
+            return { ok: true, result: projected };
+          },
+          'session.configuration.update': async (input) => {
+            assert.ok(projected);
+            assert.equal(input.expectedRevision, projected.revision);
+            projected = session(projected.id, {
+              ...projected,
+              revision: projected.revision + 1,
+              permissionMode: input.configuration.permissionMode,
+              collaborationMode: input.configuration.collaborationMode,
+              orchestrationMode: input.configuration.orchestrationMode,
+              ...(input.configuration.thinkingLevel === null
+                ? {}
+                : { thinkingLevel: input.configuration.thinkingLevel }),
+            });
+            return { ok: true, result: { kind: 'committed', session: projected } };
+          },
+          'session.lifecycle.set': async (input) => {
+            assert.ok(projected);
+            const archived = input.state === 'archived';
+            projected = session(projected.id, {
+              ...projected,
+              revision: projected.revision + 1,
+              isArchived: archived,
+              status: archived ? 'archived' : 'active',
+            });
+            return { ok: true, result: projected };
+          },
+          'session.remove': async (input) => {
+            assert.ok(projected);
+            assert.equal(input.expectedRevision, projected.revision);
+            const sessionId = projected.id;
+            projected = undefined;
+            return { ok: true, result: { kind: 'removed', sessionId } };
+          },
+        }),
+        beginDrain() {},
+        async recover() {},
+        async close() {},
+      }),
+    });
+    const connected = await connectRuntimeHost({
+      rootPath: base,
+      surface: 'desktop',
+      protocol: {
+        min: RUNTIME_HOST_PROTOCOL_VERSION,
+        max: RUNTIME_HOST_PROTOCOL_VERSION,
+      },
+    });
+    assert.equal(connected.kind, 'connected');
+    if (connected.kind !== 'connected') throw new Error('Desktop did not connect to Runtime Host');
+    const client = new DesktopRuntimeHostClient(connected.connection);
+    const ipc = ipcHarness();
+    const changes: Array<{ reason: string; sessionId?: string }> = [];
+    registerRuntimeHostSessionCatalogIpc(
+      {
+        client,
+        workspaceRoot: base,
+        emitSessionsChanged: (reason, sessionId) => changes.push({ reason, sessionId }),
+        newId: () => 'session-ipc',
+      },
+      ipc,
+    );
+
+    const created = await ipc.invoke('sessions:create', undefined);
+    assert.deepEqual((await ipc.invoke('sessions:list')) as unknown[], [created]);
+    assert.equal(
+      (await ipc.invoke('sessions:setPermissionMode', 'session-ipc', 'execute') as {
+        permissionMode: string;
+      }).permissionMode,
+      'execute',
+    );
+    await ipc.invoke('sessions:archive', 'session-ipc');
+    assert.equal((await ipc.invoke('sessions:list') as Array<{ isArchived: boolean }>)[0]?.isArchived, true);
+    await ipc.invoke('sessions:remove', 'session-ipc');
+    assert.deepEqual(await ipc.invoke('sessions:list'), []);
+    assert.deepEqual(changes, [
+      { reason: 'created', sessionId: 'session-ipc' },
+      { reason: 'mode-change', sessionId: 'session-ipc' },
+      { reason: 'archived', sessionId: 'session-ipc' },
+      { reason: 'deleted', sessionId: 'session-ipc' },
+    ]);
+
+    await client.close();
+  } finally {
+    await host?.close().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 type TestHandlers = Partial<RuntimeHostComposition['handlers']>;
 
 function handlers(overrides: TestHandlers): RuntimeHostComposition['handlers'] {
@@ -112,7 +246,27 @@ function catalogRevision(seed: string): `sha256:${string}` {
   return `sha256:${seed.repeat(64)}`;
 }
 
-function session(id: string) {
+type IpcHandler = Parameters<Pick<IpcMain, 'handle'>['handle']>[1];
+
+function ipcHarness() {
+  const ipcHandlers = new Map<string, IpcHandler>();
+  return {
+    handle(channel: string, handler: IpcHandler) {
+      assert.equal(ipcHandlers.has(channel), false, `duplicate handler: ${channel}`);
+      ipcHandlers.set(channel, handler);
+    },
+    async invoke(channel: string, ...args: unknown[]): Promise<unknown> {
+      const handler = ipcHandlers.get(channel);
+      assert.ok(handler, `missing handler: ${channel}`);
+      return handler({} as never, ...args);
+    },
+  };
+}
+
+function session(
+  id: string,
+  overrides: Partial<SessionCatalogProjection> = {},
+): SessionCatalogProjection {
   return {
     id,
     revision: 1,
@@ -133,5 +287,6 @@ function session(id: string) {
     permissionMode: 'ask',
     collaborationMode: 'agent',
     orchestrationMode: 'default',
-  } as const;
+    ...overrides,
+  };
 }

--- a/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
@@ -1,0 +1,246 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { IpcMain } from 'electron';
+import { DEEP_RESEARCH_SESSION_NAME, DEFAULT_SESSION_NAME } from '@maka/core';
+import type { SessionCatalogProjection } from '@maka/runtime-host/protocol';
+import {
+  registerRuntimeHostSessionCatalogIpc,
+  type RuntimeHostSessionCatalogIpcDeps,
+} from '../runtime-host-session-catalog-ipc-main.js';
+
+test('leaves ordinary Session defaults to the Host while preserving product modes', async () => {
+  const creates: unknown[] = [];
+  const events: Array<{ reason: string; sessionId?: string }> = [];
+  const client = catalogClient({
+    createSession: async (input) => {
+      creates.push(input);
+      return session(input.sessionId, {
+        name: input.mode === 'deep_research' ? DEEP_RESEARCH_SESSION_NAME : input.name,
+      });
+    },
+  });
+  const ipc = ipcHarness();
+  let sequence = 0;
+  registerRuntimeHostSessionCatalogIpc(
+    {
+      client,
+      workspaceRoot: '/workspace',
+      emitSessionsChanged: (reason, sessionId) => events.push({ reason, sessionId }),
+      newId: () => `session-${++sequence}`,
+    },
+    ipc,
+  );
+
+  const ordinary = await ipc.invoke('sessions:create', undefined);
+  const research = await ipc.invoke('sessions:create', {
+    mode: 'deep_research',
+    labels: ['customer-label'],
+  });
+
+  assert.equal((ordinary as { name: string }).name, DEFAULT_SESSION_NAME);
+  assert.equal((research as { id: string }).id, 'session-2');
+  assert.deepEqual(creates, [
+    {
+      sessionId: 'session-1',
+      cwd: '/workspace',
+      name: DEFAULT_SESSION_NAME,
+      modelTarget: { kind: 'default' },
+      collaborationMode: 'agent',
+      orchestrationMode: 'default',
+    },
+    {
+      sessionId: 'session-2',
+      cwd: '/workspace',
+      mode: 'deep_research',
+      labels: ['customer-label'],
+      modelTarget: { kind: 'default' },
+      collaborationMode: 'agent',
+      orchestrationMode: 'default',
+    },
+  ]);
+  assert.deepEqual(events, [
+    { reason: 'created', sessionId: 'session-1' },
+    { reason: 'created', sessionId: 'session-2' },
+  ]);
+});
+
+test('filters linked subagents without exposing the filter to the Host protocol', async () => {
+  const filters: unknown[] = [];
+  const child = session('child', {
+    subagent: { parentSessionId: 'parent', agentName: 'Worker', profile: 'default' },
+  });
+  const client = catalogClient({
+    listSessions: async (filter) => {
+      filters.push(filter);
+      return [session('parent'), child, session('other-child', { subagent: { parentSessionId: 'other' } })];
+    },
+  });
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionCatalogIpc(
+    {
+      client,
+      workspaceRoot: '/workspace',
+      emitSessionsChanged() {},
+    },
+    ipc,
+  );
+
+  const listed = await ipc.invoke('sessions:list', { subagentParentSessionId: 'parent' });
+
+  assert.deepEqual(filters, [undefined]);
+  assert.ok(Array.isArray(listed));
+  assert.equal(listed.length, 1);
+  assert.equal((listed[0] as { id: string }).id, 'child');
+  assert.deepEqual((listed[0] as { labels: string[] }).labels, []);
+  assert.deepEqual((listed[0] as { subagent: unknown }).subagent, {
+    parentSessionId: 'parent',
+    agentName: 'Worker',
+    profile: 'default',
+  });
+});
+
+test('applies family metadata and retirement actions through Host-owned operations', async () => {
+  const metadata: unknown[] = [];
+  const lifecycle: unknown[] = [];
+  const removed: string[] = [];
+  const root = session('root', { revisionRootSessionId: 'root' });
+  const revision = session('revision', { revisionRootSessionId: 'root' });
+  const client = catalogClient({
+    listSessions: async () => [root, revision],
+    updateSessionMetadata: async (sessionId, patch) => {
+      metadata.push({ sessionId, patch });
+      return session(sessionId, { name: 'Renamed', revisionRootSessionId: 'root' });
+    },
+    setSessionLifecycle: async (sessionId, state) => {
+      lifecycle.push({ sessionId, state });
+      return session(sessionId, { isArchived: state === 'archived', revisionRootSessionId: 'root' });
+    },
+    removeSession: async (sessionId) => {
+      removed.push(sessionId);
+    },
+  });
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionCatalogIpc(
+    {
+      client,
+      workspaceRoot: '/workspace',
+      emitSessionsChanged() {},
+    },
+    ipc,
+  );
+
+  await ipc.invoke('sessions:rename', 'revision', 'Renamed', { revisionFamily: true });
+  await ipc.invoke('sessions:archive', 'root', { revisionFamily: true });
+  await ipc.invoke('sessions:remove', 'revision', { revisionFamily: true });
+
+  assert.deepEqual(metadata, [
+    { sessionId: 'root', patch: { name: 'Renamed' } },
+    { sessionId: 'revision', patch: { name: 'Renamed' } },
+  ]);
+  assert.deepEqual(lifecycle, [{ sessionId: 'root', state: 'archived' }]);
+  assert.deepEqual(removed, ['revision']);
+});
+
+test('normalizes renderer configuration actions into Host patches', async () => {
+  const patches: unknown[] = [];
+  const client = catalogClient({
+    updateSessionConfiguration: async (sessionId, patch) => {
+      patches.push({ sessionId, patch });
+      return session(sessionId);
+    },
+  });
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionCatalogIpc(
+    {
+      client,
+      workspaceRoot: '/workspace',
+      emitSessionsChanged() {},
+    },
+    ipc,
+  );
+
+  await ipc.invoke('sessions:setModel', 'session-1', {
+    llmConnectionSlug: 'test-connection',
+    model: 'test-model',
+  });
+  await ipc.invoke('sessions:setThinkingLevel', 'session-1', undefined);
+  await ipc.invoke('sessions:setPermissionMode', 'session-1', 'execute');
+
+  assert.deepEqual(patches, [
+    {
+      sessionId: 'session-1',
+      patch: {
+        modelTarget: {
+          kind: 'explicit',
+          connectionSlug: 'test-connection',
+          model: 'test-model',
+        },
+        thinkingLevel: null,
+      },
+    },
+    { sessionId: 'session-1', patch: { thinkingLevel: null } },
+    { sessionId: 'session-1', patch: { permissionMode: 'execute' } },
+  ]);
+});
+
+type CatalogClient = RuntimeHostSessionCatalogIpcDeps['client'];
+
+function catalogClient(overrides: Partial<CatalogClient>): CatalogClient {
+  const unavailable = async (): Promise<never> => {
+    throw new Error('Unexpected Runtime Host Session catalog operation');
+  };
+  return {
+    createSession: unavailable,
+    listSessions: unavailable,
+    removeSession: unavailable,
+    setSessionLifecycle: unavailable,
+    updateSessionConfiguration: unavailable,
+    updateSessionMetadata: unavailable,
+    ...overrides,
+  };
+}
+
+type IpcHandler = Parameters<Pick<IpcMain, 'handle'>['handle']>[1];
+
+function ipcHarness() {
+  const handlers = new Map<string, IpcHandler>();
+  return {
+    handle(channel: string, handler: IpcHandler) {
+      assert.equal(handlers.has(channel), false, `duplicate handler: ${channel}`);
+      handlers.set(channel, handler);
+    },
+    async invoke(channel: string, ...args: unknown[]): Promise<unknown> {
+      const handler = handlers.get(channel);
+      assert.ok(handler, `missing handler: ${channel}`);
+      return handler({} as never, ...args);
+    },
+  };
+}
+
+function session(
+  id: string,
+  overrides: Partial<SessionCatalogProjection> = {},
+): SessionCatalogProjection {
+  return {
+    id,
+    revision: 1,
+    cwd: '/workspace',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: id,
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    labelsTruncated: false,
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test-connection',
+    connectionLocked: true,
+    model: 'test-model',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+    ...overrides,
+  };
+}

--- a/apps/desktop/src/main/create-session-input.ts
+++ b/apps/desktop/src/main/create-session-input.ts
@@ -24,58 +24,21 @@ import type {
   SessionStartMode,
 } from '@maka/core';
 import {
-  DEEP_RESEARCH_SESSION_LABEL,
   DEFAULT_SESSION_NAME,
   isChatDefaultPermissionMode,
   isCollaborationMode,
   isOrchestrationMode,
+  isSessionStartMode,
+  sessionStartModeSpec,
 } from '@maka/core';
 
 import { resolveDefaultPermissionMode } from './permission-mode-default.js';
-
-/**
- * The renderer names a product intent; main stays the sole authority on what
- * that intent means. A closed mapping rather than a passthrough, so nothing
- * the renderer sends can reach `explore` except the mode that earns it.
- */
-interface SessionModeSeed {
-  permissionMode: PermissionMode;
-  name: string;
-  labels: string[];
-}
-
-/**
- * Closed over `SessionStartMode`, not over an `if`: adding a member without a
- * seed is a compile error here, which is the only place that catches it. A
- * missing arm would otherwise degrade silently into "no mode at all" — a plain
- * session at the configured default, with the new mode's name, label and
- * boundary all quietly absent.
- */
-const SESSION_MODE_SEEDS = {
-  deep_research: {
-    // Deep Research is a read-only exploration boundary, so it overrides the
-    // user's configured default rather than seeding from it.
-    permissionMode: 'explore',
-    name: 'Deep Research',
-    labels: [DEEP_RESEARCH_SESSION_LABEL],
-  },
-} satisfies Record<SessionStartMode, SessionModeSeed>;
 
 /**
  * `unknown`, because this is an IPC boundary and the renderer's type is a
  * promise, not a guarantee. An unrecognized value confers nothing — it is not
  * a mode — and the caller falls through to an ordinary session, which is the
  * same session it would have got by not naming one.
- */
-function sessionModeSeed(mode: unknown): SessionModeSeed | undefined {
-  return typeof mode === 'string' && Object.hasOwn(SESSION_MODE_SEEDS, mode)
-    ? SESSION_MODE_SEEDS[mode as SessionStartMode]
-    : undefined;
-}
-
-/**
- * The part of a create request this module resolves. Everything else — cwd,
- * backend, connection, model, thinking level — stays the handler's.
  */
 export interface CreateSessionRequest {
   mode?: SessionStartMode;
@@ -94,12 +57,15 @@ export interface ResolvedCreateSessionInput {
   labels: string[] | undefined;
 }
 
-export async function resolveCreateSessionInput(
-  input: CreateSessionRequest | undefined,
-  deps: { readSettings: () => Promise<AppSettings> },
-): Promise<ResolvedCreateSessionInput> {
-  const modeSeed = sessionModeSeed(input?.mode);
+export interface ResolvedCreateSessionRequest
+  extends Omit<ResolvedCreateSessionInput, 'permissionMode'> {
+  mode?: SessionStartMode;
+  permissionMode?: PermissionMode;
+}
 
+export function resolveCreateSessionRequest(
+  input: CreateSessionRequest | undefined,
+): ResolvedCreateSessionRequest {
   const collaborationMode = input?.collaborationMode ?? 'agent';
   if (!isCollaborationMode(collaborationMode)) {
     throw new TypeError('Invalid collaboration mode.');
@@ -108,26 +74,39 @@ export async function resolveCreateSessionInput(
   if (!isOrchestrationMode(orchestrationMode)) {
     throw new TypeError('Invalid orchestration mode.');
   }
-  // `explore` is a boundary a mode confers, never one a caller may open a
-  // session at — core already spells that out as `ChatDefaultPermissionMode`
-  // (the modes a user can pick). Refusing it here is what makes the seed the
-  // only way in; `sessions:setPermissionMode` stays the separate, deliberate
-  // path for moving an existing session (the quote companion uses it).
+  // `explore` is a boundary a product mode confers, not one a caller may
+  // request directly. Existing Sessions use a separate deliberate mutation.
   if (input?.permissionMode !== undefined && !isChatDefaultPermissionMode(input.permissionMode)) {
     throw new TypeError('Invalid permission mode.');
   }
 
   return {
-    permissionMode:
-      modeSeed?.permissionMode ??
-      input?.permissionMode ??
-      (await resolveDefaultPermissionMode(deps.readSettings)),
+    ...(isSessionStartMode(input?.mode) ? { mode: input.mode } : {}),
+    ...(input?.permissionMode === undefined ? {} : { permissionMode: input.permissionMode }),
     collaborationMode,
     orchestrationMode,
-    name: modeSeed?.name ?? input?.name ?? DEFAULT_SESSION_NAME,
-    // Merged, not replaced: a mode adds a label, it does not own the set. No
-    // caller sends both today, and silently dropping the caller's would be the
-    // surprising half of that.
-    labels: modeSeed ? [...new Set([...(input?.labels ?? []), ...modeSeed.labels])] : input?.labels,
+    name: input?.name ?? DEFAULT_SESSION_NAME,
+    labels: input?.labels,
+  };
+}
+
+export async function resolveCreateSessionInput(
+  input: CreateSessionRequest | undefined,
+  deps: { readSettings: () => Promise<AppSettings> },
+): Promise<ResolvedCreateSessionInput> {
+  const request = resolveCreateSessionRequest(input);
+  const mode = request.mode === undefined ? undefined : sessionStartModeSpec(request.mode);
+  return {
+    collaborationMode: request.collaborationMode,
+    orchestrationMode: request.orchestrationMode,
+    name: mode?.name ?? request.name,
+    labels:
+      mode === undefined
+        ? request.labels
+        : [...new Set([...(request.labels ?? []), ...mode.labels])],
+    permissionMode:
+      mode?.permissionMode ??
+      request.permissionMode ??
+      (await resolveDefaultPermissionMode(deps.readSettings)),
   };
 }

--- a/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
@@ -1,0 +1,280 @@
+import { randomUUID } from 'node:crypto';
+import type { IpcMain } from 'electron';
+import {
+  isCollaborationMode,
+  isOrchestrationMode,
+  isPermissionMode,
+  isThinkingLevel,
+  type CreateSessionRequestInput,
+  type SessionChangedEvent,
+  type SessionChangedReason,
+  type SessionListFilter,
+  type SessionSummary,
+} from '@maka/core';
+import type {
+  SessionCatalogFilter,
+  SessionCatalogProjection,
+  SessionCreateInput,
+  SessionModelTarget,
+} from '@maka/runtime-host/protocol';
+import { resolveCreateSessionRequest } from './create-session-input.js';
+import type {
+  DesktopRuntimeHostClient,
+  DesktopSessionConfigurationPatch,
+} from './runtime-host-client.js';
+import {
+  requestsRevisionFamily,
+  resolveSessionActionIds,
+} from './session-family-action.js';
+import { normalizeSessionModelSelection } from './session-model-input.js';
+
+type RuntimeHostSessionCatalogClient = Pick<
+  DesktopRuntimeHostClient,
+  | 'createSession'
+  | 'listSessions'
+  | 'removeSession'
+  | 'setSessionLifecycle'
+  | 'updateSessionConfiguration'
+  | 'updateSessionMetadata'
+>;
+
+export interface DesktopHostSessionSummary extends SessionSummary {
+  labelsTruncated: boolean;
+}
+
+export interface RuntimeHostSessionCatalogIpcDeps {
+  client: RuntimeHostSessionCatalogClient;
+  workspaceRoot: string;
+  emitSessionsChanged: (
+    reason: SessionChangedReason,
+    sessionId?: string,
+    extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId' | 'turnId'>,
+  ) => void;
+  newId?: () => string;
+}
+
+export function registerRuntimeHostSessionCatalogIpc(
+  deps: RuntimeHostSessionCatalogIpcDeps,
+  ipcMain: Pick<IpcMain, 'handle'>,
+): void {
+  const newId = deps.newId ?? randomUUID;
+  const listSessions = async (filter?: SessionListFilter): Promise<DesktopHostSessionSummary[]> => {
+    const parentSessionId = normalizeParentSessionFilter(filter?.subagentParentSessionId);
+    const sessions = await deps.client.listSessions(toHostCatalogFilter(filter));
+    return sessions
+      .filter((session) =>
+        parentSessionId === undefined ? true : session.subagent?.parentSessionId === parentSessionId,
+      )
+      .map(toDesktopHostSessionSummary);
+  };
+  const actionIds = (sessionId: string, options: unknown) =>
+    resolveSessionActionIds(() => listSessions(), sessionId, options);
+
+  ipcMain.handle('sessions:list', (_event, filter?: SessionListFilter) => listSessions(filter));
+  ipcMain.handle('sessions:create', async (_event, input?: CreateSessionRequestInput) => {
+    if (input?.backend !== undefined && input.backend !== 'ai-sdk') {
+      throw new Error('Unsupported Runtime Host Session backend');
+    }
+    const request = resolveCreateSessionRequest(input);
+    const session = await deps.client.createSession({
+      sessionId: newId(),
+      cwd: input?.cwd ?? deps.workspaceRoot,
+      ...(request.mode === undefined ? {} : { mode: request.mode }),
+      ...(input?.projectId === undefined ? {} : { projectId: input.projectId }),
+      ...(request.mode === undefined ? { name: request.name } : {}),
+      ...(request.labels === undefined ? {} : { labels: request.labels }),
+      modelTarget: normalizeModelTarget(input),
+      ...normalizeCreateThinkingLevel(input?.thinkingLevel),
+      ...(request.mode !== undefined || request.permissionMode === undefined
+        ? {}
+        : { permissionMode: request.permissionMode }),
+      collaborationMode: request.collaborationMode,
+      orchestrationMode: request.orchestrationMode,
+    });
+    deps.emitSessionsChanged('created', session.id);
+    return toDesktopHostSessionSummary(session);
+  });
+  ipcMain.handle('sessions:archive', async (_event, sessionId: string, options?: unknown) => {
+    requestsRevisionFamily(options);
+    await deps.client.setSessionLifecycle(sessionId, 'archived');
+    deps.emitSessionsChanged('archived', sessionId);
+  });
+  ipcMain.handle('sessions:unarchive', async (_event, sessionId: string, options?: unknown) => {
+    requestsRevisionFamily(options);
+    await deps.client.setSessionLifecycle(sessionId, 'active');
+    deps.emitSessionsChanged('updated', sessionId);
+  });
+  ipcMain.handle(
+    'sessions:setFlagged',
+    async (_event, sessionId: string, isFlagged: unknown, options?: unknown) => {
+      if (typeof isFlagged !== 'boolean') throw new Error('Invalid flagged state');
+      for (const id of await actionIds(sessionId, options)) {
+        await deps.client.updateSessionMetadata(id, { isFlagged });
+        deps.emitSessionsChanged('pinned', id);
+      }
+    },
+  );
+  ipcMain.handle(
+    'sessions:rename',
+    async (_event, sessionId: string, name: unknown, options?: unknown) => {
+      if (typeof name !== 'string') throw new Error('Invalid Session name');
+      for (const id of await actionIds(sessionId, options)) {
+        await deps.client.updateSessionMetadata(id, { name });
+        deps.emitSessionsChanged('renamed', id);
+      }
+    },
+  );
+  ipcMain.handle('sessions:setPermissionMode', async (_event, sessionId: string, mode: unknown) => {
+    if (!isPermissionMode(mode)) throw new Error(`Invalid permission mode: ${String(mode)}`);
+    return updateConfiguration(deps, sessionId, { permissionMode: mode }, 'mode-change');
+  });
+  ipcMain.handle(
+    'sessions:setCollaborationMode',
+    async (_event, sessionId: string, mode: unknown) => {
+      if (!isCollaborationMode(mode)) {
+        throw new Error(`Invalid collaboration mode: ${String(mode)}`);
+      }
+      return updateConfiguration(deps, sessionId, { collaborationMode: mode }, 'mode-change');
+    },
+  );
+  ipcMain.handle(
+    'sessions:setOrchestrationMode',
+    async (_event, sessionId: string, mode: unknown) => {
+      if (!isOrchestrationMode(mode)) {
+        throw new Error(`Invalid orchestration mode: ${String(mode)}`);
+      }
+      return updateConfiguration(deps, sessionId, { orchestrationMode: mode }, 'mode-change');
+    },
+  );
+  ipcMain.handle('sessions:setModel', async (_event, sessionId: string, input: unknown) => {
+    const modelTarget = normalizeExplicitModel(input);
+    return updateConfiguration(
+      deps,
+      sessionId,
+      { modelTarget, thinkingLevel: null },
+      'updated',
+      { connectionSlug: modelTarget.connectionSlug, modelId: modelTarget.model },
+    );
+  });
+  ipcMain.handle('sessions:setThinkingLevel', async (_event, sessionId: string, level: unknown) => {
+    if (level !== undefined && level !== null && !isThinkingLevel(level)) {
+      throw new Error(`Invalid thinking level: ${String(level)}`);
+    }
+    return updateConfiguration(deps, sessionId, { thinkingLevel: level ?? null }, 'updated');
+  });
+  ipcMain.handle('sessions:remove', async (_event, sessionId: string, options?: unknown) => {
+    requestsRevisionFamily(options);
+    await deps.client.removeSession(sessionId);
+    deps.emitSessionsChanged('deleted', sessionId);
+  });
+}
+
+async function updateConfiguration(
+  deps: RuntimeHostSessionCatalogIpcDeps,
+  sessionId: string,
+  patch: DesktopSessionConfigurationPatch,
+  reason: SessionChangedReason,
+  extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId' | 'turnId'>,
+): Promise<DesktopHostSessionSummary> {
+  const session = await deps.client.updateSessionConfiguration(sessionId, patch);
+  deps.emitSessionsChanged(reason, sessionId, extra);
+  return toDesktopHostSessionSummary(session);
+}
+
+function toHostCatalogFilter(filter: SessionListFilter | undefined): SessionCatalogFilter | undefined {
+  if (!filter) return undefined;
+  const result: SessionCatalogFilter = {
+    ...(filter.isArchived === undefined ? {} : { isArchived: filter.isArchived }),
+    ...(filter.isFlagged === undefined ? {} : { isFlagged: filter.isFlagged }),
+    ...(filter.labelSlug === undefined ? {} : { labelSlug: filter.labelSlug }),
+  };
+  return Object.keys(result).length === 0 ? undefined : result;
+}
+
+function normalizeParentSessionFilter(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error('Invalid subagent parent Session filter');
+  }
+  return value;
+}
+
+function normalizeModelTarget(input: CreateSessionRequestInput | undefined): SessionModelTarget {
+  const slug = normalizeOptionalString(input?.llmConnectionSlug, 'model connection');
+  const model = normalizeOptionalString(input?.model, 'model');
+  if (slug === undefined && model === undefined) return { kind: 'default' };
+  if (slug === undefined || model === undefined) {
+    throw new Error('Explicit model selection requires both connection and model');
+  }
+  return { kind: 'explicit', connectionSlug: slug, model };
+}
+
+function normalizeExplicitModel(input: unknown): Extract<SessionModelTarget, { kind: 'explicit' }> {
+  const selection = normalizeSessionModelSelection(input);
+  return {
+    kind: 'explicit',
+    connectionSlug: selection.llmConnectionSlug,
+    model: selection.model,
+  };
+}
+
+function normalizeOptionalString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Invalid ${label}`);
+  }
+  return value.trim();
+}
+
+function normalizeCreateThinkingLevel(
+  value: unknown,
+): Pick<SessionCreateInput, 'thinkingLevel'> | Record<string, never> {
+  if (value === undefined) return {};
+  if (!isThinkingLevel(value)) throw new Error(`Invalid thinking level: ${String(value)}`);
+  return { thinkingLevel: value };
+}
+
+function toDesktopHostSessionSummary(
+  session: SessionCatalogProjection,
+): DesktopHostSessionSummary {
+  return {
+    id: session.id,
+    cwd: session.cwd,
+    ...(session.projectId === undefined ? {} : { projectId: session.projectId }),
+    name: session.name,
+    isFlagged: session.isFlagged,
+    isArchived: session.isArchived,
+    labels: [...session.labels],
+    labelsTruncated: session.labelsTruncated,
+    hasUnread: session.hasUnread,
+    ...(session.lastMessageAt === undefined ? {} : { lastMessageAt: session.lastMessageAt }),
+    ...(session.lastMessagePreview === undefined
+      ? {}
+      : { lastMessagePreview: session.lastMessagePreview }),
+    status: session.status,
+    ...(session.blockedReason === undefined ? {} : { blockedReason: session.blockedReason }),
+    ...(session.statusUpdatedAt === undefined ? {} : { statusUpdatedAt: session.statusUpdatedAt }),
+    ...(session.parentSessionId === undefined ? {} : { parentSessionId: session.parentSessionId }),
+    ...(session.branchOfTurnId === undefined ? {} : { branchOfTurnId: session.branchOfTurnId }),
+    ...(session.subagent === undefined ? {} : { subagent: session.subagent }),
+    ...(session.revisionRootSessionId === undefined
+      ? {}
+      : { revisionRootSessionId: session.revisionRootSessionId }),
+    ...(session.revisionParentSessionId === undefined
+      ? {}
+      : { revisionParentSessionId: session.revisionParentSessionId }),
+    ...(session.revisionOfTurnId === undefined
+      ? {}
+      : { revisionOfTurnId: session.revisionOfTurnId }),
+    ...(session.revisionIndex === undefined ? {} : { revisionIndex: session.revisionIndex }),
+    ...(session.revisionState === undefined ? {} : { revisionState: session.revisionState }),
+    backend: session.backend,
+    llmConnectionSlug: session.llmConnectionSlug,
+    connectionLocked: session.connectionLocked,
+    model: session.model,
+    ...(session.thinkingLevel === undefined ? {} : { thinkingLevel: session.thinkingLevel }),
+    permissionMode: session.permissionMode,
+    collaborationMode: session.collaborationMode,
+    orchestrationMode: session.orchestrationMode,
+  };
+}

--- a/apps/desktop/src/main/session-family-action.ts
+++ b/apps/desktop/src/main/session-family-action.ts
@@ -1,0 +1,21 @@
+import { revisionFamilySessionIds, type SessionSummary } from '@maka/core';
+
+export function requestsRevisionFamily(options: unknown): boolean {
+  if (options === undefined) return false;
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    throw new Error('Invalid session family action options');
+  }
+  const value = (options as { revisionFamily?: unknown }).revisionFamily;
+  if (value === undefined) return false;
+  if (typeof value !== 'boolean') throw new Error('Invalid revisionFamily option');
+  return value;
+}
+
+export async function resolveSessionActionIds(
+  listSessions: () => Promise<readonly SessionSummary[]>,
+  sessionId: string,
+  options: unknown,
+): Promise<string[]> {
+  if (!requestsRevisionFamily(options)) return [sessionId];
+  return revisionFamilySessionIds(await listSessions(), sessionId);
+}

--- a/apps/desktop/src/main/session-model-input.ts
+++ b/apps/desktop/src/main/session-model-input.ts
@@ -1,0 +1,21 @@
+export interface SessionModelSelection {
+  llmConnectionSlug: string;
+  model: string;
+}
+
+export function normalizeSessionModelSelection(input: unknown): SessionModelSelection {
+  if (!input || typeof input !== 'object') {
+    throw new Error('Invalid model selection');
+  }
+  const record = input as Record<string, unknown>;
+  const llmConnectionSlug = normalizeRequiredString(record.llmConnectionSlug, 'model connection');
+  const model = normalizeRequiredString(record.model, 'model');
+  return { llmConnectionSlug, model };
+}
+
+function normalizeRequiredString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Invalid ${label}`);
+  }
+  return value.trim();
+}

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -6,7 +6,6 @@ import {
   isCollaborationMode,
   isOrchestrationMode,
   isPermissionMode,
-  revisionFamilySessionIds,
   isThinkingLevel,
   sanitizeTaskLedgerTask,
   thinkingVariantsForModel,
@@ -57,6 +56,8 @@ import type { DesktopCreateSessionInput } from './new-session-project.js';
 import { registerSessionExecutionIpc } from './session-execution-ipc-main.js';
 import { createQuoteCompanionCleanupAuthority } from './quote-companion-cleanup.js';
 import { mergeSentInlineReferences } from './session-send-inline-references.js';
+import { resolveSessionActionIds } from './session-family-action.js';
+import { normalizeSessionModelSelection } from './session-model-input.js';
 
 type SessionStore = ReturnType<typeof createSessionStore>;
 type MainWindowController = ReturnType<typeof createMainWindowController>;
@@ -155,22 +156,6 @@ function latestStoredMessageTs(messages: readonly StoredMessage[]): number | und
   return latest;
 }
 
-function normalizeSessionModelSelection(input: unknown): { llmConnectionSlug: string; model: string } {
-  if (!input || typeof input !== 'object') {
-    throw new Error('Invalid model selection');
-  }
-  const record = input as Record<string, unknown>;
-  const llmConnectionSlug = typeof record.llmConnectionSlug === 'string' ? record.llmConnectionSlug.trim() : '';
-  const model = typeof record.model === 'string' ? record.model.trim() : '';
-  if (!llmConnectionSlug) {
-    throw new Error('Missing model connection');
-  }
-  if (!model) {
-    throw new Error('Missing model');
-  }
-  return { llmConnectionSlug, model };
-}
-
 function normalizeSupportedSessionThinkingLevel(
   input: unknown,
   providerType: ProviderType,
@@ -185,26 +170,6 @@ function normalizeSupportedSessionThinkingLevel(
     throw new Error(`当前模型不支持思考级别：${thinkingLevel}`);
   }
   return thinkingLevel;
-}
-
-function requestsRevisionFamily(options: unknown): boolean {
-  if (options === undefined) return false;
-  if (!options || typeof options !== 'object' || Array.isArray(options)) {
-    throw new Error('Invalid session family action options');
-  }
-  const value = (options as { revisionFamily?: unknown }).revisionFamily;
-  if (value === undefined) return false;
-  if (typeof value !== 'boolean') throw new Error('Invalid revisionFamily option');
-  return value;
-}
-
-async function resolveSessionActionIds(
-  runtime: SessionManager,
-  sessionId: string,
-  options: unknown,
-): Promise<string[]> {
-  if (!requestsRevisionFamily(options)) return [sessionId];
-  return revisionFamilySessionIds(await runtime.listSessions(), sessionId);
 }
 
 export function registerSessionsIpc(
@@ -615,7 +580,7 @@ export function registerSessionsIpc(
     });
   });
   ipcMain.handle('sessions:archive', async (_event, sessionId: string, options?: unknown) => {
-    for (const id of await resolveSessionActionIds(runtime, sessionId, options)) {
+    for (const id of await resolveSessionActionIds(() => runtime.listSessions(), sessionId, options)) {
       computerUseOverlay.clearForSession(id);
       computerUsePip?.clearForSession(id);
       computerUseScreenLock?.clearForSession(id);
@@ -631,7 +596,7 @@ export function registerSessionsIpc(
     }
   });
   ipcMain.handle('sessions:unarchive', async (_event, sessionId: string, options?: unknown) => {
-    for (const id of await resolveSessionActionIds(runtime, sessionId, options)) {
+    for (const id of await resolveSessionActionIds(() => runtime.listSessions(), sessionId, options)) {
       await goalWiring.unarchiveSession(id, () => runtime.unarchive(id));
       emitSessionsChanged('updated', id);
     }
@@ -642,7 +607,7 @@ export function registerSessionsIpc(
     isFlagged: boolean,
     options?: unknown,
   ) => {
-    for (const id of await resolveSessionActionIds(runtime, sessionId, options)) {
+    for (const id of await resolveSessionActionIds(() => runtime.listSessions(), sessionId, options)) {
       await runtime.setFlagged(id, isFlagged);
       emitSessionsChanged('pinned', id);
     }
@@ -653,7 +618,7 @@ export function registerSessionsIpc(
     name: string,
     options?: unknown,
   ) => {
-    for (const id of await resolveSessionActionIds(runtime, sessionId, options)) {
+    for (const id of await resolveSessionActionIds(() => runtime.listSessions(), sessionId, options)) {
       await runtime.renameSession(id, name);
       emitSessionsChanged('renamed', id);
     }
@@ -758,7 +723,7 @@ export function registerSessionsIpc(
     return next;
   });
   ipcMain.handle('sessions:remove', async (_event, sessionId: string, options?: unknown) => {
-    for (const id of await resolveSessionActionIds(runtime, sessionId, options)) {
+    for (const id of await resolveSessionActionIds(() => runtime.listSessions(), sessionId, options)) {
       await removeSession(id);
     }
   });

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -21,6 +21,7 @@ import {
   collapseSessionRevisions,
   filterLinkedSessionTree,
   hasSettledInitialOnboarding,
+  isLinkedSubagentSession,
   parseGraphCommand,
   parseSwarmCommand,
   projectRevisionLinkedSessionTree,
@@ -2220,7 +2221,7 @@ function AppShellContent({
                     {navSelection.section === 'sessions' &&
                     activeId &&
                     activeSessionForView &&
-                    !activeSessionForView.subagentParent ? (
+                    !isLinkedSubagentSession(activeSessionForView) ? (
                       <AgentGraphPanel
                         rootSessionId={activeId}
                         enabled={(activeSessionForView.orchestrationMode ?? 'default') === 'graph'}

--- a/packages/core/src/__tests__/subagent-session-parent.test.ts
+++ b/packages/core/src/__tests__/subagent-session-parent.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   childSessionsForParent,
   filterLinkedSessionTree,
+  isLinkedSubagentSession,
   isSubagentSessionParent,
   isSubagentSessionRuntime,
   isSubagentSessionSpawn,
@@ -142,13 +143,19 @@ describe('subagent session parent relation', () => {
     const otherChild = summary('other-child', {
       subagentParent: { ...relation, parentSessionId: 'other-parent' },
     });
+    const hostChild = summary('host-child', {
+      subagent: { parentSessionId: 'parent-session', agentName: 'Worker' },
+    });
 
     assert.deepEqual(
-      childSessionsForParent([childA, branch, childB, otherChild], 'parent-session').map(
+      childSessionsForParent([childA, branch, childB, otherChild, hostChild], 'parent-session').map(
         (session) => session.id,
       ),
-      ['child-a', 'child-b'],
+      ['child-a', 'child-b', 'host-child'],
     );
+    assert.equal(isLinkedSubagentSession(childA), true);
+    assert.equal(isLinkedSubagentSession(hostChild), true);
+    assert.equal(isLinkedSubagentSession(branch), false);
   });
 
   test('projects linked children beneath parents while preserving branches and orphans', () => {
@@ -185,10 +192,10 @@ describe('subagent session parent relation', () => {
 
   test('keeps cyclic linked relations visible as roots', () => {
     const childA = summary('child-a', {
-      subagentParent: { ...relation, parentSessionId: 'child-b' },
+      subagent: { parentSessionId: 'child-b' },
     });
     const childB = summary('child-b', {
-      subagentParent: { ...relation, parentSessionId: 'child-a' },
+      subagent: { parentSessionId: 'child-a' },
     });
 
     const tree = projectLinkedSessionTree([childA, childB]);

--- a/packages/core/src/explore-agent.ts
+++ b/packages/core/src/explore-agent.ts
@@ -7,6 +7,7 @@
  */
 
 import type { DeepResearchRun } from './deep-research-run.js';
+import type { PermissionMode } from './permission.js';
 
 /**
  * A product intent a caller can open a new session at, distinct from the
@@ -14,9 +15,42 @@ import type { DeepResearchRun } from './deep-research-run.js';
  * not a `'chat'` member: a second spelling of "no mode" is a second thing to
  * keep in agreement.
  */
-export type SessionStartMode = 'deep_research';
+export interface SessionStartModeSpec {
+  readonly name: string;
+  readonly labels: readonly string[];
+  readonly permissionMode: PermissionMode;
+}
 
-export const DEEP_RESEARCH_SESSION_LABEL = 'mode:deep_research';
+export const SESSION_START_MODE_SPECS = {
+  deep_research: {
+    name: 'Deep Research',
+    labels: ['mode:deep_research'],
+    permissionMode: 'explore',
+  },
+} as const satisfies Record<string, SessionStartModeSpec>;
+
+export type SessionStartMode = keyof typeof SESSION_START_MODE_SPECS;
+export const SESSION_START_MODES: readonly SessionStartMode[] = Object.keys(
+  SESSION_START_MODE_SPECS,
+) as SessionStartMode[];
+export const SESSION_START_MODE_LABELS: readonly string[] = [
+  ...new Set(Object.values(SESSION_START_MODE_SPECS).flatMap((spec) => spec.labels)),
+];
+
+export function isSessionStartMode(value: unknown): value is SessionStartMode {
+  return typeof value === 'string' && Object.hasOwn(SESSION_START_MODE_SPECS, value);
+}
+
+export function sessionStartModeSpec(mode: SessionStartMode): SessionStartModeSpec {
+  return SESSION_START_MODE_SPECS[mode];
+}
+
+export function isSessionStartModeLabel(value: unknown): value is string {
+  return typeof value === 'string' && SESSION_START_MODE_LABELS.includes(value);
+}
+
+export const DEEP_RESEARCH_SESSION_NAME = SESSION_START_MODE_SPECS.deep_research.name;
+export const DEEP_RESEARCH_SESSION_LABEL = SESSION_START_MODE_SPECS.deep_research.labels[0];
 
 export const DEEP_RESEARCH_WORKFLOW_STEPS = [
   {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -340,6 +340,7 @@ export type {
   SessionChangedReason,
   SessionStatus,
   SessionBlockedReason,
+  SessionSubagentProjection,
   SubagentSessionLifecycle,
   SubagentSessionParent,
   SubagentSessionRuntime,
@@ -374,6 +375,7 @@ export {
   deriveTurnRecords,
   isSessionStatus,
   isSessionBlockedReason,
+  isLinkedSubagentSession,
   isSubagentSessionParent,
   isSubagentSessionRuntime,
   isSubagentSessionSpawn,
@@ -1806,18 +1808,25 @@ export {
 } from './web-search.js';
 
 // explore-agent.ts — read-only deep research session profile.
-export type { SessionStartMode } from './explore-agent.js';
+export type { SessionStartMode, SessionStartModeSpec } from './explore-agent.js';
 export {
+  SESSION_START_MODES,
+  SESSION_START_MODE_LABELS,
+  SESSION_START_MODE_SPECS,
   DEEP_RESEARCH_EVIDENCE_CHECKLIST,
   DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_CHARS,
   DEEP_RESEARCH_PROGRESS_CHECKPOINTS,
   DEEP_RESEARCH_SESSION_LABEL,
+  DEEP_RESEARCH_SESSION_NAME,
   DEEP_RESEARCH_REPORT_SECTIONS,
   DEEP_RESEARCH_SCOPE_OPTIONS,
   DEEP_RESEARCH_STARTER_PROMPTS,
   DEEP_RESEARCH_WORKFLOW_STEPS,
   buildDeepResearchSystemPromptFragment,
   buildDeepResearchImplementationPrompt,
+  sessionStartModeSpec,
+  isSessionStartMode,
+  isSessionStartModeLabel,
   isDeepResearchSession,
 } from './explore-agent.js';
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -162,6 +162,17 @@ export type SubagentSessionRuntimeSummary = Omit<
   'systemPrompt' | 'categoryPolicy'
 >;
 
+/**
+ * Client-facing child-session relation when the durable spawn record remains
+ * inside the Runtime Host authority boundary.
+ */
+export interface SessionSubagentProjection {
+  parentSessionId: string;
+  agentId?: string;
+  agentName?: string;
+  profile?: string;
+}
+
 export function isSessionStatus(value: unknown): value is SessionStatus {
   return typeof value === 'string' && (SESSION_STATUSES as readonly string[]).includes(value);
 }
@@ -289,6 +300,7 @@ export interface SessionSummary {
   runningTurnIds?: string[];
   parentSessionId?: string;
   branchOfTurnId?: string;
+  subagent?: SessionSubagentProjection;
   subagentParent?: SubagentSessionParent;
   subagentRuntime?: SubagentSessionRuntimeSummary;
   subagentWorkspace?: SubagentWorkspaceBinding;
@@ -489,11 +501,14 @@ export function childSessionsForParent(
   sessions: readonly SessionSummary[],
   parentSessionId: string,
 ): SessionSummary[] {
-  return sessions.filter(
-    (session) =>
-      isSubagentSessionParent(session.subagentParent) &&
-      session.subagentParent.parentSessionId === parentSessionId,
-  );
+  return sessions.filter((session) => linkedSubagentParentId(session) === parentSessionId);
+}
+
+/** Whether a Session is a linked child in either local or Host projection form. */
+export function isLinkedSubagentSession(
+  session: Pick<SessionSummary, 'subagent' | 'subagentParent'>,
+): boolean {
+  return linkedSubagentParentId(session) !== undefined;
 }
 
 /** Read-model projection; input order is preserved at every tree level. */
@@ -504,11 +519,9 @@ export function projectLinkedSessionTree(
   const sessionsById = new Map(sessions.map((session) => [session.id, session]));
   const nestedParentByChildId = new Map<string, string>();
   const linkedParentId = (session: SessionSummary): string | undefined => {
-    const relation = session.subagentParent;
-    if (!isSubagentSessionParent(relation)) return undefined;
-    return (
-      options.parentSessionIdAliases?.get(relation.parentSessionId) ?? relation.parentSessionId
-    );
+    const parentSessionId = linkedSubagentParentId(session);
+    if (!parentSessionId) return undefined;
+    return options.parentSessionIdAliases?.get(parentSessionId) ?? parentSessionId;
   };
 
   for (const session of sessions) {
@@ -537,6 +550,15 @@ export function projectLinkedSessionTree(
     roots,
     childrenByParentId: mutableChildren,
   };
+}
+
+function linkedSubagentParentId(
+  session: Pick<SessionSummary, 'subagent' | 'subagentParent'>,
+): string | undefined {
+  if (isSubagentSessionParent(session.subagentParent)) {
+    return session.subagentParent.parentSessionId;
+  }
+  return session.subagent?.parentSessionId;
 }
 
 /**

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -89,6 +89,7 @@ const allowedExternalImports = {
     '@maka/core/deep-research-run',
     '@maka/core/daily-review',
     '@maka/core/execution-inspect',
+    '@maka/core/explore-agent',
     '@maka/core/goal',
     '@maka/core/interaction',
     '@maka/core/local-memory',

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -6,6 +6,7 @@ import test from 'node:test';
 import {
   createDefaultRuntimePolicy,
   DEEP_RESEARCH_SESSION_LABEL,
+  DEEP_RESEARCH_SESSION_NAME,
   type SessionHeader,
 } from '@maka/core';
 import { SessionConfigurationTransitionError, headerToSummary } from '@maka/runtime';
@@ -216,6 +217,73 @@ test('creation rejects reserved execution labels before claiming a Session ident
     },
   });
   assert.equal(createAttempts, 0);
+  assert.equal(fixture.drainRequests(), 0);
+});
+
+test('creation rejects explore permission without a declared mode', async () => {
+  let createAttempts = 0;
+  const fixture = createFixture({
+    stores: {
+      createStableSession: async () => {
+        createAttempts += 1;
+        assert.fail('Unscoped explore permission must be rejected before persistence');
+      },
+    },
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.create'](
+    {
+      sessionId: fixture.sessionId,
+      cwd: process.cwd(),
+      modelTarget: { kind: 'default' },
+      permissionMode: 'explore',
+    },
+    context,
+  );
+
+  assert.deepEqual(outcome, {
+    ok: false,
+    error: {
+      code: 'invalid_request',
+      message: 'Session creation requires a declared mode for explore permission',
+    },
+  });
+  assert.equal(createAttempts, 0);
+  assert.equal(fixture.drainRequests(), 0);
+});
+
+test('creation materializes Deep Research semantics inside the Host transaction', async () => {
+  let created: Parameters<CatalogStores['createStableSession']>[0] | undefined;
+  const fixture = createFixture({
+    stores: {
+      createStableSession: async (request) => {
+        created = request;
+        return {
+          kind: 'existing',
+          record: headerSnapshot(sessionHeader(request.sessionId, request.input.labels ?? []), 3),
+        };
+      },
+    },
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.create'](
+    {
+      sessionId: fixture.sessionId,
+      cwd: process.cwd(),
+      mode: 'deep_research',
+      name: 'Caller override',
+      labels: ['customer-label'],
+      modelTarget: { kind: 'default' },
+      permissionMode: 'execute',
+    },
+    context,
+  );
+
+  assert.equal(outcome.ok, true);
+  assert.ok(created);
+  assert.equal(created.input.name, DEEP_RESEARCH_SESSION_NAME);
+  assert.deepEqual(created.input.labels, ['customer-label', DEEP_RESEARCH_SESSION_LABEL]);
+  assert.equal(created.input.permissionMode, 'explore');
   assert.equal(fixture.drainRequests(), 0);
 });
 

--- a/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
@@ -221,6 +221,37 @@ describe('Session catalog protocol', () => {
     );
   });
 
+  test('accepts only declared Session start modes', () => {
+    const decoded = decodeClientFrame({
+      requestId: 'request-mode',
+      operation: 'session.create',
+      input: {
+        sessionId: 'session-mode',
+        cwd: '/workspace',
+        mode: 'deep_research',
+        modelTarget: { kind: 'default' },
+      },
+    });
+    if ('kind' in decoded || decoded.operation !== 'session.create') {
+      assert.fail('Expected Session create frame');
+    }
+    assert.equal(decoded.input.mode, 'deep_research');
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          requestId: 'request-invalid-mode',
+          operation: 'session.create',
+          input: {
+            sessionId: 'session-invalid-mode',
+            cwd: '/workspace',
+            mode: 'unknown',
+            modelTarget: { kind: 'default' },
+          },
+        }),
+      isProtocolError,
+    );
+  });
+
   test('correlates committed and conflicting update outputs with the request Session', () => {
     const session = projection();
     assert.deepEqual(

--- a/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
@@ -6,6 +6,7 @@ import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import { DEEP_RESEARCH_SESSION_LABEL, DEEP_RESEARCH_SESSION_NAME } from '@maka/core';
 import { openInteractiveArtifactStoreForWrite } from '@maka/storage/artifact-stores';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
@@ -173,6 +174,20 @@ test('two UDS Clients share stable Session creation, CAS configuration, and cata
       });
       if ('kind' in planSession) assert.fail('Plan Session must be wire-representable');
       assert.equal(planSession.collaborationMode, 'plan');
+      const researchSession = requireSessionProjection(
+        await desktop.request('session.create', {
+          sessionId: 'deep-research-session',
+          cwd: root,
+          mode: 'deep_research',
+          name: 'Caller override',
+          labels: ['customer-label'],
+          modelTarget: { kind: 'default' },
+          permissionMode: 'bypass',
+        }),
+      );
+      assert.equal(researchSession.name, DEEP_RESEARCH_SESSION_NAME);
+      assert.deepEqual(researchSession.labels, ['customer-label', DEEP_RESEARCH_SESSION_LABEL]);
+      assert.equal(researchSession.permissionMode, 'explore');
 
       const policy = await tui.request('runtime.policy.query', {});
       const changedPolicy = await tui.request('runtime.policy.mutate', {
@@ -366,6 +381,12 @@ test('two UDS Clients share stable Session creation, CAS configuration, and cata
       assert.equal(readFromTui.hasUnread, false);
       assert.equal(readFromTui.lastReadMessageId, 'message-2');
 
+      const catalogBeforeBulk = await desktop.request('session.catalog.query', {
+        kind: 'list_start',
+      });
+      if (catalogBeforeBulk.kind !== 'page' || catalogBeforeBulk.nextCursor !== null) {
+        assert.fail('Pre-bulk Session catalog must fit on one page');
+      }
       const bulk = (
         await Promise.all(
           Array.from({ length: 34 }, (_, index) =>
@@ -394,7 +415,10 @@ test('two UDS Clients share stable Session creation, CAS configuration, and cata
       if (continuation.kind !== 'page') {
         assert.fail('Stable Session catalog continuation must return a page');
       }
-      assert.equal(firstPage.sessions.length + continuation.sessions.length, bulk.length + 6);
+      assert.equal(
+        firstPage.sessions.length + continuation.sessions.length,
+        bulk.length + catalogBeforeBulk.sessions.length,
+      );
 
       const filteredStart = await desktop.request('session.catalog.query', {
         kind: 'list_start',

--- a/packages/runtime-host/src/protocol/session-catalog.ts
+++ b/packages/runtime-host/src/protocol/session-catalog.ts
@@ -1,11 +1,13 @@
 import { isCollaborationMode, type CollaborationMode } from '@maka/core/collaboration';
 import { isOrchestrationMode, type OrchestrationMode } from '@maka/core/orchestration';
 import { isPermissionMode, type PermissionMode } from '@maka/core/permission';
+import { isSessionStartMode, type SessionStartMode } from '@maka/core/explore-agent';
 import {
   isSessionBlockedReason,
   isSessionStatus,
   type SessionBlockedReason,
   type SessionStatus,
+  type SessionSubagentProjection,
 } from '@maka/core/session';
 import { isThinkingLevel, type ThinkingLevel } from '@maka/core/model-thinking';
 import {
@@ -20,6 +22,8 @@ import {
 } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
 import { defineOperation } from './operation-spec.js';
+
+export type { SessionSubagentProjection } from '@maka/core/session';
 
 export const SESSION_CATALOG_PAGE_MAX_ITEMS = 32;
 export const SESSION_CATALOG_RESULT_MAX_BYTES = 48 * 1024;
@@ -119,6 +123,7 @@ export type SessionModelTarget =
 export interface SessionCreateInput {
   readonly sessionId: string;
   readonly cwd: string;
+  readonly mode?: SessionStartMode;
   readonly projectId?: string | null;
   readonly name?: string;
   readonly labels?: readonly string[];
@@ -164,13 +169,6 @@ export interface SessionCwdRelocateInput {
 export interface SessionReadMarkerSetInput {
   readonly sessionId: string;
   readonly readThroughMessageId: string;
-}
-
-export interface SessionSubagentProjection {
-  readonly parentSessionId: string;
-  readonly agentId?: string;
-  readonly agentName?: string;
-  readonly profile?: string;
 }
 
 export interface SessionCatalogProjection {
@@ -363,6 +361,7 @@ export function decodeSessionCreateInput(value: unknown): SessionCreateInput {
     'Session create input',
     ['sessionId', 'cwd', 'modelTarget'],
     [
+      'mode',
       'projectId',
       'name',
       'labels',
@@ -375,6 +374,7 @@ export function decodeSessionCreateInput(value: unknown): SessionCreateInput {
   return {
     sessionId: requireEntityId(input.sessionId, 'sessionId'),
     cwd: requireUtf8String(input.cwd, 'Session cwd', SESSION_CATALOG_CWD_MAX_BYTES),
+    ...(Object.hasOwn(input, 'mode') ? { mode: sessionStartMode(input.mode) } : {}),
     ...(Object.hasOwn(input, 'projectId')
       ? {
           projectId:
@@ -403,6 +403,11 @@ export function decodeSessionCreateInput(value: unknown): SessionCreateInput {
       ? { orchestrationMode: orchestrationMode(input.orchestrationMode) }
       : {}),
   };
+}
+
+function sessionStartMode(value: unknown): SessionStartMode {
+  if (!isSessionStartMode(value)) throw invalidProtocolFrame('Invalid Session start mode');
+  return value;
 }
 
 export function decodeSessionMetadataUpdateInput(value: unknown): SessionMetadataUpdateInput {

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -5,7 +5,11 @@ import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
 import { thinkingVariantsForModel } from '@maka/core/model-thinking';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
 import { DEFAULT_SESSION_NAME, normalizeUserSessionName } from '@maka/core/session-name';
-import { DEEP_RESEARCH_SESSION_LABEL, type SessionHeader } from '@maka/core/session';
+import {
+  isSessionStartModeLabel as isExecutionSemanticLabel,
+  sessionStartModeSpec,
+} from '@maka/core/explore-agent';
+import type { SessionHeader } from '@maka/core/session';
 import {
   isSessionNotFoundError,
   SessionMetadataConflictError,
@@ -212,7 +216,7 @@ export class HostSessionCatalogCoordinator {
           llmConnectionSlug: model.connectionSlug,
           model: model.model,
           ...(input.thinkingLevel === undefined ? {} : { thinkingLevel: input.thinkingLevel }),
-          permissionMode: input.permissionMode ?? policy.policy.chatDefaults.permissionMode,
+          permissionMode: prepared.permissionMode ?? policy.policy.chatDefaults.permissionMode,
           collaborationMode: input.collaborationMode ?? 'agent',
           orchestrationMode: input.orchestrationMode ?? 'default',
         };
@@ -635,6 +639,7 @@ interface PreparedSessionCreate {
   readonly cwd: string;
   readonly name: string;
   readonly labels: readonly string[];
+  readonly permissionMode?: SessionCreateInput['permissionMode'];
   readonly requestFingerprint: string;
 }
 
@@ -648,9 +653,17 @@ async function prepareCreate(input: SessionCreateInput): Promise<PreparedSession
       'Session creation cannot set reserved execution labels',
     );
   }
+  const mode = input.mode === undefined ? undefined : sessionStartModeSpec(input.mode);
+  if (mode === undefined && input.permissionMode === 'explore') {
+    throw new SessionOperationFailure(
+      'invalid_request',
+      'Session creation requires a declared mode for explore permission',
+    );
+  }
   const cwd = await canonicalSessionDirectory(input.cwd);
-  const name = normalizedSessionName(input.name ?? DEFAULT_SESSION_NAME);
-  const labels = [...(input.labels ?? [])];
+  const name = normalizedSessionName(mode?.name ?? input.name ?? DEFAULT_SESSION_NAME);
+  const labels = [...(input.labels ?? []), ...(mode?.labels ?? [])];
+  const permissionMode = mode?.permissionMode ?? input.permissionMode;
   const identity = [
     'session.create.v1',
     input.sessionId,
@@ -662,7 +675,7 @@ async function prepareCreate(input: SessionCreateInput): Promise<PreparedSession
       ? ['default']
       : ['explicit', input.modelTarget.connectionSlug, input.modelTarget.model],
     input.thinkingLevel ?? null,
-    input.permissionMode ?? ['runtime_default'],
+    permissionMode ?? ['runtime_default'],
     input.collaborationMode ?? 'agent',
     input.orchestrationMode ?? 'default',
   ];
@@ -670,6 +683,7 @@ async function prepareCreate(input: SessionCreateInput): Promise<PreparedSession
     cwd,
     name,
     labels,
+    ...(permissionMode === undefined ? {} : { permissionMode }),
     requestFingerprint: `sha256:${createHash('sha256')
       .update(JSON.stringify(identity))
       .digest('hex')}`,
@@ -933,10 +947,6 @@ function normalizedSessionName(name: string): string {
 
 function normalizeSessionNamePatch(name: string): Pick<SessionHeader, 'name' | 'titleIsManual'> {
   return { name: normalizedSessionName(name), titleIsManual: true };
-}
-
-function isExecutionSemanticLabel(label: string): boolean {
-  return label === DEEP_RESEARCH_SESSION_LABEL;
 }
 
 function replaceUserOwnedLabels(


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Add an isolated Desktop main-process registrar that backs the existing Session catalog, creation, metadata, configuration, lifecycle, and removal IPC channels with typed Runtime Host operations.
- Keep product-mode semantics Host-owned: a shared core registry defines each mode, while the Host atomically materializes its name, protected labels, and permission boundary.
- Preserve revision-family behavior without duplicating Host retirement authority, and share the existing family/model input normalization with the embedded path.
- Project Host subagent relationships into the common Session read model so linked children keep the existing tree behavior and do not appear as graph roots.

## Scope

This is a production-shaped candidate composition only. Desktop production boot remains on the embedded runtime until the later atomic cutover; this PR adds no fallback, dual owner, or production activation.

## Validation

- Core, Runtime Host, and Desktop typechecks
- Real Runtime Host UDS coverage for Host-owned Session mode semantics and the renderer-facing Desktop IPC facade
- Full Core test suite: 776 passed
- Full Runtime Host test suite: 662 passed
- Full Desktop test suite: 1631 passed
- Repository format and lint checks

</details>

<details>
<summary>中文</summary>

## 摘要

- 增加隔离的 Desktop main-process registrar，让现有 Session catalog、创建、metadata、配置、生命周期与删除 IPC channel 使用 typed Runtime Host operation。
- 保持 product mode 语义由 Host 管理：共享 core registry 定义各 mode，Host 在同一创建事务中原子写入名称、受保护标签与权限边界。
- 在不重复 Host retirement authority 的前提下保持 revision-family 行为，并让 embedded path 复用相同的 family/model 输入规范化逻辑。
- 将 Host subagent relation 投影到共享 Session read model，使 linked child 继续沿用现有树形行为，且不会被误当成 graph root。

## 范围

这仍是 production-shaped candidate composition。Desktop production boot 在后续原子 cutover 前继续使用 embedded runtime；本 PR 不增加 fallback、双 owner 或 production activation。

## 验证

- Core、Runtime Host 与 Desktop typecheck
- 通过真实 Runtime Host UDS 验证 Host-owned Session mode 语义与 renderer-facing Desktop IPC facade
- 完整 Core 测试：776 项通过
- 完整 Runtime Host 测试：662 项通过
- 完整 Desktop 测试：1631 项通过
- 仓库 format 与 lint 检查

</details>

Part of #2010.
