### PR TITLE
test(runtime,runtime-host): replace fixed waits with explicit barriers

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -1463,7 +1463,7 @@ test('production Host publishes and retires an implementation child patch', asyn
 });
 
 test('Host auxiliary models meter provider usage and abort physical requests', {
-  timeout: 10_000,
+  timeout: 20_000,
 }, async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-goal-evaluator-'));
   const provider = await startProvider();
@@ -1787,14 +1787,21 @@ test('Host auxiliary models meter provider usage and abort physical requests', {
         },
       }),
     });
+    // An explicit controller instead of AbortSignal.timeout(10): a wall-clock
+    // timer races the preflight under load, and an abort that lands before
+    // dispatch takes a different error path (#2132). Aborting after the
+    // dispatch barrier settles pins the abort mid-flight; the TimeoutError
+    // reason name keeps the errorClass classification.
+    const effectTimeout = new AbortController();
     const timedEffect = stalledEffect.generateRecap({
       sessionId: session.id,
       effectId: 'recap-timeout',
       header: session,
       events: [],
-      abortSignal: AbortSignal.timeout(10),
+      abortSignal: effectTimeout.signal,
     });
     await settleWithin(effectProviderDispatched.promise);
+    effectTimeout.abort(new DOMException('provider stalled', 'TimeoutError'));
     const timedResult = await settleWithin(timedEffect);
     assert.equal(timedResult.ok, false);
     if (timedResult.ok) return;

--- a/packages/runtime/src/__tests__/filesystem-authority.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-authority.test.ts
@@ -250,16 +250,45 @@ describe('file tools follow the execution boundary', () => {
       // atomic, so the survivor is whole even with no lock at all. Only an
       // overlap counter distinguishes a held lock from the kernel's own
       // serialisation, and only two spellings of one path prove the key
-      // canonicalises.
+      // canonicalises. Ordering is enforced with barriers instead of timers
+      // (#2132): submission order cannot promise acquisition order, because
+      // the lock key derivation is itself async. The first edit parks inside
+      // the locked region, and the second is released into the region only
+      // after its lock key resolved, so a lockless implementation overlaps
+      // deterministically while the first reader is still parked.
       const host = createLocalWorkspaceExecutor();
       let active = 0;
       let overlapped = false;
+      let reads = 0;
+      let keys = 0;
+      let firstReadStarted!: () => void;
+      const firstReadStartedPromise = new Promise<void>((resolve) => {
+        firstReadStarted = resolve;
+      });
+      let releaseFirstRead!: () => void;
+      const releaseFirstReadPromise = new Promise<void>((resolve) => {
+        releaseFirstRead = resolve;
+      });
+      let secondKeyResolved!: () => void;
+      const secondKeyResolvedPromise = new Promise<void>((resolve) => {
+        secondKeyResolved = resolve;
+      });
       const tools = toolsFor({
         executor: Object.assign(Object.create(host) as typeof host, {
+          writeLockKey: async (input: Parameters<typeof host.writeLockKey>[0]) => {
+            const result = await host.writeLockKey(input);
+            keys += 1;
+            if (keys === 2) secondKeyResolved();
+            return result;
+          },
           readFile: async (input: Parameters<typeof host.readFile>[0]) => {
             active += 1;
             overlapped ||= active > 1;
-            await new Promise((resolve) => setTimeout(resolve, 20));
+            reads += 1;
+            if (reads === 1) {
+              firstReadStarted();
+              await releaseFirstReadPromise;
+            }
             try {
               return await host.readFile(input);
             } finally {
@@ -270,15 +299,22 @@ describe('file tools follow the execution boundary', () => {
       });
       const edit = toolNamed(tools, 'Edit');
 
-      await Promise.all([
-        runTool(edit, { path: target, old_string: 'a', new_string: 'b' }, cwd, BYPASS),
-        runTool(
-          edit,
-          { path: join('..', 'outside', 'note.md'), old_string: 'b', new_string: 'c' },
-          cwd,
-          BYPASS,
-        ),
-      ]);
+      const first = runTool(edit, { path: target, old_string: 'a', new_string: 'b' }, cwd, BYPASS);
+      await firstReadStartedPromise;
+      const second = runTool(
+        edit,
+        { path: join('..', 'outside', 'note.md'), old_string: 'b', new_string: 'c' },
+        cwd,
+        BYPASS,
+      );
+      await secondKeyResolvedPromise;
+      // Give a lockless second edit every chance to reach readFile while the
+      // first reader is parked; a working lock keeps it queued instead.
+      for (let tick = 0; tick < 25; tick += 1) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      releaseFirstRead();
+      await Promise.all([first, second]);
 
       expect(overlapped).toBe(false);
       // The second edit saw the first one's output, so they ran in sequence

--- a/packages/runtime/src/__tests__/filesystem-authority.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-authority.test.ts
@@ -250,12 +250,12 @@ describe('file tools follow the execution boundary', () => {
       // atomic, so the survivor is whole even with no lock at all. Only an
       // overlap counter distinguishes a held lock from the kernel's own
       // serialisation, and only two spellings of one path prove the key
-      // canonicalises. Ordering is enforced with barriers instead of timers
-      // (#2132): submission order cannot promise acquisition order, because
-      // the lock key derivation is itself async. The first edit parks inside
-      // the locked region, and the second is released into the region only
-      // after its lock key resolved, so a lockless implementation overlaps
-      // deterministically while the first reader is still parked.
+      // canonicalises. Ordering is enforced with causal barriers instead of
+      // timers (#2132): submission order cannot promise acquisition order,
+      // because the lock key derivation is itself async. The first read waits
+      // for the second key to resolve. A working lock keeps that second read
+      // queued; a lockless implementation necessarily overlaps it with the
+      // first read, which is still active at that exact boundary.
       const host = createLocalWorkspaceExecutor();
       let active = 0;
       let overlapped = false;
@@ -264,10 +264,6 @@ describe('file tools follow the execution boundary', () => {
       let firstReadStarted!: () => void;
       const firstReadStartedPromise = new Promise<void>((resolve) => {
         firstReadStarted = resolve;
-      });
-      let releaseFirstRead!: () => void;
-      const releaseFirstReadPromise = new Promise<void>((resolve) => {
-        releaseFirstRead = resolve;
       });
       let secondKeyResolved!: () => void;
       const secondKeyResolvedPromise = new Promise<void>((resolve) => {
@@ -287,7 +283,7 @@ describe('file tools follow the execution boundary', () => {
             reads += 1;
             if (reads === 1) {
               firstReadStarted();
-              await releaseFirstReadPromise;
+              await secondKeyResolvedPromise;
             }
             try {
               return await host.readFile(input);
@@ -307,13 +303,6 @@ describe('file tools follow the execution boundary', () => {
         cwd,
         BYPASS,
       );
-      await secondKeyResolvedPromise;
-      // Give a lockless second edit every chance to reach readFile while the
-      // first reader is parked; a working lock keeps it queued instead.
-      for (let tick = 0; tick < 25; tick += 1) {
-        await new Promise<void>((resolve) => setImmediate(resolve));
-      }
-      releaseFirstRead();
       await Promise.all([first, second]);
 
       expect(overlapped).toBe(false);

--- a/scripts/run-workspace-tests-parallel.mjs
+++ b/scripts/run-workspace-tests-parallel.mjs
@@ -28,26 +28,11 @@ const defaultRepoRoot = dirname(dirname(scriptPath));
 // conservatism for root orchestration, not a claim that its suite shares FS
 // state with other packages.
 //
-// runtime and runtime-host join it as a TEMPORARY mitigation for #2132, and
-// the reason is worth stating precisely so this list does not become a
-// dumping ground: they do NOT contend over a shared resource. Measured, at
-// --concurrency 3 some run fails 3 times out of 3; at --concurrency 1 across
-// every workspace, 0 out of 2; and each package alone passes repeatedly. Two
-// tempting explanations were tested and are false — /tmp does not fill up
-// (331 -> 339 entries under load, readdir in 1ms) and leftover child
-// processes are not the cause (running them back to back passes 3 of 3).
-// What is left is saturation: three tests with fixed waits miss their window
-// when the machine is busy.
-//
-// So this buys a quiet review pipeline at the cost of wall clock, and it is
-// the wrong permanent answer — the fix is in those tests' timing assumptions
-// (#2132). Remove these two entries when that lands. The unrelated /tmp
-// isolation gap found during the same investigation is #2133.
-export const SERIAL_WORKSPACE_DIRS = [
-  'packages/headless',
-  'packages/runtime',
-  'packages/runtime-host',
-];
+// Additions to this list need a measured, precisely stated reason. runtime
+// and runtime-host sat here temporarily while three tests relied on fixed
+// waits that missed their window under load; #2132 replaced those waits with
+// explicit barriers and the entries came out again.
+export const SERIAL_WORKSPACE_DIRS = ['packages/headless'];
 export const DEFAULT_WORKSPACE_TIMEOUT_MS = 15 * 60_000;
 
 const PROCESS_TERMINATION_GRACE_MS = 1_000;


### PR DESCRIPTION
## Summary

Two tests relied on wall-clock waits. Under --concurrency 3 they could miss their window and fail. #2136 serialized their workspaces as a temporary shield; this fixes the tests and removes the shield.

- execution-model-composition: replace AbortSignal.timeout(10) with an explicit controller. Abort only after the provider-dispatch barrier settles, preserving the TimeoutError classification while pinning the intended mid-flight path. The outer test guard moves to the existing 20-second precedent.
- filesystem-authority: replace the 20ms sleep with causal barriers. The first read remains active until the second lock key resolves. With the lock, the second read stays queued; without the lock, overlap is inevitable at that exact boundary. There are no wall-clock waits or fixed event-loop tick counts.
- Remove packages/runtime and packages/runtime-host from SERIAL_WORKSPACE_DIRS; packages/headless remains serial for its separately documented reason.

Closes #2132

## Verification

- Clean npm ci and npm run build:test passed.
- filesystem-authority: 11 passed, 0 failed.
- Targeted Host auxiliary model test passed.
- Mutation check: temporarily bypassing withFileWriteLock makes the causal barrier test fail immediately; restoring the lock makes it pass.
- runtime and runtime-host completed three green concurrent runner rounds at --concurrency 3.
- Biome and git diff --check passed.
- The original author also ran all non-desktop workspaces three times at --concurrency 3 with three passes.