### PR TITLE
feat(cli): add Runtime Host-backed maka run

### DIFF
--- a/packages/cli/src/__tests__/run-command-fixture.ts
+++ b/packages/cli/src/__tests__/run-command-fixture.ts
@@ -2,12 +2,20 @@ import type { SessionEvent } from '@maka/core/events';
 import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
 import type { SessionSummary } from '@maka/core/session';
 import type { InvocationResult } from '@maka/runtime';
-import { runMakaTextCli, type MakaRunContext, type MakaRunRuntime } from '../run-command.js';
-import type { CreateMakaCliRuntimeContextInput } from '../runtime-bootstrap.js';
+import {
+  runMakaTextCli,
+  type MakaRunContext,
+  type MakaRunContextInput,
+  type MakaRunRuntime,
+} from '../run-command.js';
+import {
+  invocationHasSandboxBoundaryFailure,
+  invocationRecoveredSandboxBoundaryFailure,
+} from '../sandbox-boundary-failure.js';
 import type { ReadySessionTarget } from '../connection-target.js';
 
 const scenario = process.env.MAKA_RUN_FIXTURE_SCENARIO ?? 'completed';
-let observer: CreateMakaCliRuntimeContextInput['runtimeInvocationObserver'];
+let observer: MakaRunContextInput['runOutcomeObserver'];
 let permissionDenied = false;
 let releaseStop: (() => void) | undefined;
 let releaseGraphWait: (() => void) | undefined;
@@ -218,7 +226,7 @@ const runtime: MakaRunRuntime = {
   },
 };
 
-async function createContext(input: CreateMakaCliRuntimeContextInput): Promise<MakaRunContext> {
+async function createContext(input: MakaRunContextInput): Promise<MakaRunContext> {
   if (scenario === 'config-error') throw new Error('unknown connection fixture-missing');
   if (
     process.env.MAKA_RUN_EXPECT_MAX_STEPS &&
@@ -250,7 +258,7 @@ async function createContext(input: CreateMakaCliRuntimeContextInput): Promise<M
       throw new Error(`unexpected sessionCwdOverride ${actual}`);
     }
   }
-  observer = input.runtimeInvocationObserver;
+  observer = input.runOutcomeObserver;
   if (
     process.env.MAKA_RUN_EXPECT_GRAPH === '1' ||
     scenario === 'graph-runtime-error' ||
@@ -382,7 +390,17 @@ function functionResponseEvent(
 }
 
 async function notify(result: InvocationResult): Promise<void> {
-  await observer?.(result);
+  await observer?.({
+    outcomeId: result.invocationId,
+    status: result.status === 'completed' ? 'completed' : 'failed',
+    ...(result.finalOutput !== undefined ? { finalOutput: result.finalOutput } : {}),
+    ...(result.failure ? { failure: result.failure } : {}),
+    sandboxBoundary: invocationRecoveredSandboxBoundaryFailure(result)
+      ? 'recovered'
+      : invocationHasSandboxBoundaryFailure(result)
+        ? 'unresolved'
+        : 'none',
+  });
 }
 
 runMakaTextCli(process.argv.slice(2), { createContext, listSessions }).then(

--- a/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { basename } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import type { RuntimeHostConnection } from '@maka/runtime-host/client';
+import { connectRuntimeHostCli } from '../runtime-host-cli-context.js';
+
+test('CLI Runtime Host bootstrap launches the execution composition', async () => {
+  let candidateEntrypoint: string | URL | undefined;
+  let closes = 0;
+  const connection = {
+    status: async () => ({ state: 'ready' }),
+    close: async () => {
+      closes += 1;
+    },
+  } as unknown as RuntimeHostConnection;
+
+  const context = await connectRuntimeHostCli(
+    { rootPath: '/runtime-host-root', surface: 'run' },
+    {
+      connectOrSpawn: async (input) => {
+        candidateEntrypoint = input.candidateEntrypoint;
+        return { kind: 'connected', connection };
+      },
+      readConnectionCatalog: async () => ({
+        revision: 1,
+        defaultTarget: null,
+        connections: [],
+      }),
+    },
+  );
+
+  assert.ok(candidateEntrypoint instanceof URL);
+  assert.equal(basename(fileURLToPath(candidateEntrypoint)), 'execution-candidate-main.js');
+  await context.close();
+  assert.equal(closes, 1);
+});

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -1,0 +1,990 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { SessionEvent, SessionSummary, StoredMessage } from '@maka/core';
+import type { RuntimeHostConnection } from '@maka/runtime-host/client';
+import type {
+  InteractionPendingSnapshot,
+  SessionCatalogProjection,
+} from '@maka/runtime-host/protocol';
+import { resolveRuntimeHostCliTarget } from '../runtime-host-cli-context.js';
+import { createRuntimeHostRunContext, runRuntimeHostTextCli } from '../runtime-host-run-command.js';
+import type { RuntimeHostMakaSessionDriver } from '../runtime-host-session-driver.js';
+import type { MakaRunContextInput, MakaRunOutcome } from '../run-command-core.js';
+
+describe('Runtime Host maka run adapter', () => {
+  test('runs the public command through one Host connection and preserves stdout semantics', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let closes = 0;
+    const exitCode = await runRuntimeHostTextCli(
+      ['answer once'],
+      {
+        workspaceRoot: () => '/runtime-host-data',
+        processCwd: () => process.cwd(),
+        stdinIsTTY: () => true,
+        readStdin: async () => '',
+        writeStdout: (text) => stdout.push(text),
+        writeStderr: (text) => stderr.push(text),
+        onSigint: () => () => {},
+        newId: () => 'turn-1',
+      },
+      {
+        connect: async () => ({
+          connection: {} as RuntimeHostConnection,
+          catalog: connectionCatalog(),
+          close: async () => {
+            closes += 1;
+          },
+        }),
+        createContext: (_connection, _catalog, input) => publicCommandContext(input),
+      },
+    );
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(stdout, ['Host answer\n']);
+    assert.deepEqual(stderr, []);
+    assert.equal(closes, 1);
+  });
+
+  test('continues the Host-owned cwd Session without creating another identity', async () => {
+    const cwd = process.cwd();
+    let creates = 0;
+    let contextInput: MakaRunContextInput | undefined;
+    const connection = {
+      request: async (operation: string) => {
+        if (operation !== 'session.catalog.query') {
+          throw new Error(`Unexpected operation: ${operation}`);
+        }
+        return {
+          kind: 'page',
+          revision: 1,
+          nextCursor: null,
+          sessions: [
+            {
+              ...sessionProjection('session-existing'),
+              cwd,
+              lastUsedAt: 10,
+              lastMessageAt: 10,
+            },
+          ],
+        };
+      },
+    } as unknown as RuntimeHostConnection;
+    const exitCode = await runRuntimeHostTextCli(
+      ['continue once', '--continue'],
+      {
+        workspaceRoot: () => '/runtime-host-data',
+        processCwd: () => cwd,
+        stdinIsTTY: () => true,
+        readStdin: async () => '',
+        writeStdout: () => {},
+        writeStderr: () => {},
+        onSigint: () => () => {},
+        newId: () => 'turn-continue',
+      },
+      {
+        connect: async () => ({
+          connection,
+          catalog: connectionCatalog(),
+          close: async () => {},
+        }),
+        createContext: (_connection, _catalog, input) => {
+          contextInput = input;
+          return publicCommandContext(input, () => {
+            creates += 1;
+          });
+        },
+      },
+    );
+
+    assert.equal(exitCode, 0);
+    assert.equal(creates, 0);
+    assert.equal(contextInput?.sessionCwdOverride?.sessionId, 'session-existing');
+  });
+
+  test('fails the public command explicitly when an ordinary Host Turn requests permission', async () => {
+    const stderr: string[] = [];
+    const fixture = runFixture({
+      pendingInteractions: [pendingPermission('turn-1')],
+      pendingAfterTurnStarts: true,
+    });
+
+    const exitCode = await runRuntimeHostTextCli(
+      ['run a protected tool'],
+      {
+        workspaceRoot: () => '/runtime-host-data',
+        processCwd: () => process.cwd(),
+        stdinIsTTY: () => true,
+        readStdin: async () => '',
+        writeStdout: () => {},
+        writeStderr: (text) => stderr.push(text),
+        onSigint: () => () => {},
+        newId: () => 'turn-1',
+      },
+      {
+        connect: async () => ({
+          connection: {} as RuntimeHostConnection,
+          catalog: connectionCatalog(),
+          close: async () => {},
+        }),
+        createContext: () => fixture.context,
+      },
+    );
+
+    assert.equal(exitCode, 1);
+    assert.match(stderr.join(''), /interactive permission requests are unavailable/);
+    assert.deepEqual(fixture.exactTurnStops, [
+      { sessionId: 'session-created', turnId: 'turn-1', runId: 'run-1' },
+    ]);
+  });
+
+  test('folds one Host Turn into the shared one-shot invocation contract', async () => {
+    const observed: MakaRunOutcome[] = [];
+    const fixture = runFixture({ observed });
+    const context = fixture.context;
+    const session = await context.runtime.createSession({
+      cwd: '/workspace',
+      name: 'Run once',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+    const events = await collect(
+      context.runtime.sendMessage(session.id, { turnId: 'turn-1', text: 'answer once' }),
+    );
+
+    assert.deepEqual(
+      events.map((event) => event.type),
+      ['text_complete', 'complete'],
+    );
+    assert.equal(observed.length, 1);
+    assert.equal(observed[0]?.outcomeId, 'run-1');
+    assert.equal(observed[0]?.status, 'completed');
+    assert.equal(observed[0]?.finalOutput, 'Host answer');
+    assert.deepEqual(context.target, {
+      connection: { slug: 'openai-main' },
+      model: 'gpt-5',
+    });
+  });
+
+  test('waits for Host-started graph supervisor Turns before returning', async () => {
+    const observed: MakaRunOutcome[] = [];
+    const fixture = runFixture({ observed, graph: true, graphProjectionRace: true });
+    const session = await fixture.context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+    await collect(
+      fixture.context.runtime.sendMessage(session.id, {
+        turnId: 'turn-1',
+        text: 'delegate',
+        turnOrchestration: { mode: 'graph', source: 'host_api' },
+      }),
+    );
+    await fixture.context.agentGraph?.waitForCompletion(session.id);
+
+    assert.equal(observed.length, 2);
+    assert.equal(observed.at(-1)?.outcomeId, 'turn-2');
+    assert.equal(observed.at(-1)?.finalOutput, 'Final graph answer');
+  });
+
+  test('uses the durable Graph supervisor outcome independently of live projection', async () => {
+    const observed: MakaRunOutcome[] = [];
+    const fixture = runFixture({ observed, graph: true });
+    const session = await fixture.context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+    await collect(
+      fixture.context.runtime.sendMessage(session.id, {
+        turnId: 'turn-1',
+        text: 'delegate',
+        turnOrchestration: { mode: 'graph', source: 'host_api' },
+      }),
+    );
+
+    await fixture.context.agentGraph?.waitForCompletion(session.id);
+
+    assert.equal(observed.at(-1)?.outcomeId, 'turn-2');
+    assert.equal(observed.at(-1)?.finalOutput, 'Final graph answer');
+  });
+
+  test('waits for the exact final Graph wake after an earlier wake already settled', async () => {
+    const observed: MakaRunOutcome[] = [];
+    const fixture = runFixture({ observed, graph: true, graphMultiWakeRace: true });
+    const session = await fixture.context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+    await collect(
+      fixture.context.runtime.sendMessage(session.id, {
+        turnId: 'turn-1',
+        text: 'delegate twice',
+        turnOrchestration: { mode: 'graph', source: 'host_api' },
+      }),
+    );
+
+    await fixture.context.agentGraph?.waitForCompletion(session.id);
+
+    assert.equal(observed.at(-1)?.outcomeId, 'turn-3');
+    assert.equal(observed.at(-1)?.finalOutput, 'Final wake answer');
+  });
+
+  test('releases a pending Graph durable-terminal wait when the context closes', async () => {
+    const finalRead = deferred<void>();
+    const fixture = runFixture({
+      graph: true,
+      graphProjectionNeverCompletes: true,
+      onFinalGraphRead: () => finalRead.resolve(),
+    });
+    const context = fixture.context;
+    const session = await context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+    await collect(
+      context.runtime.sendMessage(session.id, {
+        turnId: 'turn-1',
+        text: 'delegate',
+        turnOrchestration: { mode: 'graph', source: 'host_api' },
+      }),
+    );
+    const waiting = context.agentGraph?.waitForCompletion(session.id);
+    assert.ok(waiting);
+    await finalRead.promise;
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await context.close();
+
+    await assert.rejects(waiting, new Error('Runtime Host run context closed'));
+  });
+
+  test('does not reuse a historical Graph outcome when this execution has no successor', async () => {
+    const observed: MakaRunOutcome[] = [];
+    const historical = graphMessages();
+    const fixture = runFixture({
+      observed,
+      graph: true,
+      initialMessages: historical,
+      finalMessages: historical,
+    });
+    const session = await fixture.context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+    await collect(
+      fixture.context.runtime.sendMessage(session.id, {
+        turnId: 'turn-1',
+        text: 'finish without another wake',
+        turnOrchestration: { mode: 'graph', source: 'host_api' },
+      }),
+    );
+
+    await fixture.context.agentGraph?.waitForCompletion(session.id);
+
+    assert.equal(observed.length, 1);
+    assert.equal(observed[0]?.finalOutput, 'Host answer');
+  });
+
+  test('fails closed for a legacy resumed Session whose Host cwd is not canonical', async () => {
+    const fixture = runFixture({
+      sessionCwdOverride: { sessionId: 'session-legacy', cwd: '/canonical-workspace' },
+      switchSummaryCwd: '/workspace-link',
+    });
+
+    await assert.rejects(
+      collect(
+        fixture.context.runtime.sendMessage('session-legacy', {
+          turnId: 'turn-1',
+          text: 'resume safely',
+        }),
+      ),
+      new Error(
+        'Runtime Host cannot resume Session session-legacy: its stored working directory is not canonical',
+      ),
+    );
+  });
+
+  test('fails explicitly instead of ignoring an unsupported Host step cap', () => {
+    const fixture = runFixture({ maxSteps: 3 });
+    assert.throws(
+      () => fixture.context,
+      new Error('--max-steps is not available through the Runtime Host yet'),
+    );
+  });
+
+  test('never selects a discovered model that the Host has not enabled', () => {
+    const catalog = {
+      revision: 1,
+      defaultTarget: null,
+      connections: [
+        {
+          connectionId: 'connection-1',
+          revision: 1,
+          slug: 'openai-main',
+          name: 'OpenAI',
+          providerType: 'openai' as const,
+          enabled: true,
+          enabledModelIds: ['gpt-5'],
+          models: [{ id: 'gpt-5' }, { id: 'gpt-6-preview' }],
+        },
+      ],
+    };
+
+    assert.equal(
+      resolveRuntimeHostCliTarget(catalog, { connectionSlug: 'openai-main' }).model,
+      'gpt-5',
+    );
+    assert.throws(
+      () =>
+        resolveRuntimeHostCliTarget(catalog, {
+          connectionSlug: 'openai-main',
+          model: 'gpt-6-preview',
+        }),
+      new Error('Runtime Host model is unavailable for openai-main: gpt-6-preview'),
+    );
+  });
+
+  test('stops both the active Host Turn and its Graph on cancellation', async () => {
+    const fixture = runFixture({ graph: true });
+    const session = await fixture.context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+
+    await fixture.context.runtime.stopSession(session.id);
+
+    assert.equal(fixture.turnStops, 1);
+    assert.deepEqual(fixture.graphStops, [session.id]);
+  });
+
+  test('stops a Turn that starts after cancellation was requested', async () => {
+    const prepareGate = deferred<void>();
+    const prepareStarted = deferred<void>();
+    const fixture = runFixture({
+      graph: true,
+      prepareGate: prepareGate.promise,
+      onPrepareStarted: () => prepareStarted.resolve(),
+    });
+    const session = await fixture.context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+    const sending = collect(
+      fixture.context.runtime.sendMessage(session.id, {
+        turnId: 'turn-1',
+        text: 'answer once',
+        turnOrchestration: { mode: 'graph', source: 'host_api' },
+      }),
+    );
+    await prepareStarted.promise;
+
+    await fixture.context.runtime.stopSession(session.id);
+    prepareGate.resolve();
+    await sending;
+
+    assert.deepEqual(fixture.exactTurnStops, [
+      { sessionId: session.id, turnId: 'turn-1', runId: 'run-1' },
+    ]);
+    assert.deepEqual(fixture.graphStops, [session.id, session.id]);
+  });
+
+  test('fails and stops instead of waiting for an interactive question', async () => {
+    const fixture = runFixture({
+      turnEvents: questionEvents('turn-1'),
+      pendingInteractions: [pendingQuestion('turn-1')],
+      pendingAfterTurnStarts: true,
+    });
+    const session = await fixture.context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+
+    await assert.rejects(
+      collect(
+        fixture.context.runtime.sendMessage(session.id, {
+          turnId: 'turn-1',
+          text: 'ask me something',
+        }),
+      ),
+      new Error('interactive user questions are unavailable in non-interactive mode'),
+    );
+    assert.deepEqual(fixture.exactTurnStops, [
+      { sessionId: session.id, turnId: 'turn-1', runId: 'run-1' },
+    ]);
+  });
+
+  test('stops Graph Mode when a successor waits for an interactive question', async () => {
+    const fixture = runFixture({
+      graph: true,
+      pendingInteractions: [pendingQuestion('turn-2')],
+    });
+    const session = await fixture.context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+
+    const graph = fixture.context.agentGraph;
+    assert.ok(graph);
+    await assert.rejects(
+      graph.waitForCompletion(session.id),
+      new Error('interactive user questions are unavailable in non-interactive mode'),
+    );
+    assert.deepEqual(fixture.graphStops, [session.id]);
+  });
+
+  test('preserves the interaction error when Graph stop races an in-flight query', async () => {
+    const queryStarted = deferred<void>();
+    const queryGate = deferred<void>();
+    const graphStopped = deferred<void>();
+    const fixture = runFixture({
+      graph: true,
+      graphQueryGate: queryGate.promise,
+      graphQueryStatus: 'stopped',
+      onGraphQueryStarted: () => queryStarted.resolve(),
+      onGraphStop: () => graphStopped.resolve(),
+    });
+    const session = await fixture.context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+    const waiting = fixture.context.agentGraph?.waitForCompletion(session.id);
+    assert.ok(waiting);
+    await queryStarted.promise;
+
+    fixture.publishPendingInteraction(pendingQuestion('turn-2'));
+    await graphStopped.promise;
+    queryGate.resolve();
+
+    await assert.rejects(
+      waiting,
+      new Error('interactive user questions are unavailable in non-interactive mode'),
+    );
+  });
+
+  test('denies a Graph successor sandbox expansion in non-interactive mode', async () => {
+    const fixture = runFixture({
+      graph: true,
+      pendingInteractions: [
+        {
+          schemaVersion: 1,
+          sessionId: 'session-created',
+          turnId: 'turn-2',
+          runId: 'run-2',
+          interactionId: 'boundary-1',
+          revision: 1,
+          status: 'pending',
+          outcome: null,
+          request: {
+            kind: 'sandbox_boundary',
+            justification: 'Needs broader access',
+            expansion: {
+              filesystem: {
+                entries: [{ path: '/outside', access: 'read', scope: 'subtree' }],
+              },
+            },
+          },
+        },
+      ],
+    });
+    const session = await fixture.context.runtime.createSession({
+      cwd: '/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+    });
+
+    await fixture.context.agentGraph?.waitForCompletion(session.id);
+
+    assert.deepEqual(fixture.sandboxResponses, [{ requestId: 'boundary-1', decision: 'deny' }]);
+  });
+});
+
+function publicCommandContext(input: MakaRunContextInput, onCreate: () => void = () => {}) {
+  return {
+    runtime: {
+      createSession: async () => {
+        onCreate();
+        return sessionSummary('session-public');
+      },
+      readExecutionBoundary: async () => ({
+        kind: 'managed' as const,
+        access: 'writable' as const,
+        revision: 0,
+      }),
+      sendMessage: async function* (_sessionId: string, message: { turnId: string }) {
+        yield* eventsFor(message.turnId, 'Host answer');
+        await input.runOutcomeObserver?.({
+          outcomeId: 'run-public',
+          status: 'completed',
+          finalOutput: 'Host answer',
+          sandboxBoundary: 'none',
+        });
+      },
+      respondToSandboxBoundary: async () => {},
+      stopSession: async () => {},
+      setExecutionBoundaryKind: async () => {},
+    },
+    target: { connection: { slug: 'openai-main' }, model: 'gpt-5' },
+    close: async () => {},
+  };
+}
+
+function runFixture(input: {
+  observed?: MakaRunOutcome[];
+  graph?: boolean;
+  maxSteps?: number;
+  prepareGate?: Promise<void>;
+  onPrepareStarted?: () => void;
+  turnEvents?: AsyncIterable<SessionEvent>;
+  pendingInteractions?: InteractionPendingSnapshot[];
+  pendingAfterTurnStarts?: boolean;
+  graphProjectionRace?: boolean;
+  graphMultiWakeRace?: boolean;
+  graphProjectionNeverCompletes?: boolean;
+  onFinalGraphRead?: () => void;
+  sessionCwdOverride?: { sessionId: string; cwd: string };
+  switchSummaryCwd?: string;
+  graphQueryGate?: Promise<void>;
+  graphQueryStatus?: 'completed' | 'stopped';
+  onGraphQueryStarted?: () => void;
+  onGraphStop?: () => void;
+  initialMessages?: StoredMessage[];
+  finalMessages?: StoredMessage[];
+}) {
+  const switches: string[] = [];
+  const graphStops: string[] = [];
+  const exactTurnStops: { sessionId: string; turnId: string; runId: string }[] = [];
+  const sandboxResponses: { requestId: string; decision: 'deny' }[] = [];
+  let turnStops = 0;
+  const pendingInteractionListeners = new Set<(pending: InteractionPendingSnapshot) => void>();
+  const transcriptListeners = new Set<
+    (sessionId: string, turnId: string, messages: StoredMessage[]) => void
+  >();
+  let messageReads = 0;
+  const driver = {
+    createSession: async () => sessionSummary('session-created'),
+    readMessages: async () => {
+      messageReads += 1;
+      if (messageReads === 1) {
+        if (input.graphMultiWakeRace) {
+          queueMicrotask(() => {
+            for (const listener of transcriptListeners) {
+              listener('session-created', 'turn-2', structuredClone(graphMessages()));
+            }
+          });
+        }
+        return structuredClone(input.initialMessages ?? []);
+      }
+      if (input.graphMultiWakeRace) {
+        queueMicrotask(() => {
+          const terminal = multiWakeGraphMessages(true);
+          for (const listener of transcriptListeners) {
+            listener('session-created', 'turn-3', structuredClone(terminal));
+          }
+        });
+        return multiWakeGraphMessages(false);
+      }
+      if (input.graphProjectionNeverCompletes) {
+        input.onFinalGraphRead?.();
+        return graphMessages(false);
+      }
+      const messages = input.finalMessages ?? graphMessages();
+      if (input.graphProjectionRace) {
+        queueMicrotask(() => {
+          for (const listener of transcriptListeners) {
+            listener('session-created', 'turn-2', structuredClone(messages));
+          }
+        });
+        return graphMessages(false);
+      }
+      return structuredClone(messages);
+    },
+    listPendingInteractions: () => input.pendingInteractions ?? [],
+    subscribePendingInteractions: (listener: (pending: InteractionPendingSnapshot) => void) => {
+      pendingInteractionListeners.add(listener);
+      if (!input.pendingAfterTurnStarts) {
+        for (const pending of input.pendingInteractions ?? []) {
+          queueMicrotask(() => listener(structuredClone(pending)));
+        }
+      }
+      return () => pendingInteractionListeners.delete(listener);
+    },
+    switchSession: async (sessionId: string) => {
+      switches.push(sessionId);
+      return {
+        summary: { ...sessionSummary(sessionId), cwd: input.switchSummaryCwd ?? '/workspace' },
+        messages: [],
+      };
+    },
+    preparePrompt: async (_prompt: string, options: { turnId?: string } = {}) => {
+      input.onPrepareStarted?.();
+      await input.prepareGate;
+      const events = input.turnEvents ?? eventsFor(options.turnId ?? 'turn-1', 'Host answer');
+      return {
+        sessionId: switches.at(-1) ?? 'session-created',
+        turnId: options.turnId ?? 'turn-1',
+        runId: 'run-1',
+        events: input.pendingAfterTurnStarts
+          ? eventsAfterPendingNotification(
+              events,
+              pendingInteractionListeners,
+              input.pendingInteractions ?? [],
+            )
+          : events,
+      };
+    },
+    respondToSandboxBoundary: async (response: { requestId: string; decision: 'deny' }) => {
+      sandboxResponses.push(response);
+    },
+    setPermissionMode: async () => {},
+    stop: async () => {
+      turnStops += 1;
+    },
+    subscribeStartedTurns: () => () => {},
+    subscribeTranscriptReplacements: (
+      listener: (sessionId: string, turnId: string, messages: StoredMessage[]) => void,
+    ) => {
+      transcriptListeners.add(listener);
+      return () => transcriptListeners.delete(listener);
+    },
+  } as unknown as RuntimeHostMakaSessionDriver;
+  const connection = {
+    hostEpoch: 'host-1',
+    request: async (operation: string, requestInput: Record<string, unknown>) => {
+      if (operation === 'session.execution_boundary.query') {
+        return { kind: 'managed', access: 'writable', revision: 0 };
+      }
+      if (operation === 'agent.graph.query') {
+        input.onGraphQueryStarted?.();
+        await input.graphQueryGate;
+        return { status: input.graphQueryStatus ?? 'completed' };
+      }
+      if (operation === 'agent.graph.stop') {
+        graphStops.push(String(requestInput.rootSessionId));
+        input.onGraphStop?.();
+        return { rootSessionId: requestInput.rootSessionId, graphId: 'graph-1' };
+      }
+      if (operation === 'turn.stop') {
+        exactTurnStops.push({
+          sessionId: String(requestInput.sessionId),
+          turnId: String(requestInput.turnId),
+          runId: String(requestInput.runId),
+        });
+        return { kind: 'stopped' };
+      }
+      throw new Error(`Unexpected operation: ${operation}`);
+    },
+  } as unknown as RuntimeHostConnection;
+  let create = () =>
+    createRuntimeHostRunContext(
+      connection,
+      connectionCatalog(),
+      {
+        surface: 'run',
+        workspaceRoot: '/data',
+        cwd: '/workspace',
+        ...(input.graph ? { enableAgentGraph: true } : {}),
+        ...(input.maxSteps ? { maxSteps: input.maxSteps } : {}),
+        ...(input.sessionCwdOverride ? { sessionCwdOverride: input.sessionCwdOverride } : {}),
+        ...(input.observed
+          ? {
+              runOutcomeObserver: (result: MakaRunOutcome) => {
+                input.observed?.push(result);
+              },
+            }
+          : {}),
+      },
+      { createDriver: () => driver },
+    );
+  return {
+    get context() {
+      const context = create();
+      create = () => context;
+      return context;
+    },
+    switches,
+    graphStops,
+    exactTurnStops,
+    sandboxResponses,
+    publishPendingInteraction(pending: InteractionPendingSnapshot) {
+      for (const listener of pendingInteractionListeners) listener(structuredClone(pending));
+    },
+    get turnStops() {
+      return turnStops;
+    },
+  };
+}
+
+function connectionCatalog() {
+  return {
+    revision: 1,
+    defaultTarget: { connectionId: 'connection-1', modelId: 'gpt-5' },
+    connections: [
+      {
+        connectionId: 'connection-1',
+        revision: 1,
+        slug: 'openai-main',
+        name: 'OpenAI',
+        providerType: 'openai' as const,
+        enabled: true,
+        enabledModelIds: ['gpt-5'],
+        models: [],
+      },
+    ],
+  };
+}
+
+async function* questionEvents(turnId: string): AsyncIterable<SessionEvent> {
+  yield {
+    type: 'user_question_request',
+    id: `${turnId}-question`,
+    turnId,
+    ts: 1,
+    requestId: 'question-1',
+    toolUseId: 'tool-1',
+    questions: [
+      {
+        question: 'Choose one',
+        options: [{ label: 'One' }, { label: 'Two' }],
+      },
+    ],
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function pendingQuestion(turnId: string): InteractionPendingSnapshot {
+  return {
+    schemaVersion: 1,
+    interactionId: 'interaction-1',
+    sessionId: 'session-created',
+    turnId,
+    runId: turnId === 'turn-1' ? 'run-1' : 'run-2',
+    revision: 1,
+    status: 'pending',
+    outcome: null,
+    request: {
+      kind: 'question',
+      toolUseId: 'tool-question',
+      questions: [{ question: 'Continue?', options: [{ label: 'Yes' }] }],
+    },
+  };
+}
+
+function pendingPermission(turnId: string): InteractionPendingSnapshot {
+  return {
+    schemaVersion: 1,
+    interactionId: 'permission-1',
+    sessionId: 'session-created',
+    turnId,
+    runId: 'run-1',
+    revision: 1,
+    status: 'pending',
+    outcome: null,
+    request: {
+      kind: 'permission',
+      toolUseId: 'tool-permission',
+      prompt: {
+        kind: 'tool_permission',
+        toolName: 'Bash',
+        category: 'shell_unsafe',
+        reason: 'shell_dangerous',
+        review: { kind: 'command', command: 'echo protected', cwd: '/workspace' },
+        rememberForTurnAllowed: true,
+      },
+    },
+  };
+}
+
+function graphMessages(includeTerminal = true): StoredMessage[] {
+  const messages: StoredMessage[] = [
+    {
+      type: 'user',
+      id: 'user-turn-2',
+      turnId: 'turn-2',
+      ts: 3,
+      text: 'Graph wake',
+      origin: {
+        kind: 'agent_graph',
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-1',
+      },
+    },
+    {
+      type: 'assistant',
+      id: 'assistant-turn-2',
+      turnId: 'turn-2',
+      ts: 4,
+      text: 'Final graph answer',
+      modelId: 'gpt-5',
+    },
+  ];
+  if (includeTerminal) {
+    messages.push({
+      type: 'turn_state',
+      id: 'state-turn-2',
+      turnId: 'turn-2',
+      ts: 5,
+      status: 'completed',
+      partialOutputRetained: false,
+    });
+  }
+  return messages;
+}
+
+function multiWakeGraphMessages(includeFinalTerminal: boolean): StoredMessage[] {
+  const messages = [
+    ...graphMessages(),
+    {
+      type: 'user' as const,
+      id: 'user-turn-3',
+      turnId: 'turn-3',
+      ts: 6,
+      text: 'Final Graph wake',
+      origin: {
+        kind: 'agent_graph' as const,
+        graphId: 'graph-1',
+        wakeId: 'wake-2',
+        attemptId: 'attempt-2',
+      },
+    },
+    {
+      type: 'assistant' as const,
+      id: 'assistant-turn-3',
+      turnId: 'turn-3',
+      ts: 7,
+      text: 'Final wake answer',
+      modelId: 'gpt-5',
+    },
+  ];
+  if (includeFinalTerminal) {
+    messages.push({
+      type: 'turn_state',
+      id: 'state-turn-3',
+      turnId: 'turn-3',
+      ts: 8,
+      status: 'completed',
+      partialOutputRetained: false,
+    });
+  }
+  return messages;
+}
+
+async function* eventsFor(turnId: string, text: string): AsyncIterable<SessionEvent> {
+  yield {
+    type: 'text_complete',
+    id: `${turnId}-text`,
+    turnId,
+    messageId: `${turnId}-message`,
+    ts: 1,
+    text,
+  };
+  yield { type: 'complete', id: `${turnId}-complete`, turnId, ts: 2, stopReason: 'end_turn' };
+}
+
+async function* eventsAfterPendingNotification(
+  events: AsyncIterable<SessionEvent>,
+  listeners: ReadonlySet<(pending: InteractionPendingSnapshot) => void>,
+  pending: readonly InteractionPendingSnapshot[],
+): AsyncIterable<SessionEvent> {
+  let notified = false;
+  for await (const event of events) {
+    if (!notified) {
+      notified = true;
+      for (const interaction of pending) {
+        for (const listener of listeners) listener(structuredClone(interaction));
+      }
+    }
+    yield event;
+  }
+}
+
+async function collect(events: AsyncIterable<SessionEvent>): Promise<SessionEvent[]> {
+  const collected: SessionEvent[] = [];
+  for await (const event of events) collected.push(event);
+  return collected;
+}
+
+function sessionProjection(id: string): SessionCatalogProjection {
+  return {
+    id,
+    revision: 1,
+    cwd: '/workspace',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Run once',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    labelsTruncated: false,
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'openai-main',
+    connectionLocked: true,
+    model: 'gpt-5',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+  };
+}
+
+function sessionSummary(id: string): SessionSummary {
+  return {
+    id,
+    cwd: '/workspace',
+    name: 'Run once',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'openai-main',
+    connectionLocked: true,
+    model: 'gpt-5',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+  };
+}

--- a/packages/cli/src/__tests__/runtime-host-run-dependency.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-dependency.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { dirname, join, relative, resolve } from 'node:path';
+import { after, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript/unstable/ast';
+import { API } from 'typescript/unstable/sync';
+
+const sourceRoot = fileURLToPath(new URL('../../src/', import.meta.url));
+const packageRoot = resolve(sourceRoot, '..');
+const projectConfig = join(packageRoot, 'tsconfig.json');
+const compilerApi = new API({ cwd: packageRoot });
+const compilerSnapshot = compilerApi.updateSnapshot({ openProjects: [projectConfig] });
+const compilerProject = loadCompilerProject();
+
+after(() => {
+  compilerSnapshot.dispose();
+  compilerApi.close();
+});
+
+function loadCompilerProject() {
+  const project = compilerSnapshot.getProject(projectConfig);
+  if (!project) throw new Error('TypeScript did not load the CLI project');
+  return project;
+}
+
+test('the Runtime Host run entry cannot reach the embedded Runtime or writer Stores', () => {
+  const reached = reachableModules(join(sourceRoot, 'runtime-host-run-command.ts'));
+  const forbiddenModules = new Set([
+    'embedded-tui-command.ts',
+    'run-command.ts',
+    'runtime-bootstrap.ts',
+  ]);
+  const violations: string[] = [];
+  for (const path of reached) {
+    const localPath = relative(sourceRoot, path);
+    if (forbiddenModules.has(localPath)) violations.push(localPath);
+    for (const specifier of runtimeModuleSpecifiers(path)) {
+      if (specifier === '@maka/storage' || specifier.startsWith('@maka/storage/')) {
+        violations.push(`${localPath}: ${specifier}`);
+      }
+    }
+  }
+  assert.deepEqual(violations, []);
+});
+
+function reachableModules(entrypoint: string): Set<string> {
+  const reached = new Set<string>();
+  const pending = [entrypoint];
+  while (pending.length > 0) {
+    const path = pending.pop();
+    if (!path || reached.has(path)) continue;
+    reached.add(path);
+    for (const specifier of runtimeModuleSpecifiers(path)) {
+      if (!specifier.startsWith('.')) continue;
+      const target = resolve(dirname(path), specifier).replace(/\.js$/, '.ts');
+      if (target.startsWith(`${sourceRoot}/`)) pending.push(target);
+    }
+  }
+  return reached;
+}
+
+function runtimeModuleSpecifiers(path: string): string[] {
+  const source = compilerProject.program.getSourceFile(path);
+  if (!source) throw new Error(`TypeScript did not load ${path}`);
+  const specifiers: string[] = [];
+  source.forEachChild((node: ts.Node) => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      specifiers.push(node.moduleSpecifier.text);
+    }
+    if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    }
+  });
+  return specifiers;
+}

--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeHostSessionSubscription,
 } from '@maka/runtime-host/client';
 import type {
+  InteractionPendingSnapshot,
   OperationInput,
   OperationOutput,
   SessionCatalogProjection,
@@ -591,6 +592,27 @@ describe('Runtime Host Maka Session driver', () => {
     });
   });
 
+  test('publishes a pending permission that has no transcript event', async () => {
+    const permission = pendingPermission();
+    const subscription = new FakeSubscription(
+      continuitySnapshot({ interactions: { pending: [permission] } }),
+      Promise.resolve([]),
+    );
+    const connection = new FakeConnection([subscription]);
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: '/tmp',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+    });
+    const published = deferred<InteractionPendingSnapshot>();
+    driver.subscribePendingInteractions((pending) => published.resolve(pending));
+
+    await driver.switchSession('session-1');
+
+    assert.deepEqual(await published.promise, permission);
+  });
+
   test('reads a fresh Host transcript when listing rewind targets', async () => {
     const attached = new FakeSubscription(continuitySnapshot(), Promise.resolve([]));
     const current = new FakeSubscription(
@@ -959,6 +981,31 @@ function pendingQuestion() {
       kind: 'question' as const,
       toolUseId: 'tool-question',
       questions: [{ question: 'Continue?', options: [{ label: 'Yes' }] }],
+    },
+  };
+}
+
+function pendingPermission() {
+  return {
+    schemaVersion: 1 as const,
+    interactionId: 'permission-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    runId: 'run-1',
+    revision: 1 as const,
+    status: 'pending' as const,
+    outcome: null,
+    request: {
+      kind: 'permission' as const,
+      toolUseId: 'tool-permission',
+      prompt: {
+        kind: 'tool_permission' as const,
+        toolName: 'Bash',
+        category: 'shell_unsafe' as const,
+        reason: 'shell_dangerous' as const,
+        review: { kind: 'command' as const, command: 'echo protected', cwd: '/tmp' },
+        rememberForTurnAllowed: true,
+      },
     },
   };
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -107,6 +107,11 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
   const command = parseMakaCliArgs(argv, version);
   switch (command.kind) {
     case 'run': {
+      const runtimeOwner = resolveCliRuntimeOwner(process.env.MAKA_CLI_RUNTIME_OWNER);
+      if (runtimeOwner === 'runtime-host') {
+        const { runRuntimeHostTextCli } = await import('./runtime-host-run-command.js');
+        return runRuntimeHostTextCli(command.args);
+      }
       const { runMakaTextCli } = await import('./run-command.js');
       return runMakaTextCli(command.args);
     }

--- a/packages/cli/src/run-command-core.ts
+++ b/packages/cli/src/run-command-core.ts
@@ -1,0 +1,505 @@
+import { randomUUID } from 'node:crypto';
+import { realpath, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { SessionEvent } from '@maka/core/events';
+import { isThinkingLevel, type ThinkingLevel } from '@maka/core/model-thinking';
+import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
+import type { ExecutionBoundaryReadModel } from '@maka/core/sandbox-boundary';
+import type { SessionSummary } from '@maka/core/session';
+import { selectMakaRunSession } from './run-session-selection.js';
+import { sessionEventSandboxBoundaryFailureReason } from './sandbox-boundary-failure.js';
+import { resolveMakaWorkspaceRoot } from './workspace-root.js';
+
+export interface MakaRunOptions {
+  prompt?: string;
+  stdinPrompt: boolean;
+  cwd?: string;
+  connection?: string;
+  model?: string;
+  thinking?: ThinkingLevel;
+  timeoutMs?: number;
+  maxSteps?: number;
+  yolo?: boolean;
+  resumeId?: string;
+  continueLatest?: boolean;
+  graph?: true;
+  thinkingDefaultExplicit?: boolean;
+}
+
+export type ParseMakaRunArgsResult =
+  | { kind: 'run'; options: MakaRunOptions }
+  | { kind: 'help' }
+  | { kind: 'error'; message: string };
+
+export interface MakaRunRuntime {
+  createSession(input: CreateSessionInput): Promise<SessionSummary>;
+  readExecutionBoundary(sessionId: string): Promise<ExecutionBoundaryReadModel>;
+  sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
+  respondToSandboxBoundary(
+    sessionId: string,
+    response: { requestId: string; decision: 'deny' },
+  ): Promise<void>;
+  stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
+  setExecutionBoundaryKind(sessionId: string, kind: 'managed' | 'bypass'): Promise<unknown>;
+}
+
+export interface MakaRunContext {
+  runtime: MakaRunRuntime;
+  target: { connection: { slug: string }; model: string };
+  agentGraph?: {
+    reserveActivity(sessionId: string): { release(): void };
+    waitForCompletion(sessionId: string): Promise<void>;
+  };
+  close(): Promise<void>;
+}
+
+export interface MakaRunOutcome {
+  outcomeId: string;
+  status: 'completed' | 'failed';
+  finalOutput?: string;
+  failure?: { class: string; message?: string };
+  sandboxBoundary: 'none' | 'unresolved' | 'recovered';
+}
+
+export interface MakaRunContextInput {
+  surface: 'run';
+  workspaceRoot: string;
+  cwd: string;
+  requestedConnectionSlug?: string;
+  requestedModel?: string;
+  maxSteps?: number;
+  enableAgentGraph?: boolean;
+  sessionCwdOverride?: { sessionId: string; cwd: string };
+  runOutcomeObserver?: (outcome: MakaRunOutcome) => void | Promise<void>;
+}
+
+export interface MakaRunDeps {
+  createContext(input: MakaRunContextInput): Promise<MakaRunContext>;
+  listSessions(workspaceRoot: string): Promise<SessionSummary[]>;
+  workspaceRoot(): string;
+  processCwd(): string;
+  stdinIsTTY(): boolean;
+  readStdin(): Promise<string>;
+  writeStdout(text: string): void;
+  writeStderr(text: string): void;
+  onSigint(handler: () => void): () => void;
+  setTimer(handler: () => void, ms: number): unknown;
+  clearTimer(timer: unknown): void;
+  newId(): string;
+}
+
+export type MakaRunAdapter = Pick<MakaRunDeps, 'createContext' | 'listSessions'>;
+export type MakaRunEnvironmentDeps = Omit<MakaRunDeps, keyof MakaRunAdapter>;
+
+const VALUE_FLAGS = new Set([
+  'cwd',
+  'connection',
+  'model',
+  'thinking',
+  'timeout',
+  'max-steps',
+  'resume',
+]);
+
+const REPEATABLE_VALUE_FLAGS = new Set<string>();
+const BOOLEAN_FLAGS = new Set(['continue', 'yolo', 'graph']);
+
+export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResult {
+  const positional: string[] = [];
+  const flags = new Map<string, string>();
+  const booleanFlags = new Set<string>();
+  let literal = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (!literal && (arg === '--help' || arg === '-h')) return { kind: 'help' };
+    if (!literal && arg === '--') {
+      literal = true;
+      continue;
+    }
+    if (!literal && arg.startsWith('--')) {
+      const name = arg.slice(2);
+      if (BOOLEAN_FLAGS.has(name)) {
+        if (booleanFlags.has(name)) return { kind: 'error', message: `option repeated: ${arg}` };
+        booleanFlags.add(name);
+        continue;
+      }
+      if (!VALUE_FLAGS.has(name)) return { kind: 'error', message: `unknown option: ${arg}` };
+      if (!REPEATABLE_VALUE_FLAGS.has(name) && flags.has(name)) {
+        return { kind: 'error', message: `option repeated: ${arg}` };
+      }
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        return { kind: 'error', message: `option ${arg} needs a value` };
+      }
+      flags.set(name, value);
+      index += 1;
+      continue;
+    }
+    if (!literal && arg.startsWith('-') && arg !== '-') {
+      return { kind: 'error', message: `unknown option: ${arg}` };
+    }
+    positional.push(arg);
+  }
+
+  if (positional.length > 1) {
+    return { kind: 'error', message: 'maka run accepts at most one positional prompt' };
+  }
+  const prompt = positional[0];
+  const timeout = flags.get('timeout');
+  const maxSteps = flags.get('max-steps');
+  const thinking = flags.get('thinking');
+  const resumeId = flags.get('resume');
+  const continueLatest = booleanFlags.has('continue');
+  const graph = booleanFlags.has('graph');
+  if (resumeId !== undefined && continueLatest) {
+    return { kind: 'error', message: '--resume and --continue cannot be used together' };
+  }
+  const timeoutSeconds = timeout === undefined ? undefined : Number(timeout);
+  if (timeoutSeconds !== undefined && (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0)) {
+    return { kind: 'error', message: '--timeout must be a positive number of seconds' };
+  }
+  const parsedMaxSteps = maxSteps === undefined ? undefined : Number(maxSteps);
+  if (parsedMaxSteps !== undefined && (!Number.isInteger(parsedMaxSteps) || parsedMaxSteps < 1)) {
+    return { kind: 'error', message: '--max-steps must be a positive integer' };
+  }
+  if (thinking !== undefined && thinking !== 'default' && !isThinkingLevel(thinking)) {
+    return { kind: 'error', message: `unknown thinking level: ${thinking}` };
+  }
+  return {
+    kind: 'run',
+    options: {
+      ...(prompt !== undefined && prompt !== '-' ? { prompt } : {}),
+      stdinPrompt: prompt === '-',
+      ...(flags.get('cwd') !== undefined ? { cwd: flags.get('cwd') } : {}),
+      ...(flags.get('connection') !== undefined ? { connection: flags.get('connection') } : {}),
+      ...(flags.get('model') !== undefined ? { model: flags.get('model') } : {}),
+      ...(thinking !== undefined && thinking !== 'default' ? { thinking } : {}),
+      ...(timeoutSeconds !== undefined ? { timeoutMs: Math.ceil(timeoutSeconds * 1_000) } : {}),
+      ...(parsedMaxSteps !== undefined ? { maxSteps: parsedMaxSteps } : {}),
+      ...(booleanFlags.has('yolo') ? { yolo: true } : {}),
+      ...(resumeId !== undefined ? { resumeId } : {}),
+      ...(continueLatest ? { continueLatest: true } : {}),
+      ...(graph ? { graph: true as const } : {}),
+      ...(thinking === 'default' ? { thinkingDefaultExplicit: true } : {}),
+    },
+  };
+}
+
+export async function runMakaTextCliCore(
+  argv: readonly string[],
+  adapter: MakaRunAdapter,
+  overrides: Partial<MakaRunEnvironmentDeps> = {},
+): Promise<number> {
+  const deps: MakaRunDeps = { ...defaultMakaRunEnvironmentDeps(), ...adapter, ...overrides };
+  const parsed = parseMakaRunArgs(argv);
+  if (parsed.kind === 'help') {
+    deps.writeStdout(`${makaRunHelpText()}\n`);
+    return 0;
+  }
+  if (parsed.kind === 'error') {
+    deps.writeStderr(`maka run: ${parsed.message}\n\n${makaRunHelpText()}\n`);
+    return 2;
+  }
+
+  let prompt: string;
+  let selection: Awaited<ReturnType<typeof selectMakaRunSession>>;
+  const workspaceRoot = deps.workspaceRoot();
+  try {
+    prompt = await resolveRunPrompt(parsed.options, deps);
+    const sessions =
+      parsed.options.resumeId !== undefined || parsed.options.continueLatest === true
+        ? await deps.listSessions(workspaceRoot)
+        : [];
+    selection = await selectMakaRunSession(
+      {
+        sessions,
+        ...(parsed.options.resumeId !== undefined ? { resumeId: parsed.options.resumeId } : {}),
+        continueLatest: parsed.options.continueLatest === true,
+        ...(parsed.options.cwd !== undefined ? { explicitCwd: parsed.options.cwd } : {}),
+        processCwd: deps.processCwd(),
+        ...(parsed.options.connection !== undefined
+          ? { explicitConnection: parsed.options.connection }
+          : {}),
+        ...(parsed.options.model !== undefined ? { explicitModel: parsed.options.model } : {}),
+        thinkingSpecified:
+          parsed.options.thinking !== undefined || parsed.options.thinkingDefaultExplicit === true,
+        ...(parsed.options.thinking !== undefined
+          ? { explicitThinking: parsed.options.thinking }
+          : {}),
+      },
+      { canonicalizeDirectory: canonicalDirectory },
+    );
+  } catch (error) {
+    deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
+    return 2;
+  }
+
+  let outcome: MakaRunOutcome | undefined;
+  let streamBoundaryFailure = false;
+  const boundaryFailureInvocationIds = new Set<string>();
+  let context: MakaRunContext;
+  try {
+    context = await deps.createContext({
+      surface: 'run',
+      workspaceRoot,
+      cwd: selection.cwd,
+      ...(selection.kind === 'existing' || parsed.options.connection
+        ? {
+            requestedConnectionSlug:
+              selection.kind === 'existing'
+                ? selection.session.llmConnectionSlug
+                : parsed.options.connection,
+          }
+        : {}),
+      ...(selection.kind === 'existing' || parsed.options.model
+        ? {
+            requestedModel:
+              selection.kind === 'existing' ? selection.session.model : parsed.options.model,
+          }
+        : {}),
+      ...(selection.kind === 'existing'
+        ? { sessionCwdOverride: { sessionId: selection.session.id, cwd: selection.cwd } }
+        : {}),
+      ...(parsed.options.maxSteps !== undefined ? { maxSteps: parsed.options.maxSteps } : {}),
+      ...(parsed.options.graph ? { enableAgentGraph: true } : {}),
+      runOutcomeObserver: (result) => {
+        if (result.sandboxBoundary === 'recovered') {
+          boundaryFailureInvocationIds.delete(result.outcomeId);
+        } else if (result.sandboxBoundary === 'unresolved') {
+          boundaryFailureInvocationIds.add(result.outcomeId);
+        }
+        outcome = result;
+      },
+    });
+  } catch (error) {
+    deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
+    return 2;
+  }
+
+  let session: SessionSummary;
+  try {
+    session =
+      selection.kind === 'existing'
+        ? selection.session
+        : await context.runtime.createSession({
+            cwd: selection.cwd,
+            name: firstLine(prompt).slice(0, 42) || 'Maka run',
+            backend: 'ai-sdk',
+            llmConnectionSlug: context.target.connection.slug,
+            model: context.target.model,
+            permissionMode: parsed.options.yolo ? 'bypass' : 'ask',
+            ...(parsed.options.thinking !== undefined
+              ? { thinkingLevel: parsed.options.thinking }
+              : {}),
+          });
+    if (selection.kind === 'existing') {
+      const boundary = await context.runtime.readExecutionBoundary(session.id);
+      if (parsed.options.yolo) {
+        await context.runtime.setExecutionBoundaryKind(session.id, 'bypass');
+      } else if (boundary.kind === 'bypass') {
+        throw new Error(`resuming a full-access session ${session.id} requires --yolo`);
+      } else if (boundary.kind === 'external') {
+        throw new Error(`cannot resume externally isolated session ${session.id} from maka run`);
+      }
+    }
+  } catch (error) {
+    await context.close();
+    deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
+    return 2;
+  }
+
+  let interrupted = false;
+  let timedOut = false;
+  let streamFailed = false;
+  let stopPromise: Promise<void> | undefined;
+  let resolveStopSignal: (() => void) | undefined;
+  const stopSignal = new Promise<void>((resolve) => {
+    resolveStopSignal = resolve;
+  });
+  const stop = (): void => {
+    resolveStopSignal?.();
+    resolveStopSignal = undefined;
+    if (stopPromise) return;
+    stopPromise = context.runtime.stopSession(session.id, { source: 'stop_button' });
+    void stopPromise.catch(() => {});
+  };
+  const removeSigint = deps.onSigint(() => {
+    interrupted = true;
+    stop();
+  });
+  const timer =
+    parsed.options.timeoutMs === undefined
+      ? undefined
+      : deps.setTimer(() => {
+          timedOut = true;
+          stop();
+        }, parsed.options.timeoutMs);
+  const graphActivity = parsed.options.graph
+    ? context.agentGraph?.reserveActivity(session.id)
+    : undefined;
+
+  try {
+    if (parsed.options.graph && !context.agentGraph) {
+      throw new Error('Graph Mode is unavailable in this CLI runtime');
+    }
+    for await (const event of context.runtime.sendMessage(session.id, {
+      turnId: deps.newId(),
+      text: prompt,
+      ...(parsed.options.graph
+        ? { turnOrchestration: { mode: 'graph' as const, source: 'host_api' as const } }
+        : {}),
+    })) {
+      if (event.type === 'sandbox_boundary_request') {
+        streamBoundaryFailure = true;
+        deps.writeStderr(
+          'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
+        );
+        await context.runtime.respondToSandboxBoundary(session.id, {
+          requestId: event.requestId,
+          decision: 'deny',
+        });
+      }
+      const sandboxFailureReason = sessionEventSandboxBoundaryFailureReason(event);
+      if (sandboxFailureReason) {
+        streamBoundaryFailure = true;
+        deps.writeStderr(
+          sandboxFailureReason === 'requires_bypass'
+            ? 'maka run: sandbox bypass requires an explicit --yolo\n'
+            : 'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
+        );
+      }
+    }
+    graphActivity?.release();
+    if (parsed.options.graph && outcome?.status === 'completed') {
+      await Promise.race([context.agentGraph!.waitForCompletion(session.id), stopSignal]);
+    }
+    await stopPromise;
+  } catch (error) {
+    streamFailed = true;
+    graphActivity?.release();
+    await stopPromise?.catch(() => undefined);
+    if (!interrupted && !timedOut) {
+      deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
+    }
+  } finally {
+    removeSigint();
+    if (timer !== undefined) deps.clearTimer(timer);
+    await context.close();
+  }
+
+  if (interrupted) return 130;
+  if (timedOut) {
+    deps.writeStderr(`maka run: timed out after ${parsed.options.timeoutMs}ms\n`);
+    return 1;
+  }
+  if (streamFailed) return 1;
+  if (
+    (streamBoundaryFailure && outcome?.sandboxBoundary !== 'recovered') ||
+    boundaryFailureInvocationIds.size > 0
+  ) {
+    return 1;
+  }
+  if (!outcome) {
+    deps.writeStderr('maka run: runtime produced no outcome\n');
+    return 1;
+  }
+  if (outcome.status !== 'completed' || outcome.finalOutput === undefined) {
+    const detail = outcome.failure?.message ?? outcome.failure?.class ?? 'runtime failure';
+    deps.writeStderr(`maka run: ${detail}\n`);
+    return 1;
+  }
+  deps.writeStdout(withTrailingNewline(outcome.finalOutput));
+  return 0;
+}
+
+async function resolveRunPrompt(options: MakaRunOptions, deps: MakaRunDeps): Promise<string> {
+  const shouldReadStdin = options.stdinPrompt || !deps.stdinIsTTY();
+  const stdin = shouldReadStdin ? await deps.readStdin() : '';
+  if (options.stdinPrompt || options.prompt === undefined) {
+    if (stdin.trim().length === 0) throw new Error('missing prompt input');
+    return stdin;
+  }
+  if (options.prompt.trim().length === 0) throw new Error('missing prompt input');
+  return stdin.trim().length > 0 ? `${options.prompt}\n\n${stdin}` : options.prompt;
+}
+
+async function canonicalDirectory(input: string): Promise<string> {
+  const canonical = await realpath(resolve(input));
+  if (!(await stat(canonical)).isDirectory()) throw new Error(`cwd is not a directory: ${input}`);
+  return canonical;
+}
+
+function makaRunHelpText(): string {
+  return [
+    'Usage: maka run [PROMPT] [options]',
+    '       maka -p [PROMPT] [options]',
+    '',
+    'Input:',
+    '  -                         Read the complete prompt from stdin',
+    '  PROMPT with piped stdin   Use PROMPT as instruction and stdin as context',
+    '',
+    'Options:',
+    '  --cwd <path>              Working directory (default: current directory)',
+    '  --connection <slug>       Model connection to use',
+    '  --model <id>              Model to use',
+    '  --thinking <level>        off|minimal|low|medium|high|xhigh|max|default',
+    '  --timeout <seconds>       Invocation timeout',
+    '  --max-steps <count>       Tool-step cap',
+    '  --yolo                    Give this session full access to your files and network',
+    '  --resume <session-id>     Continue an explicit compatible session',
+    '  --continue                Continue the latest compatible session for cwd',
+    '  --graph                   Run this turn in Graph Mode and wait for graph completion',
+    '  -h, --help                Show help',
+  ].join('\n');
+}
+
+function defaultMakaRunEnvironmentDeps(): MakaRunEnvironmentDeps {
+  return {
+    workspaceRoot: () => resolveMakaWorkspaceRoot(),
+    processCwd: () => process.cwd(),
+    stdinIsTTY: () => process.stdin.isTTY === true,
+    readStdin: readProcessStdin,
+    writeStdout: (text) => {
+      process.stdout.write(text);
+    },
+    writeStderr: (text) => {
+      process.stderr.write(text);
+    },
+    onSigint: (handler) => {
+      process.on('SIGINT', handler);
+      return () => process.off('SIGINT', handler);
+    },
+    setTimer: (handler, ms) => {
+      const timer = setTimeout(handler, ms);
+      timer.unref();
+      return timer;
+    },
+    clearTimer: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+    newId: randomUUID,
+  };
+}
+
+async function readProcessStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function firstLine(text: string): string {
+  return (
+    text
+      .split('\n')
+      .map((line) => line.trim())
+      .find(Boolean) ?? ''
+  );
+}
+
+function withTrailingNewline(text: string): string {
+  return text.endsWith('\n') ? text : `${text}\n`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -1,496 +1,59 @@
-import { randomUUID } from 'node:crypto';
-import { realpath, stat } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import type { SessionEvent } from '@maka/core/events';
-import { isThinkingLevel, type ThinkingLevel } from '@maka/core/model-thinking';
-import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
-import type { ExecutionBoundary } from '@maka/core/sandbox-boundary';
-import type { SessionSummary } from '@maka/core/session';
 import type { InvocationResult } from '@maka/runtime';
 import { createSessionStore } from '@maka/storage';
-import {
-  createMakaCliRuntimeContext,
-  type CreateMakaCliRuntimeContextInput,
-} from './runtime-bootstrap.js';
-import type { ReadySessionTarget } from './connection-target.js';
-import { selectMakaRunSession } from './run-session-selection.js';
+import { createMakaCliRuntimeContext } from './runtime-bootstrap.js';
 import {
   invocationHasSandboxBoundaryFailure,
   invocationRecoveredSandboxBoundaryFailure,
-  sessionEventSandboxBoundaryFailureReason,
 } from './sandbox-boundary-failure.js';
-import { resolveMakaWorkspaceRoot } from './workspace-root.js';
+import {
+  runMakaTextCliCore,
+  type MakaRunContextInput,
+  type MakaRunDeps,
+  type MakaRunOutcome,
+} from './run-command-core.js';
 
-export interface MakaRunOptions {
-  prompt?: string;
-  stdinPrompt: boolean;
-  cwd?: string;
-  connection?: string;
-  model?: string;
-  thinking?: ThinkingLevel;
-  timeoutMs?: number;
-  maxSteps?: number;
-  yolo?: boolean;
-  resumeId?: string;
-  continueLatest?: boolean;
-  graph?: true;
-  thinkingDefaultExplicit?: boolean;
-}
+export {
+  parseMakaRunArgs,
+  type MakaRunContext,
+  type MakaRunContextInput,
+  type MakaRunDeps,
+  type MakaRunOptions,
+  type MakaRunRuntime,
+  type ParseMakaRunArgsResult,
+} from './run-command-core.js';
 
-export type ParseMakaRunArgsResult =
-  | { kind: 'run'; options: MakaRunOptions }
-  | { kind: 'help' }
-  | { kind: 'error'; message: string };
-
-export interface MakaRunRuntime {
-  createSession(input: CreateSessionInput): Promise<SessionSummary>;
-  readExecutionBoundary(sessionId: string): Promise<ExecutionBoundary>;
-  sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
-  respondToSandboxBoundary(
-    sessionId: string,
-    response: { requestId: string; decision: 'deny' },
-  ): Promise<void>;
-  stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
-  setExecutionBoundaryKind(sessionId: string, kind: 'managed' | 'bypass'): Promise<unknown>;
-}
-
-export interface MakaRunContext {
-  runtime: MakaRunRuntime;
-  target: ReadySessionTarget;
-  agentGraph?: {
-    reserveActivity(sessionId: string): { release(): void };
-    waitForCompletion(sessionId: string): Promise<void>;
-  };
-  close(): Promise<void>;
-}
-
-export interface MakaRunDeps {
-  createContext(input: CreateMakaCliRuntimeContextInput): Promise<MakaRunContext>;
-  listSessions(workspaceRoot: string): Promise<SessionSummary[]>;
-  workspaceRoot(): string;
-  processCwd(): string;
-  stdinIsTTY(): boolean;
-  readStdin(): Promise<string>;
-  writeStdout(text: string): void;
-  writeStderr(text: string): void;
-  onSigint(handler: () => void): () => void;
-  setTimer(handler: () => void, ms: number): unknown;
-  clearTimer(timer: unknown): void;
-  newId(): string;
-}
-
-const VALUE_FLAGS = new Set([
-  'cwd',
-  'connection',
-  'model',
-  'thinking',
-  'timeout',
-  'max-steps',
-  'resume',
-]);
-
-const REPEATABLE_VALUE_FLAGS = new Set<string>();
-const BOOLEAN_FLAGS = new Set(['continue', 'yolo', 'graph']);
-
-export function parseMakaRunArgs(argv: readonly string[]): ParseMakaRunArgsResult {
-  const positional: string[] = [];
-  const flags = new Map<string, string>();
-  const booleanFlags = new Set<string>();
-  let literal = false;
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index]!;
-    if (!literal && (arg === '--help' || arg === '-h')) return { kind: 'help' };
-    if (!literal && arg === '--') {
-      literal = true;
-      continue;
-    }
-    if (!literal && arg.startsWith('--')) {
-      const name = arg.slice(2);
-      if (BOOLEAN_FLAGS.has(name)) {
-        if (booleanFlags.has(name)) return { kind: 'error', message: `option repeated: ${arg}` };
-        booleanFlags.add(name);
-        continue;
-      }
-      if (!VALUE_FLAGS.has(name)) return { kind: 'error', message: `unknown option: ${arg}` };
-      if (!REPEATABLE_VALUE_FLAGS.has(name) && flags.has(name)) {
-        return { kind: 'error', message: `option repeated: ${arg}` };
-      }
-      const value = argv[index + 1];
-      if (value === undefined || value.startsWith('--')) {
-        return { kind: 'error', message: `option ${arg} needs a value` };
-      }
-      flags.set(name, value);
-      index += 1;
-      continue;
-    }
-    if (!literal && arg.startsWith('-') && arg !== '-') {
-      return { kind: 'error', message: `unknown option: ${arg}` };
-    }
-    positional.push(arg);
-  }
-
-  if (positional.length > 1) {
-    return { kind: 'error', message: 'maka run accepts at most one positional prompt' };
-  }
-  const prompt = positional[0];
-  const timeout = flags.get('timeout');
-  const maxSteps = flags.get('max-steps');
-  const thinking = flags.get('thinking');
-  const resumeId = flags.get('resume');
-  const continueLatest = booleanFlags.has('continue');
-  const graph = booleanFlags.has('graph');
-  if (resumeId !== undefined && continueLatest) {
-    return { kind: 'error', message: '--resume and --continue cannot be used together' };
-  }
-  const timeoutSeconds = timeout === undefined ? undefined : Number(timeout);
-  if (timeoutSeconds !== undefined && (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0)) {
-    return { kind: 'error', message: '--timeout must be a positive number of seconds' };
-  }
-  const parsedMaxSteps = maxSteps === undefined ? undefined : Number(maxSteps);
-  if (parsedMaxSteps !== undefined && (!Number.isInteger(parsedMaxSteps) || parsedMaxSteps < 1)) {
-    return { kind: 'error', message: '--max-steps must be a positive integer' };
-  }
-  if (thinking !== undefined && thinking !== 'default' && !isThinkingLevel(thinking)) {
-    return { kind: 'error', message: `unknown thinking level: ${thinking}` };
-  }
-  return {
-    kind: 'run',
-    options: {
-      ...(prompt !== undefined && prompt !== '-' ? { prompt } : {}),
-      stdinPrompt: prompt === '-',
-      ...(flags.get('cwd') !== undefined ? { cwd: flags.get('cwd') } : {}),
-      ...(flags.get('connection') !== undefined ? { connection: flags.get('connection') } : {}),
-      ...(flags.get('model') !== undefined ? { model: flags.get('model') } : {}),
-      ...(thinking !== undefined && thinking !== 'default' ? { thinking } : {}),
-      ...(timeoutSeconds !== undefined ? { timeoutMs: Math.ceil(timeoutSeconds * 1_000) } : {}),
-      ...(parsedMaxSteps !== undefined ? { maxSteps: parsedMaxSteps } : {}),
-      ...(booleanFlags.has('yolo') ? { yolo: true } : {}),
-      ...(resumeId !== undefined ? { resumeId } : {}),
-      ...(continueLatest ? { continueLatest: true } : {}),
-      ...(graph ? { graph: true as const } : {}),
-      ...(thinking === 'default' ? { thinkingDefaultExplicit: true } : {}),
-    },
-  };
-}
-
-export async function runMakaTextCli(
+export function runMakaTextCli(
   argv: readonly string[],
   overrides: Partial<MakaRunDeps> = {},
 ): Promise<number> {
-  const deps = { ...defaultMakaRunDeps(), ...overrides };
-  const parsed = parseMakaRunArgs(argv);
-  if (parsed.kind === 'help') {
-    deps.writeStdout(`${makaRunHelpText()}\n`);
-    return 0;
-  }
-  if (parsed.kind === 'error') {
-    deps.writeStderr(`maka run: ${parsed.message}\n\n${makaRunHelpText()}\n`);
-    return 2;
-  }
+  const {
+    createContext = createEmbeddedRunContext,
+    listSessions = (workspaceRoot: string) => createSessionStore(workspaceRoot).list(),
+    ...environmentOverrides
+  } = overrides;
+  return runMakaTextCliCore(argv, { createContext, listSessions }, environmentOverrides);
+}
 
-  let prompt: string;
-  let selection: Awaited<ReturnType<typeof selectMakaRunSession>>;
-  const workspaceRoot = deps.workspaceRoot();
-  try {
-    prompt = await resolveRunPrompt(parsed.options, deps);
-    const sessions =
-      parsed.options.resumeId !== undefined || parsed.options.continueLatest === true
-        ? await deps.listSessions(workspaceRoot)
-        : [];
-    selection = await selectMakaRunSession(
-      {
-        sessions,
-        ...(parsed.options.resumeId !== undefined ? { resumeId: parsed.options.resumeId } : {}),
-        continueLatest: parsed.options.continueLatest === true,
-        ...(parsed.options.cwd !== undefined ? { explicitCwd: parsed.options.cwd } : {}),
-        processCwd: deps.processCwd(),
-        ...(parsed.options.connection !== undefined
-          ? { explicitConnection: parsed.options.connection }
-          : {}),
-        ...(parsed.options.model !== undefined ? { explicitModel: parsed.options.model } : {}),
-        thinkingSpecified:
-          parsed.options.thinking !== undefined || parsed.options.thinkingDefaultExplicit === true,
-        ...(parsed.options.thinking !== undefined
-          ? { explicitThinking: parsed.options.thinking }
-          : {}),
-      },
-      { canonicalizeDirectory: canonicalDirectory },
-    );
-  } catch (error) {
-    deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
-    return 2;
-  }
-
-  let invocation: InvocationResult | undefined;
-  let streamBoundaryFailure = false;
-  const boundaryFailureInvocationIds = new Set<string>();
-  let context: MakaRunContext;
-  try {
-    context = await deps.createContext({
-      surface: 'run',
-      workspaceRoot,
-      cwd: selection.cwd,
-      ...(selection.kind === 'existing' || parsed.options.connection
-        ? {
-            requestedConnectionSlug:
-              selection.kind === 'existing'
-                ? selection.session.llmConnectionSlug
-                : parsed.options.connection,
-          }
-        : {}),
-      ...(selection.kind === 'existing' || parsed.options.model
-        ? {
-            requestedModel:
-              selection.kind === 'existing' ? selection.session.model : parsed.options.model,
-          }
-        : {}),
-      ...(selection.kind === 'existing'
-        ? { sessionCwdOverride: { sessionId: selection.session.id, cwd: selection.cwd } }
-        : {}),
-      ...(parsed.options.maxSteps !== undefined ? { maxSteps: parsed.options.maxSteps } : {}),
-      ...(parsed.options.graph ? { enableAgentGraph: true } : {}),
-      runtimeInvocationObserver: (result) => {
-        if (invocationHasSandboxBoundaryFailure(result)) {
-          if (invocationRecoveredSandboxBoundaryFailure(result)) {
-            boundaryFailureInvocationIds.delete(result.invocationId);
-          } else {
-            boundaryFailureInvocationIds.add(result.invocationId);
-          }
+async function createEmbeddedRunContext(input: MakaRunContextInput) {
+  const { runOutcomeObserver, ...runtimeInput } = input;
+  return createMakaCliRuntimeContext({
+    ...runtimeInput,
+    ...(runOutcomeObserver
+      ? {
+          runtimeInvocationObserver: (result) =>
+            runOutcomeObserver({
+              outcomeId: result.invocationId,
+              status: result.status === 'completed' ? 'completed' : 'failed',
+              ...(result.finalOutput !== undefined ? { finalOutput: result.finalOutput } : {}),
+              ...(result.failure ? { failure: result.failure } : {}),
+              sandboxBoundary: sandboxBoundaryOutcome(result),
+            }),
         }
-        invocation = result;
-      },
-    });
-  } catch (error) {
-    deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
-    return 2;
-  }
-
-  let session: SessionSummary;
-  try {
-    session =
-      selection.kind === 'existing'
-        ? selection.session
-        : await context.runtime.createSession({
-            cwd: selection.cwd,
-            name: firstLine(prompt).slice(0, 42) || 'Maka run',
-            backend: 'ai-sdk',
-            llmConnectionSlug: context.target.connection.slug,
-            model: context.target.model,
-            permissionMode: parsed.options.yolo ? 'bypass' : 'ask',
-            ...(parsed.options.thinking !== undefined
-              ? { thinkingLevel: parsed.options.thinking }
-              : {}),
-          });
-    if (selection.kind === 'existing') {
-      const boundary = await context.runtime.readExecutionBoundary(session.id);
-      if (parsed.options.yolo) {
-        await context.runtime.setExecutionBoundaryKind(session.id, 'bypass');
-      } else if (boundary.kind === 'bypass') {
-        throw new Error(`resuming a full-access session ${session.id} requires --yolo`);
-      } else if (boundary.kind === 'external') {
-        throw new Error(`cannot resume externally isolated session ${session.id} from maka run`);
-      }
-    }
-  } catch (error) {
-    await context.close();
-    deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
-    return 2;
-  }
-
-  let interrupted = false;
-  let timedOut = false;
-  let streamFailed = false;
-  let stopPromise: Promise<void> | undefined;
-  let resolveStopSignal: (() => void) | undefined;
-  const stopSignal = new Promise<void>((resolve) => {
-    resolveStopSignal = resolve;
+      : {}),
   });
-  const stop = (): void => {
-    resolveStopSignal?.();
-    resolveStopSignal = undefined;
-    if (stopPromise) return;
-    stopPromise = context.runtime.stopSession(session.id, { source: 'stop_button' });
-    void stopPromise.catch(() => {});
-  };
-  const removeSigint = deps.onSigint(() => {
-    interrupted = true;
-    stop();
-  });
-  const timer =
-    parsed.options.timeoutMs === undefined
-      ? undefined
-      : deps.setTimer(() => {
-          timedOut = true;
-          stop();
-        }, parsed.options.timeoutMs);
-  const graphActivity = parsed.options.graph
-    ? context.agentGraph?.reserveActivity(session.id)
-    : undefined;
-
-  try {
-    if (parsed.options.graph && !context.agentGraph) {
-      throw new Error('Graph Mode is unavailable in this CLI runtime');
-    }
-    for await (const event of context.runtime.sendMessage(session.id, {
-      turnId: deps.newId(),
-      text: prompt,
-      ...(parsed.options.graph
-        ? { turnOrchestration: { mode: 'graph' as const, source: 'host_api' as const } }
-        : {}),
-    })) {
-      if (event.type === 'sandbox_boundary_request') {
-        streamBoundaryFailure = true;
-        deps.writeStderr(
-          'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
-        );
-        await context.runtime.respondToSandboxBoundary(session.id, {
-          requestId: event.requestId,
-          decision: 'deny',
-        });
-      }
-      const sandboxFailureReason = sessionEventSandboxBoundaryFailureReason(event);
-      if (sandboxFailureReason) {
-        streamBoundaryFailure = true;
-        deps.writeStderr(
-          sandboxFailureReason === 'requires_bypass'
-            ? 'maka run: sandbox bypass requires an explicit --yolo\n'
-            : 'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
-        );
-      }
-    }
-    graphActivity?.release();
-    if (parsed.options.graph && invocation?.status === 'completed') {
-      await Promise.race([context.agentGraph!.waitForCompletion(session.id), stopSignal]);
-    }
-    await stopPromise;
-  } catch (error) {
-    streamFailed = true;
-    graphActivity?.release();
-    await stopPromise?.catch(() => undefined);
-    if (!interrupted && !timedOut) {
-      deps.writeStderr(`maka run: ${errorMessage(error)}\n`);
-    }
-  } finally {
-    removeSigint();
-    if (timer !== undefined) deps.clearTimer(timer);
-    await context.close();
-  }
-
-  if (interrupted) return 130;
-  if (timedOut) {
-    deps.writeStderr(`maka run: timed out after ${parsed.options.timeoutMs}ms\n`);
-    return 1;
-  }
-  if (streamFailed) return 1;
-  if (
-    (streamBoundaryFailure && !invocationRecoveredSandboxBoundaryFailure(invocation)) ||
-    boundaryFailureInvocationIds.size > 0
-  ) {
-    return 1;
-  }
-  if (!invocation) {
-    deps.writeStderr('maka run: runtime produced no InvocationResult\n');
-    return 1;
-  }
-  if (invocation.status !== 'completed' || invocation.finalOutput === undefined) {
-    const detail = invocation.failure?.message ?? invocation.failure?.class ?? 'runtime failure';
-    deps.writeStderr(`maka run: ${detail}\n`);
-    return 1;
-  }
-  deps.writeStdout(withTrailingNewline(invocation.finalOutput));
-  return 0;
 }
 
-async function resolveRunPrompt(options: MakaRunOptions, deps: MakaRunDeps): Promise<string> {
-  const shouldReadStdin = options.stdinPrompt || !deps.stdinIsTTY();
-  const stdin = shouldReadStdin ? await deps.readStdin() : '';
-  if (options.stdinPrompt || options.prompt === undefined) {
-    if (stdin.trim().length === 0) throw new Error('missing prompt input');
-    return stdin;
-  }
-  if (options.prompt.trim().length === 0) throw new Error('missing prompt input');
-  return stdin.trim().length > 0 ? `${options.prompt}\n\n${stdin}` : options.prompt;
-}
-
-async function canonicalDirectory(input: string): Promise<string> {
-  const canonical = await realpath(resolve(input));
-  if (!(await stat(canonical)).isDirectory()) throw new Error(`cwd is not a directory: ${input}`);
-  return canonical;
-}
-
-function makaRunHelpText(): string {
-  return [
-    'Usage: maka run [PROMPT] [options]',
-    '       maka -p [PROMPT] [options]',
-    '',
-    'Input:',
-    '  -                         Read the complete prompt from stdin',
-    '  PROMPT with piped stdin   Use PROMPT as instruction and stdin as context',
-    '',
-    'Options:',
-    '  --cwd <path>              Working directory (default: current directory)',
-    '  --connection <slug>       Model connection to use',
-    '  --model <id>              Model to use',
-    '  --thinking <level>        off|minimal|low|medium|high|xhigh|max|default',
-    '  --timeout <seconds>       Invocation timeout',
-    '  --max-steps <count>       Tool-step cap',
-    '  --yolo                    Give this session full access to your files and network',
-    '  --resume <session-id>     Continue an explicit compatible session',
-    '  --continue                Continue the latest compatible session for cwd',
-    '  --graph                   Run this turn in Graph Mode and wait for graph completion',
-    '  -h, --help                Show help',
-  ].join('\n');
-}
-
-function defaultMakaRunDeps(): MakaRunDeps {
-  return {
-    createContext: createMakaCliRuntimeContext,
-    listSessions: (workspaceRoot) => createSessionStore(workspaceRoot).list(),
-    workspaceRoot: () => resolveMakaWorkspaceRoot(),
-    processCwd: () => process.cwd(),
-    stdinIsTTY: () => process.stdin.isTTY === true,
-    readStdin: readProcessStdin,
-    writeStdout: (text) => {
-      process.stdout.write(text);
-    },
-    writeStderr: (text) => {
-      process.stderr.write(text);
-    },
-    onSigint: (handler) => {
-      process.on('SIGINT', handler);
-      return () => process.off('SIGINT', handler);
-    },
-    setTimer: (handler, ms) => {
-      const timer = setTimeout(handler, ms);
-      timer.unref();
-      return timer;
-    },
-    clearTimer: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
-    newId: randomUUID,
-  };
-}
-
-async function readProcessStdin(): Promise<string> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-  }
-  return Buffer.concat(chunks).toString('utf8');
-}
-
-function firstLine(text: string): string {
-  return (
-    text
-      .split('\n')
-      .map((line) => line.trim())
-      .find(Boolean) ?? ''
-  );
-}
-
-function withTrailingNewline(text: string): string {
-  return text.endsWith('\n') ? text : `${text}\n`;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+function sandboxBoundaryOutcome(result: InvocationResult): MakaRunOutcome['sandboxBoundary'] {
+  if (invocationRecoveredSandboxBoundaryFailure(result)) return 'recovered';
+  return invocationHasSandboxBoundaryFailure(result) ? 'unresolved' : 'none';
 }

--- a/packages/cli/src/runtime-host-cli-context.ts
+++ b/packages/cli/src/runtime-host-cli-context.ts
@@ -1,0 +1,89 @@
+import type { ConnectionCatalogEntry, ConnectionCatalogSnapshot } from '@maka/core/runtime-policy';
+import {
+  connectOrSpawnRuntimeHost,
+  readRuntimeHostConnectionCatalog,
+  type RuntimeHostConnection,
+} from '@maka/runtime-host/client';
+import { RUNTIME_HOST_PROTOCOL_VERSION, type ClientSurface } from '@maka/runtime-host/protocol';
+
+export interface RuntimeHostCliConnectionContext {
+  readonly connection: RuntimeHostConnection;
+  readonly catalog: ConnectionCatalogSnapshot;
+  close(): Promise<void>;
+}
+
+export interface RuntimeHostCliTarget {
+  readonly connection: ConnectionCatalogEntry;
+  readonly model: string;
+}
+
+export async function connectRuntimeHostCli(input: {
+  readonly rootPath: string;
+  readonly surface: ClientSurface;
+}): Promise<RuntimeHostCliConnectionContext> {
+  const connected = await connectOrSpawnRuntimeHost({
+    rootPath: input.rootPath,
+    surface: input.surface,
+    protocol: { min: RUNTIME_HOST_PROTOCOL_VERSION, max: RUNTIME_HOST_PROTOCOL_VERSION },
+  });
+  if (connected.kind === 'incompatible') {
+    throw new Error(
+      `Runtime Host protocol is incompatible (Host ${connected.handshake.protocolMin}-${connected.handshake.protocolMax}, CLI ${RUNTIME_HOST_PROTOCOL_VERSION})`,
+    );
+  }
+  if (connected.kind === 'failed') {
+    throw new Error(`Runtime Host startup failed: ${connected.reason}`);
+  }
+  const connection = connected.connection;
+  try {
+    await waitForReady(connection);
+    return {
+      connection,
+      catalog: await readRuntimeHostConnectionCatalog(connection),
+      close: () => connection.close(),
+    };
+  } catch (error) {
+    await connection.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+export function resolveRuntimeHostCliTarget(
+  catalog: ConnectionCatalogSnapshot,
+  input: { readonly connectionSlug?: string; readonly model?: string } = {},
+): RuntimeHostCliTarget {
+  const defaultTarget = catalog.defaultTarget;
+  const connection = input.connectionSlug
+    ? catalog.connections.find((candidate) => candidate.slug === input.connectionSlug)
+    : catalog.connections.find(
+        (candidate) => candidate.connectionId === defaultTarget?.connectionId,
+      );
+  if (!connection || !connection.enabled) {
+    throw new Error(
+      input.connectionSlug
+        ? `Runtime Host model connection is unavailable: ${input.connectionSlug}`
+        : 'Runtime Host has no default model connection',
+    );
+  }
+  const model =
+    input.model ??
+    (connection.connectionId === defaultTarget?.connectionId
+      ? defaultTarget.modelId
+      : connection.enabledModelIds[0]);
+  if (!model || !connection.enabledModelIds.includes(model)) {
+    throw new Error(`Runtime Host model is unavailable for ${connection.slug}: ${model ?? ''}`);
+  }
+  return { connection, model };
+}
+
+async function waitForReady(connection: RuntimeHostConnection): Promise<void> {
+  const deadline = Date.now() + 45_000;
+  while (true) {
+    const status = await connection.status(Math.max(1, deadline - Date.now()));
+    if (status.state === 'ready') return;
+    if (status.state === 'draining') throw new Error('Runtime Host drained before becoming ready');
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw new Error('Runtime Host did not become ready before the deadline');
+    await new Promise((resolve) => setTimeout(resolve, Math.min(25, remaining)));
+  }
+}

--- a/packages/cli/src/runtime-host-cli-context.ts
+++ b/packages/cli/src/runtime-host-cli-context.ts
@@ -17,14 +17,32 @@ export interface RuntimeHostCliTarget {
   readonly model: string;
 }
 
-export async function connectRuntimeHostCli(input: {
-  readonly rootPath: string;
-  readonly surface: ClientSurface;
-}): Promise<RuntimeHostCliConnectionContext> {
-  const connected = await connectOrSpawnRuntimeHost({
+interface RuntimeHostCliContextDeps {
+  readonly connectOrSpawn: typeof connectOrSpawnRuntimeHost;
+  readonly readConnectionCatalog: typeof readRuntimeHostConnectionCatalog;
+  readonly executionCandidateEntrypoint: URL;
+}
+
+export async function connectRuntimeHostCli(
+  input: {
+    readonly rootPath: string;
+    readonly surface: ClientSurface;
+  },
+  overrides: Partial<RuntimeHostCliContextDeps> = {},
+): Promise<RuntimeHostCliConnectionContext> {
+  const deps: RuntimeHostCliContextDeps = {
+    connectOrSpawn: connectOrSpawnRuntimeHost,
+    readConnectionCatalog: readRuntimeHostConnectionCatalog,
+    executionCandidateEntrypoint: new URL(
+      import.meta.resolve('@maka/runtime-host/execution-candidate-main'),
+    ),
+    ...overrides,
+  };
+  const connected = await deps.connectOrSpawn({
     rootPath: input.rootPath,
     surface: input.surface,
     protocol: { min: RUNTIME_HOST_PROTOCOL_VERSION, max: RUNTIME_HOST_PROTOCOL_VERSION },
+    candidateEntrypoint: deps.executionCandidateEntrypoint,
   });
   if (connected.kind === 'incompatible') {
     throw new Error(
@@ -39,7 +57,7 @@ export async function connectRuntimeHostCli(input: {
     await waitForReady(connection);
     return {
       connection,
-      catalog: await readRuntimeHostConnectionCatalog(connection),
+      catalog: await deps.readConnectionCatalog(connection),
       close: () => connection.close(),
     };
   } catch (error) {

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -1,0 +1,615 @@
+import { type SessionEvent, type StoredMessage } from '@maka/core';
+import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
+import type { ExecutionBoundaryReadModel } from '@maka/core/sandbox-boundary';
+import type { SessionSummary } from '@maka/core/session';
+import {
+  readRuntimeHostSessions,
+  RuntimeHostOperationError,
+  type RuntimeHostConnection,
+} from '@maka/runtime-host/client';
+import type { InteractionPendingSnapshot, SessionCatalogItem } from '@maka/runtime-host/protocol';
+import {
+  runMakaTextCliCore,
+  type MakaRunContext,
+  type MakaRunContextInput,
+  type MakaRunDeps,
+  type MakaRunEnvironmentDeps,
+  type MakaRunOutcome,
+  type MakaRunRuntime,
+} from './run-command-core.js';
+import {
+  connectRuntimeHostCli,
+  resolveRuntimeHostCliTarget,
+  type RuntimeHostCliConnectionContext,
+} from './runtime-host-cli-context.js';
+import {
+  createRuntimeHostMakaSessionDriver,
+  runtimeHostSessionSummary,
+  type RuntimeHostMakaSessionDriver,
+} from './runtime-host-session-driver.js';
+import type { MakaPreparedSessionTurn } from './session-driver.js';
+
+const GRAPH_POLL_INTERVAL_MS = 25;
+
+export interface RuntimeHostRunCommandDeps {
+  connect(rootPath: string): Promise<RuntimeHostCliConnectionContext>;
+  createContext(
+    connection: RuntimeHostConnection,
+    catalog: RuntimeHostCliConnectionContext['catalog'],
+    input: Parameters<MakaRunDeps['createContext']>[0],
+  ): MakaRunContext;
+  run: typeof runMakaTextCliCore;
+}
+
+export interface RuntimeHostRunContextDeps {
+  createDriver(
+    input: Parameters<typeof createRuntimeHostMakaSessionDriver>[0],
+  ): RuntimeHostMakaSessionDriver;
+}
+
+export async function runRuntimeHostTextCli(
+  argv: readonly string[],
+  overrides: Partial<MakaRunEnvironmentDeps> = {},
+  commandOverrides: Partial<RuntimeHostRunCommandDeps> = {},
+): Promise<number> {
+  const commandDeps = { ...defaultRuntimeHostRunCommandDeps(), ...commandOverrides };
+  let connected: RuntimeHostCliConnectionContext | undefined;
+  const connect = async (rootPath: string): Promise<RuntimeHostCliConnectionContext> => {
+    connected ??= await commandDeps.connect(rootPath);
+    return connected;
+  };
+  try {
+    return await commandDeps.run(
+      argv,
+      {
+        listSessions: async (rootPath) =>
+          runtimeHostSessionSummaries(
+            await readRuntimeHostSessions((await connect(rootPath)).connection),
+          ),
+        createContext: async (input) => {
+          const context = await connect(input.workspaceRoot);
+          return commandDeps.createContext(context.connection, context.catalog, input);
+        },
+      },
+      overrides,
+    );
+  } finally {
+    await connected?.close().catch(() => undefined);
+  }
+}
+
+function defaultRuntimeHostRunCommandDeps(): RuntimeHostRunCommandDeps {
+  return {
+    connect: (rootPath) => connectRuntimeHostCli({ rootPath, surface: 'run' }),
+    createContext: createRuntimeHostRunContext,
+    run: runMakaTextCliCore,
+  };
+}
+
+export function createRuntimeHostRunContext(
+  connection: RuntimeHostConnection,
+  catalog: RuntimeHostCliConnectionContext['catalog'],
+  input: Parameters<MakaRunDeps['createContext']>[0],
+  overrides: Partial<RuntimeHostRunContextDeps> = {},
+): MakaRunContext {
+  if (input.maxSteps !== undefined) {
+    throw new Error('--max-steps is not available through the Runtime Host yet');
+  }
+  const target = resolveRuntimeHostCliTarget(catalog, {
+    ...(input.requestedConnectionSlug ? { connectionSlug: input.requestedConnectionSlug } : {}),
+    ...(input.requestedModel ? { model: input.requestedModel } : {}),
+  });
+  const contextDeps = {
+    createDriver: createRuntimeHostMakaSessionDriver,
+    ...overrides,
+  };
+  const driver = contextDeps.createDriver({
+    connection,
+    cwd: input.cwd,
+    llmConnectionSlug: target.connection.slug,
+    model: target.model,
+    permissionMode: 'ask',
+  });
+  const runtime = new RuntimeHostRunRuntime(
+    connection,
+    driver,
+    input.runOutcomeObserver,
+    input.enableAgentGraph === true,
+    input.sessionCwdOverride,
+  );
+  return {
+    runtime,
+    target: { connection: { slug: target.connection.slug }, model: target.model },
+    ...(input.enableAgentGraph
+      ? {
+          agentGraph: {
+            reserveActivity: () => ({ release: () => {} }),
+            waitForCompletion: (sessionId: string) => runtime.waitForGraphCompletion(sessionId),
+          },
+        }
+      : {}),
+    close: async () => runtime.close(),
+  };
+}
+
+class RuntimeHostRunRuntime implements MakaRunRuntime {
+  readonly #connection: RuntimeHostConnection;
+  readonly #driver: RuntimeHostMakaSessionDriver;
+  readonly #observer: ((outcome: MakaRunOutcome) => void | Promise<void>) | undefined;
+  readonly #graphEnabled: boolean;
+  readonly #sessionCwdOverride: MakaRunContextInput['sessionCwdOverride'];
+  readonly #unsubscribeTranscriptReplacements: () => void;
+  #sessionId: string | undefined;
+  #activeTurn: { sessionId: string; turnId: string; runId: string } | undefined;
+  #stopRequested = false;
+  #closed = false;
+  readonly #interactions: NonInteractiveInteractionController;
+  #graphAdmissionTurnIds = new Set<string>();
+  #latestTranscriptReplacement: StoredMessage[] | undefined;
+  readonly #graphTerminalWaiters = new Map<
+    string,
+    Set<{
+      resolve(messages: StoredMessage[]): void;
+      reject(error: Error): void;
+      timer: ReturnType<typeof setTimeout>;
+    }>
+  >();
+
+  constructor(
+    connection: RuntimeHostConnection,
+    driver: RuntimeHostMakaSessionDriver,
+    observer: ((outcome: MakaRunOutcome) => void | Promise<void>) | undefined,
+    graphEnabled: boolean,
+    sessionCwdOverride: MakaRunContextInput['sessionCwdOverride'],
+  ) {
+    this.#connection = connection;
+    this.#driver = driver;
+    this.#observer = observer;
+    this.#graphEnabled = graphEnabled;
+    this.#sessionCwdOverride = sessionCwdOverride;
+    this.#interactions = new NonInteractiveInteractionController(driver, (pending) =>
+      this.#stopForInteraction(pending),
+    );
+    this.#unsubscribeTranscriptReplacements = driver.subscribeTranscriptReplacements(
+      (_sessionId, _turnId, messages) => this.#acceptGraphTranscript(messages),
+    );
+  }
+
+  async createSession(input: CreateSessionInput): Promise<SessionSummary> {
+    const created = await this.#driver.createSession(input);
+    this.#sessionId = created.id;
+    return created;
+  }
+
+  async readExecutionBoundary(sessionId: string): Promise<ExecutionBoundaryReadModel> {
+    await this.#attach(sessionId);
+    return this.#connection.request('session.execution_boundary.query', { sessionId });
+  }
+
+  async *sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent> {
+    await this.#attach(sessionId);
+    if (this.#stopRequested) throw new Error('Turn was cancelled before start');
+    if (input.turnOrchestration?.mode === 'graph') {
+      this.#graphAdmissionTurnIds = graphSupervisorTurnIds(await this.#driver.readMessages());
+    }
+    const turn = await this.#driver.preparePrompt(input.text, {
+      turnId: input.turnId,
+      ...(input.turnOrchestration ? { turnOrchestration: input.turnOrchestration } : {}),
+    });
+    if (!turn.runId) throw new Error('Runtime Host did not return a Run identity');
+    const activeTurn = { sessionId: turn.sessionId, turnId: turn.turnId, runId: turn.runId };
+    this.#activeTurn = activeTurn;
+    if (this.#stopRequested) {
+      await this.#stopTurn(activeTurn);
+      if (input.turnOrchestration?.mode === 'graph') await this.#stopGraph(sessionId);
+    }
+    try {
+      yield* this.#observeTurn(turn);
+    } finally {
+      if (this.#activeTurn === activeTurn) this.#activeTurn = undefined;
+    }
+  }
+
+  async respondToSandboxBoundary(
+    sessionId: string,
+    response: { requestId: string; decision: 'deny' },
+  ): Promise<void> {
+    await this.#attach(sessionId);
+    await this.#driver.respondToSandboxBoundary(response);
+  }
+
+  async stopSession(sessionId: string): Promise<void> {
+    this.#stopRequested = true;
+    await this.#attach(sessionId);
+    const stops: Promise<unknown>[] = [
+      this.#activeTurn ? this.#stopTurn(this.#activeTurn) : this.#driver.stop(),
+    ];
+    if (this.#graphEnabled) {
+      stops.push(this.#stopGraph(sessionId));
+    }
+    const settled = await Promise.allSettled(stops);
+    const failure = settled.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    this.#cancelGraphTerminalWaiters(new Error('Agent Graph wait was cancelled'));
+    if (failure) throw failure.reason;
+  }
+
+  async setExecutionBoundaryKind(sessionId: string, kind: 'managed' | 'bypass'): Promise<void> {
+    await this.#attach(sessionId);
+    await this.#driver.setPermissionMode(kind === 'bypass' ? 'bypass' : 'ask');
+  }
+
+  async waitForGraphCompletion(sessionId: string): Promise<void> {
+    let terminalStatus: 'completed' | 'failed' | 'stopped' | undefined;
+    for (;;) {
+      await this.#interactions.settle();
+      if (this.#stopRequested) throw new Error('Agent Graph wait was cancelled');
+      try {
+        const graph = await this.#connection.request('agent.graph.query', {
+          rootSessionId: sessionId,
+        });
+        await this.#interactions.settle();
+        if (this.#stopRequested) throw new Error('Agent Graph wait was cancelled');
+        if (graph.status === 'empty' || graph.status === 'completed') {
+          terminalStatus = 'completed';
+          break;
+        }
+        if (graph.status === 'failed' || graph.status === 'stopped') {
+          terminalStatus = graph.status;
+          break;
+        }
+      } catch (error) {
+        if (error instanceof RuntimeHostOperationError && error.code === 'not_found') return;
+        throw error;
+      }
+      await this.#interactions.race(delay(GRAPH_POLL_INTERVAL_MS));
+    }
+    if (terminalStatus !== 'completed') {
+      throw new Error(`Agent Graph ${terminalStatus}`);
+    }
+    await this.#interactions.settle();
+    let messages = await this.#driver.readMessages();
+    let graphTurnId = lastNewGraphSupervisorTurnId(messages, this.#graphAdmissionTurnIds);
+    let outcome = graphTurnId ? outcomeFromStoredTurn(messages, graphTurnId) : undefined;
+    if (graphTurnId && !outcome) {
+      messages = await this.#waitForGraphTurnTerminal(graphTurnId);
+      graphTurnId = lastNewGraphSupervisorTurnId(messages, this.#graphAdmissionTurnIds);
+      outcome = graphTurnId ? outcomeFromStoredTurn(messages, graphTurnId) : undefined;
+      if (!outcome)
+        throw new Error('Agent Graph final Turn did not reach a durable terminal boundary');
+    }
+    if (outcome) await this.#observer?.(outcome);
+  }
+
+  close(): Promise<void> {
+    this.#closed = true;
+    this.#interactions.close();
+    this.#unsubscribeTranscriptReplacements();
+    this.#cancelGraphTerminalWaiters(new Error('Runtime Host run context closed'));
+    return Promise.resolve();
+  }
+
+  async #attach(sessionId: string): Promise<void> {
+    if (this.#sessionId === sessionId) return;
+    const switched = await this.#driver.switchSession(sessionId);
+    if (
+      this.#sessionCwdOverride?.sessionId === sessionId &&
+      switched.summary.cwd !== this.#sessionCwdOverride.cwd
+    ) {
+      throw new Error(
+        `Runtime Host cannot resume Session ${sessionId}: its stored working directory is not canonical`,
+      );
+    }
+    this.#sessionId = sessionId;
+  }
+
+  async *#observeTurn(turn: MakaPreparedSessionTurn): AsyncIterable<SessionEvent> {
+    const accumulator = new TurnOutcomeAccumulator(turn.runId ?? turn.turnId);
+    const events = turn.events[Symbol.asyncIterator]();
+    for (;;) {
+      const next = await this.#interactions.race(events.next());
+      if (next.done) break;
+      const event = next.value;
+      if (event.type === 'user_question_request' || event.type === 'sandbox_boundary_request') {
+        continue;
+      }
+      accumulator.accept(event);
+      yield event;
+    }
+    await this.#interactions.settle();
+    await this.#observer?.(accumulator.finish());
+  }
+
+  async #stopTurn(turn: { sessionId: string; turnId: string; runId: string }): Promise<void> {
+    await this.#connection.request('turn.stop', turn);
+  }
+
+  async #stopGraph(sessionId: string): Promise<void> {
+    try {
+      await this.#connection.request('agent.graph.stop', { rootSessionId: sessionId });
+    } catch (error) {
+      if (!(error instanceof RuntimeHostOperationError) || error.code !== 'not_found') throw error;
+    }
+  }
+
+  #acceptGraphTranscript(messages: StoredMessage[]): void {
+    const replacement = messages.map((message) => structuredClone(message));
+    this.#latestTranscriptReplacement = replacement;
+    for (const [turnId, waiters] of this.#graphTerminalWaiters) {
+      if (!outcomeFromStoredTurn(replacement, turnId)) continue;
+      this.#graphTerminalWaiters.delete(turnId);
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timer);
+        waiter.resolve(replacement);
+      }
+    }
+  }
+
+  #waitForGraphTurnTerminal(turnId: string): Promise<StoredMessage[]> {
+    if (this.#closed) return Promise.reject(new Error('Runtime Host run context closed'));
+    if (this.#stopRequested) return Promise.reject(new Error('Agent Graph wait was cancelled'));
+    const latest = this.#latestTranscriptReplacement;
+    if (latest && outcomeFromStoredTurn(latest, turnId)) return Promise.resolve(latest);
+    return new Promise<StoredMessage[]>((resolve, reject) => {
+      let waiters = this.#graphTerminalWaiters.get(turnId);
+      if (!waiters) {
+        waiters = new Set();
+        this.#graphTerminalWaiters.set(turnId, waiters);
+      }
+      const waiter = {
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          waiters?.delete(waiter);
+          if (waiters?.size === 0) this.#graphTerminalWaiters.delete(turnId);
+          reject(new Error('Agent Graph final Turn did not reach a durable terminal boundary'));
+        }, 45_000),
+      };
+      waiters.add(waiter);
+    });
+  }
+
+  async #stopForInteraction(pending: InteractionPendingSnapshot): Promise<void> {
+    this.#stopRequested = true;
+    const stops: Promise<unknown>[] = [
+      this.#stopTurn({
+        sessionId: pending.sessionId,
+        turnId: pending.turnId,
+        runId: pending.runId,
+      }),
+    ];
+    if (this.#graphEnabled) stops.push(this.#stopGraph(pending.sessionId));
+    const settled = await Promise.allSettled(stops);
+    const failure = settled.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    if (failure) throw failure.reason;
+  }
+
+  #cancelGraphTerminalWaiters(error: Error): void {
+    for (const waiters of this.#graphTerminalWaiters.values()) {
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timer);
+        waiter.reject(error);
+      }
+    }
+    this.#graphTerminalWaiters.clear();
+  }
+}
+
+function runtimeHostSessionSummaries(items: readonly SessionCatalogItem[]): SessionSummary[] {
+  return items.flatMap((item) => ('kind' in item ? [] : [runtimeHostSessionSummary(item)]));
+}
+
+class TurnOutcomeAccumulator {
+  readonly #outcomeId: string;
+  #finalOutput: string | undefined;
+  #failure: { class: string; message: string } | undefined;
+  #completed = false;
+  #unresolvedBoundary = false;
+  #recoveredBoundary = false;
+
+  constructor(outcomeId: string) {
+    this.#outcomeId = outcomeId;
+  }
+
+  accept(event: SessionEvent): void {
+    if (event.type === 'text_complete' && event.text.trim().length > 0) {
+      this.#finalOutput = event.text;
+    } else if (event.type === 'error') {
+      this.#failure = { class: event.reason ?? 'runtime_error', message: event.message };
+    } else if (event.type === 'abort') {
+      this.#failure = { class: 'aborted', message: 'Turn was cancelled' };
+    } else if (event.type === 'complete') {
+      this.#completed = true;
+    }
+    if (event.type !== 'tool_result') return;
+    if (event.isError && event.content.kind === 'text' && event.content.sandboxFailure) {
+      this.#unresolvedBoundary = true;
+      return;
+    }
+    if (!event.isError && this.#unresolvedBoundary) {
+      this.#unresolvedBoundary = false;
+      this.#recoveredBoundary = true;
+    }
+  }
+
+  finish(): MakaRunOutcome {
+    const completed = this.#completed && !this.#failure;
+    return {
+      outcomeId: this.#outcomeId,
+      status: completed ? 'completed' : 'failed',
+      ...(completed && this.#finalOutput !== undefined ? { finalOutput: this.#finalOutput } : {}),
+      ...(!completed
+        ? {
+            failure: this.#failure ?? {
+              class: 'missing_terminal_event',
+              message: 'Turn ended unexpectedly',
+            },
+          }
+        : {}),
+      sandboxBoundary: this.#unresolvedBoundary
+        ? 'unresolved'
+        : this.#recoveredBoundary
+          ? 'recovered'
+          : 'none',
+    };
+  }
+}
+
+function graphSupervisorTurnIds(messages: readonly StoredMessage[]): Set<string> {
+  return new Set(
+    messages.flatMap((message) =>
+      message.type === 'user' && message.origin?.kind === 'agent_graph' ? [message.turnId] : [],
+    ),
+  );
+}
+
+function lastNewGraphSupervisorTurnId(
+  messages: readonly StoredMessage[],
+  admissionTurnIds: ReadonlySet<string>,
+): string | undefined {
+  return [...messages]
+    .reverse()
+    .find(
+      (message) =>
+        message.type === 'user' &&
+        message.origin?.kind === 'agent_graph' &&
+        !admissionTurnIds.has(message.turnId),
+    )?.turnId;
+}
+
+function outcomeFromStoredTurn(
+  messages: readonly StoredMessage[],
+  turnId: string,
+): MakaRunOutcome | undefined {
+  const turnMessages = messages.filter((message) => message.turnId === turnId);
+  const finalOutput = [...turnMessages]
+    .reverse()
+    .find(
+      (message): message is Extract<StoredMessage, { type: 'assistant' }> =>
+        message.type === 'assistant' && message.text.trim().length > 0,
+    )?.text;
+  const storedTerminal = [...turnMessages]
+    .reverse()
+    .find(
+      (message): message is Extract<StoredMessage, { type: 'turn_state' }> =>
+        message.type === 'turn_state' && message.status !== 'running',
+    );
+  const status = storedTerminal?.status;
+  if (!status) return undefined;
+  const completed = status === 'completed';
+  return {
+    outcomeId: turnId,
+    status: completed ? 'completed' : 'failed',
+    ...(completed && finalOutput !== undefined ? { finalOutput } : {}),
+    ...(!completed
+      ? {
+          failure: {
+            class: storedTerminal?.errorClass ?? storedTerminal?.abortSource ?? status,
+            message: status === 'aborted' ? 'Turn was cancelled' : 'Agent Graph final Turn failed',
+          },
+        }
+      : {}),
+    sandboxBoundary: storedSandboxBoundaryOutcome(turnMessages),
+  };
+}
+
+class NonInteractiveInteractionController {
+  readonly #driver: RuntimeHostMakaSessionDriver;
+  readonly #stop: (pending: InteractionPendingSnapshot) => Promise<void>;
+  readonly #handled = new Set<string>();
+  readonly #tasks = new Set<Promise<void>>();
+  readonly #unsubscribe: () => void;
+  #failure: Error | undefined;
+  readonly #failureSignal: Promise<Error>;
+  #publishFailure!: (error: Error) => void;
+
+  constructor(
+    driver: RuntimeHostMakaSessionDriver,
+    stop: (pending: InteractionPendingSnapshot) => Promise<void>,
+  ) {
+    this.#driver = driver;
+    this.#stop = stop;
+    this.#failureSignal = new Promise((resolve) => {
+      this.#publishFailure = resolve;
+    });
+    this.#unsubscribe = driver.subscribePendingInteractions((pending) => this.#accept(pending));
+  }
+
+  race<T>(operation: Promise<T>): Promise<T> {
+    this.throwIfFailed();
+    return Promise.race([operation, this.#failureSignal.then((error) => Promise.reject(error))]);
+  }
+
+  async settle(): Promise<void> {
+    await Promise.all([...this.#tasks]);
+    this.throwIfFailed();
+  }
+
+  throwIfFailed(): void {
+    if (this.#failure) throw this.#failure;
+  }
+
+  close(): void {
+    this.#unsubscribe();
+  }
+
+  #accept(pending: InteractionPendingSnapshot): void {
+    if (this.#handled.has(pending.interactionId)) return;
+    this.#handled.add(pending.interactionId);
+    const task = this.#handle(pending).catch((error) => {
+      this.#fail(error instanceof Error ? error : new Error(String(error)));
+    });
+    this.#tasks.add(task);
+    void task.finally(() => this.#tasks.delete(task));
+  }
+
+  async #handle(pending: InteractionPendingSnapshot): Promise<void> {
+    if (pending.request.kind === 'sandbox_boundary') {
+      await this.#driver.respondToSandboxBoundary({
+        requestId: pending.interactionId,
+        decision: 'deny',
+      });
+      return;
+    }
+    await this.#stop(pending);
+    throw new Error(
+      pending.request.kind === 'question'
+        ? 'interactive user questions are unavailable in non-interactive mode'
+        : 'interactive permission requests are unavailable in non-interactive mode',
+    );
+  }
+
+  #fail(error: Error): void {
+    if (this.#failure) return;
+    this.#failure = error;
+    this.#publishFailure(error);
+  }
+}
+
+function storedSandboxBoundaryOutcome(
+  messages: readonly StoredMessage[],
+): MakaRunOutcome['sandboxBoundary'] {
+  let unresolved = false;
+  let recovered = false;
+  for (const message of messages) {
+    if (
+      message.type === 'tool_result' &&
+      message.isError &&
+      message.content.kind === 'text' &&
+      message.content.sandboxFailure
+    ) {
+      unresolved = true;
+    } else if (message.type === 'tool_result' && !message.isError && unresolved) {
+      unresolved = false;
+      recovered = true;
+    }
+  }
+  return unresolved ? 'unresolved' : recovered ? 'recovered' : 'none';
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cli/src/runtime-host-session-channel.ts
+++ b/packages/cli/src/runtime-host-session-channel.ts
@@ -32,6 +32,7 @@ export interface RuntimeHostSessionChannelOptions {
   now: () => number;
   onTurnStarted: (turn: MakaPreparedSessionTurn) => void;
   onRuntimeResourceChanged: (sourceSessionId: string, ref: string) => void;
+  onInteractionPending: (pending: InteractionPendingSnapshot) => void;
   onInteractionResolved: (pending: InteractionPendingSnapshot) => void;
   onTurnTerminal: (turn: TerminalTurnSnapshot) => void;
 }
@@ -44,11 +45,13 @@ export class RuntimeHostSessionChannel {
   readonly #now: () => number;
   readonly #onTurnStarted: (turn: MakaPreparedSessionTurn) => void;
   readonly #onRuntimeResourceChanged: (sourceSessionId: string, ref: string) => void;
+  readonly #onInteractionPending: (pending: InteractionPendingSnapshot) => void;
   readonly #onInteractionResolved: (pending: InteractionPendingSnapshot) => void;
   readonly #onTurnTerminal: (turn: TerminalTurnSnapshot) => void;
   readonly #turns = new Map<string, SessionEventQueue>();
   readonly #pendingFrames: SubscriptionFrame[] = [];
   readonly #pendingStartedTurns = new Map<string, MakaPreparedSessionTurn>();
+  readonly #pendingOpenedInteractions: InteractionPendingSnapshot[] = [];
   readonly #pendingResolvedInteractions: InteractionPendingSnapshot[] = [];
   readonly #pendingTerminalTurns: TerminalTurnSnapshot[] = [];
   #projector: RuntimeHostSessionProjector | undefined;
@@ -70,6 +73,7 @@ export class RuntimeHostSessionChannel {
     this.#now = options.now;
     this.#onTurnStarted = options.onTurnStarted;
     this.#onRuntimeResourceChanged = options.onRuntimeResourceChanged;
+    this.#onInteractionPending = options.onInteractionPending;
     this.#onInteractionResolved = options.onInteractionResolved;
     this.#onTurnTerminal = options.onTurnTerminal;
   }
@@ -135,6 +139,12 @@ export class RuntimeHostSessionChannel {
       this.#startedTurnBarrier = claimedTurnId;
     } else {
       this.#flushStartedTurns();
+    }
+    for (const interaction of this.snapshot.interactions.pending) {
+      this.#onInteractionPending(structuredClone(interaction));
+    }
+    for (const interaction of this.#pendingOpenedInteractions.splice(0)) {
+      this.#onInteractionPending(interaction);
     }
     for (const interaction of this.#pendingResolvedInteractions.splice(0)) {
       this.#onInteractionResolved(interaction);
@@ -231,9 +241,18 @@ export class RuntimeHostSessionChannel {
       this.#fail(new Error(`Runtime Host Session subscription closed: ${frame.reason}`));
       return;
     }
+    const previousPendingIds = new Set(
+      this.snapshot.interactions.pending.map((interaction) => interaction.interactionId),
+    );
     const update = this.#projector?.accept(frame);
     if (!update || !this.#projector) return;
     this.snapshot = this.#projector.snapshot;
+    for (const interaction of this.snapshot.interactions.pending) {
+      if (previousPendingIds.has(interaction.interactionId)) continue;
+      const pending = structuredClone(interaction);
+      if (this.#activated) this.#onInteractionPending(pending);
+      else this.#pendingOpenedInteractions.push(pending);
+    }
     for (const interaction of update.resolvedInteractions) {
       if (this.#activated) this.#onInteractionResolved(interaction);
       else this.#pendingResolvedInteractions.push(interaction);
@@ -243,6 +262,7 @@ export class RuntimeHostSessionChannel {
       const turn = {
         sessionId: this.sessionId,
         turnId: update.startedTurn.turnId,
+        runId: update.startedTurn.runId,
         events: this.eventsForTurn(update.startedTurn.turnId),
       } satisfies MakaPreparedSessionTurn;
       if (this.#activated && !this.#startedTurnBarrier) this.#onTurnStarted(turn);

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -12,6 +12,7 @@ import {
 } from '@maka/core';
 import type { OrchestrationMode } from '@maka/core/orchestration';
 import type { PermissionMode } from '@maka/core/permission';
+import type { CreateSessionInput } from '@maka/core/runtime-inputs';
 import { executionBoundaryDisplayMode } from '@maka/core/sandbox-boundary';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
@@ -69,6 +70,9 @@ export interface RuntimeHostMakaSessionDriverInput {
 }
 
 export interface RuntimeHostMakaSessionDriver extends MakaSessionDriver {
+  createSession(input: CreateSessionInput): Promise<SessionSummary>;
+  readMessages(): Promise<StoredMessage[]>;
+  subscribePendingInteractions(listener: (pending: InteractionPendingSnapshot) => void): () => void;
   subscribeStartedTurns(listener: (turn: MakaAttachedSessionTurn) => void): () => void;
   subscribeResolvedInteractions(
     listener: (sessionId: string, requestId: string) => void,
@@ -105,6 +109,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   #sessionGeneration = 0;
   #channelGeneration = 0;
   readonly #startedTurnListeners = new Set<(turn: MakaAttachedSessionTurn) => void>();
+  readonly #pendingInteractionListeners = new Set<(pending: InteractionPendingSnapshot) => void>();
   readonly #claimedTurnIds = new Set<string>();
   readonly #shellRunListeners = new Set<(update: ShellRunUpdate) => void>();
   readonly #resolvedInteractionListeners = new Set<
@@ -126,10 +131,26 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     this.#orchestrationMode = input.orchestrationMode ?? 'default';
   }
 
+  readMessages(): Promise<StoredMessage[]> {
+    return loadCurrentMessages(this.#connection, this.#requireSession('read messages'));
+  }
+
+  async createSession(input: CreateSessionInput): Promise<SessionSummary> {
+    if (this.#sessionId) throw new Error('Cannot create a Session while another is active.');
+    if (!input.model) throw new Error('Runtime Host Session creation requires an explicit model');
+    this.#cwd = input.cwd;
+    this.#llmConnectionSlug = input.llmConnectionSlug;
+    this.#model = input.model;
+    this.#thinkingLevel = input.thinkingLevel;
+    this.#permissionMode = input.permissionMode ?? 'ask';
+    const session = await this.#createSession(input.name ?? DEFAULT_SESSION_NAME);
+    return runtimeHostSessionSummary(session);
+  }
+
   async listSessions(): Promise<SessionSummary[]> {
     const sessions = (await readRuntimeHostSessions(this.#connection))
       .flatMap(representableSession)
-      .map(sessionSummary);
+      .map(runtimeHostSessionSummary);
     return sessions
       .map((session, index) => ({ session, index }))
       .sort((left, right) => {
@@ -159,7 +180,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     const events = channel.eventsForTurn(turnId);
     const modelText = options.modelText ?? prompt;
     try {
-      await this.#request('turn.start', {
+      const started = await this.#request('turn.start', {
         sessionId,
         turnId,
         content: {
@@ -168,11 +189,17 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
         },
         ...(options.turnOrchestration ? { turnOrchestration: options.turnOrchestration } : {}),
       });
+      return {
+        sessionId,
+        turnId,
+        runId: started.runId,
+        events,
+        summary: runtimeHostSessionSummary(configuration.session),
+      };
     } catch (error) {
       channel.failTurn(turnId, error);
       throw error;
     }
-    return { sessionId, turnId, events, summary: sessionSummary(configuration.session) };
   }
 
   async *compactSession(): AsyncIterable<SessionEvent> {
@@ -313,7 +340,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
 
   async renameSession(name: string): Promise<string> {
     const sessionId = this.#requireSession('rename');
-    const session = await updateSession(this.#connection, sessionId, (current) =>
+    const session = await updateRuntimeHostSession(this.#connection, sessionId, (current) =>
       this.#request('session.metadata.update', {
         sessionId,
         expectedRevision: current.revision,
@@ -331,7 +358,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       return { previousCwd, cwd: nextCwd, changed: false, oldCwdDirty: false };
     }
     const oldCwdDirty = await this.#inspectCwdChanges(previousCwd).catch(() => undefined);
-    const session = await updateSession(this.#connection, sessionId, (current) =>
+    const session = await updateRuntimeHostSession(this.#connection, sessionId, (current) =>
       this.#request('session.cwd.relocate', {
         sessionId,
         expectedRevision: current.revision,
@@ -343,9 +370,9 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   }
 
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
-    const session = await getSession(this.#connection, sessionId);
+    const session = await getRuntimeHostSession(this.#connection, sessionId);
     if (!session) throw new Error(`Session not found: ${sessionId}`);
-    const summary = sessionSummary(session);
+    const summary = runtimeHostSessionSummary(session);
     const availability = await inspectSessionResumeAvailability(summary);
     if (!availability.available) {
       throw new Error(
@@ -383,6 +410,9 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
             activeTurn: {
               sessionId,
               turnId: attachedTurnId,
+              ...(opened.channel.snapshot.rootTurn?.turnId === attachedTurnId
+                ? { runId: opened.channel.snapshot.rootTurn.runId }
+                : {}),
               events: opened.channel.eventsForTurn(attachedTurnId),
             },
           }
@@ -416,7 +446,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     if (!promptMessage) throw new Error(`Cannot rewind to turn ${turnId}: no user prompt.`);
     const targetSessionId = this.#newId();
     for (let attempt = 0; attempt < MAX_CATALOG_ATTEMPTS; attempt += 1) {
-      const current = await getSession(this.#connection, sourceSessionId);
+      const current = await getRuntimeHostSession(this.#connection, sourceSessionId);
       if (!current) throw new Error(`Session not found: ${sourceSessionId}`);
       const result = await this.#request('session.revision.create', {
         sourceSessionId,
@@ -445,6 +475,13 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   subscribeStartedTurns(listener: (turn: MakaAttachedSessionTurn) => void): () => void {
     this.#startedTurnListeners.add(listener);
     return () => this.#startedTurnListeners.delete(listener);
+  }
+
+  subscribePendingInteractions(
+    listener: (pending: InteractionPendingSnapshot) => void,
+  ): () => void {
+    this.#pendingInteractionListeners.add(listener);
+    return () => this.#pendingInteractionListeners.delete(listener);
   }
 
   subscribeResolvedInteractions(
@@ -508,12 +545,16 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
 
   async #ensureSession(): Promise<string> {
     if (this.#sessionId) return this.#sessionId;
+    return (await this.#createSession(DEFAULT_SESSION_NAME)).id;
+  }
+
+  async #createSession(name: string): Promise<SessionCatalogProjection> {
     const sessionId = this.#newId();
     const session = requireSession(
       await this.#request('session.create', {
         sessionId,
         cwd: this.#cwd,
-        name: DEFAULT_SESSION_NAME,
+        name,
         modelTarget: {
           kind: 'explicit',
           connectionSlug: this.#llmConnectionSlug,
@@ -530,7 +571,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     this.#sessionId = sessionId;
     this.#adoptConfiguration(session);
     await this.#ensureChannel(sessionId);
-    return sessionId;
+    return session;
   }
 
   async #ensureChannel(sessionId: string): Promise<RuntimeHostSessionChannel> {
@@ -598,7 +639,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       orchestrationMode?: OrchestrationMode;
     },
   ): Promise<SessionCatalogProjection> {
-    return updateSession(this.#connection, sessionId, (current) =>
+    return updateRuntimeHostSession(this.#connection, sessionId, (current) =>
       this.#request('session.configuration.update', {
         sessionId,
         expectedRevision: current.revision,
@@ -634,7 +675,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
 
   async #loadConfiguration(sessionId: string): Promise<LoadedSessionConfiguration> {
     const [session, boundary] = await Promise.all([
-      getSession(this.#connection, sessionId),
+      getRuntimeHostSession(this.#connection, sessionId),
       this.#request('session.execution_boundary.query', { sessionId }),
     ]);
     if (!session) throw new Error(`Session not found: ${sessionId}`);
@@ -722,9 +763,12 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     const turn = {
       sessionId,
       turnId,
+      ...(opened.channel.snapshot.rootTurn?.turnId === turnId
+        ? { runId: opened.channel.snapshot.rootTurn.runId }
+        : {}),
       events: opened.channel.eventsForTurn(turnId),
       messages: opened.messages,
-      summary: sessionSummary(configuration.session),
+      summary: runtimeHostSessionSummary(configuration.session),
     } satisfies MakaAttachedSessionTurn;
     for (const listener of this.#startedTurnListeners) listener(turn);
     opened.channel.activate(turnId);
@@ -741,6 +785,9 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       onTurnStarted: (turn) => this.#publishStartedTurn(turn, sessionGeneration),
       onRuntimeResourceChanged: (sourceSessionId, ref) =>
         this.#publishRuntimeResource(sourceSessionId, ref),
+      onInteractionPending: (pending) => {
+        for (const listener of this.#pendingInteractionListeners) listener(pending);
+      },
       onInteractionResolved: (pending) => this.#resolveExternalInteraction(pending),
       onTurnTerminal: (turn) => this.#refreshTerminalTranscript(turn),
     });
@@ -804,7 +851,7 @@ interface LoadedSessionConfiguration {
   boundaryDisplayMode: PermissionMode | undefined;
 }
 
-async function getSession(
+async function getRuntimeHostSession(
   connection: RuntimeHostConnection,
   sessionId: string,
 ): Promise<SessionCatalogProjection | null> {
@@ -822,13 +869,13 @@ function requireSession(item: SessionCatalogItem): SessionCatalogProjection {
   throw new Error(`Runtime Host Session is not representable by this CLI: ${item.id}`);
 }
 
-async function updateSession(
+async function updateRuntimeHostSession(
   connection: RuntimeHostConnection,
   sessionId: string,
   update: (current: SessionCatalogProjection) => Promise<SessionUpdateResult>,
 ): Promise<SessionCatalogProjection> {
   for (let attempt = 0; attempt < MAX_CATALOG_ATTEMPTS; attempt += 1) {
-    const current = await getSession(connection, sessionId);
+    const current = await getRuntimeHostSession(connection, sessionId);
     if (!current) throw new Error(`Session not found: ${sessionId}`);
     const result = await update(current);
     if (result.kind === 'committed') return requireSession(result.session);
@@ -855,7 +902,7 @@ async function loadCurrentMessages(
   }
 }
 
-function sessionSummary(session: SessionCatalogProjection): SessionSummary {
+export function runtimeHostSessionSummary(session: SessionCatalogProjection): SessionSummary {
   return {
     id: session.id,
     cwd: session.cwd,

--- a/packages/cli/src/runtime-host-tui-context.ts
+++ b/packages/cli/src/runtime-host-tui-context.ts
@@ -1,16 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import type { ConnectionCatalogEntry, ConnectionCatalogSnapshot } from '@maka/core/runtime-policy';
 import { SessionActivityRegistry, type InvocableSkillEntry } from '@maka/runtime';
-import {
-  connectOrSpawnRuntimeHost,
-  readRuntimeHostConnectionCatalog,
-  readRuntimeHostSkillCatalog,
-  type RuntimeHostConnection,
-} from '@maka/runtime-host/client';
-import { RUNTIME_HOST_PROTOCOL_VERSION } from '@maka/runtime-host/protocol';
+import { readRuntimeHostSkillCatalog, type RuntimeHostConnection } from '@maka/runtime-host/client';
 import type { ModelChoice } from './connection-target.js';
 import type { MakaPiTuiGoalLifecycle } from './pi-tui-runner.js';
 import type { SessionRecapGenerator } from './runtime-bootstrap.js';
+import { connectRuntimeHostCli, resolveRuntimeHostCliTarget } from './runtime-host-cli-context.js';
 import {
   createRuntimeHostMakaSessionDriver,
   type RuntimeHostMakaSessionDriverInput,
@@ -41,23 +36,13 @@ export interface CreateRuntimeHostTuiContextInput {
 export async function createRuntimeHostTuiContext(
   input: CreateRuntimeHostTuiContextInput,
 ): Promise<RuntimeHostTuiContext> {
-  const connected = await connectOrSpawnRuntimeHost({
+  const connected = await connectRuntimeHostCli({
     rootPath: input.rootPath,
     surface: 'tui',
-    protocol: { min: RUNTIME_HOST_PROTOCOL_VERSION, max: RUNTIME_HOST_PROTOCOL_VERSION },
   });
-  if (connected.kind === 'incompatible') {
-    throw new Error(
-      `Runtime Host protocol is incompatible (Host ${connected.handshake.protocolMin}-${connected.handshake.protocolMax}, CLI ${RUNTIME_HOST_PROTOCOL_VERSION})`,
-    );
-  }
-  if (connected.kind === 'failed') {
-    throw new Error(`Runtime Host startup failed: ${connected.reason}`);
-  }
   const connection = connected.connection;
   try {
-    await waitForReady(connection);
-    const catalog = await loadConnectionCatalog(connection);
+    const catalog = connected.catalog;
     const target = input.resumeSessionId
       ? await resolveResumeTarget(connection, catalog, input.resumeSessionId)
       : resolveTarget(catalog);
@@ -84,7 +69,7 @@ export async function createRuntimeHostTuiContext(
       goalLifecycle: createHostOwnedGoalLifecycle(),
       listSkills: (cwd) => listStablePresentedSkills(connection, cwd),
       recap: createRuntimeHostRecapGenerator(connection),
-      close: () => connection.close(),
+      close: () => connected.close(),
     };
   } catch (error) {
     await connection.close().catch(() => undefined);
@@ -126,37 +111,11 @@ async function listStablePresentedSkills(
   );
 }
 
-async function waitForReady(connection: RuntimeHostConnection): Promise<void> {
-  const deadline = Date.now() + 45_000;
-  while (true) {
-    const status = await connection.status(Math.max(1, deadline - Date.now()));
-    if (status.state === 'ready') return;
-    if (status.state === 'draining') throw new Error('Runtime Host drained before becoming ready');
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) throw new Error('Runtime Host did not become ready before the deadline');
-    await new Promise((resolve) => setTimeout(resolve, Math.min(25, remaining)));
-  }
-}
-
-async function loadConnectionCatalog(
-  connection: RuntimeHostConnection,
-): Promise<ConnectionCatalogSnapshot> {
-  return readRuntimeHostConnectionCatalog(connection);
-}
-
 function resolveTarget(catalog: ConnectionCatalogSnapshot): {
   connection: ConnectionCatalogEntry;
   model: string;
 } {
-  const target = catalog.defaultTarget;
-  if (!target) throw new Error('Runtime Host has no default model connection');
-  const connection = catalog.connections.find(
-    (candidate) => candidate.connectionId === target.connectionId,
-  );
-  if (!connection || !connection.enabled) {
-    throw new Error('Runtime Host default model connection is unavailable');
-  }
-  return { connection, model: target.modelId };
+  return resolveRuntimeHostCliTarget(catalog);
 }
 
 async function resolveResumeTarget(

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -113,6 +113,8 @@ export interface MakaSessionSwitchResult {
 export interface MakaPreparedSessionTurn {
   sessionId: string;
   turnId: string;
+  /** Host-owned Run identity when the adapter exposes exact Turn cancellation. */
+  runId?: string;
   events: AsyncIterable<SessionEvent>;
   /** Authoritative Session metadata available when the Turn was attached. */
   summary?: SessionSummary;

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -158,7 +158,6 @@ describe('SessionManager running-turn projection', () => {
     const after = await manager.listSessions();
     expect(after.find((session) => session.id === busy.id)?.runningTurnIds).toEqual(undefined);
   });
-
 });
 
 describe('SessionManager Plan control boundaries', () => {
@@ -1506,7 +1505,6 @@ describe('SessionManager claimed graph intent execution', () => {
     expect(await store.readMessages(child.id)).toEqual([]);
     expect((await runStore.readRun(child.id, claim.targetRunId)).status).toBe('completed');
   });
-
 
   test('hosted explicit abort stops only the exact claimed root identity', async () => {
     const store = new MemorySessionStore();
@@ -4355,7 +4353,6 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
     expect(abortErrorRun?.status).toBe('cancelled');
   });
 
-
   test('stopSession waits for compaction blocked before Run reservation', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -4498,7 +4495,6 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
     sendGate.release();
     await sendPromise;
   });
-
 
   test('configuration transitions fence active runs and unavailable resource side effects', async () => {
     const store = new VersionedConfigurationMemorySessionStore();
@@ -5071,10 +5067,6 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
 });
 
 describe('SessionManager permission mode updates', () => {
-
-
-
-
   test('revokes background shell authority before narrowing Auto to Explore', async () => {
     const store = new AtomicBoundaryMemorySessionStore();
     const calls: string[] = [];
@@ -5220,7 +5212,6 @@ describe('SessionManager permission mode updates', () => {
     expect(store.disposeCount).toBe(3);
   });
 
-
   test('keeps mode changes blocked until all overlapping turns finish', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -5275,7 +5266,6 @@ describe('SessionManager permission mode updates', () => {
     const summary = await manager.setPermissionMode(session.id, 'execute');
     expect(summary.permissionMode).toBe('execute');
   });
-
 
   test('persists orchestration mode changes and records a dimensioned audit note', async () => {
     const store = new MemorySessionStore();
@@ -5450,8 +5440,6 @@ describe('SessionManager permission mode updates', () => {
       'ai-sdk:zai-coding-plan:glm-4.7:/tmp/worktree-cwd',
     ]);
   });
-
-
 
   test('records the authoritative workspace identity on a new AgentRun', async () => {
     const store = new MemorySessionStore();
@@ -7171,7 +7159,6 @@ describe('SessionManager permission mode updates', () => {
     expect(await runStore.readEvents(session.id, runId)).toHaveLength(0);
   });
 
-
   test('rejects continuation when the authoritative workspace identity changes after planning', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -7625,11 +7612,6 @@ describe('SessionManager permission mode updates', () => {
     }).getSessionView(session.id);
     expect(view.terminalFacts.map((fact) => fact.runStatus)).toEqual(['completed']);
   });
-
-
-
-
-
 
   test('terminal header is never persisted without a terminal RuntimeEvent', async () => {
     const store = new MemorySessionStore();
@@ -8219,8 +8201,6 @@ describe('SessionManager permission mode updates', () => {
     ).toEqual(['legacy-user', 'legacy-assistant', 'legacy-state']);
   });
 
-
-
   test('RuntimeReadModel projects messages turns replay and terminal facts without SessionStore messages', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -8409,7 +8389,6 @@ describe('SessionManager permission mode updates', () => {
       );
     }
   });
-
 
   test('RuntimeReadModel bounds concurrent hosted permission outcome reads', {
     timeout: 2_000,
@@ -8935,7 +8914,6 @@ describe('SessionManager permission mode updates', () => {
     expect(runtimeEvents.at(-1)?.refs?.storedMessageId).toBe('legacy-state');
   });
 
-
   test('getMessages does not trust failed legacy terminal state for a completed run header', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -9093,7 +9071,6 @@ describe('SessionManager permission mode updates', () => {
     expect(runtimeEvents.at(-1)?.status).toBe('failed');
   });
 
-
   test('getMessages preserves failed legacy terminal state when failureClass is missing', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -9172,7 +9149,6 @@ describe('SessionManager permission mode updates', () => {
     });
     expect(runtimeEvents.at(-1)?.status).toBe('failed');
   });
-
 
   test('getMessages waits for legacy messages before fallback repair', async () => {
     const store = new MemorySessionStore();
@@ -9260,7 +9236,6 @@ describe('SessionManager permission mode updates', () => {
     expect(terminalEvents).toHaveLength(1);
     expect(terminalEvents[0]?.status).toBe('completed');
   });
-
 
   test('getMessages repair writes terminal turn_state for a continuation run', async () => {
     const store = new MemorySessionStore();
@@ -9566,7 +9541,6 @@ describe('SessionManager permission mode updates', () => {
     expect(runtimeEvents.filter((event) => event.status === 'failed')).toHaveLength(1);
   });
 
-
   test('getMessages serializes concurrent terminal repairs for the same run', async () => {
     const store = new MemorySessionStore();
     let repairReads = 0;
@@ -9630,7 +9604,6 @@ describe('SessionManager permission mode updates', () => {
     const runtimeEvents = await runStore.readRuntimeEvents(session.id, 'run-1');
     expect(runtimeEvents.filter((event) => event.status === 'failed')).toHaveLength(1);
   });
-
 
   test('getMessages includes continuation output without inlining child agent output', async () => {
     const store = new MemorySessionStore();
@@ -10068,8 +10041,6 @@ describe('SessionManager permission mode updates', () => {
     ).toEqual(['boundary-pending']);
   });
 
-
-
   test('MAKA_RUNTIME_READ_SOURCE does not force legacy reads when RuntimeEvents are complete', async () => {
     const previous = process.env.MAKA_RUNTIME_READ_SOURCE;
     process.env.MAKA_RUNTIME_READ_SOURCE = 'legacy';
@@ -10442,7 +10413,6 @@ describe('SessionManager permission mode updates', () => {
     expect(regenUser?.type === 'user' ? regenUser.text : undefined).toBe('aborted turn text');
   });
 
-
   test('branchFromTurn copies through the RuntimeEvent-primary message boundary', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -10786,9 +10756,6 @@ describe('SessionManager permission mode updates', () => {
       branchOfTurnId: 'root',
     });
   });
-
-
-
 
   test('next turn projects failed prior RuntimeEvents with the terminal fact failure class', async () => {
     const store = new MemorySessionStore();
@@ -11566,7 +11533,6 @@ describe('SessionManager permission mode updates', () => {
     ).toEqual([]);
   });
 
-
   test('parent and child runs can read their ledger while only parents may compact session history', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -11975,8 +11941,6 @@ describe('SessionManager permission mode updates', () => {
     expect(run?.status).toBe('cancelled');
     expect((await store.readHeader(session.id)).status === 'blocked').toBe(false);
   });
-
-
 
   test('a factory AbortError is not normalized as execution cancellation', async () => {
     const store = new MemorySessionStore();
@@ -12578,7 +12542,6 @@ describe('SessionManager permission mode updates', () => {
     childGate.release();
     while (!(await child.next()).done) {}
   });
-
 
   test('stopSession does not reenter a failed backend in a multi-generation stop', async () => {
     const store = new MemorySessionStore();
@@ -13258,9 +13221,6 @@ describe('SessionManager permission mode updates', () => {
     expect(output.budget.projectedBytes <= output.budget.maxBytes).toBe(true);
   });
 
-
-
-
   test('rejects backend configuration updates while a turn is actively streaming', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -13601,7 +13561,6 @@ describe('SessionManager permission mode updates', () => {
     );
   });
 
-
   test('complete(stopReason=error) without a prior error event classifies as runtime_error not unknown', async () => {
     // Reproduces the DeepSeek-reasoner smoke failure: the backend ended with
     // stopReason='error' but never emitted a preceding error event, so the
@@ -13698,7 +13657,6 @@ describe('SessionManager permission mode updates', () => {
     expect(turn?.errorClass).toBe('tool_failed');
   });
 
-
   test('stopSession records renderer abort source for diagnostics', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -13723,7 +13681,6 @@ describe('SessionManager permission mode updates', () => {
     if (abortNote?.type !== 'system_note') throw new Error('abort note missing');
     expect(abortNote.data).toEqual({ source: 'renderer.stop_button' });
   });
-
 
   test('stopSession persists abortSource on a terminal RuntimeEvent emitted during backend stop', async () => {
     const store = new MemorySessionStore();
@@ -13942,7 +13899,6 @@ describe('SessionManager permission mode updates', () => {
     expect(JSON.stringify(events).includes('sk-live-secret-token-value')).toBe(false);
   });
 
-
   test('required capture and later attempt still write after an attempt append fails', async () => {
     const store = new MemorySessionStore();
     const attemptFailureRecorded = makeGate();
@@ -14068,8 +14024,6 @@ describe('SessionManager permission mode updates', () => {
     expect(run?.status).toBe('failed');
     expect(run?.completedAt).toBeDefined();
   });
-
-
 
   test('schedules legacy artifact cleanup only after the V2 checkpoint is durable', async () => {
     const store = new MemorySessionStore();
@@ -14546,7 +14500,6 @@ describe('SessionManager permission mode updates', () => {
     expect(physicalCoverage).toEqual([1, 2]);
   });
 
-
   test('rejects checkpoint recording after the current AgentRun store becomes unavailable', async () => {
     const store = new MemorySessionStore();
     const runStoreUnavailable = makeGate();
@@ -14975,8 +14928,6 @@ describe('SessionManager permission mode updates', () => {
     expect(activeTurn?.status).toBe('completed');
   });
 
-
-
   test('startup recovery writes terminal turn_state for a stale continuation run', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -15040,7 +14991,6 @@ describe('SessionManager permission mode updates', () => {
       parentTurnId: 'source-turn',
     });
   });
-
 
   test('startup recovery maps failed aborted and cancelled RuntimeEvent terminal facts consistently', async () => {
     const store = new MemorySessionStore();
@@ -15303,7 +15253,6 @@ describe('SessionManager permission mode updates', () => {
     ).toBe('model_stream_completed_without_runtime_terminal');
   });
 
-
   test('startup recovery derives the interrupted outcome sink from the runtime store', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -15520,7 +15469,6 @@ describe('SessionManager permission mode updates', () => {
     ]);
   });
 
-
   test('startup recovery re-reads a closure it settled before an earlier crash', async () => {
     // Stands in for a first recovery that settled the request and then died
     // before committing the run's terminal fact: the row is no longer pending,
@@ -15623,10 +15571,6 @@ describe('SessionManager permission mode updates', () => {
     const [turn] = await store.listTurns(session.id);
     expect(turn?.errorClass).toBe('app_restarted');
   });
-
-
-
-
 
   test('startup recovery treats terminal AgentRun headers without RuntimeEvent facts as missing terminal events', async () => {
     const store = new MemorySessionStore();
@@ -15747,7 +15691,6 @@ describe('SessionManager permission mode updates', () => {
       'missing_terminal_event',
     );
   });
-
 
   test('regenerate creates a new sibling turn from an aborted source turn (retry merged)', async () => {
     const store = new MemorySessionStore();
@@ -15897,7 +15840,6 @@ describe('SessionManager permission mode updates', () => {
       }
     }
   });
-
 
   test('branch and revision sessions rewrite tool operation authority facts', async () => {
     const store = new MemorySessionStore();
@@ -16593,7 +16535,6 @@ describe('SessionManager permission mode updates', () => {
     expect(version3.parentSessionId).toBeUndefined();
   });
 
-
   test('startup recovery removes empty preparing revisions and commits admitted edits', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -16920,7 +16861,6 @@ describe('SessionManager steering and followup queues', () => {
     expect(failure instanceof RuntimeInteractionInvariantError).toBe(true);
     expect(releases).toBe(1);
   });
-
 
   test('hosted owner is released when backend execution fails', async () => {
     const store = new MemorySessionStore();


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- add an explicit Runtime Host owner path for `maka run` while keeping embedded Runtime as the default
- share owner-neutral one-shot parsing and orchestration between the embedded and Host adapters
- launch the execution-capable Runtime Host composition when the CLI is the first Host client
- preserve Session create, resume, continue, Graph completion, SIGINT/timeout cancellation, and exit/output semantics through typed Host operations
- handle non-interactive permission and question requests explicitly, deny sandbox expansion, and use durable Graph outcomes without polling subscriptions or reusing historical wakes
- add a dependency-path gate that prevents the Host-backed run entry from reaching embedded Runtime or writer Store modules
- restore repository formatting after the session-manager test trimming on `main`

## Compatibility boundaries

- `--max-steps` fails explicitly because Runtime Host does not expose a per-invocation step cap yet
- legacy resumed Sessions whose stored working directory is not canonical fail closed instead of silently using a different workspace or sandbox identity

## Validation

- `npm --workspace packages/cli test` — 515 passed
- `npm --workspace @maka/runtime-host test` — 735 passed
- full repository build and TypeScript typecheck
- full repository lint and format check
- dependency-path regression test
- fresh Runtime Host smoke with OpenRouter Free: create, explicit resume, and continue all returned the expected stdout and exit status

Related to #2010. Fixes #2405.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 为 `maka run` 增加显式 Runtime Host owner 路径，同时继续以 embedded Runtime 为默认实现
- 在 embedded 与 Host adapter 之间共享 owner-neutral 的一次性命令解析与编排逻辑
- 当 CLI 是首个 Host client 时，启动具备 execution 能力的 Runtime Host composition
- 通过 typed Host operation 保持 Session 创建、resume、continue、Graph 完成等待、SIGINT/timeout 取消以及退出码/输出语义
- 明确处理非交互 permission 与 question、拒绝 sandbox 扩权，并通过 durable Graph outcome 获取最终结果，不轮询 subscription，也不复用历史 wake
- 增加 dependency-path gate，确保 Host-backed run 入口无法到达 embedded Runtime 或 writer Store 模块
- 修复 `main` 上 session-manager 测试裁剪后遗留的仓库格式问题

## 兼容性边界

- Runtime Host 尚未提供 invocation-local step cap，因此 `--max-steps` 会明确报错
- 对 stored working directory 仍非 canonical 的旧 Session，resume 会 fail closed，避免静默使用不同的 workspace 或 sandbox identity

## 验证

- `npm --workspace packages/cli test` — 515 项通过
- `npm --workspace @maka/runtime-host test` — 735 项通过
- 全仓 build 与 TypeScript typecheck
- 全仓 lint 与 format check
- dependency-path 回归测试
- 使用 OpenRouter Free 对全新 Runtime Host 做 smoke test：create、显式 resume 与 continue 均返回预期 stdout 和退出状态

关联 #2010。修复 #2405。

</details>
