### PR TITLE
test(cli,headless): stop gating ordering assertions on fixed wall-clock budgets

### DIFF
--- a/packages/cli/src/__tests__/cli-goal-continuation.test.ts
+++ b/packages/cli/src/__tests__/cli-goal-continuation.test.ts
@@ -8,6 +8,7 @@ import {
   type GoalTurnOutcome,
 } from '@maka/runtime';
 import { CliGoalContinuation } from '../cli-goal-continuation.js';
+import { WAIT_BUDGET_MS } from './tui-terminal-mock.js';
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -18,7 +19,10 @@ function deferred<T>() {
 }
 
 async function waitFor(condition: () => boolean, message: string): Promise<void> {
-  const deadline = Date.now() + 1_000;
+  // Same budget policy as the shared TUI waitFor (#2221): the wait returns as
+  // soon as the condition holds, so the floor only bounds a failing report,
+  // and CI runners get the scaled budget instead of losing scheduling races.
+  const deadline = Date.now() + Math.max(1_000, WAIT_BUDGET_MS);
   while (!condition()) {
     if (Date.now() >= deadline) assert.fail(message);
     await new Promise<void>((resolve) => setImmediate(resolve));

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -43,6 +43,7 @@ import {
   isMakaClaudeSubscriptionCloakEnabled,
   resolveCliStreamConnectTimeoutMs,
 } from '../runtime-bootstrap.js';
+import { WAIT_BUDGET_MS } from './tui-terminal-mock.js';
 
 function modelCallAttemptFixture(): ModelCallAttempt {
   return {
@@ -1364,7 +1365,11 @@ async function withWorkspace(fn: (workspaceRoot: string) => Promise<void>): Prom
 }
 
 async function waitFor<T>(read: () => T | undefined | Promise<T | undefined>): Promise<T> {
-  const deadline = Date.now() + 3_000;
+  // Same budget policy as the shared TUI waitFor (#2221): the wait returns as
+  // soon as the read yields a value, so the floor only bounds a failing
+  // report, and CI runners get the scaled budget instead of losing
+  // scheduling races.
+  const deadline = Date.now() + Math.max(3_000, WAIT_BUDGET_MS);
   while (Date.now() < deadline) {
     const value = await read();
     if (value !== undefined) return value;

--- a/packages/cli/src/__tests__/tui-terminal-mock.ts
+++ b/packages/cli/src/__tests__/tui-terminal-mock.ts
@@ -124,13 +124,26 @@ export function latestPlainLineContaining(output: string, text: string): string 
   return line;
 }
 
-export async function waitFor(predicate: () => boolean): Promise<void> {
-  const deadline = Date.now() + 250;
+// A passing wait returns the moment the predicate turns true, so the budget
+// below only bounds how long a FAILING assertion takes to report. 250ms kept
+// local red runs snappy but lost races on loaded CI runners (#2221: a
+// docs-only PR failed test_workspaces at 262ms); CI pays a bigger budget
+// because a red test there costs one report, while a false red costs every
+// reader a log dive. MAKA_TEST_WAIT_BUDGET_MS overrides both.
+export const WAIT_BUDGET_MS =
+  Number(process.env.MAKA_TEST_WAIT_BUDGET_MS ?? '') || (process.env.CI ? 5_000 : 250);
+
+export async function waitFor(predicate: () => boolean, description?: string): Promise<void> {
+  const deadline = Date.now() + WAIT_BUDGET_MS;
   while (Date.now() < deadline) {
     if (predicate()) return;
     await delay(5);
   }
-  assert.equal(predicate(), true);
+  assert.equal(
+    predicate(),
+    true,
+    `waited ${WAIT_BUDGET_MS}ms for ${description ?? 'a predicate that never became true'}`,
+  );
 }
 
 function renderTerminalScreen(writes: readonly string[], rows: number): string {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -387,7 +387,10 @@ class TerminalClaimBeforeDeadlineBackend implements AgentBackend {
   readonly sessionId: string;
   stopCalls = 0;
 
-  constructor(sessionId: string) {
+  constructor(
+    sessionId: string,
+    private readonly terminalClaimed?: () => void,
+  ) {
     this.sessionId = sessionId;
   }
 
@@ -409,7 +412,13 @@ class TerminalClaimBeforeDeadlineBackend implements AgentBackend {
       ts: Date.now(),
       stopReason: 'end_turn',
     };
-    await new Promise((resolve) => setTimeout(resolve, 1_100));
+    // Resuming here proves the runtime accepted the terminal event: the
+    // post-terminal drain pulls the next value only after the previous one
+    // was processed, so by now the terminal claim is taken. A deadline the
+    // test fires from this hook is late by construction (#2221), where the
+    // old shape made it late by racing a 1100ms sleep against a 1000ms
+    // timer and lost on loaded runners.
+    this.terminalClaimed?.();
   }
 
   async stop(): Promise<void> {
@@ -1284,16 +1293,23 @@ describe('runHarborCell', () => {
   test('does not report deadline settlement after normal completion already claimed the terminal state', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       let backend: TerminalClaimBeforeDeadlineBackend | undefined;
+      let claimReached!: () => void;
+      const terminalClaimed = new Promise<void>((resolve) => {
+        claimReached = resolve;
+      });
       const result = await runHarborCell({
         config,
         instruction: 'finish before the deadline',
         cwd: workspaceDir,
         outputDir,
         storageRoot,
-        settleAfterMs: 1_000,
+        // The deadline this test cares about is one that lands after normal
+        // completion claimed the terminal state, so fire it from the claim
+        // itself instead of hoping a wall-clock budget loses the race.
+        settleSignal: terminalClaimed,
         registerBackends: (registry) => {
           registry.register('fake', (ctx) => {
-            backend = new TerminalClaimBeforeDeadlineBackend(ctx.sessionId);
+            backend = new TerminalClaimBeforeDeadlineBackend(ctx.sessionId, claimReached);
             return backend;
           });
         },

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -148,6 +148,14 @@ export interface RunHarborCellInput {
   continuationPolicy?: HarborCellContinuationPolicy;
   taskToolSummaryEnabled?: boolean;
   settleAfterMs?: number;
+  /**
+   * Deterministic trigger for the same settlement the settleAfterMs timer
+   * arms. A wall-clock budget cannot encode an ordering guarantee, so a test
+   * about "deadline fires before/after completion" resolves this promise at
+   * the exact point in the run it means, instead of hoping a fixed number of
+   * milliseconds lands on the right side of the race (#2221).
+   */
+  settleSignal?: Promise<void>;
   now?: () => number;
   newId?: () => string;
   /** Resume one already-materialized session instead of creating a fresh session. */
@@ -430,19 +438,23 @@ export async function runHarborCellWithStorage(
   let deadlineReached = false;
   let settlementError: unknown;
   let settlementAttempt: Promise<void> | undefined;
+  let settlementClosed = false;
+  const armDeadlineSettlement = () => {
+    if (settlementClosed || deadlineReached) return;
+    deadlineReached = true;
+    settlementAttempt = sessionCapabilities
+      .settle(session.id, {
+        source: 'benchmark_deadline',
+      })
+      .catch((error) => {
+        settlementError = error;
+      });
+  };
   const settlementTimer =
     input.settleAfterMs === undefined
       ? undefined
-      : setTimeout(() => {
-          deadlineReached = true;
-          settlementAttempt = sessionCapabilities
-            .settle(session.id, {
-              source: 'benchmark_deadline',
-            })
-            .catch((error) => {
-              settlementError = error;
-            });
-        }, input.settleAfterMs);
+      : setTimeout(armDeadlineSettlement, input.settleAfterMs);
+  if (input.settleSignal) void input.settleSignal.then(armDeadlineSettlement);
 
   const continuationPolicy = input.continuationPolicy ?? {
     enabled: false,
@@ -488,6 +500,7 @@ export async function runHarborCellWithStorage(
     if (isStorageRootAuthorityError(error)) throw error;
     sendMessageError = error;
   } finally {
+    settlementClosed = true;
     if (settlementTimer) clearTimeout(settlementTimer);
     // The agent phase is over here, and grading runs after this process exits.
     // Anything the model left managed — a background build, a PTY it never


### PR DESCRIPTION
## Summary

Closes #2221

Three pieces, matching the issue and its follow-up comment:

- The shared TUI `waitFor` keeps its 250 ms budget locally but takes 5 s under CI (`MAKA_TEST_WAIT_BUDGET_MS` overrides both). A passing wait returns the moment the predicate turns true, so the budget only bounds how long a failing assertion takes to report; the fixed 250 ms bought nothing on green runs and lost scheduling races on loaded runners. It also takes an optional description now, and the expiry message names the budget and what was being waited on instead of `false !== true`.
- The harbor-cell test that raced normal completion against `settleAfterMs: 1_000` now expresses the ordering it always meant. `runHarborCell` takes a `settleSignal` promise that arms the same settlement the timer would, and the test resolves it from the backend at the point where the terminal claim is provably taken: the post-terminal drain pulls the next generator value only after the previous event was processed, so resuming after `yield complete` is the barrier. The 1100 ms sleep against a 1000 ms timer is gone.
- Sweep for the same shape, per the follow-up comment: two more fixed-deadline local waiters in the cli tests (`runtime-bootstrap`, `cli-goal-continuation`) now share the scaled budget as a floor-raise. The two remaining `settleAfterMs` uses in harbor-cell assert the direction where the deadline should win; load only widens their margin, and both already carry guards, so they are left alone.

## Verification

- `packages/cli` suite passes with the new helper signature across all 373 call sites.
- `packages/headless` harbor-cell suite passes three consecutive runs with the rewritten test.
- The original failure shapes cannot recur by construction: the CI budget is twenty times the observed 262 ms overshoot, and the harbor-cell ordering no longer involves a clock.
