### PR TITLE
fix(ui): keep composer model/thinking pickers mounted mid-turn and unify them as ghost menus

### DIFF
--- a/apps/desktop/e2e/floating-layers.spec.ts
+++ b/apps/desktop/e2e/floating-layers.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test, COMPOSER_INPUT } from './fixtures.js';
 
-test('model and adjacent thinking Selectors persist one real Electron journey', async ({
+test('model and adjacent thinking menus persist one real Electron journey', async ({
   modelPickerLongWindow: page,
 }) => {
-  const thinkingTrigger = page.getByRole('combobox', { name: '思考级别' });
+  const thinkingTrigger = page.getByRole('button', { name: /思考级别/ });
   await thinkingTrigger.click();
-  await page.getByRole('option', { name: '关', exact: true }).click();
+  await page.getByRole('menuitem', { name: '关', exact: true }).click();
   await expect(thinkingTrigger).toContainText('关');
 
   const composer = page.locator(COMPOSER_INPUT);
@@ -15,17 +15,15 @@ test('model and adjacent thinking Selectors persist one real Electron journey', 
     page.getByText(/Fake backend received: model selector persistence journey/),
   ).toBeVisible();
 
-  const activeThinkingTrigger = page.getByRole('combobox', { name: '思考级别' });
+  const activeThinkingTrigger = page.getByRole('button', { name: /思考级别/ });
   await expect(activeThinkingTrigger).toContainText('关');
   await page.reload();
   await expect(page.locator(COMPOSER_INPUT)).toBeVisible();
-  await expect(page.getByRole('combobox', { name: '思考级别' })).toContainText('关');
+  await expect(page.getByRole('button', { name: /思考级别/ })).toContainText('关');
 
   const modelTrigger = page.getByRole('button', { name: '切换当前会话模型' });
   await modelTrigger.click();
-  const search = page.getByPlaceholder('搜索模型');
-  await search.fill('claude-e2e-1');
-  await page.getByRole('option', { name: 'claude-e2e-1', exact: true }).click();
+  await page.getByRole('menuitem', { name: 'claude-e2e-1', exact: true }).click();
   await expect(page.getByText('已切换当前会话模型')).toBeVisible();
   await expect(modelTrigger).toContainText('claude-e2e-1');
 });

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -106,6 +106,16 @@
   padding-block: var(--space-1);
 }
 
+/* Astryx sizes the popover to its widest row (min-width:anchor-size, no max).
+   The model menu lost the 260px/56vw option-label cap with the Selector, so
+   the menu itself needs the ceiling: a long model name (BYOK catalogs love
+   `vendor/a-very-long-model-name`) must wrap inside the panel, never push it
+   off the window. Rows already wrap (Item has no nowrap) and the panel has
+   overflow-y:auto for the tall direction. */
+.maka-composer-quiet-menu {
+  max-width: min(320px, 92vw);
+}
+
 /* Model chip (static fallback) still owns its own quiet geometry. */
 .maka-composer-model-chip {
   font: var(--maka-text-label);
@@ -163,17 +173,10 @@
   min-width: 0;
   max-width: min(420px, 52vw);
 }
-.maka-composer-left-controls .maka-model-switcher {
-  margin: 0;
-  max-width: min(360px, 42vw);
-}
 .maka-composer-left-controls .maka-model-switcher-trigger,
 .maka-composer-left-controls .maka-new-chat-model-selector {
   min-width: 100px;
   max-width: min(220px, 28vw);
-}
-.maka-composer-left-controls .maka-thinking-level-selector {
-  margin: 0;
 }
 
 .maka-composer-model-chip-text {

--- a/apps/desktop/src/renderer/styles/model-switcher.css
+++ b/apps/desktop/src/renderer/styles/model-switcher.css
@@ -1,31 +1,3 @@
-.maka-model-switcher {
-  display: inline-flex;
-  align-items: center;
-  margin: 0;
-  min-width: 0;
-  max-width: min(440px, 42vw);
-  -webkit-app-region: no-drag;
-}
-
-/* No disabled opacity here. The Astryx Selector inside already dims itself
-   when disabled, and this wrapper rule multiplied on top of it: two stacked
-   `opacity: 0.5` layers composite to 0.25, which took the model label from
-   17.9:1 down to roughly 1.4:1 — a control that reads as absent rather than
-   as disabled. State is Astryx's, per the layout-only note below. */
-
-/* Justified state-cursor exception: pending model change shows progress,
-   not the product default. native-cursor owns default/pointer/text only. */
-.maka-model-switcher[data-pending="true"] {
-  /* Pending has no Astryx counterpart (it is a Maka concept: a model change is
-     in flight), so this one does not stack. */
-  opacity: var(--opacity-pending);
-  cursor: progress !important;
-}
-
-.maka-model-switcher[data-pending="true"] :where(button, [role="button"]) {
-  cursor: progress !important;
-}
-
 /* Model + thinking sit as one left-footer pair after permission. */
 .maka-model-selection-controls {
   display: inline-flex;
@@ -35,37 +7,39 @@
   max-width: 100%;
 }
 
+/* The composer footer's model and thinking pickers are ghost-button
+   DropdownMenus — the same toolbar primitive as ＋ and permission, so their
+   resting, hover, focus, and disabled chrome all derive from the Astryx
+   Button and no product overlay is needed here. Trigger geometry (min/max
+   width) is owned by composer.css, the one real context these triggers
+   render in; the Button's label span truncates inside that cap. */
+
+/* Connection group heading inside the model menus. Mirrors Astryx's
+   data-driven DropdownMenu section title (supporting role, secondary ink,
+   sm menu padding) so the compound menu reads like a native sectioned one. */
+.maka-model-menu-group-heading {
+  padding-block: var(--space-1);
+  padding-inline: var(--space-2);
+  font: var(--maka-text-supporting);
+  color: var(--foreground-secondary);
+  user-select: none;
+  white-space: nowrap;
+}
+
 .maka-model-picker-root {
   display: inline-flex;
   min-width: 0;
   max-width: 100%;
 }
 
-.maka-model-switcher-trigger,
-.maka-new-chat-model-selector {
-  min-width: 100px;
-  max-width: min(260px, 28vw);
-}
-
-/* Quiet ghost triggers for the chat surface: the composer's model and thinking
-   pickers, and the project picker beside them. Astryx Selector's
-   default is a bordered field, which reads as an input asking to be filled in
-   rather than as a chip carrying a current value; product owns these
-   classNames only on chat pickers — Settings ModelPicker does not set them.
+/* Quiet ghost trigger for the chat surface's project picker — the one
+   remaining Selector in the composer footer. Astryx Selector's default is a
+   bordered field, which reads as an input asking to be filled in rather than
+   as a chip carrying a current value; product owns this className only on
+   chat pickers — Settings ModelPicker does not set it.
    Geometry mirrors .maka-composer-model-chip. */
-.maka-model-switcher-trigger.astryx-selector,
-.maka-new-chat-model-selector.astryx-selector,
-.maka-thinking-level-selector.astryx-selector,
 .maka-workspace-picker.astryx-selector {
   font: var(--maka-text-label);
-  /* #1879: this rule used to force a height — 26px originally, then 24px on the
-     ruler. Both were wrong for the same reason the sidebar update button was:
-     these ARE Astryx Selectors (`size="sm"`), and Selector sizes off
-     `--size-element-sm` (28px). Forcing 24px pushed a component below its own
-     smallest tier and desynced it from `ModelChipStatic`, the inert state of
-     the same chip, which is a `Button size="sm"` at 28px — the pill changed
-     height when it became clickable. Declaring no height is what makes the two
-     states agree by derivation. */
   padding-block: 0;
   padding-inline: var(--space-2);
   border-color: transparent;
@@ -76,16 +50,6 @@
   transition:
     background-color var(--duration-base) var(--ease-out-strong),
     color var(--duration-base) var(--ease-out-strong);
-}
-
-/* Thinking is a short single-token control (关 / 中 / 超高). Size to content;
-   Astryx popover min-width:anchor-size(width) then grows with the longest option. */
-.maka-thinking-level-selector,
-.maka-thinking-level-selector.astryx-selector {
-  width: max-content;
-  min-width: 0;
-  max-width: none;
-  flex: 0 0 auto;
 }
 
 /* Sizes to the project name rather than holding a column width: it is the last
@@ -99,9 +63,6 @@
   flex: 0 0 auto;
 }
 
-.maka-model-switcher-trigger.astryx-selector:hover:not([aria-disabled="true"]),
-.maka-new-chat-model-selector.astryx-selector:hover:not([aria-disabled="true"]),
-.maka-thinking-level-selector.astryx-selector:hover:not([aria-disabled="true"]),
 .maka-workspace-picker.astryx-selector:hover:not([aria-disabled="true"]) {
   background: var(--state-hover-bg);
   color: var(--foreground);
@@ -109,9 +70,6 @@
   box-shadow: none;
 }
 
-.maka-model-switcher-trigger.astryx-selector:focus-within,
-.maka-new-chat-model-selector.astryx-selector:focus-within,
-.maka-thinking-level-selector.astryx-selector:focus-within,
 .maka-workspace-picker.astryx-selector:focus-within {
   border-color: transparent;
   background: var(--state-hover-bg);
@@ -119,9 +77,6 @@
   color: var(--foreground);
 }
 
-.maka-model-switcher-trigger.astryx-selector[aria-disabled="true"],
-.maka-new-chat-model-selector.astryx-selector[aria-disabled="true"],
-.maka-thinking-level-selector.astryx-selector[aria-disabled="true"],
 .maka-workspace-picker.astryx-selector[aria-disabled="true"] {
   background: transparent;
   border-color: transparent;

--- a/packages/ui/src/__tests__/chat-model-switcher.test.tsx
+++ b/packages/ui/src/__tests__/chat-model-switcher.test.tsx
@@ -1,0 +1,109 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { LocaleProvider } from '../locale-context.js';
+import { ChatModelSwitcher, ThinkingLevelSelector } from '../chat-model-switcher.js';
+import type { ChatModelChoice } from '../chat-model-helpers.js';
+import type { SessionSummary } from '@maka/core';
+
+function render(children: ReactNode): string {
+  return renderToStaticMarkup(<LocaleProvider locale="zh">{children}</LocaleProvider>);
+}
+
+const SESSION: SessionSummary = {
+  id: 'session-1',
+  name: 'Test',
+  isFlagged: false,
+  isArchived: false,
+  labels: [],
+  hasUnread: false,
+  status: 'done',
+  backend: 'fake',
+  llmConnectionSlug: 'anthropic-main',
+  connectionLocked: false,
+  model: 'claude-sonnet-4',
+  permissionMode: 'ask',
+};
+
+const CHOICES: ChatModelChoice[] = [
+  { connectionSlug: 'anthropic-main', providerType: 'anthropic', model: 'claude-opus-4-1', label: 'Claude Opus 4.1' },
+  { connectionSlug: 'anthropic-main', providerType: 'anthropic', model: 'claude-sonnet-4', label: 'Claude Sonnet 4' },
+  { connectionSlug: 'openai-main', providerType: 'openai', model: 'gpt-5', label: 'GPT-5' },
+];
+
+describe('ChatModelSwitcher menu', () => {
+  it('groups the catalog by connection, each section named by its heading', () => {
+    const markup = render(
+      <ChatModelSwitcher
+        activeSession={SESSION}
+        choices={CHOICES}
+        onChange={() => {}}
+      />,
+    );
+    const groups = [...markup.matchAll(/role="group" aria-label="([^"]+)"/g)].map((m) => m[1]);
+    assert.deepEqual(groups, ['Anthropic', 'OpenAI'], 'one named group per connection');
+    assert.match(markup, /Claude Opus 4\.1/);
+    // The current value wears the check; other rows must not.
+    const checks = markup.match(/lucide-check/g) ?? [];
+    assert.equal(checks.length, 1, 'exactly the current model is checked');
+  });
+
+  it('offers an unknown current model as a checked leading row', () => {
+    const markup = render(
+      <ChatModelSwitcher
+        activeSession={{ ...SESSION, model: 'claude-retired-3' }}
+        choices={CHOICES}
+        onChange={() => {}}
+      />,
+    );
+    assert.match(markup, /claude-retired-3/, 'the current model stays visible even off-catalog');
+  });
+
+  it('locks every menu row, not just the trigger, when disabled', () => {
+    // An aria-disabled trigger still opens its menu on ArrowDown (Astryx
+    // DropdownMenu's keydown path does not consult isDisabled), so a lock
+    // that lived only on the trigger would be bypassable by keyboard.
+    const markup = render(
+      <ChatModelSwitcher
+        activeSession={SESSION}
+        choices={CHOICES}
+        disabledReason="locked"
+        onChange={() => {}}
+      />,
+    );
+    const items = (markup.match(/<div\b[^>]*role="menuitem"[^>]*>/g) ?? [])
+      .filter((tag) => tag.includes('aria-disabled="true"'));
+    assert.equal(items.length, CHOICES.length, 'every row is inert while locked');
+  });
+});
+
+describe('ThinkingLevelSelector menu', () => {
+  it('locks rows with the trigger and explains the lock on the trigger', () => {
+    const markup = render(
+      <ThinkingLevelSelector
+        levels={['off', 'high']}
+        current="high"
+        onChange={() => {}}
+        disabled
+        disabledReason="等结束后再切换思考级别。"
+      />,
+    );
+    const items = (markup.match(/<div\b[^>]*role="menuitem"[^>]*>/g) ?? [])
+      .filter((tag) => tag.includes('aria-disabled="true"'));
+    assert.equal(items.length, 3, 'default + two levels all locked');
+    assert.match(markup, /等结束后再切换思考级别/, 'the tooltip carries the lock reason');
+  });
+
+  it('maps the default row back to undefined', () => {
+    // The sentinel round-trip: DEFAULT_THINKING_LEVEL is menu-only; hosts see
+    // `undefined` for the default. This is a render-level fact — the default
+    // row exists and the current ladder entry is the checked one.
+    const markup = render(
+      <ThinkingLevelSelector levels={['off', 'high']} current={undefined} onChange={() => {}} />,
+    );
+    assert.match(markup, /默认/);
+    const checks = markup.match(/lucide-check/g) ?? [];
+    assert.equal(checks.length, 1, 'the default row is the checked one');
+  });
+});

--- a/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
+++ b/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
@@ -59,7 +59,7 @@ describe('composer quiet chrome', () => {
     )?.[0] ?? '';
     assert.match(
       leftControls,
-      /maka-composer-model-chip|maka-model-switcher|maka-new-chat-model-selector|maka-model-picker-root/,
+      /maka-composer-model-chip|maka-model-switcher-trigger|maka-new-chat-model-selector/,
       'model control must render in left-controls after permission',
     );
     // Thinking stays out of the model menu; without levels it does not mount.
@@ -102,6 +102,72 @@ describe('composer quiet chrome', () => {
       /maka-thinking-level-selector/,
       'thinking must not sit next to send',
     );
+  });
+
+  it('keeps the model + thinking pair mounted mid-turn, locked with the reason', () => {
+    // A turn in flight locks the model and thinking parameters; it does not
+    // remove their meaning. The pair must stay in the footer — unmounting it
+    // reflowed the whole row on turn start/end — and the lock must explain
+    // itself: Astryx Button keeps a tooltipped trigger focusable via
+    // aria-disabled, so the reason copy is discoverable by pointer, keyboard,
+    // and screen reader alike.
+    //
+    // The fixture must make streaming the ONLY lock source: an activeSession
+    // already at rest ('done') and a catalog that contains the current model,
+    // so the assertions below attribute the lock to `streaming` alone — and a
+    // deletion of the streaming branch in composer.tsx turns this red.
+    const session = {
+      id: 'session-1',
+      name: 'Test',
+      isFlagged: false,
+      isArchived: false,
+      labels: [],
+      hasUnread: false,
+      status: 'done' as const,
+      backend: 'fake' as const,
+      llmConnectionSlug: 'fake',
+      connectionLocked: false,
+      model: 'fake',
+      permissionMode: 'ask' as const,
+    };
+    const choices = [
+      { connectionSlug: 'fake', providerType: 'anthropic' as const, model: 'fake', label: 'fake' },
+    ];
+    const thinkingProps = {
+      activeThinkingLevels: ['off', 'high'] as ('off' | 'high')[],
+      activeThinkingLevel: 'high' as const,
+      onThinkingLevelChange: () => {},
+    };
+    const renderComposer = (streaming: boolean) => render(
+      <Composer
+        onSend={() => true}
+        onStop={() => {}}
+        streaming={streaming}
+        activeSession={session}
+        modelLabel="demo-model"
+        modelChoices={choices}
+        onModelChange={() => {}}
+        {...thinkingProps}
+      />,
+    );
+
+    // The lock trigger is any element carrying the class — the component
+    // family behind it (ghost button today) is its own business.
+    const tagCarrying = (markup: string, className: string): string =>
+      new RegExp(`<[a-z]+[^>]*${className}[^>]*>`).exec(markup)?.[0] ?? '';
+
+    const midTurn = renderComposer(true);
+    assert.match(midTurn, /maka-model-selection-controls/, 'the pair must not unmount mid-turn');
+    assert.match(tagCarrying(midTurn, 'maka-model-switcher-trigger'), /aria-disabled="true"/, 'mid-turn the model menu is locked, not gone');
+    assert.match(tagCarrying(midTurn, 'maka-thinking-level-selector'), /aria-disabled="true"/, 'mid-turn the thinking menu is locked, not gone');
+    // The contract is the reason, not the attribute: each locked control
+    // explains the lock in its own words (tooltip markup renders in SSR).
+    assert.match(midTurn, /等结束后再切换模型/, 'the model lock names its reason');
+    assert.match(midTurn, /等结束后再切换思考级别/, 'the thinking lock names its reason');
+
+    const atRest = renderComposer(false);
+    assert.doesNotMatch(tagCarrying(atRest, 'maka-model-switcher-trigger'), /aria-disabled/, 'at rest the model menu is enabled');
+    assert.doesNotMatch(tagCarrying(atRest, 'maka-thinking-level-selector'), /aria-disabled/, 'at rest the thinking menu is enabled');
   });
 
   it('reads active modes off the footer toolbar, after the model pair', () => {

--- a/packages/ui/src/chat-model-switcher.tsx
+++ b/packages/ui/src/chat-model-switcher.tsx
@@ -7,25 +7,101 @@
  * the grouped model-choice helpers, so they form a clean seam. `index.ts` does
  * not re-export them (they are internal to the `@maka/ui` Composer surface).
  *
- * Thinking level is a separate Selector (not nested in the model menu). The
+ * Composer footer pickers are ghost-button DropdownMenus — the same toolbar
+ * primitive as the ＋ and permission controls beside them, so resting, hover,
+ * focus, and disabled chrome all derive from one Button instead of a product
+ * overlay restyling a form field. The Astryx Selector (a field primitive,
+ * with search) remains the right shape for Settings forms via `ModelPicker`.
+ *
+ * Thinking level is a separate menu (not nested in the model menu). The
  * Composer places it immediately after the model control in the left footer.
  */
 
 import { type ReactNode, useMemo } from 'react';
-import { Button as UiButton, Selector } from '@astryxdesign/core';
-import { ModelPicker } from './model-picker.js';
-import { Settings } from './icons.js';
+import { Button as UiButton } from '@astryxdesign/core';
+import { DropdownMenu, DropdownMenuItem } from '@astryxdesign/core/DropdownMenu';
+import { Check, Settings } from './icons.js';
 import {
   type ChatModelChoice,
+  type ModelMenuGroup,
   modelMenuGroups,
   modelChoiceValue,
-  parseModelChoiceValue,
 } from './chat-model-helpers.js';
 import { type ProviderType, type SessionSummary, type ThinkingLevel } from '@maka/core';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 
 const DEFAULT_THINKING_LEVEL = '__default__';
+
+function providerMarkIcon(
+  providerType: ProviderType | undefined,
+  renderProviderMark: ((type: ProviderType) => ReactNode) | undefined,
+): ReactNode {
+  if (!providerType || !renderProviderMark) return undefined;
+  return (
+    <span className="modelPickerProviderMark" data-provider={providerType} aria-hidden="true">
+      {renderProviderMark(providerType)}
+    </span>
+  );
+}
+
+const currentCheck = <Check size={14} aria-hidden="true" />;
+
+/**
+ * The one shared body of both model menus: an optional leading row for a
+ * current model the catalog no longer lists, then one `role="group"` section
+ * per connection (heading + its models). The current value wears a check —
+ * plain menu items, not radio rows, so the menu keeps the quiet footer's sm
+ * density. `disabled` locks every row, not just the trigger: an aria-disabled
+ * trigger still opens its menu on ArrowDown (Astryx DropdownMenu's keydown
+ * path does not consult `isDisabled`), so the lock must live on the items too.
+ */
+function ModelMenuItems(props: {
+  groups: readonly ModelMenuGroup[];
+  currentValue?: string;
+  leadingOption?: { label: string; providerType?: ProviderType };
+  renderProviderMark?(type: ProviderType): ReactNode;
+  disabled?: boolean;
+  onPick(input: { llmConnectionSlug: string; model: string }): void | Promise<void>;
+}) {
+  return (
+    <>
+      {props.leadingOption ? (
+        <DropdownMenuItem
+          icon={providerMarkIcon(props.leadingOption.providerType, props.renderProviderMark)}
+          label={props.leadingOption.label}
+          endContent={currentCheck}
+          isDisabled={props.disabled}
+          // Current value: picking it changes nothing, but the click still
+          // owes the user the menu close every other item gives.
+          onClick={() => {}}
+        />
+      ) : null}
+      {props.groups.map((group) => (
+        <div role="group" aria-label={group.heading} key={group.connectionSlug}>
+          <div className="maka-model-menu-group-heading" aria-hidden="true">
+            {group.heading}
+          </div>
+          {group.choices.map((choice) => {
+            const value = modelChoiceValue(choice.connectionSlug, choice.model);
+            return (
+              <DropdownMenuItem
+                key={value}
+                icon={providerMarkIcon(choice.providerType, props.renderProviderMark)}
+                label={choice.label}
+                endContent={value === props.currentValue ? currentCheck : undefined}
+                isDisabled={props.disabled}
+                onClick={() => {
+                  void props.onPick({ llmConnectionSlug: choice.connectionSlug, model: choice.model });
+                }}
+              />
+            );
+          })}
+        </div>
+      ))}
+    </>
+  );
+}
 
 /**
  * Standalone thinking-level picker. Hidden when the active model has no
@@ -37,6 +113,8 @@ export function ThinkingLevelSelector(props: {
   current?: ThinkingLevel;
   onChange?(level: ThinkingLevel | undefined): void | Promise<void>;
   disabled?: boolean;
+  /** Why the control is locked (mid-turn etc.); replaces the action tooltip so the reason is discoverable, matching the model switcher beside it. */
+  disabledReason?: string;
   loading?: boolean;
 }) {
   const copy = getConversationCopy(useUiLocale()).model;
@@ -51,25 +129,39 @@ export function ThinkingLevelSelector(props: {
 
   if (!hasVariants) return null;
 
+  const currentValue = props.current ?? DEFAULT_THINKING_LEVEL;
+  const currentLabel = options.find((option) => option.value === currentValue)?.label ?? copy.defaultLevel;
+
   return (
-    <Selector
-      label={copy.thinkingLevel}
-      isLabelHidden
-      options={options}
-      value={props.current ?? DEFAULT_THINKING_LEVEL}
-      size="sm"
+    <DropdownMenu
       placement="above"
-      // Content-sized: short zh labels (关/中/高) must not sit in a fixed field.
-      width="max-content"
-      className="maka-thinking-level-selector"
-      isDisabled={props.disabled}
-      isLoading={props.loading}
-      changeAction={(value) =>
-        props.onChange?.(
-          value === DEFAULT_THINKING_LEVEL ? undefined : value as ThinkingLevel,
-        )
-      }
-    />
+      hasChevron={false}
+      className="maka-composer-quiet-menu"
+      button={{
+        label: currentLabel,
+        variant: 'ghost',
+        size: 'sm',
+        isDisabled: props.disabled,
+        isLoading: props.loading,
+        tooltip: props.disabledReason ?? copy.changeThinkingLevel,
+        className: 'maka-thinking-level-selector',
+        'aria-label': `${copy.thinkingLevel}: ${currentLabel}`,
+      }}
+    >
+      {options.map((option) => (
+        <DropdownMenuItem
+          key={option.value}
+          label={option.label}
+          endContent={option.value === currentValue ? currentCheck : undefined}
+          isDisabled={props.disabled}
+          onClick={() => {
+            void props.onChange?.(
+              option.value === DEFAULT_THINKING_LEVEL ? undefined : (option.value as ThinkingLevel),
+            );
+          }}
+        />
+      ))}
+    </DropdownMenu>
   );
 }
 
@@ -102,29 +194,29 @@ export function ChatModelSwitcher(props: {
     : props.disabledReason ?? copy.switchTitle(currentSessionModelTitle);
 
   return (
-    <div
-      className="maka-model-switcher"
-      title={title}
-      data-disabled={disabled ? 'true' : undefined}
-      data-pending={pending ? 'true' : undefined}
-      aria-busy={pending ? 'true' : undefined}
+    <DropdownMenu
+      placement="above"
+      hasChevron={false}
+      className="maka-composer-quiet-menu"
+      button={{
+        label: displayLabel,
+        icon: providerMarkIcon(props.currentProviderType, props.renderProviderMark),
+        variant: 'ghost',
+        size: 'sm',
+        isDisabled: disabled,
+        isLoading: pending,
+        tooltip: title,
+        className: 'maka-model-switcher-trigger',
+        'aria-label': copy.switchAriaLabel,
+      }}
     >
-      <ModelPicker
+      <ModelMenuItems
         groups={grouped}
-        value={currentValue}
-        disabled={disabled}
-        loading={pending}
+        currentValue={currentValue}
+        leadingOption={!currentKnownChoice ? { label: displayLabel, providerType: props.currentProviderType } : undefined}
         renderProviderMark={props.renderProviderMark}
-        ariaLabel={copy.switchAriaLabel}
-        triggerClassName="maka-model-switcher-trigger"
-        leadingOption={!currentKnownChoice ? {
-          value: currentValue,
-          label: displayLabel,
-          providerType: props.currentProviderType,
-        } : undefined}
-        onValueChange={async (value) => {
-          const next = parseModelChoiceValue(value);
-          if (!next) return;
+        disabled={disabled}
+        onPick={async (next) => {
           if (
             next.llmConnectionSlug === props.activeSession.llmConnectionSlug &&
             next.model === currentModel
@@ -136,7 +228,7 @@ export function ChatModelSwitcher(props: {
           }
         }}
       />
-    </div>
+    </DropdownMenu>
   );
 }
 
@@ -144,9 +236,10 @@ export function ChatModelSwitcher(props: {
  * Home / empty-state model picker (no active session yet). Unlike
  * `ChatModelSwitcher` — which is bound to a live session and switches THAT
  * session's model — this one just records which model the next new chat should
- * start with. Reuses the model chip's look so the only visible change is that
- * the chevron now actually opens a menu. The thinking level for new chats is a
- * separate right-footer control owned by the Composer.
+ * start with. Reuses the model chip's look: a chevronless ghost button like
+ * the ＋ and permission controls beside it — the hover wash and tooltip are
+ * the menu affordance. The thinking level for new chats is a separate
+ * right-footer control owned by the Composer.
  */
 export function NewChatModelPicker(props: {
   label: string;
@@ -164,22 +257,28 @@ export function NewChatModelPicker(props: {
     (choice) => modelChoiceValue(choice.connectionSlug, choice.model) === currentValue,
   );
   return (
-    <ModelPicker
-      groups={grouped}
-      value={currentValue}
-      renderProviderMark={props.renderProviderMark}
-      ariaLabel={copy.newChatAriaLabel(props.label)}
-      triggerClassName="maka-new-chat-model-selector"
-      leadingOption={!currentKnownChoice ? {
-        value: currentValue,
+    <DropdownMenu
+      placement="above"
+      hasChevron={false}
+      className="maka-composer-quiet-menu"
+      button={{
         label: props.label,
-        providerType: props.currentProviderType,
-      } : undefined}
-      onValueChange={async (value) => {
-        const next = parseModelChoiceValue(value);
-        if (next) await props.onPick(next);
+        icon: providerMarkIcon(props.currentProviderType, props.renderProviderMark),
+        variant: 'ghost',
+        size: 'sm',
+        tooltip: copy.newChatTitle(props.label),
+        className: 'maka-new-chat-model-selector',
+        'aria-label': copy.newChatAriaLabel(props.label),
       }}
-    />
+    >
+      <ModelMenuItems
+        groups={grouped}
+        currentValue={currentValue}
+        leadingOption={!currentKnownChoice && currentValue ? { label: props.label, providerType: props.currentProviderType } : undefined}
+        renderProviderMark={props.renderProviderMark}
+        onPick={props.onPick}
+      />
+    </DropdownMenu>
   );
 }
 

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -158,7 +158,9 @@ export const Composer = forwardRef<
     /**
      * When true, a turn is in flight — live output OR the pre-first-token wait.
      * Send becomes Stop. The ＋ menu and permission control stay reachable
-     * (#1444); import stays blocked mid-turn.
+     * (#1444); the model and thinking menus stay mounted but lock with an
+     * explanatory tooltip, so the footer row never reflows mid-turn; import
+     * stays blocked mid-turn.
      */
     streaming?: boolean;
     /**
@@ -1407,56 +1409,57 @@ export const Composer = forwardRef<
                 />
               ) : null}
               {/* Model + thinking sit left after permission (adjacent pair), not
-                  in the send cluster. Thinking is its own Selector, only when
-                  the active/new-chat model offers levels. */}
-              {!props.streaming ? (
-                <div className="maka-model-selection-controls">
-                  {props.activeSession ? (
-                    <ChatModelSwitcher
-                      activeSession={props.activeSession}
-                      activeModel={props.activeModel}
-                      activeConnectionLabel={props.activeConnectionLabel}
-                      activeModelLabel={props.activeModelLabel}
-                      currentProviderType={props.activeProviderType}
-                      choices={props.modelChoices ?? []}
-                      pending={props.modelChangePending}
-                      disabledReason={modelSwitcherDisabledReason}
-                      renderProviderMark={props.renderProviderMark}
-                      onChange={props.onModelChange}
-                    />
-                  ) : props.onPickNewChatModel && (props.modelChoices?.length ?? 0) > 0 ? (
-                    <NewChatModelPicker
-                      label={modelChipLabel}
-                      choices={props.modelChoices ?? []}
-                      currentValue={
-                        props.newChatModel
-                          ? modelChoiceValue(props.newChatModel.llmConnectionSlug, props.newChatModel.model)
-                          : undefined
-                      }
-                      currentProviderType={props.newChatProviderType}
-                      renderProviderMark={props.renderProviderMark}
-                      onPick={props.onPickNewChatModel}
-                    />
-                  ) : (
-                    <ModelChipStatic label={modelChipLabel} onOpenSettings={props.onOpenModelSettings} />
-                  )}
-                  {props.activeSession ? (
-                    <ThinkingLevelSelector
-                      levels={props.activeThinkingLevels ?? []}
-                      current={props.activeThinkingLevel}
-                      onChange={props.onThinkingLevelChange}
-                      disabled={Boolean(modelSwitcherDisabledReason) || props.modelChangePending}
-                      loading={props.modelChangePending}
-                    />
-                  ) : (
-                    <ThinkingLevelSelector
-                      levels={props.newChatThinkingLevels ?? []}
-                      current={props.newChatThinkingLevel}
-                      onChange={props.onNewChatThinkingLevelChange}
-                    />
-                  )}
-                </div>
-              ) : null}
+                  in the send cluster. Thinking is its own menu, only when the
+                  active/new-chat model offers levels. Mid-turn the pair stays
+                  mounted — `modelSwitcherDisabledReason` carries the lock and
+                  its explanation, so the footer never reflows when a turn
+                  starts or ends. */}
+              <div className="maka-model-selection-controls">
+                {props.activeSession ? (
+                  <ChatModelSwitcher
+                    activeSession={props.activeSession}
+                    activeModel={props.activeModel}
+                    activeConnectionLabel={props.activeConnectionLabel}
+                    activeModelLabel={props.activeModelLabel}
+                    currentProviderType={props.activeProviderType}
+                    choices={props.modelChoices ?? []}
+                    pending={props.modelChangePending}
+                    disabledReason={modelSwitcherDisabledReason}
+                    renderProviderMark={props.renderProviderMark}
+                    onChange={props.onModelChange}
+                  />
+                ) : props.onPickNewChatModel && (props.modelChoices?.length ?? 0) > 0 ? (
+                  <NewChatModelPicker
+                    label={modelChipLabel}
+                    choices={props.modelChoices ?? []}
+                    currentValue={
+                      props.newChatModel
+                        ? modelChoiceValue(props.newChatModel.llmConnectionSlug, props.newChatModel.model)
+                        : undefined
+                    }
+                    currentProviderType={props.newChatProviderType}
+                    renderProviderMark={props.renderProviderMark}
+                    onPick={props.onPickNewChatModel}
+                  />
+                ) : (
+                  <ModelChipStatic label={modelChipLabel} onOpenSettings={props.onOpenModelSettings} />
+                )}
+                {props.activeSession ? (
+                  <ThinkingLevelSelector
+                    levels={props.activeThinkingLevels ?? []}
+                    current={props.activeThinkingLevel}
+                    onChange={props.onThinkingLevelChange}
+                    disabled={Boolean(modelSwitcherDisabledReason) || props.modelChangePending}
+                    loading={props.modelChangePending}
+                  />
+                ) : (
+                  <ThinkingLevelSelector
+                    levels={props.newChatThinkingLevels ?? []}
+                    current={props.newChatThinkingLevel}
+                    onChange={props.onNewChatThinkingLevelChange}
+                  />
+                )}
+              </div>
               {/* The project decides where a NEW chat starts, which makes it a
                   parameter of this send like the model beside it — so it sits
                   at the end of that group rather than in a header row of its

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -1076,13 +1076,26 @@ export const Composer = forwardRef<
   // disabled reasons (empty draft, in-flight import) keep the neutral label.
   const sendTitle = noModelConnection && !props.disabled ? copy.noModelSendTitle : copy.sendLabel;
   const modelChipLabel = props.modelLabel?.trim() || copy.selectModel;
-  const modelSwitcherDisabledReason = props.streaming
-    ? copy.switchDisabledStreaming
+  // Mid-turn the model and thinking menus stay mounted but locked, each
+  // carrying the reason in its own words (model vs thinking level) — the
+  // lock is one state with two wordings, not two locks.
+  const switchLock = props.streaming
+    ? 'streaming'
     : props.activeSession?.status === 'running'
-      ? copy.switchDisabledRunning
+      ? 'running'
       : props.activeSession?.status === 'waiting_for_user'
-        ? copy.switchDisabledPermission
+        ? 'permission'
         : undefined;
+  const modelSwitcherDisabledReason =
+    switchLock === 'streaming' ? copy.switchDisabledStreaming
+    : switchLock === 'running' ? copy.switchDisabledRunning
+    : switchLock === 'permission' ? copy.switchDisabledPermission
+    : undefined;
+  const thinkingSwitcherDisabledReason =
+    switchLock === 'streaming' ? copy.thinkingDisabledStreaming
+    : switchLock === 'running' ? copy.thinkingDisabledRunning
+    : switchLock === 'permission' ? copy.thinkingDisabledPermission
+    : undefined;
 
   /**
    * The drawer's contract is context staged for the *next send*: quotes and
@@ -1217,7 +1230,6 @@ export const Composer = forwardRef<
         <AstryxChatComposer
           className="maka-composer-astryx"
           data-maka-contract="composer-inner"
-          data-streaming={props.streaming ? 'true' : undefined}
           // Unreachable, and required. The shell only submits its own value,
           // and it never has one: `value` is passed straight to the controlled
           // ChatComposerInput, so the shell's copy stays empty and its submit
@@ -1294,7 +1306,7 @@ export const Composer = forwardRef<
             </div>
           )}
           footerActions={(
-            <div className="maka-composer-left-controls" data-streaming={props.streaming ? 'true' : undefined}>
+            <div className="maka-composer-left-controls">
               {/* Resting order: ＋ leftmost, then permission icon. */}
               {showPlusMenu ? (
                 <span className="maka-composer-plus-menu">
@@ -1450,6 +1462,7 @@ export const Composer = forwardRef<
                     current={props.activeThinkingLevel}
                     onChange={props.onThinkingLevelChange}
                     disabled={Boolean(modelSwitcherDisabledReason) || props.modelChangePending}
+                    disabledReason={thinkingSwitcherDisabledReason}
                     loading={props.modelChangePending}
                   />
                 ) : (

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -79,6 +79,10 @@ export interface ConversationCopy {
     switchDisabledStreaming: string;
     switchDisabledRunning: string;
     switchDisabledPermission: string;
+    /** Same three lock states as the model switcher, worded for the thinking-level menu beside it. */
+    thinkingDisabledStreaming: string;
+    thinkingDisabledRunning: string;
+    thinkingDisabledPermission: string;
     planModeLabel: string;
     enablePlanMode: string;
     disablePlanMode: string;
@@ -320,6 +324,7 @@ const CONVERSATION_COPY = {
       selectModel: '选择模型', dropToImport: '松开以导入文件内容', addingAttachment: '正在添加附件', addFileOrDirectory: '添加文件或目录',
       chooseSkill: '选择技能', noSkillsAvailable: '当前没有可用技能',
       switchDisabledStreaming: '当前对话正在流式输出，等结束后再切换模型。', switchDisabledRunning: '当前对话正在运行，等结束后再切换模型。', switchDisabledPermission: '当前有工具调用正在等待确认，处理后再切换模型。',
+      thinkingDisabledStreaming: '当前对话正在流式输出，等结束后再切换思考级别。', thinkingDisabledRunning: '当前对话正在运行，等结束后再切换思考级别。', thinkingDisabledPermission: '当前有工具调用正在等待确认，处理后再切换思考级别。',
       planModeLabel: 'Plan', enablePlanMode: '开启 Plan Mode', disablePlanMode: '退出 Plan Mode',
       planModeOnTitle: 'Plan 模式已启用，点击关闭',
       swarmModeLabel: 'Swarm', enableSwarmMode: '开启 Swarm Mode', disableSwarmMode: '退出 Swarm Mode',
@@ -462,6 +467,7 @@ const CONVERSATION_COPY = {
       selectModel: 'Choose model', dropToImport: 'Drop to import file contents', addingAttachment: 'Adding attachment', addFileOrDirectory: 'Add file or directory',
       chooseSkill: 'Choose skills', noSkillsAvailable: 'No skills available',
       switchDisabledStreaming: 'Wait for the current response to finish before switching models.', switchDisabledRunning: 'Wait for the current run to finish before switching models.', switchDisabledPermission: 'Resolve the pending tool permission before switching models.',
+      thinkingDisabledStreaming: 'Wait for the current response to finish before changing the thinking level.', thinkingDisabledRunning: 'Wait for the current run to finish before changing the thinking level.', thinkingDisabledPermission: 'Resolve the pending tool permission before changing the thinking level.',
       planModeLabel: 'Plan', enablePlanMode: 'Enable Plan Mode', disablePlanMode: 'Disable Plan Mode',
       planModeOnTitle: 'Plan mode is on — click to turn off',
       swarmModeLabel: 'Swarm', enableSwarmMode: 'Enable Swarm Mode', disableSwarmMode: 'Disable Swarm Mode',

--- a/packages/ui/stories/model-picker.stories.tsx
+++ b/packages/ui/stories/model-picker.stories.tsx
@@ -89,7 +89,7 @@ export const EmptyCatalog: Story = {
   ),
 };
 
-// Real path: quiet composer left footer — model + adjacent thinking Selector.
+// Real path: quiet composer left footer — model + adjacent thinking menu.
 export const ThinkingLevelSeparate: Story = {
   render: function ThinkingLevelSeparateRender() {
     const [value, setValue] = useState('anthropic-team:claude-sonnet-4');
@@ -113,8 +113,8 @@ export const ThinkingLevelSeparate: Story = {
     );
   },
   play: async ({ canvasElement }) => {
-    const thinking = within(canvasElement).getByRole('combobox', { name: '思考级别' });
+    const thinking = within(canvasElement).getByRole('button', { name: /思考级别/ });
     await userEvent.click(thinking);
-    await within(document.body).findByRole('option', { name: '中' });
+    await within(document.body).findByRole('menuitem', { name: '中' });
   },
 };


### PR DESCRIPTION
## What

**Fix** — the composer unmounted the model + thinking pair while a turn was in flight (`!props.streaming` gate, #1835), so the footer row reflowed on every turn start/end, and the disabled-reason path built for exactly that state sat unreachable. The pair now stays mounted mid-turn, locked with an explanatory tooltip — the same treatment the ＋ menu and permission control already had by design (#1444).

**Refactor** — the pair moves from Astryx Selector form fields (disguised by ~60 lines of product CSS clearing field chrome state by state) onto ghost-button DropdownMenus, the same toolbar primitive as ＋/permission, so resting/hover/focus/disabled chrome derives from one Button. This is also why the two controls never matched their neighbours when tabbing through the footer.

- Model menu keeps one `role=group` section per connection + provider marks; the current value wears a plain check — no radio rows, keeping the quiet footer's sm density.
- Menu search is dropped; the panel keeps its built-in 300px scroll and Astryx typeahead.
- The Selector-based `ModelPicker` with search stays for Settings forms; the workspace picker keeps its quiet-Selector overlay until its own migration.

## External review round (deepseek-v4-flash × 3 lenses, adjudicated)

Three independent review passes (architecture/minimality, defect hunting, test quality) — no P0; findings and their resolution:

- **P1 — mid-turn lock bypassable by keyboard** (an aria-disabled DropdownMenu trigger still opens on ArrowDown; items had no guard). Fixed: the lock now rides on every menu row via item-level `isDisabled`, not just the trigger. Upstream note: Astryx DropdownMenu's `handleButtonKeyDown` should consult `button.isDisabled`.
- **P2 — thinking lock reason unreachable** (tooltip showed the action copy while locked). Fixed: new `thinkingDisabled*` copy; each locked control explains the lock in its own words.
- **P2 — menu popover lost its width ceiling** (the Selector's 260px option cap died with it). Fixed: `.maka-composer-quiet-menu` gets `max-width: min(320px, 92vw)`.
- **P1/P2 — the new streaming test was vacuous** (fixture stacked three independent lock sources, so it passed with the streaming branch deleted) and pinned the derived attribute, not the contract. Fixed: streaming is now the only lock source in the fixture, the test asserts the reason copy plus an at-rest reverse assertion, and the fix is verified by mutation (deleting the streaming branch turns it red).
- **P2 — group markup had zero coverage.** Fixed: new `chat-model-switcher` SSR test pins `role=group` headings, the current-check, the unknown-current leading row, and the row-level lock.
- **P3 batch**: deleted the orphaned 260px trigger rule (the scoped 220px rule always won), dead regex alternatives, stale chevron/Selector comments, and the never-read `data-streaming` attributes.
- **Recorded, not code-changed**: menu accessible name derives from the trigger label (Astryx design); transient aria-label swap during `isLoading` (Astryx behavior); the new-chat empty-state no longer renders the no-op "选择模型" leading row (intentional cleanup).

## Validation

- `@maka/ui`: 348 tests green (mid-turn regression + new chat-model-switcher suite)
- desktop typecheck, biome format/lint, dead-css check green
- E2E `floating-layers` + `send-message` green on real Electron
- Live-app evidence captured: footer resting, model menu open (groups + check + scroll), mid-turn with the pair still mounted (dimmed)
