### PR TITLE
fix(desktop): close xai oauth callback connections and retry a busy port

### DIFF
--- a/apps/desktop/src/main/oauth/xai-oauth-service.ts
+++ b/apps/desktop/src/main/oauth/xai-oauth-service.ts
@@ -334,6 +334,28 @@ export class XaiOAuthService {
     resolveCode: (value: { code: string; state: string }) => void,
     rejectCode: (error: Error) => void,
   ): Promise<Server> {
+    // The port is fixed, and the previous login's server releases it
+    // asynchronously (disposePending cannot await inside a finally). A
+    // fresh login racing that close sees EADDRINUSE for a few milliseconds,
+    // so retry briefly instead of failing the whole flow (#2197).
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      try {
+        return await this.listenOnce(expectedState, resolveCode, rejectCode);
+      } catch (error) {
+        lastError = error;
+        if ((error as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw error;
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+      }
+    }
+    throw lastError;
+  }
+
+  private async listenOnce(
+    expectedState: string,
+    resolveCode: (value: { code: string; state: string }) => void,
+    rejectCode: (error: Error) => void,
+  ): Promise<Server> {
     return await new Promise<Server>((resolve, reject) => {
       const server = createServer((request, response) =>
         this.handleCallback(request, response, expectedState, resolveCode, rejectCode),
@@ -355,6 +377,12 @@ export class XaiOAuthService {
     resolveCode: (value: { code: string; state: string }) => void,
     rejectCode: (error: Error) => void,
   ): void {
+    // One callback is this server's whole life; a kept-alive socket only
+    // outlives it into disposePending's closeAllConnections, and that
+    // destroy is an RST a pooled client can trip over on its next request
+    // to the same port (#2197: the next login's fetch died on it). Close
+    // the connection with the response instead.
+    response.setHeader('Connection', 'close');
     let url: URL;
     try {
       url = new URL(request.url ?? '', XAI_REDIRECT_URI);


### PR DESCRIPTION
## Summary

Closes #2197

The three Node 26 failures and the post-run hang share one root. The callback server keeps connections alive, so the client pool holds a socket to the fixed port after a login finishes; `disposePending` then destroys it, and on Node 26 the next login's callback request can die on that reset instead of reconnecting. The denial test's callback never arrived, its login never settled, and the leaked listener held the port (failing the two tests after it) and kept the process alive.

Two changes in the service:

- Callback responses now send `Connection: close`. One callback is the server's whole life; a kept-alive socket only exists to be reset later.
- `startCallbackServer` retries `EADDRINUSE` briefly. The port is fixed and the previous login releases it asynchronously, so a fresh login racing that close no longer fails the whole flow.

## Verification

- Before: `node --test dist/main/__tests__/xai-oauth-service.test.js` on Node 26.0.0 fails 3 of 6 and the process does not exit. After: 6 of 6 across three consecutive runs, clean exit.
- Full desktop main suite passes on Node 26 (1748 tests), which it could not finish before because this file hung it.
