### PR TITLE
fix(desktop): isolate dev build userData root from release (Maka Dev)

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -3,7 +3,13 @@ import { isIsolatedE2e } from './startup-context.js';
 
 // The macOS app menu title and app.getName() consumers read this name. Set it
 // before ready, unchanged from its historical pre-ready position.
-app.setName('Maka');
+//
+// Safe-by-default isolation: a dev build must not share the released app's
+// userData root. Electron derives userData from the app name, so a distinct
+// dev name yields a distinct root (and thus a distinct runtime-host rootId,
+// socket/pipe namespace, and single-instance lock) without touching any
+// path logic. See https://github.com/maka-agent/maka-agent/issues/2252.
+app.setName(app.isPackaged ? 'Maka' : 'Maka Dev');
 
 // E2E isolation: redirect userData BEFORE the single-instance lock so the
 // lock judges the throwaway dir, not the real user data — otherwise a


### PR DESCRIPTION
Closes #2252

## Problem

A dev build and the released app share the name `Maka`, so Electron derives the **same `userData` root** for both. Dev sessions can silently pollute release data — especially schema migrations, which are irreversible. Per the review on #2252, this is the minimal one-line fix.

## Change

```ts
app.setName(app.isPackaged ? 'Maka' : 'Maka Dev');
```

Electron derives `userData` from the app name, so the dev build now gets a disjoint root — and with it a disjoint runtime-host `rootId`, socket/pipe namespace, and single-instance lock — without touching any path logic.

## Blast radius (checked)

- `app.getName()` consumers: permission-overlay copy and macOS menu bar only (both reasonably say `Maka Dev` in dev).
- Window title is hard-coded — no regression.
- `MAKA_E2E_USER_DATA_DIR` redirect (e2e gate) is untouched and still outranks the dev-default root.

## Verification (Electron 43.1.1, Windows)

- `setName('Maka')` → `%APPDATA%\Maka`; `setName('Maka Dev')` → `%APPDATA%\Maka Dev` — userData is resolved lazily, and `main.ts` calls `setName` before the first `getPath('userData')` (top-level order: `setName` → e2e `setPath` → `requestSingleInstanceLock` → ready).
- Single-instance lock: `Maka` and `Maka Dev` processes both acquire the lock concurrently; two `Maka` processes conflict (second gets `lock=false`). Lock namespace follows userData.
- Launch matrix:
  - **Windows/Linux dev** (`npm run dev`/`npm start`): `electron apps/desktop` directly, no bootstrap — fix applies, dev root becomes `Maka Dev`.
  - **macOS dev**: `Maka Dev.app` bootstrap already pins `setPath('userData', ~/Library/Application Support/Maka Dev-<worktreeId>)` before loading `main.js` — already isolated; the `setName` is a harmless no-op there.
  - **Release**: `isPackaged=true` → `Maka`, unchanged.
  - **E2E**: `MAKA_E2E_USER_DATA_DIR` gate (`startup-context.ts`) still outranks the dev-default root.

## Tests

Typecheck passes. Desktop main test suites (computer-use-host, e2e-fixture, attachment-ingest) show identical results before/after the change (78 tests / 46 pass / 32 fail — the failures are pre-existing environment-related ones, unrelated to this diff).

<details>
<summary><strong>简体中文</strong></summary>

## 问题

开发版与正式版共用应用名 `Maka`，Electron 因此为两者解析出**同一个 `userData` 根目录**。开发会话可能静默污染正式数据——尤其是 schema 迁移，不可逆。按 #2252 评审意见，这是最小的一行修复。

## 改动

```ts
app.setName(app.isPackaged ? 'Maka' : 'Maka Dev');
```

Electron 从应用名派生 `userData`，开发版因此获得独立数据根——连带 runtime-host `rootId`、socket/pipe 命名空间与 single-instance 锁全部隔离，无需触碰任何路径逻辑。

## 影响面（已核查）

- `app.getName()` 消费者：仅 permission overlay 文案与 macOS 菜单栏（dev 下显示 `Maka Dev` 本就合理）。
- 窗口标题硬编码——无回归。
- `MAKA_E2E_USER_DATA_DIR` 重定向（e2e 门控）不动，仍优先于 dev 默认根。

## 验证（Electron 43.1.1，Windows）

- `setName('Maka')` → `%APPDATA%\Maka`；`setName('Maka Dev')` → `%APPDATA%\Maka Dev`——userData 为惰性解析，`main.ts` 顶层顺序（`setName` → e2e `setPath` → `requestSingleInstanceLock` → ready）保证首次 `getPath('userData')` 前已生效。
- 单实例锁：`Maka` 与 `Maka Dev` 两个进程可同时拿到锁；同名两个 `Maka` 则冲突（第二个 `lock=false`）。锁命名空间随 userData 走。
- 启动矩阵：
  - **Windows/Linux dev**（`npm run dev`/`npm start`）：直接 `electron apps/desktop`，无 bootstrap 介入——修复生效，dev 根变为 `Maka Dev`。
  - **macOS dev**：`Maka Dev.app` 的 bootstrap 在加载 `main.js` 前已 `setPath('userData', ~/Library/Application Support/Maka Dev-<worktreeId>)`——本就隔离，`setName` 在此为无害冗余。
  - **正式版**：`isPackaged=true` → `Maka`，不变。
  - **e2e**：`MAKA_E2E_USER_DATA_DIR` 门控（`startup-context.ts`）仍优先于 dev 默认根。

## 测试

类型检查通过。desktop main 相关测试套件（computer-use-host、e2e-fixture、attachment-ingest）改动前后结果一致（78 tests / 46 pass / 32 fail——失败为环境固有，与本 diff 无关）。

</details>
