### PR TITLE
fix(ui): keep the prompt rail clickable on macOS

### DIFF
--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -21,6 +21,19 @@ import type { Page } from '@playwright/test';
  * motion resolves to — where the highlight lands, how wide each bar computes —
  * and cannot assert that anything animated on the way there. The tick entrance
  * has no end state to check and therefore no coverage here at all.
+ *
+ * Platform note: the pointer-reachability assertions in this file
+ * (`unreachableTicks`, `activeTickVisibility`) are load-bearing on macOS and
+ * nowhere else. macOS renders the chat scroller's vertical scrollbar as an
+ * overlay: it takes no layout space, so a rail parked on the scroller's right
+ * edge draws on top of it, but the scrollbar's hit region still intercepts
+ * the pointer — every tick under it renders yet never receives a click or
+ * hover, and the rail reads as gone. Linux's in-flow scrollbar moves the
+ * content column left instead, so the regression itself goes green in CI.
+ * What CI *does* catch is the platform-neutral geometry the fix rests on:
+ * the `stays inside the scrollport` test asserts the rail keeps clear
+ * of the measured dead band. Run this spec on a macOS machine before merging
+ * anything that touches the rail's edge or scrollbar.
  */
 
 const RAIL_PROBE = `(() => {
@@ -167,6 +180,18 @@ test('the prompt rail stays inside the scrollport at every scroll position', asy
     expect(probe!.insetTop, where).toBeGreaterThanOrEqual(0);
     expect(probe!.insetBottom, where).toBeGreaterThanOrEqual(0);
     expect(probe!.insetRight, where).toBeGreaterThanOrEqual(0);
+    // macOS's overlay scrollbar hit band starts ~14px in from the scroller's
+    // right edge; the tick bar must stay clear of it. Platform-neutral: a
+    // Linux in-flow scrollbar passes this trivially, but it is the geometry
+    // the macOS click-through fix rests on — pre-fix this read ~5px.
+    const barInset = await page.evaluate(() => {
+      const scroller = document.querySelector('[data-chat-scroll-container="true"]') as HTMLElement;
+      const bar = document.querySelector('.maka-prompt-rail-tick-bar') as HTMLElement;
+      const s = scroller.getBoundingClientRect();
+      const b = bar.getBoundingClientRect();
+      return Math.round(s.right - b.right);
+    });
+    expect(barInset, where).toBeGreaterThanOrEqual(14);
   }
 });
 

--- a/apps/desktop/src/renderer/styles/prompt-rail.css
+++ b/apps/desktop/src/renderer/styles/prompt-rail.css
@@ -27,8 +27,9 @@
    engage while any transcript is on screen, and the rail does its own
    centring from the measured band below.
 
-   `--maka-prompt-rail-scrollport` / `--maka-prompt-rail-dock` are measured in
-   prompt-anchor-rail.tsx; see the rail's own rule for what they buy. */
+   `--maka-prompt-rail-scrollport` / `--maka-prompt-rail-dock` /
+   `--maka-prompt-rail-height` are measured in prompt-anchor-rail.tsx; see the
+   rail's own rule for what they buy. */
 .maka-prompt-rail-anchor {
   position: sticky;
   top: 0;
@@ -41,26 +42,32 @@
 
 .maka-prompt-rail {
   position: absolute;
-  right: var(--space-1);
-  /* The scrollport's lower band belongs to the sticky composer dock, so the
-     rail centres on — and is capped to — what is left above it. Centring on
-     the bare scrollport ran the lower ticks under the dock (122px of overlap
-     at 1240x617), over the frosted blur and the composer card.
-
-     Measured from the anchor's top edge, which is the scrollport's, so this is
-     an absolute position rather than an offset from a centreline that sticky
-     clamping can move. The fallbacks are the pre-measurement first paint: no
-     dock inset, and the window standing in for the scrollport. */
+  /* On macOS the chat scroller's vertical scrollbar is overlay: it takes no
+     layout space, but its hit region still intercepts the pointer, so a rail
+     parked under it renders yet reads as dead. Linux's in-flow scrollbar
+     moves the content column left instead, which is why the regression
+     sailed through CI green. Measured on macOS the dead band starts 14px in
+     from the scroller's right edge, so the rail rests at
+     `right: space-1 + space-2` (12px), clear of it, and hovering settles it
+     3px further inward — the old motion's translateX(3px) did the opposite
+     and pushed the ticks into the band. `translateY(-50%)` stays: it only
+     centres vertically and has no part in the hit-region problem. */
+  right: calc(var(--space-1) + var(--space-2));
   top: calc((var(--maka-prompt-rail-scrollport, 100svh) - var(--maka-prompt-rail-dock, 0px)) / 2);
-  /* The -50% is the centring; the X offset is motion. The rail rests
-     tucked a few px toward the window edge and settles inward when the
-     pointer arrives, so reaching for it is met halfway. */
-  transform: translateY(-50%) translateX(3px);
+  transform: translateY(-50%);
   max-height: calc(
     var(--maka-prompt-rail-scrollport, 100svh) - var(--maka-prompt-rail-dock, 0px) - (2 * var(--space-2))
   );
   overflow-y: auto;
   overscroll-behavior: contain;
+  /* The rail is 22px wide: a visible scrollbar crowds the ticks, and on macOS
+     the overlay scrollbar's hit region swallows the right half of every tick
+     for a beat after the rail scrolls itself. Wheel/trackpad scrolling still
+     works with the bar hidden. */
+  scrollbar-width: none;
+  ::-webkit-scrollbar {
+    width: 0;
+  }
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -73,13 +80,14 @@
   opacity: var(--opacity-muted);
   transition:
     opacity var(--duration-base) var(--ease-out-strong),
-    transform var(--duration-emphasized) var(--ease-out-strong);
+    right var(--duration-emphasized) var(--ease-out-strong);
   -webkit-app-region: no-drag;
 }
 
 .maka-prompt-rail:hover {
   opacity: 1;
-  transform: translateY(-50%) translateX(0);
+  right: calc(var(--space-1) + var(--space-2) + 3px);
+  transform: translateY(-50%);
 }
 
 /* Ticks arrive rather than appear: a new prompt's tick slides in from the edge,


### PR DESCRIPTION
## 问题

Prompt Rail 在新 main 上"消失"了:rail 正常渲染,但所有 tick 点击/hover 无响应。本地 macOS 上 prompt-rail E2E 3 挂 6 过,CI(Linux)93 个测试全绿。

## 根因(经对抗性审查与实测修正)

rail 贴死在 chat scroller 右缘(`right: 4px` + `translateX(3px)`)。macOS 的 scrollbar 是 overlay——不占布局空间,rail 画在它上面,但**scrollbar 命中区域依然拦截指针**:

- 实测死区:距 scroller 右缘 14px 内(边界 ≈1222px)指针全部穿透;
- #2215 的 `translateX(3px)` 把 tick 中心(1221→1224)推进死区 → 全灭;#2161 之前只是擦边;
- Linux in-flow scrollbar 把内容列左移,CI 永远绿;
- 次要问题:rail 自身滚动后,其 overlay scrollbar 命中区短暂吞掉 tick 右半。

## 修复(2 个文件,+51/-18,组件零改动)

- **prompt-rail.css**:rail 停靠 `right: calc(space-1 + space-2)`(12px,实测死区外,余量 8px);hover 向内微移 3px 改用 `right`(不再用 translateX 推入死区);**保留 `translateY(-50%)` 纯 CSS 垂直居中**(垂直位移与水平命中无关,JS 测高方案已废弃);隐藏 rail 自身 scrollbar(22px 宽的 rail 不需要可见滚动条,wheel 滚动保留)。
- **prompt-rail.spec.ts**:平台注记如实描述机制;"stays inside the scrollport" 测试新增平台无关几何回归锁——**tick bar 距 scroller 右缘 ≥ 14px**(修复前实测 ~5px,会失败;已在旧几何下验证断言确实变红)。

## 验证

- `prompt-rail.spec.ts` macOS 单 worker(CI 配置)**9/9 通过**(修复前 3 挂 6 过);
- 全量 desktop e2e 93 个通过(并行);format/lint 干净;
- 回归锁有效性:临时改回旧几何(right 4px)→ barInset 8px < 14 断言失败 ✓;
- 本地 4 workers 并行下 "clicking" 偶发超时是后台窗口节流(配置注释已声明该本地并行问题),CI 单 worker 不触发。

## 对抗性审查结论(独立子代理)

- 初版含 ~35 行 JS 测高(替代 translateY),经 4 路独立审查确认是过度设计——translateY 从未参与水平命中问题,已重构移除;
- 初版注释"stays clear of the edge"/"无 transform"与几何不符,已按实测重写;
- 余量从 1px(压线)提升到 8px,并把几何不变量写成 CI 可断言的回归锁。
