### PR TITLE
test(runtime): silence expected post-close pty write noise

### DIFF
--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -1918,28 +1918,44 @@ describe('ShellRunProcessManager', () => {
   });
 
   test('fails closed before terminal protocol replies can form an unbounded native write queue', async () => {
-    const manager = await createTestManager();
-    const queries = Math.floor(PTY_PROTOCOL_REPLY_MAX_BYTES / 4) + 1;
-    const initial = await manager.runBackgroundBash(
-      shellInput({
-        cwd: await workspace(),
-        command: nodeCommand(`
-        process.stdin.setRawMode?.(true);
-        process.stdin.pause();
-        const query = '\\u001b[5n'.repeat(${queries});
-        process.stdout.write(query);
-        setInterval(() => {}, 1000);
-      `),
-        pty: true,
-        timeoutMs: 10_000,
-      }),
-    );
-    const result = await waitForTerminalShellRun(manager, initial.ref, 10_000);
-    assertShellRunSnapshot(result);
-    assert.equal(result.status, 'failed');
-    assert.match(result.failureMessage ?? '', /protocol replies exceeded/);
-    assert.equal(manager.liveCount(), 0);
-    assert.equal(manager.livePtyCount(), 0);
+    const originalConsoleError = console.error;
+    console.error = (...args: unknown[]) => {
+      const error = args[1] as NodeJS.ErrnoException | undefined;
+      if (
+        args[0] === 'Unhandled pty write error' &&
+        (error?.code === 'EBADF' || error?.code === 'EIO')
+      ) {
+        return;
+      }
+      originalConsoleError(...args);
+    };
+    try {
+      const manager = await createTestManager();
+      const queries = Math.floor(PTY_PROTOCOL_REPLY_MAX_BYTES / 4) + 1;
+      const initial = await manager.runBackgroundBash(
+        shellInput({
+          cwd: await workspace(),
+          command: nodeCommand(`
+          process.stdin.setRawMode?.(true);
+          process.stdin.pause();
+          const query = '\\u001b[5n'.repeat(${queries});
+          process.stdout.write(query);
+          setInterval(() => {}, 1000);
+        `),
+          pty: true,
+          timeoutMs: 10_000,
+        }),
+      );
+      const result = await waitForTerminalShellRun(manager, initial.ref, 10_000);
+      assertShellRunSnapshot(result);
+      assert.equal(result.status, 'failed');
+      assert.match(result.failureMessage ?? '', /protocol replies exceeded/);
+      assert.equal(manager.liveCount(), 0);
+      assert.equal(manager.livePtyCount(), 0);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    } finally {
+      console.error = originalConsoleError;
+    }
   });
 
   test('redacts a secret across a soft wrap and the scrollback/screen boundary', async () => {


### PR DESCRIPTION
## Summary

- silence the expected post-close `node-pty` `EBADF`/`EIO` errors in the protocol-reply overflow fixture
- continue forwarding unrelated `console.error` calls
- restore the original console handler after the asynchronous PTY write callback settles

Closes #2296

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npm --workspace @maka/runtime run test:dist` (3317 passed, 0 failed, 9 skipped)
- affected workspace tests for computer-use, CLI, desktop, runtime-host, and headless

All locally runnable checks completed with zero failures. The Linux-only sandbox smoke was not run locally and is left to CI.
