### PR TITLE
fix(runtime): enforce swarm failure boundaries

### DIFF
--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -722,7 +722,12 @@ describe('Maka CLI runtime bootstrap', () => {
         assert.deepEqual(
           childAgents.definitions.find((definition) => definition.id === IMPLEMENTATION_AGENT_ID)
             ?.availability,
-          { status: 'available' },
+          {
+            status: 'unavailable',
+            reason: 'workspace_isolation_unavailable',
+            workspace: 'worktree',
+            requiredRuntime: 'worktree_child_executor',
+          },
         );
         assert.deepEqual(
           childAgents.definitions.find((definition) => definition.id === WEB_RESEARCH_AGENT_ID)

--- a/packages/core/src/__tests__/agent-swarm-result.test.ts
+++ b/packages/core/src/__tests__/agent-swarm-result.test.ts
@@ -30,17 +30,23 @@ describe('agent swarm result contract', () => {
       () =>
         decodeCanonicalToolResultContent({
           ...agentSwarmResult(),
-          status: 'failed',
+          status: 'unknown',
         }),
       /Invalid tool result content/,
     );
   });
 
-  test('keeps partial batches settled and classifies cancellation as interrupted', () => {
+  test('keeps partial batches settled and classifies failed and cancelled batches', () => {
     const partial = { ...agentSwarmResult(), status: 'partial' as const };
+    const failed = decodeCanonicalToolResultContent({
+      ...agentSwarmResult(),
+      status: 'failed',
+      items: [{ ...agentSwarmResult().items[0], status: 'failed' }],
+    });
     const cancelled = { ...agentSwarmResult(), status: 'cancelled' as const };
 
     assert.equal(toolResultActivityStatus(false, partial), 'completed');
+    assert.equal(toolResultActivityStatus(true, failed), 'errored');
     assert.equal(isCancelledToolResultContent(cancelled), true);
     assert.equal(toolResultActivityStatus(true, cancelled), 'interrupted');
   });

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -726,7 +726,7 @@ export type ToolResultContent =
     }
   | {
       kind: 'agent_swarm';
-      status: 'completed' | 'partial' | 'cancelled';
+      status: 'completed' | 'partial' | 'failed' | 'cancelled';
       items: ReadonlyArray<{
         itemId: string;
         index: number;

--- a/packages/core/src/subagent-workspace.ts
+++ b/packages/core/src/subagent-workspace.ts
@@ -32,6 +32,10 @@ export interface ProvisionSubagentWorktreeInput {
 }
 
 export interface SubagentWorktreeExecutor {
+  /** Whether the current source project can back an isolated Git worktree. */
+  isAvailable(
+    input: Pick<ProvisionSubagentWorktreeInput, 'sourceCwd' | 'sourceProjectId'>,
+  ): Promise<boolean>;
   provision(input: ProvisionSubagentWorktreeInput): Promise<SubagentWorkspaceBinding>;
   ensure(binding: SubagentWorkspaceBinding): Promise<void>;
   /** Capture the complete workspace delta relative to the durable base commit. */

--- a/packages/core/src/tool-result-record-schema.ts
+++ b/packages/core/src/tool-result-record-schema.ts
@@ -343,7 +343,7 @@ function hasValidSubagentResultFields(value: Record<string, unknown>): boolean {
 function isAgentSwarmResult(value: Record<string, unknown>): value is AgentSwarmResult {
   return (
     hasExactShape(value, AGENT_SWARM_SHAPE) &&
-    ['completed', 'partial', 'cancelled'].includes(value.status as string) &&
+    ['completed', 'partial', 'failed', 'cancelled'].includes(value.status as string) &&
     Array.isArray(value.items) &&
     value.items.every(isAgentSwarmItem) &&
     isFiniteNumber(value.startedAt) &&

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -145,6 +145,27 @@ describe('AgentSwarm adapter', () => {
     );
   });
 
+  test('rejects a missing per-item selector at the shared runtime boundary', async () => {
+    let starts = 0;
+    const runtime = buildRuntime(async () => {
+      starts += 1;
+      return childResult(starts);
+    });
+
+    const result = await executeTool(
+      runtime,
+      buildAgentSwarmTool(),
+      { items: [{ item_id: 'missing-selector', task: 'Inspect runtime validation.' }] },
+      new AbortController(),
+    );
+
+    assert.equal(starts, 0);
+    assert.match(
+      String((result as { error?: unknown }).error),
+      /Provide exactly one of subagent_id or legacy profile/,
+    );
+  });
+
   test('accepts prompt_template with string items and rejects ambiguous template input', () => {
     const tool = buildAgentSwarmTool();
     const schema = tool.parameters as {
@@ -1218,7 +1239,7 @@ describe('AgentSwarm adapter', () => {
     await Promise.all(pending.slice(0, -1));
   });
 
-  test('persists partial as settled and cancellation as interrupted', async () => {
+  test('persists partial as settled, all-failed as errored, and cancellation as interrupted', async () => {
     const events: SessionEvent[] = [];
     const telemetry: ToolInvocationRecord[] = [];
     const runtime = buildRuntime(
@@ -1245,6 +1266,24 @@ describe('AgentSwarm adapter', () => {
       'tool-partial',
     );
 
+    const failedResult = await executeTool(
+      buildRuntime(
+        async (input) => {
+          const index = Number(input.prompt.slice('task-'.length));
+          return childResult(index, 'failed');
+        },
+        { recordToolInvocation: (record) => telemetry.push(record) },
+      ),
+      swarmTool,
+      {
+        items: [swarmItem(2), swarmItem(3)],
+        max_concurrency: 2,
+      },
+      new AbortController(),
+      events,
+      'tool-failed',
+    );
+
     const cancelledController = new AbortController();
     cancelledController.abort(new Error('stop before start'));
     await executeTool(
@@ -1262,6 +1301,14 @@ describe('AgentSwarm adapter', () => {
           event.type === 'tool_result' && event.toolUseId === 'tool-partial',
       )?.isError,
       false,
+    );
+    assert.equal((failedResult as AgentSwarmToolResult).status, 'failed');
+    assert.equal(
+      events.find(
+        (event): event is Extract<SessionEvent, { type: 'tool_result' }> =>
+          event.type === 'tool_result' && event.toolUseId === 'tool-failed',
+      )?.isError,
+      true,
     );
     assert.equal(
       events.find(
@@ -1286,6 +1333,11 @@ describe('AgentSwarm adapter', () => {
     assert.equal(
       telemetry.find((record) => record.toolCallId === 'tool-cancelled')?.resultSummary?.status,
       'cancelled',
+    );
+    assert.equal(telemetry.find((record) => record.toolCallId === 'tool-failed')?.status, 'error');
+    assert.equal(
+      telemetry.find((record) => record.toolCallId === 'tool-failed')?.resultSummary?.status,
+      'failed',
     );
   });
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -875,6 +875,48 @@ describe('SessionManager graph operator provisioning', () => {
     expect(outputs[4]?.result?.text).toBe('Replacement branch completed with a verified answer.');
   });
 
+  test('does not advertise implementation when the current project cannot use worktrees', async () => {
+    const store = new MemorySessionStore();
+    const checkedSources: unknown[] = [];
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      childTools: ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash'].map(testTool),
+      worktreeChildExecutor: {
+        isAvailable: async (input) => {
+          checkedSources.push(input);
+          return false;
+        },
+        provision: async () => {
+          throw new Error('unavailable executor must not provision');
+        },
+        ensure: async () => {},
+        capturePatch: async () => new Uint8Array(),
+        recover: async () => {},
+        retire: async () => {},
+      },
+      newId: nextId(),
+      now: nextNow(40),
+    });
+    const parent = await manager.createSession(
+      makeInput({ cwd: '/tmp/plain-folder', projectId: 'plain-project' }),
+    );
+
+    const implementation = (await manager.listChildAgents(parent.id)).definitions.find(
+      (definition) => definition.id === IMPLEMENTATION_AGENT_ID,
+    );
+
+    expect(checkedSources).toEqual([
+      { sourceCwd: '/tmp/plain-folder', sourceProjectId: 'plain-project' },
+    ]);
+    expect(implementation?.availability).toEqual({
+      status: 'unavailable',
+      reason: 'workspace_isolation_unavailable',
+      workspace: AGENT_WORKSPACE_WORKTREE,
+      requiredRuntime: 'worktree_child_executor',
+    });
+  });
+
   test('binds implementation operators to a durable project worktree', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -895,6 +937,7 @@ describe('SessionManager graph operator provisioning', () => {
       backends: new BackendRegistry(),
       childTools: ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash'].map(testTool),
       worktreeChildExecutor: {
+        isAvailable: async () => true,
         provision: async (input) => {
           provisioned.push(input);
           return {
@@ -1044,6 +1087,7 @@ describe('SessionManager graph operator provisioning', () => {
       runtimeEventStore: runStore,
       backends: new BackendRegistry(),
       worktreeChildExecutor: {
+        isAvailable: async () => true,
         provision: async () => binding,
         ensure: async () => {},
         capturePatch: async () => {

--- a/packages/runtime/src/__tests__/tool-args-violation.test.ts
+++ b/packages/runtime/src/__tests__/tool-args-violation.test.ts
@@ -164,7 +164,7 @@ describe('tool argument refusal text', () => {
   });
 });
 
-test('a tool call refused for its shape is told which fields the tool takes', async () => {
+test('ToolRuntime enforces the declared schema before impl without a permissionArgs workaround', async () => {
   const messages: StoredMessage[] = [];
   const events: SessionEvent[] = [];
   const runtime = createTestToolRuntime({
@@ -183,7 +183,6 @@ test('a tool call refused for its shape is told which fields the tool takes', as
     name: 'Read',
     description: 'test',
     parameters: readSchema,
-    permissionArgs: (args) => readSchema.parse(args),
     impl: async () => {
       assert.fail('invalid arguments must not reach the implementation');
     },
@@ -206,6 +205,53 @@ test('a tool call refused for its shape is told which fields the tool takes', as
   const said = (result as { error?: string }).error ?? '';
   assert.match(said, /Tool "Read" arguments failed validation/);
   assert.match(said, /Read takes `file_path`, `offset`, `limit`\./);
+});
+
+test('ToolRuntime validates without rewriting arguments at permission and implementation boundaries', async () => {
+  const observed: unknown[] = [];
+  const runtime = createTestToolRuntime({
+    sessionId: 'session-1',
+    header: header(),
+    connection: connection(),
+    modelId: 'mock-model',
+    appendMessage: async () => {},
+    newId: nextId(),
+    now: () => 1,
+    getPermissionPauseTarget: () => null,
+  });
+  const parameters = z.object({
+    file_path: z.string().transform((value) => value.trim()),
+    limit: z.number().default(25),
+  });
+  const tool: MakaTool = {
+    name: 'Read',
+    description: 'test',
+    parameters,
+    permissionArgs: (args) => {
+      observed.push(structuredClone(args));
+      return args;
+    },
+    impl: async (args) => {
+      observed.push(structuredClone(args));
+      return args;
+    },
+  };
+
+  const { result } = await runtime.settleToolCall({
+    tool,
+    turnId: 'turn-1',
+    toolCallId: 'tool-normalized',
+    input: { file_path: '  /workspace/a.ts  ' },
+    abortSignal: new AbortController().signal,
+    eventSink: {
+      push: () => {},
+      pushAndWaitUntilConsumed: async () => {},
+    },
+  });
+
+  const expected = { file_path: '  /workspace/a.ts  ' };
+  assert.deepEqual(observed, [expected, expected]);
+  assert.deepEqual(result, expected);
 });
 
 test('a sandbox denial names the tool that widens the boundary', async () => {

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -438,10 +438,15 @@ export function buildAgentSwarmTool(
         completedAt,
         durationMs: Math.max(0, completedAt - startedAt),
       };
-      traceAgentSwarm(ctx, 'tool_completed', 'batch_completed', {
-        ...projectAgentSwarmResult(result),
-        resumedItemCount: prepared.items.filter((item) => item.mode === 'resume').length,
-      });
+      traceAgentSwarm(
+        ctx,
+        status === 'failed' ? 'tool_failed' : 'tool_completed',
+        'batch_completed',
+        {
+          ...projectAgentSwarmResult(result),
+          resumedItemCount: prepared.items.filter((item) => item.mode === 'resume').length,
+        },
+      );
       return result;
     },
   };
@@ -1116,6 +1121,7 @@ function mapChildResult(
 function aggregateAgentSwarmStatus(
   items: AgentSwarmToolResult['items'],
 ): AgentSwarmToolResult['status'] {
+  if (items.every((item) => item.status === 'failed')) return 'failed';
   if (items.some((item) => item.status === 'cancelled')) return 'cancelled';
   if (items.every((item) => item.status === 'completed')) return 'completed';
   return 'partial';

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1000,8 +1000,15 @@ export class SessionManager {
     );
   }
 
-  private hasWorktreeChildExecutor(): boolean {
-    return this.deps.worktreeChildExecutor !== undefined;
+  private async isWorktreeChildExecutorAvailable(
+    header: Pick<SessionHeader, 'cwd' | 'projectId'>,
+  ): Promise<boolean> {
+    const executor = this.deps.worktreeChildExecutor;
+    if (!executor) return false;
+    return await executor.isAvailable({
+      sourceCwd: header.cwd,
+      ...(header.projectId !== undefined ? { sourceProjectId: header.projectId } : {}),
+    });
   }
 
   private async finalizeAndListChildTurnArtifacts(
@@ -2437,7 +2444,7 @@ export class SessionManager {
     assertAgentDefinitionRunnable({
       definition,
       tools: await this.childToolsForSession(input.source.sessionId),
-      worktreeChildExecutorAvailable: this.hasWorktreeChildExecutor(),
+      worktreeChildExecutorAvailable: await this.isWorktreeChildExecutorAvailable(parentHeader),
     });
     const childPermissionMode =
       parentHeader.permissionMode === 'bypass' ? 'bypass' : definition.permissionMode;
@@ -3007,7 +3014,7 @@ export class SessionManager {
     assertAgentDefinitionRunnable({
       definition,
       tools: availableChildTools,
-      worktreeChildExecutorAvailable: this.hasWorktreeChildExecutor(),
+      worktreeChildExecutorAvailable: await this.isWorktreeChildExecutorAvailable(parentHeader),
     });
 
     const proposedTurnId = input.turnId ?? this.deps.newId();
@@ -3343,7 +3350,7 @@ export class SessionManager {
     assertAgentDefinitionRunnable({
       definition,
       tools: await this.childToolsForSession(sessionId),
-      worktreeChildExecutorAvailable: this.hasWorktreeChildExecutor(),
+      worktreeChildExecutorAvailable: await this.isWorktreeChildExecutorAvailable(sessionHeader),
     });
     const visited = new Set<string>();
     let cursor: AgentRunHeader | undefined = source;
@@ -4318,9 +4325,13 @@ export class SessionManager {
   }
 
   async listChildAgents(sessionId: string): Promise<AgentListResult> {
+    const [header, tools] = await Promise.all([
+      this.deps.store.readHeader(sessionId),
+      this.childToolsForSession(sessionId),
+    ]);
     const definitions = listBuiltinAgentDefinitions({
-      tools: await this.childToolsForSession(sessionId),
-      worktreeChildExecutorAvailable: this.hasWorktreeChildExecutor(),
+      tools,
+      worktreeChildExecutorAvailable: await this.isWorktreeChildExecutorAvailable(header),
     });
     const presets = this.deps.subagentCatalog ? await this.deps.subagentCatalog.list() : [];
     if (!this.deps.runStore) return { definitions, presets, executions: [], runs: [] };

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -777,14 +777,25 @@ export class ToolRuntime {
     },
     stepId?: string,
   ): Promise<unknown> {
-    const executionArgs = snapshotToolArgs(args);
+    const rawExecutionArgs = snapshotToolArgs(args);
     const toolUseId = ctx.toolCallId;
     // Registration is synchronous and happens before the first await, so
     // parallel Runtime settlements cannot race past exclusive admission.
     const admissionFailure = this.admitToolForStep(tool, stepId);
-    let permissionArgs = executionArgs;
+    const executionArgs = rawExecutionArgs;
+    let permissionArgs = rawExecutionArgs;
     let permissionArgsError: unknown;
     try {
+      // A surface that cannot carry a sandbox-boundary request rejects the
+      // operation before it interprets the requested expansion. Preserve that
+      // availability contract even when an older caller sends a legacy shape.
+      const sandboxBoundaryUnavailable =
+        tool.name === 'request_sandbox_boundary' &&
+        !this.interactionRun() &&
+        (!this.input.createSandboxBoundaryRequest || !this.input.settleSandboxBoundaryRequest);
+      if (!sandboxBoundaryUnavailable) {
+        await validateDeclaredToolArgs(tool.parameters, rawExecutionArgs);
+      }
       permissionArgs = tool.permissionArgs
         ? snapshotToolArgs(
             tool.permissionArgs(structuredClone(executionArgs) as never, {
@@ -2145,6 +2156,55 @@ export class ToolRuntime {
   }
 }
 
+async function validateDeclaredToolArgs(parameters: unknown, args: unknown): Promise<void> {
+  if (!parameters || (typeof parameters !== 'object' && typeof parameters !== 'function')) {
+    return;
+  }
+  const schema = parameters as {
+    safeParseAsync?: (
+      value: unknown,
+    ) => PromiseLike<{ success: true; data: unknown } | { success: false; error: unknown }>;
+    safeParse?: (
+      value: unknown,
+    ) => { success: true; data: unknown } | { success: false; error: unknown };
+    validate?: (
+      value: unknown,
+    ) =>
+      | { success: true; value: unknown }
+      | { success: false; error: unknown }
+      | PromiseLike<{ success: true; value: unknown } | { success: false; error: unknown }>;
+    '~standard'?: {
+      validate?: (
+        value: unknown,
+      ) =>
+        | { value: unknown }
+        | { issues: readonly unknown[] }
+        | PromiseLike<{ value: unknown } | { issues: readonly unknown[] }>;
+    };
+  };
+
+  if (typeof schema.safeParseAsync === 'function') {
+    const parsed = await schema.safeParseAsync(args);
+    if (parsed.success) return;
+    throw parsed.error;
+  }
+  if (typeof schema.safeParse === 'function') {
+    const parsed = schema.safeParse(args);
+    if (parsed.success) return;
+    throw parsed.error;
+  }
+  if (typeof schema.validate === 'function') {
+    const parsed = await schema.validate(args);
+    if (parsed.success) return;
+    throw parsed.error;
+  }
+  if (typeof schema['~standard']?.validate === 'function') {
+    const parsed = await schema['~standard'].validate(args);
+    if ('value' in parsed) return;
+    throw new Error('Tool arguments failed declared schema validation', { cause: parsed.issues });
+  }
+}
+
 function isInteractionControlError(error: unknown): boolean {
   return (
     error instanceof RuntimeInteractionAdmissionRejectedError ||
@@ -2549,6 +2609,7 @@ function deriveToolResultStatus(
     return 'error';
   }
   if (content.kind === 'agent_swarm') {
+    if (content.status === 'failed') return 'error';
     return content.status === 'cancelled' ? 'aborted' : 'success';
   }
   if (content.kind === 'rive_workflow' && content.ok === false) return 'error';

--- a/packages/storage/src/__tests__/git-worktree-child-executor.test.ts
+++ b/packages/storage/src/__tests__/git-worktree-child-executor.test.ts
@@ -16,6 +16,18 @@ afterEach(async () => {
 });
 
 describe('Git worktree child executor', () => {
+  test('reports availability only when the source workspace is a Git project', async () => {
+    const root = await temporaryRoot();
+    const repository = join(root, 'repository');
+    const folder = join(root, 'folder');
+    await createGitRepositoryWithWorktree(repository, join(root, 'existing-worktree'), 'existing');
+    await writeFileAfterMkdir(folder, 'file.txt', 'plain\n');
+    const executor = createGitWorktreeChildExecutor({ storageRoot: join(root, 'storage') });
+
+    assert.equal(await executor.isAvailable({ sourceCwd: repository }), true);
+    assert.equal(await executor.isAvailable({ sourceCwd: folder }), false);
+  });
+
   test('provisions deterministic isolated worktrees for concurrent child leases', async () => {
     const root = await temporaryRoot();
     const repository = join(root, 'repository');

--- a/packages/storage/src/__tests__/git-worktree-child-executor.test.ts
+++ b/packages/storage/src/__tests__/git-worktree-child-executor.test.ts
@@ -26,6 +26,7 @@ describe('Git worktree child executor', () => {
 
     assert.equal(await executor.isAvailable({ sourceCwd: repository }), true);
     assert.equal(await executor.isAvailable({ sourceCwd: folder }), false);
+    assert.equal(await executor.isAvailable({ sourceCwd: join(root, 'missing') }), false);
   });
 
   test('provisions deterministic isolated worktrees for concurrent child leases', async () => {

--- a/packages/storage/src/git-worktree-child-executor.ts
+++ b/packages/storage/src/git-worktree-child-executor.ts
@@ -45,8 +45,12 @@ class GitWorktreeChildExecutor implements SubagentWorktreeExecutor {
   async isAvailable(
     input: Pick<ProvisionSubagentWorktreeInput, 'sourceCwd' | 'sourceProjectId'>,
   ): Promise<boolean> {
-    const source = await resolveProjectLocation({ path: input.sourceCwd });
-    return source.kind === 'git' && source.git !== undefined;
+    try {
+      const source = await resolveProjectLocation({ path: input.sourceCwd });
+      return source.kind === 'git' && source.git !== undefined;
+    } catch {
+      return false;
+    }
   }
 
   async provision(input: ProvisionSubagentWorktreeInput): Promise<SubagentWorkspaceBinding> {

--- a/packages/storage/src/git-worktree-child-executor.ts
+++ b/packages/storage/src/git-worktree-child-executor.ts
@@ -42,6 +42,13 @@ class GitWorktreeChildExecutor implements SubagentWorktreeExecutor {
 
   constructor(private readonly worktreeRoot: string) {}
 
+  async isAvailable(
+    input: Pick<ProvisionSubagentWorktreeInput, 'sourceCwd' | 'sourceProjectId'>,
+  ): Promise<boolean> {
+    const source = await resolveProjectLocation({ path: input.sourceCwd });
+    return source.kind === 'git' && source.git !== undefined;
+  }
+
   async provision(input: ProvisionSubagentWorktreeInput): Promise<SubagentWorkspaceBinding> {
     const suffix = leaseSuffix(input.leaseId);
     const existing = this.inFlight.get(input.leaseId);


### PR DESCRIPTION
## Summary

- validate declared tool parameters in ToolRuntime before invoking implementations
- advertise implementation agents only when the current project supports Git worktrees
- classify all-failed agent swarms as failed across result decoding, events, and telemetry

Closes #2200
Closes #2201

## Verification

- affected regression tests: 59 passed
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- core full suite: 781 passed
- runtime full suite passes when excluding the unchanged macOS executable-root assertion tied to the local `/usr/local/bin/node` layout
- storage full suite passes when excluding the unchanged `node:sqlite` warning assertion on the local Node runtime