### PR TITLE
fix(desktop): keep modal dialogs out of the window drag region

### DIFF
--- a/apps/desktop/e2e/attachment.spec.ts
+++ b/apps/desktop/e2e/attachment.spec.ts
@@ -109,7 +109,22 @@ test('a mixed attachment send has the Astryx message hierarchy', async ({ window
   expect(imageBox!.y + imageBox!.height).toBeLessThanOrEqual(bubbleBox!.y);
 
   await image.getByRole('button').click();
-  await expect(page.locator('.astryx-lightbox')).toBeVisible();
+  const lightbox = page.locator('.astryx-lightbox');
+  await expect(lightbox).toBeVisible();
+
+  // The lightbox parks its close button in the window's top-right corner, which
+  // is inside the titlebar's drag rect. The OS hit-tests drag regions from
+  // element rects and never sees the top layer, so a modal that does not
+  // subtract its own rect leaks clicks on that button to the window manager as
+  // drags. Assert both halves of the contract: the overlap is real (otherwise
+  // the app-region assertion guards nothing), and the modal is `no-drag`.
+  const titlebar = page.locator('.maka-window-titlebar');
+  const [titlebarBox, lightboxBox] = await Promise.all([titlebar.boundingBox(), lightbox.boundingBox()]);
+  expect(titlebarBox).not.toBeNull();
+  expect(lightboxBox).not.toBeNull();
+  expect(lightboxBox!.y).toBeLessThan(titlebarBox!.y + titlebarBox!.height);
+  await expect(lightbox).toHaveCSS('-webkit-app-region', 'no-drag');
+
   await page.keyboard.press('Escape');
   await expect(page.locator('.astryx-lightbox')).not.toBeVisible();
 });

--- a/apps/desktop/e2e/attachment.spec.ts
+++ b/apps/desktop/e2e/attachment.spec.ts
@@ -112,12 +112,9 @@ test('a mixed attachment send has the Astryx message hierarchy', async ({ window
   const lightbox = page.locator('.astryx-lightbox');
   await expect(lightbox).toBeVisible();
 
-  // The lightbox parks its close button in the window's top-right corner, which
-  // is inside the titlebar's drag rect. The OS hit-tests drag regions from
-  // element rects and never sees the top layer, so a modal that does not
-  // subtract its own rect leaks clicks on that button to the window manager as
-  // drags. Assert both halves of the contract: the overlap is real (otherwise
-  // the app-region assertion guards nothing), and the modal is `no-drag`.
+  // The lightbox close button lands inside the titlebar's drag rect, where the
+  // OS eats clicks unless the modal is `no-drag`. The overlap is asserted first —
+  // without it the app-region check would guard nothing.
   const titlebar = page.locator('.maka-window-titlebar');
   const [titlebarBox, lightboxBox] = await Promise.all([titlebar.boundingBox(), lightbox.boundingBox()]);
   expect(titlebarBox).not.toBeNull();

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -259,6 +259,21 @@
   -webkit-app-region: drag;
 }
 
+/* The other half of that drag surface: modal dialogs carve themselves out.
+   Chromium builds drag regions from element rects and the top layer is invisible
+   to that pass — a `showModal()` dialog paints over the titlebar, but any control
+   it places inside the titlebar rect still reaches the OS as a window drag. The
+   lightbox close button sits in the top-right corner and was half-dead for
+   exactly this reason: only the part of it overlapping a `no-drag` titlebar
+   cluster's rect responded to clicks. A modal owns everything it covers and the
+   titlebar under it is inert, so subtracting the whole dialog rect is the rule,
+   not a per-button patch — every `showModal()` surface (Astryx Dialog, Lightbox)
+   gets it. Declared after the drag rect and matching a later node in document
+   order, which is how Chromium resolves the subtraction. */
+dialog:modal {
+  -webkit-app-region: no-drag;
+}
+
 .maka-shell-topbar-rail {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -259,17 +259,9 @@
   -webkit-app-region: drag;
 }
 
-/* The other half of that drag surface: modal dialogs carve themselves out.
-   Chromium builds drag regions from element rects and the top layer is invisible
-   to that pass — a `showModal()` dialog paints over the titlebar, but any control
-   it places inside the titlebar rect still reaches the OS as a window drag. The
-   lightbox close button sits in the top-right corner and was half-dead for
-   exactly this reason: only the part of it overlapping a `no-drag` titlebar
-   cluster's rect responded to clicks. A modal owns everything it covers and the
-   titlebar under it is inert, so subtracting the whole dialog rect is the rule,
-   not a per-button patch — every `showModal()` surface (Astryx Dialog, Lightbox)
-   gets it. Declared after the drag rect and matching a later node in document
-   order, which is how Chromium resolves the subtraction. */
+/* Drag regions are hit-tested from element rects, and the top layer is invisible
+   to that pass: a `showModal()` dialog paints over the titlebar, but its controls
+   inside the titlebar rect still reach the OS as window drags. */
 dialog:modal {
   -webkit-app-region: no-drag;
 }


### PR DESCRIPTION
## Summary

Clicking the lightbox close button only worked on its left half: the button sits in the window's top-right corner, inside `.maka-window-titlebar`, the app's only `-webkit-app-region: drag` surface. Chromium builds drag regions from element rects and that pass never sees the top layer, so a `showModal()` dialog paints over the titlebar while its controls inside the titlebar rect still reach the OS as window drags. The half that did respond was the part overlapping a `no-drag` titlebar cluster's rect.

The fix subtracts every modal dialog's own rect from the drag surface (`dialog:modal { -webkit-app-region: no-drag }`) rather than patching one third-party button: a modal owns everything it covers, and the titlebar beneath it is already `inert`. This also covers Astryx `Dialog`, which uses the same `showModal()` path.

## Verification

- `apps/desktop` Playwright suite: 65 passed. The attachment journey now asserts both halves of the contract — the open lightbox really overlaps the titlebar rect (so the check guards something) and it computes `-webkit-app-region: no-drag`. Without the CSS rule that assertion fails with `none`.
- `npm run lint`, `npm run format:check`: clean.
- Not run: OS-level hit testing cannot be exercised from Playwright, so the drag-region contract is asserted through computed style rather than a real window-manager click.