### PR TITLE
feat(runtime-host): own plan turn transitions

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
@@ -83,7 +83,7 @@ test('adapts Host Goal, Task, Deep Research, and Resource projections', async ()
   });
 });
 
-test('adapts non-starting Plan controls without exposing a split Plan-to-Turn transition', async () => {
+test('adapts Plan controls and starts approved execution through one Host command', async () => {
   const calls: unknown[] = [];
   const state: PlanSessionState = {
     schemaVersion: 1,
@@ -107,15 +107,66 @@ test('adapts non-starting Plan controls without exposing a split Plan-to-Turn tr
             executionId: null,
           };
         },
+        startPlanTurn: async (input) => {
+          calls.push({ kind: 'start', input });
+          return {
+            plan: {
+              sessionId: 'session-1',
+              storeVersion: 4,
+              eventType:
+                input.kind === 'approve_proposal'
+                  ? 'plan_approved'
+                  : 'plan_execution_resumed',
+              proposalId: input.kind === 'approve_proposal' ? 'proposal-1' : null,
+              executionId: 'execution-1',
+            },
+            turn: {
+              sessionId: 'session-1',
+              turnId: input.turnId,
+              runId: 'run-1',
+              status: 'running',
+            },
+          };
+        },
       }),
       emitModeChanged: (sessionId) => calls.push({ kind: 'changed', sessionId }),
-      newId: () => 'operation-1',
+      newId: (() => {
+        let sequence = 0;
+        return () => `operation-${++sequence}`;
+      })(),
     },
     ipc,
   );
 
   assert.deepEqual(await ipc.invoke('plan-mode:requestRevision', 'session-1', 'proposal-1'), state);
-  await assert.rejects(() => ipc.invoke('plan-mode:approve', 'session-1', {}), /missing handler/);
+  const approvalInput = {
+    proposalId: 'proposal-1',
+    expectedRevision: 2,
+    expectedStoreVersion: 3,
+    turnId: 'approval-turn',
+  };
+  assert.deepEqual(
+    await ipc.invoke('plan-mode:approve', 'session-1', approvalInput),
+    { turnId: 'approval-turn', executionId: 'execution-1' },
+  );
+  assert.deepEqual(
+    await ipc.invoke('plan-mode:approve', 'session-1', approvalInput),
+    { turnId: 'approval-turn', executionId: 'execution-1' },
+  );
+  assert.deepEqual(
+    await ipc.invoke('plan-mode:resume', 'session-1', 'execution-1', 'resume-turn'),
+    {
+      turnId: 'resume-turn',
+      executionId: 'execution-1',
+    },
+  );
+  assert.deepEqual(
+    await ipc.invoke('plan-mode:resume', 'session-1', 'execution-1', 'resume-turn'),
+    {
+      turnId: 'resume-turn',
+      executionId: 'execution-1',
+    },
+  );
   assert.deepEqual(calls, [
     {
       kind: 'control',
@@ -124,6 +175,50 @@ test('adapts non-starting Plan controls without exposing a split Plan-to-Turn tr
         sessionId: 'session-1',
         proposalId: 'proposal-1',
         operationId: 'operation-1',
+      },
+    },
+    { kind: 'changed', sessionId: 'session-1' },
+    {
+      kind: 'start',
+      input: {
+        kind: 'approve_proposal',
+        sessionId: 'session-1',
+        proposalId: 'proposal-1',
+        expectedRevision: 2,
+        expectedStoreVersion: 3,
+        turnId: 'approval-turn',
+      },
+    },
+    { kind: 'changed', sessionId: 'session-1' },
+    {
+      kind: 'start',
+      input: {
+        kind: 'approve_proposal',
+        sessionId: 'session-1',
+        proposalId: 'proposal-1',
+        expectedRevision: 2,
+        expectedStoreVersion: 3,
+        turnId: 'approval-turn',
+      },
+    },
+    { kind: 'changed', sessionId: 'session-1' },
+    {
+      kind: 'start',
+      input: {
+        kind: 'resume_execution',
+        sessionId: 'session-1',
+        executionId: 'execution-1',
+        turnId: 'resume-turn',
+      },
+    },
+    { kind: 'changed', sessionId: 'session-1' },
+    {
+      kind: 'start',
+      input: {
+        kind: 'resume_execution',
+        sessionId: 'session-1',
+        executionId: 'execution-1',
+        turnId: 'resume-turn',
       },
     },
     { kind: 'changed', sessionId: 'session-1' },

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -441,6 +441,12 @@ export class DesktopRuntimeHostClient {
     return this.#request('plan.control', input);
   }
 
+  startPlanTurn(
+    input: OperationInput<'plan.turn.start'>,
+  ): Promise<OperationOutput<'plan.turn.start'>> {
+    return this.#request('plan.turn.start', input);
+  }
+
   queryAgentGraph(
     input: OperationInput<'agent.graph.query'>,
   ): Promise<OperationOutput<'agent.graph.query'>> {

--- a/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
@@ -23,6 +23,7 @@ type RuntimeHostSessionDomainClient = Pick<
   | 'queryAgentGraphOperator'
   | 'queryDeepResearch'
   | 'queryGoal'
+  | 'startPlanTurn'
   | 'stopAgentGraph'
 >;
 
@@ -102,6 +103,48 @@ export function registerRuntimeHostSessionDomainsIpc(
       });
       deps.emitModeChanged(normalizedSessionId);
       return deps.client.getPlanState(normalizedSessionId);
+    },
+  );
+  ipcMain.handle(
+    'plan-mode:approve',
+    async (_event, sessionId: unknown, value: unknown) => {
+      const normalizedSessionId = requiredId(sessionId, 'Session');
+      const input = planApprovalInput(value);
+      const result = await deps.client.startPlanTurn({
+        kind: 'approve_proposal',
+        sessionId: normalizedSessionId,
+        proposalId: input.proposalId,
+        expectedRevision: input.expectedRevision,
+        expectedStoreVersion: input.expectedStoreVersion,
+        turnId: input.turnId,
+      });
+      if (result.plan.executionId === null) {
+        throw new Error('Plan approval did not create an execution');
+      }
+      deps.emitModeChanged(normalizedSessionId);
+      return {
+        turnId: input.turnId,
+        executionId: result.plan.executionId,
+      };
+    },
+  );
+  ipcMain.handle(
+    'plan-mode:resume',
+    async (_event, sessionId: unknown, executionId: unknown, turnId: unknown) => {
+      const normalizedSessionId = requiredId(sessionId, 'Session');
+      const normalizedExecutionId = requiredId(executionId, 'Plan execution');
+      const normalizedTurnId = requiredId(turnId, 'Turn');
+      await deps.client.startPlanTurn({
+        kind: 'resume_execution',
+        sessionId: normalizedSessionId,
+        executionId: normalizedExecutionId,
+        turnId: normalizedTurnId,
+      });
+      deps.emitModeChanged(normalizedSessionId);
+      return {
+        turnId: normalizedTurnId,
+        executionId: normalizedExecutionId,
+      };
     },
   );
   ipcMain.handle(
@@ -252,4 +295,35 @@ function requiredId(value: unknown, name: string, maxLength = 512): string {
     throw new TypeError(`Invalid ${name} id`);
   }
   return value;
+}
+
+function planApprovalInput(value: unknown): {
+  proposalId: string;
+  expectedRevision: number;
+  expectedStoreVersion: number;
+  turnId: string;
+} {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('Invalid plan approval');
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    Object.keys(record).some(
+      (key) =>
+        key !== 'proposalId'
+        && key !== 'expectedRevision'
+        && key !== 'expectedStoreVersion'
+        && key !== 'turnId',
+    ) ||
+    !Number.isSafeInteger(record.expectedRevision) ||
+    !Number.isSafeInteger(record.expectedStoreVersion)
+  ) {
+    throw new TypeError('Invalid plan approval');
+  }
+  return {
+    proposalId: requiredId(record.proposalId, 'Plan proposal'),
+    expectedRevision: record.expectedRevision as number,
+    expectedStoreVersion: record.expectedStoreVersion as number,
+    turnId: requiredId(record.turnId, 'Turn'),
+  };
 }

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -299,10 +299,10 @@ export interface MakaBridge {
     approvePlan(sessionId: string, input: {
       proposalId: string;
       expectedRevision: number;
-      expectedStoreVersion?: number;
-    }): Promise<{ state: PlanSessionState; turnId: string; executionId: string }>;
-    resumePlan(sessionId: string, executionId: string): Promise<{
-      state: PlanSessionState;
+      expectedStoreVersion: number;
+      turnId: string;
+    }): Promise<{ turnId: string; executionId: string }>;
+    resumePlan(sessionId: string, executionId: string, turnId: string): Promise<{
       turnId: string;
       executionId: string;
     }>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -341,16 +341,16 @@ const makaBridge = {
     approvePlan(sessionId: string, input: {
       proposalId: string;
       expectedRevision: number;
-      expectedStoreVersion?: number;
-    }): Promise<{ state: PlanSessionState; turnId: string; executionId: string }> {
+      expectedStoreVersion: number;
+      turnId: string;
+    }): Promise<{ turnId: string; executionId: string }> {
       return ipcRenderer.invoke('plan-mode:approve', sessionId, input);
     },
-    resumePlan(sessionId: string, executionId: string): Promise<{
-      state: PlanSessionState;
+    resumePlan(sessionId: string, executionId: string, turnId: string): Promise<{
       turnId: string;
       executionId: string;
     }> {
-      return ipcRenderer.invoke('plan-mode:resume', sessionId, executionId);
+      return ipcRenderer.invoke('plan-mode:resume', sessionId, executionId, turnId);
     },
     abandonPlanExecution(sessionId: string, executionId: string): Promise<PlanSessionState> {
       return ipcRenderer.invoke('plan-mode:abandonExecution', sessionId, executionId);

--- a/apps/desktop/src/renderer/plan-mode-panel.tsx
+++ b/apps/desktop/src/renderer/plan-mode-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useState, type JSX } from 'react';
+import { useCallback, useEffect, useId, useRef, useState, type JSX } from 'react';
 import type {
   PlanExecutionStep,
   PlanProposal,
@@ -24,6 +24,18 @@ export function usePlanModeState(session: SessionSummary | undefined): PlanModeS
   const [state, setState] = useState<PlanSessionState>();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string>();
+  const approvalRetry = useRef<{
+    sessionId: string;
+    proposalId: string;
+    expectedRevision: number;
+    expectedStoreVersion: number;
+    turnId: string;
+  } | undefined>(undefined);
+  const resumeRetry = useRef<{
+    sessionId: string;
+    executionId: string;
+    turnId: string;
+  } | undefined>(undefined);
 
   const refresh = useCallback(async () => {
     if (!session) return;
@@ -77,20 +89,44 @@ export function usePlanModeState(session: SessionSummary | undefined): PlanModeS
   }, [run, session?.id]);
 
   const approve = useCallback(async (proposal: PlanProposal): Promise<void> => {
-    if (!session) return;
+    if (!session || !state) return;
+    const current = approvalRetry.current;
+    const input =
+      current
+      && current.sessionId === session.id
+      && current.proposalId === proposal.proposalId
+      && current.expectedRevision === proposal.revision
+        ? current
+        : {
+            sessionId: session.id,
+            proposalId: proposal.proposalId,
+            expectedRevision: proposal.revision,
+            expectedStoreVersion: state.storeVersion,
+            turnId: crypto.randomUUID(),
+          };
+    approvalRetry.current = input;
     await run(async () => {
       await window.maka.sessions.approvePlan(session.id, {
-        proposalId: proposal.proposalId,
-        expectedRevision: proposal.revision,
-        expectedStoreVersion: state?.storeVersion,
+        proposalId: input.proposalId,
+        expectedRevision: input.expectedRevision,
+        expectedStoreVersion: input.expectedStoreVersion,
+        turnId: input.turnId,
       });
+      approvalRetry.current = undefined;
     });
-  }, [run, session?.id, state?.storeVersion]);
+  }, [run, session?.id, state]);
 
   const resume = useCallback(async (executionId: string): Promise<void> => {
     if (!session) return;
+    const current = resumeRetry.current;
+    const input =
+      current && current.sessionId === session.id && current.executionId === executionId
+        ? current
+        : { sessionId: session.id, executionId, turnId: crypto.randomUUID() };
+    resumeRetry.current = input;
     await run(async () => {
-      await window.maka.sessions.resumePlan(session.id, executionId);
+      await window.maka.sessions.resumePlan(session.id, executionId, input.turnId);
+      resumeRetry.current = undefined;
     });
   }, [run, session?.id]);
 

--- a/packages/runtime-host/src/__tests__/plan-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/plan-protocol.test.ts
@@ -23,6 +23,7 @@ const proposal = {
 test('Plan protocol declares bounded snapshot queries and stable controls', () => {
   assert.equal(HOST_OPERATION_SPECS['plan.query'].mode, 'query');
   assert.equal(HOST_OPERATION_SPECS['plan.control'].mode, 'control');
+  assert.equal(HOST_OPERATION_SPECS['plan.turn.start'].mode, 'command');
   assert.deepEqual(
     decodeRequestFrame({
       requestId: 'request-1',
@@ -93,6 +94,51 @@ test('Plan protocol declares bounded snapshot queries and stable controls', () =
         executionId: null,
       },
     ),
+  );
+});
+
+test('Plan Turn start closes approve and resume into one correlated command', () => {
+  const input = {
+    kind: 'approve_proposal' as const,
+    sessionId: 'session-1',
+    proposalId: 'proposal-1',
+    expectedRevision: 1,
+    expectedStoreVersion: 2,
+    turnId: 'turn-2',
+  };
+  assert.deepEqual(
+    decodeRequestFrame({ requestId: 'request-1', operation: 'plan.turn.start', input }),
+    { requestId: 'request-1', operation: 'plan.turn.start', input },
+  );
+  const result = {
+    plan: {
+      sessionId: 'session-1',
+      storeVersion: 3,
+      eventType: 'plan_approved' as const,
+      proposalId: 'proposal-1',
+      executionId: 'execution-1',
+    },
+    turn: {
+      sessionId: 'session-1',
+      turnId: 'turn-2',
+      runId: 'run-1',
+      status: 'running' as const,
+    },
+  };
+  assert.deepEqual(
+    decodeResponseFrame({
+      requestId: 'request-1',
+      operation: 'plan.turn.start',
+      ok: true,
+      result,
+    }),
+    { requestId: 'request-1', operation: 'plan.turn.start', ok: true, result },
+  );
+  assert.throws(() =>
+    HOST_OPERATION_SPECS['plan.turn.start'].assertOutputForInput?.(input, {
+      ...result,
+      turn: { ...result.turn, turnId: 'turn-other' },
+    }),
   );
 });
 

--- a/packages/runtime-host/src/__tests__/plan-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/plan-two-client-uds.test.ts
@@ -78,11 +78,13 @@ test('two UDS Clients and a restarted production Host share one retry-safe Plan 
       proposalId: submitted.event.proposal.proposalId,
       expectedRevision: submitted.event.proposal.revision,
       expectedStoreVersion: first.storeVersion,
-      operationId: 'approve-operation',
+      turnId: 'approve-turn',
     };
-    const approved = await tui.controlPlan(approval);
+    const started = await tui.startPlanTurn(approval);
+    const approved = started.plan;
     assert.equal(approved.eventType, 'plan_approved');
     assert.ok(approved.executionId);
+    assert.equal(started.turn.turnId, approval.turnId);
     const changed = await withTimeout(
       nextFrameOfKind(subscription, 'subscription.session_domain_changed'),
       2_000,
@@ -116,9 +118,10 @@ test('two UDS Clients and a restarted production Host share one retry-safe Plan 
     owner = undefined;
     tui = await connect(root, 'tui');
 
-    const replayed = await tui.controlPlan(approval);
-    assert.equal(replayed.executionId, approved.executionId);
-    assert.equal(replayed.storeVersion, approved.storeVersion);
+    const replayed = await tui.startPlanTurn(approval);
+    assert.equal(replayed.plan.executionId, approved.executionId);
+    assert.equal(replayed.plan.storeVersion, approved.storeVersion);
+    assert.equal(replayed.turn.turnId, approval.turnId);
     const recovered = await tui.queryPlan({ kind: 'list_start', sessionId: session.id });
     assert.equal(recovered.kind, 'page');
     if (recovered.kind !== 'page') return;
@@ -128,14 +131,41 @@ test('two UDS Clients and a restarted production Host share one retry-safe Plan 
     if (!execution || execution.kind !== 'execution') return;
     assert.equal(execution.execution.status, 'interrupted');
 
-    const cancelled = await tui.controlPlan({
-      kind: 'cancel_execution',
+    await assert.rejects(
+      tui.startPlanTurn({
+        kind: 'resume_execution',
+        sessionId: session.id,
+        executionId: execution.execution.executionId,
+        turnId: approval.turnId,
+      }),
+      (error: unknown) =>
+        error instanceof Error && 'code' in error && error.code === 'operation_conflict',
+    );
+    const unchanged = await tui.queryPlan({ kind: 'list_start', sessionId: session.id });
+    assert.equal(unchanged.kind, 'page');
+    assert.equal(
+      unchanged.kind === 'page'
+        ? unchanged.items.find((item) => item.kind === 'execution')?.execution.status
+        : undefined,
+      'interrupted',
+    );
+
+    const resumed = await tui.startPlanTurn({
+      kind: 'resume_execution',
       sessionId: session.id,
       executionId: execution.execution.executionId,
-      operationId: 'cancel-operation',
+      turnId: 'resume-turn',
     });
-    assert.equal(cancelled.eventType, 'plan_execution_cancelled');
-    assert.equal(cancelled.storeVersion, approved.storeVersion + 2);
+    assert.equal(resumed.plan.eventType, 'plan_execution_resumed');
+    assert.equal(resumed.plan.executionId, execution.execution.executionId);
+    assert.equal(resumed.turn.turnId, 'resume-turn');
+    await waitForTerminal(tui, resumed.turn);
+    const afterResume = await tui.queryPlan({ kind: 'list_start', sessionId: session.id });
+    assert.equal(afterResume.kind, 'page');
+    assert.equal(
+      afterResume.kind === 'page' ? afterResume.activeExecutionId : undefined,
+      execution.execution.executionId,
+    );
   } finally {
     await Promise.allSettled([desktop?.close(), tui?.close()]);
     await host?.close().catch(() => undefined);
@@ -152,6 +182,28 @@ async function connect(
   assert.equal(result.kind, 'connected');
   if (result.kind !== 'connected') throw new Error('Unable to connect to Runtime Host');
   return result.connection;
+}
+
+async function waitForTerminal(
+  connection: RuntimeHostConnection,
+  initial: Awaited<ReturnType<RuntimeHostConnection['startPlanTurn']>>['turn'],
+): Promise<void> {
+  let snapshot = initial;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (
+      snapshot.status === 'completed' ||
+      snapshot.status === 'failed' ||
+      snapshot.status === 'cancelled'
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    snapshot = await connection.queryTurn({
+      sessionId: snapshot.sessionId,
+      turnId: snapshot.turnId,
+    });
+  }
+  throw new Error('Plan execution Turn did not settle');
 }
 
 async function nextFrameOfKind<K extends SubscriptionFrame['kind']>(

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -87,6 +87,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'oauth.login.start',
       'plan.control',
       'plan.query',
+      'plan.turn.start',
       'pricing.mutate',
       'pricing.query',
       'queue.retract',

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -39,6 +39,8 @@ import {
   type PlanControlResult,
   type PlanQueryInput,
   type PlanQueryResult,
+  type PlanTurnStartInput,
+  type PlanTurnStartResult,
   type ProtocolRange,
   type RequestFrame,
   type ResponseFrame,
@@ -161,6 +163,7 @@ export interface RuntimeHostConnection {
   ): Promise<SessionRecapGenerateResult>;
   queryPlan(input: PlanQueryInput, timeoutMs?: number): Promise<PlanQueryResult>;
   controlPlan(input: PlanControlInput, timeoutMs?: number): Promise<PlanControlResult>;
+  startPlanTurn(input: PlanTurnStartInput, timeoutMs?: number): Promise<PlanTurnStartResult>;
   queryDeepResearch(
     input: DeepResearchQueryInput,
     timeoutMs?: number,
@@ -383,6 +386,10 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
 
   controlPlan(input: PlanControlInput, timeoutMs?: number): Promise<PlanControlResult> {
     return this.request('plan.control', input, timeoutMs);
+  }
+
+  startPlanTurn(input: PlanTurnStartInput, timeoutMs?: number): Promise<PlanTurnStartResult> {
+    return this.request('plan.turn.start', input, timeoutMs);
   }
 
   queryDeepResearch(

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -45,7 +45,7 @@ export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // The wire version remains v0 before the first release. This independent epoch
 // lets a new Client retire a stale same-version Host whose closed schema is no
 // longer safe to use.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 3 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 4 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such

--- a/packages/runtime-host/src/protocol/plan.ts
+++ b/packages/runtime-host/src/protocol/plan.ts
@@ -29,6 +29,7 @@ import {
 } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
 import { defineOperation } from './operation-spec.js';
+import { decodeTurnSnapshot, type TurnSnapshot } from './turn.js';
 
 export const PLAN_PAGE_MAX_ITEMS = 16;
 export const PLAN_RESULT_MAX_BYTES = 64 * 1024;
@@ -88,6 +89,27 @@ export interface PlanControlResult {
   readonly executionId: string | null;
 }
 
+export type PlanTurnStartInput =
+  | {
+      readonly kind: 'approve_proposal';
+      readonly sessionId: string;
+      readonly proposalId: string;
+      readonly expectedRevision: number;
+      readonly expectedStoreVersion: number;
+      readonly turnId: string;
+    }
+  | {
+      readonly kind: 'resume_execution';
+      readonly sessionId: string;
+      readonly executionId: string;
+      readonly turnId: string;
+    };
+
+export interface PlanTurnStartResult {
+  readonly plan: PlanControlResult;
+  readonly turn: TurnSnapshot;
+}
+
 export const PLAN_OPERATION_SPECS = {
   'plan.query': defineOperation<PlanQueryInput, PlanQueryResult, (typeof QUERY_ERRORS)[number]>({
     mode: 'query',
@@ -112,6 +134,27 @@ export const PLAN_OPERATION_SPECS = {
     decodeInput: decodePlanControlInput,
     decodeOutput: decodePlanControlResult,
     assertOutputForInput: assertPlanControlResult,
+  }),
+  'plan.turn.start': defineOperation<
+    PlanTurnStartInput,
+    PlanTurnStartResult,
+    (typeof CONTROL_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: CONTROL_ERRORS,
+    decodeInput: decodePlanTurnStartInput,
+    decodeOutput: decodePlanTurnStartResult,
+    assertOutputForInput(input, output) {
+      if (
+        output.plan.sessionId !== input.sessionId ||
+        output.turn.sessionId !== input.sessionId ||
+        output.turn.turnId !== input.turnId
+      ) {
+        throw invalidProtocolFrame('Plan Turn start result changed operation identity');
+      }
+      assertPlanControlResult(planTurnControlInput(input), output.plan);
+    },
   }),
 } as const;
 
@@ -254,6 +297,70 @@ export function decodePlanControlResult(value: unknown): PlanControlResult {
     proposalId: nullableId(result.proposalId, 'proposalId'),
     executionId: nullableId(result.executionId, 'executionId'),
   };
+}
+
+export function decodePlanTurnStartInput(value: unknown): PlanTurnStartInput {
+  const record = requireRecord(value, 'Plan Turn start input');
+  if (record.kind === 'approve_proposal') {
+    const input = requireExactRecord(record, 'Plan approval Turn input', [
+      'kind',
+      'sessionId',
+      'proposalId',
+      'expectedRevision',
+      'expectedStoreVersion',
+      'turnId',
+    ]);
+    return {
+      kind: 'approve_proposal',
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      proposalId: requireEntityId(input.proposalId, 'proposalId'),
+      expectedRevision: requireCount(input.expectedRevision, 'expectedRevision'),
+      expectedStoreVersion: requireCount(input.expectedStoreVersion, 'expectedStoreVersion'),
+      turnId: requireEntityId(input.turnId, 'turnId'),
+    };
+  }
+  if (record.kind === 'resume_execution') {
+    const input = requireExactRecord(record, 'Plan resume Turn input', [
+      'kind',
+      'sessionId',
+      'executionId',
+      'turnId',
+    ]);
+    return {
+      kind: 'resume_execution',
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      executionId: requireEntityId(input.executionId, 'executionId'),
+      turnId: requireEntityId(input.turnId, 'turnId'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid Plan Turn start kind');
+}
+
+export function decodePlanTurnStartResult(value: unknown): PlanTurnStartResult {
+  requireEncodedByteLimit(value, 'Plan Turn start result', PLAN_RESULT_MAX_BYTES);
+  const result = requireExactRecord(value, 'Plan Turn start result', ['plan', 'turn']);
+  return {
+    plan: decodePlanControlResult(result.plan),
+    turn: decodeTurnSnapshot(result.turn),
+  };
+}
+
+export function planTurnControlInput(input: PlanTurnStartInput): PlanControlInput {
+  return input.kind === 'approve_proposal'
+    ? {
+        kind: input.kind,
+        sessionId: input.sessionId,
+        proposalId: input.proposalId,
+        expectedRevision: input.expectedRevision,
+        expectedStoreVersion: input.expectedStoreVersion,
+        operationId: input.turnId,
+      }
+    : {
+        kind: input.kind,
+        sessionId: input.sessionId,
+        executionId: input.executionId,
+        operationId: input.turnId,
+      };
 }
 
 function decodePlanProjectionItem(value: unknown): PlanProjectionItem {

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -755,6 +755,7 @@ export async function createExecutionRuntimeHostComposition(
       onProjectionChanged: (sessionId) =>
         continuityCoordinator.enqueueSessionDomainChanged(sessionId, 'plan'),
       requestDrain: context.requestDrain,
+      root: coordinator,
     });
     const executionInspect = new HostExecutionInspectCoordinator(stores);
     const sessionRevisions = new HostSessionRevisionCoordinator({

--- a/packages/runtime-host/src/server/plan-coordinator.ts
+++ b/packages/runtime-host/src/server/plan-coordinator.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import {
   PlanConflictError,
   planUserControlMutationInput,
@@ -19,11 +20,14 @@ import {
   type OperationOutcome,
   type PlanControlInput,
   type PlanControlResult,
+  type PlanTurnStartInput,
   type PlanProjectionItem,
   type PlanQueryInput,
   type PlanQueryResult,
+  planTurnControlInput,
 } from '../protocol/index.js';
-import type { PlanOperationHandlerMap } from './operation-dispatcher.js';
+import type { ConnectionContext, PlanOperationHandlerMap } from './operation-dispatcher.js';
+import type { RootTurnCoordinator } from './root-turn-coordinator.js';
 import { SessionAdmissionGate, type SessionAdmissionLease } from './session-admission-gate.js';
 
 type PlanRuntime = Pick<
@@ -35,6 +39,10 @@ type PlanRuntime = Pick<
   | 'cancelPlanExecution'
 >;
 
+type AdmittedPlanControlRequest =
+  | { readonly kind: 'ordinary'; readonly input: PlanControlInput }
+  | { readonly kind: 'plan_turn'; readonly input: PlanTurnStartInput };
+
 export interface HostPlanCoordinatorInput {
   readonly store: InteractivePlanStoreWriter;
   readonly sessions: Pick<ExecutionSessionWriter, 'readHeaderSnapshot'>;
@@ -44,6 +52,7 @@ export interface HostPlanCoordinatorInput {
   readonly refreshContinuity: (sessionId: string, lease: SessionAdmissionLease) => Promise<void>;
   readonly onProjectionChanged: (sessionId: string) => void;
   readonly requestDrain: () => void;
+  readonly root: Pick<RootTurnCoordinator, 'startHostedExternalTransition'>;
 }
 
 /** Host-owned Plan query and user-control boundary. */
@@ -51,7 +60,10 @@ export class HostPlanCoordinator {
   readonly handlers: PlanOperationHandlerMap = {
     'plan.query': (input) => this.#sessionAdmission.run(input.sessionId, () => this.#query(input)),
     'plan.control': (input) =>
-      this.#sessionAdmission.run(input.sessionId, (lease) => this.#control(input, lease)),
+      this.#sessionAdmission.run(input.sessionId, (lease) =>
+        this.#control({ kind: 'ordinary', input }, lease),
+      ),
+    'plan.turn.start': (input, context) => this.#startTurn(input, context),
   };
 
   readonly #store: InteractivePlanStoreWriter;
@@ -62,6 +74,7 @@ export class HostPlanCoordinator {
   readonly #refreshContinuity: HostPlanCoordinatorInput['refreshContinuity'];
   readonly #onProjectionChanged: HostPlanCoordinatorInput['onProjectionChanged'];
   readonly #requestDrain: () => void;
+  readonly #root: HostPlanCoordinatorInput['root'];
 
   constructor(input: HostPlanCoordinatorInput) {
     this.#store = authenticateInteractivePlanStoreWriter(input.store);
@@ -72,6 +85,49 @@ export class HostPlanCoordinator {
     this.#refreshContinuity = input.refreshContinuity;
     this.#onProjectionChanged = input.onProjectionChanged;
     this.#requestDrain = input.requestDrain;
+    this.#root = input.root;
+  }
+
+  async #startTurn(
+    input: PlanTurnStartInput,
+    context: ConnectionContext,
+  ): Promise<OperationOutcome<'plan.turn.start'>> {
+    let plan: PlanControlResult | undefined;
+    let planFailure: Extract<OperationOutcome<'plan.control'>, { ok: false }> | undefined;
+    const turn = await this.#root.startHostedExternalTransition(
+      {
+        sessionId: input.sessionId,
+        turnId: input.turnId,
+        inputDigest: planTurnInputDigest(input),
+        archivedMessage: 'Cannot start Plan execution in an archived Session',
+        prepareContent: async (lease) => {
+          const outcome = await this.#control({ kind: 'plan_turn', input }, lease);
+          if (!outcome.ok) {
+            planFailure = outcome;
+            return {
+              kind: 'rejected',
+              outcome: {
+                ok: false,
+                error: { code: 'operation_conflict', message: outcome.error.message },
+              },
+            };
+          }
+          plan = outcome.result;
+          return { kind: 'ready', content: { text: planTurnPrompt(input, outcome.result) } };
+        },
+      },
+      context,
+    );
+    if (planFailure) return { ok: false, error: planFailure.error };
+    if (!turn.ok) return { ok: false, error: turn.error };
+    if (!plan) {
+      this.#requestDrain();
+      return {
+        ok: false,
+        error: { code: 'internal_failure', message: 'Plan Turn transition outcome is unknown' },
+      };
+    }
+    return { ok: true, result: { plan, turn: turn.result } };
   }
 
   async #query(input: PlanQueryInput): Promise<OperationOutcome<'plan.query'>> {
@@ -120,9 +176,10 @@ export class HostPlanCoordinator {
   }
 
   async #control(
-    input: PlanControlInput,
+    request: AdmittedPlanControlRequest,
     lease: SessionAdmissionLease,
   ): Promise<OperationOutcome<'plan.control'>> {
+    const input = request.kind === 'ordinary' ? request.input : planTurnControlInput(request.input);
     let replay = false;
     try {
       replay =
@@ -137,7 +194,7 @@ export class HostPlanCoordinator {
     if (!replay) {
       const unavailable = await this.#assertSessionAvailable(input.sessionId);
       if (unavailable) return controlAvailabilityFailure(unavailable.code, unavailable.message);
-      if (this.#isSessionActive(input.sessionId)) {
+      if (request.kind === 'ordinary' && this.#isSessionActive(input.sessionId)) {
         return controlFailure('session_busy', 'Session has an active root Turn');
       }
     }
@@ -314,4 +371,28 @@ function controlAvailabilityFailure(
   message: string,
 ): OperationOutcome<'plan.control'> {
   return { ok: false, error: { code, message } };
+}
+
+function planTurnInputDigest(input: PlanTurnStartInput): `sha256:${string}` {
+  const canonical =
+    input.kind === 'approve_proposal'
+      ? [
+          input.kind,
+          input.sessionId,
+          input.proposalId,
+          input.expectedRevision,
+          input.expectedStoreVersion,
+        ]
+      : [input.kind, input.sessionId, input.executionId];
+  return `sha256:${createHash('sha256').update(JSON.stringify(canonical)).digest('hex')}`;
+}
+
+function planTurnPrompt(input: PlanTurnStartInput, result: PlanControlResult): string {
+  if (input.kind === 'approve_proposal') {
+    if (result.executionId === null) {
+      throw new PlanConflictError('Plan approval did not create an execution');
+    }
+    return `Execute the approved plan execution ${result.executionId}.`;
+  }
+  return `Resume the approved plan execution ${input.executionId}.`;
 }

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -121,7 +121,7 @@ interface ActiveRootTurn {
   messageTransitionCommitted: boolean;
 }
 
-type TurnStartOutcome = OperationOutcome<'turn.start'>;
+export type TurnStartOutcome = OperationOutcome<'turn.start'>;
 
 type RootMessageExecution = Extract<
   RootExecutionDescriptor,
@@ -132,6 +132,9 @@ interface RootMessageStartRequestBase {
   readonly sessionId: string;
   readonly turnId: string;
   readonly archivedMessage: string;
+  readonly prepareReplayContent?: (
+    lease: SessionAdmissionLease,
+  ) => Promise<RootMessageContentPreparation>;
 }
 
 type RootMessageStartRequest =
@@ -143,7 +146,7 @@ type RootMessageStartRequest =
   | (RootMessageStartRequestBase & {
       readonly execution: Extract<RootMessageExecution, { kind: 'external_message' }>;
       readonly turnOrchestration?: TurnStartInput['turnOrchestration'];
-      prepareFreshContent(): Promise<RootMessageContentPreparation>;
+      prepareFreshContent(lease: SessionAdmissionLease): Promise<RootMessageContentPreparation>;
     })
   | (RootMessageStartRequestBase & {
       readonly execution: Extract<RootMessageExecution, { kind: 'regenerate' }>;
@@ -151,7 +154,7 @@ type RootMessageStartRequest =
       prepareContent(): Promise<MessageContent>;
     });
 
-type RootMessageContentPreparation =
+export type RootMessageContentPreparation =
   | {
       readonly kind: 'ready';
       readonly content: MessageContent;
@@ -160,6 +163,14 @@ type RootMessageContentPreparation =
       >;
     }
   | { readonly kind: 'rejected'; readonly outcome: TurnStartOutcome };
+
+export interface HostedExternalTurnTransitionInput {
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly inputDigest: `sha256:${string}`;
+  readonly archivedMessage: string;
+  prepareContent(lease: SessionAdmissionLease): Promise<RootMessageContentPreparation>;
+}
 
 type RootTurnActivationInput =
   | TurnStartInput
@@ -635,6 +646,23 @@ export class RootTurnCoordinator {
       };
     }
     return this.#reservationsBySession.has(sessionId) ? { kind: 'reserved' } : { kind: 'idle' };
+  }
+
+  startHostedExternalTransition(
+    input: HostedExternalTurnTransitionInput,
+    context: ConnectionContext,
+  ): Promise<TurnStartOutcome> {
+    return this.startRootMessage(
+      {
+        sessionId: input.sessionId,
+        turnId: input.turnId,
+        execution: { kind: 'external_message', inputDigest: input.inputDigest },
+        archivedMessage: input.archivedMessage,
+        prepareFreshContent: input.prepareContent,
+        prepareReplayContent: input.prepareContent,
+      },
+      context,
+    );
   }
 
   private reserveRootTurn(sessionId: string): RootTurnReservation | undefined {
@@ -1693,8 +1721,20 @@ export class RootTurnCoordinator {
               operationConflict('Turn identity belongs to a different execution kind'),
             );
           }
-          const content =
-            'content' in request ? request.content : requireAdmissionMessageContent(existing);
+          if (!isDeepStrictEqual(existing.execution, request.execution)) {
+            return completedStart(
+              operationConflict('Turn identity belongs to a different execution payload'),
+            );
+          }
+          let content: MessageContent;
+          if (request.prepareReplayContent) {
+            const prepared = await request.prepareReplayContent(lease);
+            if (prepared.kind === 'rejected') return completedStart(prepared.outcome);
+            content = normalizeMessageContent(prepared.content);
+          } else {
+            content =
+              'content' in request ? request.content : requireAdmissionMessageContent(existing);
+          }
           if (!rootMessageAdmissionMatches(existing, request, content)) {
             return completedStart(
               operationConflict('Turn identity was already admitted with a different payload'),
@@ -1757,7 +1797,7 @@ export class RootTurnCoordinator {
           return completedStart(operationConflict('Turn identity already exists'));
         }
 
-        const prepared = await this.prepareRootMessageContent(request);
+        const prepared = await this.prepareRootMessageContent(request, lease);
         if (prepared.kind === 'rejected') return completedStart(prepared.outcome);
         const canonicalContent = preflightRootMessageContent(prepared.content);
         if (!canonicalContent.ok) return completedStart(canonicalContent.outcome);
@@ -1831,9 +1871,10 @@ export class RootTurnCoordinator {
 
   private async prepareRootMessageContent(
     request: RootMessageStartRequest,
+    lease: SessionAdmissionLease,
   ): Promise<RootMessageContentPreparation> {
     if ('content' in request) return { kind: 'ready', content: request.content };
-    if ('prepareFreshContent' in request) return request.prepareFreshContent();
+    if ('prepareFreshContent' in request) return request.prepareFreshContent(lease);
     try {
       return { kind: 'ready', content: normalizeMessageContent(await request.prepareContent()) };
     } catch (error) {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- add a correlated `plan.turn.start` command that keeps Plan approval/resume and root Turn startup under one Host-owned Session admission
- reuse one durable identity across Plan mutation and Turn admission, including exact replay after a lost response or Host restart
- reject conflicting Turn descriptors before replaying a Plan mutation
- adapt the Desktop candidate Plan actions to generate and retain retry identities in the renderer, then pass them unchanged through IPC
- advance the compatibility epoch for the expanded operation surface while keeping the experimental wire protocol at v0

## Validation

- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- Runtime Host protocol, real UDS/restart Plan, and Desktop IPC tests (34 passed)
- full Runtime Host suite exercised; the two observed failures both passed isolated reruns after the in-scope contract regression was fixed

Part of #2010.

</details>

<details>
<summary>中文</summary>

## 概要

- 新增关联式 `plan.turn.start` 命令，使计划批准/恢复与根 Turn 启动统一处于 Host 管理的 Session admission 中
- Plan mutation 与 Turn admission 共用同一个持久身份，可在响应丢失或 Host 重启后进行精确重放
- 在重放 Plan mutation 前拒绝与既有 Turn descriptor 冲突的请求
- Desktop candidate 的 Plan 操作改为由 renderer 生成并保留重试身份，再通过 IPC 原样传递
- 为扩展后的操作面推进 compatibility epoch，同时实验性 wire protocol 继续保持 v0

## 验证

- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- Runtime Host 协议、真实 UDS/重启 Plan 和 Desktop IPC 测试（34 项通过）
- 已执行完整 Runtime Host 测试；观察到的两项失败在修复本次范围内的契约回归后，分别精确复跑均通过

属于 #2010 的一部分。

</details>
