### PR TITLE
perf(ui): seed transcript geometry before progressive fill

### DIFF
--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -281,7 +281,27 @@ test('the empty-chat hero centres in the reading column', async ({ window: page 
 // already covered by the pinned settles above.
 test('progressive fill preserves the reading anchor while earlier turns mount', async ({ longTranscriptWindow: page }) => {
   await expect(page.locator('.maka-turn')).toHaveCount(24);
+  // Geometry measured under one width is deliberately invalid under another
+  // (#2224), and it is only recorded when the width held still from fill to
+  // record. The sidebar expansion below finishes AFTER the boot warm-up
+  // settles, so the boot visit refuses to record. One priming round trip
+  // rebuilds the transcript under the expanded width; that visit records,
+  // and the measured journey below returns to a seeded session.
+  await page.locator('button[aria-label="展开侧边栏"]').dispatchEvent('click');
+  await page.locator('[data-session-id="e2e-fixture-long-transcript"]').waitFor({ timeout: 10_000 });
+  await page.getByRole('button', { name: '新任务', exact: true }).dispatchEvent('click');
+  await expect(page.locator('.maka-turn')).toHaveCount(0);
+  await page.getByText('超长会话滚动几何').first().dispatchEvent('click');
+  await expect(page.locator('.maka-turn')).toHaveCount(24);
   await settleGeometry(page, { pinned: true });
+  // data-turn-geometry carries the layout key of the record it announces;
+  // ask for the record covering the width the return trip will run under.
+  await page.waitForFunction(() => {
+    const root = document.querySelector<HTMLElement>('[data-chat-scroll-container="true"]');
+    if (!root) return false;
+    const column = root.querySelector<HTMLElement>('.maka-chat-message-list');
+    return root.dataset.turnGeometry === `${(column ?? root).clientWidth}:${root.dataset.density ?? ''}`;
+  }, undefined, { timeout: 10_000 });
 
   // Widen the fill window so the anchor is sampled while chunks are still
   // mounting; unthrottled, an M-series host can finish the whole fill before
@@ -289,11 +309,7 @@ test('progressive fill preserves the reading anchor while earlier turns mount', 
   const cdp = await page.context().newCDPSession(page);
   await cdp.send('Emulation.setCPUThrottlingRate', { rate: 20 });
 
-  await page.locator('button[aria-label="展开侧边栏"]').dispatchEvent('click');
-  await page
-    .getByRole('navigation', { name: '对话列表' })
-    .getByRole('button', { name: '扩展', exact: true })
-    .dispatchEvent('click');
+  await page.getByRole('button', { name: '新任务', exact: true }).dispatchEvent('click');
   await expect(page.locator('.maka-turn')).toHaveCount(0);
   // Release the bottom follower the way any upward scroll does (Astryx
   // unlocks on scroll direction, any source), then PROVE the reading state
@@ -308,7 +324,7 @@ test('progressive fill preserves the reading anchor while earlier turns mount', 
   // empty.
   const watchPromise = page.evaluate(
     () =>
-      new Promise<{ maxDrift: number; fillSteps: number }>((resolveWatch, rejectWatch) => {
+      new Promise<{ maxDrift: number; fillSteps: number; heightRange: number }>((resolveWatch, rejectWatch) => {
         const root = document.querySelector('[data-chat-scroll-container="true"]') as HTMLElement;
         const guard = window.setTimeout(() => {
           rejectWatch(new Error('Fill did not complete while watching the anchor'));
@@ -331,6 +347,12 @@ test('progressive fill preserves the reading anchor while earlier turns mount', 
           let turnCount = root.querySelectorAll('[data-turn-id]').length;
           let fillSteps = 0;
           let drift = 0;
+          let minHeight = root.scrollHeight;
+          let maxHeight = root.scrollHeight;
+          const noteHeight = () => {
+            minHeight = Math.min(minHeight, root.scrollHeight);
+            maxHeight = Math.max(maxHeight, root.scrollHeight);
+          };
           const observer = new MutationObserver(() => {
             if (root.dataset.progressiveFill === 'complete') {
               observer.disconnect();
@@ -339,7 +361,8 @@ test('progressive fill preserves the reading anchor while earlier turns mount', 
                 rejectWatch(new Error('Fill completed with no step observed; raise the throttle'));
                 return;
               }
-              resolveWatch({ maxDrift: drift, fillSteps });
+              noteHeight();
+              resolveWatch({ maxDrift: drift, fillSteps, heightRange: maxHeight - minHeight });
               return;
             }
             const count = root.querySelectorAll('[data-turn-id]').length;
@@ -347,6 +370,7 @@ test('progressive fill preserves the reading anchor while earlier turns mount', 
               turnCount = count;
               fillSteps += 1;
               drift = Math.max(drift, Math.abs(anchor.getBoundingClientRect().top - baseTop));
+              noteHeight();
             }
           });
           observer.observe(root, {
@@ -424,6 +448,11 @@ test('progressive fill preserves the reading anchor while earlier turns mount', 
   const watch = await watchPromise;
   expect(watch.fillSteps).toBeGreaterThan(0);
   expect(watch.maxDrift).toBeLessThanOrEqual(2);
+  // #2224: the first visit measured every turn, so the return trip holds the
+  // unmounted prefix with a spacer and the document's total height stays
+  // put while chunks replace it. The bound is sub-pixel rounding at the
+  // spacer boundary, far below anything a scrollbar thumb can show.
+  expect(watch.heightRange, JSON.stringify(watch)).toBeLessThanOrEqual(8);
 
   await cdp.send('Emulation.setCPUThrottlingRate', { rate: 1 });
 });

--- a/packages/ui/src/__tests__/turn-size-index.test.ts
+++ b/packages/ui/src/__tests__/turn-size-index.test.ts
@@ -1,0 +1,100 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  createTurnSizeIndex,
+  layoutKeyFor,
+  measureTurnGeometry,
+  prefixHeightFor,
+} from '../turn-size-index.js';
+
+function geometry(heights: Record<string, number>, gap = 4) {
+  return { heights: new Map(Object.entries(heights)), gap };
+}
+
+describe('createTurnSizeIndex', () => {
+  it('returns a record only for the layout it was measured under', () => {
+    const index = createTurnSizeIndex();
+    index.record('s1', layoutKeyFor(900, 'balanced'), geometry({ a: 100 }));
+    assert.ok(index.lookup('s1', layoutKeyFor(900, 'balanced')));
+    assert.equal(index.lookup('s1', layoutKeyFor(700, 'balanced')), undefined);
+    assert.equal(index.lookup('s1', layoutKeyFor(900, 'compact')), undefined);
+    assert.equal(index.lookup('s2', layoutKeyFor(900, 'balanced')), undefined);
+  });
+
+  it('drops the oldest session past capacity', () => {
+    const index = createTurnSizeIndex(2);
+    index.record('s1', 'k', geometry({ a: 1 }));
+    index.record('s2', 'k', geometry({ a: 1 }));
+    index.record('s3', 'k', geometry({ a: 1 }));
+    assert.equal(index.lookup('s1', 'k'), undefined);
+    assert.ok(index.lookup('s2', 'k'));
+    assert.ok(index.lookup('s3', 'k'));
+  });
+
+  it('re-recording refreshes a session instead of evicting it', () => {
+    const index = createTurnSizeIndex(2);
+    index.record('s1', 'k', geometry({ a: 1 }));
+    index.record('s2', 'k', geometry({ a: 1 }));
+    index.record('s1', 'k', geometry({ a: 2 }));
+    index.record('s3', 'k', geometry({ a: 1 }));
+    assert.equal(index.lookup('s2', 'k'), undefined);
+    assert.equal(index.lookup('s1', 'k')?.heights.get('a'), 2);
+  });
+
+  it('ignores an empty measurement', () => {
+    const index = createTurnSizeIndex();
+    index.record('s1', 'k', geometry({}));
+    assert.equal(index.lookup('s1', 'k'), undefined);
+  });
+});
+
+describe('prefixHeightFor', () => {
+  const ids = ['a', 'b', 'c', 'd'];
+
+  it('is zero for a complete transcript', () => {
+    assert.equal(prefixHeightFor(ids, 0, geometry({})), 0);
+    assert.equal(prefixHeightFor(ids, 0, undefined), 0);
+  });
+
+  it('is undefined without a record', () => {
+    assert.equal(prefixHeightFor(ids, 2, undefined), undefined);
+  });
+
+  it('is undefined when any prefix turn lacks a height', () => {
+    assert.equal(prefixHeightFor(ids, 2, geometry({ a: 100 })), undefined);
+  });
+
+  it('sums the prefix turns plus the gaps between them', () => {
+    // Two turns and the one gap between them; the gap joining the spacer to
+    // the first mounted turn belongs to the list.
+    assert.equal(prefixHeightFor(ids, 2, geometry({ a: 100, b: 250.5 }, 4)), 355);
+  });
+});
+
+describe('measureTurnGeometry', () => {
+  it('needs at least one adjacent pair to learn the gap', () => {
+    assert.equal(measureTurnGeometry([]), undefined);
+    assert.equal(measureTurnGeometry([{ turnId: 'a', top: 0, height: 100 }]), undefined);
+  });
+
+  it('records heights and the median between-turn gap', () => {
+    const record = measureTurnGeometry([
+      { turnId: 'a', top: 0, height: 100 },
+      { turnId: 'b', top: 104, height: 200 },
+      { turnId: 'c', top: 308, height: 50 },
+    ]);
+    assert.ok(record);
+    assert.equal(record.gap, 4);
+    assert.equal(record.heights.get('b'), 200);
+  });
+
+  it('rejects a negative gap reading', () => {
+    assert.equal(
+      measureTurnGeometry([
+        { turnId: 'a', top: 0, height: 100 },
+        { turnId: 'b', top: 90, height: 200 },
+      ]),
+      undefined,
+    );
+  });
+});

--- a/packages/ui/src/__tests__/turn-size-index.test.ts
+++ b/packages/ui/src/__tests__/turn-size-index.test.ts
@@ -3,12 +3,34 @@ import { describe, it } from 'node:test';
 import {
   createTurnSizeIndex,
   layoutKeyFor,
+  layoutKeyOf,
+  measureSettledGeometry,
   measureTurnGeometry,
   prefixHeightFor,
 } from '../turn-size-index.js';
 
 function geometry(heights: Record<string, number>, gap = 4) {
   return { heights: new Map(Object.entries(heights)), gap };
+}
+
+function fakeRoot(options: {
+  warmup?: string;
+  width?: number;
+  columnWidth?: number;
+  turns?: Array<{ id: string; top: number; height: number; streaming?: boolean }>;
+}) {
+  return {
+    clientWidth: options.width ?? 900,
+    dataset: { turnWarmup: options.warmup, density: 'balanced' },
+    querySelector: () =>
+      options.columnWidth === undefined ? null : { clientWidth: options.columnWidth },
+    querySelectorAll: () =>
+      (options.turns ?? []).map((turn) => ({
+        hasAttribute: (name: string) => name === 'data-live-streaming' && (turn.streaming ?? false),
+        getAttribute: (name: string) => (name === 'data-turn-id' ? turn.id : null),
+        getBoundingClientRect: () => ({ top: turn.top, height: turn.height }),
+      })),
+  };
 }
 
 describe('createTurnSizeIndex', () => {
@@ -68,6 +90,53 @@ describe('prefixHeightFor', () => {
     // Two turns and the one gap between them; the gap joining the spacer to
     // the first mounted turn belongs to the list.
     assert.equal(prefixHeightFor(ids, 2, geometry({ a: 100, b: 250.5 }, 4)), 355);
+  });
+});
+
+describe('layoutKeyOf', () => {
+  it('keys on the reading column, not the scroller', () => {
+    assert.equal(layoutKeyOf(fakeRoot({ width: 900, columnWidth: 720 })), '720:balanced');
+  });
+
+  it('falls back to the scroller when no column is mounted', () => {
+    assert.equal(layoutKeyOf(fakeRoot({ width: 900 })), '900:balanced');
+  });
+});
+
+describe('measureSettledGeometry', () => {
+  const turns = [
+    { id: 'a', top: 0, height: 100 },
+    { id: 'b', top: 104, height: 200 },
+  ];
+
+  it('is pending until the warm-up settles', () => {
+    const root = fakeRoot({ turns });
+    assert.deepEqual(measureSettledGeometry(root, layoutKeyOf(root)), { status: 'pending' });
+  });
+
+  it('aborts when the layout moved since the key was captured', () => {
+    const before = layoutKeyOf(fakeRoot({ width: 900 }));
+    const root = fakeRoot({ warmup: 'settled', width: 700, turns });
+    assert.deepEqual(measureSettledGeometry(root, before), { status: 'aborted' });
+  });
+
+  it('measures a settled transcript and skips live-streaming turns', () => {
+    const root = fakeRoot({
+      warmup: 'settled',
+      turns: [...turns, { id: 'c', top: 308, height: 40, streaming: true }],
+    });
+    const attempt = measureSettledGeometry(root, layoutKeyOf(root));
+    assert.equal(attempt.status, 'measured');
+    if (attempt.status === 'measured') {
+      assert.equal(attempt.geometry.heights.size, 2);
+      assert.equal(attempt.geometry.heights.get('c'), undefined);
+      assert.equal(attempt.geometry.gap, 4);
+    }
+  });
+
+  it('aborts a settled transcript with no measurable pair', () => {
+    const root = fakeRoot({ warmup: 'settled', turns: [turns[0]!] });
+    assert.deepEqual(measureSettledGeometry(root, layoutKeyOf(root)), { status: 'aborted' });
   });
 });
 

--- a/packages/ui/src/__tests__/turn-size-warmup.test.ts
+++ b/packages/ui/src/__tests__/turn-size-warmup.test.ts
@@ -2,10 +2,12 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { createTurnSizeWarmup, type WarmupScheduler } from '../turn-size-warmup.js';
 
-function fakeTurn(overrides: { live?: boolean; connected?: boolean } = {}) {
+function fakeTurn(overrides: { live?: boolean; connected?: boolean; seeded?: boolean } = {}) {
   return {
     isConnected: overrides.connected ?? true,
-    hasAttribute: (name: string) => name === 'data-live-streaming' && (overrides.live ?? false),
+    hasAttribute: (name: string) =>
+      (name === 'data-live-streaming' && (overrides.live ?? false)) ||
+      (name === 'data-size-seeded' && (overrides.seeded ?? false)),
     style: { contentVisibility: '', contain: '' },
   };
 }
@@ -193,6 +195,17 @@ describe('createTurnSizeWarmup', () => {
 
     flushIdle();
     assert.deepEqual(forced(turns), [0, 2]);
+  });
+
+  it('skips turns whose size was seeded from a previous visit', () => {
+    // #2224: a seeded placeholder already equals the real height, so the
+    // walk has nothing to learn from it.
+    const turns = [fakeTurn({ seeded: true }), fakeTurn(), fakeTurn({ seeded: true })];
+    const { scheduler, flushIdle } = fakeScheduler();
+    createTurnSizeWarmup({ turns: () => turns, chunkSize: 4, scheduler });
+
+    flushIdle();
+    assert.deepEqual(forced(turns), [1]);
   });
 
   it('cancel releases the in-flight chunk and stops the walk', () => {

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -301,6 +301,12 @@ function MessageCopyButton(props: { text: string }) {
  */
 export const TurnView = memo(function TurnView(props: {
   turn: TurnViewModel;
+  /**
+   * #2224: this turn's height as measured on a previous visit under the
+   * current layout. Seeds contain-intrinsic-size so the placeholder equals
+   * the real size, and marks the turn for the warm-up to skip.
+   */
+  seededHeight?: number;
   userLabel?: string;
   /**
    * PR109d-b: footer actions derived from `TurnStatus` + lineage map
@@ -401,6 +407,12 @@ export const TurnView = memo(function TurnView(props: {
       data-turn-id={turn.turnId}
       data-live-streaming={props.liveStreaming ? 'true' : undefined}
       data-search-highlight={props.searchHighlighted ? 'true' : undefined}
+      data-size-seeded={props.seededHeight !== undefined ? 'true' : undefined}
+      style={
+        props.seededHeight !== undefined
+          ? { containIntrinsicSize: `auto ${props.seededHeight}px` }
+          : undefined
+      }
       tabIndex={props.searchHighlighted ? -1 : undefined}
     >
       {forwardBadges.length > 0 && (

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -34,7 +34,7 @@ import {
 } from './chat-turn.js';
 import { useChatScroll } from './use-chat-scroll.js';
 import { useProgressiveTurnMount } from './use-progressive-turn-mount.js';
-import { createTurnSizeIndex, layoutKeyFor, measureTurnGeometry } from './turn-size-index.js';
+import { createTurnSizeIndex, layoutKeyOf, measureSettledGeometry } from './turn-size-index.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 import { SessionContextLayer } from './session-context-layer.js';
@@ -42,15 +42,6 @@ import { SessionContextLayer } from './session-context-layer.js';
 // #2224: one geometry cache for the app's single ChatView. Session-keyed
 // inside; module scope only saves threading it through the shell.
 const turnSizeIndex = createTurnSizeIndex();
-
-// Turn heights are set by the reading column's width, not the scroller's:
-// the column is max-width capped and centred, so chrome around the scroller
-// (sidebar, panels) can change the scroller's width without moving a single
-// line break. Key on the column so records survive that chrome.
-function layoutKeyOf(root: HTMLElement): string {
-  const column = root.querySelector<HTMLElement>('.maka-chat-message-list');
-  return layoutKeyFor((column ?? root).clientWidth, root.dataset.density);
-}
 
 export function ChatView(props: {
   messages: StoredMessage[];
@@ -391,17 +382,17 @@ export function ChatView(props: {
   // the fill runs. Without them (first visit, resized window) everything
   // below degrades to the plain #2052 fill and the warm-up relearns sizes.
   const sessionId = props.activeSession?.id;
-  // The lookup must land in the same commit as the session switch, or the
-  // scroller paints one frame at its unseeded height and the spacer arrives
-  // as a visible jump. An in-place switch has the scroller ref during
-  // render, so the memo reads it there. Two things invalidate that read
-  // and are answered by the nudge effect below, each costing one late
-  // frame: on a fresh mount the ref is still null (the scroller is an
-  // ancestor host whose ref attaches after descendant effects), and on
-  // platforms with classic scrollbars the column is wider until enough
-  // turns mount to overflow, so the empty-surface read misses the record.
-  // Nudges stop once the fill completes; token streaming never re-reads
-  // layout.
+  // The lookup should land in the same commit as the session switch, so the
+  // scroller never paints a frame at its unseeded height. An in-place
+  // switch has the scroller ref during render and the memo reads it there.
+  // Two things invalidate that read: on a fresh mount the ref is still null
+  // (the scroller is an ancestor host whose ref attaches after descendant
+  // effects), and on platforms with classic scrollbars the column is wider
+  // until enough turns mount to overflow, so an early read misses the
+  // record. The nudge effect below answers both by retrying after every
+  // commit while the fill window is open (each fill chunk moves mountStart)
+  // and stopping on the first hit or when the window closes, so token
+  // streaming never re-reads layout.
   const [lookupPass, setLookupPass] = useState(0);
   const seededGeometry = useMemo(() => {
     const root = scrollRef.current;
@@ -416,8 +407,10 @@ export function ChatView(props: {
     seededGeometry,
   });
   useEffect(() => {
-    if (!turnsFilled && scrollRef.current) setLookupPass((count) => count + 1);
-  }, [sessionId, orderedTurnIds, turnsFilled, scrollRef]);
+    if (!turnsFilled && !seededGeometry && scrollRef.current) {
+      setLookupPass((count) => count + 1);
+    }
+  }, [sessionId, orderedTurnIds, mountStart, turnsFilled, seededGeometry, scrollRef]);
   const mountedTurns = mountStart === 0 ? turns : turns.slice(mountStart);
   // Record geometry once the transcript has settled: fill complete and the
   // warm-up done, so every turn's box is its remembered final size and
@@ -426,32 +419,28 @@ export function ChatView(props: {
   // Streaming turns are still moving and are left out.
   useEffect(() => {
     const root = scrollRef.current;
-    if (!sessionId || !root || !turnsFilled) return;
+    // A pair of turns is the smallest transcript measureSettledGeometry
+    // accepts, and the pair gate also keeps an empty session from polling
+    // forever: with no turns the warm-up never runs, so 'settled' is never
+    // written and the wait below would have no end.
+    if (!sessionId || !root || !turnsFilled || orderedTurnIds.length < 2) return;
     let disposed = false;
     let timer: number | undefined;
-    // Boxes are only real at the width the warm-up walked under. If the
-    // layout changes while we wait (a sidebar toggle finishing late),
-    // off-screen turns keep remembered sizes from the old width, and a
-    // measurement now would file stale heights under the new key. Give up
-    // instead; the next visit re-learns at the new width.
+    // Backstop for the same never-settles shape arriving some other way: a
+    // walk that has not settled after 150 polls is not going to, and a dead
+    // timer must not keep reading layout on a resting surface.
+    let polls = 0;
     const startKey = layoutKeyOf(root);
     const measure = () => {
-      if (disposed || layoutKeyOf(root) !== startKey) return;
-      if (root.dataset.turnWarmup !== 'settled') {
-        timer = window.setTimeout(measure, 200);
+      if (disposed) return;
+      const attempt = measureSettledGeometry(root, startKey);
+      if (attempt.status === 'pending') {
+        polls += 1;
+        if (polls < 150) timer = window.setTimeout(measure, 200);
         return;
       }
-      const boxes: Array<{ turnId: string; top: number; height: number }> = [];
-      for (const el of root.querySelectorAll<HTMLElement>('.maka-turn[data-turn-id]')) {
-        if (el.hasAttribute('data-live-streaming')) continue;
-        const turnId = el.getAttribute('data-turn-id');
-        if (!turnId) continue;
-        const rect = el.getBoundingClientRect();
-        boxes.push({ turnId, top: rect.top, height: rect.height });
-      }
-      const geometry = measureTurnGeometry(boxes);
-      if (geometry) {
-        turnSizeIndex.record(sessionId, startKey, geometry);
+      if (attempt.status === 'measured') {
+        turnSizeIndex.record(sessionId, startKey, attempt.geometry);
         // Published like data-turn-warmup, with the key as the value: a
         // wait can then ask for the record covering the layout it is about
         // to rely on, not merely some record from an earlier width.
@@ -462,6 +451,9 @@ export function ChatView(props: {
     return () => {
       disposed = true;
       window.clearTimeout(timer);
+      // The key describes the transcript that was measured; whatever
+      // replaces it must not inherit the announcement.
+      delete root.dataset.turnGeometry;
     };
   }, [sessionId, turnsFilled, orderedTurnIds, scrollRef]);
   const { highlightedTurnId } = useChatScroll({

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   AlertTriangle,
   ArrowRight,
@@ -34,9 +34,23 @@ import {
 } from './chat-turn.js';
 import { useChatScroll } from './use-chat-scroll.js';
 import { useProgressiveTurnMount } from './use-progressive-turn-mount.js';
+import { createTurnSizeIndex, layoutKeyFor, measureTurnGeometry } from './turn-size-index.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 import { SessionContextLayer } from './session-context-layer.js';
+
+// #2224: one geometry cache for the app's single ChatView. Session-keyed
+// inside; module scope only saves threading it through the shell.
+const turnSizeIndex = createTurnSizeIndex();
+
+// Turn heights are set by the reading column's width, not the scroller's:
+// the column is max-width capped and centred, so chrome around the scroller
+// (sidebar, panels) can change the scroller's width without moving a single
+// line break. Key on the column so records survive that chrome.
+function layoutKeyOf(root: HTMLElement): string {
+  const column = root.querySelector<HTMLElement>('.maka-chat-message-list');
+  return layoutKeyFor((column ?? root).clientWidth, root.dataset.density);
+}
 
 export function ChatView(props: {
   messages: StoredMessage[];
@@ -371,13 +385,82 @@ export function ChatView(props: {
   // prompt rail, so presentation caching (#2030) and rail geometry are not
   // window-dependent; only the JSX mapping below is sliced.
   const orderedTurnIds = useMemo(() => turns.map((turn) => turn.turnId), [turns]);
-  const { start: mountStart, filled: turnsFilled, revealTurn } = useProgressiveTurnMount({
-    sessionId: props.activeSession?.id,
+  // #2224: heights measured on a previous visit under the current layout.
+  // With them the unmounted prefix is held by one spacer and each turn's
+  // intrinsic size is seeded, so the scroller's total height stays put while
+  // the fill runs. Without them (first visit, resized window) everything
+  // below degrades to the plain #2052 fill and the warm-up relearns sizes.
+  const sessionId = props.activeSession?.id;
+  // The lookup must land in the same commit as the session switch, or the
+  // scroller paints one frame at its unseeded height and the spacer arrives
+  // as a visible jump. An in-place switch has the scroller ref during
+  // render, so the memo reads it there (once per session, never per token,
+  // clientWidth stays out of the streaming render path). On a fresh mount
+  // the ref is still null, because the scroller is an ancestor host whose
+  // ref attaches after descendant effects; the effect below nudges one
+  // re-render once it exists, and that path pays the one late frame.
+  const [refReady, setRefReady] = useState(0);
+  useEffect(() => {
+    if (scrollRef.current) setRefReady((count) => count + 1);
+  }, [sessionId, scrollRef]);
+  const seededGeometry = useMemo(() => {
+    const root = scrollRef.current;
+    if (!sessionId || !root) return undefined;
+    return turnSizeIndex.lookup(sessionId, layoutKeyOf(root));
+  }, [sessionId, scrollRef, refReady]);
+  const { start: mountStart, filled: turnsFilled, prefixHeight, revealTurn } = useProgressiveTurnMount({
+    sessionId,
     turnIds: orderedTurnIds,
     scrollRef,
     targetTurnId: props.scrollTargetTurn?.turnId,
+    seededGeometry,
   });
   const mountedTurns = mountStart === 0 ? turns : turns.slice(mountStart);
+  // Record geometry once the transcript has settled: fill complete and the
+  // warm-up done, so every turn's box is its remembered final size and
+  // reading it forces no render. An exit-time capture would be too late,
+  // React runs effect cleanups after the next session's DOM is already in.
+  // Streaming turns are still moving and are left out.
+  useEffect(() => {
+    const root = scrollRef.current;
+    if (!sessionId || !root || !turnsFilled) return;
+    let disposed = false;
+    let timer: number | undefined;
+    // Boxes are only real at the width the warm-up walked under. If the
+    // layout changes while we wait (a sidebar toggle finishing late),
+    // off-screen turns keep remembered sizes from the old width, and a
+    // measurement now would file stale heights under the new key. Give up
+    // instead; the next visit re-learns at the new width.
+    const startKey = layoutKeyOf(root);
+    const measure = () => {
+      if (disposed || layoutKeyOf(root) !== startKey) return;
+      if (root.dataset.turnWarmup !== 'settled') {
+        timer = window.setTimeout(measure, 200);
+        return;
+      }
+      const boxes: Array<{ turnId: string; top: number; height: number }> = [];
+      for (const el of root.querySelectorAll<HTMLElement>('.maka-turn[data-turn-id]')) {
+        if (el.hasAttribute('data-live-streaming')) continue;
+        const turnId = el.getAttribute('data-turn-id');
+        if (!turnId) continue;
+        const rect = el.getBoundingClientRect();
+        boxes.push({ turnId, top: rect.top, height: rect.height });
+      }
+      const geometry = measureTurnGeometry(boxes);
+      if (geometry) {
+        turnSizeIndex.record(sessionId, startKey, geometry);
+        // Published like data-turn-warmup, with the key as the value: a
+        // wait can then ask for the record covering the layout it is about
+        // to rely on, not merely some record from an earlier width.
+        root.dataset.turnGeometry = startKey;
+      }
+    };
+    timer = window.setTimeout(measure, 200);
+    return () => {
+      disposed = true;
+      window.clearTimeout(timer);
+    };
+  }, [sessionId, turnsFilled, orderedTurnIds, scrollRef]);
   const { highlightedTurnId } = useChatScroll({
     scrollRef,
     sessionId: props.activeSession?.id,
@@ -516,11 +599,27 @@ export function ChatView(props: {
           {showEmptyState ? null : (
             <>
               {chat.length === 0 && !streamingActive ? emptyContent : null}
+              {/* #2224: stands in for the unmounted prefix so the scroller's
+                  total height (and the native scrollbar) holds still while
+                  the fill replaces it chunk by chunk. */}
+              {mountStart > 0 && prefixHeight !== undefined && prefixHeight > 0 && (
+                <div
+                  aria-hidden="true"
+                  className="maka-turn-prefix-spacer"
+                  // transition: none matters: the app-wide transition rule
+                  // (even at its near-zero duration) applies height changes
+                  // a frame after the commit, so the fill's same-frame
+                  // scroll compensation would read the old spacer height
+                  // and the anchor would jump by one chunk per step.
+                  style={{ height: prefixHeight, flex: '0 0 auto', transition: 'none' }}
+                />
+              )}
               {mountedTurns.map((turn) => {
                 return (
                   <Fragment key={turn.turnId}>
                     <TurnView
                       turn={turn}
+                      seededHeight={seededGeometry?.heights.get(turn.turnId)}
                       userLabel={props.userLabel}
                       footerActions={turnPresentation?.footerActionsByTurn[turn.turnId]}
                       onFooterAction={stableTurnFooterAction}

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -394,20 +394,20 @@ export function ChatView(props: {
   // The lookup must land in the same commit as the session switch, or the
   // scroller paints one frame at its unseeded height and the spacer arrives
   // as a visible jump. An in-place switch has the scroller ref during
-  // render, so the memo reads it there (once per session, never per token,
-  // clientWidth stays out of the streaming render path). On a fresh mount
-  // the ref is still null, because the scroller is an ancestor host whose
-  // ref attaches after descendant effects; the effect below nudges one
-  // re-render once it exists, and that path pays the one late frame.
-  const [refReady, setRefReady] = useState(0);
-  useEffect(() => {
-    if (scrollRef.current) setRefReady((count) => count + 1);
-  }, [sessionId, scrollRef]);
+  // render, so the memo reads it there. Two things invalidate that read
+  // and are answered by the nudge effect below, each costing one late
+  // frame: on a fresh mount the ref is still null (the scroller is an
+  // ancestor host whose ref attaches after descendant effects), and on
+  // platforms with classic scrollbars the column is wider until enough
+  // turns mount to overflow, so the empty-surface read misses the record.
+  // Nudges stop once the fill completes; token streaming never re-reads
+  // layout.
+  const [lookupPass, setLookupPass] = useState(0);
   const seededGeometry = useMemo(() => {
     const root = scrollRef.current;
     if (!sessionId || !root) return undefined;
     return turnSizeIndex.lookup(sessionId, layoutKeyOf(root));
-  }, [sessionId, scrollRef, refReady]);
+  }, [sessionId, scrollRef, lookupPass]);
   const { start: mountStart, filled: turnsFilled, prefixHeight, revealTurn } = useProgressiveTurnMount({
     sessionId,
     turnIds: orderedTurnIds,
@@ -415,6 +415,9 @@ export function ChatView(props: {
     targetTurnId: props.scrollTargetTurn?.turnId,
     seededGeometry,
   });
+  useEffect(() => {
+    if (!turnsFilled && scrollRef.current) setLookupPass((count) => count + 1);
+  }, [sessionId, orderedTurnIds, turnsFilled, scrollRef]);
   const mountedTurns = mountStart === 0 ? turns : turns.slice(mountStart);
   // Record geometry once the transcript has settled: fill complete and the
   // warm-up done, so every turn's box is its remembered final size and

--- a/packages/ui/src/turn-size-index.ts
+++ b/packages/ui/src/turn-size-index.ts
@@ -1,0 +1,107 @@
+/**
+ * Measured turn geometry, remembered across session switches (#2224).
+ *
+ * The progressive mount (#2052) starts a revisited session with no geometry
+ * for the unmounted prefix, so the scroller's height grows during the idle
+ * fill and the native scrollbar visibly shrinks and jumps. Remounting also
+ * discards the sizes content-visibility had remembered, so the warm-up had
+ * to learn the same geometry again.
+ *
+ * A record keeps each turn's own height plus the list's between-turn gap,
+ * keyed by session and by the layout the measurement was taken under. A
+ * revisit under the same layout holds the unmounted prefix with one spacer
+ * and seeds each turn's contain-intrinsic-size; a first visit, a changed
+ * layout, or a missing turn yields no answer and the caller falls back to
+ * the plain fill and warm-up path.
+ *
+ * Deliberately in-memory and bounded: geometry is cheap to relearn, so the
+ * index is a cache, not a store.
+ */
+
+export interface TurnGeometryRecord {
+  /** Each turn's own border-box height, unrounded. */
+  readonly heights: ReadonlyMap<string, number>;
+  /** The list's between-turn gap, so a spacer can stand in for N turns
+   *  plus the N-1 gaps between them. */
+  readonly gap: number;
+}
+
+export interface TurnSizeIndex {
+  record(sessionKey: string, layoutKey: string, geometry: TurnGeometryRecord): void;
+  lookup(sessionKey: string, layoutKey: string): TurnGeometryRecord | undefined;
+}
+
+export function createTurnSizeIndex(capacity = 12): TurnSizeIndex {
+  const sessions = new Map<string, { layoutKey: string; geometry: TurnGeometryRecord }>();
+  return {
+    record(sessionKey, layoutKey, geometry) {
+      if (geometry.heights.size === 0) return;
+      sessions.delete(sessionKey);
+      sessions.set(sessionKey, { layoutKey, geometry });
+      while (sessions.size > capacity) {
+        const oldest = sessions.keys().next().value;
+        if (oldest === undefined) break;
+        sessions.delete(oldest);
+      }
+    },
+    lookup(sessionKey, layoutKey) {
+      const entry = sessions.get(sessionKey);
+      if (!entry || entry.layoutKey !== layoutKey) return undefined;
+      return entry.geometry;
+    },
+  };
+}
+
+/** One key per geometry-relevant layout: measurements do not survive a
+ *  width or density change. */
+export function layoutKeyFor(width: number, density: string | undefined): string {
+  return `${Math.round(width)}:${density ?? ''}`;
+}
+
+/**
+ * Height of the spacer standing in for the unmounted prefix, or undefined
+ * when any prefix turn lacks a measurement. All-or-nothing on purpose: a
+ * partially estimated spacer would still let the total height wander, which
+ * is the symptom this index exists to remove.
+ *
+ * The spacer replaces `start` turns and the gaps BETWEEN them; the gap that
+ * joins it to the first mounted turn is the list's own and is not counted.
+ */
+export function prefixHeightFor(
+  turnIds: readonly string[],
+  start: number,
+  geometry: TurnGeometryRecord | undefined,
+): number | undefined {
+  if (start <= 0) return 0;
+  if (!geometry) return undefined;
+  let total = (start - 1) * geometry.gap;
+  for (let index = 0; index < start; index += 1) {
+    const height = geometry.heights.get(turnIds[index]!);
+    if (height === undefined) return undefined;
+    total += height;
+  }
+  return Math.round(total);
+}
+
+/**
+ * Build a record from mounted turn boxes, in document order. The gap is
+ * taken from the space between adjacent boxes; without at least one
+ * adjacent settled pair there is no gap to learn and nothing is recorded.
+ */
+export function measureTurnGeometry(
+  boxes: ReadonlyArray<{ turnId: string; top: number; height: number }>,
+): TurnGeometryRecord | undefined {
+  if (boxes.length < 2) return undefined;
+  const heights = new Map<string, number>();
+  const gaps: number[] = [];
+  for (let index = 0; index < boxes.length; index += 1) {
+    const box = boxes[index]!;
+    heights.set(box.turnId, box.height);
+    const next = boxes[index + 1];
+    if (next) gaps.push(next.top - box.top - box.height);
+  }
+  gaps.sort((a, b) => a - b);
+  const gap = gaps[Math.floor(gaps.length / 2)]!;
+  if (!(gap >= 0)) return undefined;
+  return { heights, gap };
+}

--- a/packages/ui/src/turn-size-index.ts
+++ b/packages/ui/src/turn-size-index.ts
@@ -14,8 +14,9 @@
  * layout, or a missing turn yields no answer and the caller falls back to
  * the plain fill and warm-up path.
  *
- * Deliberately in-memory and bounded: geometry is cheap to relearn, so the
- * index is a cache, not a store.
+ * Deliberately in-memory and bounded, one entry per session (a session's
+ * record is replaced, never accumulated per layout): geometry is cheap to
+ * relearn, so the index is a cache, not a store.
  */
 
 export interface TurnGeometryRecord {
@@ -81,6 +82,71 @@ export function prefixHeightFor(
     total += height;
   }
   return Math.round(total);
+}
+
+/** The DOM surface the measurement reads, structurally typed so the guards
+ *  are testable without a real scroller (same pattern as the warm-up). */
+export interface GeometryRoot {
+  readonly clientWidth: number;
+  readonly dataset: { turnWarmup?: string; density?: string };
+  querySelector(selectors: string): { clientWidth: number } | null;
+  querySelectorAll(selectors: string): ArrayLike<GeometryTurnElement>;
+}
+
+export interface GeometryTurnElement {
+  hasAttribute(qualifiedName: string): boolean;
+  getAttribute(qualifiedName: string): string | null;
+  getBoundingClientRect(): { top: number; height: number };
+}
+
+/**
+ * The layout key of a live scroller. Turn heights are set by the reading
+ * column's width, not the scroller's: the column is max-width capped and
+ * centred, so chrome around the scroller (sidebar, panels) can change the
+ * scroller's width without moving a single line break. Key on the column so
+ * records survive that chrome.
+ */
+export function layoutKeyOf(root: GeometryRoot): string {
+  const column = root.querySelector('.maka-chat-message-list');
+  return layoutKeyFor((column ?? root).clientWidth, root.dataset.density);
+}
+
+export type SettledGeometryResult =
+  | { status: 'pending' }
+  | { status: 'aborted' }
+  | { status: 'measured'; geometry: TurnGeometryRecord };
+
+/**
+ * One measurement attempt against a settled transcript. The guards are what
+ * keep the cache honest, so they live here where a unit test can drive each
+ * one deterministically:
+ *
+ * - `aborted` when the layout key moved since `startKey` was captured: the
+ *   warm-up walked under the old width, so off-screen turns still report
+ *   remembered sizes from it, and recording them under the new key would
+ *   poison every future lookup there. Terminal; the next visit re-learns.
+ * - `pending` while the warm-up has not settled: boxes are still moving,
+ *   ask again later.
+ * - `aborted` when the settled transcript has no measurable pair (a lone
+ *   turn, or every turn still streaming). Terminal for the same reason the
+ *   walk is done: nothing further will appear without a remount.
+ *
+ * Live-streaming turns are skipped, not aborted over: their boxes grow
+ * every frame, but the turns around them are final.
+ */
+export function measureSettledGeometry(root: GeometryRoot, startKey: string): SettledGeometryResult {
+  if (layoutKeyOf(root) !== startKey) return { status: 'aborted' };
+  if (root.dataset.turnWarmup !== 'settled') return { status: 'pending' };
+  const boxes: Array<{ turnId: string; top: number; height: number }> = [];
+  for (const turn of Array.from(root.querySelectorAll('.maka-turn[data-turn-id]'))) {
+    if (turn.hasAttribute('data-live-streaming')) continue;
+    const turnId = turn.getAttribute('data-turn-id');
+    if (!turnId) continue;
+    const rect = turn.getBoundingClientRect();
+    boxes.push({ turnId, top: rect.top, height: rect.height });
+  }
+  const geometry = measureTurnGeometry(boxes);
+  return geometry ? { status: 'measured', geometry } : { status: 'aborted' };
 }
 
 /**

--- a/packages/ui/src/turn-size-warmup.ts
+++ b/packages/ui/src/turn-size-warmup.ts
@@ -83,6 +83,10 @@ export function createTurnSizeWarmup(options: {
   // and grows every frame, so leave it alone. Seeded turns (#2224) carry a
   // measured intrinsic size from a previous visit, so their placeholder is
   // already the real height and there is nothing left for the walk to learn.
+  // If a turn's content changed between visits (a late image, an edit), its
+  // seed is stale until the turn scrolls into view and renders; that error is
+  // bounded to the changed turns and self-heals, which is the trade taken for
+  // skipping their forced render here.
   const queue = Array.from(options.turns())
     .filter((turn) => !turn.hasAttribute('data-live-streaming') && !turn.hasAttribute('data-size-seeded'))
     .reverse();

--- a/packages/ui/src/turn-size-warmup.ts
+++ b/packages/ui/src/turn-size-warmup.ts
@@ -80,9 +80,11 @@ export function createTurnSizeWarmup(options: {
   if (!scheduler) return () => {};
   const chunkSize = options.chunkSize ?? 16;
   // Bottom-up queue. The live-streaming tail is already forced visible by CSS
-  // and grows every frame — leave it alone.
+  // and grows every frame, so leave it alone. Seeded turns (#2224) carry a
+  // measured intrinsic size from a previous visit, so their placeholder is
+  // already the real height and there is nothing left for the walk to learn.
   const queue = Array.from(options.turns())
-    .filter((turn) => !turn.hasAttribute('data-live-streaming'))
+    .filter((turn) => !turn.hasAttribute('data-live-streaming') && !turn.hasAttribute('data-size-seeded'))
     .reverse();
   let forcedChunk: WarmupTurnElement[] = [];
   let cancelScheduled: (() => void) | undefined;

--- a/packages/ui/src/use-progressive-turn-mount.ts
+++ b/packages/ui/src/use-progressive-turn-mount.ts
@@ -8,6 +8,7 @@ import {
   type MountWindowState,
   type ViewportMetrics,
 } from './progressive-turn-mount.js';
+import { prefixHeightFor, type TurnGeometryRecord } from './turn-size-index.js';
 import type { WarmupScheduler } from './turn-size-warmup.js';
 
 function defaultScheduler(): WarmupScheduler | undefined {
@@ -53,12 +54,23 @@ export function useProgressiveTurnMount(input: {
   scrollRef: RefObject<HTMLElement | null>;
   /** Search navigation target; mounted before use-chat-scroll queries it. */
   targetTurnId?: string;
+  /**
+   * Turn geometry measured on a previous visit (#2224). When every
+   * unmounted turn has a height, the caller renders a prefix spacer
+   * instead of letting the document grow during the fill.
+   */
+  seededGeometry?: TurnGeometryRecord;
   scheduler?: WarmupScheduler;
 }): {
   /** Render turns from this index on; 0 means the transcript is complete. */
   start: number;
   /** True once every turn is mounted; gates the turn-size warm-up. */
   filled: boolean;
+  /**
+   * Height standing in for the unmounted prefix, undefined when any prefix
+   * turn lacks a measurement; 0 once the transcript is complete.
+   */
+  prefixHeight: number | undefined;
   /** Mount a specific turn now and scroll to it once it exists. */
   revealTurn: (turnId: string) => void;
 } {
@@ -134,5 +146,10 @@ export function useProgressiveTurnMount(input: {
     setPendingReveal(turnId);
   }, []);
 
-  return { start: reconciled.start, filled: reconciled.start === 0, revealTurn };
+  return {
+    start: reconciled.start,
+    filled: reconciled.start === 0,
+    prefixHeight: prefixHeightFor(input.turnIds, reconciled.start, input.seededGeometry),
+    revealTurn,
+  };
 }


### PR DESCRIPTION
## Summary

Closes #2224

Returning to a session rebuilds the transcript from a 10-turn tail, so during the progressive fill the document grows chunk by chunk and the scrollbar keeps moving. This PR remembers turn heights once a session settles and uses them on the next visit:

- `turn-size-index`: a small in-memory LRU keyed by session and layout (reading-column width plus density). Geometry is recorded after the fill and warm-up finish, and only if the layout held still in between, since stale remembered sizes would poison the record.
- On return, one spacer stands in for the unmounted prefix and each turn seeds its `contain-intrinsic-size` from the record. The scroller's total height stays put while chunks replace the spacer, and seeded turns skip the warm-up walk.
- Without a record (first visit, resized window) everything degrades to the plain #2052 fill.

Two timing details worth calling out: the spacer sets `transition: none` because the app-wide transition rule delays height changes past the commit that mounts a chunk, which broke same-frame scroll compensation; and the lookup retries until the fill window closes, because on platforms with classic scrollbars the column stays wider until enough turns mount to overflow.

## Verification

- `packages/ui` unit tests pass, with new coverage for the index, the prefix arithmetic, geometry measurement, and the warm-up skip.
- `apps/desktop` scroll-geometry e2e suite passes. The reading-anchor test now drives the full journey (settle, record, leave, return under 20x CPU throttle) and asserts the anchored turn holds still and the total height stays within rounding while the fill runs.
