### PR TITLE
fix(runtime-host): resolve OAuth tokens for connection effects

### DIFF
--- a/packages/runtime-host/src/__tests__/connection-effect-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-effect-coordinator.test.ts
@@ -8,13 +8,18 @@ import type {
   ConnectionCatalogEntryDraft,
   CredentialStatus,
 } from '@maka/core/runtime-policy';
-import type { ConnectionEffectFetchTransport, ConnectionTestEffectOutcome } from '@maka/runtime';
+import {
+  serializeOAuthSubscriptionTokens,
+  type ConnectionEffectFetchTransport,
+  type ConnectionTestEffectOutcome,
+} from '@maka/runtime';
 import {
   openInteractiveRuntimePolicyStoresForWrite,
   type RuntimePolicyStoresWriter,
 } from '@maka/storage/runtime-policy-stores';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import { HostConnectionEffectCoordinator } from '../server/connection-effect-coordinator.js';
+import { HostOAuthExecutionAuthority } from '../server/oauth-execution-authority.js';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
 import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
 
@@ -41,6 +46,7 @@ test('serializes one connection, runs different connections concurrently, and co
     const coordinator = new HostConnectionEffectCoordinator({
       stores,
       activation: new RuntimePolicyActivationGate(),
+      oauthCredentials: new HostOAuthExecutionAuthority(stores),
       createTransport: () =>
         recordingTransport(() => {
           transportCloses += 1;
@@ -111,6 +117,7 @@ test('beginDrain rejects new effects while close waits for an already accepted e
     const coordinator = new HostConnectionEffectCoordinator({
       stores,
       activation: new RuntimePolicyActivationGate(),
+      oauthCredentials: new HostOAuthExecutionAuthority(stores),
       runModelDiscovery: async () => {
         started.resolve(undefined);
         await release.promise;
@@ -161,6 +168,7 @@ test('provider discovery failure preserves the existing catalog and returns no s
     const coordinator = new HostConnectionEffectCoordinator({
       stores,
       activation: new RuntimePolicyActivationGate(),
+      oauthCredentials: new HostOAuthExecutionAuthority(stores),
       now: () => 123,
       onCommittedMutation: () => {
         invalidations += 1;
@@ -201,6 +209,69 @@ test('provider discovery failure preserves the existing catalog and returns no s
   });
 });
 
+test('OAuth connection effects resolve the canonical access token instead of sending the vault payload', async () => {
+  await withFixture(async ({ stores }) => {
+    const connection = await createConnection(
+      stores,
+      0,
+      connectionDraft('oauth-effects', 'openai-codex'),
+    );
+    const accessToken = 'oauth-access-token-must-not-escape';
+    const storedCredential = serializeOAuthSubscriptionTokens({
+      access_token: accessToken,
+      refresh_token: 'oauth-refresh-token-must-not-escape',
+      expires_at: Date.now() + 60 * 60_000,
+    });
+    const enrollment = await stores.operations.beginInteractiveOAuthLogin(connection.connectionId);
+    assert.equal(enrollment.kind, 'ready');
+    if (enrollment.kind !== 'ready') throw new Error('OAuth enrollment did not start');
+    const credential = await stores.operations.completeInteractiveOAuthLogin(
+      enrollment.ticket,
+      storedCredential,
+    );
+    assert.equal(credential.kind, 'committed');
+    let transportCloses = 0;
+    let receivedDiscoverySecret = '';
+    let receivedTestSecret = '';
+    const coordinator = new HostConnectionEffectCoordinator({
+      stores,
+      activation: new RuntimePolicyActivationGate(),
+      oauthCredentials: new HostOAuthExecutionAuthority(stores),
+      createTransport: () =>
+        recordingTransport(() => {
+          transportCloses += 1;
+        }),
+      runModelDiscovery: async (_connection, secret) => {
+        receivedDiscoverySecret = secret;
+        return { ok: true, models: [{ id: 'gpt-5.6-terra' }] };
+      },
+      runConnectionTest: async (_connection, secret) => {
+        receivedTestSecret = secret;
+        return { ok: true, modelId: 'gpt-5.6-terra', latencyMs: 3 };
+      },
+    });
+
+    const discovery = await coordinator.handlers['connection.models.fetch'](
+      { connectionId: connection.connectionId },
+      context,
+    );
+    const tested = await coordinator.handlers['connection.test.run'](
+      { connectionId: connection.connectionId, modelId: 'gpt-5.6-terra' },
+      context,
+    );
+
+    assert.equal(discovery.ok, true);
+    assert.equal(tested.ok, true);
+    assert.equal(receivedDiscoverySecret, accessToken);
+    assert.equal(receivedTestSecret, accessToken);
+    assert.notEqual(receivedDiscoverySecret, storedCredential);
+    assert.notEqual(receivedTestSecret, storedCredential);
+    assert.equal(transportCloses, 2);
+    assertRedacted(discovery, [accessToken, storedCredential]);
+    assertRedacted(tested, [accessToken, storedCredential]);
+  });
+});
+
 test('connection test derives a persisted summary from one bounded projection', async () => {
   await withFixture(async ({ stores }) => {
     const connection = await createConnection(stores, 0, connectionDraft('test-failure', 'openai'));
@@ -210,6 +281,7 @@ test('connection test derives a persisted summary from one bounded projection', 
     const coordinator = new HostConnectionEffectCoordinator({
       stores,
       activation: new RuntimePolicyActivationGate(),
+      oauthCredentials: new HostOAuthExecutionAuthority(stores),
       now: () => Date.parse('2026-07-29T12:00:00.000Z'),
       createTransport: () =>
         recordingTransport(() => {
@@ -267,6 +339,7 @@ test('projects credential changes during provider I/O as semantic superseded and
     const coordinator = new HostConnectionEffectCoordinator({
       stores,
       activation: new RuntimePolicyActivationGate(),
+      oauthCredentials: new HostOAuthExecutionAuthority(stores),
       createTransport: () =>
         recordingTransport(() => {
           transportCloses += 1;

--- a/packages/runtime-host/src/server/connection-effect-coordinator.ts
+++ b/packages/runtime-host/src/server/connection-effect-coordinator.ts
@@ -6,6 +6,7 @@ import type {
 } from '@maka/core/runtime-policy';
 import {
   createConnectionEffectFetchTransport,
+  isOAuthSubscriptionProvider,
   runConnectionModelDiscoveryEffect,
   runConnectionTestEffect,
   type ConnectionEffectErrorKind,
@@ -21,7 +22,6 @@ import {
   type BeginConnectionTestResult,
   type BeginModelFetchResult,
   type ConnectionEffectCompletionResult,
-  type RuntimePolicyOperationSecretMaterial,
   type RuntimePolicyStoresWriter,
 } from '@maka/storage/runtime-policy-stores';
 import type {
@@ -36,6 +36,7 @@ import type {
   OperationOutcome,
 } from '../protocol/index.js';
 import type { ConnectionEffectOperationHandlerMap } from './operation-dispatcher.js';
+import type { HostOAuthExecutionAuthority } from './oauth-execution-authority.js';
 import { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js';
 import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
 
@@ -55,6 +56,7 @@ type ConnectionTestRunner = (
 export interface HostConnectionEffectCoordinatorOptions {
   readonly stores: RuntimePolicyStoresWriter;
   readonly activation: RuntimePolicyActivationGate;
+  readonly oauthCredentials: Pick<HostOAuthExecutionAuthority, 'bind'>;
   readonly onCommittedMutation?: () => void;
   readonly now?: () => number;
   readonly runModelDiscovery?: ModelDiscoveryRunner;
@@ -73,6 +75,7 @@ export class HostConnectionEffectCoordinator {
 
   readonly #stores: RuntimePolicyStoresWriter;
   readonly #activation: RuntimePolicyActivationGate;
+  readonly #oauthCredentials: Pick<HostOAuthExecutionAuthority, 'bind'>;
   readonly #onCommittedMutation: () => void;
   readonly #now: () => number;
   readonly #runModelDiscovery: ModelDiscoveryRunner;
@@ -87,6 +90,7 @@ export class HostConnectionEffectCoordinator {
   constructor(options: HostConnectionEffectCoordinatorOptions) {
     this.#stores = authenticateRuntimePolicyStoresWriter(options.stores);
     this.#activation = options.activation;
+    this.#oauthCredentials = options.oauthCredentials;
     this.#onCommittedMutation = options.onCommittedMutation ?? (() => {});
     this.#now = options.now ?? Date.now;
     this.#runModelDiscovery = options.runModelDiscovery ?? runConnectionModelDiscoveryEffect;
@@ -112,10 +116,8 @@ export class HostConnectionEffectCoordinator {
       const prepared = await this.#stores.operations.beginModelFetch(input.connectionId);
       if (prepared.kind !== 'ready') return preparationResult(prepared);
 
-      const effect = await this.#withTransport(prepared, (fetch) =>
-        this.#runModelDiscovery(prepared.connection, connectionSecret(prepared.secretMaterial), {
-          fetch,
-        }),
+      const effect = await this.#withTransport(prepared, (fetch, secret) =>
+        this.#runModelDiscovery(prepared.connection, secret, { fetch }),
       );
       if (!effect.ok || effect.models.length === 0) {
         return {
@@ -156,10 +158,10 @@ export class HostConnectionEffectCoordinator {
       );
       if (prepared.kind !== 'ready') return preparationResult(prepared);
 
-      const effect = await this.#withTransport(prepared, (fetch) =>
+      const effect = await this.#withTransport(prepared, (fetch, secret) =>
         this.#runConnectionTest(
           prepared.connection,
-          connectionSecret(prepared.secretMaterial),
+          secret,
           { fetch },
           prepared.modelId ?? undefined,
         ),
@@ -208,18 +210,40 @@ export class HostConnectionEffectCoordinator {
   async #withTransport<T>(
     prepared: Pick<
       BeginModelFetchReady | BeginConnectionTestReady,
-      'networkProxy' | 'secretMaterial'
+      'connection' | 'networkProxy' | 'secretMaterial'
     >,
-    run: (fetch: typeof globalThis.fetch) => Promise<T>,
+    run: (fetch: typeof globalThis.fetch, secret: string) => Promise<T>,
   ): Promise<T> {
-    const transport = this.#createTransport(
-      toRuntimePolicyProxy(prepared.networkProxy, prepared.secretMaterial.networkProxy?.secret),
+    const proxy = toRuntimePolicyProxy(
+      prepared.networkProxy,
+      prepared.secretMaterial.networkProxy?.secret,
     );
+    const secret = await this.#connectionSecret(prepared, proxy);
+    const transport = this.#createTransport(proxy);
     try {
-      return await run(transport.fetch);
+      return await run(transport.fetch, secret);
     } finally {
       await transport.close();
     }
+  }
+
+  async #connectionSecret(
+    prepared: Pick<
+      BeginModelFetchReady | BeginConnectionTestReady,
+      'connection' | 'secretMaterial'
+    >,
+    proxy: ConnectionEffectProxySnapshot | null,
+  ): Promise<string> {
+    const material = prepared.secretMaterial.connection;
+    if (!material) return '';
+    if (!isOAuthSubscriptionProvider(prepared.connection.providerType)) return material.secret;
+    const binding = this.#oauthCredentials.bind({
+      providerType: prepared.connection.providerType,
+      connectionSlug: prepared.connection.slug,
+      material,
+      createRefreshTransport: () => this.#createTransport(proxy),
+    });
+    return (await binding.resolve()).access_token;
   }
 
   async #complete(
@@ -279,10 +303,6 @@ function projectSuperseded(
     kind: 'superseded',
     changed: completion.changed.map((domain) => domain satisfies ConnectionEffectChangedDomain),
   };
-}
-
-function connectionSecret(material: RuntimePolicyOperationSecretMaterial): string {
-  return material.connection?.secret ?? '';
 }
 
 function projectConnectionTest(

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -835,6 +835,7 @@ export async function createExecutionRuntimeHostComposition(
     const connectionEffects = new HostConnectionEffectCoordinator({
       stores: runtimePolicyStores,
       activation: runtimePolicyActivation,
+      oauthCredentials,
       onCommittedMutation: registerBackendInvalidation,
     });
     const sessionCatalog = new HostSessionCatalogCoordinator({


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Route Runtime Host model discovery and connection tests through the canonical OAuth execution authority.
- Pass the resolved access token instead of the serialized OAuth credential bundle.
- Reuse the existing token refresh and proxy-aware transport path without hardcoding model IDs.

## Why

Runtime Host stores subscription credentials as a refreshable OAuth token bundle. Connection Effects were forwarding that entire serialized bundle as the provider credential, so authenticated model discovery failed and Desktop fell back to the curated model list. Embedded Runtime was not affected because it already resolved the bundle to an access token before discovery.

## Validation

- Runtime Host full test suite
- Repository build
- Repository typecheck
- Biome format and lint
- Regression coverage for both model discovery and connection testing with a canonical OpenAI OAuth credential

</details>

<details>
<summary>中文</summary>

## 概要

- 让 Runtime Host 的模型发现和连接测试统一经过现有 OAuth execution authority。
- 向 provider 传递解析后的 access token，而不是序列化的 OAuth 凭据包。
- 复用既有 token 刷新与代理感知 transport，不硬编码任何模型 ID。

## 原因

Runtime Host 会把订阅凭据保存为可刷新的 OAuth token bundle。Connection Effect 原先错误地把整个序列化 bundle 当作 provider 凭据发送，导致已登录账号的模型发现失败，Desktop 因而只能显示兜底模型目录。Embedded Runtime 原本就会在模型发现前解析 access token，因此不受这个问题影响。

## 验证

- Runtime Host 全量测试
- 仓库全量构建
- 仓库全量 typecheck
- Biome format 与 lint
- 使用规范 OpenAI OAuth 凭据覆盖模型发现和连接测试的回归测试

</details>
