### PR TITLE
fix(desktop): settings chat-defaults column alignment + assistant-tone textarea resize [AI cross reviewed]

### DIFF
--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -247,6 +247,11 @@ export function PersonalizationSettingsPage(props: {
         />
 
         <SettingsField>
+          {/* No fixed height style: it lands as inline style on the wrapper,
+              which pins the visible box while the inner textarea keeps its
+              native `resize: vertical` — dragging then moves only the grip.
+              `rows` owns the default height; the wrapper follows the
+              textarea, so user resizing works. */}
           <TextArea
             value={assistantTone}
             onChange={(value) => {
@@ -261,10 +266,6 @@ export function PersonalizationSettingsPage(props: {
             label={copy.assistantTone}
             description={copy.assistantToneHelp}
             width="100%"
-            style={{
-              boxSizing: 'border-box',
-              height: 'calc(var(--space-16) + var(--space-5))',
-            }}
           />
         </SettingsField>
       </SettingsSection>

--- a/apps/desktop/src/renderer/styles/settings/select.css
+++ b/apps/desktop/src/renderer/styles/settings/select.css
@@ -6,7 +6,12 @@
    the 默认模型 picker rendered at ~103px while its neighbour 默认权限模式 —
    which carries no width rule — expanded to 320px. Two adjacent rows in the
    same card staggered their controls by 200px. An explicit width gives both a
-   real column; max-width keeps it from overflowing a narrow settings pane. */
+   real column; max-width keeps it from overflowing a narrow settings pane.
+   This only works because neither component passes Selector's `width` prop:
+   that prop sizes the OUTER field, and a fixed field around a 260px trigger
+   re-staggers the column by the difference (the 默认权限模式 width={320}
+   regression did exactly that). The field wraps the trigger, so sizing the
+   trigger here sizes the whole control. */
 .settingsRows .settingsModelPickerTrigger,
 .settingsRows .permissionModeSelector {
   width: 260px;

--- a/packages/ui/src/model-picker.tsx
+++ b/packages/ui/src/model-picker.tsx
@@ -55,6 +55,9 @@ export function ModelPicker(props: ModelPickerProps) {
     [props.groups, props.leadingOption],
   );
 
+  // size=md matches the other settings-row selectors. Settings is the only
+  // production host since the composer footer moved to ghost DropdownMenus,
+  // so the size is a fact of the component, not a prop.
   return (
     <div className="maka-model-picker-root">
       <Selector
@@ -64,7 +67,7 @@ export function ModelPicker(props: ModelPickerProps) {
         value={props.value}
         hasSearch
         searchPlaceholder={props.searchPlaceholder ?? copy.searchPlaceholder}
-        size="sm"
+        size="md"
         placement="above"
         isDisabled={props.disabled}
         isLoading={props.loading}

--- a/packages/ui/src/permission-mode-menu.tsx
+++ b/packages/ui/src/permission-mode-menu.tsx
@@ -149,7 +149,6 @@ export function PermissionModeSelect(props: {
       disabledMessage={props.disabledReason}
       aria-description={meta.hint}
       placement="below"
-      width={320}
       className={cn('permissionModeSelector', props.className)}
       renderOption={(option) => (
         <SelectorOption

--- a/packages/ui/stories/model-picker.stories.tsx
+++ b/packages/ui/stories/model-picker.stories.tsx
@@ -75,9 +75,13 @@ export const Default: Story = {
 };
 
 // Real path: Settings → 通用 before any provider exposes a model choice.
+// The 260px frame stands in for the one part that cannot be imported from
+// this package: the desktop's `select.css` sizes the trigger to 260px via
+// `.settingsRows .settingsModelPickerTrigger`, which only exists in the
+// renderer's stylesheet. Size and state are the production ones.
 export const EmptyCatalog: Story = {
   render: () => (
-    <div style={{ width: 320 }}>
+    <div style={{ width: 260 }}>
       <ModelPicker
         groups={[]}
         value=""


### PR DESCRIPTION
<img width="924" height="653" alt="image" src="https://github.com/user-attachments/assets/fa91b7b9-061c-4919-8146-8e81abbeeaee" />


Two Settings → 通用 paper cuts, one commit each.

## 1. The chat-defaults selects staggered by 60px

The 默认模型 and 默认权限模式 rows are meant to form one trailing-control column — `select.css` sizes both triggers to 260px and its comment prescribes exactly that. But the 默认权限模式 selector passed `width={320}` to Astryx Selector, which sizes the **outer field**, while the CSS sizes the **inner trigger**: the 260px trigger left-aligned inside the 320px field and the two adjacent rows staggered by the 60px difference.

The Selector branch of `PermissionModeSelect` has no other consumer (the composer uses the icon appearance), so the prop served nobody. Dropping it lets the field wrap the trigger and the CSS own the column. The `select.css` comment now states the contract explicitly: the rule works only while neither component passes Selector's `width` prop.

The two triggers also rendered at different sizes (`sm` vs `md`). ModelPicker's `sm` dated from the composer footer, which has since moved to ghost DropdownMenus — General Settings is its only production host, and settings rows are `md`. The size is hardcoded `md` now, and the `EmptyCatalog` story renders the production size inside a 260px frame matching the column the desktop's `select.css` imposes (the one part a `packages/ui` story cannot import; the annotation says so per FIDELITY.md).

Measured after the fix: both controls at left 916 / right 1176 / height 32, aligned at 1280/900/620/480 viewport widths with no horizontal overflow.

## 2. Dragging the assistant-tone textarea's resize grip moved only the grip

The field passed `style={{ height: calc(…) }}` to TextArea, which lands as an inline height on the visible wrapper and pins it at 84px. The inner native textarea keeps the design system's `resize: vertical`, so dragging resized an element with a transparent background overflowing an unmoving box — only the grip appeared to travel.

Dropped the fixed height (and the `boxSizing` that existed for it): `rows={4}` already owns the default height (90px vs the pinned 84), and the wrapper follows the textarea, so the grip now resizes the visible control. Verified live: textarea 80→220px moves the wrapper 90→230px.

## Validation

- `@maka/ui` suite 382/382; typecheck (ui + desktop), biome lint, full monorepo build clean
- Both fixes verified in the running app via DOM measurement (numbers above)

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01Ac5rv6WUKWtMZgQb5QPN16