### PR TITLE
refactor(ui): unify the workspace picker onto the composer's ghost-menu family

### DIFF
--- a/apps/desktop/src/main/__tests__/workspace-picker-menu-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/workspace-picker-menu-contract.test.ts
@@ -1,24 +1,31 @@
 /**
- * Project menu pinning contract.
+ * Project menu scroll contract.
  *
- * The open project menu keeps `添加项目` / `无项目` against its bottom edge
- * while the catalogue scrolls behind them. Astryx `DropdownMenu` has no footer
- * slot, so the pinning is product CSS — and it is the kind of CSS that fails
- * silently: the rows still render, just in the wrong place or over each other,
- * and nothing throws.
+ * In the open project menu, only the project catalogue scrolls: `添加项目` /
+ * `无项目` sit after it in normal flow, outside the scroller, so they can
+ * never be carried along by the wheel. That is product CSS — and it is the
+ * kind of CSS that fails silently: the rows still render, just scrolling
+ * together with the actions or chaining overscroll into the page behind the
+ * popover, and nothing throws.
  *
- * Two properties carry the whole construction, so this pins those rather than
- * the pixels:
+ * Three properties carry the whole construction, so this pins those rather
+ * than the pixels:
  *
- * 1. The sticky box is the actions' `role="group"`, not the item rows. The
- *    group's height is whatever it contains, so it pins exactly its two rows.
- *    An earlier version stuck the rows and declared the block's height in CSS,
- *    which left an opaque backdrop taller than the rows, covering the
- *    catalogue rows behind it and swallowing their clicks.
- * 2. The background sits on the group, never on the item rows. Astryx paints
- *    hover and keyboard-highlight as `background-color` on the row, and this
- *    file's `components` layer outranks `astryx-components` — so an opaque
- *    colour on a row would win the cascade and silently kill both states.
+ * 1. The only scrollable element under the menu is the catalogue region
+ *    (`.maka-workspace-picker-scroll`): it owns `overflow-y: auto` and the
+ *    `max-height` budget. The menu panel itself must not scroll — Astryx
+ *    caps it at 300px with `overflow-y: auto`, which would scroll the actions
+ *    too, so the product rules lift that cap.
+ * 2. No `position: sticky` anywhere under the menu. The actions' old pinned
+ *    box moved with the panel when overscroll chained to the page; being
+ *    outside the scroller is what actually fixes them, and sticky would be a
+ *    second authority that can drift.
+ * 3. No rule under the menu paints a background on the group or the item
+ *    rows. Astryx paints hover and keyboard-highlight as `background-color`
+ *    on the row, and this file's `components` layer outranks
+ *    `astryx-components` — an opaque colour on a row or on the group would
+ *    win the cascade and silently kill both states. Nothing scrolls under the
+ *    actions any more, so they need no backdrop of their own.
  *
  * The lifetime and placement of the trigger are pinned separately, in
  * packages/ui/src/__tests__/composer-workspace-picker.test.tsx.
@@ -28,6 +35,7 @@ import { describe, it } from 'node:test';
 import { readAllRendererCss, stripCssComments } from './css-test-helpers.js';
 
 const SCOPE = '.maka-composer-workspace [role="menu"]';
+const SCROLL_SCOPE = '.maka-workspace-picker-scroll';
 
 /** Rule bodies whose selector starts with `prefix`, in source order. */
 function ruleBodiesForPrefix(css: string, prefix: string): { selector: string; body: string }[] {
@@ -51,40 +59,57 @@ function ruleBodiesForPrefix(css: string, prefix: string): { selector: string; b
   return out;
 }
 
-describe('project menu pinning contract', () => {
-  it('sticks the actions as one group box, not as individual rows', async () => {
+describe('project menu scroll contract', () => {
+  it('scrolls only the catalogue region, not the menu panel', async () => {
     const css = stripCssComments(await readAllRendererCss());
     const scoped = ruleBodiesForPrefix(css, SCOPE);
 
-    const sticky = scoped.filter((rule) => /position:\s*sticky/.test(rule.body));
+    const scrollers = ruleBodiesForPrefix(css, SCROLL_SCOPE).filter((rule) =>
+      /overflow(-y)?:\s*(auto|scroll)/.test(rule.body),
+    );
     assert.equal(
-      sticky.length,
+      scrollers.length,
       1,
-      `exactly one rule under ${SCOPE} may stick; got ${sticky.length}: ${JSON.stringify(sticky.map((r) => r.selector))}`,
+      `exactly one rule may scroll the catalogue region; got ${scrollers.length}: ${JSON.stringify(scrollers.map((r) => r.selector))}`,
     );
     assert.match(
-      sticky[0]?.selector ?? '',
-      /\[role="group"\]/,
-      'the sticky box must be the section group, whose height follows its contents',
+      scrollers[0]?.selector ?? '',
+      /^\.maka-workspace-picker-scroll(?:\s|$|:|\[)/,
+      'the scroller must be the catalogue region, not the menu panel',
     );
-    // A row-level offset is the shape the group formulation replaced: it can
-    // only be written against a height the CSS has to assume.
-    assert.doesNotMatch(
-      sticky[0]?.body ?? '',
-      /calc\(/,
-      'the group pins to the list edge; a computed offset means a hardcoded row height is back',
+    assert.match(scrollers[0]?.body ?? '', /max-height/, 'the catalogue region owns the height budget');
+
+    // The panel rule may lift Astryx's 300px cap (max-height/overflow), but
+    // must not introduce a scroller of its own.
+    for (const rule of scoped) {
+      if (!/overflow/.test(rule.body)) continue;
+      assert.doesNotMatch(
+        rule.body,
+        /overflow(-y)?:\s*(auto|scroll)/,
+        `${rule.selector} makes the menu panel scroll; the panel must leave scrolling to the catalogue region`,
+      );
+    }
+  });
+
+  it('has no sticky positioning anywhere under the menu', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const sticky = ruleBodiesForPrefix(css, SCOPE).filter((rule) => /position:\s*sticky/.test(rule.body));
+
+    assert.equal(
+      sticky.length,
+      0,
+      `sticky pinning is the construction the scroll region replaced; got ${sticky.length}: ${JSON.stringify(sticky.map((r) => r.selector))}`,
     );
   });
 
-  it('paints the backdrop on the group, leaving the rows to Astryx', async () => {
+  it('paints no backdrop on the group or the rows, leaving Astryx the hover tints', async () => {
     const css = stripCssComments(await readAllRendererCss());
 
     for (const rule of ruleBodiesForPrefix(css, SCOPE)) {
-      if (!/background(-color)?:/.test(rule.body)) continue;
-      assert.match(
-        rule.selector,
-        /\[role="group"\]/,
-        `${rule.selector} paints a background on an option row; that wins over Astryx's hover and keyboard-highlight tints`,
+      assert.doesNotMatch(
+        rule.body,
+        /background(-color)?:/,
+        `${rule.selector} paints a background; that wins over Astryx's hover and keyboard-highlight tints`,
       );
     }
   });

--- a/apps/desktop/src/main/__tests__/workspace-picker-menu-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/workspace-picker-menu-contract.test.ts
@@ -2,7 +2,7 @@
  * Project menu pinning contract.
  *
  * The open project menu keeps `添加项目` / `无项目` against its bottom edge
- * while the catalogue scrolls behind them. Astryx `Selector` has no footer
+ * while the catalogue scrolls behind them. Astryx `DropdownMenu` has no footer
  * slot, so the pinning is product CSS — and it is the kind of CSS that fails
  * silently: the rows still render, just in the wrong place or over each other,
  * and nothing throws.
@@ -10,13 +10,12 @@
  * Two properties carry the whole construction, so this pins those rather than
  * the pixels:
  *
- * 1. The sticky box is the section's `role="group"`, not the option rows. The
- *    group's height is whatever it contains, so a search that matches one
- *    action pins one row. An earlier version stuck the rows and declared the
- *    block's height in CSS; a search that filtered one action out then left an
- *    opaque backdrop 29px taller than the rows, covering the catalogue rows
- *    behind it and swallowing their clicks.
- * 2. The background sits on the group, never on the option rows. Astryx paints
+ * 1. The sticky box is the actions' `role="group"`, not the item rows. The
+ *    group's height is whatever it contains, so it pins exactly its two rows.
+ *    An earlier version stuck the rows and declared the block's height in CSS,
+ *    which left an opaque backdrop taller than the rows, covering the
+ *    catalogue rows behind it and swallowing their clicks.
+ * 2. The background sits on the group, never on the item rows. Astryx paints
  *    hover and keyboard-highlight as `background-color` on the row, and this
  *    file's `components` layer outranks `astryx-components` — so an opaque
  *    colour on a row would win the cascade and silently kill both states.
@@ -28,7 +27,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { readAllRendererCss, stripCssComments } from './css-test-helpers.js';
 
-const SCOPE = '.maka-composer-workspace [role="listbox"]';
+const SCOPE = '.maka-composer-workspace [role="menu"]';
 
 /** Rule bodies whose selector starts with `prefix`, in source order. */
 function ruleBodiesForPrefix(css: string, prefix: string): { selector: string; body: string }[] {

--- a/apps/desktop/src/main/__tests__/workspace-picker-menu-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/workspace-picker-menu-contract.test.ts
@@ -78,9 +78,24 @@ describe('project menu scroll contract', () => {
       'the scroller must be the catalogue region, not the menu panel',
     );
     assert.match(scrollers[0]?.body ?? '', /max-height/, 'the catalogue region owns the height budget');
+    // The chaining fix: without `contain`, a wheel past the catalogue's end
+    // scrolls the page behind the popover and drags the actions along — the
+    // exact bug this construction exists to fix.
+    assert.match(
+      scrollers[0]?.body ?? '',
+      /overscroll-behavior:\s*contain/,
+      'the catalogue region must contain its overscroll',
+    );
 
-    // The panel rule may lift Astryx's 300px cap (max-height/overflow), but
-    // must not introduce a scroller of its own.
+    // The panel rule must LIFT Astryx's 300px cap: the cap comes with
+    // `overflow-y: auto` (astryx.css), which would scroll the actions with
+    // the panel again even with the region in place.
+    const panelRule = scoped.find((rule) => rule.selector === SCOPE);
+    assert.ok(panelRule, `a rule on the bare ${SCOPE} selector must lift the cap`);
+    assert.match(panelRule.body, /max-height:\s*none/, 'the panel must lift Astryx\'s 300px max-height');
+    assert.match(panelRule.body, /overflow:\s*visible/, 'the panel must not scroll itself');
+
+    // No other rule under the menu may scroll.
     for (const rule of scoped) {
       if (!/overflow/.test(rule.body)) continue;
       assert.doesNotMatch(
@@ -89,6 +104,22 @@ describe('project menu scroll contract', () => {
         `${rule.selector} makes the menu panel scroll; the panel must leave scrolling to the catalogue region`,
       );
     }
+  });
+
+  it('keeps the catalogue/actions divider only when there is a catalogue', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const divider = ruleBodiesForPrefix(css, SCOPE).filter((rule) => /border-top/.test(rule.body));
+
+    assert.equal(
+      divider.length,
+      1,
+      `exactly one rule may draw the catalogue/actions divider; got ${divider.length}: ${JSON.stringify(divider.map((r) => r.selector))}`,
+    );
+    assert.match(
+      divider[0]?.selector ?? '',
+      /:not\(:first-child\)/,
+      'first run (no projects) must open with the actions group as the menu\'s first child and no divider above it',
+    );
   });
 
   it('has no sticky positioning anywhere under the menu', async () => {

--- a/apps/desktop/src/renderer/styles/astryx-mount.css
+++ b/apps/desktop/src/renderer/styles/astryx-mount.css
@@ -33,11 +33,11 @@
   color: inherit;
 }
 
-/* Palette seam for Astryx value controls.
+/* Palette seam for the composer footer's Astryx popover surfaces.
 
    The Astryx neutral theme lives on the app Theme wrapper, closer to these
-   controls than Maka's palette tokens on <html>, so a Selector left alone
-   paints from the neutral defaults: `--color-text-primary` resolves to
+   controls than Maka's palette tokens on <html>, so a Selector or menu left
+   alone paints from the neutral defaults: `--color-text-primary` resolves to
    light-dark(#171717, #fafafa) rather than the product foreground. That is
    invisible in isolation and obvious side by side — before this seam covered
    the workspace picker, its options came out in #171717 next to the model
@@ -46,11 +46,12 @@
 
    One rule, listed per seam, rather than a copy per control: a second block
    would be a second authority, and the two would drift the first time the
-   palette changes. Every Maka surface that mounts an Astryx value control
-   belongs on this selector list.
+   palette changes. Every Maka surface that mounts an Astryx value control or
+   menu popover belongs on this selector list — the model pair's DropdownMenus
+   and the project picker's both read these tokens through their wrapper.
 
    Verified against the live app per the note above, not reasoned about: the
-   two seams' option rows now report identical computed color, weight, size and
+   seams' option rows now report identical computed color, weight, size and
    padding. */
 .maka-model-selection-controls,
 .maka-composer-workspace {

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -324,41 +324,36 @@
   min-width: 0;
 }
 
-.maka-workspace-picker-option {
-  min-width: 0;
-}
-
 /* Cap the open menu at the window. Astryx gives the popover
-   `min-width: anchor-size(width)` and no ceiling, and the option labels are not
+   `min-width: anchor-size(width)` and no ceiling, and the item labels are not
    truncated, so one long project name grows the shrink-to-fit popover past the
    right edge of a narrow window — where the pinned actions go with it and there
-   is no way to scroll them back. Same cap the DropdownMenu this replaced
-   carried. */
-.maka-composer-workspace [role="listbox"] {
+   is no way to scroll them back. Same cap the model menus carry
+   (`.maka-composer-quiet-menu`), expressed in the workspace's own tokens. */
+.maka-composer-workspace [role="menu"] {
   max-width: min(320px, calc(100vw - var(--space-6)));
 }
 
 /* Pin "add project" / "no project" to the bottom of the open menu so only the
-   project catalogue scrolls. Astryx `Selector` scrolls its whole list as one
-   region and exposes no footer slot, so the two rows are stuck here — as one
-   box, because `workspace-picker.tsx` puts them in a section and Selector
+   project catalogue scrolls. Astryx `DropdownMenu` scrolls its whole list as
+   one region and exposes no footer slot, so the two rows are stuck here — as
+   one box, because `workspace-picker.tsx` puts them in a section and the menu
    renders that as a single `role="group"`. Sticking the box rather than its
-   rows is what keeps this one rule: the box is as tall as whatever it holds, so
-   a search that matches one action pins one row. Sticking the rows meant
-   declaring the block's height in CSS, and a search that filtered one action
-   out then left a backdrop taller than the rows, covering — and swallowing the
-   clicks of — the catalogue rows behind it.
+   rows is what keeps this one rule: the box is as tall as whatever it holds.
+   Sticking the rows meant declaring the block's height in CSS, which left a
+   backdrop taller than the rows, covering — and swallowing the clicks of — the
+   catalogue rows behind it.
 
    The group's own background is what hides the scrolled rows, and it sits below
-   its options rather than on them, so Astryx keeps painting the hover and
+   its items rather than on them, so Astryx keeps painting the hover and
    keyboard-highlight tints on the rows themselves. An opaque colour on the rows
    would win the cascade (this file's `components` layer sits after
    `astryx-components`) and silently kill both states.
 
-   `padding-bottom` restores the list's own bottom padding, which the sticky box
+   `padding-bottom` restores the menu's own bottom padding, which the sticky box
    parks on top of; without it the pinned rows sit flush against the popover's
    bottom edge while the first row keeps its inset. */
-.maka-composer-workspace [role="listbox"] > [role="group"] {
+.maka-composer-workspace [role="menu"] > [role="group"] {
   position: sticky;
   bottom: 0;
   z-index: 1;
@@ -368,10 +363,9 @@
 }
 
 /* The rule between catalogue and actions, drawn by the box that is always
-   there. `:not(:first-child)` covers first run and a search that matches no
-   project: with nothing above it, the group would open the menu with a rule
-   dividing nothing. */
-.maka-composer-workspace [role="listbox"] > [role="group"]:not(:first-child) {
+   there. `:not(:first-child)` covers first run — no projects yet — where the
+   group would open the menu with a rule dividing nothing. */
+.maka-composer-workspace [role="menu"] > [role="group"]:not(:first-child) {
   border-top: 1px solid var(--border);
 }
 

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -327,44 +327,54 @@
 /* Cap the open menu at the window. Astryx gives the popover
    `min-width: anchor-size(width)` and no ceiling, and the item labels are not
    truncated, so one long project name grows the shrink-to-fit popover past the
-   right edge of a narrow window — where the pinned actions go with it and there
-   is no way to scroll them back. Same cap the model menus carry
-   (`.maka-composer-quiet-menu`), expressed in the workspace's own tokens. */
+   right edge of a narrow window — where the actions go with it and there is no
+   way to scroll them back. Same cap the model menus carry
+   (`.maka-composer-quiet-menu`), expressed in the workspace's own tokens.
+
+   The panel itself must not scroll: the catalogue scrolls inside its own
+   region below, and the actions after it must stay put. Astryx caps the menu
+   at 300px with `overflow-y: auto`, which scrolls the actions too and chains
+   overscroll to the page behind the popover — lift both so the only scroller
+   in this menu is the catalogue region. */
 .maka-composer-workspace [role="menu"] {
   max-width: min(320px, calc(100vw - var(--space-6)));
+  max-height: none;
+  overflow: visible;
 }
 
-/* Pin "add project" / "no project" to the bottom of the open menu so only the
-   project catalogue scrolls. Astryx `DropdownMenu` scrolls its whole list as
-   one region and exposes no footer slot, so the two rows are stuck here — as
-   one box, because `workspace-picker.tsx` puts them in a section and the menu
-   renders that as a single `role="group"`. Sticking the box rather than its
-   rows is what keeps this one rule: the box is as tall as whatever it holds.
-   Sticking the rows meant declaring the block's height in CSS, which left a
-   backdrop taller than the rows, covering — and swallowing the clicks of — the
-   catalogue rows behind it.
-
-   The group's own background is what hides the scrolled rows, and it sits below
-   its items rather than on them, so Astryx keeps painting the hover and
-   keyboard-highlight tints on the rows themselves. An opaque colour on the rows
-   would win the cascade (this file's `components` layer sits after
-   `astryx-components`) and silently kill both states.
-
-   `padding-bottom` restores the menu's own bottom padding, which the sticky box
-   parks on top of; without it the pinned rows sit flush against the popover's
-   bottom edge while the first row keeps its inset. */
-.maka-composer-workspace [role="menu"] > [role="group"] {
-  position: sticky;
-  bottom: 0;
-  z-index: 1;
-  padding-bottom: var(--space-1);
-  background: var(--color-background-popover);
-  border-radius: 0 0 var(--radius-container) var(--radius-container);
+/* The catalogue's own scroll region — the ONLY thing that scrolls in this
+   menu. `max-height` is the budget the whole popover used to share (224px of
+   catalogue + two action rows ≈ the old 300px ceiling); `overscroll-behavior:
+   contain` stops the wheel from chaining past the catalogue's ends into the
+   page behind the popover, which is what dragged the sticky-pinned actions
+   along before. `scrollbar-gutter: stable` keeps the row width constant when
+   the scrollbar appears. */
+.maka-workspace-picker-scroll {
+  max-height: 224px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  scrollbar-color: var(--border-strong) transparent;
+  scrollbar-width: thin;
 }
 
-/* The rule between catalogue and actions, drawn by the box that is always
-   there. `:not(:first-child)` covers first run — no projects yet — where the
-   group would open the menu with a rule dividing nothing. */
+.maka-workspace-picker-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.maka-workspace-picker-scroll::-webkit-scrollbar-thumb {
+  border: var(--border-width-thick) solid transparent;
+  border-radius: var(--radius-pill);
+  background: var(--border-strong);
+  background-clip: padding-box;
+}
+
+/* The rule between catalogue and actions, drawn by the group's own top border.
+   `:not(:first-child)` covers first run — no projects yet — where the group
+   would open the menu with a rule dividing nothing. Nothing scrolls under the
+   group, so it needs no background of its own: the menu surface shows through
+   and Astryx keeps painting its hover and keyboard-highlight tints on the
+   rows. */
 .maka-composer-workspace [role="menu"] > [role="group"]:not(:first-child) {
   border-top: 1px solid var(--border);
 }

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -358,17 +358,6 @@
   scrollbar-width: thin;
 }
 
-.maka-workspace-picker-scroll::-webkit-scrollbar {
-  width: 8px;
-}
-
-.maka-workspace-picker-scroll::-webkit-scrollbar-thumb {
-  border: var(--border-width-thick) solid transparent;
-  border-radius: var(--radius-pill);
-  background: var(--border-strong);
-  background-clip: padding-box;
-}
-
 /* The rule between catalogue and actions, drawn by the group's own top border.
    `:not(:first-child)` covers first run — no projects yet — where the group
    would open the menu with a rule dividing nothing. Nothing scrolls under the

--- a/apps/desktop/src/renderer/styles/model-switcher.css
+++ b/apps/desktop/src/renderer/styles/model-switcher.css
@@ -32,55 +32,19 @@
   max-width: 100%;
 }
 
-/* Quiet ghost trigger for the chat surface's project picker — the one
-   remaining Selector in the composer footer. Astryx Selector's default is a
-   bordered field, which reads as an input asking to be filled in rather than
-   as a chip carrying a current value; product owns this className only on
-   chat pickers — Settings ModelPicker does not set it.
-   Geometry mirrors .maka-composer-model-chip. */
-.maka-workspace-picker.astryx-selector {
-  font: var(--maka-text-label);
-  padding-block: 0;
-  padding-inline: var(--space-2);
-  border-color: transparent;
-  border-radius: var(--radius-pill);
-  background: transparent;
-  box-shadow: none;
-  color: var(--foreground-secondary);
-  transition:
-    background-color var(--duration-base) var(--ease-out-strong),
-    color var(--duration-base) var(--ease-out-strong);
-}
-
-/* Sizes to the project name rather than holding a column width: it is the last
-   control in a row that already wraps, so a fixed width would spend space the
-   model chip beside it needs. The cap is what keeps a long directory name from
-   pushing the send button off the row. */
-.maka-workspace-picker.astryx-selector {
-  width: max-content;
+/* The project picker's trigger is now a ghost-button DropdownMenu like the
+   model and thinking chips beside it (workspace-picker.tsx), so resting,
+   hover, focus, disabled and tooltip chrome all derive from Astryx Button —
+   no field overlay needed here.
+   Geometry sizes to the project name rather than holding the model pair's
+   column width: it is the last control in a row that already wraps, so a
+   fixed width would spend space the model chip beside it needs. The cap is
+   what keeps a long directory name from pushing the send button off the
+   row. */
+.maka-workspace-picker {
   min-width: 0;
   max-width: min(280px, 60vw);
   flex: 0 0 auto;
-}
-
-.maka-workspace-picker.astryx-selector:hover:not([aria-disabled="true"]) {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-  border-color: transparent;
-  box-shadow: none;
-}
-
-.maka-workspace-picker.astryx-selector:focus-within {
-  border-color: transparent;
-  background: var(--state-hover-bg);
-  box-shadow: none;
-  color: var(--foreground);
-}
-
-.maka-workspace-picker.astryx-selector[aria-disabled="true"] {
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
 }
 
 /* Cursor: product-wide native-cursor.css (maka.legacy) owns default vs pointer. */

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -476,6 +476,28 @@ export const NewChatComposer: Story = {
   ),
 };
 
+// Real path: 新任务 → 切换项目 → 项目 picker 处于 pending（切换中）。
+// Production passes `pending: projectPickerPending` while a project switch is
+// in flight; the trigger locks with a spinner and every menu row disables,
+// matching the model switcher's mid-switch treatment.
+export const NewChatComposerProjectPending: Story = {
+  render: () => (
+    <ComposedShell
+      session={null}
+      chat={{ messages: [] }}
+      composer={{
+        newChatModel: { llmConnectionSlug: 'anthropic-main', model: 'claude-sonnet-4-5' },
+        onPickNewChatModel: noop,
+        onOpenModelSettings: noop,
+        workspacePicker: {
+          ...baseComposerProps.workspacePicker!,
+          pending: true,
+        },
+      }}
+    />
+  ),
+};
+
 const longConversation: StoredMessage[] = [
   user(
     'msg-user-long',

--- a/packages/ui/src/__tests__/composer-workspace-picker.test.tsx
+++ b/packages/ui/src/__tests__/composer-workspace-picker.test.tsx
@@ -70,6 +70,13 @@ describe('Composer workspace picker', () => {
     const modelIdx = leftControls.indexOf('maka-model-selection-controls');
     const pickerIdx = leftControls.indexOf('maka-composer-workspace');
     assert.ok(modelIdx >= 0 && pickerIdx > modelIdx, 'picker follows the model pair');
+
+    // The trigger is a ghost button opening a menu — the footer toolbar
+    // family (model, thinking, ＋, permission) — not a combobox field. That
+    // family is what carries the tooltip and the Button focus ring the
+    // Selector this replaced had no slots for.
+    const pickerTrigger = leftControls.match(/<button[^>]*maka-workspace-picker[^>]*>/)?.[0] ?? '';
+    assert.match(pickerTrigger, /aria-haspopup="menu"/, 'picker trigger opens a menu, not a listbox');
   });
 
   it('drops it once a session owns the composer, even though the host still passes it', () => {

--- a/packages/ui/src/__tests__/composer-workspace-picker.test.tsx
+++ b/packages/ui/src/__tests__/composer-workspace-picker.test.tsx
@@ -1,8 +1,39 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { renderToStaticMarkup } from 'react-dom/server';
+import type { ProjectRecord } from '@maka/core';
 import { LocaleProvider } from '../locale-context.js';
 import { Composer } from '../composer.js';
+import { WorkspacePicker } from '../workspace-picker.js';
+
+const catalog = [
+  { id: 'project-a', name: 'Alpha', locations: [{ path: '/a', isWorktree: false }], available: true },
+  { id: 'project-b', name: 'Beta', locations: [{ path: '/b', isWorktree: false }], available: true },
+  { id: 'project-c', name: 'Gamma', locations: [{ path: '/old', isWorktree: false }], available: false },
+] satisfies readonly ProjectRecord[];
+
+function renderPicker(props: {
+  pending?: boolean;
+  selectedProjectId?: string | null;
+  projects?: readonly ProjectRecord[];
+}): string {
+  return renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <WorkspacePicker
+        workspacePicker={{
+          label: 'Alpha',
+          pending: props.pending,
+          projects: props.projects ?? catalog,
+          selectedProjectId: props.selectedProjectId ?? 'project-a',
+          onAdd: () => undefined,
+          onSelectProject: () => undefined,
+          onRelink: () => undefined,
+          onSelectNoProject: () => undefined,
+        }}
+      />
+    </LocaleProvider>,
+  );
+}
 
 /**
  * The project is a session-creation parameter: it decides where a NEW chat
@@ -84,5 +115,81 @@ describe('Composer workspace picker', () => {
 
     assert.doesNotMatch(markup, /maka-composer-workspace/);
     assert.doesNotMatch(markup, /maka-workspace-picker/);
+  });
+
+  /**
+   * The open menu's structure — one catalogue in its own scroll region, the
+   * two actions after it in normal flow — is the fix for the reported "the
+   * pinned actions scroll along" bug. Mid-PR this tree accidentally rendered
+   * TWO copies of the catalogue, which made keyboard roving unreachable and
+   * wrapped back to the first row; the CSS contract cannot see the
+   * duplication, so the single-copy tree is pinned here.
+   */
+  it('renders the catalogue exactly once, in its own region, actions after it', () => {
+    const markup = renderPicker({});
+
+    const scrollRegions = markup.match(/maka-workspace-picker-scroll/g) ?? [];
+    assert.equal(scrollRegions.length, 1, 'one catalogue region; a second copy made roving unreachable');
+
+    const scrollIdx = markup.indexOf('maka-workspace-picker-scroll');
+    const groupIdx = markup.indexOf('role="group"');
+    assert.ok(scrollIdx >= 0 && groupIdx > scrollIdx, 'the actions sit after the catalogue, outside the scroller');
+
+    assert.match(
+      markup,
+      /Gamma[\s\S]*?maka-workspace-picker-status/,
+      'an unavailable project offers relink on its row',
+    );
+
+    const checks = markup.match(/lucide-check/g) ?? [];
+    assert.equal(checks.length, 1, 'exactly the current project wears the check');
+  });
+
+  it('wears the check on the no-project row when no project is selected', () => {
+    const markup = renderPicker({ selectedProjectId: null });
+
+    const checks = markup.match(/lucide-check/g) ?? [];
+    assert.equal(checks.length, 1, 'exactly one current-value check');
+
+    const noProjectRow = markup.match(
+      /<div\b[^>]*role="menuitem"[^>]*>[\s\S]*?No project[\s\S]*?<\/div>/,
+    )?.[0] ?? '';
+    assert.match(noProjectRow, /lucide-check/, 'the no-project row carries the current-value check');
+  });
+
+  it('renders no scroll region on first run, the actions as the menu\'s first child', () => {
+    const markup = renderPicker({ projects: [] });
+
+    assert.doesNotMatch(markup, /maka-workspace-picker-scroll/);
+    assert.match(markup, /role="menu"/, 'the menu still renders');
+    const groupIdx = markup.indexOf('role="group"');
+    assert.ok(groupIdx > 0, 'the actions group renders');
+  });
+
+  it('locks the trigger and every row while a switch is pending', () => {
+    // An aria-disabled trigger still opens its menu on ArrowDown (Astryx
+    // DropdownMenu's keydown path does not consult isDisabled), so a lock
+    // that lived only on the trigger would be bypassable by keyboard — the
+    // same reason the model switcher locks its rows (#2230).
+    const markup = renderPicker({ pending: true });
+
+    const trigger = markup.match(/<button[^>]*maka-workspace-picker[^>]*>/)?.[0] ?? '';
+    assert.match(trigger, /aria-disabled="true"/, 'the trigger is inert while pending');
+    assert.match(trigger, /aria-busy="true"/, 'the trigger carries the loading marker');
+
+    const items = markup.match(/<div\b[^>]*role="menuitem"[^>]*>/g) ?? [];
+    assert.ok(items.length >= 4, 'catalogue rows and both actions render');
+    assert.ok(
+      items.every((tag) => tag.includes('aria-disabled="true"')),
+      'every menu row is inert while pending',
+    );
+  });
+
+  it('leaves the rows enabled at rest', () => {
+    const markup = renderPicker({});
+
+    const items = markup.match(/<div\b[^>]*role="menuitem"[^>]*>/g) ?? [];
+    assert.ok(items.length >= 4, 'catalogue rows and both actions render');
+    assert.ok(items.every((tag) => !tag.includes('aria-disabled="true"')), 'rows are enabled at rest');
   });
 });

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -164,11 +164,12 @@ export interface ConversationCopy {
     loading: string;
   };
   workspace: {
+    choose: string;
     current: string;
     addProject: string;
     noProject: string;
     relink: string;
-    searchPlaceholder: string;
+    chooseTitle: (branch?: string) => string;
     chooseAriaLabel: (label: string, branch?: string) => string;
   };
   messages: {
@@ -370,7 +371,8 @@ const CONVERSATION_COPY = {
     questions: { other: '其他', otherDescription: '输入一个不同的答案。', otherAriaLabel: '其他答案', otherPlaceholder: '输入你的答案', stop: '停止', stopping: '停止中…', previous: '上一题', submitting: '正在提交…', submit: '提交答案', next: '下一题' },
     mentions: { noFiles: '未找到文件', noSkills: '暂无技能', filesAriaLabel: '工作区文件', skillsAriaLabel: '技能', loading: '加载中…' },
     workspace: {
-      current: '当前项目', addProject: '添加项目', noProject: '无项目', relink: '重新定位', searchPlaceholder: '搜索项目…',
+      choose: '选择项目', current: '当前项目', addProject: '添加项目', noProject: '无项目', relink: '重新定位',
+      chooseTitle: (branch) => branch ? `选择项目 · ${branch}` : '选择项目',
       chooseAriaLabel: (label, branch) => branch ? `选择项目：${label}，当前分支 ${branch}` : `选择项目：${label}`,
     },
     messages: {
@@ -511,7 +513,8 @@ const CONVERSATION_COPY = {
     questions: { other: 'Other', otherDescription: 'Enter a different answer.', otherAriaLabel: 'Other answer', otherPlaceholder: 'Enter your answer', stop: 'Stop', stopping: 'Stopping…', previous: 'Previous', submitting: 'Submitting…', submit: 'Submit answers', next: 'Next' },
     mentions: { noFiles: 'No files found', noSkills: 'No skills available', filesAriaLabel: 'Workspace files', skillsAriaLabel: 'Skills', loading: 'Loading…' },
     workspace: {
-      current: 'Current project', addProject: 'Add project', noProject: 'No project', relink: 'Relink', searchPlaceholder: 'Search projects…',
+      choose: 'Choose project', current: 'Current project', addProject: 'Add project', noProject: 'No project', relink: 'Relink',
+      chooseTitle: (branch) => branch ? `Choose project · ${branch}` : 'Choose project',
       chooseAriaLabel: (label, branch) => branch ? `Choose project: ${label}, current branch ${branch}` : `Choose project: ${label}`,
     },
     messages: {

--- a/packages/ui/src/workspace-picker.tsx
+++ b/packages/ui/src/workspace-picker.tsx
@@ -89,47 +89,50 @@ export function WorkspacePicker(props: { workspacePicker: WorkspacePickerModel }
         'aria-label': copy.chooseAriaLabel(wp.label ?? copy.current, wp.branch ?? undefined),
       }}
     >
-      {wp.projects.map((project) => {
-        const missing = unavailable.has(project.id);
-        return (
-          <DropdownMenuItem
-            key={project.id}
-            icon={
-              missing ? (
-                <AlertTriangle size={13} aria-hidden="true" />
-              ) : (
-                <FolderOpen size={13} aria-hidden="true" />
-              )
-            }
-            label={project.name}
-            // A project whose directory has moved cannot be selected until it
-            // is pointed at a path again, so its row relinks instead of
-            // switching. The current project wears the same plain check as the
-            // model and thinking menus' current values.
-            endContent={
-              missing ? (
-                <span className="maka-workspace-picker-status">{copy.relink}</span>
-              ) : project.id === wp.selectedProjectId ? (
-                <Check size={13} aria-hidden="true" />
-              ) : undefined
-            }
-            isDisabled={locked}
-            onClick={() => {
-              if (missing) wp.onRelink(project.id);
-              else wp.onSelectProject(project.id);
-            }}
-          />
-        );
-      })}
-      {/* Catalogue first, then the two actions — pinned to the menu's bottom
-          edge while only the catalogue scrolls, so "add a project" never falls
-          under the fold on a long list. DropdownMenu scrolls its whole list as
-          one region and has no footer slot, so the pinning is done in CSS;
-          what makes it one rule instead of a stack of them is the group, which
-          renders as a single `role="group"` box. `composer.css` sticks that
-          box, and its height is whatever it actually contains.
-
-          Both actions carry an icon so every row shares one text axis. Without
+      {/* Catalogue first, in its own scroll region — the only thing that
+          scrolls. The two actions sit AFTER it in normal flow, so they are
+          outside the scroller entirely and cannot be carried along by it: the
+          old sticky-pinned box moved with the panel when overscroll chained
+          to the page behind the menu. The region renders only when there is a
+          catalogue; on first run the actions group is the menu's first child
+          and the CSS drops the divider that separates the two. */}
+      {wp.projects.length > 0 ? (
+        <div className="maka-workspace-picker-scroll">
+          {wp.projects.map((project) => {
+            const missing = unavailable.has(project.id);
+            return (
+              <DropdownMenuItem
+                key={project.id}
+                icon={
+                  missing ? (
+                    <AlertTriangle size={13} aria-hidden="true" />
+                  ) : (
+                    <FolderOpen size={13} aria-hidden="true" />
+                  )
+                }
+                label={project.name}
+                // A project whose directory has moved cannot be selected until
+                // it is pointed at a path again, so its row relinks instead of
+                // switching. The current project wears the same plain check as
+                // the model and thinking menus' current values.
+                endContent={
+                  missing ? (
+                    <span className="maka-workspace-picker-status">{copy.relink}</span>
+                  ) : project.id === wp.selectedProjectId ? (
+                    <Check size={13} aria-hidden="true" />
+                  ) : undefined
+                }
+                isDisabled={locked}
+                onClick={() => {
+                  if (missing) wp.onRelink(project.id);
+                  else wp.onSelectProject(project.id);
+                }}
+              />
+            );
+          })}
+        </div>
+      ) : null}
+      {/* Both actions carry an icon so every row shares one text axis. Without
           them the two labels started at the icon column while the projects'
           text started past it, which read as a broken list rather than as a
           separate group. The × also says what its row means: not using a

--- a/packages/ui/src/workspace-picker.tsx
+++ b/packages/ui/src/workspace-picker.tsx
@@ -28,13 +28,18 @@
  * beside it was one too); #2230 moved the model and thinking pickers onto the
  * ghost-menu family, and this control followed once the row had one toolbar
  * convention left. Search died with the Selector, matching the model menu's
- * precedent — the panel keeps its 300px scroll and Astryx first-character
- * typeahead. The trigger's tooltip came back with the Button: Selector had no
- * slot for it, so the current git branch rode in the accessible name alone.
+ * precedent: the menu keeps Astryx's first-character typeahead over printable
+ * keys, which for CJK labels means arrow traversal in practice — IME input
+ * does not produce the keydown events typeahead listens for. The catalogue
+ * scrolls inside its own region, and the two actions after it sit outside the
+ * scroller, so the wheel can never carry them away. The trigger's tooltip
+ * came back with the Button: Selector had no slot for it, so the current git
+ * branch rode in the accessible name alone.
  *
  * The current git branch rides in the trigger's tooltip and accessible name
- * only. Switching branches is the agent's job — see the commit that removed
- * the branch picker.
+ * only — the open menu's own name is the short trigger label, an Astryx
+ * behaviour the model menu shares. Switching branches is the agent's job —
+ * see the commit that removed the branch picker.
  *
  * Purely presentational: a value control fed by host-injected props.
  */
@@ -119,7 +124,7 @@ export function WorkspacePicker(props: { workspacePicker: WorkspacePickerModel }
                   missing ? (
                     <span className="maka-workspace-picker-status">{copy.relink}</span>
                   ) : project.id === wp.selectedProjectId ? (
-                    <Check size={13} aria-hidden="true" />
+                    <Check size={14} aria-hidden="true" />
                   ) : undefined
                 }
                 isDisabled={locked}
@@ -137,7 +142,7 @@ export function WorkspacePicker(props: { workspacePicker: WorkspacePickerModel }
           text started past it, which read as a broken list rather than as a
           separate group. The × also says what its row means: not using a
           project is a deliberate way to work, not a missing setting. */}
-      <div role="group" className="maka-workspace-picker-actions">
+      <div role="group">
         <DropdownMenuItem
           icon={<Plus size={13} aria-hidden="true" />}
           label={copy.addProject}
@@ -149,7 +154,7 @@ export function WorkspacePicker(props: { workspacePicker: WorkspacePickerModel }
         <DropdownMenuItem
           icon={<X size={13} aria-hidden="true" />}
           label={copy.noProject}
-          endContent={wp.selectedProjectId === null ? <Check size={13} aria-hidden="true" /> : undefined}
+          endContent={wp.selectedProjectId === null ? <Check size={14} aria-hidden="true" /> : undefined}
           isDisabled={locked}
           onClick={() => {
             wp.onSelectNoProject();

--- a/packages/ui/src/workspace-picker.tsx
+++ b/packages/ui/src/workspace-picker.tsx
@@ -19,28 +19,30 @@
  * a layout jump on every new task, paid to avoid one chip disappearing from the
  * end of a row.
  *
- * Built on Astryx `Selector`, the same primitive as the model picker, because
- * picking a project IS choosing a value: one selection out of a catalogue,
- * with a current one. It used to be a `DropdownMenu` — an action menu — which
- * it could only be because the catalogue and the actions (add, relink, no
- * project) shared one surface. That choice was visible: menu items came out at
- * weight 400 in `#171717` next to the model list's weight 500 in the theme's
- * oklch foreground, two dropdowns from one library that did not read as
- * relatives. The actions are now ordinary options after a divider, following
- * `ModelPicker`'s `leadingOption` precedent for product values that are not
- * catalogue entries.
+ * Built on the composer footer's ghost-button DropdownMenu family — the same
+ * primitive as the model, thinking, ＋ and permission controls beside it —
+ * because this row is a toolbar, and toolbar members share one Button chrome:
+ * resting, hover, focus, and disabled states plus the tooltip all derive from
+ * Astryx Button instead of a product overlay restyling a form field. It used
+ * to be an Astryx Selector (rebuilt onto it in #2217, when the model picker
+ * beside it was one too); #2230 moved the model and thinking pickers onto the
+ * ghost-menu family, and this control followed once the row had one toolbar
+ * convention left. Search died with the Selector, matching the model menu's
+ * precedent — the panel keeps its 300px scroll and Astryx first-character
+ * typeahead. The trigger's tooltip came back with the Button: Selector had no
+ * slot for it, so the current git branch rode in the accessible name alone.
  *
- * The current git branch rides along in the trigger's accessible name only.
- * Switching branches is the agent's job — see the commit that removed the
- * branch picker.
+ * The current git branch rides in the trigger's tooltip and accessible name
+ * only. Switching branches is the agent's job — see the commit that removed
+ * the branch picker.
  *
  * Purely presentational: a value control fed by host-injected props.
  */
 
 import type { ProjectRecord } from '@maka/core';
-import { Selector, SelectorOption, type SelectorOptionData, type SelectorOptionType } from '@astryxdesign/core/Selector';
+import { DropdownMenu, DropdownMenuItem } from '@astryxdesign/core/DropdownMenu';
 import { useMemo } from 'react';
-import { AlertTriangle, FolderOpen, Plus, X } from './icons.js';
+import { AlertTriangle, Check, FolderOpen, Plus, X } from './icons.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 
@@ -56,13 +58,6 @@ export interface WorkspacePickerModel {
   onSelectNoProject(): void;
 }
 
-/**
- * Sentinel option values for the two entries that are not projects. Namespaced
- * so they can never collide with a real project id.
- */
-const ADD_PROJECT_VALUE = 'maka:workspace/add-project';
-const NO_PROJECT_VALUE = 'maka:workspace/no-project';
-
 export function WorkspacePicker(props: { workspacePicker: WorkspacePickerModel }) {
   const wp = props.workspacePicker;
   const copy = getConversationCopy(useUiLocale()).workspace;
@@ -72,104 +67,92 @@ export function WorkspacePicker(props: { workspacePicker: WorkspacePickerModel }
     [wp.projects],
   );
 
-  // Catalogue first, then the two actions — which stay pinned to the menu's
-  // bottom edge while only the catalogue scrolls, so "add a project" never
-  // falls under the fold on a long list. Selector scrolls its whole list as one
-  // region and has no footer slot, so the pinning is done in CSS; what makes it
-  // one rule instead of a stack of them is the section, which Selector renders
-  // as a single `role="group"` box. `composer.css` sticks that box, and its
-  // height is whatever it actually contains — so a search that matches only one
-  // action pins exactly that row.
-  //
-  // Both actions carry an icon so every row shares one text axis. Without them
-  // the two labels started at the icon column while the projects' text started
-  // past it, which read as a broken list rather than as a separate group.
-  const options = useMemo<SelectorOptionType[]>(
-    () => [
-      ...wp.projects.map((project): SelectorOptionData => ({
-        value: project.id,
-        label: project.name,
-      })),
-      // The rule that separates the catalogue from the actions is the group's
-      // own top border, not a divider option: a divider would scroll away with
-      // the catalogue while the group stayed, and it would need suppressing on
-      // first run — no projects yet — where it would divide nothing. The border
-      // is on the box that is always there, and CSS drops it when the group is
-      // the list's first child.
-      {
-        type: 'section',
-        options: [
-          { value: ADD_PROJECT_VALUE, label: copy.addProject },
-          // Codex names this row "work without a project", which says the act
-          // rather than the empty value. Not adopted: Selector paints the
-          // trigger from the selected option's own label, with no slot to
-          // shorten it, so that phrasing would also become the label sitting in
-          // the composer footer — a seven-character negative sentence beside
-          // the model name. The × carries the same "deliberate, not missing"
-          // meaning at trigger length.
-          { value: NO_PROJECT_VALUE, label: copy.noProject },
-        ],
-      },
-    ],
-    [wp.projects, copy.addProject, copy.noProject],
-  );
+  // A project switch is in flight: lock the trigger and every row, like the
+  // model switcher beside it — an aria-disabled DropdownMenu trigger still
+  // opens on ArrowDown, so the lock must ride on the items too.
+  const locked = wp.pending === true;
 
   return (
-    <Selector
-      label={copy.chooseAriaLabel(wp.label ?? copy.current, wp.branch ?? undefined)}
-      isLabelHidden
-      options={options}
-      // `null` means "no project", which is a real choice here rather than the
-      // absence of one, so it maps to its own option instead of the placeholder.
-      value={wp.selectedProjectId ?? NO_PROJECT_VALUE}
-      // Always searchable, like the model picker: a threshold would make the
-      // menu change shape as the catalogue grows, so the same control would
-      // answer the keyboard differently on different days.
-      hasSearch
-      searchPlaceholder={copy.searchPlaceholder}
-      size="sm"
-      // The trigger sits in the composer footer, at the bottom of the window,
-      // so the menu opens upward like every other control in that row.
+    <DropdownMenu
       placement="above"
-      isDisabled={wp.pending === true}
-      startIcon={<FolderOpen size={13} aria-hidden="true" />}
-      className="maka-workspace-picker"
-      changeAction={(value: string) => {
-        if (value === ADD_PROJECT_VALUE) {
-          wp.onAdd();
-          return;
-        }
-        if (value === NO_PROJECT_VALUE) {
-          wp.onSelectNoProject();
-          return;
-        }
-        // A project whose directory has moved cannot be selected until it is
-        // pointed at a path again, so its row relinks instead of switching.
-        if (unavailable.has(value)) wp.onRelink(value);
-        else wp.onSelectProject(value);
+      hasChevron={false}
+      className="maka-composer-quiet-menu"
+      button={{
+        label: wp.label ?? copy.choose,
+        icon: <FolderOpen size={13} aria-hidden="true" />,
+        variant: 'ghost',
+        size: 'sm',
+        isDisabled: locked,
+        isLoading: locked,
+        tooltip: copy.chooseTitle(wp.branch ?? undefined),
+        className: 'maka-workspace-picker',
+        'aria-label': copy.chooseAriaLabel(wp.label ?? copy.current, wp.branch ?? undefined),
       }}
-      renderOption={(option: SelectorOptionData) => (
-        <SelectorOption
-          className={
-            option.value === ADD_PROJECT_VALUE || option.value === NO_PROJECT_VALUE
-              ? 'maka-workspace-picker-option maka-workspace-picker-option-pinned'
-              : 'maka-workspace-picker-option'
-          }
-          icon={
-            option.value === ADD_PROJECT_VALUE
-              ? <Plus size={13} aria-hidden="true" />
-              : option.value === NO_PROJECT_VALUE
-                ? <X size={13} aria-hidden="true" />
-                : unavailable.has(option.value)
-                  ? <AlertTriangle size={13} aria-hidden="true" />
-                  : <FolderOpen size={13} aria-hidden="true" />
-          }
-          label={option.label ?? option.value}
-          endContent={unavailable.has(option.value) ? (
-            <span className="maka-workspace-picker-status">{copy.relink}</span>
-          ) : undefined}
+    >
+      {wp.projects.map((project) => {
+        const missing = unavailable.has(project.id);
+        return (
+          <DropdownMenuItem
+            key={project.id}
+            icon={
+              missing ? (
+                <AlertTriangle size={13} aria-hidden="true" />
+              ) : (
+                <FolderOpen size={13} aria-hidden="true" />
+              )
+            }
+            label={project.name}
+            // A project whose directory has moved cannot be selected until it
+            // is pointed at a path again, so its row relinks instead of
+            // switching. The current project wears the same plain check as the
+            // model and thinking menus' current values.
+            endContent={
+              missing ? (
+                <span className="maka-workspace-picker-status">{copy.relink}</span>
+              ) : project.id === wp.selectedProjectId ? (
+                <Check size={13} aria-hidden="true" />
+              ) : undefined
+            }
+            isDisabled={locked}
+            onClick={() => {
+              if (missing) wp.onRelink(project.id);
+              else wp.onSelectProject(project.id);
+            }}
+          />
+        );
+      })}
+      {/* Catalogue first, then the two actions — pinned to the menu's bottom
+          edge while only the catalogue scrolls, so "add a project" never falls
+          under the fold on a long list. DropdownMenu scrolls its whole list as
+          one region and has no footer slot, so the pinning is done in CSS;
+          what makes it one rule instead of a stack of them is the group, which
+          renders as a single `role="group"` box. `composer.css` sticks that
+          box, and its height is whatever it actually contains.
+
+          Both actions carry an icon so every row shares one text axis. Without
+          them the two labels started at the icon column while the projects'
+          text started past it, which read as a broken list rather than as a
+          separate group. The × also says what its row means: not using a
+          project is a deliberate way to work, not a missing setting. */}
+      <div role="group" className="maka-workspace-picker-actions">
+        <DropdownMenuItem
+          icon={<Plus size={13} aria-hidden="true" />}
+          label={copy.addProject}
+          isDisabled={locked}
+          onClick={() => {
+            wp.onAdd();
+          }}
         />
-      )}
-    />
+        <DropdownMenuItem
+          icon={<X size={13} aria-hidden="true" />}
+          label={copy.noProject}
+          endContent={wp.selectedProjectId === null ? <Check size={13} aria-hidden="true" /> : undefined}
+          isDisabled={locked}
+          onClick={() => {
+            wp.onSelectNoProject();
+          }}
+        />
+      </div>
+    </DropdownMenu>
   );
 }


### PR DESCRIPTION
## Background

After #2230 moved the model and thinking pickers onto ghost-button `DropdownMenu`s, the project picker became the last Astryx `Selector` (a form-field primitive) left in the composer footer — the one toolbar row where every other control (＋, permission, model, thinking) is a ghost button. #2230's commit message explicitly left this as a follow-up: "The workspace picker keeps its quiet Selector overlay until it gets its own migration."

Every symptom reported maps to that family mismatch:

- **Different weight/color** — Selector field typography/ink vs Button chrome (the field was disguised by ~60 lines of product CSS clearing field state by state).
- **No tooltip** — `Selector` has no tooltip slot (#2217 recorded this loss), so the current git branch only rode in the accessible name.
- **No focus ring** — the disguise CSS suppressed the field's focus (`box-shadow: none`), while ghost buttons get the accent focus-visible ring.

## Change

`WorkspacePicker` migrates from `Selector` to the same chevronless ghost-button `DropdownMenu` as the model chip beside it, so resting, hover, focus, disabled and tooltip chrome all derive from one Astryx `Button`:

- **Trigger**: FolderOpen icon + current project name (or 无项目); tooltip restored (`选择项目 · <branch>`, branch stays read-only context); accessible name unchanged.
- **Menu rows**: project list with the current value's plain check (same convention as the model/thinking menus), the relink status row for unavailable projects, and 添加项目 / 无项目 after the catalogue in normal flow — outside the scroller, so they can never be carried along by the wheel.
- **Scroll confined to the catalogue**: the project rows live in their own scroll region (`.maka-workspace-picker-scroll`, 224px budget, `overscroll-behavior: contain`); the menu panel lifts Astryx's 300px cap (`max-height: none; overflow: visible`) so it never scrolls itself. This replaces the sticky-pinned footer from the first iteration of this PR, which moved with the panel when overscroll chained into the page behind the popover.
- **Search dies with the Selector**, following the model menu's precedent: the region keeps the scroll and Astryx first-character typeahead (documented: CJK labels are arrow-traversed in practice, since IME input does not produce the keydown events typeahead listens for).
- **Pending** (project switch in flight): the trigger locks with a spinner and every row disables, like the model switcher.

Also removes the now-dead Selector overlay rules, the `searchPlaceholder` copy, a dead `::-webkit-scrollbar` block (standard `scrollbar-color`/`scrollbar-width` win in Chromium 121+) and a dead class hook; restores the `choose`/`chooseTitle` copy; updates the palette-seam and header docs.

## Storybook

The existing `NewChatComposer` story already renders the picker (draft state); this PR adds `NewChatComposerProjectPending` for the uncovered `pending: true` state.

## Testing

Two external reviews (deepseek-v4-flash, design + test angles) found no P0/P1/P2 in the design, but flagged that the two behaviors that mattered most were verified manually, not by tests. Both gaps are now closed:

- **SSR structure tests** (composer-workspace-picker.test.tsx, +5 cases): the catalogue renders exactly once in its own region with the actions after it (the mid-PR duplicate-catalogue regression that broke keyboard roving would now go red); relink row; current-value check placement (selected project / no-project row); first run renders no scroll region; pending locks the trigger (`aria-disabled` + `aria-busy`) and every row, with an at-rest reverse assertion — mirroring chat-model-switcher's lock pin.
- **CSS contract extensions** (workspace-picker-menu-contract.test.ts, +2 cases): the panel **must** lift the cap (`max-height: none` + `overflow: visible` — Astryx's cap comes with `overflow-y: auto`), the scroller **must** declare `overscroll-behavior: contain`, and the `:not(:first-child)` divider rule is pinned. Mutation-checked: dropping `overscroll-behavior: contain` now fails the contract (was green before).

- `@maka/ui`: 419 tests pass; contract test 5/5; check-dead-css 13/13; biome format/lint clean.
- Live Storybook checks (Playwright + computed styles): trigger and model chip report identical computed styles (color `oklch(0.17 0.005 286)`, weight 500, 14px, radius 16px); keyboard focus shows the accent ring; the actions' rect is constant while the catalogue scrolls and after a wheel over it; keyboard roving reaches every row and stops (no wrap); tooltip renders "选择项目 · opencode/storybook-surface-coverage"; pending story shows `aria-disabled` + `aria-busy` + spinner.
