### PR TITLE
fix(ui): preserve Astryx List accessible names

### DIFF
--- a/packages/ui/src/__tests__/astryx-list-accessible-name.test.tsx
+++ b/packages/ui/src/__tests__/astryx-list-accessible-name.test.tsx
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { List } from '@astryxdesign/core';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+describe('Astryx List accessible name', () => {
+  /**
+   * Guard for `patches/@astryxdesign+core+0.2.0.patch`. `ListProps` accepts
+   * `aria-label`, but upstream 0.2.0 drops it before rendering the root list.
+   * Delete the patch when this passes against an unpatched package.
+   */
+  it('forwards its supported aria-label to the root list', () => {
+    const markup = renderToStaticMarkup(
+      <List aria-label="Available models">
+        <li>Example model</li>
+      </List>,
+    );
+
+    assert.match(markup, /<ul[^>]*aria-label="Available models"/);
+  });
+
+  it('keeps the visible header association when an aria-label is also present', () => {
+    const markup = renderToStaticMarkup(
+      <List aria-label="Fallback name" header="Visible heading">
+        <li>Example model</li>
+      </List>,
+    );
+
+    const labelledBy = markup.match(/<ul[^>]*aria-labelledby="([^"]+)"/)?.[1];
+    assert.ok(labelledBy);
+    assert.match(markup, /<ul[^>]*aria-label="Fallback name"/);
+    assert.ok(markup.includes(`id="${labelledBy}"`));
+  });
+});

--- a/patches/@astryxdesign+core+0.2.0.patch
+++ b/patches/@astryxdesign+core+0.2.0.patch
@@ -20,6 +20,26 @@ index b5a8d9e..89a72cd 100644
  
    // A group label (e.g. for a radiogroup) must not be a literal `<label>`
    // element: a `<label>` semantically names a single form control and can't be
+diff --git a/node_modules/@astryxdesign/core/dist/List/List.js b/node_modules/@astryxdesign/core/dist/List/List.js
+index 7a4083d..2b93545 100644
+--- a/node_modules/@astryxdesign/core/dist/List/List.js
++++ b/node_modules/@astryxdesign/core/dist/List/List.js
+@@ -89,6 +89,7 @@ export function List({
+   className,
+   style,
+   'data-testid': testId,
++  'aria-label': ariaLabel,
+   ref
+ }) {
+   const headerId = useId();
+@@ -102,6 +103,7 @@ export function List({
+   const listElement = /*#__PURE__*/_jsx(Tag, {
+     ref: ref,
+     "data-testid": testId,
++    "aria-label": ariaLabel,
+     "aria-labelledby": header != null ? headerId : undefined,
+     ...(isOrdered && start != null && start !== 1 ? {
+       start
 diff --git a/node_modules/@astryxdesign/core/locales/en.json b/node_modules/@astryxdesign/core/locales/en.json
 index fa4644c..505d815 100644
 --- a/node_modules/@astryxdesign/core/locales/en.json

--- a/patches/README.md
+++ b/patches/README.md
@@ -95,3 +95,13 @@ Only `dist/Field/FieldLabel.js` is patched — `package.json` `exports` resolves
 ### Lifecycle
 
 Upstreamable, unlike the `@ai-sdk` patch: the key naming follows `@astryx.fileInput.required`, which upstream already ships for the screen-reader mirror of this same marker. **Delete it when `packages/ui/src/__tests__/astryx-form-controls-localization.test.tsx` passes without it** — `localizes the required marker while keeping aria-required` asserts both halves, the localized marker and the surviving `aria-required`, and `keeps Astryx's English markers when the locale is en` asserts the `en` path did not regress into a raw key. Reinstall without the patch and run `npm --workspace @maka/ui run test`.
+
+## `@astryxdesign/core`: `List` must render the accessible name its interface accepts
+
+Fixes [#2189](https://github.com/maka-agent/maka-agent/issues/2189). `ListProps` extends Astryx `BaseProps`, whose interface includes `aria-label`, but `List` 0.2.0 destructures a fixed prop set and never forwards that name to its root `<ul>` or `<ol>`. Six Maka lists pass localized accessible names that therefore disappear at runtime.
+
+The patch explicitly forwards `aria-label` to the root list. That is narrower than spreading every remaining `BaseProps` field through a vendored component, and it leaves the existing visible `header` / `aria-labelledby` path untouched. Replacing the six call sites with visible `header` props would add redundant headings and leave the advertised `List` interface broken.
+
+Only `dist/List/List.js` is patched because package exports resolve there and Maka does not compile Astryx `src/` or load its UMD bundle. The source and map remain upstream copies, so debugger locations inside these two lines do not describe the patched runtime exactly.
+
+**Delete it when `packages/ui/src/__tests__/astryx-list-accessible-name.test.tsx` passes without the patch.** Reinstall an unpatched `@astryxdesign/core` and run `npm --workspace @maka/ui test`; the guard renders the public `List` interface and asserts that its root carries the caller-provided accessible name.


### PR DESCRIPTION
Closes #2189

## Summary
- fix the patched Astryx `List` seam so `aria-label` is forwarded to the root `ul/ol`
- preserve the existing `aria-labelledby` behavior for headered lists
- add a regression test for runtime accessible-name rendering
- update patch docs to reflect the additional seam expectation

## Why
`@astryxdesign/core` `List` accepts `aria-label` by type, but at runtime it was dropped, leaving several desktop lists without accessible names.

## Validation
- Added focused regression coverage in UI tests
- Rebuilt and validated patch application workflow with existing Astryx patch docs
- No visible UI/API surface change except accessible-name output

## Impact
- Accessibility improves for 6 existing list call sites in Desktop
- No layout/behavior change for sighted users

<details><summary>中文</summary>

关闭 #2189

## 概要
- 修复 Astryx `List` 的补丁缝，使 `aria-label` 能正确透传到根 `ul/ol`
- 保持已有 `header` 时的 `aria-labelledby` 行为不变
- 补充运行时可访问名称回归测试
- 补充 `patches/README.md` 中的说明

## 原因
`@astryxdesign/core` 的 `List` 类型层支持 `aria-label`，但运行时未转发，导致桌面端 6 个列表在无障碍里没有可访问名称。

## 验证
- 新增专项回归测试
- 已保持现有 Astryx 补丁应用链路与文档一致
- 除了可访问性属性外，不改变页面可视化行为

## 影响
- 提升桌面端 6 处列表的可访问性
- 对可见 UI 无影响

</details>
