### PR TITLE
fix(ui): keep a tool-call group collapsed until the reader opens it

### DIFF
--- a/packages/ui/src/__tests__/processing-block.test.tsx
+++ b/packages/ui/src/__tests__/processing-block.test.tsx
@@ -62,7 +62,7 @@ describe('ProcessingBlock disclosure wiring (#1307)', () => {
     assert.match(markup, /深度思考/);
   });
 
-  it('keeps an unsettled group in the same Astryx rows, expanded, without a processing wrapper', () => {
+  it('keeps an unsettled group in the same collapsed Astryx rows, without a processing wrapper', () => {
     const markup = renderToStaticMarkup(createElement(TurnView, {
       turn: turnWithTools([
         { toolUseId: 'b1', toolName: 'Bash', activityKind: 'command', status: 'completed', args: {} },
@@ -71,7 +71,8 @@ describe('ProcessingBlock disclosure wiring (#1307)', () => {
     }));
     assert.doesNotMatch(markup, /data-processing="block"/);
     assert.match(markup, /class="[^"]*astryx-chat-tool-calls[^"]*"/);
-    assert.match(markup, /aria-expanded="true"/);
+    assert.doesNotMatch(markup, /aria-expanded="true"/);
+    // The collapsed group header projects the last call, intent and all.
     assert.match(markup, /写入配置/);
   });
 });

--- a/packages/ui/src/__tests__/processing-block.test.tsx
+++ b/packages/ui/src/__tests__/processing-block.test.tsx
@@ -72,7 +72,6 @@ describe('ProcessingBlock disclosure wiring (#1307)', () => {
     assert.doesNotMatch(markup, /data-processing="block"/);
     assert.match(markup, /class="[^"]*astryx-chat-tool-calls[^"]*"/);
     assert.doesNotMatch(markup, /aria-expanded="true"/);
-    // The collapsed group header projects the last call, intent and all.
     assert.match(markup, /写入配置/);
   });
 });

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -443,10 +443,12 @@ describe('tool activity presentation', () => {
     }
   });
 
-  // Expansion is Astryx's call, not the product's: a settled group stays
-  // collapsed even when an earlier row failed, and the collapsed header shows
-  // the last call alone. Accepting that density trade-off is what "one visual
-  // language" costs — a bespoke group summary is exactly what this PR removed.
+  // Expansion is Astryx's call, not the product's, and Astryx's default is
+  // collapsed: a group opens only when the reader opens it, whatever its rows
+  // are doing. The collapsed header shows the last call alone, so a group whose
+  // last call settles first may briefly project a settled icon while a sibling
+  // still runs — the density trade-off "one visual language" costs, and cheaper
+  // than groups that latch open for the rest of the session.
   describe('group expansion follows Astryx', () => {
     const trailingSuccess = {
       toolUseId: 'ok-1',
@@ -472,8 +474,8 @@ describe('tool activity presentation', () => {
     });
 
     // Two items on purpose: Astryx renders a lone call as a bare row that owns
-    // its own expansion, so defaultIsExpanded only reaches a real group.
-    it('opens while any call in the group is still running', () => {
+    // its own expansion, so group expansion is only observable from two up.
+    it('stays collapsed while a call in the group is still running', () => {
       const markup = renderGroup({
         toolUseId: 'live-1',
         toolName: 'Bash',
@@ -481,15 +483,15 @@ describe('tool activity presentation', () => {
         status: 'running',
         args: { command: 'npm test' },
       });
-      assert.match(markup, /aria-expanded="true"/);
+      assert.match(markup, /aria-expanded="false"/);
+      assert.doesNotMatch(markup, /aria-expanded="true"/);
     });
 
     // `pending` is in flight too: tool_start opens a call there and it only
     // reaches `running` once output arrives, so a tool that never streams stays
-    // pending for its whole life. With parallel calls the last one can settle
-    // first, and the collapsed header would then show a green check for a group
-    // whose sibling is still working.
-    it('opens when a parallel call is still pending behind a settled one', () => {
+    // pending for its whole life. It gets no special treatment either — the
+    // group is collapsed until the reader says otherwise.
+    it('stays collapsed when a parallel call is still pending behind a settled one', () => {
       const markup = renderGroup({
         toolUseId: 'quiet-1',
         toolName: 'Bash',
@@ -497,7 +499,8 @@ describe('tool activity presentation', () => {
         status: 'pending',
         args: { command: 'sleep 600' },
       });
-      assert.match(markup, /aria-expanded="true"/);
+      assert.match(markup, /aria-expanded="false"/);
+      assert.doesNotMatch(markup, /aria-expanded="true"/);
     });
   });
 });

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -443,12 +443,8 @@ describe('tool activity presentation', () => {
     }
   });
 
-  // Expansion is Astryx's call, not the product's, and Astryx's default is
-  // collapsed: a group opens only when the reader opens it, whatever its rows
-  // are doing. The collapsed header shows the last call alone, so a group whose
-  // last call settles first may briefly project a settled icon while a sibling
-  // still runs — the density trade-off "one visual language" costs, and cheaper
-  // than groups that latch open for the rest of the session.
+  // Expansion is Astryx's call, not the product's, and its default is collapsed
+  // whatever the rows are doing.
   describe('group expansion follows Astryx', () => {
     const trailingSuccess = {
       toolUseId: 'ok-1',
@@ -473,8 +469,8 @@ describe('tool activity presentation', () => {
       assert.match(markup, /aria-expanded="false"/);
     });
 
-    // Two items on purpose: Astryx renders a lone call as a bare row that owns
-    // its own expansion, so group expansion is only observable from two up.
+    // Two items on purpose: a lone call is a bare row that owns its own
+    // expansion, so group expansion is only observable from two up.
     it('stays collapsed while a call in the group is still running', () => {
       const markup = renderGroup({
         toolUseId: 'live-1',
@@ -483,14 +479,11 @@ describe('tool activity presentation', () => {
         status: 'running',
         args: { command: 'npm test' },
       });
-      assert.match(markup, /aria-expanded="false"/);
       assert.doesNotMatch(markup, /aria-expanded="true"/);
     });
 
-    // `pending` is in flight too: tool_start opens a call there and it only
-    // reaches `running` once output arrives, so a tool that never streams stays
-    // pending for its whole life. It gets no special treatment either — the
-    // group is collapsed until the reader says otherwise.
+    // `pending` is in flight too: a tool that never streams stays pending for
+    // its whole life, and gets no special treatment either.
     it('stays collapsed when a parallel call is still pending behind a settled one', () => {
       const markup = renderGroup({
         toolUseId: 'quiet-1',
@@ -499,7 +492,6 @@ describe('tool activity presentation', () => {
         status: 'pending',
         args: { command: 'sleep 600' },
       });
-      assert.match(markup, /aria-expanded="false"/);
       assert.doesNotMatch(markup, /aria-expanded="true"/);
     });
   });

--- a/packages/ui/src/__tests__/tool-trow-stability.test.tsx
+++ b/packages/ui/src/__tests__/tool-trow-stability.test.tsx
@@ -28,7 +28,9 @@ describe('ToolTrow stable structure', () => {
     assert.match(one, /class="astryx-chat-tool-calls\b/);
     assert.match(one, /aria-expanded="false"/);
     assert.match(two, /class="astryx-chat-tool-calls\b/);
-    assert.match(two, /aria-expanded="true"/);
-    assert.match(two, />2 tool calls</);
+    // Both render collapsed — a second call does not open the group, and the
+    // collapsed group header projects the last call ("Grep") on its own.
+    assert.doesNotMatch(two, /aria-expanded="true"/);
+    assert.match(two, />Grep</);
   });
 });

--- a/packages/ui/src/__tests__/tool-trow-stability.test.tsx
+++ b/packages/ui/src/__tests__/tool-trow-stability.test.tsx
@@ -28,8 +28,7 @@ describe('ToolTrow stable structure', () => {
     assert.match(one, /class="astryx-chat-tool-calls\b/);
     assert.match(one, /aria-expanded="false"/);
     assert.match(two, /class="astryx-chat-tool-calls\b/);
-    // Both render collapsed — a second call does not open the group, and the
-    // collapsed group header projects the last call ("Grep") on its own.
+    // Still collapsed, and its header projects the last call on its own.
     assert.doesNotMatch(two, /aria-expanded="true"/);
     assert.match(two, />Grep</);
   });

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -296,23 +296,18 @@ export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
     ),
   }));
 
-  // Only reaches a group of two or more: Astryx renders a lone call as a bare
-  // row that owns its own expansion. A group opens while anything inside is
-  // still in flight, because the collapsed header projects the last call alone
-  // — with parallel calls the last one can settle first, and a collapsed green
-  // check would report the whole group done while a sibling still runs.
+  // Expansion is Astryx's own default — collapsed — and opening a group is the
+  // reader's move, never the turn's. Seeding it open from in-flight status only
+  // sets Astryx's initial state: the timeline key is deliberately stable so a
+  // disclosure survives mid-turn inserts (see timelineEntryKey), so such a group
+  // never re-collapses once its tools settle and every live turn leaves a trail
+  // of permanently open groups behind it.
   //
-  // This seeds Astryx's initial state only; the group does not re-collapse when
-  // its tools settle, since the timeline key is deliberately stable so a
-  // disclosure survives mid-turn inserts (see timelineEntryKey). So a group
-  // watched live stays open, while the same turn reloaded renders collapsed —
-  // work in progress stays visible, history starts tidy.
-  return (
-    <ChatToolCalls
-      calls={calls}
-      defaultIsExpanded={items.some((item) => isInFlightToolStatus(item.status))}
-    />
-  );
+  // The accepted cost: a collapsed header projects the last call alone, so with
+  // parallel calls the last one can settle first and the header may briefly show
+  // a settled icon while a sibling still runs. It resolves on its own as the
+  // group finishes, and expanding shows every row's real status.
+  return <ChatToolCalls calls={calls} />;
 }
 
 function astryxToolStatus(item: ToolActivityItem): ChatToolCallItem['status'] {

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -296,17 +296,10 @@ export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
     ),
   }));
 
-  // Expansion is Astryx's own default — collapsed — and opening a group is the
-  // reader's move, never the turn's. Seeding it open from in-flight status only
-  // sets Astryx's initial state: the timeline key is deliberately stable so a
-  // disclosure survives mid-turn inserts (see timelineEntryKey), so such a group
-  // never re-collapses once its tools settle and every live turn leaves a trail
-  // of permanently open groups behind it.
-  //
-  // The accepted cost: a collapsed header projects the last call alone, so with
-  // parallel calls the last one can settle first and the header may briefly show
-  // a settled icon while a sibling still runs. It resolves on its own as the
-  // group finishes, and expanding shows every row's real status.
+  // No defaultIsExpanded: opening a group is the reader's move. Seeding it open
+  // from in-flight status latches, since the prop is uncontrolled and the
+  // timeline key is stable (see timelineEntryKey). Cost: the collapsed header
+  // projects the last call, which can settle before a parallel sibling.
   return <ChatToolCalls calls={calls} />;
 }
 


### PR DESCRIPTION
## Summary

A turn with multiple tool calls rendered its group expanded, and it stayed expanded forever. `ToolTrow` seeded Astryx `ChatToolCalls` with `defaultIsExpanded={items.some(isInFlightToolStatus)}` so a live group would open, but that prop is uncontrolled: it sets the initial state only, and the timeline key is deliberately stable so a disclosure survives mid-turn inserts. A group opened while running therefore never re-collapsed, and every live turn left a trail of permanently open groups behind it.

This drops the custom seed and returns to Astryx's own default — collapsed. Opening a group is the reader's move, never the turn's.

The accepted trade-off, now recorded in the comment the workaround used to justify: a collapsed header projects the last call alone, so with parallel calls the last one can settle first and the header may briefly show a settled icon while a sibling still runs. It resolves as the group finishes, and expanding shows every row's real status.

## Verification

- `npm run test -w @maka/ui` — 341/341 pass. Three suites asserted the expanded-by-default seed and now assert the collapsed default: `tool-activity-presentation`, `tool-trow-stability`, `processing-block`.
- `node --test` on the desktop renderer contracts that touch this surface (`streaming-handoff`, `tool-error-collapse-contract`) — 12/12 pass.
- `npm run typecheck`, `npm run format`, `npm run lint` — clean.
- `apps/desktop/e2e/disclosure-output.spec.ts` and the `fixtures.ts` readiness selector already gate on a collapsed row (single call), so they are unaffected. The Storybook stories in `packages/ui/stories/tool-activity.stories.tsx` render settled items and already rendered collapsed.
- Not run: full `npm run test -w @maka/desktop` is green except 14 pre-existing failures in project-root/workspace-picker suites, which resolve macOS temp paths and never import the UI package; Playwright E2E was not run locally.
