### PR TITLE
test(headless): read both ways an adapter names a mounted repo file

### DIFF
--- a/packages/headless/src/__tests__/agent-repo-mount.test.ts
+++ b/packages/headless/src/__tests__/agent-repo-mount.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
@@ -25,14 +25,27 @@ const AGENTS: readonly HarnessAgentId[] = ['maka', ...COMPETITORS];
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
 
+/** The repo's own top-level directories: what a container path can start with. */
+const REPO_TOP_LEVEL = new Set(
+  readdirSync(REPO_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name),
+);
+
 /**
  * Every repo file an adapter names at a container path.
  *
- * Adapters write one of two forms, and both must be read: the mounted path
- * spelled out in full, and the same path built by joining segments onto the
- * mount root. Matching a bare filename instead would be neither — it resolves
- * against whichever directory the matcher happens to scan, so a read outside
- * that directory looks like no read at all.
+ * Two forms carry a container path, and both must be read: the mounted path
+ * spelled out in full, and the same path built by joining segments onto some
+ * expression for the mount root. Matching a bare filename instead would be
+ * neither — it resolves against whichever directory the matcher happens to
+ * scan, so a read outside that directory looks like no read at all.
+ *
+ * The join form is matched by the chain rather than by what it hangs off,
+ * because what it hangs off varies: `maka_repo` from the environment in one
+ * adapter, a `Path("/opt/maka-agent")` constant in another, and nothing stops a
+ * third from binding its own name. The chain is the part that cannot vary — a
+ * repo path starts at a repo directory.
  */
 function adapterContainerRepoReads(source: string): Set<string> {
   const read = new Set<string>();
@@ -41,8 +54,10 @@ function adapterContainerRepoReads(source: string): Set<string> {
       read.add(literal.slice(CONTAINER_MAKA_REPO.length + 1));
     }
   }
-  for (const [, segments] of source.matchAll(/Path\(maka_repo\)((?:\s*\/\s*"[^"\n]+")+)/g)) {
-    read.add([...segments.matchAll(/"([^"]+)"/g)].map(([, segment]) => segment).join('/'));
+  for (const [, head, rest] of source.matchAll(/\/\s*"([^"\n]+)"((?:\s*\/\s*"[^"\n]+")*)/g)) {
+    if (!REPO_TOP_LEVEL.has(head)) continue;
+    const tail = [...rest.matchAll(/"([^"]+)"/g)].map(([, segment]) => segment);
+    read.add([head, ...tail].join('/'));
   }
   return read;
 }
@@ -207,7 +222,15 @@ describe('agent repo mounts', () => {
         'utf8',
       );
       const mounted = agent === 'maka' ? makaRepoPaths() : competitorRepoFiles(agent);
-      for (const repoFile of adapterContainerRepoReads(source)) {
+      const reads = adapterContainerRepoReads(source);
+      // A reader that matches nothing passes everything. An adapter with files
+      // declared for it is one whose source names them, so an empty read set
+      // here is the reader having stopped reading — the way a regex guard
+      // rots, and the way the form it replaced rotted.
+      if (mounted.length > 0) {
+        assert.ok(reads.size > 0, `no container paths were found in ${adapterModule}.py`);
+      }
+      for (const repoFile of reads) {
         // A file may be mounted directly or inside a mounted directory.
         const covered = mounted.some(
           (repoPath) => repoPath === repoFile || repoFile.startsWith(`${repoPath}/`),
@@ -234,6 +257,13 @@ describe('agent repo mounts', () => {
         ),
       ],
       ['packages/headless/dist/index.js'],
+    );
+    // The same chain hung off a different name for the mount root. Both
+    // spellings are in the adapters today, and reading only the first left the
+    // second — `_CONTAINER_MAKA_REPO / "packages" / …` — unseen.
+    assert.deepEqual(
+      [...adapterContainerRepoReads('_CLI = _CONTAINER_MAKA_REPO / "packages" / "a" / "cli.js"')],
+      ['packages/a/cli.js'],
     );
   });
 

--- a/packages/headless/src/__tests__/agent-repo-mount.test.ts
+++ b/packages/headless/src/__tests__/agent-repo-mount.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
 import {
@@ -21,7 +21,31 @@ const COMPETITORS: readonly Exclude<HarnessAgentId, 'maka'>[] = [
   'reasonix',
 ];
 
+const AGENTS: readonly HarnessAgentId[] = ['maka', ...COMPETITORS];
+
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/**
+ * Every repo file an adapter names at a container path.
+ *
+ * Adapters write one of two forms, and both must be read: the mounted path
+ * spelled out in full, and the same path built by joining segments onto the
+ * mount root. Matching a bare filename instead would be neither — it resolves
+ * against whichever directory the matcher happens to scan, so a read outside
+ * that directory looks like no read at all.
+ */
+function adapterContainerRepoReads(source: string): Set<string> {
+  const read = new Set<string>();
+  for (const [, literal] of source.matchAll(/["']([^"'\n]+)["']/g)) {
+    if (literal.startsWith(`${CONTAINER_MAKA_REPO}/`)) {
+      read.add(literal.slice(CONTAINER_MAKA_REPO.length + 1));
+    }
+  }
+  for (const [, segments] of source.matchAll(/Path\(maka_repo\)((?:\s*\/\s*"[^"\n]+")+)/g)) {
+    read.add([...segments.matchAll(/"([^"]+)"/g)].map(([, segment]) => segment).join('/'));
+  }
+  return read;
+}
 
 const RENDERER_ONLY = new Set(RENDERER_ONLY_WORKSPACES);
 
@@ -168,67 +192,49 @@ describe('agent repo mounts', () => {
     });
   }
 
-  test('declares every repo file the adapters read at a container path', () => {
-    // Every assertion above derives its expectation from competitorRepoFiles(),
+  test('declares every repo file an adapter names at a container path', () => {
+    // Every assertion above derives its expectation from the declaration lists,
     // so none of them can tell a wrong list from a right one. The adapters are
     // the authority for what is read at a container path, so read them instead:
-    // a repo read added there without an entry here mounts nothing, and the arm
-    // fails inside the container partway through a graded run.
-    const harborDir = join(REPO_ROOT, 'packages/headless/harbor');
-    const repoFileByBasename = new Map(
-      readdirSync(harborDir, { recursive: true, withFileTypes: true })
-        .filter((entry) => entry.isFile())
-        .map((entry) => {
-          const absolute = join(entry.parentPath, entry.name);
-          return [entry.name, relative(REPO_ROOT, absolute)] as const;
-        }),
-    );
-
-    for (const agent of COMPETITORS) {
+    // a repo read added there without an entry in the list mounts nothing.
+    // `run-host-cell.mjs` is what that costs — `install()` probes for it in
+    // every cell-mode branch, it was left out of the declaration, and a missing
+    // probe target aborts the trial before the arm runs at all.
+    for (const agent of AGENTS) {
       const adapterModule = harnessAgentImportPath(agent).split(':')[0];
-      const source = readFileSync(join(harborDir, `${adapterModule}.py`), 'utf8');
-      const read = new Set<string>();
-      for (const [, literal] of source.matchAll(/["']([^"'\n]+)["']/g)) {
-        // Adapters name a file either by its absolute container path or by
-        // joining MAKA_REPO_ROOT with the path segments, so match both.
-        if (literal.startsWith(`${CONTAINER_MAKA_REPO}/`)) {
-          read.add(literal.slice(CONTAINER_MAKA_REPO.length + 1));
-          continue;
-        }
-        const repoFile = repoFileByBasename.get(literal);
-        if (repoFile) read.add(repoFile);
-      }
-      for (const repoFile of read) {
-        assert.ok(
-          competitorRepoFiles(agent).includes(repoFile),
-          `${adapterModule}.py reads ${repoFile}, which ${agent} is not mounted`,
+      const source = readFileSync(
+        join(REPO_ROOT, 'packages/headless/harbor', `${adapterModule}.py`),
+        'utf8',
+      );
+      const mounted = agent === 'maka' ? makaRepoPaths() : competitorRepoFiles(agent);
+      for (const repoFile of adapterContainerRepoReads(source)) {
+        // A file may be mounted directly or inside a mounted directory.
+        const covered = mounted.some(
+          (repoPath) => repoPath === repoFile || repoFile.startsWith(`${repoPath}/`),
         );
+        assert.ok(covered, `${adapterModule}.py names ${repoFile}, which ${agent} is not mounted`);
       }
     }
   });
 
-  test('declares every repo file the Maka adapter names at a container path', () => {
-    // The same authority check, which the Maka side did not have — and its
-    // absence is why `run-host-cell.mjs` was left out of the declaration while
-    // `install()` probes for it in every cell-mode branch. A missing probe
-    // target aborts the trial before the arm runs at all.
-    //
-    // `maka_agent.py` builds container paths by joining segments onto the mount
-    // root rather than writing them out, so match the join instead of a literal.
-    const source = readFileSync(join(REPO_ROOT, 'packages/headless/harbor/maka_agent.py'), 'utf8');
-    const mounted = new Set(makaRepoPaths());
-    const read = new Set<string>();
-    for (const [, segments] of source.matchAll(/Path\(maka_repo\)((?:\s*\/\s*"[^"\n]+")+)/g)) {
-      read.add([...segments.matchAll(/"([^"]+)"/g)].map(([, segment]) => segment).join('/'));
-    }
-    assert.ok(read.size > 0, 'no container paths were found in maka_agent.py');
-    for (const repoFile of read) {
-      // A file may be mounted directly or inside a mounted directory.
-      const covered = [...mounted].some(
-        (repoPath) => repoPath === repoFile || repoFile.startsWith(`${repoPath}/`),
-      );
-      assert.ok(covered, `maka_agent.py names ${repoFile}, which Maka is not mounted`);
-    }
+  test('the container-path reader sees both ways an adapter names a file', () => {
+    // The check above is worth exactly what this reader sees, and what it saw
+    // was narrower than it looked: competitor adapters used to be scanned for
+    // bare filenames resolved against `harbor/`, so a read of any repo file
+    // outside that one directory — `dist/index.js`, say — matched nothing and
+    // passed. Both forms below appear in adapters today.
+    assert.deepEqual(
+      [...adapterContainerRepoReads(`_P = Path("${CONTAINER_MAKA_REPO}/packages/a/b.json")`)],
+      ['packages/a/b.json'],
+    );
+    assert.deepEqual(
+      [
+        ...adapterContainerRepoReads(
+          'p = (\n    Path(maka_repo)\n    / "packages"\n    / "headless"\n    / "dist"\n    / "index.js"\n)',
+        ),
+      ],
+      ['packages/headless/dist/index.js'],
+    );
   });
 
   test('keeps the benchmark identity out of every graded container', () => {


### PR DESCRIPTION
## Summary

Each arm is mounted exactly the repo files it declares, and the check that holds those declarations to what the adapters actually read is the only thing standing between a missed entry and a trial that aborts inside the container. #2298 added that check for the Maka adapter after `run-host-cell.mjs` — probed by `install()` in every cell-mode branch — was left out of the declaration. It left the competitor half as it was.

The competitor half saw less than it looked like it saw. It scanned adapter sources for bare filenames and resolved them against `packages/headless/harbor`, so it could only ever notice a read of a file in that one directory. A competitor adapter reaching for `packages/headless/dist/index.js` — a path the Maka adapter already reads — matched nothing and passed. It was also matching by coincidence in the other direction: any string literal equal to some filename under `harbor/` counted as a read of it.

Both halves now share one reader that matches the two forms adapters actually write:

- the mounted path spelled out in full (`codex_agent.py`'s `_DEEPSEEK_MODELS_PATH`),
- the same path built by joining segments onto the mount root (`opencode_agent.py`, `maka_agent.py`).

Bare-filename matching is gone; both forms above cover every read in the adapters today, so nothing is lost with it. The reader is also exercised directly, so it is no longer worth only what today's adapters happen to spell.

Refs #2298.

## Verification

- **Red**: pointed `opencode_agent.py` at `packages/headless/dist/index.js` (a path outside `harbor/`, undeclared, unmounted). On `main` all 19 mount tests pass — the gap, reproduced. With this change: `opencode_agent.py names packages/headless/dist/index.js, which opencode is not mounted`.
- **Green**: `@maka/headless` 1431 pass / 0 fail. `npm run lint` and `npm run format` clean.

Not run: desktop E2E and Storybook — test-only change in headless.

## Review focus

The reader is a regex over Python source, which is a heuristic, not a parser: an adapter that builds a container path through a variable or an f-string is still invisible to it. That limit is unchanged from #2298; what changes here is that the limit is now the same on both sides and is stated in one place instead of being an accident of which directory the matcher scanned.
