### PR TITLE
fix(headless): teach the trajectory exporter the two envelope fields it never learned

### DIFF
--- a/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
+++ b/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
@@ -889,6 +889,76 @@
           }
         }
       }
+    },
+    {
+      "name": "valid-provider-origin",
+      "accepted": true,
+      "overrides": {
+        "origin": "provider"
+      }
+    },
+    {
+      "name": "valid-code-mode-origin",
+      "accepted": true,
+      "overrides": {
+        "origin": "code_mode"
+      }
+    },
+    {
+      "name": "invalid-unknown-origin",
+      "accepted": false,
+      "overrides": {
+        "origin": "harness"
+      }
+    },
+    {
+      "name": "valid-visible-model-visibility",
+      "accepted": true,
+      "overrides": {
+        "modelVisibility": "visible"
+      }
+    },
+    {
+      "name": "valid-hidden-model-visibility",
+      "accepted": true,
+      "overrides": {
+        "modelVisibility": "hidden"
+      }
+    },
+    {
+      "name": "invalid-non-string-model-visibility",
+      "accepted": false,
+      "overrides": {
+        "modelVisibility": 7
+      }
+    },
+    {
+      "name": "valid-branch",
+      "accepted": true,
+      "overrides": {
+        "branch": "lane-1"
+      }
+    },
+    {
+      "name": "invalid-non-string-branch",
+      "accepted": false,
+      "overrides": {
+        "branch": 3
+      }
+    },
+    {
+      "name": "valid-terminal-status",
+      "accepted": true,
+      "overrides": {
+        "status": "completed"
+      }
+    },
+    {
+      "name": "invalid-unknown-status",
+      "accepted": false,
+      "overrides": {
+        "status": "finished"
+      }
     }
   ]
 }

--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -24,6 +24,7 @@ import {
   isTerminalRuntimeEvent,
   isTerminalRuntimeEventStatus,
   isPartialRuntimeEvent,
+  runtimeEventEnvelopeKeys,
   runtimeEventHasModelVisibleContent,
   type RuntimeEvent,
   type RuntimeEventActions,
@@ -62,6 +63,21 @@ const runtimeEventValidationCorpus = JSON.parse(
     'utf8',
   ),
 ) as RuntimeEventValidationCorpus;
+
+test('the shared validation corpus exercises every envelope key', () => {
+  // The corpus is what the Python exporter in `packages/headless/harbor`
+  // validates against, and it is the only thing tying that re-implementation to
+  // this one. A key no case ever sets is a key the exporter can silently not
+  // know about — which is exactly how `origin` and `modelVisibility` came to
+  // fail every event of an 89-cell benchmark run.
+  const exercised = new Set([
+    ...Object.keys(runtimeEventValidationCorpus.baseEvent),
+    ...runtimeEventValidationCorpus.cases.flatMap((entry) => Object.keys(entry.overrides)),
+  ]);
+  for (const key of runtimeEventEnvelopeKeys()) {
+    assert.ok(exercised.has(key), `no corpus case sets the envelope key ${key}`);
+  }
+});
 
 test('Core decoder matches the shared RuntimeEvent validation corpus', () => {
   for (const entry of runtimeEventValidationCorpus.cases) {

--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -70,9 +70,15 @@ test('the shared validation corpus exercises every envelope key', () => {
   // this one. A key no case ever sets is a key the exporter can silently not
   // know about — which is exactly how `origin` and `modelVisibility` came to
   // fail every event of an 89-cell benchmark run.
+  // Only cases the corpus expects to be accepted count. A rejected case carries
+  // a value both sides refuse, so it passes just as well against an exporter
+  // that never learned the key at all — which is the one thing this is here to
+  // catch.
   const exercised = new Set([
     ...Object.keys(runtimeEventValidationCorpus.baseEvent),
-    ...runtimeEventValidationCorpus.cases.flatMap((entry) => Object.keys(entry.overrides)),
+    ...runtimeEventValidationCorpus.cases
+      .filter((entry) => entry.accepted)
+      .flatMap((entry) => Object.keys(entry.overrides)),
   ]);
   for (const key of runtimeEventEnvelopeKeys()) {
     assert.ok(exercised.has(key), `no corpus case sets the envelope key ${key}`);

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -403,6 +403,23 @@ export interface RuntimeEvent {
   refs?: RuntimeEventRefs;
 }
 
+/**
+ * Every key a RuntimeEvent envelope may carry. TypeScript forces this list to
+ * cover the interface, so it moves whenever the interface does — which makes it
+ * the thing anything re-implementing the envelope check must be pinned to.
+ *
+ * The Harbor trajectory exporter re-implements it in Python and drifted: it
+ * never learned `origin` or `modelVisibility`, so once the runtime started
+ * emitting them every event failed the check and all 89 cells of a benchmark
+ * run exported a one-line summary instead of a trajectory. The shared
+ * validation corpus was supposed to catch that and could not — it exercised
+ * the keys someone thought to write cases for, and those two were never among
+ * them. `runtime-event.test.ts` now holds the corpus to this list.
+ */
+export function runtimeEventEnvelopeKeys(): readonly string[] {
+  return [...RUNTIME_EVENT_SHAPE.allowed];
+}
+
 const RUNTIME_EVENT_SHAPE = defineObjectShape<RuntimeEvent>()(
   ['id', 'invocationId', 'runId', 'sessionId', 'turnId', 'ts', 'partial', 'role', 'author'],
   ['branch', 'origin', 'modelVisibility', 'status', 'content', 'actions', 'refs'],

--- a/packages/headless/harbor/maka_trajectory.py
+++ b/packages/headless/harbor/maka_trajectory.py
@@ -1013,6 +1013,8 @@ def _is_runtime_event(event: dict[str, Any]) -> bool:
         "partial",
         "role",
         "author",
+        "origin",
+        "modelVisibility",
         "status",
         "content",
         "actions",
@@ -1037,6 +1039,14 @@ def _is_runtime_event(event: dict[str, Any]) -> bool:
     ):
         return False
     if "branch" in event and not isinstance(event["branch"], str):
+        return False
+    if "origin" in event and not _is_string_choice(
+        event["origin"], {"provider", "code_mode"}
+    ):
+        return False
+    if "modelVisibility" in event and not _is_string_choice(
+        event["modelVisibility"], {"visible", "hidden"}
+    ):
         return False
     if "status" in event and not _is_string_choice(
         event["status"], _TERMINAL_STATUSES | {"streaming"}


### PR DESCRIPTION
## What

Every Maka cell of the #2245 two-arm run exported a one-line summary in place of its trajectory — **89 of 89**, all with `maka_summary_reason: runtime_event_schema_invalid`. Codex exported 89 of 89 complete, 15 to 184 steps each.

That means any analysis built on the normalized ATIF trajectory is blind on our own arm, which is how this surfaced: it is the data source a contamination detector would read.

Refs #2245

## Root cause

`maka_trajectory.py`'s `_is_runtime_event` validates the RuntimeEvent envelope against a hand-copied key whitelist and rejects any event carrying a key it does not list. The runtime's envelope gained `origin` and `modelVisibility`; the whitelist never learned them.

Replaying the run's own `runtime-events.jsonl`, all 89 files fail at the same shape, and always with the same two keys:

```
89 files, 89 rejected — extra keys: modelVisibility, origin
first: adaptive-rejection-sampler, event 4 of 507
  { ..., "role": "model", "author": "agent",
    "origin": "provider", "modelVisibility": "visible", ... }
```

Both are legitimate optional envelope fields — `RUNTIME_EVENT_SHAPE` in `packages/core/src/runtime-event.ts` lists them, and `defineObjectShape<RuntimeEvent>()` type-forces that list to cover the interface. Only the Python copy could drift, and it did. In this corpus the values are only ever `provider`/`visible` or absent, so nothing semantic was lost — the events were simply refused.

## Why the existing guard missed it

Core's decoder and the Python exporter already share one validation corpus (`runtime-event-validation-corpus.json`), run from both sides. It did not catch this because the corpus is a hand-written list of cases: 52 of them, and **four envelope keys — `origin`, `modelVisibility`, `branch`, `status` — set by none of them.** It covered the keys someone thought to write cases for.

So the fix is in two parts:

- `maka_trajectory.py` accepts both fields with the value constraints the TypeScript decoder applies (`provider`/`code_mode`, `visible`/`hidden`).
- The corpus covers all four previously unexercised keys, accepted and rejected, and a new Core test holds the corpus to `runtimeEventEnvelopeKeys()`. TypeScript already forces that list to cover the interface, so the chain is now: interface → shape → corpus → Python. A field added without a case fails in Core rather than silently blinding a benchmark run.

## Verification

Replaying all 89 cells' real `runtime-events.jsonl` through the exporter, with the run's own status and runtime refs:

| | before | after |
|---|---|---|
| full trajectory | **0** | **78** |
| `runtime_event_schema_invalid` | **89** | 0 |
| `image_artifact_metadata_missing` | 0 | 11 |

Recovered trajectories run 9 to 252 steps (median 26).

The 11 remaining cells carry image content whose artifact metadata resolves against a trajectory-state store that is not present in any of the 89 exported cells, so **this corpus cannot say whether those 11 would have exported fully in production** — a different reason code and a separate question.

Red/green, both directions:

- Removing the two keys from the Python whitelist again → the corpus-driven Python test fails on `valid-provider-origin`.
- Removing the `origin` corpus cases → the new Core test fails with `no corpus case sets the envelope key origin`.

`npm run -w @maka/core test` — 796 pass. `npm run -w @maka/headless test` — 1421 pass. Lint and format clean.