### PR TITLE
fix(headless): mount Maka's build outputs into the task container, not the repo root

### DIFF
--- a/packages/headless/src/__tests__/agent-repo-mount.test.ts
+++ b/packages/headless/src/__tests__/agent-repo-mount.test.ts
@@ -94,7 +94,19 @@ describe('agent repo mounts', () => {
     // benchmark's own per-task results under docs/eval, and the verifier source
     // under packages/headless/src. The container executes dist, so neither is
     // needed to run — only to look up what this benchmark expects.
-    for (const repoPath of makaRepoPaths()) {
+    //
+    // Read the produced mounts, not the declaration. A declaration that names
+    // no forbidden path still leaks every one of them if the builder mounts the
+    // root anyway, and asserting the list cannot tell those apart.
+    const mounts = buildAgentRepoMounts('maka', '/repo', { pathExists: () => true }) as Array<{
+      target: string;
+    }>;
+    for (const mount of mounts) {
+      assert.notEqual(mount.target, CONTAINER_MAKA_REPO, 'Maka must not receive the repo root');
+    }
+    for (const repoPath of mounts.map((mount) =>
+      mount.target.slice(CONTAINER_MAKA_REPO.length + 1),
+    )) {
       assert.ok(!repoPath.startsWith('docs'), `Maka must not be handed evaluation records`);
       assert.ok(!/(^|\/)src(\/|$)/.test(repoPath), `Maka must not be handed sources (${repoPath})`);
       assert.ok(!/(^|\/)\.git(\/|$)/.test(repoPath), `Maka must not be handed repo history`);
@@ -195,6 +207,30 @@ describe('agent repo mounts', () => {
           `${adapterModule}.py reads ${repoFile}, which ${agent} is not mounted`,
         );
       }
+    }
+  });
+
+  test('declares every repo file the Maka adapter names at a container path', () => {
+    // The same authority check, which the Maka side did not have — and its
+    // absence is why `run-host-cell.mjs` was left out of the declaration while
+    // `install()` probes for it in every cell-mode branch. A missing probe
+    // target aborts the trial before the arm runs at all.
+    //
+    // `maka_agent.py` builds container paths by joining segments onto the mount
+    // root rather than writing them out, so match the join instead of a literal.
+    const source = readFileSync(join(REPO_ROOT, 'packages/headless/harbor/maka_agent.py'), 'utf8');
+    const mounted = new Set(makaRepoPaths());
+    const read = new Set<string>();
+    for (const [, segments] of source.matchAll(/Path\(maka_repo\)((?:\s*\/\s*"[^"\n]+")+)/g)) {
+      read.add([...segments.matchAll(/"([^"]+)"/g)].map(([, segment]) => segment).join('/'));
+    }
+    assert.ok(read.size > 0, 'no container paths were found in maka_agent.py');
+    for (const repoFile of read) {
+      // A file may be mounted directly or inside a mounted directory.
+      const covered = [...mounted].some(
+        (repoPath) => repoPath === repoFile || repoFile.startsWith(`${repoPath}/`),
+      );
+      assert.ok(covered, `maka_agent.py names ${repoFile}, which Maka is not mounted`);
     }
   });
 

--- a/packages/headless/src/__tests__/agent-repo-mount.test.ts
+++ b/packages/headless/src/__tests__/agent-repo-mount.test.ts
@@ -22,6 +22,17 @@ const COMPETITORS: readonly Exclude<HarnessAgentId, 'maka'>[] = [
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
 
+/**
+ * Renderer-only workspaces never load in the headless container; the rest sit
+ * in the CLI's import graph directly or through `@maka/*` symlinks.
+ */
+const RENDERER_ONLY = new Set(['packages/ui', 'apps/desktop', 'packages/cli']);
+
+/** The workspaces the container is expected to be able to load. */
+const MAKA_WORKSPACES = (
+  JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')) as { workspaces: string[] }
+).workspaces.filter((workspace) => !RENDERER_ONLY.has(workspace));
+
 describe('agent repo mounts', () => {
   test('gives Maka its build outputs, not the repo root', () => {
     const mounts = buildAgentRepoMounts('maka', '/repo', { pathExists: () => true }) as Array<{
@@ -47,6 +58,23 @@ describe('agent repo mounts', () => {
     for (const repoPath of makaRepoPaths()) {
       if (isOptionalRepoPath(repoPath)) continue;
       assert.ok(existsSync(join(REPO_ROOT, repoPath)), `Maka declares missing ${repoPath}`);
+    }
+  });
+
+  test('declares every workspace dependency tree npm could not hoist away', () => {
+    // This is the direction that actually broke: `packages/runtime/node_modules`
+    // exists — npm could not hoist `@slack/socket-mode` past a version conflict
+    // — and omitting it resolved fine on the host, then failed in the container
+    // on the first import that needed it. Nothing but a live container run
+    // caught that. The repo already knows the answer, so ask it here.
+    const mounted = new Set(makaRepoPaths());
+    for (const workspace of MAKA_WORKSPACES) {
+      const repoPath = `${workspace}/node_modules`;
+      if (!existsSync(join(REPO_ROOT, repoPath))) continue;
+      assert.ok(
+        mounted.has(repoPath),
+        `${workspace} keeps a private ${repoPath} that is not mounted`,
+      );
     }
   });
 
@@ -83,15 +111,8 @@ describe('agent repo mounts', () => {
     // nothing else checks it against the workspaces that actually ship. A new
     // runtime workspace added without an entry here resolves at build time and
     // fails inside the container partway through a graded run.
-    const rootManifest = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')) as {
-      workspaces: string[];
-    };
     const mounted = new Set(makaRepoPaths());
-    // Renderer-only workspaces never load in the headless container; the rest
-    // sit in the CLI's import graph directly or through `@maka/*` symlinks.
-    const rendererOnly = new Set(['packages/ui', 'apps/desktop', 'packages/cli']);
-    for (const workspace of rootManifest.workspaces) {
-      if (rendererOnly.has(workspace)) continue;
+    for (const workspace of MAKA_WORKSPACES) {
       assert.ok(
         mounted.has(`${workspace}/dist`),
         `${workspace} ships but its dist is not mounted for Maka`,

--- a/packages/headless/src/__tests__/agent-repo-mount.test.ts
+++ b/packages/headless/src/__tests__/agent-repo-mount.test.ts
@@ -9,6 +9,7 @@ import {
   CONTAINER_MAKA_REPO,
   isOptionalRepoPath,
   makaRepoPaths,
+  RENDERER_ONLY_WORKSPACES,
 } from '../agent-repo-mount.js';
 import { type HarnessAgentId, harnessAgentImportPath } from '../harness-agent-registry.js';
 
@@ -22,11 +23,7 @@ const COMPETITORS: readonly Exclude<HarnessAgentId, 'maka'>[] = [
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
 
-/**
- * Renderer-only workspaces never load in the headless container; the rest sit
- * in the CLI's import graph directly or through `@maka/*` symlinks.
- */
-const RENDERER_ONLY = new Set(['packages/ui', 'apps/desktop', 'packages/cli']);
+const RENDERER_ONLY = new Set(RENDERER_ONLY_WORKSPACES);
 
 /** The workspaces the container is expected to be able to load. */
 const MAKA_WORKSPACES = (

--- a/packages/headless/src/__tests__/agent-repo-mount.test.ts
+++ b/packages/headless/src/__tests__/agent-repo-mount.test.ts
@@ -7,6 +7,8 @@ import {
   buildAgentRepoMounts,
   competitorRepoFiles,
   CONTAINER_MAKA_REPO,
+  isOptionalRepoPath,
+  makaRepoPaths,
 } from '../agent-repo-mount.js';
 import { type HarnessAgentId, harnessAgentImportPath } from '../harness-agent-registry.js';
 
@@ -21,10 +23,84 @@ const COMPETITORS: readonly Exclude<HarnessAgentId, 'maka'>[] = [
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
 
 describe('agent repo mounts', () => {
-  test('gives Maka the tree it executes out of', () => {
-    assert.deepEqual(buildAgentRepoMounts('maka', '/repo'), [
-      { type: 'bind', source: '/repo', target: CONTAINER_MAKA_REPO, read_only: true },
-    ]);
+  test('gives Maka its build outputs, not the repo root', () => {
+    const mounts = buildAgentRepoMounts('maka', '/repo', { pathExists: () => true }) as Array<{
+      source: string;
+      target: string;
+      read_only: boolean;
+    }>;
+    assert.ok(
+      mounts.every((mount) => mount.target !== CONTAINER_MAKA_REPO),
+      'Maka must not receive the repo root',
+    );
+    assert.deepEqual(
+      mounts.map((mount) => mount.target),
+      makaRepoPaths().map((repoPath) => `${CONTAINER_MAKA_REPO}/${repoPath}`),
+    );
+    assert.ok(
+      mounts.every((mount) => mount.read_only),
+      'Maka must not receive a writable repo path',
+    );
+  });
+
+  test('every required path Maka declares exists in the repo', () => {
+    for (const repoPath of makaRepoPaths()) {
+      if (isOptionalRepoPath(repoPath)) continue;
+      assert.ok(existsSync(join(REPO_ROOT, repoPath)), `Maka declares missing ${repoPath}`);
+    }
+  });
+
+  test('drops a workspace dependency tree npm managed to hoist away', () => {
+    // Mounting it blind would have Docker create the directory on the host,
+    // inside the repo, as a side effect of starting a graded run.
+    const absent = `${CONTAINER_MAKA_REPO}/packages/runtime/node_modules`;
+    const mounts = buildAgentRepoMounts('maka', '/repo', {
+      pathExists: (path) => !path.endsWith('packages/runtime/node_modules'),
+    }) as Array<{ target: string }>;
+    assert.ok(!mounts.some((mount) => mount.target === absent));
+    assert.ok(mounts.some((mount) => mount.target.endsWith('/packages/runtime/dist')));
+  });
+
+  test('keeps sources and evaluation records out of the Maka container', () => {
+    // What the #2245 run actually reached through the old repo-root mount: the
+    // benchmark's own per-task results under docs/eval, and the verifier source
+    // under packages/headless/src. The container executes dist, so neither is
+    // needed to run — only to look up what this benchmark expects.
+    for (const repoPath of makaRepoPaths()) {
+      assert.ok(!repoPath.startsWith('docs'), `Maka must not be handed evaluation records`);
+      assert.ok(!/(^|\/)src(\/|$)/.test(repoPath), `Maka must not be handed sources (${repoPath})`);
+      assert.ok(!/(^|\/)\.git(\/|$)/.test(repoPath), `Maka must not be handed repo history`);
+      assert.notEqual(
+        repoPath,
+        'packages/headless/harbor/run-harness-ab.mjs',
+        'Maka must not be handed the harness manifest source',
+      );
+    }
+  });
+
+  test('mounts the build output of every workspace the container CLI can reach', () => {
+    // The declared list is the authority for what exists in the container, and
+    // nothing else checks it against the workspaces that actually ship. A new
+    // runtime workspace added without an entry here resolves at build time and
+    // fails inside the container partway through a graded run.
+    const rootManifest = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')) as {
+      workspaces: string[];
+    };
+    const mounted = new Set(makaRepoPaths());
+    // Renderer-only workspaces never load in the headless container; the rest
+    // sit in the CLI's import graph directly or through `@maka/*` symlinks.
+    const rendererOnly = new Set(['packages/ui', 'apps/desktop', 'packages/cli']);
+    for (const workspace of rootManifest.workspaces) {
+      if (rendererOnly.has(workspace)) continue;
+      assert.ok(
+        mounted.has(`${workspace}/dist`),
+        `${workspace} ships but its dist is not mounted for Maka`,
+      );
+      assert.ok(
+        mounted.has(`${workspace}/package.json`),
+        `${workspace} ships but its manifest is not mounted for Maka`,
+      );
+    }
   });
 
   for (const agent of COMPETITORS) {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -602,7 +602,11 @@ describe('createHarborTaskRunner', () => {
       assert.equal(env.MAKA_TRIAL_CACHE_READ_USD_PER_1M, '0.0029');
       assert.equal(env.MAKA_TRIAL_PRICING_SOURCE, 'v4-flash');
       const mounts = (config.environment as { mounts: Array<Record<string, unknown>> }).mounts;
-      assert.ok(mounts.some((m) => m.target === '/opt/maka-agent' && m.read_only === true));
+      assert.ok(
+        mounts.some(
+          (m) => m.target === '/opt/maka-agent/packages/headless/dist' && m.read_only === true,
+        ),
+      );
       assert.equal(
         mounts.some((m) => m.target === '/run/secrets/deepseek-key' || m.source === keyFile),
         false,
@@ -2932,11 +2936,23 @@ describe('buildHarborJobConfig', () => {
         }
       ).mounts;
 
-    // Maka executes out of the tree, so it still gets the tree.
-    assert.ok(forAgent('maka').some((mount) => mount.target === '/opt/maka-agent'));
+    // Maka executes out of this repo, but out of its build outputs — not the
+    // root. In the #2245 run a root mount let it read docs/eval and the
+    // verifier source, so it now gets the same declared-list treatment.
+    const makaRepoMounts = forAgent('maka').filter((mount) =>
+      String(mount.target).startsWith('/opt/maka-agent'),
+    );
+    assert.ok(
+      makaRepoMounts.every((mount) => mount.target !== '/opt/maka-agent'),
+      'maka must not receive the repo root',
+    );
+    assert.ok(
+      makaRepoMounts.some((mount) => mount.target === '/opt/maka-agent/packages/headless/dist'),
+      'maka must receive the build output it executes',
+    );
 
     // A competitor gets the files it named and no directory to walk. Reverting
-    // to the shared tree mount re-opens the path Codex used in the #1970 run:
+    // to a shared tree mount re-opens the path Codex used in the #1970 run:
     // read the pinned benchmark revision, fetch the task's reference solution.
     for (const agent of ['codex', 'claude-code'] as const) {
       const repoMounts = forAgent(agent).filter((mount) =>

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -526,7 +526,14 @@ test('createPierTaskRunner withholds the repo tree from a competitor arm', async
       return mounts.filter((mount) => mount.target.startsWith('/opt/maka-agent'));
     };
 
-    assert.ok((await repoMountsFor('maka')).some((mount) => mount.target === '/opt/maka-agent'));
+    // Maka executes out of its build outputs, not the repo root: a root mount
+    // is what let it read docs/eval and the verifier source in the #2245 run.
+    const maka = await repoMountsFor('maka');
+    assert.ok(maka.every((mount) => mount.target !== '/opt/maka-agent'));
+    assert.ok(
+      maka.some((mount) => mount.target === '/opt/maka-agent/packages/headless/dist'),
+      'maka must receive the build output it executes',
+    );
 
     // Pier shares agent-repo-mount with the Harbor runner precisely so this
     // cannot regress in one executor while the other stays fixed.

--- a/packages/headless/src/agent-repo-mount.ts
+++ b/packages/headless/src/agent-repo-mount.ts
@@ -32,6 +32,18 @@ import type { HarnessAgentId } from './harness-agent-registry.js';
 
 export const CONTAINER_MAKA_REPO = '/opt/maka-agent';
 
+/**
+ * Workspaces that never load in the headless container, and so are the only
+ * ones absent below. Exported because the test that cross-checks this list
+ * against the root manifest needs the same exclusion, and two copies of it
+ * drift into a workspace nobody mounts.
+ */
+export const RENDERER_ONLY_WORKSPACES: readonly string[] = [
+  'packages/ui',
+  'packages/cli',
+  'apps/desktop',
+];
+
 /** Workspaces whose build output the in-container Maka runtime resolves. */
 const MAKA_RUNTIME_WORKSPACES: readonly string[] = [
   'packages/code-mode',

--- a/packages/headless/src/agent-repo-mount.ts
+++ b/packages/headless/src/agent-repo-mount.ts
@@ -47,7 +47,7 @@ const MAKA_RUNTIME_WORKSPACES: readonly string[] = [
 /**
  * Repo paths the Maka arm executes out of: installed dependencies, workspace
  * manifests so the `@maka/*` symlinks in `node_modules` resolve, each
- * workspace's build output, and the one harbor entrypoint the adapter runs.
+ * workspace's build output, and the harbor entrypoints the adapter names.
  *
  * Sources are deliberately absent. The container runs `dist`, so shipping `src`
  * adds nothing to run and hands over the verifier and the harness manifest —
@@ -64,8 +64,11 @@ const MAKA_REPO_PATHS: readonly string[] = [
     // the container on the first import that needs one.
     `${workspace}/node_modules`,
   ]),
-  // maka_agent.py `_run_cell_path`.
+  // maka_agent.py `_run_cell_path` and `_run_host_cell_path`. Both are probed
+  // by `install()` before either can run, so a missing one aborts the trial
+  // rather than degrading it.
   'packages/headless/harbor/run-cell.mjs',
+  'packages/headless/harbor/run-host-cell.mjs',
 ];
 
 export function makaRepoPaths(): readonly string[] {

--- a/packages/headless/src/agent-repo-mount.ts
+++ b/packages/headless/src/agent-repo-mount.ts
@@ -1,10 +1,10 @@
 /**
  * What a graded arm may read out of this repo, and the mounts that enforce it.
  *
- * Both executors bind this repo into the task container. Maka executes out of
- * that tree, so it gets the tree. A competitor runs from its own pinned
- * toolchain and only ever names individual files here, so it gets those files
- * and no directory to walk.
+ * Both executors bind this repo into the task container. Every arm gets a
+ * declared list and no directory it could walk up out of: a competitor runs
+ * from its own pinned toolchain and names individual files, while Maka executes
+ * out of this tree and needs whole build outputs.
  *
  * The distinction is not tidiness. This repo is not benchmark-neutral cargo:
  * `packages/headless/harbor/run-harness-ab.mjs` carries
@@ -15,13 +15,62 @@
  * from the public repository at that exact revision, and lifted the expected
  * output out of its test file — a recorded pass that measured retrieval.
  *
+ * The Maka arm used to be exempt on the theory that it runs our own runtime.
+ * The model does not know it is ours. In the #2245 two-arm run it grepped the
+ * mount and read `docs/eval/terminal-bench-2.1-*.csv` — this benchmark's own
+ * per-task pass/fail table from earlier runs — and, on another task, the
+ * verifier source at `packages/headless/src/terminal-bench-adapter.ts`. Neither
+ * is a file the runtime executes; both were reachable only because the mount
+ * was the repo root.
+ *
  * Both executors resolve their repo mounts here so the two cannot drift: a file
  * added for one arm in one runner is not silently absent in the other.
  */
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { HarnessAgentId } from './harness-agent-registry.js';
 
 export const CONTAINER_MAKA_REPO = '/opt/maka-agent';
+
+/** Workspaces whose build output the in-container Maka runtime resolves. */
+const MAKA_RUNTIME_WORKSPACES: readonly string[] = [
+  'packages/code-mode',
+  'packages/core',
+  'packages/storage',
+  'packages/mcp',
+  'packages/runtime',
+  'packages/runtime-host',
+  'packages/computer-use',
+  'packages/headless',
+];
+
+/**
+ * Repo paths the Maka arm executes out of: installed dependencies, workspace
+ * manifests so the `@maka/*` symlinks in `node_modules` resolve, each
+ * workspace's build output, and the one harbor entrypoint the adapter runs.
+ *
+ * Sources are deliberately absent. The container runs `dist`, so shipping `src`
+ * adds nothing to run and hands over the verifier and the harness manifest —
+ * including TERMINAL_BENCH_2_1_REVISION — as readable text.
+ */
+const MAKA_REPO_PATHS: readonly string[] = [
+  'node_modules',
+  'package.json',
+  ...MAKA_RUNTIME_WORKSPACES.flatMap((workspace) => [
+    `${workspace}/package.json`,
+    `${workspace}/dist`,
+    // npm hoists what it can, but a workspace that pins a conflicting version
+    // keeps it here. Omitting these resolves fine on the host and then fails in
+    // the container on the first import that needs one.
+    `${workspace}/node_modules`,
+  ]),
+  // maka_agent.py `_run_cell_path`.
+  'packages/headless/harbor/run-cell.mjs',
+];
+
+export function makaRepoPaths(): readonly string[] {
+  return MAKA_REPO_PATHS;
+}
 
 /**
  * Repo-relative files each competitor adapter reads at its container path.
@@ -46,20 +95,34 @@ export function competitorRepoFiles(agent: Exclude<HarnessAgentId, 'maka'>): rea
 }
 
 /**
- * The repo mounts for one arm. Maka gets the tree it runs from; every other arm
- * gets exactly the files it declared and nothing it could enumerate.
+ * The repo mounts for one arm: exactly what it declared, and no path from which
+ * the rest of the repo can be enumerated.
+ *
+ * Optional paths are dropped when absent rather than mounted blind, because
+ * Docker materialises a missing bind source as a new empty directory — on the
+ * host, inside the repo. Which workspaces keep a private `node_modules` depends
+ * on what npm managed to hoist, so those are declared and filtered here rather
+ * than pinned to one install's outcome.
  */
 export function buildAgentRepoMounts(
   agent: HarnessAgentId,
   makaRepoPath: string,
+  options: { pathExists?: (path: string) => boolean } = {},
 ): Array<Record<string, unknown>> {
-  if (agent === 'maka') {
-    return [{ type: 'bind', source: makaRepoPath, target: CONTAINER_MAKA_REPO, read_only: true }];
-  }
-  return competitorRepoFiles(agent).map((repoFile) => ({
-    type: 'bind',
-    source: join(makaRepoPath, repoFile),
-    target: `${CONTAINER_MAKA_REPO}/${repoFile}`,
-    read_only: true,
-  }));
+  const pathExists = options.pathExists ?? existsSync;
+  const repoPaths = agent === 'maka' ? makaRepoPaths() : competitorRepoFiles(agent);
+  return repoPaths
+    .map((repoPath) => ({ repoPath, source: join(makaRepoPath, repoPath) }))
+    .filter(({ repoPath, source }) => !isOptionalRepoPath(repoPath) || pathExists(source))
+    .map(({ repoPath, source }) => ({
+      type: 'bind',
+      source,
+      target: `${CONTAINER_MAKA_REPO}/${repoPath}`,
+      read_only: true,
+    }));
+}
+
+/** Workspace-private dependency trees exist only where npm could not hoist. */
+export function isOptionalRepoPath(repoPath: string): boolean {
+  return repoPath.startsWith('packages/') && repoPath.endsWith('/node_modules');
 }


### PR DESCRIPTION
## Summary

The Maka arm received the repo root at `/opt/maka-agent`, exempt from the declared-mount rule every competitor arm follows. The exemption's premise was that Maka runs our own runtime — but the model does not know it is ours, and it reads what is reachable.

In the #2245 two-arm run it did exactly that. On `extract-elf` it ran `grep -rl "extract-elf|extract memory values" /opt/maka-agent` and read `docs/eval/terminal-bench-2.1-*.csv` — this benchmark's own per-task pass/fail table from earlier runs. On `db-wal-recovery` it read `packages/headless/src/terminal-bench-adapter.ts`, the verifier source. Both cells passed. Neither file is one the runtime executes; both were reachable only because the mount was the root.

The container runs `dist`, so the arm now gets dependencies, workspace manifests, each workspace's build output, and the single harbor entrypoint the adapter invokes. Sources, `docs/`, repo history and the harness manifest source are gone from inside it.

Refs #2245

## Verification

- `npm run -w @maka/headless test` — 1425 pass, 0 fail. Three existing tests asserted the root mount and now assert the narrowed shape.
- `npm run lint`, `npm run format` — clean
- Ran the container for real, since the contract tests only check that the declared list is self-consistent — they cannot tell whether Maka still starts:

```
docker run --rm $(mounts from makaRepoPaths()) node:24-slim \
  node /opt/maka-agent/packages/headless/dist/cli.js --help
```

The first attempt failed with `Cannot find package '@slack/socket-mode'`: npm keeps a private `node_modules` in any workspace whose version pin it could not hoist, and the list only had the root one. That is exactly the class of failure the contract tests cannot see. With those added, the CLI starts and `harbor --help` resolves.

Reachability from inside the same container, after the change:

| path | before | after |
|---|---|---|
| `docs/` (per-task results) | readable | **blocked** |
| `packages/headless/src/` (verifier source) | readable | **blocked** |
| `.git/` | readable | **blocked** |
| `maka-eval/` | readable | **blocked** |
| `packages/headless/harbor/run-harness-ab.mjs` | readable | **blocked** |
| `packages/headless/dist/harness-ab-manifest.js` | readable | readable |

## Known gap — now closed by #2303

The last row is not fixed here. `harness-ab-manifest.ts` compiles TERMINAL_BENCH_2_1_REVISION, the upstream repository URL, the task-tree fingerprint and all 89 task ids into `packages/headless/dist`, which the container needs as a directory. Fixing it means moving benchmark identity out of a compiled runtime package, which is a data-layout change rather than a mount change; #2303 does that, and adds the content-level check this PR's path-level assertions structurally cannot make.

## Review round 2

The suite checked that an absent workspace dependency tree is dropped. The incident was the opposite direction: `packages/runtime/node_modules` exists — npm could not hoist `@slack/socket-mode` past a version conflict — and omitting it resolved on the host, then failed inside the container on the first import that needed it. Only a live container run caught that.

`declares every workspace dependency tree npm could not hoist away` now asks the repo directly, and fails on the pre-fix list. The renderer-only exclusion and the workspace list are also derived from the root manifest in one place instead of two.
