### PR TITLE
chore(security): pin actions and configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       unit: ${{ steps.plan.outputs.unit }}
       workspaces: ${{ steps.plan.outputs.workspaces }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - id: plan
@@ -50,8 +50,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
@@ -88,8 +88,8 @@ jobs:
     if: needs.changes.outputs.standard_workspaces != '' || needs.changes.outputs.script_mode != 'none'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
@@ -142,8 +142,8 @@ jobs:
     if: needs.changes.outputs.runtime_host == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
@@ -157,12 +157,12 @@ jobs:
     if: needs.changes.outputs.headless == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - name: Install pinned Harbor contract runtime
         run: |
           uv tool install "harbor==0.13.2"
@@ -233,8 +233,8 @@ jobs:
       matrix:
         shard: [1, 2]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
@@ -259,8 +259,8 @@ jobs:
     if: needs.changes.outputs.e2e == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
@@ -312,8 +312,8 @@ jobs:
     if: needs.changes.outputs.storybook == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/oracle-evidence-audit.yml
+++ b/.github/workflows/oracle-evidence-audit.yml
@@ -26,13 +26,13 @@ jobs:
       matrix: ${{ steps.plan.outputs.matrix }}
       has_misses: ${{ steps.plan.outputs.has_misses }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
-      - uses: astral-sh/setup-uv@v6
-      - uses: docker/setup-buildx-action@v3
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - run: npm ci
       - run: npm run build:test
       - name: Install pinned Harbor
@@ -74,7 +74,7 @@ jobs:
           count="$(jq '.include | length' "$RUNNER_TEMP/oracle-plan/matrix.json")"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           [[ "$count" -gt 0 ]] && echo "has_misses=true" >> "$GITHUB_OUTPUT" || echo "has_misses=false" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: oracle-audit-plan
           path: ${{ runner.temp }}/oracle-plan/plan.json
@@ -89,13 +89,13 @@ jobs:
       max-parallel: 6
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
-      - uses: astral-sh/setup-uv@v6
-      - uses: docker/setup-buildx-action@v3
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - run: npm ci
       - run: npm run build:test
       - name: Install pinned Harbor
@@ -106,7 +106,7 @@ jobs:
         run: |
           git clone --filter=blob:none https://github.com/harbor-framework/terminal-bench-2-1.git "$RUNNER_TEMP/terminal-bench-2-1"
           git -C "$RUNNER_TEMP/terminal-bench-2-1" checkout "$TERMINAL_BENCH_REVISION"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: oracle-audit-plan
           path: ${{ runner.temp }}/oracle-plan
@@ -118,7 +118,7 @@ jobs:
             --task-id "${{ matrix.task_id }}" \
             --jobs-dir "$RUNNER_TEMP/oracle-jobs" \
             --out "$RUNNER_TEMP/oracle-entry/${{ matrix.task_id }}.json"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: oracle-entry-${{ matrix.task_id }}
           path: ${{ runner.temp }}/oracle-entry/${{ matrix.task_id }}.json
@@ -131,18 +131,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
       - run: npm ci
       - run: npm run build:test
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: oracle-audit-plan
           path: ${{ runner.temp }}/oracle-plan
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         if: needs.prepare.outputs.has_misses == 'true'
         with:
           pattern: oracle-entry-*

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -34,14 +34,14 @@ jobs:
 
     steps:
       - name: Check out the dispatched commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
@@ -136,7 +136,7 @@ jobs:
         run: npm run verify:windows-x64 -- "${{ steps.release.outputs.exe }}"
 
       - name: Upload the verified release assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-${{ matrix.platform }}
           path: |
@@ -161,13 +161,13 @@ jobs:
 
     steps:
       - name: Check out the dispatched commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Download the verified release assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: release-*
           path: release-assets

--- a/.github/workflows/release-windows-check.yml
+++ b/.github/workflows/release-windows-check.yml
@@ -42,11 +42,11 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/windows-baseline.yml
+++ b/.github/workflows/windows-baseline.yml
@@ -23,9 +23,9 @@ jobs:
     env:
       WINDOWS_BASELINE_LOG_DIR: artifacts/windows-baseline
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: npm
@@ -229,7 +229,7 @@ jobs:
 
       - name: Upload Windows baseline logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: windows-baseline
           path: artifacts/windows-baseline

--- a/scripts/windows-baseline-workflow.test.mjs
+++ b/scripts/windows-baseline-workflow.test.mjs
@@ -54,7 +54,7 @@ test('Windows baseline workflow keeps its non-blocking evidence contract', async
     /--workspaces=packages\/storage \*> "\$env:WINDOWS_BASELINE_LOG_DIR\/storage\.log"/u,
   );
   assert.match(workflow, /Get-Content "\$env:WINDOWS_BASELINE_LOG_DIR\/storage\.log"/u);
-  assert.match(workflow, /actions\/upload-artifact@v4/u);
+  assert.match(workflow, /actions\/upload-artifact@[0-9a-f]{40} # v4\.\d+\.\d+/u);
   assert.match(workflow, /name: windows-baseline/u);
   assert.match(workflow, /retention-days: 14/u);
 });


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- pin all 41 external GitHub Action references across five workflows to verified immutable commit SHAs
- retain exact release versions as inline comments so Dependabot can maintain the pinned references
- configure weekly Dependabot updates for the root npm workspace and GitHub Actions
- group npm minor and patch updates while keeping major updates separate
- align the existing Windows baseline workflow contract test with immutable Action references

## Pinned Actions

| Action | Release | Commit SHA |
| --- | --- | --- |
| `actions/checkout` | `v4.4.0` | `11d5960a326750d5838078e36cf38b85af677262` |
| `actions/setup-node` | `v4.4.0` | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `actions/upload-artifact` | `v4.6.2` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact` | `v4.3.0` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `astral-sh/setup-uv` | `v6.8.0` | `d0cc045d04ccac9d8b7881df0226f9e82c39688e` |
| `docker/setup-buildx-action` | `v3.12.0` | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` |

Each SHA was resolved from the corresponding official stable release tag. All Actions stay within their existing major version.

## Security boundary

Workflow triggers, jobs, steps, permissions, inputs, and execution logic are unchanged. Dependabot is limited to weekly npm and GitHub Actions updates with `open-pull-requests-limit: 10`; npm minor and patch updates share one group, while major updates remain independent. This PR does not add auto-merge, automatic approval, audit workflows, CodeQL, advisory remediation, application changes, or new dependencies.

## Verification

- `actionlint .github/workflows/*.yml` — passed
- `npm run test:scripts` — 115 passed
- all changed YAML parsed successfully; Dependabot ecosystem, directory, schedule, grouping, and limit semantics checked
- 41/41 external `uses:` references use full 40-character SHAs with exact version comments; no tag-only references remain
- all six SHA/version mappings verified against official GitHub release tags through the GitHub API
- independent `glm-5.2:cloud` configuration review — no findings
- `git diff --check origin/main...HEAD` — passed
- full application tests not run; changes are limited to GitHub configuration and its workflow contract test

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 摘要

- 将 5 个 workflow 中全部 41 条外部 GitHub Action 引用固定到经过验证的不可变 commit SHA
- 使用行内注释保留准确 release 版本，使 Dependabot 能持续维护 pinned 引用
- 为根 npm workspace 和 GitHub Actions 配置每周 Dependabot 更新
- 将 npm minor 与 patch 更新分组，major 更新保持独立
- 同步现有 Windows baseline workflow 契约测试，使其验证不可变 Action 引用

## 固定的 Actions

| Action | Release | Commit SHA |
| --- | --- | --- |
| `actions/checkout` | `v4.4.0` | `11d5960a326750d5838078e36cf38b85af677262` |
| `actions/setup-node` | `v4.4.0` | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `actions/upload-artifact` | `v4.6.2` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact` | `v4.3.0` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `astral-sh/setup-uv` | `v6.8.0` | `d0cc045d04ccac9d8b7881df0226f9e82c39688e` |
| `docker/setup-buildx-action` | `v3.12.0` | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` |

每个 SHA 都由对应 Action 的官方稳定 release tag 解析得到。所有 Action 都保持在原有 major 版本内。

## 安全边界

Workflow 的触发条件、job、step、权限、input 和执行逻辑均未改变。Dependabot 仅每周维护 npm 与 GitHub Actions，两个 ecosystem 的 `open-pull-requests-limit` 均为 10；npm minor 与 patch 更新使用同一分组，major 更新保持独立。本 PR 不添加 auto-merge、自动审批、依赖审计 workflow、CodeQL、advisory 修复、应用修改或新依赖。

## 验证

- `actionlint .github/workflows/*.yml` — 通过
- `npm run test:scripts` — 115 项通过
- 所有变更 YAML 均成功解析，并核对 Dependabot ecosystem、目录、schedule、分组和 limit 语义
- 41/41 条外部 `uses:` 引用均使用完整 40 字符 SHA 和准确版本注释，不存在剩余 tag-only 引用
- 通过 GitHub API 对照官方 release tag 验证全部 6 组 SHA/版本映射
- 独立 `glm-5.2:cloud` 配置 review — 无 findings
- `git diff --check origin/main...HEAD` — 通过
- 变更仅限 GitHub 配置及其 workflow 契约测试，因此未运行完整应用测试

</details>

Part of #2207
