### PR TITLE
fix(desktop): give selection quote actions an opaque popover surface

### DIFF
--- a/apps/desktop/src/renderer/styles/quote-side-panel.css
+++ b/apps/desktop/src/renderer/styles/quote-side-panel.css
@@ -4,9 +4,15 @@
    control. This file adds only the native window hit-test opt-out plus the
    workbar "追问引用" tab and in-tab companion. */
 
-/* Selection coordinates and top-layer behavior belong to Astryx useLayer. */
+/* Selection coordinates and top-layer behavior belong to Astryx useLayer.
+   The secondary buttons inside use the translucent `--color-neutral` surface,
+   which assumes an opaque backdrop — floating over transcript text it reads
+   as transparent, so the wrapper supplies the popover surface itself (same
+   convention as ChatLayoutScrollButton). */
 .maka-quote-actions {
   display: inline-flex;
+  border-radius: var(--radius-element);
+  background: var(--color-background-popover);
   -webkit-app-region: no-drag;
 }
 

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -246,7 +246,6 @@ export interface ConversationCopy {
     loadFailed: string;
     loading: string;
     retryLoad: string;
-    jumpLatest: string;
     quoteSelection: string;
     askInSidePanel: string;
     noMessages: string;
@@ -408,7 +407,7 @@ const CONVERSATION_COPY = {
         },
       },
       clearGoal: (condition, iteration, max, status) => `自主执行目标进行中：「${condition}」（第 ${iteration}/${max} 轮，${status}）。系统每轮后自动续行；点击可清除目标、停止续行。`, clearGoalAriaLabel: (iteration, max) => `清除自主执行目标（已进行 ${iteration}/${max} 轮）`, goalProgress: (iteration, max) => `目标 ${iteration} / ${max}`, goalRunningAriaLabel: '自主目标正在运行',
-      loadFailed: '对话载入失败', loading: '载入中…', retryLoad: '重试载入', jumpLatest: '跳到最新消息', quoteSelection: '引用', askInSidePanel: '在侧栏追问', noMessages: '暂无消息',
+      loadFailed: '对话载入失败', loading: '载入中…', retryLoad: '重试载入', quoteSelection: '引用', askInSidePanel: '在侧栏追问', noMessages: '暂无消息',
       branchBeforeInterrupt: '从中断前分支', sessionContextAriaLabel: '会话上下文', sessionLineageAriaLabel: '会话来源', sessionContextMore: (count) => `更多会话上下文（${count}）`,
       revisionVersionsAriaLabel: '对话版本', revisionVersion: (current, total) => `版本 ${current} / ${total}`, previousRevision: '查看上一版本', nextRevision: '查看下一版本',
     },
@@ -550,7 +549,7 @@ const CONVERSATION_COPY = {
         },
       },
       clearGoal: (condition, iteration, max, status) => `Autonomous goal in progress: “${condition}” (iteration ${iteration}/${max}, ${status}). Maka continues after each iteration; click to clear the goal and stop continuing.`, clearGoalAriaLabel: (iteration, max) => `Clear autonomous goal after ${iteration}/${max} iterations`, goalProgress: (iteration, max) => `Goal ${iteration} of ${max}`, goalRunningAriaLabel: 'Autonomous goal running',
-      loadFailed: 'Conversation failed to load', loading: 'Loading…', retryLoad: 'Retry', jumpLatest: 'Jump to latest message', quoteSelection: 'Quote', askInSidePanel: 'Ask in side panel', noMessages: 'No messages yet',
+      loadFailed: 'Conversation failed to load', loading: 'Loading…', retryLoad: 'Retry', quoteSelection: 'Quote', askInSidePanel: 'Ask in side panel', noMessages: 'No messages yet',
       branchBeforeInterrupt: 'Branched before interruption', sessionContextAriaLabel: 'Session context', sessionLineageAriaLabel: 'Session origin', sessionContextMore: (count) => `More session context (${count})`,
       revisionVersionsAriaLabel: 'Conversation versions', revisionVersion: (current, total) => `Version ${current} of ${total}`, previousRevision: 'View previous version', nextRevision: 'View next version',
     },


### PR DESCRIPTION
Before:
<img width="476" height="99" alt="image" src="https://github.com/user-attachments/assets/cdec0d82-bf84-4a8e-b437-0daea255fb59" />

After:
<img width="338" height="131" alt="image" src="https://github.com/user-attachments/assets/ff0a6820-bf44-45a0-8da9-b7d106fd56ad" />


## Problem

The floating **引用 / 在侧栏追问** popup that appears after selecting response text is effectively transparent — transcript text bleeds straight through the buttons, making them hard to read:

- `.maka-quote-actions` (the layer wrapper) sets only `display: inline-flex`, no background.
- `ButtonGroup elevation="med"` only adds a box-shadow, by design.
- The secondary buttons fill with `--color-neutral`, which is `light-dark(#0000000F, #FFFFFF1A)` — a 6%-alpha translucent tone meant to sit on an opaque app surface, not to float over text.

## Fix

Give `.maka-quote-actions` the opaque `--color-background-popover` surface plus the element radius, so the translucent button fills and the group shadow land on a real surface. This mirrors the existing convention for controls floating over scrollable content (`ChatLayoutScrollButton` puts the same popover surface behind its ghost button).

Also removes the `jumpLatest` copy key from `conversation-copy.ts` — it had no consumers in either locale (dead copy found while auditing other floating surfaces).

## Validation

- `npm --workspace @maka/ui run typecheck` passes
- `dist/__tests__/conversation-localization.test.js` — 17/17 pass
- Audited the other floating surfaces (prompt-rail preview, scroll-to-bottom pill, session context bar, workbar sheet, overlay windows) — all already sit on opaque surfaces; this popup was the only instance.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01Ac5rv6WUKWtMZgQb5QPN16