### PR TITLE
feat(runtime): Edit/Write/FormatJson emit file_diff results for both renderers

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -3987,6 +3987,12 @@ describe('Maka Pi TUI transcript', () => {
     // Green (32) around the added line, red (31) around the removed line.
     assert.match(raw, /\x1b\[32m\+added line\x1b\[39m/);
     assert.match(raw, /\x1b\[31m-removed line\x1b\[39m/);
+    // The `---`/`+++` file headers repeat the path the card already shows;
+    // the hunk header stays as the only line-number anchor.
+    const expanded = stripAnsi(raw);
+    assert.doesNotMatch(expanded, /--- a\/file\.ts/);
+    assert.doesNotMatch(expanded, /\+\+\+ b\/file\.ts/);
+    assert.match(expanded, /@@ -1 \+1 @@/);
   });
 
   test('caps long terminal output to head and tail lines when expanded', () => {

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -11,7 +11,7 @@ import {
 } from '@maka/core';
 import { truncateToWidth, visibleWidth } from '@earendil-works/pi-tui';
 import { ansi, disc } from './tui-ansi.js';
-import { colorDiff, diffLineKind } from './tui-diff.js';
+import { colorDiff, diffLineKind, isDiffHeaderLine } from './tui-diff.js';
 import {
   collapseToSingleLine,
   fitLine,
@@ -668,7 +668,11 @@ function renderShellRunResult(
 }
 
 function renderDiffResult(diff: string, width: number): string[] {
-  return renderIndented(colorDiff(limitText(diff, 12_000)), width, 2);
+  const visible = diff
+    .split('\n')
+    .filter((line) => !isDiffHeaderLine(line))
+    .join('\n');
+  return renderIndented(colorDiff(limitText(visible, 12_000)), width, 2);
 }
 
 function byteLength(text: string): number {

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -3,6 +3,7 @@ import {
   formatQuietJsonValue,
   formatToolInvocationLine,
   isActiveShellRunStatus,
+  countDiffLineStats,
   ptyTuiTerminalRows,
   ptyTuiTerminalView,
   readWriteStdinInputPreview,
@@ -11,7 +12,7 @@ import {
 } from '@maka/core';
 import { truncateToWidth, visibleWidth } from '@earendil-works/pi-tui';
 import { ansi, disc } from './tui-ansi.js';
-import { colorDiff, diffLineKind, isDiffHeaderLine } from './tui-diff.js';
+import { colorDiff } from './tui-diff.js';
 import {
   collapseToSingleLine,
   fitLine,
@@ -311,15 +312,9 @@ function compactTerminalSummary(
 function compactDiffSummary(
   content: Extract<ToolResultContent, { kind: 'file_diff' }>,
 ): CompactToolSummary {
-  let adds = 0;
-  let dels = 0;
-  for (const line of content.diff.split('\n')) {
-    const kind = diffLineKind(line);
-    if (kind === 'add') adds += 1;
-    else if (kind === 'del') dels += 1;
-  }
+  const { additions, deletions } = countDiffLineStats(content.diff);
   // The path is already the card's input summary; the tally is the outcome.
-  return { text: `${ansi.green(`+${adds}`)} ${ansi.red(`-${dels}`)}`, protect: true };
+  return { text: `${ansi.green(`+${additions}`)} ${ansi.red(`-${deletions}`)}`, protect: true };
 }
 
 /**
@@ -668,11 +663,9 @@ function renderShellRunResult(
 }
 
 function renderDiffResult(diff: string, width: number): string[] {
-  const visible = diff
-    .split('\n')
-    .filter((line) => !isDiffHeaderLine(line))
-    .join('\n');
-  return renderIndented(colorDiff(limitText(visible, 12_000)), width, 2);
+  // The structural parse drops the `---`/`+++` file headers the card already
+  // names; the copyable ledger keeps them.
+  return renderIndented(colorDiff(limitText(diff, 12_000)), width, 2);
 }
 
 function byteLength(text: string): number {

--- a/packages/cli/src/tui-diff.ts
+++ b/packages/cli/src/tui-diff.ts
@@ -16,6 +16,17 @@ export function diffLineKind(line: string): DiffLineKind {
   return 'ctx';
 }
 
+/**
+ * File header lines the expanded diff hides: the `---`/`+++` markers repeat
+ * the path the tool card already names, and `index` hashes are noise. The
+ * trailing space is what separates a real file marker from the deletion of a
+ * YAML `---` line. `diff --git` stays visible as the only in-body boundary
+ * between files.
+ */
+export function isDiffHeaderLine(line: string): boolean {
+  return line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('index ');
+}
+
 /** Tint a diff line by kind: add→green, del→red, hunk→accent, meta→dim, ctx→plain. */
 export function colorDiffLine(line: string): string {
   switch (diffLineKind(line)) {

--- a/packages/cli/src/tui-diff.ts
+++ b/packages/cli/src/tui-diff.ts
@@ -1,49 +1,30 @@
+import { parseUnifiedDiffRows, type UnifiedDiffRow } from '@maka/core';
 import { ansi } from './tui-ansi.js';
 
-export type DiffLineKind = 'add' | 'del' | 'hunk' | 'meta' | 'ctx';
-
 /**
- * Classify a single unified-diff line. Copied from the renderer-side
- * `diffLineKind` in `@maka/ui` (tool-result-preview.tsx) so the CLI stays
- * free of React/DOM imports. `+++`/`---` file headers count as metadata,
- * `@@` hunk headers get their own kind, and bare `+`/`-` are add/del.
+ * Diff coloring for the transcript, over the shared structural parse in
+ * `@maka/core`. The parse drives classification with the declared hunk
+ * counts, so a deleted `-- `-prefixed line colors red instead of dimming as
+ * a false file header, and file headers (`---`/`+++`/`index`) never reach
+ * the transcript at all. Hunk headers stay: they are the only line-number
+ * anchor in the terminal rendering.
  */
-export function diffLineKind(line: string): DiffLineKind {
-  if (line.startsWith('+++') || line.startsWith('---')) return 'meta';
-  if (line.startsWith('@@')) return 'hunk';
-  if (line.startsWith('+')) return 'add';
-  if (line.startsWith('-')) return 'del';
-  return 'ctx';
-}
-
-/**
- * File header lines the expanded diff hides: the `---`/`+++` markers repeat
- * the path the tool card already names, and `index` hashes are noise. The
- * trailing space is what separates a real file marker from the deletion of a
- * YAML `---` line. `diff --git` stays visible as the only in-body boundary
- * between files.
- */
-export function isDiffHeaderLine(line: string): boolean {
-  return line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('index ');
-}
-
-/** Tint a diff line by kind: add→green, del→red, hunk→accent, meta→dim, ctx→plain. */
-export function colorDiffLine(line: string): string {
-  switch (diffLineKind(line)) {
+export function colorDiffRow(row: UnifiedDiffRow): string {
+  switch (row.kind) {
     case 'add':
-      return ansi.green(line);
+      return ansi.green(row.text);
     case 'del':
-      return ansi.red(line);
+      return ansi.red(row.text);
     case 'hunk':
-      return ansi.accent(line);
+      return ansi.accent(row.text);
     case 'meta':
-      return ansi.dim(line);
+      return ansi.dim(row.text);
     case 'ctx':
-      return line;
+      return row.text;
   }
 }
 
 /** Color a whole diff body, preserving line breaks. */
 export function colorDiff(diff: string): string {
-  return diff.split('\n').map(colorDiffLine).join('\n');
+  return parseUnifiedDiffRows(diff).map(colorDiffRow).join('\n');
 }

--- a/packages/core/src/__tests__/unified-diff.test.ts
+++ b/packages/core/src/__tests__/unified-diff.test.ts
@@ -126,25 +126,13 @@ describe('parseUnifiedDiffRows', () => {
 
 describe('countDiffLineStats', () => {
   test('counts every change line, including `--`/`++`-prefixed content', () => {
-    const diff = [
-      '@@ -1,3 +1,3 @@',
-      ' kept',
-      '--- a',
-      '+i += 1;',
-      ' tail',
-    ].join('\n');
+    const diff = ['@@ -1,3 +1,3 @@', ' kept', '--- a', '+i += 1;', ' tail'].join('\n');
 
     assert.deepEqual(countDiffLineStats(diff), { additions: 1, deletions: 1 });
   });
 
   test('ignores file headers and hunk headers', () => {
-    const diff = [
-      '--- /dev/null',
-      '+++ b/new.md',
-      '@@ -0,0 +1,2 @@',
-      '+alpha',
-      '+beta',
-    ].join('\n');
+    const diff = ['--- /dev/null', '+++ b/new.md', '@@ -0,0 +1,2 @@', '+alpha', '+beta'].join('\n');
 
     assert.deepEqual(countDiffLineStats(diff), { additions: 2, deletions: 0 });
   });

--- a/packages/core/src/__tests__/unified-diff.test.ts
+++ b/packages/core/src/__tests__/unified-diff.test.ts
@@ -1,0 +1,151 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+
+import { countDiffLineStats, parseUnifiedDiffRows } from '../unified-diff.js';
+
+describe('parseUnifiedDiffRows', () => {
+  test('parses a standard single-hunk diff, omitting file headers', () => {
+    const rows = parseUnifiedDiffRows(
+      ['--- a/x.ts', '+++ b/x.ts', '@@ -1,3 +1,3 @@', ' kept', '-old', '+new', ' tail'].join('\n'),
+    );
+
+    assert.deepEqual(rows, [
+      { kind: 'hunk', text: '@@ -1,3 +1,3 @@' },
+      { kind: 'ctx', text: ' kept', oldLine: 1, newLine: 1 },
+      { kind: 'del', text: '-old', oldLine: 2 },
+      { kind: 'add', text: '+new', newLine: 2 },
+      { kind: 'ctx', text: ' tail', oldLine: 3, newLine: 3 },
+    ]);
+  });
+
+  test('a deleted line whose content starts with `-- ` is a deletion, not a file header', () => {
+    // Unified diff writes the deletion of `-- a` as `--- a`: inside a hunk
+    // body the first character is the marker, however header-like the rest
+    // looks. Heuristic prefix matching hides these lines and desyncs every
+    // line number after them.
+    const rows = parseUnifiedDiffRows(
+      ['@@ -1,3 +1,2 @@', ' SELECT 1;', '--- a', '-SELECT 3;'].join('\n'),
+    );
+
+    assert.deepEqual(rows, [
+      { kind: 'hunk', text: '@@ -1,3 +1,2 @@' },
+      { kind: 'ctx', text: ' SELECT 1;', oldLine: 1, newLine: 1 },
+      { kind: 'del', text: '--- a', oldLine: 2 },
+      { kind: 'del', text: '-SELECT 3;', oldLine: 3 },
+    ]);
+  });
+
+  test('an added line whose content starts with `++` is an addition', () => {
+    const rows = parseUnifiedDiffRows(
+      ['@@ -1,2 +1,3 @@', ' let i = 0;', '+++i;', '+i += 1;', ' return i;'].join('\n'),
+    );
+
+    assert.deepEqual(rows, [
+      { kind: 'hunk', text: '@@ -1,2 +1,3 @@' },
+      { kind: 'ctx', text: ' let i = 0;', oldLine: 1, newLine: 1 },
+      { kind: 'add', text: '+++i;', newLine: 2 },
+      { kind: 'add', text: '+i += 1;', newLine: 3 },
+      { kind: 'ctx', text: ' return i;', oldLine: 2, newLine: 4 },
+    ]);
+  });
+
+  test('`\\ No newline at end of file` markers carry no number and advance no counter', () => {
+    const rows = parseUnifiedDiffRows(
+      [
+        '@@ -1 +1 @@',
+        '-old',
+        '\\ No newline at end of file',
+        '+new',
+        '\\ No newline at end of file',
+      ].join('\n'),
+    );
+
+    assert.deepEqual(rows, [
+      { kind: 'hunk', text: '@@ -1 +1 @@' },
+      { kind: 'del', text: '-old', oldLine: 1 },
+      { kind: 'meta', text: '\\ No newline at end of file' },
+      { kind: 'add', text: '+new', newLine: 1 },
+      { kind: 'meta', text: '\\ No newline at end of file' },
+    ]);
+  });
+
+  test('resumes numbering per hunk and treats post-hunk `---`/`+++` as the next file', () => {
+    const rows = parseUnifiedDiffRows(
+      [
+        '@@ -10,1 +10,1 @@',
+        '-a',
+        '+b',
+        '--- a/second.ts',
+        '+++ b/second.ts',
+        '@@ -1,1 +1,1 @@',
+        '-c',
+        '+d',
+      ].join('\n'),
+    );
+
+    assert.deepEqual(rows, [
+      { kind: 'hunk', text: '@@ -10,1 +10,1 @@' },
+      { kind: 'del', text: '-a', oldLine: 10 },
+      { kind: 'add', text: '+b', newLine: 10 },
+      { kind: 'hunk', text: '@@ -1,1 +1,1 @@' },
+      { kind: 'del', text: '-c', oldLine: 1 },
+      { kind: 'add', text: '+d', newLine: 1 },
+    ]);
+  });
+
+  test('keeps `diff --git` separators as meta rows and a new-file diff reads from /dev/null', () => {
+    const rows = parseUnifiedDiffRows(
+      [
+        'diff --git a/new.md b/new.md',
+        'index 0000000..1111111',
+        '--- /dev/null',
+        '+++ b/new.md',
+        '@@ -0,0 +1,2 @@',
+        '+alpha',
+        '+beta',
+      ].join('\n'),
+    );
+
+    assert.deepEqual(rows, [
+      { kind: 'meta', text: 'diff --git a/new.md b/new.md' },
+      { kind: 'hunk', text: '@@ -0,0 +1,2 @@' },
+      { kind: 'add', text: '+alpha', newLine: 1 },
+      { kind: 'add', text: '+beta', newLine: 2 },
+    ]);
+  });
+
+  test('a foreign diff without hunk headers degrades to unnumbered meta rows', () => {
+    const rows = parseUnifiedDiffRows(['+function main() {', '-// old comment'].join('\n'));
+
+    assert.deepEqual(rows, [
+      { kind: 'meta', text: '+function main() {' },
+      { kind: 'meta', text: '-// old comment' },
+    ]);
+  });
+});
+
+describe('countDiffLineStats', () => {
+  test('counts every change line, including `--`/`++`-prefixed content', () => {
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' kept',
+      '--- a',
+      '+i += 1;',
+      ' tail',
+    ].join('\n');
+
+    assert.deepEqual(countDiffLineStats(diff), { additions: 1, deletions: 1 });
+  });
+
+  test('ignores file headers and hunk headers', () => {
+    const diff = [
+      '--- /dev/null',
+      '+++ b/new.md',
+      '@@ -0,0 +1,2 @@',
+      '+alpha',
+      '+beta',
+    ].join('\n');
+
+    assert.deepEqual(countDiffLineStats(diff), { additions: 2, deletions: 0 });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -505,6 +505,12 @@ export {
   type QuietPreview,
   type ToolInvocationInput,
 } from './tool-quiet-preview.js';
+export {
+  countDiffLineStats,
+  parseUnifiedDiffRows,
+  type UnifiedDiffRow,
+  type UnifiedDiffRowKind,
+} from './unified-diff.js';
 export { redactSecrets as displayRedactSecrets } from './display-redaction.js';
 export {
   SHELL_RUN_ID_MAX_CHARS,

--- a/packages/core/src/unified-diff.ts
+++ b/packages/core/src/unified-diff.ts
@@ -1,0 +1,113 @@
+/**
+ * Structural parser for unified diffs, shared by every surface that reads one:
+ * the desktop diff panel (line-number gutter), the tool-row +/- badges, the
+ * TUI transcript, and the model-facing result summaries.
+ *
+ * The parse is driven by the declared hunk counts, not per-line heuristics:
+ * inside a hunk body the first character is the marker, however header-like
+ * the rest of the line looks — the deletion of a SQL `-- a` comment arrives
+ * as `--- a`, and an added `++i` as `+++i`. Prefix matching cannot tell those
+ * from file headers; the hunk counts can.
+ *
+ * Pure and dependency-free, like `tool-quiet-preview.ts` — the packages that
+ * consume it (ui, cli, runtime) must not pull React or Node builtins from
+ * here.
+ */
+
+export type UnifiedDiffRowKind = 'add' | 'del' | 'ctx' | 'meta' | 'hunk';
+
+export type UnifiedDiffRow = {
+  kind: UnifiedDiffRowKind;
+  /** The raw diff line, prefix included. */
+  text: string;
+  /** Old-side line number, set on del/ctx rows. */
+  oldLine?: number;
+  /** New-side line number, set on add/ctx rows. */
+  newLine?: number;
+};
+
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+/**
+ * Parse a unified diff into display rows. File headers (`---`/`+++`/`index`)
+ * are structure, not content, and are omitted; `diff --git` separators and
+ * `\ No newline at end of file` markers survive as unnumbered meta rows;
+ * hunk headers survive as hunk rows so callers that want them (the TUI) can
+ * keep them. Anything before the first hunk header — a foreign diff with no
+ * structure — degrades to unnumbered meta rows.
+ */
+export function parseUnifiedDiffRows(diff: string): UnifiedDiffRow[] {
+  const lines = diff.split('\n');
+  // A trailing newline terminates the diff rather than starting an empty row.
+  if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
+
+  const rows: UnifiedDiffRow[] = [];
+  let oldLine = 0;
+  let newLine = 0;
+  let remainingOld = 0;
+  let remainingNew = 0;
+  let inHunk = false;
+
+  for (const line of lines) {
+    if (inHunk && remainingOld + remainingNew > 0) {
+      const marker = line.charAt(0);
+      if (marker === '\\') {
+        // `\ No newline at end of file` annotates the previous row without
+        // consuming a line on either side.
+        rows.push({ kind: 'meta', text: line });
+        continue;
+      }
+      if (marker === '-') {
+        rows.push({ kind: 'del', text: line, oldLine });
+        oldLine += 1;
+        remainingOld -= 1;
+        continue;
+      }
+      if (marker === '+') {
+        rows.push({ kind: 'add', text: line, newLine });
+        newLine += 1;
+        remainingNew -= 1;
+        continue;
+      }
+      // ' ' context, and the bare empty line some generators emit for one.
+      rows.push({ kind: 'ctx', text: line, oldLine, newLine });
+      oldLine += 1;
+      newLine += 1;
+      remainingOld -= 1;
+      remainingNew -= 1;
+      continue;
+    }
+    inHunk = false;
+
+    const hunk = HUNK_HEADER.exec(line);
+    if (hunk) {
+      oldLine = Number(hunk[1]);
+      newLine = Number(hunk[3]);
+      remainingOld = hunk[2] === undefined ? 1 : Number(hunk[2]);
+      remainingNew = hunk[4] === undefined ? 1 : Number(hunk[4]);
+      inHunk = true;
+      rows.push({ kind: 'hunk', text: line });
+      continue;
+    }
+    if (line.startsWith('diff ')) {
+      rows.push({ kind: 'meta', text: line });
+      continue;
+    }
+    if (line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('index ')) {
+      continue;
+    }
+    rows.push({ kind: 'meta', text: line });
+  }
+  return rows;
+}
+
+/** Green `+N` / red `-N` counts, from the structural parse. */
+export function countDiffLineStats(diff: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const row of parseUnifiedDiffRows(diff)) {
+    if (row.kind === 'add') additions += 1;
+    else if (row.kind === 'del') deletions += 1;
+  }
+  return { additions, deletions };
+}

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -9647,6 +9647,52 @@ describe('AiSdkBackend context budget and prompt attribution', () => {
     );
   });
 
+  test('replay hands the model a bounded summary for an Edit file_diff result, not the diff', () => {
+    const diff = ['--- a/a.ts', '+++ b/a.ts', '@@ -1,2 +1,2 @@', ' keep', '-old', '+new'].join(
+      '\n',
+    );
+    const events = [
+      runtimeEvent({
+        id: 'edit-call',
+        turnId: 't1',
+        role: 'model',
+        author: 'agent',
+        content: {
+          kind: 'function_call',
+          id: 'tool-edit',
+          name: 'Edit',
+          args: { path: 'a.ts' },
+        },
+      }),
+      runtimeEvent({
+        id: 'edit-result',
+        turnId: 't1',
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'tool-edit',
+          name: 'Edit',
+          result: { kind: 'file_diff', paths: ['a.ts'], diff },
+        },
+      }),
+    ];
+
+    const plan = buildRuntimeEventModelReplayPlan(events);
+    const result = plan.items.find(
+      (item) => item.kind === 'tool_result' && item.toolCallId === 'tool-edit',
+    );
+
+    assert.equal(result?.kind === 'tool_result' ? result.output : undefined, 'Edited a.ts (+1 -1)');
+    // The durable event itself keeps the full diff — only the model-facing
+    // projection is bounded.
+    const durable = events[1].content;
+    assert.equal(
+      durable?.kind === 'function_response' ? (durable.result as { kind: string }).kind : undefined,
+      'file_diff',
+    );
+  });
+
   test('usage events include prompt segments and context budget diagnostics', async () => {
     const model = completionModel();
     const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/builtin-tools-file-worker.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools-file-worker.test.ts
@@ -244,7 +244,12 @@ describe('file tools surface a file_diff result', () => {
       diff: DIFF,
     });
 
-    const result = await runTool(tools, 'Edit', { path: 'a.ts', old_string: 'old', new_string: 'new' }, cwd);
+    const result = await runTool(
+      tools,
+      'Edit',
+      { path: 'a.ts', old_string: 'old', new_string: 'new' },
+      cwd,
+    );
 
     assert.deepEqual(result, { kind: 'file_diff', paths: ['a.ts'], diff: DIFF });
   });
@@ -261,7 +266,12 @@ describe('file tools surface a file_diff result', () => {
       endLine: 2,
     });
 
-    const result = await runTool(tools, 'Edit', { path: 'a.ts', old_string: 'old', new_string: 'new' }, cwd);
+    const result = await runTool(
+      tools,
+      'Edit',
+      { path: 'a.ts', old_string: 'old', new_string: 'new' },
+      cwd,
+    );
 
     assert.deepEqual(result, {
       ok: true,
@@ -294,7 +304,12 @@ describe('file tools surface a file_diff result', () => {
 
   test('Write degrades to a file_write descriptor when the worker reports no diff', async () => {
     const cwd = await temporaryDirectory('maka-write-nodiff-');
-    const tools = toolsWithWorkerResult({ kind: 'write', ok: true, path: 'huge.bin', bytes: 70000 });
+    const tools = toolsWithWorkerResult({
+      kind: 'write',
+      ok: true,
+      path: 'huge.bin',
+      bytes: 70000,
+    });
 
     const result = await runTool(tools, 'Write', { path: 'huge.bin', content: 'x' }, cwd);
 

--- a/packages/runtime/src/__tests__/builtin-tools-file-worker.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools-file-worker.test.ts
@@ -221,6 +221,121 @@ describe('builtin file tools use the sandboxed worker', () => {
   });
 });
 
+describe('file tools surface a file_diff result', () => {
+  const DIFF = ['--- a/a.ts', '+++ b/a.ts', '@@ -1,2 +1,2 @@', ' keep', '-old', '+new'].join('\n');
+
+  function toolsWithWorkerResult(result: Record<string, unknown>) {
+    return buildBuiltinTools({
+      filesystemWorker: { execute: async () => result as never },
+      sandboxPlatform: 'darwin',
+    });
+  }
+
+  test('Edit returns a file_diff content when the worker reports a diff', async () => {
+    const cwd = await temporaryDirectory('maka-edit-diff-');
+    const tools = toolsWithWorkerResult({
+      kind: 'edit',
+      ok: true,
+      path: 'a.ts',
+      replacements: 1,
+      matchedVia: 'exact',
+      startLine: 1,
+      endLine: 2,
+      diff: DIFF,
+    });
+
+    const result = await runTool(tools, 'Edit', { path: 'a.ts', old_string: 'old', new_string: 'new' }, cwd);
+
+    assert.deepEqual(result, { kind: 'file_diff', paths: ['a.ts'], diff: DIFF });
+  });
+
+  test('Edit keeps the fact summary when the worker reports no diff', async () => {
+    const cwd = await temporaryDirectory('maka-edit-nodiff-');
+    const tools = toolsWithWorkerResult({
+      kind: 'edit',
+      ok: true,
+      path: 'a.ts',
+      replacements: 1,
+      matchedVia: 'exact',
+      startLine: 1,
+      endLine: 2,
+    });
+
+    const result = await runTool(tools, 'Edit', { path: 'a.ts', old_string: 'old', new_string: 'new' }, cwd);
+
+    assert.deepEqual(result, {
+      ok: true,
+      path: 'a.ts',
+      replacements: 1,
+      matchedVia: 'exact',
+      startLine: 1,
+      endLine: 2,
+    });
+  });
+
+  test('Write returns a file_diff content when the worker reports a diff', async () => {
+    const cwd = await temporaryDirectory('maka-write-diff-');
+    const tools = toolsWithWorkerResult({
+      kind: 'write',
+      ok: true,
+      path: 'new.md',
+      bytes: 12,
+      diff: ['--- /dev/null', '+++ b/new.md', '@@ -0,0 +1,2 @@', '+alpha', '+beta'].join('\n'),
+    });
+
+    const result = await runTool(tools, 'Write', { path: 'new.md', content: 'alpha\nbeta\n' }, cwd);
+
+    assert.deepEqual(result, {
+      kind: 'file_diff',
+      paths: ['new.md'],
+      diff: ['--- /dev/null', '+++ b/new.md', '@@ -0,0 +1,2 @@', '+alpha', '+beta'].join('\n'),
+    });
+  });
+
+  test('Write degrades to a file_write descriptor when the worker reports no diff', async () => {
+    const cwd = await temporaryDirectory('maka-write-nodiff-');
+    const tools = toolsWithWorkerResult({ kind: 'write', ok: true, path: 'huge.bin', bytes: 70000 });
+
+    const result = await runTool(tools, 'Write', { path: 'huge.bin', content: 'x' }, cwd);
+
+    assert.deepEqual(result, { kind: 'file_write', path: 'huge.bin', bytes: 70000 });
+  });
+
+  test('FormatJson returns a file_diff content and never leaks the diff as json', async () => {
+    const cwd = await temporaryDirectory('maka-format-diff-');
+    const tools = toolsWithWorkerResult({
+      kind: 'format_json',
+      ok: true,
+      valid: true,
+      path: 'data.json',
+      bytesBefore: 12,
+      bytesAfter: 20,
+      byteDelta: 8,
+      changed: true,
+      diff: DIFF,
+    });
+
+    const result = await runTool(tools, 'FormatJson', { path: 'data.json' }, cwd);
+
+    assert.deepEqual(result, { kind: 'file_diff', paths: ['data.json'], diff: DIFF });
+  });
+
+  test('the model output for an edit is a bounded summary, not the diff', async () => {
+    const tools = buildBuiltinTools();
+    const tool = tools.find((candidate) => candidate.name === 'Edit');
+    if (!tool) throw new Error('Edit tool missing');
+    if (!tool.toModelOutput) throw new Error('Edit toModelOutput missing');
+
+    const output = await tool.toModelOutput({
+      toolCallId: 'tool-1',
+      input: { path: 'a.ts', old_string: 'old', new_string: 'new' },
+      output: { kind: 'file_diff', paths: ['a.ts'], diff: DIFF },
+    });
+
+    assert.deepEqual(output, { type: 'text', value: 'Edited a.ts (+1 -1)' });
+  });
+});
+
 async function runTool(
   tools: ReturnType<typeof buildBuiltinTools>,
   name: string,

--- a/packages/runtime/src/__tests__/builtin-tools-file-worker.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools-file-worker.test.ts
@@ -349,6 +349,42 @@ describe('file tools surface a file_diff result', () => {
 
     assert.deepEqual(output, { type: 'text', value: 'Edited a.ts (+1 -1)' });
   });
+
+  test('the model output counts additions whose content starts with ++', async () => {
+    const tools = buildBuiltinTools();
+    const tool = tools.find((candidate) => candidate.name === 'Edit');
+    if (!tool?.toModelOutput) throw new Error('Edit toModelOutput missing');
+
+    const output = await tool.toModelOutput({
+      toolCallId: 'tool-1',
+      input: { path: 'a.ts', old_string: 'let i = 0;', new_string: 'let i = 0;\n++i;' },
+      output: {
+        kind: 'file_diff',
+        paths: ['a.ts'],
+        diff: '@@ -1,1 +1,2 @@\n let i = 0;\n+++i;',
+      },
+    });
+
+    assert.deepEqual(output, { type: 'text', value: 'Edited a.ts (+1 -0)' });
+  });
+
+  test('the model output for a new-file write names it created with its line count', async () => {
+    const tools = buildBuiltinTools();
+    const tool = tools.find((candidate) => candidate.name === 'Write');
+    if (!tool?.toModelOutput) throw new Error('Write toModelOutput missing');
+
+    const output = await tool.toModelOutput({
+      toolCallId: 'tool-1',
+      input: { path: 'new.md', content: 'alpha\nbeta\n' },
+      output: {
+        kind: 'file_diff',
+        paths: ['new.md'],
+        diff: '--- /dev/null\n+++ b/new.md\n@@ -0,0 +1,2 @@\n+alpha\n+beta',
+      },
+    });
+
+    assert.deepEqual(output, { type: 'text', value: 'Created new.md (+2)' });
+  });
 });
 
 async function runTool(

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -1995,7 +1995,7 @@ describe('builtin write tools path containment', () => {
         content: 'from-executor',
       },
     ]);
-    expect(result).toMatchObject({ ok: true, path: '/workspace/created.txt', bytes: 13 });
+    expect(result).toMatchObject({ kind: 'file_diff', paths: ['/workspace/created.txt'] });
   });
 
   test('Write delegates file writing to the injected workspace executor', async () => {
@@ -2016,7 +2016,7 @@ describe('builtin write tools path containment', () => {
     expect(writes).toHaveLength(1);
     expect(writes[0]?.path.endsWith('created.txt')).toBe(true);
     expect(writes[0]?.content).toBe('from-executor');
-    expect(result).toMatchObject({ ok: true, bytes: 13 });
+    expect(result).toMatchObject({ kind: 'file_diff' });
   });
 
   test('Edit reads and writes through the injected workspace executor', async () => {
@@ -2047,10 +2047,9 @@ describe('builtin write tools path containment', () => {
     expect(reads).toHaveLength(1);
     expect(writes).toHaveLength(1);
     expect(writes[0]?.content).toBe('hello Maka\n');
-    expect(result).toMatchObject({
-      ok: true,
-      replacements: 1,
-    });
+    expect(result).toMatchObject({ kind: 'file_diff' });
+    expect((result as { diff: string }).diff).toContain('-hello world');
+    expect((result as { diff: string }).diff).toContain('+hello Maka');
   });
 
   test('Edit rejects image results from the workspace executor', async () => {
@@ -2223,13 +2222,7 @@ describe('builtin write tools path containment', () => {
         ),
       ),
     );
-    expect(
-      results.every(
-        (r) =>
-          (r as { ok: boolean; replacements: number }).ok === true &&
-          (r as { replacements: number }).replacements === 1,
-      ),
-    ).toBe(true);
+    expect(results.every((r) => (r as { kind: string }).kind === 'file_diff')).toBe(true);
     const expected = `${Array.from({ length: n }, (_, i) => `done-${String(i).padStart(2, '0')}`).join('\n')}\n`;
     expect(await readFile(join(root, 'data.txt'), 'utf8')).toBe(expected);
   });
@@ -2256,7 +2249,7 @@ describe('builtin write tools path containment', () => {
         ),
       ),
     );
-    expect(results.every((r) => (r as { ok: boolean }).ok === true)).toBe(true);
+    expect(results.every((r) => (r as { kind: string }).kind === 'file_diff')).toBe(true);
     const expected = `${Array.from({ length: n }, (_, i) => `done-${String(i).padStart(2, '0')}`).join('\n')}\n`;
     expect(await readFile(join(root, 'data.txt'), 'utf8')).toBe(expected);
   });
@@ -2287,7 +2280,7 @@ describe('builtin write tools path containment', () => {
         ),
       ),
     );
-    expect(results.every((r) => (r as { ok: boolean }).ok === true)).toBe(true);
+    expect(results.every((r) => (r as { kind: string }).kind === 'file_diff')).toBe(true);
     const expected = `${Array.from({ length: n }, (_, i) => `done-${String(i).padStart(2, '0')}`).join('\n')}\n`;
     expect(await readFile(join(workspace, 'data.txt'), 'utf8')).toBe(expected);
   });
@@ -2349,12 +2342,9 @@ describe('builtin FormatJson (file in place)', () => {
 
     const onDisk = await readFile(join(root, name), 'utf8');
     expect(onDisk).toBe(JSON.stringify(JSON.parse(input), null, 2));
-    expect(result.ok).toBe(true);
-    expect(result.valid).toBe(true);
-    expect(result.changed).toBe(true);
-    expect(result.bytesBefore).toBe(Buffer.byteLength(input, 'utf8'));
-    expect(result.bytesAfter).toBe(Buffer.byteLength(onDisk, 'utf8'));
-    expect(result.byteDelta).toBe((result.bytesAfter ?? 0) - result.bytesBefore);
+    expect(result).toMatchObject({ kind: 'file_diff' });
+    expect((result as unknown as { paths: string[] }).paths[0]?.endsWith('data.json')).toBe(true);
+    expect((result as unknown as { diff: string }).diff).toContain(`-${input}`);
   });
 
   test('rejects image results from the workspace executor', async () => {
@@ -2380,7 +2370,7 @@ describe('builtin FormatJson (file in place)', () => {
 
     const onDisk = await readFile(join(root, name), 'utf8');
     expect(onDisk).toBe('{\n  "a": 2,\n  "m": 3,\n  "z": 1\n}');
-    expect(result.changed).toBe(true);
+    expect((result as unknown as { kind: string }).kind).toBe('file_diff');
   });
 
   test('sort_keys: true preserves __proto__ as a data property', async () => {
@@ -2443,7 +2433,7 @@ describe('builtin FormatJson (file in place)', () => {
     const result = await runFormatJson({ path: name }, root);
 
     const onDisk = await readFile(join(root, name), 'utf8');
-    expect(result.valid).toBe(true);
+    expect((result as unknown as { kind: string }).kind).toBe('file_diff');
     expect(onDisk).toContain('🎉');
     expect(onDisk).toContain('你好');
   });

--- a/packages/runtime/src/__tests__/filesystem-authority.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-authority.test.ts
@@ -80,7 +80,9 @@ describe('file tools follow the execution boundary', () => {
         cwd,
         BYPASS,
       );
-      expect(written).toMatchObject({ ok: true, path: target });
+      expect(written).toMatchObject({ kind: 'file_diff', paths: [target] });
+      expect((written as { diff: string }).diff).toContain('--- /dev/null');
+      expect((written as { diff: string }).diff).toContain('+hello');
       expect(await readFile(target, 'utf8')).toBe('hello');
 
       const read = await runTool(toolNamed(tools, 'Read'), { path: target }, cwd, BYPASS);
@@ -92,7 +94,9 @@ describe('file tools follow the execution boundary', () => {
         cwd,
         BYPASS,
       );
-      expect(edited).toMatchObject({ ok: true, replacements: 1 });
+      expect(edited).toMatchObject({ kind: 'file_diff', paths: [target] });
+      expect((edited as { diff: string }).diff).toContain('-hello');
+      expect((edited as { diff: string }).diff).toContain('+bye');
       expect(await readFile(target, 'utf8')).toBe('bye');
 
       await writeFile(join(outside, 'data.json'), '{"b":1,"a":2}', 'utf8');
@@ -102,7 +106,7 @@ describe('file tools follow the execution boundary', () => {
         cwd,
         BYPASS,
       );
-      expect(formatted).toMatchObject({ ok: true, valid: true, changed: true });
+      expect(formatted).toMatchObject({ kind: 'file_diff' });
 
       const globbed = (await runTool(
         toolNamed(tools, 'Glob'),
@@ -216,7 +220,7 @@ describe('file tools follow the execution boundary', () => {
         cwd,
         MANAGED,
       );
-      expect(result).toMatchObject({ ok: true, path: target });
+      expect(result).toMatchObject({ kind: 'file_write', path: target, bytes: 1 });
       expect(calls).toHaveLength(1);
       // The worker decided; nothing was written by the host backend.
       await assert.rejects(readFile(target, 'utf8'));

--- a/packages/runtime/src/__tests__/filesystem-worker.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker.test.ts
@@ -254,6 +254,155 @@ describe('filesystem worker operations', () => {
     assert.equal(response.ok, false);
     if (!response.ok) assert.equal(response.error.code, 'path_changed');
   });
+
+  test('returns a unified diff for an applied edit', async () => {
+    const root = await temporaryDirectory('maka-worker-edit-diff-');
+    const target = join(root, 'file.ts');
+    await writeFile(target, 'one\ntwo\nthree\nfour\nfive\n', 'utf8');
+
+    const response = await executeFilesystemWorkerRequest(
+      requestFor(
+        { kind: 'edit', cwd: root, path: target, oldString: 'three', newString: 'THREE' },
+        { enforcementPath: target, access: 'write', scope: 'exact', targetType: 'file' },
+      ),
+    );
+
+    assert.ok(response.ok);
+    assert.equal(response.result.kind, 'edit');
+    if (response.result.kind !== 'edit') return;
+    assert.equal(
+      response.result.diff,
+      [
+        `--- a/${target}`,
+        `+++ b/${target}`,
+        '@@ -1,5 +1,5 @@',
+        ' one',
+        ' two',
+        '-three',
+        '+THREE',
+        ' four',
+        ' five',
+      ].join('\n'),
+    );
+  });
+
+  test('returns the whole content as additions when writing a new file', async () => {
+    const root = await temporaryDirectory('maka-worker-write-new-');
+    const target = join(root, 'new.md');
+
+    const response = await executeFilesystemWorkerRequest(
+      requestFor(
+        { kind: 'write', cwd: root, path: target, content: 'alpha\nbeta\n' },
+        { enforcementPath: target, access: 'write', scope: 'exact', targetType: 'missing' },
+      ),
+    );
+
+    assert.ok(response.ok);
+    assert.equal(response.result.kind, 'write');
+    if (response.result.kind !== 'write') return;
+    assert.equal(
+      response.result.diff,
+      ['--- /dev/null', `+++ b/${target}`, '@@ -0,0 +1,2 @@', '+alpha', '+beta'].join('\n'),
+    );
+  });
+
+  test('returns a unified diff when overwriting an existing file', async () => {
+    const root = await temporaryDirectory('maka-worker-write-over-');
+    const target = join(root, 'existing.md');
+    await writeFile(target, 'alpha\nold\nomega\n', 'utf8');
+
+    const response = await executeFilesystemWorkerRequest(
+      requestFor(
+        { kind: 'write', cwd: root, path: target, content: 'alpha\nnew\nomega\n' },
+        { enforcementPath: target, access: 'write', scope: 'exact', targetType: 'file' },
+      ),
+    );
+
+    assert.ok(response.ok);
+    assert.equal(response.result.kind, 'write');
+    if (response.result.kind !== 'write') return;
+    assert.equal(
+      response.result.diff,
+      [
+        `--- a/${target}`,
+        `+++ b/${target}`,
+        '@@ -1,3 +1,3 @@',
+        ' alpha',
+        '-old',
+        '+new',
+        ' omega',
+      ].join('\n'),
+    );
+  });
+
+  test('returns a unified diff when FormatJson normalizes a file', async () => {
+    const root = await temporaryDirectory('maka-worker-format-diff-');
+    const target = join(root, 'data.json');
+    await writeFile(target, '{"b":1,"a":2}', 'utf8');
+
+    const response = await executeFilesystemWorkerRequest(
+      requestFor(
+        { kind: 'format_json', cwd: root, path: target, sortKeys: false },
+        { enforcementPath: target, access: 'write', scope: 'exact', targetType: 'file' },
+      ),
+    );
+
+    assert.ok(response.ok);
+    assert.equal(response.result.kind, 'format_json');
+    if (response.result.kind !== 'format_json') return;
+    assert.equal(response.result.changed, true);
+    assert.equal(
+      response.result.diff,
+      [
+        `--- a/${target}`,
+        `+++ b/${target}`,
+        '@@ -1,1 +1,4 @@',
+        '-{"b":1,"a":2}',
+        '+{',
+        '+  "b": 1,',
+        '+  "a": 2',
+        '+}',
+      ].join('\n'),
+    );
+  });
+
+  test('omits the diff when the content is too large to diff cheaply', async () => {
+    const root = await temporaryDirectory('maka-worker-huge-');
+    const target = join(root, 'huge.ts');
+    const before = Array.from({ length: 900 }, (_, i) => `const v${i} = ${i};`).join('\n') + '\n';
+    await writeFile(target, before, 'utf8');
+
+    const response = await executeFilesystemWorkerRequest(
+      requestFor(
+        { kind: 'edit', cwd: root, path: target, oldString: 'const v0 = 0;', newString: 'const v0 = -1;' },
+        { enforcementPath: target, access: 'write', scope: 'exact', targetType: 'file' },
+      ),
+    );
+
+    assert.ok(response.ok);
+    assert.equal(response.result.kind, 'edit');
+    if (response.result.kind !== 'edit') return;
+    assert.equal(response.result.diff, undefined);
+  });
+
+  test('returns no diff when FormatJson leaves the file unchanged', async () => {
+    const root = await temporaryDirectory('maka-worker-format-same-');
+    const target = join(root, 'data.json');
+    await writeFile(target, '{\n  "a": 1\n}', 'utf8');
+
+    const response = await executeFilesystemWorkerRequest(
+      requestFor(
+        { kind: 'format_json', cwd: root, path: target, sortKeys: false },
+        { enforcementPath: target, access: 'write', scope: 'exact', targetType: 'file' },
+      ),
+    );
+
+    assert.ok(response.ok);
+    assert.equal(response.result.kind, 'format_json');
+    if (response.result.kind !== 'format_json') return;
+    assert.equal(response.result.changed, false);
+    assert.equal(response.result.diff, undefined);
+  });
 });
 
 function requestFor(

--- a/packages/runtime/src/__tests__/filesystem-worker.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker.test.ts
@@ -374,7 +374,13 @@ describe('filesystem worker operations', () => {
 
     const response = await executeFilesystemWorkerRequest(
       requestFor(
-        { kind: 'edit', cwd: root, path: target, oldString: 'const v0 = 0;', newString: 'const v0 = -1;' },
+        {
+          kind: 'edit',
+          cwd: root,
+          path: target,
+          oldString: 'const v0 = 0;',
+          newString: 'const v0 = -1;',
+        },
         { enforcementPath: target, access: 'write', scope: 'exact', targetType: 'file' },
       ),
     );

--- a/packages/runtime/src/__tests__/filesystem-worker.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker.test.ts
@@ -391,7 +391,7 @@ describe('filesystem worker operations', () => {
     assert.equal(response.result.diff, undefined);
   });
 
-  test('returns no diff when FormatJson leaves the file unchanged', async () => {
+  test('omits the diff when FormatJson leaves the file unchanged', async () => {
     const root = await temporaryDirectory('maka-worker-format-same-');
     const target = join(root, 'data.json');
     await writeFile(target, '{\n  "a": 1\n}', 'utf8');
@@ -407,6 +407,44 @@ describe('filesystem worker operations', () => {
     assert.equal(response.result.kind, 'format_json');
     if (response.result.kind !== 'format_json') return;
     assert.equal(response.result.changed, false);
+    assert.equal(response.result.diff, undefined);
+  });
+
+  test('reports no diff — not a new-file diff — when an existing file cannot be read', async () => {
+    const root = await temporaryDirectory('maka-worker-unreadable-');
+    const target = join(root, 'locked.md');
+    await writeFile(target, 'secret\n', { mode: 0o222 });
+
+    const response = await executeFilesystemWorkerRequest(
+      requestFor(
+        { kind: 'write', cwd: root, path: target, content: 'replacement\n' },
+        { enforcementPath: target, access: 'write', scope: 'exact', targetType: 'file' },
+      ),
+    );
+
+    assert.ok(response.ok);
+    assert.equal(response.result.kind, 'write');
+    if (response.result.kind !== 'write') return;
+    // The write landed, but what was there before is unknown — claiming
+    // `--- /dev/null` would report the file as created.
+    assert.equal(response.result.diff, undefined);
+  });
+
+  test('reports no diff when overwriting an image', async () => {
+    const root = await temporaryDirectory('maka-worker-image-write-');
+    const target = join(root, 'pixel.png');
+    await writeFile(target, ONE_PIXEL_PNG);
+
+    const response = await executeFilesystemWorkerRequest(
+      requestFor(
+        { kind: 'write', cwd: root, path: target, content: 'not an image anymore\n' },
+        { enforcementPath: target, access: 'write', scope: 'exact', targetType: 'file' },
+      ),
+    );
+
+    assert.ok(response.ok);
+    assert.equal(response.result.kind, 'write');
+    if (response.result.kind !== 'write') return;
     assert.equal(response.result.diff, undefined);
   });
 });

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -26,6 +26,7 @@ import {
   type ToolResultContent,
 } from '@maka/core';
 import { bashToolResultToModelOutput } from './bash-model-output.js';
+import { fileWriteToolResultToModelOutput } from './file-tool-model-output.js';
 import {
   buildManagedBashTool,
   buildStopBackgroundTaskTool,
@@ -383,8 +384,11 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
         });
         if (result.kind !== 'write')
           throw internalFilesystemWriteFailure('Write', 'the file was written');
-        return { ok: result.ok, path: result.path, bytes: result.bytes };
+        if (result.diff !== undefined)
+          return { kind: 'file_diff' as const, paths: [result.path], diff: result.diff };
+        return { kind: 'file_write' as const, path: result.path, bytes: result.bytes };
       },
+      toModelOutput: ({ output }) => fileWriteToolResultToModelOutput('Write', output),
     },
     {
       name: 'Edit',
@@ -417,6 +421,8 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
             'the edit was applied',
             'a different old_string will not help',
           );
+        if (result.diff !== undefined)
+          return { kind: 'file_diff' as const, paths: [result.path], diff: result.diff };
         return {
           ok: result.ok,
           path: result.path,
@@ -426,6 +432,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
           endLine: result.endLine,
         };
       },
+      toModelOutput: ({ output }) => fileWriteToolResultToModelOutput('Edit', output),
     },
     {
       name: 'FormatJson',
@@ -461,11 +468,14 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
         if (result.kind !== 'format_json') {
           throw internalFilesystemWriteFailure('FormatJson', 'the file was rewritten');
         }
+        if (result.diff !== undefined)
+          return { kind: 'file_diff' as const, paths: [result.path], diff: result.diff };
         // The discriminator is how the backends name their results to each
         // other; the model is owed the payload, as with every other file tool.
         const { kind: _kind, ...diagnostic } = result;
         return diagnostic;
       },
+      toModelOutput: ({ output }) => fileWriteToolResultToModelOutput('FormatJson', output),
     },
     {
       name: 'Glob',

--- a/packages/runtime/src/file-tool-model-output.ts
+++ b/packages/runtime/src/file-tool-model-output.ts
@@ -24,7 +24,9 @@ export function fileWriteToolResultToModelOutput(
   return toolResultOutput(output, false);
 }
 
-function isFileDiff(output: unknown): output is { kind: 'file_diff'; paths: string[]; diff: string } {
+function isFileDiff(
+  output: unknown,
+): output is { kind: 'file_diff'; paths: string[]; diff: string } {
   return (
     typeof output === 'object' &&
     output !== null &&
@@ -34,7 +36,9 @@ function isFileDiff(output: unknown): output is { kind: 'file_diff'; paths: stri
   );
 }
 
-function isFileWrite(output: unknown): output is { kind: 'file_write'; path: string; bytes: number } {
+function isFileWrite(
+  output: unknown,
+): output is { kind: 'file_write'; path: string; bytes: number } {
   return (
     typeof output === 'object' &&
     output !== null &&

--- a/packages/runtime/src/file-tool-model-output.ts
+++ b/packages/runtime/src/file-tool-model-output.ts
@@ -1,0 +1,55 @@
+import type { ToolResultOutput } from './model-protocol.js';
+import { toolResultOutput } from './tool-result-output.js';
+
+/**
+ * The diff is for the reader; the model is owed only what happened — a bounded
+ * one-line summary. Editing is the hottest tool in the loop, so anything
+ * attached to its output compounds across a turn; the full diff stays in the
+ * durable result where the UI renders it.
+ */
+export function fileWriteToolResultToModelOutput(
+  toolName: 'Write' | 'Edit' | 'FormatJson',
+  output: unknown,
+): ToolResultOutput {
+  if (isFileDiff(output)) {
+    const path = output.paths[0] ?? 'file';
+    const { additions, deletions } = diffLineStats(output.diff);
+    if (toolName === 'Write' && output.diff.startsWith('--- /dev/null'))
+      return { type: 'text', value: `Created ${path} (+${additions})` };
+    const verb = toolName === 'Write' ? 'Overwrote' : toolName === 'Edit' ? 'Edited' : 'Formatted';
+    return { type: 'text', value: `${verb} ${path} (+${additions} -${deletions})` };
+  }
+  if (isFileWrite(output))
+    return { type: 'text', value: `Wrote ${output.bytes} bytes to ${output.path}` };
+  return toolResultOutput(output, false);
+}
+
+function isFileDiff(output: unknown): output is { kind: 'file_diff'; paths: string[]; diff: string } {
+  return (
+    typeof output === 'object' &&
+    output !== null &&
+    (output as { kind?: unknown }).kind === 'file_diff' &&
+    Array.isArray((output as { paths?: unknown }).paths) &&
+    typeof (output as { diff?: unknown }).diff === 'string'
+  );
+}
+
+function isFileWrite(output: unknown): output is { kind: 'file_write'; path: string; bytes: number } {
+  return (
+    typeof output === 'object' &&
+    output !== null &&
+    (output as { kind?: unknown }).kind === 'file_write' &&
+    typeof (output as { bytes?: unknown }).bytes === 'number'
+  );
+}
+
+function diffLineStats(diff: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+++') || line.startsWith('---')) continue;
+    if (line.startsWith('+')) additions += 1;
+    else if (line.startsWith('-')) deletions += 1;
+  }
+  return { additions, deletions };
+}

--- a/packages/runtime/src/file-tool-model-output.ts
+++ b/packages/runtime/src/file-tool-model-output.ts
@@ -1,3 +1,4 @@
+import { countDiffLineStats } from '@maka/core';
 import type { ToolResultOutput } from './model-protocol.js';
 import { toolResultOutput } from './tool-result-output.js';
 
@@ -11,17 +12,37 @@ export function fileWriteToolResultToModelOutput(
   toolName: 'Write' | 'Edit' | 'FormatJson',
   output: unknown,
 ): ToolResultOutput {
+  const summary = fileWriteToolResultSummary(toolName, output);
+  return summary !== undefined ? { type: 'text', value: summary } : toolResultOutput(output, false);
+}
+
+/**
+ * Replay counterpart of `fileWriteToolResultToModelOutput`. The durable ledger
+ * keeps the full diff for the UI, and every model re-read of history — prior
+ * turns, compaction, resume — flows through the replay plan. Without this
+ * projection the model saw a one-line summary live but the full diff JSON on
+ * every later turn, which is both a token leak and a shape inconsistency.
+ * Same precedent as `projectBashToolResultForModel`.
+ */
+export function projectFileWriteToolResultForModel(toolName: string, output: unknown): unknown {
+  if (toolName !== 'Edit' && toolName !== 'Write' && toolName !== 'FormatJson') return output;
+  return fileWriteToolResultSummary(toolName, output) ?? output;
+}
+
+function fileWriteToolResultSummary(
+  toolName: 'Write' | 'Edit' | 'FormatJson',
+  output: unknown,
+): string | undefined {
   if (isFileDiff(output)) {
     const path = output.paths[0] ?? 'file';
-    const { additions, deletions } = diffLineStats(output.diff);
+    const { additions, deletions } = countDiffLineStats(output.diff);
     if (toolName === 'Write' && output.diff.startsWith('--- /dev/null'))
-      return { type: 'text', value: `Created ${path} (+${additions})` };
+      return `Created ${path} (+${additions})`;
     const verb = toolName === 'Write' ? 'Overwrote' : toolName === 'Edit' ? 'Edited' : 'Formatted';
-    return { type: 'text', value: `${verb} ${path} (+${additions} -${deletions})` };
+    return `${verb} ${path} (+${additions} -${deletions})`;
   }
-  if (isFileWrite(output))
-    return { type: 'text', value: `Wrote ${output.bytes} bytes to ${output.path}` };
-  return toolResultOutput(output, false);
+  if (isFileWrite(output)) return `Wrote ${output.bytes} bytes to ${output.path}`;
+  return undefined;
 }
 
 function isFileDiff(
@@ -45,15 +66,4 @@ function isFileWrite(
     (output as { kind?: unknown }).kind === 'file_write' &&
     typeof (output as { bytes?: unknown }).bytes === 'number'
   );
-}
-
-function diffLineStats(diff: string): { additions: number; deletions: number } {
-  let additions = 0;
-  let deletions = 0;
-  for (const line of diff.split('\n')) {
-    if (line.startsWith('+++') || line.startsWith('---')) continue;
-    if (line.startsWith('+')) additions += 1;
-    else if (line.startsWith('-')) deletions += 1;
-  }
-  return { additions, deletions };
 }

--- a/packages/runtime/src/filesystem-executor.ts
+++ b/packages/runtime/src/filesystem-executor.ts
@@ -215,16 +215,27 @@ function createWorkspaceFilesystemExecutor(
             scope,
           });
           // Read-before-write: an overwrite's diff is what tells the reader
-          // what was lost; a missing file means the whole content is new.
-          let previous: string | undefined;
+          // what was lost. Only a missing file means the whole content is
+          // new — an unreadable or binary existing file leaves the previous
+          // state unknown, and claiming `--- /dev/null` would report the
+          // file as created.
+          let previous: 'new' | 'unknown' | string;
           try {
             const read = await workspace.readFile({ cwd, path });
-            previous = 'bytes' in read ? undefined : read.content;
-          } catch {
-            previous = undefined;
+            previous = 'bytes' in read ? 'unknown' : read.content;
+          } catch (error) {
+            const code = (error as NodeJS.ErrnoException).code;
+            previous = code === 'ENOENT' || code === 'ENOTDIR' ? 'new' : 'unknown';
           }
           const written = await workspace.writeFile({ cwd, path, content: operation.content });
-          const diff = createUnifiedDiff(written.path, previous, operation.content);
+          const diff =
+            previous === 'unknown'
+              ? undefined
+              : createUnifiedDiff(
+                  written.path,
+                  previous === 'new' ? undefined : previous,
+                  operation.content,
+                );
           return {
             kind: 'write',
             ok: true,

--- a/packages/runtime/src/filesystem-executor.ts
+++ b/packages/runtime/src/filesystem-executor.ts
@@ -14,6 +14,7 @@ import { realpath } from 'node:fs/promises';
 import { isAbsolute } from 'node:path';
 import type { ExecutionBoundary, PermissionMode, PermissionProfile } from '@maka/core';
 import { computeEditedSource } from './edit-replace.js';
+import { createUnifiedDiff } from './unified-diff.js';
 import { withFileWriteLock } from './file-write-lock.js';
 import type {
   FilesystemWorkerClient,
@@ -213,8 +214,24 @@ function createWorkspaceFilesystemExecutor(
             label: 'Write',
             scope,
           });
+          // Read-before-write: an overwrite's diff is what tells the reader
+          // what was lost; a missing file means the whole content is new.
+          let previous: string | undefined;
+          try {
+            const read = await workspace.readFile({ cwd, path });
+            previous = 'bytes' in read ? undefined : read.content;
+          } catch {
+            previous = undefined;
+          }
           const written = await workspace.writeFile({ cwd, path, content: operation.content });
-          return { kind: 'write', ok: true, path: written.path, bytes: written.bytes };
+          const diff = createUnifiedDiff(written.path, previous, operation.content);
+          return {
+            kind: 'write',
+            ok: true,
+            path: written.path,
+            bytes: written.bytes,
+            ...(diff !== undefined ? { diff } : {}),
+          };
         }
         case 'edit': {
           const { path } = await workspace.resolveExistingPath({
@@ -232,6 +249,7 @@ function createWorkspaceFilesystemExecutor(
             operation.path,
           );
           await workspace.writeFile({ cwd, path, content: edited.content });
+          const diff = createUnifiedDiff(path, read.content, edited.content);
           return {
             kind: 'edit',
             ok: true,
@@ -240,6 +258,7 @@ function createWorkspaceFilesystemExecutor(
             matchedVia: edited.matchedVia,
             startLine: edited.startLine,
             endLine: edited.endLine,
+            ...(diff !== undefined ? { diff } : {}),
           };
         }
         case 'format_json': {
@@ -275,6 +294,8 @@ function createWorkspaceFilesystemExecutor(
             path,
             content: formatted,
           });
+          const diff =
+            formatted === original ? undefined : createUnifiedDiff(path, original, formatted);
           return {
             kind: 'format_json',
             ok: true,
@@ -284,6 +305,7 @@ function createWorkspaceFilesystemExecutor(
             bytesAfter,
             byteDelta: bytesAfter - bytesBefore,
             changed: formatted !== original,
+            ...(diff !== undefined ? { diff } : {}),
           };
         }
         case 'glob': {

--- a/packages/runtime/src/filesystem-worker/operations.ts
+++ b/packages/runtime/src/filesystem-worker/operations.ts
@@ -117,15 +117,21 @@ export async function executeFilesystemOperation(
         operationBoundary,
       );
       // Read-before-write: the diff of an overwrite is what tells the reader
-      // what was lost. A missing file means the whole content is new.
-      let previous: string | undefined;
+      // what was lost. Only a missing file means the whole content is new —
+      // any other read failure leaves the previous state unknown, and
+      // claiming `--- /dev/null` would report the file as created.
+      let previous: 'new' | 'unknown' | string;
       try {
         previous = await fs.readFile(path, 'utf8');
-      } catch {
-        previous = undefined;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        previous = code === 'ENOENT' || code === 'ENOTDIR' ? 'new' : 'unknown';
       }
       await fs.writeFile(path, operation.content, 'utf8');
-      const diff = createUnifiedDiff(path, previous, operation.content);
+      const diff =
+        previous === 'unknown'
+          ? undefined
+          : createUnifiedDiff(path, previous === 'new' ? undefined : previous, operation.content);
       return {
         kind: 'write',
         ok: true,

--- a/packages/runtime/src/filesystem-worker/operations.ts
+++ b/packages/runtime/src/filesystem-worker/operations.ts
@@ -6,6 +6,7 @@ import { isPathInside, realpathAllowMissing } from '../path-containment.js';
 import { sandboxBoundaryExpansionAllowsPath } from '@maka/core';
 
 import { computeEditedSource } from '../edit-replace.js';
+import { createUnifiedDiff } from '../unified-diff.js';
 import { isSupportedImagePath, readWorkspaceImage } from '../image-file.js';
 import {
   FILESYSTEM_WORKER_PROTOCOL_VERSION,
@@ -115,8 +116,23 @@ export async function executeFilesystemOperation(
         'Write',
         operationBoundary,
       );
+      // Read-before-write: the diff of an overwrite is what tells the reader
+      // what was lost. A missing file means the whole content is new.
+      let previous: string | undefined;
+      try {
+        previous = await fs.readFile(path, 'utf8');
+      } catch {
+        previous = undefined;
+      }
       await fs.writeFile(path, operation.content, 'utf8');
-      return { kind: 'write', ok: true, path, bytes: Buffer.byteLength(operation.content, 'utf8') };
+      const diff = createUnifiedDiff(path, previous, operation.content);
+      return {
+        kind: 'write',
+        ok: true,
+        path,
+        bytes: Buffer.byteLength(operation.content, 'utf8'),
+        ...(diff !== undefined ? { diff } : {}),
+      };
     }
     case 'edit': {
       const path = await resolveExistingAllowed(
@@ -142,6 +158,7 @@ export async function executeFilesystemOperation(
         );
       }
       await fs.writeFile(path, edited.content, 'utf8');
+      const diff = createUnifiedDiff(path, content, edited.content);
       return {
         kind: 'edit',
         ok: true,
@@ -150,6 +167,7 @@ export async function executeFilesystemOperation(
         matchedVia: edited.matchedVia,
         startLine: edited.startLine,
         endLine: edited.endLine,
+        ...(diff !== undefined ? { diff } : {}),
       };
     }
     case 'format_json': {
@@ -180,6 +198,8 @@ export async function executeFilesystemOperation(
       const formatted = JSON.stringify(operation.sortKeys ? sortKeysDeep(parsed) : parsed, null, 2);
       await fs.writeFile(path, formatted, 'utf8');
       const bytesAfter = Buffer.byteLength(formatted, 'utf8');
+      const diff =
+        formatted === original ? undefined : createUnifiedDiff(path, original, formatted);
       return {
         kind: 'format_json',
         ok: true,
@@ -189,6 +209,7 @@ export async function executeFilesystemOperation(
         bytesAfter,
         byteDelta: bytesAfter - bytesBefore,
         changed: formatted !== original,
+        ...(diff !== undefined ? { diff } : {}),
       };
     }
     case 'glob': {

--- a/packages/runtime/src/filesystem-worker/protocol.ts
+++ b/packages/runtime/src/filesystem-worker/protocol.ts
@@ -120,6 +120,7 @@ export const FilesystemWorkerResultSchema = z.discriminatedUnion('kind', [
       ok: z.literal(true),
       path: z.string(),
       bytes: z.number().int().nonnegative(),
+      diff: z.string().optional(),
     })
     .strict(),
   z
@@ -131,6 +132,7 @@ export const FilesystemWorkerResultSchema = z.discriminatedUnion('kind', [
       matchedVia: z.enum(['exact', 'line-trimmed', 'whitespace', 'escape']),
       startLine: z.number().int().positive(),
       endLine: z.number().int().positive(),
+      diff: z.string().optional(),
     })
     .strict(),
   z
@@ -144,6 +146,7 @@ export const FilesystemWorkerResultSchema = z.discriminatedUnion('kind', [
       bytesAfter: z.number().int().nonnegative().optional(),
       byteDelta: z.number().int(),
       changed: z.boolean(),
+      diff: z.string().optional(),
     })
     .strict(),
   z.object({ kind: z.literal('glob'), files: z.array(z.string()) }).strict(),

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -50,6 +50,7 @@ import {
 import type { AttachmentRef, QuoteRef } from '@maka/core/events';
 import type { ModelMessage, UserContent, UserModelMessage } from './model-protocol.js';
 import { projectBashToolResultForModel } from './bash-model-output.js';
+import { projectFileWriteToolResultForModel } from './file-tool-model-output.js';
 
 export const PROVIDER_REPLAY_PROJECTION_VERSION = 1;
 
@@ -596,6 +597,11 @@ export function buildRuntimeEventModelReplayPlan(
         }
         if (!invalidResultMessage && event.content.name === 'Bash') {
           normalizedResult = projectBashToolResultForModel(normalizedResult);
+        } else if (!invalidResultMessage) {
+          normalizedResult = projectFileWriteToolResultForModel(
+            event.content.name,
+            normalizedResult,
+          );
         }
         if (invalidResultMessage) {
           const call = callsById.get(event.content.id);

--- a/packages/runtime/src/unified-diff.ts
+++ b/packages/runtime/src/unified-diff.ts
@@ -1,0 +1,129 @@
+/**
+ * Minimal unified-diff generator for tool results. Producing the diff at the
+ * write site — where both contents are already in memory — lets the UI show
+ * what actually changed without a verification read, at zero extra I/O for
+ * edits. Bounded by design: anything beyond the caps returns `undefined` and
+ * callers fall back to a plain summary.
+ */
+
+const MAX_DIFF_SOURCE_LINES = 800;
+const MAX_DIFF_SOURCE_BYTES = 32 * 1024;
+const CONTEXT_LINES = 3;
+
+/**
+ * Unified diff of `oldContent` → `newContent` for `path`, or `undefined` when
+ * the content is binary-ish or too large to diff cheaply. `oldContent` is
+ * `undefined` for a newly created file — the whole content renders as
+ * additions under a `--- /dev/null` header.
+ */
+export function createUnifiedDiff(
+  path: string,
+  oldContent: string | undefined,
+  newContent: string,
+): string | undefined {
+  if (isUndiffable(newContent)) return undefined;
+  if (oldContent !== undefined && isUndiffable(oldContent)) return undefined;
+  const oldLines = oldContent === undefined ? [] : splitLines(oldContent);
+  const newLines = splitLines(newContent);
+  if (oldLines.length > MAX_DIFF_SOURCE_LINES || newLines.length > MAX_DIFF_SOURCE_LINES)
+    return undefined;
+
+  const ops = diffLines(oldLines, newLines);
+  if (ops.every((op) => op.kind === 'keep')) return undefined;
+
+  const header =
+    oldContent === undefined
+      ? [`--- /dev/null`, `+++ b/${path}`]
+      : [`--- a/${path}`, `+++ b/${path}`];
+  return [...header, ...formatHunks(ops)].join('\n');
+}
+
+function isUndiffable(content: string): boolean {
+  return content.includes('\0') || Buffer.byteLength(content, 'utf8') > MAX_DIFF_SOURCE_BYTES;
+}
+
+function splitLines(content: string): string[] {
+  const lines = content.split('\n');
+  // A trailing newline terminates the last line rather than starting an empty
+  // one; newline-termination differences are deliberately invisible.
+  if (lines.at(-1) === '') lines.pop();
+  return lines;
+}
+
+type DiffOp = { kind: 'keep' | 'del' | 'add'; oldIndex: number; newIndex: number; line: string };
+
+/** Line-level edit script via LCS dynamic programming, bounded by the caps above. */
+function diffLines(oldLines: string[], newLines: string[]): DiffOp[] {
+  const n = oldLines.length;
+  const m = newLines.length;
+  const width = m + 1;
+  const table = new Uint32Array((n + 1) * width);
+  for (let i = n - 1; i >= 0; i -= 1) {
+    for (let j = m - 1; j >= 0; j -= 1) {
+      table[i * width + j] =
+        oldLines[i] === newLines[j]
+          ? table[(i + 1) * width + j + 1] + 1
+          : Math.max(table[(i + 1) * width + j], table[i * width + j + 1]);
+    }
+  }
+  const ops: DiffOp[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (oldLines[i] === newLines[j]) {
+      ops.push({ kind: 'keep', oldIndex: i, newIndex: j, line: oldLines[i] });
+      i += 1;
+      j += 1;
+    } else if (table[(i + 1) * width + j] >= table[i * width + j + 1]) {
+      ops.push({ kind: 'del', oldIndex: i, newIndex: j, line: oldLines[i] });
+      i += 1;
+    } else {
+      ops.push({ kind: 'add', oldIndex: i, newIndex: j, line: newLines[j] });
+      j += 1;
+    }
+  }
+  while (i < n) {
+    ops.push({ kind: 'del', oldIndex: i, newIndex: j, line: oldLines[i] });
+    i += 1;
+  }
+  while (j < m) {
+    ops.push({ kind: 'add', oldIndex: i, newIndex: j, line: newLines[j] });
+    j += 1;
+  }
+  return ops;
+}
+
+/** Group the edit script into hunks with CONTEXT_LINES of surrounding context. */
+function formatHunks(ops: DiffOp[]): string[] {
+  const changed = ops.flatMap((op, index) => (op.kind === 'keep' ? [] : [index]));
+  if (changed.length === 0) return [];
+
+  const groups: Array<{ start: number; end: number }> = [];
+  let start = Math.max(0, changed[0] - CONTEXT_LINES);
+  let end = Math.min(ops.length - 1, changed[0] + CONTEXT_LINES);
+  for (let c = 1; c < changed.length; c += 1) {
+    const next = changed[c];
+    if (next - end > CONTEXT_LINES * 2 + 1) {
+      groups.push({ start, end });
+      start = Math.max(0, next - CONTEXT_LINES);
+    }
+    end = Math.min(ops.length - 1, next + CONTEXT_LINES);
+  }
+  groups.push({ start, end });
+
+  const out: string[] = [];
+  for (const group of groups) {
+    const slice = ops.slice(group.start, group.end + 1);
+    const oldStart = slice[0].oldIndex + 1;
+    const newStart = slice[0].newIndex + 1;
+    const oldCount = slice.filter((op) => op.kind !== 'add').length;
+    const newCount = slice.filter((op) => op.kind !== 'del').length;
+    out.push(
+      `@@ -${oldCount === 0 ? 0 : oldStart},${oldCount} +${newCount === 0 ? 0 : newStart},${newCount} @@`,
+    );
+    for (const op of slice) {
+      out.push(`${op.kind === 'keep' ? ' ' : op.kind === 'del' ? '-' : '+'}${op.line}`);
+    }
+  }
+  return out;
+}

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -449,7 +449,13 @@ describe('tool activity presentation', () => {
     }));
 
     const kinds = Array.from(markup.matchAll(/data-line="(\w+)"/g)).map((m) => m[1]);
-    assert.deepEqual(kinds, ['meta', 'meta', 'meta', 'meta', 'hunk', 'ctx', 'del', 'add']);
+    // `index` and the `---`/`+++` file headers are hidden: the heading already
+    // names the path. The `diff --git` separator stays — it is the only
+    // in-body boundary between files in a multi-file diff.
+    assert.deepEqual(kinds, ['meta', 'hunk', 'ctx', 'del', 'add']);
+    assert.doesNotMatch(markup, /index 1111111/);
+    assert.doesNotMatch(markup, /--- a\/packages/);
+    assert.doesNotMatch(markup, /\+\+\+ b\/packages/);
     // The heading is the changed path, in the same surface a command uses.
     assert.equal((markup.match(/data-slot="tool-output"/g) ?? []).length, 1);
     assert.match(markup, /class="maka-tool-output-command"[^>]*>packages\/ui\/src\/tool-activity\.tsx</);

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -471,7 +471,7 @@ describe('tool activity presentation', () => {
         kind: 'file_diff',
         paths: ['x.ts'],
         diff: [
-          '@@ -10,2 +10,2 @@',
+          '@@ -10,3 +10,3 @@',
           ' kept',
           '-old',
           '+new',
@@ -490,6 +490,15 @@ describe('tool activity presentation', () => {
     );
     assert.deepEqual(diffGutterNumbers(markup), ['10', '11', '11', '12', '20', '20', '21']);
     assert.doesNotMatch(markup, /@@/);
+  });
+
+  it('describes a file_write result with its path and byte count', () => {
+    const markup = renderToStaticMarkup(createElement(ToolResultPreview, {
+      content: { kind: 'file_write', path: 'huge.bin', bytes: 70000 },
+    }));
+
+    assert.match(markup, /Wrote 70000 bytes to huge\.bin/);
+    assert.doesNotMatch(markup, /\[file_write\]/);
   });
 
   // `---`/`+++` only mark a file when the marker is followed by a path. Testing

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -452,14 +452,44 @@ describe('tool activity presentation', () => {
     // `index` and the `---`/`+++` file headers are hidden: the heading already
     // names the path. The `diff --git` separator stays — it is the only
     // in-body boundary between files in a multi-file diff.
-    assert.deepEqual(kinds, ['meta', 'hunk', 'ctx', 'del', 'add']);
+    assert.deepEqual(kinds, ['meta', 'ctx', 'del', 'add']);
     assert.doesNotMatch(markup, /index 1111111/);
     assert.doesNotMatch(markup, /--- a\/packages/);
     assert.doesNotMatch(markup, /\+\+\+ b\/packages/);
+    // Every content row carries its line number: new-side for ctx/add,
+    // old-side for del; the hunk header feeds the counters and is not a row.
+    assert.deepEqual(diffGutterNumbers(markup), ['', '1', '2', '2']);
     // The heading is the changed path, in the same surface a command uses.
     assert.equal((markup.match(/data-slot="tool-output"/g) ?? []).length, 1);
     assert.match(markup, /class="maka-tool-output-command"[^>]*>packages\/ui\/src\/tool-activity\.tsx</);
     assert.doesNotMatch(markup, /astryx-codeblock/);
+  });
+
+  it('resumes line numbering from each hunk header', () => {
+    const markup = renderToStaticMarkup(createElement(ToolResultPreview, {
+      content: {
+        kind: 'file_diff',
+        paths: ['x.ts'],
+        diff: [
+          '@@ -10,2 +10,2 @@',
+          ' kept',
+          '-old',
+          '+new',
+          ' tail',
+          '@@ -20,1 +20,2 @@',
+          '-gone',
+          '+first',
+          '+second',
+        ].join('\n'),
+      },
+    }));
+
+    assert.deepEqual(
+      Array.from(markup.matchAll(/data-line="(\w+)"/g)).map((m) => m[1]),
+      ['ctx', 'del', 'add', 'ctx', 'del', 'add', 'add'],
+    );
+    assert.deepEqual(diffGutterNumbers(markup), ['10', '11', '11', '12', '20', '20', '21']);
+    assert.doesNotMatch(markup, /@@/);
   });
 
   // `---`/`+++` only mark a file when the marker is followed by a path. Testing
@@ -485,7 +515,7 @@ describe('tool activity presentation', () => {
     }));
     assert.deepEqual(
       Array.from(markup.matchAll(/data-line="(\w+)"/g)).map((m) => m[1]),
-      ['hunk', 'del', 'add'],
+      ['del', 'add'],
     );
   });
 
@@ -658,6 +688,10 @@ describe('tool activity presentation', () => {
     });
   });
 });
+
+function diffGutterNumbers(markup: string): string[] {
+  return Array.from(markup.matchAll(/maka-tool-diff-gutter"[^>]*>([^<]*)</g)).map((m) => m[1]);
+}
 
 function pipeOutput(stdout = '', stderr = '') {
   return {

--- a/packages/ui/src/__tests__/tool-trow-stability.test.tsx
+++ b/packages/ui/src/__tests__/tool-trow-stability.test.tsx
@@ -32,4 +32,23 @@ describe('ToolTrow stable structure', () => {
     assert.doesNotMatch(two, /aria-expanded="true"/);
     assert.match(two, />Grep</);
   });
+
+  it('renders addition and deletion counts for a file_diff result', () => {
+    const item: ToolActivityItem = {
+      toolUseId: 'tool-1',
+      toolName: 'Edit',
+      status: 'completed',
+      args: { path: 'a.ts' },
+      result: {
+        kind: 'file_diff',
+        paths: ['a.ts'],
+        diff: '--- a/a.ts\n+++ b/a.ts\n@@ -1,2 +1,3 @@\n keep\n-old\n+new\n+more',
+      },
+    };
+
+    const html = renderToStaticMarkup(createElement(ToolTrow, { items: [item] }));
+
+    assert.match(html, />\+2</);
+    assert.match(html, />-1</);
+  });
 });

--- a/packages/ui/src/__tests__/tool-trow-stability.test.tsx
+++ b/packages/ui/src/__tests__/tool-trow-stability.test.tsx
@@ -51,4 +51,23 @@ describe('ToolTrow stable structure', () => {
     assert.match(html, />\+2</);
     assert.match(html, />-1</);
   });
+
+  it('omits a zero count instead of painting -0 on a pure-additions write', () => {
+    const item: ToolActivityItem = {
+      toolUseId: 'tool-1',
+      toolName: 'Write',
+      status: 'completed',
+      args: { path: 'new.md' },
+      result: {
+        kind: 'file_diff',
+        paths: ['new.md'],
+        diff: '--- /dev/null\n+++ b/new.md\n@@ -0,0 +1,2 @@\n+alpha\n+beta',
+      },
+    };
+
+    const html = renderToStaticMarkup(createElement(ToolTrow, { items: [item] }));
+
+    assert.match(html, />\+2</);
+    assert.doesNotMatch(html, />-0</);
+  });
 });

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -505,6 +505,16 @@
   padding-block: 0;
 }
 .maka-tool-diff-line { display: block; padding-inline: var(--space-2); white-space: pre; }
+.maka-tool-diff-gutter {
+  display: inline-block;
+  box-sizing: content-box;
+  text-align: right;
+  padding-right: var(--space-2);
+  margin-right: var(--space-1);
+  border-right: 1px solid var(--border);
+  color: var(--muted-foreground);
+  user-select: none;
+}
 .maka-tool-diff-line[data-line="add"] { background: oklch(from var(--success) l c h / 0.1); color: var(--success-text); }
 .maka-tool-diff-line[data-line="del"] { background: oklch(from var(--destructive) l c h / 0.1); color: var(--destructive); }
 .maka-tool-diff-line[data-line="hunk"] {

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -314,8 +314,8 @@ export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
   return <ChatToolCalls calls={calls} />;
 }
 
-/** Green `+N` / red `-N` on the row, counted from the result's unified diff. */
-function diffLineStats(diff: string): { additions: number; deletions: number } {
+/** Green `+N` / red `-N` on the row, counted from the result's unified diff; zero counts stay unpainted. */
+function diffLineStats(diff: string): { additions?: number; deletions?: number } {
   let additions = 0;
   let deletions = 0;
   for (const line of diff.split('\n')) {
@@ -323,7 +323,10 @@ function diffLineStats(diff: string): { additions: number; deletions: number } {
     if (line.startsWith('+')) additions += 1;
     else if (line.startsWith('-')) deletions += 1;
   }
-  return { additions, deletions };
+  return {
+    ...(additions > 0 ? { additions } : {}),
+    ...(deletions > 0 ? { deletions } : {}),
+  };
 }
 
 function astryxToolStatus(item: ToolActivityItem): ChatToolCallItem['status'] {

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -283,30 +283,47 @@ export function ToolCallDetail({ item }: { item: ToolActivityItem }) {
 export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
   const locale = useUiLocale();
   if (items.length === 0) return null;
-  const calls: ChatToolCallItem[] = items.map((item) => ({
-    key: item.toolUseId,
-    // The name is what a person reads to tell one call from the next, and for
-    // Computer Use the display name is "Maka Computer" — a noun, identical on
-    // every row of a ten-call turn. A label derived from the call's own
-    // arguments says what happened instead.
-    name: computerActionLabel(item, locale) ?? resolveToolDisplayName(item, locale),
-    status: astryxToolStatus(item),
-    target: item.intent ? formatToolIntent(item.intent) : undefined,
-    duration: formatDuration(item.durationMs) ?? undefined,
-    errorMessage: toolCallErrorMessage(item, locale),
-    stats: outcomeWord(item, locale),
-    resultDetail: (
-      <ToolDetailReveal>
-        <ToolCallDetail item={item} />
-      </ToolDetailReveal>
-    ),
-  }));
+  const calls: ChatToolCallItem[] = items.map((item) => {
+    const diffStats =
+      item.result?.kind === 'file_diff' ? diffLineStats(item.result.diff) : undefined;
+    return {
+      key: item.toolUseId,
+      // The name is what a person reads to tell one call from the next, and for
+      // Computer Use the display name is "Maka Computer" — a noun, identical on
+      // every row of a ten-call turn. A label derived from the call's own
+      // arguments says what happened instead.
+      name: computerActionLabel(item, locale) ?? resolveToolDisplayName(item, locale),
+      status: astryxToolStatus(item),
+      target: item.intent ? formatToolIntent(item.intent) : undefined,
+      duration: formatDuration(item.durationMs) ?? undefined,
+      errorMessage: toolCallErrorMessage(item, locale),
+      stats: outcomeWord(item, locale),
+      ...(diffStats ?? {}),
+      resultDetail: (
+        <ToolDetailReveal>
+          <ToolCallDetail item={item} />
+        </ToolDetailReveal>
+      ),
+    };
+  });
 
   // No defaultIsExpanded: opening a group is the reader's move. Seeding it open
   // from in-flight status latches, since the prop is uncontrolled and the
   // timeline key is stable (see timelineEntryKey). Cost: the collapsed header
   // projects the last call, which can settle before a parallel sibling.
   return <ChatToolCalls calls={calls} />;
+}
+
+/** Green `+N` / red `-N` on the row, counted from the result's unified diff. */
+function diffLineStats(diff: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+++') || line.startsWith('---')) continue;
+    if (line.startsWith('+')) additions += 1;
+    else if (line.startsWith('-')) deletions += 1;
+  }
+  return { additions, deletions };
 }
 
 function astryxToolStatus(item: ToolActivityItem): ChatToolCallItem['status'] {

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, type ComponentType } from 'react';
-import { isInFlightToolStatus, type ToolResultContent, type UiLocale } from '@maka/core';
+import {
+  countDiffLineStats,
+  isInFlightToolStatus,
+  type ToolResultContent,
+  type UiLocale,
+} from '@maka/core';
 import {
   Check,
   Clock,
@@ -285,7 +290,7 @@ export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
   if (items.length === 0) return null;
   const calls: ChatToolCallItem[] = items.map((item) => {
     const diffStats =
-      item.result?.kind === 'file_diff' ? diffLineStats(item.result.diff) : undefined;
+      item.result?.kind === 'file_diff' ? diffRowStats(item.result.diff) : undefined;
     return {
       key: item.toolUseId,
       // The name is what a person reads to tell one call from the next, and for
@@ -314,15 +319,9 @@ export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
   return <ChatToolCalls calls={calls} />;
 }
 
-/** Green `+N` / red `-N` on the row, counted from the result's unified diff; zero counts stay unpainted. */
-function diffLineStats(diff: string): { additions?: number; deletions?: number } {
-  let additions = 0;
-  let deletions = 0;
-  for (const line of diff.split('\n')) {
-    if (line.startsWith('+++') || line.startsWith('---')) continue;
-    if (line.startsWith('+')) additions += 1;
-    else if (line.startsWith('-')) deletions += 1;
-  }
+/** Green `+N` / red `-N` on the row, from the shared structural parse; zero counts stay unpainted. */
+function diffRowStats(diff: string): { additions?: number; deletions?: number } {
+  const { additions, deletions } = countDiffLineStats(diff);
   return {
     ...(additions > 0 ? { additions } : {}),
     ...(deletions > 0 ? { deletions } : {}),

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -300,6 +300,54 @@ export function isDiffHeaderLine(line: string): boolean {
   return line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('index ');
 }
 
+type DiffPreviewRow = {
+  kind: 'add' | 'del' | 'ctx' | 'meta';
+  text: string;
+  lineNumber?: number;
+};
+
+/**
+ * Parse a unified diff into display rows. `@@` headers feed the line-number
+ * counters instead of becoming rows: a deletion shows its old-side number,
+ * additions and context the new-side one, and a numbering jump is what marks
+ * a hunk boundary. `diff --git` separators stay as unnumbered meta rows —
+ * the only in-body boundary between files. A foreign diff with no hunk
+ * headers degrades to unnumbered rows.
+ */
+function diffPreviewRows(lines: string[]): DiffPreviewRow[] {
+  const rows: DiffPreviewRow[] = [];
+  let oldLine = 0;
+  let newLine = 0;
+  let seenHunk = false;
+  for (const line of lines) {
+    if (isDiffHeaderLine(line)) continue;
+    const hunk = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      oldLine = Number(hunk[1]);
+      newLine = Number(hunk[2]);
+      seenHunk = true;
+      continue;
+    }
+    const kind = diffLineKind(line);
+    if (kind === 'del') {
+      rows.push({ kind, text: line, ...(seenHunk ? { lineNumber: oldLine } : {}) });
+      if (seenHunk) oldLine += 1;
+    } else if (kind === 'add') {
+      rows.push({ kind, text: line, ...(seenHunk ? { lineNumber: newLine } : {}) });
+      if (seenHunk) newLine += 1;
+    } else if (kind === 'ctx') {
+      rows.push({ kind, text: line, ...(seenHunk ? { lineNumber: newLine } : {}) });
+      if (seenHunk) {
+        oldLine += 1;
+        newLine += 1;
+      }
+    } else {
+      rows.push({ kind: 'meta', text: line });
+    }
+  }
+  return rows;
+}
+
 function FileDiffPreview(props: { diff: string; paths: string[] }) {
   const copy = getToolActivityCopy(useUiLocale()).result;
   // Apply UI-level redaction then cap the displayed lines. Both are
@@ -314,9 +362,12 @@ function FileDiffPreview(props: { diff: string; paths: string[] }) {
   if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
   // `---`/`+++` file headers and `index` hashes repeat what the heading
   // already says — hidden visually; the copyable body keeps the full
-  // standard diff. `diff --git` stays: it is the only in-body boundary
-  // between files in a multi-file diff.
-  const visible = lines.filter((line) => !isDiffHeaderLine(line));
+  // standard diff.
+  const rows = diffPreviewRows(lines);
+  const numbered = rows.some((row) => row.lineNumber !== undefined);
+  const digits = numbered
+    ? String(rows.reduce((max, row) => Math.max(max, row.lineNumber ?? 0), 0)).length
+    : 0;
   return (
     <ToolOutputSurface
       kind="file_diff"
@@ -324,15 +375,20 @@ function FileDiffPreview(props: { diff: string; paths: string[] }) {
       body={body}
     >
       <pre className={previewVariants({ part: 'diff-body' })}>
-        {visible.map((line, index) => (
+        {rows.map((row, index) => (
           <span
             // Index keys: the list is a re-split of one immutable string, so a
             // line's position is its identity.
             key={index}
             className={previewVariants({ part: 'diff-line' })}
-            data-line={diffLineKind(line)}
+            data-line={row.kind}
           >
-            {line}
+            {numbered && (
+              <span className="maka-tool-diff-gutter" style={{ minWidth: `${digits}ch` }}>
+                {row.lineNumber ?? ''}
+              </span>
+            )}
+            {row.text}
             {'\n'}
           </span>
         ))}

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, type ReactNode } from 'react';
 import {
   isShellOutput,
   normalizeSearchUrl,
+  parseUnifiedDiffRows,
   ptyHumanTerminalText,
   readWriteStdinInputPreview,
   type ShellOutput,
@@ -212,8 +213,15 @@ export function ToolResultPreview(props: {
     );
   }
 
-  // file_write / image / summary / unknown — show a compact descriptor so the
-  // user knows what kind landed without dumping binary or storage refs.
+  // image / summary / unknown — show a compact descriptor so the user knows
+  // what kind landed without dumping binary or storage refs.
+  if (content.kind === 'file_write') {
+    return (
+      <div data-kind={content.kind}>
+        <ToolCodeBlock code={`Wrote ${content.bytes} bytes to ${content.path}`} />
+      </div>
+    );
+  }
   return (
     <div data-kind={content.kind}>
       <ToolCodeBlock code={`[${content.kind}]`} />
@@ -295,11 +303,6 @@ export function diffLineKind(line: string): 'add' | 'del' | 'hunk' | 'meta' | 'c
  * `previewVariants` has always declared for exactly this — the call site was
  * what went missing.
  */
-/** File header lines the diff panel hides visually (the heading names the path). */
-export function isDiffHeaderLine(line: string): boolean {
-  return line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('index ');
-}
-
 type DiffPreviewRow = {
   kind: 'add' | 'del' | 'ctx' | 'meta';
   text: string;
@@ -307,45 +310,22 @@ type DiffPreviewRow = {
 };
 
 /**
- * Parse a unified diff into display rows. `@@` headers feed the line-number
- * counters instead of becoming rows: a deletion shows its old-side number,
- * additions and context the new-side one, and a numbering jump is what marks
- * a hunk boundary. `diff --git` separators stay as unnumbered meta rows —
- * the only in-body boundary between files. A foreign diff with no hunk
- * headers degrades to unnumbered rows.
+ * Display rows for the gutter, from the shared structural parse in
+ * `@maka/core`: hunk headers are consumed into the line numbers (a deletion
+ * shows its old-side number, additions and context the new-side one) and file
+ * headers never survive the parse — so a deleted SQL `-- a` comment can no
+ * longer be mistaken for one. A foreign diff with no hunk headers degrades
+ * to unnumbered meta rows.
  */
 function diffPreviewRows(lines: string[]): DiffPreviewRow[] {
-  const rows: DiffPreviewRow[] = [];
-  let oldLine = 0;
-  let newLine = 0;
-  let seenHunk = false;
-  for (const line of lines) {
-    if (isDiffHeaderLine(line)) continue;
-    const hunk = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
-    if (hunk) {
-      oldLine = Number(hunk[1]);
-      newLine = Number(hunk[2]);
-      seenHunk = true;
-      continue;
-    }
-    const kind = diffLineKind(line);
-    if (kind === 'del') {
-      rows.push({ kind, text: line, ...(seenHunk ? { lineNumber: oldLine } : {}) });
-      if (seenHunk) oldLine += 1;
-    } else if (kind === 'add') {
-      rows.push({ kind, text: line, ...(seenHunk ? { lineNumber: newLine } : {}) });
-      if (seenHunk) newLine += 1;
-    } else if (kind === 'ctx') {
-      rows.push({ kind, text: line, ...(seenHunk ? { lineNumber: newLine } : {}) });
-      if (seenHunk) {
-        oldLine += 1;
-        newLine += 1;
-      }
-    } else {
-      rows.push({ kind: 'meta', text: line });
-    }
-  }
-  return rows;
+  return parseUnifiedDiffRows(lines.join('\n')).flatMap((row): DiffPreviewRow[] => {
+    if (row.kind === 'hunk') return [];
+    if (row.kind === 'meta') return [{ kind: 'meta' as const, text: row.text }];
+    const lineNumber = row.kind === 'del' ? row.oldLine : row.newLine;
+    return [
+      { kind: row.kind, text: row.text, ...(lineNumber !== undefined ? { lineNumber } : {}) },
+    ];
+  });
 }
 
 function FileDiffPreview(props: { diff: string; paths: string[] }) {
@@ -360,9 +340,8 @@ function FileDiffPreview(props: { diff: string; paths: string[] }) {
   // a blank tinted row at the end of every diff.
   const lines = body.split('\n');
   if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
-  // `---`/`+++` file headers and `index` hashes repeat what the heading
-  // already says — hidden visually; the copyable body keeps the full
-  // standard diff.
+  // The copyable body keeps the full standard diff; the rendered rows come
+  // from the structural parse, which drops the redundant file headers.
   const rows = diffPreviewRows(lines);
   const numbered = rows.some((row) => row.lineNumber !== undefined);
   const digits = numbered

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -295,6 +295,11 @@ export function diffLineKind(line: string): 'add' | 'del' | 'hunk' | 'meta' | 'c
  * `previewVariants` has always declared for exactly this — the call site was
  * what went missing.
  */
+/** File header lines the diff panel hides visually (the heading names the path). */
+export function isDiffHeaderLine(line: string): boolean {
+  return line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('index ');
+}
+
 function FileDiffPreview(props: { diff: string; paths: string[] }) {
   const copy = getToolActivityCopy(useUiLocale()).result;
   // Apply UI-level redaction then cap the displayed lines. Both are
@@ -307,6 +312,11 @@ function FileDiffPreview(props: { diff: string; paths: string[] }) {
   // a blank tinted row at the end of every diff.
   const lines = body.split('\n');
   if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
+  // `---`/`+++` file headers and `index` hashes repeat what the heading
+  // already says — hidden visually; the copyable body keeps the full
+  // standard diff. `diff --git` stays: it is the only in-body boundary
+  // between files in a multi-file diff.
+  const visible = lines.filter((line) => !isDiffHeaderLine(line));
   return (
     <ToolOutputSurface
       kind="file_diff"
@@ -314,7 +324,7 @@ function FileDiffPreview(props: { diff: string; paths: string[] }) {
       body={body}
     >
       <pre className={previewVariants({ part: 'diff-body' })}>
-        {lines.map((line, index) => (
+        {visible.map((line, index) => (
           <span
             // Index keys: the list is a re-split of one immutable string, so a
             // line's position is its identity.

--- a/packages/ui/stories/tool-activity.fixtures.ts
+++ b/packages/ui/stories/tool-activity.fixtures.ts
@@ -386,15 +386,14 @@ const editDiffResult = {
   diff: [
     '--- a/packages/ui/src/tool-activity.tsx',
     '+++ b/packages/ui/src/tool-activity.tsx',
-    '@@ -286,9 +286,10 @@',
+    '@@ -286,7 +286,8 @@',
     '   const calls: ChatToolCallItem[] = items.map((item) => ({',
     '     key: item.toolUseId,',
     '     name: resolveToolDisplayName(item, locale),',
     '     status: astryxToolStatus(item),',
-    '+    ...(item.result?.kind === \'file_diff\' ? diffLineStats(item.result.diff) : {}),',
+    '+    ...(item.result?.kind === \'file_diff\' ? diffRowStats(item.result.diff) : {}),',
     '     duration: formatDuration(item.durationMs) ?? undefined,',
-    '-    stats: outcomeWord(item, locale) ?? \'\',',
-    '+    stats: outcomeWord(item, locale),',
+    '     stats: outcomeWord(item, locale),',
     '     resultDetail: (',
   ].join('\n'),
 } satisfies ToolResultContent;

--- a/packages/ui/stories/tool-activity.fixtures.ts
+++ b/packages/ui/stories/tool-activity.fixtures.ts
@@ -374,6 +374,91 @@ export const shellCommandSurfaceItems = [
   }),
 ] satisfies ToolActivityItem[];
 
+/**
+ * What the runtime now produces for real Edit/Write calls (#2232): no
+ * `diff --git` preamble, straight `---`/`+++` headers; `/dev/null` for a
+ * created file. The collapsed rows are where the green `+N` / red `-N`
+ * stats show.
+ */
+const editDiffResult = {
+  kind: 'file_diff',
+  paths: ['packages/ui/src/tool-activity.tsx'],
+  diff: [
+    '--- a/packages/ui/src/tool-activity.tsx',
+    '+++ b/packages/ui/src/tool-activity.tsx',
+    '@@ -286,9 +286,10 @@',
+    '   const calls: ChatToolCallItem[] = items.map((item) => ({',
+    '     key: item.toolUseId,',
+    '     name: resolveToolDisplayName(item, locale),',
+    '     status: astryxToolStatus(item),',
+    '+    ...(item.result?.kind === \'file_diff\' ? diffLineStats(item.result.diff) : {}),',
+    '     duration: formatDuration(item.durationMs) ?? undefined,',
+    '-    stats: outcomeWord(item, locale) ?? \'\',',
+    '+    stats: outcomeWord(item, locale),',
+    '     resultDetail: (',
+  ].join('\n'),
+} satisfies ToolResultContent;
+
+const writeNewFileDiffResult = {
+  kind: 'file_diff',
+  paths: ['docs/tool-result-diff.md'],
+  diff: [
+    '--- /dev/null',
+    '+++ b/docs/tool-result-diff.md',
+    '@@ -0,0 +1,4 @@',
+    '+# Tool result diffs',
+    '+',
+    '+Edit/Write/FormatJson carry a unified diff in their tool result,',
+    '+rendered by FileDiffPreview on desktop and renderDiffResult in the TUI.',
+  ].join('\n'),
+} satisfies ToolResultContent;
+
+const writeOverwriteDiffResult = {
+  kind: 'file_diff',
+  paths: ['.maka/config.json'],
+  diff: [
+    '--- a/.maka/config.json',
+    '+++ b/.maka/config.json',
+    '@@ -1,5 +1,5 @@',
+    ' {',
+    '   "theme": "dark",',
+    '-  "model": "glm-5",',
+    '+  "model": "glm-5.1",',
+    '   "telemetry": false',
+    ' }',
+  ].join('\n'),
+} satisfies ToolResultContent;
+
+export const editWriteDiffItems = [
+  toolItem({
+    toolUseId: 'edit-diff',
+    toolName: 'Edit',
+    intent: 'Pass diff stats to the tool row.',
+    status: 'completed',
+    args: { path: 'packages/ui/src/tool-activity.tsx' },
+    result: editDiffResult,
+    durationMs: 220,
+  }),
+  toolItem({
+    toolUseId: 'write-new-diff',
+    toolName: 'Write',
+    intent: 'Document the diff result kind.',
+    status: 'completed',
+    args: { path: 'docs/tool-result-diff.md' },
+    result: writeNewFileDiffResult,
+    durationMs: 160,
+  }),
+  toolItem({
+    toolUseId: 'write-overwrite-diff',
+    toolName: 'Write',
+    intent: 'Bump the configured model version.',
+    status: 'completed',
+    args: { path: '.maka/config.json' },
+    result: writeOverwriteDiffResult,
+    durationMs: 140,
+  }),
+] satisfies ToolActivityItem[];
+
 export const fileDiffAndWebSearchItems = [
   toolItem({
     toolUseId: 'file-diff',

--- a/packages/ui/stories/tool-activity.stories.tsx
+++ b/packages/ui/stories/tool-activity.stories.tsx
@@ -4,6 +4,7 @@ import { ToolCallDetail, ToolTrow } from '../src/tool-activity.js';
 import type { ToolActivityItem } from '../src/materialize.js';
 import {
   denseMixedResultItems,
+  editWriteDiffItems,
   errorsAndPermissionDeniedItems,
   shellCommandSurfaceItems,
 } from './tool-activity.fixtures.js';
@@ -133,6 +134,19 @@ export const DenseMixedResults: Story = {
 // background case has no other story.
 export const ShellCommandSurface: Story = {
   args: { items: shellCommandSurfaceItems },
+  render: (args) => <ToolDetailBoard items={args.items} width={860} />,
+};
+
+// Real path: an Edit or Write settles in a turn (#2232) — the collapsed row
+// carries green +N / red -N counted from the result's diff, and expanding the
+// row renders the diff itself in the shared panel.
+export const EditWriteDiffRows: Story = {
+  args: { items: editWriteDiffItems },
+  render: (args) => <ToolRowBoard items={args.items} width={860} />,
+};
+
+export const EditWriteDiffDetails: Story = {
+  args: { items: editWriteDiffItems },
   render: (args) => <ToolDetailBoard items={args.items} width={860} />,
 };
 

--- a/packages/ui/stories/tool-activity.stories.tsx
+++ b/packages/ui/stories/tool-activity.stories.tsx
@@ -145,6 +145,8 @@ export const EditWriteDiffRows: Story = {
   render: (args) => <ToolRowBoard items={args.items} width={860} />,
 };
 
+// Real path: same settled Edit/Write call, its row expanded — the detail panel
+// renders the result's diff with the line-number gutter.
 export const EditWriteDiffDetails: Story = {
   args: { items: editWriteDiffItems },
   render: (args) => <ToolDetailBoard items={args.items} width={860} />,


### PR DESCRIPTION
## Summary

Closes #2232.

`Edit`, `Write`, and `FormatJson` now produce a unified diff at the write site — where both file contents are already in memory — and return it as the canonical `file_diff` tool-result kind. That kind has had consumers on every surface (desktop `FileDiffPreview`, TUI `renderDiffResult`/`compactDiffSummary`, storage schema) but no producer outside fixtures; this PR is the producer, which also makes the #2227 line-level diff rendering reachable in the product.

Decisions (from the issue's open questions):

- **Per call, not per turn.** The diff answers "what did this call do".
- **The model gets a bounded summary, not the diff — everywhere.** `toModelOutput` returns one line live (`Edited a.ts (+1 -1)`, `Created new.md (+2)`), and the same summary is what the model sees on every later re-read: a replay-plan projection (the `projectBashToolResultForModel` precedent) keeps prior turns, compaction, and resume from materializing the stored full diff into the prompt.
- **`Write` on a new file** renders the whole content as additions under `--- /dev/null`; **overwrites** read the previous content first (inside the per-file write lock). Only `ENOENT`/`ENOTDIR` counts as "new file" — an unreadable or binary previous state yields no diff rather than a false "Created".
- **Degradation:** content over 800 lines / 32 KB or containing NUL bytes yields no diff; `Write` then falls back to a `file_write` descriptor (`Wrote N bytes to <path>` on every surface).
- **`FormatJson`** is covered by the same seam and never leaks its diff through the stripped diagnostic json.

Rendering, on top of the raw diff becoming reachable:

- All diff reading — desktop gutter panel, row `+N`/`-N` badges, TUI transcript, model summaries — goes through one structural parser in `@maka/core`, driven by the declared hunk counts: inside a hunk body the first character is the marker, so a deleted SQL `-- a` comment (`--- a` in the diff) or an added `++i` (`+++i`) can no longer be hidden as a file header, desync line numbers, or escape the +/- counts. This replaced three divergent heuristic classifiers.
- The desktop panel numbers every line in a left gutter (old-side for deletions, new-side otherwise); hunk headers feed the counters instead of rendering. The copyable body keeps the full standard diff. The TUI keeps `@@` as its line-number anchor.
- New Storybook variants (`Product/Tool Activity → EditWriteDiffRows`/`EditWriteDiffDetails`) cover the newly reachable states with self-consistent fixtures.

Deferred from review: `matchedVia` is no longer surfaced to the model when a diff exists (the `file_diff` contract is exact-shape; fuzzy matches are rare and unambiguous; the no-diff fallback path still returns it). Headless keeps its own result shapes (separate harness contract, no rendering surface).

## Verification

- Worker: edit/new-file/overwrite/format diffs, no-diff-when-unchanged, oversized degradation, unreadable-overwrite and image-overwrite reporting no diff.
- Builtin tools: `file_diff` mapping, `file_write` fallback, no diff leaking as json, bounded `toModelOutput` incl. `++`-prefixed content.
- Replay: an Edit `file_diff` materializes as `Edited a.ts (+1 -1)` for the model while the durable event keeps the full diff.
- Core parser: standard hunks, `-- `/`++`-prefixed content, `\\ No newline` markers, multi-file/multi-hunk numbering, foreign-diff degradation, header/hunk exclusion from counts.
- Renderers: gutter numbering incl. cross-hunk resume, header hiding, `-0` suppression, `file_write` descriptor; TUI expanded diff drops headers, keeps `@@`.
- Suites green: core 787, runtime 3099, ui 386, cli 470, headless 1410; desktop typecheck + stories typecheck + story-annotations check; biome clean. **CI: all checks pass.**
- Visual: `EditWriteDiffRows`/`EditWriteDiffDetails` reviewed against the live Storybook dev server after the parser migration.
- Not run: desktop e2e (no e2e covers this path; branches are covered by contract tests and stories).