### PR TITLE
chore(deps): stop dependabot from bumping code-mode's runtime typescript pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
         update-types:
           - minor
           - patch
+    # packages/code-mode depends on the typescript JS API (transpileModule,
+    # ScriptTarget, …) at runtime; the 6.0+ native compiler removed those
+    # exports, so the package stays pinned to 5.9. The workspace root already
+    # compiles on 7.x, so ignoring >=6 only affects that runtime pin.
+    ignore:
+      - dependency-name: 'typescript'
+        versions:
+          - '>=6.0.0'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
packages/code-mode depends on the typescript JS API (transpileModule, ScriptTarget, ModuleKind, DiagnosticCategory, flattenDiagnosticMessageText) at runtime. The 6.0+ native compiler removed those exports, so #2276 (5.9.3 → 7.0.2) cannot build and will keep recurring weekly. Ignore typescript >=6 for the npm ecosystem; the workspace root already compiles on 7.x so this only guards the runtime pin.