### PR TITLE
fix(opencode-free): replace unhealthy bootstrap model

### DIFF
--- a/apps/desktop/e2e/onboarding.spec.ts
+++ b/apps/desktop/e2e/onboarding.spec.ts
@@ -54,7 +54,7 @@ test('first run connects a provider and starts the first task without workspace 
   await expect(onboarding).toHaveCount(0);
   await expect(page.locator(COMPOSER_INPUT)).toBeVisible();
   await expect(page.getByRole('button', { name: /选择新对话模型/ })).toHaveAccessibleName(
-    /Big Pickle/,
+    /Nemotron 3 Ultra Free/,
   );
 
   await page.locator(COMPOSER_INPUT).fill('完成首次任务');

--- a/apps/desktop/e2e/onboarding.spec.ts
+++ b/apps/desktop/e2e/onboarding.spec.ts
@@ -47,7 +47,7 @@ test('first run connects a provider and starts the first task without workspace 
     .toEqual({
       defaultSlug: null,
       defaultModel: '',
-      enabledModelIds: ['big-pickle'],
+      enabledModelIds: ['nemotron-3-ultra-free'],
     });
   await page.getByRole('button', { name: '返回应用', exact: true }).click();
 
@@ -69,5 +69,5 @@ test('first run connects a provider and starts the first task without workspace 
         }));
       }),
     )
-    .toContainEqual({ connectionSlug: 'opencode-free', model: 'big-pickle' });
+    .toContainEqual({ connectionSlug: 'opencode-free', model: 'nemotron-3-ultra-free' });
 });

--- a/apps/desktop/src/main/__tests__/connections-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/connections-ipc-main.test.ts
@@ -455,4 +455,66 @@ describe('connection IPC credential boundary', () => {
       });
     }
   });
+
+  test('test records the healthy fallback without changing a customized default model', async () => {
+    const updates: UpdateConnectionInput[] = [];
+    const server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on('data', (chunk: Buffer) => chunks.push(chunk));
+      request.on('end', () => {
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as { model: string };
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(
+          JSON.stringify(
+            body.model === 'custom-broken-free'
+              ? { error: { type: 'server_error' } }
+              : { choices: [{ message: { role: 'assistant', content: 'ok' } }] },
+          ),
+        );
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+    const connection: LlmConnection = {
+      slug: 'my-opencode-free',
+      name: 'My free connection',
+      providerType: 'opencode-free',
+      baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      defaultModel: 'custom-broken-free',
+      enabledModelIds: ['custom-broken-free'],
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const handlers = registerHandlers({
+      connectionStore: {
+        get: async () => connection,
+        update: async (_slug: string, patch: UpdateConnectionInput) => {
+          updates.push(patch);
+          return connection;
+        },
+      },
+    });
+
+    try {
+      const testConnection = handlers.get('connections:test');
+      assert.ok(testConnection);
+      const result = (await testConnection({}, connection.slug)) as {
+        ok: boolean;
+        modelTested?: string;
+      };
+
+      assert.equal(result.ok, true);
+      assert.equal(result.modelTested, 'nemotron-3-ultra-free');
+      assert.equal(updates.length, 1);
+      assert.equal(updates[0]?.lastTestStatus, 'verified');
+      assert.equal('defaultModel' in updates[0]!, false);
+      assert.equal('enabledModelIds' in updates[0]!, false);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
 });

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -2,7 +2,10 @@ import { app, nativeImage } from 'electron';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { setActiveProxy } from '@maka/runtime';
-import { resolveBootstrapConnections } from '@maka/core';
+import {
+  resolveBootstrapConnections,
+  resolveOpenCodeFreeBootstrapMigration,
+} from '@maka/core';
 import type {
   AgentGraphCoordinator,
   AgentGraphSupervisorWakeCoordinator,
@@ -210,7 +213,20 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
 
   async function ensureBootstrapConnection(): Promise<void> {
     await mkdir(workspaceRoot, { recursive: true });
-    if ((await connectionStore.list()).length > 0) return;
+    const existingConnections = await connectionStore.list();
+    let migrated = false;
+    for (const connection of existingConnections) {
+      const patch = resolveOpenCodeFreeBootstrapMigration(connection);
+      if (!patch) continue;
+      const updated = await connectionStore.updateIfUnchanged(
+        connection.slug,
+        connection.updatedAt,
+        patch,
+      );
+      migrated ||= updated !== null;
+    }
+    if (migrated) emitConnectionListChanged();
+    if (existingConnections.length > 0) return;
 
     // opencode-free is seeded unconditionally so a fresh install is usable with
     // zero credentials; env-keyed providers layer on top and take the default
@@ -225,6 +241,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
         name: seed.name,
         providerType: seed.providerType,
         defaultModel: seed.defaultModel,
+        extras: seed.extras,
       });
       const envApiKey =
         seed.providerType === 'anthropic'

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -2,11 +2,7 @@ import { app, nativeImage } from 'electron';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { setActiveProxy } from '@maka/runtime';
-import {
-  OPENCODE_FREE_DEFAULT_MODEL,
-  isHistoricalOpenCodeFreeSeed,
-  resolveBootstrapConnections,
-} from '@maka/core';
+import { resolveBootstrapConnections } from '@maka/core';
 import type {
   AgentGraphCoordinator,
   AgentGraphSupervisorWakeCoordinator,
@@ -214,16 +210,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
 
   async function ensureBootstrapConnection(): Promise<void> {
     await mkdir(workspaceRoot, { recursive: true });
-    const connections = await connectionStore.list();
-    const historicalFreeSeed = connections.find(isHistoricalOpenCodeFreeSeed);
-    if (historicalFreeSeed) {
-      await connectionStore.update(historicalFreeSeed.slug, {
-        defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
-        enabledModelIds: [OPENCODE_FREE_DEFAULT_MODEL],
-      });
-      emitConnectionListChanged();
-    }
-    if (connections.length > 0) return;
+    if ((await connectionStore.list()).length > 0) return;
 
     // opencode-free is seeded unconditionally so a fresh install is usable with
     // zero credentials; env-keyed providers layer on top and take the default

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -2,7 +2,11 @@ import { app, nativeImage } from 'electron';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { setActiveProxy } from '@maka/runtime';
-import { resolveBootstrapConnections } from '@maka/core';
+import {
+  OPENCODE_FREE_DEFAULT_MODEL,
+  isHistoricalOpenCodeFreeSeed,
+  resolveBootstrapConnections,
+} from '@maka/core';
 import type {
   AgentGraphCoordinator,
   AgentGraphSupervisorWakeCoordinator,
@@ -210,7 +214,16 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
 
   async function ensureBootstrapConnection(): Promise<void> {
     await mkdir(workspaceRoot, { recursive: true });
-    if ((await connectionStore.list()).length > 0) return;
+    const connections = await connectionStore.list();
+    const historicalFreeSeed = connections.find(isHistoricalOpenCodeFreeSeed);
+    if (historicalFreeSeed) {
+      await connectionStore.update(historicalFreeSeed.slug, {
+        defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
+        enabledModelIds: [OPENCODE_FREE_DEFAULT_MODEL],
+      });
+      emitConnectionListChanged();
+    }
+    if (connections.length > 0) return;
 
     // opencode-free is seeded unconditionally so a fresh install is usable with
     // zero credentials; env-keyed providers layer on top and take the default

--- a/apps/desktop/src/main/connections-ipc-main.ts
+++ b/apps/desktop/src/main/connections-ipc-main.ts
@@ -2,6 +2,7 @@ import type { IpcMain } from 'electron';
 import {
   buildConnectionModelCatalogEntries,
   generalizedErrorMessageChinese,
+  isManagedOpenCodeFreeSeed,
   normalizeConnectionBaseUrl,
 } from '@maka/core';
 import type {
@@ -231,7 +232,18 @@ export function registerConnectionsIpc(deps: ConnectionsIpcDeps): void {
       };
     }
     const result = await testConnection(connection, apiKey ?? '', opts?.model);
-    await connectionStore.update(slug, connectionTestStatusPatch(result));
+    const healthyFreeModel = result.ok ? result.modelTested : undefined;
+    const adoptsHealthyFreeModel =
+      healthyFreeModel !== undefined &&
+      !opts?.model?.trim() &&
+      healthyFreeModel !== connection.defaultModel &&
+      isManagedOpenCodeFreeSeed(connection);
+    await connectionStore.update(slug, {
+      ...connectionTestStatusPatch(result),
+      ...(adoptsHealthyFreeModel
+        ? { defaultModel: healthyFreeModel, enabledModelIds: [healthyFreeModel] }
+        : {}),
+    });
     emitConnectionListChanged();
     return result;
   });

--- a/apps/desktop/src/main/connections-ipc-main.ts
+++ b/apps/desktop/src/main/connections-ipc-main.ts
@@ -2,7 +2,6 @@ import type { IpcMain } from 'electron';
 import {
   buildConnectionModelCatalogEntries,
   generalizedErrorMessageChinese,
-  isManagedOpenCodeFreeSeed,
   normalizeConnectionBaseUrl,
 } from '@maka/core';
 import type {
@@ -232,18 +231,7 @@ export function registerConnectionsIpc(deps: ConnectionsIpcDeps): void {
       };
     }
     const result = await testConnection(connection, apiKey ?? '', opts?.model);
-    const healthyFreeModel = result.ok ? result.modelTested : undefined;
-    const adoptsHealthyFreeModel =
-      healthyFreeModel !== undefined &&
-      !opts?.model?.trim() &&
-      healthyFreeModel !== connection.defaultModel &&
-      isManagedOpenCodeFreeSeed(connection);
-    await connectionStore.update(slug, {
-      ...connectionTestStatusPatch(result),
-      ...(adoptsHealthyFreeModel
-        ? { defaultModel: healthyFreeModel, enabledModelIds: [healthyFreeModel] }
-        : {}),
-    });
+    await connectionStore.update(slug, connectionTestStatusPatch(result));
     emitConnectionListChanged();
     return result;
   });

--- a/packages/core/src/__tests__/bootstrap-connections.test.ts
+++ b/packages/core/src/__tests__/bootstrap-connections.test.ts
@@ -16,9 +16,13 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  OPENCODE_FREE_BOOTSTRAP_VERSION,
   OPENCODE_FREE_DEFAULT_MODEL,
+  OPENCODE_FREE_LEGACY_DEFAULT_MODEL,
   resolveBootstrapConnections,
+  resolveOpenCodeFreeBootstrapMigration,
 } from '../bootstrap-connections.js';
+import type { LlmConnection } from '../llm-connections.js';
 
 describe('resolveBootstrapConnections — zero-credential default seed', () => {
   it('selects one default while keeping the credential-free fallback', () => {
@@ -33,6 +37,9 @@ describe('resolveBootstrapConnections — zero-credential default seed', () => {
       const seeds = resolveBootstrapConnections(env);
       const free = seeds.find((seed) => seed.slug === 'opencode-free');
       assert.equal(free?.defaultModel, OPENCODE_FREE_DEFAULT_MODEL);
+      assert.deepEqual(free?.extras, {
+        makaBootstrap: { id: 'opencode-free', version: OPENCODE_FREE_BOOTSTRAP_VERSION },
+      });
       assert.deepEqual(
         seeds.filter((seed) => seed.isDefault).map((seed) => seed.slug),
         [defaultSlug],
@@ -41,6 +48,39 @@ describe('resolveBootstrapConnections — zero-credential default seed', () => {
         seeds.some((seed) => seed.slug === 'env-openai'),
         !excludesOpenAi && 'OPENAI_API_KEY' in env,
       );
+    }
+  });
+
+  it('migrates only the untouched historical OpenCode Free seed', () => {
+    const legacy: LlmConnection = {
+      slug: 'opencode-free',
+      name: 'OpenCode Free',
+      providerType: 'opencode-free',
+      defaultModel: OPENCODE_FREE_LEGACY_DEFAULT_MODEL,
+      enabledModelIds: [OPENCODE_FREE_LEGACY_DEFAULT_MODEL],
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const migration = resolveOpenCodeFreeBootstrapMigration(legacy);
+    assert.deepEqual(migration, {
+      defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
+      enabledModelIds: [OPENCODE_FREE_DEFAULT_MODEL],
+      extras: {
+        makaBootstrap: { id: 'opencode-free', version: OPENCODE_FREE_BOOTSTRAP_VERSION },
+      },
+    });
+    assert.equal(resolveOpenCodeFreeBootstrapMigration({ ...legacy, ...migration }), undefined);
+
+    for (const customized of [
+      { ...legacy, name: 'My free connection' },
+      { ...legacy, baseUrl: 'https://custom.example/v1' },
+      { ...legacy, enabledModelIds: [OPENCODE_FREE_LEGACY_DEFAULT_MODEL, 'custom-free'] },
+      { ...legacy, models: [{ id: OPENCODE_FREE_LEGACY_DEFAULT_MODEL }] },
+      { ...legacy, extras: { owner: 'user' } },
+    ]) {
+      assert.equal(resolveOpenCodeFreeBootstrapMigration(customized), undefined);
     }
   });
 });

--- a/packages/core/src/__tests__/bootstrap-connections.test.ts
+++ b/packages/core/src/__tests__/bootstrap-connections.test.ts
@@ -15,7 +15,11 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { resolveBootstrapConnections } from '../bootstrap-connections.js';
+import {
+  OPENCODE_FREE_DEFAULT_MODEL,
+  isHistoricalOpenCodeFreeSeed,
+  resolveBootstrapConnections,
+} from '../bootstrap-connections.js';
 
 describe('resolveBootstrapConnections — zero-credential default seed', () => {
   it('selects one default while keeping the credential-free fallback', () => {
@@ -29,7 +33,7 @@ describe('resolveBootstrapConnections — zero-credential default seed', () => {
     for (const [env, defaultSlug, excludesOpenAi] of cases) {
       const seeds = resolveBootstrapConnections(env);
       const free = seeds.find((seed) => seed.slug === 'opencode-free');
-      assert.equal(free?.defaultModel, 'big-pickle');
+      assert.equal(free?.defaultModel, OPENCODE_FREE_DEFAULT_MODEL);
       assert.deepEqual(
         seeds.filter((seed) => seed.isDefault).map((seed) => seed.slug),
         [defaultSlug],
@@ -39,5 +43,29 @@ describe('resolveBootstrapConnections — zero-credential default seed', () => {
         !excludesOpenAi && 'OPENAI_API_KEY' in env,
       );
     }
+  });
+
+  it('recognizes only the untouched historical OpenCode Free seed', () => {
+    const historical = {
+      slug: 'opencode-free',
+      name: 'OpenCode Free',
+      providerType: 'opencode-free' as const,
+      defaultModel: 'big-pickle',
+      enabledModelIds: ['big-pickle'],
+    };
+
+    assert.equal(isHistoricalOpenCodeFreeSeed(historical), true);
+    assert.equal(
+      isHistoricalOpenCodeFreeSeed({ ...historical, name: 'My free connection' }),
+      false,
+    );
+    assert.equal(
+      isHistoricalOpenCodeFreeSeed({
+        ...historical,
+        enabledModelIds: ['big-pickle', 'mimo-v2.5-free'],
+      }),
+      false,
+    );
+    assert.equal(isHistoricalOpenCodeFreeSeed({ ...historical, models: [] }), false);
   });
 });

--- a/packages/core/src/__tests__/bootstrap-connections.test.ts
+++ b/packages/core/src/__tests__/bootstrap-connections.test.ts
@@ -18,6 +18,7 @@ import { describe, it } from 'node:test';
 import {
   OPENCODE_FREE_DEFAULT_MODEL,
   isHistoricalOpenCodeFreeSeed,
+  isManagedOpenCodeFreeSeed,
   resolveBootstrapConnections,
 } from '../bootstrap-connections.js';
 
@@ -52,6 +53,9 @@ describe('resolveBootstrapConnections — zero-credential default seed', () => {
       providerType: 'opencode-free' as const,
       defaultModel: 'big-pickle',
       enabledModelIds: ['big-pickle'],
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
     };
 
     assert.equal(isHistoricalOpenCodeFreeSeed(historical), true);
@@ -67,5 +71,7 @@ describe('resolveBootstrapConnections — zero-credential default seed', () => {
       false,
     );
     assert.equal(isHistoricalOpenCodeFreeSeed({ ...historical, models: [] }), false);
+    assert.equal(isManagedOpenCodeFreeSeed(historical), true);
+    assert.equal(isManagedOpenCodeFreeSeed({ ...historical, name: 'My free connection' }), false);
   });
 });

--- a/packages/core/src/__tests__/bootstrap-connections.test.ts
+++ b/packages/core/src/__tests__/bootstrap-connections.test.ts
@@ -17,8 +17,6 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
   OPENCODE_FREE_DEFAULT_MODEL,
-  isHistoricalOpenCodeFreeSeed,
-  isManagedOpenCodeFreeSeed,
   resolveBootstrapConnections,
 } from '../bootstrap-connections.js';
 
@@ -44,34 +42,5 @@ describe('resolveBootstrapConnections — zero-credential default seed', () => {
         !excludesOpenAi && 'OPENAI_API_KEY' in env,
       );
     }
-  });
-
-  it('recognizes only the untouched historical OpenCode Free seed', () => {
-    const historical = {
-      slug: 'opencode-free',
-      name: 'OpenCode Free',
-      providerType: 'opencode-free' as const,
-      defaultModel: 'big-pickle',
-      enabledModelIds: ['big-pickle'],
-      enabled: true,
-      createdAt: 1,
-      updatedAt: 1,
-    };
-
-    assert.equal(isHistoricalOpenCodeFreeSeed(historical), true);
-    assert.equal(
-      isHistoricalOpenCodeFreeSeed({ ...historical, name: 'My free connection' }),
-      false,
-    );
-    assert.equal(
-      isHistoricalOpenCodeFreeSeed({
-        ...historical,
-        enabledModelIds: ['big-pickle', 'mimo-v2.5-free'],
-      }),
-      false,
-    );
-    assert.equal(isHistoricalOpenCodeFreeSeed({ ...historical, models: [] }), false);
-    assert.equal(isManagedOpenCodeFreeSeed(historical), true);
-    assert.equal(isManagedOpenCodeFreeSeed({ ...historical, name: 'My free connection' }), false);
   });
 });

--- a/packages/core/src/bootstrap-connections.ts
+++ b/packages/core/src/bootstrap-connections.ts
@@ -13,10 +13,9 @@
  * prior env-bootstrap precedence (Anthropic before OpenAI).
  */
 
-import type { LlmConnection, ProviderType } from './llm-connections.js';
+import type { ProviderType } from './llm-connections.js';
 
 export const OPENCODE_FREE_DEFAULT_MODEL = 'nemotron-3-ultra-free';
-const HISTORICAL_OPENCODE_FREE_DEFAULT_MODEL = 'big-pickle';
 
 export interface BootstrapConnectionSeed {
   readonly slug: string;
@@ -37,42 +36,6 @@ const OPENCODE_FREE_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
   providerType: 'opencode-free',
   defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
 };
-
-/**
- * Recognize the exact connection shape written by the historical bootstrap.
- * Anything the user customized (including its name or model inventory) is
- * deliberately excluded from this one-time repair.
- */
-export function isHistoricalOpenCodeFreeSeed(
-  connection: Pick<
-    LlmConnection,
-    'slug' | 'name' | 'providerType' | 'baseUrl' | 'defaultModel' | 'enabledModelIds' | 'models'
-  >,
-): boolean {
-  return (
-    connection.slug === 'opencode-free' &&
-    connection.name === 'OpenCode Free' &&
-    connection.providerType === 'opencode-free' &&
-    !connection.baseUrl &&
-    connection.defaultModel === HISTORICAL_OPENCODE_FREE_DEFAULT_MODEL &&
-    connection.enabledModelIds?.length === 1 &&
-    connection.enabledModelIds[0] === HISTORICAL_OPENCODE_FREE_DEFAULT_MODEL &&
-    connection.models === undefined
-  );
-}
-
-/** Whether a connection still represents Maka's single-model managed seed. */
-export function isManagedOpenCodeFreeSeed(connection: LlmConnection): boolean {
-  return (
-    connection.slug === 'opencode-free' &&
-    connection.name === 'OpenCode Free' &&
-    connection.providerType === 'opencode-free' &&
-    !connection.baseUrl &&
-    connection.models === undefined &&
-    connection.enabledModelIds?.length === 1 &&
-    connection.enabledModelIds[0] === connection.defaultModel
-  );
-}
 
 const ANTHROPIC_ENV_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
   slug: 'env-anthropic',

--- a/packages/core/src/bootstrap-connections.ts
+++ b/packages/core/src/bootstrap-connections.ts
@@ -13,9 +13,15 @@
  * prior env-bootstrap precedence (Anthropic before OpenAI).
  */
 
-import type { ProviderType } from './llm-connections.js';
+import type { LlmConnection, ProviderType, UpdateConnectionInput } from './llm-connections.js';
 
 export const OPENCODE_FREE_DEFAULT_MODEL = 'nemotron-3-ultra-free';
+export const OPENCODE_FREE_LEGACY_DEFAULT_MODEL = 'big-pickle';
+export const OPENCODE_FREE_BOOTSTRAP_VERSION = 2;
+
+const OPENCODE_FREE_BOOTSTRAP_EXTRAS = {
+  makaBootstrap: { id: 'opencode-free', version: OPENCODE_FREE_BOOTSTRAP_VERSION },
+} as const;
 
 export interface BootstrapConnectionSeed {
   readonly slug: string;
@@ -23,6 +29,7 @@ export interface BootstrapConnectionSeed {
   readonly providerType: ProviderType;
   readonly defaultModel: string;
   readonly isDefault: boolean;
+  readonly extras?: Record<string, unknown>;
 }
 
 export interface BootstrapEnv {
@@ -35,6 +42,7 @@ const OPENCODE_FREE_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
   name: 'OpenCode Free',
   providerType: 'opencode-free',
   defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
+  extras: OPENCODE_FREE_BOOTSTRAP_EXTRAS,
 };
 
 const ANTHROPIC_ENV_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
@@ -73,4 +81,34 @@ export function resolveBootstrapConnections(env: BootstrapEnv): readonly Bootstr
     seeds.push({ ...OPENAI_ENV_SEED, isDefault: true });
   }
   return seeds;
+}
+
+/**
+ * Migrate only the exact connection shape written by Maka's historical
+ * OpenCode Free bootstrap. Any user-visible customization makes ownership
+ * ambiguous and therefore fails closed.
+ */
+export function resolveOpenCodeFreeBootstrapMigration(
+  connection: LlmConnection,
+): UpdateConnectionInput | undefined {
+  if (
+    connection.slug !== 'opencode-free' ||
+    connection.name !== 'OpenCode Free' ||
+    connection.providerType !== 'opencode-free' ||
+    connection.baseUrl !== undefined ||
+    connection.defaultModel !== OPENCODE_FREE_LEGACY_DEFAULT_MODEL ||
+    connection.enabled !== true ||
+    connection.enabledModelIds?.length !== 1 ||
+    connection.enabledModelIds[0] !== OPENCODE_FREE_LEGACY_DEFAULT_MODEL ||
+    connection.models !== undefined ||
+    connection.extras !== undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
+    enabledModelIds: [OPENCODE_FREE_DEFAULT_MODEL],
+    extras: OPENCODE_FREE_BOOTSTRAP_EXTRAS,
+  };
 }

--- a/packages/core/src/bootstrap-connections.ts
+++ b/packages/core/src/bootstrap-connections.ts
@@ -13,7 +13,10 @@
  * prior env-bootstrap precedence (Anthropic before OpenAI).
  */
 
-import type { ProviderType } from './llm-connections.js';
+import type { LlmConnection, ProviderType } from './llm-connections.js';
+
+export const OPENCODE_FREE_DEFAULT_MODEL = 'nemotron-3-ultra-free';
+const HISTORICAL_OPENCODE_FREE_DEFAULT_MODEL = 'big-pickle';
 
 export interface BootstrapConnectionSeed {
   readonly slug: string;
@@ -32,8 +35,31 @@ const OPENCODE_FREE_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
   slug: 'opencode-free',
   name: 'OpenCode Free',
   providerType: 'opencode-free',
-  defaultModel: 'big-pickle',
+  defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
 };
+
+/**
+ * Recognize the exact connection shape written by the historical bootstrap.
+ * Anything the user customized (including its name or model inventory) is
+ * deliberately excluded from this one-time repair.
+ */
+export function isHistoricalOpenCodeFreeSeed(
+  connection: Pick<
+    LlmConnection,
+    'slug' | 'name' | 'providerType' | 'baseUrl' | 'defaultModel' | 'enabledModelIds' | 'models'
+  >,
+): boolean {
+  return (
+    connection.slug === 'opencode-free' &&
+    connection.name === 'OpenCode Free' &&
+    connection.providerType === 'opencode-free' &&
+    !connection.baseUrl &&
+    connection.defaultModel === HISTORICAL_OPENCODE_FREE_DEFAULT_MODEL &&
+    connection.enabledModelIds?.length === 1 &&
+    connection.enabledModelIds[0] === HISTORICAL_OPENCODE_FREE_DEFAULT_MODEL &&
+    connection.models === undefined
+  );
+}
 
 const ANTHROPIC_ENV_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
   slug: 'env-anthropic',

--- a/packages/core/src/bootstrap-connections.ts
+++ b/packages/core/src/bootstrap-connections.ts
@@ -61,6 +61,19 @@ export function isHistoricalOpenCodeFreeSeed(
   );
 }
 
+/** Whether a connection still represents Maka's single-model managed seed. */
+export function isManagedOpenCodeFreeSeed(connection: LlmConnection): boolean {
+  return (
+    connection.slug === 'opencode-free' &&
+    connection.name === 'OpenCode Free' &&
+    connection.providerType === 'opencode-free' &&
+    !connection.baseUrl &&
+    connection.models === undefined &&
+    connection.enabledModelIds?.length === 1 &&
+    connection.enabledModelIds[0] === connection.defaultModel
+  );
+}
+
 const ANTHROPIC_ENV_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
   slug: 'env-anthropic',
   name: 'Anthropic (env)',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1530,6 +1530,7 @@ export type {
 export {
   OPENCODE_FREE_DEFAULT_MODEL,
   isHistoricalOpenCodeFreeSeed,
+  isManagedOpenCodeFreeSeed,
   resolveBootstrapConnections,
 } from './bootstrap-connections.js';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1529,8 +1529,6 @@ export type {
 } from './bootstrap-connections.js';
 export {
   OPENCODE_FREE_DEFAULT_MODEL,
-  isHistoricalOpenCodeFreeSeed,
-  isManagedOpenCodeFreeSeed,
   resolveBootstrapConnections,
 } from './bootstrap-connections.js';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1528,8 +1528,11 @@ export type {
   BootstrapEnv,
 } from './bootstrap-connections.js';
 export {
+  OPENCODE_FREE_BOOTSTRAP_VERSION,
   OPENCODE_FREE_DEFAULT_MODEL,
+  OPENCODE_FREE_LEGACY_DEFAULT_MODEL,
   resolveBootstrapConnections,
+  resolveOpenCodeFreeBootstrapMigration,
 } from './bootstrap-connections.js';
 
 // model-catalog.ts

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1527,7 +1527,11 @@ export type {
   BootstrapConnectionSeed,
   BootstrapEnv,
 } from './bootstrap-connections.js';
-export { resolveBootstrapConnections } from './bootstrap-connections.js';
+export {
+  OPENCODE_FREE_DEFAULT_MODEL,
+  isHistoricalOpenCodeFreeSeed,
+  resolveBootstrapConnections,
+} from './bootstrap-connections.js';
 
 // model-catalog.ts
 export type {

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -506,6 +506,7 @@ export interface CreateConnectionInput {
   baseUrl?: string;
   defaultModel?: string;
   apiKey?: string;
+  extras?: Record<string, unknown>;
 }
 
 export interface UpdateConnectionInput {
@@ -521,6 +522,7 @@ export interface UpdateConnectionInput {
   lastTestStatus?: ConnectionLastTestStatus;
   lastTestAt?: string;
   lastTestMessage?: string;
+  extras?: Record<string, unknown>;
 }
 
 export function migrateConnectionV1ToV2(old: unknown): LlmConnection {

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -1,4 +1,5 @@
 import type { BackendKind } from './session.js';
+import { OPENCODE_FREE_DEFAULT_MODEL } from './bootstrap-connections.js';
 import {
   GENERATED_MODELS_DEV_METADATA,
   GENERATED_MODELS_DEV_MODEL_PROVIDER_OVERRIDES,
@@ -572,9 +573,9 @@ const opencodeGoModelIds = toolCallingModelIds(
 // validated against the opencode snapshot for active + tool-capable, mirroring
 // the bootstrap validation every other opencode plan entry performs.
 const opencodeFreeModelIds = [
-  'big-pickle',
+  OPENCODE_FREE_DEFAULT_MODEL,
   'mimo-v2.5-free',
-  'nemotron-3-ultra-free',
+  'big-pickle',
   'deepseek-v4-flash-free',
   'north-mini-code-free',
   'laguna-s-2.1-free',

--- a/packages/runtime/src/__tests__/opencode-free-anonymous.test.ts
+++ b/packages/runtime/src/__tests__/opencode-free-anonymous.test.ts
@@ -15,7 +15,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { generateText } from 'ai';
 import type { LlmConnection } from '@maka/core';
-import { getAIModel } from '@maka/runtime';
+import { getAIModel, testConnection } from '@maka/runtime';
 
 describe('opencode-free anonymous runtime', () => {
   test('omits Authorization and posts to zen/v1 with the model id (empty key, no secret)', async () => {
@@ -77,5 +77,41 @@ describe('opencode-free anonymous runtime', () => {
     assert.equal(captured?.url, 'https://opencode.ai/zen/v1/chat/completions');
     assert.equal(captured?.model, 'big-pickle');
     assert.equal(result.text, 'ok');
+  });
+
+  test('rejects a 200 error envelope and probes the next free model', async () => {
+    const requestedModels: string[] = [];
+    const connection: LlmConnection = {
+      slug: 'opencode-free',
+      name: 'OpenCode Free',
+      providerType: 'opencode-free',
+      defaultModel: 'big-pickle',
+      enabledModelIds: ['big-pickle'],
+      enabled: true,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const fakeFetch: typeof globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { model: string };
+      requestedModels.push(body.model);
+      if (body.model === 'big-pickle') {
+        return new Response(JSON.stringify({ error: { type: 'server_error' } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    };
+
+    const result = await testConnection(connection, '', undefined, { fetch: fakeFetch });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.modelTested, 'nemotron-3-ultra-free');
+    assert.deepEqual(requestedModels, ['big-pickle', 'nemotron-3-ultra-free']);
   });
 });

--- a/packages/runtime/src/__tests__/opencode-free-anonymous.test.ts
+++ b/packages/runtime/src/__tests__/opencode-free-anonymous.test.ts
@@ -114,4 +114,132 @@ describe('opencode-free anonymous runtime', () => {
     assert.equal(result.modelTested, 'nemotron-3-ultra-free');
     assert.deepEqual(requestedModels, ['big-pickle', 'nemotron-3-ultra-free']);
   });
+
+  test('probes a healthy fallback for a customized connection without hiding the model tested', async () => {
+    const requestedModels: string[] = [];
+    const connection: LlmConnection = {
+      slug: 'my-opencode-free',
+      name: 'My free connection',
+      providerType: 'opencode-free',
+      baseUrl: 'https://custom.example/v1',
+      defaultModel: 'custom-broken-free',
+      enabledModelIds: ['custom-broken-free'],
+      enabled: true,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const fakeFetch: typeof globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { model: string };
+      requestedModels.push(body.model);
+      return new Response(
+        JSON.stringify(
+          body.model === 'custom-broken-free'
+            ? { error: { type: 'server_error' } }
+            : { choices: [{ message: { role: 'assistant', content: 'ok' } }] },
+        ),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    };
+
+    const result = await testConnection(connection, '', undefined, { fetch: fakeFetch });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.modelTested, 'nemotron-3-ultra-free');
+    assert.deepEqual(requestedModels, ['custom-broken-free', 'nemotron-3-ultra-free']);
+  });
+
+  test('tests an explicit model once without probing fallbacks', async () => {
+    const requestedModels: string[] = [];
+    const connection: LlmConnection = {
+      slug: 'opencode-free',
+      name: 'OpenCode Free',
+      providerType: 'opencode-free',
+      defaultModel: 'nemotron-3-ultra-free',
+      enabled: true,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const fakeFetch: typeof globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { model: string };
+      requestedModels.push(body.model);
+      return new Response(JSON.stringify({ error: { type: 'server_error' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+
+    const result = await testConnection(connection, '', 'explicit-free', { fetch: fakeFetch });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.modelTested, 'explicit-free');
+    assert.deepEqual(requestedModels, ['explicit-free']);
+  });
+
+  test('rejects malformed completion choices before accepting a fallback', async () => {
+    const requestedModels: string[] = [];
+    const connection: LlmConnection = {
+      slug: 'opencode-free',
+      name: 'OpenCode Free',
+      providerType: 'opencode-free',
+      defaultModel: 'big-pickle',
+      enabledModelIds: ['big-pickle'],
+      enabled: true,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const fakeFetch: typeof globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { model: string };
+      requestedModels.push(body.model);
+      return new Response(
+        JSON.stringify(
+          body.model === 'big-pickle'
+            ? { choices: [{}] }
+            : { choices: [{ message: { role: 'assistant', content: 'ok' } }] },
+        ),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    };
+
+    const result = await testConnection(connection, '', undefined, { fetch: fakeFetch });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.modelTested, 'nemotron-3-ultra-free');
+    assert.deepEqual(requestedModels, ['big-pickle', 'nemotron-3-ultra-free']);
+  });
+
+  test('bounds all fallback probes by one shared deadline', async () => {
+    const requestedModels: string[] = [];
+    const connection: LlmConnection = {
+      slug: 'opencode-free',
+      name: 'OpenCode Free',
+      providerType: 'opencode-free',
+      defaultModel: 'big-pickle',
+      enabledModelIds: ['big-pickle'],
+      enabled: true,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const fakeFetch: typeof globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { model: string };
+      requestedModels.push(body.model);
+      return await new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        assert.ok(signal);
+        const rejectFromAbort = () => reject(signal.reason);
+        if (signal.aborted) rejectFromAbort();
+        else signal.addEventListener('abort', rejectFromAbort, { once: true });
+      });
+    };
+    const startedAt = Date.now();
+
+    const result = await testConnection(connection, '', undefined, {
+      fetch: fakeFetch,
+      timeoutMs: 40,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errorClass, 'timeout');
+    assert.ok(Date.now() - startedAt < 1_000);
+    assert.ok(requestedModels.length > 0);
+  });
 });

--- a/packages/runtime/src/__tests__/opencode-free-anonymous.test.ts
+++ b/packages/runtime/src/__tests__/opencode-free-anonymous.test.ts
@@ -207,6 +207,39 @@ describe('opencode-free anonymous runtime', () => {
     assert.deepEqual(requestedModels, ['big-pickle', 'nemotron-3-ultra-free']);
   });
 
+  test('accepts a reasoning completion whose final content is null', async () => {
+    const connection: LlmConnection = {
+      slug: 'opencode-free',
+      name: 'OpenCode Free',
+      providerType: 'opencode-free',
+      defaultModel: 'mimo-v2.5-free',
+      enabled: true,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const fakeFetch: typeof globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: null,
+                reasoning_content: 'The answer was truncated before final text.',
+              },
+              finish_reason: 'length',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+
+    const result = await testConnection(connection, '', 'mimo-v2.5-free', { fetch: fakeFetch });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.modelTested, 'mimo-v2.5-free');
+  });
+
   test('bounds all fallback probes by one shared deadline', async () => {
     const requestedModels: string[] = [];
     const connection: LlmConnection = {

--- a/packages/runtime/src/connection-effect-fetch.ts
+++ b/packages/runtime/src/connection-effect-fetch.ts
@@ -36,10 +36,6 @@ export async function fetchForConnectionEffect(
   input: string | URL,
   init: ProxiedFetchInit = {},
 ): Promise<ConnectionEffectResponse> {
-  if (!fetchFn) {
-    return manageConnectionEffectResponse(await proxiedFetch(input.toString(), init));
-  }
-
   const { timeoutMs = 15_000, signal, ...requestInit } = init;
   const controller = new AbortController();
   let timedOut = false;
@@ -61,10 +57,19 @@ export async function fetchForConnectionEffect(
   }
 
   try {
-    const response = await fetchFn(input, {
-      ...requestInit,
-      signal: controller.signal,
-    } as RequestInit);
+    // Own the timeout above both transports so it remains active until the
+    // response body is consumed or cancelled. proxiedFetch's native timeout
+    // ends at headers because it also serves streaming callers.
+    const response = fetchFn
+      ? await fetchFn(input, {
+          ...requestInit,
+          signal: controller.signal,
+        } as RequestInit)
+      : await proxiedFetch(input.toString(), {
+          ...requestInit,
+          signal: controller.signal,
+          timeoutMs: 0,
+        });
     return manageConnectionEffectResponse(response, {
       didTimeOut: () => timedOut,
       finish: () => {

--- a/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
+++ b/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
@@ -169,6 +169,31 @@ describe('connection effect network transport', () => {
     }
   });
 
+  test('production proxied fetch keeps the deadline active while reading the body', async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, {
+        'content-type': 'application/json',
+        'content-length': '1000',
+      });
+      response.write('{"data":[');
+    });
+    const port = await listen(server);
+
+    try {
+      const response = await fetchForConnectionEffect(
+        undefined,
+        `http://127.0.0.1:${port}/models`,
+        { timeoutMs: 50 },
+      );
+      await assert.rejects(
+        response.readJson(),
+        (error: unknown) => error instanceof ConnectionEffectFetchError && error.kind === 'timeout',
+      );
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   test('oversized provider JSON and error bodies fail without escaping their bounds', async () => {
     const server = createServer((request, response) => {
       if (request.url?.startsWith('/models/')) {

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -30,6 +30,10 @@ import {
 
 const CONNECTION_TEST_TIMEOUT_MS = 15_000;
 
+export interface ConnectionTestOptions extends ConnectionEffectFetchOptions {
+  readonly timeoutMs?: number;
+}
+
 /**
  * Prefer an explicit model, then a still-live configured model. Legacy
  * connections without a discovered inventory keep the historical
@@ -66,11 +70,18 @@ export async function testConnection(
   connection: LlmConnection,
   apiKey: string,
   model?: string,
-  options: ConnectionEffectFetchOptions = {},
+  options: ConnectionTestOptions = {},
 ): Promise<ConnectionTestResult> {
   const t0 = Date.now();
+  const configuredTimeoutMs = options.timeoutMs;
+  const timeoutMs =
+    typeof configuredTimeoutMs === 'number' &&
+    Number.isFinite(configuredTimeoutMs) &&
+    configuredTimeoutMs > 0
+      ? Math.floor(configuredTimeoutMs)
+      : CONNECTION_TEST_TIMEOUT_MS;
   try {
-    return await testConnectionStrict(connection, apiKey, model, options.fetch, t0);
+    return await testConnectionStrict(connection, apiKey, model, options.fetch, t0, timeoutMs);
   } catch (error) {
     return connectionTestFailure(error, t0, true);
   }
@@ -115,6 +126,7 @@ async function testConnectionStrict(
   model: string | undefined,
   fetchFn: ConnectionEffectFetch | undefined,
   t0: number,
+  timeoutMs = CONNECTION_TEST_TIMEOUT_MS,
 ): Promise<ConnectionTestResult> {
   const defaults = PROVIDER_DEFAULTS[connection.providerType];
   // Unknown providerType → can't pick an auth path or fallback model. Return a
@@ -136,7 +148,7 @@ async function testConnectionStrict(
     let lastFailure: ConnectionTestResult | undefined;
     for (let index = 0; index < candidates.length; index += 1) {
       const candidate = candidates[index]!;
-      const remainingMs = CONNECTION_TEST_TIMEOUT_MS - (Date.now() - t0);
+      const remainingMs = timeoutMs - (Date.now() - t0);
       if (remainingMs <= 0) break;
       const remainingCandidates = candidates.length - index;
       const attemptTimeoutMs = Math.max(1, Math.floor(remainingMs / remainingCandidates));
@@ -165,7 +177,7 @@ async function testConnectionStrict(
     );
   }
 
-  return await testConnectionModel(connection, secret, testModel, fetchFn, t0);
+  return await testConnectionModel(connection, secret, testModel, fetchFn, t0, timeoutMs);
 }
 
 async function testConnectionModel(
@@ -380,7 +392,15 @@ async function probeOpenAI(
 function isOpenAIChatCompletion(value: unknown): boolean {
   if (!value || typeof value !== 'object') return false;
   const choices = (value as { choices?: unknown }).choices;
-  return Array.isArray(choices) && choices.length > 0;
+  return (
+    Array.isArray(choices) &&
+    choices.some((choice) => {
+      if (!choice || typeof choice !== 'object') return false;
+      const message = (choice as { message?: unknown }).message;
+      if (!message || typeof message !== 'object') return false;
+      return typeof (message as { content?: unknown }).content === 'string';
+    })
+  );
 }
 
 async function probeGoogle(

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -129,6 +129,53 @@ async function testConnectionStrict(
   if (!testModel) {
     return { ok: false, errorMessage: 'No model to test' };
   }
+  if (connection.providerType === 'opencode-free' && !model?.trim()) {
+    const candidates = [
+      ...new Set([...connectionEnabledModelIds(connection), ...defaults.fallbackModels]),
+    ];
+    let lastFailure: ConnectionTestResult | undefined;
+    for (let index = 0; index < candidates.length; index += 1) {
+      const candidate = candidates[index]!;
+      const remainingMs = CONNECTION_TEST_TIMEOUT_MS - (Date.now() - t0);
+      if (remainingMs <= 0) break;
+      const remainingCandidates = candidates.length - index;
+      const attemptTimeoutMs = Math.max(1_000, Math.floor(remainingMs / remainingCandidates));
+      try {
+        const result = await testConnectionModel(
+          connection,
+          secret,
+          candidate,
+          fetchFn,
+          t0,
+          attemptTimeoutMs,
+        );
+        if (result.ok) return result;
+        lastFailure = result;
+      } catch (error) {
+        lastFailure = connectionTestFailure(error, t0, true);
+      }
+    }
+    return (
+      lastFailure ?? {
+        ok: false,
+        errorMessage: 'No OpenCode Free model responded within the connection-test budget',
+        errorClass: 'provider_unavailable',
+        latencyMs: Date.now() - t0,
+      }
+    );
+  }
+
+  return await testConnectionModel(connection, secret, testModel, fetchFn, t0);
+}
+
+async function testConnectionModel(
+  connection: ConnectionEffectConnection,
+  secret: string,
+  testModel: string,
+  fetchFn: ConnectionEffectFetch | undefined,
+  t0: number,
+  timeoutMs = CONNECTION_TEST_TIMEOUT_MS,
+): Promise<ConnectionTestResult> {
   const { adapter, baseUrl, apiProtocol } = resolveModelRuntime(connection, testModel);
 
   switch (adapter.kind) {
@@ -142,11 +189,11 @@ async function testConnectionStrict(
         openAiAdapterApiProtocol(testModel, connection.providerType);
       return resolvedApiProtocol === 'openai-responses'
         ? await probeOpenAIResponses(baseUrl, secret, testModel, t0, fetchFn)
-        : await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn);
+        : await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn, timeoutMs);
     }
     case 'openai-codex':
     case 'openai-compatible':
-      return await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn);
+      return await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn, timeoutMs);
     case 'github-copilot':
       return await probeGitHubCopilot(baseUrl, secret, testModel, t0, fetchFn);
     case 'google':
@@ -287,6 +334,7 @@ async function probeOpenAI(
   model: string,
   t0: number,
   fetchFn: ConnectionEffectFetch | undefined,
+  timeoutMs = CONNECTION_TEST_TIMEOUT_MS,
 ): Promise<ConnectionTestResult> {
   if (connection.providerType === 'openai-codex') {
     // Codex Subscription credentials are ChatGPT account-scoped OAuth
@@ -309,11 +357,30 @@ async function probeOpenAI(
       max_tokens: 16,
       messages: [{ role: 'user', content: 'Hi' }],
     }),
-    timeoutMs: CONNECTION_TEST_TIMEOUT_MS,
+    timeoutMs,
   });
   if (!r.ok) return httpFailure(r, t0);
+  if (connection.providerType === 'opencode-free') {
+    const body = await r.readJson<unknown>();
+    if (!isOpenAIChatCompletion(body)) {
+      return {
+        ok: false,
+        errorMessage: 'OpenCode Free returned no valid chat completion',
+        errorClass: 'provider_unavailable',
+        latencyMs: Date.now() - t0,
+        modelTested: model,
+      };
+    }
+    return { ok: true, latencyMs: Date.now() - t0, modelTested: model };
+  }
   await r.cancel();
   return { ok: true, latencyMs: Date.now() - t0, modelTested: model };
+}
+
+function isOpenAIChatCompletion(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const choices = (value as { choices?: unknown }).choices;
+  return Array.isArray(choices) && choices.length > 0;
 }
 
 async function probeGoogle(

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -139,7 +139,7 @@ async function testConnectionStrict(
       const remainingMs = CONNECTION_TEST_TIMEOUT_MS - (Date.now() - t0);
       if (remainingMs <= 0) break;
       const remainingCandidates = candidates.length - index;
-      const attemptTimeoutMs = Math.max(1_000, Math.floor(remainingMs / remainingCandidates));
+      const attemptTimeoutMs = Math.max(1, Math.floor(remainingMs / remainingCandidates));
       try {
         const result = await testConnectionModel(
           connection,

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -398,7 +398,18 @@ function isOpenAIChatCompletion(value: unknown): boolean {
       if (!choice || typeof choice !== 'object') return false;
       const message = (choice as { message?: unknown }).message;
       if (!message || typeof message !== 'object') return false;
-      return typeof (message as { content?: unknown }).content === 'string';
+      const completion = message as {
+        content?: unknown;
+        reasoning?: unknown;
+        reasoning_content?: unknown;
+        tool_calls?: unknown;
+      };
+      return (
+        typeof completion.content === 'string' ||
+        typeof completion.reasoning === 'string' ||
+        typeof completion.reasoning_content === 'string' ||
+        (Array.isArray(completion.tool_calls) && completion.tool_calls.length > 0)
+      );
     })
   );
 }

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -843,6 +843,36 @@ describe('FileConnectionStore', () => {
     });
   });
 
+  test('conditionally updates a bootstrap seed without overwriting concurrent edits', async () => {
+    await withConnectionStore(async (store) => {
+      const created = await store.create({
+        slug: 'opencode-free',
+        name: 'OpenCode Free',
+        providerType: 'opencode-free',
+        defaultModel: 'big-pickle',
+      });
+
+      assert.equal(
+        await store.updateIfUnchanged(created.slug, created.updatedAt - 1, {
+          defaultModel: 'nemotron-3-ultra-free',
+        }),
+        null,
+      );
+      assert.equal((await store.get(created.slug))?.defaultModel, 'big-pickle');
+
+      const migrated = await store.updateIfUnchanged(created.slug, created.updatedAt, {
+        defaultModel: 'nemotron-3-ultra-free',
+        enabledModelIds: ['nemotron-3-ultra-free'],
+        extras: { makaBootstrap: { id: 'opencode-free', version: 2 } },
+      });
+      assert.equal(migrated?.defaultModel, 'nemotron-3-ultra-free');
+      assert.deepEqual(migrated?.enabledModelIds, ['nemotron-3-ultra-free']);
+      assert.deepEqual(migrated?.extras, {
+        makaBootstrap: { id: 'opencode-free', version: 2 },
+      });
+    });
+  });
+
   test('save drops the provider default baseUrl instead of persisting it as an override', async () => {
     await withConnectionStore(async (store, dir) => {
       // save()'s OAuth-sync caller constructs `{ baseUrl: defaults.baseUrl }`;

--- a/packages/storage/src/connection-store.ts
+++ b/packages/storage/src/connection-store.ts
@@ -18,6 +18,11 @@ export interface ConnectionStore {
   get(slug: string): Promise<LlmConnection | null>;
   create(input: CreateConnectionInput): Promise<LlmConnection>;
   update(slug: string, patch: UpdateConnectionInput): Promise<LlmConnection>;
+  updateIfUnchanged(
+    slug: string,
+    expectedUpdatedAt: number,
+    patch: UpdateConnectionInput,
+  ): Promise<LlmConnection | null>;
   delete(slug: string): Promise<void>;
   save(connection: LlmConnection): Promise<LlmConnection>;
   remove(slug: string): Promise<void>;
@@ -79,6 +84,7 @@ class FileConnectionStore implements ConnectionStore {
         enabledModelIds: connectionEnabledModelIds({ defaultModel }),
         createdAt: now,
         updatedAt: now,
+        ...(input.extras ? { extras: input.extras } : {}),
       };
       file.connections.push(next);
       claimVacantWorkspaceDefault(file, next);
@@ -90,12 +96,31 @@ class FileConnectionStore implements ConnectionStore {
   }
 
   async update(slug: string, patch: UpdateConnectionInput): Promise<LlmConnection> {
+    const updated = await this.updateInternal(slug, patch);
+    if (!updated) throw new Error(`No such connection: ${slug}`);
+    return updated;
+  }
+
+  async updateIfUnchanged(
+    slug: string,
+    expectedUpdatedAt: number,
+    patch: UpdateConnectionInput,
+  ): Promise<LlmConnection | null> {
+    return await this.updateInternal(slug, patch, expectedUpdatedAt);
+  }
+
+  private async updateInternal(
+    slug: string,
+    patch: UpdateConnectionInput,
+    expectedUpdatedAt?: number,
+  ): Promise<LlmConnection | null> {
     let updated: LlmConnection | null = null;
     await this.withQueue(async () => {
       const file = await this.readUnlocked();
       const index = file.connections.findIndex((connection) => connection.slug === slug);
-      if (index < 0) throw new Error(`No such connection: ${slug}`);
+      if (index < 0) return;
       const current = file.connections[index]!;
+      if (expectedUpdatedAt !== undefined && current.updatedAt !== expectedUpdatedAt) return;
       const updatesTestStatus =
         Object.prototype.hasOwnProperty.call(patch, 'lastTestStatus') ||
         Object.prototype.hasOwnProperty.call(patch, 'lastTestAt') ||
@@ -178,6 +203,7 @@ class FileConnectionStore implements ConnectionStore {
           : clearsTestStatus
             ? undefined
             : current.lastTestMessage,
+        extras: patch.extras ?? current.extras,
         updatedAt: Date.now(),
       };
       file.connections[index] = next;
@@ -196,7 +222,6 @@ class FileConnectionStore implements ConnectionStore {
       updated = next;
       await this.write(file);
     });
-    if (!updated) throw new Error(`Failed to update connection: ${slug}`);
     return updated;
   }
 


### PR DESCRIPTION
## Summary

- replace the unhealthy historical `big-pickle` bootstrap preference
- probe OpenCode Free candidates within one shared 15-second budget instead of assuming one free model stays healthy
- reject HTTP 200 error envelopes unless they contain a real OpenAI chat completion
- persist a healthy fallback only for Maka-managed, single-model seeds; preserve customized connections
- align bootstrap, runtime, and onboarding regression coverage

Closes #2165

## Verification

- `npm test`
- `npm run format:check`
- focused bootstrap and anonymous-runtime tests
- live runtime probe (2026-08-04): rejected an invalid `nemotron-3-ultra-free` response, fell back to `mimo-v2.5-free`, and returned `ok: true` in 4.3s
