### PR TITLE
test(storage): close Artifact SQLite owners before Windows cleanup

### DIFF
--- a/packages/storage/src/__tests__/artifact-attachments.test.ts
+++ b/packages/storage/src/__tests__/artifact-attachments.test.ts
@@ -215,9 +215,11 @@ async function withStore(
   run: (store: ReturnType<typeof createArtifactStore>) => Promise<void>,
 ): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'maka-artifact-attachment-'));
+  const store = createArtifactStore(root);
   try {
-    await run(createArtifactStore(root));
+    await run(store);
   } finally {
+    store.close?.();
     await rm(root, { recursive: true, force: true });
   }
 }

--- a/packages/storage/src/__tests__/artifact-store.test.ts
+++ b/packages/storage/src/__tests__/artifact-store.test.ts
@@ -22,15 +22,44 @@ import {
 } from '@maka/core/artifacts';
 import {
   ARTIFACT_TEXT_PREVIEW_LIMIT_BYTES,
+  type ArtifactStore,
+  type ArtifactStoreWriteAuthority,
   type CreateArtifactInput,
-  createSqliteArtifactStore as createArtifactStore,
-  createSqliteArtifactStoreWriteAuthority as createArtifactStoreWriteAuthority,
+  createSqliteArtifactStore,
+  createSqliteArtifactStoreWriteAuthority,
   isSafeRelativeArtifactPath,
   resolveArtifactPath,
   sanitizeArtifactName,
 } from '../artifact-store.js';
 import { withArtifactWriterLock } from '../artifact-writer-lock.js';
 import { createSqliteArtifactMetadataRepository } from '../sqlite-artifact-metadata.js';
+
+const artifactStoreClosersByRoot = new Map<string, Set<() => void>>();
+
+function trackArtifactStoreCloser(root: string, close: () => void): void {
+  const closers = artifactStoreClosersByRoot.get(root) ?? new Set<() => void>();
+  closers.add(close);
+  artifactStoreClosersByRoot.set(root, closers);
+}
+
+function createArtifactStore(root: string): ArtifactStore {
+  const store = createSqliteArtifactStore(root);
+  trackArtifactStoreCloser(root, () => store.close?.());
+  return store;
+}
+
+function createArtifactStoreWriteAuthority(root: string): ArtifactStoreWriteAuthority {
+  const authority = createSqliteArtifactStoreWriteAuthority(root);
+  trackArtifactStoreCloser(root, () => authority.close());
+  return authority;
+}
+
+function closeArtifactStores(root: string): void {
+  const closers = artifactStoreClosersByRoot.get(root);
+  artifactStoreClosersByRoot.delete(root);
+  if (!closers) return;
+  for (const close of [...closers].reverse()) close();
+}
 
 describe('SQLite Artifact store', () => {
   test('creates a missing workspace root before acquiring the writer lock', async () => {
@@ -48,6 +77,7 @@ describe('SQLite Artifact store', () => {
         ['missing-root'],
       );
     } finally {
+      closeArtifactStores(root);
       await rm(parent, { recursive: true, force: true });
     }
   });
@@ -1519,6 +1549,7 @@ async function withWorkspace(run: (root: string) => Promise<void>): Promise<void
   try {
     await run(root);
   } finally {
+    closeArtifactStores(root);
     await rm(root, { recursive: true, force: true });
   }
 }

--- a/packages/storage/src/__tests__/artifact-stores.test.ts
+++ b/packages/storage/src/__tests__/artifact-stores.test.ts
@@ -21,7 +21,7 @@ import {
 
 describe('interactive artifact store authority', () => {
   test('requires authentic leases and writer facades', async () => {
-    await withTemporaryRoot('headless', async (root) => {
+    await withTemporaryRoot('headless', async (root, track) => {
       const capability = await resolveStorageRoot({ path: root, kind: 'headless' });
       const lease = createHeadlessRootLease(capability, 'write');
       await assert.rejects(
@@ -31,7 +31,7 @@ describe('interactive artifact store authority', () => {
           ),
         invalidLease,
       );
-      const headless = await openHeadlessArtifactStoreForWrite(lease);
+      const headless = track(await openHeadlessArtifactStoreForWrite(lease));
       assert.equal((await headless.create(artifactInput('headless', 'leased'))).id, 'headless');
     });
 
@@ -43,11 +43,13 @@ describe('interactive artifact store authority', () => {
   });
 
   test('returns one authenticated writer per lease and preserves mutation operations', async () => {
-    await withInteractiveOwner(async (owner, root) => {
+    await withInteractiveOwner(async (owner, root, track) => {
       const [first, second] = await Promise.all([
         openInteractiveArtifactStoreForWrite(owner.lease),
         openInteractiveArtifactStoreForWrite(owner.lease),
       ]);
+      track(first);
+      track(second);
 
       assert.strictEqual(first, second);
       assert.strictEqual(authenticateInteractiveArtifactStoreWriter(first), first);
@@ -75,18 +77,18 @@ describe('interactive artifact store authority', () => {
       await assert.rejects(() => stat(join(root, ARTIFACT_WRITER_LOCK_FILE)), { code: 'ENOENT' });
 
       first.close();
-      const reopened = await openInteractiveArtifactStoreForWrite(owner.lease);
+      const reopened = track(await openInteractiveArtifactStoreForWrite(owner.lease));
       assert.notStrictEqual(reopened, first);
       assert.equal((await reopened.getInSession('session-1', 'deleted')).record?.status, 'deleted');
     });
   });
 
   test('root close revokes new facade operations after draining an in-flight write', async () => {
-    await withTemporaryRoot('interactive', async (root) => {
+    await withTemporaryRoot('interactive', async (root, track) => {
       const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
       const owner = await tryAcquireInteractiveRootOwner(capability);
       assert.ok(owner);
-      const writer = await openInteractiveArtifactStoreForWrite(owner.lease);
+      const writer = track(await openInteractiveArtifactStoreForWrite(owner.lease));
       await writer.recover();
       const accepted = writer.create(
         artifactInput('accepted', new Uint8Array(8 * 1024 * 1024).fill(0x62)),
@@ -102,8 +104,8 @@ describe('interactive artifact store authority', () => {
   });
 
   test('snapshots create inputs and makes user deletion idempotent', async () => {
-    await withInteractiveOwner(async (owner) => {
-      const writer = await openInteractiveArtifactStoreForWrite(owner.lease);
+    await withInteractiveOwner(async (owner, _root, track) => {
+      const writer = track(await openInteractiveArtifactStoreForWrite(owner.lease));
       await writer.recover();
       const bytes = Uint8Array.from([0x73, 0x61, 0x66, 0x65]);
       const createInput = artifactInput('accepted', bytes);
@@ -133,13 +135,15 @@ describe('interactive artifact store authority', () => {
 
 describe('headless artifact store authority', () => {
   test('returns one facade per lease and preserves concurrent writes', async () => {
-    await withTemporaryRoot('headless', async (root) => {
+    await withTemporaryRoot('headless', async (root, track) => {
       const capability = await resolveStorageRoot({ path: root, kind: 'headless' });
       const lease = createHeadlessRootLease(capability, 'write');
       const [first, second] = await Promise.all([
         openHeadlessArtifactStoreForWrite(lease),
         openHeadlessArtifactStoreForWrite(lease),
       ]);
+      track(first);
+      track(second);
 
       assert.strictEqual(first, second);
       await Promise.all([
@@ -155,7 +159,7 @@ describe('headless artifact store authority', () => {
   });
 
   test('serializes concurrent opener recovery while recovering every authority', async () => {
-    await withTemporaryRoot('headless', async (root) => {
+    await withTemporaryRoot('headless', async (root, track) => {
       const capability = await resolveStorageRoot({ path: root, kind: 'headless' });
       const firstLease = createHeadlessRootLease(capability, 'write');
       const secondLease = createHeadlessRootLease(capability, 'write');
@@ -165,6 +169,8 @@ describe('headless artifact store authority', () => {
         openHeadlessArtifactStoreForWrite(firstLease),
         openHeadlessArtifactStoreForWrite(secondLease),
       ]);
+      track(first);
+      track(second);
 
       assert.notStrictEqual(first, second);
       await assert.rejects(() => stat(residue.stagingPath), { code: 'ENOENT' });
@@ -184,7 +190,7 @@ describe('headless artifact store authority', () => {
         second.create(artifactInput('concurrent-second', 'second')),
       ]);
       const verificationLease = createHeadlessRootLease(capability, 'write');
-      const verificationStore = await openHeadlessArtifactStoreForWrite(verificationLease);
+      const verificationStore = track(await openHeadlessArtifactStoreForWrite(verificationLease));
       assert.deepEqual(
         (await verificationStore.list('session-1', { includeDeleted: true }))
           .map((record) => record.id)
@@ -234,14 +240,15 @@ async function withInteractiveOwner(
   run: (
     owner: NonNullable<Awaited<ReturnType<typeof tryAcquireInteractiveRootOwner>>>,
     root: string,
+    track: TrackArtifactWriter,
   ) => Promise<void>,
 ): Promise<void> {
-  await withTemporaryRoot('interactive', async (root) => {
+  await withTemporaryRoot('interactive', async (root, track) => {
     const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
     const owner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(owner);
     try {
-      await run(owner, root);
+      await run(owner, root, track);
     } finally {
       await owner.close();
     }
@@ -250,12 +257,20 @@ async function withInteractiveOwner(
 
 async function withTemporaryRoot(
   kind: 'interactive' | 'headless',
-  run: (root: string) => Promise<void>,
+  run: (root: string, track: TrackArtifactWriter) => Promise<void>,
 ): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), `maka-artifact-${kind}-`));
+  const writers = new Set<{ close(): void }>();
+  const track: TrackArtifactWriter = (writer) => {
+    writers.add(writer);
+    return writer;
+  };
   try {
-    await run(root);
+    await run(root, track);
   } finally {
+    for (const writer of [...writers].reverse()) writer.close();
     await rm(root, { recursive: true, force: true });
   }
 }
+
+type TrackArtifactWriter = <T extends { close(): void }>(writer: T) => T;

--- a/packages/storage/src/__tests__/artifact-writer-lock.test.ts
+++ b/packages/storage/src/__tests__/artifact-writer-lock.test.ts
@@ -13,12 +13,16 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { test } from 'node:test';
 import type { ArtifactRecord } from '@maka/core/artifacts';
 import { openHeadlessArtifactStoreForWrite } from '../artifact-stores.js';
-import { createSqliteArtifactStore, type CreateArtifactInput } from '../artifact-store.js';
+import {
+  type ArtifactStore,
+  type CreateArtifactInput,
+  createSqliteArtifactStore,
+} from '../artifact-store.js';
 import { withArtifactWriterLock } from '../artifact-writer-lock.js';
 import { createHeadlessRootLease, resolveStorageRoot } from '../root-authority.js';
 import { exportSessionBundleState } from '../session-bundle-policy.js';
@@ -27,7 +31,23 @@ import { createSessionStore } from '../session-store.js';
 const TEST_TIMEOUT_MS = 15_000;
 const OPERATION_TIMEOUT_MS = 5_000;
 const COMPETING_PAYLOAD_BYTES = 4 * 1024 * 1024;
-const createArtifactStore = createSqliteArtifactStore;
+const artifactStoreClosersByRoot = new Map<string, Set<() => void>>();
+
+function createArtifactStore(root: string): ArtifactStore {
+  const store = createSqliteArtifactStore(root);
+  const closers = artifactStoreClosersByRoot.get(root) ?? new Set<() => void>();
+  closers.add(() => store.close?.());
+  artifactStoreClosersByRoot.set(root, closers);
+  return store;
+}
+
+function closeArtifactStoresUnder(root: string): void {
+  for (const [storeRoot, closers] of artifactStoreClosersByRoot) {
+    if (storeRoot !== root && !storeRoot.startsWith(`${root}${sep}`)) continue;
+    artifactStoreClosersByRoot.delete(storeRoot);
+    for (const close of [...closers].reverse()) close();
+  }
+}
 
 test('public Store mutation waits for a child-held writer lock and preserves metadata', {
   timeout: TEST_TIMEOUT_MS,
@@ -633,6 +653,7 @@ async function withTemporaryDirectory(run: (root: string) => Promise<void>): Pro
   try {
     await run(root);
   } finally {
+    closeArtifactStoresUnder(root);
     await rm(root, { recursive: true, force: true });
   }
 }

--- a/packages/storage/src/__tests__/artifact-writer-lock.test.ts
+++ b/packages/storage/src/__tests__/artifact-writer-lock.test.ts
@@ -17,7 +17,10 @@ import { join, sep } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { test } from 'node:test';
 import type { ArtifactRecord } from '@maka/core/artifacts';
-import { openHeadlessArtifactStoreForWrite } from '../artifact-stores.js';
+import {
+  openHeadlessArtifactStoreForWrite as openHeadlessArtifactStoreForWriteRaw,
+  type HeadlessArtifactStoreWriter,
+} from '../artifact-stores.js';
 import {
   type ArtifactStore,
   type CreateArtifactInput,
@@ -31,12 +34,27 @@ import { createSessionStore } from '../session-store.js';
 const TEST_TIMEOUT_MS = 15_000;
 const OPERATION_TIMEOUT_MS = 5_000;
 const COMPETING_PAYLOAD_BYTES = 4 * 1024 * 1024;
+// Windows does not permit replacing or deleting a directory while SQLite has files open in it.
+// These tests exercise POSIX root-replacement semantics; Windows coverage verifies cleanup after
+// every owner is closed instead.
+const SKIP_OPEN_SQLITE_ROOT_REPLACEMENT = process.platform === 'win32';
 const artifactStoreClosersByRoot = new Map<string, Set<() => void>>();
 
 function createArtifactStore(root: string): ArtifactStore {
   const store = createSqliteArtifactStore(root);
   const closers = artifactStoreClosersByRoot.get(root) ?? new Set<() => void>();
   closers.add(() => store.close?.());
+  artifactStoreClosersByRoot.set(root, closers);
+  return store;
+}
+
+async function openHeadlessArtifactStoreForWrite(
+  lease: Parameters<typeof openHeadlessArtifactStoreForWriteRaw>[0],
+): Promise<HeadlessArtifactStoreWriter> {
+  const store = await openHeadlessArtifactStoreForWriteRaw(lease);
+  const root = lease.canonicalPath;
+  const closers = artifactStoreClosersByRoot.get(root) ?? new Set<() => void>();
+  closers.add(() => store.close());
   artifactStoreClosersByRoot.set(root, closers);
   return store;
 }
@@ -196,6 +214,7 @@ test('mutations spanning initial root marking remain serialized by the bootstrap
 
 test('public mutation rejects an unmarked replacement installed while waiting for bootstrap', {
   timeout: TEST_TIMEOUT_MS,
+  skip: SKIP_OPEN_SQLITE_ROOT_REPLACEMENT,
 }, async () => {
   await withTemporaryDirectory(async (root) => {
     const stateRoot = join(root, 'state');
@@ -265,6 +284,7 @@ test('public mutation through a retargeted alias stays bound to its verified can
 
 test('admitted lease-bound mutations reject a replacement root without modifying it', {
   timeout: TEST_TIMEOUT_MS,
+  skip: SKIP_OPEN_SQLITE_ROOT_REPLACEMENT,
 }, async () => {
   await withTemporaryDirectory(async (root) => {
     const stateRoot = join(root, 'state');
@@ -309,6 +329,7 @@ test('admitted lease-bound mutations reject a replacement root without modifying
 
 test('lease-bound mutation does not rebuild a root deleted while waiting for the writer lock', {
   timeout: TEST_TIMEOUT_MS,
+  skip: SKIP_OPEN_SQLITE_ROOT_REPLACEMENT,
 }, async () => {
   await withTemporaryDirectory(async (root) => {
     const stateRoot = join(root, 'state');


### PR DESCRIPTION
## Summary

- make Artifact test fixtures own every SQLite store, authority, and lease-bound writer they open
- close registered owners in reverse order before deleting temporary workspace roots
- classify three open-SQLite root replacement/deletion cases as POSIX-only instead of retrying or swallowing Windows filesystem failures

Part of #2142 (Phase 1: deterministic SQLite lifecycle).

## Windows evidence

The `windows-baseline` lane provides the acceptance evidence:

- upstream `main` run 31024210634: 104 storage failures
- first PR run 31025226651: 49 storage failures
- final PR run 31026684532: 38 storage failures, 622 passed, 38 skipped
- all `maka-artifact-store-*`, `maka-artifact-attachment-*`, `maka-artifact-writer-lock-*`, and interactive/headless Artifact authority cleanup failures are gone
- the three new Windows skips are tests that replace or delete a root while SQLite files remain open, an operation Windows does not permit
- no residual job processes were reported

The remaining Windows baseline failures belong to separate owner families such as Graph supervisor admission, Project Catalog, and Usage stores; they are intentionally outside this PR.

## Validation

- all blocking PR checks pass
- `windows_baseline (non-blocking)` completed successfully in 6m06s
- `npx biome check` on the changed tests
- `git diff --check`
- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- targeted Artifact authority/writer-lock tests: 16 pass, 0 fail
- full local storage run: 694 pass, 1 unrelated `package-import` warning assertion failure, 12 skipped
