### PR TITLE
fix(models): expose thinking levels for discovered Codex OAuth models

### DIFF
--- a/packages/core/src/__tests__/model-thinking.test.ts
+++ b/packages/core/src/__tests__/model-thinking.test.ts
@@ -62,6 +62,10 @@ test('account access paths inherit thinking metadata from their provider', () =>
     thinkingOptionsForModel('claude-subscription', 'claude-opus-4-8'),
     thinkingOptionsForModel('anthropic', 'claude-opus-4-8'),
   );
+  assert.deepEqual(
+    thinkingOptionsForModel('openai-codex', 'gpt-5.6-luna'),
+    thinkingOptionsForModel('openai', 'gpt-5.6-luna'),
+  );
 });
 
 test('provider-scoped model ids do not leak metadata to ambiguous ids', () => {

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -29,14 +29,20 @@ const generatedModelProviderOverrides: Partial<
   Record<ProviderType, Record<string, { npm: string; api?: string }>>
 > = GENERATED_MODELS_DEV_MODEL_PROVIDER_OVERRIDES;
 
+/** Access paths that serve a canonical provider's model catalog. */
+const GENERATED_METADATA_PROVIDER_ALIASES: Partial<Record<ProviderType, ProviderType>> = {
+  'xai-oauth': 'xai',
+  'opencode-free': 'opencode',
+  'openai-codex': 'openai',
+};
+
+function generatedMetadataProviderType(providerType: ProviderType): ProviderType {
+  return GENERATED_METADATA_PROVIDER_ALIASES[providerType] ?? providerType;
+}
+
 export function lookupModelMetadata(providerType: ProviderType, modelId: string): ModelMetadata {
   const id = modelId.trim();
-  const metadataProviderType =
-    providerType === 'xai-oauth'
-      ? 'xai'
-      : providerType === 'opencode-free'
-        ? 'opencode'
-        : providerType;
+  const metadataProviderType = generatedMetadataProviderType(providerType);
   const generated = generatedMetadata[metadataProviderType]?.[id];
   const override =
     STATIC_MODEL_METADATA[providerType]?.[id] ??
@@ -64,12 +70,7 @@ export function lookupModelMetadata(providerType: ProviderType, modelId: string)
  * the declaration-to-wire invariant cannot silently shrink.
  */
 export function modelMetadataIdsForProvider(providerType: ProviderType): string[] {
-  const metadataProviderType =
-    providerType === 'xai-oauth'
-      ? 'xai'
-      : providerType === 'opencode-free'
-        ? 'opencode'
-        : providerType;
+  const metadataProviderType = generatedMetadataProviderType(providerType);
   return Array.from(
     new Set([
       ...Object.keys(generatedMetadata[metadataProviderType] ?? {}),


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Inherit canonical OpenAI model metadata for ChatGPT/Codex OAuth models when no access-path override exists.
- Preserve existing OAuth-specific overrides while enabling thinking controls for dynamically discovered models such as GPT-5.6 Luna and Terra.
- Cover the access-path inheritance boundary without duplicating the existing model-to-wire contract suite.

## Validation

- Core model-thinking regression: passed
- Runtime all-model thinking wire contract: passed
- Repository build: passed

</details>

<details>
<summary>中文</summary>

## 概要

- 当 ChatGPT/Codex OAuth 模型没有访问路径专用覆盖时，继承标准 OpenAI 模型元数据。
- 保留现有 OAuth 专用覆盖，同时为 GPT-5.6 Luna、Terra 等动态发现的模型启用思考程度控制。
- 仅覆盖访问路径继承边界，不重复既有的模型到 wire contract 测试。

## 验证

- Core 模型思考回归测试：通过
- Runtime 全模型思考 wire contract：通过
- 仓库整体构建：通过

</details>