### PR TITLE
fix(settings): use standard tab order in provider catalog

### DIFF
--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -41,8 +41,17 @@ async function openCatalog(page: Page, options: { category: string; search: stri
   // The catalog level lands on its search field before anything else is
   // touched: it is what a user arrives here to do, and the shared route-focus
   // hook is what puts them there.
-  await expect(catalog.getByPlaceholder('搜索服务商')).toBeFocused();
-  await catalog.getByRole('combobox', { name: '分类', exact: true }).click();
+  const search = catalog.getByPlaceholder('搜索服务商');
+  const category = catalog.getByRole('combobox', { name: '分类', exact: true });
+  await expect(search).toBeFocused();
+  // These are independent filters, not one composite toolbar: ordinary Tab
+  // order must move between them in both directions.
+  await page.keyboard.press('Tab');
+  await expect(category).toBeFocused();
+  await page.keyboard.press('Shift+Tab');
+  await expect(search).toBeFocused();
+  await expect(catalog.getByRole('toolbar')).toHaveCount(0);
+  await category.click();
   await page.getByRole('option', { name: options.category, exact: true }).click();
   await catalog.getByPlaceholder('搜索服务商').fill(options.search);
   return catalog;

--- a/apps/desktop/e2e/providers.spec.ts
+++ b/apps/desktop/e2e/providers.spec.ts
@@ -44,6 +44,9 @@ async function openCatalog(page: Page, options: { category: string; search: stri
   const search = catalog.getByPlaceholder('搜索服务商');
   const category = catalog.getByRole('combobox', { name: '分类', exact: true });
   await expect(search).toBeFocused();
+  const searchIcon = search.locator('xpath=..').locator('svg').first();
+  await expect(searchIcon).toHaveCSS('width', '16px');
+  await expect(searchIcon).toHaveCSS('height', '16px');
   // These are independent filters, not one composite toolbar: ordinary Tab
   // order must move between them in both directions.
   await page.keyboard.press('Tab');

--- a/apps/desktop/src/renderer/settings/provider-catalog-page.tsx
+++ b/apps/desktop/src/renderer/settings/provider-catalog-page.tsx
@@ -82,6 +82,12 @@ export function ProviderCatalogPage(props: {
       <Toolbar
         label={copy.categoriesAria}
         gap={2}
+        // Suppress the Toolbar's automatic "← → to navigate" keyboard hint.
+        // This toolbar has only two controls (search + category selector);
+        // arrow-key navigation between them is not a meaningful interaction,
+        // and the hint's CSS anchor positioning renders at a broken offset
+        // inside the settings panel layout.
+        onFocus={(e) => e.preventDefault()}
         startContent={(
           <TextInput
             value={query}

--- a/apps/desktop/src/renderer/settings/provider-catalog-page.tsx
+++ b/apps/desktop/src/renderer/settings/provider-catalog-page.tsx
@@ -1,10 +1,11 @@
 import {
   Banner,
   EmptyState,
+  HStack,
   List,
   ListItem,
+  Section,
   Selector,
-  Toolbar,
   VStack,
 } from '@astryxdesign/core';
 import { ChevronRight, Search } from '@maka/ui/icons';
@@ -79,16 +80,8 @@ export function ProviderCatalogPage(props: {
 
   return (
     <VStack gap={4} data-maka-contract="provider-catalog">
-      <Toolbar
-        label={copy.categoriesAria}
-        gap={2}
-        // Suppress the Toolbar's automatic "← → to navigate" keyboard hint.
-        // This toolbar has only two controls (search + category selector);
-        // arrow-key navigation between them is not a meaningful interaction,
-        // and the hint's CSS anchor positioning renders at a broken offset
-        // inside the settings panel layout.
-        onFocus={(e) => e.preventDefault()}
-        startContent={(
+      <Section variant="transparent" paddingBlock={2}>
+        <HStack gap={2} hAlign="between" vAlign="center">
           <TextInput
             value={query}
             onChange={(value) => props.onFilterChange({ ...props.filter, query: value })}
@@ -96,10 +89,7 @@ export function ProviderCatalogPage(props: {
             label={copy.searchAria}
             isLabelHidden
             startIcon={<Search aria-hidden="true" />}
-            width="100%"
           />
-        )}
-        endContent={(
           <Selector
             label={copy.category}
             isLabelHidden
@@ -108,8 +98,8 @@ export function ProviderCatalogPage(props: {
             options={categoryOptions}
             data-catalog-category={category}
           />
-        )}
-      />
+        </HStack>
+      </Section>
       {oauth.refreshError && (
         <Banner
           status="warning"

--- a/apps/desktop/src/renderer/settings/provider-catalog-page.tsx
+++ b/apps/desktop/src/renderer/settings/provider-catalog-page.tsx
@@ -88,7 +88,7 @@ export function ProviderCatalogPage(props: {
             placeholder={copy.searchPlaceholder}
             label={copy.searchAria}
             isLabelHidden
-            startIcon={<Search aria-hidden="true" />}
+            startIcon={Search}
           />
           <Selector
             label={copy.category}


### PR DESCRIPTION
Before:
<img width="350" height="113" alt="image" src="https://github.com/user-attachments/assets/29fc0b52-a8ff-492e-9f06-af466b240d2e" />


After:
<img width="387" height="128" alt="image" src="https://github.com/user-attachments/assets/10ab8326-4ae9-4d74-82f2-3fc8e2aa3106" />


## Summary

- replace the provider catalog Toolbar with a neutral Section/HStack layout so search and category remain independent controls
- remove the misplaced arrow-key hint without cancelling Toolbar focus management
- route the search glyph through the TextInput icon slot so it uses the 16px small-icon scale
- cover bidirectional Tab order, non-toolbar semantics, and search-icon sizing in the provider E2E flow

## Verification

- `npm run format:check`
- `npm run lint`
- `npm --workspace @maka/desktop run test:checks`
- `npm --workspace @maka/desktop run build:renderer`
- `npx playwright test --config=e2e/playwright.config.ts e2e/providers.spec.ts --grep "canonical API-key"` (1 passed)
- real Electron fixture: search and category both report `tabIndex=0`; `Tab` / `Shift+Tab` round-trip, the search icon is 16x16px, and measured layout geometry matches the prior toolbar
- `npm --workspace @maka/desktop run typecheck` remains blocked by existing `ChatLayoutProps.conversationKey` mismatches in unchanged `app-shell.tsx` and `quote-companion-panel.tsx`