### PR TITLE
refactor(core): extract shared TokenUsageFields interface (#1404)

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -25,12 +25,7 @@ import type {
   ShellRunTerminalStatus,
 } from './shell-run.js';
 export { SHELL_RUN_SOURCE_TOOL_CALL_ID_MAX_BYTES } from './shell-run.js';
-import type {
-  CacheMissInputSource,
-  ContextBudgetDiagnostic,
-  PrefixChangeReason,
-  PromptSegmentEstimate,
-} from './usage-stats/types.js';
+import { type TokenUsageFields } from './usage-record-schema.js';
 import { defineObjectShape, hasExactShape, isRecord } from './record-schema.js';
 
 export const TOOL_OUTPUT_STREAMS = ['stdout', 'stderr'] as const;
@@ -929,34 +924,8 @@ export interface PlanStep {
   complexity?: 'low' | 'medium' | 'high';
 }
 
-export interface TokenUsageEvent extends BaseEvent {
+export interface TokenUsageEvent extends BaseEvent, TokenUsageFields {
   type: 'token_usage';
-  input: number;
-  output: number;
-  cacheHitInput?: number;
-  cacheMissInput?: number;
-  cacheWriteInput?: number;
-  cacheMissInputSource?: CacheMissInputSource;
-  reasoning?: number;
-  total?: number;
-  rawFinishReason?: string;
-  /** Number of provider runtime/tool-loop steps represented by this usage. */
-  runtimeSteps?: number;
-  /** Backward-compatible alias for cacheHitInput. */
-  cacheRead?: number;
-  /** Backward-compatible alias for cacheWriteInput. */
-  cacheCreation?: number;
-  costUsd?: number;
-  systemPromptHash?: string;
-  contextRemaining?: number;
-  prefixHash?: string;
-  prefixChangeReason?: PrefixChangeReason;
-  requestShapeHash?: string;
-  requestShapeChangeReason?: PrefixChangeReason;
-  promptSegments?: PromptSegmentEstimate[];
-  contextBudget?: ContextBudgetDiagnostic;
-  /** Links this aggregate to per-physical-request AgentRun trace rows. */
-  providerRequestTraceId?: string;
 }
 
 /**

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -24,12 +24,6 @@ import { INTERACTION_ID_MAX_BYTES, INTERACTION_TOOL_NAME_MAX_BYTES } from './int
 import type { PermissionRequestPayload, PermissionResponse } from './permission.js';
 import type { TurnOrigin } from './runtime-inputs.js';
 import type { UserQuestionRequest } from './user-question.js';
-import type {
-  CacheMissInputSource,
-  ContextBudgetDiagnostic,
-  PrefixChangeReason,
-  PromptSegmentEstimate,
-} from './usage-stats/types.js';
 import {
   defineObjectShape,
   hasExactShape,
@@ -43,7 +37,7 @@ import {
   isPermissionRequestPayload,
   isUserQuestionRequest,
 } from './interaction-record-schema.js';
-import { isTokenUsageFields } from './usage-record-schema.js';
+import { isTokenUsageFields, type TokenUsageFields } from './usage-record-schema.js';
 import { isToolRecoveryFactEnvelope, type ToolRecoveryFactEnvelope } from './tool-recovery-fact.js';
 import {
   isRuntimeEventWorkspaceFactEnvelope,
@@ -207,32 +201,7 @@ export type RuntimeEventContentKind = (typeof RUNTIME_EVENT_CONTENT_KINDS)[numbe
  * Token usage carried as a runtime action rather than a content payload.
  * Mirrors TokenUsageEvent / TokenUsageMessage so projections can map 1:1.
  */
-export interface RuntimeEventTokenUsage {
-  input: number;
-  output: number;
-  cacheHitInput?: number;
-  cacheMissInput?: number;
-  cacheWriteInput?: number;
-  cacheMissInputSource?: CacheMissInputSource;
-  reasoning?: number;
-  total?: number;
-  rawFinishReason?: string;
-  /** Number of provider runtime/tool-loop steps represented by this usage. */
-  runtimeSteps?: number;
-  /** Backward-compatible alias for cacheHitInput. */
-  cacheRead?: number;
-  /** Backward-compatible alias for cacheWriteInput. */
-  cacheCreation?: number;
-  costUsd?: number;
-  systemPromptHash?: string;
-  contextRemaining?: number;
-  prefixHash?: string;
-  prefixChangeReason?: PrefixChangeReason;
-  requestShapeHash?: string;
-  requestShapeChangeReason?: PrefixChangeReason;
-  promptSegments?: PromptSegmentEstimate[];
-  contextBudget?: ContextBudgetDiagnostic;
-}
+export interface RuntimeEventTokenUsage extends TokenUsageFields {}
 
 /**
  * Permission decision attached to an event. Runtime history may retain the
@@ -543,6 +512,7 @@ const RUNTIME_TOKEN_USAGE_SHAPE = defineObjectShape<RuntimeEventTokenUsage>()(
     'requestShapeChangeReason',
     'promptSegments',
     'contextBudget',
+    'providerRequestTraceId',
   ],
 );
 const RUNTIME_REFS_SHAPE = defineObjectShape<RuntimeEventRefs>()(

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -22,12 +22,6 @@ import {
 } from './permission.js';
 import type { CollaborationMode } from './collaboration.js';
 import type { OrchestrationMode } from './orchestration.js';
-import type {
-  CacheMissInputSource,
-  ContextBudgetDiagnostic,
-  PrefixChangeReason,
-  PromptSegmentEstimate,
-} from './usage-stats/types.js';
 import {
   defineObjectShape,
   hasExactShape,
@@ -36,7 +30,7 @@ import {
   isRecord,
 } from './record-schema.js';
 import { isPermissionDecisionFields } from './interaction-record-schema.js';
-import { isTokenUsageFields } from './usage-record-schema.js';
+import { isTokenUsageFields, type TokenUsageFields } from './usage-record-schema.js';
 import {
   decodePersistedToolResultContentForRecovery,
   normalizeToolResultContentForRead,
@@ -805,36 +799,11 @@ export interface PermissionDecisionMessage {
   hint?: string;
 }
 
-export interface TokenUsageMessage {
+export interface TokenUsageMessage extends TokenUsageFields {
   type: 'token_usage';
   id: string;
   turnId: string;
   ts: number;
-  input: number;
-  output: number;
-  cacheHitInput?: number;
-  cacheMissInput?: number;
-  cacheWriteInput?: number;
-  cacheMissInputSource?: CacheMissInputSource;
-  reasoning?: number;
-  total?: number;
-  rawFinishReason?: string;
-  /** Number of provider runtime/tool-loop steps represented by this usage. */
-  runtimeSteps?: number;
-  /** Backward-compatible alias for cacheHitInput. */
-  cacheRead?: number;
-  /** Backward-compatible alias for cacheWriteInput. */
-  cacheCreation?: number;
-  costUsd?: number;
-  systemPromptHash?: string;
-  contextRemaining?: number;
-  prefixHash?: string;
-  prefixChangeReason?: PrefixChangeReason;
-  requestShapeHash?: string;
-  requestShapeChangeReason?: PrefixChangeReason;
-  promptSegments?: PromptSegmentEstimate[];
-  contextBudget?: ContextBudgetDiagnostic;
-  providerRequestTraceId?: string;
 }
 
 export interface TurnStateMessage {

--- a/packages/core/src/usage-record-schema.ts
+++ b/packages/core/src/usage-record-schema.ts
@@ -1,6 +1,8 @@
 import type {
+  CacheMissInputSource,
   CompactionDecisionDiagnostic,
   ContextBudgetDiagnostic,
+  PrefixChangeReason,
   PromptSegmentEstimate,
 } from './usage-stats/types.js';
 import {
@@ -263,7 +265,42 @@ const CONTEXT_REASON_COUNTS = [
   'historyCompactWriteSkippedReasonCounts',
 ] as const;
 
-export function isTokenUsageFields(value: Record<string, unknown>): boolean {
+/**
+ * Token-usage field bundle shared by the runtime-event, message, and event
+ * projections (RuntimeEventTokenUsage / TokenUsageMessage / TokenUsageEvent).
+ * Single source of truth — `isTokenUsageFields` validates exactly this shape.
+ */
+export interface TokenUsageFields {
+  input: number;
+  output: number;
+  cacheHitInput?: number;
+  cacheMissInput?: number;
+  cacheWriteInput?: number;
+  cacheMissInputSource?: CacheMissInputSource;
+  reasoning?: number;
+  total?: number;
+  rawFinishReason?: string;
+  /** Number of provider runtime/tool-loop steps represented by this usage. */
+  runtimeSteps?: number;
+  /** Backward-compatible alias for cacheHitInput. */
+  cacheRead?: number;
+  /** Backward-compatible alias for cacheWriteInput. */
+  cacheCreation?: number;
+  costUsd?: number;
+  systemPromptHash?: string;
+  contextRemaining?: number;
+  prefixHash?: string;
+  prefixChangeReason?: PrefixChangeReason;
+  requestShapeHash?: string;
+  requestShapeChangeReason?: PrefixChangeReason;
+  promptSegments?: PromptSegmentEstimate[];
+  contextBudget?: ContextBudgetDiagnostic;
+  /** Links this aggregate to per-physical-request AgentRun trace rows. */
+  providerRequestTraceId?: string;
+}
+
+export function isTokenUsageFields(value: unknown): value is TokenUsageFields {
+  if (!isRecord(value)) return false;
   if (!isFiniteNumber(value.input) || !isFiniteNumber(value.output)) return false;
   if (OPTIONAL_TOKEN_NUMBERS.some((key) => !isOptionalFiniteNumber(value[key]))) return false;
   return (
@@ -276,6 +313,7 @@ export function isTokenUsageFields(value: Record<string, unknown>): boolean {
     isOptionalPrefixChangeReason(value.prefixChangeReason) &&
     isOptionalString(value.requestShapeHash) &&
     isOptionalPrefixChangeReason(value.requestShapeChangeReason) &&
+    isOptionalString(value.providerRequestTraceId) &&
     (value.promptSegments === undefined ||
       (Array.isArray(value.promptSegments) &&
         value.promptSegments.every(isPromptSegmentEstimate))) &&


### PR DESCRIPTION
## Summary

### 1. New shared `TokenUsageFields` interface (`usage-record-schema.ts`)

- Added a new `TokenUsageFields` interface covering the shared 22-field bundle (token counts, cache breakdown, cost, prefix/cache diagnostics, and `providerRequestTraceId`). This is now the single source of truth for the field set and its optionality.
- Imported `CacheMissInputSource` and `PrefixChangeReason` so the interface references the canonical type aliases rather than inline string unions.

### 2. `isTokenUsageFields` upgraded to a real type guard (`usage-record-schema.ts`)

- Changed the signature from `(value: Record<string, unknown>): boolean` to `(value: unknown): value is TokenUsageFields`. This aligns it with the other domain guards in the file (`isPromptSegmentEstimate`, `isContextBudgetDiagnostic`, `isCompactionDecisionDiagnostic`), all of which use the `value is X` predicate form — `isTokenUsageFields` was the sole outlier returning `boolean`.
- Added a `if (!isRecord(value)) return false;` precondition at the top, so the guard is now self-contained and no longer relies on callers having pre-validated that the input is an object.
- Added `providerRequestTraceId` validation to the predicate's `&&` chain (validated as an optional string via `isOptionalString`, alongside `systemPromptHash` / `prefixHash`).

### 3. Three interfaces now extend `TokenUsageFields`

- `RuntimeEventTokenUsage` (in `runtime-event.ts`) → `extends TokenUsageFields {}`. The duplicated field declarations were removed.
- `TokenUsageMessage` (in `session.ts`) → `extends TokenUsageFields`, keeping only its envelope fields (`type`, `id`, `turnId`, `ts`).
- `TokenUsageEvent` (in `events.ts`) → `extends BaseEvent, TokenUsageFields { type: 'token_usage' }`.

### 4. Drift fix: `providerRequestTraceId`

`RuntimeEventTokenUsage` was missing `providerRequestTraceId` even though its comment claimed to mirror `TokenUsageEvent` / `TokenUsageMessage` "so projections can map 1:1". Both of those carried the field. The interface now inherits it from `TokenUsageFields`, and `RUNTIME_TOKEN_USAGE_SHAPE` was updated to include `providerRequestTraceId` in its optional keys — without this, `hasExactShape` would reject any legitimate runtime payload that included the field.

### 5. Cleanup

Removed the now-unused `CacheMissInputSource`, `PrefixChangeReason`, `ContextBudgetDiagnostic`, and `PromptSegmentEstimate` imports from `runtime-event.ts`, `session.ts`, and `events.ts` (these were only referenced by the previously-inlined field declarations).

Refs: #1404 

## Verification

- `npm run format:check` — clean (1538 files)
- `npm run lint` — clean (2547 files)
- `npm --workspace @maka/core run typecheck` — no errors
- `npm --workspace @maka/core run build` — succeeds
- `npm --workspace @maka/core run test:dist` — 784 passed