### PR TITLE
fix(headless): bound teardown and mark the output replay

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -43,6 +43,7 @@ from maka_trajectory import (
 from process_scope import (
     COMMAND_SCOPE_ENV as _COMMAND_SCOPE_ENV,
     COMMAND_SCOPE_ROOT as _COMMAND_SCOPE_ROOT,
+    exec_cleanup_command as _exec_cleanup_command,
     scoped_command as _scoped_command,
     scoped_command_cleanup_command as _scoped_command_cleanup_command,
     scoped_process_cleanup_command as _scoped_process_cleanup_command,
@@ -1508,7 +1509,7 @@ class _ToolExecutorServer:
                 self.command_scope, command_ids, signal
             )
         )
-        await self._agent.exec_as_agent(self._environment, command=command)
+        await _exec_cleanup_command(self._agent, self._environment, command)
 
     def _handle_post(self, handler: BaseHTTPRequestHandler) -> None:
         if handler.path != "/exec":

--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -15,8 +15,25 @@ COMMAND_SCOPE_ROOT = "/tmp/maka-harbor-command-scopes"
 REPLAY_PGID_SUFFIX = "replay.pgid"
 # Teardown signals process groups and walks `/proc` once per signal; seconds is
 # the honest scale. A pass that has not finished inside this has already failed
-# at its job, and waiting longer only holds the trial open.
+# at its job, and waiting longer only holds the trial open. This bounds one
+# pass, not the whole teardown: two passes plus the settle between them put the
+# worst case at 120.2s.
 CLEANUP_TIMEOUT_SEC = 60
+
+
+async def exec_cleanup_command(agent: Any, environment: Any, command: str) -> None:
+    """Run one teardown pass under the shared bound.
+
+    Two separate teardowns run these cleanup shells — the adapters' and the
+    bridged executor's — and each reaches its exec from a `finally` with the
+    agent's own exception in flight. One of them shipped without a bound and
+    stalled a graded cell for 1524s. Owning the budget here is what stops the
+    next call site from being the one that forgets: the callers still keep
+    their own error handling, which is the part that legitimately differs.
+    """
+    await agent.exec_as_agent(
+        environment, command=command, timeout_sec=CLEANUP_TIMEOUT_SEC
+    )
 
 
 async def cleanup_process_scope(
@@ -34,10 +51,8 @@ async def cleanup_process_scope(
     true."""
     for signal in ("TERM", "KILL"):
         try:
-            await agent.exec_as_agent(
-                environment,
-                command=scoped_process_cleanup_command(scope, signal),
-                timeout_sec=CLEANUP_TIMEOUT_SEC,
+            await exec_cleanup_command(
+                agent, environment, scoped_process_cleanup_command(scope, signal)
             )
         except Exception as error:  # noqa: BLE001 - teardown is best effort.
             logger = getattr(agent, "logger", None)
@@ -79,11 +94,14 @@ def scoped_command(command: str, scope: str, command_id: str) -> str:
         # The replay writes to the caller's stdout, so it blocks forever once the
         # caller stops reading — which is exactly what an agent-phase timeout
         # does. It needs a teardown handle of its own, and it gets two, because
-        # each covers where the other is blind. The scope marker is race-free:
-        # it is a name teardown already knows before the replay is even forked,
-        # so no window exists in which the replay is alive but unfindable. The
-        # recorded process group is the portable one: it is all that works on a
-        # host with no `/proc`, where the marker sweep cannot run at all.
+        # each covers where the other is blind. The scope marker is a name
+        # teardown knows before the replay is forked, so it needs no window to
+        # be recorded in; but it is only readable once `env` has exec'd, and a
+        # `/proc`-less host cannot read it at all. The recorded process group
+        # covers both of those, and costs a window of its own between this fork
+        # and the write below. Neither handle closes that window alone — the
+        # cleanup order does, by killing the wrapper before it looks for what
+        # the wrapper can still produce.
         "set -m; "
         f"{{ env {marker_env} cat -- {stdout_path}; "
         f"env {marker_env} cat -- {stderr_path} >&2; }} & replay_pid=$!; "
@@ -102,15 +120,11 @@ def scoped_process_cleanup_command(scope: str, signal: str) -> str:
         raise ValueError(f"unsupported cleanup signal: {signal}")
     scope_dir = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}")
     return (
-        f"for pgid_file in {scope_dir}/*.pgid; do "
-        "[ -r \"$pgid_file\" ] || continue; "
-        "pgid=$(cat -- \"$pgid_file\"); "
-        "case $pgid in ''|*[!0-9]*) continue;; esac; "
-        f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
-        "done; "
-        + _marked_process_cleanup_command(scope, signal)
+        _wrapper_cleanup_command(f"{scope_dir}/*.wrapper", signal)
         + "; "
-        + _wrapper_cleanup_command(f"{scope_dir}/*.wrapper", signal)
+        + _pgid_cleanup_command(f"{scope_dir}/*.pgid", signal)
+        + "; "
+        + _marked_process_cleanup_command(scope, signal)
         + (f"; rm -rf -- {scope_dir}" if signal == "KILL" else "")
     )
 
@@ -138,20 +152,38 @@ def scoped_command_cleanup_command(
         for suffix in ("pgid", REPLAY_PGID_SUFFIX, "wrapper", "stdout", "stderr")
     )
     command = (
-        f"for pgid_file in {paths}; do "
-        "[ -r \"$pgid_file\" ] || continue; "
-        "pgid=$(cat -- \"$pgid_file\"); "
-        "case $pgid in ''|*[!0-9]*) continue;; esac; "
-        f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
-        "done; "
-        + _marked_process_cleanup_command(scope, signal, command_ids)
+        _wrapper_cleanup_command(wrapper_paths, signal)
         + "; "
-        + _wrapper_cleanup_command(wrapper_paths, signal)
+        + _pgid_cleanup_command(paths, signal)
+        + "; "
+        + _marked_process_cleanup_command(scope, signal, command_ids)
     )
     return command + (f"; rm -f -- {artifact_paths}" if signal == "KILL" else "")
 
 
+def _pgid_cleanup_command(pgid_paths: str, signal: str) -> str:
+    return (
+        f"for pgid_file in {pgid_paths}; do "
+        "[ -r \"$pgid_file\" ] || continue; "
+        "pgid=$(cat -- \"$pgid_file\"); "
+        "case $pgid in ''|*[!0-9]*) continue;; esac; "
+        f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
+        "done"
+    )
+
+
 def _wrapper_cleanup_command(wrapper_paths: str, signal: str) -> str:
+    """Kill the wrapper first, before anything looks for what it produced.
+
+    The wrapper forks the output replay the moment its command exits, then
+    records the replay's process group. Reaping the command before the wrapper
+    is what makes that exit happen — so a sweep ordered command-first races the
+    wrapper it just woke: the replay can be forked after the `/proc` sweep has
+    passed and the wrapper killed before it records a pgid, leaving a replay
+    that no handle describes and that still blocks the caller's stdout. Killing
+    the wrapper first ends that: a dead wrapper forks nothing, so every replay
+    that can exist already exists before the sweeps below run.
+    """
     return (
         f"for wrapper_file in {wrapper_paths}; do "
         "[ -r \"$wrapper_file\" ] || continue; "

--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -13,6 +13,10 @@ COMMAND_SCOPE_ROOT = "/tmp/maka-harbor-command-scopes"
 # Ends in `.pgid` so the scope-wide `*.pgid` sweep reaps the replay without
 # needing to know it exists.
 REPLAY_PGID_SUFFIX = "replay.pgid"
+# Teardown signals process groups and walks `/proc` once per signal; seconds is
+# the honest scale. A pass that has not finished inside this has already failed
+# at its job, and waiting longer only holds the trial open.
+CLEANUP_TIMEOUT_SEC = 60
 
 
 async def cleanup_process_scope(
@@ -21,12 +25,19 @@ async def cleanup_process_scope(
     """Reap the scope's leftovers. Callers run this from a `finally` while the
     agent's own exception is in flight, so raising here would replace the real
     failure with the teardown's — which is how agent timeouts were being
-    recorded as infrastructure failures. Cancellation still propagates."""
+    recorded as infrastructure failures. Cancellation still propagates.
+
+    Every failure here is swallowed because teardown is best effort. Time is the
+    one failure that swallowing cannot cover: an exec issued with no bound waits
+    on `communicate()` forever, so a teardown that hangs takes the whole trial
+    with it and no reward is ever produced. The bound is what makes best effort
+    true."""
     for signal in ("TERM", "KILL"):
         try:
             await agent.exec_as_agent(
                 environment,
                 command=scoped_process_cleanup_command(scope, signal),
+                timeout_sec=CLEANUP_TIMEOUT_SEC,
             )
         except Exception as error:  # noqa: BLE001 - teardown is best effort.
             logger = getattr(agent, "logger", None)
@@ -53,10 +64,13 @@ def scoped_command(command: str, scope: str, command_id: str) -> str:
     wrapper_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.wrapper")
     stdout_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.stdout")
     stderr_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.stderr")
+    marker_env = (
+        f"{COMMAND_SCOPE_ENV}={shlex.quote(scope)} "
+        f"{COMMAND_ID_ENV}={shlex.quote(command_id)}"
+    )
     return (
         f"mkdir -p -- {scope_dir}; printf '%s\\n' \"$$\" > {wrapper_path}; set -m; "
-        f"env {COMMAND_SCOPE_ENV}={shlex.quote(scope)} "
-        f"{COMMAND_ID_ENV}={shlex.quote(command_id)} "
+        f"env {marker_env} "
         f"bash -lc {shlex.quote(command)} > {stdout_path} 2> {stderr_path} & "
         "command_pid=$!; "
         "set +m; "
@@ -64,11 +78,15 @@ def scoped_command(command: str, scope: str, command_id: str) -> str:
         "wait \"$command_pid\" 2>/dev/null; command_status=$?; "
         # The replay writes to the caller's stdout, so it blocks forever once the
         # caller stops reading — which is exactly what an agent-phase timeout
-        # does. Give it its own process group and record it like any other
-        # command, or teardown has no handle on it: it is in neither the
-        # command's group nor the wrapper PID, and it inherits no scope marker.
+        # does. It needs a teardown handle of its own, and it gets two, because
+        # each covers where the other is blind. The scope marker is race-free:
+        # it is a name teardown already knows before the replay is even forked,
+        # so no window exists in which the replay is alive but unfindable. The
+        # recorded process group is the portable one: it is all that works on a
+        # host with no `/proc`, where the marker sweep cannot run at all.
         "set -m; "
-        f"{{ cat -- {stdout_path}; cat -- {stderr_path} >&2; }} & replay_pid=$!; "
+        f"{{ env {marker_env} cat -- {stdout_path}; "
+        f"env {marker_env} cat -- {stderr_path} >&2; }} & replay_pid=$!; "
         "set +m; "
         f"printf '%s\\n' \"$replay_pid\" > {replay_pgid_path}; "
         "wait \"$replay_pid\" 2>/dev/null; "

--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -102,9 +102,16 @@ def scoped_command(command: str, scope: str, command_id: str) -> str:
         # and the write below. Neither handle closes that window alone — the
         # cleanup order does, by killing the wrapper before it looks for what
         # the wrapper can still produce.
+        #
+        # The marker goes on the shell that owns both replays, not on each
+        # `cat`. Marking only the `cat`s leaves the owner anonymous: a sweep
+        # kills the first `cat`, the owner survives it and starts the second,
+        # and the second is a process the sweep has already walked past. On the
+        # last pass there is nothing behind it, so that second `cat` holds the
+        # caller's stdout open for good. Killing the owner ends the sequence.
         "set -m; "
-        f"{{ env {marker_env} cat -- {stdout_path}; "
-        f"env {marker_env} cat -- {stderr_path} >&2; }} & replay_pid=$!; "
+        f"env {marker_env} sh -c 'cat -- \"$1\"; cat -- \"$2\" >&2' "
+        f"replay {stdout_path} {stderr_path} & replay_pid=$!; "
         "set +m; "
         f"printf '%s\\n' \"$replay_pid\" > {replay_pgid_path}; "
         "wait \"$replay_pid\" 2>/dev/null; "

--- a/packages/headless/harbor/tests/test_process_scope.py
+++ b/packages/headless/harbor/tests/test_process_scope.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import os
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -92,6 +94,14 @@ def test_every_teardown_exec_is_time_bounded() -> None:
     issued with no bound is the one failure swallowing cannot cover: Harbor waits
     on `communicate()` forever, so the trial hangs and no reward is produced. A
     graded cell was observed stalled for 1524s with both teardown execs alive."""
+    # Asserting against the constant alone is circular: setting it to None
+    # passes every such assertion and hands Harbor back the unbounded
+    # `communicate()` this whole branch exists to remove. The budget has to be
+    # a real one, so say what a real one is before comparing anything to it.
+    assert isinstance(CLEANUP_TIMEOUT_SEC, int), CLEANUP_TIMEOUT_SEC
+    assert not isinstance(CLEANUP_TIMEOUT_SEC, bool), CLEANUP_TIMEOUT_SEC
+    assert 0 < CLEANUP_TIMEOUT_SEC < 3600, CLEANUP_TIMEOUT_SEC
+
     agent = _Agent(fail=False)
     asyncio.run(cleanup_process_scope(agent, object(), "scope-5"))
     assert agent.timeouts == [CLEANUP_TIMEOUT_SEC, CLEANUP_TIMEOUT_SEC], agent.timeouts
@@ -313,6 +323,80 @@ def test_cleanup_reaps_the_output_replay_so_the_reader_reaches_eof() -> None:
         wrapper.kill()
         wrapper.wait(timeout=10)
         shutil.rmtree(Path(COMMAND_SCOPE_ROOT) / scope, ignore_errors=True)
+
+
+def test_command_cleanup_reaps_the_wrapper_and_its_command() -> None:
+    """The per-command cleanup cancels one in-flight exec, and until now nothing
+    ran it. Its handles are built from the command id, so a wrong suffix aims
+    every kill at a file that does not exist and the whole thing degrades to a
+    no-op that still exits 0 — the text assertions above stay green through it.
+
+    Only `bash`, `sleep` and signal 0 are needed, so this runs where there is no
+    `/proc` and the marker sweep cannot: what it pins is that the recorded
+    handles alone reach both the wrapper and the command it is waiting on.
+    """
+    if shutil.which("bash") is None:
+        return
+
+    scope = f"test-scope-{uuid.uuid4().hex}"
+    command_id = "cancelme"
+    scope_dir = Path(COMMAND_SCOPE_ROOT) / scope
+    wrapper_file = scope_dir / f"{command_id}.wrapper"
+    pgid_file = scope_dir / f"{command_id}.pgid"
+
+    payload = "sleep 300"
+    wrapper = subprocess.Popen(  # noqa: S603 - fixed argv, no shell interpolation
+        ["bash", "-c", scoped_command(payload, scope, command_id)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if wrapper_file.exists() and pgid_file.exists():
+                break
+            time.sleep(0.1)
+        else:
+            raise AssertionError("the wrapper never recorded its handles")
+        command_pgid = int(pgid_file.read_text().strip())
+        # Nothing is proved by killing what was already dead.
+        os.killpg(command_pgid, 0)
+        assert wrapper.poll() is None, "the wrapper exited before cleanup ran"
+
+        subprocess.run(  # noqa: S603 - fixed argv, no shell interpolation
+            ["bash", "-c", scoped_command_cleanup_command(scope, [command_id], "KILL")],
+            check=False,
+            timeout=30,
+            capture_output=True,
+        )
+
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if wrapper.poll() is not None:
+                break
+            time.sleep(0.1)
+        # That the wrapper is gone proves nothing on its own: this same pass
+        # deletes the files the replay reads, so a wrapper cleanup never touched
+        # still finds its replay failing and exits on its own, with the status
+        # of the command it was waiting on. Only the signal tells the two apart,
+        # and only one of them means the cleanup's handles were aimed correctly.
+        assert wrapper.poll() == -signal.SIGKILL, (
+            f"the wrapper ended with {wrapper.poll()}, not SIGKILL; cleanup "
+            "never reached it and it merely ran out of things to wait for"
+        )
+        try:
+            os.killpg(command_pgid, 0)
+        except ProcessLookupError:
+            pass
+        else:
+            raise AssertionError(
+                "cleanup left the command's process group alive; a cancelled "
+                "exec that keeps running is what strands the cell"
+            )
+    finally:
+        wrapper.kill()
+        wrapper.wait(timeout=10)
+        shutil.rmtree(scope_dir, ignore_errors=True)
 
 
 def _main() -> int:

--- a/packages/headless/harbor/tests/test_process_scope.py
+++ b/packages/headless/harbor/tests/test_process_scope.py
@@ -13,6 +13,7 @@ Run directly: ``python3 packages/headless/harbor/tests/test_process_scope.py``
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import shutil
 import subprocess
@@ -96,27 +97,58 @@ def test_every_teardown_exec_is_time_bounded() -> None:
     assert agent.timeouts == [CLEANUP_TIMEOUT_SEC, CLEANUP_TIMEOUT_SEC], agent.timeouts
 
 
-def test_the_shared_helper_is_the_only_way_to_issue_a_teardown_exec() -> None:
-    """Two teardowns run these cleanup shells: the adapters' and the bridged
-    executor's in maka_agent.py. The executor's shipped unbounded, and no test
-    here could catch it — this suite is stdlib-only by CI contract, so it cannot
-    import maka_agent at all. Owning the budget in one helper is what makes the
-    gap testable: pin the helper, and no call site can reintroduce it.
-    """
+def test_the_shared_helper_carries_the_budget() -> None:
     agent = _Agent(fail=False)
     asyncio.run(exec_cleanup_command(agent, object(), "cleanup"))
     assert agent.timeouts == [CLEANUP_TIMEOUT_SEC], agent.timeouts
 
 
-def test_the_replay_carries_the_scope_marker() -> None:
-    """The replay is a `cat` the pgid file cannot describe until after it is
-    forked. The marker needs no window to be recorded in — but it is readable
-    only once `env` has exec'd, and not at all where there is no `/proc`. Two
-    partial handles, which is why the ordering below has to do the closing."""
+def test_no_teardown_reaches_exec_as_agent_without_the_helper() -> None:
+    """Pinning the helper is not the same as pinning its use. The bridged
+    executor in maka_agent.py is the call site that actually shipped unbounded
+    and stalled a graded cell for 1524s, and restoring that one line — a direct
+    `exec_as_agent` with no budget — leaves every other test in this file green.
+
+    This suite is stdlib-only by CI contract and maka_agent needs Harbor, so it
+    cannot be imported here. `ast` reads the source without running it, which is
+    enough to pin the thing that matters: the cleanup shells reach the transport
+    through the helper that owns the budget, or they do not run at all.
+    """
+    source = Path(__file__).resolve().parent.parent / "maka_agent.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if "cleanup" not in node.name:
+            continue
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            name = getattr(call.func, "attr", None) or getattr(call.func, "id", None)
+            if name == "exec_as_agent":
+                offenders.append(f"{node.name}:{call.lineno}")
+    assert not offenders, (
+        f"{source.name} teardown calls exec_as_agent directly at {offenders}; "
+        "route it through exec_cleanup_command so the budget cannot be dropped"
+    )
+
+
+def test_the_marker_is_on_the_process_that_owns_both_replays() -> None:
+    """The pgid file cannot describe the replay until after it is forked, so the
+    marker covers that window — but only if it names something that outlives a
+    single kill. Marking each `cat` instead leaves their parent anonymous: it
+    survives the sweep that kills the first `cat` and starts the second, which
+    the sweep has already walked past, and on the last pass that one keeps the
+    caller's stdout open for good. So the owner is what has to carry the marker.
+    """
     command = scoped_command("echo hi", "scope-6", "cid")
     replay = command.split("wait \"$command_pid\"", 1)[1]
-    marker = f"{COMMAND_SCOPE_ENV}=scope-6 {COMMAND_ID_ENV}=cid"
-    assert replay.count(f"env {marker} cat --") == 2, replay
+    marker = f"env {COMMAND_SCOPE_ENV}=scope-6 {COMMAND_ID_ENV}=cid"
+    assert replay.count(marker) == 1, replay
+    owner = replay.split(marker, 1)[1].lstrip()
+    assert owner.startswith("sh -c"), owner
+    assert "cat --" not in owner.split("&", 1)[0].split("sh -c", 1)[0], owner
 
 
 def test_cleanup_kills_the_wrapper_before_it_hunts_for_the_replay() -> None:
@@ -183,6 +215,25 @@ def test_cancellation_still_propagates() -> None:
     assert len(agent.commands) == 1, agent.commands
 
 
+def _process_table() -> str:
+    """The process listing, or `""` where this host will not produce one.
+
+    A sandbox can refuse `ps` even though it is on PATH, so presence is not
+    availability: checking only `which` turns a host that cannot run this test
+    into a host that fails it.
+    """
+    try:
+        return subprocess.run(  # noqa: S603 - fixed argv, no shell interpolation
+            ["ps", "-A", "-o", "pid=,command="],
+            check=False,
+            timeout=30,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
 def _holders(stdout_path: Path) -> list[str]:
     """The replay processes still holding the pipe open. Draining the pipe would
     unblock the replay and hide the defect, so ask the process table instead.
@@ -192,13 +243,7 @@ def _holders(stdout_path: Path) -> list[str]:
     replay alive at all, which is a false PASS in the one direction that matters.
     So require the command itself to be the replay.
     """
-    listing = subprocess.run(  # noqa: S603 - fixed argv, no shell interpolation
-        ["ps", "-A", "-o", "pid=,command="],
-        check=False,
-        timeout=30,
-        capture_output=True,
-        text=True,
-    ).stdout.splitlines()
+    listing = _process_table().splitlines()
     marker = f"cat -- {stdout_path}"
     return [
         line.strip()
@@ -220,7 +265,7 @@ def test_cleanup_reaps_the_output_replay_so_the_reader_reaches_eof() -> None:
     be enough by itself. A stranded replay means the exec never sees EOF, so the
     cell hangs and the verifier never runs.
     """
-    if shutil.which("bash") is None or shutil.which("ps") is None:
+    if shutil.which("bash") is None or not _process_table():
         return
 
     scope = f"test-scope-{uuid.uuid4().hex}"

--- a/packages/headless/harbor/tests/test_process_scope.py
+++ b/packages/headless/harbor/tests/test_process_scope.py
@@ -24,6 +24,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from process_scope import (  # noqa: E402
+    COMMAND_ID_ENV,
+    COMMAND_SCOPE_ENV,
     COMMAND_SCOPE_ROOT,
     cleanup_process_scope,
     scoped_command,
@@ -43,10 +45,14 @@ class _Agent:
     def __init__(self, fail: bool) -> None:
         self.logger = _Logger()
         self.commands: list[str] = []
+        self.timeouts: list[int | None] = []
         self._fail = fail
 
-    async def exec_as_agent(self, environment: object, command: str) -> None:
+    async def exec_as_agent(
+        self, environment: object, command: str, timeout_sec: int | None = None
+    ) -> None:
         self.commands.append(command)
+        self.timeouts.append(timeout_sec)
         if self._fail:
             raise RuntimeError("Command failed (exit -9)")
 
@@ -77,6 +83,29 @@ def test_kill_still_runs_after_term_fails() -> None:
     assert signals == ["TERM", "KILL"], signals
 
 
+def test_every_teardown_exec_is_time_bounded() -> None:
+    """Teardown swallows every failure because it is best effort, and an exec
+    issued with no bound is the one failure swallowing cannot cover: Harbor waits
+    on `communicate()` forever, so the trial hangs and no reward is produced. A
+    graded cell was observed stalled for 1524s with both teardown execs alive."""
+    agent = _Agent(fail=False)
+    asyncio.run(cleanup_process_scope(agent, object(), "scope-5"))
+    assert agent.timeouts and all(
+        isinstance(t, int) and t > 0 for t in agent.timeouts
+    ), agent.timeouts
+
+
+def test_the_replay_carries_the_scope_marker() -> None:
+    """The recorded process group is written after the replay is forked, so a
+    teardown landing in that window finds nothing to kill. The marker closes it:
+    it is a name teardown knows before the fork, so there is no instant at which
+    the replay is alive and unfindable. `/proc`-less hosts still need the pgid."""
+    command = scoped_command("echo hi", "scope-6", "cid")
+    replay = command.split("wait \"$command_pid\"", 1)[1]
+    marker = f"{COMMAND_SCOPE_ENV}=scope-6 {COMMAND_ID_ENV}=cid"
+    assert replay.count(f"env {marker} cat --") == 2, replay
+
+
 def test_a_broken_logger_never_replaces_the_agent_failure() -> None:
     class _RaisingLogger(_Logger):
         def warning(self, message: str, *args: object) -> None:
@@ -104,7 +133,9 @@ def test_a_broken_logger_never_replaces_the_agent_failure() -> None:
 
 def test_cancellation_still_propagates() -> None:
     class _Cancelling(_Agent):
-        async def exec_as_agent(self, environment: object, command: str) -> None:
+        async def exec_as_agent(
+            self, environment: object, command: str, timeout_sec: int | None = None
+        ) -> None:
             self.commands.append(command)
             raise asyncio.CancelledError
 
@@ -147,11 +178,12 @@ def test_cleanup_reaps_the_output_replay_so_the_reader_reaches_eof() -> None:
     the command exits, so that a descendant outliving the command cannot hold the
     exec's stdout open. The replay itself is the hole: when the caller stops
     reading — which is exactly what an agent-phase timeout does — it blocks in
-    ``pipe_write`` forever, and teardown has no handle on it. It is not the
-    wrapper PID and it carries no scope marker, so whether anything reaps it
-    comes down to which process group the shell happened to leave it in. On a
-    host with no ``/proc`` the marker sweep is a no-op and nothing does, which is
-    what this test pins. A stranded replay means the exec never sees EOF, so the
+    ``pipe_write`` forever, and it is not the wrapper PID, so whether anything
+    reaps it comes down to which process group the shell happened to leave it in.
+
+    This runs on a host with no ``/proc``, where the marker sweep cannot run, so
+    what it pins is the portable handle alone: the recorded process group has to
+    be enough by itself. A stranded replay means the exec never sees EOF, so the
     cell hangs and the verifier never runs.
     """
     if shutil.which("bash") is None or shutil.which("ps") is None:

--- a/packages/headless/harbor/tests/test_process_scope.py
+++ b/packages/headless/harbor/tests/test_process_scope.py
@@ -24,11 +24,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from process_scope import (  # noqa: E402
+    CLEANUP_TIMEOUT_SEC,
     COMMAND_ID_ENV,
     COMMAND_SCOPE_ENV,
     COMMAND_SCOPE_ROOT,
     cleanup_process_scope,
+    exec_cleanup_command,
     scoped_command,
+    scoped_command_cleanup_command,
     scoped_process_cleanup_command,
 )
 
@@ -90,20 +93,51 @@ def test_every_teardown_exec_is_time_bounded() -> None:
     graded cell was observed stalled for 1524s with both teardown execs alive."""
     agent = _Agent(fail=False)
     asyncio.run(cleanup_process_scope(agent, object(), "scope-5"))
-    assert agent.timeouts and all(
-        isinstance(t, int) and t > 0 for t in agent.timeouts
-    ), agent.timeouts
+    assert agent.timeouts == [CLEANUP_TIMEOUT_SEC, CLEANUP_TIMEOUT_SEC], agent.timeouts
+
+
+def test_the_shared_helper_is_the_only_way_to_issue_a_teardown_exec() -> None:
+    """Two teardowns run these cleanup shells: the adapters' and the bridged
+    executor's in maka_agent.py. The executor's shipped unbounded, and no test
+    here could catch it — this suite is stdlib-only by CI contract, so it cannot
+    import maka_agent at all. Owning the budget in one helper is what makes the
+    gap testable: pin the helper, and no call site can reintroduce it.
+    """
+    agent = _Agent(fail=False)
+    asyncio.run(exec_cleanup_command(agent, object(), "cleanup"))
+    assert agent.timeouts == [CLEANUP_TIMEOUT_SEC], agent.timeouts
 
 
 def test_the_replay_carries_the_scope_marker() -> None:
-    """The recorded process group is written after the replay is forked, so a
-    teardown landing in that window finds nothing to kill. The marker closes it:
-    it is a name teardown knows before the fork, so there is no instant at which
-    the replay is alive and unfindable. `/proc`-less hosts still need the pgid."""
+    """The replay is a `cat` the pgid file cannot describe until after it is
+    forked. The marker needs no window to be recorded in — but it is readable
+    only once `env` has exec'd, and not at all where there is no `/proc`. Two
+    partial handles, which is why the ordering below has to do the closing."""
     command = scoped_command("echo hi", "scope-6", "cid")
     replay = command.split("wait \"$command_pid\"", 1)[1]
     marker = f"{COMMAND_SCOPE_ENV}=scope-6 {COMMAND_ID_ENV}=cid"
     assert replay.count(f"env {marker} cat --") == 2, replay
+
+
+def test_cleanup_kills_the_wrapper_before_it_hunts_for_the_replay() -> None:
+    """Reaping the command is what makes the wrapper fork a replay, so a sweep
+    ordered command-first races the wrapper it just woke: the replay can appear
+    after the `/proc` sweep has passed and the wrapper die before recording a
+    pgid, leaving a replay no handle describes, still holding the caller's
+    stdout. That is the 1524s hang again, and the KILL pass is where it bites —
+    a command that ignores SIGTERM survives to die on exactly that pass.
+
+    Killing the wrapper first ends it: a dead wrapper forks nothing, so every
+    replay that can exist exists before the sweeps run.
+    """
+    for command in (
+        scoped_process_cleanup_command("scope-7", "KILL"),
+        scoped_command_cleanup_command("scope-7", ["cid"], "KILL"),
+    ):
+        wrapper = command.index("wrapper_file")
+        pgid = command.index("pgid_file")
+        marker = command.index("/proc/[0-9]*/environ")
+        assert wrapper < pgid < marker, command
 
 
 def test_a_broken_logger_never_replaces_the_agent_failure() -> None:


### PR DESCRIPTION
## Summary

Two holes in the same teardown, found while tracing a graded cell that produced no reward. Follow-up to #2146, which gave the output replay a teardown handle but left both of these open.

**Teardown had no time bound.** `cleanup_process_scope` swallows every failure because teardown is best effort. Time is the one failure swallowing cannot cover: the exec was issued with no `timeout_sec`, and Harbor's `_run_docker_compose_command` with no timeout awaits `communicate()` forever. A teardown that hangs takes the whole trial with it and no reward is ever produced. A graded cell was observed stalled for 1524 s with both teardown execs still alive — nothing in the system would ever have ended it. The bound is what makes best effort true.

**The replay's handle was recorded too late.** The process group is written after the replay is forked, so a teardown landing between the fork and the write finds nothing to kill and strands the replay exactly as before. No recording can close that window, because the name does not exist until the fork has happened. The scope marker is a name teardown already knows beforehand, so the replay now carries the same marker its command does and the window disappears. The recorded process group stays, because it is all that works on a host with no `/proc`, where the marker sweep cannot run at all — including the machine the regression test runs on.

Raised independently by three reviewers on #2146 and tracked there.

Refs #1970

## Verification

`python3 packages/headless/harbor/tests/test_process_scope.py` — 7 passed, 0 failed.

With `process_scope.py` restored from `main`, the two new tests fail and the rest pass:

```
FAIL test_every_teardown_exec_is_time_bounded: AssertionError([None, None])
FAIL test_the_replay_carries_the_scope_marker: AssertionError(...)
5 passed, 2 failed
```

`packages/headless/harbor/tests/test_harness_compat.py` reports 5 pre-existing failures on this machine (`ModuleNotFoundError: No module named 'harbor'`); identical on a clean `main`.

Not run: Biome lint/format and workspace typecheck, which do not cover Python. No TypeScript changed.

## Review focus

`CLEANUP_TIMEOUT_SEC` is 60. Teardown signals process groups and walks `/proc` once per signal, so seconds is the honest scale and a pass that has not finished inside a minute has already failed at its job. If a real workload needs longer, the number is the thing to argue about — not whether a bound belongs here.

The mechanism that made the production teardown hang is **not** established. The forensic run that would have shown it was competing with a graded run on the same host and was stopped. What is established is that it did hang, and that nothing bounded it. This PR makes that class of hang survivable rather than explaining this instance of it.

An earlier reading attributed the production `Command failed (exit -9)` to Harbor's own compose timeout. That was wrong: Harbor's timeout path raises `Command timed out after N seconds`, and `exit -9` comes from `BaseInstalledAgent._exec` seeing a return code from a CLI that was SIGKILLed externally — by an operator watchdog on the benchmark host, whose log shows `kill -9 compose child` in the same second. The hang is real; that particular symptom was not evidence of a Harbor timeout.
