### PR TITLE
fix: preserve reasoning across provider steps

### DIFF
--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -21,7 +21,6 @@ export type ProviderRuntimeAdapter =
       kind: 'openai-compatible';
       name: 'provider' | 'connection';
       includeUsage?: boolean;
-      passFetch?: boolean;
       requireBaseUrl?: boolean;
       supportsOpenAiResponses?: true;
       replayAssistantReasoningAs?: 'reasoning';
@@ -918,7 +917,7 @@ const providerRegistry = {
     fallbackModels: siliconflowModelIds,
     status: 'ready',
     protocol: 'openai',
-    runtimeAdapter: { kind: 'openai-compatible', name: 'provider', passFetch: true },
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
     modelDiscovery: { kind: 'protocol', query: { sub_type: 'chat' } },
     category: 'domestic',
     catalogGroup: 'aggregators',

--- a/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
@@ -312,7 +312,67 @@ describe('Anthropic-compatible Computer Use product loops', () => {
   }
 });
 
-describe('Kimi OpenAI-compatible product loop', () => {
+describe('OpenAI-compatible product loops', () => {
+  test('replays non-Kimi reasoning_content across Maka-owned provider steps', async () => {
+    const sessionId = 'session-deepseek-openai-chat';
+    const durable = createDurableTurnHarness({
+      sessionId,
+      turnId: 'turn-deepseek-openai-chat',
+      text: 'List the available applications.',
+    });
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/v1/chat/completions');
+      const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      requestBodies.push(body);
+      const step = requestBodies.length;
+      respondOpenAiStream(
+        response,
+        'deepseek-v4-pro',
+        step,
+        step === 1 ? { action: 'list_apps' } : undefined,
+        'reasoning_content',
+      );
+    });
+    const [computerTool] = buildComputerUseTools({
+      backend: fakeSemanticBackend({ current: '' }),
+    });
+    const providerConnection = connection(
+      'deepseek',
+      `${server.url}/v1`,
+      'deepseek-v4-pro',
+      'openai-chat',
+    );
+    const runtime = createTestAiSdkBackend({
+      sessionId,
+      header: header('deepseek', 'deepseek-v4-pro'),
+      appendMessage: async () => {},
+      connection: providerConnection,
+      apiKey: 'test-key',
+      modelId: 'deepseek-v4-pro',
+      modelFactory: (input) => getAIModel(input),
+      tools: [computerTool],
+      maxSteps: 2,
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    for await (const event of runtime.send(durable.sendInput())) durable.record(event);
+
+    assert.equal(requestBodies.length, 2);
+    const replayedAssistant = (requestBodies[1]!.messages as unknown[]).find(
+      (message) =>
+        isRecord(message) &&
+        message.role === 'assistant' &&
+        Array.isArray(message.tool_calls) &&
+        message.tool_calls.some((toolCall) => isRecord(toolCall) && toolCall.id === 'call-1'),
+    );
+    assert.ok(replayedAssistant && isRecord(replayedAssistant));
+    assert.equal(replayedAssistant.reasoning_content, 'reasoning-step-1');
+  });
+
   test('reconstructs a recovered reasoning and tool-call step as one assistant message', async () => {
     const sessionId = 'session-kimi-openai-recovered-tool-step';
     const previousTurnId = 'turn-kimi-openai-recovered-tool-step-1';
@@ -972,6 +1032,7 @@ function respondOpenAiStream(
   model: string,
   step: number,
   toolInput: Record<string, unknown> | undefined,
+  reasoningField: 'reasoning' | 'reasoning_content' = 'reasoning',
 ) {
   response.writeHead(200, {
     'content-type': 'text/event-stream',
@@ -987,7 +1048,13 @@ function respondOpenAiStream(
     model,
     choices: [{ index: 0, delta, finish_reason: finishReason }],
   });
-  send(choice({ role: 'assistant', reasoning: step === 1 ? '' : `reasoning-step-${step}` }));
+  send(
+    choice({
+      role: 'assistant',
+      [reasoningField]:
+        step === 1 && reasoningField === 'reasoning' ? '' : `reasoning-step-${step}`,
+    }),
+  );
   if (toolInput) {
     send(
       choice({

--- a/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
@@ -313,65 +313,86 @@ describe('Anthropic-compatible Computer Use product loops', () => {
 });
 
 describe('OpenAI-compatible product loops', () => {
-  test('replays non-Kimi reasoning_content across Maka-owned provider steps', async () => {
-    const sessionId = 'session-deepseek-openai-chat';
-    const durable = createDurableTurnHarness({
-      sessionId,
-      turnId: 'turn-deepseek-openai-chat',
-      text: 'List the available applications.',
-    });
-    const requestBodies: Array<Record<string, unknown>> = [];
-    const server = await startJsonServer(async (request, response) => {
-      assert.equal(request.method, 'POST');
-      assert.equal(request.url, '/v1/chat/completions');
-      const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
-      requestBodies.push(body);
-      const step = requestBodies.length;
-      respondOpenAiStream(
-        response,
-        'deepseek-v4-pro',
-        step,
-        step === 1 ? { action: 'list_apps' } : undefined,
-        'reasoning_content',
+  for (const provider of [
+    {
+      providerType: 'deepseek',
+      modelId: 'deepseek-v4-pro',
+      responseField: 'reasoning_content',
+      requestField: 'reasoning_content',
+    },
+    {
+      providerType: 'ollama-cloud',
+      modelId: 'glm-5.2',
+      responseField: 'reasoning_content',
+      requestField: 'reasoning',
+    },
+  ] as const) {
+    test(`${provider.providerType} replays observed reasoning as its declared request field`, async () => {
+      const sessionId = `session-${provider.providerType}-openai-chat`;
+      const durable = createDurableTurnHarness({
+        sessionId,
+        turnId: `turn-${provider.providerType}-openai-chat`,
+        text: 'List the available applications.',
+      });
+      const requestBodies: Array<Record<string, unknown>> = [];
+      const server = await startJsonServer(async (request, response) => {
+        assert.equal(request.method, 'POST');
+        assert.equal(request.url, '/v1/chat/completions');
+        const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+        requestBodies.push(body);
+        const step = requestBodies.length;
+        respondOpenAiStream(
+          response,
+          provider.modelId,
+          step,
+          step === 1 ? { action: 'list_apps' } : undefined,
+          provider.responseField,
+        );
+      });
+      const [computerTool] = buildComputerUseTools({
+        backend: fakeSemanticBackend({ current: '' }),
+      });
+      const providerConnection = connection(
+        provider.providerType,
+        `${server.url}/v1`,
+        provider.modelId,
+        'openai-chat',
+      );
+      const runtime = createTestAiSdkBackend({
+        sessionId,
+        header: header(provider.providerType, provider.modelId),
+        appendMessage: async () => {},
+        connection: providerConnection,
+        apiKey: 'test-key',
+        modelId: provider.modelId,
+        modelFactory: (input) => getAIModel(input),
+        tools: [computerTool],
+        maxSteps: 2,
+        loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+        newId: idGenerator(),
+        now: monotonicClock(),
+      });
+
+      for await (const event of runtime.send(durable.sendInput())) durable.record(event);
+
+      assert.equal(requestBodies.length, 2);
+      const replayedAssistant = (requestBodies[1]!.messages as unknown[]).find(
+        (message) =>
+          isRecord(message) &&
+          message.role === 'assistant' &&
+          Array.isArray(message.tool_calls) &&
+          message.tool_calls.some((toolCall) => isRecord(toolCall) && toolCall.id === 'call-1'),
+      );
+      assert.ok(replayedAssistant && isRecord(replayedAssistant));
+      assert.equal(replayedAssistant[provider.requestField], 'reasoning-step-1');
+      assert.equal(
+        replayedAssistant[
+          provider.requestField === 'reasoning' ? 'reasoning_content' : 'reasoning'
+        ],
+        undefined,
       );
     });
-    const [computerTool] = buildComputerUseTools({
-      backend: fakeSemanticBackend({ current: '' }),
-    });
-    const providerConnection = connection(
-      'deepseek',
-      `${server.url}/v1`,
-      'deepseek-v4-pro',
-      'openai-chat',
-    );
-    const runtime = createTestAiSdkBackend({
-      sessionId,
-      header: header('deepseek', 'deepseek-v4-pro'),
-      appendMessage: async () => {},
-      connection: providerConnection,
-      apiKey: 'test-key',
-      modelId: 'deepseek-v4-pro',
-      modelFactory: (input) => getAIModel(input),
-      tools: [computerTool],
-      maxSteps: 2,
-      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
-    });
-
-    for await (const event of runtime.send(durable.sendInput())) durable.record(event);
-
-    assert.equal(requestBodies.length, 2);
-    const replayedAssistant = (requestBodies[1]!.messages as unknown[]).find(
-      (message) =>
-        isRecord(message) &&
-        message.role === 'assistant' &&
-        Array.isArray(message.tool_calls) &&
-        message.tool_calls.some((toolCall) => isRecord(toolCall) && toolCall.id === 'call-1'),
-    );
-    assert.ok(replayedAssistant && isRecord(replayedAssistant));
-    assert.equal(replayedAssistant.reasoning_content, 'reasoning-step-1');
-  });
+  }
 
   test('reconstructs a recovered reasoning and tool-call step as one assistant message', async () => {
     const sessionId = 'session-kimi-openai-recovered-tool-step';
@@ -702,7 +723,7 @@ describe('OpenAI-compatible product loops', () => {
     for (const capture of captures) {
       assert.doesNotMatch(
         capture.serializedRequest,
-        /MAKA_KIMI_EMPTY_REASONING/,
+        /MAKA_(?:KIMI|OPENAI_CHAT)_EMPTY_REASONING/,
         'provider request evidence must not persist the SDK-only empty-reasoning marker',
       );
     }

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -108,6 +108,37 @@ describe('ModelAdapter stream and error normalization', () => {
     });
   });
 
+  test('shares one resolved OpenAI Chat reasoning contract with the model factory', () => {
+    let observedWire: string | undefined;
+    let observedReplayKind: string | undefined;
+    let observedRequestField: string | undefined;
+    const adapter = new ModelAdapter({
+      connection: {
+        slug: 'deepseek',
+        providerType: 'deepseek',
+        defaultModel: 'deepseek-v4-pro',
+        models: [{ id: 'deepseek-v4-pro', apiProtocol: 'openai-chat' }],
+      },
+      apiKey: 'deepseek-token',
+      modelId: 'deepseek-v4-pro',
+      modelFactory: (input) => {
+        observedWire = input.resolvedRuntime?.wire;
+        observedReplayKind = input.resolvedRuntime?.reasoningReplay.kind;
+        observedRequestField = input.openAiChatReasoningTransportState?.requestField;
+        return {};
+      },
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    adapter.resolveModel();
+
+    assert.equal(observedWire, 'openai-chat');
+    assert.equal(observedReplayKind, 'openai-chat-plaintext');
+    assert.equal(observedRequestField, 'observed');
+    assert.equal(adapter.runtimeEventReplaySupport().unsignedThinking, true);
+  });
+
   test('supports Responses reasoning replay for Volcengine Agent Plan', () => {
     const adapter = new ModelAdapter({
       connection: {

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -930,6 +930,31 @@ describe('models.dev provider conformance', () => {
     assert.equal(body?.store, false);
   });
 
+  test('DeepSeek connection probes use the same account-declared Responses wire as execution', async () => {
+    let body: Record<string, unknown> | undefined;
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/v1/responses');
+      body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      respondJson(response, 200, {});
+    });
+    const connection: LlmConnection = {
+      slug: 'deepseek',
+      name: 'DeepSeek',
+      providerType: 'deepseek',
+      baseUrl: `${server.url}/v1`,
+      defaultModel: 'deepseek-v4-pro',
+      models: [{ id: 'deepseek-v4-pro', apiProtocol: 'openai-responses' }],
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    assert.equal((await testConnection(connection, 'deepseek-token')).ok, true);
+    assert.equal(body?.model, 'deepseek-v4-pro');
+    assert.equal(body?.store, false);
+  });
+
   test('Ollama Cloud requests usage in streamed chat completions', async () => {
     let requestBody: Record<string, unknown> | undefined;
     const server = await startJsonServer(async (request, response) => {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -139,7 +139,7 @@ import {
 } from './ai-sdk-compaction.js';
 import type { AiSdkCompactionCapabilities } from './ai-sdk-compaction-contract.js';
 import type { ToolArtifactRecorder } from './tool-artifacts.js';
-import { kimiReasoningFieldFromProviderOptions } from './kimi-openai-transport.js';
+import { openAiChatReasoningFieldFromProviderOptions } from './openai-chat-reasoning-transport.js';
 import { RunTrace, type RunTraceRecorder } from './run-trace.js';
 import {
   toSandboxRunTraceProjection,
@@ -2952,11 +2952,11 @@ export class AiSdkBackend implements AgentBackend {
         }
       }
       if (!replaySupport.unsignedThinking) return undefined;
-      const kimiReasoningField = kimiReasoningFieldFromProviderOptions(item.providerOptions);
-      if (!kimiReasoningField) return undefined;
+      const reasoningField = openAiChatReasoningFieldFromProviderOptions(item.providerOptions);
+      if (!reasoningField) return undefined;
       return {
         providerOptions: {
-          openaiCompatible: { [kimiReasoningField]: item.text },
+          openaiCompatible: { [reasoningField]: item.text },
         } as NonNullable<ModelMessage['providerOptions']>,
       };
     };

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -5,7 +5,7 @@ import {
   providerAuthRequiresSecret,
   type RuntimeExecutionConnection,
 } from '@maka/core/llm-connections';
-import { lookupModelMetadata, openAiAdapterApiProtocol } from '@maka/core/model-metadata';
+import { lookupModelMetadata } from '@maka/core/model-metadata';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import type { CacheMissInputSource } from '@maka/core/usage-stats/types';
 import { rawFinishReasonString } from './model-protocol.js';
@@ -34,7 +34,7 @@ export type {
   ModelToolSet,
 } from './model-protocol.js';
 
-import { resolveModelRuntime } from './model-runtime.js';
+import { resolveModelRuntime, type ResolvedModelRuntime } from './model-runtime.js';
 import {
   classifyError,
   errorPresentationFromClass,
@@ -45,11 +45,12 @@ import {
   type ProviderRequestTracker,
 } from './provider-request-telemetry.js';
 import {
-  createKimiOpenAiTransportState,
-  kimiReasoningFieldProviderOptions,
-  restoreKimiEmptyReasoning,
-  type KimiOpenAiTransportState,
-} from './kimi-openai-transport.js';
+  createOpenAiChatReasoningTransportState,
+  openAiChatReasoningFieldProviderOptions,
+  restoreOpenAiChatEmptyReasoning,
+  type OpenAiChatReasoningTransportState,
+} from './openai-chat-reasoning-transport.js';
+import type { ModelFactoryInput } from './model-factory.js';
 import {
   mergeOpenAiResponsesProviderOptions,
   planOpenAiResponsesContinuation,
@@ -68,13 +69,7 @@ import {
  * We type-erase the return as `unknown` here to avoid pulling ai-sdk's
  * `LanguageModelV2` type into core's dependency graph.
  */
-export interface ModelFactoryInput {
-  connection: RuntimeExecutionConnection;
-  apiKey: string;
-  modelId: string;
-  kimiOpenAiTransportState?: KimiOpenAiTransportState;
-  openAiResponsesTransportState?: OpenAiResponsesTransportState;
-}
+export type { ModelFactoryInput };
 export type ModelFactory = (input: ModelFactoryInput) => unknown;
 
 export interface RepairableAiSdkToolCall {
@@ -147,18 +142,26 @@ interface ProviderMiddlewareStreamInput {
 }
 
 export class ModelAdapter {
-  private readonly kimiOpenAiTransportState = createKimiOpenAiTransportState();
+  private readonly runtime: ResolvedModelRuntime;
+  private readonly openAiChatReasoningTransportState: OpenAiChatReasoningTransportState;
   private readonly openAiResponsesTransportState = createOpenAiResponsesTransportState();
 
-  constructor(private readonly input: ModelAdapterInput) {}
+  constructor(private readonly input: ModelAdapterInput) {
+    this.runtime = resolveModelRuntime(input.connection, input.modelId);
+    this.openAiChatReasoningTransportState = createOpenAiChatReasoningTransportState(
+      this.runtime.reasoningReplay.kind === 'openai-chat-plaintext'
+        ? this.runtime.reasoningReplay.requestField
+        : 'observed',
+    );
+  }
 
   runtimeEventReplaySupport(): ModelAdapterRuntimeEventReplaySupport {
     return {
       toolCalls: true,
       toolResults: true,
-      signedThinking: usesAnthropicMessages(this.input.connection, this.input.modelId),
-      unsignedThinking: usesKimiOpenAiChat(this.input.connection, this.input.modelId),
-      openAiResponsesThinking: usesOpenAiResponses(this.input.connection, this.input.modelId),
+      signedThinking: this.runtime.reasoningReplay.kind === 'anthropic-signed',
+      unsignedThinking: this.runtime.reasoningReplay.kind === 'openai-chat-plaintext',
+      openAiResponsesThinking: this.runtime.reasoningReplay.kind === 'openai-responses-item',
     };
   }
 
@@ -170,10 +173,11 @@ export class ModelAdapter {
       connection: this.input.connection,
       apiKey: this.input.apiKey,
       modelId: this.input.modelId,
-      ...(usesKimiOpenAiChat(this.input.connection, this.input.modelId)
-        ? { kimiOpenAiTransportState: this.kimiOpenAiTransportState }
+      resolvedRuntime: this.runtime,
+      ...(this.runtime.reasoningReplay.kind === 'openai-chat-plaintext'
+        ? { openAiChatReasoningTransportState: this.openAiChatReasoningTransportState }
         : {}),
-      ...(usesNativeOpenAiResponses(this.input.connection, this.input.modelId)
+      ...(usesNativeOpenAiResponses(this.input.connection, this.runtime)
         ? { openAiResponsesTransportState: this.openAiResponsesTransportState }
         : {}),
     });
@@ -194,6 +198,7 @@ export class ModelAdapter {
       this.input.connection,
       this.input.modelId,
       this.input.providerOptions,
+      this.runtime,
     );
     const trackedModel = input.providerRequestTracker
       ? wrapLanguageModel({
@@ -225,7 +230,7 @@ export class ModelAdapter {
     );
     const fullMessages = lowerNativeAudioMessages(input.messages);
     const responsesLane =
-      input.continuationKey && usesNativeOpenAiResponses(this.input.connection, this.input.modelId)
+      input.continuationKey && usesNativeOpenAiResponses(this.input.connection, this.runtime)
         ? input.continuationKey
         : undefined;
     const continuation = responsesLane
@@ -234,7 +239,7 @@ export class ModelAdapter {
           this.openAiResponsesTransportState.semanticBaseline(responsesLane),
         )
       : { messages: fullMessages };
-    const providerOptions = usesNativeOpenAiResponses(this.input.connection, this.input.modelId)
+    const providerOptions = usesNativeOpenAiResponses(this.input.connection, this.runtime)
       ? mergeOpenAiResponsesProviderOptions(
           this.input.providerOptions,
           this.input.sessionId ?? this.input.connection.slug,
@@ -289,9 +294,10 @@ export class ModelAdapter {
     onStreamActivity: () => void,
     continuation: { lane?: string; requestMessages: ModelMessage[] },
   ): ModelStreamResult {
-    const kimiOpenAiTransportState = usesKimiOpenAiChat(this.input.connection, this.input.modelId)
-      ? this.kimiOpenAiTransportState
-      : undefined;
+    const openAiChatReasoningTransportState =
+      this.runtime.reasoningReplay.kind === 'openai-chat-plaintext'
+        ? this.openAiChatReasoningTransportState
+        : undefined;
     const openAiResponsesTransportState = this.openAiResponsesTransportState;
     const events: AsyncIterable<ModelStreamEvent> = {
       async *[Symbol.asyncIterator]() {
@@ -299,7 +305,7 @@ export class ModelAdapter {
         try {
           for await (const chunk of sdk.stream as AsyncIterable<AiSdkStreamChunk>) {
             onStreamActivity();
-            for (const event of translateChunk(chunk, kimiOpenAiTransportState)) {
+            for (const event of translateChunk(chunk, openAiChatReasoningTransportState)) {
               if (event.kind === 'error') succeeded = false;
               yield event;
             }
@@ -412,8 +418,8 @@ export class ModelAdapter {
   translateChunk(chunk: AiSdkStreamChunk): ModelStreamEvent[] {
     return translateChunk(
       chunk,
-      usesKimiOpenAiChat(this.input.connection, this.input.modelId)
-        ? this.kimiOpenAiTransportState
+      this.runtime.reasoningReplay.kind === 'openai-chat-plaintext'
+        ? this.openAiChatReasoningTransportState
         : undefined,
     );
   }
@@ -488,9 +494,11 @@ function selectedModelMaxOutputTokens(
   connection: RuntimeExecutionConnection,
   modelId: string,
   providerOptions: Record<string, unknown> | undefined,
+  runtime: ResolvedModelRuntime,
 ): number | undefined {
-  const anthropicMessages = usesAnthropicMessages(connection, modelId);
-  const kimiOpenAiChat = usesKimiOpenAiChat(connection, modelId);
+  const anthropicMessages = runtime.wire === 'anthropic-messages';
+  const kimiOpenAiChat =
+    connection.providerType === 'kimi-coding-plan' && runtime.wire === 'openai-chat';
   if (!anthropicMessages && !kimiOpenAiChat) return undefined;
   const wireOutputLimit =
     connection.models?.find((model) => model.id === modelId)?.maxOutputTokens ??
@@ -501,37 +509,11 @@ function selectedModelMaxOutputTokens(
     : wireOutputLimit;
 }
 
-function usesAnthropicMessages(connection: RuntimeExecutionConnection, modelId: string): boolean {
-  const { adapter, apiProtocol } = resolveModelRuntime(connection, modelId);
-  return (
-    adapter.kind === 'anthropic' ||
-    adapter.kind === 'claude-subscription' ||
-    (adapter.kind === 'github-copilot' && apiProtocol === 'anthropic-messages')
-  );
-}
-
-function usesKimiOpenAiChat(connection: RuntimeExecutionConnection, modelId: string): boolean {
-  return (
-    connection.providerType === 'kimi-coding-plan' &&
-    resolveModelRuntime(connection, modelId).apiProtocol === 'openai-chat'
-  );
-}
-
-function usesOpenAiResponses(connection: RuntimeExecutionConnection, modelId: string): boolean {
-  const runtime = resolveModelRuntime(connection, modelId);
-  if (runtime.adapter.kind !== 'openai') return false;
-  return (
-    runtime.adapter.apiProtocol === 'openai-responses' ||
-    runtime.apiProtocol === 'openai-responses' ||
-    openAiAdapterApiProtocol(modelId, connection.providerType) === 'openai-responses'
-  );
-}
-
 function usesNativeOpenAiResponses(
   connection: RuntimeExecutionConnection,
-  modelId: string,
+  runtime: ResolvedModelRuntime,
 ): boolean {
-  return connection.providerType === 'openai' && usesOpenAiResponses(connection, modelId);
+  return connection.providerType === 'openai' && runtime.wire === 'openai-responses';
 }
 
 function fixedAnthropicThinkingBudget(
@@ -640,7 +622,7 @@ function openAiResponsesReasoningProviderOptionsFromChunk(
  */
 function translateChunk(
   chunk: AiSdkStreamChunk,
-  kimiOpenAiTransportState?: KimiOpenAiTransportState,
+  openAiChatReasoningTransportState?: OpenAiChatReasoningTransportState,
 ): ModelStreamEvent[] {
   switch (chunk.type) {
     case 'text-start':
@@ -678,13 +660,13 @@ function translateChunk(
       if (text !== undefined && (text.length > 0 || signature === undefined)) {
         events.push({
           kind: 'thinking',
-          text: restoreKimiEmptyReasoning(text),
+          text: restoreOpenAiChatEmptyReasoning(text),
           ...(responsesProviderOptions
             ? { providerOptions: responsesProviderOptions }
-            : kimiOpenAiTransportState
+            : openAiChatReasoningTransportState
               ? {
-                  providerOptions: kimiReasoningFieldProviderOptions(
-                    kimiOpenAiTransportState.reasoningField,
+                  providerOptions: openAiChatReasoningFieldProviderOptions(
+                    openAiChatReasoningTransportState.reasoningField,
                   ),
                 }
               : {}),

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -13,7 +13,6 @@ import {
 } from '@ai-sdk/provider';
 import { type RuntimeExecutionConnection } from '@maka/core/llm-connections';
 import type { ProviderRuntimeAdapter } from '@maka/core/llm-connections';
-import { openAiAdapterApiProtocol } from '@maka/core/model-metadata';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import {
   thinkingOptionsForModel,
@@ -21,12 +20,13 @@ import {
   type ThinkingOptions,
 } from '@maka/core/model-thinking';
 import {
-  createKimiOpenAiTransport,
-  type KimiOpenAiTransportState,
-} from './kimi-openai-transport.js';
+  createOpenAiChatReasoningTransport,
+  createOpenAiChatReasoningTransportState,
+  type OpenAiChatReasoningTransportState,
+} from './openai-chat-reasoning-transport.js';
 import type { OpenAiResponsesTransportState } from './openai-responses-websocket.js';
 import { anthropicV1BaseUrl, googleV1BetaBaseUrl } from './provider-urls.js';
-import { resolveModelRuntime } from './model-runtime.js';
+import { resolveModelRuntime, type ResolvedModelRuntime } from './model-runtime.js';
 import { claudeSubscriptionHeaders, openAiCodexHeaders } from './subscription-auth.js';
 
 export interface ModelFactoryInput {
@@ -34,7 +34,8 @@ export interface ModelFactoryInput {
   apiKey: string;
   modelId: string;
   fetch?: typeof globalThis.fetch;
-  kimiOpenAiTransportState?: KimiOpenAiTransportState;
+  resolvedRuntime?: ResolvedModelRuntime;
+  openAiChatReasoningTransportState?: OpenAiChatReasoningTransportState;
   openAiResponsesTransportState?: OpenAiResponsesTransportState;
 }
 
@@ -45,10 +46,12 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
     apiKey,
     modelId,
     fetch,
-    kimiOpenAiTransportState,
+    resolvedRuntime,
+    openAiChatReasoningTransportState,
     openAiResponsesTransportState,
   } = input;
-  const { adapter, baseUrl: baseURL, apiProtocol } = resolveModelRuntime(connection, modelId);
+  const runtime = resolvedRuntime ?? resolveModelRuntime(connection, modelId);
+  const { adapter, baseUrl: baseURL, wire, reasoningReplay } = runtime;
 
   if (adapter.kind === 'google' && adapter.normalizeBaseUrl === false) {
     return createGoogle({ apiKey, baseURL, fetch }).chat(modelId);
@@ -80,10 +83,10 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
       }).responses(modelId);
 
     case 'github-copilot': {
-      if (apiProtocol === 'openai-responses') {
+      if (wire === 'openai-responses') {
         return createOpenAI({ apiKey, baseURL, fetch }).responses(modelId);
       }
-      if (apiProtocol === 'anthropic-messages') {
+      if (wire === 'anthropic-messages') {
         return createAnthropic({
           authToken: apiKey,
           baseURL: anthropicV1BaseUrl(baseURL),
@@ -107,15 +110,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
         baseURL,
         fetch: openAiResponsesTransportState?.wrapFetch(fetch ?? globalThis.fetch) ?? fetch,
       });
-      // Routing is declaration-driven via the ModelInfo.apiProtocol seam: an
-      // account-declared protocol wins (mirrors the github-copilot case above);
-      // otherwise the model's declared OpenAI-adapter protocol decides. gpt-5*
-      // families are Responses-only; everything else uses Chat Completions.
-      const apiProtocol =
-        adapter.apiProtocol ??
-        connection.models?.find((model) => model.id === modelId)?.apiProtocol ??
-        openAiAdapterApiProtocol(modelId, connection.providerType);
-      return apiProtocol === 'openai-responses' ? openai.responses(modelId) : openai.chat(modelId);
+      return wire === 'openai-responses' ? openai.responses(modelId) : openai.chat(modelId);
     }
 
     case 'google':
@@ -134,35 +129,42 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
           `${connection.providerType} connection ${connection.slug} requires a base URL`,
         );
       }
-      const resolvedApiProtocol =
-        apiProtocol ?? openAiAdapterApiProtocol(modelId, connection.providerType);
-      if (adapter.supportsOpenAiResponses === true && resolvedApiProtocol === 'openai-responses') {
+      if (wire === 'openai-responses') {
         return createOpenAI({ apiKey, baseURL, fetch }).responses(modelId);
       }
-      const kimiTransport =
-        connection.providerType === 'kimi-coding-plan' && apiProtocol === 'openai-chat'
-          ? createKimiOpenAiTransport(fetch ?? globalThis.fetch, kimiOpenAiTransportState)
+      const reasoningTransport =
+        reasoningReplay.kind === 'openai-chat-plaintext'
+          ? createOpenAiChatReasoningTransport(
+              fetch ?? globalThis.fetch,
+              openAiChatReasoningTransportState ??
+                createOpenAiChatReasoningTransportState(reasoningReplay.requestField),
+              connection.providerType === 'kimi-coding-plan',
+            )
+          : undefined;
+      const transformRequestBody = reasoningTransport
+        ? adapter.replayAssistantReasoningDetails
+          ? composeRequestTransforms(
+              reasoningTransport.transformRequestBody,
+              replayAssistantReasoning('reasoning', true),
+            )
+          : reasoningTransport.transformRequestBody
+        : adapter.replayAssistantReasoningAs
+          ? replayAssistantReasoning(
+              adapter.replayAssistantReasoningAs,
+              adapter.replayAssistantReasoningDetails === true,
+            )
           : undefined;
       const model = createOpenAICompatible({
         name: openAiCompatibleProviderOptionsName(adapter, connection),
         apiKey,
         baseURL,
         includeUsage: adapter.includeUsage,
-        ...(kimiTransport
-          ? { fetch: kimiTransport.fetch }
+        ...(reasoningTransport
+          ? { fetch: reasoningTransport.fetch }
           : adapter.passFetch || fetch
             ? { fetch }
             : {}),
-        ...(kimiTransport
-          ? { transformRequestBody: kimiTransport.transformRequestBody }
-          : adapter.replayAssistantReasoningAs
-            ? {
-                transformRequestBody: replayAssistantReasoning(
-                  adapter.replayAssistantReasoningAs,
-                  adapter.replayAssistantReasoningDetails === true,
-                ),
-              }
-            : {}),
+        ...(transformRequestBody ? { transformRequestBody } : {}),
         ...(adapter.replayAssistantReasoningDetails
           ? { metadataExtractor: reasoningDetailsMetadataExtractor() }
           : {}),
@@ -170,6 +172,13 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
       return adapter.replayAssistantReasoningDetails ? attachReasoningDetails(model) : model;
     }
   }
+}
+
+function composeRequestTransforms(
+  first: (body: Record<string, unknown>) => Record<string, unknown>,
+  second: (body: Record<string, unknown>) => Record<string, unknown>,
+) {
+  return (body: Record<string, unknown>) => second(first(body));
 }
 
 function replayAssistantReasoning(field: 'reasoning', replayDetails: boolean) {

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -132,39 +132,28 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
       if (wire === 'openai-responses') {
         return createOpenAI({ apiKey, baseURL, fetch }).responses(modelId);
       }
-      const reasoningTransport =
-        reasoningReplay.kind === 'openai-chat-plaintext'
-          ? createOpenAiChatReasoningTransport(
-              fetch ?? globalThis.fetch,
-              openAiChatReasoningTransportState ??
-                createOpenAiChatReasoningTransportState(reasoningReplay.requestField),
-              connection.providerType === 'kimi-coding-plan',
-            )
-          : undefined;
-      const transformRequestBody = reasoningTransport
-        ? adapter.replayAssistantReasoningDetails
-          ? composeRequestTransforms(
-              reasoningTransport.transformRequestBody,
-              replayAssistantReasoning('reasoning', true),
-            )
-          : reasoningTransport.transformRequestBody
-        : adapter.replayAssistantReasoningAs
-          ? replayAssistantReasoning(
-              adapter.replayAssistantReasoningAs,
-              adapter.replayAssistantReasoningDetails === true,
-            )
-          : undefined;
+      if (reasoningReplay.kind !== 'openai-chat-plaintext') {
+        throw new Error('OpenAI-compatible Chat wire requires plaintext reasoning replay');
+      }
+      const reasoningTransport = createOpenAiChatReasoningTransport(
+        fetch ?? globalThis.fetch,
+        openAiChatReasoningTransportState ??
+          createOpenAiChatReasoningTransportState(reasoningReplay.requestField),
+        connection.providerType === 'kimi-coding-plan',
+      );
+      const transformRequestBody = adapter.replayAssistantReasoningDetails
+        ? composeRequestTransforms(
+            reasoningTransport.transformRequestBody,
+            replayAssistantReasoning('reasoning', true),
+          )
+        : reasoningTransport.transformRequestBody;
       const model = createOpenAICompatible({
         name: openAiCompatibleProviderOptionsName(adapter, connection),
         apiKey,
         baseURL,
         includeUsage: adapter.includeUsage,
-        ...(reasoningTransport
-          ? { fetch: reasoningTransport.fetch }
-          : adapter.passFetch || fetch
-            ? { fetch }
-            : {}),
-        ...(transformRequestBody ? { transformRequestBody } : {}),
+        fetch: reasoningTransport.fetch,
+        transformRequestBody,
         ...(adapter.replayAssistantReasoningDetails
           ? { metadataExtractor: reasoningDetailsMetadataExtractor() }
           : {}),

--- a/packages/runtime/src/model-runtime.ts
+++ b/packages/runtime/src/model-runtime.ts
@@ -5,13 +5,31 @@ import {
   type ProviderRuntimeAdapter,
   type ProviderType,
 } from '@maka/core/llm-connections';
-import { lookupModelProviderOverride } from '@maka/core/model-metadata';
+import { lookupModelProviderOverride, openAiAdapterApiProtocol } from '@maka/core/model-metadata';
+
+export type ModelRuntimeWire =
+  | 'anthropic-messages'
+  | 'openai-chat'
+  | 'openai-responses'
+  | 'google-generate'
+  | 'cohere-v2'
+  | 'unavailable';
+
+export type ReasoningReplayContract =
+  | { kind: 'none' }
+  | { kind: 'anthropic-signed' }
+  | { kind: 'openai-chat-plaintext'; requestField: 'observed' | 'reasoning' }
+  | { kind: 'openai-responses-item' };
 
 export interface ResolvedModelRuntime {
   adapter: ProviderRuntimeAdapter;
   baseUrl: string;
   /** Account-advertised request wire for adapters that route per model. */
   apiProtocol?: ModelInfo['apiProtocol'];
+  /** Effective wire after account, adapter, and model defaults are resolved. */
+  wire: ModelRuntimeWire;
+  /** Durable reasoning replay semantics carried by that wire. */
+  reasoningReplay: ReasoningReplayContract;
 }
 
 export interface ModelRuntimeConnection {
@@ -60,6 +78,7 @@ export function resolveModelRuntime(
   const resolvedBaseUrl = configuredBaseUrl
     ? effectiveBaseUrl(connection)
     : (override?.api ?? effectiveBaseUrl(connection));
+  const wire = resolveModelRuntimeWire(connection.providerType, modelId, adapter, apiProtocol);
   return {
     adapter,
     baseUrl:
@@ -67,7 +86,71 @@ export function resolveModelRuntime(
         ? kimiOpenAiBaseUrl(resolvedBaseUrl)
         : resolvedBaseUrl,
     ...(apiProtocol ? { apiProtocol } : {}),
+    wire,
+    reasoningReplay: reasoningReplayContract(adapter, wire),
   };
+}
+
+function resolveModelRuntimeWire(
+  providerType: ProviderType,
+  modelId: string,
+  adapter: ProviderRuntimeAdapter,
+  apiProtocol: ModelInfo['apiProtocol'] | undefined,
+): ModelRuntimeWire {
+  switch (adapter.kind) {
+    case 'anthropic':
+    case 'claude-subscription':
+      return 'anthropic-messages';
+    case 'openai-codex':
+      return 'openai-responses';
+    case 'github-copilot':
+      return apiProtocol === 'anthropic-messages'
+        ? 'anthropic-messages'
+        : apiProtocol === 'openai-responses'
+          ? 'openai-responses'
+          : 'openai-chat';
+    case 'openai':
+      return (adapter.apiProtocol ??
+        apiProtocol ??
+        openAiAdapterApiProtocol(modelId, providerType)) === 'openai-responses'
+        ? 'openai-responses'
+        : 'openai-chat';
+    case 'openai-compatible':
+      return adapter.supportsOpenAiResponses === true &&
+        (apiProtocol ?? openAiAdapterApiProtocol(modelId, providerType)) === 'openai-responses'
+        ? 'openai-responses'
+        : 'openai-chat';
+    case 'google':
+      return 'google-generate';
+    case 'cohere':
+      return 'cohere-v2';
+    case 'unavailable':
+      return 'unavailable';
+  }
+}
+
+function reasoningReplayContract(
+  adapter: ProviderRuntimeAdapter,
+  wire: ModelRuntimeWire,
+): ReasoningReplayContract {
+  switch (wire) {
+    case 'anthropic-messages':
+      return { kind: 'anthropic-signed' };
+    case 'openai-responses':
+      return { kind: 'openai-responses-item' };
+    case 'openai-chat':
+      return adapter.kind === 'openai-compatible'
+        ? {
+            kind: 'openai-chat-plaintext',
+            requestField:
+              adapter.replayAssistantReasoningAs === 'reasoning' ? 'reasoning' : 'observed',
+          }
+        : { kind: 'none' };
+    case 'google-generate':
+    case 'cohere-v2':
+    case 'unavailable':
+      return { kind: 'none' };
+  }
 }
 
 function kimiOpenAiBaseUrl(baseUrl: string): string {

--- a/packages/runtime/src/model-runtime.ts
+++ b/packages/runtime/src/model-runtime.ts
@@ -69,7 +69,6 @@ export function resolveModelRuntime(
           kind: 'openai-compatible',
           name: 'provider',
           includeUsage: true,
-          passFetch: true,
         } as const)
       : override
         ? runtimeAdapterOverride(override.npm)

--- a/packages/runtime/src/openai-chat-reasoning-transport.ts
+++ b/packages/runtime/src/openai-chat-reasoning-transport.ts
@@ -1,65 +1,77 @@
-interface KimiOpenAiTransport {
+export interface OpenAiChatReasoningTransport {
   fetch: typeof globalThis.fetch;
   transformRequestBody: (body: Record<string, unknown>) => Record<string, unknown>;
 }
 
-export type KimiReasoningField = 'reasoning_content' | 'reasoning';
+export type OpenAiChatReasoningField = 'reasoning_content' | 'reasoning';
 
-const EMPTY_REASONING_MARKER = '\0MAKA_KIMI_EMPTY_REASONING\0';
+const EMPTY_REASONING_MARKER = '\0MAKA_OPENAI_CHAT_EMPTY_REASONING\0';
 
-export interface KimiOpenAiTransportState {
-  reasoningField: KimiReasoningField;
+export interface OpenAiChatReasoningTransportState {
+  reasoningField: OpenAiChatReasoningField;
+  requestField: 'observed' | 'reasoning';
 }
 
 const MAKA_PROVIDER_OPTIONS_NAMESPACE = 'maka';
 
-export function kimiReasoningFieldProviderOptions(
-  field: KimiReasoningField,
+export function openAiChatReasoningFieldProviderOptions(
+  field: OpenAiChatReasoningField,
 ): Record<string, Record<string, string>> {
-  return { [MAKA_PROVIDER_OPTIONS_NAMESPACE]: { kimiReasoningField: field } };
+  return { [MAKA_PROVIDER_OPTIONS_NAMESPACE]: { openAiChatReasoningField: field } };
 }
 
-export function kimiReasoningFieldFromProviderOptions(
+export function openAiChatReasoningFieldFromProviderOptions(
   providerOptions: Record<string, unknown> | undefined,
-): KimiReasoningField | undefined {
+): OpenAiChatReasoningField | undefined {
   const maka = providerOptions?.[MAKA_PROVIDER_OPTIONS_NAMESPACE];
   if (!isRecord(maka)) return undefined;
-  return maka.kimiReasoningField === 'reasoning' || maka.kimiReasoningField === 'reasoning_content'
-    ? maka.kimiReasoningField
-    : undefined;
+  const field = maka.openAiChatReasoningField ?? maka.kimiReasoningField;
+  return field === 'reasoning' || field === 'reasoning_content' ? field : undefined;
 }
 
-export function createKimiOpenAiTransportState(): KimiOpenAiTransportState {
-  return { reasoningField: 'reasoning_content' };
+export function createOpenAiChatReasoningTransportState(
+  requestField: OpenAiChatReasoningTransportState['requestField'] = 'observed',
+): OpenAiChatReasoningTransportState {
+  return { reasoningField: 'reasoning_content', requestField };
 }
 
-export function restoreKimiEmptyReasoning(text: string): string {
+export function restoreOpenAiChatEmptyReasoning(text: string): string {
   return text === EMPTY_REASONING_MARKER ? '' : text;
 }
 
-export function createKimiOpenAiTransport(
+export function createOpenAiChatReasoningTransport(
   fetchImpl: typeof globalThis.fetch = globalThis.fetch,
-  state: KimiOpenAiTransportState = createKimiOpenAiTransportState(),
-): KimiOpenAiTransport {
+  state: OpenAiChatReasoningTransportState = createOpenAiChatReasoningTransportState(),
+  normalizeUsage = false,
+): OpenAiChatReasoningTransport {
   return {
     fetch: async (input, init) =>
-      normalizeKimiOpenAiResponse(await fetchImpl(input, init), (observed) => {
-        state.reasoningField = observed;
-      }),
-    transformRequestBody: (body) => replayAssistantReasoning(body, state.reasoningField),
+      normalizeOpenAiChatReasoningResponse(
+        await fetchImpl(input, init),
+        (observed) => {
+          state.reasoningField = observed;
+        },
+        normalizeUsage,
+      ),
+    transformRequestBody: (body) =>
+      replayAssistantReasoning(
+        body,
+        state.requestField === 'reasoning' ? 'reasoning' : state.reasoningField,
+      ),
   };
 }
 
-async function normalizeKimiOpenAiResponse(
+async function normalizeOpenAiChatReasoningResponse(
   response: Response,
-  observeReasoning: (field: KimiReasoningField) => void,
+  observeReasoning: (field: OpenAiChatReasoningField) => void,
+  normalizeUsage: boolean,
 ): Promise<Response> {
   if (!response.ok) return response;
   const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
   if (contentType.includes('text/event-stream') && response.body) {
     return responseWithBody(
       response,
-      response.body.pipeThrough(kimiSseNormalizer(observeReasoning)),
+      response.body.pipeThrough(openAiChatSseNormalizer(observeReasoning, normalizeUsage)),
     );
   }
   if (contentType.includes('application/json')) {
@@ -72,14 +84,15 @@ async function normalizeKimiOpenAiResponse(
     }
     return responseWithBody(
       response,
-      JSON.stringify(normalizeKimiPayload(parsed, observeReasoning)),
+      JSON.stringify(normalizeOpenAiChatPayload(parsed, observeReasoning, normalizeUsage)),
     );
   }
   return response;
 }
 
-function kimiSseNormalizer(
-  observeReasoning: (field: KimiReasoningField) => void,
+function openAiChatSseNormalizer(
+  observeReasoning: (field: OpenAiChatReasoningField) => void,
+  normalizeUsage: boolean,
 ): TransformStream<Uint8Array, Uint8Array> {
   const decoder = new TextDecoder();
   const encoder = new TextEncoder();
@@ -90,7 +103,9 @@ function kimiSseNormalizer(
       let newline = buffered.indexOf('\n');
       while (newline >= 0) {
         controller.enqueue(
-          encoder.encode(normalizeSseLine(buffered.slice(0, newline + 1), observeReasoning)),
+          encoder.encode(
+            normalizeSseLine(buffered.slice(0, newline + 1), observeReasoning, normalizeUsage),
+          ),
         );
         buffered = buffered.slice(newline + 1);
         newline = buffered.indexOf('\n');
@@ -99,7 +114,9 @@ function kimiSseNormalizer(
     flush(controller) {
       buffered += decoder.decode();
       if (buffered) {
-        controller.enqueue(encoder.encode(normalizeSseLine(buffered, observeReasoning)));
+        controller.enqueue(
+          encoder.encode(normalizeSseLine(buffered, observeReasoning, normalizeUsage)),
+        );
       }
     },
   });
@@ -107,25 +124,30 @@ function kimiSseNormalizer(
 
 function normalizeSseLine(
   line: string,
-  observeReasoning: (field: KimiReasoningField) => void,
+  observeReasoning: (field: OpenAiChatReasoningField) => void,
+  normalizeUsage: boolean,
 ): string {
   const newline = line.endsWith('\r\n') ? '\r\n' : line.endsWith('\n') ? '\n' : '';
   const body = newline ? line.slice(0, -newline.length) : line;
   const match = /^(\s*data:\s*)(.*)$/.exec(body);
   if (!match || match[2] === '[DONE]') return line;
   try {
-    return `${match[1]}${JSON.stringify(normalizeKimiPayload(JSON.parse(match[2]!), observeReasoning))}${newline}`;
+    return `${match[1]}${JSON.stringify(
+      normalizeOpenAiChatPayload(JSON.parse(match[2]!), observeReasoning, normalizeUsage),
+    )}${newline}`;
   } catch {
     return line;
   }
 }
 
-function normalizeKimiPayload(
+function normalizeOpenAiChatPayload(
   value: unknown,
-  observeReasoning: (field: KimiReasoningField) => void,
+  observeReasoning: (field: OpenAiChatReasoningField) => void,
+  normalizeUsage: boolean,
 ): unknown {
   if (!isRecord(value)) return value;
-  const normalizedValue = normalizeKimiReasoningFields(value, observeReasoning);
+  const normalizedValue = normalizeOpenAiChatReasoningFields(value, observeReasoning);
+  if (!normalizeUsage) return normalizedValue;
   const nestedUsage = Array.isArray(normalizedValue.choices)
     ? normalizedValue.choices.find((choice) => isRecord(choice) && isRecord(choice.usage))
     : undefined;
@@ -141,9 +163,9 @@ function normalizeKimiPayload(
     : { ...normalizedValue, usage: normalizedUsage };
 }
 
-function normalizeKimiReasoningFields(
+function normalizeOpenAiChatReasoningFields(
   payload: Record<string, unknown>,
-  observe: (field: KimiReasoningField) => void,
+  observe: (field: OpenAiChatReasoningField) => void,
 ): Record<string, unknown> {
   if (!Array.isArray(payload.choices)) return payload;
   let changed = false;
@@ -175,14 +197,14 @@ function normalizeKimiReasoningFields(
 
 function replayAssistantReasoning(
   body: Record<string, unknown>,
-  field: KimiReasoningField,
+  field: OpenAiChatReasoningField,
 ): Record<string, unknown> {
   if (!Array.isArray(body.messages)) return body;
   let changed = false;
   const messages = body.messages.map((value) => {
     if (!isRecord(value) || value.role !== 'assistant') return value;
     if (typeof value.reasoning_content !== 'string') return value;
-    const restoredReasoning = restoreKimiEmptyReasoning(value.reasoning_content);
+    const restoredReasoning = restoreOpenAiChatEmptyReasoning(value.reasoning_content);
     if (field === 'reasoning_content') {
       if (restoredReasoning === value.reasoning_content) return value;
       changed = true;

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -5,7 +5,6 @@ import {
   type ConnectionTestResult,
   type LlmConnection,
 } from '@maka/core/llm-connections';
-import { openAiAdapterApiProtocol } from '@maka/core/model-metadata';
 import { anthropicV1Url, googleApiUrl } from './provider-urls.js';
 import { resolveModelRuntime } from './model-runtime.js';
 import { claudeSubscriptionHeaders } from './subscription-auth.js';
@@ -188,24 +187,22 @@ async function testConnectionModel(
   t0: number,
   timeoutMs = CONNECTION_TEST_TIMEOUT_MS,
 ): Promise<ConnectionTestResult> {
-  const { adapter, baseUrl, apiProtocol } = resolveModelRuntime(connection, testModel);
+  const { adapter, baseUrl, wire } = resolveModelRuntime(connection, testModel);
 
   switch (adapter.kind) {
     case 'anthropic':
     case 'claude-subscription':
       return await probeAnthropic(connection, baseUrl, secret, testModel, t0, fetchFn);
-    case 'openai': {
-      const resolvedApiProtocol =
-        adapter.apiProtocol ??
-        apiProtocol ??
-        openAiAdapterApiProtocol(testModel, connection.providerType);
-      return resolvedApiProtocol === 'openai-responses'
+    case 'openai':
+      return wire === 'openai-responses'
         ? await probeOpenAIResponses(baseUrl, secret, testModel, t0, fetchFn)
         : await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn, timeoutMs);
-    }
     case 'openai-codex':
-    case 'openai-compatible':
       return await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn, timeoutMs);
+    case 'openai-compatible':
+      return wire === 'openai-responses'
+        ? await probeOpenAIResponses(baseUrl, secret, testModel, t0, fetchFn)
+        : await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn, timeoutMs);
     case 'github-copilot':
       return await probeGitHubCopilot(baseUrl, secret, testModel, t0, fetchFn);
     case 'google':


### PR DESCRIPTION
## Summary

- resolve each model runtime wire and reasoning replay contract once, then share that decision across model construction, execution, and connection probes
- generalize OpenAI Chat reasoning capture/replay from Kimi to compatible providers while preserving the observed `reasoning` or `reasoning_content` field and legacy persisted metadata
- keep Anthropic signed thinking, OpenAI Responses items/continuation, Gemini metadata, and structured `reasoning_details` on their existing protocol-specific paths

Closes #2241

## Verification

- `npm --workspace @maka/runtime test` (3203 tests, 0 failures, 9 skipped)
- `npm run lint`
- `npm run format:check`
- focused durable DeepSeek Chat replay, shared runtime-contract, and DeepSeek Responses probe tests
- `npm run build` and `npm run typecheck` reach existing desktop protocol type errors also reproducible on the unchanged `main` checkout; all preceding affected workspaces build/typecheck successfully