### PR TITLE
fix(e2e): make attachment drop readiness atomic

### DIFF
--- a/apps/desktop/e2e/attachment.spec.ts
+++ b/apps/desktop/e2e/attachment.spec.ts
@@ -6,8 +6,7 @@ test('chat input preserves an IME composition when a file paste arrives', async 
   await firstSend.press('Enter');
   await expect(page.getByText(/Fake backend received: ime-paste-test/)).toBeVisible();
 
-  const composer = page.locator('.maka-composer');
-  await expect(composer).toHaveAttribute('data-maka-file-drop-target', 'true');
+  const composer = page.locator('.maka-composer[data-maka-file-drop-target="true"]');
   const editable = composer.locator('[contenteditable="true"]');
 
   const pasteResults = await editable.evaluate((input) => {
@@ -50,18 +49,23 @@ test('a mixed attachment send has the Astryx message hierarchy', async ({ window
   await expect(composer).toBeVisible();
   // Assistant text becomes visible before the turn's terminal event can clear
   // the streaming state. The composer intentionally rejects attachments until
-  // that happens, so synchronize on its actual file-drop readiness contract.
-  await expect(composer).toHaveAttribute('data-maka-file-drop-target', 'true');
-  const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
-  await dataTransfer.evaluate((dt: DataTransfer) => {
-    dt.items.add(new File(['hello attachment content'], 'note.txt', { type: 'text/plain' }));
+  // that happens. Match the ready target and dispatch from the same renderer
+  // task so a state transition cannot land between readiness and the drop.
+  const dropTarget = page.locator('.maka-composer[data-maka-file-drop-target="true"]');
+  await dropTarget.evaluate((element) => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(
+      new File(['hello attachment content'], 'note.txt', { type: 'text/plain' }),
+    );
     const png = Uint8Array.from(
       atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='),
       (character) => character.charCodeAt(0),
     );
-    dt.items.add(new File([png], 'pixel.png', { type: 'image/png' }));
+    dataTransfer.items.add(new File([png], 'pixel.png', { type: 'image/png' }));
+    element.dispatchEvent(
+      new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer }),
+    );
   });
-  await composer.dispatchEvent('drop', { dataTransfer });
 
   // Both attachment kinds appear in the composer before send.
   await expect(page.getByText('note.txt')).toBeVisible();


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- make attachment paste and drop target the composer only while its real file-acceptance contract is active
- construct and dispatch the mixed-file `DataTransfer` in one renderer task
- remove the check-then-dispatch window that intermittently caused the main CI attachment test to drop no files

## Root cause

The test first observed `data-maka-file-drop-target="true"`, then used separate browser round trips to create and populate a `DataTransfer`, and finally dispatched to a generic composer locator. A Composer state transition could land between the readiness check and dispatch, so the real drop handler correctly rejected the now-unavailable import while the test waited for attachment tokens that would never appear.

This is a test synchronization defect rather than a Runtime Host attachment regression. The merge commit and the passing PR head have identical Git trees, and the failure happened before attachment send or Runtime Host ingestion.

## Validation

- attachment E2E, 100 repeated runs with 4 workers
- attachment E2E, 40 repeated runs with 1 worker and `CI=1`
- CI-order shard 1 reached and passed the attachment case
- `npm run format:check`
- `npm run lint`
- `git diff --check`

</details>

<details>
<summary>中文</summary>

## 摘要

- 仅在 Composer 的真实文件接收契约生效时定位附件粘贴与拖放目标
- 在同一个 renderer task 中构造并派发混合文件 `DataTransfer`
- 消除先检查、后派发的时间窗口，避免 main CI 的附件测试间歇性丢失全部文件

## 根因

测试先观察 `data-maka-file-drop-target="true"`，随后通过多次浏览器往返创建和填充 `DataTransfer`，最后向普通 Composer locator 派发事件。Composer 状态可能在 readiness 检查与事件派发之间变化；此时真实 drop handler 会按设计拒绝已经不可接收的导入，而测试则一直等待不会出现的附件 token。

这是测试同步缺陷，不是 Runtime Host 附件回归。合并提交与通过 PR CI 的 head 具有完全相同的 Git tree，并且失败发生在附件发送或 Runtime Host ingest 之前。

## 验证

- 附件 E2E：4 workers 重复运行 100 次
- 附件 E2E：`CI=1`、单 worker 重复运行 40 次
- 按 CI 顺序运行 shard 1，附件用例通过
- `npm run format:check`
- `npm run lint`
- `git diff --check`

</details>