### PR TITLE
refactor(ui): drop the dead [data-trow] chat rules

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -105,6 +105,9 @@
   --text-supporting-leading: var(--maka-line-body);
 }
 
+/* These boxes need no !important to beat Astryx: its StyleX atoms live in the
+   earlier astryx-components layer, so product CSS in `components` wins on
+   cascade order alone, whatever the specificity — measured, not assumed. */
 .maka-turn .astryx-chat-reasoning [role="button"] > span:last-child,
 .maka-turn .astryx-chat-tool-calls [role="button"] > span:last-child {
   width: 14px;
@@ -122,41 +125,10 @@
 
 @media (hover: hover) {
   .maka-turn .astryx-chat-tool-calls [role="button"]:hover,
-  .maka-turn .astryx-chat-reasoning [role="button"]:hover,
-  .maka-turn [data-trow] .astryx-collapsible-trigger:hover {
+  .maka-turn .astryx-chat-reasoning [role="button"]:hover {
     background-color: var(--color-overlay-hover);
     border-radius: var(--radius-element);
   }
-}
-
-/* Product trow (permission / sandbox / interrupted): Collapsible defaults large.
-
-   Nothing in this file declares !important any more, including the icon-box
-   sizes above. Astryx's StyleX atoms live in the earlier astryx-components
-   layer, so product CSS in `components` already wins on cascade order alone,
-   whatever their specificity — verified by deleting all eight of them and
-   re-measuring: the disclosure chevrons still render 14x14 with a 10x10 svg.
-   Everything here that is not running prose snaps to --maka-line-body, which
-   is declared with the type tiers in maka-tokens.css, so a turn reads as one
-   rhythm rather than a stack of differently-spaced blocks. */
-.maka-turn [data-trow] .astryx-collapsible-trigger {
-  font: var(--maka-text-label);
-  min-height: 24px;
-  gap: var(--spacing-1-5, 6px);
-  padding-block: 2px;
-  border-radius: var(--radius-element);
-  color: var(--color-text-secondary);
-}
-
-.maka-turn [data-trow] .astryx-collapsible-trigger > span:last-child {
-  width: 14px;
-  height: 14px;
-}
-
-.maka-turn [data-trow] .astryx-collapsible-trigger > span:last-child svg,
-.maka-turn [data-trow] .astryx-collapsible-trigger > span:last-child > * {
-  width: 10px;
-  height: 10px;
 }
 
 /* Row detail open: same 0fr→1fr medium motion as group/reasoning.

--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -123,8 +123,8 @@ const DYNAMIC_STYLE_HOOKS = new Set([
   // multi-node hit target (label button + sibling chevron) stays one cursor.
   'astryx-selector',
   'astryx-multi-selector',
-  // Rendered by Astryx's own Collapsible; chat-message.css targets it to give
-  // reasoning/tool disclosures one trigger dialect inside the turn body (#1768).
+  // Rendered by Astryx's own Collapsible; settings/permission.css targets it to
+  // size the capability group's disclosure row.
   'astryx-collapsible-trigger',
   // Astryx's Item (themeProps class on every settings row). rows.css squares
   // its corners inside an open row group: Item ships a 10px radius for its


### PR DESCRIPTION
## Summary

`chat-message.css` still carried four rules keyed on `[data-trow]`: the hover arm inside `@media (hover: hover)`, and the `.astryx-collapsible-trigger` type/box rule plus its two chevron-sizing rules. Nothing renders that attribute any more.

The attribute went away in 6745aa118 ("render every tool row through Astryx"), which retired the bespoke trow renderer — `data-trow="group"` / `data-trow="row"` were emitted by `packages/ui/src/tool-activity.tsx` and are deleted in that diff — and moved permission / sandbox / interrupted rows onto Astryx `ChatToolCalls`. Confirmations: no `data-trow` anywhere in `packages/*/src` or `apps/desktop/src` outside this stylesheet, and `grep -o data-trow apps/desktop/dist-renderer/assets/*.js` is empty, so the shipped bundle has no element these selectors could match.

The block's long comment split three ways rather than going wholesale:

- **Dead with the rules.** "Product trow (permission / sandbox / interrupted): Collapsible defaults large" describes a renderer that no longer exists.
- **Live, and about the rules above.** Product CSS in the `components` layer beats Astryx's StyleX atoms on layer order alone, which is why this file declares no `!important`. That is a fact about the surviving reasoning/tool-call icon boxes, so it moves onto them — minus its count of "all eight" flags, since some of those lived on the rules deleted here and the number no longer resolves to anything a reader can check. The mechanism it was evidence for still holds.
- **Dropped.** The `--maka-line-body` note. That token's only use in this file is the supporting-leading rebind one rule earlier, which its own comment already explains; the rules the note sat above declare nothing but `width` and `height`, so it had no force where it stood.

`--maka-line-body`, `--radius-element` and `--maka-text-label` all keep live consumers elsewhere in the file, so nothing became a dead token.

One follow-on: `check-dead-css.mjs` keeps `astryx-collapsible-trigger` in `DYNAMIC_STYLE_HOOKS` with a comment pointing at chat-message.css. After this change its only consumer is `styles/settings/permission.css`, so the comment is retargeted; the allowlist entry itself is still needed.

### Why `check:stale` did not flag this — and what actually should have

`check:stale` is `scripts/check-stale-dist.mjs`. It compares `src` mtimes against `dist` mtimes per workspace to force a rebuild before tests. It never reads CSS and has no opinion about selectors, so it was never going to catch this — no gap there.

The tool that *is* meant to catch dead CSS is `scripts/check-dead-css.mjs` (wired into `check:release`, not `check:stale`). **It also misses these rules, and that is the real find.** Its class scan matches `/\.(-?[_a-zA-Z][_a-zA-Z0-9-]*)/` — class selectors only — and its token scan looks at `--custom-properties`. An attribute selector such as `[data-trow]` is in neither vocabulary, so a rule can be keyed entirely on a `data-*` hook that no component renders and the script still reports "no dead classes or tokens found ✓", exactly as it does before and after this PR.

The two classes in these selectors did not help either: `maka-turn` and `astryx-collapsible-trigger` are both live elsewhere (`astryx-collapsible-trigger` is in the `DYNAMIC_STYLE_HOOKS` allowlist precisely because it is rendered at runtime), so even a per-rule liveness check that reasoned over class names alone would have called this rule live. Detecting it requires scanning the `data-*` attribute hooks a stylesheet keys on and checking each against source — a real extension to the script rather than a config tweak, and one that needs its own baseline because the renderer keys plenty of live rules on `data-*` (`[data-sender]`, `[data-maka-contract]` in this file alone).

Not doing that extension here: it would land a new detector plus its own baseline alongside an unrelated cleanup. Flagging it so the gap is on the record.

## Verification

Rebased onto `main` after #2228 landed; the two changes touch adjacent but disjoint rules in this stylesheet and merged without conflict.

- `npm run format` / `npm run format:check` / `npm run lint` — clean (Biome, no fixes applied).
- `node scripts/check-dead-css.mjs` — `no dead classes or tokens found ✓` (unchanged, and per above, unchanged for the wrong reason).
- `node --test scripts/check-dead-css.test.mjs` — 13/13 pass.
- CSS contract tests under `apps/desktop/src/main/__tests__/`: `node --test "dist/main/**/*contract*.test.js" "dist/main/**/css-test-helpers.test.js"` — 145/145 pass, 35 suites. This covers every test that parses this stylesheet through `css-test-helpers` / `contract-css-helpers`, including `chat-reasoning-wrap-contract` and #2228's `chat-disclosure-chevron-contract` (the latter asserts the reasoning and tool-call rows declare a 10x10 chevron svg and wrapper, which the deleted trow rules never contributed to).
- `tsc -p tsconfig.main.json` reports pre-existing errors in `runtime-host` / oauth / voice tests. They reproduce identically on a clean `main` checkout and are unrelated to this change.
- No live-app screenshot: the deleted rules cannot match any rendered element, so there is no before/after to show. The bundle grep above is the evidence that rendering is untouched.