### PR TITLE
fix(desktop): complete macOS quit lifecycle

### DIFF
--- a/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
@@ -23,6 +23,36 @@ describe('app quit coordinator', () => {
     assert.equal(coordinator.getWindowCreationSignal(), windowCreationSignal);
   });
 
+  it('keeps quit prevented until it resumes in a fresh event-loop turn', async () => {
+    let resumeQuitCount = 0;
+    let preventedCount = 0;
+    const coordinator = createAppQuitCoordinator({
+      cleanup: async () => {},
+      focusOrCreateWindow: () => {},
+      onCleanupError: () => {},
+      resumeQuit: () => {
+        resumeQuitCount += 1;
+      },
+    });
+
+    const event = {
+      preventDefault: () => {
+        preventedCount += 1;
+      },
+    };
+    coordinator.handleBeforeQuit(event);
+    await Promise.resolve();
+    await Promise.resolve();
+    coordinator.handleBeforeQuit(event);
+
+    assert.equal(resumeQuitCount, 0);
+    assert.equal(preventedCount, 2);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.equal(resumeQuitCount, 1);
+  });
+
   it('runs async cleanup once and resumes quitting when it settles', async () => {
     let cleanupCount = 0;
     let focusOrCreateCount = 0;
@@ -60,6 +90,7 @@ describe('app quit coordinator', () => {
     releaseCleanup();
     await cleanupPending;
     await Promise.resolve();
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
     assert.equal(resumeQuitCount, 1);
 
@@ -114,6 +145,7 @@ describe('app quit coordinator', () => {
     const coordinator = createAppQuitCoordinator(deps);
 
     coordinator.handleBeforeQuit({ preventDefault: () => {} });
+    await Promise.resolve();
     await new Promise<void>((resolve) => setImmediate(resolve));
     let secondQuitPrevented = false;
     coordinator.focusOrCreateWindow();

--- a/apps/desktop/src/main/app-quit-coordinator.ts
+++ b/apps/desktop/src/main/app-quit-coordinator.ts
@@ -36,8 +36,15 @@ export function createAppQuitCoordinator(deps: AppQuitCoordinatorDeps): AppQuitC
       phase = 'cleaning';
       windowCreationAbort.abort();
       const finishCleanup = () => {
-        phase = 'ready-to-exit';
-        deps.resumeQuit();
+        // `before-quit` was cancelled inside Electron's native quit transaction.
+        // Resuming from the cleanup Promise's microtask re-enters that transaction:
+        // Electron closes the windows but emits `window-all-closed` instead of
+        // `will-quit`, leaving the macOS process alive. Start a fresh transaction
+        // only after the current event-loop turn has unwound.
+        setImmediate(() => {
+          phase = 'ready-to-exit';
+          deps.resumeQuit();
+        });
       };
       void deps.cleanup().then(finishCleanup, (error) => {
         deps.onCleanupError(error);

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -25,6 +25,7 @@ import {
   createSqlitePlanReminderStore,
 } from "@maka/storage";
 import { registerAppIpc } from "./app-ipc-main.js";
+import { createAppQuitCoordinator } from "./app-quit-coordinator.js";
 import { createAppUpdateService } from "./app-update-service.js";
 import { createAttachmentApprovalRegistry } from "./attachment-approval.js";
 import { resizeImageForAttachment } from "./attachment-resize-native.js";
@@ -577,33 +578,33 @@ function emitSessionsChanged(
 }
 
 function wireLifecycle(): void {
-  let quitting = false;
-  const focusOrCreateWindow = () => {
-    if (quitting) return;
-    if (mainWindowController.hasOpenWindows()) mainWindowController.focus();
-    else void mainWindowController.createWindow(new AbortController().signal);
-  };
+  const quitCoordinator = createAppQuitCoordinator({
+    cleanup: closeRuntimeHostDesktop,
+    focusOrCreateWindow: (signal) => {
+      if (mainWindowController.hasOpenWindows()) mainWindowController.focus();
+      else void mainWindowController.createWindow(signal);
+    },
+    onCleanupError: (error) =>
+      console.error("[runtime-host] shutdown failed:", error),
+    resumeQuit: () => app.quit(),
+  });
   installDesktopShellPresentation({
     startHidden: false,
     mainWindowController,
-    focusOrCreateWindow,
+    focusOrCreateWindow: quitCoordinator.focusOrCreateWindow,
     onIconError: (error) =>
       console.error("[icon] failed to set dock icon:", error),
   });
-  app.on("second-instance", focusOrCreateWindow);
-  app.on("activate", focusOrCreateWindow);
+  app.on("second-instance", quitCoordinator.focusOrCreateWindow);
+  app.on("activate", quitCoordinator.focusOrCreateWindow);
   app.on("window-all-closed", () => {
     native.computerUseOverlay.destroyAll();
     native.computerUsePip.destroyAll();
     if (process.platform !== "darwin") app.quit();
   });
-  app.on("before-quit", (event) => {
-    if (quitting) return;
-    event.preventDefault();
-    quitting = true;
-    void closeRuntimeHostDesktop().finally(() => app.quit());
-  });
-  void mainWindowController.createWindow(new AbortController().signal);
+  app.on("before-quit", quitCoordinator.handleBeforeQuit);
+  const initialWindowSignal = quitCoordinator.getWindowCreationSignal();
+  if (initialWindowSignal) void mainWindowController.createWindow(initialWindowSignal);
 }
 
 async function closeRuntimeHostDesktop(): Promise<void> {


### PR DESCRIPTION
## Summary

- resume Electron quit in a fresh event-loop turn after asynchronous cleanup, so macOS reaches `will-quit` instead of falling through `window-all-closed` with a live Dock process
- make the Runtime Host desktop boot reuse the canonical app quit coordinator instead of maintaining a parallel `quitting` state machine
- keep window creation aborted and repeated quit requests prevented until the fresh quit transaction begins

## Verification

- RED: coordinator regression failed on the old implementation because `resumeQuit` ran in the cleanup Promise microtask (`1 !== 0`)
- targeted lifecycle suite: 27 passed
- `npm --workspace @maka/desktop run typecheck`
- `npm run lint`
- `npm run format:check`
- live Electron 43.1.1 macOS check with a real system `Cmd+Q`: observed `window-close → will-quit`; the process exited in about 2 seconds
- broader Desktop main run: 1,726 passed; 14 unrelated environment failures (missing overlay output after a main-only build, plus Node 26 temporary-directory realpath expectations)

## Root cause

The first `before-quit` is deliberately cancelled while process resources close. The coordinator previously called `app.quit()` directly from the cleanup Promise continuation. That re-entered Electron inside the original native quit transaction: Electron closed the window but emitted `window-all-closed`, not `will-quit`, and the macOS lifecycle correctly kept the now-windowless process alive. Deferring the resumed quit with `setImmediate` starts a new native transaction after the current event-loop turn unwinds.