### PR TITLE
feat(desktop): add Runtime Host Bot adapter

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-incoming-goal-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-goal-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@maka/runtime';
 import type { SessionEvent } from '@maka/core';
 import { createBotIncomingMainService } from '../bot-incoming-main.js';
+import { createEmbeddedBotSessionAdapter } from '../embedded-bot-session-adapter.js';
 import { startDesktopSessionTurn } from '../session-turn-stream.js';
 
 const SESSION_ID = 'bot-session';
@@ -67,8 +68,6 @@ describe('bot incoming Goal lifecycle', () => {
     } as unknown as SessionManager;
 
     const service = createBotIncomingMainService({
-      runtime,
-      createSession: (input) => runtime.createSession({ ...input, cwd: input.cwd ?? '/repo' }),
       botRegistry: {
         async sendMessage(_platform: string, _chatId: string, text: string) {
           replies.push(text);
@@ -78,33 +77,48 @@ describe('bot incoming Goal lifecycle', () => {
           return true;
         },
       } as unknown as BotRegistry,
-      getDefaultConnectionSlug: async () => 'provider',
-      getReadyConnection: async () => ({ connection: { slug: 'provider' }, model: 'model' }),
-      readSessionHeader: async () => ({ permissionMode: 'explore', isArchived: false, status: 'active' }),
-      ensureSessionCanSend: async () => {},
-      emitSessionsChanged() {},
-      async runAgentTurn(input) {
-        runnerCalls++;
-        const started = startDesktopSessionTurn({
-          sessionId: input.sessionId,
-          events: input.iterator,
-          turnId: input.turnId,
-          goalBoundary: 'external',
-          activities,
-          beginObservedTurn: (sessionId, turnId) => coordinator.beginObservedTurn(sessionId, turnId),
-          onEvent: input.onEvent,
-          onStreamError: (error) => { assert.fail(String(error)); },
-          onDrained: () => {},
-        });
-        assert.equal(started.kind, 'started');
-        const outcome = await started.completion;
-        return {
-          outcome,
-          ...((outcome.kind === 'errored' || outcome.kind === 'suspended')
-            ? { error: outcome.reason }
-            : {}),
-        };
-      },
+      sessions: createEmbeddedBotSessionAdapter({
+        runtime,
+        createSession: (input) =>
+          runtime.createSession({ ...input, cwd: input.cwd ?? '/repo' }),
+        getDefaultConnectionSlug: async () => 'provider',
+        getReadyConnection: async () => ({
+          connection: { slug: 'provider' },
+          model: 'model',
+        }),
+        readSessionHeader: async () => ({
+          permissionMode: 'explore',
+          isArchived: false,
+          status: 'active',
+        }),
+        ensureSessionCanSend: async () => {},
+        emitSessionsChanged() {},
+        async runAgentTurn(input) {
+          runnerCalls++;
+          const started = startDesktopSessionTurn({
+            sessionId: input.sessionId,
+            events: input.iterator,
+            turnId: input.turnId,
+            goalBoundary: 'external',
+            activities,
+            beginObservedTurn: (sessionId, turnId) =>
+              coordinator.beginObservedTurn(sessionId, turnId),
+            onEvent: input.onEvent,
+            onStreamError: (error) => {
+              assert.fail(String(error));
+            },
+            onDrained: () => {},
+          });
+          assert.equal(started.kind, 'started');
+          const outcome = await started.completion;
+          return {
+            outcome,
+            ...(outcome.kind === 'errored' || outcome.kind === 'suspended'
+              ? { error: outcome.reason }
+              : {}),
+          };
+        },
+      }),
     });
 
     await service.handleBotIncomingMessage({

--- a/apps/desktop/src/main/__tests__/bot-incoming-project-cwd.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-project-cwd.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import type { BotIncomingMessage, BotRegistry, SessionManager } from '@maka/runtime';
 import { createBotIncomingMainService } from '../bot-incoming-main.js';
+import { createEmbeddedBotSessionAdapter } from '../embedded-bot-session-adapter.js';
 
 describe('bot incoming new-session cwd', () => {
   it('leaves the cwd to the shared desktop session resolver', async () => {
@@ -11,14 +12,6 @@ describe('bot incoming new-session cwd', () => {
       resolveCreated = resolve;
     });
     const service = createBotIncomingMainService({
-      // createSession captures the cwd it was given, signals the test, then
-      // throws to short-circuit before the streaming / typing path runs.
-      runtime: {} as SessionManager,
-      async createSession(input) {
-        capturedCwd = input.cwd;
-        resolveCreated();
-        throw new Error('__short_circuit_after_create__');
-      },
       botRegistry: {
         async sendMessage() {},
         async sendTypingIndicator() {
@@ -28,14 +21,28 @@ describe('bot incoming new-session cwd', () => {
           return true;
         },
       } as unknown as BotRegistry,
-      getDefaultConnectionSlug: async () => 'slug',
-      getReadyConnection: async () => ({ connection: { slug: 'slug' }, model: 'm' }),
-      readSessionHeader: async () => ({ permissionMode: 'ask', isArchived: false, status: 'active' }),
-      ensureSessionCanSend: async () => {},
-      emitSessionsChanged() {},
-      async runAgentTurn() {
-        throw new Error('runAgentTurn must not be reached');
-      },
+      sessions: createEmbeddedBotSessionAdapter({
+        runtime: {} as SessionManager,
+        // createSession captures the cwd it was given, signals the test, then
+        // throws to short-circuit before the streaming / typing path runs.
+        async createSession(input) {
+          capturedCwd = input.cwd;
+          resolveCreated();
+          throw new Error('__short_circuit_after_create__');
+        },
+        getDefaultConnectionSlug: async () => 'slug',
+        getReadyConnection: async () => ({ connection: { slug: 'slug' }, model: 'm' }),
+        readSessionHeader: async () => ({
+          permissionMode: 'ask',
+          isArchived: false,
+          status: 'active',
+        }),
+        ensureSessionCanSend: async () => {},
+        emitSessionsChanged() {},
+        async runAgentTurn() {
+          throw new Error('runAgentTurn must not be reached');
+        },
+      }),
     });
 
     await service.handleBotIncomingMessage({
@@ -53,7 +60,9 @@ describe('bot incoming new-session cwd', () => {
     // for createSession to actually be invoked (or time out).
     await Promise.race([
       created,
-      new Promise<void>((_, reject) => setTimeout(() => reject(new Error('createSession was not called')), 1000)),
+      new Promise<void>((_, reject) =>
+        setTimeout(() => reject(new Error('createSession was not called')), 1000),
+      ),
     ]);
 
     assert.equal(capturedCwd, undefined);

--- a/apps/desktop/src/main/__tests__/bot-incoming-session-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-session-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 import type { BotIncomingMessage, BotRegistry, SessionManager } from '@maka/runtime';
 import type { SessionEvent } from '@maka/core';
 import { createBotIncomingMainService } from '../bot-incoming-main.js';
+import { createEmbeddedBotSessionAdapter } from '../embedded-bot-session-adapter.js';
 import { SessionLifecycleError } from '../session-lifecycle.js';
 
 async function waitFor(predicate: () => boolean): Promise<void> {
@@ -43,8 +44,6 @@ describe('bot session lifecycle bindings', () => {
     } as unknown as SessionManager;
 
     const service = createBotIncomingMainService({
-      runtime,
-      createSession: (input) => runtime.createSession({ ...input, cwd: input.cwd ?? '/repo' }),
       botRegistry: {
         async sendMessage(_platform: string, _chatId: string, text: string) {
           replies.push(text);
@@ -54,20 +53,32 @@ describe('bot session lifecycle bindings', () => {
           return true;
         },
       } as unknown as BotRegistry,
-      getDefaultConnectionSlug: async () => 'provider',
-      getReadyConnection: async () => ({ connection: { slug: 'provider' }, model: 'model' }),
-      readSessionHeader: async () => ({ permissionMode: 'explore', isArchived: false, status: 'active' }),
-      ensureSessionCanSend: async (sessionId) => {
-        ensureCalls += 1;
-        if (sessionId === 'bot-session-1' && ensureCalls === 2) {
-          throw new SessionLifecycleError('archived');
-        }
-      },
-      emitSessionsChanged() {},
-      runAgentTurn: async ({ iterator, turnId, onEvent }) => {
-        for await (const event of iterator) onEvent(event);
-        return { outcome: { kind: 'completed', turnId } } as never;
-      },
+      sessions: createEmbeddedBotSessionAdapter({
+        runtime,
+        createSession: (input) =>
+          runtime.createSession({ ...input, cwd: input.cwd ?? '/repo' }),
+        getDefaultConnectionSlug: async () => 'provider',
+        getReadyConnection: async () => ({
+          connection: { slug: 'provider' },
+          model: 'model',
+        }),
+        readSessionHeader: async () => ({
+          permissionMode: 'explore',
+          isArchived: false,
+          status: 'active',
+        }),
+        ensureSessionCanSend: async (sessionId) => {
+          ensureCalls += 1;
+          if (sessionId === 'bot-session-1' && ensureCalls === 2) {
+            throw new SessionLifecycleError('archived');
+          }
+        },
+        emitSessionsChanged() {},
+        runAgentTurn: async ({ iterator, turnId, onEvent }) => {
+          for await (const event of iterator) onEvent(event);
+          return { outcome: { kind: 'completed', turnId } } as never;
+        },
+      }),
     });
 
     const base = {

--- a/apps/desktop/src/main/__tests__/bot-incoming-typing.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-typing.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
 import { getEventListeners } from 'node:events';
 import { test } from 'node:test';
-import type { BotIncomingMessage, BotRegistry, SessionManager } from '@maka/runtime';
-import type { SessionEvent } from '@maka/core';
+import type { BotIncomingMessage, BotRegistry } from '@maka/runtime';
 import { createBotIncomingMainService } from '../bot-incoming-main.js';
 
 async function waitFor(predicate: () => boolean, message: string): Promise<void> {
@@ -31,17 +30,7 @@ test('the bot typing loop owns only its active abort listener', async (t) => {
   });
   let typingAttempts = 0;
   const replies: string[] = [];
-  const runtime = {
-    async createSession() {
-      return { id: 'bot-session' };
-    },
-    sendMessage() {
-      return (async function* (): AsyncIterable<SessionEvent> {})();
-    },
-  } as unknown as SessionManager;
   const service = createBotIncomingMainService({
-    runtime,
-    createSession: (input) => runtime.createSession({ ...input, cwd: input.cwd ?? '/repo' }),
     botRegistry: {
       async sendMessage(_platform: string, _chatId: string, text: string) {
         replies.push(text);
@@ -52,22 +41,17 @@ test('the bot typing loop owns only its active abort listener', async (t) => {
         throw new Error('typing unavailable');
       },
     } as unknown as BotRegistry,
-    getDefaultConnectionSlug: async () => 'provider',
-    getReadyConnection: async () => ({ connection: { slug: 'provider' }, model: 'model' }),
-    readSessionHeader: async () => ({ permissionMode: 'explore', isArchived: false, status: 'active' }),
-    ensureSessionCanSend: async () => {},
-    emitSessionsChanged() {},
-    runAgentTurn: async ({ turnId, onEvent }) => {
-      await turnReleased;
-      onEvent({
-        type: 'text_complete',
-        id: 'text',
-        turnId,
-        ts: Date.now(),
-        messageId: 'assistant',
-        text: 'Bot reply',
-      });
-      return { outcome: { kind: 'completed', turnId } } as never;
+    sessions: {
+      async createSession() {
+        return 'bot-session';
+      },
+      async prepareSession() {
+        return 'ready';
+      },
+      async runTurn() {
+        await turnReleased;
+        return { kind: 'completed', text: 'Bot reply' };
+      },
     },
   });
 

--- a/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
@@ -1,0 +1,338 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RuntimeHostOperationError } from '@maka/runtime-host/client';
+import type {
+  SessionCatalogProjection,
+  SessionContinuitySnapshot,
+  SubscriptionFrame,
+  TurnSnapshot,
+} from '@maka/runtime-host/protocol';
+import { BotSessionUnavailableError } from '../bot-session-adapter.js';
+import {
+  createRuntimeHostBotSessionAdapter,
+  type RuntimeHostBotSessionAdapterDeps,
+} from '../runtime-host-bot-session-adapter.js';
+import type { DesktopRuntimeHostSession } from '../runtime-host-client.js';
+
+type BotClient = RuntimeHostBotSessionAdapterDeps['client'];
+
+test('creates an explore Session through the Host-owned default model route', async () => {
+  const creates: unknown[] = [];
+  const changes: unknown[] = [];
+  const client = botClient({
+    createSession: async (input) => {
+      creates.push(input);
+      return session(input.sessionId, { permissionMode: 'explore' });
+    },
+  });
+  const adapter = createRuntimeHostBotSessionAdapter({
+    client,
+    resolveCreateTarget: async () => ({ cwd: '/workspace', projectId: 'project-1' }),
+    emitSessionsChanged: (reason, sessionId, extra) =>
+      changes.push({ reason, sessionId, extra }),
+    newId: () => 'bot-session-1',
+  });
+
+  const sessionId = await adapter.createSession({
+    name: 'Telegram conversation',
+    labels: ['bot', 'telegram'],
+  });
+
+  assert.equal(sessionId, 'bot-session-1');
+  assert.deepEqual(creates, [
+    {
+      sessionId: 'bot-session-1',
+      cwd: '/workspace',
+      projectId: 'project-1',
+      name: 'Telegram conversation',
+      labels: ['bot', 'telegram'],
+      modelTarget: { kind: 'default' },
+      permissionMode: 'explore',
+    },
+  ]);
+  assert.deepEqual(changes, [
+    { reason: 'created', sessionId: 'bot-session-1', extra: undefined },
+  ]);
+});
+
+test('prepares a bound Session without exposing Host configuration revisions to the Bot', async () => {
+  const updates: unknown[] = [];
+  const client = botClient({
+    getSession: async () => session('bot-session-1', { permissionMode: 'ask' }),
+    updateSessionConfiguration: async (sessionId, patch) => {
+      updates.push({ sessionId, patch });
+      return session(sessionId, { permissionMode: 'explore' });
+    },
+  });
+  const adapter = createRuntimeHostBotSessionAdapter({
+    client,
+    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    emitSessionsChanged() {},
+  });
+
+  assert.equal(await adapter.prepareSession('bot-session-1'), 'ready');
+  assert.deepEqual(updates, [
+    { sessionId: 'bot-session-1', patch: { permissionMode: 'explore' } },
+  ]);
+
+  const unavailable = createRuntimeHostBotSessionAdapter({
+    client: botClient({ getSession: async () => null }),
+    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    emitSessionsChanged() {},
+  });
+  await assert.rejects(
+    unavailable.prepareSession('removed-session'),
+    BotSessionUnavailableError,
+  );
+});
+
+test('reconciles an uncertain Host Session create with its stable Session identity', async () => {
+  const adapter = createRuntimeHostBotSessionAdapter({
+    client: botClient({
+      createSession: async () => {
+        throw new RuntimeHostOperationError(
+          'session.create',
+          'commit_outcome_unknown',
+          'response lost',
+        );
+      },
+      getSession: async (sessionId) => session(sessionId, { permissionMode: 'explore' }),
+    }),
+    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    emitSessionsChanged() {},
+    newId: () => 'stable-session-id',
+  });
+
+  assert.equal(
+    await adapter.createSession({ name: 'Bot conversation', labels: ['bot'] }),
+    'stable-session-id',
+  );
+});
+
+test('subscribes before Turn start and settles a fast Host reply without losing text', async () => {
+  const events = new AsyncFrameQueue();
+  const changes: unknown[] = [];
+  let closeCount = 0;
+  const handle: DesktopRuntimeHostSession = {
+    snapshot: continuitySnapshot(null),
+    transcript: Promise.resolve([]),
+    events,
+    async close() {
+      closeCount += 1;
+      events.end();
+    },
+  };
+  const client = botClient({
+    openSession: async () => handle,
+    startTurn: async (input) => {
+      assert.equal(events.nextCount, 1, 'the subscription must be draining before Turn start');
+      events.push(projectionFrame(1, runningTurn(input.sessionId, input.turnId)));
+      events.push(deltaFrame(2, input.sessionId, input.turnId, 0, 'Hello'));
+      events.push(deltaFrame(3, input.sessionId, input.turnId, 3, 'lo world'));
+      events.push(
+        projectionFrame(4, {
+          ...runningTurn(input.sessionId, input.turnId),
+          status: 'completed',
+          terminalEventId: 'terminal-1',
+        }),
+      );
+      return runningTurn(input.sessionId, input.turnId);
+    },
+  });
+  const adapter = createRuntimeHostBotSessionAdapter({
+    client,
+    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    emitSessionsChanged: (reason, sessionId, extra) =>
+      changes.push({ reason, sessionId, extra }),
+  });
+
+  const result = await adapter.runTurn({
+    sessionId: 'bot-session-1',
+    turnId: 'turn-1',
+    text: 'hello',
+  });
+
+  assert.deepEqual(result, { kind: 'completed', text: 'Hello world' });
+  assert.equal(closeCount, 1);
+  assert.deepEqual(changes, [
+    {
+      reason: 'status-change',
+      sessionId: 'bot-session-1',
+      extra: { turnId: 'turn-1' },
+    },
+  ]);
+});
+
+test('projects Host interaction and failure outcomes into the Bot reply contract', async () => {
+  const suspended = await runProjectedTurn({
+    ...runningTurn('bot-session-1', 'turn-1'),
+    status: 'waiting_for_user',
+  });
+  const failed = await runProjectedTurn({
+    ...runningTurn('bot-session-1', 'turn-1'),
+    status: 'failed',
+    terminalEventId: 'terminal-1',
+    failureClass: 'model_unavailable',
+  });
+
+  assert.deepEqual(suspended, { kind: 'suspended' });
+  assert.deepEqual(failed, { kind: 'errored', reason: 'model_unavailable' });
+});
+
+async function runProjectedTurn(rootTurn: TurnSnapshot) {
+  const events = new AsyncFrameQueue();
+  const adapter = createRuntimeHostBotSessionAdapter({
+    client: botClient({
+      openSession: async () => ({
+        snapshot: continuitySnapshot(null),
+        transcript: Promise.resolve([]),
+        events,
+        async close() {
+          events.end();
+        },
+      }),
+      startTurn: async () => {
+        events.push(projectionFrame(1, rootTurn));
+        return runningTurn(rootTurn.sessionId, rootTurn.turnId);
+      },
+    }),
+    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    emitSessionsChanged() {},
+  });
+  return adapter.runTurn({
+    sessionId: rootTurn.sessionId,
+    turnId: rootTurn.turnId,
+    text: 'hello',
+  });
+}
+
+function botClient(overrides: Partial<BotClient>): BotClient {
+  const unexpected = (): never => {
+    throw new Error('Unexpected Runtime Host Bot client call');
+  };
+  return {
+    createSession: unexpected,
+    getSession: unexpected,
+    openSession: unexpected,
+    startTurn: unexpected,
+    updateSessionConfiguration: unexpected,
+    ...overrides,
+  };
+}
+
+function session(
+  id: string,
+  overrides: Partial<SessionCatalogProjection> = {},
+): SessionCatalogProjection {
+  return {
+    id,
+    revision: 1,
+    cwd: '/workspace',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: id,
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    labelsTruncated: false,
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test-connection',
+    connectionLocked: false,
+    model: 'test-model',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+    ...overrides,
+  };
+}
+
+function runningTurn(sessionId: string, turnId: string): TurnSnapshot {
+  return { sessionId, turnId, runId: 'run-1', status: 'running' };
+}
+
+function continuitySnapshot(rootTurn: TurnSnapshot | null): SessionContinuitySnapshot {
+  return {
+    schemaVersion: 3,
+    session: {
+      sessionId: 'bot-session-1',
+      metadataRevision: 1,
+      status: rootTurn ? 'running' : 'active',
+      createdAt: 1,
+      lastUsedAt: 1,
+      isArchived: false,
+    },
+    projectionRevision: 1,
+    rootTurn,
+    goal: null,
+    queue: { hostEpoch: 'host-1', queueRevision: 0, steering: [], followup: [] },
+    interactions: { pending: [] },
+  };
+}
+
+function projectionFrame(sequence: number, rootTurn: TurnSnapshot): SubscriptionFrame {
+  return {
+    kind: 'subscription.session_projection',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence,
+    snapshot: continuitySnapshot(rootTurn),
+  };
+}
+
+function deltaFrame(
+  sequence: number,
+  sessionId: string,
+  turnId: string,
+  startOffset: number,
+  text: string,
+): SubscriptionFrame {
+  return {
+    kind: 'subscription.session_delta',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence,
+    sessionId,
+    delta: {
+      kind: 'text',
+      turnId,
+      runId: 'run-1',
+      messageId: 'message-1',
+      startOffset,
+      text,
+    },
+  };
+}
+
+class AsyncFrameQueue implements AsyncIterable<SubscriptionFrame> {
+  readonly #frames: SubscriptionFrame[] = [];
+  readonly #waiters: Array<(result: IteratorResult<SubscriptionFrame>) => void> = [];
+  nextCount = 0;
+  #ended = false;
+
+  push(frame: SubscriptionFrame): void {
+    const waiter = this.#waiters.shift();
+    if (waiter) waiter({ value: frame, done: false });
+    else this.#frames.push(frame);
+  }
+
+  end(): void {
+    this.#ended = true;
+    for (const waiter of this.#waiters.splice(0)) {
+      waiter({ value: undefined, done: true });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<SubscriptionFrame> {
+    return {
+      next: () => {
+        this.nextCount += 1;
+        const frame = this.#frames.shift();
+        if (frame) return Promise.resolve({ value: frame, done: false });
+        if (this.#ended) return Promise.resolve({ value: undefined, done: true });
+        return new Promise((resolve) => this.#waiters.push(resolve));
+      },
+    };
+  }
+}

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -104,6 +104,7 @@ import { createMainWindowController } from './main-window.js';
 import { createDailyReviewMainService } from './daily-review-main.js';
 import { createPlanReminderMainService } from './plan-reminders-main.js';
 import { createBotIncomingMainService } from './bot-incoming-main.js';
+import { createEmbeddedBotSessionAdapter } from './embedded-bot-session-adapter.js';
 import { createSubscriptionModelFetch } from './subscription-model-fetch.js';
 import { createSystemPromptMainService } from './system-prompt-main.js';
 import { createMainTaskLedgerWiring } from './task-ledger-wiring.js';
@@ -1070,24 +1071,27 @@ const dailyReview = createDailyReviewMainService({
   buildSubscriptionModelFetch,
 });
 botIncoming = createBotIncomingMainService({
-  runtime,
-  createSession: createDesktopSession,
   botRegistry,
-  getDefaultConnectionSlug: () => connectionStore.getDefault(),
-  getReadyConnection,
-  readSessionHeader: async (sessionId) => {
-    try {
-      return await store.readHeader(sessionId);
-    } catch (error) {
-      throw sessionLifecycleErrorFromReadFailure(error) ?? error;
-    }
-  },
-  ensureSessionCanSend,
-  emitSessionsChanged,
-  runAgentTurn: ({ sessionId, iterator, turnId, onEvent }) => streamEvents(sessionId, iterator, {
-    turnId,
-    goalBoundary: 'external',
-    observeEvent: onEvent,
+  sessions: createEmbeddedBotSessionAdapter({
+    runtime,
+    createSession: createDesktopSession,
+    getDefaultConnectionSlug: () => connectionStore.getDefault(),
+    getReadyConnection,
+    readSessionHeader: async (sessionId) => {
+      try {
+        return await store.readHeader(sessionId);
+      } catch (error) {
+        throw sessionLifecycleErrorFromReadFailure(error) ?? error;
+      }
+    },
+    ensureSessionCanSend,
+    emitSessionsChanged,
+    runAgentTurn: ({ sessionId, iterator, turnId, onEvent }) =>
+      streamEvents(sessionId, iterator, {
+        turnId,
+        goalBoundary: 'external',
+        observeEvent: onEvent,
+      }),
   }),
 });
 

--- a/apps/desktop/src/main/bot-incoming-main.ts
+++ b/apps/desktop/src/main/bot-incoming-main.ts
@@ -10,23 +10,10 @@ import {
   nonTextMessageAck,
   plaintextHelpReply,
 } from '@maka/core';
-import type {
-  SessionChangedEvent,
-  SessionChangedReason,
-  SessionEvent,
-} from '@maka/core';
-import type {
-  BotIncomingMessage,
-  BotRegistry,
-  GoalTurnOutcome,
-  SessionManager,
-} from '@maka/runtime';
-import type { DesktopCreateSessionInput } from './new-session-project.js';
+import type { BotIncomingMessage, BotRegistry } from '@maka/runtime';
+import type { BotSessionAdapter, BotSessionTurnResult } from './bot-session-adapter.js';
+import { isBotSessionUnavailableError } from './bot-session-adapter.js';
 import { isSessionWorkspaceUnavailableError } from './project-context-root.js';
-import {
-  assertSessionCanSendFromHeader,
-  isSessionLifecycleError,
-} from './session-lifecycle.js';
 
 const BOT_RECENT_SOURCE_EVENT_LIMIT = 1_000;
 const BOT_RECENT_SOURCE_EVENT_TTL_MS = 60 * 60 * 1_000;
@@ -47,33 +34,8 @@ export interface BotIncomingMainService {
 }
 
 interface BotIncomingMainServiceDeps {
-  runtime: SessionManager;
-  createSession: (
-    input: DesktopCreateSessionInput,
-  ) => ReturnType<SessionManager['createSession']>;
+  sessions: BotSessionAdapter;
   botRegistry: BotRegistry;
-  getDefaultConnectionSlug(): Promise<string | null>;
-  getReadyConnection(
-    slug: string | null | undefined,
-    model?: string,
-  ): Promise<{ connection: { slug: string }; model: string }>;
-  readSessionHeader(sessionId: string): Promise<{
-    permissionMode: string;
-    isArchived: boolean;
-    status: string;
-  }>;
-  ensureSessionCanSend(sessionId: string): Promise<void>;
-  emitSessionsChanged(
-    reason: SessionChangedReason,
-    sessionId?: string,
-    extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId'>,
-  ): void;
-  runAgentTurn(input: {
-    sessionId: string;
-    iterator: AsyncIterable<SessionEvent>;
-    turnId: string;
-    onEvent: (event: SessionEvent) => void;
-  }): Promise<{ outcome: GoalTurnOutcome; error?: string }>;
 }
 
 export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): BotIncomingMainService {
@@ -202,19 +164,12 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
       await sendTransientBotNotice(message, 'Maka 收到的机器人消息过于频繁，请稍后再试。', noticeTtlMs);
       return undefined;
     }
-    const ready = await deps.getReadyConnection(await deps.getDefaultConnectionSlug(), undefined);
-    const summary = await deps.createSession({
-      backend: 'ai-sdk',
-      llmConnectionSlug: ready.connection.slug,
-      model: ready.model,
-      permissionMode: 'explore',
+    const sessionId = await deps.sessions.createSession({
       name: `${botDisplayLabel(message.platform)} 对话`,
       labels: ['bot', message.platform],
     });
-    botConversationSessions.set(conversationKey, summary.id);
-    deps.emitSessionsChanged('created', summary.id);
-    await deps.ensureSessionCanSend(summary.id);
-    return summary.id;
+    botConversationSessions.set(conversationKey, sessionId);
+    return sessionId;
   }
 
   async function processBotIncomingMessage(
@@ -265,47 +220,29 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
     let sessionId = botConversationSessions.get(conversationKey);
     try {
       if (!sessionId) {
-        if (botConversationSessions.size >= BOT_CONVERSATION_SESSION_LIMIT) {
-          await sendTransientBotNotice(
-            message,
-            'Maka 当前机器人会话数量已达上限，请重置或清理旧会话后再试。',
-            SYSTEM_NOTICE_TTL_MS,
-          );
-          return;
-        }
-        if (!consumeBotConversationToken(conversationKey)) {
-          await sendTransientBotNotice(
-            message,
-            'Maka 收到的机器人消息过于频繁，请稍后再试。',
-            SYSTEM_NOTICE_TTL_MS,
-          );
-          return;
-        }
-        const ready = await deps.getReadyConnection(await deps.getDefaultConnectionSlug(), undefined);
-        const summary = await deps.createSession({
-          backend: 'ai-sdk',
-          llmConnectionSlug: ready.connection.slug,
-          model: ready.model,
-          // Bot conversations must not execute local side effects without an
-          // in-app approval surface. Explore allows read/web-read only.
-          permissionMode: 'explore',
-          name: `${botDisplayLabel(message.platform)} 对话`,
-          labels: ['bot', message.platform],
-        });
-        sessionId = summary.id;
-        botConversationSessions.set(conversationKey, sessionId);
-        deps.emitSessionsChanged('created', sessionId);
-        await deps.ensureSessionCanSend(sessionId);
+        sessionId = await createBotConversationSession(
+          conversationKey,
+          message,
+          SYSTEM_NOTICE_TTL_MS,
+        );
+        if (!sessionId) return;
       } else {
         let rebound = false;
         try {
-          const permissionModeOk = await ensureBotSessionExploreMode(sessionId, message, SYSTEM_NOTICE_TTL_MS);
+          const permissionModeOk = await ensureBotSessionExploreMode(
+            sessionId,
+            message,
+            SYSTEM_NOTICE_TTL_MS,
+          );
           if (!permissionModeOk) return;
-          await deps.ensureSessionCanSend(sessionId);
         } catch (error) {
-          if (!isSessionLifecycleError(error)) throw error;
+          if (!isBotSessionUnavailableError(error)) throw error;
           invalidateSessionBindings(sessionId);
-          sessionId = await createBotConversationSession(conversationKey, message, SYSTEM_NOTICE_TTL_MS);
+          sessionId = await createBotConversationSession(
+            conversationKey,
+            message,
+            SYSTEM_NOTICE_TTL_MS,
+          );
           if (!sessionId) return;
           rebound = true;
         }
@@ -320,7 +257,8 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
       }
 
       const turnId = randomUUID();
-      const iterator = deps.runtime.sendMessage(sessionId, {
+      const turn = deps.sessions.runTurn({
+        sessionId,
         turnId,
         text: formatBotMessageForSession({ ...message, text }),
       });
@@ -353,7 +291,7 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
       })();
       let reply: string;
       try {
-        reply = await collectBotReply(sessionId, iterator, turnId);
+        reply = botReply(await turn);
       } finally {
         typingAbort.abort();
         await typingLoop.catch(() => {});
@@ -406,44 +344,22 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
     message: BotIncomingMessage,
     noticeTtlMs: number,
   ): Promise<boolean> {
-    const header = await deps.readSessionHeader(sessionId);
-    assertSessionCanSendFromHeader(header);
-    try {
-      await deps.runtime.setPermissionMode(sessionId, 'explore');
-      deps.emitSessionsChanged('updated', sessionId);
-      return true;
-    } catch {
-      await sendTransientBotNotice(
-        message,
-        'Maka 已拒绝这条机器人消息：绑定会话当前不是只读探索模式，请先在桌面端切回 explore 后再试。',
-        noticeTtlMs,
-      );
-      return false;
-    }
-  }
-
-  async function collectBotReply(
-    sessionId: string,
-    iterator: AsyncIterable<SessionEvent>,
-    turnId: string,
-  ): Promise<string> {
-    let latestText = '';
-    const result = await deps.runAgentTurn({
-      sessionId,
-      iterator,
-      turnId,
-      onEvent: (event) => {
-        if (event.type === 'text_complete') latestText = event.text;
-      },
-    });
-    if (result.outcome.kind === 'suspended') {
-      return '这条请求需要在 Maka 桌面端审批后才能继续。';
-    }
-    if (result.outcome.kind === 'errored') {
-      return `Maka 处理失败：${result.error ?? result.outcome.reason}`;
-    }
-    return latestText;
+    if ((await deps.sessions.prepareSession(sessionId)) === 'ready') return true;
+    await sendTransientBotNotice(
+      message,
+      'Maka 已拒绝这条机器人消息：绑定会话当前不是只读探索模式，请先在桌面端切回 explore 后再试。',
+      noticeTtlMs,
+    );
+    return false;
   }
 
   return { handleBotIncomingMessage, invalidateSessionBindings };
+}
+
+function botReply(result: BotSessionTurnResult): string {
+  if (result.kind === 'suspended') {
+    return '这条请求需要在 Maka 桌面端审批后才能继续。';
+  }
+  if (result.kind === 'errored') return `Maka 处理失败：${result.reason}`;
+  return result.text;
 }

--- a/apps/desktop/src/main/bot-session-adapter.ts
+++ b/apps/desktop/src/main/bot-session-adapter.ts
@@ -1,0 +1,34 @@
+export interface BotSessionCreateInput {
+  readonly name: string;
+  readonly labels: readonly string[];
+}
+
+export type BotSessionPreparation = 'ready' | 'permission_refused';
+
+export type BotSessionTurnResult =
+  | { readonly kind: 'completed'; readonly text: string }
+  | { readonly kind: 'suspended' }
+  | { readonly kind: 'errored'; readonly reason: string };
+
+export interface BotSessionAdapter {
+  createSession(input: BotSessionCreateInput): Promise<string>;
+  prepareSession(sessionId: string): Promise<BotSessionPreparation>;
+  runTurn(input: {
+    readonly sessionId: string;
+    readonly turnId: string;
+    readonly text: string;
+  }): Promise<BotSessionTurnResult>;
+}
+
+export class BotSessionUnavailableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'BotSessionUnavailableError';
+  }
+}
+
+export function isBotSessionUnavailableError(
+  error: unknown,
+): error is BotSessionUnavailableError {
+  return error instanceof BotSessionUnavailableError;
+}

--- a/apps/desktop/src/main/embedded-bot-session-adapter.ts
+++ b/apps/desktop/src/main/embedded-bot-session-adapter.ts
@@ -1,0 +1,104 @@
+import type { SessionChangedEvent, SessionChangedReason, SessionEvent } from '@maka/core';
+import type { GoalTurnOutcome, SessionManager } from '@maka/runtime';
+import {
+  BotSessionUnavailableError,
+  type BotSessionAdapter,
+} from './bot-session-adapter.js';
+import type { DesktopCreateSessionInput } from './new-session-project.js';
+import {
+  assertSessionCanSendFromHeader,
+  isSessionLifecycleError,
+} from './session-lifecycle.js';
+
+interface EmbeddedBotSessionAdapterDeps {
+  runtime: SessionManager;
+  createSession: (
+    input: DesktopCreateSessionInput,
+  ) => ReturnType<SessionManager['createSession']>;
+  getDefaultConnectionSlug(): Promise<string | null>;
+  getReadyConnection(
+    slug: string | null | undefined,
+    model?: string,
+  ): Promise<{ connection: { slug: string }; model: string }>;
+  readSessionHeader(sessionId: string): Promise<{
+    permissionMode: string;
+    isArchived: boolean;
+    status: string;
+  }>;
+  ensureSessionCanSend(sessionId: string): Promise<void>;
+  emitSessionsChanged(
+    reason: SessionChangedReason,
+    sessionId?: string,
+    extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId'>,
+  ): void;
+  runAgentTurn(input: {
+    sessionId: string;
+    iterator: AsyncIterable<SessionEvent>;
+    turnId: string;
+    onEvent: (event: SessionEvent) => void;
+  }): Promise<{ outcome: GoalTurnOutcome; error?: string }>;
+}
+
+export function createEmbeddedBotSessionAdapter(
+  deps: EmbeddedBotSessionAdapterDeps,
+): BotSessionAdapter {
+  return {
+    async createSession(input) {
+      const ready = await deps.getReadyConnection(
+        await deps.getDefaultConnectionSlug(),
+        undefined,
+      );
+      const summary = await deps.createSession({
+        backend: 'ai-sdk',
+        llmConnectionSlug: ready.connection.slug,
+        model: ready.model,
+        permissionMode: 'explore',
+        name: input.name,
+        labels: [...input.labels],
+      });
+      deps.emitSessionsChanged('created', summary.id);
+      await deps.ensureSessionCanSend(summary.id);
+      return summary.id;
+    },
+
+    async prepareSession(sessionId) {
+      try {
+        const header = await deps.readSessionHeader(sessionId);
+        assertSessionCanSendFromHeader(header);
+        try {
+          await deps.runtime.setPermissionMode(sessionId, 'explore');
+        } catch (error) {
+          if (isSessionLifecycleError(error)) throw error;
+          return 'permission_refused';
+        }
+        deps.emitSessionsChanged('updated', sessionId);
+        await deps.ensureSessionCanSend(sessionId);
+        return 'ready';
+      } catch (error) {
+        if (!isSessionLifecycleError(error)) throw error;
+        throw new BotSessionUnavailableError(error.message, { cause: error });
+      }
+    },
+
+    async runTurn({ sessionId, turnId, text }) {
+      const iterator = deps.runtime.sendMessage(sessionId, { turnId, text });
+      let latestText = '';
+      const result = await deps.runAgentTurn({
+        sessionId,
+        iterator,
+        turnId,
+        onEvent: (event) => {
+          if (event.type === 'text_complete') latestText = event.text;
+        },
+      });
+      if (result.outcome.kind === 'suspended') return { kind: 'suspended' };
+      if (result.outcome.kind === 'errored') {
+        return {
+          kind: 'errored',
+          reason: result.error ?? result.outcome.reason,
+        };
+      }
+      return { kind: 'completed', text: latestText };
+    },
+  };
+}

--- a/apps/desktop/src/main/runtime-host-assistant-delta.ts
+++ b/apps/desktop/src/main/runtime-host-assistant-delta.ts
@@ -1,0 +1,25 @@
+import type { SessionAssistantDelta } from '@maka/runtime-host/protocol';
+
+export interface RuntimeHostAssistantDeltaFold {
+  readonly text: string;
+  readonly tail: string;
+}
+
+export function foldRuntimeHostAssistantDelta(
+  current: string,
+  delta: Pick<SessionAssistantDelta, 'startOffset' | 'text'>,
+): RuntimeHostAssistantDeltaFold {
+  if (delta.startOffset > current.length) {
+    throw new Error('Runtime Host assistant delta has a gap');
+  }
+  const overlapLength = Math.min(current.length - delta.startOffset, delta.text.length);
+  if (
+    overlapLength > 0 &&
+    current.slice(delta.startOffset, delta.startOffset + overlapLength) !==
+      delta.text.slice(0, overlapLength)
+  ) {
+    throw new Error('Runtime Host assistant delta conflicts with prior output');
+  }
+  const tail = delta.text.slice(overlapLength);
+  return { text: current + tail, tail };
+}

--- a/apps/desktop/src/main/runtime-host-bot-session-adapter.ts
+++ b/apps/desktop/src/main/runtime-host-bot-session-adapter.ts
@@ -1,0 +1,202 @@
+import { randomUUID } from 'node:crypto';
+import { RuntimeHostOperationError } from '@maka/runtime-host/client';
+import type {
+  SessionCatalogProjection,
+  SubscriptionFrame,
+} from '@maka/runtime-host/protocol';
+import type {
+  BotSessionAdapter,
+  BotSessionTurnResult,
+} from './bot-session-adapter.js';
+import { BotSessionUnavailableError } from './bot-session-adapter.js';
+import {
+  DesktopRuntimeHostClientError,
+  type DesktopRuntimeHostClient,
+} from './runtime-host-client.js';
+import { foldRuntimeHostAssistantDelta } from './runtime-host-assistant-delta.js';
+
+type RuntimeHostBotSessionClient = Pick<
+  DesktopRuntimeHostClient,
+  | 'createSession'
+  | 'getSession'
+  | 'openSession'
+  | 'startTurn'
+  | 'updateSessionConfiguration'
+>;
+
+export interface RuntimeHostBotSessionCreateTarget {
+  readonly cwd: string;
+  readonly projectId?: string | null;
+}
+
+export interface RuntimeHostBotSessionAdapterDeps {
+  client: RuntimeHostBotSessionClient;
+  resolveCreateTarget(): Promise<RuntimeHostBotSessionCreateTarget>;
+  emitSessionsChanged(
+    reason: 'created' | 'updated' | 'status-change',
+    sessionId: string,
+    extra?: { readonly turnId?: string },
+  ): void;
+  newId?: () => string;
+}
+
+export function createRuntimeHostBotSessionAdapter(
+  deps: RuntimeHostBotSessionAdapterDeps,
+): BotSessionAdapter {
+  const newId = deps.newId ?? randomUUID;
+
+  return {
+    async createSession(input) {
+      const target = await deps.resolveCreateTarget();
+      const sessionId = newId();
+      let session: SessionCatalogProjection;
+      try {
+        session = await deps.client.createSession({
+          sessionId,
+          cwd: target.cwd,
+          ...(target.projectId === undefined ? {} : { projectId: target.projectId }),
+          name: input.name,
+          labels: [...input.labels],
+          modelTarget: { kind: 'default' },
+          permissionMode: 'explore',
+        });
+      } catch (error) {
+        if (
+          !(error instanceof RuntimeHostOperationError) ||
+          error.code !== 'commit_outcome_unknown'
+        ) {
+          throw error;
+        }
+        const reconciled = await deps.client.getSession(sessionId);
+        if (!reconciled) throw error;
+        session = reconciled;
+      }
+      deps.emitSessionsChanged('created', session.id);
+      return session.id;
+    },
+
+    async prepareSession(sessionId) {
+      let session: SessionCatalogProjection | null;
+      try {
+        session = await deps.client.getSession(sessionId);
+      } catch (error) {
+        throwUnavailable(error, sessionId);
+        throw error;
+      }
+      if (!session || session.isArchived || session.status === 'archived') {
+        throw unavailableSession(sessionId);
+      }
+      if (session.permissionMode === 'explore') return 'ready';
+
+      try {
+        session = await deps.client.updateSessionConfiguration(sessionId, {
+          permissionMode: 'explore',
+        });
+      } catch (error) {
+        throwUnavailable(error, sessionId);
+        if (isPermissionUpdateRefusal(error)) return 'permission_refused';
+        throw error;
+      }
+      if (session.isArchived || session.status === 'archived') {
+        throw unavailableSession(sessionId);
+      }
+      if (session.permissionMode !== 'explore') return 'permission_refused';
+      deps.emitSessionsChanged('updated', sessionId);
+      return 'ready';
+    },
+
+    async runTurn({ sessionId, turnId, text }) {
+      let session;
+      try {
+        session = await deps.client.openSession(sessionId);
+      } catch (error) {
+        throwUnavailable(error, sessionId);
+        throw error;
+      }
+
+      const completion = collectRuntimeHostBotTurn(session.events, turnId);
+      try {
+        try {
+          await deps.client.startTurn({
+            sessionId,
+            turnId,
+            content: { text },
+          });
+        } catch (error) {
+          await session.close().catch(() => undefined);
+          await completion.catch(() => undefined);
+          throwUnavailable(error, sessionId);
+          throw error;
+        }
+        deps.emitSessionsChanged('status-change', sessionId, { turnId });
+        return await completion;
+      } finally {
+        await session.close().catch(() => undefined);
+      }
+    },
+  };
+}
+
+async function collectRuntimeHostBotTurn(
+  events: AsyncIterable<SubscriptionFrame>,
+  turnId: string,
+): Promise<BotSessionTurnResult> {
+  const assistantText = new Map<string, string>();
+  let latestMessageId: string | undefined;
+
+  for await (const frame of events) {
+    if (frame.kind === 'subscription.closed') {
+      throw new Error(`Runtime Host Bot Session subscription closed: ${frame.reason}`);
+    }
+    if (frame.kind === 'subscription.session_delta') {
+      if (frame.delta.turnId !== turnId || frame.delta.kind !== 'text') continue;
+      latestMessageId = frame.delta.messageId;
+      const folded = foldRuntimeHostAssistantDelta(
+        assistantText.get(latestMessageId) ?? '',
+        frame.delta,
+      );
+      assistantText.set(latestMessageId, folded.text);
+      continue;
+    }
+    if (frame.kind !== 'subscription.session_projection') continue;
+    const turn = frame.snapshot.rootTurn;
+    if (!turn || turn.turnId !== turnId) continue;
+    if (turn.status === 'waiting_for_user') return { kind: 'suspended' };
+    if (turn.status === 'completed') {
+      return {
+        kind: 'completed',
+        text: latestMessageId ? (assistantText.get(latestMessageId) ?? '') : '',
+      };
+    }
+    if (turn.status === 'failed') {
+      return { kind: 'errored', reason: turn.failureClass };
+    }
+    if (turn.status === 'cancelled') {
+      return { kind: 'errored', reason: `Turn cancelled: ${turn.abortSource}` };
+    }
+  }
+
+  throw new Error('Runtime Host Bot Session subscription ended before the Turn settled');
+}
+
+function throwUnavailable(error: unknown, sessionId: string): void {
+  if (
+    (error instanceof RuntimeHostOperationError &&
+      (error.code === 'not_found' || error.code === 'session_archived')) ||
+    (error instanceof DesktopRuntimeHostClientError && error.code === 'session_not_found')
+  ) {
+    throw unavailableSession(sessionId, error);
+  }
+}
+
+function isPermissionUpdateRefusal(error: unknown): boolean {
+  return (
+    (error instanceof RuntimeHostOperationError &&
+      (error.code === 'session_busy' || error.code === 'operation_conflict')) ||
+    (error instanceof DesktopRuntimeHostClientError && error.code === 'revision_conflict')
+  );
+}
+
+function unavailableSession(sessionId: string, cause?: unknown): BotSessionUnavailableError {
+  return new BotSessionUnavailableError(`Bot Session is unavailable: ${sessionId}`, { cause });
+}

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -19,6 +19,7 @@ import type {
   DesktopRuntimeHostClient,
   DesktopRuntimeHostSession,
 } from './runtime-host-client.js';
+import { foldRuntimeHostAssistantDelta } from './runtime-host-assistant-delta.js';
 
 const MAX_PENDING_FRAMES = 512;
 
@@ -395,32 +396,21 @@ export class RuntimeHostSessionObserver {
       const key = accumulatorKey(delta.kind, delta.messageId);
       const current = state.accumulators.get(key);
       const previousText = current?.text ?? '';
-      if (delta.startOffset > previousText.length) {
-        throw new Error('Runtime Host Session assistant delta has a gap');
-      }
-      const overlapLength = Math.min(previousText.length - delta.startOffset, delta.text.length);
-      if (
-        overlapLength > 0 &&
-        previousText.slice(delta.startOffset, delta.startOffset + overlapLength) !==
-          delta.text.slice(0, overlapLength)
-      ) {
-        throw new Error('Runtime Host Session assistant delta conflicts with the transcript');
-      }
-      const tail = delta.text.slice(overlapLength);
+      const folded = foldRuntimeHostAssistantDelta(previousText, delta);
       state.accumulators.set(key, {
         kind: delta.kind,
         turnId: delta.turnId,
         messageId: delta.messageId,
-        text: previousText + tail,
+        text: folded.text,
       });
-      if (tail.length > 0) {
+      if (folded.tail.length > 0) {
         this.#broadcast(state.sessionId, {
           type: delta.kind === 'text' ? 'text_delta' : 'thinking_delta',
           id: frameIdentity(frame),
           turnId: delta.turnId,
           messageId: delta.messageId,
           ts: this.#now(),
-          text: tail,
+          text: folded.tail,
         });
       }
       return;


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

This PR prepares the existing Desktop-owned Bot surface for Runtime Host ownership without changing the production owner.

- Replace the Bot service's direct Runtime, Store, connection-resolution, and Desktop stream dependencies with a narrow Session adapter contract.
- Preserve the current production behavior through an explicit embedded adapter while adding a separate Runtime Host-backed adapter for the candidate path.
- Create Bot Sessions through the Host-owned default model route in `explore` mode, reconcile an uncertain create by stable Session identity, and keep configuration revisions inside the Desktop Host client.
- Subscribe before starting a Turn, fold offset-bearing assistant deltas through the shared Desktop continuity helper, and map Host waiting, completed, failed, and cancelled outcomes into the existing Bot reply contract.
- Keep transport, authentication, source-event deduplication, rate limiting, conversation mapping, typing indicators, and reply delivery in the Client-owned Bot service.

## Ownership and cutover safety

The production Desktop boot still injects the embedded adapter. This PR does not activate a second Runtime owner, add an embedded fallback to the Host path, or move Bot transport concerns into Runtime core. The Host adapter imports only the pure Bot Session contract and the Desktop Host client boundary; it does not capture `SessionManager` or Runtime Store objects.

## Verification

- `npm --workspace @maka/desktop test` — 1,695 tests passed
- Focused Bot, Session observer, lifecycle, Goal settlement, typing, and project-selection suites — 17 tests passed after the shared continuity extraction
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Part of #2010.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

本 PR 在不改变 production owner 的前提下，为现有 Desktop-owned Bot surface 接入 Runtime Host ownership 做准备。

- 用窄化的 Session adapter contract 取代 Bot service 对 Runtime、Store、connection resolution 与 Desktop stream 的直接依赖。
- 通过显式 embedded adapter 保持当前 production 行为，同时为 candidate path 新增独立的 Runtime Host-backed adapter。
- 通过 Host-owned default model route 以 `explore` 模式创建 Bot Session；使用稳定 Session identity 对结果不确定的 create 进行核对；Session configuration revision 只留在 Desktop Host client 内部。
- 在启动 Turn 前先建立 subscription，通过 Desktop 共用的 continuity helper 折叠带 offset 的 assistant delta，并把 Host 的等待、完成、失败与取消状态映射到现有 Bot reply contract。
- Transport、authentication、source-event deduplication、rate limit、conversation mapping、typing indicator 与 reply delivery 继续由 Client-owned Bot service 持有。

## Ownership 与切换安全

Production Desktop boot 仍然注入 embedded adapter。本 PR 不激活第二个 Runtime owner，不在 Host path 增加 embedded fallback，也不把 Bot transport concern 移入 Runtime core。Host adapter 只依赖纯 Bot Session contract 与 Desktop Host client boundary，不捕获 `SessionManager` 或 Runtime Store object。

## 验证

- `npm --workspace @maka/desktop test` — 1,695 项测试通过
- 共用 continuity 提取后的 Bot、Session observer、lifecycle、Goal settlement、typing 与 project-selection focused suite — 17 项测试通过
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

属于 #2010 的一部分。

</details>
