### PR TITLE
fix(runtime): replay provider-facing MCP arguments

### DIFF
--- a/packages/runtime/src/__tests__/tool-runtime-sqlite-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sqlite-boundary.test.ts
@@ -12,6 +12,8 @@ import {
 } from '@maka/core';
 import { createSqliteRuntimeStore } from '@maka/storage';
 import { createSessionEventMapMemory, mapSessionEventToRuntimeEvent } from '../ai-sdk-flow.js';
+import { buildRuntimeEventModelReplayPlan } from '../model-history.js';
+import { buildMcpTools } from '../mcp-tools.js';
 import type { InvocationContext } from '../invocation-context.js';
 import { MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN, ToolRuntime, type MakaTool } from '../tool-runtime.js';
 
@@ -21,6 +23,29 @@ describe('ToolRuntime with real SQLite boundary', () => {
     const store = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));
     try {
       let implementationCalls = 0;
+      const [clientTool] = buildMcpTools(
+        {
+          tools: () => [
+            {
+              serverId: 'desktop_computer_use',
+              name: 'maka_computer',
+              description: 'Client-owned Computer Use',
+              inputSchema: {
+                type: 'object',
+                properties: { action: { const: 'list_apps' } },
+                required: ['action'],
+                additionalProperties: false,
+              },
+            },
+          ],
+          callTool: async () => {
+            implementationCalls += 1;
+            return { content: [{ type: 'text', text: 'ok' }] };
+          },
+        },
+        { categoryHint: 'client_capability', recoveryMode: 'outcome_unknown' },
+      );
+      assert.ok(clientTool);
       const runtime = createTestToolRuntime({
         sessionId: 'session-1',
         header: header(),
@@ -37,16 +62,7 @@ describe('ToolRuntime with real SQLite boundary', () => {
       });
       const published: SessionEvent[] = [];
       const result = await runtime.settleToolCall({
-        tool: {
-          name: 'mcp__desktop_computer_use__maka_computer',
-          description: 'Client-owned Computer Use',
-          parameters: {},
-          categoryHint: 'client_capability',
-          impl: async () => {
-            implementationCalls += 1;
-            return { ok: true };
-          },
-        },
+        tool: clientTool,
         turnId: 'turn-1',
         toolCallId: 'provider-call-computer-use',
         input: { action: 'list_apps' },
@@ -78,10 +94,17 @@ describe('ToolRuntime with real SQLite boundary', () => {
           mapSessionEventToRuntimeEvent(event, invocationContext(), memory),
         );
       }
+      const runtimeEvents = await store.readRuntimeEvents('session-1', 'run-1');
       assert.deepEqual(
-        (await store.readRuntimeEvents('session-1', 'run-1')).map((event) => event.content?.kind),
+        runtimeEvents.map((event) => event.content?.kind),
         ['function_call', 'function_response'],
       );
+      const replayCall = buildRuntimeEventModelReplayPlan(runtimeEvents).items.find(
+        (item) => item.kind === 'tool_call',
+      );
+      assert.deepEqual(replayCall?.kind === 'tool_call' ? replayCall.input : undefined, {
+        action: 'list_apps',
+      });
     } finally {
       store.close();
       await rm(root, { recursive: true, force: true });

--- a/packages/runtime/src/mcp-tools.ts
+++ b/packages/runtime/src/mcp-tools.ts
@@ -77,11 +77,6 @@ export function buildMcpTools(
       categoryHint: options.categoryHint ?? 'network_send',
       ...(options.recoveryMode ? { recoveryMode: options.recoveryMode } : {}),
       parameters: jsonSchema(descriptor.inputSchema),
-      permissionArgs: (args) => ({
-        serverId: descriptor.serverId,
-        toolName: descriptor.name,
-        arguments: args,
-      }),
       impl: async (args: unknown, context) =>
         callTool(asArguments(args), {
           signal: context.abortSignal,


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- persist provider-facing MCP arguments instead of the proxy transport envelope
- keep rejected Client Capability calls replayable with the schema the model originally used
- cover the Ask-boundary rejection and subsequent RuntimeEvent replay with a real SQLite regression test

## Root cause

`buildMcpTools` projected every MCP call into `{ serverId, toolName, arguments }` before persistence. RuntimeEvent history later replayed that internal transport shape as the model's own tool input. A model following its history nested the envelope again, so the actual MCP schema rejected the call.

The MCP proxy closure already owns the server and tool identity. Persisting that identity inside provider-facing arguments was redundant and made the model history invalid.

## Validation

- `@maka/runtime` full test suite: 3,179 passed, 0 failed, 9 skipped
- Runtime Host execution-model composition: 19 passed, 0 failed
- `@maka/runtime` typecheck
- Biome check

</details>

<details>
<summary>中文</summary>

## 概要

- 持久化 provider-facing MCP 参数，不再持久化 proxy 内部传输 envelope
- 确保被执行边界拒绝的 Client Capability 调用仍以模型最初使用的合法 schema 回放
- 使用真实 SQLite 回归测试覆盖 Ask 边界拒绝和后续 RuntimeEvent replay

## 根因

`buildMcpTools` 在持久化前将每个 MCP 调用投影为 `{ serverId, toolName, arguments }`。RuntimeEvent 历史随后把这个内部传输结构作为模型自己的工具参数回放。模型模仿历史时再次嵌套 envelope，最终被真实 MCP schema 拒绝。

MCP proxy 的闭包已经持有 server 和 tool 身份，因此把这部分身份写入 provider-facing 参数既重复，又会破坏模型历史。

## 验证

- `@maka/runtime` 全量测试：3,179 passed，0 failed，9 skipped
- Runtime Host execution-model composition：19 passed，0 failed
- `@maka/runtime` typecheck
- Biome check

</details>
