### PR TITLE
fix(ui): localize the field required/optional marker app-wide

### DIFF
--- a/apps/desktop/src/renderer/locales/settings-provider-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-provider-copy.ts
@@ -100,7 +100,7 @@ const zhCopy = {
     slug: '连接标识', name: '显示名称',
     accountIdPlaceholder: '填写账户 ID',
     saving: '保存中…', save: '保存供应商', keyRequired: (name: string) => `请填写 ${name} API Key`,
-    apiKeyLabel: (required: boolean) => `API Key（${required ? '必填' : '可选'}）`, accountIdLabel: 'Cloudflare Account ID（必填）', endpointLabel: (required: boolean) => `服务地址${required ? '（必填）' : ''}`,
+    apiKeyLabel: 'API Key', accountIdLabel: 'Cloudflare Account ID', endpointLabel: '服务地址',
     defaultModel: '默认模型', defaultModelPlaceholder: '填写你的中转站模型 ID，例如 gpt-4o、claude-sonnet-4-5 或自定义模型名', defaultModelHelp: '用于首次连接测试和模型选择器兜底；保存后仍会自动拉取模型目录。', defaultModelRequired: '请填写默认模型 ID。保存后仍会自动拉取模型目录。',
   },
   oauthFlow: {
@@ -241,7 +241,7 @@ const enCopy: ProviderSettingsCopy = {
     slug: 'Connection identifier', name: 'Display name',
     accountIdPlaceholder: 'Enter account ID',
     saving: 'Saving…', save: 'Save provider', keyRequired: (name: string) => `Enter the ${name} API key`,
-    apiKeyLabel: (required: boolean) => `API key (${required ? 'required' : 'optional'})`, accountIdLabel: 'Cloudflare Account ID (required)', endpointLabel: (required: boolean) => `Service URL${required ? ' (required)' : ''}`,
+    apiKeyLabel: 'API key', accountIdLabel: 'Cloudflare Account ID', endpointLabel: 'Service URL',
     defaultModel: 'Default model', defaultModelPlaceholder: 'Enter your relay model id, e.g. gpt-4o, claude-sonnet-4-5, or a custom model name', defaultModelHelp: 'Used as the first connection-test and picker fallback; Maka still fetches the model catalog after saving.', defaultModelRequired: 'Enter a default model id. Maka still fetches the model catalog after saving.',
   },
   oauthFlow: {

--- a/apps/desktop/src/renderer/settings/password-input.tsx
+++ b/apps/desktop/src/renderer/settings/password-input.tsx
@@ -86,10 +86,11 @@ export function PasswordInput(props: {
     }
   }
   return (
-    // The marker rides on the group label because that is the visible one; the
-    // inner input's label is hidden. `aria-required` is separate — Astryx only
-    // writes it from `isRequired` on the control itself, so the inner TextInput
-    // carries the prop too.
+    // The marker rides on the group label because it is the only one: a
+    // TextInput inside an InputGroup returns its bare input wrapper and renders
+    // no Field at all, so its own `isRequired` produces no marker anywhere. It
+    // still carries the prop, because that input is what `aria-required` is
+    // written on, and the group's `aria-labelledby` is what names it.
     <InputGroup
       label={props.label}
       description={props.description}

--- a/apps/desktop/src/renderer/settings/password-input.tsx
+++ b/apps/desktop/src/renderer/settings/password-input.tsx
@@ -37,6 +37,7 @@ export function PasswordInput(props: {
   description?: string;
   status?: InputGroupProps['status'];
   isRequired?: boolean;
+  isOptional?: boolean;
   isDisabled?: boolean;
   onBlur?(): void;
   hasAutoFocus?: boolean;
@@ -85,13 +86,17 @@ export function PasswordInput(props: {
     }
   }
   return (
-    // No isRequired on the group label: Astryx hardcodes an English "· Required"
-    // and our labels already carry 「（必填）」; the semantic lives on the inner input.
+    // The marker rides on the group label because that is the visible one; the
+    // inner input's label is hidden. `aria-required` is separate — Astryx only
+    // writes it from `isRequired` on the control itself, so the inner TextInput
+    // carries the prop too.
     <InputGroup
       label={props.label}
       description={props.description}
       isLabelHidden={props.isLabelHidden}
       isDisabled={props.isDisabled}
+      isRequired={props.isRequired}
+      isOptional={props.isOptional}
       status={props.status}
     >
       <TextInput

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -181,8 +181,9 @@ export function AddProviderForm(props: {
             clearFieldError('apiKey');
           }}
           placeholder={copy.apiKeyPlaceholder}
-          label={copy.apiKeyLabel(requiresApiKey)}
+          label={copy.apiKeyLabel}
           isRequired={requiresApiKey}
+          isOptional={!requiresApiKey}
           status={
             error?.field === 'apiKey'
               ? { type: 'error', message: error.message }
@@ -221,8 +222,9 @@ export function AddProviderForm(props: {
               clearFieldError('apiKey');
             }}
             placeholder={copy.apiKeyPlaceholder}
-            label={copy.apiKeyLabel(requiresApiKey)}
+            label={copy.apiKeyLabel}
             isRequired={requiresApiKey}
+            isOptional={!requiresApiKey}
             isDisabled={isExperimental || busy}
             status={
               error?.field === 'apiKey'
@@ -279,7 +281,7 @@ export function AddProviderForm(props: {
             }}
             placeholder={defaults.baseUrl || 'https://…'}
             isDisabled={isExperimental || busy}
-            label={copy.endpointLabel(requiresBaseUrl)}
+            label={copy.endpointLabel}
             isRequired={requiresBaseUrl}
             status={
               error?.field === 'baseUrl'

--- a/packages/ui/src/__tests__/astryx-form-controls-localization.test.tsx
+++ b/packages/ui/src/__tests__/astryx-form-controls-localization.test.tsx
@@ -60,16 +60,24 @@ describe('Astryx form-control localization', () => {
     assert.doesNotMatch(markup, /Optional/);
   });
 
+  /**
+   * `en` resolves through the catalog the patch adds to, not through a
+   * hard-coded string, so a key missing from `locales/en.json` surfaces as the
+   * raw key in the markup. Both markers are asserted because they are separate
+   * entries: dropping one leaves the other's assertion green.
+   */
   it('keeps Astryx’s English markers when the locale is en', () => {
     const markup = renderToStaticMarkup(
       <LocaleProvider locale="en">
         <AstryxLocaleProvider>
           <TextInput label="API key" value="" onChange={() => {}} isRequired />
+          <TextInput label="Note" value="" onChange={() => {}} isOptional />
         </AstryxLocaleProvider>
       </LocaleProvider>,
     );
 
     assert.match(markup, /Required/);
+    assert.match(markup, /Optional/);
     assert.doesNotMatch(markup, /@astryx\.field/);
   });
 

--- a/packages/ui/src/__tests__/astryx-form-controls-localization.test.tsx
+++ b/packages/ui/src/__tests__/astryx-form-controls-localization.test.tsx
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { CommandPaletteList, NumberInput } from '@astryxdesign/core';
+import { CommandPaletteList, NumberInput, TextInput } from '@astryxdesign/core';
 import {
   AstryxLocaleProvider,
   astryxMessageOverrides,
@@ -32,6 +32,45 @@ describe('Astryx form-control localization', () => {
         numberClear: '清除{label}',
       },
     );
+  });
+
+  /**
+   * Guard for `patches/@astryxdesign+core+0.2.0.patch`. Upstream `FieldLabel`
+   * hard-codes the two words; the patch routes them through the catalog. Both
+   * halves matter and they fail differently: the marker is what the patch adds,
+   * `aria-required` is what a CSS-only or drop-the-prop workaround would have
+   * cost. Delete the patch when this passes without it.
+   */
+  it('localizes the required marker while keeping aria-required', () => {
+    const markup = renderChineseControl(
+      <TextInput label="API Key" value="" onChange={() => {}} isRequired />,
+    );
+
+    assert.match(markup, /必填/);
+    assert.doesNotMatch(markup, /Required/);
+    assert.match(markup, /aria-required="true"/);
+  });
+
+  it('localizes the optional marker', () => {
+    const markup = renderChineseControl(
+      <TextInput label="备注" value="" onChange={() => {}} isOptional />,
+    );
+
+    assert.match(markup, /可选/);
+    assert.doesNotMatch(markup, /Optional/);
+  });
+
+  it('keeps Astryx’s English markers when the locale is en', () => {
+    const markup = renderToStaticMarkup(
+      <LocaleProvider locale="en">
+        <AstryxLocaleProvider>
+          <TextInput label="API key" value="" onChange={() => {}} isRequired />
+        </AstryxLocaleProvider>
+      </LocaleProvider>,
+    );
+
+    assert.match(markup, /Required/);
+    assert.doesNotMatch(markup, /@astryx\.field/);
   });
 
   it('renders a Chinese accessible clear name', () => {

--- a/packages/ui/src/astryx-i18n.tsx
+++ b/packages/ui/src/astryx-i18n.tsx
@@ -23,6 +23,11 @@ import type { UiLocale } from './locale-helpers.js';
  * config, not coverage.
  *
  * `en` needs no overrides — it resolves to Astryx's shipped defaults.
+ *
+ * `@astryx.field.required` / `@astryx.field.optional` are the one pair Astryx
+ * does not ship: upstream hard-codes those two words in `FieldLabel`. The keys
+ * exist because `patches/@astryxdesign+core+0.2.0.patch` routes the marker
+ * through this catalog — see that patch's entry in `patches/README.md`.
  */
 export function AstryxLocaleProvider({
   children,
@@ -64,6 +69,8 @@ export function astryxMessageOverrides(locale: UiLocale): Overrides | undefined 
       '@astryx.popover.close': shared.primitives.close,
       '@astryx.toast.dismiss': shared.toast.closeNotification,
       '@astryx.toast.viewport': shared.toast.notifications,
+      '@astryx.field.required': form.required,
+      '@astryx.field.optional': form.optional,
       '@astryx.selector.placeholder': form.selectPlaceholder,
       '@astryx.selector.clearLabel': form.clear,
       '@astryx.numberInput.clearLabel': form.clear,

--- a/packages/ui/src/shared-ui-copy.ts
+++ b/packages/ui/src/shared-ui-copy.ts
@@ -37,6 +37,8 @@ export interface SharedUiCopy {
   formControls: {
     selectPlaceholder: string;
     clear: string;
+    required: string;
+    optional: string;
   };
   modelPicker: {
     searchPlaceholder: string;
@@ -139,6 +141,8 @@ const SHARED_UI_COPY = {
     formControls: {
       selectPlaceholder: '选择…',
       clear: '清除{label}',
+      required: '必填',
+      optional: '可选',
     },
     modelPicker: {
       searchPlaceholder: '搜索模型…',
@@ -225,6 +229,8 @@ const SHARED_UI_COPY = {
     formControls: {
       selectPlaceholder: 'Select…',
       clear: 'Clear {label}',
+      required: 'Required',
+      optional: 'Optional',
     },
     modelPicker: {
       searchPlaceholder: 'Search models…',

--- a/patches/@astryxdesign+core+0.2.0.patch
+++ b/patches/@astryxdesign+core+0.2.0.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/@astryxdesign/core/dist/Field/FieldLabel.js b/node_modules/@astryxdesign/core/dist/Field/FieldLabel.js
+index b5a8d9e..89a72cd 100644
+--- a/node_modules/@astryxdesign/core/dist/Field/FieldLabel.js
++++ b/node_modules/@astryxdesign/core/dist/Field/FieldLabel.js
+@@ -19,6 +19,7 @@ import { colorVars, fontWeightVars, spacingVars, typographyVars, typeScaleVars }
+ import { Icon, renderIconSlot } from "../Icon/index.js";
+ import { Tooltip } from "../Tooltip/index.js";
+ import { themeProps } from "../utils/themeProps.js";
++import { useTranslator } from "../i18n/index.js";
+ import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-runtime";
+ const styles = {
+   label: {
+@@ -87,7 +88,8 @@ export function FieldLabel({
+   ref,
+   ...rest
+ }) {
+-  const statusText = isOptional ? 'Optional' : isRequired ? 'Required' : null;
++  const t = useTranslator();
++  const statusText = isOptional ? t('@astryx.field.optional') : isRequired ? t('@astryx.field.required') : null;
+ 
+   // A group label (e.g. for a radiogroup) must not be a literal `<label>`
+   // element: a `<label>` semantically names a single form control and can't be
+diff --git a/node_modules/@astryxdesign/core/locales/en.json b/node_modules/@astryxdesign/core/locales/en.json
+index fa4644c..505d815 100644
+--- a/node_modules/@astryxdesign/core/locales/en.json
++++ b/node_modules/@astryxdesign/core/locales/en.json
+@@ -747,6 +747,14 @@
+     "defaultMessage": "Code",
+     "description": "Screen-reader-only fallback name for a code-snippet scroll container when the code's language is unknown. \"Code\" = source code, not secret code or code of conduct."
+   },
++  "@astryx.field.required": {
++    "defaultMessage": "Required",
++    "description": "Visible marker after a field label indicating the field must be filled in. Rendered after an aria-hidden separator, so it reads on its own. Pairs with `field.optional`."
++  },
++  "@astryx.field.optional": {
++    "defaultMessage": "Optional",
++    "description": "Visible marker after a field label indicating the field may be left empty. Rendered after an aria-hidden separator, so it reads on its own. Pairs with `field.required`."
++  },
+   "@astryx.fileInput.clearLabel": {
+     "defaultMessage": "Clear {label}",
+     "description": "Screen-reader-only label on the X that removes the selected file from a FileInput. Example: `Clear Attachment`, `Clear Résumé`."

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,6 @@
 # patches
 
-`scripts/apply-dependency-patches.mjs` applies everything here during the root `postinstall`, with `--error-on-fail` so a patch that no longer applies blocks the install instead of silently disappearing. It skips when `patch-package` itself is absent, which happens under `npm ci --workspace <name>` and `npm ci --omit=dev`; those trees are not what ships, and an unpatched one fails the regression test below.
+`scripts/apply-dependency-patches.mjs` applies everything here during the root `postinstall`, with `--error-on-fail` so a patch that no longer applies blocks the install instead of silently disappearing. It skips when `patch-package` itself is absent, which happens under `npm ci --workspace <name>` and `npm ci --omit=dev`; those trees are not what ships, and an unpatched one fails the guard test named in each section below.
 
 After bumping a patched dependency, re-run `npx patch-package <name>` so the patch filename tracks the installed version.
 
@@ -60,3 +60,25 @@ Not upstreamed, by decision — treat this as a long-lived vendored correction, 
 Two `typeValidation` branches sit untouched inside a patched hunk and neither can execute in this tree: `openai-compatible` passes no setting, so it gets `'none'`, and its chunk schema has no `type` field to validate anyway; `openai` passes `'if-present'`, but its schema declares `type: z.literal('function').nullish()`, so a wrong type is rejected before the tracker is reached. Left alone deliberately — the class is upstream's, and narrowing it to what this repo happens to exercise would widen the diff for nothing.
 
 **Delete it when the guard still holds without it.** Remove the patch, reinstall, and run `packages/runtime/src/__tests__/model-factory-tool-call-index.test.ts`. Read the result by property, not by count. The patch is unnecessary once, on both the `openai` and `openai-compatible` paths, no case merges two calls' arguments into one input, drops a call, emits a duplicate or empty tool call id, emits a `tool-input-start`/`-delta`/`-end` sequence that does not match the `tool-call` it precedes, or crashes. `assertInputsSelfContained`, `assertToolCallIdsUsable`, and `assertEventLifecycle` are those properties. Two caveats when reading a red result: seven cases assert that an *undecidable* shape fails, and an upstream that genuinely fixed the layers below would make those shapes succeed — turning the guard red for a better implementation. And self-containment is a property of the shapes the guard covers, not of any implementation: the `shapes that cannot be demultiplexed` suite exists because a shared alias makes it unachievable, and it deliberately does not assert it. Related upstream reports, for context only: [vercel/ai#18333](https://github.com/vercel/ai/issues/18333), [vercel/ai#14277](https://github.com/vercel/ai/pull/14277), [vercel/ai#15879](https://github.com/vercel/ai/pull/15879).
+
+## `@astryxdesign/core`: a field's required/optional marker is copy, so it belongs in the catalog
+
+`FieldLabel` renders the marker beside a label as the literal words `'Optional'` / `'Required'` — no message id, so `AstryxLocaleProvider` cannot reach them. Every Astryx field the app marks with `isRequired` or `isOptional` therefore prints an English word inside a Chinese-first UI: the provider add form, the MCP server editor, the WeChat bot login, the plan-reminder dialog.
+
+The patch is two lines of behaviour: `FieldLabel` takes `useTranslator()` and resolves `@astryx.field.required` / `@astryx.field.optional`, and `locales/en.json` gains those two keys so `en` still resolves to `Required` / `Optional` through the shipped catalog rather than through a hard-coded string. `packages/ui/src/astryx-i18n.tsx` supplies the `zh` values from `getSharedUiCopy(...).formControls`, the same place every other Astryx override reads from.
+
+### Why not the two workarounds
+
+**Put the marker in the `label` string.** That is what `settings-provider-copy.ts` used to do (`API Key（必填）`), and it is why those fields rendered `API Key（必填） ∙ Required` — two markers, one of them untranslated. It also forces every copy catalog to re-derive a component-level convention, and it folds the marker into the field's accessible name, where it reads as part of the name rather than as a state.
+
+**Hide the marker with CSS and keep the prop.** `isRequired` is the only way to get `aria-required` onto the input — Astryx writes that attribute *after* spreading `...rest`, so passing it through is silently overwritten — so dropping the prop drops the semantics, and hiding the marker is the only alternative. That was the scoped stopgap in `apps/desktop/src/renderer/styles/astryx-field.css` on the plan-reminder form (PR #2155). It keys on the marker's DOM shape (a label's one element child wrapping an `aria-hidden` separator), which is not a contract; and unscoped it removes the visible required affordance from every form in the app. The patch keeps `aria-required` untouched *and* keeps the marker visible, so that file has nothing left to do.
+
+### Known boundaries
+
+Only `dist/Field/FieldLabel.js` is patched — `package.json` `exports` resolves there, and nothing in this repo compiles `src/`, so patching the `.tsx` would double the conflict surface for no runtime effect. `dist/astryx.umd.js` carries its own minified copy of the same logic and is left alone; nothing here loads the UMD bundle. `dist/Field/FieldLabel.js.map` is now stale for these two lines.
+
+`FieldLabel` gains a hook call. It is rendered by `Field`, `InputGroup`, `CheckboxInput`, and `Switch`, all of which already render under React; `useTranslator` reads a context with a default value, so a subtree with no `InternationalizationProvider` still resolves through the shipped `en` catalog exactly as before.
+
+### Lifecycle
+
+Upstreamable, unlike the `@ai-sdk` patch: the key naming follows `@astryx.fileInput.required`, which upstream already ships for the screen-reader mirror of this same marker. **Delete it when `packages/ui/src/__tests__/astryx-form-controls-localization.test.tsx` passes without it** — `localizes the required marker while keeping aria-required` asserts both halves, the localized marker and the surviving `aria-required`, and `keeps Astryx's English markers when the locale is en` asserts the `en` path did not regress into a raw key. Reinstall without the patch and run `npm --workspace @maka/ui run test`.


### PR DESCRIPTION
## Summary

Astryx's `FieldLabel` renders a field's required/optional marker as the literal English words `'Required'` / `'Optional'`. There is no message id, so `AstryxLocaleProvider` (`packages/ui/src/astryx-i18n.tsx`) cannot reach them. The consequence: **every form that passes `isRequired` / `isOptional` prints an English word inside a Chinese-first UI** — the provider add form, the MCP server editor, the WeChat bot login, the plan-reminder dialog.

This PR takes the app-wide answer: **make those two words a copy entry in the catalog, where they belong.**

- `patches/@astryxdesign+core+0.2.0.patch` — `FieldLabel` resolves `@astryx.field.required` / `@astryx.field.optional` through `useTranslator()`, and `locales/en.json` gains both keys. `en` still renders `Required` / `Optional`, now through the shipped catalog instead of a hard-coded string.
- `packages/ui/src/astryx-i18n.tsx` — the `zh` values come from `getSharedUiCopy(...).formControls`, the same place every other Astryx override reads from.

**`aria-required` is untouched.** That is precisely why the marker is translated rather than hidden: `isRequired` is the only prop that writes `aria-required` onto the input (Astryx writes the attribute *after* spreading `...rest`, so passing it through is silently overwritten). Suppressing the visible marker therefore means keeping the prop and deleting the only visible required affordance — and keying a CSS rule on "the one element child of a field label that wraps an `aria-hidden` separator", which is not a contract. That is exactly why the rule in `apps/desktop/src/renderer/styles/astryx-field.css` on #2155 was deliberately scoped to `#maka-plan-reminder-form`.

The two rejected alternatives and the reasoning against each are written up in the new section of `patches/README.md`, together with this patch's deletion condition.

One duplicate falls out of the fix: `settings-provider-copy.ts` used to hand-roll `API Key（必填）` into the label, which stacked with the component's own marker and rendered as `API Key（必填） ∙ Required` — two markers, one of them untranslated. The marker now comes only from the component; `PasswordInput` hangs it on the visible group label while the inner input keeps `isRequired` for the semantics.

Refs #2155

### Review focus: the relationship to #2155

`astryx-field.css` exists only on #2155's branch — it is not on `main` — so this PR cannot delete it. **#2155 should delete `apps/desktop/src/renderer/styles/astryx-field.css` and its stylesheet-entry import after rebasing onto this PR.** Once the patch lands, that rule's only remaining effect is to re-hide the now-translated 「必填」 in the plan-reminder form.

Either PR can merge first, but whichever merges second owns this cleanup, and **nothing catches it automatically**: `check-dead-css.mjs` scans class selectors for consumers, and that rule is keyed on an id selector whose id genuinely exists in #2155's DOM. A forgotten deletion is green CI and a silent regression.

## Verification

- `npm run format` / `npm run lint` — clean
- `npm --workspace @maka/desktop run typecheck` (four tsconfigs) — pass
- `npm --workspace @maka/ui run test` — 324 pass
- `npm --workspace @maka/desktop run test` — 1664 pass
- `npm run test:scripts` — 110 pass
- `node scripts/check-dead-css.mjs --check` — pass
- `npm --workspace @maka/desktop run smoke:storybook` — 68 manifest checks + 82 catalog renders pass
- CI — all jobs green, including both `e2e_shard` jobs

### Playwright, and why it was run deliberately

This PR changes accessible names (`API Key（必填）` → `API Key ∙ 必填`), and `providers.spec.ts` selects on them at lines 77 and 263 via `getByRole('textbox', { name: /API Key/ })`. Skipping the suite was not defensible.

CI runs both shards green. Locally the same spec is 1 pass / 1 fail: `providers.spec.ts:71` times out on the delete-button click at line 231 because this machine has no network, the model-catalog fetch fails, and the resulting 「网络错误 · 当前继续显示静态列表」 toast intercepts the pointer. That is the same pre-existing failure #2155 recorded against an unmodified baseline. It is also the evidence that matters here: the run reaches line 231, which means the label selectors at 77 and 263 were never disturbed.

### The patch guard actually fails without the patch

Three reverse scenarios, each verified by hand:

| Reverted | Result |
|---|---|
| The `FieldLabel.js` hunk (back to the upstream hard-coded line) | the two `zh` tests go red, the rest green |
| `@astryx.field.required` from `en.json` | the `en` test goes red |
| `@astryx.field.optional` from `en.json` | the `en` test goes red |

With the patch applied, all six pass. That is the deletion condition recorded in `patches/README.md`: the day those tests pass without the patch, delete it.

### Rendered output (Storybook, zh)

`product-settings-providers--add-provider`:

```
API Key ∙ 必填
[{"type":"password","ariaRequired":"true"}]
```

`product-module-hubs--extensions-mcp-configured` → 添加 MCP:

```
[{"t":"服务器 ID ∙ 必填","req":"true"},
 {"t":"命令 ∙ 必填","req":"true"},
 {"t":"参数","req":null},
 {"t":"工作目录","req":null}]
```

<!-- live app screenshot -->

### External review

Pi / `opencode-go/deepseek-v4-flash` (effort `max`) reviewed the branch: no P0/P1/P2, three P3s. After verifying each independently:

- **Fixed** — the `en` guard pinned only the required marker. Deleting just `@astryx.field.optional` left all six tests green while `en` leaked the raw key. Reproduced, then closed: that scenario now goes red.
- **Fixed (found while verifying)** — the comment in `password-input.tsx` claimed the inner input's label is hidden. It is not rendered at all: a `TextInput` inside an `InputGroup` returns its bare input wrapper and skips `Field` entirely, which is why the marker has to ride on the group label rather than being a second copy of it.
- **Deferred** — `PasswordInput`'s `isOptional` threading and the copy changes have no unit test. Both forms had zero coverage in the desktop suite before this PR; adding it is a new coverage layer, out of scope here. The provider form is exercised by the e2e run above.
- **Rejected** — "the accessible name of grouped inputs now carries the marker *and* `aria-required`, announcing it twice". Checked against the vendored source: this is Astryx's existing shape for every standalone field (the marker sits inside the element that names the input). It cannot change without removing the visible marker, which is the point of this PR.

---

<details>
<summary>中文对照</summary>

## 概要

Astryx 的 `FieldLabel` 把字段的必填/选填标记写死成英文字面量 `'Required'` / `'Optional'`，没有 message id，`AstryxLocaleProvider`（`packages/ui/src/astryx-i18n.tsx`）够不到它。结果是：**只要表单传了 `isRequired` / `isOptional`，中文界面里就会冒出一个英文词** —— 模型连接添加表单、MCP 服务器编辑器、微信 Bot 登录、计划提醒弹窗都中招。

这个 PR 给出全局答案：**把这两个词变成 catalog 里的一条 copy，放回它该在的地方。**

- `patches/@astryxdesign+core+0.2.0.patch` —— `FieldLabel` 改用 `useTranslator()` 解析 `@astryx.field.required` / `@astryx.field.optional`，同时给 `locales/en.json` 补上这两个 key。`en` 仍然渲染 `Required` / `Optional`，只是改从 shipped catalog 走，而不是硬编码。
- `packages/ui/src/astryx-i18n.tsx` —— `zh` 取值来自 `getSharedUiCopy(...).formControls`，和其他所有 Astryx override 同一个出处。

**`aria-required` 完好无损。** 这正是选「翻译」而不是「隐藏」的原因：`isRequired` 是唯一能把 `aria-required` 写到 input 上的入口（Astryx 在 `...rest` 之后才写这个属性，自己传会被静默覆盖）。所以要去掉可见标记就只能保留 prop、并删掉唯一的可见必填提示 —— 还要把 CSS 规则 key 在「label 下唯一一个包着 `aria-hidden` 分隔符的元素子节点」这种非契约的 DOM 形状上。#2155 里 `apps/desktop/src/renderer/styles/astryx-field.css` 那条规则正是因此才刻意只 scope 到 `#maka-plan-reminder-form`。

两个被拒方案及其理由，连同这个 patch 的删除条件，写在 `patches/README.md` 新增的小节里。

顺带清掉一处重复：`settings-provider-copy.ts` 原本自己在 label 里拼了 `API Key（必填）`，叠加组件自带的标记后实际渲染成 `API Key（必填） ∙ Required` —— 两个标记，其中一个还没翻译。现在标记只由组件出，`PasswordInput` 把它挂在可见的 group label 上，内层 input 继续拿 `isRequired` 保住语义。

### Review focus：和 #2155 的关系

`astryx-field.css` 只存在于 #2155 的分支上，`main` 上没有，所以这个 PR 无法直接删掉它。**#2155 应该在 rebase 到本 PR 之后，删除 `apps/desktop/src/renderer/styles/astryx-field.css` 及其样式入口引用。** patch 落地后，那条规则唯一的效果就是把计划提醒表单里已经翻译好的「必填」重新藏起来。

两个 PR 谁先合都行，但后合的那个要负责这次清理，而且**没有任何自动兜底**：`check-dead-css.mjs` 只扫 class 选择器的消费者，而那条规则 key 在一个 id 选择器上，该 id 在 #2155 的 DOM 里真实存在。忘了删 = CI 全绿 + 静默回归。

## 验证

- `npm run format` / `npm run lint` —— clean
- `npm --workspace @maka/desktop run typecheck`（四个 tsconfig）—— pass
- `npm --workspace @maka/ui run test` —— 324 pass
- `npm --workspace @maka/desktop run test` —— 1664 pass
- `npm run test:scripts` —— 110 pass
- `node scripts/check-dead-css.mjs --check` —— pass
- `npm --workspace @maka/desktop run smoke:storybook` —— 68 manifest checks + 82 catalog renders pass
- CI —— 全绿，包括两个 `e2e_shard`

### Playwright，以及为什么这次是特意跑的

本 PR 改了 accessible name（`API Key（必填）` → `API Key ∙ 必填`），而 `providers.spec.ts` 第 77、263 行正是用 `getByRole('textbox', { name: /API Key/ })` 选元素的。跳过这个套件说不过去。

CI 两个 shard 全绿。本机同一个 spec 是 1 pass / 1 fail：`providers.spec.ts:71` 卡在第 231 行的删除按钮点击上超时 —— 本机无网络，模型目录拉取失败，弹出的「网络错误 · 当前继续显示静态列表」toast 拦住了 pointer。这与 #2155 在未改动基线上记录的是同一个既有失败。它同时也是这里真正有用的证据：用例跑到了第 231 行，说明第 77、263 行的选择器完全没被打断。

### 补丁守卫确实会在缺少补丁时变红

三个反向场景，逐个手工验证：

| 还原对象 | 结果 |
|---|---|
| `FieldLabel.js` hunk（回到上游硬编码那行） | 两个 `zh` 测试红，其余绿 |
| 从 `en.json` 删掉 `@astryx.field.required` | `en` 测试红 |
| 从 `en.json` 删掉 `@astryx.field.optional` | `en` 测试红 |

补丁应用后六条全绿。这就是 `patches/README.md` 里记录的删除条件：哪天不打补丁这些测试也能过，就删掉它。

### 实际渲染（Storybook，zh）

见上方英文段落中的输出。

### 外部 review

Pi / `opencode-go/deepseek-v4-flash`（effort `max`）做了一轮 review：无 P0/P1/P2，三条 P3。逐条独立复核后：

- **已修** —— `en` 守卫只钉了 required。单独删掉 `@astryx.field.optional` 时六条测试仍全绿，而 `en` 会泄漏 raw key。已复现并堵上：该场景现在会红。
- **已修（复核时自己发现的）** —— `password-input.tsx` 的注释说「内层 input 的 label 是 hidden 的」。它根本没被渲染：InputGroup 内的 `TextInput` 直接返回裸 input wrapper、完全跳过 `Field`，所以 marker 只能挂在 group label 上，不存在第二份。
- **推迟** —— `PasswordInput` 的 `isOptional` 穿线与文案改动没有单元测试。这两个表单在本 PR 之前于 desktop 套件里就是零覆盖；补齐属于新增覆盖层，不在本 PR 范围。provider 表单已由上面的 e2e 走到。
- **驳回** —— 「分组输入框的 accessible name 现在同时带 marker 和 `aria-required`，等于宣告两次」。已核对 vendored 源码：这是 Astryx 对所有独立字段的既有形状（marker 就在给 input 命名的那个元素里）。不移除可见标记就无法改变，而可见标记正是本 PR 的目的。

</details>
