### PR TITLE
refactor(composer): project and branch join the footer control row

### DIFF
--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -21,22 +21,6 @@
   max-width: var(--maka-chat-measure);
 }
 
-/* New-chat project/branch bar — above the composer card, same measure. */
-.maka-composer-workspace-dock {
-  display: flex;
-  width: min(var(--maka-chat-measure), 100%);
-  max-width: var(--maka-chat-measure);
-  margin-inline: auto;
-  padding-inline: var(--space-6);
-  box-sizing: border-box;
-}
-
-.maka-composer-workspace-dock .maka-composer-workspace-row {
-  width: 100%;
-  margin: 0;
-  padding-block: var(--space-1) 0;
-}
-
 .maka-composer-context-drawer {
   display: flex;
   min-width: 0;
@@ -70,8 +54,16 @@
   flex-wrap: wrap;
 }
 
+/* Shrinkable so the `flex-wrap: wrap` above can actually engage. At
+   `flex: 0 0 auto` this box sizes to max-content, which means it never has a
+   width to wrap inside — it just overflows, and the overflow runs under the
+   send button and past the card's right edge. That stayed invisible while the
+   row held four controls; the project and branch pickers add ~224px and a
+   480px window has nowhere to put it. `min-width: 0` because the default
+   `auto` floor would keep the same overflow for a long model name. */
 .maka-composer-left-controls {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .maka-composer-right-controls {
@@ -204,22 +196,6 @@
    background after the transcript viewport has already ended. */
 .mainColumn:not([data-home-surface="true"]) .composer {
   padding-top: 0;
-}
-
-/* Composer send button — flat solid action fill. #546: dropped the gradient
-   + inner sheen + drop shadow (the "machined hardware" look read heavy next
-   to the calm parchment container). Flat --action with darken on hover/press
-   keeps it the clear primary CTA without the weight. */
-.maka-composer-workspace-row {
-  /* PR-PARCHMENT-HOME-2: must share the new composer card measure
-     (620px) so the "选择工作目录 ▾" pill stays aligned with the card
-     left edge above it. */
-  width: min(var(--maka-chat-measure), 100%);
-  display: flex;
-  justify-content: flex-start;
-  gap: var(--space-1);
-  box-sizing: border-box;
-  margin: 0 auto var(--space-2);
 }
 
 .maka-composer-workspace-picker {

--- a/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
+++ b/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
@@ -203,12 +203,20 @@ describe('composer quiet chrome', () => {
     assert.doesNotMatch(markup, /maka-composer-realtime-voice-button/);
   });
 
-  it('places the workspace picker above the composer card for new chats', () => {
+  /**
+   * The picker used to sit on a bar of its own above the card, which is what
+   * made it read as a leftover rather than a control: same kind of thing as
+   * the model chip, different address. It now shares the footer row with the
+   * other send-context controls, so the assertion is containment — inside the
+   * left controls, not merely somewhere in the markup.
+   */
+  it('puts the workspace picker in the footer controls beside the model', () => {
     const markup = render(
       <Composer
         onSend={() => true}
         onStop={() => {}}
         modelLabel="demo"
+        modelChoices={[]}
         workspacePicker={{
           projects: [],
           onAdd: () => {},
@@ -218,18 +226,28 @@ describe('composer quiet chrome', () => {
         }}
       />,
     );
-    assert.match(markup, /maka-composer-workspace-dock/);
-    // Workspace row is a sibling above the form, not nested after the card.
-    const dockIdx = markup.indexOf('maka-composer-workspace-dock');
-    const formIdx = markup.indexOf('maka-composer composer');
-    assert.ok(dockIdx >= 0 && formIdx > dockIdx);
+    assert.doesNotMatch(markup, /maka-composer-workspace-dock/, 'the lone bar is gone');
+    const leftControls = markup.match(
+      /maka-composer-left-controls[\s\S]*?maka-composer-right-controls/,
+    )?.[0] ?? '';
+    assert.match(leftControls, /maka-composer-workspace-picker/, 'picker rides the footer row');
+    // Beside the model, and ahead of it is the model's own slot — so the
+    // picker joins the send-context group instead of trailing the modes.
+    const modelIdx = leftControls.indexOf('maka-model-selection-controls');
+    const pickerIdx = leftControls.indexOf('maka-composer-workspace-picker');
+    assert.ok(modelIdx >= 0 && pickerIdx > modelIdx, 'picker follows the model pair');
   });
 
   /**
    * The project and branch decide where a NEW chat starts; once a session
-   * exists they no longer move it. Leaving the row on screen in an open chat
+   * exists they no longer move it. Leaving them on screen in an open chat
    * reads as "you can still change this session's context here", which is
    * false — so the same wired picker must render nothing.
+   *
+   * Asserts on the picker's own class, not on the container it happens to sit
+   * in. The previous version named the dock that used to wrap it, and once
+   * that dock was deleted the assertion would have passed against any markup
+   * at all — including markup that wrongly kept rendering the picker.
    */
   it('drops the workspace picker once a session is active', () => {
     const workspacePicker = {
@@ -261,6 +279,7 @@ describe('composer quiet chrome', () => {
         }}
       />,
     );
-    assert.doesNotMatch(markup, /maka-composer-workspace-dock/);
+    assert.doesNotMatch(markup, /maka-composer-workspace-picker/);
+    assert.doesNotMatch(markup, /maka-composer-branch-picker/);
   });
 });

--- a/packages/ui/src/composer-workspace-pickers.tsx
+++ b/packages/ui/src/composer-workspace-pickers.tsx
@@ -1,7 +1,16 @@
 /**
- * Composer workspace row (issue #1044) — the workspace picker + git branch
- * picker rendered above the composer card. Extracted from `composer.tsx`;
- * purely presentational: both pickers are standard compact menu triggers fed
+ * Composer workspace + git branch pickers (issue #1044) — the two controls
+ * that decide where a NEW chat starts. They live in the composer card's
+ * footer control row, beside the model chip, and speak the same quiet chip
+ * dialect as the ＋ menu, the permission shield and the model picker.
+ *
+ * They render as bare siblings rather than inside a wrapper: the control row
+ * owns the gap, so a wrapper would introduce a second spacing authority and
+ * group these two apart from the controls they belong with. They used to sit
+ * in exactly such a wrapper on a lone bar above the card, which is what made
+ * them read as leftovers rather than part of the control surface.
+ *
+ * Purely presentational: both pickers are standard compact menu triggers fed
  * by host-injected props. Shared Button owns their visual and interaction
  * states; local classes only constrain layout and label truncation.
  */
@@ -31,10 +40,10 @@ export interface ComposerWorkspacePicker {
 }
 
 /**
- * Git branch picker for the workspace row, shown to the right of
- * the folder indicator when the workspace is a git repository.
- * Clicking the trigger opens a Menu listing local branches; selecting
- * one fires `onSelect` to switch branches (handled in the shell).
+ * Git branch picker, shown to the right of the folder indicator when the
+ * workspace is a git repository. Clicking the trigger opens a Menu listing
+ * local branches; selecting one fires `onSelect` to switch branches (handled
+ * in the shell).
  */
 export interface ComposerBranchPicker {
   branch: string | null;
@@ -44,7 +53,7 @@ export interface ComposerBranchPicker {
   onSelect(branch: string): void;
 }
 
-export function ComposerWorkspaceRow(props: {
+export function ComposerWorkspacePickers(props: {
   workspacePicker: ComposerWorkspacePicker;
   branchPicker?: ComposerBranchPicker;
 }) {
@@ -54,7 +63,7 @@ export function ComposerWorkspaceRow(props: {
     wp.defaultOpen ?? false,
   );
   return (
-    <div className="maka-composer-workspace-row">
+    <>
       {/* The workspace and branch pickers are standard compact menu
           triggers. Shared Button owns their visual and interaction states;
           local classes only constrain layout and label truncation. */}
@@ -167,6 +176,6 @@ export function ComposerWorkspaceRow(props: {
           </DropdownMenu>
         );
       })()}
-    </div>
+    </>
   );
 }

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -47,7 +47,7 @@ import {
   type ChatInputActionOwner,
   type ComposerTextPort,
 } from './chat-input-behavior.js';
-import { ComposerWorkspaceRow, type ComposerBranchPicker, type ComposerWorkspacePicker } from './composer-workspace-row.js';
+import { ComposerWorkspacePickers, type ComposerBranchPicker, type ComposerWorkspacePicker } from './composer-workspace-pickers.js';
 import { SKILL_INVOCATION_TOKEN_SOURCE } from '@maka/core';
 import type { AttachmentRef, PermissionMode, ProviderType, QuoteRef, SessionSummary } from '@maka/core';
 import {
@@ -1200,12 +1200,6 @@ export const Composer = forwardRef<
           </button>
         </div>
       )}
-      {/* New-chat project/branch bar sits above the card (quiet chrome). */}
-      {!props.activeSession && props.workspacePicker ? (
-        <div className="maka-composer-workspace-dock" hidden={props.hidden}>
-          <ComposerWorkspaceRow workspacePicker={props.workspacePicker} branchPicker={props.branchPicker} />
-        </div>
-      ) : null}
       <form
         ref={formRef}
         className="maka-composer composer"
@@ -1461,6 +1455,20 @@ export const Composer = forwardRef<
                     />
                   )}
                 </div>
+              ) : null}
+              {/* Project and branch decide where a NEW chat starts, which makes
+                  them send context like the model beside them — so they sit in
+                  this row rather than on a bar of their own above the card,
+                  where they read as leftovers rather than controls. Not gated
+                  on `streaming`: `activeSession` already covers it, since
+                  sending the first message creates the session that hides
+                  these. They stay ahead of the mode marks so the modes keep
+                  trailing the send-context group. */}
+              {!props.activeSession && props.workspacePicker ? (
+                <ComposerWorkspacePickers
+                  workspacePicker={props.workspacePicker}
+                  branchPicker={props.branchPicker}
+                />
               ) : null}
               {/* Mode readouts sit after the model pair, so a mode turning on
                   or off never nudges the model and thinking pickers (#1897).


### PR DESCRIPTION

## 会话态的连带影响
`.maka-composer-left-controls` 是新会话和会话态共用的。wrap 现在真的会生效，所以会话里控件较多时（＋ · 盾 · 模型切换 · 思考 · 最多三个 mode 标记）也会换行、行高变高，而不是像以前那样溢出到发送按钮下面和卡片外。**这是严格变好，不需要额外处理。**

标注一下证据等级：四档视口的表是**实测**；这一段会话态的推论是**从同一条 CSS 规则和会话态控件数推出来的，没有单独跑截图**。
