### PR TITLE
fix(desktop): release settled bot typing listeners

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-incoming-typing.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-typing.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { getEventListeners } from 'node:events';
+import { test } from 'node:test';
+import type { BotIncomingMessage, BotRegistry, SessionManager } from '@maka/runtime';
+import type { SessionEvent } from '@maka/core';
+import { createBotIncomingMainService } from '../bot-incoming-main.js';
+
+async function waitFor(predicate: () => boolean, message: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  assert.fail(message);
+}
+
+test('the bot typing loop owns only its active abort listener', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+
+  const NativeAbortController = globalThis.AbortController;
+  let typingSignal: AbortSignal | undefined;
+  t.mock.method(globalThis, 'AbortController', class extends NativeAbortController {
+    constructor() {
+      super();
+      typingSignal = this.signal;
+    }
+  });
+
+  let releaseTurn: () => void = () => {};
+  const turnReleased = new Promise<void>((resolve) => {
+    releaseTurn = resolve;
+  });
+  let typingAttempts = 0;
+  const replies: string[] = [];
+  const runtime = {
+    async createSession() {
+      return { id: 'bot-session' };
+    },
+    sendMessage() {
+      return (async function* (): AsyncIterable<SessionEvent> {})();
+    },
+  } as unknown as SessionManager;
+  const service = createBotIncomingMainService({
+    runtime,
+    createSession: (input) => runtime.createSession({ ...input, cwd: input.cwd ?? '/repo' }),
+    botRegistry: {
+      async sendMessage(_platform: string, _chatId: string, text: string) {
+        replies.push(text);
+        return 'bot-message';
+      },
+      async sendTypingIndicator() {
+        typingAttempts += 1;
+        throw new Error('typing unavailable');
+      },
+    } as unknown as BotRegistry,
+    getDefaultConnectionSlug: async () => 'provider',
+    getReadyConnection: async () => ({ connection: { slug: 'provider' }, model: 'model' }),
+    readSessionHeader: async () => ({ permissionMode: 'explore', isArchived: false, status: 'active' }),
+    ensureSessionCanSend: async () => {},
+    emitSessionsChanged() {},
+    runAgentTurn: async ({ turnId, onEvent }) => {
+      await turnReleased;
+      onEvent({
+        type: 'text_complete',
+        id: 'text',
+        turnId,
+        ts: Date.now(),
+        messageId: 'assistant',
+        text: 'Bot reply',
+      });
+      return { outcome: { kind: 'completed', turnId } } as never;
+    },
+  });
+
+  await service.handleBotIncomingMessage({
+    platform: 'telegram',
+    userId: 'user',
+    userName: 'User',
+    chatId: 'chat',
+    isGroup: false,
+    text: 'hello',
+    sourceMessageId: 'source',
+    receivedAt: Date.now(),
+  } as BotIncomingMessage);
+
+  await waitFor(() => typingAttempts === 1 && typingSignal !== undefined, 'first typing attempt did not run');
+  assert.equal(getEventListeners(typingSignal!, 'abort').length, 1);
+
+  for (let expectedAttempts = 2; expectedAttempts <= 4; expectedAttempts += 1) {
+    t.mock.timers.tick(3_999);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(typingAttempts, expectedAttempts - 1);
+
+    t.mock.timers.tick(1);
+    await waitFor(() => typingAttempts === expectedAttempts, `typing attempt ${expectedAttempts} did not run`);
+    assert.equal(
+      getEventListeners(typingSignal!, 'abort').length,
+      1,
+      'a completed delay must leave only the next active delay listener',
+    );
+  }
+
+  releaseTurn();
+  await waitFor(() => replies.length === 1, 'bot reply was not delivered');
+  assert.equal(typingSignal!.aborted, true);
+  assert.equal(getEventListeners(typingSignal!, 'abort').length, 0);
+
+  t.mock.timers.tick(4_000);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(typingAttempts, 4, 'abort must not allow a later typing attempt');
+  assert.deepEqual(replies, ['Bot reply']);
+});

--- a/apps/desktop/src/main/bot-incoming-main.ts
+++ b/apps/desktop/src/main/bot-incoming-main.ts
@@ -337,11 +337,15 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
         await deps.botRegistry.sendTypingIndicator(message.platform, message.chatId).catch(() => false);
         while (!typingAbort.signal.aborted) {
           await new Promise<void>((resolve) => {
-            const timer = setTimeout(resolve, 4000);
-            typingAbort.signal.addEventListener('abort', () => {
+            const onAbort = (): void => {
               clearTimeout(timer);
               resolve();
-            }, { once: true });
+            };
+            const timer = setTimeout(() => {
+              typingAbort.signal.removeEventListener('abort', onAbort);
+              resolve();
+            }, 4000);
+            typingAbort.signal.addEventListener('abort', onAbort, { once: true });
           });
           if (typingAbort.signal.aborted) break;
           await deps.botRegistry.sendTypingIndicator(message.platform, message.chatId).catch(() => false);


### PR DESCRIPTION
## Summary

The bot typing loop kept every completed delay's `{ once: true }` abort listener until the whole reply ended. This removes the listener when the four-second timer wins, while keeping the existing abort path, immediate first attempt, cadence, and best-effort delivery behavior unchanged.

The regression test drives the real service with a fake clock. It covers the 3,999/4,000 ms boundary, steady-state listener ownership, prompt abort cleanup, no late typing attempt, and reply delivery while the typing endpoint is failing.

Closes #2127

## Verification

- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run build:workspace-deps`
- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run build:main`
- `mise exec node@24.18.1 -- node --test apps/desktop/dist/main/__tests__/bot-incoming-typing.test.js`
- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run test:dist` (`1632` passed)
