### PR TITLE
feat(desktop): compose Runtime Host candidate

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-incoming-project-cwd.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-project-cwd.test.ts
@@ -7,10 +7,6 @@ import { createEmbeddedBotSessionAdapter } from '../embedded-bot-session-adapter
 describe('bot incoming new-session cwd', () => {
   it('leaves the cwd to the shared desktop session resolver', async () => {
     let capturedCwd: unknown = undefined;
-    let resolveCreated: () => void = () => {};
-    const created = new Promise<void>((resolve) => {
-      resolveCreated = resolve;
-    });
     const service = createBotIncomingMainService({
       botRegistry: {
         async sendMessage() {},
@@ -23,11 +19,10 @@ describe('bot incoming new-session cwd', () => {
       } as unknown as BotRegistry,
       sessions: createEmbeddedBotSessionAdapter({
         runtime: {} as SessionManager,
-        // createSession captures the cwd it was given, signals the test, then
-        // throws to short-circuit before the streaming / typing path runs.
+        // createSession captures the cwd it was given, then throws to
+        // short-circuit before the streaming / typing path runs.
         async createSession(input) {
           capturedCwd = input.cwd;
-          resolveCreated();
           throw new Error('__short_circuit_after_create__');
         },
         getDefaultConnectionSlug: async () => 'slug',
@@ -55,15 +50,6 @@ describe('bot incoming new-session cwd', () => {
       sourceMessageId: '',
       receivedAt: Date.now(),
     } as unknown as BotIncomingMessage);
-
-    // handleBotIncomingMessage returns before the queued create runs; wait
-    // for createSession to actually be invoked (or time out).
-    await Promise.race([
-      created,
-      new Promise<void>((_, reject) =>
-        setTimeout(() => reject(new Error('createSession was not called')), 1000),
-      ),
-    ]);
 
     assert.equal(capturedCwd, undefined);
   });

--- a/apps/desktop/src/main/__tests__/bot-incoming-typing.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-typing.test.ts
@@ -55,7 +55,7 @@ test('the bot typing loop owns only its active abort listener', async (t) => {
     },
   });
 
-  await service.handleBotIncomingMessage({
+  const handling = service.handleBotIncomingMessage({
     platform: 'telegram',
     userId: 'user',
     userName: 'User',
@@ -84,7 +84,7 @@ test('the bot typing loop owns only its active abort listener', async (t) => {
   }
 
   releaseTurn();
-  await waitFor(() => replies.length === 1, 'bot reply was not delivered');
+  await handling;
   assert.equal(typingSignal!.aborted, true);
   assert.equal(getEventListeners(typingSignal!, 'abort').length, 0);
 

--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import type { IpcMain } from 'electron';
+import type { BotRegistry, ComputerUseToolSet, MakaTool } from '@maka/runtime';
 import { connectRuntimeHost } from '@maka/runtime-host/client';
 import {
   HOST_OPERATION_SPECS,
@@ -19,9 +20,10 @@ import {
   resolveStorageRoot,
   tryAcquireInteractiveRootOwner,
 } from '@maka/storage/root-authority';
+import { z } from 'zod';
 import { DesktopRuntimeHostClient } from '../runtime-host-client.js';
 import { createAttachmentApprovalRegistry } from '../attachment-approval.js';
-import { registerRuntimeHostSessionCatalogIpc } from '../runtime-host-session-catalog-ipc-main.js';
+import { startDesktopRuntimeHostCandidate } from '../runtime-host-desktop-candidate.js';
 import { registerRuntimeHostSessionExecutionIpc } from '../runtime-host-session-execution-ipc-main.js';
 import { registerRuntimeHostSessionDomainsIpc } from '../runtime-host-session-domains-ipc-main.js';
 import { RuntimeHostSessionObserver } from '../runtime-host-session-observer.js';
@@ -108,6 +110,14 @@ test('drives the renderer Session catalog facade through real UDS framing', asyn
       idleGraceMs: 10_000,
       compositionFactory: async () => ({
         handlers: handlers({
+          'client.capability.replace': async (input) => ({
+            ok: true,
+            result: { registrationId: input.registrationId, revision: 1 },
+          }),
+          'client.capability.unregister': async (input) => ({
+            ok: true,
+            result: { registrationId: input.registrationId, revision: 2 },
+          }),
           'session.catalog.query': async (input) => {
             if (input.kind === 'get') {
               return {
@@ -177,28 +187,32 @@ test('drives the renderer Session catalog facade through real UDS framing', asyn
         async close() {},
       }),
     });
-    const connected = await connectRuntimeHost({
-      rootPath: base,
-      surface: 'desktop',
-      protocol: {
-        min: RUNTIME_HOST_PROTOCOL_VERSION,
-        max: RUNTIME_HOST_PROTOCOL_VERSION,
-      },
-    });
-    assert.equal(connected.kind, 'connected');
-    if (connected.kind !== 'connected') throw new Error('Desktop did not connect to Runtime Host');
-    const client = new DesktopRuntimeHostClient(connected.connection);
     const ipc = ipcHarness();
     const changes: Array<{ reason: string; sessionId?: string }> = [];
-    registerRuntimeHostSessionCatalogIpc(
-      {
-        client,
-        workspaceRoot: base,
-        emitSessionsChanged: (reason, sessionId) => changes.push({ reason, sessionId }),
-        newId: () => 'session-ipc',
+    const started = await startDesktopRuntimeHostCandidate({
+      rootPath: base,
+      ipcMain: ipc,
+      workspaceRoot: base,
+      attachmentApprovals: createAttachmentApprovalRegistry(),
+      stat: async () => ({ size: 0 }),
+      resizeImage: async (bytes) => bytes,
+      nativeCapabilities: {
+        browserTools: [nativeTool()],
+        releaseBrowserSession() {},
+        computerUseTools: Object.assign([], {
+          clearSession() {},
+        }) as unknown as ComputerUseToolSet,
+        releaseComputerUseSession() {},
       },
-      ipc,
-    );
+      botRegistry: {} as BotRegistry,
+      resolveBotCreateTarget: async () => ({ cwd: base }),
+      emitSessionsChanged: (reason, sessionId) => changes.push({ reason, sessionId }),
+      emitModeChanged() {},
+      newId: () => 'session-ipc',
+    });
+    assert.equal(started.kind, 'ready');
+    if (started.kind !== 'ready') throw new Error('Desktop candidate did not start');
+    const { candidate } = started;
 
     const created = await ipc.invoke('sessions:create', undefined);
     assert.deepEqual((await ipc.invoke('sessions:list')) as unknown[], [created]);
@@ -219,7 +233,7 @@ test('drives the renderer Session catalog facade through real UDS framing', asyn
       { reason: 'deleted', sessionId: 'session-ipc' },
     ]);
 
-    await client.close();
+    await candidate.close();
   } finally {
     await host?.close().catch(() => undefined);
     await rm(base, { recursive: true, force: true });
@@ -462,6 +476,9 @@ function ipcHarness() {
       assert.equal(ipcHandlers.has(channel), false, `duplicate handler: ${channel}`);
       ipcHandlers.set(channel, handler);
     },
+    removeHandler(channel: string) {
+      ipcHandlers.delete(channel);
+    },
     async invoke(channel: string, ...args: unknown[]): Promise<unknown> {
       const handler = ipcHandlers.get(channel);
       assert.ok(handler, `missing handler: ${channel}`);
@@ -495,5 +512,14 @@ function session(
     collaborationMode: 'agent',
     orchestrationMode: 'default',
     ...overrides,
+  };
+}
+
+function nativeTool(): MakaTool {
+  return {
+    name: 'browser_snapshot',
+    description: 'Capture the current page.',
+    parameters: z.object({}),
+    impl: async () => 'snapshot',
   };
 }

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate-dependency.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate-dependency.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { basename, dirname, join, normalize, resolve } from 'node:path';
+import test from 'node:test';
+import { build } from 'esbuild';
+
+const workingDirectory = process.cwd();
+const repositoryRoot =
+  basename(workingDirectory) === 'desktop' && basename(dirname(workingDirectory)) === 'apps'
+    ? resolve(workingDirectory, '..', '..')
+    : workingDirectory;
+const candidateEntrypoint = join(
+  repositoryRoot,
+  'apps',
+  'desktop',
+  'src',
+  'main',
+  'runtime-host-desktop-candidate.ts',
+);
+
+test('the Desktop Host candidate cannot reach an embedded Runtime owner', async () => {
+  const result = await build({
+    absWorkingDir: repositoryRoot,
+    entryPoints: [candidateEntrypoint],
+    bundle: true,
+    format: 'esm',
+    metafile: true,
+    packages: 'external',
+    platform: 'node',
+    write: false,
+  });
+  assert.ok(result.metafile);
+
+  const reached = new Set(Object.keys(result.metafile.inputs).map(normalize));
+  const forbiddenModules = [
+    'apps/desktop/src/main/app-lifecycle.ts',
+    'apps/desktop/src/main/boot.ts',
+    'apps/desktop/src/main/embedded-bot-session-adapter.ts',
+    'apps/desktop/src/main/execution-store-wiring.ts',
+    'apps/desktop/src/main/sessions-ipc-main.ts',
+    'apps/desktop/src/main/startup-safe-boundary-resume.ts',
+  ];
+  assert.deepEqual(
+    forbiddenModules.filter((path) => reached.has(normalize(path))),
+    [],
+  );
+
+  const externalImports = Object.values(result.metafile.inputs).flatMap(({ imports }) =>
+    imports.filter(({ external }) => external).map(({ path }) => path),
+  );
+  assert.deepEqual(
+    externalImports.filter(
+      (path) =>
+        path === '@maka/runtime' ||
+        path.startsWith('@maka/runtime/') ||
+        path === '@maka/storage' ||
+        path.startsWith('@maka/storage/'),
+    ),
+    [],
+  );
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -1,0 +1,435 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { IpcMain } from 'electron';
+import type {
+  BotIncomingMessage,
+  BotRegistry,
+  ComputerUseToolSet,
+  MakaTool,
+} from '@maka/runtime';
+import type { ClientCapabilityProvider, RuntimeHostConnection } from '@maka/runtime-host/client';
+import type {
+  ClientCapabilityCallFrame,
+  OperationInput,
+  OperationKey,
+  SessionCatalogProjection,
+} from '@maka/runtime-host/protocol';
+import { z } from 'zod';
+import { createAttachmentApprovalRegistry } from '../attachment-approval.js';
+import {
+  createDesktopRuntimeHostCandidate,
+  type DesktopRuntimeHostCandidateDeps,
+} from '../runtime-host-desktop-candidate.js';
+
+test('owns one complete Desktop candidate generation and can restart cleanly', async () => {
+  const ipc = ipcHarness();
+  const first = connectionHarness('first');
+  const candidate = await createDesktopRuntimeHostCandidate(first.connection, deps(ipc));
+
+  assert.equal(first.capabilityRegistrations, 1);
+  assert.deepEqual(
+    ((await ipc.invoke('sessions:list')) as SessionCatalogProjection[]).map(({ id }) => id),
+    ['session-first'],
+  );
+  assert.deepEqual(await ipc.invoke('shell-runs:list', 'session-first'), []);
+  assert.deepEqual(await ipc.invoke('sessions:readExecutionBoundary', 'session-first'), {
+    kind: 'managed',
+    access: 'read_only',
+    revision: 1,
+  });
+
+  await candidate.close();
+  assert.equal(ipc.size, 0);
+  assert.equal(first.capabilityUnregistrations, 1);
+  assert.equal(first.closeCalls, 1);
+
+  const second = connectionHarness('second');
+  const reconnected = await createDesktopRuntimeHostCandidate(second.connection, deps(ipc));
+  assert.deepEqual(
+    ((await ipc.invoke('sessions:list')) as SessionCatalogProjection[]).map(({ id }) => id),
+    ['session-second'],
+  );
+  await reconnected.close();
+  assert.equal(ipc.size, 0);
+});
+
+test('tears down the whole candidate when the Host connection closes', async () => {
+  const ipc = ipcHarness();
+  const host = connectionHarness('closed');
+  const candidate = await createDesktopRuntimeHostCandidate(host.connection, deps(ipc));
+
+  host.disconnect();
+  await candidate.closed;
+
+  assert.equal(ipc.size, 0);
+  assert.equal(host.closeCalls, 1);
+});
+
+test('starts without registering an empty native capability set', async () => {
+  const ipc = ipcHarness();
+  const host = connectionHarness('no-capabilities');
+  const candidate = await createDesktopRuntimeHostCandidate(
+    host.connection,
+    deps(ipc, {
+      browserTools: [],
+      releaseBrowserSession() {},
+      computerUseTools: emptyComputerUseTools(),
+      releaseComputerUseSession() {},
+    }),
+  );
+
+  assert.equal(host.capabilityRegistrations, 0);
+  await candidate.close();
+  assert.equal(host.capabilityUnregistrations, 0);
+});
+
+test('releases all native Session resources on retirement and generation close', async () => {
+  const ipc = ipcHarness();
+  const host = connectionHarness('native-lifecycle');
+  const browserReleased: string[] = [];
+  const computerReleased: string[] = [];
+  const candidate = await createDesktopRuntimeHostCandidate(
+    host.connection,
+    deps(ipc, {
+      browserTools: [nativeTool()],
+      releaseBrowserSession: async (sessionId) => {
+        browserReleased.push(sessionId);
+      },
+      computerUseTools: emptyComputerUseTools(),
+      releaseComputerUseSession: (sessionId) => {
+        computerReleased.push(sessionId);
+      },
+    }),
+  );
+
+  await host.invokeCapability(capabilityFrame('session-native-lifecycle'));
+  await ipc.invoke('sessions:archive', 'session-native-lifecycle');
+  assert.deepEqual(browserReleased, ['session-native-lifecycle']);
+  assert.deepEqual(computerReleased, ['session-native-lifecycle']);
+
+  await host.invokeCapability(capabilityFrame('close-owned-session'));
+  await candidate.close();
+  assert.deepEqual(browserReleased, ['session-native-lifecycle', 'close-owned-session']);
+  assert.deepEqual(computerReleased, ['session-native-lifecycle', 'close-owned-session']);
+});
+
+test('drains an accepted Host-backed Bot turn before closing its generation', async () => {
+  const ipc = ipcHarness();
+  const host = connectionHarness('bot');
+  const replies: string[] = [];
+  const input = {
+    ...deps(ipc),
+    botRegistry: {
+      sendMessage: async (_platform: unknown, _chatId: unknown, text: string) => {
+        replies.push(text);
+        return null;
+      },
+      sendTypingIndicator: async () => false,
+    } as unknown as BotRegistry,
+  };
+  const candidate = await createDesktopRuntimeHostCandidate(host.connection, input);
+
+  const accepted = candidate.botIncoming.handleBotIncomingMessage({
+    platform: 'telegram',
+    userId: 'user',
+    userName: 'User',
+    chatId: 'chat',
+    isGroup: false,
+    text: 'answer this',
+    sourceMessageId: 'source-1',
+    receivedAt: 1,
+  } as BotIncomingMessage);
+  await host.turnStarted;
+
+  await candidate.close();
+  await accepted;
+  assert.deepEqual(replies, []);
+  assert.equal(host.startTurnCalls, 1);
+
+  await candidate.botIncoming.handleBotIncomingMessage({
+    platform: 'telegram',
+    userId: 'user',
+    userName: 'User',
+    chatId: 'chat',
+    isGroup: false,
+    text: 'must not start',
+    sourceMessageId: 'source-2',
+    receivedAt: 2,
+  } as BotIncomingMessage);
+  assert.equal(host.startTurnCalls, 1);
+});
+
+test('rolls back only candidate-owned IPC after a registration collision', async () => {
+  const ipc = ipcHarness();
+  ipc.handle('deepResearch:get', async () => 'embedded');
+  const host = connectionHarness('collision');
+
+  await assert.rejects(
+    () => createDesktopRuntimeHostCandidate(host.connection, deps(ipc)),
+    /duplicate handler: deepResearch:get/,
+  );
+
+  assert.equal(await ipc.invoke('deepResearch:get'), 'embedded');
+  assert.deepEqual(ipc.channels, ['deepResearch:get']);
+  assert.equal(host.closeCalls, 1);
+});
+
+test('closes the claimed Host connection when native capability construction fails', async () => {
+  const ipc = ipcHarness();
+  const host = connectionHarness('invalid-capability');
+  const invalidTool = {
+    ...nativeTool(),
+    parameters: z.string(),
+  } as unknown as MakaTool;
+
+  await assert.rejects(
+    () =>
+      createDesktopRuntimeHostCandidate(
+        host.connection,
+        deps(ipc, {
+          browserTools: [invalidTool],
+          releaseBrowserSession() {},
+          computerUseTools: emptyComputerUseTools(),
+          releaseComputerUseSession() {},
+        }),
+      ),
+    /tool schema must be an object/,
+  );
+
+  assert.equal(ipc.size, 0);
+  assert.equal(host.closeCalls, 1);
+});
+
+type IpcHandler = Parameters<Pick<IpcMain, 'handle'>['handle']>[1];
+
+function ipcHarness() {
+  const handlers = new Map<string, IpcHandler>();
+  return {
+    handle(channel: string, handler: IpcHandler): void {
+      if (handlers.has(channel)) throw new Error(`duplicate handler: ${channel}`);
+      handlers.set(channel, handler);
+    },
+    removeHandler(channel: string): void {
+      handlers.delete(channel);
+    },
+    async invoke(channel: string, ...args: unknown[]): Promise<unknown> {
+      const handler = handlers.get(channel);
+      assert.ok(handler, `missing handler: ${channel}`);
+      return handler({ sender: { id: 1 } } as never, ...args);
+    },
+    get channels(): string[] {
+      return [...handlers.keys()].sort();
+    },
+    get size(): number {
+      return handlers.size;
+    },
+  };
+}
+
+function deps(
+  ipcMain: ReturnType<typeof ipcHarness>,
+  nativeCapabilities: DesktopRuntimeHostCandidateDeps['nativeCapabilities'] = {
+    browserTools: [nativeTool()],
+    releaseBrowserSession() {},
+    computerUseTools: emptyComputerUseTools(),
+    releaseComputerUseSession() {},
+  },
+): DesktopRuntimeHostCandidateDeps {
+  return {
+    ipcMain,
+    workspaceRoot: '/workspace',
+    attachmentApprovals: createAttachmentApprovalRegistry(),
+    stat: async () => ({ size: 0 }),
+    resizeImage: async (bytes) => bytes,
+    nativeCapabilities,
+    botRegistry: {} as BotRegistry,
+    resolveBotCreateTarget: async () => ({ cwd: '/workspace' }),
+    emitSessionsChanged() {},
+    emitModeChanged() {},
+    newId: () => 'candidate-id',
+  };
+}
+
+function emptyComputerUseTools(): ComputerUseToolSet {
+  return Object.assign([], { clearSession() {} }) as unknown as ComputerUseToolSet;
+}
+
+function nativeTool(): MakaTool {
+  return {
+    name: 'browser_snapshot',
+    description: 'Capture the current page.',
+    parameters: z.object({}),
+    impl: async () => 'snapshot',
+  };
+}
+
+function connectionHarness(label: string) {
+  let resolveClosed: (() => void) | undefined;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  let resolveTurnStarted: (() => void) | undefined;
+  const turnStarted = new Promise<void>((resolve) => {
+    resolveTurnStarted = resolve;
+  });
+  const closeSubscriptions = new Set<() => void>();
+  let provider: ClientCapabilityProvider | undefined;
+  let capabilityRegistrations = 0;
+  let capabilityUnregistrations = 0;
+  let closeCalls = 0;
+  let startTurnCalls = 0;
+  const connection = {
+    hostEpoch: `host-${label}`,
+    connectionId: `connection-${label}`,
+    selectedProtocol: 0,
+    closed,
+    request: async <K extends OperationKey>(operation: K, input: OperationInput<K>) => {
+      if (
+        operation === 'session.catalog.query' &&
+        (input as { kind?: unknown }).kind === 'list_start'
+      ) {
+        return {
+          kind: 'page',
+          revision: catalogRevision(label),
+          sessions: [session(`session-${label}`)],
+          nextCursor: null,
+        };
+      }
+      if (operation === 'session.create') {
+        return session((input as { sessionId: string }).sessionId);
+      }
+      if (
+        operation === 'session.catalog.query' &&
+        (input as { kind?: unknown }).kind === 'get'
+      ) {
+        return { kind: 'session', session: session((input as { sessionId: string }).sessionId) };
+      }
+      if (operation === 'runtime.resource.query') {
+        return {
+          kind: 'page',
+          sessionId: (input as { sessionId: string }).sessionId,
+          revision: catalogRevision(`${label}-resource`),
+          resources: [],
+          nextCursor: null,
+        };
+      }
+      if (operation === 'session.execution_boundary.query') {
+        return { kind: 'managed', access: 'read_only', revision: 1 };
+      }
+      if (operation === 'session.lifecycle.set') {
+        return session((input as { sessionId: string }).sessionId);
+      }
+      if (operation === 'turn.start') {
+        startTurnCalls += 1;
+        resolveTurnStarted?.();
+        return {};
+      }
+      throw new Error(`Unexpected operation: ${operation}`);
+    },
+    openSessionSubscription: async ({ sessionId }: { sessionId: string }) => {
+      let resolveSubscriptionClosed: (() => void) | undefined;
+      const subscriptionClosed = new Promise<void>((resolve) => {
+        resolveSubscriptionClosed = resolve;
+      });
+      const closeSubscription = () => resolveSubscriptionClosed?.();
+      closeSubscriptions.add(closeSubscription);
+      return {
+        hostEpoch: `host-${label}`,
+        subscriptionId: `subscription-${label}`,
+        snapshot: {
+          projectionRevision: 1,
+          session: { sessionId },
+        },
+        loadTranscript: async () => [],
+        async *[Symbol.asyncIterator]() {
+          await subscriptionClosed;
+          yield { kind: 'subscription.closed', reason: 'connection_closed' };
+        },
+        close: async () => closeSubscription(),
+      };
+    },
+    replaceClientCapabilities: async (next: ClientCapabilityProvider) => {
+      provider = next;
+      capabilityRegistrations += 1;
+      return { registrationId: `registration-${label}`, revision: 1 };
+    },
+    unregisterClientCapabilities: async () => {
+      capabilityUnregistrations += 1;
+      return { registrationId: `registration-${label}`, revision: 2 };
+    },
+    close: async () => {
+      closeCalls += 1;
+      for (const closeSubscription of closeSubscriptions) closeSubscription();
+      await provider?.close?.();
+      resolveClosed?.();
+    },
+  } as unknown as RuntimeHostConnection;
+  return {
+    connection,
+    turnStarted,
+    invokeCapability: async (frame: ClientCapabilityCallFrame) => {
+      assert.ok(provider?.call);
+      return provider.call(frame, {
+        signal: new AbortController().signal,
+        accept: async () => undefined,
+      });
+    },
+    disconnect: () => resolveClosed?.(),
+    get capabilityRegistrations() {
+      return capabilityRegistrations;
+    },
+    get capabilityUnregistrations() {
+      return capabilityUnregistrations;
+    },
+    get closeCalls() {
+      return closeCalls;
+    },
+    get startTurnCalls() {
+      return startTurnCalls;
+    },
+  };
+}
+
+function capabilityFrame(sessionId: string): ClientCapabilityCallFrame {
+  return {
+    kind: 'client.capability.call',
+    registrationId: 'registration-native-lifecycle',
+    invocationId: `invocation-${sessionId}`,
+    offerId: 'desktop_browser',
+    serverId: 'desktop_browser',
+    toolName: 'browser_snapshot',
+    sessionId,
+    turnId: `turn-${sessionId}`,
+    cwd: '/workspace',
+    toolCallId: `tool-${sessionId}`,
+    arguments: {},
+  };
+}
+
+function catalogRevision(seed: string): `sha256:${string}` {
+  return `sha256:${seed.padEnd(64, seed).slice(0, 64)}`;
+}
+
+function session(id: string): SessionCatalogProjection {
+  return {
+    id,
+    revision: 1,
+    cwd: '/workspace',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: id,
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    labelsTruncated: false,
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test-connection',
+    connectionLocked: true,
+    model: 'test-model',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+  };
+}

--- a/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
@@ -2,14 +2,19 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { ComputerUseToolSet, MakaTool, MakaToolContext } from '@maka/runtime';
 import type { ClientCapabilityProvider } from '@maka/runtime-host/client';
-import type { ClientCapabilityCallFrame } from '@maka/runtime-host/protocol';
+import {
+  decodeClientCapabilityReplaceInput,
+  type ClientCapabilityCallFrame,
+} from '@maka/runtime-host/protocol';
 import { z } from 'zod';
 import { createDesktopNativeCapabilityProvider } from '../runtime-host-native-capabilities.js';
 
 test('publishes self-described session-affine Browser and Computer Use offers', () => {
   const provider = createDesktopNativeCapabilityProvider({
     browserTools: [tool('browser_snapshot', z.object({ includeHidden: z.boolean().optional() }), async () => 'ok')],
+    releaseBrowserSession() {},
     computerUseTools: computerTools(async () => ({ text: 'ok' })),
+    releaseComputerUseSession() {},
   });
 
   assert.deepEqual(
@@ -41,6 +46,12 @@ test('publishes self-described session-affine Browser and Computer Use offers', 
   assert.equal(browserSchema?.type, 'object');
   assert.equal(browserSchema?.required, undefined);
   assert.deepEqual(Object.keys((browserSchema?.properties as object | undefined) ?? {}), ['includeHidden']);
+  assert.doesNotThrow(() =>
+    decodeClientCapabilityReplaceInput({
+      registrationId: 'registration-1',
+      offers: provider.offers(),
+    }),
+  );
 });
 
 test('validates before admission and invokes the exact offered tool with Host context', async () => {
@@ -69,7 +80,9 @@ test('validates before admission and invokes the exact offered tool with Host co
         return 'Loaded';
       }),
     ],
+    releaseBrowserSession() {},
     computerUseTools: computerTools(),
+    releaseComputerUseSession() {},
   });
 
   await assert.rejects(
@@ -94,8 +107,9 @@ test('validates before admission and invokes the exact offered tool with Host co
   });
 });
 
-test('projects Computer Use screenshots and releases only sessions used by that group', async () => {
-  const cleared: string[] = [];
+test('projects Computer Use screenshots and releases all native resources for a Session', async () => {
+  const browserReleased: string[] = [];
+  const computerReleased: string[] = [];
   let invocationStarted!: () => void;
   const started = new Promise<void>((resolve) => {
     invocationStarted = resolve;
@@ -115,12 +129,32 @@ test('projects Computer Use screenshots and releases only sessions used by that 
         screenshot: { base64: 'aW1hZ2U=', mimeType: 'image/png' },
       };
     },
-    (sessionId) => cleared.push(sessionId),
+    (sessionId) => computerReleased.push(sessionId),
   );
   const provider = createDesktopNativeCapabilityProvider({
     browserTools: [tool('browser_snapshot', z.object({}), async () => 'snapshot')],
+    releaseBrowserSession: (sessionId) => {
+      browserReleased.push(sessionId);
+    },
     computerUseTools,
+    releaseComputerUseSession: (sessionId) => computerUseTools.clearSession(sessionId),
   });
+
+  await provider.releaseSession('manual-session');
+  assert.deepEqual(browserReleased, ['manual-session']);
+  assert.deepEqual(computerReleased, ['manual-session']);
+
+  await call(
+    provider,
+    capabilityFrame({
+      sessionId: 'browser-session',
+      toolName: 'browser_snapshot',
+      arguments: {},
+    }),
+  );
+  await provider.releaseSession('browser-session');
+  assert.deepEqual(browserReleased, ['manual-session', 'browser-session']);
+  assert.deepEqual(computerReleased, ['manual-session', 'browser-session']);
 
   const completed = await call(provider, computerFrame({ sessionId: 'completed-session', arguments: {} }));
   assert.deepEqual(completed, {
@@ -129,21 +163,36 @@ test('projects Computer Use screenshots and releases only sessions used by that 
       { type: 'image', data: 'aW1hZ2U=', mimeType: 'image/png' },
     ],
   });
+  await provider.releaseSession('completed-session');
+  assert.deepEqual(browserReleased, ['manual-session', 'browser-session', 'completed-session']);
+  assert.deepEqual(computerReleased, ['manual-session', 'browser-session', 'completed-session']);
 
   const inFlight = call(provider, computerFrame({ sessionId: 'active-session', arguments: { wait: true } }));
   await started;
-  await provider.close?.();
+  await provider.close();
   await assert.rejects(inFlight, /provider closed/u);
-  assert.deepEqual(cleared.sort(), ['active-session', 'completed-session']);
-  await provider.close?.();
-  assert.deepEqual(cleared.sort(), ['active-session', 'completed-session']);
+  assert.deepEqual(browserReleased, [
+    'manual-session',
+    'browser-session',
+    'completed-session',
+    'active-session',
+  ]);
+  assert.deepEqual(computerReleased, [
+    'manual-session',
+    'browser-session',
+    'completed-session',
+    'active-session',
+  ]);
+  await provider.close();
   await assert.rejects(() => call(provider, capabilityFrame()), /provider is closed/u);
 });
 
 test('does not advertise unavailable capability groups or dispatch unknown identities', async () => {
   const provider = createDesktopNativeCapabilityProvider({
     browserTools: [tool('browser_snapshot', z.object({}), async () => 'ok')],
+    releaseBrowserSession() {},
     computerUseTools: computerTools(),
+    releaseComputerUseSession() {},
   });
   assert.deepEqual(
     provider.offers().map((offer) => offer.offerId),
@@ -159,6 +208,32 @@ test('does not advertise unavailable capability groups or dispatch unknown ident
     /not offered/u,
   );
   assert.equal(admitted, false);
+});
+
+test('settles every native Session cleanup before reporting a release failure', async () => {
+  let resolveComputerRelease: (() => void) | undefined;
+  const computerRelease = new Promise<void>((resolve) => {
+    resolveComputerRelease = resolve;
+  });
+  let computerReleased = false;
+  const provider = createDesktopNativeCapabilityProvider({
+    browserTools: [],
+    releaseBrowserSession() {
+      throw new Error('browser release failed');
+    },
+    computerUseTools: computerTools(),
+    async releaseComputerUseSession() {
+      await computerRelease;
+      computerReleased = true;
+    },
+  });
+
+  const releasing = provider.releaseSession('session-1');
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(computerReleased, false);
+  resolveComputerRelease?.();
+  await assert.rejects(releasing, /browser release failed/u);
+  assert.equal(computerReleased, true);
 });
 
 test('forwards Host cancellation to an admitted Desktop invocation', async () => {
@@ -179,7 +254,9 @@ test('forwards Host cancellation to an admitted Desktop invocation', async () =>
         });
       }),
     ],
+    releaseBrowserSession() {},
     computerUseTools: computerTools(),
+    releaseComputerUseSession() {},
   });
   const controller = new AbortController();
   if (!provider.call) throw new Error('Expected a callable provider');

--- a/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
@@ -26,6 +26,7 @@ test('leaves ordinary Session defaults to the Host while preserving product mode
       client,
       workspaceRoot: '/workspace',
       emitSessionsChanged: (reason, sessionId) => events.push({ reason, sessionId }),
+      releaseSessionResources() {},
       newId: () => `session-${++sequence}`,
     },
     ipc,
@@ -81,6 +82,7 @@ test('filters linked subagents without exposing the filter to the Host protocol'
       client,
       workspaceRoot: '/workspace',
       emitSessionsChanged() {},
+      releaseSessionResources() {},
     },
     ipc,
   );
@@ -103,6 +105,7 @@ test('applies family metadata and retirement actions through Host-owned operatio
   const metadata: unknown[] = [];
   const lifecycle: unknown[] = [];
   const removed: string[] = [];
+  const released: string[] = [];
   const root = session('root', { revisionRootSessionId: 'root' });
   const revision = session('revision', { revisionRootSessionId: 'root' });
   const client = catalogClient({
@@ -125,6 +128,9 @@ test('applies family metadata and retirement actions through Host-owned operatio
       client,
       workspaceRoot: '/workspace',
       emitSessionsChanged() {},
+      releaseSessionResources: async (sessionId) => {
+        released.push(sessionId);
+      },
     },
     ipc,
   );
@@ -139,6 +145,7 @@ test('applies family metadata and retirement actions through Host-owned operatio
   ]);
   assert.deepEqual(lifecycle, [{ sessionId: 'root', state: 'archived' }]);
   assert.deepEqual(removed, ['revision']);
+  assert.deepEqual(released, ['root', 'revision', 'root', 'revision']);
 });
 
 test('normalizes renderer configuration actions into Host patches', async () => {
@@ -155,6 +162,7 @@ test('normalizes renderer configuration actions into Host patches', async () => 
       client,
       workspaceRoot: '/workspace',
       emitSessionsChanged() {},
+      releaseSessionResources() {},
     },
     ipc,
   );

--- a/apps/desktop/src/main/bot-incoming-main.ts
+++ b/apps/desktop/src/main/bot-incoming-main.ts
@@ -31,6 +31,7 @@ interface BotConversationRateBucket {
 export interface BotIncomingMainService {
   handleBotIncomingMessage(message: BotIncomingMessage): Promise<void>;
   invalidateSessionBindings(sessionId: string): void;
+  close(): Promise<void>;
 }
 
 interface BotIncomingMainServiceDeps {
@@ -43,6 +44,9 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
   const botConversationQueues = new Map<string, Promise<void>>();
   const botRecentSourceEventKeys = new Map<string, number>();
   const botConversationRateBuckets = new Map<string, BotConversationRateBucket>();
+  const activeTasks = new Set<Promise<void>>();
+  let closed = false;
+  let closeTask: Promise<void> | undefined;
 
   function invalidateSessionBindings(sessionId: string): void {
     for (const [conversationKey, boundSessionId] of botConversationSessions) {
@@ -52,7 +56,15 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
     }
   }
 
-  async function handleBotIncomingMessage(message: BotIncomingMessage): Promise<void> {
+  function handleBotIncomingMessage(message: BotIncomingMessage): Promise<void> {
+    if (closed) return Promise.resolve();
+    const task = handleAcceptedBotIncomingMessage(message);
+    const tracked = task.finally(() => activeTasks.delete(tracked));
+    activeTasks.add(tracked);
+    return tracked;
+  }
+
+  async function handleAcceptedBotIncomingMessage(message: BotIncomingMessage): Promise<void> {
     if (rememberBotSourceEvent(message)) return;
     const text = message.text.trim();
     // PR-BOT-NON-TEXT-MESSAGE-ACK-0: previously a photo / voice / sticker
@@ -76,11 +88,24 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
     const current = botConversationQueues.get(key) ?? Promise.resolve();
     const next = current
       .catch(() => {})
-      .then(() => processBotIncomingMessage(key, message, text));
+      .then(() => (closed ? undefined : processBotIncomingMessage(key, message, text)));
     const tracked = next.finally(() => {
       if (botConversationQueues.get(key) === tracked) botConversationQueues.delete(key);
     });
     botConversationQueues.set(key, tracked);
+    await tracked;
+  }
+
+  function close(): Promise<void> {
+    if (closeTask) return closeTask;
+    closed = true;
+    closeTask = Promise.allSettled([...activeTasks]).then(() => {
+      botConversationSessions.clear();
+      botConversationQueues.clear();
+      botRecentSourceEventKeys.clear();
+      botConversationRateBuckets.clear();
+    });
+    return closeTask;
   }
 
   function rememberBotSourceEvent(message: BotIncomingMessage): boolean {
@@ -140,6 +165,7 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
   }
 
   async function sendTransientBotNotice(message: BotIncomingMessage, text: string, ttlMs: number): Promise<void> {
+    if (closed) return;
     await deps.botRegistry.sendMessage(
       message.platform,
       message.chatId,
@@ -177,6 +203,7 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
     message: BotIncomingMessage,
     text: string,
   ): Promise<void> {
+    if (closed) return;
     // PR-BOT-EPHEMERAL-REPLY-0: TTL for system notices (help / reset ack /
     // fallback errors). Five minutes is long enough for the user to read
     // and process the notice on mobile; short enough that bot DMs do not
@@ -296,6 +323,7 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
         typingAbort.abort();
         await typingLoop.catch(() => {});
       }
+      if (closed) return;
       // PR-BOT-REPLY-TO-MESSAGE-0 (external bot research): thread the bot reply
       // under the originating user message. Group chats with concurrent
       // conversations otherwise visually scramble; even in DMs the threading
@@ -321,6 +349,7 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
         }
       }
     } catch (error) {
+      if (closed) return;
       const detail = isSessionWorkspaceUnavailableError(error)
         ? '工作目录不可用，请在桌面端选择有效目录后重试'
         : generalizedErrorMessage(error, '机器人对话处理失败');
@@ -353,7 +382,7 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
     return false;
   }
 
-  return { handleBotIncomingMessage, invalidateSessionBindings };
+  return { handleBotIncomingMessage, invalidateSessionBindings, close };
 }
 
 function botReply(result: BotSessionTurnResult): string {

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -1,0 +1,273 @@
+import type { IpcMain } from 'electron';
+import type { SessionChangedEvent, SessionChangedReason } from '@maka/core';
+import type { BotRegistry } from '@maka/runtime';
+import {
+  connectOrSpawnRuntimeHost,
+  type ConnectOrSpawnRuntimeHostInput,
+  type ConnectOrSpawnRuntimeHostResult,
+  type RuntimeHostConnection,
+} from '@maka/runtime-host/client';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '@maka/runtime-host/protocol';
+import type { AttachmentApprovalRegistry } from './attachment-approval.js';
+import { createBotIncomingMainService, type BotIncomingMainService } from './bot-incoming-main.js';
+import { createRuntimeHostBotSessionAdapter } from './runtime-host-bot-session-adapter.js';
+import { DesktopRuntimeHostClient } from './runtime-host-client.js';
+import {
+  createDesktopNativeCapabilityProvider,
+  type DesktopNativeCapabilityProvider,
+  type DesktopNativeCapabilityProviderInput,
+} from './runtime-host-native-capabilities.js';
+import { registerRuntimeHostSessionCatalogIpc } from './runtime-host-session-catalog-ipc-main.js';
+import {
+  registerRuntimeHostSessionDomainsIpc,
+  type RuntimeHostSessionDomainsIpcDeps,
+} from './runtime-host-session-domains-ipc-main.js';
+import { registerRuntimeHostSessionExecutionIpc } from './runtime-host-session-execution-ipc-main.js';
+import { RuntimeHostSessionObserver } from './runtime-host-session-observer.js';
+
+type CandidateIpcMain = Pick<IpcMain, 'handle' | 'removeHandler'>;
+
+export interface DesktopRuntimeHostCandidateDeps {
+  readonly ipcMain: CandidateIpcMain;
+  readonly workspaceRoot: string;
+  readonly attachmentApprovals: AttachmentApprovalRegistry;
+  readonly stat: (path: string) => Promise<{ size: number }>;
+  readonly resizeImage: (bytes: Uint8Array) => Promise<Uint8Array>;
+  readonly nativeCapabilities: DesktopNativeCapabilityProviderInput;
+  readonly botRegistry: BotRegistry;
+  readonly resolveBotCreateTarget: () => Promise<{
+    readonly cwd: string;
+    readonly projectId?: string | null;
+  }>;
+  readonly emitSessionsChanged: (
+    reason: SessionChangedReason,
+    sessionId?: string,
+    extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId' | 'turnId'>,
+  ) => void;
+  readonly emitModeChanged: RuntimeHostSessionDomainsIpcDeps['emitModeChanged'];
+  readonly sendToRenderer?: RuntimeHostSessionDomainsIpcDeps['sendToRenderer'];
+  readonly onError?: RuntimeHostSessionDomainsIpcDeps['onError'];
+  readonly newId?: () => string;
+  readonly now?: () => number;
+}
+
+export interface DesktopRuntimeHostCandidateStartInput extends DesktopRuntimeHostCandidateDeps {
+  readonly rootPath: string;
+  readonly clientInstanceId?: string;
+  readonly electionDeadlineMs?: number;
+  readonly connectTimeoutMs?: number;
+  readonly handshakeTimeoutMs?: number;
+}
+
+export type DesktopRuntimeHostCandidateStartResult =
+  | {
+      readonly kind: 'ready';
+      readonly candidate: DesktopRuntimeHostCandidate;
+    }
+  | Exclude<ConnectOrSpawnRuntimeHostResult, { kind: 'connected' }>;
+
+export interface DesktopRuntimeHostCandidate {
+  readonly botIncoming: BotIncomingMainService;
+  readonly closed: Promise<void>;
+  close(): Promise<void>;
+}
+
+class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
+  readonly botIncoming: BotIncomingMainService;
+  readonly closed: Promise<void>;
+  readonly #client: DesktopRuntimeHostClient;
+  readonly #observer: RuntimeHostSessionObserver;
+  readonly #ipc: ScopedIpcMain;
+  readonly #botIncoming: BotIncomingMainService;
+  readonly #nativeCapabilities: DesktopNativeCapabilityProvider;
+  readonly #capabilitiesRegistered: boolean;
+  #closeTask: Promise<void> | undefined;
+
+  constructor(input: {
+    client: DesktopRuntimeHostClient;
+    observer: RuntimeHostSessionObserver;
+    ipc: ScopedIpcMain;
+    botIncoming: BotIncomingMainService;
+    nativeCapabilities: DesktopNativeCapabilityProvider;
+    connectionClosed: Promise<void>;
+    capabilitiesRegistered: boolean;
+  }) {
+    this.#client = input.client;
+    this.#observer = input.observer;
+    this.#ipc = input.ipc;
+    this.#botIncoming = input.botIncoming;
+    this.#nativeCapabilities = input.nativeCapabilities;
+    this.#capabilitiesRegistered = input.capabilitiesRegistered;
+    this.botIncoming = input.botIncoming;
+    this.closed = input.connectionClosed.then(() => this.close());
+  }
+
+  close(): Promise<void> {
+    this.#closeTask ??= this.#close();
+    return this.#closeTask;
+  }
+
+  async #close(): Promise<void> {
+    const results = await Promise.allSettled([
+      this.#botIncoming.close(),
+      this.#nativeCapabilities.close(),
+      this.#closeConnection(),
+    ]);
+    const failed = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+    if (failed) throw failed.reason;
+  }
+
+  async #closeConnection(): Promise<void> {
+    this.#ipc.close();
+    await this.#observer.close().catch(() => undefined);
+    if (this.#capabilitiesRegistered) {
+      await this.#client.unregisterClientCapabilities().catch(() => undefined);
+    }
+    await this.#client.close();
+  }
+}
+
+export async function startDesktopRuntimeHostCandidate(
+  input: DesktopRuntimeHostCandidateStartInput,
+): Promise<DesktopRuntimeHostCandidateStartResult> {
+  const connection = await connectOrSpawnRuntimeHost(connectInput(input));
+  if (connection.kind !== 'connected') return connection;
+  return {
+    kind: 'ready',
+    candidate: await createDesktopRuntimeHostCandidate(connection.connection, input),
+  };
+}
+
+export async function createDesktopRuntimeHostCandidate(
+  connection: RuntimeHostConnection,
+  deps: DesktopRuntimeHostCandidateDeps,
+): Promise<DesktopRuntimeHostCandidate> {
+  const client = new DesktopRuntimeHostClient(connection);
+  const ipc = new ScopedIpcMain(deps.ipcMain);
+  let provider: ReturnType<typeof createDesktopNativeCapabilityProvider> | undefined;
+  let observer: RuntimeHostSessionObserver | undefined;
+  let capabilitiesRegistered = false;
+  try {
+    const nativeCapabilities = createDesktopNativeCapabilityProvider(deps.nativeCapabilities);
+    provider = nativeCapabilities;
+    if (
+      nativeCapabilities.offers().length > 0 ||
+      (nativeCapabilities.services?.().length ?? 0) > 0
+    ) {
+      await client.replaceClientCapabilities(nativeCapabilities);
+      capabilitiesRegistered = true;
+    }
+    const domains = registerRuntimeHostSessionDomainsIpc(
+      {
+        client,
+        emitModeChanged: deps.emitModeChanged,
+        ...(deps.sendToRenderer ? { sendToRenderer: deps.sendToRenderer } : {}),
+        ...(deps.onError ? { onError: deps.onError } : {}),
+        ...(deps.newId ? { newId: deps.newId } : {}),
+        ...(deps.now ? { now: deps.now } : {}),
+      },
+      ipc,
+    );
+    observer = new RuntimeHostSessionObserver({
+      client,
+      emitSessionsChanged: (reason, sessionId, extra) =>
+        deps.emitSessionsChanged(reason, sessionId, extra),
+      emitSessionDomainChanged: domains.sessionDomainChanged,
+      emitAgentGraphChanged: domains.agentGraphChanged,
+      ...(deps.now ? { now: deps.now } : {}),
+    });
+    registerRuntimeHostSessionCatalogIpc(
+      {
+        client,
+        workspaceRoot: deps.workspaceRoot,
+        emitSessionsChanged: deps.emitSessionsChanged,
+        releaseSessionResources: (sessionId) => nativeCapabilities.releaseSession(sessionId),
+        ...(deps.newId ? { newId: deps.newId } : {}),
+      },
+      ipc,
+    );
+    registerRuntimeHostSessionExecutionIpc(
+      {
+        client,
+        observer,
+        attachmentApprovals: deps.attachmentApprovals,
+        emitSessionsChanged: deps.emitSessionsChanged,
+        stat: deps.stat,
+        resizeImage: deps.resizeImage,
+        ...(deps.newId ? { newId: deps.newId } : {}),
+      },
+      ipc,
+    );
+    const botIncoming = createBotIncomingMainService({
+      botRegistry: deps.botRegistry,
+      sessions: createRuntimeHostBotSessionAdapter({
+        client,
+        resolveCreateTarget: deps.resolveBotCreateTarget,
+        emitSessionsChanged: deps.emitSessionsChanged,
+        ...(deps.newId ? { newId: deps.newId } : {}),
+      }),
+    });
+    return new DesktopRuntimeHostCandidateImpl({
+      client,
+      observer,
+      ipc,
+      botIncoming,
+      nativeCapabilities,
+      connectionClosed: connection.closed,
+      capabilitiesRegistered,
+    });
+  } catch (error) {
+    ipc.close();
+    await observer?.close().catch(() => undefined);
+    await client.close().catch(() => undefined);
+    await Promise.resolve(provider?.close?.()).catch(() => undefined);
+    throw error;
+  }
+}
+
+function connectInput(
+  input: DesktopRuntimeHostCandidateStartInput,
+): ConnectOrSpawnRuntimeHostInput {
+  return {
+    rootPath: input.rootPath,
+    surface: 'desktop',
+    protocol: {
+      min: RUNTIME_HOST_PROTOCOL_VERSION,
+      max: RUNTIME_HOST_PROTOCOL_VERSION,
+    },
+    ...(input.clientInstanceId === undefined ? {} : { clientInstanceId: input.clientInstanceId }),
+    ...(input.electionDeadlineMs === undefined
+      ? {}
+      : { electionDeadlineMs: input.electionDeadlineMs }),
+    ...(input.connectTimeoutMs === undefined ? {} : { connectTimeoutMs: input.connectTimeoutMs }),
+    ...(input.handshakeTimeoutMs === undefined
+      ? {}
+      : { handshakeTimeoutMs: input.handshakeTimeoutMs }),
+  };
+}
+
+class ScopedIpcMain implements Pick<IpcMain, 'handle'> {
+  readonly #ipcMain: CandidateIpcMain;
+  readonly #channels = new Set<string>();
+  #closed = false;
+
+  constructor(ipcMain: CandidateIpcMain) {
+    this.#ipcMain = ipcMain;
+  }
+
+  handle(channel: string, listener: Parameters<IpcMain['handle']>[1]): void {
+    if (this.#closed) throw new Error('Desktop Runtime Host candidate IPC is closed');
+    if (this.#channels.has(channel)) {
+      throw new Error(`Desktop Runtime Host candidate registered duplicate IPC: ${channel}`);
+    }
+    this.#ipcMain.handle(channel, listener);
+    this.#channels.add(channel);
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const channel of this.#channels) this.#ipcMain.removeHandler(channel);
+    this.#channels.clear();
+  }
+}

--- a/apps/desktop/src/main/runtime-host-native-capabilities.ts
+++ b/apps/desktop/src/main/runtime-host-native-capabilities.ts
@@ -18,11 +18,9 @@ interface NativeCapabilityGroup {
   readonly label: string;
   readonly description: string;
   readonly tools: readonly MakaTool[];
-  readonly clearSession?: (sessionId: string) => void;
 }
 
 interface NativeToolBinding {
-  readonly group: NativeCapabilityGroup;
   readonly tool: MakaTool;
 }
 
@@ -31,73 +29,99 @@ type DesktopToolContentPart = Extract<DesktopToolModelOutput, { type: 'content' 
 
 export interface DesktopNativeCapabilityProviderInput {
   readonly browserTools: readonly MakaTool[];
+  readonly releaseBrowserSession: (sessionId: string) => void | Promise<void>;
   readonly computerUseTools: ComputerUseToolSet;
+  readonly releaseComputerUseSession: (sessionId: string) => void | Promise<void>;
+}
+
+export interface DesktopNativeCapabilityProvider extends ClientCapabilityProvider {
+  releaseSession(sessionId: string): Promise<void>;
+  close(): Promise<void>;
 }
 
 /** Adapt Desktop-owned Maka tools to the open Client Capability protocol. */
 export function createDesktopNativeCapabilityProvider(
   input: DesktopNativeCapabilityProviderInput,
-): ClientCapabilityProvider {
+): DesktopNativeCapabilityProvider {
   const groups = capabilityGroups(input);
   const offers = Object.freeze(groups.map(capabilityOffer));
   const bindings = indexBindings(groups);
-  const activeInvocations = new Set<AbortController>();
-  const usedSessions = new Map<NativeCapabilityGroup, Set<string>>();
+  const releaseSessionResources = [
+    input.releaseBrowserSession,
+    input.releaseComputerUseSession,
+  ] as const;
+  const activeInvocations = new Map<
+    AbortController,
+    { readonly sessionId: string; readonly settled: Promise<void> }
+  >();
+  const usedSessionIds = new Set<string>();
   let closed = false;
+  let closeTask: Promise<void> | undefined;
+
+  function close(): Promise<void> {
+    if (closeTask) return closeTask;
+    closed = true;
+    closeTask = closeProvider(activeInvocations, usedSessionIds, releaseSessionResources);
+    return closeTask;
+  }
 
   return {
     offers: () => offers,
-    call: async (frame, options) => {
+    call: (frame, options) => {
       if (closed) throw new Error('Desktop native capability provider is closed');
       const binding = bindings.get(bindingKey(frame));
       if (!binding) throw new Error('Desktop native capability is not offered');
 
       const invocation = new AbortController();
-      activeInvocations.add(invocation);
-      const signal = AbortSignal.any([options.signal, invocation.signal]);
-      try {
-        signal.throwIfAborted();
-        const parameters = requireZodSchema(binding.tool);
-        const args = await parameters.parseAsync(frame.arguments);
-        signal.throwIfAborted();
-        await options.accept();
-        signal.throwIfAborted();
-        if (binding.group.clearSession) {
-          let sessions = usedSessions.get(binding.group);
-          if (!sessions) {
-            sessions = new Set();
-            usedSessions.set(binding.group, sessions);
-          }
-          sessions.add(frame.sessionId);
-        }
-        const output = await binding.tool.impl(args, {
-          sessionId: frame.sessionId,
-          turnId: frame.turnId,
-          cwd: frame.cwd,
-          toolCallId: frame.toolCallId,
-          abortSignal: signal,
-          emitOutput() {},
-        });
-        return projectToolResult(binding.tool, frame.toolCallId, args, output);
-      } finally {
-        activeInvocations.delete(invocation);
-      }
+      const task = invokeNativeTool(binding, frame, options, invocation, usedSessionIds);
+      const settled = task.then(
+        () => undefined,
+        () => undefined,
+      );
+      activeInvocations.set(invocation, { sessionId: frame.sessionId, settled });
+      void settled.finally(() => activeInvocations.delete(invocation));
+      return task;
     },
-    close: async () => {
-      if (closed) return;
-      closed = true;
-      for (const invocation of activeInvocations) {
-        invocation.abort(new Error('Desktop native capability provider closed'));
-      }
-      activeInvocations.clear();
-      const sessionCleanup =
-        [...usedSessions].flatMap(([group, sessions]) =>
-          [...sessions].map(async (sessionId) => group.clearSession?.(sessionId)),
-        );
-      usedSessions.clear();
-      await Promise.all(sessionCleanup);
+    releaseSession: async (sessionId) => {
+      const settling = abortInvocations(activeInvocations, sessionId);
+      await Promise.all(settling);
+      usedSessionIds.delete(sessionId);
+      await settleSessionReleases(releaseSessionResources, [sessionId]);
     },
+    close,
   };
+}
+
+async function closeProvider(
+  activeInvocations: ReadonlyMap<
+    AbortController,
+    { readonly sessionId: string; readonly settled: Promise<void> }
+  >,
+  usedSessionIds: Set<string>,
+  releases: readonly ((sessionId: string) => void | Promise<void>)[],
+): Promise<void> {
+  const settling: Promise<void>[] = [];
+  for (const [invocation, active] of activeInvocations) {
+    invocation.abort(new Error('Desktop native capability provider closed'));
+    settling.push(active.settled);
+  }
+  await Promise.all(settling);
+  const sessionIds = [...usedSessionIds];
+  usedSessionIds.clear();
+  await settleSessionReleases(releases, sessionIds);
+}
+
+async function settleSessionReleases(
+  releases: readonly ((sessionId: string) => void | Promise<void>)[],
+  sessionIds: readonly string[],
+): Promise<void> {
+  const results = await Promise.allSettled(
+    sessionIds.flatMap((sessionId) =>
+      releases.map(async (release) => release(sessionId)),
+    ),
+  );
+  const failed = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+  if (failed) throw failed.reason;
 }
 
 function capabilityGroups(input: DesktopNativeCapabilityProviderInput): NativeCapabilityGroup[] {
@@ -119,11 +143,52 @@ function capabilityGroups(input: DesktopNativeCapabilityProviderInput): NativeCa
             label: 'Computer Use',
             description: 'Observe and operate the desktop through this Desktop client.',
             tools: input.computerUseTools,
-            clearSession: (sessionId: string) => input.computerUseTools.clearSession(sessionId),
           },
         ]
       : []),
   ];
+}
+
+async function invokeNativeTool(
+  binding: NativeToolBinding,
+  frame: ClientCapabilityCallFrame,
+  options: Parameters<NonNullable<ClientCapabilityProvider['call']>>[1],
+  invocation: AbortController,
+  usedSessionIds: Set<string>,
+): Promise<ClientCapabilityCallResult> {
+  const signal = AbortSignal.any([options.signal, invocation.signal]);
+  signal.throwIfAborted();
+  const parameters = requireZodSchema(binding.tool);
+  const args = await parameters.parseAsync(frame.arguments);
+  signal.throwIfAborted();
+  await options.accept();
+  signal.throwIfAborted();
+  usedSessionIds.add(frame.sessionId);
+  const output = await binding.tool.impl(args, {
+    sessionId: frame.sessionId,
+    turnId: frame.turnId,
+    cwd: frame.cwd,
+    toolCallId: frame.toolCallId,
+    abortSignal: signal,
+    emitOutput() {},
+  });
+  return projectToolResult(binding.tool, frame.toolCallId, args, output);
+}
+
+function abortInvocations(
+  activeInvocations: ReadonlyMap<
+    AbortController,
+    { readonly sessionId: string; readonly settled: Promise<void> }
+  >,
+  sessionId: string,
+): Promise<void>[] {
+  const settling: Promise<void>[] = [];
+  for (const [invocation, active] of activeInvocations) {
+    if (active.sessionId !== sessionId) continue;
+    invocation.abort(new Error('Desktop native capability Session released'));
+    settling.push(active.settled);
+  }
+  return settling;
 }
 
 function capabilityOffer(group: NativeCapabilityGroup): ClientCapabilityOffer {
@@ -155,6 +220,7 @@ function toolInputSchema(tool: MakaTool): Record<string, unknown> {
     cycles: 'ref',
     reused: 'inline',
   });
+  delete schema.$schema;
   if (schema.type !== 'object') {
     throw new Error(`Desktop native capability tool schema must be an object: ${tool.name}`);
   }
@@ -180,7 +246,7 @@ function indexBindings(groups: readonly NativeCapabilityGroup[]): Map<string, Na
       if (bindings.has(key)) {
         throw new Error(`Duplicate Desktop native capability tool: ${group.offerId}/${tool.name}`);
       }
-      bindings.set(key, { group, tool });
+      bindings.set(key, { tool });
     }
   }
   return bindings;

--- a/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
@@ -50,6 +50,7 @@ export interface RuntimeHostSessionCatalogIpcDeps {
     sessionId?: string,
     extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId' | 'turnId'>,
   ) => void;
+  releaseSessionResources: (sessionId: string) => void | Promise<void>;
   newId?: () => string;
 }
 
@@ -96,13 +97,15 @@ export function registerRuntimeHostSessionCatalogIpc(
   });
   ipcMain.handle('sessions:archive', async (_event, sessionId: string, options?: unknown) => {
     requestsRevisionFamily(options);
+    const ids = await actionIds(sessionId, { revisionFamily: true });
     await deps.client.setSessionLifecycle(sessionId, 'archived');
-    deps.emitSessionsChanged('archived', sessionId);
+    await finishSessionRetirement(deps, ids, 'archived');
   });
   ipcMain.handle('sessions:unarchive', async (_event, sessionId: string, options?: unknown) => {
     requestsRevisionFamily(options);
+    const ids = await actionIds(sessionId, { revisionFamily: true });
     await deps.client.setSessionLifecycle(sessionId, 'active');
-    deps.emitSessionsChanged('updated', sessionId);
+    for (const id of ids) deps.emitSessionsChanged('updated', id);
   });
   ipcMain.handle(
     'sessions:setFlagged',
@@ -164,9 +167,23 @@ export function registerRuntimeHostSessionCatalogIpc(
   });
   ipcMain.handle('sessions:remove', async (_event, sessionId: string, options?: unknown) => {
     requestsRevisionFamily(options);
+    const ids = await actionIds(sessionId, { revisionFamily: true });
     await deps.client.removeSession(sessionId);
-    deps.emitSessionsChanged('deleted', sessionId);
+    await finishSessionRetirement(deps, ids, 'deleted');
   });
+}
+
+async function finishSessionRetirement(
+  deps: RuntimeHostSessionCatalogIpcDeps,
+  sessionIds: readonly string[],
+  reason: Extract<SessionChangedReason, 'archived' | 'deleted'>,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    sessionIds.map((sessionId) => deps.releaseSessionResources(sessionId)),
+  );
+  for (const sessionId of sessionIds) deps.emitSessionsChanged(reason, sessionId);
+  const failed = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+  if (failed) throw failed.reason;
 }
 
 async function updateConfiguration(

--- a/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
@@ -24,7 +24,7 @@ import {
   type RuntimeHostSessionObserverTarget,
 } from './runtime-host-session-observer.js';
 import { toDesktopHostSessionSummary } from './runtime-host-session-catalog-ipc-main.js';
-import { mergeSentInlineReferences } from './session-send-inline-references.js';
+import { mergeWorkspaceFileInlineReferences } from './session-workspace-inline-references.js';
 
 const EMPTY_SKILL_INVOCATION: SkillInvocationResult = {
   loaded: [],
@@ -139,10 +139,9 @@ export function registerRuntimeHostSessionExecutionIpc(
       });
     }
     const displayText = command.displayText ?? command.text;
-    const inlineReferences = mergeSentInlineReferences({
+    const inlineReferences = mergeWorkspaceFileInlineReferences({
       displayText,
       workspaceFileReferences: command.workspaceFileReferences,
-      receipts: [],
     });
     await deps.client.startTurn({
       sessionId,

--- a/apps/desktop/src/main/session-send-inline-references.ts
+++ b/apps/desktop/src/main/session-send-inline-references.ts
@@ -1,14 +1,9 @@
+import type { InlineReference } from '@maka/core';
+import { skillInvocationInlineReferences, type SkillInvocationReceipt } from '@maka/runtime';
 import {
-  INLINE_REFERENCE_LABEL_MAX_LENGTH,
-  INLINE_REFERENCE_MAX_COUNT,
-  isInlineReference,
-  type InlineReference,
-} from '@maka/core';
-import { posix } from 'node:path';
-import {
-  skillInvocationInlineReferences,
-  type SkillInvocationReceipt,
-} from '@maka/runtime';
+  mergeSessionInlineReferences,
+  workspaceFileInlineReferenceCandidates,
+} from './session-workspace-inline-references.js';
 
 /**
  * Join the two authorities for sent inline tokens, then freeze their transcript
@@ -20,42 +15,8 @@ export function mergeSentInlineReferences(input: {
   workspaceFileReferences?: ReadonlyArray<Pick<InlineReference, 'value' | 'start'>>;
   receipts: readonly SkillInvocationReceipt[];
 }): InlineReference[] {
-  const candidates: InlineReference[] = [
-    ...(input.workspaceFileReferences ?? []).map((reference) => ({
-      kind: 'workspace_file' as const,
-      value: reference.value,
-      label: posix.basename(reference.value.slice(1)),
-      start: reference.start,
-    })),
+  return mergeSessionInlineReferences(input.displayText, [
+    ...workspaceFileInlineReferenceCandidates(input),
     ...skillInvocationInlineReferences(input.receipts, input.displayText),
-  ].sort((left, right) => left.start - right.start || right.value.length - left.value.length);
-  const references: InlineReference[] = [];
-  let previousEnd = 0;
-  for (const candidate of candidates) {
-    if (references.length >= INLINE_REFERENCE_MAX_COUNT) break;
-    const reference = {
-      ...candidate,
-      label: truncateWithoutSplittingSurrogate(
-        candidate.label,
-        INLINE_REFERENCE_LABEL_MAX_LENGTH,
-      ),
-    };
-    if (
-      !isInlineReference(reference) ||
-      reference.start < previousEnd ||
-      input.displayText.slice(reference.start, reference.start + reference.value.length) !==
-        reference.value
-    ) {
-      continue;
-    }
-    references.push(reference);
-    previousEnd = reference.start + reference.value.length;
-  }
-  return references;
-}
-
-function truncateWithoutSplittingSurrogate(value: string, maxCodeUnits: number): string {
-  const truncated = value.slice(0, maxCodeUnits);
-  const lastCodeUnit = truncated.charCodeAt(truncated.length - 1);
-  return lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? truncated.slice(0, -1) : truncated;
+  ]);
 }

--- a/apps/desktop/src/main/session-workspace-inline-references.ts
+++ b/apps/desktop/src/main/session-workspace-inline-references.ts
@@ -1,0 +1,63 @@
+import {
+  INLINE_REFERENCE_LABEL_MAX_LENGTH,
+  INLINE_REFERENCE_MAX_COUNT,
+  isInlineReference,
+  type InlineReference,
+} from '@maka/core';
+import { posix } from 'node:path';
+
+export function mergeWorkspaceFileInlineReferences(input: {
+  displayText: string;
+  workspaceFileReferences?: ReadonlyArray<Pick<InlineReference, 'value' | 'start'>>;
+}): InlineReference[] {
+  return mergeSessionInlineReferences(
+    input.displayText,
+    workspaceFileInlineReferenceCandidates(input),
+  );
+}
+
+export function workspaceFileInlineReferenceCandidates(input: {
+  workspaceFileReferences?: ReadonlyArray<Pick<InlineReference, 'value' | 'start'>>;
+}): InlineReference[] {
+  return (input.workspaceFileReferences ?? []).map((reference) => ({
+    kind: 'workspace_file' as const,
+    value: reference.value,
+    label: posix.basename(reference.value.slice(1)),
+    start: reference.start,
+  }));
+}
+
+export function mergeSessionInlineReferences(
+  displayText: string,
+  candidates: readonly InlineReference[],
+): InlineReference[] {
+  const ordered = [...candidates].sort(
+    (left, right) => left.start - right.start || right.value.length - left.value.length,
+  );
+  const references: InlineReference[] = [];
+  let previousEnd = 0;
+  for (const candidate of ordered) {
+    if (references.length >= INLINE_REFERENCE_MAX_COUNT) break;
+    const reference = {
+      ...candidate,
+      label: truncateWithoutSplittingSurrogate(candidate.label, INLINE_REFERENCE_LABEL_MAX_LENGTH),
+    };
+    if (
+      !isInlineReference(reference) ||
+      reference.start < previousEnd ||
+      displayText.slice(reference.start, reference.start + reference.value.length) !==
+        reference.value
+    ) {
+      continue;
+    }
+    references.push(reference);
+    previousEnd = reference.start + reference.value.length;
+  }
+  return references;
+}
+
+function truncateWithoutSplittingSurrogate(value: string, maxCodeUnits: number): string {
+  const truncated = value.slice(0, maxCodeUnits);
+  const lastCodeUnit = truncated.charCodeAt(truncated.length - 1);
+  return lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? truncated.slice(0, -1) : truncated;
+}


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- compose the existing Desktop Runtime Host catalog, execution, domain, observer, native-capability, and Bot adapters behind one isolated connection generation
- give that generation explicit ownership of scoped IPC registration, queued Bot work, native Session resources, subscriptions, capability registration, and connection teardown
- add a production-shaped real-UDS journey plus a dependency-graph gate that prevents the candidate from reaching embedded Runtime or Store owners

## Ownership and lifecycle

The candidate uses one `DesktopRuntimeHostClient` and closes the complete generation before a fresh connection can be started. Setup failures roll back claimed resources, Session retirement releases Browser and Computer Use state for the full Host-owned revision family, and shutdown waits for all Bot/native cleanup to settle.

The production Desktop boot path is unchanged and continues to use the embedded owner until the atomic M5 cutover.

## Verification

- Desktop tests: 1704 passed
- full workspace typecheck
- lint and format checks
- production build

Part of #2010.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 将现有 Desktop Runtime Host catalog、execution、domain、observer、native capability 与 Bot adapter 组合到同一个隔离的 connection generation 中
- 让该 generation 明确拥有 scoped IPC 注册、排队中的 Bot 工作、native Session 资源、subscription、capability registration 与 connection teardown
- 增加 production-shaped 的真实 UDS journey 与 dependency graph gate，确保 candidate 无法到达 embedded Runtime 或 Store owner

## Ownership 与生命周期

Candidate 只使用一个 `DesktopRuntimeHostClient`，并在启动新连接前完整关闭旧 generation。初始化失败会回滚已经接管的资源；Session retirement 会为 Host-owned 的完整 revision family 释放 Browser 与 Computer Use 状态；shutdown 会等待全部 Bot/native cleanup settle。

Production Desktop boot path 保持不变，在 M5 原子 cutover 前继续使用 embedded owner。

## 验证

- Desktop 测试：1704 项通过
- 整库 typecheck
- lint 与 format 检查
- production build

属于 #2010 的一部分。

</details>
