### PR TITLE
feat(desktop): add Runtime Host Session execution IPC

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
@@ -200,6 +200,24 @@ test('treats empty configuration patches as read-only lookups', async () => {
   ]);
 });
 
+test('reads the bounded Host execution boundary summary', async () => {
+  const { client, requests } = clientWithResponses([
+    { kind: 'managed', access: 'read_only', revision: 4 },
+  ]);
+
+  assert.deepEqual(await client.readExecutionBoundary('session-1'), {
+    kind: 'managed',
+    access: 'read_only',
+    revision: 4,
+  });
+  assert.deepEqual(requests, [
+    {
+      operation: 'session.execution_boundary.query',
+      input: { sessionId: 'session-1' },
+    },
+  ]);
+});
+
 test('binds message controls to the current Host Epoch', async () => {
   const { client, requests } = clientWithResponses([
     { disposition: 'steering', queueRevision: 2 },
@@ -262,6 +280,118 @@ test('binds message controls to the current Host Epoch', async () => {
       },
     },
   ]);
+});
+
+test('uploads Attachment bytes in bounded Host chunks and commits the digest', async () => {
+  const bytes = new Uint8Array(48 * 1024 + 3).fill(7);
+  const attachment = {
+    kind: 'file' as const,
+    name: 'notes.txt',
+    mimeType: 'text/plain',
+    bytes: bytes.byteLength,
+    ref: {
+      kind: 'session_file' as const,
+      sessionId: 'session-1',
+      relativePath: 'artifact-1',
+    },
+  };
+  const { client, requests } = clientWithResponses([
+    { kind: 'upload_opened', nextOffset: 0 },
+    { kind: 'chunk_accepted', nextOffset: 48 * 1024 },
+    { kind: 'chunk_accepted', nextOffset: bytes.byteLength },
+    { kind: 'committed', attachment },
+  ]);
+
+  assert.deepEqual(
+    await client.ingestAttachment({
+      sessionId: 'session-1',
+      uploadId: 'upload-1',
+      name: 'notes.txt',
+      mimeType: 'text/plain',
+      content: bytes,
+    }),
+    attachment,
+  );
+  assert.deepEqual(
+    requests.map(({ operation, input }) => ({
+      operation,
+      kind: (input as { kind?: string }).kind,
+      offset: (input as { offset?: number }).offset,
+    })),
+    [
+      { operation: 'artifact.ingest', kind: 'begin', offset: undefined },
+      { operation: 'artifact.ingest', kind: 'chunk', offset: 0 },
+      { operation: 'artifact.ingest', kind: 'chunk', offset: 48 * 1024 },
+      { operation: 'artifact.ingest', kind: 'commit', offset: undefined },
+    ],
+  );
+  const begin = requests[0]?.input as { contentSha256: string; totalBytes: number };
+  assert.equal(begin.totalBytes, bytes.byteLength);
+  assert.match(begin.contentSha256, /^sha256:[a-f0-9]{64}$/);
+});
+
+test('aborts an opened Attachment upload when a later chunk fails', async () => {
+  const requests: RecordedRequest[] = [];
+  const connection = {
+    hostEpoch: 'host-current',
+    request: async <K extends OperationKey>(operation: K, input: OperationInput<K>) => {
+      requests.push({ operation, input });
+      if ((input as { kind?: string }).kind === 'begin') {
+        return { kind: 'upload_opened', nextOffset: 0 };
+      }
+      if ((input as { kind?: string }).kind === 'abort') {
+        return { kind: 'upload_aborted', uploadId: 'upload-1' };
+      }
+      throw new Error('chunk failed');
+    },
+    close: async () => undefined,
+  } as unknown as RuntimeHostConnection;
+  const client = new DesktopRuntimeHostClient(connection);
+
+  await assert.rejects(
+    () =>
+      client.ingestAttachment({
+        sessionId: 'session-1',
+        uploadId: 'upload-1',
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        content: new Uint8Array([1]),
+      }),
+    /chunk failed/,
+  );
+  assert.deepEqual(
+    requests.map(({ input }) => (input as { kind: string }).kind),
+    ['begin', 'chunk', 'abort'],
+  );
+});
+
+test('accepts an idempotently committed Attachment upload at begin', async () => {
+  const attachment = {
+    kind: 'file' as const,
+    name: 'notes.txt',
+    mimeType: 'text/plain',
+    bytes: 1,
+    ref: {
+      kind: 'session_file' as const,
+      sessionId: 'session-1',
+      relativePath: 'artifact-1',
+    },
+  };
+  const { client, requests } = clientWithResponses([
+    { kind: 'committed', uploadId: 'upload-1', attachment },
+  ]);
+
+  assert.deepEqual(
+    await client.ingestAttachment({
+      sessionId: 'session-1',
+      uploadId: 'upload-1',
+      name: 'notes.txt',
+      mimeType: 'text/plain',
+      content: new Uint8Array([1]),
+    }),
+    attachment,
+  );
+  assert.equal(requests.length, 1);
 });
 
 test('fails explicitly when the Host cannot represent a legacy Session', async () => {

--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -20,7 +20,10 @@ import {
   tryAcquireInteractiveRootOwner,
 } from '@maka/storage/root-authority';
 import { DesktopRuntimeHostClient } from '../runtime-host-client.js';
+import { createAttachmentApprovalRegistry } from '../attachment-approval.js';
 import { registerRuntimeHostSessionCatalogIpc } from '../runtime-host-session-catalog-ipc-main.js';
+import { registerRuntimeHostSessionExecutionIpc } from '../runtime-host-session-execution-ipc-main.js';
+import { RuntimeHostSessionObserver } from '../runtime-host-session-observer.js';
 
 test('drives Desktop Session operations through a real Runtime Host connection', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-desktop-host-client-'));
@@ -215,6 +218,106 @@ test('drives the renderer Session catalog facade through real UDS framing', asyn
       { reason: 'deleted', sessionId: 'session-ipc' },
     ]);
 
+    await client.close();
+  } finally {
+    await host?.close().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('drives the renderer Session execution facade through real UDS framing', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-desktop-host-execution-ipc-'));
+  let host: RuntimeHostKernel | undefined;
+  try {
+    const capability = await resolveStorageRoot({ path: base, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    const projected = session('session-1');
+    host = await RuntimeHostKernel.start({
+      owner,
+      idleGraceMs: 10_000,
+      compositionFactory: async () => ({
+        handlers: handlers({
+          'session.catalog.query': async (input) => ({
+            ok: true,
+            result: {
+              kind: 'session',
+              session: input.kind === 'get' && input.sessionId === projected.id ? projected : null,
+            },
+          }),
+          'session.execution_boundary.query': async (input) => {
+            assert.equal(input.sessionId, projected.id);
+            return {
+              ok: true,
+              result: { kind: 'managed', access: 'read_only', revision: 2 },
+            };
+          },
+          'turn.start': async (input) => {
+            assert.equal(input.sessionId, projected.id);
+            assert.equal(input.content.text, 'Run through the Host');
+            return {
+              ok: true,
+              result: {
+                sessionId: input.sessionId,
+                turnId: input.turnId,
+                runId: 'run-1',
+                status: 'running',
+              },
+            };
+          },
+        }),
+        beginDrain() {},
+        async recover() {},
+        async close() {},
+      }),
+    });
+    const connected = await connectRuntimeHost({
+      rootPath: base,
+      surface: 'desktop',
+      protocol: {
+        min: RUNTIME_HOST_PROTOCOL_VERSION,
+        max: RUNTIME_HOST_PROTOCOL_VERSION,
+      },
+    });
+    assert.equal(connected.kind, 'connected');
+    if (connected.kind !== 'connected') throw new Error('Desktop did not connect to Runtime Host');
+    const client = new DesktopRuntimeHostClient(connected.connection);
+    const observer = new RuntimeHostSessionObserver({ client, emitSessionsChanged() {} });
+    const ipc = ipcHarness();
+    registerRuntimeHostSessionExecutionIpc(
+      {
+        client,
+        observer,
+        attachmentApprovals: createAttachmentApprovalRegistry(),
+        emitSessionsChanged() {},
+        stat: async () => ({ size: 0 }),
+        resizeImage: async (bytes) => bytes,
+        newId: () => 'turn-1',
+      },
+      ipc,
+    );
+
+    assert.deepEqual(await ipc.invoke('sessions:readExecutionBoundary', projected.id), {
+      kind: 'managed',
+      access: 'read_only',
+      revision: 2,
+    });
+    assert.deepEqual(
+      await ipc.invoke('sessions:send', projected.id, {
+        type: 'send',
+        turnId: 'turn-1',
+        text: 'Run through the Host',
+      }),
+      {
+        ok: true,
+        turnId: 'turn-1',
+        attachments: [],
+        inlineReferences: [],
+        skillInvocation: { loaded: [], failed: [], receipts: [] },
+      },
+    );
+
+    await observer.close();
     await client.close();
   } finally {
     await host?.close().catch(() => undefined);

--- a/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
@@ -1,0 +1,377 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import type { IpcMain } from 'electron';
+import type { AttachmentRef } from '@maka/core';
+import type { SessionCatalogProjection } from '@maka/runtime-host/protocol';
+import { createAttachmentApprovalRegistry } from '../attachment-approval.js';
+import type { DesktopRuntimeHostSession } from '../runtime-host-client.js';
+import {
+  registerRuntimeHostSessionExecutionIpc,
+  type RuntimeHostSessionExecutionIpcDeps,
+} from '../runtime-host-session-execution-ipc-main.js';
+import { RuntimeHostSessionObserver } from '../runtime-host-session-observer.js';
+
+test('sends canonical content and uploads owned Attachment bytes through the Host', async () => {
+  const starts: unknown[] = [];
+  const uploads: unknown[] = [];
+  const changes: unknown[] = [];
+  const attachment: AttachmentRef = {
+    kind: 'other',
+    name: 'notes.txt',
+    mimeType: 'text/plain',
+    bytes: 5,
+    ref: { kind: 'session_file', sessionId: 'session-1', relativePath: 'artifact-1' },
+  };
+  const client = executionClient({
+    getSession: async () => session(),
+    ingestAttachment: async (input) => {
+      uploads.push(input);
+      return attachment;
+    },
+    startTurn: async (input) => {
+      starts.push(input);
+      return {
+        sessionId: input.sessionId,
+        turnId: input.turnId,
+        runId: 'run-1',
+        status: 'running',
+      };
+    },
+  });
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionExecutionIpc(
+    {
+      client,
+      observer: unusedObserver(),
+      attachmentApprovals: createAttachmentApprovalRegistry(),
+      emitSessionsChanged: (reason, sessionId, extra) =>
+        changes.push({ reason, sessionId, ...extra }),
+      stat: async () => ({ size: 0 }),
+      resizeImage: async (bytes) => bytes,
+      newId: () => 'turn-1',
+    },
+    ipc,
+  );
+
+  const result = await ipc.invoke('sessions:send', 'session-1', {
+    type: 'send',
+    text: 'Read @notes.txt',
+    attachmentItems: [
+      {
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        base64: Buffer.from('hello').toString('base64'),
+      },
+    ],
+    workspaceFileReferences: [{ value: '@notes.txt', start: 5 }],
+  });
+
+  assert.equal((uploads[0] as { content: Uint8Array }).content.byteLength, 5);
+  assert.deepEqual(starts, [
+    {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      content: {
+        text: 'Read @notes.txt',
+        attachments: [attachment],
+        inlineReferences: [
+          {
+            kind: 'workspace_file',
+            value: '@notes.txt',
+            start: 5,
+            label: 'notes.txt',
+          },
+        ],
+      },
+    },
+  ]);
+  assert.deepEqual(result, {
+    ok: true,
+    turnId: 'turn-1',
+    attachments: [attachment],
+    inlineReferences: [
+      {
+        kind: 'workspace_file',
+        value: '@notes.txt',
+        start: 5,
+        label: 'notes.txt',
+      },
+    ],
+    skillInvocation: { loaded: [], failed: [], receipts: [] },
+  });
+  assert.deepEqual(changes, [
+    { reason: 'status-change', sessionId: 'session-1', turnId: 'turn-1' },
+  ]);
+});
+
+test('uploads a selected workspace file as a Host-owned Session Artifact', async (t) => {
+  const cwd = await mkdtemp(join(tmpdir(), 'maka-host-attachment-'));
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+  const path = join(cwd, 'notes.txt');
+  await writeFile(path, 'hello');
+  const approvals = createAttachmentApprovalRegistry();
+  const [approved] = approvals.issueApprovals(9, [
+    { path, name: 'notes.txt', mimeType: 'text/plain', size: 5 },
+  ]);
+  assert.ok(approved);
+  const uploads: Array<{ content: Uint8Array }> = [];
+  const starts: unknown[] = [];
+  const attachment: AttachmentRef = {
+    kind: 'other',
+    name: 'notes.txt',
+    mimeType: 'text/plain',
+    bytes: 5,
+    ref: { kind: 'session_file', sessionId: 'session-1', relativePath: 'artifact-1' },
+  };
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionExecutionIpc(
+    {
+      client: executionClient({
+        getSession: async () => session(cwd),
+        ingestAttachment: async (input) => {
+          uploads.push(input);
+          return attachment;
+        },
+        startTurn: async (input) => {
+          starts.push(input);
+          return {
+            sessionId: input.sessionId,
+            turnId: input.turnId,
+            runId: 'run-1',
+            status: 'running',
+          };
+        },
+      }),
+      observer: unusedObserver(),
+      attachmentApprovals: approvals,
+      emitSessionsChanged() {},
+      stat: async () => ({ size: 5 }),
+      resizeImage: async (bytes) => bytes,
+      newId: () => 'turn-1',
+    },
+    ipc,
+  );
+
+  await ipc.invoke('sessions:send', 'session-1', {
+    type: 'send',
+    text: 'Read the attachment',
+    attachmentItems: [approved],
+  });
+
+  assert.equal(Buffer.from(uploads[0]?.content ?? []).toString('utf8'), 'hello');
+  assert.deepEqual(
+    (starts[0] as { content: { attachments: AttachmentRef[] } }).content.attachments,
+    [attachment],
+  );
+});
+
+test('rejects Skill invocation until the Host Runtime-domain adapter owns its feedback contract', async () => {
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionExecutionIpc(
+    {
+      client: executionClient({}),
+      observer: unusedObserver(),
+      attachmentApprovals: createAttachmentApprovalRegistry(),
+      emitSessionsChanged() {},
+      stat: async () => ({ size: 0 }),
+      resizeImage: async (bytes) => bytes,
+    },
+    ipc,
+  );
+
+  await assert.rejects(
+    ipc.invoke('sessions:send', 'session-1', {
+      type: 'send',
+      text: '/skill:review',
+    }),
+    /Skill invocation is not available/,
+  );
+  await assert.rejects(
+    ipc.invoke('sessions:send', 'session-1', {
+      type: 'send',
+      text: '',
+      skillIds: ['review'],
+    }),
+    /Skill invocation is not available/,
+  );
+});
+
+test('binds steer and stop to Host-owned queue and active Turn identities', async () => {
+  const submits: unknown[] = [];
+  const interrupts: unknown[] = [];
+  let sequence = 0;
+  const client = executionClient({
+    submitMessage: async (input) => {
+      submits.push(input);
+      return { disposition: 'steering', queueRevision: 2 };
+    },
+    interruptTurn: async (input) => {
+      interrupts.push(input);
+      return {
+        queueRevision: 3,
+        retracted: [],
+        turn: {
+          sessionId: input.sessionId,
+          turnId: input.turnId,
+          runId: input.runId,
+          status: 'cancelled',
+          terminalEventId: 'terminal-1',
+          abortSource: 'user',
+        },
+      };
+    },
+  });
+  const observer = observerWithSnapshot();
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionExecutionIpc(
+    {
+      client,
+      observer,
+      attachmentApprovals: createAttachmentApprovalRegistry(),
+      emitSessionsChanged() {},
+      stat: async () => ({ size: 0 }),
+      resizeImage: async (bytes) => bytes,
+      newId: () => `id-${++sequence}`,
+    },
+    ipc,
+  );
+
+  assert.deepEqual(await ipc.invoke('sessions:steer', 'session-1', '  Continue  '), {
+    kind: 'queued',
+  });
+  await ipc.invoke('sessions:stop', 'session-1');
+
+  assert.deepEqual(submits, [
+    {
+      sessionId: 'session-1',
+      messageId: 'id-1',
+      content: { text: 'Continue' },
+      placement: 'current_turn',
+    },
+  ]);
+  assert.deepEqual(interrupts, [
+    {
+      sessionId: 'session-1',
+      interruptId: 'id-2',
+      turnId: 'turn-1',
+      runId: 'run-1',
+    },
+  ]);
+  await observer.close();
+});
+
+type ExecutionClient = RuntimeHostSessionExecutionIpcDeps['client'];
+
+function executionClient(overrides: Partial<ExecutionClient>): ExecutionClient {
+  const unavailable = async (): Promise<never> => {
+    throw new Error('Unexpected Runtime Host Session execution operation');
+  };
+  return {
+    answerInteraction: unavailable,
+    compactContext: unavailable,
+    copySession: unavailable,
+    getSession: unavailable,
+    ingestAttachment: unavailable,
+    interruptTurn: unavailable,
+    queryTurnResume: unavailable,
+    readExecutionBoundary: unavailable,
+    regenerateTurn: unavailable,
+    setSessionReadMarker: unavailable,
+    startTurn: unavailable,
+    startTurnResume: unavailable,
+    submitMessage: unavailable,
+    updateSessionMetadata: unavailable,
+    ...overrides,
+  };
+}
+
+function unusedObserver(): RuntimeHostSessionObserver {
+  return new RuntimeHostSessionObserver({
+    client: {
+      openSession: async (): Promise<DesktopRuntimeHostSession> => {
+        throw new Error('Unexpected Runtime Host Session subscription');
+      },
+    },
+    emitSessionsChanged() {},
+  });
+}
+
+function observerWithSnapshot(): RuntimeHostSessionObserver {
+  return new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: {
+          schemaVersion: 3,
+          session: {
+            sessionId: 'session-1',
+            metadataRevision: 1,
+            status: 'running',
+            createdAt: 1,
+            lastUsedAt: 1,
+            isArchived: false,
+          },
+          projectionRevision: 1,
+          rootTurn: {
+            sessionId: 'session-1',
+            turnId: 'turn-1',
+            runId: 'run-1',
+            status: 'running',
+          },
+          goal: null,
+          queue: { hostEpoch: 'host-1', queueRevision: 0, steering: [], followup: [] },
+          interactions: { pending: [] },
+        },
+        transcript: Promise.resolve([]),
+        events: emptyEvents(),
+        async close() {},
+      }),
+    },
+    emitSessionsChanged() {},
+  });
+}
+
+async function* emptyEvents(): AsyncIterable<never> {}
+
+type IpcHandler = Parameters<Pick<IpcMain, 'handle'>['handle']>[1];
+
+function ipcHarness() {
+  const handlers = new Map<string, IpcHandler>();
+  return {
+    handle(channel: string, handler: IpcHandler) {
+      assert.equal(handlers.has(channel), false, `duplicate handler: ${channel}`);
+      handlers.set(channel, handler);
+    },
+    async invoke(channel: string, ...args: unknown[]): Promise<unknown> {
+      const handler = handlers.get(channel);
+      assert.ok(handler, `missing handler: ${channel}`);
+      return handler({ sender: { id: 9 } } as never, ...args);
+    },
+  };
+}
+
+function session(cwd = '/workspace'): SessionCatalogProjection {
+  return {
+    id: 'session-1',
+    revision: 1,
+    cwd,
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Session',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    labelsTruncated: false,
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test-connection',
+    connectionLocked: true,
+    model: 'test-model',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+  };
+}

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -1,0 +1,461 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+import type { SessionEvent, StoredMessage } from '@maka/core';
+import type {
+  SessionContinuitySnapshot,
+  SubscriptionFrame,
+} from '@maka/runtime-host/protocol';
+import type { DesktopRuntimeHostSession } from '../runtime-host-client.js';
+import {
+  RuntimeHostSessionObserver,
+  type RuntimeHostSessionObserverTarget,
+} from '../runtime-host-session-observer.js';
+
+test('joins an active Turn without losing or replaying assistant text', async () => {
+  const transcript = deferred<StoredMessage[]>();
+  const events = new AsyncFrameQueue();
+  let closeCount = 0;
+  const handle: DesktopRuntimeHostSession = {
+    snapshot: continuitySnapshot(),
+    transcript: transcript.promise,
+    events,
+    async close() {
+      closeCount += 1;
+      events.end();
+    },
+  };
+  const observer = new RuntimeHostSessionObserver({
+    client: { openSession: async () => handle },
+    emitSessionsChanged() {},
+    now: () => 50,
+  });
+  const target = eventTarget(1);
+
+  const observing = observer.observe('session-1', 'observer-1', target);
+  events.push(deltaFrame(1, 5, ' world'));
+  transcript.resolve([
+    {
+      type: 'assistant',
+      id: 'message-1',
+      turnId: 'turn-1',
+      ts: 10,
+      text: 'Hello',
+      modelId: 'test-model',
+    },
+  ]);
+  await observing;
+  await waitFor(() => target.events.length === 2);
+
+  assert.deepEqual(
+    target.events.map((event) => [event.type, 'text' in event ? event.text : undefined]),
+    [
+      ['text_delta', 'Hello'],
+      ['text_delta', ' world'],
+    ],
+  );
+
+  events.push({
+    kind: 'subscription.session_projection',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence: 2,
+    snapshot: continuitySnapshot({
+      rootTurn: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        runId: 'run-1',
+        status: 'completed',
+        terminalEventId: 'terminal-1',
+      },
+    }),
+  });
+  await waitFor(() => target.events.some((event) => event.type === 'complete'));
+
+  assert.deepEqual(
+    target.events.filter(
+      (event): event is Extract<SessionEvent, { type: 'text_complete' }> =>
+        event.type === 'text_complete',
+    ),
+    [
+      {
+        type: 'text_complete',
+        id: 'terminal-1:text:message-1',
+        turnId: 'turn-1',
+        messageId: 'message-1',
+        ts: 50,
+        text: 'Hello world',
+      },
+    ],
+  );
+
+  await observer.unobserve('observer-1');
+  assert.equal(closeCount, 1);
+});
+
+test('shares one Host subscription and one delivery per renderer target', async () => {
+  const events = new AsyncFrameQueue();
+  let openCount = 0;
+  let closeCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => {
+        openCount += 1;
+        return {
+          snapshot: continuitySnapshot(),
+          transcript: Promise.resolve([]),
+          events,
+          async close() {
+            closeCount += 1;
+            events.end();
+          },
+        };
+      },
+    },
+    emitSessionsChanged() {},
+  });
+  const target = eventTarget(7);
+
+  await Promise.all([
+    observer.observe('session-1', 'observer-1', target),
+    observer.observe('session-1', 'observer-2', target),
+  ]);
+  events.push(deltaFrame(1, 0, 'one'));
+  await waitFor(() => target.events.length === 1);
+
+  assert.equal(openCount, 1);
+  assert.equal(target.events.length, 1);
+  await observer.unobserve('observer-1');
+  assert.equal(closeCount, 0);
+  await observer.unobserve('observer-2');
+  assert.equal(closeCount, 1);
+});
+
+test('releases the renderer destroyed listener when its last observer leaves', async () => {
+  const events = new AsyncFrameQueue();
+  const destroyed = new EventEmitter();
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: continuitySnapshot(),
+        transcript: Promise.resolve([]),
+        events,
+        async close() {
+          events.end();
+        },
+      }),
+    },
+    emitSessionsChanged() {},
+  });
+  const target: RuntimeHostSessionObserverTarget = {
+    id: 10,
+    send() {},
+    once: (event, listener) => destroyed.once(event, listener),
+    off: (event, listener) => destroyed.off(event, listener),
+  };
+
+  await observer.observe('session-1', 'observer-1', target);
+  assert.equal(destroyed.listenerCount('destroyed'), 1);
+  await observer.unobserve('observer-1');
+  assert.equal(destroyed.listenerCount('destroyed'), 0);
+});
+
+test('closes a Host handle that arrives after the observer is closed', async () => {
+  const opened = deferred<DesktopRuntimeHostSession>();
+  let closeCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: { openSession: () => opened.promise },
+    emitSessionsChanged() {},
+  });
+  const observing = observer.observe('session-1', 'observer-1', eventTarget(8));
+
+  await observer.close();
+  opened.resolve({
+    snapshot: continuitySnapshot(),
+    transcript: Promise.resolve([]),
+    events: new AsyncFrameQueue(),
+    async close() {
+      closeCount += 1;
+    },
+  });
+
+  await assert.rejects(observing, /closed while opening/);
+  assert.equal(closeCount, 1);
+});
+
+test('drains live frames while refreshing the canonical transcript', async () => {
+  const initialEvents = new AsyncFrameQueue();
+  const refreshEvents = new AsyncFrameQueue();
+  const refreshTranscript = deferred<StoredMessage[]>();
+  let openCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => {
+        openCount += 1;
+        if (openCount === 1) {
+          return {
+            snapshot: continuitySnapshot(),
+            transcript: Promise.resolve([]),
+            events: initialEvents,
+            async close() {
+              initialEvents.end();
+            },
+          };
+        }
+        return {
+          snapshot: continuitySnapshot(),
+          transcript: refreshTranscript.promise,
+          events: refreshEvents,
+          async close() {
+            refreshEvents.end();
+          },
+        };
+      },
+    },
+    emitSessionsChanged() {},
+  });
+  await observer.observe('session-1', 'observer-1', eventTarget(9));
+  await observer.readMessages('session-1');
+
+  const refreshing = observer.readMessages('session-1');
+  await waitFor(() => refreshEvents.nextCount > 0);
+  refreshTranscript.resolve([]);
+
+  assert.deepEqual(await refreshing, []);
+  await observer.close();
+});
+
+test('rehydrates pending interactions and publishes answer acknowledgements', async () => {
+  const pending = {
+    schemaVersion: 1 as const,
+    interactionId: 'interaction-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    runId: 'run-1',
+    revision: 1 as const,
+    status: 'pending' as const,
+    outcome: null,
+    request: {
+      kind: 'question' as const,
+      toolUseId: 'tool-1',
+      questions: [
+        {
+          question: 'Proceed?',
+          options: [{ label: 'Yes', description: 'Continue.' }],
+        },
+      ],
+    },
+  };
+  const events = new AsyncFrameQueue();
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: continuitySnapshot({ interactions: { pending: [pending] } }),
+        transcript: Promise.resolve([]),
+        events,
+        async close() {
+          events.end();
+        },
+      }),
+    },
+    emitSessionsChanged() {},
+    now: () => 75,
+  });
+  const target = eventTarget(2);
+  await observer.observe('session-1', 'observer-1', target);
+
+  assert.deepEqual(await observer.readActiveInteractions('session-1'), target.events);
+  observer.publishInteractionAnswer(
+    {
+      ...pending,
+      revision: 2,
+      status: 'answered',
+      outcome: { kind: 'question_answer', answers: ['Yes'], committedAt: 75 },
+    },
+    pending,
+  );
+
+  assert.equal(target.events.at(-1)?.type, 'user_question_answer_ack');
+  await observer.close();
+});
+
+test('projects Host queue revisions and newly delivered steering messages', async () => {
+  const events = new AsyncFrameQueue();
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: continuitySnapshot(),
+        transcript: Promise.resolve([]),
+        events,
+        async close() {
+          events.end();
+        },
+      }),
+    },
+    emitSessionsChanged() {},
+    now: () => 90,
+  });
+  const target = eventTarget(3);
+  await observer.observe('session-1', 'observer-1', target);
+  const queued = {
+    entryId: 'entry-1',
+    messageId: 'message-steer',
+    content: { text: 'Change direction' },
+    placement: 'current_turn' as const,
+    state: 'queued' as const,
+  };
+
+  events.push({
+    kind: 'subscription.session_projection',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence: 1,
+    snapshot: continuitySnapshot({
+      projectionRevision: 2,
+      queue: {
+        hostEpoch: 'host-1',
+        queueRevision: 1,
+        steering: [queued],
+        followup: [],
+      },
+    }),
+  });
+  await waitFor(() => target.events.length === 1);
+  events.push({
+    kind: 'subscription.session_projection',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence: 2,
+    snapshot: continuitySnapshot({
+      projectionRevision: 3,
+      queue: {
+        hostEpoch: 'host-1',
+        queueRevision: 2,
+        steering: [{ ...queued, state: 'in_flight' }],
+        followup: [],
+      },
+    }),
+  });
+  await waitFor(() => target.events.length === 3);
+
+  assert.deepEqual(
+    target.events.map((event) => event.type),
+    ['queue_update', 'steering_message', 'queue_update'],
+  );
+  assert.deepEqual(target.events[1], {
+    type: 'steering_message',
+    id: 'host-queue:host-1:2:entry-1',
+    turnId: 'turn-1',
+    messageId: 'message-steer',
+    ts: 90,
+    content: { text: 'Change direction' },
+  });
+  await observer.close();
+});
+
+function continuitySnapshot(
+  overrides: Partial<SessionContinuitySnapshot> = {},
+): SessionContinuitySnapshot {
+  return {
+    schemaVersion: 3,
+    session: {
+      sessionId: 'session-1',
+      metadataRevision: 1,
+      status: 'running',
+      createdAt: 1,
+      lastUsedAt: 1,
+      isArchived: false,
+    },
+    projectionRevision: 1,
+    rootTurn: {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      status: 'running',
+    },
+    goal: null,
+    queue: { hostEpoch: 'host-1', queueRevision: 0, steering: [], followup: [] },
+    interactions: { pending: [] },
+    ...overrides,
+  };
+}
+
+function deltaFrame(sequence: number, startOffset: number, text: string): SubscriptionFrame {
+  return {
+    kind: 'subscription.session_delta',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence,
+    sessionId: 'session-1',
+    delta: {
+      kind: 'text',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      messageId: 'message-1',
+      startOffset,
+      text,
+    },
+  };
+}
+
+function eventTarget(id: number): RuntimeHostSessionObserverTarget & { events: SessionEvent[] } {
+  const events: SessionEvent[] = [];
+  return {
+    id,
+    events,
+    send(_channel, event) {
+      events.push(event);
+    },
+    once() {},
+    off() {},
+  };
+}
+
+class AsyncFrameQueue implements AsyncIterable<SubscriptionFrame> {
+  readonly #frames: SubscriptionFrame[] = [];
+  readonly #waiters: Array<(result: IteratorResult<SubscriptionFrame>) => void> = [];
+  nextCount = 0;
+  #ended = false;
+
+  push(frame: SubscriptionFrame): void {
+    const waiter = this.#waiters.shift();
+    if (waiter) waiter({ value: frame, done: false });
+    else this.#frames.push(frame);
+  }
+
+  end(): void {
+    this.#ended = true;
+    for (const waiter of this.#waiters.splice(0)) waiter({ value: undefined, done: true });
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<SubscriptionFrame> {
+    return {
+      next: () => {
+        this.nextCount += 1;
+        const frame = this.#frames.shift();
+        if (frame) return Promise.resolve({ value: frame, done: false });
+        if (this.#ended) return Promise.resolve({ value: undefined, done: true });
+        return new Promise((resolve) => this.#waiters.push(resolve));
+      },
+    };
+  }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.fail('Timed out waiting for observer state');
+}

--- a/apps/desktop/src/main/attachment-ingest.ts
+++ b/apps/desktop/src/main/attachment-ingest.ts
@@ -10,6 +10,14 @@ export type AttachmentIngestFile =
   | { path: string; mimeType?: string; size: number }
   | { name: string; mimeType?: string; size: number; content: Uint8Array };
 
+export interface AttachmentSnapshotInput {
+  name: string;
+  mimeType: string;
+  artifactKind: ArtifactKind;
+  attachmentKind: AttachmentRef['kind'];
+  content: Uint8Array;
+}
+
 /**
  * Resolve a selected/dropped file into an {@link AttachmentRef} the runtime
  * can consume:
@@ -36,6 +44,52 @@ export async function ingestAttachments(input: {
   now?: () => number;
   maxBytes?: number;
 }): Promise<AttachmentRef[]> {
+  return resolveAttachmentRefs({
+    ...input,
+    workspaceFiles: 'reference',
+    snapshot: async ({ name, mimeType, artifactKind, attachmentKind, content }) => {
+      const source: ArtifactSource = 'user_upload';
+      const record = await input.artifactStore.create({
+        sessionId: input.sessionId,
+        turnId: input.sessionId,
+        name,
+        kind: artifactKind,
+        content,
+        mimeType,
+        source,
+        ...(input.now ? { now: input.now() } : {}),
+      });
+      return {
+        kind: attachmentKind,
+        name,
+        mimeType,
+        bytes: content.byteLength,
+        ref: {
+          kind: 'session_file',
+          sessionId: input.sessionId,
+          relativePath: record.id,
+        },
+      };
+    },
+  });
+}
+
+/**
+ * Resolve attachment references while making workspace-file ownership
+ * explicit. Embedded execution can preserve cwd-contained files as workspace
+ * references; the Runtime Host adapter snapshots every selected path because
+ * hosted Turn attachments accept only canonical Session Artifacts.
+ */
+export async function resolveAttachmentRefs(input: {
+  files: AttachmentIngestFile[];
+  cwd: string;
+  sessionId: string;
+  workspaceFiles: 'reference' | 'snapshot';
+  snapshot: (input: AttachmentSnapshotInput) => Promise<AttachmentRef>;
+  resizeImage?: (bytes: Uint8Array) => Promise<Uint8Array>;
+  realpath?: (path: string) => Promise<string>;
+  maxBytes?: number;
+}): Promise<AttachmentRef[]> {
   const maxBytes = input.maxBytes ?? MAX_ATTACHMENT_BYTES;
   const refs: AttachmentRef[] = [];
   for (const file of input.files) {
@@ -43,7 +97,12 @@ export async function ingestAttachments(input: {
     const mimeType = file.mimeType && file.mimeType.length > 0 ? file.mimeType : guessMimeFromName(name);
     const kind = attachmentKindFromMimeType(mimeType, name);
 
-    if (kind !== 'image' && isPathAttachment(file) && (await isInsideCwdReal(input.cwd, file.path, input.realpath))) {
+    if (
+      input.workspaceFiles === 'reference' &&
+      kind !== 'image' &&
+      isPathAttachment(file) &&
+      (await isInsideCwdReal(input.cwd, file.path, input.realpath))
+    ) {
       const realCwd = await resolveReal(input.cwd, input.realpath);
       const realTarget = await resolveReal(file.path, input.realpath);
       refs.push({
@@ -60,25 +119,17 @@ export async function ingestAttachments(input: {
     if (kind === 'image' && input.resizeImage) {
       bytes = await input.resizeImage(bytes);
     }
-    const artifactKind: ArtifactKind = kind === 'image' ? 'image' : kind === 'pdf' ? 'pdf' : 'file';
-    const source: ArtifactSource = 'user_upload';
-    const record = await input.artifactStore.create({
-      sessionId: input.sessionId,
-      turnId: input.sessionId,
-      name,
-      kind: artifactKind,
-      content: bytes,
-      mimeType,
-      source,
-      ...(input.now ? { now: input.now() } : {}),
-    });
-    refs.push({
-      kind,
-      name,
-      mimeType,
-      bytes: bytes.byteLength,
-      ref: { kind: 'session_file', sessionId: input.sessionId, relativePath: record.id },
-    });
+    const artifactKind: ArtifactKind =
+      kind === 'image' ? 'image' : kind === 'pdf' ? 'pdf' : 'file';
+    refs.push(
+      await input.snapshot({
+        name,
+        mimeType,
+        artifactKind,
+        attachmentKind: kind,
+        content: bytes,
+      }),
+    );
   }
   return refs;
 }

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -1,3 +1,5 @@
+import { createHash, randomUUID } from 'node:crypto';
+import type { AttachmentRef } from '@maka/core/events';
 import { decodeStoredMessageForRead, type StoredMessage } from '@maka/core/session';
 import {
   type DirectRequestOperationKey,
@@ -5,6 +7,7 @@ import {
   type RuntimeHostSessionSubscription,
 } from '@maka/runtime-host/client';
 import {
+  ARTIFACT_INGEST_CHUNK_MAX_BYTES,
   type InteractionAnswerInput,
   type OperationInput,
   type OperationOutput,
@@ -19,6 +22,7 @@ import {
   type SessionConversationCopyInput,
   type SessionConversationCopyResult,
   type SessionCreateInput,
+  type ExecutionBoundarySummary,
   type SessionLifecycleState,
   type SessionMetadataPatch,
   type SessionUpdateResult,
@@ -154,6 +158,10 @@ export class DesktopRuntimeHostClient {
     );
   }
 
+  readExecutionBoundary(sessionId: string): Promise<ExecutionBoundarySummary> {
+    return this.#request('session.execution_boundary.query', { sessionId });
+  }
+
   async setSessionLifecycle(
     sessionId: string,
     state: SessionLifecycleState,
@@ -189,6 +197,70 @@ export class DesktopRuntimeHostClient {
       if (result.kind === 'committed') return requireSessionProjection(result.session);
     }
     throw revisionConflict(`${kind} copy`, input.sourceSessionId);
+  }
+
+  async ingestAttachment(input: {
+    sessionId: string;
+    name: string;
+    mimeType: string;
+    content: Uint8Array;
+    uploadId?: string;
+  }): Promise<AttachmentRef> {
+    const uploadId = input.uploadId ?? randomUUID();
+    const digest = `sha256:${createHash('sha256').update(input.content).digest('hex')}` as const;
+    let opened = false;
+    try {
+      const begin = await this.#request('artifact.ingest', {
+        kind: 'begin',
+        sessionId: input.sessionId,
+        uploadId,
+        name: input.name,
+        mimeType: input.mimeType,
+        totalBytes: input.content.byteLength,
+        contentSha256: digest,
+      });
+      if (begin.kind === 'committed') return begin.attachment;
+      if (begin.kind !== 'upload_opened') {
+        throw new Error('Runtime Host did not open the Attachment upload');
+      }
+      opened = true;
+      let offset = begin.nextOffset;
+      while (offset < input.content.byteLength) {
+        const chunk = input.content.subarray(
+          offset,
+          Math.min(input.content.byteLength, offset + ARTIFACT_INGEST_CHUNK_MAX_BYTES),
+        );
+        const accepted = await this.#request('artifact.ingest', {
+          kind: 'chunk',
+          sessionId: input.sessionId,
+          uploadId,
+          offset,
+          chunkBase64: Buffer.from(chunk).toString('base64'),
+        });
+        if (accepted.kind !== 'chunk_accepted' || accepted.nextOffset <= offset) {
+          throw new Error('Runtime Host did not advance the Attachment upload');
+        }
+        offset = accepted.nextOffset;
+      }
+      const committed = await this.#request('artifact.ingest', {
+        kind: 'commit',
+        sessionId: input.sessionId,
+        uploadId,
+      });
+      if (committed.kind !== 'committed') {
+        throw new Error('Runtime Host did not commit the Attachment upload');
+      }
+      return committed.attachment;
+    } catch (error) {
+      if (opened) {
+        await this.#request('artifact.ingest', {
+          kind: 'abort',
+          sessionId: input.sessionId,
+          uploadId,
+        }).catch(() => undefined);
+      }
+      throw error;
+    }
   }
 
   submitMessage(

--- a/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
@@ -234,7 +234,7 @@ function normalizeCreateThinkingLevel(
   return { thinkingLevel: value };
 }
 
-function toDesktopHostSessionSummary(
+export function toDesktopHostSessionSummary(
   session: SessionCatalogProjection,
 ): DesktopHostSessionSummary {
   return {

--- a/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
@@ -1,0 +1,326 @@
+import { randomUUID } from 'node:crypto';
+import type { IpcMain } from 'electron';
+import {
+  deriveTurnRecords,
+  SKILL_INVOCATION_TOKEN_SOURCE,
+  type AttachmentRef,
+  type SessionChangedEvent,
+  type SessionChangedReason,
+} from '@maka/core';
+import type { SkillInvocationResult } from '@maka/runtime';
+import type { AttachmentApprovalRegistry } from './attachment-approval.js';
+import { resolveAttachmentRefs, resolveIngestItems } from './attachment-ingest.js';
+import {
+  normalizeBranchFromTurnInput,
+  normalizeRegenerateTurnInput,
+  normalizeReviseBeforeTurnInput,
+  normalizeSandboxBoundaryResponse,
+  normalizeSessionSendCommand,
+  normalizeUserQuestionResponse,
+} from './permission-response-guard.js';
+import type { DesktopRuntimeHostClient } from './runtime-host-client.js';
+import {
+  RuntimeHostSessionObserver,
+  type RuntimeHostSessionObserverTarget,
+} from './runtime-host-session-observer.js';
+import { toDesktopHostSessionSummary } from './runtime-host-session-catalog-ipc-main.js';
+import { mergeSentInlineReferences } from './session-send-inline-references.js';
+
+const EMPTY_SKILL_INVOCATION: SkillInvocationResult = {
+  loaded: [],
+  failed: [],
+  receipts: [],
+};
+
+type RuntimeHostSessionExecutionClient = Pick<
+  DesktopRuntimeHostClient,
+  | 'answerInteraction'
+  | 'compactContext'
+  | 'copySession'
+  | 'getSession'
+  | 'ingestAttachment'
+  | 'interruptTurn'
+  | 'queryTurnResume'
+  | 'readExecutionBoundary'
+  | 'regenerateTurn'
+  | 'setSessionReadMarker'
+  | 'startTurn'
+  | 'startTurnResume'
+  | 'submitMessage'
+  | 'updateSessionMetadata'
+>;
+
+export interface RuntimeHostSessionExecutionIpcDeps {
+  client: RuntimeHostSessionExecutionClient;
+  observer: RuntimeHostSessionObserver;
+  attachmentApprovals: AttachmentApprovalRegistry;
+  emitSessionsChanged: (
+    reason: SessionChangedReason,
+    sessionId?: string,
+    extra?: Pick<SessionChangedEvent, 'turnId'>,
+  ) => void;
+  stat(path: string): Promise<{ size: number }>;
+  resizeImage(bytes: Uint8Array): Promise<Uint8Array>;
+  newId?: () => string;
+}
+
+/**
+ * Register the isolated Runtime Host-backed half of the existing Desktop
+ * Session IPC facade. Production continues to register the embedded facade
+ * until M5 performs the atomic owner switch.
+ */
+export function registerRuntimeHostSessionExecutionIpc(
+  deps: RuntimeHostSessionExecutionIpcDeps,
+  ipcMain: Pick<IpcMain, 'handle'>,
+): void {
+  const newId = deps.newId ?? randomUUID;
+
+  ipcMain.handle('sessions:observe', async (event, sessionId: unknown, observerId: unknown) => {
+    const normalizedSessionId = requiredId(sessionId, 'Session');
+    const normalizedObserverId = requiredId(observerId, 'Session observer');
+    await deps.observer.observe(
+      normalizedSessionId,
+      normalizedObserverId,
+      event.sender as RuntimeHostSessionObserverTarget,
+    );
+  });
+  ipcMain.handle('sessions:unobserve', async (_event, observerId: unknown) => {
+    await deps.observer.unobserve(requiredId(observerId, 'Session observer'));
+  });
+  ipcMain.handle('sessions:readMessages', async (_event, sessionId: string) => {
+    const messages = await deps.observer.readMessages(sessionId);
+    const readThroughMessageId = messages.at(-1)?.id;
+    if (readThroughMessageId) {
+      await deps.client.setSessionReadMarker(sessionId, readThroughMessageId).catch(() => undefined);
+    }
+    return messages;
+  });
+  ipcMain.handle('sessions:listTurns', async (_event, sessionId: string) =>
+    deriveTurnRecords(await deps.observer.readMessages(sessionId)),
+  );
+  ipcMain.handle('sessions:readExecutionBoundary', (_event, sessionId: string) =>
+    deps.client.readExecutionBoundary(sessionId),
+  );
+  ipcMain.handle('sessions:listActiveInteractions', (_event, sessionId: string) =>
+    deps.observer.readActiveInteractions(sessionId),
+  );
+
+  ipcMain.handle('sessions:send', async (event, sessionId: string, input: unknown) => {
+    const command = normalizeSessionSendCommand(input);
+    if (!command) return;
+    if (command.voiceOperationId) {
+      throw new Error('Runtime Host Session voice input is not available yet');
+    }
+    if (
+      (command.skillIds?.length ?? 0) > 0 ||
+      new RegExp(SKILL_INVOCATION_TOKEN_SOURCE).test(command.text)
+    ) {
+      throw new Error('Runtime Host Session Skill invocation is not available yet');
+    }
+    const session = await deps.client.getSession(sessionId);
+    if (!session) throw new Error(`Runtime Host Session not found: ${sessionId}`);
+    const turnId = command.turnId ?? newId();
+    let attachments: AttachmentRef[] = [];
+    if (command.attachmentItems !== undefined) {
+      const files = await resolveIngestItems({
+        senderId: event.sender.id,
+        items: command.attachmentItems,
+        approvals: deps.attachmentApprovals,
+        stat: deps.stat,
+      });
+      attachments = await resolveAttachmentRefs({
+        files,
+        cwd: session.cwd,
+        sessionId,
+        workspaceFiles: 'snapshot',
+        resizeImage: deps.resizeImage,
+        snapshot: ({ name, mimeType, content }) =>
+          deps.client.ingestAttachment({ sessionId, name, mimeType, content }),
+      });
+    }
+    const displayText = command.displayText ?? command.text;
+    const inlineReferences = mergeSentInlineReferences({
+      displayText,
+      workspaceFileReferences: command.workspaceFileReferences,
+      receipts: [],
+    });
+    await deps.client.startTurn({
+      sessionId,
+      turnId,
+      content: {
+        text: command.text,
+        ...(command.displayText !== undefined ? { displayText: command.displayText } : {}),
+        ...(attachments.length > 0 ? { attachments } : {}),
+        ...(command.quotes ? { quotes: command.quotes } : {}),
+        inlineReferences,
+      },
+      ...(command.turnOrchestration
+        ? { turnOrchestration: command.turnOrchestration }
+        : {}),
+    });
+    deps.emitSessionsChanged('status-change', sessionId, { turnId });
+    return {
+      ok: true as const,
+      turnId,
+      attachments,
+      inlineReferences,
+      skillInvocation: EMPTY_SKILL_INVOCATION,
+    };
+  });
+
+  ipcMain.handle('sessions:steer', async (_event, sessionId: string, text: unknown) => {
+    const content = steeringContent(text);
+    await deps.client.submitMessage({
+      sessionId,
+      messageId: newId(),
+      content: { text: content },
+      placement: 'current_turn',
+    });
+    return { kind: 'queued' as const };
+  });
+  ipcMain.handle('sessions:stop', async (_event, sessionId: string) => {
+    const turn = (await deps.observer.snapshot(sessionId)).rootTurn;
+    if (!turn || isTerminalStatus(turn.status)) return;
+    await deps.client.interruptTurn({
+      sessionId,
+      interruptId: newId(),
+      turnId: turn.turnId,
+      runId: turn.runId,
+    });
+    deps.emitSessionsChanged('turn-status-change', sessionId, { turnId: turn.turnId });
+  });
+
+  ipcMain.handle(
+    'sessions:respondToSandboxBoundary',
+    async (_event, sessionId: string, input: unknown) => {
+      const response = normalizeSandboxBoundaryResponse(input);
+      const pending = await requireInteraction(deps.observer, sessionId, response.requestId);
+      if (pending.request.kind !== 'sandbox_boundary') {
+        throw new Error('Interaction is not a sandbox boundary request');
+      }
+      const answered = await deps.client.answerInteraction({
+        sessionId,
+        interactionId: response.requestId,
+        answer: { kind: 'sandbox_boundary', decision: response.decision },
+      });
+      deps.observer.publishInteractionAnswer(answered, pending);
+    },
+  );
+  ipcMain.handle(
+    'sessions:respondToUserQuestion',
+    async (_event, sessionId: string, input: unknown) => {
+      const response = normalizeUserQuestionResponse(input);
+      const pending = await requireInteraction(deps.observer, sessionId, response.requestId);
+      if (pending.request.kind !== 'question') {
+        throw new Error('Interaction is not a user question request');
+      }
+      const answered = await deps.client.answerInteraction({
+        sessionId,
+        interactionId: response.requestId,
+        answer: { kind: 'question', answers: response.answers },
+      });
+      deps.observer.publishInteractionAnswer(answered, pending);
+    },
+  );
+
+  ipcMain.handle('sessions:compact', async (_event, sessionId: string) => {
+    const turnId = newId();
+    await deps.client.compactContext({ sessionId, turnId });
+    deps.emitSessionsChanged('status-change', sessionId, { turnId });
+  });
+  ipcMain.handle('sessions:resumeLatest', async (_event, sessionId: string) => {
+    const plan = await deps.client.queryTurnResume({ sessionId });
+    if (plan.disposition === 'parked') {
+      return {
+        disposition: 'park' as const,
+        rejectionReasons: [plan.reason],
+        diagnostics: [],
+      };
+    }
+    const turnId = newId();
+    const result = await deps.client.startTurnResume({
+      sessionId,
+      turnId,
+      sourceRunId: plan.sourceRunId,
+      sourceRuntimeEventHighWater: plan.sourceRuntimeEventHighWater,
+    });
+    if (result.kind === 'parked') {
+      return {
+        disposition: 'park' as const,
+        rejectionReasons: [result.plan.reason],
+        diagnostics: [],
+      };
+    }
+    deps.emitSessionsChanged('status-change', sessionId, { turnId });
+    return {
+      disposition: 'started' as const,
+      runId: result.turn.runId,
+      turnId: result.turn.turnId,
+    };
+  });
+  ipcMain.handle(
+    'sessions:regenerateTurn',
+    async (_event, sessionId: string, input: unknown) => {
+      const normalized = normalizeRegenerateTurnInput(input);
+      const turnId = normalized.turnId ?? newId();
+      await deps.client.regenerateTurn({
+        sessionId,
+        sourceTurnId: normalized.sourceTurnId,
+        turnId,
+      });
+      deps.emitSessionsChanged('status-change', sessionId, { turnId });
+    },
+  );
+
+  ipcMain.handle('sessions:branchFromTurn', async (_event, sessionId: string, input: unknown) => {
+    const normalized = normalizeBranchFromTurnInput(input);
+    let branch = await deps.client.copySession('branch', {
+      sourceSessionId: sessionId,
+      targetSessionId: newId(),
+      sourceTurnId: normalized.sourceTurnId,
+    });
+    if (normalized.name) {
+      branch = await deps.client.updateSessionMetadata(branch.id, { name: normalized.name });
+    }
+    deps.emitSessionsChanged('created', branch.id);
+    return toDesktopHostSessionSummary(branch);
+  });
+  ipcMain.handle('sessions:reviseBeforeTurn', async (_event, sessionId: string, input: unknown) => {
+    const normalized = normalizeReviseBeforeTurnInput(input);
+    const revision = await deps.client.copySession('revision', {
+      sourceSessionId: sessionId,
+      targetSessionId: newId(),
+      sourceTurnId: normalized.sourceTurnId,
+    });
+    deps.emitSessionsChanged('created', revision.id);
+    return toDesktopHostSessionSummary(revision);
+  });
+}
+
+async function requireInteraction(
+  observer: RuntimeHostSessionObserver,
+  sessionId: string,
+  interactionId: string,
+) {
+  const interaction = await observer.readInteraction(sessionId, interactionId);
+  if (!interaction) throw new Error(`Runtime Host Interaction not found: ${interactionId}`);
+  return interaction;
+}
+
+function requiredId(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 256) {
+    throw new Error(`Invalid ${label} identity`);
+  }
+  return value;
+}
+
+function steeringContent(value: unknown): string {
+  if (typeof value !== 'string' || value.trim().length === 0 || value.length > 128_000) {
+    throw new Error('Invalid steering text');
+  }
+  return value.trim();
+}
+
+function isTerminalStatus(status: string): boolean {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
+}

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -1,0 +1,818 @@
+import type {
+  ActiveInteractionRequestEvent,
+  SessionChangedReason,
+  SessionEvent,
+  StoredMessage,
+} from '@maka/core';
+import type {
+  InteractionAnsweredSnapshot,
+  InteractionPendingSnapshot,
+  SessionMessageQueueProjection,
+  SessionContinuitySnapshot,
+  SteeringMessageSnapshot,
+  SubscriptionFrame,
+  TurnSnapshot,
+} from '@maka/runtime-host/protocol';
+import type {
+  DesktopRuntimeHostClient,
+  DesktopRuntimeHostSession,
+} from './runtime-host-client.js';
+
+const MAX_PENDING_FRAMES = 512;
+
+type SessionObserverClient = Pick<DesktopRuntimeHostClient, 'openSession'>;
+
+export interface RuntimeHostSessionObserverTarget {
+  readonly id: number;
+  send(channel: string, event: SessionEvent): void;
+  once(event: 'destroyed', listener: () => void): void;
+  off(event: 'destroyed', listener: () => void): void;
+}
+
+export interface RuntimeHostSessionObserverDeps {
+  client: SessionObserverClient;
+  emitSessionsChanged: (
+    reason: SessionChangedReason,
+    sessionId: string,
+    extra?: { turnId?: string },
+  ) => void;
+  now?: () => number;
+}
+
+interface AssistantAccumulator {
+  kind: 'text' | 'thinking';
+  turnId: string;
+  messageId: string;
+  text: string;
+}
+
+interface ObserverTargetGroup {
+  readonly target: RuntimeHostSessionObserverTarget;
+  readonly observerIds: Set<string>;
+  readonly destroyedListener: () => void;
+  seeded: boolean;
+}
+
+type TerminalTurnSnapshot = Extract<
+  TurnSnapshot,
+  { status: 'completed' } | { status: 'failed' } | { status: 'cancelled' }
+>;
+
+interface ObservedSessionState {
+  readonly sessionId: string;
+  readonly targets: Map<number, ObserverTargetGroup>;
+  readonly pendingFrames: SubscriptionFrame[];
+  readonly accumulators: Map<string, AssistantAccumulator>;
+  openTask: Promise<void>;
+  handle?: DesktopRuntimeHostSession;
+  transcript?: StoredMessage[];
+  transcriptConsumed: boolean;
+  snapshot?: SessionContinuitySnapshot;
+  ready: boolean;
+  closing: boolean;
+}
+
+interface ObserverRegistration {
+  readonly state: ObservedSessionState;
+  readonly group: ObserverTargetGroup;
+}
+
+/**
+ * Owns the Desktop-side lifetime of Host Session subscriptions.
+ *
+ * The initial transcript and the following frames come from one atomic Host
+ * subscription. The observer seeds the live projection from the active
+ * transcript, then applies offset-bearing deltas, so joining mid-Turn neither
+ * loses the already-generated prefix nor renders it twice.
+ */
+export class RuntimeHostSessionObserver {
+  readonly #states = new Map<string, ObservedSessionState>();
+  readonly #observers = new Map<string, ObserverRegistration>();
+  readonly #client: SessionObserverClient;
+  readonly #emitSessionsChanged: RuntimeHostSessionObserverDeps['emitSessionsChanged'];
+  readonly #now: () => number;
+  #closed = false;
+
+  constructor(deps: RuntimeHostSessionObserverDeps) {
+    this.#client = deps.client;
+    this.#emitSessionsChanged = deps.emitSessionsChanged;
+    this.#now = deps.now ?? Date.now;
+  }
+
+  async readMessages(sessionId: string): Promise<StoredMessage[]> {
+    this.#assertOpen();
+    const existing = this.#states.get(sessionId);
+    if (existing && !existing.transcriptConsumed) {
+      await existing.openTask;
+      existing.transcriptConsumed = true;
+      return cloneMessages(existing.transcript ?? []);
+    }
+    if (!existing) {
+      const state = this.#state(sessionId);
+      await state.openTask;
+      state.transcriptConsumed = true;
+      const transcript = cloneMessages(state.transcript ?? []);
+      void this.#closeIfIdle(state);
+      return transcript;
+    }
+    return this.#loadCurrentTranscript(sessionId);
+  }
+
+  async snapshot(sessionId: string): Promise<SessionContinuitySnapshot> {
+    this.#assertOpen();
+    const existing = this.#states.get(sessionId);
+    if (existing) {
+      await existing.openTask;
+      if (existing.snapshot) return structuredClone(existing.snapshot);
+    }
+    const handle = await this.#client.openSession(sessionId);
+    try {
+      return structuredClone(handle.snapshot);
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async observe(
+    sessionId: string,
+    observerId: string,
+    target: RuntimeHostSessionObserverTarget,
+  ): Promise<void> {
+    this.#assertOpen();
+    const previous = this.#observers.get(observerId);
+    if (previous) {
+      if (previous.state.sessionId !== sessionId || previous.group.target.id !== target.id) {
+        throw new Error('Runtime Host Session observer identity was reused');
+      }
+      return;
+    }
+    const state = this.#state(sessionId);
+    let group = state.targets.get(target.id);
+    if (!group) {
+      const destroyedListener = () => {
+        void this.#removeTarget(state, target.id);
+      };
+      group = {
+        target,
+        observerIds: new Set(),
+        destroyedListener,
+        seeded: false,
+      };
+      state.targets.set(target.id, group);
+      target.once('destroyed', destroyedListener);
+    }
+    group.observerIds.add(observerId);
+    this.#observers.set(observerId, { state, group });
+    try {
+      await state.openTask;
+      this.#seedTarget(state, group);
+    } catch (error) {
+      this.#detachObserver(observerId);
+      throw error;
+    }
+  }
+
+  async unobserve(observerId: string): Promise<void> {
+    const state = this.#detachObserver(observerId);
+    if (state) await this.#closeIfIdle(state);
+  }
+
+  activeInteraction(
+    sessionId: string,
+    interactionId: string,
+  ): InteractionPendingSnapshot | undefined {
+    return this.#states
+      .get(sessionId)
+      ?.snapshot?.interactions.pending.find((item) => item.interactionId === interactionId);
+  }
+
+  listActiveInteractions(sessionId: string): ActiveInteractionRequestEvent[] | undefined {
+    const snapshot = this.#states.get(sessionId)?.snapshot;
+    return snapshot
+      ? snapshot.interactions.pending.flatMap((interaction) =>
+          projectInteractionRequest(interaction, this.#now()),
+        )
+      : undefined;
+  }
+
+  async readActiveInteractions(sessionId: string): Promise<ActiveInteractionRequestEvent[]> {
+    const cached = this.listActiveInteractions(sessionId);
+    if (cached) return cached;
+    const snapshot = await this.snapshot(sessionId);
+    return snapshot.interactions.pending.flatMap((interaction) =>
+      projectInteractionRequest(interaction, this.#now()),
+    );
+  }
+
+  async readInteraction(
+    sessionId: string,
+    interactionId: string,
+  ): Promise<InteractionPendingSnapshot | undefined> {
+    const cached = this.activeInteraction(sessionId, interactionId);
+    if (cached) return cached;
+    return (await this.snapshot(sessionId)).interactions.pending.find(
+      (interaction) => interaction.interactionId === interactionId,
+    );
+  }
+
+  publishInteractionAnswer(
+    answered: InteractionAnsweredSnapshot,
+    knownPending?: InteractionPendingSnapshot,
+  ): void {
+    const pending =
+      knownPending ?? this.activeInteraction(answered.sessionId, answered.interactionId);
+    if (!pending) return;
+    const base = {
+      id: `host-interaction:${answered.interactionId}:${answered.revision}`,
+      turnId: answered.turnId,
+      ts: this.#now(),
+      requestId: answered.interactionId,
+      toolUseId: interactionToolUseId(pending),
+    };
+    if (answered.outcome.kind === 'question_answer') {
+      this.#broadcast(answered.sessionId, { type: 'user_question_answer_ack', ...base });
+    } else if (answered.outcome.kind === 'sandbox_boundary_decision') {
+      this.#broadcast(answered.sessionId, {
+        type: 'sandbox_boundary_decision_ack',
+        ...base,
+        decision: answered.outcome.decision,
+        status: answered.outcome.status,
+        revision: answered.revision,
+      });
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    const states = [...this.#states.values()];
+    this.#states.clear();
+    this.#observers.clear();
+    await Promise.all(states.map((state) => this.#closeState(state)));
+  }
+
+  #state(sessionId: string): ObservedSessionState {
+    const existing = this.#states.get(sessionId);
+    if (existing) return existing;
+    const state: ObservedSessionState = {
+      sessionId,
+      targets: new Map(),
+      pendingFrames: [],
+      accumulators: new Map(),
+      openTask: Promise.resolve(),
+      transcriptConsumed: false,
+      ready: false,
+      closing: false,
+    };
+    state.openTask = this.#open(state);
+    this.#states.set(sessionId, state);
+    return state;
+  }
+
+  async #open(state: ObservedSessionState): Promise<void> {
+    try {
+      const handle = await this.#client.openSession(state.sessionId);
+      if (state.closing) {
+        await handle.close();
+        throw new Error('Runtime Host Session observer closed while opening');
+      }
+      state.handle = handle;
+      state.snapshot = structuredClone(handle.snapshot);
+      void this.#pump(state, handle);
+      state.transcript = await handle.transcript;
+      if (state.closing) throw new Error('Runtime Host Session observer closed while opening');
+      this.#seedAccumulators(state);
+      state.ready = true;
+      for (const group of state.targets.values()) this.#seedTarget(state, group);
+      for (const frame of state.pendingFrames.splice(0)) this.#acceptFrame(state, frame);
+    } catch (error) {
+      await this.#closeState(state);
+      throw error;
+    }
+  }
+
+  async #pump(state: ObservedSessionState, handle: DesktopRuntimeHostSession): Promise<void> {
+    try {
+      for await (const frame of handle.events) {
+        if (state.closing) return;
+        if (!state.ready) {
+          if (state.pendingFrames.length >= MAX_PENDING_FRAMES) {
+            throw new Error('Runtime Host Session initial transcript could not keep up with live events');
+          }
+          state.pendingFrames.push(frame);
+        } else {
+          this.#acceptFrame(state, frame);
+        }
+      }
+      if (!state.closing) {
+        this.#publishSubscriptionFailure(
+          state,
+          new Error('Runtime Host Session subscription ended unexpectedly'),
+        );
+      }
+    } catch (error) {
+      if (!state.closing) this.#publishSubscriptionFailure(state, error);
+    }
+  }
+
+  #seedAccumulators(state: ObservedSessionState): void {
+    const root = state.snapshot?.rootTurn;
+    if (!root || isTerminalTurn(root)) return;
+    for (const message of state.transcript ?? []) {
+      if (message.type !== 'assistant' || message.turnId !== root.turnId) continue;
+      if (message.thinking?.text) {
+        state.accumulators.set(accumulatorKey('thinking', message.id), {
+          kind: 'thinking',
+          turnId: root.turnId,
+          messageId: message.id,
+          text: message.thinking.text,
+        });
+      }
+      if (message.text) {
+        state.accumulators.set(accumulatorKey('text', message.id), {
+          kind: 'text',
+          turnId: root.turnId,
+          messageId: message.id,
+          text: message.text,
+        });
+      }
+    }
+  }
+
+  #seedTarget(state: ObservedSessionState, group: ObserverTargetGroup): void {
+    if (group.seeded) return;
+    group.seeded = true;
+    const snapshot = state.snapshot;
+    const root = snapshot?.rootTurn;
+    if (snapshot && root && !isTerminalTurn(root)) {
+      for (const accumulator of state.accumulators.values()) {
+        this.#send(state, group, {
+          type: accumulator.kind === 'text' ? 'text_delta' : 'thinking_delta',
+          id: `host-seed:${root.runId}:${accumulator.kind}:${accumulator.messageId}`,
+          turnId: accumulator.turnId,
+          messageId: accumulator.messageId,
+          ts: this.#now(),
+          text: accumulator.text,
+        });
+      }
+      for (const interaction of snapshot.interactions.pending) {
+        for (const event of projectInteractionRequest(interaction, this.#now())) {
+          this.#send(state, group, event);
+        }
+      }
+      for (const entry of rootQueueInFlight(snapshot.queue)) {
+        if (state.transcript?.some((message) => message.id === entry.messageId)) continue;
+        this.#send(state, group, {
+          type: 'steering_message',
+          id: `host-queue:${snapshot.queue.hostEpoch}:${snapshot.queue.queueRevision}:${entry.entryId}`,
+          turnId: root.turnId,
+          messageId: entry.messageId,
+          ts: this.#now(),
+          content: structuredClone(entry.content),
+        });
+      }
+      if (queueHasEntries(snapshot.queue)) {
+        this.#send(
+          state,
+          group,
+          projectQueueUpdate(snapshot.queue, root.turnId, this.#now()),
+        );
+      }
+    }
+  }
+
+  #acceptFrame(state: ObservedSessionState, frame: SubscriptionFrame): void {
+    if (frame.kind === 'subscription.session_delta') {
+      const delta = frame.delta;
+      const key = accumulatorKey(delta.kind, delta.messageId);
+      const current = state.accumulators.get(key);
+      const previousText = current?.text ?? '';
+      if (delta.startOffset > previousText.length) {
+        throw new Error('Runtime Host Session assistant delta has a gap');
+      }
+      const overlapLength = Math.min(previousText.length - delta.startOffset, delta.text.length);
+      if (
+        overlapLength > 0 &&
+        previousText.slice(delta.startOffset, delta.startOffset + overlapLength) !==
+          delta.text.slice(0, overlapLength)
+      ) {
+        throw new Error('Runtime Host Session assistant delta conflicts with the transcript');
+      }
+      const tail = delta.text.slice(overlapLength);
+      state.accumulators.set(key, {
+        kind: delta.kind,
+        turnId: delta.turnId,
+        messageId: delta.messageId,
+        text: previousText + tail,
+      });
+      if (tail.length > 0) {
+        this.#broadcast(state.sessionId, {
+          type: delta.kind === 'text' ? 'text_delta' : 'thinking_delta',
+          id: frameIdentity(frame),
+          turnId: delta.turnId,
+          messageId: delta.messageId,
+          ts: this.#now(),
+          text: tail,
+        });
+      }
+      return;
+    }
+    if (frame.kind === 'subscription.session_event') {
+      const event = projectToolEvent(frame);
+      if (event) {
+        this.#broadcast(state.sessionId, event);
+        if (event.type === 'tool_result') {
+          this.#emitSessionsChanged('message-appended', state.sessionId, {
+            turnId: event.turnId,
+          });
+        }
+      }
+      return;
+    }
+    if (frame.kind === 'subscription.session_projection') {
+      this.#acceptProjection(state, frame.snapshot);
+      return;
+    }
+    if (frame.kind === 'subscription.agent_graph_changed') {
+      this.#emitSessionsChanged('status-change', state.sessionId);
+      return;
+    }
+    if (frame.reason === 'session_removed') {
+      this.#emitSessionsChanged('deleted', state.sessionId);
+      void this.#closeState(state);
+    } else {
+      this.#publishSubscriptionFailure(
+        state,
+        new Error('Runtime Host Session subscription closed for a slow consumer'),
+      );
+    }
+  }
+
+  #acceptProjection(state: ObservedSessionState, snapshot: SessionContinuitySnapshot): void {
+    const previous = state.snapshot;
+    state.snapshot = structuredClone(snapshot);
+    for (const interaction of newlyPendingInteractions(previous, snapshot)) {
+      for (const event of projectInteractionRequest(interaction, this.#now())) {
+        this.#broadcast(state.sessionId, event);
+      }
+    }
+    const previousRoot = previous?.rootTurn;
+    const root = snapshot.rootTurn;
+    if (root && queueChanged(previous?.queue, snapshot.queue)) {
+      for (const entry of newlyInFlight(previous?.queue, snapshot.queue)) {
+        this.#broadcast(state.sessionId, {
+          type: 'steering_message',
+          id: `host-queue:${snapshot.queue.hostEpoch}:${snapshot.queue.queueRevision}:${entry.entryId}`,
+          turnId: root.turnId,
+          messageId: entry.messageId,
+          ts: this.#now(),
+          content: structuredClone(entry.content),
+        });
+      }
+      this.#broadcast(
+        state.sessionId,
+        projectQueueUpdate(snapshot.queue, root.turnId, this.#now()),
+      );
+    }
+    if (root && (!previousRoot || previousRoot.runId !== root.runId)) {
+      state.accumulators.clear();
+      this.#emitSessionsChanged('status-change', state.sessionId, { turnId: root.turnId });
+    }
+    if (root && isTerminalTurn(root) && !sameTerminalTurn(previousRoot, root)) {
+      this.#publishTerminal(state, root);
+      this.#emitSessionsChanged('turn-status-change', state.sessionId, { turnId: root.turnId });
+      this.#emitSessionsChanged('message-appended', state.sessionId, { turnId: root.turnId });
+    } else {
+      this.#emitSessionsChanged('status-change', state.sessionId, root ? { turnId: root.turnId } : undefined);
+    }
+  }
+
+  #publishTerminal(state: ObservedSessionState, root: TerminalTurnSnapshot): void {
+    for (const accumulator of state.accumulators.values()) {
+      this.#broadcast(state.sessionId, {
+        type: accumulator.kind === 'text' ? 'text_complete' : 'thinking_complete',
+        id: `${root.terminalEventId}:${accumulator.kind}:${accumulator.messageId}`,
+        turnId: root.turnId,
+        messageId: accumulator.messageId,
+        ts: this.#now(),
+        text: accumulator.text,
+      });
+    }
+    if (root.status === 'completed') {
+      this.#broadcast(state.sessionId, {
+        type: 'complete',
+        id: root.terminalEventId,
+        turnId: root.turnId,
+        ts: this.#now(),
+        stopReason: 'end_turn',
+      });
+    } else if (root.status === 'failed') {
+      this.#broadcast(state.sessionId, {
+        type: 'error',
+        id: root.terminalEventId,
+        turnId: root.turnId,
+        ts: this.#now(),
+        recoverable: false,
+        reason: root.failureClass,
+        message: `Turn failed: ${root.failureClass}`,
+      });
+    } else {
+      this.#broadcast(state.sessionId, {
+        type: 'abort',
+        id: root.terminalEventId,
+        turnId: root.turnId,
+        ts: this.#now(),
+        reason: abortReason(root.abortSource),
+      });
+    }
+  }
+
+  #broadcast(sessionId: string, event: SessionEvent): void {
+    const state = this.#states.get(sessionId);
+    if (!state) return;
+    for (const group of state.targets.values()) {
+      this.#send(state, group, event);
+    }
+  }
+
+  #send(
+    state: ObservedSessionState,
+    group: ObserverTargetGroup,
+    event: SessionEvent,
+  ): void {
+    try {
+      group.target.send(sessionEventChannel(state.sessionId), event);
+    } catch {
+      this.#detachTarget(state, group);
+      void this.#closeIfIdle(state);
+    }
+  }
+
+  #publishSubscriptionFailure(state: ObservedSessionState, error: unknown): void {
+    const root = state.snapshot?.rootTurn;
+    if (root && !isTerminalTurn(root)) {
+      this.#broadcast(state.sessionId, {
+        type: 'error',
+        id: `host-subscription-error:${root.runId}`,
+        turnId: root.turnId,
+        ts: this.#now(),
+        recoverable: true,
+        reason: 'subscription_closed',
+        message: error instanceof Error ? error.message : 'Runtime Host Session subscription closed',
+      });
+    }
+    this.#emitSessionsChanged('status-change', state.sessionId, root ? { turnId: root.turnId } : undefined);
+    void this.#closeState(state);
+  }
+
+  async #loadCurrentTranscript(sessionId: string): Promise<StoredMessage[]> {
+    const handle = await this.#client.openSession(sessionId);
+    void drainFrames(handle.events).catch(() => undefined);
+    try {
+      return cloneMessages(await handle.transcript);
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async #closeIfIdle(state: ObservedSessionState): Promise<void> {
+    if (state.targets.size > 0) return;
+    await Promise.resolve();
+    if (state.targets.size === 0) await this.#closeState(state);
+  }
+
+  async #closeState(state: ObservedSessionState): Promise<void> {
+    if (!state.closing) {
+      state.closing = true;
+      if (this.#states.get(state.sessionId) === state) this.#states.delete(state.sessionId);
+      for (const group of state.targets.values()) this.#detachTarget(state, group);
+    }
+    const handle = state.handle;
+    state.handle = undefined;
+    await handle?.close().catch(() => undefined);
+  }
+
+  async #removeTarget(state: ObservedSessionState, targetId: number): Promise<void> {
+    const group = state.targets.get(targetId);
+    if (!group) return;
+    this.#detachTarget(state, group);
+    await this.#closeIfIdle(state);
+  }
+
+  #detachTarget(state: ObservedSessionState, group: ObserverTargetGroup): void {
+    if (state.targets.get(group.target.id) !== group) return;
+    state.targets.delete(group.target.id);
+    group.target.off('destroyed', group.destroyedListener);
+    for (const observerId of group.observerIds) this.#observers.delete(observerId);
+    group.observerIds.clear();
+  }
+
+  #detachObserver(observerId: string): ObservedSessionState | undefined {
+    const registration = this.#observers.get(observerId);
+    if (!registration) return undefined;
+    this.#observers.delete(observerId);
+    registration.group.observerIds.delete(observerId);
+    if (registration.group.observerIds.size === 0) {
+      this.#detachTarget(registration.state, registration.group);
+    }
+    return registration.state;
+  }
+
+  #assertOpen(): void {
+    if (this.#closed) throw new Error('Runtime Host Session observer is closed');
+  }
+}
+
+function projectInteractionRequest(
+  interaction: InteractionPendingSnapshot,
+  now: number,
+): ActiveInteractionRequestEvent[] {
+  const base = {
+    id: `host-interaction:${interaction.interactionId}:${interaction.revision}`,
+    turnId: interaction.turnId,
+    ts: now,
+    requestId: interaction.interactionId,
+    toolUseId: interactionToolUseId(interaction),
+  };
+  if (interaction.request.kind === 'question') {
+    return [
+      {
+        type: 'user_question_request',
+        ...base,
+        questions: interaction.request.questions.map((question) => ({
+          question: question.question,
+          options: question.options.map((option) => ({ ...option })),
+        })),
+      },
+    ];
+  }
+  if (interaction.request.kind === 'sandbox_boundary') {
+    return [
+      {
+        type: 'sandbox_boundary_request',
+        ...base,
+        justification: interaction.request.justification,
+        expansion: interaction.request.expansion,
+      },
+    ];
+  }
+  return [];
+}
+
+function projectToolEvent(
+  frame: Extract<SubscriptionFrame, { kind: 'subscription.session_event' }>,
+): SessionEvent | undefined {
+  const event = frame.event;
+  const base = { id: event.id, turnId: event.turnId, ts: event.ts, toolUseId: event.toolUseId };
+  if (event.type === 'tool_start') {
+    return {
+      type: event.type,
+      ...base,
+      toolName: event.toolName,
+      args: undefined,
+      ...(event.operationId ? { operationId: event.operationId } : {}),
+      ...(event.activityKind ? { activityKind: event.activityKind } : {}),
+      ...(event.displayName ? { displayName: event.displayName } : {}),
+      ...(event.stepId ? { stepId: event.stepId } : {}),
+    };
+  }
+  if (event.type === 'tool_output_delta') {
+    return {
+      type: event.type,
+      ...base,
+      sessionId: frame.sessionId,
+      toolCallId: event.toolUseId,
+      seq: event.seq,
+      stream: event.stream,
+      chunk: event.chunk,
+      redacted: event.redacted,
+      createdAt: event.createdAt,
+    };
+  }
+  if (event.type === 'tool_progress') return { type: event.type, ...base, chunk: event.chunk };
+  return {
+    type: 'tool_result',
+    ...base,
+    isError: event.status === 'errored',
+    content: { kind: 'text', text: '' },
+    ...(event.operationId ? { operationId: event.operationId } : {}),
+    ...(event.durationMs === undefined ? {} : { durationMs: event.durationMs }),
+  };
+}
+
+function newlyPendingInteractions(
+  previous: SessionContinuitySnapshot | undefined,
+  next: SessionContinuitySnapshot,
+): InteractionPendingSnapshot[] {
+  const previousIds = new Set(
+    previous?.interactions.pending.map((interaction) => interaction.interactionId) ?? [],
+  );
+  return next.interactions.pending.filter(
+    (interaction) => !previousIds.has(interaction.interactionId),
+  );
+}
+
+function queueChanged(
+  previous: SessionMessageQueueProjection | undefined,
+  next: SessionMessageQueueProjection,
+): boolean {
+  return (
+    previous === undefined ||
+    previous.hostEpoch !== next.hostEpoch ||
+    previous.queueRevision !== next.queueRevision
+  );
+}
+
+function newlyInFlight(
+  previous: SessionMessageQueueProjection | undefined,
+  next: SessionMessageQueueProjection,
+): Extract<SteeringMessageSnapshot, { state: 'in_flight' }>[] {
+  const previousInFlight = new Set(
+    previous?.steering
+      .filter((entry) => entry.state === 'in_flight')
+      .map((entry) => entry.entryId) ?? [],
+  );
+  return rootQueueInFlight(next).filter((entry) => !previousInFlight.has(entry.entryId));
+}
+
+function rootQueueInFlight(
+  queue: SessionMessageQueueProjection | undefined,
+): Extract<SteeringMessageSnapshot, { state: 'in_flight' }>[] {
+  return (queue?.steering ?? []).filter(
+    (entry): entry is Extract<SteeringMessageSnapshot, { state: 'in_flight' }> =>
+      entry.state === 'in_flight',
+  );
+}
+
+function queueHasEntries(queue: SessionMessageQueueProjection | undefined): boolean {
+  return (queue?.steering.length ?? 0) > 0 || (queue?.followup.length ?? 0) > 0;
+}
+
+function projectQueueUpdate(
+  queue: SessionMessageQueueProjection,
+  turnId: string,
+  now: number,
+): Extract<SessionEvent, { type: 'queue_update' }> {
+  return {
+    type: 'queue_update',
+    id: `host-queue:${queue.hostEpoch}:${queue.queueRevision}`,
+    turnId,
+    ts: now,
+    steering: queue.steering.map((entry) => entry.content.text),
+    followup: queue.followup.map((entry) => entry.content.text),
+  };
+}
+
+function interactionToolUseId(interaction: InteractionPendingSnapshot): string {
+  return interaction.request.kind === 'sandbox_boundary'
+    ? interaction.interactionId
+    : interaction.request.toolUseId;
+}
+
+function accumulatorKey(kind: 'text' | 'thinking', messageId: string): string {
+  return `${kind}\0${messageId}`;
+}
+
+function frameIdentity(frame: SubscriptionFrame): string {
+  return `host-frame:${frame.hostEpoch}:${frame.subscriptionId}:${frame.sequence}`;
+}
+
+function sessionEventChannel(sessionId: string): string {
+  return `sessions:event:${sessionId}`;
+}
+
+function isTerminalTurn(
+  turn: TurnSnapshot,
+): turn is TerminalTurnSnapshot {
+  return turn.status === 'completed' || turn.status === 'failed' || turn.status === 'cancelled';
+}
+
+function sameTerminalTurn(previous: TurnSnapshot | null | undefined, next: TurnSnapshot): boolean {
+  return (
+    previous !== null &&
+    previous !== undefined &&
+    isTerminalTurn(previous) &&
+    isTerminalTurn(next) &&
+    previous.runId === next.runId &&
+    previous.terminalEventId === next.terminalEventId
+  );
+}
+
+function abortReason(source: string): Extract<SessionEvent, { type: 'abort' }>['reason'] {
+  if (source.includes('timeout')) return 'timeout';
+  if (source.includes('crash') || source.includes('restart')) return 'crash';
+  if (source.includes('redirect')) return 'redirect';
+  return 'user_stop';
+}
+
+function cloneMessages(messages: readonly StoredMessage[]): StoredMessage[] {
+  return messages.map((message) => structuredClone(message));
+}
+
+async function drainFrames(frames: AsyncIterable<SubscriptionFrame>): Promise<void> {
+  for await (const _frame of frames) {
+    // A one-shot transcript read still owns a live Host subscription until it
+    // closes. Drain bounded frames so transcript pagination cannot be evicted
+    // as a slow consumer.
+  }
+}

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -318,6 +318,11 @@ export function registerSessionsIpc(
     }
     return messages;
   });
+  // The Runtime Host candidate uses these channels to bind renderer listeners
+  // to one atomic transcript/live subscription. Embedded execution already
+  // owns its stream lifetime, so its implementation is intentionally a no-op.
+  ipcMain.handle('sessions:observe', () => undefined);
+  ipcMain.handle('sessions:unobserve', () => undefined);
   ipcMain.handle('sessions:listTurns', (_event, sessionId: string) => runtime.listTurns(sessionId));
   // Goal kill-switch surface: the renderer reads the active goal to badge a
   // session running an autonomous loop, and clears it to stop the loop. `get`

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -7,7 +7,7 @@ import type {
   BotOnboardingSnapshot,
   BotOnboardingStartInput,
   HealthSnapshot,
-  ExecutionBoundary,
+  ExecutionBoundaryReadModel,
   LlmConnection,
   ModelDiscoveryResult,
   ModelInfo,
@@ -261,7 +261,7 @@ export interface MakaBridge {
     stop(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
     steer(sessionId: string, text: string): Promise<QueueEnqueueOutcome>;
     readMessages(sessionId: string): Promise<StoredMessage[]>;
-    readExecutionBoundary(sessionId: string): Promise<ExecutionBoundary>;
+    readExecutionBoundary(sessionId: string): Promise<ExecutionBoundaryReadModel>;
     listActiveInteractions(sessionId: string): Promise<ActiveInteractionRequestEvent[]>;
     listTurns(sessionId: string): Promise<TurnRecord[]>;
     compact(sessionId: string): Promise<void>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -20,7 +20,7 @@ import type {
   BotOnboardingSnapshot,
   BotOnboardingStartInput,
   HealthSnapshot,
-  ExecutionBoundary,
+  ExecutionBoundaryReadModel,
   LlmConnection,
   ModelDiscoveryResult,
   ModelInfo,
@@ -243,7 +243,7 @@ const makaBridge = {
     readMessages(sessionId: string): Promise<StoredMessage[]> {
       return ipcRenderer.invoke('sessions:readMessages', sessionId);
     },
-    readExecutionBoundary(sessionId: string): Promise<ExecutionBoundary> {
+    readExecutionBoundary(sessionId: string): Promise<ExecutionBoundaryReadModel> {
       return ipcRenderer.invoke('sessions:readExecutionBoundary', sessionId);
     },
     listActiveInteractions(sessionId: string): Promise<ActiveInteractionRequestEvent[]> {
@@ -285,7 +285,12 @@ const makaBridge = {
       const channel = `sessions:event:${sessionId}`;
       const listener = (_event: Electron.IpcRendererEvent, payload: SessionEvent) => handler(payload);
       ipcRenderer.on(channel, listener);
-      return () => ipcRenderer.off(channel, listener);
+      const observerId = crypto.randomUUID();
+      void ipcRenderer.invoke('sessions:observe', sessionId, observerId).catch(() => undefined);
+      return () => {
+        ipcRenderer.off(channel, listener);
+        void ipcRenderer.invoke('sessions:unobserve', observerId).catch(() => undefined);
+      };
     },
     subscribeChanges(handler: (event: SessionChangedEvent) => void): () => void {
       const listener = (_event: Electron.IpcRendererEvent, payload: SessionChangedEvent) => handler(payload);

--- a/apps/desktop/src/renderer/desktop-execution-boundary-surface.ts
+++ b/apps/desktop/src/renderer/desktop-execution-boundary-surface.ts
@@ -1,4 +1,4 @@
-import type { ExecutionBoundary, PermissionMode } from '@maka/core';
+import type { ExecutionBoundaryReadModel, PermissionMode } from '@maka/core';
 import { executionBoundaryDisplayMode } from '@maka/core';
 
 export interface DesktopExecutionBoundarySurface {
@@ -8,7 +8,7 @@ export interface DesktopExecutionBoundarySurface {
 
 export function deriveDesktopExecutionBoundarySurface(
   activeSessionId: string | undefined,
-  boundary: ExecutionBoundary | undefined,
+  boundary: ExecutionBoundaryReadModel | undefined,
   fallbackMode: PermissionMode,
 ): DesktopExecutionBoundarySurface {
   if (!activeSessionId) {

--- a/apps/desktop/src/renderer/use-active-execution-boundary.ts
+++ b/apps/desktop/src/renderer/use-active-execution-boundary.ts
@@ -1,4 +1,4 @@
-import type { ExecutionBoundary } from '@maka/core';
+import type { ExecutionBoundaryReadModel } from '@maka/core';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * not answered yet, and the surface has no honest state to show (#1629).
  */
 export type ExecutionBoundaryReadResult =
-  | { outcome: 'read'; boundary: ExecutionBoundary }
+  | { outcome: 'read'; boundary: ExecutionBoundaryReadModel }
   | { outcome: 'unreadable' }
   | { outcome: 'cancelled' };
 
@@ -34,7 +34,7 @@ export const EXECUTION_BOUNDARY_READ_RETRY_DELAYS_MS: readonly number[] = [150, 
  * the retry policy is the fix for #1629, so it has to be assertable directly.
  */
 export async function readExecutionBoundaryWithRetry(input: {
-  read(): Promise<ExecutionBoundary>;
+  read(): Promise<ExecutionBoundaryReadModel>;
   wait(delayMs: number): Promise<void>;
   cancelled(): boolean;
   retryDelaysMs?: readonly number[];
@@ -67,7 +67,7 @@ export async function readExecutionBoundaryWithRetry(input: {
  */
 export interface ActiveExecutionBoundarySnapshot {
   sessionId: string;
-  boundary: ExecutionBoundary | undefined;
+  boundary: ExecutionBoundaryReadModel | undefined;
 }
 
 /**
@@ -78,7 +78,7 @@ export interface ActiveExecutionBoundarySnapshot {
 export function activeExecutionBoundaryOf(
   snapshot: ActiveExecutionBoundarySnapshot | undefined,
   activeSessionId: string | undefined,
-): ExecutionBoundary | undefined {
+): ExecutionBoundaryReadModel | undefined {
   if (!activeSessionId || snapshot?.sessionId !== activeSessionId) return undefined;
   return snapshot.boundary;
 }
@@ -121,7 +121,7 @@ export interface ActiveExecutionBoundaryReadCommit {
  */
 export function startActiveExecutionBoundaryRead(input: {
   sessionId: string;
-  read(sessionId: string): Promise<ExecutionBoundary>;
+  read(sessionId: string): Promise<ExecutionBoundaryReadModel>;
   commit: ActiveExecutionBoundaryReadCommit;
   retryDelaysMs?: readonly number[];
 }): () => void {
@@ -190,7 +190,7 @@ export function useActiveExecutionBoundary(
   /** Re-read when the session's stored permission mode changes under us. */
   permissionMode: string | undefined,
 ): {
-  boundary: ExecutionBoundary | undefined;
+  boundary: ExecutionBoundaryReadModel | undefined;
   /** The read for this session ran out of attempts; the boundary is unknown. */
   unreadable: boolean;
   /** A read for this session is in flight. */

--- a/packages/core/src/__tests__/sandbox-boundary.test.ts
+++ b/packages/core/src/__tests__/sandbox-boundary.test.ts
@@ -36,6 +36,12 @@ describe('executionBoundaryDisplayMode', () => {
       }),
     ).toBe('ask');
     expect(executionBoundaryDisplayMode({ kind: 'bypass', revision: 1 })).toBe('bypass');
+    expect(
+      executionBoundaryDisplayMode({ kind: 'managed', access: 'read_only', revision: 2 }),
+    ).toBe('explore');
+    expect(executionBoundaryDisplayMode({ kind: 'managed', access: 'writable', revision: 2 })).toBe(
+      'ask',
+    );
   });
 
   test('an approved expansion that grants a write stops reading as read-only', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -675,6 +675,8 @@ export {
 // sandbox-boundary.ts
 export type {
   ExecutionBoundary,
+  ExecutionBoundaryReadModel,
+  ExecutionBoundarySummary,
   CreateSandboxBoundaryRequest,
   LegacyPermissionMode,
   SandboxBoundaryAccess,

--- a/packages/core/src/sandbox-boundary.ts
+++ b/packages/core/src/sandbox-boundary.ts
@@ -148,6 +148,27 @@ export type ExecutionBoundary =
       readonly revision: number;
     };
 
+/**
+ * Bounded Client read model for presenting an execution boundary without
+ * exposing the potentially large Host-owned permission profile.
+ */
+export type ExecutionBoundarySummary =
+  | {
+      readonly kind: 'managed';
+      readonly access: 'read_only' | 'writable';
+      readonly revision: number;
+    }
+  | {
+      readonly kind: 'bypass';
+      readonly revision: number;
+    }
+  | {
+      readonly kind: 'external';
+      readonly revision: number;
+    };
+
+export type ExecutionBoundaryReadModel = ExecutionBoundary | ExecutionBoundarySummary;
+
 export type LegacyPermissionMode = 'ask' | 'execute' | 'explore' | 'bypass';
 
 /**
@@ -170,11 +191,15 @@ export type LegacyPermissionMode = 'ask' | 'execute' | 'explore' | 'bypass';
  * them — it never claims a specific boundary.
  */
 export function executionBoundaryDisplayMode(
-  boundary: ExecutionBoundary,
+  boundary: ExecutionBoundaryReadModel,
 ): PermissionMode | undefined {
   if (boundary.kind === 'external') return undefined;
   if (boundary.kind === 'bypass') return 'bypass';
-  return isReadOnlyPermissionProfile(boundary.profile) ? 'explore' : 'ask';
+  const readOnly =
+    'profile' in boundary
+      ? isReadOnlyPermissionProfile(boundary.profile)
+      : boundary.access === 'read_only';
+  return readOnly ? 'explore' : 'ask';
 }
 
 export function createGenesisExecutionBoundary(mode: LegacyPermissionMode): ExecutionBoundary {

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -13,6 +13,7 @@ import { readHostRegistration } from '../control/registration.js';
 import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.js';
 import {
   decodeHostFrame,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   type HostFrame,
   type ResponseFrame,
@@ -697,7 +698,7 @@ async function openAcceptedTransport(
     surface: 'tui',
     protocolMin: CURRENT_PROTOCOL.min,
     protocolMax: CURRENT_PROTOCOL.max,
-    compatibilityEpoch: 1,
+    compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
   });
   const handshake = decodeHostFrame(await transport.read(1_000));
   assert.ok('kind' in handshake);

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -98,6 +98,7 @@ const allowedExternalImports = {
     '@maka/core/plan',
     '@maka/core/permission',
     '@maka/core/runtime-policy',
+    '@maka/core/sandbox-boundary',
     '@maka/core/session',
     '@maka/core/shell-run-result',
     '@maka/core/task-ledger',

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
@@ -60,6 +60,7 @@ import {
 } from '../../client/index.js';
 import {
   decodeHostFrame,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   TASK_LEDGER_PAGE_MAX_ITEMS,
   type ConnectionCatalogQueryResult,
@@ -1097,7 +1098,7 @@ export async function sendStartWithoutReadingResponse(
     surface: 'desktop',
     protocolMin: CURRENT_PROTOCOL.min,
     protocolMax: CURRENT_PROTOCOL.max,
-    compatibilityEpoch: 1,
+    compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
   });
   const handshake = decodeHostFrame(await transport.read(2_000));
   assert.ok('kind' in handshake);

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -30,6 +30,7 @@ import {
 import { readHostRegistration } from '../control/registration.js';
 import {
   decodeHostFrame,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_MAX_FRAME_BYTES,
   RUNTIME_HOST_PROTOCOL_VERSION,
   RuntimeHostProtocolError,
@@ -169,7 +170,7 @@ describe('non-serving Runtime Host kernel', () => {
           surface: 'inspect',
           protocolMin: CURRENT_PROTOCOL.min,
           protocolMax: CURRENT_PROTOCOL.max,
-          compatibilityEpoch: 1,
+          compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
         });
         const handshake = decodeHostFrame(await transport.read(1_000));
         assert.ok('kind' in handshake && handshake.kind === 'accepted');
@@ -406,7 +407,7 @@ describe('non-serving Runtime Host kernel', () => {
         hostEpoch: candidate.host.hostEpoch,
         protocolMin: CURRENT_PROTOCOL.min,
         protocolMax: CURRENT_PROTOCOL.max,
-        compatibilityEpoch: 1,
+        compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
         state: 'ready',
         replacement: 'blocked_by_residency',
       });
@@ -931,7 +932,7 @@ describe('non-serving Runtime Host kernel', () => {
         surface: 'tui',
         protocolMin: CURRENT_PROTOCOL.min,
         protocolMax: CURRENT_PROTOCOL.max,
-        compatibilityEpoch: 1,
+        compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
       });
       const response = decodeHostFrame(await transport.read(2_000));
       assert.deepEqual(response, { kind: 'draining', hostEpoch: candidate.host.hostEpoch });
@@ -993,7 +994,7 @@ describe('non-serving Runtime Host kernel', () => {
           surface: 'tui',
           protocolMin: CURRENT_PROTOCOL.min,
           protocolMax: CURRENT_PROTOCOL.max,
-          compatibilityEpoch: 1,
+          compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
         });
         const handshake = decodeHostFrame(await transport.read(2_000));
         assert.ok('kind' in handshake && handshake.kind === 'accepted');
@@ -1045,7 +1046,7 @@ describe('non-serving Runtime Host kernel', () => {
           surface: 'tui',
           protocolMin: CURRENT_PROTOCOL.min,
           protocolMax: CURRENT_PROTOCOL.max,
-          compatibilityEpoch: 1,
+          compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
         });
         const handshake = decodeHostFrame(await transport.read(2_000));
         assert.ok('kind' in handshake);
@@ -1175,7 +1176,7 @@ describe('non-serving Runtime Host kernel', () => {
           surface: 'tui',
           protocolMin: CURRENT_PROTOCOL.min,
           protocolMax: CURRENT_PROTOCOL.max,
-          compatibilityEpoch: 1,
+          compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
         });
         const handshake = decodeHostFrame(await transport.read(2_000));
         assert.ok('kind' in handshake);
@@ -1218,7 +1219,7 @@ describe('non-serving Runtime Host kernel', () => {
             surface: 'inspect',
             protocolMin: CURRENT_PROTOCOL.min,
             protocolMax: CURRENT_PROTOCOL.max,
-            compatibilityEpoch: 1,
+            compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
           });
           assert.deepEqual(decodeHostFrame(await rejectedHandshakeTransport.read(1_000)), {
             kind: 'draining',
@@ -2012,7 +2013,7 @@ async function openNonReadingStatusSocket(path: string): Promise<Socket> {
         surface: 'tui',
         protocolMin: CURRENT_PROTOCOL.min,
         protocolMax: CURRENT_PROTOCOL.max,
-        compatibilityEpoch: 1,
+        compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
       })}\n`,
     );
   });

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -102,6 +102,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'session.configuration.update',
       'session.create',
       'session.cwd.relocate',
+      'session.execution_boundary.query',
       'session.lifecycle.set',
       'session.metadata.update',
       'session.read_marker.set',

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 import {
   createDefaultRuntimePolicy,
+  createGenesisExecutionBoundary,
   DEEP_RESEARCH_SESSION_LABEL,
   DEEP_RESEARCH_SESSION_NAME,
   type SessionHeader,
@@ -37,6 +38,24 @@ const context: ConnectionContext = {
   principal: 'local_os_user',
   acquireResidency: () => ({ release: () => undefined }),
 };
+
+test('projects only bounded execution boundary presentation facts', async () => {
+  const fixture = createFixture({
+    stores: {
+      readExecutionBoundary: async () => createGenesisExecutionBoundary('explore'),
+    },
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.execution_boundary.query'](
+    { sessionId: fixture.sessionId },
+    context,
+  );
+
+  assert.deepEqual(outcome, {
+    ok: true,
+    result: { kind: 'managed', access: 'read_only', revision: 0 },
+  });
+});
 
 test('metadata replacement preserves execution-semantic labels and ignores injected ones', async () => {
   const fixture = createFixture({
@@ -525,6 +544,7 @@ function createFixture(
     markSessionReadThroughMessage: async () => headerSnapshot(header, revision),
     probeStableSessionCreate: async () => ({ kind: 'absent' }),
     readCatalogRecord: async () => catalogRecord(header, revision),
+    readExecutionBoundary: async () => createGenesisExecutionBoundary('ask'),
     readHeaderRecordSnapshot: async () => headerSnapshot(header, revision),
     updateHeaderVersioned: async (_sessionId, patch, expectedRevision) => {
       if (expectedRevision !== revision) {

--- a/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
@@ -23,6 +23,7 @@ describe('Session catalog protocol', () => {
             'session.configuration.update',
             'session.cwd.relocate',
             'session.read_marker.set',
+            'session.execution_boundary.query',
           ] as const
         ).map((operation) => [
           operation,
@@ -39,7 +40,56 @@ describe('Session catalog protocol', () => {
         'session.configuration.update': { mode: 'command', availability: 'ready' },
         'session.cwd.relocate': { mode: 'command', availability: 'ready' },
         'session.read_marker.set': { mode: 'command', availability: 'ready' },
+        'session.execution_boundary.query': { mode: 'query', availability: 'ready' },
       },
+    );
+  });
+
+  test('decodes only bounded execution boundary summaries', () => {
+    assert.deepEqual(
+      decodeClientFrame({
+        requestId: 'request-1',
+        operation: 'session.execution_boundary.query',
+        input: { sessionId: 'session-1' },
+      }),
+      {
+        requestId: 'request-1',
+        operation: 'session.execution_boundary.query',
+        input: { sessionId: 'session-1' },
+      },
+    );
+    assert.deepEqual(
+      decodeHostFrame({
+        requestId: 'request-1',
+        operation: 'session.execution_boundary.query',
+        ok: true,
+        result: { kind: 'managed', access: 'read_only', revision: 3 },
+      }),
+      {
+        requestId: 'request-1',
+        operation: 'session.execution_boundary.query',
+        ok: true,
+        result: { kind: 'managed', access: 'read_only', revision: 3 },
+      },
+    );
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'request-1',
+          operation: 'session.execution_boundary.query',
+          ok: true,
+          result: { kind: 'managed', access: 'read_only', revision: 3, profile: {} },
+        }),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          requestId: 'request-1',
+          operation: 'session.execution_boundary.query',
+          input: { sessionId: 'session-1', includeProfile: true },
+        }),
+      isProtocolError,
     );
   });
 

--- a/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../client/index.js';
 import {
   decodeHostFrame,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   type SessionCatalogItem,
   type SessionCatalogProjection,
@@ -1057,7 +1058,7 @@ async function sendCreateWithoutReadingResponse(
     surface: 'desktop',
     protocolMin: CURRENT_PROTOCOL.min,
     protocolMax: CURRENT_PROTOCOL.max,
-    compatibilityEpoch: 1,
+    compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
   });
   const handshake = decodeHostFrame(await transport.read(2_000));
   assert.ok('kind' in handshake);

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -20,6 +20,7 @@ import { removeHostRegistration, writeHostRegistration } from '../control/regist
 import {
   decodeClientFrame,
   encodeProtocolFrame,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
   SESSION_CONTINUITY_SCHEMA_VERSION,
@@ -456,7 +457,7 @@ async function withProtocolPeer(
       endpoint: endpoint.path,
       protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
       protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
-      compatibilityEpoch: 1,
+      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
       state: 'ready',
       pid: process.pid,
       createdAt: new Date().toISOString(),
@@ -493,7 +494,7 @@ async function acceptConnectionAndReadOpen(
     hostEpoch,
     connectionId: 'connection-1',
     selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
-    compatibilityEpoch: 1,
+    compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
     state: 'ready',
   });
   const request = decodeClientFrame(await transport.read(1_000));

--- a/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
@@ -14,6 +14,7 @@ import { prepareRuntimeHostEndpoint } from '../control/endpoint.js';
 import { removeHostRegistration, writeHostRegistration } from '../control/registration.js';
 import {
   decodeClientFrame,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
   RuntimeHostProtocolError,
@@ -280,7 +281,7 @@ async function withProtocolPeer(
       endpoint: endpoint.path,
       protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
       protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
-      compatibilityEpoch: 1,
+      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
       state: 'ready',
       pid: process.pid,
       createdAt: new Date().toISOString(),
@@ -317,7 +318,7 @@ async function acceptConnectionAndReadRequest(
     hostEpoch,
     connectionId: 'usage-pricing-correlation',
     selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
-    compatibilityEpoch: 1,
+    compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
     state: 'ready',
   });
   const request = decodeClientFrame(await transport.read(REQUEST_TIMEOUT_MS));

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -45,7 +45,7 @@ export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // The wire version remains v0 before the first release. This independent epoch
 // lets a new Client retire a stale same-version Host whose closed schema is no
 // longer safe to use.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 1 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 2 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such

--- a/packages/runtime-host/src/protocol/session-catalog.ts
+++ b/packages/runtime-host/src/protocol/session-catalog.ts
@@ -10,6 +10,8 @@ import {
   type SessionSubagentProjection,
 } from '@maka/core/session';
 import { isThinkingLevel, type ThinkingLevel } from '@maka/core/model-thinking';
+import type { ExecutionBoundarySummary } from '@maka/core/sandbox-boundary';
+export type { ExecutionBoundarySummary } from '@maka/core/sandbox-boundary';
 import {
   assertAllowedKeys,
   requireCount,
@@ -53,6 +55,7 @@ const CONFIGURATION_UPDATE_ERRORS = [
   'operation_conflict',
 ] as const;
 const READ_MARKER_ERRORS = [...METADATA_UPDATE_ERRORS, 'operation_conflict'] as const;
+const EXECUTION_BOUNDARY_QUERY_ERRORS = [...QUERY_ERRORS, 'not_found'] as const;
 
 const PROJECTION_REQUIRED_FIELDS = [
   'id',
@@ -169,6 +172,10 @@ export interface SessionCwdRelocateInput {
 export interface SessionReadMarkerSetInput {
   readonly sessionId: string;
   readonly readThroughMessageId: string;
+}
+
+export interface SessionExecutionBoundaryQueryInput {
+  readonly sessionId: string;
 }
 
 export interface SessionCatalogProjection {
@@ -314,7 +321,52 @@ export const SESSION_CATALOG_OPERATION_SPECS = {
     decodeOutput: decodeSessionCatalogItem,
     assertOutputForInput: (input, output) => assertSessionIdentity(input.sessionId, output),
   }),
+  'session.execution_boundary.query': defineOperation<
+    SessionExecutionBoundaryQueryInput,
+    ExecutionBoundarySummary,
+    (typeof EXECUTION_BOUNDARY_QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: EXECUTION_BOUNDARY_QUERY_ERRORS,
+    decodeInput: decodeSessionExecutionBoundaryQueryInput,
+    decodeOutput: decodeExecutionBoundarySummary,
+  }),
 } as const;
+
+export function decodeSessionExecutionBoundaryQueryInput(
+  value: unknown,
+): SessionExecutionBoundaryQueryInput {
+  const input = requireExactRecord(value, 'Session execution boundary query input', ['sessionId']);
+  return { sessionId: requireEntityId(input.sessionId, 'sessionId') };
+}
+
+export function decodeExecutionBoundarySummary(value: unknown): ExecutionBoundarySummary {
+  const boundary = requireRecord(value, 'Session execution boundary summary');
+  if (boundary.kind === 'managed') {
+    const exact = requireExactRecord(boundary, 'Managed execution boundary summary', [
+      'kind',
+      'access',
+      'revision',
+    ]);
+    if (exact.access !== 'read_only' && exact.access !== 'writable') {
+      throw invalidProtocolFrame('Invalid managed execution boundary access');
+    }
+    return {
+      kind: 'managed',
+      access: exact.access,
+      revision: requireCount(exact.revision, 'Execution boundary revision'),
+    };
+  }
+  if (boundary.kind === 'bypass' || boundary.kind === 'external') {
+    const exact = requireExactRecord(boundary, 'Execution boundary summary', ['kind', 'revision']);
+    return {
+      kind: boundary.kind,
+      revision: requireCount(exact.revision, 'Execution boundary revision'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid execution boundary summary');
+}
 
 export function decodeSessionCatalogQueryInput(value: unknown): SessionCatalogQueryInput {
   const input = requireRecord(value, 'Session catalog query input');

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -3,6 +3,11 @@ import { realpath, stat } from 'node:fs/promises';
 import { isAbsolute, resolve } from 'node:path';
 import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
 import { thinkingVariantsForModel } from '@maka/core/model-thinking';
+import {
+  executionBoundaryDisplayMode,
+  type ExecutionBoundary,
+  type ExecutionBoundarySummary,
+} from '@maka/core/sandbox-boundary';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
 import { DEFAULT_SESSION_NAME, normalizeUserSessionName } from '@maka/core/session-name';
 import {
@@ -44,6 +49,7 @@ import {
   type SessionConfigurationUpdateInput,
   type SessionCreateInput,
   type SessionCwdRelocateInput,
+  type SessionExecutionBoundaryQueryInput,
   type SessionMetadataUpdateInput,
   type SessionModelTarget,
   type SessionReadMarkerSetInput,
@@ -60,6 +66,7 @@ type SessionCatalogStores = Pick<
   | 'markSessionReadThroughMessage'
   | 'probeStableSessionCreate'
   | 'readCatalogRecord'
+  | 'readExecutionBoundary'
   | 'readHeaderRecordSnapshot'
   | 'updateHeaderVersioned'
 >;
@@ -115,6 +122,7 @@ export class HostSessionCatalogCoordinator {
     'session.configuration.update': (input) => this.#updateConfiguration(input),
     'session.cwd.relocate': (input) => this.#relocateCwd(input),
     'session.read_marker.set': (input) => this.#setReadMarker(input),
+    'session.execution_boundary.query': (input) => this.#queryExecutionBoundary(input),
   };
 
   readonly #stores: SessionCatalogStores;
@@ -174,6 +182,25 @@ export class HostSessionCatalogCoordinator {
       );
     } catch {
       return queryFailure('persistence_failed', 'Session catalog is unavailable');
+    }
+  }
+
+  async #queryExecutionBoundary(
+    input: SessionExecutionBoundaryQueryInput,
+  ): Promise<OperationOutcome<'session.execution_boundary.query'>> {
+    try {
+      return {
+        ok: true,
+        result: projectExecutionBoundary(await this.#stores.readExecutionBoundary(input.sessionId)),
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return executionBoundaryFailure('not_found', 'Session does not exist');
+      }
+      return executionBoundaryFailure(
+        'persistence_failed',
+        'Session execution boundary is unavailable',
+      );
     }
   }
 
@@ -1011,6 +1038,22 @@ function queryFailure(
   message: string,
 ): Extract<OperationOutcome<'session.catalog.query'>, { readonly ok: false }> {
   return { ok: false, error: { code, message } };
+}
+
+function executionBoundaryFailure(
+  code: OperationError<'session.execution_boundary.query'>['code'],
+  message: string,
+): Extract<OperationOutcome<'session.execution_boundary.query'>, { readonly ok: false }> {
+  return { ok: false, error: { code, message } };
+}
+
+function projectExecutionBoundary(boundary: ExecutionBoundary): ExecutionBoundarySummary {
+  if (boundary.kind !== 'managed') return { kind: boundary.kind, revision: boundary.revision };
+  return {
+    kind: 'managed',
+    access: executionBoundaryDisplayMode(boundary) === 'explore' ? 'read_only' : 'writable',
+    revision: boundary.revision,
+  };
 }
 
 function metadataFailure(


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Add an isolated Runtime Host-backed Desktop Session and Turn IPC candidate while production continues to use the embedded Runtime until M5.
- Preserve the existing renderer contract across canonical transcript loading, mid-Turn attach, live assistant and tool events, Interactions, queue and steering, interruption, context actions, branching, and revision.
- Route selected attachments through Host-owned Session Artifacts and expose a bounded execution-boundary read model without transferring the permission profile to the Client.
- Keep native voice and Skill invocation explicitly unavailable on the candidate path until their Desktop Runtime-domain adapters land; the current production path is unchanged.
- Advance the same-`v0` compatibility epoch so a Client cannot reuse a stale Host that lacks the new closed operation schema.

## Testing

- `npm --workspace @maka/core test` (776 passed)
- `npm --workspace @maka/runtime-host test` (664 passed)
- `npm --workspace @maka/desktop test` (1647 passed)
- `npm run typecheck`
- `npm run lint -- --diagnostic-level=error`
- Real UDS coverage for the Desktop Session facade, attachment ingest, canonical transcript/live continuity, Interaction, queue, and Turn control

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 新增隔离的 Runtime Host-backed Desktop Session 与 Turn IPC candidate；在 M5 之前，production 仍继续使用 embedded Runtime。
- 在 canonical transcript 加载、Turn 中途接入、assistant/tool live event、Interaction、queue/steering、中断、context action、branch 与 revision 流程中保留现有 renderer contract。
- 将用户选择的附件写入 Host-owned Session Artifact，并提供有界的 execution-boundary read model，不把完整 permission profile 转交给 Client。
- 在对应的 Desktop Runtime-domain adapter 完成前，candidate path 会明确拒绝 native voice 与 Skill invocation；现有 production path 不受影响。
- 推进同一 `v0` 下的 compatibility epoch，避免 Client 复用缺少新 closed operation schema 的旧 Host。

## 测试

- `npm --workspace @maka/core test`（776 项通过）
- `npm --workspace @maka/runtime-host test`（664 项通过）
- `npm --workspace @maka/desktop test`（1647 项通过）
- `npm run typecheck`
- `npm run lint -- --diagnostic-level=error`
- 通过真实 UDS 覆盖 Desktop Session facade、附件 ingest、canonical transcript/live continuity、Interaction、queue 与 Turn control

</details>
