### PR TITLE
fix(cli): give signal/fatal exit probes a cold-start budget before the READY reset

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -8286,7 +8286,12 @@ async function runSignalExitProbe(
   });
   let stdout = '';
   let signalSent = false;
-  let killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
+  // Cold-start guard: spawning Node and synchronously importing the TUI stack
+  // (runner, driver, shell-run manager) can take well over 5 s on a loaded CI
+  // runner before READY is ever flushed, so the pre-READY budget must be a
+  // generous backstop against a child that never becomes ready, not a tight
+  // deadline. The precise budget starts once READY arrives, below.
+  let killTimer = setTimeout(() => child.kill('SIGKILL'), 30_000);
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', (chunk: string) => {
     stdout += chunk;
@@ -8294,10 +8299,11 @@ async function runSignalExitProbe(
       signalSent = true;
       child.kill(signalToSend);
       // Time the kill against the signal handling window, not the child's
-      // startup: on a slow CI runner importing the TUI and reaching READY can
-      // itself take seconds, which would otherwise leave the 3s exit grace
-      // (beginMakaCliExit) past the 5s kill timer and the probe would be
-      // SIGKILLed before the graceful exit it is asserting.
+      // startup: the post-signal path is synchronous (terminal restore, TUI
+      // stop, resolve, exit), so a few seconds is ample once READY is in; the
+      // 3s exit grace (beginMakaCliExit) plus the pre-READY startup must not
+      // share a single 5s budget or a slow CI runner gets SIGKILLed before the
+      // graceful exit it is asserting.
       clearTimeout(killTimer);
       killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
     }
@@ -8393,7 +8399,11 @@ async function runFatalExitProbe(
   let stdout = '';
   let stderr = '';
   let childReady = false;
-  let killTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
+  // Same two-budget scheme as runSignalExitProbe: a generous 30 s pre-READY
+  // backstop for cold starts on loaded CI runners, then a tight 5 s budget
+  // for the post-READY fatal path (which is synchronous and needs at most the
+  // 3 s exit grace from beginMakaCliExit).
+  let killTimer = setTimeout(() => child.kill('SIGKILL'), 30_000);
   child.stdout.setEncoding('utf8');
   child.stderr.setEncoding('utf8');
   child.stdout.on('data', (chunk: string) => {


### PR DESCRIPTION
Fixes #2293.

## Problem

`runSignalExitProbe` / `runFatalExitProbe` started the SIGKILL kill timer at spawn with a **5s budget**. The post-READY reset only covered the signal-handling window, so on a loaded CI runner, cold-starting Node and synchronously importing the full TUI stack (runner, driver, shell-run manager) can exceed 5s before `READY` is ever flushed — the probe gets SIGKILLed before the graceful exit it asserts.

Observed on #2277 (`test_workspaces`, twice) and on main after merging #2273:

```
✖ restores the terminal before exiting on SIGTERM (5135.876169ms)
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
'SIGKILL' !== null
```

## Fix

- Initial timer: 5s → **30s** — a generous backstop against a child that never becomes ready (cold start on loaded runners).
- Post-READY timer stays at **5s** — the signal path after READY is fully synchronous (`TUI.stop()` is sync: terminal restore → resolve → exit), so a few seconds is ample.

Applied to both `runSignalExitProbe` and `runFatalExitProbe` (identical structure).

## Verification

- Reproduced the failure locally by delaying the child's `READY` write by 6s: with the old 5s budget → `'SIGKILL' !== null` (5019ms, identical to CI); with the 30s budget → passes (6442ms).
- Full CLI suite: 470/470 pass (includes the three probe tests).