### PR TITLE
refactor(core): extract shared sanitizeUnicodeText from session-name/…

### DIFF
--- a/packages/core/src/__tests__/session-name.test.ts
+++ b/packages/core/src/__tests__/session-name.test.ts
@@ -49,6 +49,23 @@ describe('normalizeUserSessionName', () => {
     }
   });
 
+  // #1404: the shared sanitizeUnicodeText pipeline (union coverage) now also
+  // neutralizes the bidi marks (ALM/LRM/RLM) and invisible operators
+  // (WJ/IT/IS/IP) that session-name used to miss. Written with \u escapes so
+  // the source stays plain text. Locks the coverage so it can't silently drift
+  // back out of sync with foreign-session.
+  it('neutralizes the bidi marks and invisible operators the union pipeline adds', () => {
+    const cases = [
+      // bidi marks → space: U+061C ALM, U+200E LRM, U+200F RLM
+      ['a\u061Cb\u200Ec\u200Fd', 'a b c d'],
+      // invisible format chars → removed: U+2060 WJ, U+2061 IT, U+2062 IS, U+2063 IP, U+2064 IP
+      ['x\u2060y\u2061z\u2062w\u2063v\u2064u', 'xyzwvu'],
+    ] as const;
+    for (const [input, value] of cases) {
+      assert.deepEqual(normalizeUserSessionName(input), { ok: true, value });
+    }
+  });
+
   it('normalizes canonically equivalent text to NFC', () => {
     assert.deepEqual(normalizeUserSessionName('café'), { ok: true, value: 'café' });
   });

--- a/packages/core/src/foreign-session.ts
+++ b/packages/core/src/foreign-session.ts
@@ -11,9 +11,9 @@
  * bidi spoofs. This module is the single gate all foreign text passes
  * through before it may reach a Maka surface or an LLM prompt:
  *
- *   - `sanitizeForeignText` — NFC, C0/C1/bidi controls → space, zero-width
- *     removal, whitespace collapse, code-point cap (the session-name.ts
- *     pipeline, parameterized for longer payloads).
+ *   - `sanitizeForeignText` — the shared Unicode pipeline in text-sanitize.ts
+ *     (NFC, C0/C1/bidi controls → space, zero-width removal, whitespace
+ *     collapse, code-point cap), parameterized for longer payloads.
  *   - digest building redacts secrets (`redactSecrets`) and never includes
  *     tool outputs, system prompts, or thinking blocks — only user-authored
  *     messages, assistant text, and file paths, each capped.
@@ -24,6 +24,7 @@
  */
 
 import { redactSecrets } from './redaction.js';
+import { sanitizeUnicodeText } from './text-sanitize.js';
 
 export const FOREIGN_SESSION_SOURCES = ['claude-code', 'codex'] as const;
 export type ForeignSessionSource = (typeof FOREIGN_SESSION_SOURCES)[number];
@@ -86,23 +87,15 @@ export interface ForeignSessionDigest {
 }
 
 /**
- * session-name.ts pipeline generalized for foreign payloads: same character
- * classes, parameterized cap, and empty-in → empty-out (callers decide the
- * fallback; foreign text has no "reject" path because we never block a scan
- * on one bad string).
+ * Shared Unicode pipeline (text-sanitize.ts) wrapped for foreign payloads:
+ * empty-in → empty-out (callers decide the fallback; foreign text has no
+ * "reject" path because we never block a scan on one bad string). The cap is
+ * caller-supplied because foreign payloads vary (title 120 / message 2000 /
+ * path 260 code points).
  */
 export function sanitizeForeignText(input: unknown, maxCodePoints: number): string {
   if (typeof input !== 'string') return '';
-  const cleaned = input
-    .normalize('NFC')
-    .replace(/[\u0000-\u001F\u007F\u0080-\u009F]/g, ' ')
-    .replace(/[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/g, ' ')
-    .replace(/[\u200B-\u200D\u2060-\u2064\uFEFF]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-  const points = Array.from(cleaned);
-  if (points.length <= maxCodePoints) return cleaned;
-  return points.slice(0, maxCodePoints).join('') + '…';
+  return sanitizeUnicodeText(input, { maxCodePoints });
 }
 
 /** Sanitize + redact in one step for digest payloads. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1081,6 +1081,10 @@ export {
   stripEnvelopeTags,
 } from './foreign-session.js';
 
+// text-sanitize.ts (#1404)
+export type { SanitizeUnicodeOptions } from './text-sanitize.js';
+export { sanitizeUnicodeText } from './text-sanitize.js';
+
 // task-ledger.ts (main agent session task tracking)
 export type {
   CreateTaskInput,

--- a/packages/core/src/session-name.ts
+++ b/packages/core/src/session-name.ts
@@ -18,35 +18,17 @@
  *   1. **Runtime type guard**: `typeof input !== 'string'` → typed
  *      reject. IPC payloads cross a process boundary; TypeScript
  *      signature alone is not enough.
- *   2. **NFC canonicalization**: `input.normalize('NFC')`. Combines
- *      composed forms so visually-identical strings hash equally.
- *      NOT a security boundary — it doesn't prevent bidi spoofing
- *      or zero-width injection.
- *   3. **C0/C1 control character → single space**: matches
- *      `\u0000-\u001F` (NUL through US), `\u007F` (DEL),
- *      `\u0080-\u009F` (C1 controls). Replaced with space (not
- *      removed) so `foo\nbar` becomes `foo bar`, not `foobar`.
- *   4. **Bidi format chars → single space**: U+202A..U+202E
- *      (LRE/RLE/PDF/LRO/RLO) and U+2066..U+2069 (LRI/RLI/FSI/PDI).
- *      Defense against right-to-left override spoofs that could
- *      make a session name display as something other than the
- *      stored bytes.
- *   5. **Zero-width format chars → removed**: U+200B (ZWSP),
- *      U+200C (ZWNJ), U+200D (ZWJ), U+FEFF (BOM). These are
- *      invisible characters that can be used to inject deceptive
- *      content into otherwise-identical-looking strings; removing
- *      (not space-replacing) avoids gratuitous spaces in legitimate
- *      Chinese/emoji text (which uses ZWJ internally for compound
- *      emoji).
- *   6. **Whitespace collapse**: any `\s+` → single space.
- *   7. **Trim**: leading/trailing whitespace removed.
- *   8. **Empty check**: if the result is empty, typed reject. The
- *      caller decides whether to fall back to a default or
- *      surface the error.
- *   9. **Code-point length cap (80)**: not byte length, not UTF-16
- *      code unit length — uses `Array.from(...)` to iterate by
- *      code points so a surrogate pair (emoji) isn't cut in half.
- *      80 matches the existing `store.rename` cap.
+ *   2. **Unicode sanitize + cap**: delegates to the shared
+ *      `sanitizeUnicodeText` helper in `text-sanitize.ts` (the single
+ *      source of truth shared with `foreign-session.ts`, #1404). That
+ *      pipeline is NFC → control/bidi chars → space, zero-width/invisible
+ *      chars → removed, whitespace collapse, trim, code-point cap. See its
+ *      module doc for the full char-class rationale. Here we pass
+ *      `truncatedSuffix: ''` so a capped name doesn't grow a visible
+ *      ellipsis in the sidebar.
+ *   3. **Empty check**: if the sanitized result is empty, typed reject.
+ *      The caller decides whether to fall back to a default or surface
+ *      the error.
  *
  * Returns `{ ok: true; value }` with the normalized canonical
  * string, or `{ ok: false; error }` with a typed reason.
@@ -63,6 +45,8 @@
  *     `'New Chat'`); this helper only accepts string inputs.
  */
 
+import { sanitizeUnicodeText } from './text-sanitize.js';
+
 export type NormalizeSessionNameResult = { ok: true; value: string } | { ok: false; error: string };
 
 export const DEFAULT_SESSION_NAME = 'New Chat';
@@ -73,72 +57,27 @@ export const DEFAULT_SESSION_NAME = 'New Chat';
  */
 export const SESSION_NAME_MAX_CODE_POINTS = 80;
 
-// PR-UI-IPC-2 review fixup v2 (@kenji msg f5daa4d4):
-// Regex character classes MUST use escaped `\uXXXX` ranges, NOT
-// literal control bytes. Literal U+0000 / bidi / zero-width
-// bytes in source make git treat the TS file as binary, which
-// breaks diff/patch review and the merge gate's source grep.
-// The `\u....` form compiles to an identical regex at runtime
-// but keeps the source readable as plain text.
-
-// C0 control characters: U+0000..U+001F (NUL through US),
-// U+007F (DEL), U+0080..U+009F (C1 controls). Replaced with
-// single space so multi-line input becomes readable single-line.
-const CONTROL_CHARS_REGEX = /[\u0000-\u001F\u007F-\u009F]/g;
-
-// Bidi format characters that can spoof display direction.
-// Replaced with space (not removed) so adjacent words remain
-// separated.
-//   U+202A LRE, U+202B RLE, U+202C PDF, U+202D LRO, U+202E RLO
-//   U+2066 LRI, U+2067 RLI, U+2068 FSI, U+2069 PDI
-const BIDI_FORMAT_REGEX = /[\u202A-\u202E\u2066-\u2069]/g;
-
-// Zero-width format characters. Removed entirely (no replacement)
-// because they're meant to be invisible and replacing with space
-// would inject visible whitespace into legitimate CJK/emoji
-// sequences that may contain ZWJ for compound emoji.
-//   U+200B ZWSP, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM
-const ZERO_WIDTH_REGEX = /[\u200B-\u200D\uFEFF]/g;
-
 export function normalizeUserSessionName(input: unknown): NormalizeSessionNameResult {
   // L1: runtime type guard — IPC payloads cross process boundary.
   if (typeof input !== 'string') {
     return { ok: false, error: 'Session name must be a string' };
   }
-  // L2: NFC canonicalization. Visually-equivalent composed forms
-  // get a single canonical representation. NOT a security
-  // boundary by itself — see L3-L5 for spoofing defenses.
-  const canonical = input.normalize('NFC');
-  // L3: C0/C1 controls → single space. `foo\nbar` becomes
-  // `foo bar`, not `foobar`.
-  const noControls = canonical.replace(CONTROL_CHARS_REGEX, ' ');
-  // L4: bidi format chars → single space. Defense against
-  // right-to-left override display spoofs.
-  const noBidi = noControls.replace(BIDI_FORMAT_REGEX, ' ');
-  // L5: zero-width format chars → removed. Defense against
-  // invisible-character injection. NOT space-replaced because
-  // legitimate compound emoji (e.g. 👨\u200D👩\u200D👧) use ZWJ internally
-  // and we want to remove them entirely from the title rather
-  // than visibly fragment text.
-  const noZeroWidth = noBidi.replace(ZERO_WIDTH_REGEX, '');
-  // L6: collapse internal whitespace runs to a single space.
-  const collapsed = noZeroWidth.replace(/\s+/g, ' ');
-  // L7: trim leading/trailing whitespace.
-  const trimmed = collapsed.trim();
-  // L8: empty-after-sanitize → reject. Caller decides whether to
-  // fall back to a default (e.g. `'New Chat'` for create) or
-  // surface the error (e.g. inline rename).
-  if (trimmed === '') {
+  // L2–L9: the shared Unicode pipeline (NFC, control/bidi → space,
+  // zero-width removal, whitespace collapse, trim, code-point cap). Lives in
+  // text-sanitize.ts so the session-name and foreign-session surfaces cannot
+  // drift apart again (#1404). We pass `truncatedSuffix: ''` to keep this
+  // surface's "silently cap at 80, no visible marker" behavior — a session
+  // name truncated mid-word should not grow a dangling ellipsis in the
+  // sidebar. Note the cap also runs the cleaner, so this one call covers both.
+  const value = sanitizeUnicodeText(input, {
+    maxCodePoints: SESSION_NAME_MAX_CODE_POINTS,
+    truncatedSuffix: '',
+  });
+  // Empty-after-sanitize → reject. Caller decides whether to fall back to a
+  // default (e.g. `'New Chat'` for create) or surface the error (e.g. inline
+  // rename). Done AFTER the pipeline so we catch "sanitizes down to nothing".
+  if (value === '') {
     return { ok: false, error: 'Session name cannot be empty after sanitization' };
   }
-  // L9: code-point cap. `Array.from(string)` iterates by code
-  // points so a surrogate pair (e.g. emoji `🦊` = U+1F98A,
-  // encoded as 2 UTF-16 code units) counts as one code point and
-  // never gets cut in half.
-  const codePoints = Array.from(trimmed);
-  if (codePoints.length > SESSION_NAME_MAX_CODE_POINTS) {
-    const capped = codePoints.slice(0, SESSION_NAME_MAX_CODE_POINTS).join('');
-    return { ok: true, value: capped };
-  }
-  return { ok: true, value: trimmed };
+  return { ok: true, value };
 }

--- a/packages/core/src/text-sanitize.ts
+++ b/packages/core/src/text-sanitize.ts
@@ -1,0 +1,89 @@
+/**
+ * Unicode text-sanitize pipeline — single source of truth (#1404).
+ *
+ * `session-name.ts` and `foreign-session.ts` each used to carry their own copy
+ * of the "NFC + control/bidi/zero-width + whitespace-collapse + code-point
+ * cap" pipeline, and the two had drifted: `session-name` was missing 8 code
+ * points that `foreign-session` (and its own `FOREIGN_UNSAFE_CHARS` id guard)
+ * already covered. This module is the one place that pipeline lives now.
+ *
+ * Boundary: this helper does ONE thing — given an already-type-checked string,
+ * clean it and cap it. It is deliberately agnostic about:
+ *   - the runtime type guard (`unknown` → reject vs coerce),
+ *   - the empty-after-sanitize policy (reject vs return `''`),
+ *   - the return shape (`Result` vs bare string).
+ * Those are caller policies and stay with the callers, so each surface keeps
+ * its existing contract while sharing the same character classes.
+ *
+ * NOT a security boundary on its own — NFC canonicalization doesn't stop bidi
+ * spoofing; the bidi/zero-width steps below do. Apply at every trust boundary
+ * where untrusted text may reach storage or a prompt.
+ */
+
+// Regex character classes use escaped `\uXXXX` ranges, NOT literal control
+// bytes: literal U+0000 / bidi / zero-width bytes in source make git treat the
+// TS file as binary, which breaks diff/patch review and the merge gate's
+// source grep. The `\u....` form compiles to an identical regex at runtime but
+// keeps the source readable as plain text.
+
+// C0 control characters: U+0000..U+001F (NUL through US), U+007F (DEL),
+// U+0080..U+009F (C1 controls). Replaced with single space so multi-line input
+// becomes readable single-line (`foo\nbar` → `foo bar`, not `foobar`).
+const CONTROL_CHARS_REGEX = /[\u0000-\u001F\u007F-\u009F]/g;
+
+// Bidi format characters that can spoof display direction. Replaced with space
+// (not removed) so adjacent words remain separated.
+//   U+061C  ALM (Arabic letter mark)
+//   U+200E  LRM (left-to-right mark)
+//   U+200F  RLM (right-to-left mark)
+//   U+202A  LRE, U+202B RLE, U+202C PDF, U+202D LRO, U+202E RLO
+//   U+2066  LRI, U+2067 RLI, U+2068 FSI, U+2069 PDI
+const BIDI_FORMAT_REGEX = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/g;
+
+// Zero-width / invisible format characters. Removed entirely (no replacement)
+// because they're meant to be invisible and replacing with space would inject
+// visible whitespace into legitimate CJK/emoji sequences that may contain ZWJ
+// for compound emoji. NOTE: U+200D (ZWJ) is in the set, but emoji that use ZWJ
+// internally are compound-grapheme sequences (👨‍👩‍👧); removing the joiner does
+// not corrupt the code points, it only splits the ligature rendering — the
+// lesser evil vs. leaving a zero-width injection vector open.
+//   U+200B  ZWSP, U+200C ZWNJ, U+200D ZWJ
+//   U+2060  WJ (word joiner), U+2061 IT, U+2062 IS, U+2063 IP, U+2064 IP
+//   U+FEFF  BOM / zero-width no-break space
+const ZERO_WIDTH_REGEX = /[\u200B-\u200D\u2060-\u2064\uFEFF]/g;
+
+export interface SanitizeUnicodeOptions {
+  /** Hard cap on the number of Unicode code points in the cleaned string. */
+  maxCodePoints: number;
+  /**
+   * Appended when the cleaned string exceeds `maxCodePoints` and is truncated.
+   * Defaults to `'…'`. Pass `''` for a silent cap (no visible marker).
+   */
+  truncatedSuffix?: string;
+}
+
+/**
+ * Clean and truncate untrusted Unicode text.
+ *
+ * Pipeline (applied in order): NFC → control chars → space, bidi format →
+ * space, zero-width/invisible → removed, whitespace collapse, trim, then
+ * code-point cap. The cap uses `Array.from(...)` to iterate by code points so a
+ * surrogate pair (e.g. `🦊` = U+1F98A, two UTF-16 code units) counts as one and
+ * is never split in half.
+ *
+ * Empty input (or input that sanitizes down to `''`) returns `''`; the caller
+ * decides whether that's acceptable.
+ */
+export function sanitizeUnicodeText(text: string, opts: SanitizeUnicodeOptions): string {
+  const suffix = opts.truncatedSuffix ?? '…';
+  const cleaned = text
+    .normalize('NFC')
+    .replace(CONTROL_CHARS_REGEX, ' ')
+    .replace(BIDI_FORMAT_REGEX, ' ')
+    .replace(ZERO_WIDTH_REGEX, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const points = Array.from(cleaned);
+  if (points.length <= opts.maxCodePoints) return cleaned;
+  return points.slice(0, opts.maxCodePoints).join('') + suffix;
+}


### PR DESCRIPTION
# Summary

- foreign-session.ts:sanitizeForeignText duplicated the session-name.ts unicode pipeline and the two had drifted — session-name was missing 8 code points that foreign-session (and its own FOREIGN_UNSAFE_CHARS id guard) already covered: U+061C, U+200E, U+200F (bidi marks) and U+2060–U+2064 (invisible format chars).

- I extracted the pipeline into a shared pure helper sanitizeUnicodeText(text, {maxCodePoints, truncatedSuffix}) in a new packages/core/src/text-sanitize.ts leaf module, which now holds the three character-class regexes as the single source of truth. The character classes take the union — the stricter foreign-session coverage — so session-name picks up the 8 previously-missing code points as a pure coverage gain (they never appear in legitimate CJK/emoji text, so no false positives).

- Because the two callers disagree on truncation behavior and both are pinned by existing tests, I parameterized the suffix: foreign-session appends … (the default), while session-name passes '' to preserve its silent-cap behavior. The helper boundary is clean-and-truncate only; the type guard, empty-string policy, and Result-vs-string return shape stay with each caller, so both export signatures are unchanged and no downstream caller needs edits.

- foreign-session.ts:sanitizeForeignText is now a thin wrapper around the helper, and session-name.ts:normalizeUserSessionName calls it with truncatedSuffix: '' (net −59 lines). I also exported sanitizeUnicodeText from index.ts and added one session-name test case locking in the newly-covered bidi marks and invisible operators so they can't silently drift back out of sync. FOREIGN_UNSAFE_CHARS and isSafeForeignId (the verbatim-rendered id guard) are a separate concern and left untouched.

Refs: #1404 

# Verification
- npm run format:check
- npm run lint
- npm run typecheck (packages/core) — passed, 0 errors
- npm --workspace @maka/core run build — passed
- npm --workspace @maka/core run test:dist -- 782 passed
