### PR TITLE
feat(desktop): provide Runtime Host native capabilities

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
@@ -1,0 +1,287 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ComputerUseToolSet, MakaTool, MakaToolContext } from '@maka/runtime';
+import type { ClientCapabilityProvider } from '@maka/runtime-host/client';
+import type { ClientCapabilityCallFrame } from '@maka/runtime-host/protocol';
+import { z } from 'zod';
+import { createDesktopNativeCapabilityProvider } from '../runtime-host-native-capabilities.js';
+
+test('publishes self-described session-affine Browser and Computer Use offers', () => {
+  const provider = createDesktopNativeCapabilityProvider({
+    browserTools: [tool('browser_snapshot', z.object({ includeHidden: z.boolean().optional() }), async () => 'ok')],
+    computerUseTools: computerTools(async () => ({ text: 'ok' })),
+  });
+
+  assert.deepEqual(
+    provider.offers().map((offer) => ({
+      offerId: offer.offerId,
+      version: offer.version,
+      affinity: offer.affinity,
+      toolNames: offer.tools.map((descriptor) => descriptor.name),
+      serverIds: offer.tools.map((descriptor) => descriptor.serverId),
+    })),
+    [
+      {
+        offerId: 'desktop_browser',
+        version: '0',
+        affinity: 'session',
+        toolNames: ['browser_snapshot'],
+        serverIds: ['desktop_browser'],
+      },
+      {
+        offerId: 'desktop_computer_use',
+        version: '0',
+        affinity: 'session',
+        toolNames: ['maka_computer'],
+        serverIds: ['desktop_computer_use'],
+      },
+    ],
+  );
+  const browserSchema = provider.offers()[0]?.tools[0]?.inputSchema;
+  assert.equal(browserSchema?.type, 'object');
+  assert.equal(browserSchema?.required, undefined);
+  assert.deepEqual(Object.keys((browserSchema?.properties as object | undefined) ?? {}), ['includeHidden']);
+});
+
+test('validates before admission and invokes the exact offered tool with Host context', async () => {
+  let admitted = false;
+  let invoked = false;
+  let received:
+    | {
+        args: unknown;
+        context: Pick<MakaToolContext, 'sessionId' | 'turnId' | 'cwd' | 'toolCallId'>;
+      }
+    | undefined;
+  const provider = createDesktopNativeCapabilityProvider({
+    browserTools: [
+      tool('browser_navigate', z.object({ url: z.string().url() }), async (args, context) => {
+        assert.equal(admitted, true);
+        invoked = true;
+        received = {
+          args,
+          context: {
+            sessionId: context.sessionId,
+            turnId: context.turnId,
+            cwd: context.cwd,
+            toolCallId: context.toolCallId,
+          },
+        };
+        return 'Loaded';
+      }),
+    ],
+    computerUseTools: computerTools(),
+  });
+
+  await assert.rejects(
+    () => call(provider, capabilityFrame({ arguments: { url: 'not a url' } }), () => undefined),
+    /Invalid URL/u,
+  );
+  assert.equal(invoked, false);
+  assert.equal(admitted, false);
+
+  const result = await call(provider, capabilityFrame({ arguments: { url: 'https://example.com' } }), () => {
+    admitted = true;
+  });
+  assert.deepEqual(result, { content: [{ type: 'text', text: 'Loaded' }] });
+  assert.deepEqual(received, {
+    args: { url: 'https://example.com' },
+    context: {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      cwd: '/workspace',
+      toolCallId: 'tool-call-1',
+    },
+  });
+});
+
+test('projects Computer Use screenshots and releases only sessions used by that group', async () => {
+  const cleared: string[] = [];
+  let invocationStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    invocationStarted = resolve;
+  });
+  const computerUseTools = computerTools(
+    async (args: { wait?: boolean }, context) => {
+      if (args.wait) {
+        invocationStarted();
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener('abort', () => reject(context.abortSignal.reason), {
+            once: true,
+          });
+        });
+      }
+      return {
+        text: 'captured',
+        screenshot: { base64: 'aW1hZ2U=', mimeType: 'image/png' },
+      };
+    },
+    (sessionId) => cleared.push(sessionId),
+  );
+  const provider = createDesktopNativeCapabilityProvider({
+    browserTools: [tool('browser_snapshot', z.object({}), async () => 'snapshot')],
+    computerUseTools,
+  });
+
+  const completed = await call(provider, computerFrame({ sessionId: 'completed-session', arguments: {} }));
+  assert.deepEqual(completed, {
+    content: [
+      { type: 'text', text: 'captured' },
+      { type: 'image', data: 'aW1hZ2U=', mimeType: 'image/png' },
+    ],
+  });
+
+  const inFlight = call(provider, computerFrame({ sessionId: 'active-session', arguments: { wait: true } }));
+  await started;
+  await provider.close?.();
+  await assert.rejects(inFlight, /provider closed/u);
+  assert.deepEqual(cleared.sort(), ['active-session', 'completed-session']);
+  await provider.close?.();
+  assert.deepEqual(cleared.sort(), ['active-session', 'completed-session']);
+  await assert.rejects(() => call(provider, capabilityFrame()), /provider is closed/u);
+});
+
+test('does not advertise unavailable capability groups or dispatch unknown identities', async () => {
+  const provider = createDesktopNativeCapabilityProvider({
+    browserTools: [tool('browser_snapshot', z.object({}), async () => 'ok')],
+    computerUseTools: computerTools(),
+  });
+  assert.deepEqual(
+    provider.offers().map((offer) => offer.offerId),
+    ['desktop_browser'],
+  );
+
+  let admitted = false;
+  await assert.rejects(
+    () =>
+      call(provider, capabilityFrame({ serverId: 'another_client' }), () => {
+        admitted = true;
+      }),
+    /not offered/u,
+  );
+  assert.equal(admitted, false);
+});
+
+test('forwards Host cancellation to an admitted Desktop invocation', async () => {
+  let invocationStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    invocationStarted = resolve;
+  });
+  const provider = createDesktopNativeCapabilityProvider({
+    browserTools: [
+      tool('browser_navigate', z.object({ url: z.string() }), async (_args, context) => {
+        invocationStarted();
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener(
+            'abort',
+            () => reject(context.abortSignal.reason),
+            { once: true },
+          );
+        });
+      }),
+    ],
+    computerUseTools: computerTools(),
+  });
+  const controller = new AbortController();
+  if (!provider.call) throw new Error('Expected a callable provider');
+  const inFlight = provider.call(capabilityFrame(), {
+    signal: controller.signal,
+    accept: async () => undefined,
+  });
+
+  await started;
+  controller.abort(new Error('Host cancelled invocation'));
+  await assert.rejects(inFlight, /Host cancelled invocation/u);
+});
+
+function tool<P, R>(
+  name: string,
+  parameters: z.ZodType<P>,
+  impl: (args: P, context: MakaToolContext) => Promise<R>,
+): MakaTool<P, R> {
+  return {
+    name,
+    displayName: name,
+    description: `${name} description`,
+    parameters,
+    impl,
+  };
+}
+
+function computerTools(
+  impl?: (args: { wait?: boolean }, context: MakaToolContext) => Promise<unknown>,
+  clearSession: (sessionId: string) => void = () => undefined,
+): ComputerUseToolSet {
+  const tools = (impl
+    ? [
+        {
+          ...tool('maka_computer', z.object({ wait: z.boolean().optional() }), impl),
+          toModelOutput: ({ output }: { output: unknown }) => {
+            const result = output as {
+              text: string;
+              screenshot?: { base64: string; mimeType: string };
+            };
+            return {
+              type: 'content' as const,
+              value: [
+                { type: 'text' as const, text: result.text },
+                ...(result.screenshot
+                  ? [
+                      {
+                        type: 'file' as const,
+                        data: {
+                          type: 'data' as const,
+                          data: result.screenshot.base64,
+                        },
+                        mediaType: result.screenshot.mimeType,
+                      },
+                    ]
+                  : []),
+              ],
+            };
+          },
+        },
+      ]
+    : []) as unknown as ComputerUseToolSet;
+  tools.clearSession = clearSession;
+  tools.sessionEvents = {} as ComputerUseToolSet['sessionEvents'];
+  return tools;
+}
+
+function capabilityFrame(overrides: Partial<ClientCapabilityCallFrame> = {}): ClientCapabilityCallFrame {
+  return {
+    kind: 'client.capability.call',
+    invocationId: 'invocation-1',
+    registrationId: 'registration-1',
+    offerId: 'desktop_browser',
+    serverId: 'desktop_browser',
+    toolName: 'browser_navigate',
+    arguments: { url: 'https://example.com' },
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    toolCallId: 'tool-call-1',
+    cwd: '/workspace',
+    ...overrides,
+  };
+}
+
+function computerFrame(overrides: Partial<ClientCapabilityCallFrame> = {}): ClientCapabilityCallFrame {
+  return capabilityFrame({
+    offerId: 'desktop_computer_use',
+    serverId: 'desktop_computer_use',
+    toolName: 'maka_computer',
+    arguments: {},
+    ...overrides,
+  });
+}
+
+async function call(
+  provider: ClientCapabilityProvider,
+  frame: ClientCapabilityCallFrame,
+  accept: () => void = () => undefined,
+) {
+  if (!provider.call) throw new Error('Expected a callable provider');
+  return provider.call(frame, {
+    signal: new AbortController().signal,
+    accept: async () => accept(),
+  });
+}

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -9,6 +9,7 @@ import {
 } from '@maka/core/usage-stats/pricing';
 import type { PricingConfig } from '@maka/core/usage-stats/types';
 import {
+  type ClientCapabilityProvider,
   type DirectRequestOperationKey,
   type RuntimeHostConnection,
   type RuntimeHostSessionSubscription,
@@ -18,6 +19,8 @@ import {
   ARTIFACT_INGEST_CHUNK_MAX_BYTES,
   decodePricingMutateInput,
   type EffectivePricingEntry,
+  type ClientCapabilityReplaceResult,
+  type ClientCapabilityUnregisterResult,
   type InteractionAnswerInput,
   type GoalControlAction,
   type GoalProjection,
@@ -639,6 +642,19 @@ export class DesktopRuntimeHostClient {
     input: OperationInput<'runtime.resource.stop'>,
   ): Promise<OperationOutput<'runtime.resource.stop'>> {
     return this.#request('runtime.resource.stop', input);
+  }
+
+  replaceClientCapabilities(
+    provider: ClientCapabilityProvider,
+    timeoutMs?: number,
+  ): Promise<ClientCapabilityReplaceResult> {
+    this.#assertOpen();
+    return this.connection.replaceClientCapabilities(provider, timeoutMs);
+  }
+
+  unregisterClientCapabilities(timeoutMs?: number): Promise<ClientCapabilityUnregisterResult> {
+    this.#assertOpen();
+    return this.connection.unregisterClientCapabilities(timeoutMs);
   }
 
   async openSession(sessionId: string): Promise<DesktopRuntimeHostSession> {

--- a/apps/desktop/src/main/runtime-host-native-capabilities.ts
+++ b/apps/desktop/src/main/runtime-host-native-capabilities.ts
@@ -1,0 +1,255 @@
+import { Buffer } from 'node:buffer';
+import type { ComputerUseToolSet, MakaTool } from '@maka/runtime';
+import type { ClientCapabilityProvider } from '@maka/runtime-host/client';
+import type {
+  ClientCapabilityCallFrame,
+  ClientCapabilityCallResult,
+  ClientCapabilityContentBlock,
+  ClientCapabilityOffer,
+} from '@maka/runtime-host/protocol';
+import { toJSONSchema, z } from 'zod';
+
+const CAPABILITY_VERSION = '0';
+const BROWSER_OFFER_ID = 'desktop_browser';
+const COMPUTER_USE_OFFER_ID = 'desktop_computer_use';
+
+interface NativeCapabilityGroup {
+  readonly offerId: string;
+  readonly label: string;
+  readonly description: string;
+  readonly tools: readonly MakaTool[];
+  readonly clearSession?: (sessionId: string) => void;
+}
+
+interface NativeToolBinding {
+  readonly group: NativeCapabilityGroup;
+  readonly tool: MakaTool;
+}
+
+type DesktopToolModelOutput = Awaited<ReturnType<NonNullable<MakaTool['toModelOutput']>>>;
+type DesktopToolContentPart = Extract<DesktopToolModelOutput, { type: 'content' }>['value'][number];
+
+export interface DesktopNativeCapabilityProviderInput {
+  readonly browserTools: readonly MakaTool[];
+  readonly computerUseTools: ComputerUseToolSet;
+}
+
+/** Adapt Desktop-owned Maka tools to the open Client Capability protocol. */
+export function createDesktopNativeCapabilityProvider(
+  input: DesktopNativeCapabilityProviderInput,
+): ClientCapabilityProvider {
+  const groups = capabilityGroups(input);
+  const offers = Object.freeze(groups.map(capabilityOffer));
+  const bindings = indexBindings(groups);
+  const activeInvocations = new Set<AbortController>();
+  const usedSessions = new Map<NativeCapabilityGroup, Set<string>>();
+  let closed = false;
+
+  return {
+    offers: () => offers,
+    call: async (frame, options) => {
+      if (closed) throw new Error('Desktop native capability provider is closed');
+      const binding = bindings.get(bindingKey(frame));
+      if (!binding) throw new Error('Desktop native capability is not offered');
+
+      const invocation = new AbortController();
+      activeInvocations.add(invocation);
+      const signal = AbortSignal.any([options.signal, invocation.signal]);
+      try {
+        signal.throwIfAborted();
+        const parameters = requireZodSchema(binding.tool);
+        const args = await parameters.parseAsync(frame.arguments);
+        signal.throwIfAborted();
+        await options.accept();
+        signal.throwIfAborted();
+        if (binding.group.clearSession) {
+          let sessions = usedSessions.get(binding.group);
+          if (!sessions) {
+            sessions = new Set();
+            usedSessions.set(binding.group, sessions);
+          }
+          sessions.add(frame.sessionId);
+        }
+        const output = await binding.tool.impl(args, {
+          sessionId: frame.sessionId,
+          turnId: frame.turnId,
+          cwd: frame.cwd,
+          toolCallId: frame.toolCallId,
+          abortSignal: signal,
+          emitOutput() {},
+        });
+        return projectToolResult(binding.tool, frame.toolCallId, args, output);
+      } finally {
+        activeInvocations.delete(invocation);
+      }
+    },
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      for (const invocation of activeInvocations) {
+        invocation.abort(new Error('Desktop native capability provider closed'));
+      }
+      activeInvocations.clear();
+      const sessionCleanup =
+        [...usedSessions].flatMap(([group, sessions]) =>
+          [...sessions].map(async (sessionId) => group.clearSession?.(sessionId)),
+        );
+      usedSessions.clear();
+      await Promise.all(sessionCleanup);
+    },
+  };
+}
+
+function capabilityGroups(input: DesktopNativeCapabilityProviderInput): NativeCapabilityGroup[] {
+  return [
+    ...(input.browserTools.length > 0
+      ? [
+          {
+            offerId: BROWSER_OFFER_ID,
+            label: 'Browser',
+            description: 'Operate the embedded browser owned by this Desktop client.',
+            tools: input.browserTools,
+          },
+        ]
+      : []),
+    ...(input.computerUseTools.length > 0
+      ? [
+          {
+            offerId: COMPUTER_USE_OFFER_ID,
+            label: 'Computer Use',
+            description: 'Observe and operate the desktop through this Desktop client.',
+            tools: input.computerUseTools,
+            clearSession: (sessionId: string) => input.computerUseTools.clearSession(sessionId),
+          },
+        ]
+      : []),
+  ];
+}
+
+function capabilityOffer(group: NativeCapabilityGroup): ClientCapabilityOffer {
+  return Object.freeze({
+    offerId: group.offerId,
+    version: CAPABILITY_VERSION,
+    affinity: 'session',
+    label: group.label,
+    description: group.description,
+    tools: Object.freeze(
+      group.tools.map((tool) =>
+        Object.freeze({
+          serverId: group.offerId,
+          name: tool.name,
+          description: tool.description,
+          inputSchema: toolInputSchema(tool),
+          ...(tool.displayName ? { annotations: Object.freeze({ title: tool.displayName }) } : {}),
+        }),
+      ),
+    ),
+  });
+}
+
+function toolInputSchema(tool: MakaTool): Record<string, unknown> {
+  const schema = toJSONSchema(requireZodSchema(tool), {
+    io: 'input',
+    target: 'draft-07',
+    unrepresentable: 'any',
+    cycles: 'ref',
+    reused: 'inline',
+  });
+  if (schema.type !== 'object') {
+    throw new Error(`Desktop native capability tool schema must be an object: ${tool.name}`);
+  }
+  return Object.freeze(schema);
+}
+
+function requireZodSchema(tool: MakaTool): z.ZodType {
+  if (!(tool.parameters instanceof z.ZodType)) {
+    throw new Error(`Desktop native capability tool has an invalid schema: ${tool.name}`);
+  }
+  return tool.parameters;
+}
+
+function indexBindings(groups: readonly NativeCapabilityGroup[]): Map<string, NativeToolBinding> {
+  const bindings = new Map<string, NativeToolBinding>();
+  for (const group of groups) {
+    for (const tool of group.tools) {
+      const key = bindingKey({
+        offerId: group.offerId,
+        serverId: group.offerId,
+        toolName: tool.name,
+      });
+      if (bindings.has(key)) {
+        throw new Error(`Duplicate Desktop native capability tool: ${group.offerId}/${tool.name}`);
+      }
+      bindings.set(key, { group, tool });
+    }
+  }
+  return bindings;
+}
+
+function bindingKey(frame: Pick<ClientCapabilityCallFrame, 'offerId' | 'serverId' | 'toolName'>): string {
+  return `${frame.offerId}\0${frame.serverId}\0${frame.toolName}`;
+}
+
+async function projectToolResult(
+  tool: MakaTool,
+  toolCallId: string,
+  input: unknown,
+  output: unknown,
+): Promise<ClientCapabilityCallResult> {
+  const modelOutput = tool.toModelOutput
+    ? await tool.toModelOutput({
+        toolCallId,
+        input,
+        output,
+      })
+    : undefined;
+  if (!modelOutput) {
+    return typeof output === 'string'
+      ? { content: [{ type: 'text', text: output }] }
+      : { content: [], structuredContent: output };
+  }
+  switch (modelOutput.type) {
+    case 'text':
+    case 'error-text':
+      return { content: [{ type: 'text', text: modelOutput.value }] };
+    case 'json':
+    case 'error-json':
+      return { content: [], structuredContent: modelOutput.value };
+    case 'execution-denied':
+      return {
+        content: [{ type: 'text', text: modelOutput.reason ?? 'Execution denied' }],
+      };
+    case 'content':
+      return { content: modelOutput.value.map(projectContentPart) };
+  }
+}
+
+function projectContentPart(part: DesktopToolContentPart): ClientCapabilityContentBlock {
+  switch (part.type) {
+    case 'text':
+      return { type: 'text', text: part.text };
+    case 'file':
+      if (part.data.type !== 'data') {
+        throw new Error('Desktop native capability cannot return referenced or URL files');
+      }
+      return projectBinaryContent(part.data.data, part.mediaType);
+    case 'file-data':
+    case 'image-data':
+      return projectBinaryContent(part.data, part.mediaType);
+    default:
+      throw new Error(`Desktop native capability cannot return ${part.type} content`);
+  }
+}
+
+function projectBinaryContent(
+  data: string | Uint8Array | ArrayBuffer | Buffer,
+  mimeType: string,
+): ClientCapabilityContentBlock {
+  const encoded =
+    typeof data === 'string'
+      ? data
+      : Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data).toString('base64');
+  if (mimeType.startsWith('image/')) return { type: 'image', data: encoded, mimeType };
+  if (mimeType.startsWith('audio/')) return { type: 'audio', data: encoded, mimeType };
+  throw new Error(`Desktop native capability cannot return file type ${mimeType}`);
+}


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- adapt the existing Desktop Browser and Computer Use `MakaTool` implementations into self-described, session-affine Client Capability offers;
- validate arguments before admission, forward Host invocation context and cancellation, and preserve Computer Use screenshots as native image content;
- reject identities that were not offered and release provider-owned Computer Use session state during shutdown;
- expose capability replacement and unregistration through the Desktop Runtime Host client boundary.

Runtime Host remains open-world: it does not know Browser or Computer Use names or Desktop implementation details. This slice provides the composable provider but does not activate it in the production or candidate boot path; activation remains part of the final Desktop composition slice.

## Validation

- `npm --workspace @maka/desktop test` — 1665 passed
- `npm --workspace @maka/desktop run typecheck`
- `npm run lint`
- `npm run format:check`
- focused native capability provider tests
- `git diff --check`

Refs #2010

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 将现有 Desktop Browser 与 Computer Use `MakaTool` 实现适配为自描述、Session-affine 的 Client Capability offer；
- 在 admission 前校验参数，透传 Host invocation context 与取消信号，并将 Computer Use 截图保留为原生图片内容；
- 拒绝未声明的 capability identity，并在 shutdown 时释放 provider 持有的 Computer Use Session 状态；
- 通过 Desktop Runtime Host client 边界暴露 capability replacement 与 unregistration。

Runtime Host 继续保持开放世界设计：它不知道 Browser 或 Computer Use 的名称，也不依赖 Desktop 的具体实现。本 slice 只提供可组合的 provider，不在 production 或 candidate boot path 中提前激活；实际激活仍属于最终的 Desktop composition slice。

## 验证

- `npm --workspace @maka/desktop test` — 1665 项通过
- `npm --workspace @maka/desktop run typecheck`
- `npm run lint`
- `npm run format:check`
- native capability provider 聚焦测试
- `git diff --check`

关联 #2010

</details>
