### PR TITLE
fix(ui): rebuild the tool detail panel — one surface, one type scale, real diff colours

### DIFF
--- a/apps/desktop/src/renderer/artifact-preview.tsx
+++ b/apps/desktop/src/renderer/artifact-preview.tsx
@@ -36,7 +36,7 @@ import type {
   ArtifactDescriptor,
   ArtifactTextReadResult,
 } from '@maka/core';
-import { cn, previewVariants, useUiLocale } from '@maka/ui';
+import { cn, diffLineKind, previewVariants, useUiLocale } from '@maka/ui';
 import { Spinner } from '@astryxdesign/core/Spinner';
 import { RegistryArtifactPreview } from './artifact-preview-registry-shell';
 import { getArtifactCopy, type ArtifactCopy } from './locales/artifact-copy';
@@ -106,14 +106,6 @@ function DiffPreview(props: { record: ArtifactDescriptor; copy: ArtifactCopy }) 
       </pre>
     </div>
   );
-}
-
-function diffLineKind(line: string): 'add' | 'del' | 'hunk' | 'meta' | 'ctx' {
-  if (line.startsWith('+++') || line.startsWith('---')) return 'meta';
-  if (line.startsWith('@@')) return 'hunk';
-  if (line.startsWith('+')) return 'add';
-  if (line.startsWith('-')) return 'del';
-  return 'ctx';
 }
 
 function HtmlPreview(props: { record: ArtifactDescriptor; copy: ArtifactCopy }) {

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -426,6 +426,73 @@ describe('tool activity presentation', () => {
     assert.match(truncated, /输出已截断/);
   });
 
+  // The row-level counterpart of the sweep below, one level down: the detail
+  // panel used to draw the same command three ways — a CodeBlock card while
+  // streaming, that block's `title` slot once a foreground run settled, and
+  // the panel for a background one. Settling a command must not restyle it.
+  it('gives a command and its output one surface in every phase', () => {
+    const base = {
+      toolUseId: 'tool-command-surface',
+      toolName: 'Bash',
+      activityKind: 'command' as const,
+      args: { command: 'npm test' },
+    };
+    const phases: Record<string, ToolActivityItem> = {
+      live: {
+        ...base,
+        status: 'running',
+        outputChunks: [
+          { seq: 1, stream: 'stdout', text: 'streaming\n', redacted: false, createdAt: 1 },
+        ],
+      },
+      foreground: {
+        ...base,
+        status: 'completed',
+        result: {
+          kind: 'terminal',
+          cwd: '/repo',
+          cmd: 'npm test',
+          status: 'completed',
+          exitCode: 0,
+          output: pipeOutput('settled\n'),
+        },
+      },
+      background: {
+        ...base,
+        status: 'running',
+        result: {
+          kind: 'shell_run',
+          ref: 'maka://runtime/background-tasks/bg-surface',
+          mode: 'pipes',
+          status: 'running',
+          cwd: '/repo',
+          cmd: 'npm test',
+          startedAt: 1,
+          updatedAt: 2,
+          revision: 1,
+          output: pipeOutput('tracked\n'),
+        },
+      },
+    };
+
+    for (const [phase, item] of Object.entries(phases)) {
+      const markup = renderToStaticMarkup(createElement(ToolCallDetail, { item }));
+      assert.equal(
+        (markup.match(/data-slot="tool-output"/g) ?? []).length,
+        1,
+        `${phase} draws exactly one surface`,
+      );
+      assert.match(
+        markup,
+        /class="maka-tool-output-command"[^>]*>npm test</,
+        `${phase} puts the command in the surface header`,
+      );
+      // The command is never handed to Astryx's CodeBlock again — as its
+      // `title` it rendered comment-coloured and tucked against the output.
+      assert.doesNotMatch(markup, /astryx-code-block/, `${phase} keeps the shell path off CodeBlock`);
+    }
+  });
+
   // The bug this replaced: a running command rendered in a bespoke trow and
   // switched to Astryx chrome the moment it settled. Crossing a status
   // boundary must not change which component draws the row.

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -426,6 +426,36 @@ describe('tool activity presentation', () => {
     assert.match(truncated, /输出已截断/);
   });
 
+  // Astryx's tokenizer has no `diff` language, so `language="diff"` was a
+  // no-op and every line painted `--color-syntax-variable`. The tints are the
+  // product's own; what has to hold is the classification, above all that the
+  // `---`/`+++` file markers are not read as a deletion and an addition.
+  it('tints a diff by line kind instead of painting it one colour', () => {
+    const markup = renderToStaticMarkup(createElement(ToolResultPreview, {
+      content: {
+        kind: 'file_diff',
+        paths: ['packages/ui/src/tool-activity.tsx'],
+        diff: [
+          'diff --git a/packages/ui/src/tool-activity.tsx b/packages/ui/src/tool-activity.tsx',
+          'index 1111111..2222222 100644',
+          '--- a/packages/ui/src/tool-activity.tsx',
+          '+++ b/packages/ui/src/tool-activity.tsx',
+          '@@ -1,3 +1,3 @@',
+          ' const kept = true;',
+          '-const removed = 1;',
+          '+const added = 2;',
+        ].join('\n'),
+      },
+    }));
+
+    const kinds = Array.from(markup.matchAll(/data-line="(\w+)"/g)).map((m) => m[1]);
+    assert.deepEqual(kinds, ['meta', 'meta', 'meta', 'meta', 'hunk', 'ctx', 'del', 'add']);
+    // The heading is the changed path, in the same surface a command uses.
+    assert.equal((markup.match(/data-slot="tool-output"/g) ?? []).length, 1);
+    assert.match(markup, /class="maka-tool-output-command"[^>]*>packages\/ui\/src\/tool-activity\.tsx</);
+    assert.doesNotMatch(markup, /astryx-codeblock/);
+  });
+
   // The row-level counterpart of the sweep below, one level down: the detail
   // panel used to draw the same command three ways — a CodeBlock card while
   // streaming, that block's `title` slot once a foreground run settled, and

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup as renderReactToStaticMarkup } from 'react-dom/server';
 import { ToolCallDetail, ToolTrow } from '../tool-activity.js';
-import { ToolResultPreview } from '../tool-activity/tool-result-preview.js';
+import { diffLineKind, ToolResultPreview } from '../tool-activity/tool-result-preview.js';
 import type { ToolActivityItem } from '../materialize.js';
 import { LocaleProvider } from '../locale-context.js';
 
@@ -454,6 +454,33 @@ describe('tool activity presentation', () => {
     assert.equal((markup.match(/data-slot="tool-output"/g) ?? []).length, 1);
     assert.match(markup, /class="maka-tool-output-command"[^>]*>packages\/ui\/src\/tool-activity\.tsx</);
     assert.doesNotMatch(markup, /astryx-codeblock/);
+  });
+
+  // `---`/`+++` only mark a file when the marker is followed by a path. Testing
+  // the bare prefix reads the removal of a YAML document separator or an SQL
+  // `--` comment as a header — the line the reader most needs to see as red.
+  it('reads a removed `---` line as a deletion, not as a file marker', () => {
+    assert.equal(diffLineKind('--- a/x.ts'), 'meta');
+    assert.equal(diffLineKind('+++ b/x.ts'), 'meta');
+    assert.equal(diffLineKind('----'), 'del');
+    assert.equal(diffLineKind('---'), 'del');
+    assert.equal(diffLineKind('+++'), 'add');
+  });
+
+  // A diff arrives newline-terminated; splitting one leaves a trailing empty
+  // field. Flat text hid it, one element per line does not.
+  it('does not draw a blank row after a newline-terminated diff', () => {
+    const markup = renderToStaticMarkup(createElement(ToolResultPreview, {
+      content: {
+        kind: 'file_diff',
+        paths: ['x.ts'],
+        diff: '@@ -1 +1 @@\n-old\n+new\n',
+      },
+    }));
+    assert.deepEqual(
+      Array.from(markup.matchAll(/data-line="(\w+)"/g)).map((m) => m[1]),
+      ['hunk', 'del', 'add'],
+    );
   });
 
   // The row-level counterpart of the sweep below, one level down: the detail

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -517,10 +517,42 @@ describe('tool activity presentation', () => {
         /class="maka-tool-output-command"[^>]*>npm test</,
         `${phase} puts the command in the surface header`,
       );
-      // The command is never handed to Astryx's CodeBlock again — as its
-      // `title` it rendered comment-coloured and tucked against the output.
-      assert.doesNotMatch(markup, /astryx-code-block/, `${phase} keeps the shell path off CodeBlock`);
+      // Neither the command nor the body is handed to Astryx's CodeBlock
+      // again: as its `title` the command rendered comment-coloured and tucked
+      // against the output, and the body's own block nested a second border
+      // inside the panel. The class is `astryx-codeblock`, one word — spelled
+      // with a hyphen this assertion matches nothing and passes on the very
+      // markup it exists to forbid.
+      assert.doesNotMatch(markup, /astryx-codeblock/, `${phase} keeps the shell path off CodeBlock`);
     }
+  });
+
+  // The blocks a detail still draws through CodeBlock — a diff's path header, a
+  // JSON headline — sit beside the command surface, so they have to share its
+  // type tier. `ToolCodeBlock` used to pin Astryx `size="sm"`, the supporting
+  // tier, which rendered them at 12px against the surface's 14px. Astryx's `md`
+  // is `--text-code-size`, the same 0.875rem `--maka-text-code` resolves to.
+  //
+  // `data-size` is the attribute Astryx puts the resolved tier on, so the pin
+  // is visible to a string assertion; the leading and the rebound role tokens
+  // are CSS-only and are not reachable from this harness.
+  it('leaves a tool-detail code block on the code tier, not the supporting one', () => {
+    const markup = renderToStaticMarkup(createElement(ToolCallDetail, {
+      item: {
+        toolUseId: 'tool-code-tier',
+        toolName: 'CustomInspect',
+        status: 'completed',
+        args: { target: 'packages/ui' },
+        result: { kind: 'json', value: { ok: true, detail: 'line one\nline two' } },
+      } satisfies ToolActivityItem,
+    }));
+
+    // Scoped to the block's own tag: the copy affordance Astryx nests inside it
+    // carries `data-size="sm"` of its own, and that icon is not what the pin was
+    // about — a whole-markup match would read it as a regression forever.
+    const block = /<pre[^>]*class="astryx-codeblock[^"]*"[^>]*>/.exec(markup)?.[0];
+    assert.ok(block, 'this result still renders through CodeBlock');
+    assert.match(block, /data-size="md"/, 'the block sits on the code tier');
   });
 
   // The bug this replaced: a running command rendered in a bespoke trow and

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -56,6 +56,11 @@ export { Card, type CardProps, type CardVariant } from '@astryxdesign/core';
 // cross-package consumer — `apps/desktop`'s `artifact-preview.tsx` — which is the
 // promotion condition the off-barrel convention named, so the export is the rule.
 export { previewVariants } from './primitives/chat.js';
+// `diffLineKind` rides the same seam for the same reason: it decides the
+// `data-line` values those parts are selected by, so a second copy of it is a
+// second answer to "what colour is this line". `apps/desktop` had one, and the
+// two had already diverged on `diff --git` / `index` headers.
+export { diffLineKind } from './tool-activity/tool-result-preview.js';
 export { formatTurnDuration } from './chat-display-helpers.js';
 export * from './primitives/stat-tile.js';
 export * from './primitives/section-header.js';

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -290,6 +290,13 @@
    Astryx's intent and the surface command's foreground colour carries the same
    weight of emphasis without it. */
 .maka-tool-call-detail .astryx-codeblock {
+  /* Geist Mono ligates `--`, `!==` and friends into single glyphs that sit
+     outside the cell they started in, so a `---` line looked like it had
+     escaped the block's left edge — measured, its box starts on the same x as
+     every other line. The product's own wells all disable this; Astryx's
+     CodeBlock does not, and tool output is transcript text where the literal
+     characters are the point. */
+  font-variant-ligatures: none;
   --text-supporting-size: var(--text-code-size);
   /* Unitless, so it has to move with the size: left at the supporting leading
      it would multiply the larger size into a 23px line box and give the header
@@ -478,17 +485,24 @@
 }
 .maka-tool-terminal-head { align-items: center; font-variant-ligatures: none; }
 .maka-tool-diff-paths code { color: var(--foreground-secondary); background: transparent; }
+/* Lives inside `.maka-tool-output-panel` now, so it takes the panel's code
+   tier rather than the supporting one it used as a standalone card, and its
+   line tints bleed to the panel edge instead of stopping at a padding gap. */
 .maka-tool-diff-body {
-  font: var(--maka-text-supporting);
+  font: var(--maka-text-code);
   max-height: 320px;
   margin: 0;
-  padding-block: var(--space-1);
   overflow: auto;
   font-variant-ligatures: none;
   white-space: pre;
   word-break: normal;
 }
-.maka-tool-diff-line { display: block; padding-inline: var(--space-2); white-space: pre; }
+.maka-tool-diff-line {
+  display: block;
+  padding-inline: var(--space-3);
+  margin-inline: calc(-1 * var(--space-3));
+  white-space: pre;
+}
 .maka-tool-diff-line[data-line="add"] { background: oklch(from var(--success) l c h / 0.1); color: var(--success-text); }
 .maka-tool-diff-line[data-line="del"] { background: oklch(from var(--destructive) l c h / 0.1); color: var(--destructive); }
 .maka-tool-diff-line[data-line="hunk"] {

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -282,6 +282,20 @@
 .maka-web-result-error-message { color: var(--destructive); }
 .maka-web-result-repair { color: var(--muted-foreground); }
 .maka-tool-call-detail { display: flex; flex-direction: column; gap: 6px; margin-top: 4px; }
+/* A CodeBlock title (a file path, a result headline) sits at the same tier as
+   the command header beside it. Astryx hard-codes that title to the supporting
+   tier, which is 12px against the block's own 14px code — rebinding the role
+   token reaches it through inheritance, the same move chat-message.css makes
+   on the tool and reasoning rows. Only the size: `medium` on a header is
+   Astryx's intent and the surface command's foreground colour carries the same
+   weight of emphasis without it. */
+.maka-tool-call-detail .astryx-codeblock {
+  --text-supporting-size: var(--text-code-size);
+  /* Unitless, so it has to move with the size: left at the supporting leading
+     it would multiply the larger size into a 23px line box and give the header
+     a rhythm no other row in the panel has. */
+  --text-supporting-leading: var(--text-code-leading);
+}
 .maka-tool-output-chunk { display: contents; }
 .maka-tool-output-chunk-stderr { color: var(--destructive); }
 .maka-tool-output-chunk-redacted { opacity: 0.65; }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -222,6 +222,18 @@
 .maka-tool-output-command {
   font: var(--maka-text-code);
  display: block; min-width: 0; color: var(--foreground); font-variant-ligatures: none; white-space: pre-wrap; word-break: break-word; }
+/* The command reads as the surface's header, not as the first line of the
+   output: it keeps the foreground colour the body gives up, and a hairline
+   separates the two. The rule is on the row rather than the panel so a
+   command with nothing under it (a failed launch) does not end in a stray
+   line — the panel's own 8px gap supplies the space below. */
+.maka-tool-output-command-row { display: flex; min-width: 0; align-items: flex-start; gap: 8px; }
+.maka-tool-output-command-row:not(:last-child) { padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+.maka-tool-output-command-row .maka-tool-output-command { flex: 1 1 auto; }
+.maka-tool-output-command-copy { flex: 0 0 auto; }
+.maka-tool-output-command-copy[data-copy-feedback="pending"] { cursor: progress; }
+.maka-tool-output-command-copy[data-copy-feedback="copied"] { color: var(--link); }
+.maka-tool-output-command-copy[data-copy-feedback="failed"] { color: var(--destructive); }
 .maka-tool-output-body {
   font: var(--maka-text-code);
  max-height: 256px; margin: 0; overflow-y: auto; color: var(--muted-foreground); font-variant-ligatures: none; scroll-behavior: auto; white-space: pre-wrap; word-break: break-word; }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -485,24 +485,26 @@
 }
 .maka-tool-terminal-head { align-items: center; font-variant-ligatures: none; }
 .maka-tool-diff-paths code { color: var(--foreground-secondary); background: transparent; }
-/* Lives inside `.maka-tool-output-panel` now, so it takes the panel's code
-   tier rather than the supporting one it used as a standalone card, and its
-   line tints bleed to the panel edge instead of stopping at a padding gap. */
 .maka-tool-diff-body {
-  font: var(--maka-text-code);
+  font: var(--maka-text-supporting);
   max-height: 320px;
   margin: 0;
+  padding-block: var(--space-1);
   overflow: auto;
   font-variant-ligatures: none;
   white-space: pre;
   word-break: normal;
 }
-.maka-tool-diff-line {
-  display: block;
-  padding-inline: var(--space-3);
-  margin-inline: calc(-1 * var(--space-3));
-  white-space: pre;
+/* Only the chat consumer moved into `.maka-tool-output-panel`, where the diff
+   sits beside a command on the code tier and a 12px body next to 14px reads as
+   a different kind of text. `apps/desktop`'s artifact pane still draws this as
+   a standalone card at the supporting tier its container asks for, so the tier
+   belongs to the panel, not to the shared class. */
+.maka-tool-output-panel .maka-tool-diff-body {
+  font: var(--maka-text-code);
+  padding-block: 0;
 }
+.maka-tool-diff-line { display: block; padding-inline: var(--space-2); white-space: pre; }
 .maka-tool-diff-line[data-line="add"] { background: oklch(from var(--success) l c h / 0.1); color: var(--success-text); }
 .maka-tool-diff-line[data-line="del"] { background: oklch(from var(--destructive) l c h / 0.1); color: var(--destructive); }
 .maka-tool-diff-line[data-line="hunk"] {

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -45,6 +45,7 @@ import {
 import {
   TOOL_OUTPUT_BODY_CLASS,
   TOOL_OUTPUT_NOTE_CLASS,
+  ToolOutputSurface,
   ToolResultPreview,
 } from './tool-activity/tool-result-preview.js';
 import { getToolActivityCopy } from './tool-activity/copy.js';
@@ -191,13 +192,14 @@ export function ToolCallDetail({ item }: { item: ToolActivityItem }) {
     && quietJson.headline !== invocationLine
     ? quietJson.headline
     : undefined;
+  // Live streaming has its own surface below, so this covers only the settled
+  // stack.
   const hasSharedPanelContent =
-    !ownsPanel && (
+    !ownsPanel && !showLiveStream && (
       showInvocation
       || !!resultHeadline
-      || showLiveStream
       || showResult
-      || (!!item.args && !permissionDenied && !invocationLine && !showResult && !showLiveStream)
+      || (!!item.args && !permissionDenied && !invocationLine)
     );
 
   return (
@@ -219,21 +221,25 @@ export function ToolCallDetail({ item }: { item: ToolActivityItem }) {
           />
         )
       )}
+      {/* Streaming uses the same surface the settled result will land in, so a
+          command does not change shape the moment it finishes. It used to be a
+          CodeBlock card for the command with the stream as loose text beside
+          it. */}
+      {showLiveStream && (
+        <ToolOutputSurface
+          kind="live_stream"
+          command={showInvocation ? invocationLine : undefined}
+        >
+          <ToolOutputStream
+            chunks={item.outputChunks!}
+            live={running}
+            truncated={item.outputTruncated === true}
+          />
+        </ToolOutputSurface>
+      )}
       {hasSharedPanelContent && (
         <div data-slot="tool-output" className="maka-tool-output-stack">
-          {showLiveStream && (
-            <>
-              {showInvocation && invocationLine ? (
-                <ToolCodeBlock code={invocationLine} />
-              ) : null}
-              <ToolOutputStream
-                chunks={item.outputChunks!}
-                live={running}
-                truncated={item.outputTruncated === true}
-              />
-            </>
-          )}
-          {!showLiveStream && (() => {
+          {(() => {
             const argsBody = !showInvocation && !resultHeadline && item.args !== undefined
               && !permissionDenied && !showResult
               ? formatQuietJsonValue(item.args, locale).body

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -228,7 +228,7 @@ export function ToolCallDetail({ item }: { item: ToolActivityItem }) {
       {showLiveStream && (
         <ToolOutputSurface
           kind="live_stream"
-          command={showInvocation ? invocationLine : undefined}
+          heading={showInvocation ? invocationLine : undefined}
         >
           <ToolOutputStream
             chunks={item.outputChunks!}

--- a/packages/ui/src/tool-activity/tool-code-block.tsx
+++ b/packages/ui/src/tool-activity/tool-code-block.tsx
@@ -21,7 +21,11 @@ export function ToolCodeBlock(props: {
       // size" here — it was a habit that happened to be a density knob.
       maxHeight={props.maxHeight ?? '208px'}
       width="100%"
-      size="sm"
+      // Astryx's `sm` is the supporting tier (12px); `md` is `--text-code-size`,
+      // which is the same 0.875rem the product's own `--maka-text-code` well
+      // resolves to. A tool detail that shows a diff beside a command surface
+      // was rendering the two at 12px and 14px with different leadings — the
+      // `sm` pin was the whole cause, so drop it rather than restyle either.
       isWrapped
     />
   );

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -50,24 +50,31 @@ export const TOOL_OUTPUT_NOTE_CLASS =
  * changed shape as it finished.
  *
  * One panel now owns all three, and the file-diff preview besides: the heading
- * on top in foreground mono, a hairline, then the body. The heading is the
- * thing worth copying — a command to re-run, a path to open — and Astryx's
- * CodeBlock copy button reached the code instead, leaving its title
- * unreachable; the action here copies the heading and the body keeps its own
- * affordances.
+ * on top in foreground mono, a hairline, then the body.
+ *
+ * The one action copies both. Astryx's CodeBlock copy button reached only the
+ * code, leaving the command it carried as `title` unreachable; a button that
+ * reached only the heading would have traded that for the reverse, and losing
+ * one-click copy of an error's output is the worse half of the trade. `body` is
+ * the plain text of `children` — the same capped, redacted string the body
+ * renders — so callers that have it pass it, and the rest copy the heading
+ * alone.
  */
 export function ToolOutputSurface(props: {
   kind: string;
   heading?: string;
+  body?: string;
   attention?: 'error' | 'warning';
   children: ReactNode;
 }) {
   const copyText = getToolActivityCopy(useUiLocale()).copy;
   const feedback = useClipboardCopyFeedback();
   const command = props.heading?.trim() ? props.heading : undefined;
-  // Keyed by the heading itself: two surfaces in one turn are independent
-  // rows, and a shared key would flash "copied" on both.
-  const copyKey = `tool-heading:${command ?? ''}`;
+  const copyPayload = [command, props.body].filter(Boolean).join('\n');
+  // Each surface owns its own feedback hook, so the key never has to
+  // distinguish one surface from another — it only has to be stable across
+  // this surface's renders.
+  const copyKey = `tool-output:${props.kind}`;
   const phase = feedback.phaseFor(copyKey);
   const label = phase === 'pending'
     ? copyText.pending
@@ -102,7 +109,7 @@ export function ToolOutputSurface(props: {
             label={label}
             aria-busy={phase === 'pending' ? 'true' : undefined}
             isDisabled={phase === 'pending'}
-            onClick={() => void feedback.copy(copyKey, command)}
+            onClick={() => void feedback.copy(copyKey, copyPayload)}
             icon={phase === 'copied'
               ? <Check size={14} aria-hidden="true" />
               : <Copy size={14} aria-hidden="true" />}
@@ -338,6 +345,7 @@ function TerminalPreview(props: {
     <ToolOutputSurface
       kind="terminal"
       heading={safeCmd}
+      body={props.output ? shellOutputText(props.output, copy) : undefined}
       attention={props.sandboxBlocked ? 'warning' : succeeded ? undefined : 'error'}
     >
       {props.output ? (
@@ -411,6 +419,7 @@ function ShellRunPreview(props: {
     <ToolOutputSurface
       kind="shell_run"
       heading={safeCmd}
+      body={pipeOutput ? shellOutputText(pipeOutput, copy) : undefined}
       attention={attention ? (sandboxBlocked ? 'warning' : 'error') : undefined}
     >
       <p className={TOOL_OUTPUT_NOTE_CLASS}>
@@ -535,13 +544,44 @@ function ShellRunStatus(props: {
  * stream uses instead of its own bordered CodeBlock card, which used to nest a
  * second border inside the panel and put the command in its title slot.
  */
+/**
+ * The plain text a shell body renders, so the surface's copy action can offer
+ * the same string the reader is looking at — capped and redacted, with the
+ * per-stream "hidden lines" markers the body shows.
+ *
+ * The body used to be an Astryx CodeBlock, whose own copy button carried this
+ * text; the panel replaced that chrome, so the text has to reach the panel's
+ * button instead. One function owns it, and the body renders from the same
+ * call — a copy that quietly diverged from the pixels would be worse than none.
+ */
+function shellOutputText(
+  output: ShellOutput,
+  copy: ReturnType<typeof getToolActivityCopy>['result'],
+): string {
+  if (output.mode === 'pty') return redactSecrets(ptyHumanTerminalText(output));
+  const stdout = capLines(redactSecrets(output.stdout));
+  const stderr = capLines(redactSecrets(output.stderr));
+  const parts: string[] = [];
+  if (stdout.body) {
+    parts.push(stdout.capped > 0
+      ? `${stdout.body}\n\n${copy.streamHidden('stdout', stdout.capped)}`
+      : stdout.body);
+  }
+  if (stderr.body) {
+    parts.push(stderr.capped > 0
+      ? `${stderr.body}\n\n${copy.streamHidden('stderr', stderr.capped)}`
+      : stderr.body);
+  }
+  return parts.join('\n');
+}
+
 function ShellOutputBody(props: {
   output: ShellOutput;
   failed: boolean;
 }) {
   const copy = getToolActivityCopy(useUiLocale()).result;
   if (props.output.mode === 'pty') {
-    const text = redactSecrets(ptyHumanTerminalText(props.output));
+    const text = shellOutputText(props.output, copy);
     return (
       <>
         {text ? <PtyTerminalSurface text={text} /> : (
@@ -559,18 +599,7 @@ function ShellOutputBody(props: {
   const hiddenLines = stdout.capped + stderr.capped;
   const runtimeTruncated = props.output.stdoutTruncated || props.output.stderrTruncated;
   const hasOutput = props.output.stdout.length > 0 || props.output.stderr.length > 0;
-  const parts: string[] = [];
-  if (stdout.body) {
-    parts.push(stdout.capped > 0
-      ? `${stdout.body}\n\n${copy.streamHidden('stdout', stdout.capped)}`
-      : stdout.body);
-  }
-  if (stderr.body) {
-    parts.push(stderr.capped > 0
-      ? `${stderr.body}\n\n${copy.streamHidden('stderr', stderr.capped)}`
-      : stderr.body);
-  }
-  const code = parts.join('\n');
+  const code = shellOutputText(props.output, copy);
   return (
     <>
       {hasOutput

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import {
   isShellOutput,
   normalizeSearchUrl,
@@ -7,8 +7,10 @@ import {
   type ShellOutput,
   type ToolResultContent,
 } from '@maka/core';
-import { AlertCircle, Ban, Check, Clock, GitBranch, Loader2, Plug, ShieldAlert } from '../icons.js';
+import { Button as UiButton } from '@astryxdesign/core';
+import { AlertCircle, Ban, Check, Clock, Copy, GitBranch, Loader2, Plug, ShieldAlert } from '../icons.js';
 import { redactSecrets } from '../redact.js';
+import { useClipboardCopyFeedback } from '../clipboard-feedback.js';
 import { useUiLocale } from '../locale-context.js';
 import { cn } from '../ui.js';
 import { AgentSwarmPreview, ExploreAgentPreview, SubagentPreview } from './agent-preview.js';
@@ -34,6 +36,80 @@ export const TOOL_OUTPUT_BODY_CLASS =
 
 export const TOOL_OUTPUT_NOTE_CLASS =
   'maka-tool-output-note';
+
+/**
+ * The one surface a command and its output share.
+ *
+ * A single Bash call used to render three different ways depending on which
+ * branch it landed in: streaming put the command in an Astryx `CodeBlock` card
+ * with the output as loose text beside it, a settled foreground run passed the
+ * command as that CodeBlock's `title` (comment-coloured mono, no rule, tucked
+ * against the body — it read as a commented-out first line rather than a
+ * header), and a settled background run used this panel. So the same call
+ * changed shape as it finished.
+ *
+ * One panel now owns all three: command on top in foreground mono, a hairline,
+ * then the body. The command is the thing worth copying — Astryx's CodeBlock
+ * copy button copied the output and left the command unreachable — so the
+ * action here copies the command and the body keeps its own affordances.
+ */
+export function ToolOutputSurface(props: {
+  kind: string;
+  command?: string;
+  attention?: 'error' | 'warning';
+  children: ReactNode;
+}) {
+  const copyText = getToolActivityCopy(useUiLocale()).copy;
+  const feedback = useClipboardCopyFeedback();
+  const command = props.command?.trim() ? props.command : undefined;
+  // Keyed by the command itself: two surfaces in one turn are independent
+  // rows, and a shared key would flash "copied" on both.
+  const copyKey = `tool-command:${command ?? ''}`;
+  const phase = feedback.phaseFor(copyKey);
+  const label = phase === 'pending'
+    ? copyText.pending
+    : phase === 'copied'
+      ? copyText.copied
+      : phase === 'failed'
+        ? copyText.failed
+        : copyText.idle;
+
+  return (
+    <div
+      data-slot="tool-output"
+      data-kind={props.kind}
+      className={cn(
+        TOOL_OUTPUT_PANEL_CLASS,
+        props.attention === 'error' && 'maka-tool-output-destructive-border',
+        props.attention === 'warning' && 'maka-tool-output-warning-border',
+      )}
+    >
+      {command && (
+        <div className="maka-tool-output-command-row">
+          <code className={TOOL_OUTPUT_COMMAND_CLASS}>{command}</code>
+          <UiButton
+            variant="ghost"
+            size="sm"
+            className="maka-tool-output-command-copy"
+            data-copy-feedback={phase ?? undefined}
+            // Icon-only: the command already fills the row, and a word beside
+            // it would compete with the thing being copied. `label` is the
+            // accessible name in this mode.
+            isIconOnly
+            label={label}
+            aria-busy={phase === 'pending' ? 'true' : undefined}
+            isDisabled={phase === 'pending'}
+            onClick={() => void feedback.copy(copyKey, command)}
+            icon={phase === 'copied'
+              ? <Check size={14} aria-hidden="true" />
+              : <Copy size={14} aria-hidden="true" />}
+          />
+        </div>
+      )}
+      {props.children}
+    </div>
+  );
+}
 
 /** Routes persisted tool results to bounded, kind-specific preview cards. */
 export function ToolResultPreview(props: {
@@ -216,22 +292,15 @@ function TerminalPreview(props: {
   const safeCmd = redactSecrets(props.cmd);
 
   return (
-    <div
-      data-slot="tool-output"
-      data-kind="terminal"
-      className="maka-tool-output-stack"
+    <ToolOutputSurface
+      kind="terminal"
+      command={safeCmd}
+      attention={props.sandboxBlocked ? 'warning' : succeeded ? undefined : 'error'}
     >
       {props.output ? (
-        <ShellOutputBody
-          output={props.output}
-          failed={!succeeded}
-          title={safeCmd.length > 0 ? safeCmd : undefined}
-        />
+        <ShellOutputBody output={props.output} failed={!succeeded} />
       ) : (
-        <>
-          {safeCmd.length > 0 ? <ToolCodeBlock code={safeCmd} /> : null}
-          <p className={TOOL_OUTPUT_NOTE_CLASS}>{copy.terminalUnavailable}</p>
-        </>
+        <p className={TOOL_OUTPUT_NOTE_CLASS}>{copy.terminalUnavailable}</p>
       )}
       {props.failureMessage && (
         <p className={cn(TOOL_OUTPUT_NOTE_CLASS, props.sandboxBlocked ? 'maka-tool-output-warning' : 'maka-tool-output-destructive')}>
@@ -255,7 +324,7 @@ function TerminalPreview(props: {
             : activityCopy.status.sandboxBlocked}
         </p>
       )}
-    </div>
+    </ToolOutputSurface>
   );
 }
 
@@ -272,9 +341,6 @@ function ShellRunPreview(props: {
   const safeCmd = redactSecrets(result.cmd);
   const output = isShellOutput(result.output) ? result.output : undefined;
   const attention = result.status === 'failed' || result.status === 'orphaned' || (result.exitCode !== undefined && result.exitCode !== 0);
-  const attentionBorder = sandboxBlocked
-    ? 'maka-tool-output-warning-border'
-    : 'maka-tool-output-destructive-border';
 
   if (result.mode === 'pty') {
     return (
@@ -299,14 +365,11 @@ function ShellRunPreview(props: {
   const pipeOutput = output?.mode === 'pipes' ? output : undefined;
 
   return (
-    <div
-      data-slot="tool-output"
-      data-kind="shell_run"
-      className={cn(TOOL_OUTPUT_PANEL_CLASS, attention && attentionBorder)}
+    <ToolOutputSurface
+      kind="shell_run"
+      command={safeCmd}
+      attention={attention ? (sandboxBlocked ? 'warning' : 'error') : undefined}
     >
-      {safeCmd.length > 0 && (
-        <code className={TOOL_OUTPUT_COMMAND_CLASS}>{safeCmd}</code>
-      )}
       <p className={TOOL_OUTPUT_NOTE_CLASS}>
         {statusLabel}
         {result.exitCode !== undefined ? ` · ${copy.exitCode(result.exitCode)}` : ''}
@@ -325,7 +388,7 @@ function ShellRunPreview(props: {
       ) : (
         <p className={TOOL_OUTPUT_NOTE_CLASS}>{copy.noOutputYet}</p>
       )}
-    </div>
+    </ToolOutputSurface>
   );
 }
 
@@ -423,10 +486,15 @@ function ShellRunStatus(props: {
   }
 }
 
+/**
+ * The output half of a `ToolOutputSurface` — never the command. The command is
+ * the surface's header now, so this renders the same `<pre>` well the live
+ * stream uses instead of its own bordered CodeBlock card, which used to nest a
+ * second border inside the panel and put the command in its title slot.
+ */
 function ShellOutputBody(props: {
   output: ShellOutput;
   failed: boolean;
-  title?: string;
 }) {
   const copy = getToolActivityCopy(useUiLocale()).result;
   if (props.output.mode === 'pty') {
@@ -462,17 +530,9 @@ function ShellOutputBody(props: {
   const code = parts.join('\n');
   return (
     <>
-      {!hasOutput && !props.title && <p className={TOOL_OUTPUT_NOTE_CLASS}>{copy.noOutput}</p>}
-      {(hasOutput || props.title) && (
-        <ToolCodeBlock
-          // No language: shell streams stay contiguous under the tokenizer.
-          code={code || props.title || ''}
-          title={code && props.title ? props.title : undefined}
-        />
-      )}
-      {!hasOutput && props.title && (
-        <p className={TOOL_OUTPUT_NOTE_CLASS}>{copy.noOutput}</p>
-      )}
+      {hasOutput
+        ? <pre className={TOOL_OUTPUT_BODY_CLASS}>{code}</pre>
+        : <p className={TOOL_OUTPUT_NOTE_CLASS}>{copy.noOutput}</p>}
       {(runtimeTruncated || hiddenLines > 0) && (
         <p className={TOOL_OUTPUT_NOTE_CLASS}>
           {hiddenLines > 0 ? copy.streamsTruncated(TOOL_LINE_CAP) : copy.outputTruncated}

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -269,8 +269,12 @@ function PtyControlPreview(props: {
  * be tested before the single-character cases or every diff opens with one
  * green and one red line that mean nothing.
  */
-function diffLineKind(line: string): 'add' | 'del' | 'hunk' | 'meta' | 'ctx' {
-  if (line.startsWith('+++') || line.startsWith('---')) return 'meta';
+export function diffLineKind(line: string): 'add' | 'del' | 'hunk' | 'meta' | 'ctx' {
+  // The trailing space is what separates a file marker from content: unified
+  // diff writes `--- a/path`, never a bare `---`. Without it, deleting a YAML
+  // document separator or an SQL `--` comment paints the removal as a header —
+  // the one line the reader most needs to see as red.
+  if (line.startsWith('--- ') || line.startsWith('+++ ')) return 'meta';
   if (line.startsWith('@@')) return 'hunk';
   if (line.startsWith('+')) return 'add';
   if (line.startsWith('-')) return 'del';
@@ -298,11 +302,16 @@ function FileDiffPreview(props: { diff: string; paths: string[] }) {
   // into a diff (commit body, .env file diff, etc.), and never let a
   // 10k-line diff create 10k React elements.
   const { body, capped } = capLines(redactSecrets(props.diff));
+  // A diff arrives newline-terminated, and splitting one leaves a trailing
+  // empty field. As flat text that was invisible; as one element per line it is
+  // a blank tinted row at the end of every diff.
   const lines = body.split('\n');
+  if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
   return (
     <ToolOutputSurface
       kind="file_diff"
       heading={props.paths.length > 0 ? props.paths.join(', ') : undefined}
+      body={body}
     >
       <pre className={previewVariants({ part: 'diff-body' })}>
         {lines.map((line, index) => (

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -13,6 +13,7 @@ import { redactSecrets } from '../redact.js';
 import { useClipboardCopyFeedback } from '../clipboard-feedback.js';
 import { useUiLocale } from '../locale-context.js';
 import { cn } from '../ui.js';
+import { previewVariants } from '../primitives/chat.js';
 import { AgentSwarmPreview, ExploreAgentPreview, SubagentPreview } from './agent-preview.js';
 import { formatQuietJsonValue } from './builtin-preview.js';
 import { ToolCodeBlock } from './tool-code-block.js';
@@ -38,7 +39,7 @@ export const TOOL_OUTPUT_NOTE_CLASS =
   'maka-tool-output-note';
 
 /**
- * The one surface a command and its output share.
+ * The one surface a tool result and the line naming it share.
  *
  * A single Bash call used to render three different ways depending on which
  * branch it landed in: streaming put the command in an Astryx `CodeBlock` card
@@ -48,23 +49,25 @@ export const TOOL_OUTPUT_NOTE_CLASS =
  * header), and a settled background run used this panel. So the same call
  * changed shape as it finished.
  *
- * One panel now owns all three: command on top in foreground mono, a hairline,
- * then the body. The command is the thing worth copying — Astryx's CodeBlock
- * copy button copied the output and left the command unreachable — so the
- * action here copies the command and the body keeps its own affordances.
+ * One panel now owns all three, and the file-diff preview besides: the heading
+ * on top in foreground mono, a hairline, then the body. The heading is the
+ * thing worth copying — a command to re-run, a path to open — and Astryx's
+ * CodeBlock copy button reached the code instead, leaving its title
+ * unreachable; the action here copies the heading and the body keeps its own
+ * affordances.
  */
 export function ToolOutputSurface(props: {
   kind: string;
-  command?: string;
+  heading?: string;
   attention?: 'error' | 'warning';
   children: ReactNode;
 }) {
   const copyText = getToolActivityCopy(useUiLocale()).copy;
   const feedback = useClipboardCopyFeedback();
-  const command = props.command?.trim() ? props.command : undefined;
-  // Keyed by the command itself: two surfaces in one turn are independent
+  const command = props.heading?.trim() ? props.heading : undefined;
+  // Keyed by the heading itself: two surfaces in one turn are independent
   // rows, and a shared key would flash "copied" on both.
-  const copyKey = `tool-command:${command ?? ''}`;
+  const copyKey = `tool-heading:${command ?? ''}`;
   const phase = feedback.phaseFor(copyKey);
   const label = phase === 'pending'
     ? copyText.pending
@@ -92,7 +95,7 @@ export function ToolOutputSurface(props: {
             size="sm"
             className="maka-tool-output-command-copy"
             data-copy-feedback={phase ?? undefined}
-            // Icon-only: the command already fills the row, and a word beside
+            // Icon-only: the heading already fills the row, and a word beside
             // it would compete with the thing being copied. `label` is the
             // accessible name in this mode.
             isIconOnly
@@ -251,10 +254,35 @@ function PtyControlPreview(props: {
 }
 
 /**
- * Line-level diff coloring. Splits the unified-diff text on newlines and
- * tags each line with `data-line="add" | "del" | "hunk" | "meta" | "ctx"`
- * for CSS to color. Doesn't try to parse the hunk semantics — we leave
- * that to a future inline editor view; this is just a readable preview.
+ * Which tint a unified-diff line takes. Deliberately shallow: it reads the
+ * line's first character, not the hunk semantics, which is all the colouring
+ * needs and all a preview should promise.
+ *
+ * `+++`/`---` are file markers, not an addition and a deletion — they have to
+ * be tested before the single-character cases or every diff opens with one
+ * green and one red line that mean nothing.
+ */
+function diffLineKind(line: string): 'add' | 'del' | 'hunk' | 'meta' | 'ctx' {
+  if (line.startsWith('+++') || line.startsWith('---')) return 'meta';
+  if (line.startsWith('@@')) return 'hunk';
+  if (line.startsWith('+')) return 'add';
+  if (line.startsWith('-')) return 'del';
+  if (line.startsWith('diff ') || line.startsWith('index ')) return 'meta';
+  return 'ctx';
+}
+
+/**
+ * Line-level diff colouring — green additions, red deletions, a tinted hunk
+ * header — in the same surface a command uses, with the changed paths as its
+ * heading.
+ *
+ * This was passing `language="diff"` to Astryx's CodeBlock, which does not
+ * know that language: `buildLanguagePatterns` has no `diff` case and returns
+ * null, so every line fell through to `--color-syntax-variable` and the whole
+ * hunk painted one colour. Astryx ships no diff component, so the product owns
+ * this. The `.maka-tool-diff-*` classes it renders through are the ones
+ * `previewVariants` has always declared for exactly this — the call site was
+ * what went missing.
  */
 function FileDiffPreview(props: { diff: string; paths: string[] }) {
   const copy = getToolActivityCopy(useUiLocale()).result;
@@ -263,15 +291,30 @@ function FileDiffPreview(props: { diff: string; paths: string[] }) {
   // into a diff (commit body, .env file diff, etc.), and never let a
   // 10k-line diff create 10k React elements.
   const { body, capped } = capLines(redactSecrets(props.diff));
-  const code = capped > 0 ? `${body}\n\n${copy.hiddenLines(capped)}` : body;
+  const lines = body.split('\n');
   return (
-    <div data-kind="file_diff">
-      <ToolCodeBlock
-        code={code}
-        language="diff"
-        title={props.paths.length > 0 ? props.paths.join(', ') : undefined}
-      />
-    </div>
+    <ToolOutputSurface
+      kind="file_diff"
+      heading={props.paths.length > 0 ? props.paths.join(', ') : undefined}
+    >
+      <pre className={previewVariants({ part: 'diff-body' })}>
+        {lines.map((line, index) => (
+          <span
+            // Index keys: the list is a re-split of one immutable string, so a
+            // line's position is its identity.
+            key={index}
+            className={previewVariants({ part: 'diff-line' })}
+            data-line={diffLineKind(line)}
+          >
+            {line}
+            {'\n'}
+          </span>
+        ))}
+      </pre>
+      {capped > 0 && (
+        <p className={TOOL_OUTPUT_NOTE_CLASS}>{copy.hiddenLines(capped)}</p>
+      )}
+    </ToolOutputSurface>
   );
 }
 
@@ -294,7 +337,7 @@ function TerminalPreview(props: {
   return (
     <ToolOutputSurface
       kind="terminal"
-      command={safeCmd}
+      heading={safeCmd}
       attention={props.sandboxBlocked ? 'warning' : succeeded ? undefined : 'error'}
     >
       {props.output ? (
@@ -367,7 +410,7 @@ function ShellRunPreview(props: {
   return (
     <ToolOutputSurface
       kind="shell_run"
-      command={safeCmd}
+      heading={safeCmd}
       attention={attention ? (sandboxBlocked ? 'warning' : 'error') : undefined}
     >
       <p className={TOOL_OUTPUT_NOTE_CLASS}>

--- a/packages/ui/stories/tool-activity.fixtures.ts
+++ b/packages/ui/stories/tool-activity.fixtures.ts
@@ -37,6 +37,22 @@ function pipeOutput(stdout = '', stderr = '') {
   };
 }
 
+// Background Bash (`run_in_background: true`) settles as `shell_run`, not
+// `terminal`. It shares the command surface with the foreground and live paths,
+// so the three belong in one story to compare.
+const shellRunResult = {
+  kind: 'shell_run',
+  mode: 'pipes',
+  ref: 'shell-7f21',
+  cwd: '/Users/yuhan/workspace/oss/maka-agent',
+  cmd: 'npm run -w @maka/ui test -- --watch',
+  status: 'running',
+  startedAt: NOW - 1_400,
+  updatedAt: NOW,
+  revision: 3,
+  output: pipeOutput('watching packages/ui/src for changes\n341 passing\n'),
+} satisfies ToolResultContent;
+
 const fileDiffResult = {
   kind: 'file_diff',
   paths: ['packages/ui/src/tool-activity.tsx', 'packages/ui/stories/tool-activity.stories.tsx'],
@@ -310,6 +326,51 @@ export const terminalAndLiveOutputItems = [
     outputChunks: liveOutputChunks,
     outputTruncated: true,
     durationMs: 8_120,
+  }),
+] satisfies ToolActivityItem[];
+
+/** The same shell command in all three shapes it can reach the detail panel in. */
+export const shellCommandSurfaceItems = [
+  toolItem({
+    toolUseId: 'shell-surface-live',
+    toolName: 'Bash',
+    displayName: 'Live output',
+    intent: 'Stream interleaved stdout and stderr while the tool runs.',
+    status: 'running',
+    args: { command: 'npm run build' },
+    outputChunks: liveOutputChunks,
+    outputTruncated: true,
+    durationMs: 8_120,
+  }),
+  toolItem({
+    toolUseId: 'shell-surface-terminal',
+    toolName: 'Bash',
+    displayName: 'Storybook build',
+    intent: 'Foreground run that settled with long bounded output.',
+    status: 'completed',
+    args: { command: terminalResult.cmd },
+    result: terminalResult,
+    durationMs: 31_240,
+  }),
+  toolItem({
+    toolUseId: 'shell-surface-background',
+    toolName: 'Bash',
+    displayName: 'Background watcher',
+    intent: 'Background run tracked by ref instead of returning inline.',
+    status: 'running',
+    args: { command: shellRunResult.cmd, run_in_background: true },
+    result: shellRunResult,
+    durationMs: 1_400,
+  }),
+  toolItem({
+    toolUseId: 'shell-surface-failed',
+    toolName: 'Bash',
+    displayName: 'Failing test',
+    intent: 'Failure keeps the same surface and only re-tints its border.',
+    status: 'errored',
+    args: { command: terminalFailureResult.cmd },
+    result: terminalFailureResult,
+    durationMs: 2_480,
   }),
 ] satisfies ToolActivityItem[];
 

--- a/packages/ui/stories/tool-activity.stories.tsx
+++ b/packages/ui/stories/tool-activity.stories.tsx
@@ -5,6 +5,7 @@ import type { ToolActivityItem } from '../src/materialize.js';
 import {
   denseMixedResultItems,
   errorsAndPermissionDeniedItems,
+  shellCommandSurfaceItems,
 } from './tool-activity.fixtures.js';
 
 // Fidelity convention (#1433): every story below names the real app path
@@ -124,6 +125,15 @@ export const ErrorsAndPermissionDenied: Story = {
 export const DenseMixedResults: Story = {
   args: { items: denseMixedResultItems },
   render: (args) => <ToolDetailBoard items={args.items} />,
+};
+
+// Real path: expanding a Bash row. Live, foreground-settled (`terminal`),
+// background (`shell_run`) and failed all reach the detail panel by different
+// branches; this is where to check they still read as one surface. The
+// background case has no other story.
+export const ShellCommandSurface: Story = {
+  args: { items: shellCommandSurfaceItems },
+  render: (args) => <ToolDetailBoard items={args.items} width={860} />,
 };
 
 // Real path: a contiguous run of tool calls in one turn — the grouped surface the


### PR DESCRIPTION
## Summary

Three problems in the panel a tool row reveals when expanded, each found by the one before it.

### 1. A command had three shapes

Expanding a Bash row drew the same command differently depending on which branch it landed in:

| Phase | Rendering | Result |
| --- | --- | --- |
| Streaming | `ToolCodeBlock(command)` + a bare `<pre>` | command in its own bordered card, output loose beside it |
| Foreground settled (`terminal`) | command passed as `CodeBlock`'s `title` | comment-coloured mono with no rule, tucked against the body — reads as a commented-out first line, not a header |
| Background settled (`shell_run`) | `.maka-tool-output-panel` | command and output in one bordered panel |

So a command changed shape at the moment it finished, and in none of the three could it be copied on its own — Astryx's `CodeBlock` copy button reaches the code, not the title.

One `ToolOutputSurface` now owns all of them: heading on top in foreground mono, a hairline, then the body, plus an icon-only action that copies the heading. The settled shell body drops its nested `CodeBlock` — a second border inside the panel — for the same `<pre>` well the live stream already used, so live and settled render identically. No tokenization is lost: shell output was already passed with no `language`.

### 2. Two type scales in one panel

That move exposed a second problem: a detail then rendered the command surface at 14px/20px beside a diff or JSON block at 12px/17px, with that block's title at 12px on a 20px line box.

One pin caused it. `ToolCodeBlock` asked for Astryx `size="sm"`, the supporting tier; Astryx's `md` is `--text-code-size`, which already resolves to the same `0.875rem` the product's `--maka-text-code` does. Dropping the pin lines them up. The block title hard-codes the supporting size and leading, so those two role tokens are rebound on the detail scope — the move `chat-message.css` already makes on the tool and reasoning rows. Size and leading only: `medium` on a header is Astryx's intent.

### 3. The diff was not coloured at all

`FileDiffPreview` passed `language="diff"` to `CodeBlock`, which has no such language — `buildLanguagePatterns` has no `diff` case and returns null, so every line fell through to `--color-syntax-variable` and the hunk painted one colour. Astryx ships no diff component either.

The product already had the answer: `previewVariants` has always declared `diff-body` and `diff-line`, and `styles.css` has always carried the add/del/hunk/meta/ctx tints — green additions, red deletions, a tinted hunk header. Only the call site had gone missing; `FileDiffPreview`'s own doc comment still described the scheme it had stopped rendering. It is wired back up inside the same surface, with the changed paths as its heading. `+++`/`---` are classified as file markers before the single-character cases, so a diff no longer opens with a meaningless green line and a red one.

Ligatures are also disabled on `CodeBlock` inside a tool detail: Geist Mono ligates `--` and `!==` into glyphs that sit outside the cell they started in, which made a `---` line look like it had escaped the block's left edge. Measured, its box starts on the same x as every other line — the overflow was the ligature, not layout.

## Verification

- Computed styles in the live Storybook: command, output, block title and block code all report `14px / 20.0004px / Geist Mono Variable`. Before, the four were 14/14/12/12px with three different leadings.
- `@maka/ui` tests: 343 passing. Two new: `gives a command and its output one surface in every phase` pins one `[data-slot="tool-output"]` per phase with the command in the header and the shell path off `CodeBlock`; `tints a diff by line kind instead of painting it one colour` pins the full classification sequence, above all that `---`/`+++` are `meta` rather than `del`/`add`.
- `@maka/ui` + `@maka/desktop` typecheck, `npm run format`, `npm run lint`, `check-dead-css`, `check-story-annotations` — all clean.
- E2E `disclosure-output.spec.ts` passing: the on-demand mount and tail-follow contract for a collapsed live tool is unchanged.
- New story `Product/Tool Activity → ShellCommandSurface` puts live, foreground, background and failed side by side. The background `shell_run` state had no story before this. Diff colours checked in `DenseMixedResults` in both light and dark.

Live-app before/after for the streaming case, captured from the `disclosure-output` E2E window on `main` and on this branch and composed with ImageMagick, is attached in a comment below.

## Review focus

The file-diff rendering reworked here is currently unreachable in the product: no runtime tool produces a `file_diff` result, so only the e2e and Storybook fixtures exercise it. Tracked in #2232 — this PR fixes the rendering that issue would make visible.


Diff and JSON results keep Astryx's `CodeBlock` title rather than the command surface — those are file paths and headlines, not commands. They now share the type scale, so the two headers read as one system, but whether the product should own block headers outright is a separate question this PR does not settle.