### PR TITLE
refactor(runtime): make the tool-result archive capability indivisible

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
@@ -1,3 +1,4 @@
+import { createToolResultArchiveCapability } from '@maka/runtime';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { LlmConnection, SessionHeader } from '@maka/core';
@@ -586,8 +587,7 @@ function makeFactoryDeps(
     desktopSessionSkillHosts: new Map(),
     sandboxDiagnosticsProvider: { resolve: async () => undefined },
     persistToolArtifacts: async () => {},
-    persistArchivedToolResult: async () => undefined,
-    readArchivedToolResult: async () => undefined,
+    toolResultArchive: testDesktopToolResultArchive(),
     runtimeCommitStore: undefined,
     safeSendToRenderer: () => {},
     emitSessionsChanged: () => {},
@@ -611,4 +611,12 @@ async function backendInput(
   };
   const backend = await factory(context);
   return (backend as unknown as { input: AiSdkBackendInput }).input;
+}
+
+function testDesktopToolResultArchive() {
+  return createToolResultArchiveCapability({
+    archiveToolResult: async () => undefined,
+    readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
+    readArchivedToolResultResource: async () => ({ ok: false, reason: 'not_found' }),
+  });
 }

--- a/apps/desktop/src/main/__tests__/session-stream-usage-readiness.test.ts
+++ b/apps/desktop/src/main/__tests__/session-stream-usage-readiness.test.ts
@@ -1,3 +1,4 @@
+import { createToolResultArchiveCapability } from '@maka/runtime';
 import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -80,8 +81,7 @@ test('the first Desktop backend waits for canonical telemetry readiness', async 
       toolAvailability: { economy: false, groups: [] },
       sandboxDiagnosticsProvider: createSandboxDiagnosticsProvider({ platform: 'win32' }),
       persistToolArtifacts: async () => {},
-      persistArchivedToolResult: async () => {},
-      readArchivedToolResult: async () => undefined,
+      toolResultArchive: testDesktopToolResultArchive(),
       runtimeCommitStore: undefined,
       planStore,
       safeSendToRenderer: () => {},
@@ -134,4 +134,12 @@ function factoryContext(root: string): BackendFactoryContext {
     store: { appendMessage: async () => {} } as unknown as BackendFactoryContext['store'],
     tools: [],
   };
+}
+
+function testDesktopToolResultArchive() {
+  return createToolResultArchiveCapability({
+    archiveToolResult: async () => undefined,
+    readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
+    readArchivedToolResultResource: async () => ({ ok: false, reason: 'not_found' }),
+  });
 }

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -692,9 +692,7 @@ const updateService = createAppUpdateService({
 const {
   persistToolArtifacts,
   snapshotReadImage,
-  persistArchivedToolResult,
-  readArchivedToolResult,
-  readArchivedToolResultResource,
+  toolResultArchive,
 } = createToolArtifactPersistence({ artifactStore, storeReadImage, safeSendToRenderer });
 
 const {
@@ -727,7 +725,6 @@ const {
   shellRuns,
   artifactStore,
   snapshotReadImage,
-  readArchivedToolResultResource,
   getWorkspacePrivacyContext,
   resolveDesktopSkillHost,
 });
@@ -903,8 +900,7 @@ backends.register('ai-sdk', createAiSdkBackendFactory({
   desktopSessionSkillHosts,
   sandboxDiagnosticsProvider,
   persistToolArtifacts,
-  persistArchivedToolResult,
-  readArchivedToolResult,
+  toolResultArchive,
   runtimeCommitStore: runtimePersistence.runtimeCommitStore,
   safeSendToRenderer,
   emitSessionsChanged,

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -25,8 +25,6 @@ import type {
   SessionActivityRegistry,
   SessionManager,
   ToolArtifactRecorderInput,
-  ToolResultArchiveReaderInput,
-  ToolResultArchiveRecorderInput,
   buildPricingLookup,
 } from '@maka/runtime';
 import type { createSqliteModelCallLedger } from '@maka/storage';
@@ -69,8 +67,7 @@ export interface AiSdkBackendFactoryDeps extends DesktopBackendToolSurfaceDeps {
   desktopSessionSkillHosts: Map<string, HostCapabilities>;
   sandboxDiagnosticsProvider: AssembledTools['sandboxDiagnosticsProvider'];
   persistToolArtifacts: ToolArtifactPersistence['persistToolArtifacts'];
-  persistArchivedToolResult: ToolArtifactPersistence['persistArchivedToolResult'];
-  readArchivedToolResult: ToolArtifactPersistence['readArchivedToolResult'];
+  toolResultArchive: ToolArtifactPersistence['toolResultArchive'];
   runtimeCommitStore: RuntimeCommitStore;
   safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
   emitSessionsChanged: (reason: SessionChangedReason, sessionId?: string) => void;
@@ -98,8 +95,7 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
     desktopSessionSkillHosts,
     sandboxDiagnosticsProvider,
     persistToolArtifacts,
-    persistArchivedToolResult,
-    readArchivedToolResult,
+    toolResultArchive,
     runtimeCommitStore,
     safeSendToRenderer,
     emitSessionsChanged,
@@ -329,8 +325,7 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
             : event,
         ),
       recordToolArtifacts: (event: ToolArtifactRecorderInput) => persistToolArtifacts(ctx.header.cwd, event),
-      archiveToolResult: (event: ToolResultArchiveRecorderInput) => persistArchivedToolResult(event),
-      readToolResultArchive: (event: ToolResultArchiveReaderInput) => readArchivedToolResult(event),
+      toolResultArchive,
       readAttachmentBytes: createAttachmentByteReader({ artifactStore, sessionId: ctx.sessionId }),
       ...(runtimeCommitStore
         ? { runtimeCommitSink: runtimeCommitStore }

--- a/apps/desktop/src/main/tool-artifact-persistence.ts
+++ b/apps/desktop/src/main/tool-artifact-persistence.ts
@@ -1,7 +1,9 @@
 import { readFile, realpath } from 'node:fs/promises';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { createToolResultArchiveCapability } from '@maka/runtime';
 import type {
   ToolArtifactRecorderInput,
+  ToolResultArchiveCapability,
   ToolResultArchiveReaderInput,
   ToolResultArchiveReadResult,
   ToolResultArchiveRecorderInput,
@@ -31,11 +33,11 @@ export interface ToolArtifactPersistence {
     bytes: Uint8Array;
     mimeType: string;
   }): Promise<Awaited<ReturnType<ReadImageSnapshotter>>>;
-  persistArchivedToolResult(event: ToolResultArchiveRecorderInput): Promise<{ artifactId: string }>;
-  readArchivedToolResult(event: ToolResultArchiveReaderInput): Promise<ToolResultArchiveReadResult>;
-  readArchivedToolResultResource(
-    event: ToolResultArchiveResourceReadInput,
-  ): Promise<ToolResultArchiveReadResult>;
+  /**
+   * One archive authority over the session artifact store (#2026): the writer,
+   * both readers, and the `ArchiveRead` decoder that pruned placeholders name.
+   */
+  toolResultArchive: ToolResultArchiveCapability;
 }
 
 function isInsideOrSamePath(root: string, target: string): boolean {
@@ -137,8 +139,10 @@ export function createToolArtifactPersistence(deps: ToolArtifactPersistenceDeps)
   return {
     persistToolArtifacts,
     snapshotReadImage,
-    persistArchivedToolResult,
-    readArchivedToolResult,
-    readArchivedToolResultResource,
+    toolResultArchive: createToolResultArchiveCapability({
+      archiveToolResult: persistArchivedToolResult,
+      readToolResultArchive: readArchivedToolResult,
+      readArchivedToolResultResource,
+    }),
   };
 }

--- a/apps/desktop/src/main/tool-assembly.ts
+++ b/apps/desktop/src/main/tool-assembly.ts
@@ -57,7 +57,6 @@ export interface DesktopToolAssemblyDeps {
   shellRuns: ShellRunProcessManager;
   artifactStore: ArtifactStore;
   snapshotReadImage: ToolArtifactPersistence['snapshotReadImage'];
-  readArchivedToolResultResource: ToolArtifactPersistence['readArchivedToolResultResource'];
   getWorkspacePrivacyContext: () => Promise<WorkspacePrivacyContext>;
   /**
    * The power-assertion controller, so a Computer Use run holds the machine
@@ -108,7 +107,6 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
     shellRuns,
     artifactStore,
     snapshotReadImage,
-    readArchivedToolResultResource,
     getWorkspacePrivacyContext,
     resolveDesktopSkillHost,
   } = deps;
@@ -186,7 +184,6 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
       shellRuns,
       runtimeResources: shellRuns,
       attachmentResources,
-      archiveResources: { readArchivedToolResultResource },
       backgroundTasks: shellRuns,
       ptyControls: shellRuns,
       snapshotImage: snapshotReadImage,
@@ -257,7 +254,6 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
   const childAgentTools = buildChildAgentTools([
     ...buildDesktopBuiltinTools({
       attachmentResources,
-      archiveResources: { readArchivedToolResultResource },
       snapshotImage: snapshotReadImage,
       ...(sandboxManager ? { sandboxManager } : {}),
       ...(filesystemWorker ? {

--- a/packages/headless/src/__tests__/harbor-cell-archive-artifact-id.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell-archive-artifact-id.test.ts
@@ -69,7 +69,7 @@ async function archiveToolResult(
   const originalBytes = Buffer.byteLength(serializedResult, 'utf8');
   const recorder = buildHarborCellContextBudgetBackendOptions({
     MAKA_CONTEXT_TOOL_RESULT_ARCHIVE_DIR: archiveDir,
-  }).archiveToolResult;
+  }).toolResultArchive?.services.archiveToolResult;
   assert.ok(recorder);
 
   const archived = await recorder({

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -50,7 +50,6 @@ import {
   buildHarborCellContextBudgetBackendOptions,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellTaskLedgerExperimentPolicy,
-  buildHarborCellToolResultArchiveResourceReader,
   type RunHarborCellEnv,
   harborCellMaxStepsFromEnv,
   harborCellSoftTimeoutMsFromEnv,
@@ -3504,13 +3503,13 @@ describe('runHarborCell', () => {
       assert.equal(backendInput.contextBudget?.archiveRetrieval?.enabled, true);
       assert.equal(backendInput.contextBudget?.archiveRetrieval?.mode, 'history_search_gated');
       assert.equal(backendInput.contextBudget?.archiveRetrieval?.maxResults, 1);
-      assert.ok(backendInput.archiveToolResult, 'expected archive writer');
-      assert.ok(backendInput.readToolResultArchive, 'expected archive reader');
+      const archive = backendInput.toolResultArchive;
+      assert.ok(archive, 'expected the archive capability');
 
       const serializedResult = JSON.stringify({ body: 'large tool result' });
       const bodySha256 = createHash('sha256').update(serializedResult).digest('hex');
       const originalBytes = Buffer.byteLength(serializedResult, 'utf8');
-      const archived = await backendInput.archiveToolResult({
+      const archived = await archive.services.archiveToolResult({
         sessionId: 'session-1',
         runtimeEventId: 'rt-result',
         turnId: 'turn-old',
@@ -3530,7 +3529,7 @@ describe('runHarborCell', () => {
         /"runtimeEventId":"rt-result"/,
       );
 
-      const read = await backendInput.readToolResultArchive({
+      const read = await archive.services.readToolResultArchive({
         kind: 'maka.archived_tool_result',
         rewriteVersion: 1,
         artifactId: archived.artifactId,
@@ -3592,10 +3591,9 @@ describe('runHarborCell', () => {
       assert.equal(backendInput.contextBudget?.archiveRetrieval?.enabled, true);
       assert.equal(backendInput.contextBudget?.archiveRetrieval?.mode, undefined);
       assert.ok(
-        backendInput.archiveToolResult,
-        'expected archive writer for the placeholder producer',
+        backendInput.toolResultArchive,
+        'eager hydration needs a placeholder producer and a reader, which arrive together',
       );
-      assert.ok(backendInput.readToolResultArchive, 'expected archive reader for eager hydration');
     });
   });
 
@@ -3637,8 +3635,7 @@ describe('runHarborCell', () => {
         }
       ).input;
       assert.equal(backendInput.contextBudget, undefined);
-      assert.equal(backendInput.archiveToolResult, undefined);
-      assert.equal(backendInput.readToolResultArchive, undefined);
+      assert.equal(backendInput.toolResultArchive, undefined);
     });
   });
 
@@ -3651,14 +3648,21 @@ describe('runHarborCell', () => {
         MAKA_STORAGE_ROOT: storageRoot,
       });
 
+      const archive = buildHarborCellContextBudgetBackendOptions({
+        MAKA_OUTPUT_DIR: outputDir,
+      }).toolResultArchive;
       assert.ok(
-        buildHarborCellContextBudgetBackendOptions({ MAKA_OUTPUT_DIR: outputDir })
-          .archiveToolResult,
-        'the default Harbor output dir resolves an archive dir, so the writer is on',
+        archive,
+        'the default Harbor output dir resolves an archive dir, so this cell archives',
       );
-      assert.ok(
+      // The decoder is no longer part of the product binding: it travels with the
+      // capability and the backend advertises it. The cell can therefore no longer
+      // arrive at a state where it archives and the tool is missing (#2025).
+      assert.equal(archive.archiveReadTool.name, 'ArchiveRead');
+      assert.equal(
         context.productToolSurface?.tools.some((tool) => tool.name === 'ArchiveRead'),
-        'archived placeholders instruct the model to call ArchiveRead, so it must be bound',
+        false,
+        'ArchiveRead is a runtime protocol tool, not one of the host-bound product tools',
       );
     });
   });
@@ -3675,9 +3679,9 @@ describe('runHarborCell', () => {
       const context = await runHarborCellCapturingBackendContext(env);
 
       assert.equal(
-        buildHarborCellContextBudgetBackendOptions(env).archiveToolResult,
+        buildHarborCellContextBudgetBackendOptions(env).toolResultArchive,
         undefined,
-        'context budget off disables the archive writer',
+        'context budget off means this cell archives nothing at all',
       );
       assert.equal(
         context.productToolSurface?.tools.some((tool) => tool.name === 'ArchiveRead'),
@@ -3696,7 +3700,9 @@ describe('runHarborCell', () => {
         MAKA_STORAGE_ROOT: storageRoot,
       };
       const context = await runHarborCellCapturingBackendContext(env);
-      const archiveToolResult = buildHarborCellContextBudgetBackendOptions(env).archiveToolResult;
+      const archiveToolResult =
+        buildHarborCellContextBudgetBackendOptions(env).toolResultArchive?.services
+          .archiveToolResult;
       assert.ok(archiveToolResult);
 
       const serializedResult = JSON.stringify({ body: 'archived tool output' });
@@ -3718,9 +3724,11 @@ describe('runHarborCell', () => {
       });
       assert.ok(archived?.artifactId);
 
-      const archiveRead = context.productToolSurface?.tools.find(
-        (tool) => tool.name === 'ArchiveRead',
-      );
+      // The decoder comes from the same capability as the writer above, so this
+      // is the whole #2025 round trip: what the cell archived is what the tool
+      // its placeholders name reads back.
+      const archiveRead =
+        buildHarborCellContextBudgetBackendOptions(env).toolResultArchive?.archiveReadTool;
       assert.ok(archiveRead);
       const output = (await archiveRead.impl(
         {
@@ -3749,10 +3757,10 @@ describe('runHarborCell', () => {
   test('Harbor archive resource reader refuses every way a ref can fail to match', async () => {
     await withDirs(async ({ outputDir }) => {
       const env: RunHarborCellEnv = { MAKA_OUTPUT_DIR: outputDir };
-      const archiveToolResult = buildHarborCellContextBudgetBackendOptions(env).archiveToolResult;
-      const reader = buildHarborCellToolResultArchiveResourceReader(env);
-      assert.ok(archiveToolResult);
-      assert.ok(reader);
+      const archive = buildHarborCellContextBudgetBackendOptions(env).toolResultArchive;
+      assert.ok(archive);
+      const { archiveToolResult } = archive.services;
+      const reader = archive.services;
 
       const serializedResult = JSON.stringify({ body: 'archived' });
       const bodySha256 = sha256(serializedResult);

--- a/packages/headless/src/harbor-cell-context-budget-env.ts
+++ b/packages/headless/src/harbor-cell-context-budget-env.ts
@@ -8,13 +8,12 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
-import type {
-  ContextBudgetPolicy,
-  ToolResultArchiveReader,
-  ToolResultArchiveReadFailureReason,
-  ToolResultArchiveReadResult,
-  ToolResultArchiveRecorder,
-  ToolResultArchiveResourceReader,
+import {
+  createToolResultArchiveCapability,
+  type ContextBudgetPolicy,
+  type ToolResultArchiveCapability,
+  type ToolResultArchiveReadFailureReason,
+  type ToolResultArchiveReadResult,
 } from '@maka/runtime';
 import type { HarborCellContextBudgetPolicySnapshot } from './cell-output.js';
 import {
@@ -26,8 +25,13 @@ import {
 
 export interface HarborCellContextBudgetBackendOptions {
   contextBudget?: ContextBudgetPolicy;
-  archiveToolResult?: ToolResultArchiveRecorder;
-  readToolResultArchive?: ToolResultArchiveReader;
+  /**
+   * Present exactly when `MAKA_TOOL_RESULT_ARCHIVE_DIR` resolves. Writer, replay
+   * reader, ref reader and the `ArchiveRead` decoder come from that one resolved
+   * directory, so the cell cannot archive into a directory it cannot read back
+   * out of — which is what #2025 actually was.
+   */
+  toolResultArchive?: ToolResultArchiveCapability;
 }
 
 export interface HarborCellTaskLedgerExperimentPolicy {
@@ -443,8 +447,7 @@ export function buildHarborCellContextBudgetBackendOptions(
 
   const archiveDir = harborCellToolResultArchiveDir(env);
   if (!archiveDir) return { contextBudget };
-  return {
-    contextBudget,
+  const toolResultArchive = createToolResultArchiveCapability({
     archiveToolResult: async (input) => {
       await mkdir(archiveDir, { recursive: true });
       const artifactId = harborCellToolResultArchiveArtifactId(input);
@@ -469,25 +472,13 @@ export function buildHarborCellContextBudgetBackendOptions(
         runtimeEventId: input.runtimeEventId,
         toolCallId: input.toolCallId,
       }),
-  };
-}
-
-/**
- * Ref-addressed reader backing the `ArchiveRead` tool. Unlike replay hydration it
- * has no runtime event identity to check — a `maka://archive/...` ref only carries
- * artifact id, hash, and size — and it must never synthesize one to satisfy the
- * stricter path.
- */
-export function buildHarborCellToolResultArchiveResourceReader(
-  env: RunHarborCellEnv = process.env,
-): ToolResultArchiveResourceReader | undefined {
-  normalizeHarborCellContextEnv(env);
-  const archiveDir = harborCellToolResultArchiveDir(env);
-  if (!archiveDir) return undefined;
-  return {
+    // The ref-addressed read has no runtime event identity to check — a
+    // `maka://archive/...` ref only carries artifact id, hash, and size — and it
+    // must never synthesize one to satisfy the stricter path above.
     readArchivedToolResultResource: async (input) =>
       readHarborCellArchivedToolResult(archiveDir, input),
-  };
+  });
+  return { contextBudget, toolResultArchive };
 }
 
 async function readHarborCellArchivedToolResult(
@@ -836,9 +827,9 @@ function semanticCompactModeEnv(
 }
 
 /**
- * Sole authority for whether a cell archives tool results, and where. Both the
- * writer and every reader derive from it, so the model can never be told to call
- * `ArchiveRead` for a run that archives nothing — nor archive what it cannot read.
+ * Sole authority for whether a cell archives tool results, and where. The whole
+ * capability derives from it, so a cell can never archive into a directory it
+ * cannot read back out of.
  */
 function harborCellToolResultArchiveDir(env: RunHarborCellEnv): string | undefined {
   if (env.MAKA_CONTEXT_BUDGET === 'off') return undefined;

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -32,7 +32,6 @@ import {
   type SynthesisCacheArtifactStore,
   type SynthesisCacheLoader,
   type SynthesisCacheWriter,
-  type ToolResultArchiveResourceReader,
   type TurnStartOptions,
 } from '@maka/runtime';
 import {
@@ -90,7 +89,6 @@ import {
   buildHarborCellContextBudgetBackendOptions,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellTaskLedgerExperimentPolicy,
-  buildHarborCellToolResultArchiveResourceReader,
 } from './harbor-cell-context-budget-env.js';
 import {
   buildHarborCellAiSdkTools,
@@ -108,7 +106,6 @@ export {
   buildHarborCellContextBudgetBackendOptions,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellTaskLedgerExperimentPolicy,
-  buildHarborCellToolResultArchiveResourceReader,
   type HarborCellContextEnvKey,
   type HarborCellContextBudgetBackendOptions,
   type HarborCellTaskLedgerExperimentPolicy,
@@ -147,12 +144,6 @@ export interface RunHarborCellInput {
     context: HeadlessBackendContext,
   ) => void | Promise<void>;
   realBackendIsolation?: RealBackendIsolation;
-  /**
-   * Ref-addressed archive reader backing `ArchiveRead`. Must be supplied whenever
-   * the backend also archives tool results, since pruned results are replaced by
-   * placeholders that tell the model to call `ArchiveRead`.
-   */
-  archiveResources?: ToolResultArchiveResourceReader;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   continuationPolicy?: HarborCellContinuationPolicy;
   taskToolSummaryEnabled?: boolean;
@@ -360,7 +351,6 @@ export async function runHarborCellWithStorage(
     {
       agentTools: config.agentTools,
       snapshotImage: createReadImageSnapshotter(storage.artifactStore),
-      ...(input.archiveResources ? { archiveResources: input.archiveResources } : {}),
     },
   );
   const registerBackends =
@@ -768,7 +758,6 @@ export async function runHarborCellFromEnv(
   const continuationPolicy = buildHarborCellContinuationPolicy(resolvedEnv);
   const economyTaskMode = economyTaskModeFromEnv(resolvedEnv.MAKA_ECONOMY_TASK_MODE);
   const taskLedgerExperimentPolicy = buildHarborCellTaskLedgerExperimentPolicy(resolvedEnv);
-  const archiveResources = buildHarborCellToolResultArchiveResourceReader(resolvedEnv);
   const maxSteps = harborCellMaxStepsFromEnv(resolvedEnv);
   const settleAfterMs = harborCellSoftTimeoutMsFromEnv(resolvedEnv);
   const reasoningEffort = reasoningEffortFromEnv(resolvedEnv.MAKA_REASONING_EFFORT);
@@ -866,9 +855,6 @@ export async function runHarborCellFromEnv(
       ...(contextBudgetPolicy ? { contextBudgetPolicy } : {}),
       ...(continuationPolicy ? { continuationPolicy } : {}),
       ...(taskLedgerExperimentPolicy ? { taskToolSummaryEnabled: true } : {}),
-      // Gated on the same resolved archive dir as the writer wired into the backend,
-      // so a cell can never archive a result it cannot read back.
-      ...(archiveResources ? { archiveResources } : {}),
       ...(settleAfterMs !== undefined ? { settleAfterMs } : {}),
       ...(registerBackends ? { registerBackends } : {}),
       ...(backendNeedsIsolation(backend)

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -1,13 +1,8 @@
 import { MAX_READ_IMAGE_BYTES, type BackendKind, type StorageRef } from '@maka/core';
-import type {
-  EffectiveProductToolSurface,
-  MakaTool,
-  ToolResultArchiveResourceReader,
-} from '@maka/runtime';
+import type { EffectiveProductToolSurface, MakaTool } from '@maka/runtime';
 import {
   assertProductBindingCatalogClean,
   bashToolShellGuidance,
-  buildArchiveReadTool,
   buildForegroundBashTool,
   buildParentAgentTools,
   computeEditedSource,
@@ -36,12 +31,6 @@ import {
 
 export interface BuildIsolatedHeadlessToolsOptions {
   agentTools?: boolean;
-  /**
-   * Ref-addressed archive reader. Supplying it binds `ArchiveRead`, which pruned
-   * tool results name explicitly in their placeholders. Pass it whenever the host
-   * also archives tool results, or the model is told to call a tool it does not have.
-   */
-  archiveResources?: ToolResultArchiveResourceReader;
   heavyTaskEvidence?: HeavyTaskEvidenceRecorder;
   heavyTaskProgress?: HeavyTaskProgressRecorder;
   heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
@@ -99,7 +88,7 @@ export function buildIsolatedHeadlessProductToolSurface(
   executor: IsolatedToolExecutor,
   options: Pick<
     BuildIsolatedHeadlessToolsOptions,
-    'agentTools' | 'archiveResources' | 'heavyTaskEvidence' | 'snapshotImage'
+    'agentTools' | 'heavyTaskEvidence' | 'snapshotImage'
   > = {},
 ): EffectiveProductToolSurface {
   const productTools = [
@@ -110,7 +99,6 @@ export function buildIsolatedHeadlessProductToolSurface(
     buildIsolatedGlobTool(executor, options),
     buildIsolatedGrepTool(executor, options),
     ...buildParentAgentTools(),
-    ...(options.archiveResources ? [buildArchiveReadTool(options.archiveResources)] : []),
   ];
   assertProductBindingCatalogClean(
     'headless',
@@ -135,7 +123,7 @@ export function buildHeadlessProductToolSurfaceForBackend(
   executor: IsolatedToolExecutor | undefined,
   options: Pick<
     BuildIsolatedHeadlessToolsOptions,
-    'agentTools' | 'archiveResources' | 'heavyTaskEvidence' | 'snapshotImage'
+    'agentTools' | 'heavyTaskEvidence' | 'snapshotImage'
   > = {},
 ): EffectiveProductToolSurface | undefined {
   if (!headlessBackendBindsMakaProductTools(backend) || !executor) return undefined;

--- a/packages/runtime-host/src/__tests__/execution-artifacts.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-artifacts.test.ts
@@ -64,10 +64,14 @@ test('Hosted execution publishes contained Tool Artifacts and durable result arc
       reason: 'stale_tool_result_pruned_before_compact' as const,
       bodySha256,
     };
-    const archived = await services.archiveToolResult(archiveInput);
-    assert.deepEqual(await services.archiveToolResult(archiveInput), archived);
+    const archived = await services.toolResultArchive.services.archiveToolResult(archiveInput);
+    assert.ok(archived, 'the host archive writer always reports where it stored the body');
     assert.deepEqual(
-      await services.readToolResultArchive({
+      await services.toolResultArchive.services.archiveToolResult(archiveInput),
+      archived,
+    );
+    assert.deepEqual(
+      await services.toolResultArchive.services.readToolResultArchive({
         ...archiveInput,
         kind: 'maka.archived_tool_result',
         artifactId: archived.artifactId,

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -33,6 +33,7 @@ import {
   agentGraphIdForRootSession,
   buildParentAgentTools,
   SESSION_RECAP_INSTRUCTION,
+  createToolResultArchiveCapability,
 } from '@maka/runtime';
 import { createSqliteRuntimeStore } from '@maka/storage';
 import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
@@ -1188,10 +1189,14 @@ test('production Host executes a durable runnable child with an exact tool ceili
       'web_research',
       'implementation',
     ]);
-    assert.deepEqual(toolNames(requests[2]?.body), ['Glob', 'Grep', 'Read']);
+    // A child now carries the archive decoder alongside its allowlist (#2026).
+    // Its own placeholders name `ArchiveRead`, so the ceiling that governs
+    // agent-permission tools cannot be the thing that decides whether the child
+    // can read back a result the runtime itself pruned.
+    assert.deepEqual(toolNames(requests[2]?.body), ['ArchiveRead', 'Glob', 'Grep', 'Read']);
     assert.ok(toolNames(requests[3]?.body).includes('agent_spawn'));
-    assert.deepEqual(toolNames(requests[4]?.body), ['WebSearch']);
-    assert.deepEqual(toolNames(requests[5]?.body), ['WebSearch']);
+    assert.deepEqual(toolNames(requests[4]?.body), ['ArchiveRead', 'WebSearch']);
+    assert.deepEqual(toolNames(requests[5]?.body), ['ArchiveRead', 'WebSearch']);
     assert.ok(toolNames(requests[6]?.body).includes('agent_spawn'));
 
     const sessions = await execution.sessionStore.listForRecovery();
@@ -1398,6 +1403,7 @@ test('production Host publishes and retires an implementation child patch', asyn
       'implementation',
     ]);
     assert.deepEqual(toolNames(requests[2]?.body), [
+      'ArchiveRead',
       'Bash',
       'Edit',
       'Glob',
@@ -2570,9 +2576,11 @@ function backendCreationFixture(input: {
     artifacts: {},
     executionArtifacts: {
       recordToolArtifacts: async () => undefined,
-      archiveToolResult: async () => ({ artifactId: 'fixture-tool-result-archive' }),
-      readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
-      readArchivedToolResultResource: async () => ({ ok: false, reason: 'not_found' }),
+      toolResultArchive: createToolResultArchiveCapability({
+        archiveToolResult: async () => ({ artifactId: 'fixture-tool-result-archive' }),
+        readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
+        readArchivedToolResultResource: async () => ({ ok: false, reason: 'not_found' }),
+      }),
     },
     usage: {
       pricing: {
@@ -2919,7 +2927,7 @@ async function handleProviderRequest(
     return;
   }
   if (flow.kind === 'child_agent' && streamRequestIndex === 3) {
-    assert.deepEqual(toolNames(body), ['Glob', 'Grep', 'Read']);
+    assert.deepEqual(toolNames(body), ['ArchiveRead', 'Glob', 'Grep', 'Read']);
     respondProviderText(response, CHILD_AGENT_RESULT_TEXT);
     return;
   }
@@ -2934,7 +2942,7 @@ async function handleProviderRequest(
     return;
   }
   if (flow.kind === 'child_agent' && streamRequestIndex === 5) {
-    assert.deepEqual(toolNames(body), ['WebSearch']);
+    assert.deepEqual(toolNames(body), ['ArchiveRead', 'WebSearch']);
     respondProviderToolCall(response, streamRequestIndex, 'WebSearch', {
       query: 'latest hosted web result',
       limit: 1,
@@ -2942,12 +2950,20 @@ async function handleProviderRequest(
     return;
   }
   if (flow.kind === 'child_agent' && streamRequestIndex === 6) {
-    assert.deepEqual(toolNames(body), ['WebSearch']);
+    assert.deepEqual(toolNames(body), ['ArchiveRead', 'WebSearch']);
     respondProviderText(response, WEB_RESEARCH_CHILD_RESULT_TEXT);
     return;
   }
   if (flow.kind === 'implementation_child_agent' && streamRequestIndex === 3) {
-    assert.deepEqual(toolNames(body), ['Bash', 'Edit', 'Glob', 'Grep', 'Read', 'Write']);
+    assert.deepEqual(toolNames(body), [
+      'ArchiveRead',
+      'Bash',
+      'Edit',
+      'Glob',
+      'Grep',
+      'Read',
+      'Write',
+    ]);
     respondProviderToolCall(response, streamRequestIndex, 'Write', {
       path: 'implementation.txt',
       content: 'HOSTED_IMPLEMENTATION_PATCH_SENTINEL\n',

--- a/packages/runtime-host/src/__tests__/fixtures/agent-graph-provider-scenario.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/agent-graph-provider-scenario.ts
@@ -23,7 +23,9 @@ export class AgentGraphProviderScenario {
 
   respond(body: Record<string, unknown>, reply: AgentGraphProviderReply): void {
     const names = toolNames(body);
-    if (names.join(',') === 'Glob,Grep,Read') {
+    // The graph child's exact surface: its read-only allowlist plus the archive
+    // decoder every session that archives now carries (#2026).
+    if (names.join(',') === 'ArchiveRead,Glob,Grep,Read') {
       assert.equal(this.#childCompleted, false, 'Graph child provider request was repeated');
       this.#childCompleted = true;
       reply.text(this.childResultText);

--- a/packages/runtime-host/src/server/execution-artifacts.ts
+++ b/packages/runtime-host/src/server/execution-artifacts.ts
@@ -3,8 +3,10 @@ import { open, realpath, stat } from 'node:fs/promises';
 import { isAbsolute, resolve } from 'node:path';
 import { MAX_ATTACHMENT_BYTES } from '@maka/core/attachments';
 import {
+  createToolResultArchiveCapability,
   isPathInside,
   stableToolResultArchiveArtifactId,
+  type ToolResultArchiveCapability,
   type ToolArtifactRecorderInput,
   type ToolResultArchiveReaderInput,
   type ToolResultArchiveReadResult,
@@ -15,11 +17,12 @@ import type { InteractiveArtifactStoreWriter } from '@maka/storage/artifact-stor
 
 export interface HostExecutionArtifactServices {
   recordToolArtifacts(event: ToolArtifactRecorderInput): Promise<void>;
-  archiveToolResult(event: ToolResultArchiveRecorderInput): Promise<{ artifactId: string }>;
-  readToolResultArchive(event: ToolResultArchiveReaderInput): Promise<ToolResultArchiveReadResult>;
-  readArchivedToolResultResource(
-    event: ToolResultArchiveResourceReadInput,
-  ): Promise<ToolResultArchiveReadResult>;
+  /**
+   * One archive authority over the session artifact store (#2026). All three
+   * reads and the writer address the same store, so the host has no way to hand
+   * out half of it.
+   */
+  toolResultArchive: ToolResultArchiveCapability;
 }
 
 export function createHostExecutionArtifactServices(input: {
@@ -35,62 +38,66 @@ export function createHostExecutionArtifactServices(input: {
     }
   };
 
-  const services: HostExecutionArtifactServices = {
-    recordToolArtifacts: async (event: ToolArtifactRecorderInput) => {
-      for (const candidate of event.candidates) {
-        let content = candidate.content;
-        if (content === undefined && candidate.sourcePath) {
-          content = (await readBoundedSourceFile(event.cwd, candidate.sourcePath)) ?? undefined;
-        }
-        if (content === undefined || contentBytes(content) > MAX_ATTACHMENT_BYTES) continue;
-        await runWrite(() =>
-          input.artifacts.create({
-            sessionId: event.sessionId,
-            turnId: event.turnId,
-            name: candidate.name,
-            kind: candidate.kind,
-            content,
-            ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
-            source: candidate.source ?? 'tool_result',
-            ...(candidate.summary ? { summary: candidate.summary } : {}),
-          }),
-        );
+  const recordToolArtifacts = async (event: ToolArtifactRecorderInput): Promise<void> => {
+    for (const candidate of event.candidates) {
+      let content = candidate.content;
+      if (content === undefined && candidate.sourcePath) {
+        content = (await readBoundedSourceFile(event.cwd, candidate.sourcePath)) ?? undefined;
       }
-    },
-    archiveToolResult: (event: ToolResultArchiveRecorderInput) =>
-      runWrite(async () => {
-        const artifactId = stableToolResultArchiveArtifactId(event);
-        const existing = await input.artifacts.getInSession(event.sessionId, artifactId);
-        if (existing.record?.status === 'live') {
-          const read = await readArchive(input.artifacts, {
-            artifactId,
-            sessionId: event.sessionId,
-            bodySha256: event.bodySha256,
-            originalBytes: event.originalBytes,
-            maxBytes: event.originalBytes,
-          });
-          if (!read.ok) {
-            throw new Error(`Tool result archive identity conflict: ${read.reason}`);
-          }
-          return { artifactId };
-        }
-        const artifact = await input.artifacts.create({
-          id: artifactId,
+      if (content === undefined || contentBytes(content) > MAX_ATTACHMENT_BYTES) continue;
+      await runWrite(() =>
+        input.artifacts.create({
           sessionId: event.sessionId,
           turnId: event.turnId,
-          name: `archived-${event.toolName}-${event.runtimeEventId}.json`,
-          kind: 'file',
-          content: event.serializedResult,
-          mimeType: 'application/json',
-          source: 'tool_result_archive',
-          summary: `Archived ${event.toolName} tool result for context budget replay`,
-        });
-        return { artifactId: artifact.id };
-      }),
-    readToolResultArchive: (event: ToolResultArchiveReaderInput) =>
-      readArchive(input.artifacts, event),
-    readArchivedToolResultResource: (event: ToolResultArchiveResourceReadInput) =>
-      readArchive(input.artifacts, event),
+          name: candidate.name,
+          kind: candidate.kind,
+          content,
+          ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+          source: candidate.source ?? 'tool_result',
+          ...(candidate.summary ? { summary: candidate.summary } : {}),
+        }),
+      );
+    }
+  };
+
+  const services: HostExecutionArtifactServices = {
+    recordToolArtifacts,
+    toolResultArchive: createToolResultArchiveCapability({
+      archiveToolResult: (event: ToolResultArchiveRecorderInput) =>
+        runWrite(async () => {
+          const artifactId = stableToolResultArchiveArtifactId(event);
+          const existing = await input.artifacts.getInSession(event.sessionId, artifactId);
+          if (existing.record?.status === 'live') {
+            const read = await readArchive(input.artifacts, {
+              artifactId,
+              sessionId: event.sessionId,
+              bodySha256: event.bodySha256,
+              originalBytes: event.originalBytes,
+              maxBytes: event.originalBytes,
+            });
+            if (!read.ok) {
+              throw new Error(`Tool result archive identity conflict: ${read.reason}`);
+            }
+            return { artifactId };
+          }
+          const artifact = await input.artifacts.create({
+            id: artifactId,
+            sessionId: event.sessionId,
+            turnId: event.turnId,
+            name: `archived-${event.toolName}-${event.runtimeEventId}.json`,
+            kind: 'file',
+            content: event.serializedResult,
+            mimeType: 'application/json',
+            source: 'tool_result_archive',
+            summary: `Archived ${event.toolName} tool result for context budget replay`,
+          });
+          return { artifactId: artifact.id };
+        }),
+      readToolResultArchive: (event: ToolResultArchiveReaderInput) =>
+        readArchive(input.artifacts, event),
+      readArchivedToolResultResource: (event: ToolResultArchiveResourceReadInput) =>
+        readArchive(input.artifacts, event),
+    }),
   };
   return Object.freeze(services);
 }

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -277,7 +277,6 @@ export async function createExecutionRuntimeHostComposition(
       attachmentResources: createArtifactAttachmentResourceReader({
         artifactStore: openedArtifactStore,
       }),
-      archiveResources: executionArtifacts,
       backgroundTasks: runtimeResources,
       ptyControls: runtimeResources,
       snapshotImage: createReadImageSnapshotter(openedArtifactStore),

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -578,8 +578,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
           sessionId: input.context.sessionId,
         }),
         recordToolArtifacts: input.executionArtifacts.recordToolArtifacts,
-        archiveToolResult: input.executionArtifacts.archiveToolResult,
-        readToolResultArchive: input.executionArtifacts.readToolResultArchive,
+        toolResultArchive: input.executionArtifacts.toolResultArchive,
         loadHistoryCompactCheckpoint: input.context.loadHistoryCompactCheckpoint,
         summarizeHistoryCompact: buildLlmHistorySummarizer({
           resolveModel: () =>

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -77,7 +77,10 @@ import type {
 } from '../provider-request-telemetry.js';
 import { decodeModelCallAttempt, type ModelCallAttempt } from '@maka/core/model-call-attempt';
 import { buildLlmHistorySummarizer } from '../history-compact-summarizer.js';
-import { createTestAiSdkBackend } from './execution-boundary-test-helpers.js';
+import {
+  createTestAiSdkBackend,
+  testToolResultArchive,
+} from './execution-boundary-test-helpers.js';
 
 describe('AiSdkBackend model history', () => {
   test('preserves operation-owned audio through the durable request path and redacts its capture', async () => {
@@ -3037,14 +3040,16 @@ describe('AiSdkBackend model history', () => {
         },
         charsPerToken: 1,
       },
-      archiveToolResult: async (event) => {
-        archiveRequests.push({
-          runtimeEventId: event.runtimeEventId,
-          serializedResult: event.serializedResult,
-          bodySha256: event.bodySha256,
-        });
-        return { artifactId: `artifact-${event.runtimeEventId}` };
-      },
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async (event) => {
+          archiveRequests.push({
+            runtimeEventId: event.runtimeEventId,
+            serializedResult: event.serializedResult,
+            bodySha256: event.bodySha256,
+          });
+          return { artifactId: `artifact-${event.runtimeEventId}` };
+        },
+      }),
     });
 
     await drain(
@@ -3132,10 +3137,12 @@ describe('AiSdkBackend model history', () => {
         },
         charsPerToken: 1,
       },
-      archiveToolResult: async (event) =>
-        event.runtimeEventId === 'rt-new-result'
-          ? { artifactId: 'artifact-new-rt-result' }
-          : undefined,
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async (event) =>
+          event.runtimeEventId === 'rt-new-result'
+            ? { artifactId: 'artifact-new-rt-result' }
+            : undefined,
+      }),
     });
 
     await drain(
@@ -3237,7 +3244,9 @@ describe('AiSdkBackend model history', () => {
         },
         charsPerToken: 1,
       },
-      archiveToolResult: async (event) => ({ artifactId: `artifact-${event.runtimeEventId}` }),
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async (event) => ({ artifactId: `artifact-${event.runtimeEventId}` }),
+      }),
     });
 
     for await (const event of backend.send({
@@ -3323,19 +3332,21 @@ describe('AiSdkBackend model history', () => {
         },
         charsPerToken: 1,
       },
-      archiveToolResult: async (event) => {
-        archivedBody = event.serializedResult;
-        return { artifactId: `artifact-${event.runtimeEventId}` };
-      },
-      readToolResultArchive: async (event) => {
-        if (event.originalBytes !== utf8Bytes(archivedBody)) {
-          return { ok: false, reason: 'size_mismatch' };
-        }
-        return {
-          ok: true,
-          serializedResult: event.bodySha256 === sha256(archivedBody) ? archivedBody : 'tampered',
-        };
-      },
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async (event) => {
+          archivedBody = event.serializedResult;
+          return { artifactId: `artifact-${event.runtimeEventId}` };
+        },
+        readToolResultArchive: async (event) => {
+          if (event.originalBytes !== utf8Bytes(archivedBody)) {
+            return { ok: false, reason: 'size_mismatch' };
+          }
+          return {
+            ok: true,
+            serializedResult: event.bodySha256 === sha256(archivedBody) ? archivedBody : 'tampered',
+          };
+        },
+      }),
     });
 
     for await (const event of backend.send({
@@ -3482,15 +3493,17 @@ describe('AiSdkBackend model history', () => {
         },
         charsPerToken: 1,
       },
-      archiveToolResult: async (event) => {
-        archivedBodies.set(event.runtimeEventId, event.serializedResult);
-        return { artifactId: `artifact-${event.runtimeEventId}` };
-      },
-      readToolResultArchive: async (event) => {
-        readRuntimeEventIds.push(event.runtimeEventId);
-        const body = archivedBodies.get(event.runtimeEventId);
-        return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
-      },
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async (event) => {
+          archivedBodies.set(event.runtimeEventId, event.serializedResult);
+          return { artifactId: `artifact-${event.runtimeEventId}` };
+        },
+        readToolResultArchive: async (event) => {
+          readRuntimeEventIds.push(event.runtimeEventId);
+          const body = archivedBodies.get(event.runtimeEventId);
+          return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
+        },
+      }),
       writeSynthesisCache: async (event) => {
         writeInputs.push({ turnId: event.turnId, query: event.source.query });
         return { blocks: [] };
@@ -3613,14 +3626,16 @@ describe('AiSdkBackend model history', () => {
             : {}),
           charsPerToken: CHARS_PER_TOKEN,
         },
-        archiveToolResult: async (event) => {
-          archivedBodies.set(event.runtimeEventId, event.serializedResult);
-          return { artifactId: `artifact-${event.runtimeEventId}` };
-        },
-        readToolResultArchive: async (event) => {
-          const body = archivedBodies.get(event.runtimeEventId);
-          return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
-        },
+        toolResultArchive: testToolResultArchive({
+          archiveToolResult: async (event) => {
+            archivedBodies.set(event.runtimeEventId, event.serializedResult);
+            return { artifactId: `artifact-${event.runtimeEventId}` };
+          },
+          readToolResultArchive: async (event) => {
+            const body = archivedBodies.get(event.runtimeEventId);
+            return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
+          },
+        }),
         writeSynthesisCache: async () => ({ blocks: [] }),
       });
       for await (const _event of backend.send({
@@ -3750,15 +3765,17 @@ describe('AiSdkBackend model history', () => {
         },
         charsPerToken: 1,
       },
-      archiveToolResult: async (event) => {
-        archivedBodies.set(event.runtimeEventId, event.serializedResult);
-        return { artifactId: `artifact-${event.runtimeEventId}` };
-      },
-      readToolResultArchive: async (event) => {
-        readRuntimeEventIds.push(event.runtimeEventId);
-        const body = archivedBodies.get(event.runtimeEventId);
-        return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
-      },
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async (event) => {
+          archivedBodies.set(event.runtimeEventId, event.serializedResult);
+          return { artifactId: `artifact-${event.runtimeEventId}` };
+        },
+        readToolResultArchive: async (event) => {
+          readRuntimeEventIds.push(event.runtimeEventId);
+          const body = archivedBodies.get(event.runtimeEventId);
+          return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
+        },
+      }),
       loadSynthesisCache: async () => {
         loadCalls += 1;
         return { blocks: [block] };
@@ -3877,14 +3894,16 @@ describe('AiSdkBackend model history', () => {
         },
         charsPerToken: 1,
       },
-      archiveToolResult: async (event) => {
-        archivedBodies.set(event.runtimeEventId, event.serializedResult);
-        return { artifactId: `artifact-${event.runtimeEventId}` };
-      },
-      readToolResultArchive: async (event) => {
-        const body = archivedBodies.get(event.runtimeEventId);
-        return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
-      },
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async (event) => {
+          archivedBodies.set(event.runtimeEventId, event.serializedResult);
+          return { artifactId: `artifact-${event.runtimeEventId}` };
+        },
+        readToolResultArchive: async (event) => {
+          const body = archivedBodies.get(event.runtimeEventId);
+          return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
+        },
+      }),
       writeSynthesisCache: async (input) => {
         writeInputs.push({
           sourceRefCount: input.source.retrievedArchiveRefs.length,
@@ -4009,15 +4028,17 @@ describe('AiSdkBackend model history', () => {
         },
         charsPerToken: 1,
       },
-      archiveToolResult: async (event) => {
-        archivedBodies.set(event.runtimeEventId, event.serializedResult);
-        return { artifactId: `artifact-${event.runtimeEventId}` };
-      },
-      readToolResultArchive: async (event) => {
-        readRuntimeEventIds.push(event.runtimeEventId);
-        const body = archivedBodies.get(event.runtimeEventId);
-        return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
-      },
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async (event) => {
+          archivedBodies.set(event.runtimeEventId, event.serializedResult);
+          return { artifactId: `artifact-${event.runtimeEventId}` };
+        },
+        readToolResultArchive: async (event) => {
+          readRuntimeEventIds.push(event.runtimeEventId);
+          const body = archivedBodies.get(event.runtimeEventId);
+          return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
+        },
+      }),
       writeSynthesisCache: async (event) => {
         writeInputs.push({ turnId: event.turnId, query: event.source.query });
         return { blocks: [] };
@@ -8032,7 +8053,9 @@ describe('AiSdkBackend usage telemetry', () => {
       contextBudget: {
         activeToolResultPrune: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
       },
-      archiveToolResult: async () => ({ artifactId: 'artifact-tool-1' }),
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async () => ({ artifactId: 'artifact-tool-1' }),
+      }),
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
       newId: idGenerator(),
       now: monotonicClock(),
@@ -8145,7 +8168,9 @@ describe('AiSdkBackend usage telemetry', () => {
           maxSummaryEstimatedTokens: 512,
         },
       },
-      archiveToolResult: async () => ({ artifactId: 'artifact-tool-1' }),
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async () => ({ artifactId: 'artifact-tool-1' }),
+      }),
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
       newId: idGenerator(),
       now: monotonicClock(),
@@ -8412,10 +8437,12 @@ describe('AiSdkBackend usage telemetry', () => {
         },
       ],
       contextBudget: semanticCompactContextBudget('replace'),
-      archiveToolResult: async () => {
-        archiveCalls += 1;
-        return { artifactId: 'archived-covered-semantic-result' };
-      },
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async () => {
+          archiveCalls += 1;
+          return { artifactId: 'archived-covered-semantic-result' };
+        },
+      }),
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
       newId: idGenerator(),
       now: monotonicClock(),
@@ -8578,7 +8605,9 @@ describe('AiSdkBackend usage telemetry', () => {
         },
       ],
       contextBudget: semanticCompactContextBudget('validate_only'),
-      archiveToolResult: async () => ({ artifactId: 'archived-covered-semantic-result' }),
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async () => ({ artifactId: 'archived-covered-semantic-result' }),
+      }),
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
       newId: idGenerator(),
       now: monotonicClock(),
@@ -8656,7 +8685,9 @@ describe('AiSdkBackend usage telemetry', () => {
         ...budget,
         semanticCompact: { ...budget.semanticCompact, summarizerModel: 'summarizer-model-id' },
       },
-      archiveToolResult: async () => ({ artifactId: 'archived-covered-semantic-result' }),
+      toolResultArchive: testToolResultArchive({
+        archiveToolResult: async () => ({ artifactId: 'archived-covered-semantic-result' }),
+      }),
       loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
       newId: idGenerator(),
       now: monotonicClock(),
@@ -12687,18 +12718,20 @@ async function runArchiveGatedReplay(input: {
       },
       charsPerToken: 1,
     },
-    archiveToolResult: async (event) => {
-      archivedBodies.set(event.runtimeEventId, event.serializedResult);
-      return { artifactId: `artifact-${event.runtimeEventId}` };
-    },
-    readToolResultArchive: async (event) => {
-      readRuntimeEventIds.push(event.runtimeEventId);
-      const body = archivedBodies.get(event.runtimeEventId);
-      assert.ok(body);
-      return event.bodySha256 === sha256(body)
-        ? { ok: true, serializedResult: body }
-        : { ok: false, reason: 'corrupt' };
-    },
+    toolResultArchive: testToolResultArchive({
+      archiveToolResult: async (event) => {
+        archivedBodies.set(event.runtimeEventId, event.serializedResult);
+        return { artifactId: `artifact-${event.runtimeEventId}` };
+      },
+      readToolResultArchive: async (event) => {
+        readRuntimeEventIds.push(event.runtimeEventId);
+        const body = archivedBodies.get(event.runtimeEventId);
+        assert.ok(body);
+        return event.bodySha256 === sha256(body)
+          ? { ok: true, serializedResult: body }
+          : { ok: false, reason: 'corrupt' };
+      },
+    }),
   });
   const selectedEvents = archiveGatedTurnEvents('a', input.selectedPath, input.selectedResult);
   const unselectedEvents = archiveGatedTurnEvents(

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -77,6 +77,7 @@ import type {
 } from '../provider-request-telemetry.js';
 import { decodeModelCallAttempt, type ModelCallAttempt } from '@maka/core/model-call-attempt';
 import { buildLlmHistorySummarizer } from '../history-compact-summarizer.js';
+import { createToolResultArchiveCapability } from '../tool-result-archive-capability.js';
 import {
   createTestAiSdkBackend,
   testToolResultArchive,
@@ -7960,6 +7961,126 @@ describe('AiSdkBackend usage telemetry', () => {
 
     assert.equal(usageCheckpoints.length, 1);
     assert.equal(usageCheckpoints[0]?.costUsd, undefined);
+  });
+
+  test('a pruned tool result is readable again through the tool its placeholder names', async () => {
+    // The whole loop through real dispatch (#2026): the budget prunes an
+    // oversized result, the runtime mints a placeholder naming `ArchiveRead`,
+    // the model calls it with the ref that placeholder carried, and the body
+    // lands back in the conversation. Advertising the decoder is only half the
+    // invariant; the other half is that calling it works from inside the turn.
+    const durable = durableTurnHarness('turn-1', 'read the big file');
+    const largeBody = 'ARCHIVED_BODY_SENTINEL'.repeat(200);
+    const store = new Map<string, string>();
+    const prompts: unknown[] = [];
+    let streamCalls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async ({ prompt }) => {
+        streamCalls += 1;
+        prompts.push(prompt);
+        const call = (toolCallId: string, toolName: string, input: unknown) =>
+          [
+            { type: 'stream-start', warnings: [] },
+            { type: 'tool-call', toolCallId, toolName, input: JSON.stringify(input) },
+            {
+              type: 'finish',
+              finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+              usage: {
+                inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+                outputTokens: { total: 1, text: 1, reasoning: 0 },
+              },
+            },
+          ] as LanguageModelV4StreamPart[];
+        const chunks: LanguageModelV4StreamPart[] =
+          streamCalls === 1
+            ? call('tool-1', 'Read', { path: 'big.md' })
+            : // The newest completed step is never pruned, so a second call is
+              // what makes the Read result stale enough to be archived.
+              streamCalls === 2
+              ? call('tool-2', 'Bash', { cmd: 'continue' })
+              : streamCalls === 3
+                ? call('tool-3', 'ArchiveRead', {
+                    // Read the ref out of the placeholder the runtime just
+                    // handed us, exactly as a model would.
+                    ref: /maka:\/\/archive\/[^"\\]+/.exec(JSON.stringify(prompt))?.[0] ?? 'missing',
+                    operation: 'read',
+                  })
+                : [
+                    { type: 'stream-start', warnings: [] },
+                    {
+                      type: 'finish',
+                      finishReason: { unified: 'stop', raw: 'stop' },
+                      usage: {
+                        inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+                        outputTokens: { total: 1, text: 1, reasoning: 0 },
+                      },
+                    },
+                  ];
+        return {
+          stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [
+        {
+          name: 'Read',
+          description: 'Read description',
+          parameters: z.object({ path: z.string() }),
+          impl: async () => ({ body: largeBody }),
+        },
+        {
+          name: 'Bash',
+          description: 'Bash description',
+          parameters: z.object({ cmd: z.string() }),
+          impl: async () => ({ body: 'small' }),
+        },
+      ],
+      contextBudget: {
+        activeToolResultPrune: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      },
+      // A real store, so the decoder has to reach what the writer actually wrote.
+      toolResultArchive: createToolResultArchiveCapability({
+        archiveToolResult: async (event) => {
+          const artifactId = `artifact-${store.size + 1}`;
+          store.set(artifactId, event.serializedResult);
+          return { artifactId };
+        },
+        readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
+        readArchivedToolResultResource: async (event) => {
+          const serializedResult = store.get(event.artifactId);
+          return serializedResult === undefined
+            ? { ok: false, reason: 'not_found' }
+            : { ok: true, serializedResult };
+        },
+      }),
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    for await (const event of backend.send(durable.input())) durable.record(event);
+
+    assert.match(
+      store.get('artifact-1') ?? '',
+      /ARCHIVED_BODY_SENTINEL/,
+      'the oversized Read result must have been archived',
+    );
+    const thirdPrompt = JSON.stringify(prompts[2]);
+    assert.doesNotMatch(thirdPrompt, /ARCHIVED_BODY_SENTINEL/);
+    assert.match(thirdPrompt, /maka:\/\/archive\//);
+    assert.match(
+      JSON.stringify(prompts[3]),
+      /ARCHIVED_BODY_SENTINEL/,
+      'the ArchiveRead result must carry the archived body back into the conversation',
+    );
   });
 
   test('records active tool-result prune diagnostics in usage telemetry', async () => {

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -119,42 +119,14 @@ describe('builtin Read capabilities', () => {
 });
 
 describe('builtin ArchiveRead capabilities', () => {
-  test('is present only with a host reader and preserves the invoking session', async () => {
-    const body = JSON.stringify({ kind: 'agent_swarm', items: [] });
-    const bodySha256 = createHash('sha256').update(body).digest('hex');
-    const artifactId = `tool-result-archive-${'a'.repeat(32)}`;
-    const seen: unknown[] = [];
-    const withoutReader = buildBuiltinTools().find((tool) => tool.name === 'ArchiveRead');
-    const archiveRead = buildBuiltinTools({
-      archiveResources: {
-        readArchivedToolResultResource(input) {
-          seen.push(input);
-          return { ok: true, serializedResult: body };
-        },
-      },
-    }).find((tool) => tool.name === 'ArchiveRead');
-    if (!archiveRead) throw new Error('ArchiveRead tool missing');
-
-    assert.equal(withoutReader, undefined);
-    assert.equal(archiveRead.activityKind, 'read');
-    const result = await archiveRead.impl(
-      {
-        ref: `maka://archive/${artifactId}?sha256=${bodySha256}&bytes=${Buffer.byteLength(body)}`,
-        operation: 'inspect',
-      },
-      {
-        sessionId: 'session-1',
-        runId: 'run-1',
-        turnId: 'turn-1',
-        cwd: '/workspace',
-        toolCallId: 'tool-1',
-        abortSignal: new AbortController().signal,
-        emitOutput: () => {},
-      },
+  test('is not a built-in tool', () => {
+    // The archive decoder travels with the archive capability and is bound by
+    // the backend (#2026). A host that assembles built-ins can no longer
+    // forget it, and can no longer register it without a writer behind it.
+    assert.equal(
+      buildBuiltinTools().find((tool) => tool.name === 'ArchiveRead'),
+      undefined,
     );
-
-    assert.equal((result as { operation: string }).operation, 'inspect');
-    assert.equal((seen[0] as { sessionId: string }).sessionId, 'session-1');
   });
 });
 

--- a/packages/runtime/src/__tests__/execution-boundary-test-helpers.ts
+++ b/packages/runtime/src/__tests__/execution-boundary-test-helpers.ts
@@ -1,6 +1,11 @@
 import { createExternalExecutionBoundary } from '@maka/core';
 
 import { AiSdkBackend, type AiSdkBackendInput } from '../ai-sdk-backend.js';
+import {
+  createToolResultArchiveCapability,
+  type ToolResultArchiveCapability,
+  type ToolResultArchiveServices,
+} from '../tool-result-archive-capability.js';
 import { ToolRuntime, type ToolRuntimeInput } from '../tool-runtime.js';
 
 export const readExternalExecutionBoundary: AiSdkBackendInput['readExecutionBoundary'] = async () =>
@@ -13,6 +18,23 @@ export function createTestAiSdkBackend(input: TestAiSdkBackendInput): AiSdkBacke
   return new AiSdkBackend({
     readExecutionBoundary: readExternalExecutionBoundary,
     ...input,
+  });
+}
+
+/**
+ * An archive capability for tests whose subject is the writer or the replay
+ * reader. The unexercised halves resolve to `not_found` rather than being
+ * absent: a test may leave a road untravelled, but the capability itself is
+ * still whole, which is the invariant these fixtures used to be able to break.
+ */
+export function testToolResultArchive(
+  services: Partial<ToolResultArchiveServices>,
+): ToolResultArchiveCapability {
+  return createToolResultArchiveCapability({
+    archiveToolResult: async () => undefined,
+    readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
+    readArchivedToolResultResource: async () => ({ ok: false, reason: 'not_found' }),
+    ...services,
   });
 }
 

--- a/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
@@ -23,7 +23,10 @@ import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
 import { HistoryCompactSummarizerError } from '../history-compact-error.js';
 import { buildLlmHistorySummarizer } from '../history-compact-summarizer.js';
 import { decodeModelCallAttempt, type ModelCallAttempt } from '@maka/core/model-call-attempt';
-import { createTestAiSdkBackend } from './execution-boundary-test-helpers.js';
+import {
+  createTestAiSdkBackend,
+  testToolResultArchive,
+} from './execution-boundary-test-helpers.js';
 
 const RAW_SPAN_ONE = 'RAW_SPAN_ONE_'.repeat(24);
 const RAW_SPAN_TWO = 'RAW_SPAN_TWO_'.repeat(160);
@@ -355,7 +358,11 @@ function buildFixture(options: MidTurnFixtureOptions = {}): MidTurnFixture {
             : {}),
         },
     ...(options.activeToolResultPrune
-      ? { archiveToolResult: () => ({ artifactId: 'artifact-archived-1' }) }
+      ? {
+          toolResultArchive: testToolResultArchive({
+            archiveToolResult: () => ({ artifactId: 'artifact-archived-1' }),
+          }),
+        }
       : {}),
     summarizeHistoryCompact: async (input) => {
       fixture.summarizerCalls += 1;

--- a/packages/runtime/src/__tests__/overflow-reactive-recovery.test.ts
+++ b/packages/runtime/src/__tests__/overflow-reactive-recovery.test.ts
@@ -11,7 +11,10 @@ import { AiSdkBackend } from '../ai-sdk-backend.js';
 import { createSessionEventMapMemory, mapSessionEventToRuntimeEvent } from '../ai-sdk-flow.js';
 import type { InvocationContext } from '../invocation-context.js';
 import type { HistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
-import { createTestAiSdkBackend } from './execution-boundary-test-helpers.js';
+import {
+  createTestAiSdkBackend,
+  testToolResultArchive,
+} from './execution-boundary-test-helpers.js';
 
 const RAW_SPAN_ONE = 'RAW_SPAN_ONE_'.repeat(24);
 const ANCHOR_TEXT = 'reactive overflow recovery keep my exact words';
@@ -444,7 +447,11 @@ function buildReactiveFixture(options: ReactiveFixtureOptions): ReactiveFixture 
         : {}),
     },
     ...(options.activeToolResultPrune
-      ? { archiveToolResult: () => ({ artifactId: 'artifact-archived-1' }) }
+      ? {
+          toolResultArchive: testToolResultArchive({
+            archiveToolResult: () => ({ artifactId: 'artifact-archived-1' }),
+          }),
+        }
       : {}),
     ...durableReader,
     ...compactionSeams,

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -454,17 +454,20 @@ describe('subagent tools', () => {
     ]);
   });
 
-  test('keeps host-provided ArchiveRead available for child recovery', () => {
-    const archiveRead = testCatalogTool('ArchiveRead', 'read');
+  test('does not smuggle ArchiveRead through the child allowlist', () => {
+    // The pool-level pass-through this replaces never worked: every child
+    // surface is re-narrowed against `definition.tools`, and no definition
+    // lists ArchiveRead. The decoder now reaches a child from its own backend's
+    // archive capability, so the allowlist stays exactly what it says it is.
     const tools = buildChildAgentTools([
       testCatalogTool('Read', 'read'),
       testCatalogTool('Glob', 'read'),
       testCatalogTool('Grep', 'read'),
       testCatalogTool('WebSearch', 'web_read'),
-      archiveRead,
+      testCatalogTool('ArchiveRead', 'read'),
     ]);
 
-    expect(tools.find((tool) => tool.name === 'ArchiveRead')).toBe(archiveRead);
+    expect(tools.find((tool) => tool.name === 'ArchiveRead')).toBeUndefined();
   });
 
   test('child agent toolset enforces explore-mode read-only behavior without prompting', async () => {

--- a/packages/runtime/src/__tests__/tool-result-archive-capability-backend.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-capability-backend.test.ts
@@ -114,6 +114,34 @@ describe('AiSdkBackend tool-result archive capability', () => {
     assert.equal(page.ok, true, 'the ref the placeholder carries must resolve');
     assert.equal(page.content, serializedResult);
   });
+
+  test('the decoder reads as the invoking session', async () => {
+    // A ref carries no session identity, so the session boundary is only as
+    // strong as the id the tool passes down from its own invocation context.
+    const seen: { sessionId: string }[] = [];
+    const archive = createToolResultArchiveCapability({
+      archiveToolResult: async () => ({ artifactId: 'artifact-1' }),
+      readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
+      readArchivedToolResultResource: async (input) => {
+        seen.push({ sessionId: input.sessionId });
+        return { ok: true, serializedResult: JSON.stringify({ kind: 'agent_swarm', items: [] }) };
+      },
+    });
+
+    await archive.archiveReadTool.impl(
+      {
+        ref: buildToolResultArchiveResourceRef({
+          artifactId: `tool-result-archive-${'a'.repeat(32)}`,
+          bodySha256: 'b'.repeat(64),
+          originalBytes: 128,
+        }),
+        operation: 'inspect',
+      },
+      { ...toolContext(), sessionId: 'session-invoking' },
+    );
+
+    assert.equal(seen[0]?.sessionId, 'session-invoking');
+  });
 });
 
 function toolContext(): MakaToolContext {

--- a/packages/runtime/src/__tests__/tool-result-archive-capability-backend.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-capability-backend.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
+import type { LanguageModelV4StreamPart, LanguageModelV4Usage } from '@ai-sdk/provider';
+import type { LlmConnection, SessionHeader } from '@maka/core';
+
+import type { AiSdkBackend } from '../ai-sdk-backend.js';
+import {
+  createToolResultArchiveCapability,
+  type ToolResultArchiveCapability,
+} from '../tool-result-archive-capability.js';
+import { createTestAiSdkBackend } from './execution-boundary-test-helpers.js';
+
+// The pruned tool-result placeholder is a runtime-generated protocol value that
+// names `ArchiveRead` as the way back to the content. These tests observe the
+// tool surface the provider actually receives, not an internal array: the
+// defects in #2025 and on the child-agent path were both "the model was told to
+// call a tool that was never advertised to it".
+
+const ZERO_USAGE: LanguageModelV4Usage = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+};
+
+describe('AiSdkBackend tool-result archive capability', () => {
+  test('advertises ArchiveRead when the session archives tool results', async () => {
+    const capturedTools: string[][] = [];
+    const model = capturingModel(capturedTools);
+
+    await drain(
+      backendWith(model, capability()).send({
+        turnId: 'turn-1',
+        text: 'hello',
+        context: [],
+      }),
+    );
+
+    assert.ok(
+      capturedTools[0]?.includes('ArchiveRead'),
+      'a session that archives tool results must advertise the tool its placeholders name',
+    );
+  });
+});
+
+function capability(): ToolResultArchiveCapability {
+  return createToolResultArchiveCapability({
+    archiveToolResult: async () => ({ artifactId: 'artifact-1' }),
+    readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
+    readArchivedToolResultResource: async () => ({ ok: false, reason: 'not_found' }),
+  });
+}
+
+function backendWith(
+  model: MockLanguageModelV4,
+  toolResultArchive: ToolResultArchiveCapability | undefined,
+): AiSdkBackend {
+  let n = 0;
+  return createTestAiSdkBackend({
+    sessionId: 'session-1',
+    header: header(),
+    appendMessage: async () => {},
+    connection: connection(),
+    apiKey: 'sk-test',
+    modelId: 'mock-model-id',
+    modelFactory: () => model,
+    // The host binds no tools at all: whether the decoder reaches the model is
+    // not a host wiring question.
+    tools: [],
+    ...(toolResultArchive ? { toolResultArchive } : {}),
+    newId: () => `id-${++n}`,
+    now: () => 1,
+  });
+}
+
+function capturingModel(capturedTools: string[][]): MockLanguageModelV4 {
+  return new MockLanguageModelV4({
+    doStream: async ({ tools: stepTools }) => {
+      capturedTools.push((stepTools ?? []).map((tool) => tool.name));
+      return {
+        stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+          { type: 'stream-start', warnings: [] },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: ZERO_USAGE,
+          },
+        ]),
+      };
+    },
+  });
+}
+
+async function drain(iterable: AsyncIterable<unknown>): Promise<void> {
+  for await (const _ of iterable) {
+    void _;
+  }
+}
+
+function header(): SessionHeader {
+  return {
+    id: 'session-1',
+    workspaceRoot: '/tmp/maka',
+    cwd: '/tmp/maka',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Test',
+    titleIsManual: true,
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    statusUpdatedAt: 1,
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'c',
+    connectionLocked: true,
+    model: 'm',
+    permissionMode: 'ask',
+    schemaVersion: 1,
+  };
+}
+
+function connection(): LlmConnection {
+  return {
+    slug: 'c',
+    name: 'OpenAI',
+    providerType: 'openai',
+    defaultModel: 'mock-model-id',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/packages/runtime/src/__tests__/tool-result-archive-capability-backend.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-capability-backend.test.ts
@@ -113,6 +113,9 @@ describe('AiSdkBackend tool-result archive capability', () => {
 
     assert.equal(page.ok, true, 'the ref the placeholder carries must resolve');
     assert.equal(page.content, serializedResult);
+    // Kept from the built-in tool contract this replaced: the decoder is a read,
+    // which is what lets it travel to a read-only child.
+    assert.equal(archive.archiveReadTool.activityKind, 'read');
   });
 
   test('the decoder reads as the invoking session', async () => {

--- a/packages/runtime/src/__tests__/tool-result-archive-capability-backend.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-capability-backend.test.ts
@@ -9,6 +9,9 @@ import {
   createToolResultArchiveCapability,
   type ToolResultArchiveCapability,
 } from '../tool-result-archive-capability.js';
+import { buildToolResultArchiveResourceRef } from '../tool-result-archive-resource.js';
+import { ARCHIVED_TOOL_RESULT_REWRITE_VERSION } from '../tool-result-archive.js';
+import type { MakaToolContext } from '../tool-runtime.js';
 import { createTestAiSdkBackend } from './execution-boundary-test-helpers.js';
 
 // The pruned tool-result placeholder is a runtime-generated protocol value that
@@ -40,7 +43,89 @@ describe('AiSdkBackend tool-result archive capability', () => {
       'a session that archives tool results must advertise the tool its placeholders name',
     );
   });
+
+  test('advertises no ArchiveRead when the session archives nothing', async () => {
+    const capturedTools: string[][] = [];
+    const model = capturingModel(capturedTools);
+
+    await drain(
+      backendWith(model, undefined).send({
+        turnId: 'turn-1',
+        text: 'hello',
+        context: [],
+      }),
+    );
+
+    assert.ok(capturedTools.length > 0, 'expected the model to be called');
+    assert.ok(
+      !capturedTools[0]?.includes('ArchiveRead'),
+      'a session that never archives has nothing to decode, so the CLI stays free of the tool',
+    );
+  });
+
+  test('the decoder reads back what the writer archived', async () => {
+    // Indivisibility is about one authority, not two co-present fields: the
+    // tool the model is told to call must reach the storage the writer used.
+    const store = new Map<string, string>();
+    const archive = createToolResultArchiveCapability({
+      archiveToolResult: async (event) => {
+        store.set(event.bodySha256, event.serializedResult);
+        return { artifactId: `artifact-${event.bodySha256.slice(0, 8)}` };
+      },
+      readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
+      readArchivedToolResultResource: async (input) => {
+        const serializedResult = store.get(input.bodySha256);
+        return serializedResult === undefined
+          ? { ok: false, reason: 'not_found' }
+          : { ok: true, serializedResult };
+      },
+    });
+
+    const serializedResult = JSON.stringify({ kind: 'text', text: 'the pruned body' });
+    const bodySha256 = 'a'.repeat(64);
+    const written = await archive.services.archiveToolResult({
+      sessionId: 'session-1',
+      runtimeEventId: 'event-1',
+      turnId: 'turn-1',
+      toolCallId: 'call-1',
+      toolName: 'Bash',
+      result: undefined,
+      serializedResult,
+      bodySha256,
+      originalEstimatedTokens: 1_000,
+      originalBytes: Buffer.byteLength(serializedResult),
+      rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+      reason: 'active_current_turn_tool_result_pruned_before_next_step',
+    });
+    assert.ok(written, 'the writer must report where it archived the body');
+
+    const page = (await archive.archiveReadTool.impl(
+      {
+        ref: buildToolResultArchiveResourceRef({
+          artifactId: written.artifactId,
+          bodySha256,
+          originalBytes: Buffer.byteLength(serializedResult),
+        }),
+        operation: 'read',
+      },
+      toolContext(),
+    )) as { ok: boolean; content: string };
+
+    assert.equal(page.ok, true, 'the ref the placeholder carries must resolve');
+    assert.equal(page.content, serializedResult);
+  });
 });
+
+function toolContext(): MakaToolContext {
+  return {
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    cwd: '/tmp/maka',
+    toolCallId: 'call-1',
+    abortSignal: new AbortController().signal,
+    emitOutput: () => {},
+  };
+}
 
 function capability(): ToolResultArchiveCapability {
   return createToolResultArchiveCapability({

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -201,7 +201,6 @@ import {
   shouldAppendContextCompactedNote,
   shouldAppendContextCompactionFailedOpenNote,
   type ContextBudgetPolicy,
-  type ToolResultArchiveReader,
 } from './context-budget.js';
 import {
   evaluateHistoryCompactCheckpointReplay,
@@ -454,8 +453,6 @@ export type {
   SynthesisCacheWriter,
   SynthesisCacheWriteInput,
   SynthesisCacheWriteResult,
-  ToolResultArchiveRecorder,
-  ToolResultArchiveRecorderInput,
 } from './ai-sdk-compaction-contract.js';
 
 export interface AiSdkBackendInput extends AiSdkCompactionCapabilities {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -600,18 +600,6 @@ export interface AiSdkBackendInput extends AiSdkCompactionCapabilities {
    */
   supportsVision?: boolean;
   maxProviderImageRequestBytes?: number;
-  /**
-   * Optional archive reader for replay-only stale tool-result retrieval. The
-   * runtime never mutates persisted RuntimeEvents; successful reads hydrate
-   * the current model request only.
-   */
-  readToolResultArchive?: ToolResultArchiveReader;
-  /**
-   * The whole tool-result archive authority (#2026): writer, replay reader,
-   * ref reader, and the `ArchiveRead` decoder the pruned placeholder names.
-   * Absent means this session archives nothing, which is a valid state.
-   */
-  toolResultArchive?: ToolResultArchiveCapability;
 }
 
 export interface SystemPromptContext {
@@ -2741,7 +2729,7 @@ export class AiSdkBackend implements AgentBackend {
       const retrieval = await retrieveArchivedToolResultsForReplay(
         runtimeContext,
         contextBudget?.archiveRetrieval,
-        this.input.readToolResultArchive,
+        this.input.toolResultArchive?.services.readToolResultArchive,
         {
           sessionId: this.sessionId,
           charsPerToken: contextBudget?.charsPerToken,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -68,6 +68,10 @@ import {
 } from '@maka/core/orchestration';
 import type { PlanToolResult } from './plan-tools.js';
 import {
+  bindToolResultArchiveDecoder,
+  type ToolResultArchiveCapability,
+} from './tool-result-archive-capability.js';
+import {
   YIELD_AGENT_GRAPH_TOOL_NAME,
   type YieldAgentGraphToolResult,
 } from './stream-graph-supervisor-tools.js';
@@ -602,6 +606,12 @@ export interface AiSdkBackendInput extends AiSdkCompactionCapabilities {
    * the current model request only.
    */
   readToolResultArchive?: ToolResultArchiveReader;
+  /**
+   * The whole tool-result archive authority (#2026): writer, replay reader,
+   * ref reader, and the `ArchiveRead` decoder the pruned placeholder names.
+   * Absent means this session archives nothing, which is a valid state.
+   */
+  toolResultArchive?: ToolResultArchiveCapability;
 }
 
 export interface SystemPromptContext {
@@ -799,7 +809,9 @@ export class AiSdkBackend implements AgentBackend {
         this.appendTurnTailPrompt(content, turnTailPrompt),
     });
     this.toolAvailabilityRuntime = new ToolAvailabilityRuntime(
-      input.tools,
+      // The archive decoder is a runtime protocol tool, not a host binding:
+      // this session's placeholders name it, so this session advertises it.
+      bindToolResultArchiveDecoder(input.tools, input.toolResultArchive),
       input.toolAvailability,
       buildInvalidMakaTool(),
     );

--- a/packages/runtime/src/ai-sdk-compaction-contract.ts
+++ b/packages/runtime/src/ai-sdk-compaction-contract.ts
@@ -17,17 +17,6 @@ import type { ModelFactory } from './model-adapter.js';
 import type { SemanticCompactBlock } from './semantic-compact.js';
 import type { ToolResultArchiveCapability } from './tool-result-archive-capability.js';
 
-export type ToolResultArchiveRecorderInput = (
-  | StaleToolResultArchiveCandidate
-  | (ActiveToolResultArchiveCandidate & { runtimeEventId: string })
-) & {
-  sessionId: string;
-  bodySha256: string;
-};
-export type ToolResultArchiveRecorder = (
-  input: ToolResultArchiveRecorderInput,
-) => Promise<{ artifactId: string } | void> | { artifactId: string } | void;
-
 export interface SynthesisCacheLoadInput {
   sessionId: string;
   maxBlocks?: number;

--- a/packages/runtime/src/ai-sdk-compaction-contract.ts
+++ b/packages/runtime/src/ai-sdk-compaction-contract.ts
@@ -15,6 +15,7 @@ import type {
 import type { HistoryCompactCheckpoint } from './history-compact-checkpoint.js';
 import type { ModelFactory } from './model-adapter.js';
 import type { SemanticCompactBlock } from './semantic-compact.js';
+import type { ToolResultArchiveCapability } from './tool-result-archive-capability.js';
 
 export type ToolResultArchiveRecorderInput = (
   | StaleToolResultArchiveCandidate
@@ -153,11 +154,13 @@ export interface AiSdkCompactionCapabilities {
   /** Optional prior-history budget. Keeps whole turns to preserve tool-call/result pairs. */
   contextBudget?: ContextBudgetPolicy;
   /**
-   * Optional archive writer for replay-only stale tool-result pruning. The
-   * runtime rewrites only candidates whose original body has been durably
-   * archived by this callback.
+   * The whole tool-result archive authority (#2026): the writer that durably
+   * stores a pruned body, the replay reader that hydrates it back, the
+   * ref-addressed reader, and the `ArchiveRead` decoder the placeholder names.
+   * Absent means this session archives nothing, which is a valid state — but
+   * it can no longer mean "archives without a way back".
    */
-  archiveToolResult?: ToolResultArchiveRecorder;
+  toolResultArchive?: ToolResultArchiveCapability;
   /** Optional best-effort source-bearing synthesis cache loader. */
   loadSynthesisCache?: SynthesisCacheLoader;
   /** Optional best-effort source-bearing synthesis cache writer. */

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -944,7 +944,7 @@ export class AiSdkCompaction {
         for (const candidate of candidates) {
           const bodySha256 = sha256(candidate.serializedResult);
           const archived = await Promise.resolve(
-            this.input.archiveToolResult?.({
+            this.input.toolResultArchive?.services.archiveToolResult({
               ...candidate,
               sessionId: this.sessionId,
               bodySha256,
@@ -1013,7 +1013,7 @@ export class AiSdkCompaction {
         archivedPlaceholders,
         archiveToolResult: async (candidate) => {
           return await Promise.resolve(
-            this.input.archiveToolResult?.({
+            this.input.toolResultArchive?.services.archiveToolResult({
               ...candidate,
               sessionId: this.sessionId,
               runtimeEventId: candidate.runtimeEventId ?? activeToolResultArchiveKey(candidate),

--- a/packages/runtime/src/archive-read-tool.ts
+++ b/packages/runtime/src/archive-read-tool.ts
@@ -7,6 +7,8 @@ import {
   type ToolResultArchiveResourceReader,
 } from './tool-result-archive-resource.js';
 
+export const ARCHIVE_READ_TOOL_NAME = 'ArchiveRead';
+
 export function buildArchiveReadTool(reader: ToolResultArchiveResourceReader): MakaTool {
   const parameters = z
     .object({
@@ -58,7 +60,7 @@ export function buildArchiveReadTool(reader: ToolResultArchiveResourceReader): M
     });
   const providerSchema = zodSchema(parameters);
   return {
-    name: 'ArchiveRead',
+    name: ARCHIVE_READ_TOOL_NAME,
     displayName: 'Read archived result',
     activityKind: 'read',
     description:

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -62,8 +62,6 @@ import { linuxExecutableRoots } from './sandbox/linux-sandbox.js';
 import { pinExistingLinuxProfilePath } from './sandbox/linux-profile-path.js';
 import type { SandboxPlatform, SandboxType } from './sandbox/types.js';
 import type { ChildFdInput } from './child-fd-input.js';
-import { buildArchiveReadTool } from './archive-read-tool.js';
-import type { ToolResultArchiveResourceReader } from './tool-result-archive-resource.js';
 import { normalizeSandboxBoundaryPath } from './sandbox-boundary-path.js';
 import type { FilesystemWorkerClient } from './filesystem-worker/client.js';
 import {
@@ -144,7 +142,6 @@ export interface BuildBuiltinToolsOptions {
       abortSignal: AbortSignal,
     ): Promise<ToolResultContent>;
   };
-  archiveResources?: ToolResultArchiveResourceReader;
   backgroundTasks?: BackgroundTaskStopper;
   ptyControls?: PtyControlWriter;
   executor?: WorkspaceExecutor;
@@ -298,7 +295,6 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
   const tools: MakaTool[] = [
     ...bashTools,
     ...backgroundTools,
-    ...(options.archiveResources ? [buildArchiveReadTool(options.archiveResources)] : []),
     {
       name: 'Read',
       activityKind: 'read',

--- a/packages/runtime/src/deep-research-tools.ts
+++ b/packages/runtime/src/deep-research-tools.ts
@@ -42,7 +42,6 @@ export const DEEP_RESEARCH_COMPLETE_TOOL_NAME = 'deep_research_complete';
 const DEEP_RESEARCH_ALLOWED_TOOL_NAMES = new Set([
   'AskUserQuestion',
   'Read',
-  'ArchiveRead',
   'Glob',
   'Grep',
   'ExploreAgent',

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -412,8 +412,6 @@ export type {
   SynthesisCacheWriter,
   SynthesisCacheWriteInput,
   SynthesisCacheWriteResult,
-  ToolResultArchiveRecorder,
-  ToolResultArchiveRecorderInput,
   SemanticCompactBlockRecorder,
 } from './ai-sdk-compaction-contract.js';
 export { PiAgentBackend, normalizePiAgentFrame } from './pi-agent-backend.js';
@@ -425,12 +423,11 @@ export type {
 } from './pi-agent-backend.js';
 
 export { buildBuiltinTools } from './builtin-tools.js';
-export {
-  createToolResultArchiveCapability,
-  ARCHIVE_READ_TOOL_NAME,
-} from './tool-result-archive-capability.js';
+export { createToolResultArchiveCapability } from './tool-result-archive-capability.js';
 export type {
   ToolResultArchiveCapability,
+  ToolResultArchiveRecorder,
+  ToolResultArchiveRecorderInput,
   ToolResultArchiveServices,
 } from './tool-result-archive-capability.js';
 export { queryTavily } from './tavily-search.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -425,7 +425,14 @@ export type {
 } from './pi-agent-backend.js';
 
 export { buildBuiltinTools } from './builtin-tools.js';
-export { buildArchiveReadTool } from './archive-read-tool.js';
+export {
+  createToolResultArchiveCapability,
+  ARCHIVE_READ_TOOL_NAME,
+} from './tool-result-archive-capability.js';
+export type {
+  ToolResultArchiveCapability,
+  ToolResultArchiveServices,
+} from './tool-result-archive-capability.js';
 export { queryTavily } from './tavily-search.js';
 export { buildWebSearchTool } from './web-search-tool.js';
 export type {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -702,9 +702,18 @@ export interface BackendFactoryContext {
    */
   systemPrompt?: string;
   /**
-   * Optional hard tool ceiling for this backend activation. When present, a
-   * host may remove tools for stricter local policy, but must never append,
-   * substitute, or otherwise expose a tool outside this exact set.
+   * Optional hard tool ceiling on the *agent-permission* tools for this backend
+   * activation. When present, a host may remove tools for stricter local
+   * policy, but must never append, substitute, or otherwise expose an
+   * agent-permission tool outside this exact set.
+   *
+   * Runtime protocol tools are outside that ceiling by construction (#2026).
+   * `ArchiveRead` decodes a placeholder the runtime itself generated during
+   * pruning; it grants no reach the parent did not already exercise, and
+   * withholding it only strands content the model was explicitly told to
+   * retrieve. The backend therefore binds it from the archive capability, not
+   * from this set, which is why narrowing a child's allowlist can no longer
+   * silently strip the decoder for placeholders that child will still receive.
    */
   tools?: readonly MakaTool[];
   recordRunTrace?: RunTraceRecorder;

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -32,7 +32,6 @@ export const AGENT_TOOL_NAMES = [
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
 ] as const;
-const CHILD_RECOVERY_TOOL_NAMES = ['ArchiveRead'] as const;
 export const CHILD_AGENT_TOOL_NAMES = [
   ...new Set(BUILTIN_AGENT_DEFINITIONS.flatMap((definition) => definition.tools)),
 ] as readonly string[];
@@ -66,15 +65,6 @@ export function buildChildAgentTools(tools: readonly MakaTool[]): MakaTool[] {
       seen.add(tool.name);
       out.push(tool);
     }
-  }
-  // Runtime recovery tools are capability-dependent and must follow a child
-  // whenever the host provides them. Otherwise a child can receive an archive
-  // placeholder that explicitly names ArchiveRead without having that tool.
-  for (const name of CHILD_RECOVERY_TOOL_NAMES) {
-    const tool = tools.find((candidate) => candidate.name === name);
-    if (!tool || seen.has(name)) continue;
-    seen.add(name);
-    out.push(tool);
   }
   return out;
 }

--- a/packages/runtime/src/tool-result-archive-capability.ts
+++ b/packages/runtime/src/tool-result-archive-capability.ts
@@ -1,0 +1,68 @@
+/**
+ * The tool-result archive is one capability, not three optional fields (#2026).
+ *
+ * When the context budget prunes a large tool result, the placeholder that
+ * replaces it is a runtime-generated protocol value naming `ArchiveRead` as the
+ * way back to the content. Writer, replay reader, ref-addressed reader and that
+ * decoder tool therefore share one authority: a host either archives and can
+ * read back, or does neither. Splitting them across backend options and tool
+ * options made "writer on, decoder absent" representable, and it shipped twice
+ * (#2025 on the headless surface, and the child-agent path).
+ *
+ * Hosts supply only storage. The decoder travels with the capability and is
+ * bound by the backend, so which host remembered to register a tool is no
+ * longer part of the question.
+ */
+
+import { buildArchiveReadTool } from './archive-read-tool.js';
+import type { ToolResultArchiveRecorder } from './ai-sdk-compaction-contract.js';
+import type { ToolResultArchiveReader } from './tool-result-archive.js';
+import type { ToolResultArchiveResourceReader } from './tool-result-archive-resource.js';
+import type { MakaTool } from './tool-runtime.js';
+
+export const ARCHIVE_READ_TOOL_NAME = 'ArchiveRead';
+
+/** Host-owned storage for one archive authority. */
+export interface ToolResultArchiveServices {
+  /** Durably archives a pruned tool result body. */
+  archiveToolResult: ToolResultArchiveRecorder;
+  /** Replay hydration, addressed by the originating runtime event. */
+  readToolResultArchive: ToolResultArchiveReader;
+  /** Ref-addressed read backing `ArchiveRead`; carries no runtime-event identity. */
+  readArchivedToolResultResource: ToolResultArchiveResourceReader['readArchivedToolResultResource'];
+}
+
+/**
+ * One indivisible archive authority. Constructible only through
+ * {@link createToolResultArchiveCapability}, so a half-built capability has no
+ * spelling.
+ */
+export interface ToolResultArchiveCapability {
+  readonly services: ToolResultArchiveServices;
+  readonly archiveReadTool: MakaTool;
+}
+
+export function createToolResultArchiveCapability(
+  services: ToolResultArchiveServices,
+): ToolResultArchiveCapability {
+  return Object.freeze({
+    services: Object.freeze({ ...services }),
+    archiveReadTool: buildArchiveReadTool({
+      readArchivedToolResultResource: services.readArchivedToolResultResource,
+    }),
+  });
+}
+
+/**
+ * Add the decoder to a session's tool set when — and only when — that session
+ * archives. Idempotent, so a host that still binds `ArchiveRead` itself keeps
+ * exactly one of it while the surfaces are being migrated.
+ */
+export function bindToolResultArchiveDecoder(
+  tools: readonly MakaTool[],
+  capability: ToolResultArchiveCapability | undefined,
+): MakaTool[] {
+  if (!capability) return [...tools];
+  if (tools.some((tool) => tool.name === ARCHIVE_READ_TOOL_NAME)) return [...tools];
+  return [...tools, capability.archiveReadTool];
+}

--- a/packages/runtime/src/tool-result-archive-capability.ts
+++ b/packages/runtime/src/tool-result-archive-capability.ts
@@ -14,13 +14,30 @@
  * longer part of the question.
  */
 
-import { buildArchiveReadTool } from './archive-read-tool.js';
-import type { ToolResultArchiveRecorder } from './ai-sdk-compaction-contract.js';
+import { ARCHIVE_READ_TOOL_NAME, buildArchiveReadTool } from './archive-read-tool.js';
+import type { ActiveToolResultArchiveCandidate } from './active-tool-result-prune.js';
+import type { StaleToolResultArchiveCandidate } from './context-budget.js';
 import type { ToolResultArchiveReader } from './tool-result-archive.js';
 import type { ToolResultArchiveResourceReader } from './tool-result-archive-resource.js';
 import type { MakaTool } from './tool-runtime.js';
 
-export const ARCHIVE_READ_TOOL_NAME = 'ArchiveRead';
+export { ARCHIVE_READ_TOOL_NAME };
+
+/**
+ * What the writer is handed for one pruned body. The union spans both prune
+ * paths — a stale prior-turn result and an active current-turn one — because
+ * the archive is one authority over both.
+ */
+export type ToolResultArchiveRecorderInput = (
+  | StaleToolResultArchiveCandidate
+  | (ActiveToolResultArchiveCandidate & { runtimeEventId: string })
+) & {
+  sessionId: string;
+  bodySha256: string;
+};
+export type ToolResultArchiveRecorder = (
+  input: ToolResultArchiveRecorderInput,
+) => Promise<{ artifactId: string } | void> | { artifactId: string } | void;
 
 /** Host-owned storage for one archive authority. */
 export interface ToolResultArchiveServices {
@@ -28,14 +45,26 @@ export interface ToolResultArchiveServices {
   archiveToolResult: ToolResultArchiveRecorder;
   /** Replay hydration, addressed by the originating runtime event. */
   readToolResultArchive: ToolResultArchiveReader;
-  /** Ref-addressed read backing `ArchiveRead`; carries no runtime-event identity. */
+  /**
+   * Ref-addressed read backing `ArchiveRead`. A `maka://archive/...` ref carries
+   * only artifact id, hash and size — no runtime-event identity — so this read
+   * must never synthesize one to satisfy the stricter replay path above.
+   *
+   * It MUST reject a read whose `sessionId` does not own the artifact. The
+   * runtime passes down the invoking session's id but cannot verify ownership
+   * itself, so this is the only place the session boundary is enforced, and the
+   * argument that the decoder grants a child no reach it lacked rests on it.
+   */
   readArchivedToolResultResource: ToolResultArchiveResourceReader['readArchivedToolResultResource'];
 }
 
 /**
- * One indivisible archive authority. Constructible only through
- * {@link createToolResultArchiveCapability}, so a half-built capability has no
- * spelling.
+ * One indivisible archive authority. Build it through
+ * {@link createToolResultArchiveCapability}: the decoder is derived from the
+ * same services the writer uses, so "archives, but the placeholder names a tool
+ * nobody bound" has no spelling. A capability whose readers merely fail is of
+ * course still constructible — but that failure is legible to the model and the
+ * host, which is what the old missing-tool state never was.
  */
 export interface ToolResultArchiveCapability {
   readonly services: ToolResultArchiveServices;
@@ -55,8 +84,13 @@ export function createToolResultArchiveCapability(
 
 /**
  * Add the decoder to a session's tool set when — and only when — that session
- * archives. Idempotent, so a host that still binds `ArchiveRead` itself keeps
- * exactly one of it while the surfaces are being migrated.
+ * archives.
+ *
+ * No in-tree host binds `ArchiveRead` any more, so the dedup guard exists for
+ * tool sets this runtime does not own: an embedder's custom tool, or an agent
+ * definition that names it. Such a tool wins, which also means it — not this
+ * capability — is what the placeholder's ref will be handed to. Advertising two
+ * tools under one name would be worse.
  */
 export function bindToolResultArchiveDecoder(
   tools: readonly MakaTool[],


### PR DESCRIPTION
## Summary

The tool-result archive was three optional fields spread across two configuration surfaces. The writer (`archiveToolResult`) and the replay reader (`readToolResultArchive`) went to the backend; the ref-addressed reader (`archiveResources`) went to the tool builder. Nothing tied them together, so "this session archives but has no way to decode a placeholder" was a spellable state at all four hosts that assemble the capability — embedded desktop, runtime-host server, CLI, and headless/Harbor.

It shipped twice. #2025 was the headless surface. The child-agent path was the second instance, and `CHILD_RECOVERY_TOOL_NAMES` did not fix it: every child surface is re-narrowed by `buildToolsForAgentDefinition` against `definition.tools`, no built-in definition lists `ArchiveRead`, and durable snapshots record `[...definition.tools]`. The pass-through was undone by the very next step every time.

The fix is not a stricter assertion at the assembly points. It is noticing what the decoder actually is. When the context budget prunes a large tool result, the placeholder that replaces it is a **runtime-generated protocol value** naming `ArchiveRead` as the way back. Which tool decodes a value the runtime itself wrote is not a host configuration question and not an agent permission. So:

- `ToolResultArchiveCapability` bundles the writer, both readers, and the decoder tool. It is constructible only through `createToolResultArchiveCapability`, so a half-built capability has no spelling.
- Hosts supply storage and nothing else. The single `AiSdkBackendInput` field replaces the two backend options, and the backend binds the decoder itself at the one place `input.tools` is consumed.
- `archiveResources`, the hand-wired desktop and runtime-host `ArchiveRead` registrations, and the separate headless resource-reader builder are deleted. So are `CHILD_RECOVERY_TOOL_NAMES` and the `ArchiveRead` entry in the deep-research allowlist — both were pool-level pass-throughs that later narrowing undid.
- The CLI's legitimate "archives nothing at all" state stays expressible with no escape hatch: it simply passes no capability, and gets no decoder.

Closes #2026. Refs #2025, #2036, #2028.

## Breaking change

`BackendFactoryContext.tools` is now documented as a ceiling on **agent-permission** tools, not on everything the provider sees. A child receives its exact allowlist plus the archive decoder. That is the point of the change: withholding the decoder grants no safety — it only strands content the model was explicitly instructed to retrieve, using a ref the runtime minted from the parent's own tool output. The contract comment at `packages/runtime/src/session-manager.ts` says so explicitly rather than leaving the carve-out implicit.

The product tool surface identity no longer lists `ArchiveRead`, for the same reason: it records the host's product binding, and the decoder is not part of it. Nothing consumes that identity as "what the model will see" — the benchmark arm classifiers compare connection slug, model, reasoning effort, `agentTools`, prompt hash and pricing profile, never `productToolNames`, and `validateHarborCellExecutionIdentity` only checks catalog membership. So the under-report has no reader.

## Review

Reviewed by four independent passes (correctness/completeness, first-principles design, test quality, leftovers). No P0/P1. The one finding worth acting on was that every test observed *advertisement* and none observed *execution*, leaving half the invariant unpinned — a tool can reach the provider's list and still be unreachable at dispatch. Fixed with an end-to-end test that drives a real turn (prune → placeholder → model calls `ArchiveRead` with the ref → body returns), verified by mutation: deleting the binding fails it. Also cleaned three second-sources-of-truth the move left behind (a type cycle, a duplicated tool-name literal, a dead import) and corrected docblocks whose prose outlived the migration they described.

Declined: extracting the two 6-line desktop test helpers into a new `test-only` package export — a public-surface change costing more than the duplication it removes. Deferred: a second round-trip test for the runtime-host ref reader, which is literally the same `readArchive` function the replay reader already covers.

## Verification

- `npm run lint`, `npm run format:check`, `npm run build` — clean.
- `@maka/runtime` — 3195 pass, 0 fail (9 skipped).
- `@maka/runtime-host` — 699 pass, 0 fail. The child-ceiling assertions moved from `['Glob','Grep','Read']` to `['ArchiveRead','Glob','Grep','Read']` against a real provider wire, which is the observable proof that a narrowed child now keeps its decoder.
- `@maka/headless` — 1409 pass, 0 fail. Includes the #2025 round trip, now driven end to end from one capability.
- `@maka/core` — 784 pass, 0 fail.
- `@maka/desktop` — 13 failures, all pre-existing: the same set fails on `main` (33 failures there, a strict superset), and they are macOS temp-path and project-root resolution tests untouched by this change.
- `@maka/storage` — 15 failures, 16 on `main`; Git-worktree tests, and `packages/storage` does not depend on `@maka/runtime`.
- Not run: the Playwright E2E suite. This change is main-process and runtime wiring with no renderer surface, and the E2E suite runs the fake backend, which archives nothing.

New tests pin both halves of the contract at the provider-visible boundary — a session that archives advertises the tool its placeholders name, a session that archives nothing does not, the decoder reads back exactly what the writer stored, and it reads as the invoking session.
