### PR TITLE
fix(window): align traffic lights with the sidebar icon column

### DIFF
--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -87,7 +87,14 @@ export function safeSendToRenderer(channel: string, ...args: unknown[]): void {
   wc.send(channel, ...args);
 }
 
-const MAIN_WINDOW_TRAFFIC_LIGHT_POSITION = { x: 14, y: 14 } as const;
+// The close button's centre sits on the same vertical line as the sidebar's
+// icon column, so the window's top-left reads as one column rather than two
+// near-misses. Contract: centre = x + 7 (the disc measures 14pt, not the 12pt
+// it is often quoted as), and the icon column centres on 24 (item edge 8 +
+// half of the 32pt icon slot) — so x = 24 - 7 = 17. Both numbers were read off
+// a screenshot of the running window, not derived. Move the sidebar's left
+// padding or icon slot and this has to move with it.
+const MAIN_WINDOW_TRAFFIC_LIGHT_POSITION = { x: 17, y: 14 } as const;
 const HIDDEN_TRAFFIC_LIGHT_POSITION = { x: -100, y: -100 } as const;
 
 // PR-SHOW-AFTER-FIRST-COMMIT: fallback reveal delay for a renderer that never


### PR DESCRIPTION
## 改了什么
`main-window.ts` 的 `MAIN_WINDOW_TRAFFIC_LIGHT_POSITION.x` 14 → 17。y 不动。

## 为什么
关闭按钮圆心比侧栏图标列中心偏左 3pt，窗口左上角读起来是两条差一点的竖线，不是一条。

**是 17 不是 18**：首灯中心 = `x + 7`，因为灯径实测 **14pt**，不是常被引用的 12pt。
对齐目标是图标列中心 24（item 左缘 8 + 32pt 图标槽的一半），所以 x = 24 − 7 = 17。

收起态不需要单独处理：收起轨宽 `--spacing-12` = 48 = 8 + 32 + 8，图标槽中心同样是 24，
一个常量两态都对。

## 怎么验的
Playwright 截不到 OS 原生 chrome，所以直接读运行窗口截图的像素（Retina 2x，量差值不量绝对坐标）。

三个值**都改常量 + 重新构建 + 重启 + 重新量**，没有靠外推：

| x | 首灯中心 | 相对图标列 |
|---|---|---|
| 14（改前） | 1009.5 | 偏左 3.08pt |
| **17** | 1015.5 | **0.08pt** |
| 18 | 1017.5 | 偏右 0.92pt |

测量自检：红盘 bbox 中心 == 亮度加权质心（差 0.00px）；图标列取 3 个图标，sd = 0.24 物理像素。

build / typecheck / format:check / lint / check:release 全绿。全仓无任何测试引用这个常量。
