### PR TITLE
refactor(ui): give the update action a slot instead of a row of its own

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-app-update.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-app-update.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { AppUpdateStatus } from '../../preload/bridge-contract.js';
+import { updateReminderFromStatus } from '../../renderer/app-shell-app-update.js';
+
+describe('updateReminderFromStatus', () => {
+  it('leaves the silent phases silent', () => {
+    const silent: AppUpdateStatus[] = [
+      { state: 'idle', currentVersion: '0.1.6' },
+      { state: 'checking', currentVersion: '0.1.6' },
+      { state: 'not-available', currentVersion: '0.1.6' },
+      { state: 'available', currentVersion: '0.1.6', latestVersion: '0.1.7' },
+      {
+        state: 'downloading',
+        currentVersion: '0.1.6',
+        latestVersion: '0.1.7',
+        progress: { percent: 42 },
+      },
+      { state: 'installing', currentVersion: '0.1.6', latestVersion: '0.1.7' },
+    ];
+
+    for (const status of silent) {
+      assert.equal(
+        updateReminderFromStatus(status),
+        undefined,
+        `${status.state} resolves itself and must not reach the footer`,
+      );
+    }
+    assert.equal(updateReminderFromStatus(null), undefined);
+  });
+
+  it('asks for a restart once the update is on disk', () => {
+    assert.deepEqual(
+      updateReminderFromStatus({
+        state: 'downloaded',
+        currentVersion: '0.1.6',
+        latestVersion: '0.1.7',
+      }),
+      { state: 'downloaded', latestVersion: '0.1.7' },
+    );
+  });
+
+  it('offers a retry for a failure that knows which release it was', () => {
+    assert.deepEqual(
+      updateReminderFromStatus({
+        state: 'error',
+        currentVersion: '0.1.6',
+        latestVersion: '0.1.7',
+        message: 'ENOTFOUND',
+        operation: 'download',
+      }),
+      { state: 'error', latestVersion: '0.1.7' },
+    );
+  });
+
+  it('stays quiet when a failed check never learned of a release', () => {
+    assert.equal(
+      updateReminderFromStatus({
+        state: 'error',
+        currentVersion: '0.1.6',
+        message: 'ENOTFOUND',
+        operation: 'check',
+      }),
+      undefined,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/app-shell-app-update.ts
+++ b/apps/desktop/src/renderer/app-shell-app-update.ts
@@ -1,0 +1,32 @@
+import type { SidebarUpdateReminder } from '@maka/ui';
+import type { AppUpdateStatus } from '../preload/bridge-contract.js';
+
+/**
+ * The single answer to "which update states need the user".
+ *
+ * The updater runs with `autoDownload = true` and `autoInstallOnAppQuit =
+ * false` (app-update-service.ts), so `available` and `downloading` resolve
+ * themselves and ask nothing of anyone; only `downloaded` (which needs a
+ * restart) and `error` (which needs a retry) do. The footer used to carry a
+ * control through all four, which meant it spent most of its visible life
+ * asking for attention on behalf of a background download.
+ *
+ * This lives in one function rather than in the shell's render and its click
+ * handler both, because two copies of that list are free to disagree — and the
+ * one in the handler had already drifted into offering a retry for states that
+ * can no longer reach it.
+ */
+export function updateReminderFromStatus(
+  status: AppUpdateStatus | null,
+): SidebarUpdateReminder | undefined {
+  if (status?.state === 'downloaded') {
+    return { state: 'downloaded', latestVersion: status.latestVersion };
+  }
+  // `error` is the one state whose `latestVersion` is optional: a check that
+  // fails before it learns of a release has no version to name, and a reminder
+  // that cannot say which update failed is not worth a button.
+  if (status?.state === 'error' && status.latestVersion) {
+    return { state: 'error', latestVersion: status.latestVersion };
+  }
+  return undefined;
+}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -105,6 +105,7 @@ import {
 import { modelSetupToastCopy } from './model-connection-errors';
 import type { AppShellCommandListOptions } from './app-shell-command-actions';
 import { AppShellTopbarActions, AppShellWorkspaceTopActions } from './app-shell-chrome-actions';
+import { updateReminderFromStatus } from './app-shell-app-update';
 import { AppShellDetailPanel } from './app-shell-detail-panel';
 import { AppShellOverlays } from './app-shell-overlays';
 import { createAppShellDailyReviewBridge } from './app-shell-daily-review-bridge';
@@ -413,22 +414,13 @@ function AppShellContent({
     };
   }, []);
 
-  // `available` and `downloading` are deliberately absent. The updater sets
-  // `autoDownload = true`, so both phases resolve themselves and there is
-  // nothing for a user to decide; only `downloaded` (which needs a restart,
-  // because `autoInstallOnAppQuit` is false) and `error` do. The footer used
-  // to carry a control through all four, which meant it spent most of its
-  // visible life asking for attention on behalf of a background download.
-  const updateReminder =
-    appUpdateStatus?.state === 'downloaded' ||
-    (appUpdateStatus?.state === 'error' && Boolean(appUpdateStatus.latestVersion))
-    ? {
-        state: appUpdateStatus.state,
-        latestVersion: appUpdateStatus.latestVersion ?? appUpdateStatus.currentVersion,
-      }
-    : undefined;
+  const updateReminder = updateReminderFromStatus(appUpdateStatus);
+  // Dispatches on the reminder, not on the raw status: the footer is this
+  // callback's only caller and it only renders for the two states above, so
+  // reading the status again here would be the same "who needs the user" list
+  // maintained twice.
   const openUpdateDownload = useCallback(() => {
-    if (appUpdateStatus?.state === 'downloaded') {
+    if (updateReminder?.state === 'downloaded') {
       if (updateInstallInFlightRef.current) return;
       updateInstallInFlightRef.current = true;
       void requestDownloadedAppUpdate({
@@ -460,44 +452,23 @@ function AppShellContent({
         });
       return;
     }
-    if (
-      appUpdateStatus?.state === 'available' ||
-      appUpdateStatus?.state === 'downloading' ||
-      appUpdateStatus?.state === 'error'
-    ) {
-      void window.maka.app
-        .retryUpdateDownload()
-        .then((next) => {
-          if (next.state !== 'error') return;
-          toastApi.error(
-            shellCopy.updateRetryFailedTitle,
-            shellCopy.updateRetryFailedFallback,
-          );
-        })
-        .catch((error) => {
-          toastApi.error(
-            shellCopy.updateRetryFailedTitle,
-            localizedShellErrorMessage(error, shellCopy.updateRetryFailedFallback, uiLocale),
-          );
-        });
-      return;
-    }
+    if (!updateReminder) return;
     void window.maka.app
-      .openUpdateDownload()
-      .then((result) => {
-        if (result.ok) return;
+      .retryUpdateDownload()
+      .then((next) => {
+        if (next.state !== 'error') return;
         toastApi.error(
-          shellCopy.updateOpenFailedTitle,
-          shellCopy.updateOpenManualFallback,
+          shellCopy.updateRetryFailedTitle,
+          shellCopy.updateRetryFailedFallback,
         );
       })
       .catch((error) => {
         toastApi.error(
-          shellCopy.updateOpenFailedTitle,
-          localizedShellErrorMessage(error, shellCopy.tryAgainLater, uiLocale),
+          shellCopy.updateRetryFailedTitle,
+          localizedShellErrorMessage(error, shellCopy.updateRetryFailedFallback, uiLocale),
         );
       });
-  }, [appUpdateStatus, shellCopy, toastApi, uiLocale]);
+  }, [updateReminder, shellCopy, toastApi, uiLocale]);
   const moduleHubCopy = getSharedUiCopy(uiLocale).moduleHubs;
   const extensionsHubHeader = {
     title: moduleHubCopy.extensions.title,

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -413,15 +413,18 @@ function AppShellContent({
     };
   }, []);
 
+  // `available` and `downloading` are deliberately absent. The updater sets
+  // `autoDownload = true`, so both phases resolve themselves and there is
+  // nothing for a user to decide; only `downloaded` (which needs a restart,
+  // because `autoInstallOnAppQuit` is false) and `error` do. The footer used
+  // to carry a control through all four, which meant it spent most of its
+  // visible life asking for attention on behalf of a background download.
   const updateReminder =
-    appUpdateStatus?.state === 'available' ||
-    appUpdateStatus?.state === 'downloading' ||
     appUpdateStatus?.state === 'downloaded' ||
     (appUpdateStatus?.state === 'error' && Boolean(appUpdateStatus.latestVersion))
     ? {
         state: appUpdateStatus.state,
         latestVersion: appUpdateStatus.latestVersion ?? appUpdateStatus.currentVersion,
-        progressPercent: appUpdateStatus.state === 'downloading' ? appUpdateStatus.progress.percent : undefined,
       }
     : undefined;
   const openUpdateDownload = useCallback(() => {

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -384,8 +384,6 @@ type ShellCopy = {
     updateActiveTasksCancel: string;
     updateRetryFailedTitle: string;
     updateRetryFailedFallback: string;
-    updateOpenFailedTitle: string;
-    updateOpenManualFallback: string;
     loading: string;
     goToModels: string;
     boundaryUnreadableTitle: string;
@@ -1047,8 +1045,6 @@ const SHELL_COPY_BY_LOCALE = {
       updateActiveTasksCancel: '取消',
       updateRetryFailedTitle: '无法重新下载更新',
       updateRetryFailedFallback: '请稍后重试，或手动下载最新版本。',
-      updateOpenFailedTitle: '无法打开更新',
-      updateOpenManualFallback: '请稍后重试，或前往 GitHub Releases 下载最新版本。',
       loading: '加载中',
       goToModels: '去模型',
       boundaryUnreadableTitle: '暂时读不到这个对话的权限',
@@ -1548,8 +1544,6 @@ const SHELL_COPY_BY_LOCALE = {
       updateActiveTasksCancel: 'Cancel',
       updateRetryFailedTitle: 'Could not retry update download',
       updateRetryFailedFallback: 'Try again later, or download the latest version manually.',
-      updateOpenFailedTitle: 'Could not open update',
-      updateOpenManualFallback: 'Try again later, or download the latest version from GitHub Releases.',
       loading: 'Loading',
       goToModels: 'Go to Models',
       boundaryUnreadableTitle: 'Could not read this conversation’s permissions',

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -136,81 +136,34 @@
   background: transparent;
 }
 
-.maka-session-panel-footer .maka-sidebar-update-button {
-  margin-block-start: var(--space-1);
-}
-
-/* #1879: this rule used to force `height: 34px` onto an Astryx Button. It is a
-   `<Button size="md">` now (session-sidebar-nav.tsx), so the 32px comes from
-   the component's own `--size-element-md` — the same token the 32px nav rows
-   it stacks under already read. Overriding a component's size from product CSS
-   is the drift the control ruler exists to end; declaring no height here is
-   what makes the two agree by derivation instead of by coincidence. */
-.maka-sidebar-update-button {
-  font: var(--maka-text-heading-4);
-  position: relative;
-  min-width: 0;
-  display: inline-grid;
-  grid-template-columns: auto;
+/* Settings and the update action are siblings in one row (SessionSidebarFooter).
+   Everything the old chip needed from product CSS — a pill radius, an accent
+   background, hand-computed hover/pressed/downloading colors, an absolutely
+   positioned progress fill — is gone: it is an Astryx IconButton with
+   `variant="primary"` now, so shape, color and every state come from the
+   component and the theme's accent. What is left here is the one thing no
+   component can know, which is how the two controls share the row. */
+.maka-sidebar-footer-row {
+  display: flex;
   align-items: center;
   gap: var(--space-1);
-  /* Astryx Button reads `--_button-radius` for its own shape (Carousel and
-     Thumbnail set it the same way); declaring `border-radius` here would be a
-     product rule racing the component again. */
-  --_button-radius: var(--radius-pill);
-  padding: 0 var(--space-3);
-  /* `background-color`, not the `background` shorthand — here and in EVERY
-     state rule below. The shorthand also resets `background-image`, which is
-     where Button's ghost variant keeps its hover and pressed overlays, so a
-     single shorthand anywhere in this file cancels the `variant` the component
-     was given. Product CSS is in the last cascade layer, so it wins that reset
-     regardless of specificity; fixing only the base rule left the overlays
-     dead on hover and in both download states, which is where they are most
-     visible. `border: 0` and `box-shadow: none` used to sit here too; both
-     restated what Button already computes. */
-  background-color: var(--control);
-  color: var(--control-foreground);
-  overflow: hidden;
+}
+
+/* Collapsed the rail is 48px wide and the labels are gone; two controls cannot
+   sit side by side, so the row stacks and the update button keeps its slot. */
+.maka-sidebar-footer-row[data-collapsed="true"] {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.maka-sidebar-footer-row-primary {
+  flex: 1;
+  min-width: 0;
+}
+
+.maka-sidebar-update-button {
+  flex: none;
   -webkit-app-region: no-drag;
-  transition:
-    background-color var(--duration-base) var(--ease-out-strong),
-    transform var(--duration-quick) var(--ease-out-strong);
-}
-
-.maka-sidebar-update-button > span:not(.maka-sidebar-update-progress) {
-  position: relative;
-}
-
-.maka-sidebar-update-button[data-update-state="downloading"] {
-  cursor: default;
-  background-color: oklch(from var(--control) calc(l + 0.04) calc(c * 0.68) h);
-  opacity: 1;
-}
-
-.maka-sidebar-update-button[data-update-state="downloaded"] {
-  background-color: var(--control);
-}
-
-.maka-sidebar-update-progress {
-  position: absolute;
-  inset: 0;
-  transform: scaleX(var(--maka-update-progress, 0));
-  transform-origin: left center;
-  background-color: oklch(from var(--control) calc(l - 0.08) c h);
-  transition: transform var(--duration-base) var(--ease-out-strong);
-}
-
-.maka-sidebar-update-button:hover {
-  background-color: oklch(from var(--control) calc(l - 0.04) c h);
-}
-
-.maka-sidebar-update-button:disabled:hover {
-  background-color: oklch(from var(--control) calc(l + 0.04) calc(c * 0.68) h);
-}
-
-.maka-sidebar-update-button:focus-visible {
-  outline: var(--focus-ring-width) solid var(--focus-ring);
-  outline-offset: var(--focus-ring-offset);
 }
 
 .maka-session-row {

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -163,6 +163,12 @@
 
 .maka-sidebar-update-button {
   flex: none;
+  /* Astryx has no shape prop — `isIconOnly` is documented as rendering a
+     SQUARE button — but Button reads `--_button-radius` for its own geometry,
+     which is how Carousel and Thumbnail reshape it too. Setting that variable
+     asks the component to be round; declaring `border-radius` here would race
+     it instead. On a 28px square this resolves to a true circle. */
+  --_button-radius: var(--radius-pill);
   -webkit-app-region: no-drag;
 }
 

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -150,8 +150,12 @@
 }
 
 /* Collapsed the rail is 48px wide and the labels are gone; two controls cannot
-   sit side by side, so the row stacks and the update button keeps its slot. */
-.maka-sidebar-footer-row[data-collapsed="true"] {
+   sit side by side, so the row stacks and the update button keeps its slot.
+   Read off the frame, which is where the shell already writes the rail's
+   collapsed state (app-shell.tsx) and where the hairline rule above reads it
+   from: a second marker on this row would be the same fact written twice, free
+   to disagree with the first. */
+.appFrame[data-sidebar-state="collapsed"] .maka-sidebar-footer-row {
   flex-direction: column;
   align-items: stretch;
 }
@@ -159,6 +163,13 @@
 .maka-sidebar-footer-row-primary {
   flex: 1;
   min-width: 0;
+}
+
+/* Stacked, the row stretches its children to the rail's width so the settings
+   row still fills it. A 28px button stretched to 32 is a pill, not the circle
+   it is expanded, so it opts out and keeps its own width. */
+.appFrame[data-sidebar-state="collapsed"] .maka-sidebar-update-button {
+  align-self: center;
 }
 
 .maka-sidebar-update-button {

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -271,6 +271,8 @@ function ComposedShell(props: {
    * supplying the relatives, not by hand-writing what the helpers would return.
    */
   relatedSessions?: SessionSummary[];
+  /** Drives the footer's update action; `undefined` is the silent phase. */
+  updateReminder?: SessionListPanelProps['updateReminder'];
 }) {
   const [collapsed, setCollapsed] = useState(props.sidebarCollapsed ?? false);
   const [viewMode, setViewMode] = useState<SessionViewMode>(props.initialViewMode ?? 'conversation');
@@ -358,6 +360,8 @@ function ComposedShell(props: {
             onSelect={noop}
             onSelectSession={noop}
             onOpenSettings={noop}
+            updateReminder={props.updateReminder}
+            onOpenUpdate={noop}
             onNew={noop}
             rowActions={sidebarRowActions}
             projectActions={projectRowActions}
@@ -404,6 +408,28 @@ function ComposedShell(props: {
 // messages (sidebar expanded, composer ready).
 export const DefaultLayout: Story = {
   render: () => <ComposedShell />,
+};
+
+// Real path: the updater finishes downloading in the background (autoDownload
+// is on) → the footer's settings row grows an accent update button. Discovery
+// and download show nothing, so this is the first moment the shell says
+// anything about an update at all.
+export const UpdateDownloaded: Story = {
+  render: () => <ComposedShell updateReminder={{ state: 'downloaded', latestVersion: '0.1.7' }} />,
+};
+
+// Real path: the same download fails → same slot, muted variant, retry.
+export const UpdateFailed: Story = {
+  render: () => <ComposedShell updateReminder={{ state: 'error', latestVersion: '0.1.7' }} />,
+};
+
+// Real path: an update is waiting while the rail is collapsed to 48px. The row
+// cannot hold two controls side by side there, so it stacks — the reason the
+// footer reads collapse state at all.
+export const UpdateDownloadedCollapsed: Story = {
+  render: () => (
+    <ComposedShell sidebarCollapsed updateReminder={{ state: 'downloaded', latestVersion: '0.1.7' }} />
+  ),
 };
 
 // Real path: send a message → the turn is streaming (composer shows the

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -424,8 +424,8 @@ export const UpdateFailed: Story = {
 };
 
 // Real path: an update is waiting while the rail is collapsed to 48px. The row
-// cannot hold two controls side by side there, so it stacks — the reason the
-// footer reads collapse state at all.
+// cannot hold two controls side by side there, so it stacks — off the frame's
+// own `data-sidebar-state`, which is why ShellFrame above has to carry it.
 export const UpdateDownloadedCollapsed: Story = {
   render: () => (
     <ComposedShell sidebarCollapsed updateReminder={{ state: 'downloaded', latestVersion: '0.1.7' }} />

--- a/packages/ui/src/__tests__/sidebar-update-entry.test.tsx
+++ b/packages/ui/src/__tests__/sidebar-update-entry.test.tsx
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { LocaleProvider } from '../locale-context.js';
+import { SessionListPanel } from '../session-list-panel.js';
+import type { SidebarUpdateReminder } from '../session-sidebar-nav.js';
+
+function renderSidebar(options: {
+  updateReminder?: SidebarUpdateReminder;
+  collapsed?: boolean;
+} = {}): string {
+  return renderToStaticMarkup(
+    <LocaleProvider locale="zh">
+      <SessionListPanel
+        collapsed={options.collapsed}
+        selection={{ section: 'sessions', filter: 'chats' }}
+        sessions={[]}
+        updateReminder={options.updateReminder}
+        onSelectSession={() => {}}
+        onSelect={() => {}}
+        onOpenSettings={() => {}}
+        onOpenUpdate={() => {}}
+        onNew={() => {}}
+      />
+    </LocaleProvider>,
+  );
+}
+
+/**
+ * The deepest run of unclosed <button> tags. The update action is a button and
+ * it sits beside a SideNavItem that is also a button, so the only structurally
+ * invalid way to build this row — nesting one inside the other, which is what
+ * `endContent` would do — has to be something a test can see.
+ */
+function maxButtonDepth(markup: string): number {
+  let depth = 0;
+  let deepest = 0;
+  for (const [tag] of markup.matchAll(/<button\b|<\/button>/g)) {
+    if (tag === '</button>') depth -= 1;
+    else deepest = Math.max(deepest, (depth += 1));
+  }
+  return deepest;
+}
+
+describe('sidebar update entry', () => {
+  it('shows nothing while the update needs no one', () => {
+    const markup = renderSidebar();
+
+    assert.match(markup, /maka-sidebar-footer-row/);
+    assert.doesNotMatch(markup, /maka-sidebar-update-button/);
+    assert.match(markup, />设置</);
+  });
+
+  it('names the whole decision on the downloaded action, not a bare verb', () => {
+    const markup = renderSidebar({
+      updateReminder: { state: 'downloaded', latestVersion: '0.1.7' },
+    });
+
+    assert.match(markup, /maka-sidebar-update-button/);
+    assert.match(markup, /aria-label="新版本 0\.1\.7 已下载，重启后安装"/);
+  });
+
+  it('keeps the failed update distinguishable from the ready one', () => {
+    const markup = renderSidebar({
+      updateReminder: { state: 'error', latestVersion: '0.1.7' },
+    });
+
+    assert.match(markup, /aria-label="新版本 0\.1\.7 更新失败，点击重试或手动下载"/);
+    assert.doesNotMatch(markup, /lucide-download/);
+  });
+
+  it('carries the download glyph only when the update is ready to install', () => {
+    assert.match(
+      renderSidebar({ updateReminder: { state: 'downloaded', latestVersion: '0.1.7' } }),
+      /lucide-download/,
+    );
+  });
+
+  it('keeps the update action a sibling of settings, never nested in it', () => {
+    for (const collapsed of [false, true]) {
+      const markup = renderSidebar({
+        collapsed,
+        updateReminder: { state: 'downloaded', latestVersion: '0.1.7' },
+      });
+
+      assert.equal(
+        maxButtonDepth(markup),
+        1,
+        `collapsed=${collapsed}: the update action must not render inside another button`,
+      );
+      assert.ok(
+        markup.indexOf('>设置<') < markup.indexOf('maka-sidebar-update-button'),
+        `collapsed=${collapsed}: settings leads the row`,
+      );
+    }
+  });
+
+  it('survives the collapsed rail instead of being dropped with the labels', () => {
+    const markup = renderSidebar({
+      collapsed: true,
+      updateReminder: { state: 'downloaded', latestVersion: '0.1.7' },
+    });
+
+    assert.match(markup, /maka-sidebar-update-button/);
+  });
+});

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -11,6 +11,7 @@ export type { ModuleHubHeader } from './module-hub-selector.js';
 export { SearchModal } from './search-modal.js';
 export { SessionListPanel } from './session-list-panel.js';
 export type { SessionViewMode } from './session-list-panel.js';
+export type { SidebarUpdateReminder } from './session-sidebar-nav.js';
 export type { BundledSkillCatalogEntry, DailyReviewMarkdownActionInput, ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry, SkillGovernanceDetails } from './module-panel-types.js';
 export { describeLoadToolResult, formatRedactedJson, formatToolIntent, loadToolDisplayName } from './tool-format.js';
 export { formatBytes, ToolCallDetail, ToolTrow } from './tool-activity.js';

--- a/packages/ui/src/icons.tsx
+++ b/packages/ui/src/icons.tsx
@@ -38,7 +38,6 @@ export {
   ChevronLeft,
   ChevronRight,
   ChevronRightIcon,
-  CircleArrowUp,
   CircleCheckBig,
   CircleGauge,
   Clipboard,

--- a/packages/ui/src/icons.tsx
+++ b/packages/ui/src/icons.tsx
@@ -38,6 +38,7 @@ export {
   ChevronLeft,
   ChevronRight,
   ChevronRightIcon,
+  CircleArrowUp,
   CircleCheckBig,
   CircleGauge,
   Clipboard,

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -1,11 +1,12 @@
 import type { PlanReminder } from '@maka/core';
-import type { CSSProperties } from 'react';
-import { Blocks, Settings, SquarePen, Timer } from './icons.js';
+import { AlertCircle, Blocks, CircleArrowUp, Settings, SquarePen, Timer } from './icons.js';
 import type { NavModuleMemory, NavSelection } from './nav-selection.js';
 import { useUiLocale } from './locale-context.js';
 import { getShellControlsCopy } from './shell-controls-copy.js';
-import { Button } from '@astryxdesign/core/Button';
-import { SideNavItem, SideNavSection } from '@astryxdesign/core/SideNav';
+import { Icon } from '@astryxdesign/core/Icon';
+import { IconButton } from '@astryxdesign/core/IconButton';
+import { SideNavItem, SideNavSection, useSideNavCollapse } from '@astryxdesign/core/SideNav';
+import { Tooltip } from '@astryxdesign/core/Tooltip';
 
 export function SessionSidebarNav(props: {
   selection: NavSelection;
@@ -63,10 +64,19 @@ export function SessionSidebarNav(props: {
   );
 }
 
+/**
+ * Only the two states that need the user.
+ *
+ * The updater runs with `autoDownload = true` and `autoInstallOnAppQuit =
+ * false` (app-update-service.ts), so discovery and download ask nothing of
+ * anyone — the shell drops `available` and `downloading` before they reach
+ * here rather than the footer rendering a control for them. That is what the
+ * old chip did: it sat in the footer through the entire silent phase showing a
+ * progress bar whose own percentage label the bar painted over.
+ */
 export type SidebarUpdateReminder = {
-  state: 'available' | 'downloading' | 'downloaded' | 'error';
+  state: 'downloaded' | 'error';
   latestVersion: string;
-  progressPercent?: number;
 };
 
 export function SessionSidebarFooter(props: {
@@ -76,52 +86,58 @@ export function SessionSidebarFooter(props: {
 }) {
   const locale = useUiLocale();
   const copy = getShellControlsCopy(locale).navigation;
-  const updatePercent = Math.round(props.updateReminder?.progressPercent ?? 0);
-  const updateLabel = props.updateReminder?.state === 'downloaded'
-    ? copy.restartUpdate
-    : props.updateReminder?.state === 'error'
-      ? copy.retryUpdate
-    : props.updateReminder?.state === 'downloading'
-      ? `${updatePercent}%`
-      : copy.update;
-  const updateTitle = props.updateReminder?.state === 'downloaded'
-    ? copy.updateDownloaded(props.updateReminder.latestVersion)
-    : props.updateReminder?.state === 'error'
-      ? copy.updateFailed(props.updateReminder.latestVersion)
-    : props.updateReminder?.state === 'downloading'
-      ? copy.downloadingUpdate(updatePercent)
-      : props.updateReminder
-        ? copy.updateAvailable(props.updateReminder.latestVersion)
-        : copy.update;
-  // shell-side-nav footer authority: SideNavSection + SideNavItem, not a
-  // product grid that re-lays out nav chrome beside the update chip.
+  const { isCollapsed } = useSideNavCollapse();
+  const reminder = props.updateReminder;
+  const updateAction = reminder && props.onOpenUpdate
+    ? {
+        label: reminder.state === 'downloaded' ? copy.restartUpdate : copy.retryUpdate,
+        title: reminder.state === 'downloaded'
+          ? copy.updateDownloaded(reminder.latestVersion)
+          : copy.updateFailed(reminder.latestVersion),
+        icon: reminder.state === 'downloaded' ? CircleArrowUp : AlertCircle,
+        onClick: props.onOpenUpdate,
+      }
+    : undefined;
+
+  // Settings and the update action are SIBLINGS in a row, not one nested in
+  // the other: SideNavItem renders `endContent` inside its own <button>, and
+  // an <button> cannot contain a second one. This is the same split-action
+  // shape SideNavItem itself falls back to when a row carries both a primary
+  // action and a collapse toggle ("<div> row with <a> + <button> as siblings"
+  // — SideNavItem.tsx), for exactly this reason.
+  //
+  // Collapsed, the rail is 48px and the label is gone; two controls cannot sit
+  // side by side there, so the row stacks and the update button keeps its own
+  // slot under settings instead of being dropped.
   return (
     <SideNavSection title={copy.settings} isHeaderHidden className="maka-session-panel-footer">
-      <SideNavItem
-        label={copy.settings}
-        icon={Settings}
-        size="md"
-        onClick={props.onOpenSettings}
-      />
-      {props.updateReminder && props.onOpenUpdate && (
-        <Button
-          className="maka-sidebar-update-button"
-          data-update-state={props.updateReminder.state}
-          style={{ '--maka-update-progress': String(Math.max(0, Math.min(100, props.updateReminder.progressPercent ?? 0)) / 100) } as CSSProperties}
-          label={updateTitle}
-          // #1879: was `sm` with a 34px height forced from product CSS. Astryx
-          // sizes Button off --size-element-* (sm 28 / md 32), so `md` IS the
-          // 32px this button wants, and the CSS height is gone rather than
-          // fighting the component's own size token.
-          size="md"
-          variant="ghost"
-          width="100%"
-          onClick={props.onOpenUpdate}
-        >
-          {props.updateReminder.state === 'downloading' && <span className="maka-sidebar-update-progress" aria-hidden="true" />}
-          <span>{updateLabel}</span>
-        </Button>
-      )}
+      <div className="maka-sidebar-footer-row" data-collapsed={isCollapsed ? 'true' : 'false'}>
+        <div className="maka-sidebar-footer-row-primary">
+          <SideNavItem
+            label={copy.settings}
+            icon={Settings}
+            size="md"
+            onClick={props.onOpenSettings}
+          />
+        </div>
+        {updateAction && (
+          <Tooltip content={updateAction.title}>
+            <IconButton
+              className="maka-sidebar-update-button"
+              label={updateAction.label}
+              icon={<Icon icon={updateAction.icon} size="sm" />}
+              // `primary` resolves to the theme's own accent, so the button
+              // follows Catppuccin and Tokyo Night instead of a hard-coded
+              // blue. The previous chip reached for `--control` through
+              // product CSS and had to hand-compute every hover and pressed
+              // state in oklch(); none of that is restated here.
+              variant={reminder?.state === 'error' ? 'secondary' : 'primary'}
+              size="md"
+              onClick={updateAction.onClick}
+            />
+          </Tooltip>
+        )}
+      </div>
     </SideNavSection>
   );
 }

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -1,5 +1,5 @@
 import type { PlanReminder } from '@maka/core';
-import { AlertCircle, Blocks, CircleArrowUp, Settings, SquarePen, Timer } from './icons.js';
+import { AlertCircle, ArrowUp, Blocks, Settings, SquarePen, Timer } from './icons.js';
 import type { NavModuleMemory, NavSelection } from './nav-selection.js';
 import { useUiLocale } from './locale-context.js';
 import { getShellControlsCopy } from './shell-controls-copy.js';
@@ -94,7 +94,11 @@ export function SessionSidebarFooter(props: {
         title: reminder.state === 'downloaded'
           ? copy.updateDownloaded(reminder.latestVersion)
           : copy.updateFailed(reminder.latestVersion),
-        icon: reminder.state === 'downloaded' ? CircleArrowUp : AlertCircle,
+        // A bare arrow, not CircleArrowUp: the button is a circle, so a ringed
+        // glyph draws a second concentric one and the two blur together at
+        // 16px. The alert glyph keeps its ring — it has no round container to
+        // borrow, and the ring is what makes it read as a warning.
+        icon: reminder.state === 'downloaded' ? ArrowUp : AlertCircle,
         onClick: props.onOpenUpdate,
       }
     : undefined;
@@ -132,7 +136,11 @@ export function SessionSidebarFooter(props: {
               // product CSS and had to hand-compute every hover and pressed
               // state in oklch(); none of that is restated here.
               variant={reminder?.state === 'error' ? 'secondary' : 'primary'}
-              size="md"
+              // `sm` (28px) against the settings row's 32px: a filled button
+              // at the row's own height fills it edge to edge and competes
+              // with it. Two pixels of air on each side is what makes it read
+              // as something ON the row rather than a second row.
+              size="sm"
               onClick={updateAction.onClick}
             />
           </Tooltip>

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -1,5 +1,5 @@
 import type { PlanReminder } from '@maka/core';
-import { AlertCircle, ArrowUp, Blocks, Settings, SquarePen, Timer } from './icons.js';
+import { AlertCircle, Blocks, Download, Settings, SquarePen, Timer } from './icons.js';
 import type { NavModuleMemory, NavSelection } from './nav-selection.js';
 import { useUiLocale } from './locale-context.js';
 import { getShellControlsCopy } from './shell-controls-copy.js';
@@ -94,11 +94,19 @@ export function SessionSidebarFooter(props: {
         title: reminder.state === 'downloaded'
           ? copy.updateDownloaded(reminder.latestVersion)
           : copy.updateFailed(reminder.latestVersion),
-        // A bare arrow, not CircleArrowUp: the button is a circle, so a ringed
-        // glyph draws a second concentric one and the two blur together at
-        // 16px. The alert glyph keeps its ring — it has no round container to
-        // borrow, and the ring is what makes it read as a warning.
-        icon: reminder.state === 'downloaded' ? ArrowUp : AlertCircle,
+        // Download, and specifically NOT an up arrow: the composer's send
+        // button is already an accent circle carrying a 16px ArrowUp
+        // (composer.tsx), so an arrow here — in either direction — is the same
+        // control drawn twice for two unrelated actions. The tray line under
+        // this glyph is structure the send button has no counterpart for, so
+        // the two stay apart without relying on the viewer comparing them.
+        //
+        // It reads as "download" even though the bytes are already on disk.
+        // That matches what a user is deciding, which is whether to take the
+        // new version; when the download finished is our bookkeeping, and the
+        // downward arrow is the convention every app store made for exactly
+        // this moment.
+        icon: reminder.state === 'downloaded' ? Download : AlertCircle,
         onClick: props.onOpenUpdate,
       }
     : undefined;

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -5,7 +5,7 @@ import { useUiLocale } from './locale-context.js';
 import { getShellControlsCopy } from './shell-controls-copy.js';
 import { Icon } from '@astryxdesign/core/Icon';
 import { IconButton } from '@astryxdesign/core/IconButton';
-import { SideNavItem, SideNavSection, useSideNavCollapse } from '@astryxdesign/core/SideNav';
+import { SideNavItem, SideNavSection } from '@astryxdesign/core/SideNav';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 
 export function SessionSidebarNav(props: {
@@ -70,9 +70,9 @@ export function SessionSidebarNav(props: {
  * The updater runs with `autoDownload = true` and `autoInstallOnAppQuit =
  * false` (app-update-service.ts), so discovery and download ask nothing of
  * anyone — the shell drops `available` and `downloading` before they reach
- * here rather than the footer rendering a control for them. That is what the
- * old chip did: it sat in the footer through the entire silent phase showing a
- * progress bar whose own percentage label the bar painted over.
+ * here rather than the footer rendering a control for them. The old chip sat
+ * in the footer through that whole silent phase counting bytes at someone who
+ * had nothing to decide.
  */
 export type SidebarUpdateReminder = {
   state: 'downloaded' | 'error';
@@ -86,12 +86,13 @@ export function SessionSidebarFooter(props: {
 }) {
   const locale = useUiLocale();
   const copy = getShellControlsCopy(locale).navigation;
-  const { isCollapsed } = useSideNavCollapse();
   const reminder = props.updateReminder;
   const updateAction = reminder && props.onOpenUpdate
     ? {
-        label: reminder.state === 'downloaded' ? copy.restartUpdate : copy.retryUpdate,
-        title: reminder.state === 'downloaded'
+        // One sentence, serving as both the tooltip and the accessible name.
+        // The button carries no visible text, so a bare verb ("Restart")
+        // reaches a screen reader without saying restart what, or why now.
+        label: reminder.state === 'downloaded'
           ? copy.updateDownloaded(reminder.latestVersion)
           : copy.updateFailed(reminder.latestVersion),
         // Download, and specifically NOT an up arrow: the composer's send
@@ -123,7 +124,7 @@ export function SessionSidebarFooter(props: {
   // slot under settings instead of being dropped.
   return (
     <SideNavSection title={copy.settings} isHeaderHidden className="maka-session-panel-footer">
-      <div className="maka-sidebar-footer-row" data-collapsed={isCollapsed ? 'true' : 'false'}>
+      <div className="maka-sidebar-footer-row">
         <div className="maka-sidebar-footer-row-primary">
           <SideNavItem
             label={copy.settings}
@@ -133,7 +134,7 @@ export function SessionSidebarFooter(props: {
           />
         </div>
         {updateAction && (
-          <Tooltip content={updateAction.title}>
+          <Tooltip content={updateAction.label}>
             <IconButton
               className="maka-sidebar-update-button"
               label={updateAction.label}

--- a/packages/ui/src/shell-controls-copy.ts
+++ b/packages/ui/src/shell-controls-copy.ts
@@ -10,11 +10,8 @@ type ShellControlsCopy = {
     automations: string;
     extensions: string;
     settings: string;
-    update: string;
     retryUpdate: string;
     restartUpdate: string;
-    downloadingUpdate(percent: number): string;
-    updateAvailable(version: string): string;
     updateDownloaded(version: string): string;
     updateFailed(version: string): string;
     pendingReminders(count: number): string;
@@ -48,11 +45,8 @@ const SHELL_CONTROLS_COPY_BY_LOCALE = {
       automations: '定时任务',
       extensions: '扩展',
       settings: '设置',
-      update: '更新',
       retryUpdate: '重试更新',
       restartUpdate: '重启',
-      downloadingUpdate: (percent: number) => `正在下载更新，${percent}%；点击可重新下载`,
-      updateAvailable: (version: string) => `发现新版本 ${version}`,
       updateDownloaded: (version: string) => `新版本 ${version} 已下载，重启后安装`,
       updateFailed: (version: string) => `新版本 ${version} 更新失败，点击重试或手动下载`,
       pendingReminders: (count: number) => `定时任务，${count} 个未完成提醒`,
@@ -84,11 +78,8 @@ const SHELL_CONTROLS_COPY_BY_LOCALE = {
       automations: 'Scheduled tasks',
       extensions: 'Extensions',
       settings: 'Settings',
-      update: 'Update',
       retryUpdate: 'Retry update',
       restartUpdate: 'Restart',
-      downloadingUpdate: (percent: number) => `Downloading update, ${percent}%. Click to retry.`,
-      updateAvailable: (version: string) => `Update available: ${version}`,
       updateDownloaded: (version: string) => `Update ${version} downloaded. Restart to install.`,
       updateFailed: (version: string) => `Update ${version} failed. Click to retry or download manually.`,
       pendingReminders: (count: number) => `Scheduled tasks, ${count} unfinished ${count === 1 ? 'reminder' : 'reminders'}`,

--- a/packages/ui/src/shell-controls-copy.ts
+++ b/packages/ui/src/shell-controls-copy.ts
@@ -10,8 +10,6 @@ type ShellControlsCopy = {
     automations: string;
     extensions: string;
     settings: string;
-    retryUpdate: string;
-    restartUpdate: string;
     updateDownloaded(version: string): string;
     updateFailed(version: string): string;
     pendingReminders(count: number): string;
@@ -45,8 +43,6 @@ const SHELL_CONTROLS_COPY_BY_LOCALE = {
       automations: '定时任务',
       extensions: '扩展',
       settings: '设置',
-      retryUpdate: '重试更新',
-      restartUpdate: '重启',
       updateDownloaded: (version: string) => `新版本 ${version} 已下载，重启后安装`,
       updateFailed: (version: string) => `新版本 ${version} 更新失败，点击重试或手动下载`,
       pendingReminders: (count: number) => `定时任务，${count} 个未完成提醒`,
@@ -78,8 +74,6 @@ const SHELL_CONTROLS_COPY_BY_LOCALE = {
       automations: 'Scheduled tasks',
       extensions: 'Extensions',
       settings: 'Settings',
-      retryUpdate: 'Retry update',
-      restartUpdate: 'Restart',
       updateDownloaded: (version: string) => `Update ${version} downloaded. Restart to install.`,
       updateFailed: (version: string) => `Update ${version} failed. Click to retry or download manually.`,
       pendingReminders: (count: number) => `Scheduled tasks, ${count} unfinished ${count === 1 ? 'reminder' : 'reminders'}`,

--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -193,6 +193,16 @@ const RESERVED_SCALE_TOKENS = new Set([
   // dead shell recipes (#1980), but deleting the named curve is what invites
   // the next bare cubic-bezier.
   '--ease-in-out-strong',
+  // Accent lightness ladder — --action (L0.85 chip), --control (L0.65, the
+  // rung tuned for WCAG 1.4.11 non-text 3:1) and --accent-solid (L0.52, the
+  // lowest that clears 1.4.3 for text). The middle rung lost its last
+  // consumer when the sidebar update chip became an Astryx IconButton and
+  // stopped hand-painting an accent background; the ladder, and the contrast
+  // derivation recorded against each rung in maka-tokens.css, only reads as a
+  // series with it present. --control-foreground is its paired foreground,
+  // meaningless apart from it.
+  '--control',
+  '--control-foreground',
 ]);
 
 async function readCssFiles(dir) {


### PR DESCRIPTION
## Summary

The sidebar footer carried a full-width accent pill for all four updater states. Three problems compounded there.

**It was present when there was nothing to do.** `autoDownload` is true and `autoInstallOnAppQuit` is false (`app-update-service.ts`), so discovery and download resolve themselves — only `downloaded` and `error` need a user. The shell drops the other two before they reach the footer, so the silent phase, which is most of the control's visible life, renders nothing.

**It was not really an Astryx Button.** Sixty lines of product CSS rewrote a `variant="ghost"` Button into a filled pill: a pill radius, `--control` as a background, hover/pressed/downloading colors hand-computed in `oklch()`, and an absolutely positioned progress fill. It is an `IconButton` with `variant="primary"` now, so shape, accent and every state come from the component and the theme; the accent follows Catppuccin and Tokyo Night instead of a hard-coded blue.

**It could not sit beside settings**, because `SideNavItem` renders `endContent` inside its own `<button>`. The row is a `<div>` holding the two as siblings — the same split-action shape `SideNavItem` falls back to when a row carries both a primary action and a collapse toggle, for the same reason. Collapsed to 48px the row stacks instead of overflowing.

The result is a 28px circular accent button on the settings row. Every part of that is a component knob, not a rule fighting the component:

- **Round** through `--_button-radius`, the variable Button reads for its own geometry (Carousel and Thumbnail reshape it the same way). IconButton is documented as rendering a *square* button and has no shape prop.
- **`sm` (28px)**, not `md`: a filled button at the row's own 32px fills it edge to edge. 28 is also Button's smallest size, so anything below it would mean overriding a component's height — the drift #1879 removed from this very button.
- **A `Download` glyph, never an arrow.** The composer's send button is already an accent circle carrying a 16px `ArrowUp` (`composer.tsx`), and both are on screen at once. A downward arrow would not have been enough — that is the same stroke mirrored, and mirroring only distinguishes while both glyphs are in view to compare. The tray line under `Download` is structure the send glyph has no counterpart for. It reads as "download" while the bytes are already on disk, which is the right register: the user is deciding whether to take the new version, and when the transfer finished is our bookkeeping. The error state keeps `AlertCircle`, which never collided with anything.
- **Filled `primary` on purpose.** An update the user must opt into by restarting should be hard to miss; this is the loudest element on the rail by design.

`--control` and `--control-foreground` lose their last consumer here. They are reserved rather than deleted: they are the middle rung of the accent lightness ladder (`--action` L0.85 / `--control` L0.65 / `--accent-solid` L0.52), and the WCAG derivation recorded against each rung only reads as a series with it present.

## One writer per fact

An adversarial review of the first three commits found no blocker but two places where the change had left the same fact written twice, and one where it had no way to fail.

**The collapsed rail.** The footer read Astryx's collapse context and stamped its own `data-collapsed`, while the shell was already writing `data-sidebar-state` on the frame and the hairline rule directly above was already reading it. Two markers for one state are free to disagree. The stacking rule hangs off the frame now; the hook and the attribute are gone.

**Which states need the user.** The shell narrowed the status for the footer, then the click handler matched on the raw status again — and that second copy had already drifted, offering a retry for `available` and `downloading` and falling through to an "open the download page" branch nothing could reach. `updateReminderFromStatus` is the one answer now; the handler dispatches on its result. The unreachable branches are gone, and with them the two copy strings only that fallback used. (`app.openUpdateDownload` itself is now unused across main, preload and the contract; removing that chain crosses the process boundary and is tracked separately rather than folded in here.)

**Nothing could fail.** The stories are a pixel review surface, not a regression net: moving the update action back inside `endContent` — a `<button>` inside a `<button>` — would have failed no check. `sidebar-update-entry.test.tsx` pins the markup contract, including a nesting-depth assertion that only passes while the two controls are siblings, and the narrowing has unit tests over every status the updater can produce.

The button is also icon-only, so `重启` was its entire accessible name — restart what, and why now, lived in the tooltip alone. The sentence is now both, and the two bare verbs it replaced are deleted.

## Verification

`npm run typecheck`, `npm run lint`, `npm run format:check` — all clean.
`node scripts/check-dead-css.mjs --check` — no dead classes or tokens.
`node scripts/check-story-annotations.mjs` — clean.
`npm --workspace @maka/ui run test` — 432 passing.
`npm --workspace @maka/desktop run test` — 1744/1756; the 12 failures are project-root/symlink path tests that fail identically on a clean `main` in this environment, untouched by this change.

Three stories cover the states (`Product/Shell Official AppShell` → `UpdateDownloaded`, `UpdateFailed`, `UpdateDownloadedCollapsed`). Measured against the live theme in Storybook rather than eyeballed:

- downloaded: 28×28 with a 999px radius (a true circle), centered on the 32px settings row (vertical offset 0); glyph 16px, the same size as the settings gear beside it; background resolves to `oklch(0.52 0.135 250)` = `--accent-solid`, not a literal blue; hit area clears the WCAG 2.5.8 24×24 minimum.
- distinct from send: the two buttons' glyph paths differ — send is `m5 12 7-7 7 7` + `M12 19V5`, update adds the tray `M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4`.
- error: `secondary` variant with the ringed alert glyph.
- collapsed: rail 48px, row `flex-direction: column`, and the button stays a 28×28 circle centred on the rail — stacking stretches its children to the rail width, which had been flattening it into a 32×28 pill until it opted out.
- silent (`DefaultLayout`): no update control in the DOM at all; the settings row takes the full 244px.
- accessible name carries the whole decision in both states (`新版本 0.1.7 已下载，重启后安装` / `…更新失败，点击重试或手动下载`).
