### PR TITLE
feat(desktop): add isolated Pricing settings editor

### DIFF
--- a/apps/desktop/src/main/__tests__/pricing-settings-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/pricing-settings-boundary.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const PANEL = new URL('../../../src/renderer/settings/pricing-settings-panel.tsx', import.meta.url);
+const SURFACE = new URL('../../../src/renderer/settings/settings-surface.tsx', import.meta.url);
+
+test('Pricing renderer stays behind the semantic adapter and away from legacy authorities', async () => {
+  const source = await readFile(PANEL, 'utf8');
+
+  assert.match(source, /DesktopPricingSettingsPort/);
+  assert.doesNotMatch(source, /window\.maka\.usage/);
+  assert.doesNotMatch(source, /usage:pricing:(?:list|put|reset)/);
+  assert.doesNotMatch(source, /@maka\/storage/);
+  assert.doesNotMatch(source, /runtime-host-client/);
+});
+
+test('production SettingsSurface keeps Pricing activation as an optional injection', async () => {
+  const source = await readFile(SURFACE, 'utf8');
+
+  assert.match(source, /pricingPort\?: DesktopPricingSettingsPort/);
+  assert.doesNotMatch(source, /window\.maka\.(?:usage|runtimeHost).*pricing/i);
+});

--- a/apps/desktop/src/main/__tests__/pricing-settings-model.test.ts
+++ b/apps/desktop/src/main/__tests__/pricing-settings-model.test.ts
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { EffectivePricingEntry } from '@maka/runtime-host/protocol';
+import type { DesktopPricingSnapshot } from '../../shared/runtime-host-pricing.js';
+import {
+  decidePricingRecovery,
+  findCurrentPricingDeleteTarget,
+  createPricingDraft,
+  formatPricingRate,
+  preparePricingDraftForAuthorityReview,
+  pricingSnapshotIdentityChanged,
+  pricingTargetMatchesSnapshot,
+  validatePricingDraft,
+} from '../../renderer/settings/pricing-settings-model.js';
+
+test('Pricing draft preserves exact keys and distinguishes blank cache rates from zero', () => {
+  const result = validatePricingDraft({
+    mode: 'add',
+    modelKey: '  Acme:Coder-β  ',
+    inputUsdPer1M: '1.25',
+    outputUsdPer1M: '2.5',
+    cacheReadUsdPer1M: '',
+    cacheWriteUsdPer1M: '0',
+  }, []);
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.deepEqual(result.pricing, {
+    modelKey: 'Acme:Coder-β',
+    inputUsdPer1M: 1.25,
+    outputUsdPer1M: 2.5,
+    cacheWriteUsdPer1M: 0,
+  });
+});
+
+test('Pricing draft rejects missing, non-finite, negative, overlong, and duplicate values', () => {
+  const existing = [builtin('provider:Existing', 1)];
+  const invalid = validatePricingDraft({
+    mode: 'add',
+    modelKey: 'provider:Existing',
+    inputUsdPer1M: '',
+    outputUsdPer1M: 'Infinity',
+    cacheReadUsdPer1M: '-0.1',
+    cacheWriteUsdPer1M: 'NaN',
+  }, existing);
+  assert.deepEqual(invalid, {
+    ok: false,
+    errors: {
+      modelKey: 'duplicate_model_key',
+      inputUsdPer1M: 'required',
+      outputUsdPer1M: 'invalid_rate',
+      cacheReadUsdPer1M: 'invalid_rate',
+      cacheWriteUsdPer1M: 'invalid_rate',
+    },
+  });
+
+  const overlong = validatePricingDraft({
+    mode: 'add',
+    modelKey: 'x'.repeat(129),
+    inputUsdPer1M: '0',
+    outputUsdPer1M: '0',
+    cacheReadUsdPer1M: '',
+    cacheWriteUsdPer1M: '',
+  }, existing);
+  assert.deepEqual(overlong.errors, { modelKey: 'model_key_too_long' });
+
+  const caseDistinct = validatePricingDraft({
+    mode: 'add',
+    modelKey: 'provider:existing',
+    inputUsdPer1M: '0',
+    outputUsdPer1M: '0',
+    cacheReadUsdPer1M: '',
+    cacheWriteUsdPer1M: '',
+  }, existing);
+  assert.equal(caseDistinct.ok, true);
+});
+
+test('editing seeds canonical numeric strings without filling omitted optionals', () => {
+  assert.deepEqual(createPricingDraft(custom('provider:model', 0.00000001, 'become_unpriced')), {
+    mode: 'edit',
+    modelKey: 'provider:model',
+    inputUsdPer1M: '1e-8',
+    outputUsdPer1M: '2e-8',
+    cacheReadUsdPer1M: '',
+    cacheWriteUsdPer1M: '0',
+  });
+  assert.equal(formatPricingRate(0.00000001), '$1e-8');
+  assert.notEqual(formatPricingRate(0.00000001), '$0');
+});
+
+test('authority review preserves an Add draft and makes an exact fresh key editable', () => {
+  const draft = {
+    mode: 'add' as const,
+    modelKey: '  Acme:Coder-β  ',
+    inputUsdPer1M: '1.25',
+    outputUsdPer1M: '2.5',
+    cacheReadUsdPer1M: '',
+    cacheWriteUsdPer1M: '0',
+  };
+  assert.deepEqual(
+    preparePricingDraftForAuthorityReview(draft, [builtin('Acme:Coder-β', 4)]),
+    { ...draft, mode: 'edit' },
+  );
+  assert.equal(
+    preparePricingDraftForAuthorityReview(draft, [builtin('acme:coder-β', 4)]),
+    draft,
+  );
+});
+
+test('recovery matching includes override provenance and delete consequence', () => {
+  const equalBuiltin = builtin('provider:model', 4);
+  const equalCustom = custom('provider:model', 4, 'restore_builtin');
+  const upsertTarget = { kind: 'upsert' as const, pricing: equalCustom.pricing };
+
+  assert.equal(pricingTargetMatchesSnapshot(upsertTarget, snapshot([equalBuiltin])), false);
+  assert.equal(pricingTargetMatchesSnapshot(upsertTarget, snapshot([equalCustom])), true);
+  assert.equal(pricingTargetMatchesSnapshot({
+    kind: 'delete',
+    modelKey: 'provider:model',
+    expected: 'builtin',
+  }, snapshot([equalBuiltin])), true);
+  assert.equal(pricingTargetMatchesSnapshot({
+    kind: 'delete',
+    modelKey: 'provider:model',
+    expected: 'unpriced',
+  }, snapshot([])), true);
+});
+
+test('a revision or connection change invalidates the editor save base', () => {
+  const base = snapshot([], 4);
+  assert.equal(pricingSnapshotIdentityChanged(base, snapshot([], 4)), false);
+  assert.equal(pricingSnapshotIdentityChanged(base, snapshot([], 5)), true);
+  assert.equal(pricingSnapshotIdentityChanged(base, {
+    ...base,
+    connectionId: 'connection-replaced',
+  }), true);
+  assert.equal(pricingSnapshotIdentityChanged(base, {
+    ...base,
+    hostEpoch: 'host-replaced',
+  }), true);
+});
+
+test('delayed recovery preserves the real conflict, unknown, saved, or stale cause', () => {
+  assert.deepEqual(decidePricingRecovery('revision_conflict', true), {
+    kind: 'complete',
+    notice: 'synchronized_conflict',
+  });
+  assert.deepEqual(decidePricingRecovery('revision_conflict', false), {
+    kind: 'review',
+    reason: 'revision_conflict',
+    notice: 'review_conflict',
+  });
+  assert.deepEqual(decidePricingRecovery('outcome_unknown', true), {
+    kind: 'complete',
+    notice: 'synchronized_unknown',
+  });
+  assert.deepEqual(decidePricingRecovery('outcome_unknown', false), {
+    kind: 'review',
+    reason: 'outcome_unknown',
+    notice: 'review_unknown',
+  });
+  assert.deepEqual(decidePricingRecovery('known_saved', false), {
+    kind: 'review',
+    reason: 'authority_changed',
+    notice: 'authority_changed',
+  });
+  assert.deepEqual(decidePricingRecovery('stale', true), {
+    kind: 'complete',
+    notice: 'synchronized_conflict',
+  });
+});
+
+test('delete review derives its consequence only from a current Custom override', () => {
+  assert.deepEqual(findCurrentPricingDeleteTarget(
+    'provider:model',
+    [custom('provider:model', 4, 'restore_builtin')],
+  ), {
+    kind: 'delete',
+    modelKey: 'provider:model',
+    expected: 'builtin',
+  });
+  assert.deepEqual(findCurrentPricingDeleteTarget(
+    'provider:model',
+    [custom('provider:model', 4, 'become_unpriced')],
+  ), {
+    kind: 'delete',
+    modelKey: 'provider:model',
+    expected: 'unpriced',
+  });
+  assert.equal(findCurrentPricingDeleteTarget(
+    'provider:model',
+    [builtin('provider:model', 4)],
+  ), undefined);
+  assert.equal(findCurrentPricingDeleteTarget('provider:model', []), undefined);
+});
+
+function builtin(modelKey: string, rate: number): EffectivePricingEntry {
+  return {
+    pricing: {
+      modelKey,
+      inputUsdPer1M: rate,
+      outputUsdPer1M: rate * 2,
+    },
+    source: 'builtin',
+  };
+}
+
+function custom(
+  modelKey: string,
+  rate: number,
+  resetEffect: 'restore_builtin' | 'become_unpriced',
+): EffectivePricingEntry {
+  return {
+    pricing: {
+      modelKey,
+      inputUsdPer1M: rate,
+      outputUsdPer1M: rate * 2,
+      cacheWriteUsdPer1M: 0,
+    },
+    source: 'custom',
+    resetEffect,
+  };
+}
+
+function snapshot(
+  entries: readonly EffectivePricingEntry[],
+  revision = 4,
+): DesktopPricingSnapshot {
+  return {
+    hostEpoch: 'host-current',
+    connectionId: 'connection-current',
+    revision,
+    entries,
+  };
+}

--- a/apps/desktop/src/main/__tests__/pricing-settings-model.test.ts
+++ b/apps/desktop/src/main/__tests__/pricing-settings-model.test.ts
@@ -124,6 +124,21 @@ test('recovery matching includes override provenance and delete consequence', ()
     modelKey: 'provider:model',
     expected: 'unpriced',
   }, snapshot([])), true);
+  assert.equal(pricingTargetMatchesSnapshot({
+    kind: 'delete',
+    modelKey: 'provider:model',
+    expected: 'no_override',
+  }, snapshot([equalBuiltin])), true);
+  assert.equal(pricingTargetMatchesSnapshot({
+    kind: 'delete',
+    modelKey: 'provider:model',
+    expected: 'no_override',
+  }, snapshot([])), true);
+  assert.equal(pricingTargetMatchesSnapshot({
+    kind: 'delete',
+    modelKey: 'provider:model',
+    expected: 'no_override',
+  }, snapshot([equalCustom])), false);
 });
 
 test('a revision or connection change invalidates the editor save base', () => {

--- a/apps/desktop/src/main/__tests__/pricing-settings-operation-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/pricing-settings-operation-gate.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { PricingSettingsOperationGate } from '../../renderer/settings/pricing-settings-operation-gate.js';
+
+test('Pricing Settings serializes reads and writes through one operation gate', () => {
+  const gate = new PricingSettingsOperationGate();
+  const read = gate.begin('read');
+  assert.ok(read);
+  assert.equal(gate.activeKind, 'read');
+  assert.equal(gate.begin('write'), null);
+
+  assert.equal(gate.finish(read), true);
+  const write = gate.begin('write');
+  assert.ok(write);
+  assert.equal(gate.begin('read'), null);
+  assert.equal(gate.finish(write), true);
+  assert.equal(gate.activeKind, null);
+});
+
+test('a late read from a replaced Pricing port cannot overwrite new authority', async () => {
+  const gate = new PricingSettingsOperationGate();
+  const oldResponse = deferred<string>();
+  const newResponse = deferred<string>();
+  const committed: string[] = [];
+
+  const oldRead = captureCurrent(gate, oldResponse.promise, committed);
+  gate.replacePort();
+  const newRead = captureCurrent(gate, newResponse.promise, committed);
+
+  newResponse.resolve('new-port');
+  await newRead;
+  oldResponse.resolve('old-port');
+  await oldRead;
+
+  assert.deepEqual(committed, ['new-port']);
+  assert.equal(gate.activeKind, null);
+});
+
+async function captureCurrent(
+  gate: PricingSettingsOperationGate,
+  response: Promise<string>,
+  committed: string[],
+): Promise<void> {
+  const token = gate.begin('read');
+  assert.ok(token);
+  const value = await response;
+  if (gate.isCurrent(token)) committed.push(value);
+  gate.finish(token);
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((accept) => {
+    resolve = accept;
+  });
+  return { promise, resolve };
+}

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -95,6 +95,18 @@ import {
   type TurnMessageSubmitInput,
   type TurnMessageSubmitResult,
 } from "@maka/runtime-host/protocol";
+import type {
+  DesktopPricingMutationInput,
+  DesktopPricingMutationOutcome,
+  DesktopPricingSnapshot,
+} from "../shared/runtime-host-pricing.js";
+
+export type {
+  DesktopPricingMutationInput,
+  DesktopPricingMutationOutcome,
+  DesktopPricingSettingsPort,
+  DesktopPricingSnapshot,
+} from "../shared/runtime-host-pricing.js";
 
 const MAX_OPTIMISTIC_ATTEMPTS = 3;
 const MAX_SESSION_REVISION_ATTEMPTS = 8;
@@ -130,44 +142,11 @@ export interface DesktopRuntimeHostSession {
   close(): Promise<void>;
 }
 
-export interface DesktopPricingSnapshot {
-  readonly hostEpoch: string;
-  readonly connectionId: string;
-  readonly revision: number;
-  readonly entries: readonly EffectivePricingEntry[];
-}
-
 export interface DesktopSkillCatalogSnapshot {
   readonly revision: SkillCatalogRevision;
   readonly view: SkillCatalogView;
   readonly items: readonly SkillCatalogPageItem[];
 }
-
-export interface DesktopPricingMutationInput {
-  readonly base: DesktopPricingSnapshot;
-  readonly mutation: PricingMutation;
-}
-
-export type DesktopPricingMutationOutcome =
-  | {
-      readonly kind: "saved";
-      readonly disposition: "committed" | "unchanged";
-      readonly snapshot: DesktopPricingSnapshot;
-    }
-  | {
-      readonly kind: "saved_refresh_failed";
-      readonly disposition: "committed" | "unchanged";
-    }
-  | {
-      readonly kind: "synchronized" | "review_required";
-      readonly reason: "revision_conflict" | "outcome_unknown";
-      readonly snapshot: DesktopPricingSnapshot;
-    }
-  | {
-      readonly kind: "reconciliation_unavailable";
-      readonly reason: "revision_conflict" | "outcome_unknown";
-    };
-
 type PricingReconciliationTarget =
   | { readonly kind: "upsert"; readonly pricing: Readonly<PricingConfig> }
   | {

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -15,10 +15,7 @@ import type {
   RuntimePolicy,
   RuntimePolicyMutation,
 } from "@maka/core/runtime-policy";
-import {
-  canonicalPricingConfigsEqual,
-  comparePricingModelKeys,
-} from "@maka/core/usage-stats/pricing";
+import { comparePricingModelKeys } from "@maka/core/usage-stats/pricing";
 import type { PricingConfig } from "@maka/core/usage-stats/types";
 import {
   isSessionTrace,
@@ -99,7 +96,9 @@ import type {
   DesktopPricingMutationInput,
   DesktopPricingMutationOutcome,
   DesktopPricingSnapshot,
+  PricingReconciliationTarget,
 } from "../shared/runtime-host-pricing.js";
+import { pricingTargetMatchesSnapshot } from "../shared/runtime-host-pricing.js";
 
 export type {
   DesktopPricingMutationInput,
@@ -147,14 +146,6 @@ export interface DesktopSkillCatalogSnapshot {
   readonly view: SkillCatalogView;
   readonly items: readonly SkillCatalogPageItem[];
 }
-type PricingReconciliationTarget =
-  | { readonly kind: "upsert"; readonly pricing: Readonly<PricingConfig> }
-  | {
-      readonly kind: "delete";
-      readonly modelKey: string;
-      readonly expected: "builtin" | "unpriced" | "no_override";
-    };
-
 export class DesktopRuntimeHostClient {
   readonly #sessions = new Set<DesktopSessionHandle>();
   #closeTask: Promise<void> | undefined;
@@ -1560,33 +1551,6 @@ function createPricingReconciliationTarget(
         : "unpriced"
       : "no_override";
   return { kind: "delete", modelKey: mutation.modelKey, expected };
-}
-
-function pricingTargetMatchesSnapshot(
-  target: PricingReconciliationTarget,
-  snapshot: DesktopPricingSnapshot,
-): boolean {
-  const current = snapshot.entries.find(
-    ({ pricing }) => pricing.modelKey === pricingTargetModelKey(target),
-  );
-  if (target.kind === "upsert") {
-    return (
-      current?.source === "custom" &&
-      canonicalPricingConfigsEqual(current.pricing, target.pricing)
-    );
-  }
-  switch (target.expected) {
-    case "builtin":
-      return current?.source === "builtin";
-    case "unpriced":
-      return current === undefined;
-    case "no_override":
-      return current === undefined || current.source === "builtin";
-  }
-}
-
-function pricingTargetModelKey(target: PricingReconciliationTarget): string {
-  return target.kind === "upsert" ? target.pricing.modelKey : target.modelKey;
 }
 
 function pricingEntriesAreCanonical(

--- a/apps/desktop/src/renderer/locales/settings-pricing-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-pricing-copy.ts
@@ -1,0 +1,243 @@
+import type { UiCatalog, UiLocale } from '@maka/core';
+import type { PricingDraftError, PricingDraftField } from '../settings/pricing-settings-model';
+
+export type PricingSettingsCopy = {
+  heading: string;
+  description: string;
+  disclaimer: string;
+  refresh: string;
+  refreshing: string;
+  addPrice: string;
+  loading: string;
+  tableAria: string;
+  headers: readonly [string, string, string, string, string, string, string];
+  emptyTitle: string;
+  emptyBody: string;
+  notSet: string;
+  sourceBuiltin: string;
+  sourceCustomWithFallback: string;
+  sourceCustomOnly: string;
+  customize: string;
+  edit: string;
+  reset: string;
+  delete: string;
+  editor: {
+    addTitle: string;
+    editTitle: string;
+    modelKey: string;
+    modelKeyDescription: string;
+    inputRate: string;
+    outputRate: string;
+    cacheReadRate: string;
+    cacheWriteRate: string;
+    rateDescription: string;
+    cacheDescription: string;
+    draftValues: string;
+    latestValues: string;
+    latestMissing: string;
+    cancel: string;
+    save: string;
+    saveAgain: string;
+    saving: string;
+  };
+  validation(field: PricingDraftField, error: PricingDraftError): string;
+  confirm: {
+    resetTitle: string;
+    deleteTitle: string;
+    resetDescription(modelKey: string): string;
+    deleteDescription(modelKey: string): string;
+    reviewDescription(modelKey: string, action: 'reset' | 'delete'): string;
+    cancel: string;
+    confirmAgain: string;
+  };
+  notice: {
+    loadFailed: string;
+    loadFailedDescription(detail: string): string;
+    saved: string;
+    unchanged: string;
+    savedRefreshFailed: string;
+    savedRefreshFailedDescription: string;
+    synchronizedConflict: string;
+    synchronizedUnknown: string;
+    reviewConflict: string;
+    reviewUnknown: string;
+    reconciliationUnavailable: string;
+    reconciliationUnavailableDescription: string;
+    staleSnapshot: string;
+    staleSnapshotDescription: string;
+    mutationFailed: string;
+    mutationFailedDescription(detail: string): string;
+    refreshed: string;
+    refreshedForReview: string;
+    deleteNoLongerApplies: string;
+    reviewDelete: string;
+    pending: string;
+  };
+};
+
+const SETTINGS_PRICING_COPY = {
+  zh: {
+    heading: '定价配置',
+    description: '单位为 USD / 百万 Token。修改适用于之后新激活的模型工作；正在运行的 Run 保持启动时的价格。',
+    disclaimer: '历史费用不会重算；最终账单以模型供应商为准。',
+    refresh: '刷新定价',
+    refreshing: '正在刷新定价',
+    addPrice: '添加价格',
+    loading: '正在加载生效价格…',
+    tableAria: '生效模型定价',
+    headers: ['模型 Key', '来源', '输入', '输出', '缓存读取', '缓存写入', '操作'],
+    emptyTitle: '暂无生效价格',
+    emptyBody: '添加精确的 Runtime 模型 Key，为之后新激活的模型工作设置价格。',
+    notSet: '未设置 · Maka 估算不计缓存费用',
+    sourceBuiltin: '内置',
+    sourceCustomWithFallback: '自定义 · 有内置回退',
+    sourceCustomOnly: '仅自定义',
+    customize: '自定义',
+    edit: '编辑',
+    reset: '恢复',
+    delete: '删除',
+    editor: {
+      addTitle: '添加模型价格',
+      editTitle: '编辑模型价格',
+      modelKey: '模型 Key',
+      modelKeyDescription: '填写 Runtime 精确查找 Key，例如 openai:gpt-4o。Key 区分大小写，不要填写连接 slug。',
+      inputRate: '输入 / 1M Token',
+      outputRate: '输出 / 1M Token',
+      cacheReadRate: '缓存读取 / 1M Token',
+      cacheWriteRate: '缓存写入 / 1M Token',
+      rateDescription: '必填，有限且不小于 0。',
+      cacheDescription: '可选；留空表示未设置，填写 0 表示显式零费率。',
+      draftValues: '草稿',
+      latestValues: '当前权威值',
+      latestMissing: '当前没有这个 Key',
+      cancel: '取消',
+      save: '保存',
+      saveAgain: '复核后保存',
+      saving: '正在保存定价',
+    },
+    validation: (field, error) => {
+      if (error === 'required') return '此费率为必填项';
+      if (error === 'invalid_rate') return '请输入有限且不小于 0 的数字';
+      if (error === 'model_key_empty') return '模型 Key 不能为空';
+      if (error === 'model_key_too_long') return '模型 Key 最多 128 个字符';
+      if (error === 'duplicate_model_key') return '这个 Key 已存在，请从列表中编辑或自定义';
+      return field === 'modelKey' ? '模型 Key 无效' : '费率无效';
+    },
+    confirm: {
+      resetTitle: '恢复内置价格？',
+      deleteTitle: '删除自定义价格？',
+      resetDescription: (modelKey) => `将删除 ${modelKey} 的 override。之后新激活的模型工作会恢复内置价格；正在运行的工作保持启动时的价格。`,
+      deleteDescription: (modelKey) => `将删除 ${modelKey} 的 override。之后新激活的模型工作会变为未定价，而不是 $0；正在运行的工作保持启动时的价格。`,
+      reviewDescription: (modelKey, action) => `${modelKey} 的当前权威状态已经变化。请核对最新列表，再次确认${action === 'reset' ? '恢复' : '删除'}。`,
+      cancel: '取消',
+      confirmAgain: '再次确认',
+    },
+    notice: {
+      loadFailed: '无法加载定价',
+      loadFailedDescription: (detail) => `Runtime Host 没有返回生效价格。${detail}`,
+      saved: '定价已保存并重新加载',
+      unchanged: '定价未发生变化，当前列表已重新加载',
+      savedRefreshFailed: '保存已完成，但最新定价未能加载',
+      savedRefreshFailedDescription: '草稿已保留，旧列表已隐藏。刷新成功前不会发送新的写入。',
+      synchronizedConflict: '其他更改已经产生了相同结果，未重复写入',
+      synchronizedUnknown: '当前权威状态与草稿一致；无法判断是哪次命令完成了写入',
+      reviewConflict: '定价已被其他更改更新，请对照最新值后再次保存',
+      reviewUnknown: '写入结果无法确定，最新权威状态与草稿不同；请复核后再决定是否保存',
+      reconciliationUnavailable: '暂时无法核对写入结果',
+      reconciliationUnavailableDescription: '草稿已保留，旧列表已隐藏。请先刷新权威状态，不会自动重发写入。',
+      staleSnapshot: 'Runtime Host 连接已经变化',
+      staleSnapshotDescription: '草稿已保留。请刷新并核对新连接返回的价格后再保存。',
+      mutationFailed: '定价未保存',
+      mutationFailedDescription: (detail) => `Runtime Host 拒绝了这次操作。${detail}`,
+      refreshed: '已加载最新生效价格',
+      refreshedForReview: '已加载最新价格，草稿仍保留，请复核后保存',
+      deleteNoLongerApplies: '该 override 已不存在；已显示最新生效价格，不会发送无效删除',
+      reviewDelete: '复核待处理操作',
+      pending: '正在提交定价更改',
+    },
+  },
+  en: {
+    heading: 'Pricing',
+    description: 'USD per 1M tokens. Changes apply to newly activated model work; an active run keeps its starting prices.',
+    disclaimer: 'Historical costs are not recalculated. Provider billing is authoritative.',
+    refresh: 'Refresh pricing',
+    refreshing: 'Refreshing pricing',
+    addPrice: 'Add price',
+    loading: 'Loading effective prices…',
+    tableAria: 'Effective model pricing',
+    headers: ['Model key', 'Source', 'Input', 'Output', 'Cache read', 'Cache write', 'Actions'],
+    emptyTitle: 'No effective prices',
+    emptyBody: 'Add an exact Runtime model key to price newly activated model work.',
+    notSet: 'Not set · no cache charge in Maka estimates',
+    sourceBuiltin: 'Built-in',
+    sourceCustomWithFallback: 'Custom · built-in fallback',
+    sourceCustomOnly: 'Custom-only',
+    customize: 'Customize',
+    edit: 'Edit',
+    reset: 'Reset',
+    delete: 'Delete',
+    editor: {
+      addTitle: 'Add model price',
+      editTitle: 'Edit model price',
+      modelKey: 'Model key',
+      modelKeyDescription: 'Enter the exact Runtime lookup key, such as openai:gpt-4o. Keys are case-sensitive; do not use a connection slug.',
+      inputRate: 'Input / 1M tokens',
+      outputRate: 'Output / 1M tokens',
+      cacheReadRate: 'Cache read / 1M tokens',
+      cacheWriteRate: 'Cache write / 1M tokens',
+      rateDescription: 'Required, finite, and at least 0.',
+      cacheDescription: 'Optional. Blank means not set; 0 is an explicit zero rate.',
+      draftValues: 'Draft',
+      latestValues: 'Current authority',
+      latestMissing: 'This key is not currently priced',
+      cancel: 'Cancel',
+      save: 'Save',
+      saveAgain: 'Save after review',
+      saving: 'Saving pricing',
+    },
+    validation: (field, error) => {
+      if (error === 'required') return 'This rate is required';
+      if (error === 'invalid_rate') return 'Enter a finite number that is at least 0';
+      if (error === 'model_key_empty') return 'Model key cannot be empty';
+      if (error === 'model_key_too_long') return 'Model key must be 128 characters or fewer';
+      if (error === 'duplicate_model_key') return 'This key already exists; edit or customize it from the list';
+      return field === 'modelKey' ? 'Invalid model key' : 'Invalid rate';
+    },
+    confirm: {
+      resetTitle: 'Restore built-in pricing?',
+      deleteTitle: 'Delete custom pricing?',
+      resetDescription: (modelKey) => `This deletes the override for ${modelKey}. Newly activated work will use built-in pricing; active work keeps its starting prices.`,
+      deleteDescription: (modelKey) => `This deletes the override for ${modelKey}. Newly activated work becomes unpriced, not $0; active work keeps its starting prices.`,
+      reviewDescription: (modelKey, action) => `Current authority for ${modelKey} changed. Review the latest list, then confirm ${action === 'reset' ? 'reset' : 'delete'} again.`,
+      cancel: 'Cancel',
+      confirmAgain: 'Confirm again',
+    },
+    notice: {
+      loadFailed: 'Pricing could not be loaded',
+      loadFailedDescription: (detail) => `The Runtime Host did not return effective prices. ${detail}`,
+      saved: 'Pricing saved and reloaded',
+      unchanged: 'Pricing was unchanged and the current list was reloaded',
+      savedRefreshFailed: 'The save completed, but current pricing could not be loaded',
+      savedRefreshFailedDescription: 'The draft is preserved and the old list is hidden. No new write will be sent until refresh succeeds.',
+      synchronizedConflict: 'Another change already produced the same result; no write was replayed',
+      synchronizedUnknown: 'Current authority matches the draft; Maka cannot tell which command completed the write',
+      reviewConflict: 'Pricing changed elsewhere. Compare the latest value before saving again',
+      reviewUnknown: 'The write outcome is unknown and current authority differs from the draft. Review before deciding whether to save again',
+      reconciliationUnavailable: 'The write outcome cannot be reconciled yet',
+      reconciliationUnavailableDescription: 'The draft is preserved and the old list is hidden. Refresh authority first; the write will not be replayed automatically.',
+      staleSnapshot: 'The Runtime Host connection changed',
+      staleSnapshotDescription: 'The draft is preserved. Refresh and review pricing from the new connection before saving.',
+      mutationFailed: 'Pricing was not saved',
+      mutationFailedDescription: (detail) => `The Runtime Host rejected this operation. ${detail}`,
+      refreshed: 'Latest effective pricing loaded',
+      refreshedForReview: 'Latest pricing loaded. The draft is preserved for review',
+      deleteNoLongerApplies: 'The override no longer exists. Current effective pricing is shown; no invalid delete will be sent',
+      reviewDelete: 'Review pending action',
+      pending: 'Submitting pricing changes',
+    },
+  },
+} satisfies UiCatalog<PricingSettingsCopy>;
+
+export function getPricingSettingsCopy(locale: UiLocale): PricingSettingsCopy {
+  return SETTINGS_PRICING_COPY[locale];
+}

--- a/apps/desktop/src/renderer/locales/settings-pricing-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-pricing-copy.ts
@@ -38,7 +38,6 @@ export type PricingSettingsCopy = {
     cancel: string;
     save: string;
     saveAgain: string;
-    saving: string;
   };
   validation(field: PricingDraftField, error: PricingDraftError): string;
   confirm: {
@@ -113,7 +112,6 @@ const SETTINGS_PRICING_COPY = {
       cancel: '取消',
       save: '保存',
       saveAgain: '复核后保存',
-      saving: '正在保存定价',
     },
     validation: (field, error) => {
       if (error === 'required') return '此费率为必填项';
@@ -193,7 +191,6 @@ const SETTINGS_PRICING_COPY = {
       cancel: 'Cancel',
       save: 'Save',
       saveAgain: 'Save after review',
-      saving: 'Saving pricing',
     },
     validation: (field, error) => {
       if (error === 'required') return 'This rate is required';

--- a/apps/desktop/src/renderer/settings/pricing-settings-model.ts
+++ b/apps/desktop/src/renderer/settings/pricing-settings-model.ts
@@ -1,11 +1,13 @@
 import {
-  canonicalPricingConfigsEqual,
   normalizePricingConfig,
   normalizePricingModelKey,
 } from '@maka/core/usage-stats/pricing';
 import type { PricingConfig } from '@maka/core/usage-stats/types';
 import type { EffectivePricingEntry } from '@maka/runtime-host/protocol';
-import type { DesktopPricingSnapshot } from '../../shared/runtime-host-pricing';
+export {
+  pricingTargetMatchesSnapshot,
+} from '../../shared/runtime-host-pricing.js';
+import type { DesktopPricingSnapshot } from '../../shared/runtime-host-pricing.js';
 
 export type PricingDraftField =
   | 'modelKey'
@@ -156,23 +158,6 @@ export function validatePricingDraft(
 /** Display is deliberately separate from editor seeding and persisted input. */
 export function formatPricingRate(rate: number): string {
   return `$${String(rate)}`;
-}
-
-export function pricingTargetMatchesSnapshot(
-  target: PricingMutationTarget,
-  snapshot: DesktopPricingSnapshot,
-): boolean {
-  const modelKey = target.kind === 'upsert' ? target.pricing.modelKey : target.modelKey;
-  const current = snapshot.entries.find(
-    (entry) => entry.pricing.modelKey === modelKey,
-  );
-  if (target.kind === 'upsert') {
-    return current?.source === 'custom'
-      && canonicalPricingConfigsEqual(current.pricing, target.pricing);
-  }
-  return target.expected === 'builtin'
-    ? current?.source === 'builtin'
-    : current === undefined;
 }
 
 export function pricingSnapshotIdentityChanged(

--- a/apps/desktop/src/renderer/settings/pricing-settings-model.ts
+++ b/apps/desktop/src/renderer/settings/pricing-settings-model.ts
@@ -1,0 +1,249 @@
+import {
+  canonicalPricingConfigsEqual,
+  normalizePricingConfig,
+  normalizePricingModelKey,
+} from '@maka/core/usage-stats/pricing';
+import type { PricingConfig } from '@maka/core/usage-stats/types';
+import type { EffectivePricingEntry } from '@maka/runtime-host/protocol';
+import type { DesktopPricingSnapshot } from '../../shared/runtime-host-pricing';
+
+export type PricingDraftField =
+  | 'modelKey'
+  | 'inputUsdPer1M'
+  | 'outputUsdPer1M'
+  | 'cacheReadUsdPer1M'
+  | 'cacheWriteUsdPer1M';
+
+export type PricingDraftError =
+  | 'required'
+  | 'invalid_rate'
+  | 'model_key_empty'
+  | 'model_key_too_long'
+  | 'duplicate_model_key';
+
+export interface PricingDraft {
+  readonly mode: 'add' | 'edit';
+  readonly modelKey: string;
+  readonly inputUsdPer1M: string;
+  readonly outputUsdPer1M: string;
+  readonly cacheReadUsdPer1M: string;
+  readonly cacheWriteUsdPer1M: string;
+}
+
+export type PricingDraftValidation =
+  | {
+      readonly ok: true;
+      readonly pricing: PricingConfig;
+      readonly errors: Readonly<Partial<Record<PricingDraftField, PricingDraftError>>>;
+    }
+  | {
+      readonly ok: false;
+      readonly errors: Readonly<Partial<Record<PricingDraftField, PricingDraftError>>>;
+    };
+
+export type PricingMutationTarget =
+  | { readonly kind: 'upsert'; readonly pricing: Readonly<PricingConfig> }
+  | {
+      readonly kind: 'delete';
+      readonly modelKey: string;
+      readonly expected: 'builtin' | 'unpriced';
+    };
+
+export type PricingReviewReason =
+  | 'revision_conflict'
+  | 'outcome_unknown'
+  | 'authority_changed';
+
+export type PricingRecoveryCause =
+  | 'known_saved'
+  | 'revision_conflict'
+  | 'outcome_unknown'
+  | 'stale';
+
+export type PricingRecoveryDecision =
+  | {
+      readonly kind: 'complete';
+      readonly notice: 'saved' | 'synchronized_conflict' | 'synchronized_unknown';
+    }
+  | {
+      readonly kind: 'review';
+      readonly reason: PricingReviewReason;
+      readonly notice: 'review_conflict' | 'review_unknown' | 'authority_changed';
+    };
+
+export function createPricingDraft(entry?: EffectivePricingEntry): PricingDraft {
+  if (!entry) {
+    return {
+      mode: 'add',
+      modelKey: '',
+      inputUsdPer1M: '',
+      outputUsdPer1M: '',
+      cacheReadUsdPer1M: '',
+      cacheWriteUsdPer1M: '',
+    };
+  }
+  return {
+    mode: 'edit',
+    modelKey: entry.pricing.modelKey,
+    inputUsdPer1M: String(entry.pricing.inputUsdPer1M),
+    outputUsdPer1M: String(entry.pricing.outputUsdPer1M),
+    cacheReadUsdPer1M: rateDraftValue(entry.pricing.cacheReadUsdPer1M),
+    cacheWriteUsdPer1M: rateDraftValue(entry.pricing.cacheWriteUsdPer1M),
+  };
+}
+
+export function preparePricingDraftForAuthorityReview(
+  draft: PricingDraft,
+  entries: readonly EffectivePricingEntry[],
+): PricingDraft {
+  if (draft.mode !== 'add') return draft;
+  const modelKey = normalizePricingModelKey(draft.modelKey);
+  if (
+    !modelKey.ok
+    || !entries.some((entry) => entry.pricing.modelKey === modelKey.value)
+  ) return draft;
+  return { ...draft, mode: 'edit' };
+}
+
+export function validatePricingDraft(
+  draft: PricingDraft,
+  entries: readonly EffectivePricingEntry[],
+): PricingDraftValidation {
+  const errors: Partial<Record<PricingDraftField, PricingDraftError>> = {};
+  const normalizedKey = normalizePricingModelKey(draft.modelKey);
+  if (!normalizedKey.ok) {
+    errors.modelKey = draft.modelKey.trim() === '' ? 'model_key_empty' : 'model_key_too_long';
+  } else if (
+    draft.mode === 'add'
+    && entries.some((entry) => entry.pricing.modelKey === normalizedKey.value)
+  ) {
+    errors.modelKey = 'duplicate_model_key';
+  }
+
+  const input = parseRate(draft.inputUsdPer1M, true);
+  if (!input.ok) errors.inputUsdPer1M = input.error;
+  const output = parseRate(draft.outputUsdPer1M, true);
+  if (!output.ok) errors.outputUsdPer1M = output.error;
+  const cacheRead = parseRate(draft.cacheReadUsdPer1M, false);
+  if (!cacheRead.ok) errors.cacheReadUsdPer1M = cacheRead.error;
+  const cacheWrite = parseRate(draft.cacheWriteUsdPer1M, false);
+  if (!cacheWrite.ok) errors.cacheWriteUsdPer1M = cacheWrite.error;
+
+  if (
+    !normalizedKey.ok
+    || !input.ok
+    || !output.ok
+    || !cacheRead.ok
+    || !cacheWrite.ok
+    || Object.keys(errors).length > 0
+  ) {
+    return { ok: false, errors };
+  }
+
+  const canonical = normalizePricingConfig({
+    modelKey: normalizedKey.value,
+    inputUsdPer1M: input.value,
+    outputUsdPer1M: output.value,
+    ...(cacheRead.value !== undefined ? { cacheReadUsdPer1M: cacheRead.value } : {}),
+    ...(cacheWrite.value !== undefined ? { cacheWriteUsdPer1M: cacheWrite.value } : {}),
+  });
+  if (!canonical.ok) {
+    return { ok: false, errors: { inputUsdPer1M: 'invalid_rate' } };
+  }
+  return { ok: true, pricing: canonical.value, errors };
+}
+
+/** Display is deliberately separate from editor seeding and persisted input. */
+export function formatPricingRate(rate: number): string {
+  return `$${String(rate)}`;
+}
+
+export function pricingTargetMatchesSnapshot(
+  target: PricingMutationTarget,
+  snapshot: DesktopPricingSnapshot,
+): boolean {
+  const modelKey = target.kind === 'upsert' ? target.pricing.modelKey : target.modelKey;
+  const current = snapshot.entries.find(
+    (entry) => entry.pricing.modelKey === modelKey,
+  );
+  if (target.kind === 'upsert') {
+    return current?.source === 'custom'
+      && canonicalPricingConfigsEqual(current.pricing, target.pricing);
+  }
+  return target.expected === 'builtin'
+    ? current?.source === 'builtin'
+    : current === undefined;
+}
+
+export function pricingSnapshotIdentityChanged(
+  previous: DesktopPricingSnapshot,
+  current: DesktopPricingSnapshot,
+): boolean {
+  return previous.hostEpoch !== current.hostEpoch
+    || previous.connectionId !== current.connectionId
+    || previous.revision !== current.revision;
+}
+
+export function decidePricingRecovery(
+  cause: PricingRecoveryCause,
+  targetMatches: boolean,
+): PricingRecoveryDecision {
+  if (targetMatches) {
+    if (cause === 'known_saved') return { kind: 'complete', notice: 'saved' };
+    if (cause === 'outcome_unknown') {
+      return { kind: 'complete', notice: 'synchronized_unknown' };
+    }
+    return { kind: 'complete', notice: 'synchronized_conflict' };
+  }
+  if (cause === 'revision_conflict') {
+    return { kind: 'review', reason: 'revision_conflict', notice: 'review_conflict' };
+  }
+  if (cause === 'outcome_unknown') {
+    return { kind: 'review', reason: 'outcome_unknown', notice: 'review_unknown' };
+  }
+  return { kind: 'review', reason: 'authority_changed', notice: 'authority_changed' };
+}
+
+export function createPricingDeleteTarget(
+  entry: Extract<EffectivePricingEntry, { source: 'custom' }>,
+): Extract<PricingMutationTarget, { kind: 'delete' }> {
+  return {
+    kind: 'delete',
+    modelKey: entry.pricing.modelKey,
+    expected: entry.resetEffect === 'restore_builtin' ? 'builtin' : 'unpriced',
+  };
+}
+
+export function findCurrentPricingDeleteTarget(
+  modelKey: string,
+  entries: readonly EffectivePricingEntry[],
+): Extract<PricingMutationTarget, { kind: 'delete' }> | undefined {
+  const entry = entries.find(
+    (candidate): candidate is Extract<EffectivePricingEntry, { source: 'custom' }> =>
+      candidate.pricing.modelKey === modelKey && candidate.source === 'custom',
+  );
+  return entry ? createPricingDeleteTarget(entry) : undefined;
+}
+
+function rateDraftValue(rate: number | undefined): string {
+  return rate === undefined ? '' : String(rate);
+}
+
+function parseRate(
+  raw: string,
+  required: boolean,
+):
+  | { readonly ok: true; readonly value: number | undefined }
+  | { readonly ok: false; readonly error: PricingDraftError } {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return required
+      ? { ok: false, error: 'required' }
+      : { ok: true, value: undefined };
+  }
+  const value = Number(trimmed);
+  if (!Number.isFinite(value) || value < 0) {
+    return { ok: false, error: 'invalid_rate' };
+  }
+  return { ok: true, value };
+}

--- a/apps/desktop/src/renderer/settings/pricing-settings-operation-gate.ts
+++ b/apps/desktop/src/renderer/settings/pricing-settings-operation-gate.ts
@@ -1,0 +1,51 @@
+export type PricingSettingsOperationKind = 'read' | 'write';
+
+export interface PricingSettingsOperationToken {
+  readonly generation: number;
+  readonly id: number;
+  readonly kind: PricingSettingsOperationKind;
+}
+
+/**
+ * Serializes Pricing Settings reads and writes and invalidates completions from
+ * a replaced semantic port. React state mirrors this gate for presentation;
+ * the token remains the authority at every async completion boundary.
+ */
+export class PricingSettingsOperationGate {
+  #generation = 0;
+  #nextId = 0;
+  #active: PricingSettingsOperationToken | null = null;
+
+  get activeKind(): PricingSettingsOperationKind | null {
+    return this.#active?.kind ?? null;
+  }
+
+  begin(kind: PricingSettingsOperationKind): PricingSettingsOperationToken | null {
+    if (this.#active) return null;
+    const token = {
+      generation: this.#generation,
+      id: this.#nextId,
+      kind,
+    } satisfies PricingSettingsOperationToken;
+    this.#nextId += 1;
+    this.#active = token;
+    return token;
+  }
+
+  isCurrent(token: PricingSettingsOperationToken): boolean {
+    return this.#active?.generation === token.generation
+      && this.#active.id === token.id
+      && this.#active.kind === token.kind;
+  }
+
+  finish(token: PricingSettingsOperationToken): boolean {
+    if (!this.isCurrent(token)) return false;
+    this.#active = null;
+    return true;
+  }
+
+  replacePort(): void {
+    this.#generation += 1;
+    this.#active = null;
+  }
+}

--- a/apps/desktop/src/renderer/settings/pricing-settings-operation-gate.ts
+++ b/apps/desktop/src/renderer/settings/pricing-settings-operation-gate.ts
@@ -10,6 +10,8 @@ export interface PricingSettingsOperationToken {
  * Serializes Pricing Settings reads and writes and invalidates completions from
  * a replaced semantic port. React state mirrors this gate for presentation;
  * the token remains the authority at every async completion boundary.
+ * Unlike the shared action guards, the generation is part of correctness here:
+ * replacing the port must invalidate an already-running read or write.
  */
 export class PricingSettingsOperationGate {
   #generation = 0;

--- a/apps/desktop/src/renderer/settings/pricing-settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings/pricing-settings-panel.tsx
@@ -21,7 +21,7 @@ import {
   Layout,
   LayoutContent,
   LayoutFooter,
-  Spinner,
+  Skeleton,
   Table,
   Text,
   TextInput,
@@ -34,7 +34,7 @@ import {
 import type { PricingConfig } from '@maka/core/usage-stats/types';
 import type { EffectivePricingEntry, PricingMutation } from '@maka/runtime-host/protocol';
 import { useMountedRef, useUiLocale } from '@maka/ui';
-import { BarChart3, Plus, RefreshCcw } from '@maka/ui/icons';
+import { ICON_SIZE, BarChart3, Plus, RefreshCcw } from '@maka/ui/icons';
 import type {
   DesktopPricingSettingsPort,
   DesktopPricingSnapshot,
@@ -573,7 +573,7 @@ export function PricingSettingsPanel(props: { port: DesktopPricingSettingsPort }
               variant="ghost"
               size="sm"
               label={refreshing ? copy.refreshing : copy.refresh}
-              icon={<RefreshCcw size={15} aria-hidden="true" />}
+              icon={<RefreshCcw size={ICON_SIZE.control} aria-hidden="true" />}
               isLoading={refreshing}
               isDisabled={initialLoading || writePending}
               onClick={() => void loadSnapshot(true)}
@@ -583,7 +583,7 @@ export function PricingSettingsPanel(props: { port: DesktopPricingSettingsPort }
               variant="secondary"
               size="sm"
               label={copy.addPrice}
-              icon={<Plus size={15} aria-hidden="true" />}
+              icon={<Plus size={ICON_SIZE.control} aria-hidden="true" />}
               isDisabled={snapshot === null || refreshing || writePending}
               onClick={(event) => openEditor(undefined, event.currentTarget)}
             />
@@ -603,17 +603,13 @@ export function PricingSettingsPanel(props: { port: DesktopPricingSettingsPort }
             />
           ) : null}
           {initialLoading ? (
-            <div className="settingsPricingLoading" role="status" aria-live="polite">
-              <Spinner label={copy.loading} />
-            </div>
+            <PricingTableSkeleton label={copy.loading} />
           ) : snapshot === null ? null : data.length === 0 ? (
-            <Card padding={3}>
-              <EmptyState
-                icon={<BarChart3 />}
-                title={copy.emptyTitle}
-                description={copy.emptyBody}
-              />
-            </Card>
+            <EmptyState
+              icon={<BarChart3 size={ICON_SIZE.empty} />}
+              title={copy.emptyTitle}
+              description={copy.emptyBody}
+            />
           ) : (
             <Card className="settingsPricingTable" padding={3}>
               <Table
@@ -663,6 +659,37 @@ export function PricingSettingsPanel(props: { port: DesktopPricingSettingsPort }
         }}
       />
     </div>
+  );
+}
+
+function PricingTableSkeleton(props: { label: string }) {
+  return (
+    <Card className="settingsPricingTable" padding={3}>
+      {/* Loading (DESIGN.md §10): Pricing has a known table shape, so reserve
+          the header plus this surface's typical three ready rows. */}
+      <div
+        className="settingsPricingTableSkeleton"
+        role="status"
+        aria-busy="true"
+        aria-label={props.label}
+      >
+        {[0, 1, 2, 3].map((rowIndex) => (
+          <div
+            key={rowIndex}
+            className="settingsPricingTableSkeletonRow"
+            aria-hidden="true"
+          >
+            <Skeleton width="76%" height={rowIndex === 0 ? 10 : 12} radius="rounded" index={rowIndex} />
+            <Skeleton width="58%" height={rowIndex === 0 ? 10 : 12} radius="rounded" index={rowIndex + 1} />
+            <Skeleton width="64%" height={rowIndex === 0 ? 10 : 12} radius="rounded" index={rowIndex + 2} />
+            <Skeleton width="64%" height={rowIndex === 0 ? 10 : 12} radius="rounded" index={rowIndex + 3} />
+            <Skeleton width="72%" height={rowIndex === 0 ? 10 : 12} radius="rounded" index={rowIndex + 4} />
+            <Skeleton width="72%" height={rowIndex === 0 ? 10 : 12} radius="rounded" index={rowIndex + 5} />
+            <Skeleton width="68%" height={rowIndex === 0 ? 10 : 12} radius="rounded" index={rowIndex + 6} />
+          </div>
+        ))}
+      </div>
+    </Card>
   );
 }
 

--- a/apps/desktop/src/renderer/settings/pricing-settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings/pricing-settings-panel.tsx
@@ -350,6 +350,9 @@ export function PricingSettingsPanel(props: { port: DesktopPricingSettingsPort }
     if (operationGateRef.current.activeKind === 'write') return;
     if (recoveryRef.current?.target.kind === 'upsert') replaceRecovery(null);
     replaceEditor(null);
+    setNotice((current) => snapshotRef.current === null && current
+      ? { ...current, description: undefined }
+      : null);
     requestFocusRestore();
   }
 

--- a/apps/desktop/src/renderer/settings/pricing-settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings/pricing-settings-panel.tsx
@@ -371,7 +371,9 @@ export function PricingSettingsPanel(props: { port: DesktopPricingSettingsPort }
 
   function closeDelete() {
     if (operationGateRef.current.activeKind === 'write') return;
+    const current = deleteSessionRef.current;
     replaceDeleteSession(null);
+    if (current?.review) setNotice(null);
     requestFocusRestore();
   }
 
@@ -763,7 +765,7 @@ function PricingEditorDialog(props: {
                   label={props.copy.editor.modelKey}
                   description={props.copy.editor.modelKeyDescription}
                   isRequired
-                  hasAutoFocus
+                  hasAutoFocus={props.session.draft.mode === 'add'}
                   value={props.session.draft.modelKey}
                   isDisabled={interactionDisabled || props.session.draft.mode === 'edit'}
                   status={fieldStatus('modelKey')}
@@ -774,6 +776,7 @@ function PricingEditorDialog(props: {
                     label={props.copy.editor.inputRate}
                     description={props.copy.editor.rateDescription}
                     isRequired
+                    hasAutoFocus={props.session.draft.mode === 'edit'}
                     value={props.session.draft.inputUsdPer1M}
                     isDisabled={interactionDisabled}
                     status={fieldStatus('inputUsdPer1M')}

--- a/apps/desktop/src/renderer/settings/pricing-settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings/pricing-settings-panel.tsx
@@ -1,0 +1,992 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from 'react';
+import {
+  AlertDialog,
+  Badge,
+  Banner,
+  Button,
+  Card,
+  Dialog,
+  DialogHeader,
+  EmptyState,
+  FormLayout,
+  HStack,
+  Layout,
+  LayoutContent,
+  LayoutFooter,
+  Spinner,
+  Table,
+  Text,
+  TextInput,
+  type BannerStatus,
+  type TableColumn,
+  type TablePlugin,
+  pixel,
+  proportional,
+} from '@astryxdesign/core';
+import type { PricingConfig } from '@maka/core/usage-stats/types';
+import type { EffectivePricingEntry, PricingMutation } from '@maka/runtime-host/protocol';
+import { useMountedRef, useUiLocale } from '@maka/ui';
+import { BarChart3, Plus, RefreshCcw } from '@maka/ui/icons';
+import type {
+  DesktopPricingSettingsPort,
+  DesktopPricingSnapshot,
+} from '../../shared/runtime-host-pricing';
+import {
+  getPricingSettingsCopy,
+  type PricingSettingsCopy,
+} from '../locales/settings-pricing-copy';
+import { settingsActionErrorMessage } from './settings-error-copy';
+import {
+  createPricingDeleteTarget,
+  createPricingDraft,
+  decidePricingRecovery,
+  findCurrentPricingDeleteTarget,
+  formatPricingRate,
+  preparePricingDraftForAuthorityReview,
+  pricingSnapshotIdentityChanged,
+  pricingTargetMatchesSnapshot,
+  validatePricingDraft,
+  type PricingDraft,
+  type PricingDraftField,
+  type PricingMutationTarget,
+  type PricingRecoveryCause,
+  type PricingRecoveryDecision,
+  type PricingReviewReason,
+} from './pricing-settings-model';
+import { PricingSettingsOperationGate } from './pricing-settings-operation-gate';
+import { SettingsSection } from './settings-section';
+
+interface EditorSession {
+  readonly draft: PricingDraft;
+  readonly touched: Readonly<Partial<Record<PricingDraftField, true>>>;
+  readonly review?: PricingReviewReason;
+}
+
+interface DeleteSession {
+  readonly modelKey: string;
+  readonly action: 'reset' | 'delete';
+  readonly target: Extract<PricingMutationTarget, { kind: 'delete' }>;
+  readonly open: boolean;
+  readonly review?: PricingReviewReason;
+}
+
+interface RecoveryState {
+  readonly cause: PricingRecoveryCause;
+  readonly target: PricingMutationTarget;
+}
+
+interface PricingNotice {
+  readonly status: BannerStatus;
+  readonly title: string;
+  readonly description?: string;
+}
+
+type PricingTableRow = Record<string, unknown> & {
+  readonly modelKey: string;
+  readonly entry: EffectivePricingEntry;
+};
+
+const pricingTablePlugins = {
+  rowHeader: {
+    transformBodyCell: (cell, _column, _row, columnIndex) => columnIndex === 0
+      ? { ...cell, htmlProps: { ...cell.htmlProps, role: 'rowheader' } }
+      : cell,
+  },
+} satisfies Record<string, TablePlugin<PricingTableRow>>;
+
+export function PricingSettingsPanel(props: { port: DesktopPricingSettingsPort }) {
+  const locale = useUiLocale();
+  const copy = getPricingSettingsCopy(locale);
+  const mountedRef = useMountedRef();
+  const copyRef = useRef(copy);
+  const localeRef = useRef(locale);
+  copyRef.current = copy;
+  localeRef.current = locale;
+
+  const [snapshot, setSnapshot] = useState<DesktopPricingSnapshot | null>(null);
+  const snapshotRef = useRef<DesktopPricingSnapshot | null>(null);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [writePending, setWritePending] = useState(false);
+  const [notice, setNotice] = useState<PricingNotice | null>(null);
+  const operationGateRef = useRef(new PricingSettingsOperationGate());
+  const portRef = useRef(props.port);
+  const appliedPortRef = useRef<DesktopPricingSettingsPort | null>(null);
+  const authorityReviewPendingRef = useRef(false);
+  portRef.current = props.port;
+
+  const [editor, setEditor] = useState<EditorSession | null>(null);
+  const editorRef = useRef<EditorSession | null>(null);
+  const [deleteSession, setDeleteSession] = useState<DeleteSession | null>(null);
+  const deleteSessionRef = useRef<DeleteSession | null>(null);
+  const recoveryRef = useRef<RecoveryState | null>(null);
+
+  const addButtonRef = useRef<HTMLButtonElement>(null);
+  const refreshButtonRef = useRef<HTMLButtonElement>(null);
+  const returnFocusRef = useRef<HTMLButtonElement | null>(null);
+  const shouldRestoreFocusRef = useRef(false);
+
+  function replaceSnapshot(next: DesktopPricingSnapshot | null) {
+    snapshotRef.current = next;
+    setSnapshot(next);
+  }
+
+  function replaceEditor(next: EditorSession | null) {
+    editorRef.current = next;
+    setEditor(next);
+  }
+
+  function updateEditor(update: (current: EditorSession) => EditorSession) {
+    const current = editorRef.current;
+    if (!current) return;
+    replaceEditor(update(current));
+  }
+
+  function replaceDeleteSession(next: DeleteSession | null) {
+    deleteSessionRef.current = next;
+    setDeleteSession(next);
+  }
+
+  function replaceRecovery(next: RecoveryState | null) {
+    recoveryRef.current = next;
+  }
+
+  function requestFocusRestore() {
+    shouldRestoreFocusRef.current = true;
+  }
+
+  useEffect(() => {
+    if (!shouldRestoreFocusRef.current || editor !== null || deleteSession?.open) return;
+    shouldRestoreFocusRef.current = false;
+    const requested = returnFocusRef.current;
+    const fallback = addButtonRef.current && !addButtonRef.current.disabled
+      ? addButtonRef.current
+      : refreshButtonRef.current;
+    (requested?.isConnected ? requested : fallback)?.focus();
+    returnFocusRef.current = null;
+  }, [editor, deleteSession]);
+
+  function reviewEditor(
+    reason: PricingReviewReason,
+    latest: DesktopPricingSnapshot,
+  ): boolean {
+    if (!editorRef.current) return false;
+    updateEditor((current) => ({
+      ...current,
+      draft: preparePricingDraftForAuthorityReview(current.draft, latest.entries),
+      review: reason,
+    }));
+    return true;
+  }
+
+  function reviewIntent(
+    target: PricingMutationTarget,
+    reason: PricingReviewReason,
+    latest: DesktopPricingSnapshot,
+  ): 'review' | 'no_override' | 'missing_intent' {
+    if (target.kind === 'upsert') {
+      return reviewEditor(reason, latest)
+        ? 'review'
+        : 'missing_intent';
+    }
+    const current = deleteSessionRef.current;
+    if (!current) return 'missing_intent';
+    const nextTarget = findCurrentPricingDeleteTarget(target.modelKey, latest.entries);
+    if (!nextTarget) {
+      replaceDeleteSession(null);
+      requestFocusRestore();
+      return 'no_override';
+    }
+    replaceDeleteSession({
+      ...current,
+      action: nextTarget.expected === 'builtin' ? 'reset' : 'delete',
+      target: nextTarget,
+      open: false,
+      review: reason,
+    });
+    return 'review';
+  }
+
+  function clearIntent(target: PricingMutationTarget) {
+    if (target.kind === 'upsert') replaceEditor(null);
+    else replaceDeleteSession(null);
+    requestFocusRestore();
+  }
+
+  const loadSnapshot = useCallback(async (
+    announce: boolean,
+    requestedPort: DesktopPricingSettingsPort = portRef.current,
+  ) => {
+    const gate = operationGateRef.current;
+    const operation = gate.begin('read');
+    if (!operation) return;
+    const previous = snapshotRef.current;
+    if (previous === null) setInitialLoading(true);
+    setRefreshing(true);
+    try {
+      const latest = await requestedPort.loadPricingSnapshot();
+      if (!mountedRef.current || !gate.isCurrent(operation)) return;
+      replaceSnapshot(latest);
+      const pendingRecovery = recoveryRef.current;
+      if (pendingRecovery) {
+        replaceRecovery(null);
+        const decision = decidePricingRecovery(
+          pendingRecovery.cause,
+          pricingTargetMatchesSnapshot(pendingRecovery.target, latest),
+        );
+        if (decision.kind === 'complete') {
+          clearIntent(pendingRecovery.target);
+          setNotice({
+            status: decision.notice === 'saved' ? 'success' : 'info',
+            title: recoveryNoticeTitle(decision.notice, copyRef.current),
+          });
+        } else {
+          const reviewed = reviewIntent(pendingRecovery.target, decision.reason, latest);
+          setNotice(reviewed === 'no_override'
+            ? { status: 'info', title: copyRef.current.notice.deleteNoLongerApplies }
+            : { status: 'warning', title: recoveryNoticeTitle(decision.notice, copyRef.current) });
+        }
+      } else if (authorityReviewPendingRef.current) {
+        authorityReviewPendingRef.current = false;
+        const currentEditor = editorRef.current;
+        if (currentEditor) {
+          reviewEditor('authority_changed', latest);
+        }
+        const currentDelete = deleteSessionRef.current;
+        const deleteReview = currentDelete
+          ? reviewIntent(currentDelete.target, 'authority_changed', latest)
+          : 'missing_intent';
+        setNotice(deleteReview === 'no_override' && !currentEditor
+          ? { status: 'info', title: copyRef.current.notice.deleteNoLongerApplies }
+          : currentEditor || deleteReview === 'review'
+            ? { status: 'warning', title: copyRef.current.notice.refreshedForReview }
+            : null);
+      } else if (
+        previous
+        && pricingSnapshotIdentityChanged(previous, latest)
+        && (editorRef.current || deleteSessionRef.current)
+      ) {
+        const currentEditor = editorRef.current;
+        if (currentEditor) {
+          reviewEditor('authority_changed', latest);
+        }
+        const currentDelete = deleteSessionRef.current;
+        const deleteReview = currentDelete
+          ? reviewIntent(currentDelete.target, 'authority_changed', latest)
+          : 'missing_intent';
+        setNotice(deleteReview === 'no_override' && !currentEditor
+          ? { status: 'info', title: copyRef.current.notice.deleteNoLongerApplies }
+          : { status: 'warning', title: copyRef.current.notice.refreshedForReview });
+      } else if (announce) {
+        setNotice({ status: 'success', title: copyRef.current.notice.refreshed });
+      } else {
+        setNotice(null);
+      }
+    } catch (error) {
+      if (!mountedRef.current || !gate.isCurrent(operation)) return;
+      const detail = settingsActionErrorMessage(error, localeRef.current);
+      setNotice({
+        status: 'error',
+        title: copyRef.current.notice.loadFailed,
+        description: copyRef.current.notice.loadFailedDescription(detail),
+      });
+    } finally {
+      if (gate.finish(operation) && mountedRef.current) {
+        setInitialLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, [mountedRef]);
+
+  useLayoutEffect(() => {
+    const replacement = appliedPortRef.current !== null
+      && appliedPortRef.current !== props.port;
+    appliedPortRef.current = props.port;
+    operationGateRef.current.replacePort();
+    setRefreshing(false);
+    setWritePending(false);
+    replaceSnapshot(null);
+    replaceRecovery(null);
+    if (replacement) {
+      const currentEditor = editorRef.current;
+      const currentDelete = deleteSessionRef.current;
+      if (currentEditor) {
+        replaceEditor({ ...currentEditor, review: 'authority_changed' });
+      }
+      if (currentDelete) {
+        replaceDeleteSession({ ...currentDelete, open: false, review: 'authority_changed' });
+      }
+      authorityReviewPendingRef.current = Boolean(currentEditor || currentDelete);
+      setNotice(currentEditor || currentDelete
+        ? {
+            status: 'warning',
+            title: copyRef.current.notice.staleSnapshot,
+            description: copyRef.current.notice.staleSnapshotDescription,
+          }
+        : null);
+    } else {
+      authorityReviewPendingRef.current = false;
+      setNotice(null);
+    }
+    setInitialLoading(true);
+    void loadSnapshot(false, props.port);
+  }, [loadSnapshot, props.port]);
+
+  function openEditor(entry: EffectivePricingEntry | undefined, trigger: HTMLButtonElement) {
+    if (!snapshotRef.current || operationGateRef.current.activeKind !== null) return;
+    returnFocusRef.current = trigger;
+    replaceEditor({ draft: createPricingDraft(entry), touched: {} });
+  }
+
+  function closeEditor() {
+    if (operationGateRef.current.activeKind === 'write') return;
+    if (recoveryRef.current?.target.kind === 'upsert') replaceRecovery(null);
+    replaceEditor(null);
+    requestFocusRestore();
+  }
+
+  function openDelete(entry: EffectivePricingEntry, trigger: HTMLButtonElement) {
+    if (
+      entry.source !== 'custom'
+      || !snapshotRef.current
+      || operationGateRef.current.activeKind !== null
+    ) return;
+    const target = createPricingDeleteTarget(entry);
+    returnFocusRef.current = trigger;
+    replaceDeleteSession({
+      modelKey: entry.pricing.modelKey,
+      action: target.expected === 'builtin' ? 'reset' : 'delete',
+      target,
+      open: true,
+    });
+  }
+
+  function closeDelete() {
+    if (operationGateRef.current.activeKind === 'write') return;
+    replaceDeleteSession(null);
+    requestFocusRestore();
+  }
+
+  async function applyMutation(target: PricingMutationTarget, mutation: PricingMutation) {
+    const base = snapshotRef.current;
+    if (!base) return;
+    const gate = operationGateRef.current;
+    const operation = gate.begin('write');
+    if (!operation) return;
+    const requestedPort = portRef.current;
+    setWritePending(true);
+    setNotice(null);
+    try {
+      const outcome = await requestedPort.applyPricingMutation({ base, mutation });
+      if (!mountedRef.current || !gate.isCurrent(operation)) return;
+      switch (outcome.kind) {
+        case 'saved':
+          replaceSnapshot(outcome.snapshot);
+          clearIntent(target);
+          setNotice({
+            status: 'success',
+            title: outcome.disposition === 'committed'
+              ? copyRef.current.notice.saved
+              : copyRef.current.notice.unchanged,
+          });
+          break;
+        case 'saved_refresh_failed':
+          replaceSnapshot(null);
+          replaceRecovery({ cause: 'known_saved', target });
+          if (target.kind === 'delete' && deleteSessionRef.current) {
+            replaceDeleteSession({ ...deleteSessionRef.current, open: false });
+          }
+          setNotice({
+            status: 'warning',
+            title: copyRef.current.notice.savedRefreshFailed,
+            description: copyRef.current.notice.savedRefreshFailedDescription,
+          });
+          break;
+        case 'synchronized':
+          replaceSnapshot(outcome.snapshot);
+          clearIntent(target);
+          setNotice({
+            status: 'info',
+            title: outcome.reason === 'revision_conflict'
+              ? copyRef.current.notice.synchronizedConflict
+              : copyRef.current.notice.synchronizedUnknown,
+          });
+          break;
+        case 'review_required':
+          replaceSnapshot(outcome.snapshot);
+          setNotice(reviewIntent(target, outcome.reason, outcome.snapshot) === 'no_override'
+            ? { status: 'info', title: copyRef.current.notice.deleteNoLongerApplies }
+            : {
+                status: 'warning',
+                title: outcome.reason === 'revision_conflict'
+                  ? copyRef.current.notice.reviewConflict
+                  : copyRef.current.notice.reviewUnknown,
+              });
+          break;
+        case 'reconciliation_unavailable':
+          replaceSnapshot(null);
+          replaceRecovery({ cause: outcome.reason, target });
+          if (target.kind === 'delete' && deleteSessionRef.current) {
+            replaceDeleteSession({ ...deleteSessionRef.current, open: false });
+          }
+          setNotice({
+            status: 'warning',
+            title: copyRef.current.notice.reconciliationUnavailable,
+            description: copyRef.current.notice.reconciliationUnavailableDescription,
+          });
+          break;
+      }
+    } catch (error) {
+      if (!mountedRef.current || !gate.isCurrent(operation)) return;
+      if (runtimeHostErrorCode(error) === 'pricing_snapshot_stale') {
+        replaceSnapshot(null);
+        replaceRecovery({ cause: 'stale', target });
+        if (target.kind === 'delete' && deleteSessionRef.current) {
+          replaceDeleteSession({ ...deleteSessionRef.current, open: false });
+        }
+        setNotice({
+          status: 'warning',
+          title: copyRef.current.notice.staleSnapshot,
+          description: copyRef.current.notice.staleSnapshotDescription,
+        });
+      } else {
+        if (target.kind === 'delete' && deleteSessionRef.current) {
+          replaceDeleteSession({ ...deleteSessionRef.current, open: false });
+        }
+        setNotice({
+          status: 'error',
+          title: copyRef.current.notice.mutationFailed,
+          description: copyRef.current.notice.mutationFailedDescription(
+            settingsActionErrorMessage(error, localeRef.current),
+          ),
+        });
+      }
+    } finally {
+      if (gate.finish(operation) && mountedRef.current) setWritePending(false);
+    }
+  }
+
+  const entries = snapshot?.entries ?? [];
+  const data: PricingTableRow[] = entries.map((entry) => ({
+    modelKey: entry.pricing.modelKey,
+    entry,
+  }));
+  const columns: Array<TableColumn<PricingTableRow>> = [
+    {
+      key: 'modelKey',
+      header: copy.headers[0],
+      width: proportional(2, { minWidth: 180 }),
+      renderCell: (row) => <code className="settingsPricingModelKey">{row.modelKey}</code>,
+    },
+    {
+      key: 'source',
+      header: copy.headers[1],
+      width: pixel(150),
+      renderCell: (row) => <PricingSourceBadge entry={row.entry} copy={copy} />,
+    },
+    ...(['inputUsdPer1M', 'outputUsdPer1M', 'cacheReadUsdPer1M', 'cacheWriteUsdPer1M'] as const)
+      .map((field, index): TableColumn<PricingTableRow> => ({
+        key: field,
+        header: copy.headers[index + 2],
+        align: 'end',
+        width: pixel(field.startsWith('cache') ? 112 : 72),
+        renderCell: (row) => (
+          <span className="settingsPricingRate">
+            {rateCell(row.entry.pricing[field], copy)}
+          </span>
+        ),
+      })),
+    {
+      key: 'actions',
+      header: copy.headers[6],
+      width: pixel(132),
+      resizable: false,
+      renderCell: (row) => (
+        <HStack gap={1} wrap="wrap">
+          <Button
+            variant="ghost"
+            size="sm"
+            label={row.entry.source === 'builtin' ? copy.customize : copy.edit}
+            isDisabled={refreshing || writePending || snapshot === null}
+            onClick={(event) => openEditor(row.entry, event.currentTarget)}
+          />
+          {row.entry.source === 'custom' ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              label={row.entry.resetEffect === 'restore_builtin' ? copy.reset : copy.delete}
+              isDisabled={refreshing || writePending || snapshot === null}
+              onClick={(event) => openDelete(row.entry, event.currentTarget)}
+            />
+          ) : null}
+        </HStack>
+      ),
+    },
+  ];
+
+  const recoveryAction = snapshot === null && !initialLoading
+    ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          label={refreshing ? copy.refreshing : copy.refresh}
+          isLoading={refreshing}
+          onClick={() => void loadSnapshot(true)}
+        />
+      )
+    : deleteSession && !deleteSession.open && snapshot !== null
+      ? (
+          <Button
+          variant="ghost"
+          size="sm"
+          label={copy.notice.reviewDelete}
+          isDisabled={refreshing || writePending}
+          onClick={() => replaceDeleteSession({ ...deleteSession, open: true })}
+          />
+        )
+      : undefined;
+
+  return (
+    <div className="settingsPricingPanel">
+      <SettingsSection
+        title={copy.heading}
+        titleId="settings-pricing-heading"
+        description={copy.description}
+        variant="bare"
+        action={(
+          <HStack gap={1.5}>
+            <Button
+              ref={refreshButtonRef}
+              variant="ghost"
+              size="sm"
+              label={refreshing ? copy.refreshing : copy.refresh}
+              icon={<RefreshCcw size={15} aria-hidden="true" />}
+              isLoading={refreshing}
+              isDisabled={initialLoading || writePending}
+              onClick={() => void loadSnapshot(true)}
+            />
+            <Button
+              ref={addButtonRef}
+              variant="secondary"
+              size="sm"
+              label={copy.addPrice}
+              icon={<Plus size={15} aria-hidden="true" />}
+              isDisabled={snapshot === null || refreshing || writePending}
+              onClick={(event) => openEditor(undefined, event.currentTarget)}
+            />
+          </HStack>
+        )}
+      >
+        <div className="settingsPricingContent">
+          <Text as="p" type="supporting" size="sm" color="secondary">
+            {copy.disclaimer}
+          </Text>
+          {notice ? (
+            <Banner
+              status={notice.status}
+              title={notice.title}
+              description={notice.description}
+              endContent={recoveryAction}
+            />
+          ) : null}
+          {initialLoading ? (
+            <div className="settingsPricingLoading" role="status" aria-live="polite">
+              <Spinner label={copy.loading} />
+            </div>
+          ) : snapshot === null ? null : data.length === 0 ? (
+            <Card padding={3}>
+              <EmptyState
+                icon={<BarChart3 />}
+                title={copy.emptyTitle}
+                description={copy.emptyBody}
+              />
+            </Card>
+          ) : (
+            <Card className="settingsPricingTable" padding={3}>
+              <Table
+                aria-label={copy.tableAria}
+                data={data}
+                columns={columns}
+                idKey="modelKey"
+                density="compact"
+                dividers="rows"
+                textOverflow="wrap"
+                plugins={pricingTablePlugins}
+              />
+            </Card>
+          )}
+        </div>
+      </SettingsSection>
+
+      <PricingEditorDialog
+        session={editor}
+        snapshot={snapshot}
+        pending={writePending}
+        refreshing={refreshing}
+        notice={notice}
+        copy={copy}
+        onClose={closeEditor}
+        onRefresh={() => void loadSnapshot(true)}
+        onChange={(field, value) => updateEditor((current) => ({
+          ...current,
+          draft: { ...current.draft, [field]: value },
+          touched: { ...current.touched, [field]: true },
+        }))}
+        onSave={(pricing) => void applyMutation(
+          { kind: 'upsert', pricing },
+          { kind: 'upsert', pricing },
+        )}
+      />
+
+      <PricingDeleteDialog
+        session={deleteSession}
+        pending={writePending}
+        copy={copy}
+        onClose={closeDelete}
+        onConfirm={() => {
+          const current = deleteSessionRef.current;
+          if (!current) return;
+          void applyMutation(current.target, { kind: 'delete', modelKey: current.modelKey });
+        }}
+      />
+    </div>
+  );
+}
+
+function PricingEditorDialog(props: {
+  session: EditorSession | null;
+  snapshot: DesktopPricingSnapshot | null;
+  pending: boolean;
+  refreshing: boolean;
+  notice: PricingNotice | null;
+  copy: PricingSettingsCopy;
+  onClose(): void;
+  onRefresh(): void;
+  onChange(field: PricingDraftField, value: string): void;
+  onSave(pricing: PricingConfig): void;
+}) {
+  const validation = props.session
+    ? validatePricingDraft(props.session.draft, props.snapshot?.entries ?? [])
+    : null;
+  const interactionDisabled = props.pending || props.refreshing || props.snapshot === null;
+  const formId = 'maka-pricing-settings-form';
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (interactionDisabled || !validation?.ok) return;
+    props.onSave(validation.pricing);
+  }
+
+  function fieldStatus(field: PricingDraftField) {
+    if (!props.session?.touched[field]) return undefined;
+    const error = validation?.errors[field];
+    return error
+      ? { type: 'error' as const, message: props.copy.validation(field, error) }
+      : undefined;
+  }
+
+  const latestEntry = props.session && props.snapshot
+    ? props.snapshot.entries.find(
+        (entry) => entry.pricing.modelKey === props.session?.draft.modelKey.trim(),
+      )
+    : undefined;
+  const dialogNotice = props.notice?.status === 'error'
+    ? props.notice
+    : props.snapshot === null
+      ? props.notice
+      : props.session?.review
+        ? reviewNotice(props.session.review, props.copy)
+        : null;
+
+  return (
+    <Dialog
+      isOpen={props.session !== null}
+      onOpenChange={(open) => {
+        if (!open) props.onClose();
+      }}
+      purpose="form"
+      width={600}
+      maxHeight="calc(100dvh - 32px)"
+    >
+      <Layout
+        height="auto"
+        header={props.session ? (
+          <DialogHeader
+            title={props.session.draft.mode === 'add'
+              ? props.copy.editor.addTitle
+              : props.copy.editor.editTitle}
+            onOpenChange={props.pending ? undefined : (open) => {
+              if (!open) props.onClose();
+            }}
+          />
+        ) : undefined}
+        content={props.session ? (
+          <LayoutContent>
+            <form id={formId} onSubmit={submit} aria-busy={props.pending ? 'true' : undefined}>
+              <FormLayout>
+                {dialogNotice ? (
+                  <Banner
+                    status={dialogNotice.status}
+                    title={dialogNotice.title}
+                    description={(
+                      <>
+                        {dialogNotice.description}
+                        {props.session.review ? (
+                          <PricingReviewComparison
+                            draft={props.session.draft}
+                            latest={latestEntry}
+                            copy={props.copy}
+                          />
+                        ) : null}
+                      </>
+                    )}
+                    endContent={props.snapshot === null ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        label={props.refreshing ? props.copy.refreshing : props.copy.refresh}
+                        isLoading={props.refreshing}
+                        onClick={props.onRefresh}
+                      />
+                    ) : undefined}
+                  />
+                ) : null}
+                <TextInput
+                  label={props.copy.editor.modelKey}
+                  description={props.copy.editor.modelKeyDescription}
+                  isRequired
+                  hasAutoFocus
+                  value={props.session.draft.modelKey}
+                  isDisabled={interactionDisabled || props.session.draft.mode === 'edit'}
+                  status={fieldStatus('modelKey')}
+                  onChange={(value) => props.onChange('modelKey', value)}
+                />
+                <FormLayout direction="horizontal">
+                  <TextInput
+                    label={props.copy.editor.inputRate}
+                    description={props.copy.editor.rateDescription}
+                    isRequired
+                    value={props.session.draft.inputUsdPer1M}
+                    isDisabled={interactionDisabled}
+                    status={fieldStatus('inputUsdPer1M')}
+                    onChange={(value) => props.onChange('inputUsdPer1M', value)}
+                  />
+                  <TextInput
+                    label={props.copy.editor.outputRate}
+                    description={props.copy.editor.rateDescription}
+                    isRequired
+                    value={props.session.draft.outputUsdPer1M}
+                    isDisabled={interactionDisabled}
+                    status={fieldStatus('outputUsdPer1M')}
+                    onChange={(value) => props.onChange('outputUsdPer1M', value)}
+                  />
+                </FormLayout>
+                <FormLayout direction="horizontal">
+                  <TextInput
+                    label={props.copy.editor.cacheReadRate}
+                    description={props.copy.editor.cacheDescription}
+                    isOptional
+                    value={props.session.draft.cacheReadUsdPer1M}
+                    isDisabled={interactionDisabled}
+                    status={fieldStatus('cacheReadUsdPer1M')}
+                    onChange={(value) => props.onChange('cacheReadUsdPer1M', value)}
+                  />
+                  <TextInput
+                    label={props.copy.editor.cacheWriteRate}
+                    description={props.copy.editor.cacheDescription}
+                    isOptional
+                    value={props.session.draft.cacheWriteUsdPer1M}
+                    isDisabled={interactionDisabled}
+                    status={fieldStatus('cacheWriteUsdPer1M')}
+                    onChange={(value) => props.onChange('cacheWriteUsdPer1M', value)}
+                  />
+                </FormLayout>
+                {props.pending ? (
+                  <Text as="p" type="supporting" size="sm" role="status" aria-live="polite">
+                    {props.copy.notice.pending}
+                  </Text>
+                ) : null}
+              </FormLayout>
+            </form>
+          </LayoutContent>
+        ) : undefined}
+        footer={props.session ? (
+          <LayoutFooter>
+            <HStack gap={2} hAlign="end">
+              <Button
+                variant="ghost"
+                label={props.copy.editor.cancel}
+                isDisabled={props.pending}
+                onClick={props.onClose}
+              />
+              <Button
+                type="submit"
+                form={formId}
+                variant="primary"
+                label={props.session.review ? props.copy.editor.saveAgain : props.copy.editor.save}
+                isLoading={props.pending}
+                isDisabled={interactionDisabled || validation?.ok !== true}
+              />
+            </HStack>
+          </LayoutFooter>
+        ) : undefined}
+      />
+    </Dialog>
+  );
+}
+
+function PricingDeleteDialog(props: {
+  session: DeleteSession | null;
+  pending: boolean;
+  copy: PricingSettingsCopy;
+  onClose(): void;
+  onConfirm(): void;
+}) {
+  const session = props.session;
+  const consequence = session?.action === 'reset'
+    ? props.copy.confirm.resetDescription(session.modelKey)
+    : session
+      ? props.copy.confirm.deleteDescription(session.modelKey)
+      : '';
+  const description = session?.review
+    ? `${props.copy.confirm.reviewDescription(session.modelKey, session.action)} ${consequence}`
+    : consequence;
+  return (
+    <AlertDialog
+      isOpen={session?.open === true}
+      onOpenChange={(open) => {
+        if (!open) props.onClose();
+      }}
+      title={session?.action === 'reset'
+        ? props.copy.confirm.resetTitle
+        : props.copy.confirm.deleteTitle}
+      description={description}
+      cancelLabel={props.copy.confirm.cancel}
+      actionLabel={session?.review
+        ? props.copy.confirm.confirmAgain
+        : session?.action === 'reset'
+          ? props.copy.reset
+          : props.copy.delete}
+      actionVariant="destructive"
+      isActionLoading={props.pending}
+      onAction={props.onConfirm}
+    />
+  );
+}
+
+function PricingSourceBadge(props: {
+  entry: EffectivePricingEntry;
+  copy: PricingSettingsCopy;
+}) {
+  return (
+    <Badge
+      variant={props.entry.source === 'builtin'
+        ? 'neutral'
+        : props.entry.resetEffect === 'restore_builtin'
+          ? 'info'
+          : 'warning'}
+      label={pricingSourceLabel(props.entry, props.copy)}
+    />
+  );
+}
+
+function PricingReviewComparison(props: {
+  draft: PricingDraft;
+  latest: EffectivePricingEntry | undefined;
+  copy: PricingSettingsCopy;
+}) {
+  return (
+    <div className="settingsPricingReviewComparison">
+      <div>
+        <strong>{props.copy.editor.draftValues}</strong>
+        <span>
+          {props.copy.headers[1]} {intendedCustomSourceLabel(props.latest, props.copy)} ·{' '}
+          {draftSummary(props.draft, props.copy)}
+        </span>
+      </div>
+      <div>
+        <strong>{props.copy.editor.latestValues}</strong>
+        <span>{props.latest
+          ? `${props.copy.headers[1]} ${pricingSourceLabel(props.latest, props.copy)} · ${pricingSummary(props.latest.pricing, props.copy)}`
+          : props.copy.editor.latestMissing}</span>
+      </div>
+    </div>
+  );
+}
+
+function reviewNotice(reason: PricingReviewReason, copy: PricingSettingsCopy): PricingNotice {
+  if (reason === 'revision_conflict') {
+    return { status: 'warning', title: copy.notice.reviewConflict };
+  }
+  if (reason === 'outcome_unknown') {
+    return { status: 'warning', title: copy.notice.reviewUnknown };
+  }
+  return { status: 'warning', title: copy.notice.refreshedForReview };
+}
+
+function pricingSourceLabel(
+  entry: EffectivePricingEntry,
+  copy: PricingSettingsCopy,
+): string {
+  if (entry.source === 'builtin') return copy.sourceBuiltin;
+  return entry.resetEffect === 'restore_builtin'
+    ? copy.sourceCustomWithFallback
+    : copy.sourceCustomOnly;
+}
+
+function intendedCustomSourceLabel(
+  latest: EffectivePricingEntry | undefined,
+  copy: PricingSettingsCopy,
+): string {
+  if (!latest) return copy.sourceCustomOnly;
+  return latest.source === 'builtin' || latest.resetEffect === 'restore_builtin'
+    ? copy.sourceCustomWithFallback
+    : copy.sourceCustomOnly;
+}
+
+function rateCell(rate: number | undefined, copy: PricingSettingsCopy): ReactNode {
+  return rate === undefined ? copy.notSet : formatPricingRate(rate);
+}
+
+function pricingSummary(pricing: Readonly<PricingConfig>, copy: PricingSettingsCopy): string {
+  return [
+    `${copy.headers[2]} ${formatPricingRate(pricing.inputUsdPer1M)}`,
+    `${copy.headers[3]} ${formatPricingRate(pricing.outputUsdPer1M)}`,
+    `${copy.headers[4]} ${rateCell(pricing.cacheReadUsdPer1M, copy)}`,
+    `${copy.headers[5]} ${rateCell(pricing.cacheWriteUsdPer1M, copy)}`,
+  ].join(' · ');
+}
+
+function draftSummary(draft: PricingDraft, copy: PricingSettingsCopy): string {
+  return [
+    `${copy.headers[2]} ${draft.inputUsdPer1M}`,
+    `${copy.headers[3]} ${draft.outputUsdPer1M}`,
+    `${copy.headers[4]} ${draft.cacheReadUsdPer1M || copy.notSet}`,
+    `${copy.headers[5]} ${draft.cacheWriteUsdPer1M || copy.notSet}`,
+  ].join(' · ');
+}
+
+function recoveryNoticeTitle(
+  notice: PricingRecoveryDecision['notice'],
+  copy: PricingSettingsCopy,
+): string {
+  if (notice === 'saved') return copy.notice.saved;
+  if (notice === 'synchronized_conflict') return copy.notice.synchronizedConflict;
+  if (notice === 'synchronized_unknown') return copy.notice.synchronizedUnknown;
+  if (notice === 'review_conflict') return copy.notice.reviewConflict;
+  if (notice === 'review_unknown') return copy.notice.reviewUnknown;
+  return copy.notice.refreshedForReview;
+}
+
+function runtimeHostErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return undefined;
+  return typeof error.code === 'string' ? error.code : undefined;
+}

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -52,6 +52,7 @@ import { UsageSettingsPage } from './usage-settings-page';
 import { WebSearchSettingsPage } from './web-search-settings-page';
 import type { UiLocaleUpdateGate } from './ui-locale-update-gate';
 import { getSettingsSharedCopy } from '../locales/settings-shared-copy.js';
+import type { DesktopPricingSettingsPort } from '../../shared/runtime-host-pricing';
 
 const NARROW_SETTINGS_QUERY = '(max-width: 760px)';
 
@@ -76,6 +77,8 @@ export function SettingsSurface(props: {
   onOpenDailyReview?(): void;
   onOpenKeyboardHelp?(): void;
   onOpenSession?(sessionId: string): void;
+  /** Isolated M4 seam. Production leaves this unset until the M5 cutover. */
+  pricingPort?: DesktopPricingSettingsPort;
 }) {
   const locale = useUiLocale();
   const copy = getSettingsSharedCopy(locale);
@@ -352,6 +355,7 @@ export function SettingsSurface(props: {
                       section={section}
                       settings={settings}
                       usageStats={usageStats}
+                      pricingPort={props.pricingPort}
                       connections={props.connections}
                       defaultSlug={props.defaultSlug}
                       themePref={props.themePref}
@@ -385,6 +389,7 @@ function SettingsPageBody(props: {
   section: SettingsSection;
   settings: AppSettings;
   usageStats: UsageStats | null;
+  pricingPort?: DesktopPricingSettingsPort;
   connections: LlmConnection[];
   defaultSlug: string | null;
   themePref: ThemePreference;
@@ -440,6 +445,7 @@ function SettingsPageBody(props: {
           onUpdate={props.onUpdateSettings}
           onReload={props.onReloadUsage}
           onOpenSession={props.onOpenSession}
+          pricingPort={props.pricingPort}
         />
       );
     case 'bot-chat':

--- a/apps/desktop/src/renderer/settings/usage-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/usage-settings-page.tsx
@@ -29,11 +29,13 @@ import {
   Banner,
 } from '@maka/ui';
 import { ICON_SIZE, Activity, BarChart3, Cpu, Database, RefreshCcw, Search } from '@maka/ui/icons';
+import type { DesktopPricingSettingsPort } from '../../shared/runtime-host-pricing';
 import {
   getUsageSettingsCopy,
   type UsageSettingsCopy,
 } from '../locales/settings-usage-copy';
 import { MetricCard } from './settings-metric-card';
+import { PricingSettingsPanel } from './pricing-settings-panel';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsPage } from './settings-section';
 import { useActionGuard } from './use-action-guard';
@@ -47,6 +49,7 @@ export function UsageSettingsPage(props: {
   onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
   onReload(range?: UsageRange): Promise<void>;
   onOpenSession?(sessionId: string): void;
+  pricingPort?: DesktopPricingSettingsPort;
 }) {
   const locale = useUiLocale();
   const copy = getUsageSettingsCopy(locale);
@@ -80,13 +83,13 @@ export function UsageSettingsPage(props: {
       );
   }, [stats, usageDraft.status, normalizedModelFilter]);
 
-  const tabCounts: Record<UsageActiveTab, number> = {
+  const tabCounts: Record<Exclude<UsageActiveTab, 'pricing'>, number> = {
     requests: stats?.logs.length ?? 0,
     providers: stats?.byProvider.length ?? 0,
     models: stats?.byModel.length ?? 0,
     tools: stats?.byTool.length ?? 0,
-    pricing: stats?.pricing.length ?? 0,
   };
+  const isolatedPricingActive = usageDraft.activeTab === 'pricing' && props.pricingPort !== undefined;
 
   async function setRange(range: UsageRange) {
     const saved = await updateUsage({ range });
@@ -117,7 +120,7 @@ export function UsageSettingsPage(props: {
 
   return (
     <SettingsPage className="settingsUsagePage">
-      <div className="settingsUsageOverview">
+      {!isolatedPricingActive ? <div className="settingsUsageOverview">
         <div className="settingsUsageToolbar" role="group" aria-label={copy.toolbarAria}>
           <SegmentedControl
             value={usageDraft.range}
@@ -154,7 +157,7 @@ export function UsageSettingsPage(props: {
           <MetricCard title={copy.totalTokens} value={String(stats?.summary.totalTokens ?? 0)} detail={copy.tokenDetail(stats?.summary.inputTokens ?? 0, stats?.summary.outputTokens ?? 0)} />
           <MetricCard title={copy.cacheTokens} value={String(stats?.summary.cacheTokens ?? 0)} detail={copy.cacheDetail(stats?.summary.cacheMiss ?? 0, stats?.summary.cacheRead ?? 0, stats?.summary.cacheCreation ?? 0)} />
         </div>
-      </div>
+      </div> : null}
 
       <div className="settingsUsageBreakdown">
         <div className="settingsUsageTabsBar">
@@ -168,7 +171,11 @@ export function UsageSettingsPage(props: {
             <Tab value="providers" label={copy.tabs[1]} endContent={<span>{tabCounts.providers}</span>} />
             <Tab value="models" label={copy.tabs[2]} endContent={<span>{tabCounts.models}</span>} />
             <Tab value="tools" label={copy.tabs[3]} endContent={<span>{tabCounts.tools}</span>} />
-            <Tab value="pricing" label={copy.tabs[4]} endContent={<span>{tabCounts.pricing}</span>} />
+            <Tab
+              value="pricing"
+              label={copy.tabs[4]}
+              endContent={props.pricingPort ? undefined : <span>0</span>}
+            />
           </TabList>
         </div>
 
@@ -215,7 +222,9 @@ export function UsageSettingsPage(props: {
 
         {usageDraft.activeTab === 'pricing' ? (
           <div className="settingsUsageTabPanel">
-            <UsagePricingPanel stats={stats} copy={copy} />
+            {props.pricingPort
+              ? <PricingSettingsPanel port={props.pricingPort} />
+              : <UsagePricingPanel copy={copy} />}
           </div>
         ) : null}
       </div>
@@ -392,7 +401,7 @@ function UsageToolsPanel(props: { stats: UsageStats | null; copy: UsageSettingsC
   );
 }
 
-function UsagePricingPanel(props: { stats: UsageStats | null; copy: UsageSettingsCopy }) {
+function UsagePricingPanel(props: { copy: UsageSettingsCopy }) {
   return (
     <UsageStatsTable
       ariaLabel={props.copy.tables.pricingAria}
@@ -402,7 +411,7 @@ function UsagePricingPanel(props: { stats: UsageStats | null; copy: UsageSetting
         { header: props.copy.tables.pricingHeaders[2], numeric: true },
         { header: props.copy.tables.pricingHeaders[3], numeric: true },
       ]}
-      rows={(props.stats?.pricing ?? []).map((row) => [row.provider, row.model, `$${row.inputPerMTokUsd}`, `$${row.outputPerMTokUsd}`])}
+      rows={[]}
       empty={{ Icon: BarChart3, title: props.copy.tables.noPricing, body: props.copy.tables.pricingEmptyBody }}
     />
   );

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -7,6 +7,7 @@
 @import "./settings/theme-preview.css";
 @import "./settings/bot.css";
 @import "./settings/usage.css";
+@import "./settings/pricing.css";
 @import "./settings/wechat.css";
 @import "./settings/connection.css";
 @import "./settings/provider-editor.css";

--- a/apps/desktop/src/renderer/styles/settings/pricing.css
+++ b/apps/desktop/src/renderer/styles/settings/pricing.css
@@ -13,21 +13,26 @@
 }
 
 .settingsPricingTableSkeleton {
-  min-width: 820px;
+  min-width: 819px;
   display: grid;
 }
 
 .settingsPricingTableSkeletonRow {
-  min-height: 40px;
+  min-height: 44px;
   display: grid;
-  grid-template-columns: minmax(180px, 2fr) 150px 72px 72px 112px 112px 132px;
+  grid-template-columns: minmax(169px, 2fr) 150px 72px 72px 112px 112px 132px;
   align-items: center;
-  gap: var(--space-3);
   border-bottom: 1px solid var(--border-soft);
 }
 
 .settingsPricingTableSkeletonRow:last-child {
   border-bottom: 0;
+}
+
+@media (max-width: 760px) {
+  .settingsPricingTableSkeletonRow {
+    min-height: 48px;
+  }
 }
 
 .settingsPricingTable {

--- a/apps/desktop/src/renderer/styles/settings/pricing.css
+++ b/apps/desktop/src/renderer/styles/settings/pricing.css
@@ -12,14 +12,27 @@
   gap: var(--space-3);
 }
 
-.settingsPricingLoading {
-  min-height: 160px;
+.settingsPricingTableSkeleton {
+  min-width: 820px;
   display: grid;
-  place-items: center;
+}
+
+.settingsPricingTableSkeletonRow {
+  min-height: 40px;
+  display: grid;
+  grid-template-columns: minmax(180px, 2fr) 150px 72px 72px 112px 112px 132px;
+  align-items: center;
+  gap: var(--space-3);
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.settingsPricingTableSkeletonRow:last-child {
+  border-bottom: 0;
 }
 
 .settingsPricingTable {
   min-width: 0;
+  overflow-x: auto;
 }
 
 .settingsPricingModelKey {

--- a/apps/desktop/src/renderer/styles/settings/pricing.css
+++ b/apps/desktop/src/renderer/styles/settings/pricing.css
@@ -1,0 +1,47 @@
+/* Settings → Usage → Pricing. Astryx owns controls, dialogs, banners and
+   table geometry; this file only composes the Pricing-specific hierarchy. */
+
+.settingsPricingPanel,
+.settingsPricingContent {
+  min-width: 0;
+}
+
+.settingsPricingContent {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-3);
+}
+
+.settingsPricingLoading {
+  min-height: 160px;
+  display: grid;
+  place-items: center;
+}
+
+.settingsPricingTable {
+  min-width: 0;
+}
+
+.settingsPricingModelKey {
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
+.settingsPricingRate {
+  font-variant-numeric: tabular-nums;
+}
+
+.settingsPricingReviewComparison {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
+  gap: var(--space-2);
+}
+
+.settingsPricingReviewComparison > div {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.settingsPricingReviewComparison span {
+  overflow-wrap: anywhere;
+}

--- a/apps/desktop/src/shared/runtime-host-pricing.ts
+++ b/apps/desktop/src/shared/runtime-host-pricing.ts
@@ -1,3 +1,5 @@
+import { canonicalPricingConfigsEqual } from '@maka/core/usage-stats/pricing';
+import type { PricingConfig } from '@maka/core/usage-stats/types';
 import type { EffectivePricingEntry, PricingMutation } from '@maka/runtime-host/protocol';
 
 /**
@@ -15,6 +17,39 @@ export interface DesktopPricingSnapshot {
 export interface DesktopPricingMutationInput {
   readonly base: DesktopPricingSnapshot;
   readonly mutation: PricingMutation;
+}
+
+export type PricingReconciliationTarget =
+  | { readonly kind: 'upsert'; readonly pricing: Readonly<PricingConfig> }
+  | {
+      readonly kind: 'delete';
+      readonly modelKey: string;
+      readonly expected: 'builtin' | 'unpriced' | 'no_override';
+    };
+
+/**
+ * Shared reconciliation semantics for the Host adapter and renderer recovery
+ * path. Keeping provenance here prevents the two callers from drifting on
+ * what counts as an already-applied mutation.
+ */
+export function pricingTargetMatchesSnapshot(
+  target: PricingReconciliationTarget,
+  snapshot: DesktopPricingSnapshot,
+): boolean {
+  const modelKey = target.kind === 'upsert' ? target.pricing.modelKey : target.modelKey;
+  const current = snapshot.entries.find((entry) => entry.pricing.modelKey === modelKey);
+  if (target.kind === 'upsert') {
+    return current?.source === 'custom'
+      && canonicalPricingConfigsEqual(current.pricing, target.pricing);
+  }
+  switch (target.expected) {
+    case 'builtin':
+      return current?.source === 'builtin';
+    case 'unpriced':
+      return current === undefined;
+    case 'no_override':
+      return current === undefined || current.source === 'builtin';
+  }
 }
 
 export type DesktopPricingMutationOutcome =

--- a/apps/desktop/src/shared/runtime-host-pricing.ts
+++ b/apps/desktop/src/shared/runtime-host-pricing.ts
@@ -1,0 +1,49 @@
+import type { EffectivePricingEntry, PricingMutation } from '@maka/runtime-host/protocol';
+
+/**
+ * One authoritative, connection-scoped Pricing Settings snapshot assembled by
+ * the Desktop Runtime Host adapter. Renderer consumers never receive paging
+ * cursors or transport details.
+ */
+export interface DesktopPricingSnapshot {
+  readonly hostEpoch: string;
+  readonly connectionId: string;
+  readonly revision: number;
+  readonly entries: readonly EffectivePricingEntry[];
+}
+
+export interface DesktopPricingMutationInput {
+  readonly base: DesktopPricingSnapshot;
+  readonly mutation: PricingMutation;
+}
+
+export type DesktopPricingMutationOutcome =
+  | {
+      readonly kind: 'saved';
+      readonly disposition: 'committed' | 'unchanged';
+      readonly snapshot: DesktopPricingSnapshot;
+    }
+  | {
+      readonly kind: 'saved_refresh_failed';
+      readonly disposition: 'committed' | 'unchanged';
+    }
+  | {
+      readonly kind: 'synchronized' | 'review_required';
+      readonly reason: 'revision_conflict' | 'outcome_unknown';
+      readonly snapshot: DesktopPricingSnapshot;
+    }
+  | {
+      readonly kind: 'reconciliation_unavailable';
+      readonly reason: 'revision_conflict' | 'outcome_unknown';
+    };
+
+/**
+ * The complete renderer boundary for Pricing Settings. The production
+ * DesktopRuntimeHostClient and Storybook/test adapters both satisfy it.
+ */
+export interface DesktopPricingSettingsPort {
+  loadPricingSnapshot(): Promise<DesktopPricingSnapshot>;
+  applyPricingMutation(
+    input: DesktopPricingMutationInput,
+  ): Promise<DesktopPricingMutationOutcome>;
+}

--- a/apps/desktop/stories/product-smoke-manifest.json
+++ b/apps/desktop/stories/product-smoke-manifest.json
@@ -61,6 +61,16 @@
         "compact": "The floor viewport is the stricter horizontal-containment case for the same Pricing table."
       }
     },
+    "pricingSettingsLoading": {
+      "storyId": "product-settings-pages--pricing-loading",
+      "productionHost": "SettingsSurface > UsageSettingsPage > PricingSettingsPanel (M5 preview)",
+      "state": "Table-shaped initial loading state at wide and minimum desktop widths",
+      "viewports": ["wide", "floor"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "The floor viewport is the stricter horizontal-containment case for the same Pricing skeleton."
+      }
+    },
     "providers": {
       "storyId": "product-settings-providers--configured-providers",
       "productionHost": "ProvidersPanel",

--- a/apps/desktop/stories/product-smoke-manifest.json
+++ b/apps/desktop/stories/product-smoke-manifest.json
@@ -51,6 +51,16 @@
         "floor": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent."
       }
     },
+    "pricingSettings": {
+      "storyId": "product-settings-pages--pricing-mixed",
+      "productionHost": "SettingsSurface > UsageSettingsPage > PricingSettingsPanel (M5 preview)",
+      "state": "Effective built-in and custom pricing at wide and minimum desktop widths",
+      "viewports": ["wide", "floor"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "The floor viewport is the stricter horizontal-containment case for the same Pricing table."
+      }
+    },
     "providers": {
       "storyId": "product-settings-providers--configured-providers",
       "productionHost": "ProvidersPanel",

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -1501,12 +1501,33 @@ export const PricingStaleSnapshot: Story = {
     />
   ),
   play: async ({ canvasElement }) => {
-    const dialog = await submitPricingStoryEditor(canvasElement);
+    const reachStaleRecovery = async () => {
+      const dialog = await submitPricingStoryEditor(canvasElement);
+      await waitForStoryCondition(
+        () => dialog.textContent?.includes('Runtime Host 连接已经变化') === true
+          && dialog.textContent.includes('刷新定价'),
+        'Pricing stale-snapshot recovery did not render',
+      );
+      return dialog;
+    };
+
+    const firstRecovery = await reachStaleRecovery();
+    await clickPricingDialogButton(firstRecovery, '取消');
     await waitForStoryCondition(
-      () => dialog.textContent?.includes('Runtime Host 连接已经变化') === true
-        && dialog.textContent.includes('刷新定价'),
-      'Pricing stale-snapshot recovery did not render',
+      () => document.querySelector('dialog[open]') === null
+        && canvasElement.textContent?.includes('草稿已保留') === false,
+      'Cancelling stale Pricing recovery still claimed to preserve the draft',
     );
+    const refresh = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.trim() === '刷新定价',
+    );
+    await userEvent.click(refresh);
+    await waitForStoryCondition(
+      () => canvasElement.textContent?.includes('已加载最新生效价格') === true,
+      'Pricing authority did not reload after abandoning stale recovery',
+    );
+    await reachStaleRecovery();
   },
 };
 
@@ -1524,18 +1545,25 @@ export const PricingConflictReview: Story = {
     />
   ),
   play: async ({ canvasElement }) => {
-    const dialog = await openPricingStoryEditor(canvasElement, '自定义');
-    const save = Array.from(dialog.querySelectorAll<HTMLButtonElement>('button')).find(
-      (button) => button.textContent?.trim() === '保存',
-    );
-    if (!save) throw new Error('Pricing save action did not render');
-    await userEvent.click(save);
+    const reachConflictReview = async () => {
+      const dialog = await submitPricingStoryEditor(canvasElement);
+      await waitForStoryCondition(
+        () => dialog.textContent?.includes('当前权威值') === true
+          && dialog.textContent.includes('内置')
+          && dialog.textContent.includes('自定义 · 有内置回退'),
+        'Pricing conflict comparison did not render',
+      );
+      return dialog;
+    };
+
+    const firstReview = await reachConflictReview();
+    await clickPricingDialogButton(firstReview, '取消');
     await waitForStoryCondition(
-      () => dialog.textContent?.includes('当前权威值') === true
-        && dialog.textContent.includes('内置')
-        && dialog.textContent.includes('自定义 · 有内置回退'),
-      'Pricing conflict comparison did not render',
+      () => document.querySelector('dialog[open]') === null
+        && canvasElement.textContent?.includes('定价已被其他更改更新') === false,
+      'Cancelling Pricing editor review left an actionless warning',
     );
+    await reachConflictReview();
   },
 };
 

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -29,6 +29,12 @@ import {
   mergeSettings,
 } from '@maka/core';
 import { SettingsSurface } from '../../src/renderer/settings/settings-surface';
+import type {
+  DesktopPricingMutationOutcome,
+  DesktopPricingSettingsPort,
+  DesktopPricingSnapshot,
+} from '../../src/shared/runtime-host-pricing';
+import type { EffectivePricingEntry } from '@maka/runtime-host/protocol';
 import { createUiLocaleUpdateGate } from '../../src/renderer/settings/ui-locale-update-gate';
 import type { ConnectionsBridge } from '../../src/renderer/settings/providers-panel';
 import { withScopedMakaBridge } from '../maka-bridge';
@@ -209,7 +215,6 @@ const usageStats: UsageStats = {
     },
     { tool: 'Bash', calls: 120, success: 118, errors: 2, avgDurationMs: 840 },
   ],
-  pricing: [{ provider: 'zai-coding-plan', model: 'glm-4.7', inputPerMTokUsd: 0, outputPerMTokUsd: 0 }],
 };
 
 const emptyUsageStats: UsageStats = {
@@ -229,7 +234,6 @@ const emptyUsageStats: UsageStats = {
   byProvider: [],
   byModel: [],
   byTool: [],
-  pricing: [],
 };
 
 const singleProviderUsageStats: UsageStats = {
@@ -695,6 +699,140 @@ const withUsageLongTailBridge = withUsageStoryBridge(usageStats, {
   activeTab: 'requests',
 });
 
+const withPricingBridge = withUsageStoryBridge(emptyUsageStats, {
+  activeTab: 'pricing',
+});
+
+function storyPricing(
+  modelKey: string,
+  inputUsdPer1M: number,
+  outputUsdPer1M: number,
+  cacheReadUsdPer1M?: number,
+  cacheWriteUsdPer1M?: number,
+): EffectivePricingEntry['pricing'] {
+  return {
+    modelKey,
+    inputUsdPer1M,
+    outputUsdPer1M,
+    ...(cacheReadUsdPer1M !== undefined ? { cacheReadUsdPer1M } : {}),
+    ...(cacheWriteUsdPer1M !== undefined ? { cacheWriteUsdPer1M } : {}),
+  };
+}
+
+const pricingBuiltinOnly: readonly EffectivePricingEntry[] = [
+  { pricing: storyPricing('anthropic:claude-sonnet-4-5', 3, 15, 0.3, 3.75), source: 'builtin' },
+  { pricing: storyPricing('openai:gpt-4o', 2.5, 10, 1.25), source: 'builtin' },
+];
+
+const pricingMixed: readonly EffectivePricingEntry[] = [
+  {
+    pricing: storyPricing('anthropic:claude-sonnet-4-5', 2, 12, 0.3, 3.75),
+    source: 'custom',
+    resetEffect: 'restore_builtin',
+  },
+  { pricing: storyPricing('openai:gpt-4o', 2.5, 10, 1.25), source: 'builtin' },
+  {
+    pricing: storyPricing('vendor:coder-v2', 0.8, 2.4, 0),
+    source: 'custom',
+    resetEffect: 'become_unpriced',
+  },
+];
+
+const pricingCustomOnly: readonly EffectivePricingEntry[] = [
+  {
+    pricing: storyPricing('Acme:Case-Sensitive-β', 0.00000001, 0.42),
+    source: 'custom',
+    resetEffect: 'become_unpriced',
+  },
+  {
+    pricing: storyPricing('vendor:coder-v2', 0.8, 2.4, 0, 0),
+    source: 'custom',
+    resetEffect: 'become_unpriced',
+  },
+];
+
+function createPricingStoryPort(input: {
+  entries?: readonly EffectivePricingEntry[];
+  load?: 'ready' | 'loading' | 'error';
+  mutation?: 'save' | 'review_required' | 'reconciliation_unavailable';
+}): DesktopPricingSettingsPort {
+  let snapshot: DesktopPricingSnapshot = {
+    hostEpoch: 'storybook-host',
+    connectionId: 'storybook-connection',
+    revision: 7,
+    entries: input.entries ?? [],
+  };
+
+  return {
+    async loadPricingSnapshot() {
+      if (input.load === 'loading') {
+        return new Promise<DesktopPricingSnapshot>(() => undefined);
+      }
+      if (input.load === 'error') throw new Error('Storybook Runtime Host is offline');
+      return snapshot;
+    },
+    async applyPricingMutation({ mutation }): Promise<DesktopPricingMutationOutcome> {
+      if (input.mutation === 'reconciliation_unavailable') {
+        return { kind: 'reconciliation_unavailable', reason: 'outcome_unknown' };
+      }
+      if (input.mutation === 'review_required') {
+        const modelKey = mutation.kind === 'upsert' ? mutation.pricing.modelKey : mutation.modelKey;
+        const latest = mutation.kind === 'upsert'
+          ? mutation.pricing
+          : storyPricing(modelKey, 99, 199, 9, 19);
+        snapshot = storySnapshot(snapshot, [
+          ...snapshot.entries.filter((entry) => entry.pricing.modelKey !== modelKey),
+          { pricing: latest, source: 'builtin' },
+        ]);
+        return { kind: 'review_required', reason: 'revision_conflict', snapshot };
+      }
+
+      if (mutation.kind === 'upsert') {
+        const existing = snapshot.entries.find(
+          (entry) => entry.pricing.modelKey === mutation.pricing.modelKey,
+        );
+        const resetEffect = existing?.source === 'builtin'
+          || (existing?.source === 'custom' && existing.resetEffect === 'restore_builtin')
+          ? 'restore_builtin'
+          : 'become_unpriced';
+        snapshot = storySnapshot(snapshot, [
+          ...snapshot.entries.filter(
+            (entry) => entry.pricing.modelKey !== mutation.pricing.modelKey,
+          ),
+          { pricing: mutation.pricing, source: 'custom', resetEffect },
+        ]);
+      } else {
+        const existing = snapshot.entries.find(
+          (entry) => entry.pricing.modelKey === mutation.modelKey,
+        );
+        const remaining = snapshot.entries.filter(
+          (entry) => entry.pricing.modelKey !== mutation.modelKey,
+        );
+        const bundled = pricingBuiltinOnly.find(
+          (entry) => entry.pricing.modelKey === mutation.modelKey,
+        );
+        snapshot = storySnapshot(snapshot, existing?.source === 'custom'
+          && existing.resetEffect === 'restore_builtin' && bundled
+          ? [...remaining, bundled]
+          : remaining);
+      }
+      return { kind: 'saved', disposition: 'committed', snapshot };
+    },
+  };
+}
+
+function storySnapshot(
+  previous: DesktopPricingSnapshot,
+  entries: readonly EffectivePricingEntry[],
+): DesktopPricingSnapshot {
+  return {
+    ...previous,
+    revision: previous.revision + 1,
+    entries: [...entries].sort((left, right) =>
+      left.pricing.modelKey < right.pricing.modelKey ? -1 : 1),
+  };
+}
+
 const subagentStorySettings = mergeSettings(createDefaultSettings(), {
   subagents: {
     presets: [
@@ -842,6 +980,7 @@ function SettingsStory(props: {
   section: SettingsSection;
   connections?: LlmConnection[];
   defaultSlug?: string | null;
+  createPricingPort?(): DesktopPricingSettingsPort;
 }) {
   const initialFocusRef = useRef<HTMLButtonElement>(null);
   const [uiLocaleUpdateGate] = useState(createUiLocaleUpdateGate);
@@ -851,6 +990,9 @@ function SettingsStory(props: {
   // holds both in AppShell state and applies them optimistically on click.
   const [themePref, setThemePref] = useState<ThemePreference>('auto');
   const [themePalette, setThemePalette] = useState<ThemePalette>('default');
+  const [pricingPort] = useState<DesktopPricingSettingsPort | undefined>(
+    () => props.createPricingPort?.(),
+  );
 
   return (
     <ToastProvider>
@@ -884,6 +1026,7 @@ function SettingsStory(props: {
           initialFocusRef={initialFocusRef}
           onOpenDailyReview={noop}
           onOpenSession={noop}
+          pricingPort={pricingPort}
         />
       </div>
     </ToastProvider>
@@ -910,6 +1053,28 @@ async function waitForStoryCondition(predicate: () => boolean, errorMessage: str
     await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
   }
   throw new Error(errorMessage);
+}
+
+async function waitForPricingDialog(canvasElement: HTMLElement): Promise<HTMLDialogElement> {
+  let dialog: HTMLDialogElement | null = null;
+  await waitForStoryCondition(() => {
+    dialog = canvasElement.querySelector<HTMLDialogElement>('dialog[open]')
+      ?? document.querySelector<HTMLDialogElement>('dialog[open]');
+    return dialog !== null;
+  }, 'Pricing editor dialog did not open');
+  return dialog!;
+}
+
+async function openPricingStoryEditor(
+  canvasElement: HTMLElement,
+  buttonLabel: string,
+): Promise<HTMLDialogElement> {
+  const button = await waitForStoryButton(
+    canvasElement,
+    (candidate) => candidate.textContent?.trim() === buttonLabel,
+  );
+  await userEvent.click(button);
+  return waitForPricingDialog(canvasElement);
 }
 
 async function openDailyReviewModelSelector(canvasElement: HTMLElement): Promise<HTMLButtonElement> {
@@ -1029,6 +1194,143 @@ export const UsageLongTail: Story = {
 // Real path: the same long-content Usage page at the minimum supported window width.
 export const UsageNarrow: Story = {
   ...UsageLongTail,
+  parameters: { viewport: { defaultViewport: 'mobile2' } },
+};
+
+// Real path: 设置 → 使用统计 → 定价配置, while the semantic Host adapter is loading.
+export const PricingLoading: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({ load: 'loading' })}
+    />
+  ),
+};
+
+// Real path: 设置 → 使用统计 → 定价配置, when the authoritative read fails.
+export const PricingReadError: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({ load: 'error' })}
+    />
+  ),
+};
+
+// Real path: 设置 → 使用统计 → 定价配置, with bundled prices only.
+export const PricingBuiltinOnly: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({ entries: pricingBuiltinOnly })}
+    />
+  ),
+};
+
+// Real path: 设置 → 使用统计 → 定价配置, with all three provenance states.
+export const PricingMixed: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({ entries: pricingMixed })}
+    />
+  ),
+};
+
+// Real path: 设置 → 使用统计 → 定价配置, with exact custom-only keys and explicit zero cache rates.
+export const PricingCustomOnly: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({ entries: pricingCustomOnly })}
+    />
+  ),
+};
+
+// Real path: 设置 → 使用统计 → 定价配置 → 添加价格, with immediate field validation.
+export const PricingValidation: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({ entries: pricingMixed })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const dialog = await openPricingStoryEditor(canvasElement, '添加价格');
+    const inputs = dialog.querySelectorAll<HTMLInputElement>('input');
+    if (inputs.length < 5) throw new Error('Pricing editor fields did not render');
+    await userEvent.type(inputs[0]!, 'vendor:new-model');
+    await userEvent.type(inputs[1]!, '-1');
+    await waitForStoryCondition(
+      () => dialog.textContent?.includes('请输入有限且不小于 0 的数字') === true,
+      'Pricing rate validation did not render',
+    );
+  },
+};
+
+// Real path: 设置 → 使用统计 → 定价配置 → 自定义, after a CAS conflict returns fresh authority.
+export const PricingConflictReview: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({
+        entries: pricingBuiltinOnly,
+        mutation: 'review_required',
+      })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const dialog = await openPricingStoryEditor(canvasElement, '自定义');
+    const save = Array.from(dialog.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === '保存',
+    );
+    if (!save) throw new Error('Pricing save action did not render');
+    await userEvent.click(save);
+    await waitForStoryCondition(
+      () => dialog.textContent?.includes('当前权威值') === true
+        && dialog.textContent.includes('内置')
+        && dialog.textContent.includes('自定义 · 有内置回退'),
+      'Pricing conflict comparison did not render',
+    );
+  },
+};
+
+// Real path: 设置 → 使用统计 → 定价配置 → 自定义, after a response-losing uncertain write.
+export const PricingUncertainBlocked: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({
+        entries: pricingBuiltinOnly,
+        mutation: 'reconciliation_unavailable',
+      })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const dialog = await openPricingStoryEditor(canvasElement, '自定义');
+    const save = Array.from(dialog.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === '保存',
+    );
+    if (!save) throw new Error('Pricing save action did not render');
+    await userEvent.click(save);
+    await waitForStoryCondition(
+      () => dialog.textContent?.includes('暂时无法核对写入结果') === true,
+      'Pricing uncertain blocked state did not render',
+    );
+  },
+};
+
+// Real path: 设置 → 使用统计 → 定价配置 at the minimum supported window width.
+export const PricingNarrow: Story = {
+  ...PricingMixed,
   parameters: { viewport: { defaultViewport: 'mobile2' } },
 };
 /**

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -1115,6 +1115,17 @@ async function waitForPricingAlertDialog(): Promise<HTMLElement> {
   return dialog!;
 }
 
+async function waitForPricingDialogText(
+  dialog: HTMLElement,
+  text: string,
+  errorMessage: string,
+): Promise<void> {
+  await waitForStoryCondition(
+    () => dialog.textContent?.includes(text) === true,
+    errorMessage,
+  );
+}
+
 async function clickPricingDialogButton(dialog: HTMLElement, label: string): Promise<void> {
   const button = Array.from(dialog.querySelectorAll<HTMLButtonElement>('button')).find(
     (candidate) => candidate.textContent?.trim() === label,
@@ -1341,12 +1352,16 @@ export const PricingDeleteConfirmation: Story = {
     );
     await userEvent.click(deleteButton);
     const dialog = await waitForPricingAlertDialog();
-    if (!dialog.textContent?.includes('之后新激活的模型工作会变为未定价，而不是 $0')) {
-      throw new Error('Pricing delete consequence did not render');
-    }
-    if (!dialog.textContent.includes('删除')) {
-      throw new Error('Pricing delete confirmation action did not render');
-    }
+    await waitForPricingDialogText(
+      dialog,
+      '之后新激活的模型工作会变为未定价，而不是 $0',
+      'Pricing delete consequence did not render',
+    );
+    await waitForPricingDialogText(
+      dialog,
+      '删除',
+      'Pricing delete confirmation action did not render',
+    );
   },
 };
 
@@ -1371,9 +1386,11 @@ export const PricingDeleteReviewConfirmation: Story = {
       );
       await userEvent.click(resetButton);
       const initial = await waitForPricingAlertDialog();
-      if (!initial.textContent?.includes('恢复内置价格')) {
-        throw new Error('Pricing reset consequence did not render');
-      }
+      await waitForPricingDialogText(
+        initial,
+        '恢复内置价格',
+        'Pricing reset consequence did not render',
+      );
       await clickPricingDialogButton(initial, '恢复');
       const reviewButton = await waitForStoryButton(
         canvasElement,
@@ -1381,12 +1398,16 @@ export const PricingDeleteReviewConfirmation: Story = {
       );
       await userEvent.click(reviewButton);
       const review = await waitForPricingAlertDialog();
-      if (!review.textContent?.includes('当前权威状态已经变化')) {
-        throw new Error('Pricing delete authority review did not render');
-      }
-      if (!review.textContent.includes('再次确认')) {
-        throw new Error('Pricing delete second confirmation did not render');
-      }
+      await waitForPricingDialogText(
+        review,
+        '当前权威状态已经变化',
+        'Pricing delete authority review did not render',
+      );
+      await waitForPricingDialogText(
+        review,
+        '再次确认',
+        'Pricing delete second confirmation did not render',
+      );
       return review;
     };
 

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -754,7 +754,13 @@ const pricingCustomOnly: readonly EffectivePricingEntry[] = [
 function createPricingStoryPort(input: {
   entries?: readonly EffectivePricingEntry[];
   load?: 'ready' | 'loading' | 'error';
-  mutation?: 'save' | 'review_required' | 'reconciliation_unavailable';
+  mutation?:
+    | 'save'
+    | 'saved_refresh_failed'
+    | 'synchronized'
+    | 'review_required'
+    | 'reconciliation_unavailable'
+    | 'stale';
 }): DesktopPricingSettingsPort {
   let snapshot: DesktopPricingSnapshot = {
     hostEpoch: 'storybook-host',
@@ -772,53 +778,76 @@ function createPricingStoryPort(input: {
       return snapshot;
     },
     async applyPricingMutation({ mutation }): Promise<DesktopPricingMutationOutcome> {
+      if (input.mutation === 'stale') {
+        throw Object.assign(new Error('Storybook Pricing snapshot is stale'), {
+          code: 'pricing_snapshot_stale',
+        });
+      }
       if (input.mutation === 'reconciliation_unavailable') {
         return { kind: 'reconciliation_unavailable', reason: 'outcome_unknown' };
       }
       if (input.mutation === 'review_required') {
         const modelKey = mutation.kind === 'upsert' ? mutation.pricing.modelKey : mutation.modelKey;
-        const latest = mutation.kind === 'upsert'
-          ? mutation.pricing
-          : storyPricing(modelKey, 99, 199, 9, 19);
+        const current = snapshot.entries.find((entry) => entry.pricing.modelKey === modelKey);
+        const latest: EffectivePricingEntry = mutation.kind === 'upsert'
+          ? { pricing: mutation.pricing, source: 'builtin' }
+          : {
+              pricing: storyPricing(modelKey, 99, 199, 9, 19),
+              source: 'custom',
+              resetEffect: current?.source === 'custom'
+                ? current.resetEffect
+                : 'become_unpriced',
+            };
         snapshot = storySnapshot(snapshot, [
           ...snapshot.entries.filter((entry) => entry.pricing.modelKey !== modelKey),
-          { pricing: latest, source: 'builtin' },
+          latest,
         ]);
         return { kind: 'review_required', reason: 'revision_conflict', snapshot };
       }
-
-      if (mutation.kind === 'upsert') {
-        const existing = snapshot.entries.find(
-          (entry) => entry.pricing.modelKey === mutation.pricing.modelKey,
-        );
-        const resetEffect = existing?.source === 'builtin'
-          || (existing?.source === 'custom' && existing.resetEffect === 'restore_builtin')
-          ? 'restore_builtin'
-          : 'become_unpriced';
-        snapshot = storySnapshot(snapshot, [
-          ...snapshot.entries.filter(
-            (entry) => entry.pricing.modelKey !== mutation.pricing.modelKey,
-          ),
-          { pricing: mutation.pricing, source: 'custom', resetEffect },
-        ]);
-      } else {
-        const existing = snapshot.entries.find(
-          (entry) => entry.pricing.modelKey === mutation.modelKey,
-        );
-        const remaining = snapshot.entries.filter(
-          (entry) => entry.pricing.modelKey !== mutation.modelKey,
-        );
-        const bundled = pricingBuiltinOnly.find(
-          (entry) => entry.pricing.modelKey === mutation.modelKey,
-        );
-        snapshot = storySnapshot(snapshot, existing?.source === 'custom'
-          && existing.resetEffect === 'restore_builtin' && bundled
-          ? [...remaining, bundled]
-          : remaining);
+      snapshot = applyPricingStoryMutation(snapshot, mutation);
+      if (input.mutation === 'saved_refresh_failed') {
+        return { kind: 'saved_refresh_failed', disposition: 'committed' };
+      }
+      if (input.mutation === 'synchronized') {
+        return { kind: 'synchronized', reason: 'outcome_unknown', snapshot };
       }
       return { kind: 'saved', disposition: 'committed', snapshot };
     },
   };
+}
+
+function applyPricingStoryMutation(
+  snapshot: DesktopPricingSnapshot,
+  mutation: Parameters<DesktopPricingSettingsPort['applyPricingMutation']>[0]['mutation'],
+): DesktopPricingSnapshot {
+  if (mutation.kind === 'upsert') {
+    const existing = snapshot.entries.find(
+      (entry) => entry.pricing.modelKey === mutation.pricing.modelKey,
+    );
+    const resetEffect = existing?.source === 'builtin'
+      || (existing?.source === 'custom' && existing.resetEffect === 'restore_builtin')
+      ? 'restore_builtin'
+      : 'become_unpriced';
+    return storySnapshot(snapshot, [
+      ...snapshot.entries.filter(
+        (entry) => entry.pricing.modelKey !== mutation.pricing.modelKey,
+      ),
+      { pricing: mutation.pricing, source: 'custom', resetEffect },
+    ]);
+  }
+  const existing = snapshot.entries.find(
+    (entry) => entry.pricing.modelKey === mutation.modelKey,
+  );
+  const remaining = snapshot.entries.filter(
+    (entry) => entry.pricing.modelKey !== mutation.modelKey,
+  );
+  const bundled = pricingBuiltinOnly.find(
+    (entry) => entry.pricing.modelKey === mutation.modelKey,
+  );
+  return storySnapshot(snapshot, existing?.source === 'custom'
+    && existing.resetEffect === 'restore_builtin' && bundled
+    ? [...remaining, bundled]
+    : remaining);
 }
 
 function storySnapshot(
@@ -1077,6 +1106,32 @@ async function openPricingStoryEditor(
   return waitForPricingDialog(canvasElement);
 }
 
+async function waitForPricingAlertDialog(): Promise<HTMLElement> {
+  let dialog: HTMLElement | null = null;
+  await waitForStoryCondition(() => {
+    dialog = document.querySelector<HTMLElement>('[role="alertdialog"]');
+    return dialog !== null;
+  }, 'Pricing confirmation dialog did not open');
+  return dialog!;
+}
+
+async function clickPricingDialogButton(dialog: HTMLElement, label: string): Promise<void> {
+  const button = Array.from(dialog.querySelectorAll<HTMLButtonElement>('button')).find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!button) throw new Error(`Pricing dialog action did not render: ${label}`);
+  await userEvent.click(button);
+}
+
+async function submitPricingStoryEditor(
+  canvasElement: HTMLElement,
+  buttonLabel = '自定义',
+): Promise<HTMLDialogElement> {
+  const dialog = await openPricingStoryEditor(canvasElement, buttonLabel);
+  await clickPricingDialogButton(dialog, '保存');
+  return dialog;
+}
+
 async function openDailyReviewModelSelector(canvasElement: HTMLElement): Promise<HTMLButtonElement> {
   const selector = await waitForStoryButton(
     canvasElement,
@@ -1197,7 +1252,8 @@ export const UsageNarrow: Story = {
   parameters: { viewport: { defaultViewport: 'mobile2' } },
 };
 
-// Real path: 设置 → 使用统计 → 定价配置, while the semantic Host adapter is loading.
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置,
+// while the semantic Host adapter is loading; production does not pass pricingPort yet.
 export const PricingLoading: Story = {
   decorators: [withPricingBridge],
   render: () => (
@@ -1208,7 +1264,8 @@ export const PricingLoading: Story = {
   ),
 };
 
-// Real path: 设置 → 使用统计 → 定价配置, when the authoritative read fails.
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置,
+// when the authoritative read fails; production does not pass pricingPort yet.
 export const PricingReadError: Story = {
   decorators: [withPricingBridge],
   render: () => (
@@ -1219,7 +1276,20 @@ export const PricingReadError: Story = {
   ),
 };
 
-// Real path: 设置 → 使用统计 → 定价配置, with bundled prices only.
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置,
+// after a ready Host returns no effective prices; production does not pass pricingPort yet.
+export const PricingEmpty: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({ entries: [] })}
+    />
+  ),
+};
+
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置,
+// with bundled prices only; production does not pass pricingPort yet.
 export const PricingBuiltinOnly: Story = {
   decorators: [withPricingBridge],
   render: () => (
@@ -1230,7 +1300,8 @@ export const PricingBuiltinOnly: Story = {
   ),
 };
 
-// Real path: 设置 → 使用统计 → 定价配置, with all three provenance states.
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置,
+// with all three provenance states; production does not pass pricingPort yet.
 export const PricingMixed: Story = {
   decorators: [withPricingBridge],
   render: () => (
@@ -1241,7 +1312,8 @@ export const PricingMixed: Story = {
   ),
 };
 
-// Real path: 设置 → 使用统计 → 定价配置, with exact custom-only keys and explicit zero cache rates.
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置,
+// with exact custom-only keys and explicit zero cache rates; production does not pass pricingPort yet.
 export const PricingCustomOnly: Story = {
   decorators: [withPricingBridge],
   render: () => (
@@ -1252,7 +1324,84 @@ export const PricingCustomOnly: Story = {
   ),
 };
 
-// Real path: 设置 → 使用统计 → 定价配置 → 添加价格, with immediate field validation.
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置 → 删除,
+// before a custom-only override is removed; production does not pass pricingPort yet.
+export const PricingDeleteConfirmation: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({ entries: pricingCustomOnly })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const deleteButton = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.trim() === '删除',
+    );
+    await userEvent.click(deleteButton);
+    const dialog = await waitForPricingAlertDialog();
+    if (!dialog.textContent?.includes('之后新激活的模型工作会变为未定价，而不是 $0')) {
+      throw new Error('Pricing delete consequence did not render');
+    }
+    if (!dialog.textContent.includes('删除')) {
+      throw new Error('Pricing delete confirmation action did not render');
+    }
+  },
+};
+
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置 → 恢复,
+// after authority changes and requires a second confirmation; production does not pass pricingPort yet.
+export const PricingDeleteReviewConfirmation: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({
+        entries: pricingMixed,
+        mutation: 'review_required',
+      })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const reachReview = async () => {
+      const resetButton = await waitForStoryButton(
+        canvasElement,
+        (candidate) => candidate.textContent?.trim() === '恢复',
+      );
+      await userEvent.click(resetButton);
+      const initial = await waitForPricingAlertDialog();
+      if (!initial.textContent?.includes('恢复内置价格')) {
+        throw new Error('Pricing reset consequence did not render');
+      }
+      await clickPricingDialogButton(initial, '恢复');
+      const reviewButton = await waitForStoryButton(
+        canvasElement,
+        (candidate) => candidate.textContent?.trim() === '复核待处理操作',
+      );
+      await userEvent.click(reviewButton);
+      const review = await waitForPricingAlertDialog();
+      if (!review.textContent?.includes('当前权威状态已经变化')) {
+        throw new Error('Pricing delete authority review did not render');
+      }
+      if (!review.textContent.includes('再次确认')) {
+        throw new Error('Pricing delete second confirmation did not render');
+      }
+      return review;
+    };
+
+    const firstReview = await reachReview();
+    await clickPricingDialogButton(firstReview, '取消');
+    await waitForStoryCondition(
+      () => !canvasElement.textContent?.includes('定价已被其他更改更新'),
+      'Cancelling Pricing delete review left an actionless warning',
+    );
+    await reachReview();
+  },
+};
+
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置 → 添加价格,
+// with immediate field validation; production does not pass pricingPort yet.
 export const PricingValidation: Story = {
   decorators: [withPricingBridge],
   render: () => (
@@ -1274,7 +1423,95 @@ export const PricingValidation: Story = {
   },
 };
 
-// Real path: 设置 → 使用统计 → 定价配置 → 自定义, after a CAS conflict returns fresh authority.
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置 → 自定义,
+// after the Host saves and reloads the override; production does not pass pricingPort yet.
+export const PricingSaved: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({ entries: pricingBuiltinOnly })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await submitPricingStoryEditor(canvasElement);
+    await waitForStoryCondition(
+      () => canvasElement.textContent?.includes('定价已保存并重新加载') === true,
+      'Pricing saved outcome did not render',
+    );
+  },
+};
+
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置 → 自定义,
+// after a committed save cannot reload authority; production does not pass pricingPort yet.
+export const PricingSavedRefreshFailed: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({
+        entries: pricingBuiltinOnly,
+        mutation: 'saved_refresh_failed',
+      })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const dialog = await submitPricingStoryEditor(canvasElement);
+    await waitForStoryCondition(
+      () => dialog.textContent?.includes('保存已完成，但最新定价未能加载') === true
+        && dialog.textContent.includes('刷新定价'),
+      'Pricing saved-refresh-failed recovery did not render',
+    );
+  },
+};
+
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置 → 自定义,
+// when reconciliation finds the intended override already authoritative; production does not pass pricingPort yet.
+export const PricingSynchronized: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({
+        entries: pricingBuiltinOnly,
+        mutation: 'synchronized',
+      })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await submitPricingStoryEditor(canvasElement);
+    await waitForStoryCondition(
+      () => canvasElement.textContent?.includes('当前权威状态与草稿一致') === true,
+      'Pricing synchronized outcome did not render',
+    );
+  },
+};
+
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置 → 自定义,
+// after a stale connection invalidates the save base; production does not pass pricingPort yet.
+export const PricingStaleSnapshot: Story = {
+  decorators: [withPricingBridge],
+  render: () => (
+    <SettingsStory
+      section="usage"
+      createPricingPort={() => createPricingStoryPort({
+        entries: pricingBuiltinOnly,
+        mutation: 'stale',
+      })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const dialog = await submitPricingStoryEditor(canvasElement);
+    await waitForStoryCondition(
+      () => dialog.textContent?.includes('Runtime Host 连接已经变化') === true
+        && dialog.textContent.includes('刷新定价'),
+      'Pricing stale-snapshot recovery did not render',
+    );
+  },
+};
+
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置 → 自定义,
+// after a CAS conflict returns fresh authority; production does not pass pricingPort yet.
 export const PricingConflictReview: Story = {
   decorators: [withPricingBridge],
   render: () => (
@@ -1302,7 +1539,8 @@ export const PricingConflictReview: Story = {
   },
 };
 
-// Real path: 设置 → 使用统计 → 定价配置 → 自定义, after a response-losing uncertain write.
+// Real path: M5-preview, story-only today — intended path is 设置 → 使用统计 → 定价配置 → 自定义,
+// after a response-losing uncertain write; production does not pass pricingPort yet.
 export const PricingUncertainBlocked: Story = {
   decorators: [withPricingBridge],
   render: () => (
@@ -1326,12 +1564,6 @@ export const PricingUncertainBlocked: Story = {
       'Pricing uncertain blocked state did not render',
     );
   },
-};
-
-// Real path: 设置 → 使用统计 → 定价配置 at the minimum supported window width.
-export const PricingNarrow: Story = {
-  ...PricingMixed,
-  parameters: { viewport: { defaultViewport: 'mobile2' } },
 };
 /**
  * #1364: entry list (long title / content / tag set), archived group, and

--- a/apps/desktop/tsconfig.renderer.json
+++ b/apps/desktop/tsconfig.renderer.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src/renderer",
+    "rootDir": "src",
     "outDir": "dist-renderer-types",
     "jsx": "react-jsx",
     "types": ["vite/client"]

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -368,12 +368,6 @@ export interface UsageStats {
     errors: number;
     avgDurationMs: number;
   }>;
-  pricing: Array<{
-    provider: string;
-    model: string;
-    inputPerMTokUsd: number;
-    outputPerMTokUsd: number;
-  }>;
 }
 
 export interface SettingsTestResult {

--- a/packages/storage/src/usage-stats-store.ts
+++ b/packages/storage/src/usage-stats-store.ts
@@ -112,7 +112,6 @@ export async function readUsageStats(
     byProvider: aggregateBy(modelLogs, 'provider'),
     byModel: aggregateBy(modelLogs, 'model'),
     byTool: toolRows,
-    pricing: [],
   };
 }
 


### PR DESCRIPTION
## Summary

This PR lands the isolated M4 Pricing renderer/editor slice on top of the Host-backed semantic adapter added by #2148 and #2024.

- Add an effective Pricing table with Builtin/Custom provenance and add, edit, reset, and delete flows through `DesktopPricingSettingsPort`.
- Preserve raw drafts and exact-key semantics, including blank optional values versus explicit zero.
- Make revision conflicts, uncertain mutation outcomes, refresh/write races, and Host replacement explicit. Writes are never replayed automatically; the user reviews against fresh authority before retrying.
- Add English/Chinese copy, responsive dialogs, focused model/gate/boundary tests, and nine Storybook states covering loading, errors, provenance mixes, validation, conflicts, uncertain outcomes, and narrow layouts.
- Remove the unused `UsageStats.pricing` projection so Pricing has one Host-backed source of truth.

Part of #2015.

## Verification

- `mise exec node@24.18.1 -- npm run lint`
- `mise exec node@24.18.1 -- npm run format:check`
- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run typecheck`
- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run build:renderer`
- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run build-storybook`
- Desktop compiled test suite: 1,716 passed, 0 failed.
- Core suite: 781 passed, 0 failed.
- Storage suite: 681 passed, 14 skipped, 0 failed on the final full run. An earlier run hit the process-crash fixture timing path once; that test passed in isolation and in the next full run.
- Storybook browser QA covered add/edit/reset/delete, conflict review, uncertain-outcome recovery, focus restoration, and a 480 x 720 viewport with no horizontal overflow or console errors.

## Scope

This PR intentionally does not activate Pricing in the production `SettingsModal` and does not add a legacy IPC path. The copyable exact-key source from Host-backed Usage/Inspector remains a follow-up acceptance item before #2015 can close; production activation remains part of the M5 cutover.

<details>
<summary>中文说明</summary>

## 摘要

本 PR 在 #2148 与 #2024 提供的 Host-backed 语义适配器之上，实现独立的 M4 Pricing renderer/editor 切片。

- 新增有效 Pricing 表格，展示 Builtin/Custom 来源，并通过 `DesktopPricingSettingsPort` 支持新增、编辑、重置和删除。
- 保留用户的原始输入与精确 key 语义，明确区分可选空值和显式 `0`。
- 显式处理 revision 冲突、结果不确定、刷新/写入竞态及 Host 替换。写操作不会自动重放，用户必须基于最新 authority 复核后再试。
- 新增中英文文案、响应式对话框、聚焦的 model/gate/boundary 测试，以及覆盖加载、错误、来源组合、校验、冲突、不确定结果和窄屏的九个 Storybook 状态。
- 移除未使用的 `UsageStats.pricing` 投影，使 Pricing 只保留一个 Host-backed 事实来源。

这是 #2015 的一部分。

## 验证

- `mise exec node@24.18.1 -- npm run lint`
- `mise exec node@24.18.1 -- npm run format:check`
- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run typecheck`
- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run build:renderer`
- `mise exec node@24.18.1 -- npm --workspace @maka/desktop run build-storybook`
- Desktop 编译后测试：1,716 项通过，0 项失败。
- Core 测试：781 项通过，0 项失败。
- Storage 最终全量运行：681 项通过、14 项跳过、0 项失败。此前一次运行触发了 process-crash fixture 的时序路径；该用例单独重跑及下一次全量运行均通过。
- Storybook 浏览器实测覆盖新增、编辑、重置、删除、冲突复核、结果不确定恢复、焦点恢复及 480 x 720 窄屏布局，未发现横向溢出或控制台错误。

## 范围

本 PR 不会在生产 `SettingsModal` 中提前激活 Pricing，也不会新增 legacy IPC 路径。来自 Host-backed Usage/Inspector 的可复制 exact-key 来源仍是 #2015 关闭前的后续验收项；生产激活仍属于 M5 cutover。

</details>
