### PR TITLE
fix(ci): normalize Windows process identities

### DIFF
--- a/.github/workflows/windows-baseline.yml
+++ b/.github/workflows/windows-baseline.yml
@@ -127,13 +127,14 @@ jobs:
         continue-on-error: true
         shell: pwsh
         run: |
+          . ./scripts/windows-process-identity.ps1
           $baseline = Get-Content "$env:WINDOWS_BASELINE_LOG_DIR/process-baseline.json" -Raw |
             ConvertFrom-Json
           $baselineKeys = [System.Collections.Generic.HashSet[string]]::new(
             [System.StringComparer]::Ordinal
           )
           foreach ($process in @($baseline.Processes)) {
-            [void]$baselineKeys.Add("$($process.ProcessId)|$($process.CreationDate)")
+            [void]$baselineKeys.Add((Get-WindowsProcessIdentityKey $process))
           }
           $allProcesses = @(
             Get-CimInstance Win32_Process |
@@ -150,7 +151,7 @@ jobs:
           $leaks = @(
             $allProcesses | Where-Object {
                 $_.Name -in @('node.exe', 'electron.exe') -and
-                -not $baselineKeys.Contains("$($_.ProcessId)|$($_.CreationDate)")
+                -not $baselineKeys.Contains((Get-WindowsProcessIdentityKey $_))
               }
           )
           ConvertTo-Json -InputObject $leaks -Depth 3 |
@@ -188,12 +189,12 @@ jobs:
           $remainingById = @{}
           Get-CimInstance Win32_Process |
             ForEach-Object {
-              $key = "$($_.ProcessId)|$($_.CreationDate.ToUniversalTime().ToString('o'))"
+              $key = Get-WindowsProcessIdentityKey $_
               $remainingById[$key] = $_
             }
           $unreaped = @(
             $ownedTree | Where-Object {
-              $remainingById.ContainsKey("$($_.ProcessId)|$($_.CreationDate)")
+              $remainingById.ContainsKey((Get-WindowsProcessIdentityKey $_))
             }
           )
           ConvertTo-Json -InputObject $unreaped -Depth 3 |

--- a/scripts/windows-baseline-workflow.test.mjs
+++ b/scripts/windows-baseline-workflow.test.mjs
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 const workflowUrl = new URL('../.github/workflows/windows-baseline.yml', import.meta.url);
+const processIdentityScriptUrl = new URL('./windows-process-identity.ps1', import.meta.url);
 
 test('Windows baseline workflow keeps its non-blocking evidence contract', async () => {
   const workflow = await readFile(workflowUrl, 'utf8');
@@ -40,6 +43,8 @@ test('Windows baseline workflow keeps its non-blocking evidence contract', async
   assert.match(workflow, /name: Capture process baseline/u);
   assert.match(workflow, /process-baseline\.json/u);
   assert.match(workflow, /CreationDate/u);
+  assert.match(workflow, /\. \.\/scripts\/windows-process-identity\.ps1/u);
+  assert.equal(workflow.match(/Get-WindowsProcessIdentityKey/gmu)?.length, 4);
   assert.match(workflow, /HashSet\[string\]/u);
   assert.match(workflow, /HashSet\[int\]/u);
   assert.doesNotMatch(workflow, /CommandLine -match/u);
@@ -61,4 +66,29 @@ test('Windows baseline workflow keeps its non-blocking evidence contract', async
   assert.match(workflow, /actions\/upload-artifact@[0-9a-f]{40} # v\d+\.\d+\.\d+/u);
   assert.match(workflow, /name: windows-baseline/u);
   assert.match(workflow, /retention-days: 14/u);
+});
+
+test('Windows process identity matches a non-empty JSON baseline to a live process object', {
+  skip: process.platform !== 'win32',
+}, () => {
+  const fixture = String.raw`
+      . '${fileURLToPath(processIdentityScriptUrl).replaceAll("'", "''")}'
+      $captured = [pscustomobject]@{
+        Processes = @([pscustomobject]@{
+          ProcessId = 4242
+          CreationDate = [DateTimeOffset]::Parse('2026-08-05T08:09:10.1234567+08:00')
+        })
+      } | ConvertTo-Json -Depth 3 | ConvertFrom-Json
+      $live = [pscustomobject]@{
+        ProcessId = 4242
+        CreationDate = [DateTime]::Parse('2026-08-05T00:09:10.1234567Z').ToUniversalTime()
+      }
+      if ((Get-WindowsProcessIdentityKey $captured.Processes) -ne (Get-WindowsProcessIdentityKey $live)) {
+        exit 1
+      }
+    `;
+  const result = spawnSync('pwsh.exe', ['-NoProfile', '-NonInteractive', '-Command', fixture], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
 });

--- a/scripts/windows-process-identity.ps1
+++ b/scripts/windows-process-identity.ps1
@@ -1,0 +1,10 @@
+function Get-WindowsProcessIdentityKey {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Process
+  )
+
+  $creationDate = [DateTimeOffset]$Process.CreationDate
+  $creationDateUtc = $creationDate.ToUniversalTime().ToString('o')
+  return "$($Process.ProcessId)|$creationDateUtc"
+}


### PR DESCRIPTION
## Summary

- normalize baseline, live, and post-cleanup Windows process identities through one PowerShell helper
- prevent `ConvertFrom-Json` date typing from changing `(PID, CreationDate)` comparisons
- cover a non-empty serialized baseline matched against an equivalent live process object on Windows

Follow-up to #2173. Part of #2142.

## Validation

- `npm run test:scripts` (123 pass, 1 Windows-only skip on macOS)
- `npm run windows:inventory`
- `npx biome check scripts/windows-baseline-workflow.test.mjs .github/workflows/windows-baseline.yml`
- `git diff --check`