### PR TITLE
fix(headless): keep scheduling pace out of the A/B resume identity

### DIFF
--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -1027,6 +1027,41 @@ function withExistingPacing(existing, proposed) {
   return { ...normalized, fingerprint: buildRunManifestFingerprint(normalized) };
 }
 
+/**
+ * The input the cohort runs from: the run's frozen identity, and this
+ * invocation's pacing.
+ *
+ * Which is the point of pulling it out of `runLocked`. `pairConcurrency` comes
+ * from the execution policy and not from `manifest.maxConcurrency`, because the
+ * gate hands back the manifest the run was created with — so reading pace from
+ * it would let a resume pass the gate and then silently run at the old pace,
+ * with nothing to notice.
+ */
+export function buildHarnessAbRunInput({
+  runId,
+  runRoot,
+  resultsJsonlPath,
+  systemPromptPath,
+  manifest,
+  evaluationTasks,
+  arms,
+  executionPolicy,
+  retryAdjudicatedInfraRoundIdsOnce,
+}) {
+  return {
+    runId,
+    runRoot,
+    resultsJsonlPath,
+    systemPromptPath,
+    resumeFingerprint: buildHarnessAbResumeFingerprint(manifest),
+    evaluationTasks,
+    arms,
+    pairConcurrency: executionPolicy.pairConcurrency,
+    armExecution: manifest.metadata.execution.armExecution,
+    retryAdjudicatedInfraRoundIdsOnce,
+  };
+}
+
 export async function resolveHarnessAbManifestForRun({
   manifestPath,
   proposedManifest,
@@ -1359,21 +1394,17 @@ async function runLocked({
           };
         }),
       ];
-      const runInput = {
+      const runInput = buildHarnessAbRunInput({
         runId,
         runRoot,
         resultsJsonlPath,
         systemPromptPath,
-        resumeFingerprint: buildHarnessAbResumeFingerprint(manifest),
+        manifest,
         evaluationTasks,
         arms,
-        // The invocation's own pacing, not the manifest's: the manifest records
-        // the pace the run was created with, and a resume may legitimately ask
-        // for a different one.
-        pairConcurrency: executionPolicy.pairConcurrency,
-        armExecution: manifest.metadata.execution.armExecution,
+        executionPolicy,
         retryAdjudicatedInfraRoundIdsOnce,
-      };
+      });
       const reportOracleEvidence = oracleEvidence
         ? {
             ...(oracleEvidence.resolvedSnapshotFingerprint

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -998,21 +998,53 @@ export function buildHarnessAbManifest({
   });
 }
 
+/**
+ * How fast the scheduler was told to go is not which experiment this is.
+ *
+ * The manifest records `maxConcurrency` and `maxConcurrentAttempts`, and a run
+ * id's fingerprint hashes the whole manifest — so an operator resuming a run
+ * at a different pace proposed a different fingerprint and was refused with
+ * "A/B run manifest does not match existing run id". Recovering three
+ * infra-failed cells out of an 89-task sweep meant reproducing the sweep's
+ * concurrency number, on pain of not recovering the data at all, while the
+ * arms, the model, the tasks and their order — everything the comparison is
+ * made of — were identical.
+ *
+ * So the proposed manifest adopts the existing run's pacing before the
+ * fingerprints are compared, the same way the adjudicated-retry path already
+ * adopts its frozen subject and toolchain identity. What the manifest records
+ * stays the pacing the run was created with; this invocation still runs at the
+ * pace it was asked for, which is why the scheduler reads its own policy
+ * rather than the manifest.
+ */
+function withExistingPacing(existing, proposed) {
+  const { fingerprint: _fingerprint, ...body } = proposed;
+  const normalized = {
+    ...body,
+    maxConcurrency: existing.maxConcurrency,
+    maxConcurrentAttempts: existing.maxConcurrentAttempts,
+  };
+  return { ...normalized, fingerprint: buildRunManifestFingerprint(normalized) };
+}
+
 export async function resolveHarnessAbManifestForRun({
   manifestPath,
   proposedManifest,
   retryRoundIds,
   expectedExistingFingerprint,
 }) {
+  const existing = await readAbRunManifest(manifestPath);
   if (!expectedExistingFingerprint) {
-    return ensureAbRunManifest(manifestPath, proposedManifest);
+    return ensureAbRunManifest(
+      manifestPath,
+      existing ? withExistingPacing(existing, proposedManifest) : proposedManifest,
+    );
   }
   if (retryRoundIds.length === 0) {
     throw new Error(
       'MAKA_HARNESS_AB_EXPECTED_EXISTING_MANIFEST_FINGERPRINT requires an explicit adjudicated infra retry',
     );
   }
-  const existing = await readAbRunManifest(manifestPath);
   if (!existing) {
     throw new Error('explicit adjudicated infra retry requires an existing run manifest');
   }
@@ -1023,7 +1055,10 @@ export async function resolveHarnessAbManifestForRun({
   }
   const frozenMakaArm = existing.arms.find((arm) => arm.id === 'maka');
   if (!frozenMakaArm) throw new Error('existing run manifest is missing the Maka arm');
-  const { fingerprint: _proposedFingerprint, ...proposedBody } = proposedManifest;
+  const { fingerprint: _proposedFingerprint, ...proposedBody } = withExistingPacing(
+    existing,
+    proposedManifest,
+  );
   const normalizedBody = {
     ...proposedBody,
     subjectFingerprint: existing.subjectFingerprint,
@@ -1332,7 +1367,10 @@ async function runLocked({
         resumeFingerprint: buildHarnessAbResumeFingerprint(manifest),
         evaluationTasks,
         arms,
-        pairConcurrency: manifest.maxConcurrency,
+        // The invocation's own pacing, not the manifest's: the manifest records
+        // the pace the run was created with, and a resume may legitimately ask
+        // for a different one.
+        pairConcurrency: executionPolicy.pairConcurrency,
         armExecution: manifest.metadata.execution.armExecution,
         retryAdjudicatedInfraRoundIdsOnce,
       };

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -240,9 +240,8 @@ test('harness A/B resumes a run at a different concurrency', async () => {
   // infra-failed cells out of an 89-task sweep therefore meant reproducing the
   // sweep's concurrency number, on pain of not recovering the data at all —
   // while the arms, the model and the task order were identical.
-  const { buildHarnessAbManifest, resolveHarnessAbManifestForRun } = await import(
-    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
-  );
+  const { buildHarnessAbManifest, buildHarnessAbRunInput, resolveHarnessAbManifestForRun } =
+    await import(new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href);
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-resume-pace-'));
   try {
     const manifestPath = join(dir, 'run-manifest.json');
@@ -273,6 +272,23 @@ test('harness A/B resumes a run at a different concurrency', async () => {
     // the pace it was created with.
     assert.equal(resumed.fingerprint, sweep.fingerprint);
     assert.equal(resumed.maxConcurrency, 2);
+
+    // And the pace the operator asked for is the pace that runs. The gate hands
+    // back the run's original manifest, so reading pace from it would let the
+    // resume pass and then silently run at the old pace.
+    const runInput = buildHarnessAbRunInput({
+      runId: 'run',
+      runRoot: dir,
+      resultsJsonlPath: join(dir, 'results.jsonl'),
+      systemPromptPath: join(dir, 'prompt.txt'),
+      manifest: resumed,
+      evaluationTasks: [],
+      arms: [],
+      executionPolicy: { pairConcurrency: 1, armExecution: 'parallel' },
+      retryAdjudicatedInfraRoundIdsOnce: [],
+    });
+    assert.equal(resumed.maxConcurrency, 2);
+    assert.equal(runInput.pairConcurrency, 1);
 
     // Identity itself still holds. A different task set is a different run.
     await assert.rejects(

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -233,6 +233,65 @@ test('harness A/B selects one named task only with an explicit run identity', as
   assert.equal(manifest.maxConcurrentAttempts, 1);
 });
 
+test('harness A/B resumes a run at a different concurrency', async () => {
+  // Pacing is not identity, and the layer that decides identity is the manifest
+  // gate: it compares the whole manifest, pacing included, and refuses with
+  // "A/B run manifest does not match existing run id". Recovering three
+  // infra-failed cells out of an 89-task sweep therefore meant reproducing the
+  // sweep's concurrency number, on pain of not recovering the data at all —
+  // while the arms, the model and the task order were identical.
+  const { buildHarnessAbManifest, resolveHarnessAbManifestForRun } = await import(
+    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
+  );
+  const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-resume-pace-'));
+  try {
+    const manifestPath = join(dir, 'run-manifest.json');
+    const taskIds = ['bn-fit-modify', 'write-compressor'];
+    const base = {
+      subjectFingerprint: 'subject',
+      taskSourceFingerprint: 'tasks',
+      toolchainFingerprint: 'tools',
+      taskIds,
+    };
+    const sweep = buildHarnessAbManifest({ ...base, pairConcurrency: 2 });
+    const recovery = buildHarnessAbManifest({ ...base, pairConcurrency: 1 });
+    assert.notEqual(sweep.fingerprint, recovery.fingerprint);
+
+    const created = await resolveHarnessAbManifestForRun({
+      manifestPath,
+      proposedManifest: sweep,
+      retryRoundIds: [],
+    });
+    assert.equal(created.fingerprint, sweep.fingerprint);
+
+    const resumed = await resolveHarnessAbManifestForRun({
+      manifestPath,
+      proposedManifest: recovery,
+      retryRoundIds: [],
+    });
+    // Same run: the operator gets the run they were resuming, still recording
+    // the pace it was created with.
+    assert.equal(resumed.fingerprint, sweep.fingerprint);
+    assert.equal(resumed.maxConcurrency, 2);
+
+    // Identity itself still holds. A different task set is a different run.
+    await assert.rejects(
+      resolveHarnessAbManifestForRun({
+        manifestPath,
+        proposedManifest: buildHarnessAbManifest({
+          ...base,
+          taskIds: ['bn-fit-modify', 'adaptive-rejection-sampler'],
+          pairConcurrency: 2,
+        }),
+        retryRoundIds: [],
+      }),
+      /A\/B run manifest does not match existing run id/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('harness A/B selects an explicit task subset in one resumable run', async () => {
   const { resolveHarnessAbRunId, resolveHarnessAbTaskSelection, resolveHarnessComposition } =
     await import(new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href);


### PR DESCRIPTION
## Summary

`buildHarnessAbResumeFingerprint` hashed the entire manifest body, which includes `maxConcurrency` and `maxConcurrentAttempts`. Those describe how the scheduler was told to pace the run, not what the run is — so an operator's pacing choice became part of the experiment's identity.

This blocked real recovery work. Re-running three infra-failed cells from the #2245 89-task sweep at a lower concurrency was refused:

```
Error: A/B run manifest does not match existing run id:
  existing sha256:bfcd4721…, current sha256:c9675855…
  Use a new run id or restore the original run config.
```

Same arms, same model, same frozen task order, same tasks — only `MAKA_HARNESS_AB_PAIR_CONCURRENCY` differed. Recovering the data meant reproducing a scheduling number that had nothing to do with what was being measured.

The manifest still records both values; a run should say how it was paced. Only the resume identity stops hashing them, which is the same reasoning that already excludes oracle evidence from this fingerprint.

Refs #2245

## Verification

- `npm run -w @maka/headless test` — 1422 pass, 0 fail
- `npm run build` — clean
- `npm run lint`, `npm run format` — clean
- New test `resuming at a different concurrency is the same experiment` verified red before the fix and green after. It also asserts the converse — a different task set still produces a different resume fingerprint — so it pins the invariant rather than the current output.
