### PR TITLE
perf(runtime): stream OpenAI Responses incrementally

### DIFF
--- a/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
+++ b/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
@@ -3199,6 +3199,37 @@ SOFTWARE.
 
 ================================================================================
 
+Package: agent-base@7.1.4
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/TooTallNate/proxy-agents.git#packages/agent-base
+
+--- LICENSE ---
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
 Package: ai@7.0.52
 Declared license: Apache-2.0
 Selected license: Apache-2.0
@@ -8176,6 +8207,37 @@ SOFTWARE.
 
 ================================================================================
 
+Package: https-proxy-agent@7.0.6
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/TooTallNate/proxy-agents.git#packages/https-proxy-agent
+
+--- LICENSE ---
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
 Package: iconv-lite@0.6.3
 Declared license: MIT
 Selected license: MIT
@@ -12075,6 +12137,37 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+Package: socks-proxy-agent@8.0.5
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/TooTallNate/proxy-agents.git#packages/socks-proxy-agent
+
+--- LICENSE ---
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 

--- a/docs/architecture/openai-responses-incremental-transport.md
+++ b/docs/architecture/openai-responses-incremental-transport.md
@@ -1,0 +1,66 @@
+# OpenAI Responses incremental transport
+
+## 1. Problem and invariant
+
+Long tool loops currently rebuild and upload the complete provider history on every step. The
+durable Runtime event ledger remains the source of truth, but the OpenAI Responses transport may
+reuse a turn-scoped WebSocket and send only the suffix after the previous response.
+
+The optimization must never change the logical request. A continuation is eligible only when the
+current Maka message list is exactly:
+
+1. the previous request messages;
+2. followed by the previous SDK response messages;
+3. followed by at least one new message.
+
+Otherwise the adapter sends the complete request and starts a new continuation chain.
+
+## 2. Ownership and lifecycle
+
+- `ModelAdapter` owns semantic continuation state, keyed by turn id so concurrent turns never
+  share a chain.
+- The OpenAI Responses transport owns the matching WebSocket and wire request/response state.
+- The session id supplies a stable `prompt_cache_key`; an explicit caller value wins.
+- Durable history remains complete. Only the provider-bound wire projection is incremental.
+
+## 3. Failure matrix
+
+| Condition | Behavior |
+| --- | --- |
+| First request or message-prefix mismatch | Full request over WebSocket |
+| Request options/model/tools changed | Full request; replace the chain baseline |
+| Missing/stale response id | Clear the chain; Runtime retry starts from durable full history |
+| WebSocket connect failure | Full HTTP request; disable continuation for that turn |
+| Socket closes or stream fails | Clear the chain; normal Runtime retry starts from full history |
+| Same turn attempts concurrent requests | Full HTTP request for the contender |
+| Abort/cancel | Close the socket and clear the chain |
+| Configured network proxy | WebSocket uses the same immutable proxy snapshot and bypass list |
+| OAuth subscription or Chat Completions model | Existing transport, unchanged |
+
+## 4. Test plan
+
+- Unit-test exact semantic prefix/delta selection and every mismatch fallback.
+- Unit-test stable cache-key merging without overwriting explicit provider options.
+- Exercise a local WebSocket server to verify connection reuse, `previous_response_id`, delta-only
+  input, and SSE translation.
+- Verify WebSocket setup failure reconstructs and sends a complete HTTP request.
+- Run Runtime typecheck and focused tests, then the repository validation appropriate to the diff.
+
+## 5. Observability and rollout
+
+The existing provider-attempt telemetry already records request bytes, latency, time to first token,
+and cache usage. Rollout can compare those fields by provider step. WebSocket is limited to the
+API-key OpenAI Responses adapter; direct, HTTP(S)-proxy, and SOCKS5 routes follow the existing
+transport snapshot. Every failure path preserves a complete HTTP fallback. OAuth subscription
+transports remain on their refresh-aware HTTP path.
+
+## 6. Verification outcome
+
+- Runtime TypeScript build passes.
+- Focused continuation, WebSocket, existing Responses HTTP, model-adapter, and scoped-network tests:
+  60 passed.
+- HTTP proxy behavior is exercised end-to-end through an authenticated local CONNECT proxy.
+- SOCKS5 selection and shared bypass-list routing are covered at the transport boundary.
+- A Runtime-wide run passed 3,150 tests before repository dependency patches were applied; the 27
+  patch-dependent failures pass after applying the patches. One unrelated pre-existing macOS
+  sandbox assertion remains environment-sensitive (`/usr/local` executable-root ordering).

--- a/package-lock.json
+++ b/package-lock.json
@@ -11987,6 +11987,29 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13081,16 +13104,20 @@
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/headless": "^6.0.0",
         "ai": "^7.0.31",
+        "https-proxy-agent": "^7.0.6",
         "image-dimensions": "^2.5.1",
         "node-pty": "^1.2.0-beta.14",
         "qrcode": "^1.5.4",
         "socks": "^2.8.9",
+        "socks-proxy-agent": "^8.0.5",
         "undici": "^8.7.0",
+        "ws": "^8.21.0",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
         "@maka/storage": "0.1.0",
+        "@types/ws": "^8.18.1",
         "esbuild": "^0.27.7"
       }
     },
@@ -13105,6 +13132,28 @@
       },
       "devDependencies": {
         "electron": "^43.1.1"
+      }
+    },
+    "packages/runtime/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "packages/runtime/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "packages/runtime/node_modules/undici": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -84,15 +84,19 @@
     "@xterm/headless": "^6.0.0",
     "ai": "^7.0.31",
     "image-dimensions": "^2.5.1",
+    "https-proxy-agent": "^7.0.6",
     "node-pty": "^1.2.0-beta.14",
     "qrcode": "^1.5.4",
     "socks": "^2.8.9",
+    "socks-proxy-agent": "^8.0.5",
     "undici": "^8.7.0",
+    "ws": "^8.21.0",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@maka/storage": "0.1.0",
+    "@types/ws": "^8.18.1",
     "esbuild": "^0.27.7"
   }
 }

--- a/packages/runtime/src/__tests__/openai-responses-continuation.test.ts
+++ b/packages/runtime/src/__tests__/openai-responses-continuation.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  mergeOpenAiResponsesProviderOptions,
+  planOpenAiResponsesContinuation,
+} from '../openai-responses-continuation.js';
+import type { ModelMessage } from '../model-protocol.js';
+
+const user = (text: string): ModelMessage => ({ role: 'user', content: text });
+const assistant = (text: string): ModelMessage => ({
+  role: 'assistant',
+  content: [{ type: 'text', text, providerOptions: { openai: { itemId: `msg-${text}` } } }],
+});
+const tool = (toolCallId: string, value: string): ModelMessage => ({
+  role: 'tool',
+  content: [
+    {
+      type: 'tool-result',
+      toolCallId,
+      toolName: 'shell',
+      output: { type: 'text', value },
+    },
+  ],
+});
+
+describe('OpenAI Responses semantic continuation', () => {
+  test('sends only messages after the exact prior request and response', () => {
+    const priorRequest = [user('fix it')];
+    const priorResponse = [assistant('calling shell')];
+    const delta = [tool('call-1', 'ok')];
+
+    assert.deepEqual(
+      planOpenAiResponsesContinuation([...priorRequest, ...priorResponse, ...delta], {
+        requestMessages: priorRequest,
+        responseMessages: priorResponse,
+        responseId: 'resp-1',
+      }),
+      { messages: delta, previousResponseId: 'resp-1' },
+    );
+  });
+
+  test('uses a full request when any prior request message changed', () => {
+    const messages = [user('changed'), assistant('calling shell'), tool('call-1', 'ok')];
+    assert.deepEqual(
+      planOpenAiResponsesContinuation(messages, {
+        requestMessages: [user('fix it')],
+        responseMessages: [assistant('calling shell')],
+        responseId: 'resp-1',
+      }),
+      { messages },
+    );
+  });
+
+  test('uses a full request when the replayed response is not exact', () => {
+    const messages = [user('fix it'), assistant('different'), tool('call-1', 'ok')];
+    assert.deepEqual(
+      planOpenAiResponsesContinuation(messages, {
+        requestMessages: [user('fix it')],
+        responseMessages: [assistant('calling shell')],
+        responseId: 'resp-1',
+      }),
+      { messages },
+    );
+  });
+
+  test('does not create an empty continuation', () => {
+    const messages = [user('fix it'), assistant('done')];
+    assert.deepEqual(
+      planOpenAiResponsesContinuation(messages, {
+        requestMessages: [user('fix it')],
+        responseMessages: [assistant('done')],
+        responseId: 'resp-1',
+      }),
+      { messages },
+    );
+  });
+
+  test('adds a session-stable cache key while preserving explicit OpenAI options', () => {
+    assert.deepEqual(
+      mergeOpenAiResponsesProviderOptions(
+        { openai: { store: false, reasoningEffort: 'high' }, other: { keep: true } },
+        'session-1',
+      ),
+      {
+        openai: { store: false, reasoningEffort: 'high', promptCacheKey: 'maka:session-1' },
+        other: { keep: true },
+      },
+    );
+  });
+
+  test('never overwrites an explicit cache key or mutates caller options', () => {
+    const input = { openai: { store: false, promptCacheKey: 'caller-key' } };
+    const merged = mergeOpenAiResponsesProviderOptions(input, 'session-1');
+    assert.deepEqual(merged, input);
+    assert.notEqual(merged, input);
+    assert.notEqual(merged.openai, input.openai);
+  });
+});

--- a/packages/runtime/src/__tests__/openai-responses-websocket.test.ts
+++ b/packages/runtime/src/__tests__/openai-responses-websocket.test.ts
@@ -1,0 +1,346 @@
+import assert from 'node:assert/strict';
+import { createServer, type IncomingMessage } from 'node:http';
+import { connect as connectTcp, type AddressInfo } from 'node:net';
+import type { Duplex } from 'node:stream';
+import { afterEach, describe, test } from 'node:test';
+import WebSocket, { WebSocketServer } from 'ws';
+
+import {
+  createOpenAiResponsesTransportState,
+  OPENAI_RESPONSES_LANE_HEADER,
+  webSocketProxyAgent,
+} from '../openai-responses-websocket.js';
+import { createProxiedFetchTransport } from '../network/scoped-fetch-transport.js';
+
+const disposers: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  await Promise.all(disposers.splice(0).map((dispose) => dispose()));
+});
+
+describe('OpenAI Responses WebSocket transport', () => {
+  test('reuses a turn socket and sends previous_response_id with delta-only input', async () => {
+    const requests: Record<string, unknown>[] = [];
+    const server = await websocketServer((socket) => {
+      socket.on('message', (data) => {
+        const body = JSON.parse(data.toString()) as Record<string, unknown>;
+        requests.push(body);
+        const index = requests.length;
+        socket.send(
+          JSON.stringify({
+            type: 'response.created',
+            response: { id: `resp-${index}`, created_at: 1, model: 'gpt-test' },
+          }),
+        );
+        socket.send(
+          JSON.stringify({
+            type: 'response.completed',
+            response: {
+              id: `resp-${index}`,
+              output: [{ type: 'message', id: `msg-${index}`, content: [] }],
+            },
+          }),
+        );
+      });
+    });
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(globalThis.fetch);
+
+    await consume(
+      await fetch(server.url, request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] })),
+    );
+    await consume(
+      await fetch(
+        server.url,
+        request('turn-1', {
+          model: 'gpt-test',
+          input: [{ type: 'function_call_output', call_id: 'call-1', output: 'ok' }],
+          previous_response_id: 'resp-1',
+        }),
+      ),
+    );
+
+    assert.equal(server.connections(), 1);
+    assert.deepEqual(requests[0], {
+      type: 'response.create',
+      model: 'gpt-test',
+      input: [{ role: 'user' }],
+    });
+    assert.deepEqual(requests[1], {
+      type: 'response.create',
+      model: 'gpt-test',
+      input: [{ type: 'function_call_output', call_id: 'call-1', output: 'ok' }],
+      previous_response_id: 'resp-1',
+    });
+  });
+
+  test('reconstructs the complete history for HTTP when WebSocket setup fails', async () => {
+    const httpBodies: Record<string, unknown>[] = [];
+    const httpFetch: typeof globalThis.fetch = async (_input, init) => {
+      httpBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response('http', { status: 200 });
+    };
+    const state = createOpenAiResponsesTransportState({ webSocketUrl: 'ws://127.0.0.1:1' });
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(httpFetch);
+
+    const response = await fetch(
+      'https://api.openai.com/v1/responses',
+      request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] }),
+    );
+
+    assert.equal(await response.text(), 'http');
+    assert.deepEqual(httpBodies, [{ model: 'gpt-test', stream: true, input: [{ role: 'user' }] }]);
+    assert.equal(state.canRecordSemantic('turn-1', 'resp-any'), false);
+  });
+
+  test('uses the HTTP/SOCKS proxy snapshot and honors the same bypass list', () => {
+    const httpTransport = createProxiedFetchTransport({
+      enabled: true,
+      type: 'http',
+      host: 'proxy.local',
+      port: 8080,
+      username: 'user',
+      password: 'secret',
+      bypassList: ['bypass.test'],
+    });
+    const socksTransport = createProxiedFetchTransport({
+      enabled: true,
+      type: 'socks5',
+      host: '127.0.0.1',
+      port: 1080,
+      bypassList: [],
+    });
+    disposers.push(httpTransport.close, socksTransport.close);
+
+    assert.equal(
+      webSocketProxyAgent(httpTransport.fetch, 'https://api.openai.com/v1/responses')?.constructor
+        .name,
+      'HttpsProxyAgent',
+    );
+    assert.equal(
+      webSocketProxyAgent(httpTransport.fetch, 'https://bypass.test/v1/responses'),
+      undefined,
+    );
+    assert.equal(
+      webSocketProxyAgent(socksTransport.fetch, 'https://api.openai.com/v1/responses')?.constructor
+        .name,
+      'SocksProxyAgent',
+    );
+  });
+
+  test('connects through the configured authenticated HTTP proxy', async () => {
+    const target = await websocketServer((socket) => {
+      socket.once('message', () => {
+        socket.send(
+          JSON.stringify({
+            type: 'response.completed',
+            response: { id: 'resp-proxied', output: [] },
+          }),
+        );
+      });
+    });
+    const proxy = await connectProxyServer();
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const transport = createProxiedFetchTransport({
+      enabled: true,
+      type: 'http',
+      host: '127.0.0.1',
+      port: proxy.port,
+      username: 'proxy-user',
+      password: 'proxy-secret',
+      bypassList: [],
+    });
+    disposers.push(transport.close);
+    const fetch = state.wrapFetch(transport.fetch);
+
+    await consume(
+      await fetch(target.url, request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] })),
+    );
+
+    assert.equal(proxy.connections(), 1);
+    assert.equal(target.connections(), 1);
+    assert.equal(
+      proxy.authorization(),
+      `Basic ${Buffer.from('proxy-user:proxy-secret').toString('base64')}`,
+    );
+  });
+
+  test('reconnects with complete history instead of using a socket-local id', async () => {
+    const requests: Record<string, unknown>[] = [];
+    const server = await websocketServer((socket) => {
+      socket.once('message', (data) => {
+        requests.push(JSON.parse(data.toString()) as Record<string, unknown>);
+        socket.send(
+          JSON.stringify({
+            type: 'response.completed',
+            response: {
+              id: `resp-${requests.length}`,
+              output: [{ type: 'function_call', call_id: 'call-1', name: 'shell' }],
+            },
+          }),
+        );
+        socket.close();
+      });
+    });
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(globalThis.fetch);
+
+    await consume(
+      await fetch(server.url, request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] })),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await consume(
+      await fetch(
+        server.url,
+        request('turn-1', {
+          model: 'gpt-test',
+          input: [{ type: 'function_call_output', call_id: 'call-1', output: 'ok' }],
+          previous_response_id: 'resp-1',
+        }),
+      ),
+    );
+
+    assert.equal(server.connections(), 2);
+    assert.deepEqual(requests[1], {
+      type: 'response.create',
+      model: 'gpt-test',
+      input: [
+        { role: 'user' },
+        { type: 'function_call', call_id: 'call-1', name: 'shell' },
+        { type: 'function_call_output', call_id: 'call-1', output: 'ok' },
+      ],
+    });
+  });
+
+  test('reconstructs prior input, provider output, and the delta when a reused lane falls back', async () => {
+    const httpBodies: Record<string, unknown>[] = [];
+    const server = await websocketServer((socket) => {
+      socket.once('message', () => {
+        socket.send(
+          JSON.stringify({
+            type: 'response.completed',
+            response: {
+              id: 'resp-1',
+              output: [{ type: 'function_call', call_id: 'call-1', name: 'shell' }],
+            },
+          }),
+        );
+      });
+    });
+    const state = createOpenAiResponsesTransportState({ connectTimeoutMs: 100 });
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(async (_input, init) => {
+      httpBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response('http', { status: 200 });
+    });
+
+    await consume(
+      await fetch(server.url, request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] })),
+    );
+    await server.stopWebSockets();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const response = await fetch(
+      server.url,
+      request('turn-1', {
+        model: 'gpt-test',
+        input: [{ type: 'function_call_output', call_id: 'call-1', output: 'ok' }],
+        previous_response_id: 'resp-1',
+      }),
+    );
+
+    assert.equal(await response.text(), 'http');
+    assert.deepEqual(httpBodies, [
+      {
+        model: 'gpt-test',
+        stream: true,
+        input: [
+          { role: 'user' },
+          { type: 'function_call', call_id: 'call-1', name: 'shell' },
+          { type: 'function_call_output', call_id: 'call-1', output: 'ok' },
+        ],
+      },
+    ]);
+  });
+});
+
+function request(lane: string, body: Record<string, unknown>): RequestInit {
+  return {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer test',
+      'content-type': 'application/json',
+      [OPENAI_RESPONSES_LANE_HEADER]: lane,
+    },
+    body: JSON.stringify({ ...body, stream: true }),
+  };
+}
+
+async function consume(response: Response): Promise<string> {
+  return await response.text();
+}
+
+async function websocketServer(
+  onConnection: (socket: WebSocket, request: IncomingMessage) => void,
+) {
+  const http = createServer();
+  const sockets = new Set<WebSocket>();
+  const ws = new WebSocketServer({ server: http });
+  let connections = 0;
+  ws.on('connection', (socket, request) => {
+    connections += 1;
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    onConnection(socket, request);
+  });
+  await new Promise<void>((resolve) => http.listen(0, '127.0.0.1', resolve));
+  const address = http.address() as AddressInfo;
+  const url = `http://127.0.0.1:${address.port}/v1/responses`;
+  let webSocketsStopped = false;
+  const stopWebSockets = async () => {
+    if (webSocketsStopped) return;
+    webSocketsStopped = true;
+    for (const socket of sockets) socket.terminate();
+    await new Promise<void>((resolve) => ws.close(() => resolve()));
+  };
+  disposers.push(async () => {
+    await stopWebSockets();
+    await new Promise<void>((resolve) => http.close(() => resolve()));
+  });
+  return { url, connections: () => connections, stopWebSockets };
+}
+
+async function connectProxyServer() {
+  const server = createServer();
+  const sockets = new Set<Duplex>();
+  let connections = 0;
+  let authorization: string | undefined;
+  server.on('connect', (request, client, head) => {
+    connections += 1;
+    authorization = request.headers['proxy-authorization'];
+    const [host, rawPort] = (request.url ?? '').split(':');
+    const upstream = connectTcp(Number(rawPort), host);
+    sockets.add(client);
+    sockets.add(upstream);
+    client.on('close', () => sockets.delete(client));
+    upstream.on('close', () => sockets.delete(upstream));
+    upstream.once('connect', () => {
+      client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      if (head.length > 0) upstream.write(head);
+      client.pipe(upstream).pipe(client);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as AddressInfo;
+  disposers.push(async () => {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+  return {
+    port: address.port,
+    connections: () => connections,
+    authorization: () => authorization,
+  };
+}

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -776,6 +776,7 @@ export class AiSdkBackend implements AgentBackend {
     this.maxSteps = input.maxSteps;
     this.providerRetrySleep = input.providerRetrySleep ?? sleepForProviderRetry;
     this.modelAdapter = new ModelAdapter({
+      sessionId: input.sessionId,
       connection: input.connection,
       apiKey: input.apiKey,
       modelId: input.modelId,
@@ -1586,6 +1587,7 @@ export class AiSdkBackend implements AgentBackend {
               system: requestSystemPrompt,
               abortSignal: turnAbortController.signal,
               ...(providerRequestTracker ? { providerRequestTracker } : {}),
+              continuationKey: scope.turnId,
             });
 
             let streamFailure: unknown;
@@ -2386,6 +2388,7 @@ export class AiSdkBackend implements AgentBackend {
   async dispose(): Promise<void> {
     if (this.activeTurns.size > 0) await this.stop('user_stop');
     else this.compaction.abortHistoryCompact();
+    this.modelAdapter.dispose();
   }
 
   /** Map ai-sdk finishReason → our CompleteEvent.stopReason. */
@@ -3486,6 +3489,7 @@ export class AiSdkBackend implements AgentBackend {
    */
   private async cleanupAfterTurn(scope: TurnScope): Promise<void> {
     this.activeTurns.delete(scope);
+    this.modelAdapter.endContinuation(scope.turnId);
     await scope.toolRuntime.endTurn(scope.aborted ? 'aborted' : 'completed');
   }
 

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -50,6 +50,15 @@ import {
   restoreKimiEmptyReasoning,
   type KimiOpenAiTransportState,
 } from './kimi-openai-transport.js';
+import {
+  mergeOpenAiResponsesProviderOptions,
+  planOpenAiResponsesContinuation,
+} from './openai-responses-continuation.js';
+import {
+  createOpenAiResponsesTransportState,
+  OPENAI_RESPONSES_LANE_HEADER,
+  type OpenAiResponsesTransportState,
+} from './openai-responses-websocket.js';
 
 /**
  * Build an ai-sdk LanguageModel from a single input object.
@@ -64,6 +73,7 @@ export interface ModelFactoryInput {
   apiKey: string;
   modelId: string;
   kimiOpenAiTransportState?: KimiOpenAiTransportState;
+  openAiResponsesTransportState?: OpenAiResponsesTransportState;
 }
 export type ModelFactory = (input: ModelFactoryInput) => unknown;
 
@@ -76,6 +86,7 @@ export interface RepairableAiSdkToolCall {
 }
 
 export interface ModelAdapterInput {
+  sessionId?: string;
   connection: RuntimeExecutionConnection;
   apiKey: string;
   modelId: string;
@@ -121,6 +132,8 @@ export interface ModelAdapterStreamInput {
   }) => RepairableAiSdkToolCall | null | Promise<RepairableAiSdkToolCall | null>;
   /** Main-agent provider-call tracker. Auxiliary calls track their own generates. */
   providerRequestTracker?: ProviderRequestTracker;
+  /** Turn-scoped continuation lane. Omitted callers keep the full-request path. */
+  continuationKey?: string;
 }
 
 interface ProviderMiddlewareStreamInput {
@@ -135,6 +148,7 @@ interface ProviderMiddlewareStreamInput {
 
 export class ModelAdapter {
   private readonly kimiOpenAiTransportState = createKimiOpenAiTransportState();
+  private readonly openAiResponsesTransportState = createOpenAiResponsesTransportState();
 
   constructor(private readonly input: ModelAdapterInput) {}
 
@@ -158,6 +172,9 @@ export class ModelAdapter {
       modelId: this.input.modelId,
       ...(usesKimiOpenAiChat(this.input.connection, this.input.modelId)
         ? { kimiOpenAiTransportState: this.kimiOpenAiTransportState }
+        : {}),
+      ...(usesNativeOpenAiResponses(this.input.connection, this.input.modelId)
+        ? { openAiResponsesTransportState: this.openAiResponsesTransportState }
         : {}),
     });
   }
@@ -206,9 +223,27 @@ export class ModelAdapter {
             },
       ]),
     );
+    const fullMessages = lowerNativeAudioMessages(input.messages);
+    const responsesLane =
+      input.continuationKey && usesNativeOpenAiResponses(this.input.connection, this.input.modelId)
+        ? input.continuationKey
+        : undefined;
+    const continuation = responsesLane
+      ? planOpenAiResponsesContinuation(
+          fullMessages,
+          this.openAiResponsesTransportState.semanticBaseline(responsesLane),
+        )
+      : { messages: fullMessages };
+    const providerOptions = usesNativeOpenAiResponses(this.input.connection, this.input.modelId)
+      ? mergeOpenAiResponsesProviderOptions(
+          this.input.providerOptions,
+          this.input.sessionId ?? this.input.connection.slug,
+          continuation.previousResponseId,
+        )
+      : this.input.providerOptions;
     const sdkResult = streamText({
       model: trackedModel,
-      messages: lowerNativeAudioMessages(input.messages),
+      messages: continuation.messages,
       tools: sdkTools,
       activeTools: input.activeTools,
       // An empty active set is an authoritative tool-free request (not merely
@@ -221,7 +256,8 @@ export class ModelAdapter {
       repairToolCall: input.repairToolCall,
       ...(input.system ? { instructions: input.system } : {}),
       ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
-      providerOptions: this.input.providerOptions,
+      providerOptions,
+      ...(responsesLane ? { headers: { [OPENAI_RESPONSES_LANE_HEADER]: responsesLane } } : {}),
       maxRetries: 0,
       // Preserve the final request's Maka-owned message projection without
       // retaining the provider request body. ProviderRequestTracker owns body
@@ -236,7 +272,10 @@ export class ModelAdapter {
       // `error` event → ErrorEvent path, so silence the default.
       onError: () => {},
     }) as unknown as SdkStreamResult;
-    return this.toModelStreamResult(sdkResult, input.onStreamActivity);
+    return this.toModelStreamResult(sdkResult, input.onStreamActivity, {
+      ...(responsesLane ? { lane: responsesLane } : {}),
+      requestMessages: fullMessages,
+    });
   }
 
   /**
@@ -248,19 +287,45 @@ export class ModelAdapter {
   private toModelStreamResult(
     sdk: SdkStreamResult,
     onStreamActivity: () => void,
+    continuation: { lane?: string; requestMessages: ModelMessage[] },
   ): ModelStreamResult {
     const kimiOpenAiTransportState = usesKimiOpenAiChat(this.input.connection, this.input.modelId)
       ? this.kimiOpenAiTransportState
       : undefined;
+    const openAiResponsesTransportState = this.openAiResponsesTransportState;
     const events: AsyncIterable<ModelStreamEvent> = {
       async *[Symbol.asyncIterator]() {
+        let succeeded = true;
         try {
           for await (const chunk of sdk.stream as AsyncIterable<AiSdkStreamChunk>) {
             onStreamActivity();
-            for (const event of translateChunk(chunk, kimiOpenAiTransportState)) yield event;
+            for (const event of translateChunk(chunk, kimiOpenAiTransportState)) {
+              if (event.kind === 'error') succeeded = false;
+              yield event;
+            }
           }
         } catch (error) {
+          succeeded = false;
           yield { kind: 'error', failure: normalizeModelFailure(error) };
+        } finally {
+          if (!continuation.lane) return;
+          if (!succeeded) {
+            openAiResponsesTransportState.clearSemantic(continuation.lane);
+            return;
+          }
+          const response = await Promise.resolve(sdk.response).catch(() => undefined);
+          if (
+            response?.id &&
+            openAiResponsesTransportState.canRecordSemantic(continuation.lane, response.id)
+          ) {
+            openAiResponsesTransportState.recordSemantic(continuation.lane, {
+              requestMessages: structuredClone(continuation.requestMessages),
+              responseMessages: structuredClone(response.messages ?? []),
+              responseId: response.id,
+            });
+          } else {
+            openAiResponsesTransportState.clearSemantic(continuation.lane);
+          }
         }
       },
     };
@@ -273,10 +338,20 @@ export class ModelAdapter {
     })();
     const finishReason = (async () =>
       rawFinishReasonString(await sdk.finishReason.catch(() => undefined)))();
-    const request = Promise.resolve(sdk.request)
-      .then(normalizeRequestMetadata)
-      .catch(() => undefined);
+    // The SDK request contains only the wire delta during continuation. Keep
+    // Maka's public request metadata anchored to the complete durable
+    // projection so diagnostics and recovery never mistake an optimization for
+    // lost history.
+    const request = Promise.resolve({ messages: continuation.requestMessages });
     return { events, usage, finishReason, request };
+  }
+
+  endContinuation(lane: string): void {
+    this.openAiResponsesTransportState.endLane(lane);
+  }
+
+  dispose(): void {
+    this.openAiResponsesTransportState.close();
   }
 
   async generateCompactSummary(input: CompactSummaryRequest): Promise<CompactSummaryResult> {
@@ -452,6 +527,13 @@ function usesOpenAiResponses(connection: RuntimeExecutionConnection, modelId: st
   );
 }
 
+function usesNativeOpenAiResponses(
+  connection: RuntimeExecutionConnection,
+  modelId: string,
+): boolean {
+  return connection.providerType === 'openai' && usesOpenAiResponses(connection, modelId);
+}
+
 function fixedAnthropicThinkingBudget(
   providerOptions: Record<string, unknown> | undefined,
 ): number {
@@ -507,6 +589,10 @@ interface SdkStreamResult {
   usage: Promise<AiSdkUsageLike | undefined>;
   finishReason: Promise<unknown>;
   request: PromiseLike<{
+    messages?: ModelMessage[];
+  }>;
+  response: PromiseLike<{
+    id: string;
     messages?: ModelMessage[];
   }>;
 }

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -24,6 +24,7 @@ import {
   createKimiOpenAiTransport,
   type KimiOpenAiTransportState,
 } from './kimi-openai-transport.js';
+import type { OpenAiResponsesTransportState } from './openai-responses-websocket.js';
 import { anthropicV1BaseUrl, googleV1BetaBaseUrl } from './provider-urls.js';
 import { resolveModelRuntime } from './model-runtime.js';
 import { claudeSubscriptionHeaders, openAiCodexHeaders } from './subscription-auth.js';
@@ -34,11 +35,19 @@ export interface ModelFactoryInput {
   modelId: string;
   fetch?: typeof globalThis.fetch;
   kimiOpenAiTransportState?: KimiOpenAiTransportState;
+  openAiResponsesTransportState?: OpenAiResponsesTransportState;
 }
 
 const ANTHROPIC_BETA = 'interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14';
 export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
-  const { connection, apiKey, modelId, fetch, kimiOpenAiTransportState } = input;
+  const {
+    connection,
+    apiKey,
+    modelId,
+    fetch,
+    kimiOpenAiTransportState,
+    openAiResponsesTransportState,
+  } = input;
   const { adapter, baseUrl: baseURL, apiProtocol } = resolveModelRuntime(connection, modelId);
 
   if (adapter.kind === 'google' && adapter.normalizeBaseUrl === false) {
@@ -66,7 +75,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
       return createOpenAI({
         apiKey,
         baseURL,
-        fetch,
+        fetch: openAiResponsesTransportState?.wrapFetch(fetch ?? globalThis.fetch) ?? fetch,
         headers: openAiCodexHeaders(apiKey),
       }).responses(modelId);
 
@@ -93,7 +102,11 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
       throw new Error(`${connection.providerType} is experimental and not wired yet`);
 
     case 'openai': {
-      const openai = createOpenAI({ apiKey, baseURL, fetch });
+      const openai = createOpenAI({
+        apiKey,
+        baseURL,
+        fetch: openAiResponsesTransportState?.wrapFetch(fetch ?? globalThis.fetch) ?? fetch,
+      });
       // Routing is declaration-driven via the ModelInfo.apiProtocol seam: an
       // account-declared protocol wins (mirrors the github-copilot case above);
       // otherwise the model's declared OpenAI-adapter protocol decides. gpt-5*

--- a/packages/runtime/src/network/scoped-fetch-transport.ts
+++ b/packages/runtime/src/network/scoped-fetch-transport.ts
@@ -4,6 +4,8 @@ import type { ConnectionEffectFetch } from '../connection-effect-fetch.js';
 import { matchesBypassList } from './bypass-matcher.js';
 import { buildProxyDispatcher } from './proxy-dispatcher.js';
 
+export const FETCH_PROXY_SNAPSHOT = Symbol.for('maka.fetch.proxy-snapshot');
+
 export interface ConnectionEffectProxySnapshot {
   readonly enabled: boolean;
   readonly type: ProxySettings['type'];
@@ -61,6 +63,10 @@ export function createProxiedFetchTransport(
       } as Parameters<typeof undiciFetch>[1],
     )) as unknown as Response;
   };
+  Object.defineProperty(fetch, FETCH_PROXY_SNAPSHOT, {
+    value: proxySnapshot,
+    enumerable: false,
+  });
 
   const close = (): Promise<void> => {
     if (closePromise) return closePromise;

--- a/packages/runtime/src/openai-responses-continuation.ts
+++ b/packages/runtime/src/openai-responses-continuation.ts
@@ -1,0 +1,52 @@
+import { isDeepStrictEqual } from 'node:util';
+
+import type { ModelMessage } from './model-protocol.js';
+
+export interface OpenAiResponsesSemanticBaseline {
+  requestMessages: readonly ModelMessage[];
+  responseMessages: readonly ModelMessage[];
+  responseId: string;
+}
+
+export interface OpenAiResponsesContinuationPlan {
+  messages: ModelMessage[];
+  previousResponseId?: string;
+}
+
+export function planOpenAiResponsesContinuation(
+  messages: readonly ModelMessage[],
+  baseline: OpenAiResponsesSemanticBaseline | undefined,
+): OpenAiResponsesContinuationPlan {
+  const full = [...messages];
+  if (!baseline?.responseId) return { messages: full };
+
+  const prefix = [...baseline.requestMessages, ...baseline.responseMessages];
+  if (messages.length <= prefix.length) return { messages: full };
+  for (let index = 0; index < prefix.length; index += 1) {
+    if (!isDeepStrictEqual(messages[index], prefix[index])) return { messages: full };
+  }
+  return {
+    messages: messages.slice(prefix.length),
+    previousResponseId: baseline.responseId,
+  };
+}
+
+export function mergeOpenAiResponsesProviderOptions(
+  providerOptions: Record<string, unknown> | undefined,
+  sessionId: string,
+  previousResponseId?: string,
+): Record<string, unknown> {
+  const openaiValue = providerOptions?.openai;
+  const openai =
+    openaiValue && typeof openaiValue === 'object' && !Array.isArray(openaiValue)
+      ? (openaiValue as Record<string, unknown>)
+      : {};
+  return {
+    ...providerOptions,
+    openai: {
+      ...openai,
+      ...(openai.promptCacheKey === undefined ? { promptCacheKey: `maka:${sessionId}` } : {}),
+      ...(previousResponseId === undefined ? {} : { previousResponseId }),
+    },
+  };
+}

--- a/packages/runtime/src/openai-responses-websocket.ts
+++ b/packages/runtime/src/openai-responses-websocket.ts
@@ -1,0 +1,459 @@
+import { isDeepStrictEqual } from 'node:util';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { SocksProxyAgent } from 'socks-proxy-agent';
+import WebSocket from 'ws';
+
+import type { ModelMessage } from './model-protocol.js';
+import { matchesBypassList } from './network/bypass-matcher.js';
+import { FETCH_PROXY_SNAPSHOT, type ProxiedFetchProxy } from './network/scoped-fetch-transport.js';
+import { bracketIfIpv6, buildProxyUrl } from './network/proxy-parser.js';
+import type { OpenAiResponsesSemanticBaseline } from './openai-responses-continuation.js';
+
+export const OPENAI_RESPONSES_LANE_HEADER = 'x-maka-openai-responses-lane';
+const RESPONSES_WEBSOCKET_PROTOCOL = 'responses_websockets=2026-02-06';
+const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
+
+interface WireBaseline {
+  fullBody: Record<string, unknown>;
+  responseId: string;
+  responseOutput: unknown[];
+}
+
+interface LaneState {
+  socket?: WebSocket;
+  busy: boolean;
+  httpFallback: boolean;
+  wire?: WireBaseline;
+  semantic?: OpenAiResponsesSemanticBaseline;
+}
+
+export interface OpenAiResponsesTransportOptions {
+  webSocketUrl?: string;
+  connectTimeoutMs?: number;
+}
+
+export class OpenAiResponsesTransportState {
+  private readonly lanes = new Map<string, LaneState>();
+
+  constructor(private readonly options: OpenAiResponsesTransportOptions = {}) {}
+
+  semanticBaseline(lane: string): OpenAiResponsesSemanticBaseline | undefined {
+    return this.lanes.get(lane)?.semantic;
+  }
+
+  recordSemantic(lane: string, baseline: OpenAiResponsesSemanticBaseline): void {
+    const state = this.lanes.get(lane);
+    if (!state || state.httpFallback || state.wire?.responseId !== baseline.responseId) return;
+    state.semantic = baseline;
+  }
+
+  clearSemantic(lane: string): void {
+    const state = this.lanes.get(lane);
+    if (state) state.semantic = undefined;
+  }
+
+  canRecordSemantic(lane: string, responseId: string): boolean {
+    const state = this.lanes.get(lane);
+    return state?.httpFallback === false && state.wire?.responseId === responseId;
+  }
+
+  wrapFetch(httpFetch: typeof globalThis.fetch): typeof globalThis.fetch {
+    return async (input, init) => await this.fetch(input, init, httpFetch);
+  }
+
+  endLane(lane: string): void {
+    const state = this.lanes.get(lane);
+    if (!state) return;
+    terminate(state.socket);
+    this.lanes.delete(lane);
+  }
+
+  close(): void {
+    for (const state of this.lanes.values()) terminate(state.socket);
+    this.lanes.clear();
+  }
+
+  private async fetch(
+    input: RequestInfo | URL,
+    init: RequestInit | undefined,
+    httpFetch: typeof globalThis.fetch,
+  ): Promise<Response> {
+    const url = requestUrl(input);
+    const headers = new Headers(init?.headers);
+    const lane = headers.get(OPENAI_RESPONSES_LANE_HEADER) ?? undefined;
+    headers.delete(OPENAI_RESPONSES_LANE_HEADER);
+    const cleanInit = { ...init, headers };
+    const body = parseStreamingResponsesBody(url, cleanInit);
+    if (!lane || !body) return await httpFetch(input, cleanInit);
+
+    const state = this.lanes.get(lane) ?? { busy: false, httpFallback: false };
+    this.lanes.set(lane, state);
+    const prepared = prepareWireRequest(body, state.wire);
+    if (!prepared) {
+      state.semantic = undefined;
+      state.httpFallback = true;
+      return failedStream('OpenAI Responses continuation state is unavailable');
+    }
+
+    if (state.httpFallback || state.busy) {
+      state.semantic = undefined;
+      return await httpFetch(input, withJsonBody(cleanInit, prepared.fullBody));
+    }
+
+    // `store: false` continuations exist only in the server memory attached to
+    // this exact socket. A reconnect must start a fresh chain with the complete
+    // reconstructed body; sending the old id on a new socket is guaranteed to
+    // produce previous_response_not_found.
+    const wireBody =
+      body.previous_response_id !== undefined && state.socket?.readyState !== WebSocket.OPEN
+        ? prepared.fullBody
+        : prepared.wireBody;
+    state.busy = true;
+    try {
+      state.socket = await this.openSocketIfNeeded(state, url, headers, httpFetch, init?.signal);
+    } catch (error) {
+      state.busy = false;
+      state.httpFallback = true;
+      state.semantic = undefined;
+      terminate(state.socket);
+      state.socket = undefined;
+      if (isAbort(error, init?.signal)) throw error;
+      return await httpFetch(input, withJsonBody(cleanInit, prepared.fullBody));
+    }
+
+    return websocketResponse({
+      socket: state.socket,
+      body: wireBody,
+      signal: init?.signal ?? undefined,
+      onComplete: (response) => {
+        state.busy = false;
+        const responseId = typeof response.id === 'string' ? response.id : undefined;
+        const output = Array.isArray(response.output) ? response.output : undefined;
+        if (!responseId || !output) {
+          invalidateLane(state, false);
+          return;
+        }
+        state.wire = {
+          fullBody: prepared.fullBody,
+          responseId,
+          responseOutput: structuredClone(output),
+        };
+      },
+      onFailure: (fallback) => {
+        state.busy = false;
+        state.semantic = undefined;
+        state.wire = undefined;
+        if (fallback) state.httpFallback = true;
+        terminate(state.socket);
+        state.socket = undefined;
+      },
+    });
+  }
+
+  private async openSocketIfNeeded(
+    state: LaneState,
+    httpUrl: string,
+    headers: Headers,
+    httpFetch: typeof globalThis.fetch,
+    signal: AbortSignal | null | undefined,
+  ): Promise<WebSocket> {
+    if (state.socket?.readyState === WebSocket.OPEN) return state.socket;
+    terminate(state.socket);
+    const wsUrl = this.options.webSocketUrl ?? httpUrl.replace(/^http/, 'ws');
+    const wsHeaders = Object.fromEntries(headers.entries());
+    delete wsHeaders['content-length'];
+    wsHeaders['openai-beta'] ??= RESPONSES_WEBSOCKET_PROTOCOL;
+    return await connectWebSocket(
+      wsUrl,
+      wsHeaders,
+      this.options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
+      webSocketProxyAgent(httpFetch, httpUrl),
+      signal ?? undefined,
+    );
+  }
+}
+
+export function createOpenAiResponsesTransportState(
+  options?: OpenAiResponsesTransportOptions,
+): OpenAiResponsesTransportState {
+  return new OpenAiResponsesTransportState(options);
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  return input instanceof URL ? input.toString() : typeof input === 'string' ? input : input.url;
+}
+
+function parseStreamingResponsesBody(
+  url: string,
+  init: RequestInit | undefined,
+): Record<string, unknown> | undefined {
+  if (init?.method !== 'POST' || !new URL(url).pathname.endsWith('/responses')) return undefined;
+  if (typeof init.body !== 'string') return undefined;
+  try {
+    const value = JSON.parse(init.body) as unknown;
+    return isRecord(value) && value.stream === true ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function prepareWireRequest(
+  body: Record<string, unknown>,
+  baseline: WireBaseline | undefined,
+): { wireBody: Record<string, unknown>; fullBody: Record<string, unknown> } | undefined {
+  const previousResponseId = body.previous_response_id;
+  if (previousResponseId === undefined) {
+    return { wireBody: body, fullBody: body };
+  }
+  if (
+    typeof previousResponseId !== 'string' ||
+    baseline?.responseId !== previousResponseId ||
+    !Array.isArray(baseline.fullBody.input) ||
+    !Array.isArray(body.input)
+  ) {
+    return undefined;
+  }
+
+  const { previous_response_id: _previousResponseId, ...currentProperties } = body;
+  const fullBody = {
+    ...currentProperties,
+    input: [
+      ...structuredClone(baseline.fullBody.input),
+      ...structuredClone(baseline.responseOutput),
+      ...structuredClone(body.input),
+    ],
+  };
+  const sameProperties = isDeepStrictEqual(
+    requestProperties(baseline.fullBody),
+    requestProperties(fullBody),
+  );
+  return {
+    wireBody: sameProperties ? body : fullBody,
+    fullBody,
+  };
+}
+
+function requestProperties(body: Record<string, unknown>): Record<string, unknown> {
+  const { input: _input, previous_response_id: _previousResponseId, ...properties } = body;
+  return properties;
+}
+
+function withJsonBody(init: RequestInit | undefined, body: Record<string, unknown>): RequestInit {
+  const headers = new Headers(init?.headers);
+  headers.delete('content-length');
+  return { ...init, headers, body: JSON.stringify(body) };
+}
+
+function websocketResponse(input: {
+  socket: WebSocket;
+  body: Record<string, unknown>;
+  signal?: AbortSignal;
+  onComplete: (response: Record<string, unknown>) => void;
+  onFailure: (fallback: boolean) => void;
+}): Response {
+  const encoder = new TextEncoder();
+  let settled = false;
+  let controller: ReadableStreamDefaultController<Uint8Array>;
+
+  const cleanup = () => {
+    input.socket.off('message', onMessage);
+    input.socket.off('error', onError);
+    input.socket.off('close', onClose);
+    input.signal?.removeEventListener('abort', onAbort);
+  };
+  const fail = (error: Error, fallback: boolean) => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    input.onFailure(fallback);
+    controller.error(error);
+  };
+  const finish = (response: Record<string, unknown>) => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    input.onComplete(response);
+    controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+    controller.close();
+  };
+  const onMessage = (data: WebSocket.RawData, isBinary: boolean) => {
+    if (isBinary) {
+      fail(new Error('Unexpected binary OpenAI Responses WebSocket frame'), true);
+      return;
+    }
+    const text = data.toString();
+    let event: Record<string, unknown> | undefined;
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      if (isRecord(parsed)) event = parsed;
+    } catch {
+      // Let the SDK report malformed provider data after receiving the SSE line.
+    }
+    controller.enqueue(encoder.encode(`data: ${text}\n\n`));
+    if (!event) return;
+    if (event.type === 'response.completed' || event.type === 'response.done') {
+      finish(isRecord(event.response) ? event.response : {});
+    } else if (
+      event.type === 'response.failed' ||
+      event.type === 'response.incomplete' ||
+      event.type === 'error'
+    ) {
+      settled = true;
+      cleanup();
+      input.onFailure(false);
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+      controller.close();
+    }
+  };
+  const onError = (error: Error) => fail(error, true);
+  const onClose = (code: number, reason: Buffer) =>
+    fail(
+      new Error(
+        `OpenAI Responses WebSocket closed before completion (code ${code}${reason.length ? `: ${reason.toString()}` : ''})`,
+      ),
+      true,
+    );
+  const onAbort = () =>
+    fail(
+      input.signal?.reason instanceof Error
+        ? input.signal.reason
+        : new DOMException('Aborted', 'AbortError'),
+      false,
+    );
+
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(next) {
+        controller = next;
+        input.socket.on('message', onMessage);
+        input.socket.once('error', onError);
+        input.socket.once('close', onClose);
+        input.signal?.addEventListener('abort', onAbort, { once: true });
+        if (input.signal?.aborted) {
+          onAbort();
+          return;
+        }
+        const { stream: _stream, background: _background, ...body } = input.body;
+        input.socket.send(JSON.stringify({ type: 'response.create', ...body }), (error) => {
+          if (error) fail(error, true);
+        });
+      },
+      cancel() {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        input.onFailure(false);
+        terminate(input.socket);
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+function connectWebSocket(
+  url: string,
+  headers: Record<string, string>,
+  timeoutMs: number,
+  agent: HttpsProxyAgent<string> | SocksProxyAgent | undefined,
+  signal?: AbortSignal,
+): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(
+        signal.reason instanceof Error ? signal.reason : new DOMException('Aborted', 'AbortError'),
+      );
+      return;
+    }
+    const socket = new WebSocket(url, { headers, ...(agent ? { agent } : {}) });
+    const timer = setTimeout(
+      () => finish(new Error('OpenAI Responses WebSocket connect timed out')),
+      timeoutMs,
+    );
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.off('open', onOpen);
+      socket.off('error', onError);
+      socket.off('close', onClose);
+      signal?.removeEventListener('abort', onAbort);
+    };
+    const finish = (error?: Error) => {
+      cleanup();
+      if (error) {
+        terminate(socket);
+        reject(error);
+      } else {
+        resolve(socket);
+      }
+    };
+    const onOpen = () => finish();
+    const onError = (error: Error) => finish(error);
+    const onClose = (code: number) => finish(new Error(`WebSocket closed during setup (${code})`));
+    const onAbort = () =>
+      finish(
+        signal?.reason instanceof Error ? signal.reason : new DOMException('Aborted', 'AbortError'),
+      );
+    socket.once('open', onOpen);
+    socket.once('error', onError);
+    socket.once('close', onClose);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function failedStream(message: string): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.error(new Error(message));
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+function invalidateLane(state: LaneState, fallback: boolean): void {
+  state.busy = false;
+  state.semantic = undefined;
+  state.wire = undefined;
+  state.httpFallback ||= fallback;
+  terminate(state.socket);
+  state.socket = undefined;
+}
+
+function terminate(socket: WebSocket | undefined): void {
+  if (!socket) return;
+  socket.on('error', () => {});
+  socket.terminate();
+}
+
+function isAbort(error: unknown, signal: AbortSignal | null | undefined): boolean {
+  return signal?.aborted === true || (error instanceof DOMException && error.name === 'AbortError');
+}
+
+export function webSocketProxyAgent(
+  httpFetch: typeof globalThis.fetch,
+  url: string,
+): HttpsProxyAgent<string> | SocksProxyAgent | undefined {
+  const proxy = (
+    httpFetch as typeof globalThis.fetch & {
+      [FETCH_PROXY_SNAPSHOT]?: ProxiedFetchProxy | null;
+    }
+  )[FETCH_PROXY_SNAPSHOT];
+  if (!proxy?.enabled || matchesBypassList(new URL(url).hostname, [...proxy.bypassList])) {
+    return undefined;
+  }
+  if (proxy.type === 'socks5') {
+    const auth = proxy.username
+      ? `${encodeURIComponent(proxy.username)}${
+          proxy.password ? `:${encodeURIComponent(proxy.password)}` : ''
+        }@`
+      : '';
+    return new SocksProxyAgent(
+      `socks5://${auth}${bracketIfIpv6(proxy.host)}:${String(proxy.port)}`,
+    );
+  }
+  return new HttpsProxyAgent(buildProxyUrl({ ...proxy, bypassList: [...proxy.bypassList] }));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

- add turn-scoped WebSocket lanes for native OpenAI Responses requests
- continue exact histories with delta-only input and `previous_response_id`, plus a session-stable `prompt_cache_key`
- use the same immutable HTTP/HTTPS/SOCKS proxy snapshot, credentials, and bypass list as the configured HTTP transport
- reconstruct complete history on WebSocket setup failure, disconnect, request changes, or HTTP fallback
- keep the refresh-aware Codex OAuth path on HTTP; the new WebSocket path is scoped to native OpenAI API-key Responses

## Verification

- `npm --workspace @maka/runtime run build`
- focused runtime regression suite: 60 passed, 0 failed
- authenticated local HTTP CONNECT proxy end-to-end test
- HTTP/SOCKS proxy selection and bypass-list tests
- `npm run check:third-party-notices`

The full runtime suite was also exercised while developing. One environment-specific pre-existing macOS Bash cwd assertion remains unrelated to this change; all tests covering the changed paths pass.

## Review focus

The main invariants are strict continuation eligibility, connection-local response IDs, complete-history reconstruction after reconnect/fallback, and never bypassing the user's configured proxy policy.
