### PR TITLE
test(core): pin the shared validation corpus to every envelope value domain

### DIFF
--- a/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
+++ b/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
@@ -978,13 +978,6 @@
       }
     },
     {
-      "name": "valid-host-author",
-      "accepted": true,
-      "overrides": {
-        "author": "host"
-      }
-    },
-    {
       "name": "valid-streaming-status",
       "accepted": true,
       "overrides": {

--- a/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
+++ b/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
@@ -954,6 +954,37 @@
       }
     },
     {
+      "name": "valid-user-role",
+      "accepted": true,
+      "overrides": {
+        "role": "user",
+        "author": "user"
+      }
+    },
+    {
+      "name": "valid-tool-role",
+      "accepted": true,
+      "overrides": {
+        "role": "tool",
+        "author": "tool"
+      }
+    },
+    {
+      "name": "valid-system-role",
+      "accepted": true,
+      "overrides": {
+        "role": "system",
+        "author": "system"
+      }
+    },
+    {
+      "name": "valid-host-author",
+      "accepted": true,
+      "overrides": {
+        "author": "host"
+      }
+    },
+    {
       "name": "valid-streaming-status",
       "accepted": true,
       "overrides": {

--- a/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
+++ b/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
@@ -954,6 +954,35 @@
       }
     },
     {
+      "name": "valid-streaming-status",
+      "accepted": true,
+      "overrides": {
+        "status": "streaming",
+        "partial": true
+      }
+    },
+    {
+      "name": "valid-failed-status",
+      "accepted": true,
+      "overrides": {
+        "status": "failed"
+      }
+    },
+    {
+      "name": "valid-aborted-status",
+      "accepted": true,
+      "overrides": {
+        "status": "aborted"
+      }
+    },
+    {
+      "name": "valid-cancelled-status",
+      "accepted": true,
+      "overrides": {
+        "status": "cancelled"
+      }
+    },
+    {
       "name": "invalid-unknown-status",
       "accepted": false,
       "overrides": {

--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -25,6 +25,7 @@ import {
   isTerminalRuntimeEventStatus,
   isPartialRuntimeEvent,
   runtimeEventEnvelopeKeys,
+  runtimeEventEnvelopeValueDomains,
   runtimeEventHasModelVisibleContent,
   type RuntimeEvent,
   type RuntimeEventActions,
@@ -82,6 +83,23 @@ test('the shared validation corpus exercises every envelope key', () => {
   ]);
   for (const key of runtimeEventEnvelopeKeys()) {
     assert.ok(exercised.has(key), `no corpus case sets the envelope key ${key}`);
+  }
+});
+
+test('the shared validation corpus exercises every envelope value domain', () => {
+  // The same drift one level down. Python spells these domains out again, so a
+  // member no accepted case carries is a member the exporter may reject while
+  // this side accepts it — and every event that carries it degrades to a
+  // one-line summary, exactly as an unknown key did.
+  const accepted = runtimeEventValidationCorpus.cases.filter((entry) => entry.accepted);
+  for (const [key, domain] of Object.entries(runtimeEventEnvelopeValueDomains())) {
+    const carried = new Set([
+      runtimeEventValidationCorpus.baseEvent[key],
+      ...accepted.map((entry) => entry.overrides[key]),
+    ]);
+    for (const member of domain) {
+      assert.ok(carried.has(member), `no corpus case carries ${key}: ${member}`);
+    }
   }
 });
 

--- a/packages/core/src/record-schema.ts
+++ b/packages/core/src/record-schema.ts
@@ -61,6 +61,19 @@ export function isOptionalString(value: unknown): boolean {
   return value === undefined || typeof value === 'string';
 }
 
+/**
+ * An absent value, or one the given domain contains. Taking the domain as an
+ * argument rather than spelling its members out at the call site is what lets a
+ * value domain be enumerated: a check written as a chain of `!==` comparisons
+ * is invisible to anything that wants to know what the field may hold.
+ */
+export function isOptionalMember<T extends string>(
+  value: unknown,
+  domain: readonly T[],
+): value is T | undefined {
+  return value === undefined || (domain as readonly string[]).includes(value as string);
+}
+
 export function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string');
 }

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -28,6 +28,7 @@ import {
   defineObjectShape,
   hasExactShape,
   isFiniteNumber,
+  isOptionalMember,
   isOptionalString,
   isRecord,
   isStringArray,
@@ -102,6 +103,14 @@ export const TERMINAL_RUNTIME_EVENT_STATUSES: readonly RuntimeEventStatus[] = [
 export function isRuntimeEventStatus(value: unknown): value is RuntimeEventStatus {
   return typeof value === 'string' && (RUNTIME_EVENT_STATUSES as readonly string[]).includes(value);
 }
+
+/** Execution surface that produced a fact; absent on legacy ledgers. */
+export const RUNTIME_EVENT_ORIGINS = ['provider', 'code_mode'] as const;
+export type RuntimeEventOrigin = (typeof RUNTIME_EVENT_ORIGINS)[number];
+
+/** Explicit provider-history policy; absent means visible. */
+export const RUNTIME_EVENT_MODEL_VISIBILITIES = ['visible', 'hidden'] as const;
+export type RuntimeEventModelVisibility = (typeof RUNTIME_EVENT_MODEL_VISIBILITIES)[number];
 
 export function isTerminalRuntimeEventStatus(value: unknown): boolean {
   return (
@@ -392,9 +401,9 @@ export interface RuntimeEvent {
   role: RuntimeEventRole;
   author: RuntimeEventAuthor;
   /** Execution surface that produced this fact; absent on legacy ledgers. */
-  origin?: 'provider' | 'code_mode';
+  origin?: RuntimeEventOrigin;
   /** Explicit provider-history policy; absent means visible for legacy compatibility. */
-  modelVisibility?: 'visible' | 'hidden';
+  modelVisibility?: RuntimeEventModelVisibility;
   /** Lifecycle assertion; omitted on ordinary in-flight content events. */
   status?: RuntimeEventStatus;
 
@@ -418,6 +427,24 @@ export interface RuntimeEvent {
  */
 export function runtimeEventEnvelopeKeys(): readonly string[] {
   return [...RUNTIME_EVENT_SHAPE.allowed];
+}
+
+/**
+ * Every value each closed-domain envelope key may hold.
+ *
+ * Pinning the corpus to the key list closed one half of the drift the Harbor
+ * exporter fell through: a key nobody wrote a case for. The other half is a
+ * value nobody wrote a case for — the exporter spells these domains out again
+ * in Python, and a member added here that no case carries would leave the two
+ * disagreeing about what is valid with nothing red. Only the closed domains
+ * appear; `branch` is free text and has nothing to enumerate.
+ */
+export function runtimeEventEnvelopeValueDomains(): Readonly<Record<string, readonly string[]>> {
+  return {
+    origin: RUNTIME_EVENT_ORIGINS,
+    modelVisibility: RUNTIME_EVENT_MODEL_VISIBILITIES,
+    status: RUNTIME_EVENT_STATUSES,
+  };
 }
 
 const RUNTIME_EVENT_SHAPE = defineObjectShape<RuntimeEvent>()(
@@ -579,10 +606,8 @@ export function decodeRuntimeEvent(value: unknown): RuntimeEvent {
     typeof value.partial !== 'boolean' ||
     !isRuntimeEventRole(value.role) ||
     !isRuntimeEventAuthor(value.author) ||
-    (value.origin !== undefined && value.origin !== 'provider' && value.origin !== 'code_mode') ||
-    (value.modelVisibility !== undefined &&
-      value.modelVisibility !== 'visible' &&
-      value.modelVisibility !== 'hidden') ||
+    !isOptionalMember(value.origin, RUNTIME_EVENT_ORIGINS) ||
+    !isOptionalMember(value.modelVisibility, RUNTIME_EVENT_MODEL_VISIBILITIES) ||
     (value.status !== undefined && !isRuntimeEventStatus(value.status)) ||
     (value.content !== undefined && !isRuntimeEventContent(value.content)) ||
     (value.actions !== undefined && !isRuntimeEventActions(value.actions)) ||

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -441,6 +441,8 @@ export function runtimeEventEnvelopeKeys(): readonly string[] {
  */
 export function runtimeEventEnvelopeValueDomains(): Readonly<Record<string, readonly string[]>> {
   return {
+    role: RUNTIME_EVENT_ROLES,
+    author: RUNTIME_EVENT_AUTHORS,
     origin: RUNTIME_EVENT_ORIGINS,
     modelVisibility: RUNTIME_EVENT_MODEL_VISIBILITIES,
     status: RUNTIME_EVENT_STATUSES,


### PR DESCRIPTION
## Summary

#2314 fixed a drift that made every one of an 89-cell benchmark run's Maka trajectories export as a one-line summary: the Harbor exporter re-implements the RuntimeEvent envelope check in Python and had never learned `origin` or `modelVisibility`. It closed that class of drift at the key level — the shared validation corpus is now held to `runtimeEventEnvelopeKeys()`, so a key added to the interface cannot ship without a corpus case, and a corpus case the Python side rejects turns the exporter's silence into a red test.

The same drift is still open one level down. Python spells the closed value domains out again (`{"provider", "code_mode"}`, `{"visible", "hidden"}`, the status set), so a member added on the TypeScript side that no corpus case carries leaves the two disagreeing about what is valid with nothing red — and every event carrying that member degrades to a summary exactly as an unknown key did.

Two changes, and the first is what makes the second possible:

- `status` already derived its type from `RUNTIME_EVENT_STATUSES`. `origin` and `modelVisibility` were inline unions that the decoder compared against by hand, which left their domains unenumerable: a chain of `!==` is invisible to anything asking what a field may hold. They now have the same shape as `status`, and the decoder reads the constants through a shared `isOptionalMember` in `record-schema.ts` rather than repeating their members.
- `runtimeEventEnvelopeValueDomains()` exports those three domains, and a new test requires an accepted corpus case for every member. `branch` is free text and has nothing to enumerate, so it does not appear.

The corpus gains the four `status` members it never carried (`streaming`, `failed`, `aborted`, `cancelled`) — only `completed` was ever exercised.

Refs #2314.

## Verification

Both halves of the chain proved by reverting, not by reading:

- **Red, TypeScript side**: added `'harness'` to `RUNTIME_EVENT_ORIGINS` without touching the corpus → `no corpus case carries origin: harness`.
- **Red, Python side**: narrowed the exporter's `modelVisibility` set to `{"hidden"}` → the headless corpus round-trip fails on `valid-visible-model-visibility` with `runtime_event_schema_invalid` — the exact degradation #2314 was about, now caught by a test instead of by a benchmark run.
- **Green**: `@maka/core` 799 pass / 0 fail, `@maka/headless` 1431 pass / 0 fail (includes the Python corpus round-trip), `@maka/runtime` 3293 pass / 0 fail. `npm run lint` and `npm run format` clean.

Not run: desktop E2E and Storybook — this touches no renderer surface.

## Review focus

The value-domain test is only as strong as the corpus round-trip it feeds: it guarantees a *case exists*, and the Python side is what turns that case into a cross-language assertion. It does not reach nested shapes (`content`, `actions`, `refs`), whose domains are still pinned only by the cases someone thought to write.
