### PR TITLE
fix(ui): draw the reasoning chevron from the Astryx icon registry

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-disclosure-chevron-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-disclosure-chevron-contract.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Disclosure chevron sizing contract.
+ *
+ * The Thinking row and the tool row draw the same Astryx registry chevron —
+ * that half is locked in packages/ui/src/__tests__/processing-block.test.tsx.
+ * A registry icon renders as `span > svg`, and chat-message.css is what pulls
+ * both halves down to 10x10 inside the 14px box. Miss either half on either
+ * row and the two chevrons stop matching: sizing only the svg leaves the
+ * wrapper at its own 0.75rem, and dropping a row from the selector list leaves
+ * that row's chevron at the icon's natural size.
+ *
+ * So this pins the outcome, not the wording: each row's chevron svg AND its
+ * wrapper are declared 10x10. Splitting the shared rule in two, reordering the
+ * selector list, or moving the arms between `:is()` and a plain list all stay
+ * green — restating one row at another size, or letting a row fall out
+ * entirely, does not.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { parseCssBlocks, readAllRendererCss, splitSelectorList, stripCssComments } from './css-test-helpers.js';
+
+/** The chevron sits last in the trigger; `svg` is the glyph, `> *` its wrapper. */
+const CHEVRON_PARTS = [
+  { name: 'svg', endsWith: 'span:last-child svg' },
+  { name: 'wrapper', endsWith: 'span:last-child > *' },
+] as const;
+
+const ROWS = ['.astryx-chat-reasoning', '.astryx-chat-tool-calls'] as const;
+
+/** Every selector declaring exactly a 10x10 box, `:is()` arms left intact —
+ *  a row inside `:is(a, b)` is covered by that selector just as a row named in
+ *  a comma list is, so membership is read off the selector text either way. */
+function tenBySelector(css: string): string[] {
+  const out: string[] = [];
+  for (const block of parseCssBlocks(css)) {
+    const last = (prop: string) =>
+      block.decls.filter((decl) => decl.prop === prop).at(-1)?.value;
+    if (last('width') !== '10px' || last('height') !== '10px') continue;
+    out.push(...splitSelectorList(block.rule));
+  }
+  return out;
+}
+
+describe('disclosure chevron sizing contract', () => {
+  it('sizes both the chevron svg and its wrapper to 10x10 on every disclosure row', async () => {
+    const selectors = tenBySelector(stripCssComments(await readAllRendererCss()));
+    assert.ok(selectors.length > 0, 'expected at least one 10x10 chevron rule');
+
+    for (const row of ROWS) {
+      for (const part of CHEVRON_PARTS) {
+        assert.ok(
+          selectors.some((selector) => selector.includes(row) && selector.endsWith(part.endsWith)),
+          `${row} must declare its chevron ${part.name} 10x10`,
+        );
+      }
+    }
+  });
+});

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -112,9 +112,11 @@
   margin-inline-start: auto;
 }
 
-.maka-turn .astryx-chat-reasoning [role="button"] > span:last-child svg,
-.maka-turn .astryx-chat-tool-calls [role="button"] > span:last-child svg,
-.maka-turn .astryx-chat-tool-calls [role="button"] > span:last-child > * {
+/* Both disclosure chevrons are now the same Astryx registry icon, which wraps
+   its svg in an `astryx-icon` span — so both need the wrapper (`> *`) and the
+   svg sized, not just the svg. */
+.maka-turn :is(.astryx-chat-reasoning, .astryx-chat-tool-calls) [role="button"] > span:last-child svg,
+.maka-turn :is(.astryx-chat-reasoning, .astryx-chat-tool-calls) [role="button"] > span:last-child > * {
   width: 10px;
   height: 10px;
 }

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -112,9 +112,8 @@
   margin-inline-start: auto;
 }
 
-/* Both disclosure chevrons are now the same Astryx registry icon, which wraps
-   its svg in an `astryx-icon` span — so both need the wrapper (`> *`) and the
-   svg sized, not just the svg. */
+/* Both chevrons are the same registry icon, which wraps its svg in a span —
+   so the wrapper (`> *`) needs sizing too, not just the svg. */
 .maka-turn :is(.astryx-chat-reasoning, .astryx-chat-tool-calls) [role="button"] > span:last-child svg,
 .maka-turn :is(.astryx-chat-reasoning, .astryx-chat-tool-calls) [role="button"] > span:last-child > * {
   width: 10px;

--- a/packages/ui/src/__tests__/processing-block.test.tsx
+++ b/packages/ui/src/__tests__/processing-block.test.tsx
@@ -126,6 +126,43 @@ describe('deep-thinking disclosure', () => {
     assert.doesNotMatch(markup, /data-slot="reasoning-disclosure"/);
   });
 
+  it('draws its chevron from the same Astryx icon registry as the tool rows', () => {
+    // One chevron authority. The ejected lab component used to hand-write its
+    // own 12-viewBox chevron at strokeWidth 1.5; the tool rows use Astryx
+    // `Icon icon="chevronDown"`, a 24-viewBox glyph at the theme's 1.75.
+    // chat-message.css forces both to 10x10, so the two identical-looking
+    // glyphs rendered at 1.25px and 0.73px of stroke — the reasoning chevron
+    // read visibly heavier.
+    // Comparing the rendered chevron markup pins the shared source: any
+    // divergence in viewBox, stroke width, or size class fails here.
+    const markup = renderToStaticMarkup(createElement(TurnView, {
+      turn: {
+        ...turnWithTools([
+          { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
+          { toolUseId: 'r2', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
+        ]),
+        timeline: [
+          { kind: 'thinking', text: 'private reasoning', messageId: 'a1' },
+          {
+            kind: 'tools',
+            items: [
+              { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
+              { toolUseId: 'r2', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
+            ],
+          },
+        ],
+      },
+    }));
+
+    const icons = markup.match(/<span[^>]*class="astryx-icon[^"]*"[^>]*>.*?<\/svg><\/span>/g) ?? [];
+    const chevrons = icons.filter((icon) => icon.includes('M6 9l6 6 6-6'));
+    assert.ok(chevrons.length >= 2, `expected reasoning + tool chevrons, got ${chevrons.length}`);
+    assert.equal(new Set(chevrons).size, 1, 'reasoning and tool chevrons must render identical markup');
+    assert.match(chevrons[0]!, /data-size="xsm"/);
+    assert.match(chevrons[0]!, /viewBox="0 0 24 24"/);
+    assert.doesNotMatch(markup, /viewBox="0 0 12 12"/);
+  });
+
   it('places assistant actions on ChatMessageMetadata, not a product Marker footer shell', () => {
     const markup = renderToStaticMarkup(createElement(TurnView, {
       turn: {

--- a/packages/ui/src/__tests__/processing-block.test.tsx
+++ b/packages/ui/src/__tests__/processing-block.test.tsx
@@ -127,14 +127,10 @@ describe('deep-thinking disclosure', () => {
   });
 
   it('draws its chevron from the same Astryx icon registry as the tool rows', () => {
-    // One chevron authority. The ejected lab component used to hand-write its
-    // own 12-viewBox chevron at strokeWidth 1.5; the tool rows use Astryx
-    // `Icon icon="chevronDown"`, a 24-viewBox glyph at the theme's 1.75.
-    // chat-message.css forces both to 10x10, so the two identical-looking
-    // glyphs rendered at 1.25px and 0.73px of stroke — the reasoning chevron
-    // read visibly heavier.
-    // Comparing the rendered chevron markup pins the shared source: any
-    // divergence in viewBox, stroke width, or size class fails here.
+    // The ejected lab component used to hand-write its own 12-viewBox chevron,
+    // which drew a heavier stroke than the tool rows' registry glyph once
+    // chat-message.css forced both to 10x10. Comparing the rendered markup
+    // pins the shared source: a divergent viewBox or size class fails here.
     const markup = renderToStaticMarkup(createElement(TurnView, {
       turn: {
         ...turnWithTools([

--- a/packages/ui/src/__tests__/processing-block.test.tsx
+++ b/packages/ui/src/__tests__/processing-block.test.tsx
@@ -129,8 +129,7 @@ describe('deep-thinking disclosure', () => {
   it('draws its chevron from the same Astryx icon registry as the tool rows', () => {
     // The ejected lab component used to hand-write its own 12-viewBox chevron,
     // which drew a heavier stroke than the tool rows' registry glyph once
-    // chat-message.css forced both to 10x10. Comparing the rendered markup
-    // pins the shared source: a divergent viewBox or size class fails here.
+    // chat-message.css forced both to 10x10.
     const markup = renderToStaticMarkup(createElement(TurnView, {
       turn: {
         ...turnWithTools([
@@ -150,13 +149,32 @@ describe('deep-thinking disclosure', () => {
       },
     }));
 
-    const icons = markup.match(/<span[^>]*class="astryx-icon[^"]*"[^>]*>.*?<\/svg><\/span>/g) ?? [];
-    const chevrons = icons.filter((icon) => icon.includes('M6 9l6 6 6-6'));
-    assert.ok(chevrons.length >= 2, `expected reasoning + tool chevrons, got ${chevrons.length}`);
-    assert.equal(new Set(chevrons).size, 1, 'reasoning and tool chevrons must render identical markup');
-    assert.match(chevrons[0]!, /data-size="xsm"/);
-    assert.match(chevrons[0]!, /viewBox="0 0 24 24"/);
-    assert.doesNotMatch(markup, /viewBox="0 0 12 12"/);
+    // Compared per row, not over one filtered pool of the whole turn. A pool
+    // can only ever prove the icons it collected are alike, and the reasoning
+    // row's old hand-written chevron was not a registry icon at all — it fell
+    // out of the pool, leaving the tool rows to agree with themselves. Slicing
+    // the turn at the two row roots keeps the reasoning row inside its own
+    // assertion, so it fails whichever way the row diverges: no registry icon,
+    // a different icon name, or a different size.
+    const registryIcons = (region: string) =>
+      region.match(/<span[^>]*class="astryx-icon[^"]*"[^>]*>.*?<\/svg><\/span>/g) ?? [];
+    const toolsAt = markup.indexOf('class="astryx-chat-tool-calls');
+    const reasoningAt = markup.indexOf('class="astryx-chat-reasoning');
+    assert.ok(reasoningAt >= 0 && toolsAt > reasoningAt, 'expected a reasoning row before the tool row');
+
+    // The reasoning row's only registry icon is the chevron: its leading
+    // thinking glyph is still the ejected lab's own inline svg.
+    const reasoningIcons = registryIcons(markup.slice(reasoningAt, toolsAt));
+    assert.equal(reasoningIcons.length, 1, 'the reasoning row must draw exactly one registry icon');
+
+    // The tool row also carries per-call status icons, so name the chevron by
+    // its glyph. Both rows resolve the same registry entry, so whichever path
+    // data that entry holds, the two spans have to come out byte-identical.
+    const toolChevrons = registryIcons(markup.slice(toolsAt)).filter((icon) => icon.includes('M6 9l6 6 6-6'));
+    assert.ok(toolChevrons.length > 0, 'expected a chevron on the tool row');
+    assert.equal(reasoningIcons[0], toolChevrons[0], 'both rows must render the same chevron markup');
+    assert.match(reasoningIcons[0]!, /data-size="xsm"/);
+    assert.match(reasoningIcons[0]!, /viewBox="0 0 24 24"/);
   });
 
   it('places assistant actions on ChatMessageMetadata, not a product Marker footer shell', () => {

--- a/packages/ui/src/astryx-chat-reasoning.tsx
+++ b/packages/ui/src/astryx-chat-reasoning.tsx
@@ -13,15 +13,10 @@
  * call has already been compiled, matching the published package output.
  *
  * Product dialect lives in chat-message.css (cursor default, hover wash,
- * chevron size). This file keeps the ejected lab DOM/behavior, with one
- * deliberate deviation: the disclosure chevron is Astryx `Icon`
- * (`icon="chevronDown" size="xsm"`), not the lab's hand-written 12-viewBox
- * SVG. The lab glyph carried `strokeWidth: 1.5` on a 12 viewBox where the
- * registry glyph carries the theme's 1.75 on a 24 viewBox; once
- * chat-message.css forces both to 10x10 that is 1.25px of stroke against
- * 0.73px, so the reasoning chevron rendered ~70% heavier than the identical
- * chevron on tool rows. Going through the registry keeps one chevron
- * authority app-wide — and one place to retune it.
+ * chevron size). This file keeps the ejected lab DOM/behavior, except that
+ * the chevron is Astryx `Icon` rather than the lab's own 12-viewBox SVG: at
+ * the 10x10 chat-message.css forces, that glyph drew 1.25px of stroke beside
+ * the tool rows' 0.73px. One registry, one chevron.
  */
 import { useCallback, useState, type HTMLAttributes, type ReactNode } from 'react';
 import { Icon } from '@astryxdesign/core/Icon';

--- a/packages/ui/src/astryx-chat-reasoning.tsx
+++ b/packages/ui/src/astryx-chat-reasoning.tsx
@@ -13,9 +13,18 @@
  * call has already been compiled, matching the published package output.
  *
  * Product dialect lives in chat-message.css (cursor default, hover wash,
- * chevron size). This file keeps the ejected lab DOM/behavior.
+ * chevron size). This file keeps the ejected lab DOM/behavior, with one
+ * deliberate deviation: the disclosure chevron is Astryx `Icon`
+ * (`icon="chevronDown" size="xsm"`), not the lab's hand-written 12-viewBox
+ * SVG. The lab glyph carried `strokeWidth: 1.5` on a 12 viewBox where the
+ * registry glyph carries the theme's 1.75 on a 24 viewBox; once
+ * chat-message.css forces both to 10x10 that is 1.25px of stroke against
+ * 0.73px, so the reasoning chevron rendered ~70% heavier than the identical
+ * chevron on tool rows. Going through the registry keeps one chevron
+ * authority app-wide — and one place to retune it.
  */
 import { useCallback, useState, type HTMLAttributes, type ReactNode } from 'react';
+import { Icon } from '@astryxdesign/core/Icon';
 import { mergeProps, themeProps } from '@astryxdesign/core/utils';
 
 export interface ChatReasoningProps extends HTMLAttributes<HTMLDivElement> {
@@ -34,25 +43,6 @@ function ThinkingIcon() {
       <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.5" strokeDasharray="3 2" />
       <circle cx="5.5" cy="7" r="0.75" fill="currentColor" />
       <circle cx="8.5" cy="7" r="0.75" fill="currentColor" />
-    </svg>
-  );
-}
-
-/** Match Astryx Icon `size="xsm"` (12px) used by ChatToolCalls chevrons. */
-function ChevronDownIcon() {
-  // The attributes carry the size. There used to be a `0.75rem` inline style
-  // beside them, which disagreed with them (9.75px) for as long as the root
-  // was pinned to 13px; the type-scale convergence removed that pin, so the
-  // duplicate is now merely redundant instead of wrong. Drop it either way.
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      aria-hidden="true"
-    >
-      <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }
@@ -140,7 +130,7 @@ export function ChatReasoning(props: ChatReasoningProps) {
               : 'x3nfvp2 x6s0dn4 xl56j7k x2lah0s x6jxa94 x1v9usgg xnbbluu x1ob6yzd xvc5jky'
           }
         >
-          <ChevronDownIcon />
+          <Icon icon="chevronDown" size="xsm" color="inherit" />
         </span>
       </div>
       <div className={isExpanded ? 'xrvj5dj xb0j27v x1tu4anv' : 'xrvj5dj xihq33y xb0j27v'}>


### PR DESCRIPTION
## Summary

The disclosure chevron on the Thinking row rendered with a visibly heavier stroke than the identical chevron on tool rows.

Root cause: two different chevron sources. Tool rows use Astryx `<Icon icon="chevronDown" size="xsm">` — a 24-viewBox glyph carrying the theme's `stroke-width: 1.75`. `ChatReasoning`, ejected from the Astryx lab package, hand-wrote its own chevron at 12 viewBox / `strokeWidth 1.5`. Both are then forced to 10x10 by `chat-message.css`, so the effective stroke was **1.25px vs 0.73px** — the same-looking glyph, ~70% heavier on one row. Path geometry was otherwise identical.

The reasoning chevron now goes through the registry (`<Icon icon="chevronDown" size="xsm" color="inherit" />`), so the app has one chevron authority and one place to retune it. The registry's string mode wraps its svg in an `astryx-icon` span, so the 10x10 rule now covers the wrapper (`> *`) on both rows, not just on tool rows — the two selectors collapse into one `:is()` pair.

The file header already documents the product-dialect deviations layered on the ejected lab DOM (cursor, hover wash, chevron size); this deviation is recorded there too.

## Verification

Measured in Storybook (`Product/Shell Official AppShell → NativeConversation`) against the live DOM, not eyeballed — `getComputedStyle(path).strokeWidth × path.getScreenCTM().a` for the trailing chevron of each disclosure:

| | viewBox | stroke (user units) | CTM scale | effective stroke |
|---|---|---|---|---|
| **before** — reasoning | `0 0 12 12` | 1.5 | 0.8333 | **1.25px** |
| **before** — tool calls | `0 0 24 24` | 1.75 | 0.4167 | **0.7292px** |
| **after** — reasoning | `0 0 24 24` | 1.75 | 0.4167 | **0.7292px** |
| **after** — tool calls | `0 0 24 24` | 1.75 | 0.4167 | **0.7292px** |

Layout and motion are unchanged: both chevron wrappers still measure 14x14 with a 10x10 svg, `margin-inline-start: auto` intact, and expanding still rotates the chevron 180°.

(One measuring trap worth recording: read the expanded chevron's `transform` in a throttled background tab and you get an identity matrix, because the `CSSTransition` sits at `currentTime: 0` forever. Force a paint first, or `getAnimations().forEach(a => a.finish())`.)

Also run:

- `npm run format` / `npm run format:check` / `npm run lint` — clean
- `npm run typecheck` (all workspaces) — clean
- `node --test "packages/ui/dist/**/*.test.js"` — 342 pass, 0 fail, including the new chevron contract
- `apps/desktop` main tests — the 12 failures in `project-root-controller` / project-management reproduce on a clean `main` checkout (tmpdir symlink resolution) and are untouched by this change
- Not run: Playwright E2E — no user journey changes.

Two contracts guard the invariant, one per half, each verified to fail on the state it claims to catch:

- `processing-block.test.tsx` slices the turn at the two row roots and compares each row's own chevron markup. Restoring the pre-fix component fails on *"the reasoning row must draw exactly one registry icon"*; swapping the row to `chevronRight` fails on *"both rows must render the same chevron markup"*.
- `chat-disclosure-chevron-contract.test.ts` (new, at the existing `css-test-helpers` seam) asserts each row declares both its chevron svg and its wrapper 10x10. Dropping the reasoning arm from the `:is()` fails; dropping the wrapper arm fails. It pins the outcome, not the wording — resplitting or reordering the selector list stays green.
