### PR TITLE
fix(ui): keep tool details visible during live turns

### DIFF
--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -557,6 +557,72 @@ describe("live tool status over persisted", () => {
     );
   });
 
+  test("keeps durable tool detail while a Runtime Host Turn is still live", () => {
+    const settled = materializeTurns([
+      userMsg("t1", 1, "use the computer"),
+      {
+        type: "turn_state",
+        id: "s1",
+        turnId: "t1",
+        ts: 2,
+        status: "running",
+        partialOutputRetained: false,
+      },
+      {
+        type: "tool_call",
+        id: "computer-1",
+        turnId: "t1",
+        ts: 3,
+        toolName: "maka_computer",
+        args: { action: "click_element", element_id: "615" },
+      },
+      {
+        type: "tool_result",
+        id: "result-1",
+        turnId: "t1",
+        ts: 4,
+        toolUseId: "computer-1",
+        isError: false,
+        content: { kind: "text", text: "unsupported_action" },
+      },
+    ]);
+
+    const turns = overlayLiveTurn(settled, {
+      turnId: "t1",
+      phase: "streamed",
+      steps: [
+        {
+          stepId: "tool:computer-1",
+          tools: [
+            {
+              toolUseId: "computer-1",
+              toolName: "maka_computer",
+              status: "completed",
+              args: undefined,
+              // Runtime Host live events carry lifecycle but not the durable
+              // result payload.
+              result: { kind: "text", text: "" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const toolGroup = turns
+      .find((turn) => turn.turnId === "t1")
+      ?.timeline.find((item: TurnTimelineItem) => item.kind === "tools");
+    const tool = toolGroup?.kind === "tools" ? toolGroup.items[0] : undefined;
+    assert.deepEqual(tool?.args, {
+      action: "click_element",
+      element_id: "615",
+    });
+    assert.deepEqual(tool?.result, {
+      kind: "text",
+      text: "unsupported_action",
+    });
+    assert.equal(tool?.status, "completed");
+  });
+
   // Deleting the merge exception rests entirely on the live side carrying its
   // own interrupted signal, so drive the real chain — a tool_start followed by
   // an abort — rather than hand-building an already-interrupted projection,

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -597,7 +597,7 @@ describe("live tool status over persisted", () => {
             {
               toolUseId: "computer-1",
               toolName: "maka_computer",
-              status: "completed",
+              status: "running",
               args: undefined,
               // Runtime Host live events carry lifecycle but not the durable
               // result payload.
@@ -620,7 +620,7 @@ describe("live tool status over persisted", () => {
       kind: "text",
       text: "unsupported_action",
     });
-    assert.equal(tool?.status, "completed");
+    assert.equal(tool?.status, "running");
   });
 
   // Deleting the merge exception rests entirely on the live side carrying its

--- a/packages/ui/src/__tests__/shell-run-projection.test.ts
+++ b/packages/ui/src/__tests__/shell-run-projection.test.ts
@@ -98,6 +98,49 @@ describe('ShellRun UI projection', () => {
     assert.equal(result?.kind === 'shell_run' ? result.status : undefined, 'completed');
   });
 
+  test('keeps a newer live PTY screen ahead of the persisted snapshot', () => {
+    const messages: StoredMessage[] = [
+      toolCall('bash-1', 'turn-1', 'Bash', { command: 'job', pty: true }, 1),
+      toolResult('bash-1', 'turn-1', shellRun(1), 2),
+    ];
+    const liveResult = shellRun(2);
+    if (liveResult.output?.mode !== 'pty') assert.fail('expected PTY output');
+    liveResult.output.screen = 'still running';
+    const live: LiveTurnProjection = {
+      turnId: 'turn-1',
+      phase: 'streamed',
+      steps: [{
+        stepId: 'tool:bash-1',
+        contentOrder: ['tools'],
+        tools: [{
+          toolUseId: 'bash-1',
+          toolName: 'Bash',
+          status: 'running',
+          args: { command: 'job', pty: true },
+          result: liveResult,
+          outputChunks: [{
+            seq: 1,
+            stream: 'stdout',
+            text: 'still running',
+            redacted: false,
+            createdAt: 3,
+          }],
+        }],
+      }],
+    };
+
+    const tool = createTranscriptProjection()
+      .project({ messages, liveTurn: live })[0]?.tools[0];
+    assert.equal(tool?.result?.kind === 'shell_run' ? tool.result.revision : undefined, 2);
+    assert.equal(
+      tool?.result?.kind === 'shell_run' && tool.result.output?.mode === 'pty'
+        ? tool.result.output.screen
+        : undefined,
+      'still running',
+    );
+    assert.equal(tool?.outputChunks?.[0]?.text, 'still running');
+  });
+
   test('applies a durable update that arrives before the live Bash result', () => {
     const live: LiveTurnProjection = {
       turnId: 'turn-1',

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -249,9 +249,6 @@ function mergeLiveOverPersisted(
     // live result at all. In both cases the committed result supplies detail
     // without taking a newer, meaningful live result away.
     merged.result = persisted.result;
-    if (isInFlightToolStatus(live.status)) {
-      merged.status = persisted.status;
-    }
   }
   // A settled turn always yields a settled persisted status — materializeTools
   // only reads a tool as in-flight while the turn record says `running` — so

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -211,10 +211,13 @@ function materializeToolResultStatus(
 }
 
 /**
- * Merge live tool state on top of the persisted tool. Live normally wins: its
- * events arrive ahead of the persisted JSONL refresh, so it carries the most
- * current status, and preferring the lagging side painted every long command
- * as interrupted until it exited.
+ * Merge live tool state on top of the persisted tool. Live owns transient
+ * state: its events arrive ahead of the persisted transcript refresh, so it
+ * carries the most current status and output chunks. The durable transcript
+ * fills call arguments and settled results when the live path has no payload.
+ * Runtime Host live events deliberately omit both; letting those empty
+ * projections win made an expanded tool row blank until the whole Turn
+ * settled.
  *
  * The exception is a turn that has already ended. Live only stays current
  * while events keep arriving, and the subscription does not replay — a missed
@@ -233,6 +236,23 @@ function mergeLiveOverPersisted(
   turnSettled: boolean,
 ): ToolActivityItem {
   const merged: ToolActivityItem = { ...persisted, ...live };
+  if (live.args === undefined) {
+    merged.args = persisted.args;
+  }
+  const liveResultIsEmpty =
+    live.result === undefined ||
+    (live.result.kind === "text" && live.result.text.length === 0);
+  if (persisted.result !== undefined && liveResultIsEmpty) {
+    // Runtime Host represents its deliberately omitted result payload as an
+    // empty text result at the SessionEvent compatibility seam. A transcript
+    // refresh can also win the race with the terminal live event, leaving no
+    // live result at all. In both cases the committed result supplies detail
+    // without taking a newer, meaningful live result away.
+    merged.result = persisted.result;
+    if (isInFlightToolStatus(live.status)) {
+      merged.status = persisted.status;
+    }
+  }
   // A settled turn always yields a settled persisted status — materializeTools
   // only reads a tool as in-flight while the turn record says `running` — so
   // this needs no guard on the persisted side.


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Preserve durable tool arguments and settled results when the live projection intentionally carries no payload.
- Keep meaningful live results, transient status, and output chunks authoritative.
- Add regressions for a completed Runtime Host tool while the surrounding Turn is still running and for newer live PTY output staying ahead of its persisted snapshot.

## Root cause

Runtime Host subscription events carry tool lifecycle but omit argument and result payloads. Desktop refreshes the durable transcript after each tool result, but the live overlay spread `undefined` arguments and an empty compatibility result over the newly refreshed record. The detail row therefore stayed blank until the live Turn retired at the end of the task.

This change fixes the ownership rule at the merge seam instead of expanding the wire protocol: live state owns transient progress, while the durable transcript fills details that the live event does not carry.

## Validation

- `npm --workspace @maka/ui test` — 359 passed
- `npm exec biome check -- packages/ui/src/materialize.ts packages/ui/src/__tests__/materialize.test.ts`
- `git diff --check`

</details>

<details>
<summary>中文</summary>

## 概要

- 当实时投影按设计不携带 payload 时，保留持久化的工具参数和已完成结果。
- 有实际内容的实时结果、临时状态和输出流仍然保持最高优先级。
- 增加回归测试，覆盖 Runtime Host 工具已完成但整个 Turn 仍在运行，以及较新的实时 PTY 输出继续领先于持久化快照的场景。

## 根因

Runtime Host 的订阅事件只传递工具生命周期，不传递参数和结果 payload。Desktop 会在工具结果产生后刷新持久化 transcript，但实时 overlay 随后用 `undefined` 参数和空的兼容结果覆盖了刚刷新的完整记录。因此，在整个任务结束、实时 Turn 被移除以前，展开工具行只能看到空白。

本次修复没有扩大 wire protocol，而是在数据合并边界纠正所有权：实时状态负责临时进度，持久化 transcript 负责补齐实时事件没有携带的详情。

## 验证

- `npm --workspace @maka/ui test` — 359 项通过
- `npm exec biome check -- packages/ui/src/materialize.ts packages/ui/src/__tests__/materialize.test.ts`
- `git diff --check`

</details>
