### PR TITLE
refactor(desktop): drop the update-download bridge and the status fields it fed

### DIFF
--- a/apps/desktop/src/main/__tests__/app-update-service.test.ts
+++ b/apps/desktop/src/main/__tests__/app-update-service.test.ts
@@ -103,7 +103,6 @@ function createHarness(input: {
   const service = createAppUpdateService({
     currentVersion: '1.0.0',
     isPackaged: input.isPackaged ?? true,
-    openExternal: async () => undefined,
     updater: updater as unknown as AppUpdater,
     clock,
     onStatusChange: input.onStatusChange,

--- a/apps/desktop/src/main/__tests__/app-update-service.test.ts
+++ b/apps/desktop/src/main/__tests__/app-update-service.test.ts
@@ -215,8 +215,6 @@ describe('AppUpdateService', () => {
       state: 'downloaded',
       currentVersion: '1.0.0',
       latestVersion: '1.1.0',
-      releaseName: undefined,
-      downloadedFile: '/tmp/maka-update.zip',
     });
   });
 

--- a/apps/desktop/src/main/app-ipc-main.ts
+++ b/apps/desktop/src/main/app-ipc-main.ts
@@ -84,7 +84,6 @@ export function registerAppIpc(
     if (!isAppUpdateInstallRequest(input)) throw new TypeError('Invalid app update install request');
     return updateService.installUpdate(input);
   });
-  targetIpc.handle('app:openUpdateDownload', () => updateService.openUpdateDownload());
   targetIpc.handle('projects:list', () => deps.projectManagement.list());
   targetIpc.handle('projects:add', () => deps.projectManagement.add());
   targetIpc.handle('projects:select', (_event, projectId: unknown) =>

--- a/apps/desktop/src/main/app-update-service.ts
+++ b/apps/desktop/src/main/app-update-service.ts
@@ -18,7 +18,6 @@ export type AppUpdateStatus =
       currentVersion: string;
       latestVersion: string;
       releaseName?: string;
-      releaseUrl?: string;
       publishedAt?: string;
     }
   | {
@@ -75,7 +74,6 @@ interface AppUpdateServiceDeps {
   };
 }
 
-const RELEASES_URL = 'https://github.com/Maka-Agent/maka-agent/releases/latest';
 const FIRST_UPDATE_CHECK_DELAY_MS = 10_000;
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
 
@@ -118,12 +116,6 @@ function updateInfoReleaseDate(info: UpdateInfo | undefined): string | undefined
   return typeof info?.releaseDate === 'string' ? info.releaseDate : undefined;
 }
 
-function updateInfoReleaseUrl(info: UpdateInfo | undefined): string | undefined {
-  const files = Array.isArray(info?.files) ? info.files : [];
-  const firstUrl = files.find((file) => typeof file.url === 'string')?.url;
-  return firstUrl ? new URL(firstUrl, RELEASES_URL).toString() : RELEASES_URL;
-}
-
 function progressFromInfo(info: ProgressInfo): AppUpdateProgress {
   return {
     percent: Math.max(0, Math.min(100, Number.isFinite(info.percent) ? info.percent : 0)),
@@ -159,7 +151,6 @@ function mockStatus(currentVersion: string, latestVersion: string, state: AppUpd
     currentVersion,
     latestVersion,
     releaseName: `Maka ${latestVersion}`,
-    releaseUrl: RELEASES_URL,
     publishedAt: new Date().toISOString(),
   };
 }
@@ -252,7 +243,6 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       currentVersion: deps.currentVersion,
       latestVersion: version,
       releaseName: updateInfoReleaseName(info),
-      releaseUrl: updateInfoReleaseUrl(info),
       publishedAt: updateInfoReleaseDate(info),
     });
   });

--- a/apps/desktop/src/main/app-update-service.ts
+++ b/apps/desktop/src/main/app-update-service.ts
@@ -59,13 +59,11 @@ export interface AppUpdateService {
   getStatus(): AppUpdateStatus;
   retryUpdateDownload(): Promise<AppUpdateStatus>;
   installUpdate(input: AppUpdateInstallRequest): Promise<AppUpdateInstallResult>;
-  openUpdateDownload(): Promise<{ ok: true } | { ok: false; reason: 'not_available' | 'open_failed' }>;
 }
 
 interface AppUpdateServiceDeps {
   currentVersion: string;
   isPackaged: boolean;
-  openExternal(url: string): Promise<void>;
   updater?: AppUpdater;
   mockLatestVersion?: string;
   mockState?: 'available' | 'downloading' | 'downloaded';
@@ -397,25 +395,11 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     }
   }
 
-  async function openUpdateDownload(): Promise<{ ok: true } | { ok: false; reason: 'not_available' | 'open_failed' }> {
-    const url = status.state === 'available' ? status.releaseUrl ?? RELEASES_URL : RELEASES_URL;
-    if (status.state === 'not-available' || status.state === 'idle' || status.state === 'checking') {
-      return { ok: false, reason: 'not_available' };
-    }
-    try {
-      await deps.openExternal(url);
-      return { ok: true };
-    } catch {
-      return { ok: false, reason: 'open_failed' };
-    }
-  }
-
   return {
     start,
     dispose,
     getStatus: currentStatus,
     retryUpdateDownload,
     installUpdate,
-    openUpdateDownload,
   };
 }

--- a/apps/desktop/src/main/app-update-service.ts
+++ b/apps/desktop/src/main/app-update-service.ts
@@ -17,8 +17,6 @@ export type AppUpdateStatus =
       state: 'available';
       currentVersion: string;
       latestVersion: string;
-      releaseName?: string;
-      publishedAt?: string;
     }
   | {
       state: 'downloading';
@@ -30,8 +28,6 @@ export type AppUpdateStatus =
       state: 'downloaded';
       currentVersion: string;
       latestVersion: string;
-      releaseName?: string;
-      downloadedFile?: string;
     }
   | { state: 'installing'; currentVersion: string; latestVersion: string }
   | {
@@ -108,14 +104,6 @@ function updateInfoVersion(info: Pick<UpdateInfo, 'version'> | undefined): strin
   return typeof info?.version === 'string' ? normalizeVersion(info.version) : undefined;
 }
 
-function updateInfoReleaseName(info: UpdateInfo | undefined): string | undefined {
-  return typeof info?.releaseName === 'string' ? info.releaseName : undefined;
-}
-
-function updateInfoReleaseDate(info: UpdateInfo | undefined): string | undefined {
-  return typeof info?.releaseDate === 'string' ? info.releaseDate : undefined;
-}
-
 function progressFromInfo(info: ProgressInfo): AppUpdateProgress {
   return {
     percent: Math.max(0, Math.min(100, Number.isFinite(info.percent) ? info.percent : 0)),
@@ -134,8 +122,6 @@ function mockStatus(currentVersion: string, latestVersion: string, state: AppUpd
       state: 'downloaded',
       currentVersion,
       latestVersion,
-      releaseName: `Maka ${latestVersion}`,
-      downloadedFile: 'mock-update.zip',
     };
   }
   if (state === 'downloading') {
@@ -150,8 +136,6 @@ function mockStatus(currentVersion: string, latestVersion: string, state: AppUpd
     state: 'available',
     currentVersion,
     latestVersion,
-    releaseName: `Maka ${latestVersion}`,
-    publishedAt: new Date().toISOString(),
   };
 }
 
@@ -242,8 +226,6 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       state: 'available',
       currentVersion: deps.currentVersion,
       latestVersion: version,
-      releaseName: updateInfoReleaseName(info),
-      publishedAt: updateInfoReleaseDate(info),
     });
   });
   updater.on('update-not-available', (info) => {
@@ -269,8 +251,6 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       state: 'downloaded',
       currentVersion: deps.currentVersion,
       latestVersion: updateInfoVersion(event) ?? latestVersion() ?? deps.currentVersion,
-      releaseName: updateInfoReleaseName(event),
-      downloadedFile: event.downloadedFile,
     });
   });
   updater.on('error', (error) => {

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -679,7 +679,6 @@ const shellRuns = new ShellRunProcessManager({
 const updateService = createAppUpdateService({
   currentVersion: app.getVersion(),
   isPackaged: app.isPackaged,
-  openExternal: (url) => shell.openExternal(url),
   mockLatestVersion: process.env.MAKA_UPDATE_MOCK_VERSION,
   mockState: updateMockState,
   onStatusChange: (status) => safeSendToRenderer('app:updateStatusChanged', status),

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -193,7 +193,6 @@ const updateMockState =
 const updateService = createAppUpdateService({
   currentVersion: app.getVersion(),
   isPackaged: app.isPackaged,
-  openExternal: (url) => shell.openExternal(url),
   mockLatestVersion: process.env.MAKA_UPDATE_MOCK_VERSION,
   mockState: updateMockState,
   onStatusChange: (status) =>

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -153,8 +153,6 @@ export type AppUpdateStatus =
       state: 'available';
       currentVersion: string;
       latestVersion: string;
-      releaseName?: string;
-      publishedAt?: string;
     }
   | {
       state: 'downloading';
@@ -171,8 +169,6 @@ export type AppUpdateStatus =
       state: 'downloaded';
       currentVersion: string;
       latestVersion: string;
-      releaseName?: string;
-      downloadedFile?: string;
     }
   | { state: 'installing'; currentVersion: string; latestVersion: string }
   | {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -154,7 +154,6 @@ export type AppUpdateStatus =
       currentVersion: string;
       latestVersion: string;
       releaseName?: string;
-      releaseUrl?: string;
       publishedAt?: string;
     }
   | {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -659,7 +659,6 @@ export interface MakaBridge {
     updateStatus(): Promise<AppUpdateStatus>;
     retryUpdateDownload(): Promise<AppUpdateStatus>;
     installUpdate(input: AppUpdateInstallRequest): Promise<AppUpdateInstallResult>;
-    openUpdateDownload(): Promise<{ ok: true } | { ok: false; reason: 'not_available' | 'open_failed' }>;
     sessionProjectInfo(sessionId: string): Promise<{
       projectPath: string;
       projectGit: { isGitRepo: boolean; branch?: string };

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1031,9 +1031,6 @@ const makaBridge = {
     installUpdate(input: AppUpdateInstallRequest): Promise<AppUpdateInstallResult> {
       return ipcRenderer.invoke('app:installUpdate', input);
     },
-    openUpdateDownload(): Promise<{ ok: true } | { ok: false; reason: 'not_available' | 'open_failed' }> {
-      return ipcRenderer.invoke('app:openUpdateDownload');
-    },
     sessionProjectInfo(sessionId: string): Promise<{
       projectPath: string;
       projectGit: { isGitRepo: boolean; branch?: string };


### PR DESCRIPTION
## Summary

#2320 narrowed the sidebar footer to the `downloaded` and `error` update states, which made the renderer fallback that called `window.maka.app.openUpdateDownload()` unreachable; that PR deleted it. This one removes what it left behind, and then follows the same judgment — a value is live only if something reads it — through the rest of the update status. The cut was deliberately kept out of #2320 because it crosses the main/preload/renderer contract boundary and the UI PR should stay reviewable as a UI change.

Three commits, each a complete cut, each independently revertable.

**1. The bridge** — service method, IPC handler, preload binding, contract entry. Verified against current `main` that nothing else reaches for it: a repo-wide search for both `openUpdateDownload` and the `app:openUpdateDownload` channel string, unrestricted by file type, hits nothing in the E2E specs, the main-process tests, the settings pages, or the Storybook stories. The `openUpdateDownload` symbol still in `app-shell.tsx` is the same-named local callback #2320 rewrote; it dispatches on the narrowed reminder and never touches the bridge. `openUpdateDownload` was also the only reader of `AppUpdateServiceDeps.openExternal`, so that dependency goes too, along with the `openExternal: (url) => shell.openExternal(url)` line at each of its two boot sites (`boot.ts` and `runtime-host-boot.ts`) and the matching stub in the service's test fixture. `shell` stays imported in both; its remaining uses feed the OAuth, subscription, and settings-bots services.

**2. The release URL it was reading** — the method resolved `status.releaseUrl ?? RELEASES_URL` and handed the result to `shell.openExternal`, and it was that field's only reader anywhere in the repo. With the field gone, `updateInfoReleaseUrl` has no caller and `RELEASES_URL` no reader, so the producer chain goes with it.

**3. The metadata that never had a reader at all** — `releaseName`, `publishedAt`, and `downloadedFile` have ridden along on the status since it was written without ever reaching a consumer. The sidebar reminder reads `state` and `latestVersion`; the install path reads `message` and `operation`. The only assertion naming them was a status snapshot in this service's own test — coverage of the shape, not of a behavior.

`progress` stays, and not because it is hard to remove — deleting it costs nothing and no test asserts it. It stays because of what removal would leave behind. `publish` broadcasts on every call and `download-progress` fires per chunk, so `progress` is the only thing those broadcasts carry that changes; strip it and the handler spends an IPC message per chunk restating a constant, purely to maintain the `downloading` flag that guards re-entrant downloads. Finishing that thought means publishing `downloading` once on transition — a change to the broadcast cadence, which is a behavior change rather than a deletion.

Refs #2320.

## Verification

- `npm run lint` — 2599 files, clean
- `npm run format:check` — 1570 files, clean
- `npm run typecheck` — clean across the workspace (this is what surfaced the second boot site, in `runtime-host-boot.ts`)
- `npm --workspace @maka/desktop run test:checks` — console, a11y, and copy all clean
- desktop main-process tests — 1770 tests, 1756 pass, 14 fail

`ipc-surface-contract.test.ts` is the real safety net for the first commit: it asserts strict two-way parity between `targetIpc.handle` registrations in main and `ipcRenderer.invoke` channels in preload, so dropping either side alone turns it red. It passes here. The preload object is `satisfies MakaBridge`, so the contract entries are compiler-checked too.

The 14 failures are pre-existing on macOS and unrelated. I ran the same suite on unmodified `main` first: identical counts and the identical set of failing top-level cases — seven `project-*` / workspace-picker cases hitting the `/var` vs `/private/var` symlink mismatch, plus two computer-use overlay placeholder cases. The counts were re-checked after each commit and never moved.

Not run: Playwright E2E and a packaged build. This deletes an IPC surface with no caller and status fields with no reader, so there is nothing for either to exercise; correspondingly there is no user-visible behavior to attach evidence for.

## Review focus

Neither contract check in this repo would have caught the bridge going stale. The IPC parity test only proves main and preload agree with each other, and `satisfies MakaBridge` only proves preload matches the contract — both stayed green while the surface sat with zero renderer callers. Nothing asserts that a preload method still has a consumer.

That gap is not hypothetical. Scanning the bridge for methods with no consumer in the renderer, `packages/ui`, the stories, or the E2E specs turns up eleven more: seven on `memory` (`propose`, `listProposals`, `approveProposal`, `rejectProposal`, `remember`, `archiveEntry`, `restoreEntry`), plus `onboarding.clearMilestone`, `graphs.inspectOperator`, `skills.details`, and `mcp.reconnect`. They are deliberately not touched here. The memory set in particular is a coherent, fully implemented proposal workflow with main-side test coverage in `local-memory-service.test.ts` — that reads as a feature whose UI was never wired, not as residue, and deleting it would be a product decision rather than a cleanup. Each of the eleven needs its own history checked. Worth a follow-up; out of scope for this PR.