### PR TITLE
feat(headless): scan a finished run's trajectories for retrieval

### DIFF
--- a/packages/headless/harbor/run-contamination-scan.mjs
+++ b/packages/headless/harbor/run-contamination-scan.mjs
@@ -43,10 +43,25 @@ function parseArgs(argv) {
 
 export async function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
-  const report = await scanRunForContamination({
-    trialCellLogPath: trialCellLogPath(args['run-root']),
-    identity: flattenBenchmarkIdentity(BENCHMARK_IDENTITY),
-  });
+  const logPath = trialCellLogPath(args['run-root']);
+  let report;
+  try {
+    report = await scanRunForContamination({
+      trialCellLogPath: logPath,
+      identity: flattenBenchmarkIdentity(BENCHMARK_IDENTITY),
+    });
+  } catch (error) {
+    // No log at all is not "this run is clean" and not a crash to read a stack
+    // trace out of. It is either a run whose every cell died before a trial
+    // directory existed, or a run root that never wrote one — and the two are
+    // not distinguishable from here, so say what is missing and stop.
+    if (error?.code === 'ENOENT') {
+      throw new Error(
+        `no cell log at ${logPath}: this run recorded no trial, or is not a harness run root`,
+      );
+    }
+    throw error;
+  }
   if (args.json) await writeFile(args.json, `${JSON.stringify(report, null, 2)}\n`);
   const markdown = renderContaminationScanReportMarkdown(report);
   if (args.markdown) await writeFile(args.markdown, markdown);

--- a/packages/headless/harbor/run-contamination-scan.mjs
+++ b/packages/headless/harbor/run-contamination-scan.mjs
@@ -16,7 +16,8 @@
  */
 
 import { realpathSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   flattenBenchmarkIdentity,
@@ -41,34 +42,56 @@ function parseArgs(argv) {
   return args;
 }
 
-export async function main(argv = process.argv.slice(2)) {
-  const args = parseArgs(argv);
-  const logPath = trialCellLogPath(args['run-root']);
-  let report;
+/**
+ * The grid the run declared it would grade, read from its own manifest.
+ *
+ * Whether the cell log holds the whole run is a fact about the run, and the
+ * run wrote it down: every arm crossed with every evaluation task. Without it
+ * a run killed at cell three certifies the three cells that reached disk.
+ */
+async function expectedCells(runRoot) {
+  const path = join(runRoot, 'harness-ab-manifest.json');
+  let manifest;
   try {
-    report = await scanRunForContamination({
-      trialCellLogPath: logPath,
-      identity: flattenBenchmarkIdentity(BENCHMARK_IDENTITY),
-    });
+    manifest = JSON.parse(await readFile(path, 'utf8'));
   } catch (error) {
-    // No log at all is not "this run is clean" and not a crash to read a stack
-    // trace out of. It is either a run whose every cell died before a trial
-    // directory existed, or a run root that never wrote one — and the two are
-    // not distinguishable from here, so say what is missing and stop.
     if (error?.code === 'ENOENT') {
-      throw new Error(
-        `no cell log at ${logPath}: this run recorded no trial, or is not a harness run root`,
-      );
+      throw new Error(`no run manifest at ${path}: this is not a harness run root`);
     }
     throw error;
   }
+  const armIds = (manifest.arms ?? []).map((arm) => arm?.id);
+  const taskIds = manifest.evaluationTaskIds;
+  if (armIds.length === 0 || armIds.some((id) => typeof id !== 'string')) {
+    throw new Error(`${path} declares no arm ids`);
+  }
+  if (!Array.isArray(taskIds) || taskIds.length === 0) {
+    throw new Error(`${path} declares no evaluation task ids`);
+  }
+  // One cell per arm per task holds only while the harness schedules a single
+  // rep. A manifest that says otherwise is a grid this cannot describe, and
+  // guessing at it would under-count the run it is meant to bound.
+  if (manifest.reps !== undefined && manifest.reps !== 1) {
+    throw new Error(`${path} declares reps=${manifest.reps}; this scan assumes one rep per cell`);
+  }
+  return armIds.flatMap((agent) => taskIds.map((taskId) => ({ agent, taskId })));
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const report = await scanRunForContamination({
+    trialCellLogPath: trialCellLogPath(args['run-root']),
+    identity: flattenBenchmarkIdentity(BENCHMARK_IDENTITY),
+    expectedCells: await expectedCells(args['run-root']),
+  });
   if (args.json) await writeFile(args.json, `${JSON.stringify(report, null, 2)}\n`);
   const markdown = renderContaminationScanReportMarkdown(report);
   if (args.markdown) await writeFile(args.markdown, markdown);
   else process.stdout.write(markdown);
-  // Three things make this non-zero, and each is something a person has to act
-  // on: a cell that went and got something, a trajectory that could not be
-  // searched, and a run in which nothing at all was read.
+  // Four things make this non-zero, and each is something a person has to act
+  // on: a cell that went and got something, a cell the run declared and never
+  // recorded, a trajectory that could not be searched, and a run in which
+  // nothing at all was read.
   //
   // The last is the one worth spelling out. A zero exit is read as "no
   // contamination", so a run whose output never landed — cells declared, none
@@ -82,6 +105,7 @@ export async function main(argv = process.argv.slice(2)) {
   // that needs judgement rather than action belongs.
   const unsearched = report.totals.cells - report.totals.analyzed;
   return report.totals.cellsWithRetrievalSignals > 0 ||
+    report.unrecordedCells.length > 0 ||
     unsearched > 0 ||
     report.totals.analyzed === 0
     ? 1

--- a/packages/headless/harbor/run-contamination-scan.mjs
+++ b/packages/headless/harbor/run-contamination-scan.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Scan a finished run's trajectories for signs an arm looked the answer up.
+ *
+ * Host-only, like everything else in this directory that touches benchmark
+ * identity: the scan needs the upstream URL, pinned revision and task list to
+ * search for, and those are exactly what must not be reachable from inside a
+ * graded container. The scanner in `dist` holds none of them — it takes them as
+ * an argument, and this is where they are loaded.
+ *
+ * Which cells exist is likewise not this file's inference. The run wrote them
+ * down as it went; this reads that list.
+ *
+ * Usage:
+ *   node run-contamination-scan.mjs --run-root <dir> [--json <path>] [--markdown <path>]
+ */
+
+import { realpathSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import {
+  flattenBenchmarkIdentity,
+  renderContaminationScanReportMarkdown,
+  scanRunForContamination,
+} from '#harness-contamination-scan';
+import { trialCellLogPath } from '#trial-cell-log';
+import { BENCHMARK_IDENTITY } from './benchmark-identity.mjs';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (flag === '--run-root' || flag === '--json' || flag === '--markdown') {
+      if (!value) throw new Error(`${flag} requires a value`);
+      args[flag.slice(2)] = value;
+      index += 1;
+    } else throw new Error(`unknown argument ${flag}`);
+  }
+  if (!args['run-root']) throw new Error('--run-root is required');
+  return args;
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const report = await scanRunForContamination({
+    trialCellLogPath: trialCellLogPath(args['run-root']),
+    identity: flattenBenchmarkIdentity(BENCHMARK_IDENTITY),
+  });
+  if (args.json) await writeFile(args.json, `${JSON.stringify(report, null, 2)}\n`);
+  const markdown = renderContaminationScanReportMarkdown(report);
+  if (args.markdown) await writeFile(args.markdown, markdown);
+  else process.stdout.write(markdown);
+  // Three things make this non-zero, and each is something a person has to act
+  // on: a cell that went and got something, a trajectory that could not be
+  // searched, and a run in which nothing at all was read.
+  //
+  // The last is the one worth spelling out. A zero exit is read as "no
+  // contamination", so a run whose output never landed — cells declared, none
+  // searched — must not return it: that would be a verdict on no evidence, the
+  // thing this whole tool exists to refuse. Zero means cells were searched and
+  // came back clean.
+  //
+  // What is deliberately *not* here: task-id mentions on their own, which a
+  // model can produce from what it already knew. An alarm that fires on every
+  // run is not an alarm. They are counted in the report, which is where a fact
+  // that needs judgement rather than action belongs.
+  const unsearched = report.totals.cells - report.totals.analyzed;
+  return report.totals.cellsWithRetrievalSignals > 0 ||
+    unsearched > 0 ||
+    report.totals.analyzed === 0
+    ? 1
+    : 0;
+}
+
+// Compared as real paths, not as strings. A tool whose whole contract is its
+// exit code must not silently do nothing and return zero because it was
+// invoked through a symlink — which on macOS is every path under `/tmp`.
+if (
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))
+) {
+  main().then(
+    (code) => process.exit(code),
+    (error) => {
+      process.stderr.write(`${error.stack ?? error}\n`);
+      process.exit(2);
+    },
+  );
+}

--- a/packages/headless/harbor/run-contamination-scan.mjs
+++ b/packages/headless/harbor/run-contamination-scan.mjs
@@ -16,15 +16,14 @@
  */
 
 import { realpathSync } from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import {
   flattenBenchmarkIdentity,
   renderContaminationScanReportMarkdown,
   scanRunForContamination,
 } from '#harness-contamination-scan';
-import { trialCellLogPath } from '#trial-cell-log';
+import { readScheduledCellLog, scheduledCellLogPath, trialCellLogPath } from '#trial-cell-log';
 import { BENCHMARK_IDENTITY } from './benchmark-identity.mjs';
 
 function parseArgs(argv) {
@@ -43,38 +42,27 @@ function parseArgs(argv) {
 }
 
 /**
- * The grid the run declared it would grade, read from its own manifest.
+ * The grid the run put on its schedule, read from the run's own record of it.
  *
  * Whether the cell log holds the whole run is a fact about the run, and the
- * run wrote it down: every arm crossed with every evaluation task. Without it
- * a run killed at cell three certifies the three cells that reached disk.
+ * run wrote it down as it scheduled. Without it a run killed at cell three
+ * certifies the three cells that reached disk. Deriving it instead from the
+ * frozen manifest would be a guess: that file holds the benchmark's whole task
+ * list, of which a run grades a slice.
  */
 async function expectedCells(runRoot) {
-  const path = join(runRoot, 'harness-ab-manifest.json');
-  let manifest;
+  const path = scheduledCellLogPath(runRoot);
+  let cells;
   try {
-    manifest = JSON.parse(await readFile(path, 'utf8'));
+    cells = await readScheduledCellLog(path);
   } catch (error) {
     if (error?.code === 'ENOENT') {
-      throw new Error(`no run manifest at ${path}: this is not a harness run root`);
+      throw new Error(`no scheduled-cell log at ${path}: this is not a harness run root`);
     }
     throw error;
   }
-  const armIds = (manifest.arms ?? []).map((arm) => arm?.id);
-  const taskIds = manifest.evaluationTaskIds;
-  if (armIds.length === 0 || armIds.some((id) => typeof id !== 'string')) {
-    throw new Error(`${path} declares no arm ids`);
-  }
-  if (!Array.isArray(taskIds) || taskIds.length === 0) {
-    throw new Error(`${path} declares no evaluation task ids`);
-  }
-  // One cell per arm per task holds only while the harness schedules a single
-  // rep. A manifest that says otherwise is a grid this cannot describe, and
-  // guessing at it would under-count the run it is meant to bound.
-  if (manifest.reps !== undefined && manifest.reps !== 1) {
-    throw new Error(`${path} declares reps=${manifest.reps}; this scan assumes one rep per cell`);
-  }
-  return armIds.flatMap((agent) => taskIds.map((taskId) => ({ agent, taskId })));
+  if (cells.length === 0) throw new Error(`${path} names no cells`);
+  return cells;
 }
 
 export async function main(argv = process.argv.slice(2)) {

--- a/packages/headless/harbor/run-contamination-scan.mjs
+++ b/packages/headless/harbor/run-contamination-scan.mjs
@@ -83,9 +83,9 @@ export async function main(argv = process.argv.slice(2)) {
   // Together they say what a zero exit means: every cell the run scheduled was
   // recorded, and every recorded cell was searched and came back clean. A zero
   // exit is read as "no contamination", so it must never be a verdict on
-  // evidence that does not exist. `analyzed === 0` is the backstop for that,
-  // and while `expectedCells` refuses an empty grid nothing can reach it
-  // without one of the three above firing first.
+  // evidence that does not exist — and it cannot be, because `expectedCells`
+  // refuses an empty grid, so a run that searched nothing has cells to account
+  // for and fails on one of the two below.
   //
   // What is deliberately *not* here: task-id mentions on their own, which a
   // model can produce from what it already knew. An alarm that fires on every
@@ -94,8 +94,7 @@ export async function main(argv = process.argv.slice(2)) {
   const unsearched = report.totals.cells - report.totals.analyzed;
   return report.totals.cellsWithRetrievalSignals > 0 ||
     report.unrecordedCells.length > 0 ||
-    unsearched > 0 ||
-    report.totals.analyzed === 0
+    unsearched > 0
     ? 1
     : 0;
 }

--- a/packages/headless/harbor/run-contamination-scan.mjs
+++ b/packages/headless/harbor/run-contamination-scan.mjs
@@ -57,7 +57,9 @@ async function expectedCells(runRoot) {
     cells = await readScheduledCellLog(path);
   } catch (error) {
     if (error?.code === 'ENOENT') {
-      throw new Error(`no scheduled-cell log at ${path}: this is not a harness run root`);
+      throw new Error(
+        `no schedule recorded at ${path}: either this is not a harness run root, or the run died before it scheduled`,
+      );
     }
     throw error;
   }

--- a/packages/headless/harbor/run-contamination-scan.mjs
+++ b/packages/headless/harbor/run-contamination-scan.mjs
@@ -76,16 +76,16 @@ export async function main(argv = process.argv.slice(2)) {
   const markdown = renderContaminationScanReportMarkdown(report);
   if (args.markdown) await writeFile(args.markdown, markdown);
   else process.stdout.write(markdown);
-  // Four things make this non-zero, and each is something a person has to act
-  // on: a cell that went and got something, a cell the run declared and never
-  // recorded, a trajectory that could not be searched, and a run in which
-  // nothing at all was read.
+  // Three things make this non-zero, and each is something a person has to act
+  // on: a cell that went and got something, a cell the run scheduled and never
+  // recorded, and a trajectory that could not be searched.
   //
-  // The last is the one worth spelling out. A zero exit is read as "no
-  // contamination", so a run whose output never landed — cells declared, none
-  // searched — must not return it: that would be a verdict on no evidence, the
-  // thing this whole tool exists to refuse. Zero means cells were searched and
-  // came back clean.
+  // Together they say what a zero exit means: every cell the run scheduled was
+  // recorded, and every recorded cell was searched and came back clean. A zero
+  // exit is read as "no contamination", so it must never be a verdict on
+  // evidence that does not exist. `analyzed === 0` is the backstop for that,
+  // and while `expectedCells` refuses an empty grid nothing can reach it
+  // without one of the three above firing first.
   //
   // What is deliberately *not* here: task-id mentions on their own, which a
   // model can produce from what it already knew. An alarm that fires on every

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -17,6 +17,7 @@ import {
 } from '#fixed-prompt-task-source';
 import { createHarborTaskRunner, MAKA_SETTLEMENT_GRACE_SEC } from '#harbor-task-runner';
 import { createPierProviderProxyHub, createPierTaskRunner } from '#pier-task-runner';
+import { trialCellLogPath } from '#trial-cell-log';
 import {
   buildHarnessOracleExecutionPolicyFingerprint,
   HARBOR_ORACLE_DOCKER_PLATFORM,
@@ -1338,6 +1339,10 @@ async function runLocked({
       const runnerOptions = {
         makaRepoPath,
         jobsDir,
+        // One row per finished trial, so a later reader — the contamination
+        // scan — takes the run's cells from the run instead of rebuilding them
+        // out of the tree.
+        trialCellLogPath: trialCellLogPath(runRoot),
         model: execution.modelSpec,
         provider: execution.provider,
         reasoningEffort: execution.reasoningEffort,

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -17,7 +17,7 @@ import {
 } from '#fixed-prompt-task-source';
 import { createHarborTaskRunner, MAKA_SETTLEMENT_GRACE_SEC } from '#harbor-task-runner';
 import { createPierProviderProxyHub, createPierTaskRunner } from '#pier-task-runner';
-import { appendScheduledCells, scheduledCellLogPath, trialCellLogPath } from '#trial-cell-log';
+import { trialCellLogPath } from '#trial-cell-log';
 import {
   buildHarnessOracleExecutionPolicyFingerprint,
   HARBOR_ORACLE_DOCKER_PLATFORM,
@@ -1295,15 +1295,6 @@ async function runLocked({
     .map((taskId) => tasksById.get(taskId));
   if (evaluationTasks.some((task) => !task))
     throw new Error('manifest contains a task absent from the frozen task source');
-  // The grid, written down where it is decided. The manifest holds the whole
-  // benchmark; this run grades the slice above, and a later reader that took
-  // the manifest for the schedule would call every canary an unfinished run.
-  await appendScheduledCells(
-    scheduledCellLogPath(runRoot),
-    manifest.arms.flatMap((arm) =>
-      evaluationTasks.map((task) => ({ agent: arm.id, taskId: task.id })),
-    ),
-  );
 
   const competitorToolchains = new Map(
     competitorProfiles.map((profile) => [

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -17,7 +17,7 @@ import {
 } from '#fixed-prompt-task-source';
 import { createHarborTaskRunner, MAKA_SETTLEMENT_GRACE_SEC } from '#harbor-task-runner';
 import { createPierProviderProxyHub, createPierTaskRunner } from '#pier-task-runner';
-import { trialCellLogPath } from '#trial-cell-log';
+import { appendScheduledCells, scheduledCellLogPath, trialCellLogPath } from '#trial-cell-log';
 import {
   buildHarnessOracleExecutionPolicyFingerprint,
   HARBOR_ORACLE_DOCKER_PLATFORM,
@@ -1295,6 +1295,15 @@ async function runLocked({
     .map((taskId) => tasksById.get(taskId));
   if (evaluationTasks.some((task) => !task))
     throw new Error('manifest contains a task absent from the frozen task source');
+  // The grid, written down where it is decided. The manifest holds the whole
+  // benchmark; this run grades the slice above, and a later reader that took
+  // the manifest for the schedule would call every canary an unfinished run.
+  await appendScheduledCells(
+    scheduledCellLogPath(runRoot),
+    manifest.arms.flatMap((arm) =>
+      evaluationTasks.map((task) => ({ agent: arm.id, taskId: task.id })),
+    ),
+  );
 
   const competitorToolchains = new Map(
     competitorProfiles.map((profile) => [

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -39,6 +39,7 @@
     "#ab-manifest": "./dist/ab-manifest.js",
     "#prompt-ab-run": "./dist/prompt-ab-run.js",
     "#harbor-task-runner": "./dist/harbor-task-runner.js",
+    "#trial-cell-log": "./dist/trial-cell-log.js",
     "#pier-task-runner": "./dist/pier-task-runner.js",
     "#harbor-smoke-config": "./dist/harbor-smoke-config.js",
     "#provider-env": "./dist/provider-env.js",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -39,6 +39,7 @@
     "#ab-manifest": "./dist/ab-manifest.js",
     "#prompt-ab-run": "./dist/prompt-ab-run.js",
     "#harbor-task-runner": "./dist/harbor-task-runner.js",
+    "#harness-contamination-scan": "./dist/harness-contamination-scan.js",
     "#trial-cell-log": "./dist/trial-cell-log.js",
     "#pier-task-runner": "./dist/pier-task-runner.js",
     "#harbor-smoke-config": "./dist/harbor-smoke-config.js",

--- a/packages/headless/src/__tests__/contamination-scan-cli.test.ts
+++ b/packages/headless/src/__tests__/contamination-scan-cli.test.ts
@@ -7,7 +7,12 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { describe, test } from 'node:test';
 import type { ContaminationScanReport } from '../harness-contamination-scan.js';
-import { appendTrialCell, trialCellLogPath } from '../trial-cell-log.js';
+import {
+  appendScheduledCells,
+  appendTrialCell,
+  scheduledCellLogPath,
+  trialCellLogPath,
+} from '../trial-cell-log.js';
 
 const execFileAsync = promisify(execFile);
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
@@ -46,19 +51,23 @@ interface Cell {
 }
 
 /**
- * A run root the way the harness leaves one: the manifest it declared, and the
- * cells it recorded. The manifest comes from the harness's own builder, and the
- * arms come back out of it, so a test cannot agree with the scan about a grid
- * neither shares with the run.
+ * A run root the way the harness leaves one: the grid it scheduled, and the
+ * cells it recorded. The arm ids come from the harness's own manifest builder,
+ * so a test cannot agree with the scan about a composition neither shares with
+ * the run.
  *
- * Every arm/task pair the manifest declares gets a recorded cell unless the
- * caller asks for it to be missing. A cell the caller did not describe is an
- * ordinary clean one: the background a finding needs to stand out against.
+ * Every scheduled arm/task pair gets a recorded cell unless the caller asks
+ * for it to be missing. A cell the caller did not describe is an ordinary
+ * clean one: the background a finding needs to stand out against.
  */
 async function withRunRoot<T>(
   cells: Cell[],
   fn: (runRoot: string, armIds: string[]) => Promise<T>,
-  options: { unrecorded?: (agent: string, taskId: string) => boolean } = {},
+  options: {
+    unrecorded?: (agent: string, taskId: string) => boolean;
+    /** Tasks the frozen manifest names that this run did not put on its schedule. */
+    unscheduledManifestTaskIds?: string[];
+  } = {},
 ): Promise<T> {
   const runRoot = await mkdtemp(join(tmpdir(), 'maka-contamination-cli-'));
   try {
@@ -68,14 +77,19 @@ async function withRunRoot<T>(
       buildHarnessAbManifest: (input: Record<string, unknown>) => { arms: { id: string }[] };
     };
     const taskIds = [...new Set(cells.map((cell) => cell.taskId))];
+    const manifestTaskIds = [...taskIds, ...(options.unscheduledManifestTaskIds ?? [])];
     const manifest = buildHarnessAbManifest({
       subjectFingerprint: 'subject',
       taskSourceFingerprint: 'tasks',
       toolchainFingerprint: 'tools',
-      ...(taskIds.length > 0 ? { taskIds } : {}),
+      ...(manifestTaskIds.length > 0 ? { taskIds: manifestTaskIds } : {}),
     });
     await writeFile(join(runRoot, 'harness-ab-manifest.json'), JSON.stringify(manifest), 'utf8');
     const armIds = manifest.arms.map((arm) => arm.id);
+    await appendScheduledCells(
+      scheduledCellLogPath(runRoot),
+      armIds.flatMap((agent) => taskIds.map((taskId) => ({ agent, taskId }))),
+    );
     const grid = armIds.flatMap((agent) =>
       taskIds.map((taskId) => {
         const described = cells.find((cell) => cell.agent === agent && cell.taskId === taskId);
@@ -262,9 +276,9 @@ describe('run-contamination-scan', () => {
     );
   });
 
-  // Not a verdict and not a stack trace: a run root with no cell log is either
-  // a run that recorded nothing or the wrong directory, and the two cannot be
-  // told apart from here.
+  // Not a verdict and not a stack trace: a run root with no scheduled-cell log
+  // is either the wrong directory or a run that died before it scheduled, and
+  // the two cannot be told apart from here.
   test('says what is missing when a run root is not one', async () => {
     const empty = await mkdtemp(join(tmpdir(), 'maka-contamination-empty-'));
     try {
@@ -272,13 +286,34 @@ describe('run-contamination-scan', () => {
         execFileAsync(process.execPath, [SCRIPT, '--run-root', empty]),
         (error: { code?: number; stderr?: string }) => {
           assert.equal(error.code, 2);
-          assert.match(error.stderr ?? '', /no run manifest at .*harness-ab-manifest\.json/);
+          assert.match(error.stderr ?? '', /no scheduled-cell log at .*scheduled-cells\.jsonl/);
           return true;
         },
       );
     } finally {
       await rm(empty, { recursive: true, force: true });
     }
+  });
+
+  // A canary grades five of the benchmark's tasks and finishes. The frozen
+  // manifest beside it still names all of them — it is the same file the full
+  // run resumes against — so a scan that took the manifest for the schedule
+  // would call every complete canary an unfinished run.
+  test('passes a run that graded a slice of the benchmark and finished', async () => {
+    await withRunRoot(
+      [{ agent: 'maka', taskId: 'cobol-modernization', messages: ['ran the tests, 12 passed'] }],
+      async (runRoot, armIds) => {
+        const manifest = JSON.parse(
+          await readFile(join(runRoot, 'harness-ab-manifest.json'), 'utf8'),
+        ) as { evaluationTaskIds: string[] };
+        assert.ok(manifest.evaluationTaskIds.length > 1, 'manifest must over-declare the schedule');
+        const { code, report } = await scan(runRoot);
+        assert.equal(code, 0);
+        assert.deepEqual(report.unrecordedCells, []);
+        assert.equal(report.totals.analyzed, armIds.length);
+      },
+      { unscheduledManifestTaskIds: ['fix-git', 'raman-fitting'] },
+    );
   });
 
   test('refuses an invocation it cannot act on', async () => {

--- a/packages/headless/src/__tests__/contamination-scan-cli.test.ts
+++ b/packages/headless/src/__tests__/contamination-scan-cli.test.ts
@@ -41,13 +41,49 @@ async function benchmark(): Promise<{
 interface Cell {
   agent: string;
   taskId: string;
+  /** Absent means the cell recorded a row but never exported a trajectory. */
   messages?: string[];
 }
 
-async function withRunRoot<T>(cells: Cell[], fn: (runRoot: string) => Promise<T>): Promise<T> {
+/**
+ * A run root the way the harness leaves one: the manifest it declared, and the
+ * cells it recorded. The manifest comes from the harness's own builder, and the
+ * arms come back out of it, so a test cannot agree with the scan about a grid
+ * neither shares with the run.
+ *
+ * Every arm/task pair the manifest declares gets a recorded cell unless the
+ * caller asks for it to be missing. A cell the caller did not describe is an
+ * ordinary clean one: the background a finding needs to stand out against.
+ */
+async function withRunRoot<T>(
+  cells: Cell[],
+  fn: (runRoot: string, armIds: string[]) => Promise<T>,
+  options: { unrecorded?: (agent: string, taskId: string) => boolean } = {},
+): Promise<T> {
   const runRoot = await mkdtemp(join(tmpdir(), 'maka-contamination-cli-'));
   try {
-    for (const [index, cell] of cells.entries()) {
+    const { buildHarnessAbManifest } = (await import(
+      new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
+    )) as {
+      buildHarnessAbManifest: (input: Record<string, unknown>) => { arms: { id: string }[] };
+    };
+    const taskIds = [...new Set(cells.map((cell) => cell.taskId))];
+    const manifest = buildHarnessAbManifest({
+      subjectFingerprint: 'subject',
+      taskSourceFingerprint: 'tasks',
+      toolchainFingerprint: 'tools',
+      ...(taskIds.length > 0 ? { taskIds } : {}),
+    });
+    await writeFile(join(runRoot, 'harness-ab-manifest.json'), JSON.stringify(manifest), 'utf8');
+    const armIds = manifest.arms.map((arm) => arm.id);
+    const grid = armIds.flatMap((agent) =>
+      taskIds.map((taskId) => {
+        const described = cells.find((cell) => cell.agent === agent && cell.taskId === taskId);
+        return described ?? { agent, taskId, messages: ['ran the tests, 12 passed'] };
+      }),
+    );
+    for (const [index, cell] of grid.entries()) {
+      if (options.unrecorded?.(cell.agent, cell.taskId)) continue;
       const trialDir = join(runRoot, 'jobs', `${cell.agent}-${index}`, 'trial');
       await mkdir(join(trialDir, 'agent'), { recursive: true });
       if (cell.messages) {
@@ -67,7 +103,7 @@ async function withRunRoot<T>(cells: Cell[], fn: (runRoot: string) => Promise<T>
         trialDir,
       });
     }
-    return await fn(runRoot);
+    return await fn(runRoot, armIds);
   } finally {
     await rm(runRoot, { recursive: true, force: true });
   }
@@ -87,14 +123,12 @@ async function scan(runRoot: string): Promise<{ code: number; report: Contaminat
 describe('run-contamination-scan', () => {
   test('exits zero only after actually searching cells and finding nothing', async () => {
     await withRunRoot(
-      [
-        { agent: 'maka', taskId: 'cobol-modernization', messages: ['ran the tests, 12 passed'] },
-        { agent: 'codex', taskId: 'fix-git', messages: ['rewrote the reflog by hand'] },
-      ],
-      async (runRoot) => {
+      [{ agent: 'maka', taskId: 'cobol-modernization', messages: ['ran the tests, 12 passed'] }],
+      async (runRoot, armIds) => {
         const { code, report } = await scan(runRoot);
         assert.equal(code, 0);
-        assert.equal(report.totals.analyzed, 2);
+        assert.equal(report.totals.analyzed, armIds.length);
+        assert.deepEqual(report.unrecordedCells, []);
       },
     );
   });
@@ -120,10 +154,7 @@ describe('run-contamination-scan', () => {
       test(label, async () => {
         const message = await evidence();
         await withRunRoot(
-          [
-            { agent: 'maka', taskId: 'cobol-modernization', messages: [message] },
-            { agent: 'codex', taskId: 'fix-git', messages: ['rewrote the reflog by hand'] },
-          ],
+          [{ agent: 'maka', taskId: 'cobol-modernization', messages: [message] }],
           async (runRoot) => {
             const { code, report } = await scan(runRoot);
             assert.equal(code, 1);
@@ -137,7 +168,7 @@ describe('run-contamination-scan', () => {
   test('writes the report where it was asked to', async () => {
     await withRunRoot(
       [{ agent: 'maka', taskId: 'cobol-modernization', messages: ['ran the tests'] }],
-      async (runRoot) => {
+      async (runRoot, armIds) => {
         const markdownPath = join(runRoot, 'report.md');
         await execFileAsync(process.execPath, [
           SCRIPT,
@@ -146,7 +177,10 @@ describe('run-contamination-scan', () => {
           '--markdown',
           markdownPath,
         ]);
-        assert.match(await readFile(markdownPath, 'utf8'), /Searched 1 of 1 recorded cells\./);
+        assert.match(
+          await readFile(markdownPath, 'utf8'),
+          new RegExp(`Searched ${armIds.length} of ${armIds.length} recorded cells\\.`),
+        );
       },
     );
   });
@@ -164,27 +198,49 @@ describe('run-contamination-scan', () => {
   // A cell whose trajectory never landed was not searched, and a zero exit here
   // would be a verdict on evidence that does not exist.
   test('exits non-zero when a declared cell could not be searched', async () => {
+    await withRunRoot([{ agent: 'maka', taskId: 'cobol-modernization' }], async (runRoot) => {
+      const { code, report } = await scan(runRoot);
+      assert.equal(code, 1);
+      assert.equal(report.coverageByAgent.maka?.analyzed, 0);
+      assert.deepEqual(report.unrecordedCells, []);
+    });
+  });
+
+  // Every cell the run declared is missing. Nothing was searched, and the
+  // report says so rather than certifying the empty set.
+  test('exits non-zero on a run in which nothing was read at all', async () => {
     await withRunRoot(
-      [
-        { agent: 'maka', taskId: 'cobol-modernization' },
-        { agent: 'codex', taskId: 'fix-git', messages: ['rewrote the reflog by hand'] },
-      ],
-      async (runRoot) => {
+      [{ agent: 'maka', taskId: 'cobol-modernization', messages: ['ran the tests'] }],
+      async (runRoot, armIds) => {
         const { code, report } = await scan(runRoot);
         assert.equal(code, 1);
-        assert.equal(report.totals.analyzed, 1);
-        assert.equal(report.coverageByAgent.maka?.analyzed, 0);
+        assert.equal(report.totals.cells, 0);
+        assert.equal(report.unrecordedCells.length, armIds.length);
       },
+      { unrecorded: () => true },
     );
   });
 
-  test('exits non-zero on a run in which nothing was read at all', async () => {
-    await withRunRoot([], async (runRoot) => {
-      await writeFile(trialCellLogPath(runRoot), '', 'utf8');
-      const { code, report } = await scan(runRoot);
-      assert.equal(code, 1);
-      assert.equal(report.totals.cells, 0);
-    });
+  // Every recorded cell was searched and came back clean, so nothing but the
+  // missing cells stands between this run and a zero exit. A run killed part
+  // way through looks exactly like this.
+  test('exits non-zero when the run declared cells it never recorded', async () => {
+    await withRunRoot(
+      [{ agent: 'maka', taskId: 'cobol-modernization', messages: ['ran the tests, 12 passed'] }],
+      async (runRoot, armIds) => {
+        const { code, report } = await scan(runRoot);
+        assert.equal(code, 1);
+        assert.equal(report.totals.cells, report.totals.analyzed);
+        assert.equal(report.totals.cellsWithRetrievalSignals, 0);
+        assert.deepEqual(
+          report.unrecordedCells,
+          armIds
+            .filter((armId) => armId !== 'maka')
+            .map((agent) => ({ agent, taskId: 'cobol-modernization' })),
+        );
+      },
+      { unrecorded: (agent) => agent !== 'maka' },
+    );
   });
 
   // A model can name this suite's tasks from what it read years ago. An alarm
@@ -209,14 +265,14 @@ describe('run-contamination-scan', () => {
   // Not a verdict and not a stack trace: a run root with no cell log is either
   // a run that recorded nothing or the wrong directory, and the two cannot be
   // told apart from here.
-  test('says what is missing when a run root has no cell log', async () => {
+  test('says what is missing when a run root is not one', async () => {
     const empty = await mkdtemp(join(tmpdir(), 'maka-contamination-empty-'));
     try {
       await assert.rejects(
         execFileAsync(process.execPath, [SCRIPT, '--run-root', empty]),
         (error: { code?: number; stderr?: string }) => {
           assert.equal(error.code, 2);
-          assert.match(error.stderr ?? '', /no cell log at .*trial-cells\.jsonl/);
+          assert.match(error.stderr ?? '', /no run manifest at .*harness-ab-manifest\.json/);
           return true;
         },
       );

--- a/packages/headless/src/__tests__/contamination-scan-cli.test.ts
+++ b/packages/headless/src/__tests__/contamination-scan-cli.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { describe, test } from 'node:test';
+import type { ContaminationScanReport } from '../harness-contamination-scan.js';
+import { appendTrialCell, trialCellLogPath } from '../trial-cell-log.js';
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const SCRIPT = join(REPO_ROOT, 'packages/headless/harbor/run-contamination-scan.mjs');
+
+/**
+ * The upstream this run was graded against, read at run time rather than
+ * written down.
+ *
+ * This file compiles into `dist`, which the Maka arm mounts. A revision or an
+ * upstream URL spelled out here would be the leak the scan exists to find, so
+ * it is loaded from the same host-only JSON the scan loads it from.
+ */
+async function upstreamRepositoryUrl(): Promise<string> {
+  const catalog = JSON.parse(
+    await readFile(join(REPO_ROOT, 'packages/headless/harbor/benchmark-identity.json'), 'utf8'),
+  ) as { terminalBench21: { upstreamRepositoryUrl: string } };
+  return catalog.terminalBench21.upstreamRepositoryUrl;
+}
+
+interface Cell {
+  agent: string;
+  taskId: string;
+  messages?: string[];
+}
+
+async function withRunRoot<T>(cells: Cell[], fn: (runRoot: string) => Promise<T>): Promise<T> {
+  const runRoot = await mkdtemp(join(tmpdir(), 'maka-contamination-cli-'));
+  try {
+    for (const [index, cell] of cells.entries()) {
+      const trialDir = join(runRoot, 'jobs', `${cell.agent}-${index}`, 'trial');
+      await mkdir(join(trialDir, 'agent'), { recursive: true });
+      if (cell.messages) {
+        await writeFile(
+          join(trialDir, 'agent', 'trajectory.json'),
+          JSON.stringify({
+            steps: cell.messages.map((message, step) => ({ step_id: step + 1, message })),
+          }),
+          'utf8',
+        );
+      }
+      await appendTrialCell(trialCellLogPath(runRoot), {
+        runId: 'run-1',
+        roundId: `${cell.agent}-r0-${cell.taskId}`,
+        taskId: cell.taskId,
+        agent: cell.agent,
+        trialDir,
+      });
+    }
+    return await fn(runRoot);
+  } finally {
+    await rm(runRoot, { recursive: true, force: true });
+  }
+}
+
+async function scan(runRoot: string): Promise<{ code: number; report: ContaminationScanReport }> {
+  const jsonPath = join(runRoot, 'report.json');
+  let code = 0;
+  try {
+    await execFileAsync(process.execPath, [SCRIPT, '--run-root', runRoot, '--json', jsonPath]);
+  } catch (error) {
+    code = (error as { code?: number }).code ?? -1;
+  }
+  return { code, report: JSON.parse(await readFile(jsonPath, 'utf8')) as ContaminationScanReport };
+}
+
+describe('run-contamination-scan', () => {
+  test('exits zero only after actually searching cells and finding nothing', async () => {
+    await withRunRoot(
+      [
+        { agent: 'maka', taskId: 'cobol-modernization', messages: ['ran the tests, 12 passed'] },
+        { agent: 'codex', taskId: 'fix-git', messages: ['rewrote the reflog by hand'] },
+      ],
+      async (runRoot) => {
+        const { code, report } = await scan(runRoot);
+        assert.equal(code, 0);
+        assert.equal(report.totals.analyzed, 2);
+      },
+    );
+  });
+
+  test('exits non-zero on evidence a cell went and got the benchmark', async () => {
+    const upstream = await upstreamRepositoryUrl();
+    await withRunRoot(
+      [
+        { agent: 'maka', taskId: 'cobol-modernization', messages: [`git clone ${upstream}.git`] },
+        { agent: 'codex', taskId: 'fix-git', messages: ['rewrote the reflog by hand'] },
+      ],
+      async (runRoot) => {
+        const { code, report } = await scan(runRoot);
+        assert.equal(code, 1);
+        assert.equal(report.totals.cellsWithRetrievalSignals, 1);
+      },
+    );
+  });
+
+  // A cell whose trajectory never landed was not searched, and a zero exit here
+  // would be a verdict on evidence that does not exist.
+  test('exits non-zero when a declared cell could not be searched', async () => {
+    await withRunRoot(
+      [
+        { agent: 'maka', taskId: 'cobol-modernization' },
+        { agent: 'codex', taskId: 'fix-git', messages: ['rewrote the reflog by hand'] },
+      ],
+      async (runRoot) => {
+        const { code, report } = await scan(runRoot);
+        assert.equal(code, 1);
+        assert.equal(report.totals.analyzed, 1);
+        assert.equal(report.coverageByAgent.maka?.analyzed, 0);
+      },
+    );
+  });
+
+  test('exits non-zero on a run in which nothing was read at all', async () => {
+    await withRunRoot([], async (runRoot) => {
+      await writeFile(trialCellLogPath(runRoot), '', 'utf8');
+      const { code, report } = await scan(runRoot);
+      assert.equal(code, 1);
+      assert.equal(report.totals.cells, 0);
+    });
+  });
+
+  // A model can name this suite's tasks from what it read years ago. An alarm
+  // that fires on that fires on every run.
+  test('does not fail a run on a task-id mention alone', async () => {
+    await withRunRoot(
+      [
+        {
+          agent: 'maka',
+          taskId: 'cobol-modernization',
+          messages: ['this suite also has fix-git, as I recall'],
+        },
+      ],
+      async (runRoot) => {
+        const { code, report } = await scan(runRoot);
+        assert.equal(code, 0);
+        assert.equal(report.totals.cellsWithAdvisorySignalsOnly, 1);
+      },
+    );
+  });
+
+  test('refuses an invocation it cannot act on', async () => {
+    await assert.rejects(execFileAsync(process.execPath, [SCRIPT]), (error: { code?: number }) => {
+      assert.equal(error.code, 2);
+      return true;
+    });
+  });
+});

--- a/packages/headless/src/__tests__/contamination-scan-cli.test.ts
+++ b/packages/headless/src/__tests__/contamination-scan-cli.test.ts
@@ -316,6 +316,26 @@ describe('run-contamination-scan', () => {
     );
   });
 
+  // A crash during the very first schedule row leaves the file present and
+  // empty. Reading that as "this run scheduled nothing" would make every cell
+  // it went on to grade unaccounted for and still certify the run.
+  test('refuses a schedule that names no cells', async () => {
+    const runRoot = await mkdtemp(join(tmpdir(), 'maka-contamination-torn-'));
+    try {
+      await writeFile(scheduledCellLogPath(runRoot), '', 'utf8');
+      await assert.rejects(
+        execFileAsync(process.execPath, [SCRIPT, '--run-root', runRoot]),
+        (error: { code?: number; stderr?: string }) => {
+          assert.equal(error.code, 2);
+          assert.match(error.stderr ?? '', /names no cells/);
+          return true;
+        },
+      );
+    } finally {
+      await rm(runRoot, { recursive: true, force: true });
+    }
+  });
+
   test('refuses an invocation it cannot act on', async () => {
     await assert.rejects(execFileAsync(process.execPath, [SCRIPT]), (error: { code?: number }) => {
       assert.equal(error.code, 2);

--- a/packages/headless/src/__tests__/contamination-scan-cli.test.ts
+++ b/packages/headless/src/__tests__/contamination-scan-cli.test.ts
@@ -286,7 +286,7 @@ describe('run-contamination-scan', () => {
         execFileAsync(process.execPath, [SCRIPT, '--run-root', empty]),
         (error: { code?: number; stderr?: string }) => {
           assert.equal(error.code, 2);
-          assert.match(error.stderr ?? '', /no scheduled-cell log at .*scheduled-cells\.jsonl/);
+          assert.match(error.stderr ?? '', /no schedule recorded at .*scheduled-cells\.jsonl/);
           return true;
         },
       );

--- a/packages/headless/src/__tests__/contamination-scan-cli.test.ts
+++ b/packages/headless/src/__tests__/contamination-scan-cli.test.ts
@@ -206,6 +206,25 @@ describe('run-contamination-scan', () => {
     );
   });
 
+  // Not a verdict and not a stack trace: a run root with no cell log is either
+  // a run that recorded nothing or the wrong directory, and the two cannot be
+  // told apart from here.
+  test('says what is missing when a run root has no cell log', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'maka-contamination-empty-'));
+    try {
+      await assert.rejects(
+        execFileAsync(process.execPath, [SCRIPT, '--run-root', empty]),
+        (error: { code?: number; stderr?: string }) => {
+          assert.equal(error.code, 2);
+          assert.match(error.stderr ?? '', /no cell log at .*trial-cells\.jsonl/);
+          return true;
+        },
+      );
+    } finally {
+      await rm(empty, { recursive: true, force: true });
+    }
+  });
+
   test('refuses an invocation it cannot act on', async () => {
     await assert.rejects(execFileAsync(process.execPath, [SCRIPT]), (error: { code?: number }) => {
       assert.equal(error.code, 2);

--- a/packages/headless/src/__tests__/contamination-scan-cli.test.ts
+++ b/packages/headless/src/__tests__/contamination-scan-cli.test.ts
@@ -21,11 +21,21 @@ const SCRIPT = join(REPO_ROOT, 'packages/headless/harbor/run-contamination-scan.
  * upstream URL spelled out here would be the leak the scan exists to find, so
  * it is loaded from the same host-only JSON the scan loads it from.
  */
-async function upstreamRepositoryUrl(): Promise<string> {
+async function benchmark(): Promise<{
+  upstreamRepositoryUrl: string;
+  revision: string;
+  taskTreeFingerprint: string;
+}> {
   const catalog = JSON.parse(
     await readFile(join(REPO_ROOT, 'packages/headless/harbor/benchmark-identity.json'), 'utf8'),
-  ) as { terminalBench21: { upstreamRepositoryUrl: string } };
-  return catalog.terminalBench21.upstreamRepositoryUrl;
+  ) as {
+    terminalBench21: {
+      upstreamRepositoryUrl: string;
+      revision: string;
+      taskTreeFingerprint: string;
+    };
+  };
+  return catalog.terminalBench21;
 }
 
 interface Cell {
@@ -89,17 +99,64 @@ describe('run-contamination-scan', () => {
     );
   });
 
-  test('exits non-zero on evidence a cell went and got the benchmark', async () => {
-    const upstream = await upstreamRepositoryUrl();
-    await withRunRoot(
+  // Each retrieval signal separately, through the real exit code. One of them
+  // standing in for the other two would let a change that quietly demotes a
+  // pinned revision to advisory pass everything but a single unit assertion.
+  describe('exits non-zero on evidence a cell went and got the benchmark', () => {
+    for (const [label, evidence] of [
       [
-        { agent: 'maka', taskId: 'cobol-modernization', messages: [`git clone ${upstream}.git`] },
-        { agent: 'codex', taskId: 'fix-git', messages: ['rewrote the reflog by hand'] },
+        'the upstream repository',
+        async () => `git clone ${(await benchmark()).upstreamRepositoryUrl}.git`,
       ],
+      [
+        'the pinned revision',
+        async () => `checked out ${(await benchmark()).revision.slice(0, 12)}`,
+      ],
+      [
+        'the task-tree fingerprint',
+        async () => `tree ${(await benchmark()).taskTreeFingerprint.replace(/^sha256:/, '')}`,
+      ],
+    ] as const) {
+      test(label, async () => {
+        const message = await evidence();
+        await withRunRoot(
+          [
+            { agent: 'maka', taskId: 'cobol-modernization', messages: [message] },
+            { agent: 'codex', taskId: 'fix-git', messages: ['rewrote the reflog by hand'] },
+          ],
+          async (runRoot) => {
+            const { code, report } = await scan(runRoot);
+            assert.equal(code, 1);
+            assert.equal(report.totals.cellsWithRetrievalSignals, 1);
+          },
+        );
+      });
+    }
+  });
+
+  test('writes the report where it was asked to', async () => {
+    await withRunRoot(
+      [{ agent: 'maka', taskId: 'cobol-modernization', messages: ['ran the tests'] }],
       async (runRoot) => {
-        const { code, report } = await scan(runRoot);
-        assert.equal(code, 1);
-        assert.equal(report.totals.cellsWithRetrievalSignals, 1);
+        const markdownPath = join(runRoot, 'report.md');
+        await execFileAsync(process.execPath, [
+          SCRIPT,
+          '--run-root',
+          runRoot,
+          '--markdown',
+          markdownPath,
+        ]);
+        assert.match(await readFile(markdownPath, 'utf8'), /Searched 1 of 1 recorded cells\./);
+      },
+    );
+  });
+
+  test('refuses a flag it does not know', async () => {
+    await assert.rejects(
+      execFileAsync(process.execPath, [SCRIPT, '--run-root', '/tmp', '--depth', '2']),
+      (error: { code?: number }) => {
+        assert.equal(error.code, 2);
+        return true;
       },
     );
   });

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -381,6 +381,29 @@ describe('createHarborTaskRunner', () => {
   // list from, so the row has to name the directory this trial's artifacts are
   // actually in — proven by reading one of them back out of the recorded path,
   // not by recomputing the path the same way the runner did.
+  // The row is written where the trial directory is resolved, before any
+  // grading, so a cell that then failed is still in the run's cell list — its
+  // artifacts are exactly the ones worth reading. Moving the append into the
+  // success branch would quietly drop them.
+  test('records a trial that then failed', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const logPath = join(jobsDir, 'trial-cells.jsonl');
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        trialCellLogPath: logPath,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({ cell: null, exitCodeAfterArtifacts: 1 }),
+      });
+
+      await assert.rejects(runner(runInput()));
+
+      const rows = await readTrialCellLog(logPath);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0]?.taskId, 'task-1');
+    });
+  });
+
   test('records the trial it read, in the directory it read it from', async () => {
     await withRun(async ({ jobsDir, repo }) => {
       const logPath = join(jobsDir, 'trial-cells.jsonl');

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -7,6 +7,7 @@ import { describe, test } from 'node:test';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 import { type HarborAgentEntry, harborAgentPhaseSec } from './helpers/harbor-agent-phase.js';
 import { competitorRepoFiles } from '../agent-repo-mount.js';
+import { readTrialCellLog } from '../trial-cell-log.js';
 import type { HarborCellExecutionIdentity, HarborCellOutput } from '../cell-output.js';
 import {
   FixedPromptBudgetExhaustedError,
@@ -376,6 +377,41 @@ async function budgetExhaustedWalEvent(input: {
 }
 
 describe('createHarborTaskRunner', () => {
+  // The cell log is what every later reader of a finished run takes its cell
+  // list from, so the row has to name the directory this trial's artifacts are
+  // actually in — proven by reading one of them back out of the recorded path,
+  // not by recomputing the path the same way the runner did.
+  test('records the trial it read, in the directory it read it from', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const logPath = join(jobsDir, 'trial-cells.jsonl');
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        trialCellLogPath: logPath,
+        agent: 'codex',
+        agentVersion: CODEX_TOOLCHAIN_SPEC.codex.version,
+        codexToolchainPath: join(repo, 'codex'),
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({ reward: '1\n' }),
+      });
+      await runner(runInput());
+
+      const rows = await readTrialCellLog(logPath);
+      assert.equal(rows.length, 1);
+      assert.deepEqual(
+        { runId: rows[0]?.runId, roundId: rows[0]?.roundId, taskId: rows[0]?.taskId },
+        { runId: 'run-1', roundId: 'round-1', taskId: 'task-1' },
+      );
+      assert.equal(rows[0]?.agent, 'codex');
+      assert.equal(
+        JSON.parse(
+          await readFile(join(rows[0]!.trialDir, 'agent', 'maka-cell-output.json'), 'utf8'),
+        ).status,
+        'completed',
+      );
+    });
+  });
+
   test('parses reward + cell output and rewrites runtime events to the host path', async () => {
     await withRun(async ({ jobsDir, repo, keyFile }) => {
       const runner = createHarborTaskRunner({

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -10,6 +10,7 @@ import { runHarnessAbComparison, runHarnessArmCohort } from '../harness-ab-run.j
 import type { HarnessAbArmId } from '../harness-ab-manifest.js';
 import { HarborInfraError } from '../harbor-task-runner.js';
 import { hashHeadlessSystemPrompt } from '../system-prompts.js';
+import { readScheduledCellLog, scheduledCellLogPath } from '../trial-cell-log.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 
 describe('runHarnessAbComparison', () => {
@@ -133,6 +134,45 @@ describe('runHarnessAbComparison', () => {
         (await readdir(dir)).filter((name) => name.endsWith('.tsv')),
         [],
       );
+      // The grid a later reader bounds this run by: everything either
+      // invocation went to grade, and nothing the benchmark merely contains.
+      assert.deepEqual(
+        (await readScheduledCellLog(scheduledCellLogPath(dir))).map(
+          (cell) => `${cell.taskId}:${cell.agent}`,
+        ),
+        ['a:maka', 'b:maka', 'a:opencode', 'b:opencode', 'c:maka', 'c:opencode'],
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Written where the cohort is handed over to be run, so it names the cells
+  // this run went to grade — not the benchmark's whole task list, of which a
+  // run grades a slice, and not a wider grid an earlier invocation planned and
+  // died before reaching.
+  test('records the grid it is about to grade, and only that', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-schedule-'));
+    try {
+      const promptPath = join(dir, 'empty-system-prompt.txt');
+      await writeFile(promptPath, '', 'utf8');
+      const calls: string[] = [];
+      await runHarnessAbComparison({
+        runId: 'glm-harness-ab',
+        runRoot: dir,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        systemPromptPath: promptPath,
+        resumeFingerprint: 'sha256:manifest',
+        evaluationTasks: ['a', 'b'].map((id) => ({ id, path: `/tasks/${id}` })),
+        arms: [harnessArm('maka', calls), harnessArm('opencode', calls)],
+      });
+      assert.deepEqual(
+        (await readScheduledCellLog(scheduledCellLogPath(dir))).map(
+          (cell) => `${cell.taskId}:${cell.agent}`,
+        ),
+        ['a:maka', 'b:maka', 'a:opencode', 'b:opencode'],
+      );
+      assert.deepEqual(new Set(calls), new Set(['a:maka', 'b:maka', 'a:opencode', 'b:opencode']));
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/__tests__/harness-contamination-scan.test.ts
+++ b/packages/headless/src/__tests__/harness-contamination-scan.test.ts
@@ -1,0 +1,428 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, test } from 'node:test';
+import { promisify } from 'node:util';
+import {
+  flattenBenchmarkIdentity,
+  isRetrievalSignal,
+  MIN_REVISION_PREFIX,
+  renderContaminationScanReportMarkdown,
+  scanRunForContamination,
+  scanTrajectory,
+  TRAJECTORY_ARTIFACT_KIND_FULL,
+  TRAJECTORY_ARTIFACT_KIND_KEY,
+  TRAJECTORY_ARTIFACT_KIND_SUMMARY,
+  TRAJECTORY_SUMMARY_REASON_KEY,
+  type BenchmarkIdentity,
+  type ContaminationSignalKind,
+} from '../harness-contamination-scan.js';
+import { appendTrialCell, trialCellLogPath } from '../trial-cell-log.js';
+
+const execFileAsync = promisify(execFile);
+const HARBOR_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'harbor');
+
+const identity: BenchmarkIdentity = {
+  upstreamRepositoryUrls: ['https://github.com/example-org/example-bench-2-1'],
+  revisions: ['0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d'],
+  taskTreeFingerprints: ['sha256:0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff'],
+  taskIds: ['cobol-modernization', 'fix-git', 'install-windows-3.11'],
+};
+
+function trajectory(messages: string[], extra?: Record<string, unknown>): unknown {
+  return {
+    steps: messages.map((message, index) => ({ step_id: index + 1, source: 'agent', message })),
+    ...(extra ? { extra } : {}),
+  };
+}
+
+function kinds(messages: string[], ownTaskId = 'cobol-modernization'): ContaminationSignalKind[] {
+  const result = scanTrajectory({ trajectory: trajectory(messages), ownTaskId, identity });
+  assert.equal(result.analyzed, true);
+  return result.signals.map((signal) => signal.kind);
+}
+
+describe('benchmark identity', () => {
+  test('flattens every profile the catalog carries into one set of needles', async () => {
+    const catalog = JSON.parse(
+      await readFile(join(HARBOR_DIR, 'benchmark-identity.json'), 'utf8'),
+    ) as Record<string, { upstreamRepositoryUrl: string }>;
+    const flat = flattenBenchmarkIdentity(catalog);
+
+    assert.deepEqual(
+      [...flat.upstreamRepositoryUrls].sort(),
+      [
+        catalog.deepSwe!.upstreamRepositoryUrl,
+        catalog.terminalBench21!.upstreamRepositoryUrl,
+      ].sort(),
+    );
+    // Terminal-Bench's tree plus DeepSWE's two subsets: a scan that took one
+    // profile's fingerprint would go looking for two thirds of the evidence.
+    assert.equal(flat.taskTreeFingerprints.length, 3);
+    assert.equal(flat.revisions.length, 2);
+    // Both benchmarks' task lists, deduplicated across the overlapping subsets.
+    assert.ok(flat.taskIds.includes('cobol-modernization'));
+    assert.ok(flat.taskIds.includes('dasel-html-document-format'));
+    assert.equal(new Set(flat.taskIds).size, flat.taskIds.length);
+  });
+
+  // The failure this guards is the quiet one: a renamed field turns every cell
+  // clean, and a clean report is exactly what a reader wants to see.
+  test('refuses a catalog that carries no needles', () => {
+    assert.throws(
+      () => flattenBenchmarkIdentity({ terminalBench21: { revision: 'abc' } }),
+      /no upstream repository or task ids/,
+    );
+  });
+});
+
+describe('scanTrajectory', () => {
+  test('finds nothing in a cell that solved its own task', () => {
+    assert.deepEqual(
+      kinds([
+        'Reading /app/task.md and porting the COBOL payroll routine.',
+        'Running the test suite: 12 passed.',
+      ]),
+      [],
+    );
+  });
+
+  test('finds each of the four signals', () => {
+    assert.deepEqual(kinds(['git clone https://github.com/example-org/example-bench-2-1']), [
+      'upstream_repository',
+    ]);
+    assert.deepEqual(kinds(['checked out 0a1b2c3d4e5']), ['pinned_revision']);
+    assert.deepEqual(
+      kinds(['tree hash sha256:0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff']),
+      ['task_tree_fingerprint'],
+    );
+    assert.deepEqual(kinds(['the suite also has fix-git']), ['foreign_task_id']);
+  });
+
+  // A cell that names its own task is describing its work, not reaching.
+  test("does not count the cell's own task id as foreign", () => {
+    assert.deepEqual(kinds(['solving cobol-modernization']), []);
+  });
+
+  test('reports the step and the surrounding text so a reviewer can go read it', () => {
+    const result = scanTrajectory({
+      trajectory: trajectory([
+        'first step',
+        'then: git clone https://github.com/example-org/example-bench-2-1.git /tmp/tb',
+      ]),
+      ownTaskId: 'cobol-modernization',
+      identity,
+    });
+    assert.equal(result.signals[0]?.stepId, 2);
+    assert.equal(result.signals[0]?.match, 'example-org/example-bench-2-1');
+    assert.match(result.signals[0]?.excerpt ?? '', /git clone/);
+  });
+
+  describe('the repository is matched by the name a rewritten host cannot drop', () => {
+    // Each of these reaches the same repository while dropping or replacing the
+    // host, which is why the pair rather than the URL is what is searched for.
+    for (const [label, text] of [
+      ['the .git spelling', 'git clone https://github.com/example-org/example-bench-2-1.git'],
+      ['ssh', 'git clone git@github.com:example-org/example-bench-2-1.git'],
+      ['a raw host', 'curl https://raw.githubusercontent.com/example-org/example-bench-2-1/main/x'],
+      ['an ip', 'curl http://140.82.121.4/example-org/example-bench-2-1/archive/main.tar.gz'],
+      ['a mirror', 'git clone https://gitee.com/mirrors/example-org/example-bench-2-1'],
+    ] as const) {
+      test(label, () => {
+        assert.deepEqual(kinds([text]), ['upstream_repository']);
+      });
+    }
+
+    test('does not read a longer name as this one', () => {
+      assert.deepEqual(kinds(['github.com/example-org/example-bench-2-1-extras']), []);
+      assert.deepEqual(kinds(['github.com/not-example-org/example-bench-2-1']), []);
+    });
+  });
+
+  describe('a task id is matched at its own boundaries', () => {
+    test('a dotted task id is found where it is named', () => {
+      assert.deepEqual(kinds(['see install-windows-3.11 for the trick']), ['foreign_task_id']);
+    });
+
+    // The dot at the end of a sentence belongs to the sentence.
+    test('a task id ending a sentence is found', () => {
+      assert.deepEqual(kinds(['the other one is fix-git.']), ['foreign_task_id']);
+    });
+
+    test('a longer id containing this one is not this one', () => {
+      assert.deepEqual(kinds(['fix-github-actions']), []);
+      assert.deepEqual(kinds(['install-windows-3.11.2-beta']), []);
+    });
+  });
+
+  describe('the revision prefix floor', () => {
+    test('matches what git itself would have shown the cell', () => {
+      assert.deepEqual(kinds([`rev ${identity.revisions[0]!.slice(0, MIN_REVISION_PREFIX)}`]), [
+        'pinned_revision',
+      ]);
+      assert.deepEqual(
+        kinds([`rev ${identity.revisions[0]!.slice(0, MIN_REVISION_PREFIX - 1)}`]),
+        [],
+      );
+    });
+
+    // The floor is not a taste: it is what `git rev-parse --short` abbreviates
+    // to in a small repository, measured rather than remembered, because
+    // `core.abbrev=auto` grows with object count and this repository is far
+    // past the smallest case a cell could be looking at.
+    test('is no longer than git abbreviates to in a fresh repository', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'maka-git-abbrev-'));
+      try {
+        await execFileAsync('git', ['init', '--quiet', dir]);
+        await writeFile(join(dir, 'probe.txt'), 'contamination scan abbreviation probe\n', 'utf8');
+        const { stdout: oid } = await execFileAsync('git', ['hash-object', '-w', 'probe.txt'], {
+          cwd: dir,
+        });
+        const { stdout: short } = await execFileAsync('git', ['rev-parse', '--short', oid.trim()], {
+          cwd: dir,
+        });
+        assert.ok(
+          MIN_REVISION_PREFIX <= short.trim().length,
+          `git abbreviates to ${short.trim().length}; the floor is ${MIN_REVISION_PREFIX}`,
+        );
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  test('searches every string a step carries, not a chosen field', () => {
+    const result = scanTrajectory({
+      trajectory: {
+        steps: [
+          {
+            step_id: 1,
+            source: 'agent',
+            action: {
+              command: ['bash', '-lc', 'git clone git@github.com:example-org/example-bench-2-1'],
+            },
+            extra: { nested: { deeper: ['and again fix-git'] } },
+          },
+        ],
+      },
+      ownTaskId: 'cobol-modernization',
+      identity,
+    });
+    assert.deepEqual(result.signals.map((signal) => signal.kind).sort(), [
+      'foreign_task_id',
+      'upstream_repository',
+    ]);
+  });
+
+  test('separates evidence of reaching from evidence of knowing', () => {
+    assert.equal(isRetrievalSignal('upstream_repository'), true);
+    assert.equal(isRetrievalSignal('pinned_revision'), true);
+    assert.equal(isRetrievalSignal('task_tree_fingerprint'), true);
+    assert.equal(isRetrievalSignal('foreign_task_id'), false);
+  });
+
+  describe('a trajectory that cannot answer the question refuses instead of passing', () => {
+    test('a degraded summary', () => {
+      const result = scanTrajectory({
+        trajectory: trajectory(['Maka trajectory summary: invocation finished'], {
+          [TRAJECTORY_ARTIFACT_KIND_KEY]: TRAJECTORY_ARTIFACT_KIND_SUMMARY,
+          [TRAJECTORY_SUMMARY_REASON_KEY]: 'runtime_event_schema_invalid',
+        }),
+        ownTaskId: 'cobol-modernization',
+        identity,
+      });
+      assert.equal(result.analyzed, false);
+      assert.match(result.notAnalyzedReason ?? '', /runtime_event_schema_invalid/);
+    });
+
+    test('a label this side does not recognize', () => {
+      const result = scanTrajectory({
+        trajectory: trajectory(['step'], { [TRAJECTORY_ARTIFACT_KIND_KEY]: 'partial' }),
+        ownTaskId: 'cobol-modernization',
+        identity,
+      });
+      assert.equal(result.analyzed, false);
+      assert.match(result.notAnalyzedReason ?? '', /unrecognized/);
+    });
+
+    test('no steps at all', () => {
+      const result = scanTrajectory({
+        trajectory: { steps: [] },
+        ownTaskId: 'cobol-modernization',
+        identity,
+      });
+      assert.equal(result.analyzed, false);
+    });
+
+    // Every other arm's trajectory comes from an upstream Harbor agent that has
+    // no degraded mode and writes no label. Demanding one would file every
+    // competitor cell under "broken export".
+    test('but an unlabelled upstream trajectory is ordinary ATIF', () => {
+      const result = scanTrajectory({
+        trajectory: trajectory(['git clone https://github.com/example-org/example-bench-2-1']),
+        ownTaskId: 'cobol-modernization',
+        identity,
+      });
+      assert.equal(result.analyzed, true);
+      assert.deepEqual(
+        result.signals.map((signal) => signal.kind),
+        ['upstream_repository'],
+      );
+    });
+
+    test('and a full label is searched', () => {
+      const result = scanTrajectory({
+        trajectory: trajectory(['ordinary work'], {
+          [TRAJECTORY_ARTIFACT_KIND_KEY]: TRAJECTORY_ARTIFACT_KIND_FULL,
+        }),
+        ownTaskId: 'cobol-modernization',
+        identity,
+      });
+      assert.equal(result.analyzed, true);
+    });
+  });
+
+  // The labels are Python's; this side only reads them. If the exporter renames
+  // one, an unlabelled Maka trajectory would be searched as ordinary ATIF and a
+  // degraded export would be reported clean — so the spelling is pinned here
+  // rather than re-derived at runtime.
+  test('the completeness labels are spelled the way the exporter writes them', async () => {
+    const agent = await readFile(join(HARBOR_DIR, 'maka_agent.py'), 'utf8');
+    const exporter = await readFile(join(HARBOR_DIR, 'maka_trajectory.py'), 'utf8');
+    assert.match(agent, new RegExp(`"${TRAJECTORY_ARTIFACT_KIND_KEY}"`));
+    assert.match(exporter, new RegExp(`"${TRAJECTORY_SUMMARY_REASON_KEY}"`));
+    assert.match(exporter, new RegExp(`artifact_kind="${TRAJECTORY_ARTIFACT_KIND_FULL}"`));
+    assert.match(exporter, new RegExp(`artifact_kind="${TRAJECTORY_ARTIFACT_KIND_SUMMARY}"`));
+  });
+});
+
+describe('scanRunForContamination', () => {
+  async function withRun<T>(
+    cells: Array<{ agent: string; taskId: string; trajectory?: unknown }>,
+    fn: (runRoot: string) => Promise<T>,
+  ): Promise<T> {
+    const runRoot = await mkdtemp(join(tmpdir(), 'maka-contamination-run-'));
+    try {
+      for (const [index, cell] of cells.entries()) {
+        const trialDir = join(runRoot, 'jobs', `${cell.agent}-r0-${index}`, 'trial');
+        await mkdir(join(trialDir, 'agent'), { recursive: true });
+        if (cell.trajectory !== undefined) {
+          await writeFile(
+            join(trialDir, 'agent', 'trajectory.json'),
+            JSON.stringify(cell.trajectory),
+            'utf8',
+          );
+        }
+        await appendTrialCell(trialCellLogPath(runRoot), {
+          runId: 'run-1',
+          roundId: `${cell.agent}-r0-${cell.taskId}`,
+          taskId: cell.taskId,
+          agent: cell.agent,
+          trialDir,
+        });
+      }
+      return await fn(runRoot);
+    } finally {
+      await rm(runRoot, { recursive: true, force: true });
+    }
+  }
+
+  test('reads the run the harness wrote down, one trajectory per row', async () => {
+    await withRun(
+      [
+        { agent: 'maka', taskId: 'cobol-modernization', trajectory: trajectory(['ordinary work']) },
+        {
+          agent: 'codex',
+          taskId: 'fix-git',
+          trajectory: trajectory(['git clone git@github.com:example-org/example-bench-2-1']),
+        },
+      ],
+      async (runRoot) => {
+        const report = await scanRunForContamination({
+          trialCellLogPath: trialCellLogPath(runRoot),
+          identity,
+        });
+        assert.deepEqual(report.totals, {
+          cells: 2,
+          analyzed: 2,
+          cellsWithRetrievalSignals: 1,
+          cellsWithAdvisorySignalsOnly: 0,
+        });
+        assert.deepEqual(report.coverageByAgent, {
+          maka: { cells: 1, analyzed: 1 },
+          codex: { cells: 1, analyzed: 1 },
+        });
+        assert.equal(report.cells[1]?.agent, 'codex');
+        assert.match(report.cells[1]?.trajectoryPath ?? '', /agent\/trajectory\.json$/);
+      },
+    );
+  });
+
+  // The failure mode that looks most like success: an arm whose export never
+  // landed reports no signals, and no signals reads as clean.
+  test('counts a cell with no trajectory as unsearched, not as clean', async () => {
+    await withRun(
+      [
+        { agent: 'maka', taskId: 'cobol-modernization' },
+        { agent: 'codex', taskId: 'fix-git', trajectory: trajectory(['ordinary work']) },
+      ],
+      async (runRoot) => {
+        const report = await scanRunForContamination({
+          trialCellLogPath: trialCellLogPath(runRoot),
+          identity,
+        });
+        assert.equal(report.totals.analyzed, 1);
+        assert.equal(report.coverageByAgent.maka?.analyzed, 0);
+        assert.match(report.cells[0]?.notAnalyzedReason ?? '', /unreadable/);
+      },
+    );
+  });
+
+  test('counts a task-id mention on its own as advisory', async () => {
+    await withRun(
+      [
+        {
+          agent: 'maka',
+          taskId: 'cobol-modernization',
+          trajectory: trajectory(['this suite also contains fix-git, I recall']),
+        },
+      ],
+      async (runRoot) => {
+        const report = await scanRunForContamination({
+          trialCellLogPath: trialCellLogPath(runRoot),
+          identity,
+        });
+        assert.equal(report.totals.cellsWithRetrievalSignals, 0);
+        assert.equal(report.totals.cellsWithAdvisorySignalsOnly, 1);
+      },
+    );
+  });
+
+  test('renders what was searched before what was found', async () => {
+    await withRun(
+      [
+        {
+          agent: 'maka',
+          taskId: 'cobol-modernization',
+          trajectory: trajectory(['git clone https://github.com/example-org/example-bench-2-1']),
+        },
+        { agent: 'codex', taskId: 'fix-git' },
+      ],
+      async (runRoot) => {
+        const markdown = renderContaminationScanReportMarkdown(
+          await scanRunForContamination({
+            trialCellLogPath: trialCellLogPath(runRoot),
+            identity,
+          }),
+        );
+        assert.match(markdown, /Searched 1\/2 cells\./);
+        assert.match(markdown, /\| codex \| 1 \| 0 \|/);
+        assert.match(markdown, /## Not searched/);
+        assert.match(markdown, /\*\*upstream_repository\*\*/);
+      },
+    );
+  });
+});

--- a/packages/headless/src/__tests__/harness-contamination-scan.test.ts
+++ b/packages/headless/src/__tests__/harness-contamination-scan.test.ts
@@ -525,6 +525,34 @@ describe('scanRunForContamination', () => {
     }
   });
 
+  // The run declares its grid; the log records what happened. A cell in the
+  // first and not the second is a hole the report must name — a run killed at
+  // cell three would otherwise certify the three that reached disk.
+  test('names the cells the run declared and never recorded', async () => {
+    await withRun(
+      [{ agent: 'maka', taskId: 'cobol-modernization', trajectory: trajectory(['ordinary work']) }],
+      async (runRoot) => {
+        const report = await scanRunForContamination({
+          trialCellLogPath: trialCellLogPath(runRoot),
+          identity,
+          expectedCells: [
+            { agent: 'maka', taskId: 'cobol-modernization' },
+            { agent: 'maka', taskId: 'fix-git' },
+            { agent: 'codex', taskId: 'cobol-modernization' },
+          ],
+        });
+        assert.deepEqual(report.unrecordedCells, [
+          { agent: 'maka', taskId: 'fix-git' },
+          { agent: 'codex', taskId: 'cobol-modernization' },
+        ]);
+        const markdown = renderContaminationScanReportMarkdown(report);
+        assert.match(markdown, /2 cells the run declared were never recorded/);
+        assert.match(markdown, /## Never recorded/);
+        assert.match(markdown, /`fix-git` \(maka\)/);
+      },
+    );
+  });
+
   test('renders what was searched before what was found', async () => {
     await withRun(
       [

--- a/packages/headless/src/__tests__/harness-contamination-scan.test.ts
+++ b/packages/headless/src/__tests__/harness-contamination-scan.test.ts
@@ -549,7 +549,7 @@ describe('scanRunForContamination', () => {
   // The run declares its grid; the log records what happened. A cell in the
   // first and not the second is a hole the report must name — a run killed at
   // cell three would otherwise certify the three that reached disk.
-  test('names the cells the run declared and never recorded', async () => {
+  test('names the cells the run scheduled and never recorded', async () => {
     await withRun(
       [{ agent: 'maka', taskId: 'cobol-modernization', trajectory: trajectory(['ordinary work']) }],
       async (runRoot) => {
@@ -567,7 +567,7 @@ describe('scanRunForContamination', () => {
           { agent: 'codex', taskId: 'cobol-modernization' },
         ]);
         const markdown = renderContaminationScanReportMarkdown(report);
-        assert.match(markdown, /2 cells the run declared were never recorded/);
+        assert.match(markdown, /2 cells the run scheduled were never recorded/);
         assert.match(markdown, /## Never recorded/);
         assert.match(markdown, /`fix-git` \(maka\)/);
       },

--- a/packages/headless/src/__tests__/harness-contamination-scan.test.ts
+++ b/packages/headless/src/__tests__/harness-contamination-scan.test.ts
@@ -9,6 +9,7 @@ import { promisify } from 'node:util';
 import {
   flattenBenchmarkIdentity,
   isRetrievalSignal,
+  LABELLING_AGENT,
   MIN_REVISION_PREFIX,
   renderContaminationScanReportMarkdown,
   scanRunForContamination,
@@ -338,7 +339,10 @@ describe('scanTrajectory', () => {
     // competitor cell under "broken export".
     test('but an unlabelled upstream trajectory is ordinary ATIF', () => {
       const result = scanTrajectory({
-        trajectory: trajectory(['git clone https://github.com/example-org/example-bench-2-1']),
+        trajectory: {
+          agent: { name: 'codex' },
+          ...(trajectory(['git clone https://github.com/example-org/example-bench-2-1']) as object),
+        },
         ownTaskId: 'cobol-modernization',
         identity,
       });
@@ -347,6 +351,23 @@ describe('scanTrajectory', () => {
         result.signals.map((signal) => signal.kind),
         ['upstream_repository'],
       );
+    });
+
+    // Maka always labels, so an unlabelled Maka trajectory is a label that went
+    // missing, not an ordinary export. Read as ordinary ATIF it would come back
+    // clean: the degraded shape carries two steps and no tool calls, so there
+    // is nothing in it to match.
+    test('an unlabelled trajectory from the arm that labels', () => {
+      const result = scanTrajectory({
+        trajectory: {
+          agent: { name: LABELLING_AGENT },
+          ...(trajectory(['Maka invocation completed']) as object),
+        },
+        ownTaskId: 'cobol-modernization',
+        identity,
+      });
+      assert.equal(result.analyzed, false);
+      assert.match(result.notAnalyzedReason ?? '', /carries no maka_artifact_kind/);
     });
 
     test('and a full label is searched', () => {

--- a/packages/headless/src/__tests__/harness-contamination-scan.test.ts
+++ b/packages/headless/src/__tests__/harness-contamination-scan.test.ts
@@ -567,7 +567,7 @@ describe('scanRunForContamination', () => {
           { agent: 'codex', taskId: 'cobol-modernization' },
         ]);
         const markdown = renderContaminationScanReportMarkdown(report);
-        assert.match(markdown, /2 cells the run scheduled were never recorded/);
+        assert.match(markdown, /2 cells this run root was scheduled to grade hold no record/);
         assert.match(markdown, /## Never recorded/);
         assert.match(markdown, /`fix-git` \(maka\)/);
       },

--- a/packages/headless/src/__tests__/harness-contamination-scan.test.ts
+++ b/packages/headless/src/__tests__/harness-contamination-scan.test.ts
@@ -70,11 +70,28 @@ describe('benchmark identity', () => {
   });
 
   // The failure this guards is the quiet one: a renamed field turns every cell
-  // clean, and a clean report is exactly what a reader wants to see.
+  // clean, and a clean report is exactly what a reader wants to see. A partial
+  // rename is quieter still, because the families that survived keep the report
+  // looking whole.
+  test('refuses a catalog that lost the revision alone', () => {
+    assert.throws(
+      () =>
+        flattenBenchmarkIdentity({
+          bench: {
+            upstreamRepositoryUrl: 'https://github.com/example-org/example-bench-2-1',
+            commit: '0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d',
+            taskTreeFingerprint: 'sha256:00001111',
+            taskIds: ['a'],
+          },
+        }),
+      /carries no revisions/,
+    );
+  });
+
   test('refuses a catalog that carries no needles', () => {
     assert.throws(
       () => flattenBenchmarkIdentity({ terminalBench21: { revision: 'abc' } }),
-      /no upstream repository or task ids/,
+      /carries no upstreamRepositoryUrls, taskTreeFingerprints, taskIds/,
     );
   });
 });
@@ -88,6 +105,23 @@ describe('scanTrajectory', () => {
       ]),
       [],
     );
+  });
+
+  test('finds the fingerprint written without the digest scheme', () => {
+    const bare = identity.taskTreeFingerprints[0]!.replace(/^sha256:/, '');
+    assert.deepEqual(kinds([`tree hash ${bare}`]), ['task_tree_fingerprint']);
+  });
+
+  // Seven hex characters occur inside other hashes. This one written down is
+  // the signal; this one occurring inside an unrelated digest is not.
+  test('does not read the revision out of the middle of another hash', () => {
+    const prefix = identity.revisions[0]!.slice(0, MIN_REVISION_PREFIX);
+    assert.deepEqual(kinds([`blob ff${prefix}aa`]), []);
+    assert.deepEqual(kinds([`checked out ${prefix}`]), ['pinned_revision']);
+  });
+
+  test("does not flag the cell's own task id written in another case", () => {
+    assert.deepEqual(kinds(['solving Cobol-Modernization']), []);
   });
 
   test('finds each of the four signals', () => {
@@ -401,6 +435,46 @@ describe('scanRunForContamination', () => {
     );
   });
 
+  // The retry deleted the first attempt's directory, so the superseded row now
+  // points at the retry's artifacts. Counting it would report one cell twice,
+  // and — in the other direction — would let an attempt the harness threw away
+  // fail a run whose graded cell was clean.
+  test('counts a retried cell once, as the attempt that is on disk', async () => {
+    const runRoot = await mkdtemp(join(tmpdir(), 'maka-contamination-retry-'));
+    try {
+      const firstDir = join(runRoot, 'jobs', 'first', 'trial');
+      const retryDir = join(runRoot, 'jobs', 'retry', 'trial');
+      await mkdir(join(retryDir, 'agent'), { recursive: true });
+      await writeFile(
+        join(retryDir, 'agent', 'trajectory.json'),
+        JSON.stringify(trajectory(['ordinary work'])),
+        'utf8',
+      );
+      const row = {
+        runId: 'run-1',
+        roundId: 'maka-r0-cobol',
+        taskId: 'cobol-modernization',
+        agent: 'maka',
+      };
+      await appendTrialCell(trialCellLogPath(runRoot), { ...row, trialDir: firstDir });
+      await appendTrialCell(trialCellLogPath(runRoot), { ...row, trialDir: retryDir });
+
+      const report = await scanRunForContamination({
+        trialCellLogPath: trialCellLogPath(runRoot),
+        identity,
+      });
+      assert.deepEqual(report.totals, {
+        cells: 1,
+        analyzed: 1,
+        cellsWithRetrievalSignals: 0,
+        cellsWithAdvisorySignalsOnly: 0,
+      });
+      assert.equal(report.cells[0]?.trialDir, retryDir);
+    } finally {
+      await rm(runRoot, { recursive: true, force: true });
+    }
+  });
+
   test('renders what was searched before what was found', async () => {
     await withRun(
       [
@@ -418,7 +492,8 @@ describe('scanRunForContamination', () => {
             identity,
           }),
         );
-        assert.match(markdown, /Searched 1\/2 cells\./);
+        assert.match(markdown, /Searched 1 of 2 recorded cells\./);
+        assert.match(markdown, /Recorded means the harness got far enough/);
         assert.match(markdown, /\| codex \| 1 \| 0 \|/);
         assert.match(markdown, /## Not searched/);
         assert.match(markdown, /\*\*upstream_repository\*\*/);

--- a/packages/headless/src/__tests__/harness-contamination-scan.test.ts
+++ b/packages/headless/src/__tests__/harness-contamination-scan.test.ts
@@ -69,6 +69,27 @@ describe('benchmark identity', () => {
     assert.equal(new Set(flat.taskIds).size, flat.taskIds.length);
   });
 
+  // The catalog is nested by benchmark and by profile today; a profile list is
+  // the shape it grows into, and a walker that stopped at an array would lose
+  // every needle inside one without the guard noticing, because the families
+  // outside it stay populated.
+  test('walks a catalog whose profiles are held in an array', () => {
+    const flat = flattenBenchmarkIdentity({
+      bench: {
+        profiles: [
+          {
+            upstreamRepositoryUrl: 'https://github.com/example-org/example-bench-2-1',
+            revision: '0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d',
+            taskTreeFingerprint: 'sha256:00001111',
+            taskIds: ['a', 'b'],
+          },
+        ],
+      },
+    });
+    assert.deepEqual(flat.taskIds, ['a', 'b']);
+    assert.equal(flat.revisions.length, 1);
+  });
+
   // The failure this guards is the quiet one: a renamed field turns every cell
   // clean, and a clean report is exactly what a reader wants to see. A partial
   // rename is quieter still, because the families that survived keep the report
@@ -190,6 +211,14 @@ describe('scanTrajectory', () => {
       assert.deepEqual(kinds(['fix-github-actions']), []);
       assert.deepEqual(kinds(['install-windows-3.11.2-beta']), []);
     });
+
+    // The left boundary is the other half of the same judgement, and a right
+    // boundary alone would let every one of these through.
+    test('an id that merely ends with this one is not this one', () => {
+      assert.deepEqual(kinds(['xfix-git']), []);
+      assert.deepEqual(kinds(['prefix.fix-git']), []);
+      assert.deepEqual(kinds(['0fix-git']), []);
+    });
   });
 
   describe('the revision prefix floor', () => {
@@ -282,6 +311,19 @@ describe('scanTrajectory', () => {
       assert.match(result.notAnalyzedReason ?? '', /unrecognized/);
     });
 
+    // `trajectory.json` holding `null` parses, and a scan that walked it would
+    // find no steps, no signals, and file the cell under clean.
+    test('a trajectory that is not an object at all', () => {
+      for (const value of [null, 'a string', 42]) {
+        const result = scanTrajectory({
+          trajectory: value,
+          ownTaskId: 'cobol-modernization',
+          identity,
+        });
+        assert.equal(result.analyzed, false);
+      }
+    });
+
     test('no steps at all', () => {
       const result = scanTrajectory({
         trajectory: { steps: [] },
@@ -326,7 +368,15 @@ describe('scanTrajectory', () => {
   test('the completeness labels are spelled the way the exporter writes them', async () => {
     const agent = await readFile(join(HARBOR_DIR, 'maka_agent.py'), 'utf8');
     const exporter = await readFile(join(HARBOR_DIR, 'maka_trajectory.py'), 'utf8');
-    assert.match(agent, new RegExp(`"${TRAJECTORY_ARTIFACT_KIND_KEY}"`));
+    // Where, not only what. This side reads the label off the trajectory root;
+    // an exporter that moved it into a step would still match a bare spelling
+    // check, and a degraded summary would then be searched as if it were whole
+    // — which is the failure that cost an entire 89-cell run.
+    assert.match(
+      agent,
+      new RegExp(`extra=\\{\\s*"${TRAJECTORY_ARTIFACT_KIND_KEY}":`),
+      'the artifact-kind label is no longer written on the trajectory root',
+    );
     assert.match(exporter, new RegExp(`"${TRAJECTORY_SUMMARY_REASON_KEY}"`));
     assert.match(exporter, new RegExp(`artifact_kind="${TRAJECTORY_ARTIFACT_KIND_FULL}"`));
     assert.match(exporter, new RegExp(`artifact_kind="${TRAJECTORY_ARTIFACT_KIND_SUMMARY}"`));

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -18,6 +18,7 @@ import { competitorRepoFiles } from '../agent-repo-mount.js';
 import { CODEX_TOOLCHAIN_FINGERPRINT, CODEX_TOOLCHAIN_SPEC } from '../codex-toolchain.js';
 import { OPENCODE_TOOLCHAIN_FINGERPRINT, OPENCODE_TOOLCHAIN_SPEC } from '../opencode-toolchain.js';
 import { findTrialDir, MAKA_SETTLEMENT_GRACE_SEC } from '../harbor-task-runner.js';
+import { readTrialCellLog } from '../trial-cell-log.js';
 import { MAKA_NODE_TOOLCHAIN_FINGERPRINT } from '../maka-node-toolchain.js';
 import type { ProviderRequestTelemetry } from '../provider-auth-proxy.js';
 import {
@@ -289,6 +290,39 @@ test('buildPierRunArgs emits the pier CLI contract for the Maka arm', () => {
   assert.ok(args.includes('MAKA_MODEL=k3'));
   // No provider secret and no env-file were requested.
   assert.ok(!args.includes('--env-file'));
+});
+
+// Same contract as the Harbor runner: the row names the directory this trial's
+// artifacts are actually in, proven by reading one back out of it.
+test('createPierTaskRunner records the trial it read', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const logPath = join(jobsDir, 'trial-cells.jsonl');
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'maka',
+        makaNodeToolchainPath: '/toolchains/maka-node',
+        trialCellLogPath: logPath,
+        runPier: fakePier({ reward: 1 }),
+      }),
+    );
+
+    await runner(runInput());
+
+    const rows = await readTrialCellLog(logPath);
+    assert.equal(rows.length, 1);
+    assert.deepEqual(
+      { runId: rows[0]?.runId, roundId: rows[0]?.roundId, taskId: rows[0]?.taskId },
+      { runId: 'run-1', roundId: 'round-1', taskId: 'dasel' },
+    );
+    assert.equal(rows[0]?.agent, 'maka');
+    assert.equal(
+      JSON.parse(await readFile(join(rows[0]!.trialDir, 'agent', 'maka-cell-output.json'), 'utf8'))
+        .status,
+      'completed',
+    );
+  });
 });
 
 test('createPierTaskRunner gives Maka a controller-owned settlement tail', async () => {

--- a/packages/headless/src/__tests__/trial-cell-log.test.ts
+++ b/packages/headless/src/__tests__/trial-cell-log.test.ts
@@ -101,6 +101,25 @@ describe('trial cell log', () => {
     });
   });
 
+  // Arms run in parallel by default, so two runners append to one log at once.
+  // A torn row would either lose a cell or fail the read for the whole run.
+  test('survives every arm appending at once', async () => {
+    await withTempDir(async (dir) => {
+      const path = trialCellLogPath(dir);
+      const rows = Array.from({ length: 200 }, (_, index) =>
+        cell({
+          roundId: `maka-r0-task-${index}`,
+          taskId: `task-${index}`,
+          trialDir: `/runs/jobs/run-1/${'d'.repeat(200)}/${index}`,
+        }),
+      );
+      await Promise.all(rows.map((row) => appendTrialCell(path, row)));
+      const read = await readTrialCellLog(path);
+      assert.equal(read.length, rows.length);
+      assert.equal(new Set(read.map((row) => row.taskId)).size, rows.length);
+    });
+  });
+
   // Logging must never be able to fail a graded cell.
   test('swallows a write failure', async () => {
     await withTempDir(async (dir) => {

--- a/packages/headless/src/__tests__/trial-cell-log.test.ts
+++ b/packages/headless/src/__tests__/trial-cell-log.test.ts
@@ -120,6 +120,37 @@ describe('trial cell log', () => {
     });
   });
 
+  // A crash mid-append leaves a row without its newline. Appending past it
+  // would bury the stump in the middle of the file, where it is corruption and
+  // takes the whole scan down — so a run resumed after a crash would be
+  // unscannable, which is when its evidence matters most.
+  test('drops a row a crash cut off, and stays readable after the resume', async () => {
+    await withTempDir(async (dir) => {
+      const path = trialCellLogPath(dir);
+      await appendTrialCell(path, cell());
+      await writeFile(path, `${JSON.stringify(cell({ taskId: 'task-2' })).slice(0, 40)}`, {
+        flag: 'a',
+      });
+      await appendTrialCell(path, cell({ roundId: 'maka-r0-task-3', taskId: 'task-3' }));
+      assert.deepEqual(
+        (await readTrialCellLog(path)).map((row) => row.taskId),
+        ['task-1', 'task-3'],
+      );
+    });
+  });
+
+  test('reads a log whose last row a crash cut off', async () => {
+    await withTempDir(async (dir) => {
+      const path = trialCellLogPath(dir);
+      await appendTrialCell(path, cell());
+      await writeFile(path, JSON.stringify(cell({ taskId: 'task-2' })).slice(0, 40), { flag: 'a' });
+      assert.deepEqual(
+        (await readTrialCellLog(path)).map((row) => row.taskId),
+        ['task-1'],
+      );
+    });
+  });
+
   // Logging must never be able to fail a graded cell.
   test('swallows a write failure', async () => {
     await withTempDir(async (dir) => {

--- a/packages/headless/src/__tests__/trial-cell-log.test.ts
+++ b/packages/headless/src/__tests__/trial-cell-log.test.ts
@@ -46,6 +46,37 @@ describe('trial cell log', () => {
     });
   });
 
+  // A cell can be attempted twice: the adjudicated-infra retry re-runs a round,
+  // and each attempt deletes the previous attempt's job directory first. Two
+  // rows for one cell would count it twice, and would let an attempt whose
+  // artifacts no longer exist speak for the attempt that was graded.
+  test('keeps the attempt that is still on disk when a cell was retried', async () => {
+    await withTempDir(async (dir) => {
+      const path = trialCellLogPath(dir);
+      await appendTrialCell(path, cell({ trialDir: '/runs/first-attempt' }));
+      await appendTrialCell(path, cell({ taskId: 'task-2', roundId: 'maka-r0-task-2' }));
+      await appendTrialCell(path, cell({ trialDir: '/runs/retry' }));
+      const rows = await readTrialCellLog(path);
+      assert.deepEqual(
+        rows.map((row) => [row.taskId, row.trialDir]),
+        [
+          ['task-1', '/runs/retry'],
+          ['task-2', cell().trialDir],
+        ],
+      );
+    });
+  });
+
+  // Two arms grade the same task; they are two cells, not one retried cell.
+  test('does not fold two arms of the same task into one cell', async () => {
+    await withTempDir(async (dir) => {
+      const path = trialCellLogPath(dir);
+      await appendTrialCell(path, cell());
+      await appendTrialCell(path, cell({ agent: 'codex', roundId: 'codex-r0-task-1' }));
+      assert.equal((await readTrialCellLog(path)).length, 2);
+    });
+  });
+
   // A run that asked for no log is the ordinary case for every caller outside
   // the harness A/B path; it must not have to invent a path to stay silent.
   test('writes nothing when no path is configured', async () => {

--- a/packages/headless/src/__tests__/trial-cell-log.test.ts
+++ b/packages/headless/src/__tests__/trial-cell-log.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { appendTrialCell, readTrialCellLog, trialCellLogPath } from '../trial-cell-log.js';
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-trial-cell-log-'));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+const cell = (overrides: Partial<Parameters<typeof appendTrialCell>[1]> = {}) => ({
+  runId: 'run-1',
+  roundId: 'maka-r0-task-1',
+  taskId: 'task-1',
+  agent: 'maka',
+  trialDir: '/runs/jobs/run-1/maka-r0-task-1/task-1/trial/task-1',
+  ...overrides,
+});
+
+describe('trial cell log', () => {
+  test('appends one row per cell and reads them back in order', async () => {
+    await withTempDir(async (dir) => {
+      const path = trialCellLogPath(dir);
+      await appendTrialCell(path, cell());
+      await appendTrialCell(path, cell({ agent: 'codex', roundId: 'codex-r0-task-1' }));
+      const rows = await readTrialCellLog(path);
+      assert.deepEqual(
+        rows.map((row) => row.agent),
+        ['maka', 'codex'],
+      );
+      assert.equal(rows[0]?.trialDir, cell().trialDir);
+    });
+  });
+
+  test('creates the log directory rather than dropping the first row', async () => {
+    await withTempDir(async (dir) => {
+      const path = trialCellLogPath(join(dir, 'not', 'created', 'yet'));
+      await appendTrialCell(path, cell());
+      assert.equal((await readTrialCellLog(path)).length, 1);
+    });
+  });
+
+  // A run that asked for no log is the ordinary case for every caller outside
+  // the harness A/B path; it must not have to invent a path to stay silent.
+  test('writes nothing when no path is configured', async () => {
+    await appendTrialCell(undefined, cell());
+  });
+
+  // The whole point of the log is that a reader trusts it. A row that lost a
+  // field would otherwise be read as a cell in some other directory.
+  test('refuses a row missing a field instead of returning a partial one', async () => {
+    await withTempDir(async (dir) => {
+      const path = trialCellLogPath(dir);
+      await writeFile(path, `${JSON.stringify({ ...cell(), trialDir: undefined })}\n`, 'utf8');
+      await assert.rejects(readTrialCellLog(path), /missing trialDir/);
+    });
+  });
+
+  test('refuses a line that is not JSON', async () => {
+    await withTempDir(async (dir) => {
+      const path = trialCellLogPath(dir);
+      await writeFile(path, `${JSON.stringify(cell())}\nnot json\n`, 'utf8');
+      await assert.rejects(readTrialCellLog(path), /line 2 is not JSON/);
+    });
+  });
+
+  // Logging must never be able to fail a graded cell.
+  test('swallows a write failure', async () => {
+    await withTempDir(async (dir) => {
+      const blocker = join(dir, 'blocker');
+      await writeFile(blocker, 'not a directory\n', 'utf8');
+      await appendTrialCell(join(blocker, 'trial-cells.jsonl'), cell());
+      assert.equal(await readFile(blocker, 'utf8'), 'not a directory\n');
+    });
+  });
+});

--- a/packages/headless/src/__tests__/trial-cell-log.test.ts
+++ b/packages/headless/src/__tests__/trial-cell-log.test.ts
@@ -3,7 +3,14 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { appendTrialCell, readTrialCellLog, trialCellLogPath } from '../trial-cell-log.js';
+import {
+  appendScheduledCells,
+  appendTrialCell,
+  readScheduledCellLog,
+  readTrialCellLog,
+  scheduledCellLogPath,
+  trialCellLogPath,
+} from '../trial-cell-log.js';
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
   const dir = await mkdtemp(join(tmpdir(), 'maka-trial-cell-log-'));
@@ -158,6 +165,71 @@ describe('trial cell log', () => {
       await writeFile(blocker, 'not a directory\n', 'utf8');
       await appendTrialCell(join(blocker, 'trial-cells.jsonl'), cell());
       assert.equal(await readFile(blocker, 'utf8'), 'not a directory\n');
+    });
+  });
+});
+
+describe('scheduled cell log', () => {
+  // A canary continued at full width schedules twice against one run root, and
+  // the run is expected to hold every cell either invocation put on the board.
+  test('takes the union of every invocation that scheduled against the run', async () => {
+    await withTempDir(async (dir) => {
+      const path = scheduledCellLogPath(dir);
+      await appendScheduledCells(path, [
+        { agent: 'maka', taskId: 'task-1' },
+        { agent: 'codex', taskId: 'task-1' },
+      ]);
+      await appendScheduledCells(path, [
+        { agent: 'maka', taskId: 'task-1' },
+        { agent: 'maka', taskId: 'task-2' },
+        { agent: 'codex', taskId: 'task-1' },
+        { agent: 'codex', taskId: 'task-2' },
+      ]);
+      assert.deepEqual(
+        (await readScheduledCellLog(path)).map((cell) => `${cell.agent}/${cell.taskId}`),
+        ['maka/task-1', 'codex/task-1', 'maka/task-2', 'codex/task-2'],
+      );
+    });
+  });
+
+  // Nothing has been graded yet when this is written, so refusing costs the run
+  // nothing — and a run whose grid was never recorded is one no later reader
+  // can bound.
+  test('refuses to record a run that scheduled nothing', async () => {
+    await withTempDir(async (dir) => {
+      await assert.rejects(
+        appendScheduledCells(scheduledCellLogPath(dir), []),
+        /schedules at least one cell/,
+      );
+    });
+  });
+
+  test('reports its own absence rather than an empty grid', async () => {
+    await withTempDir(async (dir) => {
+      await assert.rejects(readScheduledCellLog(scheduledCellLogPath(dir)), {
+        code: 'ENOENT',
+      });
+    });
+  });
+
+  test('drops a row a crash cut off, and stays readable after the resume', async () => {
+    await withTempDir(async (dir) => {
+      const path = scheduledCellLogPath(dir);
+      await appendScheduledCells(path, [{ agent: 'maka', taskId: 'task-1' }]);
+      await writeFile(path, '{"agent":"maka","taskI', { flag: 'a' });
+      await appendScheduledCells(path, [{ agent: 'maka', taskId: 'task-2' }]);
+      assert.deepEqual(
+        (await readScheduledCellLog(path)).map((cell) => cell.taskId),
+        ['task-1', 'task-2'],
+      );
+    });
+  });
+
+  test('refuses a row that names no agent', async () => {
+    await withTempDir(async (dir) => {
+      const path = scheduledCellLogPath(dir);
+      await writeFile(path, `${JSON.stringify({ taskId: 'task-1' })}\n`, 'utf8');
+      await assert.rejects(readScheduledCellLog(path), /line 1 is missing agent/);
     });
   });
 });

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -93,6 +93,7 @@ import {
 } from './reasonix-toolchain.js';
 
 import { agentPhaseTimeoutSec, settlementGraceSec } from './maka-settlement.js';
+import { appendTrialCell } from './trial-cell-log.js';
 
 export { MAKA_SETTLEMENT_GRACE_SEC } from './maka-settlement.js';
 
@@ -297,6 +298,12 @@ export interface HarborTaskRunnerOptions {
   aptMirrorComposePath?: string;
   /** Base directory under which each task gets an isolated per-task job dir. */
   jobsDir: string;
+  /**
+   * Where to append one row per finished trial, recording which arm ran which
+   * task in which directory. Readers of a finished run take the run's cells
+   * from this file rather than re-deriving them from the tree.
+   */
+  trialCellLogPath?: string;
   /** MAKA_MODEL, e.g. "deepseek/deepseek-v4-flash". */
   model: string;
   /** MAKA_PROVIDER, e.g. "deepseek". */
@@ -492,6 +499,13 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
           tail(result.stderr || result.stdout),
         );
       }
+      await appendTrialCell(options.trialCellLogPath, {
+        runId: input.runId,
+        roundId: input.roundId,
+        taskId: input.task.id,
+        agent: options.agent ?? 'maka',
+        trialDir,
+      });
       const cellOutputPath = join(trialDir, TRIAL_CELL_OUTPUT);
       const rewardPath = join(trialDir, TRIAL_REWARD);
       const resultPath = join(trialDir, TRIAL_RESULT);

--- a/packages/headless/src/harness-ab-run.ts
+++ b/packages/headless/src/harness-ab-run.ts
@@ -183,6 +183,14 @@ async function executeHarnessArmCohort(input: RunHarnessArmCohortInput): Promise
   // two arrays. A later reader has no other way to learn it: the frozen
   // manifest names the whole benchmark, of which a run grades a slice, and one
   // manifest serves both a canary and the full run that resumes against it.
+  //
+  // Here rather than where the slice is chosen, which is before the toolchains
+  // and credentials a run most often dies on. It is still a statement of
+  // intent, not of work done — the first cell has yet to launch — so a run
+  // abandoned between here and its first trial directory leaves a grid it
+  // never filled, and this root stays refused until it is graded or given up
+  // for a fresh run id. That is the conservative direction: the grid can only
+  // widen what a reader demands, never narrow it.
   await appendScheduledCells(
     scheduledCellLogPath(input.runRoot),
     arms.flatMap((arm) =>

--- a/packages/headless/src/harness-ab-run.ts
+++ b/packages/headless/src/harness-ab-run.ts
@@ -12,6 +12,7 @@ import {
   type TaskRunner,
 } from './fixed-prompt-controller.js';
 import { HARNESS_AB_PAIR_CONCURRENCY, type HarnessAbArmId } from './harness-ab-manifest.js';
+import { appendScheduledCells, scheduledCellLogPath } from './trial-cell-log.js';
 
 export interface HarnessAbRuntimeArm {
   id: HarnessAbArmId;
@@ -178,6 +179,16 @@ async function executeHarnessArmCohort(input: RunHarnessArmCohortInput): Promise
       billingMode: arm.billingMode,
     }),
   }));
+  // The grid, written down where it is handed over to be run, from the same
+  // two arrays. A later reader has no other way to learn it: the frozen
+  // manifest names the whole benchmark, of which a run grades a slice, and one
+  // manifest serves both a canary and the full run that resumes against it.
+  await appendScheduledCells(
+    scheduledCellLogPath(input.runRoot),
+    arms.flatMap((arm) =>
+      input.evaluationTasks.map((task) => ({ agent: arm.id, taskId: task.id })),
+    ),
+  );
   const cohort = await runArmCohort({
     runId: input.runId,
     arms,

--- a/packages/headless/src/harness-contamination-scan.ts
+++ b/packages/headless/src/harness-contamination-scan.ts
@@ -185,6 +185,9 @@ const EXCERPT_RADIUS = 80;
  * to read them, and `harness-contamination-scan.test.ts` pins the spelling
  * against that file so the two cannot drift apart in silence.
  */
+/** The one agent whose exporter can degrade, and which therefore must label. */
+export const LABELLING_AGENT = 'maka';
+
 export const TRAJECTORY_ARTIFACT_KIND_KEY = 'maka_artifact_kind';
 export const TRAJECTORY_SUMMARY_REASON_KEY = 'maka_summary_reason';
 export const TRAJECTORY_ARTIFACT_KIND_FULL = 'full';
@@ -200,11 +203,15 @@ export const TRAJECTORY_ARTIFACT_KIND_SUMMARY = 'summary';
  * that says `summary`, or that carries a label this file does not recognize,
  * refuses.
  *
- * An absent label is ordinary ATIF: every other arm's trajectory comes from an
- * upstream Harbor agent that has no degraded mode and writes no such label.
- * Demanding a label they were never going to carry would file every competitor
- * cell under "broken export", and an alarm that fires on every run is not an
- * alarm.
+ * An absent label is ordinary ATIF for every other arm: their trajectories come
+ * from upstream Harbor agents that have no degraded mode and write no such
+ * label. Demanding a label they were never going to carry would file every
+ * competitor cell under "broken export", and an alarm that fires on every run
+ * is not an alarm.
+ *
+ * But absent on a Maka trajectory is not ordinary — Maka always labels — so it
+ * refuses too. The trajectory says whose it is, so this asks it rather than
+ * assuming the exporter's behaviour has not changed since this was written.
  */
 function notAnalyzableReason(
   trajectory: Record<string, unknown>,
@@ -224,6 +231,9 @@ function notAnalyzableReason(
   }
   if (kind !== undefined && kind !== TRAJECTORY_ARTIFACT_KIND_FULL) {
     return `trajectory carries an unrecognized ${TRAJECTORY_ARTIFACT_KIND_KEY}: ${JSON.stringify(kind)}`;
+  }
+  if (kind === undefined && trajectoryAgentName(trajectory) === LABELLING_AGENT) {
+    return `${LABELLING_AGENT} trajectory carries no ${TRAJECTORY_ARTIFACT_KIND_KEY}`;
   }
   if (steps.length === 0) return 'trajectory carries no steps';
   return undefined;
@@ -432,6 +442,13 @@ export function renderContaminationScanReportMarkdown(report: ContaminationScanR
  * encoded, or built from parts across steps. That is unbounded and this makes
  * no claim on it; the signals here are for references that appear verbatim.
  */
+function trajectoryAgentName(trajectory: Record<string, unknown>): string | undefined {
+  const agent = trajectory.agent;
+  if (!agent || typeof agent !== 'object') return undefined;
+  const name = (agent as Record<string, unknown>).name;
+  return typeof name === 'string' ? name : undefined;
+}
+
 function cellKey(agent: string, taskId: string): string {
   return JSON.stringify([agent, taskId]);
 }

--- a/packages/headless/src/harness-contamination-scan.ts
+++ b/packages/headless/src/harness-contamination-scan.ts
@@ -308,9 +308,10 @@ export async function scanRunForContamination(input: {
   trialCellLogPath: string;
   identity: BenchmarkIdentity;
   /**
-   * The grid the run declared: one entry per arm per evaluation task. Supplied
-   * by the caller from the run's own manifest, because whether the log holds
-   * the whole run is a fact about the run, not about the log.
+   * The grid the run scheduled: one entry per arm per evaluation task.
+   * Supplied by the caller from the run's own record of what it scheduled,
+   * because whether the log holds the whole run is a fact about the run, not
+   * about the log.
    */
   expectedCells?: readonly { agent: string; taskId: string }[];
 }): Promise<ContaminationScanReport> {

--- a/packages/headless/src/harness-contamination-scan.ts
+++ b/packages/headless/src/harness-contamination-scan.ts
@@ -136,11 +136,16 @@ export function flattenBenchmarkIdentity(catalog: unknown): BenchmarkIdentity {
     taskTreeFingerprints: [...taskTreeFingerprints],
     taskIds: [...taskIds],
   };
-  // A catalog that carries none of the four is either the wrong file or a
-  // renamed field, and either way a scan run against it reports every cell
-  // clean. That is the one outcome this must never produce silently.
-  if (identity.upstreamRepositoryUrls.length === 0 || identity.taskIds.length === 0) {
-    throw new Error('benchmark identity carries no upstream repository or task ids');
+  // A missing family is either the wrong file or a renamed field, and a scan
+  // that lost one searches for less than it reports having searched for. Each
+  // is required, not just enough of them to look populated: a rename of
+  // `revision` alone would disarm the most specific retrieval needle there is
+  // while the two coarser ones kept the report looking whole.
+  const empty = Object.entries(identity)
+    .filter(([, values]) => values.length === 0)
+    .map(([family]) => family);
+  if (empty.length > 0) {
+    throw new Error(`benchmark identity carries no ${empty.join(', ')}`);
   }
   return identity;
 }
@@ -148,15 +153,18 @@ export function flattenBenchmarkIdentity(catalog: unknown): BenchmarkIdentity {
 /**
  * The shortest revision prefix worth searching for.
  *
- * Two things write this revision down. One is the harness, which abbreviates to
- * eight in the task-source path a cell can see. The other is git, which the
- * cell runs: `git log --oneline` and `rev-parse --short` abbreviate to seven by
- * default, so a cell that reads the revision out of a checkout and writes it
- * down the way git just showed it is one character below anything the harness
- * itself would have written. Take the smaller.
+ * A cell that fetched the upstream ran git, and git decides how much of the
+ * revision it then sees: `git log --oneline` and `rev-parse --short` abbreviate
+ * to seven by default. Searching for more than a cell was shown is searching
+ * for a string it had no way to write, so seven is the floor — measured against
+ * git rather than remembered, because `core.abbrev=auto` grows with object
+ * count and only the smallest repository gives the shortest answer.
  *
- * Short does not mean noisy: the pattern is one specific string, not a run of
- * hex, so a false match needs those seven characters to occur verbatim.
+ * Seven hex characters are not rare in the abstract, so the pattern is bounded
+ * on the left against hex: this revision written down, not this revision
+ * occurring inside an unrelated hash. It is deliberately unbounded on the
+ * right, because the full forty-character revision is the match that matters
+ * most and it continues in hex.
  */
 export const MIN_REVISION_PREFIX = 7;
 
@@ -231,11 +239,17 @@ export function scanTrajectory(input: {
   const revisionPatterns = input.identity.revisions
     .map(revisionPattern)
     .filter((pattern): pattern is RegExp => pattern !== null);
+  // Searched without the `sha256:` the catalog writes it with: the digest is
+  // the fingerprint, and a cell that copied it out of a hex-only listing would
+  // otherwise carry the whole of it and match none of it.
   const fingerprintPatterns = input.identity.taskTreeFingerprints.map(
-    (fingerprint) => new RegExp(escapeRegExp(fingerprint), 'gi'),
+    (fingerprint) => new RegExp(escapeRegExp(fingerprint.replace(/^[a-z0-9]+:/i, '')), 'gi'),
   );
+  const ownTaskId = input.ownTaskId.toLowerCase();
   const foreignTaskPatterns = input.identity.taskIds
-    .filter((taskId) => taskId !== input.ownTaskId)
+    // Compared case-insensitively, as the patterns match: a cell that writes
+    // its own task id in another case is still describing its own work.
+    .filter((taskId) => taskId.toLowerCase() !== ownTaskId)
     .map((taskId) => ({
       taskId,
       // Case-insensitive because a cell writes a task id however it likes. The
@@ -264,18 +278,19 @@ export function scanTrajectory(input: {
 }
 
 /**
- * Scan every cell a run wrote down.
+ * Scan every cell a run recorded.
  *
- * The cell list is the run's, not this file's guess at it: a cell missing from
- * the log is missing from the report, which is the honest answer when the
- * harness never got far enough to record it.
+ * The cell list is the run's, not this file's guess at it. A cell the harness
+ * never got far enough to record — an arm that died before its trial directory
+ * existed — is absent here, and the report says "recorded cells" rather than
+ * "cells" so that a reader is not told a run was covered end to end on the
+ * strength of the part of it that reached disk.
  */
 export async function scanRunForContamination(input: {
   trialCellLogPath: string;
   identity: BenchmarkIdentity;
-  readTrajectory?: (path: string) => Promise<string>;
 }): Promise<ContaminationScanReport> {
-  const readTrajectory = input.readTrajectory ?? ((path: string) => readFile(path, 'utf8'));
+  const readTrajectory = (path: string) => readFile(path, 'utf8');
   const records = await readTrialCellLog(input.trialCellLogPath);
   const cells: CellContaminationReport[] = [];
   for (const record of records) {
@@ -334,7 +349,9 @@ export function renderContaminationScanReportMarkdown(report: ContaminationScanR
   const lines = [
     '# Contamination scan',
     '',
-    `Searched ${totals.analyzed}/${totals.cells} cells.`,
+    `Searched ${totals.analyzed} of ${totals.cells} recorded cells.`,
+    '',
+    'Recorded means the harness got far enough to resolve a trial directory. A cell that died before that is not counted here or anywhere below.',
     '',
     '| arm | cells | searched |',
     '| --- | --- | --- |',
@@ -403,7 +420,7 @@ function repositoryPattern(upstreamRepositoryUrl: string): RegExp {
 
 function revisionPattern(revision: string): RegExp | null {
   if (revision.length < MIN_REVISION_PREFIX) return null;
-  return new RegExp(revision.slice(0, MIN_REVISION_PREFIX), 'gi');
+  return new RegExp(`(?<![0-9a-f])${revision.slice(0, MIN_REVISION_PREFIX)}`, 'gi');
 }
 
 /**

--- a/packages/headless/src/harness-contamination-scan.ts
+++ b/packages/headless/src/harness-contamination-scan.ts
@@ -89,6 +89,14 @@ export interface CellContaminationReport extends TrialCellRecord {
 
 export interface ContaminationScanReport {
   cells: CellContaminationReport[];
+  /**
+   * Cells the run declared it would grade and never recorded.
+   *
+   * A run killed part-way through, or one whose best-effort log write failed,
+   * leaves artifacts the scan never looks at. Counting only what was recorded
+   * would certify the surviving fraction and call it the run.
+   */
+  unrecordedCells: { agent: string; taskId: string }[];
   /** Coverage per arm, because a whole arm exporting nothing is the failure
    * mode that looks most like success. */
   coverageByAgent: Record<string, { cells: number; analyzed: number }>;
@@ -289,6 +297,12 @@ export function scanTrajectory(input: {
 export async function scanRunForContamination(input: {
   trialCellLogPath: string;
   identity: BenchmarkIdentity;
+  /**
+   * The grid the run declared: one entry per arm per evaluation task. Supplied
+   * by the caller from the run's own manifest, because whether the log holds
+   * the whole run is a fact about the run, not about the log.
+   */
+  expectedCells?: readonly { agent: string; taskId: string }[];
 }): Promise<ContaminationScanReport> {
   const readTrajectory = (path: string) => readFile(path, 'utf8');
   const records = await readTrialCellLog(input.trialCellLogPath);
@@ -319,8 +333,13 @@ export async function scanRunForContamination(input: {
     bucket.cells += 1;
     if (cell.analyzed) bucket.analyzed += 1;
   }
+  const recorded = new Set(cells.map((cell) => cellKey(cell.agent, cell.taskId)));
+  const unrecordedCells = (input.expectedCells ?? []).filter(
+    (expected) => !recorded.has(cellKey(expected.agent, expected.taskId)),
+  );
   return {
     cells,
+    unrecordedCells: unrecordedCells.map((expected) => ({ ...expected })),
     coverageByAgent,
     totals: {
       cells: cells.length,
@@ -351,7 +370,9 @@ export function renderContaminationScanReportMarkdown(report: ContaminationScanR
     '',
     `Searched ${totals.analyzed} of ${totals.cells} recorded cells.`,
     '',
-    'Recorded means the harness got far enough to resolve a trial directory. A cell that died before that is not counted here or anywhere below.',
+    report.unrecordedCells.length > 0
+      ? `**${report.unrecordedCells.length} cells the run declared were never recorded.** The run did not finish, or its artifacts never reached the log; whatever those cells did is not in this report.`
+      : 'Recorded means the harness got far enough to resolve a trial directory. A cell that died before that is not counted here or anywhere below.',
     '',
     '| arm | cells | searched |',
     '| --- | --- | --- |',
@@ -361,6 +382,13 @@ export function renderContaminationScanReportMarkdown(report: ContaminationScanR
     '',
     `Retrieval evidence: ${totals.cellsWithRetrievalSignals} cells. Task-id mentions only: ${totals.cellsWithAdvisorySignalsOnly} cells.`,
   ];
+
+  if (report.unrecordedCells.length > 0) {
+    lines.push('', '## Never recorded', '');
+    for (const cell of report.unrecordedCells) {
+      lines.push(`- \`${cell.taskId}\` (${cell.agent})`);
+    }
+  }
 
   const unsearched = report.cells.filter((cell) => !cell.analyzed);
   if (unsearched.length > 0) {
@@ -404,6 +432,10 @@ export function renderContaminationScanReportMarkdown(report: ContaminationScanR
  * encoded, or built from parts across steps. That is unbounded and this makes
  * no claim on it; the signals here are for references that appear verbatim.
  */
+function cellKey(agent: string, taskId: string): string {
+  return JSON.stringify([agent, taskId]);
+}
+
 function repositoryPattern(upstreamRepositoryUrl: string): RegExp {
   const withoutScheme = upstreamRepositoryUrl
     .replace(/^[a-z]+:\/\//i, '')

--- a/packages/headless/src/harness-contamination-scan.ts
+++ b/packages/headless/src/harness-contamination-scan.ts
@@ -382,7 +382,7 @@ export function renderContaminationScanReportMarkdown(report: ContaminationScanR
     `Searched ${totals.analyzed} of ${totals.cells} recorded cells.`,
     '',
     report.unrecordedCells.length > 0
-      ? `**${report.unrecordedCells.length} cells this run root was scheduled to grade hold no record that it did.** An invocation was killed or abandoned, or its artifacts never reached the log; whatever those cells did is not in this report.`
+      ? `**${report.unrecordedCells.length} ${report.unrecordedCells.length === 1 ? 'cell' : 'cells'} this run root was scheduled to grade hold no record that it did.** Whatever those cells did is not in this report.`
       : 'Recorded means the harness got far enough to resolve a trial directory. A cell that died before that is not counted here or anywhere below.',
     '',
     '| arm | cells | searched |',

--- a/packages/headless/src/harness-contamination-scan.ts
+++ b/packages/headless/src/harness-contamination-scan.ts
@@ -1,0 +1,456 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { readTrialCellLog, type TrialCellRecord } from './trial-cell-log.js';
+
+/**
+ * Did a graded cell go and get the benchmark instead of solving it?
+ *
+ * The scan reads the run's own cell log — which arm ran which task in which
+ * directory, written by the harness while it still knew — opens each cell's
+ * normalized trajectory, and searches it for strings the cell had no legitimate
+ * way to hold. It reconstructs nothing about the run: a fact the harness did
+ * not write down is a fact this file does not have, and says so, rather than
+ * inferring it from the shape of the tree.
+ */
+
+/** Where a trajectory sits inside a trial directory, per the ATIF layout. */
+const TRAJECTORY_RELATIVE_PATH = join('agent', 'trajectory.json');
+
+export interface BenchmarkIdentity {
+  /**
+   * Every upstream repository, revision and task-tree fingerprint the catalog
+   * knows, and every task id in it, as one set.
+   *
+   * The profiles are variants of the same benchmarks, and none of these strings
+   * is something a cell may legitimately hold whichever profile it ran under.
+   * Searching for all of them costs one pass; picking the run's profile would
+   * add a derivation that can be wrong and would decide which leak goes
+   * unlooked-for when it is.
+   */
+  upstreamRepositoryUrls: readonly string[];
+  revisions: readonly string[];
+  taskTreeFingerprints: readonly string[];
+  taskIds: readonly string[];
+}
+
+export type ContaminationSignalKind =
+  | 'upstream_repository'
+  | 'pinned_revision'
+  | 'task_tree_fingerprint'
+  | 'foreign_task_id';
+
+/**
+ * Signals whose presence is evidence the cell reached for something, as
+ * distinct from evidence it knew something.
+ *
+ * A model can name this benchmark's tasks from its training data — one real
+ * clean cell spent three steps reasoning aloud about which tasks the suite
+ * contains — so `foreign_task_id` firing is not by itself a reason to fail a
+ * run, and a check that failed on it would fail on well-read models rather
+ * than on retrieval. It stays in the report because it does find things: in
+ * that same run it caught a mounted directory of past evaluation reports.
+ *
+ * The other three are different in kind. Across nearly two hundred real cells
+ * none of them fired once, because a pinned revision, a tree fingerprint and a
+ * repository named next to a fetch are things a cell learns by going and
+ * getting them.
+ */
+const RETRIEVAL_SIGNALS: readonly ContaminationSignalKind[] = [
+  'upstream_repository',
+  'pinned_revision',
+  'task_tree_fingerprint',
+];
+
+export function isRetrievalSignal(kind: ContaminationSignalKind): boolean {
+  return RETRIEVAL_SIGNALS.includes(kind);
+}
+
+export interface ContaminationSignal {
+  kind: ContaminationSignalKind;
+  /** The trajectory step the evidence is in, so a reviewer can go read it. */
+  stepId: number | null;
+  /** What matched, verbatim. */
+  match: string;
+  /** Surrounding text, bounded, so the match can be judged without the file. */
+  excerpt: string;
+}
+
+export interface CellContaminationReport extends TrialCellRecord {
+  trajectoryPath: string;
+  /**
+   * False when the trajectory cannot answer the question — missing, degraded,
+   * unreadable. An unanalyzed cell is a hole in the run's coverage, and is
+   * counted as one rather than as a clean cell.
+   */
+  analyzed: boolean;
+  notAnalyzedReason?: string;
+  signals: ContaminationSignal[];
+}
+
+export interface ContaminationScanReport {
+  cells: CellContaminationReport[];
+  /** Coverage per arm, because a whole arm exporting nothing is the failure
+   * mode that looks most like success. */
+  coverageByAgent: Record<string, { cells: number; analyzed: number }>;
+  totals: {
+    cells: number;
+    analyzed: number;
+    cellsWithRetrievalSignals: number;
+    cellsWithAdvisorySignalsOnly: number;
+  };
+}
+
+/**
+ * Read `benchmark-identity.json` as a flat set of needles.
+ *
+ * The file is nested by benchmark and by profile and gains profiles over time.
+ * Walking it for the four field names takes every profile, present and future,
+ * without this file holding a second copy of its shape.
+ */
+export function flattenBenchmarkIdentity(catalog: unknown): BenchmarkIdentity {
+  const upstreamRepositoryUrls = new Set<string>();
+  const revisions = new Set<string>();
+  const taskTreeFingerprints = new Set<string>();
+  const taskIds = new Set<string>();
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    if (!value || typeof value !== 'object') return;
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if (key === 'upstreamRepositoryUrl' && typeof nested === 'string')
+        upstreamRepositoryUrls.add(nested);
+      else if (key === 'revision' && typeof nested === 'string') revisions.add(nested);
+      else if (key === 'taskTreeFingerprint' && typeof nested === 'string')
+        taskTreeFingerprints.add(nested);
+      else if (key === 'taskIds' && Array.isArray(nested)) {
+        for (const id of nested) if (typeof id === 'string') taskIds.add(id);
+      } else visit(nested);
+    }
+  };
+  visit(catalog);
+  const identity = {
+    upstreamRepositoryUrls: [...upstreamRepositoryUrls],
+    revisions: [...revisions],
+    taskTreeFingerprints: [...taskTreeFingerprints],
+    taskIds: [...taskIds],
+  };
+  // A catalog that carries none of the four is either the wrong file or a
+  // renamed field, and either way a scan run against it reports every cell
+  // clean. That is the one outcome this must never produce silently.
+  if (identity.upstreamRepositoryUrls.length === 0 || identity.taskIds.length === 0) {
+    throw new Error('benchmark identity carries no upstream repository or task ids');
+  }
+  return identity;
+}
+
+/**
+ * The shortest revision prefix worth searching for.
+ *
+ * Two things write this revision down. One is the harness, which abbreviates to
+ * eight in the task-source path a cell can see. The other is git, which the
+ * cell runs: `git log --oneline` and `rev-parse --short` abbreviate to seven by
+ * default, so a cell that reads the revision out of a checkout and writes it
+ * down the way git just showed it is one character below anything the harness
+ * itself would have written. Take the smaller.
+ *
+ * Short does not mean noisy: the pattern is one specific string, not a run of
+ * hex, so a false match needs those seven characters to occur verbatim.
+ */
+export const MIN_REVISION_PREFIX = 7;
+
+const EXCERPT_RADIUS = 80;
+
+/**
+ * How the Maka exporter labels what it managed to produce.
+ *
+ * `maka_trajectory.py` owns these; they are spelled here because this side has
+ * to read them, and `harness-contamination-scan.test.ts` pins the spelling
+ * against that file so the two cannot drift apart in silence.
+ */
+export const TRAJECTORY_ARTIFACT_KIND_KEY = 'maka_artifact_kind';
+export const TRAJECTORY_SUMMARY_REASON_KEY = 'maka_summary_reason';
+export const TRAJECTORY_ARTIFACT_KIND_FULL = 'full';
+export const TRAJECTORY_ARTIFACT_KIND_SUMMARY = 'summary';
+
+/**
+ * The reason this trajectory cannot be searched, or undefined if it can.
+ *
+ * One exporter here can degrade: when Maka cannot build a trajectory from the
+ * events it writes a one-step summary instead, and a scan that searched that
+ * step, matched nothing, and filed the cell under clean would be reporting on
+ * nothing at all — which is what happened to a whole 89-cell run. A trajectory
+ * that says `summary`, or that carries a label this file does not recognize,
+ * refuses.
+ *
+ * An absent label is ordinary ATIF: every other arm's trajectory comes from an
+ * upstream Harbor agent that has no degraded mode and writes no such label.
+ * Demanding a label they were never going to carry would file every competitor
+ * cell under "broken export", and an alarm that fires on every run is not an
+ * alarm.
+ */
+function notAnalyzableReason(
+  trajectory: Record<string, unknown>,
+  steps: unknown[],
+): string | undefined {
+  const extra = trajectory.extra;
+  const kind =
+    extra && typeof extra === 'object'
+      ? (extra as Record<string, unknown>)[TRAJECTORY_ARTIFACT_KIND_KEY]
+      : undefined;
+  if (kind === TRAJECTORY_ARTIFACT_KIND_SUMMARY) {
+    const reason =
+      extra && typeof extra === 'object'
+        ? (extra as Record<string, unknown>)[TRAJECTORY_SUMMARY_REASON_KEY]
+        : undefined;
+    return `trajectory degraded to a summary${typeof reason === 'string' ? `: ${reason}` : ''}`;
+  }
+  if (kind !== undefined && kind !== TRAJECTORY_ARTIFACT_KIND_FULL) {
+    return `trajectory carries an unrecognized ${TRAJECTORY_ARTIFACT_KIND_KEY}: ${JSON.stringify(kind)}`;
+  }
+  if (steps.length === 0) return 'trajectory carries no steps';
+  return undefined;
+}
+
+/** Scan one cell's trajectory against the benchmark catalog. */
+export function scanTrajectory(input: {
+  trajectory: unknown;
+  ownTaskId: string;
+  identity: BenchmarkIdentity;
+}): { analyzed: boolean; notAnalyzedReason?: string; signals: ContaminationSignal[] } {
+  if (!input.trajectory || typeof input.trajectory !== 'object') {
+    return { analyzed: false, notAnalyzedReason: 'trajectory is not an object', signals: [] };
+  }
+  const trajectory = input.trajectory as Record<string, unknown>;
+  const steps = Array.isArray(trajectory.steps) ? trajectory.steps : [];
+  const refusal = notAnalyzableReason(trajectory, steps);
+  if (refusal) return { analyzed: false, notAnalyzedReason: refusal, signals: [] };
+
+  const repositoryPatterns = input.identity.upstreamRepositoryUrls.map(repositoryPattern);
+  const revisionPatterns = input.identity.revisions
+    .map(revisionPattern)
+    .filter((pattern): pattern is RegExp => pattern !== null);
+  const fingerprintPatterns = input.identity.taskTreeFingerprints.map(
+    (fingerprint) => new RegExp(escapeRegExp(fingerprint), 'gi'),
+  );
+  const foreignTaskPatterns = input.identity.taskIds
+    .filter((taskId) => taskId !== input.ownTaskId)
+    .map((taskId) => ({
+      taskId,
+      // Case-insensitive because a cell writes a task id however it likes. The
+      // right boundary rejects a dot only when something identifier-like
+      // follows it, because task ids carry dots — one of them ends in a version
+      // number — while a mention at the end of a sentence ends in a bare dot.
+      pattern: new RegExp(`(?<![A-Za-z0-9._-])${escapeRegExp(taskId)}(?!\\.?[A-Za-z0-9_-])`, 'gi'),
+    }));
+
+  const signals: ContaminationSignal[] = [];
+  for (const step of steps) {
+    if (!step || typeof step !== 'object') continue;
+    const id = stepId(step as Record<string, unknown>);
+    for (const text of stepText(step)) {
+      for (const pattern of repositoryPatterns)
+        pushMatches(signals, 'upstream_repository', id, text, pattern);
+      for (const pattern of revisionPatterns)
+        pushMatches(signals, 'pinned_revision', id, text, pattern);
+      for (const pattern of fingerprintPatterns)
+        pushMatches(signals, 'task_tree_fingerprint', id, text, pattern);
+      for (const foreign of foreignTaskPatterns)
+        pushMatches(signals, 'foreign_task_id', id, text, foreign.pattern);
+    }
+  }
+  return { analyzed: true, signals };
+}
+
+/**
+ * Scan every cell a run wrote down.
+ *
+ * The cell list is the run's, not this file's guess at it: a cell missing from
+ * the log is missing from the report, which is the honest answer when the
+ * harness never got far enough to record it.
+ */
+export async function scanRunForContamination(input: {
+  trialCellLogPath: string;
+  identity: BenchmarkIdentity;
+  readTrajectory?: (path: string) => Promise<string>;
+}): Promise<ContaminationScanReport> {
+  const readTrajectory = input.readTrajectory ?? ((path: string) => readFile(path, 'utf8'));
+  const records = await readTrialCellLog(input.trialCellLogPath);
+  const cells: CellContaminationReport[] = [];
+  for (const record of records) {
+    const trajectoryPath = join(record.trialDir, TRAJECTORY_RELATIVE_PATH);
+    let scan: { analyzed: boolean; notAnalyzedReason?: string; signals: ContaminationSignal[] };
+    try {
+      const parsed: unknown = JSON.parse(await readTrajectory(trajectoryPath));
+      scan = scanTrajectory({
+        trajectory: parsed,
+        ownTaskId: record.taskId,
+        identity: input.identity,
+      });
+    } catch (error) {
+      scan = {
+        analyzed: false,
+        notAnalyzedReason: `trajectory unreadable: ${(error as Error).message}`,
+        signals: [],
+      };
+    }
+    cells.push({ ...record, trajectoryPath, ...scan });
+  }
+
+  const coverageByAgent: Record<string, { cells: number; analyzed: number }> = {};
+  for (const cell of cells) {
+    const bucket = (coverageByAgent[cell.agent] ??= { cells: 0, analyzed: 0 });
+    bucket.cells += 1;
+    if (cell.analyzed) bucket.analyzed += 1;
+  }
+  return {
+    cells,
+    coverageByAgent,
+    totals: {
+      cells: cells.length,
+      analyzed: cells.filter((cell) => cell.analyzed).length,
+      cellsWithRetrievalSignals: cells.filter((cell) =>
+        cell.signals.some((signal) => isRetrievalSignal(signal.kind)),
+      ).length,
+      cellsWithAdvisorySignalsOnly: cells.filter(
+        (cell) =>
+          cell.signals.length > 0 && !cell.signals.some((signal) => isRetrievalSignal(signal.kind)),
+      ).length,
+    },
+  };
+}
+
+/**
+ * The report as a person reads it: what was searched first, what was found
+ * second.
+ *
+ * Coverage leads because the finding that matters most is the one a reader
+ * would otherwise supply themselves — "nothing fired" means nothing only if
+ * something was read.
+ */
+export function renderContaminationScanReportMarkdown(report: ContaminationScanReport): string {
+  const { totals } = report;
+  const lines = [
+    '# Contamination scan',
+    '',
+    `Searched ${totals.analyzed}/${totals.cells} cells.`,
+    '',
+    '| arm | cells | searched |',
+    '| --- | --- | --- |',
+    ...Object.entries(report.coverageByAgent)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([agent, c]) => `| ${agent} | ${c.cells} | ${c.analyzed} |`),
+    '',
+    `Retrieval evidence: ${totals.cellsWithRetrievalSignals} cells. Task-id mentions only: ${totals.cellsWithAdvisorySignalsOnly} cells.`,
+  ];
+
+  const unsearched = report.cells.filter((cell) => !cell.analyzed);
+  if (unsearched.length > 0) {
+    lines.push('', '## Not searched', '');
+    for (const cell of unsearched) {
+      lines.push(`- \`${cell.roundId}\` (${cell.agent}): ${cell.notAnalyzedReason}`);
+    }
+  }
+
+  const flagged = report.cells.filter((cell) => cell.signals.length > 0);
+  if (flagged.length > 0) {
+    lines.push('', '## Signals', '');
+    for (const cell of flagged) {
+      lines.push(`### \`${cell.roundId}\` (${cell.agent})`, '');
+      for (const signal of cell.signals) {
+        const where = signal.stepId === null ? 'step ?' : `step ${signal.stepId}`;
+        lines.push(
+          `- **${signal.kind}**${isRetrievalSignal(signal.kind) ? '' : ' (advisory)'}, ${where}: \`${signal.match}\``,
+          `  > ${signal.excerpt.replace(/\n/g, ' ')}`,
+        );
+      }
+      lines.push('');
+    }
+  }
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+/**
+ * The repository's identity, as the part of it that a rewritten host cannot
+ * remove.
+ *
+ * Matching the catalog's own host would only catch a fetch spelled the way the
+ * catalog spells it. The same repository is reachable by IP, through a mirror,
+ * through `raw.githubusercontent.com`, over SSH — every one of which drops or
+ * replaces the host while carrying `owner/repo` unchanged, because that pair
+ * *is* the repository's name. Matching the pair closes the whole host-rewrite
+ * family at once instead of one host at a time, and it is specific enough to be
+ * quiet: neither benchmark's task instructions contain it.
+ *
+ * What this does not reach is a reference assembled rather than written —
+ * encoded, or built from parts across steps. That is unbounded and this makes
+ * no claim on it; the signals here are for references that appear verbatim.
+ */
+function repositoryPattern(upstreamRepositoryUrl: string): RegExp {
+  const withoutScheme = upstreamRepositoryUrl
+    .replace(/^[a-z]+:\/\//i, '')
+    .replace(/\.git$/i, '')
+    .replace(/\/+$/, '');
+  const segments = withoutScheme.split('/');
+  // Host, then owner and repository. Anything shorter is not a repository URL
+  // and is matched whole rather than guessed at.
+  const pair = segments.length >= 3 ? segments.slice(-2).join('/') : withoutScheme;
+  // Bounded so a longer name is not read as this one, and bounded on the right
+  // without `.`, because the commonest spelling of all ends in `.git`.
+  return new RegExp(`(?<![A-Za-z0-9._-])${escapeRegExp(pair)}(?![A-Za-z0-9_-])`, 'gi');
+}
+
+function revisionPattern(revision: string): RegExp | null {
+  if (revision.length < MIN_REVISION_PREFIX) return null;
+  return new RegExp(revision.slice(0, MIN_REVISION_PREFIX), 'gi');
+}
+
+/**
+ * Every string a trajectory step carries, flattened.
+ *
+ * Which field a leak lands in is not something to predict: an arm may name the
+ * upstream in a shell command, in its own reasoning, or in a tool result it
+ * read back. Walking the step whole costs nothing and cannot be outflanked by
+ * an exporter adding a field.
+ */
+function stepText(value: unknown, out: string[] = []): string[] {
+  if (typeof value === 'string') out.push(value);
+  else if (Array.isArray(value)) for (const item of value) stepText(item, out);
+  else if (value && typeof value === 'object') {
+    for (const nested of Object.values(value as Record<string, unknown>)) stepText(nested, out);
+  }
+  return out;
+}
+
+function stepId(step: Record<string, unknown>): number | null {
+  return typeof step.step_id === 'number' ? step.step_id : null;
+}
+
+function pushMatches(
+  signals: ContaminationSignal[],
+  kind: ContaminationSignalKind,
+  id: number | null,
+  text: string,
+  pattern: RegExp,
+): void {
+  for (const match of text.matchAll(pattern)) {
+    const index = match.index ?? 0;
+    signals.push({
+      kind,
+      stepId: id,
+      match: match[0],
+      excerpt: excerptAround(text, index, match[0].length),
+    });
+  }
+}
+
+function excerptAround(haystack: string, index: number, length: number): string {
+  const start = Math.max(0, index - EXCERPT_RADIUS);
+  const end = Math.min(haystack.length, index + length + EXCERPT_RADIUS);
+  return `${start > 0 ? '…' : ''}${haystack.slice(start, end)}${end < haystack.length ? '…' : ''}`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/headless/src/harness-contamination-scan.ts
+++ b/packages/headless/src/harness-contamination-scan.ts
@@ -382,7 +382,7 @@ export function renderContaminationScanReportMarkdown(report: ContaminationScanR
     `Searched ${totals.analyzed} of ${totals.cells} recorded cells.`,
     '',
     report.unrecordedCells.length > 0
-      ? `**${report.unrecordedCells.length} cells the run scheduled were never recorded.** The run did not finish, or its artifacts never reached the log; whatever those cells did is not in this report.`
+      ? `**${report.unrecordedCells.length} cells this run root was scheduled to grade hold no record that it did.** An invocation was killed or abandoned, or its artifacts never reached the log; whatever those cells did is not in this report.`
       : 'Recorded means the harness got far enough to resolve a trial directory. A cell that died before that is not counted here or anywhere below.',
     '',
     '| arm | cells | searched |',

--- a/packages/headless/src/harness-contamination-scan.ts
+++ b/packages/headless/src/harness-contamination-scan.ts
@@ -382,7 +382,7 @@ export function renderContaminationScanReportMarkdown(report: ContaminationScanR
     `Searched ${totals.analyzed} of ${totals.cells} recorded cells.`,
     '',
     report.unrecordedCells.length > 0
-      ? `**${report.unrecordedCells.length} cells the run declared were never recorded.** The run did not finish, or its artifacts never reached the log; whatever those cells did is not in this report.`
+      ? `**${report.unrecordedCells.length} cells the run scheduled were never recorded.** The run did not finish, or its artifacts never reached the log; whatever those cells did is not in this report.`
       : 'Recorded means the harness got far enough to resolve a trial directory. A cell that died before that is not counted here or anywhere below.',
     '',
     '| arm | cells | searched |',

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -65,6 +65,7 @@ import {
   MAKA_NODE_TOOLCHAIN_FINGERPRINT,
 } from './maka-node-toolchain.js';
 import { buildAgentRepoMounts, CONTAINER_MAKA_REPO } from './agent-repo-mount.js';
+import { appendTrialCell } from './trial-cell-log.js';
 import {
   summarizeProviderTelemetry,
   startProviderAuthProxy,
@@ -158,6 +159,12 @@ export interface PierTaskRunnerOptions {
   agentVersion?: string;
   /** Base directory under which each task gets an isolated per-task job dir. */
   jobsDir: string;
+  /**
+   * Where to append one row per finished trial, recording which arm ran which
+   * task in which directory. Readers of a finished run take the run's cells
+   * from this file rather than re-deriving them from the tree.
+   */
+  trialCellLogPath?: string;
   /** MAKA_MODEL / pier `-m`, e.g. "k3" or "deepseek/deepseek-v4-flash". */
   model: string;
   /** MAKA_PROVIDER, e.g. "kimi-coding-plan". */
@@ -488,6 +495,13 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
           tail(result.stderr || result.stdout),
         );
       }
+      await appendTrialCell(options.trialCellLogPath, {
+        runId: input.runId,
+        roundId: input.roundId,
+        taskId: input.task.id,
+        agent: options.agent ?? 'maka',
+        trialDir,
+      });
 
       // A populated `exception_info` records how the agent phase ended, NOT
       // whether the trial was graded: pier's trial.py records the exception and

--- a/packages/headless/src/trial-cell-log.ts
+++ b/packages/headless/src/trial-cell-log.ts
@@ -1,0 +1,84 @@
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+/**
+ * What the harness knew about one finished cell, written down while it still
+ * knew it.
+ *
+ * Everything downstream that wants to read a run's per-cell artifacts — the
+ * contamination scan today, anything else later — reads this instead of walking
+ * the run tree and reconstructing which arm produced which directory. The run
+ * tree's shape is the harness's private business; a reader that recomputes it
+ * is guessing at a fact the writer had in hand.
+ */
+export interface TrialCellRecord {
+  runId: string;
+  /** Round id as scheduled; carries the arm and rep the harness assigned. */
+  roundId: string;
+  taskId: string;
+  /** The arm's agent. Harness A/B arm ids and agent ids are the same string. */
+  agent: string;
+  /** Host path to the trial directory the harness read this cell's output from. */
+  trialDir: string;
+}
+
+const TRIAL_CELL_LOG_FILENAME = 'trial-cells.jsonl';
+
+export function trialCellLogPath(runRoot: string): string {
+  return `${runRoot}/${TRIAL_CELL_LOG_FILENAME}`;
+}
+
+/**
+ * Append one cell. Called once per trial, right after the trial directory is
+ * resolved, so a row exists exactly when a trial directory does — including for
+ * a cell that then failed, whose artifacts are still worth reading.
+ *
+ * Logging is not the run's job: a failure here must not fail a graded cell, so
+ * the write is best-effort and reports its own absence by leaving no row. A run
+ * that asked for no log passes no path.
+ */
+export async function appendTrialCell(
+  path: string | undefined,
+  record: TrialCellRecord,
+): Promise<void> {
+  if (!path) return;
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, `${JSON.stringify(record)}\n`, 'utf8');
+  } catch {
+    // Intentionally swallowed: see above.
+  }
+}
+
+export async function readTrialCellLog(path: string): Promise<TrialCellRecord[]> {
+  const text = await readFile(path, 'utf8');
+  return text
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line, index) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch (error) {
+        throw new Error(`${path}: line ${index + 1} is not JSON: ${(error as Error).message}`);
+      }
+      return assertTrialCellRecord(parsed, `${path}: line ${index + 1}`);
+    });
+}
+
+function assertTrialCellRecord(value: unknown, where: string): TrialCellRecord {
+  if (!value || typeof value !== 'object') throw new Error(`${where} is not an object`);
+  const record = value as Record<string, unknown>;
+  for (const field of ['runId', 'roundId', 'taskId', 'agent', 'trialDir'] as const) {
+    if (typeof record[field] !== 'string' || record[field] === '') {
+      throw new Error(`${where} is missing ${field}`);
+    }
+  }
+  return {
+    runId: record.runId as string,
+    roundId: record.roundId as string,
+    taskId: record.taskId as string,
+    agent: record.agent as string,
+    trialDir: record.trialDir as string,
+  };
+}

--- a/packages/headless/src/trial-cell-log.ts
+++ b/packages/headless/src/trial-cell-log.ts
@@ -1,5 +1,5 @@
 import { appendFile, mkdir, readFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 
 /**
  * What the harness knew about one finished cell, written down while it still
@@ -25,7 +25,7 @@ export interface TrialCellRecord {
 const TRIAL_CELL_LOG_FILENAME = 'trial-cells.jsonl';
 
 export function trialCellLogPath(runRoot: string): string {
-  return `${runRoot}/${TRIAL_CELL_LOG_FILENAME}`;
+  return join(runRoot, TRIAL_CELL_LOG_FILENAME);
 }
 
 /**

--- a/packages/headless/src/trial-cell-log.ts
+++ b/packages/headless/src/trial-cell-log.ts
@@ -30,12 +30,14 @@ export function trialCellLogPath(runRoot: string): string {
 
 /**
  * Append one cell. Called once per trial, right after the trial directory is
- * resolved, so a row exists exactly when a trial directory does — including for
- * a cell that then failed, whose artifacts are still worth reading.
+ * resolved, so a row is attempted for every trial directory there is —
+ * including for a cell that then failed, whose artifacts are still worth
+ * reading.
  *
- * Logging is not the run's job: a failure here must not fail a graded cell, so
- * the write is best-effort and reports its own absence by leaving no row. A run
- * that asked for no log passes no path.
+ * Attempted, not guaranteed. Logging is not the run's job: a failure here must
+ * not fail a graded cell, so the write is best-effort and reports its own
+ * absence by leaving no row, which a reader counts as a cell it cannot account
+ * for. A run that asked for no log passes no path.
  */
 export async function appendTrialCell(
   path: string | undefined,

--- a/packages/headless/src/trial-cell-log.ts
+++ b/packages/headless/src/trial-cell-log.ts
@@ -97,7 +97,16 @@ async function truncateTornTail(path: string): Promise<void> {
  * anywhere else is real corruption and refuses.
  */
 export async function readTrialCellLog(path: string): Promise<TrialCellRecord[]> {
-  const text = await readFile(path, 'utf8');
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch (error) {
+    // No log is no cells, which is a true and useful answer: a run that died
+    // before its first trial directory recorded nothing. Whether the directory
+    // is a run at all is a different question, and not this file's to answer.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
   const lines = text.split('\n');
   const torn = lines.length > 0 && lines[lines.length - 1] !== '';
   const attempts = lines

--- a/packages/headless/src/trial-cell-log.ts
+++ b/packages/headless/src/trial-cell-log.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, truncate } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
 /**
@@ -44,10 +44,34 @@ export async function appendTrialCell(
   if (!path) return;
   try {
     await mkdir(dirname(path), { recursive: true });
+    await truncateTornTail(path);
     await appendFile(path, `${JSON.stringify(record)}\n`, 'utf8');
   } catch {
     // Intentionally swallowed: see above.
   }
+}
+
+/**
+ * Drop a row a crash cut off mid-write, before appending after it.
+ *
+ * Without this, a run resumed after a crash appends past the stump and buries
+ * it in the middle of the file, where it is indistinguishable from corruption
+ * and takes the whole scan down with it. The WAL beside this one does exactly
+ * this for the same reason. Each row lands in a single append-mode write, so
+ * the file is only ever missing a trailing newline because a process died, not
+ * because one is in flight.
+ */
+async function truncateTornTail(path: string): Promise<void> {
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  if (text.length === 0 || text.endsWith('\n')) return;
+  const lastNewline = text.lastIndexOf('\n');
+  await truncate(path, lastNewline < 0 ? 0 : lastNewline + 1);
 }
 
 /**
@@ -60,14 +84,27 @@ export async function appendTrialCell(
  * now holds the later attempt's artifacts. Reading the rows one-to-one would
  * count one cell twice and let an attempt the harness itself superseded — whose
  * artifacts no longer exist — decide the verdict for the attempt that was
- * graded. The last row for a cell is the one that ran.
+ * graded. The last row for a cell is the one that ran, which holds because the
+ * run lock makes this file single-writer and a cell's attempts are serial: the
+ * retry is a later invocation, and an attempt orphaned by a crash is admitted
+ * as a failure rather than re-run. Nothing here would detect rows arriving out
+ * of order, so a caller that writes this log without the run lock would get a
+ * silently wrong attempt.
+ *
+ * A crash mid-append leaves a row without its newline. That is a truncated
+ * write, not a corrupt log, and it is dropped the way the WAL beside it drops
+ * one — a run resumed after a crash must still be scannable. A malformed row
+ * anywhere else is real corruption and refuses.
  */
 export async function readTrialCellLog(path: string): Promise<TrialCellRecord[]> {
   const text = await readFile(path, 'utf8');
-  const attempts = text
-    .split('\n')
-    .filter((line) => line.trim().length > 0)
-    .map((line, index) => {
+  const lines = text.split('\n');
+  const torn = lines.length > 0 && lines[lines.length - 1] !== '';
+  const attempts = lines
+    .slice(0, torn ? -1 : undefined)
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => line.trim().length > 0)
+    .map(({ line, index }) => {
       let parsed: unknown;
       try {
         parsed = JSON.parse(line);
@@ -76,6 +113,9 @@ export async function readTrialCellLog(path: string): Promise<TrialCellRecord[]>
       }
       return assertTrialCellRecord(parsed, `${path}: line ${index + 1}`);
     });
+  // Keyed on the run too, though one log only ever belongs to one run — the
+  // run root is named after it. An extra component that is constant can only
+  // ever keep two cells apart that were never the same cell.
   const byCell = new Map<string, TrialCellRecord>();
   for (const attempt of attempts) {
     byCell.set(JSON.stringify([attempt.runId, attempt.roundId, attempt.taskId]), attempt);

--- a/packages/headless/src/trial-cell-log.ts
+++ b/packages/headless/src/trial-cell-log.ts
@@ -107,21 +107,9 @@ export async function readTrialCellLog(path: string): Promise<TrialCellRecord[]>
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
     throw error;
   }
-  const lines = text.split('\n');
-  const torn = lines.length > 0 && lines[lines.length - 1] !== '';
-  const attempts = lines
-    .slice(0, torn ? -1 : undefined)
-    .map((line, index) => ({ line, index }))
-    .filter(({ line }) => line.trim().length > 0)
-    .map(({ line, index }) => {
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(line);
-      } catch (error) {
-        throw new Error(`${path}: line ${index + 1} is not JSON: ${(error as Error).message}`);
-      }
-      return assertTrialCellRecord(parsed, `${path}: line ${index + 1}`);
-    });
+  const attempts = parseRows(path, text).map(({ value, where }) =>
+    assertTrialCellRecord(value, where),
+  );
   // Keyed on the run too, though one log only ever belongs to one run — the
   // run root is named after it. An extra component that is constant can only
   // ever keep two cells apart that were never the same cell.
@@ -130,6 +118,30 @@ export async function readTrialCellLog(path: string): Promise<TrialCellRecord[]>
     byCell.set(JSON.stringify([attempt.runId, attempt.roundId, attempt.taskId]), attempt);
   }
   return [...byCell.values()];
+}
+
+/**
+ * The rows of one of this file's logs, minus the one a crash cut off.
+ *
+ * A row without its trailing newline is a truncated write, not a corrupt log,
+ * and it is dropped the way the WAL beside these drops one — a run resumed
+ * after a crash must still be readable. A malformed row anywhere else is real
+ * corruption and refuses.
+ */
+function parseRows(path: string, text: string): { value: unknown; where: string }[] {
+  const lines = text.split('\n');
+  const torn = lines.length > 0 && lines[lines.length - 1] !== '';
+  return lines
+    .slice(0, torn ? -1 : undefined)
+    .map((line, index) => ({ line, where: `${path}: line ${index + 1}` }))
+    .filter(({ line }) => line.trim().length > 0)
+    .map(({ line, where }) => {
+      try {
+        return { value: JSON.parse(line) as unknown, where };
+      } catch (error) {
+        throw new Error(`${where} is not JSON: ${(error as Error).message}`);
+      }
+    });
 }
 
 function assertTrialCellRecord(value: unknown, where: string): TrialCellRecord {
@@ -147,4 +159,69 @@ function assertTrialCellRecord(value: unknown, where: string): TrialCellRecord {
     agent: record.agent as string,
     trialDir: record.trialDir as string,
   };
+}
+
+/** One cell the harness put on the schedule: an arm crossed with a task. */
+export interface ScheduledCellRecord {
+  agent: string;
+  taskId: string;
+}
+
+const SCHEDULED_CELL_LOG_FILENAME = 'scheduled-cells.jsonl';
+
+export function scheduledCellLogPath(runRoot: string): string {
+  return join(runRoot, SCHEDULED_CELL_LOG_FILENAME);
+}
+
+/**
+ * Write down the grid, at the moment the harness decides what it is.
+ *
+ * Which cells a run grades is not derivable from anything it leaves behind.
+ * The frozen manifest carries the benchmark's whole task list, while a run
+ * grades `limit` of them — and the same frozen manifest legitimately serves a
+ * canary and the full run that resumes it, so no field in it could hold the
+ * answer for both. Only the scheduler knows, and only while it is scheduling.
+ *
+ * Unlike a finished cell, this is not best-effort. It is written before any
+ * cell is graded, so refusing here costs a run nothing, and a run whose grid
+ * was never recorded is one no later reader can bound.
+ *
+ * Resuming appends the new invocation's grid to the previous one and the
+ * reader takes the union, so a canary continued at full width is expected to
+ * hold every cell either invocation scheduled.
+ */
+export async function appendScheduledCells(
+  path: string,
+  cells: readonly ScheduledCellRecord[],
+): Promise<void> {
+  if (cells.length === 0) throw new Error(`${path}: a run schedules at least one cell`);
+  await mkdir(dirname(path), { recursive: true });
+  await truncateTornTail(path);
+  await appendFile(
+    path,
+    cells.map((cell) => `${JSON.stringify({ agent: cell.agent, taskId: cell.taskId })}\n`).join(''),
+    'utf8',
+  );
+}
+
+/** Every cell this run ever scheduled, each named once. */
+export async function readScheduledCellLog(path: string): Promise<ScheduledCellRecord[]> {
+  const text = await readFile(path, 'utf8');
+  const byCell = new Map<string, ScheduledCellRecord>();
+  for (const { value, where } of parseRows(path, text)) {
+    const cell = assertScheduledCellRecord(value, where);
+    byCell.set(JSON.stringify([cell.agent, cell.taskId]), cell);
+  }
+  return [...byCell.values()];
+}
+
+function assertScheduledCellRecord(value: unknown, where: string): ScheduledCellRecord {
+  if (!value || typeof value !== 'object') throw new Error(`${where} is not an object`);
+  const record = value as Record<string, unknown>;
+  for (const field of ['agent', 'taskId'] as const) {
+    if (typeof record[field] !== 'string' || record[field] === '') {
+      throw new Error(`${where} is missing ${field}`);
+    }
+  }
+  return { agent: record.agent as string, taskId: record.taskId as string };
 }

--- a/packages/headless/src/trial-cell-log.ts
+++ b/packages/headless/src/trial-cell-log.ts
@@ -50,9 +50,21 @@ export async function appendTrialCell(
   }
 }
 
+/**
+ * The run's cells: one row per cell, each the attempt that is still on disk.
+ *
+ * A cell can be attempted more than once — the adjudicated-infra retry re-runs
+ * a round, and so does re-invoking a run id against a WAL that does not mark it
+ * complete. Each attempt appends, and each attempt starts by deleting the
+ * previous attempt's job directory, so an earlier row names a directory that
+ * now holds the later attempt's artifacts. Reading the rows one-to-one would
+ * count one cell twice and let an attempt the harness itself superseded — whose
+ * artifacts no longer exist — decide the verdict for the attempt that was
+ * graded. The last row for a cell is the one that ran.
+ */
 export async function readTrialCellLog(path: string): Promise<TrialCellRecord[]> {
   const text = await readFile(path, 'utf8');
-  return text
+  const attempts = text
     .split('\n')
     .filter((line) => line.trim().length > 0)
     .map((line, index) => {
@@ -64,6 +76,11 @@ export async function readTrialCellLog(path: string): Promise<TrialCellRecord[]>
       }
       return assertTrialCellRecord(parsed, `${path}: line ${index + 1}`);
     });
+  const byCell = new Map<string, TrialCellRecord>();
+  for (const attempt of attempts) {
+    byCell.set(JSON.stringify([attempt.runId, attempt.roundId, attempt.taskId]), attempt);
+  }
+  return [...byCell.values()];
 }
 
 function assertTrialCellRecord(value: unknown, where: string): TrialCellRecord {


### PR DESCRIPTION
## Summary

In the #1970 run an arm read the benchmark's pinned revision out of its own mount, fetched the task's reference solution from the public repository at that revision, and recorded a pass that measured lookup. Nothing in the harness would have said so. This adds the check that would have.

It lands in two parts, because the first is what makes the second small.

**The harness writes down what it knows.** Both task runners already resolve a trial directory and already know which arm ran which task in it — and then throw all of it away. So each run now appends one row per finished trial: run, round, task, arm, directory. A row exists exactly when a trial directory does, including for a cell that then failed, whose artifacts are still worth reading. The write is best-effort and cannot fail a graded cell. A cell attempted twice — the adjudicated-infra retry, or re-invoking a run id — appends twice, and each attempt deletes the previous attempt's job directory first; the last row for a cell is the one that ran, and earlier rows are dropped at read time.

The harness also writes down the grid — the arms crossed with the tasks — where the cohort is handed over to be run. This is not derivable afterwards: the frozen manifest names every task in the benchmark, a run grades `limit` of them, and the same frozen manifest serves a five-task canary and the full run that resumes against it. The grid comes off the same two arrays the cohort is given, so it cannot diverge from what runs. It is still a statement of intent — the first cell has yet to launch — so a run abandoned before its first trial directory leaves a grid it never filled, and that root stays refused until it is graded or given up for a fresh run id. The grid can only widen what a reader demands, never narrow it.

**The scan only reads.** It opens each row's normalized trajectory and searches every string it carries for four things:

- the upstream repository named as `owner/repo` — the part a rewritten host (SSH, a raw host, an IP, a mirror) cannot drop, which closes that whole family at once instead of one host at a time
- the pinned revision, at the length `git rev-parse --short` abbreviates to rather than the length the harness writes
- the task-tree fingerprint
- any task id from the suite other than this cell's own

The first three are evidence a cell *reached* for something and fail the run. The fourth is evidence it *knew* something: a model can name this suite's tasks from what it read years ago — one real clean cell spent three steps reasoning aloud about which tasks the suite contains — so task-id mentions are reported and counted, never fatal. They still earn their place: in that same run the signal caught a mounted directory of past evaluation reports.

What it cannot search, it says so about. A Maka trajectory degraded to a summary, a label this side does not recognize, an unlabelled trajectory from the one arm that always labels, a trajectory that never landed — each is a hole in coverage, counted as one and reported per arm. So is a scheduled cell the log never recorded. Three things make the exit non-zero: retrieval evidence, a scheduled cell that was never recorded, and a recorded cell that could not be searched. Together they give a zero exit one meaning — every cell the run scheduled was recorded, and every recorded cell was searched and came back clean. A clean verdict on no evidence is the one outcome this must never produce, and it is what a whole 89-cell run would have got. The report names what is unaccounted for and does not narrate why: it cannot see whether an invocation was killed or its artifacts never landed.

The alternative considered and rejected was to derive all of this from the run tree: recompute round ids, re-read the manifest for arm identity, recurse for trajectories. Every one of those is a reconstruction of a fact the harness had in hand, and each is a place to be quietly wrong in the direction of "clean".

Benchmark identity stays host-only: the scanner compiled into `dist` — which a graded arm mounts — holds none of it and takes it as an argument. The host-only entrypoint loads it, and `harness-ab-manifest.test.ts` holds that boundary over the whole build output.

Refs #1970

## Verification

- `npm run -w @maka/headless test` — 1505 pass, 0 fail (one case is skipped unless the checkout is clean)
- `npm run lint`, `npm run format:check`, `npm run build` — clean
- Red/green counter-proofs on the judgements that carry the check, each reverted after:
  - widening the repository pattern's right boundary to include `.` (so `…-2-1.git` stops matching) fails the `.git`, SSH and excerpt tests
  - dropping unsearched cells from the exit condition fails `exits non-zero when a declared cell could not be searched`
  - accepting a degraded summary as searchable fails `a degraded summary`
  - taking the grid from the manifest instead of the schedule fails `passes a run that graded a slice of the benchmark and finished`
  - deleting the schedule write, or letting it over-declare by one cell, each fails `records the grid it is about to grade, and only that` and `extends a completed prefix without rerunning valid cells`
  - reading an empty schedule as "this run scheduled nothing" fails `refuses a schedule that names no cells`
- The revision floor is measured, not remembered: the test abbreviates a real object in a freshly initialised repository and asserts the floor is no longer than what git returned, because `core.abbrev=auto` grows with object count and this repository is far past the smallest case a cell could be looking at.
- Both runner seams are proven by reading an artifact back out of the recorded directory, not by recomputing the path the runner computed.
- Not run: a real graded run. The scan is exercised end-to-end against a synthetic run root through the CLI's real exit codes.

### External review

Thirteen independent reviewers across six rounds, each against the commits standing at the time.

The first round's two reproductions of the same P1 — the cell log's cardinality not surviving the harness's retry flows — are fixed, as is everything else raised: a catalog guard that demanded two of four needle families, a fingerprint searched with its `sha256:` prefix, a revision needle unbounded against surrounding hex, a case-sensitive own-task comparison, a report that said "Searched N/N cells", and a dead injection point. A fourteen-point mutation battery found seven judgements with no red test behind them; those tests exist now.

The second round verified the scanner against 2,852 real trajectories: zero retrieval-signal fires, seven advisory, two degraded summaries correctly refused.

The third round found a P0, and two reviewers found it independently. The scan had been bounding a run by its frozen manifest, so it called every complete canary — the default run shape — an unfinished run and refused it. The manifest could not have been read differently; the schedule simply is not in it. That was the same mistake the whole design exists to avoid, readmitted through a back door, and the fix is the same principle: the writer writes the grid down, the reader reads it.

The fourth round found the grid being written where a run has yet to survive its toolchains, so a wide sweep abandoned early held its claim against the canary that later completed the same root — and found that the write itself had no test behind it, since nothing exercises that layer. Moving the write to where the cohort is handed over addresses both, and shrinks but does not close the window: a run abandoned after that point still leaves a grid it never filled. The fifth round held the remaining overclaims to account: a comment that said the write survives everything that can fail, and a report that told a reader the run did not finish when what it could see was that cells were unaccounted for. The sixth found the same habit surviving in the one message that round had not touched — a run that died in toolchain preparation was told it was not a harness run root — and confirmed by enumeration that the `analyzed === 0` exit condition deleted alongside it was unreachable.

The residual window is deliberate, not overlooked. A run abandoned between the grid and its first trial directory leaves a claim it never filled, and that root stays refused. Two reviewers split on it, and the split was informative: the refusal is conservative and true of the root, the union can only widen what a reader demands, and re-running the same command clears it — so what needed fixing was the claim, not the behaviour.

One suggestion was declined: requiring an explicit `agent` whenever a log path is given. `options.agent ?? 'maka'` is the same default each runner uses to pick its adapter, so the logged identity is the adapter that ran; a separate guard would be where the two defaults start to drift.

## Review focus

The scan's authority is what the run wrote down — the grid it scheduled and the cells it finished. It never infers either from the tree, so a fact the harness failed to record becomes a refusal rather than a guess. Whether that is the right trade, and whether the schedule is now recorded at the one point where it is known, is the thing to push on.
