### PR TITLE
feat(headless): let the Maka arm run where its competitors run

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -253,9 +253,20 @@ class MakaAgent(BaseInstalledAgent):
         )
 
     def _task_run_in_container(self) -> bool:
-        """Pier task runs execute in the task container; plain Harbor keeps its
-        existing host bridge for Terminal-Bench callers."""
-        return self._harbor_mode() == "task-run" and _NetworkAllowlist is not None
+        """A task run executes in the task container. The caller asks for that
+        by mode; nothing else here decides it.
+
+        This used to also require a `NetworkAllowlist`, which exists only under
+        Pier — so the clause read as "Pier only" while looking like a safety
+        check. It was neither. Every competitor adapter runs in the task
+        container under plain Harbor and returns `None` from
+        `network_allowlist` there, so the allowlist was a condition this arm
+        alone had to satisfy to stand where the others already stood, and the
+        arms it was compared against were the ones it excluded it from joining.
+        Where an allowlist exists it is still applied; where the harness has
+        none to give, this arm is confined exactly as its competitors are.
+        """
+        return self._harbor_mode() == "task-run"
 
     def _harbor_mode(self) -> str:
         """cell (default) runs a RuntimeRunner cell. task-run runs the full

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -3,6 +3,7 @@
 import { readFile, rename, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { execFile } from 'node:child_process';
+import { lookup } from 'node:dns/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -800,6 +801,42 @@ export function harnessMakaPlacement(benchmarkProfile, env = process.env) {
   return requested === 'task-container' ? 'task-container' : 'host-bridge';
 }
 
+/**
+ * The Ubuntu apt hosts a task container reaches, and where they point.
+ *
+ * Terminal-Bench task images are bare `ubuntu:24.04` plus curl, so most tasks
+ * apt-install what they need and the benchmark silently depends on
+ * archive.ubuntu.com being reachable from the run host. Where that link is
+ * degraded the dependency stops being a constant and becomes noise: the same
+ * arm on the same task finished in 479s on one run and hit the 900s deadline on
+ * the next, issuing an identical 24 tool calls both times, with the entire
+ * difference sitting in how long apt stalled. Noise of that shape does not
+ * cancel across arms — it charges whichever agent happened to need more
+ * packages, which is not the thing this benchmark is trying to measure.
+ *
+ * Redirecting is opt-in, and recorded in the manifest, because it changes the
+ * environment every task runs in. It changes no task image and no sources list:
+ * the container still resolves and requests archive.ubuntu.com, so what an
+ * agent observes — and what its trace shows it observed — is unchanged.
+ */
+export const UBUNTU_APT_HOSTS = ['archive.ubuntu.com', 'security.ubuntu.com'];
+
+export function harnessAptMirror(env = process.env) {
+  return (env.MAKA_HARNESS_AB_APT_MIRROR || '').trim() || null;
+}
+
+/**
+ * Compose only accepts a literal address in `extra_hosts`, so the mirror name is
+ * resolved once per run rather than per cell. Pinning the address is also what
+ * makes the redirect reportable: the manifest records the address every cell
+ * actually used, not a name that could have resolved differently under each.
+ */
+export function aptMirrorComposeContent(address) {
+  if (!address) throw new Error('apt mirror address is required');
+  const entries = UBUNTU_APT_HOSTS.map((host) => `      - '${host}:${address}'`).join('\n');
+  return `services:\n  main:\n    extra_hosts:\n${entries}\n`;
+}
+
 export function harnessMakaAgentEnv(benchmarkProfile, env = process.env) {
   return {
     ...(harnessMakaPlacement(benchmarkProfile, env) === 'task-container'
@@ -828,6 +865,7 @@ export function buildHarnessAbManifest({
   oracleEvidence,
   credentialIdentity,
   pierVersion = null,
+  aptMirrorAddress = null,
   env = process.env,
 }) {
   assertResolvedHarnessComposition(composition);
@@ -852,6 +890,19 @@ export function buildHarnessAbManifest({
       // task-native model budget, so every arm gets the same model time.
       agentSettlementGraceSec: MAKA_SETTLEMENT_GRACE_SEC,
       outerTimeoutGraceSec: HARBOR_SETUP_TEARDOWN_GRACE_SEC,
+      // Recorded only when the run redirects apt, for the same reason the Maka
+      // arm records its placement only when it moves: every existing run fetched
+      // packages from Ubuntu's own hosts, and saying so explicitly would fork
+      // their fingerprints without changing what they ran.
+      ...(aptMirrorAddress
+        ? {
+            packageMirror: {
+              hosts: UBUNTU_APT_HOSTS,
+              name: harnessAptMirror(env),
+              address: aptMirrorAddress,
+            },
+          }
+        : {}),
     },
     taskIds: resolvedTaskIds,
     orderSeed: `${benchmarkProfile.id}:${execution.model}:harness-comparison:v1`,
@@ -1115,6 +1166,8 @@ async function runLocked({
   });
 
   const pierVersion = benchmarkProfile.executor === 'pier' ? await readPierVersion() : null;
+  const aptMirrorName = harnessAptMirror();
+  const aptMirrorAddress = aptMirrorName ? (await lookup(aptMirrorName)).address : null;
   const toolchainFingerprint = buildHarnessAbToolchainFingerprint({
     hostToolchainFingerprint,
     competitorProfile,
@@ -1136,6 +1189,7 @@ async function runLocked({
     ...(oracleEvidence ? { oracleEvidence } : {}),
     credentialIdentity: credentials.credentialIdentity,
     pierVersion,
+    aptMirrorAddress,
   });
   const manifest = await resolveHarnessAbManifestForRun({
     manifestPath,
@@ -1158,9 +1212,13 @@ async function runLocked({
   const makaPlacement = harnessMakaPlacement(benchmarkProfile);
   const makaNodeToolchain =
     makaPlacement === 'task-container' ? resolveHarnessMakaNodeToolchain(runRoot) : null;
+  const aptMirrorComposePath = aptMirrorAddress ? join(runRoot, 'apt-mirror.compose.yaml') : null;
   await Promise.all([
     ...[...competitorToolchains.values()].map((toolchain) => toolchain.prepare(toolchain.path)),
     makaNodeToolchain?.prepare(makaNodeToolchain.path),
+    aptMirrorComposePath
+      ? writeFile(aptMirrorComposePath, aptMirrorComposeContent(aptMirrorAddress))
+      : null,
   ]);
 
   const execution = buildHarnessExecutionProfile(runtimeProfile);
@@ -1204,6 +1262,7 @@ async function runLocked({
           : {
               agentEnv: { MAKA_BASE_URL: execution.baseUrl },
               dockerPlatform: 'linux/amd64',
+              ...(aptMirrorComposePath ? { aptMirrorComposePath } : {}),
             }),
       };
       const config = (id) => ({

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -965,7 +965,15 @@ export function buildHarnessAbManifest({
           billingMode: runtimeProfile.billingMode,
           externalSystemPrompt: 'none',
           profile: profile.id,
-          ...(benchmarkProfile.executor === 'pier'
+          // Placement is declared by every arm or by none: the report refuses a
+          // manifest where only some arms state where they ran, because a
+          // comparison that names one arm's environment and not the others'
+          // invites the reader to assume they shared it. These arms have always
+          // run in the task container, so the condition is really about the
+          // Maka arm — once it joins them the fact is worth stating, and while
+          // it bridges from the host no existing manifest states it at all.
+          // Pier reaches this through the same door: it forces task-container.
+          ...(makaPlacement === 'task-container'
             ? { execution: { placement: 'task-container' } }
             : {}),
         },

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -821,8 +821,16 @@ export function harnessMakaPlacement(benchmarkProfile, env = process.env) {
  */
 export const UBUNTU_APT_HOSTS = ['archive.ubuntu.com', 'security.ubuntu.com'];
 
-export function harnessAptMirror(env = process.env) {
-  return (env.MAKA_HARNESS_AB_APT_MIRROR || '').trim() || null;
+export function harnessAptMirror(benchmarkProfile, env = process.env) {
+  const name = (env.MAKA_HARNESS_AB_APT_MIRROR || '').trim() || null;
+  // Only the harbor runner layers the overlay, so a pier run would record a
+  // redirect in its manifest that no cell performed, and fork its identity on
+  // that false record. Refuse the combination rather than silently dropping the
+  // mirror, the same way the placement guard refuses host-bridge under pier.
+  if (name && benchmarkProfile.executor === 'pier') {
+    throw new Error('the pier executor does not redirect package hosts');
+  }
+  return name;
 }
 
 /**
@@ -898,7 +906,7 @@ export function buildHarnessAbManifest({
         ? {
             packageMirror: {
               hosts: UBUNTU_APT_HOSTS,
-              name: harnessAptMirror(env),
+              name: harnessAptMirror(benchmarkProfile, env),
               address: aptMirrorAddress,
             },
           }
@@ -1174,7 +1182,8 @@ async function runLocked({
   });
 
   const pierVersion = benchmarkProfile.executor === 'pier' ? await readPierVersion() : null;
-  const aptMirrorName = harnessAptMirror();
+  const makaPlacement = harnessMakaPlacement(benchmarkProfile);
+  const aptMirrorName = harnessAptMirror(benchmarkProfile);
   const aptMirrorAddress = aptMirrorName ? (await lookup(aptMirrorName)).address : null;
   const toolchainFingerprint = buildHarnessAbToolchainFingerprint({
     hostToolchainFingerprint,
@@ -1182,9 +1191,7 @@ async function runLocked({
     competitorProfiles,
     pierVersion,
     makaNodeToolchainFingerprint:
-      harnessMakaPlacement(benchmarkProfile) === 'task-container'
-        ? MAKA_NODE_TOOLCHAIN_FINGERPRINT
-        : null,
+      makaPlacement === 'task-container' ? MAKA_NODE_TOOLCHAIN_FINGERPRINT : null,
   });
   const proposedManifest = buildHarnessAbManifest({
     subjectFingerprint,
@@ -1217,7 +1224,6 @@ async function runLocked({
       resolveHarnessCompetitorToolchain(runRoot, profile),
     ]),
   );
-  const makaPlacement = harnessMakaPlacement(benchmarkProfile);
   const makaNodeToolchain =
     makaPlacement === 'task-container' ? resolveHarnessMakaNodeToolchain(runRoot) : null;
   const aptMirrorComposePath = aptMirrorAddress ? join(runRoot, 'apt-mirror.compose.yaml') : null;

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -772,9 +772,39 @@ export function harnessMakaContextBudgetEnv() {
   };
 }
 
-export function harnessMakaAgentEnv(benchmarkProfile) {
+/**
+ * Where the Maka arm runs. Pier always places it in the task container; under
+ * Harbor it bridges from the host unless the caller asks otherwise.
+ *
+ * This is opt-in rather than a flipped default because it changes the shape of
+ * the experiment, not a parameter of it. Every competitor arm runs in the task
+ * container, so a host-side Maka arm is the one arm that cannot be hit by a
+ * defect in the container path — and three such defects were found during this
+ * benchmark. Moving it is what makes the arms comparable; keeping the old
+ * placement reachable is what lets the two topologies be run against each other
+ * to show whether a difference came from the agent or from where it ran.
+ */
+export function harnessMakaPlacement(benchmarkProfile, env = process.env) {
+  const requested = (env.MAKA_HARNESS_AB_MAKA_PLACEMENT || '').trim();
+  if (requested && requested !== 'task-container' && requested !== 'host-bridge') {
+    throw new Error(
+      `MAKA_HARNESS_AB_MAKA_PLACEMENT must be task-container or host-bridge, got ${requested}`,
+    );
+  }
+  if (benchmarkProfile.executor === 'pier') {
+    if (requested === 'host-bridge') {
+      throw new Error('the pier executor always runs the Maka arm in the task container');
+    }
+    return 'task-container';
+  }
+  return requested === 'task-container' ? 'task-container' : 'host-bridge';
+}
+
+export function harnessMakaAgentEnv(benchmarkProfile, env = process.env) {
   return {
-    ...(benchmarkProfile.executor === 'pier' ? { MAKA_HARBOR_MODE: 'task-run' } : {}),
+    ...(harnessMakaPlacement(benchmarkProfile, env) === 'task-container'
+      ? { MAKA_HARBOR_MODE: 'task-run' }
+      : {}),
     ...harnessMakaContextBudgetEnv(),
   };
 }
@@ -798,9 +828,11 @@ export function buildHarnessAbManifest({
   oracleEvidence,
   credentialIdentity,
   pierVersion = null,
+  env = process.env,
 }) {
   assertResolvedHarnessComposition(composition);
   const { benchmarkProfile, runtimeProfile, competitorProfiles } = composition;
+  const makaPlacement = harnessMakaPlacement(benchmarkProfile, env);
   const resolvedTaskIds = taskIds ?? benchmarkProfile.taskIds;
   const resolvedPairConcurrency =
     pairConcurrency ?? Math.min(DEFAULT_PAIR_CONCURRENCY, resolvedTaskIds.length);
@@ -849,7 +881,13 @@ export function buildHarnessAbManifest({
           attemptPolicy: 'single',
           billingMode: runtimeProfile.billingMode,
           contextBudget: HARNESS_MAKA_CONTEXT_BUDGET,
-          ...(benchmarkProfile.executor === 'pier'
+          // Recorded only where this arm leaves its historical placement. The
+          // fingerprint is an experiment's identity, and host-bridge Maka is
+          // the experiment every existing run already is: describing it more
+          // fully would fork their identity without changing what they ran.
+          // Moving into the task container is a different experiment, and gets
+          // a different fingerprint because it deserves one.
+          ...(makaPlacement === 'task-container'
             ? {
                 execution: {
                   placement: 'task-container',
@@ -1083,7 +1121,9 @@ async function runLocked({
     competitorProfiles,
     pierVersion,
     makaNodeToolchainFingerprint:
-      benchmarkProfile.executor === 'pier' ? MAKA_NODE_TOOLCHAIN_FINGERPRINT : null,
+      harnessMakaPlacement(benchmarkProfile) === 'task-container'
+        ? MAKA_NODE_TOOLCHAIN_FINGERPRINT
+        : null,
   });
   const proposedManifest = buildHarnessAbManifest({
     subjectFingerprint,
@@ -1115,8 +1155,9 @@ async function runLocked({
       resolveHarnessCompetitorToolchain(runRoot, profile),
     ]),
   );
+  const makaPlacement = harnessMakaPlacement(benchmarkProfile);
   const makaNodeToolchain =
-    benchmarkProfile.executor === 'pier' ? resolveHarnessMakaNodeToolchain(runRoot) : null;
+    makaPlacement === 'task-container' ? resolveHarnessMakaNodeToolchain(runRoot) : null;
   await Promise.all([
     ...[...competitorToolchains.values()].map((toolchain) => toolchain.prepare(toolchain.path)),
     makaNodeToolchain?.prepare(makaNodeToolchain.path),
@@ -1182,6 +1223,15 @@ async function runLocked({
             ...runnerOptions,
             agent: 'maka',
             agentEnv: { ...runnerOptions.agentEnv, ...harnessMakaAgentEnv(benchmarkProfile) },
+            // Harbor needs both to place the arm: the placement decides the
+            // provider channel and the loopback address, the toolchain is what
+            // the container has to execute the repo mount with.
+            ...(benchmarkProfile.executor === 'pier'
+              ? {}
+              : {
+                  makaPlacement,
+                  ...(makaNodeToolchain ? { makaNodeToolchainPath: makaNodeToolchain.path } : {}),
+                }),
           }),
         },
         ...competitorProfiles.map((profile) => {

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1806,6 +1806,19 @@ with tempfile.TemporaryDirectory() as tmp:
             self.domains = domains or []
 
     original_network_allowlist = maka_agent_mod._NetworkAllowlist
+
+    # Plain Harbor exports no NetworkAllowlist, and the placement gate must not
+    # care. Requiring one made this the single arm that had to satisfy a
+    # Pier-only condition to stand where its competitors already stood -- and
+    # because the manifest declares task-container either way, a regression
+    # here runs on the host while the report says otherwise.
+    maka_agent_mod._NetworkAllowlist = None
+    plain_harbor_task_run = MakaAgent(Path(tmp), extra_env={"MAKA_HARBOR_MODE": "task-run"})
+    assert plain_harbor_task_run._task_run_in_container() is True
+    assert plain_harbor_task_run.network_allowlist() is None
+    plain_harbor_cell = MakaAgent(Path(tmp), extra_env={})
+    assert plain_harbor_cell._task_run_in_container() is False
+
     maka_agent_mod._NetworkAllowlist = FakeNetworkAllowlist
     os.environ["MAKA_PROVIDER_PROXY_URL"] = "http://host.docker.internal:443"
     os.environ["MAKA_PROVIDER_PROXY_TOKEN"] = "ephemeral-token"

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -2642,6 +2642,30 @@ describe('buildHarborJobConfig', () => {
     );
   });
 
+  test('layers the apt mirror overlay after the harness compose file', () => {
+    // Order is the assertion. Both files set `extra_hosts`, and Compose merges
+    // later files over earlier ones, so the overlay has to come second for the
+    // host-gateway mapping every competitor arm dials to survive alongside it.
+    const config = buildHarborJobConfig(runInput(), {
+      makaRepoPath: '/repo',
+      jobsDir: '/jobs/x',
+      jobName: 'trial',
+      agent: 'maka',
+      model: 'zai-coding-plan/glm-5.2',
+      provider: 'zai-coding-plan',
+      dockerPlatform: 'linux/amd64',
+      aptMirrorComposePath: '/runs/r1/apt-mirror.compose.yaml',
+    } as unknown as Parameters<typeof buildHarborJobConfig>[1]);
+
+    assert.deepEqual(
+      (config.environment as { extra_docker_compose?: string[] }).extra_docker_compose,
+      [
+        '/repo/packages/headless/harbor/docker-compose-linux-amd64.yaml',
+        '/runs/r1/apt-mirror.compose.yaml',
+      ],
+    );
+  });
+
   test('pins the Kimi Code adapter and official toolchain without serializing credentials', () => {
     const config = buildHarborJobConfig(runInput(), {
       makaRepoPath: '/repo',

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -512,6 +512,51 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
+  test('the provider channel follows where the arm runs, not which arm it is', async () => {
+    const channelFor = async (
+      makaPlacement: 'task-container' | undefined,
+    ): Promise<Record<string, string>> => {
+      let harborEnv: Record<string, string> = {};
+      await withRun(async ({ jobsDir, repo, keyFile }) => {
+        const captured: { config?: Record<string, unknown> } = {};
+        const runner = createHarborTaskRunner({
+          makaRepoPath: repo,
+          jobsDir,
+          model: 'deepseek/deepseek-v4-flash',
+          provider: 'deepseek',
+          apiKeyFile: keyFile,
+          agentEnv: { DEEPSEEK_BASE_URL: 'https://api.deepseek.com' },
+          ...(makaPlacement
+            ? { makaPlacement, makaNodeToolchainPath: join(repo, 'toolchain') }
+            : {}),
+          runHarbor: async (request) => {
+            harborEnv = (request.env ?? {}) as Record<string, string>;
+            return fakeRunner({ reward: '0\n', captured })(request);
+          },
+        });
+        await runner(runInput());
+      });
+      return harborEnv;
+    };
+
+    // Host-bridge is the historical channel: the arm runs beside the proxy and
+    // dials it directly.
+    const hostBridge = await channelFor(undefined);
+    assert.equal(typeof hostBridge.MAKA_HOST_BASE_URL, 'string');
+    assert.equal(hostBridge.MAKA_PROVIDER_PROXY_URL, undefined);
+
+    // In the task container the arm is on the far side of the same boundary as
+    // every competitor, so it needs the competitors' channel. Routing this by
+    // arm name instead of by placement is the revert that would leave the run
+    // dialling 127.0.0.1 from inside the container -- itself -- while the
+    // manifest still declared task-container.
+    const inContainer = await channelFor('task-container');
+    assert.equal(typeof inContainer.MAKA_PROVIDER_PROXY_URL, 'string');
+    assert.equal(typeof inContainer.MAKA_PROVIDER_PROXY_TOKEN, 'string');
+    assert.equal(inContainer.MAKA_HOST_BASE_URL, undefined);
+    assert.doesNotMatch(inContainer.MAKA_PROVIDER_PROXY_URL ?? '', /127\.0\.0\.1|localhost/);
+  });
+
   test('generates a JobConfig with verbatim prompt, host-side provider auth, and trial pricing', async () => {
     await withRun(async ({ jobsDir, repo, keyFile }) => {
       const captured: { config?: Record<string, unknown> } = {};
@@ -2639,6 +2684,72 @@ describe('buildHarborJobConfig', () => {
     assert.deepEqual(
       (config.environment as { extra_docker_compose?: string[] }).extra_docker_compose,
       ['/repo/packages/headless/harbor/docker-compose-linux-amd64.yaml'],
+    );
+  });
+
+  test('the in-container Maka arm carries its toolchain and the fingerprint that admits it', async () => {
+    const { MAKA_NODE_TOOLCHAIN_CONTAINER_PATH, MAKA_NODE_TOOLCHAIN_FINGERPRINT } = await import(
+      '../maka-node-toolchain.js'
+    );
+    const base = {
+      makaRepoPath: '/repo',
+      jobsDir: '/jobs/x',
+      jobName: 'trial',
+      agent: 'maka',
+      model: 'deepseek-v4-flash',
+      provider: 'deepseek',
+    } as unknown as Parameters<typeof buildHarborJobConfig>[1];
+
+    const inContainer = buildHarborJobConfig(runInput(), {
+      ...base,
+      makaPlacement: 'task-container',
+      makaNodeToolchainPath: '/runs/r1/toolchains/maka-node',
+    } as unknown as Parameters<typeof buildHarborJobConfig>[1]);
+
+    // The arm cannot start without both halves: the adapter re-verifies the
+    // mounted toolchain against the fingerprint before it will install, so a
+    // mount without the fingerprint leaves the arm dead with the mount in
+    // place -- which is exactly how this failed the first time.
+    const mounts = (inContainer.environment as { mounts: Array<Record<string, unknown>> }).mounts;
+    assert.ok(
+      mounts.some(
+        (m) =>
+          m.target === MAKA_NODE_TOOLCHAIN_CONTAINER_PATH &&
+          m.source === '/runs/r1/toolchains/maka-node' &&
+          m.read_only === true,
+      ),
+    );
+    const agent = (inContainer.agents as Array<Record<string, unknown>>)[0]!;
+    assert.equal(
+      (agent.env as Record<string, string>).MAKA_NODE_TOOLCHAIN_FINGERPRINT,
+      MAKA_NODE_TOOLCHAIN_FINGERPRINT,
+    );
+
+    // Host-bridge is the historical shape and must stay free of both, or every
+    // existing Terminal-Bench manifest changes identity for a run that did not.
+    const hostBridge = buildHarborJobConfig(runInput(), base);
+    const hostMounts = (hostBridge.environment as { mounts: Array<Record<string, unknown>> })
+      .mounts;
+    assert.equal(
+      hostMounts.some((m) => m.target === MAKA_NODE_TOOLCHAIN_CONTAINER_PATH),
+      false,
+    );
+    assert.equal(
+      ((hostBridge.agents as Array<Record<string, unknown>>)[0]!.env as Record<string, string>)
+        .MAKA_NODE_TOOLCHAIN_FINGERPRINT,
+      undefined,
+    );
+
+    // A placement that asks for the container without supplying the toolchain
+    // has to fail at config time; the alternative is a container that starts
+    // and finds nothing at the mount point.
+    assert.throws(
+      () =>
+        buildHarborJobConfig(runInput(), {
+          ...base,
+          makaPlacement: 'task-container',
+        } as unknown as Parameters<typeof buildHarborJobConfig>[1]),
+      /makaNodeToolchainPath is required for task-container Maka placement/,
     );
   });
 

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -2643,9 +2643,13 @@ describe('buildHarborJobConfig', () => {
   });
 
   test('layers the apt mirror overlay after the harness compose file', () => {
-    // Order is the assertion. Both files set `extra_hosts`, and Compose merges
-    // later files over earlier ones, so the overlay has to come second for the
-    // host-gateway mapping every competitor arm dials to survive alongside it.
+    // Order is the assertion. Compose appends `extra_hosts` across `-f` files
+    // rather than replacing them -- `docker compose config` over a base and an
+    // overlay keeps every entry from both, duplicate keys included -- so the
+    // host-gateway mapping every competitor dials survives either way. What the
+    // order pins is a deterministic overlay position; it does not let the
+    // mirror override a task image that declares its own archive.ubuntu.com
+    // entry, which would sit beside ours and be resolved by /etc/hosts order.
     const config = buildHarborJobConfig(runInput(), {
       makaRepoPath: '/repo',
       jobsDir: '/jobs/x',

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -780,6 +780,40 @@ test('harness composition preserves historical manifest fingerprints', async () 
   }
 });
 
+test('task-container placement is declared by every arm, or by none', async () => {
+  // The report throws on a manifest where only some arms declare placement, so
+  // this is not a documentation preference: leaving the competitors silent once
+  // the Maka arm moved is what made four-arm-canary-v1 finish all four cells
+  // and produce no report at all.
+  const { buildHarnessAbManifest, resolveHarnessComposition } = await import(
+    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
+  );
+  const args = {
+    subjectFingerprint: 'subject',
+    taskSourceFingerprint: 'tasks',
+    toolchainFingerprint: 'tools',
+    composition: resolveHarnessComposition({ competitor: 'codex' }),
+  };
+  const placements = (manifest: { arms: { metadata?: { config?: { execution?: unknown } } }[] }) =>
+    manifest.arms.map(
+      (arm) => (arm.metadata?.config?.execution as { placement?: string } | undefined)?.placement,
+    );
+
+  assert.deepEqual(
+    placements(
+      buildHarnessAbManifest({
+        ...args,
+        env: { MAKA_HARNESS_AB_MAKA_PLACEMENT: 'task-container' },
+      }),
+    ),
+    ['task-container', 'task-container'],
+  );
+  assert.deepEqual(placements(buildHarnessAbManifest({ ...args, env: {} })), [
+    undefined,
+    undefined,
+  ]);
+});
+
 test('redirecting apt is recorded, and leaves runs that do not redirect untouched', async () => {
   const {
     aptMirrorComposeContent,

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -854,6 +854,30 @@ test('redirecting apt is recorded, and leaves runs that do not redirect untouche
   assert.throws(() => aptMirrorComposeContent(''), /apt mirror address is required/);
 });
 
+test('only the executor that applies the mirror is allowed to name one', async () => {
+  const { harnessAptMirror, resolveHarnessComposition } = await import(
+    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
+  );
+  const harbor = resolveHarnessComposition({ competitor: 'reasonix' }).benchmarkProfile;
+  const pier = resolveHarnessComposition({
+    benchmark: 'deep-swe-1.1',
+    competitor: 'kimi-code',
+  }).benchmarkProfile;
+  const env = { MAKA_HARNESS_AB_APT_MIRROR: 'mirrors.example.com' };
+
+  assert.equal(harnessAptMirror(harbor, env), 'mirrors.example.com');
+  // Only the harbor runner receives the compose overlay, so a pier run that
+  // accepted the name would publish a redirect its cells never performed and
+  // fork its resume identity on that false record. A shared shell env carrying
+  // the variable across both benchmarks is the way this actually happens, which
+  // is why it has to fail at launch rather than be dropped quietly.
+  assert.throws(
+    () => harnessAptMirror(pier, env),
+    /the pier executor does not redirect package hosts/,
+  );
+  assert.equal(harnessAptMirror(pier, {}), null);
+});
+
 test('Reasonix comparison freezes the DeepSeek runtime, toolchain, and run identity', async () => {
   const {
     buildHarnessAbManifest,

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -780,6 +780,46 @@ test('harness composition preserves historical manifest fingerprints', async () 
   }
 });
 
+test('redirecting apt is recorded, and leaves runs that do not redirect untouched', async () => {
+  const {
+    aptMirrorComposeContent,
+    buildHarnessAbManifest,
+    resolveHarnessComposition,
+    UBUNTU_APT_HOSTS,
+  } = await import(new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href);
+  const composition = resolveHarnessComposition({ competitor: 'reasonix' });
+  const args = {
+    subjectFingerprint: 'subject',
+    taskSourceFingerprint: 'tasks',
+    toolchainFingerprint: 'tools',
+    composition,
+    env: { MAKA_HARNESS_AB_APT_MIRROR: 'mirrors.example.com' },
+  };
+
+  const plain = buildHarnessAbManifest({ ...args, env: {} });
+  const redirected = buildHarnessAbManifest({ ...args, aptMirrorAddress: '10.0.0.7' });
+
+  assert.equal(plain.metadata.benchmark.packageMirror, undefined);
+  assert.deepEqual(redirected.metadata.benchmark.packageMirror, {
+    hosts: UBUNTU_APT_HOSTS,
+    name: 'mirrors.example.com',
+    address: '10.0.0.7',
+  });
+  // Where packages came from is part of what a run was, so the two must not be
+  // resumable as each other. Recording it without forking the fingerprint would
+  // let a redirected run continue a manifest that fetched from Ubuntu's hosts.
+  assert.notEqual(plain.fingerprint, redirected.fingerprint);
+
+  // Both hosts the base image's sources list names have to move together: apt
+  // reads noble-security from security.ubuntu.com, and leaving it behind puts
+  // every security-pocket fetch back on the link the redirect exists to avoid.
+  const overlay = aptMirrorComposeContent('10.0.0.7');
+  for (const host of UBUNTU_APT_HOSTS)
+    assert.match(overlay, new RegExp(`'${host}:10\\.0\\.0\\.7'`));
+  assert.match(overlay, /^services:\n {2}main:\n {4}extra_hosts:\n/);
+  assert.throws(() => aptMirrorComposeContent(''), /apt mirror address is required/);
+});
+
 test('Reasonix comparison freezes the DeepSeek runtime, toolchain, and run identity', async () => {
   const {
     buildHarnessAbManifest,

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -593,6 +593,79 @@ test('provider auth proxy totals OpenAI chat streaming usage without changing th
   }
 });
 
+test('provider auth proxy keeps usage from a stream the client hangs up on', async () => {
+  // A client that stops reading once it has its answer still spent every token
+  // the provider streamed, and the usage frame usually arrived before it let
+  // go. Dropping it does not leave a gap the report can see: the cell keeps the
+  // usage of whichever requests happened to reach `[DONE]` and reads as fully
+  // metered. One arm was credited 1,088 output tokens against a true 27,633
+  // that way, because its short requests completed and its long ones did not.
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-hangup-usage-'));
+  const usageFrame =
+    'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":25,"prompt_tokens_details":{"cached_tokens":20},"completion_tokens_details":{"reasoning_tokens":15}}}\n\n';
+  let releaseUpstream!: () => void;
+  const upstreamHeld = new Promise<void>((resolve) => {
+    releaseUpstream = resolve;
+  });
+  const upstream = createServer(async (_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    // The usage frame lands, then the stream stays open without `[DONE]` --
+    // the shape a client hangs up on.
+    response.write(usageFrame);
+    await upstreamHeld;
+    response.end();
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address !== 'string');
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+    usageProtocol: 'openai-chat-sse',
+  });
+  const controller = new AbortController();
+
+  try {
+    const response = await fetch(`${proxy.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${proxy.token}` },
+      body: '{}',
+      signal: controller.signal,
+    });
+    const reader = response.body?.getReader();
+    assert.ok(reader);
+    await reader.read();
+    controller.abort();
+    await assert.rejects(reader.read());
+    // The abort has to land in the proxy before its telemetry is final.
+    for (let attempt = 0; attempt < 100 && proxy.telemetry().length === 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+
+    assert.deepEqual(proxy.usage(), {
+      input: 100,
+      cacheRead: 20,
+      cacheWrite: 0,
+      output: 25,
+      reasoning: 15,
+    });
+    const [request] = proxy.telemetry();
+    assert.equal(request?.outcome, 'aborted');
+    // Recorded as unterminated, so a caller that wants only whole streams can
+    // still tell this one apart from a request that ran to `[DONE]`.
+    assert.equal(request?.terminalEvent, false);
+  } finally {
+    releaseUpstream();
+    await proxy.close();
+    upstream.closeAllConnections();
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('provider auth proxy totals Responses streaming usage at response.completed', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-responses-usage-'));
   const stream = [

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -1211,6 +1211,14 @@ export function buildHarborJobConfig(
     }
   }
 
+  if (makaInContainer) {
+    // The adapter re-verifies the mounted toolchain against this before it will
+    // install, and it reads it from the agent env — the same place every other
+    // pinned-toolchain fingerprint is read from. Putting it on the provider
+    // channel instead left the mount in place and the arm unable to start.
+    agentEnv.MAKA_NODE_TOOLCHAIN_FINGERPRINT = MAKA_NODE_TOOLCHAIN_FINGERPRINT;
+  }
+
   Object.assign(agentEnv, attemptAgentEnv ?? {});
   // Lenient by shared contract with the Python adapter: a malformed value must
   // fall back (metadata, then the adapter's default) rather than fail the run.
@@ -1416,7 +1424,6 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
           : {
               MAKA_PROVIDER_PROXY_URL: providerProxyClientBaseUrl(proxy.baseUrl, agent, provider),
               MAKA_PROVIDER_PROXY_TOKEN: proxy.token,
-              ...(agent === 'maka' ? { MAKA_NODE_TOOLCHAIN_FINGERPRINT } : {}),
             },
       usage: proxy.usage,
       telemetry: proxy.telemetry,

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -406,7 +406,7 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
       runnerOptions.resolveProviderCredential !== undefined ||
       githubCopilotAccountTokenFromEnv(runnerOptions.provider, runnerOptions.agentEnv) !==
         undefined ||
-      (!usesHostProviderProxy(runnerOptions.agent) &&
+      (!usesHostProviderProxy(runnerOptions.agent, runnerOptions.makaPlacement) &&
         !providerRequiresSecret(runnerOptions.provider));
     const configPath = join(jobsDir, 'job-config.json');
     const { agentEnv: _attemptAgentEnv, ...inputWithoutAttemptEnv } = input;
@@ -1347,7 +1347,7 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
 } | null> {
   const agent = options.agent ?? 'maka';
   const provider = options.provider ?? 'deepseek';
-  if (usesHostProviderProxy(agent) && provider === 'github-copilot') {
+  if (usesHostProviderProxy(agent, options.makaPlacement) && provider === 'github-copilot') {
     const adapter =
       agent === 'kimi-code'
         ? 'Kimi Code'
@@ -1388,7 +1388,7 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
       )
     : undefined;
   const baseUrl = copilotCredential?.baseUrl ?? configuredBaseUrl;
-  if (options.resolveProviderCredential || usesHostProviderProxy(agent)) {
+  if (options.resolveProviderCredential || usesHostProviderProxy(agent, options.makaPlacement)) {
     const apiKeyFile = options.apiKeyFile;
     const resolveProviderCredential = options.resolveProviderCredential;
     if (!apiKeyFile && !resolveProviderCredential) return null;
@@ -1445,8 +1445,19 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
   };
 }
 
-function usesHostProviderProxy(agent: HarborTaskRunnerOptions['agent']): boolean {
-  return agent !== undefined && agent !== 'maka';
+/**
+ * Whether this arm reaches the provider through the host proxy rather than
+ * holding host credentials itself. That follows the container boundary, not the
+ * arm's name: Maka was exempt because it ran on the host, and an in-container
+ * Maka is on the same side as every competitor, with no host credential to use.
+ */
+function usesHostProviderProxy(
+  agent: HarborTaskRunnerOptions['agent'],
+  makaPlacement?: HarborTaskRunnerOptions['makaPlacement'],
+): boolean {
+  if (agent === undefined) return false;
+  if (agent === 'maka') return makaPlacement === 'task-container';
+  return true;
 }
 
 /** Shared cost math across runners: build the cell token summary from proxy-observed usage and per-1M pricing. */

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -287,6 +287,12 @@ export interface HarborTaskRunnerOptions {
   makaNodeToolchainPath?: string;
   /** Explicit Docker target platform shared by comparison arms. */
   dockerPlatform?: 'linux/amd64';
+  /**
+   * Compose overlay that points the task container's Ubuntu apt hosts at a
+   * mirror. Layered after the harness compose file so it adds `extra_hosts`
+   * entries beside the host-gateway mapping rather than replacing them.
+   */
+  aptMirrorComposePath?: string;
   /** Base directory under which each task gets an isolated per-task job dir. */
   jobsDir: string;
   /** MAKA_MODEL, e.g. "deepseek/deepseek-v4-flash". */
@@ -1267,6 +1273,7 @@ export function buildHarborJobConfig(
                 options.makaRepoPath,
                 'packages/headless/harbor/docker-compose-linux-amd64.yaml',
               ),
+              ...(options.aptMirrorComposePath ? [options.aptMirrorComposePath] : []),
             ],
           }
         : {}),

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -1355,6 +1355,14 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
   const agent = options.agent ?? 'maka';
   const provider = options.provider ?? 'deepseek';
   if (usesHostProviderProxy(agent, options.makaPlacement) && provider === 'github-copilot') {
+    // Maka reaches this guard only in task-container placement, where it too
+    // goes through the proxy. Its remedy is the placement it came from, not the
+    // competitors' dead end, so it must not be told an adapter is missing.
+    if (agent === 'maka') {
+      throw new Error(
+        'GitHub Copilot Harbor runs require the host-bridge Maka placement; the host provider proxy does not carry this provider',
+      );
+    }
     const adapter =
       agent === 'kimi-code'
         ? 'Kimi Code'

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -27,6 +27,10 @@ import {
   type TaskRunner,
 } from './fixed-prompt-controller.js';
 import { buildAgentRepoMounts } from './agent-repo-mount.js';
+import {
+  MAKA_NODE_TOOLCHAIN_CONTAINER_PATH,
+  MAKA_NODE_TOOLCHAIN_FINGERPRINT,
+} from './maka-node-toolchain.js';
 import type {
   HarborTrialGrade,
   HarborVerifierAttempt,
@@ -269,6 +273,18 @@ export interface HarborTaskRunnerOptions {
   claudeCodeToolchainPath?: string;
   /** Prepared Reasonix toolchain mounted read-only into task containers. */
   reasonixToolchainPath?: string;
+  /**
+   * Where the Maka arm runs. `host-bridge` keeps the controller on the host and
+   * bridges tool calls in; `task-container` puts it where every competitor arm
+   * already is, which is what makes the arms answer for the same environment.
+   */
+  makaPlacement?: 'host-bridge' | 'task-container';
+  /**
+   * Prepared Maka Node toolchain, mounted read-only into task containers.
+   * Required by `task-container` placement: the repo mount carries Maka's code
+   * but nothing in the task image is pinned to execute it.
+   */
+  makaNodeToolchainPath?: string;
   /** Explicit Docker target platform shared by comparison arms. */
   dockerPlatform?: 'linux/amd64';
   /** Base directory under which each task gets an isolated per-task job dir. */
@@ -1125,6 +1141,10 @@ export function buildHarborJobConfig(
   const adapter = options.agent ?? 'maka';
   const agentModel = adapter === 'opencode' ? modelForOpenCode(options.model, provider) : makaModel;
   const toolchain = adapter === 'maka' ? undefined : COMPETITOR_TOOLCHAINS[adapter];
+  const makaInContainer = adapter === 'maka' && options.makaPlacement === 'task-container';
+  if (makaInContainer && !options.makaNodeToolchainPath) {
+    throw new Error('makaNodeToolchainPath is required for task-container Maka placement');
+  }
   if (toolchain) {
     const toolchainPath = options[toolchain.optionKey];
     if (!toolchainPath) {
@@ -1144,6 +1164,16 @@ export function buildHarborJobConfig(
             type: 'bind',
             source: options[toolchain.optionKey]!,
             target: toolchain.containerPath,
+            read_only: true,
+          },
+        ]
+      : []),
+    ...(makaInContainer
+      ? [
+          {
+            type: 'bind',
+            source: options.makaNodeToolchainPath!,
+            target: MAKA_NODE_TOOLCHAIN_CONTAINER_PATH,
             read_only: true,
           },
         ]
@@ -1358,7 +1388,12 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
     const apiProtocol = providerProxyApiProtocol(agent, options.agentEnv);
     const proxy = await startProviderAuthProxy({
       upstreamBaseUrl: providerProxyUpstreamBaseUrl(baseUrl, provider, apiProtocol),
-      ...(agent === 'maka' ? { advertisedHost: '127.0.0.1' } : {}),
+      // Loopback is the right address only for a controller on this host. From
+      // inside the task container it names the container, so the arm would dial
+      // itself; competitors set nothing here for exactly that reason.
+      ...(agent === 'maka' && options.makaPlacement !== 'task-container'
+        ? { advertisedHost: '127.0.0.1' }
+        : {}),
       ...(resolveProviderCredential
         ? { resolveUpstreamCredential: resolveProviderCredential }
         : { apiKeyFile: apiKeyFile! }),
@@ -1368,7 +1403,12 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
     });
     return {
       env:
-        agent === 'maka'
+        // Which channel an arm gets follows where it runs, not which arm it is.
+        // A host-side Maka reaches the proxy directly; in the task container it
+        // is on the far side of the same boundary as every competitor, so it
+        // needs the same client channel they do — `MAKA_HOST_*` names a host
+        // that is not there.
+        agent === 'maka' && options.makaPlacement !== 'task-container'
           ? {
               MAKA_HOST_BASE_URL: proxy.baseUrl,
               MAKA_HOST_API_KEY: proxy.token,
@@ -1376,6 +1416,7 @@ async function hostSideProviderRuntime(options: HarborTaskRunnerOptions): Promis
           : {
               MAKA_PROVIDER_PROXY_URL: providerProxyClientBaseUrl(proxy.baseUrl, agent, provider),
               MAKA_PROVIDER_PROXY_TOKEN: proxy.token,
+              ...(agent === 'maka' ? { MAKA_NODE_TOOLCHAIN_FINGERPRINT } : {}),
             },
       usage: proxy.usage,
       telemetry: proxy.telemetry,

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -412,6 +412,10 @@ async function forwardProviderRequest(input: {
   signal: AbortSignal;
 }): Promise<void> {
   let requestTelemetry: MutableProviderRequestTelemetry | null = null;
+  // Hoisted so the abort path can drain what the parser already read. Scoped to
+  // the streaming block it is reachable only when the stream ran to its end,
+  // which is exactly the case that never needed draining.
+  let responseUsage: SseUsageParser | null = null;
   try {
     const presentedCredential =
       input.clientAuthMode === 'x-api-key'
@@ -479,7 +483,7 @@ async function forwardProviderRequest(input: {
     });
     input.response.writeHead(upstreamResponse.status, responseHeaders);
     input.response.flushHeaders();
-    const responseUsage =
+    responseUsage =
       input.usageProtocol &&
       upstreamResponse.headers.get('content-type')?.includes('text/event-stream')
         ? new SseUsageParser(input.usageProtocol)
@@ -532,6 +536,18 @@ async function forwardProviderRequest(input: {
     input.response.end();
   } catch (error) {
     if (requestTelemetry) {
+      // A client that hangs up once it has what it needs still spent every
+      // token the provider already streamed, and the usage frame is normally
+      // among the chunks that arrived before it hung up -- this path used to
+      // drop whatever the parser had read. The cost of dropping it is not a
+      // gap, it is a wrong number: a cell keeps the usage of the requests that
+      // happened to run to `[DONE]` and reads as fully metered. One arm was
+      // credited 1,088 output tokens against a true 27,633 that way, because
+      // its short requests completed and its long ones were hung up on.
+      const parsed = responseUsage?.finish() ?? null;
+      if (parsed?.usage) input.usage.add(parsed.usage);
+      requestTelemetry.usage = parsed?.usage ?? undefined;
+      requestTelemetry.terminalEvent = parsed?.terminalEvent ?? false;
       requestTelemetry.outcome = input.signal.aborted ? 'aborted' : 'failed';
       requestTelemetry.durationMs = elapsedMs(requestTelemetry.startedAt, input.now());
       requestTelemetry.errorClass = error instanceof Error ? error.name : 'UnknownError';


### PR DESCRIPTION
## Summary

Every competitor adapter runs its CLI inside the task container. The Maka arm ran from the host and bridged tool calls in, so it was the one arm a defect in the container path could not reach — and this benchmark found three of those (#2090, #2146, #2151), each of which cost in-container arms cells that the host-side arm never risked. A comparison whose arms do not share an environment cannot attribute a difference to the agents, which is the only thing the comparison exists to measure.

The adapter already had the mode. What gated it was `_task_run_in_container` also requiring a `NetworkAllowlist`, which exists only under Pier. That clause reads as a safety check and is not one: every competitor runs in the task container under plain Harbor and returns `None` from `network_allowlist` there. It was a condition this arm alone had to satisfy in order to stand where the others already stood, and the arms it was compared against were exactly the ones it excluded it from joining.

Harbor's runner then had no way to place it. The Node toolchain mount, its fingerprint, and the container-side provider channel lived only in the Pier runner; the repo mount carries Maka's code but nothing in the task image is pinned to execute it. Harbor's runner has them now. Two settings also had to start following placement instead of arm identity: `MAKA_HOST_*` names a host the container cannot see, and `advertisedHost: 127.0.0.1` inside the container names the container, so the arm would dial itself.

Opt-in via `MAKA_HARNESS_AB_MAKA_PLACEMENT=task-container`, not a flipped default. This changes the shape of the experiment rather than a parameter of it, so both topologies stay runnable and can be run against each other — which is the only way to show whether a difference came from the agent or from where it ran.

Refs #1970.

## Verification

- `npm --workspace @maka/headless run test:dist` — 0 failures.
- `npm run typecheck` — clean; `npm run format:check` — clean.
- Placement resolution: `harbor` defaults to `host-bridge`, honours `task-container`, `pier` is always `task-container`, and both an unknown value and `host-bridge` under Pier are rejected.
- Manifest identity: host-bridge and task-container produce different fingerprints, and the historical Terminal-Bench and DeepSWE fingerprints are unchanged (`harness composition preserves historical manifest fingerprints` passes).

**Not verified: no container has been run in this placement.** Everything above is wiring and identity; whether an in-container Maka arm actually starts, mounts its toolchain, reaches the provider proxy and produces a graded cell is untested. That is what the task list below covers, and it is why this is a draft.

## Review focus

Recording placement in the manifest was deliberately narrowed. An earlier revision recorded it for every arm on every executor, which is more accurate but changed the fingerprints of every historical run: describing a fact that was always true would have forked the identity of runs whose configuration never changed. It is now recorded only where this arm leaves its historical placement. The cost is that a Harbor-executor manifest still does not state that the competitor arms run in the task container; that fact is currently recoverable only from the adapter type.

## Second commit: the apt mirror

`639f9002` is a separate concern from placement and is revertable on its own. It is here because both are harness-environment changes that have to be deployed together to run the canary, and because the canary itself is what exposed the problem.

Terminal-Bench task images are bare `ubuntu:24.04` plus curl, so most tasks apt-install what they need. That makes the benchmark depend on `archive.ubuntu.com` being reachable from the run host. On the current run host it is not: measured directly, it returned 0 bytes on two of three attempts and 9.8 KB/s on the third, while `github.com` (2.1 MB/s) and the model provider (150ms) were both fine.

The cost is not slowness, it is noise. The Maka arm ran `configure-git-webserver` twice in `task-container` placement, issued an identical 24 tool calls both times, and finished in 479s on one run and hit the 900s deadline on the other. The whole difference was how long apt stalled — 775s of the failing run sat in three Bash calls. Noise of that shape does not cancel across arms; it charges whichever agent happened to need more packages.

`MAKA_HARNESS_AB_APT_MIRROR` redirects the two apt hosts through a compose overlay layered *after* the harness compose file, so Compose merges the redirect beside the `host.docker.internal:host-gateway` mapping every competitor arm dials rather than replacing it (verified with `docker compose config`). No task image and no sources list changes — the container still resolves and requests `archive.ubuntu.com`.

It is opt-in and recorded in the manifest, in a way that forks the fingerprint so a redirected run cannot resume one that fetched from Ubuntu's own hosts. Runs that do not redirect keep their existing fingerprints.

**Any published number from a redirected run has to disclose this.** It changes the environment every task runs in.

## Third commit: the proxy's usage on abort

`9dae4bee` is the second thing the canary found, and the more serious one. The proxy is the only token and cost source for every arm that is not Maka, and its abort path never asked the usage parser for what it had already read. Providers put the usage frame at the end of a stream but not after it, so the frame had usually arrived; it was simply discarded.

That does not produce a gap the report can see. The cell keeps the usage of whichever requests happened to reach `[DONE]` and reads as fully metered. On `four-arm-canary-v5` one arm was credited **1,088 output tokens against a true 27,633** — its short requests completed, its long ones were hung up on — while the other three matched their own logs to the token, so nothing looked wrong.

Measured on `four-arm-canary-v6` after the fix, from the proxy's own per-request telemetry:

| arm | requests | aborted | aborted **with** usage kept | aborted, usage lost |
|---|---|---|---|---|
| reasonix | 43 | 20 | 20 | 0 |
| codex | 31 | 1 | 1 | 0 |
| claude-code | 14 | 0 | — | 0 |

All four arms' proxy-metered output now equals their own logs exactly (maka 10,040 / codex 24,708 / claude-code 9,994 / reasonix 16,334). Codex had one aborted request this round and zero the round before, which is why it happened to agree in v5 — agreement there was luck, not immunity.

Locked by `provider auth proxy keeps usage from a stream the client hangs up on`, verified by mutation: reverting the drain turns that test red.

## Remaining work

- [ ] Run one cell with the `fake` backend in `task-container` placement — proves the toolchain mount, provider channel and process scope without spending provider budget.
- [x] Run the predeclared canary in this placement for all arms — four arms, all in the task container, all scored, teardown clean, zero stalls. `codex`, `claude-code` and `reasonix` passed; the Maka cell hit the deadline on an apt stall, which is what the second commit addresses.
- [x] Re-run the canary with the mirror redirect — the Maka cell went from a 900s deadline abort to 111s and a pass, on an identical 23–24 tool calls.
- [x] Confirm every arm's economy column is trustworthy — `four-arm-canary-v6`, all four arms metered exactly, `infraFailed: 0`, zero stalls.
- [ ] Decide whether the full run adopts this topology, and record the decision on #1970.


