### PR TITLE
fix(runtime): harden incremental OpenAI Responses transport

### DIFF
--- a/docs/architecture/openai-responses-incremental-transport.md
+++ b/docs/architecture/openai-responses-incremental-transport.md
@@ -30,8 +30,8 @@ Otherwise the adapter sends the complete request and starts a new continuation c
 | First request or message-prefix mismatch | Full request over WebSocket |
 | Request options/model/tools changed | Full request; replace the chain baseline |
 | Missing/stale response id | Clear the chain; Runtime retry starts from durable full history |
-| WebSocket connect failure | Full HTTP request; disable continuation for that turn |
-| Socket closes or stream fails | Clear the chain; normal Runtime retry starts from full history |
+| WebSocket connect failure | Full HTTP request; suppress new socket attempts for five minutes across turns |
+| Socket closes or stream fails | Clear the chain, start the retry cooldown, and let Runtime retry from full history |
 | Same turn attempts concurrent requests | Full HTTP request for the contender |
 | Abort/cancel | Close the socket and clear the chain |
 | Configured network proxy | WebSocket uses the same immutable proxy snapshot and bypass list |
@@ -44,6 +44,8 @@ Otherwise the adapter sends the complete request and starts a new continuation c
 - Exercise a local WebSocket server to verify connection reuse, `previous_response_id`, delta-only
   input, and SSE translation.
 - Verify WebSocket setup failure reconstructs and sends a complete HTTP request.
+- Verify the failure cooldown survives turn cleanup, expires deterministically, and does not evict
+  an already healthy concurrent lane.
 - Run Runtime typecheck and focused tests, then the repository validation appropriate to the diff.
 
 ## 5. Observability and rollout

--- a/docs/architecture/openai-responses-incremental-transport.md
+++ b/docs/architecture/openai-responses-incremental-transport.md
@@ -10,10 +10,15 @@ The optimization must never change the logical request. A continuation is eligib
 current Maka message list is exactly:
 
 1. the previous request messages;
-2. followed by the previous SDK response messages;
+2. followed by Maka's durable replay projection of the previous provider step;
 3. followed by at least one new message.
 
 Otherwise the adapter sends the complete request and starts a new continuation chain.
+
+The provider response id is observed at the adapter boundary, but the semantic response messages
+are not copied from `sdk.response.messages`. After client tools settle durably, the Runtime reloads
+that step from the event ledger and completes the continuation baseline with the same projection
+the next request will use. A projection mismatch fails closed to a full request.
 
 ## 2. Ownership and lifecycle
 
@@ -22,6 +27,11 @@ Otherwise the adapter sends the complete request and starts a new continuation c
 - The OpenAI Responses transport owns the matching WebSocket and wire request/response state.
 - The session id supplies a stable `prompt_cache_key`; an explicit caller value wins.
 - Durable history remains complete. Only the provider-bound wire projection is incremental.
+- Each active lane retains at most one full wire request/output baseline and one semantic
+  request/response baseline until the turn ends. These snapshots are intentionally not byte-capped:
+  image-heavy requests can retain several megabytes for the turn so an HTTP retry can reconstruct
+  complete history. `endLane`/`close` synchronously releases them; adding a byte cap would trade that
+  recovery guarantee for lower peak memory and requires a separate policy decision.
 
 ## 3. Failure matrix
 
@@ -31,10 +41,12 @@ Otherwise the adapter sends the complete request and starts a new continuation c
 | Request options/model/tools changed | Full request; replace the chain baseline |
 | Missing/stale response id | Clear the chain; Runtime retry starts from durable full history |
 | WebSocket connect failure | Full HTTP request; suppress new socket attempts for five minutes across turns |
+| Cooldown expires on a lane that temporarily used HTTP | Retry WebSocket with full history, then resume delta continuation on that socket |
 | Socket closes or stream fails | Clear the chain, start the retry cooldown, and let Runtime retry from full history |
+| `response.incomplete` for a reason other than output-token truncation | Surface a provider failure instead of a silent successful turn |
 | Same turn attempts concurrent requests | Full HTTP request for the contender |
 | Abort/cancel | Close the socket and clear the chain |
-| Configured network proxy | WebSocket uses the same immutable proxy snapshot and bypass list |
+| Model fetch carries an immutable network-proxy snapshot | WebSocket uses the same proxy and bypass list; direct legacy fetch wiring has no proxy snapshot to inherit |
 | OAuth subscription or Chat Completions model | Existing transport, unchanged |
 
 ## 4. Test plan
@@ -43,9 +55,15 @@ Otherwise the adapter sends the complete request and starts a new continuation c
 - Unit-test stable cache-key merging without overwriting explicit provider options.
 - Exercise a local WebSocket server to verify connection reuse, `previous_response_id`, delta-only
   input, and SSE translation.
+- Exercise the complete adapter/backend loop so a reasoning step is persisted, replayed, and used
+  as the next delta baseline rather than comparing against the SDK response representation.
 - Verify WebSocket setup failure reconstructs and sends a complete HTTP request.
+- Verify mid-stream close, binary frames, and stale continuation state are retryable; abort remains
+  non-retryable and does not start the cross-turn cooldown.
+- Verify busy-lane HTTP fallback, non-truncation incomplete responses, and idle-socket protocol
+  errors without fixed-duration sleeps.
 - Verify the failure cooldown survives turn cleanup, expires deterministically, and does not evict
-  an already healthy concurrent lane.
+  an already healthy concurrent lane; a lane used during cooldown recovers after expiry.
 - Run Runtime typecheck and focused tests, then the repository validation appropriate to the diff.
 
 ## 5. Observability and rollout
@@ -59,10 +77,8 @@ transports remain on their refresh-aware HTTP path.
 ## 6. Verification outcome
 
 - Runtime TypeScript build passes.
-- Focused continuation, WebSocket, existing Responses HTTP, model-adapter, and scoped-network tests:
-  60 passed.
+- Focused continuation, adapter/backend contract, WebSocket failure, and provider-classification
+  tests: 34 passed.
 - HTTP proxy behavior is exercised end-to-end through an authenticated local CONNECT proxy.
 - SOCKS5 selection and shared bypass-list routing are covered at the transport boundary.
-- A Runtime-wide run passed 3,150 tests before repository dependency patches were applied; the 27
-  patch-dependent failures pass after applying the patches. One unrelated pre-existing macOS
-  sandbox assertion remains environment-sensitive (`/usr/local` executable-root ordering).
+- Runtime-wide verification: 3,217 tests, 3,208 passed, 9 skipped, 0 failed.

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -82,6 +82,8 @@ import {
   createTestAiSdkBackend,
   testToolResultArchive,
 } from './execution-boundary-test-helpers.js';
+import type { OpenAiResponsesSemanticBaseline } from '../openai-responses-continuation.js';
+import type { OpenAiResponsesTransportState } from '../openai-responses-websocket.js';
 
 describe('AiSdkBackend model history', () => {
   test('preserves operation-owned audio through the durable request path and redacts its capture', async () => {
@@ -12831,6 +12833,126 @@ describe('AiSdkBackend thinking persistence', () => {
         [assistants[1]!.id, 'final answer'],
       ],
     );
+  });
+
+  test('continues a reasoning tool step from Maka durable replay instead of SDK response shape', async () => {
+    let baseline: OpenAiResponsesSemanticBaseline | undefined;
+    let pending: Omit<OpenAiResponsesSemanticBaseline, 'responseMessages'> | undefined;
+    const transport = {
+      semanticBaseline: () => baseline,
+      hasPendingSemantic: () => pending !== undefined,
+      recordSemanticRequest: (
+        _lane: string,
+        value: Omit<OpenAiResponsesSemanticBaseline, 'responseMessages'>,
+      ) => {
+        pending = value;
+        baseline = undefined;
+      },
+      recordSemanticResponse: (_lane: string, responseMessages: readonly ModelMessage[]) => {
+        if (!pending) return;
+        baseline = { ...pending, responseMessages: structuredClone(responseMessages) };
+        pending = undefined;
+      },
+      clearSemantic: () => {
+        baseline = undefined;
+        pending = undefined;
+      },
+      canRecordSemantic: () => true,
+      wrapFetch: (fetch: typeof globalThis.fetch) => fetch,
+      endLane: () => {},
+      close: () => {},
+    } as unknown as OpenAiResponsesTransportState;
+    let streamCalls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        streamCalls += 1;
+        const chunks: LanguageModelV4StreamPart[] =
+          streamCalls === 1
+            ? [
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'response-metadata',
+                  id: 'resp-1',
+                  modelId: 'gpt-5',
+                  timestamp: new Date(0),
+                },
+                { type: 'reasoning-start', id: 'r1' },
+                {
+                  type: 'reasoning-delta',
+                  id: 'r1',
+                  delta: 'inspect first',
+                  providerMetadata: { openai: { itemId: 'reasoning-1' } },
+                },
+                {
+                  type: 'reasoning-end',
+                  id: 'r1',
+                  providerMetadata: {
+                    openai: {
+                      itemId: 'reasoning-1',
+                      reasoningEncryptedContent: 'encrypted-reasoning',
+                    },
+                  },
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'tool-1',
+                  toolName: 'Read',
+                  input: JSON.stringify({ path: 'a.md' }),
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                  usage: emptyUsage(),
+                },
+              ]
+            : [
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'response-metadata',
+                  id: 'resp-2',
+                  modelId: 'gpt-5',
+                  timestamp: new Date(0),
+                },
+                { type: 'text-start', id: 't2' },
+                { type: 'text-delta', id: 't2', delta: 'done' },
+                { type: 'text-end', id: 't2' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: emptyUsage(),
+                },
+              ];
+        return {
+          stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }),
+        };
+      },
+    });
+    const durable = durableTurnHarness('turn-1', 'inspect it');
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        slug: 'openai-main',
+        providerType: 'openai',
+        defaultModel: 'gpt-5',
+      },
+      apiKey: 'openai-test-key',
+      modelId: 'gpt-5',
+      modelFactory: () => model,
+      tools: [testTool('Read', z.object({ path: z.string() }))],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      openAiResponsesTransportState: transport,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drainDurably(backend.send(durable.input()), durable);
+
+    assert.equal(model.doStreamCalls.length, 2);
+    assert.equal(model.doStreamCalls[1]?.prompt.length, 1);
+    assert.equal(model.doStreamCalls[1]?.prompt[0]?.role, 'tool');
+    assert.equal(model.doStreamCalls[1]?.providerOptions?.openai?.previousResponseId, 'resp-1');
   });
 });
 

--- a/packages/runtime/src/__tests__/openai-responses-continuation.test.ts
+++ b/packages/runtime/src/__tests__/openai-responses-continuation.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 
 import {
   mergeOpenAiResponsesProviderOptions,
+  persistedOpenAiResponsesStepMessages,
   planOpenAiResponsesContinuation,
 } from '../openai-responses-continuation.js';
 import type { ModelMessage } from '../model-protocol.js';
@@ -25,6 +26,62 @@ const tool = (toolCallId: string, value: string): ModelMessage => ({
 });
 
 describe('OpenAI Responses semantic continuation', () => {
+  test('uses Maka persisted reasoning shape as the next continuation baseline', () => {
+    const requestMessages = [user('fix it')];
+    const reasoningOptions = { openai: { itemId: 'reasoning-1' } };
+    const persistedResponse: ModelMessage = {
+      role: 'assistant',
+      content: [
+        { type: 'reasoning', text: 'inspect first', providerOptions: reasoningOptions },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'shell',
+          input: { command: 'pwd' },
+        },
+      ],
+      // Durable replay hoists the reasoning item metadata to the message.
+      providerOptions: reasoningOptions,
+    };
+    const result = tool('call-1', '/workspace');
+    const responseMessages = persistedOpenAiResponsesStepMessages(
+      requestMessages,
+      [...requestMessages, persistedResponse, result],
+      ['call-1'],
+    );
+
+    assert.deepEqual(responseMessages, [persistedResponse]);
+    assert.deepEqual(
+      planOpenAiResponsesContinuation(
+        [...requestMessages, persistedResponse, result],
+        responseMessages ? { requestMessages, responseMessages, responseId: 'resp-1' } : undefined,
+      ),
+      { messages: [result], previousResponseId: 'resp-1' },
+    );
+  });
+
+  test('fails closed when the persisted request prefix or tool-result tail changed', () => {
+    const requestMessages = [user('fix it')];
+    const response = assistant('calling shell');
+
+    assert.equal(
+      persistedOpenAiResponsesStepMessages(
+        requestMessages,
+        [user('changed'), response, tool('call-1', 'ok')],
+        ['call-1'],
+      ),
+      undefined,
+    );
+    assert.equal(
+      persistedOpenAiResponsesStepMessages(
+        requestMessages,
+        [...requestMessages, response, tool('other-call', 'ok')],
+        ['call-1'],
+      ),
+      undefined,
+    );
+  });
+
   test('sends only messages after the exact prior request and response', () => {
     const priorRequest = [user('fix it')];
     const priorResponse = [assistant('calling shell')];

--- a/packages/runtime/src/__tests__/openai-responses-model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/openai-responses-model-adapter.test.ts
@@ -1,0 +1,239 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type {
+  LanguageModelV4CallOptions,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+} from '@ai-sdk/provider';
+import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
+import { z } from 'zod';
+
+import { ModelAdapter } from '../model-adapter.js';
+import type { ModelMessage } from '../model-protocol.js';
+import type { OpenAiResponsesSemanticBaseline } from '../openai-responses-continuation.js';
+import type { OpenAiResponsesTransportState } from '../openai-responses-websocket.js';
+
+const ZERO_USAGE: LanguageModelV4Usage = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+};
+
+describe('OpenAI Responses ModelAdapter continuation', () => {
+  test('preserves retryable WebSocket failures through the AI SDK stream boundary', async () => {
+    const transportError = Object.assign(new Error('closed before completion'), {
+      name: 'OpenAiResponsesTransportError',
+      code: 'OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR',
+    });
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: new ReadableStream<LanguageModelV4StreamPart>({
+          start(controller) {
+            controller.error(transportError);
+          },
+        }),
+      }),
+    });
+    const adapter = new ModelAdapter({
+      sessionId: 'session-1',
+      connection: {
+        slug: 'openai-main',
+        providerType: 'openai',
+        defaultModel: 'gpt-5',
+      },
+      apiKey: 'test-key',
+      modelId: 'gpt-5',
+      modelFactory: () => model,
+      newId: () => 'id',
+      now: () => 0,
+    });
+    const result = await adapter.startStream({
+      model,
+      messages: [{ role: 'user', content: 'continue' }],
+      tools: {},
+      activeTools: [],
+      onStreamActivity: () => {},
+      abortSignal: new AbortController().signal,
+      repairToolCall: async () => null,
+    });
+    const failures = [];
+    for await (const event of result.events) {
+      if (event.kind === 'error') failures.push(event.failure);
+    }
+
+    assert.deepEqual(failures, [
+      {
+        type: 'model_failure',
+        kind: 'network',
+        retryable: true,
+        code: 'OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR',
+        message: 'Network error',
+      },
+    ]);
+  });
+
+  test('feeds the persisted reasoning projection back into the next delta request', async () => {
+    let baseline: OpenAiResponsesSemanticBaseline | undefined;
+    let pending: Omit<OpenAiResponsesSemanticBaseline, 'responseMessages'> | undefined;
+    const transport = {
+      semanticBaseline: () => baseline,
+      hasPendingSemantic: () => pending !== undefined,
+      recordSemanticRequest: (
+        _lane: string,
+        value: Omit<OpenAiResponsesSemanticBaseline, 'responseMessages'>,
+      ) => {
+        pending = value;
+        baseline = undefined;
+      },
+      recordSemanticResponse: (_lane: string, responseMessages: readonly ModelMessage[]) => {
+        if (!pending) return;
+        baseline = { ...pending, responseMessages: structuredClone(responseMessages) };
+        pending = undefined;
+      },
+      clearSemantic: () => {
+        baseline = undefined;
+        pending = undefined;
+      },
+      canRecordSemantic: () => true,
+      wrapFetch: (fetch: typeof globalThis.fetch) => fetch,
+      endLane: () => {},
+      close: () => {},
+    } as unknown as OpenAiResponsesTransportState;
+    const calls: LanguageModelV4CallOptions[] = [];
+    let providerCall = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls.push(options);
+        providerCall += 1;
+        return {
+          stream: convertArrayToReadableStream<LanguageModelV4StreamPart>(
+            providerCall === 1
+              ? firstReasoningToolStep()
+              : [
+                  { type: 'stream-start', warnings: [] },
+                  {
+                    type: 'response-metadata',
+                    id: 'resp-2',
+                    modelId: 'gpt-5',
+                    timestamp: new Date(0),
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: { unified: 'stop', raw: 'stop' },
+                    usage: ZERO_USAGE,
+                  },
+                ],
+          ),
+        };
+      },
+    });
+    const adapter = new ModelAdapter({
+      sessionId: 'session-1',
+      connection: {
+        slug: 'openai-main',
+        providerType: 'openai',
+        defaultModel: 'gpt-5',
+      },
+      apiKey: 'test-key',
+      modelId: 'gpt-5',
+      modelFactory: () => model,
+      newId: () => 'id',
+      now: () => 0,
+      openAiResponsesTransportState: transport,
+    });
+    const user: ModelMessage = { role: 'user', content: 'inspect it' };
+    await drain(adapter, model, [user], ['shell']);
+
+    assert.deepEqual(pending, {
+      requestMessages: [user],
+      responseId: 'resp-1',
+    });
+    const reasoningOptions = { openai: { itemId: 'reasoning-1' } };
+    const persistedResponse: ModelMessage = {
+      role: 'assistant',
+      content: [
+        { type: 'reasoning', text: 'inspect first', providerOptions: reasoningOptions },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'shell',
+          input: { command: 'pwd' },
+        },
+      ],
+      providerOptions: reasoningOptions,
+    };
+    adapter.recordContinuationResponse('turn-1', [persistedResponse]);
+    const toolResult: ModelMessage = {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'shell',
+          output: { type: 'text', value: '/workspace' },
+        },
+      ],
+    };
+
+    await drain(adapter, model, [user, persistedResponse, toolResult], ['shell']);
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1]?.prompt.length, 1);
+    assert.equal(calls[1]?.prompt[0]?.role, 'tool');
+    assert.deepEqual(calls[1]?.providerOptions?.openai, {
+      promptCacheKey: 'maka:session-1',
+      previousResponseId: 'resp-1',
+    });
+    assert.equal(calls[1]?.headers?.['x-maka-openai-responses-lane'], 'turn-1');
+  });
+});
+
+function firstReasoningToolStep(): LanguageModelV4StreamPart[] {
+  const reasoningMetadata = { openai: { itemId: 'reasoning-1' } };
+  return [
+    { type: 'stream-start', warnings: [] },
+    {
+      type: 'response-metadata',
+      id: 'resp-1',
+      modelId: 'gpt-5',
+      timestamp: new Date(0),
+    },
+    { type: 'reasoning-start', id: 'reasoning-1', providerMetadata: reasoningMetadata },
+    {
+      type: 'reasoning-delta',
+      id: 'reasoning-1',
+      delta: 'inspect first',
+      providerMetadata: reasoningMetadata,
+    },
+    { type: 'reasoning-end', id: 'reasoning-1', providerMetadata: reasoningMetadata },
+    {
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: 'shell',
+      input: JSON.stringify({ command: 'pwd' }),
+    },
+    {
+      type: 'finish',
+      finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+      usage: ZERO_USAGE,
+    },
+  ];
+}
+
+async function drain(
+  adapter: ModelAdapter,
+  model: MockLanguageModelV4,
+  messages: ModelMessage[],
+  activeTools: string[],
+): Promise<void> {
+  const result = await adapter.startStream({
+    model,
+    messages,
+    tools: { shell: { inputSchema: z.object({ command: z.string() }) } },
+    activeTools,
+    onStreamActivity: () => {},
+    abortSignal: new AbortController().signal,
+    repairToolCall: async () => null,
+    continuationKey: 'turn-1',
+  });
+  for await (const event of result.events) void event;
+}

--- a/packages/runtime/src/__tests__/openai-responses-websocket.test.ts
+++ b/packages/runtime/src/__tests__/openai-responses-websocket.test.ts
@@ -94,6 +94,122 @@ describe('OpenAI Responses WebSocket transport', () => {
     assert.equal(state.canRecordSemantic('turn-1', 'resp-any'), false);
   });
 
+  test('skips WebSocket setup across turns during the failure cooldown and retries after it', async () => {
+    let now = 1_000;
+    let upgrades = 0;
+    const server = createServer();
+    server.on('upgrade', (_request, socket) => {
+      upgrades += 1;
+      socket.destroy();
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address() as AddressInfo;
+    disposers.push(
+      async () =>
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    );
+
+    const httpBodies: Record<string, unknown>[] = [];
+    const state = createOpenAiResponsesTransportState({
+      webSocketUrl: `ws://127.0.0.1:${address.port}/v1/responses`,
+      failureCooldownMs: 1_000,
+      now: () => now,
+    });
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(async (_input, init) => {
+      httpBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response('http', { status: 200 });
+    });
+
+    const fullBody = { model: 'gpt-test', input: [{ role: 'user' }] };
+    assert.equal(
+      await (
+        await fetch('https://api.openai.com/v1/responses', request('turn-1', fullBody))
+      ).text(),
+      'http',
+    );
+    state.endLane('turn-1');
+    assert.equal(
+      await (
+        await fetch('https://api.openai.com/v1/responses', request('turn-2', fullBody))
+      ).text(),
+      'http',
+    );
+    assert.equal(upgrades, 1);
+
+    state.endLane('turn-2');
+    now += 1_001;
+    assert.equal(
+      await (
+        await fetch('https://api.openai.com/v1/responses', request('turn-3', fullBody))
+      ).text(),
+      'http',
+    );
+    assert.equal(upgrades, 2);
+    assert.equal(httpBodies.length, 3);
+  });
+
+  test('keeps a healthy lane socket active while the cooldown suppresses new connections', async () => {
+    let connectionIndex = 0;
+    let healthyLaneRequests = 0;
+    const server = await websocketServer((socket) => {
+      connectionIndex += 1;
+      const currentConnection = connectionIndex;
+      socket.on('message', () => {
+        if (currentConnection === 2) {
+          socket.terminate();
+          return;
+        }
+        healthyLaneRequests += 1;
+        socket.send(
+          JSON.stringify({
+            type: 'response.completed',
+            response: { id: `resp-${healthyLaneRequests}`, output: [] },
+          }),
+        );
+      });
+    });
+    const httpBodies: Record<string, unknown>[] = [];
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(async (_input, init) => {
+      httpBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response('http', { status: 200 });
+    });
+
+    await consume(
+      await fetch(server.url, request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] })),
+    );
+    const failed = await fetch(
+      server.url,
+      request('turn-2', { model: 'gpt-test', input: [{ role: 'user' }] }),
+    );
+    await assert.rejects(() => consume(failed), /closed before completion/);
+
+    assert.equal(
+      await (
+        await fetch(server.url, request('turn-3', { model: 'gpt-test', input: [{ role: 'user' }] }))
+      ).text(),
+      'http',
+    );
+    await consume(
+      await fetch(
+        server.url,
+        request('turn-1', {
+          model: 'gpt-test',
+          input: [{ type: 'function_call_output', call_id: 'call-1', output: 'ok' }],
+          previous_response_id: 'resp-1',
+        }),
+      ),
+    );
+
+    assert.equal(server.connections(), 2);
+    assert.equal(healthyLaneRequests, 2);
+    assert.equal(httpBodies.length, 1);
+  });
+
   test('uses the HTTP/SOCKS proxy snapshot and honors the same bypass list', () => {
     const httpTransport = createProxiedFetchTransport({
       enabled: true,

--- a/packages/runtime/src/__tests__/openai-responses-websocket.test.ts
+++ b/packages/runtime/src/__tests__/openai-responses-websocket.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { once } from 'node:events';
 import { createServer, type IncomingMessage } from 'node:http';
 import { connect as connectTcp, type AddressInfo } from 'node:net';
 import type { Duplex } from 'node:stream';
@@ -11,6 +12,7 @@ import {
   webSocketProxyAgent,
 } from '../openai-responses-websocket.js';
 import { createProxiedFetchTransport } from '../network/scoped-fetch-transport.js';
+import { classifyError, providerRetryMetadata } from '../provider-error-classification.js';
 
 const disposers: Array<() => Promise<void>> = [];
 afterEach(async () => {
@@ -151,6 +153,99 @@ describe('OpenAI Responses WebSocket transport', () => {
     assert.equal(httpBodies.length, 3);
   });
 
+  test('recovers the same lane after cooldown expiry and resumes delta transport', async () => {
+    let now = 1_000;
+    let upgrades = 0;
+    let connections = 0;
+    const requests: Record<string, unknown>[] = [];
+    const http = createServer();
+    const ws = new WebSocketServer({ noServer: true });
+    const sockets = new Set<WebSocket>();
+    http.on('upgrade', (request, socket, head) => {
+      upgrades += 1;
+      if (upgrades === 1) {
+        socket.destroy();
+        return;
+      }
+      ws.handleUpgrade(request, socket, head, (client) => ws.emit('connection', client, request));
+    });
+    ws.on('connection', (socket) => {
+      connections += 1;
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+      socket.on('message', (data) => {
+        requests.push(JSON.parse(data.toString()) as Record<string, unknown>);
+        socket.send(
+          JSON.stringify({
+            type: 'response.completed',
+            response: { id: `resp-${requests.length}`, output: [] },
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolve) => http.listen(0, '127.0.0.1', resolve));
+    const address = http.address() as AddressInfo;
+    disposers.push(async () => {
+      for (const socket of sockets) socket.terminate();
+      await new Promise<void>((resolve) => ws.close(() => resolve()));
+      await new Promise<void>((resolve) => http.close(() => resolve()));
+    });
+
+    const httpBodies: Record<string, unknown>[] = [];
+    const state = createOpenAiResponsesTransportState({
+      webSocketUrl: `ws://127.0.0.1:${address.port}/v1/responses`,
+      failureCooldownMs: 1_000,
+      now: () => now,
+    });
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(async (_input, init) => {
+      httpBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response('http', { status: 200 });
+    });
+    const fullBody = { model: 'gpt-test', input: [{ role: 'user', content: 'run it' }] };
+
+    assert.equal(
+      await (
+        await fetch('https://api.openai.com/v1/responses', request('turn-1', fullBody))
+      ).text(),
+      'http',
+    );
+    state.endLane('turn-1');
+    assert.equal(
+      await (
+        await fetch('https://api.openai.com/v1/responses', request('turn-2', fullBody))
+      ).text(),
+      'http',
+    );
+    assert.equal(upgrades, 1);
+
+    now += 1_001;
+    await consume(await fetch('https://api.openai.com/v1/responses', request('turn-2', fullBody)));
+    await consume(
+      await fetch(
+        'https://api.openai.com/v1/responses',
+        request('turn-2', {
+          model: 'gpt-test',
+          input: [{ type: 'function_call_output', call_id: 'call-1', output: 'ok' }],
+          previous_response_id: 'resp-1',
+        }),
+      ),
+    );
+
+    assert.equal(upgrades, 2);
+    assert.equal(connections, 1);
+    assert.equal(httpBodies.length, 2);
+    assert.deepEqual(requests, [
+      { type: 'response.create', ...fullBody },
+      {
+        type: 'response.create',
+        model: 'gpt-test',
+        input: [{ type: 'function_call_output', call_id: 'call-1', output: 'ok' }],
+        previous_response_id: 'resp-1',
+      },
+    ]);
+  });
+
   test('keeps a healthy lane socket active while the cooldown suppresses new connections', async () => {
     let connectionIndex = 0;
     let healthyLaneRequests = 0;
@@ -186,7 +281,20 @@ describe('OpenAI Responses WebSocket transport', () => {
       server.url,
       request('turn-2', { model: 'gpt-test', input: [{ role: 'user' }] }),
     );
-    await assert.rejects(() => consume(failed), /closed before completion/);
+    await assert.rejects(
+      () => consume(failed),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /closed before completion/);
+        assert.equal(
+          (error as Error & { code?: string }).code,
+          'OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR',
+        );
+        assert.equal(classifyError(error), 'Network');
+        assert.deepEqual(providerRetryMetadata(error), { retryable: true });
+        return true;
+      },
+    );
 
     assert.equal(
       await (
@@ -208,6 +316,349 @@ describe('OpenAI Responses WebSocket transport', () => {
     assert.equal(server.connections(), 2);
     assert.equal(healthyLaneRequests, 2);
     assert.equal(httpBodies.length, 1);
+  });
+
+  test('falls back to HTTP for a concurrent request on a busy lane', async () => {
+    let releaseFirst!: () => void;
+    const firstCanComplete = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const server = await websocketServer((socket) => {
+      socket.once('message', async () => {
+        await firstCanComplete;
+        socket.send(
+          JSON.stringify({
+            type: 'response.completed',
+            response: { id: 'resp-1', output: [] },
+          }),
+        );
+      });
+    });
+    const httpBodies: Record<string, unknown>[] = [];
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(async (_input, init) => {
+      httpBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response('http', { status: 200 });
+    });
+
+    const first = await fetch(
+      server.url,
+      request('turn-1', { model: 'gpt-test', input: [{ role: 'user', content: 'first' }] }),
+    );
+    const contender = await fetch(
+      server.url,
+      request('turn-1', { model: 'gpt-test', input: [{ role: 'user', content: 'second' }] }),
+    );
+
+    assert.equal(await contender.text(), 'http');
+    assert.deepEqual(httpBodies, [
+      { model: 'gpt-test', stream: true, input: [{ role: 'user', content: 'second' }] },
+    ]);
+    releaseFirst();
+    await consume(first);
+  });
+
+  test('makes a stale continuation retryable and sends the retry through HTTP', async () => {
+    const server = await websocketServer((socket) => {
+      socket.once('message', () => {
+        socket.send(
+          JSON.stringify({
+            type: 'response.completed',
+            response: { id: 'resp-1', output: [] },
+          }),
+        );
+      });
+    });
+    const httpBodies: Record<string, unknown>[] = [];
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(async (_input, init) => {
+      httpBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response('http', { status: 200 });
+    });
+    await consume(
+      await fetch(server.url, request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] })),
+    );
+
+    const stale = await fetch(
+      server.url,
+      request('turn-1', {
+        model: 'gpt-test',
+        input: [{ type: 'function_call_output', call_id: 'call-1', output: 'ok' }],
+        previous_response_id: 'stale-response',
+      }),
+    );
+    await assert.rejects(
+      () => consume(stale),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.equal(
+          (error as Error & { code?: string }).code,
+          'OPENAI_RESPONSES_CONTINUATION_UNAVAILABLE',
+        );
+        assert.deepEqual(providerRetryMetadata(error), { retryable: true });
+        return true;
+      },
+    );
+
+    assert.equal(
+      await (
+        await fetch(
+          server.url,
+          request('turn-1', {
+            model: 'gpt-test',
+            input: [{ role: 'user' }, { role: 'tool', content: 'ok' }],
+          }),
+        )
+      ).text(),
+      'http',
+    );
+    assert.equal(httpBodies.length, 1);
+  });
+
+  test('keeps an idle error listener on a reusable socket', async () => {
+    let connection = 0;
+    let firstSocket: WebSocket | undefined;
+    const server = await websocketServer((socket) => {
+      connection += 1;
+      if (connection === 1) firstSocket = socket;
+      socket.once('message', () => {
+        socket.send(
+          JSON.stringify({
+            type: 'response.completed',
+            response: { id: `resp-${connection}`, output: [] },
+          }),
+        );
+      });
+    });
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(globalThis.fetch);
+
+    await consume(
+      await fetch(server.url, request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] })),
+    );
+    assert.ok(firstSocket);
+    const closed = once(firstSocket, 'close');
+    const rawSocket = (firstSocket as unknown as { _socket: Duplex })._socket;
+    // Reserved opcode 3 is an invalid server frame. ws emits `error` on the
+    // idle client before closing; the permanent listener must absorb it.
+    rawSocket.write(Buffer.from([0x83, 0x00]));
+    await closed;
+
+    await consume(
+      await fetch(
+        server.url,
+        request('turn-1', {
+          model: 'gpt-test',
+          input: [{ type: 'function_call_output', call_id: 'call-1', output: 'ok' }],
+          previous_response_id: 'resp-1',
+        }),
+      ),
+    );
+    assert.equal(server.connections(), 2);
+  });
+
+  test('fails binary frames as retryable transport errors', async () => {
+    const server = await websocketServer((socket) => {
+      socket.once('message', () => socket.send(Buffer.from([1, 2, 3])));
+    });
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const response = await state.wrapFetch(globalThis.fetch)(
+      server.url,
+      request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] }),
+    );
+
+    await assert.rejects(
+      () => consume(response),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /Unexpected binary/);
+        assert.deepEqual(providerRetryMetadata(error), { retryable: true });
+        return true;
+      },
+    );
+  });
+
+  test('surfaces non-truncation incomplete responses but accepts max-output truncation', async () => {
+    let requestIndex = 0;
+    const server = await websocketServer((socket) => {
+      socket.once('message', () => {
+        requestIndex += 1;
+        socket.send(
+          JSON.stringify({
+            type: 'response.incomplete',
+            response: {
+              id: `resp-${requestIndex}`,
+              output: [],
+              incomplete_details: {
+                reason: requestIndex === 1 ? 'content_filter' : 'max_output_tokens',
+              },
+            },
+          }),
+        );
+      });
+    });
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(globalThis.fetch);
+
+    const filtered = await fetch(
+      server.url,
+      request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] }),
+    );
+    await assert.rejects(() => consume(filtered), /stream incomplete \(content_filter\)/);
+
+    const truncated = await fetch(
+      server.url,
+      request('turn-2', { model: 'gpt-test', input: [{ role: 'user' }] }),
+    );
+    assert.match(await consume(truncated), /data: \[DONE\]/);
+    assert.equal(server.connections(), 2);
+  });
+
+  test('does not start the failure cooldown for a provider response.failed event', async () => {
+    let requestIndex = 0;
+    const server = await websocketServer((socket) => {
+      socket.once('message', () => {
+        requestIndex += 1;
+        socket.send(
+          JSON.stringify(
+            requestIndex === 1
+              ? {
+                  type: 'response.failed',
+                  sequence_number: 1,
+                  response: {
+                    error: { code: 'provider_error', message: 'provider rejected the response' },
+                    incomplete_details: null,
+                  },
+                }
+              : {
+                  type: 'response.completed',
+                  response: { id: 'resp-2', output: [] },
+                },
+          ),
+        );
+      });
+    });
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(globalThis.fetch);
+
+    const failed = await fetch(
+      server.url,
+      request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] }),
+    );
+    assert.match(await consume(failed), /response.failed/);
+    await consume(
+      await fetch(server.url, request('turn-2', { model: 'gpt-test', input: [{ role: 'user' }] })),
+    );
+
+    assert.equal(server.connections(), 2);
+  });
+
+  test('aborts a live stream without entering the cross-turn failure cooldown', async () => {
+    let requestIndex = 0;
+    const server = await websocketServer((socket) => {
+      socket.once('message', () => {
+        requestIndex += 1;
+        if (requestIndex === 2) {
+          socket.send(
+            JSON.stringify({
+              type: 'response.completed',
+              response: { id: 'resp-2', output: [] },
+            }),
+          );
+        }
+      });
+    });
+    const state = createOpenAiResponsesTransportState();
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(globalThis.fetch);
+    const abort = new AbortController();
+    const pending = await fetch(
+      server.url,
+      request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] }, abort.signal),
+    );
+    abort.abort(new DOMException('Stopped', 'AbortError'));
+    await assert.rejects(() => consume(pending), /Stopped/);
+
+    await consume(
+      await fetch(server.url, request('turn-2', { model: 'gpt-test', input: [{ role: 'user' }] })),
+    );
+    assert.equal(server.connections(), 2);
+  });
+
+  test('aborts WebSocket setup without starting the failure cooldown', async () => {
+    let acceptUpgrade = false;
+    let upgrades = 0;
+    let connections = 0;
+    let observeFirstUpgrade!: () => void;
+    const firstUpgrade = new Promise<void>((resolve) => {
+      observeFirstUpgrade = resolve;
+    });
+    const http = createServer();
+    const ws = new WebSocketServer({ noServer: true });
+    const rawSockets = new Set<Duplex>();
+    http.on('upgrade', (request, socket, head) => {
+      upgrades += 1;
+      rawSockets.add(socket);
+      socket.on('close', () => rawSockets.delete(socket));
+      if (!acceptUpgrade) {
+        observeFirstUpgrade();
+        return;
+      }
+      ws.handleUpgrade(request, socket, head, (client) => ws.emit('connection', client, request));
+    });
+    ws.on('connection', (socket) => {
+      connections += 1;
+      socket.once('message', () => {
+        socket.send(
+          JSON.stringify({
+            type: 'response.completed',
+            response: { id: 'resp-2', output: [] },
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolve) => http.listen(0, '127.0.0.1', resolve));
+    const address = http.address() as AddressInfo;
+    disposers.push(async () => {
+      for (const socket of rawSockets) socket.destroy();
+      await new Promise<void>((resolve) => ws.close(() => resolve()));
+      await new Promise<void>((resolve) => http.close(() => resolve()));
+    });
+
+    let httpFallbacks = 0;
+    const state = createOpenAiResponsesTransportState({
+      webSocketUrl: `ws://127.0.0.1:${address.port}/v1/responses`,
+    });
+    disposers.push(async () => state.close());
+    const fetch = state.wrapFetch(async () => {
+      httpFallbacks += 1;
+      return new Response('http', { status: 200 });
+    });
+    const abort = new AbortController();
+    const connecting = fetch(
+      'https://api.openai.com/v1/responses',
+      request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] }, abort.signal),
+    );
+    await firstUpgrade;
+    abort.abort(new DOMException('Stopped during setup', 'AbortError'));
+    await assert.rejects(() => connecting, /Stopped during setup/);
+
+    acceptUpgrade = true;
+    await consume(
+      await fetch(
+        'https://api.openai.com/v1/responses',
+        request('turn-2', { model: 'gpt-test', input: [{ role: 'user' }] }),
+      ),
+    );
+    assert.equal(upgrades, 2);
+    assert.equal(connections, 1);
+    assert.equal(httpFallbacks, 0);
   });
 
   test('uses the HTTP/SOCKS proxy snapshot and honors the same bypass list', () => {
@@ -285,7 +736,9 @@ describe('OpenAI Responses WebSocket transport', () => {
 
   test('reconnects with complete history instead of using a socket-local id', async () => {
     const requests: Record<string, unknown>[] = [];
+    let connectionClosed: Promise<void> | undefined;
     const server = await websocketServer((socket) => {
+      connectionClosed = new Promise<void>((resolve) => socket.once('close', () => resolve()));
       socket.once('message', (data) => {
         requests.push(JSON.parse(data.toString()) as Record<string, unknown>);
         socket.send(
@@ -307,7 +760,7 @@ describe('OpenAI Responses WebSocket transport', () => {
     await consume(
       await fetch(server.url, request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] })),
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await connectionClosed;
     await consume(
       await fetch(
         server.url,
@@ -333,7 +786,9 @@ describe('OpenAI Responses WebSocket transport', () => {
 
   test('reconstructs prior input, provider output, and the delta when a reused lane falls back', async () => {
     const httpBodies: Record<string, unknown>[] = [];
+    let connectionClosed: Promise<void> | undefined;
     const server = await websocketServer((socket) => {
+      connectionClosed = new Promise<void>((resolve) => socket.once('close', () => resolve()));
       socket.once('message', () => {
         socket.send(
           JSON.stringify({
@@ -343,6 +798,7 @@ describe('OpenAI Responses WebSocket transport', () => {
               output: [{ type: 'function_call', call_id: 'call-1', name: 'shell' }],
             },
           }),
+          () => socket.close(),
         );
       });
     });
@@ -356,8 +812,8 @@ describe('OpenAI Responses WebSocket transport', () => {
     await consume(
       await fetch(server.url, request('turn-1', { model: 'gpt-test', input: [{ role: 'user' }] })),
     );
+    await connectionClosed;
     await server.stopWebSockets();
-    await new Promise((resolve) => setTimeout(resolve, 10));
     const response = await fetch(
       server.url,
       request('turn-1', {
@@ -382,7 +838,7 @@ describe('OpenAI Responses WebSocket transport', () => {
   });
 });
 
-function request(lane: string, body: Record<string, unknown>): RequestInit {
+function request(lane: string, body: Record<string, unknown>, signal?: AbortSignal): RequestInit {
   return {
     method: 'POST',
     headers: {
@@ -391,6 +847,7 @@ function request(lane: string, body: Record<string, unknown>): RequestInit {
       [OPENAI_RESPONSES_LANE_HEADER]: lane,
     },
     body: JSON.stringify({ ...body, stream: true }),
+    ...(signal ? { signal } : {}),
   };
 }
 

--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -4,9 +4,28 @@ import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 import { RetryError } from 'ai';
 import { z } from 'zod/v4';
 
-import { classifyError, errorPresentationFromClass } from '../provider-error-classification.js';
+import {
+  classifyError,
+  errorPresentationFromClass,
+  providerRetryMetadata,
+} from '../provider-error-classification.js';
 
 describe('Provider error classification', () => {
+  test('retries incremental Responses transport failures with stable classification', () => {
+    const websocketFailure = Object.assign(new Error('closed before completion'), {
+      name: 'OpenAiResponsesTransportError',
+      code: 'OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR',
+    });
+    const missingContinuation = Object.assign(new Error('continuation unavailable'), {
+      name: 'OpenAiResponsesTransportError',
+      code: 'OPENAI_RESPONSES_CONTINUATION_UNAVAILABLE',
+    });
+
+    assert.equal(classifyError(websocketFailure), 'Network');
+    assert.deepEqual(providerRetryMetadata(websocketFailure), { retryable: true });
+    assert.deepEqual(providerRetryMetadata(missingContinuation), { retryable: true });
+  });
+
   test('classifies provider context-length overflow errors as ContextLength', () => {
     const overflow = (message: string, extra: Record<string, unknown> = {}) =>
       classifyError(Object.assign(new Error(message), { name: 'AI_APICallError', ...extra }));

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -131,6 +131,8 @@ import {
   type ModelStreamResult,
   type RepairableAiSdkToolCall,
 } from './model-adapter.js';
+import { persistedOpenAiResponsesStepMessages } from './openai-responses-continuation.js';
+import type { OpenAiResponsesTransportState } from './openai-responses-websocket.js';
 import {
   composeRequestProjection,
   type RequestProjection,
@@ -685,6 +687,8 @@ export interface AiSdkBackendInput extends AiSdkCompactionCapabilities {
   shellRunContextSummary?: () => string | undefined | Promise<string | undefined>;
   /** Provider-native options passed through to ai-sdk. */
   providerOptions?: Record<string, unknown>;
+  /** Test seam for the adapter-owned incremental Responses transport. */
+  openAiResponsesTransportState?: OpenAiResponsesTransportState;
   /** Optional fire-and-forget telemetry hook. Tool implementations remain unaware. */
   recordToolInvocation?: ToolTelemetryRecorder;
   /** Optional Phase 2 SQLite T1/T2 boundary for real tool execution. */
@@ -950,6 +954,9 @@ export class AiSdkBackend implements AgentBackend {
       providerOptions: input.providerOptions,
       newId: this.newId,
       now: this.now,
+      ...(input.openAiResponsesTransportState
+        ? { openAiResponsesTransportState: input.openAiResponsesTransportState }
+        : {}),
     });
     this.compaction = new AiSdkCompaction({
       input,
@@ -2165,6 +2172,27 @@ export class AiSdkBackend implements AgentBackend {
               const settlement = settlements[index];
               if (toolCall && settlement) {
                 settledModelOutputs.set(toolCall.toolCallId, settlement.modelOutput);
+              }
+            }
+
+            const continuationWillRun =
+              (this.maxSteps === undefined || runtimeSteps < this.maxSteps) &&
+              !scope.loopStopRequested &&
+              !scope.aborted;
+            if (
+              continuationWillRun &&
+              this.modelAdapter.continuationResponsePending(scope.turnId)
+            ) {
+              const persistedProjection = await loadDurableTurnProjection();
+              const responseMessages = persistedOpenAiResponsesStepMessages(
+                attemptMessages,
+                persistedProjection,
+                returnedToolCalls.map((toolCall) => toolCall.toolCallId),
+              );
+              if (responseMessages) {
+                this.modelAdapter.recordContinuationResponse(scope.turnId, responseMessages);
+              } else {
+                this.modelAdapter.clearContinuation(scope.turnId);
               }
             }
           }

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -89,6 +89,8 @@ export interface ModelAdapterInput {
   providerOptions?: Record<string, unknown>;
   newId: () => string;
   now: () => number;
+  /** Test seam; production adapters own one state instance for their lifetime. */
+  openAiResponsesTransportState?: OpenAiResponsesTransportState;
 }
 
 export interface CompactSummaryRequest {
@@ -144,7 +146,7 @@ interface ProviderMiddlewareStreamInput {
 export class ModelAdapter {
   private readonly runtime: ResolvedModelRuntime;
   private readonly openAiChatReasoningTransportState: OpenAiChatReasoningTransportState;
-  private readonly openAiResponsesTransportState = createOpenAiResponsesTransportState();
+  private readonly openAiResponsesTransportState: OpenAiResponsesTransportState;
 
   constructor(private readonly input: ModelAdapterInput) {
     this.runtime = resolveModelRuntime(input.connection, input.modelId);
@@ -153,6 +155,8 @@ export class ModelAdapter {
         ? this.runtime.reasoningReplay.requestField
         : 'observed',
     );
+    this.openAiResponsesTransportState =
+      input.openAiResponsesTransportState ?? createOpenAiResponsesTransportState();
   }
 
   runtimeEventReplaySupport(): ModelAdapterRuntimeEventReplaySupport {
@@ -324,9 +328,8 @@ export class ModelAdapter {
             response?.id &&
             openAiResponsesTransportState.canRecordSemantic(continuation.lane, response.id)
           ) {
-            openAiResponsesTransportState.recordSemantic(continuation.lane, {
+            openAiResponsesTransportState.recordSemanticRequest(continuation.lane, {
               requestMessages: structuredClone(continuation.requestMessages),
-              responseMessages: structuredClone(response.messages ?? []),
               responseId: response.id,
             });
           } else {
@@ -354,6 +357,18 @@ export class ModelAdapter {
 
   endContinuation(lane: string): void {
     this.openAiResponsesTransportState.endLane(lane);
+  }
+
+  recordContinuationResponse(lane: string, responseMessages: readonly ModelMessage[]): void {
+    this.openAiResponsesTransportState.recordSemanticResponse(lane, responseMessages);
+  }
+
+  continuationResponsePending(lane: string): boolean {
+    return this.openAiResponsesTransportState.hasPendingSemantic(lane);
+  }
+
+  clearContinuation(lane: string): void {
+    this.openAiResponsesTransportState.clearSemantic(lane);
   }
 
   dispose(): void {
@@ -570,12 +585,8 @@ interface SdkStreamResult {
   stream: AsyncIterable<AiSdkStreamChunk>;
   usage: Promise<AiSdkUsageLike | undefined>;
   finishReason: Promise<unknown>;
-  request: PromiseLike<{
-    messages?: ModelMessage[];
-  }>;
   response: PromiseLike<{
     id: string;
-    messages?: ModelMessage[];
   }>;
 }
 
@@ -849,16 +860,6 @@ function errorClassFromFailureKind(kind: ModelFailureKind): string {
     case 'unknown':
       return 'Other';
   }
-}
-
-function normalizeRequestMetadata(
-  metadata:
-    | {
-        messages?: ModelMessage[];
-      }
-    | undefined,
-): ModelRequestMetadata | undefined {
-  return metadata?.messages === undefined ? undefined : { messages: metadata.messages };
 }
 
 type TokenCountBreakdown = {

--- a/packages/runtime/src/openai-responses-continuation.ts
+++ b/packages/runtime/src/openai-responses-continuation.ts
@@ -13,6 +13,38 @@ export interface OpenAiResponsesContinuationPlan {
   previousResponseId?: string;
 }
 
+/**
+ * Recover the provider step from Maka's durable replay after its client tool
+ * calls have settled. The replay is authoritative: unlike `sdk.response.messages`
+ * it has the exact provider-option placement that the next Runtime request will
+ * carry.
+ *
+ * Fail closed when request shaping means the durable projection no longer has
+ * the sent request as an exact prefix, or when the expected tool-result tail is
+ * absent. Either case simply disables continuation for the next request.
+ */
+export function persistedOpenAiResponsesStepMessages(
+  requestMessages: readonly ModelMessage[],
+  replayedMessages: readonly ModelMessage[],
+  settledToolCallIds: readonly string[],
+): ModelMessage[] | undefined {
+  if (replayedMessages.length <= requestMessages.length + settledToolCallIds.length) {
+    return undefined;
+  }
+  for (let index = 0; index < requestMessages.length; index += 1) {
+    if (!isDeepStrictEqual(replayedMessages[index], requestMessages[index])) return undefined;
+  }
+
+  const appended = replayedMessages.slice(requestMessages.length);
+  const responseLength = appended.length - settledToolCallIds.length;
+  for (let index = 0; index < settledToolCallIds.length; index += 1) {
+    const message = appended[responseLength + index];
+    if (!isToolResultMessageFor(message, settledToolCallIds[index]!)) return undefined;
+  }
+  const responseMessages = appended.slice(0, responseLength);
+  return responseMessages.length > 0 ? responseMessages : undefined;
+}
+
 export function planOpenAiResponsesContinuation(
   messages: readonly ModelMessage[],
   baseline: OpenAiResponsesSemanticBaseline | undefined,
@@ -49,4 +81,11 @@ export function mergeOpenAiResponsesProviderOptions(
       ...(previousResponseId === undefined ? {} : { previousResponseId }),
     },
   };
+}
+
+function isToolResultMessageFor(message: ModelMessage | undefined, toolCallId: string): boolean {
+  return (
+    message?.role === 'tool' &&
+    message.content.some((part) => part.type === 'tool-result' && part.toolCallId === toolCallId)
+  );
 }

--- a/packages/runtime/src/openai-responses-websocket.ts
+++ b/packages/runtime/src/openai-responses-websocket.ts
@@ -26,6 +26,7 @@ interface LaneState {
   httpFallback: boolean;
   wire?: WireBaseline;
   semantic?: OpenAiResponsesSemanticBaseline;
+  pendingSemantic?: Omit<OpenAiResponsesSemanticBaseline, 'responseMessages'>;
 }
 
 export interface OpenAiResponsesTransportOptions {
@@ -47,15 +48,43 @@ export class OpenAiResponsesTransportState {
     return this.lanes.get(lane)?.semantic;
   }
 
-  recordSemantic(lane: string, baseline: OpenAiResponsesSemanticBaseline): void {
+  hasPendingSemantic(lane: string): boolean {
+    return this.lanes.get(lane)?.pendingSemantic !== undefined;
+  }
+
+  recordSemanticRequest(
+    lane: string,
+    baseline: Omit<OpenAiResponsesSemanticBaseline, 'responseMessages'>,
+  ): void {
     const state = this.lanes.get(lane);
     if (!state || state.httpFallback || state.wire?.responseId !== baseline.responseId) return;
-    state.semantic = baseline;
+    state.semantic = undefined;
+    state.pendingSemantic = baseline;
+  }
+
+  recordSemanticResponse(lane: string, responseMessages: readonly ModelMessage[]): void {
+    const state = this.lanes.get(lane);
+    const pending = state?.pendingSemantic;
+    if (!state || !pending || state.httpFallback || state.wire?.responseId !== pending.responseId) {
+      if (state) {
+        state.semantic = undefined;
+        state.pendingSemantic = undefined;
+      }
+      return;
+    }
+    state.semantic = {
+      ...pending,
+      responseMessages: structuredClone(responseMessages),
+    };
+    state.pendingSemantic = undefined;
   }
 
   clearSemantic(lane: string): void {
     const state = this.lanes.get(lane);
-    if (state) state.semantic = undefined;
+    if (state) {
+      state.semantic = undefined;
+      state.pendingSemantic = undefined;
+    }
   }
 
   canRecordSemantic(lane: string, responseId: string): boolean {
@@ -97,8 +126,14 @@ export class OpenAiResponsesTransportState {
     const prepared = prepareWireRequest(body, state.wire);
     if (!prepared) {
       state.semantic = undefined;
+      state.pendingSemantic = undefined;
       state.httpFallback = true;
-      return failedStream('OpenAI Responses continuation state is unavailable');
+      return failedStream(
+        retryableTransportError(
+          'OpenAI Responses continuation state is unavailable',
+          'OPENAI_RESPONSES_CONTINUATION_UNAVAILABLE',
+        ),
+      );
     }
 
     // A failure on one concurrent lane should prevent new connection attempts,
@@ -107,7 +142,7 @@ export class OpenAiResponsesTransportState {
       state.socket?.readyState !== WebSocket.OPEN && this.failureCooldownActive();
     if (state.httpFallback || failureCooldownActive || state.busy) {
       state.semantic = undefined;
-      if (failureCooldownActive) state.httpFallback = true;
+      state.pendingSemantic = undefined;
       return await httpFetch(input, withJsonBody(cleanInit, prepared.fullBody));
     }
 
@@ -126,6 +161,7 @@ export class OpenAiResponsesTransportState {
       state.busy = false;
       state.httpFallback = true;
       state.semantic = undefined;
+      state.pendingSemantic = undefined;
       terminate(state.socket);
       state.socket = undefined;
       if (isAbort(error, init?.signal)) throw error;
@@ -154,6 +190,7 @@ export class OpenAiResponsesTransportState {
       onFailure: (fallback) => {
         state.busy = false;
         state.semantic = undefined;
+        state.pendingSemantic = undefined;
         state.wire = undefined;
         if (fallback) {
           state.httpFallback = true;
@@ -292,6 +329,14 @@ function websocketResponse(input: {
     input.onFailure(fallback);
     controller.error(error);
   };
+  const failTransport = (error: Error) =>
+    fail(
+      retryableTransportError(
+        error.message || 'OpenAI Responses WebSocket transport failed',
+        'OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR',
+      ),
+      true,
+    );
   const finish = (response: Record<string, unknown>) => {
     if (settled) return;
     settled = true;
@@ -302,7 +347,7 @@ function websocketResponse(input: {
   };
   const onMessage = (data: WebSocket.RawData, isBinary: boolean) => {
     if (isBinary) {
-      fail(new Error('Unexpected binary OpenAI Responses WebSocket frame'), true);
+      failTransport(new Error('Unexpected binary OpenAI Responses WebSocket frame'));
       return;
     }
     const text = data.toString();
@@ -315,13 +360,16 @@ function websocketResponse(input: {
     }
     controller.enqueue(encoder.encode(`data: ${text}\n\n`));
     if (!event) return;
-    if (event.type === 'response.completed' || event.type === 'response.done') {
-      finish(isRecord(event.response) ? event.response : {});
-    } else if (
-      event.type === 'response.failed' ||
-      event.type === 'response.incomplete' ||
-      event.type === 'error'
+    if (
+      event.type === 'response.completed' ||
+      event.type === 'response.done' ||
+      (event.type === 'response.incomplete' && incompleteReason(event) === 'max_output_tokens')
     ) {
+      finish(isRecord(event.response) ? event.response : {});
+    } else if (event.type === 'response.incomplete') {
+      const reason = incompleteReason(event) ?? 'unknown';
+      fail(new Error(`OpenAI Responses stream incomplete (${reason})`), false);
+    } else if (event.type === 'response.failed' || event.type === 'error') {
       settled = true;
       cleanup();
       input.onFailure(false);
@@ -329,13 +377,12 @@ function websocketResponse(input: {
       controller.close();
     }
   };
-  const onError = (error: Error) => fail(error, true);
+  const onError = (error: Error) => failTransport(error);
   const onClose = (code: number, reason: Buffer) =>
-    fail(
+    failTransport(
       new Error(
         `OpenAI Responses WebSocket closed before completion (code ${code}${reason.length ? `: ${reason.toString()}` : ''})`,
       ),
-      true,
     );
   const onAbort = () =>
     fail(
@@ -359,7 +406,7 @@ function websocketResponse(input: {
         }
         const { stream: _stream, background: _background, ...body } = input.body;
         input.socket.send(JSON.stringify({ type: 'response.create', ...body }), (error) => {
-          if (error) fail(error, true);
+          if (error) failTransport(error);
         });
       },
       cancel() {
@@ -389,6 +436,11 @@ function connectWebSocket(
       return;
     }
     const socket = new WebSocket(url, { headers, ...(agent ? { agent } : {}) });
+    // `websocketResponse` removes its request-scoped listener after a successful
+    // stream while the OPEN socket remains reusable. ws emits idle protocol
+    // errors unconditionally, so retain one process-safety listener for the
+    // socket's entire lifetime.
+    socket.on('error', ignoreWebSocketError);
     const timer = setTimeout(
       () => finish(new Error('OpenAI Responses WebSocket connect timed out')),
       timeoutMs,
@@ -423,11 +475,11 @@ function connectWebSocket(
   });
 }
 
-function failedStream(message: string): Response {
+function failedStream(error: Error): Response {
   return new Response(
     new ReadableStream({
       start(controller) {
-        controller.error(new Error(message));
+        controller.error(error);
       },
     }),
     { status: 200, headers: { 'content-type': 'text/event-stream' } },
@@ -437,6 +489,7 @@ function failedStream(message: string): Response {
 function invalidateLane(state: LaneState, fallback: boolean): void {
   state.busy = false;
   state.semantic = undefined;
+  state.pendingSemantic = undefined;
   state.wire = undefined;
   state.httpFallback ||= fallback;
   terminate(state.socket);
@@ -445,8 +498,19 @@ function invalidateLane(state: LaneState, fallback: boolean): void {
 
 function terminate(socket: WebSocket | undefined): void {
   if (!socket) return;
-  socket.on('error', () => {});
   socket.terminate();
+}
+
+function ignoreWebSocketError(): void {}
+
+function retryableTransportError(message: string, code: string): Error {
+  return Object.assign(new Error(message), { name: 'OpenAiResponsesTransportError', code });
+}
+
+function incompleteReason(event: Record<string, unknown>): string | undefined {
+  const response = isRecord(event.response) ? event.response : undefined;
+  const details = isRecord(response?.incomplete_details) ? response.incomplete_details : undefined;
+  return typeof details?.reason === 'string' ? details.reason : undefined;
 }
 
 function isAbort(error: unknown, signal: AbortSignal | null | undefined): boolean {

--- a/packages/runtime/src/openai-responses-websocket.ts
+++ b/packages/runtime/src/openai-responses-websocket.ts
@@ -12,6 +12,7 @@ import type { OpenAiResponsesSemanticBaseline } from './openai-responses-continu
 export const OPENAI_RESPONSES_LANE_HEADER = 'x-maka-openai-responses-lane';
 const RESPONSES_WEBSOCKET_PROTOCOL = 'responses_websockets=2026-02-06';
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
+const DEFAULT_FAILURE_COOLDOWN_MS = 5 * 60_000;
 
 interface WireBaseline {
   fullBody: Record<string, unknown>;
@@ -30,10 +31,15 @@ interface LaneState {
 export interface OpenAiResponsesTransportOptions {
   webSocketUrl?: string;
   connectTimeoutMs?: number;
+  /** Suppress new socket attempts after a transport failure. Defaults to five minutes. */
+  failureCooldownMs?: number;
+  /** Injectable clock for deterministic cooldown tests. */
+  now?: () => number;
 }
 
 export class OpenAiResponsesTransportState {
   private readonly lanes = new Map<string, LaneState>();
+  private webSocketUnavailableUntil = 0;
 
   constructor(private readonly options: OpenAiResponsesTransportOptions = {}) {}
 
@@ -95,8 +101,13 @@ export class OpenAiResponsesTransportState {
       return failedStream('OpenAI Responses continuation state is unavailable');
     }
 
-    if (state.httpFallback || state.busy) {
+    // A failure on one concurrent lane should prevent new connection attempts,
+    // not evict another lane's already healthy socket.
+    const failureCooldownActive =
+      state.socket?.readyState !== WebSocket.OPEN && this.failureCooldownActive();
+    if (state.httpFallback || failureCooldownActive || state.busy) {
       state.semantic = undefined;
+      if (failureCooldownActive) state.httpFallback = true;
       return await httpFetch(input, withJsonBody(cleanInit, prepared.fullBody));
     }
 
@@ -118,6 +129,7 @@ export class OpenAiResponsesTransportState {
       terminate(state.socket);
       state.socket = undefined;
       if (isAbort(error, init?.signal)) throw error;
+      this.deferWebSocketRetry();
       return await httpFetch(input, withJsonBody(cleanInit, prepared.fullBody));
     }
 
@@ -143,11 +155,23 @@ export class OpenAiResponsesTransportState {
         state.busy = false;
         state.semantic = undefined;
         state.wire = undefined;
-        if (fallback) state.httpFallback = true;
+        if (fallback) {
+          state.httpFallback = true;
+          this.deferWebSocketRetry();
+        }
         terminate(state.socket);
         state.socket = undefined;
       },
     });
+  }
+
+  private failureCooldownActive(): boolean {
+    return this.webSocketUnavailableUntil > (this.options.now ?? Date.now)();
+  }
+
+  private deferWebSocketRetry(): void {
+    const cooldownMs = this.options.failureCooldownMs ?? DEFAULT_FAILURE_COOLDOWN_MS;
+    this.webSocketUnavailableUntil = (this.options.now ?? Date.now)() + Math.max(0, cooldownMs);
   }
 
   private async openSocketIfNeeded(

--- a/packages/runtime/src/provider-error-classification.ts
+++ b/packages/runtime/src/provider-error-classification.ts
@@ -40,6 +40,11 @@ export interface ProviderRetryMetadata {
 }
 
 const MAX_SAFE_TIMER_DELAY_MS = 2_147_483_647;
+const OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR = 'OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR';
+const RUNTIME_RETRYABLE_ERROR_CODES: ReadonlySet<string> = new Set([
+  OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR,
+  'OPENAI_RESPONSES_CONTINUATION_UNAVAILABLE',
+]);
 
 function providerErrorTarget(error: unknown): unknown {
   return RetryError.isInstance(error) && error.lastError !== undefined && error.lastError !== error
@@ -82,6 +87,8 @@ export function providerRetryMetadata(error: unknown): ProviderRetryMetadata {
   const target = providerErrorTarget(error);
   const evidence = normalizeErrorEvidence(target);
   if (!evidence) return { retryable: false };
+
+  if (RUNTIME_RETRYABLE_ERROR_CODES.has(evidence.code)) return { retryable: true };
 
   const status = Number(evidence.statusCode || evidence.code);
   const errorClass = classifyError(target);
@@ -294,6 +301,7 @@ export function classifyError(error: unknown): string {
   if (!evidence) return 'Other';
   const { text, statusCode, code, structuredCodes } = evidence;
   if (text.includes('abort')) return 'Abort';
+  if (code === OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR) return 'Network';
   if (statusCode === '402' || code === '402') return 'ProviderBilling';
   if (statusCode === '429' || code === '429') return 'RateLimit';
   if (statusCode === '401' || statusCode === '403' || code === '401' || code === '403')


### PR DESCRIPTION
## Summary

- remember WebSocket transport failures across turn cleanup and route new lanes to full-history HTTP during a five-minute cooldown
- let lanes that temporarily used HTTP retry WebSocket after the cooldown expires, then resume delta continuation on the recovered socket
- build semantic continuation baselines from Maka durable replay instead of `sdk.response.messages`, so reasoning turns can actually send only the new suffix
- classify WebSocket and stale-continuation failures as retryable, allowing the existing Runtime retry to restart the current step from durable full history over HTTP
- keep an idle-socket `error` listener for the lifetime of reusable connections and surface non-truncation `response.incomplete` outcomes as failures
- replace timing sleeps with event-driven tests and cover the adapter/backend continuation contract, stale ids, busy lanes, binary frames, aborts, provider failures, cooldown recovery, and healthy concurrent lanes

## Why

Follow-up to #2238 and #2248. The initial incremental transport had three reliability gaps:

1. reasoning metadata has a different shape in SDK response messages and Maka durable replay, so the prefix comparison silently disabled continuation for normal GPT-5 reasoning steps;
2. a mid-stream WebSocket close was not classified as retryable, turning a recoverable HTTP-style network interruption into a hard turn failure;
3. a successfully reused socket could be left with no `error` listener while idle, allowing a protocol error to become an uncaught exception.

The cooldown from the first commit still prevents environments that block WebSocket setup from paying the 15-second timeout on every new turn. A lane that only used HTTP because the global cooldown was active is no longer permanently pinned to HTTP; it retries safely with full history after expiry.

## Safety

- durable Runtime history remains the source of truth; semantic continuation is completed only after tool settlement is persisted and replayed
- any replay/prefix mismatch fails closed to a full request
- Runtime retries only when the failed attempt produced no observable output, preserving the existing duplicate-output guard
- transport failures clear wire and semantic baselines before the retry, so the next request cannot reuse a stale response id
- baseline memory lifetime and proxy-snapshot availability are documented explicitly

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npm --workspace @maka/runtime test` — 3,217 tests; 3,208 passed, 9 skipped, 0 failed
- focused continuation, adapter/backend, WebSocket failure, cooldown recovery, and provider-classification tests — 34 passed

Closes #2248