### PR TITLE
feat(ui): give the prompt anchor rail its motion

### DIFF
--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -13,6 +13,14 @@ import type { Page } from '@playwright/test';
  *
  * A static CSS read cannot see any of that. Only a real scroller with a real
  * transcript can, which is what these fixtures give us.
+ *
+ * One boundary worth knowing before adding to this file: e2e-fixture renders
+ * carry `data-maka-e2e-fixture`, and `base.css` gives that `animation: none`
+ * and a 0.01ms transition cap so a fixture's rendered state never depends on
+ * the millisecond it settles. So the tests below assert the *end states* the
+ * motion resolves to — where the highlight lands, how wide each bar computes —
+ * and cannot assert that anything animated on the way there. The tick entrance
+ * has no end state to check and therefore no coverage here at all.
  */
 
 const RAIL_PROBE = `(() => {
@@ -334,4 +342,120 @@ test('the active tick stays visible once the rail overflows', async ({ overflowi
   // as exactly 0: bringing the first tick flush leaves the rail's own top
   // padding scrolled through.
   expect(atStart.railScrollTop, back).toBeLessThan(atEnd.railScrollTop);
+});
+
+/**
+ * The highlight for the prompt being read is one bar that travels, anchored to
+ * the active tick with CSS anchor positioning. That fails silently — an
+ * unresolved anchor still renders the bar, just parked at a fixed offset — and
+ * it broke exactly that way first time round, because Astryx's HoverCard sets
+ * its own inline `anchor-name` on the trigger it wraps (hence the anchor
+ * living on the tick's inner bar). Only a live window can tell a tracking
+ * highlight from a stuck one.
+ */
+test('the highlight travels with the prompt being read', async ({ longTranscriptWindow: page }) => {
+  await settled(page, 24);
+
+  const readHighlight = () =>
+    page.evaluate(() => {
+      const indicator = document.querySelector<HTMLElement>('.maka-prompt-rail-indicator');
+      const active = document.querySelector<HTMLElement>('.maka-prompt-rail-tick[data-active="true"]');
+      if (!indicator || !active) return null;
+      const i = indicator.getBoundingClientRect();
+      const a = active.getBoundingClientRect();
+      return {
+        centreDrift: Math.round(Math.abs(i.top + i.height / 2 - (a.top + a.height / 2))),
+        rightDrift: Math.round(Math.abs(i.right - a.right)),
+        activeIndex: [...document.querySelectorAll('.maka-prompt-rail-tick')].indexOf(active),
+      };
+    });
+
+  const seen: number[] = [];
+  for (const ratio of [0, 0.35, 0.7]) {
+    await scrollToRatio(page, ratio);
+    // The glide is a transition on `top`; wait for it to land before reading.
+    await page.waitForTimeout(600);
+    const highlight = await readHighlight();
+    const where = `at scroll ratio ${ratio}: ${JSON.stringify(highlight)}`;
+    expect(highlight, where).not.toBeNull();
+    expect(highlight!.centreDrift, where).toBeLessThanOrEqual(1);
+    expect(highlight!.rightDrift, where).toBeLessThanOrEqual(1);
+    seen.push(highlight!.activeIndex);
+  }
+  // And it actually moved, rather than agreeing with a highlight that never
+  // left the first tick.
+  expect(new Set(seen).size, JSON.stringify(seen)).toBe(seen.length);
+});
+
+/**
+ * The rail scrolls itself once it is past its cap, and the highlight is
+ * anchored to a tick inside that scroller. Anchor positioning resolves against
+ * the anchor's actual box, so the two must stay together through the rail's own
+ * scrolling — the case the 24-turn fixture never reaches.
+ */
+test('the highlight stays on the active tick while the rail scrolls itself', async ({ overflowingRailWindow: page }) => {
+  await settled(page, 90);
+  await scrollToRatio(page, 1);
+  await expect(page.locator('.maka-prompt-rail-tick').last()).toHaveAttribute('aria-current', 'true');
+  await page.waitForTimeout(600);
+
+  const reading = await page.evaluate(() => {
+    const rail = document.querySelector<HTMLElement>('.maka-prompt-rail')!;
+    const indicator = document.querySelector<HTMLElement>('.maka-prompt-rail-indicator')!;
+    const active = rail.querySelector<HTMLElement>('.maka-prompt-rail-tick[data-active="true"]')!;
+    const i = indicator.getBoundingClientRect();
+    const a = active.getBoundingClientRect();
+    const railBox = rail.getBoundingClientRect();
+    return {
+      railScrollTop: Math.round(rail.scrollTop),
+      centreDrift: Math.round(Math.abs(i.top + i.height / 2 - (a.top + a.height / 2))),
+      indicatorInsideRail: i.top >= railBox.top - 1 && i.bottom <= railBox.bottom + 1,
+    };
+  });
+  const where = JSON.stringify(reading);
+  // The rail really did scroll, so the highlight had something to keep up with.
+  expect(reading.railScrollTop, where).toBeGreaterThan(0);
+  expect(reading.centreDrift, where).toBeLessThanOrEqual(1);
+  expect(reading.indicatorInsideRail, where).toBe(true);
+});
+
+test('hovering a tick swells its neighbours and settles back', async ({ longTranscriptWindow: page }) => {
+  await settled(page, 24);
+
+  const barWidths = () =>
+    page.evaluate(() =>
+      [...document.querySelectorAll('.maka-prompt-rail-tick-bar')].map((bar) =>
+        Math.round(Number.parseFloat(getComputedStyle(bar).width)),
+      ),
+    );
+
+  const rest = await barWidths();
+  expect(new Set(rest).size, JSON.stringify(rest)).toBe(1);
+
+  // A real mouse move never lands on a fixture window (no OS hit-testing), but
+  // React synthesises the enter/leave pair this reads from bubbling
+  // pointerover/pointerout, which do.
+  const hovered = 12;
+  await page.locator('.maka-prompt-rail-tick').nth(hovered).dispatchEvent('pointerover');
+  await page.waitForTimeout(500);
+
+  const swollen = await barWidths();
+  const note = JSON.stringify(swollen);
+  // A falloff, not a single fat tick: widest under the pointer, then stepping
+  // down on both sides until it meets the resting width.
+  expect(swollen[hovered], note).toBeGreaterThan(swollen[hovered - 1]!);
+  expect(swollen[hovered - 1], note).toBeGreaterThan(swollen[hovered - 2]!);
+  expect(swollen[hovered], note).toBeGreaterThan(swollen[hovered + 1]!);
+  expect(swollen[hovered + 1], note).toBeGreaterThan(swollen[hovered + 2]!);
+  expect(swollen[hovered - 3], note).toBe(rest[0]);
+  expect(swollen[hovered + 3], note).toBe(rest[0]);
+
+  await page.evaluate((index) => {
+    const tick = document.querySelectorAll('.maka-prompt-rail-tick')[index]!;
+    tick.dispatchEvent(
+      new PointerEvent('pointerout', { bubbles: true, composed: true, relatedTarget: document.body }),
+    );
+  }, hovered);
+  await page.waitForTimeout(500);
+  expect(await barWidths()).toEqual(rest);
 });

--- a/apps/desktop/src/renderer/styles/prompt-rail.css
+++ b/apps/desktop/src/renderer/styles/prompt-rail.css
@@ -52,7 +52,10 @@
      clamping can move. The fallbacks are the pre-measurement first paint: no
      dock inset, and the window standing in for the scrollport. */
   top: calc((var(--maka-prompt-rail-scrollport, 100svh) - var(--maka-prompt-rail-dock, 0px)) / 2);
-  transform: translateY(-50%);
+  /* The -50% is the centring; the X offset is motion. The rail rests
+     tucked a few px toward the window edge and settles inward when the
+     pointer arrives, so reaching for it is met halfway. */
+  transform: translateY(-50%) translateX(3px);
   max-height: calc(
     var(--maka-prompt-rail-scrollport, 100svh) - var(--maka-prompt-rail-dock, 0px) - (2 * var(--space-2))
   );
@@ -68,12 +71,27 @@
   padding: var(--space-1);
   pointer-events: auto;
   opacity: var(--opacity-muted);
-  transition: opacity var(--duration-base) var(--ease-out-strong);
+  transition:
+    opacity var(--duration-base) var(--ease-out-strong),
+    transform var(--duration-emphasized) var(--ease-out-strong);
   -webkit-app-region: no-drag;
 }
 
 .maka-prompt-rail:hover {
   opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+/* Ticks arrive rather than appear: a new prompt's tick slides in from the edge,
+   and a whole transcript (session switch, remount) cascades top to bottom.
+   `--maka-prompt-rail-index` is set per tick in prompt-anchor-rail.tsx.
+   `backwards` holds the from-state through the stagger delay so a late tick
+   does not flash into place before its turn. */
+@keyframes maka-prompt-rail-tick-in {
+  from {
+    opacity: 0;
+    transform: translateX(var(--space-2));
+  }
 }
 
 .maka-prompt-rail-tick {
@@ -88,6 +106,10 @@
   justify-content: flex-end;
   position: relative;
   transition: color var(--duration-base) var(--ease-out-strong);
+  animation: maka-prompt-rail-tick-in var(--duration-large) var(--ease-out-strong) backwards;
+  /* Capped, so a 90-prompt conversation cascades in a third of a second rather
+     than nearly two: past the cap the tail arrives together. */
+  animation-delay: calc(min(var(--maka-prompt-rail-index, 0), 20) * 18ms);
 }
 
 .maka-prompt-rail-tick:hover,
@@ -95,21 +117,53 @@
   color: var(--foreground);
 }
 
-.maka-prompt-rail-tick::after {
-  content: "";
-  width: 14px;
+/* Dock-style falloff. `--maka-prompt-rail-proximity` counts ticks away from the
+   pointer (0 = hovered) and rests at the falloff distance, so the whole ramp is
+   one expression and the resting width is its own tail. */
+.maka-prompt-rail-tick-bar {
+  width: calc(14px + ((3 - var(--maka-prompt-rail-proximity, 3)) * 3px));
   height: 3px;
   border-radius: var(--radius-pill);
   background: currentColor;
-  transition: width var(--duration-base) var(--ease-out-strong);
+  transition: width var(--duration-emphasized) var(--ease-out-strong);
 }
 
-.maka-prompt-rail-tick:hover::after {
-  width: 20px;
+/* The travelling highlight for the prompt currently being read. Anchor
+   positioning is Astryx's own idiom for a sliding indicator (see its Outline):
+   the active tick's bar publishes an anchor name, the highlight reads its
+   position, and the transition on `top` is what makes it glide between prompts
+   as the transcript scrolls. Sized past the widest tick so it always reads as
+   the longer bar. */
+.maka-prompt-rail-tick[data-active="true"] .maka-prompt-rail-tick-bar {
+  anchor-name: --maka-prompt-rail-active;
+  /* The highlight is drawn over this bar, so hide the bar rather than
+     double-print it. Fading rather than hiding also gives the prompt being
+     left something to do while the highlight travels away from it. */
+  opacity: 0;
+  transition:
+    width var(--duration-emphasized) var(--ease-out-strong),
+    opacity var(--duration-base) var(--ease-out-strong);
 }
 
-.maka-prompt-rail-tick[data-active="true"]::after {
-  width: 22px;
+.maka-prompt-rail-indicator {
+  position: absolute;
+  position-anchor: --maka-prompt-rail-active;
+  right: var(--space-1);
+  top: anchor(center);
+  translate: 0 -50%;
+  width: 26px;
+  height: 3px;
+  border-radius: var(--radius-pill);
+  background: var(--foreground);
+  pointer-events: none;
+  transition: top var(--duration-large) var(--ease-out-strong);
+}
+
+/* No active prompt yet (a transcript that has not been scrolled) leaves the
+   anchor undefined, and an unresolved anchor would park the bar at the top of
+   the rail. Hide it until a tick claims the anchor. */
+.maka-prompt-rail:not(:has(.maka-prompt-rail-tick[data-active="true"])) .maka-prompt-rail-indicator {
+  display: none;
 }
 
 /* HoverCard content. Astryx owns the card itself — surface, radius, shadow,

--- a/packages/ui/src/prompt-anchor-rail.tsx
+++ b/packages/ui/src/prompt-anchor-rail.tsx
@@ -10,6 +10,14 @@ import { getConversationCopy } from './conversation-copy.js';
  */
 const SCROLL_END_EPSILON_PX = 2;
 
+/**
+ * How far the dock-style hover falloff reaches, in ticks. The hovered tick is
+ * at 0 and grows most; each neighbour out to this distance grows less. Ticks
+ * beyond it — and every tick while the pointer is away — sit at rest width,
+ * which is why this doubles as the resting proximity.
+ */
+const HOVER_FALLOFF_TICKS = 3;
+
 export interface PromptAnchorRailTurn {
   turnId: string;
   /** The user prompt text for this turn; used as the hover preview + a11y label. */
@@ -49,6 +57,10 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
   // the panels docked above it.
   const [safeArea, setSafeArea] = useState<{ scrollport: number; dock: number } | null>(null);
   const railRef = useRef<HTMLElement | null>(null);
+  // Which tick the pointer is on, so its neighbours can grow with it. Sibling
+  // selectors cannot express this: Astryx's HoverCard wraps each tick in its
+  // own `display: contents` element, so the ticks are not DOM siblings.
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   // Rebuilding this observer costs one querySelector + observe per turn over
   // the whole transcript, so it must not run per streamed token (#2030). What
   // keeps it from running is the caller: ChatView hands back the same array
@@ -186,11 +198,20 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
           : undefined
       }
     >
-      <nav className="maka-prompt-rail" aria-label={copy.promptRailAriaLabel} ref={railRef}>
-        {turns.map((turn) => {
+      <nav
+        className="maka-prompt-rail"
+        aria-label={copy.promptRailAriaLabel}
+        ref={railRef}
+        onPointerLeave={() => setHoveredIndex(null)}
+      >
+        {turns.map((turn, index) => {
           const isActive = turn.turnId === activeTurnId;
           const preview = turn.label.trim() || copy.emptyPrompt;
           const replyPreview = (turn.reply ?? '').replace(/\s+/g, ' ').trim().slice(0, 140);
+          const proximity =
+            hoveredIndex === null
+              ? HOVER_FALLOFF_TICKS
+              : Math.min(Math.abs(index - hoveredIndex), HOVER_FALLOFF_TICKS);
           return (
             // HoverCard, not a hand-positioned popover: it is portalled, so the
             // topmost and bottommost ticks no longer push their preview off the
@@ -216,10 +237,29 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
                 aria-current={isActive ? 'true' : undefined}
                 aria-label={copy.jumpToPrompt(preview)}
                 onClick={() => jumpTo(turn.turnId)}
-              />
+                onPointerEnter={() => setHoveredIndex(index)}
+                style={
+                  {
+                    '--maka-prompt-rail-index': index,
+                    '--maka-prompt-rail-proximity': proximity,
+                  } as CSSProperties
+                }
+              >
+                {/* The bar is its own element, not a `::after`, because the
+                    travelling highlight anchors to it — and a pseudo-element
+                    cannot be an anchor. It cannot anchor to the button either:
+                    the HoverCard puts its own `anchor-name` there, inline,
+                    which wins over any rule of ours. */}
+                <span className="maka-prompt-rail-tick-bar" />
+              </button>
             </HoverCard>
           );
         })}
+        {/* The travelling highlight. It is one element anchored to whichever
+            tick is active rather than a state on the tick itself, so changing
+            the active prompt moves a bar the reader can follow instead of
+            swapping two static ones. */}
+        <span className="maka-prompt-rail-indicator" aria-hidden="true" />
       </nav>
     </div>
   );


### PR DESCRIPTION
## What

Follow-up to #2161, which deliberately shipped the rail as a static row of dashes so the positioning fix could be reviewed on its own. This is the motion, split out as you asked — judged on its own, and easy to decline in parts.

Three things, in descending order of how much they earn their keep:

**1. The highlight travels.** The bar marking the prompt being read is now one element anchored to the active tick with CSS anchor positioning — Astryx's own idiom for a sliding indicator, see its `Outline`. Changing the active prompt moves something the eye can follow instead of swapping two static ticks. This is the one I'd argue carries meaning rather than decoration: in a 90-prompt rail it shows the reader which way through the conversation they just moved, and how far.

The anchor sits on the tick's **inner bar**, not the tick — `HoverCard` sets its own `anchor-name` on the trigger it wraps, inline, and that beats any rule of ours. A pseudo-element cannot be an anchor, so the bar becomes a real element.

**2. Hover falloff over three ticks.** Reads as the rail leaning toward the pointer, and practically it makes a 3px target easier to aim at without permanently spending more width on it. Sibling selectors cannot express it (each tick is wrapped in its own `display: contents` element), so the rail tracks the hovered index and hands each tick its distance as a custom property.

**3. Rest and arrival.** The rail rests tucked toward the window edge and settles inward under the pointer; ticks slide in staggered rather than appearing. The stagger is capped at 20 ticks — a 90-prompt conversation should cascade in a third of a second, not nearly two.

All three are CSS transitions/animations on the existing `--duration-*` / `--ease-*` tokens, which is what puts them under the renderer's global `prefers-reduced-motion` rule rather than needing an opt-out of their own.

## Testing, and where it stops

Worth stating plainly, because it surprised me: **e2e-fixture renders cannot exercise motion.** They carry `data-maka-e2e-fixture`, and `base.css` gives that `animation: none !important` and a 0.01ms transition cap so a fixture's rendered state never depends on the millisecond it settles. I found this writing a test to prove the reduced-motion claim — the durations were already collapsed, with no reduced-motion attribute and `prefers-reduced-motion` reporting no-preference.

So the new specs assert the **end states** the motion resolves to, which is what the fixture harness can actually see:

- the highlight lands on the active tick's centreline and right edge (±1px) at three scroll positions, and the active tick actually changes across them — so a highlight that never left the first tick fails;
- it keeps up with the active tick once the rail is past its cap and scrolling itself (the `overflowing-rail` fixture from #2161) — a case the 24-turn fixture never reaches;
- the hover falloff steps down on both sides of the pointer and settles back to a uniform rail on leave.

What that leaves uncovered: **that anything animated on the way there**, and **the tick entrance**, which has no end state to check. The entrance was verified by hand in the running app. The spec's header comment now records this boundary so the next person adding to the file doesn't assume more coverage than exists.

The sliding highlight is the piece that fails *silently* — an unresolved anchor still renders the bar, just parked at a fixed offset — which is why it is asserted in a live window rather than read off the stylesheet.

## Checks

`build`, `typecheck`, `format:check`, `check-dead-css`, `check-a11y`, `check-console` clean. 1698 desktop unit tests pass. Desktop e2e: 85 passed, with `bot-onboarding.spec.ts` flaking under full-suite load only (passes in isolation; it is a QR onboarding flow that never renders the rail). `packages/ui` has 2 failures in `astryx-form-controls-localization` — confirmed identical on an untouched `main`, unrelated to this change.

## If you'd rather take less

The three parts are independent. If the falloff or the entrance read as too much for this surface, say which and I'll drop them and keep the travelling highlight — that is the one I think is worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
