### PR TITLE
fix(runtime): stop reporting a truncated provider stream as a finished turn

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -7221,11 +7221,70 @@ describe('AiSdkBackend usage telemetry', () => {
       (event): event is Extract<SessionEvent, { type: 'complete' }> => event.type === 'complete',
     );
 
-    assert.notEqual(
+    // Not merely "some other stop reason": `max_tokens` would also satisfy that
+    // and still record the turn as completed downstream, which is the bug.
+    assert.equal(
       complete?.stopReason,
-      'end_turn',
+      'error',
       'a stream that never delivered a finish frame did not end the turn',
     );
+    // And it must say so. A failed terminal whose only trace is the stop reason
+    // leaves the session's lastError empty and the request ledger reading
+    // `success` — the same silence that let the benchmark cell pass unnoticed.
+    assert.ok(
+      events.some((event) => event.type === 'error'),
+      'a failed terminal must be accompanied by an error event',
+    );
+  });
+
+  test('keeps a turn the provider named its own reason for', async () => {
+    // The SDK's `other` is not a reason, it is the SDK declining to name one:
+    // an unrecognized `finish_reason` from an OpenAI-compatible provider —
+    // llama.cpp's `eos_token`, DeepSeek's `insufficient_system_resource` —
+    // lands in the same bucket as a connection that died mid-answer. The
+    // provider's own spelling is the only thing that tells them apart, so
+    // treating the bucket itself as failure would fail complete answers.
+    const durable = durableTurnHarness('turn-unnamed', 'analyse the image');
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'The top region is empty.' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'other' as const, raw: 'eos_token' },
+              usage: emptyUsage(),
+            },
+          ],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      }),
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events = await drainDurably(backend.send(durable.input()), durable);
+    const complete = events.find(
+      (event): event is Extract<SessionEvent, { type: 'complete' }> => event.type === 'complete',
+    );
+
+    assert.equal(complete?.stopReason, 'end_turn');
+    assert.ok(!events.some((event) => event.type === 'error'));
   });
 
   test('rejects continuation-capable tools before side effects without a durable reader', async () => {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -7237,6 +7237,57 @@ describe('AiSdkBackend usage telemetry', () => {
     );
   });
 
+  test('says which failed terminal a content filter is', async () => {
+    // A named provider terminal, not a stream nobody closed. It reaches the
+    // same failed outcome and so must carry the same error event — on main it
+    // ended the turn failed while `lastError` stayed empty — but calling it
+    // "ended without finishing" would describe the wrong thing.
+    const durable = durableTurnHarness('turn-filtered', 'analyse the image');
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'I cannot' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'content-filter' as const, raw: 'content_filter' },
+              usage: emptyUsage(),
+            },
+          ],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      }),
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events = await drainDurably(backend.send(durable.input()), durable);
+    const complete = events.find(
+      (event): event is Extract<SessionEvent, { type: 'complete' }> => event.type === 'complete',
+    );
+    const error = events.find(
+      (event): event is Extract<SessionEvent, { type: 'error' }> => event.type === 'error',
+    );
+
+    assert.equal(complete?.stopReason, 'error');
+    assert.ok(error, 'a failed terminal must be accompanied by an error event');
+  });
+
   test('keeps a turn the provider named its own reason for', async () => {
     // The SDK's `other` is not a reason, it is the SDK declining to name one:
     // an unrecognized `finish_reason` from an OpenAI-compatible provider —

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -7180,6 +7180,54 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(events.at(-1)?.type, 'complete');
   });
 
+  test('does not call a truncated provider stream a finished turn', async () => {
+    // The upstream cut the SSE connection mid-answer: chunks arrived, no
+    // `finish` frame did. The stream then ends without yielding an error and
+    // without throwing, so every guard that watches for a thrown failure sees
+    // nothing. Reporting `end_turn` here tells the caller the model said its
+    // piece when the connection simply died — a benchmark cell recorded
+    // `status: completed` on exactly this shape while the agent was still
+    // mid-task.
+    const durable = durableTurnHarness('turn-truncated', 'analyse the image');
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Let me look at the top region' },
+          ],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      }),
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events = await drainDurably(backend.send(durable.input()), durable);
+    const complete = events.find(
+      (event): event is Extract<SessionEvent, { type: 'complete' }> => event.type === 'complete',
+    );
+
+    assert.notEqual(
+      complete?.stopReason,
+      'end_turn',
+      'a stream that never delivered a finish frame did not end the turn',
+    );
+  });
+
   test('rejects continuation-capable tools before side effects without a durable reader', async () => {
     const loop = countingToolLoopModel(1);
     let executions = 0;

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -521,6 +521,11 @@ describe('ModelAdapter stream and error normalization', () => {
     assert.equal(adapter.mapFinishReason('error'), 'error');
     assert.equal(adapter.mapFinishReason('tool-calls'), 'end_turn');
     assert.equal(adapter.mapFinishReason('provider-new-reason'), 'end_turn');
+    // Not the same as a new reason: these two are the SDK saying it cannot name
+    // why the stream stopped, which is what a dropped upstream connection looks
+    // like from here.
+    assert.equal(adapter.mapFinishReason('other'), 'error');
+    assert.equal(adapter.mapFinishReason('unknown'), 'error');
   });
 
   test('projects the final provider error inside an AI SDK retry wrapper', () => {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2089,7 +2089,6 @@ export class AiSdkBackend implements AgentBackend {
           // disagreeing about why the stream ended.
           finishReason =
             rawFinishReason ?? (await result.finishReason.catch(() => 'stop')) ?? 'stop';
-          rawFinishReason = finishReason;
           await queue.waitUntilConsumedThroughCurrent();
 
           if (returnedToolCalls.length > 0) {
@@ -2341,14 +2340,21 @@ export class AiSdkBackend implements AgentBackend {
             ? 'step_limit'
             : this.mapFinishReason(finishReason));
         if (stopReason === 'error') {
-          // Reaching a failed terminal without anything having been thrown: the
-          // stream ended quietly on a reason we cannot call a finished turn.
+          // Reaching a failed terminal without anything having been thrown.
           // Every other `stopReason: 'error'` here comes out of the catch below
           // with an error event and a failed trace behind it, and the session's
           // `lastError` and the request ledger are fed by exactly those. Ending
           // the turn failed while the telemetry still reads `success` is the
           // same blindness this branch exists to remove.
-          const err = new Error(`Provider stream ended without finishing (${finishReason})`);
+          //
+          // Two different things arrive here and the message says which: the
+          // provider stopping the stream on its own policy, and a stop nothing
+          // named at all.
+          const err = new Error(
+            finishReason === 'content-filter'
+              ? 'Provider stopped the stream on a content filter'
+              : `Provider stream ended without finishing (${finishReason})`,
+          );
           streamStatus = 'error';
           streamErrorClass = this.modelAdapter.classifyError(err);
           queue.push(this.makeErrorEvent(turnId, err));

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2082,8 +2082,14 @@ export class AiSdkBackend implements AgentBackend {
           // stream without a trailing `finish-step` for the last step.
           await flushStep();
 
-          finishReason = (await result.finishReason.catch(() => 'stop')) ?? 'stop';
-          rawFinishReason = rawFinishReason ?? finishReason;
+          // The settled promise reports only the SDK's unified enum; the stream
+          // events carry what the provider itself said, which is strictly more
+          // specific and is already what telemetry prefers below. Reading the
+          // same value here keeps the turn's outcome and its record from
+          // disagreeing about why the stream ended.
+          finishReason =
+            rawFinishReason ?? (await result.finishReason.catch(() => 'stop')) ?? 'stop';
+          rawFinishReason = finishReason;
           await queue.waitUntilConsumedThroughCurrent();
 
           if (returnedToolCalls.length > 0) {
@@ -2334,7 +2340,22 @@ export class AiSdkBackend implements AgentBackend {
           (this.maxSteps !== undefined && finishReason === 'tool-calls'
             ? 'step_limit'
             : this.mapFinishReason(finishReason));
-        trace.modelStreamCompleted(stopReason);
+        if (stopReason === 'error') {
+          // Reaching a failed terminal without anything having been thrown: the
+          // stream ended quietly on a reason we cannot call a finished turn.
+          // Every other `stopReason: 'error'` here comes out of the catch below
+          // with an error event and a failed trace behind it, and the session's
+          // `lastError` and the request ledger are fed by exactly those. Ending
+          // the turn failed while the telemetry still reads `success` is the
+          // same blindness this branch exists to remove.
+          const err = new Error(`Provider stream ended without finishing (${finishReason})`);
+          streamStatus = 'error';
+          streamErrorClass = this.modelAdapter.classifyError(err);
+          queue.push(this.makeErrorEvent(turnId, err));
+          trace.modelStreamFailed(streamErrorClass, err, priorReplayFailureTrace(priorReplay));
+        } else {
+          trace.modelStreamCompleted(stopReason);
+        }
         queue.push({
           type: 'complete',
           id: this.newId(),

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1233,7 +1233,7 @@ export class AiSdkBackend implements AgentBackend {
     let lastStepInputTokens: number | undefined;
     let streamStatus: LlmCallRecord['status'] = 'success';
     let streamErrorClass: string | undefined;
-    let rawFinishReason: string | undefined;
+    let streamedFinishReason: string | undefined;
     let runtimeSteps = 0;
     let requestShapeForTelemetry: RequestShapeDiagnostic | undefined;
     let promptSegmentsForTelemetry: PromptSegmentEstimate[] = [];
@@ -1835,7 +1835,7 @@ export class AiSdkBackend implements AgentBackend {
                   }
                 }
                 if (event.kind === 'finish' || event.kind === 'step-finish') {
-                  rawFinishReason = event.finishReason ?? rawFinishReason;
+                  streamedFinishReason = event.finishReason ?? streamedFinishReason;
                 }
                 if (event.kind === 'text-start') {
                   stepTextPartStartOffset = stepText.length;
@@ -2088,7 +2088,7 @@ export class AiSdkBackend implements AgentBackend {
           // same value here keeps the turn's outcome and its record from
           // disagreeing about why the stream ended.
           finishReason =
-            rawFinishReason ?? (await result.finishReason.catch(() => 'stop')) ?? 'stop';
+            streamedFinishReason ?? (await result.finishReason.catch(() => 'stop')) ?? 'stop';
           await queue.waitUntilConsumedThroughCurrent();
 
           if (returnedToolCalls.length > 0) {

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -459,6 +459,18 @@ export class ModelAdapter {
         return 'error';
       case 'tool-calls':
         return 'end_turn';
+      // The SDK's own two names for "the stream stopped and I cannot say why".
+      // An upstream that drops the connection mid-answer lands here: it yields
+      // no error part and throws nothing, so these are the only signal that it
+      // happened. Calling them `end_turn` asserts the model said its piece —
+      // the one thing we know we cannot claim. A benchmark cell recorded
+      // `status: completed` on exactly this shape while its agent was still
+      // mid-task, caught only because the proxy noticed the terminal SSE event
+      // never arrived. A genuinely new provider reason still falls through to
+      // the tolerant default below; these two are not new, they are unnamed.
+      case 'other':
+      case 'unknown':
+        return 'error';
       default:
         return 'end_turn';
     }

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -459,15 +459,20 @@ export class ModelAdapter {
         return 'error';
       case 'tool-calls':
         return 'end_turn';
-      // The SDK's own two names for "the stream stopped and I cannot say why".
+      // The SDK's own two names for "the stream stopped and nothing named why".
       // An upstream that drops the connection mid-answer lands here: it yields
       // no error part and throws nothing, so these are the only signal that it
       // happened. Calling them `end_turn` asserts the model said its piece —
       // the one thing we know we cannot claim. A benchmark cell recorded
       // `status: completed` on exactly this shape while its agent was still
       // mid-task, caught only because the proxy noticed the terminal SSE event
-      // never arrived. A genuinely new provider reason still falls through to
-      // the tolerant default below; these two are not new, they are unnamed.
+      // never arrived.
+      //
+      // These are reached only when the provider named nothing either: the SDK
+      // buckets every reason it does not recognize into `other` too, and
+      // `translateChunk` forwards the provider's own spelling in that case, so
+      // a genuinely new reason arrives here as itself and takes the tolerant
+      // default below.
       case 'other':
       case 'unknown':
         return 'error';
@@ -568,6 +573,8 @@ interface AiSdkStreamChunk {
   isError?: boolean;
   usage?: AiSdkUsageLike;
   finishReason?: unknown;
+  /** What the provider itself called it, before the SDK bucketed it. */
+  rawFinishReason?: unknown;
   error?: unknown;
   /** Provider-specific metadata; carries the Anthropic reasoning signature. */
   providerMetadata?: unknown;
@@ -589,6 +596,24 @@ interface SdkStreamResult {
     id: string;
     messages?: ModelMessage[];
   }>;
+}
+
+/**
+ * The finish reason to forward, preferring what the provider actually said.
+ *
+ * The SDK splits the reason in two: a closed unified enum, and the provider's
+ * own spelling. Unified is the right thing to forward — `runtime-runner` and
+ * the backend compare against `'tool-calls'`, which is a name only the SDK
+ * uses. Except when unified is `other`, which is not a reason but the SDK
+ * declining to name one; there it hides the only distinction that matters
+ * downstream. `other` with a provider spelling is a model that stopped for a
+ * reason we have no case for — an ordinary finished turn. `other` with nothing
+ * behind it is a stream that died without anyone saying so.
+ */
+function chunkFinishReason(chunk: AiSdkStreamChunk): string | undefined {
+  const unified = rawFinishReasonString(chunk.finishReason);
+  if (unified !== 'other' && unified !== 'unknown') return unified;
+  return rawFinishReasonString(chunk.rawFinishReason) ?? unified;
 }
 
 /**
@@ -703,7 +728,7 @@ function translateChunk(
     // compatibility — handled as a step boundary, not a text carrier.
     case 'finish-step':
     case 'step-finish': {
-      const finishReason = rawFinishReasonString(chunk.finishReason);
+      const finishReason = chunkFinishReason(chunk);
       const usage = normalizeAiSdkUsage(chunk.usage, { rawFinishReason: chunk.finishReason });
       return [
         {
@@ -714,7 +739,7 @@ function translateChunk(
       ];
     }
     case 'finish': {
-      const finishReason = rawFinishReasonString(chunk.finishReason);
+      const finishReason = chunkFinishReason(chunk);
       return [{ kind: 'finish', ...(finishReason ? { finishReason } : {}) }];
     }
     case 'reasoning-start':

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -468,11 +468,13 @@ export class ModelAdapter {
       // mid-task, caught only because the proxy noticed the terminal SSE event
       // never arrived.
       //
-      // These are reached only when the provider named nothing either: the SDK
-      // buckets every reason it does not recognize into `other` too, and
+      // These are reached when nothing else named the stop: the SDK buckets
+      // every reason it does not recognize into `other` too, and
       // `translateChunk` forwards the provider's own spelling in that case, so
       // a genuinely new reason arrives here as itself and takes the tolerant
-      // default below.
+      // default below. A provider spelling its reason `other` is
+      // indistinguishable from the bucket and lands here; the ambiguity is
+      // real and this resolves it toward the safe answer.
       case 'other':
       case 'unknown':
         return 'error';
@@ -729,7 +731,9 @@ function translateChunk(
     case 'finish-step':
     case 'step-finish': {
       const finishReason = chunkFinishReason(chunk);
-      const usage = normalizeAiSdkUsage(chunk.usage, { rawFinishReason: chunk.finishReason });
+      // The same value the turn's outcome is decided from, so the record and
+      // the outcome cannot name different reasons for the same stream.
+      const usage = normalizeAiSdkUsage(chunk.usage, { rawFinishReason: finishReason });
       return [
         {
           kind: 'step-finish',


### PR DESCRIPTION
## Summary

An upstream that drops the SSE connection mid-answer yields no error part and throws nothing. The SDK reports the stop as `other`, and the adapter's tolerant default called that `end_turn` — so the turn completed with a half-finished answer, no error event, and no retry. Nothing downstream could tell it apart from a model that had finished speaking.

This surfaced in the #2245 harness comparison. One Terminal-Bench cell recorded `status: completed` with `stopReason: end_turn` while its agent was mid-task: its last words were "Let me look at the top region structure in detail", and 5.5 seconds later the runtime declared the turn done. The proxy telemetry for that cell shows 105 completed requests and a 106th with `terminalEvent: false` and `errorClass: TypeError` (undici's `terminated`). The runtime's own trace holds zero error and zero `provider_retry` events. It was caught only because the provider proxy noticed the terminal SSE event never arrived.

Refs #2245

## Root cause

`ModelAdapter.mapFinishReason` mapped every unrecognized finish reason to `end_turn`. A truncated stream is indistinguishable from a clean one at that boundary because the SDK synthesizes a `finish` frame for it, and asking `result.finishReason` returns the same `other` a healthy stream can return.

## What `other` actually means

The first cut of this fix treated `other` itself as the signal. Review found that fails complete answers: `other` is not a finish reason, it is the SDK declining to name one, and every provider package buckets an unrecognized `finish_reason` into it too. llama.cpp's `eos_token`, DeepSeek's `insufficient_system_resource`, an OpenAI-compatible `stop_sequence` — all `other`, all ordinary finished turns, all would have been reported as failed.

The SDK does keep the distinction, in a field the adapter was discarding. Verified against the pinned `ai@7.0.52`:

| stream | `finishReason` | `rawFinishReason` |
| --- | --- | --- |
| connection died mid-answer | `other` | `undefined` |
| provider said `eos_token` | `other` | `eos_token` |

So `translateChunk` now forwards the provider's own spelling when the SDK has none — and only when it has none, because `runtime-runner` and the backend compare against `'tool-calls'`, a name only the SDK uses. A genuinely new reason arrives at `mapFinishReason` as itself and takes the tolerant default, exactly as before. Only a stop that nobody named is an error.

The backend reads the same stream-observed value it already prefers for telemetry, instead of the settled promise that carries only the unified enum, so a turn's outcome and its record can no longer disagree about why the stream ended.

## The failure is no longer silent

Every other `stopReason: 'error'` in `ai-sdk-backend` comes out of the catch path with an error event and a failed trace behind it, and the session's `lastError` and the request ledger are fed by exactly those. The truncation branch had neither: it ended the turn failed while the telemetry still read `success`. It now emits both — the same blindness this PR exists to remove.

## Verification

- `npm run -w @maka/runtime test` — 3271 pass, 0 fail
- `npm run build`, `npm run lint`, `npm run format:check` — clean
- `does not call a truncated provider stream a finished turn` drives a stream that delivers text and then ends without a finish frame; asserts `stopReason === 'error'` (not merely "not `end_turn`" — `max_tokens` would also satisfy that and still record the turn completed) and that an error event accompanies it. Verified red before the fix.
- `keeps a turn the provider named its own reason for` drives `{ unified: 'other', raw: 'eos_token' }` and asserts `end_turn` with no error event. This is the regression the first cut would have shipped.
- Not run: desktop E2E — this changes no renderer or main-process path