### PR TITLE
test(runtime): make Fireworks concurrency probe deterministic

### DIFF
--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -123,6 +123,7 @@ describe('fetchProviderModels', () => {
   test('Fireworks bounds account concurrency while preserving normal pagination', async () => {
     let activeModelRequests = 0;
     let maxActiveModelRequests = 0;
+    const initialModelResponses: Array<() => void> = [];
     const server = await startJsonServer((request, response) => {
       const url = new URL(request.url ?? '', 'http://test.local');
       if (url.pathname === '/v1/accounts') {
@@ -136,7 +137,7 @@ describe('fetchProviderModels', () => {
 
       activeModelRequests += 1;
       maxActiveModelRequests = Math.max(maxActiveModelRequests, activeModelRequests);
-      setTimeout(() => {
+      const respondWithModels = () => {
         activeModelRequests -= 1;
         const account = url.pathname.match(/^\/v1\/accounts\/([^/]+)\/models$/)?.[1] ?? 'unknown';
         const pageToken = url.searchParams.get('pageToken');
@@ -144,7 +145,15 @@ describe('fetchProviderModels', () => {
           models: [{ name: `accounts/${account}/models/${pageToken ?? 'first'}` }],
           ...(account === 'team-0' && !pageToken ? { nextPageToken: 'second' } : {}),
         });
-      }, 10);
+      };
+      if (initialModelResponses.length < 4) {
+        initialModelResponses.push(respondWithModels);
+        if (initialModelResponses.length === 4) {
+          for (const respond of initialModelResponses) respond();
+        }
+        return;
+      }
+      respondWithModels();
     });
 
     const models = await fetchProviderModels(fireworksConnection(server.url), 'fireworks-key');


### PR DESCRIPTION
## Issue

Addresses #2294. The issue comment documents the reproduction, why the wall-clock probe is flaky, and the proposed deterministic barrier.

## Change

Replace the 10ms response delay with a four-request barrier. This guarantees the test observes the configured concurrency limit without changing production code or the pagination assertions.

## Verification

- @maka/storage build
- @maka/runtime build
- focused Fireworks concurrency test, run twice
- git diff --check