### PR TITLE
fix(headless): update DeepSeek V4 Flash pricing

### DIFF
--- a/packages/headless/harbor/runtime-policy-ab-profiles/deepseek-v4-flash.json
+++ b/packages/headless/harbor/runtime-policy-ab-profiles/deepseek-v4-flash.json
@@ -6,9 +6,9 @@
   "baseUrl": "https://api.deepseek.com",
   "model": "deepseek/deepseek-v4-flash",
   "pricing": {
-    "inputUsdPer1M": 0.145,
-    "outputUsdPer1M": 0.29,
-    "cacheReadUsdPer1M": 0.0029,
+    "inputUsdPer1M": 0.14,
+    "outputUsdPer1M": 0.28,
+    "cacheReadUsdPer1M": 0.0028,
     "cacheWriteUsdPer1M": 0,
     "source": "deepseek-v4-flash"
   },

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -620,7 +620,7 @@ test('harness A/B resolves an explicit GLM 5.2 runtime independently from OpenCo
   assert.equal(resolveHarnessAbRunId(composition), 'glm-5.2-maka-vs-opencode-tbench-2.1-full-v1');
 });
 
-test('harness A/B resolves DeepSeek V4 Flash as a metered OpenCode comparison', async () => {
+test('harness A/B freezes current DeepSeek V4 Flash metered pricing', async () => {
   const {
     buildHarnessAbManifest,
     buildHarnessExecutionProfile,
@@ -641,10 +641,10 @@ test('harness A/B resolves DeepSeek V4 Flash as a metered OpenCode comparison', 
     baseUrl: 'https://api.deepseek.com',
     billingMode: 'metered',
     pricing: {
-      inputUsdPer1M: 0.145,
-      cacheReadUsdPer1M: 0.0029,
+      inputUsdPer1M: 0.14,
+      cacheReadUsdPer1M: 0.0028,
       cacheWriteUsdPer1M: 0,
-      outputUsdPer1M: 0.29,
+      outputUsdPer1M: 0.28,
       source: 'deepseek-v4-flash',
     },
   });
@@ -665,10 +665,10 @@ test('harness A/B resolves DeepSeek V4 Flash as a metered OpenCode comparison', 
   assert.deepEqual(manifest.metadata.pricing, {
     currency: 'USD',
     unit: 'per_1m_tokens',
-    input: 0.145,
-    cachedInput: 0.0029,
+    input: 0.14,
+    cachedInput: 0.0028,
     cacheWrite: 0,
-    output: 0.29,
+    output: 0.28,
     source: 'deepseek-v4-flash',
   });
   assert.equal(manifest.arms[1].id, 'opencode');

--- a/packages/headless/src/__tests__/runtime-policy-ab-profile.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-profile.test.ts
@@ -11,7 +11,13 @@ test('checked-in runtime A/B profile pins DeepSeek Flash identity, pricing, and 
   const profile = parseRuntimePolicyAbExecutionProfile(JSON.parse(await readFile(path, 'utf8')));
 
   assert.equal(profile.model, 'deepseek/deepseek-v4-flash');
-  assert.equal(profile.pricing.source, 'deepseek-v4-flash');
+  assert.deepEqual(profile.pricing, {
+    inputUsdPer1M: 0.14,
+    outputUsdPer1M: 0.28,
+    cacheReadUsdPer1M: 0.0028,
+    cacheWriteUsdPer1M: 0,
+    source: 'deepseek-v4-flash',
+  });
   assert.equal(profile.observedCostStopUsd, 20);
   assert.equal(profile.maxConcurrentAttempts, 2);
 });

--- a/packages/headless/src/deepseek-pricing.ts
+++ b/packages/headless/src/deepseek-pricing.ts
@@ -1,25 +1,23 @@
 /**
- * DeepSeek per-1M USD pricing (0.145 USD/CNY) shared by the DeepSeek A/B and
- * RSI prompt-optimization run scripts. "input" is the cache-miss rate; cache
- * writes carry no separate charge, so `cacheWriteUsdPer1M` is 0. This is vendor
- * run config, not part of the generic `@maka/headless` public API, so it is
- * imported via a package-local `#deepseek-pricing` subpath and is not
- * re-exported from `index.ts`.
+ * DeepSeek per-1M USD pricing shared by the DeepSeek A/B and RSI
+ * prompt-optimization run scripts. "input" is the cache-miss rate; cache writes
+ * carry no separate charge, so `cacheWriteUsdPer1M` is 0. This is vendor run
+ * config, not part of the generic `@maka/headless` public API, so it is imported
+ * via a package-local `#deepseek-pricing` subpath and is not re-exported from
+ * `index.ts`.
  *
- * The object is a plain constant with no per-run unit test pinning it, so a
- * mistyped field name would leave a rate `undefined` and the runner would
- * silently emit wrong/zero `costUsd`. Fail loud at import — before any Docker
- * time — if a canonical rate field is missing or is not a finite, non-negative
- * number. The field-name -> MAKA_TRIAL_* forwarding contract is covered in
- * harbor-task-runner.test.ts.
+ * Fail loud at import — before any Docker time — if a canonical rate field is
+ * missing or is not a finite, non-negative number. The published runner profile
+ * and manifest rates are pinned by their boundary tests; the field-name ->
+ * MAKA_TRIAL_* forwarding contract is covered in harbor-task-runner.test.ts.
  */
 
 import type { HarborTaskPricing } from './harbor-task-runner.js';
 
 export const DEEPSEEK_V4_FLASH_PRICING: HarborTaskPricing = {
-  inputUsdPer1M: 0.145,
-  outputUsdPer1M: 0.29,
-  cacheReadUsdPer1M: 0.0029,
+  inputUsdPer1M: 0.14,
+  outputUsdPer1M: 0.28,
+  cacheReadUsdPer1M: 0.0028,
   cacheWriteUsdPer1M: 0,
   source: 'deepseek-v4-flash',
 };


### PR DESCRIPTION
## Summary

Update the DeepSeek V4 Flash metered rates to the current official USD prices: $0.14 per 1M cache-miss input tokens, $0.0028 per 1M cache-hit input tokens, and $0.28 per 1M output tokens.

Keep the shared harness pricing and the checked-in runtime-policy profile aligned so manifests, observed costs, and benchmark cost projections use the same rates.

Official pricing: https://api-docs.deepseek.com/quick_start/pricing

## Verification

- RED: harness execution profile test failed against the old 0.145 / 0.0029 / 0.29 rates
- RED: checked-in runtime-policy profile test failed against the old rates
- PASS: 190 related headless tests across harness CLI, runtime-policy, Harbor task runner, and prompt optimization
- PASS: npm run format:check
- PASS: npm run lint
- PASS: git diff --check
- npm run build -w @maka/headless is blocked on unchanged main by existing Undici type errors in packages/headless/src/provider-auth-proxy.ts:572-577