### PR TITLE
fix(ui): bound progressive fill idle so long transcripts settle

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -338,7 +338,7 @@ export const test = base.extend<{
       use,
     );
   },
-  // Overflowing rail: boots the e2e-fixture `overflowing-rail` fixture — 60
+  // Overflowing rail: boots the e2e-fixture `overflowing-rail` fixture — 90
   // short turns — and opens it as the active session. Same readiness contract
   // as the two above. Used by the prompt-rail spec to exercise the rail once it
   // is past its cap and scrolling independently of the transcript.

--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -143,8 +143,13 @@ async function scrollToRatio(page: Page, ratio: number): Promise<void> {
 }
 
 async function settled(page: Page, turns: number): Promise<void> {
+  // Progressive mount publishes data-progressive-fill; wait on that end state
+  // instead of racing idle fill steps against Playwright's default 10s count
+  // timeout (a 90-turn overflowing rail needs ~20 fill chunks).
+  const scroller = page.locator('[data-chat-scroll-container="true"]');
+  await expect(scroller).toHaveAttribute('data-progressive-fill', 'complete', { timeout: 45_000 });
   await expect(page.locator('.maka-turn')).toHaveCount(turns);
-  await expect(page.locator('[data-chat-scroll-container="true"][data-turn-warmup="settled"]')).toBeAttached({ timeout: 15_000 });
+  await expect(scroller).toHaveAttribute('data-turn-warmup', 'settled', { timeout: 15_000 });
 }
 
 test('the prompt rail stays inside the scrollport at every scroll position', async ({ longTranscriptWindow: page }) => {

--- a/packages/ui/src/__tests__/browser-warmup-scheduler.test.ts
+++ b/packages/ui/src/__tests__/browser-warmup-scheduler.test.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import { createBrowserWarmupScheduler } from '../turn-size-warmup.js';
+
+describe('createBrowserWarmupScheduler', () => {
+  const original = {
+    requestAnimationFrame: globalThis.requestAnimationFrame,
+    cancelAnimationFrame: globalThis.cancelAnimationFrame,
+    requestIdleCallback: globalThis.requestIdleCallback,
+    cancelIdleCallback: globalThis.cancelIdleCallback,
+  };
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = original.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = original.cancelAnimationFrame;
+    globalThis.requestIdleCallback = original.requestIdleCallback;
+    globalThis.cancelIdleCallback = original.cancelIdleCallback;
+  });
+
+  it('passes a positive idle deadline so busy main threads still advance fill/warmup', () => {
+    const idleOpts: IdleRequestOptions[] = [];
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      void cb;
+      return 1;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+    globalThis.requestIdleCallback = ((cb: IdleRequestCallback, options?: IdleRequestOptions) => {
+      void cb;
+      idleOpts.push(options ?? {});
+      return 7;
+    }) as typeof requestIdleCallback;
+    globalThis.cancelIdleCallback = (() => {}) as typeof cancelIdleCallback;
+
+    const scheduler = createBrowserWarmupScheduler();
+    assert.ok(scheduler, 'expected a browser scheduler when rAF exists');
+    scheduler.requestIdle(() => {});
+
+    assert.equal(idleOpts.length, 1);
+    const timeout = idleOpts[0]?.timeout;
+    assert.equal(typeof timeout, 'number');
+    assert.ok(Number.isFinite(timeout));
+    assert.ok((timeout as number) > 0);
+  });
+
+  it('returns undefined when requestAnimationFrame is unavailable', () => {
+    // @ts-expect-error intentional absence for the SSR/no-window branch
+    delete globalThis.requestAnimationFrame;
+    assert.equal(createBrowserWarmupScheduler(), undefined);
+  });
+});

--- a/packages/ui/src/turn-size-warmup.ts
+++ b/packages/ui/src/turn-size-warmup.ts
@@ -27,12 +27,30 @@ export interface WarmupScheduler {
   requestFrame(callback: () => void): () => void;
 }
 
-function defaultScheduler(): WarmupScheduler | undefined {
+/**
+ * Upper bound on how long idle-chunked work (turn-size warm-up, progressive
+ * transcript fill) may wait for a free main-thread slice. Without a deadline,
+ * bare `requestIdleCallback` can starve under sustained layout/paint load —
+ * CI observed a 90-turn fill stuck mid-window for >10s while the count still
+ * crept up four at a time. The timeout forces each step to run even when the
+ * browser never reports idle; when the thread is free, rIC still fires early.
+ *
+ * 100ms is long enough not to stampede short frames under light load, and
+ * short enough that a 20-step fill of a long session still completes in a
+ * couple of seconds of worst-case scheduling alone.
+ */
+const BROWSER_IDLE_TIMEOUT_MS = 100;
+
+/**
+ * Default browser scheduler shared by warm-up and progressive mount. Returns
+ * `undefined` when `requestAnimationFrame` is missing (SSR / no window).
+ */
+export function createBrowserWarmupScheduler(): WarmupScheduler | undefined {
   if (typeof requestAnimationFrame !== 'function') return undefined;
   return {
     requestIdle: typeof requestIdleCallback === 'function'
       ? (callback) => {
-        const id = requestIdleCallback(callback);
+        const id = requestIdleCallback(callback, { timeout: BROWSER_IDLE_TIMEOUT_MS });
         return () => cancelIdleCallback(id);
       }
       : (callback) => {
@@ -76,7 +94,7 @@ export function createTurnSizeWarmup(options: {
    */
   onSettled?: () => void;
 }): () => void {
-  const scheduler = options.scheduler ?? defaultScheduler();
+  const scheduler = options.scheduler ?? createBrowserWarmupScheduler();
   if (!scheduler) return () => {};
   const chunkSize = options.chunkSize ?? 16;
   // Bottom-up queue. The live-streaming tail is already forced visible by CSS

--- a/packages/ui/src/use-progressive-turn-mount.ts
+++ b/packages/ui/src/use-progressive-turn-mount.ts
@@ -9,26 +9,7 @@ import {
   type ViewportMetrics,
 } from './progressive-turn-mount.js';
 import { prefixHeightFor, type TurnGeometryRecord } from './turn-size-index.js';
-import type { WarmupScheduler } from './turn-size-warmup.js';
-
-function defaultScheduler(): WarmupScheduler | undefined {
-  if (typeof requestAnimationFrame !== 'function') return undefined;
-  return {
-    requestIdle: typeof requestIdleCallback === 'function'
-      ? (callback) => {
-        const id = requestIdleCallback(callback);
-        return () => cancelIdleCallback(id);
-      }
-      : (callback) => {
-        const id = setTimeout(callback, 1);
-        return () => clearTimeout(id);
-      },
-    requestFrame: (callback) => {
-      const id = requestAnimationFrame(callback);
-      return () => cancelAnimationFrame(id);
-    },
-  };
-}
+import { createBrowserWarmupScheduler, type WarmupScheduler } from './turn-size-warmup.js';
 
 /**
  * React adapter for the #2052 progressive transcript mount.
@@ -93,7 +74,7 @@ export function useProgressiveTurnMount(input: {
   const beforeFillRef = useRef<ViewportMetrics | undefined>(undefined);
   const schedulerRef = useRef<WarmupScheduler | undefined>(undefined);
   if (schedulerRef.current === undefined) {
-    schedulerRef.current = input.scheduler ?? defaultScheduler();
+    schedulerRef.current = input.scheduler ?? createBrowserWarmupScheduler();
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Main CI was failing on `e2e/prompt-rail.spec.ts` → *the active tick stays visible once the rail overflows*: expected 90 `.maka-turn` nodes, received ~54–58 while the progressive fill was still climbing in steps of four.

Root cause: progressive mount and turn-size warm-up schedule work with bare `requestIdleCallback` (no deadline), so a busy CI main thread can starve fill for >10s. The prompt-rail `settled()` helper only raced turn count against Playwright’s default 10s expect timeout and did not wait on the published `data-progressive-fill` end state.

This PR:
- extracts a shared `createBrowserWarmupScheduler` with `{ timeout: 100 }` on idle callbacks (fill + warm-up)
- waits for `data-progressive-fill="complete"` in prompt-rail before asserting turn count / warm-up
- corrects the overflowing-rail fixture comment (90 turns, not 60)

## Verification

- `npm run build -w @maka/core && npm run build -w @maka/ui`
- `node --test packages/ui/dist/__tests__/browser-warmup-scheduler.test.js packages/ui/dist/__tests__/turn-size-warmup.test.js packages/ui/dist/__tests__/chat-view-progressive-mount.test.js` → pass
- `npm run lint` / `npm run format:check` → pass
- Full Playwright `prompt-rail` suite not run locally (Electron E2E); relies on CI `e2e_shard`

## Root cause

Unrelated main merges (#2198, #2214) were canaries: the flake is progressive-fill scheduling + a test that ignored the fill’s own completion attribute.