### PR TITLE
fix(chat): centre the empty-chat hero in the reading column

### DIFF
--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -253,3 +253,22 @@ test('returning to the session after visiting skills re-settles the new transcri
   await settleGeometry(page, { pinned: true });
   expectHonestClimb(await climbToTop(page));
 });
+
+// The empty surface is back here as a live metric, unlike the flush contract
+// the header notes moved out to static CSS. What centres the hero is the
+// ABSENCE of Astryx's push-to-bottom spacer, and the rule that collapses it
+// keys on ChatMessageList's internal DOM — a CSS read can only prove the
+// selector is written, never that it still matches. Shipped uncollapsed, the
+// hero sat 172px below this centre.
+test('the empty-chat hero centres in the reading column', async ({ window: page }) => {
+  await expect(page.locator('.maka-hero-empty-chat')).toBeVisible();
+  const offset = await page.evaluate(() => {
+    const hero = document.querySelector('.maka-hero-empty-chat');
+    const column = hero?.closest('.maka-chat-message-list');
+    if (!hero || !column) throw new Error('Expected the empty-chat hero inside the message list');
+    const heroBox = hero.getBoundingClientRect();
+    const columnBox = column.getBoundingClientRect();
+    return Math.abs((heroBox.top + heroBox.bottom) / 2 - (columnBox.top + columnBox.bottom) / 2);
+  });
+  expect(offset).toBeLessThanOrEqual(1);
+});

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -23,6 +23,22 @@
   width: 100%;
 }
 
+/* Astryx's ChatMessageList renders a `flex: 1` spacer before its rows so a
+   short conversation sits on the composer instead of hanging from the top.
+   That spacer is unconditional, so on the empty surface it splits the column
+   with the empty-state holder — which is itself `flex: 1` and centres its
+   content — and the hero lands centred in the BOTTOM half: measured 172px
+   below the reading column's centre, plus the list's 16px gap.
+   Collapsing the spacer when the last row is an empty state hands the whole
+   column back to the holder, and its own centring is then true to the
+   surface. Keyed on the empty-state content rather than on "no messages"
+   because a single-message conversation must keep the push-to-bottom. */
+.maka-chat-message-list
+  > *:has(> :last-child > :is(.maka-hero, .astryx-empty-state))
+  > [aria-hidden]:empty {
+  display: none;
+}
+
 /* The conversation reading tier is Astryx's body role: 14px with the 20px
    4px-grid leading the type scale computes for it. The leading used to be a
    hand-rolled 1.6154em (21px) that matched neither Maka's --leading-* tiers

--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -98,6 +98,9 @@ const DYNAMIC_STYLE_HOOKS = new Set([
   'astryx-button',
   'astryx-badge',
   'astryx-resize-handle-pill',
+  // EmptyState's root (EmptyState.tsx themeProps). chat-message.css reads it to
+  // tell an empty chat surface from a conversation with rows in it.
+  'astryx-empty-state',
   // The column resize handle's hit area (Resizable/ResizeHandle themeProps).
   // shell-layout.css starts it below the chrome strip so its top 36px is not
   // swallowed by the window drag rect.


### PR DESCRIPTION
## Summary

The empty chat surface rendered its hero — the wordmark plus the time-of-day greeting — noticeably low, sitting against the composer rather than in the middle of the reading column.

The cause is in Astryx's `ChatMessageList`: it renders a `flex: 1` spacer ahead of its rows so a short conversation rests on the composer instead of hanging from the top. That spacer is unconditional, so on the empty surface it split the column with the empty-state holder — which is itself `flex: 1` and centres its content — and the hero ended up centred in the bottom half. Measured on `main`: hero centre 552px against a column centre of 380px, a 172px drop, plus the list's own 16px gap.

This collapses the spacer when the list's last row is an empty state, handing the whole column back to the holder so its centring is true to the surface. The rule is keyed on the empty-state content rather than on "no messages" because a one-message conversation must keep the push-to-bottom.

The accompanying check is a live metric rather than a static CSS read: the selector matches `ChatMessageList`'s internal DOM, so a CSS contract could only prove the rule is written, never that it still matches after an Astryx bump.

## Verification

- `apps/desktop` Playwright — full `e2e/scroll-geometry.spec.ts`, 6 passed, including the new `the empty-chat hero centres in the reading column`.
- The new test was confirmed to fail for the right reason: with the spacer left visible it reports the 172px offset and goes red.
- `npm run lint`, `npm run format:check`, `node scripts/check-dead-css.mjs --check` (the allowlist entry is for `astryx-empty-state`, which Astryx emits through `themeProps` at runtime and never appears as a className literal in Maka source).
- Live app on this branch, empty session: hero centre and message-list centre both read 380px. Conversation with rows: the spacer still computes `display: block`, so push-to-bottom is intact.