### PR TITLE
fix(ui): land a switched-to session at its latest turn instead of flying there

### DIFF
--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -283,17 +283,21 @@ test('a session switch lands on the latest turn instead of flying to it', async 
         let maxDistance = 0;
         let frames = 0;
         let settled = false;
+        // Assigned below; `fail` and the watchdog reference each other, and
+        // neither runs before both exist.
+        let watchdog = 0;
         const deadline = performance.now() + 30_000;
         const fail = (why: string) => {
           if (settled) return;
           settled = true;
+          clearTimeout(watchdog);
           reject(new Error(`${why} (frames=${frames}, heights=${heights.size}, maxDistance=${maxDistance})`));
         };
         // Watchdog off the frame clock, like climbToTop's: the deadline below
         // is only reached if frames keep arriving, so a compositor that stops
         // ticking would otherwise hang here until the 60s test timeout, whose
         // "Target page closed" says nothing about what the scroller did.
-        const watchdog = setTimeout(() => fail('The frame clock stopped while watching the arrival'), 35_000);
+        watchdog = window.setTimeout(() => fail('The frame clock stopped while watching the arrival'), 35_000);
         const finish = (result: { maxDistance: number; growthSteps: number; frames: number }) => {
           if (settled) return;
           settled = true;
@@ -301,6 +305,9 @@ test('a session switch lands on the latest turn instead of flying to it', async 
           resolve(result);
         };
         const sample = () => {
+          // Both exits set `settled`, so neither leaves this loop running in a
+          // page that is about to close.
+          if (settled) return;
           const turns = root.querySelectorAll('[data-turn-id^="long-transcript-turn"]').length;
           if (turns > 0) {
             frames += 1;

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -482,7 +482,14 @@ test('progressive fill preserves the reading anchor while earlier turns mount', 
           // The wheel fast path unlocks unconditionally while the spring is
           // animating, and a dispatched WheelEvent reaches that listener
           // even though fixture windows swallow real wheel input.
-          root.dispatchEvent(
+          //
+          // Dispatched at the message list, not the scroller root: the arrival
+          // pin's eager release requires the gesture to have started inside the
+          // transcript, and a wheel targeting the root is not that. It would
+          // still release through the upward write below, but only on a scroll
+          // event that no growth shares a rendering update with — a coin flip
+          // under CPU throttling, and this loop only gets 20 of them.
+          (root.querySelector('.maka-chat-message-list') ?? root).dispatchEvent(
             new WheelEvent('wheel', { deltaY: -120, bubbles: true, cancelable: true }),
           );
           root.scrollTop = Math.max(0, (root.scrollHeight - root.clientHeight) / 2);

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -282,7 +282,24 @@ test('a session switch lands on the latest turn instead of flying to it', async 
         const heights = new Set<number>();
         let maxDistance = 0;
         let frames = 0;
+        let settled = false;
         const deadline = performance.now() + 30_000;
+        const fail = (why: string) => {
+          if (settled) return;
+          settled = true;
+          reject(new Error(`${why} (frames=${frames}, heights=${heights.size}, maxDistance=${maxDistance})`));
+        };
+        // Watchdog off the frame clock, like climbToTop's: the deadline below
+        // is only reached if frames keep arriving, so a compositor that stops
+        // ticking would otherwise hang here until the 60s test timeout, whose
+        // "Target page closed" says nothing about what the scroller did.
+        const watchdog = setTimeout(() => fail('The frame clock stopped while watching the arrival'), 35_000);
+        const finish = (result: { maxDistance: number; growthSteps: number; frames: number }) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(watchdog);
+          resolve(result);
+        };
         const sample = () => {
           const turns = root.querySelectorAll('[data-turn-id^="long-transcript-turn"]').length;
           if (turns > 0) {
@@ -300,11 +317,11 @@ test('a session switch lands on the latest turn instead of flying to it', async 
             root.dataset.turnWarmup === 'settled' &&
             root.dataset.arrivalPin !== 'pinned';
           if (arrived) {
-            resolve({ maxDistance, growthSteps: heights.size, frames });
+            finish({ maxDistance, growthSteps: heights.size, frames });
             return;
           }
           if (performance.now() > deadline) {
-            reject(new Error(`The transcript never finished arriving (frames=${frames})`));
+            fail('The transcript never finished arriving');
             return;
           }
           requestAnimationFrame(sample);

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -254,6 +254,77 @@ test('returning to the session after visiting skills re-settles the new transcri
   expectHonestClimb(await climbToTop(page));
 });
 
+// A switched-to transcript must be AT its latest turn the first time it is
+// painted, not travel there. Astryx positions the first fill of its scroller
+// instantly and springs every later growth, and that one-shot belongs to the
+// hook instance — ChatSurfaceLayout mounts once for the whole shell, so it is
+// spent on whichever session was open at boot. Every switch afterwards arrived
+// as "later growth" (mount window, fill chunks, warm-up inflation) and the
+// scroller spring-flew ~10k px over ~1.2s in front of the reader.
+//
+// Sampled per frame rather than polled: the regression is an animation, and a
+// poll reads it as a sequence of positions that each look reasonable.
+test('a session switch lands on the latest turn instead of flying to it', async ({ longTranscriptWindow: page }) => {
+  await expect(page.locator('.maka-turn')).toHaveCount(24);
+  await settleGeometry(page, { pinned: true });
+
+  // Leave for another seeded session, so returning is a real session switch
+  // rather than a section change. Fixture windows don't pass OS hit-testing —
+  // dispatch clicks.
+  await page.locator('button[aria-label="展开侧边栏"]').dispatchEvent('click');
+  await page.getByText('模型管理与工具调用示例').first().dispatchEvent('click');
+  await expect(page.locator('[data-turn-id^="long-transcript-turn"]')).toHaveCount(0);
+
+  const watchPromise = page.evaluate(
+    () =>
+      new Promise<{ maxDistance: number; growthSteps: number; frames: number }>((resolve, reject) => {
+        const root = document.querySelector('[data-chat-scroll-container="true"]') as HTMLElement;
+        const heights = new Set<number>();
+        let maxDistance = 0;
+        let frames = 0;
+        const deadline = performance.now() + 30_000;
+        const sample = () => {
+          const turns = root.querySelectorAll('[data-turn-id^="long-transcript-turn"]').length;
+          if (turns > 0) {
+            frames += 1;
+            heights.add(root.scrollHeight);
+            maxDistance = Math.max(
+              maxDistance,
+              Math.round(root.scrollHeight - root.scrollTop - root.clientHeight),
+            );
+          }
+          // The arrival is over when the warm-up says the geometry settled and
+          // the pin has handed following back to Astryx.
+          const arrived =
+            turns > 0 &&
+            root.dataset.turnWarmup === 'settled' &&
+            root.dataset.arrivalPin !== 'pinned';
+          if (arrived) {
+            resolve({ maxDistance, growthSteps: heights.size, frames });
+            return;
+          }
+          if (performance.now() > deadline) {
+            reject(new Error(`The transcript never finished arriving (frames=${frames})`));
+            return;
+          }
+          requestAnimationFrame(sample);
+        };
+        requestAnimationFrame(sample);
+      }),
+  );
+
+  await page.getByText('超长会话滚动几何').first().dispatchEvent('click');
+  const watch = await watchPromise;
+  const diagnostics = JSON.stringify(watch);
+  // The document has to have grown under the watch for the distance below to
+  // mean anything: the mount window, the idle fill chunks and the warm-up each
+  // move it, and a run that observed one height measured nothing.
+  expect(watch.growthSteps, diagnostics).toBeGreaterThanOrEqual(3);
+  // Flush in EVERY frame the transcript existed, not merely once it settled.
+  // Sub-pixel scrollTop leaves the rounded distance on 1 (see settleGeometry).
+  expect(watch.maxDistance, diagnostics).toBeLessThanOrEqual(2);
+});
+
 // The empty surface is back here as a live metric, unlike the flush contract
 // the header notes moved out to static CSS. What centres the hero is the
 // ABSENCE of Astryx's push-to-bottom spacer, and the rule that collapses it

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -337,6 +337,11 @@ test('a session switch lands on the latest turn instead of flying to it', async 
   // mean anything: the mount window, the idle fill chunks and the warm-up each
   // move it, and a run that observed one height measured nothing.
   expect(watch.growthSteps, diagnostics).toBeGreaterThanOrEqual(3);
+  // And the watch has to have looked BETWEEN those steps. A run whose frames
+  // all landed on a change never observed a quiet frame — which is precisely
+  // where a spring mid-flight would be caught — so the flush assertion below
+  // would be reading only the moments the document moved.
+  expect(watch.frames, diagnostics).toBeGreaterThan(watch.growthSteps);
   // Flush in EVERY frame the transcript existed, not merely once it settled.
   // Sub-pixel scrollTop leaves the rounded distance on 1 (see settleGeometry).
   expect(watch.maxDistance, diagnostics).toBeLessThanOrEqual(2);

--- a/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
+++ b/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
@@ -231,16 +231,21 @@ describe('createArrivalBottomPin', () => {
     }
   });
 
-  it('keeps following through a downward wheel', () => {
-    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
-    const observer = fakeSizeObserver();
-    const pin = createArrivalBottomPin({
-      viewport,
-      content: {} as Element,
-      createSizeObserver: observer.factory,
-    });
-    viewport.emit('wheel', { deltaY: 120 } as Partial<Event>);
-    assert.equal(pin.isPinned(), true);
+  it('keeps following through a wheel that is not the reader going up', () => {
+    // Down is where the pin is already heading. Zero is a horizontal wheel or
+    // a trackpad's rounding — no vertical intent at all, and reading it as one
+    // would drop the pin on a sideways swipe across a wide code block.
+    for (const deltaY of [120, 0]) {
+      const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+      const observer = fakeSizeObserver();
+      const pin = createArrivalBottomPin({
+        viewport,
+        content: {} as Element,
+        createSizeObserver: observer.factory,
+      });
+      viewport.emit('wheel', { deltaY } as Partial<Event>);
+      assert.equal(pin.isPinned(), true, `deltaY=${deltaY}`);
+    }
   });
 
   it('detaches every observer and listener on dispose', () => {

--- a/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
+++ b/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
@@ -10,8 +10,10 @@ import {
  * Clamps `scrollTop` the way a real scroller does, so the assertions below can
  * be written as the contract — flush against the bottom — rather than as the
  * literal value the pin happens to assign. Writing `scrollHeight` is how the
- * pin asks for "as far down as this goes"; an unclamping fake would let a pin
- * that overshot by a viewport still look correct.
+ * pin asks for "as far down as this goes", and a real scroller answers by
+ * clamping, so overshoot is unobservable here exactly as it is in the product.
+ * What the clamp buys is the other direction: any arithmetic that stops the
+ * scroller short shows up as a distance, whatever produced it.
  */
 function fakeViewport(initial: { scrollTop: number; scrollHeight: number; clientHeight: number }) {
   const listeners = new Map<string, Set<(event: Event) => void>>();

--- a/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
+++ b/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
@@ -45,6 +45,20 @@ function fakeViewport(initial: { scrollTop: number; scrollHeight: number; client
   };
 }
 
+/**
+ * A transcript element that answers `contains` for the nodes inside it, so the
+ * gesture handlers can be exercised the way the DOM presents them: the dock's
+ * wheels and touches bubble through the same scroller as the transcript's.
+ */
+function fakeTranscript() {
+  const inside = { name: 'turn' } as unknown as Node;
+  const dock = { name: 'composer' } as unknown as Node;
+  const element = {
+    contains: (node: Node | null) => node === inside,
+  } as unknown as Element;
+  return { element, inside, dock };
+}
+
 function fakeSizeObserver() {
   let notify: (() => void) | undefined;
   let observed: Element | undefined;
@@ -214,21 +228,41 @@ describe('createArrivalBottomPin', () => {
     assert.equal(pin.isPinned(), false);
   });
 
-  it('releases on an upward wheel and on a touch drag, before the scroll lands', () => {
+  it('releases on an upward wheel and on a touch drag over the transcript', () => {
+    const transcript = fakeTranscript();
     for (const [type, event] of [
-      ['wheel', { deltaY: -120 }],
-      ['touchmove', {}],
+      ['wheel', { deltaY: -120, target: transcript.inside }],
+      ['touchmove', { target: transcript.inside }],
     ] as const) {
-      const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+      const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 4_000, clientHeight: 600 });
       const observer = fakeSizeObserver();
       const pin = createArrivalBottomPin({
         viewport,
-        content: {} as Element,
+        content: transcript.element,
         createSizeObserver: observer.factory,
       });
-      viewport.emit(type, event as Partial<Event>);
+      viewport.emit(type, event as unknown as Partial<Event>);
       assert.equal(pin.isPinned(), false, type);
     }
+  });
+
+  it('does not read a gesture over the dock as the reader leaving the turn', () => {
+    // The composer, plan panel and graph status live inside this scroller, so
+    // their wheels and touches arrive here too — and a wheel over the composer
+    // that really does scroll the transcript still releases the pin, through
+    // the scroll event it causes rather than through where the pointer was.
+    const transcript = fakeTranscript();
+    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 4_000, clientHeight: 600 });
+    const pin = createArrivalBottomPin({ viewport, content: transcript.element });
+
+    viewport.emit('wheel', { deltaY: -120, target: transcript.dock } as unknown as Partial<Event>);
+    viewport.emit('touchmove', { target: transcript.dock } as unknown as Partial<Event>);
+    assert.equal(pin.isPinned(), true);
+    assert.equal(viewport.distanceFromBottom, 0);
+
+    viewport.scrollTop = 1_000;
+    viewport.emit('scroll');
+    assert.equal(pin.isPinned(), false);
   });
 
   it('keeps following through a wheel that is not the reader going up', () => {

--- a/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
+++ b/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
@@ -1,0 +1,212 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  createArrivalBottomPin,
+  releasesArrivalPin,
+  type ArrivalPinSizeObserver,
+} from '../arrival-bottom-pin.js';
+
+function fakeViewport(initial: { scrollTop: number; scrollHeight: number; clientHeight: number }) {
+  const listeners = new Map<string, Set<(event: Event) => void>>();
+  return {
+    ...initial,
+    addEventListener(type: string, listener: (event: Event) => void) {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+    },
+    removeEventListener(type: string, listener: (event: Event) => void) {
+      listeners.get(type)?.delete(listener);
+    },
+    emit(type: string, event: Partial<Event> = {}) {
+      for (const listener of listeners.get(type) ?? []) listener(event as Event);
+    },
+    listenerCount(type: string) {
+      return listeners.get(type)?.size ?? 0;
+    },
+  };
+}
+
+function fakeSizeObserver() {
+  let notify: (() => void) | undefined;
+  let observed: Element | undefined;
+  let disconnected = false;
+  return {
+    factory: (callback: () => void): ArrivalPinSizeObserver => {
+      notify = callback;
+      return {
+        observe: (element) => { observed = element; },
+        disconnect: () => { disconnected = true; },
+      };
+    },
+    grow: () => notify?.(),
+    get observed() { return observed; },
+    get disconnected() { return disconnected; },
+  };
+}
+
+describe('releasesArrivalPin', () => {
+  it('reads an upward scroll with unchanged geometry as the reader taking over', () => {
+    assert.equal(
+      releasesArrivalPin({
+        scrollTop: 900,
+        lastScrollTop: 1_400,
+        scrollHeight: 2_000,
+        lastScrollHeight: 2_000,
+        clientHeight: 600,
+        lastClientHeight: 600,
+      }),
+      true,
+    );
+  });
+
+  it('ignores the synthetic scroll Chromium fires when the document grows', () => {
+    // The arrival window is nothing but growth: every mounted chunk and every
+    // warmed placeholder fires a scroll event whose scrollTop can read lower
+    // than the pin's last write. Only geometry that held still is evidence.
+    assert.equal(
+      releasesArrivalPin({
+        scrollTop: 900,
+        lastScrollTop: 1_400,
+        scrollHeight: 4_000,
+        lastScrollHeight: 2_000,
+        clientHeight: 600,
+        lastClientHeight: 600,
+      }),
+      false,
+    );
+    assert.equal(
+      releasesArrivalPin({
+        scrollTop: 900,
+        lastScrollTop: 1_400,
+        scrollHeight: 2_000,
+        lastScrollHeight: 2_000,
+        clientHeight: 500,
+        lastClientHeight: 600,
+      }),
+      false,
+    );
+  });
+
+  it('holds the pin through a sub-pixel readback of its own write', () => {
+    assert.equal(
+      releasesArrivalPin({
+        scrollTop: 1_399.5,
+        lastScrollTop: 1_400,
+        scrollHeight: 2_000,
+        lastScrollHeight: 2_000,
+        clientHeight: 600,
+        lastClientHeight: 600,
+      }),
+      false,
+    );
+  });
+});
+
+describe('createArrivalBottomPin', () => {
+  it('consumes every growth step instantly while pinned', () => {
+    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+    const observer = fakeSizeObserver();
+    const content = {} as Element;
+    const states: string[] = [];
+    const pin = createArrivalBottomPin({
+      viewport,
+      content,
+      onStateChange: (state) => { states.push(state); },
+      createSizeObserver: observer.factory,
+    });
+
+    // Positioned on creation: the transcript's first commit is already growth.
+    assert.equal(viewport.scrollTop, 800);
+    assert.equal(observer.observed, content);
+    viewport.scrollHeight = 15_000;
+    observer.grow();
+    assert.equal(viewport.scrollTop, 15_000);
+    viewport.scrollHeight = 32_908;
+    observer.grow();
+    assert.equal(viewport.scrollTop, 32_908);
+    assert.deepEqual(states, ['pinned']);
+    assert.equal(pin.isPinned(), true);
+  });
+
+  it('stops following once the reader scrolls up, and stays released', () => {
+    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+    const observer = fakeSizeObserver();
+    const states: string[] = [];
+    const pin = createArrivalBottomPin({
+      viewport,
+      content: {} as Element,
+      onStateChange: (state) => { states.push(state); },
+      createSizeObserver: observer.factory,
+    });
+
+    viewport.scrollTop = 200;
+    viewport.emit('scroll');
+    assert.equal(pin.isPinned(), false);
+    viewport.scrollHeight = 4_000;
+    observer.grow();
+    assert.equal(viewport.scrollTop, 200);
+    // A later growth step must not re-pin: releasing is permanent for this
+    // arrival, the way Astryx's own unlock is.
+    viewport.scrollHeight = 9_000;
+    observer.grow();
+    assert.equal(viewport.scrollTop, 200);
+    assert.deepEqual(states, ['pinned', 'released']);
+  });
+
+  it('releases on an upward wheel and on a touch drag, before the scroll lands', () => {
+    for (const [type, event] of [
+      ['wheel', { deltaY: -120 }],
+      ['touchmove', {}],
+    ] as const) {
+      const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+      const observer = fakeSizeObserver();
+      const pin = createArrivalBottomPin({
+        viewport,
+        content: {} as Element,
+        createSizeObserver: observer.factory,
+      });
+      viewport.emit(type, event as Partial<Event>);
+      assert.equal(pin.isPinned(), false, type);
+    }
+  });
+
+  it('keeps following through a downward wheel', () => {
+    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+    const observer = fakeSizeObserver();
+    const pin = createArrivalBottomPin({
+      viewport,
+      content: {} as Element,
+      createSizeObserver: observer.factory,
+    });
+    viewport.emit('wheel', { deltaY: 120 } as Partial<Event>);
+    assert.equal(pin.isPinned(), true);
+  });
+
+  it('detaches every observer and listener on dispose', () => {
+    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+    const observer = fakeSizeObserver();
+    const pin = createArrivalBottomPin({
+      viewport,
+      content: {} as Element,
+      createSizeObserver: observer.factory,
+    });
+    pin.dispose();
+    assert.equal(observer.disconnected, true);
+    assert.equal(viewport.listenerCount('scroll'), 0);
+    assert.equal(viewport.listenerCount('wheel'), 0);
+    assert.equal(viewport.listenerCount('touchmove'), 0);
+  });
+
+  it('does nothing but position when the content element is missing', () => {
+    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+    const observer = fakeSizeObserver();
+    createArrivalBottomPin({
+      viewport,
+      content: null,
+      createSizeObserver: observer.factory,
+    });
+    assert.equal(viewport.scrollTop, 800);
+    assert.equal(observer.observed, undefined);
+  });
+});

--- a/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
+++ b/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
@@ -154,6 +154,47 @@ describe('createArrivalBottomPin', () => {
     assert.deepEqual(states, ['pinned', 'released']);
   });
 
+  it('follows a growth, rides its synthetic scroll, and still yields to the reader after it', () => {
+    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+    const observer = fakeSizeObserver();
+    const pin = createArrivalBottomPin({
+      viewport,
+      content: {} as Element,
+      createSizeObserver: observer.factory,
+    });
+
+    viewport.scrollHeight = 15_000;
+    observer.grow();
+    // Chromium fires a scroll event for the resize itself. It reports a
+    // position the reader never chose, and the pin must not read it as intent.
+    viewport.emit('scroll');
+    assert.equal(pin.isPinned(), true);
+
+    viewport.scrollTop = 9_000;
+    viewport.emit('scroll');
+    assert.equal(pin.isPinned(), false);
+  });
+
+  it('takes its geometry snapshot from growth it did not write itself', () => {
+    // Not every growth reaches the observed content element: the dock (graph
+    // status, plan panel) lives inside the scroller but outside the message
+    // list, so it moves scrollHeight with a scroll event and nothing else. The
+    // snapshot has to follow that too, or the NEXT genuine upward scroll is
+    // compared against a stale height, reads as "geometry changed", and the
+    // reader silently loses control of the transcript.
+    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+    const pin = createArrivalBottomPin({ viewport, content: null });
+
+    assert.equal(viewport.scrollTop, 800);
+    viewport.scrollHeight = 15_000;
+    viewport.emit('scroll');
+    assert.equal(pin.isPinned(), true);
+
+    viewport.scrollTop = 700;
+    viewport.emit('scroll');
+    assert.equal(pin.isPinned(), false);
+  });
+
   it('releases on an upward wheel and on a touch drag, before the scroll lands', () => {
     for (const [type, event] of [
       ['wheel', { deltaY: -120 }],

--- a/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
+++ b/packages/ui/src/__tests__/arrival-bottom-pin.test.ts
@@ -6,10 +6,28 @@ import {
   type ArrivalPinSizeObserver,
 } from '../arrival-bottom-pin.js';
 
+/**
+ * Clamps `scrollTop` the way a real scroller does, so the assertions below can
+ * be written as the contract — flush against the bottom — rather than as the
+ * literal value the pin happens to assign. Writing `scrollHeight` is how the
+ * pin asks for "as far down as this goes"; an unclamping fake would let a pin
+ * that overshot by a viewport still look correct.
+ */
 function fakeViewport(initial: { scrollTop: number; scrollHeight: number; clientHeight: number }) {
   const listeners = new Map<string, Set<(event: Event) => void>>();
+  let scrollTop = initial.scrollTop;
   return {
-    ...initial,
+    scrollHeight: initial.scrollHeight,
+    clientHeight: initial.clientHeight,
+    get scrollTop() {
+      return scrollTop;
+    },
+    set scrollTop(value: number) {
+      scrollTop = Math.max(0, Math.min(value, this.scrollHeight - this.clientHeight));
+    },
+    get distanceFromBottom() {
+      return this.scrollHeight - scrollTop - this.clientHeight;
+    },
     addEventListener(type: string, listener: (event: Event) => void) {
       const set = listeners.get(type) ?? new Set();
       set.add(listener);
@@ -117,20 +135,20 @@ describe('createArrivalBottomPin', () => {
     });
 
     // Positioned on creation: the transcript's first commit is already growth.
-    assert.equal(viewport.scrollTop, 800);
+    assert.equal(viewport.distanceFromBottom, 0);
     assert.equal(observer.observed, content);
     viewport.scrollHeight = 15_000;
     observer.grow();
-    assert.equal(viewport.scrollTop, 15_000);
+    assert.equal(viewport.distanceFromBottom, 0);
     viewport.scrollHeight = 32_908;
     observer.grow();
-    assert.equal(viewport.scrollTop, 32_908);
+    assert.equal(viewport.distanceFromBottom, 0);
     assert.deepEqual(states, ['pinned']);
     assert.equal(pin.isPinned(), true);
   });
 
   it('stops following once the reader scrolls up, and stays released', () => {
-    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 4_000, clientHeight: 600 });
     const observer = fakeSizeObserver();
     const states: string[] = [];
     const pin = createArrivalBottomPin({
@@ -140,17 +158,17 @@ describe('createArrivalBottomPin', () => {
       createSizeObserver: observer.factory,
     });
 
-    viewport.scrollTop = 200;
+    viewport.scrollTop = 1_000;
     viewport.emit('scroll');
     assert.equal(pin.isPinned(), false);
-    viewport.scrollHeight = 4_000;
-    observer.grow();
-    assert.equal(viewport.scrollTop, 200);
-    // A later growth step must not re-pin: releasing is permanent for this
-    // arrival, the way Astryx's own unlock is.
     viewport.scrollHeight = 9_000;
     observer.grow();
-    assert.equal(viewport.scrollTop, 200);
+    assert.equal(viewport.scrollTop, 1_000);
+    // A later growth step must not re-pin: releasing is permanent for this
+    // arrival, the way Astryx's own unlock is.
+    viewport.scrollHeight = 15_000;
+    observer.grow();
+    assert.equal(viewport.scrollTop, 1_000);
     assert.deepEqual(states, ['pinned', 'released']);
   });
 
@@ -165,6 +183,7 @@ describe('createArrivalBottomPin', () => {
 
     viewport.scrollHeight = 15_000;
     observer.grow();
+    assert.equal(viewport.distanceFromBottom, 0);
     // Chromium fires a scroll event for the resize itself. It reports a
     // position the reader never chose, and the pin must not read it as intent.
     viewport.emit('scroll');
@@ -182,10 +201,10 @@ describe('createArrivalBottomPin', () => {
     // snapshot has to follow that too, or the NEXT genuine upward scroll is
     // compared against a stale height, reads as "geometry changed", and the
     // reader silently loses control of the transcript.
-    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 800, clientHeight: 600 });
+    const viewport = fakeViewport({ scrollTop: 0, scrollHeight: 4_000, clientHeight: 600 });
     const pin = createArrivalBottomPin({ viewport, content: null });
 
-    assert.equal(viewport.scrollTop, 800);
+    assert.equal(viewport.distanceFromBottom, 0);
     viewport.scrollHeight = 15_000;
     viewport.emit('scroll');
     assert.equal(pin.isPinned(), true);
@@ -247,7 +266,7 @@ describe('createArrivalBottomPin', () => {
       content: null,
       createSizeObserver: observer.factory,
     });
-    assert.equal(viewport.scrollTop, 800);
+    assert.equal(viewport.distanceFromBottom, 0);
     assert.equal(observer.observed, undefined);
   });
 });

--- a/packages/ui/src/arrival-bottom-pin.ts
+++ b/packages/ui/src/arrival-bottom-pin.ts
@@ -1,0 +1,169 @@
+/**
+ * Instant bottom pin for a transcript that is still arriving.
+ *
+ * Astryx's `useChatStreamScroll` positions the FIRST fill of its scroller
+ * instantly and springs every later growth. That one-shot lives on the hook
+ * instance, and `ChatSurfaceLayout` mounts once for the whole app shell, so it
+ * is spent on the session that happened to be open at boot. Every switch after
+ * that is "later growth" — and a switched-to transcript does not arrive in one
+ * piece: the progressive mount commits a tail window, idle chunks fill the
+ * prefix, and the `content-visibility` warm-up then inflates every placeholder.
+ * Each step grows the document under a scroller the spring is chasing, so the
+ * new session opens mid-document and visibly flies to its latest turn (measured
+ * at ~10k px over ~1.2s on the 24-turn fixture).
+ *
+ * A session change is navigation, not content growth: the transcript is meant
+ * to be at its latest turn the first time it is painted, exactly as it is on a
+ * cold start. This pin owns that arrival window only. It writes `scrollTop`
+ * from a ResizeObserver — after layout, before paint — so the growth the spring
+ * would have animated is already consumed by the time a frame is painted, and
+ * the spring settles against a zero delta instead of running. Steady-state
+ * following (streaming tokens, appended turns) stays Astryx's, which is why the
+ * caller releases this at the end of the arrival window rather than keeping it.
+ *
+ * Any sign the reader took control releases the pin for good, using the same
+ * signals Astryx unlocks on: an upward wheel, a touch drag, or a scroll that
+ * moved up on its own — one where the geometry did NOT change in the same
+ * event, since Chromium fires a synthetic scroll for every content resize and
+ * the arrival window is nothing but resizes.
+ */
+
+export interface ArrivalPinViewport {
+  scrollTop: number;
+  readonly scrollHeight: number;
+  readonly clientHeight: number;
+  addEventListener(type: string, listener: (event: Event) => void, options?: { passive?: boolean }): void;
+  removeEventListener(type: string, listener: (event: Event) => void): void;
+}
+
+export interface ArrivalPinSizeObserver {
+  observe(element: Element): void;
+  disconnect(): void;
+}
+
+export type ArrivalPinSizeObserverFactory = (callback: () => void) => ArrivalPinSizeObserver;
+
+export interface ArrivalPinGeometry {
+  readonly scrollTop: number;
+  readonly lastScrollTop: number;
+  readonly scrollHeight: number;
+  readonly lastScrollHeight: number;
+  readonly clientHeight: number;
+  readonly lastClientHeight: number;
+}
+
+/**
+ * Whether a scroll event is the reader moving up rather than the document
+ * growing under them.
+ *
+ * The 1px tolerance is for Chromium's fractional `scrollTop`: pinning writes
+ * `scrollHeight`, which clamps to a maximum that can carry a sub-pixel
+ * fraction, and reading it back a frame later can land just under the value the
+ * pin recorded.
+ */
+export function releasesArrivalPin(geometry: ArrivalPinGeometry): boolean {
+  if (
+    geometry.scrollHeight !== geometry.lastScrollHeight ||
+    geometry.clientHeight !== geometry.lastClientHeight
+  ) {
+    return false;
+  }
+  return geometry.scrollTop < geometry.lastScrollTop - 1;
+}
+
+export interface ArrivalBottomPin {
+  /** Stop following; the viewport is left wherever it currently sits. */
+  release(): void;
+  /** Release and detach every observer and listener. */
+  dispose(): void;
+  /** False once the reader took control or the caller released the pin. */
+  isPinned(): boolean;
+}
+
+export function createArrivalBottomPin(options: {
+  viewport: ArrivalPinViewport;
+  /**
+   * The element whose height the transcript grows with. The scroller's own box
+   * never changes size while its content does, so observing the viewport would
+   * report nothing.
+   */
+  content: Element | null;
+  /** Published by the caller as a DOM marker; see use-chat-scroll. */
+  onStateChange?: (state: 'pinned' | 'released') => void;
+  createSizeObserver?: ArrivalPinSizeObserverFactory;
+}): ArrivalBottomPin {
+  const viewport = options.viewport;
+  let pinned = true;
+  let lastScrollTop = viewport.scrollTop;
+  let lastScrollHeight = viewport.scrollHeight;
+  let lastClientHeight = viewport.clientHeight;
+
+  const pin = (): void => {
+    if (!pinned) return;
+    viewport.scrollTop = viewport.scrollHeight;
+    lastScrollTop = viewport.scrollTop;
+    lastScrollHeight = viewport.scrollHeight;
+    lastClientHeight = viewport.clientHeight;
+  };
+
+  const release = (): void => {
+    if (!pinned) return;
+    pinned = false;
+    options.onStateChange?.('released');
+  };
+
+  const onScroll = (): void => {
+    if (!pinned) return;
+    if (
+      releasesArrivalPin({
+        scrollTop: viewport.scrollTop,
+        lastScrollTop,
+        scrollHeight: viewport.scrollHeight,
+        lastScrollHeight,
+        clientHeight: viewport.clientHeight,
+        lastClientHeight,
+      })
+    ) {
+      release();
+      return;
+    }
+    lastScrollTop = viewport.scrollTop;
+    lastScrollHeight = viewport.scrollHeight;
+    lastClientHeight = viewport.clientHeight;
+  };
+
+  // Wheel and touch are read before the scroll they cause, which is what makes
+  // them worth listening to on top of `onScroll`: they release the pin in the
+  // same frame the reader acts, rather than one growth later.
+  const onWheel = (event: Event): void => {
+    if ((event as WheelEvent).deltaY < 0) release();
+  };
+  const onTouchMove = (): void => { release(); };
+
+  viewport.addEventListener('scroll', onScroll, { passive: true });
+  viewport.addEventListener('wheel', onWheel, { passive: true });
+  viewport.addEventListener('touchmove', onTouchMove, { passive: true });
+
+  const createSizeObserver = options.createSizeObserver
+    ?? (typeof ResizeObserver === 'function'
+      ? (callback: () => void) => new ResizeObserver(callback)
+      : undefined);
+  const content = options.content;
+  const sizeObserver = content ? createSizeObserver?.(pin) : undefined;
+  if (content) sizeObserver?.observe(content);
+
+  options.onStateChange?.('pinned');
+  pin();
+
+  return {
+    release,
+    isPinned: () => pinned,
+    dispose: () => {
+      release();
+      sizeObserver?.disconnect();
+      viewport.removeEventListener('scroll', onScroll);
+      viewport.removeEventListener('wheel', onWheel);
+      viewport.removeEventListener('touchmove', onTouchMove);
+    },
+  };
+}

--- a/packages/ui/src/arrival-bottom-pin.ts
+++ b/packages/ui/src/arrival-bottom-pin.ts
@@ -22,10 +22,10 @@
  * caller releases this at the end of the arrival window rather than keeping it.
  *
  * Any sign the reader took control releases the pin for good, using the same
- * signals Astryx unlocks on: an upward wheel, a touch drag, or a scroll that
- * moved up on its own — one where the geometry did NOT change in the same
- * event, since Chromium fires a synthetic scroll for every content resize and
- * the arrival window is nothing but resizes.
+ * signals Astryx unlocks on: an upward wheel or a touch drag over the
+ * transcript, or a scroll that moved up on its own — one where the geometry did
+ * NOT change in the same event, since Chromium fires a synthetic scroll for
+ * every content resize and the arrival window is nothing but resizes.
  */
 
 export interface ArrivalPinViewport {
@@ -93,6 +93,7 @@ export function createArrivalBottomPin(options: {
   createSizeObserver?: ArrivalPinSizeObserverFactory;
 }): ArrivalBottomPin {
   const viewport = options.viewport;
+  const content = options.content;
   let pinned = true;
   let lastScrollTop = viewport.scrollTop;
   let lastScrollHeight = viewport.scrollHeight;
@@ -134,11 +135,26 @@ export function createArrivalBottomPin(options: {
 
   // Wheel and touch are read before the scroll they cause, which is what makes
   // them worth listening to on top of `onScroll`: they release the pin in the
-  // same frame the reader acts, rather than one growth later.
-  const onWheel = (event: Event): void => {
-    if ((event as WheelEvent).deltaY < 0) release();
+  // same frame the reader acts, rather than one growth later — a growth landing
+  // between the gesture and its scroll event would otherwise re-pin under them.
+  //
+  // Scoped to gestures over the transcript. The dock — composer, plan panel,
+  // graph status — sits inside this scroller, so its wheels and touches bubble
+  // here too, and neither is evidence that the reader left the latest turn.
+  // Nothing is lost by being strict: a gesture that really moves the scroller
+  // still reaches `onScroll`, which decides on what the geometry did rather
+  // than on where the pointer was.
+  const overTranscript = (event: Event): boolean => {
+    const target = event.target;
+    if (!content || typeof content.contains !== 'function' || !target) return true;
+    return content.contains(target as Node);
   };
-  const onTouchMove = (): void => { release(); };
+  const onWheel = (event: Event): void => {
+    if ((event as WheelEvent).deltaY < 0 && overTranscript(event)) release();
+  };
+  const onTouchMove = (event: Event): void => {
+    if (overTranscript(event)) release();
+  };
 
   viewport.addEventListener('scroll', onScroll, { passive: true });
   viewport.addEventListener('wheel', onWheel, { passive: true });
@@ -148,7 +164,6 @@ export function createArrivalBottomPin(options: {
     ?? (typeof ResizeObserver === 'function'
       ? (callback: () => void) => new ResizeObserver(callback)
       : undefined);
-  const content = options.content;
   const sizeObserver = content ? createSizeObserver?.(pin) : undefined;
   if (content) sizeObserver?.observe(content);
 

--- a/packages/ui/src/use-chat-scroll.ts
+++ b/packages/ui/src/use-chat-scroll.ts
@@ -1,5 +1,6 @@
-import { useEffect, useLayoutEffect, useState, type RefObject } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
 import type { StoredMessage } from '@maka/core';
+import { createArrivalBottomPin, type ArrivalBottomPin } from './arrival-bottom-pin.js';
 import { createTurnSizeWarmup } from './turn-size-warmup.js';
 
 export function useChatScroll(input: {
@@ -18,16 +19,47 @@ export function useChatScroll(input: {
   warmupReady?: boolean;
 }) {
   const [highlightedTurnId, setHighlightedTurnId] = useState<string | null>(null);
+  const arrivalPin = useRef<ArrivalBottomPin | null>(null);
 
   // ChatLayout owns steady-state following. A session change is product
-  // navigation rather than content growth, so position the shared Astryx
-  // scroller at the new transcript's latest turn immediately.
+  // navigation rather than content growth, so the new transcript must be at its
+  // latest turn the first time it is painted — and it arrives in pieces (mount
+  // window, idle fill chunks, content-visibility warm-up), each of which reads
+  // to Astryx as growth to spring after. Writing `scrollTop` once here is not
+  // enough: at this point the switched-to transcript is still an empty scroller,
+  // and every piece that lands afterwards restarts the flight. The pin consumes
+  // those growth steps instantly instead, until the warm-up below reports the
+  // geometry settled or the reader takes over; see arrival-bottom-pin.ts.
+  //
+  // Passive, not a layout effect: ChatLayout re-renders with the switch and
+  // hands React a fresh merged callback ref, so its own root ref is detached
+  // and not yet reattached while a child's layout effects run — the scroller is
+  // reliably reachable only after the commit, which is the same reason the
+  // warm-up effect below publishes its marker passively.
   useEffect(() => {
     const viewport = input.scrollRef.current;
-    if (viewport) {
+    if (!viewport) return;
+    // Nothing to arrive: keep the plain positioning this effect has always done
+    // for a transcript that is empty (or still loading its first turn), and let
+    // the pin install on the commit those turns land in.
+    if (!input.hasTurns) {
       viewport.scrollTop = viewport.scrollHeight;
+      return;
     }
-  }, [input.sessionId, input.scrollRef]);
+    const pin = createArrivalBottomPin({
+      viewport,
+      content: viewport.querySelector('.maka-chat-message-list'),
+      // Published the way the warm-up and the progressive fill publish theirs,
+      // so a test can wait on the arrival window instead of guessing at timing.
+      onStateChange: (state) => { viewport.dataset.arrivalPin = state; },
+    });
+    arrivalPin.current = pin;
+    return () => {
+      pin.dispose();
+      arrivalPin.current = null;
+      delete viewport.dataset.arrivalPin;
+    };
+  }, [input.sessionId, input.hasTurns, input.scrollRef]);
 
   // Withdraw a previous transcript's terminal marker in the same commit that
   // changes the session. ChatLayout owns the DOM ref, so on the first mount its
@@ -72,12 +104,17 @@ export function useChatScroll(input: {
             const distanceFromBottom = root.scrollHeight - root.scrollTop - root.clientHeight;
             if (distanceFromBottom <= 10) {
               root.scrollTop = root.scrollHeight;
+              // Arrival is over: nothing else grows the document on its own, so
+              // following goes back to Astryx for streaming and new turns.
+              arrivalPin.current?.release();
               return;
             }
             settleAttempts += 1;
             if (settleAttempts < 50) {
               settleTimer = window.setTimeout(finishPinnedWarmup, 100);
+              return;
             }
+            arrivalPin.current?.release();
           };
           settleTimer = window.setTimeout(finishPinnedWarmup, 100);
         },
@@ -97,6 +134,10 @@ export function useChatScroll(input: {
   useEffect(() => {
     const target = input.target;
     if (!target?.turnId) return;
+    // Navigating to a turn is the reader choosing a position, so it outranks an
+    // arrival still in flight. (An upward scroll would release the pin on its
+    // own a frame later; releasing here keeps the first frame honest too.)
+    arrivalPin.current?.release();
     const frame = window.requestAnimationFrame(() => {
       const root = input.scrollRef.current;
       if (!root) return;


### PR DESCRIPTION
## Problem

Switching sessions plays a visible scroll animation: the new transcript appears near its top and travels down to the latest turn. On the 24-turn `long-transcript` fixture the scroller covers **10844px over ~1.2s** in front of the reader, sampled every frame across the switch:

```
t=31   turns=10  scrollTop=0      scrollHeight=2976    distanceFromBottom=2196
t=52   turns=10  scrollTop=88     scrollHeight=11712   distanceFromBottom=10844
t=170  turns=24  scrollTop=8935   scrollHeight=15436   distanceFromBottom=5722
t=263  turns=24  scrollTop=27020  scrollHeight=32908   distanceFromBottom=5109
...
t=1208 turns=24  scrollTop=32128  scrollHeight=32908   distanceFromBottom=0
```

## Cause

Astryx's `useChatStreamScroll` positions the **first** fill of its scroller instantly and **springs every later growth**. That one-shot (`initialFillPendingRef`) lives on the hook instance, and `ChatSurfaceLayout` mounts **once** for the whole app shell — `app-shell.tsx` toggles `hidden`, it never remounts — so the instant path is spent on whichever session was open at boot. Every switch afterwards is "later growth".

And a switched-to transcript does not arrive in one piece. #2191's progressive mount commits a tail window, idle chunks fill the prefix, and the `content-visibility` warm-up (#827) then inflates every 250px placeholder. Each step grows the document under a scroller the spring is already chasing — which is why the flight lasts a second rather than a frame, and why the trace above shows the spring restarting at every jump in `scrollHeight`.

`useChatScroll` wrote `scrollTop = scrollHeight` once on the session change, which is too early to help: at that point the switched-to transcript is still an empty scroller.

## Fix

`packages/ui/src/arrival-bottom-pin.ts` — a bottom pin scoped to the **arrival window** of a switched-to transcript.

It writes `scrollTop` from a ResizeObserver on the message list, i.e. after layout and before paint, so the growth the spring would have animated is already consumed by the time a frame is painted and the spring settles against a zero delta instead of running.

It owns the arrival and nothing else:

- **released when the warm-up reports the geometry settled** — steady-state following (streaming, appended turns) stays Astryx's, exactly as #1795 intended;
- **released on any sign the reader took control**, using the signals Astryx itself unlocks on: an upward wheel, a touch drag, or a scroll that moved up *while the geometry held still*. The last qualifier is the load-bearing one — the arrival window is nothing but resizes, and Chromium fires a synthetic scroll for each of them;
- **released on turn navigation** (search / revision targets), where the reader has chosen a position.

The pin publishes `data-arrival-pin` on the scroller, the way the warm-up publishes `data-turn-warmup` and the fill publishes `data-progressive-fill`, so a test can wait on the real boundary instead of guessing at timing.

After the fix, the same switch, same sampling:

```
t=41  pin=pinned    turns=10  scrollTop=2196   scrollHeight=2976   distanceFromBottom=0
t=149 pin=pinned    turns=24  scrollTop=13564  scrollHeight=14344  distanceFromBottom=0
t=209 pin=pinned    turns=24  scrollTop=32128  scrollHeight=32908  distanceFromBottom=0
t=332 pin=released
```

## Tests

- `packages/ui/src/__tests__/arrival-bottom-pin.test.ts` — 9 cases over the pure module: follows every growth step, ignores the synthetic scroll a resize fires, holds through a sub-pixel readback of its own write, releases permanently on reader intent, detaches on dispose.
- `apps/desktop/e2e/scroll-geometry.spec.ts` — `a session switch lands on the latest turn instead of flying to it`. Sampled **per frame** rather than polled, because the regression is an animation and a poll reads it as a sequence of individually reasonable positions. It asserts the transcript is flush in every frame it exists, and that the document actually grew under the watch, so a run that measured nothing fails loudly. On the parent commit it fails with `maxDistance=11267`; here it reports `0`.

Verified locally: `format:check`, `lint`, `typecheck`, `knip --workspace packages/ui`, `@maka/ui` (352 tests), and the full `scroll-geometry` suite (8/8) — including `progressive fill preserves the reading anchor while earlier turns mount`, which is the case where the pin has to get out of the way.

## Notes for review

- **Why not fix this in Astryx**: the layout has no notion of "the conversation changed", which is the only thing that distinguishes navigation from growth. Its own instant path is already correct for what it can see.
- **Relationship to #2224**: orthogonal. #2224 seeds the missing geometry so the *scrollbar* stops resizing during the fill; this keeps the *viewport* flush while it does. Both survive the other landing first — if the prefix stops growing the document, the pin simply has less to consume.
- One implementation note worth knowing: this has to be a passive effect. `ChatLayout` passes `ref={mergeRefs(ref, rootRef)}`, a fresh callback ref each render, so React detaches and reattaches its root ref around every commit and `scrollContainerRef.current` is `null` while a child's layout effects run. That is the same reason the warm-up effect below it is passive.

Reported by a user watching every session switch scroll itself into place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
