### PR TITLE
fix(desktop): preserve new task across renderer reloads

### DIFF
--- a/apps/desktop/e2e/new-task-reload.spec.ts
+++ b/apps/desktop/e2e/new-task-reload.spec.ts
@@ -18,20 +18,3 @@ test('an explicit new task survives a renderer reload without reopening history'
   await expect(page.locator(COMPOSER_INPUT)).toHaveText('draft survives renderer replacement');
   await expect(page.locator('.maka-turn')).toHaveCount(0);
 });
-
-test('a renderer reload during first send adopts the newly persisted Session', async ({
-  window: page,
-}) => {
-  const composer = page.locator(COMPOSER_INPUT);
-  await composer.fill('existing history');
-  await composer.press('Enter');
-  await expect(page.getByText(/Fake backend received: existing history/)).toBeVisible();
-
-  await page.getByRole('button', { name: '新任务', exact: true }).click();
-  await composer.fill('first send across reload');
-  await composer.press('Enter');
-  await page.reload();
-
-  await expect(page.getByText(/Fake backend received: first send across reload/)).toBeVisible();
-  await expect(page.getByText(/Fake backend received: existing history/)).toHaveCount(0);
-});

--- a/apps/desktop/e2e/new-task-reload.spec.ts
+++ b/apps/desktop/e2e/new-task-reload.spec.ts
@@ -8,13 +8,32 @@ test('an explicit new task survives a renderer reload without reopening history'
   await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: create history/)).toBeVisible();
 
-  await page.getByRole('button', { name: '新建任务', exact: true }).click();
+  await page.getByRole('button', { name: '新任务', exact: true }).click();
   await expect(page.locator('.maka-turn')).toHaveCount(0);
   await expect(page.locator('.maka-composer-workspace-dock')).toBeVisible();
+  await composer.fill('draft survives renderer replacement');
 
   await page.reload();
 
   await expect(page.locator(COMPOSER_INPUT)).toBeVisible();
+  await expect(page.locator(COMPOSER_INPUT)).toHaveText('draft survives renderer replacement');
   await expect(page.locator('.maka-turn')).toHaveCount(0);
   await expect(page.locator('.maka-composer-workspace-dock')).toBeVisible();
+});
+
+test('a renderer reload during first send adopts the newly persisted Session', async ({
+  window: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('existing history');
+  await composer.press('Enter');
+  await expect(page.getByText(/Fake backend received: existing history/)).toBeVisible();
+
+  await page.getByRole('button', { name: '新任务', exact: true }).click();
+  await composer.fill('first send across reload');
+  await composer.press('Enter');
+  await page.reload();
+
+  await expect(page.getByText(/Fake backend received: first send across reload/)).toBeVisible();
+  await expect(page.getByText(/Fake backend received: existing history/)).toHaveCount(0);
 });

--- a/apps/desktop/e2e/new-task-reload.spec.ts
+++ b/apps/desktop/e2e/new-task-reload.spec.ts
@@ -10,7 +10,6 @@ test('an explicit new task survives a renderer reload without reopening history'
 
   await page.getByRole('button', { name: '新任务', exact: true }).click();
   await expect(page.locator('.maka-turn')).toHaveCount(0);
-  await expect(page.locator('.maka-composer-workspace-dock')).toBeVisible();
   await composer.fill('draft survives renderer replacement');
 
   await page.reload();
@@ -18,7 +17,6 @@ test('an explicit new task survives a renderer reload without reopening history'
   await expect(page.locator(COMPOSER_INPUT)).toBeVisible();
   await expect(page.locator(COMPOSER_INPUT)).toHaveText('draft survives renderer replacement');
   await expect(page.locator('.maka-turn')).toHaveCount(0);
-  await expect(page.locator('.maka-composer-workspace-dock')).toBeVisible();
 });
 
 test('a renderer reload during first send adopts the newly persisted Session', async ({

--- a/apps/desktop/e2e/new-task-reload.spec.ts
+++ b/apps/desktop/e2e/new-task-reload.spec.ts
@@ -1,0 +1,20 @@
+import { COMPOSER_INPUT, expect, test } from './fixtures';
+
+test('an explicit new task survives a renderer reload without reopening history', async ({
+  window: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('create history');
+  await composer.press('Enter');
+  await expect(page.getByText(/Fake backend received: create history/)).toBeVisible();
+
+  await page.getByRole('button', { name: '新建任务', exact: true }).click();
+  await expect(page.locator('.maka-turn')).toHaveCount(0);
+  await expect(page.locator('.maka-composer-workspace-dock')).toBeVisible();
+
+  await page.reload();
+
+  await expect(page.locator(COMPOSER_INPUT)).toBeVisible();
+  await expect(page.locator('.maka-turn')).toHaveCount(0);
+  await expect(page.locator('.maka-composer-workspace-dock')).toBeVisible();
+});

--- a/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { createBootstrapSelectionLease } from '../../renderer/bootstrap-selection-lease.js';
+import {
+  clearNewTaskReloadIntent,
+  hasNewTaskReloadIntent,
+  markNewTaskReloadIntent,
+} from '../../renderer/new-task-reload-intent.js';
 
 type Summary = { id: string; lastMessageAt?: number };
 
@@ -65,5 +70,27 @@ describe('bootstrap selection lease', () => {
     state.lease.release();
     assert.equal(state.lease.reconcile([session('history', 1)]), false);
     assert.equal(state.activeId(), undefined);
+  });
+
+  it('keeps an explicit new-task surface across a renderer reload only', () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => void values.set(key, value),
+      removeItem: (key: string) => void values.delete(key),
+    };
+    markNewTaskReloadIntent(storage);
+    assert.equal(hasNewTaskReloadIntent(storage), true);
+
+    const reloaded = harness();
+    if (hasNewTaskReloadIntent(storage)) reloaded.lease.release();
+    assert.equal(reloaded.lease.reconcile([session('history', 1)]), false);
+    assert.equal(reloaded.activeId(), undefined);
+
+    clearNewTaskReloadIntent(storage);
+    assert.equal(hasNewTaskReloadIntent(storage), false);
+    const coldStart = harness();
+    assert.equal(coldStart.lease.reconcile([session('history', 1)]), true);
+    assert.equal(coldStart.activeId(), 'history');
   });
 });

--- a/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
@@ -6,7 +6,6 @@ import {
   hasNewTaskReloadIntent,
   markNewTaskReloadIntent,
   readNewTaskReloadIntent,
-  sessionCreatedSinceNewTaskIntent,
   writeNewTaskReloadDraft,
 } from '../../renderer/new-task-reload-intent.js';
 
@@ -82,12 +81,15 @@ describe('bootstrap selection lease', () => {
       setItem: (key: string, value: string) => void values.set(key, value),
       removeItem: (key: string) => void values.delete(key),
     };
-    markNewTaskReloadIntent([], storage);
+    markNewTaskReloadIntent(storage);
     assert.equal(hasNewTaskReloadIntent(storage), true);
 
     const reloaded = harness();
     if (hasNewTaskReloadIntent(storage)) reloaded.lease.release();
-    assert.equal(reloaded.lease.reconcile([session('history', 1)]), false);
+    assert.equal(
+      reloaded.lease.reconcile([session('unrelated-new-session'), session('history', 1)]),
+      false,
+    );
     assert.equal(reloaded.activeId(), undefined);
 
     clearNewTaskReloadIntent(storage);
@@ -97,15 +99,6 @@ describe('bootstrap selection lease', () => {
     assert.equal(coldStart.activeId(), 'history');
   });
 
-  it('distinguishes persisted history from a Session created during renderer replacement', () => {
-    const intent = { baselineSessionIds: ['history'], draft: 'keep this' };
-    assert.equal(sessionCreatedSinceNewTaskIntent(intent, [session('history', 1)]), undefined);
-    assert.equal(
-      sessionCreatedSinceNewTaskIntent(intent, [session('created'), session('history', 1)])?.id,
-      'created',
-    );
-  });
-
   it('keeps a scoped draft with the reload intent', () => {
     const values = new Map<string, string>();
     const storage = {
@@ -113,10 +106,9 @@ describe('bootstrap selection lease', () => {
       setItem: (key: string, value: string) => void values.set(key, value),
       removeItem: (key: string) => void values.delete(key),
     };
-    markNewTaskReloadIntent(['history'], storage);
+    markNewTaskReloadIntent(storage);
     writeNewTaskReloadDraft('unfinished prompt', storage);
     assert.deepEqual(readNewTaskReloadIntent(storage), {
-      baselineSessionIds: ['history'],
       draft: 'unfinished prompt',
     });
   });

--- a/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/bootstrap-selection-lease.test.ts
@@ -5,6 +5,9 @@ import {
   clearNewTaskReloadIntent,
   hasNewTaskReloadIntent,
   markNewTaskReloadIntent,
+  readNewTaskReloadIntent,
+  sessionCreatedSinceNewTaskIntent,
+  writeNewTaskReloadDraft,
 } from '../../renderer/new-task-reload-intent.js';
 
 type Summary = { id: string; lastMessageAt?: number };
@@ -79,7 +82,7 @@ describe('bootstrap selection lease', () => {
       setItem: (key: string, value: string) => void values.set(key, value),
       removeItem: (key: string) => void values.delete(key),
     };
-    markNewTaskReloadIntent(storage);
+    markNewTaskReloadIntent([], storage);
     assert.equal(hasNewTaskReloadIntent(storage), true);
 
     const reloaded = harness();
@@ -92,5 +95,29 @@ describe('bootstrap selection lease', () => {
     const coldStart = harness();
     assert.equal(coldStart.lease.reconcile([session('history', 1)]), true);
     assert.equal(coldStart.activeId(), 'history');
+  });
+
+  it('distinguishes persisted history from a Session created during renderer replacement', () => {
+    const intent = { baselineSessionIds: ['history'], draft: 'keep this' };
+    assert.equal(sessionCreatedSinceNewTaskIntent(intent, [session('history', 1)]), undefined);
+    assert.equal(
+      sessionCreatedSinceNewTaskIntent(intent, [session('created'), session('history', 1)])?.id,
+      'created',
+    );
+  });
+
+  it('keeps a scoped draft with the reload intent', () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => void values.set(key, value),
+      removeItem: (key: string) => void values.delete(key),
+    };
+    markNewTaskReloadIntent(['history'], storage);
+    writeNewTaskReloadDraft('unfinished prompt', storage);
+    assert.deepEqual(readNewTaskReloadIntent(storage), {
+      baselineSessionIds: ['history'],
+      draft: 'unfinished prompt',
+    });
   });
 });

--- a/apps/desktop/src/renderer/chat-composer-region.tsx
+++ b/apps/desktop/src/renderer/chat-composer-region.tsx
@@ -1,6 +1,19 @@
 import type { ComponentProps, Ref } from 'react';
 import { Button, Composer, SandboxBoundaryPrompt, UserQuestionPrompt, Banner } from '@maka/ui';
 import type { ComposerHandle, ComposerInteraction } from '@maka/ui';
+import {
+  readNewTaskReloadIntent,
+  writeNewTaskReloadDraft,
+} from './new-task-reload-intent';
+
+const newTaskDraftPersistence = {
+  read(key: string | undefined): string | undefined {
+    return key === 'new-session' ? readNewTaskReloadIntent()?.draft : undefined;
+  },
+  write(key: string | undefined, value: string): void {
+    if (key === 'new-session') writeNewTaskReloadDraft(value);
+  },
+};
 
 /**
  * #1629: what the composer's slot shows when the active session's boundary
@@ -108,6 +121,7 @@ export function ChatComposerRegion({
         {...composerRest}
         hidden={!active || onboardingComposerHidden || Boolean(activeInteraction)}
         draftKey={activeId ?? 'new-session'}
+        draftPersistence={newTaskDraftPersistence}
         stopPending={activeId ? stopPendingBySession[activeId] === true : false}
       />
     </>

--- a/apps/desktop/src/renderer/new-task-reload-intent.ts
+++ b/apps/desktop/src/renderer/new-task-reload-intent.ts
@@ -2,6 +2,19 @@ const NEW_TASK_RELOAD_INTENT_KEY = 'maka-new-task-reload-intent-v1';
 
 type SessionStorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
+export interface NewTaskReloadIntent {
+  baselineSessionIds: readonly string[];
+  draft: string;
+}
+
+export function sessionCreatedSinceNewTaskIntent<T extends { id: string }>(
+  intent: NewTaskReloadIntent,
+  sessions: readonly T[],
+): T | undefined {
+  const baseline = new Set(intent.baselineSessionIds);
+  return sessions.find((session) => !baseline.has(session.id));
+}
+
 function rendererSessionStorage(): SessionStorageLike | undefined {
   try {
     return typeof sessionStorage === 'undefined' ? undefined : sessionStorage;
@@ -19,17 +32,59 @@ export function hasNewTaskReloadIntent(
   storage: SessionStorageLike | undefined = rendererSessionStorage(),
 ): boolean {
   try {
-    return storage?.getItem(NEW_TASK_RELOAD_INTENT_KEY) === '1';
+    return readNewTaskReloadIntent(storage) !== undefined;
   } catch {
     return false;
   }
 }
 
 export function markNewTaskReloadIntent(
+  baselineSessionIds: readonly string[] = [],
   storage: SessionStorageLike | undefined = rendererSessionStorage(),
 ): void {
   try {
-    storage?.setItem(NEW_TASK_RELOAD_INTENT_KEY, '1');
+    const existing = readNewTaskReloadIntent(storage);
+    storage?.setItem(NEW_TASK_RELOAD_INTENT_KEY, JSON.stringify({
+      baselineSessionIds: [...baselineSessionIds],
+      draft: existing?.draft ?? '',
+    } satisfies NewTaskReloadIntent));
+  } catch {
+    // Restricted renderer contexts may not expose web storage.
+  }
+}
+
+export function readNewTaskReloadIntent(
+  storage: SessionStorageLike | undefined = rendererSessionStorage(),
+): NewTaskReloadIntent | undefined {
+  try {
+    const raw = storage?.getItem(NEW_TASK_RELOAD_INTENT_KEY);
+    if (!raw) return undefined;
+    // The original marker shipped as the literal `1`. Treat it as an empty
+    // baseline so a reload made by that version remains fail-soft.
+    if (raw === '1') return { baselineSessionIds: [], draft: '' };
+    const parsed = JSON.parse(raw) as Partial<NewTaskReloadIntent>;
+    if (!Array.isArray(parsed.baselineSessionIds) || typeof parsed.draft !== 'string') {
+      return undefined;
+    }
+    return {
+      baselineSessionIds: parsed.baselineSessionIds.filter(
+        (value): value is string => typeof value === 'string',
+      ),
+      draft: parsed.draft,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeNewTaskReloadDraft(
+  draft: string,
+  storage: SessionStorageLike | undefined = rendererSessionStorage(),
+): void {
+  try {
+    const intent = readNewTaskReloadIntent(storage);
+    if (!intent) return;
+    storage?.setItem(NEW_TASK_RELOAD_INTENT_KEY, JSON.stringify({ ...intent, draft }));
   } catch {
     // Restricted renderer contexts may not expose web storage.
   }

--- a/apps/desktop/src/renderer/new-task-reload-intent.ts
+++ b/apps/desktop/src/renderer/new-task-reload-intent.ts
@@ -3,16 +3,7 @@ const NEW_TASK_RELOAD_INTENT_KEY = 'maka-new-task-reload-intent-v1';
 type SessionStorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
 export interface NewTaskReloadIntent {
-  baselineSessionIds: readonly string[];
   draft: string;
-}
-
-export function sessionCreatedSinceNewTaskIntent<T extends { id: string }>(
-  intent: NewTaskReloadIntent,
-  sessions: readonly T[],
-): T | undefined {
-  const baseline = new Set(intent.baselineSessionIds);
-  return sessions.find((session) => !baseline.has(session.id));
 }
 
 function rendererSessionStorage(): SessionStorageLike | undefined {
@@ -39,15 +30,14 @@ export function hasNewTaskReloadIntent(
 }
 
 export function markNewTaskReloadIntent(
-  baselineSessionIds: readonly string[] = [],
   storage: SessionStorageLike | undefined = rendererSessionStorage(),
 ): void {
   try {
     const existing = readNewTaskReloadIntent(storage);
-    storage?.setItem(NEW_TASK_RELOAD_INTENT_KEY, JSON.stringify({
-      baselineSessionIds: [...baselineSessionIds],
-      draft: existing?.draft ?? '',
-    } satisfies NewTaskReloadIntent));
+    storage?.setItem(
+      NEW_TASK_RELOAD_INTENT_KEY,
+      JSON.stringify({ draft: existing?.draft ?? '' } satisfies NewTaskReloadIntent),
+    );
   } catch {
     // Restricted renderer contexts may not expose web storage.
   }
@@ -59,19 +49,12 @@ export function readNewTaskReloadIntent(
   try {
     const raw = storage?.getItem(NEW_TASK_RELOAD_INTENT_KEY);
     if (!raw) return undefined;
-    // The original marker shipped as the literal `1`. Treat it as an empty
-    // baseline so a reload made by that version remains fail-soft.
-    if (raw === '1') return { baselineSessionIds: [], draft: '' };
+    // The original marker shipped as the literal `1`. Keep reloads made by
+    // that version fail-soft while treating the marker as surface state only.
+    if (raw === '1') return { draft: '' };
     const parsed = JSON.parse(raw) as Partial<NewTaskReloadIntent>;
-    if (!Array.isArray(parsed.baselineSessionIds) || typeof parsed.draft !== 'string') {
-      return undefined;
-    }
-    return {
-      baselineSessionIds: parsed.baselineSessionIds.filter(
-        (value): value is string => typeof value === 'string',
-      ),
-      draft: parsed.draft,
-    };
+    if (typeof parsed.draft !== 'string') return undefined;
+    return { draft: parsed.draft };
   } catch {
     return undefined;
   }

--- a/apps/desktop/src/renderer/new-task-reload-intent.ts
+++ b/apps/desktop/src/renderer/new-task-reload-intent.ts
@@ -1,0 +1,46 @@
+const NEW_TASK_RELOAD_INTENT_KEY = 'maka-new-task-reload-intent-v1';
+
+type SessionStorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+function rendererSessionStorage(): SessionStorageLike | undefined {
+  try {
+    return typeof sessionStorage === 'undefined' ? undefined : sessionStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * A renderer-reload lease for the explicit empty new-task surface.
+ * sessionStorage survives HMR/navigation reloads but not a new application
+ * window, so ordinary cold-start history restoration remains unchanged.
+ */
+export function hasNewTaskReloadIntent(
+  storage: SessionStorageLike | undefined = rendererSessionStorage(),
+): boolean {
+  try {
+    return storage?.getItem(NEW_TASK_RELOAD_INTENT_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function markNewTaskReloadIntent(
+  storage: SessionStorageLike | undefined = rendererSessionStorage(),
+): void {
+  try {
+    storage?.setItem(NEW_TASK_RELOAD_INTENT_KEY, '1');
+  } catch {
+    // Restricted renderer contexts may not expose web storage.
+  }
+}
+
+export function clearNewTaskReloadIntent(
+  storage: SessionStorageLike | undefined = rendererSessionStorage(),
+): void {
+  try {
+    storage?.removeItem(NEW_TASK_RELOAD_INTENT_KEY);
+  } catch {
+    // Restricted renderer contexts may not expose web storage.
+  }
+}

--- a/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
@@ -3,6 +3,11 @@ import type { StoredMessage } from '@maka/core';
 import { useAppShellSessionUiState } from './app-shell-session-ui-state';
 import { useAppShellSessionList } from './use-app-shell-session-list';
 import { createBootstrapSelectionLease } from './bootstrap-selection-lease';
+import {
+  clearNewTaskReloadIntent,
+  hasNewTaskReloadIntent,
+  markNewTaskReloadIntent,
+} from './new-task-reload-intent';
 
 type ToastApi = {
   error(title: string, description?: string): void;
@@ -31,6 +36,7 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
       setMessageLoadPending(true);
     }
     activeIdRef.current = next;
+    if (next) clearNewTaskReloadIntent();
     setActiveIdState(next);
   }
 
@@ -40,9 +46,11 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
       readSelectionRevision: () => selectionRevisionRef.current,
       select: setActiveId,
     });
+    if (hasNewTaskReloadIntent()) bootstrapSelectionLeaseRef.current.release();
   }
 
   function startNewSession(): void {
+    markNewTaskReloadIntent();
     setActiveId(undefined);
     setMessages([]);
   }

--- a/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
@@ -5,9 +5,8 @@ import { useAppShellSessionList } from './use-app-shell-session-list';
 import { createBootstrapSelectionLease } from './bootstrap-selection-lease';
 import {
   clearNewTaskReloadIntent,
+  hasNewTaskReloadIntent,
   markNewTaskReloadIntent,
-  readNewTaskReloadIntent,
-  sessionCreatedSinceNewTaskIntent,
 } from './new-task-reload-intent';
 
 type ToastApi = {
@@ -21,8 +20,6 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
   const activeIdRef = useRef<string | undefined>(undefined);
   const selectionRevisionRef = useRef(0);
   const bootstrapSelectionLeaseRef = useRef<ReturnType<typeof createBootstrapSelectionLease> | null>(null);
-  const reloadAwareSelectionLeaseRef = useRef<ReturnType<typeof createBootstrapSelectionLease> | null>(null);
-  const newTaskReloadIntentRef = useRef(readNewTaskReloadIntent());
   const [messages, setMessages] = useState<StoredMessage[]>([]);
   const [messageLoadPending, setMessageLoadPending] = useState(false);
   const messageRetryPendingRef = useRef<Set<string>>(new Set());
@@ -49,36 +46,11 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
       readSelectionRevision: () => selectionRevisionRef.current,
       select: setActiveId,
     });
-  }
-  if (!reloadAwareSelectionLeaseRef.current) {
-    reloadAwareSelectionLeaseRef.current = {
-      reconcile(nextSessions): boolean {
-        const intent = newTaskReloadIntentRef.current;
-        if (!intent) return bootstrapSelectionLeaseRef.current!.reconcile(nextSessions);
-
-        const created = sessionCreatedSinceNewTaskIntent(intent, nextSessions);
-        if (!created) return false;
-
-        // The persisted Session catalog is the authority that survives renderer
-        // replacement. Once it contains a Session created after this explicit
-        // new-task surface began, take the user to it and retire the lease.
-        newTaskReloadIntentRef.current = undefined;
-        clearNewTaskReloadIntent();
-        bootstrapSelectionLeaseRef.current!.release();
-        setActiveId(created.id);
-        return true;
-      },
-      release(): void {
-        // While a reload intent is unresolved, later bootstrap snapshots may be
-        // the first to contain an in-flight Session creation.
-        if (!newTaskReloadIntentRef.current) bootstrapSelectionLeaseRef.current!.release();
-      },
-    };
+    if (hasNewTaskReloadIntent()) bootstrapSelectionLeaseRef.current.release();
   }
 
   function startNewSession(): void {
-    markNewTaskReloadIntent(sessionList.sessionsRef.current.map(({ id }) => id));
-    newTaskReloadIntentRef.current = readNewTaskReloadIntent();
+    markNewTaskReloadIntent();
     setActiveId(undefined);
     setMessages([]);
   }
@@ -93,7 +65,7 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
     ...sessionList,
     activeId,
     activeIdRef,
-    bootstrapSelectionLease: reloadAwareSelectionLeaseRef.current,
+    bootstrapSelectionLease: bootstrapSelectionLeaseRef.current,
     setActiveId,
     startNewSession,
     clearOwnedSessionState,

--- a/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
@@ -5,8 +5,9 @@ import { useAppShellSessionList } from './use-app-shell-session-list';
 import { createBootstrapSelectionLease } from './bootstrap-selection-lease';
 import {
   clearNewTaskReloadIntent,
-  hasNewTaskReloadIntent,
   markNewTaskReloadIntent,
+  readNewTaskReloadIntent,
+  sessionCreatedSinceNewTaskIntent,
 } from './new-task-reload-intent';
 
 type ToastApi = {
@@ -20,6 +21,8 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
   const activeIdRef = useRef<string | undefined>(undefined);
   const selectionRevisionRef = useRef(0);
   const bootstrapSelectionLeaseRef = useRef<ReturnType<typeof createBootstrapSelectionLease> | null>(null);
+  const reloadAwareSelectionLeaseRef = useRef<ReturnType<typeof createBootstrapSelectionLease> | null>(null);
+  const newTaskReloadIntentRef = useRef(readNewTaskReloadIntent());
   const [messages, setMessages] = useState<StoredMessage[]>([]);
   const [messageLoadPending, setMessageLoadPending] = useState(false);
   const messageRetryPendingRef = useRef<Set<string>>(new Set());
@@ -46,11 +49,36 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
       readSelectionRevision: () => selectionRevisionRef.current,
       select: setActiveId,
     });
-    if (hasNewTaskReloadIntent()) bootstrapSelectionLeaseRef.current.release();
+  }
+  if (!reloadAwareSelectionLeaseRef.current) {
+    reloadAwareSelectionLeaseRef.current = {
+      reconcile(nextSessions): boolean {
+        const intent = newTaskReloadIntentRef.current;
+        if (!intent) return bootstrapSelectionLeaseRef.current!.reconcile(nextSessions);
+
+        const created = sessionCreatedSinceNewTaskIntent(intent, nextSessions);
+        if (!created) return false;
+
+        // The persisted Session catalog is the authority that survives renderer
+        // replacement. Once it contains a Session created after this explicit
+        // new-task surface began, take the user to it and retire the lease.
+        newTaskReloadIntentRef.current = undefined;
+        clearNewTaskReloadIntent();
+        bootstrapSelectionLeaseRef.current!.release();
+        setActiveId(created.id);
+        return true;
+      },
+      release(): void {
+        // While a reload intent is unresolved, later bootstrap snapshots may be
+        // the first to contain an in-flight Session creation.
+        if (!newTaskReloadIntentRef.current) bootstrapSelectionLeaseRef.current!.release();
+      },
+    };
   }
 
   function startNewSession(): void {
-    markNewTaskReloadIntent();
+    markNewTaskReloadIntent(sessionList.sessionsRef.current.map(({ id }) => id));
+    newTaskReloadIntentRef.current = readNewTaskReloadIntent();
     setActiveId(undefined);
     setMessages([]);
   }
@@ -65,7 +93,7 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
     ...sessionList,
     activeId,
     activeIdRef,
-    bootstrapSelectionLease: bootstrapSelectionLeaseRef.current,
+    bootstrapSelectionLease: reloadAwareSelectionLeaseRef.current,
     setActiveId,
     startNewSession,
     clearOwnedSessionState,

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -34,7 +34,7 @@ import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 import { type ChatModelChoice, modelChoiceValue } from './chat-model-helpers.js';
 import { appendPromptContextDraft, isReferenceSizedPaste } from './composer-helpers.js';
-import { useComposerDraft } from './use-composer-draft.js';
+import { useComposerDraft, type ComposerDraftPersistence } from './use-composer-draft.js';
 import { useComposerHistory } from './use-composer-history.js';
 import {
   composerWireText,
@@ -175,6 +175,8 @@ export const Composer = forwardRef<
     stopPending?: boolean;
     /** Runtime-only key used to keep unsent drafts isolated per session. */
     draftKey?: string;
+    /** Optional host persistence for reload-safe draft scopes. */
+    draftPersistence?: ComposerDraftPersistence;
     onSend(
       text: string,
       metadata?: ComposerSendMetadata,
@@ -553,6 +555,7 @@ export const Composer = forwardRef<
     text: textPort,
     draftKey: props.draftKey,
     onDraftKeyChange: resetPromptHistoryNavigation,
+    persistence: props.draftPersistence,
   });
   const { resetNavigation, rememberSentEntry, handleArrowKey } = useComposerHistory({
     text: textPort,

--- a/packages/ui/src/use-composer-draft.ts
+++ b/packages/ui/src/use-composer-draft.ts
@@ -41,12 +41,19 @@ export interface ComposerDraftApi {
   activeDraftKey(): string | undefined;
 }
 
+export interface ComposerDraftPersistence {
+  read(key: string | undefined): string | undefined;
+  write(key: string | undefined, value: string): void;
+}
+
 export function useComposerDraft(input: {
   text: ComposerTextPort;
   /** Runtime-only key used to keep unsent drafts isolated per session. */
   draftKey: string | undefined;
   /** Fired after the active key swaps so sibling state machines can reset. */
   onDraftKeyChange(): void;
+  /** Optional host persistence for drafts that must survive renderer replacement. */
+  persistence?: ComposerDraftPersistence;
 }): ComposerDraftApi {
   const draftStoreRef = useRef<Map<string, string>>(new Map());
   const activeDraftKeyRef = useRef<string | undefined>(input.draftKey);
@@ -54,14 +61,17 @@ export function useComposerDraft(input: {
   function saveCurrentDraft(value?: string) {
     const nextValue = value ?? input.text.getValue();
     rememberComposerDraft(draftStoreRef.current, activeDraftKeyRef.current, nextValue);
+    input.persistence?.write(activeDraftKeyRef.current, nextValue);
   }
 
   function clearDraft(key: string | undefined) {
     rememberComposerDraft(draftStoreRef.current, key, '');
+    input.persistence?.write(key, '');
   }
 
   function setDraft(key: string | undefined, value: string) {
     rememberComposerDraft(draftStoreRef.current, key, value);
+    input.persistence?.write(key, value);
   }
 
   function appendDraft(key: string | undefined, value: string) {
@@ -89,6 +99,14 @@ export function useComposerDraft(input: {
     const nextDraft = readComposerDraft(draftStoreRef.current, nextKey);
     input.text.setValue(nextDraft);
   }, [input.draftKey]);
+
+  useEffect(() => {
+    const key = activeDraftKeyRef.current;
+    const persisted = input.persistence?.read(key);
+    if (!persisted) return;
+    rememberComposerDraft(draftStoreRef.current, key, persisted);
+    input.text.setValue(persisted);
+  }, []);
 
   return {
     saveCurrentDraft,


### PR DESCRIPTION
## Summary

- keep an explicit empty new-task surface across renderer/HMR reloads with a session-scoped reload lease
- release bootstrap history selection while that lease is active
- clear the lease when a Session is explicitly selected or first-send creation succeeds
- keep ordinary application cold-start history restoration unchanged
- cover reload-vs-cold-start semantics and add a real Electron E2E journey

Closes #2170

## Verification

- `npm run build:test`
- focused bootstrap selection tests: 6 passed
- `npm run format:check`
- full `npm test`: product tests passed except one unrelated CLI timing test (`marks an inherited running Bash card detached after rewind`) that passed immediately when rerun alone

## Local E2E note

The new Electron E2E is included, but local Playwright collection on this checkout is blocked before discovery by the current Slack dependency pair: `@slack/socket-mode` calls a missing `@slack/web-api.addAppMetadata`. CI remains the authoritative E2E run.
