### PR TITLE
fix(desktop): seed plan reminders with distinct createdAt

### DIFF
--- a/apps/desktop/e2e/plan-reminders.spec.ts
+++ b/apps/desktop/e2e/plan-reminders.spec.ts
@@ -1,5 +1,20 @@
 import { expect, test } from './fixtures.js';
 
+// The seeded reminders carry distinct createdAt values so the default
+// 创建时间倒序 sort has a single answer. Without them all four tie in the
+// same millisecond and the fallback comparator decides the order, which made
+// any position-based assertion here flaky between runs.
+test('orders the seeded reminders deterministically under the default sort', async ({
+  planRemindersWindow: page,
+}) => {
+  const rows = page.getByRole('article');
+  await expect(rows).toHaveCount(4);
+  const expected = ['已触发的本地提醒', '每周竞品动态追踪', '暂停的发布检查', '同步项目风险'];
+  for (const [index, title] of expected.entries()) {
+    await expect(rows.nth(index)).toContainText(title);
+  }
+});
+
 test('keeps Plan row actions keyboard ordered and destructive confirmation reversible', async ({
   planRemindersWindow: page,
 }) => {

--- a/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
@@ -649,11 +649,14 @@ describe('e2e-fixture mode', () => {
     try {
       const fixture = resolveE2eFixture('plan-reminders', false);
       assert.ok(fixture);
+      // Seeds on the fixture's own clock (E2E_FIXTURE_NOW, the app default)
+      // rather than this file's arbitrary 2023 stamp: the reminders carry
+      // fixed 2026 run times, and the store rejects a runAt more than a year
+      // past its creation clock.
       await seedE2eFixture({
         workspaceRoot,
         fixture,
         credentialStore: fakeCredentialStore(),
-        now: 1_700_000_000_000,
       });
 
       const state = getE2eFixtureState(fixture);
@@ -673,9 +676,18 @@ describe('e2e-fixture mode', () => {
         enabled: boolean;
         nextRunAt?: number;
         lastRun?: { status: string; message: string };
+        createdAt: number;
       }>,
       );
       assert.equal(reminders.length, 4);
+      // The panel's default 创建时间倒序 sort only falls back to the status /
+      // next-run comparator on `createdAt` ties, so the seed must hand it
+      // four distinct values or row positions drift between runs.
+      assert.equal(
+        new Set(reminders.map((reminder) => reminder.createdAt)).size,
+        4,
+        'seeded plan reminders need distinct createdAt values',
+      );
       const scheduled = reminders.find((reminder) => reminder.title === '同步项目风险');
       const paused = reminders.find((reminder) => reminder.title === '暂停的发布检查');
       const weekly = reminders.find((reminder) => reminder.title === '每周竞品动态追踪');

--- a/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
@@ -183,38 +183,57 @@ function model(
   return { id, capabilities, contextWindow };
 }
 
-export async function writePlanReminders(workspaceRoot: string, _now: number): Promise<void> {
+export async function writePlanReminders(workspaceRoot: string, now: number): Promise<void> {
   const scheduledRunAt = Date.UTC(2026, 11, 18, 3, 0, 0);
   const pausedRunAt = Date.UTC(2026, 11, 20, 3, 0, 0);
+  // The panel's default 创建时间倒序 sort keys on `createdAt` and only falls
+  // back to a status/next-run comparator on ties. Four back-to-back
+  // `create()` calls land in the same millisecond, so every reminder tied
+  // and the fallback decided the order — which made any position-based
+  // assertion in `plan-reminders.spec.ts` vary between runs. Seed one
+  // explicit minute apart, oldest first, so 创建时间倒序 has a single answer.
+  const createdAt = (index: number): number => now - (4 - index) * 60_000;
   const store = createSqlitePlanReminderStore(workspaceRoot);
   try {
-    await store.create({
-      title: '同步项目风险',
-      note: '提醒我整理 Sidebar gate、搜索接入和计划任务剩余风险。',
-      runAt: scheduledRunAt,
-    });
-    const paused = await store.create({
-      title: '暂停的发布检查',
-      note: '用户可以先暂停提醒，恢复后继续按原时间触发。',
-      runAt: pausedRunAt,
-    });
+    await store.create(
+      {
+        title: '同步项目风险',
+        note: '提醒我整理 Sidebar gate、搜索接入和计划任务剩余风险。',
+        runAt: scheduledRunAt,
+      },
+      createdAt(0),
+    );
+    const paused = await store.create(
+      {
+        title: '暂停的发布检查',
+        note: '用户可以先暂停提醒，恢复后继续按原时间触发。',
+        runAt: pausedRunAt,
+      },
+      createdAt(1),
+    );
     await store.setEnabled(paused.id, false);
-    const weekly = await store.create({
-      title: '每周竞品动态追踪',
-      note: '汇总同类 AI 工具的近期产品变化，提醒我复盘可对标的交互。',
-      runAt: scheduledRunAt,
-      recurrence: 'cron',
-      cronExpression: '0 10 * * 1',
-    });
+    const weekly = await store.create(
+      {
+        title: '每周竞品动态追踪',
+        note: '汇总同类 AI 工具的近期产品变化，提醒我复盘可对标的交互。',
+        runAt: scheduledRunAt,
+        recurrence: 'cron',
+        cronExpression: '0 10 * * 1',
+      },
+      createdAt(2),
+    );
     await store.markTriggered(weekly.id, {
       at: scheduledRunAt,
       status: 'triggered',
       message: '已生成本周竞品动态摘要',
     });
-    const completed = await store.create({
-      title: '已触发的本地提醒',
-      runAt: scheduledRunAt,
-    });
+    const completed = await store.create(
+      {
+        title: '已触发的本地提醒',
+        runAt: scheduledRunAt,
+      },
+      createdAt(3),
+    );
     await store.markTriggered(completed.id, {
       at: scheduledRunAt,
       status: 'triggered',

--- a/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
@@ -395,6 +395,15 @@ describe('SQLite workflow stores', () => {
         );
         assert.equal(reminder.createdAt, createdAt);
         assert.equal(reminder.updatedAt, createdAt);
+        // The injected clock also governs validation, so a runAt still ahead
+        // of wall time but behind that clock is rejected.
+        await assert.rejects(
+          store.create(
+            { title: 'Behind the injected clock', runAt: Date.now() + 60_000 },
+            Date.now() + 2 * 60_000,
+          ),
+          /must be in the future/,
+        );
       } finally {
         store.close();
       }

--- a/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
@@ -383,6 +383,23 @@ describe('SQLite workflow stores', () => {
       }
     });
   });
+
+  test('stamps Plan Reminders with an explicit creation clock', async () => {
+    await withRoot(async (root) => {
+      const store = createSqlitePlanReminderStore(root);
+      try {
+        const createdAt = Date.now() - 5 * 60_000;
+        const reminder = await store.create(
+          { title: 'Seeded at a fixed clock', runAt: Date.now() + 60_000 },
+          createdAt,
+        );
+        assert.equal(reminder.createdAt, createdAt);
+        assert.equal(reminder.updatedAt, createdAt);
+      } finally {
+        store.close();
+      }
+    });
+  });
 });
 
 function seedLegacyPlanLedger(root: string, eventCount = 3): void {

--- a/packages/storage/src/plan-reminder-store.ts
+++ b/packages/storage/src/plan-reminder-store.ts
@@ -21,7 +21,7 @@ import {
 
 export interface PlanReminderStore {
   list(): Promise<PlanReminder[]>;
-  create(input: unknown): Promise<PlanReminder>;
+  create(input: unknown, now?: number): Promise<PlanReminder>;
   update(id: string, patch: unknown): Promise<PlanReminder>;
   setEnabled(id: string, enabled: boolean): Promise<PlanReminder>;
   snooze(id: string, delayMs: number, now?: number): Promise<PlanReminder>;
@@ -70,8 +70,7 @@ class SqlitePlanReminderStoreImpl implements SqlitePlanReminderStore {
       .sort(comparePlanRemindersForList);
   }
 
-  async create(input: unknown): Promise<PlanReminder> {
-    const now = Date.now();
+  async create(input: unknown, now = Date.now()): Promise<PlanReminder> {
     const normalized = normalizeCreatePlanReminderInput(input, now);
     if (!normalized.ok) throw new Error(normalized.message);
     const value = normalized.value;


### PR DESCRIPTION
## Summary

`writePlanReminders` seeded its four reminders with four back-to-back `store.create()` calls, so their `createdAt` stamps depended on where the four `Date.now()` reads fell relative to a millisecond boundary. The panel's default 创建时间倒序 sort (`comparePlanReminderBySort`, `'created-desc'`) breaks a `createdAt` tie by falling through to `comparePlanReminderForDisplay`, so each tie pattern produced a different — individually deterministic — row order: all four tied renders 每周 / 同步项目风险 / 暂停的发布检查 / 已触发的本地提醒, distinct keys render 已触发的本地提醒 / 每周竞品动态追踪 / 暂停的发布检查 / 同步项目风险, and partial ties render other permutations. Which reminder sat at a given row index therefore varied between runs of the same E2E suite. Every existing test locates rows by text, so nothing caught it, but any position-based assertion was flaky — an assertion that row index 2 held 暂停的发布检查 passed on one run and saw 同步项目风险 on the next.

`create()` stamped `createdAt` from its own `Date.now()` with no way in, so the fix gives it an injectable clock — the same `now = Date.now()` shape `snooze` and `listDue` already use — and the fixture seeds the four reminders one minute apart, oldest first. No sleep, seeded titles and fixture shape unchanged.

Seeding on the fixture clock also detaches the reminders' fixed 2026 run times from wall time: the store validates `runAt` against the creation clock, so the plan-reminders unit test now seeds at the fixture default (`E2E_FIXTURE_NOW`) instead of this file's arbitrary 2023 stamp. That closes a latent window bug — the seed previously validated against real `Date.now()`, so it would have started failing "runAt must be in the future" after 2026-12-18.

Two regression guards: the fixture unit test asserts the four `createdAt` values are distinct, and `plan-reminders.spec.ts` gains a position-based order assertion — the exact shape that was flaky before. The storage test pins both halves of the injected clock: the stamp it writes and the `runAt` validation it governs.

Independent of #2155 and #2185; branched from `main`, which neither touches this fixture.

## Scope

Determinism is guaranteed for the panel's default 创建时间倒序 sort, which is what the fixture and its tests use. Under 更新时间倒序 the seeded data is still partly wall-clock dependent: `setEnabled` stamps `updatedAt` from real `Date.now()`, and `markTriggered` stamps it from the run's `at`, which is the same fixed 2026-12-18 for both triggered reminders. Pinning that would mean injecting clocks into two more store methods and changing the seeded run timestamps the fixture renders. No test sorts by 更新时间倒序 today, so this PR leaves that boundary where it is rather than widening the diff.

## Verification

- `npm --workspace @maka/desktop run test` — 1682 passed, 0 failed.
- `npm --workspace @maka/storage run test` — 654 passed, 0 failed.
- `npx playwright test --config e2e/playwright.config.ts plan-reminders` from `apps/desktop`, run 6 times: 3 passed on every run, with the new order assertion (已触发的本地提醒 / 每周竞品动态追踪 / 暂停的发布检查 / 同步项目风险) holding each time.
- `npm run build`, `npm run lint`, `npm run format:check` — clean.
- `npx playwright test … providers` fails at `providers.spec.ts:71` ("adds a catalog provider through the canonical API-key setup page") on this machine for unrelated reasons: it needs network. Not touched by this change.

## Follow-up

Once this lands, #2185's new test ('reaches the inspector two tab stops from a row with rows after it') can go back to locating its row by title and drop its "Review focus" section. Not changed here.