### PR TITLE
fix(desktop): stop the collapsed rail repainting a third tone in dark mode

### DIFF
--- a/apps/desktop/e2e/sidebar-geometry.spec.ts
+++ b/apps/desktop/e2e/sidebar-geometry.spec.ts
@@ -251,3 +251,116 @@ test('keyboard resize survives a collapse round trip', async ({
   await expect(shell).toHaveAttribute('data-sidebar-state', 'expanded');
   await expect.poll(panelWidth).toBe(chosenWidth);
 });
+
+/**
+ * The rail's material contract. AppShell owns both column materials; the rail
+ * takes --color-background-body and the content column takes the product's
+ * --agents-layout-bg, and makaTheme.ts points BOTH at --surface-canvas, so the
+ * two columns are one surface and the transparent titlebar band above them
+ * reads as one band across the window.
+ *
+ * Collapsing must not re-material the rail. Product CSS used to repaint it
+ * --color-background-surface at 48px so the traffic lights would not straddle a
+ * column edge narrower than they are; by the time the content column was moved
+ * onto --agents-layout-bg that override was the only thing splitting the band,
+ * and in dark mode it landed the rail on a third tone (L 0.205 against the
+ * canvas's 0.18) that ran to the window top past the plate's 4px gutter.
+ *
+ * A screenshot cannot lock this — the bug is a state-dependent token mapping,
+ * invisible in light mode because --color-background-surface happens to equal
+ * the plate's fill there. Read the resolved colors instead, in both collapse
+ * states, and compare the rail against the column it must match rather than
+ * against a literal: the contract is "same material", not "this exact gray", so
+ * it survives a palette or theme change.
+ *
+ * Colors are compared as painted RGBA bytes, not as computed-style strings:
+ * Chromium serializes the same color differently depending on how it was
+ * derived (a relative `oklch(from …)` token resolves to `oklab()`), so equal
+ * paint could read as unequal text.
+ *
+ * The read must SETTLE before it is asserted, which is why this takes two
+ * agreeing samples rather than one read or a plain poll-until-equal. A
+ * re-materialing rule reaches its new color through an ease, so immediately
+ * after the toggle the rail still reports its old value — the collapsed
+ * material it is supposed to keep. Both a single fast read and a poll that
+ * stops at its first match would accept exactly the frame the bug flies
+ * through; measured against the pre-fix rule, poll-until-equal passed.
+ */
+interface RailMaterial {
+  rail: string;
+  column: string;
+  railEdge: string;
+}
+
+async function readRailMaterial(page: Page): Promise<RailMaterial | null> {
+  return page.evaluate(() => {
+    const rail = document.querySelector('.astryx-app-shell-sidenav');
+    const column = document.querySelector('.astryx-layout-content');
+    if (!rail || !column) return null;
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    const context = canvas.getContext('2d');
+    if (!context) return null;
+    const bytes = (color: string): string => {
+      context.clearRect(0, 0, 1, 1);
+      context.fillStyle = color;
+      context.fillRect(0, 0, 1, 1);
+      return Array.from(context.getImageData(0, 0, 1, 1).data).join(',');
+    };
+    return {
+      rail: bytes(getComputedStyle(rail).backgroundColor),
+      column: bytes(getComputedStyle(column).backgroundColor),
+      railEdge: bytes(getComputedStyle(rail).borderInlineEndColor),
+    };
+  });
+}
+
+// Two agreeing consecutive reads, 250ms apart — longer than --duration-base
+// (the ease the pre-fix rule used) so a value still in flight cannot agree with
+// itself. Same shape as scrollListToBottom above.
+async function settledRailMaterial(page: Page): Promise<RailMaterial | null> {
+  let previous: string | null = null;
+  let settled: RailMaterial | null = null;
+  await expect
+    .poll(
+      async () => {
+        const current = await readRailMaterial(page);
+        const serialized = JSON.stringify(current);
+        const agrees = current !== null && serialized === previous;
+        previous = serialized;
+        if (agrees) settled = current;
+        return agrees;
+      },
+      { timeout: 10_000, intervals: [250] },
+    )
+    .toBe(true);
+  return settled;
+}
+
+const TRANSPARENT = '0,0,0,0';
+
+test('the rail wears its column material in both collapse states', async ({
+  sidebarLongSessionsWindow: page,
+}) => {
+  const shell = page.locator('.appFrame');
+
+  await expect(shell).toHaveAttribute('data-sidebar-state', 'expanded');
+  const expanded = await settledRailMaterial(page);
+  expect(expanded, 'expanded').not.toBeNull();
+  expect(expanded?.rail, JSON.stringify(expanded)).toBe(expanded?.column);
+  // The plate's edge is the one boundary on this seam; the theme's own
+  // full-height sidenav hairline stays dropped in both states.
+  expect(expanded?.railEdge, JSON.stringify(expanded)).toBe(TRANSPARENT);
+
+  await page.getByRole('button', { name: '收起侧边栏' }).click();
+  await expect(shell).toHaveAttribute('data-sidebar-state', 'collapsed');
+  const collapsed = await settledRailMaterial(page);
+  // Collapsing is a width change, not a material change: the rail keeps wearing
+  // its column's material, and the column's material has not moved either.
+  expect(collapsed, JSON.stringify({ expanded, collapsed })).toEqual({
+    rail: expanded?.column,
+    column: expanded?.column,
+    railEdge: TRANSPARENT,
+  });
+});

--- a/apps/desktop/src/renderer/astryx-theme/maka.css
+++ b/apps/desktop/src/renderer/astryx-theme/maka.css
@@ -431,12 +431,6 @@
     --astryx-section-padding: var(--spacing-3);
   }
 
-  .astryx-app-shell-sidenav {
-    transition-property: background-color, border-color;
-    transition-duration: var(--duration-base);
-    transition-timing-function: var(--ease-out-strong);
-  }
-
   .astryx-app-shell-sidenav.elevated {
     border-inline-end-width: 1px;
     border-inline-end-style: solid;

--- a/apps/desktop/src/renderer/astryx-theme/makaTheme.ts
+++ b/apps/desktop/src/renderer/astryx-theme/makaTheme.ts
@@ -147,14 +147,11 @@ export const makaTheme = defineTheme({
   // inheriting a line that no longer matches the columns.
   components: {
     'app-shell-sidenav': {
-      // Both halves of the edge are animated, in `base` rather than under the
-      // variant: the ease belongs to the column whatever material it wears, and
-      // only the collapsed state (shell-layout.css) decides what it eases to.
-      base: {
-        transitionProperty: 'background-color, border-color',
-        transitionDuration: 'var(--duration-base)',
-        transitionTimingFunction: 'var(--ease-out-strong)',
-      },
+      // No color ease on the column: neither half of the edge changes across the
+      // collapse any more. The wash is one material in both states (the rail
+      // wears --color-background-body throughout, see shell-layout.css) and the
+      // hairline is transparent in both, so a background-color/border-color
+      // transition here had nothing left to interpolate.
       'variant:elevated': {
         borderInlineEndWidth: '1px',
         borderInlineEndStyle: 'solid',

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -42,41 +42,29 @@
   overflow: hidden;
 }
 
-/* Continuous Collapse: at 48px the rail is icons and nothing else, and the
-   traffic lights are wider than it is (measured ~62px) — a column edge there
-   would run straight through the light cluster. Collapsed, the rail drops both
-   halves of that edge, the wash and the hairline, so the lights sit on one
-   surface; expanded, the theme's border and AppShell's wash mark the column.
-   This is the only rule that overrides a column's material, and it is the
-   reason the ease (makaTheme.ts, app-shell-sidenav `base`) exists.
-
-   It has to live in product CSS rather than the theme: AppShell only forwards
-   `variant` to themeProps and has no notion of the product's collapsed state.
-   No `!important` though — Astryx's StyleX sheet is wrapped in
-   `@layer astryx-base` and imported into `astryx-components`, which this file's
-   `components` layer outranks outright; the specificity padding StyleX emits
-   does not survive a layer boundary. The border override on the next line never
-   carried the flag and has always worked, which is the same evidence read from
-   the other side.
-
-   Painting with --color-background-surface rather than --background is
-   deliberate: the rail is taking the CONTENT COLUMN's material, and that token
-   is what AppShell paints the content column with. Naming the value instead
-   would fork the mapping the moment makaTheme.ts changes it. */
-.appFrame[data-sidebar-state="collapsed"] .astryx-app-shell-sidenav {
-  background: var(--color-background-surface);
-  border-inline-end-color: transparent;
-}
-
 /* WAWQAQ msg `9f313715` (2026-08-03): the content column is a rounded floating
    plate flush to the sidebar — its edge is the ONE boundary on that seam. The
    theme's full-height sidenav hairline (`.astryx-app-shell-sidenav.elevated`
    in the built maka.css) ran on the same seam, so beside the plate's top-left
-   corner radius both lines showed and read as a doubled border. The collapsed
-   rail already dropped this edge (rule above); drop it expanded too — column
-   separation is tonal (the plate's fill against the canvas), per DESIGN.md's
-   One Working Plane rule. Override lives here because maka.css is a generated
-   artifact (`npm run astryx:theme`), not a hand-edited file. */
+   corner radius both lines showed and read as a doubled border. Drop it in both
+   collapse states — column separation is tonal (the plate's fill against the
+   canvas), per DESIGN.md's One Working Plane rule. Override lives here because
+   maka.css is a generated artifact (`npm run astryx:theme`), not a hand-edited
+   file.
+
+   Continuous Collapse used to repaint the collapsed rail with
+   --color-background-surface here as well, so the traffic lights would sit on
+   one surface instead of straddling a column edge narrower than they are. That
+   was written while AppShell's own surface was still the content column's
+   material; `.astryx-layout-content` below now paints --agents-layout-bg
+   (== --surface-canvas == --color-background-body), so the two columns already
+   share one material and the repaint was the only thing breaking the band. In
+   light mode --color-background-surface happens to equal the floating plate's
+   fill, which hid it; in dark mode the plate lifts 0.035L off --background and
+   the rail became a THIRD tone (measured L 0.205 against the canvas's 0.18),
+   painting a 49px slab that ran to the window top past the plate's 4px gutter
+   and under the light cluster. The rail now wears its column's material in both
+   states, which is what "one surface" meant in the first place. */
 .maka-shell-astryx .astryx-app-shell-sidenav {
   border-inline-end-color: transparent;
 }


### PR DESCRIPTION
## Summary

Collapsed, the sidebar rail painted a 49px slab that ran to the window top — past the content plate's 4px gutter and under the traffic-light cluster — in dark mode only.

`shell-layout.css` overrode the collapsed rail's column material with `--color-background-surface` so the lights would sit on one surface instead of straddling a column edge narrower than they are. That was written while AppShell's own surface was still the content column's material. `.astryx-layout-content` now paints `--agents-layout-bg` (`== --surface-canvas == --color-background-body`), so the two columns already share one material and the override was the only thing breaking the band:

- Light: `--color-background-surface` happens to equal the floating plate's fill (on darwin `--color-bg-container` is `--background`), so the slab was invisible.
- Dark: the plate lifts `0.035L` off `--background`, so the rail landed on a third tone — measured `L 0.205` against the canvas's `0.18` — and the slab showed.

Drop the override. The rail wears its column's material in both collapse states, which is what "one surface" meant in the first place. The `border-inline-end-color: transparent` half of the old rule was already covered by the unconditional rule below it.

The sidenav's `background-color, border-color` ease in `makaTheme.ts` goes with it: neither property changes across the collapse any more, so it had nothing left to interpolate. `maka.css` regenerated with `npm run astryx:theme`.

## Verification

New computed-style contract in `e2e/sidebar-geometry.spec.ts` — the rail's painted material must equal `.astryx-layout-content`'s in both collapse states, with a transparent inline-end edge. Red on `main` (collapsed rail `255,255,255` against the column's `247,247,247`), green here.

Two details the contract had to get right, both measured against the pre-fix rule rather than assumed:

- Compare painted RGBA bytes, not computed-style strings. Chromium serializes a relative `oklch(from …)` token as `oklab()`, so equal paint can read as unequal text.
- Take two agreeing reads rather than one sample. The pre-fix rule eased into its new color, so right after the toggle the rail still reports the material it is supposed to keep — a single read and a poll-until-equal both passed against the bug.

Computed styles read over CDP from the live dev app (darwin, vibrancy shell) for the tone analysis above:

| state | theme | `.astryx-app-shell-sidenav` | `.astryx-layout-content` | `.maka-panel-detail` |
| --- | --- | --- | --- | --- |
| collapsed (before) | dark | `oklch(0.205 0.004 286)` | `oklch(0.18 0.004 286)` | `oklch(0.24 0.004 286)` |
| collapsed (after) | dark | `oklch(0.18 0.004 286)` | `oklch(0.18 0.004 286)` | `oklch(0.24 0.004 286)` |
| collapsed (before) | light | `oklch(1 0 0)` | `oklch(0.975 0 0)` | `oklch(1 0 0)` |
| collapsed (after) | light | `oklch(0.975 0 0)` | `oklch(0.975 0 0)` | `oklch(1 0 0)` |
| expanded (after) | dark | `oklch(0.18 0.004 286)` | `oklch(0.18 0.004 286)` | — |
| expanded (after) | light | `oklch(0.975 0 0)` | `oklch(0.975 0 0)` | — |

Also ran: `npm run format:check`, `npm run lint`, `npm run typecheck --workspace @maka/desktop`, and the full `sidebar-geometry` spec (3 passed) — all clean.

## Intended consequences on the other platform/theme combinations

Expanded is unchanged everywhere. Collapsed moves wherever the rail was previously wearing the plate's fill instead of its column's:

- **Light, all platforms:** the rail goes `1.0 → 0.975`, the value its own expanded state already used. The plate's top-left radius now reads against the canvas the same way it does on the other three sides.
- **Dark, non-darwin:** the plate is `--background` there, so the rail moves `0.205 → 0.18` and now contrasts with the plate along its full height, where the two previously matched. This is the same relationship the expanded rail has always had on those platforms.

Keeping the rail on the plate's fill is what produced the darwin-dark bug, and preserving it would need a per-platform material fork. Both moves are the same decision: the rail wears its column's material, in every state and on every platform.
