### PR TITLE
feat(desktop): add Runtime Host Session domain IPC

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import type { RuntimeHostConnection } from '@maka/runtime-host/client';
+import {
+  RuntimeHostOperationError,
+  type RuntimeHostConnection,
+} from '@maka/runtime-host/client';
 import type {
   OperationInput,
   OperationKey,
@@ -414,6 +417,140 @@ test('fails explicitly when the Host cannot represent a legacy Session', async (
   );
 });
 
+test('restarts Session sidecar reads when a paginated revision changes', async () => {
+  const taskRevisionOne = catalogRevision('3');
+  const taskRevisionTwo = catalogRevision('4');
+  const resourceRevisionOne = catalogRevision('5');
+  const resourceRevisionTwo = catalogRevision('6');
+  const { client, requests } = clientWithResponses([
+    {
+      kind: 'page',
+      sessionId: 'session-1',
+      revision: taskRevisionOne,
+      tasks: [{ id: 'stale' }],
+      nextCursor: 'task-stale',
+    },
+    { kind: 'revision_changed', expected: taskRevisionOne, actual: taskRevisionTwo },
+    {
+      kind: 'page',
+      sessionId: 'session-1',
+      revision: taskRevisionTwo,
+      tasks: [{ id: 'fresh' }],
+      nextCursor: null,
+    },
+    {
+      kind: 'page',
+      sessionId: 'session-1',
+      storeVersion: 7,
+      latestProposalId: 'proposal-stale',
+      activeExecutionId: null,
+      items: [{ kind: 'proposal', proposal: { proposalId: 'proposal-stale' } }],
+      nextCursor: 'plan-stale',
+    },
+    { kind: 'revision_changed', expected: 7, actual: 8 },
+    {
+      kind: 'page',
+      sessionId: 'session-1',
+      storeVersion: 8,
+      latestProposalId: 'proposal-1',
+      activeExecutionId: null,
+      items: [{ kind: 'proposal', proposal: { proposalId: 'proposal-1' } }],
+      nextCursor: null,
+    },
+    {
+      kind: 'page',
+      sessionId: 'session-1',
+      revision: resourceRevisionOne,
+      resources: [{ result: { ref: 'shell:stale' } }],
+      nextCursor: 'resource-stale',
+    },
+    { kind: 'revision_changed', expected: resourceRevisionOne, actual: resourceRevisionTwo },
+    {
+      kind: 'page',
+      sessionId: 'session-1',
+      revision: resourceRevisionTwo,
+      resources: [{ result: { ref: 'shell:1' } }],
+      nextCursor: null,
+    },
+  ]);
+
+  assert.deepEqual(
+    (await client.listTasks('session-1')).map((task) => task.id),
+    ['fresh'],
+  );
+  const plan = await client.getPlanState('session-1');
+  assert.equal(plan.storeVersion, 8);
+  assert.equal(plan.latestProposalId, 'proposal-1');
+  assert.equal(plan.proposals[0]?.proposalId, 'proposal-1');
+  assert.equal((await client.listRuntimeResources('session-1'))[0]?.result.ref, 'shell:1');
+  assert.deepEqual(
+    requests.slice(0, 3).map(({ input }) => input),
+    [
+      { kind: 'list_start', sessionId: 'session-1' },
+      {
+        kind: 'list_continue',
+        sessionId: 'session-1',
+        revision: taskRevisionOne,
+        cursor: 'task-stale',
+      },
+      { kind: 'list_start', sessionId: 'session-1' },
+    ],
+  );
+});
+
+test('retries Goal clear only while the same Goal generation remains active', async () => {
+  const first = goalProjection(1);
+  const second = goalProjection(2);
+  const conflict = new RuntimeHostOperationError(
+    'goal.control',
+    'operation_conflict',
+    'Goal revision changed',
+  );
+  const { client, requests } = clientWithResponses([
+    { sessionId: 'session-1', goal: first },
+    conflict,
+    { sessionId: 'session-1', goal: second },
+    { sessionId: 'session-1', goal: { ...second, status: 'cleared' } },
+  ]);
+
+  await client.clearGoal('session-1');
+
+  assert.deepEqual(
+    requests.filter(({ operation }) => operation === 'goal.control').map(({ input }) => input),
+    [
+      { sessionId: 'session-1', goalId: 'goal-1', expectedRevision: 1, action: 'clear' },
+      { sessionId: 'session-1', goalId: 'goal-1', expectedRevision: 2, action: 'clear' },
+    ],
+  );
+});
+
+test('rejects an invalid sidecar continuation without misclassifying it as revision churn', async () => {
+  const revision = catalogRevision('7');
+  const { client, requests } = clientWithResponses([
+    {
+      kind: 'page',
+      sessionId: 'session-1',
+      revision,
+      tasks: [],
+      nextCursor: 'next',
+    },
+    {
+      kind: 'page',
+      sessionId: 'session-other',
+      revision,
+      tasks: [],
+      nextCursor: null,
+    },
+  ]);
+
+  await assert.rejects(
+    () => client.listTasks('session-1'),
+    (error: unknown) =>
+      error instanceof DesktopRuntimeHostClientError && error.code === 'projection_unstable',
+  );
+  assert.equal(requests.length, 2);
+});
+
 interface RecordedRequest {
   operation: OperationKey;
   input: unknown;
@@ -429,11 +566,33 @@ function clientWithResponses(responses: unknown[]): {
     request: async <K extends OperationKey>(operation: K, input: OperationInput<K>) => {
       requests.push({ operation, input });
       if (responses.length === 0) throw new Error(`Unexpected operation: ${operation}`);
-      return responses.shift();
+      const response = responses.shift();
+      if (response instanceof Error) throw response;
+      return response;
     },
     close: async () => undefined,
   } as unknown as RuntimeHostConnection;
   return { client: new DesktopRuntimeHostClient(connection), requests };
+}
+
+function goalProjection(revision: number) {
+  return {
+    goalId: 'goal-1',
+    revision,
+    sessionId: 'session-1',
+    condition: 'Finish the adapter',
+    status: 'active' as const,
+    setAt: 1,
+    iterations: 0,
+    maxIterations: 20,
+    consecutiveNoProgress: 0,
+    blockCap: 8,
+    tokenBudget: null,
+    tokensSpent: 0,
+    lastReason: null,
+    achievedAt: null,
+    pausedAt: null,
+  };
 }
 
 function catalogRevision(seed: string): `sha256:${string}` {

--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -23,6 +23,7 @@ import { DesktopRuntimeHostClient } from '../runtime-host-client.js';
 import { createAttachmentApprovalRegistry } from '../attachment-approval.js';
 import { registerRuntimeHostSessionCatalogIpc } from '../runtime-host-session-catalog-ipc-main.js';
 import { registerRuntimeHostSessionExecutionIpc } from '../runtime-host-session-execution-ipc-main.js';
+import { registerRuntimeHostSessionDomainsIpc } from '../runtime-host-session-domains-ipc-main.js';
 import { RuntimeHostSessionObserver } from '../runtime-host-session-observer.js';
 
 test('drives Desktop Session operations through a real Runtime Host connection', async () => {
@@ -318,6 +319,109 @@ test('drives the renderer Session execution facade through real UDS framing', as
     );
 
     await observer.close();
+    await client.close();
+  } finally {
+    await host?.close().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('drives bounded Session domain projections through real UDS framing', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-desktop-host-domains-ipc-'));
+  let host: RuntimeHostKernel | undefined;
+  try {
+    const capability = await resolveStorageRoot({ path: base, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    host = await RuntimeHostKernel.start({
+      owner,
+      idleGraceMs: 10_000,
+      compositionFactory: async () => ({
+        handlers: handlers({
+          'task.ledger.query': async (input) => ({
+            ok: true,
+            result: {
+              kind: 'page',
+              sessionId: input.sessionId,
+              revision: catalogRevision('6'),
+              tasks: [
+                {
+                  id: 'task-1',
+                  key: 'T1',
+                  subject: 'Verify the Desktop adapter',
+                  status: 'in_progress',
+                  createdAt: 1,
+                  updatedAt: 2,
+                },
+              ],
+              nextCursor: null,
+            },
+          }),
+          'plan.query': async (input) => ({
+            ok: true,
+            result: {
+              kind: 'page',
+              sessionId: input.sessionId,
+              storeVersion: 0,
+              latestProposalId: null,
+              activeExecutionId: null,
+              items: [],
+              nextCursor: null,
+            },
+          }),
+          'goal.query': async (input) => ({
+            ok: true,
+            result: { sessionId: input.sessionId, goal: null },
+          }),
+          'deep-research.query': async (input) => ({
+            ok: true,
+            result: { kind: 'not_started', sessionId: input.sessionId, revision: 0 },
+          }),
+          'runtime.resource.query': async (input) => ({
+            ok: true,
+            result: {
+              kind: 'page',
+              sessionId: input.sessionId,
+              revision: catalogRevision('7'),
+              resources: [],
+              nextCursor: null,
+            },
+          }),
+        }),
+        beginDrain() {},
+        async recover() {},
+        async close() {},
+      }),
+    });
+    const connected = await connectRuntimeHost({
+      rootPath: base,
+      surface: 'desktop',
+      protocol: {
+        min: RUNTIME_HOST_PROTOCOL_VERSION,
+        max: RUNTIME_HOST_PROTOCOL_VERSION,
+      },
+    });
+    assert.equal(connected.kind, 'connected');
+    if (connected.kind !== 'connected') throw new Error('Desktop did not connect to Runtime Host');
+    const client = new DesktopRuntimeHostClient(connected.connection);
+    const ipc = ipcHarness();
+    registerRuntimeHostSessionDomainsIpc({ client, emitModeChanged() {} }, ipc);
+
+    assert.equal(
+      ((await ipc.invoke('tasks:list', 'session-1')) as Array<{ id: string }>)[0]?.id,
+      'task-1',
+    );
+    assert.deepEqual(await ipc.invoke('plan-mode:getState', 'session-1'), {
+      schemaVersion: 1,
+      sessionId: 'session-1',
+      storeVersion: 0,
+      proposals: [],
+      executions: [],
+    });
+    assert.equal(await ipc.invoke('goal:get', 'session-1'), null);
+    assert.equal(await ipc.invoke('deepResearch:get', 'session-1'), undefined);
+    assert.deepEqual(await ipc.invoke('shell-runs:list', 'session-1'), []);
+
     await client.close();
   } finally {
     await host?.close().catch(() => undefined);

--- a/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
@@ -1,0 +1,398 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { IpcMain } from 'electron';
+import {
+  projectDeepResearchClientProgress,
+  type DeepResearchRun,
+  type PlanSessionState,
+  type ShellRunUpdate,
+} from '@maka/core';
+import { encodeDeepResearchSnapshot } from '@maka/runtime-host/protocol';
+import {
+  projectEmbeddedDeepResearch,
+  projectHostedDeepResearch,
+} from '../deep-research-desktop-projection.js';
+import {
+  registerRuntimeHostSessionDomainsIpc,
+  type RuntimeHostSessionDomainsIpcDeps,
+} from '../runtime-host-session-domains-ipc-main.js';
+
+type DomainClient = RuntimeHostSessionDomainsIpcDeps['client'];
+
+test('adapts Host Goal, Task, Deep Research, and Resource projections', async () => {
+  const controls: unknown[] = [];
+  const client = domainClient({
+    listTasks: async () => [{ id: 'task-1' }] as never,
+    listRuntimeResources: async () => [{ sessionId: 'session-1', result: { ref: 'shell:1' } }] as never,
+    queryGoal: async () => ({
+      sessionId: 'session-1',
+      goal: goalProjection(),
+    }),
+    clearGoal: async (sessionId) => {
+      controls.push(sessionId);
+    },
+    queryDeepResearch: async () => hostedResearch(),
+  });
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionDomainsIpc({ client, emitModeChanged() {} }, ipc);
+
+  assert.equal(((await ipc.invoke('tasks:list', 'session-1')) as Array<{ id: string }>)[0]?.id, 'task-1');
+  assert.equal(
+    ((await ipc.invoke('shell-runs:list', 'session-1')) as Array<{ result: { ref: string } }>)[0]
+      ?.result.ref,
+    'shell:1',
+  );
+  assert.deepEqual(await ipc.invoke('goal:get', 'session-1'), {
+    id: 'goal-1',
+    revision: 3,
+    sessionId: 'session-1',
+    condition: 'Finish the adapter',
+    status: 'active',
+    setAt: 1,
+    iterations: 2,
+    maxIterations: 20,
+    consecutiveNoProgress: 0,
+    blockCap: 8,
+    tokenBudget: 1_000,
+    tokensAtStart: 0,
+    tokensNow: 120,
+    tokensBaselinePending: false,
+  });
+  await ipc.invoke('goal:clear', 'session-1');
+  assert.deepEqual(controls, ['session-1']);
+  assert.deepEqual(await ipc.invoke('deepResearch:get', 'session-1'), {
+    sessionId: 'session-1',
+    objective: 'Inspect the adapter',
+    scopeLevel: 'standard',
+    status: 'completed',
+    stage: 'completed',
+    round: 2,
+    createdAt: 1,
+    updatedAt: 2,
+    artifactsCount: 4,
+    stepsCount: 3,
+    checklist: [
+      { itemId: 'entrypoints', title: 'Map entrypoints', status: 'completed' },
+    ],
+    reportSections: [{ key: 'conclusion', status: 'completed' }],
+    recentInspectedRefs: [{ kind: 'file', locator: 'apps/desktop/src/main/boot.ts' }],
+    workerRunIds: ['run-1'],
+    blockers: [],
+    reportArtifactId: 'artifact-1',
+    implementationPrompt: 'Implement the result.',
+  });
+});
+
+test('adapts non-starting Plan controls without exposing a split Plan-to-Turn transition', async () => {
+  const calls: unknown[] = [];
+  const state: PlanSessionState = {
+    schemaVersion: 1,
+    sessionId: 'session-1',
+    storeVersion: 3,
+    proposals: [],
+    executions: [],
+  };
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionDomainsIpc(
+    {
+      client: domainClient({
+        getPlanState: async () => state,
+        controlPlan: async (input) => {
+          calls.push({ kind: 'control', input });
+          return {
+            sessionId: 'session-1',
+            storeVersion: 3,
+            eventType: 'plan_revision_requested',
+            proposalId: 'proposal-1',
+            executionId: null,
+          };
+        },
+      }),
+      emitModeChanged: (sessionId) => calls.push({ kind: 'changed', sessionId }),
+      newId: () => 'operation-1',
+    },
+    ipc,
+  );
+
+  assert.deepEqual(await ipc.invoke('plan-mode:requestRevision', 'session-1', 'proposal-1'), state);
+  await assert.rejects(() => ipc.invoke('plan-mode:approve', 'session-1', {}), /missing handler/);
+  assert.deepEqual(calls, [
+    {
+      kind: 'control',
+      input: {
+        kind: 'request_revision',
+        sessionId: 'session-1',
+        proposalId: 'proposal-1',
+        operationId: 'operation-1',
+      },
+    },
+    { kind: 'changed', sessionId: 'session-1' },
+  ]);
+});
+
+test('publishes typed invalidations and refreshes only changed Runtime Resources', async () => {
+  const sent: Array<{ channel: string; payload: unknown }> = [];
+  let listCalls = 0;
+  const gets: Array<{ sessionId: string; ref: string }> = [];
+  const update = shellRunUpdate({
+    sessionId: 'session-1',
+    ownership: {
+      kind: 'source_owned',
+      sourceSessionId: 'parent-session',
+      ownerSessionId: 'parent-session',
+    },
+  });
+  const ipc = ipcHarness();
+  const handle = registerRuntimeHostSessionDomainsIpc(
+    {
+      client: domainClient({
+        listRuntimeResources: async () => {
+          listCalls += 1;
+          return [];
+        },
+        getRuntimeResource: async (sessionId, ref) => {
+          gets.push({ sessionId, ref });
+          return update;
+        },
+      }),
+      emitModeChanged() {},
+      sendToRenderer: (channel, payload) => sent.push({ channel, payload }),
+      now: () => 12,
+    },
+    ipc,
+  );
+
+  handle.sessionDomainChanged({ sessionId: 'session-1', domain: 'task' });
+  handle.sessionDomainChanged({ sessionId: 'session-1', domain: 'deep_research' });
+  handle.sessionDomainChanged({ sessionId: 'session-1', domain: 'plan' });
+  handle.sessionDomainChanged({
+    sessionId: 'session-1',
+    domain: 'runtime_resource',
+    resources: [{ sourceSessionId: 'parent-session', ref: update.result.ref }],
+  });
+  handle.agentGraphChanged({
+    schemaVersion: 1,
+    rootSessionId: 'session-1',
+    graphId: 'graph-1',
+    reason: 'runtime_activity',
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(listCalls, 0);
+  assert.deepEqual(gets, [{ sessionId: 'session-1', ref: update.result.ref }]);
+  assert.deepEqual(sent, [
+    {
+      channel: 'tasks:changed',
+      payload: { sessionId: 'session-1', taskIds: [], at: 12 },
+    },
+    {
+      channel: 'deepResearch:changed',
+      payload: { sessionId: 'session-1', ts: 12 },
+    },
+    {
+      channel: 'plan-mode:changed',
+      payload: { sessionId: 'session-1' },
+    },
+    {
+      channel: 'graphs:changed',
+      payload: {
+        schemaVersion: 1,
+        rootSessionId: 'session-1',
+        graphId: 'graph-1',
+        reason: 'runtime_activity',
+      },
+    },
+    {
+      channel: 'shell-runs:update',
+      payload: update,
+    },
+  ]);
+});
+
+test('projects embedded and hosted Deep Research into one renderer contract', () => {
+  const run: DeepResearchRun = {
+    schemaVersion: 1,
+    sessionId: 'session-1',
+    objective: 'Inspect the adapter',
+    scopeLevel: 'standard',
+    status: 'blocked',
+    stage: 'knowledge_base',
+    round: 1,
+    createdAt: 1,
+    updatedAt: 2,
+    artifacts: [],
+    checklist: [],
+    steps: [{
+      stepId: 'step-1',
+      kind: 'local_exploration',
+      status: 'blocked',
+      objective: 'Inspect the adapter',
+      summary: 'The adapter cannot continue.',
+      roots: [],
+      keywords: [],
+      ignoredPaths: [],
+      stoppingCondition: 'The boundary is known.',
+      expectedEvidence: 'A stable projection.',
+      evidenceArtifactIds: [],
+      inspectedRefs: [],
+      workerRunIds: [],
+      blockedReason: 'Runtime credentials are unavailable.',
+      createdAt: 2,
+    }],
+    reportSections: [],
+    checkpoints: [],
+  };
+  const embedded = projectEmbeddedDeepResearch(run);
+  const hosted = projectHostedDeepResearch(
+    encodeDeepResearchSnapshot(projectDeepResearchClientProgress(run), 1),
+  );
+
+  assert.deepEqual(hosted, embedded);
+  assert.deepEqual(hosted?.blockers, [
+    'Inspect the adapter: Runtime credentials are unavailable.',
+  ]);
+
+  const checklistBlocked = structuredClone(run);
+  checklistBlocked.checklist = [{
+    itemId: 'blocked-item',
+    title: '🙂'.repeat(240),
+    status: 'blocked',
+    evidenceArtifactIds: [],
+    blockedReason: 'Credentials are unavailable.',
+    updatedAt: 2,
+  }];
+  assert.match(
+    projectDeepResearchClientProgress(checklistBlocked).blockers[0] ?? '',
+    /Credentials are unavailable\./,
+  );
+
+  const stepBlocked = structuredClone(run);
+  if (!stepBlocked.steps[0]) throw new Error('Missing Deep Research step fixture');
+  stepBlocked.steps[0].objective = '🙂'.repeat(240);
+  assert.match(
+    projectDeepResearchClientProgress(stepBlocked).blockers.at(-1) ?? '',
+    /Runtime credentials are unavailable\./,
+  );
+});
+
+function domainClient(overrides: Partial<DomainClient>): DomainClient {
+  const unavailable = async () => {
+    throw new Error('Unexpected domain operation');
+  };
+  return {
+    clearGoal: unavailable,
+    controlPlan: unavailable,
+    getRuntimeResource: unavailable,
+    getPlanState: unavailable,
+    listRuntimeResources: unavailable,
+    listTasks: unavailable,
+    queryAgentGraph: unavailable,
+    queryAgentGraphOperator: unavailable,
+    queryDeepResearch: unavailable,
+    queryGoal: unavailable,
+    stopAgentGraph: unavailable,
+    ...overrides,
+  } as DomainClient;
+}
+
+function goalProjection() {
+  return {
+    goalId: 'goal-1',
+    revision: 3,
+    sessionId: 'session-1',
+    condition: 'Finish the adapter',
+    status: 'active' as const,
+    setAt: 1,
+    iterations: 2,
+    maxIterations: 20,
+    consecutiveNoProgress: 0,
+    blockCap: 8,
+    tokenBudget: 1_000,
+    tokensSpent: 120,
+    lastReason: null,
+    achievedAt: null,
+    pausedAt: null,
+  };
+}
+
+function hostedResearch() {
+  return {
+    kind: 'snapshot' as const,
+    sessionId: 'session-1',
+    revision: 4,
+    objective: 'Inspect the adapter',
+    scopeLevel: 'standard' as const,
+    status: 'completed' as const,
+    stage: 'completed' as const,
+    round: 2,
+    createdAt: 1,
+    updatedAt: 2,
+    artifactsCount: 4,
+    stepsCount: 3,
+    checklist: [
+      {
+        itemId: 'entrypoints',
+        title: 'Map entrypoints',
+        status: 'completed' as const,
+        blockedReason: null,
+      },
+    ],
+    reportSections: [{ key: 'conclusion' as const, status: 'completed' as const }],
+    recentInspectedRefs: [
+      {
+        kind: 'file' as const,
+        locator: 'apps/desktop/src/main/boot.ts',
+        label: null,
+      },
+    ],
+    workerRunIds: ['run-1'],
+    blockers: [],
+    reportArtifactId: 'artifact-1',
+    implementationPrompt: 'Implement the result.',
+  };
+}
+
+function shellRunUpdate(overrides: Partial<ShellRunUpdate> = {}): ShellRunUpdate {
+  return {
+    sessionId: 'session-1',
+    ownership: { kind: 'local' },
+    sourceTurnId: 'turn-1',
+    sourceToolCallId: 'tool-1',
+    result: {
+      kind: 'shell_run',
+      ref: 'shell:run-1',
+      mode: 'pipes',
+      status: 'running',
+      cwd: '/workspace',
+      cmd: 'sleep 60',
+      startedAt: 1,
+      updatedAt: 2,
+      revision: 2,
+      output: {
+        mode: 'pipes',
+        stdout: 'ready',
+        stderr: '',
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        redacted: false,
+      },
+    },
+    ...overrides,
+  };
+}
+
+type IpcHandler = Parameters<Pick<IpcMain, 'handle'>['handle']>[1];
+
+function ipcHarness() {
+  const handlers = new Map<string, IpcHandler>();
+  return {
+    handle(channel: string, handler: IpcHandler) {
+      assert.equal(handlers.has(channel), false, `duplicate handler: ${channel}`);
+      handlers.set(channel, handler);
+    },
+    async invoke(channel: string, ...args: unknown[]): Promise<unknown> {
+      const handler = handlers.get(channel);
+      assert.ok(handler, `missing handler: ${channel}`);
+      return handler({} as never, ...args);
+    },
+  };
+}

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -353,6 +353,90 @@ test('projects Host queue revisions and newly delivered steering messages', asyn
   await observer.close();
 });
 
+test('publishes Host sidecar and graph invalidations without inventing Session status changes', async () => {
+  const events = new AsyncFrameQueue();
+  const sessionChanges: Array<{ reason: string; sessionId: string }> = [];
+  const domainChanges: Array<{ sessionId: string; domain: string }> = [];
+  const graphChanges: unknown[] = [];
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: continuitySnapshot(),
+        transcript: Promise.resolve([]),
+        events,
+        async close() {
+          events.end();
+        },
+      }),
+    },
+    emitSessionsChanged: (reason, sessionId) => sessionChanges.push({ reason, sessionId }),
+    emitSessionDomainChanged: (change) => domainChanges.push(change),
+    emitAgentGraphChanged: (event) => graphChanges.push(event),
+  });
+  await observer.observe('session-1', 'observer-1', eventTarget(11));
+
+  events.push({
+    kind: 'subscription.session_projection',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence: 1,
+    snapshot: continuitySnapshot({
+      projectionRevision: 2,
+      goal: {
+        goalId: 'goal-1',
+        revision: 1,
+        sessionId: 'session-1',
+        condition: 'Finish the adapter',
+        status: 'active',
+        setAt: 1,
+        iterations: 0,
+        maxIterations: 20,
+        consecutiveNoProgress: 0,
+        blockCap: 8,
+        tokenBudget: null,
+        tokensSpent: 0,
+        lastReason: null,
+        achievedAt: null,
+        pausedAt: null,
+      },
+    }),
+  });
+  events.push({
+    kind: 'subscription.session_domain_changed',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence: 2,
+    sessionId: 'session-1',
+    domain: 'plan',
+  });
+  events.push({
+    kind: 'subscription.agent_graph_changed',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence: 3,
+    rootSessionId: 'session-1',
+    graphId: 'graph-1',
+    reason: 'runtime_activity',
+  });
+  await waitFor(() => graphChanges.length === 1);
+
+  assert.deepEqual(domainChanges, [{ sessionId: 'session-1', domain: 'plan' }]);
+  assert.ok(
+    sessionChanges.some(
+      (change) => change.reason === 'goal-change' && change.sessionId === 'session-1',
+    ),
+  );
+  assert.deepEqual(graphChanges, [
+    {
+      schemaVersion: 1,
+      rootSessionId: 'session-1',
+      graphId: 'graph-1',
+      reason: 'runtime_activity',
+    },
+  ]);
+  await observer.close();
+});
+
 function continuitySnapshot(
   overrides: Partial<SessionContinuitySnapshot> = {},
 ): SessionContinuitySnapshot {

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -89,6 +89,7 @@ import { assertDesktopExecutionBoundary } from './desktop-execution-admission.js
 import { createFileCredentialStore } from './credential-store.js';
 import { bindOnboardingDeps, createOnboardingService } from './onboarding-service.js';
 import { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
+import { projectEmbeddedDeepResearch } from './deep-research-desktop-projection.js';
 import { resolveE2eFixture, seedE2eFixture } from './e2e-fixture.js';
 import { resolveBuildInfo } from './build-info.js';
 import { resolveShellEnv } from './shell-env.js';
@@ -1085,8 +1086,8 @@ const onboardingService = createOnboardingService(
 
 function registerIpc(): void {
   const currentProjectRoot = resolveCurrentProjectRoot;
-  ipcMain.handle('deepResearch:get', (_event, sessionId: string) =>
-    deepResearchStore.read(sessionId));
+  ipcMain.handle('deepResearch:get', async (_event, sessionId: string) =>
+    projectEmbeddedDeepResearch(await deepResearchStore.read(sessionId)));
   registerMcpIpcMain({
     ipcMain,
     store: mcpConfigStore,

--- a/apps/desktop/src/main/deep-research-desktop-projection.ts
+++ b/apps/desktop/src/main/deep-research-desktop-projection.ts
@@ -1,0 +1,48 @@
+import {
+  projectDeepResearchClientProgress,
+  type DeepResearchClientProgress,
+  type DeepResearchRun,
+} from '@maka/core';
+import type { DeepResearchQueryResult } from '@maka/runtime-host/protocol';
+
+export function projectEmbeddedDeepResearch(
+  run: DeepResearchRun | undefined,
+): DeepResearchClientProgress | undefined {
+  return run ? projectDeepResearchClientProgress(run) : undefined;
+}
+
+export function projectHostedDeepResearch(
+  result: DeepResearchQueryResult,
+): DeepResearchClientProgress | undefined {
+  if (result.kind === 'not_started') return undefined;
+  return {
+    sessionId: result.sessionId,
+    objective: result.objective,
+    scopeLevel: result.scopeLevel,
+    status: result.status,
+    stage: result.stage,
+    round: result.round,
+    createdAt: result.createdAt,
+    updatedAt: result.updatedAt,
+    artifactsCount: result.artifactsCount,
+    stepsCount: result.stepsCount,
+    checklist: result.checklist.map(({ itemId, title, status, blockedReason }) => ({
+      itemId,
+      title,
+      status,
+      ...(blockedReason === null ? {} : { blockedReason }),
+    })),
+    reportSections: result.reportSections.map(({ key, status }) => ({ key, status })),
+    recentInspectedRefs: result.recentInspectedRefs.map(({ kind, locator, label }) => ({
+      kind,
+      locator,
+      ...(label === null ? {} : { label }),
+    })),
+    workerRunIds: [...result.workerRunIds],
+    blockers: [...result.blockers],
+    ...(result.reportArtifactId === null ? {} : { reportArtifactId: result.reportArtifactId }),
+    ...(result.implementationPrompt === null
+      ? {}
+      : { implementationPrompt: result.implementationPrompt }),
+  };
+}

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -1,16 +1,23 @@
 import { createHash, randomUUID } from 'node:crypto';
-import type { AttachmentRef } from '@maka/core/events';
+import type { AttachmentRef, ShellRunUpdate } from '@maka/core/events';
+import type { PlanSessionState, PlanUserControlInput } from '@maka/core/plan';
 import { decodeStoredMessageForRead, type StoredMessage } from '@maka/core/session';
+import type { Task } from '@maka/core/task-ledger';
 import {
   type DirectRequestOperationKey,
   type RuntimeHostConnection,
   type RuntimeHostSessionSubscription,
+  RuntimeHostOperationError,
 } from '@maka/runtime-host/client';
 import {
   ARTIFACT_INGEST_CHUNK_MAX_BYTES,
   type InteractionAnswerInput,
+  type GoalControlAction,
+  type GoalProjection,
   type OperationInput,
   type OperationOutput,
+  type PlanProjectionItem,
+  type PlanQueryResult,
   type QueueRetractInput,
   type QueueRetractResult,
   type SessionCatalogFilter,
@@ -40,6 +47,7 @@ export type DesktopSessionConfigurationPatch = Partial<SessionConfiguration>;
 export type DesktopRuntimeHostClientErrorCode =
   | 'catalog_unstable'
   | 'client_closed'
+  | 'projection_unstable'
   | 'revision_conflict'
   | 'session_not_found'
   | 'unsupported_session';
@@ -340,6 +348,181 @@ export class DesktopRuntimeHostClient {
     return this.#request('context.compact', input);
   }
 
+  async listTasks(sessionId: string): Promise<Task[]> {
+    const projection = await collectStableProjection({
+      name: 'Task ledger',
+      sessionId,
+      start: () => this.#request('task.ledger.query', { kind: 'list_start', sessionId }),
+      continue: (first, cursor) =>
+        this.#request('task.ledger.query', {
+          kind: 'list_continue',
+          sessionId,
+          revision: first.revision,
+          cursor,
+        }),
+      page(result, first) {
+        if (
+          result.kind !== 'page' ||
+          result.sessionId !== sessionId ||
+          (first !== undefined && result.revision !== first.revision)
+        ) {
+          throw invalidProjection('Task ledger');
+        }
+        return { source: result, items: result.tasks, nextCursor: result.nextCursor };
+      },
+    });
+    return projection.items;
+  }
+
+  queryGoal(sessionId: string): Promise<OperationOutput<'goal.query'>> {
+    return this.#request('goal.query', { sessionId });
+  }
+
+  controlGoal(
+    goal: Pick<GoalProjection, 'sessionId' | 'goalId' | 'revision'>,
+    action: GoalControlAction,
+  ): Promise<OperationOutput<'goal.control'>> {
+    return this.#request('goal.control', {
+      sessionId: goal.sessionId,
+      goalId: goal.goalId,
+      expectedRevision: goal.revision,
+      action,
+    });
+  }
+
+  async clearGoal(sessionId: string): Promise<void> {
+    const initial = await this.queryGoal(sessionId);
+    if (initial.goal === null) return;
+    const goalId = initial.goal.goalId;
+    let goal = initial.goal;
+    for (let attempt = 0; attempt < MAX_OPTIMISTIC_ATTEMPTS; attempt += 1) {
+      try {
+        await this.controlGoal(goal, 'clear');
+        return;
+      } catch (error) {
+        if (!(error instanceof RuntimeHostOperationError) || error.code !== 'operation_conflict') {
+          throw error;
+        }
+      }
+      const current = await this.queryGoal(sessionId);
+      if (current.goal === null || current.goal.goalId !== goalId) return;
+      goal = current.goal;
+    }
+    throw revisionConflict('Goal clear', sessionId);
+  }
+
+  async getPlanState(sessionId: string): Promise<PlanSessionState> {
+    const projection = await collectStableProjection({
+      name: 'Plan',
+      sessionId,
+      start: () => this.#request('plan.query', { kind: 'list_start', sessionId }),
+      continue: (first, cursor) =>
+        this.#request('plan.query', {
+          kind: 'list_continue',
+          sessionId,
+          storeVersion: first.storeVersion,
+          cursor,
+        }),
+      page(result, first) {
+        if (
+          result.kind !== 'page' ||
+          result.sessionId !== sessionId ||
+          (first !== undefined && result.storeVersion !== first.storeVersion)
+        ) {
+          throw invalidProjection('Plan');
+        }
+        return { source: result, items: result.items, nextCursor: result.nextCursor };
+      },
+    });
+    return planState(projection.first, projection.items);
+  }
+
+  controlPlan(input: PlanUserControlInput): Promise<OperationOutput<'plan.control'>> {
+    return this.#request('plan.control', input);
+  }
+
+  queryAgentGraph(
+    input: OperationInput<'agent.graph.query'>,
+  ): Promise<OperationOutput<'agent.graph.query'>> {
+    return this.#request('agent.graph.query', input);
+  }
+
+  queryAgentGraphOperator(
+    input: OperationInput<'agent.graph.operator.query'>,
+  ): Promise<OperationOutput<'agent.graph.operator.query'>> {
+    return this.#request('agent.graph.operator.query', input);
+  }
+
+  stopAgentGraph(
+    input: OperationInput<'agent.graph.stop'>,
+  ): Promise<OperationOutput<'agent.graph.stop'>> {
+    return this.#request('agent.graph.stop', input);
+  }
+
+  queryDeepResearch(
+    sessionId: string,
+  ): Promise<OperationOutput<'deep-research.query'>> {
+    return this.#request('deep-research.query', { sessionId });
+  }
+
+  async listRuntimeResources(sessionId: string): Promise<ShellRunUpdate[]> {
+    const projection = await collectStableProjection({
+      name: 'Runtime Resource',
+      sessionId,
+      start: () => this.#request('runtime.resource.query', { kind: 'list_start', sessionId }),
+      continue: (first, cursor) =>
+        this.#request('runtime.resource.query', {
+          kind: 'list_continue',
+          sessionId,
+          revision: first.revision,
+          cursor,
+        }),
+      page(result, first) {
+        if (
+          result.kind !== 'page' ||
+          result.sessionId !== sessionId ||
+          (first !== undefined && result.revision !== first.revision)
+        ) {
+          throw invalidProjection('Runtime Resource');
+        }
+        return { source: result, items: result.resources, nextCursor: result.nextCursor };
+      },
+    });
+    return projection.items;
+  }
+
+  async getRuntimeResource(sessionId: string, ref: string): Promise<ShellRunUpdate | null> {
+    const result = await this.#request('runtime.resource.query', { kind: 'get', sessionId, ref });
+    if (result.kind !== 'resource' || result.sessionId !== sessionId) {
+      throw invalidProjection('Runtime Resource');
+    }
+    return result.resource;
+  }
+
+  acquireRuntimeResourceController(
+    input: OperationInput<'runtime.resource.controller.acquire'>,
+  ): Promise<OperationOutput<'runtime.resource.controller.acquire'>> {
+    return this.#request('runtime.resource.controller.acquire', input);
+  }
+
+  controlRuntimeResource(
+    input: OperationInput<'runtime.resource.controller.control'>,
+  ): Promise<OperationOutput<'runtime.resource.controller.control'>> {
+    return this.#request('runtime.resource.controller.control', input);
+  }
+
+  releaseRuntimeResourceController(
+    input: OperationInput<'runtime.resource.controller.release'>,
+  ): Promise<OperationOutput<'runtime.resource.controller.release'>> {
+    return this.#request('runtime.resource.controller.release', input);
+  }
+
+  stopRuntimeResource(
+    input: OperationInput<'runtime.resource.stop'>,
+  ): Promise<OperationOutput<'runtime.resource.stop'>> {
+    return this.#request('runtime.resource.stop', input);
+  }
+
   async openSession(sessionId: string): Promise<DesktopRuntimeHostSession> {
     this.#assertOpen();
     const subscription = await this.connection.openSessionSubscription({ sessionId });
@@ -482,5 +665,88 @@ function revisionConflict(operation: string, sessionId: string): DesktopRuntimeH
   return new DesktopRuntimeHostClientError(
     'revision_conflict',
     `Runtime Host Session kept changing during ${operation}: ${sessionId}`,
+  );
+}
+
+function planState(
+  first: Extract<PlanQueryResult, { kind: 'page' }>,
+  items: readonly PlanProjectionItem[],
+): PlanSessionState {
+  return {
+    schemaVersion: 1,
+    sessionId: first.sessionId,
+    storeVersion: first.storeVersion,
+    proposals: items.flatMap((item) => (item.kind === 'proposal' ? [item.proposal] : [])),
+    executions: items.flatMap((item) => (item.kind === 'execution' ? [item.execution] : [])),
+    ...(first.latestProposalId === null ? {} : { latestProposalId: first.latestProposalId }),
+    ...(first.activeExecutionId === null ? {} : { activeExecutionId: first.activeExecutionId }),
+  };
+}
+
+interface StableProjectionPage<TResult extends { kind: string }, TItem> {
+  source: Exclude<TResult, { kind: 'revision_changed' }>;
+  items: readonly TItem[];
+  nextCursor: string | null;
+}
+
+async function collectStableProjection<
+  TResult extends { kind: string },
+  TItem,
+>(options: {
+  name: string;
+  sessionId: string;
+  start(): Promise<TResult>;
+  continue(
+    first: Exclude<TResult, { kind: 'revision_changed' }>,
+    cursor: string,
+  ): Promise<TResult>;
+  page(
+    result: TResult,
+    first: Exclude<TResult, { kind: 'revision_changed' }> | undefined,
+  ): StableProjectionPage<TResult, TItem>;
+}): Promise<{ first: Exclude<TResult, { kind: 'revision_changed' }>; items: TItem[] }> {
+  for (let attempt = 0; attempt < MAX_OPTIMISTIC_ATTEMPTS; attempt += 1) {
+    const initial = await options.start();
+    if (initial.kind === 'revision_changed') throw invalidProjection(options.name);
+    const first = options.page(initial, undefined);
+    const items = [...first.items];
+    const cursors = new Set<string>();
+    let cursor = first.nextCursor;
+    let retry = false;
+    while (cursor !== null) {
+      if (cursors.has(cursor)) throw repeatedCursor(options.name);
+      cursors.add(cursor);
+      const result = await options.continue(first.source, cursor);
+      if (result.kind === 'revision_changed') {
+        retry = true;
+        break;
+      }
+      const page = options.page(result, first.source);
+      items.push(...page.items);
+      cursor = page.nextCursor;
+    }
+    if (!retry) return { first: first.source, items };
+  }
+  throw unstableProjection(options.name, options.sessionId);
+}
+
+function invalidProjection(name: string): DesktopRuntimeHostClientError {
+  return new DesktopRuntimeHostClientError(
+    'projection_unstable',
+    `Runtime Host returned an invalid ${name} projection`,
+  );
+}
+
+function repeatedCursor(name: string): DesktopRuntimeHostClientError {
+  return new DesktopRuntimeHostClientError(
+    'projection_unstable',
+    `Runtime Host repeated a ${name} cursor`,
+  );
+}
+
+function unstableProjection(name: string, sessionId: string): DesktopRuntimeHostClientError {
+  return new DesktopRuntimeHostClientError(
+    'projection_unstable',
+    `Runtime Host ${name} kept changing while Desktop read Session ${sessionId}`,
   );
 }

--- a/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from 'node:crypto';
+import type { IpcMain } from 'electron';
+import type {
+  AgentGraphClientChangedEvent,
+  AgentGraphClientSnapshot,
+  AgentGraphClientSnapshotOptions,
+  AgentGraphOperatorInspection,
+  GoalState,
+} from '@maka/runtime';
+import type { GoalProjection, SessionDomainChange } from '@maka/runtime-host/protocol';
+import type { DesktopRuntimeHostClient } from './runtime-host-client.js';
+import { projectHostedDeepResearch } from './deep-research-desktop-projection.js';
+
+type RuntimeHostSessionDomainClient = Pick<
+  DesktopRuntimeHostClient,
+  | 'clearGoal'
+  | 'controlPlan'
+  | 'getRuntimeResource'
+  | 'getPlanState'
+  | 'listRuntimeResources'
+  | 'listTasks'
+  | 'queryAgentGraph'
+  | 'queryAgentGraphOperator'
+  | 'queryDeepResearch'
+  | 'queryGoal'
+  | 'stopAgentGraph'
+>;
+
+export interface RuntimeHostSessionDomainsIpcDeps {
+  client: RuntimeHostSessionDomainClient;
+  emitModeChanged(sessionId: string): void;
+  sendToRenderer?(channel: string, payload: unknown): void;
+  now?: () => number;
+  newId?: () => string;
+  onError?: (error: unknown) => void;
+}
+
+export interface RuntimeHostSessionDomainsIpcHandle {
+  sessionDomainChanged(change: SessionDomainChange): void;
+  agentGraphChanged(event: AgentGraphClientChangedEvent): void;
+}
+
+/**
+ * Adapt Host-owned Session sidecars to the existing Desktop renderer facade.
+ *
+ * This remains an isolated M4 candidate. Production keeps registering the
+ * embedded handlers until M5 switches the complete ownership path at once.
+ */
+export function registerRuntimeHostSessionDomainsIpc(
+  deps: RuntimeHostSessionDomainsIpcDeps,
+  ipcMain: Pick<IpcMain, 'handle'>,
+): RuntimeHostSessionDomainsIpcHandle {
+  const newId = deps.newId ?? randomUUID;
+  const now = deps.now ?? Date.now;
+
+  ipcMain.handle('tasks:list', (_event, sessionId: unknown) =>
+    deps.client.listTasks(requiredId(sessionId, 'Session')),
+  );
+  ipcMain.handle('shell-runs:list', (_event, sessionId: unknown) =>
+    deps.client.listRuntimeResources(requiredId(sessionId, 'Session')),
+  );
+  ipcMain.handle('deepResearch:get', async (_event, sessionId: unknown) =>
+    projectHostedDeepResearch(
+      await deps.client.queryDeepResearch(requiredId(sessionId, 'Session')),
+    ),
+  );
+
+  ipcMain.handle('goal:get', async (_event, sessionId: unknown) => {
+    const result = await deps.client.queryGoal(requiredId(sessionId, 'Session'));
+    return result.goal === null ? null : toDesktopGoal(result.goal);
+  });
+  ipcMain.handle('goal:clear', async (_event, sessionId: unknown) => {
+    await deps.client.clearGoal(requiredId(sessionId, 'Session'));
+  });
+
+  ipcMain.handle('plan-mode:getState', (_event, sessionId: unknown) =>
+    deps.client.getPlanState(requiredId(sessionId, 'Session')),
+  );
+  ipcMain.handle(
+    'plan-mode:requestRevision',
+    async (_event, sessionId: unknown, proposalId: unknown) => {
+      const normalizedSessionId = requiredId(sessionId, 'Session');
+      await deps.client.controlPlan({
+        kind: 'request_revision',
+        sessionId: normalizedSessionId,
+        proposalId: requiredId(proposalId, 'Plan proposal'),
+        operationId: newId(),
+      });
+      deps.emitModeChanged(normalizedSessionId);
+      return deps.client.getPlanState(normalizedSessionId);
+    },
+  );
+  ipcMain.handle(
+    'plan-mode:abandon',
+    async (_event, sessionId: unknown, proposalId: unknown) => {
+      const normalizedSessionId = requiredId(sessionId, 'Session');
+      await deps.client.controlPlan({
+        kind: 'abandon_proposal',
+        sessionId: normalizedSessionId,
+        proposalId: requiredId(proposalId, 'Plan proposal'),
+        operationId: newId(),
+      });
+      deps.emitModeChanged(normalizedSessionId);
+      return deps.client.getPlanState(normalizedSessionId);
+    },
+  );
+  ipcMain.handle(
+    'plan-mode:abandonExecution',
+    async (_event, sessionId: unknown, executionId: unknown) => {
+      const normalizedSessionId = requiredId(sessionId, 'Session');
+      await deps.client.controlPlan({
+        kind: 'cancel_execution',
+        sessionId: normalizedSessionId,
+        executionId: requiredId(executionId, 'Plan execution'),
+        operationId: newId(),
+      });
+      deps.emitModeChanged(normalizedSessionId);
+      return deps.client.getPlanState(normalizedSessionId);
+    },
+  );
+  ipcMain.handle(
+    'graphs:getSnapshot',
+    async (_event, rootSessionId: unknown, options?: unknown): Promise<AgentGraphClientSnapshot> =>
+      mutableGraphSnapshot(
+        await deps.client.queryAgentGraph({
+          rootSessionId: requiredId(rootSessionId, 'root Session'),
+          ...snapshotOptions(options),
+        }),
+      ),
+  );
+  ipcMain.handle(
+    'graphs:inspectOperator',
+    async (
+      _event,
+      rootSessionId: unknown,
+      operatorId: unknown,
+    ): Promise<AgentGraphOperatorInspection> =>
+      mutableGraphInspection(
+        await deps.client.queryAgentGraphOperator({
+          rootSessionId: requiredId(rootSessionId, 'root Session'),
+          operatorId: requiredId(operatorId, 'Agent graph operator'),
+        }),
+      ),
+  );
+  ipcMain.handle('graphs:stop', async (_event, rootSessionId: unknown) => {
+    await deps.client.stopAgentGraph({
+      rootSessionId: requiredId(rootSessionId, 'root Session'),
+    });
+  });
+
+  return {
+    sessionDomainChanged(change) {
+      switch (change.domain) {
+        case 'task':
+          deps.sendToRenderer?.('tasks:changed', {
+            sessionId: change.sessionId,
+            taskIds: [],
+            at: now(),
+          });
+          break;
+        case 'deep_research':
+          deps.sendToRenderer?.('deepResearch:changed', {
+            sessionId: change.sessionId,
+            ts: now(),
+          });
+          break;
+        case 'plan':
+          deps.sendToRenderer?.('plan-mode:changed', { sessionId: change.sessionId });
+          break;
+        case 'runtime_resource':
+          void refreshRuntimeResources(deps, change.sessionId, change.resources);
+          break;
+      }
+    },
+    agentGraphChanged(event) {
+      deps.sendToRenderer?.('graphs:changed', event);
+    },
+  };
+}
+
+async function refreshRuntimeResources(
+  deps: RuntimeHostSessionDomainsIpcDeps,
+  sessionId: string,
+  resources: readonly { ref: string }[],
+): Promise<void> {
+  for (const resource of resources) {
+    try {
+      const update = await deps.client.getRuntimeResource(sessionId, resource.ref);
+      if (update) deps.sendToRenderer?.('shell-runs:update', update);
+    } catch (error) {
+      deps.onError?.(error);
+    }
+  }
+}
+
+function toDesktopGoal(goal: GoalProjection): GoalState {
+  return {
+    id: goal.goalId,
+    revision: goal.revision,
+    sessionId: goal.sessionId,
+    condition: goal.condition,
+    status: goal.status,
+    setAt: goal.setAt,
+    iterations: goal.iterations,
+    maxIterations: goal.maxIterations,
+    consecutiveNoProgress: goal.consecutiveNoProgress,
+    blockCap: goal.blockCap,
+    ...(goal.tokenBudget === null ? {} : { tokenBudget: goal.tokenBudget }),
+    tokensAtStart: 0,
+    tokensNow: goal.tokensSpent,
+    tokensBaselinePending: false,
+    ...(goal.lastReason === null ? {} : { lastReason: goal.lastReason }),
+    ...(goal.achievedAt === null ? {} : { achievedAt: goal.achievedAt }),
+    ...(goal.pausedAt === null ? {} : { pausedAt: goal.pausedAt }),
+  };
+}
+
+function snapshotOptions(value: unknown): AgentGraphClientSnapshotOptions {
+  if (value === undefined) return {};
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('Invalid agent graph snapshot options');
+  }
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).some((key) => key !== 'terminalCursor')) {
+    throw new TypeError('Invalid agent graph snapshot options');
+  }
+  return record.terminalCursor === undefined
+    ? {}
+    : { terminalCursor: requiredId(record.terminalCursor, 'Agent graph terminal cursor', 2_048) };
+}
+
+function mutableGraphSnapshot(
+  snapshot: Awaited<ReturnType<RuntimeHostSessionDomainClient['queryAgentGraph']>>,
+): AgentGraphClientSnapshot {
+  return structuredClone(snapshot) as AgentGraphClientSnapshot;
+}
+
+function mutableGraphInspection(
+  inspection: Awaited<ReturnType<RuntimeHostSessionDomainClient['queryAgentGraphOperator']>>,
+): AgentGraphOperatorInspection {
+  return structuredClone(inspection) as AgentGraphOperatorInspection;
+}
+
+function requiredId(value: unknown, name: string, maxLength = 512): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new TypeError(`Invalid ${name} id`);
+  }
+  return value;
+}

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -4,10 +4,12 @@ import type {
   SessionEvent,
   StoredMessage,
 } from '@maka/core';
+import type { AgentGraphClientChangedEvent } from '@maka/runtime';
 import type {
   InteractionAnsweredSnapshot,
   InteractionPendingSnapshot,
   SessionMessageQueueProjection,
+  SessionDomainChange,
   SessionContinuitySnapshot,
   SteeringMessageSnapshot,
   SubscriptionFrame,
@@ -36,6 +38,8 @@ export interface RuntimeHostSessionObserverDeps {
     sessionId: string,
     extra?: { turnId?: string },
   ) => void;
+  emitSessionDomainChanged?: (change: SessionDomainChange) => void;
+  emitAgentGraphChanged?: (event: AgentGraphClientChangedEvent) => void;
   now?: () => number;
 }
 
@@ -90,12 +94,16 @@ export class RuntimeHostSessionObserver {
   readonly #observers = new Map<string, ObserverRegistration>();
   readonly #client: SessionObserverClient;
   readonly #emitSessionsChanged: RuntimeHostSessionObserverDeps['emitSessionsChanged'];
+  readonly #emitSessionDomainChanged: (change: SessionDomainChange) => void;
+  readonly #emitAgentGraphChanged: (event: AgentGraphClientChangedEvent) => void;
   readonly #now: () => number;
   #closed = false;
 
   constructor(deps: RuntimeHostSessionObserverDeps) {
     this.#client = deps.client;
     this.#emitSessionsChanged = deps.emitSessionsChanged;
+    this.#emitSessionDomainChanged = deps.emitSessionDomainChanged ?? (() => undefined);
+    this.#emitAgentGraphChanged = deps.emitAgentGraphChanged ?? (() => undefined);
     this.#now = deps.now ?? Date.now;
   }
 
@@ -433,8 +441,21 @@ export class RuntimeHostSessionObserver {
       this.#acceptProjection(state, frame.snapshot);
       return;
     }
+    if (frame.kind === 'subscription.session_domain_changed') {
+      this.#emitSessionDomainChanged(
+        frame.domain === 'runtime_resource'
+          ? { sessionId: frame.sessionId, domain: frame.domain, resources: frame.resources }
+          : { sessionId: frame.sessionId, domain: frame.domain },
+      );
+      return;
+    }
     if (frame.kind === 'subscription.agent_graph_changed') {
-      this.#emitSessionsChanged('status-change', state.sessionId);
+      this.#emitAgentGraphChanged({
+        schemaVersion: 1,
+        rootSessionId: frame.rootSessionId,
+        graphId: frame.graphId,
+        reason: frame.reason,
+      });
       return;
     }
     if (frame.reason === 'session_removed') {
@@ -451,6 +472,9 @@ export class RuntimeHostSessionObserver {
   #acceptProjection(state: ObservedSessionState, snapshot: SessionContinuitySnapshot): void {
     const previous = state.snapshot;
     state.snapshot = structuredClone(snapshot);
+    if (!sameGoal(previous?.goal, snapshot.goal)) {
+      this.#emitSessionsChanged('goal-change', state.sessionId);
+    }
     for (const interaction of newlyPendingInteractions(previous, snapshot)) {
       for (const event of projectInteractionRequest(interaction, this.#now())) {
         this.#broadcast(state.sessionId, event);
@@ -796,6 +820,14 @@ function sameTerminalTurn(previous: TurnSnapshot | null | undefined, next: TurnS
     previous.runId === next.runId &&
     previous.terminalEventId === next.terminalEventId
   );
+}
+
+function sameGoal(
+  previous: SessionContinuitySnapshot['goal'] | undefined,
+  next: SessionContinuitySnapshot['goal'],
+): boolean {
+  if (previous === null || previous === undefined) return next === null;
+  return next !== null && previous.goalId === next.goalId && previous.revision === next.revision;
 }
 
 function abortReason(source: string): Extract<SessionEvent, { type: 'abort' }>['reason'] {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -76,7 +76,7 @@ import type {
   Task,
   TaskLedgerChangedEvent,
   DeepResearchChangedEvent,
-  DeepResearchRun,
+  DeepResearchClientProgress,
   LocalMemoryEntryPreview,
 } from '@maka/core';
 import type { SessionTrace } from '@maka/core/session-trace';
@@ -205,7 +205,7 @@ export interface MakaBridge {
     subscribeChanges(handler: (event: TaskLedgerChangedEvent) => void): () => void;
   };
   deepResearch: {
-    get(sessionId: string): Promise<DeepResearchRun | undefined>;
+    get(sessionId: string): Promise<DeepResearchClientProgress | undefined>;
     subscribeChanges(handler: (event: DeepResearchChangedEvent) => void): () => void;
   };
   graphs: {
@@ -290,6 +290,7 @@ export interface MakaBridge {
     setCollaborationMode(sessionId: string, mode: CollaborationMode): Promise<SessionSummary>;
     setOrchestrationMode(sessionId: string, mode: OrchestrationMode): Promise<SessionSummary>;
     getPlanState(sessionId: string): Promise<PlanSessionState>;
+    subscribePlanChanges(sessionId: string, handler: () => void): () => void;
     requestPlanRevision(sessionId: string, proposalId: string): Promise<PlanSessionState>;
     abandonPlanProposal(
       sessionId: string,

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -90,7 +90,7 @@ import type {
   Task,
   TaskLedgerChangedEvent,
   DeepResearchChangedEvent,
-  DeepResearchRun,
+  DeepResearchClientProgress,
 } from '@maka/core';
 import type { SessionTrace } from '@maka/core/session-trace';
 import type {
@@ -136,7 +136,7 @@ const makaBridge = {
     },
   },
   deepResearch: {
-    get(sessionId: string): Promise<DeepResearchRun | undefined> {
+    get(sessionId: string): Promise<DeepResearchClientProgress | undefined> {
       return ipcRenderer.invoke('deepResearch:get', sessionId);
     },
     subscribeChanges(handler: (event: DeepResearchChangedEvent) => void): () => void {
@@ -320,6 +320,14 @@ const makaBridge = {
     },
     getPlanState(sessionId: string): Promise<PlanSessionState> {
       return ipcRenderer.invoke('plan-mode:getState', sessionId);
+    },
+    subscribePlanChanges(sessionId: string, handler: () => void): () => void {
+      const channel = 'plan-mode:changed';
+      const listener = (_event: Electron.IpcRendererEvent, payload: { sessionId: string }) => {
+        if (payload.sessionId === sessionId) handler();
+      };
+      ipcRenderer.on(channel, listener);
+      return () => ipcRenderer.off(channel, listener);
     },
     requestPlanRevision(sessionId: string, proposalId: string): Promise<PlanSessionState> {
       return ipcRenderer.invoke('plan-mode:requestRevision', sessionId, proposalId);

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -17,7 +17,6 @@ import type {
   UiLocalePreference,
 } from '@maka/core';
 import {
-  buildDeepResearchImplementationPrompt,
   collapseSessionRevisions,
   filterLinkedSessionTree,
   hasSettledInitialOnboarding,
@@ -2468,7 +2467,16 @@ function AppShellContent({
                   iterations: activeGoal.iterations,
                   maxIterations: activeGoal.maxIterations,
                             onClear: () => {
-                              void window.maka.goal.clear(activeGoal.sessionId);
+                              void window.maka.goal.clear(activeGoal.sessionId).catch((error) => {
+                                toastApi.error(
+                                  shellCopy.goalClearFailedTitle,
+                                  localizedShellErrorMessage(
+                                    error,
+                                    shellCopy.goalClearFailedFallback,
+                                    uiLocale,
+                                  ),
+                                );
+                              });
                             },
                           }
                         : undefined
@@ -2529,7 +2537,8 @@ function AppShellContent({
                     : undefined
                 }
                 onContinueDeepResearchHandoff={(run) => {
-                  const prompt = buildDeepResearchImplementationPrompt(run);
+                  const prompt = run.implementationPrompt;
+                  if (!prompt) return;
                   void createSession().then(() => {
                     window.requestAnimationFrame(() => {
                       composerRef.current?.setText(prompt);

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -367,6 +367,8 @@ type ShellCopy = {
     resumeStartedDescription: string;
     resumeFailedTitle: string;
     resumeFailedFallback: string;
+    goalClearFailedTitle: string;
+    goalClearFailedFallback: string;
     appearanceLoadErrorTitle: string;
     appearanceLoadErrorFallback: string;
     memoryRefreshErrorTitle: string;
@@ -1032,6 +1034,8 @@ const SHELL_COPY_BY_LOCALE = {
       resumeStartedDescription: '正在从最后一个完整执行边界继续',
       resumeFailedTitle: '恢复失败',
       resumeFailedFallback: '无法启动安全恢复，请检查会话状态后重试。',
+      goalClearFailedTitle: '停止目标失败',
+      goalClearFailedFallback: '目标仍可能继续运行，请立即重试。',
       appearanceLoadErrorTitle: '载入外观设置失败',
       appearanceLoadErrorFallback: '外观设置暂时无法载入，请稍后重试。',
       memoryRefreshErrorTitle: '刷新本地记忆状态失败',
@@ -1535,6 +1539,8 @@ const SHELL_COPY_BY_LOCALE = {
       resumeStartedDescription: 'Continuing from the last complete execution boundary',
       resumeFailedTitle: 'Recovery failed',
       resumeFailedFallback: 'Safe recovery could not start. Check the conversation state and try again.',
+      goalClearFailedTitle: 'Could not stop the goal',
+      goalClearFailedFallback: 'The goal may still be running. Try again now.',
       appearanceLoadErrorTitle: 'Could not load appearance settings',
       appearanceLoadErrorFallback: 'Appearance settings are temporarily unavailable. Try again later.',
       memoryRefreshErrorTitle: 'Could not refresh local memory status',

--- a/apps/desktop/src/renderer/plan-mode-panel.tsx
+++ b/apps/desktop/src/renderer/plan-mode-panel.tsx
@@ -36,7 +36,7 @@ export function usePlanModeState(session: SessionSummary | undefined): PlanModeS
     if (!session) return;
     const refreshOrReport = () => void refresh().catch((cause) => setError(message(cause)));
     refreshOrReport();
-    return window.maka.sessions.subscribeEvents(session.id, (event: SessionEvent) => {
+    const unsubscribeEvents = window.maka.sessions.subscribeEvents(session.id, (event: SessionEvent) => {
       if (
         event.type === 'plan_submitted'
         || event.type === 'complete'
@@ -46,6 +46,14 @@ export function usePlanModeState(session: SessionSummary | undefined): PlanModeS
         refreshOrReport();
       }
     });
+    const unsubscribePlanChanges = window.maka.sessions.subscribePlanChanges(
+      session.id,
+      refreshOrReport,
+    );
+    return () => {
+      unsubscribeEvents();
+      unsubscribePlanChanges();
+    };
   }, [session?.id, session?.collaborationMode, refresh]);
 
   const run = useCallback(async (action: () => Promise<void>): Promise<void> => {

--- a/apps/desktop/src/renderer/use-deep-research-run.ts
+++ b/apps/desktop/src/renderer/use-deep-research-run.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import type { DeepResearchRun } from '@maka/core';
+import type { DeepResearchClientProgress } from '@maka/core';
 
 export function useDeepResearchRun(
   sessionId: string | undefined,
   enabled: boolean,
-): DeepResearchRun | undefined {
-  const [run, setRun] = useState<DeepResearchRun>();
+): DeepResearchClientProgress | undefined {
+  const [run, setRun] = useState<DeepResearchClientProgress>();
 
   useEffect(() => {
     let active = true;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,7 @@
     "./task-ledger": "./dist/task-ledger.js",
     "./foreign-session": "./dist/foreign-session.js",
     "./deep-research-run": "./dist/deep-research-run.js",
+    "./deep-research-client-progress": "./dist/deep-research-client-progress.js",
     "./daily-review": "./dist/daily-review.js",
     "./explore-agent": "./dist/explore-agent.js",
     "./memory": "./dist/memory.js",

--- a/packages/core/src/deep-research-client-progress.ts
+++ b/packages/core/src/deep-research-client-progress.ts
@@ -1,0 +1,134 @@
+import { buildDeepResearchImplementationPrompt } from './explore-agent.js';
+import {
+  DEEP_RESEARCH_CLIENT_IMPLEMENTATION_PROMPT_MAX_BYTES,
+  DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES,
+  DEEP_RESEARCH_CLIENT_PROGRESS_MAX_BYTES,
+  DEEP_RESEARCH_CLIENT_RECENT_ITEMS_MAX,
+  DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES,
+  type DeepResearchClientProgress,
+  type DeepResearchRun,
+} from './deep-research-run.js';
+
+/** Build the single bounded product projection used by local and hosted clients. */
+export function projectDeepResearchClientProgress(
+  run: DeepResearchRun,
+): DeepResearchClientProgress {
+  const blockers = [
+    ...run.checklist.flatMap((item) =>
+      item.blockedReason ? [labeledBlocker(item.title, item.blockedReason)] : [],
+    ),
+    ...run.steps.flatMap((step) =>
+      step.blockedReason ? [labeledBlocker(step.objective, step.blockedReason)] : [],
+    ),
+  ];
+  const base: DeepResearchClientProgress = {
+    sessionId: run.sessionId,
+    objective: truncateUtf8(run.objective, DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES),
+    scopeLevel: run.scopeLevel,
+    status: run.status,
+    stage: run.stage,
+    round: run.round,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    artifactsCount: run.artifacts.length,
+    stepsCount: run.steps.length,
+    checklist: run.checklist.map((item) => ({
+      itemId: item.itemId,
+      title: truncateUtf8(item.title, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES),
+      status: item.status,
+      ...(item.blockedReason
+        ? { blockedReason: truncateUtf8(item.blockedReason, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES) }
+        : {}),
+    })),
+    reportSections: run.reportSections.map(({ key, status }) => ({ key, status })),
+    recentInspectedRefs: run.steps
+      .flatMap((step) => step.inspectedRefs)
+      .slice(-DEEP_RESEARCH_CLIENT_RECENT_ITEMS_MAX)
+      .map((ref) => ({
+        kind: ref.kind,
+        locator: truncateUtf8(ref.locator, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES),
+        ...(ref.label
+          ? { label: truncateUtf8(ref.label, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES) }
+          : {}),
+      })),
+    workerRunIds: [...new Set(run.steps.flatMap((step) => step.workerRunIds))].slice(
+      -DEEP_RESEARCH_CLIENT_RECENT_ITEMS_MAX,
+    ),
+    blockers: [
+      ...new Set(blockers.map((value) => truncateUtf8(value, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES))),
+    ].slice(-DEEP_RESEARCH_CLIENT_RECENT_ITEMS_MAX),
+    ...(run.reportArtifactId ? { reportArtifactId: run.reportArtifactId } : {}),
+  };
+  if (encodedBytes(base) > DEEP_RESEARCH_CLIENT_PROGRESS_MAX_BYTES) {
+    throw new Error('Deep Research client progress cannot fit its required fields');
+  }
+  if (run.status !== 'completed') return base;
+  return fitImplementationPrompt(base, buildDeepResearchImplementationPrompt(run));
+}
+
+function labeledBlocker(label: string, reason: string): string {
+  const separator = ': ';
+  const reasonBudget = Math.floor(DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES * 0.75);
+  const boundedReason = truncateUtf8(reason, reasonBudget);
+  const titleBudget =
+    DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES - utf8Bytes(separator) - utf8Bytes(boundedReason);
+  return `${truncateUtf8(label, titleBudget)}${separator}${boundedReason}`;
+}
+
+function fitImplementationPrompt(
+  base: DeepResearchClientProgress,
+  prompt: string,
+): DeepResearchClientProgress {
+  const bounded = truncateUtf8(prompt, DEEP_RESEARCH_CLIENT_IMPLEMENTATION_PROMPT_MAX_BYTES);
+  const full = { ...base, implementationPrompt: bounded };
+  if (encodedBytes(full) <= DEEP_RESEARCH_CLIENT_PROGRESS_MAX_BYTES) return full;
+  const characters = Array.from(bounded);
+  let low = 1;
+  let high = characters.length;
+  let best = base;
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidate = {
+      ...base,
+      implementationPrompt: truncateCharacters(bounded, midpoint),
+    };
+    if (encodedBytes(candidate) <= DEEP_RESEARCH_CLIENT_PROGRESS_MAX_BYTES) {
+      best = candidate;
+      low = midpoint + 1;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+  return best;
+}
+
+function truncateCharacters(value: string, maxCharacters: number): string {
+  const characters = Array.from(value);
+  if (characters.length <= maxCharacters) return value;
+  if (maxCharacters === 1) return characters[0] ?? '…';
+  return `${characters.slice(0, maxCharacters - 1).join('')}…`;
+}
+
+function encodedBytes(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(value).byteLength <= maxBytes) return value;
+  const marker = '…';
+  const markerBytes = encoder.encode(marker).byteLength;
+  let bytes = 0;
+  let output = '';
+  for (const character of value) {
+    const characterBytes = encoder.encode(character).byteLength;
+    if (bytes + characterBytes + markerBytes > maxBytes) break;
+    output += character;
+    bytes += characterBytes;
+  }
+  return `${output}${marker}`;
+}

--- a/packages/core/src/deep-research-run.ts
+++ b/packages/core/src/deep-research-run.ts
@@ -99,6 +99,11 @@ export const DEEP_RESEARCH_STEPS_MAX = 500;
 export const DEEP_RESEARCH_STEP_TEXT_MAX_CHARS = 2_000;
 export const DEEP_RESEARCH_STEP_LIST_ITEMS_MAX = 50;
 export const DEEP_RESEARCH_INSPECTED_REFS_MAX = 200;
+export const DEEP_RESEARCH_CLIENT_PROGRESS_MAX_BYTES = 46 * 1024;
+export const DEEP_RESEARCH_CLIENT_RECENT_ITEMS_MAX = 8;
+export const DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES = 4 * 1024;
+export const DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES = 256;
+export const DEEP_RESEARCH_CLIENT_IMPLEMENTATION_PROMPT_MAX_BYTES = 16 * 1024;
 
 export const DEEP_RESEARCH_DEFAULT_CHECKLIST = [
   { itemId: 'project_entrypoints', title: 'Map project entrypoints and execution setup' },
@@ -263,6 +268,29 @@ export interface DeepResearchRun {
   reportArtifactId?: string;
   handoff?: DeepResearchHandoff;
   completedAt?: number;
+}
+
+/** Bounded product-facing progress shared by local and Host-backed clients. */
+export interface DeepResearchClientProgress {
+  sessionId: string;
+  objective: string;
+  scopeLevel: DeepResearchScopeLevel;
+  status: DeepResearchRunStatus;
+  stage: DeepResearchStage;
+  round: number;
+  createdAt: number;
+  updatedAt: number;
+  artifactsCount: number;
+  stepsCount: number;
+  checklist: Array<
+    Pick<DeepResearchChecklistItem, 'itemId' | 'title' | 'status' | 'blockedReason'>
+  >;
+  reportSections: Array<Pick<DeepResearchReportSectionState, 'key' | 'status'>>;
+  recentInspectedRefs: Array<Pick<DeepResearchInspectedRef, 'kind' | 'locator' | 'label'>>;
+  workerRunIds: string[];
+  blockers: string[];
+  reportArtifactId?: string;
+  implementationPrompt?: string;
 }
 
 export interface DeepResearchProjection {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1150,6 +1150,7 @@ export type {
   DeepResearchArtifactRole,
   DeepResearchChecklistItem,
   DeepResearchChecklistStatus,
+  DeepResearchClientProgress,
   DeepResearchChangedEvent,
   DeepResearchCheckpoint,
   DeepResearchEvent,
@@ -1183,6 +1184,11 @@ export {
   DEEP_RESEARCH_CHECKPOINTS_MAX,
   DEEP_RESEARCH_CHECKLIST_ITEMS_MAX,
   DEEP_RESEARCH_CHECKLIST_STATUSES,
+  DEEP_RESEARCH_CLIENT_IMPLEMENTATION_PROMPT_MAX_BYTES,
+  DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES,
+  DEEP_RESEARCH_CLIENT_PROGRESS_MAX_BYTES,
+  DEEP_RESEARCH_CLIENT_RECENT_ITEMS_MAX,
+  DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES,
   DEEP_RESEARCH_DEFAULT_CHECKLIST,
   DEEP_RESEARCH_EVENT_TYPES,
   DEEP_RESEARCH_INSPECTED_REFS_MAX,
@@ -1213,6 +1219,7 @@ export {
   normalizeDeepResearchObjective,
   projectDeepResearchEvents,
 } from './deep-research-run.js';
+export { projectDeepResearchClientProgress } from './deep-research-client-progress.js';
 
 // memory.ts (PR-MEMORY-1) — core contract; no IPC/storage/embedding/UI.
 export type {

--- a/packages/runtime-host/src/__tests__/deep-research-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/deep-research-protocol.test.ts
@@ -41,6 +41,7 @@ const snapshot = {
   reportSections: [{ key: 'conclusion' as const, status: 'pending' as const }],
   recentInspectedRefs: [{ kind: 'file' as const, locator: 'src/main.ts', label: null }],
   workerRunIds: ['worker.run:1'],
+  blockers: [],
   reportArtifactId: null,
   implementationPrompt: null,
 };

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -42,6 +42,7 @@ const allowedServerExternalImports = new Set([
   '@maka/core/oauth-subscription',
   '@maka/core/plan',
   '@maka/core/deep-research-run',
+  '@maka/core/deep-research-client-progress',
   '@maka/core/daily-review',
   '@maka/core/redaction',
   '@maka/core/runtime-policy',

--- a/packages/runtime-host/src/__tests__/plan-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/plan-two-client-uds.test.ts
@@ -6,8 +6,12 @@ import { test } from 'node:test';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
 import { openInteractivePlanStoreForWrite } from '@maka/storage/plan-authority';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
-import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.js';
-import { RUNTIME_HOST_PROTOCOL_VERSION } from '../protocol/index.js';
+import {
+  connectRuntimeHost,
+  type RuntimeHostConnection,
+  type RuntimeHostSessionSubscription,
+} from '../client/index.js';
+import { RUNTIME_HOST_PROTOCOL_VERSION, type SubscriptionFrame } from '../protocol/index.js';
 import { createExecutionRuntimeHostComposition } from '../server/execution-composition.js';
 import { RuntimeHostKernel } from '../server/host-kernel.js';
 
@@ -63,6 +67,7 @@ test('two UDS Clients and a restarted production Host share one retry-safe Plan 
     });
     owner = undefined;
     [desktop, tui] = await Promise.all([connect(root, 'desktop'), connect(root, 'tui')]);
+    const subscription = await desktop.openSessionSubscription({ sessionId: session.id });
 
     const first = await desktop.queryPlan({ kind: 'list_start', sessionId: session.id });
     assert.equal(first.kind, 'page');
@@ -75,9 +80,16 @@ test('two UDS Clients and a restarted production Host share one retry-safe Plan 
       expectedStoreVersion: first.storeVersion,
       operationId: 'approve-operation',
     };
-    const approved = await desktop.controlPlan(approval);
+    const approved = await tui.controlPlan(approval);
     assert.equal(approved.eventType, 'plan_approved');
     assert.ok(approved.executionId);
+    const changed = await withTimeout(
+      nextFrameOfKind(subscription, 'subscription.session_domain_changed'),
+      2_000,
+      'Plan invalidation did not reach the other Client',
+    );
+    assert.equal(changed.sessionId, session.id);
+    assert.equal(changed.domain, 'plan');
 
     const shared = await tui.queryPlan({ kind: 'list_start', sessionId: session.id });
     assert.equal(shared.kind, 'page');
@@ -86,6 +98,7 @@ test('two UDS Clients and a restarted production Host share one retry-safe Plan 
       assert.equal(shared.items.filter((item) => item.kind === 'execution').length, 1);
     }
 
+    await subscription.close();
     await Promise.all([desktop.close(), tui.close()]);
     desktop = undefined;
     tui = undefined;
@@ -139,4 +152,32 @@ async function connect(
   assert.equal(result.kind, 'connected');
   if (result.kind !== 'connected') throw new Error('Unable to connect to Runtime Host');
   return result.connection;
+}
+
+async function nextFrameOfKind<K extends SubscriptionFrame['kind']>(
+  subscription: RuntimeHostSessionSubscription,
+  kind: K,
+): Promise<Extract<SubscriptionFrame, { kind: K }>> {
+  for await (const frame of subscription) {
+    if (frame.kind === kind) {
+      return frame as Extract<SubscriptionFrame, { kind: K }>;
+    }
+  }
+  throw new Error(`Session subscription ended before ${kind}`);
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
 }

--- a/packages/runtime-host/src/__tests__/runtime-resource-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-resource-coordinator.test.ts
@@ -112,10 +112,33 @@ describe('Host Runtime Resource coordinator', () => {
     );
     assert.equal(heavy.ok, true);
     assert.ok(Buffer.byteLength(JSON.stringify(heavy), 'utf8') < RUNTIME_RESOURCE_RESULT_MAX_BYTES);
+    assert.equal(harness.listReadCount, 0);
+    assert.equal(harness.pointReadCount, 2);
     if (!heavy.ok || heavy.result.kind !== 'resource') return;
     const output = heavy.result.resource?.result.output;
     assert.equal(output?.mode, 'pipes');
     assert.equal(output?.mode === 'pipes' && output.stdoutTruncated, true);
+  });
+
+  test('uses point reads for a full invalidation batch without rebuilding the list', async () => {
+    const harness = createHarness();
+    harness.updates = Array.from({ length: 64 }, (_, index) => resourceUpdate(index));
+
+    const results = await Promise.all(
+      harness.updates.map((update) =>
+        harness.coordinator.handlers['runtime.resource.query'](
+          { kind: 'get', sessionId: SESSION_ID, ref: update.result.ref },
+          connection('connection-1'),
+        ),
+      ),
+    );
+
+    assert.equal(
+      results.every((result) => result.ok && result.result.kind === 'resource'),
+      true,
+    );
+    assert.equal(harness.pointReadCount, 64);
+    assert.equal(harness.listReadCount, 0);
   });
 
   test('drains for canonical state failure but keeps projection failure scoped to its query', async () => {
@@ -338,6 +361,8 @@ function createHarness() {
     stopCount: 0,
     terminateCount: 0,
     drainCount: 0,
+    listReadCount: 0,
+    pointReadCount: 0,
     stateReadFailure: undefined as Error | undefined,
     activeResidencies: 0,
   };
@@ -409,8 +434,14 @@ function createHarness() {
     manager,
     sessions: {
       listShellRunUpdates: async () => {
+        state.listReadCount += 1;
         if (state.stateReadFailure) throw state.stateReadFailure;
         return structuredClone(state.updates);
+      },
+      getShellRunUpdate: async (_sessionId, ref) => {
+        state.pointReadCount += 1;
+        if (state.stateReadFailure) throw state.stateReadFailure;
+        return structuredClone(state.updates.find((update) => update.result.ref === ref) ?? null);
       },
     },
     sessionHeaders: {

--- a/packages/runtime-host/src/__tests__/runtime-resource-process.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-resource-process.test.ts
@@ -50,7 +50,11 @@ describe('real Host Runtime Resource process lifecycle', {
     });
     coordinator = new HostRuntimeResourceCoordinator({
       manager,
-      sessions: { listShellRunUpdates: (sessionId) => manager.listSessionUpdates(sessionId) },
+      sessions: {
+        listShellRunUpdates: (sessionId) => manager.listSessionUpdates(sessionId),
+        getShellRunUpdate: (sessionId, ref) =>
+          manager.getSessionUpdate(sessionId, ref).then((update) => update ?? null),
+      },
       sessionHeaders: {
         readHeader: async () => ({ status: 'idle', isArchived: false }),
       },

--- a/packages/runtime-host/src/__tests__/runtime-resource-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-resource-protocol.test.ts
@@ -7,6 +7,10 @@ import {
 } from '@maka/core';
 import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import {
+  decodeSubscriptionFrame,
+  SESSION_RUNTIME_RESOURCE_CHANGES_MAX,
+} from '../protocol/session-continuity.js';
+import {
   decodeRuntimeResourceControllerAcquireInput,
   decodeRuntimeResourceControllerAcquireResult,
   decodeRuntimeResourceControllerControlInput,
@@ -232,6 +236,44 @@ describe('Runtime Resource protocol', () => {
     );
     assertInvalid(() => decodeRuntimeResourceStopResult(oversized));
   });
+});
+
+test('Runtime Resource invalidations batch lightweight unique identities', () => {
+  const resources = Array.from({ length: SESSION_RUNTIME_RESOURCE_CHANGES_MAX }, (_, index) => ({
+    sourceSessionId: 'source-session',
+    ref: `maka://runtime/background-tasks/shell-${index}`,
+  }));
+  assert.deepEqual(
+    decodeSubscriptionFrame({
+      kind: 'subscription.session_domain_changed',
+      hostEpoch: 'host-1',
+      subscriptionId: 'subscription-1',
+      sequence: 1,
+      sessionId: 'child-session',
+      domain: 'runtime_resource',
+      resources,
+    }),
+    {
+      kind: 'subscription.session_domain_changed',
+      hostEpoch: 'host-1',
+      subscriptionId: 'subscription-1',
+      sequence: 1,
+      sessionId: 'child-session',
+      domain: 'runtime_resource',
+      resources,
+    },
+  );
+  assertInvalid(() =>
+    decodeSubscriptionFrame({
+      kind: 'subscription.session_domain_changed',
+      hostEpoch: 'host-1',
+      subscriptionId: 'subscription-1',
+      sequence: 1,
+      sessionId: 'child-session',
+      domain: 'runtime_resource',
+      resources: [resources[0], resources[0]],
+    }),
+  );
 });
 
 function resourceUpdate(overrides: Partial<ShellRunUpdate> = {}): ShellRunUpdate {

--- a/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { setImmediate as delayImmediate } from 'node:timers/promises';
 import test from 'node:test';
-import type { SessionEvent, SessionHeader, StoredMessage } from '@maka/core';
+import type { SessionEvent, SessionHeader, ShellRunUpdate, StoredMessage } from '@maka/core';
 import { TOOL_OUTPUT_DELTA_MAX_CHARS } from '@maka/core/events';
 import { PiAgentBackend, type PiAgentTransport } from '@maka/runtime';
 import {
@@ -334,6 +334,79 @@ test('coalesces Agent graph invalidations onto the Session subscription sequence
   coordinator.close();
 });
 
+test('coalesces typed domain invalidations without publishing continuity projections', async () => {
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+  );
+  const sink = new RecordingSink();
+  const connection = coordinator.attachConnection('connection-1', sink);
+  const opened = await open(coordinator, 'connection-1');
+  connection.activate(opened.subscriptionId);
+
+  coordinator.enqueueSessionDomainChanged(SESSION_ID, 'task');
+  coordinator.enqueueSessionDomainChanged(SESSION_ID, 'task');
+  coordinator.enqueueSessionDomainChanged(SESSION_ID, 'plan');
+  await waitFor(() => sink.frames.length === 2);
+
+  assert.deepEqual(
+    sink.frames.map((frame) =>
+      frame.kind === 'subscription.session_domain_changed'
+        ? { kind: frame.kind, sequence: frame.sequence, domain: frame.domain }
+        : frame.kind,
+    ),
+    [
+      { kind: 'subscription.session_domain_changed', sequence: 1, domain: 'task' },
+      { kind: 'subscription.session_domain_changed', sequence: 2, domain: 'plan' },
+    ],
+  );
+  coordinator.close();
+});
+
+test('fans one bounded Runtime Resource burst out to an inherited Session view', async () => {
+  const childSessionId = 'child-session';
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async (sessionId) => canonicalFor(sessionId),
+    new SessionAdmissionGate(),
+  );
+  const sink = new RecordingSink();
+  const connection = coordinator.attachConnection('connection-1', sink);
+  const outcome = await coordinator.handlers['subscription.open'](
+    { sessionId: childSessionId },
+    connectionContext('connection-1'),
+  );
+  assert.equal(outcome.ok, true);
+  if (!outcome.ok) return;
+  connection.activate(outcome.result.subscriptionId);
+  const updates = Array.from({ length: 64 }, (_, index) => {
+    const update = shellRunUpdate({
+      sessionId: 'parent-session',
+      sourceToolCallId: `tool-${index}`,
+    });
+    update.result.ref = `shell:run-${index}`;
+    return update;
+  });
+
+  for (const update of updates) coordinator.enqueueRuntimeResourceChanged(update);
+  await waitFor(() => sink.frames.length === 1);
+
+  assert.deepEqual(sink.frames[0], {
+    kind: 'subscription.session_domain_changed',
+    hostEpoch: HOST_EPOCH,
+    subscriptionId: outcome.result.subscriptionId,
+    sequence: 1,
+    sessionId: childSessionId,
+    domain: 'runtime_resource',
+    resources: updates.map((update) => ({
+      sourceSessionId: update.sessionId,
+      ref: update.result.ref,
+    })),
+  });
+  coordinator.close();
+});
+
 test('slow subscriber receives a terminal eviction without delaying another subscriber', async () => {
   const coordinator = new SessionContinuityCoordinator(
     HOST_EPOCH,
@@ -618,6 +691,44 @@ function canonical(
       followup: [],
     },
     interactions: overrides.interactions ?? { pending: [] },
+  };
+}
+
+function canonicalFor(sessionId: string): CanonicalSessionProjection {
+  const projection = canonical();
+  return {
+    ...projection,
+    session: { ...projection.session, sessionId },
+    rootTurn: projection.rootTurn ? { ...projection.rootTurn, sessionId } : null,
+  };
+}
+
+function shellRunUpdate(overrides: Partial<ShellRunUpdate> = {}): ShellRunUpdate {
+  return {
+    sessionId: SESSION_ID,
+    ownership: { kind: 'local' },
+    sourceTurnId: 'turn-1',
+    sourceToolCallId: 'tool-1',
+    result: {
+      kind: 'shell_run',
+      ref: 'shell:run-1',
+      mode: 'pipes',
+      status: 'running',
+      cwd: '/workspace',
+      cmd: 'sleep 60',
+      startedAt: 1,
+      updatedAt: 2,
+      revision: 2,
+      output: {
+        mode: 'pipes',
+        stdout: 'ready',
+        stderr: '',
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        redacted: false,
+      },
+    },
+    ...overrides,
   };
 }
 

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -480,6 +480,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
             case 'subscription.session_projection':
             case 'subscription.session_delta':
             case 'subscription.session_event':
+            case 'subscription.session_domain_changed':
             case 'subscription.agent_graph_changed':
             case 'subscription.closed':
               this.#acceptSubscriptionFrame(frame);

--- a/packages/runtime-host/src/client/session-subscription.ts
+++ b/packages/runtime-host/src/client/session-subscription.ts
@@ -249,7 +249,8 @@ export class ClientSessionSubscription
       this.#latestProjectionRevision = frame.snapshot.projectionRevision;
     } else if (
       (frame.kind === 'subscription.session_delta' ||
-        frame.kind === 'subscription.session_event') &&
+        frame.kind === 'subscription.session_event' ||
+        frame.kind === 'subscription.session_domain_changed') &&
       frame.sessionId !== this.#expectedSessionId
     ) {
       throw new RuntimeHostSubscriptionError(

--- a/packages/runtime-host/src/protocol/deep-research.ts
+++ b/packages/runtime-host/src/protocol/deep-research.ts
@@ -1,5 +1,9 @@
 import {
   DEEP_RESEARCH_CHECKLIST_ITEMS_MAX,
+  DEEP_RESEARCH_CLIENT_IMPLEMENTATION_PROMPT_MAX_BYTES,
+  DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES,
+  DEEP_RESEARCH_CLIENT_RECENT_ITEMS_MAX,
+  DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES,
   DEEP_RESEARCH_INSPECTED_REF_KINDS,
   DEEP_RESEARCH_REPORT_SECTION_KEYS,
   DEEP_RESEARCH_REPORT_SECTION_STATUSES,
@@ -8,6 +12,7 @@ import {
   DEEP_RESEARCH_STAGES,
   DEEP_RESEARCH_CHECKLIST_STATUSES,
   type DeepResearchChecklistStatus,
+  type DeepResearchClientProgress,
   type DeepResearchInspectedRefKind,
   type DeepResearchReportSectionKey,
   type DeepResearchReportSectionStatus,
@@ -27,10 +32,10 @@ import { invalidProtocolFrame } from './errors.js';
 import { defineOperation } from './operation-spec.js';
 
 export const DEEP_RESEARCH_RESULT_MAX_BYTES = 48 * 1024;
-export const DEEP_RESEARCH_RECENT_REFS_MAX = 8;
-export const DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES = 4 * 1024;
-export const DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES = 1024;
-export const DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_BYTES = 16 * 1024;
+export const DEEP_RESEARCH_RECENT_REFS_MAX = DEEP_RESEARCH_CLIENT_RECENT_ITEMS_MAX;
+export { DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES };
+export const DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_BYTES =
+  DEEP_RESEARCH_CLIENT_IMPLEMENTATION_PROMPT_MAX_BYTES;
 const DEEP_RESEARCH_STABLE_ID_MAX_BYTES = 128;
 const DEEP_RESEARCH_STABLE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 
@@ -89,9 +94,31 @@ export type DeepResearchQueryResult =
       readonly reportSections: readonly DeepResearchReportSectionProjection[];
       readonly recentInspectedRefs: readonly DeepResearchInspectedRefProjection[];
       readonly workerRunIds: readonly string[];
+      readonly blockers: readonly string[];
       readonly reportArtifactId: string | null;
       readonly implementationPrompt: string | null;
     };
+
+export function encodeDeepResearchSnapshot(
+  progress: DeepResearchClientProgress,
+  revision: number,
+): Extract<DeepResearchQueryResult, { kind: 'snapshot' }> {
+  return decodeDeepResearchQueryResult({
+    kind: 'snapshot',
+    revision,
+    ...progress,
+    checklist: progress.checklist.map((item) => ({
+      ...item,
+      blockedReason: item.blockedReason ?? null,
+    })),
+    recentInspectedRefs: progress.recentInspectedRefs.map((ref) => ({
+      ...ref,
+      label: ref.label ?? null,
+    })),
+    reportArtifactId: progress.reportArtifactId ?? null,
+    implementationPrompt: progress.implementationPrompt ?? null,
+  }) as Extract<DeepResearchQueryResult, { kind: 'snapshot' }>;
+}
 
 export const DEEP_RESEARCH_OPERATION_SPECS = {
   'deep-research.query': defineOperation<
@@ -137,6 +164,7 @@ export function decodeDeepResearchQueryResult(value: unknown): DeepResearchQuery
       'reportSections',
       'recentInspectedRefs',
       'workerRunIds',
+      'blockers',
       'reportArtifactId',
       'implementationPrompt',
     ],
@@ -172,6 +200,7 @@ export function decodeDeepResearchQueryResult(value: unknown): DeepResearchQuery
     'reportSections',
     'recentInspectedRefs',
     'workerRunIds',
+    'blockers',
     'reportArtifactId',
     'implementationPrompt',
   ]);
@@ -201,6 +230,7 @@ export function decodeDeepResearchQueryResult(value: unknown): DeepResearchQuery
     reportSections: decodeReportSections(record.reportSections),
     recentInspectedRefs: decodeInspectedRefs(record.recentInspectedRefs),
     workerRunIds: decodeIds(record.workerRunIds, 'Deep Research worker run ids'),
+    blockers: decodeTexts(record.blockers, 'Deep Research blockers'),
     reportArtifactId: nullableId(record.reportArtifactId, 'Deep Research report artifact id'),
     implementationPrompt: nullableText(
       record.implementationPrompt,
@@ -208,6 +238,13 @@ export function decodeDeepResearchQueryResult(value: unknown): DeepResearchQuery
       DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_BYTES,
     ),
   };
+}
+
+function decodeTexts(value: unknown, name: string): string[] {
+  if (!Array.isArray(value) || value.length > DEEP_RESEARCH_RECENT_REFS_MAX) {
+    throw invalidProtocolFrame(`Invalid ${name}`);
+  }
+  return value.map((item) => requireUtf8String(item, name, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES));
 }
 
 function decodeChecklist(value: unknown): DeepResearchChecklistProjection[] {

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -45,7 +45,7 @@ export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // The wire version remains v0 before the first release. This independent epoch
 // lets a new Client retire a stale same-version Host whose closed schema is no
 // longer safe to use.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 2 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 3 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such

--- a/packages/runtime-host/src/protocol/runtime-resource.ts
+++ b/packages/runtime-host/src/protocol/runtime-resource.ts
@@ -225,7 +225,7 @@ export function decodeRuntimeResourceQueryInput(value: unknown): RuntimeResource
     return {
       kind: 'get',
       sessionId: requireEntityId(input.sessionId, 'sessionId'),
-      ref: boundedRef(input.ref),
+      ref: decodeRuntimeResourceRef(input.ref),
     };
   }
   throw invalidProtocolFrame('Invalid Runtime Resource query kind');
@@ -328,7 +328,7 @@ export function decodeRuntimeResourceControllerControlInput(
   ]);
   return {
     sessionId: requireEntityId(input.sessionId, 'sessionId'),
-    ref: boundedRef(input.ref),
+    ref: decodeRuntimeResourceRef(input.ref),
     controllerId: requireEntityId(input.controllerId, 'controllerId'),
     sequence: controlSequence(input.sequence, 'controller sequence'),
     control: decodePtyControl(input.control),
@@ -382,7 +382,7 @@ export function decodeRuntimeResourceStopInput(value: unknown): RuntimeResourceS
   const input = requireExactRecord(value, 'Runtime Resource stop input', ['sessionId', 'ref']);
   return {
     sessionId: requireEntityId(input.sessionId, 'sessionId'),
-    ref: boundedRef(input.ref),
+    ref: decodeRuntimeResourceRef(input.ref),
   };
 }
 
@@ -445,7 +445,7 @@ function decodeControllerIdentity(
   const input = requireExactRecord(value, label, ['sessionId', 'ref', 'controllerId']);
   return {
     sessionId: requireEntityId(input.sessionId, 'sessionId'),
-    ref: boundedRef(input.ref),
+    ref: decodeRuntimeResourceRef(input.ref),
     controllerId: requireEntityId(input.controllerId, 'controllerId'),
   };
 }
@@ -539,7 +539,7 @@ function boundedCursor(value: unknown, label: string): string {
   return requireUtf8String(value, label, RUNTIME_RESOURCE_CURSOR_MAX_BYTES);
 }
 
-function boundedRef(value: unknown): string {
+export function decodeRuntimeResourceRef(value: unknown): string {
   return requireUtf8String(value, 'Runtime Resource ref', RUNTIME_RESOURCE_REF_MAX_BYTES);
 }
 

--- a/packages/runtime-host/src/protocol/session-continuity.ts
+++ b/packages/runtime-host/src/protocol/session-continuity.ts
@@ -20,6 +20,7 @@ import {
 import { defineOperation } from './operation-spec.js';
 import { decodeTurnSnapshot, type TurnSnapshot } from './turn.js';
 import { decodeGoalProjection, type GoalProjection } from './goal.js';
+import { decodeRuntimeResourceRef } from './runtime-resource.js';
 
 export const SESSION_CONTINUITY_SCHEMA_VERSION = 3 as const;
 export const SESSION_CONTINUITY_SNAPSHOT_MAX_BYTES = 56 * 1024;
@@ -150,6 +151,31 @@ export interface SessionEventFrame extends SubscriptionEnvelope {
   event: SessionToolEvent;
 }
 
+export const SESSION_DOMAINS = ['task', 'plan', 'deep_research', 'runtime_resource'] as const;
+export type SessionDomain = (typeof SESSION_DOMAINS)[number];
+export const SESSION_RUNTIME_RESOURCE_CHANGES_MAX = 64;
+
+export interface SessionRuntimeResourceChange {
+  sourceSessionId: string;
+  ref: string;
+}
+
+export type SessionDomainChange =
+  | {
+      sessionId: string;
+      domain: Exclude<SessionDomain, 'runtime_resource'>;
+    }
+  | {
+      sessionId: string;
+      domain: 'runtime_resource';
+      resources: readonly SessionRuntimeResourceChange[];
+    };
+
+export type SessionDomainChangedFrame = SubscriptionEnvelope &
+  SessionDomainChange & {
+    kind: 'subscription.session_domain_changed';
+  };
+
 export type AgentGraphChangedReason = 'observation' | 'runtime_activity' | 'reconciled' | 'stopped';
 
 export interface AgentGraphChangedFrame extends SubscriptionEnvelope {
@@ -168,6 +194,7 @@ export type SubscriptionFrame =
   | SessionProjectionFrame
   | SessionDeltaFrame
   | SessionEventFrame
+  | SessionDomainChangedFrame
   | AgentGraphChangedFrame
   | SubscriptionClosedFrame;
 
@@ -270,6 +297,28 @@ export function decodeSubscriptionFrame(value: unknown): SubscriptionFrame {
       graphId: requireEntityId(record.graphId, 'graphId'),
       reason: requireAgentGraphChangedReason(record.reason),
     };
+  } else if (record.kind === 'subscription.session_domain_changed') {
+    const domain = requireSessionDomain(record.domain);
+    assertExactKeys(record, 'Session domain changed frame', [
+      'kind',
+      'hostEpoch',
+      'subscriptionId',
+      'sequence',
+      'sessionId',
+      'domain',
+      ...(domain === 'runtime_resource' ? ['resources'] : []),
+    ]);
+    const sessionId = requireEntityId(record.sessionId, 'sessionId');
+    frame =
+      domain === 'runtime_resource'
+        ? {
+            kind: record.kind,
+            ...envelope,
+            sessionId,
+            domain,
+            resources: decodeSessionRuntimeResourceChanges(record.resources),
+          }
+        : { kind: record.kind, ...envelope, sessionId, domain };
   } else if (record.kind === 'subscription.closed') {
     assertExactKeys(record, 'subscription closed frame', [
       'kind',
@@ -288,14 +337,49 @@ export function decodeSubscriptionFrame(value: unknown): SubscriptionFrame {
   return frame;
 }
 
+function decodeSessionRuntimeResourceChanges(value: unknown): SessionRuntimeResourceChange[] {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > SESSION_RUNTIME_RESOURCE_CHANGES_MAX
+  ) {
+    throw invalidProtocolFrame('Invalid Session Runtime Resource changes');
+  }
+  const seen = new Set<string>();
+  return value.map((candidate) => {
+    const record = requireExactRecord(candidate, 'Session Runtime Resource change', [
+      'sourceSessionId',
+      'ref',
+    ]);
+    const change = {
+      sourceSessionId: requireEntityId(record.sourceSessionId, 'sourceSessionId'),
+      ref: decodeRuntimeResourceRef(record.ref),
+    };
+    const identity = JSON.stringify([change.sourceSessionId, change.ref]);
+    if (seen.has(identity)) {
+      throw invalidProtocolFrame('Duplicate Session Runtime Resource change');
+    }
+    seen.add(identity);
+    return change;
+  });
+}
+
 export function isSubscriptionFrameKind(value: unknown): value is SubscriptionFrame['kind'] {
   return (
     value === 'subscription.session_projection' ||
     value === 'subscription.session_delta' ||
     value === 'subscription.session_event' ||
+    value === 'subscription.session_domain_changed' ||
     value === 'subscription.agent_graph_changed' ||
     value === 'subscription.closed'
   );
+}
+
+function requireSessionDomain(value: unknown): SessionDomain {
+  if (typeof value !== 'string' || !(SESSION_DOMAINS as readonly string[]).includes(value)) {
+    throw invalidProtocolFrame('Invalid Session domain');
+  }
+  return value as SessionDomain;
 }
 
 export function decodeSessionContinuitySnapshot(value: unknown): SessionContinuitySnapshot {

--- a/packages/runtime-host/src/server/deep-research-coordinator.ts
+++ b/packages/runtime-host/src/server/deep-research-coordinator.ts
@@ -1,8 +1,6 @@
 import { projectDeepResearchEvents, type DeepResearchRun } from '@maka/core/deep-research-run';
-import {
-  buildDeepResearchImplementationPrompt,
-  isDeepResearchSession,
-} from '@maka/core/explore-agent';
+import { projectDeepResearchClientProgress } from '@maka/core/deep-research-client-progress';
+import { isDeepResearchSession } from '@maka/core/explore-agent';
 import { buildDeepResearchTools, type MakaTool } from '@maka/runtime';
 import {
   authenticateInteractiveArtifactStoreWriter,
@@ -17,11 +15,7 @@ import {
   type ExecutionSessionWriter,
 } from '@maka/storage/execution-stores';
 import {
-  DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES,
-  DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES,
-  DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_BYTES,
-  DEEP_RESEARCH_RECENT_REFS_MAX,
-  DEEP_RESEARCH_RESULT_MAX_BYTES,
+  encodeDeepResearchSnapshot,
   type DeepResearchQueryInput,
   type DeepResearchQueryResult,
   type OperationOutcome,
@@ -131,147 +125,11 @@ export class HostDeepResearchCoordinator {
   }
 }
 
-type DeepResearchSnapshot = Extract<DeepResearchQueryResult, { kind: 'snapshot' }>;
-
 export function projectDeepResearchRun(
   run: DeepResearchRun,
   revision: number,
 ): DeepResearchQueryResult {
-  const recentInspectedRefs = run.steps
-    .flatMap((step) => step.inspectedRefs)
-    .slice(-DEEP_RESEARCH_RECENT_REFS_MAX)
-    .map((ref) => ({
-      kind: ref.kind,
-      locator: truncateUtf8(ref.locator, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES),
-      label: ref.label ? truncateUtf8(ref.label, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES) : null,
-    }));
-  const workerRunIds = [...new Set(run.steps.flatMap((step) => step.workerRunIds))].slice(
-    -DEEP_RESEARCH_RECENT_REFS_MAX,
-  );
-  const implementationPrompt =
-    run.status === 'completed' && run.handoff && run.reportArtifactId
-      ? truncateUtf8(
-          buildDeepResearchImplementationPrompt(run),
-          DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_BYTES,
-        )
-      : null;
-  const snapshot: DeepResearchSnapshot = {
-    kind: 'snapshot',
-    sessionId: run.sessionId,
-    revision,
-    objective: truncateUtf8(run.objective, DEEP_RESEARCH_CLIENT_OBJECTIVE_MAX_BYTES),
-    scopeLevel: run.scopeLevel,
-    status: run.status,
-    stage: run.stage,
-    round: run.round,
-    createdAt: run.createdAt,
-    updatedAt: run.updatedAt,
-    artifactsCount: run.artifacts.length,
-    stepsCount: run.steps.length,
-    checklist: run.checklist.map((item) => ({
-      itemId: item.itemId,
-      title: truncateUtf8(item.title, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES),
-      status: item.status,
-      blockedReason: item.blockedReason
-        ? truncateUtf8(item.blockedReason, DEEP_RESEARCH_CLIENT_TEXT_MAX_BYTES)
-        : null,
-    })),
-    reportSections: run.reportSections.map((section) => ({
-      key: section.key,
-      status: section.status,
-    })),
-    recentInspectedRefs,
-    workerRunIds,
-    reportArtifactId: run.reportArtifactId ?? null,
-    implementationPrompt: null,
-  };
-  return fitProjectionToEncodedBudget(snapshot, implementationPrompt);
-}
-
-function fitProjectionToEncodedBudget(
-  input: DeepResearchSnapshot,
-  implementationPrompt: string | null,
-): DeepResearchSnapshot {
-  let snapshot = input;
-  if (encodedBytes(snapshot) > DEEP_RESEARCH_RESULT_MAX_BYTES) {
-    snapshot = {
-      ...snapshot,
-      recentInspectedRefs: snapshot.recentInspectedRefs.map((ref) => ({
-        ...ref,
-        label: null,
-      })),
-    };
-  }
-  while (
-    encodedBytes(snapshot) > DEEP_RESEARCH_RESULT_MAX_BYTES &&
-    snapshot.recentInspectedRefs.length > 0
-  ) {
-    snapshot = { ...snapshot, recentInspectedRefs: snapshot.recentInspectedRefs.slice(1) };
-  }
-  while (
-    encodedBytes(snapshot) > DEEP_RESEARCH_RESULT_MAX_BYTES &&
-    snapshot.workerRunIds.length > 0
-  ) {
-    snapshot = { ...snapshot, workerRunIds: snapshot.workerRunIds.slice(1) };
-  }
-  if (encodedBytes(snapshot) > DEEP_RESEARCH_RESULT_MAX_BYTES) {
-    throw new Error('Deep Research projection cannot fit the protocol result budget');
-  }
-  if (!implementationPrompt) return snapshot;
-  return fitOptionalText(snapshot, implementationPrompt, (value) => ({
-    ...snapshot,
-    implementationPrompt: value,
-  }));
-}
-
-function fitOptionalText(
-  snapshot: DeepResearchSnapshot,
-  value: string,
-  update: (value: string | null) => DeepResearchSnapshot,
-): DeepResearchSnapshot {
-  const full = update(value);
-  if (encodedBytes(full) <= DEEP_RESEARCH_RESULT_MAX_BYTES) return full;
-  const characters = Array.from(value);
-  let low = 1;
-  let high = characters.length;
-  let best = snapshot;
-  while (low <= high) {
-    const midpoint = Math.floor((low + high) / 2);
-    const candidate = update(truncateCharacters(value, midpoint));
-    if (encodedBytes(candidate) <= DEEP_RESEARCH_RESULT_MAX_BYTES) {
-      best = candidate;
-      low = midpoint + 1;
-    } else {
-      high = midpoint - 1;
-    }
-  }
-  return best;
-}
-
-function truncateCharacters(value: string, maxCharacters: number): string {
-  const characters = Array.from(value);
-  if (characters.length <= maxCharacters) return value;
-  if (maxCharacters === 1) return characters[0] ?? '…';
-  return `${characters.slice(0, maxCharacters - 1).join('')}…`;
-}
-
-function encodedBytes(value: unknown): number {
-  return Buffer.byteLength(JSON.stringify(value), 'utf8');
-}
-
-function truncateUtf8(value: string, maxBytes: number): string {
-  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value;
-  const marker = '…';
-  const markerBytes = Buffer.byteLength(marker, 'utf8');
-  let bytes = 0;
-  let output = '';
-  for (const character of value) {
-    const characterBytes = Buffer.byteLength(character, 'utf8');
-    if (bytes + characterBytes + markerBytes > maxBytes) break;
-    output += character;
-    bytes += characterBytes;
-  }
-  return `${output}${marker}`;
+  return encodeDeepResearchSnapshot(projectDeepResearchClientProgress(run), revision);
 }
 
 function success(result: DeepResearchQueryResult): OperationOutcome<'deep-research.query'> {

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -123,6 +123,7 @@ export async function createExecutionRuntimeHostComposition(
     | undefined;
   let graphClient: HostAgentGraphCoordinator | undefined;
   let sessionEffects: HostSessionEffectCoordinator | undefined;
+  let unsubscribeTaskLedger: (() => void) | undefined;
   try {
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,
@@ -196,11 +197,15 @@ export async function createExecutionRuntimeHostComposition(
       sessions: {
         listShellRunUpdates: (sessionId) =>
           requireSessionManager(manager).listShellRunUpdates(sessionId),
+        getShellRunUpdate: (sessionId, ref) =>
+          requireSessionManager(manager).getShellRunUpdate(sessionId, ref),
       },
       sessionHeaders: stores.sessionStore,
       sessionAdmission,
       acquireResidency: context.acquireResidency,
       requestDrain: context.requestDrain,
+      onProjectionChanged: (update) =>
+        requireContinuity(continuity).enqueueRuntimeResourceChanged(update),
     });
     const executionArtifacts = createHostExecutionArtifactServices({
       artifacts: openedArtifactStore,
@@ -292,12 +297,16 @@ export async function createExecutionRuntimeHostComposition(
       createSessionTranscriptReader({ stores, canonicalPermissionOutcomes }),
     );
     const continuityCoordinator = continuity;
+    unsubscribeTaskLedger = taskLedger.subscribe(({ sessionId }) =>
+      continuityCoordinator.enqueueSessionDomainChanged(sessionId, 'task'),
+    );
     deepResearch = new HostDeepResearchCoordinator({
       store: openedDeepResearchStore,
       artifacts: openedArtifactStore,
       sessions: stores.sessionStore,
       sessionAdmission,
-      onProjectionChanged: (sessionId) => continuityCoordinator.enqueueCanonicalRefresh(sessionId),
+      onProjectionChanged: (sessionId) =>
+        continuityCoordinator.enqueueSessionDomainChanged(sessionId, 'deep_research'),
     });
     dailyReview = new HostDailyReviewCoordinator({
       store: openedDailyReviewStore,
@@ -743,6 +752,8 @@ export async function createExecutionRuntimeHostComposition(
       isSessionActive: (sessionId) => coordinator.readRootState(sessionId).kind !== 'idle',
       refreshContinuity: (sessionId, lease) =>
         continuityCoordinator.refreshCanonical(sessionId, lease),
+      onProjectionChanged: (sessionId) =>
+        continuityCoordinator.enqueueSessionDomainChanged(sessionId, 'plan'),
       requestDrain: context.requestDrain,
     });
     const executionInspect = new HostExecutionInspectCoordinator(stores);
@@ -988,6 +999,7 @@ export async function createExecutionRuntimeHostComposition(
           errors.push(error);
         }
         try {
+          unsubscribeTaskLedger?.();
           taskLedgerStore?.close();
         } catch (error) {
           errors.push(error);
@@ -1076,6 +1088,7 @@ export async function createExecutionRuntimeHostComposition(
       errors.push(closeError);
     }
     try {
+      unsubscribeTaskLedger?.();
       taskLedgerStore?.close();
     } catch (closeError) {
       errors.push(closeError);

--- a/packages/runtime-host/src/server/plan-coordinator.ts
+++ b/packages/runtime-host/src/server/plan-coordinator.ts
@@ -42,6 +42,7 @@ export interface HostPlanCoordinatorInput {
   readonly sessionAdmission: SessionAdmissionGate;
   readonly isSessionActive: (sessionId: string) => boolean;
   readonly refreshContinuity: (sessionId: string, lease: SessionAdmissionLease) => Promise<void>;
+  readonly onProjectionChanged: (sessionId: string) => void;
   readonly requestDrain: () => void;
 }
 
@@ -59,6 +60,7 @@ export class HostPlanCoordinator {
   readonly #sessionAdmission: SessionAdmissionGate;
   readonly #isSessionActive: (sessionId: string) => boolean;
   readonly #refreshContinuity: HostPlanCoordinatorInput['refreshContinuity'];
+  readonly #onProjectionChanged: HostPlanCoordinatorInput['onProjectionChanged'];
   readonly #requestDrain: () => void;
 
   constructor(input: HostPlanCoordinatorInput) {
@@ -68,6 +70,7 @@ export class HostPlanCoordinator {
     this.#sessionAdmission = input.sessionAdmission;
     this.#isSessionActive = input.isSessionActive;
     this.#refreshContinuity = input.refreshContinuity;
+    this.#onProjectionChanged = input.onProjectionChanged;
     this.#requestDrain = input.requestDrain;
   }
 
@@ -140,6 +143,7 @@ export class HostPlanCoordinator {
     }
     try {
       const result = await this.#applyControl(input);
+      this.#onProjectionChanged(input.sessionId);
       await this.#refreshContinuity(input.sessionId, lease);
       return { ok: true, result: projectControlResult(result) };
     } catch (error) {

--- a/packages/runtime-host/src/server/runtime-resource-coordinator.ts
+++ b/packages/runtime-host/src/server/runtime-resource-coordinator.ts
@@ -47,6 +47,7 @@ const MAX_CONTROL_REPLAYS = 128;
 
 interface RuntimeResourceSessionReader {
   listShellRunUpdates(sessionId: string): Promise<ShellRunUpdate[]>;
+  getShellRunUpdate(sessionId: string, ref: string): Promise<ShellRunUpdate | null>;
 }
 
 interface RuntimeResourceHeaderReader {
@@ -69,6 +70,7 @@ export interface HostRuntimeResourceCoordinatorInput {
   readonly sessionAdmission: SessionAdmissionGate;
   readonly acquireResidency: () => RuntimeHostResidency;
   readonly requestDrain: () => void;
+  readonly onProjectionChanged?: (update: ShellRunUpdate) => void;
 }
 
 interface ControllerState {
@@ -104,6 +106,7 @@ export class HostRuntimeResourceCoordinator
   readonly #sessionAdmission: SessionAdmissionGate;
   readonly #acquireResidency: () => RuntimeHostResidency;
   readonly #requestDrain: () => void;
+  readonly #onProjectionChanged: (update: ShellRunUpdate) => void;
   readonly #resourceQueue = new ResourceSerialQueue();
   readonly #controllers = new Map<string, ControllerState>();
   readonly #controllerResources = new Map<string, string>();
@@ -118,6 +121,7 @@ export class HostRuntimeResourceCoordinator
     this.#sessionAdmission = input.sessionAdmission;
     this.#acquireResidency = input.acquireResidency;
     this.#requestDrain = input.requestDrain;
+    this.#onProjectionChanged = input.onProjectionChanged ?? (() => undefined);
   }
 
   runForegroundBash(input: ShellRunBashInput): ReturnType<ShellRunLauncher['runForegroundBash']> {
@@ -194,6 +198,7 @@ export class HostRuntimeResourceCoordinator
     if (!isActiveShellRunStatus(update.result.status)) {
       this.#releaseController(resourceKey(update.sessionId, update.result.ref));
     }
+    this.#onProjectionChanged(update);
   }
 
   releaseConnection(connectionId: string): void {
@@ -240,6 +245,24 @@ export class HostRuntimeResourceCoordinator
         this.#requestDrain();
         return queryFailure('internal_failure', 'Session state is unavailable');
       }
+      if (input.kind === 'get') {
+        try {
+          const resource = await this.#sessions.getShellRunUpdate(input.sessionId, input.ref);
+          const canonical = resource ? (canonicalRuntimeResources([resource])[0] ?? null) : null;
+          return {
+            ok: true,
+            result: decodeRuntimeResourceQueryResult({
+              kind: 'resource',
+              sessionId: input.sessionId,
+              revision: runtimeResourceRevision(canonical ? [canonical] : []),
+              resource: canonical,
+            }),
+          };
+        } catch {
+          this.#requestDrain();
+          return queryFailure('internal_failure', 'Runtime Resource state is unavailable');
+        }
+      }
       let updates: ShellRunUpdate[];
       try {
         updates = await this.#sessions.listShellRunUpdates(input.sessionId);
@@ -250,17 +273,6 @@ export class HostRuntimeResourceCoordinator
       try {
         const resources = canonicalRuntimeResources(updates);
         const revision = runtimeResourceRevision(resources);
-        if (input.kind === 'get') {
-          return {
-            ok: true,
-            result: decodeRuntimeResourceQueryResult({
-              kind: 'resource',
-              sessionId: input.sessionId,
-              revision,
-              resource: resources.find((resource) => resource.result.ref === input.ref) ?? null,
-            }),
-          };
-        }
         if (input.kind === 'list_continue' && input.revision !== revision) {
           return {
             ok: true,

--- a/packages/runtime-host/src/server/runtime-resource-projection.ts
+++ b/packages/runtime-host/src/server/runtime-resource-projection.ts
@@ -18,15 +18,19 @@ const TRUNCATED_FIELD_MARKER = '[runtime resource field truncated]';
 
 export function canonicalRuntimeResources(resources: readonly ShellRunUpdate[]): ShellRunUpdate[] {
   return resources
-    .map((resource) => ({
-      ...structuredClone(resource),
-      result: boundedState(resource.result),
-    }))
+    .map(boundedRuntimeResourceUpdate)
     .sort(
       (left, right) =>
         left.result.ref.localeCompare(right.result.ref) ||
         left.sourceToolCallId.localeCompare(right.sourceToolCallId),
     );
+}
+
+function boundedRuntimeResourceUpdate(update: ShellRunUpdate): ShellRunUpdate {
+  return {
+    ...structuredClone(update),
+    result: boundedState(update.result),
+  };
 }
 
 export function runtimeResourceRevision(

--- a/packages/runtime-host/src/server/session-continuity-coordinator.ts
+++ b/packages/runtime-host/src/server/session-continuity-coordinator.ts
@@ -1,17 +1,20 @@
 import { randomUUID } from 'node:crypto';
 import { isDeepStrictEqual } from 'node:util';
-import type { SessionEvent } from '@maka/core/events';
+import type { SessionEvent, ShellRunUpdate } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import {
   encodeProtocolFrame,
   RUNTIME_HOST_MAX_FRAME_BYTES,
   SESSION_LIVE_DELTA_MAX_BYTES,
+  SESSION_RUNTIME_RESOURCE_CHANGES_MAX,
   SESSION_TOOL_NAME_MAX_BYTES,
   type AgentGraphChangedFrame,
   type AgentGraphChangedReason,
   type SessionAssistantDelta,
   type SessionContinuitySnapshot,
   type SessionDeltaFrame,
+  type SessionDomainChange,
+  type SessionDomainChangedFrame,
   type SessionEventFrame,
   type SessionToolEvent,
   type SessionTranscriptQueryInput,
@@ -113,6 +116,13 @@ interface PendingAgentGraphChange {
   };
 }
 
+type SessionProjectionDomain = Exclude<SessionDomainChange['domain'], 'runtime_resource'>;
+
+interface PendingSessionDomainChanges {
+  readonly domains: Set<SessionProjectionDomain>;
+  readonly runtimeResources: Map<string, { sourceSessionId: string; ref: string }>;
+}
+
 export class SessionContinuityCoordinator implements SessionContinuityService {
   readonly handlers: SessionContinuityOperationHandlerMap = {
     'subscription.open': async (input, context) => {
@@ -140,6 +150,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
   readonly #transcriptSnapshots = new TranscriptSnapshotStore();
   readonly #pendingRefreshes = new Map<string, PendingRefresh>();
   readonly #pendingAgentGraphChanges = new Map<string, PendingAgentGraphChange>();
+  readonly #pendingSessionDomainChanges = new Map<string, PendingSessionDomainChanges>();
   readonly #hostEpoch: string;
   readonly #readCanonical: ReadCanonicalSessionProjection;
   readonly #readTranscript: ReadSessionTranscript | undefined;
@@ -267,6 +278,90 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
       .catch((error: unknown) => {
         if (this.#pendingAgentGraphChanges.get(event.rootSessionId) === change) {
           this.#pendingAgentGraphChanges.delete(event.rootSessionId);
+        }
+        this.onPublicationFailure(error);
+      });
+  }
+
+  /** Coalesce domain projection invalidations onto the Session subscription sequence. */
+  enqueueSessionDomainChanged(sessionId: string, domain: SessionProjectionDomain): void {
+    if (this.#closed) return;
+    const pending = this.#pendingSessionDomainChanges.get(sessionId);
+    if (pending) {
+      pending.domains.add(domain);
+      return;
+    }
+    const changes: PendingSessionDomainChanges = {
+      domains: new Set([domain]),
+      runtimeResources: new Map(),
+    };
+    this.#pendingSessionDomainChanges.set(sessionId, changes);
+    this.#scheduleSessionDomainChanges(sessionId, changes);
+  }
+
+  /** Publish one lightweight source invalidation to every active Session view that may inherit it. */
+  enqueueRuntimeResourceChanged(update: ShellRunUpdate): void {
+    if (this.#closed) return;
+    const resource = { sourceSessionId: update.sessionId, ref: update.result.ref };
+    const key = JSON.stringify([resource.sourceSessionId, resource.ref]);
+    for (const sessionId of this.#sessions.keys()) {
+      const pending = this.#pendingSessionDomainChanges.get(sessionId);
+      if (pending) {
+        pending.runtimeResources.set(key, resource);
+        continue;
+      }
+      const changes: PendingSessionDomainChanges = {
+        domains: new Set(),
+        runtimeResources: new Map([[key, resource]]),
+      };
+      this.#pendingSessionDomainChanges.set(sessionId, changes);
+      this.#scheduleSessionDomainChanges(sessionId, changes);
+    }
+  }
+
+  #scheduleSessionDomainChanges(sessionId: string, changes: PendingSessionDomainChanges): void {
+    void this.sessionAdmission
+      .enqueueDetached(sessionId, () => {
+        if (this.#pendingSessionDomainChanges.get(sessionId) !== changes) return;
+        this.#pendingSessionDomainChanges.delete(sessionId);
+        if (this.#closed) return;
+        const state = this.#sessions.get(sessionId);
+        if (!state) return;
+        const frames: SessionDomainChange[] = [...changes.domains].map((domain) => ({
+          sessionId,
+          domain,
+        }));
+        const runtimeResources = [...changes.runtimeResources.values()];
+        for (
+          let offset = 0;
+          offset < runtimeResources.length;
+          offset += SESSION_RUNTIME_RESOURCE_CHANGES_MAX
+        ) {
+          frames.push({
+            sessionId,
+            domain: 'runtime_resource',
+            resources: runtimeResources.slice(
+              offset,
+              offset + SESSION_RUNTIME_RESOURCE_CHANGES_MAX,
+            ),
+          });
+        }
+        for (const change of frames) {
+          for (const subscriber of state.subscribers.values()) {
+            const frame: SessionDomainChangedFrame = {
+              kind: 'subscription.session_domain_changed',
+              hostEpoch: this.#hostEpoch,
+              subscriptionId: subscriber.subscriptionId,
+              sequence: subscriber.nextSequence,
+              ...change,
+            };
+            this.#enqueue(subscriber, frame);
+          }
+        }
+      })
+      .catch((error: unknown) => {
+        if (this.#pendingSessionDomainChanges.get(sessionId) === changes) {
+          this.#pendingSessionDomainChanges.delete(sessionId);
         }
         this.onPublicationFailure(error);
       });
@@ -442,6 +537,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     this.#transcriptSnapshots.close();
     this.#pendingRefreshes.clear();
     this.#pendingAgentGraphChanges.clear();
+    this.#pendingSessionDomainChanges.clear();
   }
 
   async #open(

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -18265,6 +18265,9 @@ describe('SessionManager permission mode updates', () => {
       async listSessionUpdates() {
         return [];
       },
+      async getSessionUpdate() {
+        return undefined;
+      },
       async inspectResource(sessionId: string, candidateRef: string) {
         if (ownerAvailable && candidateRef === ref && sessionId === 'session-1')
           return sourceSnapshot;
@@ -18413,6 +18416,10 @@ describe('SessionManager permission mode updates', () => {
     });
     expect(updates[0]?.sourceToolCallId).toBe('bash-1');
     expect(updates[0]?.result).toEqual(sourceSnapshot);
+    expect(await manager.getShellRunUpdate(child.id, sourceSnapshot.ref)).toEqual(updates[0]);
+    expect(
+      await manager.getShellRunUpdate(child.id, 'maka://runtime/background-tasks/missing-shell'),
+    ).toBeNull();
 
     const revisionUpdates = await manager.listShellRunUpdates(revision.id);
     expect(revisionUpdates).toHaveLength(1);
@@ -18434,6 +18441,9 @@ describe('SessionManager permission mode updates', () => {
     });
     expect(danglingUpdates[0]?.result.status).toBe('running');
     expect(danglingUpdates[0]?.result.output).toBe(undefined);
+    expect(await manager.getShellRunUpdate(child.id, sourceSnapshot.ref)).toEqual(
+      danglingUpdates[0],
+    );
   });
 
   test('branchFromTurn preserves parent thinking, collaboration, and orchestration modes', async () => {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1228,24 +1228,9 @@ export class SessionManager {
 
     const ownUpdates = await shellRuns.listSessionUpdates(sessionId);
     const ownToolCalls = new Set(ownUpdates.map((update) => update.sourceToolCallId));
-    let messages: StoredMessage[];
-    try {
-      messages = await this.getMessages(sessionId);
-    } catch (error) {
-      if (!(error instanceof RuntimeReadModelError)) throw error;
-      // ShellRun hydration is a best-effort UI projection. A legacy RuntimeEvent
-      // incompatibility must not turn its retry loop into a permanent IPC error.
-      try {
-        messages = await this.deps.store.readMessages(sessionId);
-      } catch {
-        return ownUpdates;
-      }
-    }
-    const bashToolCalls = new Set(
-      messages.flatMap((message) =>
-        message.type === 'tool_call' && message.toolName === 'Bash' ? [message.id] : [],
-      ),
-    );
+    const messages = await this.readShellRunProjectionMessages(sessionId);
+    if (!messages) return ownUpdates;
+    const bashToolCalls = shellRunBashToolCallIds(messages);
     const inherited = new Map<
       string,
       {
@@ -1296,6 +1281,55 @@ export class SessionManager {
       }),
     );
     return [...ownUpdates, ...inheritedUpdates];
+  }
+
+  async getShellRunUpdate(sessionId: string, ref: string): Promise<ShellRunUpdate | null> {
+    const shellRuns = this.deps.shellRuns;
+    if (!shellRuns) return null;
+    const own = await shellRuns.getSessionUpdate(sessionId, ref);
+    if (own) return own;
+
+    const messages = await this.readShellRunProjectionMessages(sessionId);
+    if (!messages) return null;
+    const bashToolCalls = shellRunBashToolCallIds(messages);
+    let candidate:
+      | {
+          turnId: string;
+          toolUseId: string;
+          result: ShellRunUpdate['result'];
+        }
+      | undefined;
+    for (const message of messages) {
+      if (
+        message.type === 'tool_result' &&
+        bashToolCalls.has(message.toolUseId) &&
+        message.content.kind === 'shell_run' &&
+        message.content.ref === ref &&
+        isActiveShellRunStatus(message.content.status)
+      ) {
+        const { operation: _operation, ...result } = message.content;
+        candidate = { turnId: message.turnId, toolUseId: message.toolUseId, result };
+      }
+    }
+    if (!candidate) return null;
+
+    const inheritedFrom = await this.deps.store.readHeader(sessionId);
+    const parentSessionId = inheritedFrom.revisionParentSessionId ?? inheritedFrom.parentSessionId;
+    if (!parentSessionId) return null;
+    const owner = await this.resolveShellRunOwner(parentSessionId, ref);
+    return {
+      sessionId,
+      ownership: owner
+        ? {
+            kind: 'source_owned',
+            sourceSessionId: parentSessionId,
+            ownerSessionId: owner.sessionId,
+          }
+        : { kind: 'source_unavailable', sourceSessionId: parentSessionId },
+      sourceTurnId: candidate.turnId,
+      sourceToolCallId: candidate.toolUseId,
+      result: owner?.result ?? candidate.result,
+    };
   }
 
   async recoverInterruptedSessions(): Promise<string[]> {
@@ -5090,6 +5124,21 @@ export class SessionManager {
     return undefined;
   }
 
+  private async readShellRunProjectionMessages(sessionId: string): Promise<StoredMessage[] | null> {
+    try {
+      return await this.getMessages(sessionId);
+    } catch (error) {
+      if (!(error instanceof RuntimeReadModelError)) throw error;
+      // ShellRun hydration is a best-effort UI projection. A legacy RuntimeEvent
+      // incompatibility must not turn its retry loop into a permanent IPC error.
+      try {
+        return await this.deps.store.readMessages(sessionId);
+      } catch {
+        return null;
+      }
+    }
+  }
+
   private async findChildRunForOutput(
     sessionId: string,
     input: AgentOutputInput,
@@ -6667,6 +6716,14 @@ function boundAgentOutputCollections(
 function tail<T>(items: readonly T[], max: number): T[] {
   if (items.length <= max) return [...items];
   return items.slice(items.length - max);
+}
+
+function shellRunBashToolCallIds(messages: readonly StoredMessage[]): Set<string> {
+  return new Set(
+    messages.flatMap((message) =>
+      message.type === 'tool_call' && message.toolName === 'Bash' ? [message.id] : [],
+    ),
+  );
 }
 
 function throwIfChildExecutionAborted(signal: AbortSignal | undefined, message: string): void {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -534,6 +534,17 @@ export class ShellRunProcessManager
     return records.map(shellRunUpdate);
   }
 
+  async getSessionUpdate(sessionId: string, ref: string): Promise<ShellRunUpdate | undefined> {
+    const target = parseShellRunResourceRef(ref);
+    if (!target) return undefined;
+    try {
+      return shellRunUpdate(await this.input.store.readShellRun(sessionId, target.shellRunId));
+    } catch (error) {
+      if (isNotFoundError(error)) return undefined;
+      throw error;
+    }
+  }
+
   async recoverOrphanedSession(sessionId: string): Promise<number> {
     const records = await this.input.store.listSessionShellRuns(sessionId);
     let recovered = 0;

--- a/packages/ui/src/__tests__/deep-research-progress.test.tsx
+++ b/packages/ui/src/__tests__/deep-research-progress.test.tsx
@@ -1,15 +1,14 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { renderToStaticMarkup } from 'react-dom/server';
-import type { DeepResearchRun } from '@maka/core';
+import type { DeepResearchClientProgress } from '@maka/core';
 import { DeepResearchEmptyHero } from '../chat-empty-hero.js';
 import { DeepResearchProgressPanel } from '../chat-view.js';
 import { getConversationCopy } from '../conversation-copy.js';
 import { LocaleProvider } from '../locale-context.js';
 
-function completedRun(): DeepResearchRun {
+function completedRun(): DeepResearchClientProgress {
   return {
-    schemaVersion: 1,
     sessionId: 'session-1',
     objective: 'Verify the progress UI.',
     scopeLevel: 'standard',
@@ -18,47 +17,25 @@ function completedRun(): DeepResearchRun {
     round: 2,
     createdAt: 1,
     updatedAt: 2,
-    artifacts: [],
+    artifactsCount: 0,
+    stepsCount: 1,
     checklist: [{
       itemId: 'project_entrypoints',
       title: 'Map project entrypoints',
       status: 'completed',
-      evidenceArtifactIds: ['source-1'],
-      updatedAt: 2,
     }],
-    steps: [{
-      stepId: 'step-1',
-      kind: 'local_exploration',
-      status: 'completed',
-      objective: 'Inspect the entrypoint.',
-      summary: 'Entrypoint inspected.',
-      roots: ['packages/ui'],
-      keywords: ['ChatView'],
-      ignoredPaths: ['dist'],
-      stoppingCondition: 'Stop after the visible surface is located.',
-      expectedEvidence: 'A component symbol.',
-      evidenceArtifactIds: ['source-1'],
-      inspectedRefs: [{ kind: 'symbol', locator: 'DeepResearchProgressPanel' }],
-      workerRunIds: ['worker-1'],
-      createdAt: 2,
-    }],
+    recentInspectedRefs: [{ kind: 'symbol', locator: 'DeepResearchProgressPanel' }],
+    workerRunIds: ['worker-1'],
+    blockers: [],
     reportSections: [
-      { key: 'conclusion', status: 'completed', artifactId: 'section-1', updatedAt: 2 },
-      { key: 'source_evidence', status: 'completed', artifactId: 'section-2', updatedAt: 2 },
-      { key: 'borrow_diverge_risk_gate', status: 'completed', artifactId: 'section-3', updatedAt: 2 },
-      { key: 'implementation_recommendations', status: 'completed', artifactId: 'section-4', updatedAt: 2 },
-      { key: 'verification', status: 'completed', artifactId: 'section-5', updatedAt: 2 },
+      { key: 'conclusion', status: 'completed' },
+      { key: 'source_evidence', status: 'completed' },
+      { key: 'borrow_diverge_risk_gate', status: 'completed' },
+      { key: 'implementation_recommendations', status: 'completed' },
+      { key: 'verification', status: 'completed' },
     ],
-    checkpoints: [],
     reportArtifactId: 'report-1',
-    handoff: {
-      artifactId: 'handoff-1',
-      implementationTasks: ['Implement the approved slice.'],
-      recommendedIssues: ['Track visual QA.'],
-      recommendedPullRequests: [],
-      verificationCommands: ['npm test'],
-    },
-    completedAt: 2,
+    implementationPrompt: 'Implement the approved slice.',
   };
 }
 
@@ -81,7 +58,7 @@ describe('DeepResearchProgressPanel', () => {
     const run = completedRun();
     const markup = renderToStaticMarkup(
       <DeepResearchProgressPanel
-        run={{ ...run, status: 'active', stage: 'report_writing', completedAt: undefined }}
+        run={{ ...run, status: 'active', stage: 'report_writing', implementationPrompt: undefined }}
         onContinue={() => undefined}
       />,
     );

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -9,7 +9,7 @@ import type { ChatModelChoice } from './chat-model-helpers.js';
 import { PromptAnchorRail } from './prompt-anchor-rail.js';
 import { useMessageSelectionQuote } from './use-message-selection-quote.js';
 import type {
-  DeepResearchRun,
+  DeepResearchClientProgress,
   ProviderType,
   SessionSummary,
   ShellRunUpdate,
@@ -59,9 +59,9 @@ export function ChatView(props: {
   continuingIndicator?: boolean;
   activeSession?: SessionSummary;
   /** Durable Deep Research projection supplied by the host for visible progress and resume state. */
-  deepResearchRun?: DeepResearchRun;
+  deepResearchRun?: DeepResearchClientProgress;
   /** Explicitly starts a normal implementation task from a completed read-only research run. */
-  onContinueDeepResearchHandoff?(run: DeepResearchRun): void;
+  onContinueDeepResearchHandoff?(run: DeepResearchClientProgress): void;
   activeConnectionLabel?: string;
   activeModel?: string;
   activeModelLabel?: string;
@@ -619,21 +619,13 @@ export function DeepResearchProgressPanel({
   onContinue,
   copy = getConversationCopy('zh').chat.deepResearchProgress,
 }: {
-  run: DeepResearchRun;
-  onContinue?: (run: DeepResearchRun) => void;
+  run: DeepResearchClientProgress;
+  onContinue?: (run: DeepResearchClientProgress) => void;
   copy?: ReturnType<typeof getConversationCopy>['chat']['deepResearchProgress'];
 }) {
   const completedItems = run.checklist.filter(
     (item) => item.status === 'completed' || item.status === 'skipped',
   ).length;
-  const inspectedRefs = run.steps.flatMap((step) => step.inspectedRefs).slice(-8);
-  const workerRunIds = [...new Set(run.steps.flatMap((step) => step.workerRunIds))].slice(-8);
-  const blockers = [
-    ...run.checklist.flatMap((item) =>
-      item.blockedReason ? [`${item.title}: ${item.blockedReason}`] : []),
-    ...run.steps.flatMap((step) =>
-      step.blockedReason ? [`${step.objective}: ${step.blockedReason}`] : []),
-  ];
 
   return (
     <section
@@ -654,7 +646,7 @@ export function DeepResearchProgressPanel({
           <span className="maka-deep-research-run-count">
             {completedItems}/{run.checklist.length}
           </span>
-          {run.status === 'completed' && onContinue && (
+          {run.status === 'completed' && run.implementationPrompt && onContinue && (
             <Button
               type="button"
               label={copy.handoffAction}
@@ -693,9 +685,9 @@ export function DeepResearchProgressPanel({
         </div>
         <div>
           <h3>{copy.inspectedTitle}</h3>
-          {inspectedRefs.length > 0 ? (
+          {run.recentInspectedRefs.length > 0 ? (
             <ul>
-              {inspectedRefs.map((ref, index) => (
+              {run.recentInspectedRefs.map((ref, index) => (
                 <li key={`${ref.kind}-${ref.locator}-${index}`}>
                   <span>{ref.kind}</span>
                   <code>{ref.locator}</code>
@@ -706,11 +698,11 @@ export function DeepResearchProgressPanel({
         </div>
         <div>
           <h3>{copy.executionTitle}</h3>
-          <p>{copy.executionSummary(run.steps.length, run.artifacts.length)}</p>
-          {workerRunIds.length > 0 && <p>{copy.workersLabel}: {workerRunIds.join(', ')}</p>}
-          {blockers.length > 0 ? (
+          <p>{copy.executionSummary(run.stepsCount, run.artifactsCount)}</p>
+          {run.workerRunIds.length > 0 && <p>{copy.workersLabel}: {run.workerRunIds.join(', ')}</p>}
+          {run.blockers.length > 0 ? (
             <ul className="maka-deep-research-run-blockers">
-              {blockers.map((blocker) => <li key={blocker}>{blocker}</li>)}
+              {run.blockers.map((blocker) => <li key={blocker}>{blocker}</li>)}
             </ul>
           ) : <p>{copy.noBlockers}</p>}
         </div>


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Add the isolated Runtime Host-backed Desktop candidate adapters for Task Ledger, Goal, Agent Graph, Deep Research, Runtime Resources, and non-starting Plan controls.
- Preserve the existing renderer contracts with revision-consistent pagination, conflict-aware Goal clearing, and one shared bounded Deep Research projection for embedded and hosted paths.
- Publish mutation-driven domain changes through Session subscriptions. Runtime Resource notifications batch lightweight identities, then use true point reads so active and inherited Session views stay current without rebuilding the full resource list.
- Keep Plan approval/resume outside the candidate until the Host owns an atomic Plan-to-Turn transition. Production continues to use the embedded Runtime until the M5 switch.
- Advance the same-`v0` compatibility epoch so Clients cannot reuse a stale Host with the previous closed schema.

## Testing

- `npm test --workspace @maka/core` (776 passed)
- `npm test --workspace @maka/runtime` (3128 passed, 9 skipped)
- `npm test --workspace @maka/ui` (317 passed)
- `npm test --workspace @maka/desktop` (1656 passed)
- Runtime Host full suite: 667 passed; the single shared-load timeout passed on isolated rerun
- Focused Runtime Host protocol, point-read, subscription burst, UDS, and Desktop adapter tests
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`

Part of #2010.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 新增隔离的 Runtime Host-backed Desktop candidate adapter，覆盖 Task Ledger、Goal、Agent Graph、Deep Research、Runtime Resources，以及不会启动 Turn 的 Plan 控制。
- 通过 revision-consistent pagination、可感知冲突的 Goal clear，以及 embedded/hosted path 共用的有界 Deep Research projection，保持现有 renderer contract。
- 通过 Session subscription 发布由真实 mutation 驱动的 domain change。Runtime Resource notification 会批量携带轻量 identity，再使用真正的 point read，使当前 Session 与继承视图保持最新，同时避免重建完整资源列表。
- 在 Host 拥有原子的 Plan-to-Turn transition 之前，candidate 不接管 Plan approve/resume。M5 切换前，production 仍继续使用 embedded Runtime。
- 推进同一 `v0` 下的 compatibility epoch，避免 Client 复用采用旧 closed schema 的 Host。

## 测试

- `npm test --workspace @maka/core`（776 项通过）
- `npm test --workspace @maka/runtime`（3128 项通过，9 项跳过）
- `npm test --workspace @maka/ui`（317 项通过）
- `npm test --workspace @maka/desktop`（1656 项通过）
- Runtime Host 全量测试：667 项通过；唯一的共享负载超时在隔离重跑时通过
- Runtime Host protocol、point read、subscription burst、UDS 与 Desktop adapter 聚焦测试
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`

属于 #2010 的一部分。

</details>
