### PR TITLE
Bundle and verify a hermetic Git runtime for managed workspaces

### DIFF
--- a/.github/workflows/release-windows-check.yml
+++ b/.github/workflows/release-windows-check.yml
@@ -16,6 +16,8 @@ on:
       - 'apps/desktop/electron-builder.config.mjs'
       - 'apps/desktop/package.json'
       - 'scripts/package-windows-x64.mjs'
+      - 'scripts/prepare-bundled-git.mjs'
+      - 'scripts/prepare-bundled-git.test.mjs'
       - 'scripts/verify-windows-x64.mjs'
       - 'scripts/verify-packaged-app.mjs'
       - 'scripts/npm-spawn.mjs'
@@ -23,6 +25,7 @@ on:
       - '.gitattributes'
       - 'package.json'
       - 'package-lock.json'
+      - 'apps/desktop/resources/licenses/git/NOTICE.txt'
       - '.github/workflows/release-windows-check.yml'
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ deepseek.key
 
 # Generated Computer Use executor binary; provenance metadata stays tracked.
 apps/desktop/resources/bin/
+apps/desktop/bundled-git.json
 
 # Generated desktop release inputs and outputs.
 apps/desktop/resources/tools/

--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -9,6 +9,14 @@ export default {
   files: ['dist/**/*', 'dist-renderer/**/*', 'package.json', '!**/__tests__/**'],
   extraResources: [
     {
+      from: '../../node_modules/dugite/git',
+      to: 'git',
+    },
+    {
+      from: 'bundled-git.json',
+      to: 'bundled-git.json',
+    },
+    {
       from: 'bundled-tools.json',
       to: 'bundled-tools.json',
     },
@@ -25,6 +33,14 @@ export default {
     {
       from: '../../LICENSE',
       to: 'licenses/maka/LICENSE',
+    },
+    {
+      from: '../../node_modules/dugite/LICENSE',
+      to: 'licenses/dugite/LICENSE',
+    },
+    {
+      from: 'resources/licenses/git/NOTICE.txt',
+      to: 'licenses/git/NOTICE.txt',
     },
     {
       from: '../../NOTICE',

--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -43,6 +43,10 @@ export default {
       to: 'licenses/git/NOTICE.txt',
     },
     {
+      from: 'resources/licenses/git/LICENSE.txt',
+      to: 'licenses/git/LICENSE.txt',
+    },
+    {
       from: '../../NOTICE',
       to: 'licenses/maka/NOTICE',
     },

--- a/apps/desktop/resources/licenses/git/LICENSE.txt
+++ b/apps/desktop/resources/licenses/git/LICENSE.txt
@@ -1,0 +1,360 @@
+
+ Note that the only valid version of the GPL as far as this project
+ is concerned is _this_ particular version of the license (ie v2, not
+ v2.2 or v3.x or whatever), unless explicitly otherwise stated.
+
+ HOWEVER, in order to allow a migration to GPLv3 if that seems like
+ a good idea, I also ask that people involved with the project make
+ their preferences known. In particular, if you trust me to make that
+ decision, you might note so in your copyright message, ie something
+ like
+
+	This file is licensed under the GPL v2, or a later version
+	at the discretion of Linus.
+
+  might avoid issues. But we can also just decide to synchronize and
+  contact all copyright holders on record if/when the occasion arises.
+
+			Linus Torvalds
+
+----------------------------------------
+
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/apps/desktop/resources/licenses/git/NOTICE.txt
+++ b/apps/desktop/resources/licenses/git/NOTICE.txt
@@ -6,10 +6,11 @@ dugite-native project. The pinned release is declared by dugite 3.2.2 in
 node_modules/dugite/script/embedded-git.json and is verified by SHA-256 before
 extraction.
 
-Git is licensed under the GNU General Public License version 2. The packaged Git
-distribution carries its upstream license and component notices inside the
-resources/git directory. Corresponding source for the exact bundled release is
-available from:
+Git is licensed under the GNU General Public License version 2. Maka packages a
+stable copy of that license at resources/licenses/git/LICENSE.txt because the
+upstream platform archives do not expose one uniform internal path. Component
+notices that are present in the upstream distribution remain inside resources/git.
+Corresponding source for the exact bundled release is available from:
 
 https://github.com/desktop/dugite-native/releases/tag/v2.53.0-3
 

--- a/apps/desktop/resources/licenses/git/NOTICE.txt
+++ b/apps/desktop/resources/licenses/git/NOTICE.txt
@@ -1,0 +1,17 @@
+Maka bundled Git runtime
+========================
+
+Maka packages the cross-platform Git distribution maintained by GitHub Desktop's
+dugite-native project. The pinned release is declared by dugite 3.2.2 in
+node_modules/dugite/script/embedded-git.json and is verified by SHA-256 before
+extraction.
+
+Git is licensed under the GNU General Public License version 2. The packaged Git
+distribution carries its upstream license and component notices inside the
+resources/git directory. Corresponding source for the exact bundled release is
+available from:
+
+https://github.com/desktop/dugite-native/releases/tag/v2.53.0-3
+
+The dugite JavaScript wrapper is licensed under the MIT License; its license is
+packaged at resources/licenses/dugite/LICENSE.

--- a/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
+++ b/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
@@ -4046,10 +4046,460 @@ Apache License
 
 ================================================================================
 
+Package: bare-path@3.1.1
+Declared license: Apache-2.0
+Selected license: Apache-2.0
+Repository: git+https://github.com/holepunchto/bare-path.git
+
+--- LICENSE ---
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--- NOTICE ---
+Copyright 2023 Holepunch Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---
+
+Copyright Joyent, Inc. and other Node contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+================================================================================
+
 Package: bare-semver@1.1.0
 Declared license: Apache-2.0
 Selected license: Apache-2.0
 Repository: git+https://github.com/holepunchto/bare-semver.git
+
+--- LICENSE ---
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+================================================================================
+
+Package: bare-url@2.4.7
+Declared license: Apache-2.0
+Selected license: Apache-2.0
+Repository: git+https://github.com/holepunchto/bare-url.git
 
 --- LICENSE ---
 Apache License

--- a/docs/architecture/bundled-git-runtime-v1.md
+++ b/docs/architecture/bundled-git-runtime-v1.md
@@ -21,6 +21,16 @@ Ownership is split deliberately:
 - storage re-hashes the exact executable before every Git process and constructs the `dugite-native`
   helper environment without inheriting a system-Git `PATH`.
 
+Two digests intentionally serve different purposes:
+
+- `executableSha256` is rechecked immediately before every Git invocation. It proves which entry binary
+  storage is about to execute;
+- `runtimeIdentitySha256` is a canonical digest of the declared distribution identity: manifest
+  protocol, provider, Git version, platform, architecture, executable location and digest, and the
+  upstream archive digest. Managed repository, epoch, and worktree-binding artifacts persist this value
+  as `gitRuntimeSha256`, so changing any of that provenance creates an explicit epoch incompatibility
+  instead of silently reinterpreting an existing workspace.
+
 The manifest is evidence about one packaged distribution, not a mutable preference and not a system Git
 probe result.
 
@@ -35,6 +45,16 @@ The packaged runtime includes the complete `dugite-native` directory rather than
 Git subprograms, templates, MinGit libraries, certificates, and platform support files remain relative to
 the same root. Runtime environment variables (`GIT_EXEC_PATH`, templates, Linux `PREFIX`/CA bundle, and
 Windows MinGit paths) are derived only from that declared root.
+
+Production never resolves Git through `node_modules`. Dugite is the build-time supplier; Electron copies
+the complete extracted distribution to `resources/git`, and Runtime Host resolves only that signed
+application resource root. Storage receives a narrow verified-runtime input and has no dependency on the
+dugite npm package or its manifest format.
+
+`VerifiedGitRuntime` is currently the Maka-owned adapter boundary between managed-workspace operations
+and the distribution. A broader public `MakaGitRuntime` interface is intentionally deferred until a
+second production implementation exists; introducing a swappable system-Git or libgit2 abstraction now
+would create an unsupported execution mode rather than strengthen the present invariant.
 
 ## 3. Ordering and atomic boundary
 
@@ -51,6 +71,13 @@ Publication ordering is:
 There is no cross-filesystem transaction spanning npm download and application packaging. A partially
 prepared or mixed artifact is therefore not repaired in place: no `distributionReady: true` manifest is
 accepted unless all build checks have completed, and runtime fails closed on any mismatch.
+
+The v1 identity binds the SHA-256-verified upstream archive rather than hashing every extracted file at
+startup. This avoids an important signing ambiguity: macOS code signing may legitimately rewrite Mach-O
+bytes after the prepare step, so a pre-sign tree digest could make the signed application reject itself.
+A future post-sign runtime-tree/Merkle manifest must be generated and verified inside the release-signing
+pipeline, not added as an ordinary prepare-time hash. Until then, Maka does not claim per-file integrity
+for every helper in the extracted tree.
 
 ## 4. Failure states and rollback
 
@@ -88,5 +115,23 @@ managed-workspace artifact protocol and its crash tests.
 - packaged app contains the Git runtime, manifest, and license notices;
 - production-shaped managed workspace open using the packaged runtime (required before broad enablement).
 
+The production-shaped smoke exercises the real commands required by the current owner, including
+repository creation, ref updates, tree/index operations, and worktree lifecycle. This is the capability
+gate. Startup `--help` probes are deliberately not used: they are weaker than executing the actual
+workflow, can invoke pagers or platform-specific help behavior, and would duplicate checks before every
+application launch. Individual Git failures remain fail-closed at the operation boundary.
+
 The last item is deliberately a release gate rather than evidence that managed execution is already the
 default. Desktop/CLI activation remains a later, explicit product decision.
+
+## 7. Licensing and size policy
+
+The full `dugite-native` directory is packaged, including its component license directories, Git's
+`LICENSE.txt`, and Maka's Git/dugite notices. A generated component inventory is useful release
+hardening, but it is not represented as a runtime-authority guarantee in v1 and should be implemented as
+a dedicated supply-chain slice.
+
+The first release keeps the full upstream distribution. Pruning shells, Perl, GUI programs, docs, or
+helpers is deferred until Maka has an exact command/helper allowlist and the pruned artifact passes the
+same production-shaped release smoke on Windows, macOS, and Linux. Package size alone is not sufficient
+evidence that a helper is safe to remove.

--- a/docs/architecture/bundled-git-runtime-v1.md
+++ b/docs/architecture/bundled-git-runtime-v1.md
@@ -1,0 +1,92 @@
+# Bundled Git Runtime v1
+
+Status: implementation slice for managed-workspace execution. This is a publication capability that
+sits between M1.2 runtime-host composition and broad managed-workspace enablement; it is not M1.3
+dependency/secret provisioning.
+
+## 1. Invariant and owner
+
+The Runtime Host may enable the managed-workspace owner only with the Maka-packaged Git toolchain for
+the current platform and architecture. It must never discover or fall back to a Git executable through
+`PATH`, a shell profile, a package manager, or the source workspace.
+
+Ownership is split deliberately:
+
+- `dugite@3.2.2` owns the upstream `dugite-native` release URL and archive SHA-256;
+- `scripts/prepare-bundled-git.mjs` owns build-time version, executable, license, and digest validation;
+- `bundled-git.json` binds one packaged artifact to platform, architecture, Git version, archive digest,
+  executable path, and executable digest;
+- Runtime Host resolves the manifest and refuses missing, malformed, mismatched, escaped, symlinked, or
+  digest-mismatched artifacts;
+- storage re-hashes the exact executable before every Git process and constructs the `dugite-native`
+  helper environment without inheriting a system-Git `PATH`.
+
+The manifest is evidence about one packaged distribution, not a mutable preference and not a system Git
+probe result.
+
+## 2. Supply chain
+
+The dependency is exact-pinned as `dugite@3.2.2`. Its `embedded-git.json` pins
+`desktop/dugite-native@v2.53.0-3` and provides a SHA-256 for every supported archive. Dugite verifies that
+archive before extraction. Maka then executes the extracted binary with `--version`, hashes that exact
+binary, and emits the platform manifest used by packaging and runtime admission.
+
+The packaged runtime includes the complete `dugite-native` directory rather than copying only `git`.
+Git subprograms, templates, MinGit libraries, certificates, and platform support files remain relative to
+the same root. Runtime environment variables (`GIT_EXEC_PATH`, templates, Linux `PREFIX`/CA bundle, and
+Windows MinGit paths) are derived only from that declared root.
+
+## 3. Ordering and atomic boundary
+
+Publication ordering is:
+
+1. install the exact npm lockfile;
+2. let dugite download and SHA-256 verify the platform archive;
+3. run `prepare:bundled-git` and verify the executable version and digest;
+4. package the complete Git directory, manifest, and notices in the signed application;
+5. verify their presence in the packaged application;
+6. at Runtime Host startup, resolve and verify the manifest before composing a managed-workspace owner;
+7. immediately before each Git invocation, storage re-verifies the executable digest.
+
+There is no cross-filesystem transaction spanning npm download and application packaging. A partially
+prepared or mixed artifact is therefore not repaired in place: no `distributionReady: true` manifest is
+accepted unless all build checks have completed, and runtime fails closed on any mismatch.
+
+## 4. Failure states and rollback
+
+Stable runtime failure classes are:
+
+- `bundled_git_unavailable`: manifest or executable is absent/unreadable;
+- `bundled_git_manifest_invalid`: schema, path, or distribution metadata is invalid;
+- `bundled_git_platform_mismatch`: artifact targets a different OS or architecture;
+- `bundled_git_integrity_mismatch`: packaged executable differs from the build manifest.
+
+These failures disable managed-workspace composition. They do not change attached mode and never cause a
+system Git fallback. Rollback is release-level: ship the prior application bundle or disable the managed
+workspace feature. Runtime must not rewrite the signed resources or silently regenerate the manifest.
+
+## 5. Platform matrix
+
+| Platform | Bundled executable | Helper environment | Current promise |
+|---|---|---|---|
+| Windows x64/arm64/ia32 | `git/cmd/git.exe` | MinGit `mingw*`/`clangarm64` bin and `libexec/git-core` | Supported by the pinned dugite-native archive; managed filesystem execution remains separately gated by the Windows sandbox capability |
+| macOS x64/arm64 | `git/bin/git` | bundle `libexec/git-core` and templates | Supported; release must remain code-signed/notarized as one app bundle |
+| Linux x64/arm64/arm/ia32 | `git/bin/git` | bundle `libexec`, templates, `PREFIX`, and CA file | Supported where the corresponding pinned archive and filesystem sandbox backend are available |
+
+Power-loss durability is not created by bundling Git. Repository/worktree durability remains owned by the
+managed-workspace artifact protocol and its crash tests.
+
+## 6. Acceptance tests
+
+- strict manifest happy path;
+- platform/architecture mismatch;
+- executable tampering;
+- missing manifest with a system Git present (must still fail);
+- path escape and symlink rejection;
+- build preparation from the exact dugite platform record;
+- Git version mismatch and unsupported platform rejection;
+- packaged app contains the Git runtime, manifest, and license notices;
+- production-shaped managed workspace open using the packaged runtime (required before broad enablement).
+
+The last item is deliberately a release gate rather than evidence that managed execution is already the
+default. Desktop/CLI activation remains a later, explicit product decision.

--- a/docs/architecture/bundled-git-runtime-v1.md
+++ b/docs/architecture/bundled-git-runtime-v1.md
@@ -62,6 +62,15 @@ shell environment into this map. On Windows, the MinGit DLL/helper directories a
 the current working directory is the Maka-owned home rather than the source checkout or application
 directory.
 
+The execution profile is also injected at command priority and persisted on Maka-owned repositories:
+`core.hooksPath` points at the owned empty hooks directory, credential helpers and interactive prompts
+are disabled, `core.sshCommand` is empty, and `protocol.allow=never` prevents transport activation in
+the current local-only workspace protocol. Operation-scoped environment values are merged before the
+hermetic profile, so they cannot override its HOME, PATH, config, or prompt fences. Source repository
+configuration is never copied into the independent managed repository; unsupported indirection such as
+includes, alternates, replace refs, partial-clone state, and executable fsmonitor configuration is
+rejected before baseline import.
+
 Production never resolves Git through `node_modules`. Dugite is the build-time supplier; Electron copies
 the complete extracted distribution to `resources/git`, and Runtime Host resolves only that signed
 application resource root. Storage receives a narrow verified-runtime input and has no dependency on the
@@ -95,6 +104,16 @@ A future post-sign runtime-tree/Merkle manifest must be generated and verified i
 pipeline, not added as an ordinary prepare-time hash. Until then, Maka does not claim per-file integrity
 for every helper in the extracted tree.
 
+That limitation is deliberate but security-relevant: v1 detects entry-binary replacement before every
+Git process, while helper integrity relies on the authenticated upstream archive plus the packaged
+application boundary. Closing it requires a dedicated publication slice that observes the final signed
+helper bytes at the correct signing phase, binds that inventory into the outer application signature,
+and verifies the inventory at managed-operation admission. Hashing the pre-sign extraction here would
+be incorrect. The remaining verify-to-spawn window cannot be eliminated portably by a path-based handle;
+the current threat model relies on packaged resources not being writable by the managed workspace and
+on platform publisher authenticity. macOS supplies that authenticity today; Windows Authenticode is a
+separate release-security prerequisite and is not synthesized by `bundled-git.json`.
+
 ## 4. Failure states and rollback
 
 Stable runtime failure classes are:
@@ -124,6 +143,7 @@ managed-workspace artifact protocol and its crash tests.
 - strict manifest happy path;
 - platform/architecture mismatch;
 - executable tampering;
+- source-repository config and environment poisoning cannot override the managed execution profile;
 - missing manifest with a system Git present (must still fail);
 - path escape and symlink rejection;
 - build preparation from the exact dugite platform record;

--- a/docs/architecture/bundled-git-runtime-v1.md
+++ b/docs/architecture/bundled-git-runtime-v1.md
@@ -148,10 +148,12 @@ publication PR before that fact has a production writer and consumer.
 
 ## 7. Licensing and size policy
 
-The full `dugite-native` directory is packaged, including its component license directories, Git's
-`LICENSE.txt`, and Maka's Git/dugite notices. A generated component inventory is useful release
-hardening, but it is not represented as a runtime-authority guarantee in v1 and should be implemented as
-a dedicated supply-chain slice.
+The full `dugite-native` directory is packaged, including whatever component license directories its
+platform archive supplies. Because those archives do not expose Git's license at one uniform path, Maka
+also tracks the Git GPLv2 text and packages it consistently as `resources/licenses/git/LICENSE.txt`
+alongside the Git/dugite notices. Prepare and final-package verification both require that stable asset.
+A generated component inventory is useful release hardening, but it is not represented as a
+runtime-authority guarantee in v1 and should be implemented as a dedicated supply-chain slice.
 
 The first release keeps the full upstream distribution. Pruning shells, Perl, GUI programs, docs, or
 helpers is deferred until Maka has an exact command/helper allowlist and the pruned artifact passes the

--- a/docs/architecture/bundled-git-runtime-v1.md
+++ b/docs/architecture/bundled-git-runtime-v1.md
@@ -41,10 +41,26 @@ The dependency is exact-pinned as `dugite@3.2.2`. Its `embedded-git.json` pins
 archive before extraction. Maka then executes the extracted binary with `--version`, hashes that exact
 binary, and emits the platform manifest used by packaging and runtime admission.
 
+The archive checksum is not an independent trust root. `npm ci` first authenticates the exact dugite
+package bytes against `package-lock.json` integrity; that pinned package supplies `embedded-git.json`,
+which authenticates the native archive; Maka then regenerates `bundled-git.json` inside each platform's
+release job immediately before packaging. Review and branch protection own lockfile changes. The signed
+and notarized macOS application closes the artifact-publication chain. The current Windows release is
+explicitly unsigned, so its published SHA-256 and GitHub release transport do not provide OS-level
+publisher identity; that remains a release security limitation rather than something the runtime
+manifest can repair.
+
 The packaged runtime includes the complete `dugite-native` directory rather than copying only `git`.
 Git subprograms, templates, MinGit libraries, certificates, and platform support files remain relative to
 the same root. Runtime environment variables (`GIT_EXEC_PATH`, templates, Linux `PREFIX`/CA bundle, and
 Windows MinGit paths) are derived only from that declared root.
+
+Every managed Git process receives an isolated environment: an owner-specific `HOME` and
+`XDG_CONFIG_HOME`, `GIT_CONFIG_NOSYSTEM=1`, non-interactive credential settings, a fixed hooks directory,
+and a `PATH` containing only the declared runtime directories. Runtime Host does not merge the user's
+shell environment into this map. On Windows, the MinGit DLL/helper directories are included explicitly;
+the current working directory is the Maka-owned home rather than the source checkout or application
+directory.
 
 Production never resolves Git through `node_modules`. Dugite is the build-time supplier; Electron copies
 the complete extracted distribution to `resources/git`, and Runtime Host resolves only that signed
@@ -124,6 +140,12 @@ application launch. Individual Git failures remain fail-closed at the operation 
 The last item is deliberately a release gate rather than evidence that managed execution is already the
 default. Desktop/CLI activation remains a later, explicit product decision.
 
+The future M2 `WorkspaceVersionAccepted` fact must carry the same Git runtime identity alongside its
+parent version, accepted commit/tree, materialization profile, and policy identity. Repository/epoch
+binding protects the current managed artifact; version-fact binding is separately required to make an
+accepted mutation historically interpretable. It belongs to M2 and must not be approximated in this
+publication PR before that fact has a production writer and consumer.
+
 ## 7. Licensing and size policy
 
 The full `dugite-native` directory is packaged, including its component license directories, Git's
@@ -135,3 +157,9 @@ The first release keeps the full upstream distribution. Pruning shells, Perl, GU
 helpers is deferred until Maka has an exact command/helper allowlist and the pruned artifact passes the
 same production-shaped release smoke on Windows, macOS, and Linux. Package size alone is not sufficient
 evidence that a helper is safe to remove.
+
+An application upgrade currently replaces the packaged runtime. Existing managed artifacts whose
+recorded runtime identity differs therefore fail closed and require an explicit future migration,
+rebaseline, or compatible-runtime retention policy. V1 does not silently migrate them and does not ship
+multiple runtime generations. A versioned `resources/git-runtime/<identity>` layout is a possible future
+carrier, but adopting it requires an owner and retention/patching policy rather than a directory rename.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@astryxdesign/core": "0.2.0",
         "@biomejs/biome": "2.5.4",
         "@types/node": "^25.0.0",
+        "dugite": "3.2.2",
         "knip": "^6.26.0",
         "patch-package": "8.0.1",
         "typescript": "^7.0.2"
@@ -5200,6 +5201,21 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -5228,6 +5244,46 @@
         }
       }
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
+      "integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.28.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bare-module-resolve": {
       "version": "1.12.4",
       "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
@@ -5245,11 +5301,56 @@
         }
       }
     },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/bare-semver": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
       "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
       "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.7.tgz",
+      "integrity": "sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -6909,6 +7010,21 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dugite": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/dugite/-/dugite-3.2.2.tgz",
+      "integrity": "sha512-pGTVaxea0WqauGXF5A3GmpmPOim6oTnfYM6dS6s8nHyJxf4pRTjwtFHkqLkT5de87uUPhTI+LtlmcJQ2WkqeGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "progress": "^2.0.3",
+        "tar-stream": "^3.1.7"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7454,6 +7570,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -7559,6 +7685,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -12095,6 +12228,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -12226,6 +12371,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -12234,6 +12392,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/temp": {
@@ -12260,6 +12428,16 @@
       "dependencies": {
         "async-exit-hook": "^2.0.1",
         "fs-extra": "^10.0.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tiny-async-pool": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:dist": "npm run test:scripts:full && node scripts/run-workspace-tests-parallel.mjs --concurrency=3",
     "test:dist:serial": "npm run test:scripts:full && node scripts/run-workspace-tests-parallel.mjs --serial",
     "test:fast": "npm run build:test && npm run test:scripts && node scripts/run-workspace-tests-parallel.mjs --concurrency=3",
-    "test:scripts": "node --test scripts/electron-builder-config.test.mjs scripts/sync-model-metadata.test.mjs scripts/fixture-env.test.mjs scripts/electron-lifecycle.test.mjs scripts/check-story-annotations.test.mjs scripts/check-dead-css.test.mjs scripts/build-astryx-theme.test.mjs scripts/ci-test-plan.test.mjs scripts/run-headless-tests.test.mjs scripts/run-workspace-tests-parallel.test.mjs scripts/storybook-visual-smoke.test.mjs scripts/cu-e2e-scenarios.test.mjs scripts/cu-report-sanitize.test.mjs scripts/computer-use-provenance.test.mjs scripts/cu-trace-analyse.test.mjs scripts/windows-test-inventory.test.mjs scripts/windows-smoke.test.mjs scripts/windows-baseline-workflow.test.mjs apps/desktop/scripts/dev-app-runtime.test.mjs",
+    "test:scripts": "node --test scripts/electron-builder-config.test.mjs scripts/sync-model-metadata.test.mjs scripts/fixture-env.test.mjs scripts/electron-lifecycle.test.mjs scripts/check-story-annotations.test.mjs scripts/check-dead-css.test.mjs scripts/build-astryx-theme.test.mjs scripts/ci-test-plan.test.mjs scripts/run-headless-tests.test.mjs scripts/run-workspace-tests-parallel.test.mjs scripts/storybook-visual-smoke.test.mjs scripts/cu-e2e-scenarios.test.mjs scripts/cu-report-sanitize.test.mjs scripts/computer-use-provenance.test.mjs scripts/cu-trace-analyse.test.mjs scripts/prepare-bundled-git.test.mjs scripts/windows-test-inventory.test.mjs scripts/windows-smoke.test.mjs scripts/windows-baseline-workflow.test.mjs apps/desktop/scripts/dev-app-runtime.test.mjs",
     "test:scripts:extended": "node --test scripts/cu-provider-matrix.test.mjs scripts/cu-process-restart-harness.test.mjs scripts/cu-real-model-launcher.test.mjs scripts/macos-arm64-release.test.mjs scripts/windows-x64-release.test.mjs scripts/measure-session-bundle.test.mjs",
     "test:scripts:full": "npm run test:scripts && npm run test:scripts:extended",
     "dev": "npm --workspace @maka/desktop run dev:hmr --",
@@ -57,6 +57,7 @@
     "windows:inventory": "node scripts/windows-test-inventory.mjs --check",
     "windows:inventory:write": "node scripts/windows-test-inventory.mjs --write",
     "smoke:windows": "npm run build && node scripts/windows-smoke.mjs",
+    "prepare:bundled-git": "node scripts/prepare-bundled-git.mjs",
     "e2e:computer-use-real": "node scripts/cu-real-ax-model-e2e-launcher.mjs",
     "e2e:computer-use-process-restart": "MAKA_CU_AX_MODEL_SCENARIO=restart-recovery node scripts/cu-real-ax-model-e2e-launcher.mjs",
     "e2e:computer-use-process-restart-soak": "node scripts/cu-process-restart-e2e-launcher.mjs",
@@ -80,6 +81,7 @@
     "@astryxdesign/core": "0.2.0",
     "@biomejs/biome": "2.5.4",
     "@types/node": "^25.0.0",
+    "dugite": "3.2.2",
     "knip": "^6.26.0",
     "patch-package": "8.0.1",
     "typescript": "^7.0.2"
@@ -87,6 +89,7 @@
   "allowScripts": {
     "esbuild@0.27.7": true,
     "@jackwener/opencli@1.8.4": true,
+    "dugite@3.2.2": true,
     "node-pty@1.2.0-beta.14": true
   }
 }

--- a/packages/runtime-host/src/__tests__/bundled-git-runtime.test.ts
+++ b/packages/runtime-host/src/__tests__/bundled-git-runtime.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import { resolveBundledGitRuntime } from '../server/bundled-git-runtime.js';
+
+test('resolves the packaged Git executable from a strict platform manifest', async () => {
+  const fixture = await createFixture();
+  try {
+    assert.deepEqual(
+      await resolveBundledGitRuntime({
+        resourcesRoot: fixture.root,
+        platform: 'win32',
+        arch: 'x64',
+      }),
+      {
+        executablePath: fixture.executablePath,
+        expectedSha256: 'sha256:f391158ea86e1e56b2b0c13583821c2b752c2abccd91496d91e025d54ac616e5',
+        distribution: {
+          kind: 'dugite_native_v1',
+          rootPath: join(fixture.root, 'git'),
+        },
+      },
+    );
+  } finally {
+    await fixture.remove();
+  }
+});
+
+test('fails closed when the bundled Git platform does not match the host', async () => {
+  const fixture = await createFixture();
+  try {
+    await assert.rejects(
+      resolveBundledGitRuntime({
+        resourcesRoot: fixture.root,
+        platform: 'darwin',
+        arch: 'arm64',
+      }),
+      { code: 'bundled_git_platform_mismatch' },
+    );
+  } finally {
+    await fixture.remove();
+  }
+});
+
+test('fails closed when the packaged Git executable does not match its manifest', async () => {
+  const fixture = await createFixture();
+  try {
+    await writeFile(fixture.executablePath, 'tampered bundled git\n');
+    await assert.rejects(
+      resolveBundledGitRuntime({
+        resourcesRoot: fixture.root,
+        platform: 'win32',
+        arch: 'x64',
+      }),
+      { code: 'bundled_git_integrity_mismatch' },
+    );
+  } finally {
+    await fixture.remove();
+  }
+});
+
+test('does not fall back to PATH when the bundled Git manifest is missing', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-bundled-git-missing-'));
+  try {
+    await assert.rejects(
+      resolveBundledGitRuntime({ resourcesRoot: root, platform: 'win32', arch: 'x64' }),
+      { code: 'bundled_git_unavailable' },
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects manifest fields that could redirect execution outside resources', async () => {
+  const fixture = await createFixture({ executableRelativePath: '../system/git.exe' });
+  try {
+    await assert.rejects(
+      resolveBundledGitRuntime({
+        resourcesRoot: fixture.root,
+        platform: 'win32',
+        arch: 'x64',
+      }),
+      { code: 'bundled_git_manifest_invalid' },
+    );
+  } finally {
+    await fixture.remove();
+  }
+});
+
+const executableSha256 = 'sha256:f391158ea86e1e56b2b0c13583821c2b752c2abccd91496d91e025d54ac616e5';
+
+async function createFixture(overrides: Record<string, unknown> = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'maka-bundled-git-'));
+  const executablePath = join(root, 'git', 'cmd', 'git.exe');
+  await mkdir(join(root, 'git', 'cmd'), { recursive: true });
+  await writeFile(executablePath, 'fake bundled git\n');
+  await writeFile(
+    join(root, 'bundled-git.json'),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      protocol: 'maka_bundled_git_runtime_v1',
+      provider: 'desktop/dugite-native',
+      gitVersion: '2.53.0',
+      platform: 'win32',
+      arch: 'x64',
+      executableRelativePath: 'git/cmd/git.exe',
+      executableSha256,
+      sourceArchiveSha256:
+        'sha256:f843a87a693bfdabed83b8492bca59db6f64d1168c74d23e2c8dfb7388a97142',
+      distributionReady: true,
+      ...overrides,
+    })}\n`,
+  );
+  return {
+    root,
+    executablePath,
+    remove: () => rm(root, { recursive: true, force: true }),
+  };
+}

--- a/packages/runtime-host/src/__tests__/bundled-git-runtime.test.ts
+++ b/packages/runtime-host/src/__tests__/bundled-git-runtime.test.ts
@@ -17,6 +17,8 @@ test('resolves the packaged Git executable from a strict platform manifest', asy
       {
         executablePath: fixture.executablePath,
         expectedSha256: 'sha256:f391158ea86e1e56b2b0c13583821c2b752c2abccd91496d91e025d54ac616e5',
+        runtimeIdentitySha256:
+          'sha256:926a45a8cd95c8ae25683905dc9171c54a9e31ffe362875c8f8b7f6e67ed522f',
         distribution: {
           kind: 'dugite_native_v1',
           rootPath: join(fixture.root, 'git'),
@@ -41,6 +43,29 @@ test('fails closed when the bundled Git platform does not match the host', async
     );
   } finally {
     await fixture.remove();
+  }
+});
+
+test('binds runtime identity to the complete source archive provenance', async () => {
+  const first = await createFixture();
+  const second = await createFixture({
+    sourceArchiveSha256: `sha256:${'2'.repeat(64)}`,
+  });
+  try {
+    const firstRuntime = await resolveBundledGitRuntime({
+      resourcesRoot: first.root,
+      platform: 'win32',
+      arch: 'x64',
+    });
+    const secondRuntime = await resolveBundledGitRuntime({
+      resourcesRoot: second.root,
+      platform: 'win32',
+      arch: 'x64',
+    });
+    assert.equal(firstRuntime.expectedSha256, secondRuntime.expectedSha256);
+    assert.notEqual(firstRuntime.runtimeIdentitySha256, secondRuntime.runtimeIdentitySha256);
+  } finally {
+    await Promise.all([first.remove(), second.remove()]);
   }
 });
 

--- a/packages/runtime-host/src/__tests__/bundled-git-runtime.test.ts
+++ b/packages/runtime-host/src/__tests__/bundled-git-runtime.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
@@ -8,6 +8,7 @@ import { resolveBundledGitRuntime } from '../server/bundled-git-runtime.js';
 test('resolves the packaged Git executable from a strict platform manifest', async () => {
   const fixture = await createFixture();
   try {
+    const canonicalRoot = await realpath(fixture.root);
     assert.deepEqual(
       await resolveBundledGitRuntime({
         resourcesRoot: fixture.root,
@@ -15,13 +16,13 @@ test('resolves the packaged Git executable from a strict platform manifest', asy
         arch: 'x64',
       }),
       {
-        executablePath: fixture.executablePath,
+        executablePath: await realpath(fixture.executablePath),
         expectedSha256: 'sha256:f391158ea86e1e56b2b0c13583821c2b752c2abccd91496d91e025d54ac616e5',
         runtimeIdentitySha256:
           'sha256:926a45a8cd95c8ae25683905dc9171c54a9e31ffe362875c8f8b7f6e67ed522f',
         distribution: {
           kind: 'dugite_native_v1',
-          rootPath: join(fixture.root, 'git'),
+          rootPath: join(canonicalRoot, 'git'),
         },
       },
     );

--- a/packages/runtime-host/src/server/bundled-git-runtime.ts
+++ b/packages/runtime-host/src/server/bundled-git-runtime.ts
@@ -1,0 +1,167 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { lstat, readFile, realpath } from 'node:fs/promises';
+import { isAbsolute, join, normalize, relative } from 'node:path';
+import type { VerifiedGitRuntimeInput } from '@maka/storage/managed-workspace-owner';
+
+const MANIFEST_KEYS = [
+  'arch',
+  'distributionReady',
+  'executableRelativePath',
+  'executableSha256',
+  'gitVersion',
+  'platform',
+  'protocol',
+  'provider',
+  'schemaVersion',
+  'sourceArchiveSha256',
+] as const;
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/u;
+const VERSION_PATTERN = /^[1-9][0-9]*\.[0-9]+\.[0-9]+(?:[-.][A-Za-z0-9]+)*$/u;
+
+export type BundledGitRuntimeErrorCode =
+  | 'bundled_git_unavailable'
+  | 'bundled_git_manifest_invalid'
+  | 'bundled_git_platform_mismatch'
+  | 'bundled_git_integrity_mismatch';
+
+export class BundledGitRuntimeError extends Error {
+  constructor(
+    readonly code: BundledGitRuntimeErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'BundledGitRuntimeError';
+  }
+}
+
+export interface ResolveBundledGitRuntimeInput {
+  readonly resourcesRoot: string;
+  readonly platform?: NodeJS.Platform;
+  readonly arch?: string;
+  readonly manifestPath?: string;
+}
+
+export async function resolveBundledGitRuntime(
+  input: ResolveBundledGitRuntimeInput,
+): Promise<VerifiedGitRuntimeInput> {
+  const platform = input.platform ?? process.platform;
+  const arch = input.arch ?? process.arch;
+  try {
+    const resourcesRoot = normalize(await realpath(input.resourcesRoot));
+    const manifestPath = normalize(
+      await realpath(input.manifestPath ?? join(resourcesRoot, 'bundled-git.json')),
+    );
+    assertWithinRoot(resourcesRoot, manifestPath, 'Bundled Git manifest');
+    const manifestInfo = await lstat(manifestPath);
+    if (!manifestInfo.isFile() || manifestInfo.isSymbolicLink()) {
+      throw invalidManifest('Bundled Git manifest must be a regular non-symlink file');
+    }
+    const manifest = decodeManifest(JSON.parse(await readFile(manifestPath, 'utf8')));
+    if (manifest.platform !== platform || manifest.arch !== arch) {
+      throw new BundledGitRuntimeError(
+        'bundled_git_platform_mismatch',
+        `Bundled Git targets ${manifest.platform}-${manifest.arch}, not ${platform}-${arch}`,
+      );
+    }
+    const executablePath = normalize(
+      join(resourcesRoot, ...manifest.executableRelativePath.split('/')),
+    );
+    assertWithinRoot(resourcesRoot, executablePath, 'Bundled Git executable');
+    const executableInfo = await lstat(executablePath);
+    if (!executableInfo.isFile() || executableInfo.isSymbolicLink()) {
+      throw new BundledGitRuntimeError(
+        'bundled_git_unavailable',
+        'Bundled Git executable must be a regular non-symlink file',
+      );
+    }
+    const canonicalExecutable = normalize(await realpath(executablePath));
+    assertWithinRoot(resourcesRoot, canonicalExecutable, 'Bundled Git executable');
+    const actualSha256 = await sha256File(canonicalExecutable);
+    if (actualSha256 !== manifest.executableSha256) {
+      throw new BundledGitRuntimeError(
+        'bundled_git_integrity_mismatch',
+        `Bundled Git executable digest mismatch: ${canonicalExecutable}`,
+      );
+    }
+    return {
+      executablePath: canonicalExecutable,
+      expectedSha256: manifest.executableSha256,
+      distribution: {
+        kind: 'dugite_native_v1',
+        rootPath: normalize(await realpath(join(resourcesRoot, 'git'))),
+      },
+    };
+  } catch (error) {
+    if (error instanceof BundledGitRuntimeError) throw error;
+    throw new BundledGitRuntimeError(
+      'bundled_git_unavailable',
+      'Bundled Git runtime is unavailable',
+      { cause: error },
+    );
+  }
+}
+
+interface BundledGitManifestV1 {
+  readonly schemaVersion: 1;
+  readonly protocol: 'maka_bundled_git_runtime_v1';
+  readonly provider: 'desktop/dugite-native';
+  readonly gitVersion: string;
+  readonly platform: NodeJS.Platform;
+  readonly arch: string;
+  readonly executableRelativePath: string;
+  readonly executableSha256: `sha256:${string}`;
+  readonly sourceArchiveSha256: `sha256:${string}`;
+  readonly distributionReady: true;
+}
+
+function decodeManifest(input: unknown): BundledGitManifestV1 {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw invalidManifest('Bundled Git manifest must be an object');
+  }
+  const value = input as Record<string, unknown>;
+  if (
+    Object.keys(value).sort().join('\0') !== [...MANIFEST_KEYS].sort().join('\0') ||
+    value.schemaVersion !== 1 ||
+    value.protocol !== 'maka_bundled_git_runtime_v1' ||
+    value.provider !== 'desktop/dugite-native' ||
+    typeof value.gitVersion !== 'string' ||
+    !VERSION_PATTERN.test(value.gitVersion) ||
+    (value.platform !== 'win32' && value.platform !== 'darwin' && value.platform !== 'linux') ||
+    typeof value.arch !== 'string' ||
+    !/^[a-z0-9_]+$/u.test(value.arch) ||
+    typeof value.executableRelativePath !== 'string' ||
+    !isSafeRelativePath(value.executableRelativePath) ||
+    typeof value.executableSha256 !== 'string' ||
+    !SHA256_PATTERN.test(value.executableSha256) ||
+    typeof value.sourceArchiveSha256 !== 'string' ||
+    !SHA256_PATTERN.test(value.sourceArchiveSha256) ||
+    value.distributionReady !== true
+  ) {
+    throw invalidManifest('Bundled Git manifest is invalid');
+  }
+  return value as unknown as BundledGitManifestV1;
+}
+
+function isSafeRelativePath(value: string): boolean {
+  if (!value || isAbsolute(value) || value.includes('\\')) return false;
+  const segments = value.split('/');
+  return segments.every((segment) => segment.length > 0 && segment !== '.' && segment !== '..');
+}
+
+function assertWithinRoot(root: string, target: string, label: string): void {
+  const rel = relative(root, target);
+  if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) return;
+  throw invalidManifest(`${label} escapes the packaged resources root`);
+}
+
+function invalidManifest(message: string): BundledGitRuntimeError {
+  return new BundledGitRuntimeError('bundled_git_manifest_invalid', message);
+}
+
+async function sha256File(path: string): Promise<`sha256:${string}`> {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return `sha256:${hash.digest('hex')}`;
+}

--- a/packages/runtime-host/src/server/bundled-git-runtime.ts
+++ b/packages/runtime-host/src/server/bundled-git-runtime.ts
@@ -88,6 +88,7 @@ export async function resolveBundledGitRuntime(
     return {
       executablePath: canonicalExecutable,
       expectedSha256: manifest.executableSha256,
+      runtimeIdentitySha256: bundledGitRuntimeIdentity(manifest),
       distribution: {
         kind: 'dugite_native_v1',
         rootPath: normalize(await realpath(join(resourcesRoot, 'git'))),
@@ -101,6 +102,21 @@ export async function resolveBundledGitRuntime(
       { cause: error },
     );
   }
+}
+
+function bundledGitRuntimeIdentity(manifest: BundledGitManifestV1): `sha256:${string}` {
+  const identity = JSON.stringify({
+    protocol: 'maka_git_runtime_identity_v1',
+    manifestProtocol: manifest.protocol,
+    provider: manifest.provider,
+    gitVersion: manifest.gitVersion,
+    platform: manifest.platform,
+    arch: manifest.arch,
+    executableRelativePath: manifest.executableRelativePath,
+    executableSha256: manifest.executableSha256,
+    sourceArchiveSha256: manifest.sourceArchiveSha256,
+  });
+  return `sha256:${createHash('sha256').update(identity).digest('hex')}`;
 }
 
 interface BundledGitManifestV1 {

--- a/packages/runtime-host/src/server/bundled-git-runtime.ts
+++ b/packages/runtime-host/src/server/bundled-git-runtime.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto';
-import { createReadStream } from 'node:fs';
-import { lstat, readFile, realpath } from 'node:fs/promises';
+import { lstat, open, readFile, realpath } from 'node:fs/promises';
 import { isAbsolute, join, normalize, relative } from 'node:path';
 import type { VerifiedGitRuntimeInput } from '@maka/storage/managed-workspace-owner';
 
@@ -178,6 +177,18 @@ function invalidManifest(message: string): BundledGitRuntimeError {
 
 async function sha256File(path: string): Promise<`sha256:${string}`> {
   const hash = createHash('sha256');
-  for await (const chunk of createReadStream(path)) hash.update(chunk);
-  return `sha256:${hash.digest('hex')}`;
+  const file = await open(path, 'r');
+  try {
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    let position = 0;
+    while (true) {
+      const { bytesRead } = await file.read(buffer, 0, buffer.length, position);
+      if (bytesRead === 0) break;
+      hash.update(buffer.subarray(0, bytesRead));
+      position += bytesRead;
+    }
+    return `sha256:${hash.digest('hex')}`;
+  } finally {
+    await file.close();
+  }
 }

--- a/packages/runtime-host/src/server/execution-candidate.ts
+++ b/packages/runtime-host/src/server/execution-candidate.ts
@@ -4,6 +4,7 @@ import {
 } from '@maka/storage/root-authority';
 import type { RuntimeHostCandidateOptions } from './candidate.js';
 import type { VerifiedGitRuntimeInput } from '@maka/storage/managed-workspace-owner';
+import { resolveBundledGitRuntime } from './bundled-git-runtime.js';
 import { createExecutionRuntimeHostComposition } from './execution-composition.js';
 import { RuntimeHostKernel } from './host-kernel.js';
 
@@ -13,11 +14,19 @@ export type ExecutionRuntimeHostCandidateResult =
 
 export interface ExecutionRuntimeHostCandidateOptions extends RuntimeHostCandidateOptions {
   readonly managedWorkspaceGitRuntime?: VerifiedGitRuntimeInput;
+  /** Packaged resource root containing bundled-git.json and the Git toolchain. */
+  readonly bundledGitResourcesRoot?: string;
 }
 
 export async function startExecutionRuntimeHostCandidate(
   options: ExecutionRuntimeHostCandidateOptions,
 ): Promise<ExecutionRuntimeHostCandidateResult> {
+  if (options.managedWorkspaceGitRuntime && options.bundledGitResourcesRoot) {
+    throw new Error('Managed workspace Git runtime must have exactly one authority');
+  }
+  const managedWorkspaceGitRuntime = options.bundledGitResourcesRoot
+    ? await resolveBundledGitRuntime({ resourcesRoot: options.bundledGitResourcesRoot })
+    : options.managedWorkspaceGitRuntime;
   const capability = await resolveExistingStorageRoot({
     path: options.rootPath,
     kind: 'interactive',
@@ -31,9 +40,7 @@ export async function startExecutionRuntimeHostCandidate(
     handshakeTimeoutMs: options.handshakeTimeoutMs,
     compositionFactory: (context) =>
       createExecutionRuntimeHostComposition(context, {
-        ...(options.managedWorkspaceGitRuntime
-          ? { managedWorkspaceGitRuntime: options.managedWorkspaceGitRuntime }
-          : {}),
+        ...(managedWorkspaceGitRuntime ? { managedWorkspaceGitRuntime } : {}),
       }),
   });
   return { kind: 'winner', host };

--- a/packages/storage/src/__tests__/bundled-git-workspace-smoke.test.ts
+++ b/packages/storage/src/__tests__/bundled-git-workspace-smoke.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import test from 'node:test';
+import { bundledGitEnvironment } from '../dugite-native-environment.js';
+import { createGitWorkspaceService } from '../git-workspace-service.js';
+
+const execFileAsync = promisify(execFile);
+
+test('opens a managed workspace using only the installed dugite-native runtime', async () => {
+  const repoRoot = resolve(import.meta.dirname, '..', '..', '..', '..');
+  const gitRoot = join(repoRoot, 'node_modules', 'dugite', 'git');
+  const executablePath =
+    process.platform === 'win32' ? join(gitRoot, 'cmd', 'git.exe') : join(gitRoot, 'bin', 'git');
+  const sourceRoot = await mkdtemp(join(tmpdir(), 'maka-bundled-git-source-'));
+  const storageRoot = await mkdtemp(join(tmpdir(), 'maka-bundled-git-storage-'));
+  const homePath = await mkdtemp(join(tmpdir(), 'maka-bundled-git-home-'));
+  const env = {
+    HOME: homePath,
+    XDG_CONFIG_HOME: join(homePath, 'xdg'),
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_TERMINAL_PROMPT: '0',
+    ...bundledGitEnvironment({
+      platform: process.platform,
+      arch: process.arch,
+      rootPath: gitRoot,
+      executablePath,
+    }),
+  };
+  try {
+    await runGit(executablePath, env, ['-C', sourceRoot, 'init', '--quiet']);
+    await runGit(executablePath, env, ['-C', sourceRoot, 'config', 'user.name', 'Maka Test']);
+    await runGit(executablePath, env, [
+      '-C',
+      sourceRoot,
+      'config',
+      'user.email',
+      'test@maka.invalid',
+    ]);
+    await writeFile(join(sourceRoot, 'README.md'), 'bundled Git runtime\n');
+    await runGit(executablePath, env, ['-C', sourceRoot, 'add', 'README.md']);
+    await runGit(executablePath, env, ['-C', sourceRoot, 'commit', '--quiet', '-m', 'baseline']);
+
+    const service = createGitWorkspaceService({
+      storageRoot,
+      gitRuntime: {
+        executablePath,
+        expectedSha256: await sha256File(executablePath),
+        distribution: { kind: 'dugite_native_v1', rootPath: gitRoot },
+      },
+    });
+    const binding = await service.createManagedWorkspaceFromSource({
+      repositoryId: 'repository_11111111111111111111111111111111',
+      workspaceId: 'workspace_22222222222222222222222222222222',
+      workspaceEpochId: 'epoch_33333333333333333333333333333333',
+      workspaceInstanceId: 'instance_44444444444444444444444444444444',
+      sourceRoot,
+    });
+
+    assert.equal(
+      await readFile(join(binding.worktreePath, 'README.md'), 'utf8'),
+      'bundled Git runtime\n',
+    );
+  } finally {
+    await Promise.all(
+      [sourceRoot, storageRoot, homePath].map((path) => rm(path, { recursive: true, force: true })),
+    );
+  }
+});
+
+async function runGit(
+  executablePath: string,
+  env: NodeJS.ProcessEnv,
+  args: readonly string[],
+): Promise<void> {
+  await execFileAsync(executablePath, args, {
+    env,
+    encoding: 'utf8',
+    timeout: 30_000,
+    windowsHide: true,
+  });
+}
+
+async function sha256File(path: string): Promise<`sha256:${string}`> {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return `sha256:${hash.digest('hex')}`;
+}

--- a/packages/storage/src/__tests__/bundled-git-workspace-smoke.test.ts
+++ b/packages/storage/src/__tests__/bundled-git-workspace-smoke.test.ts
@@ -51,6 +51,7 @@ test('opens a managed workspace using only the installed dugite-native runtime',
       gitRuntime: {
         executablePath,
         expectedSha256: await sha256File(executablePath),
+        runtimeIdentitySha256: `sha256:${'1'.repeat(64)}`,
         distribution: { kind: 'dugite_native_v1', rootPath: gitRoot },
       },
     });
@@ -66,6 +67,7 @@ test('opens a managed workspace using only the installed dugite-native runtime',
       await readFile(join(binding.worktreePath, 'README.md'), 'utf8'),
       'bundled Git runtime\n',
     );
+    assert.equal(binding.gitRuntimeSha256, `sha256:${'1'.repeat(64)}`);
   } finally {
     await Promise.all(
       [sourceRoot, storageRoot, homePath].map((path) => rm(path, { recursive: true, force: true })),

--- a/packages/storage/src/__tests__/bundled-git-workspace-smoke.test.ts
+++ b/packages/storage/src/__tests__/bundled-git-workspace-smoke.test.ts
@@ -2,7 +2,18 @@ import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { createReadStream } from 'node:fs';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { promisify } from 'node:util';
@@ -12,11 +23,19 @@ import { createGitWorkspaceService } from '../git-workspace-service.js';
 
 const execFileAsync = promisify(execFile);
 
-test('opens a managed workspace using only the installed dugite-native runtime', async () => {
+test('uses the installed runtime and rejects entry-binary replacement before the next operation', async () => {
   const repoRoot = resolve(import.meta.dirname, '..', '..', '..', '..');
-  const gitRoot = join(repoRoot, 'node_modules', 'dugite', 'git');
-  const executablePath =
-    process.platform === 'win32' ? join(gitRoot, 'cmd', 'git.exe') : join(gitRoot, 'bin', 'git');
+  const installedGitRoot = join(repoRoot, 'node_modules', 'dugite', 'git');
+  const installedExecutablePath =
+    process.platform === 'win32'
+      ? join(installedGitRoot, 'cmd', 'git.exe')
+      : join(installedGitRoot, 'bin', 'git');
+  const gitRoot = await mkdtemp(join(tmpdir(), 'maka-bundled-git-runtime-'));
+  const executablePath = await materializeIsolatedRuntime(
+    installedGitRoot,
+    gitRoot,
+    process.platform === 'win32' ? 'cmd/git.exe' : 'bin/git',
+  );
   const sourceRoot = await mkdtemp(join(tmpdir(), 'maka-bundled-git-source-'));
   const storageRoot = await mkdtemp(join(tmpdir(), 'maka-bundled-git-storage-'));
   const homePath = await mkdtemp(join(tmpdir(), 'maka-bundled-git-home-'));
@@ -28,14 +47,20 @@ test('opens a managed workspace using only the installed dugite-native runtime',
     ...bundledGitEnvironment({
       platform: process.platform,
       arch: process.arch,
-      rootPath: gitRoot,
-      executablePath,
+      rootPath: installedGitRoot,
+      executablePath: installedExecutablePath,
     }),
   };
   try {
-    await runGit(executablePath, env, ['-C', sourceRoot, 'init', '--quiet']);
-    await runGit(executablePath, env, ['-C', sourceRoot, 'config', 'user.name', 'Maka Test']);
-    await runGit(executablePath, env, [
+    await runGit(installedExecutablePath, env, ['-C', sourceRoot, 'init', '--quiet']);
+    await runGit(installedExecutablePath, env, [
+      '-C',
+      sourceRoot,
+      'config',
+      'user.name',
+      'Maka Test',
+    ]);
+    await runGit(installedExecutablePath, env, [
       '-C',
       sourceRoot,
       'config',
@@ -43,8 +68,15 @@ test('opens a managed workspace using only the installed dugite-native runtime',
       'test@maka.invalid',
     ]);
     await writeFile(join(sourceRoot, 'README.md'), 'bundled Git runtime\n');
-    await runGit(executablePath, env, ['-C', sourceRoot, 'add', 'README.md']);
-    await runGit(executablePath, env, ['-C', sourceRoot, 'commit', '--quiet', '-m', 'baseline']);
+    await runGit(installedExecutablePath, env, ['-C', sourceRoot, 'add', 'README.md']);
+    await runGit(installedExecutablePath, env, [
+      '-C',
+      sourceRoot,
+      'commit',
+      '--quiet',
+      '-m',
+      'baseline',
+    ]);
 
     const service = createGitWorkspaceService({
       storageRoot,
@@ -68,12 +100,51 @@ test('opens a managed workspace using only the installed dugite-native runtime',
       'bundled Git runtime\n',
     );
     assert.equal(binding.gitRuntimeSha256, `sha256:${'1'.repeat(64)}`);
+
+    await writeFile(executablePath, 'tampered after successful workspace creation\n');
+    await assert.rejects(
+      service.inspectManagedWorkspace(binding),
+      (error: unknown) =>
+        error instanceof Error &&
+        'code' in error &&
+        error.code === 'git_runtime_integrity_mismatch',
+    );
   } finally {
     await Promise.all(
-      [sourceRoot, storageRoot, homePath].map((path) => rm(path, { recursive: true, force: true })),
+      [sourceRoot, storageRoot, homePath, gitRoot].map((path) =>
+        rm(path, { recursive: true, force: true }),
+      ),
     );
   }
 });
+
+async function materializeIsolatedRuntime(
+  sourceRoot: string,
+  targetRoot: string,
+  executableRelativePath: string,
+): Promise<string> {
+  const executablePath = join(targetRoot, ...executableRelativePath.split('/'));
+  const executableDirectory = executableRelativePath.split('/')[0] ?? '';
+  await mkdir(dirname(executablePath), { recursive: true });
+  await copyFile(join(sourceRoot, ...executableRelativePath.split('/')), executablePath);
+  if (process.platform !== 'win32') {
+    await chmod(
+      executablePath,
+      (await stat(join(sourceRoot, ...executableRelativePath.split('/')))).mode & 0o7777,
+    );
+  }
+  for (const entry of await readdir(sourceRoot, { withFileTypes: true })) {
+    if (entry.name === executableDirectory) continue;
+    const source = join(sourceRoot, entry.name);
+    const target = join(targetRoot, entry.name);
+    if (entry.isDirectory()) {
+      await symlink(source, target, process.platform === 'win32' ? 'junction' : 'dir');
+    } else if (entry.isFile()) {
+      await copyFile(source, target);
+    }
+  }
+  return executablePath;
+}
 
 async function runGit(
   executablePath: string,

--- a/packages/storage/src/__tests__/dugite-native-environment.test.ts
+++ b/packages/storage/src/__tests__/dugite-native-environment.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { bundledGitEnvironment } from '../dugite-native-environment.js';
+
+test('constructs a Windows MinGit environment without a system PATH', () => {
+  assert.deepEqual(
+    bundledGitEnvironment({
+      platform: 'win32',
+      arch: 'arm64',
+      rootPath: 'C:\\Maka\\resources\\git',
+      executablePath: 'C:\\Maka\\resources\\git\\cmd\\git.exe',
+    }),
+    {
+      PATH: [
+        'C:\\Maka\\resources\\git\\cmd',
+        'C:\\Maka\\resources\\git\\clangarm64\\bin',
+        'C:\\Maka\\resources\\git\\clangarm64\\usr\\bin',
+      ].join(';'),
+      GIT_EXEC_PATH: 'C:\\Maka\\resources\\git\\clangarm64\\libexec\\git-core',
+    },
+  );
+});
+
+test('constructs relocatable macOS and Linux Git environments', () => {
+  assert.deepEqual(
+    bundledGitEnvironment({
+      platform: 'darwin',
+      arch: 'arm64',
+      rootPath: '/Applications/Maka.app/Contents/Resources/git',
+      executablePath: '/Applications/Maka.app/Contents/Resources/git/bin/git',
+    }),
+    {
+      PATH: '/Applications/Maka.app/Contents/Resources/git/bin',
+      GIT_EXEC_PATH: '/Applications/Maka.app/Contents/Resources/git/libexec/git-core',
+      GIT_TEMPLATE_DIR: '/Applications/Maka.app/Contents/Resources/git/share/git-core/templates',
+    },
+  );
+  assert.deepEqual(
+    bundledGitEnvironment({
+      platform: 'linux',
+      arch: 'x64',
+      rootPath: '/opt/maka/resources/git',
+      executablePath: '/opt/maka/resources/git/bin/git',
+    }),
+    {
+      PATH: '/opt/maka/resources/git/bin',
+      GIT_EXEC_PATH: '/opt/maka/resources/git/libexec/git-core',
+      GIT_TEMPLATE_DIR: '/opt/maka/resources/git/share/git-core/templates',
+      PREFIX: '/opt/maka/resources/git',
+      GIT_SSL_CAINFO: '/opt/maka/resources/git/ssl/cacert.pem',
+    },
+  );
+});

--- a/packages/storage/src/__tests__/git-workspace-service.test.ts
+++ b/packages/storage/src/__tests__/git-workspace-service.test.ts
@@ -69,6 +69,9 @@ describe('Git workspace service', () => {
   test('imports only the clean source HEAD tree into an independent fixed-config workspace', async () => {
     const root = await temporaryRoot();
     const sourceRoot = await createEligibleSource(join(root, 'source'));
+    await git(sourceRoot, 'config', 'core.hooksPath', join(root, 'attacker-hooks'));
+    await git(sourceRoot, 'config', 'core.sshCommand', 'attacker-ssh-command');
+    await git(sourceRoot, 'config', 'credential.helper', '!attacker-credential-helper');
     const sourceSnapshot = await snapshotSource(sourceRoot);
     const service = await serviceAt(join(root, 'storage'));
 
@@ -106,9 +109,34 @@ describe('Git workspace service', () => {
       await gitBare(binding.repositoryPath, 'config', '--local', '--get', 'core.hooksPath'),
       binding.hooksPath,
     );
+    assert.equal(
+      await gitBare(binding.repositoryPath, 'config', '--local', '--get', 'core.sshCommand'),
+      '',
+    );
+    assert.equal(
+      await gitBare(binding.repositoryPath, 'config', '--local', '--get', 'protocol.allow'),
+      'never',
+    );
     assert.equal(existsSync(join(binding.repositoryPath, 'objects', 'info', 'alternates')), false);
     await assert.rejects(gitBare(binding.repositoryPath, 'cat-file', '-e', sourceSnapshot.head));
     await assertSourceUnchanged(sourceRoot, sourceSnapshot);
+  });
+
+  test('does not inherit a poisoned process-level Git config path', async () => {
+    const root = await temporaryRoot();
+    const sourceRoot = await createEligibleSource(join(root, 'source'));
+    const poisonedConfig = join(root, 'poisoned-global-gitconfig');
+    await writeFile(poisonedConfig, 'this is not valid Git config\n');
+    const previous = process.env.GIT_CONFIG_GLOBAL;
+    process.env.GIT_CONFIG_GLOBAL = poisonedConfig;
+    try {
+      const service = await serviceAt(join(root, 'storage'));
+      const binding = await service.createManagedWorkspaceFromSource(openRequest(sourceRoot));
+      assert.equal((await service.inspectManagedWorkspace(binding)).state, 'ready');
+    } finally {
+      if (previous === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+      else process.env.GIT_CONFIG_GLOBAL = previous;
+    }
   });
 
   test('adopts the same binding across service restart and concurrent duplicate opens', async () => {

--- a/packages/storage/src/dugite-native-environment.ts
+++ b/packages/storage/src/dugite-native-environment.ts
@@ -1,0 +1,35 @@
+import { posix, win32 } from 'node:path';
+
+export interface BundledGitEnvironmentInput {
+  readonly platform: NodeJS.Platform;
+  readonly arch: string;
+  readonly rootPath: string;
+  readonly executablePath: string;
+}
+
+export function bundledGitEnvironment(input: BundledGitEnvironmentInput): NodeJS.ProcessEnv {
+  const path = input.platform === 'win32' ? win32 : posix;
+  const env: NodeJS.ProcessEnv = {
+    PATH: path.dirname(input.executablePath),
+  };
+  if (input.platform === 'win32') {
+    const platformRoot = path.join(
+      input.rootPath,
+      input.arch === 'x64' ? 'mingw64' : input.arch === 'arm64' ? 'clangarm64' : 'mingw32',
+    );
+    env.PATH = [
+      path.dirname(input.executablePath),
+      path.join(platformRoot, 'bin'),
+      path.join(platformRoot, 'usr', 'bin'),
+    ].join(';');
+    env.GIT_EXEC_PATH = path.join(platformRoot, 'libexec', 'git-core');
+    return env;
+  }
+  env.GIT_EXEC_PATH = path.join(input.rootPath, 'libexec', 'git-core');
+  env.GIT_TEMPLATE_DIR = path.join(input.rootPath, 'share', 'git-core', 'templates');
+  if (input.platform === 'linux') {
+    env.PREFIX = input.rootPath;
+    env.GIT_SSL_CAINFO = path.join(input.rootPath, 'ssl', 'cacert.pem');
+  }
+  return env;
+}

--- a/packages/storage/src/git-workspace-service.ts
+++ b/packages/storage/src/git-workspace-service.ts
@@ -141,14 +141,26 @@ export class GitWorkspaceServiceError extends Error {
   }
 }
 
-export interface VerifiedGitRuntimeInput {
+interface GitRuntimeExecutableIdentity {
   readonly executablePath: string;
   readonly expectedSha256: `sha256:${string}`;
-  readonly distribution?: {
-    readonly kind: 'dugite_native_v1';
-    readonly rootPath: string;
-  };
 }
+
+export type VerifiedGitRuntimeInput = GitRuntimeExecutableIdentity &
+  (
+    | {
+        readonly distribution?: undefined;
+        readonly runtimeIdentitySha256?: undefined;
+      }
+    | {
+        readonly distribution: {
+          readonly kind: 'dugite_native_v1';
+          readonly rootPath: string;
+        };
+        /** Stable identity of the complete declared distribution. */
+        readonly runtimeIdentitySha256: `sha256:${string}`;
+      }
+  );
 
 export interface CreateGitWorkspaceServiceInput {
   readonly storageRoot: string;
@@ -1596,7 +1608,11 @@ class GitWorkspaceServiceImpl implements GitWorkspaceService {
 
 class VerifiedGitRuntime {
   constructor(private readonly input: VerifiedGitRuntimeInput) {
-    if (!isAbsolute(input.executablePath) || !SHA256_PATTERN.test(input.expectedSha256)) {
+    if (
+      !isAbsolute(input.executablePath) ||
+      !SHA256_PATTERN.test(input.expectedSha256) ||
+      (input.distribution !== undefined && !SHA256_PATTERN.test(input.runtimeIdentitySha256 ?? ''))
+    ) {
       throw new GitWorkspaceServiceError(
         'git_runtime_unavailable',
         'Managed workspace requires an absolute Git executable and SHA-256 digest',
@@ -1781,14 +1797,17 @@ class VerifiedGitRuntime {
       const executablePath = normalize(await realpath(this.input.executablePath));
       const info = await stat(executablePath);
       if (!info.isFile()) throw new Error('not a regular file');
-      const digest = await sha256File(executablePath);
-      if (digest !== this.input.expectedSha256) {
+      const executableDigest = await sha256File(executablePath);
+      if (executableDigest !== this.input.expectedSha256) {
         throw new GitWorkspaceServiceError(
           'git_runtime_integrity_mismatch',
-          `Git runtime digest mismatch: ${executablePath}`,
+          `Git executable digest mismatch: ${executablePath}`,
         );
       }
-      return { executablePath, digest };
+      return {
+        executablePath,
+        digest: this.input.runtimeIdentitySha256 ?? executableDigest,
+      };
     } catch (error) {
       if (error instanceof GitWorkspaceServiceError) throw error;
       throw new GitWorkspaceServiceError(

--- a/packages/storage/src/git-workspace-service.ts
+++ b/packages/storage/src/git-workspace-service.ts
@@ -1253,8 +1253,10 @@ class GitWorkspaceServiceImpl implements GitWorkspaceService {
       ['core.autocrlf', 'false'],
       ['core.safecrlf', 'true'],
       ['core.hooksPath', normalize(hooksPath)],
+      ['core.sshCommand', ''],
       ['credential.helper', ''],
       ['credential.interactive', 'never'],
+      ['protocol.allow', 'never'],
       ['gc.auto', '0'],
     ];
     for (const [key, value] of entries) {
@@ -1659,7 +1661,9 @@ class VerifiedGitRuntime {
         [...fixedGitArguments(hooksPath), ...args],
         {
           cwd: homePath ?? dirname(runtime.executablePath),
-          env: { ...env, ...extraEnv },
+          // Operation-scoped values (currently only deterministic commit
+          // identity) cannot override the hermetic Git execution profile.
+          env: { ...extraEnv, ...env },
           encoding: 'utf8',
           maxBuffer: GIT_MAX_BUFFER_BYTES,
           timeout: GIT_TIMEOUT_MS,
@@ -1690,7 +1694,7 @@ class VerifiedGitRuntime {
       [...fixedGitArguments(hooksPath), ...args],
       {
         cwd: homePath ?? dirname(runtime.executablePath),
-        env: { ...env, ...extraEnv },
+        env: { ...extraEnv, ...env },
         encoding: 'buffer',
         maxBuffer: GIT_MAX_BUFFER_BYTES,
         timeout: GIT_TIMEOUT_MS,
@@ -2869,6 +2873,10 @@ function fixedGitArguments(hooksPath: string): string[] {
     'credential.helper=',
     '-c',
     'credential.interactive=never',
+    '-c',
+    'core.sshCommand=',
+    '-c',
+    'protocol.allow=never',
     '-c',
     'gc.auto=0',
     '-c',

--- a/packages/storage/src/git-workspace-service.ts
+++ b/packages/storage/src/git-workspace-service.ts
@@ -14,6 +14,7 @@ import {
 import { dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { withArtifactWriterLock } from './artifact-writer-lock.js';
+import { bundledGitEnvironment } from './dugite-native-environment.js';
 import { registerManagedBaselineReceiptAuthorityInternal } from './managed-baseline-receipt-authority-internal.js';
 
 const execFileAsync = promisify(execFile);
@@ -143,6 +144,10 @@ export class GitWorkspaceServiceError extends Error {
 export interface VerifiedGitRuntimeInput {
   readonly executablePath: string;
   readonly expectedSha256: `sha256:${string}`;
+  readonly distribution?: {
+    readonly kind: 'dugite_native_v1';
+    readonly rootPath: string;
+  };
 }
 
 export interface CreateGitWorkspaceServiceInput {
@@ -1597,6 +1602,22 @@ class VerifiedGitRuntime {
         'Managed workspace requires an absolute Git executable and SHA-256 digest',
       );
     }
+    if (input.distribution) {
+      const rootPath = input.distribution.rootPath;
+      const executableRelativePath = relative(rootPath, input.executablePath);
+      if (
+        !isAbsolute(rootPath) ||
+        executableRelativePath === '' ||
+        executableRelativePath === '..' ||
+        executableRelativePath.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) ||
+        isAbsolute(executableRelativePath)
+      ) {
+        throw new GitWorkspaceServiceError(
+          'git_runtime_unavailable',
+          'Bundled Git executable must belong to its declared distribution root',
+        );
+      }
+    }
   }
 
   verify(): Promise<{ executablePath: string; digest: `sha256:${string}` }> {
@@ -1615,10 +1636,7 @@ class VerifiedGitRuntime {
       await mkdir(homePath, { recursive: true });
       await mkdir(hooksPath, { recursive: true });
     }
-    const env = isolatedGitEnvironment(
-      runtime.executablePath,
-      homePath ?? dirname(runtime.executablePath),
-    );
+    const env = isolatedGitEnvironment(this.input, homePath ?? dirname(runtime.executablePath));
     try {
       const { stdout } = await execFileAsync(
         runtime.executablePath,
@@ -1650,10 +1668,7 @@ class VerifiedGitRuntime {
       await mkdir(homePath, { recursive: true });
       await mkdir(hooksPath, { recursive: true });
     }
-    const env = isolatedGitEnvironment(
-      runtime.executablePath,
-      homePath ?? dirname(runtime.executablePath),
-    );
+    const env = isolatedGitEnvironment(this.input, homePath ?? dirname(runtime.executablePath));
     const { stdout } = await execFileAsync(
       runtime.executablePath,
       [...fixedGitArguments(hooksPath), ...args],
@@ -1696,7 +1711,7 @@ class VerifiedGitRuntime {
       [...fixed, '-C', sourceRoot, 'pack-objects', '--stdout', '--revs'],
       {
         cwd: homePath,
-        env: isolatedGitEnvironment(packRuntime.executablePath, homePath),
+        env: isolatedGitEnvironment(this.input, homePath),
         stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
       },
@@ -1717,7 +1732,7 @@ class VerifiedGitRuntime {
       [...fixed, '--git-dir', repositoryPath, 'index-pack', '--stdin', '--fix-thin'],
       {
         cwd: homePath,
-        env: isolatedGitEnvironment(indexRuntime.executablePath, homePath),
+        env: isolatedGitEnvironment(this.input, homePath),
         stdio: ['pipe', 'ignore', 'pipe'],
         windowsHide: true,
       },
@@ -2783,7 +2798,11 @@ function isOwnedBaselineCommit(raw: string): boolean {
   );
 }
 
-function isolatedGitEnvironment(executablePath: string, homePath: string): NodeJS.ProcessEnv {
+function isolatedGitEnvironment(
+  input: VerifiedGitRuntimeInput,
+  homePath: string,
+): NodeJS.ProcessEnv {
+  const executablePath = input.executablePath;
   const env: NodeJS.ProcessEnv = {
     HOME: homePath,
     XDG_CONFIG_HOME: join(homePath, 'xdg'),
@@ -2797,6 +2816,17 @@ function isolatedGitEnvironment(executablePath: string, homePath: string): NodeJ
     LC_ALL: 'C',
     PATH: dirname(executablePath),
   };
+  if (input.distribution?.kind === 'dugite_native_v1') {
+    Object.assign(
+      env,
+      bundledGitEnvironment({
+        platform: process.platform,
+        arch: process.arch,
+        rootPath: input.distribution.rootPath,
+        executablePath,
+      }),
+    );
+  }
   for (const name of ['SystemRoot', 'WINDIR', 'COMSPEC', 'TMP', 'TEMP', 'TMPDIR']) {
     if (process.env[name]) env[name] = process.env[name];
   }

--- a/scripts/macos-arm64-release.test.mjs
+++ b/scripts/macos-arm64-release.test.mjs
@@ -86,7 +86,7 @@ test('the packaged app is checked for every unsigned helper that could still be 
   );
   for (const helper of ['cua-driver', 'maka-cu', 'officecli']) {
     assert.ok(
-      forbidden.some((path) => path.endsWith(`/${helper}`)),
+      forbidden.some((path) => path.replaceAll('\\', '/').endsWith(`/${helper}`)),
       `${helper} is not among the paths the packaged app is checked against`,
     );
   }

--- a/scripts/package-macos-arm64.mjs
+++ b/scripts/package-macos-arm64.mjs
@@ -72,6 +72,7 @@ export async function packageMacosArm64({
 
   await run('npm', ['run', 'clean']);
   await run('npm', ['run', 'build']);
+  await run('npm', ['run', 'prepare:bundled-git']);
   await run('npm', ['run', 'check:release']);
   await remove(releaseDirectory, { recursive: true, force: true });
   await run('npm', ['--workspace', '@maka/desktop', 'run', 'package:macos-arm64']);

--- a/scripts/package-windows-x64.mjs
+++ b/scripts/package-windows-x64.mjs
@@ -66,6 +66,7 @@ export async function packageWindowsX64({
 
   await run('npm', ['run', 'clean']);
   await run('npm', ['run', 'build']);
+  await run('npm', ['run', 'prepare:bundled-git']);
   await run('npm', ['run', 'check:release']);
   await remove(releaseDirectory, { recursive: true, force: true });
   await run('npm', ['--workspace', '@maka/desktop', 'run', 'package:windows-x64']);

--- a/scripts/prepare-bundled-git.mjs
+++ b/scripts/prepare-bundled-git.mjs
@@ -13,6 +13,7 @@ const sha256Pattern = /^[a-f0-9]{64}$/u;
 
 export async function prepareBundledGit({
   dugiteRoot = join(repoRoot, 'node_modules', 'dugite'),
+  gitLicensePath = join(repoRoot, 'apps', 'desktop', 'resources', 'licenses', 'git', 'LICENSE.txt'),
   outputPath = join(repoRoot, 'apps', 'desktop', 'bundled-git.json'),
   platform = process.platform,
   arch = process.arch,
@@ -23,6 +24,7 @@ export async function prepareBundledGit({
     throw new Error(`Bundled Git preparation requires dugite ${expectedDugiteVersion}.`);
   }
   await requireRegularFile(join(dugiteRoot, 'LICENSE'), 'dugite license');
+  await requireRegularFile(gitLicensePath, 'packaged Git license');
 
   const embeddedGit = JSON.parse(
     await readFile(join(dugiteRoot, 'script', 'embedded-git.json'), 'utf8'),
@@ -45,7 +47,6 @@ export async function prepareBundledGit({
   const executablePath = resolve(dugiteRoot, ...executableRelativePath.split('/'));
   assertWithin(dugiteRoot, executablePath);
   await requireRegularFile(executablePath, 'bundled Git executable');
-  await requireRegularFile(join(dugiteRoot, 'git', 'LICENSE.txt'), 'bundled Git license');
 
   const reportedVersion = await runGit(executablePath);
   if (

--- a/scripts/prepare-bundled-git.mjs
+++ b/scripts/prepare-bundled-git.mjs
@@ -1,0 +1,121 @@
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { lstat, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const expectedDugiteVersion = '3.2.2';
+const sha256Pattern = /^[a-f0-9]{64}$/u;
+
+export async function prepareBundledGit({
+  dugiteRoot = join(repoRoot, 'node_modules', 'dugite'),
+  outputPath = join(repoRoot, 'apps', 'desktop', 'bundled-git.json'),
+  platform = process.platform,
+  arch = process.arch,
+  runGit = runGitVersion,
+} = {}) {
+  const packageManifest = JSON.parse(await readFile(join(dugiteRoot, 'package.json'), 'utf8'));
+  if (packageManifest.name !== 'dugite' || packageManifest.version !== expectedDugiteVersion) {
+    throw new Error(`Bundled Git preparation requires dugite ${expectedDugiteVersion}.`);
+  }
+  await requireRegularFile(join(dugiteRoot, 'LICENSE'), 'dugite license');
+
+  const embeddedGit = JSON.parse(
+    await readFile(join(dugiteRoot, 'script', 'embedded-git.json'), 'utf8'),
+  );
+  const archive = embeddedGit[`${platform}-${arch}`];
+  if (
+    !archive ||
+    typeof archive !== 'object' ||
+    typeof archive.name !== 'string' ||
+    typeof archive.url !== 'string' ||
+    typeof archive.checksum !== 'string' ||
+    !sha256Pattern.test(archive.checksum)
+  ) {
+    throw new Error(
+      `dugite ${expectedDugiteVersion} does not provide a pinned Git archive for ${platform}-${arch}.`,
+    );
+  }
+  const gitVersion = parseArchiveGitVersion(archive.name);
+  const executableRelativePath = platform === 'win32' ? 'git/cmd/git.exe' : 'git/bin/git';
+  const executablePath = resolve(dugiteRoot, ...executableRelativePath.split('/'));
+  assertWithin(dugiteRoot, executablePath);
+  await requireRegularFile(executablePath, 'bundled Git executable');
+  await requireRegularFile(join(dugiteRoot, 'git', 'LICENSE.txt'), 'bundled Git license');
+
+  const reportedVersion = await runGit(executablePath);
+  if (
+    !new RegExp(`^git version ${escapeRegExp(gitVersion)}(?:[.\\s]|$)`, 'u').test(
+      reportedVersion.trim(),
+    )
+  ) {
+    throw new Error(
+      `Bundled Git executable reported ${JSON.stringify(reportedVersion.trim())}; expected Git ${gitVersion}.`,
+    );
+  }
+
+  const manifest = {
+    schemaVersion: 1,
+    protocol: 'maka_bundled_git_runtime_v1',
+    provider: 'desktop/dugite-native',
+    gitVersion,
+    platform,
+    arch,
+    executableRelativePath,
+    executableSha256: await sha256File(executablePath),
+    sourceArchiveSha256: `sha256:${archive.checksum}`,
+    distributionReady: true,
+  };
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+async function runGitVersion(executablePath) {
+  const { stdout } = await execFileAsync(executablePath, ['--version'], {
+    encoding: 'utf8',
+    timeout: 15_000,
+    windowsHide: true,
+  });
+  return stdout;
+}
+
+function parseArchiveGitVersion(name) {
+  const match = /^dugite-native-v(\d+\.\d+\.\d+)-/u.exec(name);
+  if (!match) throw new Error(`dugite embedded Git archive name is invalid: ${name}`);
+  return match[1];
+}
+
+async function requireRegularFile(path, label) {
+  const info = await lstat(path);
+  if (!info.isFile() || info.isSymbolicLink()) {
+    throw new Error(`${label} must be a regular non-symlink file: ${path}`);
+  }
+}
+
+function assertWithin(root, target) {
+  const rel = relative(resolve(root), resolve(target));
+  if (rel === '' || (!rel.startsWith(`..${sep}`) && rel !== '..')) return;
+  throw new Error(`Bundled Git executable escapes dugite root: ${target}`);
+}
+
+async function sha256File(path) {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const manifest = await prepareBundledGit();
+  console.log(
+    `Prepared bundled Git ${manifest.gitVersion} for ${manifest.platform}-${manifest.arch}.`,
+  );
+}

--- a/scripts/prepare-bundled-git.test.mjs
+++ b/scripts/prepare-bundled-git.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import { prepareBundledGit } from './prepare-bundled-git.mjs';
+
+test('prepares a strict manifest from dugite embedded-git provenance', async () => {
+  const fixture = await createDugiteFixture();
+  try {
+    const manifest = await prepareBundledGit({
+      dugiteRoot: fixture.dugiteRoot,
+      outputPath: fixture.outputPath,
+      platform: 'win32',
+      arch: 'x64',
+      runGit: async (executablePath) => {
+        assert.equal(executablePath, fixture.executablePath);
+        return 'git version 2.53.0.windows.1\n';
+      },
+    });
+
+    assert.deepEqual(JSON.parse(await readFile(fixture.outputPath, 'utf8')), manifest);
+    assert.deepEqual(manifest, {
+      schemaVersion: 1,
+      protocol: 'maka_bundled_git_runtime_v1',
+      provider: 'desktop/dugite-native',
+      gitVersion: '2.53.0',
+      platform: 'win32',
+      arch: 'x64',
+      executableRelativePath: 'git/cmd/git.exe',
+      executableSha256: 'sha256:f391158ea86e1e56b2b0c13583821c2b752c2abccd91496d91e025d54ac616e5',
+      sourceArchiveSha256:
+        'sha256:f843a87a693bfdabed83b8492bca59db6f64d1168c74d23e2c8dfb7388a97142',
+      distributionReady: true,
+    });
+  } finally {
+    await fixture.remove();
+  }
+});
+
+test('fails closed when dugite reports an unexpected Git version', async () => {
+  const fixture = await createDugiteFixture();
+  try {
+    await assert.rejects(
+      prepareBundledGit({
+        dugiteRoot: fixture.dugiteRoot,
+        outputPath: fixture.outputPath,
+        platform: 'win32',
+        arch: 'x64',
+        runGit: async () => 'git version 2.52.0.windows.1\n',
+      }),
+      /expected Git 2\.53\.0/,
+    );
+  } finally {
+    await fixture.remove();
+  }
+});
+
+test('fails closed when the platform archive is not pinned by dugite', async () => {
+  const fixture = await createDugiteFixture();
+  try {
+    await assert.rejects(
+      prepareBundledGit({
+        dugiteRoot: fixture.dugiteRoot,
+        outputPath: fixture.outputPath,
+        platform: 'freebsd',
+        arch: 'x64',
+        runGit: async () => 'git version 2.53.0\n',
+      }),
+      /does not provide a pinned Git archive/,
+    );
+  } finally {
+    await fixture.remove();
+  }
+});
+
+async function createDugiteFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'maka-prepare-dugite-'));
+  const dugiteRoot = join(root, 'dugite');
+  const executablePath = join(dugiteRoot, 'git', 'cmd', 'git.exe');
+  const outputPath = join(root, 'bundled-git.json');
+  await mkdir(join(dugiteRoot, 'script'), { recursive: true });
+  await mkdir(join(dugiteRoot, 'git', 'cmd'), { recursive: true });
+  await writeFile(join(dugiteRoot, 'package.json'), '{"name":"dugite","version":"3.2.2"}\n');
+  await writeFile(join(dugiteRoot, 'LICENSE'), 'MIT fixture license\n');
+  await writeFile(join(dugiteRoot, 'git', 'LICENSE.txt'), 'GPL fixture license\n');
+  await writeFile(executablePath, 'fake bundled git\n');
+  await writeFile(
+    join(dugiteRoot, 'script', 'embedded-git.json'),
+    `${JSON.stringify({
+      'win32-x64': {
+        name: 'dugite-native-v2.53.0-f49d009-windows-x64.tar.gz',
+        url: 'https://github.com/desktop/dugite-native/releases/download/v2.53.0-3/archive.tar.gz',
+        checksum: 'f843a87a693bfdabed83b8492bca59db6f64d1168c74d23e2c8dfb7388a97142',
+      },
+    })}\n`,
+  );
+  return {
+    dugiteRoot,
+    executablePath,
+    outputPath,
+    remove: () => rm(root, { recursive: true, force: true }),
+  };
+}

--- a/scripts/prepare-bundled-git.test.mjs
+++ b/scripts/prepare-bundled-git.test.mjs
@@ -5,11 +5,12 @@ import { tmpdir } from 'node:os';
 import test from 'node:test';
 import { prepareBundledGit } from './prepare-bundled-git.mjs';
 
-test('prepares a strict manifest from dugite embedded-git provenance', async () => {
+test('prepares from dugite provenance without assuming an archive-internal license path', async () => {
   const fixture = await createDugiteFixture();
   try {
     const manifest = await prepareBundledGit({
       dugiteRoot: fixture.dugiteRoot,
+      gitLicensePath: fixture.gitLicensePath,
       outputPath: fixture.outputPath,
       platform: 'win32',
       arch: 'x64',
@@ -44,6 +45,7 @@ test('fails closed when dugite reports an unexpected Git version', async () => {
     await assert.rejects(
       prepareBundledGit({
         dugiteRoot: fixture.dugiteRoot,
+        gitLicensePath: fixture.gitLicensePath,
         outputPath: fixture.outputPath,
         platform: 'win32',
         arch: 'x64',
@@ -62,6 +64,7 @@ test('fails closed when the platform archive is not pinned by dugite', async () 
     await assert.rejects(
       prepareBundledGit({
         dugiteRoot: fixture.dugiteRoot,
+        gitLicensePath: fixture.gitLicensePath,
         outputPath: fixture.outputPath,
         platform: 'freebsd',
         arch: 'x64',
@@ -78,12 +81,13 @@ async function createDugiteFixture() {
   const root = await mkdtemp(join(tmpdir(), 'maka-prepare-dugite-'));
   const dugiteRoot = join(root, 'dugite');
   const executablePath = join(dugiteRoot, 'git', 'cmd', 'git.exe');
+  const gitLicensePath = join(root, 'Git-LICENSE.txt');
   const outputPath = join(root, 'bundled-git.json');
   await mkdir(join(dugiteRoot, 'script'), { recursive: true });
   await mkdir(join(dugiteRoot, 'git', 'cmd'), { recursive: true });
   await writeFile(join(dugiteRoot, 'package.json'), '{"name":"dugite","version":"3.2.2"}\n');
   await writeFile(join(dugiteRoot, 'LICENSE'), 'MIT fixture license\n');
-  await writeFile(join(dugiteRoot, 'git', 'LICENSE.txt'), 'GPL fixture license\n');
+  await writeFile(gitLicensePath, 'GPLv2 fixture license\n');
   await writeFile(executablePath, 'fake bundled git\n');
   await writeFile(
     join(dugiteRoot, 'script', 'embedded-git.json'),
@@ -98,6 +102,7 @@ async function createDugiteFixture() {
   return {
     dugiteRoot,
     executablePath,
+    gitLicensePath,
     outputPath,
     remove: () => rm(root, { recursive: true, force: true }),
   };

--- a/scripts/verify-macos-arm64-dmg.mjs
+++ b/scripts/verify-macos-arm64-dmg.mjs
@@ -124,6 +124,7 @@ export async function verifyPackagedMacApp(
 
   await requirePath(executable);
   await assertPackagedResources(resources, { requirePath, forbidPath });
+  await requirePath(join(resources, 'git', 'bin', 'git'));
 
   const executableArchitectures = await run('lipo', ['-archs', executable]);
   assertSingleArchitecture(executableArchitectures.stdout, 'Maka executable');

--- a/scripts/verify-packaged-app.mjs
+++ b/scripts/verify-packaged-app.mjs
@@ -301,7 +301,7 @@ export async function assertPackagedResources(
     'app.asar',
     'bundled-tools.json',
     'bundled-git.json',
-    join('git', 'LICENSE.txt'),
+    join('licenses', 'git', 'LICENSE.txt'),
     join('workers', 'filesystem-worker.js'),
     join('licenses', 'maka', 'LICENSE'),
     join('licenses', 'maka', 'NOTICE'),

--- a/scripts/verify-packaged-app.mjs
+++ b/scripts/verify-packaged-app.mjs
@@ -300,9 +300,13 @@ export async function assertPackagedResources(
   const required = [
     'app.asar',
     'bundled-tools.json',
+    'bundled-git.json',
+    join('git', 'LICENSE.txt'),
     join('workers', 'filesystem-worker.js'),
     join('licenses', 'maka', 'LICENSE'),
     join('licenses', 'maka', 'NOTICE'),
+    join('licenses', 'dugite', 'LICENSE'),
+    join('licenses', 'git', 'NOTICE.txt'),
     join('licenses', 'electron', 'LICENSE'),
     join('licenses', 'electron', 'LICENSES.chromium.html'),
     join('licenses', 'npm', 'THIRD_PARTY_NOTICES.txt'),

--- a/scripts/verify-windows-x64.mjs
+++ b/scripts/verify-windows-x64.mjs
@@ -95,6 +95,7 @@ export async function verifyPackagedWindowsApp(
   step('checking packaged resources');
   await requirePath(executable);
   await assertPackagedResources(resources, { requirePath, forbidPath });
+  await requirePath(join(resources, 'git', 'cmd', 'git.exe'));
 
   step('reading the executable architecture');
   const machine = await readMachine(executable);

--- a/scripts/windows-x64-release.test.mjs
+++ b/scripts/windows-x64-release.test.mjs
@@ -72,6 +72,25 @@ test('Windows packaging fails closed on hosts that cannot produce the release', 
   await assert.rejects(packageWindowsX64({ platform: 'win32', arch: 'arm64' }), /Windows x64 host/);
 });
 
+test('Windows packaging regenerates bundled Git evidence before electron-builder consumes it', async () => {
+  const commands = [];
+  await packageWindowsX64({
+    platform: 'win32',
+    arch: 'x64',
+    run: async (command, args) => commands.push([command, ...args].join(' ')),
+    remove: async () => {},
+    assertFile: async () => {},
+  });
+
+  assert.deepEqual(commands, [
+    'npm run clean',
+    'npm run build',
+    'npm run prepare:bundled-git',
+    'npm run check:release',
+    'npm --workspace @maka/desktop run package:windows-x64',
+  ]);
+});
+
 test('Windows verification fails closed on the host, the input, and the architecture', async () => {
   await assert.rejects(
     verifyWindowsX64Release('C:/Maka.exe', { platform: 'darwin' }),


### PR DESCRIPTION
## What changed

- provision a pinned Dugite Git distribution during release preparation and resolve it through a strict platform/architecture manifest;
- fail closed when the manifest, archive provenance, Git version, entry executable, or runtime location does not match the admitted artifact;
- bind managed-workspace artifacts to the admitted Git runtime identity and revalidate the executable before each Git invocation;
- run managed Git operations with a hermetic environment and fixed policy that disables hooks, credentials, interactive authentication, SSH commands, remote protocols, config includes, alternates, and unsafe source configuration;
- package the runtime and required notices on Windows and macOS, with release checks that require the bundled executable;
- document the authority boundary, platform behavior, signing limitation, and follow-up trust-chain work.

## Why

Managed workspaces cannot rely on an arbitrary system Git installation: PATH lookup, user/repository configuration, helper substitution, and runtime replacement would make the workspace authority depend on mutable host state. This change gives the workspace service one explicit Git artifact and one fail-closed execution profile.

The current manifest intentionally authenticates the entry executable and complete source-archive provenance, rather than hashing the helper tree before signing. On macOS, nested Mach-O signing changes helper bytes after preparation. A later publication slice will generate a final tree manifest after inner signing and bind that manifest into the outer application signature.

## User and developer impact

- packaged builds no longer need a separately installed system Git for managed-workspace lifecycle operations;
- missing or modified bundled Git fails closed instead of falling back to PATH;
- existing attached-workspace behavior and Desktop/CLI defaults are unchanged;
- remote Git operations and submodules remain intentionally disabled in this version.

## Validation

- `@maka/storage` build
- `@maka/runtime-host` build
- bundled Git preparation tests: 3 passed
- bundled Git runtime, native environment, workspace smoke, and workspace policy tests: 28 passed, 9 platform-gated Windows crash fixtures skipped
- focused Windows packaging-order test: passed

One unrelated test newly present on `main` compares Windows paths against POSIX separators in `windows-x64-release.test.mjs`; it is outside this diff and was not folded into this PR.

<details>
<summary>中文说明</summary>

## 修改内容

- 发布准备阶段从固定版本的 Dugite 包中生成 bundled Git，并通过严格的平台、架构 manifest 解析；
- manifest、源归档 provenance、Git 版本、入口可执行文件或安装位置不匹配时 fail closed；
- managed workspace artifact 绑定 Git runtime identity，每次 Git 调用前重新验证入口可执行文件；
- 使用 hermetic 环境和固定执行策略，禁用 hooks、credential helper、交互认证、SSH command、远程协议、config include、object alternates 与不安全的 source config；
- Windows/macOS 发布包纳入 Git runtime 与许可证通知，发布校验强制确认 bundled executable 存在；
- 文档明确 authority 边界、平台行为、签名限制和后续 trust-chain 工作。

## 原因

Managed workspace 不能依赖任意系统 Git。PATH、用户/仓库配置、helper 替换和运行时文件变化，都会让 workspace authority 依赖可变的宿主机状态。本 PR 为 workspace service 提供唯一、显式、fail-closed 的 Git artifact 与执行 profile。

当前 manifest 有意验证入口 executable 和完整 source archive provenance，而没有在签名前固定 helper tree hash。macOS nested Mach-O 签名会在准备阶段之后改变 helper 字节；后续独立发布切片会在 inner signing 后生成最终 tree manifest，并由 outer application signature 保护该 manifest。

## 影响

- 发布包执行 managed workspace 生命周期时不再要求用户单独安装系统 Git；
- bundled Git 缺失或被修改时直接拒绝，不回退 PATH；
- 不改变 attached workspace 与 Desktop/CLI 的默认行为；
- 当前版本仍明确禁止 remote Git 与 submodule 操作。

## 验证

- storage 与 runtime-host 构建通过；
- bundled Git preparation 测试 3 项通过；
- runtime、native environment、真实 workspace smoke 与 policy 测试 28 项通过，9 项 Windows crash fixture 按平台条件跳过；
- Windows 打包顺序定向测试通过。

最新 main 另有一个 Windows release 测试使用 POSIX 分隔符断言 Windows 路径；它不在本 PR diff 中，因此没有混入本切片修复。

</details>
