### PR TITLE
fix(desktop,runtime-host): omit WebSearch from tool surface when unavailable

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
@@ -23,6 +23,7 @@ import {
 const readTool = tool('Read', 'read');
 const writeTool = tool('Write', 'file_write');
 const computerTool = tool('maka_computer', 'computer_use');
+const webSearchTool = tool('WebSearch', 'web_read');
 const availability: ToolAvailabilityConfig = {
   economy: true,
   groups: [
@@ -285,6 +286,30 @@ describe('Desktop backend tool surface', () => {
     );
   });
 
+  it('omits unavailable WebSearch after the Deep Research allowlist and keeps it when ready', async () => {
+    const input = inputFor('claude-sonnet-4-5-20250929');
+    input.header.labels = ['mode:deep_research'];
+    const builtinTools = [readTool, webSearchTool];
+
+    const unavailable = await resolveDesktopBackendToolSurface(
+      makeDeps({
+        builtinTools,
+        resolveWebSearchAvailability: async () => false,
+      }),
+      input,
+    );
+    assert.equal(unavailable.selectedTools.some((tool) => tool.name === 'WebSearch'), false);
+
+    const ready = await resolveDesktopBackendToolSurface(
+      makeDeps({
+        builtinTools,
+        resolveWebSearchAvailability: async () => true,
+      }),
+      input,
+    );
+    assert.equal(ready.selectedTools.some((tool) => tool.name === 'WebSearch'), true);
+  });
+
   it('uses explicit preview inputs without reading a nonexistent session plan', async () => {
     let connectionReads = 0;
     let planReads = 0;
@@ -336,6 +361,7 @@ function makeDeps(
     deepResearchTools: [],
     computerUseTools: [computerTool],
     builtinTools: [readTool, writeTool, computerTool],
+    resolveWebSearchAvailability: async () => true,
     toolEconomy: availability.economy,
     planStore,
     ...overrides,

--- a/apps/desktop/src/main/__tests__/settings-runtime-effects.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-runtime-effects.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createDefaultSettings } from '@maka/core';
+import type { BotRegistry } from '@maka/runtime';
+import type { createSettingsStore } from '@maka/storage';
+import type { KeepSystemAwakeController } from '../keep-system-awake.js';
+import { createSettingsRuntimeEffects } from '../settings-runtime-effects.js';
+
+test('webSearch and privacy settings refresh idle backends', async () => {
+  const settings = createDefaultSettings();
+  let refreshes = 0;
+  const effects = createSettingsRuntimeEffects({
+    settingsStore: {
+      get: async () => settings,
+    } as ReturnType<typeof createSettingsStore>,
+    botRegistry: {} as BotRegistry,
+    keepSystemAwake: {} as KeepSystemAwakeController,
+    safeSendToRenderer: () => {},
+    refreshIdleBackends: async () => {
+      refreshes += 1;
+    },
+  });
+
+  await effects.applySettingsRuntimeEffects(settings, {
+    webSearch: { enabled: true },
+  });
+  await effects.applySettingsRuntimeEffects(settings, {
+    privacy: { incognitoActive: true },
+  });
+  await effects.applySettingsRuntimeEffects(settings, {
+    appearance: { theme: 'dark' },
+  });
+
+  assert.equal(refreshes, 2);
+});

--- a/apps/desktop/src/main/__tests__/web-search-surface.test.ts
+++ b/apps/desktop/src/main/__tests__/web-search-surface.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createDefaultSettings, mergeSettings } from '@maka/core';
+import type { SettingsStore } from '@maka/storage';
+import { resolveDesktopWebSearchAvailability } from '../web-search/surface.js';
+
+describe('Desktop WebSearch availability', () => {
+  const cases = [
+    {
+      name: 'disabled',
+      settings: mergeSettings(createDefaultSettings(), {
+        webSearch: {
+          enabled: false,
+          providers: { tavily: { apiKey: 'configured-key' } },
+        },
+      }),
+      privacy: { incognitoActive: false },
+      expected: false,
+    },
+    {
+      name: 'credential not configured',
+      settings: mergeSettings(createDefaultSettings(), {
+        webSearch: {
+          enabled: true,
+          providers: { tavily: { apiKey: '' } },
+        },
+      }),
+      privacy: { incognitoActive: false },
+      expected: false,
+    },
+    {
+      name: 'privacy mode',
+      settings: mergeSettings(createDefaultSettings(), {
+        webSearch: {
+          enabled: true,
+          providers: { tavily: { apiKey: 'configured-key' } },
+        },
+      }),
+      privacy: { incognitoActive: true },
+      expected: false,
+    },
+    {
+      name: 'ready',
+      settings: mergeSettings(createDefaultSettings(), {
+        webSearch: {
+          enabled: true,
+          providers: { tavily: { apiKey: 'configured-key' } },
+        },
+      }),
+      privacy: { incognitoActive: false },
+      expected: true,
+    },
+  ] as const;
+
+  for (const fixture of cases) {
+    it(`reports ${fixture.name}`, async () => {
+      const available = await resolveDesktopWebSearchAvailability({
+        settingsStore: {
+          get: async () => fixture.settings,
+        } as Pick<SettingsStore, 'get'>,
+        getPrivacyContext: async () => fixture.privacy,
+        env: {},
+      });
+
+      assert.equal(available, fixture.expected);
+    });
+  }
+});

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -118,6 +118,7 @@ import { registerDailyReviewIpc } from './daily-review-ipc-main.js';
 import { registerInspectorIpc } from './inspector-ipc-main.js';
 import { registerUsageIpc } from './usage-ipc-main.js';
 import { registerWebSearchIpc } from './web-search-ipc-main.js';
+import { resolveDesktopWebSearchAvailability } from './web-search/surface.js';
 import { registerNotificationsIpc } from './notifications-ipc-main.js';
 import { registerAppIpc } from './app-ipc-main.js';
 import { createAppUpdateService } from './app-update-service.js';
@@ -746,6 +747,11 @@ const desktopBackendToolSurfaceDeps = {
   deepResearchTools,
   computerUseTools,
   builtinTools,
+  resolveWebSearchAvailability: () =>
+    resolveDesktopWebSearchAvailability({
+      settingsStore,
+      getPrivacyContext: getWorkspacePrivacyContext,
+    }),
   toolEconomy: desktopProductToolSurface.identity.policy.economy,
   planStore,
   getAgentGraphSupervisorTools: (sessionId: string) =>
@@ -1291,6 +1297,7 @@ const { normalizeSettingsPatch, applySettingsRuntimeEffects, handleExternalSetti
     botRegistry,
     keepSystemAwake,
     safeSendToRenderer,
+    refreshIdleBackends: () => runtime.refreshIdleBackends(),
   });
 
 async function updateAgentSettings(patch: UpdateAppSettingsInput): Promise<AppSettings> {

--- a/apps/desktop/src/main/desktop-backend-tool-surface.ts
+++ b/apps/desktop/src/main/desktop-backend-tool-surface.ts
@@ -30,6 +30,7 @@ import type {
 import type { McpClientManager } from '@maka/mcp';
 import { computerUseToolsForModel } from './computer-use-model-tools.js';
 import type { ReadyConnection } from './chat-readiness.js';
+import { webSearchToolsForAvailability } from './web-search/surface.js';
 
 export interface DesktopBackendToolSurfaceDeps {
   isComputerUseRealModelE2e: boolean;
@@ -42,6 +43,7 @@ export interface DesktopBackendToolSurfaceDeps {
   deepResearchTools: readonly MakaTool[];
   computerUseTools: readonly MakaTool[];
   builtinTools: readonly MakaTool[];
+  resolveWebSearchAvailability: () => Promise<boolean>;
   toolEconomy: boolean;
   planStore: PlanStore;
   getAgentGraphSupervisorTools?: (
@@ -202,10 +204,19 @@ export async function resolveDesktopBackendToolSurface(
           ...buildMcpTools(deps.mcpManager),
           ...(isDeepResearchSession(input.header.labels) ? deps.deepResearchTools : []),
         ];
-  const candidateTools =
+  const deepResearchCandidateTools =
     !input.tools && isDeepResearchSession(input.header.labels)
       ? unscopedCandidateTools.filter(isDeepResearchToolAllowed)
       : unscopedCandidateTools;
+  const webSearchAvailable = deepResearchCandidateTools.some(
+    (tool) => tool.name === 'WebSearch',
+  )
+    ? await deps.resolveWebSearchAvailability()
+    : true;
+  const candidateTools = webSearchToolsForAvailability(
+    deepResearchCandidateTools,
+    webSearchAvailable,
+  );
   const toolEconomy = deps.isComputerUseRealModelE2e ? false : deps.toolEconomy;
 
   const planControlTools = input.tools

--- a/apps/desktop/src/main/settings-runtime-effects.ts
+++ b/apps/desktop/src/main/settings-runtime-effects.ts
@@ -16,6 +16,7 @@ export interface SettingsRuntimeEffectsDeps {
   botRegistry: BotRegistry;
   keepSystemAwake: KeepSystemAwakeController;
   safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
+  refreshIdleBackends: () => Promise<void>;
 }
 
 export interface SettingsRuntimeEffects {
@@ -46,6 +47,7 @@ export function createSettingsRuntimeEffects(
     botRegistry,
     keepSystemAwake,
     safeSendToRenderer,
+    refreshIdleBackends,
   } = deps;
 
   async function normalizeSettingsPatch(patch: UpdateAppSettingsInput): Promise<UpdateAppSettingsInput> {
@@ -67,6 +69,11 @@ export function createSettingsRuntimeEffects(
       // capability reflects the user's choice without waiting for a relaunch.
       keepSystemAwake.apply(settings.system.keepSystemAwake);
     }
+    if (patch.webSearch || patch.privacy) {
+      void refreshIdleBackends().catch((error) => {
+        console.warn('[settings] failed to refresh backend tool snapshots:', error);
+      });
+    }
   }
 
   async function handleExternalSettingsChange(): Promise<void> {
@@ -76,6 +83,8 @@ export function createSettingsRuntimeEffects(
         network: settings.network,
         botChat: settings.botChat,
         system: settings.system,
+        webSearch: settings.webSearch,
+        privacy: settings.privacy,
       };
       await applySettingsRuntimeEffects(settings, fullPatch);
     } catch (error) {

--- a/apps/desktop/src/main/web-search/surface.ts
+++ b/apps/desktop/src/main/web-search/surface.ts
@@ -1,0 +1,29 @@
+import { validateWorkspacePrivacyContext } from '@maka/core';
+import type { MakaTool } from '@maka/runtime';
+import type { SettingsStore } from '@maka/storage';
+import { resolveTavilyApiKey } from './credentials.js';
+
+const WEB_SEARCH_TOOL_NAME = 'WebSearch';
+
+export function webSearchToolsForAvailability(
+  tools: readonly MakaTool[],
+  available: boolean,
+): MakaTool[] {
+  if (available) return [...tools];
+  return tools.filter((tool) => tool.name !== WEB_SEARCH_TOOL_NAME);
+}
+
+export async function resolveDesktopWebSearchAvailability(deps: {
+  settingsStore: Pick<SettingsStore, 'get'>;
+  getPrivacyContext: () => Promise<unknown>;
+  env?: NodeJS.ProcessEnv;
+}): Promise<boolean> {
+  const privacy = validateWorkspacePrivacyContext(await deps.getPrivacyContext());
+  if (!privacy.ok || privacy.value.incognitoActive) return false;
+
+  const settings = await deps.settingsStore.get();
+  return (
+    settings.webSearch.enabled &&
+    resolveTavilyApiKey({ settings, ...(deps.env ? { env: deps.env } : {}) }).length > 0
+  );
+}

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -700,7 +700,6 @@ test('production Host executes a canonical ai-sdk Session against a real provide
       'Skill',
       'SkillSearch',
       'StopBackgroundTask',
-      'WebSearch',
       'Write',
       'WriteStdin',
       'load_tools',
@@ -1110,7 +1109,7 @@ test('production Host executes a durable runnable child with an exact tool ceili
     );
 
     const requests = provider.requests.filter((request) => request.body.stream === true);
-    assert.equal(requests.length, 7);
+    assert.equal(requests.length, 6);
     assert.ok(toolNames(requests[0]?.body).includes('load_tools'));
     assert.equal(toolNames(requests[0]?.body).includes('agent_spawn'), false);
     assert.ok(toolNames(requests[1]?.body).includes('agent_spawn'));
@@ -1121,9 +1120,8 @@ test('production Host executes a durable runnable child with an exact tool ceili
     ]);
     assert.deepEqual(toolNames(requests[2]?.body), ['Glob', 'Grep', 'Read']);
     assert.ok(toolNames(requests[3]?.body).includes('agent_spawn'));
-    assert.deepEqual(toolNames(requests[4]?.body), ['WebSearch']);
-    assert.deepEqual(toolNames(requests[5]?.body), ['WebSearch']);
-    assert.ok(toolNames(requests[6]?.body).includes('agent_spawn'));
+    assert.deepEqual(toolNames(requests[4]?.body), []);
+    assert.ok(toolNames(requests[5]?.body).includes('agent_spawn'));
 
     const sessions = await execution.sessionStore.listForRecovery();
     const child = sessions.find((session) => session.subagentRuntime?.profile === 'local_read');
@@ -1159,18 +1157,13 @@ test('production Host executes a durable runnable child with an exact tool ceili
       webChild.id,
       webChildRuns[0]!.runId,
     );
-    const searchResult = webChildEvents.find(
-      (event) => event.content?.kind === 'function_response' && event.content.name === 'WebSearch',
+    assert.equal(
+      webChildEvents.some(
+        (event) =>
+          event.content?.kind === 'function_response' && event.content.name === 'WebSearch',
+      ),
+      false,
     );
-    assert.ok(searchResult?.content?.kind === 'function_response');
-    assert.deepEqual(decodeCanonicalToolResultContent(searchResult.content.result), {
-      kind: 'web_search_error',
-      ok: false,
-      provider: 'tavily',
-      query: 'latest hosted web result',
-      reason: 'not_configured',
-      message: 'Enable web search before using this tool.',
-    });
     const artifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
     const childArtifacts = await artifacts.listTurnArtifacts(child.id, childRuns[0]!.turnId);
     assert.equal(childArtifacts.length, 1);
@@ -2065,6 +2058,45 @@ test('Deep Research composition keeps one read-only research surface and prompt'
   assert.doesNotMatch(prompt, /ExploreAgent/);
 });
 
+test('Host composition omits unavailable WebSearch and keeps it when ready', () => {
+  const webSearch = {
+    name: 'WebSearch',
+    description: 'Web search fixture.',
+    parameters: {},
+    impl: async () => undefined,
+  } satisfies MakaTool;
+  const base = {
+    policy: {
+      getSnapshot: async () => ({ revision: 0, policy: createDefaultRuntimePolicy() }),
+    },
+    skills: {
+      readCanonicalModelInventory: async () => ({ inventory: [] }),
+    } as unknown as HostSkillCatalogCoordinator,
+    memory: {} as HostMemoryCoordinator,
+    taskLedger: {} as TaskLedgerStore,
+    hostTools: [webSearch],
+    deepResearch: { tools: [] },
+  } as const;
+
+  const unavailable = createHostExecutionModelComposition({
+    ...base,
+    webSearchAvailable: false,
+  });
+  assert.equal(
+    unavailable.tools.some((candidate) => candidate.name === 'WebSearch'),
+    false,
+  );
+
+  const ready = createHostExecutionModelComposition({
+    ...base,
+    webSearchAvailable: true,
+  });
+  assert.equal(
+    ready.tools.some((candidate) => candidate.name === 'WebSearch'),
+    true,
+  );
+});
+
 test('Plan composition admits only planning tools before approval and execution controls after', async () => {
   const proposal = {
     planId: 'plan-1',
@@ -2858,15 +2890,7 @@ async function handleProviderRequest(
     return;
   }
   if (flow.kind === 'child_agent' && streamRequestIndex === 5) {
-    assert.deepEqual(toolNames(body), ['WebSearch']);
-    respondProviderToolCall(response, streamRequestIndex, 'WebSearch', {
-      query: 'latest hosted web result',
-      limit: 1,
-    });
-    return;
-  }
-  if (flow.kind === 'child_agent' && streamRequestIndex === 6) {
-    assert.deepEqual(toolNames(body), ['WebSearch']);
+    assert.deepEqual(toolNames(body), []);
     respondProviderText(response, WEB_RESEARCH_CHILD_RESULT_TEXT);
     return;
   }

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -96,7 +96,7 @@ import { HostSkillCatalogCoordinator } from './skill-catalog-coordinator.js';
 import { SkillCatalogRepository } from './skill-catalog-repository.js';
 import { HostTaskLedgerCoordinator } from './task-ledger-coordinator.js';
 import { HostUsagePricingCoordinator } from './usage-pricing-coordinator.js';
-import { createHostWebSearchTool } from './web-search-tool.js';
+import { createHostWebSearchTool, resolveHostWebSearchAvailability } from './web-search-tool.js';
 import { createHostExecutionArtifactServices } from './execution-artifacts.js';
 
 export async function createExecutionRuntimeHostComposition(
@@ -388,6 +388,8 @@ export async function createExecutionRuntimeHostComposition(
         goalTools: requireGoal(goal).tools,
         builtinTools,
         hostTools,
+        resolveWebSearchAvailability: () =>
+          resolveHostWebSearchAvailability(runtimePolicyStores.operations),
         resolveRootTools: (sessionId) =>
           requireGraphCoordinator(graphCoordinator).toolsForSession(sessionId),
         parentAgentTools: childAgentTools.parentTools,
@@ -413,9 +415,10 @@ export async function createExecutionRuntimeHostComposition(
       try {
         const graphTools =
           await requireGraphCoordinator(graphCoordinator).toolsForSession(sessionId);
-        const [header, planState] = await Promise.all([
+        const [header, planState, webSearchAvailable] = await Promise.all([
           stores.sessionStore.readHeaderSnapshot(sessionId),
           openedPlanStore.readState(sessionId),
+          resolveHostWebSearchAvailability(runtimePolicyStores.operations),
         ]);
         return createHostExecutionModelComposition({
           policy: runtimePolicyStores.runtimePolicy,
@@ -425,6 +428,7 @@ export async function createExecutionRuntimeHostComposition(
           ...(capabilitySnapshot ? { clientCapabilities: capabilitySnapshot } : {}),
           builtinTools,
           hostTools: [...hostTools, ...graphTools],
+          webSearchAvailable,
           automationTool: requireAutomationCoordinator(automations).modelTool,
           goalTools: requireGoal(goal).tools,
           parentAgentTools: childAgentTools.parentTools,

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -80,6 +80,7 @@ import type { HostChildAgentBackendCapabilities } from './child-agent-compositio
 import type { HostExecutionArtifactServices } from './execution-artifacts.js';
 import { readDuringBackendCreation, resolveExecutionTarget } from './execution-model-authority.js';
 import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
+import { webSearchToolsForAvailability } from './web-search-tool.js';
 
 const CHILD_INSTRUCTION_BOUNDARY = [
   'A child agent inherits the current session permission, privacy, workspace, and skill constraints.',
@@ -116,6 +117,7 @@ export interface HostExecutionModelCompositionInput {
   readonly clientCapabilities?: Pick<ClientCapabilitySnapshot, 'tools' | 'groups'>;
   readonly builtinTools?: BuildBuiltinToolsOptions;
   readonly hostTools?: readonly MakaTool[];
+  readonly webSearchAvailable?: boolean;
   readonly automationTool?: MakaTool;
   readonly goalTools?: readonly MakaTool[];
   readonly parentAgentTools?: readonly MakaTool[];
@@ -149,9 +151,13 @@ export function createHostExecutionModelComposition(
       );
   const clientCapabilityTools = input.boundTools ? [] : (input.clientCapabilities?.tools ?? []);
   const unscopedCandidateTools = [...defaultTools, ...clientCapabilityTools];
-  const candidateTools = input.deepResearch
+  const deepResearchCandidateTools = input.deepResearch
     ? unscopedCandidateTools.filter(isDeepResearchToolAllowed)
     : unscopedCandidateTools;
+  const candidateTools = webSearchToolsForAvailability(
+    deepResearchCandidateTools,
+    input.webSearchAvailable !== false,
+  );
   const activeExecution = input.plan ? activePlanExecution(input.plan.state) : undefined;
   const selectedTools = input.plan
     ? selectCollaborationTools({
@@ -268,6 +274,7 @@ export interface HostAiSdkBackendInput {
   readonly runtimeCommitSink?: RuntimeCommitSink;
   readonly builtinTools?: BuildBuiltinToolsOptions;
   readonly hostTools?: readonly MakaTool[];
+  readonly resolveWebSearchAvailability?: () => Promise<boolean>;
   readonly resolveRootTools?: (sessionId: string) => Promise<readonly MakaTool[]>;
   readonly automationTool?: MakaTool;
   readonly goalTools?: readonly MakaTool[];
@@ -348,6 +355,12 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
             input.context.abortSignal,
           )
         : [];
+    const webSearchAvailable = input.resolveWebSearchAvailability
+      ? await readDuringBackendCreation(
+          input.resolveWebSearchAvailability,
+          input.context.abortSignal,
+        )
+      : true;
     const hostTools = [...(input.hostTools ?? []), ...rootTools];
     modelComposition = createHostExecutionModelComposition({
       policy: input.runtimePolicy.runtimePolicy,
@@ -359,6 +372,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
       ...(clientCapabilities ? { clientCapabilities } : {}),
       ...(input.builtinTools ? { builtinTools: input.builtinTools } : {}),
       ...(hostTools.length > 0 ? { hostTools } : {}),
+      webSearchAvailable,
       ...(input.automationTool ? { automationTool: input.automationTool } : {}),
       ...(input.goalTools ? { goalTools: input.goalTools } : {}),
       ...(input.parentAgentTools ? { parentAgentTools: input.parentAgentTools } : {}),

--- a/packages/runtime-host/src/server/web-search-tool.ts
+++ b/packages/runtime-host/src/server/web-search-tool.ts
@@ -9,6 +9,16 @@ import {
 import type { RuntimePolicyOperationCoordinator } from '@maka/storage/runtime-policy-stores';
 import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
 
+const WEB_SEARCH_TOOL_NAME = 'WebSearch';
+
+export function webSearchToolsForAvailability(
+  tools: readonly MakaTool[],
+  available: boolean,
+): MakaTool[] {
+  if (available) return [...tools];
+  return tools.filter((tool) => tool.name !== WEB_SEARCH_TOOL_NAME);
+}
+
 export function createHostWebSearchTool(input: {
   readonly policy: Pick<RuntimePolicyOperationCoordinator, 'resolveWebSearchExecution'>;
   readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
@@ -69,4 +79,10 @@ export function createHostWebSearchTool(input: {
       }
     },
   });
+}
+
+export async function resolveHostWebSearchAvailability(
+  policy: Pick<RuntimePolicyOperationCoordinator, 'resolveWebSearchExecution'>,
+): Promise<boolean> {
+  return (await policy.resolveWebSearchExecution()).kind === 'ready';
 }


### PR DESCRIPTION
## Summary

- omit `WebSearch` from the effective model tool surface when WebSearch is disabled, unconfigured, or privacy/incognito mode is active
- refresh idle Desktop backends when `webSearch` or `privacy` settings change
- preserve call-time fail-closed guards and deep-research allowlist behavior

## Verification

- `npm --workspace @maka/desktop run build:main`
- `npm --workspace @maka/runtime-host run build`
- Desktop scoped tests: 25/25 passed
- Runtime Host `web-search-tool.test.js`: 3/3 passed
- Runtime Host `execution-model-composition.test.js`: 19/19 passed
- `npx biome check <11 touched files>`
- `git diff --check`

Closes #2085