### PR TITLE
test(ci): stop pinning the upload-artifact major in the baseline contract

### DIFF
--- a/scripts/windows-baseline-workflow.test.mjs
+++ b/scripts/windows-baseline-workflow.test.mjs
@@ -54,7 +54,11 @@ test('Windows baseline workflow keeps its non-blocking evidence contract', async
     /--workspaces=packages\/storage \*> "\$env:WINDOWS_BASELINE_LOG_DIR\/storage\.log"/u,
   );
   assert.match(workflow, /Get-Content "\$env:WINDOWS_BASELINE_LOG_DIR\/storage\.log"/u);
-  assert.match(workflow, /actions\/upload-artifact@[0-9a-f]{40} # v4\.\d+\.\d+/u);
+  // Pin-short-comment contract: the workflow must pin upload-artifact to a
+  // full SHA and annotate it with the exact version it resolves to. The major
+  // is intentionally not asserted — dependabot may bump it — but the
+  // annotation must stay truthful.
+  assert.match(workflow, /actions\/upload-artifact@[0-9a-f]{40} # v\d+\.\d+\.\d+/u);
   assert.match(workflow, /name: windows-baseline/u);
   assert.match(workflow, /retention-days: 14/u);
 });


### PR DESCRIPTION
The Windows baseline evidence contract asserted `actions/upload-artifact@<sha> # v4.x.x`, but #2271 bumped the workflow to v7.0.1 and its own CI skipped this test lane (changes filter). #2270's full run exposed the stale assertion.

Relax the major-version pin so the contract only requires a full-SHA pin plus a truthful version annotation.