### PR TITLE
perf(runtime): coalesce partial stream persistence

### DIFF
--- a/packages/core/src/runtime-event-store.ts
+++ b/packages/core/src/runtime-event-store.ts
@@ -43,6 +43,17 @@ export interface RuntimeEventStore {
     event: RuntimeEvent,
     options?: { durable?: boolean },
   ): Promise<void>;
+  /**
+   * Coalesce one already-admitted mutable presentation stream into one store
+   * transaction. Callers must preserve provider order and flush before every
+   * immutable execution boundary. Stores that do not implement this optional
+   * fast path continue to receive one append per partial event.
+   */
+  appendRuntimePartialBatch?(
+    sessionId: string,
+    runId: string,
+    events: readonly RuntimeEvent[],
+  ): Promise<void>;
   /** Append the terminal event if absent, or re-establish its stable-storage barrier if present. */
   ensureTerminalRuntimeEventDurable(
     sessionId: string,

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -39,6 +39,152 @@ import { RuntimeKernel } from '../runtime-kernel.js';
 import type { RuntimeInteractionAuthority } from '../interaction-authority.js';
 
 describe('SessionManager terminal ledger invariants', () => {
+  test('coalesces one partial stream and flushes it before the final model event', async () => {
+    const store = new TinySessionStore();
+    const session = await store.create(makeInput());
+    const runtimeEventStore = new BatchingRuntimeEventStore();
+    const run = new AgentRun({
+      sessionId: session.id,
+      header: session,
+      userInput: { turnId: 'turn-1', text: 'hello' },
+      store,
+      runtimeEventStore,
+      newId: nextId(),
+      now: nextNow(10_000),
+      hooks: inertAgentRunHooks(store),
+    });
+    const acceptDelta = async (id: string, ts: number, text: string): Promise<void> => {
+      await run.acceptMappedEvent(
+        { type: 'text_delta', id, turnId: 'turn-1', ts, messageId: 'message-1', text },
+        runtimeEvent({
+          id: `runtime-${id}`,
+          sessionId: session.id,
+          invocationId: run.invocationId,
+          runId: run.runId,
+          turnId: run.turnId,
+          ts,
+          partial: true,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text },
+          refs: { providerEventId: 'message-1' },
+        }),
+      );
+    };
+
+    await acceptDelta('delta-1', 1, 'a');
+    await acceptDelta('delta-2', 2, 'b');
+    await acceptDelta('delta-3', 3, 'c');
+    expect(runtimeEventStore.order).toEqual(['append:runtime-delta-1']);
+
+    await run.acceptMappedEvent(
+      {
+        type: 'text_complete',
+        id: 'complete-1',
+        turnId: 'turn-1',
+        ts: 4,
+        messageId: 'message-1',
+        text: 'abc',
+      },
+      runtimeEvent({
+        id: 'runtime-complete-1',
+        sessionId: session.id,
+        invocationId: run.invocationId,
+        runId: run.runId,
+        turnId: run.turnId,
+        ts: 4,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'abc' },
+        refs: { providerEventId: 'message-1' },
+      }),
+    );
+
+    expect(runtimeEventStore.order).toEqual([
+      'append:runtime-delta-1',
+      'batch:runtime-delta-2,runtime-delta-3',
+      'append:runtime-complete-1',
+    ]);
+  });
+
+  test('fails a model boundary closed when its pending partial batch cannot be stored', async () => {
+    const store = new TinySessionStore();
+    const session = await store.create(makeInput());
+    const runtimeEventStore = new BatchingRuntimeEventStore(true);
+    const run = new AgentRun({
+      sessionId: session.id,
+      header: session,
+      userInput: { turnId: 'turn-1', text: 'hello' },
+      store,
+      runtimeEventStore,
+      newId: nextId(),
+      now: nextNow(10_100),
+      hooks: inertAgentRunHooks(store),
+    });
+    const partial = (id: string, ts: number, text: string): RuntimeEvent =>
+      runtimeEvent({
+        id,
+        sessionId: session.id,
+        invocationId: run.invocationId,
+        runId: run.runId,
+        turnId: run.turnId,
+        ts,
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text },
+        refs: { providerEventId: 'message-1' },
+      });
+    await run.acceptMappedEvent(
+      {
+        type: 'text_delta',
+        id: 'delta-1',
+        turnId: 'turn-1',
+        ts: 1,
+        messageId: 'message-1',
+        text: 'a',
+      },
+      partial('runtime-delta-1', 1, 'a'),
+    );
+    await run.acceptMappedEvent(
+      {
+        type: 'text_delta',
+        id: 'delta-2',
+        turnId: 'turn-1',
+        ts: 2,
+        messageId: 'message-1',
+        text: 'b',
+      },
+      partial('runtime-delta-2', 2, 'b'),
+    );
+
+    await assert.rejects(
+      run.acceptMappedEvent(
+        {
+          type: 'text_complete',
+          id: 'complete-1',
+          turnId: 'turn-1',
+          ts: 3,
+          messageId: 'message-1',
+          text: 'ab',
+        },
+        runtimeEvent({
+          id: 'runtime-complete-1',
+          sessionId: session.id,
+          invocationId: run.invocationId,
+          runId: run.runId,
+          turnId: run.turnId,
+          ts: 3,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text: 'ab' },
+        }),
+      ),
+      /partial batch failed/,
+    );
+    expect(runtimeEventStore.order).toEqual(['append:runtime-delta-1', 'batch:runtime-delta-2']);
+  });
+
   test('error streams persist a failed terminal fact without non-terminal error ledger rows', async () => {
     const { manager, runStore, session } = await makeHarness([
       { type: 'error', recoverable: false, reason: 'tool_failed', message: 'Tool failed' },
@@ -1934,6 +2080,47 @@ class TinyAgentRunStore implements AgentRunStore, RuntimeEventStore {
         a.event.id.localeCompare(b.event.id),
     );
     return ordered.map((item) => item.event);
+  }
+}
+
+class BatchingRuntimeEventStore implements RuntimeEventStore {
+  readonly durability = 'canonical' as const;
+  readonly order: string[] = [];
+  private readonly events: RuntimeEvent[] = [];
+
+  constructor(private readonly failPartialBatch = false) {}
+
+  async appendRuntimeEvent(_sessionId: string, _runId: string, event: RuntimeEvent): Promise<void> {
+    this.order.push(`append:${event.id}`);
+    this.events.push(clone(event));
+  }
+
+  async appendRuntimePartialBatch(
+    _sessionId: string,
+    _runId: string,
+    events: readonly RuntimeEvent[],
+  ): Promise<void> {
+    this.order.push(`batch:${events.map((event) => event.id).join(',')}`);
+    if (this.failPartialBatch) throw new Error('partial batch failed');
+    this.events.push(...clone(events));
+  }
+
+  async ensureTerminalRuntimeEventDurable(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+  ): Promise<void> {
+    if (!this.events.some((candidate) => candidate.id === event.id)) {
+      await this.appendRuntimeEvent(sessionId, runId, event);
+    }
+  }
+
+  async readRuntimeEvents(): Promise<RuntimeEvent[]> {
+    return clone(this.events);
+  }
+
+  async readSessionRuntimeEvents(): Promise<RuntimeEvent[]> {
+    return clone(this.events);
   }
 }
 

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -8,6 +8,7 @@ import type {
   ToolBoundaryProtocol,
 } from '@maka/core';
 import { DurableStoreWriteError, isSessionInlineRun, isTerminalRuntimeEvent } from '@maka/core';
+import { Buffer } from 'node:buffer';
 import { isDeepStrictEqual } from 'node:util';
 import { redactSecrets } from '@maka/core/redaction';
 import {
@@ -182,6 +183,9 @@ export interface AgentRunContinuationBeginResult {
   continuationStartAdmission: RuntimeContinuationStartAdmissionProof;
 }
 
+const RUNTIME_PARTIAL_FLUSH_INTERVAL_MS = 80;
+const RUNTIME_PARTIAL_BATCH_MAX_BYTES = 8 * 1024;
+
 export class AgentRun {
   readonly runId: string;
   readonly invocationId: string;
@@ -200,6 +204,10 @@ export class AgentRun {
   private runStoreAvailable = true;
   private runtimeEventStoreAvailable = true;
   private runtimeEventStoreFailure: unknown;
+  private runtimePartialStreamKey: string | undefined;
+  private runtimePartialBuffer: RuntimeEvent[] = [];
+  private runtimePartialBufferBytes = 0;
+  private runtimePartialFlushTimer: ReturnType<typeof setTimeout> | undefined;
   private traceWriteError: string | undefined;
   private failureClass: string | undefined;
   private failureMessage: string | undefined;
@@ -305,6 +313,7 @@ export class AgentRun {
     // reports success while the run stays non-terminal is the silent loss this
     // method exists to prevent.
     if (!this.input.runtimeEventStore || !this.input.runStore) return;
+    await this.flushRuntimePartialBuffer(true);
     // The claim only fences writers inside this Run. Another owner — a Host
     // recovery, a resumed continuation — may have sealed the ledger already,
     // and a sealed run rejects further appends. Nothing to land in that case:
@@ -476,6 +485,7 @@ export class AgentRun {
     if (!this.input.runtimeEventStore || !this.runtimeEventStoreAvailable) {
       throw new Error('RuntimeEvent store is unavailable for turn runtime events');
     }
+    await this.flushRuntimePartialBuffer(false);
     await this.runtimeEventQueue.catch(() => {});
     // A write may have failed while we waited; a snapshot from a store that
     // just went unavailable must not be treated as a complete durable read.
@@ -581,6 +591,8 @@ export class AgentRun {
     runtimeEvent: RuntimeEvent,
     options: { requireTerminalWrite?: boolean; allowInteractionResume?: boolean } = {},
   ): Promise<void> {
+    const partialStreamKey = runtimePartialCoalescingKey(runtimeEvent);
+    if (!partialStreamKey) await this.flushRuntimePartialBuffer(true);
     if (isTerminalRuntimeEvent(runtimeEvent)) {
       await this.recordRuntimeEvents([runtimeEvent], {
         requireTerminalWrite: options.requireTerminalWrite ?? Boolean(this.input.runtimeEventStore),
@@ -598,6 +610,10 @@ export class AgentRun {
     }
     await this.recordSessionEvent(sessionEvent, options);
     if (sessionEvent.type === 'provider_retry') return;
+    if (partialStreamKey) {
+      await this.recordRuntimePartial(runtimeEvent, partialStreamKey);
+      return;
+    }
     // ToolRuntime already persisted protocol-tagged tool calls/results through
     // the atomic RuntimeCommitSink. Re-appending the mapped UI event through
     // the generic lane would duplicate the fact and violate that boundary.
@@ -1022,6 +1038,7 @@ export class AgentRun {
   async finalize(): Promise<void> {
     if (this.finalized) return;
     this.finalized = true;
+    await this.flushRuntimePartialBuffer(true);
     const lastTs = this.lastTs || this.input.now();
     if (this.stopped) this.finalStatus = { status: 'aborted' };
     if (!this.finalStatus) {
@@ -1590,6 +1607,90 @@ export class AgentRun {
     return next;
   }
 
+  private async recordRuntimePartial(event: RuntimeEvent, streamKey: string): Promise<void> {
+    const store = this.input.runtimeEventStore;
+    if (!store?.appendRuntimePartialBatch) {
+      await this.recordRuntimeEvents([event]);
+      return;
+    }
+    if (!this.runtimeEventStoreAvailable) {
+      await this.recordRuntimeEvents([event]);
+      return;
+    }
+    if (this.runtimePartialStreamKey !== streamKey) {
+      await this.flushRuntimePartialBuffer(true);
+      // Persist the first chunk synchronously. Besides bounding crash loss, this
+      // captures the immutable anchor before an upstream tool boundary can
+      // commit while later chunks are waiting in the coalescer.
+      await this.recordRuntimeEvents([event]);
+      this.runtimePartialStreamKey = streamKey;
+      return;
+    }
+    this.runtimePartialBuffer.push(event);
+    this.runtimePartialBufferBytes += runtimePartialTextBytes(event);
+    if (this.runtimePartialBufferBytes >= RUNTIME_PARTIAL_BATCH_MAX_BYTES) {
+      await this.flushRuntimePartialBuffer(false);
+      return;
+    }
+    this.scheduleRuntimePartialFlush();
+  }
+
+  private scheduleRuntimePartialFlush(): void {
+    if (this.runtimePartialFlushTimer) return;
+    this.runtimePartialFlushTimer = setTimeout(() => {
+      this.runtimePartialFlushTimer = undefined;
+      void this.flushRuntimePartialBuffer(false).catch(() => {
+        // enqueueRuntimeEventStore latches and reports the failure. The next
+        // event or execution boundary observes that latch and fails closed.
+      });
+    }, RUNTIME_PARTIAL_FLUSH_INTERVAL_MS);
+  }
+
+  private async flushRuntimePartialBuffer(closeStream: boolean): Promise<void> {
+    const ownedPartialWork =
+      this.runtimePartialStreamKey !== undefined ||
+      this.runtimePartialBuffer.length > 0 ||
+      this.runtimePartialFlushTimer !== undefined;
+    if (this.runtimePartialFlushTimer) {
+      clearTimeout(this.runtimePartialFlushTimer);
+      this.runtimePartialFlushTimer = undefined;
+    }
+    const events = this.runtimePartialBuffer;
+    this.runtimePartialBuffer = [];
+    this.runtimePartialBufferBytes = 0;
+    if (closeStream) this.runtimePartialStreamKey = undefined;
+    if (events.length === 0) {
+      // A timer flush may already be queued. Waiting here preserves the rule
+      // that an immutable boundary never overtakes prior presentation text.
+      if (closeStream) {
+        await this.runtimeEventQueue;
+        if (
+          ownedPartialWork &&
+          !this.runtimeEventStoreAvailable &&
+          this.input.runtimeEventStore?.durability === 'canonical'
+        ) {
+          throw (
+            this.runtimeEventStoreFailure ??
+            new Error('canonical RuntimeEvent store is unavailable')
+          );
+        }
+      }
+      return;
+    }
+    const store = this.input.runtimeEventStore;
+    if (!store?.appendRuntimePartialBatch) {
+      await this.recordRuntimeEvents(events);
+      return;
+    }
+    await this.enqueueRuntimeEventStore(
+      'append runtime partial batch',
+      async () => {
+        await store.appendRuntimePartialBatch?.(this.sessionId, this.runId, events);
+      },
+      { rethrow: store.durability === 'canonical' },
+    );
+  }
+
   private async enqueueTraceWriteFailure(
     error: unknown,
     label = 'agent run store write',
@@ -1618,6 +1719,36 @@ export class AgentRun {
       // Diagnostic persistence is best effort; never perturb model/tool execution.
     }
   }
+}
+
+function runtimePartialCoalescingKey(event: RuntimeEvent): string | undefined {
+  if (!event.partial || event.status !== undefined || event.actions) return undefined;
+  const content = event.content;
+  if (content?.kind !== 'text' && content?.kind !== 'thinking') return undefined;
+  if (content.kind === 'text' && content.attachments !== undefined) return undefined;
+  if (content.kind === 'thinking' && content.signature !== undefined) return undefined;
+  const providerEventId = event.refs?.providerEventId;
+  if (!providerEventId || Object.keys(event.refs ?? {}).some((key) => key !== 'providerEventId')) {
+    return undefined;
+  }
+  return JSON.stringify([
+    content.kind,
+    providerEventId,
+    event.sessionId,
+    event.invocationId,
+    event.runId,
+    event.turnId,
+    event.branch ?? null,
+    event.role,
+    event.author,
+  ]);
+}
+
+function runtimePartialTextBytes(event: RuntimeEvent): number {
+  const content = event.content;
+  return content?.kind === 'text' || content?.kind === 'thinking'
+    ? Buffer.byteLength(content.text, 'utf8')
+    : 0;
 }
 
 function traceToRunEvent(event: RunTraceEvent, runId: string): EmittedAgentRunEvent {

--- a/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
+++ b/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
@@ -91,7 +91,7 @@ describe('SQLite recovery persistence authority', () => {
       dispatch.ts,
     );
     db.exec(
-      'DROP TABLE runtime_storage_root_binding; DROP TABLE runtime_workspace_heads; DROP TABLE runtime_workspace_versions; DROP TABLE runtime_workspace_epochs; DROP TABLE headless_task_run_events; DROP TABLE runtime_continuation_claims; DROP TABLE runtime_capabilities; PRAGMA user_version = 4;',
+      'DROP TABLE runtime_partial_segments; DROP TABLE runtime_storage_root_binding; DROP TABLE runtime_workspace_heads; DROP TABLE runtime_workspace_versions; DROP TABLE runtime_workspace_epochs; DROP TABLE headless_task_run_events; DROP TABLE runtime_continuation_claims; DROP TABLE runtime_capabilities; PRAGMA user_version = 4;',
     );
     db.close();
 
@@ -187,7 +187,7 @@ describe('SQLite recovery persistence authority', () => {
       2,
     );
     db.exec(
-      'DROP TABLE runtime_storage_root_binding; DROP TABLE runtime_workspace_heads; DROP TABLE runtime_workspace_versions; DROP TABLE runtime_workspace_epochs; DROP TABLE headless_task_run_events; DROP TABLE runtime_continuation_claims; DROP TABLE runtime_capabilities; PRAGMA user_version = 4;',
+      'DROP TABLE runtime_partial_segments; DROP TABLE runtime_storage_root_binding; DROP TABLE runtime_workspace_heads; DROP TABLE runtime_workspace_versions; DROP TABLE runtime_workspace_epochs; DROP TABLE headless_task_run_events; DROP TABLE runtime_continuation_claims; DROP TABLE runtime_capabilities; PRAGMA user_version = 4;',
     );
     db.close();
 

--- a/packages/storage/src/__tests__/session-bundle-policy.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-policy.test.ts
@@ -4,9 +4,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { test } from 'node:test';
-import type { CreateSessionInput } from '@maka/core';
+import type { CreateSessionInput, RuntimeEvent } from '@maka/core';
 import { createSessionStore } from '../session-store.js';
 import { exportSessionBundleState } from '../session-bundle-policy.js';
+import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
 
 test('exports one Session as filtered SQLite', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-session-bundle-'));
@@ -65,6 +66,77 @@ test('exports one Session as filtered SQLite', async () => {
   }
 });
 
+test('retains only the selected Session partial stream segments', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-session-bundle-partials-'));
+  const stateRoot = join(base, 'state');
+  const configRoot = join(base, 'config');
+  const destinationRoot = join(base, 'bundle');
+  const databasePath = join(stateRoot, 'runtime.sqlite');
+  await mkdir(configRoot, { recursive: true });
+  const sessions = createSessionStore(stateRoot);
+  try {
+    const selected = await sessions.create(input('Selected'));
+    const excluded = await sessions.create(input('Excluded'));
+    await sessions.close?.();
+
+    const runtime = createSqliteRuntimeStore(databasePath);
+    try {
+      await runtime.appendRuntimeEvent(
+        selected.id,
+        'selected-run',
+        partialEvent(selected.id, 'selected-run', 'selected', 1, 'a'),
+      );
+      await runtime.appendRuntimeEvent(
+        selected.id,
+        'selected-run',
+        partialEvent(selected.id, 'selected-run', 'selected', 2, 'b'),
+      );
+      await runtime.appendRuntimeEvent(
+        excluded.id,
+        'excluded-run',
+        partialEvent(excluded.id, 'excluded-run', 'excluded', 3, 'secret'),
+      );
+    } finally {
+      runtime.close();
+    }
+
+    await exportSessionBundleState({
+      stateRoot,
+      configRoot,
+      destinationRoot,
+      sessionId: selected.id,
+    });
+
+    const bundledDatabasePath = join(destinationRoot, 'runtime.sqlite');
+    const bundledRuntime = createSqliteRuntimeStore(bundledDatabasePath, { readOnly: true });
+    try {
+      const selectedEvents = await bundledRuntime.readRuntimeEvents(selected.id, 'selected-run');
+      assert.equal(selectedEvents.length, 1);
+      assert.equal(
+        selectedEvents[0]?.content?.kind === 'text' ? selectedEvents[0].content.text : undefined,
+        'ab',
+      );
+      assert.deepEqual(await bundledRuntime.readRuntimeEvents(excluded.id, 'excluded-run'), []);
+    } finally {
+      bundledRuntime.close();
+    }
+    const bundledDatabase = new DatabaseSync(bundledDatabasePath, { readOnly: true });
+    try {
+      assert.deepEqual(
+        bundledDatabase
+          .prepare('SELECT text_content FROM runtime_partial_segments ORDER BY segment_seq')
+          .all()
+          .map((row) => (row as { text_content: string }).text_content),
+        ['a', 'b'],
+      );
+    } finally {
+      bundledDatabase.close();
+    }
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 function input(name: string): CreateSessionInput {
   return {
     cwd: '/tmp/cwd',
@@ -79,4 +151,26 @@ function input(name: string): CreateSessionInput {
 
 function message(id: string) {
   return { type: 'user' as const, id, turnId: 'turn-1', ts: 1, text: id };
+}
+
+function partialEvent(
+  sessionId: string,
+  runId: string,
+  prefix: string,
+  ts: number,
+  text: string,
+): RuntimeEvent {
+  return {
+    id: `${prefix}-partial-${ts}`,
+    invocationId: `${prefix}-invocation`,
+    runId,
+    sessionId,
+    turnId: `${prefix}-turn`,
+    ts,
+    partial: true,
+    role: 'model',
+    author: 'agent',
+    content: { kind: 'text', text },
+    refs: { providerEventId: `${prefix}-message` },
+  };
 }

--- a/packages/storage/src/__tests__/sqlite-recovery-concurrency.test.ts
+++ b/packages/storage/src/__tests__/sqlite-recovery-concurrency.test.ts
@@ -255,7 +255,7 @@ describe('SQLite recovery authority multi-process races', () => {
       const db = new DatabaseSync(dbPath);
       try {
         db.exec(
-          "DROP TABLE runtime_storage_root_binding; DROP TABLE runtime_workspace_heads; DROP TABLE runtime_workspace_versions; DROP TABLE runtime_workspace_epochs; DROP TABLE headless_task_run_events; DELETE FROM runtime_capabilities WHERE capability = 'runtime_workspace_version_authority'; PRAGMA user_version = 6;",
+          "DROP TABLE runtime_partial_segments; DROP TABLE runtime_storage_root_binding; DROP TABLE runtime_workspace_heads; DROP TABLE runtime_workspace_versions; DROP TABLE runtime_workspace_epochs; DROP TABLE headless_task_run_events; DELETE FROM runtime_capabilities WHERE capability = 'runtime_workspace_version_authority'; PRAGMA user_version = 6;",
         );
       } finally {
         db.close();

--- a/packages/storage/src/__tests__/sqlite-runtime-schema.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-schema.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { DatabaseSync } from 'node:sqlite';
 import { describe, it } from 'node:test';
-import { migrateSqliteRuntimeDatabase } from '../sqlite-runtime-schema.js';
+import {
+  SQLITE_RUNTIME_SCHEMA_VERSION,
+  migrateSqliteRuntimeDatabase,
+} from '../sqlite-runtime-schema.js';
 
 describe('SQLite runtime schema migration', () => {
   it('uses the locked current version after an optimistic stale read', () => {
@@ -13,7 +16,9 @@ describe('SQLite runtime schema migration', () => {
         return {
           get() {
             versionReads += 1;
-            return { user_version: versionReads === 1 ? 4 : 9 };
+            return {
+              user_version: versionReads === 1 ? 4 : SQLITE_RUNTIME_SCHEMA_VERSION,
+            };
           },
         };
       },

--- a/packages/storage/src/__tests__/sqlite-runtime-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-store.test.ts
@@ -48,6 +48,7 @@ describe('SqliteRuntimeStore', () => {
 
       const legacy = new DatabaseSync(dbPath);
       legacy.exec(`
+        DROP TABLE runtime_partial_segments;
         DROP TABLE runtime_storage_root_binding;
         DROP TABLE runtime_workspace_heads;
         DROP TABLE runtime_workspace_versions;
@@ -96,7 +97,7 @@ describe('SqliteRuntimeStore', () => {
 
       const upgraded = createSqliteRuntimeStore(dbPath);
       try {
-        assert.equal(upgraded.schemaVersion(), 9);
+        assert.equal(upgraded.schemaVersion(), SQLITE_RUNTIME_SCHEMA_VERSION);
         const inspect = new DatabaseSync(dbPath);
         try {
           assert.deepEqual(
@@ -126,6 +127,45 @@ describe('SqliteRuntimeStore', () => {
         } finally {
           inspect.close();
         }
+      } finally {
+        upgraded.close();
+      }
+    });
+  });
+
+  it('upgrades a schema 9 partial snapshot and appends new segments without rewriting it', async () => {
+    await withStore(async (store, dbPath) => {
+      const partial = (id: string, ts: number, text: string): RuntimeEvent =>
+        functionCallEvent({
+          id,
+          ts,
+          partial: true,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text },
+          refs: { providerEventId: 'message-1' },
+        });
+      await store.appendRuntimeEvent('session-1', 'run-1', partial('partial-old', 1, 'old'));
+      store.close();
+
+      const legacy = new DatabaseSync(dbPath);
+      legacy.prepare(`UPDATE runtime_partial_snapshots SET text_content = 'old'`).run();
+      legacy.exec('DROP TABLE runtime_partial_segments; PRAGMA user_version = 9;');
+      legacy.close();
+
+      const upgraded = createSqliteRuntimeStore(dbPath);
+      try {
+        const before = await upgraded.readRuntimeEvents('session-1', 'run-1');
+        assert.equal(
+          before[0]?.content?.kind === 'text' ? before[0].content.text : undefined,
+          'old',
+        );
+        await upgraded.appendRuntimeEvent('session-1', 'run-1', partial('partial-new', 2, 'new'));
+        const after = await upgraded.readRuntimeEvents('session-1', 'run-1');
+        assert.equal(
+          after[0]?.content?.kind === 'text' ? after[0].content.text : undefined,
+          'oldnew',
+        );
       } finally {
         upgraded.close();
       }
@@ -1239,6 +1279,73 @@ describe('SqliteRuntimeStore', () => {
     });
   });
 
+  it('stores a partial batch as one append-only segment and reconstructs the same text', async () => {
+    await withStore(async (store, dbPath) => {
+      const partial = (id: string, ts: number, text: string): RuntimeEvent =>
+        functionCallEvent({
+          id,
+          ts,
+          partial: true,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text },
+          refs: { providerEventId: 'message-1' },
+        });
+      await store.appendRuntimeEvent('session-1', 'run-1', partial('partial-1', 1, 'a'));
+      await store.appendRuntimePartialBatch('session-1', 'run-1', [
+        partial('partial-2', 2, 'b'),
+        partial('partial-3', 3, 'c'),
+      ]);
+
+      const events = await store.readRuntimeEvents('session-1', 'run-1');
+      assert.equal(events.length, 1);
+      assert.equal(events[0]?.content?.kind, 'text');
+      assert.equal(events[0]?.content?.kind === 'text' ? events[0].content.text : undefined, 'abc');
+
+      const inspect = new DatabaseSync(dbPath);
+      try {
+        assert.deepEqual(
+          inspect
+            .prepare(`
+              SELECT segment_seq, text_content
+              FROM runtime_partial_segments
+              ORDER BY segment_seq ASC
+            `)
+            .all()
+            .map((row) => ({ ...row })),
+          [
+            { segment_seq: 1, text_content: 'a' },
+            { segment_seq: 2, text_content: 'bc' },
+          ],
+        );
+      } finally {
+        inspect.close();
+      }
+    });
+  });
+
+  it('rejects a partial batch that crosses presentation streams atomically', async () => {
+    await withStore(async (store) => {
+      const partial = (id: string, providerEventId: string, text: string): RuntimeEvent =>
+        functionCallEvent({
+          id,
+          partial: true,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text },
+          refs: { providerEventId },
+        });
+      await assert.rejects(
+        store.appendRuntimePartialBatch('session-1', 'run-1', [
+          partial('partial-1', 'message-1', 'a'),
+          partial('partial-2', 'message-2', 'b'),
+        ]),
+        /exactly one presentation stream/,
+      );
+      assert.deepEqual(await store.readRuntimeEvents('session-1', 'run-1'), []);
+    });
+  });
+
   it('rejects a physical immutable prefix with an event-seq gap', async () => {
     await withStore(async (store, dbPath) => {
       for (let eventSeq = 1; eventSeq <= 3; eventSeq += 1) {
@@ -1278,7 +1385,7 @@ describe('SqliteRuntimeStore', () => {
   });
 
   it('replaces text and tool partial snapshots when their durable final arrives', async () => {
-    await withStore(async (store) => {
+    await withStore(async (store, dbPath) => {
       await store.appendRuntimeEvent(
         'session-1',
         'run-1',
@@ -1330,6 +1437,19 @@ describe('SqliteRuntimeStore', () => {
         ['text-final', 'call-event-1', 'response-event-1'],
       );
       assert.equal((await store.readImmutableRuntimeEvents('session-1', 'run-1')).length, 3);
+      const inspect = new DatabaseSync(dbPath);
+      try {
+        assert.equal(
+          (
+            inspect.prepare('SELECT count(*) AS count FROM runtime_partial_segments').get() as {
+              count: number;
+            }
+          ).count,
+          0,
+        );
+      } finally {
+        inspect.close();
+      }
     });
   });
 

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -432,6 +432,8 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
       toolBoundaryProtocol: runtimePersistence.runtimeCommitStore.toolBoundaryProtocol,
       appendRuntimeEvent: (sessionId, runId, event, options) =>
         run(() => runtimeEventStore.appendRuntimeEvent(sessionId, runId, event, options)),
+      appendRuntimePartialBatch: (sessionId, runId, events) =>
+        run(() => runtimeEventStore.appendRuntimePartialBatch(sessionId, runId, events)),
       importConversationCopyRuntimeEvents: (sessionId, batches) =>
         run(() => runtimeEventStore.importConversationCopyRuntimeEvents(sessionId, batches)),
       ensureTerminalRuntimeEventDurable: (sessionId, runId, event) =>

--- a/packages/storage/src/operational-state-backup.ts
+++ b/packages/storage/src/operational-state-backup.ts
@@ -368,6 +368,7 @@ function validateSqlite(path: string, files: readonly OperationalBackupFile[]): 
         'tool_journal_events',
         'tool_operations',
         'runtime_partial_snapshots',
+        'runtime_partial_segments',
         'runtime_capabilities',
         'runtime_continuation_claims',
         'runtime_workspace_epochs',

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -223,6 +223,15 @@ async function exportFilteredDatabase(
       .run();
     database
       .prepare(`
+      DELETE FROM runtime_partial_segments
+      WHERE NOT EXISTS (
+        SELECT 1 FROM runtime_partial_snapshots
+        WHERE runtime_partial_snapshots.stream_key = runtime_partial_segments.stream_key
+      )
+    `)
+      .run();
+    database
+      .prepare(`
       DELETE FROM tool_operations
       WHERE NOT EXISTS (
         SELECT 1 FROM runtime_events
@@ -276,6 +285,7 @@ const PORTABLE_GLOBAL_TABLES = new Set([
 const PORTABLE_DERIVED_TABLES = new Set([
   'tool_journal_events',
   'tool_operations',
+  'runtime_partial_segments',
   'core_interaction_outcomes',
   'core_message_host_epochs',
 ]);

--- a/packages/storage/src/sqlite-runtime-schema.ts
+++ b/packages/storage/src/sqlite-runtime-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_RUNTIME_SCHEMA_VERSION = 9;
+export const SQLITE_RUNTIME_SCHEMA_VERSION = 10;
 export const RUNTIME_RECOVERY_AUTHORITY_CAPABILITY = 'runtime_recovery_authority';
 export const RUNTIME_RECOVERY_AUTHORITY_CAPABILITY_VERSION = 1;
 export const RUNTIME_CONTINUATION_AUTHORITY_CAPABILITY = 'runtime_continuation_authority';
@@ -263,6 +263,21 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
       protocol_version INTEGER NOT NULL CHECK (protocol_version = 1)
     );
   `,
+  ],
+  [
+    10,
+    `
+    CREATE TABLE runtime_partial_segments (
+      stream_key TEXT NOT NULL,
+      segment_seq INTEGER NOT NULL CHECK (segment_seq > 0),
+      text_content TEXT NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (stream_key, segment_seq),
+      FOREIGN KEY (stream_key)
+        REFERENCES runtime_partial_snapshots(stream_key)
+        ON DELETE CASCADE
+    );
+    `,
   ],
 ]);
 

--- a/packages/storage/src/sqlite-runtime-store.ts
+++ b/packages/storage/src/sqlite-runtime-store.ts
@@ -295,6 +295,22 @@ export class SqliteRuntimeStore
     await this.importRuntimeEvent(sessionId, runId, canonicalEvent);
   }
 
+  async appendRuntimePartialBatch(
+    sessionId: string,
+    runId: string,
+    events: readonly RuntimeEvent[],
+  ): Promise<void> {
+    if (events.length === 0) return;
+    const canonicalEvents = events.map(canonicalizeRuntimeEventForStorage);
+    for (const event of canonicalEvents) {
+      assertNoReservedToolLedgerFact(event);
+      if (sessionId !== event.sessionId || runId !== event.runId) {
+        throw new Error(`RuntimeEvent store identity does not match event ${event.id}`);
+      }
+    }
+    this.transaction(() => this.importRuntimePartialBatchSync(canonicalEvents));
+  }
+
   async ensureTerminalRuntimeEventDurable(
     sessionId: string,
     runId: string,
@@ -450,6 +466,11 @@ export class SqliteRuntimeStore
           SELECT
             length(CAST(payload_json AS BLOB)) +
             length(CAST(text_content AS BLOB)) +
+            coalesce((
+              SELECT sum(length(CAST(segment.text_content AS BLOB)))
+              FROM runtime_partial_segments AS segment
+              WHERE segment.stream_key = runtime_partial_snapshots.stream_key
+            ), 0) +
             coalesce(length(CAST(after_event_id AS BLOB)), 0) AS stored_bytes
           FROM runtime_partial_snapshots
           WHERE session_id = ? AND run_id = ?
@@ -481,15 +502,34 @@ export class SqliteRuntimeStore
       FROM runtime_partial_snapshots
       WHERE session_id = ? AND run_id = ?
       ORDER BY updated_at ASC, stream_key ASC
-    `)
+      `)
       .all(sessionId, runId) as unknown as RuntimePartialStorageRow[];
+    const segmentText = new Map<string, string[]>();
+    const segments = this.db
+      .prepare(`
+      SELECT segment.stream_key, segment.text_content
+      FROM runtime_partial_segments AS segment
+      INNER JOIN runtime_partial_snapshots AS snapshot
+        ON snapshot.stream_key = segment.stream_key
+      WHERE snapshot.session_id = ? AND snapshot.run_id = ?
+      ORDER BY segment.stream_key ASC, segment.segment_seq ASC
+    `)
+      .all(sessionId, runId) as Array<{ stream_key: string; text_content: string }>;
+    for (const segment of segments) {
+      const text = segmentText.get(segment.stream_key) ?? [];
+      text.push(segment.text_content);
+      segmentText.set(segment.stream_key, text);
+    }
     return mergeRuntimePartialSnapshots(
       immutable,
       partials.flatMap((row) => {
         try {
           const event = decodeRuntimePartialStorageRow(row);
           if (event.content?.kind === 'text' || event.content?.kind === 'thinking') {
-            event.content = { ...event.content, text: row.text_content };
+            event.content = {
+              ...event.content,
+              text: row.text_content + (segmentText.get(row.stream_key)?.join('') ?? ''),
+            };
           }
           return [
             {
@@ -2356,6 +2396,39 @@ export class SqliteRuntimeStore
     return !existing;
   }
 
+  private importRuntimePartialBatchSync(events: readonly RuntimeEvent[]): void {
+    const first = events[0];
+    if (!first) return;
+    const partials = events.map((event) => partialRuntimeStream(event));
+    const firstPartial = partials[0];
+    if (!firstPartial) {
+      throw new Error('Runtime partial batch contains a non-partial event');
+    }
+    for (let index = 0; index < events.length; index += 1) {
+      const event = events[index]!;
+      const partial = partials[index];
+      if (!partial) throw new Error('Runtime partial batch contains a non-partial event');
+      if (
+        partial.key !== firstPartial.key ||
+        event.sessionId !== first.sessionId ||
+        event.invocationId !== first.invocationId ||
+        event.runId !== first.runId ||
+        event.turnId !== first.turnId
+      ) {
+        throw new Error('Runtime partial batch must contain exactly one presentation stream');
+      }
+    }
+    this.assertInvocationIdentity(events);
+    this.assertContinuationAuthorityAllowsEvent(first);
+    this.assertRunNotSealed(first);
+    const last = events.at(-1)!;
+    this.upsertRuntimePartial(first, {
+      ...firstPartial,
+      text: partials.map((partial) => partial!.text).join(''),
+      updatedAt: last.ts,
+    });
+  }
+
   private assertImmutableSteeringMessageIdentity(event: RuntimeEvent): void {
     const messageId = immutableSteeringMessageId(event);
     if (!messageId) return;
@@ -2444,7 +2517,7 @@ export class SqliteRuntimeStore
 
   private upsertRuntimePartial(
     event: RuntimeEvent,
-    partial: { key: string; snapshot: RuntimeEvent; text: string },
+    partial: { key: string; snapshot: RuntimeEvent; text: string; updatedAt?: number },
   ): boolean {
     const existing = this.db
       .prepare(`
@@ -2463,27 +2536,40 @@ export class SqliteRuntimeStore
       ORDER BY event_seq DESC LIMIT 1
     `)
           .get(event.sessionId, event.runId) as { event_id: string } | undefined);
-    this.db
-      .prepare(`
+    if (!existing) {
+      this.db
+        .prepare(`
       INSERT INTO runtime_partial_snapshots (
         stream_key, session_id, invocation_id, run_id, turn_id,
         after_event_id, payload_json, text_content, updated_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(stream_key) DO UPDATE SET
-        text_content = runtime_partial_snapshots.text_content || excluded.text_content,
-        updated_at = excluded.updated_at
     `)
-      .run(
-        partial.key,
-        event.sessionId,
-        event.invocationId,
-        event.runId,
-        event.turnId,
-        anchor?.event_id ?? null,
-        JSON.stringify(partial.snapshot),
-        partial.text,
-        event.ts,
-      );
+        .run(
+          partial.key,
+          event.sessionId,
+          event.invocationId,
+          event.runId,
+          event.turnId,
+          anchor?.event_id ?? null,
+          JSON.stringify(partial.snapshot),
+          '',
+          partial.updatedAt ?? event.ts,
+        );
+    } else {
+      this.db
+        .prepare('UPDATE runtime_partial_snapshots SET updated_at = ? WHERE stream_key = ?')
+        .run(partial.updatedAt ?? event.ts, partial.key);
+    }
+    if (partial.text.length > 0) {
+      this.db
+        .prepare(`
+        INSERT INTO runtime_partial_segments(stream_key, segment_seq, text_content, updated_at)
+        SELECT ?, coalesce(max(segment_seq), 0) + 1, ?, ?
+        FROM runtime_partial_segments
+        WHERE stream_key = ?
+      `)
+        .run(partial.key, partial.text, partial.updatedAt ?? event.ts, partial.key);
+    }
     return !existing;
   }
 


### PR DESCRIPTION
## Summary

- coalesce eligible text and thinking partials after a synchronous first-chunk anchor, flushing every 80 ms or 8 KiB and before immutable execution boundaries
- add an optional batched partial-store fast path while preserving the existing per-event fallback and canonical fail-closed behavior
- store SQLite partial growth as append-only segments with a schema v10 migration instead of repeatedly rewriting the accumulated snapshot text
- preserve reconstructed RuntimeEvent output, terminal ordering, continuation authority, recovery, and backup behavior

A synthetic 5,000-delta hot-path benchmark improved from roughly 1.06 s to 86.6 ms, about 12.2x.

## Verification

- `npm run build`
- `npm --workspace @maka/runtime test` — 3,124 passed, 9 skipped
- `NODE_NO_WARNINGS=1 npm --workspace @maka/storage test` — 648 passed, 12 skipped
- synthetic 5,000-delta partial persistence benchmark

## Review focus

- the first partial remains synchronous, and pending batches flush before tool, approval, stop, error, and terminal boundaries
- canonical storage failures remain blocking at execution boundaries
- schema v9 databases migrate to append-only partial segments without changing reconstructed text
- stores without `appendRuntimePartialBatch` retain the existing behavior