### PR TITLE
fix(headless): reap the scoped command's output replay

### DIFF
--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -10,6 +10,9 @@ from typing import Any
 COMMAND_SCOPE_ENV = "MAKA_HARBOR_COMMAND_SCOPE"
 COMMAND_ID_ENV = "MAKA_HARBOR_COMMAND_ID"
 COMMAND_SCOPE_ROOT = "/tmp/maka-harbor-command-scopes"
+# Ends in `.pgid` so the scope-wide `*.pgid` sweep reaps the replay without
+# needing to know it exists.
+REPLAY_PGID_SUFFIX = "replay.pgid"
 
 
 async def cleanup_process_scope(
@@ -44,6 +47,9 @@ async def cleanup_process_scope(
 def scoped_command(command: str, scope: str, command_id: str) -> str:
     scope_dir = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}")
     pgid_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.pgid")
+    replay_pgid_path = shlex.quote(
+        f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.{REPLAY_PGID_SUFFIX}"
+    )
     wrapper_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.wrapper")
     stdout_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.stdout")
     stderr_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.stderr")
@@ -56,8 +62,17 @@ def scoped_command(command: str, scope: str, command_id: str) -> str:
         "set +m; "
         f"printf '%s\\n' \"$command_pid\" > {pgid_path}; "
         "wait \"$command_pid\" 2>/dev/null; command_status=$?; "
-        f"cat -- {stdout_path}; cat -- {stderr_path} >&2; "
-        f"rm -f -- {stdout_path} {stderr_path}; "
+        # The replay writes to the caller's stdout, so it blocks forever once the
+        # caller stops reading — which is exactly what an agent-phase timeout
+        # does. Give it its own process group and record it like any other
+        # command, or teardown has no handle on it: it is in neither the
+        # command's group nor the wrapper PID, and it inherits no scope marker.
+        "set -m; "
+        f"{{ cat -- {stdout_path}; cat -- {stderr_path} >&2; }} & replay_pid=$!; "
+        "set +m; "
+        f"printf '%s\\n' \"$replay_pid\" > {replay_pgid_path}; "
+        "wait \"$replay_pid\" 2>/dev/null; "
+        f"rm -f -- {replay_pgid_path} {stdout_path} {stderr_path}; "
         f"kill -0 -- \"-$command_pid\" 2>/dev/null || rm -f -- {pgid_path}; "
         f"rm -f -- {wrapper_path}; "
         "exit \"$command_status\""
@@ -88,8 +103,9 @@ def scoped_command_cleanup_command(
     if signal not in ("TERM", "KILL"):
         raise ValueError(f"unsupported cleanup signal: {signal}")
     pgid_paths = [
-        shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.pgid")
+        shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.{suffix}")
         for command_id in command_ids
+        for suffix in ("pgid", REPLAY_PGID_SUFFIX)
     ]
     if not pgid_paths:
         return ":"
@@ -101,7 +117,7 @@ def scoped_command_cleanup_command(
     artifact_paths = " ".join(
         shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.{suffix}")
         for command_id in command_ids
-        for suffix in ("pgid", "wrapper", "stdout", "stderr")
+        for suffix in ("pgid", REPLAY_PGID_SUFFIX, "wrapper", "stdout", "stderr")
     )
     command = (
         f"for pgid_file in {paths}; do "

--- a/packages/headless/harbor/tests/test_process_scope.py
+++ b/packages/headless/harbor/tests/test_process_scope.py
@@ -14,12 +14,21 @@ Run directly: ``python3 packages/headless/harbor/tests/test_process_scope.py``
 from __future__ import annotations
 
 import asyncio
+import shutil
+import subprocess
 import sys
+import time
+import uuid
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from process_scope import cleanup_process_scope  # noqa: E402
+from process_scope import (  # noqa: E402
+    COMMAND_SCOPE_ROOT,
+    cleanup_process_scope,
+    scoped_command,
+    scoped_process_cleanup_command,
+)
 
 
 class _Logger:
@@ -107,6 +116,78 @@ def test_cancellation_still_propagates() -> None:
     else:
         raise AssertionError("teardown swallowed cancellation")
     assert len(agent.commands) == 1, agent.commands
+
+
+def _holders(stdout_path: Path) -> list[str]:
+    """PIDs still holding the replay open. Draining the pipe would unblock the
+    replay and hide the defect, so ask the process table instead."""
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell interpolation
+        ["pgrep", "-f", str(stdout_path)],
+        check=False,
+        timeout=30,
+        capture_output=True,
+        text=True,
+    ).stdout.split()
+
+
+def test_cleanup_reaps_the_output_replay_so_the_reader_reaches_eof() -> None:
+    """The wrapper captures the command's output to a file and replays it after
+    the command exits, so that a descendant outliving the command cannot hold the
+    exec's stdout open. The replay itself is the hole: when the caller stops
+    reading — which is exactly what an agent-phase timeout does — the replay
+    blocks in ``pipe_write`` forever, and it belongs to neither the command's
+    process group nor the wrapper PID, so every cleanup loop walks past it. The
+    exec never sees EOF, the cell hangs until something kills the container, and
+    the verifier never runs. EOF here is that failure, reproduced without Docker.
+    """
+    if shutil.which("bash") is None:
+        return
+
+    scope = f"test-scope-{uuid.uuid4().hex}"
+    command_id = "replay"
+    stdout_path = Path(COMMAND_SCOPE_ROOT) / scope / f"{command_id}.stdout"
+    # Comfortably past a 64 KiB pipe buffer, so the replay blocks partway
+    # through rather than finishing before anyone can observe it.
+    payload = "yes 0123456789abcdef | head -c 400000"
+
+    wrapper = subprocess.Popen(  # noqa: S603 - fixed argv, no shell interpolation
+        ["bash", "-c", scoped_command(payload, scope, command_id)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if stdout_path.exists() and stdout_path.stat().st_size >= 400000:
+                break
+            time.sleep(0.1)
+        else:
+            raise AssertionError("the command never finished writing its output")
+        # The wrapper starts the replay once the command exits; give it that
+        # step before asserting on what teardown can still reach.
+        time.sleep(1)
+        assert _holders(stdout_path), (
+            "the replay never blocked, so this test would pass no matter what "
+            "teardown reaps"
+        )
+
+        for signal in ("TERM", "KILL"):
+            subprocess.run(  # noqa: S603 - fixed argv, no shell interpolation
+                ["bash", "-c", scoped_process_cleanup_command(scope, signal)],
+                check=False,
+                timeout=30,
+                capture_output=True,
+            )
+
+        survivors = _holders(stdout_path)
+        assert not survivors, (
+            f"teardown left {len(survivors)} process(es) holding the exec's "
+            "pipe; that is the hang that strands a cell with no verifier"
+        )
+    finally:
+        wrapper.kill()
+        wrapper.wait(timeout=10)
+        shutil.rmtree(Path(COMMAND_SCOPE_ROOT) / scope, ignore_errors=True)
 
 
 def _main() -> int:

--- a/packages/headless/harbor/tests/test_process_scope.py
+++ b/packages/headless/harbor/tests/test_process_scope.py
@@ -119,28 +119,42 @@ def test_cancellation_still_propagates() -> None:
 
 
 def _holders(stdout_path: Path) -> list[str]:
-    """PIDs still holding the replay open. Draining the pipe would unblock the
-    replay and hide the defect, so ask the process table instead."""
-    return subprocess.run(  # noqa: S603 - fixed argv, no shell interpolation
-        ["pgrep", "-f", str(stdout_path)],
+    """The replay processes still holding the pipe open. Draining the pipe would
+    unblock the replay and hide the defect, so ask the process table instead.
+
+    Matching the path alone would also match the wrapper, whose `bash -c` script
+    text contains that path: the pre-cleanup guard below would then pass with no
+    replay alive at all, which is a false PASS in the one direction that matters.
+    So require the command itself to be the replay.
+    """
+    listing = subprocess.run(  # noqa: S603 - fixed argv, no shell interpolation
+        ["ps", "-A", "-o", "pid=,command="],
         check=False,
         timeout=30,
         capture_output=True,
         text=True,
-    ).stdout.split()
+    ).stdout.splitlines()
+    marker = f"cat -- {stdout_path}"
+    return [
+        line.strip()
+        for line in listing
+        if line.strip().split(maxsplit=1)[1:2] == [marker]
+    ]
 
 
 def test_cleanup_reaps_the_output_replay_so_the_reader_reaches_eof() -> None:
     """The wrapper captures the command's output to a file and replays it after
     the command exits, so that a descendant outliving the command cannot hold the
     exec's stdout open. The replay itself is the hole: when the caller stops
-    reading — which is exactly what an agent-phase timeout does — the replay
-    blocks in ``pipe_write`` forever, and it belongs to neither the command's
-    process group nor the wrapper PID, so every cleanup loop walks past it. The
-    exec never sees EOF, the cell hangs until something kills the container, and
-    the verifier never runs. EOF here is that failure, reproduced without Docker.
+    reading — which is exactly what an agent-phase timeout does — it blocks in
+    ``pipe_write`` forever, and teardown has no handle on it. It is not the
+    wrapper PID and it carries no scope marker, so whether anything reaps it
+    comes down to which process group the shell happened to leave it in. On a
+    host with no ``/proc`` the marker sweep is a no-op and nothing does, which is
+    what this test pins. A stranded replay means the exec never sees EOF, so the
+    cell hangs and the verifier never runs.
     """
-    if shutil.which("bash") is None:
+    if shutil.which("bash") is None or shutil.which("ps") is None:
         return
 
     scope = f"test-scope-{uuid.uuid4().hex}"


### PR DESCRIPTION
## Summary

The scope wrapper captures a command's output to a file and replays it after the command exits, so that a descendant outliving the command cannot hold the exec's stdout open. The replay itself is the hole: it writes to the caller's stdout, so it blocks in `pipe_write` once the caller stops reading — precisely what an agent-phase timeout does — and teardown has no handle on it. It is not the wrapper PID and it carries no scope marker, so whether anything reaps it comes down to which process group the shell happened to leave it in.

When nothing does, the exec never sees EOF. The cell hangs with no progress, and the verifier never runs, so the cell produces no reward at all rather than a graded failure.

This gives the replay its own process group and records it beside the command's, under a name the scope-wide `*.pgid` sweep already reaps. The handle stays in the mechanism teardown already trusts on every platform, rather than the `/proc` marker sweep, which does not exist on macOS.

Refs #1970

## Verification

`python3 packages/headless/harbor/tests/test_process_scope.py` — 5 passed, 0 failed. With `process_scope.py` restored from `main`, the new test fails with `teardown left 1 process(es) holding the exec's pipe`, so it is red-first on the real defect.

The test reproduces the strand without Docker: it runs the wrapper against a payload larger than a pipe buffer with a caller that never reads, asserts the replay is actually blocked, then runs both teardown signals and asserts nothing still holds the pipe. Draining the pipe to check for EOF would unblock the replay and hide the defect, so it reads the process table instead, matching the replay command itself rather than the stdout path — the path alone also matches the wrapper's own script text, which would let the guard pass with no replay alive.

`packages/headless/harbor/tests/test_harness_compat.py` reports 5 pre-existing failures on this machine (`ModuleNotFoundError: No module named 'harbor'`); identical on a clean `main`.

Not run: Biome lint/format and workspace typecheck, which do not cover Python. No TypeScript changed.

## Root cause

Observed live on the benchmark host, mid-hang, in a graded cell:

```
pid=2623720  S  do_wait        sh -c sleep infinity          <- container PID 1
pid=2623847  S  __do_sys_pause sleep infinity
pid=2636207  S  pipe_write     cat -- <scope>/<id>.stdout    <- orphan, ppid=1
```

The captured stdout was 20 MB against a 64 KiB pipe buffer. The agent process and the wrapper shell were both gone — teardown had reaped them — and `MAKA_HARBOR_COMMAND_SCOPE` was absent from the survivor's environ.

The wrapper is shared with the host-side bridged tool execs, which are individually bounded and were not observed to strand.

## Scope

A container-level check found that under that topology the command's own process group does reap the replay, so this change is not by itself sufficient to explain the production strand. In the run that stranded, the teardown exec was itself SIGKILLed partway through by Harbor's compose-command timeout (`process scope ... TERM cleanup failed: Command failed (exit -9)` in the trial log), so it never completed its loops. That is a separate defect and is not addressed here.

What this PR fixes is that the replay has no teardown handle of its own and survives on an accident of process-group placement. On a host with no `/proc` the marker sweep is a no-op and nothing reaps it at all.

## Follow-up

- [ ] The replay's pgid is recorded after the fork, so teardown landing between `&` and the `printf` leaves the same unhandled orphan. The command's own pgid has had the identical window since before this change, so the fix belongs at that shared layer rather than only on the replay. Raised independently by three reviewers, accepted as a tracked P2.
- [ ] Teardown execs can exceed Harbor's compose-command timeout and be SIGKILLed mid-loop, which is what stranded the production cell. Cause of the slowness not yet established.