### PR TITLE
fix(desktop): restore computer use presentation parity

### DIFF
--- a/apps/desktop/src/main/__tests__/computer-use-pip-wiring.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-pip-wiring.test.ts
@@ -159,6 +159,28 @@ describe('picture-in-picture lifecycle wiring', () => {
     );
   });
 
+  it('the Runtime Host keeps natural completion separate from explicit Stop', async () => {
+    const source = await read('runtime-host-boot.ts');
+    const complete = /const completeComputerUseTurn = \(sessionId: string\): void => \{([\s\S]*?)\n\};/.exec(
+      source,
+    )?.[1];
+    assert.ok(complete, 'Runtime Host boot must define natural Turn completion');
+    assert.match(complete, /computerUsePip\.complete\(sessionId\)/);
+
+    const release = /const releaseComputerUseSession = \(sessionId: string\): void => \{([\s\S]*?)\n\};/.exec(
+      source,
+    )?.[1];
+    assert.ok(release, 'Runtime Host boot must define immediate Session teardown');
+    assert.match(release, /computerUsePip\.clearForSession\(sessionId\)/);
+
+    assert.match(source, /\n    completeComputerUseTurn,\n/);
+    assert.match(
+      source,
+      /computerUsePip\.setStopHandler\(stopComputerUseSession\);[\s\S]*computerUseStatusItem\.setStopHandler\(stopComputerUseSession\);/,
+      'PiP and status Stop must share the candidate Stop authority',
+    );
+  });
+
   it('a turn ending retires the mirror', async () => {
     // The real call, not the source text: this module has no Electron in it.
     // The mirror used to be cleared only on stop, archive and delete, so it

--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -208,6 +208,7 @@ test('drives the renderer Session catalog facade through real UDS framing', asyn
       resolveBotCreateTarget: async () => ({ cwd: base }),
       emitSessionsChanged: (reason, sessionId) => changes.push({ reason, sessionId }),
       emitModeChanged() {},
+      completeComputerUseTurn() {},
       newId: () => 'session-ipc',
     });
     assert.equal(started.kind, 'ready');
@@ -307,6 +308,7 @@ test('drives the renderer Session execution facade through real UDS framing', as
         emitSessionsChanged() {},
         stat: async () => ({ size: 0 }),
         resizeImage: async (bytes) => bytes,
+        beforeStop() {},
         newId: () => 'turn-1',
       },
       ipc,

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -317,6 +317,7 @@ function deps(
     resolveBotCreateTarget: async () => ({ cwd: '/workspace' }),
     emitSessionsChanged() {},
     emitModeChanged() {},
+    completeComputerUseTurn() {},
     newId: () => 'candidate-id',
   };
 }

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
@@ -25,9 +25,11 @@ test('replaces a disconnected generation without falling back to embedded Runtim
   first.disconnect();
   await eventually(() => starts === 2);
   await owner.handleBotIncomingMessage({ text: 'hello' } as BotIncomingMessage);
+  await owner.stopSession('session-1');
 
   assert.equal(first.botMessages, 0);
   assert.equal(second.botMessages, 1);
+  assert.deepEqual(second.stoppedSessions, ['session-1']);
   await owner.close();
   assert.equal(second.closeCalls, 1);
 });
@@ -62,6 +64,7 @@ function candidateHarness() {
   });
   let closeCalls = 0;
   let botMessages = 0;
+  const stoppedSessions: string[] = [];
   const candidate = {
     closed,
     client: {},
@@ -74,6 +77,9 @@ function candidateHarness() {
       closeCalls += 1;
       resolveClosed?.();
     },
+    async stopSession(sessionId: string) {
+      stoppedSessions.push(sessionId);
+    },
   } as unknown as DesktopRuntimeHostCandidate;
   return {
     candidate,
@@ -83,6 +89,9 @@ function candidateHarness() {
     },
     get botMessages() {
       return botMessages;
+    },
+    get stoppedSessions() {
+      return stoppedSessions;
     },
   };
 }

--- a/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
@@ -134,6 +134,38 @@ test('validates before admission and invokes the exact offered tool with Host co
   });
 });
 
+test('watches Computer Use turns without widening Browser lifecycle', async () => {
+  const usedSessions: string[] = [];
+  const computerUseTurns: Array<[string, string]> = [];
+  const provider = createDesktopNativeCapabilityProvider(
+    {
+      browserTools: [tool('browser_snapshot', z.object({}), async () => 'snapshot')],
+      releaseBrowserSession() {},
+      computerUseTools: computerTools(async () => ({ text: 'observed' })),
+      releaseComputerUseSession() {},
+    },
+    {
+      onSessionUsed: (sessionId) => usedSessions.push(sessionId),
+      onComputerUseTurnUsed: (sessionId, turnId) =>
+        computerUseTurns.push([sessionId, turnId]),
+    },
+  );
+
+  await call(
+    provider,
+    capabilityFrame({ toolName: 'browser_snapshot', arguments: {} }),
+  );
+  assert.deepEqual(usedSessions, ['session-1']);
+  assert.deepEqual(computerUseTurns, []);
+
+  await call(
+    provider,
+    computerFrame({ sessionId: 'session-2', turnId: 'turn-2' }),
+  );
+  assert.deepEqual(usedSessions, ['session-1', 'session-2']);
+  assert.deepEqual(computerUseTurns, [['session-2', 'turn-2']]);
+});
+
 test('projects Computer Use screenshots and releases all native resources for a Session', async () => {
   const browserReleased: string[] = [];
   const computerReleased: string[] = [];

--- a/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
@@ -54,6 +54,7 @@ test("advances the Host read marker through the last visible message", async () 
       emitSessionsChanged() {},
       stat: async () => ({ size: 0 }),
       resizeImage: async (bytes) => bytes,
+      beforeStop() {},
     },
     ipc,
   );
@@ -110,6 +111,7 @@ test("sends canonical content and uploads owned Attachment bytes through the Hos
         changes.push({ reason, sessionId, ...extra }),
       stat: async () => ({ size: 0 }),
       resizeImage: async (bytes) => bytes,
+      beforeStop() {},
       newId: () => "turn-1",
     },
     ipc,
@@ -213,6 +215,7 @@ test("uploads a selected workspace file as a Host-owned Session Artifact", async
       emitSessionsChanged() {},
       stat: async () => ({ size: 5 }),
       resizeImage: async (bytes) => bytes,
+      beforeStop() {},
       newId: () => "turn-1",
     },
     ipc,
@@ -257,6 +260,7 @@ test("forwards explicit Skill invocation to the Host-owned Turn admission", asyn
       emitSessionsChanged() {},
       stat: async () => ({ size: 0 }),
       resizeImage: async (bytes) => bytes,
+      beforeStop() {},
       newId: () => "turn-skill",
     },
     ipc,
@@ -289,6 +293,7 @@ test("forwards explicit Skill invocation to the Host-owned Turn admission", asyn
 test("binds steer and stop to Host-owned queue and active Turn identities", async () => {
   const submits: unknown[] = [];
   const interrupts: unknown[] = [];
+  const stopLifecycle: string[] = [];
   let sequence = 0;
   const client = executionClient({
     submitMessage: async (input) => {
@@ -296,6 +301,7 @@ test("binds steer and stop to Host-owned queue and active Turn identities", asyn
       return { disposition: "steering", queueRevision: 2 };
     },
     interruptTurn: async (input) => {
+      stopLifecycle.push("interrupt");
       interrupts.push(input);
       return {
         queueRevision: 3,
@@ -321,6 +327,9 @@ test("binds steer and stop to Host-owned queue and active Turn identities", asyn
       emitSessionsChanged() {},
       stat: async () => ({ size: 0 }),
       resizeImage: async (bytes) => bytes,
+      beforeStop() {
+        stopLifecycle.push("teardown");
+      },
       newId: () => `id-${++sequence}`,
     },
     ipc,
@@ -333,6 +342,7 @@ test("binds steer and stop to Host-owned queue and active Turn identities", asyn
     },
   );
   await ipc.invoke("sessions:stop", "session-1");
+  assert.deepEqual(stopLifecycle, ["teardown", "interrupt"]);
 
   assert.deepEqual(submits, [
     {

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -15,6 +15,7 @@ import {
 test("joins an active Turn without losing or replaying assistant text", async () => {
   const transcript = deferred<StoredMessage[]>();
   const events = new AsyncFrameQueue();
+  const finishedTurns: Array<[string, "completed" | "abandoned"]> = [];
   let closeCount = 0;
   const handle: DesktopRuntimeHostSession = {
     snapshot: continuitySnapshot(),
@@ -28,10 +29,14 @@ test("joins an active Turn without losing or replaying assistant text", async ()
   const observer = new RuntimeHostSessionObserver({
     client: { openSession: async () => handle },
     emitSessionsChanged() {},
+    onWatchedTurnFinished: (sessionId, outcome) => {
+      finishedTurns.push([sessionId, outcome]);
+    },
     now: () => 50,
   });
   const target = eventTarget(1);
 
+  const watching = observer.watchTurn("session-1", "turn-1");
   const observing = observer.observe("session-1", "observer-1", target);
   events.push(deltaFrame(1, 5, " world"));
   transcript.resolve([
@@ -44,7 +49,7 @@ test("joins an active Turn without losing or replaying assistant text", async ()
       modelId: "test-model",
     },
   ]);
-  await observing;
+  await Promise.all([watching, observing]);
   await waitFor(() => target.events.length === 2);
 
   assert.deepEqual(
@@ -91,9 +96,189 @@ test("joins an active Turn without losing or replaying assistant text", async ()
       },
     ],
   );
+  assert.deepEqual(finishedTurns, [["session-1", "completed"]]);
 
   await observer.unobserve("observer-1");
   assert.equal(closeCount, 1);
+});
+
+test("keeps a native Turn watched without a renderer and releases it at terminal", async () => {
+  const events = new AsyncFrameQueue();
+  const finishedTurns: Array<[string, "completed" | "abandoned"]> = [];
+  let closeCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: continuitySnapshot(),
+        transcript: Promise.resolve([]),
+        events,
+        async close() {
+          closeCount += 1;
+          events.end();
+        },
+      }),
+    },
+    emitSessionsChanged() {},
+    onWatchedTurnFinished: (sessionId, outcome) => {
+      finishedTurns.push([sessionId, outcome]);
+    },
+  });
+
+  await observer.watchTurn("session-1", "turn-1");
+  events.push({
+    kind: "subscription.session_projection",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-1",
+    sequence: 1,
+    snapshot: continuitySnapshot({
+      rootTurn: {
+        sessionId: "session-1",
+        turnId: "turn-1",
+        runId: "run-1",
+        status: "completed",
+        terminalEventId: "terminal-1",
+      },
+    }),
+  });
+
+  await waitFor(() => closeCount === 1);
+  assert.deepEqual(finishedTurns, [["session-1", "completed"]]);
+  await observer.close();
+});
+
+test("does not let an older terminal projection finish a newer watched Turn", async () => {
+  const transcript = deferred<StoredMessage[]>();
+  const events = new AsyncFrameQueue();
+  const finishedTurns: Array<[string, "completed" | "abandoned"]> = [];
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: continuitySnapshot(),
+        transcript: transcript.promise,
+        events,
+        async close() {
+          events.end();
+        },
+      }),
+    },
+    emitSessionsChanged() {},
+    onWatchedTurnFinished: (sessionId, outcome) => {
+      finishedTurns.push([sessionId, outcome]);
+    },
+  });
+
+  const first = observer.watchTurn("session-1", "turn-1");
+  events.push({
+    kind: "subscription.session_projection",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-1",
+    sequence: 1,
+    snapshot: continuitySnapshot({
+      rootTurn: {
+        sessionId: "session-1",
+        turnId: "turn-1",
+        runId: "run-1",
+        status: "completed",
+        terminalEventId: "terminal-1",
+      },
+    }),
+  });
+  const second = observer.watchTurn("session-1", "turn-2");
+  events.push({
+    kind: "subscription.session_projection",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-1",
+    sequence: 2,
+    snapshot: continuitySnapshot({
+      rootTurn: {
+        sessionId: "session-1",
+        turnId: "turn-2",
+        runId: "run-2",
+        status: "running",
+      },
+    }),
+  });
+  transcript.resolve([]);
+  await Promise.all([first, second]);
+  assert.deepEqual(finishedTurns, []);
+
+  events.push({
+    kind: "subscription.session_projection",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-1",
+    sequence: 3,
+    snapshot: continuitySnapshot({
+      rootTurn: {
+        sessionId: "session-1",
+        turnId: "turn-2",
+        runId: "run-2",
+        status: "completed",
+        terminalEventId: "terminal-2",
+      },
+    }),
+  });
+
+  await waitFor(() => finishedTurns.length === 1);
+  assert.deepEqual(finishedTurns, [["session-1", "completed"]]);
+  await observer.close();
+});
+
+test("abandons a watched Turn when the initial Host subscription fails", async () => {
+  const finishedTurns: Array<[string, "completed" | "abandoned"]> = [];
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => {
+        throw new Error("Host subscription unavailable");
+      },
+    },
+    emitSessionsChanged() {},
+    onWatchedTurnFinished: (sessionId, outcome) => {
+      finishedTurns.push([sessionId, outcome]);
+    },
+  });
+
+  await assert.rejects(
+    observer.watchTurn("session-1", "turn-1"),
+    /subscription unavailable/u,
+  );
+  assert.deepEqual(finishedTurns, [["session-1", "abandoned"]]);
+  await observer.close();
+});
+
+test("abandons a watched Turn when the Session is removed", async () => {
+  const events = new AsyncFrameQueue();
+  const finishedTurns: Array<[string, "completed" | "abandoned"]> = [];
+  let closeCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: continuitySnapshot(),
+        transcript: Promise.resolve([]),
+        events,
+        async close() {
+          closeCount += 1;
+          events.end();
+        },
+      }),
+    },
+    emitSessionsChanged() {},
+    onWatchedTurnFinished: (sessionId, outcome) => {
+      finishedTurns.push([sessionId, outcome]);
+    },
+  });
+
+  await observer.watchTurn("session-1", "turn-1");
+  events.push({
+    kind: "subscription.closed",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-1",
+    sequence: 1,
+    reason: "session_removed",
+  });
+
+  await waitFor(() => closeCount === 1);
+  assert.deepEqual(finishedTurns, [["session-1", "abandoned"]]);
+  await observer.close();
 });
 
 test("shares one Host subscription and one delivery per renderer target", async () => {

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -134,6 +134,20 @@ const native = assembleDesktopNativeCapabilities({
   keepSystemAwake,
   mainWindow: mainWindowController,
 });
+const completeComputerUseTurn = (sessionId: string): void => {
+  native.computerUseOverlay.clearForSession(sessionId);
+  native.computerUsePip.complete(sessionId);
+  native.computerUseStatusItem.clearForSession(sessionId);
+  native.computerUseScreenLock.clearForSession(sessionId);
+  native.computerUseTools.clearSession(sessionId);
+};
+const releaseComputerUseSession = (sessionId: string): void => {
+  native.computerUseOverlay.clearForSession(sessionId);
+  native.computerUsePip.clearForSession(sessionId);
+  native.computerUseStatusItem.clearForSession(sessionId);
+  native.computerUseScreenLock.clearForSession(sessionId);
+  native.computerUseTools.clearSession(sessionId);
+};
 const permissionOverlay = createPermissionOverlayMain({
   resolveLocale: async () => {
     const settings = await settingsStore.get();
@@ -259,19 +273,14 @@ owner = await startRuntimeHostDesktopOwner(
             ];
       },
       oauthPresentation,
-      releaseComputerUseSession: (sessionId) => {
-        native.computerUseOverlay.clearForSession(sessionId);
-        native.computerUsePip.clearForSession(sessionId);
-        native.computerUseStatusItem.clearForSession(sessionId);
-        native.computerUseScreenLock.clearForSession(sessionId);
-        native.computerUseTools.clearSession(sessionId);
-      },
+      releaseComputerUseSession,
     },
     botRegistry,
     resolveBotCreateTarget: async () => ({ cwd: await projectRoot.current() }),
     emitSessionsChanged,
     emitModeChanged: (sessionId) =>
       emitSessionsChanged("mode-change", sessionId),
+    completeComputerUseTurn,
     sendToRenderer: (channel, payload) =>
       mainWindowController.send(channel, payload),
     onError: (error) =>
@@ -285,6 +294,13 @@ owner = await startRuntimeHostDesktopOwner(
     },
   },
 );
+const stopComputerUseSession = (sessionId: string): void => {
+  void owner
+    ?.stopSession(sessionId)
+    .catch((error) => console.error("[runtime-host] stop failed:", error));
+};
+native.computerUsePip.setStopHandler(stopComputerUseSession);
+native.computerUseStatusItem.setStopHandler(stopComputerUseSession);
 
 await planReminders.refreshTimers();
 updateService.start();

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -48,6 +48,9 @@ export interface DesktopRuntimeHostCandidateDeps {
     extra?: Pick<SessionChangedEvent, "connectionSlug" | "modelId" | "turnId">,
   ) => void;
   readonly emitModeChanged: RuntimeHostSessionDomainsIpcDeps["emitModeChanged"];
+  readonly completeComputerUseTurn: (
+    sessionId: string,
+  ) => void | Promise<void>;
   readonly sendToRenderer?: RuntimeHostSessionDomainsIpcDeps["sendToRenderer"];
   readonly onError?: RuntimeHostSessionDomainsIpcDeps["onError"];
   readonly newId?: () => string;
@@ -83,6 +86,7 @@ export interface DesktopRuntimeHostCandidate {
   readonly botIncoming: BotIncomingMainService;
   readonly client: DesktopRuntimeHostClient;
   readonly closed: Promise<void>;
+  stopSession(sessionId: string): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -97,6 +101,7 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
   readonly #closeNativeCapabilities: () => Promise<void>;
   readonly #disposeClientIpc: (() => void | Promise<void>) | undefined;
   readonly #hasRegisteredCapabilities: () => boolean;
+  readonly #stopSession: (sessionId: string) => Promise<void>;
   #closeTask: Promise<void> | undefined;
 
   constructor(input: {
@@ -108,6 +113,7 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
     disposeClientIpc: (() => void | Promise<void>) | undefined;
     connectionClosed: Promise<void>;
     hasRegisteredCapabilities: () => boolean;
+    stopSession: (sessionId: string) => Promise<void>;
   }) {
     this.#client = input.client;
     this.client = input.client;
@@ -117,6 +123,7 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
     this.#closeNativeCapabilities = input.closeNativeCapabilities;
     this.#disposeClientIpc = input.disposeClientIpc;
     this.#hasRegisteredCapabilities = input.hasRegisteredCapabilities;
+    this.#stopSession = input.stopSession;
     this.botIncoming = input.botIncoming;
     this.closed = input.connectionClosed.then(() => this.close());
   }
@@ -124,6 +131,10 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
   close(): Promise<void> {
     this.#closeTask ??= this.#close();
     return this.#closeTask;
+  }
+
+  stopSession(sessionId: string): Promise<void> {
+    return this.#stopSession(sessionId);
   }
 
   async #close(): Promise<void> {
@@ -199,19 +210,6 @@ export async function createDesktopRuntimeHostCandidate(
   const ipc = new ScopedIpcMain(deps.ipcMain);
   const providers = new Set<DesktopNativeCapabilityProvider>();
   const nativeSessionIds = new Set<string>();
-  const createNativeProvider = (): DesktopNativeCapabilityProvider => {
-    let provider: DesktopNativeCapabilityProvider;
-    provider = createDesktopNativeCapabilityProvider(
-      deps.nativeCapabilities,
-      {
-        releaseResourcesOnClose: false,
-        onSessionUsed: (sessionId) => nativeSessionIds.add(sessionId),
-        onClosed: () => providers.delete(provider),
-      },
-    );
-    providers.add(provider);
-    return provider;
-  };
   const releaseNativeResources = async (
     sessionIds: readonly string[],
   ): Promise<void> => {
@@ -265,6 +263,49 @@ export async function createDesktopRuntimeHostCandidate(
   let disposeClientIpc: (() => void | Promise<void>) | undefined;
   let capabilitiesRegistered = false;
   try {
+    const domains = registerRuntimeHostSessionDomainsIpc(
+      {
+        client,
+        emitModeChanged: deps.emitModeChanged,
+        ...(deps.sendToRenderer ? { sendToRenderer: deps.sendToRenderer } : {}),
+        ...(deps.onError ? { onError: deps.onError } : {}),
+        ...(deps.newId ? { newId: deps.newId } : {}),
+        ...(deps.now ? { now: deps.now } : {}),
+      },
+      ipc,
+    );
+    const sessionObserver = new RuntimeHostSessionObserver({
+      client,
+      emitSessionsChanged: (reason, sessionId, extra) =>
+        deps.emitSessionsChanged(reason, sessionId, extra),
+      emitSessionDomainChanged: domains.sessionDomainChanged,
+      emitAgentGraphChanged: domains.agentGraphChanged,
+      onWatchedTurnFinished: (sessionId, outcome) =>
+        outcome === "completed"
+          ? deps.completeComputerUseTurn(sessionId)
+          : deps.nativeCapabilities.releaseComputerUseSession(sessionId),
+      ...(deps.now ? { now: deps.now } : {}),
+    });
+    observer = sessionObserver;
+    const watchComputerUseTurn = (sessionId: string, turnId: string): void => {
+      void sessionObserver
+        .watchTurn(sessionId, turnId)
+        .catch((error) => deps.onError?.(error));
+    };
+    const createNativeProvider = (): DesktopNativeCapabilityProvider => {
+      let provider: DesktopNativeCapabilityProvider;
+      provider = createDesktopNativeCapabilityProvider(
+        deps.nativeCapabilities,
+        {
+          releaseResourcesOnClose: false,
+          onSessionUsed: (sessionId) => nativeSessionIds.add(sessionId),
+          onComputerUseTurnUsed: watchComputerUseTurn,
+          onClosed: () => providers.delete(provider),
+        },
+      );
+      providers.add(provider);
+      return provider;
+    };
     const nativeCapabilities = createNativeProvider();
     if (
       nativeCapabilities.offers().length > 0 ||
@@ -289,25 +330,6 @@ export async function createDesktopRuntimeHostCandidate(
         });
       return capabilityRefresh;
     };
-    const domains = registerRuntimeHostSessionDomainsIpc(
-      {
-        client,
-        emitModeChanged: deps.emitModeChanged,
-        ...(deps.sendToRenderer ? { sendToRenderer: deps.sendToRenderer } : {}),
-        ...(deps.onError ? { onError: deps.onError } : {}),
-        ...(deps.newId ? { newId: deps.newId } : {}),
-        ...(deps.now ? { now: deps.now } : {}),
-      },
-      ipc,
-    );
-    observer = new RuntimeHostSessionObserver({
-      client,
-      emitSessionsChanged: (reason, sessionId, extra) =>
-        deps.emitSessionsChanged(reason, sessionId, extra),
-      emitSessionDomainChanged: domains.sessionDomainChanged,
-      emitAgentGraphChanged: domains.agentGraphChanged,
-      ...(deps.now ? { now: deps.now } : {}),
-    });
     registerRuntimeHostSessionCatalogIpc(
       {
         client,
@@ -318,14 +340,15 @@ export async function createDesktopRuntimeHostCandidate(
       },
       ipc,
     );
-    registerRuntimeHostSessionExecutionIpc(
+    const stopSession = registerRuntimeHostSessionExecutionIpc(
       {
         client,
-        observer,
+        observer: sessionObserver,
         attachmentApprovals: deps.attachmentApprovals,
         emitSessionsChanged: deps.emitSessionsChanged,
         stat: deps.stat,
         resizeImage: deps.resizeImage,
+        beforeStop: deps.nativeCapabilities.releaseComputerUseSession,
         ...(deps.newId ? { newId: deps.newId } : {}),
       },
       ipc,
@@ -348,13 +371,14 @@ export async function createDesktopRuntimeHostCandidate(
     });
     return new DesktopRuntimeHostCandidateImpl({
       client,
-      observer,
+      observer: sessionObserver,
       ipc,
       botIncoming,
       closeNativeCapabilities,
       disposeClientIpc,
       connectionClosed: connection.closed,
       hasRegisteredCapabilities: () => capabilitiesRegistered,
+      stopSession,
     });
   } catch (error) {
     ipc.close();

--- a/apps/desktop/src/main/runtime-host-desktop-owner.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-owner.ts
@@ -11,6 +11,7 @@ const RECONNECT_DELAY_MS = 250;
 
 export interface RuntimeHostDesktopOwner {
   handleBotIncomingMessage(message: BotIncomingMessage): Promise<void>;
+  stopSession(sessionId: string): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -55,6 +56,12 @@ class RuntimeHostDesktopOwnerImpl implements RuntimeHostDesktopOwner {
     const candidate = this.#candidate;
     if (!candidate || this.#closed) return;
     await candidate.botIncoming.handleBotIncomingMessage(message);
+  }
+
+  async stopSession(sessionId: string): Promise<void> {
+    const candidate = this.#candidate;
+    if (!candidate || this.#closed) return;
+    await candidate.stopSession(sessionId);
   }
 
   close(): Promise<void> {

--- a/apps/desktop/src/main/runtime-host-native-capabilities.ts
+++ b/apps/desktop/src/main/runtime-host-native-capabilities.ts
@@ -59,6 +59,10 @@ export function createDesktopNativeCapabilityProvider(
   providerOptions: {
     readonly releaseResourcesOnClose?: boolean;
     readonly onSessionUsed?: (sessionId: string) => void;
+    readonly onComputerUseTurnUsed?: (
+      sessionId: string,
+      turnId: string,
+    ) => void;
     readonly onClosed?: () => void;
   } = {},
 ): DesktopNativeCapabilityProvider {
@@ -212,7 +216,13 @@ async function invokeNativeTool(
   binding: NativeToolBinding,
   frame: ClientCapabilityCallFrame,
   options: Parameters<NonNullable<ClientCapabilityProvider["call"]>>[1],
-  providerOptions: { readonly onSessionUsed?: (sessionId: string) => void },
+  providerOptions: {
+    readonly onSessionUsed?: (sessionId: string) => void;
+    readonly onComputerUseTurnUsed?: (
+      sessionId: string,
+      turnId: string,
+    ) => void;
+  },
   invocation: AbortController,
   usedSessionIds: Set<string>,
 ): Promise<ClientCapabilityCallResult> {
@@ -225,6 +235,9 @@ async function invokeNativeTool(
   signal.throwIfAborted();
   usedSessionIds.add(frame.sessionId);
   providerOptions.onSessionUsed?.(frame.sessionId);
+  if (frame.offerId === COMPUTER_USE_OFFER_ID) {
+    providerOptions.onComputerUseTurnUsed?.(frame.sessionId, frame.turnId);
+  }
   const output = await binding.tool.impl(args, {
     sessionId: frame.sessionId,
     turnId: frame.turnId,

--- a/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
@@ -64,6 +64,7 @@ export interface RuntimeHostSessionExecutionIpcDeps {
   ) => void;
   stat(path: string): Promise<{ size: number }>;
   resizeImage(bytes: Uint8Array): Promise<Uint8Array>;
+  beforeStop(sessionId: string): void | Promise<void>;
   newId?: () => string;
 }
 
@@ -75,8 +76,9 @@ export interface RuntimeHostSessionExecutionIpcDeps {
 export function registerRuntimeHostSessionExecutionIpc(
   deps: RuntimeHostSessionExecutionIpcDeps,
   ipcMain: Pick<IpcMain, "handle">,
-): void {
+): (sessionId: string) => Promise<void> {
   const newId = deps.newId ?? randomUUID;
+  const stopSession = createRuntimeHostSessionStop(deps, newId);
 
   ipcMain.handle(
     "sessions:observe",
@@ -203,19 +205,9 @@ export function registerRuntimeHostSessionExecutionIpc(
       return { kind: "queued" as const };
     },
   );
-  ipcMain.handle("sessions:stop", async (_event, sessionId: string) => {
-    const turn = (await deps.observer.snapshot(sessionId)).rootTurn;
-    if (!turn || isTerminalStatus(turn.status)) return;
-    await deps.client.interruptTurn({
-      sessionId,
-      interruptId: newId(),
-      turnId: turn.turnId,
-      runId: turn.runId,
-    });
-    deps.emitSessionsChanged("turn-status-change", sessionId, {
-      turnId: turn.turnId,
-    });
-  });
+  ipcMain.handle("sessions:stop", async (_event, sessionId: string) =>
+    stopSession(sessionId),
+  );
 
   ipcMain.handle(
     "sessions:respondToSandboxBoundary",
@@ -338,6 +330,30 @@ export function registerRuntimeHostSessionExecutionIpc(
       return toDesktopHostSessionSummary(revision);
     },
   );
+  return stopSession;
+}
+
+function createRuntimeHostSessionStop(
+  deps: Pick<
+    RuntimeHostSessionExecutionIpcDeps,
+    "beforeStop" | "client" | "observer" | "emitSessionsChanged"
+  >,
+  newId: () => string = randomUUID,
+): (sessionId: string) => Promise<void> {
+  return async (sessionId) => {
+    await deps.beforeStop(sessionId);
+    const turn = (await deps.observer.snapshot(sessionId)).rootTurn;
+    if (!turn || isTerminalStatus(turn.status)) return;
+    await deps.client.interruptTurn({
+      sessionId,
+      interruptId: newId(),
+      turnId: turn.turnId,
+      runId: turn.runId,
+    });
+    deps.emitSessionsChanged("turn-status-change", sessionId, {
+      turnId: turn.turnId,
+    });
+  };
 }
 
 function latestVisibleMessageId(

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -41,6 +41,10 @@ export interface RuntimeHostSessionObserverDeps {
   ) => void;
   emitSessionDomainChanged?: (change: SessionDomainChange) => void;
   emitAgentGraphChanged?: (event: AgentGraphClientChangedEvent) => void;
+  onWatchedTurnFinished?: (
+    sessionId: string,
+    outcome: "completed" | "abandoned",
+  ) => void | Promise<void>;
   now?: () => number;
 }
 
@@ -68,6 +72,7 @@ interface ObservedSessionState {
   readonly targets: Map<number, ObserverTargetGroup>;
   readonly pendingFrames: SubscriptionFrame[];
   readonly accumulators: Map<string, AssistantAccumulator>;
+  readonly watchedTurnIds: Set<string>;
   openTask: Promise<void>;
   handle?: DesktopRuntimeHostSession;
   transcript?: StoredMessage[];
@@ -100,6 +105,10 @@ export class RuntimeHostSessionObserver {
   readonly #emitAgentGraphChanged: (
     event: AgentGraphClientChangedEvent,
   ) => void;
+  readonly #onWatchedTurnFinished: (
+    sessionId: string,
+    outcome: "completed" | "abandoned",
+  ) => void | Promise<void>;
   readonly #now: () => number;
   #closed = false;
 
@@ -110,6 +119,8 @@ export class RuntimeHostSessionObserver {
       deps.emitSessionDomainChanged ?? (() => undefined);
     this.#emitAgentGraphChanged =
       deps.emitAgentGraphChanged ?? (() => undefined);
+    this.#onWatchedTurnFinished =
+      deps.onWatchedTurnFinished ?? (() => undefined);
     this.#now = deps.now ?? Date.now;
   }
 
@@ -192,6 +203,18 @@ export class RuntimeHostSessionObserver {
   async unobserve(observerId: string): Promise<void> {
     const state = this.#detachObserver(observerId);
     if (state) await this.#closeIfIdle(state);
+  }
+
+  async watchTurn(sessionId: string, turnId: string): Promise<void> {
+    this.#assertOpen();
+    const state = this.#state(sessionId);
+    state.watchedTurnIds.add(turnId);
+    await state.openTask;
+    const root = state.snapshot?.rootTurn;
+    if (root && root.turnId === turnId && isTerminalTurn(root)) {
+      this.#finishWatchedTurn(state, turnId, "completed");
+      void this.#closeIfIdle(state);
+    }
   }
 
   activeInteraction(
@@ -286,6 +309,7 @@ export class RuntimeHostSessionObserver {
       targets: new Map(),
       pendingFrames: [],
       accumulators: new Map(),
+      watchedTurnIds: new Set(),
       openTask: Promise.resolve(),
       transcriptConsumed: false,
       ready: false,
@@ -536,6 +560,8 @@ export class RuntimeHostSessionObserver {
     }
     if (root && isTerminalTurn(root) && !sameTerminalTurn(previousRoot, root)) {
       this.#publishTerminal(state, root);
+      this.#finishWatchedTurn(state, root.turnId, "completed");
+      void this.#closeIfIdle(state);
       this.#emitSessionsChanged("turn-status-change", state.sessionId, {
         turnId: root.turnId,
       });
@@ -669,14 +695,49 @@ export class RuntimeHostSessionObserver {
   }
 
   async #closeIfIdle(state: ObservedSessionState): Promise<void> {
-    if (state.targets.size > 0) return;
+    if (state.targets.size > 0 || state.watchedTurnIds.size > 0) return;
     await Promise.resolve();
-    if (state.targets.size === 0) await this.#closeState(state);
+    if (state.targets.size === 0 && state.watchedTurnIds.size === 0) {
+      await this.#closeState(state);
+    }
+  }
+
+  #finishWatchedTurn(
+    state: ObservedSessionState,
+    turnId: string,
+    outcome: "completed" | "abandoned",
+  ): void {
+    if (!state.watchedTurnIds.delete(turnId)) return;
+    if (state.watchedTurnIds.size > 0) return;
+    this.#notifyWatchedTurnFinished(state.sessionId, outcome);
+  }
+
+  #finishAllWatchedTurns(
+    state: ObservedSessionState,
+    outcome: "completed" | "abandoned",
+  ): void {
+    if (state.watchedTurnIds.size === 0) return;
+    state.watchedTurnIds.clear();
+    this.#notifyWatchedTurnFinished(state.sessionId, outcome);
+  }
+
+  #notifyWatchedTurnFinished(
+    sessionId: string,
+    outcome: "completed" | "abandoned",
+  ): void {
+    try {
+      void Promise.resolve(
+        this.#onWatchedTurnFinished(sessionId, outcome),
+      ).catch(() => undefined);
+    } catch {
+      // A watched-turn consumer cannot break Session projection or teardown.
+    }
   }
 
   async #closeState(state: ObservedSessionState): Promise<void> {
     if (!state.closing) {
       state.closing = true;
+      this.#finishAllWatchedTurns(state, "abandoned");
       if (this.#states.get(state.sessionId) === state)
         this.#states.delete(state.sessionId);
       for (const group of state.targets.values())

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -1410,6 +1410,57 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     });
   });
 
+  test('semantic action recaptures a pictureless result for presentation', async () => {
+    const captures: boolean[] = [];
+    const presented: Array<CuRunResult | undefined> = [];
+    const backend = fakeBackend() as CuDispatchBackend & {
+      observeApp: NonNullable<CuDispatchBackend['observeApp']>;
+      captureObservation: NonNullable<CuDispatchBackend['captureObservation']>;
+      runSemantic: NonNullable<CuDispatchBackend['runSemantic']>;
+    };
+    backend.observeApp = async () => observation();
+    backend.runSemantic = async () => ({
+      outcome: { ok: true, tier: 'ax', verified: true },
+      observation: observation({
+        observationId: 'pictureless-post-action',
+        screenshot: undefined,
+      }),
+    });
+    backend.captureObservation = async (input) => {
+      captures.push(input.includeScreenshot);
+      return observation({ observationId: 'presentation-frame' });
+    };
+    const [tool] = buildComputerUseTools({
+      backend,
+      overlay: {
+        onActionBegin() {},
+        onActionEnd(_action, result) {
+          presented.push(result);
+        },
+      },
+    });
+    const observed = (await tool.impl({ action: 'observe', app: 'Fixture' } as never, ctx())) as {
+      text: string;
+    };
+
+    const result = (await tool.impl(
+      {
+        action: 'click_element',
+        observation_id: JSON.parse(observed.text).observation_id,
+        element_id: '5',
+      } as never,
+      ctx(),
+    )) as { screenshot?: { base64: string; mimeType: string } };
+
+    assert.deepEqual(captures, [true]);
+    assert.deepEqual(result.screenshot, {
+      base64: 'AA==',
+      mimeType: 'image/png',
+    });
+    assert.equal(presented.length, 1);
+    assert.ok(presented[0]?.observation?.screenshot);
+  });
+
   test('semantic set_value keeps its semantic action name in the model summary', async () => {
     const backend = fakeBackend() as CuDispatchBackend & {
       observeApp: NonNullable<CuDispatchBackend['observeApp']>;

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -1204,19 +1204,31 @@ export function buildComputerUseTools(deps: {
   ): Promise<CuObservation | undefined> {
     const observationLease = state.beforeObservation();
     if (!observationLease.ok) return undefined;
-    const captured =
-      result.observation ??
-      (deps.backend.captureObservation && record.appId && record.windowId
-        ? await deps.backend.captureObservation(
-            {
-              app: record.appId,
-              windowId: record.windowId,
-              includeScreenshot: true,
-            },
-            signal,
-            context,
-          )
-        : undefined);
+    let captured = result.observation;
+    if (
+      (!captured || (!captured.screenshot && !result.screenshot)) &&
+      deps.backend.captureObservation &&
+      record.appId &&
+      record.windowId
+    ) {
+      try {
+        captured = await deps.backend.captureObservation(
+          {
+            app: record.appId,
+            windowId: record.windowId,
+            includeScreenshot: true,
+          },
+          signal,
+          context,
+        );
+      } catch (error) {
+        // A pictureless post-dispatch observation is still authoritative state
+        // for the model. The mirror is best-effort, so failing its richer
+        // recapture must not discard that state or turn a completed action into
+        // an unknown outcome.
+        if (!captured) throw error;
+      }
+    }
     const fresh =
       captured && result.screenshot && !captured.screenshot
         ? { ...captured, screenshot: result.screenshot }


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Recover a screenshot when a successful Computer Use action returns an authoritative post-action observation without an image, so the Desktop PiP receives the current frame.
- Keep Runtime Host Computer Use turns observed without a renderer, complete presentation only after the last watched turn ends, and clear abandoned or removed sessions immediately.
- Route renderer, PiP, and status-item Stop actions through one Host interrupt authority that tears down native presentation before interrupting the active turn.
- Keep Browser and other client capabilities outside the Computer Use presentation watcher while preserving their generation-level resource cleanup.

## Root cause

The semantic Computer Use backend can return a fresh post-action observation without a screenshot. The shared runtime treated any returned observation as complete and skipped its richer capture fallback, so cursor feedback appeared while the PiP had no frame to present.

The embedded Desktop owner also owned native presentation cleanup at turn end and on Stop, but the Runtime Host adapter only observed sessions for renderer subscribers and did not connect native capability use to the Host turn lifecycle. Background turns could therefore retain presentation state, and Stop controls did not share the immediate teardown behavior of the embedded path.

This change restores those contracts without expanding the wire protocol. Screenshot recovery remains in the shared Computer Use runtime, while the Desktop candidate retains Host subscriptions only for Computer Use turns and distinguishes natural completion from abandoned teardown.

Refs #2010

## Verification

- `npm --workspace @maka/desktop test` — 1746 passed
- `npm --workspace @maka/runtime run build && node --test packages/runtime/dist/__tests__/computer-use-tools.test.js` — 91 passed
- `npx biome check` on all changed files
- `git diff --check origin/main...HEAD`

</details>

<details>
<summary>中文</summary>

## 概要

- 当成功的 Computer Use 动作返回不含图片、但仍具权威性的动作后 observation 时，补抓一张截图，让 Desktop PiP 能收到当前画面。
- 即使没有 renderer，也继续观察 Runtime Host Computer Use Turn；仅在最后一个被观察的 Turn 结束后完成展示，订阅异常或 Session 删除时立即清理。
- 让 renderer、PiP 和状态栏的 Stop 共用同一个 Host 中断权威，并在中断活动 Turn 前立即撤下原生展示。
- Browser 和其他 Client Capability 不进入 Computer Use 展示 watcher，同时继续保留 generation 级资源清理。

## 根因

Computer Use 的语义后端可能返回一个新的动作后 observation，但其中不含截图。共享 Runtime 过去把任何已返回的 observation 都视为完整结果，因此跳过了带截图的增强捕获回退；最终表现为虚拟光标正常出现，但 PiP 没有画面可展示。

Embedded Desktop owner 还负责 Turn 终态和 Stop 时的原生展示清理；Runtime Host adapter 却只为 renderer subscriber 观察 Session，也没有把原生能力调用接入 Host Turn 生命周期。因此后台 Turn 可能残留展示状态，各处 Stop 控件也没有复用 embedded 路径的即时清理语义。

本次修改不扩大 wire protocol。截图恢复仍位于共享 Computer Use Runtime；Desktop candidate 只为 Computer Use Turn 保持 Host subscription，并明确区分自然完成与异常清理。

Refs #2010

## 验证

- `npm --workspace @maka/desktop test` — 1746 项通过
- `npm --workspace @maka/runtime run build && node --test packages/runtime/dist/__tests__/computer-use-tools.test.js` — 91 项通过
- 对全部改动文件运行 `npx biome check`
- `git diff --check origin/main...HEAD`

</details>